### PR TITLE
feat(chronicler): daily scraper agent feeding fleet metrics

### DIFF
--- a/agents/chronicler/agent.py
+++ b/agents/chronicler/agent.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Chronicler — daily scraper of fleet metrics into `metrics.series`.
+
+Intentionally lightweight: one-shot invocation (launchd drives cadence),
+no own identity, no EISV check-ins. Runs each scraper in `scrapers.py`,
+POSTs the value to the governance server, emits a `.error` metric on
+failure so silent breakage stays visible.
+
+Environment:
+    UNITARES_METRICS_URL        base URL (default http://127.0.0.1:8767)
+    UNITARES_HTTP_API_TOKEN     bearer token; optional if running locally
+                                (trusted-network bypass handles 127.0.0.1)
+    CHRONICLER_REPO_ROOT        repo to scrape (default: working directory)
+
+Usage:
+    python3 agents/chronicler/agent.py          # run all scrapers once
+    python3 agents/chronicler/agent.py --dry    # no POSTs, print to stdout
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+import httpx
+
+# Make sibling package importable when invoked via launchd (no sys.path magic
+# otherwise; the launchd plist sets PYTHONPATH to the repo root).
+project_root = Path(__file__).resolve().parent.parent.parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+from agents.chronicler.scrapers import SCRAPERS
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s chronicler: %(message)s",
+)
+log = logging.getLogger("chronicler")
+
+
+DEFAULT_URL = "http://127.0.0.1:8767"
+
+
+def post_metric(
+    client: httpx.Client,
+    base_url: str,
+    token: str | None,
+    name: str,
+    value: float,
+) -> None:
+    """POST one `(name, value)` point. Raises on HTTP error."""
+    headers = {"content-type": "application/json"}
+    if token:
+        headers["authorization"] = f"Bearer {token}"
+    resp = client.post(
+        f"{base_url}/v1/metrics",
+        headers=headers,
+        content=json.dumps({"name": name, "value": value}),
+        timeout=10.0,
+    )
+    if resp.status_code >= 400:
+        raise RuntimeError(
+            f"POST /v1/metrics failed for {name}: "
+            f"{resp.status_code} {resp.text[:200]}"
+        )
+
+
+def run(
+    base_url: str,
+    token: str | None,
+    repo_root: Path,
+    dry_run: bool = False,
+) -> tuple[int, int]:
+    """Run every registered scraper. Returns (successes, failures)."""
+    successes = 0
+    failures = 0
+
+    with httpx.Client() as client:
+        for name, scraper in sorted(SCRAPERS.items()):
+            try:
+                value = float(scraper(repo_root))
+            except Exception as exc:
+                failures += 1
+                log.warning("scraper %s failed: %s", name, exc)
+                if not dry_run:
+                    # Best-effort: the error metric may itself fail if the
+                    # server is unreachable; swallow silently in that case,
+                    # there's nothing useful to do with the inner error.
+                    try:
+                        post_metric(client, base_url, token, f"{name}.error", 1.0)
+                    except Exception as inner:
+                        log.warning("could not post error metric for %s: %s", name, inner)
+                continue
+
+            if dry_run:
+                log.info("DRY %s = %s", name, value)
+                successes += 1
+                continue
+
+            try:
+                post_metric(client, base_url, token, name, value)
+                successes += 1
+                log.info("recorded %s = %s", name, value)
+            except Exception as exc:
+                failures += 1
+                log.warning("could not post %s: %s", name, exc)
+
+    return successes, failures
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Chronicler metrics scraper.")
+    parser.add_argument("--dry", action="store_true", help="print metrics without posting")
+    args = parser.parse_args(argv)
+
+    base_url = os.environ.get("UNITARES_METRICS_URL", DEFAULT_URL).rstrip("/")
+    token = os.environ.get("UNITARES_HTTP_API_TOKEN") or None
+    repo_root = Path(os.environ.get("CHRONICLER_REPO_ROOT", os.getcwd())).resolve()
+
+    log.info("chronicler start: url=%s repo=%s scrapers=%d", base_url, repo_root, len(SCRAPERS))
+    successes, failures = run(base_url, token, repo_root, dry_run=args.dry)
+    log.info("chronicler done: success=%d fail=%d", successes, failures)
+    return 0 if failures == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agents/chronicler/scrapers.py
+++ b/agents/chronicler/scrapers.py
@@ -1,0 +1,61 @@
+"""Scraper functions for Chronicler.
+
+Each scraper maps a catalog metric name to a zero-arg callable that
+returns the scalar value at call time. Scrapers are pure "measure
+something" functions — Chronicler handles HTTP posting, error emission,
+and cadence. That separation keeps each scraper independently testable.
+
+A scraper may raise on failure; Chronicler catches the exception, logs
+it, and emits `<name>.error = 1` so silent breakage shows up in the
+dashboard instead of as a missing line.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+
+def tokei_unitares_src_code(repo_root: Path) -> float:
+    """Count `.py` lines under `src/` of the unitares repo.
+
+    Uses `wc -l` rather than tokei so no extra dep is required. Counts
+    total lines (code + comments + blanks together). Absolute accuracy
+    doesn't matter as long as the methodology is consistent over time.
+    The `find` invocation is locked to `*.py` so language drift in
+    subdirectories cannot change the reported value.
+    """
+    src = repo_root / "src"
+    if not src.is_dir():
+        raise FileNotFoundError(f"src/ not found at {src}")
+
+    # find + xargs avoids a single huge argv; `wc -l` itself totals to stdout's last line.
+    find = subprocess.run(
+        ["find", str(src), "-type", "f", "-name", "*.py"],
+        check=True, capture_output=True, text=True,
+    )
+    files = [f for f in find.stdout.splitlines() if f]
+    if not files:
+        return 0.0
+
+    wc = subprocess.run(
+        ["wc", "-l"] + files,
+        check=True, capture_output=True, text=True,
+    )
+    last_line = wc.stdout.strip().splitlines()[-1]
+    parts = last_line.split()
+    if not parts:
+        raise RuntimeError(f"Unexpected wc output: {wc.stdout!r}")
+    return float(parts[0])
+
+
+# Registry: metric name → scrape callable. Chronicler iterates this on each run.
+#
+# Keep this in sync with the server-side catalog in
+# src/fleet_metrics/catalog.py — the server validates writes against the
+# catalog, so a name here without a matching catalog entry is a 404 at
+# the POST endpoint.
+SCRAPERS: dict[str, Callable[[Path], float]] = {
+    "tokei.unitares.src.code": tokei_unitares_src_code,
+}

--- a/scripts/ops/com.unitares.chronicler.plist.template
+++ b/scripts/ops/com.unitares.chronicler.plist.template
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.unitares.chronicler</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Library/Frameworks/Python.framework/Versions/3.14/bin/python3</string>
+        <string>/Users/cirwel/projects/unitares/agents/chronicler/agent.py</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/cirwel/projects/unitares</string>
+
+    <!-- Daily — one scrape per day is enough for slow-moving metrics like LOC. -->
+    <key>StartInterval</key>
+    <integer>86400</integer>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/Users/cirwel/Library/Logs/unitares-chronicler-launchd.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/cirwel/Library/Logs/unitares-chronicler-launchd.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PYTHONPATH</key>
+        <string>/Users/cirwel/projects/unitares</string>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <key>UNITARES_METRICS_URL</key>
+        <string>http://127.0.0.1:8767</string>
+        <key>CHRONICLER_REPO_ROOT</key>
+        <string>/Users/cirwel/projects/unitares</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/test_chronicler.py
+++ b/tests/test_chronicler.py
@@ -1,0 +1,188 @@
+"""Tests for agents/chronicler/{scrapers,agent}.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# scrapers.tokei_unitares_src_code
+# ---------------------------------------------------------------------------
+
+
+class TestTokeiScraper:
+    def test_counts_lines_in_real_src(self, tmp_path: Path):
+        from agents.chronicler.scrapers import tokei_unitares_src_code
+
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "a.py").write_text("print(1)\nprint(2)\nprint(3)\n")
+        (src / "b.py").write_text("x = 1\n")
+        (src / "ignored.js").write_text("// not python\nstill not\n")
+
+        value = tokei_unitares_src_code(tmp_path)
+        # 3 + 1 = 4; the .js file must not count.
+        assert value == 4.0
+
+    def test_empty_src_returns_zero(self, tmp_path: Path):
+        from agents.chronicler.scrapers import tokei_unitares_src_code
+
+        (tmp_path / "src").mkdir()
+        assert tokei_unitares_src_code(tmp_path) == 0.0
+
+    def test_missing_src_raises(self, tmp_path: Path):
+        from agents.chronicler.scrapers import tokei_unitares_src_code
+
+        with pytest.raises(FileNotFoundError):
+            tokei_unitares_src_code(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# agent.run
+# ---------------------------------------------------------------------------
+
+
+class FakeHttpResponse:
+    def __init__(self, status_code: int, text: str = ""):
+        self.status_code = status_code
+        self.text = text
+
+
+class FakeHttpClient:
+    """Tracks calls to client.post so we can assert payload/url/auth shape."""
+
+    def __init__(self, response: FakeHttpResponse | None = None):
+        self.calls: list[dict] = []
+        self._response = response or FakeHttpResponse(201)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def post(self, url, *, headers, content, timeout):
+        self.calls.append(
+            {
+                "url": url,
+                "headers": headers,
+                "body": json.loads(content),
+                "timeout": timeout,
+            }
+        )
+        return self._response
+
+
+class TestAgentRun:
+    def test_success_case_posts_each_scraper(self, tmp_path: Path):
+        from agents.chronicler import agent as chronicler
+
+        fake = FakeHttpClient()
+        scrapers = {
+            "tokei.unitares.src.code": lambda _root: 70000.0,
+            "tests.unitares.count": lambda _root: 6601.0,
+        }
+
+        with (
+            patch.object(chronicler, "SCRAPERS", scrapers),
+            patch("agents.chronicler.agent.httpx.Client", return_value=fake),
+        ):
+            ok, fail = chronicler.run("http://127.0.0.1:8767", token=None, repo_root=tmp_path)
+
+        assert ok == 2
+        assert fail == 0
+        assert len(fake.calls) == 2
+        names = {call["body"]["name"] for call in fake.calls}
+        assert names == {"tokei.unitares.src.code", "tests.unitares.count"}
+
+    def test_dry_run_does_not_post(self, tmp_path: Path):
+        from agents.chronicler import agent as chronicler
+
+        fake = FakeHttpClient()
+        with (
+            patch.object(chronicler, "SCRAPERS", {"x.y.z": lambda _r: 1.0}),
+            patch("agents.chronicler.agent.httpx.Client", return_value=fake),
+        ):
+            ok, fail = chronicler.run(
+                "http://127.0.0.1:8767", token=None, repo_root=tmp_path, dry_run=True
+            )
+
+        assert ok == 1
+        assert fail == 0
+        assert fake.calls == []
+
+    def test_scrape_failure_emits_error_metric(self, tmp_path: Path):
+        from agents.chronicler import agent as chronicler
+
+        fake = FakeHttpClient()
+
+        def boom(_root):
+            raise RuntimeError("tokei missing")
+
+        with (
+            patch.object(chronicler, "SCRAPERS", {"tokei.unitares.src.code": boom}),
+            patch("agents.chronicler.agent.httpx.Client", return_value=fake),
+        ):
+            ok, fail = chronicler.run("http://127.0.0.1:8767", token=None, repo_root=tmp_path)
+
+        assert ok == 0
+        assert fail == 1
+        assert len(fake.calls) == 1
+        error_call = fake.calls[0]
+        assert error_call["body"]["name"] == "tokei.unitares.src.code.error"
+        assert error_call["body"]["value"] == 1.0
+
+    def test_http_error_counts_as_failure_but_does_not_raise(self, tmp_path: Path):
+        from agents.chronicler import agent as chronicler
+
+        fake = FakeHttpClient(response=FakeHttpResponse(500, "boom"))
+        with (
+            patch.object(chronicler, "SCRAPERS", {"x.y.z": lambda _r: 1.0}),
+            patch("agents.chronicler.agent.httpx.Client", return_value=fake),
+        ):
+            ok, fail = chronicler.run("http://127.0.0.1:8767", token=None, repo_root=tmp_path)
+
+        assert ok == 0
+        assert fail == 1
+
+    def test_bearer_token_header_included(self, tmp_path: Path):
+        from agents.chronicler import agent as chronicler
+
+        fake = FakeHttpClient()
+        with (
+            patch.object(chronicler, "SCRAPERS", {"x.y.z": lambda _r: 1.0}),
+            patch("agents.chronicler.agent.httpx.Client", return_value=fake),
+        ):
+            chronicler.run("http://127.0.0.1:8767", token="secret-123", repo_root=tmp_path)
+
+        assert fake.calls[0]["headers"]["authorization"] == "Bearer secret-123"
+
+    def test_post_error_metric_survives_if_server_unreachable(self, tmp_path: Path):
+        """If the post-error call itself fails, we still complete the loop."""
+        from agents.chronicler import agent as chronicler
+
+        class AlwaysFails:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def post(self, *a, **kw):
+                raise RuntimeError("network down")
+
+        def boom(_root):
+            raise RuntimeError("scrape failed")
+
+        with (
+            patch.object(chronicler, "SCRAPERS", {"x.y.z": boom}),
+            patch("agents.chronicler.agent.httpx.Client", return_value=AlwaysFails()),
+        ):
+            ok, fail = chronicler.run("http://127.0.0.1:8767", token=None, repo_root=tmp_path)
+
+        assert ok == 0
+        assert fail == 1  # scrape failure counted, post-error failure swallowed


### PR DESCRIPTION
## Summary
Second of three PRs for fleet-metrics. Adds **Chronicler** — a minimal one-shot resident agent that scrapes values and posts them to `POST /v1/metrics` on a daily cadence via launchd. Depends on #68 (the substrate + seed catalog).

## Scope — intentionally narrow
- One-shot: launchd `StartInterval=86400` drives the cadence. No persistent loop.
- **No own identity, no EISV check-ins.** This sidesteps the deferred resident-agent-identity-anchor work. Launchd restart + the `<name>.error` metric are the failure-visibility mechanisms.
- One scraper wired up: `tokei.unitares.src.code` (via `wc -l`, no new deps). Seeds the series defined in #68.

## Failure model
If a scraper raises, Chronicler catches it, posts `<name>.error = 1`, and continues to the next scraper. The error metric surfaces silent breakage in the dashboard. If the HTTP post for the error metric itself fails, we log and move on — nothing cascades.

## Operational
- Template: `scripts/ops/com.unitares.chronicler.plist.template` — copy to `~/Library/LaunchAgents/com.unitares.chronicler.plist`, then `launchctl load`.
- Env:
  - `UNITARES_METRICS_URL` (default `http://127.0.0.1:8767`)
  - `UNITARES_HTTP_API_TOKEN` (optional — localhost trusted-network bypass already covers the default local case)
  - `CHRONICLER_REPO_ROOT` (default `$PWD`)
- Dry-run: `python3 agents/chronicler/agent.py --dry`
- Verified live: dry-run against this repo returned `tokei.unitares.src.code = 70240.0`

## Test plan
- [x] Scraper unit tests — synthetic `tmp_path/src/*.py`, non-Python files ignored, missing dir raises (`tests/test_chronicler.py::TestTokeiScraper`)
- [x] Agent unit tests — success emits POSTs; dry-run posts nothing; scrape failure emits `.error`; HTTP 5xx counts as failure; bearer token header passed through; unreachable server during error-post doesn't crash the loop (`TestAgentRun`)
- [x] Live dry-run against real unitares tree
- [x] Full suite: 6626 passed, 33 skipped

## Follow-up
- PR C — dashboard panel reading `GET /v1/metrics/series` (consumer side)
- Future: add more scrapers to `SCRAPERS` + matching catalog entries. Each new metric = one tiny PR.