### PR TITLE
feat(chronicler): give Chronicler a governance identity + EISV check-ins

Chronicler was running daily as a launchd scraper but was invisible to
governance — no UUID, no check-ins, not in KNOWN_RESIDENT_LABELS, absent
from the dashboard residents strip.

Wraps the scrape loop in a ChroniclerAgent(GovernanceAgent) so each
daily run onboards via the ~/.unitares/anchors/chronicler.json anchor,
runs the existing scraper+POST loop, then checks in via
process_agent_update. Bootstrap is the usual UNITARES_FIRST_RUN=1
one-shot; refuse_fresh_onboard=True thereafter, matching Vigil/Sentinel/
Watcher.

Also:
- Adds 'Chronicler' to KNOWN_RESIDENT_LABELS (src/grounding + both
  inline script mirrors).
- 30hr silence threshold and canonical dashboard order placement.
- Alias-to-default class-conditional scales (same pattern Steward used
  on day-zero; re-calibrate once a corpus accumulates).
- --dry keeps bypassing governance entirely so operators can debug
  scrapers before the anchor is bootstrapped.

### DIFF
--- a/agents/chronicler/agent.py
+++ b/agents/chronicler/agent.py
@@ -1,25 +1,33 @@
 #!/usr/bin/env python3
 """Chronicler — daily scraper of fleet metrics into `metrics.series`.
 
-Intentionally lightweight: one-shot invocation (launchd drives cadence),
-no own identity, no EISV check-ins. Runs each scraper in `scrapers.py`,
-POSTs the value to the governance server, emits a `.error` metric on
-failure so silent breakage stays visible.
+One-shot invocation (launchd drives cadence). Runs each scraper in
+`scrapers.py`, POSTs the value to the governance server, emits a
+`.error` metric on failure so silent breakage stays visible. After the
+scrape loop, checks in to governance via `process_agent_update` so
+Chronicler appears as a first-class resident with its own EISV
+trajectory alongside Vigil/Sentinel/Watcher.
 
 Environment:
     UNITARES_METRICS_URL        base URL (default http://127.0.0.1:8767)
     UNITARES_HTTP_API_TOKEN     bearer token; optional if running locally
                                 (trusted-network bypass handles 127.0.0.1)
     CHRONICLER_REPO_ROOT        repo to scrape (default: working directory)
+    UNITARES_FIRST_RUN          set to 1 once to mint Chronicler's identity;
+                                subsequent runs resume via the anchor
 
 Usage:
-    python3 agents/chronicler/agent.py          # run all scrapers once
-    python3 agents/chronicler/agent.py --dry    # no POSTs, print to stdout
+    python3 agents/chronicler/agent.py          # run all scrapers once, check in
+    python3 agents/chronicler/agent.py --dry    # print metrics; skip POST and check-in
+
+First-time bootstrap (mints UUID into ~/.unitares/anchors/chronicler.json):
+    UNITARES_FIRST_RUN=1 python3 agents/chronicler/agent.py
 """
 
 from __future__ import annotations
 
 import argparse
+import asyncio
 import json
 import logging
 import os
@@ -35,6 +43,8 @@ if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
 
 from agents.chronicler.scrapers import SCRAPERS
+from unitares_sdk.agent import CycleResult, GovernanceAgent
+from unitares_sdk.client import GovernanceClient
 
 logging.basicConfig(
     level=logging.INFO,
@@ -110,7 +120,64 @@ def run(
                 failures += 1
                 log.warning("could not post %s: %s", name, exc)
 
+    log.info("chronicler done: success=%d fail=%d", successes, failures)
     return successes, failures
+
+
+class ChroniclerAgent(GovernanceAgent):
+    """GovernanceAgent wrapper that runs one scrape cycle and checks in.
+
+    One-shot: launchd drives cadence, so this uses ``run_once()`` not
+    ``run_forever()``. Identity is persistent; the anchor lives at
+    ``~/.unitares/anchors/chronicler.json`` (the SDK default).
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        token: str | None,
+        repo_root: Path,
+        dry_run: bool = False,
+    ):
+        # Governance tools use the MCP endpoint; metrics POSTs hit the REST
+        # endpoint. Derive the MCP URL from the same base so both aim at the
+        # same server when UNITARES_METRICS_URL is overridden.
+        mcp_url = base_url.rstrip("/") + "/mcp/"
+        super().__init__(
+            name="Chronicler",
+            mcp_url=mcp_url,
+            persistent=True,
+            refuse_fresh_onboard=True,
+        )
+        self.base_url = base_url
+        self.token = token
+        self.repo_root = repo_root
+        self.dry_run = dry_run
+
+    async def run_cycle(self, client: GovernanceClient) -> CycleResult | None:
+        # Scrapers are sync (subprocess + httpx.Client); push to a thread so
+        # the MCP anyio task group isn't blocked by their blocking I/O.
+        successes, failures = await asyncio.to_thread(
+            run, self.base_url, self.token, self.repo_root, self.dry_run,
+        )
+
+        if self.dry_run:
+            # Dry run is a diagnostic — skip the check-in so we don't pollute
+            # the trajectory with ad-hoc operator invocations.
+            return None
+
+        total = successes + failures
+        summary = f"Chronicler: {successes}/{total} scrapers ok"
+        # Clean runs are routine + deterministic (low complexity, high
+        # confidence); any failure bumps both dimensions to reflect the
+        # transient-vs-persistent uncertainty.
+        complexity = 0.4 if failures > 0 else 0.1
+        confidence = 0.5 if failures > 0 else 0.9
+        return CycleResult(
+            summary=summary,
+            complexity=complexity,
+            confidence=confidence,
+        )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -123,9 +190,22 @@ def main(argv: list[str] | None = None) -> int:
     repo_root = Path(os.environ.get("CHRONICLER_REPO_ROOT", os.getcwd())).resolve()
 
     log.info("chronicler start: url=%s repo=%s scrapers=%d", base_url, repo_root, len(SCRAPERS))
-    successes, failures = run(base_url, token, repo_root, dry_run=args.dry)
-    log.info("chronicler done: success=%d fail=%d", successes, failures)
-    return 0 if failures == 0 else 1
+    # --dry is a diagnostic — skip the governance connect + identity dance
+    # entirely so operators can debug scrapers without first bootstrapping
+    # the Chronicler anchor (refuse_fresh_onboard would otherwise block).
+    if args.dry:
+        _, failures = run(base_url, token, repo_root, dry_run=True)
+        return 0 if failures == 0 else 1
+
+    agent = ChroniclerAgent(
+        base_url=base_url, token=token, repo_root=repo_root, dry_run=False,
+    )
+    try:
+        asyncio.run(agent.run_once())
+    except Exception as e:
+        log.error("chronicler failed: %s", e)
+        return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -844,6 +844,12 @@ DELTA_NORM_MAX_BY_CLASS: Dict[str, ScaleConstant] = {
         notes="Alias to default. Steward created 2026-04-17, blocked by "
               "loop-detection on calibration day so 0 rows in core.agent_state. "
               "Re-run scripts/calibrate_class_conditional.py once corpus exists."),
+    "Chronicler": ScaleConstant(
+        name="DELTA_NORM_MAX[Chronicler]", value=0.2018, measured_on="2026-04-23",
+        corpus_size=0, percentile=None, provenance="alias",
+        notes="Alias to default. Chronicler minted an identity on 2026-04-23; "
+              "one check-in per day means a corpus takes weeks to build. "
+              "Re-run scripts/calibrate_class_conditional.py once corpus exists."),
 }
 
 # Healthy operating points per class — median (E, I, S) on healthy-regime
@@ -856,6 +862,7 @@ HEALTHY_OPERATING_POINT_BY_CLASS: Dict[str, Tuple[float, float, float]] = {
     "Vigil":    (0.7371, 0.7896, 0.2404),   # N=384
     "Watcher":  (0.7482, 0.7686, 0.2477),   # N=283
     "Steward":  (0.7264, 0.7934, 0.2364),   # alias=default (N=0; see DELTA_NORM_MAX[Steward])
+    "Chronicler": (0.7264, 0.7934, 0.2364), # alias=default (N=0; see DELTA_NORM_MAX[Chronicler])
 }
 
 # Default healthy operating point (fleet fallback for unclassified agents).

--- a/scripts/calibrate_class_conditional.py
+++ b/scripts/calibrate_class_conditional.py
@@ -44,7 +44,7 @@ except ImportError:
     sys.exit(1)
 
 
-KNOWN_RESIDENT_LABELS = {"Lumen", "Vigil", "Sentinel", "Watcher", "Steward"}
+KNOWN_RESIDENT_LABELS = {"Lumen", "Vigil", "Sentinel", "Watcher", "Steward", "Chronicler"}
 HEALTHY_REGIMES = ("nominal", "STABLE", "CONVERGENCE", "EXPLORATION")
 
 

--- a/scripts/verdict_counterfactual.py
+++ b/scripts/verdict_counterfactual.py
@@ -35,7 +35,7 @@ except ImportError:
 
 
 # ── Mirror of src/grounding/class_indicator.classify_agent ────────────
-KNOWN_RESIDENT_LABELS = {"Lumen", "Vigil", "Sentinel", "Watcher", "Steward"}
+KNOWN_RESIDENT_LABELS = {"Lumen", "Vigil", "Sentinel", "Watcher", "Steward", "Chronicler"}
 
 
 def classify_from_db_row(label: Optional[str], tags: Optional[list]) -> str:

--- a/src/grounding/class_indicator.py
+++ b/src/grounding/class_indicator.py
@@ -14,7 +14,9 @@ from typing import Any, Optional
 
 # Specific labels that identify a unique resident agent. Each is its own
 # calibration class because population N=1 means class==agent in practice.
-KNOWN_RESIDENT_LABELS = frozenset({"Lumen", "Vigil", "Sentinel", "Watcher", "Steward"})
+KNOWN_RESIDENT_LABELS = frozenset(
+    {"Lumen", "Vigil", "Sentinel", "Watcher", "Steward", "Chronicler"}
+)
 
 # Tag-derived class names.
 CLASS_EMBODIED = "embodied"

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -1306,6 +1306,8 @@ _DEFAULT_RESIDENT_SILENCE_SECONDS: Dict[str, int] = {
     "lumen": 10 * 60,      # continuous poll
     # Event-driven agents may be quiet for a long time and still be healthy.
     "watcher": 24 * 3600,
+    # Daily scraper — 24hr cadence + 6hr buffer before silence is flagged.
+    "chronicler": 30 * 3600,
 }
 
 
@@ -1346,9 +1348,10 @@ def _resolve_resident_labels(mcp_server_obj) -> tuple[list[str], str]:
         if label and label in KNOWN_RESIDENT_LABELS:
             present.add(label)
     if present:
-        # Canonical order is stable (Vigil, Sentinel, Watcher, Steward, Lumen)
-        # so dashboard layout doesn't jitter when the dict ordering shifts.
-        canonical_order = ["Vigil", "Sentinel", "Watcher", "Steward", "Lumen"]
+        # Canonical order is stable (Vigil, Sentinel, Watcher, Steward,
+        # Chronicler, Lumen) so dashboard layout doesn't jitter when the dict
+        # ordering shifts.
+        canonical_order = ["Vigil", "Sentinel", "Watcher", "Steward", "Chronicler", "Lumen"]
         ordered = [lbl for lbl in canonical_order if lbl in present]
         return ordered, "known-residents"
 
@@ -1629,7 +1632,7 @@ async def http_resident_tag_audit(request):
         {
             "success": true,
             "required_tags": ["persistent", "autonomous"],
-            "checked": ["Vigil", "Sentinel", "Watcher", "Steward", "Lumen"],
+            "checked": ["Vigil", "Sentinel", "Watcher", "Steward", "Chronicler", "Lumen"],
             "missing": {
                 "Watcher": ["autonomous"],
                 ...

--- a/tests/test_chronicler.py
+++ b/tests/test_chronicler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -217,3 +218,105 @@ class TestAgentRun:
 
         assert ok == 0
         assert fail == 1  # scrape failure counted, post-error failure swallowed
+
+
+# ---------------------------------------------------------------------------
+# ChroniclerAgent — governance identity wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestChroniclerAgent:
+    def test_is_persistent_resident_refusing_fresh_onboard(self, tmp_path: Path):
+        """Chronicler is a resident; the SDK must refuse fresh onboard without
+        UNITARES_FIRST_RUN, matching Vigil/Sentinel/Watcher."""
+        from agents.chronicler.agent import ChroniclerAgent
+
+        agent = ChroniclerAgent(
+            base_url="http://127.0.0.1:8767", token=None, repo_root=tmp_path,
+        )
+        assert agent.name == "Chronicler"
+        assert agent.persistent is True
+        assert agent.refuse_fresh_onboard is True
+        # MCP URL is derived from the metrics base URL, not hardcoded, so
+        # UNITARES_METRICS_URL overrides route to the same server.
+        assert agent.mcp_url == "http://127.0.0.1:8767/mcp/"
+
+    def test_run_cycle_returns_summary_on_clean_run(self, tmp_path: Path):
+        from agents.chronicler import agent as chronicler
+        from agents.chronicler.agent import ChroniclerAgent
+
+        scrapers = {
+            "a": lambda _r: 1.0,
+            "b": lambda _r: 2.0,
+        }
+        fake = FakeHttpClient()
+        agent = ChroniclerAgent(
+            base_url="http://127.0.0.1:8767", token=None, repo_root=tmp_path,
+        )
+        with (
+            patch.object(chronicler, "SCRAPERS", scrapers),
+            patch("agents.chronicler.agent.httpx.Client", return_value=fake),
+        ):
+            result = asyncio.run(agent.run_cycle(client=MagicMock()))
+
+        assert result is not None
+        assert result.summary == "Chronicler: 2/2 scrapers ok"
+        # Clean runs stay low-complexity / high-confidence so a routine day
+        # doesn't perturb the trajectory.
+        assert result.complexity == 0.1
+        assert result.confidence == 0.9
+
+    def test_run_cycle_bumps_complexity_when_a_scraper_fails(self, tmp_path: Path):
+        from agents.chronicler import agent as chronicler
+        from agents.chronicler.agent import ChroniclerAgent
+
+        def boom(_root):
+            raise RuntimeError("broken")
+
+        scrapers = {"ok": lambda _r: 1.0, "boom": boom}
+        fake = FakeHttpClient()
+        agent = ChroniclerAgent(
+            base_url="http://127.0.0.1:8767", token=None, repo_root=tmp_path,
+        )
+        with (
+            patch.object(chronicler, "SCRAPERS", scrapers),
+            patch("agents.chronicler.agent.httpx.Client", return_value=fake),
+        ):
+            result = asyncio.run(agent.run_cycle(client=MagicMock()))
+
+        assert result is not None
+        assert result.summary == "Chronicler: 1/2 scrapers ok"
+        # Failure bumps both dimensions so the check-in carries honest uncertainty.
+        assert result.complexity == 0.4
+        assert result.confidence == 0.5
+
+    def test_dry_run_cycle_returns_none(self, tmp_path: Path):
+        """--dry is a diagnostic — it must not write a check-in (would pollute
+        the trajectory with ad-hoc operator invocations)."""
+        from agents.chronicler import agent as chronicler
+        from agents.chronicler.agent import ChroniclerAgent
+
+        fake = FakeHttpClient()
+        agent = ChroniclerAgent(
+            base_url="http://127.0.0.1:8767", token=None, repo_root=tmp_path,
+            dry_run=True,
+        )
+        with (
+            patch.object(chronicler, "SCRAPERS", {"x": lambda _r: 1.0}),
+            patch("agents.chronicler.agent.httpx.Client", return_value=fake),
+        ):
+            result = asyncio.run(agent.run_cycle(client=MagicMock()))
+
+        assert result is None  # GovernanceAgent._handle_cycle_result skips check-in
+
+
+class TestChroniclerAsKnownResident:
+    def test_chronicler_in_known_resident_labels(self):
+        from src.grounding.class_indicator import KNOWN_RESIDENT_LABELS
+        assert "Chronicler" in KNOWN_RESIDENT_LABELS
+
+    def test_chronicler_silence_threshold_configured(self):
+        from src.http_api import _DEFAULT_RESIDENT_SILENCE_SECONDS
+        # Daily cadence → must be at least 24hr so a normal gap doesn't
+        # get flagged as silence.
+        assert _DEFAULT_RESIDENT_SILENCE_SECONDS["chronicler"] >= 24 * 3600

--- a/tests/test_http_residents_resolve.py
+++ b/tests/test_http_residents_resolve.py
@@ -62,8 +62,9 @@ class TestResolveResidentLabels:
         assert source == "known-residents"
 
     def test_known_residents_preserves_canonical_order(self):
-        # Order should be canonical (Vigil, Sentinel, Watcher, Steward, Lumen),
-        # not metadata-dict insertion order, so the dashboard layout is stable.
+        # Order should be canonical (Vigil, Sentinel, Watcher, Steward,
+        # Chronicler, Lumen), not metadata-dict insertion order, so the
+        # dashboard layout is stable.
         server = SimpleNamespace(agent_metadata={
             "a1": _meta("Lumen"),
             "a2": _meta("Vigil"),
@@ -71,6 +72,18 @@ class TestResolveResidentLabels:
         })
         labels, source = _resolve_resident_labels(server)
         assert labels == ["Vigil", "Watcher", "Lumen"]
+        assert source == "known-residents"
+
+    def test_chronicler_sorts_between_steward_and_lumen(self):
+        # Chronicler is a daily scraper resident; it belongs with the other
+        # background residents, before Lumen (which is the embodied agent).
+        server = SimpleNamespace(agent_metadata={
+            "a1": _meta("Lumen"),
+            "a2": _meta("Chronicler"),
+            "a3": _meta("Steward"),
+        })
+        labels, source = _resolve_resident_labels(server)
+        assert labels == ["Steward", "Chronicler", "Lumen"]
         assert source == "known-residents"
 
     def test_empty_when_fleet_has_no_known_residents(self):


### PR DESCRIPTION
Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.