### PR TITLE
fix(kg): coerce ISO timestamp strings at postgres backend boundary

### DIFF
--- a/src/storage/knowledge_graph_postgres.py
+++ b/src/storage/knowledge_graph_postgres.py
@@ -5,11 +5,26 @@ Implements the knowledge graph interface using PostgreSQL with FTS (tsvector).
 This provides unified storage with the main database and better FTS than AGE.
 """
 
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 from src.knowledge_graph import DiscoveryNode, ResponseTo
 from src.logging_utils import get_logger
 
 logger = get_logger(__name__)
+
+_TIMESTAMP_COLUMNS = ("updated_at", "resolved_at")
+
+
+def _coerce_timestamp(value: Any) -> Any:
+    """Accept ISO-format strings for timestamp columns; pass datetimes through.
+
+    asyncpg binds ``timestamp with time zone`` strictly and rejects strings.
+    AGE callers serialize timestamps as ISO strings, so the PG backend
+    normalizes at the boundary.
+    """
+    if isinstance(value, str):
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return value
 
 
 class KnowledgeGraphPostgres:
@@ -119,6 +134,8 @@ class KnowledgeGraphPostgres:
         for key, value in updates.items():
             if key in ("status", "resolved_at", "updated_at", "severity", "type", "summary", "details"):
                 set_clauses.append(f"{key} = ${param_idx}")
+                if key in _TIMESTAMP_COLUMNS:
+                    value = _coerce_timestamp(value)
                 params.append(value)
                 param_idx += 1
             elif key == "tags":

--- a/tests/test_knowledge_graph_postgres_unit.py
+++ b/tests/test_knowledge_graph_postgres_unit.py
@@ -1,0 +1,102 @@
+"""Unit tests for KnowledgeGraphPostgres timestamp coercion.
+
+Covers the regression where lifecycle cleanup passed ISO-format strings
+for timestamp-typed columns, which asyncpg rejected. The backend now
+coerces strings to datetime at its boundary.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.storage.knowledge_graph_postgres import (
+    KnowledgeGraphPostgres,
+    _coerce_timestamp,
+)
+
+
+class TestCoerceTimestamp:
+    def test_passes_datetime_through(self):
+        now = datetime.now(timezone.utc)
+        assert _coerce_timestamp(now) is now
+
+    def test_parses_iso_string(self):
+        result = _coerce_timestamp("2026-04-18T01:23:45.678+00:00")
+        assert isinstance(result, datetime)
+        assert result.year == 2026 and result.minute == 23
+
+    def test_parses_zulu_suffix(self):
+        result = _coerce_timestamp("2026-04-18T01:23:45Z")
+        assert isinstance(result, datetime)
+        assert result.tzinfo is not None
+
+
+@pytest.mark.asyncio
+class TestUpdateDiscoveryTimestampCoercion:
+    async def _make_backend(self, captured: list):
+        """KnowledgeGraphPostgres with a mocked pool that records fetchval args."""
+        backend = KnowledgeGraphPostgres()
+
+        async def fake_fetchval(query, *args):
+            captured.append((query, args))
+            return "discovery-id"
+
+        db = MagicMock()
+        db._pool = MagicMock()
+        db._pool.fetchval = AsyncMock(side_effect=fake_fetchval)
+        backend._db = db
+        backend._initialized = True
+
+        async def _get_db():
+            return db
+
+        backend._get_db = _get_db  # type: ignore[assignment]
+        return backend
+
+    async def test_updated_at_string_coerced_to_datetime(self):
+        captured: list = []
+        backend = await self._make_backend(captured)
+
+        ok = await backend.update_discovery(
+            "discovery-id",
+            {"status": "archived", "updated_at": "2026-04-18T01:23:45+00:00"},
+        )
+
+        assert ok is True
+        assert len(captured) == 1
+        _query, args = captured[0]
+        # args: (discovery_id, status, updated_at)
+        assert args[0] == "discovery-id"
+        assert args[1] == "archived"
+        assert isinstance(args[2], datetime), (
+            f"updated_at must be datetime for asyncpg, got {type(args[2]).__name__}"
+        )
+
+    async def test_resolved_at_string_coerced_to_datetime(self):
+        captured: list = []
+        backend = await self._make_backend(captured)
+
+        await backend.update_discovery(
+            "discovery-id",
+            {"resolved_at": "2026-04-18T01:23:45+00:00"},
+        )
+
+        assert len(captured) == 1
+        _query, args = captured[0]
+        assert isinstance(args[1], datetime)
+
+    async def test_datetime_passes_through(self):
+        captured: list = []
+        backend = await self._make_backend(captured)
+        now = datetime.now(timezone.utc)
+
+        await backend.update_discovery(
+            "discovery-id",
+            {"updated_at": now},
+        )
+
+        _query, args = captured[0]
+        assert args[1] is now


### PR DESCRIPTION
## Summary
- KG lifecycle cleanup silently failed on the `dry_run=False` path — `_batch_update_status` passed `updated_at` as an ISO string, which asyncpg rejects for `timestamptz` columns. Nothing had been auto-archiving.
- Coerce ISO strings to `datetime` inside `KnowledgeGraphPostgres.update_discovery` at the backend boundary. AGE callers can keep serializing as strings.
- New unit test exercises the coercion path (no live DB required).

## Verified
Ran live cleanup against the real governance DB after the fix:
- archived 2 ephemeral
- archived 15 old resolved (skipped 13 permanent)
- moved 264 very old archived → cold
- errors: []

## Test plan
- [x] New `tests/test_knowledge_graph_postgres_unit.py` — 6 tests pass
- [x] `tests/test_knowledge_graph_lifecycle.py` + `tests/test_kg_lifecycle.py` — 78/78 pass
- [x] Pre-existing failure `test_unitares_cli_script.py::test_update_returns_verdict` confirmed unrelated (fails on main too)