### PR TITLE
fix(auth): honor explicit agent_id when it differs from session binding

### DIFF
--- a/src/mcp_handlers/support/agent_auth.py
+++ b/src/mcp_handlers/support/agent_auth.py
@@ -147,7 +147,19 @@ def require_agent_id(arguments: Dict[str, Any]) -> Tuple[str, Optional[TextConte
         except Exception as e:
             logger.debug(f"Could not retrieve session-bound identity: {e}")
 
-    # Canonical ID clarification: warn if explicit agent_id doesn't match session
+    # Canonical ID resolution when both explicit agent_id and a session binding exist.
+    #
+    # Two cases:
+    #   1. Self-reference: the explicit agent_id is an alias (label, structured_id,
+    #      or public_agent_id) of the session-bound agent itself. Rewrite to the
+    #      canonical UUID so downstream lookups use the storage key.
+    #   2. Cross-agent reference: the explicit agent_id names a different agent
+    #      (e.g. an admin calling `agent.update(agent_id='Lumen', ...)`). Honor
+    #      the explicit value and let verify_agent_ownership downstream decide
+    #      whether the caller is allowed to touch the target's record. Silently
+    #      substituting the bound UUID here would violate the identity invariant
+    #      (``never silently substitute identity'') by writing the caller's own
+    #      record while reporting success under the requested agent_id.
     if explicit_agent_id:
         try:
             from ..context import get_context_agent_id
@@ -162,13 +174,20 @@ def require_agent_id(arguments: Dict[str, Any]) -> Tuple[str, Optional[TextConte
                         structured_id = getattr(meta, 'structured_id', None)
                         public_agent_id = getattr(meta, 'public_agent_id', None)
                         if explicit_agent_id in (label, public_agent_id, structured_id):
-                            logger.debug(f"Explicit agent_id '{explicit_agent_id}' matches label/structured_id, using UUID '{bound_uuid[:8]}...'")
+                            # Case 1: alias of the bound agent — rewrite to UUID.
+                            logger.debug(
+                                f"Explicit agent_id '{explicit_agent_id}' is an alias "
+                                f"of bound UUID '{bound_uuid[:8]}...'; using UUID."
+                            )
                             agent_id = bound_uuid
                             arguments["agent_id"] = agent_id
                         else:
-                            logger.debug(f"Explicit agent_id '{explicit_agent_id}' differs from session-bound UUID '{bound_uuid[:8]}...' - using session-bound UUID")
-                            agent_id = bound_uuid
-                            arguments["agent_id"] = agent_id
+                            # Case 2: cross-agent reference — honor the explicit
+                            # value; ownership verification runs downstream.
+                            logger.debug(
+                                f"Explicit agent_id '{explicit_agent_id}' differs from "
+                                f"bound UUID '{bound_uuid[:8]}...'; honoring explicit value."
+                            )
                 except Exception:
                     pass
         except Exception:

--- a/tests/test_mcp_utils.py
+++ b/tests/test_mcp_utils.py
@@ -540,6 +540,39 @@ class TestRequireAgentId:
         require_agent_id(args)
         assert args.get("agent_id") is not None
 
+    @patch("src.mcp_handlers.validators.validate_agent_id_reserved_names", return_value=("bound-uuid", None))
+    @patch("src.mcp_handlers.validators.validate_agent_id_format", return_value=("bound-uuid", None))
+    @patch("src.mcp_handlers.context.get_context_agent_id", return_value="bound-uuid")
+    @patch("src.mcp_handlers.shared.get_mcp_server")
+    def test_explicit_alias_of_bound_rewritten_to_uuid(self, ms, mc, mf, mr):
+        """If the explicit agent_id is a label/structured_id of the bound agent,
+        rewrite it to the canonical UUID so downstream metadata lookups work."""
+        s = _mock_server({"bound-uuid": _meta(label="Bot", structured_id="S1", display_name="Bot")})
+        ms.return_value = s
+        args = {"agent_id": "Bot"}  # alias of the bound agent
+        a, e = require_agent_id(args)
+        assert a == "bound-uuid", "alias should be rewritten to bound UUID"
+        assert args["agent_id"] == "bound-uuid"
+        assert e is None
+
+    @patch("src.mcp_handlers.validators.validate_agent_id_reserved_names", return_value=("Other", None))
+    @patch("src.mcp_handlers.validators.validate_agent_id_format", return_value=("Other", None))
+    @patch("src.mcp_handlers.context.get_context_agent_id", return_value="bound-uuid")
+    @patch("src.mcp_handlers.shared.get_mcp_server")
+    def test_explicit_cross_agent_not_silently_substituted(self, ms, mc, mf, mr):
+        """Regression: when the explicit agent_id names a different agent than
+        the session-bound one (and isn't an alias of the bound agent), the
+        explicit value must be honored. Silent substitution here violated the
+        identity invariant and caused cross-agent writes on agent.update calls
+        to land on the caller's own record."""
+        s = _mock_server({"bound-uuid": _meta(label="Caller", structured_id="S-caller", display_name="Caller")})
+        ms.return_value = s
+        args = {"agent_id": "Other"}  # label of a different agent
+        a, e = require_agent_id(args)
+        assert a == "Other", f"explicit cross-agent id must be honored, got {a!r}"
+        assert args["agent_id"] == "Other"
+        assert e is None
+
 
 class TestRequireRegisteredAgent:
     @patch("src.mcp_handlers.validators.validate_agent_id_reserved_names", return_value=("u1", None))


### PR DESCRIPTION
## Summary
\`require_agent_id\` silently overwrote an explicit \`agent_id\` with the session-bound UUID whenever the two differed and the explicit value wasn't an alias of the bound agent. This violated the identity invariant \"never silently substitute identity\" and caused cross-agent tool calls like \`agent.update(agent_id='Lumen', tags=[...])\` to land on the caller's own record while reporting success under the target's name.

The substitution was added as restart-safety — to defend against stale/forked ids after service restarts — but was too aggressive for admin-style tools operating on a different agent's record.

## The fix
- **Case 1 (alias)**: explicit agent_id is a label/structured_id/public_agent_id of the bound agent → keep rewriting to UUID. Preserves continuity across session-key changes.
- **Case 2 (cross-agent)**: explicit agent_id names a different agent → honor the explicit value. \`verify_agent_ownership\` downstream rejects the call if the caller doesn't own the target — that's the right security boundary.

## Test plan
- [x] Full suite (6355 tests) passes.
- [x] New \`test_explicit_alias_of_bound_rewritten_to_uuid\` preserves Case 1.
- [x] New \`test_explicit_cross_agent_not_silently_substituted\` regression guard for Case 2.

## Why this came up
Discovered while running tag migration for A3 (Lumen-decoupling plan). Calling \`agent.update(agent_id='Lumen', tags=[...])\` from an Opus session silently wrote my own record instead of Lumen's. Verified the commit on master was mistakenly taken (rolled back; actual fix is in this PR).

## Related
- Unblocks A3 tag migration in \`a3-tag-metadata\` (stacked on this branch).