### PR TITLE
fix(resident): stamp 'persistent' tag on fresh onboard to block orphan sweep

### DIFF
--- a/agents/sdk/src/unitares_sdk/agent.py
+++ b/agents/sdk/src/unitares_sdk/agent.py
@@ -75,11 +75,17 @@ class GovernanceAgent:
         timeout: float = 30.0,
         parent_agent_id: str | None = None,
         spawn_reason: str | None = None,
+        persistent: bool = False,
     ):
         self.name = name
         self.mcp_url = mcp_url
         self.timeout = timeout
         self.notify_on_error = notify_on_error
+        # When True, stamp the "persistent" tag after fresh onboard so
+        # auto_archive_orphan_agents (is_agent_protected in agent_lifecycle.py)
+        # skips this identity. Resident agents (Vigil, Sentinel, etc.) should
+        # set this to True to avoid sweep false-positives.
+        self.persistent = persistent
 
         # Defaults based on name
         name_lower = name.lower()
@@ -193,6 +199,25 @@ class GovernanceAgent:
         self._sync_from_client(client)
         self._save_session()
         logger.info("%s: onboarded fresh (UUID %s)", self.name, self.agent_uuid[:12] if self.agent_uuid else "?")
+
+        if self.persistent and self.agent_uuid:
+            try:
+                await client.call_tool(
+                    "update_agent_metadata",
+                    {"agent_id": self.agent_uuid, "tags": ["persistent"]},
+                )
+                logger.info(
+                    "%s: stamped 'persistent' tag to protect from orphan sweep",
+                    self.name,
+                )
+            except Exception as e:
+                # Non-fatal. The agent still runs; it's just vulnerable to
+                # archive_orphan_agents until someone tags it manually.
+                logger.warning(
+                    "%s: failed to stamp 'persistent' tag: %s "
+                    "(will retry on next fresh onboard; manual tagging may be needed)",
+                    self.name, e,
+                )
 
     # --- Check-in handling ---
 

--- a/agents/sdk/tests/test_agent.py
+++ b/agents/sdk/tests/test_agent.py
@@ -165,6 +165,68 @@ class TestIdentityResolution:
         assert "parent_agent_id" not in call_kwargs
         assert "spawn_reason" not in call_kwargs
 
+    @pytest.mark.asyncio
+    async def test_persistent_tag_stamped_on_fresh_onboard(self, tmp_path):
+        """persistent=True agents stamp the 'persistent' tag after fresh onboard.
+
+        Protects residents (Vigil, Sentinel) from orphan-sweep false-positives.
+        Root cause: low-activity windows caused sweep to archive live residents,
+        and auto-resume silently revived them, masking the problem.
+        """
+        agent = SimpleAgent(session_file=tmp_path / ".test_session", persistent=True)
+
+        client = _mock_client_connected()
+        await agent._ensure_identity(client)
+
+        # Fresh onboard + subsequent update_agent_metadata call
+        client.onboard.assert_called_once()
+        client.call_tool.assert_awaited_once_with(
+            "update_agent_metadata",
+            {"agent_id": "uuid-test", "tags": ["persistent"]},
+        )
+
+    @pytest.mark.asyncio
+    async def test_persistent_tag_not_stamped_when_not_persistent(self, tmp_path):
+        """Default persistent=False must not call update_agent_metadata."""
+        agent = SimpleAgent(session_file=tmp_path / ".test_session")
+
+        client = _mock_client_connected()
+        await agent._ensure_identity(client)
+
+        client.onboard.assert_called_once()
+        client.call_tool.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_persistent_tag_not_stamped_on_uuid_resume(self, tmp_path):
+        """Resuming an existing UUID skips tag stamping — it's already been tagged
+        on the original fresh onboard (or manually).
+        """
+        agent = SimpleAgent(session_file=tmp_path / ".test_session", persistent=True)
+        agent.agent_uuid = "uuid-test"  # triggers the resume fast path
+
+        client = _mock_client_connected()
+        await agent._ensure_identity(client)
+
+        client.identity.assert_awaited_once()
+        client.onboard.assert_not_called()
+        client.call_tool.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_persistent_tag_failure_is_non_fatal(self, tmp_path):
+        """If update_agent_metadata fails, the agent still onboards successfully."""
+        agent = SimpleAgent(session_file=tmp_path / ".test_session", persistent=True)
+
+        client = _mock_client_connected()
+        client.call_tool = AsyncMock(side_effect=RuntimeError("db down"))
+
+        # Must not raise — the exception is caught and logged.
+        await agent._ensure_identity(client)
+
+        client.onboard.assert_called_once()
+        client.call_tool.assert_awaited_once()
+        # Identity is still established.
+        assert agent.agent_uuid == "uuid-test"
+
 
 # --- Session persistence ---
 

--- a/agents/sentinel/agent.py
+++ b/agents/sentinel/agent.py
@@ -423,6 +423,7 @@ class SentinelAgent(GovernanceAgent):
             legacy_session_file=LEGACY_SESSION_FILE,
             state_dir=STATE_FILE.parent,
             timeout=30.0,
+            persistent=True,
         )
         self.ws_url = ws_url
         self.analysis_interval = analysis_interval

--- a/agents/vigil/agent.py
+++ b/agents/vigil/agent.py
@@ -272,6 +272,7 @@ class VigilAgent(GovernanceAgent):
             legacy_session_file=LEGACY_SESSION_FILE,
             state_dir=STATE_FILE.parent,
             timeout=30.0,
+            persistent=True,
         )
         self.heartbeat_interval = heartbeat_interval
         self.with_tests = with_tests

--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -196,6 +196,22 @@ def resolve_identity(client) -> None:
     try:
         client.onboard("Watcher", spawn_reason="resident_observer")
         _sync_identity(client)
+        # Stamp 'persistent' tag so auto_archive_orphan_agents skips this
+        # identity (is_agent_protected in src/agent_lifecycle.py). Without
+        # this, low-activity windows cause orphan-sweep false-positives and
+        # the Watcher gets archived-then-silently-resurrected every cycle.
+        if _watcher_identity and _watcher_identity.get("agent_uuid"):
+            try:
+                client.call_tool(
+                    "update_agent_metadata",
+                    {
+                        "agent_id": _watcher_identity["agent_uuid"],
+                        "tags": ["persistent"],
+                    },
+                )
+                log("stamped 'persistent' tag — protected from orphan sweep")
+            except Exception as e:
+                log(f"failed to stamp 'persistent' tag: {e}", "warning")
     except GovernanceTimeoutError as e:
         # Onboard timeout is the worst case — don't assume it failed, it may
         # have partial-committed on the server side (which is exactly how


### PR DESCRIPTION
## The real root cause

The 2026-04-18 incident (PR #33) was the tip of a bigger pattern. Live DB check:

\`\`\`
  agent_id                              | label    | tags             | status
  --------------------------------------|----------|------------------|---------
  4b265b4d-75cf-428c-b82a-76dbbe4ca3b1  | Vigil    | [developer...]   | archived
  aa8c92d2-5402-4048-94c8-98f7a69b90d5  | Vigil    |                  | archived
  85e15f04-adc5-4d0a-a394-cf8f75e2a23c  | Vigil    |                  | archived
  7d9966bb-9702-4c79-a1d1-fc0faa6fd542  | Vigil    |                  | active
  ec29d993-c224-4b01-95da-faecbd02e4d0  | Sentinel |                  | archived
  8a98989f-e67e-40f1-83de-3804fc9958ff  | Sentinel |                  | archived
  9a6681ec-1d16-4143-ada9-282f14483fea  | Steward  | [persistent]     | active
  e55caaf1-43a7-4fbb-a8fa-c69a9a8f50e4  | Vigil    |                  | active
  f92dcea8-4786-412a-a0eb-362c273382f5  | Sentinel |                  | active
  907e3195-c649-49db-b753-1edc1a105f33  | Watcher  |                  | active
\`\`\`

Five archived Vigil/Sentinel instances. Only Steward is tagged \`persistent\`. \`archive_orphan_agents\` has been false-positive-archiving live residents during low-activity windows, and \`process_agent_update\`'s auto-resume papered over it every time — minting no new incident, but accumulating archived ghosts.

## The fix

\`is_agent_protected\` in \`src/agent_lifecycle.py\` already respects \`tags=[\"persistent\"]\`. Just extend the tag to all residents:

- **SDK:** new \`persistent: bool = False\` param on \`GovernanceAgent.__init__\`. When \`True\`, calls \`update_agent_metadata\` after fresh onboard to stamp the tag.
- **Vigil + Sentinel:** flip \`persistent=True\` in \`super().__init__\`.
- **Watcher (non-SDK):** same pattern inline after \`client.onboard(...)\`.

Non-fatal on failure: if the tag call fails, the agent still runs (just remains vulnerable until someone tags it manually).

## Operational cleanup (run once by operator)

New code only protects residents that go through fresh onboard. Existing UUIDs are untagged. Either restart each resident to trigger the re-onboard path, **or** run this SQL once:

\`\`\`sql
UPDATE core.identities
SET metadata = jsonb_set(coalesce(metadata, '{}'::jsonb), '{tags}',
                         '[\"persistent\"]'::jsonb)
WHERE metadata->>'label' IN ('Watcher', 'Vigil', 'Sentinel')
  AND status = 'active';
\`\`\`

## Test plan

- [x] 4 new SDK tests: persistent=True stamps, persistent=False doesn't, UUID-resume skips stamping, failure is non-fatal.
- [x] SDK test suite: 27/27 pass.
- [x] Full suite: 6236 passed, 52 skipped. (2 failures pre-existing and unrelated — stale watcher test from the 5→30s timeout bump, and a pytest-asyncio config gap in \`scripts/diagnostics/\`.)

## Closes the Stage 3 question

With this in, orphan-sweep false-positives stop happening on residents. The auto-resume code in \`phases.py\` still exists as a genuine safety net for non-resident stuck agents, but its primary historical purpose (rescuing false-sweeped residents) evaporates. Stage 3's \"rip auto-resume\" becomes a low-stakes cleanup whenever someone wants to do it.