### PR TITLE
feat(middleware): UNITARES_MIDDLEWARE_REQUIRE_BIND flag — reject first-call-with-no-auth

### DIFF
--- a/src/mcp_handlers/middleware/identity_step.py
+++ b/src/mcp_handlers/middleware/identity_step.py
@@ -212,6 +212,7 @@ async def resolve_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
     # Unified session key derivation via SessionSignals + derive_session_key()
     from ..context import get_session_signals
     from ..identity.handlers import derive_session_key
+    import os
 
     signals = get_session_signals()
     client_session_id = arguments.get("client_session_id")
@@ -257,6 +258,75 @@ async def resolve_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
     # Invalidate cache on force_new
     if force_new and transport_key:
         invalidate_transport_binding(transport_key)
+
+    # -------------------------------------------------------------------------
+    # UNITARES_MIDDLEWARE_REQUIRE_BIND — identity-honesty follow-up (2026-04-17)
+    #
+    # Identity-honesty KG entry 3ea27c3a (resolved) left a follow-up open:
+    # "Middleware Ephemeral Identity (identity_step.py) still creates its own
+    # ephemerals outside the identity() handler path." The plugin's Part C
+    # took Claude Code out of the auto-onboard business, but the server's
+    # middleware still auto-creates an identity for any first-call-with-no-
+    # auth-signals fingerprint. That produced two visible ghosts tonight:
+    # 1. f319c7f4 after a governance restart wiped the sticky cache
+    # 2. (see ghost list) the "opus_hikewa_claude_ai_*" and dated auto-labels
+    #
+    # This check rejects calls that arrive without explicit auth when flag
+    # is set to "1", and logs-only when set to "log". Default "0" preserves
+    # current behavior — zero client impact until operator flips the flag.
+    #
+    # Identity tools (onboard / identity / bind_session) are always allowed
+    # through since they ARE how a caller establishes identity.
+    # -------------------------------------------------------------------------
+    _require_bind = (os.environ.get("UNITARES_MIDDLEWARE_REQUIRE_BIND", "0") or "0").lower()
+    _is_identity_tool = name in ("onboard", "identity", "bind_session")
+    _has_explicit_signal = bool(
+        (arguments and arguments.get("agent_uuid"))
+        or (arguments and arguments.get("continuity_token"))
+        or (arguments and arguments.get("client_session_id"))
+        or force_new
+        or (signals and (signals.x_agent_id or signals.x_session_id
+                         or signals.x_client_id or signals.oauth_client_id))
+    )
+    if (_require_bind in ("1", "log")
+        and not _is_identity_tool
+        and not _has_explicit_signal):
+        fingerprint = signals.ip_ua_fingerprint if signals else None
+        fp_snippet = (fingerprint[:12] + "...") if fingerprint else "unknown"
+        rejection_reason = (
+            f"Tool '{name}' called without explicit identity binding. "
+            f"No agent_uuid / continuity_token / client_session_id in arguments, "
+            f"no X-Agent-Id / X-Session-ID / X-Client-Id / OAuth-Client-Id header, "
+            f"and no sticky cache match for fingerprint {fp_snippet}."
+        )
+        if _require_bind == "log":
+            logger.warning(
+                f"[REQUIRE_BIND log-only] Would have rejected: {rejection_reason} "
+                f"— flag=log, continuing with auto-bind."
+            )
+        else:
+            logger.info(f"[REQUIRE_BIND reject] {rejection_reason}")
+            from ..utils import error_response
+            return [error_response(
+                "Identity binding required",
+                details={
+                    "error_type": "identity_binding_required",
+                    "tool": name,
+                    "reason": rejection_reason,
+                },
+                recovery={
+                    "action": (
+                        "Invoke `identity(agent_uuid=X, resume=true)` to resume a known identity, "
+                        "or `onboard(purpose=...)` to create a new one, before calling other tools."
+                    ),
+                    "related_tools": ["identity", "onboard", "bind_session"],
+                    "note": (
+                        "UNITARES_MIDDLEWARE_REQUIRE_BIND=1 requires explicit identity "
+                        "declaration. Auto-bind-from-fingerprint is disabled for this "
+                        "deployment."
+                    ),
+                }
+            )]
 
     session_key = await derive_session_key(signals, arguments)
 

--- a/tests/test_sticky_identity.py
+++ b/tests/test_sticky_identity.py
@@ -755,3 +755,218 @@ class TestTransportBindingCacheWarmup:
 
         assert called["persist"] is False
         assert step._transport_identity_cache["sticky:1.2.3.4:x"].agent_uuid == "uuid-warmed"
+
+
+# ============================================================================
+# UNITARES_MIDDLEWARE_REQUIRE_BIND — identity-honesty follow-up
+# ============================================================================
+#
+# The flag addresses KG entry 3ea27c3a's third open follow-up: "Middleware
+# Ephemeral Identity (identity_step.py) still creates its own ephemerals
+# outside the identity() handler path." Default=0 preserves existing behavior
+# (Session A of the rollout); default=1 ships in a follow-up session after an
+# external-client audit.
+# ============================================================================
+
+
+class TestRequireBindFlag:
+    """Flag-gated rejection of first-call-with-no-auth to close the final
+    auto-bind ghost generator."""
+
+    def setup_method(self):
+        _transport_identity_cache.clear()
+
+    @pytest.fixture(autouse=True)
+    def _no_redis_leak(self):
+        """Prior tests in this file persist bindings to Redis via
+        update_transport_binding → _persist_binding_to_redis. Later tests
+        then hit the Redis load path during the sticky-cache miss check
+        and find stale entries. Mock both sides to sandbox each test."""
+        with patch(
+            "src.mcp_handlers.middleware.identity_step._load_binding_from_redis",
+            new_callable=AsyncMock, return_value=None,
+        ):
+            with patch(
+                "src.mcp_handlers.middleware.identity_step._persist_binding_to_redis",
+            ):
+                yield
+
+    @pytest.mark.asyncio
+    async def test_flag_off_preserves_auto_bind(self, monkeypatch):
+        """Default (flag=0 / unset) must not change behavior — existing
+        auto-bind path runs exactly as before."""
+        monkeypatch.delenv("UNITARES_MIDDLEWARE_REQUIRE_BIND", raising=False)
+
+        signals = FakeSignals(ip_ua_fingerprint="1.2.3.4:fresh")
+        ctx = DispatchContext()
+        mock_result = {"agent_uuid": "uuid-auto", "created": True, "source": "created"}
+
+        with patch("src.mcp_handlers.context.get_session_signals", return_value=signals):
+            with patch("src.mcp_handlers.identity.handlers.derive_session_key",
+                       new_callable=AsyncMock, return_value="sk-fresh"):
+                with patch("src.mcp_handlers.identity.handlers.resolve_session_identity",
+                           new_callable=AsyncMock, return_value=mock_result):
+                    with patch("src.mcp_handlers.context.set_session_context", return_value="tok"):
+                        result = await resolve_identity("process_agent_update", {}, ctx)
+
+        assert not isinstance(result, list), "flag off must not short-circuit"
+        _, _, out_ctx = result
+        assert out_ctx.bound_agent_id == "uuid-auto"
+
+    @pytest.mark.asyncio
+    async def test_flag_on_rejects_tool_without_auth(self, monkeypatch):
+        """Flag=1: non-identity tool with no auth signals and no sticky cache
+        match must short-circuit with identity_binding_required."""
+        monkeypatch.setenv("UNITARES_MIDDLEWARE_REQUIRE_BIND", "1")
+
+        signals = FakeSignals(ip_ua_fingerprint="1.2.3.4:fresh")
+        ctx = DispatchContext()
+
+        with patch("src.mcp_handlers.context.get_session_signals", return_value=signals):
+            result = await resolve_identity("process_agent_update", {}, ctx)
+
+        assert isinstance(result, list), "flag on must short-circuit for unbound calls"
+        # Response is list[TextContent]; error_response merges details into top level
+        import json
+        payload = json.loads(result[0].text)
+        assert payload["success"] is False
+        assert payload["error_type"] == "identity_binding_required"
+        assert "identity" in payload["recovery"]["related_tools"]
+
+    @pytest.mark.asyncio
+    async def test_flag_on_allows_identity_tools_through(self, monkeypatch):
+        """Flag=1: identity / onboard / bind_session are ALWAYS allowed — they
+        are the paths that establish identity in the first place."""
+        monkeypatch.setenv("UNITARES_MIDDLEWARE_REQUIRE_BIND", "1")
+
+        signals = FakeSignals(ip_ua_fingerprint="1.2.3.4:fresh")
+        ctx = DispatchContext()
+        mock_result = {"agent_uuid": "uuid-new", "created": True, "source": "created"}
+
+        for tool_name in ("onboard", "identity", "bind_session"):
+            _transport_identity_cache.clear()
+            ctx = DispatchContext()
+            with patch("src.mcp_handlers.context.get_session_signals", return_value=signals):
+                with patch("src.mcp_handlers.identity.handlers.derive_session_key",
+                           new_callable=AsyncMock, return_value="sk-fresh"):
+                    with patch("src.mcp_handlers.identity.handlers.resolve_session_identity",
+                               new_callable=AsyncMock, return_value=mock_result):
+                        with patch("src.mcp_handlers.context.set_session_context", return_value="tok"):
+                            result = await resolve_identity(tool_name, {}, ctx)
+
+            assert not isinstance(result, list), f"{tool_name} must not be rejected"
+
+    @pytest.mark.asyncio
+    async def test_flag_on_allows_continuity_token(self, monkeypatch):
+        """Flag=1: a caller presenting continuity_token IS explicit auth."""
+        monkeypatch.setenv("UNITARES_MIDDLEWARE_REQUIRE_BIND", "1")
+
+        signals = FakeSignals(ip_ua_fingerprint="1.2.3.4:fresh")
+        ctx = DispatchContext()
+        mock_result = {"agent_uuid": "uuid-resumed", "created": False, "source": "token"}
+
+        with patch("src.mcp_handlers.context.get_session_signals", return_value=signals):
+            with patch("src.mcp_handlers.identity.handlers.derive_session_key",
+                       new_callable=AsyncMock, return_value="sk-fresh"):
+                with patch("src.mcp_handlers.identity.handlers.resolve_session_identity",
+                           new_callable=AsyncMock, return_value=mock_result):
+                    with patch("src.mcp_handlers.identity.session.extract_token_agent_uuid",
+                               return_value="uuid-resumed"):
+                        with patch("src.mcp_handlers.context.set_session_context", return_value="tok"):
+                            result = await resolve_identity(
+                                "process_agent_update",
+                                {"continuity_token": "v1.token"},
+                                ctx,
+                            )
+
+        assert not isinstance(result, list), "continuity_token caller must not be rejected"
+
+    @pytest.mark.asyncio
+    async def test_flag_on_allows_client_session_id(self, monkeypatch):
+        """Flag=1: a caller presenting client_session_id IS explicit auth."""
+        monkeypatch.setenv("UNITARES_MIDDLEWARE_REQUIRE_BIND", "1")
+
+        signals = FakeSignals(ip_ua_fingerprint="1.2.3.4:fresh")
+        ctx = DispatchContext()
+        mock_result = {"agent_uuid": "uuid-session", "created": False, "source": "redis"}
+
+        with patch("src.mcp_handlers.context.get_session_signals", return_value=signals):
+            with patch("src.mcp_handlers.identity.handlers.derive_session_key",
+                       new_callable=AsyncMock, return_value="sk-fresh"):
+                with patch("src.mcp_handlers.identity.handlers.resolve_session_identity",
+                           new_callable=AsyncMock, return_value=mock_result):
+                    with patch("src.mcp_handlers.context.set_session_context", return_value="tok"):
+                        result = await resolve_identity(
+                            "process_agent_update",
+                            {"client_session_id": "agent-abc123"},
+                            ctx,
+                        )
+
+        assert not isinstance(result, list), "client_session_id caller must not be rejected"
+
+    @pytest.mark.asyncio
+    async def test_flag_on_allows_sticky_cache_hit(self, monkeypatch):
+        """Flag=1: a prior sticky-cache binding counts as authenticated —
+        the check runs AFTER the sticky cache early-return."""
+        monkeypatch.setenv("UNITARES_MIDDLEWARE_REQUIRE_BIND", "1")
+
+        update_transport_binding("sticky:1.2.3.4:stable", "uuid-pinned", "sk-pinned", "redis")
+        signals = FakeSignals(ip_ua_fingerprint="1.2.3.4:stable")
+        ctx = DispatchContext()
+
+        with patch("src.mcp_handlers.context.get_session_signals", return_value=signals):
+            with patch("src.mcp_handlers.context.set_session_context", return_value="tok"):
+                result = await resolve_identity("process_agent_update", {}, ctx)
+
+        assert not isinstance(result, list), "sticky cache hit must bypass the require-bind check"
+        _, _, out_ctx = result
+        assert out_ctx.bound_agent_id == "uuid-pinned"
+
+    @pytest.mark.asyncio
+    async def test_flag_on_allows_x_session_id_header(self, monkeypatch):
+        """Flag=1: explicit X-Session-ID header counts as auth."""
+        monkeypatch.setenv("UNITARES_MIDDLEWARE_REQUIRE_BIND", "1")
+
+        signals = FakeSignals(
+            ip_ua_fingerprint="1.2.3.4:fresh",
+            x_session_id="explicit-session",
+        )
+        ctx = DispatchContext()
+        mock_result = {"agent_uuid": "uuid-hdr", "created": False, "source": "redis"}
+
+        with patch("src.mcp_handlers.context.get_session_signals", return_value=signals):
+            with patch("src.mcp_handlers.identity.handlers.derive_session_key",
+                       new_callable=AsyncMock, return_value="sk-fresh"):
+                with patch("src.mcp_handlers.identity.handlers.resolve_session_identity",
+                           new_callable=AsyncMock, return_value=mock_result):
+                    with patch("src.mcp_handlers.context.set_session_context", return_value="tok"):
+                        result = await resolve_identity("process_agent_update", {}, ctx)
+
+        assert not isinstance(result, list)
+
+    @pytest.mark.asyncio
+    async def test_flag_log_does_not_reject(self, monkeypatch, caplog):
+        """Flag=log: middleware logs the rejection but continues with auto-bind,
+        letting operators observe which callers WOULD fail before flipping to 1."""
+        monkeypatch.setenv("UNITARES_MIDDLEWARE_REQUIRE_BIND", "log")
+
+        signals = FakeSignals(ip_ua_fingerprint="1.2.3.4:fresh")
+        ctx = DispatchContext()
+        mock_result = {"agent_uuid": "uuid-still-bound", "created": True, "source": "created"}
+
+        import logging
+        with caplog.at_level(logging.WARNING, logger="src.mcp_handlers.middleware.identity_step"):
+            with patch("src.mcp_handlers.context.get_session_signals", return_value=signals):
+                with patch("src.mcp_handlers.identity.handlers.derive_session_key",
+                           new_callable=AsyncMock, return_value="sk-fresh"):
+                    with patch("src.mcp_handlers.identity.handlers.resolve_session_identity",
+                               new_callable=AsyncMock, return_value=mock_result):
+                        with patch("src.mcp_handlers.context.set_session_context", return_value="tok"):
+                            result = await resolve_identity("process_agent_update", {}, ctx)
+
+        assert not isinstance(result, list), "log mode must not short-circuit"
+        _, _, out_ctx = result
+        assert out_ctx.bound_agent_id == "uuid-still-bound"
+        assert any("REQUIRE_BIND log-only" in rec.message for rec in caplog.records), (
+            "log mode must emit a 'would have rejected' warning"
+        )


### PR DESCRIPTION
## Summary

Closes the third identity-fork generator. KG entry \`3ea27c3a\` (resolved tonight's survey) left this as an open follow-up: *\"Middleware Ephemeral Identity (identity_step.py) still creates its own ephemerals outside the identity() handler path.\"*

Live-reproduced earlier tonight: governance-mcp restart wiped the sticky transport cache. My next MCP tool call routed through middleware, found no cached fingerprint binding, and silently minted a fresh \`f319c7f4\` identity — binding this session to a new ghost before any handler was reached. Plugin Part C took Claude Code out of the auto-onboard business; this PR does the server-side equivalent.

## Flag

\`UNITARES_MIDDLEWARE_REQUIRE_BIND\` — three values:

| Value | Behavior |
|---|---|
| \`0\` (default) | Preserves current auto-bind |
| \`log\` | Emits \"would have rejected\" warning, then proceeds normally — operator observation mode |
| \`1\` | Short-circuits unbound first-calls with \`identity_binding_required\` error, guides caller to \`identity()\` / \`onboard()\` / \`bind_session()\` |

## Allow-list when flag=1

Requests still pass through when:
- Tool is \`onboard\`, \`identity\`, or \`bind_session\` (these ARE the creation paths)
- Arguments contain \`agent_uuid\`, \`continuity_token\`, or \`client_session_id\`
- Headers carry \`X-Agent-Id\`, \`X-Session-ID\`, \`X-Client-Id\`, or \`OAuth-Client-Id\`
- Sticky transport cache has a prior binding for the fingerprint
- \`force_new=true\` (explicit creation opt-in)

## Test plan

- [x] 8 new tests in \`test_sticky_identity.py::TestRequireBindFlag\`
- [x] Full unitares suite: **6387 passed, 33 skipped** (was 6379)
- [x] Live reproduction: the ghost \`f319c7f4\` created during this session's governance restart is the exact failure mode this flag blocks

## Rollout (subsequent PRs / sessions)

1. Deploy this with flag default \`0\` — no behavior change
2. Flip flag to \`log\` on the running server, watch logs for a few days to identify callers that would 401
3. Patch those callers to explicitly \`identity()\` / \`onboard()\` first
4. Flip default to \`1\`
5. Delete the dead auto-bind path

## Related

- Resolved KG entries this unblocks: \`7187b1c0\`, \`3ea27c3a\`
- Still open: parent_agent_id persistence gap, PG-registered-vs-KG-writable mismatch (separate investigations)
- Identity-honesty series: unitares #27 / #28 / #29 / #30, plugin #4 / #5 / #6 / #7 / #8, this PR