### PR TITLE
S19 PR2: peer_attestation.py macOS backend

### DIFF
--- a/src/substrate/peer_attestation.py
+++ b/src/substrate/peer_attestation.py
@@ -1,0 +1,255 @@
+"""S19 peer-attestation primitives — macOS backend.
+
+Pure-Python helpers for the four kernel/launchd queries the substrate-claim
+verification path needs:
+
+- ``read_peer_pid(sock)``           — kernel-attested PID of a UDS peer
+- ``read_service_label(pid)``       — launchd label currently owning a PID
+- ``read_executable_path(pid)``     — absolute binary path of a process
+- ``read_process_start_time(pid)``  — Unix epoch seconds for PID-reuse detection
+
+See ``docs/proposals/s19-attestation-mechanism.md`` v2 §Verification at
+connection-accept for how these compose into the M3-v2 attestation flow.
+
+This module is dependency-light by design (stdlib only): it has to be
+importable from any process that needs to reason about substrate identity,
+and it must not pull in the MCP server's anyio task group. The eventual
+caller (PR3) wraps these helpers in ``loop.run_in_executor`` to honor the
+anyio-deadlock constraint described in CLAUDE.md "Known Issue: anyio-asyncio
+Conflict."
+
+Linux backend is stubbed (``NotImplementedError``) until the first Linux
+substrate-anchored resident lands; see proposal v2 §Open questions deferred.
+"""
+from __future__ import annotations
+
+import ctypes
+import re
+import socket
+import struct
+import subprocess
+import sys
+from typing import Optional
+
+
+# =============================================================================
+# Platform gate
+# =============================================================================
+
+
+def _require_supported_platform() -> None:
+    """Raise NotImplementedError when called on an unsupported platform.
+
+    Accepts macOS today. Linux is a future-work stub with a specific message
+    pointing at the proposal so a future implementer knows where to start.
+    """
+    if sys.platform == "darwin":
+        return
+    if sys.platform == "linux":
+        raise NotImplementedError(
+            "S19 Linux backend not yet implemented — see "
+            "docs/proposals/s19-attestation-mechanism.md §Open questions deferred"
+        )
+    raise NotImplementedError(
+        f"S19 attestation not supported on {sys.platform!r}"
+    )
+
+
+# =============================================================================
+# Peer PID via LOCAL_PEERPID
+# =============================================================================
+#
+# macOS exposes the connected peer's PID on a Unix-domain socket via
+# getsockopt(SOL_LOCAL, LOCAL_PEERPID). The PID is written by the kernel at
+# connect/accept and cannot be forged by user-space — this is the kernel
+# attestation that closes adversary A1 (proposal v2 §Adversary models).
+#
+# Constants from <sys/un.h>; not exposed by Python's socket module:
+#   SOL_LOCAL    = 0
+#   LOCAL_PEERPID = 0x002
+_SOL_LOCAL = 0
+_LOCAL_PEERPID = 0x002
+
+
+def read_peer_pid(sock: socket.socket) -> Optional[int]:
+    """Return the kernel-attested PID of the peer connected to ``sock``.
+
+    ``sock`` must be a connected AF_UNIX socket. Returns ``None`` when the
+    socket family is wrong or the syscall fails.
+    """
+    _require_supported_platform()
+    if sock.family != socket.AF_UNIX:
+        return None
+    try:
+        raw = sock.getsockopt(_SOL_LOCAL, _LOCAL_PEERPID, struct.calcsize("i"))
+    except OSError:
+        return None
+    if not raw or len(raw) < struct.calcsize("i"):
+        return None
+    return int(struct.unpack("i", raw)[0])
+
+
+# =============================================================================
+# launchd label for a PID
+# =============================================================================
+#
+# `launchctl list` output is three whitespace-separated columns: PID, Status,
+# Label. PID is '-' for loaded-but-not-running services. We parse the column
+# format rather than the per-PID `launchctl print pid/<N>` output because
+# the latter does not expose the label directly (verified on the running
+# macOS at investigation time).
+#
+# This format has been stable across macOS 10.x → 15.x; if Apple ever
+# changes it, the regex below misses cleanly (returns None) instead of
+# false-accepting a wrong label.
+_LAUNCHCTL_LIST_RE = re.compile(r"^\s*(-|\d+)\s+(-?\d+)\s+(\S+)\s*$")
+_LAUNCHCTL_TIMEOUT_SECONDS = 2.0
+
+
+def read_service_label(pid: int) -> Optional[str]:
+    """Return the launchd service label owning ``pid``, or ``None`` if not
+    running under a launchd job (or the PID is not in this user's launchd
+    domain).
+
+    The verification path uses this to confirm a connecting peer's PID is
+    running under the substrate-claim's registered label — closes the naive
+    A2 adversary (proposal v2 §Adversary models).
+    """
+    _require_supported_platform()
+    if pid <= 0:
+        return None
+    try:
+        result = subprocess.run(
+            ["launchctl", "list"],
+            capture_output=True, text=True,
+            timeout=_LAUNCHCTL_TIMEOUT_SECONDS,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+
+    target = str(pid)
+    for line in result.stdout.splitlines():
+        m = _LAUNCHCTL_LIST_RE.match(line)
+        if not m:
+            continue
+        # m.group(1) is '-' for loaded-but-not-running rows; only literal
+        # int-string match counts. The dash rows can never accidentally
+        # match because pid > 0 so str(pid) is never '-'.
+        if m.group(1) == target:
+            return m.group(3)
+    return None
+
+
+# =============================================================================
+# Executable path via proc_pidpath
+# =============================================================================
+#
+# proc_pidpath() in libproc returns the absolute path of a process's
+# executable. Stable since macOS 10.5. PROC_PIDPATHINFO_MAXSIZE is
+# 4 * MAXPATHLEN = 4096 bytes, defined in <libproc.h>.
+_PROC_PIDPATHINFO_MAXSIZE = 4 * 1024
+
+_libproc: Optional[ctypes.CDLL] = (
+    ctypes.CDLL("/usr/lib/libproc.dylib") if sys.platform == "darwin" else None
+)
+if _libproc is not None:
+    _libproc.proc_pidpath.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_uint32]
+    _libproc.proc_pidpath.restype = ctypes.c_int
+
+
+def read_executable_path(pid: int) -> Optional[str]:
+    """Return ``pid``'s absolute executable path, or ``None`` on failure.
+
+    Used by the verification path to compare against
+    ``substrate_claims.expected_executable_path`` — closes A2-escalated
+    (binary-substitution attacker; proposal v2 §Adversary models).
+    """
+    _require_supported_platform()
+    if _libproc is None:
+        return None
+    if pid <= 0:
+        return None
+    buf = ctypes.create_string_buffer(_PROC_PIDPATHINFO_MAXSIZE)
+    rc = _libproc.proc_pidpath(pid, buf, _PROC_PIDPATHINFO_MAXSIZE)
+    if rc <= 0:
+        return None
+    try:
+        return buf.value.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+
+
+# =============================================================================
+# Process start time via proc_pidinfo (PROC_PIDTBSDINFO)
+# =============================================================================
+#
+# proc_pidinfo() with the PROC_PIDTBSDINFO selector returns BSD task info
+# including pbi_start_tvsec — the process start time in Unix epoch seconds.
+# Stable since macOS 10.5.
+#
+# The verified_pairs cache (PR3 §Sequencing step 3 sub-7) uses this to
+# detect PID reuse: even when a PID is recycled, the new process has a
+# different start_tvsec. Defeats Q3(e) per the council adversary review.
+_PROC_PIDTBSDINFO = 3
+
+
+class _ProcBsdInfo(ctypes.Structure):
+    """Mirror of ``struct proc_bsdinfo`` from <sys/proc_info.h>.
+
+    Only fields up through ``pbi_start_tvsec`` are load-bearing for our
+    needs. The layout up to that field is stable across all supported
+    macOS versions.
+    """
+    _fields_ = [
+        ("pbi_flags", ctypes.c_uint32),
+        ("pbi_status", ctypes.c_uint32),
+        ("pbi_xstatus", ctypes.c_uint32),
+        ("pbi_pid", ctypes.c_uint32),
+        ("pbi_ppid", ctypes.c_uint32),
+        ("pbi_uid", ctypes.c_uint32),
+        ("pbi_gid", ctypes.c_uint32),
+        ("pbi_ruid", ctypes.c_uint32),
+        ("pbi_rgid", ctypes.c_uint32),
+        ("pbi_svuid", ctypes.c_uint32),
+        ("pbi_svgid", ctypes.c_uint32),
+        ("rfu_1", ctypes.c_uint32),
+        ("pbi_comm", ctypes.c_char * 16),
+        ("pbi_name", ctypes.c_char * 32),
+        ("pbi_nfiles", ctypes.c_uint32),
+        ("pbi_pgid", ctypes.c_uint32),
+        ("pbi_pjobc", ctypes.c_uint32),
+        ("e_tdev", ctypes.c_uint32),
+        ("e_tpgid", ctypes.c_uint32),
+        ("pbi_nice", ctypes.c_int32),
+        ("pbi_start_tvsec", ctypes.c_uint64),
+        ("pbi_start_tvusec", ctypes.c_uint64),
+    ]
+
+
+if _libproc is not None:
+    _libproc.proc_pidinfo.argtypes = [
+        ctypes.c_int, ctypes.c_int, ctypes.c_uint64,
+        ctypes.c_void_p, ctypes.c_int,
+    ]
+    _libproc.proc_pidinfo.restype = ctypes.c_int
+
+
+def read_process_start_time(pid: int) -> Optional[int]:
+    """Return ``pid``'s start time in Unix epoch seconds, or ``None`` on
+    failure.
+    """
+    _require_supported_platform()
+    if _libproc is None:
+        return None
+    if pid <= 0:
+        return None
+    info = _ProcBsdInfo()
+    rc = _libproc.proc_pidinfo(
+        pid, _PROC_PIDTBSDINFO, 0,
+        ctypes.byref(info), ctypes.sizeof(info),
+    )
+    if rc <= 0:
+        return None
+    return int(info.pbi_start_tvsec)

--- a/tests/test_substrate_peer_attestation.py
+++ b/tests/test_substrate_peer_attestation.py
@@ -1,0 +1,261 @@
+"""S19 peer-attestation: macOS backend tests.
+
+Coverage:
+- Platform gate (macOS supported, Linux stubbed, others rejected)
+- read_peer_pid: socketpair self-PID round-trip + non-Unix-socket guard
+- read_service_label: launchctl list parser fixtures + subprocess failure modes
+- read_executable_path: self-introspection + invalid PID
+- read_process_start_time: self-introspection + invalid PID + repeated read consistency
+"""
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.substrate import peer_attestation as pa
+
+
+# =============================================================================
+# Platform gate
+# =============================================================================
+
+
+def test_macos_passes_platform_gate() -> None:
+    """No exception on darwin (the supported platform)."""
+    if sys.platform != "darwin":
+        pytest.skip("test environment is not macOS")
+    pa._require_supported_platform()  # should not raise
+
+
+def test_linux_raises_with_proposal_pointer(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pa.sys, "platform", "linux")
+    with pytest.raises(NotImplementedError, match="Linux backend"):
+        pa._require_supported_platform()
+
+
+def test_unknown_platform_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pa.sys, "platform", "win32")
+    with pytest.raises(NotImplementedError, match="not supported"):
+        pa._require_supported_platform()
+
+
+# =============================================================================
+# read_peer_pid
+# =============================================================================
+
+
+def test_read_peer_pid_returns_none_for_inet_socket() -> None:
+    """An AF_INET socket is not a Unix-domain socket — guard returns None."""
+    if sys.platform != "darwin":
+        pytest.skip("macOS-specific test")
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        assert pa.read_peer_pid(sock) is None
+    finally:
+        sock.close()
+
+
+def test_read_peer_pid_returns_self_pid_via_socketpair() -> None:
+    """A Unix socketpair: each end sees the other end's PID — both ends are us."""
+    if sys.platform != "darwin":
+        pytest.skip("macOS-specific test")
+    a, b = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        observed = pa.read_peer_pid(a)
+        assert observed == os.getpid()
+        observed_b = pa.read_peer_pid(b)
+        assert observed_b == os.getpid()
+    finally:
+        a.close()
+        b.close()
+
+
+# =============================================================================
+# read_service_label
+# =============================================================================
+
+
+_SAMPLE_LAUNCHCTL_LIST = """\
+PID	Status	Label
+3326	0	com.unitares.anima-proxy
+-	0	com.unitares.health-watchdog
+37807	0	com.unitares.governance-mcp
+13142	-9	com.unitares.sentinel
+-	0	com.apple.something.loaded-not-running
+85392	0	com.unitares.ipv6-loopback-proxy
+"""
+
+
+def _mock_launchctl(monkeypatch: pytest.MonkeyPatch, *, returncode: int = 0,
+                     stdout: str = _SAMPLE_LAUNCHCTL_LIST) -> None:
+    fake = MagicMock()
+    fake.returncode = returncode
+    fake.stdout = stdout
+    monkeypatch.setattr(pa.subprocess, "run", lambda *a, **k: fake)
+
+
+def test_read_service_label_finds_governance_mcp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_launchctl(monkeypatch)
+    assert pa.read_service_label(37807) == "com.unitares.governance-mcp"
+
+
+def test_read_service_label_finds_sentinel_with_negative_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sentinel has status=-9 (last-exit-status); regex must accept negative."""
+    _mock_launchctl(monkeypatch)
+    assert pa.read_service_label(13142) == "com.unitares.sentinel"
+
+
+def test_read_service_label_returns_none_for_unknown_pid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_launchctl(monkeypatch)
+    assert pa.read_service_label(99999) is None
+
+
+def test_read_service_label_skips_dash_pid_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Loaded-but-not-running services have '-' in PID column.
+
+    No int PID can match the dash; verifies a PID like 0 (which Python
+    string-formats as '0', never '-') doesn't false-positive.
+    """
+    _mock_launchctl(monkeypatch)
+    # PID 0 doesn't appear in fixture and definitely shouldn't match dash rows.
+    assert pa.read_service_label(0) is None
+
+
+def test_read_service_label_rejects_negative_pid_without_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Negative PIDs are rejected before the subprocess call.
+
+    Defense in depth: even if a caller passes a malformed PID upstream,
+    we don't shell out and don't risk a false-positive on a shell quirk.
+    """
+    called = MagicMock()
+    monkeypatch.setattr(pa.subprocess, "run", called)
+    assert pa.read_service_label(-1) is None
+    called.assert_not_called()
+
+
+def test_read_service_label_handles_subprocess_nonzero_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_launchctl(monkeypatch, returncode=1, stdout="")
+    assert pa.read_service_label(123) is None
+
+
+def test_read_service_label_handles_missing_launchctl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def boom(*a: object, **k: object) -> None:
+        raise FileNotFoundError("launchctl")
+
+    monkeypatch.setattr(pa.subprocess, "run", boom)
+    assert pa.read_service_label(123) is None
+
+
+def test_read_service_label_handles_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(*a: object, **k: object) -> None:
+        raise subprocess.TimeoutExpired(["launchctl", "list"], 2.0)
+
+    monkeypatch.setattr(pa.subprocess, "run", boom)
+    assert pa.read_service_label(123) is None
+
+
+def test_read_service_label_ignores_header_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The 'PID Status Label' header line must not parse as a row."""
+    _mock_launchctl(monkeypatch)
+    # If the header row parsed, str-target='Label' would match m.group(3).
+    # We're confirming the regex only matches int-like first columns.
+    assert pa.read_service_label(123) is None
+
+
+# =============================================================================
+# read_executable_path
+# =============================================================================
+
+
+def test_read_executable_path_for_self_returns_python_binary() -> None:
+    """proc_pidpath on our own PID returns the Python interpreter."""
+    if sys.platform != "darwin":
+        pytest.skip("macOS-specific test")
+    path = pa.read_executable_path(os.getpid())
+    assert path is not None
+    assert "python" in os.path.basename(path).lower()
+
+
+def test_read_executable_path_returns_absolute_path() -> None:
+    if sys.platform != "darwin":
+        pytest.skip("macOS-specific test")
+    path = pa.read_executable_path(os.getpid())
+    assert path is not None
+    assert os.path.isabs(path)
+
+
+def test_read_executable_path_invalid_pid_returns_none() -> None:
+    """A PID that almost certainly doesn't exist returns None gracefully."""
+    if sys.platform != "darwin":
+        pytest.skip("macOS-specific test")
+    assert pa.read_executable_path(999_999_999) is None
+
+
+def test_read_executable_path_rejects_nonpositive_pid() -> None:
+    if sys.platform != "darwin":
+        pytest.skip("macOS-specific test")
+    assert pa.read_executable_path(0) is None
+    assert pa.read_executable_path(-1) is None
+
+
+# =============================================================================
+# read_process_start_time
+# =============================================================================
+
+
+def test_read_process_start_time_for_self_is_recent_unix_seconds() -> None:
+    if sys.platform != "darwin":
+        pytest.skip("macOS-specific test")
+    import time
+    start = pa.read_process_start_time(os.getpid())
+    assert start is not None
+    # Sanity: start time should be in the past, well after Unix epoch.
+    assert 1_500_000_000 < start <= int(time.time())
+
+
+def test_read_process_start_time_invalid_pid_returns_none() -> None:
+    if sys.platform != "darwin":
+        pytest.skip("macOS-specific test")
+    assert pa.read_process_start_time(999_999_999) is None
+
+
+def test_read_process_start_time_rejects_nonpositive_pid() -> None:
+    if sys.platform != "darwin":
+        pytest.skip("macOS-specific test")
+    assert pa.read_process_start_time(0) is None
+    assert pa.read_process_start_time(-1) is None
+
+
+def test_read_process_start_time_consistent_across_repeated_reads() -> None:
+    """Two reads of the same PID return the same start_tvsec.
+
+    Used by the verified_pairs cache: even if PID is recycled, the new
+    process has a *different* start_tvsec — the same PID's start_tvsec
+    must be stable across reads.
+    """
+    if sys.platform != "darwin":
+        pytest.skip("macOS-specific test")
+    a = pa.read_process_start_time(os.getpid())
+    b = pa.read_process_start_time(os.getpid())
+    assert a == b


### PR DESCRIPTION
Second PR in the S19 (M3-v2) implementation sequence per `docs/proposals/s19-attestation-mechanism.md` v2 §Sequencing step 2 (the primitives half — UDS listener + verification-at-accept ship in PR3). Library code only; no runtime change to governance-mcp.

## What ships

- **`src/substrate/peer_attestation.py`** — macOS backend exposing four primitives the verification path will compose:
  - `read_peer_pid(sock)` — kernel-attested PID via `getsockopt(SOL_LOCAL, LOCAL_PEERPID)` on AF_UNIX sockets. Closes adversary A1 (Hermes case).
  - `read_service_label(pid)` — parses `launchctl list` for the row matching `pid`. Closes adversary A2-naive.
  - `read_executable_path(pid)` — `proc_pidpath` via ctypes. Closes A2-escalated when paired with `expected_executable_path` from `core.substrate_claims`.
  - `read_process_start_time(pid)` — `proc_pidinfo(PROC_PIDTBSDINFO).pbi_start_tvsec` via ctypes. Used by the verified_pairs cache (PR3) to defeat Q3(e) PID-reuse races.
- Linux backend stubbed with `NotImplementedError` pointing at the proposal — activates when the first Linux substrate-anchored resident lands (deferred per v2 §Open questions deferred).

## Adversary-review compliance

- `expected_executable_path` runtime match (proposal v2 + adversary-review §1) requires `read_executable_path`. Shipped here.
- PID-reuse mitigation (proposal v2 + adversary-review §3) requires `read_process_start_time`. Shipped here.
- `launchctl list` parsing (architect-review Q2) — verified live: governance-mcp (PID 37807, label `com.unitares.governance-mcp`) and Sentinel (PID 13142, label `com.unitares.sentinel`) round-trip correctly through the parser. Format is the column form documented stable since macOS 10.x.

## Verification

- 22 unit tests pass (mocked subprocess for `read_service_label`; real ctypes/socketpair calls for the others). 100% line coverage on the new module.
- End-to-end smoke test against running launchd services confirmed: governance-mcp and Sentinel both resolve to their correct labels.
- `scripts/dev/test-cache.sh` → 7254 passed (= 7232 prior + 22 new), 33 skipped, no regressions.

## What this PR does NOT do

- No UDS listener (PR3 §Sequencing step 3).
- No SessionSignals.peer_pid extension (PR3).
- No verification-at-connection-accept call into these primitives (PR3).
- No verified_pairs cache (PR3).
- No PATH 2.8 substrate-anchored gate (PR4).
- No SDK changes (PR5).
- No per-resident migration (PR6).

## Notes

- Module is dependency-light (stdlib only). It can be imported from any process that needs to reason about substrate identity — including outside the MCP server's anyio task group, which is critical because the eventual caller wraps these helpers in `loop.run_in_executor` per CLAUDE.md "Known Issue: anyio-asyncio Conflict."
- `read_service_label` rejects `pid <= 0` before shelling out — defense in depth against malformed upstream calls.
- `launchctl list` parser regex requires int-string match in column 1; dash-PID rows (loaded-but-not-running services) cannot accidentally match a valid PID.