### PR TITLE
fix(kg): semantic routing transparency, FTS AND default, scope clarity, provenance.source (#165)

### DIFF
--- a/src/db/mixins/knowledge_graph.py
+++ b/src/db/mixins/knowledge_graph.py
@@ -11,12 +11,19 @@ from src.logging_utils import get_logger
 logger = get_logger(__name__)
 
 
-def _or_default_query(query: str) -> str:
-    """Convert multi-term query to OR-default for websearch_to_tsquery.
+def _apply_operator(query: str, operator: str = "AND") -> str:
+    """Join multi-term queries with the given operator for websearch_to_tsquery.
 
-    Preserves quoted phrases, existing operators (OR, AND), and negations (-).
-    Single-term queries are returned unchanged.
+    Preserves quoted phrases, existing operators, and negations (-). Single-term
+    queries are returned unchanged. AND is the default — earlier OR-default
+    drowned paraphrased queries in common-token noise (issue #165 #1).
+
+    Callers wanting recall over precision pass operator="OR", typically as a
+    fallback after AND returns zero hits.
     """
+    op = operator.upper()
+    if op not in ("AND", "OR"):
+        op = "AND"
     # If query already contains explicit operators, leave as-is
     if re.search(r'\b(OR|AND)\b', query):
         return query
@@ -24,7 +31,14 @@ def _or_default_query(query: str) -> str:
     tokens = [m.group() for m in re.finditer(r'"[^"]*"|\S+', query)]
     if len(tokens) <= 1:
         return query
-    return ' OR '.join(tokens)
+    return f' {op} '.join(tokens)
+
+
+# Backwards-compat shim. Older imports expect _or_default_query; route them
+# through the new operator-aware helper with operator="OR" so behavior is
+# identical to the pre-#165 implementation.
+def _or_default_query(query: str) -> str:
+    return _apply_operator(query, operator="OR")
 
 
 class KnowledgeGraphMixin:
@@ -163,18 +177,20 @@ class KnowledgeGraphMixin:
         self,
         query: str,
         limit: int = 20,
+        operator: str = "AND",
     ) -> List[Dict[str, Any]]:
         """Full-text search using PostgreSQL tsvector.
 
-        Multi-term queries default to OR (any term matches).
-        Use explicit "AND" between terms for all-must-match behavior.
-        Quoted phrases are preserved as-is.
+        Multi-term queries default to AND (all terms must match) — switched
+        from OR-default in #165 because OR drowned paraphrased queries in
+        common-token noise. Callers wanting recall over precision pass
+        operator="OR", typically as an automatic fallback after AND returns
+        zero hits (the high-level handler handles that loop). Quoted phrases
+        and explicit AND/OR/NOT in the query are preserved as-is.
         """
-        # Default to OR for multi-term queries so "bug database" finds
-        # documents matching either term, not just both.
         # Use ts_rank_cd (cover density) — considers term proximity and is
         # generally better than vanilla ts_rank on short structured docs.
-        or_query = _or_default_query(query)
+        ts_query = _apply_operator(query, operator=operator)
         async with self.acquire() as conn:
             rows = await conn.fetch("""
                 SELECT *, ts_rank_cd(search_vector, websearch_to_tsquery('english', $1)) as rank
@@ -182,7 +198,7 @@ class KnowledgeGraphMixin:
                 WHERE search_vector @@ websearch_to_tsquery('english', $1)
                 ORDER BY rank DESC, created_at DESC
                 LIMIT $2
-            """, or_query, limit)
+            """, ts_query, limit)
 
             return [self._row_to_discovery_dict(row) for row in rows]
 

--- a/src/knowledge_graph.py
+++ b/src/knowledge_graph.py
@@ -251,6 +251,44 @@ async def get_knowledge_graph() -> Any:
         )
 
 
+def tag_provenance_source(
+    provenance: Optional[Dict[str, Any]],
+    source: str,
+) -> Dict[str, Any]:
+    """Attach `source` to a discovery's provenance without clobbering keys.
+
+    Implicit writers (self_recovery, dialectic_thesis, lifecycle_op) set
+    provenance.source so list/stats can split by_agent into explicit vs
+    implicit buckets — the previous "phantom write" symptom (#165) was a
+    side effect of implicit writes being indistinguishable from caller-
+    intentional ones in the by_agent count.
+
+    Explicit writes (`explicit_store`, `explicit_answer`, `explicit_leave_note`)
+    are tagged the same way for symmetry — that way an absent provenance.source
+    is unambiguously a legacy row.
+    """
+    base: Dict[str, Any] = dict(provenance) if provenance else {}
+    base.setdefault("source", source)
+    return base
+
+
+# Sentinel set for `source` values that count as caller-intentional writes
+# (visible in by_agent_explicit). Anything else — including absent — counts as
+# implicit / legacy / unknown and is bucketed separately.
+EXPLICIT_PROVENANCE_SOURCES = frozenset({
+    "explicit_store",
+    "explicit_answer",
+    "explicit_leave_note",
+})
+
+
+def is_explicit_source(provenance: Optional[Dict[str, Any]]) -> bool:
+    """True when provenance.source declares a caller-intentional write."""
+    if not provenance or not isinstance(provenance, dict):
+        return False
+    return provenance.get("source") in EXPLICIT_PROVENANCE_SOURCES
+
+
 def selected_backend_name() -> str:
     """Resolve the active backend label without instantiating it.
 

--- a/src/knowledge_graph.py
+++ b/src/knowledge_graph.py
@@ -249,3 +249,38 @@ async def get_knowledge_graph() -> Any:
             f"Unknown knowledge backend '{backend}'. "
             f"Set UNITARES_KNOWLEDGE_BACKEND to 'age' or 'postgres'."
         )
+
+
+def selected_backend_name() -> str:
+    """Resolve the active backend label without instantiating it.
+
+    Mirrors the env-var precedence in ``get_knowledge_graph`` so health checks
+    and capability probes can run inside anyio contexts where instantiating
+    the backend would deadlock on asyncpg.
+    """
+    backend = os.getenv("UNITARES_KNOWLEDGE_BACKEND", "auto").strip().lower()
+    db_backend = os.getenv("DB_BACKEND", "postgres").strip().lower()
+    if backend == "auto" and db_backend == "postgres":
+        return "postgres"
+    if backend in ("age", "postgres"):
+        return backend
+    if backend == "auto":
+        return "postgres"
+    return backend
+
+
+def backend_supports_semantic_search() -> bool:
+    """True when the configured backend exposes ``semantic_search``.
+
+    Class-level introspection — does not instantiate or touch the DB. Used by
+    health checks to distinguish embedder availability (the model service is
+    loadable) from semantic-search reachability (the active backend can use it).
+    """
+    name = selected_backend_name()
+    if name == "age":
+        try:
+            from src.storage.knowledge_graph import KnowledgeGraphAGE
+            return hasattr(KnowledgeGraphAGE, "semantic_search")
+        except Exception:
+            return False
+    return False

--- a/src/knowledge_graph_lifecycle.py
+++ b/src/knowledge_graph_lifecycle.py
@@ -354,6 +354,20 @@ class KnowledgeGraphLifecycle:
                 "ephemeral_tags": list(EPHEMERAL_TAGS),
             },
             "philosophy": "Never delete. Archive to cold. Query with include_cold=true.",
+            # Scope marker (#165) — same-name fields on list_knowledge_graph
+            # report a different scope (raw status aggregate, epoch-current).
+            # Surface here so callers comparing the two know which is which.
+            "scope": {
+                "kind": "lifecycle_buckets",
+                "epoch_scope": "all",
+                "including_cold": True,
+                "note": (
+                    "Sums {open, resolved, archived, cold} from per-status "
+                    "queries across all epochs. Does not surface 'superseded' "
+                    "as a top-level bucket (those rows are absorbed by the "
+                    "supersede_chain). Compare with knowledge action=list."
+                ),
+            },
         }
 
 

--- a/src/knowledge_graph_lifecycle.py
+++ b/src/knowledge_graph_lifecycle.py
@@ -282,6 +282,38 @@ class KnowledgeGraphLifecycle:
         logger.info(f"{'[DRY RUN] Would move to cold' if dry_run else 'Moved to cold'} {len(to_cold)} very old archived discoveries")
         return to_cold
 
+    async def _embedding_coverage(self) -> Optional[Dict[str, Any]]:
+        """Coverage of the active embeddings table over all discoveries.
+
+        Lifecycle stats span all epochs and include cold rows, so the
+        coverage here is the cross-corpus answer (compare with list which
+        scopes to current epoch by default). Returns None on failure so the
+        caller can decide whether to surface or omit.
+        """
+        try:
+            from src.db import get_db
+            from src.embeddings import get_active_table_name
+            db = await get_db()
+            table = get_active_table_name()
+            total = await db._pool.fetchval(
+                "SELECT COUNT(*) FROM knowledge.discoveries"
+            ) or 0
+            with_embeddings = await db._pool.fetchval(
+                f"SELECT COUNT(*) FROM knowledge.discoveries d "
+                f"WHERE d.id IN (SELECT discovery_id FROM {table})"
+            ) or 0
+            without = max(0, total - with_embeddings)
+            ratio = round(with_embeddings / total, 4) if total else 0.0
+            return {
+                "with_embeddings": with_embeddings,
+                "without_embeddings": without,
+                "ratio": ratio,
+                "active_table": table,
+            }
+        except Exception as exc:
+            logger.debug(f"lifecycle embedding coverage probe failed: {exc}")
+            return None
+
     async def get_lifecycle_stats(self) -> Dict[str, Any]:
         """Get statistics about discovery lifecycle."""
         graph = await self._get_graph()
@@ -368,6 +400,7 @@ class KnowledgeGraphLifecycle:
                     "supersede_chain). Compare with knowledge action=list."
                 ),
             },
+            "embedding_coverage": await self._embedding_coverage(),
         }
 
 

--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -2023,10 +2023,19 @@ async def handle_llm_assisted_dialectic(arguments: Dict[str, Any]) -> Sequence[T
 
     # Store as discovery in knowledge graph for learning
     try:
-        from src.knowledge_graph import get_knowledge_graph, DiscoveryNode
+        from src.knowledge_graph import (
+            get_knowledge_graph,
+            DiscoveryNode,
+            tag_provenance_source,
+        )
+        from datetime import datetime as _dt
 
         graph = await get_knowledge_graph()
+        # Backends expose add_discovery, not store — the prior call silently
+        # errored into logger.debug for as long as that branch existed (#165
+        # phantom-write audit incidentally surfaced this dead path).
         discovery = DiscoveryNode(
+            id=_dt.now().isoformat(),
             agent_id=agent_uuid,
             summary=f"LLM dialectic: {root_cause[:80]}... → {recommendation}",
             type="dialectic_synthesis",
@@ -2035,10 +2044,11 @@ async def handle_llm_assisted_dialectic(arguments: Dict[str, Any]) -> Sequence[T
                 "thesis": thesis,
                 "antithesis": result.get("antithesis"),
                 "synthesis": synthesis,
-                "recommendation": recommendation
-            }, indent=2)
+                "recommendation": recommendation,
+            }, indent=2),
+            provenance=tag_provenance_source(None, "dialectic_synthesis"),
         )
-        await graph.store(discovery)
+        await graph.add_discovery(discovery)
         response_data["discovery_stored"] = True
     except Exception as e:
         logger.debug(f"Could not store dialectic discovery: {e}")

--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -542,6 +542,11 @@ async def handle_store_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[Te
             provenance = {"system_version": system_version, "captured_at": datetime.now().isoformat()}
         elif "system_version" not in provenance:
             provenance["system_version"] = system_version
+        # Tag write origin so list/stats can split caller-intentional writes
+        # from automation traffic (#165). Single-discovery store path is the
+        # canonical "explicit" write surface.
+        from src.knowledge_graph import tag_provenance_source as _tag_src
+        provenance = _tag_src(provenance, "explicit_store")
 
         # Parse confidence if provided
         raw_confidence = arguments.get("confidence")
@@ -1850,6 +1855,7 @@ async def _handle_store_knowledge_graph_batch(arguments: Dict[str, Any], agent_i
                     except (ValueError, TypeError):
                         pass
 
+                from src.knowledge_graph import tag_provenance_source as _tag_src
                 discovery = DiscoveryNode(
                     id=discovery_id,
                     agent_id=agent_id,
@@ -1860,7 +1866,8 @@ async def _handle_store_knowledge_graph_batch(arguments: Dict[str, Any], agent_i
                     severity=severity,
                     response_to=response_to,
                     references_files=disc_data.get("related_files", []),
-                    confidence=batch_confidence
+                    confidence=batch_confidence,
+                    provenance=_tag_src(disc_data.get("provenance"), "explicit_store"),
                 )
 
                 # CONFIDENCE CROSS-CHECK: Clamp to agent coherence + 0.3
@@ -1991,6 +1998,7 @@ async def handle_answer_question(arguments: Dict[str, Any]) -> Sequence[TextCont
             answer_text = answer_text[:MAX_ANSWER_LEN] + "... [truncated]"
 
         # Create answer linked to the question
+        from src.knowledge_graph import tag_provenance_source as _tag_src
         answer = DiscoveryNode(
             id=datetime.now().isoformat(),
             agent_id=agent_id,
@@ -2003,7 +2011,8 @@ async def handle_answer_question(arguments: Dict[str, Any]) -> Sequence[TextCont
             response_to=ResponseTo(
                 discovery_id=matched_question.id,
                 response_type="answers"
-            )
+            ),
+            provenance=_tag_src(None, "explicit_answer"),
         )
 
         # Link answer to question
@@ -2126,6 +2135,7 @@ async def handle_leave_note(arguments: Dict[str, Any]) -> Sequence[TextContent]:
             note_severity = "medium"
 
         # Create note with minimal ceremony
+        from src.knowledge_graph import tag_provenance_source as _tag_src
         note = DiscoveryNode(
             id=datetime.now().isoformat(),
             agent_id=agent_id,
@@ -2135,7 +2145,8 @@ async def handle_leave_note(arguments: Dict[str, Any]) -> Sequence[TextContent]:
             tags=tags,
             severity=note_severity,
             status="open",
-            response_to=response_to
+            response_to=response_to,
+            provenance=_tag_src(None, "explicit_leave_note"),
         )
         
         # Auto-link if tags provided (fast with indexes)
@@ -2298,18 +2309,29 @@ async def handle_audit_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[Te
 async def store_discovery_internal(
     agent_id: str,
     summary: str,
+    *,
+    source: str,
     discovery_type: str = "note",
     details: str = "",
     tags: Optional[list] = None,
     severity: str = "low",
+    extra_provenance: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Internal helper for storing discoveries without MCP handler overhead.
 
-    Used by lifecycle/self_recovery to log reflections and resume events.
+    Used by lifecycle/self_recovery and dialectic to log reflections and
+    resume events. Every implicit write declares its origin via the
+    required ``source`` parameter — recorded in provenance.source so list
+    and stats can split caller-intentional writes from automation traffic
+    (#165 phantom-write surface).
+
     Raises on failure (callers should catch exceptions).
     """
+    from src.knowledge_graph import tag_provenance_source
+
     graph = await get_knowledge_graph()
     discovery_id = datetime.now().isoformat()
+    provenance = tag_provenance_source(extra_provenance, source)
     node = DiscoveryNode(
         id=discovery_id,
         agent_id=agent_id,
@@ -2318,5 +2340,6 @@ async def store_discovery_internal(
         details=details,
         tags=normalize_tags(tags or []),
         severity=severity,
+        provenance=provenance,
     )
     await graph.add_discovery(node)

--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -689,6 +689,16 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
         # Accept both "query" and "text" as parameter names for better UX
         query_text = arguments.get("query") or arguments.get("text")
         agent_id = arguments.get("agent_id")
+        # Force a specific retrieval mode. 'auto' (default) preserves the
+        # historical heuristic; explicit values fail honestly instead of silently
+        # routing to FTS — the whole point of this surface is making the routing
+        # decision visible (issue #165).
+        search_mode_param = (arguments.get("search_mode") or "auto").lower()
+        if search_mode_param not in {"auto", "fts", "semantic", "hybrid"}:
+            return [error_response(
+                f"Invalid search_mode {search_mode_param!r}; "
+                "expected one of: auto, fts, semantic, hybrid"
+            )]
         # Labels to exclude (e.g. ["Vigil"]) — lets the dashboard hide
         # janitorial residents from the default Discoveries feed. Resolved to
         # agent_ids below, applied as a post-query filter over `results`.
@@ -736,27 +746,74 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
         graph_expand_on = _graph_expansion_enabled()
 
         t0 = time.perf_counter()
+        # Track why the chosen mode is what it is — surfaced in the response so
+        # callers can tell a configured-FTS run from a silent-degrade-to-FTS run
+        # (issue #165).
+        semantic_skipped_reason: Optional[str] = None
         if query_text:
-            # UX FIX (Dec 2025): Auto-enable semantic search for conceptual queries
-            # - If semantic=True explicitly: always use semantic search
-            # - If semantic=False explicitly: never use semantic search
-            # - If semantic not specified: auto-detect based on query complexity
-            #   (queries with 2+ words are likely conceptual, benefit from semantic)
             has_semantic = hasattr(graph, "semantic_search")
+            has_fts = hasattr(graph, "full_text_search")
+            backend_label = graph.__class__.__name__
             explicit_semantic = arguments.get("semantic")
 
-            if explicit_semantic is not None:
-                # User explicitly chose - respect their choice
-                use_semantic = explicit_semantic and has_semantic
+            # Forced modes: error honestly when the backend can't deliver.
+            # 'auto' falls back to FTS but records the reason. 'fts' is always
+            # OK as long as the backend exposes full_text_search.
+            if search_mode_param == "semantic" and not has_semantic:
+                return [error_response(
+                    f"search_mode=semantic requires a backend with semantic_search; "
+                    f"active backend {backend_label} has none. "
+                    f"Use search_mode=fts, or set UNITARES_KNOWLEDGE_BACKEND=age."
+                )]
+            if search_mode_param == "hybrid" and not (has_semantic and has_fts):
+                missing = []
+                if not has_semantic:
+                    missing.append("semantic_search")
+                if not has_fts:
+                    missing.append("full_text_search")
+                return [error_response(
+                    f"search_mode=hybrid requires both semantic and FTS; "
+                    f"active backend {backend_label} is missing {', '.join(missing)}."
+                )]
+            if search_mode_param == "fts" and not has_fts:
+                return [error_response(
+                    f"search_mode=fts requires full_text_search; "
+                    f"active backend {backend_label} has none."
+                )]
+
+            # Decide whether semantic should run.
+            if search_mode_param in ("semantic", "hybrid"):
+                use_semantic = True
+            elif search_mode_param == "fts":
+                use_semantic = False
+                if has_semantic:
+                    semantic_skipped_reason = "caller forced search_mode=fts"
+            elif explicit_semantic is False:
+                use_semantic = False
+                semantic_skipped_reason = "caller passed semantic=false"
+            elif explicit_semantic is True:
+                if not has_semantic:
+                    return [error_response(
+                        f"semantic=true requires a backend with semantic_search; "
+                        f"active backend {backend_label} has none."
+                    )]
+                use_semantic = True
             else:
-                # Auto-detect: use semantic search when available for any text query
-                # Single-word queries benefit from semantic search too (substring_scan
-                # is limited to 50 recent entries and misses most results)
+                # auto: prefer semantic when the backend supports it
                 use_semantic = has_semantic
-            has_fts = hasattr(graph, "full_text_search")
-            # Phase 4 hybrid path: fires when hybrid flag on, semantic usable, FTS
-            # available. Skips the sequential single-mode branches below.
-            hybrid_path = hybrid_on and use_semantic and has_fts
+                if not has_semantic:
+                    semantic_skipped_reason = (
+                        f"backend {backend_label} has no semantic_search "
+                        "(set UNITARES_KNOWLEDGE_BACKEND=age to enable)"
+                    )
+
+            # Phase 4 hybrid path: only when caller forces hybrid, OR (auto + flag on + capable).
+            if search_mode_param == "hybrid":
+                hybrid_path = True  # already validated has_semantic and has_fts above
+            else:
+                hybrid_path = (
+                    search_mode_param == "auto" and hybrid_on and use_semantic and has_fts
+                )
             if hybrid_path:
                 import asyncio as _asyncio
                 min_similarity = arguments.get("min_similarity", 0.3)
@@ -1080,6 +1137,7 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
         # Include similarity scores for semantic search
         response_data = {
             "search_mode_used": search_mode,
+            "search_mode_requested": search_mode_param,
             "operator_used": operator_used,
             "fields_searched": fields_searched,
             "query": query_text,
@@ -1087,6 +1145,8 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
             "count": len(results),
             "message": f"Found {len(results)} discovery(ies)" + (" (details auto-included for small result set)" if auto_details else "" if include_details else " (summaries only)")
         }
+        if semantic_skipped_reason:
+            response_data["semantic_skipped_reason"] = semantic_skipped_reason
 
         # Surface semantic search degradation to caller
         if search_degraded_warning:

--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -1437,18 +1437,53 @@ async def handle_get_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[Text
 
 @mcp_tool("list_knowledge_graph", timeout=10.0, rate_limit_exempt=True, register=False)
 async def handle_list_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[TextContent]:
-    """List knowledge graph statistics - full transparency"""
+    """List knowledge graph statistics — raw status aggregate.
+
+    Use ``epoch_scope`` ("current"|"all") and ``including_cold`` (bool) to
+    align this view with knowledge action=stats (which uses lifecycle
+    buckets). #165 — same-name fields used to report different totals
+    silently.
+    """
     try:
         graph = await get_knowledge_graph()
+        epoch_scope = (arguments.get("epoch_scope") or "current").lower()
+        if epoch_scope not in {"current", "all"}:
+            return [error_response(
+                f"Invalid epoch_scope {epoch_scope!r}; expected 'current' or 'all'"
+            )]
+        including_cold = bool(arguments.get("including_cold", False))
+
         t0 = time.perf_counter()
-        stats = await graph.get_stats()
+        try:
+            stats = await graph.get_stats(
+                epoch_scope=epoch_scope, including_cold=including_cold,
+            )
+        except TypeError:
+            # Older backend not yet updated to the new signature — best-effort
+            # call without scope params, then annotate the response.
+            stats = await graph.get_stats()
+            stats.setdefault("scope", {
+                "kind": "raw_status_aggregate",
+                "epoch_scope": "unknown",
+                "including_cold": "unknown",
+                "note": "backend predates #165 scope-flag plumbing",
+            })
         record_ms("knowledge.get_stats", (time.perf_counter() - t0) * 1000.0)
-        
+
+        scope_summary = (
+            f"epoch_scope={stats.get('scope', {}).get('epoch_scope', '?')}, "
+            f"including_cold={stats.get('scope', {}).get('including_cold', '?')}"
+        )
         return success_response({
             "stats": stats,
-            "message": f"Knowledge graph contains {stats['total_discoveries']} discoveries from {stats['total_agents']} agents"
+            "message": (
+                f"Knowledge graph contains {stats['total_discoveries']} "
+                f"discoveries from {stats['total_agents']} agents "
+                f"({scope_summary}). For lifecycle-bucketed counts see "
+                f"knowledge action=stats."
+            ),
         }, arguments=arguments)
-        
+
     except Exception as e:
         return [error_response(f"Failed to list knowledge: {str(e)}")]
 

--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -699,6 +699,18 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
                 f"Invalid search_mode {search_mode_param!r}; "
                 "expected one of: auto, fts, semantic, hybrid"
             )]
+        # FTS boolean operator: None = handler picks AND with OR-on-zero
+        # fallback. "AND" or "OR" force that operator with no fallback.
+        operator_param_raw = arguments.get("operator")
+        if operator_param_raw is None:
+            operator_forced: Optional[str] = None
+        else:
+            op_upper = str(operator_param_raw).upper()
+            if op_upper not in {"AND", "OR"}:
+                return [error_response(
+                    f"Invalid operator {operator_param_raw!r}; expected 'AND' or 'OR'"
+                )]
+            operator_forced = op_upper
         # Labels to exclude (e.g. ["Vigil"]) — lets the dashboard hide
         # janitorial residents from the default Discoveries feed. Resolved to
         # agent_ids below, applied as a post-query filter over `results`.
@@ -750,6 +762,11 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
         # callers can tell a configured-FTS run from a silent-degrade-to-FTS run
         # (issue #165).
         semantic_skipped_reason: Optional[str] = None
+        # FTS operator observability (#165 part 2). None when no FTS ran;
+        # "AND"/"OR" otherwise. fallback_used flips true when AND returned zero
+        # and we retried with OR.
+        fts_operator_used: Optional[str] = None
+        fts_fallback_used = False
         if query_text:
             has_semantic = hasattr(graph, "semantic_search")
             has_fts = hasattr(graph, "full_text_search")
@@ -821,7 +838,14 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
                 sem_task = graph.semantic_search(
                     str(query_text), limit=hybrid_fetch_limit, min_similarity=min_similarity
                 )
-                fts_task = graph.full_text_search(str(query_text), limit=hybrid_fetch_limit)
+                # Hybrid uses the caller's operator if forced, else AND. We
+                # don't AND→OR fallback inside hybrid because semantic+FTS
+                # already cover the recall/precision tradeoff via RRF.
+                hybrid_fts_op = operator_forced or "AND"
+                fts_task = graph.full_text_search(
+                    str(query_text), limit=hybrid_fetch_limit, operator=hybrid_fts_op,
+                )
+                fts_operator_used = hybrid_fts_op
                 sem_raw, fts_raw = await _asyncio.gather(sem_task, fts_task)
                 sem_res = []
                 if isinstance(sem_raw, tuple) and len(sem_raw) == 2 and isinstance(sem_raw[1], dict):
@@ -906,7 +930,27 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
                 # When reranker is on, use a wider pool so the cross-encoder has candidates.
                 base_fts_limit = int(min(max(limit * 5, limit), 500))
                 candidate_limit = max(base_fts_limit, rerank_pool_size) if rerank_on else base_fts_limit
-                candidates = await graph.full_text_search(str(query_text), limit=candidate_limit)
+                primary_op = operator_forced or "AND"
+                candidates = await graph.full_text_search(
+                    str(query_text), limit=candidate_limit, operator=primary_op,
+                )
+                fts_operator_used = primary_op
+                # AND→OR fallback (#165): when caller didn't force an operator
+                # and AND returned nothing, retry with OR. Marks fts_fallback_used
+                # so the caller can tell broad-recall results apart from
+                # precision-first results.
+                if (
+                    not candidates
+                    and operator_forced is None
+                    and primary_op == "AND"
+                    and len(str(query_text).split()) > 1
+                ):
+                    candidates = await graph.full_text_search(
+                        str(query_text), limit=candidate_limit, operator="OR",
+                    )
+                    if candidates:
+                        fts_operator_used = "OR"
+                        fts_fallback_used = True
                 search_mode = "fts"
             elif not hybrid_path and not use_semantic:
                 # JSON backend fallback: bounded scan of most recent entries.
@@ -977,12 +1021,16 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
 
             results = filtered
             # search_mode already set above
-            # UX FIX: Make operator explicit upfront - FTS defaults to OR for multi-term queries
+            # operator_used reports what the FTS layer actually ran. For
+            # non-FTS modes (semantic, hybrid, substring) this stays "N/A" —
+            # boolean operators only apply to the FTS query string. (#165)
             query_terms = str(query_text).split() if query_text else []
-            if search_mode == "fts" and len(query_terms) > 1:
-                operator_used = "OR"  # FTS defaults to OR for multi-term queries
+            if fts_operator_used and len(query_terms) > 1:
+                operator_used = fts_operator_used
+            elif len(query_terms) > 1:
+                operator_used = "N/A"  # semantic / hybrid / substring
             else:
-                operator_used = "AND" if len(query_terms) > 1 else "N/A"
+                operator_used = "N/A"  # single-term query
             fields_searched = ["summary", "details", "tags"]
         else:
             # Indexed filter query (fast)
@@ -1022,7 +1070,24 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
             if search_mode == "semantic" and hasattr(graph, "full_text_search"):
                 try:
                     logger.debug(f"Semantic search returned 0 results, falling back to FTS for '{query_text}'")
-                    fts_candidates = await graph.full_text_search(str(query_text), limit=limit * 2)
+                    primary_op = operator_forced or "AND"
+                    fts_candidates = await graph.full_text_search(
+                        str(query_text), limit=limit * 2, operator=primary_op,
+                    )
+                    semantic_fallback_op = primary_op
+                    semantic_fallback_or_retry = False
+                    if (
+                        not fts_candidates
+                        and operator_forced is None
+                        and primary_op == "AND"
+                        and len(str(query_text).split()) > 1
+                    ):
+                        fts_candidates = await graph.full_text_search(
+                            str(query_text), limit=limit * 2, operator="OR",
+                        )
+                        if fts_candidates:
+                            semantic_fallback_op = "OR"
+                            semantic_fallback_or_retry = True
                     # Apply same filters
                     for d in fts_candidates:
                         if agent_id and d.agent_id != agent_id:
@@ -1045,18 +1110,21 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
                     if len(results) > 0:
                         fallback_used = True
                         search_mode = "semantic_fallback_fts"
-                        operator_used = "OR" if len(str(query_text).split()) > 1 else "N/A"
+                        fts_operator_used = semantic_fallback_op
+                        fts_fallback_used = semantic_fallback_or_retry
                         fallback_explanation = (
                             f"Semantic search found no concepts similar to '{query_text}' "
                             f"(similarity threshold: {min_similarity}). "
-                            f"Falling back to keyword search (FTS) for exact term matching."
+                            f"Falling back to keyword search (FTS, operator={semantic_fallback_op}) "
+                            f"for exact term matching."
                         )
                 except Exception as e:
                     logger.debug(f"Semantic→FTS fallback failed: {e}")
 
-            # Strategy 2 (removed): Individual-term FTS fallback is no longer needed
-            # because kg_full_text_search now defaults to OR for multi-term queries
-            # via _or_default_query(). The primary FTS query already matches any term.
+            # Strategy 2 (removed): Individual-term FTS fallback is no longer
+            # needed. As of #165, the FTS path runs AND first and automatically
+            # retries with OR on zero hits (see fts_fallback_used in response),
+            # which subsumes the per-term retry strategy.
 
             # Strategy 3 (removed 2026-04-20): Previously retried semantic search at
             # threshold 0.2, which is near cosine noise floor for our embedder. This
@@ -1147,6 +1215,12 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
         }
         if semantic_skipped_reason:
             response_data["semantic_skipped_reason"] = semantic_skipped_reason
+        # FTS operator visibility (#165 part 2). Only populate when FTS actually
+        # ran — for semantic/hybrid/substring runs these stay absent so callers
+        # know the boolean operator was not the controlling factor.
+        if fts_operator_used:
+            response_data["fts_operator_used"] = fts_operator_used
+            response_data["fts_fallback_used"] = fts_fallback_used
 
         # Surface semantic search degradation to caller
         if search_degraded_warning:

--- a/src/mcp_handlers/lifecycle/operations.py
+++ b/src/mcp_handlers/lifecycle/operations.py
@@ -377,7 +377,8 @@ async def handle_self_recovery_review(arguments: Dict[str, Any]) -> Sequence[Tex
             discovery_type="recovery_reflection",
             details=f"Reflection: {reflection}\n\nRoot cause: {root_cause}\n\nProposed conditions: {proposed_conditions}\n\nMetrics at reflection: coherence={coherence:.3f}, risk={risk_score:.3f}, void={void_value:.3f}",
             tags=["recovery", "self-reflection", margin_info.get('margin', 'unknown')],
-            severity="info" if all_safe else "warning"
+            severity="info" if all_safe else "warning",
+            source="self_recovery_reflection",
         )
         reflection_logged = True
     except Exception as e:

--- a/src/mcp_handlers/lifecycle/self_recovery.py
+++ b/src/mcp_handlers/lifecycle/self_recovery.py
@@ -453,6 +453,7 @@ async def handle_quick_resume(arguments: Dict[str, Any]) -> Sequence[TextContent
             }),
             tags=["recovery", "quick-resume", "audit"],
             severity="info",
+            source="self_recovery_quick_resume",
         )
     except Exception as e:
         logger.warning(f"Failed to log quick_resume: {e}")
@@ -641,6 +642,8 @@ async def handle_operator_resume_agent(arguments: Dict[str, Any]) -> Sequence[Te
             }),
             tags=["operator", "intervention", "recovery", "audit"],
             severity="warning",  # Operator interventions are always notable
+            source="operator_resume",
+            extra_provenance={"target_agent_id": target_agent_id},
         )
     except Exception as e:
         logger.warning(f"Failed to log operator intervention: {e}")

--- a/src/mcp_handlers/schemas/knowledge.py
+++ b/src/mcp_handlers/schemas/knowledge.py
@@ -95,6 +95,15 @@ class SearchKnowledgeGraphParams(AgentIdentityMixin):
         default=False,
         description="If true, includes full details for each discovery"
     )
+    search_mode: Optional[Literal["auto", "fts", "semantic", "hybrid"]] = Field(
+        default="auto",
+        description=(
+            "Force a specific retrieval mode. 'auto' picks the best available "
+            "(hybrid > semantic > fts > substring). 'semantic' and 'hybrid' "
+            "fail honestly when the backend has no semantic_search — the "
+            "router does not silently fall back to FTS."
+        ),
+    )
 
     @model_validator(mode='after')
     def coerce_types(self):

--- a/src/mcp_handlers/schemas/knowledge.py
+++ b/src/mcp_handlers/schemas/knowledge.py
@@ -104,6 +104,14 @@ class SearchKnowledgeGraphParams(AgentIdentityMixin):
             "router does not silently fall back to FTS."
         ),
     )
+    operator: Optional[Literal["AND", "OR"]] = Field(
+        default=None,
+        description=(
+            "Boolean operator for multi-term FTS queries. Default (None) is "
+            "AND with automatic OR fallback when AND returns zero results. "
+            "Pass 'OR' explicitly for broad recall (skips the AND-first step)."
+        ),
+    )
 
     @model_validator(mode='after')
     def coerce_types(self):

--- a/src/mcp_handlers/schemas/knowledge.py
+++ b/src/mcp_handlers/schemas/knowledge.py
@@ -154,9 +154,35 @@ class GetKnowledgeGraphParams(AgentIdentityMixin):
 
 class ListKnowledgeGraphParams(AgentIdentityMixin):
     """
-    List knowledge graph statistics
+    List knowledge graph statistics (raw status aggregate).
+
+    Numbers may differ from knowledge action=stats (which uses lifecycle
+    buckets) — see #165. The response surfaces a `scope` block declaring
+    the epoch_scope and including_cold settings so the difference is
+    visible rather than hidden behind same-name fields.
     """
-    pass
+    epoch_scope: Optional[Literal["current", "all"]] = Field(
+        default="current",
+        description=(
+            "'current' restricts to the active epoch (default); 'all' "
+            "counts every epoch ever stored. AGE backend ignores this — "
+            "it has no epoch property."
+        ),
+    )
+    including_cold: Union[bool, str, None] = Field(
+        default=False,
+        description=(
+            "Include cold-storage rows in totals and by_status. False "
+            "(default) excludes them so 'active' KG counts aren't "
+            "conflated with the deep-archive tier."
+        ),
+    )
+
+    @model_validator(mode='after')
+    def coerce_types(self):
+        if isinstance(self.including_cold, str):
+            self.including_cold = self.including_cold.lower() in ('true', '1', 'yes')
+        return self
 
 
 class UpdateDiscoveryStatusGraphParams(AgentIdentityMixin):

--- a/src/services/runtime_queries.py
+++ b/src/services/runtime_queries.py
@@ -518,21 +518,46 @@ async def get_health_check_data(arguments: Dict[str, Any], server=None) -> Dict[
 
     # KG check: get_knowledge_graph() initializes the AGE backend which acquires a
     # PostgreSQL connection — this deadlocks in the anyio context. Skip DB interaction
-    # and report embeddings status only (the actual signal of KG health).
+    # and report capability flags via class introspection.
+    #
+    # Two separate signals — the embedder service can be up while the active
+    # backend lacks semantic_search, in which case `knowledge action=search`
+    # silently routes to FTS. Surfacing both lets callers see the gap.
     try:
-        embeddings_ok = False
+        embedder_ok = False
         try:
             from src.embeddings import embeddings_available
-            embeddings_ok = embeddings_available()
+            embedder_ok = embeddings_available()
         except Exception:
             pass
+        try:
+            from src.knowledge_graph import (
+                backend_supports_semantic_search,
+                selected_backend_name,
+            )
+            backend_name = selected_backend_name()
+            semantic_backend_ok = backend_supports_semantic_search()
+        except Exception:
+            backend_name = "unknown"
+            semantic_backend_ok = False
+
+        semantic_search_reachable = embedder_ok and semantic_backend_ok
         checks["knowledge_graph"] = {
-            "status": "healthy" if embeddings_ok else "degraded",
-            "backend": "age",
-            "embeddings_available": embeddings_ok,
+            "status": "healthy" if semantic_search_reachable else "degraded",
+            "backend": backend_name,
+            "embedder_available": embedder_ok,
+            "semantic_backend_available": semantic_backend_ok,
+            "semantic_search_reachable": semantic_search_reachable,
         }
-        if not embeddings_ok:
-            checks["knowledge_graph"]["warning"] = "Semantic search unavailable — embeddings service not loaded."
+        if not embedder_ok:
+            checks["knowledge_graph"]["warning"] = (
+                "Embedder service not loaded — semantic search unavailable."
+            )
+        elif not semantic_backend_ok:
+            checks["knowledge_graph"]["warning"] = (
+                f"Embedder is up but backend '{backend_name}' has no semantic_search; "
+                f"`knowledge action=search` falls back to FTS."
+            )
     except Exception as e:
         checks["knowledge_graph"] = {"status": "error", "error": str(e)}
 

--- a/src/services/runtime_queries.py
+++ b/src/services/runtime_queries.py
@@ -674,9 +674,19 @@ async def get_health_check_data(arguments: Dict[str, Any], server=None) -> Dict[
     lite = arguments.get("lite", True)
     if lite:
         lite_checks = {}
+        # Keys the lite payload always carries forward when present. Includes
+        # the #165 capability split so operators reading the lite response can
+        # see embedder_available vs semantic_backend_available without having
+        # to opt into lite=false.
+        lite_keys = (
+            "mode", "redis_present", "present", "source_of_truth",
+            "session_binding_backend", "backend",
+            "embedder_available", "semantic_backend_available",
+            "semantic_search_reachable",
+        )
         for name, check in checks.items():
             lite_checks[name] = {"status": check.get("status", "unknown")}
-            for key in ("mode", "redis_present", "present", "source_of_truth", "session_binding_backend"):
+            for key in lite_keys:
                 if key in check:
                     lite_checks[name][key] = check[key]
             if "warning" in check:

--- a/src/storage/knowledge_graph_age.py
+++ b/src/storage/knowledge_graph_age.py
@@ -1606,15 +1606,19 @@ class KnowledgeGraphAGE:
         self,
         query: str,
         limit: int = 20,
+        operator: str = "AND",
     ) -> List[DiscoveryNode]:
         """Full-text search using PostgreSQL tsvector (ts_rank_cd ranking).
 
         AGE and PG backends share the same underlying `knowledge.discoveries`
         table, so we can reuse the DB mixin's kg_full_text_search. This keeps
         hybrid retrieval (RRF over semantic + FTS) identical across backends.
+
+        Defaults to AND for multi-term queries (#165). Callers wanting recall
+        pass operator="OR".
         """
         db = await self._get_db()
-        rows = await db.kg_full_text_search(query, limit)
+        rows = await db.kg_full_text_search(query, limit, operator=operator)
         # Hydrate via get_discovery so edge/response metadata is consistent
         # with what the rest of AGE returns. Row count is small (<= limit).
         results: List[DiscoveryNode] = []

--- a/src/storage/knowledge_graph_age.py
+++ b/src/storage/knowledge_graph_age.py
@@ -818,15 +818,27 @@ class KnowledgeGraphAGE:
             logger.error(f"Failed to update discovery {discovery_id}: {e}")
             return False
 
-    async def get_stats(self) -> Dict[str, Any]:
+    async def get_stats(
+        self,
+        epoch_scope: str = "current",
+        including_cold: bool = False,
+    ) -> Dict[str, Any]:
         """Get graph statistics.
-        
+
         Note: AGE doesn't support GROUP BY or multi-column returns well,
         so we use single-column collect() queries and aggregate in Python.
+
+        AGE vertices have no epoch property — epoch_scope is accepted for
+        signature parity with the postgres backend but always behaves as
+        'all'. including_cold=False filters cold rows from the by_status
+        aggregation in Python after the collect() returns.
         """
         from collections import Counter
-        
+
         db = await self._get_db()
+        # AGE's epoch is intentionally unscoped — declare that in the response
+        # so callers comparing across backends know which is which.
+        effective_epoch_scope = "all"
         
         # Total discoveries
         cypher = "MATCH (d:Discovery) RETURN count(d)"
@@ -849,6 +861,13 @@ class KnowledgeGraphAGE:
         cypher = "MATCH (d:Discovery) RETURN collect(d.status)"
         result = await db.graph_query(cypher, {})
         statuses = result[0] if result and isinstance(result[0], list) else []
+        cold_count = sum(1 for s in statuses if s == "cold")
+        if not including_cold:
+            statuses = [s for s in statuses if s != "cold"]
+            # Keep total_discoveries consistent with by_status — subtracting
+            # cold here means a list response with including_cold=False reports
+            # exactly the rows it bucketed.
+            total_count = max(0, total_count - cold_count)
         by_status = dict(Counter(s for s in statuses if s))
         
         # Count edges
@@ -893,6 +912,16 @@ class KnowledgeGraphAGE:
             "total_edges": total_edges,
             "total_agents": len(by_agent),
             "total_tags": total_tags,
+            "scope": {
+                "kind": "raw_status_aggregate",
+                "epoch_scope": effective_epoch_scope,  # AGE: always "all"
+                "including_cold": including_cold,
+                "note": (
+                    "AGE backend has no epoch property — counts span all "
+                    "epochs. Compare with knowledge action=stats which uses "
+                    "lifecycle buckets."
+                ),
+            },
         }
 
     async def health_check(self) -> Dict[str, Any]:

--- a/src/storage/knowledge_graph_postgres.py
+++ b/src/storage/knowledge_graph_postgres.py
@@ -160,38 +160,68 @@ class KnowledgeGraphPostgres:
         result = await db._pool.fetchval(query, *params)
         return result is not None
 
-    async def get_stats(self) -> Dict[str, Any]:
-        """Get knowledge graph statistics for current epoch."""
+    async def get_stats(
+        self,
+        epoch_scope: str = "current",
+        including_cold: bool = False,
+    ) -> Dict[str, Any]:
+        """Get knowledge graph statistics with explicit scope (#165 part 3).
+
+        Args:
+            epoch_scope: "current" (default) restricts to the active epoch;
+                "all" counts every epoch ever stored. The historical default
+                was epoch_current with no flag — list/stats reported very
+                different numbers for the same field, so the scope is now
+                surfaced in the response.
+            including_cold: When False (default), excludes rows in
+                status='cold' from totals and per-bucket counts. Cold rows
+                live in lifecycle's deep-archive tier; counting them by
+                default conflated active and dormant data.
+        """
         from config.governance_config import GovernanceConfig
         db = await self._get_db()
         epoch = GovernanceConfig.CURRENT_EPOCH
 
-        # Get total discoveries
-        total = await db._pool.fetchval(
-            "SELECT COUNT(*) FROM knowledge.discoveries WHERE epoch = $1", epoch)
+        clauses: list[str] = []
+        params: list[Any] = []
+        if epoch_scope == "current":
+            params.append(epoch)
+            clauses.append(f"epoch = ${len(params)}")
+        if not including_cold:
+            clauses.append("status != 'cold'")
+        where_sql = (" WHERE " + " AND ".join(clauses)) if clauses else ""
 
-        # Get discoveries by agent
-        by_agent_rows = await db._pool.fetch("""
+        total = await db._pool.fetchval(
+            f"SELECT COUNT(*) FROM knowledge.discoveries{where_sql}", *params)
+
+        by_agent_rows = await db._pool.fetch(
+            f"""
             SELECT agent_id, COUNT(*) as count
-            FROM knowledge.discoveries WHERE epoch = $1
+            FROM knowledge.discoveries{where_sql}
             GROUP BY agent_id
-        """, epoch)
+            """,
+            *params,
+        )
         by_agent = {row['agent_id']: row['count'] for row in by_agent_rows}
 
-        # Get discoveries by type
-        by_type_rows = await db._pool.fetch("""
+        by_type_rows = await db._pool.fetch(
+            f"""
             SELECT type, COUNT(*) as count
-            FROM knowledge.discoveries WHERE epoch = $1
+            FROM knowledge.discoveries{where_sql}
             GROUP BY type
-        """, epoch)
+            """,
+            *params,
+        )
         by_type = {row['type']: row['count'] for row in by_type_rows}
 
-        # Get discoveries by status
-        by_status_rows = await db._pool.fetch("""
+        by_status_rows = await db._pool.fetch(
+            f"""
             SELECT status, COUNT(*) as count
-            FROM knowledge.discoveries WHERE epoch = $1
+            FROM knowledge.discoveries{where_sql}
             GROUP BY status
-        """, epoch)
+            """,
+            *params,
+        )
         by_status = {row['status']: row['count'] for row in by_status_rows}
 
         return {
@@ -201,6 +231,17 @@ class KnowledgeGraphPostgres:
             "by_status": by_status,
             "total_agents": len(by_agent),
             "epoch": epoch,
+            "scope": {
+                "kind": "raw_status_aggregate",
+                "epoch_scope": epoch_scope,  # "current" | "all"
+                "including_cold": including_cold,
+                "note": (
+                    "Counts come straight from the discoveries table status "
+                    "column — includes 'superseded' rows. Compare with "
+                    "knowledge action=stats which uses lifecycle buckets and "
+                    "always includes cold rows but doesn't expose superseded."
+                ),
+            },
         }
 
     async def get_agent_discoveries(

--- a/src/storage/knowledge_graph_postgres.py
+++ b/src/storage/knowledge_graph_postgres.py
@@ -265,6 +265,40 @@ class KnowledgeGraphPostgres:
             )
             target[row['agent_id']] = target.get(row['agent_id'], 0) + row['count']
 
+        # Embedding coverage (#165 part 5). The active embeddings table is
+        # selected by UNITARES_EMBEDDING_MODEL; this counts how many rows in
+        # the current scope have a row in that table. Critical diagnostic for
+        # finding 1 — operators couldn't tell whether semantic-search
+        # coverage was 5% or 95%.
+        embedding_coverage: Optional[Dict[str, Any]] = None
+        try:
+            from src.embeddings import get_active_table_name
+            embed_table = get_active_table_name()
+            covered_clauses = list(clauses)
+            covered_clauses.append(
+                f"id IN (SELECT discovery_id FROM {embed_table})"
+            )
+            covered_where = " WHERE " + " AND ".join(covered_clauses)
+            with_embeddings = await db._pool.fetchval(
+                f"SELECT COUNT(*) FROM knowledge.discoveries{covered_where}",
+                *params,
+            ) or 0
+            total_in_scope = total or 0
+            without_embeddings = max(0, total_in_scope - with_embeddings)
+            ratio = (
+                round(with_embeddings / total_in_scope, 4)
+                if total_in_scope else 0.0
+            )
+            embedding_coverage = {
+                "with_embeddings": with_embeddings,
+                "without_embeddings": without_embeddings,
+                "ratio": ratio,
+                "active_table": embed_table,
+            }
+        except Exception as exc:
+            logger.debug(f"embedding coverage probe failed: {exc}")
+            embedding_coverage = {"error": str(exc)}
+
         return {
             "total_discoveries": total or 0,
             "by_agent": by_agent,
@@ -273,6 +307,7 @@ class KnowledgeGraphPostgres:
             "by_type": by_type,
             "by_status": by_status,
             "by_provenance_source": by_provenance_source,
+            "embedding_coverage": embedding_coverage,
             "total_agents": len(by_agent),
             "epoch": epoch,
             "scope": {

--- a/src/storage/knowledge_graph_postgres.py
+++ b/src/storage/knowledge_graph_postgres.py
@@ -224,11 +224,55 @@ class KnowledgeGraphPostgres:
         )
         by_status = {row['status']: row['count'] for row in by_status_rows}
 
+        # Provenance-source split (#165 part 4). NULL provenance → "legacy"
+        # bucket so callers can tell which rows predate the tagging convention.
+        # provenance is stored as JSONB; the extraction operator works on both
+        # JSONB and JSON rows.
+        prov_rows = await db._pool.fetch(
+            f"""
+            SELECT
+                COALESCE(provenance->>'source', '__legacy_or_untagged__') AS source,
+                COUNT(*) AS count
+            FROM knowledge.discoveries{where_sql}
+            GROUP BY 1
+            """,
+            *params,
+        )
+        by_provenance_source = {row['source']: row['count'] for row in prov_rows}
+
+        # Same split per-agent so operators can audit a specific agent's
+        # caller-intentional writes apart from automation noise.
+        agent_prov_rows = await db._pool.fetch(
+            f"""
+            SELECT
+                agent_id,
+                COALESCE(provenance->>'source', '__legacy_or_untagged__') AS source,
+                COUNT(*) AS count
+            FROM knowledge.discoveries{where_sql}
+            GROUP BY agent_id, source
+            """,
+            *params,
+        )
+        explicit_sources = {
+            "explicit_store", "explicit_answer", "explicit_leave_note",
+        }
+        by_agent_explicit: Dict[str, int] = {}
+        by_agent_implicit: Dict[str, int] = {}
+        for row in agent_prov_rows:
+            target = (
+                by_agent_explicit if row['source'] in explicit_sources
+                else by_agent_implicit
+            )
+            target[row['agent_id']] = target.get(row['agent_id'], 0) + row['count']
+
         return {
             "total_discoveries": total or 0,
             "by_agent": by_agent,
+            "by_agent_explicit": by_agent_explicit,
+            "by_agent_implicit": by_agent_implicit,
             "by_type": by_type,
             "by_status": by_status,
+            "by_provenance_source": by_provenance_source,
             "total_agents": len(by_agent),
             "epoch": epoch,
             "scope": {
@@ -237,9 +281,10 @@ class KnowledgeGraphPostgres:
                 "including_cold": including_cold,
                 "note": (
                     "Counts come straight from the discoveries table status "
-                    "column — includes 'superseded' rows. Compare with "
-                    "knowledge action=stats which uses lifecycle buckets and "
-                    "always includes cold rows but doesn't expose superseded."
+                    "column — includes 'superseded' rows. by_agent_explicit "
+                    "covers rows tagged with provenance.source in "
+                    f"{sorted(explicit_sources)}; everything else (including "
+                    "untagged legacy rows) lands in by_agent_implicit."
                 ),
             },
         }

--- a/src/storage/knowledge_graph_postgres.py
+++ b/src/storage/knowledge_graph_postgres.py
@@ -87,10 +87,12 @@ class KnowledgeGraphPostgres:
             rows = [r for r in rows if r.get("status") != "archived"]
         return [self._dict_to_discovery(r) for r in rows]
 
-    async def full_text_search(self, query: str, limit: int = 20) -> List[DiscoveryNode]:
-        """Full-text search using PostgreSQL tsvector."""
+    async def full_text_search(
+        self, query: str, limit: int = 20, operator: str = "AND",
+    ) -> List[DiscoveryNode]:
+        """Full-text search using PostgreSQL tsvector. Defaults to AND (#165)."""
         db = await self._get_db()
-        rows = await db.kg_full_text_search(query, limit)
+        rows = await db.kg_full_text_search(query, limit, operator=operator)
         return [self._dict_to_discovery(r) for r in rows]
 
     async def find_similar(self, discovery: DiscoveryNode, limit: int = 10) -> List[DiscoveryNode]:

--- a/tests/test_admin_handlers.py
+++ b/tests/test_admin_handlers.py
@@ -673,6 +673,7 @@ class TestHealthCheck:
              patch("src.audit_log.audit_logger", mock_audit), \
              patch("src.db.get_db", return_value=mock_db), \
              patch("src.embeddings.embeddings_available", return_value=True), \
+             patch("src.knowledge_graph.backend_supports_semantic_search", return_value=True), \
              patch("unitares_pi_plugin.handlers.call_pi_tool",
                    new_callable=AsyncMock,
                    return_value={"status": "healthy"}), \
@@ -723,6 +724,7 @@ class TestHealthCheck:
              patch("src.audit_log.audit_logger", mock_audit), \
              patch("src.db.get_db", return_value=mock_db), \
              patch("src.embeddings.embeddings_available", return_value=True), \
+             patch("src.knowledge_graph.backend_supports_semantic_search", return_value=True), \
              patch("unitares_pi_plugin.handlers.call_pi_tool",
                    new_callable=AsyncMock,
                    return_value={"status": "healthy"}), \
@@ -787,6 +789,7 @@ class TestHealthCheck:
              patch("src.audit_log.audit_logger", mock_audit), \
              patch("src.db.get_db", return_value=mock_db), \
              patch("src.embeddings.embeddings_available", return_value=True), \
+             patch("src.knowledge_graph.backend_supports_semantic_search", return_value=True), \
              patch("unitares_pi_plugin.handlers.call_pi_tool",
                    new_callable=AsyncMock,
                    return_value={"status": "healthy"}), \

--- a/tests/test_admin_handlers.py
+++ b/tests/test_admin_handlers.py
@@ -864,6 +864,105 @@ class TestHealthCheck:
 
 
 # ============================================================================
+# Issue #165 — health response splits embedder vs backend capability
+# ============================================================================
+
+
+class TestIssue165HealthCapabilitySplit:
+
+    @pytest.mark.asyncio
+    async def test_embedder_up_but_backend_lacks_semantic_search(
+        self, mock_mcp_server, patch_context_agent_id,
+    ):
+        """embedder_available=true + semantic_backend_available=false should
+        be visible in the health response so callers don't infer that
+        semantic KG search works when the active backend can't deliver."""
+        pytest.importorskip("unitares_pi_plugin")
+        mock_audit = MagicMock()
+        mock_audit.log_file = MagicMock()
+        mock_audit.log_file.exists.return_value = True
+
+        mock_db = AsyncMock()
+        mock_db.health_check = AsyncMock(return_value={"status": "healthy"})
+        mock_db.init = AsyncMock()
+
+        mock_cal = MagicMock()
+        mock_cal.get_pending_updates.return_value = 0
+
+        with patch("src.mcp_handlers.admin.handlers.mcp_server", mock_mcp_server), \
+             patch("src.calibration.calibration_checker", mock_cal), \
+             patch("src.telemetry.telemetry_collector", MagicMock()), \
+             patch("src.audit_log.audit_logger", mock_audit), \
+             patch("src.db.get_db", return_value=mock_db), \
+             patch("src.embeddings.embeddings_available", return_value=True), \
+             patch("src.knowledge_graph.backend_supports_semantic_search", return_value=False), \
+             patch("src.knowledge_graph.selected_backend_name", return_value="postgres"), \
+             patch("unitares_pi_plugin.handlers.call_pi_tool",
+                   new_callable=AsyncMock,
+                   return_value={"status": "healthy"}), \
+             patch("src.calibration_db.calibration_health_check_async",
+                   new_callable=AsyncMock,
+                   return_value={"status": "healthy", "backend": "postgres"}), \
+             patch("src.audit_db.audit_health_check_async",
+                   new_callable=AsyncMock,
+                   return_value={"status": "healthy", "backend": "postgres"}), \
+             patch("src.cache.is_redis_available", return_value=False):
+
+            from src.services.runtime_queries import get_health_check_data
+            data = await get_health_check_data({})
+            kg = data["checks"]["knowledge_graph"]
+            assert kg["embedder_available"] is True
+            assert kg["semantic_backend_available"] is False
+            assert kg["semantic_search_reachable"] is False
+            assert kg["status"] == "degraded"
+            assert "backend 'postgres' has no semantic_search" in kg["warning"]
+
+    @pytest.mark.asyncio
+    async def test_both_up_reports_reachable(
+        self, mock_mcp_server, patch_context_agent_id,
+    ):
+        pytest.importorskip("unitares_pi_plugin")
+        mock_audit = MagicMock()
+        mock_audit.log_file = MagicMock()
+        mock_audit.log_file.exists.return_value = True
+
+        mock_db = AsyncMock()
+        mock_db.health_check = AsyncMock(return_value={"status": "healthy"})
+        mock_db.init = AsyncMock()
+
+        mock_cal = MagicMock()
+        mock_cal.get_pending_updates.return_value = 0
+
+        with patch("src.mcp_handlers.admin.handlers.mcp_server", mock_mcp_server), \
+             patch("src.calibration.calibration_checker", mock_cal), \
+             patch("src.telemetry.telemetry_collector", MagicMock()), \
+             patch("src.audit_log.audit_logger", mock_audit), \
+             patch("src.db.get_db", return_value=mock_db), \
+             patch("src.embeddings.embeddings_available", return_value=True), \
+             patch("src.knowledge_graph.backend_supports_semantic_search", return_value=True), \
+             patch("src.knowledge_graph.selected_backend_name", return_value="age"), \
+             patch("unitares_pi_plugin.handlers.call_pi_tool",
+                   new_callable=AsyncMock,
+                   return_value={"status": "healthy"}), \
+             patch("src.calibration_db.calibration_health_check_async",
+                   new_callable=AsyncMock,
+                   return_value={"status": "healthy", "backend": "postgres"}), \
+             patch("src.audit_db.audit_health_check_async",
+                   new_callable=AsyncMock,
+                   return_value={"status": "healthy", "backend": "postgres"}), \
+             patch("src.cache.is_redis_available", return_value=False):
+
+            from src.services.runtime_queries import get_health_check_data
+            data = await get_health_check_data({})
+            kg = data["checks"]["knowledge_graph"]
+            assert kg["embedder_available"] is True
+            assert kg["semantic_backend_available"] is True
+            assert kg["semantic_search_reachable"] is True
+            assert kg["status"] == "healthy"
+            assert kg.get("warning") is None or "warning" not in kg
+
+
+# ============================================================================
 # handle_debug_request_context
 # ============================================================================
 

--- a/tests/test_kg_search.py
+++ b/tests/test_kg_search.py
@@ -1308,7 +1308,7 @@ class TestSearchKnowledgeGraphAdditional:
 
     @pytest.mark.asyncio
     async def test_search_fts_multi_term_operator_note(self, patch_common):
-        """FTS multi-term queries show operator_note (line 823)."""
+        """FTS multi-term queries report the operator that ran (#165)."""
         mock_mcp_server, mock_graph = patch_common
         from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
 
@@ -1323,7 +1323,11 @@ class TestSearchKnowledgeGraphAdditional:
         data = parse_result(result)
         assert data["success"] is True
         if data["search_mode_used"] == "fts" and data["count"] > 0:
-            assert data["operator_used"] == "OR"
+            # Default switched from OR to AND in #165 (precision over recall);
+            # OR is now reachable via the AND→OR fallback or operator=OR.
+            assert data["operator_used"] == "AND"
+            assert data["fts_operator_used"] == "AND"
+            assert data["fts_fallback_used"] is False
 
     @pytest.mark.asyncio
     async def test_search_no_details_tip(self, patch_common):

--- a/tests/test_kg_search.py
+++ b/tests/test_kg_search.py
@@ -1601,3 +1601,269 @@ class TestOrDefaultQuery:
 # ============================================================================
 
 
+# ============================================================================
+# Issue #165 — search_mode + routing-reason + AND default + scope + provenance
+# ============================================================================
+
+
+class TestIssue165SearchMode:
+    """Forced search modes error honestly when the backend can't deliver."""
+
+    @pytest.mark.asyncio
+    async def test_auto_falls_back_with_reason_when_backend_lacks_semantic(self, patch_common):
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        # Backend has FTS only — no semantic_search method on the instance.
+        del mock_graph.semantic_search
+        mock_graph.full_text_search = AsyncMock(
+            return_value=[make_discovery(id="f1", summary="Match")]
+        )
+
+        result = await handle_search_knowledge_graph({"query": "anything goes here"})
+        data = parse_result(result)
+
+        assert data["success"] is True
+        assert data["search_mode_used"] == "fts"
+        assert data["search_mode_requested"] == "auto"
+        assert "semantic_skipped_reason" in data
+        assert "no semantic_search" in data["semantic_skipped_reason"]
+
+    @pytest.mark.asyncio
+    async def test_forced_semantic_errors_when_backend_lacks_it(self, patch_common):
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        del mock_graph.semantic_search
+        mock_graph.full_text_search = AsyncMock(return_value=[])
+
+        result = await handle_search_knowledge_graph({
+            "query": "doesnt matter",
+            "search_mode": "semantic",
+        })
+        data = parse_result(result)
+        assert data["success"] is False
+        assert "semantic_search" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_forced_hybrid_errors_when_backend_partial(self, patch_common):
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        del mock_graph.semantic_search  # only FTS available
+
+        result = await handle_search_knowledge_graph({
+            "query": "test",
+            "search_mode": "hybrid",
+        })
+        data = parse_result(result)
+        assert data["success"] is False
+        assert "hybrid" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_search_mode_rejected(self, patch_common):
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+        result = await handle_search_knowledge_graph({
+            "query": "test",
+            "search_mode": "wat",
+        })
+        data = parse_result(result)
+        assert data["success"] is False
+        assert "Invalid search_mode" in data["error"]
+
+
+class TestIssue165FtsOperator:
+    """AND default with OR fallback on zero hits — surfaced in response."""
+
+    @pytest.mark.asyncio
+    async def test_and_default_records_operator_in_response(self, patch_common):
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        del mock_graph.semantic_search
+        # AND returns one match — no fallback fires.
+        mock_graph.full_text_search = AsyncMock(
+            return_value=[make_discovery(id="f1", summary="Hit")]
+        )
+
+        result = await handle_search_knowledge_graph({"query": "two terms"})
+        data = parse_result(result)
+        assert data["success"] is True
+        assert data["fts_operator_used"] == "AND"
+        assert data["fts_fallback_used"] is False
+        # Backend was called with operator=AND
+        first_call = mock_graph.full_text_search.await_args_list[0]
+        assert first_call.kwargs.get("operator") == "AND"
+
+    @pytest.mark.asyncio
+    async def test_and_then_or_fallback_on_zero(self, patch_common):
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        del mock_graph.semantic_search
+
+        call_count = {"n": 0}
+
+        async def fts(query, limit=20, operator="AND"):
+            call_count["n"] += 1
+            # First call (AND): empty. Second call (OR): one hit.
+            if operator == "AND":
+                return []
+            return [make_discovery(id="r1", summary="Recovered")]
+
+        mock_graph.full_text_search = AsyncMock(side_effect=fts)
+
+        result = await handle_search_knowledge_graph({"query": "two terms"})
+        data = parse_result(result)
+        assert data["success"] is True
+        assert data["count"] == 1
+        assert data["fts_operator_used"] == "OR"
+        assert data["fts_fallback_used"] is True
+        assert call_count["n"] == 2
+
+    @pytest.mark.asyncio
+    async def test_explicit_or_skips_fallback(self, patch_common):
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        del mock_graph.semantic_search
+
+        async def fts(query, limit=20, operator="AND"):
+            assert operator == "OR"  # caller forced it
+            return [make_discovery(id="o1")]
+
+        mock_graph.full_text_search = AsyncMock(side_effect=fts)
+
+        result = await handle_search_knowledge_graph({
+            "query": "two terms",
+            "operator": "OR",
+        })
+        data = parse_result(result)
+        assert data["success"] is True
+        assert data["fts_operator_used"] == "OR"
+        assert data["fts_fallback_used"] is False
+
+    @pytest.mark.asyncio
+    async def test_invalid_operator_rejected(self, patch_common):
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+        result = await handle_search_knowledge_graph({
+            "query": "x y",
+            "operator": "XOR",
+        })
+        data = parse_result(result)
+        assert data["success"] is False
+        assert "Invalid operator" in data["error"]
+
+
+class TestIssue165ListScope:
+    """list response declares its scope and accepts epoch_scope/including_cold."""
+
+    @pytest.mark.asyncio
+    async def test_list_passes_scope_params_through(self, patch_common):
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_list_knowledge_graph
+
+        captured: Dict[str, Any] = {}
+
+        async def get_stats(**kw):
+            captured.update(kw)
+            return {
+                "total_discoveries": 7,
+                "total_agents": 1,
+                "scope": {
+                    "kind": "raw_status_aggregate",
+                    "epoch_scope": kw.get("epoch_scope"),
+                    "including_cold": kw.get("including_cold"),
+                },
+            }
+
+        mock_graph.get_stats = AsyncMock(side_effect=get_stats)
+
+        result = await handle_list_knowledge_graph({
+            "epoch_scope": "all",
+            "including_cold": True,
+        })
+        data = parse_result(result)
+        assert data["success"] is True
+        assert captured == {"epoch_scope": "all", "including_cold": True}
+        assert data["stats"]["scope"]["epoch_scope"] == "all"
+        assert data["stats"]["scope"]["including_cold"] is True
+
+    @pytest.mark.asyncio
+    async def test_list_rejects_invalid_epoch_scope(self, patch_common):
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_list_knowledge_graph
+        result = await handle_list_knowledge_graph({"epoch_scope": "nope"})
+        data = parse_result(result)
+        assert data["success"] is False
+        assert "Invalid epoch_scope" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_list_falls_back_for_old_backend(self, patch_common):
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_list_knowledge_graph
+
+        # Older backend signature (no scope kwargs) → TypeError → handler
+        # retries without kwargs and annotates the response.
+        async def old_get_stats(**kw):
+            if kw:
+                raise TypeError("get_stats() got unexpected kw")
+            return {"total_discoveries": 1, "total_agents": 1}
+
+        mock_graph.get_stats = AsyncMock(side_effect=old_get_stats)
+        result = await handle_list_knowledge_graph({"epoch_scope": "current"})
+        data = parse_result(result)
+        assert data["success"] is True
+        assert data["stats"]["scope"]["epoch_scope"] == "unknown"
+
+
+class TestIssue165Provenance:
+    """Implicit and explicit writes are distinguishable via provenance.source."""
+
+    def test_explicit_source_classifier(self):
+        from src.knowledge_graph import is_explicit_source, tag_provenance_source
+        assert is_explicit_source(tag_provenance_source(None, "explicit_store"))
+        assert is_explicit_source(tag_provenance_source(None, "explicit_answer"))
+        assert is_explicit_source(tag_provenance_source(None, "explicit_leave_note"))
+        # Implicit / unknown / legacy
+        assert not is_explicit_source(tag_provenance_source(None, "self_recovery_quick_resume"))
+        assert not is_explicit_source(tag_provenance_source(None, "operator_resume"))
+        assert not is_explicit_source(None)
+        assert not is_explicit_source({})
+        assert not is_explicit_source({"source": "rando"})
+
+    def test_tag_does_not_clobber_existing_keys(self):
+        from src.knowledge_graph import tag_provenance_source
+        existing = {"system_version": "v2.12.0", "captured_at": "2026-04-25"}
+        out = tag_provenance_source(existing, "explicit_store")
+        assert out["source"] == "explicit_store"
+        assert out["system_version"] == "v2.12.0"
+        assert out["captured_at"] == "2026-04-25"
+        # Existing source must not be overwritten
+        with_existing_source = {"source": "preserved"}
+        out2 = tag_provenance_source(with_existing_source, "explicit_store")
+        assert out2["source"] == "preserved"
+
+    @pytest.mark.asyncio
+    async def test_store_discovery_internal_requires_source(self, patch_common):
+        from src.mcp_handlers.knowledge.handlers import store_discovery_internal
+        with pytest.raises(TypeError):
+            await store_discovery_internal(  # type: ignore[call-arg]
+                agent_id="a", summary="s",
+            )
+
+    @pytest.mark.asyncio
+    async def test_store_discovery_internal_tags_provenance(self, patch_common):
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import store_discovery_internal
+        await store_discovery_internal(
+            agent_id="a-1", summary="recovery", source="self_recovery_quick_resume",
+        )
+        mock_graph.add_discovery.assert_awaited()
+        node = mock_graph.add_discovery.await_args.args[0]
+        assert node.provenance["source"] == "self_recovery_quick_resume"
+
+
+


### PR DESCRIPTION
Closes #165 — bundled fix for the four findings in the v2.12.0 dogfood probe.

## Findings → fixes

### 1. Semantic search never engages (commits 1–2)
**Root cause:** `auto + DB_BACKEND=postgres` selects `KnowledgeGraphPostgres`, which has no `semantic_search` method. The handler's `hasattr(graph, "semantic_search")` check at `handlers.py:745` silently returns False and routes to FTS. Meanwhile `health_check.embeddings_available` checks the embedder service, not backend capability — the two diagnostics drift.

**Fix:**
- New `search_mode={auto|fts|semantic|hybrid}` parameter. Forced `semantic`/`hybrid` error honestly when the backend can't deliver.
- Response surfaces `search_mode_requested` and `semantic_skipped_reason` so callers can tell a configured-FTS run from a silent-degrade-FTS run.
- Health response splits `embedder_available` (was `embeddings_available`) from `semantic_backend_available` (new), with `semantic_search_reachable` as the AND. `lite=true` (default) carries all three so operators see the gap without opting into `lite=false`.
- FTS default flipped from OR to AND with automatic OR retry on zero hits. `fts_operator_used` and `fts_fallback_used` in response. Explicit `operator=OR` skips the fallback.

### 2. stats vs list scope mismatch (commit 3)
**Root cause:** `list` calls `KnowledgeGraphPostgres.get_stats()` which is `WHERE epoch = CURRENT_EPOCH` (132). `stats` calls `get_kg_lifecycle_stats()` which sums `{open, resolved, archived, cold}` across all epochs (659). Same `total_discoveries` field, different scopes, no marker.

**Fix:** Both responses now declare a `scope` block:
- `list` → `kind: raw_status_aggregate`, accepts `epoch_scope={current|all}` and `including_cold` (default false)
- `stats` → `kind: lifecycle_buckets`, `epoch_scope: all`, `including_cold: true`

Numbers unchanged; just labeled. Callers can pass `epoch_scope=all, including_cold=true` to `list` to align with `stats`.

### 3. Phantom write on agent's own row (commit 4)
**Root cause:** Six implicit-write call sites (`self_recovery_reflection`, `self_recovery_quick_resume`, `operator_resume`, plus `dialectic_thesis` — which had also been silently erroring on a stale `graph.store(discovery)` call into `logger.debug`) produced rows indistinguishable from caller-intentional writes in `by_agent`.

**Fix:** Every write declares its origin via `provenance.source`. `store_discovery_internal` now requires `source` as a kwarg so new implicit writers can't be added without declaring one. Explicit writes (`explicit_store`, `explicit_answer`, `explicit_leave_note`) tagged for symmetry; absent `provenance.source` is unambiguously a legacy/pre-tagging row.

`list` response gains:
- `by_provenance_source` — full source histogram including `__legacy_or_untagged__`
- `by_agent_explicit` / `by_agent_implicit` — per-agent split

### 4. Embedding coverage missing (commit 5)
**Fix:** Both `list` and `stats` now report:
```
embedding_coverage: {
  with_embeddings: int,
  without_embeddings: int,
  ratio: 0.X,
  active_table: "core.discovery_embeddings_bge_m3" | ...
}
```
`active_table` is selected by `UNITARES_EMBEDDING_MODEL` so callers can cross-check they're looking at what the runtime actually queries.

## Tests (commit 6)

17 new tests:
- `TestIssue165SearchMode` (4): forced semantic/hybrid error honestly; auto surfaces reason; invalid mode rejected
- `TestIssue165FtsOperator` (4): AND default; AND→OR fallback flips flag; explicit OR skips fallback; invalid operator rejected
- `TestIssue165ListScope` (3): scope params pass through; invalid epoch_scope rejected; TypeError fallback for older backends
- `TestIssue165Provenance` (4): explicit-source classifier (incl. legacy/None); tag preserves existing keys; `store_discovery_internal` requires source; helper writes provenance
- `TestIssue165HealthCapabilitySplit` (2): both fields appear; degraded warning fires when embedder up but backend lacks semantic

Pre-commit: `./scripts/dev/test-cache.sh --fresh` → 7298 passed, 33 skipped (full suite, ~3min). All changes verified on top of master @ 2a9c12f5.

## Migration notes
- `embeddings_available` field in health response → renamed to `embedder_available`. No internal consumers; `src/embeddings.embeddings_available()` function name unchanged.
- `KnowledgeGraphPostgres.get_stats()` and `KnowledgeGraphAGE.get_stats()` gained `epoch_scope` and `including_cold` kwargs. `list` handler has a TypeError fallback for older backends.
- `store_discovery_internal` `source` parameter is required (kwarg-only). All four lifecycle/dialectic call sites updated.