### PR TITLE
Fix describe_tool(lite=true) collapsing Optional/Union params to "any"

### DIFF
--- a/src/mcp_handlers/introspection/tool_introspection.py
+++ b/src/mcp_handlers/introspection/tool_introspection.py
@@ -18,6 +18,37 @@ from src.logging_utils import get_logger
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 logger = get_logger(__name__)
 
+
+def _resolve_json_schema_type(field_info: Dict[str, Any]) -> str:
+    """Render a Pydantic/JSON Schema field's type for lite-mode param lists.
+
+    Pydantic emits Optional[T] as ``{"anyOf": [{"type": T}, {"type": "null"}]}``
+    with no top-level ``type`` key. A naive ``.get("type", "any")`` therefore
+    collapses every Optional field to "any", which defeats the purpose of lite
+    mode — agents use lite schemas to shape arguments.
+
+    Resolution:
+      - top-level ``type`` wins if present
+      - otherwise, walk ``anyOf`` and collect non-null ``type``s
+        - 1 non-null type → return it (the Optional case)
+        - 2+ non-null types → join with ``|`` (the Union case)
+        - 0 non-null types or no shape info → fall back to "any"
+    """
+    t = field_info.get("type")
+    if isinstance(t, str):
+        return t
+    any_of = field_info.get("anyOf")
+    if isinstance(any_of, list):
+        non_null = [variant.get("type") for variant in any_of
+                    if isinstance(variant, dict)
+                    and variant.get("type")
+                    and variant.get("type") != "null"]
+        if len(non_null) == 1:
+            return non_null[0]
+        if len(non_null) > 1:
+            return "|".join(non_null)
+    return "any"
+
 @mcp_tool("list_tools", timeout=10.0, rate_limit_exempt=True)
 async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """List all available governance tools with descriptions and categories
@@ -1085,7 +1116,7 @@ async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextConten
                         if shown >= 5:
                             break
                         shown += 1
-                        field_type = field_info.get("type", "any")
+                        field_type = _resolve_json_schema_type(field_info)
                         default = field_info.get("default")
                         if default is not None:
                             params_simple.append(f"{field_name}: {field_type} (default: {default})")
@@ -1156,7 +1187,7 @@ async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextConten
                     shown_count += 1
                 for param, prop in list(properties.items())[:8]:
                     if param not in required and param != "client_session_id":
-                        ptype = prop.get("type", "any")
+                        ptype = _resolve_json_schema_type(prop)
                         params_simple.append(f"{param}: {ptype}")
                         shown_count += 1
                 total_optional = sum(1 for p in properties if p not in required)

--- a/tests/test_admin_handlers.py
+++ b/tests/test_admin_handlers.py
@@ -518,6 +518,77 @@ class TestDescribeTool:
             data = parse_result(result)
             assert data["success"] is False
 
+    @pytest.mark.asyncio
+    async def test_describe_tool_lite_resolves_optional_types(self, patch_context_agent_id):
+        """Pydantic Optional[T] emits anyOf:[{type:T},{type:null}] with no top-level
+        type. Lite mode must surface T, not 'any'. Inputs to the fallback path
+        (no Pydantic model registered) so we exercise the inputSchema branch."""
+        mock_tool = MagicMock()
+        mock_tool.name = "optional_tool"
+        mock_tool.description = "Tool with Optional params"
+        mock_tool.inputSchema = {
+            "type": "object",
+            "properties": {
+                "required_str": {"type": "string"},
+                "optional_str": {"anyOf": [{"type": "string"}, {"type": "null"}], "default": None},
+                "optional_int": {"anyOf": [{"type": "integer"}, {"type": "null"}], "default": None},
+                "optional_bool": {"anyOf": [{"type": "boolean"}, {"type": "null"}], "default": False},
+                "union_str_bool": {"anyOf": [{"type": "string"}, {"type": "boolean"}, {"type": "null"}]},
+            },
+            "required": ["required_str"],
+        }
+
+        with patch("src.tool_schemas.get_tool_definitions", return_value=[mock_tool]), \
+             patch("src.tool_schemas.get_pydantic_schemas", return_value={}), \
+             patch("src.mcp_handlers.validators.PARAM_ALIASES", {}):
+            from src.mcp_handlers.introspection.tool_introspection import handle_describe_tool
+            result = await handle_describe_tool({"tool_name": "optional_tool", "lite": True})
+
+        data = parse_result(result)
+        assert data["success"] is True
+        params = " | ".join(data["parameters"])
+        # Required param rendered without type (existing contract)
+        assert "required_str (required)" in data["parameters"]
+        # Each Optional must surface its non-null type, NOT "any"
+        assert "optional_str: string" in params
+        assert "optional_int: integer" in params
+        assert "optional_bool: boolean" in params
+        # Union[str, bool] must render both types
+        assert "union_str_bool: string|boolean" in params
+        # Regression guard: no param should be typed "any" given the above shapes
+        assert ": any" not in params
+
+    @pytest.mark.asyncio
+    async def test_describe_tool_lite_pydantic_path_resolves_optional(self, patch_context_agent_id):
+        """Pydantic-schema branch of lite mode must also resolve anyOf → concrete type."""
+        from pydantic import BaseModel
+        from typing import Optional as Opt
+
+        class OptionalParams(BaseModel):
+            required_str: str
+            optional_str: Opt[str] = None
+            optional_int: Opt[int] = 5
+
+        mock_tool = MagicMock()
+        mock_tool.name = "pydantic_tool"
+        mock_tool.description = "Pydantic-backed tool"
+        mock_tool.inputSchema = {"type": "object", "properties": {}, "required": []}
+
+        with patch("src.tool_schemas.get_tool_definitions", return_value=[mock_tool]), \
+             patch("src.tool_schemas.get_pydantic_schemas",
+                   return_value={"pydantic_tool": OptionalParams}), \
+             patch("src.mcp_handlers.validators.PARAM_ALIASES", {}):
+            from src.mcp_handlers.introspection.tool_introspection import handle_describe_tool
+            result = await handle_describe_tool({"tool_name": "pydantic_tool", "lite": True})
+
+        data = parse_result(result)
+        assert data["success"] is True
+        params = " | ".join(data["parameters"])
+        assert "required_str (required)" in data["parameters"]
+        assert "optional_str: string" in params
+        assert "optional_int: integer" in params
+        assert ": any" not in params
+
 
 # ============================================================================
 # handle_health_check


### PR DESCRIPTION
## Summary

Lite-mode `describe_tool` rendered every `Optional[T]` param as `"<name>: any"`, erasing booleans, ints, dicts, and lists. That defeated the purpose of lite mode — agents use it to shape arguments and got no usable type information.

Root cause: Pydantic emits `Optional[T]` as `{"anyOf": [{"type": T}, {"type": "null"}]}` with no top-level `"type"` key. The renderer used `field_info.get("type", "any")`, which falls through on every Optional.

## Fix

New helper `_resolve_json_schema_type(field_info)`:
- top-level `"type"` wins if present
- otherwise walks `"anyOf"`, collects non-null variant types
  - 1 non-null → return it (the `Optional[T]` case)
  - 2+ non-null → join with `"|"` (the Union case)
- falls back to `"any"` only when no shape info is available

Applied at both lite-mode render sites — the Pydantic-first path and the inputSchema fallback path. Describe_tool(lite=false) was never affected.

## Test plan

- [x] 2 new tests in `TestDescribeTool` exercise Optional[str/int/bool] and a tri-variant Union on both the fallback and Pydantic paths, with a regression guard asserting no param renders as `"any"`.
- [x] Verified both tests fail without the fix (exact output: `optional_str: any | optional_int: any | optional_bool: any | union_str_bool: any`).
- [x] Full pre-commit suite: 6825 passed, 33 skipped (test-cache.sh).

## Context

Follow-up to #125. Secondary finding from KG discovery `2026-04-24T00:16:12.229114`.