### PR TITLE
fix(dashboard): cap Chart.js ResizeObserver grow-loop on Fleet Metrics

### DIFF
--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -5058,14 +5058,36 @@ body {
     opacity: 0.85;
 }
 
+/* Chart.js grow-loop guard (GitHub chartjs/Chart.js#11821, #1798, #5805).
+ *
+ * `responsive: true` + `maintainAspectRatio: false` inside a flex-column
+ * parent without `overflow: hidden` creates an infinite ResizeObserver
+ * cycle: the canvas resizes to the parent, which causes the parent to
+ * resize, which fires the observer again, each pass adding a few pixels.
+ *
+ * The combination required to stop this on a flex-column `.panel`:
+ *   1. `flex: 0 0 200px` — wrapper has a fixed main-axis size and is
+ *      NOT allowed to stretch (flex-grow:0) or shrink (flex-shrink:0)
+ *      based on sibling content.
+ *   2. `overflow: hidden` — absorbs the grow-cycle; without it the
+ *      canvas's over-measurement propagates back into the parent.
+ *   3. Canvas `box-sizing: border-box` — including border/padding in
+ *      the canvas's own measured size is required for Chart.js to
+ *      converge instead of oscillate.
+ *   4. `contain: strict` — tells the browser to skip layout recalcs
+ *      outside this box on resize.
+ */
 .fleet-metrics-chart-wrap {
     position: relative;
-    height: 200px;         /* match peer panels' visual footprint on desktop */
+    flex: 0 0 200px;
+    height: 200px;
+    overflow: hidden;
     padding: 4px 0;
-    contain: strict;       /* prevents Chart.js resize-observer from thrashing parent layout */
+    contain: strict;
 }
 
 .fleet-metrics-chart-wrap canvas {
+    box-sizing: border-box;
     width: 100% !important;
     height: 100% !important;
 }


### PR DESCRIPTION
## Summary
Known Chart.js bug found via web search after my three research-agent sweep missed it: [Chart grows forever when maintainAspectRatio is false (#11821)](https://github.com/chartjs/Chart.js/issues/11821) and [Responsive canvas grows indefinitely in a container sized in % (#5805)](https://github.com/chartjs/Chart.js/issues/5805).

**Root cause:** \`responsive: true\` + \`maintainAspectRatio: false\` inside a flex-column parent without \`overflow: hidden\` creates an infinite ResizeObserver loop. The canvas resizes to parent → parent grows to canvas → observer fires → repeat. Each cycle adds a few pixels until the panel visually dominates adjacent panels.

This explains exactly what Kenny kept reporting across four iterations: **panel larger than peers**, **"eating up Activity box"**, no matter what height I set.

## Fix — requires all four together
Per the GitHub issue threads, single mitigations aren't enough; the grow-loop needs a combination:

1. \`flex: 0 0 200px\` — wrapper has fixed main-axis size in \`.panel { display: flex; flex-direction: column }\`, neither grows nor shrinks
2. \`overflow: hidden\` — absorbs the over-measurement cascade
3. \`box-sizing: border-box\` on canvas — Chart.js resize math converges instead of oscillating
4. \`contain: strict\` — already present from #87; keeps browser from repainting outside the box

## Why my agents missed it
The grow-loop only manifests in a live browser running ResizeObserver. Static file inspection (curl) and unit tests are clean. The right diagnostic is **\`git-grep chartjs GitHub issues\` via web search**, not reading the dashboard code in isolation. I'll add this as a red flag in the unitares-dashboard skill.

## Deployment after merge
No server restart needed — pure CSS change, served fresh from disk. Just pull + hard-refresh the dashboard.

## Test plan
- [x] 41 metrics/chronicler/allowlist tests green
- [ ] After merge + pull + hard-refresh — panel is 200px tall, matches peer footprints, does not overlap Activity panel above

## Separately needed (unblocks "only one metric shows")
The second metric \`tests.unitares.count\` (from #85) is a Python catalog entry; governance-mcp needs a restart to pick it up. I'll handle that as a separate deploy step with your approval after this CSS fix lands.

Sources:
- [Chart.js #11821 — Chart grows forever when maintainAspectRatio is false](https://github.com/chartjs/Chart.js/issues/11821)
- [Chart.js #5805 — Responsive canvas grows indefinitely](https://github.com/chartjs/Chart.js/issues/5805)
- [Chart.js #1798 — Responsive line chart keeps growing vertically](https://github.com/chartjs/Chart.js/issues/1798)