### PR TITLE
feat: phase 1 — synthetic column on agent_state for bootstrap check-ins

### DIFF
--- a/db/postgres/migrations/018_bootstrap_synthetic_state.sql
+++ b/db/postgres/migrations/018_bootstrap_synthetic_state.sql
@@ -1,0 +1,65 @@
+-- 018_bootstrap_synthetic_state.sql
+--
+-- Phase 1 of onboard-bootstrap-checkin.md (v2.1).
+--
+-- Adds a `synthetic` boolean column to core.agent_state so the server can
+-- write labeled "bootstrap" check-in rows on onboard without laundering them
+-- into measured-state code paths. The column is the load-bearing filter key;
+-- `state_json.source = "bootstrap"` is descriptive metadata.
+--
+-- Schema-only migration. No handler code, no filter-site changes. Subsequent
+-- phases (per §9 of the proposal) add: handler that writes the row, every
+-- read-path filter (`synthetic = false` default), hook integration, and the
+-- bootstrapped-but-silent observable surface.
+--
+-- Rollback shape: drop the unique index, drop the partial index, drop the
+-- column. The matview can be re-DROPped/CREATEd from migration 008 verbatim.
+
+-- 1. Add the column. Default false means every existing row is correctly
+--    classified as measured. ADD COLUMN with a constant default is instant
+--    on PostgreSQL@17 (catalog-only, no row rewrite).
+ALTER TABLE core.agent_state
+    ADD COLUMN IF NOT EXISTS synthetic BOOLEAN NOT NULL DEFAULT false;
+
+-- 2. Partial index on the dominant query shape (most-recent measured state
+--    per identity). Skips synthetic rows entirely so the filter pays no
+--    seek cost.
+CREATE INDEX IF NOT EXISTS idx_agent_state_synthetic_partial
+    ON core.agent_state (identity_id, recorded_at DESC)
+    WHERE synthetic = false;
+
+-- 3. At-most-one bootstrap row per identity. Closes the concurrent-onboard
+--    race (two parallel hooks for the same UUID) at the DB layer rather than
+--    relying on application-level locks. Bootstrap writes that lose the race
+--    catch the unique-violation and return the winning row's state_id with
+--    `bootstrap.written: false`.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_agent_state_one_bootstrap_per_identity
+    ON core.agent_state (identity_id)
+    WHERE synthetic = true;
+
+-- 4. Rebuild the dashboard materialized view to project the new column.
+--    The existing fallback at src/db/mixins/state.py:103 covers the brief
+--    drop/create window (try/except falls through to a base-table query).
+DROP MATERIALIZED VIEW IF EXISTS core.mv_latest_agent_states;
+
+CREATE MATERIALIZED VIEW core.mv_latest_agent_states AS
+SELECT DISTINCT ON (s.identity_id)
+       s.state_id, s.identity_id, i.agent_id, s.recorded_at,
+       s.entropy, s.integrity, s.stability_index, s.volatility,
+       s.regime, s.coherence, s.state_json, s.synthetic
+FROM core.agent_state s
+JOIN core.identities i ON i.identity_id = s.identity_id
+ORDER BY s.identity_id, s.recorded_at DESC;
+
+-- Unique index required for REFRESH CONCURRENTLY.
+CREATE UNIQUE INDEX idx_mv_latest_states_identity
+    ON core.mv_latest_agent_states (identity_id);
+
+-- For lookups by agent_id (mirrors migration 008).
+CREATE INDEX idx_mv_latest_states_agent
+    ON core.mv_latest_agent_states (agent_id);
+
+-- Register the migration.
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (18, 'bootstrap_synthetic_state', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -101,6 +101,7 @@ async def ensure_test_database_schema() -> None:
         await _execute_sql_file(conn, "db/postgres/migrations/011_behavioral_baselines.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/012_identity_last_activity_at.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/014_seed_epoch_2.sql")
+        await _execute_sql_file(conn, "db/postgres/migrations/018_bootstrap_synthetic_state.sql")
 
         # Ensure partitioned audit tables can accept inserts for current month.
         await _execute_sql_file(conn, "db/postgres/partitions.sql")

--- a/tests/test_migration_018_bootstrap_synthetic.py
+++ b/tests/test_migration_018_bootstrap_synthetic.py
@@ -1,0 +1,228 @@
+"""
+Phase 1 schema tests for onboard-bootstrap-checkin (migration 018).
+
+Verifies the column, partial index, unique-partial index, and matview
+projection are in place. Subsequent phases add handler tests, filter-site
+tests, and the bootstrapped-but-silent observable surface.
+
+Spec: docs/proposals/onboard-bootstrap-checkin.md §3.2, §3.4, §9 step 1.
+"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+try:
+    import asyncpg
+except ImportError:
+    pytest.skip("asyncpg not installed", allow_module_level=True)
+
+from tests.test_db_utils import (
+    TEST_DB_URL,
+    can_connect_to_test_db,
+    ensure_test_database_schema,
+)
+
+if not can_connect_to_test_db():
+    pytest.skip("governance_test database not available", allow_module_level=True)
+
+
+async def _seed_identity(conn) -> int:
+    """Insert a fresh agent + identity, return the identity_id."""
+    agent_id = f"test-{uuid.uuid4()}"
+    await conn.execute(
+        "INSERT INTO core.agents (id, api_key) VALUES ($1, 'test-key')",
+        agent_id,
+    )
+    identity_id = await conn.fetchval(
+        """
+        INSERT INTO core.identities (agent_id, api_key_hash)
+        VALUES ($1, 'test-hash')
+        RETURNING identity_id
+        """,
+        agent_id,
+    )
+    return identity_id
+
+
+@pytest.mark.asyncio
+async def test_synthetic_column_exists_with_default():
+    """The `synthetic` column exists, NOT NULL, defaults to false."""
+    await ensure_test_database_schema()
+
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        col = await conn.fetchrow(
+            """
+            SELECT column_name, data_type, is_nullable, column_default
+            FROM information_schema.columns
+            WHERE table_schema = 'core'
+              AND table_name = 'agent_state'
+              AND column_name = 'synthetic'
+            """
+        )
+    finally:
+        await conn.close()
+
+    assert col is not None, "core.agent_state.synthetic column missing"
+    assert col["data_type"] == "boolean"
+    assert col["is_nullable"] == "NO"
+    assert col["column_default"] == "false"
+
+
+@pytest.mark.asyncio
+async def test_existing_inserts_default_to_synthetic_false():
+    """Inserts that omit `synthetic` get false (existing call sites unaffected)."""
+    await ensure_test_database_schema()
+
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        identity_id = await _seed_identity(conn)
+        await conn.execute(
+            """
+            INSERT INTO core.agent_state (identity_id, entropy, integrity)
+            VALUES ($1, 0.4, 0.6)
+            """,
+            identity_id,
+        )
+        synthetic = await conn.fetchval(
+            "SELECT synthetic FROM core.agent_state WHERE identity_id = $1",
+            identity_id,
+        )
+    finally:
+        await conn.close()
+
+    assert synthetic is False
+
+
+@pytest.mark.asyncio
+async def test_partial_index_exists():
+    """idx_agent_state_synthetic_partial covers measured-state queries."""
+    await ensure_test_database_schema()
+
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        idx = await conn.fetchrow(
+            """
+            SELECT indexname, indexdef
+            FROM pg_indexes
+            WHERE schemaname = 'core'
+              AND tablename = 'agent_state'
+              AND indexname = 'idx_agent_state_synthetic_partial'
+            """
+        )
+    finally:
+        await conn.close()
+
+    assert idx is not None, "partial index for measured-state queries missing"
+    assert "WHERE (synthetic = false)" in idx["indexdef"]
+    assert "identity_id" in idx["indexdef"]
+    assert "recorded_at" in idx["indexdef"]
+
+
+@pytest.mark.asyncio
+async def test_unique_partial_index_enforces_one_bootstrap_per_identity():
+    """Two synthetic rows for one identity violate uq_agent_state_one_bootstrap_per_identity."""
+    await ensure_test_database_schema()
+
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        identity_id = await _seed_identity(conn)
+
+        await conn.execute(
+            """
+            INSERT INTO core.agent_state (identity_id, entropy, integrity, synthetic)
+            VALUES ($1, 0.5, 0.5, true)
+            """,
+            identity_id,
+        )
+
+        with pytest.raises(asyncpg.UniqueViolationError):
+            await conn.execute(
+                """
+                INSERT INTO core.agent_state (identity_id, entropy, integrity, synthetic)
+                VALUES ($1, 0.6, 0.4, true)
+                """,
+                identity_id,
+            )
+
+        # But many measured rows for the same identity stay legal.
+        for _ in range(3):
+            await conn.execute(
+                """
+                INSERT INTO core.agent_state (identity_id, entropy, integrity, synthetic)
+                VALUES ($1, 0.4, 0.7, false)
+                """,
+                identity_id,
+            )
+
+        synthetic_count = await conn.fetchval(
+            "SELECT COUNT(*) FROM core.agent_state WHERE identity_id = $1 AND synthetic = true",
+            identity_id,
+        )
+        measured_count = await conn.fetchval(
+            "SELECT COUNT(*) FROM core.agent_state WHERE identity_id = $1 AND synthetic = false",
+            identity_id,
+        )
+    finally:
+        await conn.close()
+
+    assert synthetic_count == 1
+    assert measured_count == 3
+
+
+@pytest.mark.asyncio
+async def test_matview_projects_synthetic_column():
+    """mv_latest_agent_states exposes `synthetic` so the dashboard can filter."""
+    await ensure_test_database_schema()
+
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        # Materialized view columns aren't in information_schema; use pg_attribute.
+        col = await conn.fetchrow(
+            """
+            SELECT a.attname, t.typname
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            JOIN pg_attribute a ON a.attrelid = c.oid
+            JOIN pg_type t ON t.oid = a.atttypid
+            WHERE n.nspname = 'core'
+              AND c.relname = 'mv_latest_agent_states'
+              AND a.attname = 'synthetic'
+              AND a.attnum > 0
+            """
+        )
+
+        # And REFRESH CONCURRENTLY still works (depends on the unique index).
+        await conn.execute(
+            "REFRESH MATERIALIZED VIEW CONCURRENTLY core.mv_latest_agent_states"
+        )
+    finally:
+        await conn.close()
+
+    assert col is not None, "matview must project synthetic column for dashboard filtering"
+    assert col["typname"] == "bool"
+
+
+@pytest.mark.asyncio
+async def test_migration_018_registered():
+    """Migration row landed in core.schema_migrations."""
+    await ensure_test_database_schema()
+
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        row = await conn.fetchrow(
+            "SELECT version, name FROM core.schema_migrations WHERE version = 18"
+        )
+    finally:
+        await conn.close()
+
+    assert row is not None
+    assert row["name"] == "bootstrap_synthetic_state"


### PR DESCRIPTION
Phase 1 of [docs/proposals/onboard-bootstrap-checkin.md](docs/proposals/onboard-bootstrap-checkin.md) (v2.1) — schema scaffolding for the bootstrap-checkin work.

## What

* `core.agent_state.synthetic` boolean column, NOT NULL DEFAULT false. Existing rows are correctly classified as measured.
* `idx_agent_state_synthetic_partial` — partial index covering the dominant most-recent-measured-state-per-identity query, skipping synthetic rows entirely.
* `uq_agent_state_one_bootstrap_per_identity` — unique partial index closing the concurrent-onboard race at the DB layer (per spec §3.4).
* `core.mv_latest_agent_states` matview rebuilt to project the new column so dashboard reads can filter cleanly. `REFRESH CONCURRENTLY` still works.

## What's not in this PR

* No handler code yet — `onboard.initial_state` schema + INSERT is Phase 2.
* No filter-site changes — that's Phase 3, the audit-deliverable step.
* Hook integration is Phase 4. Population observability (bootstrapped-but-silent surface) is Phase 5.

The phasing keeps each PR tightly scoped and lets the §3 filter-audit happen against a stable schema baseline.

## Spec context

Reviewed by parallel council (`docs/proposals/onboard-bootstrap-checkin.{dialectic,code}-review.md`); both endorsed proceeding. v2 folded in 11 amendments; v2.1 closed two ack-pass clarifications. The §3.5 substrate-earned check was further refined during this PR's authoring to use the existing `core.substrate_claims` registry (S19 PR1) rather than an `identity.metadata` backfill — see master commit `c98d1d18`.

## Tests

Six new tests in `tests/test_migration_018_bootstrap_synthetic.py`:
- column exists with correct default
- existing inserts default to `synthetic=false`
- partial index exists with correct WHERE clause
- unique partial index enforces at-most-one-bootstrap-per-identity (raises `UniqueViolationError` on race)
- matview projects the new column, REFRESH CONCURRENTLY still works
- migration row registered in `core.schema_migrations`

`tests/test_db_utils.py` updated to apply migration 018 in the test schema bootstrap chain.

Full suite: **7238 passed, 33 skipped, 77.70% coverage** via `./scripts/dev/test-cache.sh`.

## Rollback

Drop the unique partial index, drop the partial index, drop the column, then run migration 008 verbatim to restore the original matview shape. No data migration was performed (column added with constant default — instant catalog-only on PG@17).