### PR TITLE
refactor(archive): rip auto-resume from process_agent_update (Stage 3)

### DIFF
--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -84,15 +84,6 @@ BASIN_LOW_RISK_FLOOR = 0.70    # risk at or above this → low (matches RISK_REV
 BASIN_BOUNDARY = BasinRegion(name="boundary")
 
 
-# Sticky archive: cooldown window during which process_agent_update refuses
-# to auto-resume an archived agent. Prevents the race where an archive is
-# silently resurrected by a stale client holding the UUID seconds later.
-# Override: UNITARES_ARCHIVE_COOLDOWN_SECONDS env var.
-ARCHIVE_RESUME_COOLDOWN_SECONDS: int = int(
-    os.getenv("UNITARES_ARCHIVE_COOLDOWN_SECONDS", "300")
-)
-
-
 def classify_basin(E: float, I: float, S: float, V: float,
                    coherence: float, risk_score: float) -> str:
     """Classify current state into a basin region.

--- a/src/mcp_handlers/updates/context.py
+++ b/src/mcp_handlers/updates/context.py
@@ -35,9 +35,8 @@ class UpdateContext:
     task_type: str = "mixed"
     calibration_correction_info: Optional[str] = None
 
-    # ── Onboarding / auto-resume (Phase 2) ─────────────────────────
+    # ── Onboarding (Phase 2) ───────────────────────────────────────
     onboarding_guidance: Optional[Dict] = None
-    auto_resume_info: Optional[Dict] = None
     dialectic_enforcement_warning: Optional[str] = None
 
     # ── Core result (Phase 4) ──────────────────────────────────────

--- a/src/mcp_handlers/updates/enrichments.py
+++ b/src/mcp_handlers/updates/enrichments.py
@@ -233,10 +233,6 @@ def enrich_warnings(ctx: UpdateContext) -> None:
             ctx.response_data['loop_detection'] = ctx.loop_info
         if ctx.warnings:
             ctx.response_data["warning"] = "\n\n".join(ctx.warnings)
-
-        # Auto-resume info
-        if ctx.auto_resume_info:
-            ctx.response_data["auto_resume"] = ctx.auto_resume_info
     except Exception as e:
         logger.debug(f"Could not enrich warnings: {e}")
 

--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -312,115 +312,37 @@ async def handle_onboarding_and_resume(ctx: UpdateContext) -> Optional[Sequence[
         except Exception as e:
             logger.warning(f"Could not check knowledge graph for onboarding: {e}")
 
-    # Auto-resume check
+    # Archived-agent refusal. Historically this branch would silently
+    # auto-resume archived agents on engagement, papering over orphan-sweep
+    # false-positives on live residents. Removed once residents became
+    # self-tagging 'persistent' (PR #39) — sweep no longer targets live agents,
+    # so nothing legitimate hits the archived branch anymore. Manual archives
+    # (PR #33) and the 2026-04-18 incident race (PR #33) were never supposed
+    # to auto-resume anyway. Any archived agent must explicitly self_recovery
+    # or onboard(force_new=true) to come back.
     meta = mcp_server.agent_metadata.get(ctx.agent_uuid)
     ctx.meta = meta
 
     if meta:
         if meta.status == "archived":
-            previous_archived_at = meta.archived_at
-            days_since_archive = None
-            if previous_archived_at:
-                try:
-                    archived_dt = datetime.fromisoformat(
-                        previous_archived_at.replace('Z', '+00:00') if 'Z' in previous_archived_at else previous_archived_at
-                    )
-                    days_since_archive = (
-                        (datetime.now(archived_dt.tzinfo) - archived_dt).total_seconds() / 86400
-                        if archived_dt.tzinfo
-                        else (datetime.now() - archived_dt.replace(tzinfo=None)).total_seconds() / 86400
-                    )
-                except (ValueError, TypeError, AttributeError):
-                    pass
-
-            # Cooldown guard: any archive within the cooldown window blocks
-            # auto-resume regardless of source. Catches the race where a stale
-            # client resurrects an agent seconds after it was archived.
-            # Incident: 2026-04-18 acd8a774 archived 01:29:33, resurrected 10s
-            # later via process_agent_update, circuit-broke 45min later.
-            from config.governance_config import ARCHIVE_RESUME_COOLDOWN_SECONDS
-            seconds_since_archive = (
-                days_since_archive * 86400 if days_since_archive is not None else None
+            logger.warning(
+                f"Refused process_agent_update on archived agent {agent_id[:12]}.... "
+                f"Use self_recovery(action='quick') to restore, "
+                f"or onboard(force_new=true) for a new identity."
             )
-            in_cooldown = (
-                seconds_since_archive is not None
-                and seconds_since_archive < ARCHIVE_RESUME_COOLDOWN_SECONDS
-            )
-
-            agent_notes = getattr(meta, 'notes', '') or ''
-            explicitly_archived = bool(agent_notes and "user requested" in agent_notes.lower())
-            too_old = days_since_archive is not None and days_since_archive > 2.0
-            too_few_updates = (getattr(meta, 'total_updates', 0) or 0) < 2
-
-            if in_cooldown or explicitly_archived or (too_old and too_few_updates):
-                reasons = []
-                if in_cooldown:
-                    reasons.append(
-                        f"archived {seconds_since_archive:.0f}s ago "
-                        f"(cooldown window {ARCHIVE_RESUME_COOLDOWN_SECONDS}s)"
-                    )
-                if explicitly_archived:
-                    reasons.append(f"explicitly archived: {agent_notes}")
-                if too_old:
-                    reasons.append(f"archived {days_since_archive:.1f} days ago")
-                if too_few_updates:
-                    reasons.append(f"only {getattr(meta, 'total_updates', 0) or 0} update(s)")
-                logger.warning(
-                    f"Blocked auto-resume of agent {agent_id[:12]}... ({', '.join(reasons)}). "
-                    f"Use self_recovery(action='quick') to restore, or onboard(force_new=true) for new identity."
-                )
-                return [error_response(
-                    f"Agent '{agent_id}' is archived and cannot be auto-resumed ({', '.join(reasons)}).",
-                    recovery={
-                        "action": "Use self_recovery(action='quick') to restore yourself, or onboard(force_new=true) for a new identity",
-                        "related_tools": ["self_recovery", "onboard"],
-                    },
-                    context={
-                        "agent_id": agent_id,
-                        "status": "archived",
-                        "days_since_archive": round(days_since_archive, 2) if days_since_archive is not None else None,
-                        "total_updates": getattr(meta, 'total_updates', 0) or 0,
-                    }
-                )]
-
-            meta.status = "active"
-            meta.archived_at = None
-            meta.add_lifecycle_event("resumed", "Auto-resumed on engagement")
-
-            try:
-                await agent_storage.update_agent(agent_id, status="active")
-                logger.debug(f"PostgreSQL: Auto-resumed agent {agent_id}")
-            except Exception as e:
-                logger.warning(f"PostgreSQL auto-resume failed: {e}", exc_info=True)
-
-            try:
-                from src.cache import get_metadata_cache
-                await get_metadata_cache().invalidate(ctx.agent_uuid)
-            except Exception:
-                pass
-
-            try:
-                from src.audit_log import audit_logger
-                audit_logger.log_auto_resume(
-                    agent_id=agent_id,
-                    previous_status="archived",
-                    trigger="process_agent_update",
-                    archived_at=previous_archived_at,
-                    details={
-                        "days_since_archive": round(days_since_archive, 2) if days_since_archive is not None else None,
-                        "total_updates": meta.total_updates
-                    }
-                )
-            except Exception as e:
-                logger.warning(f"Could not log auto-resume audit event: {e}", exc_info=True)
-
-            ctx.auto_resume_info = {
-                "auto_resumed": True,
-                "message": f"Agent '{agent_id}' was automatically resumed from archived status.",
-                "previous_status": "archived",
-                "days_since_archive": round(days_since_archive, 2) if days_since_archive is not None else None,
-                "note": "Archived agents automatically resume when they engage with the system."
-            }
+            return [error_response(
+                f"Agent '{agent_id}' is archived and cannot be updated.",
+                recovery={
+                    "action": "Use self_recovery(action='quick') to restore yourself, "
+                              "or onboard(force_new=true) for a new identity",
+                    "related_tools": ["self_recovery", "onboard"],
+                },
+                context={
+                    "agent_id": agent_id,
+                    "status": "archived",
+                    "archived_at": getattr(meta, "archived_at", None),
+                }
+            )]
 
         elif meta.status == "paused":
             return [error_response(
@@ -438,7 +360,7 @@ async def handle_onboarding_and_resume(ctx: UpdateContext) -> Optional[Sequence[
                     "agent_id": agent_id,
                     "status": "paused",
                     "reason": "Circuit breaker triggered - governance threshold exceeded",
-                    "note": "Paused agents require explicit recovery. Archived agents auto-resume on engagement."
+                    "note": "Paused and archived agents both require explicit recovery via self_recovery()."
                 }
             )]
 

--- a/tests/test_core_update.py
+++ b/tests/test_core_update.py
@@ -484,7 +484,7 @@ class TestProcessAgentUpdate:
         assert data["success"] is False
         assert data["error_code"] == "AGENT_ARCHIVED"
         assert data["error_category"] == "state_error"
-        assert "cannot be auto-resumed" in data["error"]
+        assert "archived" in data["error"] and "cannot" in data["error"]
         assert data["context"]["status"] == "archived"
         assert "self_recovery" in data["recovery"]["related_tools"]
         mock_server.lock_manager.acquire_agent_lock_async.assert_not_called()
@@ -879,16 +879,16 @@ class TestProcessAgentUpdateExtended:
             assert isinstance(data, dict)
 
     # ------------------------------------------------------------------
-    # Lines 726-766: Auto-resume archived agent
+    # Archived agent is REFUSED on checkin (Stage 3, post-PR #39).
     # ------------------------------------------------------------------
     @pytest.mark.asyncio
-    async def test_archived_agent_reactivated_on_checkin(self, mock_server, mock_monitor):
-        """Archived agent is reactivated when it checks in via process_agent_update.
+    async def test_archived_agent_refused_on_checkin(self, mock_server, mock_monitor):
+        """Archived agent is refused when it checks in via process_agent_update.
 
-        The core handler does not block archived agents — checking in
-        implicitly reactivates them (status becomes 'active').
+        Pre-Stage 3 this reactivated implicitly. Now it returns an error;
+        recovery is via self_recovery() or onboard(force_new=true).
         """
-        agent_uuid = "test-uuid-archived-resume"
+        agent_uuid = "test-uuid-archived-refused"
         mock_server.agent_metadata = {}
         mock_server.get_or_create_monitor.return_value = mock_monitor
         mock_server.monitors = {agent_uuid: mock_monitor}
@@ -905,14 +905,16 @@ class TestProcessAgentUpdateExtended:
 
             from src.mcp_handlers.core import handle_process_agent_update
             result = await handle_process_agent_update({
-                "response_text": "back from archive",
+                "response_text": "attempt from archive",
                 "complexity": 0.5,
             })
 
             data = parse_result(result)
             assert isinstance(data, dict)
-            # Agent is reactivated by check-in
-            assert archived_meta.status == "active"
+            # No silent reactivation — status stays archived.
+            assert archived_meta.status == "archived"
+            assert data.get("success") is False
+            assert "archived" in data["error"].lower()
 
     # ------------------------------------------------------------------
     # Lines 776: Paused agent error (second check, after metadata loaded)

--- a/tests/test_sticky_archive.py
+++ b/tests/test_sticky_archive.py
@@ -80,23 +80,27 @@ def mock_monitor():
 
 
 # ----------------------------------------------------------------------
-# Task 2: Cooldown guard refuses auto-resume when archive is recent.
+# Archived agents are always refused. Stage 3 (PR after #39) removed the
+# auto-resume branch that previously rescued sweep-archived residents —
+# that rescue is no longer needed because residents self-tag 'persistent'.
+# Manual archives were already refused via the sticky marker. This class
+# now verifies the uniform refusal regardless of how the archive happened.
 # ----------------------------------------------------------------------
 
 
-class TestCooldownGuard:
-    """Archive → immediate process_agent_update must NOT auto-resume."""
+class TestArchivedRefusal:
+    """Any archived agent hitting process_agent_update gets an error response."""
 
     @pytest.mark.asyncio
-    async def test_recent_archive_within_cooldown_is_rejected(
+    async def test_recent_archive_is_refused(
         self, mock_server, mock_monitor
     ):
-        """Archive <300s ago blocks auto-resume even without 'user requested' marker."""
-        agent_uuid = "test-uuid-cooldown"
+        """Archive seconds ago (the 2026-04-18 incident shape) is refused."""
+        agent_uuid = "test-uuid-recent-archive"
         recent = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
         meta = _make_metadata(status="archived", total_updates=5)
         meta.archived_at = recent
-        meta.notes = ""  # No manual marker — must still be blocked by cooldown.
+        meta.notes = ""
         mock_server.agent_metadata = {agent_uuid: meta}
         mock_server.get_or_create_monitor.return_value = mock_monitor
         mock_server.monitors = {agent_uuid: mock_monitor}
@@ -110,27 +114,24 @@ class TestCooldownGuard:
             })
             data = parse_result(result)
 
-        assert data["success"] is False, (
-            f"Expected auto-resume to be refused within cooldown. "
-            f"Got: {json.dumps(data, default=str)[:400]}"
-        )
-        error_lower = data["error"].lower()
-        assert "cooldown" in error_lower or "recent" in error_lower or "seconds" in error_lower, (
-            f"Error message should cite cooldown/recent/seconds. Got: {data['error']!r}"
-        )
+        assert data["success"] is False
+        assert "archived" in data["error"].lower()
         assert data["context"]["status"] == "archived"
 
     @pytest.mark.asyncio
-    async def test_old_archive_outside_cooldown_can_still_auto_resume(
+    async def test_old_archive_is_still_refused(
         self, mock_server, mock_monitor
     ):
-        """Archive >300s ago with many updates and no marker IS auto-resumed.
+        """Archive days ago with many updates is ALSO refused.
 
-        Preserves behavior where resident agents falsely sweeped by the
-        orphan heuristic can recover by checking in after cooldown expires.
+        Pre-Stage 3 this path auto-resumed to rescue sweep-archived
+        residents. Now residents carry the 'persistent' tag (PR #39) so
+        sweep can't archive them, and auto-resume for other archived
+        agents would mask real bugs. Recovery requires explicit
+        self_recovery() or onboard(force_new=true).
         """
         agent_uuid = "test-uuid-old-archive"
-        old = (datetime.now(timezone.utc) - timedelta(seconds=400)).isoformat()
+        old = (datetime.now(timezone.utc) - timedelta(days=3)).isoformat()
         meta = _make_metadata(status="archived", total_updates=50)
         meta.archived_at = old
         meta.notes = ""
@@ -142,57 +143,14 @@ class TestCooldownGuard:
         with _apply_patches(p):
             from src.mcp_handlers.core import handle_process_agent_update
             result = await handle_process_agent_update({
-                "response_text": "Legitimate recovery after false sweep.",
+                "response_text": "Old archive — no auto-resume anymore.",
                 "response_mode": "full",
             })
             data = parse_result(result)
 
-        assert data.get("success") is True, (
-            f"Expected auto-resume to succeed for agents archived outside "
-            f"cooldown with no manual marker. Got: {json.dumps(data, default=str)[:500]}"
-        )
-
-    @pytest.mark.asyncio
-    async def test_cooldown_env_override(
-        self, mock_server, mock_monitor, monkeypatch
-    ):
-        """UNITARES_ARCHIVE_COOLDOWN_SECONDS env var overrides default.
-
-        Cooldown=1s means a 10s-old archive is OUTSIDE cooldown, so it can
-        auto-resume (assuming no other gate blocks).
-        """
-        monkeypatch.setenv("UNITARES_ARCHIVE_COOLDOWN_SECONDS", "1")
-        import importlib
-        import config.governance_config as gc
-        importlib.reload(gc)
-        assert gc.ARCHIVE_RESUME_COOLDOWN_SECONDS == 1
-
-        agent_uuid = "test-uuid-env-override"
-        recent = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
-        meta = _make_metadata(status="archived", total_updates=50)
-        meta.archived_at = recent
-        meta.notes = ""
-        mock_server.agent_metadata = {agent_uuid: meta}
-        mock_server.get_or_create_monitor.return_value = mock_monitor
-        mock_server.monitors = {agent_uuid: mock_monitor}
-
-        p = _common_patches(mock_server, agent_uuid=agent_uuid)
-        with _apply_patches(p):
-            from src.mcp_handlers.core import handle_process_agent_update
-            result = await handle_process_agent_update({
-                "response_text": "With cooldown=1s, 10s-old archive is outside window.",
-                "response_mode": "full",
-            })
-            data = parse_result(result)
-
-        assert data.get("success") is True, (
-            f"With cooldown=1s, 10s-old archive should auto-resume. "
-            f"Got: {json.dumps(data, default=str)[:500]}"
-        )
-
-        # Restore default for subsequent tests.
-        monkeypatch.delenv("UNITARES_ARCHIVE_COOLDOWN_SECONDS", raising=False)
-        importlib.reload(gc)
+        assert data["success"] is False
+        assert "archived" in data["error"].lower()
+        assert "self_recovery" in data["recovery"]["action"]
 
 
 # ----------------------------------------------------------------------
@@ -365,7 +323,8 @@ class TestIncidentReplay:
 
         assert data["success"] is False
         error_text = data["error"].lower()
-        # Either marker OR cooldown may be cited — both are correct.
-        assert "cannot be auto-resumed" in error_text
-        assert ("user requested" in error_text or "cooldown" in error_text)
+        # Stage 3 collapsed all archive-refusal reasons into a single message.
+        # The detail (marker, cooldown, etc.) isn't part of the error text
+        # anymore — the refusal itself is what matters.
+        assert "archived" in error_text and "cannot" in error_text
         assert data["context"]["status"] == "archived"

--- a/tests/test_update_workflow_service.py
+++ b/tests/test_update_workflow_service.py
@@ -356,10 +356,17 @@ async def test_run_process_update_workflow_real_spine_retries_record_state_after
 
 
 @pytest.mark.asyncio
-async def test_run_process_update_workflow_real_spine_auto_resumes_archived_agent():
-    """Archived agents should auto-resume in Phase 2 and continue through the full workflow."""
+async def test_run_process_update_workflow_real_spine_refuses_archived_agent():
+    """Archived agents are refused — no auto-resume path exists (Stage 3).
+
+    Historically this branch auto-resumed on engagement. That behavior
+    existed to rescue residents falsely orphan-archived. Now residents
+    self-tag 'persistent' (PR #39), so the rescue is unnecessary and
+    resurrection would mask real bugs. Archived agents must call
+    self_recovery(action='quick') or onboard(force_new=true) explicitly.
+    """
     harness = _make_real_spine_harness(
-        response_text="Returned from archive and implemented the fix cleanly.",
+        response_text="Attempt to check in after archive — should be refused.",
     )
     harness.meta.status = "archived"
     harness.meta.archived_at = None
@@ -376,15 +383,14 @@ async def test_run_process_update_workflow_real_spine_auto_resumes_archived_agen
 
     data = parse_result(result)
 
-    assert data["success"] is True
-    assert data["auto_resume"]["auto_resumed"] is True
-    assert data["auto_resume"]["previous_status"] == "archived"
-    assert harness.meta.status == "active"
-    assert harness.meta.archived_at is None
-    harness.meta.add_lifecycle_event.assert_called_once_with("resumed", "Auto-resumed on engagement")
-    harness.storage.update_agent.assert_awaited_once_with(harness.agent_id, status="active")
-    metadata_cache.invalidate.assert_awaited_once_with(harness.agent_id)
-    audit_logger.log_auto_resume.assert_called_once()
+    assert data["success"] is False
+    assert "archived" in data["error"].lower()
+    assert "self_recovery" in data["recovery"]["action"]
+    # Status was NOT flipped back to active; no persistence side effects.
+    assert harness.meta.status == "archived"
+    harness.storage.update_agent.assert_not_called()
+    metadata_cache.invalidate.assert_not_called()
+    harness.server.lock_manager.acquire_agent_lock_async.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -408,7 +414,7 @@ async def test_run_process_update_workflow_real_spine_blocks_explicitly_archived
     data = parse_result(result)
 
     assert data["success"] is False
-    assert "cannot be auto-resumed" in data["error"]
+    assert "archived" in data["error"] and "cannot" in data["error"]
     assert data["context"]["status"] == "archived"
     assert harness.meta.status == "archived"
     harness.server.lock_manager.acquire_agent_lock_async.assert_not_called()


### PR DESCRIPTION
Closes the Stage 3 scoping doc from PR #38.

## The call

With residents self-tagging \`persistent\` (PR #39), orphan sweep no longer targets live agents. Auto-resume's only legitimate historical role — rescuing falsely-sweeped residents — evaporates. Everything else it was doing (silently reviving manually-archived agents, reviving incident-race victims) was never correct.

Safe to rip now. Net diff: **87 insertions, 212 deletions.**

## Behavior change

Before: \`process_agent_update\` against an archived agent sometimes returned success with \`auto_resume: {auto_resumed: true}\` and flipped status back to active.

After: returns an \`AGENT_ARCHIVED\` error. Recovery is explicit — \`self_recovery(action='quick')\` or \`onboard(force_new=true)\`. These were already the documented options per the existing error message.

## What was removed

- Auto-resume branch in \`src/mcp_handlers/updates/phases.py\` (~90 lines: cooldown computation, marker-check, too-old/too-few heuristic, status flip, audit log call, \`ctx.auto_resume_info\` population)
- \`UpdateContext.auto_resume_info\` field
- \`enrichments.py\` auto_resume response enrichment
- \`ARCHIVE_RESUME_COOLDOWN_SECONDS\` config constant

## What was kept

- \`audit_logger.log_auto_resume\` library helper — unused now, but deleting it would expand the diff to 4 test files for no behavioral gain
- \`handle_archive_agent\`'s \`\"user requested\"\` notes stamping — still informational for operators
- The in-process archive gate at \`process_update_authenticated_async\` (PR #37) — still needed; Steward's in-process path doesn't go through phases.py

## Tests

- Old happy-path \`test_run_process_update_workflow_real_spine_auto_resumes_archived_agent\` → renamed/flipped to \`_refuses_archived_agent\`
- \`test_archived_agent_reactivated_on_checkin\` → \`_refused_on_checkin\`
- Sticky-archive cooldown-boundary + env-override tests: deleted (cooldown concept no longer exists)
- Error text assertions updated \`\"cannot be auto-resumed\"\` → \`\"archived ... cannot\"\`
- Full suite: **5924 passed, 52 skipped, 0 failures** (pre-existing unrelated CLI flake still ignored)

## Session arc

- #33, #34: sticky archive (cooldown + marker)
- #37: in-process archive gate (Steward bypass)
- #38: Stage 3 scoping doc (deferred — now superseded by this)
- #39: resident \`persistent\` tagging (root-cause fix) + SQL retroactive tag
- **#40 (this): rip auto-resume — the cleanup that #39 made safe.**