### PR TITLE
fix(loop-detect): freshness guard on Pattern 4 pause branch

### DIFF
--- a/src/agent_loop_detection.py
+++ b/src/agent_loop_detection.py
@@ -24,13 +24,15 @@ from src.agent_metadata_persistence import load_metadata_async
 
 logger = get_logger(__name__)
 
-# Proceed-based loop patterns (P4 proceed branch, P7) count the last 10
-# decisions but have tiny time windows (≤300s). A dormant agent whose last
-# burst of 10 proceeds happened days ago still has a window that fits the
-# threshold, so any new update re-fires the alert. Require the newest
-# timestamp to be within this horizon — if the burst isn't recent, it isn't
-# a live loop.
+# Loop-pattern freshness guards. Both decision-based branches of Pattern 4
+# (proceed-count, pause-count) and Pattern 7 count entries in fixed-size
+# windows over recent_decisions. Without a "newest timestamp is recent"
+# floor, a dormant history keeps re-firing: any new update sees the old
+# burst, gets rejected, and the burst never rolls off. Proceeds naturally
+# fire in tight bursts (<300s window), pauses spread out more, so the
+# pause guard is deliberately wider.
 PROCEED_LOOP_FRESHNESS_SECONDS = 600
+PAUSE_LOOP_FRESHNESS_SECONDS = 3600
 
 # Telemetry: ring buffer of governance circuit breaker pause timestamps
 _governance_pause_timestamps: deque[datetime] = deque(maxlen=100)
@@ -222,7 +224,19 @@ def detect_loop_pattern(agent_id: str) -> tuple[bool, str]:
 
         pause_count = decision_counts.get("pause", 0) + decision_counts.get("reject", 0)
         if pause_count >= 5:
-            return True, f"Decision loop detected: {pause_count} 'pause' decisions in recent history (stuck state)"
+            # Don't fire on stale pause histories — they'd block updates
+            # forever, keeping recent_decisions frozen with the same pauses.
+            try:
+                window_span = min(len(decision_window), len(recent_timestamps))
+                if window_span > 0:
+                    newest_pause_ts = datetime.fromisoformat(recent_timestamps[-1])
+                    newest_age = (now - newest_pause_ts).total_seconds()
+                    if newest_age <= PAUSE_LOOP_FRESHNESS_SECONDS:
+                        return True, f"Decision loop detected: {pause_count} 'pause' decisions in recent history (stuck state)"
+            except (ValueError, TypeError, IndexError):
+                # Can't parse timestamps — fall back to original behavior to
+                # avoid masking a real loop because of bad metadata.
+                return True, f"Decision loop detected: {pause_count} 'pause' decisions in recent history (stuck state)"
 
         proceed_count = decision_counts.get("proceed", 0) + decision_counts.get("approve", 0) + decision_counts.get("reflect", 0) + decision_counts.get("revise", 0)
         if proceed_count >= 10:

--- a/tests/test_loop_detection.py
+++ b/tests/test_loop_detection.py
@@ -267,6 +267,78 @@ class TestPattern7SlowProceedLoop:
 
 
 # ---------------------------------------------------------------------------
+# Pattern 4 pause branch: freshness guard
+# ---------------------------------------------------------------------------
+
+
+class TestPattern4PauseFreshness:
+    """Pause branch must not fire on stale histories.
+
+    Regression: once Pattern 4's pause branch fires, the next update is
+    rejected before it can be recorded, so the pause-heavy window never rolls
+    over. The agent is blocked indefinitely on a static 5-pause history.
+    Seen with Steward (9a6681ec): last successful DB update 2026-04-19 06:49,
+    followed by 13+ hours of rejected retries.
+    """
+
+    def test_5_pauses_recent_triggers(self):
+        """Fresh 5-pause burst still fires — preserves existing behavior."""
+        timestamps = _timestamps_spaced(10, spacing_seconds=30)
+        decisions = ["pause"] * 5 + ["proceed"] * 5
+
+        meta = _make_metadata(recent_timestamps=timestamps, recent_decisions=decisions)
+
+        with (
+            patch("src.agent_loop_detection.agent_metadata", {"test-agent": meta}),
+            patch("src.agent_process_mgmt.SERVER_START_TIME", datetime.now() - timedelta(hours=1)),
+        ):
+            from src.agent_loop_detection import detect_loop_pattern
+            is_loop, reason = detect_loop_pattern("test-agent")
+
+        assert is_loop
+        assert "pause" in reason.lower()
+
+    def test_5_pauses_stale_does_not_trigger(self):
+        """Old pause burst (newest timestamp >1h old) should NOT block the agent."""
+        timestamps = _timestamps_spaced(
+            10, spacing_seconds=30, start_offset_seconds=6 * 3600
+        )
+        decisions = ["pause"] * 5 + ["proceed"] * 5
+
+        meta = _make_metadata(recent_timestamps=timestamps, recent_decisions=decisions)
+
+        with (
+            patch("src.agent_loop_detection.agent_metadata", {"test-agent": meta}),
+            patch("src.agent_process_mgmt.SERVER_START_TIME", datetime.now() - timedelta(hours=12)),
+        ):
+            from src.agent_loop_detection import detect_loop_pattern
+            is_loop, reason = detect_loop_pattern("test-agent")
+
+        assert not is_loop, (
+            f"Stale pause burst (newest 6h old) should not lock the agent out, "
+            f"got: {reason}"
+        )
+
+    def test_unparseable_timestamps_fallback_preserves_detection(self):
+        """If timestamps can't be parsed, fall back to firing — rather a false
+        positive than silently suppressing a real pause loop."""
+        timestamps = ["not-a-timestamp"] * 10
+        decisions = ["pause"] * 5 + ["proceed"] * 5
+
+        meta = _make_metadata(recent_timestamps=timestamps, recent_decisions=decisions)
+
+        with (
+            patch("src.agent_loop_detection.agent_metadata", {"test-agent": meta}),
+            patch("src.agent_process_mgmt.SERVER_START_TIME", datetime.now() - timedelta(hours=1)),
+        ):
+            from src.agent_loop_detection import detect_loop_pattern
+            is_loop, reason = detect_loop_pattern("test-agent")
+
+        assert is_loop
+        assert "pause" in reason.lower()
+
+
+# ---------------------------------------------------------------------------
 # _safety_net_resume
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Pattern 4's pause branch counts \`pause\`/\`reject\` entries in \`recent_decisions[-10:]\` with no time window. Once it fires, every subsequent update is rejected before it can be recorded, so the pause-heavy window never rolls over. The agent is locked out indefinitely on a static history.

## Repro
Steward (\`9a6681ec\`) last successful DB update: \`2026-04-19 06:49:04\`. Then 13+ hours of:
\`\`\`
⚠️  Loop detected for agent '9a6681ec-…': Decision loop detected: 5 'pause' decisions in recent history (stuck state) (cooldown: 30s)
\`\`\`
Every 30-minute cron attempt hit the same frozen 5-pause history, got 30s cooldown, retried, same result. DB \`last_activity_at\` stuck at 06:49 the whole time. Made Steward look silent (drove the \`Vigil silent_critical\`-adjacent symptoms I initially misdiagnosed as a persistence bug).

## Fix
Symmetric to PR #57 (proceed branch). Add \`PAUSE_LOOP_FRESHNESS_SECONDS = 3600\`: if the newest timestamp in the pause-heavy window is older than an hour, skip — a frozen pause history isn't an active loop. On unparseable timestamps, fall back to firing (old behavior).

Pauses get a longer freshness window (1h) than proceeds (10min in PR #57) because pauses come slower than proceed bursts.

## Scope
Narrow. This branch is independent of PR #57 — it adds its own constant so the two PRs can land in either order. Once both merge it'd be reasonable to consolidate into a single \`LOOP_FRESHNESS\` helper.

## Test plan
- [x] \`test_5_pauses_recent_triggers\` — existing behavior on fresh histories
- [x] \`test_5_pauses_stale_does_not_trigger\` — newest 6h old → no false positive
- [x] \`test_unparseable_timestamps_fallback_preserves_detection\` — corrupt metadata still fires (fail-safe direction)
- [x] Existing 11 tests still pass
- [x] Full suite: 6515 passed, 33 skipped

## Related
- #57 — proceed-side freshness guard
- #59 — stuck-recovery self-review fix (separate root cause contributing to the same Discord spam)