### PR TITLE
feat(dashboard): Fleet Metrics panel — catalog-driven line chart

### DIFF
--- a/dashboard/fleet-metrics.js
+++ b/dashboard/fleet-metrics.js
@@ -1,0 +1,203 @@
+// fleet-metrics.js — render `metrics.series` time-series on the dashboard.
+//
+// Consumes:
+//   GET /v1/metrics/catalog       — list of available series names
+//   GET /v1/metrics/series?name=X — points for the selected series
+//
+// Deliberately small surface: one line chart, a dropdown of series, a
+// refresh button. No WS subscription (these metrics move on daily cadence,
+// so polling-on-demand is right-sized). Extends naturally as the catalog
+// grows — no code change needed to see new series, just pick them from
+// the dropdown.
+
+(function () {
+    'use strict';
+
+    var chart = null;          // Chart.js instance
+    var currentName = null;    // selected series name
+
+    function getAuthToken() {
+        try {
+            return localStorage.getItem('UNITARES_HTTP_API_TOKEN') || null;
+        } catch (_e) {
+            return null;
+        }
+    }
+
+    function authHeaders() {
+        var token = getAuthToken();
+        return token ? { 'Authorization': 'Bearer ' + token } : {};
+    }
+
+    async function fetchCatalog() {
+        try {
+            var resp = await fetch('/v1/metrics/catalog', {
+                credentials: 'same-origin',
+                headers: authHeaders(),
+            });
+            if (!resp.ok) throw new Error('HTTP ' + resp.status);
+            var data = await resp.json();
+            if (!data || data.success === false) {
+                throw new Error((data && data.error) || 'unknown');
+            }
+            return data.metrics || [];
+        } catch (e) {
+            console.warn('[FleetMetrics] catalog fetch failed:', e);
+            return [];
+        }
+    }
+
+    async function fetchSeries(name) {
+        try {
+            var url = '/v1/metrics/series?name=' + encodeURIComponent(name);
+            var resp = await fetch(url, {
+                credentials: 'same-origin',
+                headers: authHeaders(),
+            });
+            if (!resp.ok) throw new Error('HTTP ' + resp.status);
+            var data = await resp.json();
+            if (!data || data.success === false) {
+                throw new Error((data && data.error) || 'unknown');
+            }
+            return data.points || [];
+        } catch (e) {
+            console.warn('[FleetMetrics] series fetch failed:', e);
+            return [];
+        }
+    }
+
+    function renderEmpty(message) {
+        var empty = document.getElementById('fleet-metrics-empty');
+        var canvas = document.getElementById('fleet-metrics-chart');
+        if (!empty || !canvas) return;
+        empty.textContent = message;
+        empty.style.display = '';
+        canvas.style.display = 'none';
+        if (chart) {
+            chart.destroy();
+            chart = null;
+        }
+    }
+
+    function renderChart(metric, points) {
+        var empty = document.getElementById('fleet-metrics-empty');
+        var canvas = document.getElementById('fleet-metrics-chart');
+        if (!canvas) return;
+
+        if (points.length === 0) {
+            renderEmpty('No data yet for "' + metric.name + '" — wait for the next Chronicler cycle.');
+            return;
+        }
+
+        empty.style.display = 'none';
+        canvas.style.display = '';
+
+        var data = points.map(function (p) {
+            return { x: new Date(p.ts), y: p.value };
+        });
+
+        if (chart) {
+            chart.destroy();
+        }
+
+        // eslint-disable-next-line no-undef
+        chart = new Chart(canvas.getContext('2d'), {
+            type: 'line',
+            data: {
+                datasets: [{
+                    label: metric.name + (metric.unit ? ' (' + metric.unit + ')' : ''),
+                    data: data,
+                    borderColor: '#4a9eff',
+                    backgroundColor: 'rgba(74, 158, 255, 0.1)',
+                    fill: true,
+                    tension: 0.2,
+                    pointRadius: 3,
+                }],
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: { display: true, position: 'top' },
+                    tooltip: { mode: 'index', intersect: false },
+                },
+                scales: {
+                    x: {
+                        type: 'time',
+                        time: { tooltipFormat: 'yyyy-MM-dd HH:mm' },
+                        title: { display: false },
+                    },
+                    y: {
+                        beginAtZero: false,
+                        title: { display: !!metric.unit, text: metric.unit },
+                    },
+                },
+            },
+        });
+    }
+
+    function populateDropdown(metrics) {
+        var select = document.getElementById('fleet-metrics-select');
+        if (!select) return;
+        select.innerHTML = '';
+        if (metrics.length === 0) {
+            var opt = document.createElement('option');
+            opt.value = '';
+            opt.textContent = '(no metrics registered)';
+            select.appendChild(opt);
+            return;
+        }
+        for (var i = 0; i < metrics.length; i++) {
+            var m = metrics[i];
+            var o = document.createElement('option');
+            o.value = m.name;
+            o.textContent = m.name + (m.description ? '  —  ' + m.description : '');
+            select.appendChild(o);
+        }
+        if (!currentName || !metrics.some(function (m) { return m.name === currentName; })) {
+            currentName = metrics[0].name;
+            select.value = currentName;
+        }
+    }
+
+    async function refresh() {
+        var metrics = await fetchCatalog();
+        populateDropdown(metrics);
+        if (metrics.length === 0) {
+            renderEmpty('No metrics registered yet.');
+            return;
+        }
+        var metric = metrics.find(function (m) { return m.name === currentName; }) || metrics[0];
+        currentName = metric.name;
+        var points = await fetchSeries(metric.name);
+        renderChart(metric, points);
+    }
+
+    function wire() {
+        var select = document.getElementById('fleet-metrics-select');
+        var refreshBtn = document.getElementById('fleet-metrics-refresh');
+        if (select) {
+            select.addEventListener('change', function () {
+                currentName = select.value;
+                refresh();
+            });
+        }
+        if (refreshBtn) {
+            refreshBtn.addEventListener('click', refresh);
+        }
+        refresh();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', wire);
+    } else {
+        wire();
+    }
+
+    // Expose for console debugging / tests
+    window.FleetMetricsPanel = {
+        refresh: refresh,
+        _fetchCatalog: fetchCatalog,
+        _fetchSeries: fetchSeries,
+    };
+})();

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -30,6 +30,7 @@
     <script src="/dashboard/eisv-charts.js"></script>
     <script src="/dashboard/timeline.js"></script>
     <script src="/dashboard/residents.js"></script>
+    <script src="/dashboard/fleet-metrics.js" defer></script>
 </head>
 
 <body>
@@ -76,6 +77,7 @@
         <a href="#discoveries-section" class="section-nav-item" data-section="discoveries-section">Discoveries</a>
         <a href="#dialectic-section" class="section-nav-item" data-section="dialectic-section">Dialectic</a>
         <a href="#activity-timeline-section" class="section-nav-item" data-section="activity-timeline-section">Activity</a>
+        <a href="#fleet-metrics-section" class="section-nav-item" data-section="fleet-metrics-section">Metrics</a>
         <a href="/phase" style="margin-left:auto; opacity:0.6; padding:6px 14px; border-radius:20px; font-size:0.8rem; font-weight:500; color:var(--text-secondary); text-decoration:none; white-space:nowrap;">Phase Space &rarr;</a>
     </nav>
 
@@ -460,6 +462,27 @@
             </div>
             <div id="timeline-container" class="timeline-list">
                 <div class="timeline-empty">Waiting for events...</div>
+            </div>
+        </div>
+
+        <!-- Fleet Metrics — catalog-driven time-series from metrics.series.
+             One line chart per selected metric (e.g. LOC, test count, KG
+             discoveries) fed daily by the Chronicler resident agent. -->
+        <div class="panel" id="fleet-metrics-section">
+            <div class="panel-header">
+                <h2>Fleet Metrics</h2>
+                <div class="panel-controls">
+                    <select id="fleet-metrics-select" aria-label="Select metric series">
+                        <option value="">(loading…)</option>
+                    </select>
+                    <button id="fleet-metrics-refresh" class="panel-button" type="button">Refresh</button>
+                </div>
+            </div>
+            <div id="fleet-metrics-container" style="position:relative; height:320px; padding:12px;">
+                <canvas id="fleet-metrics-chart"></canvas>
+                <div id="fleet-metrics-empty" class="timeline-empty" style="display:none;">
+                    Loading metrics…
+                </div>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
Third and final PR of the fleet-metrics track (after #68 substrate, #71 Chronicler). Adds a Fleet Metrics panel to the dashboard that discovers series from the catalog endpoint and renders the selected one as a line chart.

## UX
- **Dropdown** populated from \`GET /v1/metrics/catalog\`. Name + description shown, e.g. \`tokei.unitares.src.code  —  Lines of code…\`.
- **Chart** renders points from \`GET /v1/metrics/series?name=X\` via Chart.js (already loaded in index.html, no new dep).
- **Refresh button** + auto-refresh on dropdown change. No WS subscription — these series move on daily cadence, polling is right-sized.
- Empty state for first-day, not-yet-populated series.

## Design
- Dropdown is catalog-driven, so adding a metric in #68's catalog + a scraper in #71 automatically surfaces it here on next refresh — zero dashboard change needed.
- Auth via localStorage bearer token, mirrors the \`residents.js\` / \`timeline.js\` convention.
- No CSS additions — reuses the existing panel/panel-header/panel-button patterns.

## Non-scope
- No multi-series overlay, date-range picker, or sparkline.
- No JS test harness (the dashboard layer has none in this repo; server endpoints are fully covered).

## Test plan
- [x] HTML parses (python html.parser smoke)
- [x] Full pytest suite: 6647 passed, 33 skipped (unchanged from prior)
- [ ] Live smoke after merge: visit /dashboard, pick \`tokei.unitares.src.code\`, confirm chart loads (needs #68 + #71 merged + Chronicler to have run at least once)

## Dependency
Must land after #68. Will show "No data yet" if Chronicler (#71) hasn't run yet, which is the intended empty state.