### PR TITLE
fix(onboard): archived-token onboard crashed with UnboundLocalError

### DIFF
--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -1082,6 +1082,12 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     from ..context import get_session_signals
     signals = get_session_signals()
     base_session_key = await derive_session_key(signals, arguments)
+    # Initialize session_key eagerly so no downstream branch can hit
+    # UnboundLocalError if the control flow misses its assignment (the
+    # 2026-04-19 crash was exactly this — schema/handler resume-default
+    # mismatch put us on a code path that never set session_key). The
+    # fresh-identity and force_new branches rebind it below.
+    session_key = base_session_key
     normalized_model = None
 
     # Session continuity: resume existing identity by default.
@@ -1111,20 +1117,25 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
                 base_session_key, persist=False, resume=resume,
                 token_agent_uuid=_token_agent_uuid,
             )
-            # Token-based resume failed — agent not found or not active
-            if existing_identity.get("resume_failed"):
-                return error_response(
-                    existing_identity.get("message", "Could not resume identity"),
-                    recovery={
-                        "reason": "resume_failed",
-                        "token_agent_uuid": existing_identity.get("token_agent_uuid"),
-                        "hint": "Call onboard(force_new=true) to create a new identity.",
-                    }
-                )
         else:
             existing_identity = await resolve_session_identity(
                 base_session_key, persist=False, resume=resume,
                 token_agent_uuid=_token_agent_uuid,
+            )
+        # Token-based resume can fail on either branch above (PATH 2.8 in
+        # resolve_session_identity returns resume_failed whenever the
+        # token's agent is not active, regardless of the resume flag).
+        # Hoisting the check past both branches ensures an archived-token
+        # onboard gets a clean rejection instead of falling through to
+        # code that assumes an active existing_identity.
+        if existing_identity.get("resume_failed"):
+            return error_response(
+                existing_identity.get("message", "Could not resume identity"),
+                recovery={
+                    "reason": "resume_failed",
+                    "token_agent_uuid": existing_identity.get("token_agent_uuid"),
+                    "hint": "Call onboard(force_new=true) to create a new identity.",
+                }
             )
         if not existing_identity.get("created"):
             if existing_identity.get("archived"):

--- a/src/mcp_handlers/schemas/identity.py
+++ b/src/mcp_handlers/schemas/identity.py
@@ -53,8 +53,12 @@ class OnboardParams(AgentIdentityMixin):
         description="Client hint string"
     )
     resume: Union[bool, str, None] = Field(
-        default=False,
-        description="Explicitly resume existing identity"
+        default=True,
+        description=(
+            "Resume existing identity (default True — onboard is a "
+            "resume-preferred entry point). Pass resume=false for a new "
+            "identity with predecessor link, or force_new=true for a clean break."
+        )
     )
     force_new: Union[bool, str, None] = Field(
         default=False,

--- a/tests/test_identity_handlers.py
+++ b/tests/test_identity_handlers.py
@@ -2194,6 +2194,58 @@ class TestHandleOnboardV2:
         # Verify DB update was called
         mock_db.update_agent_fields.assert_called_with(test_uuid, status="active")
 
+    @pytest.mark.asyncio
+    async def test_archived_token_without_explicit_resume_returns_clean_error(
+        self, patch_onboard_deps, mock_db, mock_redis
+    ):
+        """Regression (2026-04-19): onboard with a continuity_token for an
+        archived agent — no explicit `resume` arg — must return a clean
+        resume_failed error instead of UnboundLocalError on session_key.
+
+        The pre-fix chain was: OnboardParams default resume=False → handler's
+        `coerce_bool(default=True)` was overridden by the Pydantic-materialized
+        False → the archived-token path fell into the non-resume branch of
+        resolve_session_identity (which also returns resume_failed), but the
+        handler only checked resume_failed on the resume=True branch. The
+        non-resume branch dropped through to code that referenced an
+        uninitialized session_key, raising UnboundLocalError and returning
+        an error_response with a misleading agent_signature echo.
+        """
+        from src.mcp_handlers.identity import handlers as identity_handlers
+
+        archived_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+        async def _fake_resolve(session_key, persist, resume, token_agent_uuid=None, **_):
+            # Simulate PATH 2.8 rejecting an archived agent regardless of
+            # the resume flag (matches real resolution.py:578-634 behavior).
+            return {
+                "resume_failed": True,
+                "error": "resume_failed",
+                "token_agent_uuid": token_agent_uuid,
+                "message": (
+                    f"Continuity token references agent {token_agent_uuid[:8]}... "
+                    f"which is not active."
+                ),
+            }
+
+        with patch.object(identity_handlers, "resolve_session_identity", side_effect=_fake_resolve), \
+             patch.object(identity_handlers, "extract_token_agent_uuid", return_value=archived_uuid):
+            # Deliberately omit `resume` — exercises the Pydantic-default path.
+            result = await identity_handlers.handle_onboard_v2({
+                "client_session_id": "archived-token-no-resume",
+                "continuity_token": "v1.fake.sig",
+            })
+
+        data = parse_result(result)
+        assert data.get("success") is False, "must NOT succeed on archived-token resume"
+        err = (data.get("error") or "").lower()
+        assert "resume" in err or "not active" in err
+        recovery = data.get("recovery") or {}
+        assert recovery.get("reason") == "resume_failed"
+        assert recovery.get("token_agent_uuid") == archived_uuid
+        # Crucially: we did not raise. Before the fix this path produced
+        # UnboundLocalError on session_key.
+
 
 # ============================================================================
 # handle_verify_trajectory_identity (lines 1884-1921)


### PR DESCRIPTION
## Summary

The 2026-04-19 identity audit surfaced a Pydantic/handler contract mismatch in `handle_onboard_v2`. Passing a continuity token for an archived agent without an explicit `resume` arg produced `UnboundLocalError: cannot access local variable 'session_key'`, returned to the caller as an opaque `SESSION_ERROR` with a misleading `agent_signature` echo.

## Root cause (three-step chain)

1. **Schema/handler default mismatch.** `OnboardParams.resume` defaulted to `False`; handler at `handlers.py:1089` re-defaulted to `True` via `coerce_bool(default=True)`. `params_step` materializes Pydantic defaults into `arguments`, so the handler always saw explicit `resume=False` and the coerce default was dead code.

2. **Missing resume_failed check on one branch.** `resolve_session_identity` PATH 2.8 (`resolution.py:578-634`) returns `{resume_failed: True, ...}` for any not-active token agent, regardless of the `resume` flag. The handler only checked `resume_failed` on the `if _token_agent_uuid and resume:` branch — the else branch dropped through.

3. **session_key left unbound.** The subsequent if-elif blocks all required `created` or `resume=True`; the resume_failed-not-caught path left `session_key` unassigned, and the final else at line 1267 referenced it.

## Fixes

- **`OnboardParams.resume` default → True.** Matches documented handler intent ("Session continuity: resume existing identity by default", `handlers.py:1087-1088`) and eliminates the dead-code contradiction. `IdentityParams` and `BindSessionParams` resume defaults stay False — those tools have different semantics per their handlers.
- **Eager `session_key = base_session_key` initialization** right after `base_session_key` is derived. Belt-and-suspenders against future control-flow changes.
- **Hoisted `resume_failed` check** past both if-and-else branches. Any resume_failed from `resolve_session_identity` now yields a clean `error_response` with `recovery.reason="resume_failed"` and a `force_new=true` hint.

## Regression test

`test_archived_token_without_explicit_resume_returns_clean_error` in `TestHandleOnboardV2` — exercises the exact failure path (archived token, no resume arg), asserts no exception raised and a clean recovery payload.

## Test plan

- [x] Targeted: 24 onboard/resume-failed tests pass.
- [x] Full cached: 6510 pass, 33 skipped, 77.41% coverage.
- [ ] After merge: the 2026-04-19 incident's exact payload (`onboard(continuity_token=X)` for an archived agent, no resume) returns `success: false, error_code: resume_failed` instead of `SESSION_ERROR`.