### PR TITLE
feat(identity): PATH 2 IP:UA pin cross-check — Phase A (observation)

### DIFF
--- a/agents/vigil/agent.py
+++ b/agents/vigil/agent.py
@@ -312,12 +312,20 @@ class VigilAgent(GovernanceAgent):
             return []
         return _filter_sentinel_findings(result.results or [], since_iso)
 
-    async def _run_groundskeeper(self, client: GovernanceClient) -> Dict[str, Any]:
+    async def _run_groundskeeper(
+        self,
+        client: GovernanceClient,
+        prev_state: Dict[str, Any] | None = None,
+    ) -> Dict[str, Any]:
         """KG audit + lifecycle cleanup.
 
         Orphan agent archival is no longer part of the Groundskeeper cycle —
         the auto-sweep was hiding initializing-agent bugs behind archival.
         Operators can still invoke ``archive_orphan_agents`` manually.
+
+        ``prev_state`` is the previous cycle's state dict; when supplied, the
+        summary KG note is suppressed if (stale_found, archived) is unchanged
+        from the prior cycle. Local log + findings still surface every cycle.
         """
         summary: Dict[str, Any] = {
             "audit_run": False,
@@ -361,14 +369,23 @@ class VigilAgent(GovernanceAgent):
                 f"Groundskeeper: {summary['stale_found']} stale, "
                 f"{summary['archived']} archived"
             )
-            try:
-                await client.leave_note(
-                    summary=note_text,
-                    tags=["vigil", "groundskeeper", "audit"],
-                )
-            except Exception:
-                pass
-            log(f"GROUNDSKEEPER: {note_text}")
+            prev = prev_state or {}
+            unchanged = (
+                prev.get("groundskeeper_stale") == summary["stale_found"]
+                and prev.get("groundskeeper_archived") == summary["archived"]
+            )
+            if unchanged and prev:
+                summary["note_suppressed"] = True
+                log(f"GROUNDSKEEPER: {note_text} (note suppressed — unchanged)")
+            else:
+                try:
+                    await client.leave_note(
+                        summary=note_text,
+                        tags=["vigil", "groundskeeper", "audit"],
+                    )
+                except Exception:
+                    pass
+                log(f"GROUNDSKEEPER: {note_text}")
 
         return summary
 
@@ -461,7 +478,7 @@ class VigilAgent(GovernanceAgent):
         effective_audit = self.with_audit or sentinel_force_audit
         groundskeeper_summary: Dict[str, Any] = {}
         if effective_audit:
-            groundskeeper_summary = await self._run_groundskeeper(client)
+            groundskeeper_summary = await self._run_groundskeeper(client, prev_state)
             if groundskeeper_summary.get("stale_found", 0) > 0:
                 findings.append(
                     f"KG: {groundskeeper_summary['stale_found']} stale, "

--- a/agents/vigil/tests/test_groundskeeper.py
+++ b/agents/vigil/tests/test_groundskeeper.py
@@ -150,6 +150,51 @@ class TestRunGroundskeeper:
         assert "vigil" in call_kwargs["tags"]
 
     @pytest.mark.asyncio
+    async def test_groundskeeper_suppresses_note_when_unchanged(self):
+        """When stale/archived counts match prev_state, skip leave_note.
+
+        Regression for the KG spam where Vigil posted an identical
+        'Groundskeeper: 134 stale, 4 archived' note every 30 minutes
+        because the audit/cleanup mismatch keeps the numbers pinned.
+        """
+        agent = _make_agent()
+        client = _make_mock_client(
+            audit_result=AuditResult(
+                success=True,
+                audit={"buckets": {"healthy": 2, "stale": 1, "candidate_for_archive": 3}},
+            ),
+            cleanup_result=CleanupResult(success=True, cleaned=3),
+        )
+        prev = {"groundskeeper_stale": 4, "groundskeeper_archived": 3}
+        result = await agent._run_groundskeeper(client, prev_state=prev)
+
+        client.leave_note.assert_not_called()
+        assert result["note_suppressed"] is True
+
+    @pytest.mark.asyncio
+    async def test_groundskeeper_posts_note_on_change(self):
+        """When numbers differ from prev_state, leave_note must fire."""
+        agent = _make_agent()
+        client = _make_mock_client(
+            audit_result=AuditResult(
+                success=True,
+                audit={"buckets": {"healthy": 2, "stale": 1, "candidate_for_archive": 3}},
+            ),
+            cleanup_result=CleanupResult(success=True, cleaned=3),
+        )
+        prev = {"groundskeeper_stale": 100, "groundskeeper_archived": 0}
+        await agent._run_groundskeeper(client, prev_state=prev)
+        client.leave_note.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_groundskeeper_posts_note_on_first_cycle(self):
+        """No prev_state (cold start) must still post the inaugural note."""
+        agent = _make_agent()
+        client = _make_mock_client()
+        await agent._run_groundskeeper(client, prev_state=None)
+        client.leave_note.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_groundskeeper_handles_audit_failure(self):
         """Gracefully handles audit tool failure."""
         agent = _make_agent()

--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -945,3 +945,41 @@ def session_fingerprint_check_mode() -> str:
         "UNITARES_SESSION_FINGERPRINT_CHECK", SESSION_FINGERPRINT_CHECK_MODE
     ).strip().lower()
     return m if m in _VALID_FINGERPRINT_MODES else "log"
+
+
+# =============================================================================
+# IP:UA ONBOARD PIN CHECK MODE (PATH 2 — council follow-up to #83)
+# =============================================================================
+# `derive_session_key` step 7 resolves an unauthenticated `onboard()` call
+# (no continuity_token, no client_session_id, no mcp/oauth/x- session headers)
+# to a previously-pinned session by IP:UA fingerprint alone. On shared hosts or
+# when multiple same-family agents run on one machine this silently resumes
+# the prior agent's UUID — the PATH 2 analogue of the PATH 0/1 bleeds already
+# closed by #78/#81/#83.
+#
+# Modes (mirror UNITARES_SESSION_FINGERPRINT_CHECK):
+#   "off"    — skip the check entirely; pin-fallback resume proceeds silently
+#   "log"    — emit [PATH2_IPUA_PIN_RESUME] + identity_hijack_suspected
+#              broadcast when onboard() hits the pin fallback with no proof;
+#              resume still proceeds (default — observation phase)
+#   "strict" — same events, plus force resume=False so the onboard mints a
+#              fresh identity instead of silently adopting the pinned UUID.
+#              The pin itself is NOT deleted — the legitimate owner can still
+#              resume by presenting a continuity_token or agent_uuid.
+#
+# Override: UNITARES_IPUA_PIN_CHECK env var.
+IPUA_PIN_CHECK_MODE: str = os.getenv(
+    "UNITARES_IPUA_PIN_CHECK", "log"
+).strip().lower()
+
+_VALID_IPUA_PIN_MODES = frozenset({"off", "log", "strict"})
+if IPUA_PIN_CHECK_MODE not in _VALID_IPUA_PIN_MODES:
+    IPUA_PIN_CHECK_MODE = "log"
+
+
+def ipua_pin_check_mode() -> str:
+    """Runtime accessor — respects env changes set after module load (tests)."""
+    m = os.getenv(
+        "UNITARES_IPUA_PIN_CHECK", IPUA_PIN_CHECK_MODE
+    ).strip().lower()
+    return m if m in _VALID_IPUA_PIN_MODES else "log"

--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -101,6 +101,75 @@ async def _emit_identity_hijack_event(
     except Exception as e:
         logger.warning(f"[IDENTITY_HIJACK] broadcast_event failed: {e}")
 
+
+async def _path2_ipua_pin_check(
+    *,
+    arguments: Dict[str, Any],
+    base_session_key: str,
+    force_new: bool,
+    resume: bool,
+) -> bool:
+    """PATH 2 IP:UA pin cross-check.
+
+    `derive_session_key` step 7 resolves an unauthenticated onboard() call to
+    a previously-pinned session by IP:UA fingerprint alone. Multiple same-
+    family agents on one machine silently adopt the first agent's UUID.
+    Observation phase emits `identity_hijack_suspected` with
+    `path="path2_ipua_pin"`; strict mode additionally forces a fresh mint by
+    returning resume=False. Suppressed when the caller supplied any ownership
+    proof (token, explicit session id, agent_uuid) or when force_new is set
+    (a deliberate fresh ask).
+
+    Returns the (possibly-flipped) `resume` flag the caller should use.
+    """
+    from ..context import get_session_resolution_source
+    if get_session_resolution_source() != "pinned_onboard_session":
+        return resume
+
+    has_proof = bool(
+        arguments.get("continuity_token")
+        or arguments.get("client_session_id")
+        or arguments.get("agent_id")
+        or arguments.get("agent_uuid")
+    )
+    if has_proof or force_new:
+        return resume
+
+    from config.governance_config import ipua_pin_check_mode
+    pin_mode = ipua_pin_check_mode()
+    if pin_mode == "off":
+        return resume
+
+    logger.warning(
+        "[PATH2_IPUA_PIN_RESUME] onboard() with no ownership proof resolved "
+        "to pinned session via IP:UA fingerprint — session_key=%s... (mode=%s)",
+        str(base_session_key)[:20],
+        pin_mode,
+    )
+    try:
+        b = _broadcaster()
+        if b is not None:
+            await b.broadcast_event(
+                event_type="identity_hijack_suspected",
+                agent_id=None,
+                payload={
+                    "path": "path2_ipua_pin",
+                    "mode": pin_mode,
+                    "source": "onboard_pin_fallback",
+                    "session_key_prefix": str(base_session_key)[:16],
+                },
+            )
+    except Exception as _be:
+        logger.warning(f"[PATH2_IPUA_PIN_RESUME] broadcast failed: {_be}")
+
+    # Strict mode: force fresh mint. The pin entry is left intact so the
+    # legitimate owner can still resume by presenting a continuity_token or
+    # agent_uuid.
+    if pin_mode == "strict":
+        return False
+    return resume
+
+
 # --- identity_resolution ---
 from .resolution import (
     _generate_agent_id,
@@ -1136,6 +1205,14 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     # Session continuity: resume existing identity by default.
     # Agents can pass resume=false for a new identity, or force_new=true for a clean break.
     resume = coerce_bool(arguments.get("resume"), default=True)
+
+    # PATH 2 IP:UA pin cross-check (2026-04-20 council follow-up to #83).
+    resume = await _path2_ipua_pin_check(
+        arguments=arguments,
+        base_session_key=base_session_key,
+        force_new=force_new,
+        resume=resume,
+    )
 
     # Extract agent UUID from continuity token for direct lookup fallback (PATH 2.8).
     # Token is a cryptographic proof of identity — stronger than name claim.

--- a/tests/test_identity_path2_ipua_pin.py
+++ b/tests/test_identity_path2_ipua_pin.py
@@ -1,0 +1,231 @@
+"""PATH 2 IP:UA pin cross-check — Phase A (observation).
+
+Council follow-up to #83 (PATH 1 fingerprint cross-check). `derive_session_key`
+step 7 resolves an unauthenticated `onboard()` call (no continuity_token,
+no explicit client_session_id, no mcp/oauth/x- session headers) to a
+previously-pinned session by IP:UA fingerprint alone. Multiple same-family
+agents on one machine silently adopt the first agent's UUID — the PATH 2
+analogue of the bleeds closed for PATH 0 (#78/#81) and PATH 1 (#83).
+
+This module locks in the observation-phase behavior of the helper
+`_path2_ipua_pin_check` wired into `handle_onboard_v2`:
+
+  - Fires `identity_hijack_suspected` with `path="path2_ipua_pin"` when the
+    session-derivation source is `pinned_onboard_session` and the caller
+    supplied no ownership proof.
+  - In `log` mode (default) the resume still proceeds after emission.
+  - In `strict` mode the helper additionally returns `resume=False` so the
+    caller mints a fresh identity.
+  - In `off` mode, no check runs — no event, no resume flip.
+  - Suppressed when the caller passes continuity_token, client_session_id,
+    agent_id, agent_uuid, or force_new — any of those is treated as proof
+    or a deliberate fresh-ask.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_pin_mode(monkeypatch):
+    monkeypatch.delenv("UNITARES_IPUA_PIN_CHECK", raising=False)
+    yield
+
+
+@pytest.fixture
+def captured_events():
+    return []
+
+
+@pytest.fixture
+def broadcaster_stub(captured_events):
+    b = MagicMock()
+
+    async def _record(**kwargs):
+        captured_events.append(kwargs)
+
+    b.broadcast_event = AsyncMock(side_effect=_record)
+    return b
+
+
+class TestPath2IpuaPinCheck:
+    @pytest.mark.asyncio
+    async def test_log_mode_emits_and_leaves_resume_true(
+        self, monkeypatch, captured_events, broadcaster_stub
+    ):
+        monkeypatch.setenv("UNITARES_IPUA_PIN_CHECK", "log")
+
+        from src.mcp_handlers.identity import handlers as h_mod
+
+        with patch(
+            "src.mcp_handlers.context.get_session_resolution_source",
+            return_value="pinned_onboard_session",
+        ), patch.object(h_mod, "_broadcaster", return_value=broadcaster_stub):
+            new_resume = await h_mod._path2_ipua_pin_check(
+                arguments={},
+                base_session_key="fp-ipua-abcdef:claude",
+                force_new=False,
+                resume=True,
+            )
+
+        # Log mode: resume unchanged.
+        assert new_resume is True
+
+        # Event fired.
+        hijack_events = [
+            e for e in captured_events
+            if e.get("event_type") == "identity_hijack_suspected"
+        ]
+        assert hijack_events, (
+            f"Log mode must emit identity_hijack_suspected. Got: {captured_events}"
+        )
+        evt = hijack_events[0]
+        payload = evt.get("payload") or {}
+        assert payload.get("path") == "path2_ipua_pin"
+        assert payload.get("mode") == "log"
+        assert payload.get("source") == "onboard_pin_fallback"
+        assert payload.get("session_key_prefix") == "fp-ipua-abcdef:c"
+
+    @pytest.mark.asyncio
+    async def test_strict_mode_flips_resume_and_emits(
+        self, monkeypatch, captured_events, broadcaster_stub
+    ):
+        monkeypatch.setenv("UNITARES_IPUA_PIN_CHECK", "strict")
+
+        from src.mcp_handlers.identity import handlers as h_mod
+
+        with patch(
+            "src.mcp_handlers.context.get_session_resolution_source",
+            return_value="pinned_onboard_session",
+        ), patch.object(h_mod, "_broadcaster", return_value=broadcaster_stub):
+            new_resume = await h_mod._path2_ipua_pin_check(
+                arguments={},
+                base_session_key="fp-ipua-abcdef:claude",
+                force_new=False,
+                resume=True,
+            )
+
+        # Strict mode: resume forced False — caller mints fresh.
+        assert new_resume is False
+
+        # Event still fires with strict marker.
+        hijack_events = [
+            e for e in captured_events
+            if e.get("event_type") == "identity_hijack_suspected"
+        ]
+        assert hijack_events, (
+            "Strict mode must still emit the event for visibility"
+        )
+        assert (hijack_events[0].get("payload") or {}).get("mode") == "strict"
+
+    @pytest.mark.asyncio
+    async def test_off_mode_does_not_emit_or_flip(
+        self, monkeypatch, captured_events, broadcaster_stub
+    ):
+        monkeypatch.setenv("UNITARES_IPUA_PIN_CHECK", "off")
+
+        from src.mcp_handlers.identity import handlers as h_mod
+
+        with patch(
+            "src.mcp_handlers.context.get_session_resolution_source",
+            return_value="pinned_onboard_session",
+        ), patch.object(h_mod, "_broadcaster", return_value=broadcaster_stub):
+            new_resume = await h_mod._path2_ipua_pin_check(
+                arguments={},
+                base_session_key="fp-ipua-abcdef:claude",
+                force_new=False,
+                resume=True,
+            )
+
+        assert new_resume is True
+        hijack_events = [
+            e for e in captured_events
+            if e.get("event_type") == "identity_hijack_suspected"
+        ]
+        assert hijack_events == [], (
+            f"Off mode must not emit events. Got: {captured_events}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_pin_source_skips_check(
+        self, monkeypatch, captured_events, broadcaster_stub
+    ):
+        """When session derivation did not take the pin fallback, the helper
+        is a no-op. Ensures we don't emit events for every onboard call."""
+        monkeypatch.setenv("UNITARES_IPUA_PIN_CHECK", "strict")
+
+        from src.mcp_handlers.identity import handlers as h_mod
+
+        with patch(
+            "src.mcp_handlers.context.get_session_resolution_source",
+            return_value="continuity_token",
+        ), patch.object(h_mod, "_broadcaster", return_value=broadcaster_stub):
+            new_resume = await h_mod._path2_ipua_pin_check(
+                arguments={},
+                base_session_key="fp-ipua-abcdef:claude",
+                force_new=False,
+                resume=True,
+            )
+
+        assert new_resume is True
+        assert captured_events == []
+
+    @pytest.mark.parametrize(
+        "proof_arg",
+        [
+            "continuity_token",
+            "client_session_id",
+            "agent_id",
+            "agent_uuid",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_ownership_proof_suppresses_check(
+        self, monkeypatch, captured_events, broadcaster_stub, proof_arg
+    ):
+        """Any caller-supplied ownership signal suppresses the PATH 2 gate
+        even in strict mode — the caller has already asserted identity."""
+        monkeypatch.setenv("UNITARES_IPUA_PIN_CHECK", "strict")
+
+        from src.mcp_handlers.identity import handlers as h_mod
+
+        with patch(
+            "src.mcp_handlers.context.get_session_resolution_source",
+            return_value="pinned_onboard_session",
+        ), patch.object(h_mod, "_broadcaster", return_value=broadcaster_stub):
+            new_resume = await h_mod._path2_ipua_pin_check(
+                arguments={proof_arg: "some-value"},
+                base_session_key="fp-ipua-abcdef:claude",
+                force_new=False,
+                resume=True,
+            )
+
+        assert new_resume is True
+        assert captured_events == []
+
+    @pytest.mark.asyncio
+    async def test_force_new_suppresses_check(
+        self, monkeypatch, captured_events, broadcaster_stub
+    ):
+        """force_new=True means the caller explicitly asked for a fresh
+        identity — the pin-resume would never apply, so no event."""
+        monkeypatch.setenv("UNITARES_IPUA_PIN_CHECK", "strict")
+
+        from src.mcp_handlers.identity import handlers as h_mod
+
+        with patch(
+            "src.mcp_handlers.context.get_session_resolution_source",
+            return_value="pinned_onboard_session",
+        ), patch.object(h_mod, "_broadcaster", return_value=broadcaster_stub):
+            new_resume = await h_mod._path2_ipua_pin_check(
+                arguments={},
+                base_session_key="fp-ipua-abcdef:claude",
+                force_new=True,
+                resume=True,
+            )
+
+        # resume unchanged (caller is already going to force_new).
+        assert new_resume is True
+        assert captured_events == []


### PR DESCRIPTION
## Summary

- Closes the third identity-bleed path: a bare `onboard()` call with no ownership proof gets resolved to a previously-pinned session by IP:UA fingerprint alone, silently adopting another agent's UUID. Reproduced on claude_desktop-opus stdio transport 2026-04-20 (`session_resolution_source: pinned_onboard_session`, `is_new: false`, UUID the caller never supplied).
- Adds observation-mode cross-check mirroring #83's playbook: helper `_path2_ipua_pin_check` fires `identity_hijack_suspected` with `path='path2_ipua_pin'` when a pin-fallback resume occurs without caller-supplied proof (continuity_token / client_session_id / agent_id / agent_uuid / force_new).
- New env flag `UNITARES_IPUA_PIN_CHECK` (`off`/`log`/`strict`, default `log`). In `strict`, the helper also forces `resume=False` so the onboard mints a fresh identity; the pin entry is left intact so the legitimate owner can still resume by presenting a token or UUID.

## Context

PATH 0 (#78/#81) and PATH 1 (#83) already close similar bleeds on bare-UUID resume and `agent-{uuid[:12]}` session-id resume. PATH 2 is the last unauthenticated path: on shared hosts or when multiple same-family agents run on one machine, the second caller silently adopts the first agent's UUID.

Dashboards subscribing to `identity_hijack_suspected` will now see a `path='path2_ipua_pin'` signal within one broadcast cycle when this bleed triggers. After evidence gathering, promote `UNITARES_IPUA_PIN_CHECK` to `strict` to close the hole.

## Scope notes

- Server-side defense-in-depth. The companion plugin (`unitares-governance-plugin`) still sends a bare `onboard()` when its per-slot cache is empty (`scripts/client/onboard_helper.py:174-188`); an orthogonal plugin PR can pass `force_new` on empty-slot calls to avoid triggering the pin-resume at all.
- Council item 1 (list_agents unauth UUID dump, KG `2026-04-20T00:57:45`) remains open.

## Bundled: Vigil groundskeeper KG-spam dedupe (commit 2bd31b7e)

Independent fix included on this branch. Vigil's heartbeat (every 30 min) was posting an identical `Groundskeeper: 134 stale, 4 archived` note each cycle — observed 8+ identical KG entries in one 12h window. Root cause is an audit/cleanup contract mismatch in `src/knowledge_graph_lifecycle.py`: `_score_discovery` (line 413) buckets ANY open discovery >14d inactive as `stale`, but `_archive_ephemeral` (line 222) only archives `policy=='ephemeral'` opens — non-ephemeral opens stay stale forever, pinning the numbers.

`_run_groundskeeper` now accepts `prev_state` and suppresses the `leave_note` when `(stale_found, archived)` is unchanged. Local log + cycle findings still surface every cycle, so operators don't lose visibility. Structural follow-up filed as KG insight `2026-04-20T03:44:40.080094` with three options (audit respects policy / cleanup drains non-ephemeral / rename bucket).

Tests: 3 regression cases (suppress on unchanged, post on change, post on cold start). 59/59 vigil tests pass.

## Test plan

- [x] `tests/test_identity_path2_ipua_pin.py` — 9 cases covering log/strict/off modes, non-pin source skip, and suppression by every ownership-proof argument + force_new
- [x] Full identity-test suite (226 tests) passes — including pre-existing PATH 0 and PATH 1 coverage
- [x] `agents/vigil/tests/test_groundskeeper.py` — 18 cases (15 existing + 3 new dedupe regressions) pass
- [ ] Integration smoke: bare `onboard()` on resident host emits `identity_hijack_suspected` with `path='path2_ipua_pin'` in log mode, mints fresh in strict mode
- [ ] Dashboard shows the new event discriminator alongside existing `path1_session_id` / `path0_*` events
- [ ] Production Vigil cycle confirms the groundskeeper note no longer fires when counts are unchanged

Note: `test-cache.sh` pre-push showed one pre-existing failure unrelated to either change — `tests/test_model_inference.py::test_energy_cost_free_tier_flash` (expects `energy_cost=0.01` for `gemini-flash`, gets `0.03` — stale assertion from the Gemini provider drop in #80). Reproduces on origin/master without this branch.