### PR TITLE
docs: hero SVG + CONTRIBUTING fixes (stranded from PR #100)

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -16,8 +16,11 @@ Thanks for your interest in contributing to UNITARES. This guide covers the prac
 git clone https://github.com/CIRWEL/unitares.git
 cd unitares
 python3 -m venv venv && source venv/bin/activate
-pip install -r requirements-core.txt
+pip install -r requirements-core.txt   # lean dev/test deps
+# or: pip install -r requirements-full.txt   # also needed to run the MCP server
 ```
+
+Use `requirements-core.txt` for working on tests and handler code; use `requirements-full.txt` if you also want to run the MCP + HTTP stack locally (see the root [README](README.md) for the server start command).
 
 ### Database
 
@@ -25,25 +28,30 @@ UNITARES uses PostgreSQL 16+ with the [Apache AGE](https://github.com/apache/age
 
 See `db/postgres/README.md` for full setup instructions (Homebrew PostgreSQL 17 + AGE + pgvector).
 
-**Important:** Always access the database instance referenced by `DB_POSTGRES_URL`:
+Two databases are involved:
 
 ```bash
+# Runtime database — what the server connects to
 psql "$DB_POSTGRES_URL"
+
+# Test database — a separate `governance_test` DB the integration tests use.
+# Without it, the live-DB tests skip rather than fail.
+createdb governance_test
 ```
 
 ## Running Tests
 
-The test suite contains thousands of tests covering most of the codebase:
+The preferred pre-commit gate matches what the pre-push hook runs — a tree-hash-cached wrapper that skips when tests have already passed against this exact working tree:
 
 ```bash
-# Full suite (recommended before PRs)
-python3 -m pytest tests/ -x -q
+./scripts/dev/test-cache.sh            # use this before opening a PR
+./scripts/dev/test-cache.sh --fresh    # force re-run
+```
 
-# Specific test file
-python3 -m pytest tests/test_governance_monitor.py -v
+For inner-loop iteration (`pyproject.toml` `addopts` force coverage + verbose output, so bare `pytest` prints a lot — suppress with `--no-cov` and keep output tight):
 
-# With coverage report
-python3 -m pytest tests/ --cov=src --cov-report=term-missing
+```bash
+python3 -m pytest tests/test_governance_monitor.py --no-cov --tb=short -q | tail -40
 ```
 
 Tests use a separate `governance_test` database and mock external services. Most tests run without any live infrastructure — only a few integration tests in `test_knowledge_graph_handlers.py` require a running AGE instance.
@@ -54,16 +62,17 @@ Tests use a separate `governance_test` database and mock external services. Most
 
 ## Project Structure
 
-| Directory | Purpose |
-|-----------|---------|
-| `governance_core` (external) | Pure mathematics — ODE solvers, coherence functions, risk scoring. Distributed as a compiled package (unitares-core, private). |
+| Path | Purpose |
+|------|---------|
 | `src/` | Production MCP server, handler modules, database backends, middleware |
 | `src/mcp_handlers/` | Individual tool handlers, each decorated with `@mcp_tool` |
 | `src/mcp_handlers/schemas/` | Pydantic v2 parameter schemas for validation |
 | `src/db/` | PostgreSQL + AGE database backend |
 | `dashboard/` | Web dashboard (vanilla JS + Chart.js) |
-| `papers/` | Academic paper with contraction proofs and stability analysis |
 | `tests/` | Test suite, mirroring source structure |
+| `unitares-core` (external wheel) | EISV dynamics engine — ODE solvers, coherence, risk scoring. Installed via `requirements-core.txt`; source lives in a separate private repo (see [Core Engine Dependency](#core-engine-dependency)). |
+
+The companion paper lives in its own repo: [CIRWEL/unitares-paper-v6](https://github.com/CIRWEL/unitares-paper-v6).
 
 ## Code Style
 
@@ -80,11 +89,13 @@ The EISV dynamics engine (`governance_core`) is distributed as a compiled packag
 
 **For CI:** The GitHub Actions workflow checks out `unitares-core` using the `UNITARES_CORE_TOKEN` secret and builds it from source. Fork PRs will not have access to this token — a maintainer will run CI on your behalf.
 
-**For local development with source:** If you need to modify the core engine, symlink the source:
+**For local development with source:** If you have access to the core engine source and want to modify it, symlink your checkout into the repo root:
 ```bash
 pip uninstall unitares-core -y
-ln -sf ~/projects/unitares-core/governance_core governance_core
+ln -sf /path/to/your/unitares-core/governance_core governance_core
 ```
+
+(Adjust the path to wherever you cloned `unitares-core`.)
 
 ## Pull Requests
 

--- a/docs/assets/hero.svg
+++ b/docs/assets/hero.svg
@@ -91,7 +91,7 @@
     <!-- Descriptor line -->
     <text y="175" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#58a6ff" opacity="0.8">Runtime governance</text>
     <text y="175" x="130" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#484f58">|</text>
-    <text y="175" x="142" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#58a6ff" opacity="0.8">Thermodynamic state tracking</text>
+    <text y="175" x="142" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#58a6ff" opacity="0.8">Self-relative drift detection</text>
     <text y="175" x="340" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#484f58">|</text>
     <text y="175" x="352" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#58a6ff" opacity="0.8">MCP + HTTP</text>
 


### PR DESCRIPTION
## Summary
PR #100 landed the README changes but was merged before the hero SVG and CONTRIBUTING.md commits were pushed to the branch, so those two commits never made it to master. This PR lands them.

### Hero SVG
Swaps the hero chip `Thermodynamic state tracking` → `Self-relative drift detection` so the image doesn't contradict the README paragraph-2 jargon cleanup.

### CONTRIBUTING.md
- Drop `governance_core (external)` and `papers/` rows from the Project Structure table — neither exists as a directory in this repo (CLAUDE.md explicitly warns against creating `governance_core/`, and the paper lives in `CIRWEL/unitares-paper-v6`).
- Replace raw `pytest tests/ -x -q` and redundant `--cov=src` invocations with `./scripts/dev/test-cache.sh` — same gate the pre-push hook runs; `addopts` already force coverage so the extra flag was duplicate.
- Clarify when to use `requirements-core.txt` vs `requirements-full.txt` (lean for tests, full for running the server).
- Document both the runtime DB (`DB_POSTGRES_URL`) and the separate `governance_test` DB that integration tests need.
- Replace operator-specific `~/projects/unitares-core` symlink path with a generic placeholder.

## Test plan
- [x] `./scripts/dev/test-cache.sh` passes (6,721 passed, 77.58% cov)
- [x] Pre-push smoke tests pass (138 passed)