### PR TITLE
fix(watcher): anchor identity to shared ~/.unitares location

### DIFF
--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -98,29 +98,44 @@ MAX_LOG_LINES = 5000
 # Identity — persistent governance presence
 # ---------------------------------------------------------------------------
 
-SESSION_FILE = PROJECT_ROOT / ".watcher_session"
+# Anchor-scoped: one Watcher identity per host, shared across every git
+# worktree. The legacy per-worktree path (PROJECT_ROOT/.watcher_session)
+# minted a fresh UUID on the first edit in each new worktree, producing
+# N Watchers per developer instead of one.
+SESSION_FILE = Path.home() / ".unitares" / "anchors" / "watcher.json"
+LEGACY_SESSION_FILE = PROJECT_ROOT / ".watcher_session"
 
 _watcher_identity: dict[str, str] | None = None
 
 
 def _load_session() -> dict[str, str]:
-    """Load .watcher_session if it exists."""
+    """Load persistent identity from the anchor, migrating from legacy if needed."""
     if SESSION_FILE.exists():
         try:
             return json.loads(SESSION_FILE.read_text())
         except (json.JSONDecodeError, OSError):
             pass
+    if LEGACY_SESSION_FILE.exists():
+        try:
+            data = json.loads(LEGACY_SESSION_FILE.read_text())
+            SESSION_FILE.parent.mkdir(parents=True, exist_ok=True)
+            SESSION_FILE.write_text(json.dumps(data))
+            log(f"migrated watcher identity from {LEGACY_SESSION_FILE} to {SESSION_FILE}")
+            return data
+        except (json.JSONDecodeError, OSError) as e:
+            log(f"legacy session migration failed: {e}", "warning")
     return {}
 
 
 def _save_session(client_session_id: str, continuity_token: str, agent_uuid: str) -> None:
-    """Persist identity state to .watcher_session."""
+    """Persist identity state to the anchor."""
     data = {
         "client_session_id": client_session_id,
         "continuity_token": continuity_token,
         "agent_uuid": agent_uuid,
     }
     try:
+        SESSION_FILE.parent.mkdir(parents=True, exist_ok=True)
         SESSION_FILE.write_text(json.dumps(data))
     except OSError as e:
         log(f"failed to save session: {e}", "warning")

--- a/agents/watcher/tests/test_agent.py
+++ b/agents/watcher/tests/test_agent.py
@@ -2000,6 +2000,77 @@ class TestWatcherIdentity:
         assert watcher_module.get_watcher_identity() is None
 
 
+class TestSessionAnchor:
+    """SESSION_FILE is a host-scoped anchor, not a per-worktree file.
+
+    Before 2026-04-17 the session file lived at PROJECT_ROOT/.watcher_session.
+    Every worktree had its own copy, so each new worktree's first edit minted
+    a fresh UUID — one Watcher per worktree instead of one per host. The
+    anchor at ~/.unitares/anchors/watcher.json fixes that by being shared
+    across all worktrees.
+    """
+
+    def test_default_session_file_is_home_anchor(self, watcher_module):
+        """Default SESSION_FILE is ~/.unitares/anchors/watcher.json, not PROJECT_ROOT-scoped."""
+        expected = Path.home() / ".unitares" / "anchors" / "watcher.json"
+        assert watcher_module.SESSION_FILE == expected
+
+    def test_legacy_session_file_is_project_root(self, watcher_module):
+        """LEGACY_SESSION_FILE still resolves to the old per-worktree path for migration."""
+        assert watcher_module.LEGACY_SESSION_FILE.name == ".watcher_session"
+
+    def test_save_session_creates_anchor_parent_dir(self, watcher_module, tmp_path, monkeypatch):
+        """_save_session mkdirs the anchor parent if missing."""
+        anchor = tmp_path / "nonexistent" / "anchors" / "watcher.json"
+        monkeypatch.setattr(watcher_module, "SESSION_FILE", anchor)
+
+        watcher_module._save_session("sess", "tok", "uuid-x")
+        assert anchor.exists()
+        data = json.loads(anchor.read_text())
+        assert data["agent_uuid"] == "uuid-x"
+
+    def test_load_session_migrates_from_legacy_when_anchor_missing(
+        self, watcher_module, tmp_path, monkeypatch
+    ):
+        """If anchor is missing but legacy file exists, migrate it and return its contents."""
+        anchor = tmp_path / "anchor.json"
+        legacy = tmp_path / "legacy" / ".watcher_session"
+        legacy.parent.mkdir()
+        legacy.write_text(json.dumps({"agent_uuid": "uuid-legacy", "continuity_token": "t-legacy"}))
+
+        monkeypatch.setattr(watcher_module, "SESSION_FILE", anchor)
+        monkeypatch.setattr(watcher_module, "LEGACY_SESSION_FILE", legacy)
+
+        data = watcher_module._load_session()
+        assert data["agent_uuid"] == "uuid-legacy"
+        assert anchor.exists(), "migration should have written the anchor"
+        assert json.loads(anchor.read_text())["agent_uuid"] == "uuid-legacy"
+
+    def test_load_session_prefers_anchor_over_legacy(
+        self, watcher_module, tmp_path, monkeypatch
+    ):
+        """When both exist, the anchor wins — legacy is ignored."""
+        anchor = tmp_path / "anchor.json"
+        anchor.write_text(json.dumps({"agent_uuid": "uuid-anchor"}))
+        legacy = tmp_path / "legacy.watcher_session"
+        legacy.write_text(json.dumps({"agent_uuid": "uuid-legacy"}))
+
+        monkeypatch.setattr(watcher_module, "SESSION_FILE", anchor)
+        monkeypatch.setattr(watcher_module, "LEGACY_SESSION_FILE", legacy)
+
+        data = watcher_module._load_session()
+        assert data["agent_uuid"] == "uuid-anchor"
+
+    def test_load_session_returns_empty_when_neither_exists(
+        self, watcher_module, tmp_path, monkeypatch
+    ):
+        """No anchor, no legacy → empty dict (caller will Fresh Onboard)."""
+        monkeypatch.setattr(watcher_module, "SESSION_FILE", tmp_path / "missing.json")
+        monkeypatch.setattr(watcher_module, "LEGACY_SESSION_FILE", tmp_path / "also-missing")
+
+        assert watcher_module._load_session() == {}
+
+
 class TestMainIdentityWiring:
     """main() calls resolve_identity before dispatching subcommands."""
 


### PR DESCRIPTION
## Summary

Watcher identity storage was per-worktree (`PROJECT_ROOT/.watcher_session`), which minted a fresh UUID on every new worktree's first edit. Over a day of active development that produced 6+ concurrent Watcher UUIDs (`Watcher_7853080d`, `Watcher_d9bec102`, etc.) all claiming to be canonical.

Move anchor to `~/.unitares/anchors/watcher.json` — one per host, shared across worktrees. Migrate from legacy on first read.

## Why this happened

- \`SESSION_FILE = PROJECT_ROOT / ".watcher_session"\` (agent.py:101)
- \`PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent\` (agent.py:62)
- The plugin's post-edit hook invokes \`${PWD}/agents/watcher/watcher-hook.sh\` — PWD being Claude's current worktree
- Each git worktree resolves PROJECT_ROOT to itself, gets its own .watcher_session, and falls through to Fresh Onboard when that file is missing
- The 2026-04-16 PATH 0 fix only works when a stored UUID exists to resume from — per-worktree storage guaranteed new worktrees never had one

## Diff

- \`agents/watcher/agent.py\`: SESSION_FILE now anchors on \$HOME; LEGACY_SESSION_FILE preserved for one-shot migration; \`_save_session\` mkdirs parent; \`_load_session\` migrates legacy when anchor absent
- \`agents/watcher/tests/test_agent.py\`: 6 new tests (default location, save-mkdir, legacy migration, anchor precedence, empty-both)

## Test plan

- [x] \`pytest agents/watcher/tests/test_agent.py\` — 110 passed (104 existing + 6 new)
- [x] Full suite: 6227 passed, 52 skipped
- [ ] Post-merge: manually seed \`~/.unitares/anchors/watcher.json\` with the canonical Watcher UUID (\`907e3195\`, 200 updates) before any new edits fire — otherwise migration will propagate the ghost UUID currently in the main repo's \`.watcher_session\`
- [ ] Post-merge: archive the 5 ghost Watcher_<uuid8> agents

## Follow-ups (separate PRs)

- **unitares-governance-plugin**: session-start writes a Claude Code anchor; update SessionStart text to explicitly instruct \`identity(agent_uuid=..., resume=true)\` as first MCP tool call (verified working — flipped my session's \`agent_signature\` from ghost to canonical)
- **src/mcp_handlers/middleware**: transport binding becomes lookup-not-creator (high blast radius, needs plan + grace period)