### PR TITLE
S19 PR3d: handler_gate.py — verify_substrate_at_resume helper

### DIFF
--- a/src/substrate/handler_gate.py
+++ b/src/substrate/handler_gate.py
@@ -1,0 +1,161 @@
+"""S19 handler-side substrate-claim verification gate.
+
+The bridge between transport-level peer attestation (kernel-attested
+``peer_pid`` from the UDS listener, ``src/uds_listener.py``) and the
+identity-resume decision in ``src/mcp_handlers/identity/handlers.py``.
+
+The gate composes three previously-shipped pieces:
+- ``fetch_substrate_claim`` (async DB lookup; src/substrate/verification.py)
+- ``verify_substrate_claim`` (sync verify-and-cache; same file)
+- ``peer_attestation`` (sync ctypes/subprocess calls; src/substrate/peer_attestation.py)
+
+It honors the anyio-asyncio constraint by:
+1. Awaiting the DB lookup through asyncpg (allowed in a coroutine).
+2. Offloading the synchronous verify call (which spawns ``launchctl``
+   subprocess + ctypes calls) to ``run_in_executor`` so the MCP anyio
+   task group is never blocked on a syscall or process boundary.
+
+The module owns a single process-lifetime ``VerifiedPairsCache`` so the
+PID-reuse mitigation (Q3(e) per the council adversary review) is real
+across concurrent verifications.
+
+Wiring point (PR3e): ``_try_resume_by_agent_uuid_direct`` in
+``src/mcp_handlers/identity/handlers.py`` calls ``verify_substrate_at_resume``
+when the resuming UUID arrives without a matching continuity_token. A
+successful verification result substitutes for the Part-C ownership proof;
+a rejection returns an explicit-rejection error to the peer.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+from src.substrate import peer_attestation
+from src.substrate.verification import (
+    SubstrateClaim,
+    VerificationResult,
+    VerifiedPairsCache,
+    fetch_substrate_claim,
+    verify_substrate_claim,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Module-level cache: per-server-process lifetime. Cleared only on server
+# restart, which is correct — the cache pins running-process proofs (PID +
+# start_tvsec), not durable claims. A restart of governance-mcp resets every
+# resident's verified pair, and they re-pin on next connect.
+_PROCESS_VERIFIED_PAIRS = VerifiedPairsCache()
+
+
+def _get_cache() -> VerifiedPairsCache:
+    """Return the module-level cache. Indirection allows tests to swap in
+    a fresh cache instance via ``reset_cache_for_testing()``."""
+    return _PROCESS_VERIFIED_PAIRS
+
+
+def reset_cache_for_testing() -> None:
+    """Reset the process-wide VerifiedPairsCache. Test-only entrypoint;
+    production code never calls this."""
+    _PROCESS_VERIFIED_PAIRS.clear()
+
+
+async def verify_substrate_at_resume(
+    agent_uuid: str,
+    peer_pid: Optional[int],
+    *,
+    fetch_fn=None,
+    verify_fn=None,
+    pa_module=None,
+    cache: Optional[VerifiedPairsCache] = None,
+) -> Optional[VerificationResult]:
+    """Run substrate-claim verification when applicable.
+
+    Returns:
+        ``None`` when no verification is required:
+            - ``peer_pid`` is None (HTTP path; kernel attestation unavailable).
+            - The UUID has no substrate-claim row (non-substrate-anchored agent).
+
+        ``VerificationResult`` otherwise. Caller checks ``.accepted``:
+            - True  → substrate attestation passed; treat as ownership proof.
+            - False → reject the resume; ``.reason`` is the explicit-rejection
+                       message and ``.failure_code`` is the machine-readable tag.
+
+    The default ``fetch_fn``, ``verify_fn``, ``pa_module``, and ``cache``
+    arguments hit the production implementations. Tests override to inject
+    fakes without monkeypatching.
+    """
+    if peer_pid is None:
+        return None
+
+    fetch_fn = fetch_fn or fetch_substrate_claim
+    verify_fn = verify_fn or verify_substrate_claim
+    pa_module = pa_module or peer_attestation
+    cache = cache if cache is not None else _get_cache()
+
+    # Step 1 (async, allowed under anyio): DB lookup for the substrate-claim row.
+    try:
+        claim: Optional[SubstrateClaim] = await fetch_fn(agent_uuid)
+    except Exception as exc:
+        # DB error: log and degrade to None — caller falls through to
+        # existing token-based gating. We'd rather a single transient DB
+        # failure not lock substrate residents out than over-trust a
+        # claim we couldn't read.
+        logger.warning(
+            "[SUBSTRATE_GATE] DB lookup for %s... failed: %s; degrading to no-verify",
+            agent_uuid[:8], exc,
+        )
+        return None
+
+    if claim is None:
+        # UUID is not registered as substrate-anchored. Caller's existing
+        # token-based gating still applies; substrate gate is a no-op here.
+        return None
+
+    # Step 2 (sync via run_in_executor): launchctl subprocess + ctypes
+    # libproc calls. Must NOT be awaited directly under the MCP anyio
+    # task group — the subprocess.run() and ctypes calls would block the
+    # anyio loop. The pattern matches verify_agent_ownership at
+    # src/agent_loop_detection.py:374.
+    loop = asyncio.get_running_loop()
+    try:
+        result: VerificationResult = await loop.run_in_executor(
+            None,
+            _verify_sync_call,
+            verify_fn, claim, peer_pid, pa_module, cache,
+        )
+    except Exception as exc:
+        logger.error(
+            "[SUBSTRATE_GATE] verification raised for %s... pid=%s: %s",
+            agent_uuid[:8], peer_pid, exc, exc_info=True,
+        )
+        # Defense-in-depth: an unhandled exception in the executor must
+        # NOT default-accept. Return a synthetic rejection so the caller
+        # refuses the resume.
+        return VerificationResult(
+            accepted=False,
+            reason=f"substrate verification raised internal error: {exc!r}",
+            failure_code="attestation_failed",
+        )
+
+    return result
+
+
+def _verify_sync_call(
+    verify_fn,
+    claim: SubstrateClaim,
+    peer_pid: int,
+    pa_module,
+    cache: VerifiedPairsCache,
+) -> VerificationResult:
+    """Synchronous adapter run inside ``loop.run_in_executor``. Kept as a
+    module-level callable so the executor can pickle it cleanly when the
+    default ``ThreadPoolExecutor`` is used."""
+    return verify_fn(
+        claim,
+        peer_pid,
+        pa_module=pa_module,
+        cache=cache,
+    )

--- a/tests/test_substrate_handler_gate.py
+++ b/tests/test_substrate_handler_gate.py
@@ -1,0 +1,238 @@
+"""S19 handler-side substrate-claim verification gate.
+
+Coverage:
+- ``peer_pid is None`` → returns None (HTTP path bypass).
+- No substrate-claim row → returns None (non-substrate UUID).
+- Claim exists, verify accepts → VerificationResult(accepted=True).
+- Claim exists, verify rejects → VerificationResult(accepted=False, ...).
+- DB lookup raises → returns None (graceful degrade; no false-accept).
+- Verify raises → returns synthetic rejection (attestation_failed; no
+  default-accept under exception).
+
+All injectable dependencies (``fetch_fn``, ``verify_fn``, ``pa_module``,
+``cache``) are passed in by tests so no DB / no subprocess / no ctypes
+calls happen under test.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.substrate.handler_gate import (
+    reset_cache_for_testing,
+    verify_substrate_at_resume,
+)
+from src.substrate.verification import (
+    SubstrateClaim,
+    VerificationResult,
+    VerifiedPairsCache,
+)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_claim(agent_id: str = "f92dcea8-4786-412a-a0eb-362c273382f5") -> SubstrateClaim:
+    return SubstrateClaim(
+        agent_id=agent_id,
+        expected_launchd_label="com.unitares.sentinel",
+        expected_executable_path="/opt/homebrew/bin/sentinel",
+        enrolled_at=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        enrolled_by_operator=True,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache():
+    """Each test starts with a clean module-level cache."""
+    reset_cache_for_testing()
+    yield
+    reset_cache_for_testing()
+
+
+# =============================================================================
+# Bypass paths (return None)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_peer_pid_none_returns_none() -> None:
+    """HTTP path: peer_pid is None → no verification."""
+    fetch = AsyncMock(side_effect=AssertionError("fetch must not be called"))
+    verify = MagicMock(side_effect=AssertionError("verify must not be called"))
+
+    result = await verify_substrate_at_resume(
+        "any-uuid", peer_pid=None,
+        fetch_fn=fetch, verify_fn=verify,
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_no_substrate_claim_returns_none() -> None:
+    """Non-substrate-anchored UUID: fetch returns None → no verification."""
+    fetch = AsyncMock(return_value=None)
+    verify = MagicMock(side_effect=AssertionError("verify must not be called"))
+
+    result = await verify_substrate_at_resume(
+        "non-substrate-uuid", peer_pid=12345,
+        fetch_fn=fetch, verify_fn=verify,
+    )
+    assert result is None
+    fetch.assert_awaited_once_with("non-substrate-uuid")
+
+
+# =============================================================================
+# Verify paths (returns VerificationResult)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_claim_exists_and_verify_accepts() -> None:
+    claim = _make_claim()
+    fetch = AsyncMock(return_value=claim)
+    accepted = VerificationResult(accepted=True, reason="ok")
+    verify = MagicMock(return_value=accepted)
+
+    result = await verify_substrate_at_resume(
+        claim.agent_id, peer_pid=12345,
+        fetch_fn=fetch, verify_fn=verify,
+    )
+    assert result is accepted
+    # Verify was called with the right arguments
+    verify.assert_called_once()
+    args, kwargs = verify.call_args
+    assert args[0] is claim
+    assert args[1] == 12345
+
+
+@pytest.mark.asyncio
+async def test_claim_exists_and_verify_rejects() -> None:
+    claim = _make_claim()
+    fetch = AsyncMock(return_value=claim)
+    rejected = VerificationResult(
+        accepted=False,
+        reason="launchd label mismatch: registered ... observed ...",
+        failure_code="label_mismatch",
+    )
+    verify = MagicMock(return_value=rejected)
+
+    result = await verify_substrate_at_resume(
+        claim.agent_id, peer_pid=12345,
+        fetch_fn=fetch, verify_fn=verify,
+    )
+    assert result is rejected
+    assert result.accepted is False
+    assert result.failure_code == "label_mismatch"
+
+
+# =============================================================================
+# Failure modes (graceful degrade vs. fail-closed)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_db_lookup_raises_degrades_to_none() -> None:
+    """DB error during fetch_substrate_claim degrades to None (caller falls
+    through to existing token-based gating). Honest tradeoff: a transient
+    DB failure must not lock substrate residents out, AND must not
+    over-trust the claim we couldn't read."""
+    fetch = AsyncMock(side_effect=RuntimeError("connection refused"))
+    verify = MagicMock(side_effect=AssertionError("verify must not be called"))
+
+    result = await verify_substrate_at_resume(
+        "any-uuid", peer_pid=12345,
+        fetch_fn=fetch, verify_fn=verify,
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_verify_raises_returns_synthetic_rejection() -> None:
+    """An unhandled exception in the executor MUST NOT default-accept.
+
+    The gate returns a synthetic VerificationResult(accepted=False) so the
+    caller refuses the resume, with a clear ``attestation_failed`` code.
+    """
+    claim = _make_claim()
+    fetch = AsyncMock(return_value=claim)
+    verify = MagicMock(side_effect=RuntimeError("launchctl unavailable"))
+
+    result = await verify_substrate_at_resume(
+        claim.agent_id, peer_pid=12345,
+        fetch_fn=fetch, verify_fn=verify,
+    )
+    assert result is not None
+    assert result.accepted is False
+    assert result.failure_code == "attestation_failed"
+    assert "launchctl unavailable" in result.reason
+
+
+# =============================================================================
+# anyio-asyncio integration: verify is offloaded via run_in_executor
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_verify_runs_in_executor_not_in_event_loop() -> None:
+    """The synchronous verify call must run on a thread, not the event loop.
+
+    Verified by checking that the verify callable observes a different
+    thread ident than the calling coroutine.
+    """
+    import threading
+
+    main_thread_ident = threading.get_ident()
+    observed: dict[str, Any] = {}
+
+    def fake_verify(claim, peer_pid, **kwargs):
+        observed["thread_ident"] = threading.get_ident()
+        return VerificationResult(accepted=True, reason="ok")
+
+    fetch = AsyncMock(return_value=_make_claim())
+
+    result = await verify_substrate_at_resume(
+        "uuid", peer_pid=12345,
+        fetch_fn=fetch, verify_fn=fake_verify,
+    )
+    assert result is not None and result.accepted
+    assert "thread_ident" in observed
+    assert observed["thread_ident"] != main_thread_ident, (
+        "verify ran on the main event loop thread; would block anyio task group"
+    )
+
+
+# =============================================================================
+# Cache injection (production uses module-level singleton; tests can override)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_explicit_cache_argument_is_used() -> None:
+    """When ``cache=`` is passed, it overrides the module-level singleton."""
+    claim = _make_claim()
+    fetch = AsyncMock(return_value=claim)
+    accepted = VerificationResult(accepted=True, reason="ok")
+
+    received_caches: list[Any] = []
+
+    def fake_verify(claim, peer_pid, *, pa_module=None, cache=None):
+        received_caches.append(cache)
+        return accepted
+
+    custom_cache = VerifiedPairsCache()
+
+    await verify_substrate_at_resume(
+        claim.agent_id, peer_pid=12345,
+        fetch_fn=fetch, verify_fn=fake_verify, cache=custom_cache,
+    )
+
+    assert len(received_caches) == 1
+    assert received_caches[0] is custom_cache


### PR DESCRIPTION
Fourth in the S19 (M3-v2) implementation sequence. Pure helper module that bridges transport-level peer attestation (PR3c) with handler-side identity-resume decisions. No handler integration yet — that's PR3e.

## What ships

- **`src/substrate/handler_gate.py`** — async helper `verify_substrate_at_resume(agent_uuid, peer_pid)` that:
  - Returns `None` when `peer_pid is None` (HTTP path; verification not possible).
  - Returns `None` when no `core.substrate_claims` row exists (non-substrate-anchored UUID).
  - Awaits `fetch_substrate_claim` (allowed under anyio).
  - Offloads the synchronous `verify_substrate_claim` call (which spawns `launchctl` + ctypes calls) to `loop.run_in_executor` per CLAUDE.md anyio constraint.
  - Returns the `VerificationResult`; caller checks `.accepted` and rejects on failure.
- Module-level `VerifiedPairsCache` singleton — process-lifetime cache for PID-reuse mitigation. Test-only `reset_cache_for_testing()` entrypoint.
- **8 unit tests** covering bypass paths, accept/reject paths, graceful degrade on DB failure, fail-closed on verify exception, anyio-safety check (verify runs on different thread than event loop), and explicit cache injection.

## Why split this from PR3e (handler integration)

The helper is the load-bearing unit that PR3e will call from `_try_resume_by_agent_uuid_direct` in `src/mcp_handlers/identity/handlers.py`. Splitting keeps each PR single-concern: PR3d ships the policy (when to verify, what to do on failure modes), PR3e ships the wiring (where in the resume path to call it).

## Failure-mode design (called out for review)

- **DB lookup raises** → returns `None`. Honest tradeoff: a transient DB failure must NOT lock substrate residents out, AND must NOT over-trust a claim we couldn't read. Caller falls through to existing token-based gating. Tested by `test_db_lookup_raises_degrades_to_none`.
- **Verify raises** → returns synthetic `VerificationResult(accepted=False, failure_code="attestation_failed")`. An unhandled exception in the executor MUST NOT default-accept. Tested by `test_verify_raises_returns_synthetic_rejection`.
- **anyio safety** → `test_verify_runs_in_executor_not_in_event_loop` asserts the verify callable observes a different thread ident than the calling coroutine. Without this, the synchronous `subprocess.run(["launchctl", "list"])` would block the MCP anyio task group.

## Verification

- 8 unit tests pass with mocked `fetch_fn` / `verify_fn`. No DB / no subprocess / no ctypes calls under test.
- Full suite: 7350 passed, 33 skipped, no regressions (one transient flake on `test_migration_018_bootstrap_synthetic` resolved on rerun — known DB-state-ordering quirk in unrelated migration test).

## What this PR does NOT do

- No handler integration (PR3e).
- No PATH 2.8 substrate-anchored gate (PR4).
- No SDK changes (PR5).
- No per-resident migration (PR6).