### PR TITLE
fix(anchor-perms): Watcher anchor + client session cache must write 0600

### DIFF
--- a/agents/sdk/src/unitares_sdk/utils.py
+++ b/agents/sdk/src/unitares_sdk/utils.py
@@ -11,14 +11,22 @@ import tempfile
 from pathlib import Path
 
 
-def atomic_write(path: Path, data: str) -> None:
-    """Write data to a file atomically via temp file + os.replace."""
+def atomic_write(path: Path, data: str, mode: int = 0o600) -> None:
+    """Write data to a file atomically via temp file + os.replace.
+
+    File is created with ``mode`` (default 0o600 — owner read/write only).
+    ``tempfile.mkstemp`` already creates temp files 0o600 on POSIX, but
+    ``os.fchmod`` is called explicitly as defense-in-depth: anchor and
+    session files carry continuity tokens, and a future Python/OS change
+    to mkstemp defaults would silently regress every caller.
+    """
     fd = None
     tmp = None
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
         os.write(fd, data.encode())
+        os.fchmod(fd, mode)
         os.close(fd)
         fd = None
         os.replace(tmp, str(path))

--- a/agents/sdk/tests/test_utils.py
+++ b/agents/sdk/tests/test_utils.py
@@ -37,6 +37,41 @@ def test_atomic_write_creates_parent_dirs(tmp_path):
     assert path.read_text() == "data"
 
 
+def test_atomic_write_produces_mode_0600_by_default(tmp_path):
+    """Anchors and session files hold continuity tokens — must be 0600
+    against same-UID sibling processes reading them."""
+    import os
+    import stat as _stat
+
+    path = tmp_path / "secret.json"
+    atomic_write(path, '{"token": "secret"}')
+    assert _stat.S_IMODE(os.stat(path).st_mode) == 0o600
+
+
+def test_atomic_write_overwrite_preserves_mode_0600(tmp_path):
+    """Overwriting a previously-loose file tightens it — the old file's
+    permissions do not leak through."""
+    import os
+    import stat as _stat
+
+    path = tmp_path / "secret.json"
+    path.write_text("old")
+    os.chmod(path, 0o644)
+    atomic_write(path, "new")
+    assert _stat.S_IMODE(os.stat(path).st_mode) == 0o600
+
+
+def test_atomic_write_honors_explicit_mode(tmp_path):
+    """Caller can opt into a different mode when the file genuinely needs
+    to be world-readable (not the common case)."""
+    import os
+    import stat as _stat
+
+    path = tmp_path / "public.json"
+    atomic_write(path, "data", mode=0o644)
+    assert _stat.S_IMODE(os.stat(path).st_mode) == 0o644
+
+
 # --- load_json_state / save_json_state ---
 
 

--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -120,27 +120,35 @@ def _load_session() -> dict[str, str]:
             pass
     if LEGACY_SESSION_FILE.exists():
         try:
+            from unitares_sdk.utils import atomic_write
+
             data = json.loads(LEGACY_SESSION_FILE.read_text())
-            SESSION_FILE.parent.mkdir(parents=True, exist_ok=True)
-            SESSION_FILE.write_text(json.dumps(data))
+            atomic_write(SESSION_FILE, json.dumps(data))
             log(f"migrated watcher identity from {LEGACY_SESSION_FILE} to {SESSION_FILE}")
             return data
-        except (json.JSONDecodeError, OSError) as e:
+        except (json.JSONDecodeError, OSError, ImportError) as e:
             log(f"legacy session migration failed: {e}", "warning")
     return {}
 
 
 def _save_session(client_session_id: str, continuity_token: str, agent_uuid: str) -> None:
-    """Persist identity state to the anchor."""
+    """Persist identity state to the anchor.
+
+    Uses atomic_write (0600) because this file carries a live continuity
+    token — Watcher runs on every PostToolUse edit as the same UID as
+    every other agent on this host, so a world-readable anchor would let
+    any sibling process impersonate Watcher against the governance API.
+    """
     data = {
         "client_session_id": client_session_id,
         "continuity_token": continuity_token,
         "agent_uuid": agent_uuid,
     }
     try:
-        SESSION_FILE.parent.mkdir(parents=True, exist_ok=True)
-        SESSION_FILE.write_text(json.dumps(data))
-    except OSError as e:
+        from unitares_sdk.utils import atomic_write
+
+        atomic_write(SESSION_FILE, json.dumps(data))
+    except (OSError, ImportError) as e:
         log(f"failed to save session: {e}", "warning")
 
 

--- a/agents/watcher/tests/test_agent.py
+++ b/agents/watcher/tests/test_agent.py
@@ -2113,6 +2113,19 @@ class TestSessionAnchor:
         data = json.loads(anchor.read_text())
         assert data["agent_uuid"] == "uuid-x"
 
+    def test_save_session_writes_anchor_mode_0600(self, watcher_module, tmp_path, monkeypatch):
+        """Anchor carries continuity_token — must not be world-readable to
+        same-UID siblings. Regression guard against reintroducing
+        Path.write_text (which inherits umask 022 → 0644)."""
+        import os
+        import stat as _stat
+
+        anchor = tmp_path / "anchors" / "watcher.json"
+        monkeypatch.setattr(watcher_module, "SESSION_FILE", anchor)
+
+        watcher_module._save_session("sess", "tok", "uuid-perm")
+        assert _stat.S_IMODE(os.stat(anchor).st_mode) == 0o600
+
     def test_load_session_migrates_from_legacy_when_anchor_missing(
         self, watcher_module, tmp_path, monkeypatch
     ):

--- a/scripts/client/session_cache.py
+++ b/scripts/client/session_cache.py
@@ -16,6 +16,7 @@ import argparse
 import json
 import os
 import sys
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -51,11 +52,23 @@ def _read_json(path: Path) -> dict[str, Any]:
 
 
 def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Atomic write with mode 0600.
+
+    This file carries continuity tokens. A world-readable cache lets any
+    same-UID process impersonate the cached identity against the
+    governance API. Inlined here rather than imported from unitares_sdk
+    because this helper is intentionally dependency-free (shared by thin
+    plugin clients that don't pull in the SDK).
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(payload, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    data = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        os.write(fd, data)
+        os.fchmod(fd, 0o600)
+    finally:
+        os.close(fd)
+    os.replace(tmp, str(path))
 
 
 def _load_payload(args: argparse.Namespace) -> dict[str, Any]:

--- a/tests/test_client_session_cache_perms.py
+++ b/tests/test_client_session_cache_perms.py
@@ -1,0 +1,41 @@
+"""scripts/client/session_cache.py writes 0600.
+
+Guards against Path.write_text regression — that helper inherits umask 022,
+producing 0644 files which are readable by any same-UID process. The cache
+carries continuity tokens, so 0644 was an impersonation-by-file-read vector.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import stat as _stat
+from pathlib import Path
+
+
+def _load_session_cache_module():
+    repo_root = Path(__file__).resolve().parent.parent
+    script = repo_root / "scripts" / "client" / "session_cache.py"
+    spec = importlib.util.spec_from_file_location("client_session_cache", script)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_write_json_produces_mode_0600(tmp_path):
+    sc = _load_session_cache_module()
+    path = tmp_path / "session.json"
+    sc._write_json(path, {"continuity_token": "secret"})
+    assert _stat.S_IMODE(os.stat(path).st_mode) == 0o600
+
+
+def test_write_json_overwrite_tightens_loose_mode(tmp_path):
+    """Overwriting a pre-existing 0644 cache file drops it to 0600 —
+    old loose permissions must not leak through."""
+    sc = _load_session_cache_module()
+    path = tmp_path / "session.json"
+    path.write_text('{"old": "data"}')
+    os.chmod(path, 0o644)
+
+    sc._write_json(path, {"continuity_token": "secret"})
+    assert _stat.S_IMODE(os.stat(path).st_mode) == 0o600


### PR DESCRIPTION
## Summary

- Watcher's `_save_session` and `scripts/client/session_cache.py` wrote continuity-token files via `Path.write_text`, which inherits umask (typically 022 → 0644).
- On a single-user Mac running many agents as the same UID, any sibling process can read another agent's 0644 anchor and impersonate it against the governance API.
- Same leak the HMAC-secret rotation closed at the platform layer, re-opened at the file layer. Measured live: `~/.unitares/anchors/watcher.json` was 0644 after every re-onboard post-rotation.

## Changes

- `unitares_sdk.utils.atomic_write`: explicit `os.fchmod(fd, 0o600)` + configurable `mode` kwarg. `mkstemp` already defaults to 0600 on POSIX; fchmod is defense-in-depth.
- `agents/watcher/agent.py`: `_save_session` and legacy-migration path now use `atomic_write`.
- `scripts/client/session_cache.py._write_json`: inlined atomic write with explicit 0600 (stays dependency-free for thin plugin clients).

## Regression guards

- `test_atomic_write_produces_mode_0600_by_default`
- `test_atomic_write_overwrite_preserves_mode_0600` — overwriting a pre-existing 0644 cache file drops it to 0600.
- `test_save_session_writes_anchor_mode_0600` for Watcher.
- `test_write_json_produces_mode_0600` + overwrite-tightens variant for the client cache.

## Out of scope (follow-on PRs in own repos)

- `unitares-pi-plugin/src/unitares_pi_plugin/steward_identity.py` — same `Path.write_text` bug, payload is UUID-only (no continuity token) so lower severity.
- `unitares-governance-plugin/scripts/session_cache.py` — same bug + same severity as the unitares-repo script fixed here.

## Test plan

- [x] Targeted: `pytest agents/sdk/tests/test_utils.py agents/watcher/tests/test_agent.py tests/test_client_session_cache_perms.py` → 141 pass.
- [x] Full cached: `./scripts/dev/test-cache.sh` → 6492 pass, 33 skipped, 77.31% coverage.
- [ ] After merge: verify `stat -f '%Sp' ~/.unitares/anchors/watcher.json` reports `-rw-------` after next PostToolUse fires.