### PR TITLE
Remediate Watcher findings: timezone, rebadge, TOCTOU

### DIFF
--- a/src/agent_lifecycle.py
+++ b/src/agent_lifecycle.py
@@ -40,19 +40,21 @@ def get_or_create_monitor(agent_id: str) -> UNITARESMonitor:
 
 
 def _agent_age_hours(meta: AgentMetadata) -> float | None:
-    """Return hours since last activity, or None if unparseable."""
+    """Return hours since last activity, or None if unparseable.
+
+    Timestamps without tzinfo are interpreted as UTC (the format UNITARES
+    emits everywhere). This avoids mixing naive-local `datetime.now()` with
+    a naive-UTC stored timestamp, which would off-by-local-offset the age.
+    """
     from datetime import timezone
     try:
         last_update_str = meta.last_update or meta.created_at
         last_update_dt = datetime.fromisoformat(
             last_update_str.replace('Z', '+00:00') if 'Z' in last_update_str else last_update_str
         )
-        # Use timezone-aware comparison if the timestamp has tzinfo,
-        # otherwise fall back to naive local time.
-        if last_update_dt.tzinfo is not None:
-            now = datetime.now(timezone.utc)
-        else:
-            now = datetime.now()
+        if last_update_dt.tzinfo is None:
+            last_update_dt = last_update_dt.replace(tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
         return (now - last_update_dt).total_seconds() / 3600
     except (ValueError, TypeError, AttributeError):
         return None
@@ -237,8 +239,12 @@ def build_standardized_agent_info(
         update_count = meta.total_updates
 
     try:
+        from datetime import timezone
         created_dt = datetime.fromisoformat(created_ts.replace('Z', '+00:00') if 'Z' in created_ts else created_ts)
-        age_days = (datetime.now(created_dt.tzinfo) - created_dt).days
+        if created_dt.tzinfo is None:
+            # Naive stored timestamps are UTC (see _agent_age_hours).
+            created_dt = created_dt.replace(tzinfo=timezone.utc)
+        age_days = (datetime.now(timezone.utc) - created_dt).days
     except (ValueError, TypeError, AttributeError):
         age_days = None
 

--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -214,10 +214,17 @@ def _should_rebadge_agent_id(current_agent_id: Optional[str], model_type: Option
 
 
 async def _persist_rebadged_agent_id(agent_uuid: str, new_agent_id: str) -> None:
-    """Best-effort sync of refreshed structured agent_id to memory + DB."""
+    """Best-effort sync of refreshed structured agent_id to memory + DB.
+
+    Updates both `agent_id` and `public_agent_id` in the in-memory metadata
+    so lifecycle events and any other readers of `meta.agent_id` see the
+    current identity — not the stale pre-rebadge value.
+    """
     try:
         if agent_uuid in mcp_server.agent_metadata:
-            mcp_server.agent_metadata[agent_uuid].public_agent_id = new_agent_id
+            meta = mcp_server.agent_metadata[agent_uuid]
+            meta.agent_id = new_agent_id
+            meta.public_agent_id = new_agent_id
     except Exception:
         pass
     try:

--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -1241,8 +1241,10 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     public_agent_id = agent_id if agent_id and agent_id != agent_uuid else None
     structured_id = None
     try:
-        if agent_uuid in mcp_server.agent_metadata:
-            meta = mcp_server.agent_metadata[agent_uuid]
+        # Atomic read via .get — avoids TOCTOU between `in` check and subscript
+        # if another task mutates agent_metadata concurrently.
+        meta = mcp_server.agent_metadata.get(agent_uuid)
+        if meta is not None:
             public_agent_id = getattr(meta, "public_agent_id", None) or public_agent_id
             structured_id = getattr(meta, 'structured_id', None)
     except Exception:

--- a/tests/test_agent_lifecycle_age.py
+++ b/tests/test_agent_lifecycle_age.py
@@ -1,0 +1,83 @@
+"""Regression guards for agent_lifecycle timezone handling.
+
+These tests ensure that naive-UTC timestamps (the format UNITARES stores
+when no tzinfo is embedded) don't get compared against naive-local
+datetime.now(), which would produce off-by-local-offset age values and
+silently break orphan archival in non-UTC locales.
+
+Spawned by the 2026-04-16 Watcher follow-up remediation.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from src.agent_lifecycle import _agent_age_hours, build_standardized_agent_info
+from src.agent_metadata_model import AgentMetadata
+
+
+@pytest.fixture
+def _now_utc():
+    return datetime(2026, 4, 16, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _meta(*, last_update: str | None, created_at: str | None = None) -> AgentMetadata:
+    return AgentMetadata(
+        agent_id="dummy",
+        status="active",
+        created_at=created_at or last_update or "",
+        last_update=last_update or created_at or "",
+    )
+
+
+class TestAgentAgeHoursTimezoneNormalization:
+    def test_naive_utc_timestamp_computes_correct_age(self, _now_utc):
+        """Naive-UTC stored timestamps must be interpreted as UTC, not local."""
+        six_hours_ago_utc_naive = (_now_utc - timedelta(hours=6)).replace(tzinfo=None).isoformat()
+        meta = _meta(last_update=six_hours_ago_utc_naive)
+
+        with patch("src.agent_lifecycle.datetime") as mock_dt:
+            # Pass through real fromisoformat and real datetime constants
+            mock_dt.fromisoformat = datetime.fromisoformat
+            mock_dt.now.return_value = _now_utc
+            hours = _agent_age_hours(meta)
+
+        assert hours is not None
+        assert hours == pytest.approx(6.0, abs=0.001), (
+            f"naive-UTC timestamp 6 hours ago should yield 6.0 hours, got {hours}"
+        )
+
+    def test_aware_utc_timestamp_computes_correct_age(self, _now_utc):
+        """tz-aware UTC timestamp works the same as before."""
+        ts = (_now_utc - timedelta(hours=2)).isoformat()
+        meta = _meta(last_update=ts)
+
+        with patch("src.agent_lifecycle.datetime") as mock_dt:
+            mock_dt.fromisoformat = datetime.fromisoformat
+            mock_dt.now.return_value = _now_utc
+            hours = _agent_age_hours(meta)
+
+        assert hours == pytest.approx(2.0, abs=0.001)
+
+    def test_z_suffix_timestamp_computes_correct_age(self, _now_utc):
+        """'Z' suffix (common ISO-8601 UTC form) normalizes correctly."""
+        ts = (_now_utc - timedelta(hours=3)).replace(tzinfo=None).isoformat() + "Z"
+        meta = _meta(last_update=ts)
+
+        with patch("src.agent_lifecycle.datetime") as mock_dt:
+            mock_dt.fromisoformat = datetime.fromisoformat
+            mock_dt.now.return_value = _now_utc
+            hours = _agent_age_hours(meta)
+
+        assert hours == pytest.approx(3.0, abs=0.001)
+
+    def test_unparseable_returns_none(self):
+        meta = _meta(last_update="not a date")
+        assert _agent_age_hours(meta) is None
+
+    def test_empty_string_returns_none(self):
+        meta = _meta(last_update="")
+        assert _agent_age_hours(meta) is None


### PR DESCRIPTION
## Summary

Three real bug fixes plus a minor cleanup, in response to a Watcher sweep on recently-touched identity/lifecycle files.

### Fixes

| Finding | File:line | Fix |
|---|---|---|
| Timezone-aware comparison bug | `agent_lifecycle.py:53` | Normalize naive timestamps to UTC in `_agent_age_hours` before diffing against `datetime.now(UTC)` |
| Timezone-aware subtraction bug | `agent_lifecycle.py:236` | Same UTC-normalization pattern in `build_standardized_agent_info` |
| Rebadged agent_id stale in memory | `handlers.py:1215` (`_persist_rebadged_agent_id`) | Update `meta.agent_id` alongside `meta.public_agent_id` — lifecycle event emission reads `meta.agent_id` and would otherwise reference the pre-rebadge identity |
| TOCTOU on agent_metadata access | `handlers.py:1336` | Replace `if x in dict: dict[x]` with atomic `dict.get(x)` (cleanup — surrounding `try/except` already masked the race) |

### Regression coverage

New file `tests/test_agent_lifecycle_age.py` adds five cases covering naive-UTC / aware-UTC / `Z`-suffix / unparseable / empty-string timestamps. Previously there was no test coverage for `_agent_age_hours`.

### Dismissed as false positives (documented here rather than code-polluted with "sic" comments)

Three Watcher findings were examined and dismissed:

- **`handlers.py:1069` ("Async method called without await")** — `await srv.load_metadata_async(force=True)` already has `await`. `load_metadata_async` is an `async def` in `agent_metadata_persistence.py:270`, attached dynamically to the MCP server. Verified the same pattern is correctly used in 10+ places across `observability/handlers.py`, `dialectic/*`, etc.
- **`handlers.py:1168` ("Coroutine passed to task creator without await")** — `create_tracked_task(coro, name=...)` is `_supervised_create_task` in `background_tasks.py:940`, which is literally `asyncio.create_task(coro)`. Passing a coroutine object WITHOUT `await` is the required pattern for task scheduling. Watcher inverted the semantics here.
- **`identity_payloads.py:156` ("Mutating shared dict in loop modifies all next_calls entries")** — `next_calls` is defined inside `build_onboard_response_data()` (line 127), so it's a fresh list per call. Each entry's `args_full` is a distinct dict literal. The `for` loop's per-entry mutation is isolated. Would have been a real bug if `next_calls` were module-scoped, but it isn't.

## Test plan

- [x] New `tests/test_agent_lifecycle_age.py`: 5/5 pass
- [x] Full suite: **6337 passed, 24 skipped** in 169s (8 more tests than pre-PR due to new regression guards)
- [x] Watcher rescan: all 3 remediated findings removed from output. New findings surface in other lines (Watcher LLM instability — separate triage concern, not this PR's scope)
- [x] No touched tests broken by the fixes

## Ride-along

This branch includes one commit by @CIRWEL (`57afaae5`, "fix(watcher): exempt canonical cached factory from P003 self-flag") made directly to the branch while this PR was being prepared. Included here since it's thematically aligned and part of the same Watcher-remediation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)