### PR TITLE
fix: heal 'uninitialized' monitor via DB hydration + atomic save (#138)

### DIFF
--- a/src/agent_loop_detection.py
+++ b/src/agent_loop_detection.py
@@ -470,6 +470,12 @@ async def process_update_authenticated_async(
 
     # Get or create monitor
     monitor = await loop.run_in_executor(None, get_or_create_monitor, agent_id)
+    # Heal the DB ↔ file persistence split: if the on-disk state file is
+    # missing but core.agent_state has history, hydrate update_count +
+    # rolling histories from DB so this check-in continues from real state
+    # rather than from a fresh zero.
+    from src.agent_monitor_state import hydrate_from_db_if_fresh
+    await hydrate_from_db_if_fresh(monitor, agent_id)
 
     task_type = agent_state.get("task_type", "mixed")
 
@@ -503,7 +509,7 @@ async def process_update_authenticated_async(
                 meta.total_updates += 1
 
         # Enforce pause decisions (circuit breaker)
-        if decision_action == 'pause':
+        if decision_action == 'pause' and meta is not None:
             meta.status = "paused"
             meta.paused_at = now
             decision_reason = result.get('decision', {}).get('reason', 'Circuit breaker triggered')
@@ -560,7 +566,7 @@ async def process_update_authenticated_async(
                 logger.warning(f"Could not auto-initiate dialectic recovery: {e}")
 
         # Clear cooldown if it has passed
-        if meta.loop_cooldown_until:
+        if meta is not None and meta.loop_cooldown_until:
             cooldown_until = datetime.fromisoformat(meta.loop_cooldown_until)
             if datetime.now() >= cooldown_until:
                 meta.loop_cooldown_until = None

--- a/src/agent_monitor_state.py
+++ b/src/agent_monitor_state.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 import json
+import tempfile
 import time
 import fcntl
 import asyncio
@@ -18,6 +19,12 @@ from src.agent_metadata_model import project_root
 from src.governance_monitor import UNITARESMonitor
 
 logger = get_logger(__name__)
+
+# Budget for the file-write executor await. If the anyio task group stalls
+# the event loop (see docs anyio-deadlock note), we'd rather degrade than
+# hang the handler. hydrate_from_db_if_fresh heals the missed save on the
+# next monitor load, so dropping one write is no longer catastrophic.
+STATE_SAVE_TIMEOUT_SECONDS = 2.0
 
 # Store monitors per agent (shared mutable dict)
 monitors: dict[str, UNITARESMonitor] = {}
@@ -48,11 +55,31 @@ def get_state_file(agent_id: str) -> Path:
 
 
 def _write_state_file(state_file: Path, state_data: dict) -> None:
-    """Helper function to write state file (used by both sync and async versions)"""
-    with open(state_file, 'w') as f:
-        json.dump(state_data, f, indent=2)
-        f.flush()
-        os.fsync(f.fileno())
+    """Atomically write the state file.
+
+    Write to a tempfile in the same directory, fsync, then os.replace onto
+    the final path. Prevents zero-byte / truncated files if the process is
+    killed mid-write (which would leave loaders seeing a corrupt JSON and
+    silently falling back to None).
+    """
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_path = tempfile.mkstemp(
+        dir=state_file.parent,
+        prefix=f".{state_file.stem}.",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(tmp_fd, 'w') as f:
+            json.dump(state_data, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, state_file)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def _snapshot_governor_state(monitor: UNITARESMonitor) -> None:
@@ -99,7 +126,10 @@ async def save_monitor_state_async(agent_id: str, monitor: UNITARESMonitor) -> N
                 raise TimeoutError("State lock timeout")
 
             loop = asyncio.get_running_loop()
-            await loop.run_in_executor(None, _write_state_file, state_file, state_data)
+            await asyncio.wait_for(
+                loop.run_in_executor(None, _write_state_file, state_file, state_data),
+                timeout=STATE_SAVE_TIMEOUT_SECONDS,
+            )
 
         finally:
             if lock_fd is not None:
@@ -111,11 +141,25 @@ async def save_monitor_state_async(agent_id: str, monitor: UNITARESMonitor) -> N
                     os.close(lock_fd)
                 except (OSError, ValueError):
                     pass
+    except asyncio.TimeoutError:
+        logger.warning(
+            f"State file save for {agent_id} exceeded {STATE_SAVE_TIMEOUT_SECONDS}s "
+            f"(likely anyio/asyncio executor stall); dropped this save, "
+            f"monitor will rehydrate from DB on next load"
+        )
     except Exception as e:
         logger.warning(f"Could not acquire state lock for {agent_id}: {e}", exc_info=True)
         try:
             loop = asyncio.get_running_loop()
-            await loop.run_in_executor(None, _write_state_file, state_file, state_data)
+            await asyncio.wait_for(
+                loop.run_in_executor(None, _write_state_file, state_file, state_data),
+                timeout=STATE_SAVE_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"Unlocked fallback save for {agent_id} also exceeded "
+                f"{STATE_SAVE_TIMEOUT_SECONDS}s; dropped"
+            )
         except Exception as fallback_error:
             logger.error(f"Failed to save state even without lock for {agent_id}: {fallback_error}", exc_info=True)
 
@@ -187,3 +231,72 @@ def load_monitor_state(agent_id: str) -> 'GovernanceState | None':
     except Exception as e:
         logger.warning(f"Could not load state for {agent_id}: {e}", exc_info=True)
         return None
+
+
+async def hydrate_from_db_if_fresh(monitor: UNITARESMonitor, agent_id: str) -> bool:
+    """Rehydrate a fresh monitor from core.agent_state when the JSON file is missing.
+
+    The file and the DB are two independent persistence paths. If a save
+    attempt is dropped (anyio executor stall, crash mid-write, unwritten
+    file for any reason), every subsequent server restart loads the monitor
+    as update_count=0 — displayed to the user as "uninitialized" —
+    even though the DB has the full history. This function closes that gap:
+    when called on a fresh monitor, it populates EISV, coherence, regime,
+    and rolling histories from the last ~50 DB records.
+
+    Safe to call unconditionally — no-ops if the monitor already has updates
+    or if the DB has no history for this agent. Never raises.
+
+    Returns True if hydration actually applied new state.
+    """
+    # Defensive: some test paths hand us SimpleNamespace-style state objects
+    # without the full GovernanceState interface. Treat missing update_count
+    # as 0 (which means "attempt hydrate") rather than crashing the handler.
+    if getattr(monitor.state, "update_count", 0) > 0:
+        return False
+    try:
+        from src.db import get_db
+        db = get_db()
+        identity = await db.get_identity(agent_id)
+        if identity is None:
+            return False
+        # Most-recent-first; we'll reverse for chronological history arrays
+        rows = await db.get_agent_state_history(
+            identity_id=identity.identity_id, limit=50
+        )
+        if not rows:
+            return False
+        chrono = list(reversed(rows))
+        latest = chrono[-1]
+
+        # Core EISV + coherence from latest row
+        monitor.state.unitaires_state.E = float(latest.energy)
+        monitor.state.unitaires_state.I = float(latest.integrity)
+        monitor.state.unitaires_state.S = float(latest.entropy)
+        monitor.state.unitaires_state.V = float(latest.void)
+        monitor.state.coherence = float(latest.coherence)
+        monitor.state.regime = str(latest.regime)
+
+        # Rolling histories (capped at what we fetched; monitor trims itself on next update)
+        monitor.state.E_history = [float(r.energy) for r in chrono]
+        monitor.state.I_history = [float(r.integrity) for r in chrono]
+        monitor.state.S_history = [float(r.entropy) for r in chrono]
+        monitor.state.V_history = [float(r.void) for r in chrono]
+        monitor.state.coherence_history = [float(r.coherence) for r in chrono]
+        monitor.state.regime_history = [str(r.regime) for r in chrono]
+
+        # update_count gates the "uninitialized" display. Using len(chrono) is
+        # a floor (true count may be higher — we only fetched 50); that's fine
+        # since the gate is >0, and downstream consumers of update_count treat
+        # it as "how much history have we seen" which is exactly len(chrono).
+        monitor.state.update_count = len(chrono)
+
+        logger.info(
+            f"Hydrated {agent_id} from core.agent_state: "
+            f"{len(chrono)} records, coherence={monitor.state.coherence:.3f}, "
+            f"regime={monitor.state.regime}"
+        )
+        return True
+    except Exception as e:
+        logger.warning(f"DB hydration failed for {agent_id}: {e}", exc_info=True)
+        return False

--- a/src/services/runtime_queries.py
+++ b/src/services/runtime_queries.py
@@ -146,6 +146,11 @@ async def get_governance_metrics_data(agent_id: str, arguments: Dict[str, Any], 
         verbosity = "minimal" if lite else "full"
 
     monitor = server.get_or_create_monitor(agent_id)
+    # Heal the DB ↔ file persistence split: if the on-disk state file was
+    # dropped (anyio executor stall, crash mid-write, etc.) but core.agent_state
+    # has history, the monitor would otherwise report "uninitialized" forever.
+    from src.agent_monitor_state import hydrate_from_db_if_fresh
+    await hydrate_from_db_if_fresh(monitor, agent_id)
     include_state = arguments.get("include_state", False)
     metrics = monitor.get_metrics(include_state=include_state)
 

--- a/tests/test_monitor_hydration.py
+++ b/tests/test_monitor_hydration.py
@@ -1,0 +1,306 @@
+"""Tests for the four monitor-persistence fixes:
+
+1. DB-fallback hydration via hydrate_from_db_if_fresh
+2. Atomic file write in _write_state_file
+3. asyncio.wait_for timeout budget on save_monitor_state_async
+4. meta-None guards in agent_loop_detection.process_update_authenticated_async
+
+Background (issue #138): core.agent_state and the JSON state file are
+independent persistence paths. When file writes drop (anyio executor
+stall, crash mid-write), the monitor reloaded as fresh update_count=0
+and the agent displayed as "uninitialized" forever, even though the DB
+had full history.
+"""
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.agent_monitor_state import (
+    STATE_SAVE_TIMEOUT_SECONDS,
+    _write_state_file,
+    hydrate_from_db_if_fresh,
+    save_monitor_state_async,
+)
+
+
+# ─── Fix #1: DB-fallback hydration ────────────────────────────────────────
+
+class _FakeStateRow:
+    """Shape of AgentStateRecord returned by db.get_agent_state_history."""
+
+    def __init__(self, *, E, I, S, V, coherence, regime):
+        self.energy = E
+        self.integrity = I
+        self.entropy = S
+        self.void = V
+        self.coherence = coherence
+        self.regime = regime
+
+
+def _make_fresh_monitor(agent_id="test-agent"):
+    """Build a real UNITARESMonitor with a fresh state (update_count=0)."""
+    from src.governance_monitor import UNITARESMonitor
+
+    return UNITARESMonitor(agent_id, load_state=False)
+
+
+@pytest.mark.asyncio
+async def test_hydrate_from_db_if_fresh_populates_eisv_and_history():
+    monitor = _make_fresh_monitor("hydrate-happy")
+    assert monitor.state.update_count == 0  # precondition
+
+    fake_identity = MagicMock(identity_id=42)
+    fake_rows_desc = [
+        # Most-recent-first (DB returns DESC)
+        _FakeStateRow(E=0.7, I=0.8, S=0.1, V=-0.05, coherence=0.55, regime="DIVERGENCE"),
+        _FakeStateRow(E=0.65, I=0.78, S=0.12, V=-0.03, coherence=0.52, regime="CONVERGENCE"),
+        _FakeStateRow(E=0.6, I=0.75, S=0.15, V=0.0, coherence=0.5, regime="EXPLORATION"),
+    ]
+    fake_db = MagicMock()
+    fake_db.get_identity = AsyncMock(return_value=fake_identity)
+    fake_db.get_agent_state_history = AsyncMock(return_value=fake_rows_desc)
+
+    with patch("src.db.get_db", return_value=fake_db):
+        applied = await hydrate_from_db_if_fresh(monitor, "hydrate-happy")
+
+    assert applied is True
+    # update_count pulled from history length (gates the "uninitialized" display)
+    assert monitor.state.update_count == 3
+    # Latest EISV from the most-recent row (index 0 of the DESC list)
+    assert monitor.state.unitaires_state.E == pytest.approx(0.7)
+    assert monitor.state.unitaires_state.I == pytest.approx(0.8)
+    assert monitor.state.unitaires_state.S == pytest.approx(0.1)
+    assert monitor.state.unitaires_state.V == pytest.approx(-0.05)
+    assert monitor.state.coherence == pytest.approx(0.55)
+    assert monitor.state.regime == "DIVERGENCE"
+    # Histories are chronological (oldest → newest)
+    assert monitor.state.coherence_history == pytest.approx([0.5, 0.52, 0.55])
+    assert monitor.state.regime_history == ["EXPLORATION", "CONVERGENCE", "DIVERGENCE"]
+
+
+@pytest.mark.asyncio
+async def test_hydrate_from_db_if_fresh_noop_when_monitor_already_has_updates():
+    monitor = _make_fresh_monitor("hydrate-noop")
+    monitor.state.update_count = 5  # already hydrated
+
+    fake_db = MagicMock()
+    fake_db.get_identity = AsyncMock(side_effect=AssertionError("should not be called"))
+
+    with patch("src.db.get_db", return_value=fake_db):
+        applied = await hydrate_from_db_if_fresh(monitor, "hydrate-noop")
+
+    assert applied is False
+    fake_db.get_identity.assert_not_called()
+    assert monitor.state.update_count == 5
+
+
+@pytest.mark.asyncio
+async def test_hydrate_from_db_if_fresh_returns_false_when_no_identity():
+    monitor = _make_fresh_monitor("hydrate-no-identity")
+    fake_db = MagicMock()
+    fake_db.get_identity = AsyncMock(return_value=None)
+
+    with patch("src.db.get_db", return_value=fake_db):
+        applied = await hydrate_from_db_if_fresh(monitor, "hydrate-no-identity")
+
+    assert applied is False
+    assert monitor.state.update_count == 0
+
+
+@pytest.mark.asyncio
+async def test_hydrate_from_db_if_fresh_returns_false_when_no_history():
+    monitor = _make_fresh_monitor("hydrate-no-history")
+    fake_db = MagicMock()
+    fake_db.get_identity = AsyncMock(return_value=MagicMock(identity_id=1))
+    fake_db.get_agent_state_history = AsyncMock(return_value=[])
+
+    with patch("src.db.get_db", return_value=fake_db):
+        applied = await hydrate_from_db_if_fresh(monitor, "hydrate-no-history")
+
+    assert applied is False
+    assert monitor.state.update_count == 0
+
+
+@pytest.mark.asyncio
+async def test_hydrate_from_db_if_fresh_swallows_db_exceptions():
+    """Hydration must never raise — it's called unconditionally on every
+    monitor access in async entry points."""
+    monitor = _make_fresh_monitor("hydrate-explodes")
+    fake_db = MagicMock()
+    fake_db.get_identity = AsyncMock(side_effect=RuntimeError("DB exploded"))
+
+    with patch("src.db.get_db", return_value=fake_db):
+        applied = await hydrate_from_db_if_fresh(monitor, "hydrate-explodes")
+
+    assert applied is False
+    assert monitor.state.update_count == 0
+
+
+# ─── Fix #2: Atomic file write ────────────────────────────────────────────
+
+def test_write_state_file_is_atomic_against_crash_mid_write(tmp_path):
+    """A crash during json.dump must not leave a truncated / zero-byte file.
+
+    We prove this by pre-populating the target path with known-good content,
+    then making json.dump raise. The target file must still contain the old
+    content afterwards — this is only possible with tempfile+os.replace.
+    """
+    state_file = tmp_path / "agent_state.json"
+    state_file.write_text('{"old": "content"}')
+
+    with patch("src.agent_monitor_state.json.dump", side_effect=RuntimeError("crash")):
+        with pytest.raises(RuntimeError):
+            _write_state_file(state_file, {"new": "data"})
+
+    # Old content preserved — atomic rename never happened
+    assert json.loads(state_file.read_text()) == {"old": "content"}
+    # No leftover tempfiles
+    leftover = [p for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+    assert leftover == [], f"tempfile not cleaned up: {leftover}"
+
+
+def test_write_state_file_writes_valid_json_on_success(tmp_path):
+    state_file = tmp_path / "agent_state.json"
+    payload = {"E": 0.7, "I": 0.8, "update_count": 4}
+
+    _write_state_file(state_file, payload)
+
+    assert json.loads(state_file.read_text()) == payload
+
+
+def test_write_state_file_creates_parent_dir(tmp_path):
+    state_file = tmp_path / "nested" / "deeper" / "agent_state.json"
+    _write_state_file(state_file, {"k": "v"})
+    assert state_file.exists()
+
+
+# ─── Fix #3: wait_for timeout on save ─────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_save_monitor_state_async_times_out_instead_of_hanging(tmp_path, monkeypatch):
+    """If the run_in_executor await stalls (anyio executor starvation, etc.),
+    save_monitor_state_async must drop the write rather than hang the handler."""
+    # Redirect state file dir to a clean tmp location
+    from src import agent_monitor_state
+
+    def fake_get_state_file(agent_id):
+        return tmp_path / f"{agent_id}_state.json"
+
+    monkeypatch.setattr(agent_monitor_state, "get_state_file", fake_get_state_file)
+    # Make the executor work hang longer than the timeout
+    monkeypatch.setattr(
+        agent_monitor_state,
+        "STATE_SAVE_TIMEOUT_SECONDS",
+        0.1,
+    )
+
+    monitor = _make_fresh_monitor("save-timeout")
+
+    def _slow_write(*args, **kwargs):
+        import time as _t
+        _t.sleep(2.0)
+
+    monkeypatch.setattr(agent_monitor_state, "_write_state_file", _slow_write)
+
+    # Should return cleanly after the timeout, not hang for 2s
+    start = asyncio.get_event_loop().time()
+    await asyncio.wait_for(
+        save_monitor_state_async("save-timeout", monitor),
+        timeout=1.0,  # outer guard — if we hit this, the fix is broken
+    )
+    elapsed = asyncio.get_event_loop().time() - start
+    assert elapsed < 1.0, f"save_monitor_state_async did not honor inner timeout: {elapsed}s"
+
+
+@pytest.mark.asyncio
+async def test_save_monitor_state_async_writes_normally_under_budget(tmp_path, monkeypatch):
+    """Sanity: the happy path still produces a valid JSON file."""
+    from src import agent_monitor_state
+
+    def fake_get_state_file(agent_id):
+        return tmp_path / f"{agent_id}_state.json"
+
+    monkeypatch.setattr(agent_monitor_state, "get_state_file", fake_get_state_file)
+
+    monitor = _make_fresh_monitor("save-happy")
+    await save_monitor_state_async("save-happy", monitor)
+
+    state_file = tmp_path / "save-happy_state.json"
+    assert state_file.exists()
+    data = json.loads(state_file.read_text())
+    # Smoke check on the canonical fields
+    assert "update_count" in data or "E" in data
+
+
+# ─── Fix #4: meta-None guards in process_update_authenticated_async ───────
+
+@pytest.mark.asyncio
+async def test_process_update_authenticated_async_tolerates_missing_meta(monkeypatch):
+    """Before the fix, a None agent_metadata entry would AttributeError at
+    agent_loop_detection.py:507 (pause branch) or :563 (loop_cooldown_until),
+    short-circuiting the save call. Guard that regression."""
+    from src import agent_loop_detection
+
+    # Force meta to be missing
+    monkeypatch.setattr(
+        agent_loop_detection, "agent_metadata", {},
+    )
+    # Make ownership verification always succeed
+    monkeypatch.setattr(
+        agent_loop_detection, "verify_agent_ownership",
+        lambda *a, **kw: (True, ""),
+    )
+    # Monitor + process_update return a 'pause' decision — triggers the
+    # previously-unguarded pause branch at line 507
+    fake_monitor = MagicMock()
+    fake_monitor.process_update = MagicMock(return_value={
+        "decision": {"action": "pause", "reason": "test"},
+        "metrics": {"coherence": 0.4},
+    })
+    # get_or_create_monitor is imported lazily inside the handler; patch at source
+    monkeypatch.setattr(
+        "src.agent_lifecycle.get_or_create_monitor",
+        lambda agent_id: fake_monitor,
+    )
+    # Skip loop detection
+    monkeypatch.setattr(
+        agent_loop_detection, "detect_loop_pattern",
+        lambda agent_id: (False, ""),
+    )
+    # Hydration: no-op
+    monkeypatch.setattr(
+        "src.agent_monitor_state.hydrate_from_db_if_fresh",
+        AsyncMock(return_value=False),
+    )
+    # DB increment: pretend it succeeds
+    fake_db = MagicMock()
+    fake_db.increment_update_count = AsyncMock(return_value=1)
+    monkeypatch.setattr(
+        "src.agent_storage.get_db", lambda: fake_db,
+    )
+    # save_monitor_state_async: track whether we reached it
+    save_called = asyncio.Event()
+
+    async def _fake_save(*a, **kw):
+        save_called.set()
+
+    monkeypatch.setattr(
+        agent_loop_detection, "save_monitor_state_async", _fake_save,
+    )
+
+    # Previously raised AttributeError on None.status / None.loop_cooldown_until
+    result = await agent_loop_detection.process_update_authenticated_async(
+        agent_id="no-meta-agent",
+        api_key="dummy",
+        agent_state={"task_type": "mixed"},
+        auto_save=True,
+    )
+
+    # Handler returned, save was reached (previously skipped via exception)
+    assert result is not None
+    assert save_called.is_set(), "save_monitor_state_async was not reached"


### PR DESCRIPTION
Closes #138.

## What

Four layered fixes to close the DB↔file persistence split that left ~4 of 10 today's agents showing `uninitialized` despite having full `core.agent_state` history.

1. **`hydrate_from_db_if_fresh`** (`src/agent_monitor_state.py`) — async helper that rebuilds EISV + rolling histories from the last 50 `core.agent_state` rows when a monitor loads as fresh. Wired into both `get_governance_metrics_data` (heals the visible symptom on first read) and `process_update_authenticated_async` (check-ins continue from real state after a restart). Never raises.
2. **Atomic `_write_state_file`** — tempfile in same dir + fsync + `os.replace`. Prevents zero-byte corruption on crash mid-write.
3. **`asyncio.wait_for` budget** on the two `run_in_executor` awaits in `save_monitor_state_async` (2s default, tunable via `STATE_SAVE_TIMEOUT_SECONDS`). Matches the project-standard pattern from the anyio-asyncio known-issue doc. Drops the write with a WARN on stall; fix #1 heals it on next load.
4. **meta-None guards** at `agent_loop_detection.py:507` (pause branch) and `:563` (loop_cooldown_until). Matches the `if meta is not None` pattern already used at 486/498/502. Removes a latent AttributeError that could silently skip the save.

Each fix stands on its own. Even if I'm wrong about which failure bit those 4 agents today, (1) makes the symptom non-recurring: any agent whose file is missing gets rebuilt from DB on next load.

## Tests

`tests/test_monitor_hydration.py` — 11 new tests:
- 5 on hydration (happy path, already-hydrated no-op, no identity, no history, swallows DB exceptions)
- 3 on atomic write (atomic-against-crash, valid JSON on success, creates parent dir)
- 2 on save timeout (times out instead of hanging, happy path still writes)
- 1 on meta-None tolerance (pause branch no longer AttributeErrors)

## Test state

`./scripts/dev/test-cache.sh` → 7046 pass, 0 new failures. 9 deselected are pre-existing master failures in `agents/{sentinel,vigil}/tests/test_cycle_timeout.py` (stale API references to `SentinelAgent._bounded_analysis_cycle` and `GovernanceAgent.run_once(timeout=)`) — verified identical on master.

## Open question

Issue #138 documents the remaining mystery: for the 4 affected agents today, `core.agent_state` has rows but no state file / no lock file ever existed. Save precedes DB record by construction, so the save path *must* have been entered. Static inspection couldn't reconcile it. These fixes are robust to all three remaining hypotheses; the trace itself is follow-up work.