### PR TITLE
Fix ctx param leaking into MCP tools/list schema

### DIFF
--- a/src/mcp_handlers/support/wrapper_generator.py
+++ b/src/mcp_handlers/support/wrapper_generator.py
@@ -237,11 +237,11 @@ def _create_simple_wrapper(
         filtered = {k: v for k, v in kwargs.items() if v is not None}
         handler = get_handler(tool_name)
         return await handler(**filtered)
-    
+
     typed_wrapper.__signature__ = sig
     typed_wrapper.__name__ = tool_name
     typed_wrapper.__qualname__ = tool_name
-    
+
     return typed_wrapper
 
 def _create_session_wrapper(
@@ -313,9 +313,21 @@ def _create_session_wrapper(
         filtered = {k: v for k, v in kwargs.items() if v is not None}
         handler = get_handler(tool_name)
         return await handler(**filtered)
-    
+
     typed_wrapper.__signature__ = sig
     typed_wrapper.__name__ = tool_name
     typed_wrapper.__qualname__ = tool_name
-    
+    # Sync __annotations__ with the synthesized signature. FastMCP's
+    # find_context_parameter reads typing.get_type_hints (which walks
+    # __annotations__, not __signature__) to decide whether to skip ctx
+    # from the emitted tools/list inputSchema. Without this sync, ctx
+    # leaks into the schema as a first-class argument even though the
+    # signature annotation correctly types it as Optional[Context].
+    typed_wrapper.__annotations__ = {
+        p.name: p.annotation
+        for p in sig.parameters.values()
+        if p.annotation is not inspect.Parameter.empty
+    }
+    typed_wrapper.__annotations__["return"] = dict
+
     return typed_wrapper

--- a/tests/test_wrapper_generator.py
+++ b/tests/test_wrapper_generator.py
@@ -269,3 +269,98 @@ class TestCreateTypedWrapper:
         wrapper = create_typed_wrapper("multi_type", schema, get_handler)
         sig = inspect.signature(wrapper)
         assert len(sig.parameters) == 6
+
+
+# ============================================================================
+# FastMCP Context parameter detection
+# ============================================================================
+# Regression: wrapper_generator previously set only __signature__, leaving
+# __annotations__ empty. FastMCP's find_context_parameter reads get_type_hints
+# (→ __annotations__) to decide whether to skip `ctx` from the emitted tools/list
+# inputSchema, so ctx leaked as a user-facing argument. See KG discovery
+# 2026-04-24T00:16:12.229114.
+
+class TestSessionWrapperContextDetection:
+
+    def test_session_wrapper_annotations_match_signature(self):
+        """Synthesized signature's annotations must be mirrored in __annotations__."""
+        def get_handler(name):
+            async def handler(**kwargs):
+                return {}
+            return handler
+
+        def session_extractor(ctx):
+            return "session-id"
+
+        schema = {"properties": {"query": {"type": "string"}}, "required": []}
+        wrapper = create_typed_wrapper(
+            "session_tool", schema, get_handler,
+            inject_session=True, session_extractor=session_extractor,
+        )
+        sig = inspect.signature(wrapper)
+        assert "ctx" in sig.parameters
+        # __annotations__ must carry ctx so get_type_hints can find it.
+        assert "ctx" in wrapper.__annotations__
+        assert wrapper.__annotations__["ctx"] == sig.parameters["ctx"].annotation
+
+    def test_fastmcp_finds_ctx_in_session_wrapper(self):
+        """FastMCP's find_context_parameter must locate ctx on a session wrapper."""
+        pytest.importorskip("mcp.server.fastmcp")
+        from mcp.server.fastmcp.utilities.context_injection import find_context_parameter
+
+        def get_handler(name):
+            async def handler(**kwargs):
+                return {}
+            return handler
+
+        def session_extractor(ctx):
+            return "sid"
+
+        schema = {"properties": {"query": {"type": "string"}}, "required": []}
+        wrapper = create_typed_wrapper(
+            "session_tool", schema, get_handler,
+            inject_session=True, session_extractor=session_extractor,
+        )
+        assert find_context_parameter(wrapper) == "ctx"
+
+    def test_tools_list_schema_omits_ctx(self):
+        """With ctx detected, func_metadata must exclude it from the emitted schema."""
+        pytest.importorskip("mcp.server.fastmcp")
+        from mcp.server.fastmcp.utilities.context_injection import find_context_parameter
+        from mcp.server.fastmcp.utilities.func_metadata import func_metadata
+
+        def get_handler(name):
+            async def handler(**kwargs):
+                return {}
+            return handler
+
+        def session_extractor(ctx):
+            return "sid"
+
+        schema = {
+            "properties": {"query": {"type": "string"}, "limit": {"type": "integer"}},
+            "required": ["query"],
+        }
+        wrapper = create_typed_wrapper(
+            "session_tool", schema, get_handler,
+            inject_session=True, session_extractor=session_extractor,
+        )
+        ctx_kwarg = find_context_parameter(wrapper)
+        assert ctx_kwarg == "ctx"
+        meta = func_metadata(wrapper, skip_names=[ctx_kwarg])
+        fields = set(meta.arg_model.model_fields.keys())
+        assert "ctx" not in fields
+        assert "query" in fields
+        assert "limit" in fields
+
+    def test_simple_wrapper_has_no_ctx(self):
+        """Sanity: wrapper without session injection carries no ctx at all."""
+        def get_handler(name):
+            async def handler(**kwargs):
+                return {}
+            return handler
+
+        schema = {"properties": {"q": {"type": "string"}}, "required": []}
+        wrapper = create_typed_wrapper("plain", schema, get_handler, inject_session=False)
+        assert "ctx" not in inspect.signature(wrapper).parameters
+        assert "ctx" not in wrapper.__annotations__


### PR DESCRIPTION
## Summary

`wrapper_generator._create_session_wrapper` was synthesizing `__signature__` with `ctx: Optional[Context]` but leaving the function's real `__annotations__` empty. FastMCP's `find_context_parameter` reads `typing.get_type_hints` (which walks `__annotations__`, not `__signature__`), so it missed ctx → returned None → `func_metadata` got empty `skip_names` → ctx leaked into the emitted `tools/list` schema as a first-class user arg typed `Context | null` with empty properties.

A schema-following client (e.g. Codex dogfood 2026-04-24) would reasonably pass `ctx={}` or `ctx="..."` and hit a Pydantic "Input should be a valid dictionary or instance of Context" error. `describe_tool(lite=false)` had a clean schema because it reads the declared Pydantic params model, not the wrapper's signature — two schema sources, one leaking.

## Fix

Mirror the synthesized signature's annotations into `__annotations__` after `__signature__` is assigned, so FastMCP's Context detection sees ctx and excludes it from the emitted schema.

## Test plan

- [x] 4 new tests in `TestSessionWrapperContextDetection` exercise: annotation sync, `find_context_parameter` detection, `func_metadata` schema omission of ctx, and sanity for the no-session wrapper.
- [x] Verified the 3 behavioral tests fail without the fix and pass with it (by reverting only the code change).
- [x] Full pre-commit suite: 6803 passed, 33 skipped (test-cache.sh).

## KG

Resolves discovery `2026-04-24T00:16:12.229114`.