### PR TITLE
S19 PR5: GovernanceClient UDS transport — uds_path arg + UNITARES_UDS_SOCKET env var

### DIFF
--- a/agents/sdk/src/unitares_sdk/client.py
+++ b/agents/sdk/src/unitares_sdk/client.py
@@ -7,6 +7,7 @@ import asyncio
 import anyio
 import json
 import logging
+import os
 from typing import Any
 
 import httpx
@@ -55,10 +56,22 @@ class GovernanceClient:
         mcp_url: str = "http://127.0.0.1:8767/mcp/",
         timeout: float = 30.0,
         retry_delay: float = 3.0,
+        uds_path: str | None = None,
     ):
+        # S19 substrate-anchored residents (Vigil, Sentinel, Chronicler)
+        # connect over Unix-domain socket so the kernel attests their PID
+        # to the governance MCP. Set ``uds_path`` explicitly OR set the
+        # ``UNITARES_UDS_SOCKET`` env var (the launchd plist is the
+        # documented place to set it). Passing ``uds_path`` overrides the
+        # env var so tests can pin a value without polluting the
+        # environment.
+        if uds_path is None:
+            uds_path = os.environ.get("UNITARES_UDS_SOCKET") or None
+
         self.mcp_url = mcp_url
         self.timeout = timeout
         self.retry_delay = retry_delay
+        self.uds_path = uds_path
 
         # Session state — updated after identity/onboard responses
         self.client_session_id: str | None = None
@@ -83,7 +96,22 @@ class GovernanceClient:
         scope in a different task than it was entered in" crash that killed
         the sentinel repeatedly (KG 2026-04-19T00:51:46).
         """
-        self._http_client = httpx.AsyncClient(http2=False, timeout=self.timeout)
+        # S19: when uds_path is set, route the underlying HTTP requests over
+        # a Unix-domain socket via httpx.AsyncHTTPTransport(uds=...). The MCP
+        # client still speaks HTTP semantically; only the network boundary
+        # changes. The Host header in mcp_url is informational under UDS
+        # (the kernel resolves the connection via the socket file path).
+        if self.uds_path:
+            transport = httpx.AsyncHTTPTransport(uds=self.uds_path)
+            self._http_client = httpx.AsyncClient(
+                http2=False, timeout=self.timeout, transport=transport,
+            )
+            logger.info(
+                "[SDK] connecting via UDS at %s (substrate-attestation transport)",
+                self.uds_path,
+            )
+        else:
+            self._http_client = httpx.AsyncClient(http2=False, timeout=self.timeout)
         try:
             cm = streamable_http_client(self.mcp_url, http_client=self._http_client)
             read, write, _ = await cm.__aenter__()

--- a/agents/sdk/tests/test_client_uds.py
+++ b/agents/sdk/tests/test_client_uds.py
@@ -1,0 +1,141 @@
+"""S19 PR5: GovernanceClient UDS transport selection.
+
+Tests cover:
+- Default (no uds_path, no env): HTTP transport, no UDS configuration.
+- Explicit ``uds_path=`` parameter: UDS transport selected.
+- ``UNITARES_UDS_SOCKET`` env var: UDS transport selected.
+- Explicit ``uds_path=`` overrides the env var (so tests / config can pin).
+- Connect path actually constructs ``httpx.AsyncHTTPTransport(uds=...)``.
+
+Connection-establishment paths are not exercised end-to-end here (would
+require a running governance MCP). The focus is the transport-selection
+logic that PR5 introduces; the actual UDS connection round-trip was
+verified end-to-end by ``tests/test_uds_listener.py`` in PR3c.
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from unitares_sdk.client import GovernanceClient
+
+
+# =============================================================================
+# Construction-time transport selection
+# =============================================================================
+
+
+def test_default_no_uds_path_when_no_arg_no_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("UNITARES_UDS_SOCKET", raising=False)
+    client = GovernanceClient()
+    assert client.uds_path is None
+
+
+def test_explicit_uds_path_argument_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("UNITARES_UDS_SOCKET", raising=False)
+    client = GovernanceClient(uds_path="/tmp/explicit.sock")
+    assert client.uds_path == "/tmp/explicit.sock"
+
+
+def test_env_var_picked_up_when_no_explicit_arg(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("UNITARES_UDS_SOCKET", "/Users/cirwel/.unitares/governance.sock")
+    client = GovernanceClient()
+    assert client.uds_path == "/Users/cirwel/.unitares/governance.sock"
+
+
+def test_explicit_arg_overrides_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tests / per-call overrides must beat the env-var default."""
+    monkeypatch.setenv("UNITARES_UDS_SOCKET", "/from/env.sock")
+    client = GovernanceClient(uds_path="/from/explicit.sock")
+    assert client.uds_path == "/from/explicit.sock"
+
+
+def test_empty_env_var_treated_as_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty string env var (e.g. ``UNITARES_UDS_SOCKET=``) is treated as
+    unset, not as the literal empty string."""
+    monkeypatch.setenv("UNITARES_UDS_SOCKET", "")
+    client = GovernanceClient()
+    assert client.uds_path is None
+
+
+# =============================================================================
+# Connect path constructs httpx.AsyncHTTPTransport(uds=...)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_connect_builds_uds_transport_when_uds_path_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When uds_path is set, connect() constructs httpx with UDS transport."""
+    captured: dict[str, object] = {}
+
+    real_async_client = httpx.AsyncClient
+
+    def capturing_client(*args, **kwargs):
+        captured["transport"] = kwargs.get("transport")
+        captured["http2"] = kwargs.get("http2")
+        return real_async_client(*args, **kwargs)
+
+    # Stub out the MCP transport setup; we only care that the httpx config
+    # was right at construction time. The streamable_http_client returns
+    # a context manager whose __aenter__ returns (read, write, _).
+    mock_cm = AsyncMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=(MagicMock(), MagicMock(), None))
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session_cm = AsyncMock()
+    mock_session = AsyncMock()
+    mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("unitares_sdk.client.httpx.AsyncClient", side_effect=capturing_client), \
+         patch("unitares_sdk.client.streamable_http_client", return_value=mock_cm), \
+         patch("unitares_sdk.client.ClientSession", return_value=mock_session_cm):
+        client = GovernanceClient(uds_path="/tmp/test-s19.sock")
+        await client.connect()
+        try:
+            transport = captured.get("transport")
+            assert isinstance(transport, httpx.AsyncHTTPTransport), (
+                f"expected AsyncHTTPTransport for UDS, got {type(transport).__name__}"
+            )
+        finally:
+            await client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_connect_skips_uds_transport_when_no_uds_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When uds_path is None, connect() builds the default httpx client
+    without the explicit transport= kwarg (matches pre-PR5 behavior)."""
+    monkeypatch.delenv("UNITARES_UDS_SOCKET", raising=False)
+    captured: dict[str, object] = {"transport_set": False}
+
+    real_async_client = httpx.AsyncClient
+
+    def capturing_client(*args, **kwargs):
+        captured["transport_set"] = "transport" in kwargs and kwargs["transport"] is not None
+        return real_async_client(*args, **kwargs)
+
+    mock_cm = AsyncMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=(MagicMock(), MagicMock(), None))
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session_cm = AsyncMock()
+    mock_session = AsyncMock()
+    mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("unitares_sdk.client.httpx.AsyncClient", side_effect=capturing_client), \
+         patch("unitares_sdk.client.streamable_http_client", return_value=mock_cm), \
+         patch("unitares_sdk.client.ClientSession", return_value=mock_session_cm):
+        client = GovernanceClient()
+        await client.connect()
+        try:
+            assert captured["transport_set"] is False
+        finally:
+            await client.disconnect()


### PR DESCRIPTION
Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.