### PR TITLE
fix(agents): anchor Vigil + Sentinel identities to ~/.unitares/anchors/

### DIFF
--- a/agents/sdk/src/unitares_sdk/agent.py
+++ b/agents/sdk/src/unitares_sdk/agent.py
@@ -70,6 +70,7 @@ class GovernanceAgent:
         mcp_url: str = "http://127.0.0.1:8767/mcp/",
         state_dir: Path | None = None,
         session_file: Path | None = None,
+        legacy_session_file: Path | None = None,
         notify_on_error: bool = True,
         timeout: float = 30.0,
         parent_agent_id: str | None = None,
@@ -84,7 +85,14 @@ class GovernanceAgent:
         name_lower = name.lower()
         default_root = Path(__file__).resolve().parent.parent.parent.parent.parent
         self.state_dir = state_dir or default_root / "data" / name_lower
-        self.session_file = session_file or default_root / f".{name_lower}_session"
+        # Host-scoped anchor default: one identity per role per host, shared
+        # across every git worktree or install path (Watcher/Vigil/Sentinel
+        # previously minted a new UUID per install-path-relative session
+        # file). Subclasses override session_file+legacy_session_file pair.
+        self.session_file = session_file or (
+            Path.home() / ".unitares" / "anchors" / f"{name_lower}.json"
+        )
+        self.legacy_session_file = legacy_session_file
 
         # Opt-in lineage: when set, forwarded to the server on fresh onboard
         # so spawned agents are distinguishable from unrelated siblings.
@@ -233,7 +241,24 @@ class GovernanceAgent:
     # --- Session persistence ---
 
     def _load_session(self) -> None:
-        """Load session state from disk."""
+        """Load session state, migrating from legacy location if needed."""
+        if (
+            not self.session_file.exists()
+            and self.legacy_session_file
+            and self.legacy_session_file.exists()
+        ):
+            try:
+                legacy_data = load_json_state(self.legacy_session_file)
+                if legacy_data:
+                    self.session_file.parent.mkdir(parents=True, exist_ok=True)
+                    save_json_state(self.session_file, legacy_data)
+                    logger.info(
+                        "%s: migrated session from %s to %s",
+                        self.name, self.legacy_session_file, self.session_file,
+                    )
+            except Exception as e:
+                logger.warning("%s: legacy session migration failed: %s", self.name, e)
+
         saved = load_json_state(self.session_file)
         if saved.get("client_session_id"):
             self.client_session_id = saved["client_session_id"]
@@ -243,7 +268,7 @@ class GovernanceAgent:
             self.agent_uuid = saved["agent_uuid"]
 
     def _save_session(self) -> None:
-        """Persist session state to disk."""
+        """Persist session state to the anchor."""
         data: dict[str, Any] = {}
         if self.client_session_id:
             data["client_session_id"] = self.client_session_id
@@ -251,6 +276,7 @@ class GovernanceAgent:
             data["continuity_token"] = self.continuity_token
         if self.agent_uuid:
             data["agent_uuid"] = self.agent_uuid
+        self.session_file.parent.mkdir(parents=True, exist_ok=True)
         save_json_state(self.session_file, data)
 
     def _sync_from_client(self, client: GovernanceClient) -> None:

--- a/agents/sdk/tests/test_agent.py
+++ b/agents/sdk/tests/test_agent.py
@@ -188,6 +188,52 @@ class TestSessionPersistence:
         agent._load_session()
         assert agent.client_session_id is None
 
+    def test_default_session_file_is_home_anchor(self, tmp_path, monkeypatch):
+        """Without an explicit session_file, default is ~/.unitares/anchors/<name>.json."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        from unitares_sdk.agent import GovernanceAgent
+
+        # Use the real class directly since SimpleAgent may override defaults.
+        class _BareAgent(GovernanceAgent):
+            async def run_cycle(self, client):
+                return None
+
+        agent = _BareAgent(name="TestAgent")
+        expected = Path(tmp_path) / ".unitares" / "anchors" / "testagent.json"
+        assert agent.session_file == expected
+
+    def test_save_creates_anchor_parent_dir(self, tmp_path):
+        """_save_session mkdirs the anchor parent automatically."""
+        anchor = tmp_path / "deep" / "nested" / "anchors" / "x.json"
+        agent = SimpleAgent(session_file=anchor)
+        agent.agent_uuid = "u-1"
+        agent._save_session()
+        assert anchor.exists()
+
+    def test_migrates_from_legacy_when_anchor_missing(self, tmp_path):
+        """Legacy session file is migrated to the anchor on first load."""
+        anchor = tmp_path / "anchor.json"
+        legacy = tmp_path / "legacy.session"
+        legacy.write_text('{"agent_uuid": "u-legacy", "continuity_token": "t-legacy"}')
+
+        agent = SimpleAgent(session_file=anchor, legacy_session_file=legacy)
+        agent._load_session()
+
+        assert agent.agent_uuid == "u-legacy"
+        assert agent.continuity_token == "t-legacy"
+        assert anchor.exists(), "anchor should have been written by migration"
+
+    def test_anchor_wins_over_legacy_when_both_exist(self, tmp_path):
+        """If both anchor and legacy exist, the anchor is the source of truth."""
+        anchor = tmp_path / "anchor.json"
+        anchor.write_text('{"agent_uuid": "u-anchor"}')
+        legacy = tmp_path / "legacy.session"
+        legacy.write_text('{"agent_uuid": "u-legacy"}')
+
+        agent = SimpleAgent(session_file=anchor, legacy_session_file=legacy)
+        agent._load_session()
+        assert agent.agent_uuid == "u-anchor"
+
 
 # --- Check-in handling ---
 

--- a/agents/sentinel/agent.py
+++ b/agents/sentinel/agent.py
@@ -53,7 +53,8 @@ from agents.common.findings import post_finding, compute_fingerprint
 # Paths & Config
 # ---------------------------------------------------------------------------
 
-SESSION_FILE = project_root / ".sentinel_session"
+SESSION_FILE = Path.home() / ".unitares" / "anchors" / "sentinel.json"
+LEGACY_SESSION_FILE = project_root / ".sentinel_session"
 STATE_FILE = project_root / ".sentinel_state"
 LOG_FILE = Path.home() / "Library" / "Logs" / "unitares-sentinel.log"
 MAX_LOG_LINES = 1000
@@ -419,6 +420,7 @@ class SentinelAgent(GovernanceAgent):
             name=label,
             mcp_url=mcp_url,
             session_file=SESSION_FILE,
+            legacy_session_file=LEGACY_SESSION_FILE,
             state_dir=STATE_FILE.parent,
             timeout=30.0,
         )

--- a/agents/vigil/agent.py
+++ b/agents/vigil/agent.py
@@ -52,7 +52,8 @@ from agents.vigil.checks.runner import run_health_checks
 
 # Paths
 ANIMA_PROJECT = Path(os.getenv("ANIMA_PROJECT", str(project_root.parent / "anima-mcp")))
-SESSION_FILE = project_root / ".vigil_session"
+SESSION_FILE = Path.home() / ".unitares" / "anchors" / "vigil.json"
+LEGACY_SESSION_FILE = project_root / ".vigil_session"
 STATE_FILE = project_root / ".vigil_state"
 LOG_FILE = Path.home() / "Library" / "Logs" / "unitares-vigil.log"
 MAX_LOG_LINES = 500
@@ -268,6 +269,7 @@ class VigilAgent(GovernanceAgent):
             name=label,
             mcp_url=mcp_url,
             session_file=SESSION_FILE,
+            legacy_session_file=LEGACY_SESSION_FILE,
             state_dir=STATE_FILE.parent,
             timeout=30.0,
         )


### PR DESCRIPTION
## Summary

Applies the Watcher anchor pattern (unitares#27) to the other two resident agents. SDK-level: \`GovernanceAgent\` defaults \`session_file\` to \`~/.unitares/anchors/<name>.json\` and accepts an optional \`legacy_session_file\` for one-shot migration from the old \`PROJECT_ROOT/.<name>_session\` location.

## Why this is prophylactic

Unlike Watcher — which produced ~5 ghosts per editing session because the post-edit hook fired from worktree-relative paths — Vigil and Sentinel run from launchd at a stable install path. They haven't produced visible ghost swarms. This PR brings them in line with the axiom (one identity per role per host, independent of install path) so moving the repo, changing install paths, or running manually from a different directory cannot mint a new UUID.

Confirmed against the dogfood governance state:
- Vigil current UUID \`e55caaf1-43a7-4fbb-a8fa-c69a9a8f50e4\` (318 updates, no ghost siblings)
- Sentinel current UUID \`f92dcea8-4786-412a-a0eb-362c273382f5\` (1,935 updates, the lone \`Sentinel_72fa6aa1\` ghost was archived earlier tonight)

## What changes

- **\`agents/sdk/src/unitares_sdk/agent.py\`** — default anchor path, optional \`legacy_session_file\` constructor arg, one-shot migration on \`_load_session\`, mkdir-on-save. Future GovernanceAgent subclasses inherit the pattern automatically.
- **\`agents/vigil/agent.py\`** and **\`agents/sentinel/agent.py\`** — \`SESSION_FILE\` → anchor path, \`LEGACY_SESSION_FILE\` preserved for migration, constructor passes both.
- **4 new SDK tests** cover default anchor location, save-mkdir, migration, anchor-precedence.

## Operator action before restart

Anchors seeded from current legacy files so the first post-deploy agent restart resumes cleanly (not fresh-onboards):

\`\`\`bash
cp /Users/cirwel/projects/unitares/.vigil_session ~/.unitares/anchors/vigil.json
cp /Users/cirwel/projects/unitares/.sentinel_session ~/.unitares/anchors/sentinel.json
\`\`\`

Both files already in place on this install — verified via \`ls ~/.unitares/anchors/\` showing \`vigil.json\`, \`sentinel.json\`, \`watcher.json\`, \`steward.json\` with matching UUIDs.

## Test plan

- [x] 4 new SDK tests: \`test_default_session_file_is_home_anchor\`, \`test_save_creates_anchor_parent_dir\`, \`test_migrates_from_legacy_when_anchor_missing\`, \`test_anchor_wins_over_legacy_when_both_exist\`
- [x] Full unitares suite: **6379 passed, 33 skipped** (was 6375)
- [x] Anchor seed verified: Vigil + Sentinel anchors contain canonical UUIDs

## Identity-honesty series status

- unitares#27 Watcher anchor ✅
- unitares#28 label_source visibility ✅
- unitares#29 Part C spec ✅
- plugin#4, #5 — SessionStart clarity + naming ✅
- plugin#6, #7, #8 — Part C A/B/C ✅
- **this PR** — Vigil + Sentinel anchors ✅
- Open: two KG entries (7187b1c0 session_id fragmentation, 3ea27c3a PATH 2.8 rebind) — class of bug, may or may not still be live