### PR TITLE
fix(kg): UTC-normalize timestamps and pin writer label at write time

Bug A: get/search rebuilt 'by:' from current agent metadata, erasing
the original-writer label when a new session resumed the same UUID.
Now we capture writer_label_at_write + writer_session_id_at_write in
provenance at write time, and prefer those in get/search responses.
Falls back to live resolve for legacy rows.

Bug B: discovery id was generated with naive datetime.now() (server
local TZ) while created_at landed in UTC via PG TIMESTAMPTZ — a 6h
drift inside one row, plus broken lex-sort across multi-tz fleets.
Replaced with datetime.now(timezone.utc) at every KG write site;
fixed staleness comparison to handle aware-vs-naive uniformly.

Resolves KG discovery 2026-04-25T20:40:57.605977.

### DIFF
--- a/src/knowledge_graph.py
+++ b/src/knowledge_graph.py
@@ -11,7 +11,7 @@ Backends:
 
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Literal, Any
-from datetime import datetime
+from datetime import datetime, timezone
 import os
 import re
 import asyncio
@@ -84,7 +84,7 @@ class DiscoveryNode:
     details: str = ""
     tags: List[str] = field(default_factory=list)
     severity: Optional[str] = None  # "low", "medium", "high", "critical"
-    timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
+    timestamp: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
     status: str = "open"  # "open", "resolved", "archived", "disputed"
     related_to: List[str] = field(default_factory=list)  # IDs of related discoveries (backward compat)
     response_to: Optional[ResponseTo] = None  # Typed response to parent discovery
@@ -177,7 +177,7 @@ class DiscoveryNode:
             details=data.get("details", ""),
             tags=data.get("tags", []),
             severity=data.get("severity"),
-            timestamp=data.get("timestamp", datetime.now().isoformat()),
+            timestamp=data.get("timestamp", datetime.now(timezone.utc).isoformat()),
             status=data.get("status", "open"),
             related_to=data.get("related_to", []),
             response_to=response_to,

--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -14,7 +14,19 @@ Claude Desktop compatible: All operations are async and non-blocking.
 
 from typing import Dict, Any, Sequence, Optional
 from mcp.types import TextContent
-from datetime import datetime
+from datetime import datetime, timezone
+
+
+def _utc_now_iso() -> str:
+    """Return current UTC time as an offset-aware ISO 8601 string.
+
+    Bug fix 2026-04-25: write-path timestamps were generated with
+    naive ``datetime.now()`` (server local TZ), causing ``id`` to drift
+    from ``created_at`` (UTC, via PG TIMESTAMPTZ) by the server's offset
+    and breaking lex-sort across multi-tz fleets. All KG write-path
+    timestamps must be UTC-aware.
+    """
+    return datetime.now(timezone.utc).isoformat()
 import time
 from ..utils import success_response, error_response, require_argument, require_agent_id, require_registered_agent
 from ..decorators import mcp_tool
@@ -115,9 +127,13 @@ def _compute_staleness_warning(discovery, current_server_version: str) -> Option
     warning_parts = []
 
     # Age-based check: >60 days old
+    # Compare in UTC. Legacy rows may have naive timestamps (treat as UTC);
+    # post-2026-04-25 rows are UTC-aware.
     try:
         created = datetime.fromisoformat(discovery.timestamp) if isinstance(discovery.timestamp, str) else discovery.timestamp
-        age_days = (datetime.now() - created).days
+        if created.tzinfo is None:
+            created = created.replace(tzinfo=timezone.utc)
+        age_days = (datetime.now(timezone.utc) - created).days
         if age_days > 60:
             warning_parts.append(f"This entry is {age_days} days old and still open.")
     except (ValueError, TypeError):
@@ -432,7 +448,7 @@ async def handle_store_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[Te
             raw_details = raw_details[:MAX_DETAILS_LEN] + "... [truncated]"
         
         # Create discovery node
-        discovery_id = datetime.now().isoformat()
+        discovery_id = _utc_now_iso()
         
         # Parse response_to if provided (typed response to parent discovery)
         response_to = None
@@ -499,8 +515,30 @@ async def handle_store_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[Te
                         "total_updates": meta.total_updates,
                         **monitor_state
                     },
-                    "captured_at": datetime.now().isoformat(),
+                    "captured_at": _utc_now_iso(),
                 }
+
+                # Bug A fix 2026-04-25: pin writer attribution at write time.
+                # `agent_id` (UUID) is stable across resumed sessions; the
+                # display_name and active session_id are not. Without this,
+                # search/get rebuilds `by:` from current metadata and erases
+                # which session/label actually authored each row.
+                writer_label = (
+                    getattr(meta, "display_name", None)
+                    or getattr(meta, "label", None)
+                    or getattr(meta, "structured_id", None)
+                    or agent_id
+                )
+                provenance["writer_label_at_write"] = writer_label
+                writer_session = arguments.get("client_session_id")
+                if not writer_session:
+                    try:
+                        from ..context import get_context_client_session_id
+                        writer_session = get_context_client_session_id()
+                    except Exception:
+                        writer_session = None
+                if writer_session:
+                    provenance["writer_session_id_at_write"] = writer_session
 
                 # CAPTURE PROVENANCE CHAIN: Full lineage context
                 try:
@@ -539,7 +577,7 @@ async def handle_store_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[Te
 
         # Ensure system_version is always in provenance, even if agent metadata was unavailable
         if provenance is None:
-            provenance = {"system_version": system_version, "captured_at": datetime.now().isoformat()}
+            provenance = {"system_version": system_version, "captured_at": _utc_now_iso()}
         elif "system_version" not in provenance:
             provenance["system_version"] = system_version
 
@@ -1035,14 +1073,26 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
         current_server_version = getattr(mcp_server, "SERVER_VERSION", "unknown")
         discovery_list = []
         for d in results:
-            agent_display = _resolve_agent_display(d.agent_id)
-            display_name = agent_display.get("display_name", d.agent_id)
+            # Bug A fix 2026-04-25: prefer write-time writer label from
+            # provenance over live resolve. Multiple sessions may resume
+            # the same agent UUID; live resolve would rewrite past `by:`
+            # values to the current session's display_name.
+            prov = d.provenance if isinstance(d.provenance, dict) else None
+            display_name = (prov or {}).get("writer_label_at_write")
+            if not display_name:
+                agent_display = _resolve_agent_display(d.agent_id)
+                display_name = agent_display.get("display_name", d.agent_id)
 
             # Build dict with display_name first for prominence
             d_dict = {
                 "by": display_name,  # WHO - first for attribution
                 "summary": d.summary,  # WHAT - second for context
             }
+
+            # Surface write-time session id when present (audit trail)
+            session_at_write = (prov or {}).get("writer_session_id_at_write")
+            if session_at_write:
+                d_dict["session_id_at_write"] = session_at_write
 
             # Add remaining fields from discovery
             full_dict = d.to_dict(include_details=include_details)
@@ -1060,8 +1110,8 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
             d_dict["_agent_id"] = d.agent_id
 
             # Surface system_version from provenance (Task 1: KG version coupling)
-            if d.provenance and isinstance(d.provenance, dict):
-                d_dict["system_version"] = d.provenance.get("system_version")
+            if prov:
+                d_dict["system_version"] = prov.get("system_version")
             else:
                 d_dict["system_version"] = None  # Pre-v2.8.0 discovery
 
@@ -1231,7 +1281,7 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
             async def _touch_referenced(ids):
                 try:
                     g = await get_knowledge_graph()
-                    now_iso = datetime.now().isoformat()
+                    now_iso = _utc_now_iso()
                     for did in ids:
                         await g.update_discovery(did, {"last_referenced": now_iso})
                 except Exception:
@@ -1265,13 +1315,18 @@ async def handle_get_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[Text
 
         # UX FIX (Dec 2025): Display name FIRST for human readability
         agent_display = arguments.get("_agent_display") or _resolve_agent_display(agent_id)
-        display_name = agent_display.get("display_name", agent_id)
+        live_display_name = agent_display.get("display_name", agent_id)
         discovery_list = []
         for d in discoveries:
             full_dict = d.to_dict(include_details=include_details)
+            # Bug A fix 2026-04-25: prefer write-time label over live resolve.
+            # The same UUID may have been written under multiple display_names
+            # across resumed sessions; live resolve would erase that history.
+            prov = d.provenance if isinstance(d.provenance, dict) else None
+            row_display_name = (prov or {}).get("writer_label_at_write") or live_display_name
             # Build dict with display_name first for prominence
             d_dict = {
-                "by": display_name,  # WHO - first for attribution
+                "by": row_display_name,  # WHO - first for attribution
                 "summary": d.summary,  # WHAT - second for context
                 "id": full_dict.get("id"),
                 "type": full_dict.get("type"),
@@ -1279,6 +1334,9 @@ async def handle_get_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[Text
                 "tags": full_dict.get("tags", []),
                 "created_at": full_dict.get("created_at"),
             }
+            session_at_write = (prov or {}).get("writer_session_id_at_write")
+            if session_at_write:
+                d_dict["session_id_at_write"] = session_at_write
             if include_details and full_dict.get("details"):
                 d_dict["details"] = full_dict.get("details")
             d_dict["_agent_id"] = d.agent_id
@@ -1409,7 +1467,7 @@ async def handle_update_discovery_status_graph(arguments: Dict[str, Any]) -> Seq
                     }
                 )]
         
-        updates = {"updated_at": datetime.now().isoformat()}
+        updates = {"updated_at": _utc_now_iso()}
 
         if status is not None:
             VALID_STATUSES = {"open", "resolved", "archived", "disputed", "closed", "wont_fix", "superseded"}
@@ -1418,7 +1476,7 @@ async def handle_update_discovery_status_graph(arguments: Dict[str, Any]) -> Seq
                 return [error_response(f"Invalid status '{status}'. Valid: {sorted(VALID_STATUSES)}")]
             updates["status"] = status
             if status == "resolved":
-                updates["resolved_at"] = datetime.now().isoformat()
+                updates["resolved_at"] = _utc_now_iso()
 
         if summary is not None:
             updates["summary"] = str(summary)
@@ -1558,7 +1616,7 @@ async def handle_get_discovery_details(arguments: Dict[str, Any]) -> Sequence[Te
 
         async def _touch(did):
             try:
-                await graph.update_discovery(did, {"last_referenced": datetime.now().isoformat()})
+                await graph.update_discovery(did, {"last_referenced": _utc_now_iso()})
             except Exception:
                 pass
 
@@ -1645,7 +1703,7 @@ async def _handle_store_knowledge_graph_batch(arguments: Dict[str, Any], agent_i
                     details = details[:MAX_DETAILS_LEN] + "... [truncated]"
                 
                 # Create discovery node
-                discovery_id = datetime.now().isoformat()
+                discovery_id = _utc_now_iso()
                 
                 # Parse response_to if provided
                 response_to = None
@@ -1823,7 +1881,7 @@ async def handle_answer_question(arguments: Dict[str, Any]) -> Sequence[TextCont
 
         # Create answer linked to the question
         answer = DiscoveryNode(
-            id=datetime.now().isoformat(),
+            id=_utc_now_iso(),
             agent_id=agent_id,
             type="answer",
             summary=f"Answer: {answer_text[:200]}..." if len(answer_text) > 200 else f"Answer: {answer_text}",
@@ -1846,7 +1904,7 @@ async def handle_answer_question(arguments: Dict[str, Any]) -> Sequence[TextCont
         if arguments.get("resolve_question", False):
             await graph.update_discovery(matched_question.id, {
                 "status": "resolved",
-                "resolved_at": datetime.now().isoformat()
+                "resolved_at": _utc_now_iso()
             })
 
         return success_response({
@@ -1958,7 +2016,7 @@ async def handle_leave_note(arguments: Dict[str, Any]) -> Sequence[TextContent]:
 
         # Create note with minimal ceremony
         note = DiscoveryNode(
-            id=datetime.now().isoformat(),
+            id=_utc_now_iso(),
             agent_id=agent_id,
             type="note",
             summary=note_summary,
@@ -2140,7 +2198,7 @@ async def store_discovery_internal(
     Raises on failure (callers should catch exceptions).
     """
     graph = await get_knowledge_graph()
-    discovery_id = datetime.now().isoformat()
+    discovery_id = _utc_now_iso()
     node = DiscoveryNode(
         id=discovery_id,
         agent_id=agent_id,

--- a/tests/test_kg_store.py
+++ b/tests/test_kg_store.py
@@ -1044,3 +1044,139 @@ class TestLeaveNoteTagPassthrough:
 # Archived filtering in search
 # ============================================================================
 
+
+# ============================================================================
+# Provenance bugs (2026-04-25 dogfood)
+#   Bug A: writer display_name resolved at read time overwrites historical label
+#   Bug B: discovery id generated in local TZ while created_at is UTC
+# ============================================================================
+
+class TestProvenanceWriterLabel:
+    """Bug A: capture writer label + session_id at write time."""
+
+    @pytest.mark.asyncio
+    async def test_store_captures_writer_label_at_write(
+        self, patch_common, registered_agent
+    ):
+        """Discovery provenance records the writer's display_name at write time."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_store_knowledge_graph
+
+        result = await handle_store_knowledge_graph({
+            "agent_id": registered_agent,
+            "summary": "Provenance test write",
+            "discovery_type": "note",
+            "client_session_id": "agent-test-session-001",
+        })
+
+        data = parse_result(result)
+        assert data["success"] is True
+        discovery = mock_graph.add_discovery.call_args[0][0]
+        assert discovery.provenance is not None
+        assert discovery.provenance.get("writer_label_at_write") == "TestAgent"
+        assert discovery.provenance.get("writer_session_id_at_write") == "agent-test-session-001"
+
+    @pytest.mark.asyncio
+    async def test_search_prefers_writer_label_at_write_over_live(
+        self, patch_common, registered_agent
+    ):
+        """Search returns the writer label from provenance, not the current display_name.
+
+        Resuming the same agent UUID under a different display_name must not
+        rewrite history — the `by` field on past discoveries should reflect
+        who wrote them.
+        """
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        # Agent's CURRENT display_name has changed since the historical write
+        mock_mcp_server.agent_metadata[registered_agent].display_name = "RenamedAgent"
+
+        # Historical row: provenance pinned to original writer
+        historical = make_discovery(
+            id="2026-04-25T06:00:00.000000+00:00",
+            agent_id=registered_agent,
+            provenance={
+                "system_version": "2.12.0",
+                "writer_label_at_write": "OriginalSession",
+                "writer_session_id_at_write": "agent-original-001",
+                "captured_at": "2026-04-25T06:00:00.000000+00:00",
+            },
+        )
+        mock_graph.full_text_search = AsyncMock(return_value=[historical])
+
+        result = await handle_search_knowledge_graph({
+            "agent_id": registered_agent,
+            "query": "anything",
+        })
+
+        data = parse_result(result)
+        assert data["success"] is True
+        assert len(data["discoveries"]) == 1
+        assert data["discoveries"][0]["by"] == "OriginalSession"
+        assert data["discoveries"][0].get("session_id_at_write") == "agent-original-001"
+
+    @pytest.mark.asyncio
+    async def test_search_falls_back_to_live_for_legacy_rows(
+        self, patch_common, registered_agent
+    ):
+        """Legacy rows without writer_label_at_write fall back to live resolution."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        legacy = make_discovery(
+            id="2025-12-01T12:00:00",
+            agent_id=registered_agent,
+            provenance={"system_version": "2.10.0"},  # no writer_label_at_write
+        )
+        mock_graph.full_text_search = AsyncMock(return_value=[legacy])
+
+        result = await handle_search_knowledge_graph({
+            "agent_id": registered_agent,
+            "query": "anything",
+        })
+
+        data = parse_result(result)
+        assert data["success"] is True
+        assert data["discoveries"][0]["by"] == "TestAgent"  # live-resolved fallback
+
+
+class TestUtcTimestamps:
+    """Bug B: write-path timestamps must be UTC, not local TZ."""
+
+    @pytest.mark.asyncio
+    async def test_store_emits_utc_timestamps(
+        self, patch_common, registered_agent
+    ):
+        """Discovery id, timestamp, and provenance.captured_at are all UTC-aware."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_store_knowledge_graph
+        from datetime import datetime
+
+        result = await handle_store_knowledge_graph({
+            "agent_id": registered_agent,
+            "summary": "UTC timestamp test",
+            "discovery_type": "note",
+        })
+
+        data = parse_result(result)
+        assert data["success"] is True
+        discovery = mock_graph.add_discovery.call_args[0][0]
+
+        # All three timestamps must parse as UTC-aware (offset present)
+        for label, value in (
+            ("id", discovery.id),
+            ("timestamp", discovery.timestamp),
+            ("captured_at", discovery.provenance.get("captured_at")),
+        ):
+            assert value, f"{label} is empty"
+            parsed = datetime.fromisoformat(value)
+            assert parsed.tzinfo is not None, f"{label} is TZ-naive: {value}"
+            assert parsed.utcoffset().total_seconds() == 0, (
+                f"{label} is not UTC: {value}"
+            )
+
+        # id and captured_at represent the same instant (within a few ms)
+        id_dt = datetime.fromisoformat(discovery.id)
+        captured_dt = datetime.fromisoformat(discovery.provenance["captured_at"])
+        assert abs((id_dt - captured_dt).total_seconds()) < 1.0


### PR DESCRIPTION
Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.