### PR TITLE
tests: unit-cover monitor_phi + monitor_calibration gaps

### DIFF
--- a/tests/test_monitor_calibration_unit.py
+++ b/tests/test_monitor_calibration_unit.py
@@ -1,0 +1,276 @@
+"""Unit tests for monitor_calibration.run_calibration_recording.
+
+Scope: trajectory validation gating (elapsed time + prev verdict), state mutation,
+and strategic/tactical calibration recording branches (src/monitor_calibration.py
+lines 40-103).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.monitor_calibration import run_calibration_recording
+
+
+def _make_monitor(
+    *,
+    prev_verdict=None,
+    prev_drift_norm=None,
+    prev_confidence=0.5,
+    prev_checkin_time=None,
+    drift_norm=0.1,
+    agent_id="agent-test",
+):
+    monitor = MagicMock()
+    monitor._prev_verdict_action = prev_verdict
+    monitor._prev_drift_norm = prev_drift_norm
+    monitor._prev_confidence = prev_confidence
+    monitor._prev_checkin_time = prev_checkin_time
+    monitor._last_drift_vector = SimpleNamespace(norm=drift_norm)
+    monitor.agent_id = agent_id
+    monitor.register_tactical_prediction = MagicMock()
+    return monitor
+
+
+def _drift(norm=0.1):
+    return SimpleNamespace(norm=norm)
+
+
+class TestTrajectoryValidationGating:
+    def test_no_prev_verdict_returns_none(self):
+        monitor = _make_monitor(prev_verdict=None, prev_drift_norm=None)
+        with patch("src.monitor_calibration.calibration_checker"), \
+             patch("src.tool_usage_tracker.get_tool_usage_tracker") as g:
+            g.side_effect = Exception("no tracker")
+            result = run_calibration_recording(
+                monitor, confidence=0.7,
+                decision={"action": "proceed"},
+                drift_vector=_drift(0.1),
+            )
+        assert result is None
+
+    def test_elapsed_under_10s_returns_none(self):
+        import time
+        monitor = _make_monitor(
+            prev_verdict="proceed", prev_drift_norm=0.2,
+            prev_checkin_time=time.monotonic() - 5.0,  # only 5s ago
+        )
+        with patch("src.monitor_calibration.calibration_checker"), \
+             patch("src.tool_usage_tracker.get_tool_usage_tracker") as g:
+            g.side_effect = Exception()
+            result = run_calibration_recording(
+                monitor, confidence=0.7,
+                decision={"action": "proceed"},
+                drift_vector=_drift(0.1),
+            )
+        assert result is None
+
+    def test_elapsed_over_10s_returns_validation(self):
+        import time
+        monitor = _make_monitor(
+            prev_verdict="proceed", prev_drift_norm=0.3,
+            prev_checkin_time=time.monotonic() - 15.0,
+        )
+        with patch("src.monitor_calibration.calibration_checker"), \
+             patch("src.tool_usage_tracker.get_tool_usage_tracker") as g:
+            g.side_effect = Exception()
+            result = run_calibration_recording(
+                monitor, confidence=0.7,
+                decision={"action": "proceed"},
+                drift_vector=_drift(0.1),
+            )
+        assert result is not None
+        assert result["prev_verdict"] == "proceed"
+        assert result["prev_norm"] == 0.3
+        assert result["current_norm"] == 0.1
+        assert result["norm_delta"] == pytest.approx(0.2)
+        assert 0.0 <= result["quality"] <= 1.0
+        assert result["quality"] > 0.5  # improvement → quality above 0.5
+
+
+class TestTacticalDecisionRecording:
+    def test_large_positive_delta_records_success(self):
+        import time
+        monitor = _make_monitor(
+            prev_verdict="proceed", prev_drift_norm=0.5,
+            prev_confidence=0.8,
+            prev_checkin_time=time.monotonic() - 15.0,
+        )
+        with patch("src.monitor_calibration.calibration_checker") as ccm, \
+             patch("src.tool_usage_tracker.get_tool_usage_tracker") as g:
+            g.side_effect = Exception()
+            run_calibration_recording(
+                monitor, confidence=0.7,
+                decision={"action": "proceed"},
+                drift_vector=_drift(0.1),
+            )
+        # Tactical decision recorded with immediate_outcome=True
+        ccm.record_tactical_decision.assert_called_once()
+        call = ccm.record_tactical_decision.call_args
+        assert call.kwargs["confidence"] == 0.8
+        assert call.kwargs["decision"] == "proceed"
+        assert call.kwargs["immediate_outcome"] is True
+
+    def test_small_delta_no_tactical_recording(self):
+        import time
+        monitor = _make_monitor(
+            prev_verdict="proceed", prev_drift_norm=0.11,
+            prev_checkin_time=time.monotonic() - 15.0,
+        )
+        with patch("src.monitor_calibration.calibration_checker") as ccm, \
+             patch("src.tool_usage_tracker.get_tool_usage_tracker") as g:
+            g.side_effect = Exception()
+            run_calibration_recording(
+                monitor, confidence=0.7,
+                decision={"action": "proceed"},
+                drift_vector=_drift(0.10),
+            )
+        # abs(norm_delta)=0.01 < 0.03 threshold → no tactical record
+        ccm.record_tactical_decision.assert_not_called()
+
+    def test_guide_verdict_skips_tactical_record(self):
+        import time
+        monitor = _make_monitor(
+            prev_verdict="guide", prev_drift_norm=0.5,
+            prev_checkin_time=time.monotonic() - 15.0,
+        )
+        with patch("src.monitor_calibration.calibration_checker") as ccm, \
+             patch("src.tool_usage_tracker.get_tool_usage_tracker") as g:
+            g.side_effect = Exception()
+            run_calibration_recording(
+                monitor, confidence=0.7,
+                decision={"action": "guide"},
+                drift_vector=_drift(0.1),
+            )
+        # prev_verdict "guide" not in ('proceed', 'pause') → tactical from prev skipped
+        # current decision "guide" also not in ('proceed', 'pause')
+        ccm.record_tactical_decision.assert_not_called()
+
+
+class TestStrategicPrediction:
+    def test_tool_stats_with_enough_calls_records_prediction(self):
+        import time
+        monitor = _make_monitor(
+            prev_verdict=None, prev_checkin_time=time.monotonic(),
+        )
+        fake_stats = {
+            "total_calls": 5,
+            "tools": {"t1": {"success_count": 4}, "t2": {"success_count": 0}},
+        }
+        tracker = MagicMock()
+        tracker.get_usage_stats = MagicMock(return_value=fake_stats)
+
+        with patch("src.monitor_calibration.calibration_checker") as ccm, \
+             patch("src.tool_usage_tracker.get_tool_usage_tracker",
+                   return_value=tracker):
+            run_calibration_recording(
+                monitor, confidence=0.75,
+                decision={"action": "proceed"},
+                drift_vector=_drift(0.1),
+            )
+        ccm.record_prediction.assert_called_once()
+        call = ccm.record_prediction.call_args
+        assert call.kwargs["confidence"] == 0.75
+        assert call.kwargs["predicted_correct"] is True
+        assert call.kwargs["actual_correct"] == pytest.approx(0.8)
+        # tool_accuracy 0.8 >= 0.6 → outcome_was_good True
+        # confidence 0.75 >= 0.6 → immediate_outcome = True
+        ccm.record_tactical_decision.assert_called_once()
+        assert ccm.record_tactical_decision.call_args.kwargs["immediate_outcome"] is True
+
+    def test_low_confidence_inverts_immediate_outcome(self):
+        import time
+        monitor = _make_monitor(
+            prev_verdict=None, prev_checkin_time=time.monotonic(),
+        )
+        fake_stats = {
+            "total_calls": 5,
+            "tools": {"t1": {"success_count": 1}},
+        }
+        tracker = MagicMock()
+        tracker.get_usage_stats = MagicMock(return_value=fake_stats)
+        with patch("src.monitor_calibration.calibration_checker") as ccm, \
+             patch("src.tool_usage_tracker.get_tool_usage_tracker",
+                   return_value=tracker):
+            run_calibration_recording(
+                monitor, confidence=0.3,
+                decision={"action": "proceed"},
+                drift_vector=_drift(0.1),
+            )
+        # tool_accuracy 0.2 < 0.6 → outcome_was_good False
+        # confidence 0.3 < 0.6 → immediate_outcome = not outcome_was_good = True
+        assert ccm.record_tactical_decision.call_args.kwargs["immediate_outcome"] is True
+
+    def test_too_few_calls_no_prediction(self):
+        import time
+        monitor = _make_monitor(
+            prev_verdict=None, prev_checkin_time=time.monotonic(),
+        )
+        tracker = MagicMock()
+        tracker.get_usage_stats = MagicMock(return_value={"total_calls": 2, "tools": {}})
+        with patch("src.monitor_calibration.calibration_checker") as ccm, \
+             patch("src.tool_usage_tracker.get_tool_usage_tracker",
+                   return_value=tracker):
+            run_calibration_recording(
+                monitor, confidence=0.7,
+                decision={"action": "proceed"},
+                drift_vector=_drift(0.1),
+            )
+        ccm.record_prediction.assert_not_called()
+
+    def test_tracker_exception_silently_skips_prediction(self):
+        import time
+        monitor = _make_monitor(
+            prev_verdict=None, prev_checkin_time=time.monotonic(),
+        )
+        with patch("src.monitor_calibration.calibration_checker") as ccm, \
+             patch("src.tool_usage_tracker.get_tool_usage_tracker") as g:
+            g.side_effect = RuntimeError("boom")
+            # Should not raise
+            run_calibration_recording(
+                monitor, confidence=0.7,
+                decision={"action": "proceed"},
+                drift_vector=_drift(0.1),
+            )
+        ccm.record_prediction.assert_not_called()
+
+
+class TestStateMutation:
+    def test_mutates_prev_state_after_recording(self):
+        import time
+        monitor = _make_monitor(
+            prev_verdict="proceed", prev_drift_norm=0.5,
+            prev_confidence=0.2,
+            prev_checkin_time=time.monotonic() - 20.0,
+        )
+        before = monitor._prev_checkin_time
+        with patch("src.monitor_calibration.calibration_checker"), \
+             patch("src.tool_usage_tracker.get_tool_usage_tracker") as g:
+            g.side_effect = Exception()
+            run_calibration_recording(
+                monitor, confidence=0.9,
+                decision={"action": "pause"},
+                drift_vector=_drift(0.07),
+            )
+        assert monitor._prev_verdict_action == "pause"
+        assert monitor._prev_drift_norm == 0.07
+        assert monitor._prev_confidence == 0.9
+        assert monitor._prev_checkin_time > before
+
+    def test_registers_tactical_prediction(self):
+        import time
+        monitor = _make_monitor(
+            prev_verdict=None, prev_checkin_time=time.monotonic(),
+        )
+        with patch("src.monitor_calibration.calibration_checker"), \
+             patch("src.tool_usage_tracker.get_tool_usage_tracker") as g:
+            g.side_effect = Exception()
+            run_calibration_recording(
+                monitor, confidence=0.65,
+                decision={"action": "proceed"},
+                drift_vector=_drift(0.1),
+            )
+        monitor.register_tactical_prediction.assert_called_once_with(
+            0.65, decision_action="proceed"
+        )

--- a/tests/test_monitor_phi_unit.py
+++ b/tests/test_monitor_phi_unit.py
@@ -1,0 +1,156 @@
+"""Unit tests for monitor_phi.compute_phi_and_risk task-type adjustment branches.
+
+Scope: the pure-arithmetic risk adjustments in compute_phi_and_risk (src/monitor_phi.py
+lines 33-68). Uses a stub monitor so phi_objective/verdict_from_phi run with real
+governance_core values; only estimate_risk is controlled.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.monitor_phi import compute_phi_and_risk
+
+
+def _make_monitor(s_value: float, estimate_risk_return: float) -> MagicMock:
+    monitor = MagicMock()
+    monitor.state.S = s_value
+    monitor.state.unitaires_state = SimpleNamespace(E=0.5, I=0.5, S=s_value, V=0.0)
+    monitor.estimate_risk = MagicMock(return_value=estimate_risk_return)
+    return monitor
+
+
+class TestEmptyDeltaEta:
+    def test_missing_ethical_drift_defaults_to_zeros(self):
+        monitor = _make_monitor(s_value=0.5, estimate_risk_return=0.2)
+        phi, verdict, risk, adj, orig = compute_phi_and_risk(
+            monitor, grounded_agent_state={}, agent_state={}, task_type="mixed"
+        )
+        assert risk == 0.2
+        assert adj is None
+
+    def test_empty_list_ethical_drift_defaults_to_zeros(self):
+        monitor = _make_monitor(s_value=0.5, estimate_risk_return=0.2)
+        phi, verdict, risk, adj, orig = compute_phi_and_risk(
+            monitor,
+            grounded_agent_state={"ethical_drift": []},
+            agent_state={},
+            task_type="mixed",
+        )
+        assert adj is None
+
+
+class TestConvergentTask:
+    def test_convergent_s_zero_high_risk_is_reduced(self):
+        monitor = _make_monitor(s_value=0.0, estimate_risk_return=0.6)
+        phi, verdict, risk, adj, orig = compute_phi_and_risk(
+            monitor, grounded_agent_state={}, agent_state={}, task_type="convergent"
+        )
+        assert orig == 0.6
+        assert risk == pytest.approx(0.48)  # max(0.2, 0.6 * 0.8)
+        assert adj["applied"] is True
+        assert adj["adjustment"] == "reduced"
+
+    def test_convergent_s_zero_low_risk_hits_floor(self):
+        monitor = _make_monitor(s_value=0.0, estimate_risk_return=0.31)
+        _, _, risk, adj, orig = compute_phi_and_risk(
+            monitor, grounded_agent_state={}, agent_state={}, task_type="convergent"
+        )
+        assert risk == pytest.approx(0.248)  # 0.31 * 0.8 > 0.2
+        assert adj is not None
+
+    def test_convergent_s_zero_below_threshold_no_adjustment(self):
+        monitor = _make_monitor(s_value=0.0, estimate_risk_return=0.25)
+        _, _, risk, adj, _ = compute_phi_and_risk(
+            monitor, grounded_agent_state={}, agent_state={}, task_type="convergent"
+        )
+        assert risk == 0.25
+        assert adj is None
+
+    def test_convergent_s_nonzero_no_adjustment(self):
+        monitor = _make_monitor(s_value=0.1, estimate_risk_return=0.6)
+        _, _, risk, adj, _ = compute_phi_and_risk(
+            monitor, grounded_agent_state={}, agent_state={}, task_type="convergent"
+        )
+        assert risk == 0.6
+        assert adj is None
+
+
+class TestDivergentTask:
+    def test_divergent_s_zero_low_risk_is_increased(self):
+        monitor = _make_monitor(s_value=0.0, estimate_risk_return=0.3)
+        _, _, risk, adj, orig = compute_phi_and_risk(
+            monitor, grounded_agent_state={}, agent_state={}, task_type="divergent"
+        )
+        assert orig == 0.3
+        assert risk == pytest.approx(0.345)  # min(0.5, 0.3 * 1.15)
+        assert adj["adjustment"] == "increased"
+
+    def test_divergent_s_zero_risk_ceiling_capped(self):
+        monitor = _make_monitor(s_value=0.0, estimate_risk_return=0.39)
+        _, _, risk, adj, _ = compute_phi_and_risk(
+            monitor, grounded_agent_state={}, agent_state={}, task_type="divergent"
+        )
+        # 0.39 * 1.15 = 0.4485, under 0.5 cap
+        assert risk == pytest.approx(0.4485)
+        assert adj is not None
+
+    def test_divergent_s_zero_high_risk_no_adjustment(self):
+        monitor = _make_monitor(s_value=0.0, estimate_risk_return=0.45)
+        _, _, risk, adj, _ = compute_phi_and_risk(
+            monitor, grounded_agent_state={}, agent_state={}, task_type="divergent"
+        )
+        assert risk == 0.45
+        assert adj is None
+
+
+class TestExplorationIntrospection:
+    @pytest.mark.parametrize("task_type", ["exploration", "introspection"])
+    def test_high_risk_reduced_by_0_08_with_floor_0_45(self, task_type):
+        monitor = _make_monitor(s_value=0.3, estimate_risk_return=0.7)
+        _, _, risk, adj, orig = compute_phi_and_risk(
+            monitor, grounded_agent_state={}, agent_state={}, task_type=task_type
+        )
+        assert orig == 0.7
+        assert risk == pytest.approx(0.62)  # max(0.45, 0.7 - 0.08)
+        assert adj["risk_adjusted_by"] == -0.08
+
+    @pytest.mark.parametrize("task_type", ["exploration", "introspection"])
+    def test_risk_reduction_respects_floor(self, task_type):
+        monitor = _make_monitor(s_value=0.3, estimate_risk_return=0.51)
+        _, _, risk, adj, _ = compute_phi_and_risk(
+            monitor, grounded_agent_state={}, agent_state={}, task_type=task_type
+        )
+        assert risk == pytest.approx(0.45)  # 0.51 - 0.08 = 0.43, clamped up to 0.45
+        assert adj is not None
+
+    def test_exploration_low_risk_no_adjustment(self):
+        monitor = _make_monitor(s_value=0.3, estimate_risk_return=0.4)
+        _, _, risk, adj, _ = compute_phi_and_risk(
+            monitor, grounded_agent_state={}, agent_state={}, task_type="exploration"
+        )
+        assert risk == 0.4
+        assert adj is None
+
+
+class TestMixedTaskType:
+    def test_mixed_reads_task_type_from_agent_state(self):
+        monitor = _make_monitor(s_value=0.0, estimate_risk_return=0.6)
+        _, _, risk, adj, _ = compute_phi_and_risk(
+            monitor,
+            grounded_agent_state={},
+            agent_state={"task_type": "convergent"},
+            task_type="mixed",
+        )
+        assert risk == pytest.approx(0.48)
+        assert adj is not None
+
+    def test_mixed_defaults_to_mixed_when_agent_state_omits(self):
+        monitor = _make_monitor(s_value=0.0, estimate_risk_return=0.6)
+        _, _, risk, adj, _ = compute_phi_and_risk(
+            monitor, grounded_agent_state={}, agent_state={}, task_type="mixed"
+        )
+        # "mixed" doesn't match any branch → no adjustment
+        assert risk == 0.6
+        assert adj is None


### PR DESCRIPTION
Lifts direct coverage:
- `src/monitor_phi.py`: 63% → 100%
- `src/monitor_calibration.py`: 60% → 100%

Both modules were previously exercised only transitively via `test_governance_monitor*.py`, leaving task-type risk-adjustment branches and trajectory/strategic/tactical calibration paths uncovered.

**No production changes.** 28 new pure-unit tests, 0.8s runtime, full suite passes (6567 passed / 33 skipped).

Methodology: measured gap against both governance_monitor test files (16.5 min run). The lowest-coverage module, `monitor_cirs.py` (48%), was deliberately skipped — its gap is the legacy v0.1 dispatcher branch, and `src/cirs.py` already has direct tests (`test_cirs.py`, `test_cirs_resonance_wiring.py`).