### PR TITLE
feat(identity): S8a Phase-1 default-stamp class tags at onboard

### DIFF
--- a/agents/sdk/src/unitares_sdk/agent.py
+++ b/agents/sdk/src/unitares_sdk/agent.py
@@ -243,6 +243,14 @@ class GovernanceAgent:
             #                    can't respond to pause verdicts within the 30s
             #                    cooldown, so pattern-4 rejection silently starves
             #                    their state writes (Steward 2026-04-20 regression).
+            #
+            # S8a Phase-1 (2026-04-23): the server now stamps these tags in the
+            # onboard handler for any name matching KNOWN_RESIDENT_LABELS (see
+            # src/grounding/onboard_classifier.py + identity/handlers.py
+            # _stamp_default_tags_on_onboard). This client-side write is now
+            # redundant against a current server, but retained as backward
+            # compatibility for older server deploys that predate Phase 1. It
+            # is a no-op when the server already stamped the same tags.
             try:
                 await client.call_tool(
                     "update_agent_metadata",

--- a/docs/ontology/plan.md
+++ b/docs/ontology/plan.md
@@ -160,7 +160,8 @@ S5 and S6-Option-B (plus Q2 `seed_genesis_from_parent` primitive) both shipped t
 1. **S6 follow-up: wire `seed_genesis_from_parent` into onboard** — **Shipped 2026-04-23** as PR #112 (`a8bf5d71`). `_seed_genesis_from_parent_bg` in `src/mcp_handlers/identity/handlers.py:1790` scheduled alongside `_create_spawned_edge_bg` on both fresh-identity and force_new branches.
 2. **v7 outline draft** — fresh session in `unitares-paper-v6` repo. Produces a `.tex` skeleton you can read and redirect. Independent of all code work.
 3. **Pre-dispatch PR-scan checkpoint** — **Resolved 2026-04-23** as the lighter `WIP-PR:` convention + handoff-template pre-flight (see "How to change this plan" and "Handoff prompt template" below). Docs-only; no enforcement hook. If the convention fails to prevent duplicates in practice, escalate to a dispatch-path hook.
-4. **S8a follow-up: Phase-1 default-stamp at onboard** — S8a findings doc shipped (`docs/ontology/s8a-tag-discipline-audit.md`); recommendation is Option 1 (default-stamp at onboard) + partial Option 2 (later promotion sweep). Needs operator sign-off on the Phase-1 rule set and the `session_like` class addition before implementation. Unblocks S6 recalibration and S8b backfill.
+4. **S8a follow-up: Phase-1 default-stamp at onboard** — **In flight 2026-04-23**. Operator signed off on a 2-branch rule (resident label → persistent+autonomous; else → ephemeral); `session_like` class deferred to Phase 2; Phase 2 held pending empirical data.
+   WIP-PR: branch `feat/s8a-phase1-classify-on-onboard` (agent-59e966aa-7b8)
 
 After those, re-read this plan and decide whether remaining rows still matter or have been superseded.
 

--- a/src/grounding/onboard_classifier.py
+++ b/src/grounding/onboard_classifier.py
@@ -1,0 +1,53 @@
+"""S8a Phase-1 default-stamp: classify fresh identities at onboard.
+
+Rule (2-branch, per docs/ontology/s8a-tag-discipline-audit.md):
+  - ``name`` matches ``KNOWN_RESIDENT_LABELS`` → resident default tags.
+  - otherwise → ``["ephemeral"]``.
+
+If the caller already supplied tags, return ``None`` to signal "don't
+override." This preserves backward compatibility with callers that stamp
+their own class tag at onboard time (SDK residents, custom harnesses).
+
+The rule deliberately does NOT introduce new classes (``resident_lineage``,
+``session_like``). Phase 1 populates the existing ``ephemeral`` bucket;
+Phase 2 decides what promotes out of it based on observed behavior.
+"""
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+from src.grounding.class_indicator import KNOWN_RESIDENT_LABELS
+
+# Mirror of agents/sdk/src/unitares_sdk/agent.py:RESIDENT_TAGS. Residents
+# need BOTH tags: 'persistent' protects from auto_archive_orphan_agents,
+# 'autonomous' exempts from loop-detection pattern 4. Keeping the list in
+# sync across SDK and server is a known Phase-1 cost.
+RESIDENT_DEFAULT_TAGS = ["persistent", "autonomous"]
+EPHEMERAL_DEFAULT_TAGS = ["ephemeral"]
+
+
+def default_tags_for_onboard(
+    name: Optional[str],
+    existing_tags: Optional[Iterable[str]] = None,
+) -> Optional[list[str]]:
+    """Return the default tag list to stamp at onboard, or ``None``.
+
+    Args:
+      name: Display name supplied at onboard (e.g. "Lumen"). Matched
+        exactly against ``KNOWN_RESIDENT_LABELS``; structured labels like
+        "Lumen_abc123" do not match.
+      existing_tags: Tags already on the identity metadata. If truthy,
+        the caller has asserted class and the default must not override.
+
+    Returns:
+      ``None`` when ``existing_tags`` is non-empty (skip stamping).
+      ``RESIDENT_DEFAULT_TAGS`` when ``name`` is a known resident.
+      ``EPHEMERAL_DEFAULT_TAGS`` otherwise.
+    """
+    if existing_tags:
+        return None
+
+    if name and name in KNOWN_RESIDENT_LABELS:
+        return list(RESIDENT_DEFAULT_TAGS)
+
+    return list(EPHEMERAL_DEFAULT_TAGS)

--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -1483,6 +1483,17 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
                 agent_label = name
                 identity["label"] = name
 
+    # S8a Phase-1: default-stamp class tag on fresh identities so the class
+    # partition (ephemeral / resident / ...) is populated from onboard rather
+    # than left to out-of-band SDK writes that only fire for resident
+    # subclasses. Rule lives in src/grounding/onboard_classifier.py; see
+    # docs/ontology/s8a-tag-discipline-audit.md.
+    if is_new:
+        try:
+            await _stamp_default_tags_on_onboard(agent_uuid, name)
+        except Exception as e:
+            logger.debug(f"[ONBOARD] default-stamp failed (non-fatal): {e}")
+
     # TRAJECTORY IDENTITY: Store genesis signature if provided (optional, non-blocking)
     # Agents from anima-mcp can include trajectory_signature in their onboard call
     trajectory_result = None
@@ -1785,6 +1796,42 @@ async def _create_spawned_edge_bg(
         logger.info(f"[SPAWNED] Created edge {parent_id[:8]}... -> {child_id[:8]}...")
     except Exception as e:
         logger.debug(f"SPAWNED edge creation failed (non-fatal): {e}")
+
+
+async def _stamp_default_tags_on_onboard(agent_uuid: str, name: Optional[str]) -> None:
+    """S8a Phase-1: stamp default class tags on a freshly-created identity.
+
+    Synchronous (not background) because the first `process_agent_update`
+    call can immediately follow `onboard` and the class tag governs
+    class-conditional calibration, trust-tier routing, and
+    archive-orphan-sweep exemptions. If tags aren't persisted before
+    onboard returns, the first check-in classifies as `default` and uses
+    the wrong scale maps.
+
+    Rule (2-branch): resident label → ["persistent", "autonomous"];
+    otherwise → ["ephemeral"]. See src/grounding/onboard_classifier.py.
+
+    Non-fatal on exception — onboard succeeds without the tag stamp, but
+    the agent will be misclassified until a later `update_agent_metadata`
+    call. Caller catches and logs.
+    """
+    from src import agent_storage
+    from src.grounding.onboard_classifier import default_tags_for_onboard
+
+    meta = mcp_server.agent_metadata.get(agent_uuid)
+    existing_tags = getattr(meta, "tags", None) if meta is not None else None
+    default_tags = default_tags_for_onboard(name, existing_tags=existing_tags)
+    if default_tags is None:
+        return
+
+    # In-memory sync so subsequent reads in the same request see the tags;
+    # DB write so load_metadata_async() reloads don't clobber them.
+    if meta is not None:
+        meta.tags = default_tags
+    await agent_storage.update_agent(agent_id=agent_uuid, tags=default_tags)
+    logger.info(
+        f"[ONBOARD] S8a default-stamp: {agent_uuid[:8]}... tagged {default_tags} (name={name!r})"
+    )
 
 
 async def _seed_genesis_from_parent_bg(child_id: str, parent_id: str):

--- a/tests/test_onboard_classifier.py
+++ b/tests/test_onboard_classifier.py
@@ -1,0 +1,109 @@
+"""Unit tests for S8a Phase-1 default-stamp rule.
+
+Covers `src/grounding/onboard_classifier.py:default_tags_for_onboard`
+and the handler-side wiring `_stamp_default_tags_on_onboard`.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.grounding.onboard_classifier import (
+    EPHEMERAL_DEFAULT_TAGS,
+    RESIDENT_DEFAULT_TAGS,
+    default_tags_for_onboard,
+)
+
+
+class TestDefaultTagsForOnboard:
+    def test_resident_name_returns_resident_tags(self):
+        for name in ("Lumen", "Vigil", "Sentinel", "Watcher", "Steward", "Chronicler"):
+            assert default_tags_for_onboard(name, existing_tags=None) == RESIDENT_DEFAULT_TAGS
+
+    def test_unknown_name_returns_ephemeral(self):
+        assert default_tags_for_onboard("some-agent", existing_tags=None) == EPHEMERAL_DEFAULT_TAGS
+
+    def test_none_name_returns_ephemeral(self):
+        assert default_tags_for_onboard(None, existing_tags=None) == EPHEMERAL_DEFAULT_TAGS
+
+    def test_empty_name_returns_ephemeral(self):
+        assert default_tags_for_onboard("", existing_tags=None) == EPHEMERAL_DEFAULT_TAGS
+
+    def test_resident_name_with_existing_tags_returns_none(self):
+        assert default_tags_for_onboard("Lumen", existing_tags=["custom"]) is None
+
+    def test_unknown_name_with_existing_tags_returns_none(self):
+        assert default_tags_for_onboard("some-agent", existing_tags=["persistent"]) is None
+
+    def test_empty_list_is_treated_as_no_tags(self):
+        assert default_tags_for_onboard("Lumen", existing_tags=[]) == RESIDENT_DEFAULT_TAGS
+        assert default_tags_for_onboard("other", existing_tags=[]) == EPHEMERAL_DEFAULT_TAGS
+
+    def test_return_value_is_a_new_list_not_shared_reference(self):
+        a = default_tags_for_onboard("Lumen", existing_tags=None)
+        b = default_tags_for_onboard("Lumen", existing_tags=None)
+        a.append("mutated")
+        assert b == RESIDENT_DEFAULT_TAGS
+
+    def test_resident_label_matching_is_case_sensitive(self):
+        assert default_tags_for_onboard("lumen", existing_tags=None) == EPHEMERAL_DEFAULT_TAGS
+        assert default_tags_for_onboard("LUMEN", existing_tags=None) == EPHEMERAL_DEFAULT_TAGS
+
+    def test_structured_agent_id_does_not_match_resident(self):
+        assert default_tags_for_onboard("Lumen_abc123", existing_tags=None) == EPHEMERAL_DEFAULT_TAGS
+
+
+def _make_meta(tags=None):
+    class _Meta:
+        pass
+    m = _Meta()
+    m.tags = tags
+    return m
+
+
+async def _run_stamp(name, existing_tags, *, missing_meta=False):
+    meta = None if missing_meta else _make_meta(tags=existing_tags)
+    agent_uuid = "uuid-1234"
+    fake_server = MagicMock()
+    fake_server.agent_metadata = {} if missing_meta else {agent_uuid: meta}
+    fake_update = AsyncMock()
+
+    with patch(
+        "src.mcp_handlers.identity.handlers.mcp_server", fake_server
+    ), patch("src.agent_storage.update_agent", fake_update):
+        from src.mcp_handlers.identity.handlers import _stamp_default_tags_on_onboard
+        await _stamp_default_tags_on_onboard(agent_uuid, name)
+
+    return meta, fake_update
+
+
+@pytest.mark.asyncio
+async def test_stamp_unknown_name_gets_ephemeral_and_persists():
+    meta, fake_update = await _run_stamp("some-agent", existing_tags=None)
+    assert meta.tags == ["ephemeral"]
+    fake_update.assert_awaited_once_with(agent_id="uuid-1234", tags=["ephemeral"])
+
+
+@pytest.mark.asyncio
+async def test_stamp_resident_name_gets_persistent_autonomous():
+    meta, fake_update = await _run_stamp("Sentinel", existing_tags=None)
+    assert meta.tags == ["persistent", "autonomous"]
+    fake_update.assert_awaited_once_with(
+        agent_id="uuid-1234", tags=["persistent", "autonomous"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_stamp_preexisting_tags_are_not_overwritten():
+    meta, fake_update = await _run_stamp("Sentinel", existing_tags=["custom"])
+    assert meta.tags == ["custom"]
+    fake_update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stamp_missing_metadata_object_still_writes_tags_to_db():
+    """Identity with no in-memory metadata entry yet — DB write is still
+    source of truth; next load_metadata_async picks it up."""
+    _, fake_update = await _run_stamp("some-agent", existing_tags=None, missing_meta=True)
+    fake_update.assert_awaited_once_with(agent_id="uuid-1234", tags=["ephemeral"])


### PR DESCRIPTION
## Summary

Server-side default-stamp of class tags on fresh identities at `onboard`, closing the 96.5% untagged gap surfaced by S8a findings (docs/ontology/s8a-tag-discipline-audit.md).

Rule (2-branch, per operator sign-off):
- `name` matches `KNOWN_RESIDENT_LABELS` → `["persistent", "autonomous"]`
- otherwise → `["ephemeral"]`

Skips stamping when caller already supplied tags (backward-compat for callers that assert class themselves). Synchronous write because the first `process_agent_update` can immediately follow `onboard`, and class tag governs class-conditional calibration, trust-tier routing, and archive-orphan-sweep exemptions.

## Deferred to Phase 2 (pending empirical data)

- `session_like` class addition
- Promotion sweep for long-running `ephemeral` agents
- Archived-identity backfill

## Unblocks

- S6 session-like threshold recalibration
- S8b archival backfill

## Files

- `src/grounding/onboard_classifier.py` — new pure helper `default_tags_for_onboard(name, existing_tags)`
- `src/mcp_handlers/identity/handlers.py` — async helper `_stamp_default_tags_on_onboard` + call on both fresh-identity + force_new branches (gated on `is_new`)
- `agents/sdk/src/unitares_sdk/agent.py` — deprecation comment on the SDK's `update_agent_metadata` call (retained as backward-compat fallback for pre-Phase-1 servers)
- `tests/test_onboard_classifier.py` — 14 tests (10 unit, 4 handler integration)
- `docs/ontology/plan.md` — WIP-PR stamp on priority #4

## Test plan

- [x] Unit tests on `default_tags_for_onboard` (edge cases: None/empty name, case-sensitivity, structured labels, existing tags)
- [x] Handler tests on `_stamp_default_tags_on_onboard` (resident vs unknown, preexisting-tags no-override, missing-metadata path)
- [x] Full suite — 6799 passed (+14 from baseline), 33 skipped, no regressions