### PR TITLE
fix(auth): remove caller-claimed operator label privilege escalation

### DIFF
--- a/src/mcp_handlers/dialectic/auth.py
+++ b/src/mcp_handlers/dialectic/auth.py
@@ -62,7 +62,7 @@ async def resolve_dialectic_agent_id(
             from ..utils import verify_agent_ownership
 
             bound_uuid = get_context_agent_id()
-            if bound_uuid and not verify_agent_ownership(provided, arguments, allow_operator=True):
+            if bound_uuid and not verify_agent_ownership(provided, arguments):
                 return None, [error_response(
                     "agent_id override is not allowed for this call. Use your bound identity.",
                     error_code="AUTH_REQUIRED",

--- a/src/mcp_handlers/support/agent_auth.py
+++ b/src/mcp_handlers/support/agent_auth.py
@@ -393,12 +393,20 @@ def require_registered_agent(arguments: Dict[str, Any]) -> Tuple[str, Optional[T
         )
 
 
-def verify_agent_ownership(agent_id: str, arguments: Dict[str, Any], allow_operator: bool = False) -> bool:
+def verify_agent_ownership(agent_id: str, arguments: Dict[str, Any]) -> bool:
     """
     Verify that the current session owns/is bound to the given agent_id.
 
-    Uses UUID-based auth via session binding. Supports operator exception
-    for cross-agent operations.
+    Uses UUID-based auth via session binding.
+
+    The former ``allow_operator`` parameter has been removed. It granted
+    cross-agent access whenever the caller's own metadata carried
+    ``label == 'operator'`` or ``'operator'`` in ``tags``. Since labels and
+    tags are self-claimed at onboard and never server-verified, that branch
+    let any agent self-promote by onboarding with the right string. Name and
+    tag are cosmetic per the identity-invariants; lookup by label is not an
+    authorization primitive. If cross-agent privilege is needed in future,
+    it must come from an explicit server-side ACL, not caller-claimed strings.
     """
     try:
         from ..context import get_context_agent_id
@@ -414,17 +422,6 @@ def verify_agent_ownership(agent_id: str, arguments: Dict[str, Any], allow_opera
             meta = mcp_server.agent_metadata.get(bound_id)
             if meta and getattr(meta, 'agent_uuid', None) == agent_id:
                 return True
-
-            if allow_operator and meta:
-                label = getattr(meta, 'label', '') or ''
-                tags = getattr(meta, 'tags', []) or []
-                is_operator = (
-                    label.lower() == 'operator' or
-                    'operator' in [t.lower() for t in tags]
-                )
-                if is_operator:
-                    logger.info(f"Operator {bound_id} granted cross-agent access to {agent_id}")
-                    return True
 
         return False
     except Exception as e:

--- a/tests/test_mcp_utils.py
+++ b/tests/test_mcp_utils.py
@@ -683,20 +683,20 @@ class TestVerifyAgentOwnership:
 
     @patch("src.mcp_handlers.shared.get_mcp_server")
     @patch("src.mcp_handlers.context.get_context_agent_id", return_value="op")
-    def test_operator_cross(self, mc, ms):
+    def test_operator_label_no_longer_grants_access(self, mc, ms):
+        """Caller-claimed label='operator' must not grant cross-agent access.
+
+        The former allow_operator branch read self-claimed label/tag strings,
+        which any agent could set at onboard to self-promote. Removed; ACL
+        primitives that grant cross-agent access must be server-verified.
+        """
         ms.return_value = _mock_server({"op": _meta(label="Operator")})
-        assert verify_agent_ownership("other", {}, allow_operator=True) is True
+        assert verify_agent_ownership("other", {}) is False
 
     @patch("src.mcp_handlers.shared.get_mcp_server")
     @patch("src.mcp_handlers.context.get_context_agent_id", return_value="op")
-    def test_operator_tag(self, mc, ms):
+    def test_operator_tag_no_longer_grants_access(self, mc, ms):
         ms.return_value = _mock_server({"op": _meta(label="Bot", tags=["Operator"])})
-        assert verify_agent_ownership("other", {}, allow_operator=True) is True
-
-    @patch("src.mcp_handlers.shared.get_mcp_server")
-    @patch("src.mcp_handlers.context.get_context_agent_id", return_value="op")
-    def test_operator_denied_no_flag(self, mc, ms):
-        ms.return_value = _mock_server({"op": _meta(label="Operator")})
         assert verify_agent_ownership("other", {}) is False
 
     @patch("src.mcp_handlers.context.get_context_agent_id", side_effect=Exception("x"))


### PR DESCRIPTION
## Summary

- Removes the `allow_operator` branch in `verify_agent_ownership`, which honored self-claimed `label=='operator'` / `'operator' in tags` to grant cross-agent access.
- Labels and tags are set by the caller at onboard and never server-verified. Any agent could self-promote by onboarding with the right string.
- Zero active operator-tagged agents in production at time of change — regressing no live flow.

## Context

Part of the 2026-04-19 identity audit. The name-claim ghost was structurally removed 2026-04-17 (`project_name-claim-identity-ghost.md`); this was a surviving branch of the same anti-pattern (label-as-authz).

Preceded by HMAC secret rotation + plist permission lockdown (done out-of-band, no PR — launchd config).

## Follow-on

- Pydantic `OnboardParams.resume` default + `session_key` init bug (separate PR).
- Threat-model doc for scope decision (Alt A asymmetric keys vs. bearer+hygiene).
- If cross-agent privilege is needed: explicit server-side ACL table, not caller strings.

## Test plan

- [x] `tests/test_mcp_utils.py` — operator-grant tests converted to operator-denial tests; all pass.
- [x] `tests/test_dialectic_handlers.py` — passes (single caller site updated).
- [x] Full cached suite: 6486 passed, 33 skipped, 77.31% coverage.