### PR TITLE
fix(watcher): truthful dashboard + audit-trail for resolutions

### DIFF
--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -827,28 +827,40 @@ def parse_findings(
 # ---------------------------------------------------------------------------
 
 
-def _post_resolution_event(finding: dict, action: str, resolver_agent_id: str | None) -> None:
+def _post_resolution_event(
+    finding: dict,
+    action: str,
+    resolver_agent_id: str | None,
+    reason: str | None = None,
+) -> None:
     """Post a watcher_resolution event to the governance event stream."""
     identity = get_watcher_identity()
     if identity is None:
         return
 
+    base_msg = f"[{action}] {finding.get('pattern', '?')} {finding.get('file', '?')}:{finding.get('line', '?')} — {finding.get('hint', '')}"
+    message = f"{base_msg} · {reason}" if reason else base_msg
+
+    extra = {
+        "action": action,
+        "pattern": finding.get("pattern", ""),
+        "file": finding.get("file", ""),
+        "line": finding.get("line", 0),
+        "violation_class": finding.get("violation_class", ""),
+        "resolved_by": resolver_agent_id,
+    }
+    if reason:
+        extra["resolution_reason"] = reason
+
     try:
         post_finding(
             event_type="watcher_resolution",
             severity=finding.get("severity", "unknown"),
-            message=f"[{action}] {finding.get('pattern', '?')} {finding.get('file', '?')}:{finding.get('line', '?')} — {finding.get('hint', '')}",
+            message=message,
             agent_id=identity["agent_uuid"],
             agent_name="Watcher",
             fingerprint=finding.get("fingerprint", ""),
-            extra={
-                "action": action,
-                "pattern": finding.get("pattern", ""),
-                "file": finding.get("file", ""),
-                "line": finding.get("line", 0),
-                "violation_class": finding.get("violation_class", ""),
-                "resolved_by": resolver_agent_id,
-            },
+            extra=extra,
         )
     except Exception as e:
         log(f"resolution event failed: {e}", "warning")
@@ -1438,6 +1450,11 @@ def main() -> int:
         help="governance UUID of the agent resolving/dismissing (for audit trail)",
     )
     parser.add_argument(
+        "--reason",
+        metavar="TEXT",
+        help="short rationale for --resolve/--dismiss; stored on the finding and included in the governance event",
+    )
+    parser.add_argument(
         "--compact",
         action="store_true",
         help="drop resolved/dismissed/aged_out findings older than the TTL",
@@ -1472,9 +1489,13 @@ def main() -> int:
     if args.list_findings:
         return list_findings(only_open=args.only_open)
     if args.resolve:
-        return update_finding_status(args.resolve, "confirmed", resolver_agent_id=args.agent_id)
+        return update_finding_status(
+            args.resolve, "confirmed", resolver_agent_id=args.agent_id, reason=args.reason
+        )
     if args.dismiss:
-        return update_finding_status(args.dismiss, "dismissed", resolver_agent_id=args.agent_id)
+        return update_finding_status(
+            args.dismiss, "dismissed", resolver_agent_id=args.agent_id, reason=args.reason
+        )
     if args.sweep_stale:
         return sweep_stale_findings()
     if args.compact:

--- a/agents/watcher/findings.py
+++ b/agents/watcher/findings.py
@@ -270,8 +270,26 @@ def match_fingerprint(prefix: str, findings: list[dict[str, Any]]) -> tuple[list
     return matches, None
 
 
-def update_finding_status(fingerprint_prefix: str, new_status: str, resolver_agent_id: str | None = None) -> int:
+_STATUS_TIMESTAMP_FIELD = {
+    "confirmed": "confirmed_at",
+    "dismissed": "dismissed_at",
+    "aged_out": "aged_out_at",
+}
+
+
+def update_finding_status(
+    fingerprint_prefix: str,
+    new_status: str,
+    resolver_agent_id: str | None = None,
+    reason: str | None = None,
+) -> int:
     """Mark a finding as ``new_status`` by fingerprint prefix.
+
+    Writes a status-transition timestamp (``confirmed_at``/``dismissed_at``/
+    ``aged_out_at``) and, when supplied, ``resolved_by`` + ``resolution_reason``
+    so the dashboard timeline and audit trail have the data they need — the
+    prior implementation only mutated ``status`` and the timeline series were
+    always zero as a result.
 
     Returns exit code:
       0 — updated exactly one finding
@@ -305,10 +323,20 @@ def update_finding_status(fingerprint_prefix: str, new_status: str, resolver_age
         return 1
 
     target_fp = matches[0].get("fingerprint", "")
+    now_iso = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    timestamp_field = _STATUS_TIMESTAMP_FIELD.get(new_status)
+
     updated: list[dict[str, Any]] = []
     for f in findings:
         if f.get("fingerprint") == target_fp:
-            f = {**f, "status": new_status}
+            merged = {**f, "status": new_status}
+            if timestamp_field:
+                merged[timestamp_field] = now_iso
+            if resolver_agent_id:
+                merged["resolved_by"] = resolver_agent_id
+            if reason:
+                merged["resolution_reason"] = reason
+            f = merged
         updated.append(f)
     _write_findings_atomic(updated)
     log(f"update_finding_status: {target_fp[:8]} → {new_status}")
@@ -322,7 +350,7 @@ def update_finding_status(fingerprint_prefix: str, new_status: str, resolver_age
         # Lazy import: _post_resolution_event needs get_watcher_identity
         # from agent.py's identity block. Top-level import would be circular.
         from agents.watcher.agent import _post_resolution_event
-        _post_resolution_event(matches[0], new_status, resolver_agent_id)
+        _post_resolution_event(matches[0], new_status, resolver_agent_id, reason=reason)
 
     return 0
 

--- a/agents/watcher/patterns.md
+++ b/agents/watcher/patterns.md
@@ -113,7 +113,14 @@ literal asyncpg/Redis call marker (`asyncpg`, `pool.acquire`, `conn.fetch`,
 False-positive sweep 2026-04-14 (flagged `async def http_dashboard` and
 unrelated arithmetic in `src/http_api.py`) motivated the verifier constraints.
 
-**Hint template:** `asyncpg inside MCP handler — will deadlock, wrap in executor`
+**Hint template:** `asyncpg/Redis in MCP handler — will deadlock, wrap in executor`
+
+> NOTE for resolvers: the hint historically said only "asyncpg", which led
+> agents to dismiss real `await raw_redis.get(...)` deadlock sites. Both
+> drivers share the same anyio task-group conflict — see CLAUDE.md
+> "Known Issue: anyio-asyncio Conflict" and the existing
+> `_load_binding_from_redis` `wait_for` mitigation. Do not dismiss a
+> P004 just because the call is Redis rather than asyncpg.
 
 ### P005 — Acquire without paired release (severity: high, violation_class: REC)
 

--- a/agents/watcher/tests/test_agent.py
+++ b/agents/watcher/tests/test_agent.py
@@ -879,6 +879,60 @@ def test_update_finding_status_handles_missing_file(watcher_module, capsys):
     assert "empty" in captured.out or "absent" in captured.out
 
 
+def test_update_finding_status_writes_confirmed_at_timestamp(watcher_module):
+    """confirmed_at must be set when transitioning to confirmed — the dashboard
+    timeline series reads this field; before this fix it was never written and
+    the resolved/confirmed line was a flat zero across the whole window."""
+    _seed_findings(watcher_module, [_make_raw_entry("aaaaaaaaaaaaaaaa")])
+    rc = watcher_module.update_finding_status("aaaaaaaaaaaaaaaa", "confirmed")
+    assert rc == 0
+    row = watcher_module._iter_findings_raw()[0]
+    assert row["status"] == "confirmed"
+    assert "confirmed_at" in row
+    # ISO 8601 with trailing Z (matches detected_at convention in this file)
+    assert row["confirmed_at"].endswith("Z")
+    # Sibling timestamp not written for the wrong transition
+    assert "dismissed_at" not in row
+
+
+def test_update_finding_status_writes_dismissed_at_timestamp(watcher_module):
+    _seed_findings(watcher_module, [_make_raw_entry("bbbbbbbbbbbbbbbb")])
+    rc = watcher_module.update_finding_status("bbbbbbbbbbbbbbbb", "dismissed")
+    assert rc == 0
+    row = watcher_module._iter_findings_raw()[0]
+    assert row["status"] == "dismissed"
+    assert row["dismissed_at"].endswith("Z")
+    assert "confirmed_at" not in row
+
+
+def test_update_finding_status_persists_resolver_and_reason(watcher_module):
+    """--reason rationale is stored on the finding so future agents can see why
+    a prior agent dismissed it instead of re-deriving the judgment from
+    nothing."""
+    _seed_findings(watcher_module, [_make_raw_entry("ccccccccccccccccc"[:16])])
+    rc = watcher_module.update_finding_status(
+        "cccccccccccccccc",
+        "dismissed",
+        resolver_agent_id="uuid-resolver-1",
+        reason="false positive: file is a Starlette REST handler, not an MCP tool",
+    )
+    assert rc == 0
+    row = watcher_module._iter_findings_raw()[0]
+    assert row["resolved_by"] == "uuid-resolver-1"
+    assert "Starlette REST handler" in row["resolution_reason"]
+
+
+def test_update_finding_status_omits_reason_when_not_provided(watcher_module):
+    """No --reason → no resolution_reason key on the finding (we don't want
+    'null'/'' littering the schema)."""
+    _seed_findings(watcher_module, [_make_raw_entry("dddddddddddddddd")])
+    rc = watcher_module.update_finding_status("dddddddddddddddd", "confirmed")
+    assert rc == 0
+    row = watcher_module._iter_findings_raw()[0]
+    assert "resolution_reason" not in row
+    assert "resolved_by" not in row
+
+
 # --- sweep_stale_findings ---------------------------------------------------
 
 

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -509,8 +509,8 @@
                     <span class="watcher-stat-value" id="watcher-count-open">—</span>
                 </div>
                 <div class="watcher-stat">
-                    <span class="watcher-stat-label">resolved</span>
-                    <span class="watcher-stat-value" id="watcher-count-resolved">—</span>
+                    <span class="watcher-stat-label">confirmed</span>
+                    <span class="watcher-stat-value" id="watcher-count-confirmed">—</span>
                 </div>
                 <div class="watcher-stat">
                     <span class="watcher-stat-label">dismissed</span>
@@ -533,7 +533,7 @@
                     <tr>
                         <th>pattern</th>
                         <th>open</th>
-                        <th>resolved</th>
+                        <th>confirmed</th>
                         <th>dismissed</th>
                         <th>dismiss rate</th>
                     </tr>

--- a/dashboard/watcher.js
+++ b/dashboard/watcher.js
@@ -49,7 +49,9 @@
         var byStatus = summary.by_status || {};
         var bySev = summary.by_severity_open || {};
         setMetric('watcher-count-open', (byStatus.surfaced || 0) + (byStatus.open || 0));
-        setMetric('watcher-count-resolved', byStatus.resolved || 0);
+        // Resolved-as-bug status is "confirmed" in the watcher data model —
+        // see agents/watcher/findings.py VALID_FINDING_STATUSES.
+        setMetric('watcher-count-confirmed', byStatus.confirmed || 0);
         setMetric('watcher-count-dismissed', byStatus.dismissed || 0);
         setMetric('watcher-count-critical', bySev.critical || 0);
         setMetric('watcher-count-high', bySev.high || 0);
@@ -76,7 +78,7 @@
             var cells = [
                 p.pattern,
                 String(p.surfaced),
-                String(p.resolved),
+                String(p.confirmed),
                 String(p.dismissed),
                 p.dismiss_ratio == null ? '—' : (Math.round(p.dismiss_ratio * 100) + '%'),
             ];
@@ -141,7 +143,7 @@
         var timeline = summary.timeline || [];
         var hex = (typeof MetricColors !== 'undefined' && MetricColors.HEX) ? MetricColors.HEX : {};
         var detectedColor = hex.chartSurprise || '#f59e0b';
-        var resolvedColor = hex.chartIntegrity || '#10b981';
+        var confirmedColor = hex.chartIntegrity || '#10b981';
         var dismissedColor = hex.chartDrift || '#6b7280';
 
         function series(key, color, label) {
@@ -166,7 +168,7 @@
             data: {
                 datasets: [
                     series('detected', detectedColor, 'new findings'),
-                    series('resolved', resolvedColor, 'resolved'),
+                    series('confirmed', confirmedColor, 'confirmed'),
                     series('dismissed', dismissedColor, 'dismissed'),
                 ],
             },

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -1215,9 +1215,9 @@ def _watcher_summary_from_rows(rows, now=None, window_days=_WATCHER_DAILY_WINDOW
 
     by_status = Counter()
     by_severity = Counter()   # open-only (surfaced + open) — the actionable queue
-    by_pattern = defaultdict(lambda: {"surfaced": 0, "resolved": 0, "dismissed": 0, "other": 0})
+    by_pattern = defaultdict(lambda: {"surfaced": 0, "confirmed": 0, "dismissed": 0, "other": 0})
     daily = defaultdict(int)  # yyyy-mm-dd → count of detected_at in that day
-    resolutions_daily = defaultdict(lambda: {"resolved": 0, "dismissed": 0})
+    resolutions_daily = defaultdict(lambda: {"confirmed": 0, "dismissed": 0})
 
     if now is None:
         now = datetime.now(timezone.utc)
@@ -1234,6 +1234,11 @@ def _watcher_summary_from_rows(rows, now=None, window_days=_WATCHER_DAILY_WINDOW
         except Exception:
             return None
 
+    # Status names used by Watcher (findings.py:VALID_FINDING_STATUSES):
+    # the closed-resolved status is "confirmed", not "resolved" — earlier
+    # versions of this aggregator looked for "resolved" and silently dropped
+    # every confirmed finding into "other", which made the dashboard claim
+    # zero confirms regardless of reality.
     for row in rows:
         status = str(row.get("status", "surfaced"))
         pattern = str(row.get("pattern") or "?")
@@ -1241,7 +1246,7 @@ def _watcher_summary_from_rows(rows, now=None, window_days=_WATCHER_DAILY_WINDOW
         by_status[status] += 1
 
         bucket = by_pattern[pattern]
-        if status in ("resolved", "dismissed"):
+        if status in ("confirmed", "dismissed"):
             bucket[status] += 1
         elif status in ("surfaced", "open"):
             bucket["surfaced"] += 1
@@ -1253,29 +1258,28 @@ def _watcher_summary_from_rows(rows, now=None, window_days=_WATCHER_DAILY_WINDOW
         if detected and detected.date() >= window_start:
             daily[detected.date().isoformat()] += 1
 
-        # Resolution timestamp if present (fields used by watcher agent:
-        # resolved_at / dismissed_at)
-        for key in ("resolved_at", "dismissed_at"):
+        # Resolution timestamps written by update_finding_status:
+        # confirmed_at / dismissed_at (ISO 8601, UTC).
+        for key, kind in (("confirmed_at", "confirmed"), ("dismissed_at", "dismissed")):
             ts = _parse_date(row.get(key))
             if ts and ts.date() >= window_start:
-                kind = "resolved" if key == "resolved_at" else "dismissed"
                 resolutions_daily[ts.date().isoformat()][kind] += 1
 
-    # Pattern table — include resolve/dismiss ratio for noise detection
+    # Pattern table — include confirm/dismiss ratio for noise detection
     patterns_out = []
     for pat, b in by_pattern.items():
-        total_closed = b["resolved"] + b["dismissed"]
+        total_closed = b["confirmed"] + b["dismissed"]
         dismiss_ratio = (b["dismissed"] / total_closed) if total_closed else None
         patterns_out.append({
             "pattern": pat,
             "surfaced": b["surfaced"],
-            "resolved": b["resolved"],
+            "confirmed": b["confirmed"],
             "dismissed": b["dismissed"],
             "other": b["other"],
             "dismiss_ratio": dismiss_ratio,
         })
     patterns_out.sort(
-        key=lambda p: (-p["surfaced"], -(p["resolved"] + p["dismissed"]), p["pattern"])
+        key=lambda p: (-p["surfaced"], -(p["confirmed"] + p["dismissed"]), p["pattern"])
     )
 
     # Daily series spans the full window so the chart renders zeros instead of gaps
@@ -1285,7 +1289,7 @@ def _watcher_summary_from_rows(rows, now=None, window_days=_WATCHER_DAILY_WINDOW
         timeline.append({
             "day": day,
             "detected": daily.get(day, 0),
-            "resolved": resolutions_daily[day]["resolved"],
+            "confirmed": resolutions_daily[day]["confirmed"],
             "dismissed": resolutions_daily[day]["dismissed"],
         })
 

--- a/tests/test_http_api_vigil_summary.py
+++ b/tests/test_http_api_vigil_summary.py
@@ -20,7 +20,11 @@ from types import SimpleNamespace
 from src.http_api import _vigil_agent_id, _vigil_stats
 
 
-NOW = datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc)
+# Anchor on real wall-clock so offsets stay consistent with `time.time()`
+# inside _vigil_stats. A fixed datetime here goes stale once real time
+# advances past the 24h window, breaking cycles_24h / writes_24h tests
+# in CI on any day after the constant's value.
+NOW = datetime.now(timezone.utc)
 NOW_TS = NOW.timestamp()
 
 

--- a/tests/test_http_api_watcher_summary.py
+++ b/tests/test_http_api_watcher_summary.py
@@ -37,27 +37,46 @@ class TestStatusAndSeverityCounts:
         assert all(d["detected"] == 0 for d in out["timeline"])
 
     def test_status_counter_counts_everything(self):
+        # "confirmed" is the closed-as-real-bug status; see findings.py
+        # VALID_FINDING_STATUSES. Earlier the aggregator looked for "resolved"
+        # and silently dropped every confirmed finding.
         rows = [
             _row(status="surfaced"),
             _row(status="surfaced"),
-            _row(status="resolved"),
+            _row(status="confirmed"),
             _row(status="dismissed"),
         ]
         out = _watcher_summary_from_rows(rows, now=NOW)
-        assert out["by_status"] == {"surfaced": 2, "resolved": 1, "dismissed": 1}
+        assert out["by_status"] == {"surfaced": 2, "confirmed": 1, "dismissed": 1}
         assert out["total"] == 4
 
     def test_severity_counts_only_open_findings(self):
-        """by_severity_open is the actionable queue; resolved/dismissed shouldn't
+        """by_severity_open is the actionable queue; confirmed/dismissed shouldn't
         show up there or the panel implies ongoing severity that isn't real."""
         rows = [
             _row(severity="critical", status="surfaced"),
             _row(severity="high", status="surfaced"),
-            _row(severity="critical", status="resolved"),   # closed — excluded
-            _row(severity="critical", status="dismissed"),  # closed — excluded
+            _row(severity="critical", status="confirmed"),   # closed — excluded
+            _row(severity="critical", status="dismissed"),   # closed — excluded
         ]
         out = _watcher_summary_from_rows(rows, now=NOW)
         assert out["by_severity_open"] == {"critical": 1, "high": 1}
+
+    def test_legacy_resolved_status_falls_through_to_other(self):
+        """Defensive: if any pre-existing findings.jsonl rows still carry the
+        old 'resolved' status (none in current fixtures, but the file is
+        gitignored so an old machine could have them), they're tallied in
+        by_status but routed to the pattern bucket's 'other' slot — they
+        shouldn't pollute the confirmed/dismissed counts."""
+        rows = [_row(pattern="P_LEGACY", status="resolved")]
+        out = _watcher_summary_from_rows(rows, now=NOW)
+        assert out["by_status"] == {"resolved": 1}
+        bucket = out["patterns"][0]
+        assert bucket["confirmed"] == 0
+        assert bucket["dismissed"] == 0
+        assert bucket["other"] == 1
+        # Ratio undefined when nothing landed in confirmed/dismissed
+        assert bucket["dismiss_ratio"] is None
 
 
 class TestPatternTable:
@@ -68,16 +87,16 @@ class TestPatternTable:
         rows = [
             _row(pattern="P008", status="dismissed"),
             _row(pattern="P008", status="dismissed"),
-            _row(pattern="P008", status="dismissed"),  # 3/3 dismissed — noisy
-            _row(pattern="P001", status="resolved"),
-            _row(pattern="P001", status="resolved"),   # 0/2 dismissed — signal
-            _row(pattern="P001", status="surfaced"),   # 1 still open
+            _row(pattern="P008", status="dismissed"),   # 3/3 dismissed — noisy
+            _row(pattern="P001", status="confirmed"),
+            _row(pattern="P001", status="confirmed"),   # 0/2 dismissed — signal
+            _row(pattern="P001", status="surfaced"),    # 1 still open
         ]
         out = _watcher_summary_from_rows(rows, now=NOW)
         by = {p["pattern"]: p for p in out["patterns"]}
-        assert by["P008"]["dismissed"] == 3 and by["P008"]["resolved"] == 0
+        assert by["P008"]["dismissed"] == 3 and by["P008"]["confirmed"] == 0
         assert by["P008"]["dismiss_ratio"] == pytest.approx(1.0)
-        assert by["P001"]["resolved"] == 2 and by["P001"]["dismissed"] == 0
+        assert by["P001"]["confirmed"] == 2 and by["P001"]["dismissed"] == 0
         assert by["P001"]["dismiss_ratio"] == pytest.approx(0.0)
 
     def test_dismiss_ratio_is_none_when_nothing_closed(self):
@@ -129,14 +148,14 @@ class TestTimeline:
         out = _watcher_summary_from_rows([_row(detected_at=old)], now=NOW, window_days=30)
         assert all(d["detected"] == 0 for d in out["timeline"])
 
-    def test_timeline_captures_resolved_and_dismissed_timestamps(self):
-        resolved_day = datetime(2026, 4, 21, 14, 0, tzinfo=timezone.utc)
+    def test_timeline_captures_confirmed_and_dismissed_timestamps(self):
+        confirmed_day = datetime(2026, 4, 21, 14, 0, tzinfo=timezone.utc)
         dismissed_day = datetime(2026, 4, 22, 14, 0, tzinfo=timezone.utc)
         rows = [
             _row(
                 detected_at=(NOW - timedelta(days=1)).isoformat(),
-                status="resolved",
-                resolved_at=resolved_day.isoformat(),
+                status="confirmed",
+                confirmed_at=confirmed_day.isoformat(),
             ),
             _row(
                 detected_at=(NOW - timedelta(days=1)).isoformat(),
@@ -146,7 +165,7 @@ class TestTimeline:
         ]
         out = _watcher_summary_from_rows(rows, now=NOW, window_days=7)
         by_day = {d["day"]: d for d in out["timeline"]}
-        assert by_day["2026-04-21"]["resolved"] == 1
+        assert by_day["2026-04-21"]["confirmed"] == 1
         assert by_day["2026-04-22"]["dismissed"] == 1
 
 


### PR DESCRIPTION
## Summary

The Watcher dashboard at `/v1/watcher/summary` has been silently misreporting since the panel shipped (e5e5dbca, 2026-04-22). Root cause: the aggregator looked for `status="resolved"`, but the data model has always stored `status="confirmed"` (see `findings.py:VALID_FINDING_STATUSES`). Three coupled bugs surface from that mismatch.

### Bugs

1. **Confirms invisible.** Every confirmed finding silently routed into the per-pattern "other" bucket and never displayed. On this machine: 20 confirms / 58 dismisses → panel shows 0 / 58.
2. **Timeline always zero.** `_watcher_summary_from_rows` reads `resolved_at` / `dismissed_at`, but `update_finding_status` only mutated `status` — neither timestamp was ever written.
3. **Every pattern flagged "noisy."** `dismiss_ratio = dismissed / (confirmed + dismissed)` with `confirmed = 0` always meant 100%; every pattern hit the >=0.75 CSS threshold.

Together these meant operators saw uniform "100% dismiss-ratio, zero confirms" — exactly the "everything funnels to dismissed regardless of reality" pattern Kenny flagged.

### Changes

- `src/http_api.py` — aggregator keys on `confirmed` / `confirmed_at` matching the actual status names; sort key updated; bucket schema is `{surfaced, confirmed, dismissed, other}`.
- `agents/watcher/findings.py` — `update_finding_status` now writes `confirmed_at` / `dismissed_at` / `aged_out_at`, `resolved_by`, and an optional `resolution_reason`. Per-status field map keeps the schema honest (no `dismissed_at: null` on confirms).
- `agents/watcher/agent.py` — `--reason` CLI flag plumbed into local jsonl + governance event payload, so future agents reviewing prior dismisses have a 'why' line.
- `agents/watcher/patterns.md` — P004 hint widened to "asyncpg/Redis in MCP handler"; the narrow "asyncpg" wording was driving real Redis-deadlock dismisses (agents pattern-matched the literal token, saw `await raw_redis.get(...)`, dismissed). CLAUDE.md has always documented both drivers under the anyio task-group conflict.
- `dashboard/{watcher.js,index.html}` — read `byStatus.confirmed`, `pattern.confirmed`, timeline `confirmed`; HTML labels match the stored status name.
- `tests/test_http_api_watcher_summary.py` — corrected old `status="resolved"` assertions; added legacy fall-through case.
- `agents/watcher/tests/test_agent.py` — new tests for `confirmed_at`/`dismissed_at`/`resolved_by`/`resolution_reason` persistence.

### What lights up post-deploy

- Real confirm count (20 today instead of 0)
- Per-day timeline series populates on **new** resolutions (existing rows have no transition timestamps; the past stays flat)
- Per-pattern dismiss-ratio with a real denominator
- `resolution_reason` field on every dismiss going forward

## Test plan

- [x] `python3 -m pytest tests/test_http_api_watcher_summary.py agents/watcher/tests/test_agent.py` — 135 passed
- [x] `./scripts/dev/test-cache.sh` — green except pre-existing `agents/sentinel/tests/test_cycle_timeout.py::test_bounded_cycle_times_out_on_hang` (verified failing on master, unrelated)
- [ ] After merge: hit `/v1/watcher/summary` and confirm `by_status.confirmed > 0`
- [ ] After merge: dismiss a finding with `--reason`, verify `resolution_reason` lands in `findings.jsonl` and the governance event extra