### PR TITLE
fix(events): drop UUID audit rows from /api/events under int cursor

### DIFF
--- a/src/http_api.py
+++ b/src/http_api.py
@@ -925,19 +925,30 @@ async def http_events(request):
                 )
                 # Merge: use in-memory event_ids to deduplicate
                 mem_ids = {e.get("event_id") for e in events if e.get("event_id")}
+                # When `since` is given, audit rows with non-int event_ids (UUIDs)
+                # are unreachable via the int-cursor protocol and would replay
+                # every poll — drop them. See CIRWEL/unitares#25.
+                int_cursor = since is not None
                 for de in db_events:
-                    if de.get("event_id") not in mem_ids:
-                        # Reshape audit row → dashboard event shape
-                        payload = de.get("details", {})
-                        events.append({
-                            "type": payload.get("type", de.get("event_type", "")),
-                            "severity": payload.get("severity", "info"),
-                            "message": payload.get("message", de.get("event_type", "")),
-                            "agent_id": de.get("agent_id"),
-                            "agent_name": payload.get("agent_name", ""),
-                            "timestamp": de.get("timestamp"),
-                            "event_id": de.get("event_id"),
-                        })
+                    de_id = de.get("event_id")
+                    if de_id in mem_ids:
+                        continue
+                    if int_cursor:
+                        try:
+                            int(de_id)
+                        except (TypeError, ValueError):
+                            continue
+                    # Reshape audit row → dashboard event shape
+                    payload = de.get("details", {})
+                    events.append({
+                        "type": payload.get("type", de.get("event_type", "")),
+                        "severity": payload.get("severity", "info"),
+                        "message": payload.get("message", de.get("event_type", "")),
+                        "agent_id": de.get("agent_id"),
+                        "agent_name": payload.get("agent_name", ""),
+                        "timestamp": de.get("timestamp"),
+                        "event_id": de_id,
+                    })
                 events.sort(key=lambda e: e.get("timestamp", ""), reverse=True)
                 events = events[:limit]
             except Exception as db_err:

--- a/tests/test_http_api_events_cursor.py
+++ b/tests/test_http_api_events_cursor.py
@@ -1,0 +1,83 @@
+"""Tests for /api/events int-cursor protocol (CIRWEL/unitares#25).
+
+The audit-DB supplement can return rows with UUID event_ids. When a client
+supplies an int `since` cursor, those rows are unreachable — they'd replay
+every poll. Drop them from the supplement under int-cursor mode; keep them
+when no cursor is given (dashboard case).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from src.event_detector import event_detector
+from src.http_api import http_events
+
+
+@pytest.fixture(autouse=True)
+def clear_events():
+    event_detector.clear_events()
+    event_detector._recent_fingerprints.clear()
+    event_detector._event_counter = 0
+    yield
+    event_detector.clear_events()
+    event_detector._recent_fingerprints.clear()
+    event_detector._event_counter = 0
+
+
+@pytest.fixture(autouse=True)
+def _no_http_api_token(monkeypatch):
+    monkeypatch.delenv("UNITARES_HTTP_API_TOKEN", raising=False)
+
+
+@pytest.fixture
+def client():
+    app = Starlette(routes=[Route("/api/events", http_events, methods=["GET"])])
+    return TestClient(app)
+
+
+def _audit_row(event_id, event_type="cross_device_call"):
+    return {
+        "event_id": event_id,
+        "event_type": event_type,
+        "agent_id": "agent-x",
+        "timestamp": "2026-04-19T00:00:00+00:00",
+        "details": {"type": event_type, "severity": "info", "message": "m"},
+    }
+
+
+def test_since_cursor_filters_uuid_audit_rows(client):
+    """With `since`, audit rows whose event_id is a UUID must be dropped."""
+    uuid_row = _audit_row("c6d8a2da-f61e-4ed4-8f88-c1b5918bac10")
+    int_row = _audit_row(42)
+
+    with patch(
+        "src.audit_db.query_audit_events_async",
+        new=AsyncMock(return_value=[uuid_row, int_row]),
+    ):
+        r = client.get("/api/events?since=0&limit=50")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["success"] is True
+    ids = [e["event_id"] for e in body["events"]]
+    assert "c6d8a2da-f61e-4ed4-8f88-c1b5918bac10" not in ids
+    assert 42 in ids
+
+
+def test_no_since_keeps_uuid_audit_rows(client):
+    """Without `since`, the dashboard still sees UUID audit rows."""
+    uuid_row = _audit_row("c6d8a2da-f61e-4ed4-8f88-c1b5918bac10")
+
+    with patch(
+        "src.audit_db.query_audit_events_async",
+        new=AsyncMock(return_value=[uuid_row]),
+    ):
+        r = client.get("/api/events?limit=50")
+
+    assert r.status_code == 200
+    ids = [e["event_id"] for e in r.json()["events"]]
+    assert "c6d8a2da-f61e-4ed4-8f88-c1b5918bac10" in ids


### PR DESCRIPTION
## Summary
- `/api/events?since=N` merged audit-DB rows (UUID event_ids) unconditionally, which broke the int-cursor protocol — Discord bridge's `event_poller` got the same batch every 10s
- When `since` is supplied, skip audit supplement rows whose `event_id` isn't int-convertible. Dashboard path (no `since`) unchanged
- Matches the existing stopgap in `unitares-discord-bridge` (drops non-int ids at ingest) — now enforced server-side too

Closes #25.

## Test plan
- [x] New tests in `tests/test_http_api_events_cursor.py` cover both branches (UUID dropped under `since`, retained without)
- [x] `./scripts/dev/test-cache.sh` — 6548 passed / 33 skipped