### PR TITLE
fix(identity): middleware PATH 0 gate emits identity_hijack_suspected

### DIFF
--- a/src/mcp_handlers/middleware/identity_step.py
+++ b/src/mcp_handlers/middleware/identity_step.py
@@ -310,6 +310,36 @@ async def resolve_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
         if not _partc_owned:
             from config.governance_config import identity_strict_mode
             _partc_mode = identity_strict_mode()
+
+            async def _emit_middleware_hijack(mode: str) -> None:
+                """Mirror the handlers.py event emission so middleware-path
+                hijack attempts surface on the same broadcast channel as
+                handler-path attempts. Source tag distinguishes them."""
+                try:
+                    from ..identity.handlers import _broadcaster
+                except Exception:
+                    return
+                b = _broadcaster()
+                if b is None:
+                    return
+                try:
+                    await b.broadcast_event(
+                        event_type="identity_hijack_suspected",
+                        agent_id=_direct_uuid,
+                        payload={
+                            "mode": mode,
+                            "source": "middleware",
+                            "proof": "matching_token" if _partc_token_aid == _direct_uuid else "none",
+                            "token_aid_mismatch": (
+                                _partc_token_aid
+                                if (_partc_token_aid and _partc_token_aid != _direct_uuid)
+                                else None
+                            ),
+                        },
+                    )
+                except Exception as e:
+                    logger.warning(f"[IDENTITY_HIJACK] middleware broadcast_event failed: {e}")
+
             if _partc_mode == "strict":
                 ctx.strict_reject = True
                 ctx.identity_result = {
@@ -325,6 +355,7 @@ async def resolve_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
                     "agent_uuid=%s... without matching token",
                     _direct_uuid[:8],
                 )
+                await _emit_middleware_hijack("strict")
                 return name, arguments, ctx
             elif _partc_mode == "log":
                 logger.warning(
@@ -333,6 +364,8 @@ async def resolve_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
                     _direct_uuid[:8],
                     (_partc_token_aid[:8] + "...") if _partc_token_aid else "none",
                 )
+                await _emit_middleware_hijack("log")
+            # mode == "off": unchanged behavior, no log, no broadcast
 
         from ..context import set_session_context
         client_hint = arguments.get("client_hint") if arguments else None

--- a/tests/test_identity_honesty_partc.py
+++ b/tests/test_identity_honesty_partc.py
@@ -349,6 +349,122 @@ class TestMiddlewarePath0Gate:
         assert ret_ctx.identity_result.get("reason") == "bare_uuid_resume_denied"
 
     @pytest.mark.asyncio
+    async def test_middleware_strict_emits_hijack_event(self, monkeypatch):
+        """Middleware strict-mode rejection must emit identity_hijack_suspected
+        broadcast — closes the asymmetry where handlers.py emitted but the
+        middleware passthrough path stayed invisible on dashboards."""
+        monkeypatch.setenv("UNITARES_IDENTITY_STRICT", "strict")
+
+        from src.mcp_handlers.middleware import identity_step as mw
+
+        captured = []
+
+        async def _record(**kwargs):
+            captured.append(kwargs)
+
+        broadcaster_stub = MagicMock()
+        broadcaster_stub.broadcast_event = AsyncMock(side_effect=_record)
+
+        signals = MagicMock(
+            transport="http",
+            user_agent="claude-test",
+            ip_ua_fingerprint="ua:deadbe",
+            x_session_id=None,
+            x_agent_id=None,
+            mcp_session_id=None,
+            oauth_client_id=None,
+            x_client_id=None,
+            client_hint=None,
+        )
+        with patch(
+            "src.mcp_handlers.context.get_session_signals",
+            return_value=signals,
+        ), patch(
+            "src.mcp_handlers.identity.handlers._broadcaster",
+            return_value=broadcaster_stub,
+        ):
+            ctx = MagicMock()
+            ctx.strict_reject = False
+            ctx.identity_result = None
+            await mw.resolve_identity(
+                "identity",
+                {
+                    "agent_uuid": "eeeeeeee-1111-2222-3333-444444444444",
+                    "resume": True,
+                },
+                ctx,
+            )
+
+        hijack_events = [
+            e for e in captured
+            if e.get("event_type") == "identity_hijack_suspected"
+        ]
+        assert hijack_events, (
+            f"Middleware strict mode must emit identity_hijack_suspected. Got: {captured}"
+        )
+        evt = hijack_events[0]
+        assert evt.get("agent_id") == "eeeeeeee-1111-2222-3333-444444444444"
+        payload = evt.get("payload") or {}
+        assert payload.get("mode") == "strict"
+        assert payload.get("source") == "middleware"
+
+    @pytest.mark.asyncio
+    async def test_middleware_log_mode_emits_hijack_event(self, monkeypatch, caplog):
+        """Log mode also emits — operators need to see attempts even when allowed."""
+        import logging
+        monkeypatch.setenv("UNITARES_IDENTITY_STRICT", "log")
+        caplog.set_level(logging.WARNING)
+
+        from src.mcp_handlers.middleware import identity_step as mw
+
+        captured = []
+
+        async def _record(**kwargs):
+            captured.append(kwargs)
+
+        broadcaster_stub = MagicMock()
+        broadcaster_stub.broadcast_event = AsyncMock(side_effect=_record)
+
+        signals = MagicMock(
+            transport="http",
+            user_agent="claude-test",
+            ip_ua_fingerprint="ua:deadbe",
+            x_session_id=None,
+            x_agent_id=None,
+            mcp_session_id=None,
+            oauth_client_id=None,
+            x_client_id=None,
+            client_hint=None,
+        )
+        with patch(
+            "src.mcp_handlers.context.get_session_signals",
+            return_value=signals,
+        ), patch(
+            "src.mcp_handlers.identity.handlers._broadcaster",
+            return_value=broadcaster_stub,
+        ):
+            ctx = MagicMock()
+            ctx.strict_reject = False
+            await mw.resolve_identity(
+                "identity",
+                {
+                    "agent_uuid": "ffffffff-1111-2222-3333-444444444444",
+                    "resume": True,
+                },
+                ctx,
+            )
+
+        hijack_events = [
+            e for e in captured
+            if e.get("event_type") == "identity_hijack_suspected"
+        ]
+        assert hijack_events, (
+            "Log mode middleware must also emit; operators need visibility "
+            "into attempts that bypass the gate by mode-config alone"
+        )
+        assert (hijack_events[0].get("payload") or {}).get("source") == "middleware"
+
+    @pytest.mark.asyncio
     async def test_middleware_log_mode_passes_through(self, monkeypatch, caplog):
         import logging
         monkeypatch.setenv("UNITARES_IDENTITY_STRICT", "log")


### PR DESCRIPTION
## Summary

Council review of #78 (which added `identity_hijack_suspected` broadcast emission in `handlers.py` PATH 0) caught an asymmetry: the equivalent Part C gate in `src/mcp_handlers/middleware/identity_step.py` (lines 310-334) uses the same strict/log/off semantics but never emitted the broadcast event. Result: any MCP call routed through the middleware passthrough path triggered the gate but stayed invisible on dashboards — operators only saw handler-path attempts.

## Change

Patches the middleware block to mirror the emission. The helper is looked up via lazy import from `handlers._broadcaster` (no circular-import risk; consistent with the lazy broadcaster access already used in `persistence.py` and `handlers.py`). Payload carries `source='middleware'` so dashboards can distinguish handler-path vs middleware-path hijack attempts.

## Tests

- `test_middleware_strict_emits_hijack_event`
- `test_middleware_log_mode_emits_hijack_event`

Existing middleware gate tests unaffected. 17 Part C tests pass. 351 identity-suite tests pass.

**Note**: `test-cache.sh` full run was blocked on a stale lock from pid 51120 (20+ min runtime, another agent's session). Fell back to identity-suite sweep because the change is narrowly scoped to a single known code path.

## Related

- Council item #4 from KG `2026-04-20T00:57:45`
- Follow-up to #78 (handler-path emission)
- Companion plugin PR `unitares-governance-plugin#14` (SKILL.md + onboard_helper)

## Remaining council items (separate PRs)

- `list_agents` + `get_agent_metadata` unauth UUID dump (bigger risk — Discord bridge depends on it)
- PATH 1 `agent-{uuid12}` bypass (needs session-binding ownership scheme)
- `UNITARES_IDENTITY_STRICT` promotion from `log` to `strict` (blocked on above + plugin#14 merging)

## Test plan

- [ ] CI green (unblocked from stale lock)
- [ ] Verify post-merge: both handler-path and middleware-path hijack attempts surface on dashboard with distinct `source` labels