### PR TITLE
fix(test): anchor vigil-summary tests on real clock

### DIFF
--- a/tests/test_http_api_vigil_summary.py
+++ b/tests/test_http_api_vigil_summary.py
@@ -20,7 +20,11 @@ from types import SimpleNamespace
 from src.http_api import _vigil_agent_id, _vigil_stats
 
 
-NOW = datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc)
+# Anchor on real wall-clock so offsets stay consistent with `time.time()`
+# inside _vigil_stats. A fixed datetime here goes stale once real time
+# advances past the 24h window, breaking cycles_24h / writes_24h tests
+# in CI on any day after the constant's value.
+NOW = datetime.now(timezone.utc)
 NOW_TS = NOW.timestamp()
 
 


### PR DESCRIPTION
Closes the CI failure on master (`assert 2 == 3` in `test_cycles_24h_counts_only_window`).

`tests/test_http_api_vigil_summary.py` hardcoded `NOW = datetime(2026, 4, 24, 12, 0)` while `_vigil_stats` reads `time.time()` for its 24h window. Once real wall-clock advanced past the constant by >12h (which happens on any CI run on or after 2026-04-25), the `_cycle(12 * 60)` row at 2026-04-24 00:00 fell outside the live floor and `cycles_24h` returned 2 instead of 3.

Anchoring on `datetime.now(timezone.utc)` makes offsets always now-relative; works on any day. Test was introduced in #140; not from any other PR.

Local: `pytest tests/test_http_api_vigil_summary.py` → 12 pass.