### PR TITLE
fix(residents): stamp persistent+autonomous on onboard

### DIFF
--- a/agents/sdk/src/unitares_sdk/agent.py
+++ b/agents/sdk/src/unitares_sdk/agent.py
@@ -33,6 +33,12 @@ from unitares_sdk.utils import (
 
 logger = logging.getLogger(__name__)
 
+# Tag set stamped on every resident identity when persistent=True.
+#   - 'persistent':  exempts from auto_archive_orphan_agents
+#   - 'autonomous':  exempts from loop-detection pattern 4 (agent_loop_detection.py:216)
+# Keep in sync with server-side KNOWN_RESIDENT_LABELS in grounding/class_indicator.py.
+RESIDENT_TAGS: list[str] = ["persistent", "autonomous"]
+
 
 @dataclass
 class CycleResult:
@@ -230,20 +236,27 @@ class GovernanceAgent:
         logger.info("%s: onboarded fresh (UUID %s)", self.name, self.agent_uuid[:12] if self.agent_uuid else "?")
 
         if self.persistent and self.agent_uuid:
+            # Residents need BOTH tags:
+            #   - 'persistent':  protects from auto_archive_orphan_agents
+            #   - 'autonomous':  exempts from loop-detection pattern 4
+            #                    (agent_loop_detection.py:216). Resident cadences
+            #                    can't respond to pause verdicts within the 30s
+            #                    cooldown, so pattern-4 rejection silently starves
+            #                    their state writes (Steward 2026-04-20 regression).
             try:
                 await client.call_tool(
                     "update_agent_metadata",
-                    {"agent_id": self.agent_uuid, "tags": ["persistent"]},
+                    {"agent_id": self.agent_uuid, "tags": RESIDENT_TAGS},
                 )
                 logger.info(
-                    "%s: stamped 'persistent' tag to protect from orphan sweep",
-                    self.name,
+                    "%s: stamped resident tags %s",
+                    self.name, RESIDENT_TAGS,
                 )
             except Exception as e:
                 # Non-fatal. The agent still runs; it's just vulnerable to
-                # archive_orphan_agents until someone tags it manually.
+                # archive_orphan_agents AND loop-detection until someone tags it.
                 logger.warning(
-                    "%s: failed to stamp 'persistent' tag: %s "
+                    "%s: failed to stamp resident tags: %s "
                     "(will retry on next fresh onboard; manual tagging may be needed)",
                     self.name, e,
                 )

--- a/agents/sdk/tests/test_agent.py
+++ b/agents/sdk/tests/test_agent.py
@@ -166,13 +166,19 @@ class TestIdentityResolution:
         assert "spawn_reason" not in call_kwargs
 
     @pytest.mark.asyncio
-    async def test_persistent_tag_stamped_on_fresh_onboard(self, tmp_path):
-        """persistent=True agents stamp the 'persistent' tag after fresh onboard.
+    async def test_resident_tags_stamped_on_fresh_onboard(self, tmp_path):
+        """persistent=True agents stamp the full resident tag set after fresh onboard.
 
-        Protects residents (Vigil, Sentinel) from orphan-sweep false-positives.
-        Root cause: low-activity windows caused sweep to archive live residents,
-        and auto-resume silently revived them, masking the problem.
+        Residents need BOTH 'persistent' (exempts orphan-sweep) AND 'autonomous'
+        (exempts loop-detection pattern 4). Steward hit the pattern-4 gap on
+        2026-04-20 because this path stamped only 'persistent'; once every 5min
+        its sync was rejected, starving core.agent_state. RESIDENT_TAGS is the
+        single source of truth.
         """
+        from unitares_sdk.agent import RESIDENT_TAGS
+        assert "persistent" in RESIDENT_TAGS
+        assert "autonomous" in RESIDENT_TAGS
+
         agent = SimpleAgent(session_file=tmp_path / ".test_session", persistent=True)
 
         client = _mock_client_connected()
@@ -182,7 +188,7 @@ class TestIdentityResolution:
         client.onboard.assert_called_once()
         client.call_tool.assert_awaited_once_with(
             "update_agent_metadata",
-            {"agent_id": "uuid-test", "tags": ["persistent"]},
+            {"agent_id": "uuid-test", "tags": RESIDENT_TAGS},
         )
 
     @pytest.mark.asyncio

--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -225,22 +225,29 @@ def resolve_identity(client) -> None:
     try:
         client.onboard("Watcher", spawn_reason="resident_observer")
         _sync_identity(client)
-        # Stamp 'persistent' tag so auto_archive_orphan_agents skips this
-        # identity (is_agent_protected in src/agent_lifecycle.py). Without
-        # this, low-activity windows cause orphan-sweep false-positives and
-        # the Watcher gets archived-then-silently-resurrected every cycle.
+        # Stamp the resident tag set:
+        #   - 'persistent':  auto_archive_orphan_agents skips this identity
+        #                    (is_agent_protected in src/agent_lifecycle.py).
+        #                    Without it, low-activity windows cause orphan-sweep
+        #                    false-positives and Watcher gets archived-then-
+        #                    silently-resurrected every cycle.
+        #   - 'autonomous':  exempts from loop-detection pattern 4
+        #                    (agent_loop_detection.py:216). Watcher runs on
+        #                    every edit — pattern-4 rejection would starve its
+        #                    state writes (Steward 2026-04-20 regression).
         if _watcher_identity and _watcher_identity.get("agent_uuid"):
+            from unitares_sdk.agent import RESIDENT_TAGS
             try:
                 client.call_tool(
                     "update_agent_metadata",
                     {
                         "agent_id": _watcher_identity["agent_uuid"],
-                        "tags": ["persistent"],
+                        "tags": RESIDENT_TAGS,
                     },
                 )
-                log("stamped 'persistent' tag — protected from orphan sweep")
+                log(f"stamped resident tags {RESIDENT_TAGS}")
             except Exception as e:
-                log(f"failed to stamp 'persistent' tag: {e}", "warning")
+                log(f"failed to stamp resident tags: {e}", "warning")
     except GovernanceTimeoutError as e:
         # Onboard timeout is the worst case — don't assume it failed, it may
         # have partial-committed on the server side (which is exactly how


### PR DESCRIPTION
## Summary
- `unitares_sdk.agent.GovernanceAgent` + `agents/watcher/agent.py` now stamp `["persistent", "autonomous"]` on residents, not just `persistent`
- Introduces `RESIDENT_TAGS` as the single source of truth so future drift is prevented
- Tests updated to assert the full tag set

## Why
Residents need both tags:
- `persistent` — exempts from `auto_archive_orphan_agents`
- `autonomous` — exempts from `agent_loop_detection.py:216` pattern 4 (decision loop gate)

Steward hit this on 2026-04-20 — every 5-min sync got rejected with `Self-monitoring loop detected` once 5+ pauses accumulated within the 1hr freshness window, zero rows ever landed in `core.agent_state`. Watcher (runs every edit) is the next most exposed; Vigil (30min) and Sentinel (10min) were vulnerable too.

Live DB was retagged out-of-band for Vigil/Sentinel/Watcher so the running fleet is already protected. This PR makes the code-level default correct so future fresh onboards land correctly.

Steward's own path in `unitares-pi-plugin` will migrate to import `RESIDENT_TAGS` as a follow-up PR in that repo.

## Test plan
- [x] `agents/sdk/tests/test_agent.py::test_resident_tags_stamped_on_fresh_onboard` (assertion updated)
- [x] `agents/watcher/tests/` — all pass
- [x] Targeted suites: 177 passed

## Ghost rows
Still live: 5 Vigil identities with empty tags, pre-rename legacy. Not in scope for this PR — leaving for Kenny to decide whether to archive.