### PR TITLE
feat(identity): emit identity_hijack_suspected from PATH 0 Part C gate

### DIFF
--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -60,6 +60,47 @@ from .persistence import (
     set_agent_label,
 )
 
+
+def _broadcaster():
+    """Lazy accessor for the shared broadcaster. Returns None when broadcaster
+    isn't importable (e.g., unit tests without a live server). Mirrors the
+    helper in persistence.py; kept at module level here so tests patching
+    handlers._broadcaster can intercept cleanly."""
+    try:
+        from src.broadcaster import broadcaster as _b
+        return _b
+    except Exception:
+        return None
+
+
+async def _emit_identity_hijack_event(
+    direct_uuid: str,
+    mode: str,
+    token_aid: Optional[str],
+) -> None:
+    """Surface a suspected identity hijack on the shared broadcast channel.
+
+    Fires when PATH 0 detects a bare-UUID resume without a matching
+    continuity_token (see Part C gate). Dashboards and the Discord bridge
+    subscribe to this event and surface it within one broadcast cycle,
+    mirroring the `resident_fork_detected` pattern (#70).
+    """
+    b = _broadcaster()
+    if b is None:
+        return
+    try:
+        await b.broadcast_event(
+            event_type="identity_hijack_suspected",
+            agent_id=direct_uuid,
+            payload={
+                "mode": mode,
+                "proof": "matching_token" if token_aid == direct_uuid else "none",
+                "token_aid_mismatch": token_aid if (token_aid and token_aid != direct_uuid) else None,
+            },
+        )
+    except Exception as e:
+        logger.warning(f"[IDENTITY_HIJACK] broadcast_event failed: {e}")
+
 # --- identity_resolution ---
 from .resolution import (
     _generate_agent_id,
@@ -438,6 +479,7 @@ async def _try_resume_by_agent_uuid_direct(
         from config.governance_config import identity_strict_mode
         _partc_mode = identity_strict_mode()
         if _partc_mode == "strict":
+            await _emit_identity_hijack_event(_direct_uuid, "strict", _partc_token_aid)
             return error_response(
                 (
                     "Bare agent_uuid resume is not permitted. Include "
@@ -462,7 +504,8 @@ async def _try_resume_by_agent_uuid_direct(
                 _direct_uuid[:8],
                 (_partc_token_aid[:8] + "...") if _partc_token_aid else "none",
             )
-        # mode == "off": unchanged behavior, no log
+            await _emit_identity_hijack_event(_direct_uuid, "log", _partc_token_aid)
+        # mode == "off": unchanged behavior, no log, no broadcast
 
     # PATH 0 FAST: if the UUID has a live in-process monitor, trust it
     # and skip DB verification entirely. Anyio-deadlock-safe (no awaits).

--- a/tests/test_identity_honesty_partc.py
+++ b/tests/test_identity_honesty_partc.py
@@ -149,6 +149,165 @@ class TestPath0RequiresOwnershipProof:
         assert data.get("success") is True, f"Matching token must pass strict. Got: {data}"
 
 
+class TestPath0EmitsHijackEvent:
+    """When PATH 0 detects a bare-UUID resume (ownership proof missing), emit
+    a broadcast event so dashboards + Discord bridge surface the attempt.
+
+    Rationale: the Part C gate already *decides* (reject vs warn vs pass). The
+    missing piece post-2026-04-20 is *visibility* — a log line only reaches
+    the MCP server logs, which operators rarely tail. A broadcast event
+    flows through the same pipeline as `resident_fork_detected` (#70), landing
+    in the dashboard and Discord within one broadcast cycle.
+
+    Fires in `strict` and `log` modes; silent in `off` mode and when the
+    caller provides a matching continuity_token.
+
+    See KG bug 2026-04-20T00:09:51 (SessionStart-hook hijack vector).
+    """
+
+    @pytest.fixture
+    def captured_events(self):
+        return []
+
+    @pytest.fixture
+    def broadcaster_stub(self, captured_events):
+        b = MagicMock()
+
+        async def _record(**kwargs):
+            captured_events.append(kwargs)
+
+        b.broadcast_event = AsyncMock(side_effect=_record)
+        return b
+
+    @pytest.mark.asyncio
+    async def test_log_mode_bare_uuid_emits_hijack_event(
+        self, monkeypatch, captured_events, broadcaster_stub
+    ):
+        monkeypatch.setenv("UNITARES_IDENTITY_STRICT", "log")
+
+        from src.mcp_handlers.identity import handlers as h_mod
+
+        fake_server = MagicMock(
+            monitors={"aaaaaaaa-1111-2222-3333-444444444444": MagicMock()},
+            agent_metadata={},
+        )
+        with patch(
+            "src.mcp_handlers.shared.get_mcp_server",
+            return_value=fake_server,
+        ), patch.object(h_mod, "_broadcaster", return_value=broadcaster_stub):
+            result = await h_mod.handle_identity_adapter({
+                "agent_uuid": "aaaaaaaa-1111-2222-3333-444444444444",
+                "resume": True,
+            })
+
+        assert json.loads(result[0].text).get("success") is True
+        hijack_events = [
+            e for e in captured_events
+            if e.get("event_type") == "identity_hijack_suspected"
+        ]
+        assert hijack_events, (
+            f"Log mode must emit identity_hijack_suspected. Got: {captured_events}"
+        )
+        evt = hijack_events[0]
+        assert evt.get("agent_id") == "aaaaaaaa-1111-2222-3333-444444444444"
+        payload = evt.get("payload") or {}
+        assert payload.get("mode") == "log"
+        assert payload.get("proof") == "none"
+
+    @pytest.mark.asyncio
+    async def test_strict_mode_bare_uuid_still_emits_event(
+        self, monkeypatch, captured_events, broadcaster_stub
+    ):
+        """Even when strict mode rejects the call, the event still fires so
+        operators can see rejected-hijack attempts in the dashboard."""
+        monkeypatch.setenv("UNITARES_IDENTITY_STRICT", "strict")
+
+        from src.mcp_handlers.identity import handlers as h_mod
+
+        with patch.object(h_mod, "_broadcaster", return_value=broadcaster_stub):
+            result = await h_mod.handle_identity_adapter({
+                "agent_uuid": "bbbbbbbb-1111-2222-3333-444444444444",
+                "resume": True,
+            })
+
+        # Strict mode rejects.
+        assert json.loads(result[0].text).get("success") is False
+        hijack_events = [
+            e for e in captured_events
+            if e.get("event_type") == "identity_hijack_suspected"
+        ]
+        assert hijack_events, (
+            "Strict-mode rejections must still emit the event for visibility"
+        )
+        assert (hijack_events[0].get("payload") or {}).get("mode") == "strict"
+
+    @pytest.mark.asyncio
+    async def test_off_mode_does_not_emit_event(
+        self, monkeypatch, captured_events, broadcaster_stub
+    ):
+        monkeypatch.setenv("UNITARES_IDENTITY_STRICT", "off")
+
+        from src.mcp_handlers.identity import handlers as h_mod
+
+        fake_server = MagicMock(
+            monitors={"cccccccc-1111-2222-3333-444444444444": MagicMock()},
+            agent_metadata={},
+        )
+        with patch(
+            "src.mcp_handlers.shared.get_mcp_server",
+            return_value=fake_server,
+        ), patch.object(h_mod, "_broadcaster", return_value=broadcaster_stub):
+            await h_mod.handle_identity_adapter({
+                "agent_uuid": "cccccccc-1111-2222-3333-444444444444",
+                "resume": True,
+            })
+
+        hijack_events = [
+            e for e in captured_events
+            if e.get("event_type") == "identity_hijack_suspected"
+        ]
+        assert hijack_events == [], (
+            "Off mode is explicit opt-out of the whole Part C machinery — "
+            "no event should fire"
+        )
+
+    @pytest.mark.asyncio
+    async def test_matching_token_does_not_emit_event(
+        self, monkeypatch, captured_events, broadcaster_stub
+    ):
+        monkeypatch.setenv("UNITARES_IDENTITY_STRICT", "log")
+        monkeypatch.setenv("UNITARES_CONTINUITY_TOKEN_SECRET", "test-secret-hijack-evt")
+
+        from src.mcp_handlers.identity.session import create_continuity_token
+        agent_uuid = "dddddddd-1111-2222-3333-444444444444"
+        token = create_continuity_token(agent_uuid, "test-session")
+        assert token is not None
+
+        from src.mcp_handlers.identity import handlers as h_mod
+
+        fake_server = MagicMock(
+            monitors={agent_uuid: MagicMock()},
+            agent_metadata={},
+        )
+        with patch(
+            "src.mcp_handlers.shared.get_mcp_server",
+            return_value=fake_server,
+        ), patch.object(h_mod, "_broadcaster", return_value=broadcaster_stub):
+            await h_mod.handle_identity_adapter({
+                "agent_uuid": agent_uuid,
+                "continuity_token": token,
+                "resume": True,
+            })
+
+        hijack_events = [
+            e for e in captured_events
+            if e.get("event_type") == "identity_hijack_suspected"
+        ]
+        assert hijack_events == [], (
+            "Matching token proves ownership — no hijack suspicion"
+        )
+
+
 class TestMiddlewarePath0Gate:
     """Middleware PATH 0 passthrough must enforce the same ownership proof."""
 


### PR DESCRIPTION
## Summary

PATH 0 ownership-proof failures (bare `agent_uuid` resume without matching `continuity_token`) already decide — strict rejects, log warns, off ignores. Missing: visibility. The `[IDENTITY_STRICT]` log line reaches the MCP server log, which operators rarely tail. Dashboards and the Discord bridge never saw the attempts.

This adds a `broadcast_event('identity_hijack_suspected', ...)` emission from both strict and log branches of the Part C gate, following the same pattern as `resident_fork_detected` (#70). Off mode stays silent — explicit opt-out. Matching token stays silent — ownership proven.

## Payload

- `agent_id` — the UUID the caller tried to resume
- `mode` — `strict | log`
- `proof` — `none` when no token, or surfaces token/uuid mismatch
- `token_aid_mismatch` — the token's `aid` claim when it disagreed with the requested UUID

## Context

The plugin-side SessionStart hook (`unitares-governance-plugin#13`, merged) was the UX vector — it dumped a cross-instance UUID menu, inviting fresh agents to pattern-match on model name and resume into other instances' identities. That PR closed the LLM-facing door. This PR makes the server-side residue visible: any remaining mechanical vector (logs, process listings, malicious agent reading anchor files) that still drives a bare-UUID resume now surfaces on the dashboard within one broadcast cycle instead of sitting silent in MCP server logs.

## Tests

4 new in `TestPath0EmitsHijackEvent`:
- log-mode emits
- strict-mode emits even when rejected (operators need to see attempts, not just grants)
- off-mode silent
- matching-token silent

Full suite: **6653 passed, 33 skipped**.

## Related

- KG bug `2026-04-20T00:09:51`
- `unitares-governance-plugin#13` (hook-side fix, merged)
- `#42` (Part C strict-mode gates)
- `#70` (resident-fork detector — same broadcast pattern)

## Test plan

- [ ] CI green
- [ ] Post-merge: dashboard/Discord surfaces `identity_hijack_suspected` when any caller attempts bare-UUID resume
- [ ] Post-merge: no regression in legitimate token+UUID resume (no false events)