### PR TITLE
Sever fingerprint-based EISV inheritance

### DIFF
--- a/src/agent_lifecycle.py
+++ b/src/agent_lifecycle.py
@@ -30,17 +30,9 @@ def get_or_create_monitor(agent_id: str) -> UNITARESMonitor:
             monitor.state = persisted_state
             logger.info(f"Loaded persisted state for {agent_id} ({len(persisted_state.V_history)} history entries)")
         else:
-            # Inherit EISV from predecessor if available
-            meta = agent_metadata.get(agent_id)
-            if meta and meta.parent_agent_id:
-                parent_state = load_monitor_state(meta.parent_agent_id)
-                if parent_state:
-                    monitor.state = parent_state
-                    logger.info(f"Inherited EISV from predecessor {meta.parent_agent_id[:8]}...")
-                else:
-                    logger.info(f"Initialized new monitor for {agent_id} (predecessor {meta.parent_agent_id[:8]}... had no state)")
-            else:
-                logger.info(f"Initialized new monitor for {agent_id}")
+            # Lineage is recorded via meta.parent_agent_id but never transplants
+            # state; see docs/specs/2026-04-16-sever-fingerprint-eisv-inheritance-design.md
+            logger.info(f"Initialized new monitor for {agent_id}")
 
         monitors[agent_id] = monitor
 

--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -632,11 +632,11 @@ async def handle_identity_adapter(arguments: Dict[str, Any]) -> Sequence[TextCon
     # write it to PostgreSQL before returning so the token's promise is real.
     if result.get("created") and not result.get("persisted"):
         try:
-            # predecessor_uuid may be set by resolve_session_identity when it
-            # decides this identity is a successor to a prior agent in the
-            # same session — carry it through so parent_agent_id/spawn_reason
-            # get recorded on the new row.
-            _parent = result.get("predecessor_uuid") or result.get("parent_agent_id")
+            # parent_agent_id is only set when the caller explicitly asserted
+            # succession (post-2026-04-16 EISV inheritance spec). Fingerprint
+            # match no longer auto-claims lineage, so no predecessor_uuid to
+            # read here.
+            _parent = result.get("parent_agent_id")
             _spawn = result.get("spawn_reason") or ("new_session" if _parent else None)
             newly_persisted = await ensure_agent_persisted(
                 agent_uuid,

--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -1090,12 +1090,6 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
             created_fresh_identity = True
             agent_uuid = existing_identity.get("agent_uuid")
             agent_id = existing_identity.get("agent_id", agent_uuid)
-            # IDENTITY HONESTY: Wire predecessor from resolve_session_identity
-            # when resume=False found an existing identity but created a new UUID
-            if not _parent_agent_id and existing_identity.get("predecessor_uuid"):
-                _parent_agent_id = existing_identity["predecessor_uuid"]
-                if not _spawn_reason:
-                    _spawn_reason = "new_session"
             logger.info(f"[ONBOARD] Created fresh identity {agent_uuid[:8]}... (will persist)")
 
             # Use base session key — model_type goes into metadata, not session key

--- a/src/mcp_handlers/identity/resolution.py
+++ b/src/mcp_handlers/identity/resolution.py
@@ -287,9 +287,9 @@ async def resolve_session_identity(
 
         resume: If True, reuse existing identity from cache/DB (PATH 1/2).
 
-                If False (default), skip to PATH 3 (create new) with predecessor
-
-                linking when a prior identity exists.
+                If False (default), skip to PATH 3 and create a fresh identity.
+                Fingerprint match is a routing hint, not a succession claim —
+                no predecessor link is recorded (see 2026-04-16 spec).
 
 
 

--- a/src/mcp_handlers/identity/resolution.py
+++ b/src/mcp_handlers/identity/resolution.py
@@ -331,9 +331,6 @@ async def resolve_session_identity(
         session_key = re.sub(r'[^\w\-.:@]', '_', session_key)
         logger.warning(f"[SECURITY] Session key sanitized: {original[:30]}... -> {session_key[:30]}...")
 
-    # Track predecessor UUID when resume=False finds an existing identity
-    _predecessor_uuid = None
-
     # If force_new is requested, skip lookup paths and go straight to creation
 
     if not force_new:
@@ -386,14 +383,11 @@ async def resolve_session_identity(
                         agent_id = cached_id
 
                     # IDENTITY HONESTY: When resume=False, don't return cached identity.
-                    # Record it as predecessor and fall through to PATH 3 (create new).
-                    if not resume:
-                        _predecessor_uuid = agent_uuid
-                        logger.info(
-                            f"[IDENTITY] resume=False, skipping Redis hit for {agent_uuid[:8]}... "
-                            f"(will create new with predecessor link)"
-                        )
-                    else:
+                    # Fall through to PATH 3 (create new). Fingerprint match is a routing
+                    # hint only, never a succession claim — we do NOT record the cached
+                    # agent as the new identity's predecessor.
+                    # See docs/specs/2026-04-16-sever-fingerprint-eisv-inheritance-design.md
+                    if resume:
 
                         # Check if persisted in PostgreSQL
 
@@ -464,113 +458,105 @@ async def resolve_session_identity(
 
         # NOTE: As of v2.5.2, sessions reference agents by UUID.
 
-        if not _predecessor_uuid:  # Skip PG if Redis already found a predecessor
+        # IDENTITY HONESTY: When resume=False, don't return PG identity.
+        # Fingerprint match is a routing hint only, never a succession claim.
+        # See docs/specs/2026-04-16-sever-fingerprint-eisv-inheritance-design.md
+        try:
 
-            try:
+            db = get_db()
 
-                db = get_db()
+            if hasattr(db, "init"):
 
-                if hasattr(db, "init"):
-
-                    await db.init()
-
-
-
-                session = await db.get_session(session_key)
-
-                if session and session.agent_id:
-
-                    stored_id = session.agent_id
-
-                    # Detect format: UUID (correct) vs model+date (legacy)
-
-                    is_uuid = len(stored_id) == 36 and stored_id.count("-") == 4
-
-                    if is_uuid:
-
-                        agent_uuid = stored_id
-
-                        # Fetch agent_id (model+date) from metadata
-
-                        agent_id = await _get_agent_id_from_metadata(agent_uuid) or agent_uuid
-
-                    else:
-
-                        # Legacy format (pre-v2.5.2): treat as both agent_id and UUID fallback
-
-                        agent_uuid = stored_id
-
-                        agent_id = stored_id
-
-                    # IDENTITY HONESTY: When resume=False, don't return PG identity.
-                    if not resume:
-                        _predecessor_uuid = agent_uuid
-                        logger.info(
-                            f"[IDENTITY] resume=False, skipping PG hit for {agent_uuid[:8]}... "
-                            f"(will create new with predecessor link)"
-                        )
-                    else:
-
-                        label = await _get_agent_label(agent_uuid)
-
-                        # Check archived status
-                        agent_status = await _get_agent_status(agent_uuid)
-                        is_archived = agent_status == "archived"
-
-                        # Soft trajectory verification (v2.8)
-                        traj_result = await _soft_verify_trajectory(agent_uuid, trajectory_signature, "postgres")
-
-                        # Warm Redis cache for next time (cache UUID + display agent_id)
-
-                        # This also resets the TTL to 24h (sliding window)
-
-                        await _cache_session(
-                            session_key, agent_uuid, display_agent_id=agent_id,
-                            trajectory_required=traj_result.get("checked", False),
-                        )
+                await db.init()
 
 
 
-                        # Update DB last_active (non-blocking best effort)
+            session = await db.get_session(session_key)
 
-                        try:
+            if session and session.agent_id and resume:
 
-                            await db.update_session_activity(session_key)
+                stored_id = session.agent_id
 
-                        except Exception:
+                # Detect format: UUID (correct) vs model+date (legacy)
 
-                            pass
+                is_uuid = len(stored_id) == 36 and stored_id.count("-") == 4
+
+                if is_uuid:
+
+                    agent_uuid = stored_id
+
+                    # Fetch agent_id (model+date) from metadata
+
+                    agent_id = await _get_agent_id_from_metadata(agent_uuid) or agent_uuid
+
+                else:
+
+                    # Legacy format (pre-v2.5.2): treat as both agent_id and UUID fallback
+
+                    agent_uuid = stored_id
+
+                    agent_id = stored_id
+
+                label = await _get_agent_label(agent_uuid)
+
+                # Check archived status
+                agent_status = await _get_agent_status(agent_uuid)
+                is_archived = agent_status == "archived"
+
+                # Soft trajectory verification (v2.8)
+                traj_result = await _soft_verify_trajectory(agent_uuid, trajectory_signature, "postgres")
+
+                # Warm Redis cache for next time (cache UUID + display agent_id)
+
+                # This also resets the TTL to 24h (sliding window)
+
+                await _cache_session(
+                    session_key, agent_uuid, display_agent_id=agent_id,
+                    trajectory_required=traj_result.get("checked", False),
+                )
 
 
 
-                        return {
+                # Update DB last_active (non-blocking best effort)
 
-                            "agent_id": agent_id,   # Human-readable (model+date). UUID for lookup is agent_uuid.
-                            "public_agent_id": agent_id,
+                try:
 
-                            "agent_uuid": agent_uuid,
+                    await db.update_session_activity(session_key)
 
-                            "display_name": label,
+                except Exception:
 
-                            "label": label,  # backward compat
+                    pass
 
-                            "created": False,
 
-                            "persisted": True,  # Found in PostgreSQL = persisted
 
-                            "archived": is_archived,
+                return {
 
-                            "source": "postgres",
+                    "agent_id": agent_id,   # Human-readable (model+date). UUID for lookup is agent_uuid.
+                    "public_agent_id": agent_id,
 
-                            "trajectory_verified": traj_result.get("verified"),
+                    "agent_uuid": agent_uuid,
 
-                            "trajectory_warning": traj_result.get("warning"),
+                    "display_name": label,
 
-                        }
+                    "label": label,  # backward compat
 
-            except Exception as e:
+                    "created": False,
 
-                logger.debug(f"PostgreSQL session lookup failed: {e}")
+                    "persisted": True,  # Found in PostgreSQL = persisted
+
+                    "archived": is_archived,
+
+                    "source": "postgres",
+
+                    "trajectory_verified": traj_result.get("verified"),
+
+                    "trajectory_warning": traj_result.get("warning"),
+
+                }
+
+        except Exception as e:
+
+            logger.debug(f"PostgreSQL session lookup failed: {e}")
 
 
 
@@ -676,11 +662,6 @@ async def resolve_session_identity(
     # Auto-assign label from client signals to prevent future ghosts
     label = _generate_auto_label(model_type, client_hint) if not agent_name else None
 
-    if _predecessor_uuid:
-        logger.info(
-            f"[IDENTITY] New agent {agent_uuid[:8]}... with predecessor {_predecessor_uuid[:8]}..."
-        )
-
     if persist:
         # Persist immediately to PostgreSQL
         try:
@@ -740,8 +721,6 @@ async def resolve_session_identity(
                 "persisted": True,
                 "source": "created",
             }
-            if _predecessor_uuid:
-                result["predecessor_uuid"] = _predecessor_uuid
             return result
 
         except Exception as e:
@@ -763,8 +742,6 @@ async def resolve_session_identity(
         "persisted": False,
         "source": "memory_only",
     }
-    if _predecessor_uuid:
-        result["predecessor_uuid"] = _predecessor_uuid
     return result
 
 

--- a/src/services/identity_payloads.py
+++ b/src/services/identity_payloads.py
@@ -252,7 +252,7 @@ def build_onboard_response_data(
     if parent_agent_id and not force_new:
         result["predecessor"] = {
             "uuid": parent_agent_id,
-            "note": "Previous instance in this trajectory. Your state was inherited from it.",
+            "note": "Lineage record only; no state was inherited.",
         }
 
     if was_archived:

--- a/tests/test_identity_handlers.py
+++ b/tests/test_identity_handlers.py
@@ -1629,7 +1629,7 @@ class TestHandleOnboardV2:
 
     @pytest.mark.asyncio
     async def test_onboard_resume_false_creates_new_identity(self, patch_onboard_deps, mock_db, mock_redis, mock_raw_redis):
-        """onboard(resume=false) creates new identity with predecessor link."""
+        """onboard(resume=false) creates new identity (fresh — no auto lineage claim)."""
         from src.mcp_handlers.identity.handlers import handle_onboard_v2
 
         predecessor_uuid = str(uuid.uuid4())

--- a/tests/test_no_fingerprint_inheritance.py
+++ b/tests/test_no_fingerprint_inheritance.py
@@ -1,0 +1,71 @@
+"""
+Tests for the spec docs/specs/2026-04-16-sever-fingerprint-eisv-inheritance-design.md
+
+Covers:
+- State transplant is gone (agent_lifecycle.get_or_create_monitor)
+- Fingerprint match on resume=False no longer sets _predecessor_uuid
+- Explicit parent_agent_id still records lineage (without state transplant)
+- continuity_token round-trip preserves UUID
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch
+
+from src.agent_metadata_model import AgentMetadata, agent_metadata
+from src.agent_monitor_state import monitors
+
+
+@pytest.fixture(autouse=True)
+def _clear_process_state():
+    """Each test starts with fresh in-memory identity state."""
+    monitors.clear()
+    agent_metadata.clear()
+    yield
+    monitors.clear()
+    agent_metadata.clear()
+
+
+def test_get_or_create_monitor_does_not_transplant_state_from_predecessor():
+    """
+    Regression guard: once agent_lifecycle.get_or_create_monitor no longer
+    transplants state from a predecessor, a new agent with parent_agent_id
+    set should start with a fresh GovernanceState (empty V_history).
+    """
+    from src.agent_lifecycle import get_or_create_monitor
+    from src.governance_monitor import UNITARESMonitor
+
+    # Build a predecessor monitor and populate its state so
+    # load_monitor_state(parent_uuid) would return something real.
+    parent_uuid = "parent-uuid-1111"
+    parent_monitor = UNITARESMonitor(parent_uuid)
+    parent_monitor.state.V_history.extend([0.1, 0.2, 0.3])
+    monitors[parent_uuid] = parent_monitor
+
+    # Child agent metadata points to the predecessor.
+    child_uuid = "child-uuid-2222"
+    now_iso = "2026-04-16T00:00:00+00:00"
+    agent_metadata[child_uuid] = AgentMetadata(
+        agent_id=child_uuid,
+        status="active",
+        created_at=now_iso,
+        last_update=now_iso,
+        parent_agent_id=parent_uuid,
+    )
+
+    # load_monitor_state(parent_uuid) in the real code path would return
+    # the parent's persisted state. Force it to return the parent's in-memory
+    # state so the "if we wanted to transplant, we could" path is exercised.
+    def fake_load(agent_id):
+        if agent_id == parent_uuid:
+            return parent_monitor.state
+        return None
+
+    with patch("src.agent_lifecycle.load_monitor_state", side_effect=fake_load):
+        child_monitor = get_or_create_monitor(child_uuid)
+
+    assert child_monitor.state.V_history == [], (
+        "Child agent must not inherit predecessor V_history "
+        f"(got {child_monitor.state.V_history!r})"
+    )

--- a/tests/test_no_fingerprint_inheritance.py
+++ b/tests/test_no_fingerprint_inheritance.py
@@ -229,3 +229,153 @@ def test_explicit_parent_agent_id_records_lineage_without_state_transplant():
     assert agent_metadata[child_uuid].parent_agent_id == parent_uuid
     # But state is NOT transplanted.
     assert child_monitor.state.V_history == []
+
+
+@pytest.mark.asyncio
+async def test_continuity_token_roundtrip_preserves_uuid():
+    """
+    Regression guard for the explicit-continuity path (the blessed
+    alternative to fingerprint-based resumption that this spec removes).
+
+    Round-trip: onboard() -> capture uuid + continuity_token ->
+    call identity() again with that token -> the SAME UUID must come back.
+    No new identity may be forged.
+    """
+    import json
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from tests.helpers import parse_result
+
+    # --- Mock plumbing (inline to keep this file self-contained) -------------
+    mock_db = AsyncMock()
+    mock_db.init = AsyncMock()
+    mock_db.get_session = AsyncMock(return_value=None)
+    mock_db.get_identity = AsyncMock(return_value=None)
+    mock_db.get_agent = AsyncMock(return_value=None)
+    mock_db.get_agent_label = AsyncMock(return_value="RoundtripAgent")
+    mock_db.get_agent_status = AsyncMock(return_value="active")
+    mock_db.upsert_agent = AsyncMock()
+    mock_db.upsert_identity = AsyncMock()
+    mock_db.create_session = AsyncMock()
+    mock_db.update_session_activity = AsyncMock()
+    mock_db.find_agent_by_label = AsyncMock(return_value=None)
+    mock_db.get_agent_thread_info = AsyncMock(return_value=None)
+    mock_db.get_thread_nodes = AsyncMock(return_value=[])
+
+    mock_redis = AsyncMock()
+    mock_redis.get = AsyncMock(return_value=None)
+    mock_redis.bind = AsyncMock()
+
+    mock_raw_redis = AsyncMock()
+    mock_raw_redis.setex = AsyncMock()
+    mock_raw_redis.expire = AsyncMock()
+    mock_raw_redis.get = AsyncMock(return_value=None)
+
+    async def _get_raw():
+        return mock_raw_redis
+
+    def _discard_task(coro, **kwargs):
+        try:
+            coro.close()
+        except Exception:
+            pass
+        t = MagicMock()
+        t.cancel = MagicMock()
+        return t
+
+    mock_server = MagicMock()
+    mock_server.agent_metadata = {}
+
+    # --- First call: onboard a fresh identity --------------------------------
+    # get_identity is called twice: once by resolve_session_identity (expect None
+    # so we create), once by ensure_agent_persisted check (None -> persist), and
+    # then after upsert ensure_agent_persisted re-reads it.
+    mock_db.get_identity.side_effect = [
+        None,  # resolution PG lookup (PATH 2 miss)
+        None,  # ensure_agent_persisted existence check
+        SimpleNamespace(identity_id="i-new", metadata={}),  # post-upsert read
+    ]
+
+    from src.mcp_handlers.identity.handlers import (
+        handle_onboard_v2,
+        handle_identity_adapter,
+    )
+
+    env = {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-roundtrip-secret"}
+
+    with patch.dict("os.environ", env, clear=False), \
+         patch("src.mcp_handlers.identity.persistence._redis_cache", None), \
+         patch("src.cache.get_session_cache", return_value=mock_redis), \
+         patch("src.mcp_handlers.identity.handlers.get_db", return_value=mock_db), \
+         patch("src.mcp_handlers.identity.resolution.get_db", return_value=mock_db), \
+         patch("src.mcp_handlers.identity.persistence.get_db", return_value=mock_db), \
+         patch("src.cache.redis_client.get_redis", new=_get_raw), \
+         patch("src.mcp_handlers.context.get_mcp_session_id", return_value=None), \
+         patch("src.mcp_handlers.context.get_context_session_key", return_value="roundtrip-ctx"), \
+         patch("src.mcp_handlers.context.get_context_agent_id", return_value=None), \
+         patch("src.mcp_handlers.context.get_context_client_hint", return_value="test"), \
+         patch("src.mcp_handlers.context.update_context_agent_id"), \
+         patch("asyncio.create_task", side_effect=_discard_task), \
+         patch("src.mcp_handlers.shared.get_mcp_server", return_value=mock_server), \
+         patch("src.mcp_handlers.identity.shared._register_uuid_prefix"):
+
+        first_result = await handle_onboard_v2({
+            "client_session_id": "roundtrip-session-1",
+            "resume": True,
+        })
+        first_data = parse_result(first_result)
+
+        # Sanity: onboard succeeded and handed us a UUID + token.
+        assert first_data.get("success") is True, first_data
+        assert first_data.get("is_new") is True
+        first_uuid = first_data.get("uuid")
+        assert first_uuid, f"onboard response missing uuid: {first_data}"
+        captured_token = first_data.get("continuity_token")
+        assert captured_token, (
+            "onboard response must include continuity_token when the secret "
+            f"is configured (got keys: {sorted(first_data.keys())})"
+        )
+
+        # --- Second call: resume via the captured token ----------------------
+        # For the second call the resolver should find the existing agent.
+        # The token encodes agent_uuid + client_session_id; handle_identity_adapter
+        # resolves the token back to its stable session id, then resolve_session_identity
+        # is called with that. We make PATH 1 (Redis) return the existing agent
+        # cached under that session_key so no new UUID is minted.
+        display_agent_id = first_data.get("agent_id") or first_uuid
+
+        async def cache_get_second(session_id):
+            # Any session key routed through on the second call resolves to the
+            # existing agent. This models the Redis cache that the first
+            # onboard populated (we don't exercise real cache writes here).
+            return {
+                "agent_id": first_uuid,
+                "display_agent_id": display_agent_id,
+                "label": "RoundtripAgent",
+            }
+
+        mock_redis.get.side_effect = cache_get_second
+        # Identity lookups on the second call resolve the existing row.
+        mock_db.get_identity.side_effect = None
+        mock_db.get_identity.return_value = SimpleNamespace(
+            identity_id="i-new",
+            metadata={"agent_id": display_agent_id},
+        )
+
+        second_result = await handle_identity_adapter({
+            "continuity_token": captured_token,
+            "resume": True,
+        })
+        second_data = parse_result(second_result)
+
+    # --- The contract: same agent, no new identity --------------------------
+    assert second_data.get("success") is True, second_data
+    assert second_data.get("uuid") == first_uuid, (
+        "continuity_token round-trip must resolve to the original UUID; "
+        f"first={first_uuid!r} second={second_data.get('uuid')!r}"
+    )
+    # is_new should be False/absent — this is a resume, not a creation.
+    assert second_data.get("is_new") in (False, None), (
+        f"second call must not create a new identity (is_new={second_data.get('is_new')!r})"
+    )

--- a/tests/test_no_fingerprint_inheritance.py
+++ b/tests/test_no_fingerprint_inheritance.py
@@ -189,3 +189,43 @@ async def test_path2_postgres_hit_resume_false_does_not_set_predecessor():
         f"resume=False + PostgreSQL session hit must not leak predecessor_uuid "
         f"(got {result.get('predecessor_uuid')!r})"
     )
+
+
+def test_explicit_parent_agent_id_records_lineage_without_state_transplant():
+    """
+    When a caller explicitly asserts a predecessor via parent_agent_id on
+    agent_metadata, the metadata row records lineage but the new agent's
+    monitor starts with a fresh GovernanceState.
+    """
+    from datetime import datetime, timezone
+    from src.agent_lifecycle import get_or_create_monitor
+    from src.governance_monitor import UNITARESMonitor
+
+    parent_uuid = "33333333-3333-4333-8333-333333333333"
+    parent_monitor = UNITARESMonitor(parent_uuid)
+    parent_monitor.state.V_history.extend([0.5, 0.6])
+    monitors[parent_uuid] = parent_monitor
+
+    child_uuid = "44444444-4444-4444-8444-444444444444"
+    now_iso = datetime.now(timezone.utc).isoformat()
+    # Explicit caller assertion: "I am forking from parent_uuid"
+    agent_metadata[child_uuid] = AgentMetadata(
+        agent_id=child_uuid,
+        parent_agent_id=parent_uuid,
+        status="active",
+        created_at=now_iso,
+        last_update=now_iso,
+    )
+
+    def fake_load(agent_id):
+        if agent_id == parent_uuid:
+            return parent_monitor.state
+        return None
+
+    with patch("src.agent_lifecycle.load_monitor_state", side_effect=fake_load):
+        child_monitor = get_or_create_monitor(child_uuid)
+
+    # Lineage is recorded in metadata.
+    assert agent_metadata[child_uuid].parent_agent_id == parent_uuid
+    # But state is NOT transplanted.
+    assert child_monitor.state.V_history == []

--- a/tests/test_no_fingerprint_inheritance.py
+++ b/tests/test_no_fingerprint_inheritance.py
@@ -38,13 +38,24 @@ def test_get_or_create_monitor_does_not_transplant_state_from_predecessor():
 
     # Build a predecessor monitor and populate its state so
     # load_monitor_state(parent_uuid) would return something real.
-    parent_uuid = "parent-uuid-1111"
+    # Fixed UUID4s (deterministic) — real UUIDs are required because
+    # downstream code in agent_metadata_persistence.get_or_create_metadata
+    # validates agent_id against a strict UUID4 pattern; using non-UUID
+    # strings could cause the test to fail for the wrong reason or pass
+    # vacuously after the Task 2 fix lands.
+    parent_uuid = "11111111-1111-4111-8111-111111111111"
     parent_monitor = UNITARESMonitor(parent_uuid)
     parent_monitor.state.V_history.extend([0.1, 0.2, 0.3])
     monitors[parent_uuid] = parent_monitor
 
     # Child agent metadata points to the predecessor.
-    child_uuid = "child-uuid-2222"
+    # NOTE: get_or_create_monitor calls get_or_create_metadata(child_uuid)
+    # BEFORE reading agent_metadata[child_uuid] to decide about transplant.
+    # Verified (see src/agent_metadata_persistence.py:359) that
+    # get_or_create_metadata is a no-op when the entry already exists —
+    # it returns the existing AgentMetadata untouched — so the seed below
+    # survives into the transplant branch.
+    child_uuid = "22222222-2222-4222-8222-222222222222"
     now_iso = "2026-04-16T00:00:00+00:00"
     agent_metadata[child_uuid] = AgentMetadata(
         agent_id=child_uuid,

--- a/tests/test_no_fingerprint_inheritance.py
+++ b/tests/test_no_fingerprint_inheritance.py
@@ -80,3 +80,112 @@ def test_get_or_create_monitor_does_not_transplant_state_from_predecessor():
         "Child agent must not inherit predecessor V_history "
         f"(got {child_monitor.state.V_history!r})"
     )
+
+
+@pytest.mark.asyncio
+async def test_path1_redis_hit_resume_false_does_not_set_predecessor():
+    """
+    PATH 1: Redis lookup finds a cached agent. resume=False now creates
+    a new identity WITHOUT recording the cached agent as predecessor.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+    from src.mcp_handlers.identity import resolution as resolution_mod
+
+    existing_uuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+
+    cache_hit = {
+        "agent_id": existing_uuid,
+        "display_agent_id": "OldAgent",
+    }
+    mock_redis = MagicMock()
+    mock_redis.get = AsyncMock(return_value=cache_hit)
+
+    mock_raw_redis = AsyncMock()
+    mock_raw_redis.expire = AsyncMock(return_value=True)
+
+    mock_db = AsyncMock()
+    mock_db.init = AsyncMock()
+    mock_db.get_session = AsyncMock(return_value=None)
+    mock_db.upsert_agent = AsyncMock()
+    mock_db.upsert_identity = AsyncMock()
+    mock_db.create_session = AsyncMock()
+    mock_db.get_identity = AsyncMock(return_value=None)
+
+    async def _get_raw():
+        return mock_raw_redis
+
+    with patch.object(resolution_mod, "_get_redis", return_value=mock_redis), \
+         patch("src.cache.redis_client.get_redis", new=_get_raw), \
+         patch.object(resolution_mod, "get_db", return_value=mock_db), \
+         patch.object(resolution_mod, "_agent_exists_in_postgres", AsyncMock(return_value=True)), \
+         patch.object(resolution_mod, "_get_agent_label", AsyncMock(return_value="OldAgent")), \
+         patch.object(resolution_mod, "_get_agent_status", AsyncMock(return_value="active")), \
+         patch.object(resolution_mod, "_soft_verify_trajectory", AsyncMock(return_value={"verified": True})), \
+         patch.object(resolution_mod, "_cache_session", AsyncMock()):
+        result = await resolution_mod.resolve_session_identity(
+            session_key="fp-session-1",
+            resume=False,
+            persist=False,
+        )
+
+    # A brand-new identity should have been created.
+    assert result["created"] is True
+    assert result["agent_uuid"] != existing_uuid
+    # And it MUST NOT carry predecessor_uuid forward.
+    assert "predecessor_uuid" not in result, (
+        f"resume=False + Redis fingerprint hit must not leak predecessor_uuid "
+        f"(got {result.get('predecessor_uuid')!r})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_path2_postgres_hit_resume_false_does_not_set_predecessor():
+    """
+    PATH 2: Redis miss, PostgreSQL finds a session-bound agent.
+    resume=False must not claim that agent as predecessor.
+    """
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock, patch
+    from src.mcp_handlers.identity import resolution as resolution_mod
+
+    existing_uuid = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+
+    mock_redis = MagicMock()
+    mock_redis.get = AsyncMock(return_value=None)  # PATH 1 miss
+
+    mock_raw_redis = AsyncMock()
+    mock_raw_redis.expire = AsyncMock(return_value=True)
+
+    mock_db = AsyncMock()
+    mock_db.init = AsyncMock()
+    mock_db.get_session = AsyncMock(
+        return_value=SimpleNamespace(agent_id=existing_uuid)
+    )
+    mock_db.upsert_agent = AsyncMock()
+    mock_db.upsert_identity = AsyncMock()
+    mock_db.create_session = AsyncMock()
+    mock_db.get_identity = AsyncMock(return_value=None)
+
+    async def _get_raw():
+        return mock_raw_redis
+
+    with patch.object(resolution_mod, "_get_redis", return_value=mock_redis), \
+         patch("src.cache.redis_client.get_redis", new=_get_raw), \
+         patch.object(resolution_mod, "get_db", return_value=mock_db), \
+         patch.object(resolution_mod, "_agent_exists_in_postgres", AsyncMock(return_value=True)), \
+         patch.object(resolution_mod, "_get_agent_label", AsyncMock(return_value="OldAgent")), \
+         patch.object(resolution_mod, "_get_agent_status", AsyncMock(return_value="active")), \
+         patch.object(resolution_mod, "_soft_verify_trajectory", AsyncMock(return_value={"verified": True})), \
+         patch.object(resolution_mod, "_cache_session", AsyncMock()):
+        result = await resolution_mod.resolve_session_identity(
+            session_key="fp-session-2",
+            resume=False,
+            persist=False,
+        )
+
+    assert result["created"] is True
+    assert result["agent_uuid"] != existing_uuid
+    assert "predecessor_uuid" not in result, (
+        f"resume=False + PostgreSQL session hit must not leak predecessor_uuid "
+        f"(got {result.get('predecessor_uuid')!r})"
+    )


### PR DESCRIPTION
## Summary

- Stop silent transplant of predecessor `GovernanceState` onto new agents (deletes the `else` branch in `agent_lifecycle.get_or_create_monitor`).
- Stop auto-claiming lineage on fingerprint match when `resume=False` (PATH 1 Redis hit, PATH 2 PostgreSQL hit in `resolve_session_identity`). All downstream dead scaffolding (sentinel, guard, log, result-field assignments) removed for symmetry.
- Remove now-unreachable dormant block in the onboard handler.
- Update the onboard response note to reflect honest semantics.
- Update `resume=False` docstring to match post-sever behavior.

Lineage via `parent_agent_id` now records *who came before* without transplanting state. Continuity of a single agent flows through the explicit `continuity_token` path, as already documented in the governance-lifecycle skill (*"Strong continuity is better than implicit continuity"*).

Spec: `docs/specs/2026-04-16-sever-fingerprint-eisv-inheritance-design.md`
Plan: `docs/plans/2026-04-16-sever-fingerprint-eisv-inheritance.md`

## Rationale

When a caller onboards with a new display name (or `resume=False`) and the IP+UA fingerprint resolver matches a prior agent in the same environment, two silent side effects previously occurred:

1. `parent_agent_id` was set on the new identity (a silent lineage claim).
2. The predecessor's entire `GovernanceState` — `V_history`, coherence history, regime tracking, HCK/CIRS metrics, governor state — was transplanted onto the new monitor.

The response note even claimed *"Your state was inherited from it."* This corrupts the new agent's trajectory signal at the source and the distortion compounds through every subsequent check-in — a domino effect on the governance-state trajectory.

The fix separates two epistemically different things:
- **Fingerprint match** = "we recognize this workstation" (an environmental hint)
- **Lineage claim** = "this is a legitimate successor of that agent" (a positive assertion)

After this PR, fingerprint-match is purely a routing hint. Lineage is set only when a caller explicitly passes `parent_agent_id`.

## Test plan

- [x] New `tests/test_no_fingerprint_inheritance.py` covers:
  - State transplant is gone
  - PATH 1 (Redis hit) does not set `predecessor_uuid` on `resume=False`
  - PATH 2 (PostgreSQL session) does not set `predecessor_uuid` on `resume=False`
  - Explicit `parent_agent_id` records lineage without state transplant
  - `continuity_token` round-trip preserves UUID (real HMAC sign/verify, real resolution paths, infrastructure-only mocks)
- [x] Existing identity test suite passes unchanged (no test pinned on the old auto-lineage contract — TDD discipline on this branch caught everything up-front)
- [x] Full `pytest -x -q` passes: **6329 passed, 24 skipped** in 110s
- [x] Watcher scan on touched files: no new findings attributable to this PR (pre-existing highs in unrelated functions — see follow-ups below)

## Impact on consumers

- **Lumen (anima-mcp):** verified no impact. Uses explicit `creature_id` UUID continuity via `client_session_id=f"lumen-{creature_id}"` (stored in local SQLite). Never reads `predecessor`, never depends on transplanted state. See spec R1 for citations.
- **Hooks + `onboard_helper.py`:** unchanged — they already persist and pass `continuity_token` via `.unitares/session.json`.
- **SDK (`agents/sdk/`):** unchanged — `GovernanceClient` / `GovernanceAgent` already handle token-based continuity explicitly.
- **Discord bridge:** doesn't participate in per-session continuity (queries by `agent_id`). Unaffected.

## Follow-ups (not this PR)

Watcher surfaced several pre-existing findings in lines this PR did not touch:
- `src/agent_lifecycle.py:53, 236` — timezone-aware datetime bugs in `_agent_age_hours`
- `src/mcp_handlers/identity/handlers.py:1069, 1168, 1215, 1384` — unawaited coroutines / race condition
- `src/services/identity_payloads.py:156` — shared-dict mutation in loop

These are separate concerns and should be tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)