### PR TITLE
feat(metrics): catalog-gated time-series substrate

### DIFF
--- a/db/postgres/migrations/013_metrics_series.sql
+++ b/db/postgres/migrations/013_metrics_series.sql
@@ -1,0 +1,30 @@
+-- 013_metrics_series.sql
+--
+-- Introduce a minimal time-series store for catalog-defined fleet metrics
+-- (LOC, test counts, KG discovery totals, agent fleet snapshots, etc.).
+--
+-- Design notes:
+-- * One table, dotted metric names (`tokei.unitares.src.code`) instead of
+--   JSONB labels — Postgres indexes the TEXT name cheaply and we have no
+--   ad-hoc label-filter use case yet. Labels can be added as a follow-up
+--   migration if a concrete need surfaces.
+-- * Writes are constrained at the application layer by a catalog allowlist
+--   (`src/metrics/catalog.py`) so a leaked bearer token cannot pollute
+--   history with arbitrary names.
+-- * Primary query is "name X over last N days"; the (name, ts DESC) index
+--   handles that without needing a composite over labels.
+
+CREATE SCHEMA IF NOT EXISTS metrics;
+
+CREATE TABLE IF NOT EXISTS metrics.series (
+    ts    TIMESTAMPTZ      NOT NULL DEFAULT now(),
+    name  TEXT             NOT NULL,
+    value DOUBLE PRECISION NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_metrics_series_name_ts
+    ON metrics.series (name, ts DESC);
+
+INSERT INTO core.schema_migrations (version, name)
+VALUES (13, 'metrics time-series substrate')
+ON CONFLICT (version) DO NOTHING;

--- a/src/fleet_metrics/__init__.py
+++ b/src/fleet_metrics/__init__.py
@@ -1,0 +1,13 @@
+"""Time-series store for catalog-defined fleet metrics.
+
+- `catalog`: decorator-registered names that are allowed to be written.
+- `storage`: async record/query helpers against `metrics.series`.
+
+External writers (Chronicler resident agent, future scrapers) go through
+catalog validation so a leaked bearer token cannot pollute history.
+"""
+
+from src.fleet_metrics.catalog import Metric, catalog, register, require
+from src.fleet_metrics.storage import query, record
+
+__all__ = ["Metric", "catalog", "register", "require", "query", "record"]

--- a/src/fleet_metrics/catalog.py
+++ b/src/fleet_metrics/catalog.py
@@ -1,0 +1,72 @@
+"""Catalog of allowed metric names.
+
+Writing to `metrics.series` requires the name to be registered here.
+A leaked bearer token therefore cannot inject arbitrary names into the
+time-series — it can only write values for catalog-defined series.
+
+New metrics are added by registering a `Metric` instance at import time.
+Scrape implementations (in scrapers/ modules or the Chronicler agent) are
+separate from catalog entries so the catalog stays a lightweight schema.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Metric:
+    """A catalog entry for a time-series metric.
+
+    The name is dotted (`tokei.unitares.src.code`) for readability; Postgres
+    indexes it as plain TEXT, so there is no structural meaning to dots.
+
+    `description` shows up in the catalog GET endpoint and dashboard so that
+    a reader can tell what any series represents without digging for the
+    scrape source.
+    """
+
+    name: str
+    description: str
+    unit: str = ""  # e.g. "lines", "seconds", "count", "" for dimensionless
+
+
+catalog: dict[str, Metric] = {}
+
+
+def register(metric: Metric) -> Metric:
+    """Add a metric to the catalog. Idempotent on identical re-registration."""
+    existing = catalog.get(metric.name)
+    if existing is not None and existing != metric:
+        raise ValueError(
+            f"Metric {metric.name!r} is already registered with different "
+            f"fields: existing={existing!r}, new={metric!r}"
+        )
+    catalog[metric.name] = metric
+    return metric
+
+
+def require(name: str) -> Metric:
+    """Look up a metric by name; raise KeyError if the name is not registered."""
+    try:
+        return catalog[name]
+    except KeyError as exc:
+        raise KeyError(
+            f"Metric {name!r} is not in the catalog. Register it in "
+            f"src/fleet_metrics/catalog.py before writing."
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Initial catalog
+# ---------------------------------------------------------------------------
+#
+# Every metric defined here is one that answers a question the operator will
+# actually ask monthly. New entries should meet the same bar — if nobody will
+# read the resulting chart, it pollutes the surface area without paying rent.
+
+register(Metric(
+    name="tokei.unitares.src.code",
+    description="Lines of code (excluding comments/blanks) in unitares/src/ — Python only.",
+    unit="lines",
+))

--- a/src/fleet_metrics/storage.py
+++ b/src/fleet_metrics/storage.py
@@ -1,0 +1,98 @@
+"""Async read/write helpers for the `metrics.series` time-series table.
+
+These are called from HTTP handlers (outside the MCP anyio task group,
+so direct asyncpg `await` is safe) and from background tasks. MCP tool
+handlers must not call these directly without the usual deadlock
+mitigations (see project CLAUDE.md → Known Issue: anyio-asyncio Conflict).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from src.fleet_metrics.catalog import require
+
+
+@dataclass(frozen=True)
+class MetricPoint:
+    ts: datetime
+    value: float
+
+
+async def record(name: str, value: float, ts: Optional[datetime] = None) -> None:
+    """Insert one `(ts, name, value)` row after validating against the catalog.
+
+    If `ts` is omitted the DB default (`now()`) is used, which is the path
+    used by the daily Chronicler scraper. Callers backfilling historical
+    values pass an explicit `ts`.
+    """
+    require(name)
+    from src import agent_storage
+    db = agent_storage.get_db()
+    async with db.acquire() as conn:
+        if ts is None:
+            await conn.execute(
+                "INSERT INTO metrics.series (name, value) VALUES ($1, $2)",
+                name, float(value),
+            )
+        else:
+            await conn.execute(
+                "INSERT INTO metrics.series (ts, name, value) VALUES ($1, $2, $3)",
+                ts, name, float(value),
+            )
+
+
+async def query(
+    name: str,
+    since: Optional[datetime] = None,
+    until: Optional[datetime] = None,
+    limit: int = 10_000,
+) -> list[MetricPoint]:
+    """Return `(ts, value)` pairs for `name`, oldest first, capped at `limit`.
+
+    Intended shape: the dashboard requests a named series with a time range
+    and renders the result as a line chart. `name` is required so we never
+    scan the whole table; the `(name, ts DESC)` index handles this cheaply.
+
+    Unknown `name` returns an empty list (no catalog check on read — you
+    should be able to query a series after its catalog entry was removed,
+    for forensic reasons).
+    """
+    if limit <= 0:
+        return []
+    limit = min(int(limit), 10_000)
+
+    from src import agent_storage
+    db = agent_storage.get_db()
+    async with db.acquire() as conn:
+        if since is None and until is None:
+            rows = await conn.fetch(
+                "SELECT ts, value FROM metrics.series "
+                "WHERE name = $1 "
+                "ORDER BY ts ASC LIMIT $2",
+                name, limit,
+            )
+        elif until is None:
+            rows = await conn.fetch(
+                "SELECT ts, value FROM metrics.series "
+                "WHERE name = $1 AND ts >= $2 "
+                "ORDER BY ts ASC LIMIT $3",
+                name, since, limit,
+            )
+        elif since is None:
+            rows = await conn.fetch(
+                "SELECT ts, value FROM metrics.series "
+                "WHERE name = $1 AND ts <= $2 "
+                "ORDER BY ts ASC LIMIT $3",
+                name, until, limit,
+            )
+        else:
+            rows = await conn.fetch(
+                "SELECT ts, value FROM metrics.series "
+                "WHERE name = $1 AND ts >= $2 AND ts <= $3 "
+                "ORDER BY ts ASC LIMIT $4",
+                name, since, until, limit,
+            )
+    return [MetricPoint(ts=r["ts"], value=float(r["value"])) for r in rows]

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -1060,6 +1060,113 @@ _FINDING_TYPE_SUFFIX = "_finding"
 _FINDING_REQUIRED_FIELDS = ("type", "severity", "message", "agent_id", "agent_name", "fingerprint")
 
 
+async def http_post_metric(request):
+    """POST /v1/metrics — write one `(name, value)` point into `metrics.series`.
+
+    Body: `{"name": "...", "value": 1.23, "ts"?: "2026-04-20T..."}`
+    Name must be registered in `src.fleet_metrics.catalog`; a leaked bearer
+    token therefore cannot inject arbitrary metric names.
+    """
+    http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
+    if not _check_http_auth(request, http_api_token=http_api_token):
+        return _http_unauthorized()
+    try:
+        try:
+            payload = await request.json()
+        except Exception:
+            return JSONResponse({"success": False, "error": "Invalid JSON"}, status_code=400)
+
+        if not isinstance(payload, dict):
+            return JSONResponse({"success": False, "error": "Body must be a JSON object"}, status_code=400)
+
+        name = payload.get("name")
+        value = payload.get("value")
+        ts_raw = payload.get("ts")
+        if not isinstance(name, str) or not name:
+            return JSONResponse({"success": False, "error": "Missing or invalid 'name'"}, status_code=400)
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            return JSONResponse({"success": False, "error": "Missing or invalid 'value' (number required)"}, status_code=400)
+
+        ts = None
+        if ts_raw is not None:
+            if not isinstance(ts_raw, str):
+                return JSONResponse({"success": False, "error": "'ts' must be ISO8601 string"}, status_code=400)
+            try:
+                ts = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+            except ValueError:
+                return JSONResponse({"success": False, "error": "'ts' is not valid ISO8601"}, status_code=400)
+
+        from src.fleet_metrics import record
+        try:
+            await record(name, float(value), ts=ts)
+        except KeyError as exc:
+            return JSONResponse(
+                {"success": False, "error": str(exc)},
+                status_code=404,
+            )
+        return JSONResponse({"success": True}, status_code=201)
+    except Exception as e:
+        logger.error(f"Error recording metric: {e}")
+        return JSONResponse({"success": False, "error": str(e)}, status_code=500)
+
+
+async def http_get_metrics(request):
+    """GET /v1/metrics?name=...&since=...&until=...&limit=... — return a series."""
+    http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
+    if not _check_http_auth(request, http_api_token=http_api_token):
+        return _http_unauthorized()
+    try:
+        params = request.query_params
+        name = params.get("name")
+        if not name:
+            return JSONResponse({"success": False, "error": "'name' query param required"}, status_code=400)
+
+        def _parse_ts(raw: str | None):
+            if raw is None:
+                return None
+            try:
+                return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            except ValueError:
+                return "INVALID"
+
+        since = _parse_ts(params.get("since"))
+        until = _parse_ts(params.get("until"))
+        if since == "INVALID" or until == "INVALID":
+            return JSONResponse({"success": False, "error": "'since'/'until' must be ISO8601"}, status_code=400)
+
+        try:
+            limit = int(params.get("limit", "10000"))
+        except ValueError:
+            return JSONResponse({"success": False, "error": "'limit' must be integer"}, status_code=400)
+
+        from src.fleet_metrics import query
+        points = await query(name=name, since=since, until=until, limit=limit)
+        return JSONResponse({
+            "success": True,
+            "name": name,
+            "points": [{"ts": p.ts.isoformat(), "value": p.value} for p in points],
+            "count": len(points),
+        })
+    except Exception as e:
+        logger.error(f"Error querying metrics: {e}")
+        return JSONResponse({"success": False, "error": str(e)}, status_code=500)
+
+
+async def http_get_metrics_catalog(request):
+    """GET /v1/metrics/catalog — list all registered metric names and descriptions."""
+    http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
+    if not _check_http_auth(request, http_api_token=http_api_token):
+        return _http_unauthorized()
+    from src.fleet_metrics import catalog as _catalog
+    return JSONResponse({
+        "success": True,
+        "metrics": [
+            {"name": m.name, "description": m.description, "unit": m.unit}
+            for m in sorted(_catalog.values(), key=lambda x: x.name)
+        ],
+    })
+
+
 async def http_record_finding(request):
     """POST /api/findings — ingest an external finding into the event ring buffer."""
     http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
@@ -1670,6 +1777,9 @@ def register_http_routes(
     app.routes.append(Route("/v1/lifecycle/recent", http_lifecycle_recent, methods=["GET"]))
     app.routes.append(Route("/api/events", http_events, methods=["GET"]))
     app.routes.append(Route("/api/findings", http_record_finding, methods=["POST"]))
+    app.routes.append(Route("/v1/metrics", http_post_metric, methods=["POST"]))
+    app.routes.append(Route("/v1/metrics/series", http_get_metrics, methods=["GET"]))
+    app.routes.append(Route("/v1/metrics/catalog", http_get_metrics_catalog, methods=["GET"]))
     app.routes.append(Route("/api/activity", http_activity, methods=["GET"]))
     app.routes.append(Route("/api/incidents", http_incidents, methods=["GET"]))
     app.routes.append(Route("/v1/residents", http_residents, methods=["GET"]))

--- a/tests/test_fleet_metrics.py
+++ b/tests/test_fleet_metrics.py
@@ -1,0 +1,190 @@
+"""Tests for src/fleet_metrics/{catalog,storage}.py."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.fleet_metrics.catalog import Metric, catalog as _catalog, register, require
+
+
+# ---------------------------------------------------------------------------
+# Catalog
+# ---------------------------------------------------------------------------
+
+
+class TestCatalog:
+    def test_initial_entry_present(self):
+        """The module registers tokei.unitares.src.code on import."""
+        assert "tokei.unitares.src.code" in _catalog
+        entry = _catalog["tokei.unitares.src.code"]
+        assert entry.unit == "lines"
+        assert "unitares" in entry.description
+
+    def test_require_known_name_returns_entry(self):
+        entry = require("tokei.unitares.src.code")
+        assert isinstance(entry, Metric)
+
+    def test_require_unknown_name_raises_keyerror(self):
+        with pytest.raises(KeyError, match="not in the catalog"):
+            require("nope.does.not.exist")
+
+    def test_register_idempotent_on_identical(self):
+        m = Metric(name="test.idempotent", description="x", unit="y")
+        register(m)
+        try:
+            register(m)  # second call with same fields — must not raise
+            assert _catalog["test.idempotent"] == m
+        finally:
+            _catalog.pop("test.idempotent", None)
+
+    def test_register_conflict_raises(self):
+        m1 = Metric(name="test.conflict", description="a", unit="u1")
+        m2 = Metric(name="test.conflict", description="b", unit="u2")
+        register(m1)
+        try:
+            with pytest.raises(ValueError, match="different"):
+                register(m2)
+        finally:
+            _catalog.pop("test.conflict", None)
+
+
+# ---------------------------------------------------------------------------
+# Storage
+# ---------------------------------------------------------------------------
+
+
+def _make_db_mock() -> tuple[MagicMock, AsyncMock]:
+    """Return (db, conn) pair where `db.acquire()` yields the mocked conn."""
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=None)
+    conn.fetch = AsyncMock(return_value=[])
+
+    acquire_cm = MagicMock()
+    acquire_cm.__aenter__ = AsyncMock(return_value=conn)
+    acquire_cm.__aexit__ = AsyncMock(return_value=None)
+
+    db = MagicMock()
+    db.acquire = MagicMock(return_value=acquire_cm)
+    return db, conn
+
+
+class TestRecord:
+    @pytest.mark.asyncio
+    async def test_record_known_metric_no_ts_uses_db_default(self):
+        from src.fleet_metrics import record
+
+        db, conn = _make_db_mock()
+        with patch("src.agent_storage.get_db", return_value=db):
+            await record("tokei.unitares.src.code", 70000.0)
+
+        conn.execute.assert_awaited_once()
+        args = conn.execute.await_args.args
+        assert "INSERT INTO metrics.series (name, value)" in args[0]
+        assert args[1] == "tokei.unitares.src.code"
+        assert args[2] == 70000.0
+
+    @pytest.mark.asyncio
+    async def test_record_with_explicit_ts(self):
+        from src.fleet_metrics import record
+
+        db, conn = _make_db_mock()
+        ts = datetime(2026, 4, 20, 12, 0, tzinfo=timezone.utc)
+        with patch("src.agent_storage.get_db", return_value=db):
+            await record("tokei.unitares.src.code", 1.5, ts=ts)
+
+        args = conn.execute.await_args.args
+        assert "INSERT INTO metrics.series (ts, name, value)" in args[0]
+        assert args[1] == ts
+        assert args[2] == "tokei.unitares.src.code"
+        assert args[3] == 1.5
+
+    @pytest.mark.asyncio
+    async def test_record_unknown_metric_raises_without_db_hit(self):
+        from src.fleet_metrics import record
+
+        db, conn = _make_db_mock()
+        with patch("src.agent_storage.get_db", return_value=db):
+            with pytest.raises(KeyError):
+                await record("unknown.metric", 1.0)
+        conn.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_record_coerces_int_to_float(self):
+        from src.fleet_metrics import record
+
+        db, conn = _make_db_mock()
+        with patch("src.agent_storage.get_db", return_value=db):
+            await record("tokei.unitares.src.code", 42)
+        args = conn.execute.await_args.args
+        assert isinstance(args[2], float)
+        assert args[2] == 42.0
+
+
+class TestQuery:
+    @pytest.mark.asyncio
+    async def test_query_returns_parsed_points(self):
+        from src.fleet_metrics import query
+
+        db, conn = _make_db_mock()
+        ts1 = datetime(2026, 4, 18, 0, 0, tzinfo=timezone.utc)
+        ts2 = datetime(2026, 4, 19, 0, 0, tzinfo=timezone.utc)
+        conn.fetch.return_value = [
+            {"ts": ts1, "value": 100.0},
+            {"ts": ts2, "value": 101.5},
+        ]
+        with patch("src.agent_storage.get_db", return_value=db):
+            points = await query("tokei.unitares.src.code")
+        assert len(points) == 2
+        assert points[0].ts == ts1
+        assert points[0].value == 100.0
+        assert points[1].value == 101.5
+
+    @pytest.mark.asyncio
+    async def test_query_with_time_range_uses_bounded_sql(self):
+        from src.fleet_metrics import query
+
+        db, conn = _make_db_mock()
+        since = datetime(2026, 4, 1, tzinfo=timezone.utc)
+        until = datetime(2026, 4, 20, tzinfo=timezone.utc)
+        with patch("src.agent_storage.get_db", return_value=db):
+            await query("x", since=since, until=until, limit=50)
+        args = conn.fetch.await_args.args
+        assert "ts >= $2 AND ts <= $3" in args[0]
+        assert args[1] == "x"
+        assert args[2] == since
+        assert args[3] == until
+        assert args[4] == 50
+
+    @pytest.mark.asyncio
+    async def test_query_caps_limit_at_10k(self):
+        from src.fleet_metrics import query
+
+        db, conn = _make_db_mock()
+        with patch("src.agent_storage.get_db", return_value=db):
+            await query("x", limit=99999)
+        args = conn.fetch.await_args.args
+        assert args[-1] == 10_000
+
+    @pytest.mark.asyncio
+    async def test_query_zero_or_negative_limit_short_circuits(self):
+        from src.fleet_metrics import query
+
+        db, conn = _make_db_mock()
+        with patch("src.agent_storage.get_db", return_value=db):
+            result = await query("x", limit=0)
+        assert result == []
+        conn.fetch.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_query_unknown_name_does_not_raise(self):
+        """Reads don't enforce catalog membership (forensic use case)."""
+        from src.fleet_metrics import query
+
+        db, conn = _make_db_mock()
+        with patch("src.agent_storage.get_db", return_value=db):
+            result = await query("no.such.metric")
+        assert result == []

--- a/tests/test_http_metrics_endpoints.py
+++ b/tests/test_http_metrics_endpoints.py
@@ -1,0 +1,230 @@
+"""Tests for the /v1/metrics{,/series,/catalog} HTTP endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from starlette.requests import Request
+
+
+def _make_request(
+    method: str,
+    path: str,
+    body: bytes | None = None,
+    query: str = "",
+    headers: dict[str, str] | None = None,
+    client: tuple[str, int] | None = ("127.0.0.1", 55555),
+) -> Request:
+    """Construct a Starlette Request suitable for handler unit-testing."""
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": query.encode(),
+        "headers": [
+            (k.lower().encode(), v.encode())
+            for k, v in (headers or {}).items()
+        ],
+        "client": client,
+        "scheme": "http",
+        "http_version": "1.1",
+        "root_path": "",
+        "server": ("127.0.0.1", 8767),
+        "state": {},
+    }
+
+    async def receive():
+        return {
+            "type": "http.request",
+            "body": body or b"",
+            "more_body": False,
+        }
+
+    return Request(scope, receive=receive)
+
+
+async def _read_json(response):
+    body = response.body
+    import json
+    return json.loads(body.decode())
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/metrics
+# ---------------------------------------------------------------------------
+
+
+class TestPostMetric:
+    @pytest.mark.asyncio
+    async def test_valid_known_metric_returns_201(self):
+        from src.http_api import http_post_metric
+
+        req = _make_request(
+            "POST", "/v1/metrics",
+            body=b'{"name":"tokei.unitares.src.code","value":70000}',
+            headers={"content-type": "application/json"},
+        )
+        with patch("src.fleet_metrics.record", new=AsyncMock(return_value=None)) as mock_rec:
+            resp = await http_post_metric(req)
+        assert resp.status_code == 201
+        mock_rec.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_unknown_metric_returns_404(self):
+        from src.http_api import http_post_metric
+
+        req = _make_request(
+            "POST", "/v1/metrics",
+            body=b'{"name":"no.such.metric","value":1}',
+        )
+        # Patch record to raise KeyError as the real catalog-gated version would
+        async def _raise(*_a, **_kw):
+            raise KeyError("Metric 'no.such.metric' is not in the catalog.")
+
+        with patch("src.fleet_metrics.record", new=_raise):
+            resp = await http_post_metric(req)
+        assert resp.status_code == 404
+        body = await _read_json(resp)
+        assert body["success"] is False
+        assert "catalog" in body["error"]
+
+    @pytest.mark.asyncio
+    async def test_missing_name_returns_400(self):
+        from src.http_api import http_post_metric
+
+        req = _make_request("POST", "/v1/metrics", body=b'{"value":1}')
+        resp = await http_post_metric(req)
+        assert resp.status_code == 400
+        body = await _read_json(resp)
+        assert "name" in body["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_value_returns_400(self):
+        from src.http_api import http_post_metric
+
+        req = _make_request(
+            "POST", "/v1/metrics",
+            body=b'{"name":"tokei.unitares.src.code","value":"not-a-number"}',
+        )
+        resp = await http_post_metric(req)
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_bool_value_rejected(self):
+        """True/False are Python ints — explicitly reject to avoid surprise writes."""
+        from src.http_api import http_post_metric
+
+        req = _make_request(
+            "POST", "/v1/metrics",
+            body=b'{"name":"tokei.unitares.src.code","value":true}',
+        )
+        resp = await http_post_metric(req)
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_invalid_ts_returns_400(self):
+        from src.http_api import http_post_metric
+
+        req = _make_request(
+            "POST", "/v1/metrics",
+            body=b'{"name":"tokei.unitares.src.code","value":1,"ts":"not-a-timestamp"}',
+        )
+        resp = await http_post_metric(req)
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_returns_400(self):
+        from src.http_api import http_post_metric
+
+        req = _make_request("POST", "/v1/metrics", body=b"not-json")
+        resp = await http_post_metric(req)
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_non_local_caller_without_token_returns_401(self):
+        from src.http_api import http_post_metric
+
+        req = _make_request(
+            "POST", "/v1/metrics",
+            body=b'{"name":"tokei.unitares.src.code","value":1}',
+            client=("203.0.113.7", 55555),  # TEST-NET-3, not in trusted nets
+        )
+        with patch.dict("os.environ", {"UNITARES_HTTP_API_TOKEN": "secret"}):
+            resp = await http_post_metric(req)
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/metrics/series
+# ---------------------------------------------------------------------------
+
+
+class TestGetMetricsSeries:
+    @pytest.mark.asyncio
+    async def test_returns_points(self):
+        from src.http_api import http_get_metrics
+        from src.fleet_metrics.storage import MetricPoint
+
+        ts = datetime(2026, 4, 19, tzinfo=timezone.utc)
+        fake_points = [MetricPoint(ts=ts, value=123.0)]
+        with patch("src.fleet_metrics.query", new=AsyncMock(return_value=fake_points)):
+            req = _make_request("GET", "/v1/metrics/series", query="name=tokei.unitares.src.code")
+            resp = await http_get_metrics(req)
+        body = await _read_json(resp)
+        assert resp.status_code == 200
+        assert body["success"] is True
+        assert body["name"] == "tokei.unitares.src.code"
+        assert body["count"] == 1
+        assert body["points"][0]["value"] == 123.0
+
+    @pytest.mark.asyncio
+    async def test_missing_name_returns_400(self):
+        from src.http_api import http_get_metrics
+
+        req = _make_request("GET", "/v1/metrics/series", query="")
+        resp = await http_get_metrics(req)
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_invalid_since_returns_400(self):
+        from src.http_api import http_get_metrics
+
+        req = _make_request(
+            "GET", "/v1/metrics/series",
+            query="name=tokei.unitares.src.code&since=not-a-date",
+        )
+        resp = await http_get_metrics(req)
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_invalid_limit_returns_400(self):
+        from src.http_api import http_get_metrics
+
+        req = _make_request(
+            "GET", "/v1/metrics/series",
+            query="name=tokei.unitares.src.code&limit=abc",
+        )
+        resp = await http_get_metrics(req)
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/metrics/catalog
+# ---------------------------------------------------------------------------
+
+
+class TestGetMetricsCatalog:
+    @pytest.mark.asyncio
+    async def test_lists_initial_entry(self):
+        from src.http_api import http_get_metrics_catalog
+
+        req = _make_request("GET", "/v1/metrics/catalog")
+        resp = await http_get_metrics_catalog(req)
+        body = await _read_json(resp)
+        assert resp.status_code == 200
+        assert body["success"] is True
+        names = {m["name"] for m in body["metrics"]}
+        assert "tokei.unitares.src.code" in names


### PR DESCRIPTION
## Summary
First of ~3 PRs adding a fleet-metrics capability. This one is the substrate only — schema + writer + reader + catalog-gated endpoints. No scrapers yet.

## Design
- **One table**, dotted metric names: `metrics.series (ts TIMESTAMPTZ, name TEXT, value DOUBLE PRECISION)` + `(name, ts DESC)` index. No JSONB labels for MVP — can be added later if needed.
- **Writes go through a code-level catalog allowlist** (`src/fleet_metrics/catalog.py`). A leaked bearer token cannot inject arbitrary names; it can only write values for catalog-defined metrics. Removes a real pollution surface the committee flagged.
- **Three endpoints**, all using the existing `UNITARES_HTTP_API_TOKEN` + trusted-network bypass in `_check_http_auth`:
  - `POST /v1/metrics` — record point
  - `GET /v1/metrics/series?name=&since=&until=&limit=` — query
  - `GET /v1/metrics/catalog` — list registered names

## Seed catalog
One entry: `tokei.unitares.src.code`. Scrapers arrive in the follow-up PR that introduces the Chronicler resident agent to drive the catalog on a daily cadence.

## What's intentionally NOT here
- No scraper — Chronicler is its own PR
- No dashboard panel — its own PR (reads `GET /v1/metrics/series`)
- No retention sweep — worth adding before the table has many series, but cardinality at daily cadence × a dozen metrics is trivially small; punt to a follow-up

## Test plan
- [x] Catalog unit tests: register idempotency, conflict detection, require-unknown raises (`tests/test_fleet_metrics.py::TestCatalog`)
- [x] Storage unit tests: record validates against catalog before DB hit, query SQL is bounded correctly, limit capped at 10k (`TestRecord`, `TestQuery`)
- [x] HTTP unit tests: auth enforcement, 400s on bad input, 404 on unknown name, 201 on success (`tests/test_http_metrics_endpoints.py`)
- [x] Migration applied and verified locally (`db/postgres/migrations/013_metrics_series.sql`)
- [x] Full suite: 6601 passed, 33 skipped

## Follow-up PRs (planned)
- PR B — Chronicler resident agent: daily tokei/git/kg scrapers, launchd plist, catalog grows to ~10 entries
- PR C — Dashboard panel: line chart per series, reading from the catalog + query endpoints