### PR TITLE
fix(health-probe): bounded parallel scan for redis_cache.keys

### DIFF
--- a/src/services/runtime_queries.py
+++ b/src/services/runtime_queries.py
@@ -373,6 +373,27 @@ async def get_governance_metrics_data(agent_id: str, arguments: Dict[str, Any], 
     return standardized_metrics
 
 
+# Per-prefix scan ceiling for the `redis_cache.keys` health-check section.
+# At 10000 keys per prefix and a typical SCAN cost of <0.1s the probe stays
+# well inside the 15s budget; values past the cap are reported as "{cap}+".
+_HEALTH_KEYS_CAP = 10000
+_HEALTH_KEYS_SCAN_PAGE = 500
+
+
+async def _bounded_scan_count(redis, pattern: str, *, cap: int = _HEALTH_KEYS_CAP, page: int = _HEALTH_KEYS_SCAN_PAGE):
+    """Count keys matching `pattern` without materializing the cursor.
+
+    Returns the integer count, or `f"{cap}+"` once the ceiling is hit.
+    Caller should run multiple invocations under `asyncio.gather` for parallel fan-out.
+    """
+    n = 0
+    async for _ in redis.scan_iter(match=pattern, count=page):
+        n += 1
+        if n >= cap:
+            return f"{cap}+"
+    return n
+
+
 async def get_health_check_data(arguments: Dict[str, Any], server=None) -> Dict[str, Any]:
     """Build plain health-check data for operators and transports."""
     server = server or mcp_server
@@ -485,12 +506,27 @@ async def get_health_check_data(arguments: Dict[str, Any], server=None) -> Dict[
                         "note": "Keyspace hit/miss counts cover the whole Redis instance, not just session_cache lookups.",
                     }
                     try:
-                        checks["redis_cache"]["keys"] = {
-                            "sessions": len([k async for k in redis.scan_iter(match="session:*", count=100)]),
-                            "rate_limits": len([k async for k in redis.scan_iter(match="rate_limit:*", count=100)]),
-                            "metadata": len([k async for k in redis.scan_iter(match="agent_meta:*", count=100)]),
-                            "locks": len([k async for k in redis.scan_iter(match="lock:*", count=100)]),
-                        }
+                        # Count keys per prefix in parallel with a per-prefix ceiling.
+                        # Sequential materializing scans (`len([k async for k in scan_iter(...)])`)
+                        # blew the 15s probe budget once `session:*` and `agent_meta:*` grew past
+                        # ~10K keys combined. `_bounded_scan_count` streams the cursor without
+                        # materializing the key list and short-circuits at `cap`, returning
+                        # `f"{cap}+"` so operators still see an "above ceiling" signal.
+                        labels = ("sessions", "rate_limits", "metadata", "locks")
+                        patterns = ("session:*", "rate_limit:*", "agent_meta:*", "lock:*")
+                        # Read cap/page from module namespace so test patches and operator
+                        # overrides take effect without per-call argument plumbing.
+                        results = await asyncio.gather(
+                            *(_bounded_scan_count(redis, p, cap=_HEALTH_KEYS_CAP, page=_HEALTH_KEYS_SCAN_PAGE) for p in patterns),
+                            return_exceptions=True,
+                        )
+                        keys_info: Dict[str, Any] = {}
+                        for label, value in zip(labels, results):
+                            if isinstance(value, BaseException):
+                                keys_info[f"{label}_error"] = str(value)
+                            else:
+                                keys_info[label] = value
+                        checks["redis_cache"]["keys"] = keys_info
                     except Exception as e:
                         checks["redis_cache"]["keys_error"] = str(e)
             except Exception as e:

--- a/tests/test_admin_handlers.py
+++ b/tests/test_admin_handlers.py
@@ -817,6 +817,111 @@ class TestHealthCheck:
             assert data["checks"]["identity_continuity"]["redis_present"] is True
 
     @pytest.mark.asyncio
+    async def test_bounded_scan_count_returns_int_below_cap(self):
+        """Counts under the cap are returned as plain ints."""
+        from src.services.runtime_queries import _bounded_scan_count
+
+        class FakeRedis:
+            async def scan_iter(self, match=None, count=None):
+                for i in range(7):
+                    yield f"{match[:-1]}{i}"
+
+        n = await _bounded_scan_count(FakeRedis(), "session:*", cap=100)
+        assert n == 7
+
+    @pytest.mark.asyncio
+    async def test_bounded_scan_count_caps_and_short_circuits(self):
+        """At-or-above cap → returns f'{cap}+' AND stops iterating (no full keyspace materialization)."""
+        from src.services.runtime_queries import _bounded_scan_count
+
+        yielded = 0
+        cap = 50
+
+        class FakeRedis:
+            async def scan_iter(self, match=None, count=None):
+                nonlocal yielded
+                # Source has way more than `cap` keys; bounded helper must NOT exhaust it.
+                for i in range(cap * 100):
+                    yielded += 1
+                    yield f"k{i}"
+
+        result = await _bounded_scan_count(FakeRedis(), "k*", cap=cap)
+        assert result == f"{cap}+"
+        # Helper should have stopped pulling from the iterator at the cap.
+        # Allow one extra (the iteration that triggered the early return).
+        assert yielded <= cap + 1, f"helper exhausted iterator: yielded={yielded}, cap={cap}"
+
+    @pytest.mark.asyncio
+    async def test_bounded_scan_count_runs_in_parallel_for_health_check(self, mock_mcp_server, patch_context_agent_id):
+        """Health-check redis_cache.keys section uses parallel bounded counts, not sequential materialization.
+
+        Regression for KG 2026-04-11T11:28:05.774339: the old `len([k async for k in scan_iter(...)])`
+        materialization x4 sequentially blew the 15s probe budget once `session:*` and `agent_meta:*`
+        grew past ~10K combined keys. The fix runs four bounded scans in parallel via asyncio.gather.
+        """
+        mock_audit = MagicMock()
+        mock_audit.log_file = MagicMock()
+        mock_audit.log_file.exists.return_value = True
+
+        mock_db = AsyncMock()
+        mock_db.health_check = AsyncMock(return_value={"status": "healthy"})
+        mock_db.init = AsyncMock()
+
+        mock_cal = MagicMock()
+        mock_cal.get_pending_updates.return_value = 0
+
+        session_cache = AsyncMock()
+        session_cache.health_check = AsyncMock(return_value={"status": "healthy", "backend": "redis"})
+        dist_lock = AsyncMock()
+        dist_lock.health_check = AsyncMock(return_value={"status": "healthy", "backend": "redis"})
+
+        # Per-pattern key counts — chosen to exercise both the under-cap and over-cap paths.
+        # `session:*` is set just over the cap (via the test patching cap=10) so the helper must
+        # short-circuit; the others stay below cap and return real counts.
+        per_pattern_keys = {
+            "session:*": 25,        # over cap (10) → "10+"
+            "rate_limit:*": 3,
+            "agent_meta:*": 5,
+            "lock:*": 0,
+        }
+
+        raw_redis = AsyncMock()
+        raw_redis.info = AsyncMock(return_value={"keyspace_hits": 5, "keyspace_misses": 1, "total_commands_processed": 12})
+
+        async def _scan_iter(match=None, count=None):
+            for i in range(per_pattern_keys.get(match, 0)):
+                yield f"{match[:-1]}{i}"
+
+        raw_redis.scan_iter = _scan_iter
+
+        with patch("src.mcp_handlers.admin.handlers.mcp_server", mock_mcp_server), \
+             patch("src.calibration.calibration_checker", mock_cal), \
+             patch("src.telemetry.telemetry_collector", MagicMock()), \
+             patch("src.audit_log.audit_logger", mock_audit), \
+             patch("src.db.get_db", return_value=mock_db), \
+             patch("src.embeddings.embeddings_available", return_value=True), \
+             patch("src.calibration_db.calibration_health_check_async",
+                   new_callable=AsyncMock,
+                   return_value={"status": "healthy", "backend": "postgres"}), \
+             patch("src.audit_db.audit_health_check_async",
+                   new_callable=AsyncMock,
+                   return_value={"status": "healthy", "backend": "postgres"}), \
+             patch("src.cache.is_redis_available", return_value=True), \
+             patch("src.cache.get_session_cache", return_value=session_cache), \
+             patch("src.cache.get_distributed_lock", return_value=dist_lock), \
+             patch("src.cache.get_redis", new_callable=AsyncMock, return_value=raw_redis), \
+             patch("src.services.runtime_queries._HEALTH_KEYS_CAP", 10):
+
+            from src.services.runtime_queries import get_health_check_data
+            data = await get_health_check_data({"lite": False})
+
+        keys = data["checks"]["redis_cache"]["keys"]
+        assert keys["sessions"] == "10+", f"expected over-cap marker, got {keys['sessions']!r}"
+        assert keys["rate_limits"] == 3
+        assert keys["metadata"] == 5
+        assert keys["locks"] == 0
+
+    @pytest.mark.asyncio
     async def test_health_check_knowledge_graph_lifecycle_warning(self, mock_mcp_server, patch_context_agent_id):
         """KG health should degrade to warning when lifecycle cleanup recently failed."""
         mock_audit = MagicMock()


### PR DESCRIPTION
## Summary
- Replaces 4 sequential materializing `redis.scan_iter` sweeps in `get_health_check_data` with parallel bounded counters via `asyncio.gather`
- Adds `_bounded_scan_count` helper (cap=10000 keys/prefix, page=500) — streams the cursor without building a Python list and short-circuits at the cap, returning `"{cap}+"`
- Per-prefix exception isolation: a single broken pattern reports `{prefix}_error` instead of zeroing the whole `keys` block

## Why
KG `2026-04-11T11:28:05.774339`. Production has ~9.4K `session:*` + ~3.4K `agent_meta:*` keys. The old pattern (`len([k async for k in scan_iter(..., count=100)])` × 4 sequential) blew the 15s probe budget every cycle (`mcp_server_error.log` shows `[HEALTH_PROBE] Probe exceeded 15.0s budget` repeating). Stale snapshot + a worker burned per cycle.

The fix-shape was bundled into KG `2026-04-11T11:27:51.461745` (broadcaster) and `2026-04-11T11:27:40.710283` (loadAgents) — both already in master via commit `1a2d8b0b`. This is the third sibling, the only one that wasn't pre-fixed.

## Test plan
- [x] `tests/test_admin_handlers.py::TestHealthCheck::test_bounded_scan_count_returns_int_below_cap` — under-cap returns int
- [x] `tests/test_admin_handlers.py::TestHealthCheck::test_bounded_scan_count_caps_and_short_circuits` — at-cap returns `"{cap}+"` AND stops iterating (no full keyspace materialization, asserted via yielded counter)
- [x] `tests/test_admin_handlers.py::TestHealthCheck::test_bounded_scan_count_runs_in_parallel_for_health_check` — end-to-end through `get_health_check_data` with `_HEALTH_KEYS_CAP` patched to 10, verifies over-cap session prefix shows `"10+"` while smaller ones show real counts
- [x] Existing `test_health_check_with_redis` and `test_health_check_knowledge_graph_lifecycle_warning` still pass
- [x] Full test suite: 7374 passed, 33 skipped via `./scripts/dev/test-cache.sh`
- [ ] Soak: after merge + service restart, watch `data/logs/mcp_server_error.log` for ≥30 min — `[HEALTH_PROBE] Probe exceeded` should stop firing