### PR TITLE
feat: restore Docker quickstart for one-command server bring-up

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,69 @@
+# Git
+.git
+.gitignore
+
+# Worktrees (must be excluded — they live under .git but resolve as real paths)
+.worktrees
+
+# Python
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+*.so
+*.egg
+*.egg-info
+dist
+build
+.venv
+venv
+env
+uv.lock
+
+# Data — mounted as volume by docker-compose
+data/
+data_isolated/
+logs/
+*.db
+*.db-shm
+*.db-wal
+
+# IDE / tool config
+.claude
+.cursor
+.vscode
+.idea
+*.swp
+*.swo
+
+# Tests + coverage (not needed in production image)
+tests/
+.pytest_cache
+.coverage
+coverage.xml
+htmlcov/
+.mypy_cache
+.ruff_cache
+
+# Documentation / non-runtime
+papers/
+scripts/archive/
+docs/
+site/
+sketch/
+examples/
+reports/
+
+# Archives
+archive/
+archives/
+
+# Temporary
+*.tmp
+*.log
+.DS_Store
+
+# Local env (don't bake secrets into image)
+.env
+.env.local

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,29 @@
 # UNITARES Governance MCP - Environment Configuration
-# Copy to .env and fill in your values
+# Copy to .env and fill in your values:
+#   cp .env.example .env
+
+# ===========================================
+# DOCKER CREDENTIALS (used by docker-compose.yml)
+# ===========================================
+# These default the Postgres+AGE container at first startup. Change them
+# before the first `docker compose up` if you want non-default credentials.
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=governance
+
+# Host-side port mappings. Override only if those ports are already taken
+# on your machine (e.g., a Homebrew Postgres on 5432, a host redis on 6379,
+# or a separately-installed governance server on 8767).
+# POSTGRES_HOST_PORT=5432
+# REDIS_HOST_PORT=6379
+# GOVERNANCE_HOST_PORT=8767
 
 # ===========================================
 # DATABASE (Required) - PostgreSQL is the sole backend
 # ===========================================
+# In docker-compose.yml the DB_POSTGRES_URL is wired automatically from the
+# POSTGRES_* values above. Override below only for a non-Docker / external
+# Postgres setup (Homebrew install, remote host, etc.).
 DB_POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/governance
 DB_POSTGRES_MIN_CONN=2
 DB_POSTGRES_MAX_CONN=10

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# UNITARES Governance MCP Server
+#
+# This image is intended to be run via the top-level docker-compose.yml,
+# which wires it up to the postgres-age and redis services.
+#
+# Build standalone (rare):
+#   docker build -t unitares-governance .
+#
+# Run standalone (requires external Postgres+AGE):
+#   docker run -p 8767:8767 \
+#     -e DB_POSTGRES_URL=postgresql://... \
+#     -e UNITARES_BIND_ALL_INTERFACES=1 \
+#     unitares-governance
+
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# System deps for asyncpg, sentence-transformers, etc.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python deps first for better layer caching.
+COPY requirements-docker.txt .
+RUN pip install --no-cache-dir -r requirements-docker.txt
+
+# Copy application code. governance_core/ was folded back into this repo
+# in 2026-04-24 (was previously a separate compiled wheel) — no wheel install.
+COPY src/ src/
+COPY governance_core/ governance_core/
+COPY agents/ agents/
+COPY config/ config/
+COPY dashboard/ dashboard/
+COPY skills/ skills/
+COPY VERSION .
+
+EXPOSE 8767
+
+# Bind 0.0.0.0 inside the container so the host port mapping works. The
+# server still does host/origin allowlisting via UNITARES_MCP_ALLOWED_HOSTS.
+ENV UNITARES_BIND_ALL_INTERFACES=1
+ENV UNITARES_MCP_ALLOWED_HOSTS=localhost,127.0.0.1
+ENV UNITARES_MCP_ALLOWED_ORIGINS=http://localhost:8767,http://127.0.0.1:8767
+
+CMD ["python", "src/mcp_server.py", "--host", "0.0.0.0", "--port", "8767", "--force"]

--- a/README.md
+++ b/README.md
@@ -20,15 +20,24 @@ Circuit breakers and kill switches are still there — they're just the last lin
 
 Running continuously in production since November 2025 with 6,200+ passing tests at 77% coverage. Long-run trajectories are stored in PostgreSQL + AGE; the state model is derived from what agents actually do (EMA-smoothed observations, not model predictions).
 
-**Try it** (assumes Postgres + AGE — full setup in [Installation](#installation)):
+**Try it** (one command, no Postgres/AGE on the host required):
 
 ```bash
 git clone https://github.com/CIRWEL/unitares.git && cd unitares
-pip install -r requirements-full.txt
-export DB_POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/governance
-python src/mcp_server.py --port 8767
+docker compose up
 # then point any MCP client at http://localhost:8767/mcp/
 ```
+
+That brings up Postgres 17 + Apache AGE + pgvector + Redis + the governance server, all bound to `127.0.0.1`. Bare-metal setup (Homebrew Postgres, native install) is in [Installation](#installation). The Pi/Lumen embodiment side is **optional** — governance runs standalone.
+
+**Service ports** (bound to `127.0.0.1` by default; override host-side via `.env`):
+
+| Service | Port | Endpoint |
+|---|---|---|
+| Governance MCP server | `8767` | `http://localhost:8767/mcp/` |
+| Postgres + AGE + pgvector | `5432` | `postgresql://postgres:postgres@localhost:5432/governance` |
+| Redis (session cache) | `6379` | `redis://localhost:6379/0` |
+| Anima MCP (Pi-side, separate repo, optional) | `8766` | `http://lumen.local:8766/mcp/` |
 
 | | |
 |--|--|
@@ -171,9 +180,25 @@ The `onboard()` response includes `agent_uuid`. Store it as an identity anchor. 
 
 ### Installation
 
-**Prerequisites:** Python 3.12+, PostgreSQL 16+ with Apache AGE + pgvector (examples use PostgreSQL 17), Redis optional (session cache only).
+Two supported paths. Pick one.
 
-**Full local server (recommended for MCP + HTTP stack):**
+#### A. Docker Compose (recommended for evaluation)
+
+Zero host dependencies beyond Docker. Brings up Postgres+AGE+pgvector, Redis, and the governance server in one command.
+
+```bash
+git clone https://github.com/CIRWEL/unitares.git
+cd unitares
+cp .env.example .env       # optional — defaults work
+docker compose up
+# server: http://localhost:8767/mcp/
+```
+
+To override credentials or host-side ports (e.g. you already have Postgres on `5432`), edit `.env` first. Compose definition: [`docker-compose.yml`](docker-compose.yml). Postgres image: [`db/postgres/Dockerfile.age-vector`](db/postgres/Dockerfile.age-vector).
+
+#### B. Bare-metal (native Postgres + AGE)
+
+Lower overhead, faster iteration, what the maintainer runs in production. Requires PostgreSQL 16+ with Apache AGE + pgvector compiled and installed (examples use PostgreSQL 17). Redis optional (session cache only).
 
 ```bash
 git clone https://github.com/CIRWEL/unitares.git
@@ -188,7 +213,7 @@ export UNITARES_KNOWLEDGE_BACKEND=age
 python src/mcp_server.py --port 8767
 ```
 
-`requirements-full.txt` is the default for almost everything — running the local server, running tests (`pytest` is in `full` only), and handler development. `requirements-core.txt` is a 2-package subset (`mcp` + `numpy`) for thin stdio/proxy setups where the governance server runs elsewhere and you only need a local client. Database setup (PostgreSQL 17 + AGE + pgvector): [db/postgres/README.md](db/postgres/README.md).
+`requirements-full.txt` is the default for almost everything — running the local server, running tests (`pytest` is in `full` only), and handler development. `requirements-core.txt` is a 2-package subset (`mcp` + `numpy`) for thin stdio/proxy setups where the governance server runs elsewhere and you only need a local client. Database bring-up details (PostgreSQL 17 + AGE + pgvector compile): [db/postgres/README.md](db/postgres/README.md).
 
 The EISV **ODE** engine lives in this repo at `governance_core/` (pure Python, no separate install). The four-component drift decomposition is fully described in the v6 paper. To skip the ODE entirely and run with behavioral-EISV only: `export UNITARES_DISABLE_ODE=1`.
 

--- a/db/postgres/Dockerfile.age-vector
+++ b/db/postgres/Dockerfile.age-vector
@@ -1,0 +1,33 @@
+# PostgreSQL with Apache AGE + pgvector
+# Combines graph queries (AGE) with vector similarity search (pgvector).
+#
+# Build:
+#   docker build -t postgres-age-vector db/postgres/
+#
+# Or via docker-compose at the repo root:
+#   docker compose up
+
+FROM apache/age:latest
+
+# Install build dependencies for pgvector
+USER root
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    git \
+    postgresql-server-dev-17 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Build and install pgvector
+# OPTFLAGS="" avoids SIMD instructions that cause "Illegal instruction" on
+# some CPUs (notably older x86_64 and ARM under emulation).
+RUN cd /tmp && \
+    git clone --branch v0.8.0 https://github.com/pgvector/pgvector.git && \
+    cd pgvector && \
+    make OPTFLAGS="" && \
+    make install && \
+    cd / && rm -rf /tmp/pgvector
+
+USER postgres
+
+# Create extensions when an empty data volume is initialized.
+COPY --chown=postgres:postgres init-extensions.sql /docker-entrypoint-initdb.d/00-init-extensions.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,107 @@
+# UNITARES Governance — Docker Compose
+#
+# One-command quickstart for local evaluation:
+#
+#   docker compose up
+#
+# Then point an MCP client at http://localhost:8767/mcp/ and call onboard().
+#
+# This brings up:
+#   - postgres-age      Postgres 17 + Apache AGE + pgvector  (port 5432)
+#   - redis             Session cache + locks                 (port 6379)
+#   - governance-mcp    UNITARES governance server            (port 8767)
+#
+# All ports bind to 127.0.0.1 only. Override credentials via .env (copy
+# .env.example to .env). For the Pi/Lumen embodiment side (anima-mcp on
+# port 8766), see https://github.com/CIRWEL/anima-mcp — the governance
+# server runs standalone without it.
+
+services:
+  postgres-age:
+    build:
+      context: db/postgres
+      dockerfile: Dockerfile.age-vector
+    container_name: unitares-postgres-age
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-governance}
+    ports:
+      # Override the host-side port via POSTGRES_HOST_PORT in .env if 5432
+      # is already taken on your machine (e.g., by a Homebrew Postgres).
+      - "127.0.0.1:${POSTGRES_HOST_PORT:-5432}:5432"
+    volumes:
+      - postgres-age-data:/var/lib/postgresql/data
+      # Schema bootstrap: docker-entrypoint-initdb.d runs *.sql in lexical
+      # order on first startup (empty data volume). Numbering matches the
+      # order documented in db/postgres/README.md. 00-init-extensions.sql
+      # is baked into the image.
+      - ./db/postgres/schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
+      - ./db/postgres/partitions.sql:/docker-entrypoint-initdb.d/02-partitions.sql:ro
+      - ./db/postgres/knowledge_schema.sql:/docker-entrypoint-initdb.d/03-knowledge_schema.sql:ro
+      - ./db/postgres/embeddings_schema.sql:/docker-entrypoint-initdb.d/04-embeddings_schema.sql:ro
+      - ./db/postgres/embeddings_bge_m3_schema.sql:/docker-entrypoint-initdb.d/05-embeddings_bge_m3_schema.sql:ro
+      - ./db/postgres/graph_schema.sql:/docker-entrypoint-initdb.d/06-graph_schema.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-governance}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    container_name: unitares-redis
+    ports:
+      - "127.0.0.1:${REDIS_HOST_PORT:-6379}:6379"
+    volumes:
+      - redis-data:/data
+    command: redis-server --appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+  governance-mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: unitares-governance-mcp
+    ports:
+      # Override via GOVERNANCE_HOST_PORT in .env if 8767 is busy on the host.
+      - "127.0.0.1:${GOVERNANCE_HOST_PORT:-8767}:8767"
+    environment:
+      DB_POSTGRES_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres-age:5432/${POSTGRES_DB:-governance}
+      DB_BACKEND: postgres
+      DB_AGE_GRAPH: governance_graph
+      REDIS_URL: redis://redis:6379/0
+      UNITARES_KNOWLEDGE_BACKEND: age
+      UNITARES_DIALECTIC_BACKEND: postgres
+      # Optional: pick embedding backend. Default falls back to PG FTS if
+      # sentence-transformers / model not available at runtime.
+      # UNITARES_EMBEDDING_MODEL: bge-m3
+      # UNITARES_ENABLE_HYBRID: "1"
+    volumes:
+      - governance-data:/app/data
+    depends_on:
+      postgres-age:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      # /v1/tools is a plain REST endpoint that returns 200 once the server
+      # is ready. The MCP path /mcp/ requires SSE Accept headers so a bare
+      # GET 406s — fine for clients, bad for healthcheck.
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8767/v1/tools -o /dev/null || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 30s
+    restart: unless-stopped
+
+volumes:
+  postgres-age-data:
+  redis-data:
+  governance-data:

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -1,0 +1,40 @@
+# Docker dependencies for UNITARES Governance MCP
+#
+# requirements-full.txt minus:
+# - pytest* / fakeredis / hypothesis (not needed in production)
+# - sentence-transformers (saves ~1.3 GB; runtime falls back to PG FTS unless
+#   you explicitly set UNITARES_EMBEDDING_MODEL=bge-m3, in which case rebuild
+#   this image with that line uncommented below)
+# - requests (only used by integration tests)
+
+# Core MCP SDK
+mcp>=1.26.0,<2.0.0
+
+# Governance system core math (governance_core/ is in-repo, pure Python)
+numpy>=1.24.0,<3.0.0
+
+# HTTP server support (multi-client mode)
+uvicorn>=0.30.0
+starlette>=0.37.0
+websockets>=12.0
+
+# Operational dependencies
+psutil>=5.9.0
+aiofiles>=23.2.1
+orjson>=3.9.0
+
+# Metrics and monitoring
+prometheus-client>=0.19.0
+
+# PostgreSQL + AGE support
+asyncpg>=0.29.0
+
+# Redis cache support
+redis>=5.0.0
+
+# Environment variable loading
+python-dotenv>=1.0.0
+
+# Optional embedding backend — uncomment if you want bge-m3 semantic search
+# in the container. Adds ~1.3 GB to the image.
+# sentence-transformers>=2.2.0


### PR DESCRIPTION
Restores the Docker quickstart path that was dropped at some point — `Dockerfile`, `docker-compose.yml`, `.dockerignore`, `db/postgres/Dockerfile.age-vector`, `requirements-docker.txt`, plus README + .env.example updates.

## Provenance
Salvaged from the pushed-but-PR-less branch \`feature/restore-docker-quickstart\` during a worktree triage sweep (2026-04-26). Only the Docker commit was carried over; the original branch's stray vigil-summary test commit was already on master via #144.

## Status
Draft. No tests yet, no CI verification that the compose path actually boots cleanly against current master. Opening so the work isn't lost; merge needs a smoke-test pass.