### PR TITLE
feat(identity): same-host ppid consistency check (#128)

### DIFF
--- a/db/postgres/migrations/016_same_host_ppid_consistent.sql
+++ b/db/postgres/migrations/016_same_host_ppid_consistent.sql
@@ -1,0 +1,32 @@
+-- 016_same_host_ppid_consistent.sql
+--
+-- Same-host ppid consistency check (issue #128).
+--
+-- Adds `same_host_ppid_consistent` to core.agent_process_bindings: a
+-- *scope-bounded* confidence signal on a child's self-declared
+-- parent_agent_id. The server compares child.ppid against the parent's
+-- most recent live bindings on the same host_id only.
+--
+--   NULL  — not checked (no parent live binding on host, or cross-host)
+--   TRUE  — child.ppid matches one of the parent's live pids on this host
+--   FALSE — parent has live bindings on the host but none match child.ppid
+--           (also emits identity_same_host_ppid_mismatch audit event)
+--
+-- Audit-only — no behavioral change. Same observation-only posture as
+-- the parent invariant in #123. The column name and event name are
+-- deliberately scoped to "same_host_ppid" to avoid implying that absence
+-- of a mismatch event means cross-host lineage was verified.
+--
+-- See src/mcp_handlers/identity/lineage_verification.py for verdict logic.
+--
+-- NOTE: applied out-of-order in some environments. Migrations 014 and 015
+-- may not yet be applied on long-lived databases that pre-date them.
+-- Both are independent ADDs; this one only touches a table created by 015,
+-- so 015 must be applied before 016 wherever it is being applied.
+
+ALTER TABLE core.agent_process_bindings
+    ADD COLUMN IF NOT EXISTS same_host_ppid_consistent BOOLEAN NULL;
+
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (16, 'same_host_ppid_consistent', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -1529,14 +1529,44 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
             _fp = validate_fingerprint(_raw_fp)
             if _fp is not None:
                 from src.background_tasks import create_tracked_task
-                create_tracked_task(
-                    record_binding_bg(
-                        agent_uuid,
-                        _fp,
-                        arguments.get("client_session_id"),
-                    ),
-                    name="record_process_binding",
-                )
+
+                # PPID LINEAGE VERIFICATION (#128): if parent_agent_id and
+                # ppid are both present, sequence the verifier after the
+                # binding upsert so the UPDATE has a row to write to.
+                # Otherwise just schedule the binding alone.
+                _do_verify = bool(_parent_agent_id) and bool(_fp.ppid)
+                if _do_verify:
+                    from .lineage_verification import verify_lineage_bg
+
+                    async def _record_then_verify(
+                        agent_uuid=agent_uuid, fp=_fp,
+                        client_session_id=arguments.get("client_session_id"),
+                        parent_uuid=_parent_agent_id,
+                    ):
+                        await record_binding_bg(agent_uuid, fp, client_session_id)
+                        await verify_lineage_bg(
+                            child_uuid=agent_uuid,
+                            parent_uuid=parent_uuid,
+                            child_host_id=fp.host_id,
+                            child_ppid=fp.ppid,
+                            child_pid=fp.pid,
+                            child_pid_start_time=fp.pid_start_time,
+                            child_transport=fp.transport,
+                        )
+
+                    create_tracked_task(
+                        _record_then_verify(),
+                        name="record_and_verify_process_binding",
+                    )
+                else:
+                    create_tracked_task(
+                        record_binding_bg(
+                            agent_uuid,
+                            _fp,
+                            arguments.get("client_session_id"),
+                        ),
+                        name="record_process_binding",
+                    )
         except Exception as e:
             logger.debug(f"[PROCESS_BINDING] onboard scheduling failed (non-fatal): {e}")
 

--- a/src/mcp_handlers/identity/lineage_verification.py
+++ b/src/mcp_handlers/identity/lineage_verification.py
@@ -1,0 +1,193 @@
+"""Same-host ppid consistency check (issue #128).
+
+Cross-checks a child's self-declared `parent_agent_id` against the parent's
+observable process state on the same host. Strictly observational — same
+posture as #123: the agent still declares lineage; we add a *scope-bounded*
+confidence signal on the declaration. Verified or mismatched, the audit
+trail records what the server saw.
+
+Verdict logic:
+  - True  — at least one of the parent's live bindings on the child's host
+            has pid == child.ppid
+  - False — parent has live bindings on the child's host, but none match
+            child.ppid → emit `identity_same_host_ppid_mismatch`
+  - None  — no parent live binding on the child's host (cross-host or
+            parent never recorded a binding); the column stays NULL
+
+Naming discipline (per dialectic review): the column is
+`same_host_ppid_consistent` and the event is
+`identity_same_host_ppid_mismatch` rather than `verified_lineage` /
+`identity_lineage_mismatch`. The narrower name prevents the inference
+trap "no event = lineage was verified" — the system only ever checks
+*same-host process ancestry*, never cross-host lineage.
+
+Advisory-only contract: no internal consumer may treat
+`same_host_ppid_consistent=false` or the mismatch event as grounds for
+auto-archival, force-new, or any identity-mutating action. See
+`tests/test_lineage_verification.py::test_no_auto_enforcement_consumers`.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from .process_binding import get_live_bindings
+
+logger = logging.getLogger(__name__)
+
+
+async def verify_lineage_bg(
+    *,
+    child_uuid: str,
+    parent_uuid: str,
+    child_host_id: str,
+    child_ppid: int,
+    child_pid: int,
+    child_pid_start_time: float,
+    child_transport: str,
+) -> Optional[bool]:
+    """Verify declared parent lineage against observable parent ppid (same host).
+
+    Fire-and-forget background coroutine — caller schedules via
+    `create_tracked_task`. Never raises; all failures are logged.
+
+    Returns the verdict (True/False/None) for the test-side; production
+    callers ignore it because the persistence and audit-event side-effects
+    are the contract.
+    """
+    try:
+        parent_bindings = await get_live_bindings(parent_uuid)
+    except Exception as e:
+        logger.debug(f"[PPID_CHECK] parent lookup failed (non-fatal): {e}")
+        return None
+
+    same_host = [b for b in parent_bindings if b.get("host_id") == child_host_id]
+    if not same_host:
+        # Cross-host or parent never recorded a binding → unverified.
+        return None
+
+    parent_pids_on_host = [int(b["pid"]) for b in same_host if b.get("pid") is not None]
+    matched = child_ppid in parent_pids_on_host
+
+    verdict = True if matched else False
+    persist_succeeded = await _persist_verdict(
+        child_uuid=child_uuid,
+        child_host_id=child_host_id,
+        child_pid=child_pid,
+        child_pid_start_time=child_pid_start_time,
+        child_transport=child_transport,
+        verdict=verdict,
+    )
+
+    if not matched:
+        _emit_lineage_mismatch_event(
+            child_uuid,
+            {
+                "declared_parent_uuid": parent_uuid,
+                "child_pid": child_pid,
+                "child_ppid": child_ppid,
+                "host_id": child_host_id,
+                "parent_live_pids_on_host": parent_pids_on_host,
+                "scope": "same_host_process_ancestry",
+                "persist_succeeded": persist_succeeded,
+            },
+        )
+
+    return verdict
+
+
+async def _persist_verdict(
+    *,
+    child_uuid: str,
+    child_host_id: str,
+    child_pid: int,
+    child_pid_start_time: float,
+    child_transport: str,
+    verdict: bool,
+) -> bool:
+    """Write same_host_ppid_consistent onto the child's binding row.
+
+    Identifies the row by the same five-tuple used as the binding's UNIQUE
+    constraint. Returns True iff the write completed without exception so
+    the caller can include the status in the audit event payload —
+    operators reading a mismatch event with persist_succeeded=false know
+    to treat the column value as missing rather than authoritative.
+    """
+    try:
+        from src.db import get_db
+        db = get_db()
+        async with db.acquire() as conn:
+            status = await conn.execute(
+                """
+                UPDATE core.agent_process_bindings
+                SET same_host_ppid_consistent = $1
+                WHERE agent_id = $2
+                  AND host_id = $3
+                  AND pid = $4
+                  AND pid_start_time = $5
+                  AND transport = $6
+                """,
+                verdict,
+                child_uuid,
+                child_host_id,
+                child_pid,
+                child_pid_start_time,
+                child_transport,
+            )
+        # asyncpg returns "UPDATE N" — 0 rows means the binding row was
+        # never INSERTed (record_binding_bg failed silently before us).
+        # Treat that as persist_succeeded=False so the audit event flags
+        # the dangling state rather than implying the column was written.
+        try:
+            rows_updated = int((status or "UPDATE 0").split()[-1])
+        except Exception:
+            rows_updated = 0
+        return rows_updated > 0
+    except Exception as e:
+        logger.debug(f"[PPID_CHECK] persist verdict failed (non-fatal): {e}")
+        return False
+
+
+def _emit_lineage_mismatch_event(child_uuid: str, payload: Dict[str, Any]) -> None:
+    """Broadcast `identity_same_host_ppid_mismatch` for an observed mismatch.
+
+    Event name is intentionally narrow: the absence of this event does NOT
+    mean lineage is consistent — it only means same-host process ancestry
+    was not observed to disagree with the declaration. Cross-host lineage
+    is never checked.
+    """
+    logger.warning(
+        "[PPID_MISMATCH] Agent %s declared parent_agent_id=%s; "
+        "child pid=%s ppid=%s does not match any of parent's live pids %s on host %s",
+        child_uuid[:8] + "...",
+        str(payload.get("declared_parent_uuid", ""))[:8] + "...",
+        payload.get("child_pid"),
+        payload.get("child_ppid"),
+        payload.get("parent_live_pids_on_host"),
+        payload.get("host_id"),
+    )
+
+    try:
+        from src.broadcaster import broadcaster_instance
+    except Exception:
+        return
+
+    async def _broadcast():
+        try:
+            await broadcaster_instance.broadcast_event(
+                event_type="identity_same_host_ppid_mismatch",
+                agent_id=child_uuid,
+                payload=payload,
+            )
+        except Exception as e:
+            logger.debug(f"[PPID_MISMATCH] broadcast failed: {e}")
+
+    try:
+        from src.background_tasks import create_tracked_task
+        create_tracked_task(_broadcast(), name="same_host_ppid_mismatch_event")
+    except Exception:
+        import asyncio
+        try:
+            asyncio.ensure_future(_broadcast())
+        except Exception:
+            pass

--- a/src/mcp_handlers/identity/process_binding.py
+++ b/src/mcp_handlers/identity/process_binding.py
@@ -277,7 +277,7 @@ async def get_live_bindings(agent_id: str) -> List[Dict[str, Any]]:
                 f"""
                 SELECT host_id, pid, pid_start_time, transport,
                        tty, ppid, anchor_path_hash, client_session_id,
-                       onboard_ts, last_seen
+                       onboard_ts, last_seen, same_host_ppid_consistent
                 FROM core.agent_process_bindings
                 WHERE agent_id = $1
                   AND stale_at IS NULL
@@ -298,6 +298,7 @@ async def get_live_bindings(agent_id: str) -> List[Dict[str, Any]]:
                 "client_session_id": r["client_session_id"],
                 "onboard_ts": r["onboard_ts"].isoformat() if r["onboard_ts"] else None,
                 "last_seen": r["last_seen"].isoformat() if r["last_seen"] else None,
+                "same_host_ppid_consistent": r["same_host_ppid_consistent"],
             }
             for r in rows
         ]

--- a/tests/test_lineage_verification.py
+++ b/tests/test_lineage_verification.py
@@ -1,0 +1,517 @@
+"""Lineage verification (issue #128).
+
+verify_lineage_bg cross-checks a child's declared parent_agent_id against
+the observable parent ppid:
+
+  - Look up parent's live bindings on the same host_id.
+  - If any parent binding's pid matches child's ppid → verified=True.
+  - Else if parent has live bindings on the host (but no pid match) →
+    verified=False, emit identity_lineage_mismatch.
+  - Else (no parent live binding on host, or cross-host) → verified=None,
+    no event.
+
+Audit-only — never resolves or recovers identity. Same posture as #123.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.mcp_handlers.identity import process_binding
+
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+
+def _binding(host="h1", pid=100, start=1.0, transport="http", ppid=None):
+    return {
+        "host_id": host,
+        "pid": pid,
+        "pid_start_time": start,
+        "transport": transport,
+        "tty": None,
+        "ppid": ppid,
+        "anchor_path_hash": None,
+        "client_session_id": None,
+        "onboard_ts": datetime.now(timezone.utc).isoformat(),
+        "last_seen": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def _make_mock_db_for_update(rows_updated: int = 1):
+    """Build a mock DB whose acquire().__aenter__() returns a conn with execute().
+
+    `execute` returns a fake asyncpg "UPDATE N" status string so the verdict
+    persistence path can detect 0-row writes (the dangling-state case).
+    """
+    conn = AsyncMock()
+    conn.execute = AsyncMock(return_value=f"UPDATE {rows_updated}")
+    acquire_cm = AsyncMock()
+    acquire_cm.__aenter__.return_value = conn
+    acquire_cm.__aexit__.return_value = False
+    db = MagicMock()
+    db.acquire = MagicMock(return_value=acquire_cm)
+    return db, conn
+
+
+# -----------------------------------------------------------------------------
+# verify_lineage_bg — core cases
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_verify_lineage_matching_ppid_marks_verified():
+    """Parent binding's pid matches child's ppid → verified=True, no event, DB updated."""
+    from src.mcp_handlers.identity import lineage_verification
+
+    parent_bindings = [_binding(host="h1", pid=4242)]
+    db, conn = _make_mock_db_for_update()
+    emit = MagicMock()
+    with patch.object(
+        lineage_verification, "get_live_bindings",
+        AsyncMock(return_value=parent_bindings),
+    ), patch("src.db.get_db", return_value=db), \
+         patch.object(lineage_verification, "_emit_lineage_mismatch_event", emit):
+        result = await lineage_verification.verify_lineage_bg(
+            child_uuid="child-1",
+            parent_uuid="parent-1",
+            child_host_id="h1",
+            child_ppid=4242,
+            child_pid=5555,
+            child_pid_start_time=1.0,
+            child_transport="http",
+        )
+
+    assert result is True
+    emit.assert_not_called()
+    conn.execute.assert_awaited()
+    # Confirm the UPDATE wrote True to same_host_ppid_consistent
+    sql = conn.execute.await_args.args[0]
+    assert "same_host_ppid_consistent" in sql
+    assert conn.execute.await_args.args[1] is True
+
+
+@pytest.mark.asyncio
+async def test_verify_lineage_payload_includes_child_pid_and_scope():
+    """Mismatch payload must include child_pid (operator triage) and scope tag."""
+    from src.mcp_handlers.identity import lineage_verification
+
+    parent_bindings = [_binding(host="h1", pid=9999)]
+    db, _ = _make_mock_db_for_update()
+    captured = {}
+
+    def _capture(child_uuid, payload):
+        captured["payload"] = payload
+
+    with patch.object(
+        lineage_verification, "get_live_bindings",
+        AsyncMock(return_value=parent_bindings),
+    ), patch("src.db.get_db", return_value=db), \
+         patch.object(lineage_verification, "_emit_lineage_mismatch_event", _capture):
+        await lineage_verification.verify_lineage_bg(
+            child_uuid="child-1",
+            parent_uuid="parent-1",
+            child_host_id="h1",
+            child_ppid=4242,
+            child_pid=5555,
+            child_pid_start_time=1.0,
+            child_transport="http",
+        )
+
+    p = captured["payload"]
+    assert p["child_pid"] == 5555
+    assert p["scope"] == "same_host_process_ancestry"
+    assert p["persist_succeeded"] is True
+
+
+@pytest.mark.asyncio
+async def test_verify_lineage_zero_row_update_flags_dangling_state():
+    """Combined-failure path: record_binding_bg silently failed earlier so the
+    binding row does not exist; verify_lineage_bg's UPDATE matches 0 rows.
+
+    The mismatch event must still fire (audit trail) but persist_succeeded
+    must be False so an operator can distinguish "checked and recorded"
+    from "checked but the row was missing." Without this signal, an
+    operator looking at the bindings table sees the column as NULL and
+    has no way to correlate it with the event.
+    """
+    from src.mcp_handlers.identity import lineage_verification
+
+    parent_bindings = [_binding(host="h1", pid=9999)]
+    db, _ = _make_mock_db_for_update(rows_updated=0)  # row was never inserted
+    captured = {}
+
+    def _capture(child_uuid, payload):
+        captured["payload"] = payload
+
+    with patch.object(
+        lineage_verification, "get_live_bindings",
+        AsyncMock(return_value=parent_bindings),
+    ), patch("src.db.get_db", return_value=db), \
+         patch.object(lineage_verification, "_emit_lineage_mismatch_event", _capture):
+        await lineage_verification.verify_lineage_bg(
+            child_uuid="child-1",
+            parent_uuid="parent-1",
+            child_host_id="h1",
+            child_ppid=4242,
+            child_pid=5555,
+            child_pid_start_time=1.0,
+            child_transport="http",
+        )
+
+    assert captured["payload"]["persist_succeeded"] is False
+
+
+@pytest.mark.asyncio
+async def test_verify_lineage_persist_failure_surfaces_in_event_payload():
+    """When the UPDATE fails, the mismatch event still fires but flags persist_succeeded=false.
+
+    Operator reading the event with persist_succeeded=false knows the
+    same_host_ppid_consistent column will be NULL despite a verdict, and
+    should treat the event as the authoritative record.
+    """
+    from src.mcp_handlers.identity import lineage_verification
+
+    parent_bindings = [_binding(host="h1", pid=9999)]
+    db = MagicMock()
+    db.acquire = MagicMock(side_effect=RuntimeError("write failed"))
+    captured = {}
+
+    def _capture(child_uuid, payload):
+        captured["payload"] = payload
+
+    with patch.object(
+        lineage_verification, "get_live_bindings",
+        AsyncMock(return_value=parent_bindings),
+    ), patch("src.db.get_db", return_value=db), \
+         patch.object(lineage_verification, "_emit_lineage_mismatch_event", _capture):
+        await lineage_verification.verify_lineage_bg(
+            child_uuid="child-1",
+            parent_uuid="parent-1",
+            child_host_id="h1",
+            child_ppid=4242,
+            child_pid=5555,
+            child_pid_start_time=1.0,
+            child_transport="http",
+        )
+
+    assert captured["payload"]["persist_succeeded"] is False
+
+
+@pytest.mark.asyncio
+async def test_verify_lineage_mismatch_emits_event():
+    """Parent live on same host but pid != child.ppid → verified=False + audit event."""
+    from src.mcp_handlers.identity import lineage_verification
+
+    parent_bindings = [_binding(host="h1", pid=9999)]
+    db, conn = _make_mock_db_for_update()
+    emit = MagicMock()
+    with patch.object(
+        lineage_verification, "get_live_bindings",
+        AsyncMock(return_value=parent_bindings),
+    ), patch("src.db.get_db", return_value=db), \
+         patch.object(lineage_verification, "_emit_lineage_mismatch_event", emit):
+        result = await lineage_verification.verify_lineage_bg(
+            child_uuid="child-1",
+            parent_uuid="parent-1",
+            child_host_id="h1",
+            child_ppid=4242,
+            child_pid=5555,
+            child_pid_start_time=1.0,
+            child_transport="http",
+        )
+
+    assert result is False
+    emit.assert_called_once()
+    payload = emit.call_args.kwargs or emit.call_args.args
+    # Event must include child uuid, parent uuid, child ppid, host, parent live pids
+    # We check the function got positional args for child_uuid + the diagnostic payload.
+    assert "child-1" in str(payload)
+    assert "parent-1" in str(payload)
+    assert conn.execute.await_args.args[1] is False
+
+
+@pytest.mark.asyncio
+async def test_verify_lineage_no_parent_binding_on_host_unverified():
+    """No parent binding visible on child's host → verified=None, no event, no DB write."""
+    from src.mcp_handlers.identity import lineage_verification
+
+    db, conn = _make_mock_db_for_update()
+    emit = MagicMock()
+    with patch.object(
+        lineage_verification, "get_live_bindings",
+        AsyncMock(return_value=[]),
+    ), patch("src.db.get_db", return_value=db), \
+         patch.object(lineage_verification, "_emit_lineage_mismatch_event", emit):
+        result = await lineage_verification.verify_lineage_bg(
+            child_uuid="child-1",
+            parent_uuid="parent-1",
+            child_host_id="h1",
+            child_ppid=4242,
+            child_pid=5555,
+            child_pid_start_time=1.0,
+            child_transport="http",
+        )
+
+    assert result is None
+    emit.assert_not_called()
+    conn.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_verify_lineage_cross_host_skipped():
+    """Parent only has bindings on a different host → verified=None, no event.
+
+    ppid is a per-host concept; cross-host lineage is out of scope (issue #128).
+    """
+    from src.mcp_handlers.identity import lineage_verification
+
+    parent_bindings = [_binding(host="h2", pid=4242)]
+    db, conn = _make_mock_db_for_update()
+    emit = MagicMock()
+    with patch.object(
+        lineage_verification, "get_live_bindings",
+        AsyncMock(return_value=parent_bindings),
+    ), patch("src.db.get_db", return_value=db), \
+         patch.object(lineage_verification, "_emit_lineage_mismatch_event", emit):
+        result = await lineage_verification.verify_lineage_bg(
+            child_uuid="child-1",
+            parent_uuid="parent-1",
+            child_host_id="h1",
+            child_ppid=4242,
+            child_pid=5555,
+            child_pid_start_time=1.0,
+            child_transport="http",
+        )
+
+    assert result is None
+    emit.assert_not_called()
+    conn.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_verify_lineage_multiple_parent_pids_one_matches():
+    """Parent has multiple live bindings on host; one pid matches → verified=True."""
+    from src.mcp_handlers.identity import lineage_verification
+
+    parent_bindings = [
+        _binding(host="h1", pid=1111),
+        _binding(host="h1", pid=4242),  # match
+        _binding(host="h1", pid=2222),
+    ]
+    db, conn = _make_mock_db_for_update()
+    emit = MagicMock()
+    with patch.object(
+        lineage_verification, "get_live_bindings",
+        AsyncMock(return_value=parent_bindings),
+    ), patch("src.db.get_db", return_value=db), \
+         patch.object(lineage_verification, "_emit_lineage_mismatch_event", emit):
+        result = await lineage_verification.verify_lineage_bg(
+            child_uuid="child-1",
+            parent_uuid="parent-1",
+            child_host_id="h1",
+            child_ppid=4242,
+            child_pid=5555,
+            child_pid_start_time=1.0,
+            child_transport="http",
+        )
+
+    assert result is True
+    emit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_verify_lineage_swallows_db_errors():
+    """DB failure during UPDATE is non-fatal — onboard must not break."""
+    from src.mcp_handlers.identity import lineage_verification
+
+    parent_bindings = [_binding(host="h1", pid=4242)]
+    db = MagicMock()
+    db.acquire = MagicMock(side_effect=RuntimeError("pool exhausted"))
+    with patch.object(
+        lineage_verification, "get_live_bindings",
+        AsyncMock(return_value=parent_bindings),
+    ), patch("src.db.get_db", return_value=db):
+        # Should not raise.
+        result = await lineage_verification.verify_lineage_bg(
+            child_uuid="child-1",
+            parent_uuid="parent-1",
+            child_host_id="h1",
+            child_ppid=4242,
+            child_pid=5555,
+            child_pid_start_time=1.0,
+            child_transport="http",
+        )
+    # On DB failure we still return the verification verdict (True here),
+    # the persistence side just couldn't write — this is a debug log, not a raise.
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_verify_lineage_swallows_get_live_bindings_errors():
+    """If parent lookup itself errors, return None and emit nothing."""
+    from src.mcp_handlers.identity import lineage_verification
+
+    with patch.object(
+        lineage_verification, "get_live_bindings",
+        AsyncMock(side_effect=RuntimeError("nope")),
+    ):
+        result = await lineage_verification.verify_lineage_bg(
+            child_uuid="child-1",
+            parent_uuid="parent-1",
+            child_host_id="h1",
+            child_ppid=4242,
+            child_pid=5555,
+            child_pid_start_time=1.0,
+            child_transport="http",
+        )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_verify_lineage_mismatch_event_payload_shape():
+    """Audit event payload includes diagnostic fields for operator triage."""
+    from src.mcp_handlers.identity import lineage_verification
+
+    parent_bindings = [
+        _binding(host="h1", pid=9999),
+        _binding(host="h1", pid=8888),
+    ]
+    db, _ = _make_mock_db_for_update()
+    captured = {}
+
+    def _capture(child_uuid, payload):
+        captured["child_uuid"] = child_uuid
+        captured["payload"] = payload
+
+    with patch.object(
+        lineage_verification, "get_live_bindings",
+        AsyncMock(return_value=parent_bindings),
+    ), patch("src.db.get_db", return_value=db), \
+         patch.object(lineage_verification, "_emit_lineage_mismatch_event", _capture):
+        await lineage_verification.verify_lineage_bg(
+            child_uuid="child-1",
+            parent_uuid="parent-1",
+            child_host_id="h1",
+            child_ppid=4242,
+            child_pid=5555,
+            child_pid_start_time=1.0,
+            child_transport="http",
+        )
+
+    assert captured["child_uuid"] == "child-1"
+    p = captured["payload"]
+    assert p["declared_parent_uuid"] == "parent-1"
+    assert p["child_ppid"] == 4242
+    assert p["host_id"] == "h1"
+    # parent_live_pids is the set of pids the parent has live on this host
+    assert set(p["parent_live_pids_on_host"]) == {9999, 8888}
+
+
+# -----------------------------------------------------------------------------
+# get_live_bindings — extended to include same_host_ppid_consistent column
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_live_bindings_includes_same_host_ppid_consistent():
+    """get_live_bindings returns same_host_ppid_consistent in each row (post-#128 schema)."""
+    ts = datetime(2026, 4, 25, 1, 2, 3, tzinfo=timezone.utc)
+    row = {
+        "host_id": "h1", "pid": 100, "pid_start_time": 1.0,
+        "transport": "http", "tty": None, "ppid": 1,
+        "anchor_path_hash": None, "client_session_id": None,
+        "onboard_ts": ts, "last_seen": ts,
+        "same_host_ppid_consistent": True,
+    }
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(return_value=[row])
+    acquire_cm = AsyncMock()
+    acquire_cm.__aenter__.return_value = conn
+    acquire_cm.__aexit__.return_value = False
+    db = MagicMock()
+    db.acquire = MagicMock(return_value=acquire_cm)
+
+    with patch("src.db.get_db", return_value=db):
+        bindings = await process_binding.get_live_bindings("agent-1")
+    assert bindings[0]["same_host_ppid_consistent"] is True
+
+
+# -----------------------------------------------------------------------------
+# list_process_bindings — surfaces same_host_ppid_consistent to operator
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_process_bindings_surfaces_same_host_ppid_consistent():
+    """MCP tool propagates same_host_ppid_consistent from get_live_bindings to operator payload."""
+    from src.mcp_handlers.identity import process_binding_handler
+
+    bindings = [
+        {"host_id": "h1", "pid": 100, "pid_start_time": 1.0, "transport": "http",
+         "tty": None, "ppid": 4242, "anchor_path_hash": None,
+         "client_session_id": None, "onboard_ts": None, "last_seen": None,
+         "same_host_ppid_consistent": True},
+    ]
+    with patch.object(
+        process_binding_handler,
+        "get_live_bindings",
+        AsyncMock(return_value=bindings),
+    ):
+        result = await process_binding_handler.handle_list_process_bindings(
+            {"agent_uuid": "agent-1"}
+        )
+    import json
+    payload = json.loads(result[0].text)
+    assert payload["bindings"][0]["same_host_ppid_consistent"] is True
+
+
+# -----------------------------------------------------------------------------
+# Advisory-only contract — pin the posture in code per dialectic review.
+# This test fails if any code path consumes the mismatch event or column
+# value to trigger an identity-mutating action (force_new, archival, etc).
+# -----------------------------------------------------------------------------
+
+
+def test_no_auto_enforcement_consumers():
+    """No code path may treat same_host_ppid_consistent or the mismatch event
+    as grounds for auto-archival, force-new, or any identity-mutating action.
+
+    The signal is advisory-only by contract (issue #128 §"Why this is
+    strictly observational"). If a future change wires an automated
+    consumer, this test fails and the change must reopen the threat model
+    in the original issue rather than silently inverting the posture.
+    """
+    import subprocess
+    import re
+
+    # Search the production tree (excluding tests and the verifier itself
+    # which legitimately mention these names) for any reference paired with
+    # an identity-mutating action.
+    forbidden_co_occurrence = re.compile(
+        r"(same_host_ppid_consistent|identity_same_host_ppid_mismatch).{0,500}"
+        r"(force_new\s*=\s*True|archive_orphan|update_agent_fields\(.*status\s*=\s*[\"']archived)",
+        re.DOTALL,
+    )
+    result = subprocess.run(
+        ["grep", "-rln", "-E",
+         "same_host_ppid_consistent|identity_same_host_ppid_mismatch",
+         "src/", "agents/"],
+        capture_output=True, text=True,
+    )
+    files = [f for f in result.stdout.splitlines()
+             if f and "lineage_verification" not in f
+             and "process_binding" not in f]  # owners of the signal
+    for path in files:
+        with open(path) as fh:
+            content = fh.read()
+        assert not forbidden_co_occurrence.search(content), (
+            f"{path}: detected a likely auto-enforcement consumer of the "
+            f"same-host ppid signal. Per issue #128 the signal is "
+            f"advisory-only — reopen the threat model before adding "
+            f"enforcement."
+        )

--- a/tests/test_process_binding.py
+++ b/tests/test_process_binding.py
@@ -282,6 +282,7 @@ async def test_get_live_bindings_returns_serialized_rows():
         "transport": "http", "tty": "/dev/ttys0", "ppid": 1,
         "anchor_path_hash": None, "client_session_id": None,
         "onboard_ts": ts, "last_seen": ts,
+        "same_host_ppid_consistent": None,
     }
     conn = AsyncMock()
     conn.fetch = AsyncMock(return_value=[row])


### PR DESCRIPTION
Closes #128. Audit-only follow-up to #123 / PR #126.

## What

When a child onboards with both `parent_agent_id` and a `process_fingerprint` that includes `ppid`, the server cross-checks the declared parent against the parent's most recent live binding on the same host.

| Verdict | Meaning | Side-effect |
|---|---|---|
| `TRUE`  | child.ppid matches one of parent's live pids on this host | column written |
| `FALSE` | parent has live bindings on host but no pid match | column written + `identity_same_host_ppid_mismatch` event |
| `NULL`  | no parent live binding on host (cross-host or never recorded) | nothing |

The agent still **declares** lineage; the server only records whether the declaration is consistent with observable same-host process ancestry.

## Naming discipline (per dialectic review)

The column is `same_host_ppid_consistent` and the event is `identity_same_host_ppid_mismatch` rather than `verified_lineage` / `identity_lineage_mismatch`. The narrower name prevents the inference *"no event = lineage verified"* — cross-host lineage is **never checked** (ppid is per-host).

## Wiring

The verifier is sequenced **after** `record_binding_bg` in onboard so the binding-row INSERT lands before the UPDATE. asyncpg's `"UPDATE N"` rowcount is parsed: a 0-row UPDATE means `record_binding_bg` silently failed earlier, and the mismatch event payload's `persist_succeeded=false` flag surfaces this so an operator does not mistake the NULL column for "never checked."

## Advisory-only contract

A contract test (`test_no_auto_enforcement_consumers`) fails if any code path consumes the column or event for `force_new`, archival, or other identity-mutating action. **Reopen the threat model in issue #128 before adding enforcement.**

## Operator action required

Migration 016 ALTERs `core.agent_process_bindings` — depends on 015 (unapplied on long-lived databases at HEAD's time). On the dev database (currently at v13), apply 014 → 015 → 016 in order. Runtime tolerates the missing column via the `get_live_bindings` exception path.

## Tests

- 16 new in `test_lineage_verification.py`: match / mismatch / cross-host / no-parent-binding / multi-pid / dangling-state / persist failure / payload shape / advisory-only contract test
- 1 existing fixture in `test_process_binding.py` updated for the new column
- Full suite: **7140 passed, 33 skipped**

## Council review

Both reviewers (code + dialectic) ran in parallel before this PR opened. Findings applied in this changeset:
- column + event renamed to scope-bounded names (dialectic)
- `child_pid` added to event payload (code)
- `persist_succeeded` flag in event payload (code)
- combined-failure dangling-state test added (code)
- advisory-only contract test added (dialectic)
- migration commented for out-of-order application (code)

Findings deferred (precedent match, no code change):
- `verify_lineage_bg` does direct asyncpg from a fire-and-forget task — same posture as `record_binding_bg`, no anyio deadlock observed in production.