### PR TITLE
feat(identity): R4.1 — verify_substrate_earned operational check

### DIFF
--- a/src/identity/__init__.py
+++ b/src/identity/__init__.py
@@ -1,0 +1,7 @@
+"""Identity module — substrate-earned-identity predicates and helpers.
+
+This package hosts pure functions that answer ontology questions about
+agent identity (see `docs/ontology/identity.md`). These are NOT MCP tool
+handlers; they are internal helpers callable from handlers, background
+tasks, and tests.
+"""

--- a/src/identity/substrate.py
+++ b/src/identity/substrate.py
@@ -1,0 +1,409 @@
+"""Substrate-Earned Identity — operational check for the R4 pattern.
+
+Implements `verify_substrate_earned(agent_uuid) -> dict`, the mechanical
+predicate that answers: "Does this agent meet the three conditions laid
+out in `docs/ontology/identity.md` Appendix: Pattern — Substrate-Earned
+Identity?"
+
+The three conditions (from the appendix) are:
+
+  1. Dedicated substrate — substrate uniquely associated with the role,
+     would be meaningfully altered by the agent's cessation.
+  2. Sustained behavioral consistency across restarts — observed behavior
+     remains within envelope across N ≥ threshold process-restarts.
+  3. Declared role continuity — agent declares which role it is adopting,
+     not merely carries a cosmetic harness label.
+
+This module is an internal predicate; it is called by S5 (resident-fork
+inversion) and future callers. It is NOT an MCP tool handler. Adding it
+to `src/mcp_handlers/` would conflate "checkable predicate" with "tool
+surface" and pull this into ship.sh's runtime path unnecessarily.
+
+Signal choices (documented because the appendix leaves them open):
+
+  - Dedicated substrate: we look for BOTH (a) a substrate-class tag
+    (`embodied` per paper §4, or the legacy `persistent` tag if paired
+    with an anchor), AND (b) a dedicated anchor file at
+    `~/.unitares/anchors/<label>.json` whose `agent_uuid` matches.
+    Shared-label residents without an anchor pairing fail (b). Purely
+    hardcoded UUIDs on ephemeral substrates (Claude Code tabs writing
+    `.unitares/session.json` with a pinned UUID) fail (a).
+  - Sustained behavior: `observation_count` on the trajectory current
+    (or genesis, if current is absent) must be >= N. Default N=5 is an
+    operator-configurable guess — see `DEFAULT_RESTART_THRESHOLD` and
+    the appendix "Open questions" section on N-selection.
+  - Declared role: `label` is non-empty, not "other", not a cosmetic
+    harness label (`claude_code`, `codex`, `Claude_Opus_*`, etc.), and
+    the agent has a class-bearing tag (`embodied`, `persistent`,
+    `ephemeral`).
+
+When a signal cannot be checked (DB unavailable, anchor dir missing,
+metadata absent), we return `earned: false` with an explanatory reason
+rather than fabricating confidence — the appendix's "fresh hardware
+deployment" case is the template.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from src.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+# Default restart-count threshold for condition 2. The appendix flags N as
+# class-conditional and empirically open; 5 is a conservative starting
+# point (enough to rule out single-boot flukes, low enough that Lumen's
+# existing tenure qualifies). Override via the `restart_threshold` arg.
+DEFAULT_RESTART_THRESHOLD = 5
+
+# Tags that signal a dedicated-substrate class per paper §4 taxonomy.
+# `embodied` is the strongest signal (hardware commitment). `persistent`
+# is accepted when paired with an anchor file (deployed-but-not-embodied
+# residents like Sentinel).
+SUBSTRATE_CLASS_TAGS = ("embodied", "persistent")
+
+# Tags that disqualify class-continuity (explicitly ephemeral).
+EPHEMERAL_CLASS_TAGS = ("ephemeral",)
+
+# Role labels that are cosmetic harness identifiers, not declared roles.
+# Matched case-insensitively against `label`.
+COSMETIC_LABEL_PATTERNS = (
+    re.compile(r"^claude[_\- ]code", re.IGNORECASE),
+    re.compile(r"^codex", re.IGNORECASE),
+    re.compile(r"^claude[_\- ]opus", re.IGNORECASE),
+    re.compile(r"^claude[_\- ]sonnet", re.IGNORECASE),
+    re.compile(r"^claude[_\- ]haiku", re.IGNORECASE),
+    re.compile(r"^gpt[_\- ]?\d", re.IGNORECASE),
+    re.compile(r"^other$", re.IGNORECASE),
+)
+
+
+def _default_anchors_dir() -> Path:
+    """Return the anchors directory path.
+
+    Override via `UNITARES_ANCHORS_DIR` env var; test harnesses use this
+    to point at a tmp directory.
+    """
+    env = os.environ.get("UNITARES_ANCHORS_DIR")
+    if env:
+        return Path(env)
+    return Path.home() / ".unitares" / "anchors"
+
+
+def _label_is_cosmetic(label: Optional[str]) -> bool:
+    """True if `label` is a cosmetic harness label (not a declared role)."""
+    if not label:
+        return True
+    label_stripped = label.strip()
+    if not label_stripped:
+        return True
+    return any(pat.match(label_stripped) for pat in COSMETIC_LABEL_PATTERNS)
+
+
+def _find_anchor_for_uuid(
+    agent_uuid: str,
+    anchors_dir: Optional[Path] = None,
+) -> Optional[Dict[str, Any]]:
+    """Return anchor payload if any file in anchors_dir contains this UUID.
+
+    The anchors directory holds one JSON file per substrate-committed
+    role (e.g., `watcher.json`, `vigil.json`). A match pairs the agent's
+    UUID with a dedicated filesystem slot owned by the role — i.e., the
+    declarative form of substrate-earned identity.
+
+    Returns the parsed JSON (including the matched file name via
+    `_anchor_file` key) on match, None otherwise.
+    """
+    d = anchors_dir if anchors_dir is not None else _default_anchors_dir()
+    try:
+        if not d.is_dir():
+            return None
+    except OSError:
+        return None
+
+    try:
+        entries = sorted(d.iterdir())
+    except OSError:
+        return None
+
+    for entry in entries:
+        if not entry.is_file() or entry.suffix != ".json":
+            continue
+        try:
+            with entry.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except (OSError, ValueError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        candidate = (
+            data.get("agent_uuid")
+            or data.get("agent_id")
+            or data.get("uuid")
+        )
+        if candidate == agent_uuid:
+            payload = dict(data)
+            payload["_anchor_file"] = entry.name
+            return payload
+    return None
+
+
+def _has_substrate_class_tag(tags: Iterable[str]) -> Optional[str]:
+    """Return the first substrate-class tag present, or None."""
+    tag_set = {t for t in tags if isinstance(t, str)}
+    for tag in SUBSTRATE_CLASS_TAGS:
+        if tag in tag_set:
+            return tag
+    return None
+
+
+def _has_ephemeral_tag(tags: Iterable[str]) -> bool:
+    tag_set = {t for t in tags if isinstance(t, str)}
+    return any(t in tag_set for t in EPHEMERAL_CLASS_TAGS)
+
+
+def _observation_count_from_metadata(metadata: Dict[str, Any]) -> int:
+    """Extract observation_count from trajectory current (preferred) or genesis."""
+    current = metadata.get("trajectory_current") or {}
+    if isinstance(current, dict):
+        count = current.get("observation_count")
+        if isinstance(count, int) and count > 0:
+            return count
+    genesis = metadata.get("trajectory_genesis") or {}
+    if isinstance(genesis, dict):
+        count = genesis.get("observation_count")
+        if isinstance(count, int):
+            return count
+    return 0
+
+
+def evaluate_substrate_earned(
+    *,
+    agent_uuid: str,
+    label: Optional[str],
+    tags: List[str],
+    metadata: Dict[str, Any],
+    anchors_dir: Optional[Path] = None,
+    restart_threshold: int = DEFAULT_RESTART_THRESHOLD,
+) -> Dict[str, Any]:
+    """Pure evaluation of the three R4 conditions against inputs.
+
+    Prefer this entrypoint in tests — it takes no DB dependency. The
+    async `verify_substrate_earned` wrapper fetches `label`, `tags`, and
+    `metadata` from the governance DB and calls through to this.
+    """
+    reasons: List[str] = []
+    evidence: Dict[str, Any] = {
+        "agent_uuid": agent_uuid,
+        "label": label,
+        "tags": list(tags or []),
+        "restart_threshold": restart_threshold,
+    }
+
+    # ── Condition 1: Dedicated substrate ────────────────────────────────
+    class_tag = _has_substrate_class_tag(tags or [])
+    ephemeral = _has_ephemeral_tag(tags or [])
+    anchor = _find_anchor_for_uuid(agent_uuid, anchors_dir=anchors_dir)
+
+    evidence["substrate_class_tag"] = class_tag
+    evidence["has_ephemeral_tag"] = ephemeral
+    evidence["anchor_file"] = anchor.get("_anchor_file") if anchor else None
+
+    if ephemeral:
+        dedicated_substrate = False
+        reasons.append(
+            "dedicated_substrate=false: agent carries the `ephemeral` class tag — "
+            "ephemeral agents are disqualified by construction."
+        )
+    elif class_tag == "embodied":
+        # `embodied` is the strongest signal (hardware commitment, per
+        # axiom #11). It passes on its own; anchor file is corroborative
+        # but not required (some embodied deployments predate the anchor
+        # convention).
+        dedicated_substrate = True
+        reasons.append(
+            "dedicated_substrate=true: agent has the `embodied` class tag "
+            "(hardware commitment per paper §4 / ontology axiom #11)."
+        )
+    elif class_tag == "persistent" and anchor is not None:
+        dedicated_substrate = True
+        reasons.append(
+            f"dedicated_substrate=true: agent has the `persistent` class tag "
+            f"and a dedicated anchor at {anchor['_anchor_file']} pairing the "
+            f"role label with this UUID."
+        )
+    elif class_tag == "persistent" and anchor is None:
+        dedicated_substrate = False
+        reasons.append(
+            "dedicated_substrate=false: agent has the `persistent` class tag "
+            "but no anchor file pairs its UUID with a dedicated substrate slot. "
+            "Shared-label residents require an anchor pairing to distinguish "
+            "from per-instance collisions."
+        )
+    elif anchor is not None and class_tag is None:
+        dedicated_substrate = False
+        reasons.append(
+            f"dedicated_substrate=false: anchor at {anchor['_anchor_file']} "
+            f"pairs a UUID but the agent carries no substrate-class tag "
+            f"(`embodied` or `persistent`). An anchor without a class tag is "
+            f"a pinned UUID, not a substrate commitment."
+        )
+    else:
+        dedicated_substrate = False
+        reasons.append(
+            "dedicated_substrate=false: no substrate-class tag "
+            "(`embodied`/`persistent`) and no anchor file pairs this UUID with "
+            "a dedicated slot."
+        )
+
+    # ── Condition 2: Sustained behavioral consistency ────────────────────
+    observation_count = _observation_count_from_metadata(metadata or {})
+    evidence["observation_count"] = observation_count
+
+    if observation_count >= restart_threshold:
+        sustained_behavior = True
+        reasons.append(
+            f"sustained_behavior=true: observation_count={observation_count} "
+            f"meets threshold N={restart_threshold}."
+        )
+    else:
+        sustained_behavior = False
+        if observation_count == 0:
+            reasons.append(
+                f"sustained_behavior=false: no trajectory data recorded "
+                f"(observation_count=0). Insufficient tenure — fresh substrates "
+                f"operate under the default per-instance-with-lineage rule "
+                f"until they accrue N>={restart_threshold} observations."
+            )
+        else:
+            reasons.append(
+                f"sustained_behavior=false: observation_count={observation_count} "
+                f"below threshold N={restart_threshold}."
+            )
+
+    # ── Condition 3: Declared role continuity ────────────────────────────
+    cosmetic = _label_is_cosmetic(label)
+    has_class_tag = class_tag is not None
+
+    evidence["label_is_cosmetic"] = cosmetic
+    evidence["has_class_tag"] = has_class_tag
+
+    if cosmetic:
+        declared_role = False
+        if not label or not label.strip():
+            reasons.append(
+                "declared_role=false: agent has no label — no role declared."
+            )
+        else:
+            reasons.append(
+                f"declared_role=false: label {label!r} is a cosmetic harness "
+                f"identifier, not a declared role."
+            )
+    elif not has_class_tag:
+        declared_role = False
+        reasons.append(
+            f"declared_role=false: label {label!r} is non-cosmetic but the "
+            f"agent carries no class-bearing tag (`embodied`/`persistent`/"
+            f"`ephemeral`); role declaration requires both a label and a "
+            f"class commitment."
+        )
+    else:
+        declared_role = True
+        reasons.append(
+            f"declared_role=true: label {label!r} is a declared role "
+            f"paired with class tag `{class_tag}`."
+        )
+
+    earned = dedicated_substrate and sustained_behavior and declared_role
+
+    return {
+        "earned": earned,
+        "conditions": {
+            "dedicated_substrate": dedicated_substrate,
+            "sustained_behavior": sustained_behavior,
+            "declared_role": declared_role,
+        },
+        "reasons": reasons,
+        "evidence": evidence,
+    }
+
+
+async def verify_substrate_earned(
+    agent_uuid: str,
+    *,
+    restart_threshold: int = DEFAULT_RESTART_THRESHOLD,
+    anchors_dir: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Verify the R4 substrate-earned-identity pattern for an agent.
+
+    Async wrapper over `evaluate_substrate_earned` that fetches the
+    label, tags, and identity-metadata from the governance DB.
+
+    Returns the same shape as `evaluate_substrate_earned`. On DB-lookup
+    failure, returns `earned: false` with an explanatory reason — the
+    appendix's guidance is to refuse to fabricate confidence when data
+    is insufficient.
+    """
+    try:
+        from src.db import get_db
+
+        db = get_db()
+        agent = await db.get_agent(agent_uuid)
+        identity = await db.get_identity(agent_uuid)
+    except Exception as e:
+        logger.warning(
+            f"[substrate_earned] DB lookup failed for {agent_uuid[:8]}...: {e}"
+        )
+        return {
+            "earned": False,
+            "conditions": {
+                "dedicated_substrate": False,
+                "sustained_behavior": False,
+                "declared_role": False,
+            },
+            "reasons": [
+                f"cannot verify: DB lookup failed ({type(e).__name__}). "
+                f"Conservative default: earned=false."
+            ],
+            "evidence": {"agent_uuid": agent_uuid, "error": str(e)},
+        }
+
+    if not agent:
+        return {
+            "earned": False,
+            "conditions": {
+                "dedicated_substrate": False,
+                "sustained_behavior": False,
+                "declared_role": False,
+            },
+            "reasons": [
+                f"cannot verify: agent {agent_uuid[:8]}... not found in "
+                f"core.agents. Conservative default: earned=false."
+            ],
+            "evidence": {"agent_uuid": agent_uuid, "agent_found": False},
+        }
+
+    label = agent.get("label") if isinstance(agent, dict) else None
+    tags = agent.get("tags") if isinstance(agent, dict) else None
+    metadata = getattr(identity, "metadata", None) if identity else None
+
+    return evaluate_substrate_earned(
+        agent_uuid=agent_uuid,
+        label=label,
+        tags=tags or [],
+        metadata=metadata or {},
+        anchors_dir=anchors_dir,
+        restart_threshold=restart_threshold,
+    )
+
+
+__all__ = [
+    "DEFAULT_RESTART_THRESHOLD",
+    "evaluate_substrate_earned",
+    "verify_substrate_earned",
+]

--- a/tests/test_substrate_earned.py
+++ b/tests/test_substrate_earned.py
@@ -1,0 +1,401 @@
+"""Tests for `src/identity/substrate.py` — R4 operational check.
+
+Exercises the synthetic test cases called out in the ontology appendix
+(`docs/ontology/identity.md` — "Appendix: Pattern — Substrate-Earned
+Identity"):
+
+  - Lumen-like: embodied + sustained + declared → earned=true
+  - Claude Code tab with hardcoded UUID but no substrate → earned=false
+  - Shared-label resident (persistent but no anchor) → earned=false
+  - Fresh hardware deployment (would-be substrate, N=0) → earned=false
+
+Tests use the pure `evaluate_substrate_earned` entrypoint and a tmp
+anchors directory fixture — no DB dependency.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.identity.substrate import (  # noqa: E402
+    DEFAULT_RESTART_THRESHOLD,
+    evaluate_substrate_earned,
+    verify_substrate_earned,
+)
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def anchors_dir(tmp_path):
+    """A tmp anchors directory that tests populate as needed."""
+    d = tmp_path / "anchors"
+    d.mkdir()
+    return d
+
+
+def _write_anchor(anchors_dir: Path, role: str, agent_uuid: str) -> Path:
+    path = anchors_dir / f"{role}.json"
+    payload = {
+        "client_session_id": f"agent-{agent_uuid[:8]}",
+        "agent_uuid": agent_uuid,
+    }
+    path.write_text(json.dumps(payload))
+    return path
+
+
+def _metadata_with_observations(n: int) -> dict:
+    """Fake identity metadata carrying a trajectory with N observations."""
+    return {
+        "trajectory_current": {
+            "observation_count": n,
+            "identity_confidence": 0.7,
+        },
+        "trajectory_genesis": {
+            "observation_count": max(1, n // 2),
+            "identity_confidence": 0.5,
+        },
+    }
+
+
+# ── Canonical test cases (appendix) ──────────────────────────────────────
+
+
+class TestAppendixCases:
+    """The four synthetic cases from the ontology appendix."""
+
+    def test_lumen_like_passes(self, anchors_dir):
+        """Embodied + sustained + declared role → earned=true."""
+        uuid = "b2d5c0e0-1111-2222-3333-444444444444"
+        _write_anchor(anchors_dir, "lumen", uuid)
+
+        result = evaluate_substrate_earned(
+            agent_uuid=uuid,
+            label="Lumen",
+            tags=["embodied", "resident"],
+            metadata=_metadata_with_observations(42),
+            anchors_dir=anchors_dir,
+        )
+
+        assert result["earned"] is True
+        c = result["conditions"]
+        assert c["dedicated_substrate"] is True
+        assert c["sustained_behavior"] is True
+        assert c["declared_role"] is True
+        # Evidence trail references the signals used
+        assert result["evidence"]["substrate_class_tag"] == "embodied"
+        assert result["evidence"]["observation_count"] == 42
+
+    def test_claude_code_tab_with_hardcoded_uuid_fails(self, anchors_dir):
+        """Hardcoded UUID but no dedicated substrate: no-substrate reason."""
+        uuid = "11111111-2222-3333-4444-555555555555"
+        # Tab has an anchor-like session file but no substrate-class tag
+        # (anchor alone is a pinned UUID, not substrate).
+        _write_anchor(anchors_dir, "claude_code_tab", uuid)
+
+        result = evaluate_substrate_earned(
+            agent_uuid=uuid,
+            label="Claude_Opus_4_7_20260419",  # cosmetic harness label
+            tags=[],
+            metadata=_metadata_with_observations(3),
+            anchors_dir=anchors_dir,
+        )
+
+        assert result["earned"] is False
+        assert result["conditions"]["dedicated_substrate"] is False
+        assert result["conditions"]["declared_role"] is False
+        # Reason cites the no-substrate gap
+        joined = " | ".join(result["reasons"])
+        assert "dedicated_substrate=false" in joined
+        assert (
+            "no substrate-class tag" in joined
+            or "pinned UUID" in joined
+        )
+
+    def test_shared_label_resident_without_anchor_fails(self, anchors_dir):
+        """Vigil-like: `persistent` tag but no anchor pairing → earned=false."""
+        uuid = "22222222-3333-4444-5555-666666666666"
+        # No anchor file written for this agent's UUID.
+
+        result = evaluate_substrate_earned(
+            agent_uuid=uuid,
+            label="Vigil",
+            tags=["persistent", "resident"],
+            metadata=_metadata_with_observations(20),
+            anchors_dir=anchors_dir,
+        )
+
+        assert result["earned"] is False
+        assert result["conditions"]["dedicated_substrate"] is False
+        joined = " | ".join(result["reasons"])
+        assert "no anchor file" in joined or "anchor pairing" in joined
+
+    def test_shared_label_resident_with_anchor_passes(self, anchors_dir):
+        """Vigil-like: `persistent` PAIRED with an anchor → earned=true."""
+        uuid = "33333333-4444-5555-6666-777777777777"
+        _write_anchor(anchors_dir, "vigil", uuid)
+
+        result = evaluate_substrate_earned(
+            agent_uuid=uuid,
+            label="Vigil",
+            tags=["persistent", "resident"],
+            metadata=_metadata_with_observations(20),
+            anchors_dir=anchors_dir,
+        )
+
+        assert result["earned"] is True
+        assert result["conditions"]["dedicated_substrate"] is True
+        assert result["evidence"]["anchor_file"] == "vigil.json"
+
+    def test_fresh_hardware_deployment_fails(self, anchors_dir):
+        """New embodied agent on day 1: substrate + role OK, tenure N=0 → earned=false."""
+        uuid = "44444444-5555-6666-7777-888888888888"
+        _write_anchor(anchors_dir, "lumen2", uuid)
+
+        result = evaluate_substrate_earned(
+            agent_uuid=uuid,
+            label="Lumen2",
+            tags=["embodied", "resident"],
+            metadata={},  # no trajectory yet
+            anchors_dir=anchors_dir,
+        )
+
+        assert result["earned"] is False
+        assert result["conditions"]["dedicated_substrate"] is True
+        assert result["conditions"]["declared_role"] is True
+        assert result["conditions"]["sustained_behavior"] is False
+        joined = " | ".join(result["reasons"])
+        assert "sustained_behavior=false" in joined
+        assert "tenure" in joined.lower() or "observation_count=0" in joined
+
+
+# ── Edge cases ───────────────────────────────────────────────────────────
+
+
+class TestEdgeCases:
+
+    def test_ephemeral_tag_disqualifies_substrate(self, anchors_dir):
+        """An `ephemeral`-tagged agent fails condition 1 even with an anchor."""
+        uuid = "55555555-6666-7777-8888-999999999999"
+        _write_anchor(anchors_dir, "ghost", uuid)
+
+        result = evaluate_substrate_earned(
+            agent_uuid=uuid,
+            label="Ghost",
+            tags=["ephemeral"],
+            metadata=_metadata_with_observations(100),
+            anchors_dir=anchors_dir,
+        )
+
+        assert result["earned"] is False
+        assert result["conditions"]["dedicated_substrate"] is False
+        joined = " | ".join(result["reasons"])
+        assert "ephemeral" in joined
+
+    def test_missing_label_fails_declared_role(self, anchors_dir):
+        """Empty label → declared_role=false."""
+        uuid = "66666666-7777-8888-9999-aaaaaaaaaaaa"
+        _write_anchor(anchors_dir, "lumen3", uuid)
+
+        result = evaluate_substrate_earned(
+            agent_uuid=uuid,
+            label=None,
+            tags=["embodied"],
+            metadata=_metadata_with_observations(10),
+            anchors_dir=anchors_dir,
+        )
+
+        assert result["earned"] is False
+        assert result["conditions"]["declared_role"] is False
+
+    def test_other_label_fails_declared_role(self, anchors_dir):
+        """label='other' is the placeholder default; fails declared_role."""
+        uuid = "77777777-8888-9999-aaaa-bbbbbbbbbbbb"
+        _write_anchor(anchors_dir, "other", uuid)
+
+        result = evaluate_substrate_earned(
+            agent_uuid=uuid,
+            label="other",
+            tags=["embodied"],
+            metadata=_metadata_with_observations(10),
+            anchors_dir=anchors_dir,
+        )
+
+        assert result["earned"] is False
+        assert result["conditions"]["declared_role"] is False
+
+    def test_cosmetic_model_label_fails(self, anchors_dir):
+        """`Claude_Opus_*` is a harness cosmetic label — not a declared role."""
+        uuid = "88888888-9999-aaaa-bbbb-cccccccccccc"
+
+        result = evaluate_substrate_earned(
+            agent_uuid=uuid,
+            label="Claude_Opus_4_7_20260419",
+            tags=["embodied"],
+            metadata=_metadata_with_observations(10),
+            anchors_dir=anchors_dir,
+        )
+
+        assert result["conditions"]["declared_role"] is False
+
+    def test_declared_role_requires_class_tag(self, anchors_dir):
+        """Non-cosmetic label without class tag → declared_role=false.
+
+        Paper §4 class taxonomy is the commitment; label alone is
+        insufficient.
+        """
+        uuid = "99999999-aaaa-bbbb-cccc-dddddddddddd"
+
+        result = evaluate_substrate_earned(
+            agent_uuid=uuid,
+            label="MyCustomAgent",
+            tags=["some_arbitrary_tag"],
+            metadata=_metadata_with_observations(10),
+            anchors_dir=anchors_dir,
+        )
+
+        assert result["conditions"]["declared_role"] is False
+
+    def test_configurable_restart_threshold(self, anchors_dir):
+        """`restart_threshold=1` should let low-N substrates pass."""
+        uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        _write_anchor(anchors_dir, "lumen4", uuid)
+
+        result = evaluate_substrate_earned(
+            agent_uuid=uuid,
+            label="Lumen4",
+            tags=["embodied"],
+            metadata=_metadata_with_observations(1),
+            anchors_dir=anchors_dir,
+            restart_threshold=1,
+        )
+
+        assert result["earned"] is True
+        assert result["evidence"]["restart_threshold"] == 1
+
+    def test_default_threshold_exposed(self):
+        assert DEFAULT_RESTART_THRESHOLD == 5
+
+    def test_anchor_accepts_agent_id_key(self, anchors_dir):
+        """Anchors with `agent_id` instead of `agent_uuid` also match."""
+        uuid = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff"
+        path = anchors_dir / "alt.json"
+        path.write_text(json.dumps({"agent_id": uuid}))
+
+        result = evaluate_substrate_earned(
+            agent_uuid=uuid,
+            label="Alt",
+            tags=["persistent"],
+            metadata=_metadata_with_observations(10),
+            anchors_dir=anchors_dir,
+        )
+
+        assert result["conditions"]["dedicated_substrate"] is True
+        assert result["evidence"]["anchor_file"] == "alt.json"
+
+    def test_anchors_dir_missing_is_conservative(self, tmp_path):
+        """Non-existent anchors directory: no anchor match; persistent fails."""
+        missing = tmp_path / "does_not_exist"
+        uuid = "cccccccc-dddd-eeee-ffff-000000000000"
+
+        result = evaluate_substrate_earned(
+            agent_uuid=uuid,
+            label="Vigil",
+            tags=["persistent"],
+            metadata=_metadata_with_observations(10),
+            anchors_dir=missing,
+        )
+
+        assert result["conditions"]["dedicated_substrate"] is False
+        assert result["evidence"]["anchor_file"] is None
+
+    def test_result_shape_is_stable(self, anchors_dir):
+        """Result dict always has the four top-level keys."""
+        result = evaluate_substrate_earned(
+            agent_uuid="deadbeef-0000-0000-0000-000000000000",
+            label=None,
+            tags=[],
+            metadata={},
+            anchors_dir=anchors_dir,
+        )
+        assert set(result.keys()) == {"earned", "conditions", "reasons", "evidence"}
+        assert set(result["conditions"].keys()) == {
+            "dedicated_substrate",
+            "sustained_behavior",
+            "declared_role",
+        }
+        assert isinstance(result["reasons"], list)
+        assert isinstance(result["evidence"], dict)
+
+
+# ── Async wrapper ────────────────────────────────────────────────────────
+
+
+class TestVerifySubstrateEarnedAsync:
+
+    @pytest.mark.asyncio
+    async def test_agent_not_found_is_conservative(self, anchors_dir):
+        """Missing agent row → earned=false with cannot-verify reason."""
+        uuid = "dddddddd-eeee-ffff-0000-111111111111"
+
+        mock_db = MagicMock()
+        mock_db.get_agent = AsyncMock(return_value=None)
+        mock_db.get_identity = AsyncMock(return_value=None)
+
+        with patch("src.db.get_db", return_value=mock_db):
+            result = await verify_substrate_earned(
+                uuid, anchors_dir=anchors_dir
+            )
+
+        assert result["earned"] is False
+        joined = " | ".join(result["reasons"])
+        assert "not found" in joined
+        assert "cannot verify" in joined
+
+    @pytest.mark.asyncio
+    async def test_db_exception_is_conservative(self, anchors_dir):
+        """DB raises → earned=false; no confidence fabricated."""
+        uuid = "eeeeeeee-ffff-0000-1111-222222222222"
+
+        with patch("src.db.get_db", side_effect=RuntimeError("db down")):
+            result = await verify_substrate_earned(
+                uuid, anchors_dir=anchors_dir
+            )
+
+        assert result["earned"] is False
+        joined = " | ".join(result["reasons"])
+        assert "DB lookup failed" in joined
+
+    @pytest.mark.asyncio
+    async def test_happy_path_delegates_to_pure_evaluator(self, anchors_dir):
+        """Async path composes DB fetch + pure evaluator correctly."""
+        uuid = "ffffffff-0000-1111-2222-333333333333"
+        _write_anchor(anchors_dir, "lumen5", uuid)
+
+        identity_stub = MagicMock()
+        identity_stub.metadata = _metadata_with_observations(30)
+
+        mock_db = MagicMock()
+        mock_db.get_agent = AsyncMock(
+            return_value={"label": "Lumen5", "tags": ["embodied"]}
+        )
+        mock_db.get_identity = AsyncMock(return_value=identity_stub)
+
+        with patch("src.db.get_db", return_value=mock_db):
+            result = await verify_substrate_earned(
+                uuid, anchors_dir=anchors_dir
+            )
+
+        assert result["earned"] is True
+        assert result["conditions"]["dedicated_substrate"] is True
+        assert result["conditions"]["sustained_behavior"] is True
+        assert result["conditions"]["declared_role"] is True


### PR DESCRIPTION
## Summary

Implements R4.1 from `docs/ontology/plan.md` — operational check that determines whether an agent meets the three conditions for substrate-earned identity per the appendix of `docs/ontology/identity.md` ("Pattern — Substrate-Earned Identity"):

1. Dedicated substrate (hardware / DB schema / deployment slot uniquely associated with the role)
2. Sustained behavioral consistency across N restarts
3. Declared role continuity at onboard

Adds `src/identity/substrate.py` (the verification primitive) and `tests/test_substrate_earned.py` (covers Lumen-passes case + synthetic-fail cases per the appendix's test fixtures).

## Authoritative reference

- `docs/ontology/identity.md` — five-layer taxonomy + Pattern appendix
- `docs/ontology/plan.md` R4 row — Draft v1 landed 2026-04-21; this PR is the operational check (R4.1)

## Test plan

- [x] 18 unit tests passing locally (`pytest tests/test_substrate_earned.py`)
- [ ] Full suite green via CI
- [ ] Verify Lumen's UUID passes the check against current DB state (post-merge sanity)