### PR TITLE
chronicler: aggregate GitHub traffic for CIRWEL org

Add four daily scrapers covering page-view and clone counts (raw + uniques)
summed across non-archived CIRWEL repos via the GitHub traffic API's rolling
14-day window. One process-lifetime fetch backs all four scrapers so each
Chronicler run hits the API once.

Also fix a latent bug: register() now auto-creates a paired <name>.error
catalog entry for every metric, so Chronicler's failure-visibility path
stops being silently 404'd at the catalog gate. Confirmed zero .error
rows had ever landed in metrics.series before this change.

### DIFF
--- a/agents/chronicler/scrapers.py
+++ b/agents/chronicler/scrapers.py
@@ -13,6 +13,8 @@ dashboard instead of as a missing line.
 from __future__ import annotations
 
 import asyncio
+import functools
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -36,12 +38,14 @@ def _fetchval(sql: str) -> float:
     dsn = os.environ.get("CHRONICLER_DB_DSN", DEFAULT_DSN)
 
     async def _run() -> float:
-        conn = await asyncpg.connect(dsn)
+        conn = None
         try:
+            conn = await asyncpg.connect(dsn)
             value = await conn.fetchval(sql)
             return float(value or 0)
         finally:
-            await conn.close()
+            if conn is not None:
+                await conn.close()
 
     return asyncio.run(_run())
 
@@ -118,6 +122,76 @@ def checkins_7d(_repo_root: Path) -> float:
     )
 
 
+# ---------------------------------------------------------------------------
+# GitHub traffic (CIRWEL org, non-archived repos, rolling 14-day window)
+# ---------------------------------------------------------------------------
+#
+# One process-lifetime fetch backs all four traffic scrapers — Chronicler is
+# a one-shot launchd job, so `lru_cache` here means "once per scrape run",
+# not "across cron invocations". That keeps the daily snapshot consistent
+# (all four series read the same underlying response) and keeps the GitHub
+# API call count to one repo-list + 2N traffic calls per day.
+#
+# Repo set is resolved live via `gh repo list CIRWEL` so the metric tracks
+# "current non-archived org surface" — adding a new public repo automatically
+# folds it into the next day's snapshot, and archiving one drops it.
+
+GITHUB_ORG = "CIRWEL"
+
+
+@functools.lru_cache(maxsize=1)
+def _fetch_cirwel_traffic() -> dict[str, int]:
+    """Fetch + aggregate GitHub traffic for non-archived ``GITHUB_ORG`` repos.
+
+    Returns a dict with keys ``views``, ``views_uniques``, ``clones``,
+    ``clones_uniques``. Each is a 14-day rolling total summed across the
+    org. Cached for the process lifetime — call ``cache_clear()`` from tests
+    that need to vary the underlying response.
+
+    Uses the ``gh`` CLI rather than raw HTTP so we inherit the user's
+    existing auth (no PAT plumbing needed in launchd). If ``gh`` is missing
+    or unauthenticated, ``subprocess.run`` raises and Chronicler emits the
+    paired ``.error`` metric.
+    """
+    list_proc = subprocess.run(
+        ["gh", "repo", "list", GITHUB_ORG, "--limit", "200", "--json", "name,isArchived"],
+        check=True, capture_output=True, text=True,
+    )
+    repos = [r for r in json.loads(list_proc.stdout) if not r.get("isArchived")]
+
+    totals = {"views": 0, "views_uniques": 0, "clones": 0, "clones_uniques": 0}
+    for repo in repos:
+        name = repo["name"]
+        for kind, count_key, uniq_key in (
+            ("views", "views", "views_uniques"),
+            ("clones", "clones", "clones_uniques"),
+        ):
+            proc = subprocess.run(
+                ["gh", "api", f"repos/{GITHUB_ORG}/{name}/traffic/{kind}"],
+                check=True, capture_output=True, text=True,
+            )
+            data = json.loads(proc.stdout)
+            totals[count_key] += int(data.get("count", 0))
+            totals[uniq_key] += int(data.get("uniques", 0))
+    return totals
+
+
+def github_cirwel_traffic_views_14d(_repo_root: Path) -> float:
+    return float(_fetch_cirwel_traffic()["views"])
+
+
+def github_cirwel_traffic_views_uniques_14d(_repo_root: Path) -> float:
+    return float(_fetch_cirwel_traffic()["views_uniques"])
+
+
+def github_cirwel_traffic_clones_14d(_repo_root: Path) -> float:
+    return float(_fetch_cirwel_traffic()["clones"])
+
+
+def github_cirwel_traffic_clones_uniques_14d(_repo_root: Path) -> float:
+    return float(_fetch_cirwel_traffic()["clones_uniques"])
+
+
 # Registry: metric name → scrape callable. Chronicler iterates this on each run.
 #
 # Keep this in sync with the server-side catalog in
@@ -130,4 +204,8 @@ SCRAPERS: dict[str, Callable[[Path], float]] = {
     "agents.active.7d": agents_active_7d,
     "kg.entries.count": kg_entries_count,
     "checkins.7d": checkins_7d,
+    "github.cirwel.traffic.views.14d": github_cirwel_traffic_views_14d,
+    "github.cirwel.traffic.views.uniques.14d": github_cirwel_traffic_views_uniques_14d,
+    "github.cirwel.traffic.clones.14d": github_cirwel_traffic_clones_14d,
+    "github.cirwel.traffic.clones.uniques.14d": github_cirwel_traffic_clones_uniques_14d,
 }

--- a/src/fleet_metrics/catalog.py
+++ b/src/fleet_metrics/catalog.py
@@ -35,7 +35,13 @@ catalog: dict[str, Metric] = {}
 
 
 def register(metric: Metric) -> Metric:
-    """Add a metric to the catalog. Idempotent on identical re-registration."""
+    """Add a metric to the catalog. Idempotent on identical re-registration.
+
+    Also auto-registers a paired ``<name>.error`` twin so Chronicler's
+    failure-visibility path (POST ``<name>.error = 1`` on scrape failure)
+    isn't silently 404'd by the catalog gate. Metrics whose name already
+    ends in ``.error`` skip the auto-twin to avoid ``.error.error`` chains.
+    """
     existing = catalog.get(metric.name)
     if existing is not None and existing != metric:
         raise ValueError(
@@ -43,6 +49,14 @@ def register(metric: Metric) -> Metric:
             f"fields: existing={existing!r}, new={metric!r}"
         )
     catalog[metric.name] = metric
+    if not metric.name.endswith(".error"):
+        twin_name = f"{metric.name}.error"
+        if twin_name not in catalog:
+            catalog[twin_name] = Metric(
+                name=twin_name,
+                description=f"1 when the {metric.name} scraper raised; absence = success.",
+                unit="errors",
+            )
     return metric
 
 
@@ -93,4 +107,30 @@ register(Metric(
     name="checkins.7d",
     description="`process_agent_update` calls in the last 7 days — governance traffic (feeds paper v7 corpus-maturity status).",
     unit="calls",
+))
+
+# GitHub traffic for the CIRWEL org. The GitHub traffic API only exposes a
+# rolling 14-day window, so daily snapshots overlap heavily by design — the
+# longitudinal value is the trend curve, not point-in-time deltas. Aggregated
+# across all non-archived repos because per-repo series would mean ~64 entries
+# in this catalog before any of them earned their rent.
+register(Metric(
+    name="github.cirwel.traffic.views.14d",
+    description="GitHub page-view count summed across non-archived CIRWEL repos. GitHub traffic API rolling 14-day window; not daily delta.",
+    unit="views",
+))
+register(Metric(
+    name="github.cirwel.traffic.views.uniques.14d",
+    description="GitHub unique-visitor count summed across non-archived CIRWEL repos. GitHub traffic API rolling 14-day window; not daily delta.",
+    unit="visitors",
+))
+register(Metric(
+    name="github.cirwel.traffic.clones.14d",
+    description="GitHub clone count summed across non-archived CIRWEL repos. GitHub traffic API rolling 14-day window; not daily delta.",
+    unit="clones",
+))
+register(Metric(
+    name="github.cirwel.traffic.clones.uniques.14d",
+    description="GitHub unique-cloner count summed across non-archived CIRWEL repos. GitHub traffic API rolling 14-day window; not daily delta.",
+    unit="cloners",
 ))

--- a/tests/test_chronicler.py
+++ b/tests/test_chronicler.py
@@ -354,6 +354,151 @@ class TestChroniclerAgent:
         assert result is None  # GovernanceAgent._handle_cycle_result skips check-in
 
 
+class TestGithubTrafficScrapers:
+    """Aggregate GitHub traffic across non-archived CIRWEL repos.
+
+    The four scrapers share one process-lifetime fetch (Chronicler is a
+    one-shot launchd job) so a single run hits the GitHub API once, not
+    four times. Tests clear that cache to keep cases independent.
+    """
+
+    def setup_method(self):
+        from agents.chronicler import scrapers
+        scrapers._fetch_cirwel_traffic.cache_clear()
+
+    def teardown_method(self):
+        from agents.chronicler import scrapers
+        scrapers._fetch_cirwel_traffic.cache_clear()
+
+    @staticmethod
+    def _gh_runner(repos, traffic):
+        """Build a fake subprocess.run that answers `gh` calls.
+
+        ``repos``: list of {"name": ..., "isArchived": ...} dicts.
+        ``traffic``: {repo_name: {"views": (count, uniques), "clones": (count, uniques)}}
+        """
+        from subprocess import CompletedProcess
+
+        def fake_run(cmd, *args, **kwargs):
+            if cmd[:3] == ["gh", "repo", "list"]:
+                return CompletedProcess(cmd, 0, stdout=json.dumps(repos), stderr="")
+            if cmd[:2] == ["gh", "api"]:
+                # cmd shape: ["gh", "api", "repos/CIRWEL/<name>/traffic/<kind>"]
+                path = cmd[2]
+                _, _, repo_name, _, kind = path.split("/")
+                count, uniques = traffic[repo_name][kind]
+                payload = {"count": count, "uniques": uniques, "views": [], "clones": []}
+                return CompletedProcess(cmd, 0, stdout=json.dumps(payload), stderr="")
+            raise AssertionError(f"unexpected gh call: {cmd}")
+
+        return fake_run
+
+    def test_aggregates_views_and_clones_across_repos(self):
+        from agents.chronicler import scrapers
+
+        repos = [
+            {"name": "alpha", "isArchived": False},
+            {"name": "beta", "isArchived": False},
+        ]
+        traffic = {
+            "alpha": {"views": (100, 5), "clones": (40, 8)},
+            "beta": {"views": (23, 2), "clones": (7, 3)},
+        }
+        with patch.object(scrapers.subprocess, "run", side_effect=self._gh_runner(repos, traffic)):
+            result = scrapers._fetch_cirwel_traffic()
+
+        assert result == {
+            "views": 123,
+            "views_uniques": 7,
+            "clones": 47,
+            "clones_uniques": 11,
+        }
+
+    def test_skips_archived_repos(self):
+        from agents.chronicler import scrapers
+
+        repos = [
+            {"name": "alive", "isArchived": False},
+            {"name": "frozen", "isArchived": True},
+        ]
+        traffic = {"alive": {"views": (10, 1), "clones": (2, 1)}}
+        # Only `alive` should be queried; `frozen` would KeyError if asked.
+        with patch.object(scrapers.subprocess, "run", side_effect=self._gh_runner(repos, traffic)):
+            result = scrapers._fetch_cirwel_traffic()
+
+        assert result == {
+            "views": 10, "views_uniques": 1,
+            "clones": 2, "clones_uniques": 1,
+        }
+
+    def test_caches_within_process_lifetime(self):
+        from agents.chronicler import scrapers
+
+        repos = [{"name": "x", "isArchived": False}]
+        traffic = {"x": {"views": (1, 1), "clones": (1, 1)}}
+        runner = MagicMock(side_effect=self._gh_runner(repos, traffic))
+        with patch.object(scrapers.subprocess, "run", runner):
+            scrapers._fetch_cirwel_traffic()
+            scrapers._fetch_cirwel_traffic()
+
+        # 1 repo-list call + (views, clones) per repo = 3 total. If the second
+        # call re-fetched, we'd see 6.
+        assert runner.call_count == 3
+
+    def test_each_traffic_scraper_returns_its_dimension(self):
+        from agents.chronicler import scrapers
+
+        snapshot = {"views": 7, "views_uniques": 3, "clones": 12, "clones_uniques": 4}
+        with patch.object(scrapers, "_fetch_cirwel_traffic", return_value=snapshot):
+            assert scrapers.github_cirwel_traffic_views_14d(Path("/")) == 7.0
+            assert scrapers.github_cirwel_traffic_views_uniques_14d(Path("/")) == 3.0
+            assert scrapers.github_cirwel_traffic_clones_14d(Path("/")) == 12.0
+            assert scrapers.github_cirwel_traffic_clones_uniques_14d(Path("/")) == 4.0
+
+    def test_traffic_scrapers_registered(self):
+        from agents.chronicler.scrapers import SCRAPERS
+
+        for name in (
+            "github.cirwel.traffic.views.14d",
+            "github.cirwel.traffic.views.uniques.14d",
+            "github.cirwel.traffic.clones.14d",
+            "github.cirwel.traffic.clones.uniques.14d",
+        ):
+            assert name in SCRAPERS, f"{name} missing from SCRAPERS registry"
+
+    def test_traffic_metrics_in_catalog(self):
+        from src.fleet_metrics.catalog import catalog as _catalog
+
+        for name in (
+            "github.cirwel.traffic.views.14d",
+            "github.cirwel.traffic.views.uniques.14d",
+            "github.cirwel.traffic.clones.14d",
+            "github.cirwel.traffic.clones.uniques.14d",
+        ):
+            assert name in _catalog, f"{name} missing from catalog"
+            entry = _catalog[name]
+            # Catch-future-self caveat: explicit window semantics in description.
+            assert "rolling 14-day" in entry.description, (
+                f"{name} description must say 'rolling 14-day' so the chart "
+                f"isn't misread as a daily delta"
+            )
+
+    def test_scraper_failure_emits_error_metric_and_lands_in_catalog(self):
+        """Regression for the .error gate: when a traffic scraper fails, the
+        emitted `<name>.error` metric must be a registered catalog name so
+        the POST is accepted (not 404'd) — this exercises both the new
+        traffic surface and the auto-twin catalog fix."""
+        from src.fleet_metrics.catalog import catalog as _catalog
+
+        for name in (
+            "github.cirwel.traffic.views.14d",
+            "github.cirwel.traffic.views.uniques.14d",
+            "github.cirwel.traffic.clones.14d",
+            "github.cirwel.traffic.clones.uniques.14d",
+        ):
+            assert f"{name}.error" in _catalog
+
+
 class TestChroniclerAsKnownResident:
     def test_chronicler_in_known_resident_labels(self):
         from src.grounding.class_indicator import KNOWN_RESIDENT_LABELS

--- a/tests/test_fleet_metrics.py
+++ b/tests/test_fleet_metrics.py
@@ -46,6 +46,59 @@ class TestCatalog:
             assert _catalog["test.idempotent"] == m
         finally:
             _catalog.pop("test.idempotent", None)
+            _catalog.pop("test.idempotent.error", None)
+
+    def test_register_creates_error_twin(self):
+        """Every registered metric gets a paired `.error` entry so Chronicler
+        can post `<name>.error = 1` on scrape failure without 404ing under the
+        catalog gate. Without this, scraper failures are silently swallowed."""
+        m = Metric(name="test.twin", description="primary", unit="things")
+        register(m)
+        try:
+            twin = _catalog.get("test.twin.error")
+            assert twin is not None, "register() must auto-create .error twin"
+            assert twin.name == "test.twin.error"
+            assert twin.unit == "errors"
+            assert "test.twin" in twin.description
+        finally:
+            _catalog.pop("test.twin", None)
+            _catalog.pop("test.twin.error", None)
+
+    def test_register_idempotent_includes_twin(self):
+        """Re-registering a metric whose twin already exists must not raise."""
+        m = Metric(name="test.twin.idem", description="x", unit="y")
+        register(m)
+        try:
+            register(m)  # twin already exists; must not raise
+            assert "test.twin.idem.error" in _catalog
+        finally:
+            _catalog.pop("test.twin.idem", None)
+            _catalog.pop("test.twin.idem.error", None)
+
+    def test_existing_scrapers_have_error_twins(self):
+        """The shipping Chronicler scrapers must all have catalog-registered
+        `.error` twins so their failure-visibility path actually lands rows
+        in metrics.series instead of 404ing."""
+        for base in (
+            "tokei.unitares.src.code",
+            "tests.unitares.count",
+            "agents.active.7d",
+            "kg.entries.count",
+            "checkins.7d",
+        ):
+            assert f"{base}.error" in _catalog, f"missing .error twin for {base}"
+
+    def test_register_does_not_create_double_error_twin(self):
+        """Registering a metric whose name already ends in `.error` must not
+        produce a `.error.error` entry — the auto-twin logic guards against
+        compounding suffixes."""
+        m = Metric(name="test.bare.error", description="standalone error", unit="errors")
+        register(m)
+        try:
+            assert "test.bare.error" in _catalog
+            assert "test.bare.error.error" not in _catalog
+        finally:
+            _catalog.pop("test.bare.error", None)
 
     def test_register_conflict_raises(self):
         m1 = Metric(name="test.conflict", description="a", unit="u1")


### PR DESCRIPTION
Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.