### PR TITLE
instrument: per-phase latency in process_agent_update workflow

### DIFF
--- a/src/services/update_workflow_service.py
+++ b/src/services/update_workflow_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 from typing import Sequence
 
@@ -29,91 +30,119 @@ async def run_process_update_workflow(ctx, *, serializer=None) -> Sequence[TextC
     from src.mcp_handlers.response_formatter import format_response
     from src.mcp_handlers.utils import error_response
 
-    early_exit = await resolve_identity_and_guards(ctx)
-    if early_exit:
-        return early_exit
+    # Per-phase latency instrumentation. Emits one INFO line per call so we can
+    # see in data whether the anyio-asyncio serialization cost lives in the
+    # locked Phase 4 or the post-lock enrichment pipeline.
+    _phase_ms: dict[str, int] = {}
+    _t_total = time.perf_counter()
+    _t_phase = _t_total
 
-    early_exit = await handle_onboarding_and_resume(ctx)
-    if early_exit:
-        return early_exit
-
-    early_exit = transform_inputs(ctx)
-    if early_exit:
-        return early_exit
+    def _tick(label: str) -> None:
+        nonlocal _t_phase
+        now = time.perf_counter()
+        _phase_ms[label] = int((now - _t_phase) * 1000)
+        _t_phase = now
 
     try:
-        async with ctx.mcp_server.lock_manager.acquire_agent_lock_async(ctx.agent_id, timeout=5.0, max_retries=3):
-            early_exit = await execute_locked_update(ctx)
-            if early_exit:
-                return early_exit
+        early_exit = await resolve_identity_and_guards(ctx)
+        _tick("resolve_identity")
+        if early_exit:
+            return early_exit
 
-            # Capture monitor ref while lock guarantees consistent state
-            ctx.monitor = ctx.mcp_server.monitors.get(ctx.agent_id)
-    except TimeoutError:
-        cleaned = False
+        early_exit = await handle_onboarding_and_resume(ctx)
+        _tick("onboard_resume")
+        if early_exit:
+            return early_exit
+
+        early_exit = transform_inputs(ctx)
+        _tick("transform")
+        if early_exit:
+            return early_exit
+
         try:
-            from src.lock_cleanup import cleanup_stale_state_locks
-            project_root = Path(__file__).resolve().parent.parent
-            cleanup_result = await ctx.loop.run_in_executor(
-                None, cleanup_stale_state_locks, project_root, 60.0, False
+            async with ctx.mcp_server.lock_manager.acquire_agent_lock_async(ctx.agent_id, timeout=5.0, max_retries=3):
+                early_exit = await execute_locked_update(ctx)
+                _tick("locked_update")
+                if early_exit:
+                    return early_exit
+
+                # Capture monitor ref while lock guarantees consistent state
+                ctx.monitor = ctx.mcp_server.monitors.get(ctx.agent_id)
+        except TimeoutError:
+            _tick("lock_timeout")
+            cleaned = False
+            try:
+                from src.lock_cleanup import cleanup_stale_state_locks
+                project_root = Path(__file__).resolve().parent.parent
+                cleanup_result = await ctx.loop.run_in_executor(
+                    None, cleanup_stale_state_locks, project_root, 60.0, False
+                )
+                if cleanup_result["cleaned"] > 0:
+                    logger.info(f"Auto-recovery: Cleaned {cleanup_result['cleaned']} stale lock(s) after timeout")
+                    cleaned = True
+            except Exception as cleanup_error:
+                logger.warning(f"Could not perform emergency lock cleanup: {cleanup_error}")
+
+            cleanup_msg = (
+                "The system has automatically cleaned stale locks. " if cleaned
+                else "Automatic lock cleanup was attempted but did not resolve the issue. "
             )
-            if cleanup_result["cleaned"] > 0:
-                logger.info(f"Auto-recovery: Cleaned {cleanup_result['cleaned']} stale lock(s) after timeout")
-                cleaned = True
-        except Exception as cleanup_error:
-            logger.warning(f"Could not perform emergency lock cleanup: {cleanup_error}")
+            return [error_response(
+                f"Failed to acquire lock for agent '{ctx.agent_id}' after automatic retries and cleanup. "
+                f"This usually means another active process is updating this agent. "
+                f"{cleanup_msg}If this persists, try: "
+                f"1) Wait a few seconds and retry, 2) Check for other Cursor/Claude sessions, "
+                f"3) Use cleanup_stale_locks tool, or 4) Restart Cursor if stuck."
+                ,
+                error_code="LOCK_TIMEOUT",
+                error_category="system_error",
+                details={
+                    "lock_error": True,
+                    "agent_id": ctx.agent_id,
+                },
+                arguments=ctx.arguments,
+            )]
 
-        cleanup_msg = (
-            "The system has automatically cleaned stale locks. " if cleaned
-            else "Automatic lock cleanup was attempted but did not resolve the issue. "
+        # --- Everything below runs OUTSIDE the lock ---
+
+        await execute_post_update_effects(ctx)
+        _tick("post_update")
+
+        ctx.response_data = build_process_update_response_data(
+            result=ctx.result,
+            agent_id=ctx.agent_id,
+            identity_assurance=ctx.identity_assurance,
+            monitor=ctx.monitor,
         )
-        return [error_response(
-            f"Failed to acquire lock for agent '{ctx.agent_id}' after automatic retries and cleanup. "
-            f"This usually means another active process is updating this agent. "
-            f"{cleanup_msg}If this persists, try: "
-            f"1) Wait a few seconds and retry, 2) Check for other Cursor/Claude sessions, "
-            f"3) Use cleanup_stale_locks tool, or 4) Restart Cursor if stuck."
-            ,
-            error_code="LOCK_TIMEOUT",
-            error_category="system_error",
-            details={
-                "lock_error": True,
-                "agent_id": ctx.agent_id,
-            },
+        _tick("build_response")
+
+        await run_enrichment_pipeline(ctx)
+        _tick("enrichment")
+
+        try:
+            ctx.response_data = format_response(
+                ctx.response_data,
+                ctx.arguments,
+                meta=ctx.meta,
+                is_new_agent=ctx.is_new_agent,
+                key_was_generated=ctx.key_was_generated,
+                api_key_auto_retrieved=ctx.api_key_auto_retrieved,
+                task_type=ctx.task_type,
+            )
+        except Exception as fmt_err:
+            logger.error(f"Response formatting failed: {fmt_err}", exc_info=True)
+
+        ctx.arguments["lite_response"] = True
+        result = serialize_process_update_response(
+            response_data=ctx.response_data,
+            agent_uuid=ctx.agent_uuid,
             arguments=ctx.arguments,
-        )]
-
-    # --- Everything below runs OUTSIDE the lock ---
-
-    await execute_post_update_effects(ctx)
-
-    ctx.response_data = build_process_update_response_data(
-        result=ctx.result,
-        agent_id=ctx.agent_id,
-        identity_assurance=ctx.identity_assurance,
-        monitor=ctx.monitor,
-    )
-
-    await run_enrichment_pipeline(ctx)
-
-    try:
-        ctx.response_data = format_response(
-            ctx.response_data,
-            ctx.arguments,
-            meta=ctx.meta,
-            is_new_agent=ctx.is_new_agent,
-            key_was_generated=ctx.key_was_generated,
-            api_key_auto_retrieved=ctx.api_key_auto_retrieved,
-            task_type=ctx.task_type,
+            fallback_result=ctx.result,
+            serializer=serializer,
         )
-    except Exception as fmt_err:
-        logger.error(f"Response formatting failed: {fmt_err}", exc_info=True)
-
-    ctx.arguments["lite_response"] = True
-    return serialize_process_update_response(
-        response_data=ctx.response_data,
-        agent_uuid=ctx.agent_uuid,
-        arguments=ctx.arguments,
-        fallback_result=ctx.result,
-        serializer=serializer,
-    )
+        _tick("serialize")
+        return result
+    finally:
+        total_ms = int((time.perf_counter() - _t_total) * 1000)
+        phases_str = " ".join(f"{k}={v}ms" for k, v in _phase_ms.items())
+        logger.info(f"[checkin_phases] total={total_ms}ms {phases_str}")


### PR DESCRIPTION
## Why

Stop-hook check-ins (`process_agent_update`) are hitting a 20s timeout ~35% of the time with a 17.7s mean. Subagent council review split on *where* the latency lives:

- One view: the 29-step enrichment pipeline at `src/mcp_handlers/updates/pipeline.py`.
- Opposing view: Phase 4 (`execute_locked_update`) contains five bare `await` asyncpg calls with no `wait_for` guards (`phases.py:204, 535, 614/637, 667, 689`) — classic anyio-asyncio serialization surface.

There is currently **no per-phase timing instrumentation** anywhere in the update path. We'd be guessing which fix to ship.

## What

Wraps each phase in `run_process_update_workflow` with `time.perf_counter()` deltas, accumulated in a local dict, emitted as one `INFO` line per call in a `finally` block so every return path is covered (early exits, lock timeout, success).

Log format: `[checkin_phases] total=1234ms resolve_identity=42ms onboard_resume=11ms transform=0ms locked_update=891ms post_update=120ms build_response=1ms enrichment=160ms serialize=9ms`

## Scope

- **Pure instrumentation. Zero behavior change.** No new deps, no ordering change, no config.
- Only the workflow file is touched (`src/services/update_workflow_service.py`).
- 6845 tests still pass (2 pre-existing uncovered early-exit branches unchanged).

## How to use

After merge + restart, let real traffic flow through, then:

```bash
grep '\[checkin_phases\]' data/logs/mcp_server.log | awk '{for(i=1;i<=NF;i++) if($i~/=.*ms/) print $i}' | sort | awk -F= '{a[$1]+=$2; n[$1]++} END{for(k in a) printf "%-20s p_avg=%dms n=%d\n", k, a[k]/n[k], n[k]}'
```

Then pick the real fix from data, not speculation.

## Follow-up

Based on the p95 distribution, one of:

1. `asyncio.wait_for(..., timeout=0.5)` on the bare awaits in `phases.py` (if Phase 4 dominates)
2. Detach DB-touching enrichments (orders 130, 150, 170, 210, 215, 220, 250) into a background task, keeping sync enrichments (orders 10–120 + 75) synchronous (if enrichment dominates)
3. Both, if ratio is roughly balanced.