### PR TITLE
fix(lifecycle): classify itest-* labels as test agents

### DIFF
--- a/src/agent_metadata_model.py
+++ b/src/agent_metadata_model.py
@@ -54,6 +54,8 @@ def _emit_lifecycle_event(
             _label.startswith("cli-pytest")
             or _label.startswith("test_")
             or _label.startswith("test-")
+            or _label.startswith("itest-")
+            or _label.startswith("itest_")
             or _label.startswith("demo_")
             or "pytest" in _label
         )

--- a/src/mcp_handlers/lifecycle/helpers.py
+++ b/src/mcp_handlers/lifecycle/helpers.py
@@ -63,7 +63,8 @@ def _is_test_agent(agent_id: str, label: str | None = None) -> bool:
     """Identify test/demo agents by naming patterns.
 
     Checks both agent_id and label. CLI-spawned pytest agents use UUIDs
-    as agent_id but contain 'cli-pytest' in the label.
+    as agent_id but contain 'cli-pytest' in the label; integration-test
+    agents from plugin suites use UUIDs and 'itest-*' labels.
 
     Used consistently across list_agents handlers to filter test agents.
     """
@@ -82,7 +83,11 @@ def _is_test_agent(agent_id: str, label: str | None = None) -> bool:
             label_lower.startswith("cli-pytest") or
             label_lower.startswith("test_") or
             label_lower.startswith("test-") or
+            label_lower.startswith("itest-") or
+            label_lower.startswith("itest_") or
             "pytest" in label_lower or
+            "itest" in label_lower.split("-") or
+            "itest" in label_lower.split("_") or
             "test" in label_lower.split("-") or
             "test" in label_lower.split("_")
         ):

--- a/tests/test_handlers_lifecycle.py
+++ b/tests/test_handlers_lifecycle.py
@@ -538,6 +538,13 @@ class TestArchiveOldTestAgents:
                 status="active", label="test-probe-resume-fixture",
                 last_update=recent, total_updates=2,
             ),
+            # itest-plugin label from plugin integration suite — should archive
+            # (see unitares-governance-plugin tests/test_onboard_slot_isolation.py;
+            # operator flagged 2026-04-17 that these accumulate pair-wise per run)
+            "Claude_Code_20260417_d": make_agent_meta(
+                status="active", label="itest-plugin#cbbc29d1_edd06485",
+                last_update=recent, total_updates=1,
+            ),
             # dogfood / genuine work — must NOT archive
             "Claude_20260414_c": make_agent_meta(
                 status="active", label="dogfood-kg-contributor",
@@ -558,7 +565,9 @@ class TestArchiveOldTestAgents:
             data = json.loads(result[0].text)
 
         archived_ids = {a["id"] for a in data["archived_agents"]}
-        assert archived_ids == {"Claude_20260414_a", "Claude_20260414_b"}, (
+        assert archived_ids == {
+            "Claude_20260414_a", "Claude_20260414_b", "Claude_Code_20260417_d",
+        }, (
             f"expected label-based matches only, got {archived_ids}"
         )
         assert "Claude_20260414_c" not in archived_ids, "dogfood label must not match"


### PR DESCRIPTION
## Summary

- Mirror of 47cb71a2 (cli-pytest): the `_is_test_agent` classifier now also matches `itest-` / `itest_` prefixes and the `itest` hyphen/underscore token. Fixes Vigil silently skipping identities created by the plugin integration suite.
- Same one-line mirror in `agent_metadata_model.py` so broadcast suppression stays consistent with the sweep classifier.
- Extends `tests/test_handlers_lifecycle.py::test_archive_matches_on_label_not_just_agent_id` with an `itest-plugin#cbbc29d1_edd06485` case pinned to the real production label format.

## Why

`test_integration_two_slots_get_distinct_uuids` in the plugin suite hits the real governance server with `agent_name="itest-plugin"` and two slots per run. The resulting labels (e.g. `itest-plugin#cbbc29d1_edd06485`) split on `-` into `['itest', 'plugin#...']` — neither token matched the existing classifier, so Vigil never swept them. Operator caught 18 stragglers from 9 runs in a ~3-hour window on 2026-04-17.

This is the backstop. Companion PR on `unitares-governance-plugin` (`fix/itest-teardown`) adds the actual test teardown so the suite stops relying on Vigil to clean up after it.

## Test plan

- [x] `pytest tests/test_handlers_lifecycle.py::TestArchiveOldTestAgents::test_archive_matches_on_label_not_just_agent_id` passes with the new `itest-plugin#...` case in the archive set
- [x] Full lifecycle module (`tests/test_handlers_lifecycle.py tests/test_lifecycle_agents.py`) — 152/152 pass
- [x] Full test-cache.sh — 6375 pass, 33 skip (7 pre-existing `eisv_sync_task` AsyncMock leaks from `test_consolidated_handlers.py` are unrelated to this diff)