### PR TITLE
feat(lifecycle): persist circuit-breaker state + add /v1/lifecycle/recent

### DIFF
--- a/src/agent_loop_detection.py
+++ b/src/agent_loop_detection.py
@@ -474,6 +474,26 @@ async def process_update_authenticated_async(
             result["paused"] = True
             result["circuit_breaker_triggered"] = True
 
+            # P011: persist paused_at + the lifecycle event so they survive
+            # the next load_metadata_async(force=True). Without this, the
+            # agent record shows paused_at=null and lifecycle_events=[]
+            # despite the pause having actually fired.
+            try:
+                from src import agent_storage
+                await agent_storage.persist_runtime_state(
+                    agent_id,
+                    paused_at=now,
+                    append_lifecycle_event={
+                        "event": "paused",
+                        "timestamp": now,
+                        "reason": decision_reason,
+                    },
+                )
+            except Exception as e:
+                logger.warning(
+                    f"persist_runtime_state(paused) failed for {agent_id[:8]}...: {e}"
+                )
+
             # Telemetry: record governance pause timestamp
             _governance_pause_timestamps.append(datetime.now(timezone.utc))
 
@@ -589,11 +609,33 @@ async def _auto_initiate_dialectic_recovery(agent_id: str, reason: str) -> None:
                         meta.loop_detected_at = None
                         meta.recent_update_timestamps = []
                         meta.recent_decisions = []
-                        meta.add_lifecycle_event(
-                            "auto_resumed_dialectic",
-                            f"LLM dialectic recommended RESUME: {content.get('message', '')[:100]}"
+                        resume_reason = (
+                            f"LLM dialectic recommended RESUME: "
+                            f"{content.get('message', '')[:100]}"
                         )
+                        meta.add_lifecycle_event("auto_resumed_dialectic", resume_reason)
                         logger.info(f"Agent '{agent_id}' auto-resumed after LLM dialectic")
+
+                        # P011: persist the resume so paused_at=None survives
+                        # reload and the dialectic event is in the audit trail.
+                        try:
+                            from src import agent_storage
+                            await agent_storage.persist_runtime_state(
+                                agent_id,
+                                paused_at=None,
+                                loop_cooldown_until=None,
+                                loop_detected_at=None,
+                                append_lifecycle_event={
+                                    "event": "auto_resumed_dialectic",
+                                    "timestamp": datetime.now().isoformat(),
+                                    "reason": resume_reason,
+                                },
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                f"persist_runtime_state(auto_resumed_dialectic) failed "
+                                f"for {agent_id[:8]}...: {e}"
+                            )
                 elif recommendation == "COOLDOWN":
                     logger.info(f"Agent '{agent_id}' in cooldown after LLM dialectic — stuck-detector will handle later")
                 else:
@@ -637,14 +679,35 @@ async def _safety_net_resume(agent_id: str, reason: str) -> None:
             meta.loop_detected_at = None
             meta.recent_update_timestamps = []
             meta.recent_decisions = []
-            meta.add_lifecycle_event(
-                "safety_net_resumed",
-                f"All dialectic paths failed ({reason}); state safe (coherence={coherence:.2f}, risk={risk:.2f}) — auto-resumed"
+            resume_reason = (
+                f"All dialectic paths failed ({reason}); state safe "
+                f"(coherence={coherence:.2f}, risk={risk:.2f}) — auto-resumed"
             )
+            meta.add_lifecycle_event("safety_net_resumed", resume_reason)
             logger.info(
                 f"Agent '{agent_id}' safety-net resumed "
                 f"(coherence={coherence:.2f}, risk={risk:.2f}, dialectic failure: {reason})"
             )
+
+            # P011: persist the resume so paused_at=None survives reload and
+            # the safety-net event is in the audit trail.
+            try:
+                from src import agent_storage
+                await agent_storage.persist_runtime_state(
+                    agent_id,
+                    paused_at=None,
+                    loop_cooldown_until=None,
+                    loop_detected_at=None,
+                    append_lifecycle_event={
+                        "event": "safety_net_resumed",
+                        "timestamp": datetime.now().isoformat(),
+                        "reason": resume_reason,
+                    },
+                )
+            except Exception as e:
+                logger.warning(
+                    f"persist_runtime_state(safety_net_resumed) failed for {agent_id[:8]}...: {e}"
+                )
         else:
             logger.warning(
                 f"Agent '{agent_id}' NOT safe for safety-net resume "

--- a/src/audit_db.py
+++ b/src/audit_db.py
@@ -37,12 +37,13 @@ async def append_audit_event_async(entry: Dict[str, Any], raw_hash: Optional[str
 async def query_audit_events_async(
     agent_id: Optional[str] = None,
     event_type: Optional[str] = None,
+    event_types: Optional[List[str]] = None,
     start_time: Optional[str] = None,
     end_time: Optional[str] = None,
     limit: int = 1000,
     order: str = "asc",
 ) -> List[Dict[str, Any]]:
-    """Query audit events from PostgreSQL."""
+    """Query audit events from PostgreSQL. Pass event_types for IN-list filtering."""
     from src.db import get_db
     db = get_db()
     if not hasattr(db, '_pool') or db._pool is None:
@@ -54,6 +55,7 @@ async def query_audit_events_async(
     events = await db.query_audit_events(
         agent_id=agent_id,
         event_type=event_type,
+        event_types=event_types,
         start_time=start_dt,
         end_time=end_dt,
         limit=limit,

--- a/src/db/base.py
+++ b/src/db/base.py
@@ -324,12 +324,13 @@ class DatabaseBackend(ABC):
         self,
         agent_id: Optional[str] = None,
         event_type: Optional[str] = None,
+        event_types: Optional[List[str]] = None,
         start_time: Optional[datetime] = None,
         end_time: Optional[datetime] = None,
         limit: int = 1000,
         order: str = "asc",
     ) -> List[AuditEvent]:
-        """Query audit events with filtering."""
+        """Query audit events with filtering. Pass event_types for IN-list filtering."""
         pass
 
     @abstractmethod

--- a/src/db/mixins/audit.py
+++ b/src/db/mixins/audit.py
@@ -52,6 +52,7 @@ class AuditMixin:
         self,
         agent_id: Optional[str] = None,
         event_type: Optional[str] = None,
+        event_types: Optional[List[str]] = None,
         start_time: Optional[datetime] = None,
         end_time: Optional[datetime] = None,
         limit: int = 1000,
@@ -68,6 +69,10 @@ class AuditMixin:
         if event_type:
             conditions.append(f"event_type = ${param_idx}")
             params.append(event_type)
+            param_idx += 1
+        elif event_types:
+            conditions.append(f"event_type = ANY(${param_idx}::text[])")
+            params.append(list(event_types))
             param_idx += 1
         if start_time:
             conditions.append(f"ts >= ${param_idx}")

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -954,6 +954,89 @@ async def http_events(request):
         }, status_code=500)
 
 
+# Event types surfaced by /v1/lifecycle/recent. Pause-side answers
+# "why did this agent stop?", resume-side answers "how did it come back?".
+_LIFECYCLE_EVENT_TYPES = (
+    "lifecycle_paused",
+    "lifecycle_resumed",
+    "lifecycle_archived",
+    "lifecycle_loop_detected",
+    "lifecycle_stuck_detected",
+    "circuit_breaker_trip",
+    "circuit_breaker_reset",
+)
+
+
+async def http_lifecycle_recent(request):
+    """GET /v1/lifecycle/recent — recent lifecycle / circuit-breaker events
+    from audit.events with the full payload (reason, EISV, drift) and
+    agent label resolution.
+
+    Query params:
+      - agent_id: filter to one agent (UUID or label)
+      - hours: lookback window in hours (default 24, max 168)
+      - limit: max events (default 100, max 500)
+    """
+    http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
+    if not _check_http_auth(request, http_api_token=http_api_token):
+        return _http_unauthorized()
+    try:
+        from src.audit_db import query_audit_events_async
+        from datetime import datetime, timedelta, timezone
+
+        agent_id_param = request.query_params.get("agent_id")
+        hours = max(1, min(168, int(request.query_params.get("hours", 24))))
+        limit = max(1, min(500, int(request.query_params.get("limit", 100))))
+        start_time = (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
+
+        # Resolve label → UUID and build a UUID → label lookup for enrichment.
+        from src.agent_metadata_model import agent_metadata
+        label_to_uuid = {}
+        uuid_to_label = {}
+        for uuid_, meta in agent_metadata.items():
+            label = getattr(meta, "label", None) or ""
+            if label:
+                label_to_uuid[label] = uuid_
+                uuid_to_label[uuid_] = label
+        resolved_agent_id = label_to_uuid.get(agent_id_param, agent_id_param) \
+            if agent_id_param else None
+
+        rows = await query_audit_events_async(
+            agent_id=resolved_agent_id,
+            event_types=list(_LIFECYCLE_EVENT_TYPES),
+            start_time=start_time,
+            limit=limit,
+            order="desc",
+        )
+
+        events = []
+        for r in rows:
+            details = r.get("details") or {}
+            events.append({
+                "timestamp": r.get("timestamp"),
+                "event_type": r.get("event_type"),
+                "agent_id": r.get("agent_id"),
+                "agent_label": uuid_to_label.get(r.get("agent_id"), ""),
+                "reason": details.get("reason"),
+                "details": details,
+                "event_id": r.get("event_id"),
+            })
+
+        return JSONResponse({
+            "success": True,
+            "events": events,
+            "count": len(events),
+            "window_hours": hours,
+        })
+    except Exception as e:
+        logger.error(f"Error fetching lifecycle events: {e}")
+        return JSONResponse({
+            "success": False,
+            "error": str(e),
+            "events": []
+        }, status_code=500)
+
+
 # Allowed severity values for externally posted findings
 _FINDING_SEVERITIES = frozenset({"info", "low", "medium", "warning", "high", "critical"})
 # Only accept *_finding event types via this endpoint (prevents spoofing
@@ -1539,6 +1622,7 @@ def register_http_routes(
     app.routes.append(Route("/health/deep", http_health_deep, methods=["GET"]))
     app.routes.append(Route("/metrics", http_metrics, methods=["GET"]))
     app.routes.append(Route("/v1/eisv/latest", http_eisv_latest, methods=["GET"]))
+    app.routes.append(Route("/v1/lifecycle/recent", http_lifecycle_recent, methods=["GET"]))
     app.routes.append(Route("/api/events", http_events, methods=["GET"]))
     app.routes.append(Route("/api/findings", http_record_finding, methods=["POST"]))
     app.routes.append(Route("/api/activity", http_activity, methods=["GET"]))

--- a/tests/test_http_api_lifecycle_recent.py
+++ b/tests/test_http_api_lifecycle_recent.py
@@ -1,0 +1,108 @@
+"""Tests for GET /v1/lifecycle/recent — recent lifecycle / circuit-breaker events."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from src.http_api import http_lifecycle_recent, _LIFECYCLE_EVENT_TYPES
+
+
+@pytest.fixture(autouse=True)
+def _no_http_api_token(monkeypatch):
+    monkeypatch.delenv("UNITARES_HTTP_API_TOKEN", raising=False)
+
+
+@pytest.fixture
+def client():
+    app = Starlette(routes=[
+        Route("/v1/lifecycle/recent", http_lifecycle_recent, methods=["GET"]),
+    ])
+    return TestClient(app)
+
+
+def _audit_row(event_type, agent_id="agent-1", reason="boom", details_extra=None):
+    details = {"reason": reason}
+    if details_extra:
+        details.update(details_extra)
+    return {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "agent_id": agent_id,
+        "event_type": event_type,
+        "confidence": 1.0,
+        "details": details,
+        "event_id": "abc-123",
+    }
+
+
+def test_returns_pause_with_full_details_and_label(client):
+    """The endpoint must return reason + full details payload, AND resolve
+    agent_id → label so the consumer doesn't need a second lookup."""
+    rows = [_audit_row(
+        "circuit_breaker_trip",
+        agent_id="f92dcea8-uuid",
+        reason="UNITARES high-risk verdict (risk_score=0.65)",
+        details_extra={"risk_score": 0.65, "coherence": 0.47},
+    )]
+    fake_meta = SimpleNamespace(label="Sentinel")
+    with patch("src.audit_db.query_audit_events_async",
+               AsyncMock(return_value=rows)), \
+         patch("src.agent_metadata_model.agent_metadata",
+               {"f92dcea8-uuid": fake_meta}):
+        r = client.get("/v1/lifecycle/recent")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["success"] is True
+    assert body["count"] == 1
+    evt = body["events"][0]
+    assert evt["event_type"] == "circuit_breaker_trip"
+    assert evt["agent_label"] == "Sentinel"
+    assert "high-risk" in evt["reason"]
+    assert evt["details"]["risk_score"] == 0.65, \
+        "details payload must pass through — that's the whole point of this endpoint"
+
+
+def test_filter_by_agent_label_resolves_to_uuid(client):
+    """Passing agent_id=Sentinel should be resolved to the UUID before
+    hitting audit.events (which only stores UUIDs)."""
+    rows = [_audit_row("lifecycle_paused", agent_id="f92dcea8-uuid")]
+    fake_meta = SimpleNamespace(label="Sentinel")
+
+    captured_kwargs = {}
+
+    async def _capture(**kwargs):
+        captured_kwargs.update(kwargs)
+        return rows
+
+    with patch("src.audit_db.query_audit_events_async", side_effect=_capture), \
+         patch("src.agent_metadata_model.agent_metadata",
+               {"f92dcea8-uuid": fake_meta}):
+        r = client.get("/v1/lifecycle/recent?agent_id=Sentinel")
+    assert r.status_code == 200
+    assert captured_kwargs.get("agent_id") == "f92dcea8-uuid", \
+        "label 'Sentinel' must be resolved to its UUID before the DB query"
+
+
+def test_filters_to_lifecycle_event_types_only(client):
+    """The endpoint must restrict to lifecycle/circuit_breaker types so it
+    isn't a firehose — that's what /api/events is for."""
+    captured_kwargs = {}
+
+    async def _capture(**kwargs):
+        captured_kwargs.update(kwargs)
+        return []
+
+    with patch("src.audit_db.query_audit_events_async", side_effect=_capture), \
+         patch("src.agent_metadata_model.agent_metadata", {}):
+        r = client.get("/v1/lifecycle/recent")
+    assert r.status_code == 200
+    types = captured_kwargs.get("event_types") or []
+    assert "circuit_breaker_trip" in types
+    assert "lifecycle_paused" in types
+    assert "lifecycle_resumed" in types
+    # And the same set as the module constant
+    assert set(types) == set(_LIFECYCLE_EVENT_TYPES)

--- a/tests/test_lifecycle_clobber.py
+++ b/tests/test_lifecycle_clobber.py
@@ -218,3 +218,96 @@ class TestLoaderHydratesRuntimeFields:
         assert meta.last_response_at == "2026-04-16T10:30:00+00:00"
         assert meta.response_completed is True
         assert meta.recovery_attempt_at == "2026-04-16T10:35:00+00:00"
+
+
+class TestCircuitBreakerPersistsRuntimeState:
+    """Pause path in agent_loop_detection.process_update_authenticated_async
+    must persist paused_at + the 'paused' lifecycle event so the agent record
+    isn't silently empty after the next force-reload (Watcher P011 ext).
+    """
+
+    @pytest.mark.asyncio
+    async def test_pause_decision_persists_paused_at_and_lifecycle_event(self):
+        from src import agent_loop_detection as ald
+        from src import agent_storage
+
+        meta = make_agent_meta(status="active")
+        meta.recent_update_timestamps = []
+        meta.recent_decisions = []
+        meta.loop_cooldown_until = None
+        meta.add_recent_update = MagicMock()
+        meta.add_lifecycle_event = MagicMock()
+
+        monitor = make_monitor()
+        monitor.process_update = MagicMock(return_value={
+            "decision": {
+                "action": "pause",
+                "reason": "UNITARES high-risk verdict (risk_score=0.65)",
+            },
+            "metrics": {"coherence": 0.45, "risk_score": 0.65},
+        })
+
+        mock_db = MagicMock()
+        mock_db.increment_update_count = AsyncMock(return_value=42)
+
+        with patch.object(ald, "agent_metadata", {AGENT_ID: meta}), \
+             patch.object(ald, "monitors", {AGENT_ID: monitor}), \
+             patch.object(ald, "verify_agent_ownership", return_value=(True, None)), \
+             patch.object(ald, "detect_loop_pattern", return_value=(False, "")), \
+             patch("src.agent_lifecycle.get_or_create_monitor", return_value=monitor), \
+             patch.object(agent_storage, "get_db", return_value=mock_db), \
+             patch.object(agent_storage, "persist_runtime_state",
+                          AsyncMock(return_value=True)) as persist_mock, \
+             patch.object(ald, "save_monitor_state_async", AsyncMock()):
+            # Disable auto-recovery to avoid touching unrelated code paths
+            with patch.dict("os.environ", {"UNITARES_AUTO_DIALECTIC_RECOVERY": "0"}):
+                await ald.process_update_authenticated_async(
+                    AGENT_ID, "test-key", {"task_type": "mixed"}
+                )
+
+        assert persist_mock.await_count >= 1, (
+            "Circuit-breaker pause must call persist_runtime_state so paused_at "
+            "and the 'paused' lifecycle event survive a force-reload — without "
+            "this, the agent record's lifecycle_events stays [] and paused_at "
+            "comes back as null, hiding the pause from anyone querying the agent."
+        )
+        kwargs = persist_mock.await_args.kwargs
+        assert kwargs.get("paused_at"), \
+            "persist_runtime_state must be called with paused_at set"
+        event = kwargs.get("append_lifecycle_event")
+        assert event and event.get("event") == "paused", \
+            "persist_runtime_state must include the 'paused' lifecycle event"
+        assert "high-risk" in (event.get("reason") or ""), \
+            "lifecycle event reason must carry the decision reason"
+
+    @pytest.mark.asyncio
+    async def test_safety_net_resume_persists_paused_at_clear_and_event(self):
+        from src import agent_loop_detection as ald
+        from src import agent_storage
+
+        meta = make_agent_meta(status="paused", paused_at="2026-04-16T22:16:36+00:00")
+        meta.loop_cooldown_until = None
+        meta.loop_detected_at = None
+        meta.recent_update_timestamps = []
+        meta.recent_decisions = []
+        meta.add_lifecycle_event = MagicMock()
+
+        monitor = make_monitor(coherence=0.55, mean_risk=0.40)
+
+        with patch.object(ald, "agent_metadata", {AGENT_ID: meta}), \
+             patch.object(ald, "monitors", {AGENT_ID: monitor}), \
+             patch.object(agent_storage, "persist_runtime_state",
+                          AsyncMock(return_value=True)) as persist_mock:
+            await ald._safety_net_resume(AGENT_ID, reason="dialectic-failed")
+
+        assert meta.status == "active"
+        assert persist_mock.await_count >= 1, (
+            "_safety_net_resume must persist paused_at=None + the resume "
+            "lifecycle event — otherwise the next force-reload re-pauses the "
+            "agent and hides the safety-net resume from the audit trail."
+        )
+        kwargs = persist_mock.await_args.kwargs
+        assert kwargs.get("paused_at") is None, \
+            "safety-net resume must clear paused_at in the persisted record"
+        event = kwargs.get("append_lifecycle_event")
+        assert event and event.get("event") == "safety_net_resumed"


### PR DESCRIPTION
## Summary

- **Bug fix (P011 ext):** Circuit-breaker pause and the two auto-resume paths in `agent_loop_detection.py` mutated `meta.paused_at` and `meta.lifecycle_events` in memory but never called `persist_runtime_state`. Next force-reload silently wiped them — the agent record showed `paused_at=null` and `lifecycle_events=[]` despite real pauses having fired. (Discovered via Sentinel `f92dcea8-478` pause at 2026-04-17T04:16:36 — visible in `audit.events` but invisible on the agent record.)
- **New endpoint:** `GET /v1/lifecycle/recent` surfaces lifecycle / circuit-breaker events from `audit.events` with the full payload (reason, EISV, drift) and agent label resolution. The existing `/api/events` strips these to a thin shape; the new endpoint answers "why was Sentinel paused?" directly.
- **Small DB layer change:** `query_audit_events` grows an `event_types` list parameter for `IN`-list filtering.

## Test plan

- [x] `tests/test_lifecycle_clobber.py` — 2 new regression tests for circuit-breaker pause + safety-net resume persistence
- [x] `tests/test_http_api_lifecycle_recent.py` — 3 new tests: payload pass-through, label→UUID resolution, event-type filter
- [x] Full suite: 6346 passed, 34 skipped via `./scripts/dev/test-cache.sh --fresh`
- [ ] Live verification: restart governance MCP and `curl http://localhost:8767/v1/lifecycle/recent?agent_id=Sentinel`