### PR TITLE
feat(sdk): refuse_fresh_onboard opt-in for residents

Adds refuse_fresh_onboard=True flag to GovernanceAgent and wires it into
Vigil, Sentinel, Watcher. When True, _ensure_identity raises
IdentityBootstrapRefused if the anchor is missing and UNITARES_FIRST_RUN
is not set.

Before: rotation wiped anchors and every resident silently fresh-onboarded
a new UUID. Detection took ~15 hours of inspection.

After: a wipe makes the resident refuse to start with an actionable error
message. Operator restores anchor or sets UNITARES_FIRST_RUN=1 to
authorize a new identity explicitly.

Steward does not inherit GovernanceAgent (it lives in unitares-pi-plugin)
and is excluded by construction. Ephemeral agents never set this flag.

### DIFF
--- a/agents/sdk/src/unitares_sdk/agent.py
+++ b/agents/sdk/src/unitares_sdk/agent.py
@@ -1,9 +1,17 @@
-"""GovernanceAgent — lifecycle base class for long-running UNITARES agents."""
+"""GovernanceAgent — lifecycle base class for long-running UNITARES agents.
+
+First-time resident bootstrap:
+    UNITARES_FIRST_RUN=1 python3 -m agents.vigil  # or sentinel, watcher
+This is the ONLY path that mints a new UUID for a resident with
+refuse_fresh_onboard=True. Every other path must resume the stored
+anchor UUID.
+"""
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import signal
 import time
 from dataclasses import dataclass, field
@@ -76,6 +84,7 @@ class GovernanceAgent:
         parent_agent_id: str | None = None,
         spawn_reason: str | None = None,
         persistent: bool = False,
+        refuse_fresh_onboard: bool = False,
     ):
         self.name = name
         self.mcp_url = mcp_url
@@ -86,6 +95,12 @@ class GovernanceAgent:
         # skips this identity. Resident agents (Vigil, Sentinel, etc.) should
         # set this to True to avoid sweep false-positives.
         self.persistent = persistent
+        # Residents (Vigil, Sentinel, Watcher) set this True. When True,
+        # _ensure_identity refuses to fresh-onboard if the anchor is
+        # missing; the operator must set UNITARES_FIRST_RUN=1 to bootstrap
+        # a new identity. Prevents the 2026-04-19 rotation-wipe silent-fork
+        # class. See docs/superpowers/plans/2026-04-19-anchor-resilience-series.md
+        self.refuse_fresh_onboard = refuse_fresh_onboard
 
         # Defaults based on name
         name_lower = name.lower()
@@ -195,6 +210,15 @@ class GovernanceAgent:
                 raise
 
         # First run — onboard, get a UUID, save it
+        if self.refuse_fresh_onboard and os.environ.get("UNITARES_FIRST_RUN") != "1":
+            from .errors import IdentityBootstrapRefused
+            raise IdentityBootstrapRefused(
+                f"{self.name}: anchor missing at {self.session_file}, and "
+                "refuse_fresh_onboard=True. Either restore the anchor from a "
+                "rotation backup, or run this agent once with UNITARES_FIRST_RUN=1 "
+                "to explicitly bootstrap a new identity. Never silent-swap."
+            )
+
         onboard_kwargs: dict[str, Any] = {}
         if self.parent_agent_id is not None:
             onboard_kwargs["parent_agent_id"] = self.parent_agent_id

--- a/agents/sdk/src/unitares_sdk/errors.py
+++ b/agents/sdk/src/unitares_sdk/errors.py
@@ -35,3 +35,14 @@ class VerdictError(GovernanceError):
         if guidance:
             msg += f" — {guidance}"
         super().__init__(msg)
+
+
+class IdentityBootstrapRefused(GovernanceError):
+    """Raised when a resident agent's anchor is missing and the agent was
+    configured with refuse_fresh_onboard=True (the default for Vigil,
+    Sentinel, Watcher).
+
+    Fix: either restore the anchor from a rotation backup, or explicitly
+    bootstrap a new identity by running the agent once with the
+    UNITARES_FIRST_RUN=1 environment variable set. Never silently swap
+    identities."""

--- a/agents/sdk/tests/test_refuse_fresh_onboard.py
+++ b/agents/sdk/tests/test_refuse_fresh_onboard.py
@@ -1,0 +1,99 @@
+"""refuse_fresh_onboard guard: residents refuse silent fresh-onboard.
+
+Added 2026-04-19 as Phase 3 of the anchor-resilience series. Exercises the
+three identity-resolution states for a resident with the flag set:
+
+1. No anchor + no UNITARES_FIRST_RUN -> IdentityBootstrapRefused
+2. No anchor + UNITARES_FIRST_RUN=1  -> onboard runs (explicit bootstrap)
+3. Anchor present                     -> UUID-direct resume (guard irrelevant)
+"""
+from unittest.mock import AsyncMock
+
+import pytest
+
+from unitares_sdk.agent import GovernanceAgent
+from unitares_sdk.errors import IdentityBootstrapRefused
+
+
+class _Dummy(GovernanceAgent):
+    async def run_cycle(self, client):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_refuse_raises_when_no_anchor(tmp_path, monkeypatch):
+    """No anchor file + refuse=True + no FIRST_RUN env => raises."""
+    anchor = tmp_path / "watcher.json"
+    a = _Dummy(
+        name="Watcher",
+        mcp_url="stdio:test",
+        session_file=anchor,
+        refuse_fresh_onboard=True,
+    )
+    monkeypatch.delenv("UNITARES_FIRST_RUN", raising=False)
+    client = AsyncMock()
+    with pytest.raises(IdentityBootstrapRefused):
+        await a._ensure_identity(client)
+    client.onboard.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refuse_allows_when_first_run_set(tmp_path, monkeypatch):
+    """No anchor file + refuse=True + FIRST_RUN=1 => allows onboard."""
+    anchor = tmp_path / "watcher.json"
+    a = _Dummy(
+        name="Watcher",
+        mcp_url="stdio:test",
+        session_file=anchor,
+        refuse_fresh_onboard=True,
+    )
+    monkeypatch.setenv("UNITARES_FIRST_RUN", "1")
+    client = AsyncMock()
+    client.onboard = AsyncMock()
+    client.agent_uuid = "abc123"
+    client.client_session_id = "s"
+    client.continuity_token = "t"
+    await a._ensure_identity(client)
+    client.onboard.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_refuse_resumes_normally_when_anchor_present(tmp_path, monkeypatch):
+    """Anchor present => UUID-direct resume, flag irrelevant."""
+    anchor = tmp_path / "watcher.json"
+    anchor.write_text('{"agent_uuid": "907e3195-c649-49db-b753-1edc1a105f33"}')
+    a = _Dummy(
+        name="Watcher",
+        mcp_url="stdio:test",
+        session_file=anchor,
+        refuse_fresh_onboard=True,
+    )
+    monkeypatch.delenv("UNITARES_FIRST_RUN", raising=False)
+    client = AsyncMock()
+    client.identity = AsyncMock()
+    client.agent_uuid = "907e3195-c649-49db-b753-1edc1a105f33"
+    client.client_session_id = "s"
+    client.continuity_token = "t"
+    await a._ensure_identity(client)
+    client.identity.assert_called_once()
+    client.onboard.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_default_flag_false_allows_onboard(tmp_path, monkeypatch):
+    """Default refuse_fresh_onboard=False preserves legacy onboard-on-missing behavior."""
+    anchor = tmp_path / "ephemeral.json"
+    a = _Dummy(
+        name="Ephemeral",
+        mcp_url="stdio:test",
+        session_file=anchor,
+    )
+    monkeypatch.delenv("UNITARES_FIRST_RUN", raising=False)
+    assert a.refuse_fresh_onboard is False
+    client = AsyncMock()
+    client.onboard = AsyncMock()
+    client.agent_uuid = "abc123"
+    client.client_session_id = "s"
+    client.continuity_token = "t"
+    await a._ensure_identity(client)
+    client.onboard.assert_called_once()

--- a/agents/sentinel/agent.py
+++ b/agents/sentinel/agent.py
@@ -424,6 +424,7 @@ class SentinelAgent(GovernanceAgent):
             state_dir=STATE_FILE.parent,
             timeout=30.0,
             persistent=True,
+            refuse_fresh_onboard=True,
         )
         self.ws_url = ws_url
         self.analysis_interval = analysis_interval

--- a/agents/vigil/agent.py
+++ b/agents/vigil/agent.py
@@ -273,6 +273,7 @@ class VigilAgent(GovernanceAgent):
             state_dir=STATE_FILE.parent,
             timeout=30.0,
             persistent=True,
+            refuse_fresh_onboard=True,
         )
         self.heartbeat_interval = heartbeat_interval
         self.with_tests = with_tests

--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -209,6 +209,19 @@ def resolve_identity(client) -> None:
             log(f"token resume failed: {e}", "warning")
 
     # Step 2: Fresh onboard — only when nothing else works.
+    # Silent-fork guard (added 2026-04-19 anchor-resilience series): Watcher
+    # is a resident; missing anchor + no UNITARES_FIRST_RUN means the
+    # operator did not authorize a fresh identity. Refuse loudly rather
+    # than silently forking.
+    if os.environ.get("UNITARES_FIRST_RUN") != "1":
+        log(
+            "anchor missing and UNITARES_FIRST_RUN not set — refusing to fresh-onboard. "
+            "Restore the anchor from a rotation backup, or set UNITARES_FIRST_RUN=1 "
+            "to explicitly bootstrap a new Watcher identity.",
+            "error",
+        )
+        _watcher_identity = None
+        return
     try:
         client.onboard("Watcher", spawn_reason="resident_observer")
         _sync_identity(client)

--- a/agents/watcher/tests/test_agent.py
+++ b/agents/watcher/tests/test_agent.py
@@ -1924,9 +1924,14 @@ class TestWatcherIdentity:
     """
 
     def test_fresh_onboard_when_no_session_file(self, watcher_module, tmp_path, monkeypatch):
-        """First-ever invocation: no .watcher_session → fresh onboard."""
+        """First-ever invocation: no .watcher_session → fresh onboard.
+
+        refuse_fresh_onboard guard (Phase 3, 2026-04-19) requires
+        UNITARES_FIRST_RUN=1 to authorize a fresh mint.
+        """
         session_file = tmp_path / SESSION_FILE_NAME
         monkeypatch.setattr(watcher_module, "SESSION_FILE", session_file)
+        monkeypatch.setenv("UNITARES_FIRST_RUN", "1")
 
         onboard_called = {}
 
@@ -2040,13 +2045,18 @@ class TestWatcherIdentity:
         assert len(calls) == 2  # no onboard needed
 
     def test_fresh_onboard_when_both_uuid_direct_and_token_fail(self, watcher_module, tmp_path, monkeypatch):
-        """Both UUID-direct AND token fail → fresh onboard (Step 2)."""
+        """Both UUID-direct AND token fail → fresh onboard (Step 2).
+
+        refuse_fresh_onboard guard (Phase 3, 2026-04-19) requires
+        UNITARES_FIRST_RUN=1 to authorize a fresh mint.
+        """
         session_file = tmp_path / SESSION_FILE_NAME
         session_file.write_text(json.dumps({
             "continuity_token": "stale-tok",
             "agent_uuid": "uuid-archived",
         }))
         monkeypatch.setattr(watcher_module, "SESSION_FILE", session_file)
+        monkeypatch.setenv("UNITARES_FIRST_RUN", "1")
 
         calls = []
 
@@ -2069,9 +2079,14 @@ class TestWatcherIdentity:
         assert calls[2] == ("onboard", "Watcher")
 
     def test_governance_down_leaves_identity_none(self, watcher_module, tmp_path, monkeypatch):
-        """If governance is unreachable, identity is None — scanning still works."""
+        """If governance is unreachable, identity is None — scanning still works.
+
+        Test sets UNITARES_FIRST_RUN=1 to reach the onboard path; the point
+        is to verify ConnectionError from onboard is caught cleanly.
+        """
         session_file = tmp_path / SESSION_FILE_NAME
         monkeypatch.setattr(watcher_module, "SESSION_FILE", session_file)
+        monkeypatch.setenv("UNITARES_FIRST_RUN", "1")
 
         class FakeClient:
             def onboard(self, *a, **kw):
@@ -2532,6 +2547,8 @@ class TestWatcherLifecycleIntegration:
         """Identity → persist finding → surface (triggers check-in) → resolve (posts event)."""
         session_file = tmp_path / ".watcher_session"
         monkeypatch.setattr(watcher_module, "SESSION_FILE", session_file)
+        # Phase 3 silent-fork guard requires explicit bootstrap env var.
+        monkeypatch.setenv("UNITARES_FIRST_RUN", "1")
 
         # Track all governance interactions
         gov_calls = []

--- a/agents/watcher/tests/test_refuse_fresh_onboard.py
+++ b/agents/watcher/tests/test_refuse_fresh_onboard.py
@@ -1,0 +1,103 @@
+"""Watcher silent-fork guard: resolve_identity refuses to fresh-onboard
+when the anchor is missing and UNITARES_FIRST_RUN is not set.
+
+Added 2026-04-19 as Phase 3 of the anchor-resilience series. Watcher does
+NOT inherit GovernanceAgent, so the SDK's refuse_fresh_onboard flag does
+not cover it — the guard is open-coded in resolve_identity.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def watcher_module():
+    """Load agents/watcher/agent.py as a module."""
+    project_root = Path(__file__).resolve().parent.parent.parent.parent
+    module_path = project_root / "agents" / "watcher" / "agent.py"
+    spec = importlib.util.spec_from_file_location("watcher_agent", module_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["watcher_agent"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _MockClient:
+    client_session_id = "sess"
+    continuity_token = "tok"
+    agent_uuid = "uuid"
+
+    def __init__(self):
+        self.onboard_calls = 0
+        self.identity_calls = 0
+
+    def onboard(self, *a, **kw):
+        self.onboard_calls += 1
+        return type("R", (), {"success": True})()
+
+    def identity(self, **kw):
+        self.identity_calls += 1
+        return type("R", (), {"success": True})()
+
+
+def test_watcher_refuses_fresh_onboard_without_first_run(
+    watcher_module, monkeypatch, tmp_path
+):
+    """With no anchor and no UNITARES_FIRST_RUN, resolve_identity must
+    NOT call client.onboard. _watcher_identity stays None."""
+    session_file = tmp_path / "watcher.json"
+    monkeypatch.setattr(watcher_module, "SESSION_FILE", session_file)
+    monkeypatch.delenv("UNITARES_FIRST_RUN", raising=False)
+    monkeypatch.setattr(watcher_module, "_watcher_identity", None)
+
+    client = _MockClient()
+    watcher_module.resolve_identity(client)
+
+    assert client.onboard_calls == 0
+    assert watcher_module.get_watcher_identity() is None
+
+
+def test_watcher_allows_fresh_onboard_when_first_run_set(
+    watcher_module, monkeypatch, tmp_path
+):
+    """With UNITARES_FIRST_RUN=1, fresh onboard is permitted — operator
+    explicitly authorized a new identity."""
+    session_file = tmp_path / "watcher.json"
+    monkeypatch.setattr(watcher_module, "SESSION_FILE", session_file)
+    monkeypatch.setenv("UNITARES_FIRST_RUN", "1")
+    monkeypatch.setattr(watcher_module, "_watcher_identity", None)
+
+    # Avoid stamping attempt after onboard (call_tool not on _MockClient)
+    client = _MockClient()
+    client.call_tool = lambda *a, **kw: None
+    watcher_module.resolve_identity(client)
+
+    assert client.onboard_calls == 1
+    identity = watcher_module.get_watcher_identity()
+    assert identity is not None
+    assert identity["agent_uuid"] == "uuid"
+
+
+def test_watcher_resume_path_unaffected_by_guard(
+    watcher_module, monkeypatch, tmp_path
+):
+    """When anchor is present with agent_uuid, PATH 0 resume runs regardless
+    of UNITARES_FIRST_RUN — the guard only fires on the fresh-onboard branch."""
+    import json
+
+    session_file = tmp_path / "watcher.json"
+    session_file.write_text(json.dumps({"agent_uuid": "uuid"}))
+    monkeypatch.setattr(watcher_module, "SESSION_FILE", session_file)
+    monkeypatch.delenv("UNITARES_FIRST_RUN", raising=False)
+    monkeypatch.setattr(watcher_module, "_watcher_identity", None)
+
+    client = _MockClient()
+    watcher_module.resolve_identity(client)
+
+    assert client.identity_calls == 1
+    assert client.onboard_calls == 0


### PR DESCRIPTION
Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.