### PR TITLE
fix(watcher): import PROJECT_ROOT onto sys.path before first agents.* import

### DIFF
--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -59,9 +59,14 @@ from typing import Any
 # Paths & Config
 # ---------------------------------------------------------------------------
 
-# PROJECT_ROOT is defined in _util so findings.py can import it without a
-# circular dependency; the sys.path insert still has to happen before the
-# common.* / unitares_sdk imports below.
+# Put the repo root on sys.path before the first `agents.*` import. Hooks
+# invoke this script by absolute path from arbitrary cwd (e.g. $HOME), so
+# Python only adds `agents/watcher/` to sys.path by default — the `agents`
+# package is not importable without this. PROJECT_ROOT is re-exported from
+# _util as the canonical reference for downstream consumers, but we can't
+# import _util until after the path is patched.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
 from agents.watcher._util import (
     LOG_FILE,
     MAX_LOG_LINES,
@@ -70,8 +75,6 @@ from agents.watcher._util import (
     log,
     repo_relative_path,
 )
-
-sys.path.insert(0, str(PROJECT_ROOT))
 from agents.common.log import trim_log as _common_trim_log
 from agents.common.findings import post_finding
 from agents.watcher import findings as _findings_mod

--- a/agents/watcher/tests/test_hook_invocation.py
+++ b/agents/watcher/tests/test_hook_invocation.py
@@ -1,0 +1,61 @@
+"""Regression test: hooks invoke agent.py by absolute path from arbitrary cwd.
+
+Background: on 2026-04-23, both SessionStart and UserPromptSubmit Claude Code
+hooks failed with ``ModuleNotFoundError: No module named 'agents'`` in every
+new session. Root cause was an import-order bug introduced by the
+watcher-findings-split refactor (commit 384aca64):
+
+    from agents.watcher._util import ...     # line 65 — fails here
+    ...
+    sys.path.insert(0, str(PROJECT_ROOT))    # line 74 — too late
+
+When the hook runs ``python3 /abs/path/agent.py --print-unresolved`` from the
+user's home directory, Python adds ``agents/watcher/`` to sys.path (the
+script's directory) but *not* the repo root, so the top-level ``agents.*``
+import fails before the sys.path patch on line 74 runs.
+
+The existing test_agent.py tests load the module via
+``importlib.util.spec_from_file_location`` with an explicit path, which
+bypasses sys.path resolution entirely — so they never exercised the
+hook-invocation path and the regression slipped through.
+
+This test invokes agent.py the same way the hook does: as a subprocess, by
+absolute path, from an unrelated cwd, with no PYTHONPATH. If the import
+order regresses again, this will fail.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+AGENT_PATH = (
+    Path(__file__).resolve().parent.parent / "agent.py"
+)
+
+
+def test_agent_imports_from_foreign_cwd(tmp_path):
+    """Replicate the hook invocation: absolute script path, unrelated cwd, no PYTHONPATH."""
+    env = {
+        k: v for k, v in os.environ.items()
+        if k not in {"PYTHONPATH"}
+    }
+    result = subprocess.run(
+        [sys.executable, str(AGENT_PATH), "--print-unresolved"],
+        cwd=str(tmp_path),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"agent.py failed to import from foreign cwd.\n"
+        f"stdout: {result.stdout}\n"
+        f"stderr: {result.stderr}"
+    )
+    assert "ModuleNotFoundError" not in result.stderr, (
+        f"Import-order regression: {result.stderr}"
+    )


### PR DESCRIPTION
## Summary
- Fixes `ModuleNotFoundError: No module named 'agents'` in every new Claude Code session — the SessionStart (`watcher-surface.sh`) and UserPromptSubmit (`watcher-chime.sh`) hooks invoke `agents/watcher/agent.py` by absolute path from the user's home dir, which was a hook-invocation path not exercised by the existing test suite.
- Root cause was an import-order bug introduced by #119 (watcher-findings-split refactor): `sys.path.insert(0, str(PROJECT_ROOT))` landed *after* the first `from agents.watcher._util import ...`, so it only worked when the repo root was already on `sys.path`.
- Also adds a subprocess-based regression test that exercises the exact hook invocation path. `test_agent.py` loads the module via `importlib.util.spec_from_file_location` with an explicit path, bypassing `sys.path` resolution — which is why the regression slipped through.

## Test plan
- [x] `pytest agents/watcher/tests/` → 135/135 pass
- [x] `./scripts/dev/test-cache.sh` → 6785 passed, 33 skipped, coverage 77.67%
- [x] Manually verified: `cd /tmp && python3 /abs/path/agent.py --print-unresolved` now exits 0 (was ModuleNotFoundError)
- [ ] New session's hook chime surfaces cleanly (will verify post-merge)