### PR TITLE
watcher: drop P005 false-positives on context-managed acquire()

### DIFF
--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -1007,6 +1007,16 @@ _P016_GETATTR_SUCCESS = re.compile(
     r"""\bgetattr\s*\([^,]+,\s*['"]success['"]"""
 )
 
+# Regex: P005 resource-leak false positive when the acquire/cursor/connect/lock
+# call sits inside an `async with` (or plain `with`) header — the context
+# manager guarantees release on `__aexit__`, so by construction it is not a
+# leak. The model still flags these because the keyword `acquire` triggers
+# the pattern. Caught when qwen3-coder-next flagged `async with db.acquire()`
+# sites on 2026-04-24 (KG 2026-04-24T02:01:05).
+_P005_CONTEXT_MANAGED = re.compile(
+    r"\b(?:async\s+)?with\b[^#]*\.(?:acquire|cursor|connect|lock)\s*\("
+)
+
 
 def _is_inside_get_or_create_monitor(
     flagged_line: int, snippet_lines_by_num: dict[int, str]
@@ -1115,6 +1125,16 @@ def _verify_finding_against_source(
         log(
             f"drop P003 {finding.file}:{finding.line} — flag lands inside "
             f"get_or_create_monitor body (the cache itself): {src_line.strip()[:80]}",
+            "warning",
+        )
+        return False
+    # P005 specifically: `async with X.acquire() as conn:` (or plain `with`)
+    # is the canonical context-managed acquire — release is guaranteed by
+    # `__aexit__`, so this is not a leak even though `acquire` appears.
+    if finding.pattern == "P005" and _P005_CONTEXT_MANAGED.search(src_line):
+        log(
+            f"drop P005 {finding.file}:{finding.line} — context-managed acquire "
+            f"(async with / with): {src_line.strip()[:80]}",
             "warning",
         )
         return False

--- a/tests/test_watcher_p005_async_with.py
+++ b/tests/test_watcher_p005_async_with.py
@@ -1,0 +1,82 @@
+"""Tests for P005 false-positive suppression on context-managed acquires.
+
+P005 fires on resource-leak shapes (acquire/cursor/connect/lock without a
+matching release). When the call sits inside an `async with` (or plain
+`with`) header, the context manager handles release on __aexit__, so the
+finding is by construction a false positive. Caught 2026-04-24 when the
+model flagged `async with db.acquire() as conn:` lines (KG entry
+2026-04-24T02:01:05).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agents.watcher.agent import _verify_finding_against_source
+from agents.watcher.findings import Finding
+
+
+def _make(line: int, pattern: str = "P005") -> Finding:
+    return Finding(
+        pattern=pattern,
+        file="src/example.py",
+        line=line,
+        hint="resource leak",
+        severity="medium",
+        detected_at="2026-04-25T00:00:00Z",
+        model_used="test",
+    )
+
+
+class TestP005ContextManagedSuppression:
+    """`async with X.acquire()` and friends must drop — context manager releases."""
+
+    def test_async_with_db_acquire_dropped(self):
+        snippet = {1: "async with db.acquire() as conn:"}
+        assert _verify_finding_against_source(_make(1), "", snippet) is False
+
+    def test_async_with_pool_acquire_dropped(self):
+        snippet = {5: "    async with pool.acquire() as conn:"}
+        assert _verify_finding_against_source(_make(5), "", snippet) is False
+
+    def test_async_with_redis_lock_dropped(self):
+        snippet = {3: "async with redis.lock(name) as lock:"}
+        assert _verify_finding_against_source(_make(3), "", snippet) is False
+
+    def test_async_with_conn_cursor_dropped(self):
+        snippet = {7: "async with conn.cursor() as cur:"}
+        assert _verify_finding_against_source(_make(7), "", snippet) is False
+
+    def test_plain_with_connect_dropped(self):
+        snippet = {2: "with sqlite3.connect(path) as conn:"}
+        assert _verify_finding_against_source(_make(2), "", snippet) is False
+
+
+class TestP005RealLeaksKept:
+    """Bare acquires without a context manager must NOT be dropped here."""
+
+    def test_bare_acquire_assignment_kept(self):
+        # No context manager — must not be dropped by the new rule.
+        # (Survives the required-token gate; goes through to remaining checks.)
+        snippet = {4: "    conn = await db.acquire()"}
+        assert _verify_finding_against_source(_make(4), "", snippet) is True
+
+    def test_bare_cursor_assignment_kept(self):
+        snippet = {6: "    cur = conn.cursor()"}
+        assert _verify_finding_against_source(_make(6), "", snippet) is True
+
+    def test_acquire_in_comment_dropped_by_existing_rule(self):
+        # Comment lines are dropped by _looks_like_comment, not by us.
+        snippet = {8: "    # remember to .acquire() the lock"}
+        assert _verify_finding_against_source(_make(8), "", snippet) is False
+
+
+class TestP005DropDoesNotLeakToOtherPatterns:
+    """The new drop must only apply to P005."""
+
+    def test_p001_with_acquire_on_line_not_affected(self):
+        # P001 has its own required-token gate (`create_task(`), so an
+        # `async with db.acquire()` line fails P001's required-token check
+        # before reaching our new P005 branch.
+        snippet = {1: "async with db.acquire() as conn:"}
+        assert _verify_finding_against_source(_make(1, pattern="P001"), "", snippet) is False


### PR DESCRIPTION
Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.