### PR TITLE
feat: phase 4 — SessionStart hook attaches initial_state (bootstrap check-in goes live)

### DIFF
--- a/scripts/client/onboard_helper.py
+++ b/scripts/client/onboard_helper.py
@@ -150,6 +150,27 @@ def trajectory_required(parsed: dict) -> bool:
 
 # --- Core flow -------------------------------------------------------------
 
+def _build_bootstrap_initial_state() -> dict:
+    """Bootstrap check-in payload sent by the hook (per onboard-bootstrap-checkin §3.5).
+
+    Hook-driven onboards always claim task_type='introspection' — the agent
+    has no real task at session-start. The hook MUST NOT fabricate
+    confidence values from session metadata; we omit confidence and
+    complexity so the server fills its 0.5 defaults. response_text is also
+    omitted so the server's "[bootstrap] " + client_hint composition
+    applies.
+
+    Substrate-earned exemption is enforced server-side via
+    is_substrate_earned (Phase 2). The hook can safely send initial_state
+    unconditionally: substrate-earned identities receive bootstrap.written:
+    false with reason='substrate-earned-exempt' and no row is written. In
+    practice no substrate-earned resident runs through this hook (they're
+    launchd-managed), so the structural protection is "residents don't
+    fire SessionStart."
+    """
+    return {"task_type": "introspection"}
+
+
 def run_onboard(
     *,
     server_url: str,
@@ -160,6 +181,7 @@ def run_onboard(
     force_new: bool = False,
     auth_token: str | None = None,
     timeout: float = DEFAULT_TIMEOUT,
+    with_bootstrap: bool = True,
     post_json: Callable[[str, dict, float, str | None], dict] = _post_json,
     read_cache: Callable[..., dict] = _read_cache,
     write_cache: Callable[..., None] = _write_cache,
@@ -170,6 +192,11 @@ def run_onboard(
     workspace can each own their own identity (typically the Claude Code
     session_id from hook input). When omitted, falls back to the legacy
     shared session.json — preserves single-process behavior.
+
+    ``with_bootstrap`` (default True) attaches an initial_state payload so
+    the server writes a bootstrap check-in row at t=0 per
+    docs/proposals/onboard-bootstrap-checkin.md §3.5. Idempotent on resume
+    (server returns the existing bootstrap row's state_id).
     """
     url = f"{server_url.rstrip('/')}/v1/tools/call"
     cache = read_cache(workspace, slot)
@@ -184,6 +211,9 @@ def run_onboard(
             arguments["continuity_token"] = cached_token
         elif cached_session:
             arguments["client_session_id"] = cached_session
+
+    if with_bootstrap:
+        arguments["initial_state"] = _build_bootstrap_initial_state()
 
     raw = post_json(url, {"name": "onboard", "arguments": arguments}, timeout, auth_token)
     parsed = unwrap_tool_response(raw)
@@ -238,6 +268,16 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--force-new", action="store_true",
                         help="Explicit opt-in to create a fresh identity (never automatic)")
     parser.add_argument(
+        "--no-bootstrap",
+        dest="with_bootstrap",
+        action="store_false",
+        default=True,
+        help="Skip the bootstrap check-in payload. Default is to send "
+             "initial_state so the server writes a t=0 anchor (per "
+             "onboard-bootstrap-checkin §3.5). Use this for callers that "
+             "explicitly want no bootstrap row.",
+    )
+    parser.add_argument(
         "--slot",
         default=os.environ.get("UNITARES_SESSION_SLOT", ""),
         help="Per-process slot key (typically Claude Code session_id) so "
@@ -257,6 +297,7 @@ def main(argv: list[str] | None = None) -> int:
         workspace=workspace,
         slot=slot,
         force_new=args.force_new,
+        with_bootstrap=args.with_bootstrap,
         auth_token=auth_token,
         timeout=args.timeout,
     )

--- a/tests/test_onboard_helper.py
+++ b/tests/test_onboard_helper.py
@@ -372,3 +372,96 @@ class TestSlotIsolation:
         assert _slot_filename(None) == "session.json"
         assert _slot_filename("") == "session.json"
 
+
+# --- Phase 4: bootstrap initial_state wiring -------------------------------
+
+class TestBootstrapInitialState:
+    """Phase 4 of onboard-bootstrap-checkin.md — the SessionStart hook
+    wires initial_state into the onboard call. Tests live here in the
+    onboard helper test file because the helper owns the wiring."""
+
+    def test_default_attaches_initial_state(self, tmp_path: Path) -> None:
+        """Hook-driven onboards default to with_bootstrap=True so the server
+        writes a t=0 anchor."""
+        poster = FakePoster([_success_response()])
+        run_onboard(
+            server_url="http://fake",
+            agent_name="acme",
+            model_type="claude-code",
+            workspace=tmp_path,
+            post_json=poster,
+        )
+        sent_args = poster.calls[0][1]["arguments"]
+        assert "initial_state" in sent_args
+        assert sent_args["initial_state"]["task_type"] == "introspection"
+        # Hook MUST NOT fabricate confidence/complexity from session metadata —
+        # let the server fill its 0.5 defaults.
+        assert "confidence" not in sent_args["initial_state"]
+        assert "complexity" not in sent_args["initial_state"]
+
+    def test_with_bootstrap_false_omits_initial_state(self, tmp_path: Path) -> None:
+        """Explicit opt-out for callers like /governance-start that want
+        no bootstrap row."""
+        poster = FakePoster([_success_response()])
+        run_onboard(
+            server_url="http://fake",
+            agent_name="acme",
+            model_type="claude-code",
+            workspace=tmp_path,
+            with_bootstrap=False,
+            post_json=poster,
+        )
+        sent_args = poster.calls[0][1]["arguments"]
+        assert "initial_state" not in sent_args
+
+    def test_initial_state_present_on_resume(self, tmp_path: Path) -> None:
+        """Resume via continuity_token still sends initial_state — the
+        server's idempotency contract handles it (returns existing
+        bootstrap row's state_id)."""
+        initial = {
+            "continuity_token": "v1.cached-token",
+            "client_session_id": "agent-cached",
+        }
+        cache_dir = tmp_path / ".unitares"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        (cache_dir / "session.json").write_text(json.dumps(initial))
+
+        poster = FakePoster([_success_response()])
+        run_onboard(
+            server_url="http://fake",
+            agent_name="acme",
+            model_type="claude-code",
+            workspace=tmp_path,
+            post_json=poster,
+        )
+        sent_args = poster.calls[0][1]["arguments"]
+        assert sent_args.get("continuity_token") == "v1.cached-token"
+        assert "initial_state" in sent_args
+
+    def test_initial_state_present_with_force_new(self, tmp_path: Path) -> None:
+        """force_new=True still attaches initial_state — the new identity
+        gets its own t=0 anchor per spec §3.4."""
+        poster = FakePoster([_success_response()])
+        run_onboard(
+            server_url="http://fake",
+            agent_name="acme",
+            model_type="claude-code",
+            workspace=tmp_path,
+            force_new=True,
+            post_json=poster,
+        )
+        sent_args = poster.calls[0][1]["arguments"]
+        assert sent_args.get("force_new") is True
+        assert "initial_state" in sent_args
+
+    def test_initial_state_payload_shape_is_minimal(self, tmp_path: Path) -> None:
+        """The hook-built initial_state contains exactly task_type. Anything
+        beyond that — response_text, complexity, confidence, ethical_drift —
+        is left to the server's defaults so the hook stays honest about
+        what it actually knows at session-start."""
+        from scripts.client.onboard_helper import _build_bootstrap_initial_state
+
+        payload = _build_bootstrap_initial_state()
+        assert set(payload.keys()) == {"task_type"}
+        assert payload["task_type"] == "introspection"
+


### PR DESCRIPTION
Closes Phase 4 of [onboard-bootstrap-checkin.md](docs/proposals/onboard-bootstrap-checkin.md). With Phases 3a + 3b merged, every read path that matters is synthetic-aware, so the hook can safely write t=0 anchors without semantic contamination.

## What

* **`run_onboard()` gains `with_bootstrap: bool = True`.** Default-on attaches `initial_state={'task_type': 'introspection'}` to the onboard payload so the server writes a synthetic bootstrap row tagged `source='bootstrap'`.
* **Hook stays honest.** The hook MUST NOT fabricate `confidence` or `complexity` from session metadata (per spec §3.5). The helper sends only `task_type`; the server fills 0.5 defaults for the rest and composes `response_text` from `client_hint`.
* **CLI opt-out via `--no-bootstrap`.** For callers like manual `/governance-start` invocations that want to test identity recovery in isolation without writing a bootstrap row.

## Substrate-earned exemption

Server-side defensive check (Phase 2's `is_substrate_earned`) handles this. The hook can safely send `initial_state` unconditionally — substrate-earned identities receive `bootstrap.written: false` with `reason='substrate-earned-exempt'` and no row is written.

In practice no substrate-earned resident runs through this hook anyway (Vigil/Sentinel/Chronicler are launchd-managed processes that don't fire SessionStart), so the structural protection is "residents don't fire the hook."

## Idempotency on resume

Migration 018's unique partial index + Phase 2's digest contract mean a resumed onboard returns the existing bootstrap row's `state_id` with `payload_digest_match`. No second row is written.

## What's NOT in this PR

* The Codex equivalent in the public `unitares-governance-plugin` repo — separate ship, and `initial_state` is optional so existing plugin versions keep working without sending it.
* Phase 5 (population observability for bootstrapped-but-silent agents) — last phase.

## Tests

5 new tests in `TestBootstrapInitialState`:
- `test_default_attaches_initial_state` — load-bearing default
- `test_with_bootstrap_false_omits_initial_state` — explicit opt-out
- `test_initial_state_present_on_resume` — resume still sends it (server idempotency handles)
- `test_initial_state_present_with_force_new` — fresh identity gets its own t=0 anchor (spec §3.4)
- `test_initial_state_payload_shape_is_minimal` — hook stays honest, only `task_type`

Existing 23 onboard helper tests still pass — default-on doesn't break them.

Full suite: **7391 passed, 33 skipped, 77.88% coverage**.

## Phase progress

| Phase | PR | State |
|---|---|---|
| 1 — schema | #168 | merged |
| 2 — handler | #171 | merged |
| 3a — load-bearing filters + matview measured-only | #173 | merged |
| 3b — history + hydration | #178 | merged |
| 4 — SessionStart hook | this PR | pending |
| 5 — population observability | next | — |

Once this merges, **bootstrap check-ins go live for all hook-driven Claude Code sessions in this repo.** Phase 5 adds the dashboard panel + query path so we can measure whether the fix is working at population level.