### PR TITLE
fix(dashboard): add EISV history backfill for proxy polling path

### DIFF
--- a/dashboard/utils.js
+++ b/dashboard/utils.js
@@ -631,6 +631,7 @@ class EISVWebSocket {
             this._pollFallback = false;
             this.onStatusChange('connected');
             console.log('[WS] Connected to /ws/eisv');
+            this._backfillOnce();
         };
 
         this.ws.onmessage = (event) => {
@@ -673,9 +674,27 @@ class EISVWebSocket {
         this._pollFailures = 0;
         this.onStatusChange('polling');
         console.log('[WS] Polling /v1/eisv/latest every 30s');
-        // Poll immediately, then every 30s
+        // Backfill recent history, then poll immediately, then every 30s
+        this._backfillOnce();
         this._pollOnce();
         this._pollInterval = setInterval(() => this._pollOnce(), 30000);
+    }
+
+    async _backfillOnce() {
+        if (this._backfilled) return;
+        this._backfilled = true;
+        try {
+            const resp = await fetch(`${window.location.origin}/v1/eisv/recent?limit=120`);
+            if (!resp.ok) return;
+            const data = await resp.json();
+            const events = (data && Array.isArray(data.events)) ? data.events : [];
+            for (const evt of events) {
+                try { this.onUpdate(evt); } catch (_) { /* ignore per-event render errors */ }
+            }
+            console.log('[WS] Backfilled', events.length, 'EISV events');
+        } catch (e) {
+            console.debug('[WS] Backfill failed:', e);
+        }
     }
 
     async _pollOnce() {

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -887,6 +887,29 @@ async def http_eisv_latest(request):
     return JSONResponse({"type": "no_data", "message": "No EISV updates yet"}, status_code=200)
 
 
+async def http_eisv_recent(request):
+    """Return the last N eisv_update events in chronological order.
+
+    Backfill endpoint for dashboard clients that just connected — lets the
+    chart populate immediately from the broadcaster's ring buffer instead of
+    waiting for the next live check-in. Used both by WebSocket clients on
+    reconnect and polling-fallback clients (when upstream proxies block the
+    WS upgrade, e.g. Cloudflare tunnels without the WebSocket toggle).
+    """
+    try:
+        limit = int(request.query_params.get("limit", 120))
+    except (TypeError, ValueError):
+        limit = 120
+    limit = max(1, min(limit, 500))
+
+    events: list = []
+    for event in broadcaster_instance.event_history:
+        if isinstance(event, dict) and event.get("type") == "eisv_update":
+            events.append(event)
+    events = events[-limit:]
+    return JSONResponse({"type": "eisv_recent", "count": len(events), "events": events})
+
+
 # Events API endpoint for dashboard
 async def http_events(request):
     """Return recent governance events for dashboard."""
@@ -1849,6 +1872,7 @@ def register_http_routes(
     app.routes.append(Route("/health/deep", http_health_deep, methods=["GET"]))
     app.routes.append(Route("/metrics", http_metrics, methods=["GET"]))
     app.routes.append(Route("/v1/eisv/latest", http_eisv_latest, methods=["GET"]))
+    app.routes.append(Route("/v1/eisv/recent", http_eisv_recent, methods=["GET"]))
     app.routes.append(Route("/v1/lifecycle/recent", http_lifecycle_recent, methods=["GET"]))
     app.routes.append(Route("/api/events", http_events, methods=["GET"]))
     app.routes.append(Route("/api/findings", http_record_finding, methods=["POST"]))

--- a/tests/test_http_api_eisv_recent.py
+++ b/tests/test_http_api_eisv_recent.py
@@ -1,0 +1,75 @@
+"""Tests for GET /v1/eisv/recent — backfill endpoint for dashboard chart."""
+
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from src.http_api import http_eisv_recent
+from src import http_api
+
+
+def _make_event(agent_id, e_val, ts="2026-04-22T00:00:00+00:00"):
+    return {
+        "type": "eisv_update",
+        "agent_id": agent_id,
+        "agent_name": agent_id,
+        "timestamp": ts,
+        "eisv": {"E": e_val, "I": 0.5, "S": 0.1, "V": 0.0},
+        "coherence": 0.5,
+    }
+
+
+def _client():
+    app = Starlette(routes=[Route("/v1/eisv/recent", http_eisv_recent, methods=["GET"])])
+    return TestClient(app)
+
+
+def test_returns_eisv_events_in_chronological_order():
+    http_api.broadcaster_instance.event_history.clear()
+    http_api.broadcaster_instance.event_history.append(_make_event("a", 0.1))
+    http_api.broadcaster_instance.event_history.append(_make_event("b", 0.2))
+    http_api.broadcaster_instance.event_history.append(_make_event("c", 0.3))
+
+    r = _client().get("/v1/eisv/recent")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["type"] == "eisv_recent"
+    assert body["count"] == 3
+    assert [e["agent_id"] for e in body["events"]] == ["a", "b", "c"]
+
+
+def test_filters_out_non_eisv_events():
+    http_api.broadcaster_instance.event_history.clear()
+    http_api.broadcaster_instance.event_history.append(_make_event("a", 0.1))
+    http_api.broadcaster_instance.event_history.append({"type": "lifecycle_paused", "agent_id": "x"})
+    http_api.broadcaster_instance.event_history.append(_make_event("b", 0.2))
+
+    body = _client().get("/v1/eisv/recent").json()
+    assert body["count"] == 2
+    assert [e["agent_id"] for e in body["events"]] == ["a", "b"]
+
+
+def test_limit_parameter_is_honored_and_clamped():
+    http_api.broadcaster_instance.event_history.clear()
+    for i in range(10):
+        http_api.broadcaster_instance.event_history.append(_make_event(f"a{i}", i / 10))
+
+    body = _client().get("/v1/eisv/recent?limit=3").json()
+    assert body["count"] == 3
+    # Most recent three, in order
+    assert [e["agent_id"] for e in body["events"]] == ["a7", "a8", "a9"]
+
+
+def test_limit_is_clamped_to_max():
+    http_api.broadcaster_instance.event_history.clear()
+    body = _client().get("/v1/eisv/recent?limit=999999").json()
+    # Clamped internally; with an empty buffer just returns []
+    assert body["count"] == 0
+    assert body["events"] == []
+
+
+def test_invalid_limit_falls_back_to_default():
+    http_api.broadcaster_instance.event_history.clear()
+    http_api.broadcaster_instance.event_history.append(_make_event("a", 0.1))
+    body = _client().get("/v1/eisv/recent?limit=abc").json()
+    assert body["count"] == 1


### PR DESCRIPTION
## Summary
- Cloudflare Zero Trust tunnel (gov.cirwel.org) drops the WebSocket upgrade for /ws/eisv, so the dashboard falls back to 30s HTTP polling of /v1/eisv/latest — which only returns the single most-recent datum. Effect: chart looks empty / stuck at one point.
- Add `/v1/eisv/recent?limit=N` backfill endpoint returning the last N eisv_update events from the broadcaster's event_history ring buffer.
- `EISVWebSocket.connect` now calls `_backfillOnce()` on WS open; `_startPolling()` calls it before the first poll — so both transport paths populate the chart immediately from history instead of waiting for the next live check-in.

## Why not fix at Cloudflare
Root cause is the tunnel's WebSocket config in Zero Trust, but this change is durable even once that's fixed: any client (new tab, refresh, reconnect) now gets instant chart state instead of an empty canvas.

## Test plan
- [x] 5 new unit tests for /v1/eisv/recent (chronological order, filter non-eisv, limit, clamp, invalid-limit fallback)
- [x] `./scripts/dev/test-cache.sh` — 6721 passed
- [ ] After merge + restart: load gov.cirwel.org/dashboard — confirm chart populates on load, not just on next check-in