### PR TITLE
feat(chronicler): DB-backed scrapers + dashboard clarity

### DIFF
--- a/agents/chronicler/scrapers.py
+++ b/agents/chronicler/scrapers.py
@@ -12,9 +12,38 @@ dashboard instead of as a missing line.
 
 from __future__ import annotations
 
+import asyncio
+import os
 import subprocess
 from pathlib import Path
 from typing import Callable
+
+# Default matches the server's DSN (see .claude/CLAUDE.md — one Postgres
+# instance, one database). Overridable so a reflash or remote scrape can
+# point somewhere else without code changes.
+DEFAULT_DSN = "postgresql://postgres:postgres@localhost:5432/governance"
+
+
+def _fetchval(sql: str) -> float:
+    """Run ``sql`` against the governance DB and return the scalar as float.
+
+    Uses asyncpg under a one-shot ``asyncio.run`` because Chronicler is a
+    daily cron, not a long-running process — the per-call loop is cheap at
+    this cadence and keeps scrapers stateless (no shared pool to plumb).
+    """
+    import asyncpg  # local import: keeps test-time patching simple
+
+    dsn = os.environ.get("CHRONICLER_DB_DSN", DEFAULT_DSN)
+
+    async def _run() -> float:
+        conn = await asyncpg.connect(dsn)
+        try:
+            value = await conn.fetchval(sql)
+            return float(value or 0)
+        finally:
+            await conn.close()
+
+    return asyncio.run(_run())
 
 
 def tokei_unitares_src_code(repo_root: Path) -> float:
@@ -68,6 +97,27 @@ def tests_unitares_count(repo_root: Path) -> float:
     return float(len(files))
 
 
+def agents_active_7d(_repo_root: Path) -> float:
+    """Distinct agents with any tool call in the last 7 days — fleet liveness."""
+    return _fetchval(
+        "SELECT count(DISTINCT agent_id) FROM audit.tool_usage "
+        "WHERE ts > now() - interval '7 days' AND agent_id IS NOT NULL"
+    )
+
+
+def kg_entries_count(_repo_root: Path) -> float:
+    """Total discoveries in the knowledge graph — cumulative growth."""
+    return _fetchval("SELECT count(*) FROM knowledge.discoveries")
+
+
+def checkins_7d(_repo_root: Path) -> float:
+    """process_agent_update calls in the last 7 days — governance traffic."""
+    return _fetchval(
+        "SELECT count(*) FROM audit.tool_usage "
+        "WHERE ts > now() - interval '7 days' AND tool_name = 'process_agent_update'"
+    )
+
+
 # Registry: metric name → scrape callable. Chronicler iterates this on each run.
 #
 # Keep this in sync with the server-side catalog in
@@ -77,4 +127,7 @@ def tests_unitares_count(repo_root: Path) -> float:
 SCRAPERS: dict[str, Callable[[Path], float]] = {
     "tokei.unitares.src.code": tokei_unitares_src_code,
     "tests.unitares.count": tests_unitares_count,
+    "agents.active.7d": agents_active_7d,
+    "kg.entries.count": kg_entries_count,
+    "checkins.7d": checkins_7d,
 }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -77,7 +77,7 @@
         <a href="#discoveries-section" class="section-nav-item" data-section="discoveries-section">Discoveries</a>
         <a href="#dialectic-section" class="section-nav-item" data-section="dialectic-section">Dialectic</a>
         <a href="#activity-timeline-section" class="section-nav-item" data-section="activity-timeline-section">Activity</a>
-        <a href="#fleet-metrics-section" class="section-nav-item" data-section="fleet-metrics-section">Metrics</a>
+        <a href="#fleet-metrics-section" class="section-nav-item" data-section="fleet-metrics-section">Chronicler</a>
         <a href="/phase" style="margin-left:auto; opacity:0.6; padding:6px 14px; border-radius:20px; font-size:0.8rem; font-weight:500; color:var(--text-secondary); text-decoration:none; white-space:nowrap;">Phase Space &rarr;</a>
     </nav>
 
@@ -465,11 +465,11 @@
             </div>
         </div>
 
-        <!-- Fleet Metrics — catalog-driven time-series from metrics.series,
+        <!-- Chronicler — catalog-driven time-series from metrics.series,
              fed daily by the Chronicler scraper. -->
         <div class="panel" id="fleet-metrics-section">
             <div class="panel-header">
-                <h2>Fleet Metrics</h2>
+                <h2>Chronicler</h2>
                 <div class="panel-controls">
                     <select id="fleet-metrics-select" aria-label="Select metric series">
                         <option value="">(loading…)</option>

--- a/src/fleet_metrics/catalog.py
+++ b/src/fleet_metrics/catalog.py
@@ -76,3 +76,21 @@ register(Metric(
     description="Number of `test_*.py` files in unitares/tests/ — rough proxy for test-surface breadth.",
     unit="files",
 ))
+
+register(Metric(
+    name="agents.active.7d",
+    description="Distinct agents with any tool call in the last 7 days — fleet liveness curve.",
+    unit="agents",
+))
+
+register(Metric(
+    name="kg.entries.count",
+    description="Total discoveries in the knowledge graph — cumulative KG growth.",
+    unit="entries",
+))
+
+register(Metric(
+    name="checkins.7d",
+    description="`process_agent_update` calls in the last 7 days — governance traffic (feeds paper v7 corpus-maturity status).",
+    unit="calls",
+))

--- a/tests/test_chronicler.py
+++ b/tests/test_chronicler.py
@@ -42,6 +42,50 @@ class TestTokeiScraper:
             tokei_unitares_src_code(tmp_path)
 
 
+class TestDbScrapers:
+    """DB-backed scrapers delegate to `_fetchval`. Test each one calls it
+    with the right SQL shape — the actual DB round-trip is integration-tested
+    elsewhere."""
+
+    def test_agents_active_7d_queries_distinct_tool_usage(self, tmp_path: Path):
+        from agents.chronicler import scrapers
+
+        with patch.object(scrapers, "_fetchval", return_value=42.0) as m:
+            value = scrapers.agents_active_7d(tmp_path)
+
+        assert value == 42.0
+        sql = m.call_args.args[0]
+        assert "count(DISTINCT agent_id)" in sql
+        assert "audit.tool_usage" in sql
+        assert "7 days" in sql
+
+    def test_kg_entries_count_queries_discoveries(self, tmp_path: Path):
+        from agents.chronicler import scrapers
+
+        with patch.object(scrapers, "_fetchval", return_value=137.0) as m:
+            value = scrapers.kg_entries_count(tmp_path)
+
+        assert value == 137.0
+        assert "knowledge.discoveries" in m.call_args.args[0]
+
+    def test_checkins_7d_filters_process_agent_update(self, tmp_path: Path):
+        from agents.chronicler import scrapers
+
+        with patch.object(scrapers, "_fetchval", return_value=9001.0) as m:
+            value = scrapers.checkins_7d(tmp_path)
+
+        assert value == 9001.0
+        sql = m.call_args.args[0]
+        assert "tool_name = 'process_agent_update'" in sql
+        assert "7 days" in sql
+
+    def test_new_scrapers_registered_in_SCRAPERS(self):
+        from agents.chronicler.scrapers import SCRAPERS
+
+        for name in ("agents.active.7d", "kg.entries.count", "checkins.7d"):
+            assert name in SCRAPERS, f"{name} missing from SCRAPERS registry"
+
+
 class TestTestsCountScraper:
     def test_counts_only_test_prefixed_py_files(self, tmp_path: Path):
         from agents.chronicler.scrapers import tests_unitares_count

--- a/tests/test_fleet_metrics.py
+++ b/tests/test_fleet_metrics.py
@@ -24,6 +24,12 @@ class TestCatalog:
         assert entry.unit == "lines"
         assert "unitares" in entry.description
 
+    def test_db_backed_metrics_registered(self):
+        """Chronicler's DB-backed scrapers have catalog entries so the server
+        accepts POSTs from them — a missing catalog entry returns 404."""
+        for name in ("agents.active.7d", "kg.entries.count", "checkins.7d"):
+            assert name in _catalog, f"{name} missing from catalog"
+
     def test_require_known_name_returns_entry(self):
         entry = require("tokei.unitares.src.code")
         assert isinstance(entry, Metric)


### PR DESCRIPTION
## Summary

- Adds three DB-backed scrapers to Chronicler's daily run: `agents.active.7d`, `kg.entries.count`, `checkins.7d`. All three feed the paper-v7 corpus-maturity question (fleet population / KG growth / governance traffic) and nothing else records them longitudinally.
- Renames the bottom dashboard panel `Fleet Metrics` → `Chronicler` (h2 + nav link). Same for the section comment. `Fleet Metrics` collided with `Fleet Average` + `Fleet Heatmap` above it, and the panel *is* Chronicler's output.
- IDs / CSS classes / filenames unchanged — renaming those would thread through fleet-metrics.js + styles.css for zero user-visible benefit.

## Implementation

- `agents/chronicler/scrapers.py` — shared `_fetchval(sql)` using asyncpg + `asyncio.run` (daily cadence; per-call loop setup is cheap at this rate). Env-overridable via `CHRONICLER_DB_DSN`.
- `src/fleet_metrics/catalog.py` — three new `register(Metric(...))` entries. Server rejects POSTs for names missing from catalog, so both sides are updated together.

## Live validation (2026-04-23)

    agents.active.7d        = 583
    checkins.7d             = 2726
    kg.entries.count        = 643
    tests.unitares.count    = 239
    tokei.unitares.src.code = 71904

## Test plan

- [x] `./scripts/dev/test-cache.sh` — 6746 passed, 33 skipped
- [x] Targeted: 37 tests in `test_chronicler.py` + `test_fleet_metrics.py`
- [x] Live dry-run against production DB — all 5 scrapers return sane values
- [ ] Post-merge: next Chronicler daily run (launchd) will write first points for the new series; confirm dashboard dropdown picks them up