### PR TITLE
feat(audit): wire tool_usage recording through HTTP transport

### DIFF
--- a/src/mcp_server_std.py
+++ b/src/mcp_server_std.py
@@ -77,6 +77,8 @@ from src.agent_state import (
 
 from src.tool_schemas import get_tool_definitions
 from src.lock_cleanup import cleanup_stale_state_locks
+from src.services.tool_usage_recorder import record_tool_usage
+from src.background_tasks import create_tracked_task
 
 # ============================================================================
 # MCP Server Instance
@@ -356,38 +358,6 @@ async def inject_lightweight_heartbeat(
         logger.error(f"Error injecting heartbeat for {agent_id}: {e}", exc_info=True)
 
 
-def _record_tool_usage(name, agent_id, success, error_type=None, latency_ms=None):
-    """Record a tool call to JSONL (sync, local) and audit.tool_usage (fire-and-forget).
-
-    Never raises — a telemetry failure must not break the tool call.
-    """
-    try:
-        from src.tool_usage_tracker import get_tool_usage_tracker
-        get_tool_usage_tracker().log_tool_call(
-            tool_name=name, agent_id=agent_id, success=success, error_type=error_type,
-        )
-    except Exception as e:
-        logger.debug(f"JSONL tool_usage log failed (non-fatal): {e}")
-
-    try:
-        from src.background_tasks import create_tracked_task
-        from src.audit_db import append_tool_usage_async
-        create_tracked_task(
-            append_tool_usage_async(
-                agent_id=agent_id,
-                tool_name=name,
-                latency_ms=latency_ms,
-                success=success,
-                error_type=error_type,
-            ),
-            name="persist_tool_usage",
-        )
-    except RuntimeError:
-        pass  # no running event loop (CLI / tests)
-    except Exception as e:
-        logger.debug(f"DB tool_usage persist failed (non-fatal): {e}")
-
-
 @server.call_tool()
 async def call_tool(name: str, arguments: dict[str, Any] | None) -> Sequence[TextContent]:
     """Handle tool calls from MCP client"""
@@ -475,10 +445,10 @@ async def call_tool(name: str, arguments: dict[str, Any] | None) -> Sequence[Tex
         result = await dispatch_tool(name, arguments)
         latency_ms = int((time.monotonic() - t0) * 1000)
         if result is not None:
-            _record_tool_usage(name, agent_id, success=True, latency_ms=latency_ms)
+            record_tool_usage(tool_name=name, agent_id=agent_id, success=True, latency_ms=latency_ms)
             return result
-        _record_tool_usage(name, agent_id, success=False,
-                           error_type="unknown_tool", latency_ms=latency_ms)
+        record_tool_usage(tool_name=name, agent_id=agent_id, success=False,
+                          error_type="unknown_tool", latency_ms=latency_ms)
         return [TextContent(type="text", text=json.dumps({"success": False, "error": f"Unknown tool: {name}"}, indent=2))]
     except ImportError:
         return [TextContent(type="text", text=json.dumps({"success": False, "error": f"Handler registry not available for tool '{name}'"}, indent=2))]
@@ -490,8 +460,8 @@ async def call_tool(name: str, arguments: dict[str, Any] | None) -> Sequence[Tex
             f"Error executing tool '{name}': {str(e)}",
             recovery={"action": "Check tool parameters and try again"}
         )
-        _record_tool_usage(name, agent_id, success=False,
-                           error_type="execution_error", latency_ms=latency_ms)
+        record_tool_usage(tool_name=name, agent_id=agent_id, success=False,
+                          error_type="execution_error", latency_ms=latency_ms)
         return [sanitized_error]
 
 

--- a/src/services/http_tool_service.py
+++ b/src/services/http_tool_service.py
@@ -7,6 +7,7 @@ plain argument dicts. Everything else falls back to the MCP dispatch pipeline.
 from __future__ import annotations
 
 import json
+import time
 from typing import Any, Awaitable, Callable, Dict, Optional
 
 from src.mcp_handlers.identity.handlers import (
@@ -17,6 +18,7 @@ from src.mcp_handlers.core import handle_process_agent_update
 from src.mcp_handlers.utils import require_agent_id
 from src.services.http_dispatch_fallback import execute_http_dispatch_fallback
 from src.services.runtime_queries import get_governance_metrics_data, get_health_check_data
+from src.services.tool_usage_recorder import record_tool_usage
 
 ToolHandler = Callable[[Dict[str, Any]], Awaitable[Any]]
 
@@ -61,9 +63,27 @@ async def execute_http_tool(tool_name: str, arguments: Dict[str, Any]) -> Any:
     Core governance tools use direct handlers so HTTP does not always depend on
     the full MCP dispatch path. All other tools use an HTTP-specific fallback
     that skips identity-resolution middleware because HTTP already set context.
+
+    Records tool_usage telemetry (JSONL + audit.tool_usage) at every exit point.
     """
-    handler = get_direct_http_tool_handler(tool_name)
-    if handler is not None:
-        result = await handler(arguments)
-        return _normalize_direct_http_result(result)
-    return await execute_http_dispatch_fallback(tool_name, arguments)
+    agent_id = arguments.get("agent_id") if isinstance(arguments, dict) else None
+    t0 = time.monotonic()
+    try:
+        handler = get_direct_http_tool_handler(tool_name)
+        if handler is not None:
+            result = await handler(arguments)
+            latency_ms = int((time.monotonic() - t0) * 1000)
+            record_tool_usage(tool_name=tool_name, agent_id=agent_id,
+                              success=True, latency_ms=latency_ms)
+            return _normalize_direct_http_result(result)
+        result = await execute_http_dispatch_fallback(tool_name, arguments)
+        latency_ms = int((time.monotonic() - t0) * 1000)
+        record_tool_usage(tool_name=tool_name, agent_id=agent_id,
+                          success=True, latency_ms=latency_ms)
+        return result
+    except Exception as e:
+        latency_ms = int((time.monotonic() - t0) * 1000)
+        record_tool_usage(tool_name=tool_name, agent_id=agent_id,
+                          success=False, error_type=type(e).__name__,
+                          latency_ms=latency_ms)
+        raise

--- a/src/services/tool_usage_recorder.py
+++ b/src/services/tool_usage_recorder.py
@@ -1,0 +1,50 @@
+"""Records tool call telemetry to JSONL + audit.tool_usage.
+
+Shared between STDIO transport (src/mcp_server_std.py) and HTTP transport
+(src/services/http_tool_service.py). JSONL write is synchronous; DB write is
+fire-and-forget via create_tracked_task so request handlers never await
+asyncpg (anyio-asyncio deadlock rule).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from src.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+def record_tool_usage(
+    tool_name: str,
+    agent_id: Optional[str],
+    success: bool,
+    error_type: Optional[str] = None,
+    latency_ms: Optional[int] = None,
+) -> None:
+    """Record a tool call. Never raises — telemetry failure must not break the call."""
+    try:
+        from src.tool_usage_tracker import get_tool_usage_tracker
+        get_tool_usage_tracker().log_tool_call(
+            tool_name=tool_name, agent_id=agent_id, success=success, error_type=error_type,
+        )
+    except Exception as e:
+        logger.debug(f"JSONL tool_usage log failed (non-fatal): {e}")
+
+    try:
+        from src.background_tasks import create_tracked_task
+        from src.audit_db import append_tool_usage_async
+        create_tracked_task(
+            append_tool_usage_async(
+                agent_id=agent_id,
+                tool_name=tool_name,
+                latency_ms=latency_ms,
+                success=success,
+                error_type=error_type,
+            ),
+            name="persist_tool_usage",
+        )
+    except RuntimeError:
+        pass  # no running event loop (CLI / tests)
+    except Exception as e:
+        logger.debug(f"DB tool_usage persist failed (non-fatal): {e}")

--- a/tests/test_http_tool_service_tool_usage.py
+++ b/tests/test_http_tool_service_tool_usage.py
@@ -1,0 +1,88 @@
+"""Tests that execute_http_tool records tool_usage telemetry at every exit."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _consume_coro(coro, name=None):
+    if hasattr(coro, "close"):
+        coro.close()
+    return MagicMock()
+
+
+@pytest.mark.asyncio
+async def test_direct_handler_records_success():
+    from src.services.http_tool_service import execute_http_tool
+
+    mock_tracker = MagicMock()
+    direct_handler = AsyncMock(return_value={"status": "healthy"})
+
+    with patch("src.services.http_tool_service.get_direct_http_tool_handler",
+               return_value=direct_handler), \
+         patch("src.tool_usage_tracker.get_tool_usage_tracker", return_value=mock_tracker), \
+         patch("src.background_tasks.create_tracked_task", side_effect=_consume_coro) as mock_track:
+        result = await execute_http_tool("health_check", {"agent_id": "a1"})
+
+    assert result == {"status": "healthy"}
+    mock_tracker.log_tool_call.assert_called_once()
+    assert mock_tracker.log_tool_call.call_args.kwargs["success"] is True
+    assert mock_tracker.log_tool_call.call_args.kwargs["tool_name"] == "health_check"
+    assert mock_track.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatch_fallback_records_success():
+    from src.services.http_tool_service import execute_http_tool
+
+    mock_tracker = MagicMock()
+
+    with patch("src.services.http_tool_service.get_direct_http_tool_handler",
+               return_value=None), \
+         patch("src.services.http_tool_service.execute_http_dispatch_fallback",
+               new_callable=AsyncMock, return_value=[MagicMock()]), \
+         patch("src.tool_usage_tracker.get_tool_usage_tracker", return_value=mock_tracker), \
+         patch("src.background_tasks.create_tracked_task", side_effect=_consume_coro) as mock_track:
+        await execute_http_tool("custom_tool", {"agent_id": "a1"})
+
+    mock_tracker.log_tool_call.assert_called_once()
+    assert mock_tracker.log_tool_call.call_args.kwargs["success"] is True
+    assert mock_track.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_exception_records_failure_and_reraises():
+    from src.services.http_tool_service import execute_http_tool
+
+    mock_tracker = MagicMock()
+    failing = AsyncMock(side_effect=ValueError("bad input"))
+
+    with patch("src.services.http_tool_service.get_direct_http_tool_handler",
+               return_value=failing), \
+         patch("src.tool_usage_tracker.get_tool_usage_tracker", return_value=mock_tracker), \
+         patch("src.background_tasks.create_tracked_task", side_effect=_consume_coro) as mock_track:
+        with pytest.raises(ValueError, match="bad input"):
+            await execute_http_tool("bad_tool", {"agent_id": "a1"})
+
+    mock_tracker.log_tool_call.assert_called_once()
+    kwargs = mock_tracker.log_tool_call.call_args.kwargs
+    assert kwargs["success"] is False
+    assert kwargs["error_type"] == "ValueError"
+    assert mock_track.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_non_dict_arguments_do_not_raise():
+    """If arguments isn't a dict (edge case), recorder still gets called with agent_id=None."""
+    from src.services.http_tool_service import execute_http_tool
+
+    mock_tracker = MagicMock()
+    direct_handler = AsyncMock(return_value={"ok": True})
+
+    with patch("src.services.http_tool_service.get_direct_http_tool_handler",
+               return_value=direct_handler), \
+         patch("src.tool_usage_tracker.get_tool_usage_tracker", return_value=mock_tracker), \
+         patch("src.background_tasks.create_tracked_task", side_effect=_consume_coro):
+        await execute_http_tool("t", None)
+
+    assert mock_tracker.log_tool_call.call_args.kwargs["agent_id"] is None

--- a/tests/test_mcp_server_std.py
+++ b/tests/test_mcp_server_std.py
@@ -1536,6 +1536,11 @@ def _consume_coro(coro, name=None):
     return MagicMock()
 
 
+def _persist_calls(mock_track):
+    """Return calls to create_tracked_task that were for persist_tool_usage."""
+    return [c for c in mock_track.call_args_list if c.kwargs.get("name") == "persist_tool_usage"]
+
+
 class TestToolUsageRecording:
     """Every dispatched tool call should land in audit.tool_usage via fire-and-forget."""
 
@@ -1561,9 +1566,9 @@ class TestToolUsageRecording:
         assert call_kwargs["success"] is True
         assert call_kwargs["tool_name"] == "health_check"
 
-        # DB persist task created exactly once
-        assert mock_track.call_count == 1
-        assert mock_track.call_args.kwargs.get("name") == "persist_tool_usage"
+        # Exactly one persist_tool_usage task scheduled (other unrelated
+        # create_tracked_task calls like auto-heartbeat may also happen)
+        assert len(_persist_calls(mock_track)) == 1
 
     @pytest.mark.asyncio
     async def test_unknown_tool_records_failure(self):
@@ -1581,7 +1586,7 @@ class TestToolUsageRecording:
         call_kwargs = mock_tracker.log_tool_call.call_args.kwargs
         assert call_kwargs["success"] is False
         assert call_kwargs["error_type"] == "unknown_tool"
-        assert mock_track.call_count == 1
+        assert len(_persist_calls(mock_track)) == 1
 
     @pytest.mark.asyncio
     async def test_execution_error_records_failure(self):
@@ -1600,7 +1605,7 @@ class TestToolUsageRecording:
         call_kwargs = mock_tracker.log_tool_call.call_args.kwargs
         assert call_kwargs["success"] is False
         assert call_kwargs["error_type"] == "execution_error"
-        assert mock_track.call_count == 1
+        assert len(_persist_calls(mock_track)) == 1
 
     @pytest.mark.asyncio
     async def test_db_persist_failure_does_not_break_tool_call(self):


### PR DESCRIPTION
## Summary
- Extracts the tool-usage recorder (JSONL + fire-and-forget DB) from `mcp_server_std.py` into a shared `src/services/tool_usage_recorder.py` so STDIO and HTTP transports can share one implementation.
- Wires `execute_http_tool` (the single HTTP choke point in `src/services/http_tool_service.py`) to record at all three exit paths (direct handler, dispatch fallback, exception). Before this PR, HTTP callers — which is essentially every live client hitting `:8767` — were invisible to `audit.tool_usage`.
- On exception, records `error_type = type(e).__name__` and re-raises so existing error handling stays intact.
- Updates `TestToolUsageRecording` assertions to count persist-specific `create_tracked_task` calls rather than total calls (PR #12 introduced a separate auto-heartbeat tracked task that the tests were conflating with ours).

## Test plan
- [x] `pytest tests/test_mcp_server_std.py::TestToolUsageRecording tests/test_mcp_server_std.py::TestAppendToolUsageAsync tests/test_http_tool_service_tool_usage.py` — 10 passed, no coroutine leaks.
- [x] Restarted the governance LaunchAgent; `audit.tool_usage` went from 0 rows (stale for weeks) to 120+ rows across 14 tools within minutes, latencies captured, no errors in `data/logs/mcp_server_error.log`.
- [x] JSONL tracker continues to write to `data/tool_usage.jsonl` in parallel (backup path preserved).