### PR TITLE
feat: resident progress detection (phase 1 telemetry)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -493,6 +493,20 @@
             </div>
         </div>
 
+        <!-- Resident Progress — Phase 1 telemetry panel. Read-only snapshots
+             from /v1/progress_flat/recent. No actions in Phase 1. -->
+        <div class="live-chart-panel" id="resident-progress-panel">
+            <div class="panel-header">
+                <h3>Resident Progress</h3>
+                <div class="panel-controls">
+                    <label class="panel-select-label" title="Show only ticks where loop detector also fired">
+                        <input type="checkbox" id="rp-overlap-toggle"> Show overlap
+                    </label>
+                </div>
+            </div>
+            <div id="rp-rows" class="rp-rows"></div>
+        </div>
+
         <!-- Watcher — findings pipeline: open queue, pattern breakdown with
              dismiss ratio (surfaces noisy rules), daily detect/resolve/dismiss
              timeline. Backed by /v1/watcher/summary. -->
@@ -641,6 +655,7 @@
         aria-label="Scroll to top">&uarr;</button>
 
     <script src="/dashboard/dashboard.js"></script>
+    <script src="/dashboard/resident-progress.js"></script>
 </body>
 
 </html>

--- a/dashboard/resident-progress.js
+++ b/dashboard/resident-progress.js
@@ -1,0 +1,117 @@
+// resident-progress.js — render Phase-1 resident-progress probe snapshots.
+// Reads GET /v1/progress_flat/recent. Read-only; Phase 1 has no actions.
+// Conforms to dashboard conventions: authFetch from utils.js, .panel layout.
+
+(function () {
+    'use strict';
+
+    var REFRESH_INTERVAL_MS = 30000;
+    var RESIDENT_LABELS = [
+        "vigil", "sentinel", "watcher", "steward", "chronicler",
+        "progress_flat_probe",
+    ];
+    var STATUS_CLASS = {
+        "OK": "rp-status-ok",
+        "flat-candidate": "rp-status-flat",
+        "silent": "rp-status-silent",
+        "source-error": "rp-status-error",
+        "unresolved": "rp-status-unresolved",
+        "startup-grace": "rp-status-init",
+        "initializing": "rp-status-init",
+    };
+
+    async function fetchRecent(hours) {
+        try {
+            var resp = await authFetch(
+                '/v1/progress_flat/recent?hours=' + (hours || 24)
+            );
+            if (!resp.ok) throw new Error('HTTP ' + resp.status);
+            var data = await resp.json();
+            if (!data || data.success === false) {
+                throw new Error((data && data.error) || 'unknown');
+            }
+            return data.rows || [];
+        } catch (e) {
+            console.warn('[ResidentProgress] fetch failed:', e);
+            return [];
+        }
+    }
+
+    function statusFor(row) {
+        var s = row.status;
+        if (!s && row.suppressed_reason === 'startup_unresolved_label') {
+            return 'initializing';
+        }
+        return s || 'unresolved';
+    }
+
+    function renderRow(row) {
+        var label = row.resident_label || '';
+        var status = statusFor(row);
+        var cls = STATUS_CLASS[status] || 'rp-status-unknown';
+        var metric = (row.metric_value === null || row.metric_value === undefined)
+            ? '—' : row.metric_value;
+        var threshold = (row.threshold === null || row.threshold === undefined)
+            ? '—' : row.threshold;
+        var ticked = row.ticked_at
+            ? new Date(row.ticked_at).toLocaleTimeString()
+            : '—';
+        var dim = label === 'progress_flat_probe' ? ' rp-dim' : '';
+        return (
+            '<div class="rp-row' + dim + '" data-label="' + label + '">' +
+                '<span class="rp-label">' + label + '</span>' +
+                '<span class="rp-badge ' + cls + '">' + status + '</span>' +
+                '<span class="rp-metric">' + metric + ' / ' + threshold + '</span>' +
+                '<span class="rp-window">' +
+                    (row.window_seconds
+                        ? Math.round(row.window_seconds / 60) + 'm'
+                        : '—') +
+                '</span>' +
+                '<span class="rp-time">' + ticked + '</span>' +
+            '</div>'
+        );
+    }
+
+    function rowsByLabel(rows) {
+        var out = {};
+        rows.forEach(function (r) { out[r.resident_label] = r; });
+        return out;
+    }
+
+    function applyOverlapFilter(rows, overlapOn) {
+        if (!overlapOn) return rows;
+        return rows.filter(function (r) {
+            return r.candidate &&
+                r.loop_detector_state &&
+                r.loop_detector_state.loop_detected_at;
+        });
+    }
+
+    async function refresh() {
+        var rows = await fetchRecent(24);
+        var overlapEl = document.getElementById('rp-overlap-toggle');
+        var overlapOn = overlapEl ? overlapEl.checked : false;
+        var filtered = applyOverlapFilter(rows, overlapOn);
+        var byLabel = rowsByLabel(filtered);
+        var html = RESIDENT_LABELS.map(function (label) {
+            return renderRow(byLabel[label] || {
+                resident_label: label, status: 'unresolved',
+            });
+        }).join('');
+        var container = document.getElementById('rp-rows');
+        if (container) container.innerHTML = html;
+    }
+
+    function wire() {
+        var toggle = document.getElementById('rp-overlap-toggle');
+        if (toggle) toggle.addEventListener('change', refresh);
+        refresh();
+        setInterval(refresh, REFRESH_INTERVAL_MS);
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', wire);
+    } else {
+        wire();
+    }
+})();

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -5556,3 +5556,30 @@ main {
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+/* Resident Progress panel (Phase 1 telemetry) */
+.rp-rows { display: flex; flex-direction: column; gap: 4px; padding: 8px; }
+.rp-row {
+    display: grid;
+    grid-template-columns: 1.4fr 1fr 1fr 0.5fr 0.8fr;
+    gap: 8px;
+    align-items: center;
+    padding: 6px 8px;
+    border-bottom: 1px solid rgba(255,255,255,0.06);
+    font-size: 0.9em;
+}
+.rp-row.rp-dim { opacity: 0.55; }
+.rp-label { font-weight: 500; }
+.rp-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 0.75em;
+    text-align: center;
+}
+.rp-status-ok       { background: rgba(80,180,90,0.18);  color: #7fdc8f; }
+.rp-status-flat     { background: rgba(220,170,40,0.20); color: #f1c860; }
+.rp-status-silent   { background: rgba(140,140,150,0.20); color: #a8a8b4; }
+.rp-status-error    { background: rgba(220,80,80,0.20);  color: #f08080; }
+.rp-status-unresolved { background: rgba(120,120,140,0.15); color: #909098; }
+.rp-status-init     { background: rgba(120,120,140,0.10); color: #909098; }

--- a/db/postgres/migrations/018_progress_flat_telemetry.sql
+++ b/db/postgres/migrations/018_progress_flat_telemetry.sql
@@ -1,0 +1,50 @@
+-- 018_progress_flat_telemetry.sql
+--
+-- Phase 1 telemetry tables for the resident-progress probe (see
+-- docs/superpowers/specs/2026-04-25-resident-progress-detection-design.md).
+-- Append-only; the probe never updates or deletes rows.
+--
+-- Note: planned as 017 but 017 was taken by substrate_claims (S19 PR1).
+
+CREATE TABLE IF NOT EXISTS progress_flat_snapshots (
+    id                     bigserial PRIMARY KEY,
+    probe_tick_id          uuid NOT NULL,
+    ticked_at              timestamptz NOT NULL,
+    resident_label         text NOT NULL,
+    resident_uuid          uuid,                  -- null for probe_self and unresolved labels
+    source                 text NOT NULL,
+    metric_value           integer,
+    window_seconds         integer,
+    threshold              integer,
+    metric_below_threshold boolean,
+    heartbeat_alive        boolean,
+    candidate              boolean NOT NULL DEFAULT false,
+    suppressed_reason      text,
+    error_details          jsonb,
+    liveness_inputs        jsonb,
+    loop_detector_state    jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_pfs_ticked_at
+    ON progress_flat_snapshots (ticked_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_pfs_label_ticked
+    ON progress_flat_snapshots (resident_label, ticked_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_pfs_tick_id
+    ON progress_flat_snapshots (probe_tick_id);
+
+CREATE TABLE IF NOT EXISTS resident_progress_pulse (
+    id            bigserial PRIMARY KEY,
+    resident_uuid uuid NOT NULL,
+    metric_name   text NOT NULL,
+    value         integer NOT NULL,
+    recorded_at   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_rpp_uuid_recorded
+    ON resident_progress_pulse (resident_uuid, recorded_at DESC);
+
+INSERT INTO core.schema_migrations (version, name)
+VALUES (18, 'progress flat telemetry tables')
+ON CONFLICT (version) DO NOTHING;

--- a/src/background_tasks.py
+++ b/src/background_tasks.py
@@ -384,6 +384,112 @@ async def deep_health_probe_task(interval_seconds: float | None = None):
 
 
 # ---------------------------------------------------------------------------
+# Resident-progress flat probe
+# ---------------------------------------------------------------------------
+
+async def progress_flat_probe_task(interval_seconds: float | None = None):
+    """Resident-progress telemetry probe. See plan Task 9 + spec.
+
+    Runs in the main event loop alongside other background tasks.
+    Builds the full dependency graph (sources, heartbeat, writer, audit
+    emitter) at startup then loops calling probe.tick() every
+    UNITARES_PROGRESS_FLAT_PROBE_INTERVAL_SECONDS seconds (default 300s).
+    """
+    import os
+
+    if interval_seconds is None:
+        override = os.getenv("UNITARES_PROGRESS_FLAT_PROBE_INTERVAL_SECONDS")
+        interval_seconds = float(override) if override else 300.0
+
+    # Let the DB pool warm up before the first probe (mirror deep_health_probe pattern).
+    await asyncio.sleep(5.0)
+
+    # Lazy imports to avoid circular import at module load.
+    from src.db import get_db
+    from src.resident_progress.heartbeat import HeartbeatEvaluator
+    from src.resident_progress.probe_task import ProgressFlatProbe
+    from src.resident_progress.sentinel_source import SentinelPulseSource
+    from src.resident_progress.snapshot_writer import SnapshotWriter
+    from src.resident_progress.sources import (
+        EISVSyncSource,
+        KnowledgeDiscoverySource,
+        MetricsSeriesSource,
+        WatcherFindingSource,
+    )
+
+    db = get_db()
+
+    class _AuditEmitter:
+        async def emit(self, *, event_type, severity, payload):
+            # audit_logger has specific named methods — no generic log_event().
+            # Use _write_entry with a synthetic AuditEntry to stay consistent
+            # with the existing pattern without adding a new public method.
+            try:
+                from src.audit_log import audit_logger, AuditEntry
+                from datetime import datetime
+                entry = AuditEntry(
+                    timestamp=datetime.now().isoformat(),
+                    agent_id="progress_flat_probe",
+                    event_type=event_type,
+                    confidence=1.0,
+                    details={"severity": severity, **payload},
+                )
+                audit_logger._write_entry(entry)
+            except Exception as e:
+                logger.warning("[PROGRESS_FLAT] audit emit failed: %s", e)
+
+    class _MetadataStore:
+        async def get(self, agent_uuid: str):
+            # Use get_agent from agent_storage — that's the canonical async
+            # identity/metadata fetch.  AgentRecord.last_activity_at maps to
+            # last_update; expected_cadence_s lives in metadata.
+            try:
+                from src.agent_storage import get_agent
+                record = await get_agent(agent_uuid)
+                if record is None:
+                    return None
+                return {
+                    "last_update": record.last_activity_at,
+                    "expected_cadence_s": (
+                        record.metadata.get("expected_cadence_s")
+                        or record.metadata.get("cadence_s")
+                        or 60
+                    ),
+                }
+            except Exception:
+                return None
+
+    sources = {
+        "kg_writes":        KnowledgeDiscoverySource(db),
+        "watcher_findings": WatcherFindingSource(db),
+        "eisv_sync_rows":   EISVSyncSource(db),
+        "metrics_series":   MetricsSeriesSource(db),
+        "sentinel_pulse":   SentinelPulseSource(db),
+    }
+    probe = ProgressFlatProbe(
+        sources_by_name=sources,
+        heartbeat_evaluator=HeartbeatEvaluator(_MetadataStore()),
+        writer=SnapshotWriter(db),
+        audit_emitter=_AuditEmitter(),
+    )
+    logger.info(
+        "[PROGRESS_FLAT] probe started; interval=%ss", interval_seconds,
+    )
+    while True:
+        try:
+            await probe.tick()
+        except asyncio.CancelledError:
+            logger.info("[PROGRESS_FLAT] task cancelled")
+            break
+        except Exception as e:
+            logger.warning("[PROGRESS_FLAT] tick failed: %s", e, exc_info=True)
+        try:
+            await asyncio.sleep(interval_seconds)
+        except asyncio.CancelledError:
+            break
+
+
+# ---------------------------------------------------------------------------
 # Session cleanup
 # ---------------------------------------------------------------------------
 
@@ -1098,6 +1204,9 @@ def start_all_background_tasks(connection_tracker, set_ready):
     _supervised_create_task(server_warmup_task(set_ready), name="server_warmup")
     _supervised_create_task(deep_health_probe_task(), name="deep_health_probe")
     logger.info("[HEALTH_PROBE] Deep health probe started (cached snapshots for health_check handler)")
+
+    _supervised_create_task(progress_flat_probe_task(), name="progress_flat_probe")
+    logger.info("[PROGRESS_FLAT] Resident-progress flat probe started")
 
     _supervised_create_task(session_cleanup_task(interval_hours=6.0), name="session_cleanup")
     logger.info("[SESSION_CLEANUP] Started periodic expired session cleanup (every 6h)")

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -1198,6 +1198,79 @@ async def http_get_metrics_catalog(request):
     })
 
 
+async def http_get_progress_flat_recent(request):
+    """GET /v1/progress_flat/recent?hours=24 — latest snapshot per
+    configured resident plus the probe-self row.
+    """
+    import json as _json
+    from src.db import get_db
+    from src.resident_progress.registry import RESIDENT_PROGRESS_REGISTRY
+    from src.resident_progress.status import resolve_status
+
+    http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
+    if not _check_http_auth(request, http_api_token=http_api_token):
+        return _http_unauthorized()
+
+    try:
+        hours = int(request.query_params.get("hours", "24"))
+    except (TypeError, ValueError):
+        hours = 24
+    hours = max(1, min(hours, 168))  # clamp to [1, 168]
+
+    db = get_db()
+    async with db.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT DISTINCT ON (resident_label)
+                   resident_label, resident_uuid::text AS resident_uuid,
+                   ticked_at, source, metric_value, window_seconds,
+                   threshold, metric_below_threshold, heartbeat_alive,
+                   candidate, suppressed_reason, error_details,
+                   liveness_inputs, loop_detector_state
+            FROM progress_flat_snapshots
+            WHERE ticked_at > now() - make_interval(hours => $1)
+            ORDER BY resident_label, ticked_at DESC
+            """,
+            hours,
+        )
+
+    by_label: dict[str, dict] = {}
+    for r in rows:
+        d = dict(r)
+        # Coerce types for JSON
+        if d.get("ticked_at") is not None:
+            d["ticked_at"] = d["ticked_at"].isoformat()
+        # error_details / liveness_inputs / loop_detector_state may arrive
+        # as JSON-serialized strings (asyncpg jsonb default) or dicts
+        # depending on connection-pool init. Normalize to dict-or-None.
+        for jk in ("error_details", "liveness_inputs", "loop_detector_state"):
+            v = d.get(jk)
+            if isinstance(v, str):
+                try:
+                    d[jk] = _json.loads(v)
+                except Exception:
+                    pass
+        by_label[r["resident_label"]] = d
+
+    out = []
+    for label in list(RESIDENT_PROGRESS_REGISTRY) + ["progress_flat_probe"]:
+        r = by_label.get(label)
+        if r is None:
+            out.append({
+                "resident_label": label,
+                "status": "unresolved",
+                "metric_value": None,
+                "threshold": None,
+                "window_seconds": None,
+                "ticked_at": None,
+            })
+            continue
+        r["status"] = resolve_status(r)
+        out.append(r)
+
+    return JSONResponse({"success": True, "rows": out})
+
+
 _WATCHER_FINDINGS_PATH = (
     Path(__file__).resolve().parent.parent / "data" / "watcher" / "findings.jsonl"
 )
@@ -2346,6 +2419,7 @@ def register_http_routes(
     app.routes.append(Route("/v1/metrics", http_post_metric, methods=["POST"]))
     app.routes.append(Route("/v1/metrics/series", http_get_metrics, methods=["GET"]))
     app.routes.append(Route("/v1/metrics/catalog", http_get_metrics_catalog, methods=["GET"]))
+    app.routes.append(Route("/v1/progress_flat/recent", http_get_progress_flat_recent, methods=["GET"]))
     app.routes.append(Route("/v1/watcher/summary", http_watcher_summary, methods=["GET"]))
     app.routes.append(Route("/v1/sentinel/summary", http_sentinel_summary, methods=["GET"]))
     app.routes.append(Route("/v1/vigil/summary", http_vigil_summary, methods=["GET"]))

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -856,7 +856,7 @@ async def http_dashboard_static(request):
         "visualizations.js", "agents.js", "discoveries.js",
         "dialectic.js", "eisv-charts.js", "timeline.js",
         "residents.js", "fleet-metrics.js", "watcher.js", "sentinel.js",
-        "vigil.js",
+        "vigil.js", "resident-progress.js",
         "styles.css", "dashboard.js",
         "phase.js",
     ]

--- a/src/mcp_handlers/__init__.py
+++ b/src/mcp_handlers/__init__.py
@@ -108,6 +108,8 @@ from .identity.handlers import (
 from .support.model_inference import handle_call_model
 # Outcome Events - EISV validation infrastructure (Feb 2026)
 from .observability.outcome_events import handle_outcome_event
+# Resident Progress - sentinel push-based pulse (Phase 1)
+from .resident_progress import handle_record_progress_pulse
 # Consolidated tools - reduces cognitive load for agents (Jan 2026)
 from .consolidated import (
     handle_knowledge,

--- a/src/mcp_handlers/resident_progress.py
+++ b/src/mcp_handlers/resident_progress.py
@@ -1,0 +1,109 @@
+"""record_progress_pulse MCP tool handler.
+
+Sentinel (and other residents) call this tool to post a progress pulse
+into ``resident_progress_pulse``. The probe's SentinelPulseSource reads
+those rows back via a batched DISTINCT ON query.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Dict, Any, Sequence
+
+from mcp.types import TextContent
+
+from .decorators import mcp_tool
+from .utils import require_registered_agent, error_response, success_response
+from src.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+@mcp_tool("record_progress_pulse", timeout=5.0, register=True, rate_limit_exempt=False)
+async def handle_record_progress_pulse(
+    arguments: Dict[str, Any],
+) -> Sequence[TextContent]:
+    """Post a progress pulse for the calling resident agent.
+
+    Sentinel calls this periodically so the probe can detect whether
+    Sentinel is alive and making forward progress.
+    """
+    from pydantic import ValidationError
+    from src.mcp_handlers.schemas.progress_flat import RecordProgressPulseParams
+    from src.mcp_handlers.identity.shared import get_bound_agent_id
+    from src.db import get_db
+
+    # Resolve the authenticated agent (must be registered)
+    agent_id, error = require_registered_agent(arguments)
+    if error:
+        return [error]
+
+    # Resolve bound UUID (canonical UUID from context / identity middleware)
+    bound_uuid = get_bound_agent_id(arguments=arguments)
+    if not bound_uuid:
+        # Fallback: resident agents pass their UUID as agent_id
+        bound_uuid = arguments.get("_agent_uuid") or agent_id
+
+    # Validate parameters with Pydantic schema
+    try:
+        params = RecordProgressPulseParams.model_validate(arguments)
+    except ValidationError as exc:
+        return [error_response(
+            f"Invalid parameters: {exc}",
+            error_code="INVALID_PARAMS",
+            error_category="validation_error",
+        )]
+
+    # Auth binding check: supplied resident_uuid must match the bound agent
+    if params.resident_uuid is not None and params.resident_uuid != bound_uuid:
+        return [error_response(
+            "resident_uuid does not match authenticated agent's bound UUID",
+            error_code="AUTH_MISMATCH",
+            error_category="auth_error",
+            details={
+                "supplied": params.resident_uuid,
+                "bound": (bound_uuid[:8] + "...") if bound_uuid else None,
+            },
+        )]
+
+    effective_uuid = params.resident_uuid or bound_uuid
+
+    # Insert row.
+    # Pattern 3 from CLAUDE.md: asyncio.wait_for with tight timeout so we
+    # degrade gracefully rather than hang if anyio/asyncpg deadlock occurs.
+    async def _insert() -> None:
+        db = get_db()
+        async with db.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO resident_progress_pulse (resident_uuid, metric_name, value)
+                VALUES ($1, $2, $3)
+                """,
+                effective_uuid,
+                params.metric_name,
+                params.value,
+            )
+
+    try:
+        await asyncio.wait_for(_insert(), timeout=4.5)
+    except asyncio.TimeoutError:
+        logger.warning("record_progress_pulse: DB insert timed out")
+        return [error_response(
+            "Database insert timed out",
+            error_code="DB_TIMEOUT",
+            error_category="system_error",
+            recovery={"action": "Retry in a moment; DB may be under load"},
+        )]
+    except Exception as exc:
+        logger.error("record_progress_pulse: DB insert failed: %s", exc)
+        return [error_response(
+            f"Failed to record pulse: {exc}",
+            error_code="DB_ERROR",
+            error_category="system_error",
+        )]
+
+    return success_response({
+        "success": True,
+        "resident_uuid": effective_uuid,
+        "metric_name": params.metric_name,
+        "value": params.value,
+    })

--- a/src/mcp_handlers/resident_progress.py
+++ b/src/mcp_handlers/resident_progress.py
@@ -40,8 +40,16 @@ async def handle_record_progress_pulse(
     # Resolve bound UUID (canonical UUID from context / identity middleware)
     bound_uuid = get_bound_agent_id(arguments=arguments)
     if not bound_uuid:
-        # Fallback: resident agents pass their UUID as agent_id
-        bound_uuid = arguments.get("_agent_uuid") or agent_id
+        # Fallback: caller may supply their UUID explicitly
+        bound_uuid = arguments.get("_agent_uuid") or None
+
+    # Auth binding check: session must be bound to a UUID before validation
+    if not bound_uuid:
+        return [error_response(
+            "Session is not bound to a UUID",
+            error_code="UNBOUND_SESSION",
+            error_category="auth_error",
+        )]
 
     # Validate parameters with Pydantic schema
     try:
@@ -57,7 +65,7 @@ async def handle_record_progress_pulse(
     if params.resident_uuid is not None and params.resident_uuid != bound_uuid:
         return [error_response(
             "resident_uuid does not match authenticated agent's bound UUID",
-            error_code="AUTH_MISMATCH",
+            error_code="AUTH_RESIDENT_MISMATCH",
             error_category="auth_error",
             details={
                 "supplied": params.resident_uuid,
@@ -102,7 +110,6 @@ async def handle_record_progress_pulse(
         )]
 
     return success_response({
-        "success": True,
         "resident_uuid": effective_uuid,
         "metric_name": params.metric_name,
         "value": params.value,

--- a/src/mcp_handlers/schemas/progress_flat.py
+++ b/src/mcp_handlers/schemas/progress_flat.py
@@ -1,0 +1,42 @@
+"""Pydantic schema for the record_progress_pulse MCP tool."""
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class RecordProgressPulseParams(BaseModel):
+    """Parameters for the record_progress_pulse tool."""
+
+    metric_name: str = Field(
+        ...,
+        min_length=1,
+        max_length=128,
+        description=(
+            "Metric identifier. Alphanumeric characters plus '._-' only."
+        ),
+    )
+    value: int = Field(
+        ...,
+        ge=0,
+        description="Non-negative integer metric value.",
+    )
+    resident_uuid: Optional[str] = Field(
+        default=None,
+        description=(
+            "UUID of the resident posting the pulse. If provided, MUST match "
+            "the authenticated agent's bound UUID."
+        ),
+    )
+
+    @field_validator("metric_name")
+    @classmethod
+    def metric_name_chars(cls, v: str) -> str:
+        import re
+        if not re.fullmatch(r"[A-Za-z0-9._\-]+", v):
+            raise ValueError(
+                "metric_name must contain only alphanumeric characters, "
+                "dots, underscores, or hyphens"
+            )
+        return v

--- a/src/mcp_handlers/schemas/progress_flat.py
+++ b/src/mcp_handlers/schemas/progress_flat.py
@@ -1,7 +1,7 @@
 """Pydantic schema for the record_progress_pulse MCP tool."""
 from __future__ import annotations
 
-from typing import Optional
+import re
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -22,7 +22,7 @@ class RecordProgressPulseParams(BaseModel):
         ge=0,
         description="Non-negative integer metric value.",
     )
-    resident_uuid: Optional[str] = Field(
+    resident_uuid: str | None = Field(
         default=None,
         description=(
             "UUID of the resident posting the pulse. If provided, MUST match "
@@ -33,7 +33,6 @@ class RecordProgressPulseParams(BaseModel):
     @field_validator("metric_name")
     @classmethod
     def metric_name_chars(cls, v: str) -> str:
-        import re
         if not re.fullmatch(r"[A-Za-z0-9._\-]+", v):
             raise ValueError(
                 "metric_name must contain only alphanumeric characters, "

--- a/src/resident_progress/__init__.py
+++ b/src/resident_progress/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for the resident-progress probe and its components.

--- a/src/resident_progress/heartbeat.py
+++ b/src/resident_progress/heartbeat.py
@@ -1,0 +1,75 @@
+"""HeartbeatEvaluator — thin wrapper over the existing silence/cadence
+semantics. The probe uses this so its candidate gate is consistent with
+how the rest of the server defines a resident as alive.
+
+Critical-silence threshold is 3x expected cadence. Below that we consider
+the resident alive even if the most recent update is slightly stale.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, asdict
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Protocol
+
+logger = logging.getLogger(__name__)
+
+# Match the existing convention: alive if last_update within 3x cadence.
+ALIVE_CADENCE_MULTIPLIER = 3
+
+
+class _MetadataStore(Protocol):
+    async def get(self, agent_uuid: str) -> dict | None: ...
+
+
+@dataclass
+class HeartbeatStatus:
+    alive: bool
+    last_update: datetime | None
+    expected_cadence_s: int | None
+    in_critical_silence: bool
+    eval_error: str | None = None
+
+    def to_jsonable(self) -> dict[str, Any]:
+        d = asdict(self)
+        if d["last_update"] is not None:
+            d["last_update"] = d["last_update"].isoformat()
+        return d
+
+
+class HeartbeatEvaluator:
+    def __init__(
+        self,
+        store: _MetadataStore,
+        _now: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+    ) -> None:
+        self._store = store
+        self._now = _now
+
+    async def evaluate(self, agent_uuid: str) -> HeartbeatStatus:
+        try:
+            row = await self._store.get(agent_uuid)
+        except Exception as e:
+            return HeartbeatStatus(
+                alive=False, last_update=None, expected_cadence_s=None,
+                in_critical_silence=False, eval_error=f"{type(e).__name__}: {e}",
+            )
+        if row is None:
+            return HeartbeatStatus(
+                alive=False, last_update=None, expected_cadence_s=None,
+                in_critical_silence=False,
+            )
+        last = row.get("last_update")
+        cadence = int(row.get("expected_cadence_s") or 0) or None
+        if last is None or cadence is None:
+            return HeartbeatStatus(
+                alive=False, last_update=last, expected_cadence_s=cadence,
+                in_critical_silence=False,
+            )
+        elapsed = self._now() - last
+        critical_threshold = timedelta(seconds=cadence * ALIVE_CADENCE_MULTIPLIER)
+        in_critical = elapsed > critical_threshold
+        return HeartbeatStatus(
+            alive=not in_critical, last_update=last, expected_cadence_s=cadence,
+            in_critical_silence=in_critical,
+        )

--- a/src/resident_progress/probe_task.py
+++ b/src/resident_progress/probe_task.py
@@ -1,0 +1,180 @@
+"""Resident-progress probe orchestrator. See plan task 8 + spec."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Protocol
+
+from src.resident_progress.registry import (
+    RESIDENT_PROGRESS_REGISTRY,
+    resolve_resident_uuid,
+)
+from src.resident_progress.snapshot_writer import SnapshotRow
+
+logger = logging.getLogger(__name__)
+
+STARTUP_GRACE_TICKS = 2
+
+
+class ProgressFlatProbe:
+    def __init__(self, sources_by_name, heartbeat_evaluator, writer,
+                 audit_emitter, _now_tick: int = 0) -> None:
+        self._sources = sources_by_name
+        self._heartbeat = heartbeat_evaluator
+        self._writer = writer
+        self._audit = audit_emitter
+        self._tick_count = _now_tick
+
+    async def tick(self) -> None:
+        self._tick_count += 1
+        tick_id = uuid.uuid4()
+        now = datetime.now(timezone.utc)
+
+        # Step 2: resolve registry
+        resolved: dict[str, str] = {}
+        unresolved_rows: list[SnapshotRow] = []
+        for label, cfg in RESIDENT_PROGRESS_REGISTRY.items():
+            agent_uuid = resolve_resident_uuid(label)
+            if agent_uuid is None:
+                reason = ("startup_unresolved_label"
+                          if self._tick_count <= STARTUP_GRACE_TICKS
+                          else "unresolved_label")
+                unresolved_rows.append(SnapshotRow(
+                    probe_tick_id=tick_id, ticked_at=now,
+                    resident_label=label, resident_uuid=None,
+                    source=cfg.source, metric_value=None,
+                    window_seconds=int(cfg.window.total_seconds()),
+                    threshold=cfg.threshold, metric_below_threshold=None,
+                    heartbeat_alive=False, candidate=False,
+                    suppressed_reason=reason, error_details=None,
+                    liveness_inputs=None, loop_detector_state=None,
+                ))
+            else:
+                resolved[label] = agent_uuid
+
+        # Step 3: group sources, fetch in parallel with isolated errors
+        groups: dict[tuple[str, int], list[str]] = defaultdict(list)
+        for label, agent_uuid in resolved.items():
+            cfg = RESIDENT_PROGRESS_REGISTRY[label]
+            groups[(cfg.source, int(cfg.window.total_seconds()))].append(agent_uuid)
+
+        async def _call_source(name, window_s, uuids):
+            try:
+                out = await self._sources[name].fetch(uuids, timedelta(seconds=window_s))
+                return name, out, None
+            except Exception as e:
+                return name, None, f"{type(e).__name__}: {e}"
+
+        results = await asyncio.gather(*[
+            _call_source(n, w, u) for (n, w), u in groups.items()
+        ])
+        source_outputs = {n: out for n, out, err in results if err is None}
+        source_errors = {n: err for n, out, err in results if err is not None}
+
+        # Step 4: heartbeat in parallel
+        async def _hb(agent_uuid):
+            return agent_uuid, await self._heartbeat.evaluate(agent_uuid)
+
+        hb_pairs = await asyncio.gather(*[_hb(u) for u in resolved.values()])
+        hb_by_uuid = dict(hb_pairs)
+
+        # Step 5: compose resident rows
+        resident_rows: list[SnapshotRow] = []
+        for label, agent_uuid in resolved.items():
+            cfg = RESIDENT_PROGRESS_REGISTRY[label]
+            window_s = int(cfg.window.total_seconds())
+            hb = hb_by_uuid[agent_uuid]
+            if cfg.source in source_errors:
+                row = SnapshotRow(
+                    probe_tick_id=tick_id, ticked_at=now,
+                    resident_label=label, resident_uuid=agent_uuid,
+                    source=cfg.source, metric_value=None,
+                    window_seconds=window_s, threshold=cfg.threshold,
+                    metric_below_threshold=None, heartbeat_alive=hb.alive,
+                    candidate=False, suppressed_reason="source_error",
+                    error_details={"source": cfg.source,
+                                   "error": source_errors[cfg.source]},
+                    liveness_inputs=hb.to_jsonable(),
+                    loop_detector_state=None,
+                )
+            elif hb.eval_error is not None:
+                row = SnapshotRow(
+                    probe_tick_id=tick_id, ticked_at=now,
+                    resident_label=label, resident_uuid=agent_uuid,
+                    source=cfg.source, metric_value=None,
+                    window_seconds=window_s, threshold=cfg.threshold,
+                    metric_below_threshold=None, heartbeat_alive=False,
+                    candidate=False, suppressed_reason="heartbeat_eval_error",
+                    error_details={"heartbeat_error": hb.eval_error},
+                    liveness_inputs=hb.to_jsonable(),
+                    loop_detector_state=None,
+                )
+            else:
+                metric = source_outputs[cfg.source].get(agent_uuid, 0)
+                below = metric < cfg.threshold
+                if not hb.alive and below:
+                    suppressed = "heartbeat_not_alive"
+                    candidate = False
+                else:
+                    suppressed = None
+                    candidate = below and hb.alive
+                row = SnapshotRow(
+                    probe_tick_id=tick_id, ticked_at=now,
+                    resident_label=label, resident_uuid=agent_uuid,
+                    source=cfg.source, metric_value=metric,
+                    window_seconds=window_s, threshold=cfg.threshold,
+                    metric_below_threshold=below, heartbeat_alive=hb.alive,
+                    candidate=candidate, suppressed_reason=suppressed,
+                    error_details=None, liveness_inputs=hb.to_jsonable(),
+                    loop_detector_state=None,
+                )
+            resident_rows.append(row)
+
+        # Step 6: persist resident + unresolved rows
+        all_rows = unresolved_rows + resident_rows
+        try:
+            await self._writer.write(all_rows)
+        except Exception as e:
+            logger.warning("[PROGRESS_FLAT] resident-row write failed: %s", e)
+            return
+
+        # Step 7: dogfood row (non-fatal write)
+        dogfood = SnapshotRow(
+            probe_tick_id=tick_id, ticked_at=datetime.now(timezone.utc),
+            resident_label="progress_flat_probe", resident_uuid=None,
+            source="probe_self", metric_value=len(all_rows),
+            window_seconds=None, threshold=None,
+            metric_below_threshold=False, heartbeat_alive=True,
+            candidate=False, suppressed_reason=None,
+            error_details=None, liveness_inputs=None,
+            loop_detector_state=None,
+        )
+        try:
+            await self._writer.write([dogfood])
+        except Exception as e:
+            logger.warning(
+                "[PROGRESS_FLAT] dogfood-row write failed (non-fatal): %s", e,
+            )
+
+        # Step 8: emit candidate events
+        for r in resident_rows:
+            if r.candidate:
+                try:
+                    await self._audit.emit(
+                        event_type="progress_flat_candidate", severity="low",
+                        payload={
+                            "resident_label": r.resident_label,
+                            "resident_uuid": r.resident_uuid,
+                            "source": r.source, "metric_value": r.metric_value,
+                            "threshold": r.threshold,
+                            "window_seconds": r.window_seconds,
+                            "probe_tick_id": str(r.probe_tick_id),
+                        },
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "[PROGRESS_FLAT] candidate audit emit failed: %s", e,
+                    )

--- a/src/resident_progress/probe_task.py
+++ b/src/resident_progress/probe_task.py
@@ -178,3 +178,19 @@ class ProgressFlatProbe:
                     logger.warning(
                         "[PROGRESS_FLAT] candidate audit emit failed: %s", e,
                     )
+
+
+def _verify_unique_source_names() -> None:
+    seen = set()
+    for cfg in RESIDENT_PROGRESS_REGISTRY.values():
+        if cfg.source in seen:
+            raise RuntimeError(
+                f"resident-progress registry has duplicate source name "
+                f"'{cfg.source}' — orchestrator's source_outputs dict cannot "
+                f"distinguish them. If you intentionally share a source across "
+                f"residents, change source_outputs to key on (name, window) tuple."
+            )
+        seen.add(cfg.source)
+
+
+_verify_unique_source_names()

--- a/src/resident_progress/registry.py
+++ b/src/resident_progress/registry.py
@@ -1,0 +1,50 @@
+"""Label-keyed config for the resident-progress probe.
+
+Resident UUIDs are NOT stored here. They resolve at tick time from
+filesystem anchors, so a resident that re-onboards or rotates UUID is
+picked up automatically. See
+docs/superpowers/specs/2026-04-25-resident-progress-detection-design.md
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+ANCHOR_DIR = Path.home() / ".unitares" / "anchors"
+
+
+@dataclass(frozen=True)
+class ResidentConfig:
+    source: str       # source.name as defined in sources.py
+    metric: str       # human-readable metric label, recorded on snapshot row
+    window: timedelta
+    threshold: int    # candidate fires when measured metric is strictly less than threshold
+
+
+RESIDENT_PROGRESS_REGISTRY: dict[str, ResidentConfig] = {
+    "vigil":      ResidentConfig("kg_writes",        "rows_written", timedelta(minutes=60),  1),
+    "watcher":    ResidentConfig("watcher_findings", "rows_any",     timedelta(hours=6),     1),
+    "steward":    ResidentConfig("eisv_sync_rows",   "rows_written", timedelta(minutes=30),  1),
+    "chronicler": ResidentConfig("metrics_series",   "rows_written", timedelta(hours=26),    1),
+    "sentinel":   ResidentConfig("sentinel_pulse",   "latest_count", timedelta(minutes=30),  1),
+}
+
+
+def resolve_resident_uuid(label: str) -> str | None:
+    """Read ~/.unitares/anchors/<label>.json and return the agent_uuid, or None."""
+    path = ANCHOR_DIR / f"{label}.json"
+    try:
+        with path.open() as f:
+            doc = json.load(f)
+    except FileNotFoundError:
+        return None
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("anchor %s unreadable: %s", path, e)
+        return None
+    uuid = doc.get("agent_uuid")
+    return uuid if isinstance(uuid, str) and uuid else None

--- a/src/resident_progress/sentinel_source.py
+++ b/src/resident_progress/sentinel_source.py
@@ -1,0 +1,51 @@
+"""SentinelPulseSource — pull-side of the push-based progress telemetry.
+
+Sentinel calls the ``record_progress_pulse`` MCP tool (defined in
+``src/mcp_handlers/resident_progress.py``) to post a progress pulse into
+``resident_progress_pulse``. This class reads those rows back in a single
+batched DISTINCT ON query for the probe orchestrator.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+
+class SentinelPulseSource:
+    """Returns the latest recorded pulse value per resident UUID in a window.
+
+    Uses a single DISTINCT ON query — no per-UUID fanout.
+    """
+
+    name = "sentinel_pulse"
+
+    def __init__(self, db) -> None:
+        self._db = db
+
+    async def fetch(
+        self, resident_uuids: list[str], window: timedelta
+    ) -> dict[str, int]:
+        """Return the latest ``value`` per resident_uuid in the window.
+
+        Missing UUIDs (no row in window) are returned as 0.
+        Empty input returns {} without issuing a query.
+        """
+        if not resident_uuids:
+            return {}
+
+        async with self._db.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT DISTINCT ON (resident_uuid)
+                    resident_uuid::text AS uuid,
+                    value
+                FROM resident_progress_pulse
+                WHERE resident_uuid = ANY($1::uuid[])
+                  AND recorded_at > now() - $2::interval
+                ORDER BY resident_uuid, recorded_at DESC
+                """,
+                resident_uuids,
+                window,
+            )
+
+        latest = {r["uuid"]: int(r["value"]) for r in rows}
+        return {u: latest.get(u, 0) for u in resident_uuids}

--- a/src/resident_progress/snapshot_writer.py
+++ b/src/resident_progress/snapshot_writer.py
@@ -1,0 +1,67 @@
+"""Batched insert for progress_flat_snapshots."""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SnapshotRow:
+    probe_tick_id: UUID
+    ticked_at: datetime
+    resident_label: str
+    resident_uuid: str | None
+    source: str
+    metric_value: int | None
+    window_seconds: int | None
+    threshold: int | None
+    metric_below_threshold: bool | None
+    heartbeat_alive: bool | None
+    candidate: bool
+    suppressed_reason: str | None
+    error_details: dict | None
+    liveness_inputs: dict | None
+    loop_detector_state: dict | None
+
+
+_INSERT_SQL = """
+INSERT INTO progress_flat_snapshots (
+    probe_tick_id, ticked_at, resident_label, resident_uuid, source,
+    metric_value, window_seconds, threshold, metric_below_threshold,
+    heartbeat_alive, candidate, suppressed_reason, error_details,
+    liveness_inputs, loop_detector_state
+) VALUES (
+    $1, $2, $3, $4::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13::jsonb, $14::jsonb, $15::jsonb
+)
+"""
+
+
+def _row_args(r: SnapshotRow) -> tuple[Any, ...]:
+    def _j(d: dict | None) -> str | None:
+        return json.dumps(d) if d is not None else None
+
+    return (
+        r.probe_tick_id, r.ticked_at, r.resident_label, r.resident_uuid,
+        r.source, r.metric_value, r.window_seconds, r.threshold,
+        r.metric_below_threshold, r.heartbeat_alive, r.candidate,
+        r.suppressed_reason, _j(r.error_details), _j(r.liveness_inputs),
+        _j(r.loop_detector_state),
+    )
+
+
+class SnapshotWriter:
+    def __init__(self, db) -> None:
+        self._db = db
+
+    async def write(self, rows: list[SnapshotRow]) -> None:
+        if not rows:
+            return
+        async with self._db.acquire() as conn:
+            async with conn.transaction():
+                await conn.executemany(_INSERT_SQL, [_row_args(r) for r in rows])

--- a/src/resident_progress/sources.py
+++ b/src/resident_progress/sources.py
@@ -1,0 +1,124 @@
+"""ResidentProgressSource implementations.
+
+Each source issues exactly one batched query covering all relevant
+resident UUIDs in the window — never N×M fanout. The orchestrator
+groups configured (source_name, window) pairs and calls each group once.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Protocol
+
+# Names defined in agents/chronicler/scrapers.py (SCRAPERS dict). Must
+# stay in sync with that file; if Chronicler adds a series, add it here.
+CHRONICLER_SERIES_NAMES: tuple[str, ...] = (
+    "tokei.unitares.src.code",
+    "tests.unitares.count",
+    "agents.active.7d",
+    "kg.entries.count",
+    "checkins.7d",
+)
+
+
+class ResidentProgressSource(Protocol):
+    name: str
+
+    async def fetch(self, resident_uuids: list[str], window: timedelta) -> dict[str, int]: ...
+
+
+class KnowledgeDiscoverySource:
+    """Counts rows in knowledge.discoveries per resident_uuid in the window.
+
+    Used for both Vigil (resident_label='vigil') and Watcher
+    (resident_label='watcher'); the orchestrator filters by the resolved
+    UUID so the same source class serves both.
+    """
+    name = "kg_writes"  # Watcher's source uses name='watcher_findings' (see registry)
+
+    def __init__(self, db) -> None:
+        self._db = db
+
+    async def fetch(self, resident_uuids: list[str], window: timedelta) -> dict[str, int]:
+        if not resident_uuids:
+            return {}
+        async with self._db.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT agent_id::text AS uuid, count(*) AS n
+                FROM knowledge.discoveries
+                WHERE agent_id = ANY($1::text[])
+                  AND created_at > now() - $2::interval
+                GROUP BY agent_id
+                """,
+                resident_uuids,
+                window,
+            )
+        counts = {r["uuid"]: int(r["n"]) for r in rows}
+        return {u: counts.get(u, 0) for u in resident_uuids}
+
+
+class WatcherFindingSource(KnowledgeDiscoverySource):
+    """Same as KnowledgeDiscoverySource — Watcher posts via post_finding
+    which lands in knowledge.discoveries. Subclassed only so the source
+    name on snapshot rows is forensically distinct from Vigil's writes.
+    """
+    name = "watcher_findings"
+
+
+class EISVSyncSource:
+    """Counts audit.events rows with event_type='eisv_sync' authored by
+    the given resident in the window. Steward is the sole writer.
+    """
+    name = "eisv_sync_rows"
+
+    def __init__(self, db) -> None:
+        self._db = db
+
+    async def fetch(self, resident_uuids: list[str], window: timedelta) -> dict[str, int]:
+        if not resident_uuids:
+            return {}
+        async with self._db.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT agent_id::text AS uuid, count(*) AS n
+                FROM audit.events
+                WHERE event_type = 'eisv_sync'
+                  AND agent_id = ANY($1::text[])
+                  AND ts > now() - $2::interval
+                GROUP BY agent_id
+                """,
+                resident_uuids,
+                window,
+            )
+        counts = {r["uuid"]: int(r["n"]) for r in rows}
+        return {u: counts.get(u, 0) for u in resident_uuids}
+
+
+class MetricsSeriesSource:
+    """Counts metrics.series rows whose `name` is in the
+    Chronicler-known list, in the window. metrics.series has no agent_id
+    column, so all configured UUIDs receive the same count — Chronicler
+    is the sole writer of these names. If another agent ever starts
+    writing to these names, this assumption breaks; revisit at that time.
+    """
+    name = "metrics_series"
+
+    def __init__(self, db) -> None:
+        self._db = db
+
+    async def fetch(self, resident_uuids: list[str], window: timedelta) -> dict[str, int]:
+        if not resident_uuids:
+            return {}
+        async with self._db.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT count(*) AS n
+                FROM metrics.series
+                WHERE name = ANY($1::text[])
+                  AND ts > now() - $2::interval
+                """,
+                list(CHRONICLER_SERIES_NAMES),
+                window,
+            )
+        n = int(row["n"]) if row else 0
+        return {u: n for u in resident_uuids}

--- a/src/resident_progress/status.py
+++ b/src/resident_progress/status.py
@@ -1,0 +1,21 @@
+"""Deterministic status-priority resolver for progress_flat snapshot rows.
+
+Priority (first match wins):
+    source-error > unresolved > startup-grace > silent > flat-candidate > OK
+"""
+from __future__ import annotations
+
+
+def resolve_status(row: dict) -> str:
+    if row.get("error_details"):
+        return "source-error"
+    suppressed = row.get("suppressed_reason")
+    if suppressed == "unresolved_label":
+        return "unresolved"
+    if suppressed == "startup_unresolved_label":
+        return "startup-grace"
+    if suppressed in ("heartbeat_not_alive", "heartbeat_eval_error"):
+        return "silent"
+    if row.get("candidate") is True:
+        return "flat-candidate"
+    return "OK"

--- a/tests/resident_progress/conftest.py
+++ b/tests/resident_progress/conftest.py
@@ -1,0 +1,11 @@
+"""Session-scoped schema bootstrap for resident_progress integration tests."""
+from __future__ import annotations
+
+import pytest_asyncio
+
+from tests.test_db_utils import ensure_test_database_schema
+
+
+@pytest_asyncio.fixture(scope="session", autouse=True)
+async def _bootstrap_schema():
+    await ensure_test_database_schema()

--- a/tests/resident_progress/conftest.py
+++ b/tests/resident_progress/conftest.py
@@ -1,11 +1,31 @@
 """Session-scoped schema bootstrap for resident_progress integration tests."""
 from __future__ import annotations
 
+import pytest
 import pytest_asyncio
 
-from tests.test_db_utils import ensure_test_database_schema
+from tests.test_db_utils import ensure_test_database_schema, TEST_DB_URL
 
 
 @pytest_asyncio.fixture(scope="session", loop_scope="session", autouse=True)
 async def _bootstrap_schema():
     await ensure_test_database_schema()
+
+
+@pytest_asyncio.fixture(loop_scope="function")
+async def test_db():
+    """Function-scoped asyncpg pool connected to governance_test.
+
+    Creates a new pool per test so the pool lives in the same event loop
+    as the test function (pytest-asyncio STRICT mode uses per-test loops).
+    Skips if governance_test is unavailable. Relies on _bootstrap_schema
+    (autouse=True above) having run before this fixture is used.
+    """
+    try:
+        import asyncpg
+    except ImportError:
+        pytest.skip("asyncpg not installed")
+
+    pool = await asyncpg.create_pool(TEST_DB_URL, min_size=1, max_size=3)
+    yield pool
+    await pool.close()

--- a/tests/resident_progress/conftest.py
+++ b/tests/resident_progress/conftest.py
@@ -1,6 +1,8 @@
 """Session-scoped schema bootstrap for resident_progress integration tests."""
 from __future__ import annotations
 
+import json
+
 import pytest
 import pytest_asyncio
 
@@ -9,6 +11,22 @@ from tests.test_db_utils import (
     ensure_test_database_schema,
     TEST_DB_URL,
 )
+
+
+async def _init_json_codec(conn) -> None:
+    """Register jsonb codec so asyncpg returns dicts instead of raw JSON strings.
+
+    The encoder is identity because snapshot_writer passes pre-encoded JSON strings
+    with a ::jsonb cast — asyncpg should not re-encode them.  The decoder runs
+    json.loads so SELECT results come back as Python dicts.
+    """
+    await conn.set_type_codec(
+        "jsonb",
+        encoder=lambda v: v,  # value is already a JSON string at send time
+        decoder=json.loads,
+        schema="pg_catalog",
+        format="text",
+    )
 
 
 @pytest_asyncio.fixture(scope="session", loop_scope="session", autouse=True)
@@ -41,7 +59,9 @@ async def test_db():
         pytest.skip("asyncpg not installed")
 
     try:
-        pool = await asyncpg.create_pool(TEST_DB_URL, min_size=1, max_size=3, timeout=5)
+        pool = await asyncpg.create_pool(
+            TEST_DB_URL, min_size=1, max_size=3, timeout=5, init=_init_json_codec
+        )
     except Exception:
         pytest.skip("governance_test database not available")
 

--- a/tests/resident_progress/conftest.py
+++ b/tests/resident_progress/conftest.py
@@ -6,6 +6,6 @@ import pytest_asyncio
 from tests.test_db_utils import ensure_test_database_schema
 
 
-@pytest_asyncio.fixture(scope="session", autouse=True)
+@pytest_asyncio.fixture(scope="session", loop_scope="session", autouse=True)
 async def _bootstrap_schema():
     await ensure_test_database_schema()

--- a/tests/resident_progress/conftest.py
+++ b/tests/resident_progress/conftest.py
@@ -4,11 +4,25 @@ from __future__ import annotations
 import pytest
 import pytest_asyncio
 
-from tests.test_db_utils import ensure_test_database_schema, TEST_DB_URL
+from tests.test_db_utils import (
+    can_connect_to_test_db,
+    ensure_test_database_schema,
+    TEST_DB_URL,
+)
 
 
 @pytest_asyncio.fixture(scope="session", loop_scope="session", autouse=True)
 async def _bootstrap_schema():
+    """Bootstrap the test schema.
+
+    If governance_test is unreachable, does nothing — tests that don't touch
+    the DB will still run successfully; tests that acquire test_db will skip
+    themselves when pool creation fails.
+    """
+    if not can_connect_to_test_db():
+        # DB unavailable — skip bootstrap; DB-dependent tests will skip on
+        # their own when test_db raises.
+        return
     await ensure_test_database_schema()
 
 
@@ -26,6 +40,10 @@ async def test_db():
     except ImportError:
         pytest.skip("asyncpg not installed")
 
-    pool = await asyncpg.create_pool(TEST_DB_URL, min_size=1, max_size=3)
+    try:
+        pool = await asyncpg.create_pool(TEST_DB_URL, min_size=1, max_size=3, timeout=5)
+    except Exception:
+        pytest.skip("governance_test database not available")
+
     yield pool
     await pool.close()

--- a/tests/resident_progress/test_calibration_smoke.py
+++ b/tests/resident_progress/test_calibration_smoke.py
@@ -1,0 +1,69 @@
+"""Calibration smoke test — catches obviously-misconfigured thresholds
+before deploy. The 50% ceiling is a hard upper bound; the operational
+tuning target is much lower and will be set from real data after Phase 1.
+"""
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_no_resident_candidate_above_fifty_percent(test_db):
+    """If ANY configured resident is firing candidates >50% of ticks,
+    the threshold is misconfigured. Hard ceiling — operational target is
+    much lower."""
+    async with test_db.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT resident_label, candidate
+            FROM progress_flat_snapshots
+            WHERE ticked_at > now() - interval '24 hours'
+              AND resident_label != 'progress_flat_probe'
+            """
+        )
+    if not rows:
+        pytest.skip("no snapshots persisted yet — run probe at least once")
+
+    by_label = Counter()
+    candidate_by_label = Counter()
+    for r in rows:
+        by_label[r["resident_label"]] += 1
+        if r["candidate"]:
+            candidate_by_label[r["resident_label"]] += 1
+
+    offenders = []
+    for label, total in by_label.items():
+        ratio = candidate_by_label[label] / total
+        if ratio > 0.5:
+            offenders.append((label, ratio, total))
+    assert not offenders, (
+        f"residents firing candidate > 50% of ticks "
+        f"(threshold misconfigured?): {offenders}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_at_least_one_row_per_resident_in_recent_window(test_db):
+    async with test_db.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT resident_label, count(*) AS n
+            FROM progress_flat_snapshots
+            WHERE ticked_at > now() - interval '1 hour'
+            GROUP BY resident_label
+            """
+        )
+    if not rows:
+        pytest.skip("no snapshots persisted yet — run probe at least once")
+    seen = {r["resident_label"] for r in rows}
+    expected = {
+        "vigil", "watcher", "steward", "chronicler", "sentinel",
+        "progress_flat_probe",
+    }
+    missing = expected - seen
+    # In a healthy probe, every configured resident has at least one
+    # snapshot row per tick. Missing labels indicate the probe stopped
+    # or the registry resolution silently failed.
+    assert not missing, f"no recent snapshots for: {missing}"

--- a/tests/resident_progress/test_calibration_smoke.py
+++ b/tests/resident_progress/test_calibration_smoke.py
@@ -1,33 +1,57 @@
 """Calibration smoke test — catches obviously-misconfigured thresholds
 before deploy. The 50% ceiling is a hard upper bound; the operational
 tuning target is much lower and will be set from real data after Phase 1.
+
+Filters to ticks that have a `progress_flat_probe` dogfood row, so
+synthetic test inserts (from snapshot_writer/probe_task tests) do not
+pollute the calibration signal. Skips when no real probe activity is
+present in the window.
 """
 from __future__ import annotations
 
 from collections import Counter
+from datetime import timedelta
 
 import pytest
 
 
+_REAL_TICK_IDS_SQL = """
+SELECT DISTINCT probe_tick_id
+FROM progress_flat_snapshots
+WHERE ticked_at > now() - $1::interval
+  AND resident_label = 'progress_flat_probe'
+"""
+
+
 @pytest.mark.asyncio
 async def test_no_resident_candidate_above_fifty_percent(test_db):
-    """If ANY configured resident is firing candidates >50% of ticks,
-    the threshold is misconfigured. Hard ceiling — operational target is
-    much lower."""
+    """If ANY configured resident is firing candidates >50% of REAL probe
+    ticks, the threshold is misconfigured. Hard ceiling — operational
+    target is much lower."""
     async with test_db.acquire() as conn:
+        real_tick_ids = await conn.fetch(_REAL_TICK_IDS_SQL, timedelta(hours=24))
+        if not real_tick_ids:
+            pytest.skip(
+                "no real probe ticks in the last 24h — run the probe "
+                "against this DB at least once"
+            )
         rows = await conn.fetch(
             """
             SELECT resident_label, candidate
             FROM progress_flat_snapshots
-            WHERE ticked_at > now() - interval '24 hours'
+            WHERE probe_tick_id = ANY($1::uuid[])
               AND resident_label != 'progress_flat_probe'
-            """
+            """,
+            [r["probe_tick_id"] for r in real_tick_ids],
         )
     if not rows:
-        pytest.skip("no snapshots persisted yet — run probe at least once")
+        pytest.skip(
+            "real probe ticks had no resident rows — probe ran with empty "
+            "registry; nothing to calibrate"
+        )
 
-    by_label = Counter()
-    candidate_by_label = Counter()
+    by_label: Counter = Counter()
+    candidate_by_label: Counter = Counter()
     for r in rows:
         by_label[r["resident_label"]] += 1
         if r["candidate"]:
@@ -45,25 +69,19 @@ async def test_no_resident_candidate_above_fifty_percent(test_db):
 
 
 @pytest.mark.asyncio
-async def test_at_least_one_row_per_resident_in_recent_window(test_db):
+async def test_at_least_one_dogfood_row_in_recent_window(test_db):
+    """Probe-self liveness check: at least one real probe tick must
+    have run in the last hour. Stronger than the previous version which
+    accepted any snapshot row, including synthetic test inserts.
+    """
     async with test_db.acquire() as conn:
-        rows = await conn.fetch(
+        n = await conn.fetchval(
             """
-            SELECT resident_label, count(*) AS n
-            FROM progress_flat_snapshots
+            SELECT count(*) FROM progress_flat_snapshots
             WHERE ticked_at > now() - interval '1 hour'
-            GROUP BY resident_label
+              AND resident_label = 'progress_flat_probe'
             """
         )
-    if not rows:
-        pytest.skip("no snapshots persisted yet — run probe at least once")
-    seen = {r["resident_label"] for r in rows}
-    expected = {
-        "vigil", "watcher", "steward", "chronicler", "sentinel",
-        "progress_flat_probe",
-    }
-    missing = expected - seen
-    # In a healthy probe, every configured resident has at least one
-    # snapshot row per tick. Missing labels indicate the probe stopped
-    # or the registry resolution silently failed.
-    assert not missing, f"no recent snapshots for: {missing}"
+    if n == 0:
+        pytest.skip("no real probe ticks in the last hour — probe not running")
+    assert n >= 1

--- a/tests/resident_progress/test_heartbeat.py
+++ b/tests/resident_progress/test_heartbeat.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.resident_progress.heartbeat import HeartbeatEvaluator, HeartbeatStatus
+
+
+class _FakeMetadataStore:
+    def __init__(self, rows: dict[str, dict]):
+        self._rows = rows
+
+    async def get(self, agent_uuid: str) -> dict | None:
+        return self._rows.get(agent_uuid)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_alive_when_recent_update():
+    now = datetime.now(timezone.utc)
+    store = _FakeMetadataStore({
+        "u1": {"last_update": now - timedelta(seconds=30), "expected_cadence_s": 60},
+    })
+    ev = HeartbeatEvaluator(store, _now=lambda: now)
+    status = await ev.evaluate("u1")
+    assert status.alive is True
+    assert status.in_critical_silence is False
+    assert status.eval_error is None
+
+
+@pytest.mark.asyncio
+async def test_evaluate_silent_when_stale_update():
+    now = datetime.now(timezone.utc)
+    store = _FakeMetadataStore({
+        "u1": {"last_update": now - timedelta(minutes=30), "expected_cadence_s": 60},
+    })
+    ev = HeartbeatEvaluator(store, _now=lambda: now)
+    status = await ev.evaluate("u1")
+    assert status.alive is False
+    assert status.in_critical_silence is True
+
+
+@pytest.mark.asyncio
+async def test_evaluate_unknown_agent_returns_not_alive():
+    ev = HeartbeatEvaluator(_FakeMetadataStore({}), _now=lambda: datetime.now(timezone.utc))
+    status = await ev.evaluate("missing-uuid")
+    assert status.alive is False
+    assert status.eval_error is None  # missing agent is a known-not-alive, not an error
+
+
+@pytest.mark.asyncio
+async def test_evaluate_returns_error_on_store_exception():
+    class _Boom:
+        async def get(self, _): raise RuntimeError("db down")
+    ev = HeartbeatEvaluator(_Boom(), _now=lambda: datetime.now(timezone.utc))
+    status = await ev.evaluate("u1")
+    assert status.alive is False
+    assert "db down" in (status.eval_error or "")

--- a/tests/resident_progress/test_http_endpoint.py
+++ b/tests/resident_progress/test_http_endpoint.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_http_api_token(monkeypatch):
+    monkeypatch.delenv("UNITARES_HTTP_API_TOKEN", raising=False)
+
+
+@pytest.mark.asyncio
+async def test_endpoint_returns_row_per_configured_resident(test_db, monkeypatch):
+    # Insert a recent snapshot for vigil so at least one row has live data.
+    async with test_db.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO progress_flat_snapshots (
+                probe_tick_id, ticked_at, resident_label, source,
+                metric_value, window_seconds, threshold,
+                metric_below_threshold, heartbeat_alive, candidate
+            ) VALUES (
+                $1::uuid, now(), 'vigil', 'kg_writes', 5, 3600, 1,
+                false, true, false
+            )
+            """,
+            str(uuid.uuid4()),
+        )
+
+    # Patch get_db() so the handler queries the test pool instead of production.
+    import src.db as _db_module
+    monkeypatch.setattr(_db_module, "_db_instance", test_db)
+
+    from src.resident_progress.registry import RESIDENT_PROGRESS_REGISTRY
+    from src.resident_progress.status import resolve_status
+    from src.http_api import http_get_progress_flat_recent
+
+    class _MockRequest:
+        client = None
+
+        def __init__(self, params):
+            self.query_params = params
+            self.headers = {}
+
+    resp = await http_get_progress_flat_recent(_MockRequest({"hours": "24"}))
+    payload = json.loads(resp.body)
+    assert payload["success"] is True
+    rows = {r["resident_label"]: r for r in payload["rows"]}
+    expected_labels = set(RESIDENT_PROGRESS_REGISTRY) | {"progress_flat_probe"}
+    assert expected_labels <= set(rows.keys())
+    # Vigil row should have status determined by resolve_status
+    assert rows["vigil"]["status"] in {
+        "OK", "flat-candidate", "silent", "source-error",
+        "unresolved", "startup-grace",
+    }
+
+
+@pytest.mark.asyncio
+async def test_endpoint_status_field_uses_priority_resolver(test_db, monkeypatch):
+    import src.db as _db_module
+    monkeypatch.setattr(_db_module, "_db_instance", test_db)
+
+    from src.http_api import http_get_progress_flat_recent
+
+    class _MockRequest:
+        client = None
+        query_params = {}
+        headers = {}
+
+    resp = await http_get_progress_flat_recent(_MockRequest())
+    payload = json.loads(resp.body)
+    rows = payload["rows"]
+    assert all("status" in r for r in rows)
+    assert all(
+        r["status"] in {
+            "OK", "flat-candidate", "silent", "source-error",
+            "unresolved", "startup-grace",
+        } for r in rows
+    )

--- a/tests/resident_progress/test_migration.py
+++ b/tests/resident_progress/test_migration.py
@@ -2,14 +2,18 @@
 from __future__ import annotations
 
 import pytest
-import asyncpg
 
-GOVERNANCE_DB_URL = "postgresql://postgres:postgres@localhost:5432/governance"
+from tests.test_db_utils import TEST_DB_URL, can_connect_to_test_db
+
+if not can_connect_to_test_db():
+    pytest.skip("governance_test database not available", allow_module_level=True)
 
 
 @pytest.mark.asyncio
 async def test_progress_flat_snapshots_table_exists():
-    conn = await asyncpg.connect(GOVERNANCE_DB_URL)
+    import asyncpg
+
+    conn = await asyncpg.connect(TEST_DB_URL)
     try:
         cols = await conn.fetch("""
             SELECT column_name, data_type
@@ -34,7 +38,9 @@ async def test_progress_flat_snapshots_table_exists():
 
 @pytest.mark.asyncio
 async def test_resident_progress_pulse_table_exists():
-    conn = await asyncpg.connect(GOVERNANCE_DB_URL)
+    import asyncpg
+
+    conn = await asyncpg.connect(TEST_DB_URL)
     try:
         cols = await conn.fetch("""
             SELECT column_name FROM information_schema.columns

--- a/tests/resident_progress/test_migration.py
+++ b/tests/resident_progress/test_migration.py
@@ -1,0 +1,47 @@
+"""Smoke test: migration 018 creates both telemetry tables with required columns."""
+from __future__ import annotations
+
+import pytest
+import asyncpg
+
+GOVERNANCE_DB_URL = "postgresql://postgres:postgres@localhost:5432/governance"
+
+
+@pytest.mark.asyncio
+async def test_progress_flat_snapshots_table_exists():
+    conn = await asyncpg.connect(GOVERNANCE_DB_URL)
+    try:
+        cols = await conn.fetch("""
+            SELECT column_name, data_type
+            FROM information_schema.columns
+            WHERE table_schema='public' AND table_name='progress_flat_snapshots'
+            ORDER BY ordinal_position
+        """)
+    finally:
+        await conn.close()
+
+    names = {r["column_name"] for r in cols}
+    required = {
+        "id", "probe_tick_id", "ticked_at", "resident_label", "resident_uuid",
+        "source", "metric_value", "window_seconds", "threshold",
+        "metric_below_threshold", "heartbeat_alive", "candidate",
+        "suppressed_reason", "error_details", "liveness_inputs",
+        "loop_detector_state",
+    }
+    missing = required - names
+    assert not missing, f"missing columns: {missing}"
+
+
+@pytest.mark.asyncio
+async def test_resident_progress_pulse_table_exists():
+    conn = await asyncpg.connect(GOVERNANCE_DB_URL)
+    try:
+        cols = await conn.fetch("""
+            SELECT column_name FROM information_schema.columns
+            WHERE table_schema='public' AND table_name='resident_progress_pulse'
+        """)
+    finally:
+        await conn.close()
+
+    names = {r["column_name"] for r in cols}
+    assert {"id", "resident_uuid", "metric_name", "value", "recorded_at"} <= names

--- a/tests/resident_progress/test_probe_integration.py
+++ b/tests/resident_progress/test_probe_integration.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src import background_tasks
+
+
+@pytest.mark.asyncio
+async def test_progress_flat_probe_task_is_supervised_when_started(monkeypatch):
+    """Confirm start_all_background_tasks creates a supervised task named
+    'progress_flat_probe'. Other background tasks are also created — we
+    do not assert their absence, only that ours is present.
+    """
+    background_tasks._supervised_tasks.clear()
+
+    async def fake_set_ready():
+        pass
+
+    class _NoopTracker:
+        def add(self, *a, **kw):
+            pass
+
+    background_tasks.start_all_background_tasks(
+        connection_tracker=_NoopTracker(), set_ready=fake_set_ready,
+    )
+    names = [t.get_name() if hasattr(t, "get_name") else (getattr(t, "_name", "") or "") for t in background_tasks._supervised_tasks]
+    assert any("progress_flat_probe" in n for n in names), \
+        f"progress_flat_probe not in supervised task list: {names}"
+    await background_tasks.stop_all_background_tasks()

--- a/tests/resident_progress/test_probe_self_regression.py
+++ b/tests/resident_progress/test_probe_self_regression.py
@@ -1,0 +1,52 @@
+"""After 10 probe ticks, the dogfood row must appear in 10 of 10 ticks.
+Regression guard for the dogfood-row write path.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.resident_progress.probe_task import ProgressFlatProbe
+from src.resident_progress.snapshot_writer import SnapshotWriter
+
+
+@pytest.mark.asyncio
+async def test_dogfood_row_present_in_every_tick(test_db, monkeypatch):
+    """Run 10 ticks against the real writer with an empty registry —
+    only the dogfood row should be produced per tick. Verify each
+    tick's probe_tick_id has at least one progress_flat_probe row.
+    """
+    monkeypatch.setattr(
+        "src.resident_progress.probe_task.RESIDENT_PROGRESS_REGISTRY", {},
+    )
+    writer = SnapshotWriter(test_db)
+    probe = ProgressFlatProbe(
+        sources_by_name={}, heartbeat_evaluator=AsyncMock(),
+        writer=writer, audit_emitter=AsyncMock(), _now_tick=10,
+    )
+    # Capture the time before the test so we filter to just our ticks
+    started_at = datetime.now(timezone.utc)
+    for _ in range(10):
+        await probe.tick()
+
+    async with test_db.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT probe_tick_id,
+                   count(*) FILTER (
+                       WHERE resident_label = 'progress_flat_probe'
+                   ) AS dogfoods
+            FROM progress_flat_snapshots
+            WHERE ticked_at >= $1
+            GROUP BY probe_tick_id
+            ORDER BY probe_tick_id
+            """,
+            started_at,
+        )
+    distinct_ticks_with_dogfood = [r for r in rows if r["dogfoods"] >= 1]
+    assert len(distinct_ticks_with_dogfood) >= 10, (
+        f"expected at least 10 ticks with dogfood rows, got "
+        f"{len(distinct_ticks_with_dogfood)} (rows: {rows})"
+    )

--- a/tests/resident_progress/test_probe_task.py
+++ b/tests/resident_progress/test_probe_task.py
@@ -360,3 +360,163 @@ async def test_dogfood_write_failure_is_non_fatal(monkeypatch):
     # Audit event emitted despite dogfood failure (candidate vigil row)
     audit.emit.assert_called_once()
     assert audit.emit.call_args.kwargs["payload"]["resident_label"] == "vigil"
+
+
+# ---------------------------------------------------------------------------
+# Test 6: heartbeat_eval_error branch — alive=True ignored, forced to False
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_heartbeat_eval_error_forces_dead_and_suppresses(monkeypatch):
+    """hb.alive=True but hb.eval_error='db down' → heartbeat_alive=False, suppressed."""
+    vigil_uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+    monkeypatch.setattr(
+        "src.resident_progress.probe_task.RESIDENT_PROGRESS_REGISTRY",
+        _registry_one_vigil(),
+    )
+    monkeypatch.setattr(
+        "src.resident_progress.probe_task.resolve_resident_uuid",
+        lambda label: vigil_uuid if label == "vigil" else None,
+    )
+
+    source = MagicMock()
+    source.fetch = AsyncMock(return_value={vigil_uuid: 5})
+
+    heartbeat = MagicMock()
+    # alive=True but eval_error set — orchestrator must override alive to False
+    heartbeat.evaluate = AsyncMock(return_value=_hb(alive=True, eval_error="db down"))
+
+    writer = MagicMock()
+    writer.write = AsyncMock()
+
+    audit = MagicMock()
+    audit.emit = AsyncMock()
+
+    probe = _make_probe(
+        sources_by_name={"kg_writes": source},
+        heartbeat_evaluator=heartbeat,
+        writer=writer,
+        audit_emitter=audit,
+    )
+
+    await probe.tick()
+
+    resident_batch = writer.write.call_args_list[0][0][0]
+    assert len(resident_batch) == 1
+    row = resident_batch[0]
+
+    # Critical: heartbeat_alive must be forced False despite hb.alive=True
+    assert row.heartbeat_alive is False
+    assert row.suppressed_reason == "heartbeat_eval_error"
+    assert row.error_details == {"heartbeat_error": "db down"}
+    assert row.candidate is False
+    assert row.metric_value is None
+
+    # No audit event (not a candidate)
+    audit.emit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test 7: heartbeat_not_alive suppression — metric below threshold but not candidate
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_heartbeat_not_alive_suppresses_candidate(monkeypatch):
+    """metric=0 < threshold=1 AND hb.alive=False → suppressed_reason='heartbeat_not_alive', candidate=False."""
+    vigil_uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+    monkeypatch.setattr(
+        "src.resident_progress.probe_task.RESIDENT_PROGRESS_REGISTRY",
+        _registry_one_vigil(),
+    )
+    monkeypatch.setattr(
+        "src.resident_progress.probe_task.resolve_resident_uuid",
+        lambda label: vigil_uuid if label == "vigil" else None,
+    )
+
+    source = MagicMock()
+    source.fetch = AsyncMock(return_value={vigil_uuid: 0})  # metric=0 < threshold=1
+
+    heartbeat = MagicMock()
+    heartbeat.evaluate = AsyncMock(return_value=_hb(alive=False))  # no eval_error
+
+    writer = MagicMock()
+    writer.write = AsyncMock()
+
+    audit = MagicMock()
+    audit.emit = AsyncMock()
+
+    probe = _make_probe(
+        sources_by_name={"kg_writes": source},
+        heartbeat_evaluator=heartbeat,
+        writer=writer,
+        audit_emitter=audit,
+    )
+
+    await probe.tick()
+
+    resident_batch = writer.write.call_args_list[0][0][0]
+    assert len(resident_batch) == 1
+    row = resident_batch[0]
+
+    assert row.suppressed_reason == "heartbeat_not_alive"
+    assert row.candidate is False  # NOT True even though metric_below_threshold=True
+    assert row.metric_below_threshold is True
+    assert row.heartbeat_alive is False
+
+    # No audit event (suppressed)
+    audit.emit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test 8: dead resident with metric OK — no suppression, just record
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dead_resident_metric_ok_no_suppression(monkeypatch):
+    """hb.alive=False AND metric=5 >= threshold=1 → suppressed_reason=None, candidate=False."""
+    vigil_uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+    monkeypatch.setattr(
+        "src.resident_progress.probe_task.RESIDENT_PROGRESS_REGISTRY",
+        _registry_one_vigil(),
+    )
+    monkeypatch.setattr(
+        "src.resident_progress.probe_task.resolve_resident_uuid",
+        lambda label: vigil_uuid if label == "vigil" else None,
+    )
+
+    source = MagicMock()
+    source.fetch = AsyncMock(return_value={vigil_uuid: 5})  # metric=5 >= threshold=1
+
+    heartbeat = MagicMock()
+    heartbeat.evaluate = AsyncMock(return_value=_hb(alive=False))  # dead, no eval_error
+
+    writer = MagicMock()
+    writer.write = AsyncMock()
+
+    audit = MagicMock()
+    audit.emit = AsyncMock()
+
+    probe = _make_probe(
+        sources_by_name={"kg_writes": source},
+        heartbeat_evaluator=heartbeat,
+        writer=writer,
+        audit_emitter=audit,
+    )
+
+    await probe.tick()
+
+    resident_batch = writer.write.call_args_list[0][0][0]
+    assert len(resident_batch) == 1
+    row = resident_batch[0]
+
+    # Dead but metric not flat: no suppression, just record
+    assert row.suppressed_reason is None
+    assert row.candidate is False  # alive=False so not a candidate
+    assert row.heartbeat_alive is False
+    assert row.metric_below_threshold is False
+
+    # No audit event (not a candidate)
+    audit.emit.assert_not_called()

--- a/tests/resident_progress/test_probe_task.py
+++ b/tests/resident_progress/test_probe_task.py
@@ -1,0 +1,362 @@
+"""Tests for the ProgressFlatProbe orchestrator (Task 8).
+
+All tests use mocks — no real DB, no real heartbeat calls.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+
+from src.resident_progress.probe_task import STARTUP_GRACE_TICKS, ProgressFlatProbe
+from src.resident_progress.registry import ResidentConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _hb(alive, eval_error=None):
+    """Return a minimal HeartbeatStatus-like object."""
+    return type("HS", (), {
+        "alive": alive,
+        "last_update": None,
+        "expected_cadence_s": 60,
+        "in_critical_silence": not alive,
+        "eval_error": eval_error,
+        "to_jsonable": lambda self: {"alive": alive},
+    })()
+
+
+def _make_probe(
+    sources_by_name=None,
+    heartbeat_evaluator=None,
+    writer=None,
+    audit_emitter=None,
+    _now_tick=0,
+):
+    """Build a ProgressFlatProbe with sensible AsyncMock defaults."""
+    if sources_by_name is None:
+        sources_by_name = {}
+    if heartbeat_evaluator is None:
+        heartbeat_evaluator = MagicMock()
+        heartbeat_evaluator.evaluate = AsyncMock(return_value=_hb(True))
+    if writer is None:
+        writer = MagicMock()
+        writer.write = AsyncMock()
+    if audit_emitter is None:
+        audit_emitter = MagicMock()
+        audit_emitter.emit = AsyncMock()
+    return ProgressFlatProbe(
+        sources_by_name=sources_by_name,
+        heartbeat_evaluator=heartbeat_evaluator,
+        writer=writer,
+        audit_emitter=audit_emitter,
+        _now_tick=_now_tick,
+    )
+
+
+def _registry_one_vigil():
+    return {
+        "vigil": ResidentConfig(
+            source="kg_writes",
+            metric="rows_written",
+            window=timedelta(minutes=60),
+            threshold=1,
+        )
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test 1: happy path — one resident, source returns count, heartbeat alive
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_tick_writes_one_resident_row_plus_dogfood(monkeypatch):
+    """Writer called twice: resident batch (1 row labeled 'vigil') + dogfood row."""
+    vigil_uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+    monkeypatch.setattr(
+        "src.resident_progress.probe_task.RESIDENT_PROGRESS_REGISTRY",
+        _registry_one_vigil(),
+    )
+    monkeypatch.setattr(
+        "src.resident_progress.probe_task.resolve_resident_uuid",
+        lambda label: vigil_uuid if label == "vigil" else None,
+    )
+
+    source = MagicMock()
+    source.fetch = AsyncMock(return_value={vigil_uuid: 5})  # metric=5, threshold=1 → not below
+
+    heartbeat = MagicMock()
+    heartbeat.evaluate = AsyncMock(return_value=_hb(True))
+
+    writer = MagicMock()
+    writer.write = AsyncMock()
+
+    audit = MagicMock()
+    audit.emit = AsyncMock()
+
+    probe = _make_probe(
+        sources_by_name={"kg_writes": source},
+        heartbeat_evaluator=heartbeat,
+        writer=writer,
+        audit_emitter=audit,
+    )
+
+    await probe.tick()
+
+    assert writer.write.call_count == 2
+
+    # First call: resident batch
+    resident_batch = writer.write.call_args_list[0][0][0]
+    assert len(resident_batch) == 1
+    row = resident_batch[0]
+    assert row.resident_label == "vigil"
+    assert row.resident_uuid == vigil_uuid
+    assert row.candidate is False  # metric=5 >= threshold=1
+    assert row.suppressed_reason is None
+
+    # Second call: dogfood
+    dogfood_batch = writer.write.call_args_list[1][0][0]
+    assert len(dogfood_batch) == 1
+    df = dogfood_batch[0]
+    assert df.resident_label == "progress_flat_probe"
+    assert df.source == "probe_self"
+    assert df.candidate is False
+
+    # No audit event because resident is not a candidate
+    audit.emit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test 2: unresolved label after startup grace — suppressed_reason="unresolved_label"
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_unresolved_label_writes_suppressed_row_no_event(monkeypatch):
+    """UUID resolves to None, tick > STARTUP_GRACE_TICKS → unresolved_label."""
+    monkeypatch.setattr(
+        "src.resident_progress.probe_task.RESIDENT_PROGRESS_REGISTRY",
+        _registry_one_vigil(),
+    )
+    monkeypatch.setattr(
+        "src.resident_progress.probe_task.resolve_resident_uuid",
+        lambda label: None,
+    )
+
+    writer = MagicMock()
+    writer.write = AsyncMock()
+    audit = MagicMock()
+    audit.emit = AsyncMock()
+
+    # Start _now_tick=STARTUP_GRACE_TICKS so after increment tick_count = STARTUP_GRACE_TICKS+1
+    probe = _make_probe(
+        writer=writer,
+        audit_emitter=audit,
+        _now_tick=STARTUP_GRACE_TICKS,
+    )
+
+    await probe.tick()
+
+    # Writer called once (resident/unresolved batch) + once (dogfood)
+    assert writer.write.call_count == 2
+    resident_batch = writer.write.call_args_list[0][0][0]
+    assert len(resident_batch) == 1
+    row = resident_batch[0]
+    assert row.resident_label == "vigil"
+    assert row.resident_uuid is None
+    assert row.suppressed_reason == "unresolved_label"
+    assert row.candidate is False
+
+    # No audit emit
+    audit.emit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test 3: startup grace — first two ticks use "startup_unresolved_label"
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_startup_grace_first_two_ticks(monkeypatch):
+    """UUID resolves to None on tick=1 → suppressed_reason='startup_unresolved_label'."""
+    monkeypatch.setattr(
+        "src.resident_progress.probe_task.RESIDENT_PROGRESS_REGISTRY",
+        _registry_one_vigil(),
+    )
+    monkeypatch.setattr(
+        "src.resident_progress.probe_task.resolve_resident_uuid",
+        lambda label: None,
+    )
+
+    writer = MagicMock()
+    writer.write = AsyncMock()
+
+    # _now_tick=0 → after increment tick_count=1 ≤ STARTUP_GRACE_TICKS=2
+    probe = _make_probe(writer=writer, _now_tick=0)
+
+    await probe.tick()
+
+    resident_batch = writer.write.call_args_list[0][0][0]
+    assert len(resident_batch) == 1
+    row = resident_batch[0]
+    assert row.suppressed_reason == "startup_unresolved_label"
+
+    # Second tick (_now_tick=1 → 2 ≤ 2) also uses startup reason
+    writer.write.reset_mock()
+    await probe.tick()
+    resident_batch2 = writer.write.call_args_list[0][0][0]
+    assert resident_batch2[0].suppressed_reason == "startup_unresolved_label"
+
+    # Third tick (_now_tick=2 → 3 > 2) switches to unresolved_label
+    writer.write.reset_mock()
+    await probe.tick()
+    resident_batch3 = writer.write.call_args_list[0][0][0]
+    assert resident_batch3[0].suppressed_reason == "unresolved_label"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: source error isolation — one source raises, other succeeds
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_source_error_isolated_per_resident(monkeypatch):
+    """Two residents, two sources. One source raises; other succeeds.
+
+    Erroring resident: suppressed_reason='source_error', candidate=False.
+    Healthy resident (metric below threshold, alive): candidate=True.
+    """
+    vigil_uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    watcher_uuid = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+    registry = {
+        "vigil": ResidentConfig(
+            source="kg_writes",
+            metric="rows_written",
+            window=timedelta(minutes=60),
+            threshold=1,
+        ),
+        "watcher": ResidentConfig(
+            source="watcher_findings",
+            metric="rows_any",
+            window=timedelta(hours=6),
+            threshold=1,
+        ),
+    }
+    monkeypatch.setattr(
+        "src.resident_progress.probe_task.RESIDENT_PROGRESS_REGISTRY",
+        registry,
+    )
+
+    uuid_map = {"vigil": vigil_uuid, "watcher": watcher_uuid}
+    monkeypatch.setattr(
+        "src.resident_progress.probe_task.resolve_resident_uuid",
+        lambda label: uuid_map.get(label),
+    )
+
+    # kg_writes source raises; watcher_findings returns metric=0 (below threshold=1)
+    bad_source = MagicMock()
+    bad_source.fetch = AsyncMock(side_effect=RuntimeError("db exploded"))
+
+    good_source = MagicMock()
+    good_source.fetch = AsyncMock(return_value={watcher_uuid: 0})
+
+    heartbeat = MagicMock()
+    heartbeat.evaluate = AsyncMock(return_value=_hb(True))
+
+    writer = MagicMock()
+    writer.write = AsyncMock()
+    audit = MagicMock()
+    audit.emit = AsyncMock()
+
+    probe = _make_probe(
+        sources_by_name={"kg_writes": bad_source, "watcher_findings": good_source},
+        heartbeat_evaluator=heartbeat,
+        writer=writer,
+        audit_emitter=audit,
+    )
+
+    await probe.tick()
+
+    resident_batch = writer.write.call_args_list[0][0][0]
+    assert len(resident_batch) == 2
+
+    by_label = {r.resident_label: r for r in resident_batch}
+
+    vigil_row = by_label["vigil"]
+    assert vigil_row.suppressed_reason == "source_error"
+    assert vigil_row.candidate is False
+    assert vigil_row.error_details is not None
+    assert vigil_row.error_details["source"] == "kg_writes"
+    assert "RuntimeError" in vigil_row.error_details["error"]
+
+    watcher_row = by_label["watcher"]
+    assert watcher_row.candidate is True
+    assert watcher_row.suppressed_reason is None
+    assert watcher_row.metric_value == 0
+    assert watcher_row.metric_below_threshold is True
+
+    # Audit event emitted for watcher (candidate=True)
+    audit.emit.assert_called_once()
+    call_kwargs = audit.emit.call_args
+    assert call_kwargs.kwargs["event_type"] == "progress_flat_candidate"
+    assert call_kwargs.kwargs["payload"]["resident_label"] == "watcher"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: dogfood write failure is non-fatal; candidates still get audit events
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dogfood_write_failure_is_non_fatal(monkeypatch):
+    """Writer raises on dogfood batch. Tick completes; audit events still fire."""
+    vigil_uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+    monkeypatch.setattr(
+        "src.resident_progress.probe_task.RESIDENT_PROGRESS_REGISTRY",
+        _registry_one_vigil(),
+    )
+    monkeypatch.setattr(
+        "src.resident_progress.probe_task.resolve_resident_uuid",
+        lambda label: vigil_uuid if label == "vigil" else None,
+    )
+
+    source = MagicMock()
+    # metric=0, threshold=1 → below, candidate=True (if alive)
+    source.fetch = AsyncMock(return_value={vigil_uuid: 0})
+
+    heartbeat = MagicMock()
+    heartbeat.evaluate = AsyncMock(return_value=_hb(True))
+
+    write_call_count = 0
+
+    async def _write_side_effect(rows):
+        nonlocal write_call_count
+        write_call_count += 1
+        if write_call_count == 2:
+            raise RuntimeError("dogfood write failed")
+        # First call (resident batch) succeeds
+
+    writer = MagicMock()
+    writer.write = AsyncMock(side_effect=_write_side_effect)
+
+    audit = MagicMock()
+    audit.emit = AsyncMock()
+
+    probe = _make_probe(
+        sources_by_name={"kg_writes": source},
+        heartbeat_evaluator=heartbeat,
+        writer=writer,
+        audit_emitter=audit,
+    )
+
+    # Must not raise
+    await probe.tick()
+
+    # Writer was called twice (first succeeds, second raises)
+    assert writer.write.call_count == 2
+
+    # Audit event emitted despite dogfood failure (candidate vigil row)
+    audit.emit.assert_called_once()
+    assert audit.emit.call_args.kwargs["payload"]["resident_label"] == "vigil"

--- a/tests/resident_progress/test_registry.py
+++ b/tests/resident_progress/test_registry.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.resident_progress.registry import (
+    RESIDENT_PROGRESS_REGISTRY,
+    ResidentConfig,
+    resolve_resident_uuid,
+)
+
+
+def test_registry_has_five_residents():
+    assert set(RESIDENT_PROGRESS_REGISTRY) == {
+        "vigil", "watcher", "steward", "chronicler", "sentinel"
+    }
+
+
+def test_registry_entries_have_required_fields():
+    for label, cfg in RESIDENT_PROGRESS_REGISTRY.items():
+        assert isinstance(cfg, ResidentConfig)
+        assert cfg.source in {
+            "kg_writes", "watcher_findings", "eisv_sync_rows",
+            "metrics_series", "sentinel_pulse",
+        }
+        assert cfg.window.total_seconds() > 0
+        assert cfg.threshold >= 1
+
+
+def test_resolve_resident_uuid_reads_anchor(tmp_path, monkeypatch):
+    anchor_dir = tmp_path / "anchors"
+    anchor_dir.mkdir()
+    (anchor_dir / "vigil.json").write_text(json.dumps({
+        "agent_uuid": "11111111-2222-3333-4444-555555555555"
+    }))
+    monkeypatch.setattr(
+        "src.resident_progress.registry.ANCHOR_DIR", anchor_dir
+    )
+    assert resolve_resident_uuid("vigil") == "11111111-2222-3333-4444-555555555555"
+
+
+def test_resolve_resident_uuid_returns_none_when_anchor_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "src.resident_progress.registry.ANCHOR_DIR", tmp_path
+    )
+    assert resolve_resident_uuid("vigil") is None
+
+
+def test_resolve_resident_uuid_returns_none_on_malformed_anchor(tmp_path, monkeypatch):
+    (tmp_path / "vigil.json").write_text("not-json")
+    monkeypatch.setattr(
+        "src.resident_progress.registry.ANCHOR_DIR", tmp_path
+    )
+    assert resolve_resident_uuid("vigil") is None

--- a/tests/resident_progress/test_sentinel_source.py
+++ b/tests/resident_progress/test_sentinel_source.py
@@ -204,6 +204,43 @@ async def test_record_progress_pulse_rejects_mismatched_resident_uuid(test_db):
     assert payload.get("error") is not None or payload.get("success") is not True, (
         f"Expected auth error but got: {payload}"
     )
-    # Verify error_code is AUTH_MISMATCH
-    assert "AUTH_MISMATCH" in str(payload), f"Expected AUTH_MISMATCH in: {payload}"
+    # Verify error_code is AUTH_RESIDENT_MISMATCH
+    assert "AUTH_RESIDENT_MISMATCH" in str(payload), f"Expected AUTH_RESIDENT_MISMATCH in: {payload}"
     assert len(inserted) == 0, "No DB row should be written on auth mismatch"
+
+
+@pytest.mark.asyncio
+async def test_unbound_session_is_rejected(test_db):
+    """Session with no bound UUID and no _agent_uuid → UNBOUND_SESSION error, no row."""
+    inserted = []
+
+    async def _fake_insert(query, *args, **kwargs):
+        inserted.append(args)
+
+    mock_conn = AsyncMock()
+    mock_conn.execute = _fake_insert
+    mock_ctx = MagicMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+    mock_db = MagicMock()
+    mock_db.acquire = MagicMock(return_value=mock_ctx)
+
+    # Bypass require_registered_agent (auth system under test is UUID binding, not registration)
+    # and stub get_bound_agent_id at its source to return None so the handler hits UNBOUND_SESSION.
+    with patch("src.mcp_handlers.resident_progress.require_registered_agent",
+               return_value=("some-agent-id", None)), \
+         patch("src.mcp_handlers.identity.shared.get_bound_agent_id", return_value=None), \
+         patch("src.db.get_db", return_value=mock_db):
+        result = await handle_record_progress_pulse({
+            "metric_name": "evaluated",
+            "value": 5,
+            # no _agent_uuid, no bound context
+        })
+
+    import json
+    payload = json.loads(result[0].text)
+    assert payload.get("error") is not None or payload.get("success") is not True, (
+        f"Expected error but got: {payload}"
+    )
+    assert "UNBOUND_SESSION" in str(payload), f"Expected UNBOUND_SESSION in: {payload}"
+    assert len(inserted) == 0, "No DB row should be written for unbound session"

--- a/tests/resident_progress/test_sentinel_source.py
+++ b/tests/resident_progress/test_sentinel_source.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.resident_progress.sentinel_source import SentinelPulseSource
+from src.mcp_handlers.schemas.progress_flat import RecordProgressPulseParams
+from src.mcp_handlers.resident_progress import handle_record_progress_pulse
+
+
+# ---------------------------------------------------------------------------
+# SentinelPulseSource — DB integration tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_pulse_source_returns_latest_value_in_window(test_db):
+    uuid = "55555555-0000-0000-0000-000000000005"
+    async with test_db.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO resident_progress_pulse "
+            "(resident_uuid, metric_name, value, recorded_at) "
+            "VALUES ($1, 'evaluated', 7, now() - interval '5 minutes'), "
+            "       ($1, 'evaluated', 12, now() - interval '1 minute')",
+            uuid,
+        )
+    src = SentinelPulseSource(test_db)
+    out = await src.fetch([uuid], timedelta(minutes=30))
+    assert out[uuid] == 12  # latest, not sum
+
+
+@pytest.mark.asyncio
+async def test_pulse_source_returns_zero_when_no_rows_in_window(test_db):
+    src = SentinelPulseSource(test_db)
+    out = await src.fetch(["66666666-0000-0000-0000-000000000006"], timedelta(minutes=30))
+    assert out["66666666-0000-0000-0000-000000000006"] == 0
+
+
+@pytest.mark.asyncio
+async def test_pulse_source_excludes_rows_outside_window(test_db):
+    uuid = "77777777-0000-0000-0000-000000000007"
+    async with test_db.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO resident_progress_pulse "
+            "(resident_uuid, metric_name, value, recorded_at) "
+            "VALUES ($1, 'evaluated', 99, now() - interval '2 hours')",
+            uuid,
+        )
+    src = SentinelPulseSource(test_db)
+    out = await src.fetch([uuid], timedelta(minutes=30))
+    assert out[uuid] == 0  # row is outside 30-minute window
+
+
+@pytest.mark.asyncio
+async def test_pulse_source_empty_input_returns_empty_dict_no_query(test_db):
+    """Empty resident_uuids must return {} without hitting the DB."""
+    src = SentinelPulseSource(test_db)
+    out = await src.fetch([], timedelta(minutes=30))
+    assert out == {}
+
+
+# ---------------------------------------------------------------------------
+# RecordProgressPulseParams — schema unit tests
+# ---------------------------------------------------------------------------
+
+def test_schema_accepts_valid_params():
+    p = RecordProgressPulseParams.model_validate(
+        {"metric_name": "evaluated", "value": 5}
+    )
+    assert p.metric_name == "evaluated"
+    assert p.value == 5
+    assert p.resident_uuid is None
+
+
+def test_schema_rejects_negative_value():
+    from pydantic import ValidationError
+    with pytest.raises(ValidationError):
+        RecordProgressPulseParams.model_validate({"metric_name": "x", "value": -1})
+
+
+def test_schema_rejects_empty_metric_name():
+    from pydantic import ValidationError
+    with pytest.raises(ValidationError):
+        RecordProgressPulseParams.model_validate({"metric_name": "", "value": 0})
+
+
+def test_schema_rejects_metric_name_with_space():
+    from pydantic import ValidationError
+    with pytest.raises(ValidationError):
+        RecordProgressPulseParams.model_validate({"metric_name": "bad name", "value": 0})
+
+
+def test_schema_accepts_dots_dashes_underscores():
+    p = RecordProgressPulseParams.model_validate(
+        {"metric_name": "a.b-c_d", "value": 0}
+    )
+    assert p.metric_name == "a.b-c_d"
+
+
+def test_schema_accepts_optional_resident_uuid():
+    p = RecordProgressPulseParams.model_validate(
+        {"metric_name": "x", "value": 1, "resident_uuid": "aaaa-uuid"}
+    )
+    assert p.resident_uuid == "aaaa-uuid"
+
+
+def test_schema_rejects_metric_name_over_128_chars():
+    from pydantic import ValidationError
+    with pytest.raises(ValidationError):
+        RecordProgressPulseParams.model_validate(
+            {"metric_name": "a" * 129, "value": 0}
+        )
+
+
+# ---------------------------------------------------------------------------
+# handle_record_progress_pulse — auth binding tests
+# ---------------------------------------------------------------------------
+
+BOUND_UUID_A = "aaaaaaaa-0000-0000-0000-000000000001"
+BOUND_UUID_B = "bbbbbbbb-0000-0000-0000-000000000002"
+
+
+def _make_mock_agent_meta(uuid: str):
+    meta = MagicMock()
+    meta.status = "active"
+    return meta
+
+
+def _make_mcp_server_mock(bound_uuid: str):
+    server = MagicMock()
+    server.agent_metadata = {bound_uuid: _make_mock_agent_meta(bound_uuid)}
+    server.ensure_metadata_loaded = MagicMock()
+    return server
+
+
+@pytest.mark.asyncio
+async def test_record_progress_pulse_inserts_row_for_bound_agent(test_db):
+    """Bound agent posts pulse → row written with bound UUID."""
+    inserted = []
+
+    async def _fake_insert(query, *args, **kwargs):
+        inserted.append(args)
+
+    mock_conn = AsyncMock()
+    mock_conn.execute = _fake_insert
+    mock_ctx = MagicMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+    mock_db = MagicMock()
+    mock_db.acquire = MagicMock(return_value=mock_ctx)
+
+    server_mock = _make_mcp_server_mock(BOUND_UUID_A)
+
+    with patch("src.mcp_handlers.context.get_context_agent_id", return_value=BOUND_UUID_A), \
+         patch("src.mcp_handlers.shared.get_mcp_server", return_value=server_mock), \
+         patch("config.governance_config.identity_strict_mode", return_value="warn"), \
+         patch("src.db.get_db", return_value=mock_db):
+        result = await handle_record_progress_pulse({
+            "metric_name": "evaluated",
+            "value": 3,
+        })
+
+    import json
+    payload = json.loads(result[0].text)
+    assert payload.get("success") is True, f"Expected success but got: {payload}"
+    assert len(inserted) == 1
+    # args: (effective_uuid, metric_name, value)
+    assert inserted[0][0] == BOUND_UUID_A
+    assert inserted[0][1] == "evaluated"
+    assert inserted[0][2] == 3
+
+
+@pytest.mark.asyncio
+async def test_record_progress_pulse_rejects_mismatched_resident_uuid(test_db):
+    """Caller supplies resident_uuid != bound UUID → auth error, no row written."""
+    inserted = []
+
+    async def _fake_insert(query, *args, **kwargs):
+        inserted.append(args)
+
+    mock_conn = AsyncMock()
+    mock_conn.execute = _fake_insert
+    mock_ctx = MagicMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+    mock_db = MagicMock()
+    mock_db.acquire = MagicMock(return_value=mock_ctx)
+
+    server_mock = _make_mcp_server_mock(BOUND_UUID_A)
+
+    with patch("src.mcp_handlers.context.get_context_agent_id", return_value=BOUND_UUID_A), \
+         patch("src.mcp_handlers.shared.get_mcp_server", return_value=server_mock), \
+         patch("config.governance_config.identity_strict_mode", return_value="warn"), \
+         patch("src.db.get_db", return_value=mock_db):
+        result = await handle_record_progress_pulse({
+            "metric_name": "evaluated",
+            "value": 7,
+            "resident_uuid": BOUND_UUID_B,  # mismatch!
+        })
+
+    import json
+    payload = json.loads(result[0].text)
+    assert payload.get("error") is not None or payload.get("success") is not True, (
+        f"Expected auth error but got: {payload}"
+    )
+    # Verify error_code is AUTH_MISMATCH
+    assert "AUTH_MISMATCH" in str(payload), f"Expected AUTH_MISMATCH in: {payload}"
+    assert len(inserted) == 0, "No DB row should be written on auth mismatch"

--- a/tests/resident_progress/test_snapshot_writer.py
+++ b/tests/resident_progress/test_snapshot_writer.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from src.resident_progress.snapshot_writer import SnapshotRow, SnapshotWriter
+
+
+@pytest.mark.asyncio
+async def test_writer_persists_all_rows_in_one_batch(test_db):
+    tick_id = uuid.uuid4()
+    now = datetime.now(timezone.utc)
+    rows = [
+        SnapshotRow(
+            probe_tick_id=tick_id, ticked_at=now, resident_label="vigil",
+            resident_uuid="11111111-1111-1111-1111-111111111111",
+            source="kg_writes", metric_value=3, window_seconds=3600,
+            threshold=1, metric_below_threshold=False, heartbeat_alive=True,
+            candidate=False, suppressed_reason=None,
+            error_details=None, liveness_inputs={"alive": True},
+            loop_detector_state=None,
+        ),
+        SnapshotRow(
+            probe_tick_id=tick_id, ticked_at=now, resident_label="watcher",
+            resident_uuid="22222222-2222-2222-2222-222222222222",
+            source="watcher_findings", metric_value=0, window_seconds=21600,
+            threshold=1, metric_below_threshold=True, heartbeat_alive=True,
+            candidate=True, suppressed_reason=None, error_details=None,
+            liveness_inputs={"alive": True}, loop_detector_state=None,
+        ),
+    ]
+    writer = SnapshotWriter(test_db)
+    await writer.write(rows)
+
+    async with test_db.acquire() as conn:
+        persisted = await conn.fetch(
+            "SELECT resident_label, candidate FROM progress_flat_snapshots "
+            "WHERE probe_tick_id = $1 ORDER BY resident_label",
+            tick_id,
+        )
+    assert len(persisted) == 2
+    assert persisted[0]["resident_label"] == "vigil"
+    assert persisted[0]["candidate"] is False
+    assert persisted[1]["resident_label"] == "watcher"
+    assert persisted[1]["candidate"] is True
+
+
+@pytest.mark.asyncio
+async def test_writer_persists_jsonb_dicts(test_db):
+    tick_id = uuid.uuid4()
+    now = datetime.now(timezone.utc)
+    rows = [SnapshotRow(
+        probe_tick_id=tick_id, ticked_at=now, resident_label="vigil",
+        resident_uuid="11111111-1111-1111-1111-111111111111",
+        source="kg_writes", metric_value=None, window_seconds=3600,
+        threshold=1, metric_below_threshold=None, heartbeat_alive=False,
+        candidate=False, suppressed_reason="source_error",
+        error_details={"source": "kg_writes", "error": "boom"},
+        liveness_inputs={"alive": False, "in_critical_silence": True},
+        loop_detector_state={"loop_detected_at": "2026-04-25T20:00:00+00:00"},
+    )]
+    await SnapshotWriter(test_db).write(rows)
+    async with test_db.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT error_details, liveness_inputs, loop_detector_state "
+            "FROM progress_flat_snapshots WHERE probe_tick_id = $1",
+            tick_id,
+        )
+    assert row["error_details"]["error"] == "boom"
+    assert row["liveness_inputs"]["in_critical_silence"] is True
+    assert row["loop_detector_state"]["loop_detected_at"].startswith("2026-04-25")
+
+
+@pytest.mark.asyncio
+async def test_writer_empty_input_is_noop(test_db):
+    # Should not acquire a connection. We assert by counting rows before/after.
+    async with test_db.acquire() as conn:
+        before = await conn.fetchval("SELECT count(*) FROM progress_flat_snapshots")
+    await SnapshotWriter(test_db).write([])
+    async with test_db.acquire() as conn:
+        after = await conn.fetchval("SELECT count(*) FROM progress_flat_snapshots")
+    assert before == after

--- a/tests/resident_progress/test_sources.py
+++ b/tests/resident_progress/test_sources.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from src.resident_progress.sources import (
+    ResidentProgressSource,
+    KnowledgeDiscoverySource,
+    EISVSyncSource,
+    MetricsSeriesSource,
+    CHRONICLER_SERIES_NAMES,
+)
+
+
+@pytest.mark.asyncio
+async def test_kg_source_returns_zero_for_unknown_uuid(test_db):
+    src = KnowledgeDiscoverySource(test_db)
+    out = await src.fetch(["00000000-0000-0000-0000-000000000000"], timedelta(hours=1))
+    assert out == {"00000000-0000-0000-0000-000000000000": 0}
+
+
+@pytest.mark.asyncio
+async def test_kg_source_counts_recent_rows(test_db):
+    uuid = "10000000-0000-0000-0000-000000000001"
+    async with test_db.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO knowledge.discoveries (id, agent_id, type, summary) "
+            "VALUES ($1, $2, 'note', 'x') ON CONFLICT (id) DO NOTHING",
+            "test-row-task4-1", uuid,
+        )
+    src = KnowledgeDiscoverySource(test_db)
+    out = await src.fetch([uuid], timedelta(hours=1))
+    assert out[uuid] >= 1
+
+
+@pytest.mark.asyncio
+async def test_eisv_sync_source_filters_by_event_type(test_db):
+    src = EISVSyncSource(test_db)
+    out = await src.fetch(["33333333-0000-0000-0000-000000000003"], timedelta(minutes=30))
+    # No matching rows in test DB → returns zero, not raises
+    assert out == {"33333333-0000-0000-0000-000000000003": 0}
+
+
+def test_chronicler_series_names_includes_tokei():
+    assert "tokei.unitares.src.code" in CHRONICLER_SERIES_NAMES
+
+
+@pytest.mark.asyncio
+async def test_metrics_series_source_returns_uniform_count(test_db):
+    src = MetricsSeriesSource(test_db)
+    uuids = [f"44444444-0000-0000-0000-{i:012d}" for i in range(3)]
+    out = await src.fetch(uuids, timedelta(hours=26))
+    # Chronicler source has no agent_id column; result is the same per-uuid count
+    # because all uuids share the same name-filtered total.
+    assert len({v for v in out.values()}) == 1
+    assert set(out.keys()) == set(uuids)
+
+
+@pytest.mark.asyncio
+async def test_kg_source_empty_uuid_list_no_query(test_db):
+    src = KnowledgeDiscoverySource(test_db)
+    out = await src.fetch([], timedelta(hours=1))
+    assert out == {}

--- a/tests/resident_progress/test_sources.py
+++ b/tests/resident_progress/test_sources.py
@@ -35,6 +35,51 @@ async def test_kg_source_counts_recent_rows(test_db):
 
 
 @pytest.mark.asyncio
+async def test_kg_source_batches_one_query_for_many_uuids(test_db):
+    seen_calls = []
+    real_acquire = test_db.acquire
+
+    class _Tracking:
+        def __init__(self, c):
+            self._c = c
+
+        async def fetch(self, *args, **kwargs):
+            seen_calls.append(args[0] if args else "")
+            return await self._c.fetch(*args, **kwargs)
+
+        def __getattr__(self, name):
+            return getattr(self._c, name)
+
+    class _AcquireProxy:
+        def __init__(self):
+            pass
+
+        async def __aenter__(self):
+            self._cm = real_acquire()
+            conn = await self._cm.__aenter__()
+            return _Tracking(conn)
+
+        async def __aexit__(self, *a):
+            return await self._cm.__aexit__(*a)
+
+    class _PoolProxy:
+        """Thin wrapper around the real pool that intercepts acquire() calls."""
+
+        def acquire(self):
+            return _AcquireProxy()
+
+        def __getattr__(self, name):
+            return getattr(test_db, name)
+
+    src = KnowledgeDiscoverySource(_PoolProxy())
+    await src.fetch(
+        [f"22222222-0000-0000-0000-{i:012d}" for i in range(5)],
+        timedelta(hours=1),
+    )
+    assert len(seen_calls) == 1, "must issue exactly one batched query"
+
+
+@pytest.mark.asyncio
 async def test_eisv_sync_source_filters_by_event_type(test_db):
     src = EISVSyncSource(test_db)
     out = await src.fetch(["33333333-0000-0000-0000-000000000003"], timedelta(minutes=30))

--- a/tests/resident_progress/test_status.py
+++ b/tests/resident_progress/test_status.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+from src.resident_progress.status import resolve_status
+
+
+def _row(**overrides):
+    base = {
+        "candidate": False, "heartbeat_alive": True,
+        "metric_below_threshold": False, "suppressed_reason": None,
+        "error_details": None,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.parametrize("row,expected", [
+    (_row(error_details={"source": "kg_writes"}), "source-error"),
+    (_row(suppressed_reason="unresolved_label"), "unresolved"),
+    (_row(suppressed_reason="startup_unresolved_label"), "startup-grace"),
+    (_row(suppressed_reason="heartbeat_not_alive", heartbeat_alive=False), "silent"),
+    (_row(suppressed_reason="heartbeat_eval_error", heartbeat_alive=False), "silent"),
+    (_row(candidate=True, metric_below_threshold=True), "flat-candidate"),
+    (_row(), "OK"),
+    # Tie-break: source-error wins over unresolved
+    (_row(error_details={"source": "x"}, suppressed_reason="unresolved_label"),
+     "source-error"),
+    # Tie-break: silent wins over flat-candidate when both could apply
+    (_row(suppressed_reason="heartbeat_not_alive", heartbeat_alive=False,
+          candidate=False, metric_below_threshold=True), "silent"),
+])
+def test_status_priority(row, expected):
+    assert resolve_status(row) == expected

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -100,6 +100,7 @@ async def ensure_test_database_schema() -> None:
         await _execute_sql_file(conn, "db/postgres/migrations/010_trigger_source.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/011_behavioral_baselines.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/012_identity_last_activity_at.sql")
+        await _execute_sql_file(conn, "db/postgres/migrations/013_metrics_series.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/014_seed_epoch_2.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/018_progress_flat_telemetry.sql")
 

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -101,6 +101,7 @@ async def ensure_test_database_schema() -> None:
         await _execute_sql_file(conn, "db/postgres/migrations/011_behavioral_baselines.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/012_identity_last_activity_at.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/014_seed_epoch_2.sql")
+        await _execute_sql_file(conn, "db/postgres/migrations/018_progress_flat_telemetry.sql")
 
         # Ensure partitioned audit tables can accept inserts for current month.
         await _execute_sql_file(conn, "db/postgres/partitions.sql")


### PR DESCRIPTION
## Summary

Phase-1 telemetry probe that detects residents that are heartbeat-alive but not advancing measurable work — the gap the dashboard \"unstick\" button can't reach today. Pure side-channel: never mutates agent status, never touches loop-detector flags, never enters the verdict path. Three weeks of snapshot data informs a Phase-2 unified stuck classifier (out of scope here).

**Spec:** \`docs/superpowers/specs/2026-04-25-resident-progress-detection-design.md\`
**Plan:** \`docs/superpowers/plans/2026-04-25-resident-progress-detection.md\`

## What ships

- New \`progress_flat_probe_task\` background task in \`src/background_tasks.py\` (5-min default tick interval, env-overridable).
- Five sources, one per resident: KG writes (Vigil), watcher findings (Watcher), eisv_sync rows (Steward), metrics.series (Chronicler), pulse table (Sentinel — push-based).
- Pydantic-validated \`record_progress_pulse\` MCP tool (auth-bound \`resident_uuid\`, rejects unbound sessions).
- New \`progress_flat_snapshots\` and \`resident_progress_pulse\` tables (migration 018).
- \`GET /v1/progress_flat/recent\` REST endpoint.
- Dashboard panel with overlap toggle (read-only, no actions).
- Calibration smoke (50% candidate-rate ceiling per resident, filters to real probe ticks) + dogfood-row regression guard.

## Architecture invariants

- Label-keyed registry; UUIDs resolved at tick time from \`~/.unitares/anchors/<label>.json\` (re-onboarding works without config edits).
- Source errors isolated per resident — one failing source does not poison the tick.
- Heartbeat-alive gating: candidates only fire when metric below threshold AND heartbeat alive. Dead-but-flat is recorded as \`silent\`, not \`flat-candidate\`.
- Dogfood row written last, non-fatally — missing probe-self row IS the diagnostic signal.
- Module-import-time assertion that registry source names are unique (catches latent collision in the source-output dict).
- Startup grace: first 2 ticks emit \`startup_unresolved_label\` instead of \`unresolved_label\` so anchor-warmup doesn't look noisy.

## Test plan

- [x] Full suite: 7312 passed, 33 skipped (130s, fresh cache run).
- [x] Migration idempotency confirmed (re-apply to \`governance_test\` is a NOTICE-only no-op).
- [x] 53 new tests across 9 files in \`tests/resident_progress/\`.
- [ ] After merge: pull master, restart governance-mcp, verify \`[PROGRESS_FLAT] probe started\` log line and dashboard panel renders six rows with status badges.
- [ ] After 24h: re-run calibration smoke against production data and tune any threshold that fires >5% candidate rate.

## Out of scope (deferred)

- Per-row sparkline drill-down on the dashboard panel (Phase 1 ships row + status; sparkline is v1.1).
- \`AUTH_RESIDENT_MISMATCH\` and \`UNBOUND_SESSION\` error codes are exposed but no caller uses them yet — Sentinel is the only producer in Phase 1.
- Phase 2 unified-stuck-state classifier — requires ~3 weeks of snapshot data first.