### PR TITLE
feat(identity): resident-fork detector emits event on label collision with persistent agent

The onboard handler already detected label collisions and silently renamed
the new agent (Watcher -> Watcher_7bf970d4). That absorbed rotation-induced
silent forks without any signal. Detection took ~15h via human inspection
on 2026-04-19.

Now: when the existing label-holder carries the 'persistent' tag, log at
WARNING and emit broadcast_event('resident_fork_detected', ...). Dashboards
and Discord bridge surface it within one broadcast cycle. Rename behavior
preserved — the fork still completes (can't block onboard), but it
announces itself.

Adds core.agents-backed db.agent_has_tag helper on AgentMixin.

Addresses the detection-gap blindspot surfaced by the anchor-resilience
council review (see docs/superpowers/plans/2026-04-19-anchor-resilience-series.md).
Phase 1 of 3.

### DIFF
--- a/src/db/mixins/agent.py
+++ b/src/db/mixins/agent.py
@@ -173,3 +173,16 @@ class AgentMixin:
             except Exception as e:
                 logger.debug(f"Failed to find agent by label {label}: {e}")
                 return None
+
+    async def agent_has_tag(self, agent_id: str, tag: str) -> bool:
+        """Return True iff agent exists in core.agents with `tag` in tags[]."""
+        async with self.acquire() as conn:
+            try:
+                row = await conn.fetchrow(
+                    "SELECT 1 FROM core.agents WHERE id = $1 AND $2 = ANY(tags)",
+                    agent_id, tag,
+                )
+                return row is not None
+            except Exception as e:
+                logger.debug(f"Failed to check tag {tag} on {agent_id}: {e}")
+                return False

--- a/src/mcp_handlers/identity/persistence.py
+++ b/src/mcp_handlers/identity/persistence.py
@@ -198,6 +198,17 @@ async def _find_agent_by_label(label: str) -> Optional[str]:
     except Exception:
         return None
 
+
+def _broadcaster():
+    """Lazy accessor for the shared broadcaster. Returns None when broadcaster
+    isn't importable (e.g., unit tests without a live server). Kept as a
+    module-level function so tests can patch persistence._broadcaster."""
+    try:
+        from src.broadcaster import broadcaster as _b
+        return _b
+    except Exception:
+        return None
+
 # =============================================================================
 # LAZY CREATION HELPERS (v2.4.1+)
 # =============================================================================
@@ -378,12 +389,45 @@ async def set_agent_label(agent_uuid: str, label: str, session_key: Optional[str
         existing_metadata = getattr(identity_record, "metadata", None) or {}
         existing_public_agent_id = _metadata_public_agent_id(existing_metadata)
 
-        # Check for duplicate labels
+        # Check for duplicate labels.
+        # Resident-fork detector (2026-04-19, see
+        # docs/superpowers/plans/2026-04-19-anchor-resilience-series.md):
+        # when the existing label-holder is tagged 'persistent', the rename
+        # is suppressing a resident fork — emit a governance event so
+        # dashboards and Discord surface it within one broadcast cycle.
+        # The rename still happens (can't block onboard).
         existing = await _find_agent_by_label(label)
         if existing and existing != agent_uuid:
-            # Append UUID suffix to make unique
-            label = f"{label}_{agent_uuid[:8]}"
-            logger.info(f"Label collision, using: {label}")
+            new_label = f"{label}_{agent_uuid[:8]}"
+            existing_is_resident = await db.agent_has_tag(existing, "persistent")
+            if existing_is_resident:
+                logger.warning(
+                    "[RESIDENT_FORK] label collision: existing agent %s is "
+                    "persistent but onboard minted %s with same label %r — "
+                    "renaming new agent to %r. Likely rotation wipe, anchor "
+                    "corruption, or misconfigured bootstrap. See "
+                    "memory/project_identity-audit-2026-04-19.md.",
+                    existing[:8], agent_uuid[:8], label, new_label,
+                )
+                b = _broadcaster()
+                if b is not None:
+                    try:
+                        await b.broadcast_event(
+                            event_type="resident_fork_detected",
+                            agent_id=agent_uuid,
+                            payload={
+                                "existing_agent_id": existing,
+                                "label": label,
+                                "new_label": new_label,
+                            },
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            f"[RESIDENT_FORK] broadcast_event failed: {e}"
+                        )
+            else:
+                logger.info(f"Label collision, using: {new_label}")
+            label = new_label
 
         # Update agent label using the proper backend method
         success = await db.update_agent_fields(agent_uuid, label=label)

--- a/tests/test_resident_fork_detector.py
+++ b/tests/test_resident_fork_detector.py
@@ -1,0 +1,118 @@
+"""Resident-fork detector: label collision on persistent-tagged agent emits event.
+
+See docs/superpowers/plans/2026-04-19-anchor-resilience-series.md (Phase 1).
+"""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.mcp_handlers.identity import persistence
+
+
+@pytest.mark.asyncio
+async def test_label_collision_on_persistent_agent_emits_event():
+    """When fresh onboard collides with a persistent-tagged existing agent,
+    broadcaster should receive resident_fork_detected with both UUIDs."""
+    existing_uuid = "907e3195-c649-49db-b753-1edc1a105f33"
+    new_uuid = "7bf970d4-5713-4184-a6f8-58e798275f3f"
+    label = "Watcher"
+
+    mock_broadcaster = AsyncMock()
+
+    mock_db = AsyncMock()
+    mock_db.find_agent_by_label = AsyncMock(return_value=existing_uuid)
+    mock_db.agent_has_tag = AsyncMock(return_value=True)
+    mock_db.update_agent_fields = AsyncMock(return_value=True)
+    mock_db.get_identity = AsyncMock(return_value=None)
+
+    # Avoid touching mcp_server state + structured-id generation
+    with patch.object(persistence, "get_db", return_value=mock_db), \
+         patch.object(persistence, "_broadcaster", return_value=mock_broadcaster), \
+         patch.object(persistence, "mcp_server") as mock_mcp:
+        mock_mcp.agent_metadata = {}
+        await persistence.set_agent_label(new_uuid, label, session_key="sk")
+
+    mock_broadcaster.broadcast_event.assert_called_once()
+    call = mock_broadcaster.broadcast_event.call_args
+    assert call.kwargs["event_type"] == "resident_fork_detected"
+    assert call.kwargs["agent_id"] == new_uuid
+    payload = call.kwargs["payload"]
+    assert payload["existing_agent_id"] == existing_uuid
+    assert payload["label"] == label
+    assert payload["new_label"] == f"Watcher_{new_uuid[:8]}"
+
+
+@pytest.mark.asyncio
+async def test_label_collision_on_non_persistent_agent_no_event():
+    """Collision with a non-persistent existing agent is silently renamed
+    (current behavior for ephemerals, preserved)."""
+    mock_broadcaster = AsyncMock()
+
+    mock_db = AsyncMock()
+    mock_db.find_agent_by_label = AsyncMock(return_value="some-other-uuid")
+    mock_db.agent_has_tag = AsyncMock(return_value=False)
+    mock_db.update_agent_fields = AsyncMock(return_value=True)
+    mock_db.get_identity = AsyncMock(return_value=None)
+
+    with patch.object(persistence, "get_db", return_value=mock_db), \
+         patch.object(persistence, "_broadcaster", return_value=mock_broadcaster), \
+         patch.object(persistence, "mcp_server") as mock_mcp:
+        mock_mcp.agent_metadata = {}
+        await persistence.set_agent_label(
+            "new-uuid-here", "temp-ephemeral", session_key="sk",
+        )
+
+    mock_broadcaster.broadcast_event.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_no_collision_no_event_no_rename():
+    """No existing agent with that label => no rename, no event."""
+    mock_broadcaster = AsyncMock()
+
+    mock_db = AsyncMock()
+    mock_db.find_agent_by_label = AsyncMock(return_value=None)
+    mock_db.agent_has_tag = AsyncMock(return_value=False)
+    mock_db.update_agent_fields = AsyncMock(return_value=True)
+    mock_db.get_identity = AsyncMock(return_value=None)
+
+    with patch.object(persistence, "get_db", return_value=mock_db), \
+         patch.object(persistence, "_broadcaster", return_value=mock_broadcaster), \
+         patch.object(persistence, "mcp_server") as mock_mcp:
+        mock_mcp.agent_metadata = {}
+        result = await persistence.set_agent_label(
+            "new-uuid", "UniqueLabel", session_key="sk",
+        )
+
+    assert result is True
+    mock_broadcaster.broadcast_event.assert_not_called()
+    # agent_has_tag should not have been called (short-circuits on no existing)
+    mock_db.agent_has_tag.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_agent_has_tag_sql_roundtrip(live_postgres_backend):
+    """Integration test against live Postgres: verify agent_has_tag SQL is
+    correct. Skipped by the fixture if governance_test DB unavailable."""
+    be = live_postgres_backend
+    seed_uuid = "00000000-0000-0000-0000-000000000fkd"
+    async with be.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO core.agents (id, api_key, status, label, tags) "
+            "VALUES ($1, 'test-key', 'active', 'test-fork-detector', "
+            "ARRAY['persistent']) "
+            "ON CONFLICT (id) DO UPDATE SET tags = ARRAY['persistent'], "
+            "status = 'active'",
+            seed_uuid,
+        )
+    try:
+        assert await be.agent_has_tag(seed_uuid, "persistent") is True
+        assert await be.agent_has_tag(seed_uuid, "nonexistent-tag") is False
+        assert await be.agent_has_tag(
+            "00000000-0000-0000-0000-deadbeef0000", "persistent"
+        ) is False
+    finally:
+        async with be.acquire() as conn:
+            await conn.execute(
+                "DELETE FROM core.agents WHERE id = $1", seed_uuid
+            )


### PR DESCRIPTION
Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.