### PR TITLE
feat(identity): auto-label embeds UUID[:8] suffix for operator disambiguation

### DIFF
--- a/src/mcp_handlers/identity/resolution.py
+++ b/src/mcp_handlers/identity/resolution.py
@@ -743,11 +743,20 @@ async def resolve_session_identity(
     # agent_id is human-readable label (model+date format, for display)
     agent_uuid = str(uuid.uuid4())
     agent_id = _generate_agent_id(model_type, client_hint)
-    # Auto-assign a cosmetic default label from client signals. Multiple
-    # agents can share this label — it is NOT used for lookup (name-claim
-    # removed 2026-04-17). Operators set a meaningful label later via
-    # set_agent_label / identity(name=X).
+    # Auto-assign a cosmetic default label from client signals. The label is
+    # NOT used for lookup (name-claim removed 2026-04-17); operators can
+    # override later via set_agent_label / identity(name=X), at which point
+    # the explicit path's own collision rename at persistence.py:467 applies.
+    #
+    # Appended with the UUID prefix for operator-facing disambiguation: the
+    # auto-label stem ("claude_desktop-claude", "cursor-opus") is shared by
+    # every session of the same client+model, so bare labels in dashboards
+    # and logs can't tell 16 concurrent "claude_desktop-claude" agents apart.
+    # The suffix is purely display — UUID remains the real identity key, so
+    # adding it here does not re-introduce the lookup-by-name primitive.
     label = _generate_auto_label(model_type, client_hint)
+    if label:
+        label = f"{label}_{agent_uuid[:8]}"
 
     if persist:
         # Persist immediately to PostgreSQL

--- a/tests/test_identity_session.py
+++ b/tests/test_identity_session.py
@@ -759,9 +759,11 @@ class TestResolvePath3CreateNew:
         assert result["persisted"] is False
         assert result["source"] == "memory_only"
         assert result["agent_id"].startswith("Claude_Opus_4_")
-        # Lazy-created agents now get auto-labels from model_type/client_hint
-        assert result["display_name"] == "opus"
-        assert result["label"] == "opus"
+        # Auto-generated labels embed the UUID[:8] suffix for operator-facing
+        # disambiguation (otherwise every "opus"-model agent shares one stem).
+        uuid_prefix = result["agent_uuid"][:8]
+        assert result["display_name"] == f"opus_{uuid_prefix}"
+        assert result["label"] == f"opus_{uuid_prefix}"
         # UUID should be valid
         assert len(result["agent_uuid"]) == 36
         assert result["agent_uuid"].count("-") == 4
@@ -806,6 +808,31 @@ class TestResolvePath3CreateNew:
         mock_db.create_session.assert_called_once()
         call_args = mock_db.create_session.call_args
         assert call_args.kwargs["session_id"] == "session-bind-test"
+
+    @pytest.mark.asyncio
+    async def test_auto_label_embeds_uuid_prefix(self, patch_all_deps, mock_db):
+        """Auto-generated labels include the UUID[:8] suffix so dashboards and
+        logs can tell otherwise-identical sessions apart (e.g. 16 Claude Code
+        CLI sessions sharing the "claude_desktop-claude" stem). Explicit names
+        passed at onboard take a different path (set_agent_label) and keep
+        their verbatim value unless they collide."""
+        from src.mcp_handlers.identity.handlers import resolve_session_identity
+
+        r1 = await resolve_session_identity(
+            session_key="auto-label-1",
+            client_hint="claude_code",
+            model_type="claude-opus-4",
+        )
+        r2 = await resolve_session_identity(
+            session_key="auto-label-2",
+            client_hint="claude_code",
+            model_type="claude-opus-4",
+        )
+
+        assert r1["label"].startswith("claude_code-opus_")
+        assert r1["label"] == f"claude_code-opus_{r1['agent_uuid'][:8]}"
+        assert r2["label"] == f"claude_code-opus_{r2['agent_uuid'][:8]}"
+        assert r1["label"] != r2["label"]
 
     @pytest.mark.asyncio
     async def test_new_agent_uuid_is_unique(self, patch_all_deps):


### PR DESCRIPTION
## Summary

Auto-generated labels (built from `client_hint + model_type`) collide trivially: every Claude Desktop session of the same model shares the `claude_desktop-claude` stem, every Cursor session of the same model shares `cursor-opus`, etc. On a host with 16 concurrent CLI sessions (typical for this workspace), label-based disambiguation in dashboards and logs is impossible.

This appends the UUID[:8] prefix to the auto-generated stem:

```
claude_code-opus  →  claude_code-opus_a1b2c3d4
```

## Context

Recovered from 2 days of uncommitted WIP on the original `auto-label-uuid-suffix` worktree. The branch's first commit (test consolidation) already landed via PR; this is the second piece that never got pushed before context-switched away. Caught during a worktree cleanup sweep that found one of the merged-but-WIP-bearing worktrees.

Pairs naturally with #134 (lineage badges) — that PR makes the parent/child relationship visible; this one makes individual sibling sessions visible. Together you can tell "this is *which* `claude_code-opus` child of which parent."

## What this is NOT

- **Not** a re-introduction of lookup-by-name. The UUID remains the real identity key. The label is display-only and the explicit-name path (operator passes `name=` at onboard) still goes through `set_agent_label` and keeps verbatim value modulo the collision-rename at `persistence.py:467`. The name-claim primitive removed 2026-04-17 stays removed.
- **Not** applied to operator-set names. Only auto-generated labels (the implicit `_generate_auto_label` path) get the suffix.

## Tests

- New `test_auto_label_embeds_uuid_prefix`: two sessions with identical client+model produce distinct labels, both follow `stem_<uuid8>` shape.
- `test_path3_creates_new_agent` updated to assert the suffix structure.
- Full suite: `6771 passed, 33 skipped` on `./scripts/dev/test-cache.sh --fresh`.

## Test plan

- [x] `pytest tests/test_identity_session.py` — 85/85
- [x] Full suite passes
- [ ] After merge: verify next dashboard refresh shows distinct labels for sibling sessions instead of one collapsed `claude_code-opus` group