### PR TITLE
calibration: honest absence when tactical signal is starved

### DIFF
--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -1206,8 +1206,16 @@ async function loadCalibration() {
                 valueEl.textContent = '—';
                 valueEl.style.color = '';
                 detailEl.textContent = 'No samples \u00b7 Fleet-wide';
+            } else if ((result.calibration_status || (result.calibrated ? 'calibrated' : 'miscalibrated')) === 'signal_stale') {
+                var staleness = result.tactical_staleness_days;
+                valueEl.textContent = 'Stale';
+                valueEl.style.color = 'var(--color-warning, #eab308)';
+                var staleStr = (staleness != null) ? staleness.toFixed(0) + 'd' : '?';
+                detailEl.textContent = 'Tactical signal ' + staleStr + ' old · ' + samples + ' samples';
             } else {
-                var calibrated = result.calibrated === true;
+                var calibrated = (result.calibration_status
+                    ? result.calibration_status === 'calibrated'
+                    : result.calibrated === true);
                 valueEl.textContent = calibrated ? 'Yes' : 'No';
                 valueEl.style.color = calibrated
                     ? 'var(--color-success, #22c55e)'
@@ -2185,9 +2193,20 @@ if (calibrationCard) {
             const dist = r?.confidence_distribution || {};
             const samples = r?.total_samples ?? 0;
             const issues = r?.issues || [];
+            const status = r?.calibration_status
+                || (samples === 0 ? 'no_data' : (r?.calibrated ? 'calibrated' : 'miscalibrated'));
+            const staleness = r?.tactical_staleness_days;
+            const statusLabels = {
+                calibrated: 'Yes',
+                miscalibrated: 'No',
+                signal_stale: 'Unknown (signal stale)',
+                no_data: 'Unknown (no samples yet)',
+            };
             var calHtml = '<div class="detail-section">' +
-                '<div><strong>Calibrated:</strong> ' + (r?.calibrated ? 'Yes' : 'No') +
-                (samples === 0 ? ' <span style="opacity:0.6">(no samples yet)</span>' : '') + '</div>' +
+                '<div><strong>Calibrated:</strong> ' + (statusLabels[status] || status) + '</div>' +
+                (staleness != null
+                    ? '<div><strong>Tactical signal age:</strong> ' + staleness.toFixed(1) + ' days</div>'
+                    : '') +
                 '<div><strong>Trajectory health:</strong> ' + (th * 100).toFixed(1) + '%</div>' +
                 '<div><strong>Samples:</strong> ' + samples + '</div>' +
                 (dist.mean != null ? '<div><strong>Confidence mean:</strong> ' + (dist.mean * 100).toFixed(1) + '%</div>' : '');

--- a/src/calibration.py
+++ b/src/calibration.py
@@ -1018,25 +1018,70 @@ class CalibrationChecker:
             "bins": bin_characterizations,
         }
 
+    def _tactical_signal_age_days(self) -> Optional[float]:
+        """Days since the last tactical signal landed in the e-process tracker.
+
+        Returned as a positive float; None if the tracker is unavailable or
+        has no recorded signal yet. The sequential tracker shares its write
+        path with `record_tactical_decision` (both fire from outcome_event
+        on test_passed/test_failed), so its `last_updated` is a faithful
+        proxy for "is the tactical bin pipeline alive."
+        """
+        try:
+            from src.sequential_calibration import get_sequential_calibration_tracker
+            from datetime import datetime, timezone
+            metrics = get_sequential_calibration_tracker().compute_metrics()
+            last_updated = metrics.get("last_updated")
+            if not last_updated:
+                return None
+            if isinstance(last_updated, str):
+                last_dt = datetime.fromisoformat(last_updated.replace("Z", "+00:00"))
+            else:
+                last_dt = last_updated
+            if last_dt.tzinfo is None:
+                last_dt = last_dt.replace(tzinfo=timezone.utc)
+            return max(0.0, (datetime.now(timezone.utc) - last_dt).total_seconds() / 86400.0)
+        except Exception:
+            return None
+
     def apply_confidence_correction(self, reported_confidence: float,
-                                    min_samples: int = 5) -> Tuple[float, Optional[str]]:
+                                    min_samples: int = 5,
+                                    max_staleness_days: float = 7.0) -> Tuple[float, Optional[str]]:
         """
         Apply calibration correction to a reported confidence value.
 
         AUTO-CALIBRATION LOOP: This closes the learning loop by automatically
         adjusting confidence based on historical accuracy.
 
+        Honest absence: when the tactical signal pipeline is starved (no
+        outcome_event for `max_staleness_days`), bins are frozen in time and
+        scaling against them is worse than not correcting at all — they
+        carry survivorship bias from whichever sample arrived last. Return
+        identity with a `calibration_skipped` reason so callers can surface
+        the absence instead of silently using stale bins.
+
         Args:
             reported_confidence: The confidence value reported by the agent [0, 1]
             min_samples: Minimum samples needed to apply correction
+            max_staleness_days: If the tactical signal hasn't refreshed in
+                this many days, return identity. Default 7.
 
         Returns:
             Tuple of (corrected_confidence, correction_info)
             - corrected_confidence: Calibrated confidence value [0, 1]
-            - correction_info: String describing correction applied, or None
+            - correction_info: String describing correction applied or skipped,
+              or None when the call is a quiet no-op
         """
         # Clamp input to valid range
         reported_confidence = max(0.0, min(1.0, reported_confidence))
+
+        # Honest absence on stale signal — see docstring.
+        age_days = self._tactical_signal_age_days()
+        if age_days is not None and age_days > max_staleness_days:
+            return reported_confidence, (
+                f"calibration_skipped: tactical signal stale "
+                f"{age_days:.1f}d (>{max_staleness_days}d threshold)"
+            )
 
         # Find the bin for this confidence
         bin_key = None

--- a/src/mcp_handlers/admin/calibration.py
+++ b/src/mcp_handlers/admin/calibration.py
@@ -100,8 +100,45 @@ async def handle_check_calibration(arguments: Dict[str, Any]) -> Sequence[TextCo
             "agents end up healthy?), not a measurement of decision correctness."
         )
 
+    # Compute tactical-signal staleness so the dashboard can distinguish
+    # "miscalibrated" from "starved." A bin-error verdict against a frozen
+    # signal channel is a different operational story than against a live one.
+    tactical_staleness_days: Optional[float] = None
+    last_updated_raw = tactical_metrics.get("last_updated") if tactical_metrics else None
+    if last_updated_raw:
+        try:
+            from datetime import datetime, timezone
+            if isinstance(last_updated_raw, str):
+                _last_dt = datetime.fromisoformat(last_updated_raw.replace("Z", "+00:00"))
+            else:
+                _last_dt = last_updated_raw
+            if _last_dt.tzinfo is None:
+                _last_dt = _last_dt.replace(tzinfo=timezone.utc)
+            tactical_staleness_days = max(
+                0.0,
+                (datetime.now(timezone.utc) - _last_dt).total_seconds() / 86400.0,
+            )
+        except Exception:
+            tactical_staleness_days = None
+
+    # `calibration_status` is the operator-facing one-liner. The boolean
+    # `calibrated` is preserved for back-compat, but it conflates "we
+    # measured miscalibration" with "we have no signal to measure" —
+    # status splits those.
+    STALENESS_THRESHOLD_DAYS = 7.0
+    if total_samples == 0:
+        calibration_status = "no_data"
+    elif tactical_staleness_days is not None and tactical_staleness_days > STALENESS_THRESHOLD_DAYS:
+        calibration_status = "signal_stale"
+    elif is_calibrated:
+        calibration_status = "calibrated"
+    else:
+        calibration_status = "miscalibrated"
+
     response = {
         "calibrated": is_calibrated,
+        "calibration_status": calibration_status,
+        "tactical_staleness_days": tactical_staleness_days,
         "issues": metrics.get('issues', []),
         "accuracy": accuracy_value,
         "trajectory_health": overall_trajectory_health,
@@ -116,6 +153,7 @@ async def handle_check_calibration(arguments: Dict[str, Any]) -> Sequence[TextCo
     if tactical_metrics:
         response["tactical_evidence"] = {
             **tactical_metrics,
+            "staleness_days": tactical_staleness_days,
             "note": (
                 "Sequential evidence is tracked only for hard exogenous tactical outcomes "
                 "(tests, commands, files, lint, tool-result evidence)."

--- a/src/mcp_handlers/schemas/core.py
+++ b/src/mcp_handlers/schemas/core.py
@@ -180,13 +180,15 @@ class ProcessAgentUpdateParams(AgentIdentityMixin):
 
 class OutcomeEventParams(AgentIdentityMixin):
     """Parameters for outcome_event"""
-    outcome_type: Literal["drawing_completed", "drawing_abandoned", "test_passed", "test_failed", "tool_rejected", "task_completed", "task_failed"] = Field(..., description="Type of outcome event")
+    outcome_type: Literal["drawing_completed", "drawing_abandoned", "test_passed", "test_failed", "tool_rejected", "task_completed", "task_failed", "trajectory_validated"] = Field(..., description="Type of outcome event")
     outcome_score: Optional[float] = Field(None, description="Quality score 0.0 (worst) to 1.0 (best). Inferred from type if omitted.")
     is_bad: Optional[bool] = Field(None, description="Whether this is a negative outcome. Inferred from type if omitted.")
     detail: Optional[Dict[str, Any]] = Field(None, description="Type-specific metadata (e.g., mark_count, test_name, error_message)")
     confidence: Optional[float] = Field(None, ge=0.0, le=1.0, description="Agent confidence at outcome time (0-1). Looked up from last check-in if omitted.")
     prediction_id: Optional[str] = Field(None, description="Tactical prediction id from a prior process_agent_update response. When provided, the registered confidence for that id is used instead of the temporal proxy fallback.")
     agent_id: Optional[str] = Field(None, description="Agent ID. Falls back to session-bound agent_id if omitted.")
+    decision_action: Optional[str] = Field(None, description="The decision the agent took (e.g. 'proceed', 'pause'). Used by sequential calibration tracking; for test_passed/test_failed defaults to 'proceed'.")
+    session_id: Optional[str] = Field(None, description="Optional session id; falls back to client_session_id and then to context.")
 
 
 class CirsProtocolParams(AgentIdentityMixin):

--- a/tests/test_calibration_corrections.py
+++ b/tests/test_calibration_corrections.py
@@ -163,6 +163,66 @@ class TestApplyConfidenceCorrection:
         assert 0.0 <= corrected <= 1.0
 
 
+class TestStaleSignalHonestAbsence:
+    """Stale tactical signal -> identity correction with calibration_skipped reason.
+
+    The signal channel can starve (no outcome_event for days) while bins
+    keep their last-recorded values. Scaling against frozen bins amplifies
+    survivorship bias from whichever sample arrived last; honest absence
+    is the safer default.
+    """
+
+    def test_stale_signal_returns_identity_with_reason(self, checker, monkeypatch):
+        # Bin has plenty of samples that would normally trigger correction.
+        checker.tactical_bin_stats["0.8-0.9"] = {
+            "count": 20, "actual_correct": 10, "predicted_correct": 20,
+            "confidence_sum": 17.0,
+        }
+        monkeypatch.setattr(checker, "_tactical_signal_age_days", lambda: 12.5)
+
+        corrected, info = checker.apply_confidence_correction(
+            0.85, min_samples=5, max_staleness_days=7.0
+        )
+
+        assert corrected == 0.85
+        assert info is not None
+        assert "calibration_skipped" in info
+        assert "stale" in info
+
+    def test_fresh_signal_still_corrects(self, checker, monkeypatch):
+        # Same setup, but signal is fresh -> correction proceeds.
+        checker.tactical_bin_stats["0.8-0.9"] = {
+            "count": 20, "actual_correct": 10, "predicted_correct": 20,
+            "confidence_sum": 17.0,
+        }
+        monkeypatch.setattr(checker, "_tactical_signal_age_days", lambda: 0.5)
+
+        corrected, info = checker.apply_confidence_correction(
+            0.85, min_samples=5, max_staleness_days=7.0
+        )
+
+        assert corrected < 0.85
+        assert info is not None
+        assert "calibration_adjusted" in info
+
+    def test_unknown_age_does_not_skip(self, checker, monkeypatch):
+        # If we can't tell the signal's age, behave as before -- absence
+        # of evidence about staleness is not evidence of staleness.
+        checker.tactical_bin_stats["0.8-0.9"] = {
+            "count": 20, "actual_correct": 10, "predicted_correct": 20,
+            "confidence_sum": 17.0,
+        }
+        monkeypatch.setattr(checker, "_tactical_signal_age_days", lambda: None)
+
+        corrected, info = checker.apply_confidence_correction(
+            0.85, min_samples=5, max_staleness_days=7.0
+        )
+
+        assert corrected < 0.85
+        assert info is not None
+        assert "calibration_adjusted" in info
+
+
 # ============================================================================
 # update_ground_truth
 # ============================================================================


### PR DESCRIPTION
The auto-calibration loop in `apply_confidence_correction` was silently scaling agent confidence against `tactical_bin_stats` that hadn't refreshed in 12 days. Stale bins carry survivorship bias from whichever sample arrived last, so scaling against them is worse than not correcting at all.

## Behavior change

`apply_confidence_correction` now consults the sequential tracker's `last_updated`. If the tactical signal is older than `max_staleness_days` (default 7), returns identity with a `calibration_skipped: tactical signal stale Nd` info string instead of scaling.

`check_calibration` response gains:
- `calibration_status` ∈ `{calibrated, miscalibrated, signal_stale, no_data}`
- `tactical_staleness_days`

so operators can distinguish "we measured miscalibration" from "we have no signal to measure." Dashboard calibration card uses these to render *Stale (Nd old)* in yellow rather than mislabeling stale evidence as miscalibration.

## Schema/handler drift fixed

`OutcomeEventParams` now exposes `decision_action` and `session_id` (both read by the handler at `outcome_events.py:209` and `:87`, previously stripped by Pydantic validation) and adds `trajectory_validated` to the `outcome_type` enum (was in handler's `VALID_OUTCOME_TYPES` but not the public schema).

## Tests

Added `TestStaleSignalHonestAbsence` covering the staleness gate, the live-correction path, and the unknown-age fallback (absence of staleness evidence is not evidence of staleness).

Auto-shipped by ship.sh — runtime path. Auto-merge enabled; CI gate applies.