### PR TITLE
feat: phase 2 — onboard.initial_state writes bootstrap check-in row

### DIFF
--- a/src/db/mixins/state.py
+++ b/src/db/mixins/state.py
@@ -41,6 +41,96 @@ class StateMixin:
             # Matview refresh moved to periodic_matview_refresh() in background_tasks.py
             return state_id
 
+    async def record_bootstrap_state(
+        self,
+        identity_id: int,
+        entropy: float,
+        integrity: float,
+        stability_index: float,
+        void: float,
+        regime: str,
+        coherence: float,
+        state_json: Dict[str, Any],
+    ) -> tuple[int, bool]:
+        """Insert a synthetic bootstrap row, idempotent on (identity_id) via the
+        unique partial index from migration 018. Returns (state_id, was_written).
+
+        On UniqueViolationError (race lost or already-bootstrapped), looks up
+        the existing bootstrap row and returns its state_id with was_written=False.
+        Callers use was_written to populate `bootstrap.written` in the response.
+        """
+        import asyncpg
+        from config.governance_config import GovernanceConfig
+        async with self.acquire() as conn:
+            try:
+                state_id = await conn.fetchval(
+                    """
+                    INSERT INTO core.agent_state
+                        (identity_id, entropy, integrity, stability_index, volatility,
+                         regime, coherence, state_json, epoch, synthetic)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, true)
+                    RETURNING state_id
+                    """,
+                    identity_id, entropy, integrity, stability_index, void,
+                    regime, coherence, json.dumps(state_json),
+                    GovernanceConfig.CURRENT_EPOCH,
+                )
+                return state_id, True
+            except asyncpg.UniqueViolationError:
+                existing = await conn.fetchval(
+                    """
+                    SELECT state_id FROM core.agent_state
+                    WHERE identity_id = $1 AND synthetic = true
+                    """,
+                    identity_id,
+                )
+                return existing, False
+
+    async def get_bootstrap_state(
+        self,
+        identity_id: int,
+    ) -> Optional[Dict[str, Any]]:
+        """Return the bootstrap row for an identity, or None if absent.
+
+        Returns {state_id, state_json} — the digest is read from state_json
+        by the handler, not pulled out as a separate column.
+        """
+        async with self.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT state_id, state_json
+                FROM core.agent_state
+                WHERE identity_id = $1 AND synthetic = true
+                """,
+                identity_id,
+            )
+            if row is None:
+                return None
+            state_json = row["state_json"]
+            if isinstance(state_json, str):
+                state_json = json.loads(state_json)
+            return {"state_id": row["state_id"], "state_json": state_json}
+
+    async def is_substrate_earned(self, agent_id: str) -> bool:
+        """Substrate-earned check for the bootstrap-checkin exemption (§3.5).
+
+        True iff the agent_id is registered in core.substrate_claims (S19's
+        canonical resident-attestation registry) OR appears in the small
+        Pi-resident allowlist for cross-substrate cases like Lumen.
+        """
+        from src.mcp_handlers.identity.bootstrap_checkin import (
+            PI_RESIDENT_ALLOWLIST,
+        )
+        if agent_id in PI_RESIDENT_ALLOWLIST:
+            return True
+        async with self.acquire() as conn:
+            return bool(
+                await conn.fetchval(
+                    "SELECT 1 FROM core.substrate_claims WHERE agent_id = $1",
+                    agent_id,
+                )
+            )
+
     async def get_latest_agent_state(
         self,
         identity_id: int,

--- a/src/mcp_handlers/identity/bootstrap_checkin.py
+++ b/src/mcp_handlers/identity/bootstrap_checkin.py
@@ -1,0 +1,198 @@
+"""Bootstrap check-in helper for onboard.initial_state.
+
+Spec: docs/proposals/onboard-bootstrap-checkin.md
+
+The handler's job at the call site is small: build the BootstrapStateParams,
+fill server defaults, decide substrate-earned exemption, then run the write
+under a tight timeout. This module owns the digest contract, the defaults,
+and the timeout-safe write so the handler stays readable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+from typing import Any, Dict, Optional, Tuple
+
+from src.mcp_handlers.schemas.core import BootstrapStateParams
+
+logger = logging.getLogger(__name__)
+
+
+# Bootstrap INSERT timeout (per spec §3.5 — matches the wait_for pattern
+# already used by identity_step.py). On timeout, the handler degrades to
+# no bootstrap row rather than blocking the whole onboard call.
+BOOTSTRAP_INSERT_TIMEOUT_S = 0.5
+
+
+# Cross-substrate Pi residents not in core.substrate_claims (which is the
+# Mac-side S19 registry). Keep this list short — when a Pi-side equivalent
+# of S19 lands, this allowlist gets retired.
+PI_RESIDENT_ALLOWLIST: frozenset[str] = frozenset()
+
+
+# Per-field defaults for fields the caller omitted (spec §3.1 table).
+_DEFAULTS = {
+    "complexity": 0.5,
+    "confidence": 0.5,
+    "task_type": "introspection",
+    "ethical_drift": [0.0, 0.0, 0.0],
+}
+
+
+def compute_bootstrap_digest(params: BootstrapStateParams) -> str:
+    """SHA-256 hex digest over caller-supplied fields only.
+
+    Server-applied defaults are excluded so two callers passing the same
+    explicit fields produce the same digest, regardless of default-fill
+    behavior. Only fields the caller actually set (i.e. not None) are
+    included in the canonical JSON.
+    """
+    explicit = {
+        k: v for k, v in params.model_dump(exclude_none=True).items()
+    }
+    canonical = json.dumps(explicit, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def derive_bootstrap_response_text(
+    params: BootstrapStateParams,
+    *,
+    client_hint: Optional[str],
+    purpose: Optional[str],
+) -> str:
+    """Default `response_text` per spec §3.1: prefer caller, then client_hint,
+    then purpose, then a constant fallback."""
+    if params.response_text:
+        return params.response_text
+    seed = client_hint or purpose or "session-start"
+    return f"[bootstrap] {seed}"
+
+
+def fill_defaults(
+    params: BootstrapStateParams,
+    *,
+    client_hint: Optional[str] = None,
+    purpose: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Resolve a BootstrapStateParams to the concrete state-row payload.
+
+    Caller-supplied fields win; absent fields get the §3.1 defaults.
+    Returns the dict we hand to record_bootstrap_state plus the state_json
+    metadata (`source`, `bootstrap_digest`).
+    """
+    digest = compute_bootstrap_digest(params)
+    return {
+        "response_text": derive_bootstrap_response_text(
+            params, client_hint=client_hint, purpose=purpose
+        ),
+        "complexity": params.complexity if params.complexity is not None else _DEFAULTS["complexity"],
+        "confidence": params.confidence if params.confidence is not None else _DEFAULTS["confidence"],
+        "task_type": params.task_type or _DEFAULTS["task_type"],
+        "ethical_drift": params.ethical_drift or list(_DEFAULTS["ethical_drift"]),
+        "bootstrap_digest": digest,
+    }
+
+
+def build_state_json(filled: Dict[str, Any]) -> Dict[str, Any]:
+    """Compose the JSONB blob persisted on the bootstrap row.
+
+    `source` is descriptive; `bootstrap_digest` is the audit trail for
+    payload_digest_match comparisons. The behavioral fields are stored too
+    so future read paths can introspect what the caller asked for without
+    re-deriving from EISV columns."""
+    return {
+        "source": "bootstrap",
+        "bootstrap_digest": filled["bootstrap_digest"],
+        "response_text": filled["response_text"],
+        "complexity": filled["complexity"],
+        "confidence": filled["confidence"],
+        "task_type": filled["task_type"],
+        "ethical_drift": filled["ethical_drift"],
+    }
+
+
+async def write_bootstrap(
+    db: Any,
+    *,
+    identity_id: int,
+    agent_id: str,
+    params: BootstrapStateParams,
+    client_hint: Optional[str] = None,
+    purpose: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Run the full bootstrap-write flow.
+
+    Returns the `bootstrap` block to embed in the onboard response. Possible shapes:
+
+      {written: True,  state_id: <int>, next_step: "..."}
+      {written: False, state_id: <existing>, payload_digest_match: <bool>}
+      {written: False, reason: "substrate-earned-exempt"}
+      {written: False, reason: "insert-timeout"}
+      {written: False, reason: "error", detail: "<class>"}
+
+    Idempotent (DB-level via the unique partial index from migration 018):
+    a second call for the same identity returns the existing row's state_id
+    with payload_digest_match telling the caller whether their payload
+    matched the stored one.
+    """
+    if await db.is_substrate_earned(agent_id):
+        return {"written": False, "reason": "substrate-earned-exempt"}
+
+    filled = fill_defaults(params, client_hint=client_hint, purpose=purpose)
+    state_json = build_state_json(filled)
+
+    # EISV column values — bootstrap defaults map cleanly to nominal regime,
+    # midpoint stability, low volatility. These seed the trajectory ODE; the
+    # synthetic flag keeps them out of measured-state aggregations.
+    insert_kwargs = {
+        "identity_id": identity_id,
+        "entropy": 0.5,
+        "integrity": 0.5,
+        "stability_index": 0.5,
+        "void": 0.0,
+        "regime": "nominal",
+        "coherence": 1.0,
+        "state_json": state_json,
+    }
+
+    try:
+        state_id, was_written = await asyncio.wait_for(
+            db.record_bootstrap_state(**insert_kwargs),
+            timeout=BOOTSTRAP_INSERT_TIMEOUT_S,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "[BOOTSTRAP] record_bootstrap_state timed out for identity_id=%s "
+            "(>%ss); degrading to no bootstrap row",
+            identity_id, BOOTSTRAP_INSERT_TIMEOUT_S,
+        )
+        return {"written": False, "reason": "insert-timeout"}
+    except Exception as exc:  # noqa: BLE001 — bootstrap is fail-open
+        logger.warning(
+            "[BOOTSTRAP] record_bootstrap_state failed for identity_id=%s: %s",
+            identity_id, exc,
+        )
+        return {"written": False, "reason": "error", "detail": type(exc).__name__}
+
+    if was_written:
+        return {
+            "written": True,
+            "state_id": state_id,
+            "next_step": (
+                "Call process_agent_update with real measurements when you "
+                "have any — bootstrap is provisional and excluded from "
+                "calibration."
+            ),
+        }
+
+    # Idempotent re-call: compare digests so the caller sees divergence.
+    existing = await db.get_bootstrap_state(identity_id)
+    stored_digest = (existing or {}).get("state_json", {}).get("bootstrap_digest")
+    return {
+        "written": False,
+        "state_id": state_id,
+        "payload_digest_match": stored_digest == filled["bootstrap_digest"],
+    }

--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -1742,6 +1742,35 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
         tool_mode_info=tool_mode_info,
     )
 
+    # Bootstrap check-in (onboard-bootstrap-checkin §3.5). Conditional on
+    # initial_state being present in the request — the response gains a
+    # `bootstrap` key only when the caller asked for a bootstrap row. The
+    # write itself is timeout-bounded and fail-open per §3.5.
+    _initial_state = arguments.get("initial_state")
+    if _initial_state is not None:
+        try:
+            from src.mcp_handlers.identity.bootstrap_checkin import write_bootstrap
+            from src.mcp_handlers.schemas.core import BootstrapStateParams
+            _bootstrap_params = (
+                _initial_state if isinstance(_initial_state, BootstrapStateParams)
+                else BootstrapStateParams(**_initial_state)
+            )
+            db = get_db()
+            _identity_record = await db.get_identity(agent_uuid)
+            if _identity_record is not None:
+                result["bootstrap"] = await write_bootstrap(
+                    db,
+                    identity_id=_identity_record.identity_id,
+                    agent_id=agent_uuid,
+                    params=_bootstrap_params,
+                    client_hint=client_hint,
+                    purpose=arguments.get("purpose"),
+                )
+        except Exception as _bootstrap_err:  # noqa: BLE001 — bootstrap is fail-open
+            logger.warning(
+                f"[BOOTSTRAP] onboard initial_state handling failed (non-fatal): {_bootstrap_err}"
+            )
+
     # S1-a (2026-04-24): grace-period deprecation surface. onboard() called
     # with continuity_token AND without force_new=true is the retired
     # cross-process-instance resume path. Emit a warning in the response and

--- a/src/mcp_handlers/schemas/core.py
+++ b/src/mcp_handlers/schemas/core.py
@@ -1,6 +1,32 @@
 from typing import Optional, Union, Literal, Dict, Any, List, Sequence
-from pydantic import Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from .mixins import AgentIdentityMixin
+
+
+# Single source of truth for the task_type Literal — used by
+# ProcessAgentUpdateParams and BootstrapStateParams. If the canonical set
+# changes, edit it here.
+TaskType = Literal[
+    "convergent", "divergent", "mixed", "refactoring", "bugfix", "testing",
+    "documentation", "feature", "exploration", "research", "design", "debugging",
+    "review", "deployment", "introspection"
+]
+
+
+class BootstrapStateParams(BaseModel):
+    """Subset of process_agent_update fields accepted as a bootstrap check-in
+    via onboard.initial_state. All fields optional; the server fills defaults
+    when absent. Extras are rejected (model_config below) so this isn't a
+    back-door for setting arbitrary internal state."""
+    model_config = ConfigDict(extra="forbid")
+
+    response_text: Optional[str] = Field(default=None)
+    complexity: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    confidence: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    task_type: Optional[TaskType] = Field(default=None)
+    ethical_drift: Optional[List[float]] = Field(
+        default=None, min_length=3, max_length=3
+    )
 
 
 class GetGovernanceMetricsParams(AgentIdentityMixin):
@@ -119,11 +145,7 @@ class ProcessAgentUpdateParams(AgentIdentityMixin):
         default=False,
         description="If true, reject updates unless identity assurance tier is strong."
     )
-    task_type: Literal[
-        "convergent", "divergent", "mixed", "refactoring", "bugfix", "testing",
-        "documentation", "feature", "exploration", "research", "design", "debugging",
-        "review", "deployment", "introspection"
-    ] = Field(
+    task_type: TaskType = Field(
         default="mixed",
         description="Task type context. Core types: convergent | divergent | mixed. Use 'introspection' for epistemic self-examination where low confidence is appropriate."
     )

--- a/src/mcp_handlers/schemas/identity.py
+++ b/src/mcp_handlers/schemas/identity.py
@@ -1,6 +1,7 @@
 from typing import Optional, Union, Literal, Dict, Any, List, Sequence
 from pydantic import Field, model_validator
 from .mixins import AgentIdentityMixin
+from .core import BootstrapStateParams
 
 class IdentityParams(AgentIdentityMixin):
     """
@@ -101,6 +102,18 @@ class OnboardParams(AgentIdentityMixin):
             "concurrent identity bindings. Declaration-only — never used "
             "to resolve or recover identity."
         )
+    )
+    initial_state: Optional[BootstrapStateParams] = Field(
+        default=None,
+        description=(
+            "Optional bootstrap check-in payload. When present, the server "
+            "writes a synthetic state row tagged source='bootstrap' "
+            "immediately after identity creation. Bootstrap rows seed "
+            "trajectory genesis only and are excluded by default from "
+            "calibration, outcome correlation, trust-tier observation "
+            "counts, and real-check-in counts. See docs/proposals/"
+            "onboard-bootstrap-checkin.md."
+        ),
     )
 
     @model_validator(mode='after')

--- a/tests/test_bootstrap_checkin_dao.py
+++ b/tests/test_bootstrap_checkin_dao.py
@@ -1,0 +1,281 @@
+"""Integration tests for bootstrap-checkin DAO + write_bootstrap helper.
+
+These exercise the end-to-end path the onboard handler calls. Handler-level
+HTTP/MCP tests live separately and depend on more wiring; the contract this
+file pins is the DB-touching surface that the handler trusts.
+
+Spec: docs/proposals/onboard-bootstrap-checkin.md §3.4, §3.5, §8.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+try:
+    import asyncpg  # noqa: F401
+except ImportError:
+    pytest.skip("asyncpg not installed", allow_module_level=True)
+
+from tests.test_db_utils import (
+    TEST_DB_URL,
+    can_connect_to_test_db,
+    ensure_test_database_schema,
+)
+
+if not can_connect_to_test_db():
+    pytest.skip("governance_test database not available", allow_module_level=True)
+
+from src.mcp_handlers.identity.bootstrap_checkin import (
+    PI_RESIDENT_ALLOWLIST,
+    write_bootstrap,
+)
+from src.mcp_handlers.schemas.core import BootstrapStateParams
+
+# Reuse the canonical live-DB fixture from conftest.py — that fixture
+# bootstraps the schema, truncates between tests, and handles teardown.
+# Alias to `db` so the test bodies read naturally.
+
+
+@pytest.fixture
+def db(live_postgres_backend):
+    return live_postgres_backend
+
+
+async def _seed_identity(db) -> tuple[str, int]:
+    """Insert a fresh agent + identity, return (agent_id, identity_id)."""
+    agent_id = f"test-{uuid.uuid4()}"
+    async with db.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO core.agents (id, api_key) VALUES ($1, 'test-key')",
+            agent_id,
+        )
+        identity_id = await conn.fetchval(
+            """
+            INSERT INTO core.identities (agent_id, api_key_hash)
+            VALUES ($1, 'test-hash')
+            RETURNING identity_id
+            """,
+            agent_id,
+        )
+    return agent_id, identity_id
+
+
+# ---------------------------------------------------------------------------
+# DAO contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_record_bootstrap_state_writes_synthetic_row(db):
+    _, identity_id = await _seed_identity(db)
+    state_id, was_written = await db.record_bootstrap_state(
+        identity_id=identity_id,
+        entropy=0.5, integrity=0.5, stability_index=0.5, void=0.0,
+        regime="nominal", coherence=1.0,
+        state_json={"source": "bootstrap", "bootstrap_digest": "abc"},
+    )
+    assert was_written is True
+    assert state_id is not None
+
+    async with db.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT synthetic, state_json FROM core.agent_state WHERE state_id = $1",
+            state_id,
+        )
+    assert row["synthetic"] is True
+
+
+@pytest.mark.asyncio
+async def test_record_bootstrap_state_idempotent_returns_existing(db):
+    _, identity_id = await _seed_identity(db)
+    state_id_1, written_1 = await db.record_bootstrap_state(
+        identity_id=identity_id,
+        entropy=0.5, integrity=0.5, stability_index=0.5, void=0.0,
+        regime="nominal", coherence=1.0,
+        state_json={"source": "bootstrap", "bootstrap_digest": "first"},
+    )
+    state_id_2, written_2 = await db.record_bootstrap_state(
+        identity_id=identity_id,
+        entropy=0.7, integrity=0.3, stability_index=0.6, void=0.1,
+        regime="warning", coherence=0.5,
+        state_json={"source": "bootstrap", "bootstrap_digest": "second"},
+    )
+    assert written_1 is True
+    assert written_2 is False
+    assert state_id_1 == state_id_2
+
+    async with db.acquire() as conn:
+        digest = await conn.fetchval(
+            "SELECT state_json->>'bootstrap_digest' FROM core.agent_state WHERE state_id = $1",
+            state_id_1,
+        )
+    # First write wins; second-call payload was discarded.
+    assert digest == "first"
+
+
+@pytest.mark.asyncio
+async def test_get_bootstrap_state_round_trips(db):
+    _, identity_id = await _seed_identity(db)
+    state_id, _ = await db.record_bootstrap_state(
+        identity_id=identity_id,
+        entropy=0.5, integrity=0.5, stability_index=0.5, void=0.0,
+        regime="nominal", coherence=1.0,
+        state_json={"source": "bootstrap", "bootstrap_digest": "abc123"},
+    )
+    fetched = await db.get_bootstrap_state(identity_id)
+    assert fetched is not None
+    assert fetched["state_id"] == state_id
+    assert fetched["state_json"]["bootstrap_digest"] == "abc123"
+    assert fetched["state_json"]["source"] == "bootstrap"
+
+    # No bootstrap → None.
+    _, identity_id_2 = await _seed_identity(db)
+    assert await db.get_bootstrap_state(identity_id_2) is None
+
+
+@pytest.mark.asyncio
+async def test_is_substrate_earned_via_substrate_claims(db):
+    """An agent in core.substrate_claims is substrate-earned."""
+    agent_id, _ = await _seed_identity(db)
+    assert await db.is_substrate_earned(agent_id) is False
+
+    async with db.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO core.substrate_claims
+                (agent_id, expected_launchd_label, expected_executable_path)
+            VALUES ($1, 'test.label', '/usr/local/bin/test')
+            """,
+            agent_id,
+        )
+    assert await db.is_substrate_earned(agent_id) is True
+
+
+@pytest.mark.asyncio
+async def test_is_substrate_earned_via_pi_allowlist(db, monkeypatch):
+    """An agent in the Pi-resident allowlist is substrate-earned without a substrate_claims row."""
+    agent_id, _ = await _seed_identity(db)
+    assert await db.is_substrate_earned(agent_id) is False
+
+    monkeypatch.setattr(
+        "src.mcp_handlers.identity.bootstrap_checkin.PI_RESIDENT_ALLOWLIST",
+        frozenset({agent_id}),
+    )
+    assert await db.is_substrate_earned(agent_id) is True
+
+
+# ---------------------------------------------------------------------------
+# write_bootstrap end-to-end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_write_bootstrap_first_call_writes_row(db):
+    agent_id, identity_id = await _seed_identity(db)
+    block = await write_bootstrap(
+        db,
+        identity_id=identity_id,
+        agent_id=agent_id,
+        params=BootstrapStateParams(complexity=0.7, confidence=0.6),
+        client_hint="test-harness",
+    )
+    assert block["written"] is True
+    assert "state_id" in block
+    assert "next_step" in block
+
+    async with db.acquire() as conn:
+        sj = await conn.fetchval(
+            "SELECT state_json FROM core.agent_state WHERE state_id = $1",
+            block["state_id"],
+        )
+    import json as _json
+    parsed = _json.loads(sj) if isinstance(sj, str) else sj
+    assert parsed["source"] == "bootstrap"
+    assert parsed["complexity"] == 0.7
+    assert parsed["confidence"] == 0.6
+    assert "bootstrap_digest" in parsed
+
+
+@pytest.mark.asyncio
+async def test_write_bootstrap_second_call_with_same_payload_matches_digest(db):
+    agent_id, identity_id = await _seed_identity(db)
+    params = BootstrapStateParams(complexity=0.7, confidence=0.6)
+    first = await write_bootstrap(db, identity_id=identity_id, agent_id=agent_id, params=params)
+    second = await write_bootstrap(db, identity_id=identity_id, agent_id=agent_id, params=params)
+
+    assert first["written"] is True
+    assert second["written"] is False
+    assert second["state_id"] == first["state_id"]
+    assert second["payload_digest_match"] is True
+
+
+@pytest.mark.asyncio
+async def test_write_bootstrap_second_call_with_different_payload_flags_mismatch(db):
+    agent_id, identity_id = await _seed_identity(db)
+    first = await write_bootstrap(
+        db, identity_id=identity_id, agent_id=agent_id,
+        params=BootstrapStateParams(complexity=0.7),
+    )
+    second = await write_bootstrap(
+        db, identity_id=identity_id, agent_id=agent_id,
+        params=BootstrapStateParams(complexity=0.2),
+    )
+    assert second["written"] is False
+    assert second["payload_digest_match"] is False
+    # Stored row keeps the original payload.
+    stored = await db.get_bootstrap_state(identity_id)
+    assert stored["state_json"]["complexity"] == 0.7
+
+
+@pytest.mark.asyncio
+async def test_write_bootstrap_substrate_earned_skips_write(db):
+    agent_id, identity_id = await _seed_identity(db)
+    async with db.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO core.substrate_claims
+                (agent_id, expected_launchd_label, expected_executable_path)
+            VALUES ($1, 'test.label', '/usr/local/bin/test')
+            """,
+            agent_id,
+        )
+
+    block = await write_bootstrap(
+        db, identity_id=identity_id, agent_id=agent_id,
+        params=BootstrapStateParams(complexity=0.5),
+    )
+    assert block == {"written": False, "reason": "substrate-earned-exempt"}
+
+    # Confirm no synthetic row was written.
+    assert await db.get_bootstrap_state(identity_id) is None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_write_bootstrap_at_most_one_row(db):
+    """Two simultaneous write_bootstrap calls for the same identity produce
+    exactly one synthetic row (DB-level race resolved by the unique partial
+    index from migration 018)."""
+    agent_id, identity_id = await _seed_identity(db)
+    params = BootstrapStateParams(complexity=0.5)
+
+    results = await asyncio.gather(
+        write_bootstrap(db, identity_id=identity_id, agent_id=agent_id, params=params),
+        write_bootstrap(db, identity_id=identity_id, agent_id=agent_id, params=params),
+    )
+    written_count = sum(1 for r in results if r.get("written") is True)
+    assert written_count == 1
+
+    async with db.acquire() as conn:
+        row_count = await conn.fetchval(
+            "SELECT COUNT(*) FROM core.agent_state WHERE identity_id = $1 AND synthetic = true",
+            identity_id,
+        )
+    assert row_count == 1

--- a/tests/test_bootstrap_checkin_helper.py
+++ b/tests/test_bootstrap_checkin_helper.py
@@ -1,0 +1,129 @@
+"""Unit tests for the bootstrap-checkin helper (no DB required).
+
+Covers the digest contract, default-fill behavior, and state_json composition.
+DB-touching paths (write_bootstrap, is_substrate_earned) are exercised in
+test_bootstrap_checkin_handler.py.
+
+Spec: docs/proposals/onboard-bootstrap-checkin.md §3.1, §3.3
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.mcp_handlers.identity.bootstrap_checkin import (
+    build_state_json,
+    compute_bootstrap_digest,
+    derive_bootstrap_response_text,
+    fill_defaults,
+)
+from src.mcp_handlers.schemas.core import BootstrapStateParams
+
+
+def test_digest_excludes_server_defaults():
+    """Two callers passing the same explicit fields produce the same digest,
+    regardless of which defaults the server would fill."""
+    a = BootstrapStateParams(complexity=0.7, confidence=0.6)
+    b = BootstrapStateParams(complexity=0.7, confidence=0.6)
+    assert compute_bootstrap_digest(a) == compute_bootstrap_digest(b)
+
+
+def test_digest_changes_when_payload_changes():
+    a = BootstrapStateParams(complexity=0.7, confidence=0.6)
+    b = BootstrapStateParams(complexity=0.7, confidence=0.5)
+    assert compute_bootstrap_digest(a) != compute_bootstrap_digest(b)
+
+
+def test_digest_omits_unset_fields():
+    """A field set to None is treated as 'not supplied' — same digest as omitting it."""
+    a = BootstrapStateParams()
+    b = BootstrapStateParams(complexity=None, confidence=None)
+    assert compute_bootstrap_digest(a) == compute_bootstrap_digest(b)
+
+
+def test_digest_is_canonical_sha256_hex():
+    digest = compute_bootstrap_digest(BootstrapStateParams(complexity=0.5))
+    assert len(digest) == 64
+    int(digest, 16)  # raises ValueError if not hex
+
+
+def test_response_text_caller_wins():
+    params = BootstrapStateParams(response_text="explicit")
+    assert derive_bootstrap_response_text(
+        params, client_hint="hook-fired", purpose="testing"
+    ) == "explicit"
+
+
+def test_response_text_falls_back_to_client_hint_then_purpose():
+    params = BootstrapStateParams()
+    assert derive_bootstrap_response_text(
+        params, client_hint="hook-fired", purpose="testing"
+    ) == "[bootstrap] hook-fired"
+    assert derive_bootstrap_response_text(
+        params, client_hint=None, purpose="testing"
+    ) == "[bootstrap] testing"
+    assert derive_bootstrap_response_text(
+        params, client_hint=None, purpose=None
+    ) == "[bootstrap] session-start"
+
+
+def test_fill_defaults_caller_wins():
+    params = BootstrapStateParams(complexity=0.9, confidence=0.1, task_type="bugfix")
+    filled = fill_defaults(params, client_hint="claude-code", purpose=None)
+    assert filled["complexity"] == 0.9
+    assert filled["confidence"] == 0.1
+    assert filled["task_type"] == "bugfix"
+
+
+def test_fill_defaults_applies_when_absent():
+    filled = fill_defaults(BootstrapStateParams(), client_hint=None, purpose=None)
+    assert filled["complexity"] == 0.5
+    assert filled["confidence"] == 0.5
+    assert filled["task_type"] == "introspection"
+    assert filled["ethical_drift"] == [0.0, 0.0, 0.0]
+
+
+def test_state_json_marks_source_and_carries_digest():
+    params = BootstrapStateParams(complexity=0.7)
+    filled = fill_defaults(params)
+    sj = build_state_json(filled)
+    assert sj["source"] == "bootstrap"
+    assert sj["bootstrap_digest"] == filled["bootstrap_digest"]
+    assert sj["complexity"] == 0.7
+
+
+def test_pydantic_rejects_extra_fields():
+    """`extra='forbid'` on the model means {synthetic: false} cannot sneak in."""
+    from pydantic import ValidationError
+    with pytest.raises(ValidationError):
+        BootstrapStateParams(synthetic=False)
+    with pytest.raises(ValidationError):
+        BootstrapStateParams(arbitrary_key="value")
+
+
+def test_pydantic_rejects_out_of_range_floats():
+    from pydantic import ValidationError
+    with pytest.raises(ValidationError):
+        BootstrapStateParams(complexity=1.5)
+    with pytest.raises(ValidationError):
+        BootstrapStateParams(confidence=-0.1)
+
+
+def test_pydantic_rejects_invalid_task_type():
+    from pydantic import ValidationError
+    with pytest.raises(ValidationError):
+        BootstrapStateParams(task_type="not-a-real-task-type")
+
+
+def test_pydantic_rejects_wrong_drift_length():
+    from pydantic import ValidationError
+    with pytest.raises(ValidationError):
+        BootstrapStateParams(ethical_drift=[0.0, 0.0])
+    with pytest.raises(ValidationError):
+        BootstrapStateParams(ethical_drift=[0.0, 0.0, 0.0, 0.0])

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -101,6 +101,7 @@ async def ensure_test_database_schema() -> None:
         await _execute_sql_file(conn, "db/postgres/migrations/011_behavioral_baselines.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/012_identity_last_activity_at.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/014_seed_epoch_2.sql")
+        await _execute_sql_file(conn, "db/postgres/migrations/017_substrate_claims.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/018_bootstrap_synthetic_state.sql")
 
         # Ensure partitioned audit tables can accept inserts for current month.


### PR DESCRIPTION
Phase 2 of [docs/proposals/onboard-bootstrap-checkin.md](docs/proposals/onboard-bootstrap-checkin.md) (v2.1) — handler half. Phase 1 (#168) shipped the schema; this PR wires the API surface.

## What

* `BootstrapStateParams` in `schemas/core.py` — Pydantic v2 model with `extra='forbid'` (rejects `{synthetic: false}` back-door attempts) and the five-field caller-supplied subset.
* `OnboardParams` gains an optional `initial_state` field of that type.
* New helper module `src/mcp_handlers/identity/bootstrap_checkin.py` owns the digest contract (SHA-256 over canonical JSON of caller-supplied fields only — server defaults excluded), default-fill, `state_json` composition, and the timeout-bounded `write_bootstrap` entry point (`asyncio.wait_for(..., timeout=0.5)` per spec §3.5).
* `StateMixin` gains:
  - `record_bootstrap_state` — returns `(state_id, was_written)`, catches `UniqueViolationError` from the partial index and returns the existing row's `state_id`.
  - `get_bootstrap_state` — returns `{state_id, state_json}` for digest-comparison on idempotent re-calls.
  - `is_substrate_earned` — queries `core.substrate_claims` (S19 PR1) OR the `PI_RESIDENT_ALLOWLIST` const for cross-substrate cases like Lumen.
* `handle_onboard_v2` calls `write_bootstrap` when `initial_state` is present, attaches the response block to `result['bootstrap']`. The whole call is wrapped in try/except so bootstrap failure never blocks onboard itself (fail-open per spec §3.5).
* `TaskType` literal extracted as a module-level alias in `schemas/core.py` so `ProcessAgentUpdateParams` and `BootstrapStateParams` share one source of truth.

## What's not in this PR

* Filter-site changes — Phase 3, the audit-deliverable step. Until those land, `get_latest_agent_state` etc. will see the bootstrap row as the most-recent state. This is acceptable interim because no caller is writing `initial_state` yet (the hook isn't wired up). Phase 3 lands before Phase 4.
* Hook integration — Phase 4.
* Population observability surface — Phase 5.

## Spec context

Reviewed by parallel council (`docs/proposals/onboard-bootstrap-checkin.{dialectic,code}-review.md`) before code; v2.1 ack-clean. Spec §3.5 was further refined during Phase 1 (master commit `c98d1d18`) to use `core.substrate_claims` registry instead of an `identity.metadata` backfill — that decision is reflected here.

## Tests

13 helper unit tests in `tests/test_bootstrap_checkin_helper.py` — digest invariance/uniqueness/canonicalization, default-fill, state_json composition, Pydantic extra-field rejection, range/length validation.

10 DAO+integration tests in `tests/test_bootstrap_checkin_dao.py` — `record_bootstrap_state` write + idempotent fallback, `get_bootstrap_state` round-trip, `is_substrate_earned` via both `substrate_claims` and `PI_RESIDENT_ALLOWLIST`, `write_bootstrap` end-to-end (first write + same-payload digest match + different-payload digest mismatch + substrate-earned skip + concurrent-call race resolution to exactly one row).

Spec test coverage: §8 items 1, 2, 3, 11, 13. Items 4–10, 12, 14, 15 land in Phases 3–4 (filter sites + hook).

Migration 017 (`substrate_claims`) added to the test schema bootstrap chain — the test DB needed it for `is_substrate_earned`.

Full suite: **7304 passed, 33 skipped, 77.77% coverage** via `./scripts/dev/test-cache.sh --fresh`.

## Rollback

Revert this commit. No schema changes (those are in #168). Existing onboard callers without `initial_state` see no behavior change.