### PR TITLE
fix(stdio): wrap fire-and-forget tasks with create_tracked_task (P001)

### DIFF
--- a/src/mcp_server_std.py
+++ b/src/mcp_server_std.py
@@ -458,8 +458,10 @@ async def call_tool(name: str, arguments: dict[str, Any] | None) -> Sequence[Tex
                         if activity.session_start else 0
                     )
                 }
-                asyncio.create_task(
-                    inject_lightweight_heartbeat(agent_id, trigger_reason, activity_summary, activity_tracker)
+                from src.background_tasks import create_tracked_task
+                create_tracked_task(
+                    inject_lightweight_heartbeat(agent_id, trigger_reason, activity_summary, activity_tracker),
+                    name="inject_lightweight_heartbeat",
                 )
                 logger.info(f"Auto-triggered heartbeat for {agent_id}: {trigger_reason}")
             except Exception as e:
@@ -539,7 +541,11 @@ async def main():
             result = await collect_ground_truth_automatically(min_age_hours=2.0, max_decisions=50, dry_run=False)
             if result.get('updated', 0) > 0:
                 logger.info(f"Auto-collected ground truth: {result['updated']} decisions updated")
-            asyncio.create_task(auto_ground_truth_collector_task(interval_hours=6.0))
+            from src.background_tasks import create_tracked_task
+            create_tracked_task(
+                auto_ground_truth_collector_task(interval_hours=6.0),
+                name="auto_ground_truth_collector",
+            )
         except Exception as e:
             logger.warning(f"Could not auto-collect ground truth: {e}", exc_info=True)
 
@@ -579,7 +585,11 @@ async def main():
 
             # Only run background tasks in non-proxy mode
             if not (STDIO_PROXY_URL or STDIO_PROXY_HTTP_URL):
-                asyncio.create_task(safe_startup_background_tasks())
+                from src.background_tasks import create_tracked_task
+                create_tracked_task(
+                    safe_startup_background_tasks(),
+                    name="stdio_startup_background_tasks",
+                )
 
             await server.run(
                 read_stream,


### PR DESCRIPTION
## Summary

Codex's `audit.tool_usage` commit (`a3e672f9`) added 3 `asyncio.create_task` calls in `src/mcp_server_std.py` without keeping references, regressing Watcher pattern P001. The GC can drop these mid-flight, silently canceling the work.

Switched all three to `create_tracked_task` from `src.background_tasks` — the supervised wrapper used elsewhere in the codebase. Each task gets a name and crash logging via `_on_background_task_done`.

**Resolves Watcher findings:**
- `P001 #c72b60de` — `inject_lightweight_heartbeat`
- `P001 #32cfb4b1` — `auto_ground_truth_collector_task`
- `P001 #60470349` — `safe_startup_background_tasks`

## Test plan

- [x] Verified all 3 sites now use `create_tracked_task` with named tasks
- [x] Confirmed `tests/test_unitares_cli_script.py::test_update_returns_verdict` failure is pre-existing on `origin/master` (a3e672f9), not introduced by this fix
- [ ] After merge: confirm Watcher findings clear on next post-edit hook