### PR TITLE
fix(identity): persist declared lineage on onboard(force_new=true)

### DIFF
--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -1396,21 +1396,46 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
             logger.error(f"[ONBOARD] Failed to persist fresh identity: {e}")
             return error_response(f"Failed to persist identity: {e}")
     else:
-        # STEP 2b: Get or create identity (using v2 logic)
+        # STEP 2b: Get or create identity (using v2 logic).
+        # The force_new branch persists via resolve_session_identity's own
+        # create path, which — before 2026-04-21 — silently dropped declared
+        # lineage. parent_agent_id / spawn_reason are now threaded through so
+        # the create path mirrors ensure_agent_persisted's write.
         try:
-            # resolve_session_identity creates new if needed (PATH 3)
-            # We use force_new=True if requested to bypass cache/DB lookup
             identity = await resolve_session_identity(
                 session_key,
                 persist=True,  # Onboard always persists (it's an explicit "I am here" action)
                 model_type=model_type,
                 client_hint=client_hint,
-                force_new=force_new
+                force_new=force_new,
+                parent_agent_id=_parent_agent_id,
+                spawn_reason=_spawn_reason,
             )
             agent_uuid = identity["agent_uuid"]
             agent_id = identity.get("agent_id", agent_uuid)
             is_new = identity.get("created", False) or force_new
             agent_label = identity.get("label")
+
+            # Mirror the created_fresh_identity branch: sync lineage into
+            # in-memory metadata (EISV inheritance) and create the SPAWNED
+            # edge in AGE. Without this the force_new branch would have DB
+            # lineage but no trajectory/graph continuity.
+            if is_new and _parent_agent_id:
+                try:
+                    from src.agent_metadata_persistence import get_or_create_metadata
+                    meta = get_or_create_metadata(agent_uuid)
+                    meta.parent_agent_id = _parent_agent_id
+                    meta.spawn_reason = _spawn_reason
+                except Exception as e:
+                    logger.debug(f"[ONBOARD] Could not sync parent to metadata (force_new branch): {e}")
+                try:
+                    from src.background_tasks import create_tracked_task
+                    create_tracked_task(
+                        _create_spawned_edge_bg(agent_uuid, _parent_agent_id, _spawn_reason),
+                        name="spawned_edge",
+                    )
+                except Exception as e:
+                    logger.debug(f"[ONBOARD] Could not schedule SPAWNED edge (force_new branch): {e}")
         except Exception as e:
             logger.error(f"onboard() failed to create identity: {e}")
             return error_response(f"Failed to create identity: {e}")

--- a/src/mcp_handlers/identity/resolution.py
+++ b/src/mcp_handlers/identity/resolution.py
@@ -255,6 +255,10 @@ async def resolve_session_identity(
 
     token_agent_uuid: Optional[str] = None,
 
+    parent_agent_id: Optional[str] = None,
+
+    spawn_reason: Optional[str] = None,
+
 ) -> Dict[str, Any]:
 
     """
@@ -713,12 +717,19 @@ async def resolve_session_identity(
         try:
             db = get_db()
 
-            # Create agent in PostgreSQL with UUID as key (label set atomically)
+            # Create agent in PostgreSQL with UUID as key (label set atomically).
+            # parent_agent_id / spawn_reason are the descriptive-stance lineage
+            # declaration (identity ontology v2 §Worked examples). They arrive
+            # from onboard(force_new=true, parent_agent_id=..., spawn_reason=...)
+            # and must be persisted or the ontology's only earned cross-process
+            # signal is theater — dogfood regression 2026-04-21.
             await db.upsert_agent(
                 agent_id=agent_uuid,  # UUID is the primary key
                 api_key="",  # Legacy field, not used
                 status="active",
                 label=label,  # Set auto-label at creation time
+                parent_agent_id=parent_agent_id,
+                spawn_reason=spawn_reason,
             )
 
             if label:
@@ -738,6 +749,7 @@ async def resolve_session_identity(
             await db.upsert_identity(
                 agent_id=agent_uuid,
                 api_key_hash="",
+                parent_agent_id=parent_agent_id,
                 metadata=identity_metadata,
             )
 

--- a/tests/test_identity_handlers.py
+++ b/tests/test_identity_handlers.py
@@ -1856,6 +1856,58 @@ class TestHandleOnboardV2:
         assert data["success"] is True
 
     @pytest.mark.asyncio
+    async def test_onboard_force_new_persists_parent_and_spawn_reason(
+        self, patch_onboard_deps, mock_db, mock_redis,
+    ):
+        """onboard(force_new=true, parent_agent_id=..., spawn_reason=...) must land lineage in PostgreSQL.
+
+        The force_new branch goes through resolve_session_identity, which — before
+        this fix — owned its own upsert path and silently dropped parent_agent_id
+        and spawn_reason. Under the identity ontology v2 (docs/ontology/identity.md)
+        lineage declaration at onboard is the **descriptive** floor: a fresh
+        process-instance that declares a predecessor must have that link persisted,
+        or the ontology's only earned cross-process signal (declared lineage) is
+        theater. Regression against dogfood finding 2026-04-21.
+        """
+        from src.mcp_handlers.identity.handlers import handle_onboard_v2
+
+        mock_redis.get.return_value = None
+        mock_db.get_session.return_value = None
+        mock_db.find_agent_by_label.return_value = None
+        mock_db.get_identity.return_value = SimpleNamespace(identity_id="new-ident", metadata={})
+
+        parent_uuid = "da300b4a-5320-480d-bac3-d029cd062842"
+        spawn_reason = "new_session"
+
+        result = await handle_onboard_v2({
+            "client_session_id": "onboard-force-lineage",
+            "force_new": True,
+            "parent_agent_id": parent_uuid,
+            "spawn_reason": spawn_reason,
+        })
+        data = parse_result(result)
+
+        assert data["success"] is True
+        assert data["is_new"] is True
+
+        agent_calls = mock_db.upsert_agent.await_args_list
+        assert agent_calls, "upsert_agent must be called for a fresh force_new identity"
+        agent_kwargs = agent_calls[0].kwargs
+        assert agent_kwargs.get("parent_agent_id") == parent_uuid, (
+            f"parent_agent_id must reach core.agents on force_new; got {agent_kwargs!r}"
+        )
+        assert agent_kwargs.get("spawn_reason") == spawn_reason, (
+            f"spawn_reason must reach core.agents on force_new; got {agent_kwargs!r}"
+        )
+
+        identity_calls = mock_db.upsert_identity.await_args_list
+        assert identity_calls, "upsert_identity must be called for a fresh force_new identity"
+        identity_kwargs = identity_calls[0].kwargs
+        assert identity_kwargs.get("parent_agent_id") == parent_uuid, (
+            f"parent_agent_id must reach core.identities on force_new; got {identity_kwargs!r}"
+        )
+
+    @pytest.mark.asyncio
     async def test_onboard_with_model_type_gemini(self, patch_onboard_deps, mock_db, mock_redis):
         """Model normalization for gemini in onboard flow."""
         from src.mcp_handlers.identity.handlers import handle_onboard_v2


### PR DESCRIPTION
## Summary

- `onboard(force_new=true, parent_agent_id=..., spawn_reason=...)` silently dropped both fields — the row in `core.agents` landed with NULL lineage despite the columns existing.
- Fix threads `parent_agent_id` / `spawn_reason` through `resolve_session_identity` into `db.upsert_agent` + `db.upsert_identity`, mirroring what `ensure_agent_persisted` already does on the non-force_new create path.
- Also mirrors the in-memory metadata sync + SPAWNED-edge creation that the `created_fresh_identity` branch performs, so the force_new branch isn't half-declared.

## Why this matters

Identity ontology v2 (`docs/ontology/identity.md`, added today) makes **declared lineage** the descriptive-stance floor: a fresh process-instance doesn't claim resume, it declares a predecessor. The onboard surface accepted those params but the force_new write path dropped them — the most common path to a fresh identity (agent explicitly breaking from fingerprint-pin) was the exact path where lineage became theater.

Dogfooded 2026-04-21 against a freshly rebooted governance server; repro was straightforward: onboard with explicit lineage, then `SELECT parent_agent_id, spawn_reason FROM core.agents WHERE id = <uuid>` returns two NULLs.

## Scope notes

- **PR A only.** This is the mechanical write-path fix. The defaults flip (`resume=True → False`, `force_new=False → True`, remove IP/UA fingerprint from the resolver chain) is deliberately deferred to PR B — it touches the identity_hijack pipeline, session cache, and every auto-resume path, and deserves its own review surface.
- **Test added.** `test_onboard_force_new_persists_parent_and_spawn_reason` asserts both `upsert_agent` and `upsert_identity` receive lineage on the force_new branch. Red→green verified locally.
- **Regression suite.** 400 identity-adjacent tests + full 6715-test suite pass (`./scripts/dev/test-cache.sh --fresh`).

## Test plan

- [x] New test fails on master, passes on this branch
- [x] `tests/test_identity_handlers.py` + 7 adjacent identity/thread/spawned-edge suites all pass
- [x] `./scripts/dev/test-cache.sh --fresh` → 6715 passed
- [ ] Post-merge: re-run dogfood (`onboard(force_new=true, parent_agent_id=...)` → confirm `core.agents` row shows lineage)