### PR TITLE
feat: restore Docker quickstart for one-command server bring-up

### DIFF
--- a/tests/test_http_api_vigil_summary.py
+++ b/tests/test_http_api_vigil_summary.py
@@ -20,7 +20,11 @@ from types import SimpleNamespace
 from src.http_api import _vigil_agent_id, _vigil_stats
 
 
-NOW = datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc)
+# Anchor on real wall-clock so offsets stay consistent with `time.time()`
+# inside _vigil_stats. A fixed datetime here goes stale once real time
+# advances past the 24h window, breaking cycles_24h / writes_24h tests
+# in CI on any day after the constant's value.
+NOW = datetime.now(timezone.utc)
 NOW_TS = NOW.timestamp()
 
 


### PR DESCRIPTION
## Why

External users hit a wall installing UNITARES because Postgres+Apache AGE must be compiled from source manually (~5 steps, Homebrew-assumed). Docker was removed in f0a6640c when this became a single-operator repo, but external evaluation now needs a one-liner path again.

## What

- **\`docker-compose.yml\`** — postgres-age + redis + governance-mcp, with all six schema files (\`schema\`, \`partitions\`, \`knowledge\`, \`embeddings\`, \`embeddings_bge_m3\`, \`graph_schema\`) wired into init scripts
- **\`Dockerfile\`** — governance server image. No longer needs the unitares-core wheel (\`governance_core/\` folded back in-tree on 2026-04-24)
- **\`db/postgres/Dockerfile.age-vector\`** — \`apache/age\` + \`pgvector v0.8.0\`
- **\`.dockerignore\`**, **\`requirements-docker.txt\`**, expanded **\`.env.example\`**

Host ports parameterized (\`POSTGRES_HOST_PORT\` / \`REDIS_HOST_PORT\` / \`GOVERNANCE_HOST_PORT\`) so the maintainer's existing Homebrew Postgres on 5432 and launchd governance on 8767 don't conflict with test runs.

**README** — Try-it block leads with \`docker compose up\`; Installation now presents Docker (recommended for evaluation) and bare-metal (maintainer's production path) as parallel choices. Adds a service ports table and a "Pi/Lumen is optional, governance runs standalone" note.

## Smoke test

End-to-end: stack came up healthy, REST \`onboard\` returned a fresh agent UUID, AGE graph auto-created, all background tasks started, calibration loaded from DB. Image build ~3 min (pgvector compile is the slowest layer).

## Companion

\`unitares-governance-plugin\` README updated in parallel to point users at this docker-compose path before clients fail with \`localhost:8767\` connection refused.