### PR TITLE
feat(dashboard): expose parent_agent_id + render lineage badges

### DIFF
--- a/dashboard/agents.js
+++ b/dashboard/agents.js
@@ -200,6 +200,22 @@
         var agentEISVHistory = state.get('agentEISVHistory') || {};
         var displayAgents = agents.slice(0, state.get('agentPageSize'));
 
+        // Build lineage lookup maps from the full cached set, so a parent
+        // filtered out of the current view still resolves its short label
+        // for a visible child, and child counts reflect the full population.
+        var agentsById = {};
+        var childrenByParent = {};
+        for (var li = 0; li < cachedAgents.length; li++) {
+            var la = cachedAgents[li];
+            var laId = la.agent_id || la.id;
+            if (!laId) continue;
+            agentsById[laId] = la;
+            var pid = la.parent_agent_id;
+            if (pid) {
+                (childrenByParent[pid] = childrenByParent[pid] || []).push(laId);
+            }
+        }
+
         var cardsHtml = displayAgents.map(function (agent) {
             var status = getAgentStatus(agent);
             var statusClass = status === 'paused' ? 'paused' :
@@ -270,6 +286,25 @@
                 : 0;
             var tierDisplayNames = { 0: 'T0', 1: 'T1', 2: 'T2', 3: 'T3' };
             var trustTierHtml = '<span class="trust-tier tier-' + tierNum + '" title="Trust Tier ' + tierNum + ': ' + (tierNames[tierNum] || 'unknown') + '">' + tierDisplayNames[tierNum] + '</span>';
+
+            // Lineage badges: "↑ <parent>" when this agent was spawned from
+            // another, and "<N> child" when other agents declare this one as
+            // their parent. Makes the parent/child relationship visible in
+            // the flat card list.
+            var lineageBadgeHtml = '';
+            var parentId = agent.parent_agent_id;
+            if (parentId) {
+                var parentAgent = agentsById[parentId];
+                var parentShort = parentAgent
+                    ? getAgentDisplayName(parentAgent)
+                    : parentId.slice(0, 8);
+                var spawn = agent.spawn_reason ? ' (' + escapeHtml(agent.spawn_reason) + ')' : '';
+                lineageBadgeHtml += '<span class="lineage-badge lineage-child" data-parent-uuid="' + escapeHtml(parentId) + '" title="Spawned from ' + escapeHtml(parentId) + spawn + '">↑ ' + escapeHtml(parentShort) + '</span>';
+            }
+            var children = childrenByParent[agentId] || [];
+            if (children.length > 0) {
+                lineageBadgeHtml += '<span class="lineage-badge lineage-parent" title="' + children.length + ' child agent(s) declared this as parent">' + children.length + ' child' + (children.length !== 1 ? 'ren' : '') + '</span>';
+            }
 
             var hasMetrics = agentHasMetrics(agent);
             var isPinned = state.get('pinnedAgentId') === agentId;
@@ -345,7 +380,7 @@
                         '<span class="agent-name">' + nameHtml + '</span>' +
                         stuckBadgeHtml + inactiveBadgeHtml +
                         healthBadgeHtml + staleBadgeHtml +
-                        trustTierHtml + anomalyHtml +
+                        trustTierHtml + lineageBadgeHtml + anomalyHtml +
                         sparklineHtml +
                         actionsHtml +
                     '</div>' +
@@ -609,6 +644,41 @@
                     escapeHtml(agent.last_update || '-') +
                 '</div>' +
             '</div>' +
+
+            (function () {
+                // Lineage section — parent and children, resolved against cachedAgents
+                var parentId = agent.parent_agent_id;
+                var all = state.get('cachedAgents') || [];
+                var byIdLocal = {};
+                var childrenLocal = [];
+                for (var ki = 0; ki < all.length; ki++) {
+                    var other = all[ki];
+                    var oid = other.agent_id || other.id;
+                    if (!oid) continue;
+                    byIdLocal[oid] = other;
+                    if (other.parent_agent_id === agentId) childrenLocal.push(other);
+                }
+                if (!parentId && childrenLocal.length === 0) return '';
+                var parentHtml = '-';
+                if (parentId) {
+                    var parentAgent = byIdLocal[parentId];
+                    var parentName = parentAgent ? getAgentDisplayName(parentAgent) : (parentId.slice(0, 12) + '...');
+                    var spawn = agent.spawn_reason ? ' <span class="text-secondary-xs">(' + escapeHtml(agent.spawn_reason) + ')</span>' : '';
+                    parentHtml = '<code class="code-tertiary">' + escapeHtml(parentName) + '</code>' +
+                        '<br><span class="text-secondary-xs">' + escapeHtml(parentId) + '</span>' + spawn;
+                }
+                var childrenHtml = childrenLocal.length
+                    ? childrenLocal.map(function (c) {
+                        var cid = c.agent_id || c.id;
+                        return '<div><code class="code-tertiary">' + escapeHtml(getAgentDisplayName(c)) + '</code>' +
+                            ' <span class="text-secondary-xs">' + escapeHtml(cid) + '</span></div>';
+                    }).join('')
+                    : '<span class="text-secondary-sm">None</span>';
+                return '<div class="grid-2col mb-md">' +
+                    '<div><strong class="text-secondary-sm">Parent:</strong><br>' + parentHtml + '</div>' +
+                    '<div><strong class="text-secondary-sm">Children (' + childrenLocal.length + '):</strong><br>' + childrenHtml + '</div>' +
+                '</div>';
+            })() +
 
             (trustTier !== null
                 ? '<div class="info-callout">' +

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -1357,6 +1357,30 @@ main {
     box-shadow: 0 0 6px rgba(0, 240, 255, 0.2);
 }
 
+/* Lineage badges — parent/child relationships from agent.parent_agent_id */
+.lineage-badge {
+    font-size: 0.7em;
+    padding: 3px 8px;
+    border-radius: 4px;
+    font-family: var(--font-mono);
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+    margin-left: 4px;
+}
+
+.lineage-badge.lineage-child {
+    background: rgba(180, 140, 255, 0.12);
+    color: #b48cff;
+    border: 1px solid rgba(180, 140, 255, 0.3);
+    cursor: help;
+}
+
+.lineage-badge.lineage-parent {
+    background: rgba(255, 170, 80, 0.12);
+    color: #ffaa50;
+    border: 1px solid rgba(255, 170, 80, 0.3);
+}
+
 /* Stuck badge — shown on agent cards when detect_stuck_agents flags them */
 .stuck-badge {
     font-size: 0.7em;

--- a/src/mcp_handlers/lifecycle/query.py
+++ b/src/mcp_handlers/lifecycle/query.py
@@ -130,6 +130,8 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                     "last": meta.last_update[:10] if meta.last_update else None,
                     "last_update": meta.last_update,
                     "trust_tier": getattr(meta, 'trust_tier', None),
+                    "parent_agent_id": getattr(meta, 'parent_agent_id', None),
+                    "spawn_reason": getattr(meta, 'spawn_reason', None),
                 })
             # Sort: labeled first, then by most recent activity
             agents.sort(key=lambda x: (0 if x.get("label") else 1, -(x.get("updates") or 0), x.get("last_update", "") or ""), reverse=False)
@@ -156,6 +158,8 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                         "last": caller_meta.last_update[:10] if caller_meta.last_update else None,
                         "last_update": caller_meta.last_update,
                         "trust_tier": getattr(caller_meta, 'trust_tier', None),
+                        "parent_agent_id": getattr(caller_meta, 'parent_agent_id', None),
+                        "spawn_reason": getattr(caller_meta, 'spawn_reason', None),
                         "you": True,
                     })
 
@@ -280,6 +284,8 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                 "total_updates": meta.total_updates,
                 "tags": meta.tags.copy() if meta.tags else [],
                 "notes": meta.notes if meta.notes else "",
+                "parent_agent_id": getattr(meta, 'parent_agent_id', None),
+                "spawn_reason": getattr(meta, 'spawn_reason', None),
             }
 
             # Lazy load metrics only if requested (optimization)

--- a/tests/test_lifecycle_agents.py
+++ b/tests/test_lifecycle_agents.py
@@ -170,6 +170,33 @@ class TestListAgentsLite:
             assert "labeled-agent" in ids
             assert "unlabeled-agent" not in ids
 
+    @pytest.mark.asyncio
+    async def test_lite_exposes_lineage_fields(self, server):
+        """Lite mode must surface parent_agent_id + spawn_reason so the
+        dashboard can render lineage. Without these fields the DB-level
+        parent/child relationship is invisible downstream (#lineage-visibility).
+        """
+        server.agent_metadata = {
+            "parent-agent": make_agent_meta(label="Parent", total_updates=20),
+            "child-agent": make_agent_meta(
+                label="Child",
+                total_updates=3,
+                parent_agent_id="parent-agent",
+                spawn_reason="new_session",
+            ),
+            "orphan-agent": make_agent_meta(label="Orphan", total_updates=2),
+        }
+        with patch_lifecycle_server(server):
+            from src.mcp_handlers.lifecycle.handlers import handle_list_agents
+            result = await handle_list_agents({"lite": True})
+            data = _parse(result)
+            by_id = {a["id"]: a for a in data["agents"]}
+            assert by_id["child-agent"]["parent_agent_id"] == "parent-agent"
+            assert by_id["child-agent"]["spawn_reason"] == "new_session"
+            assert by_id["parent-agent"]["parent_agent_id"] is None
+            assert by_id["parent-agent"]["spawn_reason"] is None
+            assert by_id["orphan-agent"]["parent_agent_id"] is None
+
 
 # ============================================================================
 # handle_list_agents - Non-Lite (Full) Mode
@@ -276,6 +303,40 @@ class TestListAgentsFull:
             assert data["summary"]["total"] == 10
             assert data["summary"]["offset"] == 2
             assert data["summary"]["limit"] == 3
+
+    @pytest.mark.asyncio
+    async def test_full_mode_exposes_lineage_fields(self, server):
+        """Full mode agent_info must surface parent_agent_id + spawn_reason."""
+        server.agent_metadata = {
+            "parent-agent": make_agent_meta(
+                status="active", label="Parent", total_updates=20, notes=""
+            ),
+            "child-agent": make_agent_meta(
+                status="active",
+                label="Child",
+                total_updates=3,
+                notes="",
+                parent_agent_id="parent-agent",
+                spawn_reason="new_session",
+            ),
+        }
+        health_status = MagicMock()
+        health_status.value = "healthy"
+        server.health_checker = MagicMock()
+        server.health_checker.get_health_status.return_value = (health_status, {})
+        server.monitors = {}
+
+        with patch_lifecycle_server(server):
+            from src.mcp_handlers.lifecycle.handlers import handle_list_agents
+            result = await handle_list_agents({
+                "lite": False, "grouped": False, "include_metrics": False,
+            })
+            data = _parse(result)
+            agents = data["agents"]
+            by_id = {a["agent_id"]: a for a in agents}
+            assert by_id["child-agent"]["parent_agent_id"] == "parent-agent"
+            assert by_id["child-agent"]["spawn_reason"] == "new_session"
+            assert by_id["parent-agent"]["parent_agent_id"] is None
 
     @pytest.mark.asyncio
     async def test_full_mode_status_filter_all(self, server):


### PR DESCRIPTION
## Summary

`core.agents` has stored `parent_agent_id` and `spawn_reason` for weeks (since #47), and the DB cleanly reflects spawn topology — Kenny's main `Claude_Opus_4_7_20260419` agent has 28 child sessions in the last 2 days, some lasting 1–2 minutes before their updates flow back up to the parent UUID. None of that was visible on the dashboard, because `list_agents` never forwarded those fields and `dashboard/agents.js` never rendered them.

Today that's *the* source of the recurring "why does an agent appear for a minute then disappear into the parent?" confusion.

## Changes

- **`src/mcp_handlers/lifecycle/query.py`** — add `parent_agent_id` and `spawn_reason` to both lite and full `list_agents` payloads (including the caller-forced-include branch in lite mode). The in-memory metadata already carries these fields (`src/agent_metadata_model.py:156-157`); the handler just wasn't emitting them.
- **`dashboard/agents.js`** — precompute a `childrenByParent` map from `cachedAgents`, render two badges in the card title row:
  - `↑ <parent-name>` on children, with tooltip showing full parent UUID + spawn_reason
  - `N child(ren)` on parents
  - Detail modal gains a dedicated Parent / Children block.
- **`dashboard/styles.css`** — purple `.lineage-child` and orange `.lineage-parent` badges, consistent with the existing trust-tier/stale badge vocabulary.
- **`tests/test_lifecycle_agents.py`** — new test cases for lite and full mode that lock the wire contract (parent_agent_id + spawn_reason present for children, `None` for roots).

## Test plan

- [x] `./scripts/dev/test-cache.sh --fresh` — 6825 passed, 33 skipped (baseline was 6823; +2 new tests)
- [x] `node --check` on `agents.js` (syntax clean)
- [ ] Visual: open the dashboard, confirm parent/child badges appear on the Claude Code session clusters (e.g. `Claude_Opus_4_7_20260419` shows "28 children"; its children show "↑ Claude_Opus_4_7_20260419")

## Context

Paired with the session where we verified Vigil is *not* over-archiving — the auto-sweep was removed Apr 17–19 (PRs #39, #48, `a3797182`). The lingering "something's off with the agent list" feeling came from this lineage-invisibility problem, not from archival aggression.