### PR TITLE
feat(watcher): region-aware hook + dialectic deadlock guards & synthesis participant gate

### DIFF
--- a/agents/watcher/hook_input.py
+++ b/agents/watcher/hook_input.py
@@ -1,0 +1,130 @@
+"""Region-aware input helper for the watcher PostToolUse hook.
+
+The hook used to pass only ``--file`` to the watcher, which then scanned the
+whole file. For a 1951-line module the default 90s model timeout was not
+enough. This helper runs ``git diff --unified=<context>`` on the edited file,
+parses the hunk headers, and returns the changed regions so the watcher can
+scan ~60-150 lines instead of the full file.
+
+``git diff --unified=5`` is the same primitive pre-commit, reviewdog,
+CodeRabbit and Sourcery use; the 5-line surrounding context is what LLM
+review needs to reason about semantic changes (bare changed lines alone are
+too local).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+# ``@@ -a[,b] +c[,d] @@`` — we only care about the new side (+c, +d).
+# d defaults to 1 when the comma+count is absent (git convention).
+_HUNK_HEADER_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+_GIT_DIFF_TIMEOUT_SEC = 5
+
+
+def extract_regions(file_path: str, context: int = 5) -> list[tuple[int, int]]:
+    """Return the changed line ranges (1-indexed, inclusive) of ``file_path``.
+
+    Uses ``git diff --unified=<context>`` against the working tree vs HEAD.
+    ``context`` defaults to 5 because that is the empirically-grounded window
+    LLM reviewers need (Sourcery documents the same value).
+
+    Returns ``[]`` on any failure — git unavailable, file untracked, no diff,
+    timeout. The hook is best-effort and must fall back gracefully to a
+    full-file scan rather than propagating exceptions into the edit path.
+    """
+    # Pass the absolute path so git does not depend on the caller's cwd;
+    # run from the file's parent so git finds the enclosing repo.
+    abs_path = str(Path(file_path).resolve())
+    try:
+        result = subprocess.run(
+            ["git", "diff", f"--unified={context}", "--", abs_path],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_DIFF_TIMEOUT_SEC,
+            cwd=str(Path(abs_path).parent),
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+
+    if result.returncode != 0:
+        return []
+
+    regions: list[tuple[int, int]] = []
+    for line in result.stdout.splitlines():
+        match = _HUNK_HEADER_RE.match(line)
+        if not match:
+            continue
+        start = int(match.group(1))
+        count = int(match.group(2)) if match.group(2) is not None else 1
+        if count <= 0:
+            continue
+        regions.append((start, start + count - 1))
+    return regions
+
+
+def merge_adjacent(
+    regions: list[tuple[int, int]], gap: int = 50
+) -> list[tuple[int, int]]:
+    """Merge regions whose separation is at most ``gap`` lines.
+
+    Prevents both extremes:
+    - Naive bounding box: lines 10 and 900 would become one 900-line region,
+      no better than scanning the whole file.
+    - One scan per hunk: back-to-back small edits would fan out into many
+      processes and saturate the Ollama queue.
+
+    Clusters with small gaps fuse into one prompt; disjoint clusters stay
+    separate so the caller can fire one scan per cluster in sequence.
+    """
+    if not regions:
+        return []
+    ordered = sorted(regions)
+    merged: list[tuple[int, int]] = [ordered[0]]
+    for start, end in ordered[1:]:
+        prev_start, prev_end = merged[-1]
+        if start - prev_end - 1 <= gap:
+            merged[-1] = (prev_start, max(prev_end, end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def format_region(region: tuple[int, int]) -> str:
+    """Render ``(start, end)`` as the exact ``--region`` syntax ``agent.py`` expects.
+
+    agent.py's ``read_file_region`` parses ``L<start>-L<end>``; anything else
+    is silently ignored and the watcher falls back to scanning head, which
+    defeats the entire point of this module.
+    """
+    return f"L{region[0]}-L{region[1]}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint for the bash hook.
+
+    Prints one region per line (e.g. ``L10-L30``). Empty output means the
+    hook should scan the whole file. Multiple regions mean the hook should
+    fire one watcher per region, sequentially.
+    """
+    parser = argparse.ArgumentParser(description="Extract changed regions for the watcher hook")
+    parser.add_argument("--file", required=True, help="path of the edited file")
+    parser.add_argument("--context", type=int, default=5, help="unified diff context lines")
+    parser.add_argument("--gap", type=int, default=50, help="merge regions with gap <= this")
+    args = parser.parse_args(argv)
+
+    regions = extract_regions(args.file, context=args.context)
+    merged = merge_adjacent(regions, gap=args.gap)
+    for r in merged:
+        print(format_region(r))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agents/watcher/tests/test_hook_input.py
+++ b/agents/watcher/tests/test_hook_input.py
@@ -1,0 +1,257 @@
+"""Tests for the region-aware hook input helper.
+
+Background: the PostToolUse hook (agents/watcher/watcher-hook.sh) previously
+passed only --file to the watcher, so the model scanned the whole file even
+for a two-line edit. On a 1951-line file the default 90s timeout was not
+enough. The hook_input module uses ``git diff --unified=<context>`` to
+extract just the regions that changed, so the watcher sees ~60-150 lines
+instead of the full file.
+
+Design notes:
+- ``git diff --unified=5`` is the de-facto primitive used by pre-commit,
+  reviewdog, CodeRabbit and Sourcery. The 5-line surrounding context is
+  what LLM review needs for semantic reasoning (bare diff lines alone are
+  too local).
+- Hunk headers ``@@ -a,b +c,d @@`` give us the new-side (c, c+d-1) range
+  directly; no old_string location search needed.
+- ``merge_adjacent`` addresses the review concern that a naive bounding box
+  over two far-apart edits (e.g. line 10 and line 900) would pass an
+  ~900-line prompt — as useless as scanning the whole file. Clusters with
+  small gaps merge (one prompt); disjoint clusters stay separate (two
+  sequential prompts).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def hook_input_module():
+    """Load agents/watcher/hook_input.py as a module without running __main__."""
+    project_root = Path(__file__).resolve().parent.parent.parent.parent
+    module_path = project_root / "agents" / "watcher" / "hook_input.py"
+    spec = importlib.util.spec_from_file_location("watcher_hook_input", module_path)
+    assert spec and spec.loader, f"could not load {module_path}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["watcher_hook_input"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# extract_regions — parses git diff output into (start, end) tuples
+# ---------------------------------------------------------------------------
+
+
+def _stub_git_diff(monkeypatch, module, stdout_text: str, returncode: int = 0):
+    """Replace the module's subprocess.run with a stub returning the given stdout."""
+    def _fake_run(cmd, capture_output=True, text=True, timeout=None, cwd=None):
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=returncode, stdout=stdout_text, stderr=""
+        )
+    monkeypatch.setattr(module.subprocess, "run", _fake_run)
+
+
+def test_extract_regions_single_hunk(hook_input_module, monkeypatch):
+    """One @@ header → one (start, end) tuple using the new-side numbers.
+
+    Header ``@@ -10,15 +12,20 @@`` means the new file adds 20 lines starting
+    at line 12, so the region covers lines 12 through 31 inclusive."""
+    diff_output = (
+        "diff --git a/foo.py b/foo.py\n"
+        "index abc..def 100644\n"
+        "--- a/foo.py\n"
+        "+++ b/foo.py\n"
+        "@@ -10,15 +12,20 @@ def something():\n"
+        " context\n"
+        "-removed\n"
+        "+added\n"
+    )
+    _stub_git_diff(monkeypatch, hook_input_module, diff_output)
+
+    regions = hook_input_module.extract_regions("/tmp/foo.py")
+
+    assert regions == [(12, 31)]
+
+
+def test_extract_regions_multi_hunk(hook_input_module, monkeypatch):
+    """Two @@ headers → two distinct regions preserved in order."""
+    diff_output = (
+        "diff --git a/foo.py b/foo.py\n"
+        "--- a/foo.py\n"
+        "+++ b/foo.py\n"
+        "@@ -10,5 +10,7 @@\n"
+        " context\n"
+        "+added\n"
+        "@@ -100,3 +102,8 @@\n"
+        " context\n"
+        "+added\n"
+    )
+    _stub_git_diff(monkeypatch, hook_input_module, diff_output)
+
+    regions = hook_input_module.extract_regions("/tmp/foo.py")
+
+    assert regions == [(10, 16), (102, 109)]
+
+
+def test_extract_regions_empty_diff_returns_empty_list(hook_input_module, monkeypatch):
+    """No changes → git prints nothing → no regions. Caller falls back to
+    scanning the whole file (or skipping, its choice)."""
+    _stub_git_diff(monkeypatch, hook_input_module, "")
+
+    regions = hook_input_module.extract_regions("/tmp/foo.py")
+
+    assert regions == []
+
+
+def test_extract_regions_untracked_file_returns_empty_list(
+    hook_input_module, monkeypatch
+):
+    """Untracked file → git diff returns non-zero and an error on stderr.
+    Must not raise — the hook is best-effort, fall back to full-file scan."""
+    _stub_git_diff(monkeypatch, hook_input_module, "", returncode=128)
+
+    regions = hook_input_module.extract_regions("/tmp/foo.py")
+
+    assert regions == []
+
+
+def test_extract_regions_handles_single_line_hunk(hook_input_module, monkeypatch):
+    """``@@ -42 +42 @@`` (no comma) means one-line old, one-line new at line 42."""
+    diff_output = (
+        "diff --git a/foo.py b/foo.py\n"
+        "--- a/foo.py\n"
+        "+++ b/foo.py\n"
+        "@@ -42 +42 @@\n"
+        "-old\n"
+        "+new\n"
+    )
+    _stub_git_diff(monkeypatch, hook_input_module, diff_output)
+
+    regions = hook_input_module.extract_regions("/tmp/foo.py")
+
+    assert regions == [(42, 42)]
+
+
+def test_extract_regions_subprocess_timeout_returns_empty_list(
+    hook_input_module, monkeypatch
+):
+    """Git itself hanging → extraction must time out and return empty, not
+    propagate. Hook must never block the editor."""
+    def _raise_timeout(*a, **kw):
+        raise subprocess.TimeoutExpired(cmd="git", timeout=2)
+    monkeypatch.setattr(hook_input_module.subprocess, "run", _raise_timeout)
+
+    regions = hook_input_module.extract_regions("/tmp/foo.py")
+
+    assert regions == []
+
+
+def test_extract_regions_works_against_real_repo(hook_input_module, tmp_path):
+    """Regression guard for the cwd-vs-relative-path bug: git must see the
+    file regardless of where the caller invoked extract_regions from.
+
+    The first version of this module set cwd to the file's parent but passed
+    the relative file_path, so git resolved the path under the wrong root
+    and returned empty — the hook silently fell back to full-file scans.
+    """
+    import os
+    # Minimal real git repo with one committed file and an unstaged edit.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(repo)
+        subprocess.run(["git", "init", "-q"], check=True)
+        subprocess.run(["git", "config", "user.email", "t@t"], check=True)
+        subprocess.run(["git", "config", "user.name", "t"], check=True)
+        target = repo / "foo.py"
+        target.write_text("\n".join(f"line{i}" for i in range(1, 51)) + "\n")
+        subprocess.run(["git", "add", "foo.py"], check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "seed"], check=True)
+        # Edit one line in the middle.
+        content = target.read_text().splitlines()
+        content[24] = "line25_CHANGED"
+        target.write_text("\n".join(content) + "\n")
+
+        # Call with an absolute path from a cwd that is not the repo root.
+        os.chdir(tmp_path)
+        regions = hook_input_module.extract_regions(str(target))
+    finally:
+        os.chdir(original_cwd)
+
+    assert regions, "extract_regions must find the edit regardless of caller cwd"
+    start, end = regions[0]
+    assert start <= 25 <= end, f"region {regions[0]} must cover the edited line 25"
+
+
+# ---------------------------------------------------------------------------
+# merge_adjacent — collapse near clusters, keep disjoint ranges separate
+# ---------------------------------------------------------------------------
+
+
+def test_merge_adjacent_collapses_nearby_regions(hook_input_module):
+    """Two regions with a small gap must merge into one bounding range so
+    the watcher fires one prompt, not two."""
+    regions = [(10, 30), (45, 70)]  # gap of 14 lines
+
+    merged = hook_input_module.merge_adjacent(regions, gap=50)
+
+    assert merged == [(10, 70)]
+
+
+def test_merge_adjacent_keeps_disjoint_clusters(hook_input_module):
+    """Regions with a large gap must stay separate so the prompt per scan
+    stays small. The watcher fires one scan per disjoint cluster."""
+    regions = [(10, 30), (900, 920)]  # gap of 869 lines
+
+    merged = hook_input_module.merge_adjacent(regions, gap=50)
+
+    assert merged == [(10, 30), (900, 920)]
+
+
+def test_merge_adjacent_chains_three_nearby_regions(hook_input_module):
+    """Chain of close regions all fold into one span."""
+    regions = [(10, 20), (25, 40), (45, 60)]
+
+    merged = hook_input_module.merge_adjacent(regions, gap=10)
+
+    assert merged == [(10, 60)]
+
+
+def test_merge_adjacent_respects_gap_boundary(hook_input_module):
+    """Gap exactly equal to the threshold should merge (gap is 'at most')."""
+    regions = [(10, 30), (80, 100)]  # gap of 49
+
+    merged = hook_input_module.merge_adjacent(regions, gap=50)
+
+    assert merged == [(10, 100)]
+
+
+def test_merge_adjacent_empty_input_is_empty(hook_input_module):
+    """No regions in → no regions out. Caller treats empty list as
+    'scan whole file' or 'skip entirely'; this function doesn't decide."""
+    assert hook_input_module.merge_adjacent([], gap=50) == []
+
+
+def test_merge_adjacent_single_region_passes_through(hook_input_module):
+    """One region in → same region out."""
+    assert hook_input_module.merge_adjacent([(10, 30)], gap=50) == [(10, 30)]
+
+
+# ---------------------------------------------------------------------------
+# format_region — render (start, end) as the watcher's --region flag value
+# ---------------------------------------------------------------------------
+
+
+def test_format_region_matches_watcher_region_syntax(hook_input_module):
+    """Output must be the exact form agent.py's --region argument expects:
+    ``L<start>-L<end>``. If this drifts, the watcher silently ignores the
+    flag and falls back to scanning head."""
+    assert hook_input_module.format_region((42, 58)) == "L42-L58"

--- a/agents/watcher/watcher-hook.sh
+++ b/agents/watcher/watcher-hook.sh
@@ -82,11 +82,28 @@ touch "$LOCK_FILE"
 # --- Stale lock cleanup (opportunistic, non-blocking) ---
 find "$LOCK_DIR" -name "*.lock" -mmin +10 -delete 2>/dev/null &
 
-# Fire and forget: detach the watcher so the hook returns instantly.
-# stdin/stdout/stderr go to /dev/null so the editor never sees the model call.
-nohup python3 "${WATCHER_AGENT}" \
-    --all --file "$FILE_PATH" \
-    >/dev/null 2>&1 </dev/null &
+# --- Region extraction via git diff ---
+# Ask the hook_input module for the changed regions so the watcher sees
+# ~60-150 lines (one hunk + 5 context on each side) instead of the whole
+# file. Empty output = file untracked, clean, or git unavailable; fall
+# back to scanning head. Bounded by its own internal 5s timeout.
+REGIONS=$(python3 -m agents.watcher.hook_input --file "$FILE_PATH" 2>/dev/null || true)
+
+# Fire and forget: detach a subshell that runs the watcher(s) serially.
+# One scan per disjoint region cluster keeps each prompt small; running
+# them in sequence (within one background spawn) avoids saturating the
+# Ollama queue. stdin/stdout/stderr go to /dev/null so the editor never
+# sees the model call.
+(
+    if [[ -z "$REGIONS" ]]; then
+        python3 "${WATCHER_AGENT}" --all --file "$FILE_PATH"
+    else
+        while IFS= read -r REGION; do
+            [[ -z "$REGION" ]] && continue
+            python3 "${WATCHER_AGENT}" --all --file "$FILE_PATH" --region "$REGION"
+        done <<< "$REGIONS"
+    fi
+) </dev/null >/dev/null 2>&1 &
 
 # Disown so the watcher survives the hook process exit
 disown 2>/dev/null || true

--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -1152,6 +1152,34 @@ async def handle_submit_synthesis(arguments: Dict[str, Any]) -> Sequence[TextCon
                     recovery=session_not_found_recovery(),
                 )]
 
+        # Participant-set eligibility gate. The sibling handlers
+        # (submit_thesis / submit_antithesis) pass enforce_session_ownership=True
+        # to _resolve_dialectic_agent_id; submit_synthesis intentionally relaxes
+        # that check to support the "third-party synthesizer" pattern. Without
+        # a compensating allow-list, any registered agent could drive a
+        # synthesis to convergence and trigger resolution execution — a real
+        # privilege escalation surface. The allow-list is: the paused agent,
+        # the assigned reviewer, any quorum reviewer (if escalated), and an
+        # appointed mediator if one has been set.
+        eligible = set()
+        if getattr(session, "paused_agent_id", None):
+            eligible.add(session.paused_agent_id)
+        if getattr(session, "reviewer_agent_id", None):
+            eligible.add(session.reviewer_agent_id)
+        eligible.update(getattr(session, "quorum_reviewer_ids", []) or [])
+        appointed_mediator = getattr(session, "appointed_mediator_id", None)
+        if appointed_mediator:
+            eligible.add(appointed_mediator)
+        agent_uuid = resolve_agent_uuid(arguments, agent_id)
+        if agent_id not in eligible and (not agent_uuid or agent_uuid not in eligible):
+            return [error_response(
+                f"Agent '{agent_id}' is not a participant in this dialectic session.",
+                recovery=(
+                    "Only the paused agent, the assigned reviewer, or assigned "
+                    "quorum members may submit synthesis."
+                ),
+            )]
+
         # Coerce agrees to bool (MCP tools may send "true"/"false" strings)
         raw_agrees = arguments.get('agrees', False)
         if isinstance(raw_agrees, str):
@@ -1442,23 +1470,31 @@ async def _initiate_quorum(session: DialecticSession) -> Optional[Dict[str, Any]
     session.quorum_reviewer_ids = reviewer_ids
     session.quorum_deadline = deadline
 
-    # Persist to PostgreSQL
+    # Persist to PostgreSQL. Wrapped with asyncio.wait_for because a direct
+    # ``await get_db()`` in an MCP handler path can deadlock under the
+    # anyio-asyncio conflict documented in CLAUDE.md. On timeout we fall
+    # through to the in-memory session state (already mutated above) and
+    # the subsequent ``save_session`` JSON write, matching the existing
+    # degrade-on-failure behavior.
     try:
         from src.db import get_db
-        db = await get_db()
-        await db.execute(
-            """UPDATE core.dialectic_sessions
-               SET phase = 'quorum_voting',
-                   status = 'quorum_voting',
-                   quorum_reviewer_ids = $1::jsonb,
-                   quorum_deadline = $2::timestamptz,
-                   updated_at = NOW()
-             WHERE session_id = $3""",
-            json.dumps(reviewer_ids),
-            deadline,
-            session.session_id,
+        db = await asyncio.wait_for(get_db(), timeout=0.5)
+        await asyncio.wait_for(
+            db.execute(
+                """UPDATE core.dialectic_sessions
+                   SET phase = 'quorum_voting',
+                       status = 'quorum_voting',
+                       quorum_reviewer_ids = $1::jsonb,
+                       quorum_deadline = $2::timestamptz,
+                       updated_at = NOW()
+                 WHERE session_id = $3""",
+                json.dumps(reviewer_ids),
+                deadline,
+                session.session_id,
+            ),
+            timeout=1.0,
         )
-    except Exception as e:
+    except (asyncio.TimeoutError, Exception) as e:
         logger.warning(f"Could not persist quorum to PostgreSQL: {e}")
 
     try:
@@ -1526,20 +1562,24 @@ async def handle_submit_quorum_vote(arguments: Dict[str, Any]) -> Sequence[TextC
         # Read quorum reviewer IDs from session (set by _initiate_quorum)
         quorum_reviewer_ids = getattr(session, 'quorum_reviewer_ids', []) or []
 
-        # PG fallback for sessions reconstructed before quorum_reviewer_ids was added
+        # PG fallback for sessions reconstructed before quorum_reviewer_ids was added.
+        # See _initiate_quorum above for why asyncio.wait_for is required here.
         if not quorum_reviewer_ids:
             try:
                 from src.db import get_db
-                db = await get_db()
-                row = await db.fetchrow(
-                    "SELECT quorum_reviewer_ids FROM core.dialectic_sessions WHERE session_id = $1",
-                    session_id,
+                db = await asyncio.wait_for(get_db(), timeout=0.5)
+                row = await asyncio.wait_for(
+                    db.fetchrow(
+                        "SELECT quorum_reviewer_ids FROM core.dialectic_sessions WHERE session_id = $1",
+                        session_id,
+                    ),
+                    timeout=1.0,
                 )
                 if row and row["quorum_reviewer_ids"]:
                     qr = row["quorum_reviewer_ids"]
                     quorum_reviewer_ids = json.loads(qr) if isinstance(qr, str) else qr
                     session.quorum_reviewer_ids = quorum_reviewer_ids  # Cache on session
-            except Exception as e:
+            except (asyncio.TimeoutError, Exception) as e:
                 logger.warning(f"Could not load quorum_reviewer_ids from PG: {e}")
 
         if not quorum_reviewer_ids:
@@ -1640,18 +1680,22 @@ async def handle_submit_quorum_vote(arguments: Dict[str, Any]) -> Sequence[TextC
         tally = tally_quorum_votes(quorum_votes)
         result["quorum_result"] = tally.to_dict()
 
-        # Persist quorum result
+        # Persist quorum result. See _initiate_quorum above for the rationale
+        # behind the asyncio.wait_for deadlock guard.
         try:
             from src.db import get_db
-            db = await get_db()
-            await db.execute(
-                """UPDATE core.dialectic_sessions
-                   SET quorum_result = $1::jsonb, updated_at = NOW()
-                 WHERE session_id = $2""",
-                json.dumps(tally.to_dict()),
-                session_id,
+            db = await asyncio.wait_for(get_db(), timeout=0.5)
+            await asyncio.wait_for(
+                db.execute(
+                    """UPDATE core.dialectic_sessions
+                       SET quorum_result = $1::jsonb, updated_at = NOW()
+                     WHERE session_id = $2""",
+                    json.dumps(tally.to_dict()),
+                    session_id,
+                ),
+                timeout=1.0,
             )
-        except Exception as e:
+        except (asyncio.TimeoutError, Exception) as e:
             logger.warning(f"Could not persist quorum_result to PG: {e}")
 
         if tally.achieved_supermajority and tally.action == "resume":

--- a/tests/test_dialectic_handlers.py
+++ b/tests/test_dialectic_handlers.py
@@ -1039,10 +1039,137 @@ class TestHandleSubmitSynthesis:
         assert data.get("action") == "block"
         assert "safety" in data.get("reason", "").lower()
 
+    # ------------------------------------------------------------------
+    # Participant-set eligibility gate (security)
+    #
+    # Background: before this gate, ``submit_synthesis`` called
+    # ``_resolve_dialectic_agent_id(arguments)`` with the default
+    # ``enforce_session_ownership=False``, so any registered agent could
+    # drive a synthesis to convergence and trigger resolution execution
+    # — including agents with no stake in the session. The sibling
+    # handlers (thesis/antithesis) enforce ownership; the asymmetry was
+    # intentional for the "third-party synthesizer" comment at the call
+    # site, but without a compensating allow-list it was a privilege
+    # escalation surface.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_synthesis_rejects_non_participant(
+        self, mock_server, mock_pg_add_message, mock_pg_update_phase,
+        mock_save_session, mock_context_agent,
+    ):
+        """A registered agent who is neither paused, reviewer, quorum member,
+        nor appointed mediator must be rejected — otherwise any agent on the
+        server can push a synthesis to convergence and execute resolution."""
+        from src.mcp_handlers.dialectic.handlers import handle_submit_synthesis
+
+        session = _make_session(phase=DialecticPhase.SYNTHESIS)
+        session.synthesis_round = 1
+
+        with patch(f"{DIALECTIC}.load_session", new_callable=AsyncMock,
+                   return_value=session), \
+             mock_pg_add_message, mock_pg_update_phase, mock_save_session, \
+             mock_context_agent:
+            result = await handle_submit_synthesis({
+                "session_id": session.session_id,
+                "agent_id": "agent-active",  # registered but not a participant
+                "proposed_conditions": ["Lower threshold"],
+                "root_cause": "test",
+                "reasoning": "unauthorized",
+                "agrees": True,
+                "api_key": "key123",
+            })
+
+        data = parse_result(result)
+        assert data["success"] is False
+        assert "participant" in data["error"].lower(), (
+            f"expected participant-set rejection, got: {data}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_synthesis_accepts_quorum_reviewer(
+        self, mock_server, mock_pg_add_message, mock_pg_update_phase,
+        mock_save_session, mock_context_agent,
+    ):
+        """Quorum reviewers are legitimate participants once escalation has
+        assigned them; the gate must allow their synthesis submission."""
+        from src.mcp_handlers.dialectic.handlers import handle_submit_synthesis
+
+        session = _make_session(phase=DialecticPhase.SYNTHESIS)
+        session.synthesis_round = 1
+        # Simulate: session has been escalated to quorum voting, and an
+        # assigned quorum reviewer submits a synthesis proposal.
+        session.quorum_reviewer_ids = ["agent-active"]
+
+        with patch(f"{DIALECTIC}.load_session", new_callable=AsyncMock,
+                   return_value=session), \
+             mock_pg_add_message, mock_pg_update_phase, mock_save_session, \
+             mock_context_agent:
+            result = await handle_submit_synthesis({
+                "session_id": session.session_id,
+                "agent_id": "agent-active",
+                "proposed_conditions": ["Merged quorum condition"],
+                "root_cause": "test",
+                "reasoning": "on the quorum",
+                "agrees": False,
+                "api_key": "key123",
+            })
+
+        data = parse_result(result)
+        assert data["success"] is True, (
+            f"quorum reviewer must be accepted, got: {data}"
+        )
+
 
 # ============================================================================
-# 5. handle_list_dialectic_sessions
+# Deadlock guards: any direct ``await get_db()`` in a dialectic handler path
+# must not hang the anyio task group. CLAUDE.md rule: new MCP handlers that
+# need DB access must use ``run_in_executor`` or ``asyncio.wait_for`` with a
+# tight timeout and graceful degradation. The three sites covered:
+#   1448: ``_initiate_quorum`` phase persist
+#   1533: ``handle_submit_quorum_vote`` reviewer-id fallback read
+#   1646: ``handle_submit_quorum_vote`` post-vote result persist
 # ============================================================================
+
+
+class TestDeadlockGuards:
+    """Regression guards for the anyio/asyncpg deadlock pattern."""
+
+    @pytest.mark.asyncio
+    async def test_initiate_quorum_tolerates_get_db_deadlock(
+        self, mock_server, mock_save_session,
+    ):
+        """``_initiate_quorum`` must complete within a bounded time even if
+        ``get_db`` hangs. Before the guard, a stuck asyncpg pool would
+        deadlock the whole handler; after the guard, the except path logs a
+        warning and the function returns in-memory state."""
+        import asyncio as _asyncio
+        from src.mcp_handlers.dialectic.handlers import _initiate_quorum
+
+        # Seed some eligible reviewers so _initiate_quorum gets past the
+        # select_quorum_reviewers short-circuit.
+        mock_server.agent_metadata = {
+            f"reviewer-{i}": _make_agent_meta(status="active")
+            for i in range(5)
+        }
+
+        async def _never_returns():
+            await _asyncio.sleep(60)  # intentionally longer than any handler budget
+            return None  # pragma: no cover
+
+        session = _make_session(phase=DialecticPhase.ANTITHESIS)
+
+        with patch(f"{DIALECTIC}.select_quorum_reviewers", new_callable=AsyncMock,
+                   return_value=[(f"reviewer-{i}", 1.0) for i in range(3)]), \
+             patch("src.db.get_db", side_effect=_never_returns), \
+             mock_save_session:
+            # Bound the test's own patience to prove the handler has its own
+            # timeout. If the fix works the call returns quickly; if it doesn't,
+            # this wait_for fires and the test fails with a clear reason.
+            result = await _asyncio.wait_for(_initiate_quorum(session), timeout=5.0)
+
+        assert result is not None, "quorum must still form even if PG persist hangs"
+        assert len(result["reviewer_ids"]) == 3
 
 class TestHandleListDialecticSessions:
     """Tests for handle_list_dialectic_sessions handler."""


### PR DESCRIPTION
## Summary
Two commits on this branch after rebase onto current master:

**4a525d37 feat(watcher): region-aware hook — scan only changed lines** — the PostToolUse hook used to pass only ``--file`` to the watcher, so it scanned the whole file. For a 1951-line module the 90s model timeout was not enough. A new ``hook_input`` module runs ``git diff --unified=5``, parses ``@@`` hunk headers, and returns changed line ranges. The hook fires one ``--all`` watcher per disjoint cluster, serially in one background spawn.

Warm measurements on a 32-line region vs full-file scan:
- Cold full-file: 95s+ with 3 timeouts + retry
- Warm region: 23s end-to-end (pattern + review)

**0aaefd27 Dialectic deadlock guards + synthesis participant-set eligibility gate** (commit title still says "WIP: submit_synthesis eligibility gate — handoff from Codex session" but the work is complete and the full test-cache is green — the WIP label is cosmetic from when the commit was created mid-rebase to preserve the worktree). Ships two fixes identified by code review of the prior PR state:

1. **Deadlock guards** on three ``await get_db()`` sites in ``src/mcp_handlers/dialectic/handlers.py`` (formerly at lines 1448, 1533, 1646). Direct awaits on asyncpg inside MCP handlers can deadlock the anyio task group per CLAUDE.md's documented anyio-asyncio conflict. Each site now wraps both ``get_db()`` and the subsequent query in ``asyncio.wait_for(..., timeout=…)``, matching the ``_load_binding_from_redis`` precedent; on timeout the except path logs a warning and the handler degrades to in-memory state (behavior already expected by surrounding code).

2. **Participant-set eligibility gate** on ``handle_submit_synthesis``. Previously called ``_resolve_dialectic_agent_id(arguments)`` without ``enforce_session_ownership=True``, so any registered agent could drive a synthesis to convergence and trigger resolution execution. Thesis and antithesis sibling handlers both enforce ownership; synthesis kept the relaxation deliberately for a "third-party synthesizer" pattern, but without a compensating gate that was a privilege-escalation surface. Now gated to ``{paused_agent_id, reviewer_agent_id, *quorum_reviewer_ids, appointed_mediator_id}``; non-participants receive an error with a clear recovery message.

## Test plan
- [x] 14 new unit tests for ``hook_input`` (extract_regions across hunk shapes, merge_adjacent across gap boundaries, format_region, real-repo regression for cwd/path handling)
- [x] 3 new tests covering the security/deadlock fixes:
  - ``test_synthesis_rejects_non_participant`` — registered agent not in the allow-list is rejected
  - ``test_synthesis_accepts_quorum_reviewer`` — quorum reviewers are legitimate participants
  - ``test_initiate_quorum_tolerates_get_db_deadlock`` — hanging ``get_db`` is bounded, function returns in-memory state
- [x] Pre-existing ``test_synthesis_third_party_mediator`` still passes (gate accepts ``appointed_mediator_id``)
- [x] Full ``./scripts/dev/test-cache.sh --fresh`` green: 6512 passed, 23 skipped