### PR TITLE
S15-a: server-side skills MCP tool

### DIFF
--- a/src/mcp_handlers/__init__.py
+++ b/src/mcp_handlers/__init__.py
@@ -65,6 +65,7 @@ from .introspection.tool_introspection import (
     handle_list_tools,
     handle_describe_tool,
 )
+from .introspection.skills import handle_skills  # S15-a: server-side skills surface
 # Knowledge Graph
 from .knowledge.handlers import (
     handle_store_knowledge_graph,

--- a/src/mcp_handlers/introspection/skills.py
+++ b/src/mcp_handlers/introspection/skills.py
@@ -1,0 +1,234 @@
+"""Server-side `skills` MCP introspection handler.
+
+Per docs/ontology/s15-server-side-skills.md (S15-a). Reads canonical skill
+content from `unitares/skills/*/SKILL.md`, parses YAML frontmatter, and
+returns a structured response keyed by skill name + content hash.
+
+Identity-blindness invariant (§4.5): the handler does NOT consume agent
+identity. Identity-derived arguments are accepted but ignored — same
+content for every caller. Cache key downstream is content-addressed.
+
+The handler reads from disk on every call. Files total ~50KB, no DB
+involvement, so the anyio-asyncio mitigation patterns from CLAUDE.md
+do not apply (no `await` against asyncpg/Redis in this path).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import date
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+import yaml
+from mcp.types import TextContent
+
+from src.logging_utils import get_logger
+
+from ..decorators import mcp_tool
+from ..response_base import success_response
+
+logger = get_logger(__name__)
+
+# Resolve skills/ relative to repo root (this file lives at
+# <repo>/src/mcp_handlers/introspection/skills.py — go up four levels).
+_SKILLS_ROOT = Path(__file__).resolve().parents[3] / "skills"
+
+
+# ---------------------------------------------------------------------
+# Frontmatter parsing
+# ---------------------------------------------------------------------
+
+def _split_frontmatter(text: str) -> tuple[Dict[str, Any], str]:
+    """Split a SKILL.md into (frontmatter_dict, body_markdown).
+
+    Format: leading `---\\n`, YAML block, closing `---\\n`, then body.
+    Files without frontmatter return ({}, full_text).
+    """
+    if not text.startswith("---\n"):
+        return {}, text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return {}, text
+    raw_yaml = text[4:end]
+    body = text[end + 5 :]
+    try:
+        meta = yaml.safe_load(raw_yaml) or {}
+    except yaml.YAMLError as exc:
+        logger.warning("[SKILLS] frontmatter parse error: %s", exc)
+        meta = {}
+    if not isinstance(meta, dict):
+        meta = {}
+    return meta, body
+
+
+def _content_hash(body: str) -> str:
+    return "sha256:" + hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------
+# Skill loading
+# ---------------------------------------------------------------------
+
+def _load_skill(skill_dir: Path) -> Optional[Dict[str, Any]]:
+    """Load and parse one skill directory. Returns None if unloadable."""
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.is_file():
+        return None
+    try:
+        text = skill_md.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.warning("[SKILLS] could not read %s: %s", skill_md, exc)
+        return None
+
+    meta, body = _split_frontmatter(text)
+
+    # Name falls back to directory name if frontmatter missing it.
+    name = meta.get("name") or skill_dir.name
+    last_verified = meta.get("last_verified")
+    if isinstance(last_verified, date):
+        last_verified = last_verified.isoformat()
+    elif last_verified is not None:
+        last_verified = str(last_verified)
+
+    source_files = meta.get("source_files") or []
+    if not isinstance(source_files, list):
+        source_files = []
+
+    triggers = meta.get("triggers")
+    if not isinstance(triggers, dict):
+        triggers = None
+
+    skill: Dict[str, Any] = {
+        "name": str(name),
+        "description": str(meta.get("description") or "").strip(),
+        "version": last_verified,  # ISO date doubles as per-skill version
+        "last_verified": last_verified,
+        "freshness_days": meta.get("freshness_days"),
+        "source_files": [str(s) for s in source_files],
+        "triggers": triggers,
+        "stale": _compute_stale(last_verified, meta.get("freshness_days")),
+        "content": body,
+        "content_hash": _content_hash(body),
+    }
+    return skill
+
+
+def _compute_stale(last_verified: Optional[str], freshness_days: Any) -> bool:
+    """Compute stale flag based on age of last_verified vs freshness_days.
+
+    Conservative — uses date arithmetic, not git log against source_files.
+    git-log staleness is a future enhancement; the date check covers the
+    common case (skill not touched in N days).
+    """
+    if not last_verified:
+        return False
+    try:
+        verified = date.fromisoformat(last_verified)
+    except (ValueError, TypeError):
+        return False
+    if not isinstance(freshness_days, (int, float)):
+        return False
+    age = (date.today() - verified).days
+    return age > int(freshness_days)
+
+
+def _load_all_skills() -> List[Dict[str, Any]]:
+    if not _SKILLS_ROOT.is_dir():
+        return []
+    skills: List[Dict[str, Any]] = []
+    for entry in sorted(_SKILLS_ROOT.iterdir()):
+        if not entry.is_dir() or entry.name.startswith("."):
+            continue
+        skill = _load_skill(entry)
+        if skill is not None:
+            skills.append(skill)
+    return skills
+
+
+def _registry_hash(skills: List[Dict[str, Any]]) -> str:
+    """Deterministic hash over the canonical-ordered (name, content_hash) pairs.
+
+    Independent of any caller-supplied state. Stable across processes.
+    """
+    canonical = [(s["name"], s["content_hash"]) for s in sorted(skills, key=lambda s: s["name"])]
+    digest = hashlib.sha256(
+        json.dumps(canonical, ensure_ascii=False).encode("utf-8")
+    ).hexdigest()
+    return "sha256:" + digest
+
+
+def _registry_version(skills: List[Dict[str, Any]]) -> Optional[str]:
+    """Max last_verified across all skills. Drives client cache-invalidation."""
+    dates = [s["last_verified"] for s in skills if s.get("last_verified")]
+    return max(dates) if dates else None
+
+
+# ---------------------------------------------------------------------
+# Filtering
+# ---------------------------------------------------------------------
+
+def _filter_skills(
+    skills: List[Dict[str, Any]],
+    *,
+    name: Optional[str],
+    since_version: Optional[str],
+) -> List[Dict[str, Any]]:
+    out = skills
+    if name:
+        out = [s for s in out if s["name"] == name]
+    if since_version:
+        out = [
+            s for s in out
+            if s.get("last_verified") and s["last_verified"] > since_version
+        ]
+    return out
+
+
+# ---------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------
+
+@mcp_tool("skills", timeout=10.0, rate_limit_exempt=True)
+async def handle_skills(arguments: Dict[str, Any]) -> Sequence[TextContent]:
+    """Return server-authored skill bundle for adapter consumption.
+
+    Parameters:
+        name (str, optional): Return only the skill with this exact name.
+        since_version (str, optional): ISO date; return only skills with
+            last_verified > since_version. Used for cheap re-poll cache
+            invalidation by client adapters.
+
+    Identity-blind: identity-derived arguments are silently ignored (§4.5).
+
+    Returns response with shape:
+        {
+          "skills": [{name, description, version, last_verified, ...}],
+          "registry_version": "<max last_verified>",
+          "registry_hash": "sha256:..."
+        }
+    """
+    args = arguments or {}
+    name = args.get("name") if isinstance(args.get("name"), str) else None
+    since_version = (
+        args.get("since_version")
+        if isinstance(args.get("since_version"), str)
+        else None
+    )
+
+    all_skills = _load_all_skills()
+    registry_hash = _registry_hash(all_skills)
+    registry_version = _registry_version(all_skills)
+    filtered = _filter_skills(all_skills, name=name, since_version=since_version)
+
+    data = {
+        "skills": filtered,
+        "registry_version": registry_version,
+        "registry_hash": registry_hash,
+    }
+    # lite_response=True suppresses the default `agent_signature: {"uuid": None}`
+    # block — without it, even an unbound caller gets an identity-shaped field
+    # in the response, which violates the §4.5 identity-blindness invariant
+    # (skills are content-addressed; cache keys must not vary by identity).
+    return success_response(data, arguments={"lite_response": True})

--- a/src/mcp_handlers/middleware/rate_limit_step.py
+++ b/src/mcp_handlers/middleware/rate_limit_step.py
@@ -50,7 +50,7 @@ async def check_rate_limit(name: str, arguments: Dict[str, Any], ctx) -> Any:
         _tool_call_history[name].append(now)
 
     # General rate limiting (skip for read-only tools)
-    read_only_tools = {'health_check', 'get_server_info', 'list_tools', 'get_thresholds', 'search_knowledge_graph', 'get_governance_metrics'}
+    read_only_tools = {'health_check', 'get_server_info', 'list_tools', 'get_thresholds', 'search_knowledge_graph', 'get_governance_metrics', 'skills'}
     if name not in read_only_tools:
         agent_id = arguments.get('agent_id') or 'anonymous'
         rate_limiter = get_rate_limiter()

--- a/src/mcp_handlers/schemas/skills.py
+++ b/src/mcp_handlers/schemas/skills.py
@@ -1,0 +1,25 @@
+"""Pydantic schema for the `skills` MCP introspection tool.
+
+Per docs/ontology/s15-server-side-skills.md §4.1.
+
+The tool is read-only and identity-blind (§4.5): identity-derived parameters
+on the request payload are accepted (so adapters can pass through MCP
+identity middleware without dropping fields) but MUST NOT vary the response.
+"""
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class SkillsParams(BaseModel):
+    """Request shape for the `skills` introspection tool."""
+
+    name: Optional[str] = Field(
+        default=None,
+        description="Return only the skill matching this exact name (e.g. 'governance-lifecycle'). If absent, return the full bundle.",
+    )
+    since_version: Optional[str] = Field(
+        default=None,
+        description="ISO date string. Return only skills with last_verified > since_version. Used by client adapters for cheap re-poll cache invalidation.",
+    )

--- a/src/tool_schemas.py
+++ b/src/tool_schemas.py
@@ -43,6 +43,7 @@ def _load_pydantic_schemas():
         "src.mcp_handlers.schemas.identity",
         "src.mcp_handlers.schemas.admin",
         "src.mcp_handlers.schemas.dashboard",
+        "src.mcp_handlers.schemas.skills",  # S15-a
         *_EXTRA_SCHEMA_MODULES,
     ]
     all_schemas = {}
@@ -120,6 +121,7 @@ TOOL_ORDER = [
     "detect_anomalies",
     "list_tools",
     "describe_tool",
+    "skills",
     "cleanup_stale_locks",
     "validate_file_path",
     "store_knowledge_graph",

--- a/tests/test_skills_introspection.py
+++ b/tests/test_skills_introspection.py
@@ -1,0 +1,174 @@
+"""Tests for the `skills` MCP introspection handler.
+
+Per docs/ontology/s15-server-side-skills.md §4.1 + Appendix.
+
+The handler reads `unitares/skills/*/SKILL.md`, parses YAML frontmatter,
+and returns a structured response keyed by skill name + version. It does
+NOT consume any agent identity — see §4.5 (identity-blindness invariant).
+"""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from mcp.types import TextContent
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def _call_handler(arguments: dict) -> dict:
+    """Invoke the skills handler synchronously and return the parsed payload."""
+    from src.mcp_handlers.introspection.skills import handle_skills
+
+    result = asyncio.run(handle_skills(arguments))
+    assert isinstance(result, list) and len(result) > 0, "expected non-empty TextContent list"
+    assert isinstance(result[0], TextContent)
+    return json.loads(result[0].text)
+
+
+# ---------------------------------------------------------------------
+# Response shape
+# ---------------------------------------------------------------------
+
+def test_handler_returns_skills_array():
+    payload = _call_handler({})
+    assert payload["success"] is True
+    assert "skills" in payload
+    assert isinstance(payload["skills"], list)
+    assert len(payload["skills"]) > 0, (
+        "skills/ directory has 6 skills; handler must return at least one"
+    )
+
+
+def test_handler_parses_known_skill_frontmatter():
+    """`governance-fundamentals` is a known canonical skill; verify its frontmatter parses."""
+    payload = _call_handler({})
+    names = {s["name"] for s in payload["skills"]}
+    assert "governance-fundamentals" in names, (
+        f"governance-fundamentals not in response; got {names}"
+    )
+    skill = next(s for s in payload["skills"] if s["name"] == "governance-fundamentals")
+    assert skill["description"], "description must be non-empty"
+    assert "last_verified" in skill, "frontmatter must surface last_verified"
+    assert "freshness_days" in skill, "frontmatter must surface freshness_days"
+    assert "source_files" in skill, "frontmatter must surface source_files"
+    assert isinstance(skill["source_files"], list)
+    assert "content" in skill, "skill must include the markdown body"
+    assert "content_hash" in skill, "skill must include content_hash for cache invalidation"
+
+
+def test_handler_returns_registry_version_and_hash():
+    """Top-level fields per §4.5 — version + hash drive client cache invalidation."""
+    payload = _call_handler({})
+    assert "registry_version" in payload, "top-level registry_version required"
+    assert "registry_hash" in payload, "top-level registry_hash required"
+    assert payload["registry_hash"].startswith("sha256:"), (
+        "registry_hash must be sha256-prefixed for transparency"
+    )
+
+
+# ---------------------------------------------------------------------
+# Filtering
+# ---------------------------------------------------------------------
+
+def test_handler_filters_by_name_param():
+    """`name=<skill>` returns only that skill."""
+    payload = _call_handler({"name": "governance-fundamentals"})
+    assert len(payload["skills"]) == 1
+    assert payload["skills"][0]["name"] == "governance-fundamentals"
+
+
+def test_handler_unknown_name_returns_empty_skills():
+    """Asking for a skill that doesn't exist must not error — returns empty array."""
+    payload = _call_handler({"name": "no-such-skill-zzzz"})
+    assert payload["success"] is True
+    assert payload["skills"] == []
+
+
+def test_handler_filters_by_since_version_future():
+    """`since_version` newer than registry returns empty (cheap re-poll case)."""
+    payload = _call_handler({"since_version": "2099-12-31"})
+    assert payload["success"] is True
+    assert payload["skills"] == [], (
+        "since_version in the future means no skills updated since; expect empty array"
+    )
+
+
+def test_handler_filters_by_since_version_past_returns_all():
+    """`since_version` older than every skill returns the full bundle."""
+    payload = _call_handler({"since_version": "1970-01-01"})
+    assert payload["success"] is True
+    assert len(payload["skills"]) > 0
+
+
+# ---------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------
+
+def test_handler_registry_hash_is_deterministic():
+    """Same input on disk → same registry_hash. No timestamps, no agent state."""
+    p1 = _call_handler({})
+    p2 = _call_handler({})
+    assert p1["registry_hash"] == p2["registry_hash"]
+    assert p1["registry_version"] == p2["registry_version"]
+
+
+def test_handler_content_hash_is_per_skill_stable():
+    p1 = _call_handler({})
+    p2 = _call_handler({})
+    h1 = {s["name"]: s["content_hash"] for s in p1["skills"]}
+    h2 = {s["name"]: s["content_hash"] for s in p2["skills"]}
+    assert h1 == h2
+
+
+# ---------------------------------------------------------------------
+# Identity-blindness (§4.5 invariant — load-bearing)
+# ---------------------------------------------------------------------
+
+def test_handler_response_does_not_leak_agent_identity():
+    """Skills are content-addressed. The response must not include any agent-
+    derived value — no agent_uuid, no agent_id, no client_session_id at the
+    skill level. This is the §4.5 invariant guarding against future
+    'personalize per agent' optimizations that would smuggle identity into a
+    structurally identity-blind surface."""
+    payload = _call_handler({})
+    forbidden_keys = {"agent_uuid", "agent_id", "client_session_id", "continuity_token"}
+    for skill in payload["skills"]:
+        for k in skill.keys():
+            assert k not in forbidden_keys, (
+                f"identity-blindness violation: skill {skill.get('name')} contains {k}"
+            )
+    # Top-level too — agent_signature is added by success_response when agent_id passed,
+    # but the handler must not be passing agent_id.
+    assert "agent_signature" not in payload, (
+        "skills handler must not pass agent_id to success_response — would taint cache key"
+    )
+
+
+def test_handler_ignores_identity_arguments():
+    """If a caller passes agent_uuid or client_session_id, the handler must
+    return identical content (cache must not vary by identity)."""
+    p_anon = _call_handler({})
+    p_with_id = _call_handler({
+        "agent_uuid": "00000000-0000-0000-0000-000000000000",
+        "client_session_id": "irrelevant",
+    })
+    assert p_anon["registry_hash"] == p_with_id["registry_hash"], (
+        "identity arguments must not change the response shape"
+    )
+
+
+# ---------------------------------------------------------------------
+# Stale flag (§4.4)
+# ---------------------------------------------------------------------
+
+def test_handler_returns_stale_flag_per_skill():
+    """Each skill must carry a `stale: bool` field. Computation is git-log against
+    source_files vs last_verified; result is bool either way."""
+    payload = _call_handler({})
+    for skill in payload["skills"]:
+        assert "stale" in skill, f"skill {skill['name']} missing stale flag"
+        assert isinstance(skill["stale"], bool)


### PR DESCRIPTION
## Summary

Per docs/ontology/s15-server-side-skills.md §4. New `skills` MCP introspection tool reads canonical skill content from `unitares/skills/*/SKILL.md`, parses YAML frontmatter, returns structured response keyed by skill name + content hash. Adapters consume this via standard MCP describe_tool / tool dispatch and render in their native skill format.

**Identity-blindness invariant locked at §4.5:** handler does not consume agent identity. Identity-derived arguments are silently ignored — same content for every caller. Cache keys downstream are content-addressed. Implementation passes \`lite_response=True\` to \`success_response()\` to suppress the default \`agent_signature\` block (caught by regression test as a leak).

No DB access in the handler path — files total ~50KB, no asyncpg/Redis involvement, anyio-asyncio mitigation patterns from CLAUDE.md not needed.

## Files

- **NEW** \`src/mcp_handlers/introspection/skills.py\`
- **NEW** \`src/mcp_handlers/schemas/skills.py\`
- **NEW** \`tests/test_skills_introspection.py\` (12 regression tests, including identity-blindness contract test for §4.5 invariant)
- **M** \`src/mcp_handlers/__init__.py\` — register handler import
- **M** \`src/mcp_handlers/middleware/rate_limit_step.py\` — add 'skills' to \`read_only_tools\` (parity with list_tools rate-limit posture, since decorator's \`rate_limit_exempt\` flag is not consulted by middleware)
- **M** \`src/tool_schemas.py\` — register schema module + TOOL_ORDER entry

## Out of scope (per design doc §4.6)

- Skill content (S15-b consolidation)
- Per-client adapters (S15-c+)
- Triggers field population (existing skills don't have triggers in frontmatter; handler returns triggers=None when absent)

## Pairing note

§11.9 recommends pairing S15-a with at least drafted S15-b to avoid shipping a tool pointing at known-divergent source-of-truth. S15-b is the next ship; the 5/6 skill-bundle divergence between \`unitares/skills/\` and \`unitares-governance-plugin/skills/\` remains until content consolidation lands.

## Test plan

- [x] 12 new regression tests pass (frontmatter parse, name/since_version filtering, registry hash determinism, identity-blindness, stale flag)
- [x] 138 smoke tests pass via ship.sh pre-push gate
- [x] \`describe_tool(tool_name='skills')\` returns the new tool
- [x] \`skills\` registered in TOOL_HANDLERS, TOOL_ORDER, and pydantic schema discovery