### PR TITLE
fix(dashboard): cap Fleet Metrics panel at 1400px to match Activity

### DIFF
--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -4851,9 +4851,11 @@ body {
     margin-right: auto;
 }
 
-/* Activity timeline sits outside .main-content, so .panel's default
-   (no max-width) makes it stretch full viewport. Match the 1400px column. */
-#activity-timeline-section {
+/* Activity timeline and Fleet Metrics sit outside .main-content, so
+   .panel's default (no max-width) makes them stretch the full viewport.
+   Match the 1400px column used by .main-content above. */
+#activity-timeline-section,
+#fleet-metrics-section {
     max-width: 1400px;
     margin-left: auto;
     margin-right: auto;


### PR DESCRIPTION
## Summary
Kenny reported (very clearly) that Fleet Metrics is **wider** than Activity and visually **overlaps** it on desktop. Finally diagnosed correctly:

- \`.main-content\` uses a 2-column 1400px-max-width grid
- Activity lives OUTSIDE that grid as a full-width panel and sets its own \`max-width: 1400px; margin: auto\`
- Fleet Metrics also lives outside, but I never added the same rule
- Result: on a 1920px monitor, Fleet Metrics spans the full viewport while Activity sits at 1400px centered — so Fleet Metrics' edges extend past Activity's, giving the "wider / overlapping" appearance

## Fix
One CSS rule, grouping \`#fleet-metrics-section\` with \`#activity-timeline-section\` under the existing \`max-width: 1400px; margin-left/right: auto\` block. Updated the comment so the next full-width panel below \`.main-content\` doesn't miss this convention.

## Why I didn't catch this earlier
- Static HTML inspection didn't reveal it (both panels render fine in narrow viewports)
- The grow-loop fix in #88 was real but addressed a different symptom (height, not width)
- I was reading "wider" as "taller" across multiple messages. My fault — Kenny was precise.

## Test plan
- [x] Pure CSS; no Python tests affected
- [ ] After merge + pull + hard-refresh on a wide desktop — Fleet Metrics panel matches Activity's width and left/right edges align exactly