### PR TITLE
refactor(watcher): split findings.py + _util.py out of agent.py

agent.py dropped from 2023 → 1450 LOC by moving the finding model, dedup,
persistence, status lifecycle, formatting, compaction, and KG escalation
into agents/watcher/findings.py (587 LOC). A new agents/watcher/_util.py
(89 LOC) holds log/path/hash leaf helpers so findings.py can depend on
them without circular imports.

Identity, scanning, and CLI orchestration stay in agent.py. surface_pending
and _post_resolution_event also stay — they couple findings logic to the
identity block (_do_checkin / get_watcher_identity).

No behavioral changes. 134 watcher tests + full 6770-test suite all pass.
Test fixture updated: _isolate_watcher_state now patches the split-out
modules at source, and three helper patchers (_mock_post_finding,
_mock_escalate_to_kg, _mock_watcher_identity) mirror patches across the
importlib watcher_module copy, the real agents.watcher.agent module, and
findings module so the test monkeypatches reach every call site.

### DIFF
--- a/agents/watcher/_util.py
+++ b/agents/watcher/_util.py
@@ -1,0 +1,89 @@
+"""Leaf utilities shared by agent.py and findings.py.
+
+Split out so findings.py can depend on log/path helpers without pulling
+agent.py (which would create a circular import, since agent.py imports
+from findings.py).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+LOG_FILE = Path.home() / "Library" / "Logs" / "unitares-watcher.log"
+
+# Cap for ~/Library/Logs/unitares-watcher.log rotation. Watcher logs a few
+# lines per scan; 5000 lines ≈ 500 scans of operational history, which is
+# plenty for debugging. Without this, the log file was a direct P002 match
+# against the Watcher's own pattern library — unbounded append forever.
+MAX_LOG_LINES = 5000
+
+
+def log(msg: str, level: str = "info") -> None:
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    line = f"{ts} [{level}] {msg}\n"
+    try:
+        with LOG_FILE.open("a") as f:
+            f.write(line)
+    except OSError:
+        pass  # never let logging errors take down the watcher
+    if os.environ.get("WATCHER_DEBUG") == "1":
+        sys.stderr.write(line)
+
+
+_REPO_ROOT_CACHE: dict[str, str] = {}
+
+
+def repo_relative_path(file_path: str) -> str:
+    """Return ``file_path`` relative to its containing git worktree root.
+
+    Falls back to the absolute string if the path is not inside a git
+    repository or git invocation fails. Result is normalized to forward
+    slashes so the fingerprint is platform-stable.
+
+    Cached per-directory because hook-driven scans hit the same worktree
+    over and over and ``git rev-parse`` is otherwise tens of ms each call.
+    """
+    if not file_path:
+        return file_path
+    p = Path(file_path)
+    parent_key = str(p.parent if p.is_absolute() else p.resolve().parent)
+    toplevel = _REPO_ROOT_CACHE.get(parent_key)
+    if toplevel is None:
+        try:
+            result = subprocess.run(
+                ["git", "-C", parent_key, "rev-parse", "--show-toplevel"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+            toplevel = result.stdout.strip() if result.returncode == 0 else ""
+        except (OSError, subprocess.SubprocessError):
+            toplevel = ""
+        _REPO_ROOT_CACHE[parent_key] = toplevel
+    if not toplevel:
+        return file_path
+    try:
+        rel = Path(file_path).resolve().relative_to(Path(toplevel).resolve())
+    except ValueError:
+        return file_path
+    return rel.as_posix()
+
+
+def hash_line_content(source_line: str | None) -> str:
+    """Stable hash of a source line for content-aware fingerprinting.
+
+    Whitespace is stripped from both ends so indent-only reformats do not
+    trigger spurious re-flags. Internal whitespace is preserved because it
+    can be semantically meaningful (e.g. dict literal formatting).
+    """
+    normalized = (source_line or "").strip()
+    return hashlib.sha256(normalized.encode()).hexdigest()[:12]

--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -43,7 +43,6 @@ Design notes:
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import os
 import re
@@ -51,7 +50,7 @@ import subprocess
 import sys
 import time
 import urllib.request
-from dataclasses import dataclass, asdict, field
+from dataclasses import asdict, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -60,18 +59,50 @@ from typing import Any
 # Paths & Config
 # ---------------------------------------------------------------------------
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+# PROJECT_ROOT is defined in _util so findings.py can import it without a
+# circular dependency; the sys.path insert still has to happen before the
+# common.* / unitares_sdk imports below.
+from agents.watcher._util import (
+    LOG_FILE,
+    MAX_LOG_LINES,
+    PROJECT_ROOT,
+    hash_line_content,
+    log,
+    repo_relative_path,
+)
+
 sys.path.insert(0, str(PROJECT_ROOT))
 from agents.common.log import trim_log as _common_trim_log
 from agents.common.findings import post_finding
+from agents.watcher import findings as _findings_mod
+from agents.watcher.findings import (
+    DEDUP_FILE,
+    FINDINGS_FILE,
+    FINDINGS_TTL_DAYS,
+    GOV_REST_URL,
+    MIN_FINGERPRINT_PREFIX,
+    STATE_DIR,
+    VALID_FINDING_STATUSES,
+    Finding,
+    _escalate_to_kg,
+    _format_findings_block,
+    _iter_findings_raw,
+    _write_findings_atomic,
+    compact_findings,
+    escalate,
+    load_dedup,
+    match_fingerprint,
+    persist_finding,
+    persist_findings,
+    print_unresolved,
+    save_dedup,
+    sweep_stale_dedup,
+    sweep_stale_findings,
+    update_finding_status,
+)
 
 PATTERNS_FILE = Path(__file__).resolve().parent / "patterns.md"
-STATE_DIR = PROJECT_ROOT / "data" / "watcher"
-FINDINGS_FILE = STATE_DIR / "findings.jsonl"
-DEDUP_FILE = STATE_DIR / "dedup.json"
-LOG_FILE = Path.home() / "Library" / "Logs" / "unitares-watcher.log"
 
-GOV_REST_URL = "http://localhost:8767/v1/tools/call"
 OLLAMA_URL = os.environ.get(
     "WATCHER_OLLAMA_URL", "http://localhost:11434/v1/chat/completions"
 )
@@ -87,15 +118,6 @@ DEFAULT_TIMEOUT = int(os.environ.get("WATCHER_TIMEOUT", "90"))
 # missed every bug past line 200. Ogler's third-round self-review caught
 # it on 2026-04-11.
 DEFAULT_CONTEXT_LINES = 10000
-
-# Age findings out after this many days
-FINDINGS_TTL_DAYS = 14
-
-# Cap for ~/Library/Logs/unitares-watcher.log rotation. Watcher logs a few
-# lines per scan; 5000 lines ≈ 500 scans of operational history, which is
-# plenty for debugging. Without this, the log file was a direct P002 match
-# against the Watcher's own pattern library — unbounded append forever.
-MAX_LOG_LINES = 5000
 
 # ---------------------------------------------------------------------------
 # Identity — persistent governance presence
@@ -387,121 +409,6 @@ SKIP_EXTENSIONS = (
     ".png",
     ".jpg",
 )
-
-
-# ---------------------------------------------------------------------------
-# Data types
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class Finding:
-    pattern: str
-    file: str
-    line: int
-    hint: str
-    severity: str  # critical | high | medium | low
-    detected_at: str
-    model_used: str
-    # Hash of the normalized source line at `line` at the time of detection.
-    # Included in the fingerprint so the same pattern flagged at the same
-    # line number but against DIFFERENT code (e.g. you fixed bug A at line 47
-    # and a new bug B arrived at the same line) does not get silently
-    # dedup'd as a rerun of the old finding.
-    line_content_hash: str = ""
-    fingerprint: str = ""
-    status: str = "open"  # open | surfaced | confirmed | dismissed | aged_out
-    violation_class: str = ""  # CON | INT | ENT | REC | BEH | VOI
-
-    def __post_init__(self) -> None:
-        if not self.fingerprint:
-            self.fingerprint = self.compute_fingerprint()
-
-    def compute_fingerprint(self) -> str:
-        """Stable identifier combining pattern, file, line, and (optionally)
-        a content hash. Callers that want content-aware dedup should set
-        ``line_content_hash`` BEFORE invoking this and then assign the
-        result back to ``fingerprint``.
-
-        The file path is normalized to its repo-relative form (relative to
-        the git worktree root containing it) so the same line in identical
-        code checked out across multiple git worktrees produces ONE
-        fingerprint, not N. The displayed ``file`` field is left absolute so
-        the user can navigate to the right copy.
-        """
-        normalized_path = repo_relative_path(self.file)
-        key = f"{self.pattern}|{normalized_path}|{self.line}|{self.line_content_hash}"
-        return hashlib.sha256(key.encode()).hexdigest()[:16]
-
-
-_REPO_ROOT_CACHE: dict[str, str] = {}
-
-
-def repo_relative_path(file_path: str) -> str:
-    """Return ``file_path`` relative to its containing git worktree root.
-
-    Falls back to the absolute string if the path is not inside a git
-    repository or git invocation fails. Result is normalized to forward
-    slashes so the fingerprint is platform-stable.
-
-    Cached per-directory because hook-driven scans hit the same worktree
-    over and over and ``git rev-parse`` is otherwise tens of ms each call.
-    """
-    if not file_path:
-        return file_path
-    p = Path(file_path)
-    parent_key = str(p.parent if p.is_absolute() else p.resolve().parent)
-    toplevel = _REPO_ROOT_CACHE.get(parent_key)
-    if toplevel is None:
-        try:
-            result = subprocess.run(
-                ["git", "-C", parent_key, "rev-parse", "--show-toplevel"],
-                capture_output=True,
-                text=True,
-                timeout=2,
-            )
-            toplevel = result.stdout.strip() if result.returncode == 0 else ""
-        except (OSError, subprocess.SubprocessError):
-            toplevel = ""
-        _REPO_ROOT_CACHE[parent_key] = toplevel
-    if not toplevel:
-        return file_path
-    try:
-        rel = Path(file_path).resolve().relative_to(Path(toplevel).resolve())
-    except ValueError:
-        return file_path
-    return rel.as_posix()
-
-
-def hash_line_content(source_line: str) -> str:
-    """Stable hash of a source line for content-aware fingerprinting.
-
-    Whitespace is stripped from both ends so indent-only reformats do not
-    trigger spurious re-flags. Internal whitespace is preserved because it
-    can be semantically meaningful (e.g. dict literal formatting).
-    """
-    normalized = (source_line or "").strip()
-    return hashlib.sha256(normalized.encode()).hexdigest()[:12]
-
-
-# ---------------------------------------------------------------------------
-# Logging (simple rotating append)
-# ---------------------------------------------------------------------------
-
-
-def log(msg: str, level: str = "info") -> None:
-    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
-    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    line = f"{ts} [{level}] {msg}\n"
-    try:
-        with LOG_FILE.open("a") as f:
-            f.write(line)
-    except OSError:
-        pass  # never let logging errors take down the watcher
-    if os.environ.get("WATCHER_DEBUG") == "1":
-        sys.stderr.write(line)
-
-
 
 
 # ---------------------------------------------------------------------------
@@ -836,239 +743,11 @@ def parse_findings(
 
 
 # ---------------------------------------------------------------------------
-# Dedup & persistence
+# Finding lifecycle helpers — _post_resolution_event stays here because it
+# needs get_watcher_identity from the identity block above. All the rest
+# (model, dedup, persistence, status transitions, format/print, compact,
+# escalate) lives in agents/watcher/findings.py.
 # ---------------------------------------------------------------------------
-
-
-def load_dedup() -> dict[str, str]:
-    """Return mapping of fingerprint → detected_at timestamp."""
-    if not DEDUP_FILE.exists():
-        return {}
-    try:
-        return json.loads(DEDUP_FILE.read_text())
-    except (json.JSONDecodeError, OSError):
-        return {}
-
-
-def save_dedup(dedup: dict[str, str]) -> None:
-    STATE_DIR.mkdir(parents=True, exist_ok=True)
-    DEDUP_FILE.write_text(json.dumps(dedup, indent=2))
-
-
-def sweep_stale_dedup(
-    dedup: dict[str, str],
-    ttl_days: int = FINDINGS_TTL_DAYS,
-    now: datetime | None = None,
-) -> dict[str, str]:
-    """Drop dedup entries older than ``ttl_days``.
-
-    Prevents the dedup dict from growing unboundedly over months — a P002
-    pattern match against the Watcher's own code that Ogler correctly
-    flagged at :78 / :127 / :496 on 2026-04-10. ``FINDINGS_TTL_DAYS`` was
-    defined but never enforced in the first cut of this module; this
-    function is the enforcement point.
-
-    Entries with an unparseable timestamp are kept (fail-open), so a
-    corrupted dedup file never silently empties itself.
-    """
-    if not dedup:
-        return dedup
-    reference = now or datetime.now(timezone.utc)
-    cutoff = reference - timedelta(days=ttl_days)
-    pruned: dict[str, str] = {}
-    dropped = 0
-    for fingerprint, ts in dedup.items():
-        try:
-            detected = datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(
-                tzinfo=timezone.utc
-            )
-        except (TypeError, ValueError):
-            # Unparseable timestamp — keep the entry rather than drop it
-            # blindly. We'd rather leak a few entries than lose findings.
-            pruned[fingerprint] = ts
-            continue
-        if detected >= cutoff:
-            pruned[fingerprint] = ts
-        else:
-            dropped += 1
-    if dropped:
-        log(
-            f"dedup sweep: dropped {dropped} stale entries older than {ttl_days}d "
-            f"({len(pruned)} remain)"
-        )
-    return pruned
-
-
-def persist_findings(new_findings: list[Finding]) -> list[Finding]:
-    """Append new (non-duplicate) findings to findings.jsonl. Return the ones
-    that were actually new (dedup filter applied)."""
-    dedup = load_dedup()
-    dedup = sweep_stale_dedup(dedup)
-    fresh: list[Finding] = []
-    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    for f in new_findings:
-        if f.fingerprint in dedup:
-            continue  # already flagged this one
-        dedup[f.fingerprint] = now
-        fresh.append(f)
-
-    if fresh or dedup != load_dedup():
-        # Persist even if `fresh` is empty, so the sweep's pruning actually
-        # lands on disk. Otherwise stale entries would rematerialize on the
-        # next scan.
-        STATE_DIR.mkdir(parents=True, exist_ok=True)
-        if fresh:
-            for f in fresh:
-                persist_finding(f)
-        save_dedup(dedup)
-
-    return fresh
-
-
-def persist_finding(finding: Finding) -> None:
-    """Append a new finding to findings.jsonl and, for high/critical severity,
-    mirror it into the governance event stream so the Discord bridge surfaces it.
-
-    Low/medium stays local — the SessionStart hook handles surfacing those
-    to the in-editor Claude session.
-
-    The caller is responsible for the dedup gate; this function does NOT
-    check dedup itself.
-    """
-    FINDINGS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with FINDINGS_FILE.open("a") as f:
-        f.write(json.dumps(asdict(finding)) + "\n")
-
-    if finding.severity in ("high", "critical"):
-        post_finding(
-            event_type="watcher_finding",
-            severity=finding.severity,
-            message=f"[{finding.pattern}] {finding.file}:{finding.line} — {finding.hint}",
-            agent_id="watcher",
-            agent_name="Watcher",
-            fingerprint=finding.fingerprint,
-            extra={
-                "pattern": finding.pattern,
-                "file": finding.file,
-                "line": finding.line,
-                "violation_class": finding.violation_class,
-            },
-        )
-
-
-# ---------------------------------------------------------------------------
-# Lifecycle commands
-#
-# Without these, findings.jsonl is append-only with no way to mark a finding
-# as confirmed, dismissed, or stale. Governance has no calibration signal and
-# the surface hook just accumulates noise. Ogler's critique of the rollup
-# daemon was specifically "build the bottom before the top" — this is the
-# bottom.
-# ---------------------------------------------------------------------------
-
-
-VALID_FINDING_STATUSES = ("open", "surfaced", "confirmed", "dismissed", "aged_out")
-MIN_FINGERPRINT_PREFIX = 4  # users can type the first N chars instead of all 16
-
-
-def _iter_findings_raw() -> list[dict[str, Any]]:
-    """Load all findings from findings.jsonl as raw dicts. Silently skips
-    malformed lines. Returns [] if the file doesn't exist."""
-    if not FINDINGS_FILE.exists():
-        return []
-    out: list[dict[str, Any]] = []
-    with FINDINGS_FILE.open() as fh:
-        for line in fh:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                out.append(json.loads(line))
-            except json.JSONDecodeError:
-                continue
-    return out
-
-
-def _write_findings_atomic(findings: list[dict[str, Any]]) -> None:
-    """Atomically replace findings.jsonl with the given list. Writes to a
-    sibling temp file and renames, so a crash mid-write cannot corrupt the
-    findings feed."""
-    STATE_DIR.mkdir(parents=True, exist_ok=True)
-    tmp = FINDINGS_FILE.with_suffix(FINDINGS_FILE.suffix + ".tmp")
-    with tmp.open("w") as fh:
-        for f in findings:
-            fh.write(json.dumps(f) + "\n")
-    tmp.replace(FINDINGS_FILE)
-
-
-def match_fingerprint(prefix: str, findings: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], str | None]:
-    """Return (matches, error) for a fingerprint prefix lookup.
-
-    - Exact 16-char match returns at most one finding.
-    - Shorter prefixes match all findings whose fingerprint starts with it.
-    - Prefix shorter than ``MIN_FINGERPRINT_PREFIX`` is rejected to guard
-      against accidental nukes from a 1-2 char typo.
-    """
-    if not prefix:
-        return [], "empty fingerprint"
-    if len(prefix) < MIN_FINGERPRINT_PREFIX:
-        return [], f"fingerprint too short (min {MIN_FINGERPRINT_PREFIX} chars)"
-    matches = [f for f in findings if f.get("fingerprint", "").startswith(prefix)]
-    return matches, None
-
-
-def update_finding_status(fingerprint_prefix: str, new_status: str, resolver_agent_id: str | None = None) -> int:
-    """Mark a finding as ``new_status`` by fingerprint prefix.
-
-    Returns exit code:
-      0 — updated exactly one finding
-      1 — no match or ambiguous prefix
-      2 — invalid status
-    """
-    if new_status not in VALID_FINDING_STATUSES:
-        log(f"update_finding_status: invalid status {new_status!r}", "error")
-        print(f"error: invalid status {new_status!r}; must be one of {VALID_FINDING_STATUSES}")
-        return 2
-
-    findings = _iter_findings_raw()
-    if not findings:
-        print("error: findings.jsonl is empty or absent")
-        return 1
-
-    matches, err = match_fingerprint(fingerprint_prefix, findings)
-    if err:
-        print(f"error: {err}")
-        return 1
-    if not matches:
-        print(f"error: no finding matches fingerprint prefix {fingerprint_prefix!r}")
-        return 1
-    if len(matches) > 1:
-        print(f"error: fingerprint prefix {fingerprint_prefix!r} is ambiguous ({len(matches)} matches):")
-        for m in matches:
-            print(
-                f"  {m.get('fingerprint','?')[:16]} {m.get('severity','?')} "
-                f"{m.get('pattern','?')} {m.get('file','?')}:{m.get('line','?')}"
-            )
-        return 1
-
-    target_fp = matches[0].get("fingerprint", "")
-    updated: list[dict[str, Any]] = []
-    for f in findings:
-        if f.get("fingerprint") == target_fp:
-            f = {**f, "status": new_status}
-        updated.append(f)
-    _write_findings_atomic(updated)
-    log(f"update_finding_status: {target_fp[:8]} → {new_status}")
-    print(
-        f"ok: {target_fp[:16]} → {new_status} "
-        f"({matches[0].get('pattern','?')} at {matches[0].get('file','?')}:{matches[0].get('line','?')})"
-    )
-
-    # --- Post resolution event to governance ---
-    if new_status in ("confirmed", "dismissed"):
-        _post_resolution_event(matches[0], new_status, resolver_agent_id)
-
-    return 0
 
 
 def _post_resolution_event(finding: dict, action: str, resolver_agent_id: str | None) -> None:
@@ -1098,160 +777,12 @@ def _post_resolution_event(finding: dict, action: str, resolver_agent_id: str | 
         log(f"resolution event failed: {e}", "warning")
 
 
-def sweep_stale_findings() -> int:
-    """Drop findings whose target file no longer exists on disk.
-
-    This is the "the file got deleted or renamed" cleanup — we don't want
-    the surface hook to keep nagging you about a file that isn't there
-    anymore. Open/surfaced findings get aged_out via this path too because
-    there's no code to evaluate.
-    """
-    findings = _iter_findings_raw()
-    if not findings:
-        print("(no findings to sweep)")
-        return 0
-
-    kept: list[dict[str, Any]] = []
-    dropped = 0
-    for f in findings:
-        path = f.get("file", "")
-        if path and Path(path).exists():
-            kept.append(f)
-        else:
-            dropped += 1
-
-    if dropped == 0:
-        print(f"(nothing to sweep: {len(findings)} findings, all target files present)")
-        return 0
-
-    _write_findings_atomic(kept)
-    log(f"sweep_stale_findings: dropped {dropped} findings for missing files")
-    print(f"ok: dropped {dropped} finding(s) with missing target files, kept {len(kept)}")
-    return 0
-
-
 # ---------------------------------------------------------------------------
-# Surfacing — how findings reach the main Claude session
-#
-# Two hooks call the functions below:
-#
-#   SessionStart → --print-unresolved (read-only, shows open+surfaced so the
-#     new session sees the full backlog — if it only showed open, findings
-#     already "surfaced" in a previous session would silently disappear from
-#     context)
-#
-#   UserPromptSubmit → --surface-pending (chime mode: shows only open
-#     findings, transitions them to surfaced so the next prompt doesn't
-#     re-chime the same items)
-#
-# Both print a <unitares-watcher-findings> block that the Claude Code hook
-# system injects as additionalContext. The formatter is shared between the
-# two commands so the block shape stays consistent no matter which hook
-# emitted it.
+# Surfacing coordinator — surface_pending stays here because it also triggers
+# a governance check-in (_do_checkin). The read-only print_unresolved, the
+# shared _format_findings_block, and sweep/compact/escalate all live in
+# agents/watcher/findings.py.
 # ---------------------------------------------------------------------------
-
-
-def _format_findings_block(
-    findings: list[dict[str, Any]],
-    *,
-    header: str,
-) -> tuple[str | None, list[dict[str, Any]]]:
-    """Render the <unitares-watcher-findings> block.
-
-    Returns ``(block, shown)`` where:
-      - ``block`` is the formatted string to print, or None if nothing
-        should be surfaced (empty list / all-low-severity).
-      - ``shown`` is the ordered list of findings that actually made it
-        into the displayed block. Callers use this to decide which
-        findings to transition to ``surfaced`` status — we only want to
-        mark findings the user actually saw, never the ones dropped by
-        the display cap.
-
-    The (block, shown) tuple shape replaces an earlier bug where
-    surface_pending marked ALL open findings as surfaced regardless of
-    whether the display cap had hidden them. Medium-severity findings
-    behind a wall of criticals would transition silently and then get
-    dedup'd on re-detection — effectively a silent drop of real signal.
-    Ogler caught it on 2026-04-11.
-
-    Severity rules for the displayed subset:
-      - critical/high: always shown
-      - medium: shown only if there's room under the 10-item display cap
-        reserved for critical+high (keeps session context from drowning in
-        medium-severity noise while still surfacing some)
-      - low: never shown (file-only signal)
-    """
-    if not findings:
-        return None, []
-
-    severity_order = {"critical": 0, "high": 1, "medium": 2, "low": 3}
-    findings = sorted(
-        findings,
-        key=lambda f: (
-            severity_order.get(f.get("severity", "low"), 9),
-            f.get("detected_at", ""),
-        ),
-    )
-
-    critical_high = [f for f in findings if f.get("severity") in ("critical", "high")]
-    medium = [f for f in findings if f.get("severity") == "medium"]
-    shown = critical_high[:]
-    if len(shown) < 10:
-        shown += medium[: 10 - len(shown)]
-
-    if not shown:
-        return None, []
-
-    lines: list[str] = []
-    lines.append("<unitares-watcher-findings>")
-    lines.append(header)
-    lines.append("")
-    for f in shown:
-        sev = str(f.get("severity", "?")).upper()
-        pat = f.get("pattern", "?")
-        vcls = f.get("violation_class", "")
-        file = f.get("file", "?")
-        line_no = f.get("line", "?")
-        hint = f.get("hint", "")
-        fp = str(f.get("fingerprint", ""))[:8]
-        status = f.get("status", "open")
-        marker = "" if status == "open" else f" ({status})"
-        cls_tag = f"[{vcls}] " if vcls else ""
-        lines.append(f"  [{sev}] {cls_tag}{pat} {file}:{line_no} — {hint}  (#{fp}){marker}")
-    lines.append("")
-    lines.append(f"Total unresolved: {len(findings)} (showing {len(shown)})")
-    lines.append(
-        "Resolve: python3 agents/watcher/agent.py --resolve <fingerprint> --agent-id <your-uuid>"
-    )
-    lines.append(
-        "Dismiss: python3 agents/watcher/agent.py --dismiss <fingerprint> --agent-id <your-uuid>"
-    )
-    lines.append("</unitares-watcher-findings>")
-    return "\n".join(lines), shown
-
-
-def print_unresolved() -> int:
-    """Print the unresolved-findings block (open + surfaced) without mutating
-    state. Called by the SessionStart hook — it's read-only so session starts
-    never accidentally reshape the findings state.
-    """
-    findings = [
-        f
-        for f in _iter_findings_raw()
-        if f.get("status", "open") in ("open", "surfaced")
-    ]
-    block, _shown = _format_findings_block(
-        findings,
-        header=(
-            "The UNITARES Watcher agent flagged the following unresolved code\n"
-            "patterns in recently edited files. Watcher has a track record — these\n"
-            "are not noise. Investigate or explicitly --dismiss them."
-        ),
-    )
-    if block is None:
-        return 0
-    print(block)
-    return 0
 
 
 def surface_pending() -> int:
@@ -1306,110 +837,6 @@ def surface_pending() -> int:
         )
 
     return 0
-
-
-def compact_findings(max_age_days: int = 7, now: datetime | None = None) -> int:
-    """Rewrite findings.jsonl dropping confirmed/dismissed/aged_out entries
-    older than ``max_age_days``.
-
-    Active findings (``open`` / ``surfaced``) are always kept regardless of
-    age — they still need your attention. Only already-resolved entries get
-    compacted away. This is the fix for Ogler's P002-round-two: the findings
-    file itself was growing unboundedly even after the dedup dict got its
-    TTL sweep.
-    """
-    findings = _iter_findings_raw()
-    if not findings:
-        print("(no findings to compact)")
-        return 0
-
-    reference = now or datetime.now(timezone.utc)
-    cutoff = reference - timedelta(days=max_age_days)
-    resolved_states = {"confirmed", "dismissed", "aged_out"}
-
-    kept: list[dict[str, Any]] = []
-    dropped = 0
-    for f in findings:
-        status = f.get("status", "open")
-        if status not in resolved_states:
-            # open/surfaced — always keep
-            kept.append(f)
-            continue
-        ts = f.get("detected_at", "")
-        try:
-            detected = datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(
-                tzinfo=timezone.utc
-            )
-        except (TypeError, ValueError):
-            # Unparseable timestamp — keep it, fail-open
-            kept.append(f)
-            continue
-        if detected >= cutoff:
-            kept.append(f)
-        else:
-            dropped += 1
-
-    if dropped == 0:
-        print(
-            f"(nothing to compact: {len(findings)} findings, "
-            f"none resolved >{max_age_days}d ago)"
-        )
-        return 0
-
-    _write_findings_atomic(kept)
-    log(
-        f"compact_findings: dropped {dropped} resolved findings older than {max_age_days}d"
-    )
-    print(
-        f"ok: compacted {dropped} finding(s) older than {max_age_days}d, "
-        f"kept {len(kept)}"
-    )
-    return 0
-
-
-# ---------------------------------------------------------------------------
-# Severity routing
-# ---------------------------------------------------------------------------
-
-
-def escalate(finding: Finding) -> None:
-    """Route high/critical findings beyond the findings.jsonl file.
-
-    High findings: logged + surfaced via SessionStart hook (findings.jsonl).
-    Critical findings: also stored in governance KG for visibility across agents.
-    """
-    log(f"ESCALATE {finding.severity.upper()} {finding.fingerprint} {finding.pattern} {finding.file}:{finding.line} — {finding.hint}", "warning")
-
-    if finding.severity != "critical":
-        return
-
-    # --- Governance KG discovery ---
-    _escalate_to_kg(finding)
-
-
-def _escalate_to_kg(finding: Finding) -> None:
-    """Store a critical finding as a discovery in the governance knowledge graph."""
-    from unitares_sdk import SyncGovernanceClient
-
-    summary = f"[Watcher] {finding.pattern}: {finding.hint} ({Path(finding.file).name}:{finding.line})"
-    details = (
-        f"Pattern: {finding.pattern}\n"
-        f"File: {finding.file}:{finding.line}\n"
-        f"Hint: {finding.hint}\n"
-        f"Fingerprint: {finding.fingerprint}"
-    )
-    try:
-        client = SyncGovernanceClient(rest_url=GOV_REST_URL, transport="rest", timeout=30)
-        client.store_discovery(
-            summary=summary,
-            discovery_type="bug_found",
-            severity="critical",
-            tags=["watcher", finding.pattern, "critical"],
-            details=details,
-        )
-        log(f"KG discovery stored for {finding.fingerprint}", "info")
-    except Exception as e:
-        log(f"KG discovery write failed: {e}", "warning")
 
 
 # ---------------------------------------------------------------------------

--- a/agents/watcher/findings.py
+++ b/agents/watcher/findings.py
@@ -1,0 +1,587 @@
+"""Finding model, persistence, dedup, lifecycle, surfacing, compaction,
+escalation.
+
+Split out of agent.py so the file stayed navigable. Identity, scanning, and
+CLI orchestration remain in agent.py. ``surface_pending`` also stays there
+because it calls ``_do_checkin`` from the identity block; everything else
+that touches findings.jsonl / dedup.json lives here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from agents.common.findings import post_finding
+from agents.watcher._util import (
+    PROJECT_ROOT,
+    hash_line_content,
+    log,
+    repo_relative_path,
+)
+
+# ---------------------------------------------------------------------------
+# Paths & Config
+# ---------------------------------------------------------------------------
+
+STATE_DIR = PROJECT_ROOT / "data" / "watcher"
+FINDINGS_FILE = STATE_DIR / "findings.jsonl"
+DEDUP_FILE = STATE_DIR / "dedup.json"
+
+GOV_REST_URL = "http://localhost:8767/v1/tools/call"
+
+# Age findings out after this many days
+FINDINGS_TTL_DAYS = 14
+
+VALID_FINDING_STATUSES = ("open", "surfaced", "confirmed", "dismissed", "aged_out")
+MIN_FINGERPRINT_PREFIX = 4  # users can type the first N chars instead of all 16
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Finding:
+    pattern: str
+    file: str
+    line: int
+    hint: str
+    severity: str  # critical | high | medium | low
+    detected_at: str
+    model_used: str
+    # Hash of the normalized source line at `line` at the time of detection.
+    # Included in the fingerprint so the same pattern flagged at the same
+    # line number but against DIFFERENT code (e.g. you fixed bug A at line 47
+    # and a new bug B arrived at the same line) does not get silently
+    # dedup'd as a rerun of the old finding.
+    line_content_hash: str = ""
+    fingerprint: str = ""
+    status: str = "open"  # open | surfaced | confirmed | dismissed | aged_out
+    violation_class: str = ""  # CON | INT | ENT | REC | BEH | VOI
+
+    def __post_init__(self) -> None:
+        if not self.fingerprint:
+            self.fingerprint = self.compute_fingerprint()
+
+    def compute_fingerprint(self) -> str:
+        """Stable identifier combining pattern, file, line, and (optionally)
+        a content hash. Callers that want content-aware dedup should set
+        ``line_content_hash`` BEFORE invoking this and then assign the
+        result back to ``fingerprint``.
+
+        The file path is normalized to its repo-relative form (relative to
+        the git worktree root containing it) so the same line in identical
+        code checked out across multiple git worktrees produces ONE
+        fingerprint, not N. The displayed ``file`` field is left absolute so
+        the user can navigate to the right copy.
+        """
+        normalized_path = repo_relative_path(self.file)
+        key = f"{self.pattern}|{normalized_path}|{self.line}|{self.line_content_hash}"
+        return hashlib.sha256(key.encode()).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Dedup (data/watcher/dedup.json)
+# ---------------------------------------------------------------------------
+
+
+def load_dedup() -> dict[str, str]:
+    """Return mapping of fingerprint → detected_at timestamp."""
+    if not DEDUP_FILE.exists():
+        return {}
+    try:
+        return json.loads(DEDUP_FILE.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def save_dedup(dedup: dict[str, str]) -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    DEDUP_FILE.write_text(json.dumps(dedup, indent=2))
+
+
+def sweep_stale_dedup(
+    dedup: dict[str, str],
+    ttl_days: int = FINDINGS_TTL_DAYS,
+    now: datetime | None = None,
+) -> dict[str, str]:
+    """Drop dedup entries older than ``ttl_days``.
+
+    Prevents the dedup dict from growing unboundedly over months — a P002
+    pattern match against the Watcher's own code that Ogler correctly
+    flagged at :78 / :127 / :496 on 2026-04-10. ``FINDINGS_TTL_DAYS`` was
+    defined but never enforced in the first cut of this module; this
+    function is the enforcement point.
+
+    Entries with an unparseable timestamp are kept (fail-open), so a
+    corrupted dedup file never silently empties itself.
+    """
+    if not dedup:
+        return dedup
+    reference = now or datetime.now(timezone.utc)
+    cutoff = reference - timedelta(days=ttl_days)
+    pruned: dict[str, str] = {}
+    dropped = 0
+    for fingerprint, ts in dedup.items():
+        try:
+            detected = datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(
+                tzinfo=timezone.utc
+            )
+        except (TypeError, ValueError):
+            # Unparseable timestamp — keep the entry rather than drop it
+            # blindly. We'd rather leak a few entries than lose findings.
+            pruned[fingerprint] = ts
+            continue
+        if detected >= cutoff:
+            pruned[fingerprint] = ts
+        else:
+            dropped += 1
+    if dropped:
+        log(
+            f"dedup sweep: dropped {dropped} stale entries older than {ttl_days}d "
+            f"({len(pruned)} remain)"
+        )
+    return pruned
+
+
+# ---------------------------------------------------------------------------
+# Persistence (data/watcher/findings.jsonl)
+# ---------------------------------------------------------------------------
+
+
+def persist_findings(new_findings: list[Finding]) -> list[Finding]:
+    """Append new (non-duplicate) findings to findings.jsonl. Return the ones
+    that were actually new (dedup filter applied)."""
+    dedup = load_dedup()
+    dedup = sweep_stale_dedup(dedup)
+    fresh: list[Finding] = []
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    for f in new_findings:
+        if f.fingerprint in dedup:
+            continue  # already flagged this one
+        dedup[f.fingerprint] = now
+        fresh.append(f)
+
+    if fresh or dedup != load_dedup():
+        # Persist even if `fresh` is empty, so the sweep's pruning actually
+        # lands on disk. Otherwise stale entries would rematerialize on the
+        # next scan.
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        if fresh:
+            for f in fresh:
+                persist_finding(f)
+        save_dedup(dedup)
+
+    return fresh
+
+
+def persist_finding(finding: Finding) -> None:
+    """Append a new finding to findings.jsonl and, for high/critical severity,
+    mirror it into the governance event stream so the Discord bridge surfaces it.
+
+    Low/medium stays local — the SessionStart hook handles surfacing those
+    to the in-editor Claude session.
+
+    The caller is responsible for the dedup gate; this function does NOT
+    check dedup itself.
+    """
+    FINDINGS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with FINDINGS_FILE.open("a") as f:
+        f.write(json.dumps(asdict(finding)) + "\n")
+
+    if finding.severity in ("high", "critical"):
+        post_finding(
+            event_type="watcher_finding",
+            severity=finding.severity,
+            message=f"[{finding.pattern}] {finding.file}:{finding.line} — {finding.hint}",
+            agent_id="watcher",
+            agent_name="Watcher",
+            fingerprint=finding.fingerprint,
+            extra={
+                "pattern": finding.pattern,
+                "file": finding.file,
+                "line": finding.line,
+                "violation_class": finding.violation_class,
+            },
+        )
+
+
+def _iter_findings_raw() -> list[dict[str, Any]]:
+    """Load all findings from findings.jsonl as raw dicts. Silently skips
+    malformed lines. Returns [] if the file doesn't exist."""
+    if not FINDINGS_FILE.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    with FINDINGS_FILE.open() as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return out
+
+
+def _write_findings_atomic(findings: list[dict[str, Any]]) -> None:
+    """Atomically replace findings.jsonl with the given list. Writes to a
+    sibling temp file and renames, so a crash mid-write cannot corrupt the
+    findings feed."""
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    tmp = FINDINGS_FILE.with_suffix(FINDINGS_FILE.suffix + ".tmp")
+    with tmp.open("w") as fh:
+        for f in findings:
+            fh.write(json.dumps(f) + "\n")
+    tmp.replace(FINDINGS_FILE)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle commands
+#
+# Without these, findings.jsonl is append-only with no way to mark a finding
+# as confirmed, dismissed, or stale. Governance has no calibration signal and
+# the surface hook just accumulates noise. Ogler's critique of the rollup
+# daemon was specifically "build the bottom before the top" — this is the
+# bottom.
+# ---------------------------------------------------------------------------
+
+
+def match_fingerprint(prefix: str, findings: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], str | None]:
+    """Return (matches, error) for a fingerprint prefix lookup.
+
+    - Exact 16-char match returns at most one finding.
+    - Shorter prefixes match all findings whose fingerprint starts with it.
+    - Prefix shorter than ``MIN_FINGERPRINT_PREFIX`` is rejected to guard
+      against accidental nukes from a 1-2 char typo.
+    """
+    if not prefix:
+        return [], "empty fingerprint"
+    if len(prefix) < MIN_FINGERPRINT_PREFIX:
+        return [], f"fingerprint too short (min {MIN_FINGERPRINT_PREFIX} chars)"
+    matches = [f for f in findings if f.get("fingerprint", "").startswith(prefix)]
+    return matches, None
+
+
+def update_finding_status(fingerprint_prefix: str, new_status: str, resolver_agent_id: str | None = None) -> int:
+    """Mark a finding as ``new_status`` by fingerprint prefix.
+
+    Returns exit code:
+      0 — updated exactly one finding
+      1 — no match or ambiguous prefix
+      2 — invalid status
+    """
+    if new_status not in VALID_FINDING_STATUSES:
+        log(f"update_finding_status: invalid status {new_status!r}", "error")
+        print(f"error: invalid status {new_status!r}; must be one of {VALID_FINDING_STATUSES}")
+        return 2
+
+    findings = _iter_findings_raw()
+    if not findings:
+        print("error: findings.jsonl is empty or absent")
+        return 1
+
+    matches, err = match_fingerprint(fingerprint_prefix, findings)
+    if err:
+        print(f"error: {err}")
+        return 1
+    if not matches:
+        print(f"error: no finding matches fingerprint prefix {fingerprint_prefix!r}")
+        return 1
+    if len(matches) > 1:
+        print(f"error: fingerprint prefix {fingerprint_prefix!r} is ambiguous ({len(matches)} matches):")
+        for m in matches:
+            print(
+                f"  {m.get('fingerprint','?')[:16]} {m.get('severity','?')} "
+                f"{m.get('pattern','?')} {m.get('file','?')}:{m.get('line','?')}"
+            )
+        return 1
+
+    target_fp = matches[0].get("fingerprint", "")
+    updated: list[dict[str, Any]] = []
+    for f in findings:
+        if f.get("fingerprint") == target_fp:
+            f = {**f, "status": new_status}
+        updated.append(f)
+    _write_findings_atomic(updated)
+    log(f"update_finding_status: {target_fp[:8]} → {new_status}")
+    print(
+        f"ok: {target_fp[:16]} → {new_status} "
+        f"({matches[0].get('pattern','?')} at {matches[0].get('file','?')}:{matches[0].get('line','?')})"
+    )
+
+    # --- Post resolution event to governance ---
+    if new_status in ("confirmed", "dismissed"):
+        # Lazy import: _post_resolution_event needs get_watcher_identity
+        # from agent.py's identity block. Top-level import would be circular.
+        from agents.watcher.agent import _post_resolution_event
+        _post_resolution_event(matches[0], new_status, resolver_agent_id)
+
+    return 0
+
+
+def sweep_stale_findings() -> int:
+    """Drop findings whose target file no longer exists on disk.
+
+    This is the "the file got deleted or renamed" cleanup — we don't want
+    the surface hook to keep nagging you about a file that isn't there
+    anymore. Open/surfaced findings get aged_out via this path too because
+    there's no code to evaluate.
+    """
+    findings = _iter_findings_raw()
+    if not findings:
+        print("(no findings to sweep)")
+        return 0
+
+    kept: list[dict[str, Any]] = []
+    dropped = 0
+    for f in findings:
+        path = f.get("file", "")
+        if path and Path(path).exists():
+            kept.append(f)
+        else:
+            dropped += 1
+
+    if dropped == 0:
+        print(f"(nothing to sweep: {len(findings)} findings, all target files present)")
+        return 0
+
+    _write_findings_atomic(kept)
+    log(f"sweep_stale_findings: dropped {dropped} findings for missing files")
+    print(f"ok: dropped {dropped} finding(s) with missing target files, kept {len(kept)}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Surfacing — how findings reach the main Claude session
+#
+# Two hooks call the functions below:
+#
+#   SessionStart → --print-unresolved (read-only, shows open+surfaced so the
+#     new session sees the full backlog — if it only showed open, findings
+#     already "surfaced" in a previous session would silently disappear from
+#     context)
+#
+#   UserPromptSubmit → --surface-pending (chime mode, in agent.py because
+#     it also triggers a governance check-in; it reuses _format_findings_block
+#     and _write_findings_atomic from here)
+#
+# Both print a <unitares-watcher-findings> block that the Claude Code hook
+# system injects as additionalContext. The formatter is shared between the
+# two commands so the block shape stays consistent no matter which hook
+# emitted it.
+# ---------------------------------------------------------------------------
+
+
+def _format_findings_block(
+    findings: list[dict[str, Any]],
+    *,
+    header: str,
+) -> tuple[str | None, list[dict[str, Any]]]:
+    """Render the <unitares-watcher-findings> block.
+
+    Returns ``(block, shown)`` where:
+      - ``block`` is the formatted string to print, or None if nothing
+        should be surfaced (empty list / all-low-severity).
+      - ``shown`` is the ordered list of findings that actually made it
+        into the displayed block. Callers use this to decide which
+        findings to transition to ``surfaced`` status — we only want to
+        mark findings the user actually saw, never the ones dropped by
+        the display cap.
+
+    The (block, shown) tuple shape replaces an earlier bug where
+    surface_pending marked ALL open findings as surfaced regardless of
+    whether the display cap had hidden them. Medium-severity findings
+    behind a wall of criticals would transition silently and then get
+    dedup'd on re-detection — effectively a silent drop of real signal.
+    Ogler caught it on 2026-04-11.
+
+    Severity rules for the displayed subset:
+      - critical/high: always shown
+      - medium: shown only if there's room under the 10-item display cap
+        reserved for critical+high (keeps session context from drowning in
+        medium-severity noise while still surfacing some)
+      - low: never shown (file-only signal)
+    """
+    if not findings:
+        return None, []
+
+    severity_order = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+    findings = sorted(
+        findings,
+        key=lambda f: (
+            severity_order.get(f.get("severity", "low"), 9),
+            f.get("detected_at", ""),
+        ),
+    )
+
+    critical_high = [f for f in findings if f.get("severity") in ("critical", "high")]
+    medium = [f for f in findings if f.get("severity") == "medium"]
+    shown = critical_high[:]
+    if len(shown) < 10:
+        shown += medium[: 10 - len(shown)]
+
+    if not shown:
+        return None, []
+
+    lines: list[str] = []
+    lines.append("<unitares-watcher-findings>")
+    lines.append(header)
+    lines.append("")
+    for f in shown:
+        sev = str(f.get("severity", "?")).upper()
+        pat = f.get("pattern", "?")
+        vcls = f.get("violation_class", "")
+        file = f.get("file", "?")
+        line_no = f.get("line", "?")
+        hint = f.get("hint", "")
+        fp = str(f.get("fingerprint", ""))[:8]
+        status = f.get("status", "open")
+        marker = "" if status == "open" else f" ({status})"
+        cls_tag = f"[{vcls}] " if vcls else ""
+        lines.append(f"  [{sev}] {cls_tag}{pat} {file}:{line_no} — {hint}  (#{fp}){marker}")
+    lines.append("")
+    lines.append(f"Total unresolved: {len(findings)} (showing {len(shown)})")
+    lines.append(
+        "Resolve: python3 agents/watcher/agent.py --resolve <fingerprint> --agent-id <your-uuid>"
+    )
+    lines.append(
+        "Dismiss: python3 agents/watcher/agent.py --dismiss <fingerprint> --agent-id <your-uuid>"
+    )
+    lines.append("</unitares-watcher-findings>")
+    return "\n".join(lines), shown
+
+
+def print_unresolved() -> int:
+    """Print the unresolved-findings block (open + surfaced) without mutating
+    state. Called by the SessionStart hook — it's read-only so session starts
+    never accidentally reshape the findings state.
+    """
+    findings = [
+        f
+        for f in _iter_findings_raw()
+        if f.get("status", "open") in ("open", "surfaced")
+    ]
+    block, _shown = _format_findings_block(
+        findings,
+        header=(
+            "The UNITARES Watcher agent flagged the following unresolved code\n"
+            "patterns in recently edited files. Watcher has a track record — these\n"
+            "are not noise. Investigate or explicitly --dismiss them."
+        ),
+    )
+    if block is None:
+        return 0
+    print(block)
+    return 0
+
+
+def compact_findings(max_age_days: int = 7, now: datetime | None = None) -> int:
+    """Rewrite findings.jsonl dropping confirmed/dismissed/aged_out entries
+    older than ``max_age_days``.
+
+    Active findings (``open`` / ``surfaced``) are always kept regardless of
+    age — they still need your attention. Only already-resolved entries get
+    compacted away. This is the fix for Ogler's P002-round-two: the findings
+    file itself was growing unboundedly even after the dedup dict got its
+    TTL sweep.
+    """
+    findings = _iter_findings_raw()
+    if not findings:
+        print("(no findings to compact)")
+        return 0
+
+    reference = now or datetime.now(timezone.utc)
+    cutoff = reference - timedelta(days=max_age_days)
+    resolved_states = {"confirmed", "dismissed", "aged_out"}
+
+    kept: list[dict[str, Any]] = []
+    dropped = 0
+    for f in findings:
+        status = f.get("status", "open")
+        if status not in resolved_states:
+            # open/surfaced — always keep
+            kept.append(f)
+            continue
+        ts = f.get("detected_at", "")
+        try:
+            detected = datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(
+                tzinfo=timezone.utc
+            )
+        except (TypeError, ValueError):
+            # Unparseable timestamp — keep it, fail-open
+            kept.append(f)
+            continue
+        if detected >= cutoff:
+            kept.append(f)
+        else:
+            dropped += 1
+
+    if dropped == 0:
+        print(
+            f"(nothing to compact: {len(findings)} findings, "
+            f"none resolved >{max_age_days}d ago)"
+        )
+        return 0
+
+    _write_findings_atomic(kept)
+    log(
+        f"compact_findings: dropped {dropped} resolved findings older than {max_age_days}d"
+    )
+    print(
+        f"ok: compacted {dropped} finding(s) older than {max_age_days}d, "
+        f"kept {len(kept)}"
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Severity routing
+# ---------------------------------------------------------------------------
+
+
+def escalate(finding: Finding) -> None:
+    """Route high/critical findings beyond the findings.jsonl file.
+
+    High findings: logged + surfaced via SessionStart hook (findings.jsonl).
+    Critical findings: also stored in governance KG for visibility across agents.
+    """
+    log(f"ESCALATE {finding.severity.upper()} {finding.fingerprint} {finding.pattern} {finding.file}:{finding.line} — {finding.hint}", "warning")
+
+    if finding.severity != "critical":
+        return
+
+    # --- Governance KG discovery ---
+    _escalate_to_kg(finding)
+
+
+def _escalate_to_kg(finding: Finding) -> None:
+    """Store a critical finding as a discovery in the governance knowledge graph."""
+    from unitares_sdk import SyncGovernanceClient
+
+    summary = f"[Watcher] {finding.pattern}: {finding.hint} ({Path(finding.file).name}:{finding.line})"
+    details = (
+        f"Pattern: {finding.pattern}\n"
+        f"File: {finding.file}:{finding.line}\n"
+        f"Hint: {finding.hint}\n"
+        f"Fingerprint: {finding.fingerprint}"
+    )
+    try:
+        client = SyncGovernanceClient(rest_url=GOV_REST_URL, transport="rest", timeout=30)
+        client.store_discovery(
+            summary=summary,
+            discovery_type="bug_found",
+            severity="critical",
+            tags=["watcher", finding.pattern, "critical"],
+            details=details,
+        )
+        log(f"KG discovery stored for {finding.fingerprint}", "info")
+    except Exception as e:
+        log(f"KG discovery write failed: {e}", "warning")

--- a/agents/watcher/tests/test_agent.py
+++ b/agents/watcher/tests/test_agent.py
@@ -51,14 +51,36 @@ def watcher_module():
 @pytest.fixture(autouse=True)
 def _isolate_watcher_state(tmp_path, monkeypatch, watcher_module):
     """Redirect all Watcher state paths into a tmp dir so tests never touch
-    the production findings.jsonl / dedup.json / log file."""
+    the production findings.jsonl / dedup.json / log file.
+
+    Constants live in the split-out modules (findings, _util) as of the
+    watcher-findings-split refactor, so we patch them at the source. The
+    watcher_module re-exports are also patched for tests that read
+    ``watcher_module.FINDINGS_FILE`` etc. directly.
+    """
+    from agents.watcher import _util as watcher_util
+    from agents.watcher import agent as real_watcher
+    from agents.watcher import findings as watcher_findings
+
     tmp_state = tmp_path / "watcher-state"
     tmp_state.mkdir()
     tmp_log = tmp_path / "watcher.log"
-    monkeypatch.setattr(watcher_module, "STATE_DIR", tmp_state)
-    monkeypatch.setattr(watcher_module, "FINDINGS_FILE", tmp_state / "findings.jsonl")
-    monkeypatch.setattr(watcher_module, "DEDUP_FILE", tmp_state / "dedup.json")
-    monkeypatch.setattr(watcher_module, "LOG_FILE", tmp_log)
+
+    # Source modules (where the constants now live) — the canonical patch
+    # points; findings.py's own functions read these, not the re-exports.
+    monkeypatch.setattr(watcher_findings, "STATE_DIR", tmp_state)
+    monkeypatch.setattr(watcher_findings, "FINDINGS_FILE", tmp_state / "findings.jsonl")
+    monkeypatch.setattr(watcher_findings, "DEDUP_FILE", tmp_state / "dedup.json")
+    monkeypatch.setattr(watcher_util, "LOG_FILE", tmp_log)
+
+    # Re-exported names on the agent module — patched so any caller that
+    # reads them through `watcher_module.FINDINGS_FILE` / the real agent
+    # module still sees the tmp paths.
+    for target in (watcher_module, real_watcher):
+        monkeypatch.setattr(target, "STATE_DIR", tmp_state)
+        monkeypatch.setattr(target, "FINDINGS_FILE", tmp_state / "findings.jsonl")
+        monkeypatch.setattr(target, "DEDUP_FILE", tmp_state / "dedup.json")
+        monkeypatch.setattr(target, "LOG_FILE", tmp_log)
     yield
 
 
@@ -66,14 +88,49 @@ def _isolate_watcher_state(tmp_path, monkeypatch, watcher_module):
 def _mock_post_finding_by_default(monkeypatch, watcher_module):
     """Default to no-op post_finding so tests don't hit the network.
 
-    Patches both the importlib-loaded watcher_module (used by most tests)
-    and the agents.watcher.agent import (used by TestWatcherPostsFindings).
-    Tests that need to assert on the call can override via monkeypatch —
-    the later setattr wins.
+    Patches all three namespaces that hold a ``post_finding`` binding:
+      - ``watcher_module`` — the importlib-loaded copy used by most tests
+      - ``agents.watcher.agent`` — re-exported name used by TestWatcherPostsFindings
+      - ``agents.watcher.findings`` — where the binding actually lives post-refactor
+        (persist_finding and _post_resolution_event call it from inside findings.py)
+
+    Tests that need to assert on the call should use ``_mock_post_finding``
+    below rather than monkeypatching directly — it handles all three
+    namespaces so the spy fires regardless of which code path invokes it.
     """
     from agents.watcher import agent as watcher
+    from agents.watcher import findings as watcher_findings
     monkeypatch.setattr(watcher_module, "post_finding", lambda **kw: True)
     monkeypatch.setattr(watcher, "post_finding", lambda **kw: True)
+    monkeypatch.setattr(watcher_findings, "post_finding", lambda **kw: True)
+
+
+def _mock_post_finding(monkeypatch, watcher_module, spy):
+    """Install ``spy`` as post_finding on all three namespaces."""
+    from agents.watcher import agent as watcher
+    from agents.watcher import findings as watcher_findings
+    monkeypatch.setattr(watcher_module, "post_finding", spy)
+    monkeypatch.setattr(watcher, "post_finding", spy)
+    monkeypatch.setattr(watcher_findings, "post_finding", spy)
+
+
+def _mock_escalate_to_kg(monkeypatch, watcher_module, spy):
+    """Install ``spy`` as _escalate_to_kg on all namespaces that hold the binding."""
+    from agents.watcher import agent as watcher
+    from agents.watcher import findings as watcher_findings
+    monkeypatch.setattr(watcher_module, "_escalate_to_kg", spy)
+    monkeypatch.setattr(watcher, "_escalate_to_kg", spy)
+    monkeypatch.setattr(watcher_findings, "_escalate_to_kg", spy)
+
+
+def _mock_watcher_identity(monkeypatch, watcher_module, identity):
+    """Set ``_watcher_identity`` on both the importlib copy and the real agent
+    module. Needed because findings.update_finding_status does a lazy import
+    from ``agents.watcher.agent`` — patches on the watcher_module copy alone
+    miss the real module's binding."""
+    from agents.watcher import agent as watcher
+    monkeypatch.setattr(watcher_module, "_watcher_identity", identity)
+    monkeypatch.setattr(watcher, "_watcher_identity", identity)
 
 
 # ---------------------------------------------------------------------------
@@ -562,7 +619,7 @@ def test_review_file_escalates_high_severity(watcher_module, tmp_path, monkeypat
     _install_review_stubs(watcher_module, monkeypatch, review_json)
 
     calls: list[dict] = []
-    monkeypatch.setattr(watcher_module, "post_finding", lambda **kw: calls.append(kw) or True)
+    _mock_post_finding(monkeypatch, watcher_module, lambda **kw: calls.append(kw) or True)
 
     watcher_module.review_file("/tmp/fake.py")
 
@@ -581,9 +638,7 @@ def test_escalate_high_does_not_call_external_targets(watcher_module, monkeypatc
     finding = _finding(watcher_module, severity="high")
     kg_calls = []
 
-    monkeypatch.setattr(
-        watcher_module, "_escalate_to_kg", lambda f: kg_calls.append(f)
-    )
+    _mock_escalate_to_kg(monkeypatch, watcher_module, lambda f: kg_calls.append(f))
 
     watcher_module.escalate(finding)
 
@@ -594,9 +649,7 @@ def test_escalate_critical_calls_kg(watcher_module, monkeypatch):
     finding = _finding(watcher_module, severity="critical")
     calls = []
 
-    monkeypatch.setattr(
-        watcher_module, "_escalate_to_kg", lambda f: calls.append(f)
-    )
+    _mock_escalate_to_kg(monkeypatch, watcher_module, lambda f: calls.append(f))
 
     watcher_module.escalate(finding)
 
@@ -1822,9 +1875,13 @@ class TestWatcherPostsFindings:
     def test_high_severity_finding_posts_to_event_stream(self, tmp_path, monkeypatch):
         """After persisting a new high-severity finding to jsonl, Watcher posts to /api/findings."""
         from agents.watcher import agent as watcher
+        from agents.watcher import findings as watcher_findings_local
 
         monkeypatch.setattr(watcher, "FINDINGS_FILE", tmp_path / "findings.jsonl")
         monkeypatch.setattr(watcher, "DEDUP_FILE", tmp_path / "dedup.json")
+        monkeypatch.setattr(watcher_findings_local, "FINDINGS_FILE", tmp_path / "findings.jsonl")
+        monkeypatch.setattr(watcher_findings_local, "DEDUP_FILE", tmp_path / "dedup.json")
+        monkeypatch.setattr(watcher_findings_local, "STATE_DIR", tmp_path)
 
         calls = []
 
@@ -1832,7 +1889,7 @@ class TestWatcherPostsFindings:
             calls.append(kwargs)
             return True
 
-        monkeypatch.setattr(watcher, "post_finding", fake_post)
+        _mock_post_finding(monkeypatch, watcher, fake_post)
 
         finding = watcher.Finding(
             pattern="P011",
@@ -1860,12 +1917,16 @@ class TestWatcherPostsFindings:
     def test_low_severity_finding_does_not_post(self, tmp_path, monkeypatch):
         """Low/medium stay local to jsonl — only high/critical hit the stream."""
         from agents.watcher import agent as watcher
+        from agents.watcher import findings as watcher_findings_local
 
         monkeypatch.setattr(watcher, "FINDINGS_FILE", tmp_path / "findings.jsonl")
         monkeypatch.setattr(watcher, "DEDUP_FILE", tmp_path / "dedup.json")
+        monkeypatch.setattr(watcher_findings_local, "FINDINGS_FILE", tmp_path / "findings.jsonl")
+        monkeypatch.setattr(watcher_findings_local, "DEDUP_FILE", tmp_path / "dedup.json")
+        monkeypatch.setattr(watcher_findings_local, "STATE_DIR", tmp_path)
 
         calls = []
-        monkeypatch.setattr(watcher, "post_finding",
+        _mock_post_finding(monkeypatch, watcher,
                             lambda **kw: calls.append(kw) or True)
 
         finding = watcher.Finding(
@@ -1881,12 +1942,16 @@ class TestWatcherPostsFindings:
     def test_persist_findings_delegates_posting_per_high_severity_finding(self, tmp_path, monkeypatch):
         """Batch persist_findings calls post_finding for each new high-severity finding."""
         from agents.watcher import agent as watcher
+        from agents.watcher import findings as watcher_findings_local
 
         monkeypatch.setattr(watcher, "FINDINGS_FILE", tmp_path / "findings.jsonl")
         monkeypatch.setattr(watcher, "DEDUP_FILE", tmp_path / "dedup.json")
+        monkeypatch.setattr(watcher_findings_local, "FINDINGS_FILE", tmp_path / "findings.jsonl")
+        monkeypatch.setattr(watcher_findings_local, "DEDUP_FILE", tmp_path / "dedup.json")
+        monkeypatch.setattr(watcher_findings_local, "STATE_DIR", tmp_path)
 
         calls = []
-        monkeypatch.setattr(watcher, "post_finding",
+        _mock_post_finding(monkeypatch, watcher,
                             lambda **kw: calls.append(kw) or True)
 
         f1 = watcher.Finding(
@@ -2300,7 +2365,7 @@ class TestWatcherCheckin:
         ])
 
         # Set up identity so check-in proceeds
-        monkeypatch.setattr(watcher_module, "_watcher_identity", {
+        _mock_watcher_identity(monkeypatch, watcher_module, {
             "agent_uuid": "uuid-w", "client_session_id": "s1", "continuity_token": "t1",
         })
 
@@ -2328,7 +2393,7 @@ class TestWatcherCheckin:
 
     def test_checkin_skipped_when_no_identity(self, watcher_module, monkeypatch):
         """No identity → surface works, check-in silently skipped."""
-        monkeypatch.setattr(watcher_module, "_watcher_identity", None)
+        _mock_watcher_identity(monkeypatch, watcher_module, None)
 
         self._write_findings(watcher_module, [
             {"fingerprint": "ccc3", "status": "open", "severity": "low",
@@ -2342,7 +2407,7 @@ class TestWatcherCheckin:
 
     def test_checkin_idle_heartbeat(self, watcher_module, monkeypatch):
         """No active findings → idle heartbeat with low complexity."""
-        monkeypatch.setattr(watcher_module, "_watcher_identity", {
+        _mock_watcher_identity(monkeypatch, watcher_module, {
             "agent_uuid": "uuid-w", "client_session_id": "s1", "continuity_token": "t1",
         })
 
@@ -2387,7 +2452,7 @@ class TestWatcherCheckin:
         """surface_pending() must call _do_checkin even when there are no open
         findings to surface. Previously the early return skipped the check-in,
         causing Watcher to go silent between finding bursts."""
-        monkeypatch.setattr(watcher_module, "_watcher_identity", {
+        _mock_watcher_identity(monkeypatch, watcher_module, {
             "agent_uuid": "uuid-w", "client_session_id": "s1", "continuity_token": "t1",
         })
 
@@ -2429,14 +2494,14 @@ class TestResolutionAuditTrail:
              "hint": "asyncpg deadlock", "violation_class": "REC",
              "timestamp": datetime.now(timezone.utc).isoformat()},
         ])
-        monkeypatch.setattr(watcher_module, "_watcher_identity", {
+        _mock_watcher_identity(monkeypatch, watcher_module, {
             "agent_uuid": "uuid-watcher",
             "client_session_id": "s1",
             "continuity_token": "t1",
         })
 
         posted = {}
-        monkeypatch.setattr(watcher_module, "post_finding", lambda **kw: posted.update(kw) or True)
+        _mock_post_finding(monkeypatch, watcher_module, lambda **kw: posted.update(kw) or True)
 
         watcher_module.update_finding_status("ff27c1b2", "confirmed", resolver_agent_id="uuid-agent-X")
 
@@ -2454,14 +2519,14 @@ class TestResolutionAuditTrail:
              "hint": "asyncpg deadlock", "violation_class": "REC",
              "timestamp": datetime.now(timezone.utc).isoformat()},
         ])
-        monkeypatch.setattr(watcher_module, "_watcher_identity", {
+        _mock_watcher_identity(monkeypatch, watcher_module, {
             "agent_uuid": "uuid-watcher",
             "client_session_id": "s1",
             "continuity_token": "t1",
         })
 
         posted = {}
-        monkeypatch.setattr(watcher_module, "post_finding", lambda **kw: posted.update(kw) or True)
+        _mock_post_finding(monkeypatch, watcher_module, lambda **kw: posted.update(kw) or True)
 
         watcher_module.update_finding_status("8266dfb8", "dismissed", resolver_agent_id="uuid-agent-Y")
 
@@ -2477,14 +2542,14 @@ class TestResolutionAuditTrail:
              "hint": "unbounded growth", "violation_class": "ENT",
              "timestamp": datetime.now(timezone.utc).isoformat()},
         ])
-        monkeypatch.setattr(watcher_module, "_watcher_identity", {
+        _mock_watcher_identity(monkeypatch, watcher_module, {
             "agent_uuid": "uuid-watcher",
             "client_session_id": "s1",
             "continuity_token": "t1",
         })
 
         posted = {}
-        monkeypatch.setattr(watcher_module, "post_finding", lambda **kw: posted.update(kw) or True)
+        _mock_post_finding(monkeypatch, watcher_module, lambda **kw: posted.update(kw) or True)
 
         watcher_module.update_finding_status("abcd1234", "confirmed")
 
@@ -2498,10 +2563,10 @@ class TestResolutionAuditTrail:
              "hint": "test", "violation_class": "CON",
              "timestamp": datetime.now(timezone.utc).isoformat()},
         ])
-        monkeypatch.setattr(watcher_module, "_watcher_identity", None)
+        _mock_watcher_identity(monkeypatch, watcher_module, None)
 
         posted = {}
-        monkeypatch.setattr(watcher_module, "post_finding", lambda **kw: posted.update(kw) or True)
+        _mock_post_finding(monkeypatch, watcher_module, lambda **kw: posted.update(kw) or True)
 
         result = watcher_module.update_finding_status("dead0000", "confirmed")
 
@@ -2516,7 +2581,7 @@ class TestResolutionAuditTrail:
              "hint": "test", "violation_class": "REC",
              "timestamp": datetime.now(timezone.utc).isoformat()},
         ])
-        monkeypatch.setattr(watcher_module, "_watcher_identity", {
+        _mock_watcher_identity(monkeypatch, watcher_module, {
             "agent_uuid": "uuid-watcher",
             "client_session_id": "s1",
             "continuity_token": "t1",
@@ -2525,7 +2590,7 @@ class TestResolutionAuditTrail:
         def exploding_post(**kw):
             raise RuntimeError("governance exploded")
 
-        monkeypatch.setattr(watcher_module, "post_finding", exploding_post)
+        _mock_post_finding(monkeypatch, watcher_module, exploding_post)
 
         result = watcher_module.update_finding_status("beef0000", "confirmed")
         assert result == 0  # local update still worked
@@ -2579,6 +2644,13 @@ class TestWatcherLifecycleIntegration:
         assert watcher_module.get_watcher_identity()["agent_uuid"] == "uuid-watcher-int"
         assert ("onboard", "Watcher") in gov_calls
 
+        # resolve_identity only sets _watcher_identity on the importlib-loaded
+        # watcher_module copy. findings.update_finding_status does a lazy
+        # import from the real agents.watcher.agent module, so mirror the
+        # identity there for _post_resolution_event to see it.
+        from agents.watcher import agent as real_watcher
+        monkeypatch.setattr(real_watcher, "_watcher_identity", watcher_module.get_watcher_identity())
+
         # 2. Simulate a finding being persisted
         watcher_module.FINDINGS_FILE.parent.mkdir(parents=True, exist_ok=True)
         finding = {
@@ -2603,7 +2675,7 @@ class TestWatcherLifecycleIntegration:
 
         # 4. Resolve finding (posts audit event)
         posted_events = []
-        monkeypatch.setattr(watcher_module, "post_finding", lambda **kw: posted_events.append(kw) or True)
+        _mock_post_finding(monkeypatch, watcher_module, lambda **kw: posted_events.append(kw) or True)
 
         result = watcher_module.update_finding_status("integ000", "confirmed", resolver_agent_id="uuid-agent-resolver")
         assert result == 0


### PR DESCRIPTION
Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.