### PR TITLE
test(substrate): mock sys.platform=darwin in launchctl test fixture

### DIFF
--- a/tests/test_substrate_peer_attestation.py
+++ b/tests/test_substrate_peer_attestation.py
@@ -97,6 +97,11 @@ def _mock_launchctl(monkeypatch: pytest.MonkeyPatch, *, returncode: int = 0,
     fake.returncode = returncode
     fake.stdout = stdout
     monkeypatch.setattr(pa.subprocess, "run", lambda *a, **k: fake)
+    # On non-darwin CI, pa._require_supported_platform() raises NotImplementedError
+    # before the subprocess mock can take effect — these tests exercise the
+    # launchctl parser, which is a pure-Python operation worth testing on every
+    # platform. Spoof platform=darwin so the parser is reachable everywhere.
+    monkeypatch.setattr(pa.sys, "platform", "darwin")
 
 
 def test_read_service_label_finds_governance_mcp(

--- a/tests/test_substrate_peer_attestation.py
+++ b/tests/test_substrate_peer_attestation.py
@@ -147,6 +147,7 @@ def test_read_service_label_rejects_negative_pid_without_subprocess(
     Defense in depth: even if a caller passes a malformed PID upstream,
     we don't shell out and don't risk a false-positive on a shell quirk.
     """
+    monkeypatch.setattr(pa.sys, "platform", "darwin")
     called = MagicMock()
     monkeypatch.setattr(pa.subprocess, "run", called)
     assert pa.read_service_label(-1) is None
@@ -166,6 +167,7 @@ def test_read_service_label_handles_missing_launchctl(
     def boom(*a: object, **k: object) -> None:
         raise FileNotFoundError("launchctl")
 
+    monkeypatch.setattr(pa.sys, "platform", "darwin")
     monkeypatch.setattr(pa.subprocess, "run", boom)
     assert pa.read_service_label(123) is None
 
@@ -174,6 +176,7 @@ def test_read_service_label_handles_timeout(monkeypatch: pytest.MonkeyPatch) -> 
     def boom(*a: object, **k: object) -> None:
         raise subprocess.TimeoutExpired(["launchctl", "list"], 2.0)
 
+    monkeypatch.setattr(pa.sys, "platform", "darwin")
     monkeypatch.setattr(pa.subprocess, "run", boom)
     assert pa.read_service_label(123) is None
 


### PR DESCRIPTION
## Summary
- Extends `_mock_launchctl` in `tests/test_substrate_peer_attestation.py` to spoof `pa.sys.platform = \"darwin\"` so the production platform gate doesn't raise `NotImplementedError` before the subprocess mock can take effect
- Unblocks 9 `read_service_label` tests that have been silently failing on Linux CI

## Why
The 9 tests mock `pa.subprocess.run` to return canned launchctl stdout, but `read_service_label()` calls `_require_supported_platform()` first, which raises `NotImplementedError(\"S19 Linux backend not yet implemented\")` on non-darwin. The launchctl parser is pure Python — worth testing on every platform — so spoofing the platform gate in the fixture is correct.

## Side effect
This is the baseline-master failure that has been blocking PR #179 (KG UTC-normalization fix). #179 doesn't touch substrate code at all but inherits the failing `test (3.12)` job. Once this lands, #179 should be cleanly mergeable on its own merits.

## Test plan
- [x] `pytest tests/test_substrate_peer_attestation.py` on macOS — 22/22 pass
- [ ] CI run on Linux (PR check) — should now also pass all 22