### PR TITLE
feat(identity): X-Unitares-Operator header + is_operator_caller helper

### DIFF
--- a/src/http_api.py
+++ b/src/http_api.py
@@ -71,6 +71,7 @@ def _build_http_session_signals(request):
         x_agent_name=request.headers.get("x-agent-name"),
         x_agent_id=request.headers.get("x-agent-id"),
         transport="rest",
+        unitares_operator_token=request.headers.get("x-unitares-operator"),
     )
 
 

--- a/src/mcp_handlers/context.py
+++ b/src/mcp_handlers/context.py
@@ -44,6 +44,16 @@ class SessionSignals:
     # LOCAL_PEERPID; left None for HTTP/SSE/stdio transports. Read by the
     # substrate-claim verification path in src/substrate/verification.py.
     peer_pid: Optional[int] = None
+    # Operator-tier credential (X-Unitares-Operator header). Application-level
+    # bearer token presented by trusted infrastructure (Discord bridge,
+    # dashboard, ollama bridge) to opt into operator-class privileges in
+    # specific handlers (initially: list_agents UUID disclosure). Compared
+    # against UNITARES_OPERATOR_TOKENS env-var allowlist by
+    # ``is_operator_caller`` in ``src/mcp_handlers/identity/operator.py``.
+    # Distinct from transport fingerprints — see KG 2026-04-20T00:57:45 and
+    # docs/proposals/list-agents-uuid-redaction.code-review.md for why
+    # client_session_id cannot serve this role.
+    unitares_operator_token: Optional[str] = None
 
 # Contextvar for SessionSignals — set once per request at the transport layer
 _session_signals: ContextVar[Optional[SessionSignals]] = ContextVar('session_signals', default=None)

--- a/src/mcp_handlers/identity/operator.py
+++ b/src/mcp_handlers/identity/operator.py
@@ -1,0 +1,95 @@
+"""
+Operator-tier authorization for handlers that need to disclose
+cross-agent UUIDs (initially: list_agents).
+
+Background — KG 2026-04-20T00:57:45 found that ``list_agents`` returns
+every agent's UUID to any caller, enabling a two-call identity hijack
+when combined with the PATH 1 ``agent-{uuid12}`` prefix-bind. The
+proposed fix at ``docs/proposals/list-agents-uuid-redaction.md``
+redacts UUIDs except for "operator-class" callers — trusted
+infrastructure (Discord bridge, dashboard, ollama bridge) that
+genuinely needs full visibility.
+
+Code review of that proposal showed that ``client_session_id`` cannot
+serve as the operator credential: it is a transport fingerprint
+(IP:UA, MCP session header, or ``agent-{uuid12}`` prefix), not an
+application-level bearer token. This module is the explicit auth
+surface that the redaction PR will read from.
+
+Design:
+
+- Operators present an ``X-Unitares-Operator: <token>`` header.
+- The header is captured into ``SessionSignals.unitares_operator_token``
+  by the ASGI/HTTP layer.
+- Tokens are compared against ``UNITARES_OPERATOR_TOKENS`` (csv env
+  var). Empty/unset → operator status is unavailable to anyone.
+- Default deny: if no token is presented or no allowlist is
+  configured, ``is_operator_caller`` returns False.
+
+Token storage:
+
+- Tokens are deployment secrets. Recommended location:
+  ``~/.config/cirwel/secrets.env`` (mode 600) per
+  ``project_secrets-location`` memory.
+- Bridge/dashboard/ollama plists or systemd units load the token
+  into the client process and pass it on every request.
+- Rotation is operator action: update the env var in
+  ``UNITARES_OPERATOR_TOKENS`` and reissue tokens to clients.
+- Tokens should be high-entropy random strings (e.g. ``openssl rand
+  -hex 32``). Use one token per client identity, not a shared one,
+  so a compromise can be revoked without disrupting all operators.
+"""
+
+import os
+from typing import Optional, Set
+
+from src.mcp_handlers.context import SessionSignals, get_session_signals
+
+
+_OPERATOR_TOKENS_ENV = "UNITARES_OPERATOR_TOKENS"
+
+
+def _allowlisted_tokens() -> Set[str]:
+    """Parse the operator-token allowlist from env at call time.
+
+    Read fresh each call rather than caching, so operators can rotate
+    tokens without restarting the server. The set is small (a handful
+    of entries) and the env read is cheap.
+    """
+    raw = os.environ.get(_OPERATOR_TOKENS_ENV, "")
+    return {t.strip() for t in raw.split(",") if t.strip()}
+
+
+def is_operator_caller(signals: Optional[SessionSignals] = None) -> bool:
+    """Return True if the current request presents a valid operator token.
+
+    The check is two-part:
+
+    1. The request must carry a non-empty ``X-Unitares-Operator``
+       header, captured into ``SessionSignals.unitares_operator_token``.
+    2. The presented value must match a token in
+       ``UNITARES_OPERATOR_TOKENS`` (csv env var).
+
+    Both halves must hold. Empty header, missing env var, or empty
+    allowlist all yield False (default deny).
+
+    ``signals`` is optional; if omitted, we read from the contextvar
+    set by the ASGI/HTTP layer. Callers in non-request contexts (e.g.
+    in-process resident agents) will see ``signals=None`` and get
+    False — they have other paths to operator-class data and should
+    not pretend to be HTTP operators.
+    """
+    if signals is None:
+        signals = get_session_signals()
+    if signals is None:
+        return False
+
+    presented = signals.unitares_operator_token
+    if not presented:
+        return False
+
+    allowlist = _allowlisted_tokens()
+    if not allowlist:
+        return False
+
+    return presented in allowlist

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -874,6 +874,7 @@ async def main():
                         x_agent_id=headers.get("x-agent-id"),
                         transport=_transport_label,
                         peer_pid=_peer_pid,
+                        unitares_operator_token=headers.get("x-unitares-operator"),
                     )
                     signals_token = set_session_signals(signals)
 

--- a/tests/test_operator_auth.py
+++ b/tests/test_operator_auth.py
@@ -1,0 +1,96 @@
+"""
+Tests for src/mcp_handlers/identity/operator.py — operator-tier auth helper.
+
+Background: prerequisite for the list_agents UUID redaction PR
+(KG 2026-04-20T00:57:45). The helper checks an explicit
+``X-Unitares-Operator`` header against an env-var allowlist; the test
+matrix here exists so that when the redaction PR lands, the gate it
+relies on is already proven correct.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.mcp_handlers.context import SessionSignals, set_session_signals, reset_session_signals
+from src.mcp_handlers.identity.operator import is_operator_caller
+
+
+def _signals(token=None) -> SessionSignals:
+    return SessionSignals(unitares_operator_token=token, transport="mcp")
+
+
+class TestIsOperatorCaller:
+
+    def test_explicit_signals_arg_match(self, monkeypatch):
+        monkeypatch.setenv("UNITARES_OPERATOR_TOKENS", "alpha,beta")
+        assert is_operator_caller(_signals(token="alpha")) is True
+        assert is_operator_caller(_signals(token="beta")) is True
+
+    def test_explicit_signals_arg_miss(self, monkeypatch):
+        monkeypatch.setenv("UNITARES_OPERATOR_TOKENS", "alpha,beta")
+        assert is_operator_caller(_signals(token="gamma")) is False
+
+    def test_no_token_presented(self, monkeypatch):
+        monkeypatch.setenv("UNITARES_OPERATOR_TOKENS", "alpha")
+        assert is_operator_caller(_signals(token=None)) is False
+        assert is_operator_caller(_signals(token="")) is False
+
+    def test_empty_allowlist_denies_everything(self, monkeypatch):
+        monkeypatch.setenv("UNITARES_OPERATOR_TOKENS", "")
+        assert is_operator_caller(_signals(token="alpha")) is False
+
+    def test_missing_allowlist_env_denies_everything(self, monkeypatch):
+        monkeypatch.delenv("UNITARES_OPERATOR_TOKENS", raising=False)
+        assert is_operator_caller(_signals(token="alpha")) is False
+
+    def test_no_signals_no_context_denies(self, monkeypatch):
+        monkeypatch.setenv("UNITARES_OPERATOR_TOKENS", "alpha")
+        # signals=None and no contextvar set → False (in-process callers)
+        assert is_operator_caller(None) is False
+
+    def test_reads_from_contextvar_when_signals_omitted(self, monkeypatch):
+        monkeypatch.setenv("UNITARES_OPERATOR_TOKENS", "alpha")
+        token = set_session_signals(_signals(token="alpha"))
+        try:
+            assert is_operator_caller() is True
+        finally:
+            reset_session_signals(token)
+
+    def test_csv_whitespace_tolerated(self, monkeypatch):
+        monkeypatch.setenv("UNITARES_OPERATOR_TOKENS", "  alpha , beta  ")
+        assert is_operator_caller(_signals(token="alpha")) is True
+        assert is_operator_caller(_signals(token="beta")) is True
+
+    def test_token_case_sensitive(self, monkeypatch):
+        """Tokens are bearer secrets — must match exactly, including case."""
+        monkeypatch.setenv("UNITARES_OPERATOR_TOKENS", "AlphaTOKEN")
+        assert is_operator_caller(_signals(token="AlphaTOKEN")) is True
+        assert is_operator_caller(_signals(token="alphatoken")) is False
+
+    def test_rotation_visible_immediately(self, monkeypatch):
+        """Rotating tokens via env without restart should take effect on next call."""
+        monkeypatch.setenv("UNITARES_OPERATOR_TOKENS", "old-token")
+        sig = _signals(token="old-token")
+        assert is_operator_caller(sig) is True
+        monkeypatch.setenv("UNITARES_OPERATOR_TOKENS", "new-token")
+        assert is_operator_caller(sig) is False
+        monkeypatch.setenv("UNITARES_OPERATOR_TOKENS", "old-token,new-token")
+        assert is_operator_caller(sig) is True
+
+
+class TestSessionSignalsField:
+    """Plumbing assertion: the new field is reachable through the dataclass."""
+
+    def test_field_default_none(self):
+        s = SessionSignals()
+        assert s.unitares_operator_token is None
+
+    def test_field_set_explicitly(self):
+        s = SessionSignals(unitares_operator_token="x")
+        assert s.unitares_operator_token == "x"


### PR DESCRIPTION
## Summary

Adds explicit operator-tier auth surface so handlers that need to disclose cross-agent UUIDs can distinguish trusted infrastructure (Discord bridge, dashboard, ollama bridge) from arbitrary callers — separately from the identity-binding ladder.

- New `SessionSignals.unitares_operator_token` captured from the `X-Unitares-Operator` header in both ASGI paths (`mcp_server.py` and `http_api.py`)
- New `src/mcp_handlers/identity/operator.py` with `is_operator_caller()`, checking the header value against `UNITARES_OPERATOR_TOKENS` env csv. Default deny: empty header, missing env, or empty allowlist all return False.
- 12 unit tests covering match, miss, empty allowlist, missing env, contextvar fallback, csv whitespace, case sensitivity, rotation.

## Why

Prerequisite for the list_agents UUID redaction PR (KG \`2026-04-20T00:57:45.655488\`). The proposal at \`docs/proposals/list-agents-uuid-redaction.md\` and its code review identified that \`client_session_id\` (a transport fingerprint, not a bearer token) cannot serve as the operator credential. This is the explicit auth surface the redaction will read from.

No behavior change to any existing handler — ground laid only.

## Test plan

- [x] \`pytest tests/test_operator_auth.py\` — 12 passed
- [x] \`./scripts/dev/test-cache.sh\` — 7432 passed, 33 skipped