### PR TITLE
dashboard: dedicated Vigil panel + hide from main Discoveries feed

### DIFF
--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -1336,6 +1336,9 @@ async function loadDiscoveries(searchQuery = '') {
         console.log('Loading discoveries...', searchQuery ? `(search: ${searchQuery})` : '');
 
         // Single API call — get discoveries and derive count from results
+        // Vigil is hidden by default: the Vigil panel (see vigil.js) shows
+        // its groundskeeper stream separately. Searching explicitly still
+        // returns its entries since the user intent is clear.
         const toolArgs = {
             limit: 50,
             include_details: true,
@@ -1343,6 +1346,8 @@ async function loadDiscoveries(searchQuery = '') {
 
         if (searchQuery) {
             toolArgs.query = searchQuery;
+        } else {
+            toolArgs.exclude_agent_labels = ['Vigil'];
         }
 
         const searchResult = await callTool('search_knowledge_graph', toolArgs);

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -33,6 +33,7 @@
     <script src="/dashboard/fleet-metrics.js"></script>
     <script src="/dashboard/watcher.js"></script>
     <script src="/dashboard/sentinel.js"></script>
+    <script src="/dashboard/vigil.js"></script>
 </head>
 
 <body>
@@ -82,6 +83,7 @@
         <a href="#fleet-metrics-section" class="section-nav-item" data-section="fleet-metrics-section">Chronicler</a>
         <a href="#watcher-section" class="section-nav-item" data-section="watcher-section">Watcher</a>
         <a href="#sentinel-section" class="section-nav-item" data-section="sentinel-section">Sentinel</a>
+        <a href="#vigil-section" class="section-nav-item" data-section="vigil-section">Vigil</a>
         <a href="/phase" style="margin-left:auto; opacity:0.6; padding:6px 14px; border-radius:20px; font-size:0.8rem; font-weight:500; color:var(--text-secondary); text-decoration:none; white-space:nowrap;">Phase Space &rarr;</a>
     </nav>
 
@@ -575,6 +577,48 @@
             <div class="sentinel-stream" id="sentinel-stream"></div>
             <div class="fleet-metrics-meta">
                 <span id="sentinel-meta" class="fleet-metrics-scrape-status"></span>
+            </div>
+        </div>
+
+        <!-- Vigil — janitor resident panel. Segregates the 30-min cycle stream
+             and groundskeeper KG writes out of the main Discoveries feed, which
+             would otherwise be dominated by low-severity "N stale, M archived"
+             entries. Backed by /v1/vigil/summary. -->
+        <div class="panel" id="vigil-section">
+            <div class="panel-header">
+                <h2>Vigil</h2>
+                <div class="panel-controls">
+                    <button id="vigil-refresh" class="panel-button" type="button">Refresh</button>
+                </div>
+            </div>
+            <div class="vigil-counts">
+                <div class="vigil-stat">
+                    <span class="vigil-stat-label">last cycle</span>
+                    <span class="vigil-stat-value" id="vigil-last-cycle">—</span>
+                </div>
+                <div class="vigil-stat">
+                    <span class="vigil-stat-label">cycles · 24h</span>
+                    <span class="vigil-stat-value" id="vigil-cycles-24h">—</span>
+                </div>
+                <div class="vigil-stat">
+                    <span class="vigil-stat-label">KG writes · 24h</span>
+                    <span class="vigil-stat-value" id="vigil-writes-24h">—</span>
+                </div>
+                <div class="vigil-stat">
+                    <span class="vigil-stat-label">avg coherence</span>
+                    <span class="vigil-stat-value" id="vigil-avg-coherence">—</span>
+                </div>
+                <div class="vigil-stat">
+                    <span class="vigil-stat-label">last verdict</span>
+                    <span class="vigil-stat-value" id="vigil-last-verdict">—</span>
+                </div>
+            </div>
+            <h3 class="vigil-subhead">Recent cycles</h3>
+            <div class="vigil-stream" id="vigil-cycles"></div>
+            <h3 class="vigil-subhead">Recent KG writes</h3>
+            <div class="vigil-stream" id="vigil-writes"></div>
+            <div class="fleet-metrics-meta">
+                <span id="vigil-meta" class="fleet-metrics-scrape-status"></span>
             </div>
         </div>
 

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -5413,3 +5413,146 @@ main {
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+/* -----------------------------------------------------------------------
+ * Vigil panel — mirrors sentinel layout with cycles + writes streams.
+ * ----------------------------------------------------------------------- */
+
+.vigil-counts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-bottom: 14px;
+}
+
+.vigil-stat {
+    flex: 1 1 110px;
+    min-width: 110px;
+    padding: 10px 12px;
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.vigil-stat-label {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-secondary);
+}
+
+.vigil-stat-value {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1.1rem;
+    color: var(--text-primary);
+}
+
+.vigil-subhead {
+    margin: 14px 0 6px 0;
+    font-size: 0.82rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-secondary);
+    font-weight: 500;
+}
+
+.vigil-stream {
+    max-height: 300px;
+    overflow-y: auto;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    border-radius: 6px;
+    margin-bottom: 6px;
+}
+
+.vigil-stream-empty {
+    color: var(--text-secondary);
+    font-style: italic;
+    text-align: center;
+    padding: 20px;
+    font-size: 0.86rem;
+}
+
+.vigil-row {
+    display: grid;
+    gap: 10px;
+    align-items: baseline;
+    padding: 5px 10px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+    font-size: 0.82rem;
+}
+
+.vigil-row:last-child {
+    border-bottom: none;
+}
+
+/* Cycle rows: time | verdict | C | R | EISV */
+.vigil-row-cycle {
+    grid-template-columns: 72px 72px 70px 70px 1fr;
+}
+
+/* Write rows: time | severity | type | summary */
+.vigil-row-write {
+    grid-template-columns: 72px 72px 120px 1fr;
+}
+
+.vigil-row-time {
+    color: var(--text-secondary);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.74rem;
+}
+
+.vigil-row-verdict,
+.vigil-row-sev {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 1px 6px;
+    border-radius: 3px;
+    text-align: center;
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--text-secondary);
+}
+
+.vigil-verdict-proceed,
+.vigil-verdict-approve { background: rgba(34, 197, 94, 0.18); color: #86efac; }
+.vigil-verdict-guide,
+.vigil-verdict-caution { background: rgba(245, 158, 11, 0.18); color: #fcd34d; }
+.vigil-verdict-pause,
+.vigil-verdict-reject  { background: rgba(239, 68, 68, 0.18); color: #fca5a5; }
+
+.vigil-row-sev-critical { background: rgba(239, 68, 68, 0.18); color: #fca5a5; }
+.vigil-row-sev-high     { background: rgba(245, 158, 11, 0.18); color: #fcd34d; }
+.vigil-row-sev-medium   { background: rgba(59, 130, 246, 0.18); color: #93c5fd; }
+
+.vigil-row-metric {
+    font-family: 'JetBrains Mono', monospace;
+    color: var(--text-primary);
+    font-size: 0.78rem;
+}
+
+.vigil-row-eisv {
+    font-family: 'JetBrains Mono', monospace;
+    color: var(--text-secondary);
+    font-size: 0.76rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.vigil-row-type {
+    font-family: 'JetBrains Mono', monospace;
+    color: var(--text-primary);
+    font-size: 0.78rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.vigil-row-msg {
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/dashboard/vigil.js
+++ b/dashboard/vigil.js
@@ -1,0 +1,201 @@
+// vigil.js — Vigil (janitor resident) dedicated panel.
+//
+// Vigil runs every 30 min via launchd. Its KG writes are mostly low-severity
+// groundskeeper deltas ("N stale, M archived") which previously crowded the
+// main Discoveries feed. This panel segregates Vigil's cycle history and
+// recent writes so the main feed can hide them by default.
+//
+// Backed by /v1/vigil/summary. authFetch from utils.js handles the bearer
+// token; don't reach into localStorage directly here.
+
+(function () {
+    'use strict';
+
+    async function fetchSummary() {
+        try {
+            var resp = await authFetch('/v1/vigil/summary');
+            if (!resp.ok) throw new Error('HTTP ' + resp.status);
+            var data = await resp.json();
+            if (!data || data.success === false) {
+                throw new Error((data && data.error) || 'unknown');
+            }
+            return data;
+        } catch (e) {
+            console.warn('[Vigil] summary fetch failed:', e);
+            return null;
+        }
+    }
+
+    function setMetric(id, value) {
+        var el = document.getElementById(id);
+        if (el) el.textContent = value;
+    }
+
+    function formatRelative(isoStr) {
+        if (!isoStr) return '—';
+        var then = new Date(isoStr);
+        if (isNaN(then.getTime())) return isoStr;
+        var secs = Math.floor((Date.now() - then.getTime()) / 1000);
+        if (secs < 60) return 'just now';
+        if (secs < 3600) return Math.floor(secs / 60) + 'm ago';
+        if (secs < 86400) return Math.floor(secs / 3600) + 'h ago';
+        return Math.floor(secs / 86400) + 'd ago';
+    }
+
+    function fmtNum(v, digits) {
+        if (v == null || typeof v !== 'number' || isNaN(v)) return '—';
+        return v.toFixed(digits == null ? 2 : digits);
+    }
+
+    function renderStats(summary) {
+        var s = summary.stats || {};
+        setMetric('vigil-last-cycle', formatRelative(s.last_cycle_at));
+        setMetric('vigil-cycles-24h', s.cycles_24h != null ? s.cycles_24h : '—');
+        setMetric('vigil-writes-24h', s.writes_24h != null ? s.writes_24h : '—');
+        setMetric('vigil-avg-coherence', fmtNum(s.avg_coherence_window));
+        var verdictEl = document.getElementById('vigil-last-verdict');
+        if (verdictEl) {
+            var verdict = s.last_verdict || '—';
+            verdictEl.textContent = verdict;
+            verdictEl.className = 'vigil-stat-value vigil-verdict-' + String(verdict).toLowerCase();
+        }
+    }
+
+    function renderCycles(cycles) {
+        var container = document.getElementById('vigil-cycles');
+        if (!container) return;
+        container.innerHTML = '';
+        if (!cycles || cycles.length === 0) {
+            var empty = document.createElement('div');
+            empty.className = 'vigil-stream-empty';
+            empty.textContent = 'No Vigil cycles in the window (has the launchd job been loaded?).';
+            container.appendChild(empty);
+            return;
+        }
+        for (var i = 0; i < cycles.length; i++) {
+            var c = cycles[i];
+            var row = document.createElement('div');
+            row.className = 'vigil-row vigil-row-cycle';
+
+            var ts = document.createElement('span');
+            ts.className = 'vigil-row-time';
+            ts.textContent = formatRelative(c.timestamp);
+            ts.title = c.timestamp || '';
+
+            var verdict = document.createElement('span');
+            var vLower = String(c.verdict || '?').toLowerCase();
+            verdict.className = 'vigil-row-verdict vigil-verdict-' + vLower;
+            verdict.textContent = vLower;
+
+            var coh = document.createElement('span');
+            coh.className = 'vigil-row-metric';
+            coh.textContent = 'C ' + fmtNum(c.coherence);
+            coh.title = 'coherence';
+
+            var risk = document.createElement('span');
+            risk.className = 'vigil-row-metric';
+            risk.textContent = 'R ' + fmtNum(c.risk);
+            risk.title = 'risk score';
+
+            var eisv = document.createElement('span');
+            eisv.className = 'vigil-row-eisv';
+            eisv.textContent = 'E' + fmtNum(c.E, 2)
+                + ' I' + fmtNum(c.I, 2)
+                + ' S' + fmtNum(c.S, 2)
+                + ' V' + fmtNum(c.V, 2);
+
+            row.appendChild(ts);
+            row.appendChild(verdict);
+            row.appendChild(coh);
+            row.appendChild(risk);
+            row.appendChild(eisv);
+            container.appendChild(row);
+        }
+    }
+
+    function renderWrites(writes) {
+        var container = document.getElementById('vigil-writes');
+        if (!container) return;
+        container.innerHTML = '';
+        if (!writes || writes.length === 0) {
+            var empty = document.createElement('div');
+            empty.className = 'vigil-stream-empty';
+            empty.textContent = 'Vigil has not written to the knowledge graph in the window.';
+            container.appendChild(empty);
+            return;
+        }
+        for (var i = 0; i < writes.length; i++) {
+            var w = writes[i];
+            var row = document.createElement('div');
+            row.className = 'vigil-row vigil-row-write';
+
+            var ts = document.createElement('span');
+            ts.className = 'vigil-row-time';
+            ts.textContent = formatRelative(w.timestamp);
+            ts.title = w.timestamp || '';
+
+            var sev = document.createElement('span');
+            var sevVal = String(w.severity || 'low').toLowerCase();
+            sev.className = 'vigil-row-sev vigil-row-sev-' + sevVal;
+            sev.textContent = sevVal;
+
+            var type = document.createElement('span');
+            type.className = 'vigil-row-type';
+            type.textContent = w.type || 'note';
+
+            var summary = document.createElement('span');
+            summary.className = 'vigil-row-msg';
+            summary.textContent = w.summary || '';
+
+            row.appendChild(ts);
+            row.appendChild(sev);
+            row.appendChild(type);
+            row.appendChild(summary);
+            container.appendChild(row);
+        }
+    }
+
+    function setFooter(summary) {
+        var el = document.getElementById('vigil-meta');
+        if (!el) return;
+        var stats = summary.stats || {};
+        var parts = [
+            'window: ' + (summary.window_hours || 72) + 'h',
+            (stats.total_cycles_in_window || 0) + ' cycles',
+            (stats.total_writes_in_window || 0) + ' writes',
+            'refreshed ' + formatRelative(summary.generated_at),
+        ];
+        if (!summary.agent_id) parts.push('(no Vigil agent registered)');
+        el.textContent = parts.join(' · ');
+    }
+
+    async function refresh() {
+        var summary = await fetchSummary();
+        if (!summary) {
+            setMetric('vigil-last-cycle', '—');
+            setMetric('vigil-cycles-24h', '—');
+            setMetric('vigil-writes-24h', '—');
+            setMetric('vigil-avg-coherence', '—');
+            setMetric('vigil-last-verdict', '—');
+            return;
+        }
+        renderStats(summary);
+        renderCycles(summary.cycles || []);
+        renderWrites(summary.recent_writes || []);
+        setFooter(summary);
+    }
+
+    function wire() {
+        var btn = document.getElementById('vigil-refresh');
+        if (btn) btn.addEventListener('click', refresh);
+        refresh();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', wire);
+    } else {
+        wire();
+    }
+
+    window.VigilPanel = { refresh: refresh };
+})();

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -856,6 +856,7 @@ async def http_dashboard_static(request):
         "visualizations.js", "agents.js", "discoveries.js",
         "dialectic.js", "eisv-charts.js", "timeline.js",
         "residents.js", "fleet-metrics.js", "watcher.js", "sentinel.js",
+        "vigil.js",
         "styles.css", "dashboard.js",
         "phase.js",
     ]
@@ -1461,6 +1462,192 @@ async def http_sentinel_summary(request):
     )
     summary["success"] = True
     return JSONResponse(summary)
+
+
+# ---------------------------------------------------------------------------
+# Vigil panel endpoint
+# ---------------------------------------------------------------------------
+
+_VIGIL_DEFAULT_WINDOW_HOURS = 72
+_VIGIL_DEFAULT_RECENT_LIMIT = 30
+_VIGIL_CYCLE_HISTORY_LIMIT = 48  # ~24h at one cycle / 30min
+
+
+def _vigil_agent_id(mcp_server_obj) -> Optional[str]:
+    """Resolve the active Vigil agent_id from mcp_server agent_metadata.
+
+    Mirrors the label->meta preference logic in ``http_residents`` (prefer
+    active over archived; within same tier, prefer more total_updates) so
+    the panel tracks the same Vigil row the residents strip shows.
+    """
+    best: Optional[tuple[str, Any]] = None
+    for agent_id, meta in list(getattr(mcp_server_obj, "agent_metadata", {}).items()):
+        label = getattr(meta, "label", None) or getattr(meta, "display_name", None)
+        if not label or label.lower() != "vigil":
+            continue
+        if best is None:
+            best = (agent_id, meta)
+            continue
+        b_meta = best[1]
+        b_active = getattr(b_meta, "status", None) == "active"
+        n_active = getattr(meta, "status", None) == "active"
+        if n_active and not b_active:
+            best = (agent_id, meta)
+            continue
+        if b_active and not n_active:
+            continue
+        if (getattr(meta, "total_updates", 0) or 0) > \
+           (getattr(b_meta, "total_updates", 0) or 0):
+            best = (agent_id, meta)
+    return best[0] if best else None
+
+
+def _vigil_cycle_history(agent_id: str, window_hours: int,
+                         limit: int = _VIGIL_CYCLE_HISTORY_LIMIT) -> list[dict]:
+    """Flatten eisv_update events for Vigil into a cycle history for the panel.
+
+    Each entry: ts, coherence, risk, verdict, E, I, S, V. Newest first.
+    Pulls from the broadcaster ring buffer (~6h of fleet-wide events, longer
+    for low-traffic residents like Vigil), clipped to ``window_hours``.
+    """
+    cutoff = time.time() - window_hours * 3600
+    points: list[dict] = []
+    for event in broadcaster_instance.event_history:
+        if not isinstance(event, dict):
+            continue
+        if event.get("type") != "eisv_update":
+            continue
+        if event.get("agent_id") != agent_id:
+            continue
+        ts_str = event.get("timestamp")
+        try:
+            ts = datetime.fromisoformat(str(ts_str).replace("Z", "+00:00")).timestamp()
+        except (ValueError, TypeError):
+            continue
+        if ts < cutoff:
+            continue
+        flat = _extract_eisv_fields(event)
+        points.append({
+            "timestamp": ts_str,
+            "ts": ts,
+            "E": flat.get("E"),
+            "I": flat.get("I"),
+            "S": flat.get("S"),
+            "V": flat.get("V"),
+            "coherence": flat.get("coherence"),
+            "risk": flat.get("risk_score"),
+            "verdict": flat.get("verdict"),
+        })
+    points.sort(key=lambda p: p["ts"], reverse=True)
+    return points[:limit]
+
+
+def _vigil_stats(cycles: list[dict], writes: list[dict]) -> dict:
+    """Roll up cycle list + write list into summary metrics for the stat strip."""
+    now_ts = time.time()
+    last_cycle_ts = cycles[0]["ts"] if cycles else None
+    last_cycle_iso = cycles[0]["timestamp"] if cycles else None
+
+    def _within(hours, items, key="ts"):
+        floor = now_ts - hours * 3600
+        return sum(1 for it in items if (it.get(key) or 0) >= floor)
+
+    cycles_24h = _within(24, cycles)
+    writes_24h = 0
+    for w in writes:
+        ts_str = w.get("timestamp")
+        if not ts_str:
+            continue
+        try:
+            ts = datetime.fromisoformat(str(ts_str).replace("Z", "+00:00")).timestamp()
+        except (ValueError, TypeError):
+            continue
+        if ts >= now_ts - 24 * 3600:
+            writes_24h += 1
+
+    coh_values = [c.get("coherence") for c in cycles
+                  if isinstance(c.get("coherence"), (int, float))]
+    avg_coh = (sum(coh_values) / len(coh_values)) if coh_values else None
+
+    verdicts = [c.get("verdict") for c in cycles if c.get("verdict")]
+    last_verdict = verdicts[0] if verdicts else None
+
+    return {
+        "last_cycle_at": last_cycle_iso,
+        "last_cycle_age_seconds": (now_ts - last_cycle_ts) if last_cycle_ts else None,
+        "cycles_24h": cycles_24h,
+        "writes_24h": writes_24h,
+        "avg_coherence_window": avg_coh,
+        "last_verdict": last_verdict,
+        "total_cycles_in_window": len(cycles),
+        "total_writes_in_window": len(writes),
+    }
+
+
+async def http_vigil_summary(request):
+    """GET /v1/vigil/summary — Vigil panel data.
+
+    Vigil is a resident janitor that runs every 30min via launchd. Its KG
+    writes are mostly low-severity groundskeeper deltas ("N stale, M archived")
+    that crowd the main activity feed. This endpoint segregates them into a
+    dedicated stream so the main feed can filter them out by default.
+
+    Response shape::
+
+        {
+            "success": true,
+            "agent_id": "...",
+            "window_hours": 72,
+            "stats": {"last_cycle_at": ..., "cycles_24h": N, "writes_24h": N, ...},
+            "cycles": [{"timestamp": ..., "coherence": ..., "verdict": ..., ...}, ...],
+            "recent_writes": [{"id": ..., "summary": ..., "severity": ..., ...}, ...],
+            "generated_at": "..."
+        }
+    """
+    http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
+    if not _check_http_auth(request, http_api_token=http_api_token):
+        return _http_unauthorized()
+
+    try:
+        window_hours = int(request.query_params.get("window_hours", _VIGIL_DEFAULT_WINDOW_HOURS))
+    except ValueError:
+        window_hours = _VIGIL_DEFAULT_WINDOW_HOURS
+    window_hours = max(1, min(window_hours, 24 * 30))
+
+    try:
+        recent_limit = int(request.query_params.get("limit", _VIGIL_DEFAULT_RECENT_LIMIT))
+    except ValueError:
+        recent_limit = _VIGIL_DEFAULT_RECENT_LIMIT
+    recent_limit = max(1, min(recent_limit, 200))
+
+    from src.mcp_handlers.shared import lazy_mcp_server
+    agent_id = _vigil_agent_id(lazy_mcp_server)
+
+    if not agent_id:
+        return JSONResponse({
+            "success": True,
+            "agent_id": None,
+            "window_hours": window_hours,
+            "stats": {},
+            "cycles": [],
+            "recent_writes": [],
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "note": "no Vigil agent found in metadata",
+        })
+
+    cycles = _vigil_cycle_history(agent_id, window_hours)
+    writes = await _recent_writes_for_agent(agent_id, limit=recent_limit)
+    stats = _vigil_stats(cycles, writes)
+
+    return JSONResponse({
+        "success": True,
+        "agent_id": agent_id,
+        "window_hours": window_hours,
+        "stats": stats,
+        "cycles": cycles,
+        "recent_writes": writes,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    })
 
 
 async def http_record_finding(request):
@@ -2157,6 +2344,7 @@ def register_http_routes(
     app.routes.append(Route("/v1/metrics/catalog", http_get_metrics_catalog, methods=["GET"]))
     app.routes.append(Route("/v1/watcher/summary", http_watcher_summary, methods=["GET"]))
     app.routes.append(Route("/v1/sentinel/summary", http_sentinel_summary, methods=["GET"]))
+    app.routes.append(Route("/v1/vigil/summary", http_vigil_summary, methods=["GET"]))
     app.routes.append(Route("/api/activity", http_activity, methods=["GET"]))
     app.routes.append(Route("/api/incidents", http_incidents, methods=["GET"]))
     app.routes.append(Route("/v1/residents", http_residents, methods=["GET"]))

--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -689,6 +689,15 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
         # Accept both "query" and "text" as parameter names for better UX
         query_text = arguments.get("query") or arguments.get("text")
         agent_id = arguments.get("agent_id")
+        # Labels to exclude (e.g. ["Vigil"]) — lets the dashboard hide
+        # janitorial residents from the default Discoveries feed. Resolved to
+        # agent_ids below, applied as a post-query filter over `results`.
+        exclude_labels_raw = arguments.get("exclude_agent_labels") or []
+        exclude_labels_lc: set[str] = {
+            str(lbl).strip().lower()
+            for lbl in exclude_labels_raw
+            if str(lbl).strip()
+        } if isinstance(exclude_labels_raw, (list, tuple)) else set()
         tags = normalize_tags(arguments.get("tags", [])) or None
         dtype = arguments.get("discovery_type")
         severity = arguments.get("severity")
@@ -1001,7 +1010,20 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
         
         dt_ms = (time.perf_counter() - t0) * 1000.0
         record_ms(f"knowledge.search.{search_mode}", dt_ms)
-        
+
+        # Post-query exclude-by-label filter. Kept here (not in the DB query)
+        # so it composes with all retrieval modes — FTS, semantic, hybrid RRF,
+        # graph expansion — without each branch needing to know the filter.
+        if exclude_labels_lc:
+            filtered = []
+            for d in results:
+                agent_display = _resolve_agent_display(d.agent_id)
+                display_name = agent_display.get("display_name", d.agent_id) or ""
+                if str(display_name).strip().lower() in exclude_labels_lc:
+                    continue
+                filtered.append(d)
+            results = filtered
+
         # Auto-include details when result set is small (saves a round-trip)
         auto_details = not include_details and 0 < len(results) <= 3
         if auto_details:

--- a/tests/test_dashboard_static_allowlist.py
+++ b/tests/test_dashboard_static_allowlist.py
@@ -51,6 +51,9 @@ class TestDashboardStaticAllowlist:
     def test_sentinel_is_allowed(self):
         assert "sentinel.js" in _load_allowlist()
 
+    def test_vigil_is_allowed(self):
+        assert "vigil.js" in _load_allowlist()
+
     def test_every_index_html_reference_is_allowed(self):
         referenced = _scripts_referenced_by_index_html()
         allowed = set(_load_allowlist())

--- a/tests/test_http_api_vigil_summary.py
+++ b/tests/test_http_api_vigil_summary.py
@@ -1,0 +1,159 @@
+"""Tests for the pure helpers behind /v1/vigil/summary.
+
+The endpoint itself stitches together ``_vigil_agent_id`` (label resolver),
+``_vigil_cycle_history`` (broadcaster filter), ``_recent_writes_for_agent``
+(shared with residents), and ``_vigil_stats`` (rollup). The aggregator is
+pure so we test it directly; the agent-id resolver is tested against a
+hand-rolled mcp_server stub.
+
+Vigil is a janitorial resident — every cycle emits a low-severity
+groundskeeper note, and the panel needs to segregate that noise out of the
+main Discoveries feed rather than re-summarise it. So the panel data shape
+is: cycles (from check-ins) + writes (from KG) + rollup stats.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from src.http_api import _vigil_agent_id, _vigil_stats
+
+
+NOW = datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc)
+NOW_TS = NOW.timestamp()
+
+
+def _cycle(offset_minutes=0, coherence=0.5, verdict="proceed"):
+    ts = NOW - timedelta(minutes=offset_minutes)
+    return {
+        "timestamp": ts.isoformat(),
+        "ts": ts.timestamp(),
+        "E": 0.6, "I": 0.7, "S": 0.3, "V": 0.1,
+        "coherence": coherence,
+        "risk": 0.1,
+        "verdict": verdict,
+    }
+
+
+def _write(offset_minutes=0, severity="low", summary="Groundskeeper: 5 stale"):
+    ts = NOW - timedelta(minutes=offset_minutes)
+    return {
+        "id": f"d-{offset_minutes}",
+        "type": "note",
+        "severity": severity,
+        "summary": summary,
+        "tags": [],
+        "timestamp": ts.isoformat(),
+    }
+
+
+class TestVigilStats:
+    def test_empty_inputs_return_null_stats(self):
+        out = _vigil_stats([], [])
+        assert out["last_cycle_at"] is None
+        assert out["last_cycle_age_seconds"] is None
+        assert out["cycles_24h"] == 0
+        assert out["writes_24h"] == 0
+        assert out["avg_coherence_window"] is None
+        assert out["last_verdict"] is None
+        assert out["total_cycles_in_window"] == 0
+
+    def test_last_cycle_is_first_entry(self):
+        """Cycles are passed newest-first; stats mirror that without re-sorting."""
+        cycles = [_cycle(0, verdict="proceed"), _cycle(30, verdict="guide")]
+        out = _vigil_stats(cycles, [])
+        assert out["last_cycle_at"] == cycles[0]["timestamp"]
+        assert out["last_verdict"] == "proceed"
+
+    def test_cycles_24h_counts_only_window(self):
+        cycles = [
+            _cycle(0),
+            _cycle(60),
+            _cycle(12 * 60),
+            _cycle(25 * 60),  # just outside
+            _cycle(48 * 60),
+        ]
+        out = _vigil_stats(cycles, [])
+        assert out["cycles_24h"] == 3
+
+    def test_writes_24h_parses_iso_timestamps(self):
+        writes = [
+            _write(5),
+            _write(60),
+            _write(25 * 60),  # outside 24h
+        ]
+        out = _vigil_stats([], writes)
+        assert out["writes_24h"] == 2
+
+    def test_writes_with_bad_timestamps_ignored(self):
+        writes = [
+            _write(5),
+            {"id": "bad", "timestamp": "not-a-date", "severity": "low"},
+            {"id": "missing", "severity": "low"},  # no timestamp at all
+        ]
+        out = _vigil_stats([], writes)
+        # The bad/missing ones are silently skipped — showing them as zero'd
+        # counts would be less honest than counting just the parseable ones.
+        assert out["writes_24h"] == 1
+
+    def test_avg_coherence_ignores_missing_values(self):
+        cycles = [
+            _cycle(0, coherence=0.4),
+            _cycle(30, coherence=0.6),
+            _cycle(60, coherence=None),
+        ]
+        out = _vigil_stats(cycles, [])
+        assert out["avg_coherence_window"] == 0.5
+
+    def test_totals_reflect_full_input_not_window(self):
+        """total_cycles_in_window is whatever the caller passed in — the panel
+        uses this for the footer count, which should match what it displays
+        in the stream, not a re-filtered subset."""
+        cycles = [_cycle(0), _cycle(48 * 60)]  # one outside 24h
+        out = _vigil_stats(cycles, [])
+        assert out["total_cycles_in_window"] == 2
+        assert out["cycles_24h"] == 1
+
+
+class TestVigilAgentId:
+    """Resolver picks the active Vigil row from mcp_server.agent_metadata.
+
+    The concrete risk this guards: when governance-mcp restarts create
+    duplicate Vigil rows, the dashboard must track the one actually running,
+    not a stale archived copy. Mirrors the preference logic in http_residents.
+    """
+
+    def _srv(self, metadata):
+        return SimpleNamespace(agent_metadata=metadata)
+
+    def test_returns_none_when_no_vigil_registered(self):
+        srv = self._srv({"uuid-a": SimpleNamespace(label="Sentinel", status="active")})
+        assert _vigil_agent_id(srv) is None
+
+    def test_picks_vigil_by_label_case_insensitive(self):
+        srv = self._srv({
+            "uuid-a": SimpleNamespace(label="vigil", status="active", total_updates=10),
+        })
+        assert _vigil_agent_id(srv) == "uuid-a"
+
+    def test_prefers_active_over_archived(self):
+        srv = self._srv({
+            "uuid-archived": SimpleNamespace(label="Vigil", status="archived", total_updates=1000),
+            "uuid-active": SimpleNamespace(label="Vigil", status="active", total_updates=5),
+        })
+        assert _vigil_agent_id(srv) == "uuid-active"
+
+    def test_within_same_tier_prefers_more_updates(self):
+        srv = self._srv({
+            "uuid-quiet": SimpleNamespace(label="Vigil", status="active", total_updates=3),
+            "uuid-busy": SimpleNamespace(label="Vigil", status="active", total_updates=500),
+        })
+        assert _vigil_agent_id(srv) == "uuid-busy"
+
+    def test_falls_back_to_display_name_when_label_missing(self):
+        srv = self._srv({
+            "uuid-a": SimpleNamespace(label=None, display_name="Vigil",
+                                      status="active", total_updates=1),
+        })
+        assert _vigil_agent_id(srv) == "uuid-a"

--- a/tests/test_kg_search.py
+++ b/tests/test_kg_search.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock, AsyncMock, PropertyMock
 from datetime import datetime
 from dataclasses import dataclass, field
+from types import SimpleNamespace
 from typing import Optional, List, Dict, Any
 
 project_root = Path(__file__).parent.parent
@@ -284,6 +285,57 @@ class TestSearchKnowledgeGraph:
 
         data = parse_result(result)
         assert data["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_exclude_agent_labels_drops_matching_rows(self, patch_common):
+        """exclude_agent_labels filters post-query so the main Discoveries feed
+        can hide janitorial residents (e.g. Vigil) without losing them from
+        agent-drill-down views. The match is on display_name, case-insensitive."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        # Register two agents with distinct labels in agent_metadata so the
+        # display-name resolver returns something meaningful.
+        mock_mcp_server.agent_metadata = {
+            "vigil-uuid": SimpleNamespace(label="Vigil", display_name="Vigil"),
+            "worker-uuid": SimpleNamespace(label="Worker", display_name="Worker"),
+        }
+
+        mock_graph.query = AsyncMock(return_value=[
+            make_discovery(id="d-v1", agent_id="vigil-uuid", summary="Groundskeeper"),
+            make_discovery(id="d-w1", agent_id="worker-uuid", summary="Real finding"),
+            make_discovery(id="d-v2", agent_id="vigil-uuid", summary="Another groundskeeper"),
+        ])
+
+        result = await handle_search_knowledge_graph({
+            "exclude_agent_labels": ["Vigil"],
+        })
+
+        data = parse_result(result)
+        assert data["success"] is True
+        assert data["count"] == 1
+        ids = [d["id"] for d in data["discoveries"]]
+        assert ids == ["d-w1"]
+
+    @pytest.mark.asyncio
+    async def test_exclude_agent_labels_empty_list_is_no_op(self, patch_common):
+        """Passing an empty list (or omitting the param) must not filter
+        anything — otherwise the default MCP-tool call would silently lose
+        results for any caller that passes the param unconditionally."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        mock_graph.query = AsyncMock(return_value=[
+            make_discovery(id="d-1", summary="One"),
+            make_discovery(id="d-2", summary="Two"),
+        ])
+
+        result = await handle_search_knowledge_graph({
+            "exclude_agent_labels": [],
+        })
+
+        data = parse_result(result)
+        assert data["count"] == 2
 
     @pytest.mark.asyncio
     async def test_search_with_tags(self, patch_common):


### PR DESCRIPTION
## Summary
- New `/v1/vigil/summary` endpoint + `dashboard/vigil.js` panel (cycle history, recent KG writes, 24h stats). Mirrors the Sentinel panel layout.
- `search_knowledge_graph` gains `exclude_agent_labels` (post-query, case-insensitive, composes across FTS/semantic/hybrid).
- `dashboard.js::loadDiscoveries` passes `exclude_agent_labels: ['Vigil']` when no search query — hides groundskeeper noise from the default feed; explicit searches still return it.

## Why
Vigil's 30-min cycle emits a low-severity KG note every run ("Groundskeeper: N stale, M archived"). These crowded the main Discoveries feed. Segregating them into a dedicated panel + default filter solves both halves of the operator's complaint ("give it its own panel" + "all up in kg").

## Test plan
- [x] `test_http_api_vigil_summary.py` — 12 new tests for `_vigil_stats` rollup + `_vigil_agent_id` resolver (active > archived, total_updates tiebreak, display_name fallback)
- [x] `test_kg_search.py` — exclude-labels filter drops matching rows; empty list is a no-op
- [x] `test_dashboard_static_allowlist.py` — pins vigil.js into the allowlist (automatic guard also catches this)
- [ ] Manual: restart governance-mcp, load dashboard, confirm Vigil panel renders with cycles + writes, Discoveries panel no longer shows Vigil's groundskeeper entries

Pre-existing `agents/sentinel/tests/test_cycle_timeout.py::test_bounded_cycle_times_out_on_hang` failure on master is unrelated (missing `_bounded_analysis_cycle` attr).