### PR TITLE
fix(archive): only mirror meta.notes on successful persist (P011)

### DIFF
--- a/src/mcp_handlers/lifecycle/mutation.py
+++ b/src/mcp_handlers/lifecycle/mutation.py
@@ -214,13 +214,16 @@ async def handle_archive_agent(arguments: Dict[str, Any]) -> Sequence[TextConten
         new_notes = f"{existing_notes}\n{marker}".strip() if existing_notes else marker
         try:
             await agent_storage.update_agent(agent_uuid, notes=new_notes)
+            # Mirror in-memory ONLY on successful persist — otherwise the next
+            # load_metadata_async reload would clobber a divergent meta.notes
+            # and the marker would silently vanish (P011).
+            meta.notes = new_notes
         except Exception as e:
             logger.warning(
                 f"Could not persist sticky-archive marker for {agent_id}: {e}. "
                 f"Cooldown window still protects against immediate resurrection.",
                 exc_info=True,
             )
-        meta.notes = new_notes
 
     # Persist-first: write to Postgres before mutating in-memory state
     from .helpers import _archive_one_agent

--- a/tests/test_sticky_archive.py
+++ b/tests/test_sticky_archive.py
@@ -263,6 +263,65 @@ class TestManualArchiveMarker:
             f"Got kwargs={call_kwargs}"
         )
 
+    @pytest.mark.asyncio
+    async def test_meta_notes_not_mirrored_when_persist_fails(self):
+        """If update_agent raises, meta.notes must NOT be mirrored.
+
+        Otherwise in-memory diverges from DB: the next load_metadata_async
+        reload clobbers the mirror back to the persisted (empty) value,
+        and the sticky marker vanishes silently (P011, fingerprint ad43c067).
+        """
+        from types import SimpleNamespace
+
+        agent_uuid = "test-uuid-persist-fail"
+        meta = SimpleNamespace(
+            agent_id=agent_uuid,
+            status="active",
+            archived_at=None,
+            notes="",
+            total_updates=5,
+        )
+        meta.add_lifecycle_event = MagicMock()
+
+        mock_server = MagicMock()
+        mock_server.agent_metadata = {agent_uuid: meta}
+        mock_server.load_metadata_async = AsyncMock()
+        mock_server.monitors = {}
+
+        mock_storage = MagicMock(
+            update_agent=AsyncMock(side_effect=RuntimeError("db down"))
+        )
+
+        with patch("src.mcp_handlers.lifecycle.mutation.mcp_server", mock_server), \
+             patch("src.mcp_handlers.lifecycle.mutation.agent_storage", mock_storage), \
+             patch(
+                 "src.mcp_handlers.lifecycle.mutation.require_registered_agent",
+                 return_value=(agent_uuid, None),
+             ), \
+             patch(
+                 "src.mcp_handlers.lifecycle.mutation.resolve_agent_uuid",
+                 return_value=agent_uuid,
+             ), \
+             patch(
+                 "src.mcp_handlers.lifecycle.helpers._archive_one_agent",
+                 new=AsyncMock(return_value=True),
+             ), \
+             patch(
+                 "src.mcp_handlers.lifecycle.mutation._invalidate_agent_cache",
+                 new=AsyncMock(),
+             ):
+            from src.mcp_handlers.lifecycle.mutation import handle_archive_agent
+            await handle_archive_agent({
+                "agent_id": agent_uuid,
+                "reason": "Manual archive",
+            })
+
+        assert meta.notes == "", (
+            f"Persistence failed, so meta.notes must stay in sync with DB (empty). "
+            f"Got: {meta.notes!r}"
+        )
+        mock_storage.update_agent.assert_awaited_once()
+
 
 # ----------------------------------------------------------------------
 # Task 7: Full incident replay — archive then 10s-later update is refused.


### PR DESCRIPTION
## Summary

Follow-up to #33. Watcher's second-pass catch after that merge (fingerprint \`#ad43c067\`):

Before: if \`update_agent\` raised, we caught the exception but still set \`meta.notes = new_notes\`. In-memory then diverges from DB. The next \`load_metadata_async(force=True)\` reloads \`meta.notes\` from the (unchanged, empty) DB row, clobbering the mirror and silently erasing the sticky marker. An archived agent could later drift past the 300s cooldown and still get resurrected.

After: the mirror assignment lives inside the \`try\`, so \`meta.notes\` is only touched when persistence actually succeeded.

## Test plan

- [x] New \`test_meta_notes_not_mirrored_when_persist_fails\` asserts \`meta.notes == \"\"\` after a simulated \`update_agent\` raise.
- [x] All 6 sticky-archive tests pass.
- [x] No change to happy path — existing \`test_manual_archive_stamps_user_requested_marker\` still passes.