### PR TITLE
fix(phases): coerce None response_text to empty string

### DIFF
--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -390,8 +390,10 @@ def transform_inputs(ctx: UpdateContext) -> Optional[Sequence[TextContent]]:
 
     Returns an early-exit error response (None if successful).
     """
-    # Response Text
-    ctx.response_text = ctx.arguments.get("response_text", "")
+    # Response Text — Pydantic schema defines Optional[str] with default None,
+    # so the key is always present (possibly as None). Coerce None → "" so
+    # downstream string ops (re.findall, .lower(), slicing) stay safe.
+    ctx.response_text = ctx.arguments.get("response_text") or ""
 
     # Complexity (coerce to float — Pydantic schema accepts str|float|None)
     raw_complexity = ctx.arguments.get("complexity", 0.5)

--- a/tests/test_phases_transform_inputs.py
+++ b/tests/test_phases_transform_inputs.py
@@ -1,0 +1,36 @@
+"""Regression tests for transform_inputs response_text coercion.
+
+The Pydantic schema for process_agent_update defines
+`response_text: Optional[str] = Field(default=None)`. Arguments arriving at
+transform_inputs always include the key (possibly with value=None). Downstream
+code (execute_locked_update) calls re.findall / re.search on response_text,
+which raise TypeError on None — causing every call that omits response_text
+to fail with "expected string or bytes-like object, got 'NoneType'".
+"""
+
+from src.mcp_handlers.updates.context import UpdateContext
+from src.mcp_handlers.updates.phases import transform_inputs
+
+
+def test_transform_inputs_coerces_none_response_text_to_empty_string():
+    """Caller passes response_text=None explicitly (schema default).
+    transform_inputs must coerce to '' so downstream re.* calls are safe."""
+    ctx = UpdateContext(arguments={"response_text": None, "complexity": 0.5})
+    transform_inputs(ctx)
+    assert ctx.response_text == ""
+    assert isinstance(ctx.response_text, str)
+
+
+def test_transform_inputs_preserves_non_empty_response_text():
+    ctx = UpdateContext(
+        arguments={"response_text": "wrote a test", "complexity": 0.5}
+    )
+    transform_inputs(ctx)
+    assert ctx.response_text == "wrote a test"
+
+
+def test_transform_inputs_missing_key_defaults_to_empty_string():
+    """Key entirely absent (non-schema-validated callers)."""
+    ctx = UpdateContext(arguments={"complexity": 0.5})
+    transform_inputs(ctx)
+    assert ctx.response_text == ""


### PR DESCRIPTION
## Summary

- Fixes `TypeError: expected string or bytes-like object, got 'NoneType'` in `execute_locked_update:592` triggered by every `process_agent_update` call that omits `response_text`
- Pydantic schema defines `response_text: Optional[str] = Field(default=None)`, so the key is always present with value=None; `ctx.arguments.get("response_text", "")` returns None (key present, default ignored); downstream `re.findall(pattern, None)` raises

## Impact

This is the root cause behind every `process_agent_update` failure in the current deployment, including:
- Claude Code clients that don't pass `response_text` in work summaries
- The health-check path is unaffected (it doesn't route through this code) which is why overall governance reads healthy while work-logging is broken

## Test plan

- [x] New `tests/test_phases_transform_inputs.py` with three cases (None value, non-empty, missing key)
- [x] Verified None-case test fails without the fix (AssertionError: assert None == '')
- [x] Full test-cache.sh run: 6472 passed, 33 skipped, coverage 77.22%
- [ ] Post-merge: restart governance-mcp and verify `process_agent_update` against a Claude Code session