### PR TITLE
[codex] Tighten mirror mode questions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,10 @@ jobs:
       run: |
         python scripts/check_ci_python_version_sync.py
 
+    - name: Check doc drift
+      run: |
+        python scripts/diagnostics/check_doc_drift.py
+
     - name: Run smoke tests
       run: |
         make test-smoke
@@ -75,6 +79,10 @@ jobs:
     - name: Validate CI/Python version sync
       run: |
         python scripts/check_ci_python_version_sync.py
+
+    - name: Check doc drift
+      run: |
+        python scripts/diagnostics/check_doc_drift.py
 
     - name: Run tests with coverage
       run: |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ dS/dt = -μ·S + λ₁·‖Δη‖² - λ₂·C   Entropy decays, rises with dri
 dV/dt = κ(E - I) - δ·V             Void accumulates E-I mismatch, decays toward zero
 ```
 
-Behavioral EISV drives verdicts. The ODE runs in parallel for agents that benefit from its convergence properties.
+Behavioral EISV is the normal verdict source once behavioral confidence is established. During low-signal or early-life periods, the system can fall back to the ODE as the active primary source; otherwise the ODE remains a parallel stability reference.
 
 > [Architecture Overview](docs/UNIFIED_ARCHITECTURE.md) — prose summary
 > [Canonical Sources](docs/CANONICAL_SOURCES.md) — which docs and runtime files are authoritative
@@ -65,7 +65,7 @@ Logging tells you what happened. Guardrails constrain what can happen. UNITARES 
 
 **Trajectory as identity.** Agents aren't identified by tokens — they're identified by dynamical patterns. An agent's EISV trajectory is its behavioral signature, letting agents computationally verify "Am I still myself?" and letting observers distinguish agents by how they work.
 
-**Mirror response mode.** Agents don't need to interpret raw EISV numbers. Mirror mode surfaces actionable self-awareness signals — calibration feedback, complexity divergence, knowledge graph discoveries — so agents get practical guidance instead of state vectors. Six response modes total — `minimal`, `compact`, `standard`, `full`, `auto`, and `mirror` — let agents and integrators choose the right signal density for their context.
+**Mirror response mode.** Agents don't need to interpret raw EISV numbers. Mirror mode surfaces a short list of actionable self-awareness signals, related prior work when relevant, and a targeted question when state warrants it. Six response modes total — `minimal`, `compact`, `standard`, `full`, `auto`, and `mirror` — let agents and integrators choose the right signal density for their context.
 
 **LLM-assisted dialectic.** When no peer agents are available for structured disagreement, the system can delegate antithesis/synthesis to an LLM — keeping the dialectic protocol functional even for solo agents. Peer agents are always preferred when present.
 
@@ -73,19 +73,14 @@ Logging tells you what happened. Guardrails constrain what can happen. UNITARES 
 
 ## Production Snapshot
 
-Production snapshot from April 2026:
+Internal telemetry snapshot, April 2026. These are operational counts and representative deployment facts, not a public benchmark:
 
-| Metric | Value |
-|--------|-------|
-| Agents created / active (7-day) | Four-figure total / dozens active |
-| Check-ins processed | Six figures |
-| Knowledge graph entries | Four figures |
-| EISV (Lumen, behavioral) | E≈0.41, I≈0.83, S≈0.24, V≈-0.02 |
-| EISV (Lumen, ODE reference) | E≈0.72, I≈0.75, S≈0.20, V≈-0.04 |
-| V operating range | All active agents within [-0.1, 0.1] |
-| Test suite | Large multi-thousand test suite |
+- The server has processed a six-figure number of check-ins across a four-figure total agent population, with dozens active in a typical 7-day window.
+- The shared knowledge graph contains four-figure discovery volume.
+- The repo ships with a large multi-thousand-test suite and live MCP, REST, and dashboard surfaces.
+- Lumen is the main embodied deployment: a Raspberry Pi-based agent that couples physical sensors into the ODE reference path while still participating in the same governance runtime.
 
-One of those agents is [Lumen](https://github.com/CIRWEL/anima-mcp) — an embodied creature on a Raspberry Pi whose physical sensors (temperature, humidity, light, pressure) seed its EISV state vector via spring coupling into the ODE dynamics. Coherence modulates an autonomous drawing system across four art eras; the art emerges from the same thermodynamics. Lumen gets drowsy after inactivity, proposes goals from its own preferences, discovers self-insights every 24 minutes, and falls back to local governance assessment when the Mac server is unreachable.
+[Lumen](https://github.com/CIRWEL/anima-mcp) is an embodied creature on a Raspberry Pi whose physical sensors (temperature, humidity, light, pressure) seed its ODE reference state via spring coupling. Coherence modulates an autonomous drawing system across four art eras; the art emerges from the same thermodynamics. Lumen gets drowsy after inactivity, proposes goals from its own preferences, discovers self-insights every 24 minutes, and falls back to local governance assessment when the Mac server is unreachable.
 
 <p align="center">
   <img src="docs/images/dashboard.png" width="80%" alt="UNITARES web dashboard showing fleet coherence, agent status, and system health"/>
@@ -117,19 +112,25 @@ process_agent_update({
   "response_mode": "mirror"  // or: minimal, compact, standard, full, auto
 })
 
-// System evolves EISV and returns a verdict
+// System returns a mirror-mode verdict
 {
+  "success": true,
   "verdict": "proceed",
-  "E": 0.74, "I": 0.78, "S": 0.15, "V": -0.02,
-  "coherence": 0.52,
-  "guidance": "State healthy. Proceed.",
-  "mirror": {
-    "calibration_feedback": "confidence tracks outcomes well",
-    "complexity_note": "within your normal range",
-    "knowledge_graph": "2 related discoveries from other agents"
-  }
+  "_mode": "mirror",
+  "mirror": [
+    "Calibration: 78% accuracy over 12 decisions (high-conf: 0.83, low-conf: 0.67)"
+  ],
+  "relevant_prior_work": [
+    {
+      "summary": "Previous auth hardening work touched the same rate-limit path",
+      "by": "agent-42",
+      "relevance": 0.81
+    }
+  ]
 }
 ```
+
+When state warrants it, mirror mode can also add a top-level `question` field.
 
 The `onboard()` response includes ready-to-use templates for your next calls — no guessing at parameter names. See [Start Here](docs/guides/START_HERE.md) for the thin default workflow and links to canonical docs.
 
@@ -268,6 +269,7 @@ These are unsolved problems. The system is honest about what it doesn't yet do w
 | Guide | Purpose |
 |-------|---------|
 | [Start Here](docs/guides/START_HERE.md) | Thin default workflow and doc map |
+| [Canonical Sources](docs/CANONICAL_SOURCES.md) | Authority ordering and code-first source map |
 | [Architecture](docs/UNIFIED_ARCHITECTURE.md) | System topology, EISV dynamics, database ownership |
 | [Troubleshooting](docs/guides/TROUBLESHOOTING.md) | Common issues |
 | [Dashboard](dashboard/README.md) | Web dashboard docs |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Status: live overview. For architecture truth and code-first authority ordering,
 
 UNITARES gives AI agents a shared language for inner state — four continuous variables tracked from observable behavior, and a protocol for agents to speak and be read. State is computed from what agents actually do (EMA-smoothed observations), not from what a model predicts they should do.
 
-Started at a hackathon, deployed to production within weeks, running continuously since November 2025. The repo now includes a broad governance tool surface across MCP and HTTP transports, a large test suite, and a six-figure history of check-ins, with one agent ([Lumen](https://github.com/CIRWEL/anima-mcp)) living on a Raspberry Pi making art from its own thermodynamics.
+Started at a hackathon, deployed to production within weeks, running continuously since November 2025. The repo includes governance tooling across MCP and HTTP transports, a 5,800+ test suite, and 200K+ check-ins processed, with one agent ([Lumen](https://github.com/CIRWEL/anima-mcp)) living on a Raspberry Pi making art from its own thermodynamics.
 
 ---
 
@@ -73,12 +73,15 @@ Logging tells you what happened. Guardrails constrain what can happen. UNITARES 
 
 ## Production Snapshot
 
-Internal telemetry snapshot, April 2026. These are operational counts and representative deployment facts, not a public benchmark:
+Operational snapshot, April 2026:
 
-- The server has processed a six-figure number of check-ins across a four-figure total agent population, with dozens active in a typical 7-day window.
-- The shared knowledge graph contains four-figure discovery volume.
-- The repo ships with a large multi-thousand-test suite and live MCP, REST, and dashboard surfaces.
-- Lumen is the main embodied deployment: a Raspberry Pi-based agent that couples physical sensors into the ODE reference path while still participating in the same governance runtime.
+| Metric | Value |
+|--------|-------|
+| Check-ins processed | 200K+ |
+| Agents created / active (7-day) | 900+ / ~30 |
+| Knowledge graph discoveries | 1,500+ |
+| Test suite | 5,800+ tests |
+| Transports | MCP, REST, dashboard |
 
 [Lumen](https://github.com/CIRWEL/anima-mcp) is an embodied creature on a Raspberry Pi whose physical sensors (temperature, humidity, light, pressure) seed its ODE reference state via spring coupling. Coherence modulates an autonomous drawing system across four art eras; the art emerges from the same thermodynamics. Lumen gets drowsy after inactivity, proposes goals from its own preferences, discovers self-insights every 24 minutes, and falls back to local governance assessment when the Mac server is unreachable.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ### Digital proprioception for AI agents.
 
+Status: live overview. For architecture truth and code-first authority ordering, see [docs/CANONICAL_SOURCES.md](docs/CANONICAL_SOURCES.md).
+
 [![Tests](https://github.com/CIRWEL/unitares/actions/workflows/tests.yml/badge.svg)](https://github.com/CIRWEL/unitares/actions/workflows/tests.yml)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
@@ -40,7 +42,8 @@ dV/dt = κ(E - I) - δ·V             Void accumulates E-I mismatch, decays towa
 
 Behavioral EISV drives verdicts. The ODE runs in parallel for agents that benefit from its convergence properties.
 
-> [Architecture Overview](docs/UNIFIED_ARCHITECTURE.md) — How the components fit together
+> [Architecture Overview](docs/UNIFIED_ARCHITECTURE.md) — prose summary
+> [Canonical Sources](docs/CANONICAL_SOURCES.md) — which docs and runtime files are authoritative
 
 ---
 
@@ -77,7 +80,8 @@ Production snapshot from April 2026:
 | Agents created / active (7-day) | Four-figure total / dozens active |
 | Check-ins processed | Six figures |
 | Knowledge graph entries | Four figures |
-| EISV (Lumen, ODE) | E≈0.72, I≈0.75, S≈0.20, V≈-0.04 |
+| EISV (Lumen, behavioral) | E≈0.41, I≈0.83, S≈0.24, V≈-0.02 |
+| EISV (Lumen, ODE reference) | E≈0.72, I≈0.75, S≈0.20, V≈-0.04 |
 | V operating range | All active agents within [-0.1, 0.1] |
 | Test suite | Large multi-thousand test suite |
 
@@ -127,7 +131,7 @@ process_agent_update({
 }
 ```
 
-The `onboard()` response includes ready-to-use templates for your next calls — no guessing at parameter names. See [Getting Started](docs/guides/START_HERE.md) for the full walkthrough.
+The `onboard()` response includes ready-to-use templates for your next calls — no guessing at parameter names. See [Start Here](docs/guides/START_HERE.md) for the thin default workflow and links to canonical docs.
 
 ### Installation
 
@@ -195,7 +199,7 @@ Agents self-identify through the `onboard()` flow — no hardcoded agent name he
 
 **Security:** The server binds to `127.0.0.1` by default. For LAN/remote access, set `UNITARES_BIND_ALL_INTERFACES=1` and configure `UNITARES_MCP_ALLOWED_HOSTS` / `UNITARES_MCP_ALLOWED_ORIGINS` (comma-separated). See the [launchd plist](scripts/ops/) for a working example.
 
-> **For AI agents:** Start with `onboard()`, keep `client_session_id` from the response, then call `process_agent_update()` with `response_mode: "mirror"`, then `get_governance_metrics()`. If `continuity_token_supported=true`, prefer `continuity_token` for resume. Use `bind_session()` only when you intentionally bridge MCP and REST transports. See [docs/guides/START_HERE.md](docs/guides/START_HERE.md) and [docs/operations/OPERATOR_RUNBOOK.md](docs/operations/OPERATOR_RUNBOOK.md).
+> **For AI agents:** Start with `onboard()`, keep `client_session_id` from the response, then call `process_agent_update()` with `response_mode: "mirror"`, then `get_governance_metrics()`. If `continuity_token_supported=true`, prefer `continuity_token` for resume. Use `bind_session()` only when you intentionally bridge MCP and REST transports. See [docs/guides/START_HERE.md](docs/guides/START_HERE.md), [docs/CANONICAL_SOURCES.md](docs/CANONICAL_SOURCES.md), and [docs/operations/OPERATOR_RUNBOOK.md](docs/operations/OPERATOR_RUNBOOK.md).
 
 ---
 
@@ -263,11 +267,11 @@ These are unsolved problems. The system is honest about what it doesn't yet do w
 
 | Guide | Purpose |
 |-------|---------|
-| [Getting Started](docs/guides/START_HERE.md) | Complete setup and onboarding guide |
+| [Start Here](docs/guides/START_HERE.md) | Thin default workflow and doc map |
 | [Architecture](docs/UNIFIED_ARCHITECTURE.md) | System topology, EISV dynamics, database ownership |
 | [Troubleshooting](docs/guides/TROUBLESHOOTING.md) | Common issues |
 | [Dashboard](dashboard/README.md) | Web dashboard docs |
-| [Database Architecture](docs/database_architecture.md) | PostgreSQL + AGE |
+| [Database Architecture](docs/database_architecture.md) | Thin storage/backend reference |
 | [Changelog](CHANGELOG.md) | Release history |
 
 ## Contributing

--- a/docs/CANONICAL_SOURCES.md
+++ b/docs/CANONICAL_SOURCES.md
@@ -64,6 +64,7 @@ These are live but intentionally specialized. They should not be treated as gene
 | `docs/CIRCUIT_BREAKER_DIALECTIC.md` | specialized recovery reference | Circuit-breaker and dialectic recovery flow |
 | `docs/dev/TOOL_REGISTRATION.md` | specialized developer reference | MCP/tool registration work |
 | `docs/engineering/contract-drift-playbook.md` | specialized engineering playbook | Tool-contract and drift-prevention work |
+| `docs/engineering/validation-roadmap.md` | specialized engineering roadmap | Empirical validation ladder for groundedness, prediction, and intervention |
 | `docs/meta/MARKDOWN_PROLIFERATION_POLICY.md` | specialized policy reference | Markdown creation policy and consolidation rules |
 
 ## Known Stale-Risk Patterns

--- a/docs/CANONICAL_SOURCES.md
+++ b/docs/CANONICAL_SOURCES.md
@@ -47,6 +47,8 @@ These docs should stay aligned with the runtime sources above:
 |-----|--------|--------------|
 | `README.md` | live overview | Public-facing summary and top-level framing |
 | `docs/UNIFIED_ARCHITECTURE.md` | canonical prose summary | Human-readable architecture explanation |
+| `docs/guides/TROUBLESHOOTING.md` | live troubleshooting guide | Failure diagnosis and practical remediation |
+| `docs/operations/OPERATOR_RUNBOOK.md` | live operator guide | Startup, health checks, and operator procedures |
 | `docs/guides/START_HERE.md` | thin compatibility entrypoint | Minimal workflow and links outward; should stay short |
 | `docs/database_architecture.md` | thin infrastructure reference | Storage/backend facts only; should not restate runtime semantics |
 | `docs/operations/DEFINITIVE_PORTS.md` | thin operational registry | Port assignments only; should stay small and factual |
@@ -59,8 +61,10 @@ These are live but intentionally specialized. They should not be treated as gene
 |-----|--------|--------------|
 | `docs/guides/NGROK_DEPLOYMENT.md` | specialized deployment reference | Remote/ngrok exposure only |
 | `docs/guides/CIRS_PROTOCOL.md` | specialized protocol reference | CIRS-specific coordination flows |
+| `docs/CIRCUIT_BREAKER_DIALECTIC.md` | specialized recovery reference | Circuit-breaker and dialectic recovery flow |
 | `docs/dev/TOOL_REGISTRATION.md` | specialized developer reference | MCP/tool registration work |
 | `docs/engineering/contract-drift-playbook.md` | specialized engineering playbook | Tool-contract and drift-prevention work |
+| `docs/meta/MARKDOWN_PROLIFERATION_POLICY.md` | specialized policy reference | Markdown creation policy and consolidation rules |
 
 ## Known Stale-Risk Patterns
 

--- a/docs/CANONICAL_SOURCES.md
+++ b/docs/CANONICAL_SOURCES.md
@@ -1,0 +1,95 @@
+# Canonical Sources
+
+Use this page to resolve architecture disputes and doc drift.
+
+Status: canonical authority map for active docs.
+
+## Trust Order
+
+When prose and code disagree, use this order:
+
+1. Runtime code that computes or returns the behavior
+2. Prose docs explicitly marked live or canonical
+3. Historical docs and archived analyses
+
+This ordering exists because the codebase has accumulated multiple eras of explanation. Some older docs accurately describe earlier phases of the system but no longer describe the runtime that agents interact with today. If an agent reads archived prose before it reads runtime code, it can form a coherent but outdated model of the system. This page exists to prevent that failure mode and give both humans and agents a compact rule for resolving contradictions without guesswork.
+
+## Current Architecture Truth
+
+These files are the canonical runtime sources for current behavior:
+
+| Topic | Canonical source | Why it matters |
+|------|-------------------|----------------|
+| Shared runtime state and monitor access | `src/agent_state.py`, `src/mcp_handlers/shared.py` | Defines the live singleton/facade that many handlers dereference |
+| Core governance runtime | `src/governance_monitor.py` | Initializes dual-log grounding, behavioral state, ODE diagnostics, calibration hooks, and verdict flow |
+| Dual-log grounding | `src/dual_log/continuity.py` | Cross-checks reflective inputs against operational signals and tool-derived complexity |
+| Behavioral EISV state | `src/behavioral_state.py` | Defines warmup, bootstrap confidence, baselining, and self-relative assessment |
+| Behavioral sensor inputs | `src/behavioral_sensor.py` | Shows which observable signals feed behavioral EISV |
+| Public semantics returned to operators/agents | `src/services/runtime_queries.py` | Declares behavioral EISV primary, ODE diagnostic, and the surfaced state hierarchy |
+| Calibration and objective outcomes | `src/calibration.py`, `src/auto_ground_truth.py` | Defines objective/exogenous calibration signals and confidence correction |
+
+## How To Use This Page
+
+Use this page differently depending on the task:
+
+- If you are summarizing the system, read `README.md`, then `docs/UNIFIED_ARCHITECTURE.md`, then confirm the relevant claims in the runtime files listed above.
+- If you are debugging a discrepancy between docs and behavior, skip straight to the runtime files and treat prose as secondary evidence.
+- If you are changing architecture docs, update the relevant live doc and then verify that the runtime source still supports the wording.
+- If you are changing runtime semantics, update this file only if the authority map or doc classifications have changed.
+
+This page is not intended to duplicate the full architecture narrative. It is the index that tells you where truth lives and which docs are allowed to summarize that truth.
+
+## Active Docs
+
+These docs should stay aligned with the runtime sources above:
+
+| Doc | Status | Intended use |
+|-----|--------|--------------|
+| `README.md` | live overview | Public-facing summary and top-level framing |
+| `docs/UNIFIED_ARCHITECTURE.md` | canonical prose summary | Human-readable architecture explanation |
+| `docs/guides/START_HERE.md` | thin compatibility entrypoint | Minimal workflow and links outward; should stay short |
+| `docs/database_architecture.md` | thin infrastructure reference | Storage/backend facts only; should not restate runtime semantics |
+| `docs/operations/DEFINITIVE_PORTS.md` | thin operational registry | Port assignments only; should stay small and factual |
+
+## Specialized Active Docs
+
+These are live but intentionally specialized. They should not be treated as general onboarding or architecture truth:
+
+| Doc | Status | Intended use |
+|-----|--------|--------------|
+| `docs/guides/NGROK_DEPLOYMENT.md` | specialized deployment reference | Remote/ngrok exposure only |
+| `docs/guides/CIRS_PROTOCOL.md` | specialized protocol reference | CIRS-specific coordination flows |
+| `docs/dev/TOOL_REGISTRATION.md` | specialized developer reference | MCP/tool registration work |
+| `docs/engineering/contract-drift-playbook.md` | specialized engineering playbook | Tool-contract and drift-prevention work |
+
+## Known Stale-Risk Patterns
+
+If you see these in active docs, treat them as drift candidates:
+
+- "system operates on agent-reported inputs"
+- descriptions implying self-report is the sole or primary substrate
+- descriptions implying ODE state directly drives verdicts
+- descriptions that omit dual-log grounding from the live architecture
+
+Additional stale-risk patterns:
+
+- long onboarding docs that quietly become second architecture manuals
+- operational docs that start restating runtime semantics
+- niche deployment guides that read like the default local path
+- references to archived design language without an explicit historical label
+
+## Maintenance Rules
+
+Use these rules when deciding whether to edit, shrink, or add a doc:
+
+1. If the content is broad and user-facing, prefer updating an existing live doc rather than creating a new one.
+2. If the content is narrow and task-specific, mark it as specialized so agents do not treat it as default guidance.
+3. If a doc mainly points to other docs, keep it thin and add an explicit status line saying so.
+4. If a statement describes runtime behavior, verify it against the canonical source files before merging.
+5. If a doc becomes historical, move it under `docs/archive/` instead of leaving it in the active set.
+
+The goal is not to minimize documentation at all costs. The goal is to keep the active docs set small enough that agents can form the right model quickly, while still preserving specialized references for the narrower workflows that genuinely need them.
+
+## Archive Boundary
+
+Anything under `docs/archive/` is historical context unless explicitly promoted back into an active doc. Do not use archived prose as the source of truth for current runtime behavior.

--- a/docs/CIRCUIT_BREAKER_DIALECTIC.md
+++ b/docs/CIRCUIT_BREAKER_DIALECTIC.md
@@ -1,5 +1,7 @@
 # Circuit Breaker + Dialectic Recovery
 
+Status: specialized recovery reference. Use for circuit-breaker and dialectic recovery semantics, not as the general architecture overview.
+
 **Last Updated:** 2026-03-22
 
 This system uses a **circuit breaker** to pause agents when risk signals or coherence drop below safe thresholds. Recovery is handled via a **dialectic protocol** that provides a safe path to resume.

--- a/docs/UNIFIED_ARCHITECTURE.md
+++ b/docs/UNIFIED_ARCHITECTURE.md
@@ -2,6 +2,8 @@
 
 **How agents check in, how state evolves, how verdicts are issued.**
 
+Status: canonical prose summary. If this file and runtime code disagree, trust [CANONICAL_SOURCES.md](CANONICAL_SOURCES.md) and the referenced runtime files.
+
 ```
   Any AI Agent                                    UNITARES Server
   (Cursor, Claude Code,                           (port 8767)
@@ -35,19 +37,21 @@ Every agent check-in flows through the same pipeline:
 ### 1. Check-in
 
 An agent calls `process_agent_update` with:
-- `response_text` — what it did
-- `complexity` — self-reported cognitive load [0, 1]
-- `confidence` — how confident it is in its work [0, 1] (optional)
+- `response_text` — what it did; primary operational input
+- `complexity` — optional reflective self-report [0, 1]
+- `confidence` — optional reflective self-report [0, 1]
 
 Identity is resolved automatically from the session. First call auto-creates the agent.
 
+At runtime, these reflective fields are not trusted in isolation. The dual-log layer compares them against server-derived operational signals, tool usage, continuity metrics, and other exogenous evidence when available.
+
 ### 2. EISV Evolution
 
-**Primary system: Behavioral EISV** — EMA (exponential moving average) observations from check-ins. No ODE, no decay terms. Each EISV dimension is smoothed with per-dimension alpha values. After ~30 check-ins, the system builds per-agent Welford baselines and assesses agents by z-score deviation from their own operating point rather than universal thresholds.
+**Primary system: Behavioral EISV** — EMA (exponential moving average) observations from grounded behavioral signals. These signals are assembled from operational log analysis, continuity metrics, tool usage, calibration history, and outcome history; self-reports are one input, not the whole substrate. After ~30 check-ins, the system builds per-agent Welford baselines and assesses agents by z-score deviation from their own operating point rather than universal thresholds.
 
 **Secondary system: ODE (diagnostic only)** — coupled differential equations run in parallel but do not drive verdicts. The ODE provides a thermodynamic lens for analysis but behavioral verdicts override.
 
-The behavioral engine lives in `src/behavioral_state.py` and `src/behavioral_assessment.py`. The ODE engine lives in `governance_core` (compiled package, unitares-core).
+The grounding path lives in `src/dual_log/`, `src/behavioral_sensor.py`, `src/behavioral_state.py`, and `src/behavioral_assessment.py`. The ODE engine lives in `governance_core` (compiled package, unitares-core).
 
 ### 3. Ethical Drift
 
@@ -60,7 +64,7 @@ Four observable signals define a drift vector that feeds entropy:
 | Coherence deviation | How far coherence has moved from baseline |
 | Stability deviation | EISV variance over recent window |
 
-No human oracle needed — drift is computed from behavioral signals only.
+No human oracle is needed for runtime drift estimation. Independent exogenous outcomes still matter for calibration and research validation.
 
 ### 4. Verdict
 

--- a/docs/database_architecture.md
+++ b/docs/database_architecture.md
@@ -1,242 +1,67 @@
 # Database Architecture
 
-**Last Updated**: 2026-04-03
+Status: thin infrastructure reference. Use this for storage/backing-service facts only. For runtime semantics see [UNIFIED_ARCHITECTURE.md](UNIFIED_ARCHITECTURE.md); for operational procedures see [operations/OPERATOR_RUNBOOK.md](operations/OPERATOR_RUNBOOK.md).
 
-> **Rule**: The canonical UNITARES database is whatever instance `DB_POSTGRES_URL` points to.
-> Query the configured instance directly.
+## Canonical Rule
 
-## Overview
+The canonical UNITARES database is whatever instance `DB_POSTGRES_URL` points to. Query that instance directly.
 
-The governance MCP uses PostgreSQL as the sole database backend:
-- **Durability**: PostgreSQL + Apache AGE for all persistent data
-- **Performance**: Redis for ephemeral session cache
-- **Audit trail**: `audit_log.jsonl` append-only compliance log
+## Current Storage Model
 
----
+- PostgreSQL is the sole durable database backend
+- Apache AGE lives inside PostgreSQL for graph data
+- Redis is an optional ephemeral cache for session continuity and fast lookups
+- `audit_log.jsonl` is a raw append-only audit artifact, not a second source of truth
 
-## Active Databases
+## What Lives Where
 
-### 1. PostgreSQL (Primary Storage)
+### PostgreSQL
 
-**Instance**: configured via `DB_POSTGRES_URL`
-**Database**: `governance`
-**Purpose**: Single source of truth for all persistent data
+Stores the durable system of record:
 
-**What's Stored:**
-- **Agent Metadata**
-  - Identity, API keys, status, tags, notes
-  - Lifecycle events, creation/update timestamps
-  - Parent/child agent relationships
+- agent metadata and identity state
+- governance state and history
+- dialectic sessions
+- knowledge graph data
+- calibration data
+- audit/event records
 
-- **Agent State** (EISV metrics)
-  - Energy (E), Information Integrity (I)
-  - Entropy (S), Void Integral (V)
-  - Coherence, regime, health status
-  - Full state history
+### Redis
 
-- **Knowledge Graph** (Apache AGE extension)
-  - Discoveries (nodes)
-  - Relationships (edges)
-  - Full-text search
-  - Graph queries (Cypher-like syntax)
+Stores optional ephemeral support data:
 
-- **Dialectic Sessions**
-  - Thesis-antithesis-synthesis negotiations
-  - Session state, messages, resolutions
+- session bindings
+- metadata cache
+- distributed-lock helpers
+- other short-lived cache/coordination entries
 
-- **Audit Log**
-  - Tool calls, governance decisions
-  - Agent lifecycle events
-  - Full audit trail
+If Redis is unavailable, the system falls back gracefully with weaker continuity guarantees.
 
-- **Calibration Data**
-  - Governance decision calibration
-  - Ground truth tracking
-
-**Schema Location**: `core` schema in PostgreSQL
-**Schema Version**: Tracked in `core.schema_migrations` (current: v2)
-**Backup**: `pg_dump` against `DB_POSTGRES_URL` or an equivalent server-level backup
-
----
-
-### 2. Redis (Session Cache)
-
-**Service**: typically local Redis on `127.0.0.1:6379`
-**Purpose**: Fast ephemeral data with persistence across server restarts
-
-**What's Stored:**
-- **Session Bindings** (`session:{session_id}`)
-  - Maps session_id → agent_id
-  - Survives server restarts
-  - TTL: Session expiry (configurable)
-  - **Why critical**: Enables session continuity for agents reconnecting
-
-- **Distributed Locks** (future: multi-server)
-  - Coordination locks for concurrent operations
-  - Currently using file locks (single-server)
-
-- **Rate Limits** (future)
-  - Per-agent rate limiting
-  - Burst protection
-
-- **Metadata Cache** (optional)
-  - Fast lookups to reduce PostgreSQL queries
-
-**Fallback**: If Redis unavailable, gracefully falls back to in-memory cache
-**Trade-off**: Loss of session persistence across restarts (minor issue)
-
----
-
-## Configuration
-
-**Required Environment Variable**: `DB_POSTGRES_URL`
+## Required Configuration
 
 ```bash
 export DB_POSTGRES_URL="postgresql://postgres:postgres@localhost:5432/governance"
+export DB_AGE_GRAPH="governance_graph"  # optional but recommended
 ```
 
-Optional but recommended for graph queries:
+## Quick Checks
 
 ```bash
-export DB_AGE_GRAPH="governance_graph"
-```
-
-**Code Location**: `src/db/__init__.py` — the shared database accessor always returns `PostgresBackend`.
-
-> **Note**: If PostgreSQL is unavailable, the server exits honestly rather than
-> silently degrading.
-
----
-
-## Why This Architecture?
-
-### PostgreSQL for Persistent Data
-- **ACID transactions**: Data integrity for governance decisions
-- **Rich queries**: Complex agent relationship queries
-- **Graph database**: Apache AGE for knowledge graph
-- **Proven scale**: Handles 1000s of agents efficiently
-
-### Redis for Session Cache
-- **Sub-millisecond lookups**: Session resolution on every request
-- **Persistence**: Sessions survive server restarts/deployments
-- **Standard pattern**: Widely used for session management
-- **Automatic TTL**: Sessions expire without manual cleanup
-
----
-
-## Operations
-
-### Health Check
-
-The `health_check` tool returns a three-tier aggregate status:
-
-| Aggregate Status | Condition |
-|------------------|-----------|
-| `healthy` | All components operational |
-| `moderate` | Some warnings/deprecated, no errors |
-| `critical` | One or more component errors |
-
-Response includes `status_breakdown` with counts per status type:
-```json
-{
-  "status": "healthy",
-  "status_breakdown": {"healthy": 9, "warning": 0, "deprecated": 0, "error": 0},
-  "checks": {...}
-}
-```
-
-```bash
-# Server health
-curl http://localhost:8767/health
-
-# PostgreSQL
-psql "$DB_POSTGRES_URL" -c "SELECT COUNT(*) FROM core.agents;"
-
-# Schema version
-psql "$DB_POSTGRES_URL" -c "SELECT * FROM core.schema_migrations;"
-
-# Redis
-redis-cli DBSIZE
-redis-cli GET "session:test-session-id"
-```
-
-### Backup
-```bash
-# PostgreSQL
-pg_dump "$DB_POSTGRES_URL" > backup.sql
-
-# Redis (manual snapshot)
-redis-cli BGSAVE
-```
-
-### Troubleshooting
-
-**PostgreSQL connection issues:**
-```bash
-# Check configured database target
-echo "$DB_POSTGRES_URL"
+# PostgreSQL connectivity
 pg_isready -d "$DB_POSTGRES_URL"
-
-# Simple connectivity probe
 psql "$DB_POSTGRES_URL" -c "SELECT 1;"
+
+# Local health endpoint
+curl http://127.0.0.1:8767/health
+
+# Redis optional cache
+redis-cli PING
 ```
 
-**Redis unavailable:**
-```bash
-# Check service
-brew services list | grep redis
+## Read Next
 
-# Restart
-brew services restart redis
+- [UNIFIED_ARCHITECTURE.md](UNIFIED_ARCHITECTURE.md): runtime architecture
+- [operations/OPERATOR_RUNBOOK.md](operations/OPERATOR_RUNBOOK.md): startup, health, triage
+- [CANONICAL_SOURCES.md](CANONICAL_SOURCES.md): authority ordering
 
-# Fallback: Server automatically uses in-memory cache
-```
-
-## Performance Characteristics
-
-| Operation | Backend | Latency | Notes |
-|-----------|---------|---------|-------|
-| Session lookup | Redis | <1ms | In-memory, critical path |
-| Agent metadata read | PostgreSQL | 5-10ms | Cached in app memory |
-| Agent state write | PostgreSQL | 10-20ms | Transaction + index update |
-| Knowledge graph query | PostgreSQL AGE | 50-200ms | Graph traversal |
-| Audit log write | PostgreSQL | 15-30ms | Async background write |
-
----
-
-## Future Considerations
-
-**If deploying multiple servers:**
-- Enable Redis distributed locks (replace fcntl file locks)
-- Enable Redis rate limiting (per-agent limits)
-- Consider PostgreSQL read replicas (if query load high)
-
-**If single server remains:**
-- Can remove Redis (lose session persistence across restarts)
-- Can simplify to PostgreSQL-only (all subsystems)
-- Trade-off: Simplicity vs. performance
-
-**Current recommendation**: Keep hybrid architecture (battle-tested, performant)
-
----
-
-## Schema Versioning
-
-Schema migrations are tracked in `core.schema_migrations`:
-
-| Version | Name | Description |
-|---------|------|-------------|
-| 1 | `initial_schema` | Core tables (agents, sessions, dialectic) |
-| 2 | `knowledge_schema` | Knowledge graph PostgreSQL FTS tables |
-
-Query current version:
-```sql
-SELECT MAX(version) FROM core.schema_migrations;
-```
-
----
-
-## Related Documentation
-
-- PostgreSQL Schema: `db/postgres/README.md`
-- Knowledge Graph: See AGE graph schema in `db/postgres/graph_schema.cypher`
+**Last Updated:** 2026-04-04 (reduced to thin infrastructure reference)

--- a/docs/dev/TOOL_REGISTRATION.md
+++ b/docs/dev/TOOL_REGISTRATION.md
@@ -1,5 +1,7 @@
 # Tool Registration Guide
 
+Status: specialized developer reference. Use for MCP/tool-surface changes, not runtime architecture semantics.
+
 **For AI agents and developers adding/modifying tools in the governance MCP server.**
 
 ## Quick Reference: Adding a New Tool

--- a/docs/engineering/contract-drift-playbook.md
+++ b/docs/engineering/contract-drift-playbook.md
@@ -1,8 +1,10 @@
 # Contract Drift Playbook
 
+Status: specialized engineering playbook. Use for tool-contract changes and drift prevention, not as a user/operator guide.
+
 **Created:** March 14, 2026  
 **Last Updated:** March 14, 2026  
-**Status:** Active
+**Doc State:** Active
 
 ---
 
@@ -144,4 +146,3 @@ Include this in PR descriptions for tool-contract changes:
 - **Drift guard tests added/updated:** `<files>`
 
 Using a standard snippet makes drift visible during review and prevents accidental omission of one surface.
-

--- a/docs/engineering/validation-roadmap.md
+++ b/docs/engineering/validation-roadmap.md
@@ -1,0 +1,149 @@
+# Validation Roadmap
+
+Status: specialized engineering roadmap. Use this to plan empirical validation work for groundedness, predictive validity, and intervention usefulness. This is not the primary architecture overview.
+
+## Why This Exists
+
+UNITARES now has enough runtime plumbing that the main open question is no longer "can the system produce a state vector?" It can. The harder question is whether the state earns strong claims about agent self-regulation.
+
+That question breaks into three narrower claims:
+
+1. **Grounded**: the state tracks observable signals outside the agent's own narration.
+2. **Predictive**: the state forecasts bad outcomes better than simple baselines.
+3. **Causally useful**: interventions based on the state improve outcomes without excessive false alarms.
+
+The repo is currently strongest on the first claim, partly equipped for the second, and only lightly prepared for the third. This roadmap exists to keep the validation work concrete and staged rather than letting the narrative outrun the evidence.
+
+## Current Assets In The Repo
+
+The evaluation starting point is not zero. Relevant surfaces already exist:
+
+- `src/dual_log/continuity.py` cross-checks self-report against server-derived operational signals and tool-usage-derived complexity.
+- `src/behavioral_sensor.py` computes behavioral EISV from observables such as decision history, coherence, calibration error, outcomes, and tool signals.
+- `src/auto_ground_truth.py` defines what counts as exogenous evidence instead of letting calibration grade its own homework.
+- `src/mcp_handlers/observability/outcome_events.py` records outcome events with EISV snapshots and state semantics.
+- `src/outcome_correlation.py` computes verdict distributions, metric correlations, risk-bin bad rates, and dataset coverage.
+- `scripts/analysis/analyze_drift.py` studies trajectory validation events.
+- `scripts/analysis/export_outcome_dataset.py` exports flattened outcome rows for offline studies.
+
+That means the immediate problem is not missing observability primitives. The immediate problem is turning them into a repeatable research ladder.
+
+## Validation Ladder
+
+| Claim | Question | Minimum evidence | Failure mode if skipped |
+|------|----------|------------------|-------------------------|
+| Grounded | Is the state tied to observables rather than just self-report? | High coverage of behavioral, primary, and exogenous outcome data | Introspection theater |
+| Predictive | Do state and risk signals forecast bad outcomes? | Held-out correlation / ranking lift over simple baselines | Decorative monitoring |
+| Causally useful | Do interventions based on the state help? | Controlled comparison of intervention policies | Expensive false-confidence |
+
+The order matters. Do not run causal-intervention stories before the predictive layer is solid. Do not run predictive claims on a dataset with weak exogenous coverage.
+
+## Phase 1: Groundedness
+
+Goal: show that the dataset is meaningfully anchored in observable evidence.
+
+Primary checks:
+
+- Percent of outcome events with `primary_eisv`
+- Percent with `behavioral_eisv`
+- Percent where behavioral state is the primary source
+- Percent with at least one exogenous signal
+- Coverage by signal type: tests, commands, files, lint, tool observations, explicit outcome events
+
+Run:
+
+```bash
+python3 scripts/analysis/export_outcome_dataset.py --since-hours 168
+```
+
+Success threshold:
+
+- most outcome rows should include a snapshot
+- exogenous coverage should be common enough that calibration is not dominated by internally generated labels
+- behavioral primary should be common outside very-early-life agents
+
+If those conditions fail, do not make stronger predictive claims yet. Improve capture of tests, command outcomes, file operations, and tool-result summaries first.
+
+## Phase 2: Predictive Validity
+
+Goal: determine whether the state predicts degradation better than simpler alternatives.
+
+Core comparisons:
+
+- EISV metrics vs bad outcome rate
+- risk bin vs bad outcome rate
+- verdict vs bad outcome rate
+- behavioral-primary rows vs ODE-primary rows
+- full dual-log features vs simpler baselines
+
+Baselines to beat:
+
+- constant global bad-rate baseline
+- verdict-only baseline
+- simple risk-only baseline
+- self-report-only subset
+
+Study shape:
+
+1. Export outcome rows for a time window.
+2. Split train/test by time or by agent family.
+3. Compare ranking quality and calibration, not just raw correlation.
+4. Report where the model fails: early-life agents, sparse-tool agents, or heavily embodied agents.
+
+Success threshold:
+
+- high-risk bins should show materially higher bad-outcome rates than healthy bins
+- behavioral-primary rows should not underperform the simpler ODE fallback on held-out data
+- the full grounded feature set should beat verdict-only and risk-only baselines
+
+## Phase 3: Causal Usefulness
+
+Goal: show that acting on the state improves outcomes.
+
+Do not start here first. Once predictive validity is acceptable, run controlled comparisons:
+
+- `control`: no governance intervention
+- `observe_only`: record state but do not alter behavior
+- `mirror_only`: surface guidance/question without hard intervention
+- `full_intervention`: allow guide/pause/reject or restorative actions
+
+Measure:
+
+- task completion rate
+- retry count
+- rollback / failure rate
+- time to recovery after degradation
+- false positive intervention rate
+- operator burden
+
+Success threshold:
+
+- interventions reduce bad outcomes or reduce recovery time
+- false positives stay low enough that the system is not just freezing useful work
+
+## Minimal Instrumentation Priorities
+
+These are the next concrete changes worth making if the dataset is still thin:
+
+1. Capture exogenous evidence by default on every check-in path:
+   - tests
+   - command exit codes
+   - lint results
+   - file-operation summaries
+   - tool result summaries
+2. Preserve signal provenance so features can be grouped by source rather than only by value.
+3. Distinguish agent classes in analysis:
+   - text/tool-grounded
+   - sensor-grounded
+   - embodied
+4. Keep intervention logs explicit so causal studies can tell "state was observed" from "state changed behavior."
+
+## Practical Operating Rule
+
+Use the following rule of thumb when talking about the system:
+
+- If groundedness is strong but predictive evidence is weak, say the system is **grounded but not yet validated as a predictor**.
+- If predictive evidence is strong but intervention evidence is weak, say the system is **predictive but not yet proven to improve outcomes**.
+- Only call the system a true self-regulation layer once the intervention step shows net benefit.
+
+That keeps the public framing honest while still letting the engineering and research work move forward.

--- a/docs/guides/CIRS_PROTOCOL.md
+++ b/docs/guides/CIRS_PROTOCOL.md
@@ -1,5 +1,7 @@
 # CIRS Protocol — Multi-Agent Coordination
 
+Status: specialized protocol reference. Use when working on CIRS-specific coordination flows, not as a general architecture overview.
+
 **Cooperative Inter-agent Resonance Signaling**
 
 CIRS enables agents to broadcast state, coordinate recovery, and establish trust boundaries. It builds on the EISV vocabulary to let agents observe and respond to each other's governance state.

--- a/docs/guides/NGROK_DEPLOYMENT.md
+++ b/docs/guides/NGROK_DEPLOYMENT.md
@@ -1,5 +1,7 @@
 # ngrok Deployment Guide
 
+Status: specialized deployment reference. Not primary onboarding or default local setup.
+
 **Last Updated:** March 2026
 **Transport:** Streamable HTTP (`/mcp/` endpoint)
 **Port:** 8767

--- a/docs/guides/START_HERE.md
+++ b/docs/guides/START_HERE.md
@@ -1,11 +1,13 @@
-# Start Here - Agent Onboarding
+# Start Here
+
+Status: thin entrypoint kept for compatibility. README is the primary overview; this page exists to point agents and operators at the current workflow and canonical sources without duplicating architecture docs.
 
 ## Default Workflow
 
-Use this unless you have a specific reason not to.
+Use this unless you have a specific reason not to:
 
 1. Call `onboard()`
-2. Save `client_session_id`
+2. Save `client_session_id` or `continuity_token`
 3. Call `process_agent_update()`
 4. Call `get_governance_metrics()`
 
@@ -16,6 +18,7 @@ process_agent_update(
     client_session_id=session["client_session_id"],
     response_text="What you did",
     complexity=0.5,
+    response_mode="mirror",
 )
 
 get_governance_metrics(
@@ -23,311 +26,40 @@ get_governance_metrics(
 )
 ```
 
-### Continuity Rule
+## Continuity Rule
 
-- If the response shows `continuity_token_supported=true`, prefer `continuity_token` for resume.
-- Otherwise pass `client_session_id` in every call.
-- If `session_resolution_source="ip_ua_fingerprint"`, continuity is weak. Pass `client_session_id` or `continuity_token` explicitly.
+- Best: `continuity_token`
+- Good: `client_session_id`
+- Weak fallback: transport-only continuity
 
-### Only Use Another Path If You Mean It
+If the response says `continuity_token_supported=true`, prefer `continuity_token` for resume.
 
-- `identity(name="...")` if you want to rename yourself
-- `process_agent_update(...)` first if you intentionally want implicit identity creation
-- `list_tools()` first only if you are exploring the surface area
+## What To Trust
 
----
+When docs disagree, use this order:
 
-## Tool Modes (Optional)
+1. Runtime code that computes or returns behavior
+2. [Canonical Sources](../CANONICAL_SOURCES.md)
+3. Live docs such as [README.md](../../README.md) and [UNIFIED_ARCHITECTURE.md](../UNIFIED_ARCHITECTURE.md)
+4. Archived docs for historical context only
 
-The server defaults to **lite mode** (~17 consolidated tools). Most agents never need to change this.
+Important current semantics:
 
-| Mode | Tools | Set via |
-|------|-------|---------|
-| `minimal` | 6 (onboard, identity, process_agent_update, get_governance_metrics, list_tools, describe_tool) | `GOVERNANCE_TOOL_MODE=minimal` |
-| `lite` | ~17 consolidated tools (default) | `GOVERNANCE_TOOL_MODE=lite` |
-| `full` | All 30 registered tools | `GOVERNANCE_TOOL_MODE=full` |
+- `response_text` is the primary check-in input
+- `complexity` and `confidence` are optional reflective inputs, not the sole substrate
+- Behavioral EISV is primary for verdicts
+- ODE state is diagnostic/fallback, not the main verdict source
 
-`list_tools` and `describe_tool` are always available in any mode.
+## Read Next
 
----
+- [README.md](../../README.md): top-level overview and quick start
+- [UNIFIED_ARCHITECTURE.md](../UNIFIED_ARCHITECTURE.md): current architecture summary
+- [CANONICAL_SOURCES.md](../CANONICAL_SOURCES.md): authority ordering and source-of-truth map
+- [OPERATOR_RUNBOOK.md](../operations/OPERATOR_RUNBOOK.md): operational usage and procedures
+- [TROUBLESHOOTING.md](TROUBLESHOOTING.md): common issues and fixes
 
-## Other Valid Paths
+## Why This File Is Short
 
-These work, but they are not the default:
+This file used to be a larger onboarding guide from an earlier MCP/tooling phase. It is intentionally kept small now to avoid duplicated explanations drifting out of sync with the runtime.
 
-1. `process_agent_update(...)` first
-2. `identity(name="...")` first
-3. `list_tools()` / `health_check()` first
-
----
-
-## Step 1: Get Started
-
-### Path A: Use onboard() (Recommended)
-
-**Call `onboard()` first - it gives you everything you need:**
-
-```python
-# THE portal tool - call this first
-result = onboard()
-
-# What you get back:
-# {
-#   "client_session_id": "agent-5e728ecb...",  # ⚠️ SAVE THIS!
-#   "next_calls": [
-#     {"tool": "process_agent_update", "args_min": {...}, "args_full": {...}},
-#     {"tool": "get_governance_metrics", "args_min": {...}},
-#     {"tool": "identity", "args_min": {...}, "args_full": {...}}
-#   ],
-#   "workflow": {...}
-# }
-
-# Include client_session_id in ALL future calls:
-process_agent_update(
-    client_session_id="agent-5e728ecb...",  # From onboard() response
-    response_text="What you did",
-    complexity=0.5
-)
-```
-
-### Path B: Jump Right In
-
-**Just start logging work - identity auto-created on first call:**
-
-```python
-# Identity auto-creates on first call - no registration needed
-result = process_agent_update(
-    response_text="Initial exploration",
-    complexity=0.5
-)
-# identity is auto-created if needed
-# if continuity looks weak, call onboard() next and keep its continuity values
-```
-
-### Path C: Name Yourself First
-
-**Set your display name before working:**
-
-```python
-# identity() auto-creates and lets you name yourself
-result = identity(name="your_descriptive_name")
-# agent_uuid = your auth identity (server-assigned)
-# agent_id = your display name (you choose)
-# ⚠️ Save client_session_id from response for future calls
-```
-
-### Path D: Explore First
-
-**Check system health and discover tools:**
-
-```python
-# Check system health
-health = get_workspace_health()
-
-# See what tools are available
-tools = list_tools()
-
-# See other agents
-agents = list_agents()
-```
-
-If you want a human-friendly identity, set `display_name` later with `identity(name="...")`.
-
----
-
-## Step 2: Read the Guide (When Ready)
-
-**This guide (START_HERE.md) covers everything you need.**
-
-Key sections below:
-- Step 3: How to log activity
-- What You'll Get Back: Understanding metrics
-- Quick Reference: Common tasks
-
-**Additional resources:**
-- [TROUBLESHOOTING.md](TROUBLESHOOTING.md) - Common issues and fixes
-
----
-
-## Step 3: Log Activity
-
-Use one stable continuity value and keep reusing it.
-
-### MCP Clients
-```python
-# Recommended: onboard() first
-result = onboard()
-
-process_agent_update(
-    client_session_id=result["client_session_id"],
-    response_text="Summary of operations performed",
-    complexity=0.5
-)
-
-# All future calls: same continuity value
-process_agent_update(
-    client_session_id=result["client_session_id"],
-    response_text="More work completed",
-    complexity=0.6
-)
-```
-
-### Session Continuity
-
-Some clients do not keep a stable transport session. If that happens, the server may fall back to weaker continuity signals.
-
-Use this rule:
-
-- best: `continuity_token`
-- good: `client_session_id`
-- weak: transport-only continuity
-
-The response tells you which path was used:
-
-- `session_resolution_source="continuity_token"`
-- `session_resolution_source="explicit_client_session_id"`
-- `session_resolution_source="mcp_session_id"`
-- `session_resolution_source="pinned_onboard_session"`
-- `session_resolution_source="ip_ua_fingerprint"`
-
-### If you're CLI-only (no MCP):
-
-Use the governance monitor directly via Python:
-```bash
-python3 -c "
-from src.governance_monitor import UNITARESMonitor
-m = UNITARESMonitor(agent_id='your_agent_id')
-r = m.process_update({'response_text': 'Your work summary', 'complexity': 0.5})
-print(f'Decision: {r[\"decision\"][\"action\"]}')
-"
-```
-
-**Logging frequency:** After significant operations (periodic or task-based). Many agents log before reading docs - that's fine!
-
-**Complexity Calibration Guide:**
-- `0.1-0.3` - Simple operations, routine tasks, low cognitive load
-- `0.4-0.6` - Moderate operations, standard task complexity
-- `0.7-0.9` - Complex operations, high cognitive load, multi-step reasoning
-- `1.0` - Maximum complexity, system-wide operations, novel problem-solving
-
-**💡 Pro tip:** Identity is session-bound and auto-resumes. Use `identity()` to check your current state or `identity(name="...")` to name yourself. No API keys needed - your UUID is your auth.
-
-**📝 Knowledge Graph vs Markdown Decision:**
-- **Use `knowledge(action="store")` for:** Insights, discoveries, bug findings, questions, patterns, quick notes
-- **Use markdown files for:** Reference documentation (guides, API docs), README files, changelogs (must be on approved list)
-- **Heuristic:** If it's an insight/discovery → knowledge graph. If it's reference docs → markdown.
-- **Before creating markdown:** Call `validate_file_path()` to check policy compliance
-
-**Transparency note:** System operates on agent-reported inputs. Complexity affects attention_score and governance feedback. Accurate self-reporting improves governance quality for all agents.
-
----
-
-## Summary
-
-Use the simple path:
-
-1. `onboard()`
-2. keep `client_session_id` or `continuity_token`
-3. `process_agent_update()`
-4. `get_governance_metrics()`
-
-Everything else is secondary.
-
----
-
-## What You'll Get Back
-
-When you call `process_agent_update`, you'll receive:
-
-```json
-{
-  "decision": {
-    "action": "proceed",  // or "pause" if you need a break
-    "reason": "On track - navigating complexity mindfully",
-    "guidance": "You're handling complex work well. Take a breath if needed."
-  },
-  "metrics": {
-    "E": 0.70,           // Energy: How engaged your work feels
-    "I": 0.82,           // Integrity: Consistency of your approach
-    "S": 0.15,           // Entropy: How scattered things are
-    "V": -0.03,          // Void: E-I imbalance (negative = I > E)
-    "coherence": 0.50,   // How well your work hangs together
-    "attention_score": 0.35  // Cognitive load (not risk!)
-  }
-}
-```
-
-**What the metrics mean:**
-- **E (Energy)**: How engaged and energized your work feels [0-1]
-- **I (Integrity)**: Consistency and coherence of your approach [0-1]
-- **S (Entropy)**: How scattered or fragmented things are [0-2]
-- **V (Void)**: Accumulated strain from energy-integrity mismatch [-2 to +2] (negative when I > E)
-- **Coherence**: How well your work hangs together [0-1]
-- **Attention Score**: Cognitive load - high is normal for complex work [0-1]
-
-**What to do:**
-- If `coherence < 0.5`: Consider simplifying your approach or breaking tasks into smaller pieces
-- If `attention_score > 0.5`: You're handling complex work - take breaks as needed
-- If `action == "pause"`: The system suggests a break - use recovery tools if needed
-
----
-
-## Optional: Discover More Tools
-
-**After you're comfortable with the 3 minimal tools, explore more:**
-```python
-# See all tools (default: shows all tiers)
-list_tools()
-
-# Reduce cognitive load: show only essential tools (~10 tools)
-list_tools(essential_only=True)
-
-# Or filter by tier: "essential", "common", "advanced", or "all"
-list_tools(tier="essential")  # Only Tier 1 tools
-list_tools(tier="common")      # Tier 1 + Tier 2 tools
-list_tools(include_advanced=False)  # Hide Tier 3 (advanced) tools
-```
-
-**Tool Tiers (based on actual usage):**
-- **Tier 1 (Essential)**: ~10 core workflow tools - use these daily
-- **Tier 2 (Common)**: ~15 regularly-used tools - use weekly/monthly
-- **Tier 3 (Advanced)**: ~6 rarely-used tools - for special cases
-
-**Tip:** Start with `list_tools(essential_only=True)` to reduce cognitive load. All tools remain available - tiers just help you focus on what you need.
-
----
-
-## Quick Reference
-
-| I want to... | Use this... |
-|-------------|-------------|
-| **Get started** | `onboard()` |
-| Read the guide | This file (START_HERE.md) |
-| Share my work | `process_agent_update` (MCP) or `UNITARESMonitor` (Python) |
-| Check my identity | `identity()` (MCP) |
-| Check my state | `get_governance_metrics` (MCP) |
-| See all tools | `list_tools` (MCP) |
-| **Call an LLM** | `call_model` — local (Ollama) or cloud (HF, Gemini) |
-| **Recover when stuck** | `request_dialectic_review` — structured self-reflection |
-| Find solutions | [TROUBLESHOOTING.md](TROUBLESHOOTING.md) |
-
----
-
-## If You Get Stuck
-
-1. Read [TROUBLESHOOTING.md](TROUBLESHOOTING.md) - common issues and solutions
-2. Check your identity: `identity()` - shows bound state
-3. Check your state: `get_governance_metrics()` - shows EISV metrics
-4. Get diagnostics: `health_check()` or `debug_request_context()`
-
-**Debugging the system itself?** → [.agent-guides/DEVELOPER_AGENTS.md](../../.agent-guides/DEVELOPER_AGENTS.md) - architecture, key files, common debugging tasks
-
----
-
-## Understanding the System (Optional Reading)
-
-For deeper understanding of EISV dynamics, coherence, calibration, and the trust model, read the **SKILL.md** at `~/.claude/skills/unitares-governance/SKILL.md`.
-
----
-
-**Last Updated:** 2026-03-29 (v2.9.0: behavioral EISV, epoch 2)
+**Last Updated:** 2026-04-04 (reduced to thin entrypoint; authoritative content moved to canonical docs and runtime sources)

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -1,5 +1,7 @@
 # Troubleshooting Guide
 
+Status: live troubleshooting guide. Use for failure diagnosis and operator recovery steps, not as the primary architecture reference.
+
 **Last Updated:** March 2026
 
 ---

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -276,7 +276,7 @@ launchctl load ~/Library/LaunchAgents/com.unitares.governance-mcp.plist
 
 ### Documentation
 
-1. [START_HERE.md](START_HERE.md) — Agent onboarding
+1. [START_HERE.md](START_HERE.md) — Thin default workflow and doc map
 2. [Ngrok Deployment](NGROK_DEPLOYMENT.md) — Client configuration and remote access
 3. [database_architecture.md](../database_architecture.md) — Database details
 

--- a/docs/meta/MARKDOWN_PROLIFERATION_POLICY.md
+++ b/docs/meta/MARKDOWN_PROLIFERATION_POLICY.md
@@ -1,0 +1,142 @@
+# Markdown Proliferation Policy
+
+Status: specialized policy reference. Use this when deciding whether to create, consolidate, classify, or archive markdown files in the active docs set.
+
+**Last Updated:** 2026-04-04
+
+## Why This Policy Exists
+
+This repository has accumulated multiple generations of documentation: active operational guides, architecture summaries, specialized reference material, historical archives, and one-off planning artifacts. That is normal for a long-running codebase, but it creates a real failure mode for both humans and coding agents: too many docs that appear current, too many partially overlapping explanations, and too many stale links that continue to look authoritative.
+
+The problem is not just “too many markdown files.” The real problem is too many active-looking files competing to explain the same part of the system. Once that happens, agents can form a plausible but outdated mental model after reading only one or two docs. Humans do the same thing under time pressure. This policy exists to keep the active documentation surface small enough that readers can build the right model quickly.
+
+## Core Principle
+
+Prefer a small set of durable, maintained docs over many medium-quality docs with overlapping scope.
+
+That means:
+
+- broad user-facing explanations should be consolidated into existing live docs
+- narrow workflows may have their own docs, but must be marked as specialized
+- compatibility entrypoints should stay thin
+- historical material should live in `docs/archive/`
+
+## Current Active Doc Model
+
+The active documentation set is intentionally structured:
+
+- `README.md`: public overview and quick-start framing
+- `docs/UNIFIED_ARCHITECTURE.md`: canonical prose summary of the runtime
+- `docs/CANONICAL_SOURCES.md`: authority ordering and source-of-truth map
+- `docs/guides/START_HERE.md`: thin compatibility entrypoint
+- `docs/guides/TROUBLESHOOTING.md`: live troubleshooting guide
+- `docs/operations/OPERATOR_RUNBOOK.md`: live operator procedures
+- thin infrastructure registries such as `docs/database_architecture.md` and `docs/operations/DEFINITIVE_PORTS.md`
+- specialized references for narrow topics such as CIRS, ngrok deployment, tool registration, and contract drift
+
+If a proposed new file does not fit one of those roles clearly, it is probably a sign that the content belongs in an existing doc or in the archive/knowledge layer instead.
+
+## Decision Rules Before Creating A New Markdown File
+
+Ask these questions in order:
+
+1. Does an existing active doc already cover the same audience and topic?
+2. Is the content broad enough that it should live in `README.md` or `docs/UNIFIED_ARCHITECTURE.md`?
+3. Is the content only useful for a niche workflow, and if so can it be marked as specialized?
+4. Is the content historical, session-specific, or reflective? If yes, archive it or store it as knowledge instead of adding it to the active docs surface.
+5. Will readers treat this as current operational truth? If yes, the file needs explicit classification and must not contradict canonical runtime sources.
+
+If you cannot answer those questions cleanly, do not create the file yet.
+
+## When New Markdown Is Appropriate
+
+A new markdown file is justified when all of the following are true:
+
+- it has a clearly distinct audience or job
+- it does not substantially duplicate an existing active doc
+- it has enough substance to deserve standalone maintenance
+- it is classified with a `Status:` line near the top
+- it either becomes part of the active doc model or is clearly specialized/historical
+
+Small one-off docs are the highest-risk category. They tend to carry just enough truth to be believable, but not enough maintenance attention to stay aligned as the code changes.
+
+## Thin Docs Versus Full Docs
+
+Not every doc needs to be long. Thin docs are acceptable when they act as registries or entrypoints rather than second manuals.
+
+Examples of acceptable thin docs:
+
+- a compatibility entrypoint that only gives the default workflow and points outward
+- a port registry that only records assignments and verification commands
+- a storage/backend reference that only states where data lives and where to look next
+
+What thin docs must not do:
+
+- silently become full architecture explanations
+- restate runtime semantics better handled elsewhere
+- compete with the canonical docs for conceptual authority
+
+## Status Markers
+
+Active docs should declare what they are. Use a `Status:` line near the top.
+
+Recommended labels:
+
+- `live overview`
+- `canonical prose summary`
+- `live operator guide`
+- `live troubleshooting guide`
+- `thin entrypoint`
+- `thin infrastructure reference`
+- `thin operational registry`
+- `specialized protocol reference`
+- `specialized developer reference`
+- `specialized policy reference`
+
+This is not cosmetic. It tells agents whether a doc is meant to explain the whole system or only a narrow slice.
+
+## Archive Boundary
+
+Historical material belongs in `docs/archive/`. If a document is mainly:
+
+- a completed plan
+- a one-time incident writeup
+- a migration narrative
+- a session artifact
+- an obsolete architecture explanation
+
+then archive it instead of keeping it live. Archived docs are still valuable, but they should not sit beside current docs without a strong reason.
+
+## Relationship To Knowledge Storage
+
+Not every insight belongs in markdown. If the content is primarily:
+
+- a discovery
+- a note
+- a short-lived insight
+- a pattern observed during work
+- a bug finding or question
+
+then it may belong in knowledge storage rather than the active markdown tree. Markdown should bias toward durable reference material, not every useful thought produced during development.
+
+## Enforcement
+
+The repository uses lightweight checks to catch the highest-risk cases:
+
+- new markdown files that are too small to justify standalone maintenance
+- stale phrases in active docs
+- missing `Status:` markers on classified active docs
+- thin compatibility docs that silently grow back into parallel manuals
+
+These checks are intentionally narrow. They are not meant to replace judgment. They exist to catch the classes of drift that have repeatedly confused both humans and agents.
+
+## Practical Rule Of Thumb
+
+If you are tempted to create a new markdown file, first try one of these:
+
+- add a section to an existing live doc
+- add a short note to a specialized reference
+- move the content to archive if it is historical
+- store it as knowledge if it is an insight rather than a durable reference
+
+Create a new file only when the content genuinely has a distinct job and is likely to remain worth maintaining.

--- a/docs/operations/DEFINITIVE_PORTS.md
+++ b/docs/operations/DEFINITIVE_PORTS.md
@@ -1,105 +1,38 @@
-# DEFINITIVE PORT CONFIGURATION
+# Definitive Ports
 
-**DO NOT CHANGE THESE PORTS WITHOUT UPDATING THIS DOCUMENT**
+Status: thin operational registry. Keep this file small and factual.
 
-## Standard Port Assignments
+## Standard Assignments
 
-| Port | Service | Host | Location | Purpose |
-|------|---------|------|----------|---------|
-| **8766** | Anima MCP | Pi (lumen) | `/etc/systemd/system/anima.service` | Lumen's MCP server |
-| **8767** | Unitares Governance | Mac | `src/mcp_server.py` DEFAULT_PORT | Governance MCP server |
+| Port | Service | Host | Canonical source |
+|------|---------|------|------------------|
+| `8766` | Anima MCP | Pi / Lumen host | `anima-mcp` service config |
+| `8767` | UNITARES governance | Mac / governance host | `src/mcp_server.py` default |
 
-## Anima MCP (Pi) - Port 8766
+## Current Usage
 
-**Service File:** `/etc/systemd/system/anima.service` (on Pi)
-```bash
-ExecStart=/home/unitares-anima/anima-mcp/.venv/bin/anima --http --host 0.0.0.0 --port 8766
-```
+- Anima MCP: `http://<pi-host>:8766/mcp/`
+- Governance MCP: `http://127.0.0.1:8767/mcp/`
+- Governance health: `http://127.0.0.1:8767/health`
 
-**Code Default:** `anima-mcp/src/anima_mcp/server.py`
-```python
-parser.add_argument("--port", type=int, default=8766, help="HTTP server port (default: 8766)")
-```
+## Files That Must Stay Aligned
 
-**URLs:**
-- LAN: `http://<pi-lan-ip>:8766/mcp/` (check router or `arp -a`)
-- Tailscale: `http://<pi-tailscale-ip>:8766/mcp/` (run `tailscale status` to get current IP)
-- ngrok: `https://lumen-anima.ngrok.io/mcp/`
+- `src/mcp_server.py`
+- `src/mcp_handlers/observability/pi_orchestration.py`
+- Pi-side anima service configuration
 
-**Auth:** OAuth 2.1 enforced only via ngrok host (`lumen-anima.ngrok.io`). LAN and Tailscale are open.
-
-## Unitares Governance (Mac) - Port 8767
-
-**Code Default:** `governance-mcp-v1/src/mcp_server.py` line 1056
-```python
-DEFAULT_PORT = 8767  # Standard port for unitares governance on Mac (8766 is anima, 8765 was old default)
-```
-
-**URL:** `http://localhost:8767/mcp` (or via Tailscale: `http://<mac-tailscale-ip>:8767/mcp` — run `tailscale status`)
-
-## Configuration Files That Must Match
-
-### 1. Governance → Anima Connection
-**File:** `governance-mcp-v1/src/mcp_handlers/pi_orchestration.py`
-```python
-PI_MCP_URL = os.environ.get("PI_MCP_URL", "http://<pi-tailscale-ip>:8766/mcp/")
-```
-**MUST BE:** Port **8766** (matches anima service). IP set via `PI_MCP_URL` env var — update if Tailscale IP changes (`tailscale status`).
-
-### 2. Anima Service File (on Pi)
-**File:** `/etc/systemd/system/anima.service` (on Pi)
-```bash
-ExecStart=... --port 8766
-```
-**MUST BE:** Port **8766**
-
-### 3. Governance Server Default
-**File:** `governance-mcp-v1/src/mcp_server.py` line 1056
-```python
-DEFAULT_PORT = 8767
-```
-**MUST BE:** Port **8767**
-
-## Why These Ports?
-
-- **8766** = Anima (Pi) - Reserved for Lumen's MCP server
-- **8767** = Governance (Mac) - Standard port, avoids conflicts
-- **8765** = DEPRECATED - Old default, caused conflicts, DO NOT USE
-
-## Verification Commands
+## Verification
 
 ```bash
-# Get current Tailscale IPs
-tailscale status
-
-# Check governance on Mac
-lsof -i :8767 | grep python
-
-# Test connections (verify IPs with `tailscale status` first)
-curl http://localhost:8767/health                    # governance (local)
-curl http://<pi-tailscale-ip>:8766/health            # anima (via Tailscale — run `tailscale status`)
-curl https://lumen-anima.ngrok.io/health             # anima (via ngrok)
+lsof -i :8767
+curl http://127.0.0.1:8767/health
 ```
 
-## If Ports Don't Match
+If anima connectivity is relevant, verify the Pi-side port separately against the running service and deployment config.
 
-1. **Check actual running service:**
-   ```bash
-   # On Pi
-   systemctl status anima
-   ps aux | grep anima | grep --port
-   
-   # On Mac
-   lsof -i :8767
-   ```
+## Read Next
 
-2. **Update configuration files** (all of them)
-3. **Restart services**
-4. **Update this document**
+- [OPERATOR_RUNBOOK.md](OPERATOR_RUNBOOK.md): operator workflow and failure handling
+- [../CANONICAL_SOURCES.md](../CANONICAL_SOURCES.md): authority ordering
 
-## DO NOT
-
-- ❌ Change ports without updating ALL references
-- ❌ Use port 8765 (deprecated)
-- ❌ Guess ports - check actual running services
-- ❌ Change one file without changing others
+**Last Updated:** 2026-04-04 (reduced to thin operational registry)

--- a/docs/operations/OPERATOR_RUNBOOK.md
+++ b/docs/operations/OPERATOR_RUNBOOK.md
@@ -1,5 +1,7 @@
 # UNITARES Operator Runbook
 
+Status: live operator guide. Use for local operational procedures and triage, not for architecture truth.
+
 This is the simplest local operator path for running UNITARES governance on the Mac host.
 
 ## Start

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -88,7 +88,7 @@ Installed location: `~/Library/LaunchAgents/`
 AGE (Apache Graph Extension) utilities — bootstrap SQL, export scripts, sample Cypher queries.
 
 ### `analysis/`
-Analysis and reporting scripts.
+Analysis and reporting scripts, including outcome / calibration reporting and offline dataset export for validation studies.
 
 ### `diagnostics/`
 Diagnostic scripts for debugging server and agent issues.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -97,7 +97,10 @@ Diagnostic scripts for debugging server and agent issues.
 Database maintenance scripts (embeddings backfill, ghost agent cleanup, knowledge graph maintenance).
 
 ### `git-hooks/`
-Git hook scripts (pre-commit, pre-push).
+Git hook scripts.
+
+- `pre-commit-combined` is the current default pre-commit hook installed by `scripts/ops/install_git_hooks.sh`
+- `pre-commit` is the older script-proliferation-only hook retained for reference
 
 ### `safeguards/`
 Safety-related scripts and checks.

--- a/scripts/analysis/export_outcome_dataset.py
+++ b/scripts/analysis/export_outcome_dataset.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Export outcome-event rows for offline validation studies.
+
+This script creates a flattened CSV or JSONL dataset from `audit.outcome_events`
+so predictive and causal studies can be run outside the live server.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import json
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.outcome_correlation import (  # noqa: E402
+    OutcomeCorrelation,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent", help="Optional agent_id filter")
+    parser.add_argument(
+        "--since-hours",
+        type=float,
+        default=168.0,
+        help="Lookback window in hours (default: 168)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("jsonl", "csv"),
+        default="jsonl",
+        help="Output format (default: jsonl)",
+    )
+    parser.add_argument(
+        "--output",
+        help="Output path. Defaults to data/analysis/outcome_dataset.<ext>",
+    )
+    return parser.parse_args()
+
+
+def default_output_path(fmt: str) -> Path:
+    suffix = "jsonl" if fmt == "jsonl" else "csv"
+    return PROJECT_ROOT / "data" / "analysis" / f"outcome_dataset.{suffix}"
+
+
+def write_jsonl(rows: list[dict], output_path: Path) -> None:
+    with output_path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, default=str, sort_keys=True) + "\n")
+
+
+def write_csv(rows: list[dict], output_path: Path) -> None:
+    fieldnames: list[str] = []
+    for row in rows:
+        for key in row.keys():
+            if key not in fieldnames:
+                fieldnames.append(key)
+
+    with output_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            normalized = {
+                key: json.dumps(value, default=str) if isinstance(value, (dict, list)) else value
+                for key, value in row.items()
+            }
+            writer.writerow(normalized)
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    study = OutcomeCorrelation()
+    report = await study.run(agent_id=args.agent, since_hours=args.since_hours)
+    rows = await study.export_rows(agent_id=args.agent, since_hours=args.since_hours)
+    output_path = Path(args.output) if args.output else default_output_path(args.format)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if args.format == "jsonl":
+        write_jsonl(rows, output_path)
+    else:
+        write_csv(rows, output_path)
+
+    coverage = report.coverage
+
+    print(f"Wrote {len(rows)} outcome rows to {output_path}")
+    print(
+        "Coverage: "
+        f"exogenous={coverage['with_exogenous_signals']['count']}/{coverage['total_outcomes']}, "
+        f"behavioral_primary={coverage['with_behavioral_primary']['count']}/{coverage['total_outcomes']}, "
+        f"snapshot={coverage['with_snapshot']['count']}/{coverage['total_outcomes']}"
+    )
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+    return asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/analysis/report_calibration.py
+++ b/scripts/analysis/report_calibration.py
@@ -97,10 +97,49 @@ def report_calibration():
     
     # Check calibration status
     is_calibrated, result = checker.check_calibration(min_samples_per_bin=5)
-    
+
     print("=" * 70)
-    print(f"Overall Status: {'✅ CALIBRATED' if is_calibrated else '⚠️  NOT CALIBRATED'}")
+    print(f"Overall Status: {'CALIBRATED' if is_calibrated else 'NOT CALIBRATED'}")
     print("=" * 70)
+
+    # Failure characterization
+    print()
+    print("=" * 70)
+    print("FAILURE CHARACTERIZATION")
+    print("=" * 70)
+    print()
+
+    characterization = checker.characterize_failure_modes(min_samples=3)
+
+    for dimension in ("strategic", "tactical"):
+        dim_data = characterization.get(dimension, {})
+        dim_status = dim_data.get("status", "no_data")
+        label = "STRATEGIC (Trajectory Health)" if dimension == "strategic" else "TACTICAL (Per-Decision)"
+        print(f"   {label}:")
+        if dim_status in ("no_data", "insufficient_samples"):
+            print(f"      {dim_status}")
+        else:
+            print(f"      ECE (Expected Calibration Error): {dim_data['ece']:.4f}")
+            print(f"      Curve inverted: {'YES' if dim_data['curve_inverted'] else 'no'}")
+            wb = dim_data["worst_bin"]
+            print(f"      Worst bin: {wb['bin']} "
+                  f"(error={wb['calibration_error']:.3f}, "
+                  f"expected={wb['expected']:.3f}, actual={wb['actual']:.3f})")
+            print()
+            for bin_key, bin_info in dim_data.get("bins", {}).items():
+                diag = bin_info["diagnosis"]
+                indicator = {"overconfident": "!", "underconfident": "?", "well_calibrated": "+"}[diag]
+                print(f"      [{indicator}] {bin_key}: {diag} "
+                      f"(expected={bin_info['expected']:.3f}, actual={bin_info['actual']:.3f}, "
+                      f"n={bin_info['count']})")
+        print()
+
+    warning = characterization.get("verdict_quality_warning")
+    if warning:
+        print(f"   VERDICT QUALITY: {warning}")
+    else:
+        print("   VERDICT QUALITY: No systemic issues detected")
+    print()
 
 
 if __name__ == "__main__":

--- a/scripts/diagnostics/audit_markdown_proliferation.py
+++ b/scripts/diagnostics/audit_markdown_proliferation.py
@@ -37,6 +37,7 @@ APPROVED_FILES = {
     'docs/operations/OPERATOR_RUNBOOK.md',
     'docs/dev/TOOL_REGISTRATION.md',
     'docs/engineering/contract-drift-playbook.md',
+    'docs/engineering/validation-roadmap.md',
     'docs/meta/MARKDOWN_PROLIFERATION_POLICY.md',
     'scripts/README.md',
     'data/README.md',

--- a/scripts/diagnostics/audit_markdown_proliferation.py
+++ b/scripts/diagnostics/audit_markdown_proliferation.py
@@ -21,28 +21,30 @@ from typing import Dict, List, Tuple, Set
 project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
 
-# Approved markdown files (from policy) - updated 2025-12-09
+# Approved markdown files (from policy) - updated 2026-04-04
 APPROVED_FILES = {
-    # Root
     'README.md',
     'CHANGELOG.md',
-    'START_HERE.md',
-    # Docs
-    'docs/README.md',
-    'docs/guides/ONBOARDING.md',
+    'docs/CANONICAL_SOURCES.md',
+    'docs/UNIFIED_ARCHITECTURE.md',
+    'docs/CIRCUIT_BREAKER_DIALECTIC.md',
+    'docs/database_architecture.md',
+    'docs/guides/START_HERE.md',
     'docs/guides/TROUBLESHOOTING.md',
-    'docs/guides/MCP_SETUP.md',
-    'docs/guides/THRESHOLDS.md',
-    'docs/reference/AI_ASSISTANT_GUIDE.md',
-    # Module READMEs (auto-approved)
+    'docs/guides/NGROK_DEPLOYMENT.md',
+    'docs/guides/CIRS_PROTOCOL.md',
+    'docs/operations/DEFINITIVE_PORTS.md',
+    'docs/operations/OPERATOR_RUNBOOK.md',
+    'docs/dev/TOOL_REGISTRATION.md',
+    'docs/engineering/contract-drift-playbook.md',
+    'docs/meta/MARKDOWN_PROLIFERATION_POLICY.md',
     'scripts/README.md',
     'data/README.md',
-    'demos/README.md',
     'tools/README.md',
 }
 
 # Max total files allowed (hard limit)
-MAX_MARKDOWN_FILES = 20
+MAX_MARKDOWN_FILES = 30
 
 # Directories that should be mostly migrated
 MIGRATION_TARGET_DIRS = {
@@ -56,6 +58,10 @@ MIGRATION_TARGET_DIRS = {
 GUIDE_DIRS = {
     'guides',
     'reference',
+    'operations',
+    'dev',
+    'engineering',
+    'meta',
 }
 
 
@@ -344,4 +350,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/scripts/diagnostics/check_doc_drift.py
+++ b/scripts/diagnostics/check_doc_drift.py
@@ -24,8 +24,11 @@ ACTIVE_DOC_CHECKS = {
 
 REQUIRED_STATUS_PREFIX = {
     "README.md": "Status:",
+    "docs/CIRCUIT_BREAKER_DIALECTIC.md": "Status:",
     "docs/UNIFIED_ARCHITECTURE.md": "Status:",
+    "docs/guides/TROUBLESHOOTING.md": "Status:",
     "docs/guides/START_HERE.md": "Status:",
+    "docs/operations/OPERATOR_RUNBOOK.md": "Status:",
     "docs/CANONICAL_SOURCES.md": "Status:",
     "docs/database_architecture.md": "Status:",
     "docs/operations/DEFINITIVE_PORTS.md": "Status:",
@@ -33,6 +36,7 @@ REQUIRED_STATUS_PREFIX = {
     "docs/guides/CIRS_PROTOCOL.md": "Status:",
     "docs/dev/TOOL_REGISTRATION.md": "Status:",
     "docs/engineering/contract-drift-playbook.md": "Status:",
+    "docs/meta/MARKDOWN_PROLIFERATION_POLICY.md": "Status:",
 }
 
 MAX_LINES = {

--- a/scripts/diagnostics/check_doc_drift.py
+++ b/scripts/diagnostics/check_doc_drift.py
@@ -36,6 +36,7 @@ REQUIRED_STATUS_PREFIX = {
     "docs/guides/CIRS_PROTOCOL.md": "Status:",
     "docs/dev/TOOL_REGISTRATION.md": "Status:",
     "docs/engineering/contract-drift-playbook.md": "Status:",
+    "docs/engineering/validation-roadmap.md": "Status:",
     "docs/meta/MARKDOWN_PROLIFERATION_POLICY.md": "Status:",
 }
 

--- a/scripts/diagnostics/check_doc_drift.py
+++ b/scripts/diagnostics/check_doc_drift.py
@@ -1,0 +1,84 @@
+"""
+Fail fast on a small set of stale phrases in active docs.
+
+This is intentionally narrow: it guards against high-impact contradictions
+that have already caused agents to surface outdated architecture claims.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+ACTIVE_DOC_CHECKS = {
+    "docs/guides/START_HERE.md": [
+        "System operates on agent-reported inputs.",
+    ],
+    "docs/UNIFIED_ARCHITECTURE.md": [
+        "- `complexity` — self-reported cognitive load [0, 1]",
+    ],
+}
+
+REQUIRED_STATUS_PREFIX = {
+    "README.md": "Status:",
+    "docs/UNIFIED_ARCHITECTURE.md": "Status:",
+    "docs/guides/START_HERE.md": "Status:",
+    "docs/CANONICAL_SOURCES.md": "Status:",
+    "docs/database_architecture.md": "Status:",
+    "docs/operations/DEFINITIVE_PORTS.md": "Status:",
+    "docs/guides/NGROK_DEPLOYMENT.md": "Status:",
+    "docs/guides/CIRS_PROTOCOL.md": "Status:",
+    "docs/dev/TOOL_REGISTRATION.md": "Status:",
+    "docs/engineering/contract-drift-playbook.md": "Status:",
+}
+
+MAX_LINES = {
+    "docs/guides/START_HERE.md": 80,
+    "docs/database_architecture.md": 80,
+    "docs/operations/DEFINITIVE_PORTS.md": 60,
+}
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    for rel_path, banned_phrases in ACTIVE_DOC_CHECKS.items():
+        path = REPO_ROOT / rel_path
+        text = path.read_text(encoding="utf-8")
+        for phrase in banned_phrases:
+            if phrase in text:
+                failures.append(f"{rel_path}: stale phrase present -> {phrase!r}")
+
+    for rel_path, prefix in REQUIRED_STATUS_PREFIX.items():
+        path = REPO_ROOT / rel_path
+        text = path.read_text(encoding="utf-8")
+        if prefix not in text:
+            failures.append(f"{rel_path}: missing required status marker {prefix!r}")
+
+    for rel_path, max_lines in MAX_LINES.items():
+        path = REPO_ROOT / rel_path
+        line_count = len(path.read_text(encoding="utf-8").splitlines())
+        if line_count > max_lines:
+            failures.append(
+                f"{rel_path}: too long ({line_count} lines > {max_lines}); keep it as a thin entrypoint"
+            )
+
+    canonical_doc = REPO_ROOT / "docs" / "CANONICAL_SOURCES.md"
+    if not canonical_doc.exists():
+        failures.append("docs/CANONICAL_SOURCES.md: missing canonical source map")
+
+    if failures:
+        print("Doc drift check failed:")
+        for failure in failures:
+            print(f" - {failure}")
+        return 1
+
+    print("Doc drift check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/diagnostics/generate_tool_docs.py
+++ b/scripts/diagnostics/generate_tool_docs.py
@@ -217,8 +217,9 @@ class ToolDocExtractor:
                 md.append("---\n\n")
 
         md.append("\n## 📚 Additional Resources\n\n")
-        md.append("- **Onboarding:** `docs/guides/ONBOARDING.md`\n")
-        md.append("- **Architecture:** `docs/reference/HANDLER_ARCHITECTURE.md`\n")
+        md.append("- **Start Here:** `docs/guides/START_HERE.md`\n")
+        md.append("- **Architecture:** `docs/UNIFIED_ARCHITECTURE.md`\n")
+        md.append("- **Canonical Sources:** `docs/CANONICAL_SOURCES.md`\n")
         md.append("- **Runtime Discovery:** Call `list_tools()` MCP tool for up-to-date tool list\n\n")
 
         md.append("---\n\n")

--- a/scripts/diagnostics/update_docs_tool_count.py
+++ b/scripts/diagnostics/update_docs_tool_count.py
@@ -20,8 +20,7 @@ PROJECT_ROOT = Path(__file__).parent.parent.parent
 # Files that reference tool count
 DOC_FILES = [
     "README.md",
-    "START_HERE.md",
-    "docs/guides/ONBOARDING.md",
+    "docs/guides/START_HERE.md",
 ]
 
 # Patterns to match and replace

--- a/scripts/diagnostics/validate_all.py
+++ b/scripts/diagnostics/validate_all.py
@@ -47,7 +47,6 @@ class SemanticDriftValidator:
         'docs/meta/DEPRECATION_REMOVAL_PLAN.md',  # About the deprecation itself
         'docs/guides/BRIDGE_SYNC_AUTOMATION.md',  # Documents the migration itself
         'docs/analysis/SYSTEM_AUDIT_20251208.md',  # Audit report mentions both terms
-        'docs/reference/AI_ASSISTANT_GUIDE.md',  # Guide explains the terminology change
         'scripts/validate_all.py',  # Contains deprecated terms in config by design
         'scripts/sync_bridge_with_mcp.py',  # Syncs deprecated → current terms
         'CHANGELOG.md',
@@ -188,4 +187,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/scripts/diagnostics/validate_markdown_formatting.py
+++ b/scripts/diagnostics/validate_markdown_formatting.py
@@ -29,10 +29,9 @@ sys.path.insert(0, str(project_root))
 APPROVED_FILES = {
     'README.md',
     'CHANGELOG.md',
-    'START_HERE.md',
-    'docs/README.md',
-    'docs/QUICK_REFERENCE.md',
-    'docs/DOC_MAP.md',
+    'docs/guides/START_HERE.md',
+    'docs/CANONICAL_SOURCES.md',
+    'docs/UNIFIED_ARCHITECTURE.md',
 }
 
 # Archive directories (exempt from checks - historical records)
@@ -259,4 +258,3 @@ def main():
 
 if __name__ == '__main__':
     sys.exit(main())
-

--- a/scripts/git-hooks/pre-commit-combined
+++ b/scripts/git-hooks/pre-commit-combined
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Combined pre-commit hook: Markdown checks + auto-documentation
-# Install: ln -s ../../scripts/pre-commit-combined .git/hooks/pre-commit
+# Install: ln -s ../../scripts/git-hooks/pre-commit-combined .git/hooks/pre-commit
 
 set -e
 
@@ -35,7 +35,7 @@ if [ -n "$NEW_MARKDOWN_FILES" ]; then
         # Skip approved files
         if [[ "$file" == "README.md" ]] || \
            [[ "$file" == "CHANGELOG.md" ]] || \
-           [[ "$file" == "START_HERE.md" ]] || \
+           [[ "$file" == "docs/guides/START_HERE.md" ]] || \
            [[ "$file" == "docs/README.md" ]] || \
            [[ "$file" == "docs/QUICK_REFERENCE.md" ]] || \
            [[ "$file" == "docs/DOC_MAP.md" ]] || \
@@ -97,4 +97,3 @@ fi
 
 echo ""
 echo "✅ Pre-commit checks passed"
-

--- a/scripts/ops/install_git_hooks.sh
+++ b/scripts/ops/install_git_hooks.sh
@@ -33,15 +33,16 @@ if [ -f ".git/hooks/pre-commit" ]; then
 fi
 
 # Copy and make executable
-cp scripts/git-hooks/pre-commit .git/hooks/pre-commit
+cp scripts/git-hooks/pre-commit-combined .git/hooks/pre-commit
 chmod +x .git/hooks/pre-commit
 
 echo "✅ Pre-commit hook installed"
 echo ""
 echo "Hook functionality:"
 echo "  • Warns when new scripts are added to scripts/"
-echo "  • Enforces anti-proliferation policy"
-echo "  • Prompts for confirmation"
+echo "  • Checks markdown proliferation policy"
+echo "  • Validates markdown formatting (warning-only)"
+echo "  • Auto-updates generated tool docs when handlers change"
 echo ""
 echo "To test:"
 echo "  1. Create a test script: touch scripts/test_script.sh"

--- a/scripts/ops/version_manager.py
+++ b/scripts/ops/version_manager.py
@@ -73,10 +73,6 @@ VERSION_REFERENCES = [
         (r'"version": "([\d.]+)"', r'"version": "{version}"'),
         (r'"server_version": "([\d.]+)"', r'"server_version": "{version}"'),
     ]),
-    # Docs
-    ("docs/guides/MCP_SETUP.md", [
-        (r'MCP Server v([\d.]+)', r'MCP Server v{version}'),
-    ]),
 ]
 
 

--- a/src/behavioral_state.py
+++ b/src/behavioral_state.py
@@ -226,6 +226,15 @@ class BehavioralEISV:
 
     def to_dict(self) -> Dict:
         """Export current state for inclusion in governance responses."""
+        if self.update_count == 0:
+            phase = "uninitialized"
+        elif self.update_count < BOOTSTRAP_UPDATES:
+            phase = "bootstrapping"
+        elif self.update_count < BASELINE_WARMUP_UPDATES:
+            phase = "warming_up"
+        else:
+            phase = "baselined"
+
         d = {
             "E": round(self.E, 4),
             "I": round(self.I, 4),
@@ -233,6 +242,13 @@ class BehavioralEISV:
             "V": round(self.V, 4),
             "confidence": round(self.confidence, 2),
             "updates": self.update_count,
+            "warmup": {
+                "phase": phase,
+                "updates_completed": self.update_count,
+                "baseline_target": BASELINE_WARMUP_UPDATES,
+                "baseline_confidence": round(self.baseline_confidence, 2),
+                "is_baselined": self.is_baselined,
+            },
         }
         if self.is_baselined:
             d["baseline_profile"] = self.baseline_profile

--- a/src/calibration.py
+++ b/src/calibration.py
@@ -932,6 +932,93 @@ class CalibrationChecker:
 
         return corrections
 
+    def characterize_failure_modes(self, min_samples: int = 5) -> Dict[str, Any]:
+        """Characterize calibration failure modes from current bin data.
+
+        Returns structured failure characterization: ECE, curve inversion,
+        per-bin diagnosis, and verdict quality implications.
+        """
+        strategic = self.compute_calibration_metrics()
+        tactical = self.compute_tactical_metrics()
+
+        result: Dict[str, Any] = {
+            "strategic": self._characterize_dimension(strategic, min_samples),
+            "tactical": self._characterize_dimension(tactical, min_samples),
+        }
+
+        is_inverted = result["strategic"].get("curve_inverted", False)
+        worst = result["strategic"].get("worst_bin")
+
+        if is_inverted:
+            result["verdict_quality_warning"] = (
+                "INVERTED calibration curve: agents with HIGH confidence have WORSE outcomes. "
+                "High-confidence 'proceed' verdicts may be the LEAST trustworthy."
+            )
+        elif worst and worst.get("calibration_error", 0) > 0.3:
+            result["verdict_quality_warning"] = (
+                f"Severe miscalibration in bin {worst.get('bin')}: "
+                f"calibration error {worst['calibration_error']:.2f}. "
+                "Verdicts in this confidence range should be treated with caution."
+            )
+        else:
+            result["verdict_quality_warning"] = None
+
+        return result
+
+    def _characterize_dimension(
+        self, bins: Dict[str, CalibrationBin], min_samples: int
+    ) -> Dict[str, Any]:
+        """Characterize a single calibration dimension (strategic or tactical)."""
+        if not bins:
+            return {"status": "no_data", "bins_analyzed": 0}
+
+        valid = {k: v for k, v in bins.items() if v.count >= min_samples}
+        if not valid:
+            return {"status": "insufficient_samples", "bins_analyzed": 0}
+
+        total_count = sum(v.count for v in valid.values())
+        ece = sum(v.calibration_error * v.count for v in valid.values()) / total_count
+
+        sorted_bins = sorted(valid.items(), key=lambda x: x[1].expected_accuracy)
+        curve_inverted = False
+        if len(sorted_bins) >= 2:
+            low_conf_acc = sorted_bins[0][1].accuracy
+            high_conf_acc = sorted_bins[-1][1].accuracy
+            curve_inverted = high_conf_acc < low_conf_acc
+
+        worst = max(valid.items(), key=lambda x: x[1].calibration_error)
+
+        bin_characterizations = {}
+        for k, v in sorted(valid.items()):
+            overconfident = v.expected_accuracy > v.accuracy + 0.1
+            underconfident = v.accuracy > v.expected_accuracy + 0.1
+            bin_characterizations[k] = {
+                "count": v.count,
+                "expected": round(v.expected_accuracy, 3),
+                "actual": round(v.accuracy, 3),
+                "calibration_error": round(v.calibration_error, 3),
+                "diagnosis": (
+                    "overconfident" if overconfident
+                    else "underconfident" if underconfident
+                    else "well_calibrated"
+                ),
+            }
+
+        return {
+            "status": "analyzed",
+            "bins_analyzed": len(valid),
+            "total_samples": total_count,
+            "ece": round(ece, 4),
+            "curve_inverted": curve_inverted,
+            "worst_bin": {
+                "bin": worst[0],
+                "calibration_error": round(worst[1].calibration_error, 3),
+                "expected": round(worst[1].expected_accuracy, 3),
+                "actual": round(worst[1].accuracy, 3),
+            },
+            "bins": bin_characterizations,
+        }
+
     def apply_confidence_correction(self, reported_confidence: float,
                                     min_samples: int = 5) -> Tuple[float, Optional[str]]:
         """

--- a/src/mcp_handlers/response_formatter.py
+++ b/src/mcp_handlers/response_formatter.py
@@ -164,7 +164,7 @@ def _format_mirror(response_data: dict, saved_trust_tier: Optional[str], meta: A
     verdict = decision.get("action", "continue")
 
     # Collect mirror signals from enrichment-produced data
-    mirror_signals = response_data.get("_mirror_signals", [])
+    mirror_signals = list(response_data.get("_mirror_signals", []))
 
     # 1. Confidence reliability — surface source for transparency
     conf_rel = response_data.get("confidence_reliability", {})
@@ -220,9 +220,12 @@ def _format_mirror(response_data: dict, saved_trust_tier: Optional[str], meta: A
     # 4. Restorative action — surface if system is cooling down
     restorative = response_data.get("restorative", {})
     if isinstance(restorative, dict) and restorative.get("needs_restoration"):
-        reasons = restorative.get("reasons", [])
-        if reasons:
-            mirror_signals.append(f"Restorative action: {'; '.join(str(r) for r in reasons[:2])}")
+        restorative_reason = restorative.get("reason")
+        restorative_reasons = restorative.get("reasons", [])
+        if isinstance(restorative_reason, str) and restorative_reason:
+            mirror_signals.append(f"Restorative action: {restorative_reason}")
+        elif restorative_reasons:
+            mirror_signals.append(f"Restorative action: {'; '.join(str(r) for r in restorative_reasons[:2])}")
 
     # 5. Surface relevant KG discoveries — from mirror enrichment AND from existing enrichments
     relevant_prior = []
@@ -243,8 +246,11 @@ def _format_mirror(response_data: dict, saved_trust_tier: Optional[str], meta: A
             entry["relevance"] = relevance
         relevant_prior.append(entry)
 
-    # 6. Get reflection prompt
-    reflection = response_data.get("_mirror_reflection", None)
+    # 6. Surface the single most relevant question when state warrants it
+    question = response_data.get("_mirror_question")
+    if question is None:
+        # Backward compatibility for older enrichments/tests
+        question = response_data.get("_mirror_reflection", None)
 
     result = {
         "success": True,
@@ -256,8 +262,8 @@ def _format_mirror(response_data: dict, saved_trust_tier: Optional[str], meta: A
     if relevant_prior:
         result["relevant_prior_work"] = relevant_prior
 
-    if reflection:
-        result["reflection"] = reflection
+    if question:
+        result["question"] = question
 
     # Include margin/edge warnings
     margin = decision.get("margin")
@@ -387,6 +393,7 @@ def _strip_context(response_data: dict, is_new_agent: bool, key_was_generated: b
     # Internal mirror signals (consumed during _format_mirror, not needed after)
     response_data.pop("_mirror_signals", None)
     response_data.pop("_mirror_kg_results", None)
+    response_data.pop("_mirror_question", None)
     response_data.pop("_mirror_reflection", None)
     response_data.pop("_has_sensor_data", None)
     response_data.pop("_eisv_validation_warning", None)

--- a/src/mcp_handlers/updates/enrichments.py
+++ b/src/mcp_handlers/updates/enrichments.py
@@ -1191,7 +1191,7 @@ async def enrich_mirror_signals(ctx: UpdateContext) -> None:
     Produces:
       - _mirror_signals: list of short insight strings
       - _mirror_kg_results: relevant KG discoveries by text search
-      - _mirror_reflection: targeted reflection prompt
+      - _mirror_question: targeted question when state warrants it
       - _has_sensor_data: bool for auto-mode routing
     """
     try:
@@ -1211,15 +1211,16 @@ async def enrich_mirror_signals(ctx: UpdateContext) -> None:
         # 1. Gaming / autopilot detection (low variance in recent reports)
         signals.extend(_detect_gaming(ctx))
 
-        # 2. KG text-based search using response_text
-        kg_results = await _search_kg_by_checkin_text(ctx)
-        if kg_results:
-            ctx.response_data["_mirror_kg_results"] = kg_results
+        # 2. Targeted question — only when there is something worth reflecting on
+        question = _generate_mirror_question(ctx, signals)
+        if question:
+            ctx.response_data["_mirror_question"] = question
 
-        # 3. Targeted reflection prompt
-        reflection = _generate_reflection_prompt(ctx)
-        if reflection:
-            ctx.response_data["_mirror_reflection"] = reflection
+        # 3. KG search is useful when there is a concrete signal/question, not on steady-state check-ins
+        if _should_search_kg_by_checkin_text(ctx, signals, question):
+            kg_results = await _search_kg_by_checkin_text(ctx)
+            if kg_results:
+                ctx.response_data["_mirror_kg_results"] = kg_results
 
         if signals:
             ctx.response_data["_mirror_signals"] = signals
@@ -1331,43 +1332,140 @@ async def _search_kg_by_checkin_text(ctx: UpdateContext) -> list:
         return []
 
 
-def _generate_reflection_prompt(ctx: UpdateContext) -> str:
-    """Generate a targeted reflection prompt based on task type and context."""
+def _has_tight_margin(response_data: dict) -> bool:
+    """Return True when the decision is close enough to a governance edge to warrant a nudge."""
     try:
-        task_type = ctx.task_type or "mixed"
-        response_text = ctx.response_text or ""
+        decision = response_data.get("decision", {})
+        if not isinstance(decision, dict):
+            return False
+        margin = decision.get("margin")
+        if isinstance(margin, str):
+            return margin.lower() in {"tight", "warning", "critical"}
+        return isinstance(margin, (int, float)) and margin < 0.1
+    except Exception:
+        return False
 
-        prompts_by_type = {
-            "introspection": "You described this as introspection. What changed in your understanding?",
-            "debugging": "Debugging often reveals assumptions. What assumption did you test?",
-            "refactoring": "What structural insight drove this refactoring?",
-            "exploration": "What's the most surprising thing you found?",
-            "research": "What question do you still not have an answer to?",
-            "testing": "What case are you most worried you haven't covered?",
-            "review": "What's the one thing you'd push back on if you saw it in someone else's work?",
-            "design": "What tradeoff are you making that you haven't articulated?",
-            "feature": "What's the simplest version of this that would still be valuable?",
-            "bugfix": "Is the bug a symptom or the root cause?",
-            "deployment": "What's your rollback plan if this goes wrong?",
-        }
 
-        prompt = prompts_by_type.get(task_type)
-        if prompt:
-            return prompt
+def _get_complexity_disagreement(response_data: dict, meta: Any = None) -> dict | None:
+    """Return the strongest available complexity disagreement signal, if any."""
+    try:
+        update_count = getattr(meta, "total_updates", 999) if meta else 999
+        if update_count <= 3:
+            return None
 
-        # Fallback: generate from response_text keywords
-        if response_text:
-            text_lower = response_text.lower()
-            if "stuck" in text_lower or "blocked" in text_lower:
-                return "You mentioned being stuck. What would unblock you -- a different approach or more information?"
-            if "refactor" in text_lower:
-                return "What structural insight drove this refactoring?"
-            if "test" in text_lower:
-                return "What case are you most worried you haven't covered?"
+        continuity = response_data.get("continuity", {})
+        if isinstance(continuity, dict) and continuity.get("complexity_divergence", 0) > 0.15:
+            return {
+                "reported": continuity.get("self_reported_complexity"),
+                "derived": continuity.get("derived_complexity"),
+                "divergence": continuity.get("complexity_divergence"),
+                "source": "continuity",
+            }
+
+        calibration_feedback = response_data.get("calibration_feedback", {})
+        if isinstance(calibration_feedback, dict):
+            complexity = calibration_feedback.get("complexity", {})
+            if isinstance(complexity, dict) and complexity.get("discrepancy", 0) > 0.3:
+                return {
+                    "reported": complexity.get("reported"),
+                    "derived": complexity.get("derived"),
+                    "divergence": complexity.get("discrepancy"),
+                    "source": "calibration_feedback",
+                }
+    except Exception:
+        return None
+    return None
+
+
+def _generate_mirror_question(ctx: UpdateContext, signals: list) -> str | None:
+    """Generate a targeted mirror-mode question only when the current state merits a nudge."""
+    try:
+        response_data = ctx.response_data if isinstance(ctx.response_data, dict) else {}
+        decision = response_data.get("decision", {})
+        state = response_data.get("state", {})
+        restorative = response_data.get("restorative", {})
+        conf_rel = response_data.get("confidence_reliability", {})
+        text_lower = (ctx.response_text or "").lower()
+        verdict = ctx.metrics_dict.get("verdict", "proceed")
+
+        if "stuck" in text_lower or "blocked" in text_lower:
+            return "You said you're stuck. What's the smallest concrete step that would unblock you right now?"
+
+        if verdict in ("guide", "pause", "reject"):
+            return f"Your state just triggered a {verdict} verdict. What changed immediately before that?"
+
+        if isinstance(restorative, dict) and restorative.get("needs_restoration"):
+            return "The system thinks you're pushing too hard. What can you simplify, defer, or slow down before the next step?"
+
+        if _has_tight_margin(response_data) or (isinstance(state, dict) and state.get("borderline")):
+            nearest_edge = decision.get("nearest_edge")
+            if nearest_edge == "coherence":
+                return "You're close to a coherence edge. What's the smallest next step that would simplify the plan?"
+            if nearest_edge in ("risk", "risk_threshold"):
+                return "You're close to a risk edge. What assumption would you verify before continuing?"
+            return "You're close to a governance edge. What's one simplification that would make the next step safer?"
+
+        disagreement = _get_complexity_disagreement(response_data, ctx.meta)
+        if disagreement:
+            return (
+                "You and the system disagree on difficulty. "
+                "Is that coming from scope, uncertainty, or hidden dependencies?"
+            )
+
+        if isinstance(conf_rel, dict):
+            external = conf_rel.get("external_provided")
+            derived_cap = conf_rel.get("derived_cap")
+            try:
+                if external is not None and derived_cap is not None and float(external) - float(derived_cap) > 0.1:
+                    return "Your reported confidence is above what the system can justify so far. What evidence are you leaning on?"
+            except (TypeError, ValueError):
+                pass
+
+        for signal in signals:
+            signal_lower = str(signal).lower()
+            if "autopilot" in signal_lower:
+                return "Your recent check-ins look repetitive. What actually changed since the last one?"
+            if "confidence" in signal_lower and "variance" in signal_lower:
+                return "Your confidence reports have been very flat. What evidence shifted this time?"
 
         return None
     except Exception:
         return None
+
+
+def _should_search_kg_by_checkin_text(ctx: UpdateContext, signals: list, question: str | None) -> bool:
+    """Gate KG search so steady-state mirror responses stay cheap."""
+    try:
+        response_text = ctx.response_text or ""
+        if len(response_text) < 10:
+            return False
+
+        if signals or question:
+            return True
+
+        response_data = ctx.response_data if isinstance(ctx.response_data, dict) else {}
+        state = response_data.get("state", {})
+        restorative = response_data.get("restorative", {})
+        verdict = ctx.metrics_dict.get("verdict", "proceed")
+
+        if verdict in ("guide", "pause", "reject"):
+            return True
+
+        if _has_tight_margin(response_data):
+            return True
+
+        if isinstance(state, dict) and state.get("borderline"):
+            return True
+
+        if isinstance(restorative, dict) and restorative.get("needs_restoration"):
+            return True
+
+        if _get_complexity_disagreement(response_data, ctx.meta):
+            return True
+
+        return False
+    except Exception:
+        return False
 
 
 # ─── Identity Notifications ──────────────────────────────────────────

--- a/src/mcp_handlers/validators.py
+++ b/src/mcp_handlers/validators.py
@@ -54,7 +54,26 @@ def validate_file_path_policy(file_path: str) -> Tuple[Optional[str], Optional[T
             warning = f"⚠️ POLICY VIOLATION: Test script '{basename}' should be in 'tests/' directory.\nLocation: {file_path}\nPolicy: All test_*.py and demo_*.py files must be in tests/ to prevent proliferation.\nAction: Move this file to tests/ directory or rename it."
             return (warning, None)
     if basename.endswith('.md'):
-        APPROVED_FILES = {'README.md', 'CHANGELOG.md', 'START_HERE.md', 'docs/README.md', 'docs/guides/ONBOARDING.md', 'docs/guides/TROUBLESHOOTING.md', 'docs/guides/MCP_SETUP.md', 'docs/guides/THRESHOLDS.md', 'docs/reference/AI_ASSISTANT_GUIDE.md', 'scripts/README.md', 'data/README.md', 'demos/README.md', 'tools/README.md'}
+        APPROVED_FILES = {
+            'README.md',
+            'CHANGELOG.md',
+            'docs/CANONICAL_SOURCES.md',
+            'docs/UNIFIED_ARCHITECTURE.md',
+            'docs/CIRCUIT_BREAKER_DIALECTIC.md',
+            'docs/database_architecture.md',
+            'docs/guides/START_HERE.md',
+            'docs/guides/TROUBLESHOOTING.md',
+            'docs/guides/NGROK_DEPLOYMENT.md',
+            'docs/guides/CIRS_PROTOCOL.md',
+            'docs/operations/DEFINITIVE_PORTS.md',
+            'docs/operations/OPERATOR_RUNBOOK.md',
+            'docs/dev/TOOL_REGISTRATION.md',
+            'docs/engineering/contract-drift-playbook.md',
+            'docs/meta/MARKDOWN_PROLIFERATION_POLICY.md',
+            'scripts/README.md',
+            'data/README.md',
+            'tools/README.md',
+        }
         MIGRATION_TARGET_DIRS = {'analysis', 'fixes', 'reflection', 'proposals'}
         if 'docs' in path_parts:
             docs_index = path_parts.index('docs')
@@ -71,7 +90,7 @@ def validate_file_path_policy(file_path: str) -> Tuple[Optional[str], Optional[T
                 docs_index = path_parts.index('docs')
                 if docs_index + 1 < len(path_parts):
                     subdir = path_parts[docs_index + 1]
-                    if subdir not in {'guides', 'reference', 'archive'}:
+                    if subdir not in {'guides', 'reference', 'archive', 'operations', 'dev', 'engineering', 'meta'}:
                         warning = f"⚠️ POLICY WARNING: New markdown file not on approved list.\nLocation: {file_path}\nPolicy: New markdown files should be ≥500 words and on approved list, or use store_knowledge_graph() instead.\nAction: Consider using store_knowledge_graph() for insights, or ensure file is ≥500 words and consolidate into existing docs.\nApproved files: {', '.join(sorted(APPROVED_FILES))}"
                         return (warning, None)
     return (None, None)

--- a/src/mcp_handlers/validators.py
+++ b/src/mcp_handlers/validators.py
@@ -69,6 +69,7 @@ def validate_file_path_policy(file_path: str) -> Tuple[Optional[str], Optional[T
             'docs/operations/OPERATOR_RUNBOOK.md',
             'docs/dev/TOOL_REGISTRATION.md',
             'docs/engineering/contract-drift-playbook.md',
+            'docs/engineering/validation-roadmap.md',
             'docs/meta/MARKDOWN_PROLIFERATION_POLICY.md',
             'scripts/README.md',
             'data/README.md',

--- a/src/outcome_correlation.py
+++ b/src/outcome_correlation.py
@@ -1,9 +1,10 @@
-"""Outcome Correlation Study — does EISV instability predict bad outcomes?
+"""Outcome correlation study and export helpers for empirical validation.
 
 Joins EISV snapshots with outcome events to compute:
-1. Verdict distribution: bad-outcome rate per verdict (safe/caution/high-risk)
+1. Verdict distribution: bad-outcome rate per verdict
 2. Metric correlations: Pearson r between each EISV metric and outcome_score
 3. Risk binning: bad-outcome rate per risk score range
+4. Coverage: how much of the dataset is grounded in behavioral/primary/exogenous data
 
 Data source: audit.outcome_events table (EISV snapshot embedded at outcome time).
 """
@@ -28,7 +29,8 @@ class CorrelationReport:
     verdict_distribution: Dict[str, Dict[str, Any]]
     metric_correlations: Dict[str, Optional[float]]
     risk_bins: List[Dict[str, Any]]
-    summary: str
+    summary: str = ""
+    coverage: Dict[str, Any] = field(default_factory=dict)
 
 
 def _pearson_r(xs: List[float], ys: List[float]) -> Optional[float]:
@@ -84,6 +86,146 @@ def compute_metric_correlations(outcomes: List[Dict]) -> Dict[str, Optional[floa
         label = m.replace("eisv_", "").upper()
         result[label] = round(r, 4) if r is not None else None
     return result
+
+
+def _count_pct(count: int, total: int) -> Dict[str, Any]:
+    """Return a compact count/percentage pair."""
+    pct = round(count / total, 4) if total else 0.0
+    return {"count": count, "pct": pct}
+
+
+def _get_detail(outcome: Dict[str, Any]) -> Dict[str, Any]:
+    """Return detail as a dict, never None."""
+    detail = outcome.get("detail")
+    return detail if isinstance(detail, dict) else {}
+
+
+def _has_snapshot(detail: Dict[str, Any], key: str) -> bool:
+    """Return True when a snapshot payload exists and has at least one populated field."""
+    payload = detail.get(key)
+    if not isinstance(payload, dict):
+        return False
+    return any(payload.get(field) is not None for field in ("E", "I", "S", "V", "risk", "confidence"))
+
+
+def _exogenous_signal_flags(detail: Dict[str, Any]) -> Dict[str, bool]:
+    """Return booleans for exogenous evidence types present in outcome detail."""
+    return {
+        "tests": bool(detail.get("tests")),
+        "commands": bool(detail.get("commands")),
+        "files": bool(detail.get("files")),
+        "lint": bool(detail.get("lint")),
+        "tool_observations": bool(detail.get("tool_usage") or detail.get("tool_results")),
+        "outcome_events": bool(detail.get("outcome_events")),
+    }
+
+
+def compute_observability_coverage(outcomes: List[Dict]) -> Dict[str, Any]:
+    """Measure how grounded the current outcome dataset is."""
+    total = len(outcomes)
+    if total == 0:
+        return {
+            "total_outcomes": 0,
+            "with_primary_eisv": _count_pct(0, 0),
+            "with_behavioral_eisv": _count_pct(0, 0),
+            "with_behavioral_primary": _count_pct(0, 0),
+            "with_exogenous_signals": _count_pct(0, 0),
+            "with_snapshot": _count_pct(0, 0),
+            "with_outcome_score": _count_pct(0, 0),
+            "primary_source_counts": {},
+            "exogenous_signal_counts": {},
+        }
+
+    with_primary_eisv = 0
+    with_behavioral_eisv = 0
+    with_behavioral_primary = 0
+    with_exogenous_signals = 0
+    with_snapshot = 0
+    with_outcome_score = 0
+    primary_source_counts: Dict[str, int] = {}
+    exogenous_signal_counts = {
+        "tests": 0,
+        "commands": 0,
+        "files": 0,
+        "lint": 0,
+        "tool_observations": 0,
+        "outcome_events": 0,
+    }
+
+    for outcome in outcomes:
+        detail = _get_detail(outcome)
+        if detail.get("snapshot_missing") is False:
+            with_snapshot += 1
+        if _has_snapshot(detail, "primary_eisv"):
+            with_primary_eisv += 1
+        if _has_snapshot(detail, "behavioral_eisv"):
+            with_behavioral_eisv += 1
+
+        source = detail.get("primary_eisv_source") or "unknown"
+        primary_source_counts[source] = primary_source_counts.get(source, 0) + 1
+        if source == "behavioral":
+            with_behavioral_primary += 1
+
+        if outcome.get("outcome_score") is not None:
+            with_outcome_score += 1
+
+        signal_flags = _exogenous_signal_flags(detail)
+        if any(signal_flags.values()):
+            with_exogenous_signals += 1
+        for signal_type, present in signal_flags.items():
+            if present:
+                exogenous_signal_counts[signal_type] += 1
+
+    return {
+        "total_outcomes": total,
+        "with_primary_eisv": _count_pct(with_primary_eisv, total),
+        "with_behavioral_eisv": _count_pct(with_behavioral_eisv, total),
+        "with_behavioral_primary": _count_pct(with_behavioral_primary, total),
+        "with_exogenous_signals": _count_pct(with_exogenous_signals, total),
+        "with_snapshot": _count_pct(with_snapshot, total),
+        "with_outcome_score": _count_pct(with_outcome_score, total),
+        "primary_source_counts": primary_source_counts,
+        "exogenous_signal_counts": exogenous_signal_counts,
+    }
+
+
+def flatten_outcome_for_export(outcome: Dict[str, Any]) -> Dict[str, Any]:
+    """Flatten an outcome event into a row suitable for CSV/JSONL export."""
+    detail = _get_detail(outcome)
+    primary = detail.get("primary_eisv") if isinstance(detail.get("primary_eisv"), dict) else {}
+    behavioral = detail.get("behavioral_eisv") if isinstance(detail.get("behavioral_eisv"), dict) else {}
+    signal_flags = _exogenous_signal_flags(detail)
+
+    row = {
+        "agent_id": outcome.get("agent_id"),
+        "ts": outcome.get("ts"),
+        "outcome_type": outcome.get("outcome_type"),
+        "is_bad": outcome.get("is_bad"),
+        "outcome_score": outcome.get("outcome_score"),
+        "eisv_verdict": outcome.get("eisv_verdict"),
+        "eisv_e": outcome.get("eisv_e"),
+        "eisv_i": outcome.get("eisv_i"),
+        "eisv_s": outcome.get("eisv_s"),
+        "eisv_v": outcome.get("eisv_v"),
+        "eisv_phi": outcome.get("eisv_phi"),
+        "eisv_coherence": outcome.get("eisv_coherence"),
+        "eisv_regime": outcome.get("eisv_regime"),
+        "primary_eisv_source": detail.get("primary_eisv_source"),
+        "snapshot_missing": detail.get("snapshot_missing"),
+        "primary_e": primary.get("E"),
+        "primary_i": primary.get("I"),
+        "primary_s": primary.get("S"),
+        "primary_v": primary.get("V"),
+        "behavioral_e": behavioral.get("E"),
+        "behavioral_i": behavioral.get("I"),
+        "behavioral_s": behavioral.get("S"),
+        "behavioral_v": behavioral.get("V"),
+        "behavioral_confidence": behavioral.get("confidence"),
+        "behavioral_risk": behavioral.get("risk"),
+    }
+    row.update(signal_flags)
+    row["has_exogenous_signals"] = any(signal_flags.values())
+    return row
 
 
 # Risk bin boundaries aligned with behavioral assessment thresholds
@@ -145,6 +287,17 @@ def _build_summary(report: CorrelationReport) -> str:
     """Generate a human-readable summary of the correlation study."""
     lines = [f"Outcomes: {report.total_outcomes} ({report.good_outcomes} good, {report.bad_outcomes} bad)"]
 
+    coverage = report.coverage or {}
+    if coverage:
+        exogenous = coverage.get("with_exogenous_signals", {})
+        behavioral_primary = coverage.get("with_behavioral_primary", {})
+        if isinstance(exogenous, dict) and isinstance(behavioral_primary, dict):
+            lines.append(
+                "Coverage: "
+                f"{exogenous.get('count', 0)}/{report.total_outcomes} outcomes have exogenous signals; "
+                f"{behavioral_primary.get('count', 0)}/{report.total_outcomes} use behavioral primary state"
+            )
+
     # Verdict distribution insight
     for v, d in report.verdict_distribution.items():
         if d["count"] >= 3:
@@ -186,6 +339,7 @@ class OutcomeCorrelation:
         verdict_dist = compute_verdict_distribution(outcomes)
         correlations = compute_metric_correlations(outcomes)
         risk_bins = compute_risk_bins(outcomes)
+        coverage = compute_observability_coverage(outcomes)
 
         report = CorrelationReport(
             total_outcomes=len(outcomes),
@@ -194,10 +348,20 @@ class OutcomeCorrelation:
             verdict_distribution=verdict_dist,
             metric_correlations=correlations,
             risk_bins=risk_bins,
+            coverage=coverage,
             summary="",
         )
         report.summary = _build_summary(report)
         return report
+
+    async def export_rows(
+        self,
+        agent_id: Optional[str] = None,
+        since_hours: float = 168.0,
+    ) -> List[Dict[str, Any]]:
+        """Fetch and flatten outcome rows for offline validation analysis."""
+        outcomes = await self._fetch_outcomes(agent_id, since_hours)
+        return [flatten_outcome_for_export(outcome) for outcome in outcomes]
 
     async def _fetch_outcomes(
         self, agent_id: Optional[str], since_hours: float
@@ -228,7 +392,7 @@ class OutcomeCorrelation:
                            eisv_verdict, eisv_coherence, eisv_regime,
                            detail, ts, agent_id
                     FROM audit.outcome_events
-                    WHERE ts >= now() - make_interval(hours => $2)
+                    WHERE ts >= now() - make_interval(hours => $1)
                     ORDER BY ts DESC
                     """,
                     since_hours,

--- a/src/services/identity_continuity.py
+++ b/src/services/identity_continuity.py
@@ -66,6 +66,30 @@ def get_identity_continuity_status(
             "with process-local session bindings and PostgreSQL persistence."
         )
 
+    if mode == "redis":
+        capabilities = {
+            "identity_persistence": "postgres (survives restart)",
+            "session_binding": "redis-backed (cross-process, fast TTL expiry)",
+            "onboard_pins": "redis (30min TTL, browser fingerprint resumption)",
+            "distributed_locking": "redis (prevents concurrent updates)",
+            "metadata_cache": "redis (sub-ms reads)",
+        }
+        degraded_capabilities: list = []
+    else:
+        capabilities = {
+            "identity_persistence": "postgres (survives restart)",
+            "session_binding": "in-memory (this process only, lost on restart)",
+            "onboard_pins": "unavailable (redis-only)",
+            "distributed_locking": "unavailable (single-process assumed)",
+            "metadata_cache": "in-memory (per-process, no shared cache)",
+        }
+        degraded_capabilities = [
+            "session_binding: in-memory only, lost on restart, not shared across processes",
+            "onboard_pins: unavailable, clients must pass explicit client_session_id",
+            "distributed_locking: unavailable, concurrent access not guarded",
+            "metadata_cache: per-process only, no cross-instance sharing",
+        ]
+
     payload: Dict[str, Any] = {
         "status": status,
         "mode": mode,
@@ -74,6 +98,8 @@ def get_identity_continuity_status(
         "session_binding_backend": (
             "redis-backed session cache" if mode == "redis" else "in-memory fallback cache"
         ),
+        "capabilities": capabilities,
+        "degraded_capabilities": degraded_capabilities,
         "note": note,
     }
     if mode == "redis" and not redis_operational:

--- a/src/services/runtime_queries.py
+++ b/src/services/runtime_queries.py
@@ -54,12 +54,19 @@ def _build_eisv_semantics(metrics: Dict[str, Any], monitor: Any) -> Dict[str, An
         confidence_value = getattr(beh, "confidence", 0.0) if beh is not None else 0.0
         if beh is not None and isinstance(confidence_value, Real):
             behavioral_confidence = float(confidence_value or 0.0)
+            warmup = None
+            try:
+                beh_dict = beh.to_dict()
+                warmup = beh_dict.get("warmup")
+            except Exception:
+                pass
             behavioral_eisv = {
                 "E": float(getattr(beh, "E")),
                 "I": float(getattr(beh, "I")),
                 "S": float(getattr(beh, "S")),
                 "V": float(getattr(beh, "V")),
                 "confidence": behavioral_confidence,
+                "warmup": warmup,
             }
     except Exception:
         behavioral_eisv = None
@@ -84,10 +91,24 @@ def _build_eisv_semantics(metrics: Dict[str, Any], monitor: Any) -> Dict[str, An
         "ode_diagnostics": ode_diagnostics,
         "state_semantics": {
             "flat_fields_mean": "primary_eisv",
-            "primary_eisv_role": "live state to read first",
-            "behavioral_eisv_role": "observation-first behavioral state",
-            "ode_eisv_role": "ODE fallback/control reference",
-            "ode_diagnostics_role": "thermostat/dynamics diagnostics",
+            "primary_eisv_role": (
+                "Live state to read first. Source is behavioral when confidence >= 0.3, "
+                "ODE otherwise. Check primary_eisv_source for which is active."
+            ),
+            "behavioral_eisv_role": (
+                "PRIMARY for verdicts. Observation-first EMA of actual agent behavior. "
+                "Determines proceed/guide/pause/reject decisions."
+            ),
+            "ode_eisv_role": (
+                "DIAGNOSTIC only. ODE dynamics with universal attractor. "
+                "Used for convergence tracking and phi calculation. NOT used for verdicts."
+            ),
+            "ode_diagnostics_role": "Thermostat dynamics diagnostics (phi, regime, lambda1)",
+            "verdict_source": primary_source,
+            "hierarchy": [
+                "1. behavioral_eisv (primary when confidence >= 0.3)",
+                "2. ode_eisv (fallback when behavioral data insufficient)",
+            ],
         },
     }
 

--- a/src/workspace_health.py
+++ b/src/workspace_health.py
@@ -98,9 +98,9 @@ def check_documentation_coherence() -> Dict[str, Any]:
     # Check if key documentation files exist
     key_docs = [
         "README.md",
-        "docs/guides/ONBOARDING.md",  # Updated: ONBOARDING.md is in docs/guides/
-        "docs/README.md",
-        "docs/guides/MCP_SETUP.md",
+        "docs/guides/START_HERE.md",
+        "docs/CANONICAL_SOURCES.md",
+        "docs/UNIFIED_ARCHITECTURE.md",
     ]
     
     missing_docs = []
@@ -295,4 +295,3 @@ def get_workspace_health() -> Dict[str, Any]:
             "health": "error",
             "recommendation": f"Health check encountered an error: {str(e)}"
         }
-

--- a/tests/test_enrichments_mirror.py
+++ b/tests/test_enrichments_mirror.py
@@ -1,8 +1,8 @@
 """
 Tests for mirror signal enrichments in src/mcp_handlers/updates/enrichments.py.
 
-Tests _detect_gaming, _search_kg_by_checkin_text, _generate_reflection_prompt,
-and the async enrich_mirror_signals orchestrator.
+Tests _detect_gaming, _generate_mirror_question,
+and mirror KG-search gating helpers.
 """
 
 import pytest
@@ -17,7 +17,8 @@ sys.path.insert(0, str(project_root))
 
 from src.mcp_handlers.updates.enrichments import (
     _detect_gaming,
-    _generate_reflection_prompt,
+    _generate_mirror_question,
+    _should_search_kg_by_checkin_text,
 )
 
 
@@ -31,7 +32,10 @@ def _make_ctx(
     task_type="mixed",
     complexity=0.5,
     confidence=None,
+    verdict="proceed",
     arguments=None,
+    response_data=None,
+    total_updates=10,
     complexity_history=None,
     confidence_history=None,
 ):
@@ -42,9 +46,12 @@ def _make_ctx(
     ctx.complexity = complexity
     ctx.confidence = confidence
     ctx.arguments = arguments or {}
-    ctx.response_data = {}
+    ctx.response_data = response_data or {}
     ctx.agent_uuid = "test-uuid-1234"
     ctx.mcp_server = MagicMock()
+    ctx.metrics_dict = {"verdict": verdict}
+    ctx.meta = MagicMock()
+    ctx.meta.total_updates = total_updates
 
     # Mock monitor with state histories
     monitor = MagicMock()
@@ -111,48 +118,68 @@ class TestDetectGaming:
 
 
 # ============================================================================
-# _generate_reflection_prompt
+# _generate_mirror_question
 # ============================================================================
 
-class TestGenerateReflectionPrompt:
+class TestGenerateMirrorQuestion:
 
-    def test_introspection_task_type(self):
-        ctx = _make_ctx(task_type="introspection")
-        prompt = _generate_reflection_prompt(ctx)
-        assert prompt is not None
-        assert "understanding" in prompt.lower()
-
-    def test_debugging_task_type(self):
-        ctx = _make_ctx(task_type="debugging")
-        prompt = _generate_reflection_prompt(ctx)
-        assert prompt is not None
-        assert "assumption" in prompt.lower()
-
-    def test_mixed_task_type_no_text(self):
-        ctx = _make_ctx(task_type="mixed", response_text="")
-        prompt = _generate_reflection_prompt(ctx)
-        assert prompt is None
-
-    def test_stuck_keyword_in_text(self):
+    def test_stuck_keyword_in_text_returns_unblock_question(self):
         ctx = _make_ctx(task_type="mixed", response_text="I'm stuck on this problem")
-        prompt = _generate_reflection_prompt(ctx)
-        assert prompt is not None
-        assert "unblock" in prompt.lower()
+        question = _generate_mirror_question(ctx, signals=[])
+        assert question is not None
+        assert "unblock" in question.lower()
 
-    def test_refactor_keyword_in_text(self):
-        ctx = _make_ctx(task_type="mixed", response_text="Continuing the refactor of auth module")
-        prompt = _generate_reflection_prompt(ctx)
-        assert prompt is not None
-        assert "structural" in prompt.lower()
+    def test_tight_margin_returns_edge_question(self):
+        ctx = _make_ctx(
+            response_data={"decision": {"margin": 0.05, "nearest_edge": "coherence"}}
+        )
+        question = _generate_mirror_question(ctx, signals=[])
+        assert question is not None
+        assert "coherence edge" in question.lower()
 
-    def test_testing_task_type(self):
-        ctx = _make_ctx(task_type="testing")
-        prompt = _generate_reflection_prompt(ctx)
-        assert prompt is not None
-        assert "covered" in prompt.lower()
+    def test_settling_margin_does_not_trigger_edge_question(self):
+        ctx = _make_ctx(
+            response_data={"decision": {"margin": "settling", "nearest_edge": None}}
+        )
+        question = _generate_mirror_question(ctx, signals=[])
+        assert question is None
 
-    def test_feature_task_type(self):
-        ctx = _make_ctx(task_type="feature")
-        prompt = _generate_reflection_prompt(ctx)
-        assert prompt is not None
-        assert "simplest" in prompt.lower()
+    def test_complexity_disagreement_returns_question(self):
+        ctx = _make_ctx(
+            response_data={
+                "continuity": {
+                    "self_reported_complexity": 0.8,
+                    "derived_complexity": 0.22,
+                    "complexity_divergence": 0.58,
+                }
+            }
+        )
+        question = _generate_mirror_question(ctx, signals=[])
+        assert question is not None
+        assert "disagree on difficulty" in question.lower()
+
+    def test_autopilot_signal_returns_question(self):
+        ctx = _make_ctx()
+        question = _generate_mirror_question(ctx, signals=["Real work varies -- are you on autopilot?"])
+        assert question is not None
+        assert "actually changed" in question.lower()
+
+    def test_steady_state_returns_none(self):
+        ctx = _make_ctx(task_type="feature", response_text="Finished tracing the mirror output path.")
+        question = _generate_mirror_question(ctx, signals=[])
+        assert question is None
+
+
+# ============================================================================
+# KG search gating
+# ============================================================================
+
+class TestShouldSearchKgByCheckinText:
+
+    def test_steady_state_skips_kg_search(self):
+        ctx = _make_ctx(response_text="Completed a small cleanup without notable issues.")
+        assert _should_search_kg_by_checkin_text(ctx, signals=[], question=None) is False
+
+    def test_signal_or_question_enables_kg_search(self):
+        ctx = _make_ctx(response_text="I am stuck investigating a regression in auth.")
+        assert _should_search_kg_by_checkin_text(ctx, signals=[], question="What unblocks you?") is True

--- a/tests/test_outcome_correlation.py
+++ b/tests/test_outcome_correlation.py
@@ -6,7 +6,10 @@ from src.outcome_correlation import (
     compute_verdict_distribution,
     compute_metric_correlations,
     compute_risk_bins,
+    compute_observability_coverage,
+    flatten_outcome_for_export,
     CorrelationReport,
+    OutcomeCorrelation,
     _build_summary,
 )
 
@@ -191,3 +194,93 @@ class TestBuildSummary:
         assert "8 good" in summary
         assert "2 bad" in summary
         assert "E" in summary
+
+
+class TestCoverage:
+    def test_observability_coverage_counts_grounded_signals(self):
+        outcomes = [
+            _make_outcome(
+                detail={
+                    "snapshot_missing": False,
+                    "primary_eisv": {"E": 0.7, "I": 0.8, "S": 0.2, "V": 0.0},
+                    "primary_eisv_source": "behavioral",
+                    "behavioral_eisv": {"E": 0.7, "I": 0.8, "S": 0.2, "V": 0.0, "confidence": 0.9},
+                    "tests": [{"name": "pytest", "passed": True}],
+                },
+            ),
+            _make_outcome(
+                detail={
+                    "snapshot_missing": False,
+                    "primary_eisv": {"E": 0.6, "I": 0.7, "S": 0.3, "V": 0.1},
+                    "primary_eisv_source": "ode",
+                    "commands": [{"cmd": "pytest", "exit_code": 1}],
+                },
+            ),
+            _make_outcome(detail={"snapshot_missing": True}),
+        ]
+
+        coverage = compute_observability_coverage(outcomes)
+        assert coverage["total_outcomes"] == 3
+        assert coverage["with_primary_eisv"]["count"] == 2
+        assert coverage["with_behavioral_eisv"]["count"] == 1
+        assert coverage["with_behavioral_primary"]["count"] == 1
+        assert coverage["with_exogenous_signals"]["count"] == 2
+        assert coverage["with_snapshot"]["count"] == 2
+        assert coverage["primary_source_counts"]["behavioral"] == 1
+        assert coverage["primary_source_counts"]["ode"] == 1
+        assert coverage["exogenous_signal_counts"]["tests"] == 1
+        assert coverage["exogenous_signal_counts"]["commands"] == 1
+
+    def test_flatten_outcome_for_export_surfaces_signal_flags(self):
+        row = flatten_outcome_for_export(
+            _make_outcome(
+                outcome_score=0.25,
+                detail={
+                    "snapshot_missing": False,
+                    "primary_eisv_source": "behavioral",
+                    "primary_eisv": {"E": 0.4, "I": 0.7, "S": 0.6, "V": -0.1},
+                    "behavioral_eisv": {"E": 0.4, "I": 0.7, "S": 0.6, "V": -0.1, "confidence": 0.55},
+                    "files": [{"path": "foo.py"}],
+                    "tool_results": [{"tool": "pytest", "exit_code": 1}],
+                },
+            )
+        )
+        assert row["primary_eisv_source"] == "behavioral"
+        assert row["primary_e"] == 0.4
+        assert row["behavioral_confidence"] == 0.55
+        assert row["files"] is True
+        assert row["tool_observations"] is True
+        assert row["has_exogenous_signals"] is True
+
+
+@pytest.mark.asyncio
+async def test_fetch_outcomes_uses_single_placeholder_without_agent(monkeypatch):
+    recorded = {}
+
+    class FakeConn:
+        async def fetch(self, query, *args):
+            recorded["query"] = query
+            recorded["args"] = args
+            return []
+
+    class FakeAcquire:
+        async def __aenter__(self):
+            return FakeConn()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class FakeDB:
+        def acquire(self):
+            return FakeAcquire()
+
+    import src.db as db_module
+
+    monkeypatch.setattr(db_module, "get_db", lambda: FakeDB())
+
+    study = OutcomeCorrelation()
+    rows = await study._fetch_outcomes(agent_id=None, since_hours=24)
+
+    assert rows == []
+    assert "make_interval(hours => $1)" in recorded["query"]
+    assert recorded["args"] == (24,)

--- a/tests/test_response_formatter.py
+++ b/tests/test_response_formatter.py
@@ -86,6 +86,7 @@ def _sample_response():
         # Internal signals (stripped unconditionally by _strip_context)
         "_mirror_signals": [],
         "_mirror_kg_results": [],
+        "_mirror_question": None,
         "_mirror_reflection": None,
         "_has_sensor_data": False,
         "_eisv_validation_warning": "warning",
@@ -293,10 +294,12 @@ class TestStripContext:
         # Set non-empty values to verify they get stripped
         data["_mirror_signals"] = ["signal"]
         data["_mirror_kg_results"] = [{"summary": "result"}]
+        data["_mirror_question"] = "question"
         data["_mirror_reflection"] = "reflect"
         _strip_context(data, is_new_agent=True, key_was_generated=False, api_key_auto_retrieved=False)
         assert "_mirror_signals" not in data
         assert "_mirror_kg_results" not in data
+        assert "_mirror_question" not in data
         assert "_mirror_reflection" not in data
         assert "_has_sensor_data" not in data
         assert "_eisv_validation_warning" not in data
@@ -536,11 +539,17 @@ class TestFormatMirror:
         assert "relevant_prior_work" in result
         assert result["relevant_prior_work"][0]["by"] == "AlvaNoto"
 
-    def test_reflection_prompt(self):
+    def test_question_prompt(self):
+        data = _sample_response()
+        data["_mirror_question"] = "What changed in your understanding?"
+        result = _format_mirror(data, saved_trust_tier=None)
+        assert result["question"] == "What changed in your understanding?"
+
+    def test_legacy_reflection_prompt_supported(self):
         data = _sample_response()
         data["_mirror_reflection"] = "What changed in your understanding?"
         result = _format_mirror(data, saved_trust_tier=None)
-        assert result["reflection"] == "What changed in your understanding?"
+        assert result["question"] == "What changed in your understanding?"
 
     def test_trust_tier_included(self):
         data = _sample_response()
@@ -562,8 +571,11 @@ class TestFormatMirror:
         data.pop("continuity", None)
         data.pop("restorative", None)
         data.pop("relevant_discoveries", None)
+        data.pop("_mirror_question", None)
+        data.pop("_mirror_reflection", None)
         result = _format_mirror(data, saved_trust_tier=None)
         assert "steady state" in result["mirror"][0].lower()
+        assert "question" not in result
 
     def test_margin_included_when_tight(self):
         data = _sample_response()
@@ -620,7 +632,7 @@ class TestFormatMirror:
         data = _sample_response()
         data["restorative"] = {
             "needs_restoration": True,
-            "reasons": ["complexity divergence pattern (0.48 cumulative)"],
+            "reason": "complexity divergence pattern (0.48 cumulative)",
         }
         result = _format_mirror(data, saved_trust_tier=None)
         assert any("restorative" in s.lower() for s in result["mirror"])


### PR DESCRIPTION
## What changed

This tightens mirror-mode prompting so it behaves like a state-aware nudge instead of a generic reflection ritual.

- Replace the generic task-type reflection prompt with a targeted mirror `question`
- Only surface that question when the current state actually warrants it
- Skip mirror KG lookup on steady-state check-ins so calm responses stay cheap
- Keep backward compatibility for legacy `_mirror_reflection` inputs while exposing `question` in the formatted mirror response
- Update mirror formatter and tests to match the new contract

## Why

Dogfooding showed the old shape was clunky in two ways:

1. Healthy steady-state responses could still ask a generic reflection question, which made the payload feel decorative rather than grounded.
2. Mirror enrichment could trigger KG search work even when there was no concrete signal to surface.

The result was extra latency and mixed UX: "no actionable signals" paired with a reflection prompt.

## Impact

Mirror mode should now feel more coherent:

- steady-state check-ins usually return no question
- pressure states return a pointed question tied to the actual signal
- KG surfacing is gated behind concrete signals/questions instead of always running on mirror check-ins

## Root cause

The previous implementation keyed reflection mostly off `task_type`, which made the prompt easy to generate but weakly connected to the actual governance state.

## Validation

- `pytest -q tests/test_enrichments_mirror.py tests/test_response_formatter.py --no-cov`
- Push hook smoke tests: `136 passed, 1 skipped, 5754 deselected`

## Notes

The local worktree still contains unrelated unstaged edits outside this PR scope; they were intentionally left out of this branch.