### PR TITLE
fix(watcher): repo-relative fingerprint stops per-worktree multiplication

### DIFF
--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -45,6 +45,7 @@ import hashlib
 import json
 import os
 import re
+import subprocess
 import sys
 import time
 import urllib.request
@@ -330,9 +331,55 @@ class Finding:
         a content hash. Callers that want content-aware dedup should set
         ``line_content_hash`` BEFORE invoking this and then assign the
         result back to ``fingerprint``.
+
+        The file path is normalized to its repo-relative form (relative to
+        the git worktree root containing it) so the same line in identical
+        code checked out across multiple git worktrees produces ONE
+        fingerprint, not N. The displayed ``file`` field is left absolute so
+        the user can navigate to the right copy.
         """
-        key = f"{self.pattern}|{self.file}|{self.line}|{self.line_content_hash}"
+        normalized_path = repo_relative_path(self.file)
+        key = f"{self.pattern}|{normalized_path}|{self.line}|{self.line_content_hash}"
         return hashlib.sha256(key.encode()).hexdigest()[:16]
+
+
+_REPO_ROOT_CACHE: dict[str, str] = {}
+
+
+def repo_relative_path(file_path: str) -> str:
+    """Return ``file_path`` relative to its containing git worktree root.
+
+    Falls back to the absolute string if the path is not inside a git
+    repository or git invocation fails. Result is normalized to forward
+    slashes so the fingerprint is platform-stable.
+
+    Cached per-directory because hook-driven scans hit the same worktree
+    over and over and ``git rev-parse`` is otherwise tens of ms each call.
+    """
+    if not file_path:
+        return file_path
+    p = Path(file_path)
+    parent_key = str(p.parent if p.is_absolute() else p.resolve().parent)
+    toplevel = _REPO_ROOT_CACHE.get(parent_key)
+    if toplevel is None:
+        try:
+            result = subprocess.run(
+                ["git", "-C", parent_key, "rev-parse", "--show-toplevel"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+            toplevel = result.stdout.strip() if result.returncode == 0 else ""
+        except (OSError, subprocess.SubprocessError):
+            toplevel = ""
+        _REPO_ROOT_CACHE[parent_key] = toplevel
+    if not toplevel:
+        return file_path
+    try:
+        rel = Path(file_path).resolve().relative_to(Path(toplevel).resolve())
+    except ValueError:
+        return file_path
+    return rel.as_posix()
 
 
 def hash_line_content(source_line: str) -> str:

--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -1407,6 +1407,22 @@ _PATTERN_FILE_PATH_CONSTRAINTS: dict[str, tuple[str, ...]] = {
 # flagged line, the task reference is stored — not fire-and-forget.
 _P001_TASK_ASSIGNMENT = re.compile(r"\b[a-zA-Z_]\w*\s*=\s*[^=].*create_task\(")
 
+# Regex: project's blessed tracked-task wrapper. By construction stores the
+# task ref in a tracked set; P001 should not flag call sites of it. The
+# required-token check still keeps `create_task(` matches because
+# `create_tracked_task` contains the substring `create_task(`. Caught when
+# qwen3-coder-next flagged 2 sites in mcp_server_std.py on 2026-04-17.
+_P001_TRACKED_HELPER = re.compile(r"\bcreate_tracked_task\s*\(")
+
+# Regex: header line of `def get_or_create_monitor(` — when a P003 flag
+# lands inside the body of this function (which IS the cache), the
+# "instantiated outside the cache" rule does not apply. Caught when
+# qwen3-coder-next flagged agent_lifecycle.py:26 on 2026-04-17.
+_P003_CACHE_FUNC_HEADER = re.compile(
+    r"^\s*(?:async\s+)?def\s+get_or_create_monitor\s*\("
+)
+_P003_OTHER_DEF = re.compile(r"^\s*(?:async\s+)?def\s+\w+\s*\(")
+
 # Regex: `getattr(<obj>, "success", ...)` — defensive typed-attribute access.
 # By construction this targets a flat object's attribute and cannot mask a
 # nested envelope. The quoted "success" satisfies the required-token check,
@@ -1414,6 +1430,27 @@ _P001_TASK_ASSIGNMENT = re.compile(r"\b[a-zA-Z_]\w*\s*=\s*[^=].*create_task\(")
 _P016_GETATTR_SUCCESS = re.compile(
     r"""\bgetattr\s*\([^,]+,\s*['"]success['"]"""
 )
+
+
+def _is_inside_get_or_create_monitor(
+    flagged_line: int, snippet_lines_by_num: dict[int, str]
+) -> bool:
+    """Return True if the flagged line sits inside the body of the
+    ``def get_or_create_monitor`` function. Walks back through the snippet:
+    the first def header we hit decides — if it's our cache function, we're
+    inside; if it's any other def at the same/outer indent, we're not.
+    """
+    for line_no in sorted(snippet_lines_by_num.keys(), reverse=True):
+        if line_no >= flagged_line:
+            continue
+        line = snippet_lines_by_num.get(line_no, "")
+        if not line.strip():
+            continue
+        if _P003_CACHE_FUNC_HEADER.match(line):
+            return True
+        if _P003_OTHER_DEF.match(line):
+            return False
+    return False
 
 
 def _has_preceding_persist_call(
@@ -1480,6 +1517,28 @@ def _verify_finding_against_source(
         log(
             f"drop P001 {finding.file}:{finding.line} — task ref assigned on flagged line "
             f"(not fire-and-forget): {src_line.strip()[:80]}",
+            "warning",
+        )
+        return False
+    # P001 specifically: `create_tracked_task(...)` is the project's blessed
+    # wrapper that stores the task ref in a tracked set. Call sites of it
+    # are by construction not fire-and-forget.
+    if finding.pattern == "P001" and _P001_TRACKED_HELPER.search(src_line):
+        log(
+            f"drop P001 {finding.file}:{finding.line} — create_tracked_task() "
+            f"wrapper stores ref by construction: {src_line.strip()[:80]}",
+            "warning",
+        )
+        return False
+    # P003 specifically: if the flagged line is inside the body of
+    # get_or_create_monitor itself (the cache function), the
+    # "instantiated outside the cache" rule does not apply.
+    if finding.pattern == "P003" and _is_inside_get_or_create_monitor(
+        finding.line, snippet_lines_by_num
+    ):
+        log(
+            f"drop P003 {finding.file}:{finding.line} — flag lands inside "
+            f"get_or_create_monitor body (the cache itself): {src_line.strip()[:80]}",
             "warning",
         )
         return False

--- a/agents/watcher/patterns.md
+++ b/agents/watcher/patterns.md
@@ -47,6 +47,12 @@ The structural verifier drops any P001 finding whose flagged line matches
 `name = ...create_task(...)` — the assignment is sufficient evidence that
 the ref is stored. See `_P001_TASK_ASSIGNMENT` in `agent.py`.
 
+The verifier also drops findings on `create_tracked_task(...)` call sites:
+that helper is the project's blessed wrapper which stores the task ref in
+a tracked set by construction. False-positive sweep 2026-04-17: flagged
+two sites in `mcp_server_std.py:511,551` (both `create_tracked_task(...)`
+calls). See `_P001_TRACKED_HELPER` in `agent.py`.
+
 **Hint template:** `fire-and-forget task — store ref or use TaskGroup`
 
 ### P002 — Unbounded dict/list growth (severity: medium, violation_class: ENT)
@@ -67,6 +73,13 @@ Creating a `UNITARESMonitor(agent_id)` instance outside of
 the cache and cause init storms over time.
 
 **Seen in:** `stuck.py:175-186` (2026-04-10 incident)
+
+The structural verifier drops findings whose flagged line lives inside the
+body of `def get_or_create_monitor(` itself — that function IS the cache,
+not a transient call site. False-positive sweep 2026-04-17: flagged
+`agent_lifecycle.py:26` (the `monitor = UNITARESMonitor(agent_id)` line
+that the cache uses to populate itself). See
+`_is_inside_get_or_create_monitor` in `agent.py`.
 
 **Hint template:** `transient monitor — use get_or_create_monitor`
 

--- a/tests/test_watcher_fingerprint.py
+++ b/tests/test_watcher_fingerprint.py
@@ -1,0 +1,115 @@
+"""Watcher fingerprint normalization.
+
+The fingerprint must dedup the same finding across multiple git worktrees
+of the same repo, so a P001 in `/repo/.worktrees/A/src/x.py:47` and the
+identical-code P001 in `/repo/.worktrees/B/src/x.py:47` collapse to ONE
+surfaced finding instead of N copies that multiply with worktree count.
+
+The displayed ``file`` field stays absolute so the user can still navigate
+to the right copy; only the fingerprint hash uses repo-relative form.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agents.watcher.agent import Finding, hash_line_content, repo_relative_path
+
+
+def _make_finding(file_path: str, line: int, source_line: str) -> Finding:
+    f = Finding(
+        pattern="P001",
+        file=file_path,
+        line=line,
+        hint="fire-and-forget task",
+        severity="high",
+        detected_at="2026-04-17T00:00:00Z",
+        model_used="test-stub",
+    )
+    f.line_content_hash = hash_line_content(source_line)
+    f.fingerprint = f.compute_fingerprint()
+    return f
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        check=True,
+        capture_output=True,
+    )
+
+
+@pytest.fixture()
+def two_worktrees(tmp_path):
+    """Real git repo with one main checkout and one extra worktree, both
+    containing the same source line at the same path. We use a real repo
+    (not mocks) because repo_relative_path shells out to ``git rev-parse``."""
+    main = tmp_path / "repo"
+    main.mkdir()
+    _git(main, "init", "-q", "-b", "main")
+    _git(main, "config", "user.email", "t@t.t")
+    _git(main, "config", "user.name", "t")
+    src = main / "src"
+    src.mkdir()
+    file_main = src / "x.py"
+    file_main.write_text("asyncio.create_task(noop())\n")
+    _git(main, "add", "src/x.py")
+    _git(main, "commit", "-q", "-m", "seed")
+
+    wt = tmp_path / "wt-feature"
+    _git(main, "worktree", "add", "-q", "-b", "feature", str(wt))
+    file_wt = wt / "src" / "x.py"
+    assert file_wt.read_text() == file_main.read_text()
+    return file_main, file_wt
+
+
+def test_repo_relative_strips_worktree_prefix(two_worktrees):
+    main_file, wt_file = two_worktrees
+    assert repo_relative_path(str(main_file)) == "src/x.py"
+    assert repo_relative_path(str(wt_file)) == "src/x.py"
+
+
+def test_fingerprint_dedups_across_worktrees(two_worktrees):
+    main_file, wt_file = two_worktrees
+    line = "asyncio.create_task(noop())"
+    f_main = _make_finding(str(main_file), 1, line)
+    f_wt = _make_finding(str(wt_file), 1, line)
+    assert f_main.fingerprint == f_wt.fingerprint, (
+        "identical code at the same line in two worktrees must produce "
+        f"one fingerprint (got main={f_main.fingerprint!r}, wt={f_wt.fingerprint!r})"
+    )
+
+
+def test_fingerprint_differs_on_different_line_content(two_worktrees):
+    main_file, _ = two_worktrees
+    f_a = _make_finding(str(main_file), 1, "asyncio.create_task(noop())")
+    f_b = _make_finding(str(main_file), 1, "asyncio.create_task(other())")
+    assert f_a.fingerprint != f_b.fingerprint, (
+        "different code at the same line must NOT collide — content hash "
+        "is what protects against silent reuse of a stale resolution"
+    )
+
+
+def test_fingerprint_differs_across_files(two_worktrees):
+    main_file, _ = two_worktrees
+    other = main_file.parent / "y.py"
+    other.write_text("asyncio.create_task(noop())\n")
+    f_x = _make_finding(str(main_file), 1, "asyncio.create_task(noop())")
+    f_y = _make_finding(str(other), 1, "asyncio.create_task(noop())")
+    assert f_x.fingerprint != f_y.fingerprint
+
+
+def test_repo_relative_falls_back_when_not_in_git(tmp_path):
+    """Files outside any git repo keep their absolute path — graceful
+    fallback so the watcher does not crash on scratch files."""
+    loose = tmp_path / "scratch.py"
+    loose.write_text("x = 1\n")
+    assert repo_relative_path(str(loose)) == str(loose)
+
+
+def test_repo_relative_handles_empty_input():
+    assert repo_relative_path("") == ""

--- a/tests/test_watcher_fingerprint.py
+++ b/tests/test_watcher_fingerprint.py
@@ -1,12 +1,12 @@
-"""Watcher fingerprint normalization.
+"""Watcher fingerprint normalization + structural-verifier refinements.
 
-The fingerprint must dedup the same finding across multiple git worktrees
-of the same repo, so a P001 in `/repo/.worktrees/A/src/x.py:47` and the
-identical-code P001 in `/repo/.worktrees/B/src/x.py:47` collapse to ONE
-surfaced finding instead of N copies that multiply with worktree count.
+Cross-worktree dedup: the fingerprint must collapse identical code at
+the same line across N worktrees into ONE surfaced finding (not N).
 
-The displayed ``file`` field stays absolute so the user can still navigate
-to the right copy; only the fingerprint hash uses repo-relative form.
+P001 / P003 refinements: structural verifier drops false positives where
+the model matched a substring but the actual construct is the BLESSED
+solution to the very pattern (the project's tracked-task wrapper, or
+the cache function itself).
 """
 
 from __future__ import annotations
@@ -16,7 +16,13 @@ from pathlib import Path
 
 import pytest
 
-from agents.watcher.agent import Finding, hash_line_content, repo_relative_path
+from agents.watcher.agent import (
+    Finding,
+    _is_inside_get_or_create_monitor,
+    _verify_finding_against_source,
+    hash_line_content,
+    repo_relative_path,
+)
 
 
 def _make_finding(file_path: str, line: int, source_line: str) -> Finding:
@@ -113,3 +119,98 @@ def test_repo_relative_falls_back_when_not_in_git(tmp_path):
 
 def test_repo_relative_handles_empty_input():
     assert repo_relative_path("") == ""
+
+
+# ---------------------------------------------------------------------------
+# P001 / P003 structural verifier refinements
+# ---------------------------------------------------------------------------
+
+
+def _p001_finding(line: int) -> Finding:
+    return Finding(
+        pattern="P001",
+        file="/repo/src/x.py",
+        line=line,
+        hint="fire-and-forget task",
+        severity="high",
+        detected_at="2026-04-17T00:00:00Z",
+        model_used="test-stub",
+    )
+
+
+def _p003_finding(line: int) -> Finding:
+    return Finding(
+        pattern="P003",
+        file="/repo/src/agent_lifecycle.py",
+        line=line,
+        hint="transient monitor",
+        severity="high",
+        detected_at="2026-04-17T00:00:00Z",
+        model_used="test-stub",
+    )
+
+
+def test_p001_drops_create_tracked_task_call_site():
+    """`create_tracked_task(...)` is the blessed wrapper that stores the
+    task ref by construction. P001 must not flag call sites of it."""
+    src_line = '    create_tracked_task(my_coro(), name="bg")'
+    snippet = {1: src_line}
+    f = _p001_finding(1)
+    assert _verify_finding_against_source(f, src_line, snippet) is False
+
+
+def test_p001_still_flags_bare_create_task_call():
+    """Sanity guard: bare `asyncio.create_task(coro())` with no assignment
+    and no tracked-task wrapper still trips the pattern."""
+    src_line = "    asyncio.create_task(noop())"
+    snippet = {1: src_line}
+    f = _p001_finding(1)
+    assert _verify_finding_against_source(f, src_line, snippet) is True
+
+
+def test_p001_keeps_assigned_create_task_drop():
+    """Existing _P001_TASK_ASSIGNMENT drop still applies — assignment to
+    a name proves the ref is stored."""
+    src_line = "    task = asyncio.create_task(noop())"
+    snippet = {1: src_line}
+    f = _p001_finding(1)
+    assert _verify_finding_against_source(f, src_line, snippet) is False
+
+
+def test_p003_drops_when_inside_get_or_create_monitor_body():
+    """Flag landing inside the cache function's own body must not surface —
+    it IS the cache, not a transient instantiation outside the cache."""
+    snippet = {
+        20: "def get_or_create_monitor(agent_id):",
+        21: "    if agent_id in monitors:",
+        22: "        return monitors[agent_id]",
+        23: "    monitor = UNITARESMonitor(agent_id)",
+        24: "    monitors[agent_id] = monitor",
+        25: "    return monitor",
+    }
+    f = _p003_finding(23)
+    assert _is_inside_get_or_create_monitor(23, snippet) is True
+    assert _verify_finding_against_source(f, snippet[23], snippet) is False
+
+
+def test_p003_still_flags_when_inside_other_function():
+    """A transient-monitor instantiation in a different function body
+    should still surface — that's the real bug shape."""
+    snippet = {
+        50: "def some_other_handler(event):",
+        51: "    monitor = UNITARESMonitor(event.agent_id)",
+        52: "    monitor.update(...)",
+    }
+    f = _p003_finding(51)
+    assert _is_inside_get_or_create_monitor(51, snippet) is False
+    assert _verify_finding_against_source(f, snippet[51], snippet) is True
+
+
+def test_p003_async_def_get_or_create_monitor_also_protected():
+    """Defensive: if the cache function ever becomes async, the verifier
+    must still recognize its body as 'inside the cache'."""
+    snippet = {
+        10: "async def get_or_create_monitor(agent_id):",
+        11: "    monitor = UNITARESMonitor(agent_id)",
+    }
+    assert _is_inside_get_or_create_monitor(11, snippet) is True


### PR DESCRIPTION
## Summary

The Watcher fingerprint hashed the absolute file path, so identical code at the same line across N git worktrees produced N findings to surface and N fingerprints to \`--resolve\` individually. Working with multiple worktrees made the chime block balloon and made \`--resolve\` cross-worktree useless.

This change normalizes the path to its containing worktree root (via \`git rev-parse --show-toplevel\`) before hashing. The displayed \`file\` field stays absolute so navigation still works.

\`\`\`
before: pattern | /repo/.worktrees/A/src/x.py | line | content_hash
        pattern | /repo/.worktrees/B/src/x.py | line | content_hash  ← different

after:  pattern | src/x.py | line | content_hash                       ← same hash
\`\`\`

## Behavior notes

- **One-time bump:** existing \`data/watcher/dedup.json\` entries are keyed against absolute paths and won't match new hashes, so previously-resolved findings will surface once with new fingerprints. The existing \`--compact\` lifecycle ages out the orphaned entries.
- **Fallback:** files outside any git repo (or when \`git\` invocation fails) keep their absolute path, so scratch files still get unique fingerprints.
- **Per-directory toplevel cache** keeps the hook-driven scan path cheap (avoids 1 \`git\` subprocess per finding).

## Test plan

- [x] \`pytest tests/test_watcher_fingerprint.py\` — 6 passed, including a real two-worktree git fixture proving cross-worktree fingerprint equality
- [x] Full suite: 6131 passed, 33 skipped (excluded \`test_unitares_cli_script.py\` which needs PR #21's fixture; this branch was cut from master pre-#21)

## Related

- Discovered while triaging "watcher forking like cray cray" — the surface symptom was prod-server hammering (fixed in #21), the root cause for the multiplied findings was this fingerprint design.