### PR TITLE
Bound recent_decisions and _baseline_cache in governance_core/ethical_drift

### DIFF
--- a/governance_core/ethical_drift.py
+++ b/governance_core/ethical_drift.py
@@ -34,10 +34,25 @@ scalar an agent can emit at check-in time.
 """
 
 from __future__ import annotations
+from collections import OrderedDict, deque
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, Deque
 import math
+import os
+
+
+# Per-agent decision-history window. Bounded by deque(maxlen=...) on
+# AgentBaseline.recent_decisions so updates can't grow the buffer.
+_RECENT_DECISIONS_MAXLEN = 20
+
+# In-memory baseline cache size cap. Beyond this, least-recently-used
+# entries are evicted; the next access for an evicted agent_id triggers
+# a reload from PostgreSQL via src/mcp_handlers/updates/phases.py:667
+# (load_agent_baseline), so eviction is loss-free as long as write-back
+# at phases.py:1042 (save_agent_baseline) keeps the DB current.
+# Override via UNITARES_BASELINE_CACHE_MAXLEN env var.
+_BASELINE_CACHE_MAXLEN = int(os.environ.get("UNITARES_BASELINE_CACHE_MAXLEN", "1000"))
 
 
 @dataclass
@@ -161,8 +176,12 @@ class AgentBaseline:
     baseline_confidence: float = 0.6
     baseline_complexity: float = 0.4
 
-    # Decision pattern tracking
-    recent_decisions: List[str] = field(default_factory=list)  # Last N decision outcomes
+    # Decision pattern tracking — bounded by deque(maxlen=...) so the
+    # buffer can't grow past _RECENT_DECISIONS_MAXLEN regardless of how
+    # many updates land.
+    recent_decisions: Deque[str] = field(
+        default_factory=lambda: deque(maxlen=_RECENT_DECISIONS_MAXLEN)
+    )
     decision_consistency: float = 0.8  # How consistent are decisions
 
     # Update count for weighting
@@ -212,11 +231,9 @@ class AgentBaseline:
             self.prev_complexity = complexity  # Raw observation for rate-of-change
 
         if decision is not None:
+            # deque(maxlen=_RECENT_DECISIONS_MAXLEN) auto-evicts the oldest
+            # entry on append once full, so no manual trim is needed.
             self.recent_decisions.append(decision)
-            # Keep only last 20 decisions
-            if len(self.recent_decisions) > 20:
-                self.recent_decisions = self.recent_decisions[-20:]
-            # Compute consistency as mode frequency
             self._update_decision_consistency()
 
         self.update_count += 1
@@ -253,7 +270,7 @@ class AgentBaseline:
             'prev_coherence': self.prev_coherence,
             'prev_confidence': self.prev_confidence,
             'prev_complexity': self.prev_complexity,
-            'recent_decisions': self.recent_decisions,
+            'recent_decisions': list(self.recent_decisions),
             'decision_consistency': self.decision_consistency,
             'update_count': self.update_count,
             'alpha': self.alpha,
@@ -270,7 +287,9 @@ class AgentBaseline:
         baseline.prev_coherence = data.get('prev_coherence')
         baseline.prev_confidence = data.get('prev_confidence')
         baseline.prev_complexity = data.get('prev_complexity')
-        baseline.recent_decisions = data.get('recent_decisions', [])
+        baseline.recent_decisions = deque(
+            data.get('recent_decisions', []), maxlen=_RECENT_DECISIONS_MAXLEN
+        )
         baseline.decision_consistency = data.get('decision_consistency', 0.8)
         baseline.update_count = data.get('update_count', 0)
         baseline.alpha = data.get('alpha', 0.1)
@@ -393,33 +412,54 @@ def compute_ethical_drift(
     )
 
 
-# Baseline storage (in-memory, can be extended to Redis)
-_baseline_cache: Dict[str, AgentBaseline] = {}
+# Baseline storage — bounded LRU. Eviction is loss-free as long as the
+# write-back at src/mcp_handlers/updates/phases.py:1042 keeps the DB
+# current. Cap is _BASELINE_CACHE_MAXLEN (env-overridable).
+_baseline_cache: "OrderedDict[str, AgentBaseline]" = OrderedDict()
+
+
+def _touch_lru(agent_id: str) -> None:
+    """Mark agent_id as most-recently-used in the cache."""
+    _baseline_cache.move_to_end(agent_id)
+
+
+def _evict_if_over_cap() -> None:
+    """Drop the least-recently-used entry if cache exceeds the cap."""
+    while len(_baseline_cache) > _BASELINE_CACHE_MAXLEN:
+        _baseline_cache.popitem(last=False)
 
 
 def get_agent_baseline(agent_id: str) -> AgentBaseline:
-    """Get or create baseline for an agent."""
-    if agent_id not in _baseline_cache:
-        _baseline_cache[agent_id] = AgentBaseline(agent_id=agent_id)
-    return _baseline_cache[agent_id]
+    """Get or create baseline for an agent (LRU-touched on access)."""
+    if agent_id in _baseline_cache:
+        _touch_lru(agent_id)
+        return _baseline_cache[agent_id]
+    baseline = AgentBaseline(agent_id=agent_id)
+    _baseline_cache[agent_id] = baseline
+    _evict_if_over_cap()
+    return baseline
 
 
 def clear_baseline(agent_id: str):
     """Clear baseline for an agent (for testing or reset)."""
-    if agent_id in _baseline_cache:
-        del _baseline_cache[agent_id]
+    _baseline_cache.pop(agent_id, None)
 
 
 def get_all_baselines() -> Dict[str, AgentBaseline]:
-    """Get all baselines (for debugging/inspection)."""
-    return _baseline_cache.copy()
+    """Get all baselines (for debugging/inspection). Snapshot copy."""
+    return dict(_baseline_cache)
 
 
 def set_agent_baseline(agent_id: str, baseline: AgentBaseline) -> None:
-    """Preload a baseline (e.g., from persistent storage)."""
+    """Preload a baseline (e.g., from persistent storage). LRU-touched."""
     _baseline_cache[agent_id] = baseline
+    _touch_lru(agent_id)
+    _evict_if_over_cap()
 
 
 def get_baseline_or_none(agent_id: str) -> Optional[AgentBaseline]:
-    """Get baseline if cached, without creating a default."""
-    return _baseline_cache.get(agent_id)
+    """Get baseline if cached, without creating a default. LRU-touched on hit."""
+    if agent_id in _baseline_cache:
+        _touch_lru(agent_id)
+        return _baseline_cache[agent_id]
+    return None

--- a/tests/test_baseline_bounds.py
+++ b/tests/test_baseline_bounds.py
@@ -1,0 +1,115 @@
+"""Bounds tests for governance_core.ethical_drift.
+
+Watcher P002 (#ce53e83b, #b00276b6) flagged unbounded growth in:
+  - AgentBaseline.recent_decisions  (line 216)
+  - _baseline_cache global dict     (line 398)
+
+Both are now structurally bounded — recent_decisions via deque(maxlen=...),
+_baseline_cache via OrderedDict + LRU eviction at _BASELINE_CACHE_MAXLEN.
+These tests pin that behavior so regressions fail in CI rather than as
+slow memory growth in production.
+"""
+from __future__ import annotations
+
+from collections import deque
+
+import pytest
+
+from governance_core import (
+    AgentBaseline,
+    clear_baseline,
+    get_agent_baseline,
+    get_baseline_or_none,
+    set_agent_baseline,
+)
+from governance_core import ethical_drift as ed
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache():
+    """Each test gets a clean baseline cache."""
+    snapshot = ed._baseline_cache.copy()
+    ed._baseline_cache.clear()
+    yield
+    ed._baseline_cache.clear()
+    ed._baseline_cache.update(snapshot)
+
+
+def test_recent_decisions_capped_at_maxlen():
+    baseline = AgentBaseline(agent_id="cap-test")
+    for i in range(ed._RECENT_DECISIONS_MAXLEN * 5):
+        baseline.update(decision=f"d{i}")
+    assert len(baseline.recent_decisions) == ed._RECENT_DECISIONS_MAXLEN
+    # Most recent decision is preserved; oldest is evicted
+    assert baseline.recent_decisions[-1] == f"d{ed._RECENT_DECISIONS_MAXLEN * 5 - 1}"
+    assert baseline.recent_decisions[0] == f"d{ed._RECENT_DECISIONS_MAXLEN * 4}"
+
+
+def test_recent_decisions_is_deque():
+    baseline = AgentBaseline(agent_id="type-test")
+    assert isinstance(baseline.recent_decisions, deque)
+    assert baseline.recent_decisions.maxlen == ed._RECENT_DECISIONS_MAXLEN
+
+
+def test_recent_decisions_roundtrip_serializes_as_list():
+    """to_dict/from_dict preserve content and re-bound on deserialize."""
+    baseline = AgentBaseline(agent_id="roundtrip")
+    for i in range(50):
+        baseline.update(decision=f"d{i}")
+    serialized = baseline.to_dict()
+    assert isinstance(serialized["recent_decisions"], list)
+    assert len(serialized["recent_decisions"]) == ed._RECENT_DECISIONS_MAXLEN
+
+    restored = AgentBaseline.from_dict(serialized)
+    assert isinstance(restored.recent_decisions, deque)
+    assert restored.recent_decisions.maxlen == ed._RECENT_DECISIONS_MAXLEN
+    assert list(restored.recent_decisions) == serialized["recent_decisions"]
+
+
+def test_from_dict_caps_oversized_input():
+    """from_dict on a list larger than maxlen drops the oldest entries."""
+    oversized = [f"d{i}" for i in range(ed._RECENT_DECISIONS_MAXLEN + 100)]
+    baseline = AgentBaseline.from_dict({"agent_id": "oversized", "recent_decisions": oversized})
+    assert len(baseline.recent_decisions) == ed._RECENT_DECISIONS_MAXLEN
+    assert baseline.recent_decisions[-1] == oversized[-1]
+
+
+def test_baseline_cache_evicts_lru(monkeypatch):
+    """Beyond _BASELINE_CACHE_MAXLEN, oldest-touched entry is evicted."""
+    monkeypatch.setattr(ed, "_BASELINE_CACHE_MAXLEN", 3)
+    a = get_agent_baseline("a")
+    b = get_agent_baseline("b")
+    c = get_agent_baseline("c")
+    assert set(ed._baseline_cache.keys()) == {"a", "b", "c"}
+
+    # 'a' is now LRU. Touching 'b' moves it to MRU.
+    get_agent_baseline("b")
+    # Adding 'd' triggers eviction of 'a' (still LRU), not 'b' or 'c'.
+    get_agent_baseline("d")
+    assert set(ed._baseline_cache.keys()) == {"b", "c", "d"}
+
+
+def test_baseline_cache_get_baseline_or_none_touches_lru(monkeypatch):
+    monkeypatch.setattr(ed, "_BASELINE_CACHE_MAXLEN", 2)
+    get_agent_baseline("x")
+    get_agent_baseline("y")
+    # 'x' is LRU.
+    assert get_baseline_or_none("x") is not None  # touches → MRU
+    get_agent_baseline("z")  # evicts LRU, which is now 'y'
+    assert "x" in ed._baseline_cache
+    assert "y" not in ed._baseline_cache
+    assert "z" in ed._baseline_cache
+
+
+def test_baseline_cache_set_evicts(monkeypatch):
+    monkeypatch.setattr(ed, "_BASELINE_CACHE_MAXLEN", 2)
+    set_agent_baseline("a", AgentBaseline(agent_id="a"))
+    set_agent_baseline("b", AgentBaseline(agent_id="b"))
+    set_agent_baseline("c", AgentBaseline(agent_id="c"))
+    assert "a" not in ed._baseline_cache
+    assert {"b", "c"} <= set(ed._baseline_cache.keys())
+
+
+def test_clear_baseline_pop_missing_is_noop():
+    """clear_baseline is safe to call on an absent agent_id."""
+    clear_baseline("never-existed")  # must not raise


### PR DESCRIPTION
## Summary

Resolves two Watcher P002 findings that surfaced after the governance_core fold (#132):

| Fingerprint | Location | Issue | Fix |
|---|---|---|---|
| #ce53e83b | `governance_core/ethical_drift.py:216` | `recent_decisions` had imperative trim (append + len-check + slice reassign) | `Deque[str]` with `maxlen=20` — structurally bounded |
| #b00276b6 | `governance_core/ethical_drift.py:398` | `_baseline_cache` was an unbounded `Dict` growing per agent_id forever | `OrderedDict` + LRU eviction at `_BASELINE_CACHE_MAXLEN` (default 1000, env-overridable) |

## Why this matters

The `_baseline_cache` was the bigger of the two: with 2,574+ process-instances onboarded, the cache previously grew forever. Slow memory leak on long-lived `governance-mcp` processes. Eviction is loss-free because:

- `src/mcp_handlers/updates/phases.py:667` reloads from Postgres on cache miss
- `src/mcp_handlers/updates/phases.py:1042` writes back on update

So an evicted baseline rehydrates correctly on next access — provided write-back is keeping pace, which the existing pipeline guarantees.

The `recent_decisions` finding was smaller (the 20-entry cap WAS applied, just imperatively). Switching to `deque(maxlen=20)` enforces the bound structurally and removes a brittle pattern.

## Tests

`tests/test_baseline_bounds.py` — 8 new tests:

- `test_recent_decisions_capped_at_maxlen` — many appends → still 20
- `test_recent_decisions_is_deque` — type + maxlen invariant
- `test_recent_decisions_roundtrip_serializes_as_list` — to_dict/from_dict preserves bound
- `test_from_dict_caps_oversized_input` — historical data with > 20 entries gets capped on load
- `test_baseline_cache_evicts_lru` — LRU ordering correctness
- `test_baseline_cache_get_baseline_or_none_touches_lru` — read access counts as touch
- `test_baseline_cache_set_evicts` — set_agent_baseline triggers eviction at cap
- `test_clear_baseline_pop_missing_is_noop` — clear safe on absent keys

Local: 195 of the governance_core suite passing (187 prior + 8 new).

## Test plan

- [x] Local: 195/195 passed in 1.61s
- [ ] CI: smoke + test (3.12) green
- [ ] Watcher findings #ce53e83b and #b00276b6 resolved (referenced in commit message per `CLAUDE.md` audit-trail policy)