### PR TITLE
fix(identity): dual-label visibility — surface label_source in agent_signature

### DIFF
--- a/src/mcp_handlers/support/agent_auth.py
+++ b/src/mcp_handlers/support/agent_auth.py
@@ -55,6 +55,24 @@ def compute_agent_signature(
             signature["display_name"] = display_label
         elif auto_id:
             signature["agent_id"] = auto_id
+
+        # Dual-label visibility (identity-invariants #4: "Name is cosmetic").
+        # label_source surfaces whether the displayed label reflects an
+        # explicit choice by the agent or a server-derived auto-fill:
+        #   "claimed" — label differs from auto-derived IDs, agent picked it
+        #   "auto"    — label equals public_agent_id/structured_id, or the
+        #               label is absent and the signature displays auto_id
+        #   "uuid"    — neither label nor auto_id; display falls back to UUID
+        # Heuristic (no schema change): identity is inferred from whether
+        # the label matches known auto patterns. A future schema change can
+        # replace this with an explicit label_claimed_at timestamp on the
+        # agent metadata row.
+        if display_label and display_label not in (public_agent_id, structured_id):
+            signature["label_source"] = "claimed"
+        elif display_label or auto_id:
+            signature["label_source"] = "auto"
+        else:
+            signature["label_source"] = "uuid"
         return signature
 
     except Exception as e:

--- a/tests/test_mcp_utils.py
+++ b/tests/test_mcp_utils.py
@@ -51,10 +51,12 @@ def _mock_server(meta=None):
     return s
 
 def _meta(status="active", label=None, structured_id=None,
-          display_name=None, paused_at=None, agent_uuid=None, tags=None):
+          display_name=None, paused_at=None, agent_uuid=None, tags=None,
+          public_agent_id=None):
     return SimpleNamespace(status=status, label=label, structured_id=structured_id,
                            display_name=display_name, paused_at=paused_at,
-                           agent_uuid=agent_uuid, tags=tags or [])
+                           agent_uuid=agent_uuid, tags=tags or [],
+                           public_agent_id=public_agent_id)
 
 
 class TestInferErrorCodeAndCategory:
@@ -201,6 +203,49 @@ class TestComputeAgentSignature:
     @patch("src.mcp_handlers.context.get_context_agent_id", side_effect=Exception("boom"))
     def test_exception_safe(self, mock_ctx):
         assert compute_agent_signature(agent_id="x") == {"uuid": None}
+
+    # ---- label_source: dual-label visibility (identity-honesty axiom) ----
+
+    @patch("src.mcp_handlers.context.get_context_agent_id")
+    @patch("src.mcp_handlers.shared.get_mcp_server")
+    def test_label_source_claimed_when_label_differs_from_auto_ids(self, mock_srv, mock_ctx):
+        """Agent-chosen label (differs from public_agent_id/structured_id) → claimed."""
+        mock_ctx.return_value = "uuid-1"
+        mock_srv.return_value = _mock_server({
+            "uuid-1": _meta(label="hikewa", public_agent_id="Claude_Code_20260417", structured_id="mcp_20260417"),
+        })
+        sig = compute_agent_signature()
+        assert sig["agent_id"] == "hikewa"
+        assert sig["label_source"] == "claimed"
+
+    @patch("src.mcp_handlers.context.get_context_agent_id")
+    @patch("src.mcp_handlers.shared.get_mcp_server")
+    def test_label_source_auto_when_label_matches_public_agent_id(self, mock_srv, mock_ctx):
+        """Label equals the auto-derived public_agent_id → auto."""
+        mock_ctx.return_value = "uuid-2"
+        mock_srv.return_value = _mock_server({
+            "uuid-2": _meta(label="Claude_Code_20260417", public_agent_id="Claude_Code_20260417"),
+        })
+        sig = compute_agent_signature()
+        assert sig["label_source"] == "auto"
+
+    @patch("src.mcp_handlers.context.get_context_agent_id")
+    @patch("src.mcp_handlers.shared.get_mcp_server")
+    def test_label_source_auto_when_only_structured_id(self, mock_srv, mock_ctx):
+        """No label, only structured_id → auto."""
+        mock_ctx.return_value = "uuid-3"
+        mock_srv.return_value = _mock_server({"uuid-3": _meta(structured_id="mcp_20260417")})
+        sig = compute_agent_signature()
+        assert sig["label_source"] == "auto"
+
+    @patch("src.mcp_handlers.context.get_context_agent_id")
+    @patch("src.mcp_handlers.shared.get_mcp_server")
+    def test_label_source_uuid_when_nothing_else(self, mock_srv, mock_ctx):
+        """No label, no auto IDs → display is UUID, label_source reflects that."""
+        mock_ctx.return_value = "uuid-4"
+        mock_srv.return_value = _mock_server({"uuid-4": _meta()})
+        sig = compute_agent_signature()
+        assert sig["label_source"] == "uuid"
 
 
 class TestCheckAgentCanOperate:


### PR DESCRIPTION
## Summary

Part of tonight's identity-honesty series. Adds a \`label_source\` field to every \`agent_signature\` so callers can distinguish agent-claimed labels from server auto-fills without having to compare fields themselves.

## Background

Identity invariant #4 (\`~/.claude/.../identity-invariants.md\`): *\"Name is cosmetic, never a resolution key.\"* But until now, the \`display_name\` field carried both claimed labels (\`Lumen\`, \`Sentinel\`) and auto-fills (\`Watcher_d9bec102\`, \`opus_hikewa_claude_ai_20260416\`) with no way to tell them apart in responses. That asymmetry is the root of the \"how did this ghost get named that?\" confusion.

## Change

\`compute_agent_signature\` now emits one of three values in \`label_source\`:

| value | meaning |
|---|---|
| \`claimed\` | label differs from \`public_agent_id\` and \`structured_id\` → agent chose it |
| \`auto\` | label equals an auto id, or only an auto id exists |
| \`uuid\` | no label and no auto id; display falls back to raw UUID |

Heuristic — no schema change. A future migration can replace this with an explicit \`label_claimed_at\` timestamp on \`agent_metadata\`.

## Test plan

- [x] 4 new tests cover all three \`label_source\` branches
- [x] \`TestComputeAgentSignature\`: 10 passing (6 existing + 4 new)
- [x] Full suite: 6375 passed, 33 skipped

## Series

- unitares#27 (merged): watcher anchor → \`~/.unitares/anchors/watcher.json\`
- plugin#4 (merged): explicit first-call \`identity()\` bind instruction in SessionStart
- plugin#5 (auto-merge): receipt-not-assertion + hostname-fallback removal + \`~/.unitares/display-name\` override + \`\$USER@date\` default
- **this PR**: \`label_source\` in signature
- Deferred to next session: session-start stops creating identities altogether (structural Part C)