### PR TITLE
ship.sh: append Watcher-Findings trailer for unresolved findings on staged files

### DIFF
--- a/scripts/dev/_ship_watcher_fingerprints.py
+++ b/scripts/dev/_ship_watcher_fingerprints.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Helper for ship.sh: emit unresolved Watcher fingerprints touching staged files.
+
+Reads absolute paths of staged files from stdin (one per line). Reads
+``data/watcher/findings.jsonl`` from the path given as argv[1]. Prints a
+comma-separated list of fingerprints whose ``file`` matches a staged path
+and whose ``status`` is unresolved (``open`` or ``surfaced``).
+
+Exit code is always 0 — a missing findings file or no matches simply
+yields empty stdout. ship.sh treats empty output as "nothing to append".
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+UNRESOLVED = {"open", "surfaced"}
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: _ship_watcher_fingerprints.py <findings.jsonl>", file=sys.stderr)
+        return 2
+
+    findings_path = Path(sys.argv[1])
+    if not findings_path.is_file():
+        return 0
+
+    staged = {line.strip() for line in sys.stdin if line.strip()}
+    if not staged:
+        return 0
+
+    fingerprints: list[str] = []
+    seen: set[str] = set()
+    with findings_path.open() as fh:
+        for raw in fh:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                rec = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if rec.get("status") not in UNRESOLVED:
+                continue
+            if rec.get("file") not in staged:
+                continue
+            fp = rec.get("fingerprint")
+            if not fp or fp in seen:
+                continue
+            seen.add(fp)
+            fingerprints.append(fp)
+
+    if fingerprints:
+        print(",".join(fingerprints))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/ship.sh
+++ b/scripts/dev/ship.sh
@@ -45,6 +45,21 @@ classify() {
     echo "other"
 }
 
+# Emit unresolved Watcher fingerprints touching staged files, comma-separated.
+# Empty if nothing staged, no findings file, or no matches. Closes the race
+# where ship.sh would otherwise compose a commit message before the operator
+# processed a Watcher chime — CLAUDE.md asks for fingerprints in commit
+# messages, but post-edit-hook → next-turn-chime is a separate channel from
+# commit-message authorship. This pulls them back together.
+collect_watcher_fingerprints() {
+    local files; files=$(git diff --cached --name-only)
+    [[ -n "$files" ]] || return 0
+    local findings="$PROJECT_ROOT/data/watcher/findings.jsonl"
+    [[ -f "$findings" ]] || return 0
+    awk -v root="$PROJECT_ROOT" '{print root"/"$0}' <<< "$files" \
+        | python3 "$PROJECT_ROOT/scripts/dev/_ship_watcher_fingerprints.py" "$findings"
+}
+
 if [[ "${1:-}" == "--classify" ]]; then
     classify
     exit 0
@@ -58,6 +73,18 @@ fi
 
 KIND=$(classify)
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+# Append Watcher-Findings trailer if any unresolved findings touch staged files.
+# COMMIT_MESSAGE is what `git commit -m` sees; MESSAGE stays clean for PR title.
+WATCHER_FPS=$(collect_watcher_fingerprints || true)
+if [[ -n "$WATCHER_FPS" ]]; then
+    COMMIT_MESSAGE="$MESSAGE
+
+Watcher-Findings: $WATCHER_FPS"
+    echo "[ship] appended Watcher-Findings trailer: $WATCHER_FPS"
+else
+    COMMIT_MESSAGE="$MESSAGE"
+fi
 
 # S15-d gate: if this commit touches skills/, the plugin's mirror must be
 # in sync with unitares canonical. Fires only when skills/ is staged AND the
@@ -91,7 +118,7 @@ case "$KIND" in
         NEW_BRANCH="${AGENT_PREFIX}/auto/$(date +%Y%m%d-%H%M%S)-${SLUG}"
         echo "[ship] runtime path → $NEW_BRANCH (PR + auto-merge)"
         git checkout -b "$NEW_BRANCH"
-        git commit -m "$MESSAGE"
+        git commit -m "$COMMIT_MESSAGE"
         git push -u origin "$NEW_BRANCH"
         PR_URL=$(gh pr create --title "$MESSAGE" --body "Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.")
         echo "$PR_URL"
@@ -100,7 +127,7 @@ case "$KIND" in
         ;;
     other)
         echo "[ship] non-runtime → direct commit + push on $BRANCH"
-        git commit -m "$MESSAGE"
+        git commit -m "$COMMIT_MESSAGE"
         # Push to the same-name branch on origin, not whatever upstream tracks
         # (a feature branch may track master and would otherwise push ambiguously).
         git push origin "HEAD:$BRANCH"

--- a/tests/test_ship_watcher_fingerprints.py
+++ b/tests/test_ship_watcher_fingerprints.py
@@ -1,0 +1,111 @@
+"""Tests for scripts/dev/_ship_watcher_fingerprints.py — the helper ship.sh
+uses to derive a `Watcher-Findings:` trailer from staged files.
+
+Locks in the contract: read findings.jsonl, intersect file paths with
+staged set passed on stdin, emit unresolved fingerprints comma-separated."""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+HELPER = Path(__file__).resolve().parents[1] / "scripts" / "dev" / "_ship_watcher_fingerprints.py"
+
+
+def _run(findings_path: Path, staged: list[str]) -> tuple[str, str, int]:
+    proc = subprocess.run(
+        ["python3", str(HELPER), str(findings_path)],
+        input="\n".join(staged),
+        capture_output=True,
+        text=True,
+    )
+    return proc.stdout.strip(), proc.stderr.strip(), proc.returncode
+
+
+def _write_findings(path: Path, records: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+
+def test_emits_fingerprint_for_unresolved_finding_on_staged_file(tmp_path):
+    findings = tmp_path / "findings.jsonl"
+    _write_findings(findings, [
+        {"file": "/repo/agents/foo.py", "fingerprint": "abc123", "status": "surfaced"},
+    ])
+    out, err, rc = _run(findings, ["/repo/agents/foo.py"])
+    assert rc == 0, err
+    assert out == "abc123"
+
+
+def test_skips_resolved_and_dismissed_findings(tmp_path):
+    findings = tmp_path / "findings.jsonl"
+    _write_findings(findings, [
+        {"file": "/repo/a.py", "fingerprint": "kept", "status": "open"},
+        {"file": "/repo/a.py", "fingerprint": "confirmed-fp", "status": "confirmed"},
+        {"file": "/repo/a.py", "fingerprint": "dismissed-fp", "status": "dismissed"},
+        {"file": "/repo/a.py", "fingerprint": "aged-fp", "status": "aged_out"},
+    ])
+    out, _, rc = _run(findings, ["/repo/a.py"])
+    assert rc == 0
+    assert out == "kept"
+
+
+def test_only_returns_findings_for_staged_files(tmp_path):
+    findings = tmp_path / "findings.jsonl"
+    _write_findings(findings, [
+        {"file": "/repo/staged.py", "fingerprint": "match", "status": "surfaced"},
+        {"file": "/repo/elsewhere.py", "fingerprint": "noise", "status": "surfaced"},
+    ])
+    out, _, rc = _run(findings, ["/repo/staged.py"])
+    assert rc == 0
+    assert out == "match"
+
+
+def test_dedupes_same_fingerprint(tmp_path):
+    findings = tmp_path / "findings.jsonl"
+    _write_findings(findings, [
+        {"file": "/repo/a.py", "fingerprint": "dup", "status": "surfaced"},
+        {"file": "/repo/a.py", "fingerprint": "dup", "status": "open"},
+    ])
+    out, _, rc = _run(findings, ["/repo/a.py"])
+    assert rc == 0
+    assert out == "dup"
+
+
+def test_multiple_fingerprints_comma_separated(tmp_path):
+    findings = tmp_path / "findings.jsonl"
+    _write_findings(findings, [
+        {"file": "/repo/a.py", "fingerprint": "first", "status": "surfaced"},
+        {"file": "/repo/b.py", "fingerprint": "second", "status": "open"},
+    ])
+    out, _, rc = _run(findings, ["/repo/a.py", "/repo/b.py"])
+    assert rc == 0
+    assert set(out.split(",")) == {"first", "second"}
+
+
+def test_empty_when_findings_file_missing(tmp_path):
+    out, _, rc = _run(tmp_path / "absent.jsonl", ["/repo/a.py"])
+    assert rc == 0
+    assert out == ""
+
+
+def test_empty_when_no_staged_files(tmp_path):
+    findings = tmp_path / "findings.jsonl"
+    _write_findings(findings, [
+        {"file": "/repo/a.py", "fingerprint": "x", "status": "surfaced"},
+    ])
+    out, _, rc = _run(findings, [])
+    assert rc == 0
+    assert out == ""
+
+
+def test_skips_malformed_lines(tmp_path):
+    findings = tmp_path / "findings.jsonl"
+    findings.write_text(
+        "not json\n"
+        + json.dumps({"file": "/repo/a.py", "fingerprint": "good", "status": "surfaced"})
+        + "\n"
+        + "{broken\n"
+    )
+    out, _, rc = _run(findings, ["/repo/a.py"])
+    assert rc == 0
+    assert out == "good"


### PR DESCRIPTION
## Summary

- Adds `scripts/dev/_ship_watcher_fingerprints.py` — small helper that reads `data/watcher/findings.jsonl`, intersects staged files with unresolved findings (`open`/`surfaced`), prints fingerprints comma-separated.
- Modifies `scripts/dev/ship.sh` to invoke it before commit and append a `Watcher-Findings: <fp>,<fp>` trailer to the commit body. PR title (runtime path) stays clean — only the body carries the trailer.
- Closes the race documented in KG discovery `2026-04-25T20:07:01.505701`: post-edit-hook → next-turn-chime is a separate channel from commit-message authorship, so ship.sh would compose messages before the operator processed a chime, and merged commits ended up missing the fingerprint reference CLAUDE.md asks for.

## What this does NOT close

The secondary race — Watcher scanner still in flight at ship-time — needs a wait/poll on the scanner's pending queue. Out of scope for this PR. The common case (finding written before ship-time, ship.sh just didn't read it) is what 99% of operator-issued ships hit, and that's what this catches.

## Routing

`scripts/dev/` is not in `RUNTIME_PATTERNS`, so this branch was direct-pushed via the `other` path (no auto-PR). Opening explicitly because the change is to ship.sh itself — a piece of infra all agents use, worth a deliberate review surface.

## Test plan

- [x] `tests/test_ship_watcher_fingerprints.py` — 8 unit tests on the helper (happy path, status filtering, file scoping, dedup, multi-fingerprint, missing file, empty staged set, malformed JSON)
- [x] `./scripts/dev/test-cache.sh` — 7289 passed
- [x] Manual smoke: staged 3 files + dummy findings.jsonl entry → helper printed expected fingerprint

## Adjacent

Watcher fired a NEW P005 finding (`43fee3e7c75d608f`) on the merged chronicler change after the `conn = None` pre-init refactor — the LLM still flags the pattern because `_P005_CONTEXT_MANAGED` only carves out `async with`. Tracked separately; out of scope here.