### PR TITLE
Install audit + zero-assumption playbook (docs/install/)

### DIFF
--- a/docs/install/PLAYBOOK.md
+++ b/docs/install/PLAYBOOK.md
@@ -1,0 +1,267 @@
+# UNITARES Install Playbook (macOS, zero-assumption)
+
+**Goal:** take a blank macOS install to a state where the governance MCP server is serving on `http://localhost:8767`, an MCP client can perform a check-in successfully, and the dashboard is reachable.
+
+**Audience:** anyone with admin on a Mac and shell familiarity. No prior knowledge of UNITARES, EISV, AGE, or the project's history is assumed.
+
+**This doc is grep-verifiable** against `docs/install/cross-machine-surface.md`. If a step claims a value that isn't either (a) the canonical default in source or (b) something the playbook tells you to set, it's a bug — file an issue.
+
+---
+
+## What you'll have when you're done
+
+- Apache AGE + pgvector running on Homebrew PostgreSQL 17, with a `governance` database initialized.
+- `python src/mcp_server.py` running on `127.0.0.1:8767`, listening on the MCP transport (`/mcp/`), REST (`/v1/tools/call`), and the dashboard (`/dashboard`).
+- A successful round-trip: `onboard()` → `process_agent_update()` → verdict.
+- (Optional) A LaunchAgent so the server restarts at login.
+
+---
+
+## Prerequisites
+
+| Requirement | Why | How to check |
+|------------|-----|--------------|
+| macOS 12+ (Monterey or newer) | Homebrew formulae for PG 17 + Apple Silicon support | `sw_vers -productVersion` |
+| Xcode Command Line Tools | Required to build Apache AGE from source | `xcode-select -p` (should print a path; if not, `xcode-select --install`) |
+| Homebrew | Package manager | `brew --version` (if missing, see [brew.sh](https://brew.sh)) |
+| ~2 GB free disk | Postgres data dir + Python venv + AGE build | `df -h ~` |
+| Network access to GitHub + PyPI + Homebrew | For installs | — |
+
+**Architecture note:** the playbook works on both Apple Silicon (`arm64`) and Intel (`x86_64`). It uses `$(brew --prefix postgresql@17)` everywhere instead of hardcoding `/opt/homebrew/...`, so you don't need to know which machine you're on.
+
+---
+
+## Step 1 — Install Homebrew packages
+
+```bash
+brew install postgresql@17 pgvector python@3.12 git
+brew services start postgresql@17
+```
+
+**Expected:**
+
+```bash
+pg_isready -h localhost -p 5432
+# /tmp:5432 - accepting connections
+```
+
+**If `pg_isready` says "no response":** wait 5 seconds (Postgres takes a moment to start) and retry. If still failing, `brew services list | grep postgresql` should show `started`. If it says `error`, run `brew services restart postgresql@17` and check `~/Library/Logs/Homebrew/postgresql@17/server.log`.
+
+---
+
+## Step 2 — Build Apache AGE 1.7.0 against PostgreSQL 17
+
+AGE is not in Homebrew. You build it from source against the exact `pg_config` from your Homebrew Postgres.
+
+```bash
+export PG_CONFIG="$(brew --prefix postgresql@17)/bin/pg_config"
+git clone --depth 1 --branch PG17/v1.7.0-rc0 https://github.com/apache/age.git /tmp/age-build
+cd /tmp/age-build
+make PG_CONFIG="$PG_CONFIG"
+make install PG_CONFIG="$PG_CONFIG"
+cd -
+```
+
+**Expected:** `make install` ends without errors, and:
+
+```bash
+ls "$(brew --prefix postgresql@17)/lib/postgresql/age.dylib"
+# /opt/homebrew/.../lib/postgresql/age.dylib
+```
+
+**If `make` fails with `bison: command not found`:** `brew install bison flex` and prepend them to PATH: `export PATH="$(brew --prefix bison)/bin:$PATH"`. Re-run `make`.
+
+**If `make install` fails with permission errors:** the Homebrew postgres lib dir is user-writable on a normal install. If yours isn't (rare), check `ls -la "$(brew --prefix postgresql@17)/lib/postgresql/"` — the directory should be owned by your user, not root. Don't `sudo` this; that creates a root-owned file Homebrew can't manage later.
+
+---
+
+## Step 3 — Create the database, install extensions, apply schema
+
+```bash
+git clone https://github.com/CIRWEL/unitares.git
+cd unitares
+
+createdb -h localhost -p 5432 governance
+
+export DB_POSTGRES_URL="postgresql://localhost:5432/governance"
+export DB_AGE_GRAPH=governance_graph
+
+psql "$DB_POSTGRES_URL" -f db/postgres/init-extensions.sql
+psql "$DB_POSTGRES_URL" -f db/postgres/schema.sql
+psql "$DB_POSTGRES_URL" -f db/postgres/partitions.sql
+psql "$DB_POSTGRES_URL" -f db/postgres/knowledge_schema.sql
+psql "$DB_POSTGRES_URL" -f db/postgres/embeddings_schema.sql
+psql "$DB_POSTGRES_URL" -f db/postgres/graph_schema.sql
+```
+
+**Expected:** each `psql` prints zero errors. Verify:
+
+```bash
+psql "$DB_POSTGRES_URL" -c "SELECT extname, extversion FROM pg_extension WHERE extname IN ('age', 'vector');"
+#  extname | extversion
+# ---------+-----------
+#  age     | 1.7.0
+#  vector  | 0.7.x
+```
+
+**On Homebrew Postgres**, the `postgres` superuser doesn't exist by default — your macOS username is the superuser, and the connection above (no user, no password) uses local trust auth. If you see `role "postgres" does not exist`, that's the reason; the URL above already omits the user/password.
+
+**If you need to share the DB DSN with code that hardcodes `postgres:postgres@`:** create the role explicitly: `createuser -s postgres && psql -c "ALTER USER postgres WITH PASSWORD 'postgres';"`. Cross-machine surface doc explains why this default DSN is duplicated across files.
+
+---
+
+## Step 4 — Python virtualenv and dependencies
+
+```bash
+python3.12 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements-full.txt
+```
+
+**Expected:** all packages install cleanly, including `unitares-core`.
+
+**`unitares-core` install path (transitional):** as of this audit, `unitares-core` is being moved from a private repo to public. Three possible states you might be in:
+
+- **Public on PyPI (target):** the line above just works.
+- **Public on GitHub (interim):** add `pip install "unitares-core @ git+https://github.com/CIRWEL/unitares-core.git@<tag>"`.
+- **Still private (legacy):** you need a `UNITARES_CORE_TOKEN` from a maintainer. If you don't have one, you can run the server in **behavioral-only mode** by setting `UNITARES_DISABLE_ODE=1` — verdicts come from the behavioral EISV path, with the ODE diagnostic fallback skipped. The dashboard will show a banner indicating reduced diagnostic detail.
+
+---
+
+## Step 5 — Start the server
+
+```bash
+python src/mcp_server.py --port 8767
+```
+
+**Expected:** within 3 seconds you see log lines ending with something like:
+
+```
+Uvicorn running on http://127.0.0.1:8767
+```
+
+The server binds to `127.0.0.1` only by default — it is not reachable from your LAN. That's intentional; see the *Optional: expose on LAN* section if you need otherwise.
+
+---
+
+## Step 6 — Verify (the acceptance test)
+
+In a second terminal:
+
+```bash
+# Health
+curl -s http://127.0.0.1:8767/health/live
+# {"status":"alive"}
+
+# Onboard via REST
+curl -s -X POST http://127.0.0.1:8767/v1/tools/call \
+  -H 'Content-Type: application/json' \
+  -d '{"tool":"onboard","arguments":{"purpose":"install verification"}}' \
+  | python3 -m json.tool
+
+# Expect: a JSON response containing "agent_uuid" and an EISV state vector.
+
+# Dashboard
+open http://127.0.0.1:8767/dashboard
+```
+
+**You're done when:** the dashboard loads (you'll see fleet metrics, even if zeroed), the `onboard` call returns an `agent_uuid`, and there are no error log lines from the server in your first terminal.
+
+---
+
+## Step 7 — (Optional) Connect a Claude Code / Cursor / Claude Desktop client
+
+See `docs/integration/MCP_CLIENTS.md` for client-specific JSON. The short version:
+
+```jsonc
+{
+  "mcpServers": {
+    "unitares": { "url": "http://127.0.0.1:8767/mcp/" }
+  }
+}
+```
+
+Once the client connects, the server's logs will show an `onboard` call from the client's session. That's the full acceptance: stranger box → working governance fleet of one.
+
+---
+
+## Optional: install as a LaunchAgent (auto-start at login)
+
+```bash
+# 1. Render the template with your paths and a generated secret token
+sed -e "s|/PATH/TO/UNITARES|$PWD|g" \
+    -e "s|/PATH/TO/PYTHON3|$PWD/.venv/bin/python|g" \
+    -e "s|/YOUR/HOME|$HOME|g" \
+    -e "s|GENERATE_YOUR_OWN_TOKEN|$(openssl rand -hex 32)|g" \
+    -e "s|GENERATE_YOUR_OWN_SECRET|$(openssl rand -hex 32)|g" \
+    scripts/ops/com.unitares.governance-mcp.plist \
+    > ~/Library/LaunchAgents/com.unitares.governance-mcp.plist
+
+# 2. Load it
+launchctl load ~/Library/LaunchAgents/com.unitares.governance-mcp.plist
+
+# 3. Verify
+launchctl list | grep unitares
+curl -s http://127.0.0.1:8767/health/live
+```
+
+The plist's other tunables (DB DSN, allowed hosts, log paths) are inline at the top of the rendered file. Defaults bind loopback-only and use the trust-auth Postgres connection from Step 3.
+
+---
+
+## Optional: expose on LAN or via a tunnel
+
+The server defaults to `127.0.0.1`. To expose:
+
+```bash
+# LAN — bind all interfaces, allow your LAN's Host header
+export UNITARES_BIND_ALL_INTERFACES=1
+export UNITARES_MCP_ALLOWED_HOSTS="<your-lan-ip>:*,<your-hostname>.local"
+export UNITARES_MCP_ALLOWED_ORIGINS="http://<your-lan-ip>:*"
+python src/mcp_server.py --port 8767
+```
+
+For a Cloudflare tunnel: see `docs/operations/OPERATOR_RUNBOOK.md`. Anything beyond loopback should also have `UNITARES_BEARER_TOKEN` set; otherwise REST is open.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `pg_isready: no response` | Postgres not started | `brew services restart postgresql@17`, wait, retry |
+| `make` fails on AGE with `bison` errors | Apple's old bison shadows Homebrew's | `brew install bison && export PATH="$(brew --prefix bison)/bin:$PATH"` |
+| `psql: error: connection to server ... failed: FATAL: role "postgres" does not exist` | Homebrew Postgres uses your username | Drop `postgres:postgres@` from the DSN, or create the role (Step 3) |
+| `pip install unitares-core` fails | Private wheel, no token | Use behavioral-only mode (`UNITARES_DISABLE_ODE=1`) or get token from maintainer (Step 4) |
+| `Address already in use` on port 8767 | Server already running | `lsof -i :8767` — kill it or use `--port 8768` |
+| `relation "agents" does not exist` on first call | Schema not applied | Re-run Step 3 |
+| `extension "age" is not available` | AGE built against wrong `pg_config` | Verify `$PG_CONFIG` points to your Homebrew PG 17, rebuild |
+| Dashboard loads but is empty | Expected — no agents yet | Run an `onboard` call (Step 6) |
+
+For more, see `docs/guides/TROUBLESHOOTING.md`.
+
+---
+
+## What this playbook deliberately does NOT cover
+
+- **Pi / Lumen side (anima-mcp).** That's a separate install and a separate audit; deferred until cross-machine surface for anima-mcp is grep-checked.
+- **Multi-host fleet deployments.** This is a single-host install. Coordinated multi-host setups (governance on one Mac, anima on a Pi, dashboard on a third) require additional networking decisions outside the scope of "smooth install."
+- **Custom AGE / pgvector versions.** Pinned to AGE 1.7.0 + pgvector latest because that pairing is what the schema was developed against.
+- **Production hardening** (TLS, bearer rotation, multi-tenant isolation). Those belong in a separate ops runbook, not in a stranger's first install.
+
+---
+
+## Acceptance test (one-liner)
+
+If you trust the playbook and just want to know it worked:
+
+```bash
+curl -fs http://127.0.0.1:8767/health/live \
+  && curl -fs -X POST http://127.0.0.1:8767/v1/tools/call \
+       -H 'Content-Type: application/json' \
+       -d '{"tool":"onboard","arguments":{"purpose":"smoke"}}' \
+       | python3 -c 'import sys,json; d=json.load(sys.stdin); assert d.get("agent_uuid"), d; print("OK", d["agent_uuid"])'
+```
+
+If that prints `OK <uuid>`, the install is correct.

--- a/docs/install/cross-machine-surface.md
+++ b/docs/install/cross-machine-surface.md
@@ -1,0 +1,139 @@
+# Cross-Machine Install Surface
+
+A grep-derived inventory of every value in this repo that varies between machines, plus an explicit list of values that **intentionally** vary and must not be unified.
+
+**Audit date:** 2026-04-24 against `chore/install-audit` branch.
+**Scope:** unitares server only. Pi-side anima-mcp deferred to v2.
+**Acceptance:** the install playbook (`docs/install/PLAYBOOK.md`) must not assume any value classified MUST-FIX below.
+
+---
+
+## How to use this doc
+
+Every entry has a **disposition**:
+
+- **OK** — already env-var overridable with a sensible default; safe for a stranger's box.
+- **MUST-FIX** — operator-specific value shipping as a default; will mislead or break a fresh install.
+- **TEMPLATE** — file is a template that needs `__VAR__` substitution at install time.
+- **INTENTIONAL** — varies by design; do not unify (see *Intentional Heterogeneity* below).
+
+When adding new files that touch any of the patterns in *Audit Patterns*, re-check this doc and add an entry.
+
+---
+
+## MUST-FIX (operator-specific defaults)
+
+These values bake one operator's environment into code that ships to others. Each must change before a stranger install will work.
+
+| File | Line | Value | Fix |
+|------|------|-------|-----|
+| `scripts/ops/start_unitares.sh` | 14 | `UNITARES_MCP_ALLOWED_HOSTS` default = `192.168.1.151:*,192.168.1.164:*,100.96.201.46:*,gov.cirwel.org` | Default to empty (loopback-only); document opt-in env var |
+| `scripts/ops/start_unitares.sh` | 15 | `UNITARES_MCP_ALLOWED_ORIGINS` default = same LAN/Tailscale/`gov.cirwel.org` set | Same as above |
+| `scripts/ops/start_unitares.sh` | 37 | Prints `https://gov.cirwel.org/v1/tools` example | Use `${UNITARES_PUBLIC_URL:-http://localhost:$PORT}` |
+| `scripts/ops/start_unitares.sh` | 121 | Prints `Tunnel: https://gov.cirwel.org/mcp/` unconditionally | Only print when `CLOUDFLARE_TUNNEL_HOSTNAME` is set |
+| `scripts/ops/start_server.sh` | 60 | Same `gov.cirwel.org` example string | Same as start_unitares.sh:37 |
+| `scripts/ops/health_watchdog.sh` | 28 | Hardcoded Pi Tailscale IP `100.79.215.83` | `${ANIMA_HEALTH_URL:-}`; skip anima check if unset |
+| `scripts/ops/answer_lumen_questions.py` | 19 | Default `https://lumen.cirwel.org/mcp/` | Require `PI_MCP_URL`, error if unset |
+| `scripts/ops/answer_lumen_questions.py` | 84 | Hardcoded Pi LAN IP `192.168.1.165` | Same — env-var-required |
+| `requirements-core.txt` | 22 | Comment example uses `https://gov.cirwel.org/v1/tools` | Use `https://your-host.example/v1/tools` |
+| `scripts/ops/com.unitares.ipv6-loopback-proxy.plist.template` | 33 | Hardcoded `/Users/cirwel/projects/unitares/scripts/ops/ipv6_loopback_proxy.py` | Use `__UNITARES_ROOT__` placeholder (matches chronicler template convention) |
+
+---
+
+## TEMPLATE GAP (gitignored plists with no in-repo template)
+
+`.gitignore` excludes `scripts/ops/*.plist` because installed copies contain secrets. Only three templates are tracked: `governance-mcp.plist` (sanitized), `chronicler.plist.template`, `ipv6-loopback-proxy.plist.template`. The four below exist on the operator's disk but **a stranger has nothing to copy from**.
+
+| LaunchAgent | Status | Fix |
+|------------|--------|-----|
+| `com.unitares.governance-mcp.plist` | Tracked, sanitized with `/PATH/TO/UNITARES`, `GENERATE_YOUR_OWN_TOKEN` | Rename to `.template` for naming consistency (low priority) |
+| `com.unitares.chronicler.plist.template` | Tracked template using `__UNITARES_ROOT__`, `__HOME__` | OK |
+| `com.unitares.ipv6-loopback-proxy.plist.template` | Tracked template, but hardcodes `/Users/cirwel/...` (see MUST-FIX above) | Convert to `__UNITARES_ROOT__` |
+| `com.unitares.sentinel.plist` | **Gitignored — no template tracked** | Create `.template` |
+| `com.unitares.vigil.plist` | **Gitignored — no template tracked** | Create `.template` |
+| `com.unitares.gateway-mcp.plist` | **Gitignored — no template tracked** | Create `.template` |
+| `com.unitares.governance-backup.plist` | **Gitignored — no template tracked** | Create `.template` |
+
+---
+
+## ARCHITECTURE GAPS (block stranger install entirely)
+
+Beyond per-line edits, two structural issues will prevent a fresh install:
+
+1. **`unitares-core` is a private compiled wheel.** `pyproject.toml:14` instructs symlinking from `~/projects/unitares-core/governance_core`, which only exists on Kenny's machine. CI uses `UNITARES_CORE_TOKEN` (`.github/workflows/tests.yml:20,68`); fork PRs can't run CI. **Decision in flight: publish `unitares-core` to PyPI / public GitHub.** Until that ships, any third-party install fails at `pip install -r requirements-full.txt`.
+2. **Apple Silicon assumed in scripts.** `/opt/homebrew/opt/postgresql@17/bin` is hardcoded in:
+   - `scripts/ops/emergency_fix_postgres.sh:6`
+   - `scripts/ops/backup_governance.sh:10`
+   - `scripts/ops/start_with_deps.sh:12`
+   - `db/postgres/README.md:30` (instructional, but no Intel alternative shown)
+
+   On an Intel Mac the prefix is `/usr/local/opt/postgresql@17/bin`. **Fix:** replace each with `PG_BIN="$(brew --prefix postgresql@17)/bin"`. The `chronicler.plist.template:48` PATH already covers both prefixes — pattern to follow.
+3. **Apache AGE has no Homebrew formula.** `db/postgres/README.md` walks through `git clone apache/age && make && make install` against `pg_config`. Real failure modes: Xcode CLT missing; `bison`/`flex` versions mismatch; AGE tag not pinned to a known-good against PG 17. The install playbook needs to pin AGE 1.7.0 explicitly and surface build failures with a link to the AGE issue tracker.
+
+---
+
+## OK (already env-var overridable, defaults are correct)
+
+These appear in the audit but need no change. Listed so future audits don't re-flag them.
+
+| Pattern | Where it's centralized | Why OK |
+|---------|----------------------|--------|
+| Bind address (`127.0.0.1` / `0.0.0.0`) | `src/mcp_listen_config.py` | Single source; `UNITARES_BIND_ALL_INTERFACES` and `UNITARES_MCP_HOST` env vars override |
+| Governance port `8767` | `src/mcp_server.py:531` (`DEFAULT_PORT`) | `--port` CLI arg + `SERVER_PORT` env var override; this is the canonical port |
+| MCP / REST / WS / health URLs in agents | `agents/common/config.py` | All env-var-fallback defaults to `http://localhost:8767` |
+| DB connection string | `os.environ.get("DB_POSTGRES_URL", "...")` everywhere | Env var wins; default DSN works on a fresh Homebrew Postgres because Homebrew uses trust auth on localhost (the literal `postgres:postgres` password is illustrative — Homebrew ignores it) |
+| Tailscale CGNAT range `100.64.0.0/10` | `src/http_api.py:147` | This is the entire Tailscale network spec, not a specific operator's IP — correct as a constant |
+| LAN / private network ranges `192.168.0.0/16`, `10.0.0.0/8` | `src/http_api.py:148-149` | RFC 1918 ranges, machine-independent |
+| `~/Library/LaunchAgents` install path | All plist install instructions | Standard macOS path, identical across machines |
+| `~/.unitares/anchors`, `~/backups/governance` | `scripts/ops/rotate-secrets.sh`, `backup_governance.sh` | Use `${HOME}` correctly |
+| `$HOME` substitution in chronicler template | `scripts/ops/com.unitares.chronicler.plist.template` | Pattern to follow for the other plist templates |
+
+---
+
+## INTENTIONAL HETEROGENEITY (do not unify)
+
+**This section exists so a future grep-audit doesn't "fix" things that are intentional. Memory anchor: `MEMORY.md` *Ports & Endpoints — DO NOT NORMALIZE*.**
+
+| Value | Where it appears | Why heterogeneous |
+|-------|------------------|------------------|
+| Port `8767` | Governance MCP (Mac) — `src/mcp_server.py`, dashboards, all governance clients | Canonical governance port |
+| Port `8766` | Anima MCP (Pi) — `scripts/ops/health_watchdog.sh`, `config/claude-desktop-mcp-config.json`, plus skill docs | Canonical anima/Lumen port; lives on a different host |
+| Port `8768` | Gateway MCP (Mac) — `src/gateway/constants.py`, `src/gateway_server.py` | Reduced-surface proxy (6 tools vs 76) for weak external clients; same host as 8767 but **different process** |
+| `claude-ai_UNITARES` and `unitares-governance` MCP names | MCP client configs across plugin repos | Stable IDs that external clients persist; renaming churns user state |
+
+**The pattern that will trip a future agent:** they'll see `8767` everywhere in governance code and `8766` in one watchdog line, "fix" the watchdog to `8767`, and silently break the anima health check. Reference the `DEFINITIVE_PORTS.md` table before changing any port literal.
+
+---
+
+## Audit Patterns (reproduce this audit)
+
+Run these from the repo root. Excludes `.git`, `.worktrees`, `data/`, `papers/`, `__pycache__`, and `tests/` (test fixtures legitimately use any of these strings).
+
+```bash
+# Operator path
+rg -n --hidden -g '!.git' -g '!.worktrees' -g '!data/' -g '!papers/**' -g '!**/__pycache__/**' -g '!tests/**' '/Users/cirwel'
+
+# Operator's home LAN / Tailscale IPs
+rg -n --hidden -g '!.git' -g '!.worktrees' -g '!data/' -g '!papers/**' -g '!**/__pycache__/**' -g '!tests/**' '\b100\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\b|\b192\.168\.1\.[0-9]{1,3}\b'
+
+# Operator's domain
+rg -n --hidden -g '!.git' -g '!.worktrees' -g '!data/' -g '!papers/**' -g '!**/__pycache__/**' 'cirwel\.org|lumen\.local|\.ts\.net'
+
+# Apple Silicon / Intel brew prefix
+rg -n --hidden -g '!.git' -g '!.worktrees' -g '!data/' -g '!papers/**' -g '!**/__pycache__/**' '/opt/homebrew|/usr/local/opt/postgres'
+
+# Bind addresses + ports (read alongside DEFINITIVE_PORTS.md)
+rg -n --hidden -g '!.git' -g '!.worktrees' -g '!data/' -g '!papers/**' -g '!**/__pycache__/**' -g '!tests/**' '\b(8766|8767|8768|5432)\b'
+rg -n --hidden -g '!.git' -g '!.worktrees' -g '!data/' -g '!papers/**' -g '!**/__pycache__/**' -g '!tests/**' '\b127\.0\.0\.1\b|\b0\.0\.0\.0\b'
+
+# DB credentials literal
+rg -n --hidden -g '!.git' -g '!.worktrees' -g '!data/' -g '!papers/**' -g '!**/__pycache__/**' 'postgres:postgres@localhost'
+
+# Plist install path
+rg -n --hidden -g '!.git' -g '!.worktrees' -g '!data/' -g '!papers/**' -g '!**/__pycache__/**' 'Library/LaunchAgents|launchctl'
+
+# Personal identifiers
+rg -n --hidden -g '!.git' -g '!.worktrees' -g '!data/' -g '!papers/**' -g '!**/__pycache__/**' -g '!tests/**' 'hikewa|@gmail|kenny'
+```
+
+A drift in the **MUST-FIX** count between this audit and a future re-run is a regression — either fix the new entry or add it here with justification.


### PR DESCRIPTION
## Summary

Two new docs under `docs/install/` that together answer the question *is this repo set up for a smooth install on a stranger's Mac?*

**`cross-machine-surface.md`** — a grep-derived inventory of cross-machine assumptions. Categorizes each finding as **MUST-FIX**, **TEMPLATE**, **OK**, or **INTENTIONAL**. The intentional-heterogeneity section (ports 8766/8767/8768) is explicitly anchored to `MEMORY.md` so future audits don't accidentally normalize them. Includes the exact `rg` patterns used, so a follow-up audit is a one-command reproduction.

**`PLAYBOOK.md`** — zero-assumption macOS install walkthrough. Blank Mac → `:8767` serving → check-in returns a verdict. AGE pinned to 1.7.0 (tag verified via `git ls-remote`). Apple-Silicon/Intel agnostic via `brew --prefix postgresql@17`. Acceptance-test one-liner at the bottom.

## Headline findings from the audit

1. **11 MUST-FIX entries** — operator-specific values shipping as defaults. Worst offender: `scripts/ops/start_unitares.sh` bakes the operator's home LAN IPs into the default `UNITARES_MCP_ALLOWED_HOSTS` allowlist.
2. **4 LaunchAgent plists are gitignored with no in-repo template** (sentinel, vigil, gateway-mcp, governance-backup). A stranger has nothing to copy.
3. **3 architecture gaps** block stranger install entirely: `unitares-core` private wheel, Apple-Silicon-only `/opt/homebrew` paths in ops scripts, and Apache AGE not being in Homebrew (requires source build).

## Scope

Docs only. No source changes. The MUST-FIX entries and missing plist templates are left as tracked work to be addressed in follow-up PRs.

## Test plan

- [x] `ship.sh` classified as `other` → direct branch push (no PR auto-open; this PR opened manually for review visibility)
- [x] Pre-push smoke tests: 138 passed, 6362 deselected in 4.85s
- [x] Doc-health check: warnings only (pre-existing dead refs in `docs/ontology/*`, plus false-positive Tailscale IPs in `cross-machine-surface.md` that are documented as values-to-remove)
- [ ] Follow-up: either obfuscate or allow-list `docs/install/cross-machine-surface.md` in the doc-health IP check

## Follow-up work (not in this PR)

- Address the 11 MUST-FIX entries (separate PR; touches `start_unitares.sh` which is in live use)
- Create the 4 missing `.template` plist files
- `unitares-core` public-release decision (blocks third-party install entirely)
- `scripts/install.sh` automating the PLAYBOOK steps with idempotent phases