### PR TITLE
fix(sdk, sentinel): clean up connect() partial state; guard initial cycle

### DIFF
--- a/agents/sdk/src/unitares_sdk/client.py
+++ b/agents/sdk/src/unitares_sdk/client.py
@@ -73,17 +73,31 @@ class GovernanceClient:
     # --- Connection lifecycle ---
 
     async def connect(self) -> None:
-        """Open MCP transport. Call disconnect() when done."""
+        """Open MCP transport. Call disconnect() when done.
+
+        If any step fails (e.g. httpx.ConnectError during initialize), unwinds
+        whatever was already entered before re-raising. Python does NOT call
+        __aexit__ when __aenter__ raises, so without this cleanup the MCP
+        streamable_http_client's anyio task group is leaked and later unwound
+        on a different task at GC — producing the "Attempted to exit cancel
+        scope in a different task than it was entered in" crash that killed
+        the sentinel repeatedly (KG 2026-04-19T00:51:46).
+        """
         self._http_client = httpx.AsyncClient(http2=False, timeout=self.timeout)
-        cm = streamable_http_client(self.mcp_url, http_client=self._http_client)
-        read, write, _ = await cm.__aenter__()
-        self._cm_stack.append(cm)
+        try:
+            cm = streamable_http_client(self.mcp_url, http_client=self._http_client)
+            read, write, _ = await cm.__aenter__()
+            self._cm_stack.append(cm)
 
-        session_cm = ClientSession(read, write)
-        self._session = await session_cm.__aenter__()
-        self._cm_stack.append(session_cm)
+            session_cm = ClientSession(read, write)
+            self._session = await session_cm.__aenter__()
+            self._cm_stack.append(session_cm)
 
-        await self._session.initialize()
+            await self._session.initialize()
+        except Exception as e:
+            logger.warning("connect() failed (%s: %s); unwinding partial state", type(e).__name__, e)
+            await self.disconnect()
+            raise
 
     async def disconnect(self) -> None:
         """Close MCP transport."""

--- a/agents/sdk/tests/test_client.py
+++ b/agents/sdk/tests/test_client.py
@@ -471,3 +471,75 @@ class TestNotConnected:
         client = GovernanceClient()
         with pytest.raises(GovernanceConnectionError, match="Not connected"):
             await client.call_tool("onboard", {})
+
+
+# --- Connect failure cleanup ---
+
+
+class TestConnectFailureCleanup:
+    """Regression tests for the sentinel crash (KG 2026-04-19T00:51:46).
+
+    When connect() fails partway, the partially-entered context managers must
+    be unwound before the exception propagates. Otherwise Python skips
+    __aexit__, the MCP streamable_http_client's anyio task group is leaked,
+    and it crashes at GC with "Attempted to exit cancel scope in a different
+    task than it was entered in".
+    """
+
+    @pytest.mark.asyncio
+    async def test_initialize_failure_unwinds_cm_stack_and_http_client(self):
+        """session.initialize() failure must leave client in a clean state."""
+        client = GovernanceClient()
+
+        entered_cm = AsyncMock()
+        entered_cm.__aenter__ = AsyncMock(return_value=(MagicMock(), MagicMock(), MagicMock()))
+        entered_cm.__aexit__ = AsyncMock(return_value=None)
+
+        entered_session_cm = AsyncMock()
+        session_mock = AsyncMock()
+        session_mock.initialize = AsyncMock(side_effect=ConnectionError("upstream down"))
+        entered_session_cm.__aenter__ = AsyncMock(return_value=session_mock)
+        entered_session_cm.__aexit__ = AsyncMock(return_value=None)
+
+        http_client_mock = MagicMock()
+        http_client_mock.aclose = AsyncMock()
+
+        with (
+            patch("unitares_sdk.client.httpx.AsyncClient", return_value=http_client_mock),
+            patch("unitares_sdk.client.streamable_http_client", return_value=entered_cm),
+            patch("unitares_sdk.client.ClientSession", return_value=entered_session_cm),
+        ):
+            with pytest.raises(ConnectionError, match="upstream down"):
+                await client.connect()
+
+        # Original exception propagates; cleanup ran.
+        assert client._cm_stack == []
+        assert client._session is None
+        assert client._http_client is None
+        entered_cm.__aexit__.assert_called_once()
+        entered_session_cm.__aexit__.assert_called_once()
+        http_client_mock.aclose.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_transport_failure_unwinds_http_client(self):
+        """streamable_http_client.__aenter__ failure still closes the httpx client."""
+        client = GovernanceClient()
+
+        failing_cm = AsyncMock()
+        failing_cm.__aenter__ = AsyncMock(side_effect=ConnectionError("transport refused"))
+        failing_cm.__aexit__ = AsyncMock(return_value=None)
+
+        http_client_mock = MagicMock()
+        http_client_mock.aclose = AsyncMock()
+
+        with (
+            patch("unitares_sdk.client.httpx.AsyncClient", return_value=http_client_mock),
+            patch("unitares_sdk.client.streamable_http_client", return_value=failing_cm),
+        ):
+            with pytest.raises(ConnectionError, match="transport refused"):
+                await client.connect()
+
+        assert client._cm_stack == []
+        assert client._http_client is None
+        # Transport CM never registered on _cm_stack (its __aenter__ raised), so no __aexit__.
+        http_client_mock.aclose.assert_called_once()

--- a/agents/sentinel/agent.py
+++ b/agents/sentinel/agent.py
@@ -644,9 +644,14 @@ class SentinelAgent(GovernanceAgent):
         ws_task = asyncio.create_task(self.ws_consumer())
 
         try:
-            # Initial check-in
+            # Initial check-in — catch exceptions so a transient governance
+            # outage at startup doesn't kill the process and thrash launchd.
+            # Matches the periodic loop's error handling below.
             await asyncio.sleep(5)  # let WS connect
-            await self._bounded_analysis_cycle()
+            try:
+                await self._bounded_analysis_cycle()
+            except Exception as e:
+                log(f"Initial analysis cycle error: {e}")
 
             # Periodic analysis
             while self.running:


### PR DESCRIPTION
## Summary

Fixes the recurring sentinel crash cataloged in KG [2026-04-19T00:51:46](.) — 13 launchd restarts with 64 `httpx.ConnectError` → anyio cancel-scope `RuntimeError` across 36k log lines.

## Root cause

`GovernanceClient.connect()` enters two context managers onto `_cm_stack`, then calls `session.initialize()`. If `initialize()` raises (e.g. `httpx.ConnectError` when the governance endpoint is unreachable), the exception propagates out of `__aenter__` — so Python never calls `__aexit__`, `disconnect()` is never invoked, and the MCP `streamable_http_client`'s anyio task group is leaked. At GC time its cancel scope is unwound on a different task, producing:

```
RuntimeError: Attempted to exit cancel scope in a different task than it was entered in
```

This is **not** the same bug as Option F (KG 2026-04-11T11:28:22), which is a *server-side* asyncpg-in-anyio deadlock. Separate surface, separate fix.

## Changes (3 narrow, behavior-preserving)

1. **`sdk/client.py`** — wrap `connect()` body in `try/except` that calls `disconnect()` before re-raising. `disconnect()` is already robust (per-CM exception swallow). Adds one `logger.warning` on failure so future diagnostics aren't 50 lines of anyio traceback.

2. **`sentinel/agent.py`** — guard the *initial* `_bounded_analysis_cycle()` in `run_continuous()` with the same `try/except` the periodic loop already uses (matching the existing pattern exactly). Previously a connect failure at startup killed the process and launchd thrashed restarts.

3. **`sdk/tests/test_client.py`** — two regression tests in `TestConnectFailureCleanup`:
   - `test_initialize_failure_unwinds_cm_stack_and_http_client` — verifies `_cm_stack` unwinds and `httpx` client closes when `session.initialize()` raises.
   - `test_transport_failure_unwinds_http_client` — verifies cleanup when `streamable_http_client.__aenter__` itself raises.

## What's NOT in scope

- No retry/backoff semantics change. `call_tool()` already retries once on transient errors.
- No plist/launchd changes. The launchd restart behavior was masking this bug, not causing it.
- Option F / server-side asyncpg deadlock (KG 2026-04-11T11:28:22) remains open — different bug.

## Test plan

- [x] New regression tests pass: `pytest agents/sdk/tests/test_client.py::TestConnectFailureCleanup -v`
- [x] Full `test_client.py` suite still passes (33/33).
- [ ] After merge: restart `com.unitares.sentinel`, confirm `runs` count stabilizes and log no longer accumulates `httpx.ConnectError` → cancel-scope tracebacks. Transient connectivity should produce clean `Initial analysis cycle error:` log lines instead of crash-and-restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)