### PR TITLE
fix(archive): gate in-process callers at process_update_authenticated_async

### DIFF
--- a/src/agent_loop_detection.py
+++ b/src/agent_loop_detection.py
@@ -353,6 +353,20 @@ async def process_update_authenticated_async(
     if not is_valid:
         raise PermissionError(f"Authentication failed: {error_msg}")
 
+    # Sticky-archive gate for in-process callers. The MCP-tool path
+    # (handle_process_agent_update → phases.py) has its own auto-resume /
+    # refusal logic before it reaches this function, but in-process callers
+    # like Steward (unitares-pi-plugin) reach us directly and would otherwise
+    # silently resurrect archived identities. Refuse here so the gate is
+    # uniform across all paths.
+    meta = agent_metadata.get(agent_id)
+    if meta is not None and getattr(meta, "status", None) == "archived":
+        raise ValueError(
+            f"Agent '{agent_id}' is archived and cannot be updated. "
+            f"Use self_recovery(action='quick') to restore, or "
+            f"onboard(force_new=true) for a new identity."
+        )
+
     # Check for loop pattern BEFORE processing
     is_loop, loop_reason = await loop.run_in_executor(None, detect_loop_pattern, agent_id)
     if is_loop:

--- a/tests/test_in_process_archive_gate.py
+++ b/tests/test_in_process_archive_gate.py
@@ -1,0 +1,121 @@
+"""Tests for the in-process archive gate in process_update_authenticated_async.
+
+Steward (in-process, unitares-pi-plugin) bypasses handle_process_agent_update
+and calls process_update_authenticated_async directly. Before this gate, an
+archived Steward identity would still accept updates — silent resurrection via
+a different code path than the one sticky-archive guards on the MCP tool path.
+
+Regression scope: ensure archived agents are refused at the
+process_update_authenticated_async entrypoint regardless of caller.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+def _make_metadata(status: str = "active"):
+    return SimpleNamespace(
+        status=status,
+        api_key="test-key",
+        recent_update_timestamps=[],
+        recent_decisions=[],
+        loop_cooldown_until=None,
+        recovery_attempt_at=None,
+        created_at=datetime.now().isoformat(),
+        tags=[],
+        paused_at=None,
+        loop_detected_at=None,
+        loop_incidents=[],
+        total_updates=10,
+        last_update=datetime.now().isoformat(),
+        archived_at=None,
+    )
+
+
+class TestInProcessArchiveGate:
+    """process_update_authenticated_async must refuse archived agents.
+
+    The MCP-tool path has its own gate earlier (phases.py sticky-archive).
+    This covers the in-process path used by Steward (unitares-pi-plugin).
+    """
+
+    @pytest.mark.asyncio
+    async def test_archived_agent_raises_value_error(self):
+        agent_id = "test-uuid-archived-in-process"
+        meta = _make_metadata(status="archived")
+
+        with patch(
+            "src.agent_loop_detection.agent_metadata",
+            {agent_id: meta},
+        ), patch(
+            "src.agent_loop_detection.verify_agent_ownership",
+            return_value=(True, ""),
+        ):
+            from src.agent_loop_detection import process_update_authenticated_async
+            with pytest.raises(ValueError, match="archived"):
+                await process_update_authenticated_async(
+                    agent_id=agent_id,
+                    api_key="test-key",
+                    agent_state={},
+                )
+
+    @pytest.mark.asyncio
+    async def test_active_agent_not_blocked_by_archive_gate(self):
+        """Sanity: active agents pass the gate (loop-detection path still runs)."""
+        agent_id = "test-uuid-active-in-process"
+        meta = _make_metadata(status="active")
+
+        # Patch detect_loop_pattern to return no-loop so we exit cleanly right
+        # after the archive check. The function then hits get_or_create_monitor
+        # etc. which we don't want to wire up — raise a sentinel instead.
+        def _sentinel_loop(agent_id):
+            raise AssertionError("reached-loop-detection-phase")
+
+        with patch(
+            "src.agent_loop_detection.agent_metadata",
+            {agent_id: meta},
+        ), patch(
+            "src.agent_loop_detection.verify_agent_ownership",
+            return_value=(True, ""),
+        ), patch(
+            "src.agent_loop_detection.detect_loop_pattern",
+            side_effect=_sentinel_loop,
+        ):
+            from src.agent_loop_detection import process_update_authenticated_async
+            # Expect our sentinel — meaning we passed the archive gate.
+            with pytest.raises(AssertionError, match="reached-loop-detection-phase"):
+                await process_update_authenticated_async(
+                    agent_id=agent_id,
+                    api_key="test-key",
+                    agent_state={},
+                )
+
+    @pytest.mark.asyncio
+    async def test_unknown_agent_not_blocked_by_archive_gate(self):
+        """Sanity: agents missing from the in-memory dict aren't treated as archived."""
+        agent_id = "test-uuid-not-in-dict"
+
+        def _sentinel_loop(agent_id):
+            raise AssertionError("reached-loop-detection-phase")
+
+        with patch(
+            "src.agent_loop_detection.agent_metadata",
+            {},  # agent not present
+        ), patch(
+            "src.agent_loop_detection.verify_agent_ownership",
+            return_value=(True, ""),
+        ), patch(
+            "src.agent_loop_detection.detect_loop_pattern",
+            side_effect=_sentinel_loop,
+        ):
+            from src.agent_loop_detection import process_update_authenticated_async
+            with pytest.raises(AssertionError, match="reached-loop-detection-phase"):
+                await process_update_authenticated_async(
+                    agent_id=agent_id,
+                    api_key="test-key",
+                    agent_state={},
+                )


### PR DESCRIPTION
## Summary

Closes the in-process bypass of the sticky-archive gate shipped in #33 / #34.

**The hole:** PR #33 added the archive refusal in \`phases.py\`, on the MCP-tool path (\`handle_process_agent_update\`). But Steward (from \`unitares-pi-plugin\`) runs in-process and calls \`mcp_server.process_update_authenticated_async\` directly, skipping that gate entirely. Archiving Steward's identity does nothing to stop its next 5-min sync cycle from accepting governance updates.

**The fix:** add a \`status == \"archived\"\` check at the entry of \`process_update_authenticated_async\`, raising \`ValueError\` with the standard \`self_recovery\` / \`onboard\` guidance. This is after auth, before loop detection — uniform across all callers.

**Why raise (not return an error dict):** this function already raises \`PermissionError\` for auth failures and \`ValueError\` for loop-cooldown rejections. Raising keeps the contract consistent.

**Impact on Steward:** its caller at \`unitares-pi-plugin/src/unitares_pi_plugin/handlers.py:1141-1152\` wraps the call in \`try/except Exception\`. If the gate fires, the exception is caught, logged as a warning, and \`sync_result[\"governance_updated\"] = False\`. The Pi→Mac EISV collection itself still succeeds. Clean degradation.

**Impact on MCP-tool path:** unaffected. \`phases.py\` sticky-archive check runs first:
- If the gate allows auto-resume, \`meta.status\` is flipped to \`\"active\"\` before this function is called → new check passes.
- If the gate refuses, \`handle_process_agent_update\` returns an error response and never calls this function.

## Test plan

- [x] New \`tests/test_in_process_archive_gate.py\`: 3 tests (archived raises, active passes, unknown-agent passes).
- [x] Full sticky-archive suite still passes (6 tests).
- [x] Full loop-detection suite still passes (10 tests).
- [x] Full test suite (excluding pre-existing unrelated CLI flake): **5927 passed, 52 skipped, 0 failures**.