### PR TITLE
Constrain Watcher panel to 1400px like the other out-of-grid panels

### DIFF
--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -4907,11 +4907,12 @@ main {
     margin-right: auto;
 }
 
-/* Activity timeline and Fleet Metrics sit outside .main-content, so
-   .panel's default (no max-width) makes them stretch the full viewport.
+/* Activity timeline, Fleet Metrics, and Watcher sit outside .main-content,
+   so .panel's default (no max-width) makes them stretch the full viewport.
    Match the 1400px column used by .main-content above. */
 #activity-timeline-section,
-#fleet-metrics-section {
+#fleet-metrics-section,
+#watcher-section {
     max-width: 1400px;
     margin-left: auto;
     margin-right: auto;


### PR DESCRIPTION
Follow-up to #116. The Watcher panel sits outside `.main-content` alongside Activity Timeline and Fleet Metrics, but was missing from the shared `max-width: 1400px` selector — so it rendered full-viewport while peers stayed in the centered 1400px column. One-line CSS fix.