### PR TITLE
S19 PR3a: substrate-claim verification module + VerifiedPairsCache

### DIFF
--- a/src/substrate/verification.py
+++ b/src/substrate/verification.py
@@ -1,0 +1,279 @@
+"""S19 substrate-claim verification.
+
+Pure verification logic: given a substrate-claim (from ``core.substrate_claims``)
+and the kernel-attested peer PID of a connecting resident, decide accept or
+reject. Uses the four primitives from ``peer_attestation.py`` (label,
+executable path, start time) and a thread-safe in-process cache for
+PID-reuse detection.
+
+This module contains NO async or DB code. The caller (PR3b: UDS handler
+integration) is responsible for: (a) async-loading the substrate-claim row
+from PostgreSQL, (b) constructing the ``SubstrateClaim`` dataclass, and
+(c) wrapping the call in ``loop.run_in_executor`` per the anyio-deadlock
+constraint (CLAUDE.md "Known Issue").
+
+Adversary coverage (proposal v2 §Adversary models):
+- A1 (Hermes case): defeated by ``read_peer_pid`` upstream + ``no_claim``
+  rejection if the agent_uuid lacks a substrate-claim row.
+- A2 naive (copy + connect from non-launchd process): defeated by the
+  ``label_mismatch`` rejection.
+- A2 escalated (binary-substitution + ``launchctl kickstart``): defeated
+  by the ``exec_mismatch`` rejection. Residual deployment risk if the
+  binary path is same-UID-writable (warned at enrollment time).
+- Q3(e) (PID reuse race): defeated by the ``pid_reuse`` rejection — the
+  cache pins ``(pid, start_tvsec)`` on first verified connect; a recycled
+  PID has a different start_tvsec for the new process.
+"""
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional, Protocol
+
+if TYPE_CHECKING:
+    pass
+
+
+# =============================================================================
+# Data shapes
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class SubstrateClaim:
+    """Snapshot of one row from ``core.substrate_claims``.
+
+    Constructed by the DB-loading caller (PR3b) and passed to
+    ``verify_substrate_claim``. Frozen so it can't be mutated mid-verify.
+    """
+    agent_id: str
+    expected_launchd_label: str
+    expected_executable_path: str
+    enrolled_at: datetime
+    enrolled_by_operator: bool
+    notes: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    """Outcome of a single verify call.
+
+    ``accepted`` — True when the peer is the registered substrate.
+    ``reason``   — human-readable explanation, useful in audit logs and
+                   in the explicit-rejection message returned to the peer.
+    ``failure_code`` — machine-readable failure category, ``None`` on accept.
+                       One of: ``no_claim``, ``label_mismatch``,
+                       ``exec_mismatch``, ``attestation_failed``,
+                       ``pid_reuse``.
+    """
+    accepted: bool
+    reason: str
+    failure_code: Optional[str] = None
+
+
+class _PeerAttestationLike(Protocol):
+    """Subset of ``src.substrate.peer_attestation`` we depend on. Defined
+    structurally so tests can inject a fake without subclassing."""
+    @staticmethod
+    def read_service_label(pid: int) -> Optional[str]: ...
+    @staticmethod
+    def read_executable_path(pid: int) -> Optional[str]: ...
+    @staticmethod
+    def read_process_start_time(pid: int) -> Optional[int]: ...
+
+
+# =============================================================================
+# VerifiedPairsCache
+# =============================================================================
+
+
+class VerifiedPairsCache:
+    """In-process per-server-lifetime cache of ``agent_id → (pid, start_tvsec)``.
+
+    Defeats Q3(e) PID-reuse: when a substrate-anchored agent first connects
+    successfully, the cache pins its ``(pid, start_tvsec)``. A subsequent
+    connect that lands on the same PID with a *different* start_tvsec —
+    indicating PID reuse by an unrelated process — is rejected.
+
+    A subsequent connect with a *different* PID (legitimate restart) is
+    accepted and the cache entry is updated. Same PID + same start is the
+    no-op happy path.
+
+    Thread-safe; the lock is taken for atomic compare-and-update.
+    """
+
+    def __init__(self) -> None:
+        self._pairs: dict[str, tuple[int, int]] = {}
+        self._lock = threading.Lock()
+
+    def get(self, agent_id: str) -> Optional[tuple[int, int]]:
+        """Return the cached ``(pid, start_tvsec)`` or ``None`` if uncached."""
+        with self._lock:
+            return self._pairs.get(agent_id)
+
+    def record(self, agent_id: str, pid: int, start_tvsec: int) -> None:
+        """Pin or update the cache entry for ``agent_id``."""
+        with self._lock:
+            self._pairs[agent_id] = (pid, start_tvsec)
+
+    def clear(self) -> None:
+        """Drop all cached pairs. Useful in tests; not used by production code."""
+        with self._lock:
+            self._pairs.clear()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._pairs)
+
+
+# =============================================================================
+# verify_substrate_claim
+# =============================================================================
+
+
+def _get_peer_attestation_module() -> _PeerAttestationLike:
+    """Default-import the peer_attestation module. Indirection allows tests
+    to inject a fake module via the ``pa_module`` parameter."""
+    from src.substrate import peer_attestation
+    return peer_attestation  # type: ignore[return-value]
+
+
+def verify_substrate_claim(
+    claim: Optional[SubstrateClaim],
+    peer_pid: int,
+    *,
+    pa_module: Optional[_PeerAttestationLike] = None,
+    cache: Optional[VerifiedPairsCache] = None,
+) -> VerificationResult:
+    """Verify a substrate-claim against a kernel-attested peer PID.
+
+    Returns a ``VerificationResult``; the caller (PR3b) translates the
+    result into either an accept (continue with normal session binding)
+    or an explicit rejection (return error pointing at the UDS path with
+    the specific failure reason for audit).
+
+    Order of checks is significant: cheaper checks first (label, executable),
+    then the start-time check that maintains the cache. A check that fails
+    short-circuits later checks; the cache is only updated on full success.
+    """
+    if claim is None:
+        return VerificationResult(
+            accepted=False,
+            reason="no substrate-claim registered for this agent_uuid; "
+                   "operator must run scripts/ops/enroll_resident.py first",
+            failure_code="no_claim",
+        )
+
+    pa = pa_module if pa_module is not None else _get_peer_attestation_module()
+
+    # ---- launchd label check ---------------------------------------------
+    actual_label = pa.read_service_label(peer_pid)
+    if actual_label != claim.expected_launchd_label:
+        return VerificationResult(
+            accepted=False,
+            reason=(
+                f"launchd label mismatch for PID {peer_pid}: "
+                f"registered {claim.expected_launchd_label!r}, "
+                f"observed {actual_label!r}"
+            ),
+            failure_code="label_mismatch",
+        )
+
+    # ---- executable path check -------------------------------------------
+    actual_exec = pa.read_executable_path(peer_pid)
+    if actual_exec != claim.expected_executable_path:
+        return VerificationResult(
+            accepted=False,
+            reason=(
+                f"executable path mismatch for PID {peer_pid}: "
+                f"registered {claim.expected_executable_path!r}, "
+                f"observed {actual_exec!r}"
+            ),
+            failure_code="exec_mismatch",
+        )
+
+    # ---- process start time + PID-reuse cache ---------------------------
+    start_tvsec = pa.read_process_start_time(peer_pid)
+    if start_tvsec is None:
+        return VerificationResult(
+            accepted=False,
+            reason=f"could not read process start time for PID {peer_pid}",
+            failure_code="attestation_failed",
+        )
+
+    if cache is not None:
+        cached = cache.get(claim.agent_id)
+        if cached is not None:
+            cached_pid, cached_start = cached
+            if cached_pid == peer_pid and cached_start != start_tvsec:
+                # Same PID but different start_tvsec → PID was recycled
+                # between the prior verified connect and this one.
+                return VerificationResult(
+                    accepted=False,
+                    reason=(
+                        f"PID reuse detected for {claim.agent_id}: "
+                        f"PID {peer_pid} previously had start_tvsec={cached_start}, "
+                        f"now {start_tvsec} (different process)"
+                    ),
+                    failure_code="pid_reuse",
+                )
+            # else: legitimate restart (different PID), or no-op match. Either
+            # way the recorded value below is the now-current truth.
+        cache.record(claim.agent_id, peer_pid, start_tvsec)
+
+    return VerificationResult(
+        accepted=True,
+        reason=(
+            f"substrate-claim verified: label={claim.expected_launchd_label} "
+            f"pid={peer_pid} start_tvsec={start_tvsec}"
+        ),
+    )
+
+
+# =============================================================================
+# DB helper — fetch SubstrateClaim by agent_id
+# =============================================================================
+
+
+async def fetch_substrate_claim(agent_id: str) -> Optional[SubstrateClaim]:
+    """Async lookup of one row from ``core.substrate_claims``.
+
+    Returns ``None`` when no claim is registered for ``agent_id``. This
+    helper is the "load" half of verify; the caller composes the two:
+
+        claim = await fetch_substrate_claim(uuid)
+        result = await loop.run_in_executor(None, verify_substrate_claim, claim, peer_pid)
+
+    The split keeps the synchronous verify path (which calls launchctl /
+    libproc) out of the anyio task group; only ``fetch_substrate_claim``
+    awaits asyncpg.
+    """
+    from src.db import get_db
+
+    db = get_db()
+    async with db.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT
+                agent_id,
+                expected_launchd_label,
+                expected_executable_path,
+                enrolled_at,
+                enrolled_by_operator,
+                notes
+            FROM core.substrate_claims
+            WHERE agent_id = $1
+            """,
+            agent_id,
+        )
+    if row is None:
+        return None
+    return SubstrateClaim(
+        agent_id=row["agent_id"],
+        expected_launchd_label=row["expected_launchd_label"],
+        expected_executable_path=row["expected_executable_path"],
+        enrolled_at=row["enrolled_at"],
+        enrolled_by_operator=row["enrolled_by_operator"],
+        notes=row["notes"],
+    )

--- a/tests/test_substrate_verification.py
+++ b/tests/test_substrate_verification.py
@@ -1,0 +1,283 @@
+"""S19: substrate-claim verification logic.
+
+Tests cover:
+- VerifiedPairsCache: pin/match/update/clear semantics, thread safety
+- verify_substrate_claim:
+  - no_claim rejection
+  - label_mismatch rejection (label query mismatch or returns None)
+  - exec_mismatch rejection
+  - attestation_failed rejection (start-time read returns None)
+  - pid_reuse rejection (Q3(e) — same PID, different start_tvsec)
+  - happy path: cache pinned on first verified connect
+  - legitimate restart: different PID accepted, cache updated
+  - cache no-op: same PID + same start_tvsec returns accepted
+
+Pure-Python tests; ``peer_attestation`` is mocked via the ``pa_module``
+parameter (no subprocess / ctypes calls under test).
+"""
+from __future__ import annotations
+
+import threading
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Optional
+
+import pytest
+
+from src.substrate.verification import (
+    SubstrateClaim,
+    VerifiedPairsCache,
+    VerificationResult,
+    verify_substrate_claim,
+)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_claim(
+    agent_id: str = "f92dcea8-4786-412a-a0eb-362c273382f5",
+    label: str = "com.unitares.sentinel",
+    executable: str = "/opt/homebrew/bin/sentinel",
+) -> SubstrateClaim:
+    return SubstrateClaim(
+        agent_id=agent_id,
+        expected_launchd_label=label,
+        expected_executable_path=executable,
+        enrolled_at=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        enrolled_by_operator=True,
+    )
+
+
+def _fake_pa(
+    *,
+    label: Optional[str] = None,
+    executable: Optional[str] = None,
+    start_time: Optional[int] = 1_777_167_717,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        read_service_label=lambda pid: label,
+        read_executable_path=lambda pid: executable,
+        read_process_start_time=lambda pid: start_time,
+    )
+
+
+# =============================================================================
+# VerifiedPairsCache
+# =============================================================================
+
+
+def test_cache_get_returns_none_when_uncached() -> None:
+    cache = VerifiedPairsCache()
+    assert cache.get("any-uuid") is None
+
+
+def test_cache_record_then_get_round_trip() -> None:
+    cache = VerifiedPairsCache()
+    cache.record("uuid-1", 100, 1_777_000_000)
+    assert cache.get("uuid-1") == (100, 1_777_000_000)
+
+
+def test_cache_record_overwrites() -> None:
+    cache = VerifiedPairsCache()
+    cache.record("uuid-1", 100, 1_777_000_000)
+    cache.record("uuid-1", 200, 1_777_000_500)
+    assert cache.get("uuid-1") == (200, 1_777_000_500)
+
+
+def test_cache_clear_drops_all_entries() -> None:
+    cache = VerifiedPairsCache()
+    cache.record("uuid-1", 100, 1_777_000_000)
+    cache.record("uuid-2", 200, 1_777_000_500)
+    assert len(cache) == 2
+    cache.clear()
+    assert len(cache) == 0
+
+
+def test_cache_concurrent_record_is_safe() -> None:
+    """Two threads racing to record the same UUID land cleanly (lock-protected)."""
+    cache = VerifiedPairsCache()
+
+    def writer(start: int) -> None:
+        for _ in range(200):
+            cache.record("uuid-race", 1234, start)
+
+    t1 = threading.Thread(target=writer, args=(1_777_000_000,))
+    t2 = threading.Thread(target=writer, args=(1_777_000_999,))
+    t1.start(); t2.start()
+    t1.join(); t2.join()
+
+    cached = cache.get("uuid-race")
+    assert cached is not None
+    assert cached[0] == 1234
+    assert cached[1] in (1_777_000_000, 1_777_000_999)
+
+
+# =============================================================================
+# verify_substrate_claim — failure modes
+# =============================================================================
+
+
+def test_no_claim_rejection() -> None:
+    """``claim=None`` → no_claim with operator-actionable message."""
+    result = verify_substrate_claim(None, peer_pid=1234, pa_module=_fake_pa())
+    assert result.accepted is False
+    assert result.failure_code == "no_claim"
+    assert "enroll_resident.py" in result.reason
+
+
+def test_label_mismatch_when_pa_returns_different_label() -> None:
+    claim = _make_claim()
+    pa = _fake_pa(
+        label="com.someone.else",
+        executable=claim.expected_executable_path,
+    )
+    result = verify_substrate_claim(claim, peer_pid=1234, pa_module=pa)
+    assert result.accepted is False
+    assert result.failure_code == "label_mismatch"
+    assert "com.someone.else" in result.reason
+
+
+def test_label_mismatch_when_pa_returns_none() -> None:
+    """PID is not under any launchd job: read_service_label returns None."""
+    claim = _make_claim()
+    pa = _fake_pa(label=None, executable=claim.expected_executable_path)
+    result = verify_substrate_claim(claim, peer_pid=1234, pa_module=pa)
+    assert result.accepted is False
+    assert result.failure_code == "label_mismatch"
+    assert "None" in result.reason
+
+
+def test_exec_mismatch_when_actual_path_differs() -> None:
+    claim = _make_claim(executable="/opt/homebrew/bin/sentinel")
+    pa = _fake_pa(
+        label=claim.expected_launchd_label,
+        executable="/Users/cirwel/projects/unitares/agents/sentinel/agent.py",
+    )
+    result = verify_substrate_claim(claim, peer_pid=1234, pa_module=pa)
+    assert result.accepted is False
+    assert result.failure_code == "exec_mismatch"
+
+
+def test_attestation_failed_when_start_time_read_returns_none() -> None:
+    """proc_pidinfo failure: classified attestation_failed, not pid_reuse."""
+    claim = _make_claim()
+    pa = _fake_pa(
+        label=claim.expected_launchd_label,
+        executable=claim.expected_executable_path,
+        start_time=None,
+    )
+    result = verify_substrate_claim(claim, peer_pid=1234, pa_module=pa)
+    assert result.accepted is False
+    assert result.failure_code == "attestation_failed"
+
+
+# =============================================================================
+# verify_substrate_claim — happy paths and cache semantics
+# =============================================================================
+
+
+def test_happy_path_pins_cache_on_first_verified_connect() -> None:
+    claim = _make_claim()
+    pa = _fake_pa(
+        label=claim.expected_launchd_label,
+        executable=claim.expected_executable_path,
+        start_time=1_777_000_000,
+    )
+    cache = VerifiedPairsCache()
+
+    result = verify_substrate_claim(claim, peer_pid=1234, pa_module=pa, cache=cache)
+
+    assert result.accepted is True
+    assert result.failure_code is None
+    assert cache.get(claim.agent_id) == (1234, 1_777_000_000)
+
+
+def test_same_pid_same_start_time_is_noop_match() -> None:
+    """Reconnect under the same process: still accepted; cache stays put."""
+    claim = _make_claim()
+    pa = _fake_pa(
+        label=claim.expected_launchd_label,
+        executable=claim.expected_executable_path,
+        start_time=1_777_000_000,
+    )
+    cache = VerifiedPairsCache()
+    cache.record(claim.agent_id, 1234, 1_777_000_000)
+
+    result = verify_substrate_claim(claim, peer_pid=1234, pa_module=pa, cache=cache)
+
+    assert result.accepted is True
+    assert cache.get(claim.agent_id) == (1234, 1_777_000_000)
+
+
+def test_pid_reuse_rejection_for_same_pid_different_start_time() -> None:
+    """Q3(e) PID-reuse: same PID, different start_tvsec → reject."""
+    claim = _make_claim()
+    pa = _fake_pa(
+        label=claim.expected_launchd_label,
+        executable=claim.expected_executable_path,
+        start_time=1_777_000_999,  # different from cached
+    )
+    cache = VerifiedPairsCache()
+    cache.record(claim.agent_id, 1234, 1_777_000_000)  # earlier process
+
+    result = verify_substrate_claim(claim, peer_pid=1234, pa_module=pa, cache=cache)
+
+    assert result.accepted is False
+    assert result.failure_code == "pid_reuse"
+    assert "1_777_000_000" not in result.reason  # underscore form not used
+    assert "1777000000" in result.reason
+    assert "1777000999" in result.reason
+    # Cache must NOT be updated on rejection.
+    assert cache.get(claim.agent_id) == (1234, 1_777_000_000)
+
+
+def test_legitimate_restart_with_different_pid_accepted_and_cache_updated() -> None:
+    """Resident restarted; new PID. Cache update with new (pid, start)."""
+    claim = _make_claim()
+    pa = _fake_pa(
+        label=claim.expected_launchd_label,
+        executable=claim.expected_executable_path,
+        start_time=1_777_001_000,  # later, new process
+    )
+    cache = VerifiedPairsCache()
+    cache.record(claim.agent_id, 1234, 1_777_000_000)  # prior process
+
+    result = verify_substrate_claim(claim, peer_pid=5678, pa_module=pa, cache=cache)
+
+    assert result.accepted is True
+    assert cache.get(claim.agent_id) == (5678, 1_777_001_000)
+
+
+def test_cache_optional_verify_works_without_cache() -> None:
+    """``cache=None`` is allowed; verify still completes with accept/reject."""
+    claim = _make_claim()
+    pa = _fake_pa(
+        label=claim.expected_launchd_label,
+        executable=claim.expected_executable_path,
+        start_time=1_777_000_000,
+    )
+
+    result = verify_substrate_claim(claim, peer_pid=1234, pa_module=pa, cache=None)
+
+    assert result.accepted is True
+    assert result.failure_code is None
+
+
+def test_check_order_label_then_exec_then_start() -> None:
+    """When multiple things are wrong, label-mismatch reports first.
+
+    Verifies the proposal's documented check order: cheap checks first, so
+    a mismatched-everything peer gets the label-mismatch error (not a
+    confusing exec-mismatch on top of an already-bad label).
+    """
+    claim = _make_claim()
+    pa = _fake_pa(
+        label="wrong-label",
+        executable="wrong-path",
+        start_time=None,
+    )
+    result = verify_substrate_claim(claim, peer_pid=1234, pa_module=pa)
+    assert result.failure_code == "label_mismatch"


### PR DESCRIPTION
Third PR in the S19 (M3-v2) implementation sequence. Pure verification logic; no UDS integration yet (PR3b wires this into the connection-accept path on `src/mcp_server.py` + `src/mcp_handlers/middleware/identity_step.py`).

Splits v2 §Sequencing step 3 in half for cleaner review: PR3a is the load-bearing verify-and-cache primitives; PR3b is the UDS listener + handler wiring.

## What ships

- **`src/substrate/verification.py`** — verification module with five components:
  - `SubstrateClaim` dataclass (frozen) — snapshot of one `core.substrate_claims` row.
  - `VerifiedPairsCache` — thread-safe in-process per-server-lifetime `agent_id → (pid, start_tvsec)` cache. Defeats Q3(e) PID-reuse race per adversary-review §3.
  - `VerificationResult` dataclass — `accepted` + `reason` + `failure_code` (one of: `no_claim`, `label_mismatch`, `exec_mismatch`, `attestation_failed`, `pid_reuse`).
  - `verify_substrate_claim(claim, peer_pid, *, pa_module=None, cache=None)` — pure synchronous verify. Order: label → executable → start-time + cache. Cache only updated on full success.
  - `fetch_substrate_claim(agent_id) -> Optional[SubstrateClaim]` — async DB lookup against `core.substrate_claims`. Separate from verify so the sync verify can run under `loop.run_in_executor` per CLAUDE.md anyio constraint.
- **16 unit tests** covering every failure mode + every cache transition (cold pin, no-op match, PID reuse, legitimate restart, no-cache mode). 100% line coverage on the new module.

## Adversary-mode coverage

Per proposal v2 §Adversary models + adversary-review:

| Adversary | Defeated by | Tested |
|---|---|---|
| A1 Hermes case | `no_claim` rejection (no row registered) | ✓ `test_no_claim_rejection` |
| A2 naive | `label_mismatch` rejection | ✓ `test_label_mismatch_*` (2 tests) |
| A2 escalated (binary substitution) | `exec_mismatch` rejection | ✓ `test_exec_mismatch_when_actual_path_differs` |
| Q3(e) PID-reuse | `pid_reuse` rejection (cache compare-and-update) | ✓ `test_pid_reuse_rejection_for_same_pid_different_start_time` |

## What this PR does NOT do

- No UDS listener (PR3b §Sequencing).
- No SessionSignals.peer_pid extension (PR3b).
- No call into `verify_substrate_claim` from any handler (PR3b).
- No PATH 2.8 substrate-anchored gate (PR4).
- No SDK changes (PR5).

## Notes

- Module is dependency-light. The DB helper (`fetch_substrate_claim`) is the only async function and only awaits asyncpg through `db.acquire()`.
- `pa_module` parameter on `verify_substrate_claim` allows tests to inject a fake without subclassing — uses `Protocol`-shape duck typing.
- Order-of-checks (label → exec → start-time) is documented in module docstring and asserted by `test_check_order_label_then_exec_then_start`. Cheap checks first; on multi-failure peer, the user-facing reason names the most-likely root cause.
- `VerifiedPairsCache` is `threading.Lock`-protected, not `asyncio.Lock` — the cache is only touched from the synchronous verify path running under `run_in_executor`, never directly from the asyncio task group.