### PR TITLE
feat: phase 5 — bootstrap-only observability query path + REST endpoint

### DIFF
--- a/src/db/mixins/state.py
+++ b/src/db/mixins/state.py
@@ -131,6 +131,77 @@ class StateMixin:
                 )
             )
 
+    async def list_bootstrap_only_agents(
+        self,
+        min_age_hours: int = 24,
+        limit: int = 200,
+    ) -> List[Dict[str, Any]]:
+        """Agents with a bootstrap row but no measured check-in past the age window.
+
+        This is the validation surface for onboard-bootstrap-checkin §6 —
+        the population the proposal exists to count. The default 24-hour
+        window filters out agents that just onboarded and may genuinely be
+        about to check in; a positive count past 24h means the agent
+        bootstrapped and went silent.
+
+        Returns most-recent bootstraps first. Row shape:
+          {agent_id, identity_id, bootstrap_state_id, bootstrap_recorded_at,
+           bootstrap_age_hours, display_name}
+        """
+        async with self.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT i.agent_id,
+                       i.identity_id,
+                       b.state_id AS bootstrap_state_id,
+                       b.recorded_at AS bootstrap_recorded_at,
+                       EXTRACT(EPOCH FROM (now() - b.recorded_at)) / 3600.0
+                           AS bootstrap_age_hours,
+                       (i.metadata->>'display_name') AS display_name
+                FROM core.identities i
+                JOIN core.agent_state b
+                  ON b.identity_id = i.identity_id
+                  AND b.synthetic = true
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM core.agent_state m
+                    WHERE m.identity_id = i.identity_id
+                      AND m.synthetic = false
+                )
+                  AND b.recorded_at <= now() - ($1 * interval '1 hour')
+                ORDER BY b.recorded_at DESC
+                LIMIT $2
+                """,
+                min_age_hours, limit,
+            )
+            return [dict(r) for r in rows]
+
+    async def count_bootstrap_only_agents(
+        self,
+        min_age_hours: int = 24,
+    ) -> int:
+        """Count of agents bootstrapped past the age window with no measured
+        check-in. Cheap query for dashboard count badges."""
+        async with self.acquire() as conn:
+            return int(
+                await conn.fetchval(
+                    """
+                    SELECT COUNT(*)
+                    FROM core.identities i
+                    JOIN core.agent_state b
+                      ON b.identity_id = i.identity_id
+                      AND b.synthetic = true
+                    WHERE NOT EXISTS (
+                        SELECT 1 FROM core.agent_state m
+                        WHERE m.identity_id = i.identity_id
+                          AND m.synthetic = false
+                    )
+                      AND b.recorded_at <= now() - ($1 * interval '1 hour')
+                    """,
+                    min_age_hours,
+                )
+                or 0
+            )
+
     async def get_latest_agent_state(
         self,
         identity_id: int,

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -1304,6 +1304,73 @@ def _watcher_summary_from_rows(rows, now=None, window_days=_WATCHER_DAILY_WINDOW
     }
 
 
+async def http_bootstrap_silent(request):
+    """GET /v1/bootstrap/silent — agents bootstrapped past N hours with no real check-in.
+
+    Validation surface for onboard-bootstrap-checkin §6 (population
+    observability). The proposal exists to count exactly this population:
+    agents with a synthetic t=0 anchor but no measured trajectory.
+
+    Query params:
+      min_age_hours (int, default 24): skip recently-bootstrapped agents
+                                       that may genuinely be about to check in.
+      limit (int, default 50, max 200): cap the returned list.
+
+    Returns:
+      {success, count, min_age_hours, agents: [{agent_id, identity_id,
+        bootstrap_state_id, bootstrap_recorded_at, bootstrap_age_hours,
+        display_name}]}
+    """
+    http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
+    if not _check_http_auth(request, http_api_token=http_api_token):
+        return _http_unauthorized()
+
+    try:
+        min_age_hours = int(request.query_params.get("min_age_hours", 24))
+    except (TypeError, ValueError):
+        min_age_hours = 24
+    min_age_hours = max(0, min_age_hours)
+
+    try:
+        limit = int(request.query_params.get("limit", 50))
+    except (TypeError, ValueError):
+        limit = 50
+    limit = max(1, min(limit, 200))
+
+    try:
+        from src.db import get_db
+        db = get_db()
+        count = await db.count_bootstrap_only_agents(min_age_hours=min_age_hours)
+        rows = await db.list_bootstrap_only_agents(
+            min_age_hours=min_age_hours, limit=limit,
+        )
+    except Exception as e:
+        return JSONResponse(
+            {"success": False, "error": f"bootstrap_silent query failed: {e}"},
+            status_code=500,
+        )
+
+    # Datetimes need to be JSON-serializable.
+    def _norm(row):
+        out = dict(row)
+        ts = out.get("bootstrap_recorded_at")
+        if ts is not None and hasattr(ts, "isoformat"):
+            out["bootstrap_recorded_at"] = ts.isoformat()
+        age = out.get("bootstrap_age_hours")
+        if age is not None:
+            out["bootstrap_age_hours"] = round(float(age), 3)
+        return out
+
+    return JSONResponse({
+        "success": True,
+        "count": count,
+        "min_age_hours": min_age_hours,
+        "limit": limit,
+        "returned": len(rows),
+        "agents": [_norm(r) for r in rows],
+    })
+
+
 async def http_watcher_summary(request):
     """GET /v1/watcher/summary — aggregate Watcher findings for the dashboard panel.
 
@@ -2347,6 +2414,7 @@ def register_http_routes(
     app.routes.append(Route("/v1/metrics/series", http_get_metrics, methods=["GET"]))
     app.routes.append(Route("/v1/metrics/catalog", http_get_metrics_catalog, methods=["GET"]))
     app.routes.append(Route("/v1/watcher/summary", http_watcher_summary, methods=["GET"]))
+    app.routes.append(Route("/v1/bootstrap/silent", http_bootstrap_silent, methods=["GET"]))
     app.routes.append(Route("/v1/sentinel/summary", http_sentinel_summary, methods=["GET"]))
     app.routes.append(Route("/v1/vigil/summary", http_vigil_summary, methods=["GET"]))
     app.routes.append(Route("/api/activity", http_activity, methods=["GET"]))

--- a/tests/test_bootstrap_only_observability.py
+++ b/tests/test_bootstrap_only_observability.py
@@ -1,0 +1,287 @@
+"""Phase 5 observability tests for onboard-bootstrap-checkin.
+
+Covers the population query surface defined in spec §6 + the REST endpoint
+that exposes it to the dashboard.
+
+DAO:
+  - list_bootstrap_only_agents(min_age_hours=24)
+  - count_bootstrap_only_agents(min_age_hours=24)
+
+REST:
+  - GET /v1/bootstrap/silent
+
+Spec: docs/proposals/onboard-bootstrap-checkin.md §6.
+"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+try:
+    import asyncpg  # noqa: F401
+except ImportError:
+    pytest.skip("asyncpg not installed", allow_module_level=True)
+
+from tests.test_db_utils import can_connect_to_test_db
+
+if not can_connect_to_test_db():
+    pytest.skip("governance_test database not available", allow_module_level=True)
+
+from src.mcp_handlers.identity.bootstrap_checkin import write_bootstrap
+from src.mcp_handlers.schemas.core import BootstrapStateParams
+
+
+@pytest.fixture
+def db(live_postgres_backend):
+    return live_postgres_backend
+
+
+async def _seed_identity(db) -> tuple[str, int]:
+    agent_id = f"test-{uuid.uuid4()}"
+    async with db.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO core.agents (id, api_key) VALUES ($1, 'test-key')",
+            agent_id,
+        )
+        identity_id = await conn.fetchval(
+            """
+            INSERT INTO core.identities (agent_id, api_key_hash)
+            VALUES ($1, 'test-hash')
+            RETURNING identity_id
+            """,
+            agent_id,
+        )
+    return agent_id, identity_id
+
+
+async def _backdate_state(db, state_id: int, hours: float):
+    """Push a state row's recorded_at into the past so age-window filters fire."""
+    async with db.acquire() as conn:
+        await conn.execute(
+            """
+            UPDATE core.agent_state
+            SET recorded_at = now() - ($1 * interval '1 hour')
+            WHERE state_id = $2
+            """,
+            hours, state_id,
+        )
+
+
+# ---------------------------------------------------------------------------
+# DAO: list_bootstrap_only_agents
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_bootstrap_only_picks_aged_silent_agent(db):
+    """Agent bootstrapped 25h ago, no real check-in: appears in the list."""
+    agent_id, identity_id = await _seed_identity(db)
+    block = await write_bootstrap(
+        db, identity_id=identity_id, agent_id=agent_id,
+        params=BootstrapStateParams(),
+    )
+    await _backdate_state(db, block["state_id"], hours=25.0)
+
+    rows = await db.list_bootstrap_only_agents(min_age_hours=24)
+    matching = [r for r in rows if r["identity_id"] == identity_id]
+    assert len(matching) == 1
+    assert matching[0]["agent_id"] == agent_id
+    assert matching[0]["bootstrap_state_id"] == block["state_id"]
+    assert matching[0]["bootstrap_age_hours"] >= 24.0
+
+
+@pytest.mark.asyncio
+async def test_list_bootstrap_only_skips_recent_bootstrap(db):
+    """A bootstrap < min_age_hours old is excluded — caller may still check in."""
+    agent_id, identity_id = await _seed_identity(db)
+    await write_bootstrap(
+        db, identity_id=identity_id, agent_id=agent_id,
+        params=BootstrapStateParams(),
+    )
+    # Default age is "now"; with min_age_hours=24 this row is too fresh.
+
+    rows = await db.list_bootstrap_only_agents(min_age_hours=24)
+    matching = [r for r in rows if r["identity_id"] == identity_id]
+    assert len(matching) == 0
+
+
+@pytest.mark.asyncio
+async def test_list_bootstrap_only_excludes_agents_with_real_checkin(db):
+    """Agent with a measured row never appears regardless of age."""
+    agent_id, identity_id = await _seed_identity(db)
+    block = await write_bootstrap(
+        db, identity_id=identity_id, agent_id=agent_id,
+        params=BootstrapStateParams(),
+    )
+    await _backdate_state(db, block["state_id"], hours=25.0)
+    await db.record_agent_state(
+        identity_id=identity_id,
+        entropy=0.4, integrity=0.6, stability_index=0.5,
+        void=0.0, regime="nominal", coherence=1.0, state_json={},
+    )
+
+    rows = await db.list_bootstrap_only_agents(min_age_hours=24)
+    assert all(r["identity_id"] != identity_id for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_list_bootstrap_only_orders_most_recent_first(db):
+    """Multiple silent agents come back newest-bootstrap first."""
+    a_id, a_iid = await _seed_identity(db)
+    b_id, b_iid = await _seed_identity(db)
+    a_block = await write_bootstrap(db, identity_id=a_iid, agent_id=a_id,
+                                    params=BootstrapStateParams())
+    b_block = await write_bootstrap(db, identity_id=b_iid, agent_id=b_id,
+                                    params=BootstrapStateParams())
+    # Push both past the 24h gate; A older, B more recent.
+    await _backdate_state(db, a_block["state_id"], hours=72.0)
+    await _backdate_state(db, b_block["state_id"], hours=30.0)
+
+    rows = await db.list_bootstrap_only_agents(min_age_hours=24)
+    seen_ids = [r["agent_id"] for r in rows if r["agent_id"] in (a_id, b_id)]
+    assert seen_ids == [b_id, a_id]
+
+
+@pytest.mark.asyncio
+async def test_list_bootstrap_only_respects_limit(db):
+    """The limit parameter caps the result set."""
+    seeded_ids = []
+    for _ in range(3):
+        agent_id, identity_id = await _seed_identity(db)
+        block = await write_bootstrap(db, identity_id=identity_id, agent_id=agent_id,
+                                      params=BootstrapStateParams())
+        await _backdate_state(db, block["state_id"], hours=48.0)
+        seeded_ids.append(agent_id)
+
+    rows = await db.list_bootstrap_only_agents(min_age_hours=24, limit=2)
+    assert len(rows) <= 2
+
+
+# ---------------------------------------------------------------------------
+# DAO: count_bootstrap_only_agents
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_count_matches_list(db):
+    for _ in range(2):
+        agent_id, identity_id = await _seed_identity(db)
+        block = await write_bootstrap(db, identity_id=identity_id, agent_id=agent_id,
+                                      params=BootstrapStateParams())
+        await _backdate_state(db, block["state_id"], hours=48.0)
+
+    count = await db.count_bootstrap_only_agents(min_age_hours=24)
+    rows = await db.list_bootstrap_only_agents(min_age_hours=24, limit=500)
+    # The shared truncation in conftest scopes this to just-seeded rows.
+    assert count == len(rows)
+    assert count >= 2
+
+
+@pytest.mark.asyncio
+async def test_count_zero_when_no_silent_agents(db):
+    """Just measured agents → count is 0."""
+    _, identity_id = await _seed_identity(db)
+    await db.record_agent_state(
+        identity_id=identity_id,
+        entropy=0.4, integrity=0.6, stability_index=0.5,
+        void=0.0, regime="nominal", coherence=1.0, state_json={},
+    )
+    count = await db.count_bootstrap_only_agents(min_age_hours=24)
+    assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# REST endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_http_bootstrap_silent_returns_aged_agents(db, monkeypatch):
+    """GET /v1/bootstrap/silent shapes the DAO output for the dashboard."""
+    from starlette.requests import Request
+    from src.http_api import http_bootstrap_silent
+
+    agent_id, identity_id = await _seed_identity(db)
+    block = await write_bootstrap(db, identity_id=identity_id, agent_id=agent_id,
+                                  params=BootstrapStateParams())
+    await _backdate_state(db, block["state_id"], hours=48.0)
+
+    # Auth disabled so the test doesn't need a token.
+    monkeypatch.setenv("UNITARES_HTTP_API_TOKEN", "")
+
+    # Wire the request to our test backend.
+    import src.db as db_module
+    monkeypatch.setattr(db_module, "get_db", lambda: db)
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/v1/bootstrap/silent",
+        "headers": [],
+        "query_string": b"min_age_hours=24",
+    }
+    request = Request(scope)
+
+    response = await http_bootstrap_silent(request)
+    import json as _json
+    body = _json.loads(response.body)
+    assert body["success"] is True
+    assert body["min_age_hours"] == 24
+    assert body["count"] >= 1
+    assert any(r["agent_id"] == agent_id for r in body["agents"])
+    matching = next(r for r in body["agents"] if r["agent_id"] == agent_id)
+    assert matching["bootstrap_state_id"] == block["state_id"]
+    # Datetime serialized as ISO string; age serialized as float.
+    assert isinstance(matching["bootstrap_recorded_at"], str)
+    assert isinstance(matching["bootstrap_age_hours"], float)
+
+
+@pytest.mark.asyncio
+async def test_http_bootstrap_silent_rejects_unauth(db, monkeypatch):
+    """When a token is configured but not presented, the endpoint 401s."""
+    from starlette.requests import Request
+    from src.http_api import http_bootstrap_silent
+
+    monkeypatch.setenv("UNITARES_HTTP_API_TOKEN", "secret-test-token")
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/v1/bootstrap/silent",
+        "headers": [],
+        "query_string": b"",
+    }
+    request = Request(scope)
+    response = await http_bootstrap_silent(request)
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_http_bootstrap_silent_clamps_limit(db, monkeypatch):
+    """limit=9999 gets clamped to 200 (max defined in the handler)."""
+    from starlette.requests import Request
+    from src.http_api import http_bootstrap_silent
+
+    monkeypatch.setenv("UNITARES_HTTP_API_TOKEN", "")
+    import src.db as db_module
+    monkeypatch.setattr(db_module, "get_db", lambda: db)
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/v1/bootstrap/silent",
+        "headers": [],
+        "query_string": b"limit=9999",
+    }
+    request = Request(scope)
+    response = await http_bootstrap_silent(request)
+    import json as _json
+    body = _json.loads(response.body)
+    assert body["limit"] == 200


### PR DESCRIPTION
Closes Phase 5 of [onboard-bootstrap-checkin.md](docs/proposals/onboard-bootstrap-checkin.md). The validation surface that lets us measure whether the bootstrap-checkin fix is working at population level.

## Scope decision

Server-side scope only this PR; the dashboard count badge / panel is a tightly-scoped follow-up per spec §6.2 ("REQUIRED in same PR or follow-up"). Deliberately split because dashboard work has documented 4x rework history per the `unitares-dashboard` skill and warrants its own attention. The query is queryable via curl/script today, which is enough to start measuring.

## What

* **`StateMixin.list_bootstrap_only_agents(min_age_hours=24, limit=200)`** — identities with a synthetic bootstrap row + NO measured row, past the configurable age window. Returns most-recent-bootstrap first.
* **`StateMixin.count_bootstrap_only_agents(min_age_hours=24)`** — cheap COUNT for badge use.
* **`GET /v1/bootstrap/silent`** — exposes both via the existing token-gated REST path. Query params `min_age_hours` (default 24, clamps min 0) and `limit` (default 50, max 200). Returns:
  ```json
  {
    "success": true,
    "count": 7,
    "min_age_hours": 24,
    "limit": 50,
    "returned": 7,
    "agents": [
      {
        "agent_id": "...",
        "identity_id": 42,
        "bootstrap_state_id": 1234,
        "bootstrap_recorded_at": "2026-04-24T18:00:00+00:00",
        "bootstrap_age_hours": 25.012,
        "display_name": "..."
      }
    ]
  }
  ```

The default 24h gate filters out agents that just onboarded and may genuinely be about to check in. A positive count past 24h means the agent bootstrapped and went silent — exactly the population the proposal exists to count.

## Why this matters

This closes the §5 honesty loop. The supersession argument was: "the cost of a wrong bootstrap value is bounded by one decay cycle, but for sparse-cadence agents the transient regime can persist longer." That's an empirical claim. This endpoint lets us measure it. If `count` is consistently low or trends down, (1)+(3) is working. If it stays high, the §5 warning was right and a "first real wins" mechanism becomes the post-measurement next step.

## Tests

10 new tests in `tests/test_bootstrap_only_observability.py`:
- `test_list_bootstrap_only_picks_aged_silent_agent` — happy path
- `test_list_bootstrap_only_skips_recent_bootstrap` — age gate works
- `test_list_bootstrap_only_excludes_agents_with_real_checkin` — measured rows disqualify
- `test_list_bootstrap_only_orders_most_recent_first` — newest-first ordering
- `test_list_bootstrap_only_respects_limit` — limit cap honored
- `test_count_matches_list` — DAO consistency
- `test_count_zero_when_no_silent_agents` — measured-only agents don't count
- `test_http_bootstrap_silent_returns_aged_agents` — REST shape OK
- `test_http_bootstrap_silent_rejects_unauth` — auth gate works
- `test_http_bootstrap_silent_clamps_limit` — defensive bound

Full suite: **7430 passed, 33 skipped, 77.91% coverage**.

## What's NOT in this PR

- **Dashboard count badge / panel** — separate follow-up, scoped tightly to dashboard skill conventions (allowlist, Chart.js dark theme, `authFetch`, etc.).
- **Sentinel signal + alert** — post-merge per spec, gated on data accumulation.
- **MCP tool surface** — REST is sufficient for dashboard use; MCP can be added if a use case materializes.

## Phase progress — full proposal complete (server-side)

| Phase | PR | State |
|---|---|---|
| 1 — schema | #168 | merged |
| 2 — handler | #171 | merged |
| 3a — load-bearing filters + matview measured-only | #173 | merged |
| 3b — history + hydration | #178 | merged |
| 4 — SessionStart hook | #183 | merged |
| 5 — observability query path | this PR | pending |
| Follow-up — dashboard surface | optional, scoped | not started |