### PR TITLE
fix(anomaly): fan out anomaly_detected audit entries per-agent

Prior shape wrote one batch audit entry per detect_anomalies call with
agent_id='system' and a details.anomalies list truncated to 10 entries.
This was unjoinable against audit.events.agent_id for PPV pipelines
(v6 §11.6 correlation, Schmidt proposal figure) and silently dropped
anomalies 11+ when a batch was larger than 10.

Production evidence (pre-fix): 244 anomaly_detected events, all with
agent_id='system', zero overlap with lifecycle_paused agents.

- handlers.py: one AuditEntry per detected anomaly. agent_id = the
  affected agent. details holds the scalar {type, severity, description}.
- dashboard.js: accepts both shapes (legacy batch + new per-agent) so
  prior 244 entries still render.
- test_observability_handlers.py: regression test asserts fan-out (N
  entries for N anomalies, each with correct agent_id, no 'system'
  rows, no truncation past 10).

### DIFF
--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -2240,16 +2240,34 @@ if (anomaliesCard) {
                     const relative = !isNaN(tsMs) && formatRelativeTime ? formatRelativeTime(tsMs) : null;
                     const absolute = formatTimestamp(inc.timestamp);
                     const when = relative ? relative + ' — ' + absolute : (absolute || inc.timestamp);
-                    const anomalyDetails = (d.anomalies || []).map(function (a) {
-                        const agentName = a.agent_name || (a.agent_id ? a.agent_id.substring(0, 8) + '...' : '');
-                        const desc = a.description || '';
-                        return escapeHtml(a.type || '?') + ' (' + escapeHtml(a.severity || '') + ')' +
+                    // Two shapes coexist: legacy batch entries (agent_id='system',
+                    // details.anomalies is an array) and per-agent entries
+                    // (inc.agent_id is the affected agent, details has scalar
+                    // type/severity/description).
+                    let count;
+                    let anomalyDetails;
+                    if (Array.isArray(d.anomalies)) {
+                        count = d.count || d.anomalies.length || 0;
+                        anomalyDetails = d.anomalies.map(function (a) {
+                            const agentName = a.agent_name || (a.agent_id ? a.agent_id.substring(0, 8) + '...' : '');
+                            const desc = a.description || '';
+                            return escapeHtml(a.type || '?') + ' (' + escapeHtml(a.severity || '') + ')' +
+                                (agentName ? ' <code>' + escapeHtml(agentName) + '</code>' : '') +
+                                (desc ? ' — ' + escapeHtml(desc) : '');
+                        }).join('; ');
+                    } else {
+                        count = 1;
+                        const agentName = inc.agent_id && inc.agent_id !== 'system'
+                            ? inc.agent_id.substring(0, 8) + '...'
+                            : '';
+                        const desc = d.description || '';
+                        anomalyDetails = escapeHtml(d.type || '?') + ' (' + escapeHtml(d.severity || '') + ')' +
                             (agentName ? ' <code>' + escapeHtml(agentName) + '</code>' : '') +
                             (desc ? ' — ' + escapeHtml(desc) : '');
-                    }).join('; ');
+                    }
                     return '<div style="padding:6px 8px; border-left:2px solid var(--accent-orange); margin-bottom:4px; font-size:12px;">' +
                         '<span style="opacity:0.5;">' + when + '</span> &mdash; ' +
-                        '<strong>' + (d.count || '?') + ' anomal' + ((d.count || 0) === 1 ? 'y' : 'ies') + '</strong>' +
+                        '<strong>' + count + ' anomal' + (count === 1 ? 'y' : 'ies') + '</strong>' +
                         (anomalyDetails ? '<br><span style="opacity:0.7;">' + anomalyDetails + '</span>' : '') +
                         '</div>';
                 }).join('');

--- a/src/mcp_handlers/observability/handlers.py
+++ b/src/mcp_handlers/observability/handlers.py
@@ -627,16 +627,23 @@ async def handle_detect_anomalies(arguments: Dict[str, Any]) -> Sequence[TextCon
     if new_anomalies:
         from src.audit_log import audit_logger, AuditEntry
         from datetime import datetime
-        audit_logger._write_entry(AuditEntry(
-            timestamp=datetime.now().isoformat(),
-            agent_id="system",
-            event_type="anomaly_detected",
-            confidence=1.0,
-            details={
-                "count": len(new_anomalies),
-                "anomalies": [{"agent_id": a.get("agent_id"), "type": a.get("type"), "severity": a.get("severity"), "description": a.get("description", "")} for a in new_anomalies[:10]],
-            }
-        ))
+        # Fan out per-agent so audit.events.agent_id matches the affected agent.
+        # Prior shape wrote one batch entry with agent_id='system' and a
+        # truncated details.anomalies[:10] list — unjoinable in SQL and
+        # silently dropped anomalies 11+.
+        ts = datetime.now().isoformat()
+        for a in new_anomalies:
+            audit_logger._write_entry(AuditEntry(
+                timestamp=ts,
+                agent_id=a.get("agent_id") or "system",
+                event_type="anomaly_detected",
+                confidence=1.0,
+                details={
+                    "type": a.get("type"),
+                    "severity": a.get("severity"),
+                    "description": a.get("description", ""),
+                },
+            ))
 
     # Sort by severity (high first)
     all_anomalies.sort(key=lambda x: severity_levels.get(x.get("severity", "low"), 0), reverse=True)

--- a/tests/test_observability_handlers.py
+++ b/tests/test_observability_handlers.py
@@ -784,6 +784,81 @@ class TestHandleDetectAnomalies:
         assert data["summary"]["by_severity"]["medium"] == 1
 
     @pytest.mark.asyncio
+    async def test_audit_writes_per_agent_fanout(self):
+        """Each detected anomaly writes its own audit entry with the affected
+        agent_id — not a single batch entry with agent_id='system'.
+
+        Regression guard for the PPV pipeline: the Schmidt-proposal figure
+        and future v7 correlation work join audit.events.agent_id against
+        lifecycle_paused. The prior batched-write shape collapsed every
+        anomaly into one `agent_id='system'` row and truncated details at 10.
+        """
+        ids = [
+            "aaaaaaaa-bbbb-cccc-dddd-000000000001",
+            "aaaaaaaa-bbbb-cccc-dddd-000000000002",
+            "aaaaaaaa-bbbb-cccc-dddd-000000000003",
+        ]
+        server = _build_mock_server(agent_ids=ids)
+
+        # Fresh anomaly dicts per call — handlers.py mutates anomaly["agent_id"]
+        # in-place (line ~581), so a shared dict would get overwritten.
+        # Types must match the filter accepted by the handler (risk_spike /
+        # coherence_drop).
+        def patterns_side_effect(*_args, **_kwargs):
+            return {
+                "anomalies": [
+                    {"type": "risk_spike", "severity": "high",
+                     "description": "spike 1"},
+                    {"type": "risk_spike", "severity": "high",
+                     "description": "spike 2"},
+                    {"type": "coherence_drop", "severity": "high",
+                     "description": "drop 1"},
+                    {"type": "coherence_drop", "severity": "high",
+                     "description": "drop 2"},
+                ]
+            }
+
+        from src.audit_log import AuditEntry
+
+        written: list[AuditEntry] = []
+
+        with patch(_PATCH_SERVER, server), \
+             patch(_PATCH_CTX, return_value=None), \
+             patch(
+                 "src.pattern_analysis.analyze_agent_patterns",
+                 side_effect=patterns_side_effect,
+             ), \
+             patch("src.event_detector.event_detector.record_event",
+                   side_effect=lambda ev: ev), \
+             patch("src.audit_log.audit_logger._write_entry",
+                   side_effect=lambda entry: written.append(entry)):
+            from src.mcp_handlers.observability.handlers import handle_detect_anomalies
+            result = await handle_detect_anomalies({})
+
+        data = parse_result(result)
+        assert data["success"] is True
+        assert data["summary"]["total_anomalies"] == 12  # 3 agents × 4
+
+        # One audit entry per anomaly — no truncation at 10.
+        assert len(written) == 12, f"expected 12 fan-out entries, got {len(written)}"
+
+        # Every entry carries the real affected agent_id, not 'system'.
+        assert all(e.event_type == "anomaly_detected" for e in written)
+        assert all(e.agent_id in ids for e in written), (
+            f"audit entries must carry the affected agent_id: "
+            f"{[e.agent_id for e in written]}"
+        )
+        assert not any(e.agent_id == "system" for e in written)
+
+        # Each entry's details describe a single anomaly (not a list).
+        for e in written:
+            assert "type" in e.details
+            assert "severity" in e.details
+            assert "anomalies" not in e.details, (
+                "details should be per-anomaly, not a batch list"
+            )
+
+    @pytest.mark.asyncio
     async def test_specific_agent_ids(self):
         """Scan only specified agent_ids."""
         id1 = "aaaaaaaa-bbbb-cccc-dddd-111111111111"


### PR DESCRIPTION
Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.