### PR TITLE
S19 PR1: substrate_claims schema + enroll_resident CLI

### DIFF
--- a/db/postgres/migrations/017_substrate_claims.sql
+++ b/db/postgres/migrations/017_substrate_claims.sql
@@ -1,0 +1,68 @@
+-- 017_substrate_claims.sql
+--
+-- S19: Resume-time substrate attestation for R4-claiming agents.
+--
+-- Stores the operator-pre-seeded substrate-claim registry that the governance
+-- MCP consults at UDS connection-accept to verify a substrate-anchored
+-- resident agent (Vigil, Sentinel, Chronicler) is actually running under its
+-- registered launchd label and from its registered binary path.
+--
+-- See docs/proposals/s19-attestation-mechanism.md (M3-v2) for the full
+-- mechanism. Briefly: at UDS connect, server reads kernel-attested peer PID
+-- via SO_PEERCRED, queries `launchctl print pid/<peer_pid>` for the actual
+-- label, `proc_pidpath` for the actual executable, and `proc_pidinfo` for
+-- pid_start_time. Label + executable_path must match the registered values;
+-- pid_start_time is cached in-process for PID-reuse mitigation.
+--
+-- expected_executable_path is the v2 addition that closes the binary-
+-- substitution escalation of A2 (adversary-review §1) — without it, an
+-- attacker who can write to the binary path can replace the binary,
+-- kickstart the launchd job, and pass the label-match check.
+--
+-- This migration creates the registry table only. The pid_start_time cache
+-- is in-process per-server-lifetime (not persisted). Verification logic and
+-- enrollment runtime ship in subsequent PRs per v2 §Sequencing steps 2–6.
+--
+-- Watcher is excluded from S19 scope (per proposal v2). Substrate-claim
+-- registry rows are NOT expected for Watcher.
+
+CREATE TABLE IF NOT EXISTS core.substrate_claims (
+    -- The agent's UUID (stored as TEXT per project convention; see
+    -- core.identities.agent_id and core.agents.id). One row per substrate-
+    -- anchored agent.
+    agent_id TEXT PRIMARY KEY REFERENCES core.agents(id) ON DELETE CASCADE,
+
+    -- The launchd label this UUID is registered under (e.g.
+    -- 'com.unitares.sentinel'). Verified at connection-accept against
+    -- `launchctl print pid/<peer_pid>` output.
+    expected_launchd_label TEXT NOT NULL,
+
+    -- The absolute filesystem path of the resident's executable. Verified at
+    -- connection-accept against `proc_pidpath(peer_pid)`. Closes the binary-
+    -- substitution escalation of A2.
+    expected_executable_path TEXT NOT NULL,
+
+    -- TRUE when the operator ran enroll_resident.py with explicit input.
+    -- A future TOFU mode (not v1) would set this FALSE; v1 enrollment always
+    -- runs operator-seeded, so this column is informational + future-proofing.
+    enrolled_by_operator BOOLEAN NOT NULL DEFAULT TRUE,
+
+    -- Recorded when the operator ran enrollment. Useful for incident review:
+    -- if a substrate-claim row is older than the resident's deployment, it
+    -- predates the deployment and should be re-enrolled.
+    enrolled_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Free-form notes from the operator at enrollment time (e.g. the binary-
+    -- path-writable warning text, the deployment context). Audit-friendly.
+    notes TEXT NULL
+);
+
+-- Audit path: list all substrate claims by enrollment recency.
+-- (Hot-path lookup at connection-accept is by primary key; no extra index needed.)
+CREATE INDEX IF NOT EXISTS idx_substrate_claims_enrolled_at
+    ON core.substrate_claims (enrolled_at DESC);
+
+-- Register the migration.
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (17, 'substrate_claims', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/scripts/ops/enroll_resident.py
+++ b/scripts/ops/enroll_resident.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Enroll a substrate-anchored resident in core.substrate_claims (S19).
+
+Operator pre-seed enrollment per docs/proposals/s19-attestation-mechanism.md
+v2 §Enrollment workflow. Run BEFORE the resident first connects: this closes
+the launchctl-bootstrap adversary (proposal Q3 (b)) by removing the
+trust-on-first-use race.
+
+Usage:
+    scripts/ops/enroll_resident.py \\
+        --agent-id <UUID> \\
+        --launchd-label com.unitares.sentinel \\
+        --executable /opt/homebrew/bin/sentinel \\
+        [--notes "deployed 2026-04-25 by kenny"] \\
+        [--allow-user-writable]
+
+The CLI inspects the executable path's parent chain and emits a loud warning
+to stderr when any ancestor is user-writable (i.e. a same-UID adversary
+could substitute the binary; see proposal v2 §Adversary models A2-escalated).
+The warning is informational, not blocking, by design — the operator
+chooses whether to harden the deployment. Pass --allow-user-writable to
+suppress the *exit-non-zero* behavior on user-writable paths in
+non-interactive scripts; the warning is always written.
+
+Idempotent: re-running with the same agent-id updates the row in place.
+This is the right behavior for re-enrollment after deployment changes
+(binary moves, label rename); use --force to also update enrolled_at.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import re
+import sys
+import uuid
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from src.substrate.path_safety import (  # noqa: E402
+    first_user_writable_ancestor,
+    is_path_user_writable,
+)
+
+
+# Matches launchd label conventions: reverse-DNS, lowercase plus digits/dots/dashes.
+# Permissive enough to accept third-party labels but strict enough to catch typos.
+_LABEL_RE = re.compile(r"^[a-z][a-z0-9._-]+\.[a-z0-9._-]+$")
+
+
+def _validate_uuid(value: str) -> str:
+    try:
+        return str(uuid.UUID(value))
+    except (ValueError, TypeError) as exc:
+        raise argparse.ArgumentTypeError(
+            f"agent-id must be a valid UUID, got {value!r}"
+        ) from exc
+
+
+def _validate_label(value: str) -> str:
+    if not _LABEL_RE.match(value):
+        raise argparse.ArgumentTypeError(
+            f"launchd-label must be a reverse-DNS string (e.g. com.unitares.sentinel), got {value!r}"
+        )
+    return value
+
+
+def _validate_executable(value: str) -> str:
+    p = Path(value).expanduser()
+    if not p.is_absolute():
+        raise argparse.ArgumentTypeError(
+            f"executable path must be absolute, got {value!r}"
+        )
+    resolved = p.resolve()
+    if not resolved.exists():
+        raise argparse.ArgumentTypeError(
+            f"executable path does not exist: {resolved}"
+        )
+    if not os.access(str(resolved), os.X_OK):
+        raise argparse.ArgumentTypeError(
+            f"executable path is not executable: {resolved}"
+        )
+    return str(resolved)
+
+
+def _emit_user_writable_warning(executable: str) -> bool:
+    """Inspect ``executable`` and emit a loud warning if user-writable.
+
+    Returns True when the path IS user-writable (caller decides whether
+    to exit non-zero based on --allow-user-writable).
+    """
+    if not is_path_user_writable(executable):
+        return False
+
+    weak = first_user_writable_ancestor(executable) or executable
+    print(
+        "\n" + "=" * 78,
+        "DEPLOYMENT-RISK WARNING — same-UID-writable executable path",
+        "=" * 78,
+        f"  executable: {executable}",
+        f"  weak link:  {weak}",
+        "",
+        "  A same-UID process can replace the binary at this path before",
+        "  invoking `launchctl kickstart` to spawn under the registered",
+        "  label — defeating M3's launchd-label match (proposal v2",
+        "  §Adversary models A2-escalated).",
+        "",
+        "  Mitigation options:",
+        "    1. Move the binary to a non-user-writable location",
+        "       (e.g. /opt/homebrew/bin or /usr/local/bin) and re-enroll.",
+        "    2. Accept the residual risk: M3 still attests launchd identity",
+        "       and process instance, just not binary immutability.",
+        "",
+        "  Enrollment will proceed; this warning is informational.",
+        "=" * 78 + "\n",
+        sep="\n",
+        file=sys.stderr,
+    )
+    return True
+
+
+async def _upsert_substrate_claim(
+    agent_id: str,
+    label: str,
+    executable: str,
+    notes: str | None,
+    force_timestamp: bool,
+) -> str:
+    """Insert or update the substrate-claim row.
+
+    Returns "inserted" or "updated" for the caller to log. ``force_timestamp``
+    when True also resets ``enrolled_at`` (use when the operator wants to
+    record the re-enrollment as a fresh deployment event).
+    """
+    # Defer DB import until we actually need it so --help and validation
+    # paths don't pay the asyncpg/connection cost.
+    from src.db import get_db
+
+    db = get_db()
+    async with db.acquire() as conn:
+        existing = await conn.fetchval(
+            "SELECT 1 FROM core.substrate_claims WHERE agent_id = $1",
+            agent_id,
+        )
+        if existing:
+            if force_timestamp:
+                await conn.execute(
+                    """
+                    UPDATE core.substrate_claims
+                    SET expected_launchd_label = $2,
+                        expected_executable_path = $3,
+                        notes = $4,
+                        enrolled_at = NOW(),
+                        enrolled_by_operator = TRUE
+                    WHERE agent_id = $1
+                    """,
+                    agent_id, label, executable, notes,
+                )
+            else:
+                await conn.execute(
+                    """
+                    UPDATE core.substrate_claims
+                    SET expected_launchd_label = $2,
+                        expected_executable_path = $3,
+                        notes = $4,
+                        enrolled_by_operator = TRUE
+                    WHERE agent_id = $1
+                    """,
+                    agent_id, label, executable, notes,
+                )
+            return "updated"
+        else:
+            await conn.execute(
+                """
+                INSERT INTO core.substrate_claims
+                    (agent_id, expected_launchd_label, expected_executable_path,
+                     enrolled_by_operator, notes)
+                VALUES ($1, $2, $3, TRUE, $4)
+                """,
+                agent_id, label, executable, notes,
+            )
+            return "inserted"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.split("\n", 1)[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="See docs/proposals/s19-attestation-mechanism.md for the full design.",
+    )
+    parser.add_argument(
+        "--agent-id", required=True, type=_validate_uuid,
+        help="UUID of the resident to enroll (must already exist in core.agents).",
+    )
+    parser.add_argument(
+        "--launchd-label", required=True, type=_validate_label,
+        help="Expected launchd label (e.g. com.unitares.sentinel).",
+    )
+    parser.add_argument(
+        "--executable", required=True, type=_validate_executable,
+        help="Absolute path to the resident's executable binary.",
+    )
+    parser.add_argument(
+        "--notes", default=None,
+        help="Free-form notes to record at enrollment time.",
+    )
+    parser.add_argument(
+        "--allow-user-writable", action="store_true",
+        help=(
+            "Permit enrollment even if the executable path is same-UID-writable. "
+            "Without this flag, a writable path causes the script to exit non-zero "
+            "after writing the warning. The DB row is still inserted in either case."
+        ),
+    )
+    parser.add_argument(
+        "--force", action="store_true",
+        help="On re-enrollment, also reset enrolled_at to now.",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Validate inputs and emit the writability warning, but do not touch the DB.",
+    )
+
+    args = parser.parse_args(argv)
+
+    # Path-safety check is the load-bearing user-facing behavior. Always run.
+    is_writable = _emit_user_writable_warning(args.executable)
+
+    if args.dry_run:
+        print(
+            f"[dry-run] would enroll: agent_id={args.agent_id} "
+            f"label={args.launchd_label} executable={args.executable}",
+            file=sys.stderr,
+        )
+        return 1 if (is_writable and not args.allow_user_writable) else 0
+
+    try:
+        action = asyncio.run(
+            _upsert_substrate_claim(
+                args.agent_id,
+                args.launchd_label,
+                args.executable,
+                args.notes,
+                args.force,
+            )
+        )
+    except Exception as exc:
+        print(f"[error] enrollment failed: {exc}", file=sys.stderr)
+        return 2
+
+    print(
+        f"[ok] {action} substrate_claim: agent_id={args.agent_id} "
+        f"label={args.launchd_label} executable={args.executable}",
+        file=sys.stderr,
+    )
+
+    if is_writable and not args.allow_user_writable:
+        # Row is in the DB; we still exit non-zero so non-interactive
+        # callers notice the deployment-risk warning.
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/substrate/__init__.py
+++ b/src/substrate/__init__.py
@@ -1,0 +1,8 @@
+"""S19 substrate-claim attestation utilities.
+
+See docs/proposals/s19-attestation-mechanism.md (M3-v2) for the design.
+This package houses pure-Python helpers for the enrollment CLI and (in later
+PRs) the runtime peer-attestation backends. Code that touches PostgreSQL or
+the MCP server lives elsewhere; this package is dependency-light so it can
+be exercised by unit tests without a DB.
+"""

--- a/src/substrate/path_safety.py
+++ b/src/substrate/path_safety.py
@@ -1,0 +1,69 @@
+"""Path safety checks for S19 substrate-claim enrollment.
+
+A binary path is "user-writable" if a same-UID process could replace the
+file at that path — by overwriting the file or by replacing it via
+parent-directory rename/unlink. The enrollment CLI uses these helpers to
+warn loudly when a resident's binary lives somewhere a same-UID adversary
+could substitute.
+
+This is informational, not blocking — see proposal v2 §Adversary models
+A2-escalated. M3 attests launchd identity and process instance, not binary
+immutability unless deployment hardening relocates the binary to a non-user-
+writable path (e.g. /opt/homebrew/bin or /usr/local/bin).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+
+def is_path_user_writable(path: str) -> bool:
+    """Return True if a same-UID process could replace the file at ``path``.
+
+    Walks the parent chain: if any directory along the chain (up to but
+    excluding root ``/``) grants write permission to the current real user,
+    returns True. The file itself is also checked when it exists (an
+    overwrite-able file is replaceable without parent-dir write).
+
+    Edge cases:
+    - Path doesn't exist: walks from the first existing parent.
+    - Symlinks: resolved via ``Path.resolve()`` before checking.
+    - Relative paths: resolved relative to the current working directory.
+    """
+    resolved = Path(path).expanduser().resolve()
+
+    if resolved.exists() and os.access(str(resolved), os.W_OK):
+        return True
+
+    # Walk parent chain. Path.parent of '/' is '/', which terminates the loop.
+    p = resolved if resolved.exists() else resolved.parent
+    while p != p.parent:
+        if p.exists() and os.access(str(p), os.W_OK):
+            return True
+        p = p.parent
+    return False
+
+
+def first_user_writable_ancestor(path: str) -> Optional[str]:
+    """Return the deepest user-writable path in ``path``'s ancestor chain.
+
+    If the file itself is user-writable, returns the file path. Otherwise
+    returns the deepest ancestor directory that is user-writable, or
+    ``None`` if no path component up to root grants write access.
+
+    Used by the enrollment CLI to make warning messages specific:
+    "binary at /Users/cirwel/projects/.../sentinel is user-writable via
+    /Users/cirwel/projects" rather than just "is user-writable."
+    """
+    resolved = Path(path).expanduser().resolve()
+
+    if resolved.exists() and os.access(str(resolved), os.W_OK):
+        return str(resolved)
+
+    p = resolved if resolved.exists() else resolved.parent
+    while p != p.parent:
+        if p.exists() and os.access(str(p), os.W_OK):
+            return str(p)
+        p = p.parent
+    return None

--- a/tests/test_enroll_resident.py
+++ b/tests/test_enroll_resident.py
@@ -1,0 +1,193 @@
+"""S19: enrollment CLI argument validation and warning emission.
+
+Tests the pure-validation paths of ``scripts/ops/enroll_resident.py`` (UUID,
+label, executable validators) and the ``_emit_user_writable_warning`` helper.
+DB-touching paths are exercised via the CLI's ``--dry-run`` flag, which
+validates input and emits the warning without touching PostgreSQL — this
+keeps the unit tests dependency-free.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load the CLI module by file path since `scripts/ops/` is not a package.
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+CLI_PATH = PROJECT_ROOT / "scripts" / "ops" / "enroll_resident.py"
+
+_spec = importlib.util.spec_from_file_location("enroll_resident", CLI_PATH)
+assert _spec and _spec.loader
+enroll_resident = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(enroll_resident)
+
+
+# -----------------------------------------------------------------------------
+# Argument validators
+# -----------------------------------------------------------------------------
+
+
+def test_validate_uuid_accepts_canonical_form() -> None:
+    canonical = "f92dcea8-4786-412a-a0eb-362c273382f5"
+    assert enroll_resident._validate_uuid(canonical) == canonical
+
+
+def test_validate_uuid_rejects_non_uuid() -> None:
+    with pytest.raises(argparse.ArgumentTypeError, match="valid UUID"):
+        enroll_resident._validate_uuid("not-a-uuid")
+
+
+def test_validate_label_accepts_unitares_residents() -> None:
+    for label in (
+        "com.unitares.sentinel",
+        "com.unitares.vigil",
+        "com.unitares.chronicler",
+    ):
+        assert enroll_resident._validate_label(label) == label
+
+
+def test_validate_label_rejects_non_reverse_dns() -> None:
+    for bad in ("Sentinel", "com unitares sentinel", "", "no-dot-here"):
+        with pytest.raises(argparse.ArgumentTypeError, match="reverse-DNS"):
+            enroll_resident._validate_label(bad)
+
+
+def test_validate_executable_requires_absolute_path(tmp_path: Path) -> None:
+    rel = "./relative_binary"
+    with pytest.raises(argparse.ArgumentTypeError, match="absolute"):
+        enroll_resident._validate_executable(rel)
+
+
+def test_validate_executable_requires_existing_file(tmp_path: Path) -> None:
+    missing = tmp_path / "does_not_exist"
+    with pytest.raises(argparse.ArgumentTypeError, match="does not exist"):
+        enroll_resident._validate_executable(str(missing))
+
+
+def test_validate_executable_requires_executable_bit(tmp_path: Path) -> None:
+    not_x = tmp_path / "binary"
+    not_x.write_bytes(b"")
+    not_x.chmod(0o644)  # no x bit
+    with pytest.raises(argparse.ArgumentTypeError, match="not executable"):
+        enroll_resident._validate_executable(str(not_x))
+
+
+def test_validate_executable_accepts_real_binary(tmp_path: Path) -> None:
+    binary = tmp_path / "binary"
+    binary.write_bytes(b"#!/bin/sh\nexit 0\n")
+    binary.chmod(binary.stat().st_mode | stat.S_IXUSR)
+    result = enroll_resident._validate_executable(str(binary))
+    assert result == str(binary.resolve())
+
+
+# -----------------------------------------------------------------------------
+# Warning emission
+# -----------------------------------------------------------------------------
+
+
+def test_emit_warning_fires_on_user_writable_path(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    binary = tmp_path / "binary"
+    binary.write_bytes(b"")
+    binary.chmod(binary.stat().st_mode | stat.S_IXUSR)
+
+    is_writable = enroll_resident._emit_user_writable_warning(str(binary))
+    captured = capsys.readouterr()
+
+    assert is_writable is True
+    assert "DEPLOYMENT-RISK WARNING" in captured.err
+    assert "same-UID-writable" in captured.err
+    assert str(binary) in captured.err
+
+
+def test_emit_warning_silent_for_root_owned_path(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Root-owned paths produce no warning and return False."""
+    if os.geteuid() == 0:
+        pytest.skip("running as root cannot test non-root unwritable path")
+    is_writable = enroll_resident._emit_user_writable_warning("/usr/bin/env")
+    captured = capsys.readouterr()
+
+    assert is_writable is False
+    assert "DEPLOYMENT-RISK WARNING" not in captured.err
+
+
+# -----------------------------------------------------------------------------
+# End-to-end via --dry-run (no DB)
+# -----------------------------------------------------------------------------
+
+
+def test_dry_run_user_writable_returns_one(tmp_path: Path) -> None:
+    """--dry-run + user-writable executable + no --allow-user-writable: rc=1."""
+    binary = tmp_path / "binary"
+    binary.write_bytes(b"")
+    binary.chmod(binary.stat().st_mode | stat.S_IXUSR)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CLI_PATH),
+            "--agent-id", "f92dcea8-4786-412a-a0eb-362c273382f5",
+            "--launchd-label", "com.unitares.sentinel",
+            "--executable", str(binary),
+            "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "DEPLOYMENT-RISK WARNING" in result.stderr
+    assert "[dry-run]" in result.stderr
+
+
+def test_dry_run_user_writable_with_allow_returns_zero(tmp_path: Path) -> None:
+    """--dry-run + user-writable + --allow-user-writable: warning still fires, rc=0."""
+    binary = tmp_path / "binary"
+    binary.write_bytes(b"")
+    binary.chmod(binary.stat().st_mode | stat.S_IXUSR)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CLI_PATH),
+            "--agent-id", "f92dcea8-4786-412a-a0eb-362c273382f5",
+            "--launchd-label", "com.unitares.sentinel",
+            "--executable", str(binary),
+            "--dry-run",
+            "--allow-user-writable",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "DEPLOYMENT-RISK WARNING" in result.stderr  # warning is always written
+
+
+def test_invalid_uuid_rejected_with_argparse_error(tmp_path: Path) -> None:
+    binary = tmp_path / "binary"
+    binary.write_bytes(b"")
+    binary.chmod(binary.stat().st_mode | stat.S_IXUSR)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CLI_PATH),
+            "--agent-id", "not-a-uuid",
+            "--launchd-label", "com.unitares.sentinel",
+            "--executable", str(binary),
+            "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    # argparse exits with code 2 on argument errors.
+    assert result.returncode == 2
+    assert "valid UUID" in result.stderr

--- a/tests/test_substrate_path_safety.py
+++ b/tests/test_substrate_path_safety.py
@@ -1,0 +1,107 @@
+"""S19: enrollment-time path safety checks.
+
+Verifies ``is_path_user_writable`` and ``first_user_writable_ancestor``
+correctly identify paths that a same-UID process could replace. Used to
+warn operators at enrollment time when binaries live in user-writable
+locations.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from src.substrate.path_safety import (
+    first_user_writable_ancestor,
+    is_path_user_writable,
+)
+
+
+# -----------------------------------------------------------------------------
+# is_path_user_writable
+# -----------------------------------------------------------------------------
+
+
+def test_user_owned_tmp_path_is_writable(tmp_path: Path) -> None:
+    """A file under pytest's tmp_path is owned by the test runner."""
+    target = tmp_path / "binary"
+    target.write_bytes(b"#!/usr/bin/env python3\n")
+    assert is_path_user_writable(str(target)) is True
+
+
+def test_nonexistent_target_walks_to_first_existing_parent(tmp_path: Path) -> None:
+    """The check walks from the first existing parent when the target is absent."""
+    target = tmp_path / "subdir" / "binary_not_yet_created"
+    assert is_path_user_writable(str(target)) is True
+
+
+def test_relative_path_is_resolved(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Relative paths resolve against cwd before the writability check."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "binary").write_bytes(b"")
+    assert is_path_user_writable("./binary") is True
+
+
+def test_symlink_is_resolved(tmp_path: Path) -> None:
+    """Symlinks resolve before the writability check (we attest the real file)."""
+    real = tmp_path / "real_binary"
+    real.write_bytes(b"")
+    link = tmp_path / "link_to_binary"
+    link.symlink_to(real)
+    assert is_path_user_writable(str(link)) is True
+
+
+def test_root_owned_path_is_not_writable() -> None:
+    """A path entirely under root-owned directories is not user-writable.
+
+    ``/usr/bin/env`` exists on every macOS/Linux deployment and is root-owned;
+    not user-writable for non-root users.
+    """
+    if os.geteuid() == 0:
+        pytest.skip("running as root cannot test non-root unwritable path")
+    assert is_path_user_writable("/usr/bin/env") is False
+
+
+def test_nonexistent_root_owned_path_is_not_writable() -> None:
+    """When the target doesn't exist but the entire ancestor chain is root-
+    owned, the helper still reports unwritable."""
+    if os.geteuid() == 0:
+        pytest.skip("running as root cannot test non-root unwritable path")
+    # /usr/bin/<random-uuid-name> does not exist; /usr/bin and /usr are
+    # root-owned; the helper walks to the first existing parent and finds
+    # no writable directory.
+    assert is_path_user_writable("/usr/bin/this_path_should_never_exist_z19") is False
+
+
+# -----------------------------------------------------------------------------
+# first_user_writable_ancestor
+# -----------------------------------------------------------------------------
+
+
+def test_first_user_writable_ancestor_returns_file_when_file_writable(
+    tmp_path: Path,
+) -> None:
+    """When the file itself is user-writable, the helper returns that path."""
+    target = tmp_path / "binary"
+    target.write_bytes(b"")
+    result = first_user_writable_ancestor(str(target))
+    assert result == str(target.resolve())
+
+
+def test_first_user_writable_ancestor_returns_parent_when_file_absent(
+    tmp_path: Path,
+) -> None:
+    """When the file doesn't exist, returns the deepest writable parent."""
+    target = tmp_path / "subdir" / "absent_binary"
+    result = first_user_writable_ancestor(str(target))
+    # tmp_path is user-owned; subdir doesn't exist, so the deepest existing
+    # writable ancestor is tmp_path itself.
+    assert result == str(tmp_path.resolve())
+
+
+def test_first_user_writable_ancestor_none_for_root_owned_path() -> None:
+    """No user-writable ancestor → None (signal: deployment is hardened)."""
+    if os.geteuid() == 0:
+        pytest.skip("running as root cannot test non-root unwritable path")
+    assert first_user_writable_ancestor("/usr/bin/env") is None


### PR DESCRIPTION
First PR in the S19 (M3-v2) implementation sequence per `docs/proposals/s19-attestation-mechanism.md` §Sequencing step 1. Schema-only + operator-pre-seed CLI; no runtime change to governance-mcp yet.

## What ships

- **`db/postgres/migrations/017_substrate_claims.sql`** — `core.substrate_claims` table with `expected_launchd_label`, `expected_executable_path`, `enrolled_by_operator`, `enrolled_at`, `notes`. FK to `core.agents(id)` per project convention. Applied cleanly to dev DB.
- **`src/substrate/path_safety.py`** — pure-Python `is_path_user_writable()` + `first_user_writable_ancestor()` helpers. Walks the parent chain; treats admin-group-writable directories as "user-writable" (caught `/Library/Frameworks/.../bin` correctly on this Mac).
- **`scripts/ops/enroll_resident.py`** — operator pre-seed CLI. Validates UUID + reverse-DNS label + absolute executable path with x-bit. Emits a loud DEPLOYMENT-RISK WARNING to stderr when the executable path is same-UID-writable; exits non-zero by default in that case (suppress with `--allow-user-writable`). Idempotent on re-enrollment; `--force` resets `enrolled_at`. `--dry-run` validates + warns without touching the DB.
- **22 unit/integration tests** covering path-safety helpers + CLI argument validation + `--dry-run` end-to-end. 100% line coverage on the new modules.

## Adversary-review compliance

Per `docs/proposals/s19-attestation-mechanism.adversary-review.md` §1: `expected_executable_path` is the registry field that closes the binary-substitution escalation of A2. CLI honestly surfaces residual deployment risk when the path is user-writable (current state on this Mac for residents under `~/projects/unitares/`).

Per the same review §6: enrollment is operator-pre-seeded by design (no TOFU). The `enrolled_by_operator` column is informational + future-proofing for any later mode change.

## What this PR does NOT do

- No UDS listener / `peer_attestation.py` module / SO_PEERCRED reader (PR2 per v2 §Sequencing).
- No PATH 2.8 substrate-anchored gate (PR3).
- No SDK changes (PR4).
- No per-resident migration (PR6).
- No regression test for the leak path itself (PR7 — needs the runtime layer first).

## Verification

- Migration `psql -f` apply to dev `governance` DB → success, table + index created.
- `scripts/dev/test-cache.sh` → 7232 passed, 33 skipped, no regressions.
- CLI dry-run with admin-group-writable Python path → warns + rc=1.
- CLI dry-run with `/usr/bin/env` (root-owned) → no warning + rc=0.
- CLI dry-run with `--allow-user-writable` flag → warns but rc=0.