### PR TITLE
audit + feat: phase 3a — filter audit artifact + load-bearing 4 filters

### DIFF
--- a/db/postgres/migrations/019_matview_measured_only.sql
+++ b/db/postgres/migrations/019_matview_measured_only.sql
@@ -1,0 +1,46 @@
+-- 019_matview_measured_only.sql
+--
+-- Phase 3a of onboard-bootstrap-checkin.md (v2.1).
+--
+-- Bakes `WHERE synthetic = false` into the core.mv_latest_agent_states
+-- definition itself so the matview rowset never contains bootstrap rows.
+-- Migration 018 added the `synthetic` column projection so the rows could
+-- be filtered at query time; this migration goes further and makes the
+-- matview measured-only by definition.
+--
+-- Why: a reader who never expects synthetic rows in the matview can't
+-- accidentally introduce a bug by writing a SELECT that omits the filter.
+-- The base-table fallback in get_all_latest_agent_states still needs an
+-- explicit WHERE clause because it queries the base table directly.
+--
+-- Rollback shape: DROP MATERIALIZED VIEW + recreate without the WHERE
+-- clause (i.e. revert to migration 018's projection).
+
+-- Drop the prior matview (recreated by migration 018 with synthetic projection
+-- but no row-level filter).
+DROP MATERIALIZED VIEW IF EXISTS core.mv_latest_agent_states;
+
+-- Measured-only: DISTINCT ON identity, latest measured row only. Bootstrap
+-- rows are excluded at the matview-definition level.
+CREATE MATERIALIZED VIEW core.mv_latest_agent_states AS
+SELECT DISTINCT ON (s.identity_id)
+       s.state_id, s.identity_id, i.agent_id, s.recorded_at,
+       s.entropy, s.integrity, s.stability_index, s.volatility,
+       s.regime, s.coherence, s.state_json, s.synthetic
+FROM core.agent_state s
+JOIN core.identities i ON i.identity_id = s.identity_id
+WHERE s.synthetic = false
+ORDER BY s.identity_id, s.recorded_at DESC;
+
+-- Unique index required for REFRESH CONCURRENTLY (mirrors migration 008).
+CREATE UNIQUE INDEX idx_mv_latest_states_identity
+    ON core.mv_latest_agent_states (identity_id);
+
+-- For lookups by agent_id (mirrors migration 008).
+CREATE INDEX idx_mv_latest_states_agent
+    ON core.mv_latest_agent_states (agent_id);
+
+-- Register the migration.
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (19, 'matview_measured_only', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/docs/proposals/onboard-bootstrap-checkin.filter-audit.md
+++ b/docs/proposals/onboard-bootstrap-checkin.filter-audit.md
@@ -28,7 +28,7 @@ These are reads where a bootstrap row appearing as the most-recent measured stat
 | # | Site | File:line | Decision | Enforcing test |
 |---|------|-----------|----------|----------------|
 | 1 | `get_latest_agent_state` (DAO) | `src/db/mixins/state.py:134` | exclude `synthetic = true` | `test_get_latest_excludes_bootstrap` |
-| 2 | `get_all_latest_agent_states` (DAO, matview + base-table fallback) | `src/db/mixins/state.py:179` | exclude `synthetic = true` in **both** branches | `test_all_latest_excludes_bootstrap` (covers matview path AND fallback path) |
+| 2 | `get_all_latest_agent_states` (DAO, matview + base-table fallback) | `src/db/mixins/state.py:179` | **matview rebuilt as measured-only** (migration 019: `WHERE synthetic = false` in matview SELECT); base-table fallback adds query-time `WHERE s.synthetic = false`. Cleaner than query-time filtering over an unfiltered matview. | `test_all_latest_excludes_bootstrap` (covers matview path AND fallback path) + `test_matview_definition_excludes_synthetic` (matview rowset itself does not contain bootstrap rows) |
 | 3 | `get_recent_cross_agent_activity` (DAO) | `src/db/mixins/state.py:210` | exclude `synthetic = true` | `test_cross_agent_activity_excludes_bootstrap` |
 | 4 | `get_latest_eisv_by_agent_id` (DAO) | `src/db/mixins/tool_usage.py:106` | exclude `synthetic = true` | `test_outcome_correlation_excludes_bootstrap` |
 
@@ -45,7 +45,7 @@ These are reads where bootstrap leakage is **either subtle (post-genesis traject
 
 | # | Site | File:line | Decision | Enforcing test |
 |---|------|-----------|----------|----------------|
-| 5 | `get_agent_state_history` (DAO) | `src/db/mixins/state.py:157` | **include w/ flag preserved** (default), but expose an `exclude_synthetic: bool = False` parameter that callers MAY set to filter | `test_history_preserves_synthetic_by_default` + `test_history_with_exclude_synthetic_filters` |
+| 5 | `get_agent_state_history` (DAO) | `src/db/mixins/state.py:157` | **default include synthetic** — matches the audit/lineage rule and avoids silently hiding bootstrap rows from historical/debug reads. Add `exclude_synthetic: bool = False` parameter (visible in DAO signature + this audit doc); the choke point for "measured-only history" is the explicit parameter plus tests, not a hard DAO default. History is not one semantic thing — callers legitimately need both "full record" and "measured-only record." | `test_history_preserves_synthetic_by_default` + `test_history_with_exclude_synthetic_filters` |
 | 6 | `hydrate_from_db_if_fresh` (in-memory monitor seeding from DB) | `src/agent_monitor_state.py:236` | call site uses `get_agent_state_history(..., exclude_synthetic=True)` so the in-memory monitor is never seeded from a synthetic row — this is the dialectic-flagged "trajectory integrator's prior-read at update time" | `test_hydration_excludes_bootstrap` (hydrating an agent with bootstrap-only history yields update_count=0) |
 
 **Downstream paths covered by site #6 (refuse-with-explanation falls out structurally):**
@@ -94,6 +94,6 @@ These are paths that *appear* to be filter sites but are safe-by-construction. T
 
 ## Caveats
 
-- **The matview is rebuilt by Phase 1 (migration 018) to project the `synthetic` column** — Phase 3a doesn't need a migration, just a `WHERE synthetic = false` clause on the matview SELECT. The base-table fallback in `get_all_latest_agent_states` needs the same filter (the spec §4 contract is "exclude in both branches" — easy to miss because the fallback is in a `try/except` block).
-- **The default for `get_agent_state_history` stays "include synthetic"** because changing it would be a silent semantic change for every existing caller. The hydration call site at #6 is the only one that needs `exclude_synthetic=True`; everywhere else the synthetic flag travels as data (per spec §4 inclusion rule #2 "Identity audit / lineage queries").
+- **The matview is rebuilt by Phase 3a (migration 019) as measured-only.** Phase 1 (migration 018) projected the `synthetic` column for filterability; Phase 3a goes one step further and bakes `WHERE synthetic = false` into the matview definition itself, so the matview rowset never contains bootstrap rows. This is cleaner than relying on query-time filtering over a mixed-content matview — a reader who never expects synthetic rows in the matview can't accidentally introduce a bug by writing a SELECT that omits the filter. The base-table fallback in `get_all_latest_agent_states` still adds a query-time `WHERE s.synthetic = false` because it queries the base table directly.
+- **The default for `get_agent_state_history` stays "include synthetic"** because changing it would be a silent semantic change for every existing caller, and history-as-audit-record legitimately wants the full picture. The hydration call site at #6 is the only one that needs `exclude_synthetic=True`; everywhere else the synthetic flag travels as data (per spec §4 inclusion rule #2 "Identity audit / lineage queries").
 - **`get_agent_state_history` is the only DAO method whose default behavior intentionally INCLUDES synthetic rows.** This is documented inline in the DAO docstring after Phase 3b lands.

--- a/docs/proposals/onboard-bootstrap-checkin.filter-audit.md
+++ b/docs/proposals/onboard-bootstrap-checkin.filter-audit.md
@@ -1,0 +1,99 @@
+---
+status: AUDIT — control surface for Phase 3a + Phase 3b
+authored: 2026-04-25
+of: onboard-bootstrap-checkin.md (v2.1)
+phase: 3 (split into 3a + 3b per Kenny's directive 2026-04-25)
+council_threshold: ">10 distinct read sites = pause and escalate"
+total_code_sites: 5 (4 in Phase 3a, 1 in Phase 3b)
+total_invariant_sites: 3 (calibration, export, trust-tier — tests only, no code change)
+escalation_status: "below threshold — proceed solo"
+---
+
+# Filter Audit — onboard-bootstrap-checkin
+
+**Purpose:** This artifact is the control surface for Phase 3 of `onboard-bootstrap-checkin.md`. Per spec §4.1, every read path that aggregates `core.agent_state` rows must be classified here before any filter code lands. Code follows this list — it does not discover sites mid-patch.
+
+**Threshold:** if the audit names >10 distinct code-change sites, Phase 3 stops being a contained filter pass and becomes a wider state-model migration that requires council escalation. **Current count: 5 code sites + 3 invariant-only items. Below threshold. Proceed.**
+
+**Method:** exhaustive grep for `core.agent_state`, `mv_latest_agent_states`, and the DAO methods that read those tables (`get_latest_agent_state`, `get_agent_state_history`, `get_all_latest_agent_states`, `get_recent_cross_agent_activity`, `get_latest_eisv_by_agent_id`), plus their downstream callers. Verified against the live codebase as of master `311613a7`.
+
+---
+
+## Site classification matrix
+
+### Phase 3a — load-bearing reads (user-visible / runtime-critical)
+
+These are reads where a bootstrap row appearing as the most-recent measured state causes a **wrong answer** to a question a user, a Sentinel, or an outcome correlator is asking.
+
+| # | Site | File:line | Decision | Enforcing test |
+|---|------|-----------|----------|----------------|
+| 1 | `get_latest_agent_state` (DAO) | `src/db/mixins/state.py:134` | exclude `synthetic = true` | `test_get_latest_excludes_bootstrap` |
+| 2 | `get_all_latest_agent_states` (DAO, matview + base-table fallback) | `src/db/mixins/state.py:179` | exclude `synthetic = true` in **both** branches | `test_all_latest_excludes_bootstrap` (covers matview path AND fallback path) |
+| 3 | `get_recent_cross_agent_activity` (DAO) | `src/db/mixins/state.py:210` | exclude `synthetic = true` | `test_cross_agent_activity_excludes_bootstrap` |
+| 4 | `get_latest_eisv_by_agent_id` (DAO) | `src/db/mixins/tool_usage.py:106` | exclude `synthetic = true` | `test_outcome_correlation_excludes_bootstrap` |
+
+**Downstream callers covered by Phase 3a (no per-caller change needed — they all delegate to the DAO):**
+- `src/agent_storage.py:122, 467, 584` — `get_agent` / `list_agents` / module-level `get_latest_agent_state` use #1
+- `src/temporal.py:93` — temporal narrator latest-state read uses #1
+- `src/temporal.py:119` — temporal narrator cross-agent activity uses #3
+- `src/mcp_handlers/admin/dashboard.py:24` — `dashboard.handle_dashboard_overview` uses #2
+- `src/mcp_handlers/observability/outcome_events.py:94` — `outcome_event` correlator uses #4
+
+### Phase 3b — audit-discovered reads + refuse-with-explanation paths
+
+These are reads where bootstrap leakage is **either subtle (post-genesis trajectory priors) or transitive (self-recovery / dialectic via in-memory hydration)** rather than directly user-visible. Phase 3b lands before Phase 4 (hook).
+
+| # | Site | File:line | Decision | Enforcing test |
+|---|------|-----------|----------|----------------|
+| 5 | `get_agent_state_history` (DAO) | `src/db/mixins/state.py:157` | **include w/ flag preserved** (default), but expose an `exclude_synthetic: bool = False` parameter that callers MAY set to filter | `test_history_preserves_synthetic_by_default` + `test_history_with_exclude_synthetic_filters` |
+| 6 | `hydrate_from_db_if_fresh` (in-memory monitor seeding from DB) | `src/agent_monitor_state.py:236` | call site uses `get_agent_state_history(..., exclude_synthetic=True)` so the in-memory monitor is never seeded from a synthetic row — this is the dialectic-flagged "trajectory integrator's prior-read at update time" | `test_hydration_excludes_bootstrap` (hydrating an agent with bootstrap-only history yields update_count=0) |
+
+**Downstream paths covered by site #6 (refuse-with-explanation falls out structurally):**
+- `src/mcp_handlers/lifecycle/self_recovery.py:253, 375, 564` — reads `monitor.state.coherence`, `monitor.state.void_active`, etc. After Phase 3b, a bootstrap-only agent has `monitor.state.update_count == 0`, so self-recovery's existing "no measured state yet" guard naturally fires. The refuse-with-explanation contract from spec §4 inclusion list #6 holds without additional code at the self-recovery site.
+- `src/mcp_handlers/dialectic/handlers.py:505, 1849` — same pattern. `paused_agent_state = monitor.state.to_dict()` returns a dict with `update_count=0` and zeroed histories for a bootstrap-only agent. Dialectic's existing "needs measured trajectory" guard handles the refusal. Verify with test, no separate code change.
+
+`src/temporal.py:105` calls `get_agent_state_history(identity_id, limit=50)` with the new default (`exclude_synthetic=False`), which preserves the bootstrap row in the temporal narrator's history view — that's intentional (temporal context is descriptive, not measured). Verified with test that the row carries `synthetic=true` for inspection.
+
+### Invariant-only items (Phase 3a tests, no code change)
+
+These are paths that *appear* to be filter sites but are safe-by-construction. The audit document records them so the invariant is explicit; tests prove the protection holds.
+
+| # | Item | Why it's safe today | Test |
+|---|------|---------------------|------|
+| I1 | Calibration ingestion (`auto_ground_truth.collect_ground_truth_automatically`) at `src/auto_ground_truth.py:385,432` | Queries `audit.events WHERE event_type = 'auto_attest'`. Bootstrap writes via `record_bootstrap_state` (Phase 2) do NOT emit `auto_attest` events — they only INSERT a `core.agent_state` row. The exogenous-signal gate at line 432 also requires `tests`/`commands`/`files`/`lint` keys, which bootstrap state_json never carries. **Locked in by:** `test_calibration_excludes_bootstrap` (assert that even N bootstrap rows produce zero calibration entries). |
+| I2 | Export bundle (`handle_get_system_history` at `src/mcp_handlers/introspection/export.py:52`) | Reads from `monitor.export_history()` — the in-memory monitor's history, NOT DB rows. The bootstrap row never flows into this export today. The spec §4 inclusion rule for "exports preserve `synthetic` flag" is **vacuous until export is wired to DB-sourced state rows.** Documented as a follow-up, not a Phase 3 deliverable. **No test added** — there's nothing to enforce in current code. |
+| I3 | Trust-tier observation count (`compute_trust_tier` at `src/trajectory_identity.py:692`) | Reads `observation_count` from trajectory metadata, NOT from `COUNT(*)` over `agent_state` rows. The bootstrap write helper (`bootstrap_checkin.write_bootstrap`) does not call `store_genesis_signature` or otherwise touch trajectory metadata. **Locked in by:** `test_trust_tier_excludes_bootstrap` (assert a bootstrap-only agent's trust tier reflects zero observations). |
+
+---
+
+## What's NOT in this audit
+
+- **`record_agent_state`, `record_bootstrap_state`, `get_bootstrap_state`, `is_substrate_earned`** — these are write paths or already-synthetic-aware reads. No filter needed.
+- **`agents/sentinel/` aggregation** — Sentinel reads via `dashboard.handle_dashboard_overview` (covered by site #2) and `get_recent_cross_agent_activity` (site #3). It does not touch `core.agent_state` directly. Verified by `grep -rn "core.agent_state\|mv_latest" agents/sentinel/`.
+- **Knowledge-graph reads** — KG never queries `core.agent_state`.
+- **Audit log queries** — they read `audit.events`, never `core.agent_state`.
+- **The matview-refresh background task** (`src/background_tasks.py:187`) — DDL operation, not a read.
+
+---
+
+## Phase split
+
+**Phase 3a (this PR):**
+- Sites #1, #2, #3, #4 — DAO-level filter changes.
+- Tests for #1, #2, #3, #4 + invariant tests I1, I3.
+- This audit document committed in the same PR as the filter changes.
+
+**Phase 3b (next PR after 3a merges):**
+- Site #5 — `get_agent_state_history` gains `exclude_synthetic: bool = False`.
+- Site #6 — `hydrate_from_db_if_fresh` passes `exclude_synthetic=True` so the in-memory monitor never inherits bootstrap state.
+- Verification tests that self-recovery and dialectic refuse-with-explanation for bootstrap-only agents fall out structurally.
+
+**Phase 4 (hook integration) gates on both 3a AND 3b being merged.** Phase 2 is currently safe only because no caller writes `initial_state`. Once the SessionStart hook lands, any missed filter becomes semantic contamination.
+
+---
+
+## Caveats
+
+- **The matview is rebuilt by Phase 1 (migration 018) to project the `synthetic` column** — Phase 3a doesn't need a migration, just a `WHERE synthetic = false` clause on the matview SELECT. The base-table fallback in `get_all_latest_agent_states` needs the same filter (the spec §4 contract is "exclude in both branches" — easy to miss because the fallback is in a `try/except` block).
+- **The default for `get_agent_state_history` stays "include synthetic"** because changing it would be a silent semantic change for every existing caller. The hydration call site at #6 is the only one that needs `exclude_synthetic=True`; everywhere else the synthetic flag travels as data (per spec §4 inclusion rule #2 "Identity audit / lineage queries").
+- **`get_agent_state_history` is the only DAO method whose default behavior intentionally INCLUDES synthetic rows.** This is documented inline in the DAO docstring after Phase 3b lands.

--- a/src/db/mixins/state.py
+++ b/src/db/mixins/state.py
@@ -135,6 +135,10 @@ class StateMixin:
         self,
         identity_id: int,
     ) -> Optional[AgentStateRecord]:
+        """Latest measured state for an identity. Bootstrap (synthetic) rows
+        are excluded by default per onboard-bootstrap-checkin §4.1; this is
+        the user-visible "what is this agent's current state" question, and
+        a synthetic anchor is not the answer."""
         from config.governance_config import GovernanceConfig
         async with self.acquire() as conn:
             row = await conn.fetchrow(
@@ -145,6 +149,7 @@ class StateMixin:
                 FROM core.agent_state s
                 JOIN core.identities i ON i.identity_id = s.identity_id
                 WHERE s.identity_id = $1 AND s.epoch = $2
+                  AND s.synthetic = false
                 ORDER BY s.recorded_at DESC
                 LIMIT 1
                 """,
@@ -177,7 +182,15 @@ class StateMixin:
             return [self._row_to_agent_state(r) for r in rows]
 
     async def get_all_latest_agent_states(self) -> list[AgentStateRecord]:
-        """Get latest state per identity, using matview with base-table fallback."""
+        """Get latest measured state per identity, using matview with base-table fallback.
+
+        The matview is measured-only by definition (migration 019 bakes
+        `WHERE synthetic = false` into the matview SELECT), so the matview
+        path needs no query-time filter. The base-table fallback queries
+        agent_state directly and adds the filter explicitly. Both paths
+        agree: bootstrap rows never appear here. Per onboard-bootstrap-
+        checkin §4.1.
+        """
         async with self.acquire() as conn:
             try:
                 rows = await conn.fetch(
@@ -189,7 +202,9 @@ class StateMixin:
                     """,
                 )
             except Exception:
-                # Matview may not exist yet — fall back to base table
+                # Matview may not exist yet — fall back to base table.
+                # Filter `synthetic = false` here because the base table
+                # contains both measured and synthetic rows.
                 from config.governance_config import GovernanceConfig
                 logger.debug("Matview unavailable, falling back to base table")
                 rows = await conn.fetch(
@@ -201,6 +216,7 @@ class StateMixin:
                     FROM core.agent_state s
                     JOIN core.identities i ON i.identity_id = s.identity_id
                     WHERE s.epoch = $1
+                      AND s.synthetic = false
                     ORDER BY s.identity_id, s.recorded_at DESC
                     """,
                     GovernanceConfig.CURRENT_EPOCH,
@@ -212,9 +228,12 @@ class StateMixin:
         exclude_identity_id: int,
         minutes: int = 60,
     ) -> list[dict]:
-        """Get recent activity from other agents, grouped by agent.
+        """Get recent measured activity from other agents, grouped by agent.
 
         Returns list of dicts with agent_id, recorded_at (most recent), count.
+        Bootstrap (synthetic) rows are excluded — the COUNT is "how many real
+        check-ins" and a session-start anchor is not activity. Per onboard-
+        bootstrap-checkin §4.1.
         """
         from config.governance_config import GovernanceConfig
         window = minutes or GovernanceConfig.TEMPORAL_CROSS_AGENT_MINUTES
@@ -229,6 +248,7 @@ class StateMixin:
                 WHERE s.identity_id != $1
                   AND s.recorded_at > now() - ($2 * interval '1 minute')
                   AND s.epoch = $3
+                  AND s.synthetic = false
                 GROUP BY i.agent_id
                 ORDER BY MAX(s.recorded_at) DESC
                 LIMIT 5

--- a/src/db/mixins/tool_usage.py
+++ b/src/db/mixins/tool_usage.py
@@ -104,7 +104,14 @@ class ToolUsageMixin:
                 return []
 
     async def get_latest_eisv_by_agent_id(self, agent_id: str) -> Optional[Dict[str, Any]]:
-        """Fetch latest EISV snapshot for an agent."""
+        """Fetch latest measured EISV snapshot for an agent.
+
+        Bootstrap (synthetic) rows are excluded — the outcome correlator
+        snapshots EISV at outcome-event time for calibration; correlating
+        a real test outcome against a synthetic 0.5/0.5/0.5 anchor would
+        inject default-encoded noise into every agent's calibration prior.
+        Per onboard-bootstrap-checkin §4.1.
+        """
         from config.governance_config import GovernanceConfig
         async with self.acquire() as conn:
             try:
@@ -115,6 +122,7 @@ class ToolUsageMixin:
                     FROM core.agent_state s
                     JOIN core.identities i ON i.identity_id = s.identity_id
                     WHERE i.agent_id = $1 AND s.epoch = $2
+                      AND s.synthetic = false
                     ORDER BY s.recorded_at DESC
                     LIMIT 1
                     """,

--- a/tests/test_bootstrap_checkin_filters_3a.py
+++ b/tests/test_bootstrap_checkin_filters_3a.py
@@ -1,0 +1,330 @@
+"""Phase 3a filter-site tests for onboard-bootstrap-checkin.
+
+Asserts that the load-bearing 4 read paths (get_latest_agent_state,
+get_all_latest_agent_states, get_recent_cross_agent_activity,
+get_latest_eisv_by_agent_id) exclude bootstrap rows by default. Plus
+the matview-as-measured-only invariant from migration 019, plus the
+calibration and trust-tier invariant locks.
+
+Spec: docs/proposals/onboard-bootstrap-checkin.md §4.1, §8 items 4–8.
+Audit: docs/proposals/onboard-bootstrap-checkin.filter-audit.md (sites 1–4 + I1, I3).
+"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+try:
+    import asyncpg  # noqa: F401
+except ImportError:
+    pytest.skip("asyncpg not installed", allow_module_level=True)
+
+from tests.test_db_utils import can_connect_to_test_db
+
+if not can_connect_to_test_db():
+    pytest.skip("governance_test database not available", allow_module_level=True)
+
+from src.mcp_handlers.identity.bootstrap_checkin import write_bootstrap
+from src.mcp_handlers.schemas.core import BootstrapStateParams
+
+
+@pytest.fixture
+def db(live_postgres_backend):
+    return live_postgres_backend
+
+
+async def _seed_identity(db) -> tuple[str, int]:
+    agent_id = f"test-{uuid.uuid4()}"
+    async with db.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO core.agents (id, api_key) VALUES ($1, 'test-key')",
+            agent_id,
+        )
+        identity_id = await conn.fetchval(
+            """
+            INSERT INTO core.identities (agent_id, api_key_hash)
+            VALUES ($1, 'test-hash')
+            RETURNING identity_id
+            """,
+            agent_id,
+        )
+    return agent_id, identity_id
+
+
+async def _record_measured(db, identity_id, *, entropy=0.4, integrity=0.6):
+    """Insert a regular (synthetic=false) measured state row."""
+    return await db.record_agent_state(
+        identity_id=identity_id,
+        entropy=entropy, integrity=integrity, stability_index=0.5,
+        void=0.0, regime="nominal", coherence=1.0, state_json={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Site #1: get_latest_agent_state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_latest_excludes_bootstrap_only_agent(db):
+    """Bootstrap-only agent: get_latest_agent_state returns None, not the synthetic row."""
+    agent_id, identity_id = await _seed_identity(db)
+    await write_bootstrap(db, identity_id=identity_id, agent_id=agent_id,
+                          params=BootstrapStateParams(complexity=0.7))
+
+    latest = await db.get_latest_agent_state(identity_id)
+    assert latest is None
+
+
+@pytest.mark.asyncio
+async def test_get_latest_returns_measured_when_present(db):
+    """With both a bootstrap and a real check-in: latest is the real check-in."""
+    agent_id, identity_id = await _seed_identity(db)
+    await write_bootstrap(db, identity_id=identity_id, agent_id=agent_id,
+                          params=BootstrapStateParams(complexity=0.7))
+    measured_id = await _record_measured(db, identity_id, entropy=0.3)
+
+    latest = await db.get_latest_agent_state(identity_id)
+    assert latest is not None
+    assert latest.state_id == measured_id
+    assert latest.entropy == pytest.approx(0.3)
+
+
+# ---------------------------------------------------------------------------
+# Site #2: get_all_latest_agent_states (matview + base-table fallback)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_all_latest_excludes_bootstrap_only_agents(db):
+    """Bootstrap-only agent does not appear in the all-agents latest list."""
+    agent_id, identity_id = await _seed_identity(db)
+    await write_bootstrap(db, identity_id=identity_id, agent_id=agent_id,
+                          params=BootstrapStateParams())
+
+    # Refresh the matview so it sees the latest agent_state state.
+    async with db.acquire() as conn:
+        await conn.execute("REFRESH MATERIALIZED VIEW core.mv_latest_agent_states")
+
+    rows = await db.get_all_latest_agent_states()
+    assert all(r.identity_id != identity_id for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_all_latest_includes_measured_after_bootstrap(db):
+    """Bootstrap then real check-in: the agent shows up with the measured row."""
+    agent_id, identity_id = await _seed_identity(db)
+    await write_bootstrap(db, identity_id=identity_id, agent_id=agent_id,
+                          params=BootstrapStateParams())
+    measured_id = await _record_measured(db, identity_id, entropy=0.2)
+
+    async with db.acquire() as conn:
+        await conn.execute("REFRESH MATERIALIZED VIEW core.mv_latest_agent_states")
+
+    rows = await db.get_all_latest_agent_states()
+    matching = [r for r in rows if r.identity_id == identity_id]
+    assert len(matching) == 1
+    assert matching[0].state_id == measured_id
+
+
+@pytest.mark.asyncio
+async def test_matview_definition_excludes_synthetic(db):
+    """The matview rowset itself contains no bootstrap rows (migration 019 invariant)."""
+    agent_id, identity_id = await _seed_identity(db)
+    await write_bootstrap(db, identity_id=identity_id, agent_id=agent_id,
+                          params=BootstrapStateParams())
+    async with db.acquire() as conn:
+        await conn.execute("REFRESH MATERIALIZED VIEW core.mv_latest_agent_states")
+        synthetic_in_matview = await conn.fetchval(
+            "SELECT COUNT(*) FROM core.mv_latest_agent_states WHERE synthetic = true"
+        )
+    assert synthetic_in_matview == 0
+
+
+@pytest.mark.asyncio
+async def test_all_latest_base_table_fallback_excludes_bootstrap(db, monkeypatch):
+    """When the matview query raises, the base-table fallback also excludes synthetic."""
+    agent_id, identity_id = await _seed_identity(db)
+    await write_bootstrap(db, identity_id=identity_id, agent_id=agent_id,
+                          params=BootstrapStateParams())
+    measured_id = await _record_measured(db, identity_id, entropy=0.25)
+
+    # Force the matview path to fail so the fallback is exercised.
+    original_acquire = db.acquire
+
+    class _ForceFallbackConn:
+        def __init__(self, real):
+            self._real = real
+
+        async def fetch(self, query, *args):
+            if "mv_latest_agent_states" in query:
+                raise Exception("simulated matview unavailable")
+            return await self._real.fetch(query, *args)
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+    class _AcquireCM:
+        def __init__(self, inner):
+            self._inner = inner
+            self._real_conn = None
+
+        async def __aenter__(self):
+            self._real_conn = await self._inner.__aenter__()
+            return _ForceFallbackConn(self._real_conn)
+
+        async def __aexit__(self, *exc):
+            return await self._inner.__aexit__(*exc)
+
+    def _wrapped_acquire(*a, **kw):
+        return _AcquireCM(original_acquire(*a, **kw))
+
+    monkeypatch.setattr(db, "acquire", _wrapped_acquire)
+
+    rows = await db.get_all_latest_agent_states()
+    matching = [r for r in rows if r.identity_id == identity_id]
+    assert len(matching) == 1
+    assert matching[0].state_id == measured_id
+
+
+# ---------------------------------------------------------------------------
+# Site #3: get_recent_cross_agent_activity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cross_agent_activity_excludes_bootstrap_only_agents(db):
+    """A bootstrap-only neighbor doesn't show up in the cross-agent activity window."""
+    self_agent_id, self_identity_id = await _seed_identity(db)
+    neighbor_agent_id, neighbor_identity_id = await _seed_identity(db)
+    await write_bootstrap(
+        db, identity_id=neighbor_identity_id, agent_id=neighbor_agent_id,
+        params=BootstrapStateParams(),
+    )
+
+    activity = await db.get_recent_cross_agent_activity(
+        exclude_identity_id=self_identity_id, minutes=60,
+    )
+    assert all(row["agent_id"] != neighbor_agent_id for row in activity)
+
+
+@pytest.mark.asyncio
+async def test_cross_agent_activity_count_does_not_include_bootstrap(db):
+    """Count for an active neighbor reflects measured rows only."""
+    self_agent_id, self_identity_id = await _seed_identity(db)
+    neighbor_agent_id, neighbor_identity_id = await _seed_identity(db)
+    await write_bootstrap(
+        db, identity_id=neighbor_identity_id, agent_id=neighbor_agent_id,
+        params=BootstrapStateParams(),
+    )
+    # Two measured rows.
+    await _record_measured(db, neighbor_identity_id)
+    await _record_measured(db, neighbor_identity_id)
+
+    activity = await db.get_recent_cross_agent_activity(
+        exclude_identity_id=self_identity_id, minutes=60,
+    )
+    matching = [row for row in activity if row["agent_id"] == neighbor_agent_id]
+    assert len(matching) == 1
+    assert matching[0]["count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Site #4: get_latest_eisv_by_agent_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_outcome_correlation_excludes_bootstrap(db):
+    """Bootstrap-only agent: get_latest_eisv_by_agent_id returns None, not the synthetic snapshot."""
+    agent_id, identity_id = await _seed_identity(db)
+    await write_bootstrap(db, identity_id=identity_id, agent_id=agent_id,
+                          params=BootstrapStateParams(complexity=0.5))
+
+    eisv = await db.get_latest_eisv_by_agent_id(agent_id)
+    assert eisv is None
+
+
+@pytest.mark.asyncio
+async def test_outcome_correlation_returns_measured_after_bootstrap(db):
+    """Bootstrap + real check-in: snapshot reflects the measured row."""
+    agent_id, identity_id = await _seed_identity(db)
+    await write_bootstrap(db, identity_id=identity_id, agent_id=agent_id,
+                          params=BootstrapStateParams(complexity=0.5))
+    await _record_measured(db, identity_id, entropy=0.31, integrity=0.62)
+
+    eisv = await db.get_latest_eisv_by_agent_id(agent_id)
+    assert eisv is not None
+    assert eisv["S"] == pytest.approx(0.31)
+    assert eisv["I"] == pytest.approx(0.62)
+
+
+# ---------------------------------------------------------------------------
+# Invariant lock I1: bootstrap writes do not feed calibration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_calibration_excludes_bootstrap_no_audit_event(db):
+    """Bootstrap writes via write_bootstrap MUST NOT emit auto_attest audit events.
+
+    The calibration ingestor at src/auto_ground_truth.py:432 only consumes
+    rows of event_type='auto_attest' that carry exogenous-signal keys
+    (tests/commands/files/lint). If a bootstrap write ever started emitting
+    such an event, calibration would silently start consuming synthetic
+    confidence values. This test locks the invariant.
+    """
+    agent_id, identity_id = await _seed_identity(db)
+    await write_bootstrap(db, identity_id=identity_id, agent_id=agent_id,
+                          params=BootstrapStateParams(complexity=0.5, confidence=0.5))
+
+    async with db.acquire() as conn:
+        # No auto_attest event for this agent.
+        attest_count = await conn.fetchval(
+            """
+            SELECT COUNT(*) FROM audit.events
+            WHERE agent_id = $1 AND event_type = 'auto_attest'
+            """,
+            agent_id,
+        )
+    assert attest_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Invariant lock I3: bootstrap doesn't increment trajectory observation_count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trust_tier_excludes_bootstrap_no_genesis_signature(db):
+    """Bootstrap writes MUST NOT call store_genesis_signature.
+
+    compute_trust_tier reads observation_count from trajectory_current /
+    trajectory_genesis metadata. If bootstrap ever started seeding either,
+    a bootstrap-only agent would falsely count as having one observation.
+    This test asserts the absence-of-trajectory-row invariant.
+    """
+    agent_id, identity_id = await _seed_identity(db)
+    await write_bootstrap(db, identity_id=identity_id, agent_id=agent_id,
+                          params=BootstrapStateParams(complexity=0.5))
+
+    # The bootstrap path must not write any trajectory metadata for this agent.
+    async with db.acquire() as conn:
+        # Trajectory state lives in core.identities.metadata under
+        # 'trajectory_current' / 'trajectory_genesis'. Verify neither key
+        # was populated as a side effect of the bootstrap write.
+        meta = await conn.fetchval(
+            "SELECT metadata FROM core.identities WHERE agent_id = $1",
+            agent_id,
+        )
+    import json as _json
+    parsed = _json.loads(meta) if isinstance(meta, str) else (meta or {})
+    assert "trajectory_current" not in parsed
+    assert "trajectory_genesis" not in parsed

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -103,6 +103,7 @@ async def ensure_test_database_schema() -> None:
         await _execute_sql_file(conn, "db/postgres/migrations/014_seed_epoch_2.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/017_substrate_claims.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/018_bootstrap_synthetic_state.sql")
+        await _execute_sql_file(conn, "db/postgres/migrations/019_matview_measured_only.sql")
 
         # Ensure partitioned audit tables can accept inserts for current month.
         await _execute_sql_file(conn, "db/postgres/partitions.sql")


### PR DESCRIPTION
**DRAFT** — opening with the audit artifact only so the site list can be sanity-checked before any filter code lands. Code commits land on this branch after review.

## Audit summary

`docs/proposals/onboard-bootstrap-checkin.filter-audit.md` is the new control surface for Phase 3. Phase 3 was split per Kenny: 3a is the load-bearing 4 filters, 3b is the audit-discovered + refuse-with-explanation paths. Phase 4 gates on both.

**Site count: 5 distinct code-change sites + 3 invariant-only items.**

Below the council threshold (>10 distinct sites). Proceed solo.

### Phase 3a (this PR, after audit ack)

| # | Site | File:line |
|---|------|-----------|
| 1 | `get_latest_agent_state` | `src/db/mixins/state.py:134` |
| 2 | `get_all_latest_agent_states` (matview + fallback) | `src/db/mixins/state.py:179` |
| 3 | `get_recent_cross_agent_activity` | `src/db/mixins/state.py:210` |
| 4 | `get_latest_eisv_by_agent_id` | `src/db/mixins/tool_usage.py:106` |

Plus invariant tests for calibration (`auto_attest` audit-event isolation), trust-tier (`observation_count` from trajectory metadata, not row counts).

### Phase 3b (separate PR)

- `get_agent_state_history` gains `exclude_synthetic: bool = False`.
- `hydrate_from_db_if_fresh` passes `exclude_synthetic=True` so the in-memory monitor is never seeded from a synthetic row — this transitively closes the self-recovery + dialectic refuse-with-explanation contracts.

## Next step

Once this audit looks right, I'll push the 4 filter changes + tests onto this branch and mark ready-for-review. If you want to challenge any classification (especially #5 `get_agent_state_history` keeping `synthetic` by default), now's the time.