### PR TITLE
fix(dialectic): gate reviewer auto-select behind UNITARES_AUTOSELECT_REVIEWER (default off) — the candidate pool is ghost sessions + non-reasoning scripts, so auto-assign is dishonest until a real summonable reasoner is wired in. Callers already handle None cleanly (self-review / awaiting-facilitation / NO_REVIEWER).

### DIFF
--- a/src/mcp_handlers/dialectic/reviewer.py
+++ b/src/mcp_handlers/dialectic/reviewer.py
@@ -11,6 +11,7 @@ is the source of truth for queries that need cross-process visibility.
 
 from typing import Dict, Any, List, Optional
 from datetime import datetime, timedelta
+import os
 import random
 import json
 import asyncio
@@ -31,6 +32,25 @@ from src.dialectic_db import (
 )
 
 logger = get_logger(__name__)
+
+
+def _autoselect_enabled() -> bool:
+    """Gate for reviewer auto-selection.
+
+    Off by default. The candidate pool is dominated by ephemeral sessions that
+    are still flagged active in metadata long after their process exited, plus
+    resident agents that are deterministic scripts (pytest, threshold checks,
+    regex matching) and cannot perform dialectic reasoning. Assigning either
+    kind as a reviewer is dishonest. Callers receiving ``None`` fall through
+    to self-review, awaiting-facilitation, or an explicit NO_REVIEWER error.
+
+    Set ``UNITARES_AUTOSELECT_REVIEWER=1`` once a real reasoner is wired in
+    (e.g. call_model with a capable backend, or a live pool of summonable
+    agents).
+    """
+    return os.environ.get("UNITARES_AUTOSELECT_REVIEWER", "").lower() in (
+        "1", "true", "yes", "on",
+    )
 
 async def _has_recently_reviewed(reviewer_id: str, paused_agent_id: str, hours: int = 24) -> bool:
     """
@@ -254,6 +274,14 @@ async def select_reviewer(paused_agent_id: str,
     Returns:
         Selected reviewer agent_id, or None if no reviewer available
     """
+    if not _autoselect_enabled():
+        logger.info(
+            "[DIALECTIC] Reviewer auto-select disabled "
+            "(UNITARES_AUTOSELECT_REVIEWER unset). Returning None — caller "
+            "should self-review, await facilitation, or accept manual assignment."
+        )
+        return None
+
     if not metadata or not isinstance(metadata, dict):
         return None
 
@@ -356,6 +384,14 @@ async def select_quorum_reviewers(
         List of (agent_id, authority_score) tuples sorted by score descending,
         or empty list if fewer than min_reviewers are eligible.
     """
+    if not _autoselect_enabled():
+        logger.info(
+            "[DIALECTIC] Quorum auto-select disabled "
+            "(UNITARES_AUTOSELECT_REVIEWER unset). Returning empty list — "
+            "caller should escalate or assign quorum manually."
+        )
+        return []
+
     if not metadata or not isinstance(metadata, dict):
         return []
 

--- a/tests/test_dialectic_handlers.py
+++ b/tests/test_dialectic_handlers.py
@@ -1655,6 +1655,22 @@ class TestGetDialecticNextSteps:
 class TestSelectQuorumReviewers:
     """Tests for select_quorum_reviewers from reviewer.py."""
 
+    @pytest.fixture(autouse=True)
+    def _enable_autoselect(self, monkeypatch):
+        # Quorum auto-select is gated off by default (ghost-reviewer fix);
+        # these tests exercise the filter logic and opt in via the env flag.
+        monkeypatch.setenv("UNITARES_AUTOSELECT_REVIEWER", "1")
+
+    @pytest.mark.asyncio
+    async def test_disabled_by_default(self, monkeypatch):
+        """When the env flag is unset, quorum selection returns [] immediately."""
+        from src.mcp_handlers.dialectic.reviewer import select_quorum_reviewers
+        monkeypatch.delenv("UNITARES_AUTOSELECT_REVIEWER", raising=False)
+        session = _make_session(phase=DialecticPhase.ESCALATED)
+        metadata = {f"agent-{i}": _make_agent_meta() for i in range(8)}
+        result = await select_quorum_reviewers(session, metadata)
+        assert result == []
+
     @pytest.mark.asyncio
     async def test_not_enough_agents(self):
         """Returns empty list when fewer than 3 candidates exist."""

--- a/tests/test_remaining_modules.py
+++ b/tests/test_remaining_modules.py
@@ -983,6 +983,13 @@ class TestIsAgentInActiveSession:
 
 
 class TestSelectReviewer:
+    @pytest.fixture(autouse=True)
+    def _enable_autoselect(self, monkeypatch):
+        # Existing coverage asserts the ranking / filtering behavior of
+        # select_reviewer; the feature is gated off by default as of the
+        # ghost-reviewer fix, so these tests opt in via the env flag.
+        monkeypatch.setenv("UNITARES_AUTOSELECT_REVIEWER", "1")
+
     @pytest.mark.asyncio
     async def test_no_metadata(self):
         result = await select_reviewer("agent-1", metadata=None)
@@ -991,6 +998,30 @@ class TestSelectReviewer:
     @pytest.mark.asyncio
     async def test_empty_metadata(self):
         result = await select_reviewer("agent-1", metadata={})
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_disabled_by_default(self, monkeypatch):
+        # Overrides the class-level autouse fixture for this case.
+        monkeypatch.delenv("UNITARES_AUTOSELECT_REVIEWER", raising=False)
+        metadata = {
+            "agent-1": {"status": "active"},
+            "agent-2": {"status": "active"},
+        }
+        # No patches on is_agent_in_active_session / _has_recently_reviewed —
+        # the gate must short-circuit before any candidate inspection happens.
+        result = await select_reviewer("agent-1", metadata=metadata)
+        assert result is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", ""])
+    async def test_disabled_when_flag_falsy(self, monkeypatch, value):
+        monkeypatch.setenv("UNITARES_AUTOSELECT_REVIEWER", value)
+        metadata = {
+            "agent-1": {"status": "active"},
+            "agent-2": {"status": "active"},
+        }
+        result = await select_reviewer("agent-1", metadata=metadata)
         assert result is None
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.