### PR TITLE
fix(loop-detect): require fresh timestamps for proceed-based patterns

### DIFF
--- a/src/agent_loop_detection.py
+++ b/src/agent_loop_detection.py
@@ -24,6 +24,14 @@ from src.agent_metadata_persistence import load_metadata_async
 
 logger = get_logger(__name__)
 
+# Proceed-based loop patterns (P4 proceed branch, P7) count the last 10
+# decisions but have tiny time windows (≤300s). A dormant agent whose last
+# burst of 10 proceeds happened days ago still has a window that fits the
+# threshold, so any new update re-fires the alert. Require the newest
+# timestamp to be within this horizon — if the burst isn't recent, it isn't
+# a live loop.
+PROCEED_LOOP_FRESHNESS_SECONDS = 600
+
 # Telemetry: ring buffer of governance circuit breaker pause timestamps
 _governance_pause_timestamps: deque[datetime] = deque(maxlen=100)
 
@@ -224,7 +232,8 @@ def detect_loop_pattern(agent_id: str) -> tuple[bool, str]:
             try:
                 window_timestamps = [datetime.fromisoformat(ts) for ts in recent_timestamps[-10:]]
                 window_span = (window_timestamps[-1] - window_timestamps[0]).total_seconds()
-                if window_span <= 300:  # 10 proceeds in 5 minutes = suspicious
+                newest_age = (now - window_timestamps[-1]).total_seconds()
+                if window_span <= 300 and newest_age <= PROCEED_LOOP_FRESHNESS_SECONDS:
                     return True, f"Decision loop detected: {proceed_count} 'proceed' decisions in {window_span:.0f}s (agent may be stuck in feedback loop)"
             except (ValueError, TypeError, IndexError):
                 pass  # Can't parse timestamps — skip this pattern
@@ -270,8 +279,9 @@ def detect_loop_pattern(agent_id: str) -> tuple[bool, str]:
         try:
             timestamps = [datetime.fromisoformat(ts) for ts in window_timestamps]
             time_span = (timestamps[-1] - timestamps[0]).total_seconds()
+            newest_age = (now - timestamps[-1]).total_seconds()
 
-            if time_span <= 300.0:  # 5 minutes
+            if time_span <= 300.0 and newest_age <= PROCEED_LOOP_FRESHNESS_SECONDS:
                 proceed_count = sum(
                     1 for d in window_decisions
                     if d in ["proceed", "approve", "reflect", "revise"]

--- a/tests/test_loop_detection.py
+++ b/tests/test_loop_detection.py
@@ -216,6 +216,55 @@ class TestPattern7SlowProceedLoop:
             assert "Decision loop" not in reason
             assert "Slow proceed loop" not in reason
 
+    def test_stale_timestamps_do_not_trigger_pattern7(self):
+        """8 proceeds in a tight window but all >1h old should NOT re-trigger.
+
+        Regression: a dormant agent with an 8-update burst from days ago would
+        re-fire Pattern 7 (and Pattern 4) whenever a new update arrived, because
+        the last 10 timestamps still fit within 300s — the detector had no
+        freshness floor. Real-world repro: agent 2aa0ec9e burst on 2026-04-17,
+        sat idle, then a new update on 2026-04-20 re-flagged the stale 8.
+        """
+        # 8 timestamps over 200s, but the newest is 2 days old
+        timestamps = _timestamps_spaced(
+            10, spacing_seconds=25, start_offset_seconds=2 * 86400
+        )
+        decisions = ["proceed"] * 10
+
+        meta = _make_metadata(recent_timestamps=timestamps, recent_decisions=decisions)
+
+        with (
+            patch("src.agent_loop_detection.agent_metadata", {"test-agent": meta}),
+            patch("src.agent_process_mgmt.SERVER_START_TIME", datetime.now() - timedelta(hours=1)),
+        ):
+            from src.agent_loop_detection import detect_loop_pattern
+            is_loop, reason = detect_loop_pattern("test-agent")
+
+        assert not is_loop, (
+            f"Stale proceed burst (newest 2 days old) should not trigger Pattern 7, "
+            f"got: {reason}"
+        )
+
+    def test_stale_timestamps_do_not_trigger_pattern4_proceed(self):
+        """Same freshness guard should cover Pattern 4's 10-proceed-in-5-min branch."""
+        timestamps = _timestamps_spaced(
+            10, spacing_seconds=25, start_offset_seconds=2 * 86400
+        )
+        decisions = ["proceed"] * 10
+
+        meta = _make_metadata(recent_timestamps=timestamps, recent_decisions=decisions)
+
+        with (
+            patch("src.agent_loop_detection.agent_metadata", {"test-agent": meta}),
+            patch("src.agent_process_mgmt.SERVER_START_TIME", datetime.now() - timedelta(hours=1)),
+        ):
+            from src.agent_loop_detection import detect_loop_pattern
+            is_loop, reason = detect_loop_pattern("test-agent")
+
+        assert not is_loop, (
+            f"Stale proceed burst should not trigger Pattern 4 either, got: {reason}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # _safety_net_resume


### PR DESCRIPTION
## Summary
Pattern 4's 10-proceed branch and Pattern 7 both count the last 10 decisions inside a ≤300s window with no floor on timestamp freshness. Dormant agents whose last proceed burst happened days ago kept re-firing whenever a new update arrived.

## Repro
Seen 2026-04-20 in Discord `#signals`: agent `2aa0ec9e` (last active 2026-04-18) re-flagged "8 proceed decisions within 211.5s" — the burst was real but 2.5 days old.

## Fix
Add `PROCEED_LOOP_FRESHNESS_SECONDS = 600`. If the newest timestamp in the window is older than that, skip the pattern.

## Scope
Narrow — only the proceed-based branches of Pattern 4 and Pattern 7. Pause-based detection (Patterns 2, 5, 6) is unchanged. Does not address the Steward feedback loop or the Vigil `last_update` persistence bug; those are separate root causes and will get separate PRs.

## Test plan
- [x] Regression test: 10 proceeds in 225s but newest is 2 days old → no loop
- [x] Regression test for the Pattern 4 proceed branch (same scenario, covers the earlier-firing path)
- [x] Existing 11 tests still pass (cron-agent skip, autonomous skip, 9-proceed negative, etc.)
- [x] Full suite: 6514 passed, 33 skipped