### PR TITLE
S1-a: narrow continuity_token TTL to 1h + ownership_proof_version

### DIFF
--- a/src/audit_log.py
+++ b/src/audit_log.py
@@ -365,6 +365,39 @@ class AuditLogger:
         )
         self._write_entry(entry)
 
+    def log_continuity_token_deprecated_accept(
+        self,
+        *,
+        agent_id: str,
+        caller_channel: Optional[str],
+        caller_model_type: Optional[str],
+        issued_at: int,
+        accepted_at: int,
+        agent_uuid: str,
+    ) -> None:
+        """S1-a (2026-04-24) — grace-period telemetry for cross-instance token resume.
+
+        Fires when a caller invokes onboard() with a continuity_token and
+        without force_new=true. The retired cross-process-instance resume path.
+        See docs/ontology/s1-continuity-token-retirement.md §4.3, §6.
+        """
+        lifetime_seconds = max(0, int(accepted_at) - int(issued_at))
+        entry = AuditEntry(
+            timestamp=datetime.now().isoformat(),
+            agent_id=agent_id,
+            event_type="continuity_token_deprecated_accept",
+            confidence=1.0,
+            details={
+                "caller_channel": caller_channel,
+                "caller_model_type": caller_model_type,
+                "issued_at": int(issued_at),
+                "accepted_at": int(accepted_at),
+                "lifetime_seconds": lifetime_seconds,
+                "agent_uuid": agent_uuid,
+            },
+        )
+        self._write_entry(entry)
+
     def _write_entry(self, entry: AuditEntry):
         """Write audit entry to JSONL log file with locking"""
         entry_dict = asdict(entry)

--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -43,7 +43,9 @@ from .session import (
     create_continuity_token,
     resolve_continuity_token,
     extract_token_agent_uuid,
+    extract_token_iat,
     continuity_token_support_status,
+    build_token_deprecation_block,
 )
 
 # --- identity_persistence ---
@@ -1663,6 +1665,36 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
         system_activity=_get_system_evidence() if verbose else None,
         tool_mode_info=tool_mode_info,
     )
+
+    # S1-a (2026-04-24): grace-period deprecation surface. onboard() called
+    # with continuity_token AND without force_new=true is the retired
+    # cross-process-instance resume path. Emit a warning in the response and
+    # a grace-period audit event so callers can migrate and operators can
+    # observe the tail. See docs/ontology/s1-continuity-token-retirement.md §4.3 / §6.
+    # `force_new` is set once at the top of this handler (L1180) from arguments
+    # and never reassigned — signal is honest.
+    _caller_token = arguments.get("continuity_token")
+    if _caller_token and not force_new:
+        _issued_at = extract_token_iat(str(_caller_token))
+        _dep_block = build_token_deprecation_block(
+            used_token_for_resume=True,
+            token_issued_at=_issued_at,
+        )
+        if _dep_block is not None:
+            result.setdefault("deprecations", []).append(_dep_block)
+        try:
+            import time as _time
+            from src.audit_log import audit_logger as _audit
+            _audit.log_continuity_token_deprecated_accept(
+                agent_id=response_agent_id,
+                caller_channel=client_hint,
+                caller_model_type=model_type,
+                issued_at=_issued_at if _issued_at is not None else 0,
+                accepted_at=int(_time.time()),
+                agent_uuid=agent_uuid,
+            )
+        except Exception as _audit_err:
+            logger.debug(f"[S1-a] deprecated-accept audit write failed (non-fatal): {_audit_err}")
 
     # Temporal narrator — contextual time awareness (silence by default)
     try:

--- a/src/mcp_handlers/identity/session.py
+++ b/src/mcp_handlers/identity/session.py
@@ -18,19 +18,77 @@ from src.logging_utils import get_logger
 
 logger = get_logger(__name__)
 
+_S1_DEPRECATION_SUNSET = "2026-Q4"  # operator-set placeholder; see s1 doc §11
 _PIN_TTL = 1800  # 30 minutes — refresh on use
-_CONTINUITY_TTL = 30 * 24 * 3600  # 30 days
+# S1-a (2026-04-24): shrunk from 30 days to 1 hour as part of continuity_token
+# retirement-via-narrowing. See docs/ontology/s1-continuity-token-retirement.md §4.1.
+# TTL-only is not process-instance binding; this is honestly "performative, narrowed".
+# A′ (PID/nonce binding) is the follow-on for actual earned process-scope.
+_CONTINUITY_TTL = 3600  # 1 hour
+_OWNERSHIP_PROOF_VERSION = 1  # bump to 2 when A′ lands; to 3 when R1-composite ships
 
 
 def continuity_token_support_status() -> Dict[str, Any]:
     """Return continuity token support details for diagnostics."""
     if os.getenv("UNITARES_CONTINUITY_TOKEN_SECRET"):
-        return {"enabled": True, "secret_source": "UNITARES_CONTINUITY_TOKEN_SECRET"}
+        return {
+            "enabled": True,
+            "secret_source": "UNITARES_CONTINUITY_TOKEN_SECRET",
+            "ownership_proof_version": _OWNERSHIP_PROOF_VERSION,
+        }
     if os.getenv("UNITARES_HTTP_API_TOKEN"):
-        return {"enabled": True, "secret_source": "UNITARES_HTTP_API_TOKEN"}
+        return {
+            "enabled": True,
+            "secret_source": "UNITARES_HTTP_API_TOKEN",
+            "ownership_proof_version": _OWNERSHIP_PROOF_VERSION,
+        }
     if os.getenv("UNITARES_API_TOKEN"):
-        return {"enabled": True, "secret_source": "UNITARES_API_TOKEN"}
+        return {
+            "enabled": True,
+            "secret_source": "UNITARES_API_TOKEN",
+            "ownership_proof_version": _OWNERSHIP_PROOF_VERSION,
+        }
     return {"enabled": False, "secret_source": None}
+
+
+def build_token_deprecation_block(
+    *,
+    used_token_for_resume: bool,
+    token_issued_at: Optional[int] = None,
+) -> Optional[Dict[str, Any]]:
+    """Return a deprecation-warning dict for cross-instance resume, or None.
+
+    S1-a (2026-04-24): onboard() called with continuity_token (without
+    force_new=true) is the retired cross-process-instance resume path. During
+    the grace period the server still accepts these but emits a warning in
+    the response so callers can migrate.
+
+    Intra-session uses (mid-session identity() rebind, request auth via
+    continuity_token on process_agent_update, etc.) are NOT deprecated —
+    they're role (3) from s1 doc §1, the anti-hijack proof-of-ownership
+    surface that Part-C relies on.
+
+    Args:
+        used_token_for_resume: True iff onboard was called with
+            continuity_token and without force_new=true.
+        token_issued_at: Token's `iat` claim. Optional; carried through for
+            grace-period telemetry if the caller has it handy.
+    """
+    if not used_token_for_resume:
+        return None
+    block: Dict[str, Any] = {
+        "field": "continuity_token",
+        "severity": "warning",
+        "message": (
+            "cross-process-instance resume via continuity_token is deprecated; "
+            "declare lineage via parent_agent_id on force_new=true. "
+            "See docs/ontology/s1-continuity-token-retirement.md."
+        ),
+        "sunset": _S1_DEPRECATION_SUNSET,
+    }
+    if token_issued_at is not None:
+        block["token_issued_at"] = int(token_issued_at)
+    return block
 
 
 def _b64url_encode(data: bytes) -> str:
@@ -70,6 +128,7 @@ def create_continuity_token(
     now = int(time.time())
     payload = {
         "v": 1,
+        "opv": _OWNERSHIP_PROOF_VERSION,  # S1-a: forward-compat ownership-proof schema version
         "sid": str(client_session_id),
         "aid": str(agent_uuid),
         "mf": _normalize_pin_model_type(model_type),
@@ -81,6 +140,35 @@ def create_continuity_token(
     payload_b64 = _b64url_encode(payload_json)
     sig_b64 = _b64url_encode(hmac.new(secret, payload_b64.encode(), hashlib.sha256).digest())
     return f"v1.{payload_b64}.{sig_b64}"
+
+
+def extract_token_iat(token: str) -> Optional[int]:
+    """Extract the `iat` (issued-at) claim from a continuity token.
+
+    Signature-verified like `extract_token_agent_uuid`; does NOT check expiry.
+    Returned for grace-period telemetry under S1-a (docs/ontology/
+    s1-continuity-token-retirement.md §6) — callers need `iat` to compute
+    token lifetime at accept-time.
+    """
+    if not token or not isinstance(token, str):
+        return None
+    secret = _get_continuity_secret()
+    if not secret:
+        return None
+    try:
+        version, payload_b64, sig_b64 = token.split(".", 2)
+        if version != "v1":
+            return None
+        expected_sig = _b64url_encode(hmac.new(secret, payload_b64.encode(), hashlib.sha256).digest())
+        if not hmac.compare_digest(expected_sig, sig_b64):
+            return None
+        payload = json.loads(_b64url_decode(payload_b64).decode())
+        iat = payload.get("iat")
+        if iat is None:
+            return None
+        return int(iat)
+    except Exception:
+        return None
 
 
 def extract_token_agent_uuid(token: str) -> Optional[str]:

--- a/src/services/identity_payloads.py
+++ b/src/services/identity_payloads.py
@@ -36,6 +36,9 @@ def build_identity_response_data(
             "display_name": display_name,
         },
     }
+    # S1-a: surface ownership_proof_version at top level (see build_onboard_response_data).
+    if continuity_support.get("ownership_proof_version") is not None:
+        response_data["ownership_proof_version"] = continuity_support["ownership_proof_version"]
     if model_type:
         response_data["model_type"] = model_type
     if continuity_token:
@@ -209,6 +212,11 @@ def build_onboard_response_data(
         "date_context": {"date": datetime.now().strftime("%Y-%m-%d"), "source": "mcp-server"},
         "next_step": "Call process_agent_update with response_text describing your work",
     }
+    # S1-a (2026-04-24): surface ownership_proof_version at top level so log
+    # consumers and dashboards don't have to dig into the token payload or
+    # rely on verbose=True. See docs/ontology/s1-continuity-token-retirement.md §4.5.
+    if continuity_support.get("ownership_proof_version") is not None:
+        result["ownership_proof_version"] = continuity_support["ownership_proof_version"]
 
     if verbose:
         result["welcome_message"] = welcome_message

--- a/tests/test_s1_continuity_token_narrow.py
+++ b/tests/test_s1_continuity_token_narrow.py
@@ -1,0 +1,420 @@
+"""S1-a — continuity_token retirement, narrowed.
+
+Tests the TTL shrink, ownership_proof_version schema extension, and
+deprecation-warning emission per docs/ontology/s1-continuity-token-retirement.md
+§4.1, §4.3, §4.5.
+
+Reference: S1 plan doc §7 risks require regression coverage for:
+- PATH-0-with-expired-token (Part-C invariant preserved under short TTL)
+- TTL-boundary behavior (token valid at edge, rejected just past)
+- ownership_proof_version surfaces in payload and response
+- deprecation warning fires only on cross-instance resume (onboard+token)
+- deprecation does NOT fire on intra-session continuity_token use
+"""
+from __future__ import annotations
+
+import base64
+import json
+import time
+from unittest.mock import patch
+
+import pytest
+
+
+# -----------------------------------------------------------------------------
+# 4.1 TTL shrink
+# -----------------------------------------------------------------------------
+
+
+def test_continuity_ttl_is_one_hour():
+    """Per S1-a: _CONTINUITY_TTL shrinks from 30 days to 1 hour (3600s).
+
+    This is the operator-approved value. Threshold is a convenience anchor,
+    not threat-model-derived — see s1 doc §11.2.
+    """
+    from src.mcp_handlers.identity import session as session_mod
+
+    assert session_mod._CONTINUITY_TTL == 3600, (
+        f"S1-a expects 1h TTL (3600s); got {session_mod._CONTINUITY_TTL}"
+    )
+
+
+def test_token_issued_with_default_ttl_carries_1h_expiry():
+    """Newly-minted token's exp claim reflects the shrunk TTL."""
+    from src.mcp_handlers.identity.session import create_continuity_token
+
+    with patch.dict("os.environ", {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-secret"}, clear=False):
+        before = int(time.time())
+        token = create_continuity_token(
+            "11111111-2222-3333-4444-555555555555",
+            "agent-111:claude",
+        )
+        after = int(time.time())
+
+    assert token is not None and token.startswith("v1.")
+    _, payload_b64, _ = token.split(".", 2)
+    payload = json.loads(_b64url_decode(payload_b64))
+
+    expiry_offset = payload["exp"] - payload["iat"]
+    assert expiry_offset == 3600, (
+        f"expected 3600s offset, got {expiry_offset}"
+    )
+    assert before <= payload["iat"] <= after
+
+
+def test_resolve_rejects_expired_token_at_ttl_boundary():
+    """Token valid 1s before expiry; rejected 1s after.
+
+    S1 doc §7.2 flags clock-skew near boundary as a new code path under short TTL.
+    This test pins the strict-expiry semantics; any loosening must be deliberate.
+    """
+    from src.mcp_handlers.identity.session import (
+        create_continuity_token,
+        resolve_continuity_token,
+    )
+
+    with patch.dict("os.environ", {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-secret"}, clear=False):
+        token = create_continuity_token(
+            "11111111-2222-3333-4444-555555555555",
+            "agent-111:claude",
+        )
+        assert token is not None
+
+        # Token valid now
+        resolved = resolve_continuity_token(token)
+        assert resolved == "agent-111:claude"
+
+        # Freeze "now" to 1s past expiry — resolve must reject
+        now = int(time.time()) + 3601
+        with patch("src.mcp_handlers.identity.session.time.time", return_value=now):
+            assert resolve_continuity_token(token) is None
+
+
+# -----------------------------------------------------------------------------
+# 4.5 ownership_proof_version schema extension
+# -----------------------------------------------------------------------------
+
+
+def test_token_payload_carries_opv_field():
+    """JWT payload gains "opv": 1. Forward-compat: future A′/B bump to 2/3."""
+    from src.mcp_handlers.identity.session import create_continuity_token
+
+    with patch.dict("os.environ", {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-secret"}, clear=False):
+        token = create_continuity_token(
+            "11111111-2222-3333-4444-555555555555",
+            "agent-111:claude",
+        )
+
+    assert token is not None
+    _, payload_b64, _ = token.split(".", 2)
+    payload = json.loads(_b64url_decode(payload_b64))
+    assert payload.get("opv") == 1, (
+        f"expected opv=1 in payload, got {payload!r}"
+    )
+
+
+def test_continuity_support_status_exposes_ownership_proof_version():
+    """Diagnostic surface surfaces the version for log consumers + dashboards."""
+    from src.mcp_handlers.identity.session import continuity_token_support_status
+
+    with patch.dict("os.environ", {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-secret"}, clear=False):
+        status = continuity_token_support_status()
+
+    assert status["enabled"] is True
+    assert status.get("ownership_proof_version") == 1
+
+
+def test_continuity_support_status_omits_version_when_disabled():
+    """No secret = no token, no version — cleanly disabled state."""
+    from src.mcp_handlers.identity.session import continuity_token_support_status
+
+    # Clear all three possible secret sources
+    with patch.dict(
+        "os.environ",
+        {
+            "UNITARES_CONTINUITY_TOKEN_SECRET": "",
+            "UNITARES_HTTP_API_TOKEN": "",
+            "UNITARES_API_TOKEN": "",
+        },
+        clear=False,
+    ):
+        status = continuity_token_support_status()
+
+    assert status["enabled"] is False
+    assert "ownership_proof_version" not in status or status.get("ownership_proof_version") is None
+
+
+# -----------------------------------------------------------------------------
+# 4.3 Deprecation warning emission
+# -----------------------------------------------------------------------------
+
+
+def test_build_token_deprecation_block_for_resume():
+    """onboard+token (without force_new) is the retiring cross-instance resume path.
+
+    S1 doc §4.3: grace-period warning fires for this case.
+    """
+    from src.mcp_handlers.identity.session import build_token_deprecation_block
+
+    block = build_token_deprecation_block(
+        used_token_for_resume=True,
+        token_issued_at=int(time.time()) - 60,
+    )
+
+    assert block is not None
+    assert block["field"] == "continuity_token"
+    assert block["severity"] == "warning"
+    assert "deprecated" in block["message"].lower()
+    assert "parent_agent_id" in block["message"]
+    assert "force_new=true" in block["message"]
+    assert "sunset" in block
+
+
+def test_no_deprecation_for_non_resume_usage():
+    """Intra-session token use (request auth, mid-session identity calls) is NOT deprecated.
+
+    Only the onboard+token cross-instance resume path warns. S1 doc §4.3.
+    """
+    from src.mcp_handlers.identity.session import build_token_deprecation_block
+
+    assert build_token_deprecation_block(used_token_for_resume=False) is None
+
+
+# -----------------------------------------------------------------------------
+# 4.3 audit event
+# -----------------------------------------------------------------------------
+
+
+def test_audit_log_has_continuity_token_deprecated_accept_method(tmp_path):
+    """Audit sink has a typed method for the grace-period event per S1 doc §6."""
+    from src.audit_log import AuditLogger
+
+    audit = AuditLogger(log_file=tmp_path / "audit.jsonl")
+    assert hasattr(audit, "log_continuity_token_deprecated_accept"), (
+        "expected log_continuity_token_deprecated_accept on AuditLog"
+    )
+
+    # Method accepts the §6-specified fields and writes a JSONL entry.
+    audit.log_continuity_token_deprecated_accept(
+        agent_id="agent-xyz",
+        caller_channel="claude_code",
+        caller_model_type="claude",
+        issued_at=int(time.time()) - 600,
+        accepted_at=int(time.time()),
+        agent_uuid="11111111-2222-3333-4444-555555555555",
+    )
+
+    logged = (tmp_path / "audit.jsonl").read_text().strip()
+    assert logged, "expected one JSONL entry"
+    entry = json.loads(logged.splitlines()[-1])
+    assert entry["event_type"] == "continuity_token_deprecated_accept"
+    details = entry["details"]
+    assert details["caller_channel"] == "claude_code"
+    assert details["caller_model_type"] == "claude"
+    assert details["agent_uuid"] == "11111111-2222-3333-4444-555555555555"
+    assert isinstance(details["lifetime_seconds"], int)
+    assert details["lifetime_seconds"] >= 0
+
+
+# -----------------------------------------------------------------------------
+# Part-C invariant regression (§7.2)
+# -----------------------------------------------------------------------------
+
+
+def test_part_c_extract_token_agent_uuid_survives_expiry():
+    """extract_token_agent_uuid deliberately ignores exp (Part-C / PR #42).
+
+    Under short TTL this matters more, not less: residents idle past TTL still
+    need signature-verification to work for identity lookup. This test pins
+    the existing contract — any future refactor that enforces exp here breaks
+    Part-C.
+    """
+    from src.mcp_handlers.identity.session import (
+        create_continuity_token,
+        extract_token_agent_uuid,
+    )
+
+    with patch.dict("os.environ", {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-secret"}, clear=False):
+        token = create_continuity_token(
+            "11111111-2222-3333-4444-555555555555",
+            "agent-xyz",
+        )
+        assert token is not None
+
+        # Sim token aged well past 1h TTL
+        future = int(time.time()) + 7200
+        with patch("src.mcp_handlers.identity.session.time.time", return_value=future):
+            # resolve_continuity_token rejects (enforces exp)
+            from src.mcp_handlers.identity.session import resolve_continuity_token
+            assert resolve_continuity_token(token) is None
+            # extract_token_agent_uuid still returns aid (ignores exp — Part C)
+            assert extract_token_agent_uuid(token) == "11111111-2222-3333-4444-555555555555"
+
+
+# -----------------------------------------------------------------------------
+# extract_token_iat helper (§6 audit-event dependency)
+# -----------------------------------------------------------------------------
+
+
+def test_extract_token_iat_returns_issued_at():
+    """Grace-period audit needs the token's iat claim at accept time.
+
+    extract_token_iat verifies signature (like extract_token_agent_uuid) but
+    skips expiry — an expired token still carries an honest iat.
+    """
+    from src.mcp_handlers.identity.session import (
+        create_continuity_token,
+        extract_token_iat,
+    )
+
+    with patch.dict("os.environ", {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-secret"}, clear=False):
+        before = int(time.time())
+        token = create_continuity_token(
+            "11111111-2222-3333-4444-555555555555",
+            "agent-iat",
+        )
+        after = int(time.time())
+        iat = extract_token_iat(token)
+
+    assert iat is not None
+    assert before <= iat <= after
+
+
+def test_extract_token_iat_rejects_tampered_token():
+    """Signature mismatch → None (same trust model as extract_token_agent_uuid)."""
+    from src.mcp_handlers.identity.session import extract_token_iat
+
+    with patch.dict("os.environ", {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-secret"}, clear=False):
+        # Construct obviously-malformed token
+        assert extract_token_iat("v1.junk.sig") is None
+        assert extract_token_iat("") is None
+        assert extract_token_iat(None) is None  # type: ignore[arg-type]
+
+
+# -----------------------------------------------------------------------------
+# ownership_proof_version surfaces on top-level response (§4.5)
+# -----------------------------------------------------------------------------
+
+
+def test_onboard_response_surfaces_ownership_proof_version_top_level():
+    """Dashboard + log consumers can read opv without digging into token payload."""
+    from src.services.identity_payloads import build_onboard_response_data
+    from src.mcp_handlers.identity.session import continuity_token_support_status
+
+    with patch.dict("os.environ", {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-secret"}, clear=False):
+        support = continuity_token_support_status()
+
+    result = build_onboard_response_data(
+        agent_uuid="11111111-2222-3333-4444-555555555555",
+        structured_agent_id="agent_11111111",
+        agent_label=None,
+        stable_session_id="agent-111",
+        is_new=True,
+        force_new=False,
+        client_hint="unknown",
+        was_archived=False,
+        trajectory_result=None,
+        parent_agent_id=None,
+        thread_context=None,
+        verbose=False,
+        continuity_source="test",
+        continuity_support=support,
+        continuity_token="v1.dummy.token",
+        system_activity=None,
+        tool_mode_info=None,
+    )
+    assert result.get("ownership_proof_version") == 1
+
+
+def test_identity_response_surfaces_ownership_proof_version_top_level():
+    """Same shape on identity() as onboard() — keep the surface consistent."""
+    from src.services.identity_payloads import build_identity_response_data
+    from src.mcp_handlers.identity.session import continuity_token_support_status
+
+    with patch.dict("os.environ", {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-secret"}, clear=False):
+        support = continuity_token_support_status()
+
+    result = build_identity_response_data(
+        agent_uuid="11111111-2222-3333-4444-555555555555",
+        agent_id="agent_11111111",
+        display_name=None,
+        client_session_id="agent-111",
+        continuity_source="test",
+        continuity_support=support,
+        continuity_token="v1.dummy.token",
+        identity_status="active",
+        model_type=None,
+        resumed=True,
+        session_continuity=None,
+        verbose=False,
+    )
+    assert result.get("ownership_proof_version") == 1
+
+
+def test_response_omits_ownership_proof_version_when_disabled():
+    """When token support is off, the field is absent (not None, not 0)."""
+    from src.services.identity_payloads import build_onboard_response_data
+
+    support_disabled = {"enabled": False, "secret_source": None}
+    result = build_onboard_response_data(
+        agent_uuid="11111111-2222-3333-4444-555555555555",
+        structured_agent_id="agent_11111111",
+        agent_label=None,
+        stable_session_id="agent-111",
+        is_new=True,
+        force_new=False,
+        client_hint="unknown",
+        was_archived=False,
+        trajectory_result=None,
+        parent_agent_id=None,
+        thread_context=None,
+        verbose=False,
+        continuity_source="test",
+        continuity_support=support_disabled,
+        continuity_token=None,
+        system_activity=None,
+        tool_mode_info=None,
+    )
+    assert "ownership_proof_version" not in result
+
+
+# -----------------------------------------------------------------------------
+# §7.3 bind_session inherits the new short TTL
+# -----------------------------------------------------------------------------
+
+
+def test_bind_session_resolve_path_uses_1h_ttl():
+    """bind_session calls resolve_continuity_token (handlers.py:1066) which
+    uses _CONTINUITY_TTL. S1-a's shrink propagates; §7.3 operator call was
+    let-it-propagate. Verify a token past 1h is rejected by the bind_session
+    resolve path — same function, same behavior.
+    """
+    from src.mcp_handlers.identity.session import (
+        create_continuity_token,
+        resolve_continuity_token,
+    )
+
+    with patch.dict("os.environ", {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-secret"}, clear=False):
+        token = create_continuity_token(
+            "11111111-2222-3333-4444-555555555555",
+            "agent-bind-test",
+        )
+        assert token is not None
+
+        # Within TTL — resolves
+        assert resolve_continuity_token(token) == "agent-bind-test"
+
+        # Past 1h TTL — rejected (same gate bind_session hits)
+        past_ttl = int(time.time()) + 3601
+        with patch("src.mcp_handlers.identity.session.time.time", return_value=past_ttl):
+            assert resolve_continuity_token(token) is None
+
+
+# -----------------------------------------------------------------------------
+# helpers
+# -----------------------------------------------------------------------------
+
+
+def _b64url_decode(data: str) -> bytes:
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + padding)


### PR DESCRIPTION
S1-a: narrow continuity_token TTL to 1h + ownership_proof_version + deprecation telemetry

Implements S1 plan doc Option A per docs/ontology/s1-continuity-token-retirement.md §4.1 /
§4.3 / §4.5 / §6 (operator-approved with recommended parameters: 1h TTL, one release
cycle grace, let-it-propagate to bind_session).

Changes
- _CONTINUITY_TTL: 30d -> 3600s (session.py). Honest framing: "performative, narrowed" —
  a TTL-only mechanism does not achieve process-instance binding; A' (PID/nonce bind) is
  the follow-on for actual earned scope.
- ownership_proof_version=1 in JWT payload (opv claim), continuity_support dict, and
  top-level of onboard/identity response bodies. Forward-compat: bump to 2 when A' lands;
  to 3 when R1-composite ships.
- build_token_deprecation_block: emits warning dict for onboard(continuity_token=...)
  without force_new=true — the retired cross-process-instance resume path. Intra-session
  token use (request auth, identity rebind) is NOT deprecated (role 3 preserved for
  Part-C anti-hijack).
- log_continuity_token_deprecated_accept audit event on AuditLogger per §6 — fires
  alongside the deprecation block. Fields: caller_channel, caller_model_type, issued_at,
  accepted_at, lifetime_seconds, agent_uuid.
- extract_token_iat helper in session.py — signature-verified iat extraction without
  expiry check (mirrors extract_token_agent_uuid's Part-C posture).

Tests (16 new in tests/test_s1_continuity_token_narrow.py, all green; full test-cache
passed in worktree)
- TTL = 3600, payload exp offset = 3600
- Strict expiry at TTL boundary (no clock-skew tolerance — deliberate; §7.2)
- opv=1 in payload + support_status + onboard/identity response top-level
- deprecation block fires only for resume, not intra-session use
- audit event JSONL entry shape
- Part-C: extract_token_agent_uuid survives expiry (regression pin)
- bind_session inherits shrunk TTL (§7.3 propagation)
- extract_token_iat signature-verification + edge cases

Out of scope (deferred)
- S1-b: client-side onboard_helper/CLI migration (separate PRs in plugin + unitares)
- S1-c: post-grace cross-instance reject (operator-gated on telemetry)
- S1-d: continuity_token -> ownership_proof field rename (after S1-c)
- A': PID/nonce binding for actual process-instance scope
- §7.4 token-in-logs cardinality hardening

Council review: dialectic-knowledge-architect (plan-doc review, prior commit) +
feature-dev:code-reviewer (this implementation). Two reviewer findings folded in:
(1) top-level ownership_proof_version surface (was verbose-only); (2) bind_session TTL
boundary test added. Reviewer also flagged force_new shadowing risk at the deprecation
detection site — traced L1180->L1674, single assignment, no shadow; comment added at
detection site for future readers.