### PR TITLE
fix(identity): REST path must honor token ownership (#110)

### DIFF
--- a/src/http_api.py
+++ b/src/http_api.py
@@ -294,12 +294,27 @@ async def _resolve_http_bound_agent(tool_name: str, arguments: dict, signals) ->
             logger.debug("[STICKY-REST] cache check failed: %s", e)
 
     session_key = await derive_session_key(signals, arguments)
+
+    # Extract agent UUID from continuity token so PATH 2.8 can rebind via
+    # cryptographic ownership proof — without this the resolver cannot
+    # distinguish \"Watcher owns agent-907e3195-c64\" from \"some prior REST
+    # caller claimed that session_key and got cached\", and PATH 1 happily
+    # returns whichever agent the cache holds (issue #110).
+    _token_agent_uuid = None
+    if continuity_token:
+        try:
+            from src.mcp_handlers.identity.session import extract_token_agent_uuid
+            _token_agent_uuid = extract_token_agent_uuid(str(continuity_token))
+        except Exception:
+            pass
+
     resolved = await resolve_session_identity(
         session_key,
         persist=False,
         model_type=arguments.get("model_type"),
         client_hint=arguments.get("client_hint"),
         resume=True,
+        token_agent_uuid=_token_agent_uuid,
     )
     if resolved and not resolved.get("created"):
         agent_uuid = resolved.get("agent_uuid")

--- a/src/mcp_handlers/identity/resolution.py
+++ b/src/mcp_handlers/identity/resolution.py
@@ -393,6 +393,43 @@ async def resolve_session_identity(
                     # See docs/specs/2026-04-16-sever-fingerprint-eisv-inheritance-design.md
                     if resume:
 
+                        # PATH 1 token ownership cross-check (issue #110,
+                        # 2026-04-23). When the caller provided a signed
+                        # continuity_token whose aid claim doesn't match the
+                        # cached UUID, the cache entry is someone else's
+                        # binding — not the legitimate owner's. Unlike
+                        # fingerprint (soft heuristic), token mismatch is
+                        # cryptographic proof of a different owner. Fall
+                        # through to PATH 2.8 so token_rebind can take over.
+                        if token_agent_uuid and token_agent_uuid != agent_uuid:
+                            logger.warning(
+                                "[PATH1_TOKEN_MISMATCH] session_key=%s... "
+                                "cached_uuid=%s... token_uuid=%s... — "
+                                "cache hijacked, deferring to token rebind",
+                                session_key[:20],
+                                agent_uuid[:8],
+                                token_agent_uuid[:8],
+                            )
+                            try:
+                                from .handlers import _broadcaster
+                                _b = _broadcaster()
+                                if _b is not None:
+                                    await _b.broadcast_event(
+                                        event_type="identity_hijack_suspected",
+                                        agent_id=agent_uuid,
+                                        payload={
+                                            "path": "path1_token_mismatch",
+                                            "source": "path1_token_mismatch",
+                                            "cached_uuid_prefix": agent_uuid[:8],
+                                            "token_uuid_prefix": token_agent_uuid[:8],
+                                        },
+                                    )
+                            except Exception as _be:
+                                logger.warning(
+                                    f"[PATH1_TOKEN_MISMATCH] broadcast failed: {_be}"
+                                )
+                            resume = False
+
                         # PATH 1 fingerprint cross-check (2026-04-20 council follow-up
                         # to identity-honesty Part C). Session IDs of form
                         # `agent-{uuid[:12]}` are UUID-derivable; PATH 1 resume by

--- a/tests/test_identity_path1_fingerprint.py
+++ b/tests/test_identity_path1_fingerprint.py
@@ -324,3 +324,151 @@ class TestPath1FingerprintMismatchEmits:
         assert hijack_events == [], (
             "Off mode is explicit opt-out — no event even on mismatch"
         )
+
+
+class TestPath1TokenOwnershipCrossCheck:
+    """PATH 1 cache-hit with divergent token_agent_uuid falls through unconditionally.
+
+    Unlike fingerprint (soft heuristic, operator-configurable), token-uuid
+    mismatch is cryptographic proof of different ownership — we trust the
+    signed token over whatever the session_key cache happens to hold. This
+    closes the hijack vector in issue #110 where a REST caller claimed
+    Watcher's session_key and received Watcher's check-ins for 3 days.
+    """
+
+    @pytest.fixture
+    def captured_events(self):
+        return []
+
+    @pytest.fixture
+    def broadcaster_stub(self, captured_events):
+        b = MagicMock()
+
+        async def _record(**kwargs):
+            captured_events.append(kwargs)
+
+        b.broadcast_event = AsyncMock(side_effect=_record)
+        return b
+
+    @pytest.mark.asyncio
+    async def test_token_mismatch_falls_through_regardless_of_fingerprint_mode(
+        self, monkeypatch, captured_events, broadcaster_stub
+    ):
+        # Explicitly set fingerprint mode to "off" so we prove the
+        # token check is independent of the fingerprint gate.
+        monkeypatch.setenv("UNITARES_SESSION_FINGERPRINT_CHECK", "off")
+
+        from src.mcp_handlers.identity import resolution as res
+
+        cached_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        token_uuid = "99999999-8888-7777-6666-555555555555"
+        cached_payload = {
+            "agent_id": cached_uuid,
+            "display_agent_id": "hijacker_mcp_20260423",
+            "bind_ip_ua": "ip-anything:ua-anything",
+        }
+
+        fake_redis = MagicMock()
+        fake_redis.get = AsyncMock(return_value=cached_payload)
+
+        # PATH 2.8 sees the token, finds the real agent, and rebinds.
+        with patch.object(res, "_get_redis", return_value=fake_redis), patch(
+            "src.mcp_handlers.identity.resolution._agent_exists_in_postgres",
+            new=AsyncMock(return_value=True),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._get_agent_status",
+            new=AsyncMock(return_value="active"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._get_agent_id_from_metadata",
+            new=AsyncMock(return_value="Watcher_mcp_20260420"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._get_agent_label",
+            new=AsyncMock(return_value="Watcher"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._cache_session",
+            new=AsyncMock(return_value=None),
+        ), patch(
+            "src.mcp_handlers.identity.resolution.get_db",
+            side_effect=RuntimeError("DB session rebind is non-fatal"),
+        ), patch(
+            "src.mcp_handlers.identity.handlers._broadcaster",
+            return_value=broadcaster_stub,
+        ):
+            result = await res.resolve_session_identity(
+                session_key="agent-aaaaaaaaaaab",
+                resume=True,
+                token_agent_uuid=token_uuid,
+            )
+
+        # PATH 2.8 should have taken over — result must name the token's
+        # UUID, not the hijacker's cached UUID.
+        assert result.get("agent_uuid") == token_uuid, (
+            f"Token ownership must override cache hijack. Got: {result}"
+        )
+        assert result.get("source") == "token_rebind", (
+            f"Expected PATH 2.8 token_rebind, got source={result.get('source')}"
+        )
+
+        # And the hijack event fires with the new path tag.
+        hijack_events = [
+            e for e in captured_events
+            if e.get("event_type") == "identity_hijack_suspected"
+        ]
+        assert hijack_events, (
+            f"Token mismatch must emit identity_hijack_suspected. "
+            f"Captured: {captured_events}"
+        )
+        payload = hijack_events[0].get("payload") or {}
+        assert payload.get("path") == "path1_token_mismatch", (
+            f"Expected path='path1_token_mismatch', got: {payload}"
+        )
+        assert payload.get("cached_uuid_prefix") == cached_uuid[:8]
+        assert payload.get("token_uuid_prefix") == token_uuid[:8]
+
+    @pytest.mark.asyncio
+    async def test_matching_token_uuid_does_not_fall_through(
+        self, monkeypatch, captured_events, broadcaster_stub
+    ):
+        """When the token's aid matches the cached UUID, PATH 1 returns cached."""
+        monkeypatch.setenv("UNITARES_SESSION_FINGERPRINT_CHECK", "off")
+
+        from src.mcp_handlers.identity import resolution as res
+
+        agent_uuid = "cccccccc-dddd-eeee-ffff-000000000000"
+        cached_payload = {
+            "agent_id": agent_uuid,
+            "display_agent_id": "Watcher_mcp_20260420",
+            "bind_ip_ua": "ip-any:ua-any",
+        }
+
+        fake_redis = MagicMock()
+        fake_redis.get = AsyncMock(return_value=cached_payload)
+
+        with patch.object(res, "_get_redis", return_value=fake_redis), patch(
+            "src.mcp_handlers.identity.resolution._agent_exists_in_postgres",
+            new=AsyncMock(return_value=True),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._get_agent_label",
+            new=AsyncMock(return_value="Watcher"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._get_agent_status",
+            new=AsyncMock(return_value="active"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._soft_verify_trajectory",
+            new=AsyncMock(return_value={"verified": True}),
+        ), patch(
+            "src.mcp_handlers.identity.handlers._broadcaster",
+            return_value=broadcaster_stub,
+        ):
+            result = await res.resolve_session_identity(
+                session_key="agent-cccccccccddd",
+                resume=True,
+                token_agent_uuid=agent_uuid,  # matches cache
+            )
+
+        # Happy path: token says what the cache says, PATH 1 returns cached.
+        assert result.get("agent_uuid") == agent_uuid
+        assert result.get("source") == "redis"
+        assert captured_events == [], (
+            f"Matching token should not emit hijack event. Got: {captured_events}"
+        )


### PR DESCRIPTION
## Summary

Watcher's REST check-ins landed on the wrong agent for 3 days (issue #110). The REST pre-dispatch helper `_resolve_http_bound_agent` called `resolve_session_identity` without extracting `token_agent_uuid` from the request's `continuity_token`, so PATH 2.8 (token rebind) could never override PATH 1 (session-key cache lookup). A prior caller that claimed Watcher's `agent-{uuid[:12]}`-shaped session_key sat in Redis and silently absorbed Watcher's EISV check-ins.

## Changes

1. **`src/http_api.py:_resolve_http_bound_agent`** — now extracts the token's embedded agent UUID (mirroring `identity_step.py:391-398`) and passes it to `resolve_session_identity`, so PATH 2.8 has the cryptographic proof it needs to rebind.

2. **`src/mcp_handlers/identity/resolution.py`** — PATH 1 token-ownership cross-check: if the caller provided a signed `token_agent_uuid` and the Redis cache resolves to a different UUID, fall through to PATH 2.8 unconditionally. Unlike fingerprint (soft, operator-configurable), token mismatch is cryptographic — a valid signed token claiming `aid=X` always wins over a cached `session_key→Y` binding. Emits `identity_hijack_suspected` with `path="path1_token_mismatch"` for audit.

3. **`tests/test_identity_path1_fingerprint.py`** — adds `TestPath1TokenOwnershipCrossCheck` class: verifies token mismatch falls through to PATH 2.8 regardless of fingerprint mode, and matching token preserves normal cache-hit behavior.

## Operational state to clean up separately

- Redis key `session:agent-907e3195-c64` → hijacker
- Dispatch-ghost `af464221-073c-4ca3-8578-997de7518ae7` (117+ misrouted check-ins, already archived locally)
- Transport binding cache entry for fingerprint `127.0.0.1:355f8e`

Archive af464221 and clear the Redis key after merge + governance-mcp restart.

## Test plan

- [x] Full suite green (6743 passed, +2 new tests)
- [ ] After merge: clear hijacked state, restart governance-mcp, trigger Watcher, verify fresh `core.agent_state` rows land on identity 6951 (907e3195)

Fixes #110.