### PR TITLE
feat(dashboard): Watcher panel — findings pipeline + pattern dismiss-rate

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -31,6 +31,7 @@
     <script src="/dashboard/timeline.js"></script>
     <script src="/dashboard/residents.js"></script>
     <script src="/dashboard/fleet-metrics.js"></script>
+    <script src="/dashboard/watcher.js"></script>
 </head>
 
 <body>
@@ -78,6 +79,7 @@
         <a href="#dialectic-section" class="section-nav-item" data-section="dialectic-section">Dialectic</a>
         <a href="#activity-timeline-section" class="section-nav-item" data-section="activity-timeline-section">Activity</a>
         <a href="#fleet-metrics-section" class="section-nav-item" data-section="fleet-metrics-section">Chronicler</a>
+        <a href="#watcher-section" class="section-nav-item" data-section="watcher-section">Watcher</a>
         <a href="/phase" style="margin-left:auto; opacity:0.6; padding:6px 14px; border-radius:20px; font-size:0.8rem; font-weight:500; color:var(--text-secondary); text-decoration:none; white-space:nowrap;">Phase Space &rarr;</a>
     </nav>
 
@@ -484,6 +486,58 @@
             <div class="fleet-metrics-chart-wrap">
                 <canvas id="fleet-metrics-chart"></canvas>
                 <div id="fleet-metrics-empty" class="timeline-empty">Loading metrics…</div>
+            </div>
+        </div>
+
+        <!-- Watcher — findings pipeline: open queue, pattern breakdown with
+             dismiss ratio (surfaces noisy rules), daily detect/resolve/dismiss
+             timeline. Backed by /v1/watcher/summary. -->
+        <div class="panel" id="watcher-section">
+            <div class="panel-header">
+                <h2>Watcher</h2>
+                <div class="panel-controls">
+                    <button id="watcher-refresh" class="panel-button" type="button">Refresh</button>
+                </div>
+            </div>
+            <div class="watcher-counts">
+                <div class="watcher-stat">
+                    <span class="watcher-stat-label">open</span>
+                    <span class="watcher-stat-value" id="watcher-count-open">—</span>
+                </div>
+                <div class="watcher-stat">
+                    <span class="watcher-stat-label">resolved</span>
+                    <span class="watcher-stat-value" id="watcher-count-resolved">—</span>
+                </div>
+                <div class="watcher-stat">
+                    <span class="watcher-stat-label">dismissed</span>
+                    <span class="watcher-stat-value" id="watcher-count-dismissed">—</span>
+                </div>
+                <div class="watcher-stat watcher-stat-sev-critical">
+                    <span class="watcher-stat-label">open · critical</span>
+                    <span class="watcher-stat-value" id="watcher-count-critical">—</span>
+                </div>
+                <div class="watcher-stat watcher-stat-sev-high">
+                    <span class="watcher-stat-label">open · high</span>
+                    <span class="watcher-stat-value" id="watcher-count-high">—</span>
+                </div>
+            </div>
+            <div class="watcher-chart-wrap">
+                <canvas id="watcher-timeline-chart"></canvas>
+            </div>
+            <table class="watcher-patterns">
+                <thead>
+                    <tr>
+                        <th>pattern</th>
+                        <th>open</th>
+                        <th>resolved</th>
+                        <th>dismissed</th>
+                        <th>dismiss rate</th>
+                    </tr>
+                </thead>
+                <tbody id="watcher-patterns-body"></tbody>
+            </table>
+            <div class="fleet-metrics-meta">
+                <span id="watcher-meta" class="fleet-metrics-scrape-status"></span>
             </div>
         </div>
 

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -5149,3 +5149,104 @@ main {
     width: 100% !important;
     height: 100% !important;
 }
+
+/* Watcher panel — findings pipeline counts, pattern table, timeline chart.
+ * Chart wrap follows the same grow-loop guard as .fleet-metrics-chart-wrap
+ * (flex fixed-height + overflow:hidden + contain:strict + canvas 100%). */
+.watcher-counts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-bottom: 14px;
+}
+
+.watcher-stat {
+    flex: 1 1 100px;
+    min-width: 100px;
+    padding: 10px 12px;
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.watcher-stat-label {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-secondary);
+}
+
+.watcher-stat-value {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1.35rem;
+    color: var(--text-primary);
+}
+
+.watcher-stat-sev-critical .watcher-stat-value {
+    color: #ef4444;
+}
+
+.watcher-stat-sev-high .watcher-stat-value {
+    color: #f59e0b;
+}
+
+.watcher-chart-wrap {
+    position: relative;
+    flex: 0 0 200px;
+    height: 200px;
+    overflow: hidden;
+    padding: 4px 0;
+    contain: strict;
+    margin-bottom: 14px;
+}
+
+.watcher-chart-wrap canvas {
+    box-sizing: border-box;
+    width: 100% !important;
+    height: 100% !important;
+}
+
+.watcher-patterns {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.86rem;
+    margin-bottom: 10px;
+}
+
+.watcher-patterns th,
+.watcher-patterns td {
+    padding: 6px 8px;
+    text-align: left;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.watcher-patterns th {
+    font-weight: 600;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    font-size: 0.72rem;
+    letter-spacing: 0.05em;
+}
+
+.watcher-patterns td {
+    font-family: 'JetBrains Mono', monospace;
+    color: var(--text-primary);
+}
+
+.watcher-patterns td:first-child {
+    font-weight: 600;
+}
+
+.watcher-dismiss-ratio-high {
+    color: #f59e0b;
+}
+
+.watcher-patterns-empty {
+    color: var(--text-secondary);
+    font-style: italic;
+    text-align: center !important;
+    padding: 18px !important;
+}

--- a/dashboard/watcher.js
+++ b/dashboard/watcher.js
@@ -1,0 +1,225 @@
+// watcher.js — Watcher findings pipeline panel.
+//
+// Consumes:
+//   GET /v1/watcher/summary — counts by status/severity, pattern table, 30d timeline
+//
+// Theme handling mirrors dashboard/eisv-charts.js::makeChartOptions so axis
+// ticks, grid, tooltip, and fonts are legible on the dark theme — Chart.js
+// defaults are dark-grey-on-dark and render invisible.
+// Auth + fetch go through `authFetch` from utils.js.
+
+(function () {
+    'use strict';
+
+    var chart = null;
+
+    function applyChartDefaults() {
+        if (typeof Chart === 'undefined' || !Chart.defaults) return;
+        var bodyStyle = getComputedStyle(document.body);
+        var textSecondary = (bodyStyle.getPropertyValue('--text-secondary') || '').trim() || '#a0a0b0';
+        var fontFamily = (bodyStyle.getPropertyValue('--font-family') || '').trim() || "'Outfit', sans-serif";
+        Chart.defaults.color = textSecondary;
+        if (Chart.defaults.font) {
+            Chart.defaults.font.family = fontFamily;
+        }
+        Chart.defaults.borderColor = 'rgba(255,255,255,0.08)';
+    }
+
+    async function fetchSummary() {
+        try {
+            var resp = await authFetch('/v1/watcher/summary');
+            if (!resp.ok) throw new Error('HTTP ' + resp.status);
+            var data = await resp.json();
+            if (!data || data.success === false) {
+                throw new Error((data && data.error) || 'unknown');
+            }
+            return data;
+        } catch (e) {
+            console.warn('[Watcher] summary fetch failed:', e);
+            return null;
+        }
+    }
+
+    function setMetric(id, value) {
+        var el = document.getElementById(id);
+        if (el) el.textContent = value;
+    }
+
+    function renderCounts(summary) {
+        var byStatus = summary.by_status || {};
+        var bySev = summary.by_severity_open || {};
+        setMetric('watcher-count-open', (byStatus.surfaced || 0) + (byStatus.open || 0));
+        setMetric('watcher-count-resolved', byStatus.resolved || 0);
+        setMetric('watcher-count-dismissed', byStatus.dismissed || 0);
+        setMetric('watcher-count-critical', bySev.critical || 0);
+        setMetric('watcher-count-high', bySev.high || 0);
+    }
+
+    function renderPatterns(summary) {
+        var tbody = document.getElementById('watcher-patterns-body');
+        if (!tbody) return;
+        tbody.innerHTML = '';
+        var patterns = summary.patterns || [];
+        if (patterns.length === 0) {
+            var tr = document.createElement('tr');
+            var td = document.createElement('td');
+            td.colSpan = 5;
+            td.className = 'watcher-patterns-empty';
+            td.textContent = 'No findings yet.';
+            tr.appendChild(td);
+            tbody.appendChild(tr);
+            return;
+        }
+        for (var i = 0; i < patterns.length && i < 12; i++) {
+            var p = patterns[i];
+            var tr = document.createElement('tr');
+            var cells = [
+                p.pattern,
+                String(p.surfaced),
+                String(p.resolved),
+                String(p.dismissed),
+                p.dismiss_ratio == null ? '—' : (Math.round(p.dismiss_ratio * 100) + '%'),
+            ];
+            for (var c = 0; c < cells.length; c++) {
+                var td = document.createElement('td');
+                td.textContent = cells[c];
+                if (c === 4 && p.dismiss_ratio != null && p.dismiss_ratio >= 0.75) {
+                    td.className = 'watcher-dismiss-ratio-high';  // flag noisy rules
+                    td.title = 'Most closed findings for this rule were dismissed — likely false-positive heavy';
+                }
+                tr.appendChild(td);
+            }
+            tbody.appendChild(tr);
+        }
+    }
+
+    function chartOptions() {
+        return {
+            responsive: true,
+            maintainAspectRatio: false,
+            animation: { duration: 300 },
+            interaction: { mode: 'index', intersect: false },
+            plugins: {
+                legend: {
+                    display: true,
+                    position: 'top',
+                    labels: { boxWidth: 12, font: { size: 11 } },
+                },
+                tooltip: {
+                    backgroundColor: 'rgba(13,13,18,0.9)',
+                    titleFont: { family: "'Inter', sans-serif" },
+                    bodyFont: { family: "'JetBrains Mono', monospace", size: 12 },
+                    padding: 10,
+                    borderColor: '#333',
+                    borderWidth: 1,
+                },
+            },
+            scales: {
+                x: {
+                    type: 'time',
+                    time: { unit: 'day', tooltipFormat: 'yyyy-MM-dd' },
+                    grid: { color: 'rgba(255,255,255,0.05)' },
+                    ticks: { color: '#a0a0b0', font: { size: 11 }, maxRotation: 0 },
+                },
+                y: {
+                    beginAtZero: true,
+                    grid: { color: 'rgba(255,255,255,0.05)' },
+                    ticks: {
+                        color: '#a0a0b0',
+                        font: { family: "'JetBrains Mono', monospace", size: 11 },
+                        precision: 0,
+                    },
+                },
+            },
+        };
+    }
+
+    function renderChart(summary) {
+        var canvas = document.getElementById('watcher-timeline-chart');
+        if (!canvas) return;
+
+        var timeline = summary.timeline || [];
+        var hex = (typeof MetricColors !== 'undefined' && MetricColors.HEX) ? MetricColors.HEX : {};
+        var detectedColor = hex.chartSurprise || '#f59e0b';
+        var resolvedColor = hex.chartIntegrity || '#10b981';
+        var dismissedColor = hex.chartDrift || '#6b7280';
+
+        function series(key, color, label) {
+            var data = timeline.map(function (d) {
+                return { x: new Date(d.day + 'T00:00:00Z'), y: d[key] || 0 };
+            });
+            return {
+                label: label,
+                data: data,
+                borderColor: color,
+                backgroundColor: color + '33',
+                fill: false,
+                tension: 0.2,
+                pointRadius: 2,
+            };
+        }
+
+        if (chart) chart.destroy();
+        // eslint-disable-next-line no-undef
+        chart = new Chart(canvas.getContext('2d'), {
+            type: 'line',
+            data: {
+                datasets: [
+                    series('detected', detectedColor, 'new findings'),
+                    series('resolved', resolvedColor, 'resolved'),
+                    series('dismissed', dismissedColor, 'dismissed'),
+                ],
+            },
+            options: chartOptions(),
+        });
+    }
+
+    function formatRelative(isoStr) {
+        if (!isoStr) return '';
+        var then = new Date(isoStr);
+        var secs = Math.floor((Date.now() - then.getTime()) / 1000);
+        if (secs < 60) return 'just now';
+        if (secs < 3600) return Math.floor(secs / 60) + 'm ago';
+        if (secs < 86400) return Math.floor(secs / 3600) + 'h ago';
+        return Math.floor(secs / 86400) + 'd ago';
+    }
+
+    function setFooter(summary) {
+        var el = document.getElementById('watcher-meta');
+        if (!el) return;
+        el.textContent = 'total findings ever: ' + (summary.total || 0)
+            + ' · window: ' + (summary.window_days || 30) + ' days'
+            + ' · refreshed ' + formatRelative(summary.generated_at);
+    }
+
+    async function refresh() {
+        var summary = await fetchSummary();
+        if (!summary) {
+            setMetric('watcher-count-open', '—');
+            setMetric('watcher-count-resolved', '—');
+            setMetric('watcher-count-dismissed', '—');
+            setMetric('watcher-count-critical', '—');
+            setMetric('watcher-count-high', '—');
+            return;
+        }
+        renderCounts(summary);
+        renderPatterns(summary);
+        renderChart(summary);
+        setFooter(summary);
+    }
+
+    function wire() {
+        applyChartDefaults();
+        var btn = document.getElementById('watcher-refresh');
+        if (btn) btn.addEventListener('click', refresh);
+        refresh();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', wire);
+    } else {
+        wire();
+    }
+
+    window.WatcherPanel = { refresh: refresh };
+})();

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -863,7 +863,7 @@ async def http_dashboard_static(request):
         "utils.js", "state.js", "colors.js", "components.js",
         "visualizations.js", "agents.js", "discoveries.js",
         "dialectic.js", "eisv-charts.js", "timeline.js",
-        "residents.js", "fleet-metrics.js",
+        "residents.js", "fleet-metrics.js", "watcher.js",
         "styles.css", "dashboard.js",
         "phase.js",
     ]
@@ -1203,6 +1203,142 @@ async def http_get_metrics_catalog(request):
             for m in sorted(_catalog.values(), key=lambda x: x.name)
         ],
     })
+
+
+_WATCHER_FINDINGS_PATH = (
+    Path(__file__).resolve().parent.parent / "data" / "watcher" / "findings.jsonl"
+)
+_WATCHER_DAILY_WINDOW_DAYS = 30
+
+
+def _watcher_summary_from_rows(rows, now=None, window_days=_WATCHER_DAILY_WINDOW_DAYS):
+    """Aggregate watcher findings.jsonl rows into dashboard-ready shape.
+
+    Pure function so test coverage doesn't need to stand up the full HTTP app —
+    feed it a list of parsed-dict rows, get back the counts + daily buckets.
+    """
+    from collections import Counter, defaultdict
+    from datetime import datetime, timedelta, timezone
+
+    by_status = Counter()
+    by_severity = Counter()   # open-only (surfaced + open) — the actionable queue
+    by_pattern = defaultdict(lambda: {"surfaced": 0, "resolved": 0, "dismissed": 0, "other": 0})
+    daily = defaultdict(int)  # yyyy-mm-dd → count of detected_at in that day
+    resolutions_daily = defaultdict(lambda: {"resolved": 0, "dismissed": 0})
+
+    if now is None:
+        now = datetime.now(timezone.utc)
+    window_start = (now - timedelta(days=window_days - 1)).date()
+
+    def _parse_date(value):
+        if not value:
+            return None
+        try:
+            # Tolerate trailing Z and no tz
+            if value.endswith("Z"):
+                value = value[:-1] + "+00:00"
+            return datetime.fromisoformat(value)
+        except Exception:
+            return None
+
+    for row in rows:
+        status = str(row.get("status", "surfaced"))
+        pattern = str(row.get("pattern") or "?")
+        severity = str(row.get("severity") or "?")
+        by_status[status] += 1
+
+        bucket = by_pattern[pattern]
+        if status in ("resolved", "dismissed"):
+            bucket[status] += 1
+        elif status in ("surfaced", "open"):
+            bucket["surfaced"] += 1
+            by_severity[severity] += 1
+        else:
+            bucket["other"] += 1
+
+        detected = _parse_date(row.get("detected_at"))
+        if detected and detected.date() >= window_start:
+            daily[detected.date().isoformat()] += 1
+
+        # Resolution timestamp if present (fields used by watcher agent:
+        # resolved_at / dismissed_at)
+        for key in ("resolved_at", "dismissed_at"):
+            ts = _parse_date(row.get(key))
+            if ts and ts.date() >= window_start:
+                kind = "resolved" if key == "resolved_at" else "dismissed"
+                resolutions_daily[ts.date().isoformat()][kind] += 1
+
+    # Pattern table — include resolve/dismiss ratio for noise detection
+    patterns_out = []
+    for pat, b in by_pattern.items():
+        total_closed = b["resolved"] + b["dismissed"]
+        dismiss_ratio = (b["dismissed"] / total_closed) if total_closed else None
+        patterns_out.append({
+            "pattern": pat,
+            "surfaced": b["surfaced"],
+            "resolved": b["resolved"],
+            "dismissed": b["dismissed"],
+            "other": b["other"],
+            "dismiss_ratio": dismiss_ratio,
+        })
+    patterns_out.sort(
+        key=lambda p: (-p["surfaced"], -(p["resolved"] + p["dismissed"]), p["pattern"])
+    )
+
+    # Daily series spans the full window so the chart renders zeros instead of gaps
+    timeline = []
+    for i in range(window_days):
+        day = (window_start + timedelta(days=i)).isoformat()
+        timeline.append({
+            "day": day,
+            "detected": daily.get(day, 0),
+            "resolved": resolutions_daily[day]["resolved"],
+            "dismissed": resolutions_daily[day]["dismissed"],
+        })
+
+    return {
+        "total": sum(by_status.values()),
+        "by_status": dict(by_status),
+        "by_severity_open": dict(by_severity),
+        "patterns": patterns_out,
+        "timeline": timeline,
+        "window_days": window_days,
+        "generated_at": now.isoformat(),
+    }
+
+
+async def http_watcher_summary(request):
+    """GET /v1/watcher/summary — aggregate Watcher findings for the dashboard panel.
+
+    Reads data/watcher/findings.jsonl in-process (watcher's append-only audit
+    log) and returns counts + a daily time series. Data is gitignored, so
+    absence = empty summary (not an error)."""
+    http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
+    if not _check_http_auth(request, http_api_token=http_api_token):
+        return _http_unauthorized()
+
+    rows = []
+    path = _WATCHER_FINDINGS_PATH
+    try:
+        if path.exists():
+            with path.open("r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rows.append(json.loads(line))
+                    except Exception:
+                        # Skip malformed lines silently — findings.jsonl is
+                        # append-only and a partial write shouldn't 500 the panel.
+                        continue
+    except OSError as e:
+        return JSONResponse({"success": False, "error": f"findings read failed: {e}"}, status_code=500)
+
+    summary = _watcher_summary_from_rows(rows)
+    summary["success"] = True
+    summary["findings_path"] = str(path)
+    return JSONResponse(summary)
 
 
 async def http_record_finding(request):
@@ -1897,6 +2033,7 @@ def register_http_routes(
     app.routes.append(Route("/v1/metrics", http_post_metric, methods=["POST"]))
     app.routes.append(Route("/v1/metrics/series", http_get_metrics, methods=["GET"]))
     app.routes.append(Route("/v1/metrics/catalog", http_get_metrics_catalog, methods=["GET"]))
+    app.routes.append(Route("/v1/watcher/summary", http_watcher_summary, methods=["GET"]))
     app.routes.append(Route("/api/activity", http_activity, methods=["GET"]))
     app.routes.append(Route("/api/incidents", http_incidents, methods=["GET"]))
     app.routes.append(Route("/v1/residents", http_residents, methods=["GET"]))

--- a/tests/test_http_api_watcher_summary.py
+++ b/tests/test_http_api_watcher_summary.py
@@ -1,0 +1,173 @@
+"""Tests for _watcher_summary_from_rows — the pure aggregator behind
+/v1/watcher/summary. We test the aggregator directly so the test doesn't need
+to stand up Starlette or touch the filesystem; endpoint wiring is covered by
+the dashboard-allowlist regression and the route-registration smoke."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.http_api import _watcher_summary_from_rows
+
+
+NOW = datetime(2026, 4, 23, 12, 0, tzinfo=timezone.utc)
+
+
+def _row(**kwargs):
+    base = {
+        "pattern": "P001",
+        "severity": "high",
+        "detected_at": NOW.isoformat(),
+        "status": "surfaced",
+    }
+    base.update(kwargs)
+    return base
+
+
+class TestStatusAndSeverityCounts:
+    def test_empty_input_returns_zeroed_shape(self):
+        out = _watcher_summary_from_rows([], now=NOW, window_days=7)
+        assert out["total"] == 0
+        assert out["by_status"] == {}
+        assert out["by_severity_open"] == {}
+        assert out["patterns"] == []
+        assert len(out["timeline"]) == 7
+        assert all(d["detected"] == 0 for d in out["timeline"])
+
+    def test_status_counter_counts_everything(self):
+        rows = [
+            _row(status="surfaced"),
+            _row(status="surfaced"),
+            _row(status="resolved"),
+            _row(status="dismissed"),
+        ]
+        out = _watcher_summary_from_rows(rows, now=NOW)
+        assert out["by_status"] == {"surfaced": 2, "resolved": 1, "dismissed": 1}
+        assert out["total"] == 4
+
+    def test_severity_counts_only_open_findings(self):
+        """by_severity_open is the actionable queue; resolved/dismissed shouldn't
+        show up there or the panel implies ongoing severity that isn't real."""
+        rows = [
+            _row(severity="critical", status="surfaced"),
+            _row(severity="high", status="surfaced"),
+            _row(severity="critical", status="resolved"),   # closed — excluded
+            _row(severity="critical", status="dismissed"),  # closed — excluded
+        ]
+        out = _watcher_summary_from_rows(rows, now=NOW)
+        assert out["by_severity_open"] == {"critical": 1, "high": 1}
+
+
+class TestPatternTable:
+    def test_pattern_breakdown_with_dismiss_ratio(self):
+        """Patterns that get dismissed frequently are the false-positive-heavy
+        rules — surfacing dismiss_ratio on the panel lets an operator spot
+        noisy rules at a glance."""
+        rows = [
+            _row(pattern="P008", status="dismissed"),
+            _row(pattern="P008", status="dismissed"),
+            _row(pattern="P008", status="dismissed"),  # 3/3 dismissed — noisy
+            _row(pattern="P001", status="resolved"),
+            _row(pattern="P001", status="resolved"),   # 0/2 dismissed — signal
+            _row(pattern="P001", status="surfaced"),   # 1 still open
+        ]
+        out = _watcher_summary_from_rows(rows, now=NOW)
+        by = {p["pattern"]: p for p in out["patterns"]}
+        assert by["P008"]["dismissed"] == 3 and by["P008"]["resolved"] == 0
+        assert by["P008"]["dismiss_ratio"] == pytest.approx(1.0)
+        assert by["P001"]["resolved"] == 2 and by["P001"]["dismissed"] == 0
+        assert by["P001"]["dismiss_ratio"] == pytest.approx(0.0)
+
+    def test_dismiss_ratio_is_none_when_nothing_closed(self):
+        """With no closed findings for a pattern, the ratio is undefined —
+        returning None lets the frontend render a dash instead of 0.0 which
+        would falsely imply 'this rule is never dismissed'."""
+        out = _watcher_summary_from_rows([_row(pattern="P999", status="surfaced")], now=NOW)
+        p = out["patterns"][0]
+        assert p["surfaced"] == 1
+        assert p["dismiss_ratio"] is None
+
+    def test_patterns_sorted_by_open_count_desc(self):
+        rows = [
+            _row(pattern="P_LOW", status="surfaced"),
+            _row(pattern="P_HIGH", status="surfaced"),
+            _row(pattern="P_HIGH", status="surfaced"),
+            _row(pattern="P_HIGH", status="surfaced"),
+        ]
+        out = _watcher_summary_from_rows(rows, now=NOW)
+        assert [p["pattern"] for p in out["patterns"]] == ["P_HIGH", "P_LOW"]
+
+
+class TestTimeline:
+    def test_timeline_spans_full_window_with_zeros(self):
+        """Even with a single finding, the chart should have a point for every
+        day in the window so the line renders continuously, not with gaps."""
+        rows = [_row(detected_at=NOW.isoformat())]
+        out = _watcher_summary_from_rows(rows, now=NOW, window_days=5)
+        assert len(out["timeline"]) == 5
+        days_with_data = [d for d in out["timeline"] if d["detected"] > 0]
+        assert len(days_with_data) == 1
+        assert days_with_data[0]["detected"] == 1
+
+    def test_timeline_buckets_detections_by_day(self):
+        day_a = datetime(2026, 4, 20, 10, 0, tzinfo=timezone.utc)
+        day_b = datetime(2026, 4, 22, 10, 0, tzinfo=timezone.utc)
+        rows = [
+            _row(detected_at=day_a.isoformat()),
+            _row(detected_at=day_a.isoformat()),
+            _row(detected_at=day_b.isoformat()),
+        ]
+        out = _watcher_summary_from_rows(rows, now=NOW, window_days=7)
+        by_day = {d["day"]: d for d in out["timeline"]}
+        assert by_day["2026-04-20"]["detected"] == 2
+        assert by_day["2026-04-22"]["detected"] == 1
+
+    def test_timeline_excludes_findings_outside_window(self):
+        old = (NOW - timedelta(days=45)).isoformat()
+        out = _watcher_summary_from_rows([_row(detected_at=old)], now=NOW, window_days=30)
+        assert all(d["detected"] == 0 for d in out["timeline"])
+
+    def test_timeline_captures_resolved_and_dismissed_timestamps(self):
+        resolved_day = datetime(2026, 4, 21, 14, 0, tzinfo=timezone.utc)
+        dismissed_day = datetime(2026, 4, 22, 14, 0, tzinfo=timezone.utc)
+        rows = [
+            _row(
+                detected_at=(NOW - timedelta(days=1)).isoformat(),
+                status="resolved",
+                resolved_at=resolved_day.isoformat(),
+            ),
+            _row(
+                detected_at=(NOW - timedelta(days=1)).isoformat(),
+                status="dismissed",
+                dismissed_at=dismissed_day.isoformat(),
+            ),
+        ]
+        out = _watcher_summary_from_rows(rows, now=NOW, window_days=7)
+        by_day = {d["day"]: d for d in out["timeline"]}
+        assert by_day["2026-04-21"]["resolved"] == 1
+        assert by_day["2026-04-22"]["dismissed"] == 1
+
+
+class TestRobustness:
+    def test_row_with_trailing_Z_timestamp_parses(self):
+        """Watcher writes timestamps like '2026-04-14T10:57:11Z' — Python 3.10
+        datetime.fromisoformat rejects the trailing Z, so the aggregator must
+        tolerate it."""
+        rows = [_row(detected_at="2026-04-23T00:00:00Z")]
+        out = _watcher_summary_from_rows(rows, now=NOW, window_days=2)
+        by_day = {d["day"]: d for d in out["timeline"]}
+        assert by_day["2026-04-23"]["detected"] == 1
+
+    def test_row_with_malformed_timestamp_does_not_crash(self):
+        rows = [_row(detected_at="not-a-date")]
+        out = _watcher_summary_from_rows(rows, now=NOW)
+        # Still counted in totals, just not placed on the timeline
+        assert out["total"] == 1
+        assert all(d["detected"] == 0 for d in out["timeline"])
+
+    def test_row_without_pattern_falls_under_question_mark(self):
+        rows = [_row(pattern=None, status="surfaced")]
+        out = _watcher_summary_from_rows(rows, now=NOW)
+        assert out["patterns"][0]["pattern"] == "?"


### PR DESCRIPTION
## Summary
Adds a Watcher section to the unitares dashboard, mirroring the Chronicler pattern. Surfaces the findings pipeline in four ways:

- **Counts** (top): open / resolved / dismissed totals, plus open-by-severity (critical, high)
- **Timeline** (30d): detections vs. resolutions vs. dismissals per day, so the "findings pile up faster than triage" failure mode is visible
- **Pattern table**: per-rule breakdown with a **dismiss rate** column — rules that hit ≥75% dismiss rate are flagged amber. This would have surfaced during the Lumen audit that P008 (shell injection) was firing as false positives on list-form subprocess.
- **Footer**: total findings ever + window + refresh time

## Backend
New endpoint `GET /v1/watcher/summary` reads `data/watcher/findings.jsonl` in-process (append-only audit log, gitignored). Aggregation lives in pure function `_watcher_summary_from_rows` so tests don't need Starlette or filesystem. Timeline spans full window with zero-fill so the chart renders continuous lines, not gapped.

## Dashboard conventions
Followed the `unitares-dashboard` skill checklist:
- `watcher.js` added to `http_dashboard_static` allowlist (covered by `test_dashboard_static_allowlist` regression)
- Script tag without `defer`, after `fleet-metrics.js`
- `authFetch` from `utils.js`, `MetricColors.HEX` palette, themed Chart.js defaults
- `.watcher-chart-wrap` uses the same grow-loop guard as `.fleet-metrics-chart-wrap` (fixed flex-basis + `overflow:hidden` + `contain:strict` + canvas 100%)

## Test plan
- [x] 13 new unit tests covering the aggregator: status/severity/pattern counts, dismiss-ratio edge cases (None when no closed findings), timeline bucketing, window exclusion, trailing-Z timestamp tolerance, malformed-row resilience
- [x] Existing `test_dashboard_static_allowlist` still passes (picks up `watcher.js` automatically)
- [x] Full suite: 6409 passed, 33 skipped
- [ ] Post-deploy: restart governance-mcp launchd, hard-refresh dashboard, DevTools Console clean, tick colors not `rgb(102,102,102)`, `curl -sI /dashboard/watcher.js` returns 200

## Motivation
Surfaced during the Lumen audit session: three Watcher findings (#1c7de136, #a6f1f50e, #e58560c9) were all dismissed as false positives. Without a panel, the noisy rules stay invisible; you only discover them when they chime at you one at a time. With the dismiss-rate column, the next session starts with that context in one glance.