### PR TITLE
identity: concurrent identity binding invariant — audit-only v1 (#123)

### DIFF
--- a/agents/sdk/src/unitares_sdk/utils.py
+++ b/agents/sdk/src/unitares_sdk/utils.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import os
+import socket
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from typing import Any, Dict, Optional
 
 
 def atomic_write(path: Path, data: str, mode: int = 0o600) -> None:
@@ -126,3 +129,113 @@ def validate_token_uuid(token: str, expected_uuid: str) -> bool:
     if not aid:
         return False
     return aid == expected_uuid
+
+
+def capture_process_fingerprint(
+    transport: str = "unknown",
+    anchor_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build the client-reported process_fingerprint for onboard().
+
+    Concurrent identity binding invariant (issue #123). The server uses this
+    tuple to detect same-UUID siphoning across live execution contexts. The
+    fingerprint is declaration-only: it is recorded for audit, never used to
+    resolve or recover identity.
+
+    Fields:
+      - host_id: stable per-machine identifier (hostname + machine-id hash)
+      - pid, pid_start_time: identify the current process even across PID reuse
+      - ppid: optional evidence for lineage verification
+      - tty: nullable — daemons have no controlling TTY
+      - transport: caller-declared MCP channel (stdio/http/websocket/...)
+      - anchor_path_hash: SHA-256 of the resident's anchor file path if any
+
+    All fields are best-effort: any capture failure yields a skipped field
+    rather than an exception. The caller passes the resulting dict straight
+    into onboard(process_fingerprint=...).
+    """
+    fp: Dict[str, Any] = {}
+
+    try:
+        hostname = socket.gethostname()
+    except Exception:
+        hostname = "unknown"
+
+    machine_id = ""
+    for candidate in ("/etc/machine-id", "/var/lib/dbus/machine-id"):
+        try:
+            with open(candidate, "r") as f:
+                machine_id = f.read().strip()
+            if machine_id:
+                break
+        except Exception:
+            continue
+    if not machine_id and sys.platform == "darwin":
+        try:
+            out = subprocess.check_output(
+                ["ioreg", "-rd1", "-c", "IOPlatformExpertDevice"],
+                stderr=subprocess.DEVNULL,
+                timeout=2,
+            ).decode()
+            for line in out.splitlines():
+                if "IOPlatformUUID" in line:
+                    machine_id = line.split('"')[-2]
+                    break
+        except Exception:
+            pass
+
+    fp["host_id"] = hashlib.sha256(
+        f"{hostname}:{machine_id}".encode()
+    ).hexdigest()[:16]
+
+    try:
+        fp["pid"] = os.getpid()
+    except Exception:
+        pass
+
+    try:
+        fp["ppid"] = os.getppid()
+    except Exception:
+        pass
+
+    try:
+        import psutil  # type: ignore
+        fp["pid_start_time"] = psutil.Process().create_time()
+    except Exception:
+        # Linux fallback: parse /proc/self/stat field 22 (starttime in clock ticks
+        # since boot). Combine with /proc/stat's btime to get epoch seconds.
+        try:
+            with open(f"/proc/{os.getpid()}/stat", "r") as f:
+                stat_fields = f.read().split()
+            starttime_ticks = int(stat_fields[21])
+            with open("/proc/stat", "r") as f:
+                for line in f:
+                    if line.startswith("btime "):
+                        btime = int(line.split()[1])
+                        break
+                else:
+                    btime = 0
+            hz = os.sysconf(os.sysconf_names["SC_CLK_TCK"])
+            if hz > 0 and btime > 0:
+                fp["pid_start_time"] = float(btime + starttime_ticks / hz)
+        except Exception:
+            pass
+
+    try:
+        if os.isatty(0):
+            fp["tty"] = os.ttyname(0)
+    except Exception:
+        pass
+
+    if transport:
+        fp["transport"] = transport
+
+    if anchor_path:
+        try:
+            fp["anchor_path_hash"] = hashlib.sha256(
+                anchor_path.encode()
+            ).hexdigest()[:16]
+        except Exception:
+            pass
+
+    return fp

--- a/commands/diagnose.md
+++ b/commands/diagnose.md
@@ -39,6 +39,8 @@ If `health_check()` is used, also show:
 - degraded checks
 - first operator action
 
+Call `list_process_bindings()` (optionally with `agent_uuid=<uuid>`) to show live execution-context bindings for the agent. When `concurrent_binding_detected` is true, surface the `bindings[]` tuples — each row is `{host_id, pid, pid_start_time, transport, tty, last_seen}` — so the operator can see which contexts are siphoning the same UUID. See issue #123.
+
 If the live identity differs from `.unitares/session.json`, refresh the local cache with the latest `uuid`, identity fields, and continuity data using `scripts/client/session_cache.py set session --merge --stamp`.
 
 Do not dump raw JSON unless the user explicitly asks for it.

--- a/db/postgres/README.md
+++ b/db/postgres/README.md
@@ -169,6 +169,7 @@ SELECT version, name, applied_at FROM core.schema_migrations ORDER BY version;
 | 1 | `initial_schema` | Core tables (agents, sessions, dialectic) |
 | 2 | `knowledge_schema` | Knowledge graph tables for PostgreSQL FTS |
 | 3 | `dialectic_messages` | Dialectic messages table (migrated from SQLite) |
+| 15 | `agent_process_bindings` | Concurrent identity binding invariant (#123): `core.agent_process_bindings` + `allow_rebind_after_exit` / `allow_concurrent_contexts` flags on `core.agents` |
 
 The health check returns `schema_version` from this table.
 

--- a/db/postgres/migrations/015_agent_process_bindings.sql
+++ b/db/postgres/migrations/015_agent_process_bindings.sql
@@ -1,0 +1,76 @@
+-- 015_agent_process_bindings.sql
+--
+-- Concurrent identity binding invariant (issue #123).
+--
+-- Records the execution context a client declares at onboard() so the server
+-- can detect "one UUID, two concurrently live execution contexts" — the
+-- same-UUID siphoning pattern that ip_ua_fingerprint alone does not catch
+-- for same-machine clients (IP+UA is identical across two Claude Code
+-- instances on the same host).
+--
+-- V1 is audit-only: rows are recorded on every onboard(), a sweeper marks
+-- them stale, and a detection pass emits `identity_concurrent_binding`
+-- events when ≥2 live bindings for the same agent have distinct execution
+-- contexts and the agent's policy flag `allow_concurrent_contexts` is false
+-- (the default). No automatic force-new in v1 — see issue #123 §"Scope".
+--
+-- Execution-context key is (host_id, pid, pid_start_time, transport).
+-- pid_start_time disambiguates PID reuse; host_id disambiguates
+-- multi-machine deployments; transport distinguishes stdio / http / ws for
+-- the same pid. tty, ppid, and anchor_path_hash are evidence fields, not
+-- identity keys.
+
+CREATE TABLE IF NOT EXISTS core.agent_process_bindings (
+    id BIGSERIAL PRIMARY KEY,
+    agent_id TEXT NOT NULL REFERENCES core.agents(id) ON DELETE CASCADE,
+
+    -- Execution context key (four-tuple)
+    host_id TEXT NOT NULL,
+    pid INTEGER NOT NULL,
+    pid_start_time DOUBLE PRECISION NOT NULL,  -- seconds since epoch, ms precision is enough
+    transport TEXT NOT NULL DEFAULT 'unknown',
+
+    -- Evidence fields (not part of the identity key)
+    ppid INTEGER NULL,
+    tty TEXT NULL,                    -- nullable: daemons have no TTY
+    anchor_path_hash TEXT NULL,       -- SHA-256 of anchor file path if resident
+    client_session_id TEXT NULL,
+
+    -- Lifecycle
+    onboard_ts TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    stale_at TIMESTAMPTZ NULL,        -- set by sweeper when binding is no longer live
+
+    CONSTRAINT uq_agent_process_binding
+        UNIQUE (agent_id, host_id, pid, pid_start_time, transport)
+);
+
+-- Hot path: lookup live bindings for an agent (detection rule).
+CREATE INDEX IF NOT EXISTS idx_apb_agent_live
+    ON core.agent_process_bindings (agent_id, stale_at)
+    WHERE stale_at IS NULL;
+
+-- Sweeper path: find stale candidates by last_seen.
+CREATE INDEX IF NOT EXISTS idx_apb_last_seen
+    ON core.agent_process_bindings (last_seen)
+    WHERE stale_at IS NULL;
+
+-- Diagnose view path: all bindings for an agent ordered by recency.
+CREATE INDEX IF NOT EXISTS idx_apb_agent_recency
+    ON core.agent_process_bindings (agent_id, last_seen DESC);
+
+-- Policy flags on core.agents. Defaults preserve current behavior:
+--   allow_rebind_after_exit = false  — ephemeral agents don't rebind.
+--   allow_concurrent_contexts = false — nothing allows concurrent contexts today.
+-- Resident agents get allow_rebind_after_exit=true via seeding (separate step,
+-- not this migration — residents are configured out-of-band).
+ALTER TABLE core.agents
+    ADD COLUMN IF NOT EXISTS allow_rebind_after_exit BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE core.agents
+    ADD COLUMN IF NOT EXISTS allow_concurrent_contexts BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Register the migration.
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (15, 'agent_process_bindings', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/src/background_tasks.py
+++ b/src/background_tasks.py
@@ -1081,6 +1081,15 @@ def start_all_background_tasks(connection_tracker, set_ready):
     _supervised_create_task(concept_extraction_background_task(), name="concept_extraction")
     _supervised_create_task(periodic_matview_refresh(), name="matview_refresh")
     _supervised_create_task(periodic_partition_maintenance(), name="partition_maintenance")
+    # Concurrent identity binding sweeper (#123): marks bindings stale once
+    # they fall outside the live window so the diagnose view and v2
+    # enforcement can distinguish stale from live.
+    from src.mcp_handlers.identity.process_binding import (
+        process_binding_sweeper_task,
+    )
+    _supervised_create_task(
+        process_binding_sweeper_task(), name="process_binding_sweeper"
+    )
     _supervised_create_task(background_metadata_load(), name="metadata_load")
     # periodic_orphan_cleanup removed 2026-04-19 — auto-sweep was hiding
     # onboarding bugs behind archival. Use the archive_orphan_agents MCP tool

--- a/src/mcp_handlers/identity/__init__.py
+++ b/src/mcp_handlers/identity/__init__.py
@@ -14,6 +14,8 @@ from .core import (
     resolve_session_identity,
     set_agent_label,
 )
+# Concurrent identity binding invariant (#123) — registers list_process_bindings.
+from .process_binding_handler import handle_list_process_bindings
 
 __all__ = [
     "handle_identity_adapter",
@@ -27,4 +29,5 @@ __all__ = [
     "_agent_exists_in_postgres",
     "resolve_session_identity",
     "set_agent_label",
+    "handle_list_process_bindings",
 ]

--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -1494,6 +1494,27 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
         except Exception as e:
             logger.debug(f"[ONBOARD] default-stamp failed (non-fatal): {e}")
 
+    # CONCURRENT IDENTITY BINDING (#123): if the client declared a process
+    # fingerprint, record the binding and run audit-only collision detection.
+    # Fire-and-forget — declaration-only, never resolves or recovers identity.
+    _raw_fp = arguments.get("process_fingerprint")
+    if _raw_fp is not None:
+        try:
+            from .process_binding import validate_fingerprint, record_binding_bg
+            _fp = validate_fingerprint(_raw_fp)
+            if _fp is not None:
+                from src.background_tasks import create_tracked_task
+                create_tracked_task(
+                    record_binding_bg(
+                        agent_uuid,
+                        _fp,
+                        arguments.get("client_session_id"),
+                    ),
+                    name="record_process_binding",
+                )
+        except Exception as e:
+            logger.debug(f"[PROCESS_BINDING] onboard scheduling failed (non-fatal): {e}")
+
     # TRAJECTORY IDENTITY: Store genesis signature if provided (optional, non-blocking)
     # Agents from anima-mcp can include trajectory_signature in their onboard call
     trajectory_result = None

--- a/src/mcp_handlers/identity/process_binding.py
+++ b/src/mcp_handlers/identity/process_binding.py
@@ -223,3 +223,103 @@ def _emit_concurrent_binding_event(agent_id: str, live_rows: List[Any]) -> None:
             asyncio.ensure_future(_broadcast())
         except Exception:
             pass
+
+
+# -----------------------------------------------------------------------------
+# Sweeper — marks bindings stale once their last_seen falls outside the live
+# window. Audit-only v1 does not act on stale_at, but populating it lets the
+# diagnose view and future enforcement (v2) distinguish "no longer live" from
+# "never existed."
+# -----------------------------------------------------------------------------
+
+
+async def sweep_stale_bindings() -> int:
+    """Mark bindings stale when last_seen exceeds LIVE_WINDOW_SECONDS.
+
+    Returns the number of rows marked stale. Safe to call concurrently; the
+    UPDATE is idempotent and narrows on `stale_at IS NULL`.
+    """
+    try:
+        from src.db import get_db
+        db = get_db()
+        async with db.acquire() as conn:
+            updated = await conn.execute(
+                f"""
+                UPDATE core.agent_process_bindings
+                SET stale_at = NOW()
+                WHERE stale_at IS NULL
+                  AND last_seen <= NOW() - INTERVAL '{LIVE_WINDOW_SECONDS} seconds'
+                """
+            )
+        # asyncpg execute() returns a status string like "UPDATE 17"; parse the
+        # count if present, otherwise fall back to 0.
+        try:
+            return int((updated or "UPDATE 0").split()[-1])
+        except Exception:
+            return 0
+    except Exception as e:
+        logger.debug(f"[PROCESS_BINDING] sweep_stale_bindings failed: {e}")
+        return 0
+
+
+async def get_live_bindings(agent_id: str) -> List[Dict[str, Any]]:
+    """Return all live bindings for an agent, most-recent first.
+
+    "Live" = `stale_at IS NULL AND last_seen within LIVE_WINDOW_SECONDS`.
+    Returns an empty list on DB failure — callers surface that as "no
+    bindings reported" rather than raising.
+    """
+    try:
+        from src.db import get_db
+        db = get_db()
+        async with db.acquire() as conn:
+            rows = await conn.fetch(
+                f"""
+                SELECT host_id, pid, pid_start_time, transport,
+                       tty, ppid, anchor_path_hash, client_session_id,
+                       onboard_ts, last_seen
+                FROM core.agent_process_bindings
+                WHERE agent_id = $1
+                  AND stale_at IS NULL
+                  AND last_seen > NOW() - INTERVAL '{LIVE_WINDOW_SECONDS} seconds'
+                ORDER BY last_seen DESC
+                """,
+                agent_id,
+            )
+        return [
+            {
+                "host_id": r["host_id"],
+                "pid": r["pid"],
+                "pid_start_time": r["pid_start_time"],
+                "transport": r["transport"],
+                "tty": r["tty"],
+                "ppid": r["ppid"],
+                "anchor_path_hash": r["anchor_path_hash"],
+                "client_session_id": r["client_session_id"],
+                "onboard_ts": r["onboard_ts"].isoformat() if r["onboard_ts"] else None,
+                "last_seen": r["last_seen"].isoformat() if r["last_seen"] else None,
+            }
+            for r in rows
+        ]
+    except Exception as e:
+        logger.debug(f"[PROCESS_BINDING] get_live_bindings failed: {e}")
+        return []
+
+
+async def process_binding_sweeper_task() -> None:
+    """Periodic sweeper — runs every LIVE_WINDOW_SECONDS.
+
+    Registered from src/background_tasks.py alongside the other periodic
+    tasks. Cadence matches the live-window: a binding that did not refresh
+    in the last window is marked stale on the next tick.
+    """
+    import asyncio
+    await asyncio.sleep(30.0)  # startup delay, match matview/partition pattern
+    while True:
+        try:
+            n = await sweep_stale_bindings()
+            if n:
+                logger.info(f"[PROCESS_BINDING] swept {n} stale binding(s)")
+        except Exception as e:
+            logger.debug(f"[PROCESS_BINDING] sweeper tick failed: {e}")
+        await asyncio.sleep(LIVE_WINDOW_SECONDS)

--- a/src/mcp_handlers/identity/process_binding.py
+++ b/src/mcp_handlers/identity/process_binding.py
@@ -1,0 +1,225 @@
+"""Concurrent identity binding invariant (issue #123).
+
+Records the execution context a client declares at onboard() and detects
+same-UUID siphoning across live execution contexts. V1 is audit-only:
+collision emits `identity_concurrent_binding` via the broadcaster — no
+automatic force-new.
+
+See docs/ontology/identity.md and issue #123 for the design.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# "Live" window used when rows have not been explicitly marked stale.
+# Bindings whose last_seen is older than this are not counted for collision
+# detection, so a resident that restarts 10 minutes later does not trip the
+# alarm even before the sweeper runs. Kept in sync with the steward cadence.
+LIVE_WINDOW_SECONDS = 300  # 5 minutes
+
+ALLOWED_TRANSPORTS = frozenset({"stdio", "http", "websocket", "sse", "rest", "unknown"})
+
+
+@dataclass(frozen=True)
+class ProcessFingerprint:
+    """Validated client-reported execution context."""
+
+    host_id: str
+    pid: int
+    pid_start_time: float
+    transport: str = "unknown"
+    ppid: Optional[int] = None
+    tty: Optional[str] = None
+    anchor_path_hash: Optional[str] = None
+
+
+def validate_fingerprint(raw: Any) -> Optional[ProcessFingerprint]:
+    """Coerce a client-reported fingerprint dict into ProcessFingerprint.
+
+    Returns None if the payload is missing or malformed. Callers treat a
+    None return as "no fingerprint declared" — onboard still succeeds, we
+    just can't record a binding. Validation is permissive-but-typed: the
+    three identity-key fields are required; everything else is best-effort.
+    """
+    if not isinstance(raw, dict):
+        return None
+
+    host_id = raw.get("host_id")
+    pid = raw.get("pid")
+    pid_start_time = raw.get("pid_start_time")
+    if not isinstance(host_id, str) or not host_id:
+        return None
+    if not isinstance(pid, int) or pid <= 0:
+        return None
+    if not isinstance(pid_start_time, (int, float)) or pid_start_time <= 0:
+        return None
+
+    transport = raw.get("transport") or "unknown"
+    if not isinstance(transport, str) or transport not in ALLOWED_TRANSPORTS:
+        transport = "unknown"
+
+    ppid = raw.get("ppid")
+    if ppid is not None and (not isinstance(ppid, int) or ppid <= 0):
+        ppid = None
+
+    tty = raw.get("tty")
+    if tty is not None and not isinstance(tty, str):
+        tty = None
+
+    anchor_path_hash = raw.get("anchor_path_hash")
+    if anchor_path_hash is not None and not isinstance(anchor_path_hash, str):
+        anchor_path_hash = None
+
+    return ProcessFingerprint(
+        host_id=host_id,
+        pid=pid,
+        pid_start_time=float(pid_start_time),
+        transport=transport,
+        ppid=ppid,
+        tty=tty,
+        anchor_path_hash=anchor_path_hash,
+    )
+
+
+async def record_binding_bg(
+    agent_id: str,
+    fp: ProcessFingerprint,
+    client_session_id: Optional[str] = None,
+) -> None:
+    """Persist a binding and emit an audit event on concurrent collision.
+
+    Fire-and-forget background coroutine — caller schedules via
+    `create_tracked_task`. Never raises; all failures are logged.
+
+    V1 behavior:
+      1. UPSERT the binding row (last_seen bumps on repeat onboard from
+         same execution context).
+      2. Count distinct live execution-context tuples for this agent
+         (live = stale_at IS NULL AND last_seen within LIVE_WINDOW_SECONDS).
+      3. If count >= 2 and agent.allow_concurrent_contexts is false, emit
+         an `identity_concurrent_binding` broadcaster event. No force-new.
+    """
+    try:
+        from src.db import get_db
+
+        db = get_db()
+        async with db.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO core.agent_process_bindings
+                    (agent_id, host_id, pid, pid_start_time, transport,
+                     ppid, tty, anchor_path_hash, client_session_id,
+                     onboard_ts, last_seen)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW(), NOW())
+                ON CONFLICT (agent_id, host_id, pid, pid_start_time, transport)
+                DO UPDATE SET
+                    last_seen = NOW(),
+                    tty = COALESCE(EXCLUDED.tty, core.agent_process_bindings.tty),
+                    ppid = COALESCE(EXCLUDED.ppid, core.agent_process_bindings.ppid),
+                    anchor_path_hash = COALESCE(
+                        EXCLUDED.anchor_path_hash,
+                        core.agent_process_bindings.anchor_path_hash
+                    ),
+                    client_session_id = COALESCE(
+                        EXCLUDED.client_session_id,
+                        core.agent_process_bindings.client_session_id
+                    ),
+                    stale_at = NULL
+                """,
+                agent_id,
+                fp.host_id,
+                fp.pid,
+                fp.pid_start_time,
+                fp.transport,
+                fp.ppid,
+                fp.tty,
+                fp.anchor_path_hash,
+                client_session_id,
+            )
+
+            live_rows = await conn.fetch(
+                f"""
+                SELECT host_id, pid, pid_start_time, transport, tty, ppid, last_seen
+                FROM core.agent_process_bindings
+                WHERE agent_id = $1
+                  AND stale_at IS NULL
+                  AND last_seen > NOW() - INTERVAL '{LIVE_WINDOW_SECONDS} seconds'
+                ORDER BY last_seen DESC
+                """,
+                agent_id,
+            )
+
+            if len(live_rows) < 2:
+                return
+
+            agent_row = await conn.fetchrow(
+                """
+                SELECT COALESCE(allow_concurrent_contexts, FALSE) AS allow_concurrent
+                FROM core.agents
+                WHERE id = $1
+                """,
+                agent_id,
+            )
+            allow_concurrent = bool(agent_row and agent_row["allow_concurrent"])
+            if allow_concurrent:
+                return
+
+        _emit_concurrent_binding_event(agent_id, live_rows)
+
+    except Exception as e:  # pragma: no cover — defensive
+        logger.debug(f"[PROCESS_BINDING] record_binding_bg failed (non-fatal): {e}")
+
+
+def _emit_concurrent_binding_event(agent_id: str, live_rows: List[Any]) -> None:
+    """Broadcast `identity_concurrent_binding` for a detected collision."""
+    contexts = [
+        {
+            "host_id": row["host_id"],
+            "pid": row["pid"],
+            "pid_start_time": row["pid_start_time"],
+            "transport": row["transport"],
+            "tty": row["tty"],
+            "ppid": row["ppid"],
+            "last_seen": row["last_seen"].isoformat() if row["last_seen"] else None,
+        }
+        for row in live_rows
+    ]
+    logger.warning(
+        "[CONCURRENT_BINDING] Agent %s has %d live execution contexts; "
+        "allow_concurrent_contexts=false. Contexts: %s",
+        agent_id[:8] + "...",
+        len(contexts),
+        contexts,
+    )
+
+    try:
+        from src.broadcaster import broadcaster_instance
+    except Exception:
+        return
+
+    async def _broadcast():
+        try:
+            await broadcaster_instance.broadcast_event(
+                event_type="identity_concurrent_binding",
+                agent_id=agent_id,
+                payload={
+                    "live_context_count": len(contexts),
+                    "contexts": contexts,
+                },
+            )
+        except Exception as e:
+            logger.debug(f"[CONCURRENT_BINDING] broadcast failed: {e}")
+
+    try:
+        from src.background_tasks import create_tracked_task
+        create_tracked_task(_broadcast(), name="concurrent_binding_event")
+    except Exception:
+        import asyncio
+        try:
+            asyncio.ensure_future(_broadcast())
+        except Exception:
+            pass

--- a/src/mcp_handlers/identity/process_binding_handler.py
+++ b/src/mcp_handlers/identity/process_binding_handler.py
@@ -1,0 +1,77 @@
+"""MCP tool: list_process_bindings — surface live execution-context bindings.
+
+Operator-facing diagnostic for issue #123. `/diagnose` (Codex slash command at
+commands/diagnose.md) can call this to show the caller what contexts the
+server sees bound to an agent UUID. Emits a concurrent-binding warning in the
+response when ≥2 distinct live contexts are present on an agent whose
+`allow_concurrent_contexts` flag is false.
+
+Read-only, no DB writes. Uses the existing `get_live_bindings` helper.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Sequence
+
+from mcp.types import TextContent
+
+from ..decorators import mcp_tool
+from ..utils import error_response, success_response
+from .process_binding import get_live_bindings
+from .shared import get_bound_agent_id
+
+logger = logging.getLogger(__name__)
+
+
+@mcp_tool("list_process_bindings", timeout=10.0)
+async def handle_list_process_bindings(
+    arguments: Dict[str, Any],
+) -> Sequence[TextContent]:
+    """List live execution-context bindings for an agent (#123 v1 diagnose).
+
+    Arguments:
+        agent_uuid: optional — defaults to the caller's bound agent.
+
+    Returns a payload like:
+        {
+          "agent_uuid": "...",
+          "live_binding_count": 2,
+          "concurrent_binding_detected": true,
+          "bindings": [ {host_id, pid, pid_start_time, transport, tty, ...}, ... ]
+        }
+    """
+    arguments = arguments or {}
+
+    agent_uuid = arguments.get("agent_uuid")
+    if not agent_uuid:
+        agent_uuid = get_bound_agent_id(
+            session_id=arguments.get("client_session_id"),
+            arguments=arguments,
+        )
+    if not agent_uuid:
+        return error_response(
+            "list_process_bindings requires agent_uuid or a bound session."
+        )
+
+    bindings = await get_live_bindings(agent_uuid)
+
+    distinct_contexts = {
+        (b["host_id"], b["pid"], b["pid_start_time"], b["transport"])
+        for b in bindings
+    }
+    concurrent = len(distinct_contexts) >= 2
+
+    payload: Dict[str, Any] = {
+        "agent_uuid": agent_uuid,
+        "live_binding_count": len(bindings),
+        "concurrent_binding_detected": concurrent,
+        "bindings": bindings,
+    }
+    if concurrent:
+        payload["note"] = (
+            "Multiple live execution contexts for this agent. If the agent's "
+            "allow_concurrent_contexts flag is false (the default), this is a "
+            "concurrent identity binding violation — see issue #123."
+        )
+
+    return success_response(payload, agent_id=agent_uuid, arguments=arguments)

--- a/src/mcp_handlers/schemas/identity.py
+++ b/src/mcp_handlers/schemas/identity.py
@@ -81,6 +81,20 @@ class OnboardParams(AgentIdentityMixin):
         default=None,
         description="Explicit thread ID to join (auto-derived from session if not provided)"
     )
+    # Concurrent identity binding invariant (issue #123).
+    # Client-reported execution context — used to detect same-UUID siphoning
+    # when two processes on the same host claim the same UUID. Audit-only in
+    # v1; see issue #123 for the detection rule and policy flags.
+    process_fingerprint: Optional[dict] = Field(
+        default=None,
+        description=(
+            "Optional client-reported execution context: "
+            "{host_id, pid, pid_start_time, transport, ppid?, tty?, "
+            "anchor_path_hash?}. Recorded server-side; used to detect "
+            "concurrent identity bindings. Declaration-only — never used "
+            "to resolve or recover identity."
+        )
+    )
 
     @model_validator(mode='after')
     def coerce_booleans(self):

--- a/tests/test_process_binding.py
+++ b/tests/test_process_binding.py
@@ -1,0 +1,241 @@
+"""Concurrent identity binding invariant (issue #123).
+
+Covers:
+  * validate_fingerprint — schema coercion
+  * capture_process_fingerprint — client-side helper
+  * record_binding_bg — detection fires exactly when ≥2 live bindings exist
+    with distinct execution contexts AND allow_concurrent_contexts=false
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.mcp_handlers.identity import process_binding
+from src.mcp_handlers.identity.process_binding import (
+    ProcessFingerprint,
+    validate_fingerprint,
+)
+
+
+# -----------------------------------------------------------------------------
+# validate_fingerprint
+# -----------------------------------------------------------------------------
+
+
+def test_validate_fingerprint_happy_path():
+    raw = {
+        "host_id": "host-abc",
+        "pid": 1234,
+        "pid_start_time": 1_777_013_157.42,
+        "transport": "http",
+        "ppid": 1,
+        "tty": "/dev/ttys003",
+        "anchor_path_hash": "deadbeef",
+    }
+    fp = validate_fingerprint(raw)
+    assert isinstance(fp, ProcessFingerprint)
+    assert fp.host_id == "host-abc"
+    assert fp.pid == 1234
+    assert fp.pid_start_time == 1_777_013_157.42
+    assert fp.transport == "http"
+    assert fp.ppid == 1
+    assert fp.tty == "/dev/ttys003"
+    assert fp.anchor_path_hash == "deadbeef"
+
+
+def test_validate_fingerprint_rejects_non_dict():
+    assert validate_fingerprint(None) is None
+    assert validate_fingerprint("nope") is None
+    assert validate_fingerprint(42) is None
+
+
+def test_validate_fingerprint_requires_identity_key_fields():
+    assert validate_fingerprint({"pid": 1, "pid_start_time": 1.0}) is None
+    assert validate_fingerprint({"host_id": "h", "pid_start_time": 1.0}) is None
+    assert validate_fingerprint({"host_id": "h", "pid": 1}) is None
+
+
+def test_validate_fingerprint_rejects_nonpositive_pid():
+    raw = {"host_id": "h", "pid": 0, "pid_start_time": 1.0}
+    assert validate_fingerprint(raw) is None
+    raw["pid"] = -1
+    assert validate_fingerprint(raw) is None
+
+
+def test_validate_fingerprint_unknown_transport_falls_through_to_unknown():
+    raw = {
+        "host_id": "h",
+        "pid": 1,
+        "pid_start_time": 1.0,
+        "transport": "bogus-transport",
+    }
+    fp = validate_fingerprint(raw)
+    assert fp is not None
+    assert fp.transport == "unknown"
+
+
+def test_validate_fingerprint_optional_fields_dropped_when_wrong_type():
+    raw = {
+        "host_id": "h",
+        "pid": 1,
+        "pid_start_time": 1.0,
+        "ppid": "not-an-int",
+        "tty": 12345,
+        "anchor_path_hash": {"not": "a string"},
+    }
+    fp = validate_fingerprint(raw)
+    assert fp is not None
+    assert fp.ppid is None
+    assert fp.tty is None
+    assert fp.anchor_path_hash is None
+
+
+# -----------------------------------------------------------------------------
+# client-side capture helper
+# -----------------------------------------------------------------------------
+
+
+def test_capture_process_fingerprint_returns_identity_key_fields():
+    from unitares_sdk.utils import capture_process_fingerprint
+
+    fp = capture_process_fingerprint(transport="http")
+    assert "host_id" in fp and isinstance(fp["host_id"], str) and fp["host_id"]
+    assert "pid" in fp and fp["pid"] > 0
+    assert fp["transport"] == "http"
+    # pid_start_time may be missing if psutil + /proc both unavailable, but the
+    # identity-key fields host_id/pid must always be present.
+    if "pid_start_time" in fp:
+        assert fp["pid_start_time"] > 0
+
+
+def test_capture_process_fingerprint_hashes_anchor_path():
+    from unitares_sdk.utils import capture_process_fingerprint
+
+    fp = capture_process_fingerprint(anchor_path="/etc/unitares/anchor.json")
+    assert "anchor_path_hash" in fp
+    assert len(fp["anchor_path_hash"]) == 16  # truncated sha256
+
+
+# -----------------------------------------------------------------------------
+# record_binding_bg — DB side with mocked pool
+# -----------------------------------------------------------------------------
+
+
+def _make_mock_db(live_rows, allow_concurrent=False):
+    """Build a mock async DB backend that exposes .acquire() -> conn."""
+    conn = AsyncMock()
+    conn.execute = AsyncMock()
+    conn.fetch = AsyncMock(return_value=live_rows)
+    conn.fetchrow = AsyncMock(
+        return_value={"allow_concurrent": allow_concurrent}
+    )
+
+    # Async context manager returned by acquire()
+    acquire_cm = AsyncMock()
+    acquire_cm.__aenter__.return_value = conn
+    acquire_cm.__aexit__.return_value = False
+
+    db = MagicMock()
+    db.acquire = MagicMock(return_value=acquire_cm)
+    return db, conn
+
+
+def _row(host="h1", pid=100, start=1.0, transport="http", tty=None, ppid=None):
+    from datetime import datetime, timezone
+    return {
+        "host_id": host,
+        "pid": pid,
+        "pid_start_time": start,
+        "transport": transport,
+        "tty": tty,
+        "ppid": ppid,
+        "last_seen": datetime.now(timezone.utc),
+    }
+
+
+@pytest.fixture
+def fp():
+    return ProcessFingerprint(
+        host_id="h1",
+        pid=100,
+        pid_start_time=1.0,
+        transport="http",
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_binding_single_live_no_event(fp):
+    """One live binding → no collision → no audit event."""
+    db, conn = _make_mock_db(live_rows=[_row()])
+    emit = MagicMock()
+    with patch("src.db.get_db", return_value=db), \
+         patch.object(process_binding, "_emit_concurrent_binding_event", emit):
+        await process_binding.record_binding_bg("agent-1", fp)
+    conn.execute.assert_awaited()
+    emit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_record_binding_two_live_distinct_contexts_emits_event(fp):
+    """Two live bindings with distinct tuples + policy=false → audit event fires."""
+    rows = [
+        _row(host="h1", pid=100, transport="http"),
+        _row(host="h1", pid=200, transport="stdio"),
+    ]
+    db, conn = _make_mock_db(live_rows=rows, allow_concurrent=False)
+    emit = MagicMock()
+    with patch("src.db.get_db", return_value=db), \
+         patch.object(process_binding, "_emit_concurrent_binding_event", emit):
+        await process_binding.record_binding_bg("agent-1", fp)
+    emit.assert_called_once()
+    args, _ = emit.call_args
+    assert args[0] == "agent-1"
+    assert len(args[1]) == 2
+
+
+@pytest.mark.asyncio
+async def test_record_binding_allow_concurrent_suppresses_event(fp):
+    """Two live bindings but allow_concurrent_contexts=true → no event."""
+    rows = [
+        _row(host="h1", pid=100, transport="http"),
+        _row(host="h1", pid=200, transport="stdio"),
+    ]
+    db, _ = _make_mock_db(live_rows=rows, allow_concurrent=True)
+    emit = MagicMock()
+    with patch("src.db.get_db", return_value=db), \
+         patch.object(process_binding, "_emit_concurrent_binding_event", emit):
+        await process_binding.record_binding_bg("agent-1", fp)
+    emit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_record_binding_swallows_db_errors(fp):
+    """DB failure in record_binding_bg is non-fatal — onboard must not break."""
+    db = MagicMock()
+    db.acquire = MagicMock(side_effect=RuntimeError("pool exhausted"))
+    with patch("src.db.get_db", return_value=db):
+        # Should not raise.
+        await process_binding.record_binding_bg("agent-1", fp)
+
+
+@pytest.mark.asyncio
+async def test_record_binding_pid_reuse_disambiguated_by_start_time(fp):
+    """Same host+pid with different pid_start_time = different contexts.
+
+    This is the PID-reuse case: a prior process exited, a new process got the
+    same PID from the kernel, and both claim the same UUID. pid_start_time
+    distinguishes them, so two rows exist and the event fires.
+    """
+    rows = [
+        _row(host="h1", pid=100, start=1.0, transport="http"),
+        _row(host="h1", pid=100, start=99999.0, transport="http"),
+    ]
+    db, _ = _make_mock_db(live_rows=rows, allow_concurrent=False)
+    emit = MagicMock()
+    with patch("src.db.get_db", return_value=db), \
+         patch.object(process_binding, "_emit_concurrent_binding_event", emit):
+        await process_binding.record_binding_bg("agent-1", fp)
+    emit.assert_called_once()

--- a/tests/test_process_binding.py
+++ b/tests/test_process_binding.py
@@ -222,6 +222,31 @@ async def test_record_binding_swallows_db_errors(fp):
 
 
 @pytest.mark.asyncio
+async def test_sweep_stale_bindings_returns_row_count():
+    """Sweeper parses asyncpg's 'UPDATE N' status string."""
+    conn = AsyncMock()
+    conn.execute = AsyncMock(return_value="UPDATE 42")
+    acquire_cm = AsyncMock()
+    acquire_cm.__aenter__.return_value = conn
+    acquire_cm.__aexit__.return_value = False
+    db = MagicMock()
+    db.acquire = MagicMock(return_value=acquire_cm)
+    with patch("src.db.get_db", return_value=db):
+        count = await process_binding.sweep_stale_bindings()
+    assert count == 42
+
+
+@pytest.mark.asyncio
+async def test_sweep_stale_bindings_swallows_errors():
+    """Sweeper failure must not propagate — next tick retries."""
+    db = MagicMock()
+    db.acquire = MagicMock(side_effect=RuntimeError("boom"))
+    with patch("src.db.get_db", return_value=db):
+        count = await process_binding.sweep_stale_bindings()
+    assert count == 0
+
+
+@pytest.mark.asyncio
 async def test_record_binding_pid_reuse_disambiguated_by_start_time(fp):
     """Same host+pid with different pid_start_time = different contexts.
 
@@ -239,3 +264,112 @@ async def test_record_binding_pid_reuse_disambiguated_by_start_time(fp):
          patch.object(process_binding, "_emit_concurrent_binding_event", emit):
         await process_binding.record_binding_bg("agent-1", fp)
     emit.assert_called_once()
+
+
+# -----------------------------------------------------------------------------
+# get_live_bindings + list_process_bindings MCP tool
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_live_bindings_returns_serialized_rows():
+    """Helper returns dict-per-row with ISO-formatted timestamps."""
+    from datetime import datetime, timezone
+
+    ts = datetime(2026, 4, 24, 1, 2, 3, tzinfo=timezone.utc)
+    row = {
+        "host_id": "h1", "pid": 100, "pid_start_time": 1.0,
+        "transport": "http", "tty": "/dev/ttys0", "ppid": 1,
+        "anchor_path_hash": None, "client_session_id": None,
+        "onboard_ts": ts, "last_seen": ts,
+    }
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(return_value=[row])
+    acquire_cm = AsyncMock()
+    acquire_cm.__aenter__.return_value = conn
+    acquire_cm.__aexit__.return_value = False
+    db = MagicMock()
+    db.acquire = MagicMock(return_value=acquire_cm)
+
+    with patch("src.db.get_db", return_value=db):
+        bindings = await process_binding.get_live_bindings("agent-1")
+    assert len(bindings) == 1
+    assert bindings[0]["host_id"] == "h1"
+    assert bindings[0]["last_seen"] == "2026-04-24T01:02:03+00:00"
+
+
+@pytest.mark.asyncio
+async def test_get_live_bindings_returns_empty_on_db_failure():
+    db = MagicMock()
+    db.acquire = MagicMock(side_effect=RuntimeError("nope"))
+    with patch("src.db.get_db", return_value=db):
+        result = await process_binding.get_live_bindings("agent-1")
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_list_process_bindings_requires_agent():
+    """Tool errors when neither agent_uuid nor a bound session is present."""
+    from src.mcp_handlers.identity import process_binding_handler
+
+    with patch.object(
+        process_binding_handler, "get_bound_agent_id", return_value=None
+    ):
+        result = await process_binding_handler.handle_list_process_bindings({})
+    # error_response returns a Sequence[TextContent]; just confirm it is non-empty.
+    assert result
+    text = result[0].text
+    assert "agent_uuid" in text.lower() or "bound session" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_list_process_bindings_flags_concurrent_collision():
+    """Tool sets concurrent_binding_detected=true when ≥2 distinct contexts."""
+    from src.mcp_handlers.identity import process_binding_handler
+
+    bindings = [
+        {"host_id": "h1", "pid": 100, "pid_start_time": 1.0, "transport": "http",
+         "tty": None, "ppid": None, "anchor_path_hash": None,
+         "client_session_id": None, "onboard_ts": None, "last_seen": None},
+        {"host_id": "h1", "pid": 200, "pid_start_time": 2.0, "transport": "stdio",
+         "tty": None, "ppid": None, "anchor_path_hash": None,
+         "client_session_id": None, "onboard_ts": None, "last_seen": None},
+    ]
+    with patch.object(
+        process_binding_handler,
+        "get_live_bindings",
+        AsyncMock(return_value=bindings),
+    ):
+        result = await process_binding_handler.handle_list_process_bindings(
+            {"agent_uuid": "agent-1"}
+        )
+    import json
+    payload = json.loads(result[0].text)
+    assert payload["live_binding_count"] == 2
+    assert payload["concurrent_binding_detected"] is True
+    assert "note" in payload
+
+
+@pytest.mark.asyncio
+async def test_list_process_bindings_single_binding_not_flagged():
+    """One live binding → concurrent_binding_detected=false, no note."""
+    from src.mcp_handlers.identity import process_binding_handler
+
+    bindings = [
+        {"host_id": "h1", "pid": 100, "pid_start_time": 1.0, "transport": "http",
+         "tty": None, "ppid": None, "anchor_path_hash": None,
+         "client_session_id": None, "onboard_ts": None, "last_seen": None},
+    ]
+    with patch.object(
+        process_binding_handler,
+        "get_live_bindings",
+        AsyncMock(return_value=bindings),
+    ):
+        result = await process_binding_handler.handle_list_process_bindings(
+            {"agent_uuid": "agent-1"}
+        )
+    import json
+    payload = json.loads(result[0].text)
+    assert payload["live_binding_count"] == 1
+    assert payload["concurrent_binding_detected"] is False
+    assert "note" not in payload


### PR DESCRIPTION
## Summary

- Detects same-UUID siphoning across live execution contexts — the pattern where `ip_ua_fingerprint` collides for same-machine clients (two Claude Code instances on one host share IP+UA).
- Server records a client-reported process fingerprint on `onboard()` and emits `identity_concurrent_binding` when ≥2 distinct live contexts appear for an agent whose `allow_concurrent_contexts` flag is false (default).
- Audit-only in v1: no automatic force-new. Enforcement deferred to v2 pending observed false-positive rate.
- Resolves the v1 scope of #123.

## What's in the box

**Server**
- `db/postgres/migrations/015_agent_process_bindings.sql` — new `core.agent_process_bindings` table keyed on `(agent_id, host_id, pid, pid_start_time, transport) UNIQUE`; new `allow_rebind_after_exit` + `allow_concurrent_contexts` columns on `core.agents` (both default false).
- `src/mcp_handlers/identity/process_binding.py` — `validate_fingerprint`, `record_binding_bg` (fire-and-forget, anyio-deadlock-safe), `get_live_bindings`, `sweep_stale_bindings`, `process_binding_sweeper_task`.
- `src/mcp_handlers/identity/process_binding_handler.py` — `list_process_bindings` MCP tool flags `concurrent_binding_detected` when ≥2 distinct contexts.
- `src/mcp_handlers/identity/handlers.py` — onboard handler schedules `record_binding_bg` as a tracked task.
- `src/mcp_handlers/schemas/identity.py` — `OnboardParams.process_fingerprint` optional dict.
- `src/background_tasks.py` — registers the sweeper alongside `matview_refresh` and `partition_maintenance`.

**Client**
- `agents/sdk/src/unitares_sdk/utils.py::capture_process_fingerprint` — ~120 LOC best-effort capture. Uses psutil where available, falls back to `/proc/self/stat` + `/proc/stat btime`. Any single-field failure yields a dropped field, not an exception. `host_id` is truncated sha256 of hostname + machine-id so the server never sees raw values.

**Operator UX**
- `commands/diagnose.md` — points `/diagnose` at `list_process_bindings` so the collision flag + `bindings[]` surface in the operator summary.

## Why this doesn't regress 2026-04-17 identity-honesty

Identity stays declared. No observable signal resolves or recovers identity when none is claimed. The process fingerprint is an **audit invariant on the declaration** — mismatch is *visible* (event + diagnose), not papered over. Residents work unchanged: anchor → onboard with same UUID → prior pid dead → no live collision → clean rebind.

## Two-flag policy (orthogonal, per GPT review)

| Flag | Default | Meaning |
|------|---------|---------|
| `allow_rebind_after_exit` | `false` | UUID may bind to a new context *after previous exits*. Residents set `true`. |
| `allow_concurrent_contexts` | `false` | UUID may have two live contexts *simultaneously*. Reserved for swarm; nothing sets it today. |

Residents are explicitly non-concurrent. If two Watcher instances light up with the same UUID, that's a real bug (raced anchor, duplicate launchd trigger) — the event fires, as intended.

## Test plan

- [x] `tests/test_process_binding.py` — 20 cases: schema validation (happy path, rejections, transport fallthrough, optional-field coercion), client capture (required fields + anchor hashing), detection (single=no event, two distinct tuples=event, allow_concurrent=suppressed, DB error swallowed, PID reuse disambiguated), sweeper (returns row count, swallows errors), `get_live_bindings` (serializes rows, [] on failure), `list_process_bindings` tool (requires agent, flags collision, does not flag single).
- [x] Adjacent identity suites green: `test_identity_handlers`, `test_identity_payloads`, `test_onboard_helper`, `test_resident_fork_detector`, `test_identity_path1_fingerprint`, `test_identity_path2_ipua_pin`, `test_identity_honesty_partc`.
- [x] Full `./scripts/dev/test-cache.sh`: **6824 passed, 33 skipped**, coverage 77.62%.

## Deferred follow-ups (issue #123 §"Scope")

- `ppid` as lineage verification — strengthens self-declared `parent_agent_id` with runtime-observable parent pid. Separate issue.
- V2 enforcement — env-var-gated force-new on collision, landed after v1 observation confirms false-positive rate is acceptable.

## Rollout note

Migration 015 must be applied before the new code is live (otherwise onboard succeeds but `record_binding_bg` logs a non-fatal error). The migration is additive only — no data loss risk, rollback is `DROP TABLE core.agent_process_bindings; ALTER TABLE core.agents DROP COLUMN allow_rebind_after_exit, DROP COLUMN allow_concurrent_contexts;` plus removing the row from `core.schema_migrations`.