### PR TITLE
fix(call_model): stop silently rewriting llama-3.1-8b → llama3:70b; local auto-default now honors UNITARES_LLM_MODEL (gemma4:latest fallback); recovery hint points at `ollama list` instead of stale model names. Partial fix for #66.

### DIFF
--- a/src/mcp_handlers/support/model_inference.py
+++ b/src/mcp_handlers/support/model_inference.py
@@ -33,26 +33,28 @@ except ImportError:
 async def handle_call_model(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """
     Call a free/low-cost LLM for reasoning, generation, or analysis.
-    
-    Models available:
-    - gemini-flash (free, fast) - default
-    - llama-3.1-8b (via Ollama, free) - if local available
-    - gemini-pro (low-cost) - if free tier exhausted
-    
-    Routing via ngrok.ai:
-    - Automatic failover (gemini → ollama → gemini-pro)
-    - Cost optimization (route to cheapest available)
-    - Rate limit handling (distribute across providers)
-    
+
+    Providers:
+    - Ollama (local, free) — default when privacy="local" (the default). Pass a
+      model name that is actually pulled on the host (`ollama list`). The
+      local fallback for model="auto" is taken from UNITARES_LLM_MODEL
+      (default "gemma4:latest"). Requested model names are passed through
+      verbatim — no silent aliasing.
+    - Hugging Face Inference Providers (privacy="cloud", provider="hf")
+      — requires HF_TOKEN or HUGGINGFACE_TOKEN. Model names like
+      "deepseek-ai/DeepSeek-R1" or "Qwen/Qwen2.5-72B-Instruct" route here.
+    - Google Gemini (privacy="cloud", provider="gemini") — requires
+      GOOGLE_AI_API_KEY. Default model is "gemini-flash".
+
     Usage tracked in EISV (Energy consumption):
     - Model calls consume Energy
     - High usage → higher Energy → agent learns efficiency
     - Natural self-regulation
-    
+
     Example:
     {
       "prompt": "Analyze this code for potential bugs",
-      "model": "gemini-flash",
+      "model": "gemma4:latest",
       "task_type": "analysis",
       "max_tokens": 2048
     }
@@ -88,11 +90,12 @@ async def handle_call_model(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     
     # Privacy routing: Force local if requested
     if privacy == "local" or provider == "ollama":
-        # Route to Ollama (local)
+        # Route to Ollama (local). Model names pass through verbatim so
+        # callers get a clean 404 if the model isn't pulled — no silent
+        # aliasing to a model that may also be absent.
         base_url = "http://localhost:11434/v1"  # Ollama OpenAI-compatible API
-        # Use specified model or default to llama3 (common Ollama model)
-        if model == "auto" or model == "llama-3.1-8b":
-            model = "llama3:70b"  # Default Ollama model (adjust based on what's installed)
+        if model == "auto":
+            model = os.getenv("UNITARES_LLM_MODEL", "gemma4:latest")
         api_key = "ollama"  # Dummy key - Ollama ignores it but OpenAI SDK requires non-None
         provider = "ollama"
         logger.info(f"Privacy mode: local - routing to Ollama with model {model}")
@@ -325,10 +328,19 @@ async def handle_call_model(arguments: Dict[str, Any]) -> Sequence[TextContent]:
             recovery_hint = "Wait a moment and retry, or use a different model"
         elif "not found" in error_msg.lower() or "invalid" in error_msg.lower():
             error_code = "MODEL_NOT_AVAILABLE"
-            recovery_hint = f"Model '{model}' not available. Try 'gemini-flash', 'qwen2.5:14b', or 'llama-3.1-8b'"
+            if "localhost" in base_url or "127.0.0.1" in base_url:
+                recovery_hint = (
+                    f"Model '{model}' is not pulled on this host. "
+                    "Run `ollama list` to see available models, or `ollama pull {model}` to fetch it."
+                )
+            else:
+                recovery_hint = (
+                    f"Model '{model}' not available on this provider. "
+                    "Check the provider's model catalog or try a different model."
+                )
         else:
             error_code = "INFERENCE_ERROR"
-            recovery_hint = "Check ngrok.ai configuration and model availability"
+            recovery_hint = "Check provider configuration and model availability"
         
         return [error_response(
             f"Model inference failed: {error_msg}",

--- a/tests/test_model_inference.py
+++ b/tests/test_model_inference.py
@@ -179,11 +179,12 @@ class TestOllamaRouting:
         assert parsed["routed_via"] == "ollama"
 
     @pytest.mark.asyncio
-    async def test_ollama_uses_default_model_for_auto(self):
-        """Ollama with model=auto defaults to llama3:70b."""
+    async def test_ollama_uses_default_model_for_auto(self, monkeypatch):
+        """Ollama with model=auto defaults to gemma4:latest (UNITARES_LLM_MODEL fallback)."""
+        monkeypatch.delenv("UNITARES_LLM_MODEL", raising=False)
         mock_client_instance = MagicMock()
         mock_client_instance.chat.completions.create.return_value = _make_mock_response(
-            model="llama3:70b"
+            model="gemma4:latest"
         )
 
         with patch("src.mcp_handlers.support.model_inference.OPENAI_AVAILABLE", True), \
@@ -195,13 +196,53 @@ class TestOllamaRouting:
                 "model": "auto",
             })
 
-        # Verify model passed to create
         call_kwargs = mock_client_instance.chat.completions.create.call_args[1]
-        assert call_kwargs["model"] == "llama3:70b"
+        assert call_kwargs["model"] == "gemma4:latest"
+
+    @pytest.mark.asyncio
+    async def test_ollama_auto_respects_unitares_llm_model_env(self, monkeypatch):
+        """UNITARES_LLM_MODEL env var overrides the gemma4:latest default."""
+        monkeypatch.setenv("UNITARES_LLM_MODEL", "qwen3-coder-next:latest")
+        mock_client_instance = MagicMock()
+        mock_client_instance.chat.completions.create.return_value = _make_mock_response(
+            model="qwen3-coder-next:latest"
+        )
+
+        with patch("src.mcp_handlers.support.model_inference.OPENAI_AVAILABLE", True), \
+             patch("src.mcp_handlers.support.model_inference.OpenAI", return_value=mock_client_instance):
+            from src.mcp_handlers.support.model_inference import handle_call_model
+            result = await handle_call_model({
+                "prompt": "Hello",
+                "provider": "ollama",
+                "model": "auto",
+            })
+
+        call_kwargs = mock_client_instance.chat.completions.create.call_args[1]
+        assert call_kwargs["model"] == "qwen3-coder-next:latest"
+
+    @pytest.mark.asyncio
+    async def test_ollama_preserves_llama_3_1_8b_model(self):
+        """llama-3.1-8b is NOT silently rewritten to llama3:70b (was a router bug)."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.chat.completions.create.return_value = _make_mock_response(
+            model="llama-3.1-8b"
+        )
+
+        with patch("src.mcp_handlers.support.model_inference.OPENAI_AVAILABLE", True), \
+             patch("src.mcp_handlers.support.model_inference.OpenAI", return_value=mock_client_instance):
+            from src.mcp_handlers.support.model_inference import handle_call_model
+            result = await handle_call_model({
+                "prompt": "Hello",
+                "privacy": "local",
+                "model": "llama-3.1-8b",
+            })
+
+        call_kwargs = mock_client_instance.chat.completions.create.call_args[1]
+        assert call_kwargs["model"] == "llama-3.1-8b"
 
     @pytest.mark.asyncio
     async def test_ollama_preserves_specified_model(self):
-        """Ollama preserves a specific model name when not 'auto' or 'llama-3.1-8b'."""
+        """Ollama preserves a specific model name when not 'auto'."""
         mock_client_instance = MagicMock()
         mock_client_instance.chat.completions.create.return_value = _make_mock_response(
             model="my-custom-model"
@@ -218,6 +259,33 @@ class TestOllamaRouting:
 
         call_kwargs = mock_client_instance.chat.completions.create.call_args[1]
         assert call_kwargs["model"] == "my-custom-model"
+
+    @pytest.mark.asyncio
+    async def test_ollama_model_not_found_error_points_at_ollama_list(self):
+        """Model-not-found recovery hint mentions `ollama list`, not stale model names."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.chat.completions.create.side_effect = Exception(
+            "model 'nonexistent-model' not found"
+        )
+
+        with patch("src.mcp_handlers.support.model_inference.OPENAI_AVAILABLE", True), \
+             patch("src.mcp_handlers.support.model_inference.OpenAI", return_value=mock_client_instance):
+            from src.mcp_handlers.support.model_inference import handle_call_model
+            result = await handle_call_model({
+                "prompt": "test",
+                "provider": "ollama",
+                "model": "nonexistent-model",
+            })
+
+        parsed = _parse_text_content(result)
+        assert parsed["success"] is False
+        assert parsed.get("error_code") == "MODEL_NOT_AVAILABLE"
+        recovery_action = parsed["recovery"]["action"]
+        assert "ollama list" in recovery_action
+        assert "nonexistent-model" in recovery_action
+        # Stale recommendations must be gone
+        assert "qwen2.5:14b" not in recovery_action
+        assert "llama-3.1-8b" not in recovery_action
 
 
 # =============================================================================


### PR DESCRIPTION
Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.