### PR TITLE
fix(dashboard): align breakpoints + responsive main gutter

### DIFF
--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -787,6 +787,15 @@ body {
 /* ============================================
    Main Content Layout
    ============================================ */
+/* `<main>` is the outermost container below the header/nav. Explicit
+ * horizontal padding prevents the full-viewport panels (Activity,
+ * Fleet Metrics, Residents strip) from hugging the screen edges on
+ * desktop; mobile media queries override this with tighter spacing. */
+main {
+    padding-left: 20px;
+    padding-right: 20px;
+}
+
 .main-content {
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -3782,13 +3791,17 @@ body {
 /* ============================================
    Responsive
    ============================================ */
+/* 960px: collapse all 2+ column grids to single column (except
+ * .stats-grid which steps 3→2 first — 3 cards in a row gets cramped).
+ * Bumped .main-content / .eisv-chart-row / .pulse-grid up from 900px so
+ * tablets in landscape (820–960px) and narrow desktop windows don't sit
+ * in a squashed 2-column state — content gets too tight between 760 and
+ * 900px, which is exactly the tablet-landscape band. */
 @media (max-width: 960px) {
     .stats-grid {
         grid-template-columns: repeat(2, 1fr);
     }
-}
 
-@media (max-width: 900px) {
     .main-content {
         grid-template-columns: 1fr;
     }
@@ -3891,6 +3904,19 @@ body {
 @media (max-width: 600px) {
     body {
         padding: var(--spacing-md);
+    }
+
+    /* Phone-sized viewports: tighter outer gutter + relaxed panel cap so
+     * panels shrink to fit the screen instead of creating tall internal
+     * scroll areas that dominate the viewport. Previously only handled
+     * at 480px — leaving 481–599px stuck with a full 800px panel. */
+    main {
+        padding-left: 12px;
+        padding-right: 12px;
+    }
+
+    .panel {
+        max-height: min(70vh, 600px);
     }
 
     .stats-grid {


### PR DESCRIPTION
## Summary
Kenny clarified "layout in general, not just Fleet Metrics and Activity." I ran a holistic audit agent and fixed three concrete responsive gaps that affected multiple panels — not just the ones I recently added.

## Audit findings acted on

### 1. Tablet-landscape dead zone (820–960px)
\`.main-content\` (Agents / Discoveries / Dialectic), \`.eisv-chart-row\`, and \`.pulse-grid\` only collapsed to 1 column at 900px — but their content gets cramped from ~760px upward. \`.stats-grid\` already steps down at 960px. **Fix:** consolidate the three grids under the existing 960px breakpoint so landscape tablets / narrow desktop windows get a clean single-column layout immediately.

### 2. Panel max-height gap at 481–599px
\`.panel { max-height: 800px }\` only relaxed at 480px, so everything between 481–599px (mid-phone landscape, small tablets) was stuck with the full 800px cap creating tall internal scroll areas that dominated the viewport. **Fix:** add \`.panel { max-height: min(70vh, 600px) }\` to the existing 600px breakpoint.

### 3. Missing \`<main>\` outer gutter
The \`<main>\` element had no CSS, so full-viewport panels (Activity, Fleet Metrics, residents strip) hugged the screen edges on wide desktops with no side padding. **Fix:** add \`main { padding: 0 20px }\` (12px at ≤600px).

## What I did NOT change (even though audit flagged them)
- Stats-grid widening above 1600px — real but rare; would need user input on what's preferred
- Dialectic-section hardcoded 800px — opinionated, didn't want to change behavior without your say
- Section-nav intermediate states — current behavior acceptable; changing risks scroll-spy regressions

Can address any of these in a follow-up if you want.

## Test plan
- [x] 41 metrics/chronicler/allowlist tests pass
- [ ] Desktop (1920px): Activity / Fleet Metrics / residents inset 20px from edges; Agents+Discoveries+Dialectic still 2-column
- [ ] Laptop (1366px): still 2-column main, residents strip inset
- [ ] Landscape iPad (1024px): single column, clean
- [ ] Phone (≤600px): 12px gutter, panels capped at 70vh or 600px — no tall scroll-dominant panels

No JS/Python/server changes; pure CSS, no restart needed.