### PR TITLE
Add Sentinel panel to dashboard

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -32,6 +32,7 @@
     <script src="/dashboard/residents.js"></script>
     <script src="/dashboard/fleet-metrics.js"></script>
     <script src="/dashboard/watcher.js"></script>
+    <script src="/dashboard/sentinel.js"></script>
 </head>
 
 <body>
@@ -80,6 +81,7 @@
         <a href="#activity-timeline-section" class="section-nav-item" data-section="activity-timeline-section">Activity</a>
         <a href="#fleet-metrics-section" class="section-nav-item" data-section="fleet-metrics-section">Chronicler</a>
         <a href="#watcher-section" class="section-nav-item" data-section="watcher-section">Watcher</a>
+        <a href="#sentinel-section" class="section-nav-item" data-section="sentinel-section">Sentinel</a>
         <a href="/phase" style="margin-left:auto; opacity:0.6; padding:6px 14px; border-radius:20px; font-size:0.8rem; font-weight:500; color:var(--text-secondary); text-decoration:none; white-space:nowrap;">Phase Space &rarr;</a>
     </nav>
 
@@ -538,6 +540,41 @@
             </table>
             <div class="fleet-metrics-meta">
                 <span id="watcher-meta" class="fleet-metrics-scrape-status"></span>
+            </div>
+        </div>
+
+        <!-- Sentinel — fleet-anomaly findings stream. Unlike Watcher there's no
+             open/resolved lifecycle: findings are transient state signals.
+             Backed by /v1/sentinel/summary. -->
+        <div class="panel" id="sentinel-section">
+            <div class="panel-header">
+                <h2>Sentinel</h2>
+                <div class="panel-controls">
+                    <button id="sentinel-refresh" class="panel-button" type="button">Refresh</button>
+                </div>
+            </div>
+            <div class="sentinel-counts">
+                <div class="sentinel-stat">
+                    <span class="sentinel-stat-label">total · 24h</span>
+                    <span class="sentinel-stat-value" id="sentinel-count-total">—</span>
+                </div>
+                <div class="sentinel-stat sentinel-stat-sev-critical">
+                    <span class="sentinel-stat-label">critical</span>
+                    <span class="sentinel-stat-value" id="sentinel-count-critical">—</span>
+                </div>
+                <div class="sentinel-stat sentinel-stat-sev-high">
+                    <span class="sentinel-stat-label">high</span>
+                    <span class="sentinel-stat-value" id="sentinel-count-high">—</span>
+                </div>
+                <div class="sentinel-stat sentinel-stat-sev-medium">
+                    <span class="sentinel-stat-label">medium</span>
+                    <span class="sentinel-stat-value" id="sentinel-count-medium">—</span>
+                </div>
+            </div>
+            <div class="sentinel-class-breakdown" id="sentinel-class-breakdown"></div>
+            <div class="sentinel-stream" id="sentinel-stream"></div>
+            <div class="fleet-metrics-meta">
+                <span id="sentinel-meta" class="fleet-metrics-scrape-status"></span>
             </div>
         </div>
 

--- a/dashboard/sentinel.js
+++ b/dashboard/sentinel.js
@@ -1,0 +1,170 @@
+// sentinel.js — Sentinel findings stream panel.
+//
+// Consumes:
+//   GET /v1/sentinel/summary — counts by severity + violation class, recent stream
+//
+// Unlike Watcher, Sentinel findings are transient fleet-state signals with no
+// open/closed lifecycle. This panel is a chronological log with a class
+// breakdown — not an actionable queue.
+//
+// Auth + fetch go through `authFetch` from utils.js.
+
+(function () {
+    'use strict';
+
+    async function fetchSummary() {
+        try {
+            var resp = await authFetch('/v1/sentinel/summary');
+            if (!resp.ok) throw new Error('HTTP ' + resp.status);
+            var data = await resp.json();
+            if (!data || data.success === false) {
+                throw new Error((data && data.error) || 'unknown');
+            }
+            return data;
+        } catch (e) {
+            console.warn('[Sentinel] summary fetch failed:', e);
+            return null;
+        }
+    }
+
+    function setMetric(id, value) {
+        var el = document.getElementById(id);
+        if (el) el.textContent = value;
+    }
+
+    function renderCounts(summary) {
+        var bySev = summary.by_severity || {};
+        setMetric('sentinel-count-total', summary.total || 0);
+        setMetric('sentinel-count-critical', bySev.critical || 0);
+        setMetric('sentinel-count-high', bySev.high || 0);
+        setMetric('sentinel-count-medium', bySev.medium || 0);
+    }
+
+    function renderClassBreakdown(summary) {
+        var container = document.getElementById('sentinel-class-breakdown');
+        if (!container) return;
+        container.innerHTML = '';
+        var classes = summary.by_violation_class || [];
+        if (classes.length === 0) {
+            var empty = document.createElement('span');
+            empty.className = 'sentinel-class-empty';
+            empty.textContent = 'no findings in window';
+            container.appendChild(empty);
+            return;
+        }
+        for (var i = 0; i < classes.length; i++) {
+            var c = classes[i];
+            var pill = document.createElement('span');
+            pill.className = 'sentinel-class-pill';
+            var name = document.createElement('span');
+            name.className = 'sentinel-class-name';
+            name.textContent = c.violation_class;
+            var count = document.createElement('span');
+            count.className = 'sentinel-class-count';
+            count.textContent = String(c.count);
+            // Tooltip shows severity breakdown so hovering tells the full story
+            var sevParts = [];
+            var sev = c.by_severity || {};
+            for (var k in sev) {
+                if (Object.prototype.hasOwnProperty.call(sev, k)) {
+                    sevParts.push(k + ':' + sev[k]);
+                }
+            }
+            pill.title = sevParts.join(' · ');
+            pill.appendChild(name);
+            pill.appendChild(count);
+            container.appendChild(pill);
+        }
+    }
+
+    function formatRelative(isoStr) {
+        if (!isoStr) return '';
+        var then = new Date(isoStr);
+        if (isNaN(then.getTime())) return isoStr;
+        var secs = Math.floor((Date.now() - then.getTime()) / 1000);
+        if (secs < 60) return 'just now';
+        if (secs < 3600) return Math.floor(secs / 60) + 'm ago';
+        if (secs < 86400) return Math.floor(secs / 3600) + 'h ago';
+        return Math.floor(secs / 86400) + 'd ago';
+    }
+
+    function renderStream(summary) {
+        var container = document.getElementById('sentinel-stream');
+        if (!container) return;
+        container.innerHTML = '';
+        var recent = summary.recent || [];
+        if (recent.length === 0) {
+            var empty = document.createElement('div');
+            empty.className = 'sentinel-stream-empty';
+            empty.textContent = 'No Sentinel findings in the last ' + (summary.window_hours || 24) + ' hours.';
+            container.appendChild(empty);
+            return;
+        }
+        for (var i = 0; i < recent.length; i++) {
+            var r = recent[i];
+            var row = document.createElement('div');
+            row.className = 'sentinel-row';
+
+            var ts = document.createElement('span');
+            ts.className = 'sentinel-row-time';
+            ts.textContent = formatRelative(r.timestamp);
+            ts.title = r.timestamp || '';
+
+            var sev = document.createElement('span');
+            var sevValue = (r.severity || '?').toLowerCase();
+            sev.className = 'sentinel-row-sev sentinel-row-sev-' + sevValue;
+            sev.textContent = sevValue;
+
+            var vc = document.createElement('span');
+            vc.className = 'sentinel-row-class';
+            vc.textContent = r.violation_class || '?';
+
+            var msg = document.createElement('span');
+            msg.className = 'sentinel-row-msg';
+            msg.textContent = r.message || '';
+
+            row.appendChild(ts);
+            row.appendChild(sev);
+            row.appendChild(vc);
+            row.appendChild(msg);
+            container.appendChild(row);
+        }
+    }
+
+    function setFooter(summary) {
+        var el = document.getElementById('sentinel-meta');
+        if (!el) return;
+        el.textContent = 'window: ' + (summary.window_hours || 24) + 'h'
+            + ' · ' + (summary.total || 0) + ' findings'
+            + ' · refreshed ' + formatRelative(summary.generated_at);
+    }
+
+    async function refresh() {
+        var summary = await fetchSummary();
+        if (!summary) {
+            setMetric('sentinel-count-total', '—');
+            setMetric('sentinel-count-critical', '—');
+            setMetric('sentinel-count-high', '—');
+            setMetric('sentinel-count-medium', '—');
+            return;
+        }
+        renderCounts(summary);
+        renderClassBreakdown(summary);
+        renderStream(summary);
+        setFooter(summary);
+    }
+
+    function wire() {
+        var btn = document.getElementById('sentinel-refresh');
+        if (btn) btn.addEventListener('click', refresh);
+        refresh();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', wire);
+    } else {
+        wire();
+    }
+
+    window.SentinelPanel = { refresh: refresh };
+})();

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -5251,3 +5251,141 @@ main {
     text-align: center !important;
     padding: 18px !important;
 }
+
+/* Sentinel — findings stream panel. No chart (transient signals don't need
+ * a time series); stream list + class breakdown pills. */
+.sentinel-counts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-bottom: 14px;
+}
+
+.sentinel-stat {
+    flex: 1 1 100px;
+    min-width: 100px;
+    padding: 10px 12px;
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.sentinel-stat-label {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-secondary);
+}
+
+.sentinel-stat-value {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1.35rem;
+    color: var(--text-primary);
+}
+
+.sentinel-stat-sev-critical .sentinel-stat-value { color: #ef4444; }
+.sentinel-stat-sev-high     .sentinel-stat-value { color: #f59e0b; }
+.sentinel-stat-sev-medium   .sentinel-stat-value { color: #3b82f6; }
+
+.sentinel-class-breakdown {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 14px;
+    min-height: 26px;
+}
+
+.sentinel-class-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 10px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    font-size: 0.78rem;
+}
+
+.sentinel-class-name {
+    font-family: 'JetBrains Mono', monospace;
+    color: var(--text-primary);
+}
+
+.sentinel-class-count {
+    color: var(--text-secondary);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72rem;
+}
+
+.sentinel-class-empty {
+    color: var(--text-secondary);
+    font-style: italic;
+    font-size: 0.82rem;
+}
+
+.sentinel-stream {
+    max-height: 360px;
+    overflow-y: auto;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    border-radius: 6px;
+    margin-bottom: 10px;
+}
+
+.sentinel-stream-empty {
+    color: var(--text-secondary);
+    font-style: italic;
+    text-align: center;
+    padding: 24px;
+    font-size: 0.88rem;
+}
+
+.sentinel-row {
+    display: grid;
+    grid-template-columns: 80px 80px 180px 1fr;
+    gap: 10px;
+    align-items: baseline;
+    padding: 6px 10px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+    font-size: 0.84rem;
+}
+
+.sentinel-row:last-child {
+    border-bottom: none;
+}
+
+.sentinel-row-time {
+    color: var(--text-secondary);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.76rem;
+}
+
+.sentinel-row-sev {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 1px 6px;
+    border-radius: 3px;
+    text-align: center;
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--text-secondary);
+}
+
+.sentinel-row-sev-critical { background: rgba(239, 68, 68, 0.18); color: #fca5a5; }
+.sentinel-row-sev-high     { background: rgba(245, 158, 11, 0.18); color: #fcd34d; }
+.sentinel-row-sev-medium   { background: rgba(59, 130, 246, 0.18); color: #93c5fd; }
+
+.sentinel-row-class {
+    font-family: 'JetBrains Mono', monospace;
+    color: var(--text-primary);
+    font-size: 0.78rem;
+}
+
+.sentinel-row-msg {
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -855,7 +855,7 @@ async def http_dashboard_static(request):
         "utils.js", "state.js", "colors.js", "components.js",
         "visualizations.js", "agents.js", "discoveries.js",
         "dialectic.js", "eisv-charts.js", "timeline.js",
-        "residents.js", "fleet-metrics.js", "watcher.js",
+        "residents.js", "fleet-metrics.js", "watcher.js", "sentinel.js",
         "styles.css", "dashboard.js",
         "phase.js",
     ]
@@ -1330,6 +1330,136 @@ async def http_watcher_summary(request):
     summary = _watcher_summary_from_rows(rows)
     summary["success"] = True
     summary["findings_path"] = str(path)
+    return JSONResponse(summary)
+
+
+_SENTINEL_DEFAULT_WINDOW_HOURS = 24
+_SENTINEL_DEFAULT_RECENT_LIMIT = 50
+
+
+def _sentinel_summary_from_events(
+    events, now=None, window_hours=_SENTINEL_DEFAULT_WINDOW_HOURS,
+    recent_limit=_SENTINEL_DEFAULT_RECENT_LIMIT,
+):
+    """Aggregate sentinel_finding events into dashboard-ready shape.
+
+    Pure function so tests can feed parsed-dict events and assert on the
+    output without standing up Starlette or the event_detector singleton.
+
+    Unlike Watcher, sentinel findings have no open/closed lifecycle — they're
+    transient fleet-state signals. The aggregator surfaces severity + violation
+    class counts and a chronological stream, not an actionable queue.
+    """
+    from collections import Counter, defaultdict
+    from datetime import datetime, timedelta, timezone
+
+    if now is None:
+        now = datetime.now(timezone.utc)
+    window_start = now - timedelta(hours=window_hours)
+
+    def _parse_ts(value):
+        if not value:
+            return None
+        try:
+            if isinstance(value, str) and value.endswith("Z"):
+                value = value[:-1] + "+00:00"
+            return datetime.fromisoformat(value)
+        except Exception:
+            return None
+
+    windowed = []
+    for e in events:
+        ts = _parse_ts(e.get("timestamp"))
+        if ts is None:
+            # Malformed timestamp — count toward totals but skip window check
+            windowed.append((None, e))
+            continue
+        if ts >= window_start:
+            windowed.append((ts, e))
+
+    by_severity = Counter()
+    by_class_counts = Counter()
+    by_class_severity = defaultdict(Counter)
+
+    for _ts, e in windowed:
+        severity = str(e.get("severity") or "?")
+        vclass = str(e.get("violation_class") or "?")
+        by_severity[severity] += 1
+        by_class_counts[vclass] += 1
+        by_class_severity[vclass][severity] += 1
+
+    by_violation_class = [
+        {
+            "violation_class": vc,
+            "count": by_class_counts[vc],
+            "by_severity": dict(by_class_severity[vc]),
+        }
+        for vc in sorted(by_class_counts, key=lambda v: (-by_class_counts[v], v))
+    ]
+
+    # Recent stream — newest first. Events with bad timestamps sort last but
+    # are still included so operators can see they exist.
+    def _sort_key(pair):
+        ts, _ = pair
+        return ts or datetime.min.replace(tzinfo=timezone.utc)
+
+    recent_sorted = sorted(windowed, key=_sort_key, reverse=True)
+    recent = [
+        {
+            "timestamp": e.get("timestamp"),
+            "severity": e.get("severity"),
+            "violation_class": e.get("violation_class"),
+            "finding_type": e.get("finding_type"),
+            "message": e.get("message"),
+            "agent_id": e.get("agent_id"),
+            "event_id": e.get("event_id"),
+        }
+        for _ts, e in recent_sorted[:recent_limit]
+    ]
+
+    return {
+        "total": len(windowed),
+        "by_severity": dict(by_severity),
+        "by_violation_class": by_violation_class,
+        "recent": recent,
+        "window_hours": window_hours,
+        "generated_at": now.isoformat(),
+    }
+
+
+async def http_sentinel_summary(request):
+    """GET /v1/sentinel/summary — aggregate recent sentinel_finding events
+    for the dashboard panel.
+
+    Reads from event_detector's in-memory ring buffer (same source that
+    powers the live event stream). Transient across governance-mcp
+    restarts by design — sentinel findings are fleet-state signals, not a
+    historical backlog."""
+    http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
+    if not _check_http_auth(request, http_api_token=http_api_token):
+        return _http_unauthorized()
+
+    try:
+        window_hours = int(request.query_params.get("window_hours", _SENTINEL_DEFAULT_WINDOW_HOURS))
+    except ValueError:
+        window_hours = _SENTINEL_DEFAULT_WINDOW_HOURS
+    window_hours = max(1, min(window_hours, 24 * 30))
+
+    try:
+        recent_limit = int(request.query_params.get("limit", _SENTINEL_DEFAULT_RECENT_LIMIT))
+    except ValueError:
+        recent_limit = _SENTINEL_DEFAULT_RECENT_LIMIT
+    recent_limit = max(1, min(recent_limit, 500))
+
+    from src.event_detector import event_detector
+    events = event_detector.get_recent_events(
+        event_type="sentinel_finding", limit=500,
+    )
+
+    summary = _sentinel_summary_from_events(
+        events, window_hours=window_hours, recent_limit=recent_limit,
+    )
+    summary["success"] = True
     return JSONResponse(summary)
 
 
@@ -2026,6 +2156,7 @@ def register_http_routes(
     app.routes.append(Route("/v1/metrics/series", http_get_metrics, methods=["GET"]))
     app.routes.append(Route("/v1/metrics/catalog", http_get_metrics_catalog, methods=["GET"]))
     app.routes.append(Route("/v1/watcher/summary", http_watcher_summary, methods=["GET"]))
+    app.routes.append(Route("/v1/sentinel/summary", http_sentinel_summary, methods=["GET"]))
     app.routes.append(Route("/api/activity", http_activity, methods=["GET"]))
     app.routes.append(Route("/api/incidents", http_incidents, methods=["GET"]))
     app.routes.append(Route("/v1/residents", http_residents, methods=["GET"]))

--- a/tests/test_dashboard_static_allowlist.py
+++ b/tests/test_dashboard_static_allowlist.py
@@ -48,6 +48,9 @@ class TestDashboardStaticAllowlist:
     def test_fleet_metrics_is_allowed(self):
         assert "fleet-metrics.js" in _load_allowlist()
 
+    def test_sentinel_is_allowed(self):
+        assert "sentinel.js" in _load_allowlist()
+
     def test_every_index_html_reference_is_allowed(self):
         referenced = _scripts_referenced_by_index_html()
         allowed = set(_load_allowlist())

--- a/tests/test_http_api_sentinel_summary.py
+++ b/tests/test_http_api_sentinel_summary.py
@@ -1,0 +1,172 @@
+"""Tests for _sentinel_summary_from_events — the pure aggregator behind
+/v1/sentinel/summary. Mirrors the test pattern in test_http_api_watcher_summary:
+feed dict rows, assert on the shape returned, no HTTP/DB plumbing.
+
+Sentinel findings are transient fleet-state signals (a coordinated_degradation
+detected at 14:02 may already be gone at 14:07). There's no open/closed
+lifecycle — operators want a chronological stream + counts by violation class
+to spot which concerns are dominating right now."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.http_api import _sentinel_summary_from_events
+
+
+NOW = datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc)
+
+
+def _event(**kwargs):
+    base = {
+        "type": "sentinel_finding",
+        "severity": "high",
+        "message": "coordinated EISV degradation across 3 agents",
+        "agent_id": "sentinel-uuid",
+        "agent_name": "Sentinel",
+        "violation_class": "coordinated_degradation",
+        "finding_type": "cross_agent",
+        "timestamp": NOW.isoformat(),
+        "event_id": 1,
+    }
+    base.update(kwargs)
+    return base
+
+
+class TestCounts:
+    def test_empty_input_returns_zeroed_shape(self):
+        out = _sentinel_summary_from_events([], now=NOW, window_hours=24)
+        assert out["total"] == 0
+        assert out["by_severity"] == {}
+        assert out["by_violation_class"] == []
+        assert out["recent"] == []
+        assert out["window_hours"] == 24
+
+    def test_total_counts_all_findings(self):
+        events = [_event(event_id=i) for i in range(5)]
+        out = _sentinel_summary_from_events(events, now=NOW)
+        assert out["total"] == 5
+
+    def test_by_severity_counts_all_not_just_open(self):
+        """Unlike Watcher, Sentinel findings don't have open/closed state —
+        every severity count is surfaced so 'what's Sentinel seeing right
+        now' is the honest answer."""
+        events = [
+            _event(event_id=1, severity="critical"),
+            _event(event_id=2, severity="critical"),
+            _event(event_id=3, severity="high"),
+            _event(event_id=4, severity="medium"),
+        ]
+        out = _sentinel_summary_from_events(events, now=NOW)
+        assert out["by_severity"] == {"critical": 2, "high": 1, "medium": 1}
+
+
+class TestViolationClassBreakdown:
+    def test_groups_by_violation_class_with_severity_subcounts(self):
+        """The breakdown lets operators see which violation types dominate
+        and whether each class is mostly high-severity or noise."""
+        events = [
+            _event(event_id=1, violation_class="coordinated_degradation", severity="high"),
+            _event(event_id=2, violation_class="coordinated_degradation", severity="high"),
+            _event(event_id=3, violation_class="coordinated_degradation", severity="medium"),
+            _event(event_id=4, violation_class="identity_drift", severity="critical"),
+        ]
+        out = _sentinel_summary_from_events(events, now=NOW)
+        by_class = {c["violation_class"]: c for c in out["by_violation_class"]}
+        assert by_class["coordinated_degradation"]["count"] == 3
+        assert by_class["coordinated_degradation"]["by_severity"] == {"high": 2, "medium": 1}
+        assert by_class["identity_drift"]["count"] == 1
+        assert by_class["identity_drift"]["by_severity"] == {"critical": 1}
+
+    def test_breakdown_sorted_by_count_desc(self):
+        events = (
+            [_event(event_id=i, violation_class="high_vol") for i in range(4)]
+            + [_event(event_id=10, violation_class="low_vol")]
+        )
+        out = _sentinel_summary_from_events(events, now=NOW)
+        classes = [c["violation_class"] for c in out["by_violation_class"]]
+        assert classes == ["high_vol", "low_vol"]
+
+    def test_missing_violation_class_falls_under_question_mark(self):
+        """Legacy Sentinel emissions without violation_class shouldn't crash
+        the aggregator or silently disappear — they bucket under '?' so the
+        operator sees they exist."""
+        out = _sentinel_summary_from_events(
+            [_event(violation_class=None)], now=NOW
+        )
+        assert out["by_violation_class"][0]["violation_class"] == "?"
+        assert out["by_violation_class"][0]["count"] == 1
+
+
+class TestRecentStream:
+    def test_recent_is_newest_first(self):
+        events = [
+            _event(event_id=1, message="oldest",
+                   timestamp=(NOW - timedelta(minutes=30)).isoformat()),
+            _event(event_id=2, message="middle",
+                   timestamp=(NOW - timedelta(minutes=15)).isoformat()),
+            _event(event_id=3, message="newest",
+                   timestamp=NOW.isoformat()),
+        ]
+        out = _sentinel_summary_from_events(events, now=NOW)
+        messages = [r["message"] for r in out["recent"]]
+        assert messages == ["newest", "middle", "oldest"]
+
+    def test_recent_respects_limit(self):
+        events = [
+            _event(event_id=i, timestamp=(NOW - timedelta(minutes=i)).isoformat())
+            for i in range(100)
+        ]
+        out = _sentinel_summary_from_events(events, now=NOW, recent_limit=10)
+        assert len(out["recent"]) == 10
+
+    def test_recent_includes_fields_the_panel_renders(self):
+        """The panel renders timestamp, severity, violation_class, and message.
+        Locking the projection here means future changes to the internal event
+        shape can't silently break the UI."""
+        events = [_event(event_id=1)]
+        out = _sentinel_summary_from_events(events, now=NOW)
+        row = out["recent"][0]
+        for key in ("timestamp", "severity", "violation_class", "message"):
+            assert key in row, f"panel needs {key}"
+
+
+class TestWindow:
+    def test_events_outside_window_excluded_from_totals(self):
+        """A 3-day-old finding shouldn't contribute to a 24h 'right now' panel —
+        that's the whole point of the window. If you want historical view,
+        build a different panel."""
+        events = [
+            _event(event_id=1, timestamp=(NOW - timedelta(hours=2)).isoformat()),
+            _event(event_id=2, timestamp=(NOW - timedelta(hours=2)).isoformat()),
+            _event(event_id=3, timestamp=(NOW - timedelta(days=3)).isoformat()),
+        ]
+        out = _sentinel_summary_from_events(events, now=NOW, window_hours=24)
+        assert out["total"] == 2
+
+    def test_default_window_is_24h(self):
+        out = _sentinel_summary_from_events([], now=NOW)
+        assert out["window_hours"] == 24
+
+
+class TestRobustness:
+    def test_trailing_Z_timestamp_parses(self):
+        events = [_event(timestamp="2026-04-24T11:30:00Z")]
+        out = _sentinel_summary_from_events(events, now=NOW, window_hours=24)
+        assert out["total"] == 1
+
+    def test_malformed_timestamp_does_not_crash(self):
+        """A bad timestamp counts toward totals but is omitted from the window
+        check — dropping it entirely would hide findings from operators;
+        crashing would hide the whole panel."""
+        events = [_event(timestamp="not-a-date")]
+        out = _sentinel_summary_from_events(events, now=NOW)
+        # counted in totals, message still in recent
+        assert out["total"] == 1
+        assert len(out["recent"]) == 1
+
+    def test_missing_severity_falls_under_question_mark(self):
+        out = _sentinel_summary_from_events([_event(severity=None)], now=NOW)
+        assert out["by_severity"] == {"?": 1}


### PR DESCRIPTION
Adds a dedicated dashboard panel for Sentinel findings, closing the gap against Chronicler and Watcher which already have plug-and-play panel modules.

## What

- **`/v1/sentinel/summary`** — new endpoint; reads `event_detector` ring buffer filtered by `type='sentinel_finding'`, aggregates via pure `_sentinel_summary_from_events`
- **`dashboard/sentinel.js`** — 170-line panel module: counts strip (total + by-severity), violation-class pill breakdown, reverse-chronological stream
- **`#sentinel-section`** — new panel + nav link in index.html
- **sentinel.js** added to `http_dashboard_static` allowlist + explicit regression test

## Why this shape (not Watcher-parity)

Watcher uses an open/resolved lifecycle because code-issue findings persist until a human acts (`--resolve`/`--dismiss`). Sentinel findings are transient fleet-state snapshots — a `coordinated_degradation` at 14:02 may already be false at 14:07. Forcing them through an open-queue misrepresents what they are, and Sentinel has no resolve CLI anyway.

So: chronological stream + violation-class breakdown, 24h default window. No Chart.js (transient signals don't need a time series).

## Scope note

Endpoint reads the in-memory ring buffer, so the panel is transient across `governance-mcp` restarts. Adding audit_db persistence for `/api/findings` would make the panel survive restarts but is out of scope for this PR.

## Test plan

- [x] 14 unit tests on `_sentinel_summary_from_events` (counts, class breakdown, stream ordering/limit, window, robustness)
- [x] Explicit `test_sentinel_is_allowed` in allowlist regression test
- [x] Full suite: 6814 passed, 33 skipped
- [ ] Post-merge: reload LaunchAgent, curl `/v1/sentinel/summary` for 200 + JSON shape
- [ ] Post-merge: hard-refresh dashboard, verify panel loads and renders