### PR TITLE
fix(identity): retire IP:UA fingerprint pin as implicit resume path

### DIFF
--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -972,20 +972,22 @@ def session_fingerprint_check_mode() -> str:
 #   "off"    — skip the check entirely; pin-fallback resume proceeds silently
 #   "log"    — emit [PATH2_IPUA_PIN_RESUME] + identity_hijack_suspected
 #              broadcast when onboard() hits the pin fallback with no proof;
-#              resume still proceeds (default — observation phase)
+#              resume still proceeds (observation phase — pre-2026-04-21 default)
 #   "strict" — same events, plus force resume=False so the onboard mints a
 #              fresh identity instead of silently adopting the pinned UUID.
 #              The pin itself is NOT deleted — the legitimate owner can still
 #              resume by presenting a continuity_token or agent_uuid.
+#              (current default — identity ontology v2 §85 retires implicit
+#              cross-process-instance identity via fingerprint pin)
 #
 # Override: UNITARES_IPUA_PIN_CHECK env var.
 IPUA_PIN_CHECK_MODE: str = os.getenv(
-    "UNITARES_IPUA_PIN_CHECK", "log"
+    "UNITARES_IPUA_PIN_CHECK", "strict"
 ).strip().lower()
 
 _VALID_IPUA_PIN_MODES = frozenset({"off", "log", "strict"})
 if IPUA_PIN_CHECK_MODE not in _VALID_IPUA_PIN_MODES:
-    IPUA_PIN_CHECK_MODE = "log"
+    IPUA_PIN_CHECK_MODE = "strict"
 
 
 def ipua_pin_check_mode() -> str:
@@ -993,4 +995,4 @@ def ipua_pin_check_mode() -> str:
     m = os.getenv(
         "UNITARES_IPUA_PIN_CHECK", IPUA_PIN_CHECK_MODE
     ).strip().lower()
-    return m if m in _VALID_IPUA_PIN_MODES else "log"
+    return m if m in _VALID_IPUA_PIN_MODES else "strict"

--- a/tests/test_identity_path2_ipua_pin.py
+++ b/tests/test_identity_path2_ipua_pin.py
@@ -52,6 +52,50 @@ def broadcaster_stub(captured_events):
 
 class TestPath2IpuaPinCheck:
     @pytest.mark.asyncio
+    async def test_default_mode_is_strict(
+        self, monkeypatch, captured_events, broadcaster_stub
+    ):
+        """With no env override, bare onboard() hitting the pin fallback must
+        flip resume=False so a fresh identity is minted.
+
+        Retires the PATH 2 IP:UA fingerprint pin as an implicit resume path.
+        Identity ontology v2 (§85, `docs/ontology/identity.md`) names
+        fingerprint-based cross-process-instance identity as performative —
+        fresh process-instance = fresh identity unless a cryptographic resume
+        signal is presented. Invariant #2 ("force_new is explicit opt-in
+        only") is preserved: the flip to resume=False produces a fresh mint
+        through the normal onboard flow, not via auto-force_new-as-fallback.
+        """
+        # Deliberate: no monkeypatch.setenv — exercise the compile-time default.
+
+        from src.mcp_handlers.identity import handlers as h_mod
+
+        with patch(
+            "src.mcp_handlers.context.get_session_resolution_source",
+            return_value="pinned_onboard_session",
+        ), patch.object(h_mod, "_broadcaster", return_value=broadcaster_stub):
+            new_resume = await h_mod._path2_ipua_pin_check(
+                arguments={},
+                base_session_key="fp-ipua-abcdef:claude",
+                force_new=False,
+                resume=True,
+            )
+
+        # Strict-by-default: resume forced False so the caller mints fresh.
+        assert new_resume is False, (
+            "Default mode must be 'strict' — bare onboard with no ownership "
+            "proof must not adopt a fingerprint-pinned UUID. Retires "
+            "§85 performative cross-process-instance identity. Got resume=True."
+        )
+
+        hijack_events = [
+            e for e in captured_events
+            if e.get("event_type") == "identity_hijack_suspected"
+        ]
+        assert hijack_events, "Default mode must still emit the event for visibility"
+        assert (hijack_events[0].get("payload") or {}).get("mode") == "strict"
+
+    @pytest.mark.asyncio
     async def test_log_mode_emits_and_leaves_resume_true(
         self, monkeypatch, captured_events, broadcaster_stub
     ):


### PR DESCRIPTION
## Summary

- Flip `UNITARES_IPUA_PIN_CHECK` default from `"log"` to `"strict"`.
- Bare `onboard()` calls that hit the PATH 2 pin fallback now mint a fresh identity instead of silently adopting a previously-pinned UUID by IP:UA fingerprint alone.
- The pin entry is NOT deleted; the legitimate owner can still resume by presenting `continuity_token` or `agent_uuid`.

## Why

Identity ontology v2 §85 (`docs/ontology/identity.md`, added 2026-04-21) names implicit cross-process-instance identity via fingerprint as **performative**. The PATH 2 pin fallback is the exact code path that produces it — a bare onboard with no ownership proof silently resumes whatever same-family agent most recently ran on the same IP. Retiring the default ("observe" → "enforce") satisfies the ontology's descriptive floor: fresh process-instance = fresh identity unless a cryptographic resume signal is presented.

## Reconciliation with invariant #2

Memory entry `identity-invariants.md` #2 says: *"force_new=true is explicit user opt-in only. Never automatic. [...] never as a fallback retry."*

This PR does **not** auto-force_new. The flip to `resume=False` inside `_path2_ipua_pin_check` takes the caller through the normal onboard creation flow, not through a force_new retry. `force_new` remains the explicit user opt-in for "I want fresh even when a valid resume signal is present." The change narrows what counts as a "valid resume signal" — fingerprint alone no longer qualifies, which is the ontology's claim, not an invariant violation.

## Scope

Single file flip + one new test asserting the compile-time default is now `strict`. The existing `log`-mode and `strict`-mode tests still cover the env-override behavior unchanged.

## What this does NOT do

- Does not touch `resume` or `force_new` schema defaults (invariant #2 preserved).
- Does not delete pin entries or break resume for agents presenting real proof.
- Does not flip `UNITARES_SESSION_FINGERPRINT_CHECK` (PATH 1 — separate path, separate scope).

## Rollback

Set `UNITARES_IPUA_PIN_CHECK=log` in the governance-mcp plist if the flip causes unexpected churn. No plist currently sets this var, so the flip is live on merge + restart.

## Test plan

- [x] New test fails on master (default was `"log"` → `resume=True`), passes on branch (default `"strict"` → `resume=False`).
- [x] Existing 10 tests in `test_identity_path2_ipua_pin.py` pass (log/strict/off/non-pin/proof/force_new paths unchanged).
- [x] Full suite: `./scripts/dev/test-cache.sh --fresh` → 6715 passed.
- [ ] Post-merge dogfood: `onboard()` with no proof on warm server → `is_new=true`, new UUID (not the prior fingerprint-matched one).

Paired with #97 (write-path lineage fix). Together they close the two load-bearing dogfood gaps between onboard and identity ontology v2.