### PR TITLE
Watcher P008: tighten rule text + AST post-filter for list-form subprocess

### DIFF
--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -746,6 +746,68 @@ def _looks_like_comment(line: str) -> bool:
     return False
 
 
+def p008_actually_fires(file_path: str, line: int) -> bool:
+    """AST post-filter for P008 (shell injection).
+
+    The LLM keeps flagging list-form subprocess calls as P008 even though
+    the rule text says list-form is exempt. This deterministic check parses
+    the target file and suppresses the finding when no call at/spanning the
+    flagged line actually uses the shell (shell=True or os.system/os.popen).
+
+    Conservative on errors: if we can't parse the file or resolve the call,
+    return True so the finding is NOT suppressed — human review is still
+    valuable when we can't verify the exemption.
+
+    Returns True  → finding is a possible real P008; keep it
+    Returns False → verified false positive; suppress it
+    """
+    import ast
+
+    try:
+        source = Path(file_path).read_text()
+    except (OSError, UnicodeDecodeError):
+        return True  # can't read → don't hide from humans
+
+    if not file_path.endswith(".py"):
+        # P008 is Python-shell-injection; other languages not covered here.
+        # Don't suppress for now — falls back to the LLM's judgment.
+        return True
+
+    try:
+        tree = ast.parse(source, filename=file_path)
+    except SyntaxError:
+        return True  # can't parse → don't hide
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        start = getattr(node, "lineno", 0)
+        end = getattr(node, "end_lineno", start)
+        if not (start <= line <= end):
+            continue
+
+        # os.system(...) / os.popen(...) are always shell-bound
+        func = node.func
+        name = None
+        if isinstance(func, ast.Attribute):
+            name = func.attr
+            module = func.value.id if isinstance(func.value, ast.Name) else None
+            if module == "os" and name in ("system", "popen"):
+                return True
+            if module == "subprocess":
+                # subprocess.run / Popen / call / check_call / check_output
+                for kw in node.keywords:
+                    if kw.arg == "shell" and isinstance(kw.value, ast.Constant) and kw.value.value is True:
+                        return True
+        elif isinstance(func, ast.Name):
+            # Bare `system(...)` or `popen(...)` — unlikely but possible via `from os import system`
+            if func.id in ("system", "popen"):
+                return True
+
+    # No call at this line uses shell=True or os.system/popen → verified FP.
+    return False
+
+
 def parse_findings(
     text: str, file_path: str, model_used: str, region_start: int
 ) -> list[tuple[Finding, str]]:
@@ -817,6 +879,18 @@ def parse_findings(
         evidence = str(rf.get("evidence", "")).strip()[:300]
         # Authoritative severity comes from the library, never the model.
         severity = library_severities[pattern]
+
+        # P008 post-filter: the LLM keeps flagging list-form subprocess as
+        # shell injection. Verify with an AST scan; suppress when no call
+        # at this line uses shell=True / os.system / os.popen.
+        if pattern == "P008" and not p008_actually_fires(file_path, line):
+            log(
+                f"suppressing P008 false-positive at {file_path}:{line} "
+                f"(no shell=True / os.system at that line)",
+                "debug",
+            )
+            continue
+
         findings.append(
             (
                 Finding(

--- a/agents/watcher/patterns.md
+++ b/agents/watcher/patterns.md
@@ -154,8 +154,23 @@ failure the caller needs to know about.
 
 ### P008 — Unchecked shell input (severity: critical, violation_class: VOI)
 
-`subprocess.run(..., shell=True)` or `os.system(...)` with any string that
-includes user/external input without `shlex.quote` or a list-form invocation.
+Fire **only** when both conditions hold:
+1. The call is `subprocess.*(..., shell=True)` OR `os.system(...)` OR `os.popen(...)`.
+2. The command string includes user/external input without `shlex.quote`.
+
+**Do NOT fire** on list-form subprocess calls — those bypass the shell entirely
+and are the recommended safe form. Examples that must NOT be flagged:
+```python
+subprocess.run(["find", path, "-name", "*.py"], check=True)
+subprocess.run(["wc", "-l"] + files, capture_output=True)
+subprocess.Popen(["git", "log", "--oneline"])
+```
+
+Examples that SHOULD be flagged:
+```python
+subprocess.run(f"find {path} -name '*.py'", shell=True)  # unquoted interpolation
+os.system("rm -rf " + user_input)                         # shell + external input
+```
 
 **Hint template:** `shell injection — use shlex.quote or list-form subprocess`
 

--- a/tests/test_watcher_p008_post_filter.py
+++ b/tests/test_watcher_p008_post_filter.py
@@ -1,0 +1,117 @@
+"""Tests for p008_actually_fires — AST post-filter that suppresses list-form
+subprocess findings the LLM keeps mis-flagging as shell injection.
+
+Rule (from patterns.md): P008 fires only when the call is
+subprocess.*(shell=True) or os.system(...) or os.popen(...).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agents.watcher.agent import p008_actually_fires
+
+
+def _write(tmp_path: Path, name: str, source: str) -> Path:
+    p = tmp_path / name
+    p.write_text(source)
+    return p
+
+
+class TestFalsePositiveSuppression:
+    """List-form subprocess and no-shell calls must be suppressed."""
+
+    def test_list_form_subprocess_run_is_suppressed(self, tmp_path):
+        p = _write(tmp_path, "a.py", 'import subprocess\nsubprocess.run(["find", "."])\n')
+        assert p008_actually_fires(str(p), line=2) is False
+
+    def test_list_form_with_concat_is_suppressed(self, tmp_path):
+        # Mirrors the real scrapers.py:71 case that was flagged as a fp.
+        source = 'import subprocess\nfiles = ["a.py", "b.py"]\nsubprocess.run(["wc", "-l"] + files)\n'
+        p = _write(tmp_path, "a.py", source)
+        assert p008_actually_fires(str(p), line=3) is False
+
+    def test_popen_list_form_is_suppressed(self, tmp_path):
+        p = _write(tmp_path, "a.py", 'import subprocess\nsubprocess.Popen(["git", "log"])\n')
+        assert p008_actually_fires(str(p), line=2) is False
+
+    def test_explicit_shell_false_is_suppressed(self, tmp_path):
+        p = _write(tmp_path, "a.py", 'import subprocess\nsubprocess.run(["ls"], shell=False)\n')
+        assert p008_actually_fires(str(p), line=2) is False
+
+    def test_multiline_list_form_is_suppressed(self, tmp_path):
+        source = (
+            "import subprocess\n"
+            "subprocess.run(\n"
+            '    ["find", ".", "-type", "f"],\n'
+            "    check=True,\n"
+            ")\n"
+        )
+        p = _write(tmp_path, "a.py", source)
+        # LLM typically flags the opening line
+        assert p008_actually_fires(str(p), line=2) is False
+
+
+class TestRealPositivesKept:
+    """Actual shell=True / os.system calls must NOT be suppressed."""
+
+    def test_shell_true_kept(self, tmp_path):
+        p = _write(tmp_path, "a.py", 'import subprocess\nsubprocess.run("find .", shell=True)\n')
+        assert p008_actually_fires(str(p), line=2) is True
+
+    def test_os_system_kept(self, tmp_path):
+        p = _write(tmp_path, "a.py", 'import os\nos.system("rm -rf /tmp/x")\n')
+        assert p008_actually_fires(str(p), line=2) is True
+
+    def test_os_popen_kept(self, tmp_path):
+        p = _write(tmp_path, "a.py", 'import os\nos.popen("ls")\n')
+        assert p008_actually_fires(str(p), line=2) is True
+
+    def test_multiline_shell_true_kept_when_flagged_on_opening_line(self, tmp_path):
+        source = (
+            "import subprocess\n"
+            "subprocess.run(\n"
+            '    "find . -type f",\n'
+            "    shell=True,\n"
+            ")\n"
+        )
+        p = _write(tmp_path, "a.py", source)
+        # Finding flagged on opening line — span includes shell=True on line 4
+        assert p008_actually_fires(str(p), line=2) is True
+
+
+class TestConservativeOnError:
+    """When we can't verify, keep the finding — humans review what we can't check."""
+
+    def test_missing_file_is_conservative(self, tmp_path):
+        assert p008_actually_fires(str(tmp_path / "nonexistent.py"), line=10) is True
+
+    def test_syntax_error_is_conservative(self, tmp_path):
+        p = _write(tmp_path, "a.py", "def oops(:\n")
+        assert p008_actually_fires(str(p), line=1) is True
+
+    def test_non_python_file_is_conservative(self, tmp_path):
+        p = _write(tmp_path, "a.sh", 'rm -rf "$1"\n')
+        # P008 is Python-scoped; we don't know how to verify shell vars — keep it.
+        assert p008_actually_fires(str(p), line=1) is True
+
+
+class TestEdgeCases:
+    def test_no_call_at_line_is_suppressed(self, tmp_path):
+        # If the LLM flagged a line that doesn't have any Call node at all
+        # (e.g. a comment or blank), no shell=True exists there → suppress.
+        source = "import subprocess\n# just a comment\nsubprocess.run(['ls'])\n"
+        p = _write(tmp_path, "a.py", source)
+        assert p008_actually_fires(str(p), line=2) is False
+
+    def test_shell_variable_is_conservative_enough_to_suppress(self, tmp_path):
+        # `shell=use_shell` is a non-constant value — the AST check looks for
+        # the literal True constant, so a variable doesn't count as proof of
+        # shell. Suppressed for now; humans can still inspect via manual review.
+        source = 'import subprocess\nuse_shell = True\nsubprocess.run("ls", shell=use_shell)\n'
+        p = _write(tmp_path, "a.py", source)
+        # This is an acknowledged limitation — dynamic shell=var won't be kept
+        # by the AST check. Value-flow analysis would be out of scope here.
+        assert p008_actually_fires(str(p), line=3) is False


### PR DESCRIPTION
## Summary
P008 (shell injection) was firing on list-form subprocess calls that the rule's own text exempts. On Lumen the dismiss rate hit **100% (3/3)** — the dashboard panel shipped in #116 surfaced this via the dismiss-ratio column and made it actionable.

Two fixes bundled:

### A. `patterns.md` P008 — tighter rule text
Expand the rule with explicit positive **and** negative examples. The LLM (`qwen3-coder-next:latest`) was pattern-matching on `subprocess` + external-looking args rather than on the actual `shell=True` / `os.system` negative gate.

### B. `agent.py::p008_actually_fires` — deterministic AST post-filter
After the LLM flags P008 with a file+line, parse the file and walk `Call` nodes that span that line. Suppress the finding when none are `os.system` / `os.popen` / `subprocess.*(shell=True)`. Conservative on read errors, parse errors, and non-Python files — those keep the finding so humans still review.

The AST check runs inside `parse_findings`, right after pattern-validation, before the `Finding` object is constructed. No other patterns are affected.

## Known limitations
- `subprocess.run(..., shell=use_shell)` with a variable is suppressed (the AST check looks for the literal `True` constant). Value-flow analysis is out of scope. This is an acknowledged miss for a rare pattern.
- Non-Python files are kept (P008 is Python-scoped).

## Test plan
- [x] 14 new tests in `test_watcher_p008_post_filter.py` covering: list-form suppression (single-line, multi-line, with concat), popen list-form, `shell=False`; real-positive retention (`shell=True` single-line + multi-line, `os.system`, `os.popen`); conservative-on-error (missing file, syntax error, non-Python); edge cases (no call at line, `shell=var` dynamic).
- [x] Full suite: 6429 passed, 33 skipped
- [ ] Post-deploy: new P008 false positives should stop landing in findings.jsonl. The Watcher panel's dismiss-rate column will drop P008 off the ≥75% amber threshold as the next detections flow through.

## Related
Audit session close-out: #15, #16, #17, #18, #19 (anima-mcp), #116, #117 (unitares), and this. If P008 dismiss rate stays high after this, the next move would be retiring the rule.