### PR TITLE
fix: persist runtime state in direct_resume + honest export envelope

### DIFF
--- a/src/mcp_handlers/introspection/export.py
+++ b/src/mcp_handlers/introspection/export.py
@@ -59,12 +59,17 @@ async def handle_get_system_history(arguments: Dict[str, Any]) -> Sequence[TextC
             history_data = json.loads(history_data)
         except Exception as e:
             logger.warning(f"Could not parse history JSON: {e}")
-    
+            return [error_response(
+                "Export produced malformed JSON",
+                error_code="EXPORT_MALFORMED",
+                error_category="system_error",
+                details={"agent_id": agent_id, "cause": str(e)},
+            )]
+
     return success_response({
-        "success": True,
         "format": format_type,
         "history": history_data,
-        "agent_id": agent_id
+        "agent_id": agent_id,
     })
 
 @mcp_tool("export_to_file", timeout=45.0, register=False)

--- a/src/mcp_handlers/lifecycle/resume.py
+++ b/src/mcp_handlers/lifecycle/resume.py
@@ -8,10 +8,13 @@ from typing import Dict, Any, Sequence
 
 from mcp.types import TextContent
 
+from datetime import datetime, timezone
+
 from ..decorators import mcp_tool
 from ..utils import success_response, error_response, require_registered_agent
 from ..error_helpers import agent_not_found_error, system_error as system_error_helper
 from ..support.coerce import resolve_agent_uuid
+from .helpers import _invalidate_agent_cache
 from src import agent_storage
 from src.logging_utils import get_logger
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
@@ -102,20 +105,42 @@ async def handle_direct_resume_if_safe(arguments: Dict[str, Any]) -> Sequence[Te
     # Get conditions if provided
     conditions = arguments.get("conditions", [])
     reason = arguments.get("reason", "Direct resume - state is safe")
+    event_details = f"Direct resume: {reason}. Conditions: {conditions}"
+    event_entry = {
+        "event": "resumed",
+        "reason": event_details,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
 
-    # Resume agent
+    # Persist FIRST so in-memory state can't diverge from DB on persist failure.
+    # Runtime state (paused_at, lifecycle_events) must be persisted alongside
+    # status or it gets clobbered on the next load_metadata_async(force=True).
+    try:
+        await agent_storage.update_agent(agent_uuid, status="active")
+        await agent_storage.persist_runtime_state(
+            agent_uuid,
+            paused_at=None,
+            loop_detected_at=None,
+            loop_cooldown_until=None,
+            append_lifecycle_event=event_entry,
+        )
+    except Exception as e:
+        logger.warning(f"PostgreSQL update failed for direct_resume: {e}", exc_info=True)
+        return [error_response(
+            f"Failed to resume agent '{agent_id}': persistence error",
+            error_code="PERSIST_FAILED",
+            error_category="system_error",
+            details={"agent_id": agent_id, "cause": str(e)},
+        )]
+
+    await _invalidate_agent_cache(agent_uuid)
+
+    # Persist succeeded — now mutate in-memory state.
     meta.status = "active"
     meta.paused_at = None
-    # Clear loop detector state to prevent immediate re-pause
     from .self_recovery import clear_loop_detector_state
     clear_loop_detector_state(meta)
-    meta.add_lifecycle_event("resumed", f"Direct resume: {reason}. Conditions: {conditions}")
-
-    # PostgreSQL: Update status (single source of truth)
-    try:
-        await agent_storage.update_agent(agent_id, status="active")
-    except Exception as e:
-        logger.debug(f"PostgreSQL status update failed: {e}")
+    meta.add_lifecycle_event("resumed", event_details)
 
     response_data = {
         "success": True,

--- a/tests/test_core_metrics.py
+++ b/tests/test_core_metrics.py
@@ -788,6 +788,22 @@ class TestGetSystemHistory:
             data = _parse(result)
             assert data.get("agent_id") == "explicit-agent"
 
+    @pytest.mark.asyncio
+    async def test_malformed_json_returns_error_envelope(self, mock_server, mock_monitor):
+        """Watcher P016: when export_history returns non-JSON, do not lie with success=True."""
+        mock_monitor.export_history = MagicMock(return_value="not json {{{")
+        mock_server.get_or_create_monitor.return_value = mock_monitor
+
+        with patch("src.mcp_handlers.introspection.export.mcp_server", mock_server), \
+             patch("src.mcp_handlers.introspection.export.require_registered_agent", return_value=("agent-1", None)), \
+             patch("src.mcp_handlers.context.get_context_agent_id", return_value="agent-1"):
+
+            from src.mcp_handlers.introspection.export import handle_get_system_history
+            result = await handle_get_system_history({"format": "json"})
+            data = _parse(result)
+            assert data.get("success") is False
+            assert data.get("error_code") == "EXPORT_MALFORMED"
+
 
 # ============================================================================
 # handle_export_to_file (export.py)

--- a/tests/test_lifecycle_recovery.py
+++ b/tests/test_lifecycle_recovery.py
@@ -132,6 +132,54 @@ class TestDirectResumeIfSafe:
             text = result[0].text
             assert "auth" in text.lower()
 
+    @pytest.mark.asyncio
+    async def test_resume_persists_runtime_state(self, server):
+        """Watcher P011: paused_at + lifecycle_event must be persisted alongside status."""
+        meta = make_agent_meta(status="paused")
+        server.agent_metadata = {"agent-1": meta}
+        server.get_or_create_monitor.return_value = make_monitor(coherence=0.8, mean_risk=0.3, I=0.3, S=0.5)
+
+        with patch_lifecycle_server(server, require_registered=("agent-1", None)), \
+             patch("src.mcp_handlers.lifecycle.handlers.agent_storage") as mock_storage, \
+             patch("src.mcp_handlers.lifecycle.resume.agent_storage") as mock_storage_r, \
+             patch("src.mcp_handlers.lifecycle.resume._invalidate_agent_cache", new=AsyncMock()), \
+             patch("src.mcp_handlers.utils.verify_agent_ownership", return_value=True):
+            mock_storage.update_agent = AsyncMock()
+            mock_storage.persist_runtime_state = AsyncMock()
+            mock_storage_r.update_agent = AsyncMock()
+            mock_storage_r.persist_runtime_state = AsyncMock()
+            from src.mcp_handlers.lifecycle.handlers import handle_direct_resume_if_safe
+            result = await handle_direct_resume_if_safe({"agent_id": "agent-1"})
+            data = _parse(result)
+            assert data["success"] is True
+            mock_storage_r.update_agent.assert_awaited_once()
+            mock_storage_r.persist_runtime_state.assert_awaited_once()
+            kwargs = mock_storage_r.persist_runtime_state.await_args.kwargs
+            assert kwargs.get("paused_at") is None
+            assert kwargs.get("append_lifecycle_event") is not None
+            assert kwargs["append_lifecycle_event"]["event"] == "resumed"
+
+    @pytest.mark.asyncio
+    async def test_resume_persist_failure_returns_error(self, server):
+        """Persist failure must surface a PERSIST_FAILED error, not silently mutate in-memory state."""
+        meta = make_agent_meta(status="paused")
+        server.agent_metadata = {"agent-1": meta}
+        server.get_or_create_monitor.return_value = make_monitor(coherence=0.8, mean_risk=0.3, I=0.3, S=0.5)
+
+        with patch_lifecycle_server(server, require_registered=("agent-1", None)), \
+             patch("src.mcp_handlers.lifecycle.resume.agent_storage") as mock_storage_r, \
+             patch("src.mcp_handlers.lifecycle.resume._invalidate_agent_cache", new=AsyncMock()), \
+             patch("src.mcp_handlers.utils.verify_agent_ownership", return_value=True):
+            mock_storage_r.update_agent = AsyncMock(side_effect=RuntimeError("db down"))
+            mock_storage_r.persist_runtime_state = AsyncMock()
+            from src.mcp_handlers.lifecycle.handlers import handle_direct_resume_if_safe
+            result = await handle_direct_resume_if_safe({"agent_id": "agent-1"})
+            data = _parse(result)
+            assert data["success"] is False
+            assert data.get("error_code") == "PERSIST_FAILED"
+            # In-memory state must NOT have been mutated when persist failed.
+            assert meta.status == "paused"
+
 
 # ============================================================================
 # handle_self_recovery_review


### PR DESCRIPTION
## Summary
- **Watcher P011 (resume.py:107/108/112)**: `meta.status` / `meta.paused_at` / lifecycle event were mutated in memory while only `status` was persisted. On the next `load_metadata_async(force=True)` the cleared `paused_at` and the resume event were clobbered. Apply the canonical persist-FIRST pattern from `operations.py:81+`: `agent_storage.persist_runtime_state(...)` + `_invalidate_agent_cache`, mutate in-memory state only on success, return `PERSIST_FAILED` on persist exception (was a silent debug-log swallow). Also switch the storage call from `agent_id` to the authoritative `agent_uuid`.
- **Watcher P016 (export.py:64)**: when `monitor.export_history(format="json")` returned non-JSON, the previous code logged a warning and still wrapped the malformed string in `success_response({"success": True, ...})` — outer envelope lied. Bail to `error_response(EXPORT_MALFORMED)`.
- Tests cover persist-call kwargs, persist-failure path (status stays `paused`), and malformed export envelope.

Resolves Watcher fingerprints: 84df3685, 70f44e81, ebf674d4, e3c3f119
Dismissed (intentional, see commit context): d35dc009, 4a77cbb0, fc0190b5, 1fc2b59e

## Test plan
- [x] `./scripts/dev/test-cache.sh` — 7501 passed, 33 skipped
- [x] `pytest tests/test_lifecycle_recovery.py::TestDirectResumeIfSafe` — 9 passed (2 new)
- [x] `pytest tests/test_core_metrics.py::TestGetSystemHistory` — 6 passed (1 new)