### PR TITLE
fix(vigil): preserve groundskeeper counts across non-audit cycles

### DIFF
--- a/agents/vigil/agent.py
+++ b/agents/vigil/agent.py
@@ -520,10 +520,20 @@ class VigilAgent(GovernanceAgent):
         # Build cycle state (pre-checkin; coherence/verdict filled in post-checkin)
         total_cycles = prev_state.get("total_cycles", 0) + 1
 
+        # Preserve groundskeeper counts across non-audit cycles — otherwise
+        # they reset to 0, then the next audit cycle compares against 0 and
+        # dedupe fails (note re-emits even though stale/archived didn't move).
+        if groundskeeper_summary.get("audit_run"):
+            gk_stale = groundskeeper_summary.get("stale_found", 0)
+            gk_archived = groundskeeper_summary.get("archived", 0)
+        else:
+            gk_stale = prev_state.get("groundskeeper_stale", 0)
+            gk_archived = prev_state.get("groundskeeper_archived", 0)
+
         self._cycle_state = {
             **health_state,
-            "groundskeeper_stale": groundskeeper_summary.get("stale_found", 0),
-            "groundskeeper_archived": groundskeeper_summary.get("archived", 0),
+            "groundskeeper_stale": gk_stale,
+            "groundskeeper_archived": gk_archived,
             "total_cycles": total_cycles,
             "cycle_time": datetime.now(timezone.utc).isoformat(),
         }

--- a/agents/vigil/tests/test_sentinel_coordination.py
+++ b/agents/vigil/tests/test_sentinel_coordination.py
@@ -263,6 +263,33 @@ class TestRunCycleCoordination:
         client.audit_knowledge.assert_awaited()
 
     @pytest.mark.asyncio
+    async def test_non_audit_cycle_preserves_groundskeeper_counts(self, monkeypatch):
+        """Non-audit cycles must carry over prev_state's groundskeeper counts.
+
+        Regression for the dedupe failure across audit-gated cycles: a non-audit
+        cycle was overwriting groundskeeper_stale/archived with 0, so the next
+        audit cycle compared against 0 and the "unchanged" check fired even when
+        the real counts hadn't moved — duplicate KG note every time.
+        """
+        _patch_health_checks(monkeypatch)
+
+        agent = _make_agent(with_audit=False)
+        agent.load_state = lambda: {
+            "cycle_time": "2026-04-14T10:00:00+00:00",
+            "groundskeeper_stale": 5,
+            "groundskeeper_archived": 2,
+        }
+
+        client = _full_mock_client(search_results=[])
+        await agent.run_cycle(client)
+
+        # Audit didn't run this cycle
+        client.audit_knowledge.assert_not_awaited()
+        # Counts carry over from prev_state, not zeroed
+        assert agent._cycle_state["groundskeeper_stale"] == 5
+        assert agent._cycle_state["groundskeeper_archived"] == 2
+
+    @pytest.mark.asyncio
     async def test_broken_search_does_not_break_cycle(self, monkeypatch):
         _patch_health_checks(monkeypatch)
 


### PR DESCRIPTION
## Summary
- Vigil's groundskeeper dedupe (added 2bd31b7e on 2026-04-20) only worked when audit ran every cycle. In practice the groundskeeper is gated on with_audit / Sentinel coordination, so non-audit cycles overwrote groundskeeper_stale and groundskeeper_archived in cycle state with 0. The next audit cycle compared against 0 and re-emitted the same KG note even when stale/archived counts hadn't moved.
- Carry the prior counts forward when audit didn't run so dedupe survives audit-gated cycles. Adds a regression test exercising a full non-audit run_cycle path (test_sentinel_coordination.py::test_non_audit_cycle_preserves_groundskeeper_counts).

Surfaced while sweeping ritual KG noise — two identical 'Groundskeeper: 5 stale, 0 archived' notes from 2026-04-24 (01:18 + 05:00) had slipped through despite dedupe being live since 2026-04-20.

## Test plan
- [x] agents/vigil/tests/test_groundskeeper.py + test_sentinel_coordination.py — 30 passed
- [x] ./scripts/dev/test-cache.sh — 7127 passed, 33 skipped