### PR TITLE
fix(http): allow /dashboard/fleet-metrics.js (was 404) + regression guard

### DIFF
--- a/src/http_api.py
+++ b/src/http_api.py
@@ -848,7 +848,7 @@ async def http_dashboard_static(request):
         "utils.js", "state.js", "colors.js", "components.js",
         "visualizations.js", "agents.js", "discoveries.js",
         "dialectic.js", "eisv-charts.js", "timeline.js",
-        "residents.js",
+        "residents.js", "fleet-metrics.js",
         "styles.css", "dashboard.js",
         "phase.js",
     ]

--- a/tests/test_dashboard_static_allowlist.py
+++ b/tests/test_dashboard_static_allowlist.py
@@ -1,0 +1,58 @@
+"""Pins the dashboard static-file allowlist against silent regression.
+
+Each JS module listed in dashboard/index.html's <script src> tags must be
+in the allowlist, else the browser gets a 404 and the feature silently
+breaks (seen with fleet-metrics.js on initial ship). This test reads the
+HTML, pulls every /dashboard/*.js reference, and asserts each one is
+allowed.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+
+def _load_allowlist() -> list[str]:
+    """Extract the `allowed_files` list from http_dashboard_static's source.
+
+    We parse the source instead of calling the function because extracting
+    the list is structurally simpler than constructing a Starlette request
+    and inspecting the mocked response — and parsing is exactly what
+    regressions would fool.
+    """
+    from src.http_api import http_dashboard_static
+
+    src = inspect.getsource(http_dashboard_static)
+    # Find the assignment block `allowed_files = [ ... ]`
+    match = re.search(r"allowed_files\s*=\s*\[(.*?)\]", src, re.DOTALL)
+    assert match, "http_dashboard_static no longer defines `allowed_files = [...]`"
+    body = match.group(1)
+    # Extract quoted strings inside the list
+    return re.findall(r'"([^"]+)"', body)
+
+
+def _scripts_referenced_by_index_html() -> list[str]:
+    """Return every basename referenced via /dashboard/... in index.html."""
+    html_path = Path(__file__).resolve().parent.parent / "dashboard" / "index.html"
+    text = html_path.read_text()
+    # Match href or src attributes pointing at /dashboard/<file>
+    hits = re.findall(r'(?:href|src)="/dashboard/([^"?]+)"', text)
+    return sorted(set(hits))
+
+
+class TestDashboardStaticAllowlist:
+    def test_fleet_metrics_is_allowed(self):
+        assert "fleet-metrics.js" in _load_allowlist()
+
+    def test_every_index_html_reference_is_allowed(self):
+        referenced = _scripts_referenced_by_index_html()
+        allowed = set(_load_allowlist())
+        missing = [f for f in referenced if f not in allowed]
+        assert missing == [], (
+            f"These files are referenced in dashboard/index.html but missing from "
+            f"http_dashboard_static's allowlist — browser will 404 them silently: {missing}"
+        )


### PR DESCRIPTION
## Summary
The dashboard static handler maintains an explicit allowlist (\`http_api.py:846-854\`). \`fleet-metrics.js\` shipped in #75 without an entry there, so the browser silently 404'd it and the Metrics panel never wired up. Chronicler's data was in the DB, the HTML was fine, but the chart JS never ran — so the panel looked unchanged.

## Evidence
\`\`\`
$ curl -s "http://127.0.0.1:8767/dashboard/fleet-metrics.js"
{"error":"File not allowed","requested":"fleet-metrics.js",
 "allowed":["utils.js", …, "residents.js", "styles.css", "dashboard.js", "phase.js"]}
\`\`\`

## Fix
- Add \`fleet-metrics.js\` to the allowlist.
- New test \`test_dashboard_static_allowlist.py\` — parses \`dashboard/index.html\`, finds every \`/dashboard/<file>\` referenced, asserts each is in the allowlist. Fails loudly for any future dashboard module that's wired into HTML but forgotten in Python.

## Test plan
- [x] New 2 tests pass
- [ ] After merge + pull — hit /dashboard (hard-refresh), panel should wire up and show the Chronicler data point at 06:52Z

## Root cause hit twice in a row
I missed this both in #75 review ("chart will render") and in the live verification (I checked HTML served but not the JS served). Both failures are on me — the new test hardens the class of bug.