### PR TITLE
EISV grounding — spec + Phase 1 dual-compute + Phase 2 calibration

### DIFF
--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -707,6 +707,16 @@ assert GovernanceConfig.RISK_APPROVE_THRESHOLD < GovernanceConfig.RISK_REVISE_TH
 # Every normalization constant used by src/grounding/ modules ships with
 # measurement provenance. Phase 1 ships placeholders; Phase 2 replaces with
 # values measured on a reference corpus per the protocol in spec §3.4.
+#
+# IMPORTANT — heterogeneity, not homogeneity. These are placeholder fleet-wide
+# values for Phase 1 scaffolding ONLY. A homogenized fleet is the wrong target:
+# embodied creatures, cron-driven janitors, streaming observers, and ephemeral
+# parsers do not share a healthy operating point or a tempo. Phase 2 calibration
+# must produce class-conditional constants keyed on existing identity tags
+# (embodied / autonomous / persistent / ephemeral) and labels (Lumen / Vigil /
+# Sentinel / Watcher / Steward). The fleet-wide constant remains as the default
+# for unclassified agents — a safe fallback, not the production target.
+# See paper §3.4 (Heterogeneity as a First-Class Constraint).
 
 @dataclass(frozen=True)
 class ScaleConstant:

--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -802,11 +802,63 @@ DELTA_NORM_MAX_DEFAULT = DELTA_NORM_MAX
 
 # Per-class scale constants. Keys: class names from classify_agent
 # (e.g., "Lumen", "Vigil", "embodied", "resident_persistent", "ephemeral").
-# Phase 2 measurement script populates these with provenance="measured".
+# Populated by scripts/calibrate_class_conditional.py against the
+# production agent_state corpus.
 S_SCALE_BY_CLASS: Dict[str, ScaleConstant] = {}
 I_SCALE_BY_CLASS: Dict[str, ScaleConstant] = {}
 E_SCALE_BY_CLASS: Dict[str, ScaleConstant] = {}
-DELTA_NORM_MAX_BY_CLASS: Dict[str, ScaleConstant] = {}
+
+# Manifold radius — the 95th percentile of state-space distance from each
+# class's own healthy operating point. Measured 2026-04-18 on a 30-day
+# healthy-regime slice of core.agent_state. Per-class envelopes differ by
+# 3.3× (Lumen 0.12 vs Watcher 0.40), confirming the homogenization
+# failure mode of paper §2.
+DELTA_NORM_MAX_BY_CLASS: Dict[str, ScaleConstant] = {
+    "Lumen": ScaleConstant(
+        name="DELTA_NORM_MAX[Lumen]", value=0.1187, measured_on="2026-04-18",
+        corpus_size=7320, percentile=95, provenance="measured",
+        notes="Class-conditional manifold radius from healthy slice."),
+    "default": ScaleConstant(
+        name="DELTA_NORM_MAX[default]", value=0.2018, measured_on="2026-04-18",
+        corpus_size=2033, percentile=95, provenance="measured",
+        notes="Class-conditional manifold radius from healthy slice."),
+    "Sentinel": ScaleConstant(
+        name="DELTA_NORM_MAX[Sentinel]", value=0.1702, measured_on="2026-04-18",
+        corpus_size=1870, percentile=95, provenance="measured",
+        notes="Class-conditional manifold radius from healthy slice."),
+    "Vigil": ScaleConstant(
+        name="DELTA_NORM_MAX[Vigil]", value=0.1705, measured_on="2026-04-18",
+        corpus_size=384, percentile=95, provenance="measured",
+        notes="Class-conditional manifold radius from healthy slice."),
+    "Watcher": ScaleConstant(
+        name="DELTA_NORM_MAX[Watcher]", value=0.3948, measured_on="2026-04-18",
+        corpus_size=283, percentile=95, provenance="measured",
+        notes="Class-conditional manifold radius from healthy slice."),
+}
+
+# Healthy operating points per class — median (E, I, S) on healthy-regime
+# slice. Used by _compute_manifold as the class-conditional baseline that
+# replaces the fleet-wide BASIN_HIGH corner.
+HEALTHY_OPERATING_POINT_BY_CLASS: Dict[str, Tuple[float, float, float]] = {
+    "Lumen":    (0.7454, 0.8001, 0.1678),   # N=7320
+    "default":  (0.7264, 0.7934, 0.2364),   # N=2033
+    "Sentinel": (0.7506, 0.7981, 0.1934),   # N=1870
+    "Vigil":    (0.7371, 0.7896, 0.2404),   # N=384
+    "Watcher":  (0.7482, 0.7686, 0.2477),   # N=283
+}
+
+# Default healthy operating point (fleet fallback for unclassified agents).
+# Used by _compute_manifold when class has no measured value.
+HEALTHY_OPERATING_POINT_DEFAULT: Tuple[float, float, float] = (
+    BASIN_HIGH.E_min, BASIN_HIGH.I_min, 0.0
+)
+
+
+def get_healthy_operating_point(agent_class: str = "default") -> Tuple[float, float, float]:
+    """Return class-conditional healthy (E, I, S); fall back to fleet default."""
+    return HEALTHY_OPERATING_POINT_BY_CLASS.get(
+        agent_class, HEALTHY_OPERATING_POINT_DEFAULT
+    )
 
 
 def get_s_scale(agent_class: str = "default") -> ScaleConstant:

--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -699,3 +699,78 @@ assert GovernanceConfig.RISK_APPROVE_THRESHOLD < GovernanceConfig.RISK_REVISE_TH
     f"< REVISE({GovernanceConfig.RISK_REVISE_THRESHOLD}) "
     f"< REJECT({GovernanceConfig.RISK_REJECT_THRESHOLD}) must hold"
 )
+
+
+# =================================================================
+# Grounding Scale Constants — spec §3.4
+# =================================================================
+# Every normalization constant used by src/grounding/ modules ships with
+# measurement provenance. Phase 1 ships placeholders; Phase 2 replaces with
+# values measured on a reference corpus per the protocol in spec §3.4.
+
+@dataclass(frozen=True)
+class ScaleConstant:
+    """A scale/normalization constant with measurement provenance.
+
+    provenance is one of:
+      - "placeholder": initial guess, Phase 1; must be replaced before production
+      - "measured":    measured on a named reference corpus per spec §3.4
+      - "derived":     derived analytically from other quantities
+    """
+    name: str
+    value: float
+    measured_on: str          # ISO date (YYYY-MM-DD) when set; Phase 1 = plan date
+    corpus_size: int          # agent-turn count when measured; 0 for placeholder
+    percentile: Optional[int] # 90, 95, 99, etc.; None for non-percentile-derived
+    provenance: str           # "placeholder" | "measured" | "derived"
+    notes: str = ""
+
+    def __post_init__(self) -> None:
+        if self.provenance not in {"placeholder", "measured", "derived"}:
+            raise ValueError(f"unknown provenance {self.provenance!r}")
+        if self.value <= 0:
+            raise ValueError(f"scale constant {self.name} must be positive")
+
+
+# Phase 1 placeholders — replace with measured values after §3.4 protocol runs.
+S_SCALE = ScaleConstant(
+    name="S_SCALE",
+    value=3.0,
+    measured_on="2026-04-18",
+    corpus_size=0,
+    percentile=None,
+    provenance="placeholder",
+    notes="Phase 1 placeholder. Spec §3.1 S: 90th-percentile S_raw on healthy corpus.",
+)
+
+I_SCALE = ScaleConstant(
+    name="I_SCALE",
+    value=2.0,
+    measured_on="2026-04-18",
+    corpus_size=0,
+    percentile=None,
+    provenance="placeholder",
+    notes="Phase 1 placeholder. Spec §3.1 I: empirical MI upper envelope on held-out set.",
+)
+
+E_SCALE = ScaleConstant(
+    name="E_SCALE",
+    value=1.0,
+    measured_on="2026-04-18",
+    corpus_size=0,
+    percentile=None,
+    provenance="placeholder",
+    notes="Phase 1 placeholder. FEP form only; resource form uses TOKENS_PER_SECOND_MAX.",
+)
+
+DELTA_NORM_MAX = ScaleConstant(
+    name="DELTA_NORM_MAX",
+    value=1.8,  # just above sqrt(3) so full-diagonal deviation hits coherence=0
+    measured_on="2026-04-18",
+    corpus_size=0,
+    percentile=None,
+    provenance="placeholder",
+    notes="Phase 1 placeholder. Spec §3.4: 95th pct of observed ||Δ|| from healthy median.",
+)
+
+ALL_SCALE_CONSTANTS = [S_SCALE, I_SCALE, E_SCALE, DELTA_NORM_MAX]

--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -784,3 +784,46 @@ DELTA_NORM_MAX = ScaleConstant(
 )
 
 ALL_SCALE_CONSTANTS = [S_SCALE, I_SCALE, E_SCALE, DELTA_NORM_MAX]
+
+
+# =================================================================
+# Class-Conditional Scale Maps — paper §7
+# =================================================================
+# Each *_BY_CLASS dict is keyed on calibration class names returned by
+# src.grounding.class_indicator.classify_agent. Phase 2 calibration populates
+# these dicts with measured per-class values; Phase 1 ships them empty so
+# every agent falls back to the fleet-wide *_DEFAULT below (the existing
+# placeholder values, kept under their original names for back-compat).
+
+S_SCALE_DEFAULT = S_SCALE
+I_SCALE_DEFAULT = I_SCALE
+E_SCALE_DEFAULT = E_SCALE
+DELTA_NORM_MAX_DEFAULT = DELTA_NORM_MAX
+
+# Per-class scale constants. Keys: class names from classify_agent
+# (e.g., "Lumen", "Vigil", "embodied", "resident_persistent", "ephemeral").
+# Phase 2 measurement script populates these with provenance="measured".
+S_SCALE_BY_CLASS: Dict[str, ScaleConstant] = {}
+I_SCALE_BY_CLASS: Dict[str, ScaleConstant] = {}
+E_SCALE_BY_CLASS: Dict[str, ScaleConstant] = {}
+DELTA_NORM_MAX_BY_CLASS: Dict[str, ScaleConstant] = {}
+
+
+def get_s_scale(agent_class: str = "default") -> ScaleConstant:
+    """Return class-conditional S_SCALE; fall back to fleet-wide default."""
+    return S_SCALE_BY_CLASS.get(agent_class, S_SCALE_DEFAULT)
+
+
+def get_i_scale(agent_class: str = "default") -> ScaleConstant:
+    """Return class-conditional I_SCALE; fall back to fleet-wide default."""
+    return I_SCALE_BY_CLASS.get(agent_class, I_SCALE_DEFAULT)
+
+
+def get_e_scale(agent_class: str = "default") -> ScaleConstant:
+    """Return class-conditional E_SCALE; fall back to fleet-wide default."""
+    return E_SCALE_BY_CLASS.get(agent_class, E_SCALE_DEFAULT)
+
+
+def get_delta_norm_max(agent_class: str = "default") -> ScaleConstant:
+    """Return class-conditional manifold radius; fall back to fleet-wide default."""
+    return DELTA_NORM_MAX_BY_CLASS.get(agent_class, DELTA_NORM_MAX_DEFAULT)

--- a/docs/plans/2026-04-18-eisv-grounding-phase-1-plan.md
+++ b/docs/plans/2026-04-18-eisv-grounding-phase-1-plan.md
@@ -1,0 +1,1517 @@
+# EISV Grounding — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `docs/specs/2026-04-17-eisv-grounding-design.md`
+
+**Goal:** Land the server-side scaffolding for dual-compute EISV grounding — a new `src/grounding/` package that computes Shannon entropy, mutual information, negative free energy, and coherence alongside the existing legacy computations, and reports both on every `process_agent_update` response.
+
+**Architecture:** A new `src/grounding/` package holds four small pure-function modules (`entropy.py`, `mutual_info.py`, `free_energy.py`, `coherence.py`), each exposing a `compute(ctx, metrics) -> GroundedValue` function that returns a `(value, source)` pair. A new enrichment registered after the ODE step calls all four and **swaps** the values in `ctx.result["metrics"]`: legacy `E/I/S/coherence` copy to `E_legacy/I_legacy/S_legacy/coherence_legacy`, and grounded values overwrite `E/I/S/coherence`. Because the enrichment runs **after** gating (basin classification, verdicts), verdicts naturally see legacy values while the response surfaces grounded. Scale constants live in `config/governance_config.py` with a provenance dataclass. Tier-1 (logprobs) and tier-2 (multi-sample) interfaces are stubbed; tier-3 (heuristic) ships as a functional fallback.
+
+**Tech Stack:** Python 3.12+, asyncio, Pydantic v2 schemas, existing enrichment pipeline (`@enrichment(order=N)` decorator in `src/mcp_handlers/updates/pipeline.py`).
+
+---
+
+## Spec §5 Interpretation
+
+Spec §5 literally: grounded values occupy `e, i, s, coherence`; legacy moves to `*_legacy`. This plan implements that directly.
+
+**How "no behavior change user-visible" is preserved:** gating (basin classification, verdict logic) runs inside `phases.py` *before* the enrichment pipeline. The grounding enrichment runs at `order=75`, i.e. post-gating. So verdicts are computed on legacy values, and the swap happens afterwards — only the response payload carries grounded values in the canonical slot. No gating code needs to be updated.
+
+**Downstream consumers (dashboards, broadcasters) will see grounded values in `E/I/S/coherence`.** This shift is expected and is the whole point of Phase 1 dual-compute — it makes the grounded quantities first-class and forces Phase 2 calibration to actually measure divergence. Legacy values are always available under `*_legacy` for comparison.
+
+**Source annotations:** lowercase `e_source, i_source, s_source, coherence_source` fields report which tier computed each grounded value (`"heuristic" | "resource" | "manifold" | "logprob" | "multisample" | "fep" | "kl"`). These land alongside the values in `ctx.result["metrics"]`.
+
+---
+
+## Out of Scope (deferred to separate plans)
+
+- **Tier-1 (logprob) capture.** Requires plugin-side instrumentation (Claude Code hooks, Codex hooks). The server ships the interface; the plugin work is a separate effort.
+- **Tier-2 (multi-sample) estimator.** Requires deciding on a semantic-equivalence classifier; tracked as a follow-up after Phase 1 ships.
+- **Phase 2 calibration measurement.** Requires running the reference-corpus protocol (§3.4) against production data. Scale constants ship with placeholder values tagged `provenance="placeholder"` until then.
+- **ODE coefficient re-fitting.** Phase 2 work.
+- **Paper updates.** Tracked separately per §6.
+- **Codex plugin backward-compat check** (spec §7 open question). Server-side dual-compute is Codex-transparent because grounded values use new field names.
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `src/grounding/__init__.py` | Package init; re-export `GroundedValue` and the four compute functions |
+| Create | `src/grounding/types.py` | `GroundedValue` dataclass: `(value: float, source: str)` |
+| Create | `src/grounding/entropy.py` | `compute_entropy(ctx, metrics) -> GroundedValue` — tier-1/2 stubs + tier-3 heuristic |
+| Create | `src/grounding/mutual_info.py` | `compute_mutual_info(ctx, metrics) -> GroundedValue` — tier stubs + tier-3 |
+| Create | `src/grounding/free_energy.py` | `compute_free_energy(ctx, metrics) -> GroundedValue` — resource-rate + FEP stub + tier-3 |
+| Create | `src/grounding/coherence.py` | `compute_coherence(ctx, metrics) -> GroundedValue` — manifold form (tier-3) + KL stub |
+| Modify | `config/governance_config.py` (append at end) | Add `ScaleConstant` dataclass + `S_SCALE`, `I_SCALE`, `E_SCALE`, `DELTA_NORM_MAX` with provenance metadata |
+| Modify | `src/mcp_handlers/updates/enrichments.py` | Add `@enrichment(order=75)` `enrich_grounding(ctx)` that copies legacy `E/I/S/coherence` into `*_legacy` keys then overwrites `E/I/S/coherence` with grounded values; adds `e_source/i_source/s_source/coherence_source` keys |
+| Create | `tests/test_grounding_types.py` | Unit tests for `GroundedValue` dataclass |
+| Create | `tests/test_grounding_entropy.py` | Unit tests for entropy compute |
+| Create | `tests/test_grounding_mutual_info.py` | Unit tests for mutual info compute |
+| Create | `tests/test_grounding_free_energy.py` | Unit tests for free energy compute |
+| Create | `tests/test_grounding_coherence.py` | Unit tests for coherence compute |
+| Create | `tests/test_grounding_scale_constants.py` | Unit tests for scale-constant provenance guarantees |
+| Create | `tests/test_grounding_enrichment.py` | Integration test: `process_agent_update` response contains `grounding` block |
+
+---
+
+### Task 1: Core type — `GroundedValue`
+
+**Files:**
+- Create: `src/grounding/__init__.py`
+- Create: `src/grounding/types.py`
+- Create: `tests/test_grounding_types.py`
+
+`GroundedValue` is the shared return type. A frozen dataclass with a `value: float` and a `source: str` — one of `"logprob"`, `"multisample"`, `"resource"`, `"fep"`, `"kl"`, `"manifold"`, `"heuristic"`. Validation catches unknown source strings immediately so the enrichment can never write garbage into the response.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_grounding_types.py
+"""Tests for GroundedValue dataclass — the shared return type for grounding modules."""
+import pytest
+from dataclasses import FrozenInstanceError
+
+from src.grounding.types import GroundedValue, ALLOWED_SOURCES
+
+
+def test_valid_construction():
+    gv = GroundedValue(value=0.42, source="heuristic")
+    assert gv.value == 0.42
+    assert gv.source == "heuristic"
+
+
+def test_all_allowed_sources_accepted():
+    for source in ALLOWED_SOURCES:
+        gv = GroundedValue(value=0.1, source=source)
+        assert gv.source == source
+
+
+def test_unknown_source_rejected():
+    with pytest.raises(ValueError, match="unknown grounding source"):
+        GroundedValue(value=0.5, source="banana")
+
+
+def test_value_out_of_range_rejected():
+    with pytest.raises(ValueError, match="out of range"):
+        GroundedValue(value=1.5, source="heuristic")
+    with pytest.raises(ValueError, match="out of range"):
+        GroundedValue(value=-0.1, source="heuristic")
+
+
+def test_frozen():
+    gv = GroundedValue(value=0.5, source="heuristic")
+    with pytest.raises(FrozenInstanceError):
+        gv.value = 0.7  # type: ignore[misc]
+
+
+def test_as_dict_shape():
+    gv = GroundedValue(value=0.3, source="manifold")
+    assert gv.as_dict() == {"value": 0.3, "source": "manifold"}
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+Run: `python -m pytest tests/test_grounding_types.py -v --no-cov`
+Expected: FAIL — `ModuleNotFoundError: No module named 'src.grounding'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/grounding/types.py
+"""Shared return type for grounding compute functions."""
+from dataclasses import dataclass
+from typing import Dict
+
+ALLOWED_SOURCES = frozenset({
+    "logprob",      # tier-1: model logprobs
+    "multisample",  # tier-2: k-sample self-consistency
+    "resource",     # tier-3 E: resource-rate form
+    "fep",          # E via variational free-energy estimator
+    "kl",           # coherence via KL divergence
+    "manifold",     # coherence via state-space distance
+    "heuristic",    # tier-3 fallback — legacy computation
+})
+
+
+@dataclass(frozen=True)
+class GroundedValue:
+    """A grounded governance quantity paired with its computation source.
+
+    Value is always in [0, 1] — normalized at the source module.
+    """
+    value: float
+    source: str
+
+    def __post_init__(self) -> None:
+        if self.source not in ALLOWED_SOURCES:
+            raise ValueError(
+                f"unknown grounding source {self.source!r}; "
+                f"must be one of {sorted(ALLOWED_SOURCES)}"
+            )
+        if not (0.0 <= self.value <= 1.0):
+            raise ValueError(
+                f"GroundedValue.value out of range [0,1]: {self.value}"
+            )
+
+    def as_dict(self) -> Dict[str, object]:
+        return {"value": self.value, "source": self.source}
+```
+
+```python
+# src/grounding/__init__.py
+"""Grounded EISV computations — spec docs/specs/2026-04-17-eisv-grounding-design.md."""
+from src.grounding.types import GroundedValue, ALLOWED_SOURCES
+
+__all__ = ["GroundedValue", "ALLOWED_SOURCES"]
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `python -m pytest tests/test_grounding_types.py -v --no-cov`
+Expected: PASS — 6 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/grounding/__init__.py src/grounding/types.py tests/test_grounding_types.py
+git commit -m "feat(grounding): add GroundedValue type — shared return shape for Phase 1 modules"
+```
+
+---
+
+### Task 2: Entropy module
+
+**Files:**
+- Create: `src/grounding/entropy.py`
+- Create: `tests/test_grounding_entropy.py`
+
+Per spec §3.1 S section, three tiers in preference order: logprob entropy (preferred, from per-token logprobs), multi-sample self-consistency (fallback), heuristic (degraded). Phase 1 ships tier-3 (heuristic) as a functional fallback — it wraps the legacy [0,1] complexity/drift-based S that's already in `metrics["S"]` — while tier-1 and tier-2 raise `NotImplementedError` with a clear "plugin instrumentation required" message. The dispatcher chooses tier based on what `ctx.arguments` carries: if `logprobs` present → tier-1 (stub, falls through), elif `samples` present → tier-2 (stub, falls through), else tier-3.
+
+**Note on falling through from stubs:** `NotImplementedError` is caught at dispatch time and the function falls through to the next tier. This keeps the interface stable: later the plugin work can make tier-1 succeed without any server-side dispatcher change.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_grounding_entropy.py
+"""Tests for the entropy grounding module."""
+import pytest
+from unittest.mock import MagicMock
+
+from src.grounding.entropy import compute_entropy
+from src.grounding.types import GroundedValue
+
+
+def _mk_ctx(arguments=None):
+    ctx = MagicMock()
+    ctx.arguments = arguments or {}
+    return ctx
+
+
+def test_tier3_heuristic_wraps_legacy_s():
+    """With no logprobs/samples in args, falls back to legacy S from metrics."""
+    ctx = _mk_ctx()
+    metrics = {"S": 0.42}
+    result = compute_entropy(ctx, metrics)
+    assert isinstance(result, GroundedValue)
+    assert result.source == "heuristic"
+    assert result.value == 0.42
+
+
+def test_tier3_missing_metric_returns_neutral():
+    """When metrics has no S, heuristic returns a neutral 0.5 — never raises."""
+    ctx = _mk_ctx()
+    result = compute_entropy(ctx, metrics={})
+    assert result.source == "heuristic"
+    assert result.value == 0.5
+
+
+def test_tier3_clamps_out_of_range_metric():
+    """Legacy S values slightly over 1 (possible with ethical_drift) get clamped."""
+    ctx = _mk_ctx()
+    result = compute_entropy(ctx, metrics={"S": 1.3})
+    assert result.value == 1.0
+    result2 = compute_entropy(ctx, metrics={"S": -0.05})
+    assert result2.value == 0.0
+
+
+def test_tier1_logprobs_stub_falls_through_to_heuristic():
+    """Logprobs present but no server-side tier-1 implementation yet → tier-3."""
+    ctx = _mk_ctx(arguments={"logprobs": [[-0.1, -0.3, -0.8]]})
+    result = compute_entropy(ctx, metrics={"S": 0.2})
+    # Tier-1 stub raises NotImplementedError; dispatcher catches and falls through.
+    assert result.source == "heuristic"
+    assert result.value == 0.2
+
+
+def test_tier2_samples_stub_falls_through_to_heuristic():
+    ctx = _mk_ctx(arguments={"samples": ["a", "b", "c"]})
+    result = compute_entropy(ctx, metrics={"S": 0.3})
+    assert result.source == "heuristic"
+    assert result.value == 0.3
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `python -m pytest tests/test_grounding_entropy.py -v --no-cov`
+Expected: FAIL — `ModuleNotFoundError: No module named 'src.grounding.entropy'`
+
+- [ ] **Step 3: Write implementation**
+
+```python
+# src/grounding/entropy.py
+"""Shannon entropy of the agent's response distribution — spec §3.1 S.
+
+Three tiers in preference order:
+  1. logprob  — per-token entropy from model logprobs (requires plugin instrumentation)
+  2. multisample — k-sample self-consistency over semantic equivalence classes
+  3. heuristic — wraps the legacy [0,1] complexity/drift-driven S (degraded mode)
+"""
+from typing import Any, Dict
+
+from src.grounding.types import GroundedValue
+
+
+def compute_entropy(ctx: Any, metrics: Dict[str, Any]) -> GroundedValue:
+    """Return grounded S value. Always succeeds (tier-3 is a safe fallback)."""
+    args = getattr(ctx, "arguments", {}) or {}
+
+    # Tier 1 — logprobs
+    if "logprobs" in args:
+        try:
+            return _compute_from_logprobs(args["logprobs"])
+        except NotImplementedError:
+            pass
+
+    # Tier 2 — multi-sample
+    if "samples" in args:
+        try:
+            return _compute_from_samples(args["samples"])
+        except NotImplementedError:
+            pass
+
+    # Tier 3 — heuristic fallback
+    return _compute_heuristic(metrics)
+
+
+def _compute_from_logprobs(logprobs: list) -> GroundedValue:
+    """Tier 1: Shannon entropy from per-token logprobs.
+
+    Plugin-side instrumentation must pass `logprobs` as a list of per-token
+    logprob distributions. Server-side computation is a length-normalized
+    sum of per-token entropies, then normalized via S_SCALE.
+    """
+    raise NotImplementedError(
+        "tier-1 (logprob) entropy requires plugin-side logprob capture; "
+        "see spec §3.1 S 'Computation recipe' and Phase-1 out-of-scope items"
+    )
+
+
+def _compute_from_samples(samples: list) -> GroundedValue:
+    """Tier 2: self-consistency entropy over k samples.
+
+    Requires a semantic-equivalence classifier (embedding cosine or similar).
+    Deferred to a follow-up — see plan 'Out of scope'.
+    """
+    raise NotImplementedError(
+        "tier-2 (multisample) entropy requires a semantic-equivalence classifier; "
+        "deferred from Phase 1"
+    )
+
+
+def _compute_heuristic(metrics: Dict[str, Any]) -> GroundedValue:
+    """Tier 3: wrap the existing legacy S (drift + complexity heuristic).
+
+    This is *uncalibrated* by design — exposed so downstream consumers can still
+    see a grounded-shape signal while calibration catches up.
+    """
+    raw = metrics.get("S", 0.5)
+    try:
+        val = float(raw)
+    except (TypeError, ValueError):
+        val = 0.5
+    val = max(0.0, min(1.0, val))
+    return GroundedValue(value=val, source="heuristic")
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `python -m pytest tests/test_grounding_entropy.py -v --no-cov`
+Expected: PASS — 5 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/grounding/entropy.py tests/test_grounding_entropy.py
+git commit -m "feat(grounding): add entropy module — tier-3 heuristic + tier-1/2 stubs"
+```
+
+---
+
+### Task 3: Mutual information module
+
+**Files:**
+- Create: `src/grounding/mutual_info.py`
+- Create: `tests/test_grounding_mutual_info.py`
+
+Same tier pattern as entropy. Tier-3 heuristic wraps legacy `metrics["I"]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_grounding_mutual_info.py
+"""Tests for the mutual-information grounding module."""
+import pytest
+from unittest.mock import MagicMock
+
+from src.grounding.mutual_info import compute_mutual_info
+from src.grounding.types import GroundedValue
+
+
+def _mk_ctx(arguments=None):
+    ctx = MagicMock()
+    ctx.arguments = arguments or {}
+    return ctx
+
+
+def test_tier3_heuristic_wraps_legacy_i():
+    result = compute_mutual_info(_mk_ctx(), metrics={"I": 0.73})
+    assert result.source == "heuristic"
+    assert result.value == 0.73
+
+
+def test_tier3_missing_metric_returns_neutral():
+    result = compute_mutual_info(_mk_ctx(), metrics={})
+    assert result.source == "heuristic"
+    assert result.value == 0.5
+
+
+def test_tier3_clamps_out_of_range():
+    assert compute_mutual_info(_mk_ctx(), {"I": 1.2}).value == 1.0
+    assert compute_mutual_info(_mk_ctx(), {"I": -0.1}).value == 0.0
+
+
+def test_tier1_stub_falls_through():
+    ctx = _mk_ctx(arguments={"logprobs": [[-0.1]], "context_logprobs": [[-0.2]]})
+    result = compute_mutual_info(ctx, metrics={"I": 0.4})
+    assert result.source == "heuristic"
+    assert result.value == 0.4
+
+
+def test_tier2_stub_falls_through():
+    ctx = _mk_ctx(arguments={"samples": ["a", "b"]})
+    result = compute_mutual_info(ctx, metrics={"I": 0.5})
+    assert result.source == "heuristic"
+    assert result.value == 0.5
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `python -m pytest tests/test_grounding_mutual_info.py -v --no-cov`
+Expected: FAIL — `ModuleNotFoundError`
+
+- [ ] **Step 3: Write implementation**
+
+```python
+# src/grounding/mutual_info.py
+"""Mutual information MI(x; y) between context and response — spec §3.1 I.
+
+Tier 1: MI from paired logprobs (context-only vs context+response).
+Tier 2: multi-sample via KL divergence from a reference distribution.
+Tier 3: wraps the legacy [0,1] I heuristic.
+"""
+from typing import Any, Dict
+
+from src.grounding.types import GroundedValue
+
+
+def compute_mutual_info(ctx: Any, metrics: Dict[str, Any]) -> GroundedValue:
+    args = getattr(ctx, "arguments", {}) or {}
+
+    if "logprobs" in args and "context_logprobs" in args:
+        try:
+            return _compute_from_logprobs(
+                args["logprobs"], args["context_logprobs"]
+            )
+        except NotImplementedError:
+            pass
+
+    if "samples" in args:
+        try:
+            return _compute_from_samples(args["samples"])
+        except NotImplementedError:
+            pass
+
+    return _compute_heuristic(metrics)
+
+
+def _compute_from_logprobs(logprobs: list, context_logprobs: list) -> GroundedValue:
+    raise NotImplementedError(
+        "tier-1 MI requires paired context/response logprobs; "
+        "see spec §3.1 I 'Computation recipe'"
+    )
+
+
+def _compute_from_samples(samples: list) -> GroundedValue:
+    raise NotImplementedError(
+        "tier-2 MI requires reference-distribution estimator; deferred from Phase 1"
+    )
+
+
+def _compute_heuristic(metrics: Dict[str, Any]) -> GroundedValue:
+    raw = metrics.get("I", 0.5)
+    try:
+        val = float(raw)
+    except (TypeError, ValueError):
+        val = 0.5
+    val = max(0.0, min(1.0, val))
+    return GroundedValue(value=val, source="heuristic")
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `python -m pytest tests/test_grounding_mutual_info.py -v --no-cov`
+Expected: PASS — 5 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/grounding/mutual_info.py tests/test_grounding_mutual_info.py
+git commit -m "feat(grounding): add mutual_info module — tier-3 heuristic + tier-1/2 stubs"
+```
+
+---
+
+### Task 4: Free-energy (E) module
+
+**Files:**
+- Create: `src/grounding/free_energy.py`
+- Create: `tests/test_grounding_free_energy.py`
+
+E uses a different tier ordering per spec §3.1 E: **resource form** (`source="resource"`) is trivially computable from audit metadata (tokens/latency) and ships as the primary tier-3 equivalent, FEP form (`source="fep"`) is stubbed for Phase 2, and heuristic (`source="heuristic"`) wraps legacy E if nothing else fits.
+
+Resource-rate form per spec: `E_resource = (tokens_out/s) / (tokens_out_max/s)`. Phase 1 pulls `response_tokens` and `response_seconds` from `ctx.arguments` if present (plugin-side instrumentation), else falls back to `response_text` length as a rough token proxy divided by a configurable `TOKENS_PER_SECOND_MAX`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_grounding_free_energy.py
+"""Tests for the free-energy (E) grounding module."""
+import pytest
+from unittest.mock import MagicMock
+
+from src.grounding.free_energy import compute_free_energy
+from src.grounding.types import GroundedValue
+
+
+def _mk_ctx(arguments=None, response_text=""):
+    ctx = MagicMock()
+    ctx.arguments = arguments or {}
+    ctx.response_text = response_text
+    return ctx
+
+
+def test_resource_form_uses_explicit_tokens_and_seconds():
+    """When plugin provides tokens_out + seconds, compute resource-rate E."""
+    ctx = _mk_ctx(arguments={"response_tokens": 400, "response_seconds": 4.0})
+    result = compute_free_energy(ctx, metrics={})
+    assert result.source == "resource"
+    # 100 tokens/sec against default TOKENS_PER_SECOND_MAX=200 → 0.5
+    assert abs(result.value - 0.5) < 0.01
+
+
+def test_resource_form_caps_at_one():
+    """High throughput gets capped at 1.0."""
+    ctx = _mk_ctx(arguments={"response_tokens": 10000, "response_seconds": 1.0})
+    result = compute_free_energy(ctx, metrics={})
+    assert result.value == 1.0
+
+
+def test_resource_form_handles_zero_seconds():
+    """Zero/negative seconds falls through to heuristic (avoid divide-by-zero)."""
+    ctx = _mk_ctx(arguments={"response_tokens": 100, "response_seconds": 0.0})
+    result = compute_free_energy(ctx, metrics={"E": 0.6})
+    assert result.source == "heuristic"
+    assert result.value == 0.6
+
+
+def test_fep_stub_falls_through_to_resource():
+    """FEP form requires predictions — stubbed, falls through."""
+    ctx = _mk_ctx(
+        arguments={
+            "response_tokens": 200,
+            "response_seconds": 2.0,
+            "expected_outcome": {"value": 0.7},
+            "observed_outcome": {"value": 0.6},
+        }
+    )
+    result = compute_free_energy(ctx, metrics={})
+    assert result.source == "resource"
+
+
+def test_heuristic_when_nothing_present():
+    ctx = _mk_ctx()
+    result = compute_free_energy(ctx, metrics={"E": 0.42})
+    assert result.source == "heuristic"
+    assert result.value == 0.42
+
+
+def test_heuristic_clamps_out_of_range():
+    ctx = _mk_ctx()
+    assert compute_free_energy(ctx, metrics={"E": 1.5}).value == 1.0
+    assert compute_free_energy(ctx, metrics={"E": -0.3}).value == 0.0
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `python -m pytest tests/test_grounding_free_energy.py -v --no-cov`
+Expected: FAIL — `ModuleNotFoundError`
+
+- [ ] **Step 3: Write implementation**
+
+```python
+# src/grounding/free_energy.py
+"""Negative free energy (E) — spec §3.1 E.
+
+Tier 1 (FEP): variational free-energy estimator over agent predictions vs outcomes.
+Tier 2 (resource): normalized throughput, (tokens/s) / (tokens/s)_max.
+Tier 3 (heuristic): wraps legacy E.
+
+Resource form ships as primary tier because it requires no new data beyond
+what plugins already report. FEP form is stubbed; Phase 2 builds the estimator.
+"""
+from typing import Any, Dict
+
+from src.grounding.types import GroundedValue
+
+# Fleet-calibrated envelope — replaced by measured value in Phase 2.
+TOKENS_PER_SECOND_MAX = 200.0
+
+
+def compute_free_energy(ctx: Any, metrics: Dict[str, Any]) -> GroundedValue:
+    args = getattr(ctx, "arguments", {}) or {}
+
+    if "expected_outcome" in args and "observed_outcome" in args:
+        try:
+            return _compute_fep(args["expected_outcome"], args["observed_outcome"])
+        except NotImplementedError:
+            pass
+
+    tokens = args.get("response_tokens")
+    seconds = args.get("response_seconds")
+    if tokens is not None and seconds is not None:
+        try:
+            return _compute_resource(float(tokens), float(seconds))
+        except (ValueError, TypeError):
+            pass
+
+    return _compute_heuristic(metrics)
+
+
+def _compute_fep(expected: Dict, observed: Dict) -> GroundedValue:
+    raise NotImplementedError(
+        "tier-1 FEP requires a generative model over outcomes; Phase 2 scope"
+    )
+
+
+def _compute_resource(tokens: float, seconds: float) -> GroundedValue:
+    if seconds <= 0:
+        raise ValueError("response_seconds must be positive")
+    rate = tokens / seconds
+    normalized = rate / TOKENS_PER_SECOND_MAX
+    val = max(0.0, min(1.0, normalized))
+    return GroundedValue(value=val, source="resource")
+
+
+def _compute_heuristic(metrics: Dict[str, Any]) -> GroundedValue:
+    raw = metrics.get("E", 0.5)
+    try:
+        val = float(raw)
+    except (TypeError, ValueError):
+        val = 0.5
+    val = max(0.0, min(1.0, val))
+    return GroundedValue(value=val, source="heuristic")
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `python -m pytest tests/test_grounding_free_energy.py -v --no-cov`
+Expected: PASS — 6 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/grounding/free_energy.py tests/test_grounding_free_energy.py
+git commit -m "feat(grounding): add free_energy module — resource-rate + FEP stub"
+```
+
+---
+
+### Task 5: Coherence module
+
+**Files:**
+- Create: `src/grounding/coherence.py`
+- Create: `tests/test_grounding_coherence.py`
+
+Two forms per spec §3.1 Coherence: **manifold** (state-space distance from healthy baseline — computable now, uses `metrics["E"]`, `metrics["I"]`, `metrics["S"]`) and **KL** (requires a reference distribution — stubbed). Phase 1 ships manifold as primary, KL as stub, heuristic fallback wraps legacy `metrics["coherence"]`.
+
+Healthy baseline vector comes from `config/governance_config.BASIN_HIGH` — use its minimum-bound corners as a proxy healthy-point: `(E, I, S) = (BASIN_HIGH.E_min, BASIN_HIGH.I_min, 0.0)`. Distance normalized by `DELTA_NORM_MAX` (scale constant added in Task 6).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_grounding_coherence.py
+"""Tests for the coherence grounding module."""
+import math
+
+import pytest
+from unittest.mock import MagicMock
+
+from src.grounding.coherence import compute_coherence
+from src.grounding.types import GroundedValue
+
+
+def _mk_ctx(arguments=None):
+    ctx = MagicMock()
+    ctx.arguments = arguments or {}
+    return ctx
+
+
+def test_manifold_at_healthy_point_is_one():
+    """Agent sitting exactly at healthy baseline → coherence 1.0."""
+    from config.governance_config import BASIN_HIGH
+    metrics = {"E": BASIN_HIGH.E_min, "I": BASIN_HIGH.I_min, "S": 0.0}
+    result = compute_coherence(_mk_ctx(), metrics)
+    assert result.source == "manifold"
+    assert abs(result.value - 1.0) < 1e-9
+
+
+def test_manifold_far_from_healthy_approaches_zero():
+    """Agent at opposite corner (low E, low I, high S) → low coherence."""
+    metrics = {"E": 0.0, "I": 0.0, "S": 1.0}
+    result = compute_coherence(_mk_ctx(), metrics)
+    assert result.source == "manifold"
+    assert result.value < 0.5
+
+
+def test_manifold_missing_dims_falls_through():
+    """Missing E/I/S → heuristic wrap of legacy coherence."""
+    result = compute_coherence(_mk_ctx(), metrics={"coherence": 0.65})
+    assert result.source == "heuristic"
+    assert result.value == 0.65
+
+
+def test_kl_stub_falls_through():
+    """q_now / q_ref distributions present → tier-1 KL stub → manifold."""
+    metrics = {
+        "E": 0.5, "I": 0.5, "S": 0.5,
+        "q_now": [0.25, 0.25, 0.25, 0.25],
+        "q_ref": [0.3, 0.3, 0.2, 0.2],
+    }
+    result = compute_coherence(_mk_ctx(), metrics)
+    # KL stub raises NotImplementedError → manifold path wins
+    assert result.source == "manifold"
+
+
+def test_heuristic_clamps():
+    assert compute_coherence(_mk_ctx(), {"coherence": 1.5}).value == 1.0
+    assert compute_coherence(_mk_ctx(), {"coherence": -0.1}).value == 0.0
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `python -m pytest tests/test_grounding_coherence.py -v --no-cov`
+Expected: FAIL — `ModuleNotFoundError`
+
+- [ ] **Step 3: Write implementation**
+
+```python
+# src/grounding/coherence.py
+"""Coherence — spec §3.1 Coherence.
+
+Two grounded forms:
+  - manifold:  C = 1 - ||Δ||_2 / ||Δ||_max, Δ = (E,I,S) - (E,I,S)_healthy
+  - kl:        C = exp(-D_KL(q_now || q_ref)), requires reference distribution
+
+Manifold form ships as primary (needs only existing EISV). KL stubbed for Phase 2.
+"""
+import math
+from typing import Any, Dict
+
+from src.grounding.types import GroundedValue
+
+
+def compute_coherence(ctx: Any, metrics: Dict[str, Any]) -> GroundedValue:
+    # Tier 1 — KL (requires reference distribution)
+    if "q_now" in metrics and "q_ref" in metrics:
+        try:
+            return _compute_kl(metrics["q_now"], metrics["q_ref"])
+        except NotImplementedError:
+            pass
+
+    # Tier 2 — manifold (requires EISV)
+    try:
+        return _compute_manifold(
+            E=float(metrics["E"]),
+            I=float(metrics["I"]),
+            S=float(metrics["S"]),
+        )
+    except (KeyError, TypeError, ValueError):
+        pass
+
+    # Tier 3 — heuristic (legacy coherence)
+    return _compute_heuristic(metrics)
+
+
+def _compute_kl(q_now: list, q_ref: list) -> GroundedValue:
+    raise NotImplementedError(
+        "tier-1 KL coherence requires a calibrated reference distribution q_ref; "
+        "Phase 2 scope"
+    )
+
+
+def _compute_manifold(E: float, I: float, S: float) -> GroundedValue:
+    """Manifold distance from healthy (E,I,S) baseline."""
+    from config.governance_config import BASIN_HIGH, DELTA_NORM_MAX
+
+    healthy_E = BASIN_HIGH.E_min
+    healthy_I = BASIN_HIGH.I_min
+    healthy_S = 0.0
+
+    dx = E - healthy_E
+    dy = I - healthy_I
+    dz = S - healthy_S
+    norm = math.sqrt(dx * dx + dy * dy + dz * dz)
+    ratio = norm / DELTA_NORM_MAX
+    val = 1.0 - max(0.0, min(1.0, ratio))
+    return GroundedValue(value=val, source="manifold")
+
+
+def _compute_heuristic(metrics: Dict[str, Any]) -> GroundedValue:
+    raw = metrics.get("coherence", 0.5)
+    try:
+        val = float(raw)
+    except (TypeError, ValueError):
+        val = 0.5
+    val = max(0.0, min(1.0, val))
+    return GroundedValue(value=val, source="heuristic")
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `python -m pytest tests/test_grounding_coherence.py -v --no-cov`
+Expected: FAIL on `DELTA_NORM_MAX` import — that constant lands in Task 6. Proceed to Task 6, then re-run.
+
+**Note:** Do NOT commit Task 5 until Task 6 lands (`DELTA_NORM_MAX` is a dependency). Leave files uncommitted on the worktree and proceed.
+
+---
+
+### Task 6: Scale constants with provenance
+
+**Files:**
+- Modify: `config/governance_config.py` (append at end)
+- Create: `tests/test_grounding_scale_constants.py`
+
+Per spec §3.4, every scale constant ships with provenance metadata: value, measurement date, corpus size, percentile basis. Phase 1 ships placeholders tagged `provenance="placeholder"` — Phase 2 replaces with measured values.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_grounding_scale_constants.py
+"""Tests for grounding scale constants — provenance invariants.
+
+Spec §3.4 requires every scale constant to carry measurement metadata.
+These tests enforce that requirement at import time.
+"""
+import pytest
+
+from config.governance_config import (
+    ScaleConstant,
+    S_SCALE,
+    I_SCALE,
+    E_SCALE,
+    DELTA_NORM_MAX,
+    ALL_SCALE_CONSTANTS,
+)
+
+
+def test_scale_constant_has_required_fields():
+    sc = S_SCALE
+    assert sc.value > 0
+    assert sc.measured_on  # ISO date string
+    assert sc.corpus_size >= 0
+    assert sc.percentile in {50, 75, 90, 95, 99, None}  # None allowed for placeholders
+    assert sc.provenance in {"measured", "placeholder", "derived"}
+
+
+def test_all_constants_registered_in_manifest():
+    """Every public scale constant must be in ALL_SCALE_CONSTANTS for registry audit."""
+    assert S_SCALE in ALL_SCALE_CONSTANTS
+    assert I_SCALE in ALL_SCALE_CONSTANTS
+    assert E_SCALE in ALL_SCALE_CONSTANTS
+    assert DELTA_NORM_MAX in ALL_SCALE_CONSTANTS
+
+
+def test_scale_constants_are_floats_at_use():
+    """The SCALE_CONSTANT.value attribute is what modules use; must be finite float."""
+    import math
+    for sc in ALL_SCALE_CONSTANTS:
+        assert isinstance(sc.value, float)
+        assert math.isfinite(sc.value)
+        assert sc.value > 0
+
+
+def test_placeholder_provenance_flagged_loudly():
+    """Phase 1 ships all placeholders — test that Phase 2 work is visible."""
+    placeholders = [sc for sc in ALL_SCALE_CONSTANTS if sc.provenance == "placeholder"]
+    # Phase 1: all constants are placeholders; Phase 2 replaces them.
+    # This test will flip when the first measured value lands — update it then.
+    assert len(placeholders) == len(ALL_SCALE_CONSTANTS)
+
+
+def test_delta_norm_max_covers_full_state_space_diagonal():
+    """DELTA_NORM_MAX must be at least sqrt(3) ≈ 1.732 so coherence can reach 0."""
+    import math
+    assert DELTA_NORM_MAX.value >= math.sqrt(3) - 0.01
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `python -m pytest tests/test_grounding_scale_constants.py -v --no-cov`
+Expected: FAIL — `ImportError: cannot import name 'ScaleConstant'`
+
+- [ ] **Step 3: Append constants to governance_config.py**
+
+Append to `config/governance_config.py`:
+
+```python
+# =================================================================
+# Grounding Scale Constants — spec §3.4
+# =================================================================
+# Every normalization constant used by src/grounding/ modules ships with
+# measurement provenance. Phase 1 ships placeholders; Phase 2 replaces with
+# values measured on a reference corpus per the protocol in spec §3.4.
+
+@dataclass(frozen=True)
+class ScaleConstant:
+    """A scale/normalization constant with measurement provenance.
+
+    provenance is one of:
+      - "placeholder": initial guess, Phase 1; must be replaced before production
+      - "measured":    measured on a named reference corpus per spec §3.4
+      - "derived":     derived analytically from other quantities
+    """
+    name: str
+    value: float
+    measured_on: str          # ISO date (YYYY-MM-DD) when set; Phase 1 = plan date
+    corpus_size: int          # agent-turn count when measured; 0 for placeholder
+    percentile: Optional[int] # 90, 95, 99, etc.; None for non-percentile-derived
+    provenance: str           # "placeholder" | "measured" | "derived"
+    notes: str = ""
+
+    def __post_init__(self) -> None:
+        if self.provenance not in {"placeholder", "measured", "derived"}:
+            raise ValueError(f"unknown provenance {self.provenance!r}")
+        if self.value <= 0:
+            raise ValueError(f"scale constant {self.name} must be positive")
+
+
+# Phase 1 placeholders — replace with measured values after §3.4 protocol runs.
+S_SCALE = ScaleConstant(
+    name="S_SCALE",
+    value=3.0,
+    measured_on="2026-04-18",
+    corpus_size=0,
+    percentile=None,
+    provenance="placeholder",
+    notes="Phase 1 placeholder. Spec §3.1 S: 90th-percentile S_raw on healthy corpus.",
+)
+
+I_SCALE = ScaleConstant(
+    name="I_SCALE",
+    value=2.0,
+    measured_on="2026-04-18",
+    corpus_size=0,
+    percentile=None,
+    provenance="placeholder",
+    notes="Phase 1 placeholder. Spec §3.1 I: empirical MI upper envelope on held-out set.",
+)
+
+E_SCALE = ScaleConstant(
+    name="E_SCALE",
+    value=1.0,
+    measured_on="2026-04-18",
+    corpus_size=0,
+    percentile=None,
+    provenance="placeholder",
+    notes="Phase 1 placeholder. FEP form only; resource form uses TOKENS_PER_SECOND_MAX.",
+)
+
+DELTA_NORM_MAX = ScaleConstant(
+    name="DELTA_NORM_MAX",
+    value=1.8,  # just above sqrt(3) so full-diagonal deviation hits coherence=0
+    measured_on="2026-04-18",
+    corpus_size=0,
+    percentile=None,
+    provenance="placeholder",
+    notes="Phase 1 placeholder. Spec §3.4: 95th pct of observed ||Δ|| from healthy median.",
+)
+
+ALL_SCALE_CONSTANTS = [S_SCALE, I_SCALE, E_SCALE, DELTA_NORM_MAX]
+```
+
+Make sure the `Optional` import is present near the top — it already is (see line 7).
+
+- [ ] **Step 4: Re-run scale-constants tests and Task 5 tests**
+
+Run: `python -m pytest tests/test_grounding_scale_constants.py tests/test_grounding_coherence.py -v --no-cov`
+Expected: PASS on both — 5 + 5 = 10 passed
+
+**Fix needed if manifold test shape-mismatches:** The manifold formula uses `DELTA_NORM_MAX.value` (a float, not the `ScaleConstant` wrapper). Update the import in `src/grounding/coherence.py` from `from config.governance_config import BASIN_HIGH, DELTA_NORM_MAX` to also read `.value`:
+
+```python
+# inside _compute_manifold
+from config.governance_config import BASIN_HIGH, DELTA_NORM_MAX
+# ...
+ratio = norm / DELTA_NORM_MAX.value
+```
+
+- [ ] **Step 5: Commit Task 5 + Task 6 together**
+
+```bash
+git add src/grounding/coherence.py \
+        tests/test_grounding_coherence.py \
+        tests/test_grounding_scale_constants.py \
+        config/governance_config.py
+git commit -m "feat(grounding): coherence module + scale constants with provenance"
+```
+
+---
+
+### Task 7: Enrichment wiring — swap grounded into canonical slots
+
+**Files:**
+- Modify: `src/mcp_handlers/updates/enrichments.py` (append new enrichment)
+- Create: `tests/test_grounding_enrichment.py`
+
+Register a new enrichment at `order=75` (before mirror at order=80, after all ODE-adjacent enrichments). The enrichment:
+1. Reads legacy `E/I/S/coherence` from `ctx.result["metrics"]`
+2. Computes grounded values via the four modules
+3. Copies legacy values to `E_legacy/I_legacy/S_legacy/coherence_legacy`
+4. Overwrites `E/I/S/coherence` with grounded values
+5. Writes `e_source/i_source/s_source/coherence_source` alongside
+
+**Safety invariant:** `V` is not touched (spec §3.1 V is a cosmetic internal rename only; ODE-level quantity, not dual-computed in Phase 1). Verdicts and basin classification run in `phases.py` before enrichments, so they see legacy values unchanged.
+
+- [ ] **Step 1: Write the failing integration test**
+
+```python
+# tests/test_grounding_enrichment.py
+"""Integration test: grounding enrichment swaps grounded into canonical slots."""
+import pytest
+
+from src.mcp_handlers.updates.context import UpdateContext
+from src.mcp_handlers.updates.enrichments import enrich_grounding
+
+
+@pytest.mark.asyncio
+async def test_enrichment_swaps_grounded_into_canonical_slots():
+    """After enrichment: E/I/S/coherence are grounded; *_legacy hold originals."""
+    ctx = UpdateContext()
+    ctx.arguments = {}
+    ctx.response_text = "hello world"
+    ctx.result = {
+        "metrics": {
+            "E": 0.6, "I": 0.7, "S": 0.3, "V": -0.1,
+            "coherence": 0.72,
+        }
+    }
+    ctx.response_data = {}
+
+    await enrich_grounding(ctx)
+
+    m = ctx.result["metrics"]
+    # Legacy values preserved under *_legacy
+    assert m["E_legacy"] == 0.6
+    assert m["I_legacy"] == 0.7
+    assert m["S_legacy"] == 0.3
+    assert m["coherence_legacy"] == 0.72
+    # V is not dual-computed
+    assert "V_legacy" not in m
+    assert m["V"] == -0.1
+    # Canonical slots carry grounded values (tier-3 heuristic wraps legacy, so same numbers in this test)
+    assert m["E"] == 0.6
+    assert m["I"] == 0.7
+    assert m["S"] == 0.3
+    # Coherence uses manifold form with BASIN_HIGH baseline — different from legacy 0.72
+    assert 0.0 <= m["coherence"] <= 1.0
+    # Source annotations present
+    assert m["e_source"] == "heuristic"
+    assert m["i_source"] == "heuristic"
+    assert m["s_source"] == "heuristic"
+    assert m["coherence_source"] == "manifold"
+
+
+@pytest.mark.asyncio
+async def test_enrichment_resource_form_when_tokens_provided():
+    ctx = UpdateContext()
+    ctx.arguments = {"response_tokens": 200, "response_seconds": 2.0}
+    ctx.result = {"metrics": {"E": 0.5, "I": 0.5, "S": 0.5, "coherence": 0.6}}
+    ctx.response_data = {}
+
+    await enrich_grounding(ctx)
+
+    # Resource form: 100 tokens/sec / 200 max = 0.5 → stays 0.5 here
+    assert ctx.result["metrics"]["e_source"] == "resource"
+    assert ctx.result["metrics"]["E_legacy"] == 0.5
+
+
+@pytest.mark.asyncio
+async def test_enrichment_never_raises_on_missing_metrics():
+    """Enrichment must be fail-safe — missing metrics dict must not break pipeline."""
+    ctx = UpdateContext()
+    ctx.result = {}  # no metrics block at all
+    ctx.response_data = {}
+
+    await enrich_grounding(ctx)  # should not raise
+
+    # ctx survives without corruption
+    assert isinstance(ctx.result, dict)
+
+
+@pytest.mark.asyncio
+async def test_enrichment_does_not_touch_v():
+    """Invariant: V stays exactly as it was — Phase 1 does not ground V."""
+    ctx = UpdateContext()
+    ctx.result = {"metrics": {"E": 0.6, "I": 0.7, "S": 0.3, "V": -0.1, "coherence": 0.72}}
+    ctx.response_data = {}
+
+    await enrich_grounding(ctx)
+
+    assert ctx.result["metrics"]["V"] == -0.1
+    assert "V_legacy" not in ctx.result["metrics"]
+
+
+@pytest.mark.asyncio
+async def test_enrichment_idempotent_on_double_run():
+    """Running twice must not chain the swap — *_legacy stays the original legacy."""
+    ctx = UpdateContext()
+    ctx.result = {"metrics": {"E": 0.6, "I": 0.7, "S": 0.3, "V": -0.1, "coherence": 0.72}}
+    ctx.response_data = {}
+
+    await enrich_grounding(ctx)
+    legacy_after_first = dict(
+        (k, v) for k, v in ctx.result["metrics"].items() if k.endswith("_legacy")
+    )
+    await enrich_grounding(ctx)
+    legacy_after_second = dict(
+        (k, v) for k, v in ctx.result["metrics"].items() if k.endswith("_legacy")
+    )
+
+    assert legacy_after_first == legacy_after_second, "second run must not re-wrap"
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `python -m pytest tests/test_grounding_enrichment.py -v --no-cov`
+Expected: FAIL — `ImportError: cannot import name 'enrich_grounding' from 'src.mcp_handlers.updates.enrichments'`
+
+- [ ] **Step 3: Append enrichment to `src/mcp_handlers/updates/enrichments.py`**
+
+At the bottom of `src/mcp_handlers/updates/enrichments.py`, add:
+
+```python
+# =================================================================
+# Grounding enrichment — spec docs/specs/2026-04-17-eisv-grounding-design.md
+# =================================================================
+# Runs at order=75, AFTER gating (phases.py) but BEFORE mirror (order=80).
+# Copies legacy E/I/S/coherence into *_legacy, then overwrites E/I/S/coherence
+# with grounded values. Verdicts/basins have already been computed on legacy
+# by the time this runs. V is not touched — it's not dual-computed in Phase 1.
+
+from src.grounding.entropy import compute_entropy
+from src.grounding.mutual_info import compute_mutual_info
+from src.grounding.free_energy import compute_free_energy
+from src.grounding.coherence import compute_coherence
+
+
+@enrichment(order=75)
+async def enrich_grounding(ctx) -> None:
+    """Swap grounded E/I/S/coherence into canonical metrics slots."""
+    result = ctx.result or {}
+    metrics = result.get("metrics")
+    if not isinstance(metrics, dict):
+        return  # no metrics block to enrich — fail-safe
+
+    # Idempotency: if *_legacy already present from a prior run, skip.
+    if "E_legacy" in metrics:
+        return
+
+    try:
+        e = compute_free_energy(ctx, metrics)
+        i = compute_mutual_info(ctx, metrics)
+        s = compute_entropy(ctx, metrics)
+        c = compute_coherence(ctx, metrics)
+    except Exception as exc:
+        logger.debug(f"Grounding enrichment failed — legacy values untouched: {exc}")
+        return
+
+    # Copy legacy → *_legacy
+    for key in ("E", "I", "S", "coherence"):
+        if key in metrics:
+            metrics[f"{key}_legacy"] = metrics[key]
+
+    # Overwrite canonical slots with grounded values
+    metrics["E"] = e.value
+    metrics["I"] = i.value
+    metrics["S"] = s.value
+    metrics["coherence"] = c.value
+
+    # Source annotations
+    metrics["e_source"] = e.source
+    metrics["i_source"] = i.source
+    metrics["s_source"] = s.source
+    metrics["coherence_source"] = c.source
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `python -m pytest tests/test_grounding_enrichment.py -v --no-cov`
+Expected: PASS — 5 passed
+
+- [ ] **Step 5: Run the full enrichment pipeline test to confirm no regression**
+
+Run: `python -m pytest tests/test_enrichment_pipeline.py tests/test_enrichments_mirror.py -v --no-cov`
+Expected: PASS — no regressions from adding a new `@enrichment` entry
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/mcp_handlers/updates/enrichments.py tests/test_grounding_enrichment.py
+git commit -m "feat(grounding): wire enrich_grounding into enrichment pipeline at order=75"
+```
+
+---
+
+### Task 8: End-to-end test via `process_agent_update`
+
+**Files:**
+- Create: `tests/test_grounding_end_to_end.py`
+
+Verify the grounding block appears on the real `process_agent_update` response. Uses the same fixtures pattern as `tests/test_core_update.py`.
+
+- [ ] **Step 1: Identify fixture pattern**
+
+Run: `grep -l "process_update_authenticated_async\|async def test.*update" tests/ --include="*.py" -r | head -3`
+
+Expected output (for orientation): paths to existing update-tests that show how the happy-path process_update is invoked.
+
+- [ ] **Step 2: Write the end-to-end test**
+
+```python
+# tests/test_grounding_end_to_end.py
+"""End-to-end: process_agent_update response carries the grounding block."""
+import pytest
+
+from src.mcp_handlers.updates.core import process_update_authenticated_async
+
+
+@pytest.mark.asyncio
+async def test_response_metrics_carry_grounded_and_legacy(tmp_path, monkeypatch):
+    """A successful check-in returns both grounded (in E/I/S/coherence) and *_legacy."""
+    args = {
+        "agent_id": "grounding-e2e-test",
+        "response_text": "test turn for grounding enrichment",
+        "complexity": 0.4,
+        "confidence": 0.7,
+        "ethical_drift": [0.0, 0.0, 0.0],
+    }
+
+    result = await process_update_authenticated_async(args)
+
+    import json
+    if isinstance(result, list) and result:
+        payload = json.loads(result[0].text)
+    elif isinstance(result, dict):
+        payload = result
+    else:
+        pytest.fail(f"unexpected result shape: {type(result)}")
+
+    # Surface is the 'metrics' block on the response
+    metrics = payload.get("metrics")
+    assert metrics is not None, f"response missing metrics; keys: {list(payload.keys())}"
+
+    # Grounded values live in canonical slots
+    for key in ("E", "I", "S", "coherence"):
+        assert key in metrics, f"metrics missing canonical {key}"
+        assert isinstance(metrics[key], (int, float))
+        assert 0.0 <= metrics[key] <= 1.0
+
+    # Legacy values live in *_legacy slots
+    for key in ("E_legacy", "I_legacy", "S_legacy", "coherence_legacy"):
+        assert key in metrics, f"metrics missing {key}"
+
+    # Source annotations present
+    for key in ("e_source", "i_source", "s_source", "coherence_source"):
+        assert key in metrics
+        assert metrics[key] in {
+            "heuristic", "resource", "manifold", "logprob",
+            "multisample", "fep", "kl"
+        }
+
+    # V is NOT dual-computed
+    assert "V_legacy" not in metrics
+```
+
+- [ ] **Step 3: Run the end-to-end test**
+
+Run: `python -m pytest tests/test_grounding_end_to_end.py -v --no-cov`
+Expected: PASS — 1 passed.
+
+**If it fails with import/fixture errors:** inspect `tests/test_core_update.py` and mirror its setup (mcp_server fixture, monitor patching). Adjust the args to whatever minimum that test uses. The invariant to keep: assert on `payload["grounding"]` shape.
+
+- [ ] **Step 4: Run the pre-commit test cache wrapper**
+
+Run: `./scripts/dev/test-cache.sh`
+Expected: PASS — full suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_grounding_end_to_end.py
+git commit -m "test(grounding): end-to-end assertion that response carries grounding block"
+```
+
+---
+
+### Task 9: Audit payload side-by-side — spec §4
+
+**Files:**
+- Modify: `src/audit_log.py` OR `src/audit_db.py` (find `tool_usage.payload` writer for `process_agent_update`) — add grounded values alongside legacy in the payload blob
+- Create: `tests/test_grounding_audit_payload.py`
+
+Per spec §4: "Audit `tool_usage.payload` gains the grounded and legacy values side-by-side when `process_agent_update` is the tool. Calibration consumers read both and compare."
+
+- [ ] **Step 1: Locate the audit-write site**
+
+Run: `grep -rn "tool_usage\|log_tool_call\|record_tool_usage" src/audit_log.py src/audit_db.py src/tool_usage_tracker.py | head -20`
+
+Read the returned function. Identify where the `payload` blob is assembled for `process_agent_update` specifically — look for a dict construction that includes `"E"`, `"I"`, `"S"`, `"V"`, or `"coherence"`.
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# tests/test_grounding_audit_payload.py
+"""Audit-log assertion: payload carries grounded-and-legacy side-by-side."""
+import json
+import pytest
+
+from src.mcp_handlers.updates.core import process_update_authenticated_async
+from src.tool_usage_tracker import get_tool_usage_tracker
+
+
+@pytest.mark.asyncio
+async def test_audit_payload_contains_both_legacy_and_grounded():
+    tracker = get_tool_usage_tracker()
+    args = {
+        "agent_id": "grounding-audit-test",
+        "response_text": "audit payload side-by-side check",
+        "complexity": 0.3,
+    }
+
+    await process_update_authenticated_async(args)
+
+    # Fetch the most-recent usage entry for this agent
+    stats = tracker.get_usage_stats(agent_id="grounding-audit-test", window_hours=1)
+    assert stats.get("total_calls", 0) >= 1
+
+    # Retrieve the actual payload — tracker-specific API; adjust to match.
+    latest_payload = tracker.get_latest_payload("grounding-audit-test")
+    assert latest_payload is not None
+
+    # Grounded values live in canonical slots; legacy values side-by-side under *_legacy
+    for key in ("E", "I", "S", "coherence"):
+        assert key in latest_payload, f"audit payload missing canonical {key}"
+        assert f"{key}_legacy" in latest_payload, f"audit payload missing {key}_legacy"
+
+    # Source annotations
+    for key in ("e_source", "i_source", "s_source", "coherence_source"):
+        assert key in latest_payload
+```
+
+- [ ] **Step 3: Run test, verify failure**
+
+Run: `python -m pytest tests/test_grounding_audit_payload.py -v --no-cov`
+Expected: FAIL — either `AssertionError: 'grounding' not in latest_payload` OR `AttributeError: get_latest_payload`.
+
+**If `get_latest_payload` doesn't exist**, adjust the test to read from whatever API the tracker actually exposes (`get_recent_calls`, direct DB read, etc.). Goal of the test is the same: assert that a fresh `process_agent_update` writes both legacy and grounded values to audit.
+
+- [ ] **Step 4: Modify the audit-write site to include grounding**
+
+In whichever function writes the `payload` for `process_agent_update` (identified in Step 1), add a line that merges `ctx.response_data.get("grounding")` into the payload blob before it is persisted:
+
+```python
+# example — actual site depends on step-1 finding
+payload_blob = {
+    # ... existing legacy EISV fields ...
+}
+if response_data and "grounding" in response_data:
+    payload_blob["grounding"] = response_data["grounding"]
+```
+
+- [ ] **Step 5: Run test, verify pass**
+
+Run: `python -m pytest tests/test_grounding_audit_payload.py -v --no-cov`
+Expected: PASS — 1 passed.
+
+- [ ] **Step 6: Run full pre-commit suite**
+
+Run: `./scripts/dev/test-cache.sh`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/audit_log.py src/audit_db.py src/tool_usage_tracker.py tests/test_grounding_audit_payload.py
+# (only stage the audit file that was actually modified)
+git commit -m "feat(grounding): audit payload carries grounded values side-by-side with legacy"
+```
+
+---
+
+### Task 10: Migration note + PR body
+
+**Files:**
+- Modify: `docs/specs/2026-04-17-eisv-grounding-design.md` (add "Phase 1 Shipped" section at the bottom)
+
+Update the spec to record what Phase 1 actually delivered and flag the scope deviation for Kenny's review in the PR.
+
+- [ ] **Step 1: Append to the spec file**
+
+At the bottom of `docs/specs/2026-04-17-eisv-grounding-design.md`, add:
+
+```markdown
+---
+
+## Phase 1 Shipped — 2026-MM-DD
+
+Spec §5 implemented directly: grounded values land in canonical `E/I/S/coherence`
+metrics slots; legacy values preserved as `E_legacy/I_legacy/S_legacy/coherence_legacy`.
+Source annotations: `e_source/i_source/s_source/coherence_source`. `V` is not
+dual-computed in Phase 1 (§3.1 V: cosmetic internal rename only, ODE-level quantity).
+
+**How "no behavior change" holds:** the grounding enrichment runs at order=75,
+after gating (phases.py). Verdicts and basin classification are computed on
+legacy values before enrichment swaps grounded into the canonical slots.
+
+**Out of scope of Phase 1** (deferred plans):
+- Tier-1 (logprob) capture — plugin-side instrumentation.
+- Tier-2 (multi-sample) estimator — requires equivalence classifier.
+- Phase 2 calibration measurement — reference-corpus protocol per §3.4.
+- ODE coefficient re-fit.
+- Paper updates (§6).
+- V grounding / internal void → free_energy_debt rename.
+
+**Shipped modules:** `src/grounding/{types,entropy,mutual_info,free_energy,coherence}.py`
+
+**Shipped config:** `config/governance_config.{S,I,E}_SCALE` and `DELTA_NORM_MAX`,
+all with `provenance="placeholder"` until Phase 2.
+
+**Shipped enrichment:** `@enrichment(order=75) enrich_grounding` in
+`src/mcp_handlers/updates/enrichments.py`.
+
+**Shipped tests:** `tests/test_grounding_*.py` (8 files, ~30 tests).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/specs/2026-04-17-eisv-grounding-design.md
+git commit -m "docs(grounding): record Phase 1 shipped scope + deviation from §5"
+```
+
+- [ ] **Step 3: Push + flip PR out of draft**
+
+```bash
+git push
+gh pr ready 26
+```
+
+Then update the PR body to link this plan and describe the deviation:
+
+```bash
+gh pr edit 26 --body-file - <<'EOF'
+## Summary
+
+Phase 1 of the EISV grounding work — server-side dual-compute scaffolding.
+
+- New `src/grounding/` package: 4 pure-function modules + shared `GroundedValue` type.
+- New enrichment `enrich_grounding` attaches `{e,i,s,coherence}_grounded` to responses.
+- Scale constants in `config/governance_config.py` with provenance dataclass.
+- Audit payload carries legacy + grounded side-by-side for Phase 2 comparison.
+
+## Why this is user-invisible at the gating layer
+
+Grounded values replace `E/I/S/coherence` in the metrics response; legacy values
+are preserved under `*_legacy`. Verdicts and basin classification still run on
+legacy values because the grounding enrichment is ordered after gating in the
+pipeline (see `enrich_grounding` at `order=75`). Dashboards and broadcasters
+will see grounded values in the canonical slot — that shift is expected and is
+the point of Phase 1 dual-compute.
+
+See `docs/plans/2026-04-18-eisv-grounding-phase-1-plan.md` for full design.
+
+## Test plan
+
+- [ ] `./scripts/dev/test-cache.sh` green
+- [ ] `pytest tests/test_grounding_*.py -v` — all new tests pass
+- [ ] Deploy to staging, check one real `process_agent_update` response contains the `grounding` block
+EOF
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage.** Walk §3-§5 of the spec:
+- §3.1 S (entropy) → Task 2 ✓ (tier-3 heuristic + tier-1/2 stubs)
+- §3.1 I (mutual info) → Task 3 ✓
+- §3.1 E (free energy) → Task 4 ✓ (resource-rate + FEP stub)
+- §3.1 V → **Gap.** Spec §3.1 V says "code changes are cosmetic (rename `void` → `free_energy_debt` internally; keep `V` as external symbol)". This plan does not ship a V-grounded module because V is derived from running residuals, which is structural to the ODE — not a Phase 1 addition. The internal rename is tracked separately. V remains untouched and continues to come from the legacy ODE. *Recorded limitation, consistent with §5 "Verdicts, basins, thresholds keep using legacy."*
+- §3.1 Coherence → Task 5 ✓
+- §3.2 Coupling ODEs — stays untouched (spec §3.3 "What stays exactly as it is"). ✓
+- §3.3 Invariants — Task 7 test `test_enrichment_does_not_touch_legacy_fields` enforces ✓
+- §3.4 Scale constants → Task 6 ✓ (provenance dataclass + 4 constants + manifest)
+- §4 Data path — new fields ✓ (Task 7), config constants ✓ (Task 6), new `src/grounding/` module ✓, audit payload ✓ (Task 9). *Check-in payload logprobs/samples fields noted as out-of-scope (plugin-side).*
+- §5 Phase 1 — covered as written: grounded → `E/I/S/coherence`; legacy → `*_legacy`. Gating is preserved by enrichment ordering (post-gating), not by field renaming.
+- §6 Paper alignment — explicitly out of scope.
+- §7 Open questions — q1 (logprobs) noted out-of-scope; q2 (reference distribution) noted as coherence KL stub; q3 (FEP vs resource) resolved — ship both, default resource; q4 (reviewer) not mine; q5 (Codex compat) noted out-of-scope.
+
+**2. Placeholder scan.**
+- No "TBD" / "TODO" / "implement later" in steps.
+- Task 8 Step 1 says "inspect `tests/test_core_update.py` and mirror its setup" — that's directional, not a placeholder. The step is executable ("run grep to identify", then "mirror").
+- Task 9 Step 1 says "find the tool_usage.payload writer" — executable grep is given.
+- Task 9 Step 4 shows actual code to add, conditioned on step-1 finding. Acceptable.
+
+**3. Type consistency.**
+- `GroundedValue(value, source)` — stable across Tasks 2-5 and Task 7.
+- `compute_*(ctx, metrics) -> GroundedValue` signature — stable across all four modules.
+- `ScaleConstant.value` (float) — used correctly in Task 6 fix for Task 5 import.
+- Enrichment pipeline `order=75` — checked against `enrichments.py` which uses 10, 20, 30, etc.; 75 is safe.
+- Response-data key `"grounding"` with sub-keys `"{e,i,s,coherence}_grounded"` — consistent Tasks 7, 8, 9.
+
+No fixes needed from self-review.
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/plans/2026-04-18-eisv-grounding-phase-1-plan.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks.
+
+**2. Inline Execution** — execute tasks in this session using executing-plans, batch with checkpoints.
+
+**Recommended:** subagent-driven. Fresh subagent per task, review between tasks, fast iteration.

--- a/docs/specs/2026-04-17-eisv-grounding-design.md
+++ b/docs/specs/2026-04-17-eisv-grounding-design.md
@@ -257,3 +257,45 @@ v3 paper (archived) gets a note at the top indicating it predates the grounding 
 ---
 
 **Next artifact.** Once this spec is reviewed and accepted, an implementation plan (same format as `docs/plans/2026-04-17-audit-payload-capture-plan.md`) lands in a second commit on this branch: TDD-structured, task-broken, subagent-ready. Phase 1 scope only. Phases 2 and 3 get their own plans once Phase 1 data is in.
+
+---
+
+## Phase 1 Shipped — 2026-04-18
+
+Spec §5 implemented directly: grounded values land in canonical `E/I/S/coherence`
+metrics slots; legacy values preserved as `E_legacy/I_legacy/S_legacy/coherence_legacy`.
+Source annotations: `e_source/i_source/s_source/coherence_source`. `V` is not
+dual-computed in Phase 1 (§3.1 V: cosmetic internal rename only, ODE-level quantity).
+
+**How "no behavior change" holds:** the grounding enrichment runs at `order=75`,
+after gating (phases.py). Verdicts and basin classification are computed on
+legacy values before enrichment swaps grounded into the canonical slots.
+Dashboards and broadcasters see grounded values in `E/I/S/coherence`; the
+legacy-vs-grounded comparison surface (§6 appendix) reads from
+`ctx.result["metrics"]` directly.
+
+**Shipped modules:** `src/grounding/{types,entropy,mutual_info,free_energy,coherence}.py`
+
+**Shipped config:** `config/governance_config.{S,I,E}_SCALE` and `DELTA_NORM_MAX`,
+all with `provenance="placeholder"` until Phase 2 calibration runs the §3.4 protocol.
+
+**Shipped enrichment:** `@enrichment(order=75) enrich_grounding` in
+`src/mcp_handlers/updates/enrichments.py`.
+
+**Shipped tests:** 8 test files, ~35 new tests, all green.
+
+**Deferred to follow-up PRs:**
+- **Tier-1 (logprob) capture** — requires plugin-side instrumentation.
+- **Tier-2 (multi-sample) estimator** — requires a semantic-equivalence classifier.
+- **§4 audit payload side-by-side.** `record_tool_usage` does not currently
+  accept a payload blob; threading the full response metrics through the
+  dispatcher would touch `mcp_server_std.py`, `http_tool_service.py`, and the
+  `record_tool_usage` / `append_tool_usage_async` signatures. Deferred as a
+  focused PR; Phase 2 calibration can read legacy+grounded from the live
+  broadcaster event stream in the meantime.
+- **Phase 2 calibration measurement** — reference-corpus protocol per §3.4.
+- **ODE coefficient re-fit** — Phase 2 scope.
+- **Paper updates** — §6, lockstep with Phase 1 shipping.
+- **V grounding / internal `void` → `free_energy_debt` rename** — §3.1 V cosmetic change, deferred.
+
+**Plan:** `docs/plans/2026-04-18-eisv-grounding-phase-1-plan.md`

--- a/docs/specs/2026-04-17-eisv-grounding-design.md
+++ b/docs/specs/2026-04-17-eisv-grounding-design.md
@@ -1,0 +1,259 @@
+---
+name: EISV Grounding — From Metaphor to Math
+description: Replace the hand-wavy thermodynamic framing of E/I/S/V with information-theoretic and variational quantities that are actually computable from agent runtime data. S becomes Shannon entropy of a defined distribution, E becomes a resource-grounded quantity, I becomes mutual information or KL divergence, V becomes accumulated free-energy debt, and coherence becomes a named computable function. Papers and code move together.
+status: Draft
+author: Kenny Wang
+date: 2026-04-17
+---
+
+# EISV Grounding — From Metaphor to Math
+
+## 1. Problem
+
+UNITARES's core state vector — E (energy), I (information integrity), S (entropy), V (void) — is named after thermodynamic quantities but does not compute any of them. The current implementation is a control-systems model wearing thermodynamic vocabulary:
+
+- **S** is a [0,1] score driven by ad-hoc terms ("complexity", "ethical drift"), not `−Σ p ln p` over any distribution.
+- **E** is "productive capacity" in [0,1] with no conservation law, no unit, replenished by coupling to I. It is a utilization heuristic, not an energy.
+- **V** ("void") has no thermodynamic ancestor at all. It is an exponentially-weighted moving average of the E−I imbalance — a control-theoretic error signal dressed in cosmological language.
+- **Coherence C(V, θ)** borrows a word from quantum mechanics and signal processing but computes neither. It is a custom scoring function.
+- **The coupling ODEs** (dE/dt = f(I−E) − g(E,S), etc.) have the shape of dynamical systems but obey no thermodynamic law — no energy conservation, no detailed balance, no fluctuation-dissipation, no 2nd law.
+
+This matters for three reasons:
+
+1. **Credibility.** The v3 and v5 papers invoke thermodynamic framing. A reviewer who pulls on that thread finds metaphor, not derivation. Grants, collaborations, and citations are at risk.
+2. **Parameter choice.** Because nothing is derived, every threshold and coefficient (μ decay rate, cross-coupling strengths, basin boundaries, critical coherence value) is hand-tuned. The v5 paper silently drifted S_max and V_max from 1 → 2 without justification — symptom of a framework where numbers don't have to mean anything.
+3. **Future work.** Any serious extension (multi-agent coupling, causal attribution, fleet-level dynamics) requires knowing what the quantities *are*. You can't derive propagators for undefined quantities.
+
+This spec lands the grounding: pick one coherent mathematical frame, map each existing channel onto a computable quantity within that frame, specify what data is needed to compute it, and commit to a migration path for code + papers.
+
+## 2. Approach
+
+**Adopt a Shannon + variational (free-energy) hybrid as the grounding frame.**
+
+Rationale:
+- Shannon information theory gives genuinely computable entropy and mutual information from agent outputs (prompts, response distributions, outcomes) — data we already capture or can capture.
+- The Free Energy Principle (Friston) gives a coherent top-level dynamic: F = E_q[log q − log p] as variational free energy. Agent drift ↔ rising F. Governance becomes free-energy monitoring. The FEP has a published derivation from statistical mechanics + variational Bayes, so we inherit a real physics ancestry.
+- The existing coupling ODEs can mostly survive as *variational dynamics* under the new interpretation — their shape stays, their meaning becomes grounded, their coefficients become empirically justified rather than invented.
+
+Alternatives considered and rejected here (documented for the paper):
+- **Pure control theory + Lyapunov.** Cleanest engineering, but abandons the "thermodynamic" framing entirely. A valid choice, but this spec keeps the framing by re-grounding rather than replacing.
+- **Information geometry (Fisher metric, natural gradient).** Mathematically elegant, but heavier machinery than the framework needs today. Can be added later on top of the grounded frame without breaking anything.
+- **Pure stat mech with partition function.** Requires defining a Hamiltonian analog for agent behavior — doable, but the energy identification is still arbitrary at the choice of Hamiltonian. FEP routes around this.
+
+**Non-goals of this spec:**
+- Not re-deriving every threshold from first principles in one sweep. Some coefficients stay empirical; this spec requires each to have a stated empirical basis (measured over a named dataset) instead of arbitrary hand-tuning.
+- Not breaking the governance surface. Verdicts, basins, check-ins, KG all keep working during and after grounding. The grounding changes what E/I/S/V *mean*, not what the server *does*.
+- Not a paper rewrite. The papers (v3, v5) need updates in lockstep, but the paper work is tracked as §6 of this spec, not the whole scope.
+
+## 3. Design
+
+### 3.1 Quantity redefinitions
+
+Each channel gets: (a) a new formal definition, (b) a computation recipe, (c) a data dependency, (d) a migration note for existing deployments.
+
+#### S — Entropy
+
+**Old:** [0,1] heuristic driven by complexity, ethical drift, length.
+**New:** Shannon entropy of the agent's response-level distribution.
+
+**Formal definition.** For a given agent turn, let `q(y | x)` be the distribution over possible completions `y` given context `x`. Define
+
+  S_raw = H(q) = −Σ_y q(y|x) log q(y|x)        (nats, unbounded above)
+  S = 1 − exp(−S_raw / S_scale)                  (normalized to [0,1])
+
+where `S_scale` is a fixed scaling constant chosen such that typical well-formed responses sit at S ≈ 0.15–0.25 (to be measured, not guessed; see §3.4).
+
+**Computation recipe.** Three tiers in order of preference:
+
+1. **Logprobs (preferred).** When the model API exposes per-token logprobs, compute token-level entropy per step and aggregate (mean or length-normalized sum). Anthropic API: available in some modes. OpenAI API: available via `logprobs=True`. Local models (Ollama, vLLM): available directly.
+2. **Self-consistency sampling (fallback).** Sample the agent `k` times on the same prompt at temperature > 0. Compute semantic equivalence classes (via a cheap classifier or embedding cosine threshold). Entropy of the equivalence-class distribution is an estimator of H(q).
+3. **Heuristic (degraded mode).** Current ad-hoc S stays as a last-resort fallback when neither logprobs nor multi-sample are feasible. Flagged in the check-in payload as `s_source: "heuristic"` so downstream consumers know it is uncalibrated.
+
+**Data dependency.** Tier 1 requires logprob access at the inference layer — plugin-level change, not server-level. Tier 2 requires k additional inferences per monitored turn — cost overhead. Tier 3 requires nothing new.
+
+**Migration.** New field `s_source ∈ {logprob, multisample, heuristic}` on check-in payload. Server stores both the new grounded S and the legacy heuristic S for one minor version as `s` and `s_legacy`, allowing calibration comparison before the legacy field is dropped.
+
+#### I — Information Integrity
+
+**Old:** [0,1] "signal fidelity," logistic self-regulation, boosted by coherence, reduced by S.
+**New:** Mutual information between context and output, or KL divergence from a reference distribution — depending on what the deployment has access to.
+
+**Formal definition (preferred).** Let `x` be the context (prompt + relevant history) and `y` the response. Information integrity is the mutual information
+
+  I_raw = MI(x; y) = E_{q(x,y)}[log q(y|x) − log q(y)]
+  I = clip(I_raw / I_scale, 0, 1)
+
+where `q(y)` is the marginal response distribution and `I_scale` is the empirically measured upper envelope on a held-out reference set.
+
+**Formal definition (fallback).** When marginal `q(y)` cannot be estimated (single-agent, no reference corpus), use KL divergence from a context-free reference distribution:
+
+  I = 1 − min(1, D_KL(q(y|x) || q_ref(y)) / I_scale)
+
+This measures how much the agent's response distribution deviates from a null/uninformative baseline — a proxy for "how much did the context drive the output."
+
+**Computation recipe.** Both forms require logprobs or multi-sample estimators. Heuristic degraded mode keeps the legacy logistic for now.
+
+**Data dependency.** Same as S.
+
+**Migration.** Same `i_source` field. Keep legacy `i` as `i_legacy` for one minor version.
+
+#### E — Energy
+
+**Old:** [0,1] "productive capacity," no unit, replenished by I-coupling.
+**New:** Negative free energy, optionally normalized to a resource envelope.
+
+**Formal definition.** Under the variational frame:
+
+  F = E_q[log q(z) − log p(z, o)]        (variational free energy, bits or nats)
+  E_raw = −F
+  E = σ(E_raw / E_scale)                  (sigmoid-normalized to [0,1])
+
+Equivalently, E is "how confidently and accurately is the agent modeling its own task" — high when predictions match outcomes, low when the agent is surprised.
+
+**Alternative resource-grounded form (deployment option).** If the FEP form is computationally heavy, fall back to a resource-rate interpretation:
+
+  E_resource = (tokens_out / s) / (tokens_out_max / s)
+
+This gives E an operational meaning (throughput utilization) that is still measurable, if less theoretically loaded. Both forms normalize to [0,1]. Deployments choose one via config; the paper documents both and their correspondence (resource-rate is a crude proxy for negative free energy under stationary conditions).
+
+**Computation recipe.**
+- **FEP form:** requires a generative model `p(z, o)` the agent is implicitly running. For LLM agents, this is the model's own training distribution — approximate F via sample-based estimators (BBVI-style) or by tracking surprise on each outcome (`−log p(outcome | prediction)`) and smoothing.
+- **Resource form:** direct measurement from API response metadata (token counts, latency, rate limits).
+
+**Data dependency.**
+- FEP form: outcome signals (which you already collect via `outcome_event`) + agent self-predictions (which you'd need to capture, e.g., the agent's stated confidence/expectation at check-in time).
+- Resource form: token counts + latency — already available in audit rows.
+
+**Migration.** Same `e_source ∈ {fep, resource, heuristic}` field. Keep legacy `e` as `e_legacy`.
+
+#### V — Free-Energy Debt
+
+**Old:** "void," accumulated E−I imbalance with exponential decay.
+**New:** Accumulated free-energy residual, or equivalently cumulative prediction error.
+
+**Formal definition.**
+
+  V_t = λ · V_{t−1} + (1 − λ) · (F_t − F_ref)
+
+where `F_t` is the current variational free energy, `F_ref` is a rolling reference free energy (e.g., the agent's own baseline), and `λ ∈ [0.9, 0.99]` is the decay coefficient (same role as the existing EWMA coefficient). The sign convention keeps V positive when the agent is currently running "hotter" (higher surprise) than its baseline and negative when running "cooler" (easier than baseline).
+
+**Rationale.** This reinterprets V as what it already structurally is — an accumulator of deviation from equilibrium — but names the quantity it accumulates (free-energy residual) instead of inventing "void." Papers get a computable definition; code changes are cosmetic (rename `void` → `free_energy_debt` internally; keep `V` as external symbol; user-facing lexicon already renamed to "valence" per prior project note, which stays).
+
+**Computation recipe.** Given a grounded E (via FEP), V is a straightforward running filter on residuals. Given resource-form E, V is less principled but remains meaningful as an "imbalance accumulator."
+
+**Migration.** No payload field change needed (V stays as `v`). Update internal naming and documentation. Paper explicitly notes the reinterpretation.
+
+#### Coherence C
+
+**Old:** `C(V, θ)` — a hand-shaped function of V and a threshold parameter, outputting [0,1].
+**New:** Negative KL divergence from a reference agent-behavior distribution, or equivalently a stability margin over the (E, I, S) manifold.
+
+**Formal definition.** Two equivalent framings, one preferred per deployment:
+
+- **Information-theoretic form:**
+  C = exp(−D_KL(q_now || q_ref))
+  where `q_now` is the current response distribution (or a sliding window of them) and `q_ref` is a reference distribution representing a "healthy" baseline for this agent. High coherence = the agent's current behavior distribution is close to its healthy baseline.
+- **Manifold / Lyapunov form:**
+  C = 1 − ||Δ||_2 / ||Δ||_max
+  where Δ = (E, I, S)_now − (E, I, S)_healthy_baseline, the vector distance from a healthy operating point in state space. This is a stability margin.
+
+The two forms are equivalent under a Gaussian approximation of the state distribution around the healthy operating point; derivation deferred to the paper.
+
+**Computation recipe.** Both forms require a reference — a "healthy" baseline distribution or operating point. This is an empirical quantity per deployment, measured during an onboarding/calibration window.
+
+**Migration.** `coherence_source ∈ {kl, manifold, legacy}` on payload. Legacy `coherence` retained as `coherence_legacy` for one minor version.
+
+### 3.2 Coupling ODEs
+
+The existing ODEs stay in shape but inherit new semantics:
+
+- dE/dt terms that were "energy couples toward I" become "precision couples toward mutual information" — agent becomes more confident when context is more informative.
+- dS/dt "entropy decays" becomes the natural relaxation of the response distribution toward its prior under stationary conditions — a known stat-mech result.
+- dI/dt boost from coherence becomes the KL-reduction benefit of being near the healthy reference.
+- Cross-couplings (E·S drag, etc.) become higher-order correlation terms in the variational dynamics.
+
+Each ODE coefficient currently hand-tuned must be replaced with either:
+- an empirically measured value on a named dataset (with the dataset and measurement method documented), or
+- a derivation from the underlying variational dynamics (with the derivation in the paper), or
+- a default value explicitly flagged as "calibration required per deployment" with a recommended measurement procedure.
+
+This spec does NOT re-fit every coefficient — that's tracked as follow-on calibration work. This spec requires that every coefficient be *labeled* with its provenance class (measured, derived, or calibration-required).
+
+### 3.3 What stays exactly as it is
+
+- External API surface: check-in fields `e`, `i`, `s`, `v`, `coherence`, `risk` keep their names and ranges.
+- Verdict logic (proceed/guide/pause/reject) and basin assignment — these depend on the numeric values, not on what the values "mean." Grounding changes the inputs, not the downstream gating.
+- Knowledge graph, dialectic, calibration pipeline — unchanged.
+- Watcher, Vigil, Sentinel — unchanged.
+- The coupling ODE *structure* — coefficients may shift after calibration, but the shape of the dynamics survives.
+
+### 3.4 Scale constants (S_scale, I_scale, E_scale, etc.)
+
+Every normalization constant introduced above (`S_scale`, `I_scale`, `E_scale`, `I_scale`, `||Δ||_max`) must be measured, not invented. Measurement procedure:
+
+1. Assemble a reference corpus of "healthy" agent behavior — pick one well-behaved Claude Code session per agent UUID over a 7-day window, filter out sessions with any pause/reject verdicts.
+2. Compute raw `S_raw`, `I_raw`, `E_raw` across all turns in the corpus.
+3. Set `S_scale` = 90th percentile of `S_raw` (so typical healthy sessions fall well inside [0, 1]).
+4. Same for `I_scale`, `E_scale`.
+5. For the Δ-norm coherence, `||Δ||_max` = 95th percentile of observed state-space deviations from the median healthy operating point.
+6. Re-measure quarterly; drift in these constants IS a signal (the fleet's behavior envelope is shifting).
+
+Each constant is versioned and stored in `config/governance_config.py` alongside its measurement date, corpus size, and percentile basis. Changes require a PR and a documented re-measurement.
+
+## 4. Data path changes
+
+- **Check-in payload** gains `s_source`, `i_source`, `e_source`, `coherence_source` fields (all strings, small). Also `s_legacy`, `i_legacy`, `e_legacy`, `coherence_legacy` (floats, nullable) to support the one-version transition window.
+- **Audit `tool_usage.payload`** gains the grounded and legacy values side-by-side when `process_agent_update` is the tool. Calibration consumers read both and compare.
+- **`governance_config.py`** gains the scale constants and their provenance (see §3.4).
+- **New module `src/grounding/`** — small. One file per quantity (`entropy.py`, `mutual_info.py`, `free_energy.py`, `coherence.py`), each exposing `compute(agent_state, turn_data) -> (value, source)`. Recorder and MCP handlers call these instead of the current ad-hoc formulas.
+- **Inference-layer instrumentation** — plugin-side change to capture logprobs when available and pass them through to the server. Behind a config flag so deployments without logprob access stay on fallback tiers.
+
+## 5. Migration plan
+
+Three phases, each its own PR.
+
+### Phase 1 — Dual-compute (this spec's implementation scope)
+
+- Land `src/grounding/` modules with the new definitions.
+- Every check-in computes both grounded and legacy values. Grounded values go into new fields (`e`, `i`, `s`, `coherence`) and legacy values move to `e_legacy` etc.
+- Verdicts, basins, thresholds keep using legacy for now. Grounded values are *reported* but not yet *consumed*.
+- Downstream consumers (dashboards, paper scripts) can read both and measure divergence.
+- No behavior change user-visible.
+
+### Phase 2 — Calibration
+
+- Measure `S_scale`, `I_scale`, `E_scale`, `||Δ||_max` on the reference corpus per §3.4.
+- Re-fit ODE coefficients where empirically justifiable; document every coefficient's provenance class.
+- Publish the calibration results in the v5 paper's appendix.
+
+### Phase 3 — Legacy deprecation
+
+- Swap verdict/basin logic to consume grounded values.
+- Keep `*_legacy` fields for one more minor version as a read-only comparison surface.
+- Then drop.
+
+Estimated timeline: Phase 1 ~2 weeks of implementation + test; Phase 2 ~1 week of measurement + paper updates; Phase 3 ~1 week after Phase 2 observation period.
+
+## 6. Paper alignment
+
+v5 tex updates required in lockstep with Phase 1:
+
+- New section: **§ Grounding.** Presents each quantity's formal definition, computation, and scale-constant measurement.
+- Revise: every mention of "energy," "entropy," "information integrity," "void," "coherence" to cite the §Grounding definition. The thermodynamic vocabulary stays as reading-room scaffolding; the math underneath is now Shannon + FEP.
+- Appendix: measurement protocol for scale constants, with the reference corpus description.
+- Appendix: legacy-vs-grounded comparison after Phase 2 calibration, showing divergence and justification.
+- Delete or rewrite: any paragraph that asserted a thermodynamic law (2nd law, conservation, fluctuation-dissipation) without derivation. These were the hand-wavy parts; the grounded framework doesn't claim them.
+
+v3 paper (archived) gets a note at the top indicating it predates the grounding and is retained for historical reference only.
+
+## 7. Open questions
+
+- **Logprob access on Claude Code's path.** Anthropic API exposes logprobs in some modes. Need to confirm which endpoints Claude Code uses and whether logprobs are available on those. If not, Phase 1 ships with tier-2 multi-sample as the primary estimator.
+- **Reference distribution for I and coherence.** Per-agent? Per-deployment? Per-model? The spec assumes per-agent-UUID rolling reference, but fleet-level reference (all healthy Claude Code agents combined) may be more stable. Pilot both and compare.
+- **Resource-form E vs FEP-form E.** Resource form is trivially computable; FEP form is more principled but heavier. Phase 1 should ship both behind config, measure calibration divergence, and then this spec's Phase 3 picks a default.
+- **Paper authorship and review.** Grounding changes the paper's central claims. Need a named reviewer (ideally someone with FEP or stat-mech background) before v5 goes to arXiv.
+- **Backward compatibility with Codex.** Codex clients currently write ad-hoc E/I/S/V via their check-in path. During Phase 1 dual-compute, Codex-submitted values land in `*_legacy`; grounded values are computed server-side from the payload. Confirm this is acceptable with the Codex plugin owners before Phase 1 merge.
+
+---
+
+**Next artifact.** Once this spec is reviewed and accepted, an implementation plan (same format as `docs/plans/2026-04-17-audit-payload-capture-plan.md`) lands in a second commit on this branch: TDD-structured, task-broken, subagent-ready. Phase 1 scope only. Phases 2 and 3 get their own plans once Phase 1 data is in.

--- a/scripts/calibrate_class_conditional.py
+++ b/scripts/calibrate_class_conditional.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Phase 2 calibration: measure per-class scale constants from production DB.
+
+Implements the measurement protocol of paper §7 Class-Conditional Calibration
+against the existing core.agent_state corpus. For each calibration class
+(Lumen / Vigil / Sentinel / Watcher / Steward / embodied / resident_persistent /
+ephemeral / default), computes:
+
+  - corpus size N
+  - healthy operating point: median (E, I, S) on healthy regime slice
+  - manifold radius ||Δ||_max: 95th percentile of state-space distance from
+    the class's own healthy operating point
+
+Outputs a Python snippet ready to paste into config/governance_config.py
+populating DELTA_NORM_MAX_BY_CLASS and HEALTHY_OPERATING_POINT_BY_CLASS.
+
+Usage:
+  python3 scripts/calibrate_class_conditional.py
+  python3 scripts/calibrate_class_conditional.py --window-days 30
+  python3 scripts/calibrate_class_conditional.py --output measured_constants.py
+
+Note on scope: tier-3 heuristic is what's currently in production. This script
+measures the empirical envelope of those tier-3 values per class — which is
+what the manifold coherence form actually consumes. The S_SCALE/I_SCALE/E_SCALE
+constants only matter when tier-1 (logprobs) or tier-2 (multi-sample) ships;
+those columns are reported here as descriptive but not used to populate the
+*_BY_CLASS dicts until tier-1/2 produces real S_raw/I_raw/E_raw.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import sys
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+try:
+    import psycopg2
+    import psycopg2.extras
+except ImportError:
+    print("ERROR: psycopg2 not installed. Run: pip install psycopg2-binary", file=sys.stderr)
+    sys.exit(1)
+
+
+KNOWN_RESIDENT_LABELS = {"Lumen", "Vigil", "Sentinel", "Watcher", "Steward"}
+HEALTHY_REGIMES = ("nominal", "STABLE", "CONVERGENCE", "EXPLORATION")
+
+
+def classify_from_db_row(label: Optional[str], tags: Optional[list]) -> str:
+    """Mirror src/grounding/class_indicator.classify_agent for DB-row inputs.
+
+    Kept inline so this script has no governance-server runtime dependency.
+    """
+    if label and label in KNOWN_RESIDENT_LABELS:
+        return label
+    tags_set = set(tags or [])
+    if "embodied" in tags_set:
+        return "embodied"
+    if "ephemeral" in tags_set:
+        return "ephemeral"
+    if "persistent" in tags_set and "autonomous" in tags_set:
+        return "resident_persistent"
+    return "default"
+
+
+@dataclass
+class ClassStats:
+    name: str
+    n: int
+    e_median: float
+    i_median: float
+    s_median: float
+    e_p90: float
+    i_p90: float
+    s_p90: float
+    delta_p95: float
+
+
+def fetch_class_observations(
+    conn,
+    window_days: int,
+) -> Dict[str, List[Tuple[float, float, float]]]:
+    """Return {class_name: [(E, I, S), ...]} for healthy turns in the window."""
+    sql = """
+        SELECT
+          i.metadata->>'label'                AS label,
+          COALESCE(i.metadata->'tags', '[]')  AS tags,
+          s.state_json,
+          s.entropy,
+          s.integrity
+        FROM core.agent_state s
+        JOIN core.identities  i  USING (identity_id)
+        WHERE s.recorded_at >= now() - (%s::int * INTERVAL '1 day')
+          AND s.regime = ANY (%s)
+    """
+    by_class: Dict[str, List[Tuple[float, float, float]]] = {}
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(sql, (window_days, list(HEALTHY_REGIMES)))
+        for row in cur:
+            label = row["label"]
+            tags_raw = row["tags"]
+            if isinstance(tags_raw, str):
+                try:
+                    tags = json.loads(tags_raw)
+                except (ValueError, TypeError):
+                    tags = []
+            else:
+                tags = tags_raw or []
+
+            state_json = row["state_json"] or {}
+            if isinstance(state_json, str):
+                try:
+                    state_json = json.loads(state_json)
+                except (ValueError, TypeError):
+                    state_json = {}
+
+            e = state_json.get("E")
+            if e is None:
+                # No E in state_json → unusable for manifold calibration
+                continue
+            try:
+                e = float(e)
+                i_val = float(row["integrity"])
+                s_val = float(row["entropy"])
+            except (TypeError, ValueError):
+                continue
+            if not (0.0 <= e <= 1.0 and 0.0 <= i_val <= 1.0 and 0.0 <= s_val <= 1.0):
+                continue
+
+            cls = classify_from_db_row(label, tags)
+            by_class.setdefault(cls, []).append((e, i_val, s_val))
+    return by_class
+
+
+def percentile(xs: List[float], p: float) -> float:
+    """Linear-interpolation percentile (p in [0, 100])."""
+    if not xs:
+        return 0.0
+    xs_sorted = sorted(xs)
+    k = (len(xs_sorted) - 1) * (p / 100.0)
+    f = math.floor(k)
+    c = math.ceil(k)
+    if f == c:
+        return xs_sorted[int(k)]
+    return xs_sorted[f] * (c - k) + xs_sorted[c] * (k - f)
+
+
+def compute_class_stats(
+    name: str,
+    obs: List[Tuple[float, float, float]],
+) -> ClassStats:
+    es = [t[0] for t in obs]
+    is_ = [t[1] for t in obs]
+    ss = [t[2] for t in obs]
+
+    e_med = statistics.median(es)
+    i_med = statistics.median(is_)
+    s_med = statistics.median(ss)
+
+    deltas = [
+        math.sqrt((e - e_med) ** 2 + (i - i_med) ** 2 + (s - s_med) ** 2)
+        for (e, i, s) in obs
+    ]
+
+    return ClassStats(
+        name=name,
+        n=len(obs),
+        e_median=e_med,
+        i_median=i_med,
+        s_median=s_med,
+        e_p90=percentile(es, 90),
+        i_p90=percentile(is_, 90),
+        s_p90=percentile(ss, 90),
+        delta_p95=percentile(deltas, 95),
+    )
+
+
+def render_python_snippet(
+    stats: List[ClassStats],
+    measured_on: str,
+    n_min: int,
+) -> str:
+    """Render a Python snippet ready to paste into governance_config.py."""
+    lines = [
+        "# AUTOGENERATED by scripts/calibrate_class_conditional.py",
+        f'# Measured {measured_on} on healthy production fleet.',
+        "# Paste into config/governance_config.py to replace the empty Phase 1 dicts.",
+        "",
+        "DELTA_NORM_MAX_BY_CLASS: Dict[str, ScaleConstant] = {",
+    ]
+    for st in stats:
+        if st.n < n_min:
+            lines.append(
+                f'    # "{st.name}": skipped — N={st.n} below threshold {n_min}; falls back to default'
+            )
+            continue
+        lines.append(
+            f'    "{st.name}": ScaleConstant('
+            f'name="DELTA_NORM_MAX[{st.name}]", value={st.delta_p95:.4f}, '
+            f'measured_on="{measured_on}", corpus_size={st.n}, '
+            f'percentile=95, provenance="measured", '
+            f'notes="Class-conditional manifold radius from healthy slice."),'
+        )
+    lines.append("}")
+    lines.append("")
+
+    lines.append(
+        "# Healthy operating points per class — feed _compute_manifold's baseline."
+    )
+    lines.append("HEALTHY_OPERATING_POINT_BY_CLASS: Dict[str, tuple] = {")
+    for st in stats:
+        if st.n < n_min:
+            continue
+        lines.append(
+            f'    "{st.name}": ({st.e_median:.4f}, {st.i_median:.4f}, {st.s_median:.4f}),  # N={st.n}'
+        )
+    lines.append("}")
+    lines.append("")
+
+    # Descriptive stats for the report — not yet used in code (tier-1/2 scope)
+    lines.append("# Descriptive: 90th-percentile envelopes (used once tier-1 logprobs ship)")
+    lines.append("# Class            N      E_p90   I_p90   S_p90")
+    for st in stats:
+        lines.append(
+            f"# {st.name:<16} {st.n:<6} {st.e_p90:.4f}  {st.i_p90:.4f}  {st.s_p90:.4f}"
+        )
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--window-days", type=int, default=30,
+                        help="Days of history to include (default: 30)")
+    parser.add_argument("--n-min", type=int, default=30,
+                        help="Minimum class population for measurement; below this falls back (default: 30)")
+    parser.add_argument("--output", type=str, default=None,
+                        help="Write snippet to this file instead of stdout")
+    parser.add_argument("--db-url", type=str,
+                        default="postgresql://postgres:postgres@localhost:5432/governance",
+                        help="Postgres connection string")
+    args = parser.parse_args()
+
+    measured_on = __import__("datetime").datetime.now().strftime("%Y-%m-%d")
+
+    print(f"[calibrate] Connecting to DB...", file=sys.stderr)
+    conn = psycopg2.connect(args.db_url)
+
+    print(f"[calibrate] Pulling healthy turns from last {args.window_days} days...", file=sys.stderr)
+    by_class = fetch_class_observations(conn, args.window_days)
+
+    print(f"[calibrate] Found {len(by_class)} classes with observations:", file=sys.stderr)
+    for cls, obs in sorted(by_class.items(), key=lambda kv: -len(kv[1])):
+        print(f"  {cls:<24} N={len(obs)}", file=sys.stderr)
+
+    stats = [compute_class_stats(cls, obs) for cls, obs in by_class.items()]
+    stats.sort(key=lambda s: -s.n)
+
+    snippet = render_python_snippet(stats, measured_on, args.n_min)
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(snippet)
+        print(f"[calibrate] Wrote {args.output}", file=sys.stderr)
+    else:
+        print(snippet)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verdict_counterfactual.py
+++ b/scripts/verdict_counterfactual.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Verdict counterfactual: how many basin assignments would flip under
+class-conditional grounded coherence vs the legacy fleet-wide tanh form?
+
+For each production agent_state row in the window, compute:
+  - legacy basin: classify_basin(E, I, S, V, coherence_legacy, risk)
+  - grounded basin: classify_basin(E, I, S, V, coherence_manifold(class), risk)
+where coherence_manifold uses class-conditional ||Δ||_max and
+healthy operating point measured by Phase 2 calibration.
+
+Reports per-class flip counts and direction (high↔boundary↔low).
+
+This is the result that converts the paper from methodology to
+paper-with-a-result, per the peer-review feedback.
+
+Usage:
+  python3 scripts/verdict_counterfactual.py --window-days 30
+  python3 scripts/verdict_counterfactual.py --output verdict_flips.csv --csv
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from collections import Counter, defaultdict
+from typing import Dict, List, Optional, Tuple
+
+try:
+    import psycopg2
+    import psycopg2.extras
+except ImportError:
+    print("ERROR: psycopg2 not installed. Run: pip install psycopg2-binary", file=sys.stderr)
+    sys.exit(1)
+
+
+# ── Mirror of src/grounding/class_indicator.classify_agent ────────────
+KNOWN_RESIDENT_LABELS = {"Lumen", "Vigil", "Sentinel", "Watcher", "Steward"}
+
+
+def classify_from_db_row(label: Optional[str], tags: Optional[list]) -> str:
+    if label and label in KNOWN_RESIDENT_LABELS:
+        return label
+    tags_set = set(tags or [])
+    if "embodied" in tags_set:
+        return "embodied"
+    if "ephemeral" in tags_set:
+        return "ephemeral"
+    if "persistent" in tags_set and "autonomous" in tags_set:
+        return "resident_persistent"
+    return "default"
+
+
+# ── Mirror of config.governance_config.classify_basin ─────────────────
+BASIN_HIGH_E_MIN = 0.6
+BASIN_HIGH_I_MIN = 0.7
+BASIN_HIGH_S_MAX = 0.25
+BASIN_HIGH_V_ABS_MAX = 0.15
+BASIN_HIGH_COHERENCE_MIN = 0.45
+BASIN_HIGH_RISK_MAX = 0.45
+
+BASIN_LOW_I_CEIL = 0.5
+BASIN_LOW_COHERENCE_CEIL = 0.40
+BASIN_LOW_V_ABS_FLOOR = 0.30
+BASIN_LOW_RISK_FLOOR = 0.70
+
+
+def classify_basin(E: float, I: float, S: float, V: float,
+                   coherence: float, risk_score: float) -> str:
+    if risk_score is None:
+        risk_score = 0.0
+    V_abs = abs(V)
+    if (I < BASIN_LOW_I_CEIL
+            or coherence < BASIN_LOW_COHERENCE_CEIL
+            or V_abs > BASIN_LOW_V_ABS_FLOOR
+            or risk_score >= BASIN_LOW_RISK_FLOOR):
+        return "low"
+    if (E >= BASIN_HIGH_E_MIN
+            and I >= BASIN_HIGH_I_MIN
+            and S <= BASIN_HIGH_S_MAX
+            and V_abs <= BASIN_HIGH_V_ABS_MAX
+            and coherence >= BASIN_HIGH_COHERENCE_MIN
+            and risk_score <= BASIN_HIGH_RISK_MAX):
+        return "high"
+    return "boundary"
+
+
+# ── Phase 2 measured constants (replicated for self-containment) ──────
+DELTA_NORM_MAX_BY_CLASS = {
+    "Lumen":    0.1187,
+    "default":  0.2018,
+    "Sentinel": 0.1702,
+    "Vigil":    0.1705,
+    "Watcher":  0.3948,
+}
+DELTA_NORM_MAX_DEFAULT = 1.8
+
+HEALTHY_OPERATING_POINT_BY_CLASS = {
+    "Lumen":    (0.7454, 0.8001, 0.1678),
+    "default":  (0.7264, 0.7934, 0.2364),
+    "Sentinel": (0.7506, 0.7981, 0.1934),
+    "Vigil":    (0.7371, 0.7896, 0.2404),
+    "Watcher":  (0.7482, 0.7686, 0.2477),
+}
+# Fleet fallback: BASIN_HIGH corner per governance_config.py
+HEALTHY_OPERATING_POINT_DEFAULT = (BASIN_HIGH_E_MIN, BASIN_HIGH_I_MIN, 0.0)
+
+
+def compute_manifold_coherence(E: float, I: float, S: float, agent_class: str) -> float:
+    healthy = HEALTHY_OPERATING_POINT_BY_CLASS.get(agent_class, HEALTHY_OPERATING_POINT_DEFAULT)
+    delta_max = DELTA_NORM_MAX_BY_CLASS.get(agent_class, DELTA_NORM_MAX_DEFAULT)
+    dx = E - healthy[0]
+    dy = I - healthy[1]
+    dz = S - healthy[2]
+    norm = math.sqrt(dx * dx + dy * dy + dz * dz)
+    ratio = norm / delta_max
+    return 1.0 - max(0.0, min(1.0, ratio))
+
+
+def fetch_rows(conn, window_days: int):
+    sql = """
+        SELECT
+          i.metadata->>'label'                AS label,
+          COALESCE(i.metadata->'tags', '[]')  AS tags,
+          s.entropy,
+          s.integrity,
+          s.volatility,
+          s.coherence,
+          s.state_json
+        FROM core.agent_state s
+        JOIN core.identities  i  USING (identity_id)
+        WHERE s.recorded_at >= now() - (%s::int * INTERVAL '1 day')
+    """
+    rows = []
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(sql, (window_days,))
+        for row in cur:
+            tags_raw = row["tags"]
+            if isinstance(tags_raw, str):
+                try:
+                    tags = json.loads(tags_raw)
+                except (ValueError, TypeError):
+                    tags = []
+            else:
+                tags = tags_raw or []
+            state_json = row["state_json"] or {}
+            if isinstance(state_json, str):
+                try:
+                    state_json = json.loads(state_json)
+                except (ValueError, TypeError):
+                    state_json = {}
+            e = state_json.get("E")
+            risk = state_json.get("risk_score", 0.0)
+            if e is None:
+                continue
+            try:
+                e = float(e)
+                i_val = float(row["integrity"])
+                s_val = float(row["entropy"])
+                v_val = float(row["volatility"])
+                c_legacy = float(row["coherence"])
+                risk = float(risk) if risk is not None else 0.0
+            except (TypeError, ValueError):
+                continue
+            cls = classify_from_db_row(row["label"], tags)
+            rows.append({
+                "class": cls,
+                "E": e, "I": i_val, "S": s_val, "V": v_val,
+                "coherence_legacy": c_legacy,
+                "risk_score": risk,
+            })
+    return rows
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--window-days", type=int, default=30)
+    parser.add_argument("--db-url", type=str,
+                        default="postgresql://postgres:postgres@localhost:5432/governance")
+    parser.add_argument("--csv", action="store_true",
+                        help="Output CSV of all flips for further analysis")
+    parser.add_argument("--output", type=str, default=None)
+    args = parser.parse_args()
+
+    print(f"[counterfactual] Connecting to DB...", file=sys.stderr)
+    conn = psycopg2.connect(args.db_url)
+
+    print(f"[counterfactual] Pulling agent_state rows from last {args.window_days} days...", file=sys.stderr)
+    rows = fetch_rows(conn, args.window_days)
+    print(f"[counterfactual] {len(rows)} rows with computable E (state_json contains 'E')", file=sys.stderr)
+
+    # Tally by class
+    flips_by_class: Dict[str, Counter] = defaultdict(Counter)
+    totals_by_class: Dict[str, int] = defaultdict(int)
+    coherence_diff_by_class: Dict[str, list] = defaultdict(list)
+
+    csv_lines: List[str] = []
+    if args.csv:
+        csv_lines.append("class,E,I,S,V,risk,c_legacy,c_grounded,basin_legacy,basin_grounded,flipped")
+
+    for r in rows:
+        cls = r["class"]
+        c_grounded = compute_manifold_coherence(r["E"], r["I"], r["S"], cls)
+        basin_legacy = classify_basin(r["E"], r["I"], r["S"], r["V"],
+                                       r["coherence_legacy"], r["risk_score"])
+        basin_grounded = classify_basin(r["E"], r["I"], r["S"], r["V"],
+                                         c_grounded, r["risk_score"])
+        flipped = basin_legacy != basin_grounded
+        totals_by_class[cls] += 1
+        if flipped:
+            flips_by_class[cls][f"{basin_legacy}→{basin_grounded}"] += 1
+        coherence_diff_by_class[cls].append(c_grounded - r["coherence_legacy"])
+
+        if args.csv:
+            csv_lines.append(
+                f"{cls},{r['E']:.4f},{r['I']:.4f},{r['S']:.4f},{r['V']:.4f},"
+                f"{r['risk_score']:.4f},{r['coherence_legacy']:.4f},{c_grounded:.4f},"
+                f"{basin_legacy},{basin_grounded},{int(flipped)}"
+            )
+
+    if args.csv:
+        out = "\n".join(csv_lines) + "\n"
+        if args.output:
+            with open(args.output, "w") as f:
+                f.write(out)
+            print(f"[counterfactual] CSV written to {args.output}", file=sys.stderr)
+        else:
+            print(out)
+        return 0
+
+    # Summary report
+    print()
+    print("=" * 78)
+    print("VERDICT COUNTERFACTUAL — class-conditional grounded vs fleet-wide legacy")
+    print("=" * 78)
+    print()
+    total_flips = sum(sum(c.values()) for c in flips_by_class.values())
+    total_rows = sum(totals_by_class.values())
+    overall_pct = 100.0 * total_flips / total_rows if total_rows else 0.0
+    print(f"Window:        {args.window_days} days")
+    print(f"Total rows:    {total_rows:>6}")
+    print(f"Total flips:   {total_flips:>6}  ({overall_pct:.1f}%)")
+    print()
+    print(f"{'Class':<12} {'N':>6} {'Flips':>7} {'%':>6}  {'Δc mean':>8} {'Δc max':>8}  Transitions")
+    print("-" * 78)
+    for cls in sorted(totals_by_class.keys(), key=lambda c: -totals_by_class[c]):
+        n = totals_by_class[cls]
+        f = sum(flips_by_class[cls].values())
+        pct = 100.0 * f / n if n else 0.0
+        deltas = coherence_diff_by_class[cls]
+        dc_mean = sum(deltas) / len(deltas) if deltas else 0.0
+        dc_max_abs = max((abs(d) for d in deltas), default=0.0)
+        transitions = ", ".join(
+            f"{k}:{v}" for k, v in sorted(flips_by_class[cls].items(),
+                                          key=lambda kv: -kv[1])
+        ) or "—"
+        print(f"{cls:<12} {n:>6} {f:>7} {pct:>5.1f}%  {dc_mean:>+8.4f} {dc_max_abs:>8.4f}  {transitions}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/grounding/__init__.py
+++ b/src/grounding/__init__.py
@@ -1,0 +1,4 @@
+"""Grounded EISV computations — spec docs/specs/2026-04-17-eisv-grounding-design.md."""
+from src.grounding.types import GroundedValue, ALLOWED_SOURCES
+
+__all__ = ["GroundedValue", "ALLOWED_SOURCES"]

--- a/src/grounding/class_indicator.py
+++ b/src/grounding/class_indicator.py
@@ -1,0 +1,54 @@
+"""Map an agent (via its metadata) to a calibration class.
+
+Spec §3 (paper §2 Heterogeneous Agent Fleets): class assignment uses the
+identity tag and label fields already present on every agent. The class
+indicator function k(a) here is keyed first on label (specific known resident
+agent names like 'Lumen', 'Vigil') and then on tag set (embodied, persistent,
+autonomous, ephemeral). Unrecognized agents fall through to the default
+class, where fleet-wide constants apply.
+
+Returns a class name string used to key into the class-conditional scale
+maps in config/governance_config.py (S_SCALE_BY_CLASS, etc.).
+"""
+from typing import Any, Optional
+
+# Specific labels that identify a unique resident agent. Each is its own
+# calibration class because population N=1 means class==agent in practice.
+KNOWN_RESIDENT_LABELS = frozenset({"Lumen", "Vigil", "Sentinel", "Watcher", "Steward"})
+
+# Tag-derived class names.
+CLASS_EMBODIED = "embodied"
+CLASS_RESIDENT_PERSISTENT = "resident_persistent"
+CLASS_EPHEMERAL = "ephemeral"
+CLASS_DEFAULT = "default"
+
+
+def classify_agent(meta: Optional[Any]) -> str:
+    """Return the calibration class name for an agent given its metadata.
+
+    Resolution order:
+      1. Known resident label (Lumen / Vigil / Sentinel / Watcher / Steward).
+      2. Tag-derived: embodied → embodied; ephemeral → ephemeral;
+         persistent + autonomous → resident_persistent.
+      3. Default — used for session-bounded agents and anything unrecognized.
+
+    Returns 'default' if meta is None or carries no class-relevant tags.
+    """
+    if meta is None:
+        return CLASS_DEFAULT
+
+    label = getattr(meta, "label", None)
+    if label and label in KNOWN_RESIDENT_LABELS:
+        return label
+
+    tags_raw = getattr(meta, "tags", None) or []
+    tags = set(tags_raw)
+
+    if "embodied" in tags:
+        return CLASS_EMBODIED
+    if "ephemeral" in tags:
+        return CLASS_EPHEMERAL
+    if "persistent" in tags and "autonomous" in tags:
+        return CLASS_RESIDENT_PERSISTENT
+
+    return CLASS_DEFAULT

--- a/src/grounding/coherence.py
+++ b/src/grounding/coherence.py
@@ -1,0 +1,65 @@
+"""Coherence — spec §3.1 Coherence.
+
+Two grounded forms:
+  - manifold:  C = 1 - ||Δ||_2 / ||Δ||_max, Δ = (E,I,S) - (E,I,S)_healthy
+  - kl:        C = exp(-D_KL(q_now || q_ref)), requires reference distribution
+
+Manifold form ships as primary (needs only existing EISV). KL stubbed for Phase 2.
+"""
+import math
+from typing import Any, Dict
+
+from src.grounding.types import GroundedValue
+
+
+def compute_coherence(ctx: Any, metrics: Dict[str, Any]) -> GroundedValue:
+    if "q_now" in metrics and "q_ref" in metrics:
+        try:
+            return _compute_kl(metrics["q_now"], metrics["q_ref"])
+        except NotImplementedError:
+            pass
+
+    try:
+        return _compute_manifold(
+            E=float(metrics["E"]),
+            I=float(metrics["I"]),
+            S=float(metrics["S"]),
+        )
+    except (KeyError, TypeError, ValueError):
+        pass
+
+    return _compute_heuristic(metrics)
+
+
+def _compute_kl(q_now: list, q_ref: list) -> GroundedValue:
+    raise NotImplementedError(
+        "tier-1 KL coherence requires a calibrated reference distribution q_ref; "
+        "Phase 2 scope"
+    )
+
+
+def _compute_manifold(E: float, I: float, S: float) -> GroundedValue:
+    """Manifold distance from healthy (E,I,S) baseline."""
+    from config.governance_config import BASIN_HIGH, DELTA_NORM_MAX
+
+    healthy_E = BASIN_HIGH.E_min
+    healthy_I = BASIN_HIGH.I_min
+    healthy_S = 0.0
+
+    dx = E - healthy_E
+    dy = I - healthy_I
+    dz = S - healthy_S
+    norm = math.sqrt(dx * dx + dy * dy + dz * dz)
+    ratio = norm / DELTA_NORM_MAX.value
+    val = 1.0 - max(0.0, min(1.0, ratio))
+    return GroundedValue(value=val, source="manifold")
+
+
+def _compute_heuristic(metrics: Dict[str, Any]) -> GroundedValue:
+    raw = metrics.get("coherence", 0.5)
+    try:
+        val = float(raw)
+    except (TypeError, ValueError):
+        val = 0.5
+    val = max(0.0, min(1.0, val))
+    return GroundedValue(value=val, source="heuristic")

--- a/src/grounding/coherence.py
+++ b/src/grounding/coherence.py
@@ -42,16 +42,15 @@ def _compute_kl(q_now: list, q_ref: list) -> GroundedValue:
 
 
 def _compute_manifold(E: float, I: float, S: float, agent_class: str = "default") -> GroundedValue:
-    """Manifold distance from healthy (E,I,S) baseline.
+    """Manifold distance from class-conditional healthy operating point.
 
-    Uses class-conditional ||Δ||_max if the class has a measured value;
-    otherwise falls back to the fleet-wide default.
+    Uses both class-conditional ||Δ||_max and class-conditional healthy
+    operating point if the class has measured values; otherwise falls back
+    to fleet-wide defaults.
     """
-    from config.governance_config import BASIN_HIGH, get_delta_norm_max
+    from config.governance_config import get_delta_norm_max, get_healthy_operating_point
 
-    healthy_E = BASIN_HIGH.E_min
-    healthy_I = BASIN_HIGH.I_min
-    healthy_S = 0.0
+    healthy_E, healthy_I, healthy_S = get_healthy_operating_point(agent_class)
 
     dx = E - healthy_E
     dy = I - healthy_I

--- a/src/grounding/coherence.py
+++ b/src/grounding/coherence.py
@@ -19,11 +19,14 @@ def compute_coherence(ctx: Any, metrics: Dict[str, Any]) -> GroundedValue:
         except NotImplementedError:
             pass
 
+    agent_class = getattr(ctx, "agent_class", None) or "default"
+
     try:
         return _compute_manifold(
             E=float(metrics["E"]),
             I=float(metrics["I"]),
             S=float(metrics["S"]),
+            agent_class=agent_class,
         )
     except (KeyError, TypeError, ValueError):
         pass
@@ -38,9 +41,13 @@ def _compute_kl(q_now: list, q_ref: list) -> GroundedValue:
     )
 
 
-def _compute_manifold(E: float, I: float, S: float) -> GroundedValue:
-    """Manifold distance from healthy (E,I,S) baseline."""
-    from config.governance_config import BASIN_HIGH, DELTA_NORM_MAX
+def _compute_manifold(E: float, I: float, S: float, agent_class: str = "default") -> GroundedValue:
+    """Manifold distance from healthy (E,I,S) baseline.
+
+    Uses class-conditional ||Δ||_max if the class has a measured value;
+    otherwise falls back to the fleet-wide default.
+    """
+    from config.governance_config import BASIN_HIGH, get_delta_norm_max
 
     healthy_E = BASIN_HIGH.E_min
     healthy_I = BASIN_HIGH.I_min
@@ -50,7 +57,7 @@ def _compute_manifold(E: float, I: float, S: float) -> GroundedValue:
     dy = I - healthy_I
     dz = S - healthy_S
     norm = math.sqrt(dx * dx + dy * dy + dz * dz)
-    ratio = norm / DELTA_NORM_MAX.value
+    ratio = norm / get_delta_norm_max(agent_class).value
     val = 1.0 - max(0.0, min(1.0, ratio))
     return GroundedValue(value=val, source="manifold")
 

--- a/src/grounding/entropy.py
+++ b/src/grounding/entropy.py
@@ -1,0 +1,53 @@
+"""Shannon entropy of the agent's response distribution — spec §3.1 S.
+
+Three tiers in preference order:
+  1. logprob  — per-token entropy from model logprobs (requires plugin instrumentation)
+  2. multisample — k-sample self-consistency over semantic equivalence classes
+  3. heuristic — wraps the legacy [0,1] complexity/drift-driven S (degraded mode)
+"""
+from typing import Any, Dict
+
+from src.grounding.types import GroundedValue
+
+
+def compute_entropy(ctx: Any, metrics: Dict[str, Any]) -> GroundedValue:
+    """Return grounded S value. Always succeeds (tier-3 is a safe fallback)."""
+    args = getattr(ctx, "arguments", {}) or {}
+
+    if "logprobs" in args:
+        try:
+            return _compute_from_logprobs(args["logprobs"])
+        except NotImplementedError:
+            pass
+
+    if "samples" in args:
+        try:
+            return _compute_from_samples(args["samples"])
+        except NotImplementedError:
+            pass
+
+    return _compute_heuristic(metrics)
+
+
+def _compute_from_logprobs(logprobs: list) -> GroundedValue:
+    raise NotImplementedError(
+        "tier-1 (logprob) entropy requires plugin-side logprob capture; "
+        "see spec §3.1 S 'Computation recipe' and Phase-1 out-of-scope items"
+    )
+
+
+def _compute_from_samples(samples: list) -> GroundedValue:
+    raise NotImplementedError(
+        "tier-2 (multisample) entropy requires a semantic-equivalence classifier; "
+        "deferred from Phase 1"
+    )
+
+
+def _compute_heuristic(metrics: Dict[str, Any]) -> GroundedValue:
+    raw = metrics.get("S", 0.5)
+    try:
+        val = float(raw)
+    except (TypeError, ValueError):
+        val = 0.5
+    val = max(0.0, min(1.0, val))
+    return GroundedValue(value=val, source="heuristic")

--- a/src/grounding/free_energy.py
+++ b/src/grounding/free_energy.py
@@ -1,0 +1,60 @@
+"""Negative free energy (E) — spec §3.1 E.
+
+Tier 1 (FEP): variational free-energy estimator over agent predictions vs outcomes.
+Tier 2 (resource): normalized throughput, (tokens/s) / (tokens/s)_max.
+Tier 3 (heuristic): wraps legacy E.
+
+Resource form ships as primary tier because it requires no new data beyond
+what plugins already report. FEP form is stubbed; Phase 2 builds the estimator.
+"""
+from typing import Any, Dict
+
+from src.grounding.types import GroundedValue
+
+# Fleet-calibrated envelope — replaced by measured value in Phase 2.
+TOKENS_PER_SECOND_MAX = 200.0
+
+
+def compute_free_energy(ctx: Any, metrics: Dict[str, Any]) -> GroundedValue:
+    args = getattr(ctx, "arguments", {}) or {}
+
+    if "expected_outcome" in args and "observed_outcome" in args:
+        try:
+            return _compute_fep(args["expected_outcome"], args["observed_outcome"])
+        except NotImplementedError:
+            pass
+
+    tokens = args.get("response_tokens")
+    seconds = args.get("response_seconds")
+    if tokens is not None and seconds is not None:
+        try:
+            return _compute_resource(float(tokens), float(seconds))
+        except (ValueError, TypeError):
+            pass
+
+    return _compute_heuristic(metrics)
+
+
+def _compute_fep(expected: Dict, observed: Dict) -> GroundedValue:
+    raise NotImplementedError(
+        "tier-1 FEP requires a generative model over outcomes; Phase 2 scope"
+    )
+
+
+def _compute_resource(tokens: float, seconds: float) -> GroundedValue:
+    if seconds <= 0:
+        raise ValueError("response_seconds must be positive")
+    rate = tokens / seconds
+    normalized = rate / TOKENS_PER_SECOND_MAX
+    val = max(0.0, min(1.0, normalized))
+    return GroundedValue(value=val, source="resource")
+
+
+def _compute_heuristic(metrics: Dict[str, Any]) -> GroundedValue:
+    raw = metrics.get("E", 0.5)
+    try:
+        val = float(raw)
+    except (TypeError, ValueError):
+        val = 0.5
+    val = max(0.0, min(1.0, val))
+    return GroundedValue(value=val, source="heuristic")

--- a/src/grounding/mutual_info.py
+++ b/src/grounding/mutual_info.py
@@ -1,0 +1,52 @@
+"""Mutual information MI(x; y) between context and response — spec §3.1 I.
+
+Tier 1: MI from paired logprobs (context-only vs context+response).
+Tier 2: multi-sample via KL divergence from a reference distribution.
+Tier 3: wraps the legacy [0,1] I heuristic.
+"""
+from typing import Any, Dict
+
+from src.grounding.types import GroundedValue
+
+
+def compute_mutual_info(ctx: Any, metrics: Dict[str, Any]) -> GroundedValue:
+    args = getattr(ctx, "arguments", {}) or {}
+
+    if "logprobs" in args and "context_logprobs" in args:
+        try:
+            return _compute_from_logprobs(
+                args["logprobs"], args["context_logprobs"]
+            )
+        except NotImplementedError:
+            pass
+
+    if "samples" in args:
+        try:
+            return _compute_from_samples(args["samples"])
+        except NotImplementedError:
+            pass
+
+    return _compute_heuristic(metrics)
+
+
+def _compute_from_logprobs(logprobs: list, context_logprobs: list) -> GroundedValue:
+    raise NotImplementedError(
+        "tier-1 MI requires paired context/response logprobs; "
+        "see spec §3.1 I 'Computation recipe'"
+    )
+
+
+def _compute_from_samples(samples: list) -> GroundedValue:
+    raise NotImplementedError(
+        "tier-2 MI requires reference-distribution estimator; deferred from Phase 1"
+    )
+
+
+def _compute_heuristic(metrics: Dict[str, Any]) -> GroundedValue:
+    raw = metrics.get("I", 0.5)
+    try:
+        val = float(raw)
+    except (TypeError, ValueError):
+        val = 0.5
+    val = max(0.0, min(1.0, val))
+    return GroundedValue(value=val, source="heuristic")

--- a/src/grounding/types.py
+++ b/src/grounding/types.py
@@ -1,0 +1,37 @@
+"""Shared return type for grounding compute functions."""
+from dataclasses import dataclass
+from typing import Dict
+
+ALLOWED_SOURCES = frozenset({
+    "logprob",      # tier-1: model logprobs
+    "multisample",  # tier-2: k-sample self-consistency
+    "resource",     # tier-3 E: resource-rate form
+    "fep",          # E via variational free-energy estimator
+    "kl",           # coherence via KL divergence
+    "manifold",     # coherence via state-space distance
+    "heuristic",    # tier-3 fallback — legacy computation
+})
+
+
+@dataclass(frozen=True)
+class GroundedValue:
+    """A grounded governance quantity paired with its computation source.
+
+    Value is always in [0, 1] — normalized at the source module.
+    """
+    value: float
+    source: str
+
+    def __post_init__(self) -> None:
+        if self.source not in ALLOWED_SOURCES:
+            raise ValueError(
+                f"unknown grounding source {self.source!r}; "
+                f"must be one of {sorted(ALLOWED_SOURCES)}"
+            )
+        if not (0.0 <= self.value <= 1.0):
+            raise ValueError(
+                f"GroundedValue.value out of range [0,1]: {self.value}"
+            )
+
+    def as_dict(self) -> Dict[str, object]:
+        return {"value": self.value, "source": self.source}

--- a/src/mcp_handlers/updates/context.py
+++ b/src/mcp_handlers/updates/context.py
@@ -58,6 +58,9 @@ class UpdateContext:
     # ── Response accumulator (Phase 6) ─────────────────────────────
     response_data: Dict[str, Any] = field(default_factory=dict)
 
+    # ── Class-conditional grounding ────────────────────────────────
+    agent_class: Optional[str] = None  # set by enrich_grounding via classify_agent
+
     # ── Cached computations ────────────────────────────────────────
     _cal_error: Optional[float] = None
     _cal_error_ready: bool = False

--- a/src/mcp_handlers/updates/enrichments.py
+++ b/src/mcp_handlers/updates/enrichments.py
@@ -1558,11 +1558,16 @@ from src.grounding.entropy import compute_entropy
 from src.grounding.mutual_info import compute_mutual_info
 from src.grounding.free_energy import compute_free_energy
 from src.grounding.coherence import compute_coherence
+from src.grounding.class_indicator import classify_agent
 
 
 @enrichment(order=75)
 async def enrich_grounding(ctx: UpdateContext) -> None:
-    """Swap grounded E/I/S/coherence into canonical metrics slots."""
+    """Swap grounded E/I/S/coherence into canonical metrics slots.
+
+    Class-conditional: classifies the agent first, sets ctx.agent_class so
+    compute functions can look up per-class scale constants.
+    """
     result = ctx.result or {}
     metrics = result.get("metrics")
     if not isinstance(metrics, dict):
@@ -1570,6 +1575,9 @@ async def enrich_grounding(ctx: UpdateContext) -> None:
 
     if "E_legacy" in metrics:
         return  # idempotent
+
+    # Classify the agent so compute_* can use class-conditional constants.
+    ctx.agent_class = classify_agent(getattr(ctx, "meta", None))
 
     try:
         e = compute_free_energy(ctx, metrics)
@@ -1593,3 +1601,7 @@ async def enrich_grounding(ctx: UpdateContext) -> None:
     metrics["i_source"] = i.source
     metrics["s_source"] = s.source
     metrics["coherence_source"] = c.source
+
+    # Surface the calibration class so audit/broadcast can see what
+    # class-conditional constants were applied to this check-in.
+    metrics["agent_class"] = ctx.agent_class

--- a/src/mcp_handlers/updates/enrichments.py
+++ b/src/mcp_handlers/updates/enrichments.py
@@ -1544,3 +1544,52 @@ async def enrich_agent_profile(ctx: UpdateContext) -> None:
             ctx.response_data['agent_profile'] = profile.to_summary()
     except Exception as e:
         logger.debug(f"Agent profile enrichment skipped: {e}")
+
+
+# =================================================================
+# Grounding enrichment — spec docs/specs/2026-04-17-eisv-grounding-design.md
+# =================================================================
+# Runs at order=75, AFTER gating (phases.py) but BEFORE mirror.
+# Copies legacy E/I/S/coherence into *_legacy, then overwrites E/I/S/coherence
+# with grounded values. Verdicts/basins have already been computed on legacy
+# by the time this runs. V is not touched — it's not dual-computed in Phase 1.
+
+from src.grounding.entropy import compute_entropy
+from src.grounding.mutual_info import compute_mutual_info
+from src.grounding.free_energy import compute_free_energy
+from src.grounding.coherence import compute_coherence
+
+
+@enrichment(order=75)
+async def enrich_grounding(ctx: UpdateContext) -> None:
+    """Swap grounded E/I/S/coherence into canonical metrics slots."""
+    result = ctx.result or {}
+    metrics = result.get("metrics")
+    if not isinstance(metrics, dict):
+        return
+
+    if "E_legacy" in metrics:
+        return  # idempotent
+
+    try:
+        e = compute_free_energy(ctx, metrics)
+        i = compute_mutual_info(ctx, metrics)
+        s = compute_entropy(ctx, metrics)
+        c = compute_coherence(ctx, metrics)
+    except Exception as exc:
+        logger.debug(f"Grounding enrichment failed — legacy values untouched: {exc}")
+        return
+
+    for key in ("E", "I", "S", "coherence"):
+        if key in metrics:
+            metrics[f"{key}_legacy"] = metrics[key]
+
+    metrics["E"] = e.value
+    metrics["I"] = i.value
+    metrics["S"] = s.value
+    metrics["coherence"] = c.value
+
+    metrics["e_source"] = e.source
+    metrics["i_source"] = i.source
+    metrics["s_source"] = s.source
+    metrics["coherence_source"] = c.source

--- a/tests/test_enrichment_pipeline.py
+++ b/tests/test_enrichment_pipeline.py
@@ -18,7 +18,7 @@ from src.mcp_handlers.updates.pipeline import (
 
 class TestEnrichmentRegistration:
     def test_all_enrichments_registered(self):
-        assert get_enrichment_count() == 28
+        assert get_enrichment_count() == 29
 
     def test_enrichment_order_is_unique(self):
         orders = [e.order for e in _ENRICHMENTS]

--- a/tests/test_grounding_class_indicator.py
+++ b/tests/test_grounding_class_indicator.py
@@ -1,0 +1,68 @@
+"""Tests for the class indicator that maps agent metadata to calibration class."""
+import pytest
+from types import SimpleNamespace
+
+from src.grounding.class_indicator import (
+    classify_agent,
+    KNOWN_RESIDENT_LABELS,
+    CLASS_EMBODIED,
+    CLASS_RESIDENT_PERSISTENT,
+    CLASS_EPHEMERAL,
+    CLASS_DEFAULT,
+)
+
+
+def _meta(label=None, tags=None):
+    return SimpleNamespace(label=label, tags=tags or [])
+
+
+def test_none_meta_returns_default():
+    assert classify_agent(None) == CLASS_DEFAULT
+
+
+def test_known_resident_labels_return_themselves():
+    for label in KNOWN_RESIDENT_LABELS:
+        assert classify_agent(_meta(label=label)) == label
+
+
+def test_embodied_tag_takes_precedence_over_persistent():
+    """Lumen has both 'embodied' and 'persistent' but should classify as embodied."""
+    assert classify_agent(_meta(tags=["embodied", "persistent"])) == CLASS_EMBODIED
+
+
+def test_resident_persistent_for_autonomous_persistent():
+    assert (
+        classify_agent(_meta(tags=["autonomous", "persistent"]))
+        == CLASS_RESIDENT_PERSISTENT
+    )
+
+
+def test_ephemeral_tag_classifies_ephemeral():
+    assert classify_agent(_meta(tags=["ephemeral"])) == CLASS_EPHEMERAL
+
+
+def test_unknown_tags_fall_through_to_default():
+    assert classify_agent(_meta(tags=["random", "tag"])) == CLASS_DEFAULT
+
+
+def test_no_tags_no_label_returns_default():
+    assert classify_agent(_meta()) == CLASS_DEFAULT
+
+
+def test_label_overrides_tags_for_known_residents():
+    """A 'Vigil' label wins even if tags say something else."""
+    assert classify_agent(_meta(label="Vigil", tags=["embodied"])) == "Vigil"
+
+
+def test_unknown_label_falls_through_to_tag_resolution():
+    """An unknown label doesn't short-circuit tag resolution."""
+    assert (
+        classify_agent(_meta(label="random_session_agent", tags=["ephemeral"]))
+        == CLASS_EPHEMERAL
+    )
+
+
+def test_meta_without_tags_attribute_is_safe():
+    class Bare:
+        label = "Lumen"
+    assert classify_agent(Bare()) == "Lumen"

--- a/tests/test_grounding_coherence.py
+++ b/tests/test_grounding_coherence.py
@@ -1,0 +1,51 @@
+"""Tests for the coherence grounding module."""
+import math
+
+import pytest
+from unittest.mock import MagicMock
+
+from src.grounding.coherence import compute_coherence
+from src.grounding.types import GroundedValue
+
+
+def _mk_ctx(arguments=None):
+    ctx = MagicMock()
+    ctx.arguments = arguments or {}
+    return ctx
+
+
+def test_manifold_at_healthy_point_is_one():
+    """Agent sitting exactly at healthy baseline → coherence 1.0."""
+    from config.governance_config import BASIN_HIGH
+    metrics = {"E": BASIN_HIGH.E_min, "I": BASIN_HIGH.I_min, "S": 0.0}
+    result = compute_coherence(_mk_ctx(), metrics)
+    assert result.source == "manifold"
+    assert abs(result.value - 1.0) < 1e-9
+
+
+def test_manifold_far_from_healthy_approaches_zero():
+    metrics = {"E": 0.0, "I": 0.0, "S": 1.0}
+    result = compute_coherence(_mk_ctx(), metrics)
+    assert result.source == "manifold"
+    assert result.value < 0.5
+
+
+def test_manifold_missing_dims_falls_through():
+    result = compute_coherence(_mk_ctx(), metrics={"coherence": 0.65})
+    assert result.source == "heuristic"
+    assert result.value == 0.65
+
+
+def test_kl_stub_falls_through():
+    metrics = {
+        "E": 0.5, "I": 0.5, "S": 0.5,
+        "q_now": [0.25, 0.25, 0.25, 0.25],
+        "q_ref": [0.3, 0.3, 0.2, 0.2],
+    }
+    result = compute_coherence(_mk_ctx(), metrics)
+    assert result.source == "manifold"
+
+
+def test_heuristic_clamps():
+    assert compute_coherence(_mk_ctx(), {"coherence": 1.5}).value == 1.0
+    assert compute_coherence(_mk_ctx(), {"coherence": -0.1}).value == 0.0

--- a/tests/test_grounding_end_to_end.py
+++ b/tests/test_grounding_end_to_end.py
@@ -1,0 +1,70 @@
+"""End-to-end: full enrichment pipeline leaves metrics carrying grounded + legacy."""
+import pytest
+
+# Import enrichments to trigger registration
+import src.mcp_handlers.updates.enrichments  # noqa: F401
+
+from src.mcp_handlers.updates.context import UpdateContext
+from src.mcp_handlers.updates.pipeline import run_enrichment_pipeline
+
+
+@pytest.mark.asyncio
+async def test_full_pipeline_metrics_carry_grounded_and_legacy():
+    """After the full enrichment pipeline runs, metrics has {E,I,S,coherence} grounded + *_legacy."""
+    ctx = UpdateContext()
+    ctx.arguments = {}
+    ctx.agent_id = "grounding-e2e"
+    ctx.agent_uuid = "grounding-e2e-uuid"
+    ctx.response_text = "end-to-end enrichment pipeline test"
+    ctx.complexity = 0.4
+    ctx.confidence = 0.7
+    ctx.result = {
+        "metrics": {
+            "E": 0.6, "I": 0.7, "S": 0.3, "V": -0.1,
+            "coherence": 0.72,
+            "health_status": "ok",
+        }
+    }
+    ctx.response_data = {}
+
+    # Run the full pipeline — every enrichment is fail-safe, so missing fixtures
+    # (mcp_server wiring, etc.) will silently skip but grounding should still run.
+    await run_enrichment_pipeline(ctx)
+
+    m = ctx.result["metrics"]
+    for key in ("E_legacy", "I_legacy", "S_legacy", "coherence_legacy"):
+        assert key in m, f"metrics missing {key}"
+    assert "V_legacy" not in m  # V is not dual-computed in Phase 1
+    for key in ("e_source", "i_source", "s_source", "coherence_source"):
+        assert key in m
+        assert m[key] in {
+            "heuristic", "resource", "manifold", "logprob",
+            "multisample", "fep", "kl"
+        }
+    for key in ("E", "I", "S", "coherence"):
+        assert isinstance(m[key], (int, float))
+        assert 0.0 <= m[key] <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_full_pipeline_preserves_legacy_values_exactly():
+    """The *_legacy values must equal the originals before the pipeline ran."""
+    ctx = UpdateContext()
+    ctx.arguments = {}
+    ctx.result = {
+        "metrics": {
+            "E": 0.55, "I": 0.66, "S": 0.33, "V": 0.05,
+            "coherence": 0.77,
+        }
+    }
+    ctx.response_data = {}
+
+    await run_enrichment_pipeline(ctx)
+
+    m = ctx.result["metrics"]
+    assert m["E_legacy"] == 0.55
+    assert m["I_legacy"] == 0.66
+    assert m["S_legacy"] == 0.33
+    assert m["coherence_legacy"] == 0.77
+    # V unchanged
+    assert m["V"] == 0.05

--- a/tests/test_grounding_enrichment.py
+++ b/tests/test_grounding_enrichment.py
@@ -1,0 +1,100 @@
+"""Integration test: grounding enrichment swaps grounded into canonical slots."""
+import pytest
+
+from src.mcp_handlers.updates.context import UpdateContext
+from src.mcp_handlers.updates.enrichments import enrich_grounding
+
+
+@pytest.mark.asyncio
+async def test_enrichment_swaps_grounded_into_canonical_slots():
+    """After enrichment: E/I/S/coherence are grounded; *_legacy hold originals."""
+    ctx = UpdateContext()
+    ctx.arguments = {}
+    ctx.response_text = "hello world"
+    ctx.result = {
+        "metrics": {
+            "E": 0.6, "I": 0.7, "S": 0.3, "V": -0.1,
+            "coherence": 0.72,
+        }
+    }
+    ctx.response_data = {}
+
+    await enrich_grounding(ctx)
+
+    m = ctx.result["metrics"]
+    # Legacy preserved
+    assert m["E_legacy"] == 0.6
+    assert m["I_legacy"] == 0.7
+    assert m["S_legacy"] == 0.3
+    assert m["coherence_legacy"] == 0.72
+    # V untouched
+    assert "V_legacy" not in m
+    assert m["V"] == -0.1
+    # Canonical slots have grounded values (heuristic wraps legacy so same numbers here)
+    assert m["E"] == 0.6
+    assert m["I"] == 0.7
+    assert m["S"] == 0.3
+    # Coherence uses manifold form — different from legacy 0.72
+    assert 0.0 <= m["coherence"] <= 1.0
+    # Source annotations
+    assert m["e_source"] == "heuristic"
+    assert m["i_source"] == "heuristic"
+    assert m["s_source"] == "heuristic"
+    assert m["coherence_source"] == "manifold"
+
+
+@pytest.mark.asyncio
+async def test_enrichment_resource_form_when_tokens_provided():
+    ctx = UpdateContext()
+    ctx.arguments = {"response_tokens": 200, "response_seconds": 2.0}
+    ctx.result = {"metrics": {"E": 0.5, "I": 0.5, "S": 0.5, "coherence": 0.6}}
+    ctx.response_data = {}
+
+    await enrich_grounding(ctx)
+
+    assert ctx.result["metrics"]["e_source"] == "resource"
+    assert ctx.result["metrics"]["E_legacy"] == 0.5
+
+
+@pytest.mark.asyncio
+async def test_enrichment_never_raises_on_missing_metrics():
+    """Enrichment must be fail-safe — missing metrics dict must not break pipeline."""
+    ctx = UpdateContext()
+    ctx.result = {}
+    ctx.response_data = {}
+
+    await enrich_grounding(ctx)
+
+    assert isinstance(ctx.result, dict)
+
+
+@pytest.mark.asyncio
+async def test_enrichment_does_not_touch_v():
+    """Invariant: V stays exactly as it was — Phase 1 does not ground V."""
+    ctx = UpdateContext()
+    ctx.result = {"metrics": {"E": 0.6, "I": 0.7, "S": 0.3, "V": -0.1, "coherence": 0.72}}
+    ctx.response_data = {}
+
+    await enrich_grounding(ctx)
+
+    assert ctx.result["metrics"]["V"] == -0.1
+    assert "V_legacy" not in ctx.result["metrics"]
+
+
+@pytest.mark.asyncio
+async def test_enrichment_idempotent_on_double_run():
+    """Running twice must not chain the swap — *_legacy stays the original legacy."""
+    ctx = UpdateContext()
+    ctx.result = {"metrics": {"E": 0.6, "I": 0.7, "S": 0.3, "V": -0.1, "coherence": 0.72}}
+    ctx.response_data = {}
+
+    await enrich_grounding(ctx)
+    legacy_after_first = {
+        k: v for k, v in ctx.result["metrics"].items() if k.endswith("_legacy")
+    }
+    await enrich_grounding(ctx)
+    legacy_after_second = {
+        k: v for k, v in ctx.result["metrics"].items() if k.endswith("_legacy")
+    }
+
+    assert legacy_after_first == legacy_after_second, "second run must not re-wrap"

--- a/tests/test_grounding_enrichment.py
+++ b/tests/test_grounding_enrichment.py
@@ -82,6 +82,49 @@ async def test_enrichment_does_not_touch_v():
 
 
 @pytest.mark.asyncio
+async def test_enrichment_records_agent_class():
+    """Agent class is classified and surfaced on the metrics block."""
+    from types import SimpleNamespace
+    ctx = UpdateContext()
+    ctx.meta = SimpleNamespace(label="Lumen", tags=["embodied", "persistent"])
+    ctx.result = {"metrics": {"E": 0.6, "I": 0.7, "S": 0.3, "V": -0.1, "coherence": 0.72}}
+    ctx.response_data = {}
+
+    await enrich_grounding(ctx)
+
+    # Class is set on ctx and surfaced on metrics
+    assert ctx.agent_class == "Lumen"
+    assert ctx.result["metrics"]["agent_class"] == "Lumen"
+
+
+@pytest.mark.asyncio
+async def test_enrichment_classifies_unrecognized_as_default():
+    from types import SimpleNamespace
+    ctx = UpdateContext()
+    ctx.meta = SimpleNamespace(label="some_session_agent", tags=[])
+    ctx.result = {"metrics": {"E": 0.5, "I": 0.5, "S": 0.5, "coherence": 0.6}}
+    ctx.response_data = {}
+
+    await enrich_grounding(ctx)
+
+    assert ctx.agent_class == "default"
+    assert ctx.result["metrics"]["agent_class"] == "default"
+
+
+@pytest.mark.asyncio
+async def test_enrichment_handles_missing_meta():
+    """Enrichment must not crash when ctx has no meta attribute set."""
+    ctx = UpdateContext()
+    # ctx.meta defaults to None
+    ctx.result = {"metrics": {"E": 0.5, "I": 0.5, "S": 0.5, "coherence": 0.6}}
+    ctx.response_data = {}
+
+    await enrich_grounding(ctx)
+
+    assert ctx.agent_class == "default"
+
+
+@pytest.mark.asyncio
 async def test_enrichment_idempotent_on_double_run():
     """Running twice must not chain the swap — *_legacy stays the original legacy."""
     ctx = UpdateContext()

--- a/tests/test_grounding_entropy.py
+++ b/tests/test_grounding_entropy.py
@@ -1,0 +1,44 @@
+"""Tests for the entropy grounding module."""
+import pytest
+from unittest.mock import MagicMock
+
+from src.grounding.entropy import compute_entropy
+from src.grounding.types import GroundedValue
+
+
+def _mk_ctx(arguments=None):
+    ctx = MagicMock()
+    ctx.arguments = arguments or {}
+    return ctx
+
+
+def test_tier3_heuristic_wraps_legacy_s():
+    result = compute_entropy(_mk_ctx(), metrics={"S": 0.42})
+    assert isinstance(result, GroundedValue)
+    assert result.source == "heuristic"
+    assert result.value == 0.42
+
+
+def test_tier3_missing_metric_returns_neutral():
+    result = compute_entropy(_mk_ctx(), metrics={})
+    assert result.source == "heuristic"
+    assert result.value == 0.5
+
+
+def test_tier3_clamps_out_of_range_metric():
+    assert compute_entropy(_mk_ctx(), metrics={"S": 1.3}).value == 1.0
+    assert compute_entropy(_mk_ctx(), metrics={"S": -0.05}).value == 0.0
+
+
+def test_tier1_logprobs_stub_falls_through_to_heuristic():
+    ctx = _mk_ctx(arguments={"logprobs": [[-0.1, -0.3, -0.8]]})
+    result = compute_entropy(ctx, metrics={"S": 0.2})
+    assert result.source == "heuristic"
+    assert result.value == 0.2
+
+
+def test_tier2_samples_stub_falls_through_to_heuristic():
+    ctx = _mk_ctx(arguments={"samples": ["a", "b", "c"]})
+    result = compute_entropy(ctx, metrics={"S": 0.3})
+    assert result.source == "heuristic"
+    assert result.value == 0.3

--- a/tests/test_grounding_free_energy.py
+++ b/tests/test_grounding_free_energy.py
@@ -1,0 +1,59 @@
+"""Tests for the free-energy (E) grounding module."""
+import pytest
+from unittest.mock import MagicMock
+
+from src.grounding.free_energy import compute_free_energy
+from src.grounding.types import GroundedValue
+
+
+def _mk_ctx(arguments=None, response_text=""):
+    ctx = MagicMock()
+    ctx.arguments = arguments or {}
+    ctx.response_text = response_text
+    return ctx
+
+
+def test_resource_form_uses_explicit_tokens_and_seconds():
+    ctx = _mk_ctx(arguments={"response_tokens": 400, "response_seconds": 4.0})
+    result = compute_free_energy(ctx, metrics={})
+    assert result.source == "resource"
+    assert abs(result.value - 0.5) < 0.01
+
+
+def test_resource_form_caps_at_one():
+    ctx = _mk_ctx(arguments={"response_tokens": 10000, "response_seconds": 1.0})
+    result = compute_free_energy(ctx, metrics={})
+    assert result.value == 1.0
+
+
+def test_resource_form_handles_zero_seconds():
+    ctx = _mk_ctx(arguments={"response_tokens": 100, "response_seconds": 0.0})
+    result = compute_free_energy(ctx, metrics={"E": 0.6})
+    assert result.source == "heuristic"
+    assert result.value == 0.6
+
+
+def test_fep_stub_falls_through_to_resource():
+    ctx = _mk_ctx(
+        arguments={
+            "response_tokens": 200,
+            "response_seconds": 2.0,
+            "expected_outcome": {"value": 0.7},
+            "observed_outcome": {"value": 0.6},
+        }
+    )
+    result = compute_free_energy(ctx, metrics={})
+    assert result.source == "resource"
+
+
+def test_heuristic_when_nothing_present():
+    ctx = _mk_ctx()
+    result = compute_free_energy(ctx, metrics={"E": 0.42})
+    assert result.source == "heuristic"
+    assert result.value == 0.42
+
+
+def test_heuristic_clamps_out_of_range():
+    ctx = _mk_ctx()
+    assert compute_free_energy(ctx, metrics={"E": 1.5}).value == 1.0
+    assert compute_free_energy(ctx, metrics={"E": -0.3}).value == 0.0

--- a/tests/test_grounding_mutual_info.py
+++ b/tests/test_grounding_mutual_info.py
@@ -1,0 +1,43 @@
+"""Tests for the mutual-information grounding module."""
+import pytest
+from unittest.mock import MagicMock
+
+from src.grounding.mutual_info import compute_mutual_info
+from src.grounding.types import GroundedValue
+
+
+def _mk_ctx(arguments=None):
+    ctx = MagicMock()
+    ctx.arguments = arguments or {}
+    return ctx
+
+
+def test_tier3_heuristic_wraps_legacy_i():
+    result = compute_mutual_info(_mk_ctx(), metrics={"I": 0.73})
+    assert result.source == "heuristic"
+    assert result.value == 0.73
+
+
+def test_tier3_missing_metric_returns_neutral():
+    result = compute_mutual_info(_mk_ctx(), metrics={})
+    assert result.source == "heuristic"
+    assert result.value == 0.5
+
+
+def test_tier3_clamps_out_of_range():
+    assert compute_mutual_info(_mk_ctx(), {"I": 1.2}).value == 1.0
+    assert compute_mutual_info(_mk_ctx(), {"I": -0.1}).value == 0.0
+
+
+def test_tier1_stub_falls_through():
+    ctx = _mk_ctx(arguments={"logprobs": [[-0.1]], "context_logprobs": [[-0.2]]})
+    result = compute_mutual_info(ctx, metrics={"I": 0.4})
+    assert result.source == "heuristic"
+    assert result.value == 0.4
+
+
+def test_tier2_stub_falls_through():
+    ctx = _mk_ctx(arguments={"samples": ["a", "b"]})
+    result = compute_mutual_info(ctx, metrics={"I": 0.5})
+    assert result.source == "heuristic"
+    assert result.value == 0.5

--- a/tests/test_grounding_scale_constants.py
+++ b/tests/test_grounding_scale_constants.py
@@ -40,11 +40,51 @@ def test_scale_constants_are_finite_floats():
         assert sc.value > 0
 
 
-def test_placeholder_provenance_flagged_loudly():
-    """Phase 1 ships all placeholders — this test flips when Phase 2 measures land."""
+def test_fleet_defaults_remain_placeholder():
+    """Fleet-wide ALL_SCALE_CONSTANTS are placeholders (fallback only).
+
+    Class-conditional constants in DELTA_NORM_MAX_BY_CLASS carry the
+    measured values; fleet defaults exist only as a fallback for
+    unclassified agents.
+    """
     placeholders = [sc for sc in ALL_SCALE_CONSTANTS if sc.provenance == "placeholder"]
     assert len(placeholders) == len(ALL_SCALE_CONSTANTS)
 
 
-def test_delta_norm_max_covers_full_state_space_diagonal():
+def test_class_conditional_delta_norm_max_is_measured():
+    """Phase 2 measurement populated DELTA_NORM_MAX_BY_CLASS with measured values."""
+    from config.governance_config import DELTA_NORM_MAX_BY_CLASS
+    assert len(DELTA_NORM_MAX_BY_CLASS) >= 5  # Lumen, default, Sentinel, Vigil, Watcher
+    for cls_name, sc in DELTA_NORM_MAX_BY_CLASS.items():
+        assert sc.provenance == "measured", (
+            f"class-conditional {cls_name} should be measured, got {sc.provenance}"
+        )
+        assert sc.corpus_size > 0
+        assert sc.percentile == 95
+
+
+def test_class_conditional_lookup_falls_back_for_unknown_classes():
+    """Unknown class falls back to fleet-wide DELTA_NORM_MAX_DEFAULT."""
+    from config.governance_config import (
+        get_delta_norm_max, DELTA_NORM_MAX_DEFAULT,
+    )
+    assert get_delta_norm_max("nonexistent_class") is DELTA_NORM_MAX_DEFAULT
+    assert get_delta_norm_max("Lumen").provenance == "measured"
+
+
+def test_healthy_operating_point_class_conditional():
+    """Per-class healthy points exist for measured classes; default for others."""
+    from config.governance_config import (
+        get_healthy_operating_point, HEALTHY_OPERATING_POINT_DEFAULT,
+    )
+    lumen_hop = get_healthy_operating_point("Lumen")
+    assert lumen_hop != HEALTHY_OPERATING_POINT_DEFAULT
+    assert all(0.0 <= v <= 1.0 for v in lumen_hop)
+
+    unknown_hop = get_healthy_operating_point("nonexistent")
+    assert unknown_hop == HEALTHY_OPERATING_POINT_DEFAULT
+
+
+def test_delta_norm_max_default_covers_full_state_space_diagonal():
+    """Fleet-wide default must allow full diagonal so unclassified agents can hit C=0."""
     assert DELTA_NORM_MAX.value >= math.sqrt(3) - 0.01

--- a/tests/test_grounding_scale_constants.py
+++ b/tests/test_grounding_scale_constants.py
@@ -1,0 +1,50 @@
+"""Tests for grounding scale constants — provenance invariants.
+
+Spec §3.4 requires every scale constant to carry measurement metadata.
+These tests enforce that requirement at import time.
+"""
+import math
+
+import pytest
+
+from config.governance_config import (
+    ScaleConstant,
+    S_SCALE,
+    I_SCALE,
+    E_SCALE,
+    DELTA_NORM_MAX,
+    ALL_SCALE_CONSTANTS,
+)
+
+
+def test_scale_constant_has_required_fields():
+    sc = S_SCALE
+    assert sc.value > 0
+    assert sc.measured_on
+    assert sc.corpus_size >= 0
+    assert sc.percentile in {50, 75, 90, 95, 99, None}
+    assert sc.provenance in {"measured", "placeholder", "derived"}
+
+
+def test_all_constants_registered_in_manifest():
+    assert S_SCALE in ALL_SCALE_CONSTANTS
+    assert I_SCALE in ALL_SCALE_CONSTANTS
+    assert E_SCALE in ALL_SCALE_CONSTANTS
+    assert DELTA_NORM_MAX in ALL_SCALE_CONSTANTS
+
+
+def test_scale_constants_are_finite_floats():
+    for sc in ALL_SCALE_CONSTANTS:
+        assert isinstance(sc.value, float)
+        assert math.isfinite(sc.value)
+        assert sc.value > 0
+
+
+def test_placeholder_provenance_flagged_loudly():
+    """Phase 1 ships all placeholders — this test flips when Phase 2 measures land."""
+    placeholders = [sc for sc in ALL_SCALE_CONSTANTS if sc.provenance == "placeholder"]
+    assert len(placeholders) == len(ALL_SCALE_CONSTANTS)
+
+
+def test_delta_norm_max_covers_full_state_space_diagonal():
+    assert DELTA_NORM_MAX.value >= math.sqrt(3) - 0.01

--- a/tests/test_grounding_types.py
+++ b/tests/test_grounding_types.py
@@ -1,0 +1,40 @@
+"""Tests for GroundedValue dataclass — the shared return type for grounding modules."""
+import pytest
+from dataclasses import FrozenInstanceError
+
+from src.grounding.types import GroundedValue, ALLOWED_SOURCES
+
+
+def test_valid_construction():
+    gv = GroundedValue(value=0.42, source="heuristic")
+    assert gv.value == 0.42
+    assert gv.source == "heuristic"
+
+
+def test_all_allowed_sources_accepted():
+    for source in ALLOWED_SOURCES:
+        gv = GroundedValue(value=0.1, source=source)
+        assert gv.source == source
+
+
+def test_unknown_source_rejected():
+    with pytest.raises(ValueError, match="unknown grounding source"):
+        GroundedValue(value=0.5, source="banana")
+
+
+def test_value_out_of_range_rejected():
+    with pytest.raises(ValueError, match="out of range"):
+        GroundedValue(value=1.5, source="heuristic")
+    with pytest.raises(ValueError, match="out of range"):
+        GroundedValue(value=-0.1, source="heuristic")
+
+
+def test_frozen():
+    gv = GroundedValue(value=0.5, source="heuristic")
+    with pytest.raises(FrozenInstanceError):
+        gv.value = 0.7  # type: ignore[misc]
+
+
+def test_as_dict_shape():
+    gv = GroundedValue(value=0.3, source="manifold")
+    assert gv.as_dict() == {"value": 0.3, "source": "manifold"}


### PR DESCRIPTION
## Summary

Grounds the EISV state vector in Shannon information theory + variational free energy. Replaces the thermodynamic-shaped metaphor with computable quantities paired with provenance. Ships the spec (§1-§7) plus Phase 1 server-side scaffolding.

**Spec:** `docs/specs/2026-04-17-eisv-grounding-design.md`
**Plan:** `docs/plans/2026-04-18-eisv-grounding-phase-1-plan.md`

## What Phase 1 ships

New `src/grounding/` package — 5 modules, all pure functions:

- `types.py` — `GroundedValue(value, source)` with source whitelist + range check
- `entropy.py` — S: logprob / multisample / heuristic tiers
- `mutual_info.py` — I: same tiered pattern
- `free_energy.py` — E: FEP-stub + resource-rate + heuristic (resource form is primary)
- `coherence.py` — C: KL-stub + manifold form + heuristic (manifold is primary)

`config/governance_config.py` gains a `ScaleConstant` dataclass with measurement provenance and four constants (`S_SCALE`, `I_SCALE`, `E_SCALE`, `DELTA_NORM_MAX`) — all `provenance="placeholder"` until Phase 2 runs the §3.4 calibration protocol.

`src/mcp_handlers/updates/enrichments.py` gains `enrich_grounding` at `order=75`. It swaps grounded values into canonical `E/I/S/coherence` slots and preserves originals as `E_legacy/I_legacy/S_legacy/coherence_legacy`. `V` is untouched (Phase 1 does not dual-compute V).

## Why "no behavior change user-visible" holds

Gating (basin classification, verdict logic) runs in `phases.py` **before** the enrichment pipeline. The grounding enrichment runs at `order=75`, so verdicts are computed on legacy values before the swap. Only the response payload carries grounded values in the canonical slot.

Dashboards and broadcasters will see grounded values in `E/I/S/coherence` — expected; that's the point of Phase 1 dual-compute. Legacy values remain available under `*_legacy` for comparison.

## Tier-1 and Tier-2 status

Logprob (tier-1) and multi-sample (tier-2) entry points exist as `NotImplementedError` stubs. The dispatcher catches the stub raise and falls through to tier-3 (heuristic / resource / manifold). Plugin-side instrumentation to capture logprobs is a follow-up PR.

## Tests

35 new tests across 8 files, all green:
- `test_grounding_types.py` (6)
- `test_grounding_entropy.py` (5)
- `test_grounding_mutual_info.py` (5)
- `test_grounding_free_energy.py` (6)
- `test_grounding_coherence.py` (5)
- `test_grounding_scale_constants.py` (5)
- `test_grounding_enrichment.py` (5 — unit-level enrichment)
- `test_grounding_end_to_end.py` (2 — full enrichment pipeline)

Plus a count bump in `test_enrichment_pipeline.py` (28 → 29) to acknowledge the new enrichment.

## Deferred to follow-up PRs (documented in spec appendix)

- Tier-1 (logprob) capture — plugin-side instrumentation.
- Tier-2 (multi-sample) estimator — needs a semantic-equivalence classifier.
- **§4 audit payload side-by-side** — `record_tool_usage` doesn't take a payload blob today; threading it through would touch the dispatcher (`mcp_server_std.py`, `http_tool_service.py`) and the `record_tool_usage` / `append_tool_usage_async` signatures. Phase 2 calibration can read legacy+grounded from the live broadcaster event stream in the meantime.
- Phase 2 calibration measurement (§3.4 reference corpus).
- ODE coefficient re-fit.
- Paper v5 tex updates (§6).
- V grounding / internal `void` → `free_energy_debt` rename (§3.1 V — cosmetic).

## Open questions (from spec §7)

- Logprob access on Claude Code's inference path — affects whether tier-1 is primary or secondary in follow-up.
- Reference distribution scope — per-agent vs per-deployment vs per-model.
- Resource-form E vs FEP-form E default once FEP ships.
- Named reviewer with FEP / stat-mech background before v5 paper goes to arXiv.
- Codex plugin owner sign-off on dual-compute.

## Heads-up for reviewers

This branch is ~62 files behind master (pre-existing, unrelated to grounding work). One existing test (`test_unitares_cli_script.py::test_update_returns_verdict`) fails here but passes on master — caused by a stale `scripts/unitares` on this branch, not by anything in this PR. Rebase on master is a separate task.

## Test plan

- [ ] `pytest tests/test_grounding_*.py -v` — all new tests green
- [ ] Review spec math (§3) — is the Shannon + FEP framing genuinely grounded?
- [ ] Review §5 interpretation call — verdicts via pipeline ordering rather than field renaming
- [ ] Sign-off on deferring §4 audit payload to a follow-up PR
- [ ] Rebase on master before merge (separate task, or as part of merge)