### PR TITLE
fix(identity): PATH 1 fingerprint cross-check (Phase A) + anyio-asyncio guard

### DIFF
--- a/src/mcp_handlers/identity/persistence.py
+++ b/src/mcp_handlers/identity/persistence.py
@@ -7,6 +7,7 @@ and DB helper functions for identity resolution.
 
 from __future__ import annotations
 
+import asyncio
 from typing import Optional, Dict, Any
 from datetime import datetime, timedelta, timezone
 import json
@@ -23,6 +24,14 @@ from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 # =============================================================================
 
 _redis_cache = None
+
+# Tight timeout for Redis writes from inside MCP handler paths. The MCP SDK's
+# anyio task group can deadlock against asyncpg/Redis async calls (see
+# CLAUDE.md "Known Issue: anyio-asyncio Conflict"); on deadlock we bail out
+# and leave the in-memory session cache as the source of truth rather than
+# hanging the request. Matches `_REDIS_RECOVERY_TIMEOUT` in
+# src/mcp_handlers/middleware/identity_step.py.
+_REDIS_WRITE_TIMEOUT = 0.5
 
 
 def _metadata_public_agent_id(metadata: Optional[Dict[str, Any]]) -> Optional[str]:
@@ -106,55 +115,93 @@ async def _cache_session(
     session_cache = _get_redis()
     if session_cache:
         try:
-            # Store both UUID and display agent_id if provided
-            if display_agent_id and display_agent_id != agent_uuid:
-                # Get raw Redis client for custom write
-                from src.cache.redis_client import get_redis
-                redis = await get_redis()
-                if redis:
-                    data = {
-                        "agent_id": agent_uuid,
-                        "display_agent_id": display_agent_id,
-                        "bound_at": datetime.now(timezone.utc).isoformat(),
-                        "trajectory_required": trajectory_required,
-                    }
-                    if label:
-                        data["label"] = label
-                    if bind_ip_ua:
-                        data["bind_ip_ua"] = bind_ip_ua
-                    key = f"session:{session_key}"
-                    await redis.setex(key, GovernanceConfig.SESSION_TTL_SECONDS, json.dumps(data))
-                    # Keep SessionCache's in-memory fallback coherent with the richer
-                    # raw Redis payload so subsequent lookups see the same binding
-                    # even if they fall back from Redis during this process lifetime.
-                    try:
-                        from src.cache import session_cache as _session_cache_mod
-                        _session_cache_mod._fallback_cache[session_key] = data
-                    except Exception:
-                        pass
-                else:
-                    # Raw Redis unavailable but degraded-local cache is still usable.
-                    await session_cache.bind(session_key, agent_uuid)
-                    try:
-                        from src.cache import session_cache as _session_cache_mod
-                        existing = _session_cache_mod._fallback_cache.get(session_key, {})
-                        data = {
-                            "agent_id": agent_uuid,
-                            "display_agent_id": display_agent_id,
-                            "public_agent_id": display_agent_id,
-                            "bound_at": existing.get("bound_at") or datetime.now(timezone.utc).isoformat(),
-                            "bind_count": existing.get("bind_count", 0),
-                        }
-                        if label:
-                            data["label"] = label
-                        _session_cache_mod._fallback_cache[session_key] = data
-                    except Exception:
-                        pass
-            else:
-                await session_cache.bind(session_key, agent_uuid)
+            await asyncio.wait_for(
+                _cache_session_redis_write(
+                    session_cache,
+                    session_key,
+                    agent_uuid,
+                    display_agent_id,
+                    trajectory_required,
+                    label,
+                    bind_ip_ua,
+                ),
+                timeout=_REDIS_WRITE_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            # Likely the anyio-asyncio deadlock described in CLAUDE.md.
+            # Bail out — the in-memory _session_identities write above is
+            # still honored for this session; later reads miss Redis and
+            # fall through to PostgreSQL resolution.
+            logger.warning(
+                f"[IDENTITY] Redis cache write timed out after "
+                f"{_REDIS_WRITE_TIMEOUT}s for {session_key[:20]}... "
+                f"— in-memory only (anyio-asyncio guard)"
+            )
         except Exception as e:
             # WARNING level (v2.5.7): Cache failures can cause identity loss
             logger.warning(f"Redis cache write failed for session {session_key[:20]}...: {e}")
+
+
+async def _cache_session_redis_write(
+    session_cache,
+    session_key: str,
+    agent_uuid: str,
+    display_agent_id: Optional[str],
+    trajectory_required: bool,
+    label: Optional[str],
+    bind_ip_ua: Optional[str],
+) -> None:
+    """Inner: Redis writes for _cache_session, wrapped by asyncio.wait_for.
+
+    Separated so the caller can bound execution time with a tight timeout
+    to avoid hanging MCP handlers when the anyio-asyncio deadlock triggers.
+    """
+    # Store both UUID and display agent_id if provided
+    if display_agent_id and display_agent_id != agent_uuid:
+        # Get raw Redis client for custom write
+        from src.cache.redis_client import get_redis
+        redis = await get_redis()
+        if redis:
+            data = {
+                "agent_id": agent_uuid,
+                "display_agent_id": display_agent_id,
+                "bound_at": datetime.now(timezone.utc).isoformat(),
+                "trajectory_required": trajectory_required,
+            }
+            if label:
+                data["label"] = label
+            if bind_ip_ua:
+                data["bind_ip_ua"] = bind_ip_ua
+            key = f"session:{session_key}"
+            await redis.setex(key, GovernanceConfig.SESSION_TTL_SECONDS, json.dumps(data))
+            # Keep SessionCache's in-memory fallback coherent with the richer
+            # raw Redis payload so subsequent lookups see the same binding
+            # even if they fall back from Redis during this process lifetime.
+            try:
+                from src.cache import session_cache as _session_cache_mod
+                _session_cache_mod._fallback_cache[session_key] = data
+            except Exception:
+                pass
+        else:
+            # Raw Redis unavailable but degraded-local cache is still usable.
+            await session_cache.bind(session_key, agent_uuid)
+            try:
+                from src.cache import session_cache as _session_cache_mod
+                existing = _session_cache_mod._fallback_cache.get(session_key, {})
+                data = {
+                    "agent_id": agent_uuid,
+                    "display_agent_id": display_agent_id,
+                    "public_agent_id": display_agent_id,
+                    "bound_at": existing.get("bound_at") or datetime.now(timezone.utc).isoformat(),
+                    "bind_count": existing.get("bind_count", 0),
+                }
+                if label:
+                    data["label"] = label
+                _session_cache_mod._fallback_cache[session_key] = data
+            except Exception:
+                pass
+    else:
+        await session_cache.bind(session_key, agent_uuid)
 
 # =============================================================================
 # DB HELPERS

--- a/tests/test_identity_session.py
+++ b/tests/test_identity_session.py
@@ -975,6 +975,82 @@ class TestCacheSession:
             # Should not raise
             await _cache_session("sess-4", "uuid-noop")
 
+    @pytest.mark.asyncio
+    async def test_cache_session_bind_deadlock_times_out(self):
+        """If SessionCache.bind hangs (anyio-asyncio deadlock), _cache_session
+        bails out within _REDIS_WRITE_TIMEOUT instead of blocking the handler.
+
+        Watcher P004 fingerprint ee881e2a — regression guard.
+        """
+        import asyncio
+        import time
+        from src.mcp_handlers.identity.handlers import _cache_session
+        from src.mcp_handlers.identity import persistence
+
+        # Force a short timeout so the test doesn't wait half a second.
+        original_timeout = persistence._REDIS_WRITE_TIMEOUT
+
+        mock_cache = AsyncMock()
+
+        async def _never_returns(*_a, **_kw):
+            await asyncio.sleep(10)
+
+        mock_cache.bind = AsyncMock(side_effect=_never_returns)
+
+        try:
+            persistence._REDIS_WRITE_TIMEOUT = 0.05
+            with patch("src.mcp_handlers.identity.persistence._redis_cache", None), \
+                 patch("src.cache.get_session_cache", return_value=mock_cache):
+                start = time.monotonic()
+                # Must not raise, must return promptly.
+                await _cache_session("sess-deadlock", "uuid-deadlock")
+                elapsed = time.monotonic() - start
+            assert elapsed < 0.5, (
+                f"_cache_session should honor _REDIS_WRITE_TIMEOUT; "
+                f"took {elapsed:.3f}s"
+            )
+        finally:
+            persistence._REDIS_WRITE_TIMEOUT = original_timeout
+
+    @pytest.mark.asyncio
+    async def test_cache_session_raw_setex_deadlock_times_out(self, mock_raw_redis):
+        """Same guard on the raw-Redis branch (display_agent_id != uuid)."""
+        import asyncio
+        import time
+        from src.mcp_handlers.identity.handlers import _cache_session
+        from src.mcp_handlers.identity import persistence
+
+        original_timeout = persistence._REDIS_WRITE_TIMEOUT
+
+        async def _never_returns(*_a, **_kw):
+            await asyncio.sleep(10)
+
+        mock_raw_redis.setex = AsyncMock(side_effect=_never_returns)
+
+        async def _get_raw():
+            return mock_raw_redis
+
+        mock_cache = AsyncMock()
+
+        try:
+            persistence._REDIS_WRITE_TIMEOUT = 0.05
+            with patch("src.mcp_handlers.identity.persistence._redis_cache", None), \
+                 patch("src.cache.get_session_cache", return_value=mock_cache), \
+                 patch("src.cache.redis_client.get_redis", new=_get_raw):
+                start = time.monotonic()
+                await _cache_session(
+                    "sess-setex-deadlock",
+                    "uuid-setex",
+                    display_agent_id="Claude_Code_20260420",
+                )
+                elapsed = time.monotonic() - start
+            assert elapsed < 0.5, (
+                f"Raw-Redis setex path should honor _REDIS_WRITE_TIMEOUT; "
+                f"took {elapsed:.3f}s"
+            )
+        finally:
+            persistence._REDIS_WRITE_TIMEOUT = original_timeout
+
 
 # ============================================================================
 # Integration-style tests (multiple paths)

--- a/tests/test_model_inference.py
+++ b/tests/test_model_inference.py
@@ -763,25 +763,10 @@ class TestResponseContent:
         assert "task_type" in parsed
         assert "message" in parsed
 
-    @pytest.mark.asyncio
-    async def test_energy_cost_free_tier_flash(self):
-        """Free tier models (flash) get low energy cost."""
-        mock_client_instance = MagicMock()
-        mock_client_instance.chat.completions.create.return_value = _make_mock_response(
-            model="gemini-flash"
-        )
-
-        with patch("src.mcp_handlers.support.model_inference.OPENAI_AVAILABLE", True), \
-             patch("src.mcp_handlers.support.model_inference.OpenAI", return_value=mock_client_instance):
-            from src.mcp_handlers.support.model_inference import handle_call_model
-            result = await handle_call_model({
-                "prompt": "test",
-                "provider": "ollama",
-                "model": "gemini-flash",
-            })
-
-        parsed = _parse_text_content(result)
-        assert parsed["energy_cost"] == 0.01
+    # `test_energy_cost_free_tier_flash` removed: gemini-flash is no longer a
+    # supported model after #80 dropped the Gemini provider; the free-tier
+    # classifier now only matches llama/qwen/gemma. The llama variant below
+    # exercises the same free-tier branch.
 
     @pytest.mark.asyncio
     async def test_energy_cost_free_tier_llama(self):
@@ -803,25 +788,10 @@ class TestResponseContent:
         parsed = _parse_text_content(result)
         assert parsed["energy_cost"] == 0.01
 
-    @pytest.mark.asyncio
-    async def test_energy_cost_pro_tier(self):
-        """Pro tier models get medium energy cost."""
-        mock_client_instance = MagicMock()
-        mock_client_instance.chat.completions.create.return_value = _make_mock_response(
-            model="gemini-pro"
-        )
-
-        with patch("src.mcp_handlers.support.model_inference.OPENAI_AVAILABLE", True), \
-             patch("src.mcp_handlers.support.model_inference.OpenAI", return_value=mock_client_instance):
-            from src.mcp_handlers.support.model_inference import handle_call_model
-            result = await handle_call_model({
-                "prompt": "test",
-                "provider": "ollama",
-                "model": "gemini-pro",
-            })
-
-        parsed = _parse_text_content(result)
-        assert parsed["energy_cost"] == 0.02
+    # `test_energy_cost_pro_tier` removed: the 0.02 "pro tier" branch no
+    # longer exists. After #80 dropped Gemini, the energy cost has two tiers:
+    # free (0.01) for llama/qwen/gemma, default (0.03) otherwise. The default
+    # tier is covered by `test_energy_cost_default_tier` below.
 
     @pytest.mark.asyncio
     async def test_energy_cost_default_tier(self):
@@ -1132,7 +1102,12 @@ class TestRoutingViaDetection:
 
     @pytest.mark.asyncio
     async def test_routed_via_direct_for_custom_endpoint(self):
-        """Detects direct routing for non-standard endpoints."""
+        """Detects direct routing for non-standard endpoints.
+
+        Post-#80 custom endpoints require an explicit `model` (the Gemini
+        fallback was removed), so the test passes one that the caller's
+        endpoint would serve.
+        """
         mock_client_instance = MagicMock()
         mock_client_instance.chat.completions.create.return_value = _make_mock_response()
 
@@ -1145,6 +1120,7 @@ class TestRoutingViaDetection:
                 "prompt": "test",
                 "provider": "openai",
                 "privacy": "cloud",
+                "model": "gpt-4o-mini",
             })
 
         parsed = _parse_text_content(result)


### PR DESCRIPTION
## Summary

- **Phase A of PATH 1 fingerprint cross-check (`d8de8f85`)** — Council follow-up to identity-honesty Part C. `client_session_id` values of shape `agent-{uuid[:12]}` are UUID-derivable, so PATH 1 resume by session_id alone has no ownership proof. `_cache_session` now stamps `bind_ip_ua` into the Redis payload at bind time, and `resolve_session_identity` compares it against the resume-time fingerprint. On mismatch, fires `identity_hijack_suspected` with `path="path1_session_id"`. Mode-gated (`UNITARES_SESSION_FINGERPRINT_CHECK=log|strict|off`, default `log`). Legacy cache entries without `bind_ip_ua` are treated as unknown, not suspicious, so existing sessions aren't retroactively invalidated.
- **Anyio-asyncio deadlock guard for `_cache_session` (`532bfc11`)** — resolves Watcher P004 fingerprint `ee881e2a`. The Redis writes in `_cache_session` (both raw `redis.setex` and `SessionCache.bind`) were structurally unguarded against the MCP SDK's anyio task-group deadlock, mirroring the exact shape fixed in `_load_binding_from_redis`. Wrapped the Redis write section in `asyncio.wait_for(timeout=0.5)`; on timeout we log a warning and bail. The in-memory `_session_identities` write at the top of the function is unaffected.

## Test plan

- [x] `tests/test_identity_path1_fingerprint.py` — 5 new tests: log-mode emits-and-proceeds, strict-mode falls-through, matching fingerprint no-event, legacy (no `bind_ip_ua`) no-event, off-mode skips check
- [x] `tests/test_identity_session.py::TestCacheSession` — 2 new regression guards: hang the `bind` path and the raw `setex` path, assert `_cache_session` returns inside the timeout budget
- [x] Full suite cached green: **6664 passed, 33 skipped** at tree `0daf3e0d`
- [ ] Watch for `identity_hijack_suspected` events on main — Phase A is observation only; escalation to strict mode is a separate PR once the log-mode signal is understood