### PR TITLE
feat(vigil): resident tag-hygiene check + /v1/residents/tag_audit endpoint

### DIFF
--- a/agents/vigil/checks/registry.py
+++ b/agents/vigil/checks/registry.py
@@ -41,6 +41,8 @@ def load_plugins() -> None:
     # Python's module cache doesn't swallow registration on re-load (test harness).
     from .governance_health import GovernanceHealth
     register(GovernanceHealth())
+    from .resident_tag_hygiene import ResidentTagHygiene
+    register(ResidentTagHygiene())
 
     raw = os.getenv("VIGIL_CHECK_PLUGINS", "") or ""
     for mod_path in raw.split(":"):

--- a/agents/vigil/checks/resident_tag_hygiene.py
+++ b/agents/vigil/checks/resident_tag_hygiene.py
@@ -1,0 +1,96 @@
+"""Resident tag-hygiene check.
+
+Hits ``/v1/residents/tag_audit`` and emits a critical finding for every active
+resident that's missing a required tag. Catches onboarding-path drift before
+it manifests as a production incident.
+
+Background: on 2026-04-20 Steward went three days with zero rows in
+``core.agent_state`` because its onboarding path stamped ``persistent`` but
+not ``autonomous``, and loop-detection pattern 4 silently starved every sync.
+The fix was a one-line tag addition — this check makes sure the same
+single-tag-stamp class of bug is visible within one Vigil cycle rather than
+discovered by coincidence days later.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Tuple
+
+import httpx
+
+from .base import CheckResult
+
+RESIDENT_TAG_AUDIT_URL = os.environ.get(
+    "RESIDENT_TAG_AUDIT_URL", "http://localhost:8767/v1/residents/tag_audit"
+)
+
+
+def fetch_tag_audit(url: str, timeout: float = 5.0) -> Tuple[bool, dict, str]:
+    """Probe the audit endpoint. Returns (ok, payload, error_detail).
+
+    ok=False means the endpoint itself is unreachable or returned non-200.
+    ok=True with missing={} means the fleet is healthy.
+    """
+    start = time.monotonic()
+    try:
+        resp = httpx.get(url, timeout=timeout)
+        latency_ms = int((time.monotonic() - start) * 1000)
+        if resp.status_code == 200:
+            try:
+                data = resp.json()
+                return True, data, f"{latency_ms}ms"
+            except Exception as e:
+                return False, {}, f"JSON parse failed ({latency_ms}ms): {e}"
+        return False, {}, f"HTTP {resp.status_code} ({latency_ms}ms)"
+    except httpx.ConnectError:
+        return False, {}, "unreachable"
+    except httpx.TimeoutException:
+        return False, {}, f"timeout (>{int(timeout*1000)}ms)"
+    except Exception as e:
+        return False, {}, str(e)
+
+
+class ResidentTagHygiene:
+    name = "resident_tag_hygiene"
+    service_key = "governance"
+
+    async def run(self) -> CheckResult:
+        from . import resident_tag_hygiene as _this
+        ok, data, detail = _this.fetch_tag_audit(_this.RESIDENT_TAG_AUDIT_URL)
+
+        if not ok:
+            # Endpoint unreachable — don't conflate with a real gap.
+            # Degrade to warning (governance_health already fires critical
+            # when the service is fully down).
+            return CheckResult(
+                ok=False,
+                summary=f"Resident tag audit: endpoint unreachable ({detail})",
+                severity="warning",
+                fingerprint_key="resident_tag_audit_unreachable",
+            )
+
+        missing = data.get("missing") or {}
+        if not missing:
+            checked = data.get("checked") or []
+            ok_count = data.get("ok_count", len(checked))
+            return CheckResult(
+                ok=True,
+                summary=f"Resident tag audit: {ok_count}/{len(checked)} residents carry required tags ({detail})",
+            )
+
+        # Missing tags — critical. Emit one summary with all gaps so the
+        # finding is one row in the chime block, not N rows.
+        gap_parts = sorted(f"{label}:[{','.join(tags)}]" for label, tags in missing.items())
+        required = ",".join(data.get("required_tags") or [])
+        return CheckResult(
+            ok=False,
+            summary=(
+                f"Resident tag gap — {len(missing)} resident(s) missing required tags "
+                f"[{required}]: {'; '.join(gap_parts)}"
+            ),
+            detail={"missing": missing, "required_tags": data.get("required_tags")},
+            severity="critical",
+            fingerprint_key=f"resident_tag_gap:{'+'.join(sorted(missing.keys()))}",
+        )

--- a/agents/vigil/tests/test_checks_resident_tag_hygiene.py
+++ b/agents/vigil/tests/test_checks_resident_tag_hygiene.py
@@ -1,0 +1,154 @@
+"""Tests for the ResidentTagHygiene Vigil check."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+def _reset_registry():
+    from agents.vigil.checks import registry
+    registry._CHECKS.clear()
+    registry._LOADED = False
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    _reset_registry()
+    yield
+    _reset_registry()
+
+
+def test_resident_tag_hygiene_identity():
+    from agents.vigil.checks.resident_tag_hygiene import ResidentTagHygiene
+
+    check = ResidentTagHygiene()
+    assert check.name == "resident_tag_hygiene"
+    assert check.service_key == "governance"
+
+
+def test_hygiene_ok_when_no_tags_missing(monkeypatch):
+    from agents.vigil.checks import resident_tag_hygiene
+
+    monkeypatch.setattr(
+        resident_tag_hygiene,
+        "fetch_tag_audit",
+        lambda url, timeout=5.0: (
+            True,
+            {
+                "success": True,
+                "required_tags": ["autonomous", "persistent"],
+                "checked": ["Lumen", "Sentinel", "Steward", "Vigil", "Watcher"],
+                "missing": {},
+                "ok_count": 5,
+            },
+            "18ms",
+        ),
+    )
+
+    result = asyncio.run(resident_tag_hygiene.ResidentTagHygiene().run())
+    assert result.ok is True
+    assert "5/5" in result.summary
+
+
+def test_hygiene_critical_when_tags_missing(monkeypatch):
+    from agents.vigil.checks import resident_tag_hygiene
+
+    monkeypatch.setattr(
+        resident_tag_hygiene,
+        "fetch_tag_audit",
+        lambda url, timeout=5.0: (
+            True,
+            {
+                "success": True,
+                "required_tags": ["autonomous", "persistent"],
+                "checked": ["Vigil", "Watcher"],
+                "missing": {"Watcher": ["autonomous", "persistent"]},
+                "ok_count": 1,
+            },
+            "22ms",
+        ),
+    )
+
+    result = asyncio.run(resident_tag_hygiene.ResidentTagHygiene().run())
+    assert result.ok is False
+    assert result.severity == "critical"
+    assert "Watcher" in result.summary
+    assert "autonomous" in result.summary
+    assert "persistent" in result.summary
+    assert result.fingerprint_key == "resident_tag_gap:Watcher"
+
+
+def test_hygiene_multiple_residents_missing_compressed_summary(monkeypatch):
+    """Gaps across multiple residents collapse into one finding row."""
+    from agents.vigil.checks import resident_tag_hygiene
+
+    monkeypatch.setattr(
+        resident_tag_hygiene,
+        "fetch_tag_audit",
+        lambda url, timeout=5.0: (
+            True,
+            {
+                "success": True,
+                "required_tags": ["autonomous", "persistent"],
+                "checked": ["Vigil", "Sentinel", "Watcher"],
+                "missing": {"Sentinel": ["autonomous"], "Watcher": ["autonomous", "persistent"]},
+                "ok_count": 1,
+            },
+            "15ms",
+        ),
+    )
+
+    result = asyncio.run(resident_tag_hygiene.ResidentTagHygiene().run())
+    assert result.ok is False
+    assert result.fingerprint_key == "resident_tag_gap:Sentinel+Watcher"
+    assert result.detail["missing"] == {
+        "Sentinel": ["autonomous"],
+        "Watcher": ["autonomous", "persistent"],
+    }
+
+
+def test_hygiene_endpoint_unreachable_degrades_to_warning(monkeypatch):
+    """Endpoint down = governance_health's problem; don't page twice as critical."""
+    from agents.vigil.checks import resident_tag_hygiene
+
+    monkeypatch.setattr(
+        resident_tag_hygiene,
+        "fetch_tag_audit",
+        lambda url, timeout=5.0: (False, {}, "unreachable"),
+    )
+
+    result = asyncio.run(resident_tag_hygiene.ResidentTagHygiene().run())
+    assert result.ok is False
+    assert result.severity == "warning"
+    assert result.fingerprint_key == "resident_tag_audit_unreachable"
+
+
+def test_hygiene_uses_configured_url(monkeypatch):
+    from agents.vigil.checks import resident_tag_hygiene
+
+    captured = {}
+
+    def fake(url, timeout=5.0):
+        captured["url"] = url
+        return True, {"missing": {}, "checked": [], "ok_count": 0, "required_tags": []}, "ok"
+
+    monkeypatch.setattr(resident_tag_hygiene, "fetch_tag_audit", fake)
+    monkeypatch.setattr(
+        resident_tag_hygiene,
+        "RESIDENT_TAG_AUDIT_URL",
+        "http://test.local:9999/v1/residents/tag_audit",
+    )
+
+    asyncio.run(resident_tag_hygiene.ResidentTagHygiene().run())
+    assert captured["url"] == "http://test.local:9999/v1/residents/tag_audit"
+
+
+def test_load_plugins_registers_resident_tag_hygiene(monkeypatch):
+    from agents.vigil.checks import registry
+
+    monkeypatch.delenv("VIGIL_CHECK_PLUGINS", raising=False)
+    registry.load_plugins()
+    names = [c.name for c in registry.all_checks()]
+    assert "resident_tag_hygiene" in names

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -1588,6 +1588,81 @@ async def http_residents(request):
 
 
 # ---------------------------------------------------------------------------
+# Resident tag-hygiene audit — Vigil consumes this to detect tag drift
+# ---------------------------------------------------------------------------
+
+# Tags every active resident must carry. Keep in sync with
+# agents/sdk/src/unitares_sdk/agent.py::RESIDENT_TAGS. The Steward regression
+# of 2026-04-20 was caused by this set drifting across onboarding paths —
+# this endpoint exists so future drift is detectable in production.
+RESIDENT_REQUIRED_TAGS: frozenset[str] = frozenset({"persistent", "autonomous"})
+
+
+async def http_resident_tag_audit(request):
+    """Report which active residents are missing required tags.
+
+    Response shape::
+
+        {
+            "success": true,
+            "required_tags": ["persistent", "autonomous"],
+            "checked": ["Vigil", "Sentinel", "Watcher", "Steward", "Lumen"],
+            "missing": {
+                "Watcher": ["autonomous"],
+                ...
+            },
+            "ok_count": 4
+        }
+
+    `missing` is empty when the fleet is healthy. Each entry is a sorted list
+    of tags that the resident SHOULD carry but doesn't. Residents absent from
+    the running fleet are absent from both ``checked`` and ``missing``.
+    """
+    http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
+    if not _check_http_auth(request, http_api_token=http_api_token):
+        return _http_unauthorized()
+
+    try:
+        from src.mcp_handlers.shared import lazy_mcp_server
+        from src.grounding.class_indicator import KNOWN_RESIDENT_LABELS
+
+        mcp_server_obj = lazy_mcp_server
+        checked: list[str] = []
+        missing: dict[str, list[str]] = {}
+
+        for meta in getattr(mcp_server_obj, "agent_metadata", {}).values():
+            label = getattr(meta, "label", None)
+            if not label or label not in KNOWN_RESIDENT_LABELS:
+                continue
+            if getattr(meta, "status", None) != "active":
+                continue
+            if label in checked:
+                # Duplicate rows for the same label (ghost identities) — only
+                # audit the first active one we encounter. Consistent with
+                # the label_to_meta deduplication http_residents does.
+                continue
+            checked.append(label)
+            have = set(getattr(meta, "tags", None) or [])
+            gap = sorted(RESIDENT_REQUIRED_TAGS - have)
+            if gap:
+                missing[label] = gap
+
+        return JSONResponse({
+            "success": True,
+            "required_tags": sorted(RESIDENT_REQUIRED_TAGS),
+            "checked": sorted(checked),
+            "missing": missing,
+            "ok_count": len(checked) - len(missing),
+        })
+    except Exception as exc:
+        logger.error("http_resident_tag_audit error: %s", exc)
+        return JSONResponse({
+            "success": False,
+            "error": str(exc),
+        }, status_code=500)
+
+
+# ---------------------------------------------------------------------------
 # Violation taxonomy endpoint — surface vocabulary for dashboards/bridges
 # ---------------------------------------------------------------------------
 
@@ -1783,6 +1858,7 @@ def register_http_routes(
     app.routes.append(Route("/api/activity", http_activity, methods=["GET"]))
     app.routes.append(Route("/api/incidents", http_incidents, methods=["GET"]))
     app.routes.append(Route("/v1/residents", http_residents, methods=["GET"]))
+    app.routes.append(Route("/v1/residents/tag_audit", http_resident_tag_audit, methods=["GET"]))
     app.routes.append(Route("/v1/taxonomy", http_taxonomy, methods=["GET"]))
     app.routes.append(WebSocketRoute("/ws/eisv", websocket_eisv_stream))
     app.routes.append(Route("/debug/memory", http_debug_memory, methods=["GET"]))

--- a/tests/test_http_resident_tag_audit.py
+++ b/tests/test_http_resident_tag_audit.py
@@ -1,0 +1,133 @@
+"""Tests for /v1/residents/tag_audit.
+
+Regression guard for the 2026-04-20 class of bug where Steward ran three days
+with `persistent` only (missing `autonomous`) because its onboarding path
+stamped a single tag. This endpoint surfaces the gap in one cycle instead.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+def _meta(label=None, tags=None, status="active"):
+    return SimpleNamespace(label=label, tags=tags or [], status=status)
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    monkeypatch.delenv("UNITARES_HTTP_API_TOKEN", raising=False)
+
+
+@pytest.fixture
+def audit_request():
+    """Minimal Starlette Request stand-in sufficient for _check_http_auth.
+
+    client.host must be a trusted-network address (localhost) for the auth
+    short-circuit to let the request through without a bearer token.
+    """
+    return SimpleNamespace(
+        headers={},
+        query_params={},
+        url=SimpleNamespace(path="/v1/residents/tag_audit"),
+        client=SimpleNamespace(host="127.0.0.1"),
+    )
+
+
+async def _run(server_stub, audit_request):
+    from src import http_api
+    with patch("src.mcp_handlers.shared.lazy_mcp_server", server_stub):
+        return await http_api.http_resident_tag_audit(audit_request)
+
+
+@pytest.mark.asyncio
+async def test_healthy_fleet_returns_empty_missing(audit_request):
+    server = SimpleNamespace(agent_metadata={
+        "uuid-vigil":    _meta("Vigil",    ["persistent", "autonomous", "cadence.30min"]),
+        "uuid-sentinel": _meta("Sentinel", ["persistent", "autonomous", "cadence.10min"]),
+        "uuid-watcher":  _meta("Watcher",  ["persistent", "autonomous"]),
+        "uuid-steward":  _meta("Steward",  ["persistent", "autonomous"]),
+        "uuid-lumen":    _meta("Lumen",    ["persistent", "autonomous", "embodied"]),
+    })
+    resp = await _run(server, audit_request)
+    body = resp.body.decode()
+
+    import json as _json
+    data = _json.loads(body)
+    assert data["success"] is True
+    assert data["missing"] == {}
+    assert data["ok_count"] == 5
+    assert sorted(data["checked"]) == ["Lumen", "Sentinel", "Steward", "Vigil", "Watcher"]
+    assert sorted(data["required_tags"]) == ["autonomous", "persistent"]
+
+
+@pytest.mark.asyncio
+async def test_single_tag_stamp_regression_surfaces(audit_request):
+    """The original Steward bug: stamped 'persistent' only."""
+    server = SimpleNamespace(agent_metadata={
+        "uuid-steward": _meta("Steward", ["persistent"]),
+        "uuid-vigil":   _meta("Vigil",   ["persistent", "autonomous"]),
+    })
+    resp = await _run(server, audit_request)
+    import json as _json
+    data = _json.loads(resp.body.decode())
+    assert data["missing"] == {"Steward": ["autonomous"]}
+    assert data["ok_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_empty_tags_reports_both_missing(audit_request):
+    """Watcher's original state: empty tags → both required tags missing."""
+    server = SimpleNamespace(agent_metadata={
+        "uuid-watcher": _meta("Watcher", []),
+    })
+    resp = await _run(server, audit_request)
+    import json as _json
+    data = _json.loads(resp.body.decode())
+    assert data["missing"] == {"Watcher": ["autonomous", "persistent"]}
+
+
+@pytest.mark.asyncio
+async def test_archived_residents_excluded(audit_request):
+    """Archived duplicates (ghost rows) must not trigger gap alerts."""
+    server = SimpleNamespace(agent_metadata={
+        "uuid-vigil-active":   _meta("Vigil", ["persistent", "autonomous"], status="active"),
+        "uuid-vigil-archived": _meta("Vigil", [], status="archived"),
+    })
+    resp = await _run(server, audit_request)
+    import json as _json
+    data = _json.loads(resp.body.decode())
+    assert data["missing"] == {}
+    assert data["checked"] == ["Vigil"]
+
+
+@pytest.mark.asyncio
+async def test_non_resident_agents_ignored(audit_request):
+    """Ephemeral / session-bound agents aren't residents and must not appear."""
+    server = SimpleNamespace(agent_metadata={
+        "uuid-ephemeral": _meta("some-random-session-agent", []),
+        "uuid-watcher":   _meta("Watcher", ["persistent", "autonomous"]),
+    })
+    resp = await _run(server, audit_request)
+    import json as _json
+    data = _json.loads(resp.body.decode())
+    assert data["checked"] == ["Watcher"]
+    assert data["missing"] == {}
+
+
+@pytest.mark.asyncio
+async def test_duplicate_active_resident_audited_once(audit_request):
+    """If two active rows share a label, only the first is checked — match
+    the label_to_meta dedup http_residents uses. Prevents a single resident
+    from appearing twice in the audit result."""
+    server = SimpleNamespace(agent_metadata={
+        "uuid-a": _meta("Vigil", ["persistent", "autonomous"]),
+        "uuid-b": _meta("Vigil", []),
+    })
+    resp = await _run(server, audit_request)
+    import json as _json
+    data = _json.loads(resp.body.decode())
+    assert data["checked"].count("Vigil") == 1


### PR DESCRIPTION
## Summary
- New Vigil built-in check `resident_tag_hygiene` emits a critical finding when any active resident is missing `persistent` or `autonomous`
- New server endpoint `GET /v1/residents/tag_audit` returns `{required_tags, checked, missing, ok_count}`
- 13 new tests, full suite 6696 passed

## Why
On 2026-04-20 Steward ran three days with zero `core.agent_state` rows because its onboarding path stamped `persistent` but forgot `autonomous` — pattern-4 loop-detection silently starved every 5-min sync. A single-tag omission in any of three onboarding paths (SDK, Watcher custom, Steward custom) can cause the same class of bug. This check surfaces it within one Vigil cycle.

## Design notes
- Endpoint reads `lazy_mcp_server.agent_metadata` rather than hitting Postgres — checks are lightweight and don't need psycopg2 added to Vigil
- `RESIDENT_REQUIRED_TAGS` in http_api.py documented as "keep in sync with `unitares_sdk.agent.RESIDENT_TAGS`" — simplest cross-module contract given the SDK/server boundary
- Endpoint unreachable degrades to `warning` to avoid double-paging when `governance_health` is already firing critical on the full service down
- Duplicate-label rows (ghost identities) audited once, matching `http_residents` dedup

## Test plan
- [x] Healthy fleet returns empty missing
- [x] Single-tag regression (Steward 2026-04-20) surfaces
- [x] Empty-tags regression (Watcher 2026-04-20) surfaces both missing
- [x] Archived ghost rows excluded
- [x] Non-resident agents ignored
- [x] Duplicate active labels audited once
- [x] Endpoint unreachable → warning, not critical
- [x] `load_plugins` registers the new check
- [x] `./scripts/dev/test-cache.sh` — 6696 passed, 33 skipped