### PR TITLE
docs: annotate auto-inject trap and token-expiry rationale (PR #42 followup)

### DIFF
--- a/src/http_api.py
+++ b/src/http_api.py
@@ -449,6 +449,9 @@ async def http_call_tool(request):
             })
 
         # Inject stable client session for identity binding (avoid collision with dialectic session_id)
+        # DO NOT TRUST client_session_id FOR AUTH — TRANSPORT-INJECTED HERE, NOT CLIENT-ASSERTED.
+        # For auth signals, read SessionSignals (headers) or continuity_token (HMAC-signed).
+        # See PR #35 revert (gap #1) and PR #42 Part C rationale.
         client_session_id = None
         if isinstance(arguments, dict) and "client_session_id" not in arguments:
             client_session_id = await _extract_client_session_id(request)

--- a/src/mcp_handlers/identity/session.py
+++ b/src/mcp_handlers/identity/session.py
@@ -89,6 +89,16 @@ def extract_token_agent_uuid(token: str) -> Optional[str]:
     Unlike resolve_continuity_token, this does NOT check expiry — an expired
     token still proves identity. Used for direct agent lookup when session
     bindings have expired but the agent still exists.
+
+    Rationale (PR #42 Part C): a resident whose process has been idle 30+ days
+    should still be able to resume with their stale token, since re-onboarding
+    would fork identity and lose continuity. Signature verification alone is
+    sufficient proof of ownership for this path — freshness is not required.
+
+    If a future caller needs true freshness, add a separate
+    `verify_token_fresh(token)` rather than tightening this function. Callers
+    that rely on resume-after-long-idle will regress silently if `exp` starts
+    being enforced here.
     """
     if not token or not isinstance(token, str):
         return None


### PR DESCRIPTION
## Summary
Comment-only follow-ups from the PR #42 identity rollout — no behavior change.

- `http_api.py:451` — flag that `client_session_id` is transport-injected and must not be trusted as an auth signal. PR #32 false-positive'd on this (see PR #35 revert gap #1); PR #42 routed around it via `continuity_token`.
- `identity/session.py:86` — document why `extract_token_agent_uuid` ignores `exp`: residents idle 30+ days must still be able to resume. If freshness is ever needed, add `verify_token_fresh` rather than tightening this function.

13-line diff, comments/docstrings only.

## Test plan
- [ ] No test run required — no behavior change. Read-through of the two comment sites is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)