### PR TITLE
fix: heal cold monitors fleet-wide via flag-and-drain hydration

### DIFF
--- a/src/agent_lifecycle.py
+++ b/src/agent_lifecycle.py
@@ -19,8 +19,16 @@ logger = get_logger(__name__)
 
 
 def get_or_create_monitor(agent_id: str) -> UNITARESMonitor:
-    """Get existing monitor or create new one with metadata, loading state if it exists"""
-    get_or_create_metadata(agent_id)
+    """Get existing monitor or create new one with metadata, loading state if it exists.
+
+    Sync by design — async-cascading would force ~28 callers (background tasks,
+    CLI, sync handler internals) to become async. When the file snapshot is
+    missing but metadata indicates prior activity (`total_updates > 0`), the
+    monitor is marked `_needs_hydration=True`; async handlers drain that mark
+    via `ensure_hydrated(monitor, agent_id)` at their entry point. Sync callers
+    skip hydration and see the same seed-default behavior they always have.
+    """
+    meta = get_or_create_metadata(agent_id)
 
     if agent_id not in monitors:
         monitor = UNITARESMonitor(agent_id)
@@ -28,11 +36,20 @@ def get_or_create_monitor(agent_id: str) -> UNITARESMonitor:
         persisted_state = load_monitor_state(agent_id)
         if persisted_state is not None:
             monitor.state = persisted_state
+            monitor._needs_hydration = False
             logger.info(f"Loaded persisted state for {agent_id} ({len(persisted_state.V_history)} history entries)")
         else:
+            # File snapshot missing. Mark for DB hydration only if metadata says
+            # we've seen prior activity — fresh-onboard agents stay update_count=0
+            # so downstream "no measured trajectory" guards still trigger.
             # Lineage is recorded via meta.parent_agent_id but never transplants
             # state; see docs/specs/2026-04-16-sever-fingerprint-eisv-inheritance-design.md
-            logger.info(f"Initialized new monitor for {agent_id}")
+            prior_activity = int(getattr(meta, "total_updates", 0) or 0) > 0
+            monitor._needs_hydration = prior_activity
+            if prior_activity:
+                logger.info(f"Initialized monitor for {agent_id} (file missing, marked for DB hydration)")
+            else:
+                logger.info(f"Initialized new monitor for {agent_id}")
 
         monitors[agent_id] = monitor
 

--- a/src/agent_monitor_state.py
+++ b/src/agent_monitor_state.py
@@ -310,3 +310,37 @@ async def hydrate_from_db_if_fresh(monitor: UNITARESMonitor, agent_id: str) -> b
     except Exception as e:
         logger.warning(f"DB hydration failed for {agent_id}: {e}", exc_info=True)
         return False
+
+
+async def ensure_hydrated(monitor: UNITARESMonitor, agent_id: str) -> bool:
+    """Drain the `_needs_hydration` mark set by `get_or_create_monitor`.
+
+    Idempotent: returns immediately when the flag is unset (the common hot-path
+    case). When the flag is set, runs `hydrate_from_db_if_fresh` and clears the
+    flag regardless of outcome — single-shot semantics.
+
+    Call this at the top of any async handler that reads `monitor.state`.
+    Without this drain, monitors created cold from a missing snapshot would
+    return seed-default EISV (the "uninitialized" symptom) on every read.
+
+    The flag-and-drain split exists because `get_or_create_monitor` is sync
+    (used from background tasks and CLI), but DB hydration is async. Sync
+    callers that never reach an async drain see the same seed-default behavior
+    they had before this fix — no regression.
+
+    Returns True iff hydration actually applied new state.
+    """
+    # Strict identity check — `is True` (not truthy). The factory sets the flag
+    # explicitly to True or False; any other value (None, MagicMock from tests,
+    # absent attr) means "not marked" and we no-op. Without this, MagicMock
+    # monitors in test fixtures fall through to hydrate and crash on
+    # `MagicMock > 0` inside hydrate_from_db_if_fresh.
+    if getattr(monitor, "_needs_hydration", False) is not True:
+        return False
+    try:
+        return await hydrate_from_db_if_fresh(monitor, agent_id)
+    finally:
+        # Single-shot: drain the mark even on hydrate failure (DB unreachable
+        # etc.) so we don't retry on every subsequent read. Behavior degrades
+        # to seed defaults — same as the pre-fix state.
+        monitor._needs_hydration = False

--- a/src/mcp_handlers/cirs/coherence.py
+++ b/src/mcp_handlers/cirs/coherence.py
@@ -150,6 +150,8 @@ async def _handle_coherence_report_compute(arguments: Dict[str, Any]) -> Sequenc
 
     # Get source agent state
     source_monitor = mcp_server.get_or_create_monitor(source_agent_id)
+    from src.agent_monitor_state import ensure_hydrated
+    await ensure_hydrated(source_monitor, source_agent_id)
 
     # Get target agent state
     target_monitor = mcp_server.monitors.get(target_agent_id)

--- a/src/mcp_handlers/cirs/governance_action.py
+++ b/src/mcp_handlers/cirs/governance_action.py
@@ -92,6 +92,8 @@ async def _handle_governance_action_initiate(arguments: Dict[str, Any]) -> Seque
 
     if action_type == GovernanceActionType.VOID_INTERVENTION:
         monitor = mcp_server.get_or_create_monitor(agent_id)
+        from src.agent_monitor_state import ensure_hydrated
+        await ensure_hydrated(monitor, agent_id)
         metrics = monitor.get_metrics()
         payload["initiator_state"] = {
             "coherence": float(metrics.get("coherence", 0.5)),

--- a/src/mcp_handlers/cirs/state.py
+++ b/src/mcp_handlers/cirs/state.py
@@ -131,6 +131,8 @@ async def _handle_state_announce_emit(arguments: Dict[str, Any]) -> Sequence[Tex
 
     # Get current state
     monitor = mcp_server.get_or_create_monitor(agent_id)
+    from src.agent_monitor_state import ensure_hydrated
+    await ensure_hydrated(monitor, agent_id)
     metrics = monitor.get_metrics()
 
     # Build EISV dict

--- a/src/mcp_handlers/cirs/void.py
+++ b/src/mcp_handlers/cirs/void.py
@@ -48,6 +48,8 @@ async def _handle_void_alert_emit(arguments: Dict[str, Any]) -> Sequence[TextCon
 
     # Get current state for auto-detection
     monitor = mcp_server.get_or_create_monitor(agent_id)
+    from src.agent_monitor_state import ensure_hydrated
+    await ensure_hydrated(monitor, agent_id)
     current_V = float(monitor.state.V)
     current_coherence = float(monitor.state.coherence)
 

--- a/src/mcp_handlers/core.py
+++ b/src/mcp_handlers/core.py
@@ -153,6 +153,8 @@ async def handle_simulate_update(arguments: ToolArgumentsDict) -> Sequence[TextC
         if meta:
             # Agent exists - use their monitor with existing state
             monitor = mcp_server.get_or_create_monitor(agent_id)
+            from src.agent_monitor_state import ensure_hydrated
+            await ensure_hydrated(monitor, agent_id)
             agent_state_source = "existing"
 
     if monitor is None:

--- a/src/mcp_handlers/introspection/export.py
+++ b/src/mcp_handlers/introspection/export.py
@@ -37,7 +37,9 @@ async def handle_get_system_history(arguments: Dict[str, Any]) -> Sequence[TextC
     
     # Load monitor state from disk if not in memory (consistent with get_governance_metrics)
     monitor = mcp_server.get_or_create_monitor(agent_id)
-    
+    from src.agent_monitor_state import ensure_hydrated
+    await ensure_hydrated(monitor, agent_id)
+
     # Check if monitor has any history
     if not monitor.state.E_history and not monitor.state.timestamp_history:
         return [error_response(
@@ -79,7 +81,9 @@ async def handle_export_to_file(arguments: Dict[str, Any]) -> Sequence[TextConte
     
     # Load monitor state from disk if not in memory (consistent with get_governance_metrics)
     monitor = mcp_server.get_or_create_monitor(agent_id)
-    
+    from src.agent_monitor_state import ensure_hydrated
+    await ensure_hydrated(monitor, agent_id)
+
     if complete_package:
         # Export complete package: metadata + history + validation
         # NOTE: Knowledge layer removed November 28, 2025

--- a/src/mcp_handlers/lifecycle/operations.py
+++ b/src/mcp_handlers/lifecycle/operations.py
@@ -322,6 +322,8 @@ async def handle_self_recovery_review(arguments: Dict[str, Any]) -> Sequence[Tex
     meta.recovery_attempt_at = recovery_ts
 
     monitor = mcp_server.get_or_create_monitor(agent_uuid)
+    from src.agent_monitor_state import ensure_hydrated
+    await ensure_hydrated(monitor, agent_uuid)
     metrics = monitor.get_metrics()
 
     coherence = safe_float(monitor.state.coherence, 0.5)
@@ -511,6 +513,8 @@ async def handle_ping_agent(arguments: Dict[str, Any]) -> Sequence[TextContent]:
         responsive = False
         try:
             monitor = mcp_server.get_or_create_monitor(agent_id)
+            from src.agent_monitor_state import ensure_hydrated
+            await ensure_hydrated(monitor, agent_id)
             metrics = monitor.get_metrics()
             responsive = True  # If we can get metrics, agent is responsive
         except Exception as e:

--- a/src/mcp_handlers/lifecycle/query.py
+++ b/src/mcp_handlers/lifecycle/query.py
@@ -23,6 +23,7 @@ from ..decorators import mcp_tool
 from ..support.coerce import safe_float, resolve_agent_uuid
 from src.logging_utils import get_logger
 from src.cache import get_metadata_cache
+from src.agent_monitor_state import ensure_hydrated
 
 from .helpers import _is_test_agent
 
@@ -332,6 +333,7 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                     cached_health = getattr(meta, 'health_status', None)
                     try:
                         monitor = mcp_server.get_or_create_monitor(agent_id)
+                        await ensure_hydrated(monitor, agent_id)
                         metrics_dict = monitor.get_metrics()
 
                         # Get health status
@@ -384,6 +386,7 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                     # No cached health status or it's "unknown" - calculate it
                     try:
                         monitor = mcp_server.get_or_create_monitor(agent_id)
+                        await ensure_hydrated(monitor, agent_id)
                         metrics_dict = monitor.get_metrics()
                         attention_score = metrics_dict.get('attention_score') or metrics_dict.get('risk_score', None)
                         coherence = metrics_dict.get('coherence', None)

--- a/src/mcp_handlers/lifecycle/resume.py
+++ b/src/mcp_handlers/lifecycle/resume.py
@@ -66,6 +66,8 @@ async def handle_direct_resume_if_safe(arguments: Dict[str, Any]) -> Sequence[Te
     # Get current governance metrics
     try:
         monitor = mcp_server.get_or_create_monitor(agent_uuid)
+        from src.agent_monitor_state import ensure_hydrated
+        await ensure_hydrated(monitor, agent_uuid)
         metrics = monitor.get_metrics()
 
         coherence = float(monitor.state.coherence)

--- a/src/mcp_handlers/lifecycle/self_recovery.py
+++ b/src/mcp_handlers/lifecycle/self_recovery.py
@@ -248,13 +248,15 @@ async def handle_check_recovery_options(arguments: Dict[str, Any]) -> Sequence[T
     # Get current metrics (use safe_float for uninitialized agents with None coherence/risk)
     try:
         monitor = mcp_server.get_or_create_monitor(agent_uuid)
+        from src.agent_monitor_state import ensure_hydrated
+        await ensure_hydrated(monitor, agent_uuid)
         metrics = monitor.get_metrics()
-        
+
         coherence = safe_float(monitor.state.coherence, 0.5)
         risk_score = safe_float(metrics.get("mean_risk"), 0.5)
         void_active = bool(monitor.state.void_active)
         void_value = safe_float(monitor.state.V, 0.0)
-        
+
     except Exception as e:
         return [error_response(f"Could not get metrics: {e}")]
     
@@ -370,8 +372,10 @@ async def handle_quick_resume(arguments: Dict[str, Any]) -> Sequence[TextContent
     # Get current metrics (use safe_float for uninitialized agents)
     try:
         monitor = mcp_server.get_or_create_monitor(agent_uuid)
+        from src.agent_monitor_state import ensure_hydrated
+        await ensure_hydrated(monitor, agent_uuid)
         metrics = monitor.get_metrics()
-        
+
         coherence = safe_float(monitor.state.coherence, 0.5)
         risk_score = safe_float(metrics.get("mean_risk"), 0.5)
         void_active = bool(monitor.state.void_active)
@@ -560,8 +564,10 @@ async def handle_operator_resume_agent(arguments: Dict[str, Any]) -> Sequence[Te
     # Get target metrics (use safe_float for uninitialized agents)
     try:
         monitor = mcp_server.get_or_create_monitor(target_agent_id)
+        from src.agent_monitor_state import ensure_hydrated
+        await ensure_hydrated(monitor, target_agent_id)
         metrics = monitor.get_metrics()
-        
+
         coherence = safe_float(monitor.state.coherence, 0.5)
         risk_score = safe_float(metrics.get("mean_risk"), 0.5)
         void_active = bool(monitor.state.void_active)

--- a/src/mcp_handlers/lifecycle/stuck.py
+++ b/src/mcp_handlers/lifecycle/stuck.py
@@ -380,6 +380,8 @@ async def _try_recover_agent(stuck: dict, note_cooldown_minutes: float) -> list:
         # Check if agent is responsive
         try:
             monitor = mcp_server.get_or_create_monitor(agent_id)
+            from src.agent_monitor_state import ensure_hydrated
+            await ensure_hydrated(monitor, agent_id)
             metrics = monitor.get_metrics()
             coherence = float(monitor.state.coherence)
             risk_score = float(metrics.get("mean_risk") or 0.5)

--- a/src/mcp_handlers/observability/handlers.py
+++ b/src/mcp_handlers/observability/handlers.py
@@ -10,6 +10,7 @@ from ..utils import success_response, error_response, require_argument, require_
 from ..decorators import mcp_tool
 from src.logging_utils import get_logger
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
+from src.agent_monitor_state import ensure_hydrated
 logger = get_logger(__name__)
 
 # Import from mcp_server_std module (using shared utility)
@@ -89,7 +90,8 @@ async def handle_observe_agent(arguments: Dict[str, Any]) -> Sequence[TextConten
     
     # Load monitor state from disk if not in memory (consistent with get_governance_metrics)
     monitor = mcp_server.get_or_create_monitor(agent_id)
-    
+    await ensure_hydrated(monitor, agent_id)
+
     # Perform pattern analysis
     if analyze_patterns_flag:
         observation = mcp_server.analyze_agent_patterns(monitor, include_history=include_history)
@@ -298,6 +300,7 @@ async def handle_compare_me_to_similar(arguments: Dict[str, Any]) -> Sequence[Te
     
     # Get current agent's metrics
     monitor = mcp_server.get_or_create_monitor(agent_id)
+    await ensure_hydrated(monitor, agent_id)
     my_metrics = monitor.get_metrics()
     my_meta = mcp_server.agent_metadata.get(agent_id)
     
@@ -320,8 +323,9 @@ async def handle_compare_me_to_similar(arguments: Dict[str, Any]) -> Sequence[Te
         
         try:
             other_monitor = mcp_server.get_or_create_monitor(other_id)
+            await ensure_hydrated(other_monitor, other_id)
             other_metrics = other_monitor.get_metrics()
-            
+
             other_E = float(other_metrics.get('E', 0.7))
             other_I = float(other_metrics.get('I', 0.8))
             other_S = float(other_metrics.get('S', 0.2))
@@ -429,6 +433,7 @@ async def handle_compare_me_to_similar(arguments: Dict[str, Any]) -> Sequence[Te
     for similar in top_similar:
         try:
             other_monitor = mcp_server.get_or_create_monitor(similar["agent_id"])
+            await ensure_hydrated(other_monitor, similar["agent_id"])
             other_metrics = other_monitor.get_metrics()
             regime = other_metrics.get('regime', 'nominal')
             all_regimes.append(regime)

--- a/src/mcp_handlers/support/model_inference.py
+++ b/src/mcp_handlers/support/model_inference.py
@@ -237,7 +237,9 @@ async def handle_call_model(arguments: Dict[str, Any]) -> Sequence[TextContent]:
         if agent_id:
             try:
                 monitor = mcp_server.get_or_create_monitor(agent_id)
-                
+                from src.agent_monitor_state import ensure_hydrated
+                await ensure_hydrated(monitor, agent_id)
+
                 # Update Energy through a lightweight process_update
                 # Model inference consumes Energy - reflect this in EISV dynamics
                 # Use low complexity (0.1-0.2) since inference is a tool, not core work

--- a/tests/test_monitor_hydration.py
+++ b/tests/test_monitor_hydration.py
@@ -23,6 +23,7 @@ import pytest
 from src.agent_monitor_state import (
     STATE_SAVE_TIMEOUT_SECONDS,
     _write_state_file,
+    ensure_hydrated,
     hydrate_from_db_if_fresh,
     save_monitor_state_async,
 )
@@ -139,6 +140,134 @@ async def test_hydrate_from_db_if_fresh_swallows_db_exceptions():
 
     assert applied is False
     assert monitor.state.update_count == 0
+
+
+# ─── Fix #5: get_or_create_monitor flag-and-drain wire-in ────────────────
+#
+# Cold factory + missing file + DB has rows must heal on the next async read.
+# The factory marks `_needs_hydration=True` (sync) and async handlers drain
+# the mark via `ensure_hydrated()`. Without these tests we have no regression
+# guard against a future handler being added that skips the drain.
+
+
+@pytest.mark.asyncio
+async def test_factory_marks_needs_hydration_when_file_missing_and_meta_has_activity(tmp_path, monkeypatch):
+    """Mnemos repro: file missing, meta says total_updates=9 → flag set."""
+    from src.agent_lifecycle import get_or_create_monitor
+    import src.agent_monitor_state as ams
+    from src.agent_monitor_state import monitors
+
+    agent_id = "factory-flag-set"
+    monitors.pop(agent_id, None)
+    monkeypatch.setattr(ams, "get_state_file", lambda _aid: tmp_path / "missing.json")
+
+    fake_meta = MagicMock(total_updates=9)
+    with patch("src.agent_lifecycle.get_or_create_metadata", return_value=fake_meta):
+        monitor = get_or_create_monitor(agent_id)
+
+    assert monitor._needs_hydration is True
+    monitors.pop(agent_id, None)
+
+
+@pytest.mark.asyncio
+async def test_factory_does_not_mark_needs_hydration_for_genuinely_new_agent(tmp_path, monkeypatch):
+    """Fresh-onboard agent with no prior activity must NOT trigger DB roundtrip.
+
+    Saves DB cost on cold first-observe of every newly-onboarded agent and
+    preserves the bootstrap-only "no measured trajectory" guard semantics.
+    """
+    from src.agent_lifecycle import get_or_create_monitor
+    import src.agent_monitor_state as ams
+    from src.agent_monitor_state import monitors
+
+    agent_id = "factory-flag-unset"
+    monitors.pop(agent_id, None)
+    monkeypatch.setattr(ams, "get_state_file", lambda _aid: tmp_path / "missing.json")
+
+    fake_meta = MagicMock(total_updates=0)
+    with patch("src.agent_lifecycle.get_or_create_metadata", return_value=fake_meta):
+        monitor = get_or_create_monitor(agent_id)
+
+    assert monitor._needs_hydration is False
+    monitors.pop(agent_id, None)
+
+
+@pytest.mark.asyncio
+async def test_factory_clears_needs_hydration_when_file_load_succeeds(tmp_path, monkeypatch):
+    """File present → no need for DB hydration; flag must be False."""
+    from src.agent_lifecycle import get_or_create_monitor
+    import src.agent_monitor_state as ams
+    from src.agent_monitor_state import monitors
+    from src.governance_state import GovernanceState
+
+    agent_id = "factory-file-loaded"
+    monitors.pop(agent_id, None)
+
+    fake_state = MagicMock(spec=GovernanceState, V_history=[1, 2, 3])
+    monkeypatch.setattr(ams, "get_state_file", lambda _aid: tmp_path / "any.json")
+
+    fake_meta = MagicMock(total_updates=9)
+    with patch("src.agent_lifecycle.get_or_create_metadata", return_value=fake_meta), \
+         patch("src.agent_lifecycle.load_monitor_state", return_value=fake_state):
+        monitor = get_or_create_monitor(agent_id)
+
+    assert monitor._needs_hydration is False
+    monitors.pop(agent_id, None)
+
+
+@pytest.mark.asyncio
+async def test_ensure_hydrated_drains_flag_and_calls_hydrate():
+    """Flag set → ensure_hydrated calls hydrate_from_db_if_fresh and clears flag."""
+    monitor = _make_fresh_monitor("ensure-drain")
+    monitor._needs_hydration = True
+
+    fake_identity = MagicMock(identity_id=7)
+    fake_rows = [_FakeStateRow(E=0.6, I=0.7, S=0.2, V=0.0, coherence=0.48, regime="EXPLORATION")]
+    fake_db = MagicMock()
+    fake_db.get_identity = AsyncMock(return_value=fake_identity)
+    fake_db.get_agent_state_history = AsyncMock(return_value=fake_rows)
+
+    with patch("src.db.get_db", return_value=fake_db):
+        applied = await ensure_hydrated(monitor, "ensure-drain")
+
+    assert applied is True
+    assert monitor._needs_hydration is False
+    assert monitor.state.update_count == 1
+    assert monitor.state.coherence == pytest.approx(0.48)
+
+
+@pytest.mark.asyncio
+async def test_ensure_hydrated_noop_when_flag_unset():
+    """Hot monitors (flag unset) must not trigger any DB call."""
+    monitor = _make_fresh_monitor("ensure-noop")
+    monitor._needs_hydration = False
+
+    fake_db = MagicMock()
+    fake_db.get_identity = AsyncMock(side_effect=AssertionError("must not be called"))
+
+    with patch("src.db.get_db", return_value=fake_db):
+        applied = await ensure_hydrated(monitor, "ensure-noop")
+
+    assert applied is False
+    fake_db.get_identity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ensure_hydrated_clears_flag_on_db_failure():
+    """Single-shot semantics: DB unreachable still drains the flag — degrades
+    to seed defaults on subsequent reads instead of retrying every time."""
+    monitor = _make_fresh_monitor("ensure-db-down")
+    monitor._needs_hydration = True
+
+    fake_db = MagicMock()
+    fake_db.get_identity = AsyncMock(side_effect=RuntimeError("DB down"))
+
+    with patch("src.db.get_db", return_value=fake_db):
+        applied = await ensure_hydrated(monitor, "ensure-db-down")
+
+    assert applied is False
+    assert monitor._needs_hydration is False  # drained even on failure
+    assert monitor.state.update_count == 0  # seed defaults preserved
 
 
 # ─── Fix #2: Atomic file write ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Wire `hydrate_from_db_if_fresh` (PR #141) into 14 async handler call sites that previously bypassed it. Agents with DB rows but no JSON snapshot stop returning seed-default EISV through `observe` / `list_agents` / `self_recovery` / `cirs` / `export`.

**Mnemos was the trigger** — `c67b2ffb-cdaf-451f-bf04-f7290a2d0a8e` had 9 `core.agent_state` rows but `observe` returned seed defaults (`E=0.7, I=0.8, S=0.2, V=0.0, coh=0.5`). Live verification confirmed **~1222/1755 agents (~70%)** are in the same DB-but-no-file state. 4.5 months of pre-PR-#141 `auto_attest` events become readable through `observe` et al. after deploy.

## Mechanism

- `get_or_create_monitor` (sync) sets `monitor._needs_hydration = True` when the file snapshot is missing **AND** `meta.total_updates > 0`.
- Async handlers call `await ensure_hydrated(monitor, agent_id)` at entry. Idempotent, single-shot, swallows DB errors (degrades to seed defaults — same as pre-fix).
- Sync callers (background tasks, CLI) see same seed-default behavior they had before. **No async cascade** across 28 call sites.
- Bootstrap-only carve-out preserved — hydrate uses `exclude_synthetic=True`, so onboard-only agents stay `update_count=0` and downstream "no measured trajectory" guards still trigger.

## Wired sites

`observability/handlers.py` (4), `lifecycle/query.py` (2), `lifecycle/operations.py` (2), `lifecycle/self_recovery.py` (3), `lifecycle/resume.py` (1), `lifecycle/stuck.py` (1), `cirs/{void,coherence,state,governance_action}.py` (4), `core.py:155` (simulate), `introspection/export.py` (2), `support/model_inference.py` (1).

PR #141's existing inline `hydrate_from_db_if_fresh` calls in `agent_loop_detection.py:472` and `services/runtime_queries.py:148` left in place — redundant with the centralized helper, removable in a follow-up.

## Test plan

- [x] 6 new cases in `test_monitor_hydration.py`: factory flag set/unset/cleared, `ensure_hydrated` drains flag on success, no-op when unset, drains on DB failure
- [x] Full suite: **7498 passed, 33 skipped** (test-cache cached)
- [x] Pre-existing `test_handlers_core.py::TestSimulateUpdate::test_simulate_existing_agent` regression caught + fixed (strict `is True` check on flag — MagicMock attr was truthy and bypassed the no-op guard)
- [ ] **Post-merge:** observe Mnemos UUID — should return real EISV (entropy ≈ 0.38, integrity ≈ 0.70, coh ≈ 0.48) instead of seeds

## Notes

Watcher findings `#d35dc009 #4a77cbb0 #fc0190b5 #1fc2b59e #84df3685 #70f44e81 #ebf674d4 #e3c3f119` are pre-existing patterns adjacent to the wire-in (intentional simulation temp monitor, in-memory buffer mutation with same-function persist, `success_response` envelope) — not introduced or addressed by this PR.

Council reviewed: dialectic-knowledge-architect (semantic risks + flag-and-drain design), feature-dev:code-reviewer (sync/async boundary, anyio safety, concurrency, test gap), general-purpose (live verification, fleet-scope discovery).