### PR TITLE
feat(identity): PATH 1 fingerprint cross-check — Phase A (observation)

### DIFF
--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -905,3 +905,43 @@ def identity_strict_mode() -> str:
     """Runtime accessor — respects env changes set after module load (tests)."""
     m = os.getenv("UNITARES_IDENTITY_STRICT", IDENTITY_STRICT_MODE).strip().lower()
     return m if m in _VALID_STRICT_MODES else "log"
+
+
+# =============================================================================
+# PATH 1 FINGERPRINT CHECK (2026-04-20, council follow-up to identity-honesty)
+# =============================================================================
+#
+# `client_session_id` values of form `agent-{uuid[:12]}` are algorithmically
+# derivable from any UUID a caller can observe (logs, check-ins, KG metadata,
+# leaked anchor files). PATH 1 (Redis cache hit) resolves that shape to the
+# bound UUID with no ownership proof, so any caller who learns a UUID can
+# hijack the binding.
+#
+# This flag controls the fingerprint cross-check added at the PATH 1 cache
+# hit site. Binding-time fingerprint is written by `_cache_session`;
+# resume-time fingerprint is read from the request's SessionSignals.
+#
+# Modes:
+#   "off"    — skip the check entirely
+#   "log"    — emit [PATH1_FINGERPRINT_MISMATCH] + identity_hijack_suspected
+#              broadcast when the fingerprints differ; resume still proceeds
+#              (default — observation phase)
+#   "strict" — same events, but the mismatched resume falls through to
+#              PATH 3 (new session) instead of returning the cached UUID
+#
+# Override: UNITARES_SESSION_FINGERPRINT_CHECK env var.
+SESSION_FINGERPRINT_CHECK_MODE: str = os.getenv(
+    "UNITARES_SESSION_FINGERPRINT_CHECK", "log"
+).strip().lower()
+
+_VALID_FINGERPRINT_MODES = frozenset({"off", "log", "strict"})
+if SESSION_FINGERPRINT_CHECK_MODE not in _VALID_FINGERPRINT_MODES:
+    SESSION_FINGERPRINT_CHECK_MODE = "log"
+
+
+def session_fingerprint_check_mode() -> str:
+    """Runtime accessor — respects env changes set after module load (tests)."""
+    m = os.getenv(
+        "UNITARES_SESSION_FINGERPRINT_CHECK", SESSION_FINGERPRINT_CHECK_MODE
+    ).strip().lower()
+    return m if m in _VALID_FINGERPRINT_MODES else "log"

--- a/src/mcp_handlers/identity/persistence.py
+++ b/src/mcp_handlers/identity/persistence.py
@@ -88,6 +88,21 @@ async def _cache_session(
     except Exception as e:
         logger.debug(f"In-memory session cache update failed for {session_key[:20]}...: {e}")
 
+    # Capture binding-time fingerprint for PATH 1 cross-check.
+    # Council follow-up to identity-honesty (KG 2026-04-20T00:57:45): session
+    # IDs of shape `agent-{uuid[:12]}` are UUID-derivable, so PATH 1 resume
+    # by session_id alone has no ownership proof. Writing the bind fingerprint
+    # here lets the PATH 1 lookup site compare against the resume-time
+    # fingerprint and emit `identity_hijack_suspected` when they diverge.
+    bind_ip_ua = None
+    try:
+        from ..context import get_session_signals
+        _sig = get_session_signals()
+        if _sig is not None:
+            bind_ip_ua = getattr(_sig, "ip_ua_fingerprint", None)
+    except Exception:
+        bind_ip_ua = None
+
     session_cache = _get_redis()
     if session_cache:
         try:
@@ -105,6 +120,8 @@ async def _cache_session(
                     }
                     if label:
                         data["label"] = label
+                    if bind_ip_ua:
+                        data["bind_ip_ua"] = bind_ip_ua
                     key = f"session:{session_key}"
                     await redis.setex(key, GovernanceConfig.SESSION_TTL_SECONDS, json.dumps(data))
                     # Keep SessionCache's in-memory fallback coherent with the richer

--- a/src/mcp_handlers/identity/resolution.py
+++ b/src/mcp_handlers/identity/resolution.py
@@ -389,64 +389,127 @@ async def resolve_session_identity(
                     # See docs/specs/2026-04-16-sever-fingerprint-eisv-inheritance-design.md
                     if resume:
 
-                        # Check if persisted in PostgreSQL
+                        # PATH 1 fingerprint cross-check (2026-04-20 council follow-up
+                        # to identity-honesty Part C). Session IDs of form
+                        # `agent-{uuid[:12]}` are UUID-derivable; PATH 1 resume by
+                        # session_id alone has no ownership proof. Compare the
+                        # binding-time fingerprint (written by _cache_session) against
+                        # the current request's fingerprint. Mismatch fires
+                        # identity_hijack_suspected with path="path1_session_id" and,
+                        # in strict mode, falls through to a fresh session.
+                        cached_bind_fp = cached.get("bind_ip_ua")
+                        if cached_bind_fp:
+                            try:
+                                from ..context import get_session_signals
+                                _sig = get_session_signals()
+                                current_fp = getattr(_sig, "ip_ua_fingerprint", None) if _sig else None
+                            except Exception:
+                                current_fp = None
+                            if current_fp and current_fp != cached_bind_fp:
+                                from config.governance_config import session_fingerprint_check_mode
+                                _fp_mode = session_fingerprint_check_mode()
+                                if _fp_mode != "off":
+                                    logger.warning(
+                                        "[PATH1_FINGERPRINT_MISMATCH] session_key=%s... "
+                                        "bound_fp=%s current_fp=%s — suspected hijack of "
+                                        "agent=%s... (mode=%s)",
+                                        session_key[:20],
+                                        cached_bind_fp[:16],
+                                        current_fp[:16],
+                                        agent_uuid[:8],
+                                        _fp_mode,
+                                    )
+                                    try:
+                                        from .handlers import _broadcaster
+                                        _b = _broadcaster()
+                                        if _b is not None:
+                                            await _b.broadcast_event(
+                                                event_type="identity_hijack_suspected",
+                                                agent_id=agent_uuid,
+                                                payload={
+                                                    "path": "path1_session_id",
+                                                    "mode": _fp_mode,
+                                                    "source": "path1_fingerprint_mismatch",
+                                                    "bind_fp_prefix": cached_bind_fp[:8],
+                                                    "current_fp_prefix": current_fp[:8],
+                                                },
+                                            )
+                                    except Exception as _be:
+                                        logger.warning(
+                                            f"[PATH1_FINGERPRINT_MISMATCH] broadcast failed: {_be}"
+                                        )
+                                    if _fp_mode == "strict":
+                                        # Fall through to PATH 3 (fresh session).
+                                        # Do NOT delete the cache entry — the
+                                        # legitimate owner can still resume from
+                                        # the correct fingerprint.
+                                        resume = False
 
-                        persisted = await _agent_exists_in_postgres(agent_uuid)
+                        # If strict-mode fingerprint mismatch set resume=False
+                        # above, skip the cached-resume return and fall through
+                        # to PATH 2/3 so a fresh binding is established under
+                        # the current fingerprint.
+                        if not resume:
+                            pass  # drops out of the `if cached ...:` block; PATH 2 continues below
+                        else:
+                            # Check if persisted in PostgreSQL
 
-                        # Fetch label (DB first, then Redis cache fallback)
+                            persisted = await _agent_exists_in_postgres(agent_uuid)
 
-                        label = await _get_agent_label(agent_uuid) if persisted else None
-                        if not label:
-                            label = cached.get("label")
+                            # Fetch label (DB first, then Redis cache fallback)
 
-                        # Check archived status (prevents silent binding to archived agents)
-                        agent_status = await _get_agent_status(agent_uuid) if persisted else None
-                        is_archived = agent_status == "archived"
+                            label = await _get_agent_label(agent_uuid) if persisted else None
+                            if not label:
+                                label = cached.get("label")
 
-                        # Soft trajectory verification (v2.8)
-                        traj_result = await _soft_verify_trajectory(agent_uuid, trajectory_signature, "redis")
+                            # Check archived status (prevents silent binding to archived agents)
+                            agent_status = await _get_agent_status(agent_uuid) if persisted else None
+                            is_archived = agent_status == "archived"
 
-                        # SLIDING TTL: Refresh Redis expiry on every hit (v2.5.5)
+                            # Soft trajectory verification (v2.8)
+                            traj_result = await _soft_verify_trajectory(agent_uuid, trajectory_signature, "redis")
 
-                        try:
+                            # SLIDING TTL: Refresh Redis expiry on every hit (v2.5.5)
 
-                            from src.cache.redis_client import get_redis
+                            try:
 
-                            raw_redis = await get_redis()
+                                from src.cache.redis_client import get_redis
 
-                            if raw_redis:
-                                await raw_redis.expire(f"session:{session_key}", GovernanceConfig.SESSION_TTL_SECONDS)
+                                raw_redis = await get_redis()
 
-                        except Exception:
+                                if raw_redis:
+                                    await raw_redis.expire(f"session:{session_key}", GovernanceConfig.SESSION_TTL_SECONDS)
 
-                            pass
+                            except Exception:
+
+                                pass
 
 
 
-                        return {
+                            return {
 
-                            "agent_id": agent_id,   # Human-readable (model+date). UUID for lookup is agent_uuid.
-                            "public_agent_id": agent_id,
+                                "agent_id": agent_id,   # Human-readable (model+date). UUID for lookup is agent_uuid.
+                                "public_agent_id": agent_id,
 
-                            "agent_uuid": agent_uuid,
+                                "agent_uuid": agent_uuid,
 
-                            "display_name": label,
+                                "display_name": label,
 
-                            "label": label,  # backward compat
+                                "label": label,  # backward compat
 
-                            "created": False,
+                                "created": False,
 
-                            "persisted": persisted,
+                                "persisted": persisted,
 
-                            "archived": is_archived,
+                                "archived": is_archived,
 
-                            "source": "redis",
+                                "source": "redis",
 
-                            "trajectory_verified": traj_result.get("verified"),
+                                "trajectory_verified": traj_result.get("verified"),
 
-                            "trajectory_warning": traj_result.get("warning"),
+                                "trajectory_warning": traj_result.get("warning"),
 
-                        }
+                            }
 
             except Exception as e:
                 # INFO level (v2.5.7): Redis lookup failures are recoverable but should be visible

--- a/tests/test_identity_path1_fingerprint.py
+++ b/tests/test_identity_path1_fingerprint.py
@@ -1,0 +1,326 @@
+"""PATH 1 fingerprint cross-check — Phase A (observation).
+
+Council follow-up to identity-honesty Part C (KG 2026-04-20T00:57:45).
+`client_session_id` values of shape `agent-{uuid[:12]}` are UUID-derivable,
+so PATH 1 resume by session_id alone has no ownership proof. This module
+locks in the observation-phase behavior of the fingerprint cross-check
+added at the PATH 1 cache-hit site:
+
+  - `_cache_session` writes `bind_ip_ua` alongside the existing fields
+    when SessionSignals carry a fingerprint.
+  - `resolve_session_identity` PATH 1 reads `bind_ip_ua`; on mismatch with
+    the current request's fingerprint, fires `identity_hijack_suspected`
+    with `path="path1_session_id"`.
+  - In `log` mode (default) the resume still proceeds after emission.
+  - In `strict` mode, mismatched resumes fall through to a fresh session.
+  - In `off` mode, no check runs — no event, no fall-through.
+  - Legacy cache entries without `bind_ip_ua` are treated as unknown
+    (no event — preserves backward compat).
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_fingerprint_mode(monkeypatch):
+    monkeypatch.delenv("UNITARES_SESSION_FINGERPRINT_CHECK", raising=False)
+    yield
+
+
+def _signals_with_fp(fp: str):
+    sig = MagicMock()
+    sig.ip_ua_fingerprint = fp
+    return sig
+
+
+class TestPath1FingerprintMismatchEmits:
+    """PATH 1 cache-hit with divergent fingerprint emits identity_hijack_suspected."""
+
+    @pytest.fixture
+    def captured_events(self):
+        return []
+
+    @pytest.fixture
+    def broadcaster_stub(self, captured_events):
+        b = MagicMock()
+
+        async def _record(**kwargs):
+            captured_events.append(kwargs)
+
+        b.broadcast_event = AsyncMock(side_effect=_record)
+        return b
+
+    @pytest.mark.asyncio
+    async def test_log_mode_emits_and_proceeds(
+        self, monkeypatch, captured_events, broadcaster_stub
+    ):
+        monkeypatch.setenv("UNITARES_SESSION_FINGERPRINT_CHECK", "log")
+
+        from src.mcp_handlers.identity import resolution as res
+
+        agent_uuid = "11111111-2222-3333-4444-555555555555"
+        cached_payload = {
+            "agent_id": agent_uuid,
+            "display_agent_id": "Claude_Code_20260420",
+            "bind_ip_ua": "ip-1.2.3.4:ua-aaaaaaaaaaaa",
+        }
+
+        fake_redis = MagicMock()
+        fake_redis.get = AsyncMock(return_value=cached_payload)
+
+        with patch.object(res, "_get_redis", return_value=fake_redis), patch(
+            "src.mcp_handlers.identity.resolution._agent_exists_in_postgres",
+            new=AsyncMock(return_value=True),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._get_agent_label",
+            new=AsyncMock(return_value="Claude_Code_20260420"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._get_agent_status",
+            new=AsyncMock(return_value="active"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._soft_verify_trajectory",
+            new=AsyncMock(return_value={"verified": True}),
+        ), patch(
+            "src.mcp_handlers.context.get_session_signals",
+            return_value=_signals_with_fp("ip-9.9.9.9:ua-bbbbbbbbbbbb"),
+        ), patch(
+            "src.mcp_handlers.identity.handlers._broadcaster",
+            return_value=broadcaster_stub,
+        ):
+            result = await res.resolve_session_identity(
+                session_key="agent-111111111222",
+                resume=True,
+            )
+
+        # Log mode: resume still succeeds.
+        assert result.get("source") == "redis", (
+            f"Log mode must preserve the cached-resume outcome. Got: {result}"
+        )
+        assert result.get("agent_uuid") == agent_uuid
+
+        # And event fires.
+        hijack_events = [
+            e for e in captured_events
+            if e.get("event_type") == "identity_hijack_suspected"
+        ]
+        assert hijack_events, (
+            f"Mismatch must emit identity_hijack_suspected. Captured: {captured_events}"
+        )
+        evt = hijack_events[0]
+        assert evt.get("agent_id") == agent_uuid
+        payload = evt.get("payload") or {}
+        assert payload.get("path") == "path1_session_id"
+        assert payload.get("mode") == "log"
+
+    @pytest.mark.asyncio
+    async def test_strict_mode_falls_through(
+        self, monkeypatch, captured_events, broadcaster_stub
+    ):
+        monkeypatch.setenv("UNITARES_SESSION_FINGERPRINT_CHECK", "strict")
+
+        from src.mcp_handlers.identity import resolution as res
+
+        agent_uuid = "22222222-3333-4444-5555-666666666666"
+        cached_payload = {
+            "agent_id": agent_uuid,
+            "display_agent_id": "Claude_Code_strict",
+            "bind_ip_ua": "ip-original:ua-original",
+        }
+
+        fake_redis = MagicMock()
+        fake_redis.get = AsyncMock(return_value=cached_payload)
+
+        with patch.object(res, "_get_redis", return_value=fake_redis), patch(
+            "src.mcp_handlers.context.get_session_signals",
+            return_value=_signals_with_fp("ip-attacker:ua-attacker"),
+        ), patch(
+            "src.mcp_handlers.identity.handlers._broadcaster",
+            return_value=broadcaster_stub,
+        ), patch.object(res, "_agent_exists_in_postgres", new=AsyncMock(return_value=False)), patch(
+            "src.mcp_handlers.identity.resolution.get_db",
+            side_effect=RuntimeError("PATH 2 shouldn't be reached successfully"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._generate_agent_id",
+            return_value="Claude_fresh",
+        ):
+            result = await res.resolve_session_identity(
+                session_key="agent-222222222333",
+                resume=True,
+                persist=False,
+            )
+
+        # Strict mode: resume must NOT return the cached UUID.
+        assert result.get("agent_uuid") != agent_uuid, (
+            f"Strict mode must refuse to reuse the cached UUID on fingerprint "
+            f"mismatch. Got agent_uuid={result.get('agent_uuid')}, source={result.get('source')}"
+        )
+
+        # Event still fires.
+        hijack_events = [
+            e for e in captured_events
+            if e.get("event_type") == "identity_hijack_suspected"
+        ]
+        assert hijack_events
+        assert (hijack_events[0].get("payload") or {}).get("mode") == "strict"
+
+    @pytest.mark.asyncio
+    async def test_matching_fingerprint_no_event(
+        self, monkeypatch, captured_events, broadcaster_stub
+    ):
+        monkeypatch.setenv("UNITARES_SESSION_FINGERPRINT_CHECK", "log")
+
+        from src.mcp_handlers.identity import resolution as res
+
+        agent_uuid = "33333333-4444-5555-6666-777777777777"
+        fp = "ip-same:ua-same"
+        cached_payload = {
+            "agent_id": agent_uuid,
+            "display_agent_id": "Claude_Code_match",
+            "bind_ip_ua": fp,
+        }
+
+        fake_redis = MagicMock()
+        fake_redis.get = AsyncMock(return_value=cached_payload)
+
+        with patch.object(res, "_get_redis", return_value=fake_redis), patch(
+            "src.mcp_handlers.identity.resolution._agent_exists_in_postgres",
+            new=AsyncMock(return_value=True),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._get_agent_label",
+            new=AsyncMock(return_value="Claude_Code_match"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._get_agent_status",
+            new=AsyncMock(return_value="active"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._soft_verify_trajectory",
+            new=AsyncMock(return_value={"verified": True}),
+        ), patch(
+            "src.mcp_handlers.context.get_session_signals",
+            return_value=_signals_with_fp(fp),
+        ), patch(
+            "src.mcp_handlers.identity.handlers._broadcaster",
+            return_value=broadcaster_stub,
+        ):
+            result = await res.resolve_session_identity(
+                session_key="agent-333333333444",
+                resume=True,
+            )
+
+        assert result.get("agent_uuid") == agent_uuid
+        hijack_events = [
+            e for e in captured_events
+            if e.get("event_type") == "identity_hijack_suspected"
+        ]
+        assert hijack_events == [], (
+            "Matching fingerprint is the expected resume shape — no event"
+        )
+
+    @pytest.mark.asyncio
+    async def test_legacy_cache_without_bind_fp_no_event(
+        self, monkeypatch, captured_events, broadcaster_stub
+    ):
+        """Cache entries written before this feature lack `bind_ip_ua`. They
+        must be treated as unknown — not suspicious. Otherwise strict-mode
+        promotion would retroactively invalidate every pre-existing session."""
+        monkeypatch.setenv("UNITARES_SESSION_FINGERPRINT_CHECK", "log")
+
+        from src.mcp_handlers.identity import resolution as res
+
+        agent_uuid = "44444444-5555-6666-7777-888888888888"
+        cached_payload = {
+            "agent_id": agent_uuid,
+            "display_agent_id": "Claude_legacy",
+            # no bind_ip_ua field
+        }
+
+        fake_redis = MagicMock()
+        fake_redis.get = AsyncMock(return_value=cached_payload)
+
+        with patch.object(res, "_get_redis", return_value=fake_redis), patch(
+            "src.mcp_handlers.identity.resolution._agent_exists_in_postgres",
+            new=AsyncMock(return_value=True),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._get_agent_label",
+            new=AsyncMock(return_value="Claude_legacy"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._get_agent_status",
+            new=AsyncMock(return_value="active"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._soft_verify_trajectory",
+            new=AsyncMock(return_value={"verified": True}),
+        ), patch(
+            "src.mcp_handlers.context.get_session_signals",
+            return_value=_signals_with_fp("ip-any:ua-any"),
+        ), patch(
+            "src.mcp_handlers.identity.handlers._broadcaster",
+            return_value=broadcaster_stub,
+        ):
+            result = await res.resolve_session_identity(
+                session_key="agent-444444444555",
+                resume=True,
+            )
+
+        assert result.get("agent_uuid") == agent_uuid
+        hijack_events = [
+            e for e in captured_events
+            if e.get("event_type") == "identity_hijack_suspected"
+        ]
+        assert hijack_events == [], (
+            "Legacy entry without bind_ip_ua must pass silently"
+        )
+
+    @pytest.mark.asyncio
+    async def test_off_mode_skips_check(
+        self, monkeypatch, captured_events, broadcaster_stub
+    ):
+        monkeypatch.setenv("UNITARES_SESSION_FINGERPRINT_CHECK", "off")
+
+        from src.mcp_handlers.identity import resolution as res
+
+        agent_uuid = "55555555-6666-7777-8888-999999999999"
+        cached_payload = {
+            "agent_id": agent_uuid,
+            "display_agent_id": "Claude_off",
+            "bind_ip_ua": "ip-original:ua-original",
+        }
+
+        fake_redis = MagicMock()
+        fake_redis.get = AsyncMock(return_value=cached_payload)
+
+        with patch.object(res, "_get_redis", return_value=fake_redis), patch(
+            "src.mcp_handlers.identity.resolution._agent_exists_in_postgres",
+            new=AsyncMock(return_value=True),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._get_agent_label",
+            new=AsyncMock(return_value="Claude_off"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._get_agent_status",
+            new=AsyncMock(return_value="active"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._soft_verify_trajectory",
+            new=AsyncMock(return_value={"verified": True}),
+        ), patch(
+            "src.mcp_handlers.context.get_session_signals",
+            return_value=_signals_with_fp("ip-different:ua-different"),
+        ), patch(
+            "src.mcp_handlers.identity.handlers._broadcaster",
+            return_value=broadcaster_stub,
+        ):
+            result = await res.resolve_session_identity(
+                session_key="agent-555555555666",
+                resume=True,
+            )
+
+        # Off mode: resume succeeds AND no event fires.
+        assert result.get("agent_uuid") == agent_uuid
+        hijack_events = [
+            e for e in captured_events
+            if e.get("event_type") == "identity_hijack_suspected"
+        ]
+        assert hijack_events == [], (
+            "Off mode is explicit opt-out — no event even on mismatch"
+        )


### PR DESCRIPTION
## Summary

Closes council item #5 (KG `2026-04-20T00:57:45`): `client_session_id` of shape `agent-{uuid[:12]}` is UUID-derivable from any UUID a caller can observe (logs, check-in responses, KG metadata, leaked anchor files). PATH 1 resumes that shape to the bound UUID with no ownership proof — the same attack class the hook fix (plugin#13) and Part C gate (#78/#81) closed for PATH 0, but on the session-key axis.

Phase A is **observation-only**. Same `log → strict` playbook as Part C (`UNITARES_IDENTITY_STRICT`); same broadcast event type (`identity_hijack_suspected`) with `path='path1_session_id'` discriminator so dashboards can distinguish PATH 0 and PATH 1 events.

## Mechanism

1. `_cache_session` reads `ip_ua_fingerprint` from the request's `SessionSignals` and writes it as `bind_ip_ua` in the Redis JSON blob (additive field; legacy entries without it are treated as unknown, not suspect).
2. `resolve_session_identity` PATH 1 cache-hit compares cached `bind_ip_ua` against the current request's fingerprint. Divergent fingerprints fire `identity_hijack_suspected` and, in strict mode, fall through to PATH 3 (fresh session). The cache entry is NOT deleted — the legitimate owner can still resume from the correct fingerprint.
3. New env flag `UNITARES_SESSION_FINGERPRINT_CHECK` (default `log`). Same `off/log/strict` shape as `UNITARES_IDENTITY_STRICT`.

## Tests

5 in `tests/test_identity_path1_fingerprint.py`:
- log-mode mismatch emits event and still resumes (observation)
- strict-mode mismatch falls through to fresh session
- matching fingerprint: silent
- legacy cache (no `bind_ip_ua`): silent, backward compat preserved
- off-mode: no event even on mismatch

359 identity-suite tests pass (including all 5 new ones).

## Scope caveats

- Only the primary PATH 1 Redis cache-hit path is instrumented. The `session_cache.bind()` fallback (persistence.py:137) does not carry the richer metadata shape; leaving it as-is for Phase A.
- `shared.py` sync in-memory lookup (139-166) not yet instrumented; Phase B when strict promotion is scheduled.
- Architect noted fingerprint check doesn't close same-host attacker path (attacker and victim share IP+UA). Accepted: same-host attacker has filesystem access and has already won. This PR closes the cross-host vector and makes the local-host vector visible.

## Promotion to strict

Blocked on:
- `UNITARES_IDENTITY_STRICT=strict` lands first (Part C promotion)
- Plugin#14 reaches production SDK
- 1-2 week observation period shows zero legitimate false-positives on mobile/NAT clients

## Test plan

- [ ] CI green (full `test-cache.sh` unblocked from stale lock)
- [ ] Verify post-merge: dashboard/Discord surface `identity_hijack_suspected` with `path='path1_session_id'` when fingerprints diverge
- [ ] Monitor production logs for `[PATH1_FINGERPRINT_MISMATCH]` in the first week — any legitimate mobile/NAT client surfacing here changes the strict-promotion timeline