### PR TITLE
chore: remove /Users/cirwel paths from tracked scripts, tests, plist template

### DIFF
--- a/agents/watcher/tests/test_agent.py
+++ b/agents/watcher/tests/test_agent.py
@@ -1673,7 +1673,7 @@ class TestEscalation:
 # ---------------------------------------------------------------------------
 
 
-def _verify_finding(watcher_module, pattern, line, src_line, file="/Users/cirwel/projects/unitares/src/mcp_handlers/x.py", evidence=""):
+def _verify_finding(watcher_module, pattern, line, src_line, file="/repo/src/mcp_handlers/x.py", evidence=""):
     """Helper: run _verify_finding_against_source with a 1-line snippet."""
     f = watcher_module.Finding(
         pattern=pattern, file=file, line=line, hint="t",
@@ -1693,7 +1693,7 @@ def test_p004_dropped_outside_mcp_handlers_directory(watcher_module):
         pattern="P004",
         line=736,
         src_line="async def http_dashboard(request):",
-        file="/Users/cirwel/projects/unitares/src/http_api.py",
+        file="/repo/src/http_api.py",
     )
 
 
@@ -1717,7 +1717,7 @@ def test_p004_kept_for_real_asyncpg_call_inside_mcp_handler(watcher_module):
         pattern="P004",
         line=42,
         src_line="rows = await conn.fetchrow(query)",
-        file="/Users/cirwel/projects/unitares/src/mcp_handlers/identity/handlers.py",
+        file="/repo/src/mcp_handlers/identity/handlers.py",
     )
 
 
@@ -1772,7 +1772,7 @@ def test_p016_dropped_on_typed_attribute_access(watcher_module):
             pattern="P016",
             line=42,
             src_line=src_line,
-            file="/Users/cirwel/projects/unitares/agents/vigil/agent.py",
+            file="/repo/agents/vigil/agent.py",
         ), f"P016 should be dropped for typed attribute access: {src_line!r}"
 
 
@@ -1790,7 +1790,7 @@ def test_p016_kept_for_dict_envelope_parse(watcher_module):
             pattern="P016",
             line=42,
             src_line=src_line,
-            file="/Users/cirwel/projects/unitares/scripts/unitares",
+            file="/repo/scripts/unitares",
         ), f"P016 should fire on dict-envelope parse: {src_line!r}"
 
 

--- a/scripts/diagnostics/test_date_context_connection.py
+++ b/scripts/diagnostics/test_date_context_connection.py
@@ -6,6 +6,7 @@ This script tests the date-context server directly via stdio to verify it's work
 """
 
 import asyncio
+import os
 import sys
 import json
 from pathlib import Path
@@ -14,6 +15,12 @@ from datetime import datetime
 # Add project root to path
 project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
+
+# date-context-mcp is a separate repo; set DATE_CONTEXT_MCP_ROOT to point at
+# your local checkout. Defaults to ~/projects/date-context-mcp.
+DATE_CONTEXT_MCP_ROOT = Path(
+    os.environ.get("DATE_CONTEXT_MCP_ROOT", Path.home() / "projects" / "date-context-mcp")
+)
 
 try:
     from mcp import ClientSession, StdioServerParameters
@@ -33,20 +40,21 @@ async def test_date_context_connection():
     print(f"Time: {datetime.now().isoformat()}\n")
     
     # Server configuration (matches Cursor config)
-    server_path = Path("/Users/cirwel/projects/date-context-mcp/src/mcp_server.py")
-    
+    server_path = DATE_CONTEXT_MCP_ROOT / "src" / "mcp_server.py"
+
     if not server_path.exists():
         print(f"❌ Server file not found: {server_path}")
+        print(f"   Set DATE_CONTEXT_MCP_ROOT to override the default location.")
         return False
-    
+
     print(f"✅ Server file found: {server_path}")
-    
+
     # Configure server parameters
     server_params = StdioServerParameters(
         command="python3",
         args=[str(server_path)],
         env={
-            "PYTHONPATH": "/Users/cirwel/projects/date-context-mcp"
+            "PYTHONPATH": str(DATE_CONTEXT_MCP_ROOT)
         }
     )
     

--- a/scripts/diagnostics/validate_doc_dates.sh
+++ b/scripts/diagnostics/validate_doc_dates.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Documentation Date Validator
 # Checks for outdated year references in documentation
+# Override project root via UNITARES_ROOT env var; otherwise auto-derived.
 
-PROJECT_DIR="/Users/cirwel/projects/unitares"
+PROJECT_DIR="${UNITARES_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 cd "$PROJECT_DIR" || exit 1
 
 CURRENT_YEAR=$(date +%Y)

--- a/scripts/ops/cleanup_stale.sh
+++ b/scripts/ops/cleanup_stale.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Cleanup stale processes and resources from governance-mcp
 # Run: ./scripts/cleanup_stale.sh [--dry-run]
+# Override project root via UNITARES_ROOT env var; otherwise auto-derived.
+
+PROJECT_DIR="${UNITARES_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 
 DRY_RUN=false
 if [[ "$1" == "--dry-run" ]]; then
@@ -29,7 +32,7 @@ echo ""
 
 # 2. Check for stale lock files
 echo "Checking for stale lock files..."
-LOCK_DIR="/Users/cirwel/projects/unitares/data/locks"
+LOCK_DIR="$PROJECT_DIR/data/locks"
 if [[ -d "$LOCK_DIR" ]]; then
     LOCK_COUNT=$(find "$LOCK_DIR" -name "*.lock" -mmin +30 2>/dev/null | wc -l | tr -d ' ')
     if [[ "$LOCK_COUNT" -gt 0 ]]; then
@@ -50,7 +53,7 @@ echo ""
 
 # 3. Check for orphaned heartbeat files
 echo "Checking heartbeat freshness..."
-HEARTBEAT_FILE="/Users/cirwel/projects/unitares/data/mcp_heartbeat.json"
+HEARTBEAT_FILE="$PROJECT_DIR/data/mcp_heartbeat.json"
 if [[ -f "$HEARTBEAT_FILE" ]]; then
     AGE_MINUTES=$(( ($(date +%s) - $(stat -f %m "$HEARTBEAT_FILE")) / 60 ))
     if [[ $AGE_MINUTES -gt 10 ]]; then

--- a/scripts/ops/com.unitares.chronicler.plist.template
+++ b/scripts/ops/com.unitares.chronicler.plist.template
@@ -1,4 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Chronicler launchd template.
+
+    Before installing, substitute placeholders:
+      __UNITARES_ROOT__  → absolute path to your unitares checkout
+      __HOME__           → your $HOME (expanded absolute path)
+
+    Example:
+      sed -e "s|__UNITARES_ROOT__|$HOME/projects/unitares|g" \
+          -e "s|__HOME__|$HOME|g" \
+          scripts/ops/com.unitares.chronicler.plist.template \
+          > ~/Library/LaunchAgents/com.unitares.chronicler.plist
+-->
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
   "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -9,11 +22,11 @@
     <key>ProgramArguments</key>
     <array>
         <string>/Library/Frameworks/Python.framework/Versions/3.14/bin/python3</string>
-        <string>/Users/cirwel/projects/unitares/agents/chronicler/agent.py</string>
+        <string>__UNITARES_ROOT__/agents/chronicler/agent.py</string>
     </array>
 
     <key>WorkingDirectory</key>
-    <string>/Users/cirwel/projects/unitares</string>
+    <string>__UNITARES_ROOT__</string>
 
     <!-- Daily — one scrape per day is enough for slow-moving metrics like LOC. -->
     <key>StartInterval</key>
@@ -23,20 +36,20 @@
     <true/>
 
     <key>StandardOutPath</key>
-    <string>/Users/cirwel/Library/Logs/unitares-chronicler-launchd.log</string>
+    <string>__HOME__/Library/Logs/unitares-chronicler-launchd.log</string>
     <key>StandardErrorPath</key>
-    <string>/Users/cirwel/Library/Logs/unitares-chronicler-launchd.log</string>
+    <string>__HOME__/Library/Logs/unitares-chronicler-launchd.log</string>
 
     <key>EnvironmentVariables</key>
     <dict>
         <key>PYTHONPATH</key>
-        <string>/Users/cirwel/projects/unitares</string>
+        <string>__UNITARES_ROOT__</string>
         <key>PATH</key>
         <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
         <key>UNITARES_METRICS_URL</key>
         <string>http://127.0.0.1:8767</string>
         <key>CHRONICLER_REPO_ROOT</key>
-        <string>/Users/cirwel/projects/unitares</string>
+        <string>__UNITARES_ROOT__</string>
     </dict>
 </dict>
 </plist>

--- a/scripts/ops/install_git_hooks.sh
+++ b/scripts/ops/install_git_hooks.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Install git hooks for unitares
+# Override project root via UNITARES_ROOT env var; otherwise auto-derived.
 
-PROJECT_DIR="/Users/cirwel/projects/unitares"
+PROJECT_DIR="${UNITARES_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 cd "$PROJECT_DIR" || exit 1
 
 echo "🪝 Installing Git Hooks"

--- a/tests/drills/test_failure_modes.py
+++ b/tests/drills/test_failure_modes.py
@@ -180,7 +180,8 @@ class TestCrossDeviceAudit:
     def test_audit_log_exists(self):
         """Drill 7: Audit log should exist and be writable."""
         import os
-        audit_path = "/Users/cirwel/projects/unitares/data/audit.jsonl"
+        from pathlib import Path
+        audit_path = str(Path(__file__).resolve().parents[2] / "data" / "audit.jsonl")
 
         if os.path.exists(audit_path):
             size = os.path.getsize(audit_path)
@@ -192,7 +193,8 @@ class TestCrossDeviceAudit:
         """Drill 8: EISV sync should create audit entry."""
         # Get initial audit log size
         import os
-        audit_path = "/Users/cirwel/projects/unitares/data/audit.jsonl"
+        from pathlib import Path
+        audit_path = str(Path(__file__).resolve().parents[2] / "data" / "audit.jsonl")
         initial_size = os.path.getsize(audit_path) if os.path.exists(audit_path) else 0
 
         # Trigger a sync

--- a/tests/test_identity_honesty_partc.py
+++ b/tests/test_identity_honesty_partc.py
@@ -555,9 +555,7 @@ class TestResidentRegression:
         """_ensure_identity must set client.continuity_token before identity() call."""
         import sys
         import pathlib
-        sdk_path = pathlib.Path(
-            "/Users/cirwel/projects/unitares/.worktrees/identity-honesty-partc/agents/sdk/src"
-        )
+        sdk_path = pathlib.Path(__file__).resolve().parents[1] / "agents" / "sdk" / "src"
         if str(sdk_path) not in sys.path:
             sys.path.insert(0, str(sdk_path))
 


### PR DESCRIPTION
## What
Tracked scripts, tests, and the chronicler plist template hardcoded the maintainer's absolute home path (\`/Users/cirwel/projects/unitares\`), making them broken for any other contributor and leaking \"one-operator laptop\" signal on a public-facing repo.

## Categories

**Production scripts** — auto-derive from \`BASH_SOURCE\` with \`UNITARES_ROOT\` env-var override:
- \`scripts/ops/cleanup_stale.sh\`
- \`scripts/ops/install_git_hooks.sh\`
- \`scripts/diagnostics/validate_doc_dates.sh\`

**Cross-repo diagnostic** — switched to \`DATE_CONTEXT_MCP_ROOT\` env var, defaults to \`~/projects/date-context-mcp\`:
- \`scripts/diagnostics/test_date_context_connection.py\`

**Plist template** — replaced operator paths with \`__UNITARES_ROOT__\` / \`__HOME__\` sentinels and added a \`sed\` one-liner at the top of the file so installers know how to substitute:
- \`scripts/ops/com.unitares.chronicler.plist.template\`

**Tests** — fixture-only path strings replaced with \`pathlib\` resolution relative to the test file:
- \`tests/drills/test_failure_modes.py\` (audit_path)
- \`tests/test_identity_honesty_partc.py\` (stale worktree path → live \`agents/sdk/src\`)
- \`agents/watcher/tests/test_agent.py\` (\`/repo/\` prefix; verifier gates on \`src/mcp_handlers/\` substring so semantics preserved)

## Intentionally left alone
- \`tests/test_utils_pure.py\` and \`tests/test_ux_fixes.py\` — these are **redaction tests** that put \`/Users/cirwel/...\` in as input and assert it gets stripped by the error sanitizer. Removing them would weaken the sanitizer's coverage.

## Verification
- \`git grep /Users/cirwel -- ':!*.md' ':!tests/test_utils_pure.py' ':!tests/test_ux_fixes.py'\` returns zero
- \`./scripts/dev/test-cache.sh\` — 6,721 passed, 33 skipped, 77.58% cov
- Pre-push smoke tests pass