### PR TITLE
docs(coherence): cross-link legacy thermodynamic and canonical manifold forms

### DIFF
--- a/governance_core/coherence.py
+++ b/governance_core/coherence.py
@@ -1,5 +1,24 @@
 """
-UNITARES Governance Core - Coherence Functions
+UNITARES Governance Core - Coherence Functions (LEGACY THERMODYNAMIC FORM)
+
+NOTE — terminology drift. The `coherence` field exposed in MCP responses
+(`process_agent_update`, governance metrics, dashboards) is NO LONGER this
+`C(V, Θ)`. As of EISV grounding Phase 1+2 (PR #26, merged 2026-04-19), the
+canonical `coherence` slot in the runtime metrics dict is computed by
+`src/grounding/coherence.py::compute_coherence` — a manifold-distance form
+over (E, I, S) from a class-conditional healthy operating point. V is not
+in that formula. The thermodynamic value computed here lives in metrics as
+`coherence_legacy`.
+
+Use this module when you specifically want the V-driven thermodynamic
+coherence (e.g. ODE integration, drift telemetry baselines). For "is this
+agent's state coherent" questions in handler/response code, read
+`metrics["coherence"]` (manifold form) or `metrics["coherence_legacy"]`
+(this form) — and be explicit about which one your code depends on.
+
+See `src/mcp_handlers/updates/enrichments.py` for the swap site that
+populates both fields, and the paper v6.8.1 §6.7 translation table for
+the vocabulary mapping (paper ↔ runtime ↔ audit).
 
 Coherence is a key feedback mechanism in UNITARES that stabilizes
 the system. It depends on the void integral V and control parameters Θ.

--- a/src/grounding/coherence.py
+++ b/src/grounding/coherence.py
@@ -1,10 +1,22 @@
-"""Coherence — spec §3.1 Coherence.
+"""Coherence — spec §3.1 Coherence (CANONICAL runtime form).
+
+This is the form populated into `metrics["coherence"]` by
+`src/mcp_handlers/updates/enrichments.py` and exposed in MCP responses
+(`process_agent_update`, governance metrics, dashboards) since EISV
+grounding Phase 1+2 (PR #26, merged 2026-04-19). The legacy thermodynamic
+`C(V, Θ) = 0.5 · (1 + tanh(Θ.C₁ · V))` is preserved as
+`metrics["coherence_legacy"]` and lives in `governance_core/coherence.py`.
 
 Two grounded forms:
   - manifold:  C = 1 - ||Δ||_2 / ||Δ||_max, Δ = (E,I,S) - (E,I,S)_healthy
   - kl:        C = exp(-D_KL(q_now || q_ref)), requires reference distribution
 
 Manifold form ships as primary (needs only existing EISV). KL stubbed for Phase 2.
+
+Physical interpretation: "how close is this agent's (E, I, S) state to its
+class's healthy operating point?" V is NOT in this formula — for V-driven
+thermodynamic coherence read `coherence_legacy`. See paper v6.8.1 §6.7
+translation table for the paper ↔ runtime ↔ audit vocabulary mapping.
 """
 import math
 from typing import Any, Dict


### PR DESCRIPTION
## Summary

Adds bidirectional pointers between the two coherence implementations so the next agent reading either file doesn't form Hermes's mental model.

- `governance_core/coherence.py` — top-of-module note: this is the LEGACY thermodynamic form; runtime `metrics[\"coherence\"]` no longer reads from here, it lives in `coherence_legacy`.
- `src/grounding/coherence.py` — top-of-module note: this is the CANONICAL runtime form populated since EISV grounding Phase 1+2 (PR #26); V is not in this formula.

## Why

Hermes (sister agent) reported a "stuck coherence" trajectory tonight: V drifted -0.371 → -0.247 over 4 updates but coherence stayed flat at 0.481. He went looking at `governance_core/coherence.py` because its docstring describes the model in detail, and got confused why the formula didn't predict his reading.

The reason: as of 2026-04-19, the runtime `coherence` field is the manifold-distance form in `src/grounding/coherence.py` (1 − ‖(E,I,S) − healthy‖/norm_max). V isn't in that formula. The thermodynamic value still gets computed and lives as `coherence_legacy` in the metrics dict. The translation table in paper v6.8.1 §6.7 documents this, but it's nowhere in the code itself.

## What this is NOT

- No code change. No behavior change.
- Not a renaming — the field is still called `coherence`, that ship has sailed.
- Not a deprecation of `governance_core/coherence.py` — ODE integration and drift telemetry still need the V-driven form.

## Test plan

- [x] `./scripts/dev/test-cache.sh` — 7433 passed