### PR TITLE
chore: remove ngrok.ai LLM gateway path and clean stale ngrok refs

### DIFF
--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -60,7 +60,7 @@ tail -f data/logs/mcp_server_error.log
 
 **Symptoms:**
 - Remote URL returns connection error
-- Tunnel process (`cloudflared`, `ngrok`, etc.) logs show failures
+- Tunnel process (`cloudflared`, etc.) logs show failures
 
 **Solutions:**
 
@@ -257,7 +257,7 @@ grep -i error data/logs/mcp_server.log | tail -20
 cat ~/.claude.json | python3 -m json.tool
 
 # Environment variables
-env | grep -E "(DB_|UNITARES_|NGROK_)"
+env | grep -E "(DB_|UNITARES_)"
 
 # Python path
 which python3
@@ -303,8 +303,7 @@ launchctl load ~/Library/LaunchAgents/com.unitares.governance-mcp.plist
 ### Documentation
 
 1. [START_HERE.md](START_HERE.md) — Thin default workflow and doc map
-2. [Ngrok Deployment](NGROK_DEPLOYMENT.md) — Client configuration and remote access
-3. [database_architecture.md](../operations/database_architecture.md) — Database details
+2. [database_architecture.md](../operations/database_architecture.md) — Database details
 
 ### Health Monitoring
 

--- a/scripts/diagnostics/audit_markdown_proliferation.py
+++ b/scripts/diagnostics/audit_markdown_proliferation.py
@@ -28,7 +28,6 @@ APPROVED_FILES = {
     'docs/UNIFIED_ARCHITECTURE.md',
     'docs/guides/START_HERE.md',
     'docs/guides/TROUBLESHOOTING.md',
-    'docs/guides/NGROK_DEPLOYMENT.md',
     'docs/guides/CIRS_PROTOCOL.md',
     'docs/operations/DEFINITIVE_PORTS.md',
     'docs/operations/OPERATOR_RUNBOOK.md',

--- a/src/mcp_handlers/__init__.py
+++ b/src/mcp_handlers/__init__.py
@@ -104,7 +104,7 @@ from .identity.handlers import (
     handle_verify_trajectory_identity,
     handle_get_trajectory_status,
 )
-# Model Inference - Free/low-cost LLM access via ngrok.ai
+# Model Inference - Free/low-cost LLM access via Ollama (local) or HF Inference Providers
 from .support.model_inference import handle_call_model
 # Outcome Events - EISV validation infrastructure (Feb 2026)
 from .observability.outcome_events import handle_outcome_event

--- a/src/mcp_handlers/support/model_inference.py
+++ b/src/mcp_handlers/support/model_inference.py
@@ -20,7 +20,8 @@ from src.logging_utils import get_logger
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 logger = get_logger(__name__)
 
-# Check if OpenAI SDK available (used for ngrok.ai compatibility)
+# Check if OpenAI SDK available (Ollama and HF Inference Providers expose
+# OpenAI-compatible APIs that this client speaks).
 try:
     from openai import OpenAI
     OPENAI_AVAILABLE = True
@@ -177,51 +178,17 @@ async def handle_call_model(arguments: Dict[str, Any]) -> Sequence[TextContent]:
                     }
                 )]
     else:
-        # Default branch: custom OpenAI-compatible endpoint (ngrok gateway,
-        # self-hosted router, etc.). Reached when a caller passes a provider
-        # value outside the schema enum — the Pydantic layer normally blocks
-        # this, so this path only fires via direct handler calls or when the
-        # enum is widened. No hard-coded default model here: the caller must
-        # name a model the target endpoint actually serves.
-        base_url = os.getenv("NGROK_AI_ENDPOINT", "https://api.openai.com/v1")
-        api_key = os.getenv("NGROK_API_KEY") or os.getenv("OPENAI_API_KEY")
-        if not api_key:
-            return [error_response(
-                "NGROK_API_KEY or OPENAI_API_KEY required for model inference",
-                error_code="MISSING_CONFIG",
-                error_category="system_error",
-                recovery={
-                    "action": "Set NGROK_API_KEY or OPENAI_API_KEY environment variable",
-                    "related_tools": ["health_check", "get_connection_status"],
-                    "workflow": [
-                        "1. Set environment variable: export NGROK_API_KEY=your_key",
-                        "2. Or set: export OPENAI_API_KEY=your_key",
-                        "3. Restart MCP server",
-                        "4. Retry call_model tool"
-                    ]
-                }
-            )]
-        if model == "auto":
-            return [error_response(
-                "Custom provider requires an explicit model name; 'auto' is not supported here.",
-                error_code="MISSING_PARAM",
-                error_category="validation_error",
-                recovery={
-                    "action": "Pass an explicit model name that your endpoint serves",
-                    "related_tools": ["health_check"],
-                    "workflow": [
-                        "1. Identify a model your custom endpoint exposes",
-                        "2. Pass it via the 'model' parameter",
-                        "3. Retry call_model tool"
-                    ]
-                }
-            )]
-        logger.info(f"Using custom OpenAI-compatible endpoint: {model}")
+        # Unknown provider value. Pydantic schema (Literal["auto","hf","ollama"])
+        # blocks this in normal MCP calls; only direct calls can reach here.
+        return [error_response(
+            f"Unknown provider '{provider}'. Expected one of: auto, hf, ollama.",
+            error_code="INVALID_PROVIDER",
+            error_category="validation_error",
+        )]
     
     try:
         client = OpenAI(base_url=base_url, api_key=api_key)
         
-        # Call model via ngrok.ai (or direct if not using gateway)
         logger.debug(f"Calling model '{model}' via {base_url} for task_type='{task_type}'")
         
         response = client.chat.completions.create(
@@ -297,8 +264,6 @@ async def handle_call_model(arguments: Dict[str, Any]) -> Sequence[TextContent]:
             routed_via = "huggingface"
         elif "localhost" in base_url or "127.0.0.1" in base_url:
             routed_via = "ollama"
-        elif "ngrok" in base_url.lower():
-            routed_via = "ngrok.ai"
         else:
             routed_via = "direct"
         

--- a/src/mcp_handlers/validators.py
+++ b/src/mcp_handlers/validators.py
@@ -60,7 +60,6 @@ def validate_file_path_policy(file_path: str) -> Tuple[Optional[str], Optional[T
             'docs/UNIFIED_ARCHITECTURE.md',
             'docs/guides/START_HERE.md',
             'docs/guides/TROUBLESHOOTING.md',
-            'docs/guides/NGROK_DEPLOYMENT.md',
             'docs/guides/CIRS_PROTOCOL.md',
             'docs/operations/DEFINITIVE_PORTS.md',
             'docs/operations/OPERATOR_RUNBOOK.md',

--- a/tests/test_model_inference.py
+++ b/tests/test_model_inference.py
@@ -572,44 +572,16 @@ class TestAutoProviderSelection:
 
 
 # =============================================================================
-# Tests: Default/other provider (ngrok/OpenAI endpoint)
+# Tests: Unknown provider rejection (Pydantic-blocked at MCP boundary,
+# but direct callers must still get a clean error)
 # =============================================================================
 
-class TestDefaultProvider:
-    """Tests for default (ngrok/OpenAI) provider routing.
-
-    These reach the final else branch in provider routing.
-    Must use privacy="cloud" to skip the Ollama shortcut.
-    """
+class TestUnknownProvider:
+    """Tests that an unknown provider value returns INVALID_PROVIDER."""
 
     @pytest.mark.asyncio
-    async def test_default_provider_requires_api_key(self):
-        """Default provider returns error when no API key set."""
-        with patch("src.mcp_handlers.support.model_inference.OPENAI_AVAILABLE", True), \
-             patch.dict("os.environ", {}, clear=True):
-            from src.mcp_handlers.support.model_inference import handle_call_model
-            result = await handle_call_model({
-                "prompt": "Hello",
-                "provider": "openai",
-                "privacy": "cloud",
-            })
-
-        parsed = _parse_text_content(result)
-        assert parsed["success"] is False
-        assert "NGROK_API_KEY" in parsed["error"] or "OPENAI_API_KEY" in parsed["error"]
-
-    @pytest.mark.asyncio
-    async def test_default_provider_with_api_key(self):
-        """Default provider works with API key."""
-        mock_client_instance = MagicMock()
-        mock_client_instance.chat.completions.create.return_value = _make_mock_response(
-            content="openai response", model="gpt-4"
-        )
-
-        env = {"OPENAI_API_KEY": "sk-test-key"}
-        with patch("src.mcp_handlers.support.model_inference.OPENAI_AVAILABLE", True), \
-             patch("src.mcp_handlers.support.model_inference.OpenAI", return_value=mock_client_instance), \
-             patch.dict("os.environ", env, clear=False):
+    async def test_unknown_provider_rejected(self):
+        with patch("src.mcp_handlers.support.model_inference.OPENAI_AVAILABLE", True):
             from src.mcp_handlers.support.model_inference import handle_call_model
             result = await handle_call_model({
                 "prompt": "Hello",
@@ -619,27 +591,9 @@ class TestDefaultProvider:
             })
 
         parsed = _parse_text_content(result)
-        assert parsed["success"] is True
-        assert parsed["routed_via"] == "direct"
-
-    @pytest.mark.asyncio
-    async def test_default_provider_rejects_auto_model(self):
-        """Custom endpoints must specify a model — 'auto' is rejected."""
-        env = {"OPENAI_API_KEY": "sk-test-key"}
-        with patch("src.mcp_handlers.support.model_inference.OPENAI_AVAILABLE", True), \
-             patch.dict("os.environ", env, clear=False):
-            from src.mcp_handlers.support.model_inference import handle_call_model
-            result = await handle_call_model({
-                "prompt": "Hello",
-                "provider": "openai",
-                "privacy": "cloud",
-                "model": "auto",
-            })
-
-        parsed = _parse_text_content(result)
         assert parsed["success"] is False
-        assert parsed.get("error_code") == "MISSING_PARAM"
-        assert "explicit model" in parsed["error"].lower()
+        assert parsed.get("error_code") == "INVALID_PROVIDER"
+        assert "openai" in parsed["error"]
 
 
 # =============================================================================
@@ -1098,33 +1052,9 @@ class TestRoutingViaDetection:
         parsed = _parse_text_content(result)
         assert parsed["routed_via"] == "huggingface"
 
-    # Gemini provider and its routed_via="gemini-direct" label were removed.
-
-    @pytest.mark.asyncio
-    async def test_routed_via_direct_for_custom_endpoint(self):
-        """Detects direct routing for non-standard endpoints.
-
-        Post-#80 custom endpoints require an explicit `model` (the Gemini
-        fallback was removed), so the test passes one that the caller's
-        endpoint would serve.
-        """
-        mock_client_instance = MagicMock()
-        mock_client_instance.chat.completions.create.return_value = _make_mock_response()
-
-        env = {"OPENAI_API_KEY": "sk-test"}
-        with patch("src.mcp_handlers.support.model_inference.OPENAI_AVAILABLE", True), \
-             patch("src.mcp_handlers.support.model_inference.OpenAI", return_value=mock_client_instance), \
-             patch.dict("os.environ", env, clear=False):
-            from src.mcp_handlers.support.model_inference import handle_call_model
-            result = await handle_call_model({
-                "prompt": "test",
-                "provider": "openai",
-                "privacy": "cloud",
-                "model": "gpt-4o-mini",
-            })
-
-        parsed = _parse_text_content(result)
-        assert parsed["routed_via"] == "direct"
+    # Gemini provider and ngrok.ai gateway (routed_via="gemini-direct"/"ngrok.ai")
+    # were removed. The "direct" routed_via fallback is retained as defensive
+    # default but is unreachable through the supported provider set.
 
 
 # =============================================================================

--- a/tests/test_remaining_modules.py
+++ b/tests/test_remaining_modules.py
@@ -931,15 +931,10 @@ class TestHandleCallModel:
             assert data["success"] is False
 
     @pytest.mark.asyncio
-    async def test_unknown_provider_requires_openai_key(self):
-        # Gemini provider was removed; any unknown provider now falls into the
-        # custom-endpoint branch, which requires NGROK_API_KEY / OPENAI_API_KEY.
-        env_clean = {
-            k: v for k, v in os.environ.items()
-            if k not in ("NGROK_API_KEY", "OPENAI_API_KEY")
-        }
-        with patch("src.mcp_handlers.support.model_inference.OPENAI_AVAILABLE", True), \
-             patch.dict(os.environ, env_clean, clear=True):
+    async def test_unknown_provider_rejected(self):
+        # Gemini and ngrok.ai providers were removed. Pydantic blocks unknown
+        # values at the MCP boundary; direct callers get INVALID_PROVIDER.
+        with patch("src.mcp_handlers.support.model_inference.OPENAI_AVAILABLE", True):
             result = await handle_call_model({
                 "prompt": "test",
                 "provider": "custom",
@@ -947,6 +942,7 @@ class TestHandleCallModel:
             })
             data = json.loads(result[0].text)
             assert data["success"] is False
+            assert data.get("error_code") == "INVALID_PROVIDER"
 
     @pytest.mark.asyncio
     async def test_exception_handling(self):


### PR DESCRIPTION
Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.