### PR TITLE
instrument: identity resolution observation event for pin-TTL analysis

### DIFF
--- a/src/audit_log.py
+++ b/src/audit_log.py
@@ -23,7 +23,7 @@ logger = get_logger(__name__)
 class AuditEntry:
     """Single audit log entry"""
     timestamp: str
-    agent_id: str
+    agent_id: Optional[str]
     event_type: str  # "lambda1_skip", "auto_attest", "calibration_check", "complexity_derivation"
     confidence: float
     details: Dict
@@ -391,6 +391,50 @@ class AuditLogger:
                 "candidate_fingerprint_prefix": candidate_fingerprint_prefix,
                 "client_hint": client_hint,
                 "model_type": model_type,
+            },
+        )
+        self._write_entry(entry)
+
+    def log_identity_resolution_observed(
+        self,
+        *,
+        agent_uuid: Optional[str],
+        resolution_source: Optional[str],
+        pin_match_scope: Optional[str] = None,
+        pin_entry_present: Optional[bool] = None,
+        pin_fingerprint_match: Optional[bool] = None,
+        pin_entry_age_seconds: Optional[int] = None,
+        token_iat: Optional[int] = None,
+        token_exp: Optional[int] = None,
+        token_age_seconds: Optional[int] = None,
+    ) -> None:
+        """Record one observation per onboard/resume identity resolution.
+
+        Fields answer "what won, and what would the pin path have done if
+        we'd checked it?" — needed to discriminate the masking hypothesis
+        for the 30-min sliding pin TTL from the alternative explanations
+        (pin expired absolutely / fingerprint legitimately changed).
+
+        ``pin_*`` fields populated when a shadow lookup ran (winning path was
+        not the pin itself). ``token_*`` fields populated when a continuity
+        token was presented at resume. ``agent_uuid`` may be None when the
+        resolution did not bind to a known agent (e.g., onboard that minted
+        a fresh identity has it set; pre-bind diagnostics may not).
+        """
+        entry = AuditEntry(
+            timestamp=datetime.now().isoformat(),
+            agent_id=agent_uuid,
+            event_type="identity_resolution_observed",
+            confidence=1.0,
+            details={
+                "resolution_source": resolution_source,
+                "pin_match_scope": pin_match_scope,
+                "pin_entry_present": pin_entry_present,
+                "pin_fingerprint_match": pin_fingerprint_match,
+                "pin_entry_age_seconds": pin_entry_age_seconds,
+                "token_iat": token_iat,
+                "token_exp": token_exp,
+                "token_age_seconds": token_age_seconds,
             },
         )
         self._write_entry(entry)

--- a/src/mcp_handlers/context.py
+++ b/src/mcp_handlers/context.py
@@ -211,6 +211,59 @@ def get_session_resolution_source() -> Optional[str]:
     """Get session resolution source for current request."""
     return _session_resolution_source.get()
 
+
+# Pin scope detail. Set by derive_session_key when an onboard-pin lookup hits,
+# distinguishing which candidate form matched (client_model / client / model /
+# unscoped). Kept as a side-channel so the load-bearing exact-match comparison
+# at handlers.py against `session_resolution_source == "pinned_onboard_session"`
+# continues to work unchanged.
+_pin_match_scope: ContextVar[Optional[str]] = ContextVar('pin_match_scope', default=None)
+
+
+def set_pin_match_scope(scope: Optional[str]) -> object:
+    """Set pin match scope for current request. Returns token for reset."""
+    return _pin_match_scope.set(scope)
+
+
+def reset_pin_match_scope(token: object) -> None:
+    """Reset pin match scope."""
+    _pin_match_scope.reset(token)
+
+
+def get_pin_match_scope() -> Optional[str]:
+    """Get pin match scope for current request, or None if no pin matched."""
+    return _pin_match_scope.get()
+
+
+# Shadow pin lookup observation. Set by derive_session_key after-hook when a
+# non-pin path won despite an IP/UA fingerprint signal being present — answers
+# "would the pin have hit if we'd looked it up?" without changing resolution
+# order. None on all three keys means no shadow lookup ran.
+_shadow_pin_present: ContextVar[Optional[bool]] = ContextVar('shadow_pin_present', default=None)
+_shadow_pin_match: ContextVar[Optional[bool]] = ContextVar('shadow_pin_match', default=None)
+_shadow_pin_age_seconds: ContextVar[Optional[int]] = ContextVar('shadow_pin_age_seconds', default=None)
+
+
+def set_shadow_pin_observation(
+    *,
+    present: Optional[bool],
+    match: Optional[bool],
+    age_seconds: Optional[int],
+) -> None:
+    """Record an observation-only shadow pin lookup result."""
+    _shadow_pin_present.set(present)
+    _shadow_pin_match.set(match)
+    _shadow_pin_age_seconds.set(age_seconds)
+
+
+def get_shadow_pin_observation() -> Dict[str, Optional[Any]]:
+    """Get the shadow pin observation as a dict; all-None if not run."""
+    return {
+        "pin_entry_present": _shadow_pin_present.get(),
+        "pin_fingerprint_match": _shadow_pin_match.get(),
+        "pin_entry_age_seconds": _shadow_pin_age_seconds.get(),
+    }
+
 # Trajectory identity confidence - set during dispatch if verification runs
 _trajectory_confidence: ContextVar[Optional[float]] = ContextVar('trajectory_confidence', default=None)
 

--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -1865,6 +1865,45 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
 
     logger.info(f"[ONBOARD] Agent {agent_uuid[:8]}... onboarded (is_new={is_new}, label={agent_label})")
 
+    # Identity-resolution observation event. One per successful onboard, used
+    # later to answer "is the 30-min sliding pin TTL bleeding into
+    # continuity-token-only resumes?" Pin shadow fields are populated when
+    # the IP/UA pin path didn't win but a fingerprint signal was present.
+    # See docs/ontology/s1-continuity-token-retirement.md and the audit-log
+    # schema in src/audit_log.py:log_identity_resolution_observed.
+    try:
+        import time as _ires_time
+        from src.audit_log import audit_logger as _ires_audit
+        from ..context import (
+            get_session_resolution_source,
+            get_pin_match_scope,
+            get_shadow_pin_observation,
+        )
+        _ires_token = arguments.get("continuity_token")
+        _ires_iat: Optional[int] = None
+        _ires_exp: Optional[int] = None
+        _ires_age: Optional[int] = None
+        if _ires_token:
+            _ires_iat = extract_token_iat(str(_ires_token))
+            from .session import extract_token_exp as _extract_exp
+            _ires_exp = _extract_exp(str(_ires_token))
+            if _ires_iat is not None:
+                _ires_age = max(0, int(_ires_time.time()) - int(_ires_iat))
+        _ires_shadow = get_shadow_pin_observation()
+        _ires_audit.log_identity_resolution_observed(
+            agent_uuid=agent_uuid,
+            resolution_source=get_session_resolution_source(),
+            pin_match_scope=get_pin_match_scope(),
+            pin_entry_present=_ires_shadow["pin_entry_present"],
+            pin_fingerprint_match=_ires_shadow["pin_fingerprint_match"],
+            pin_entry_age_seconds=_ires_shadow["pin_entry_age_seconds"],
+            token_iat=_ires_iat,
+            token_exp=_ires_exp,
+            token_age_seconds=_ires_age,
+        )
+    except Exception as _ires_err:  # pragma: no cover — defensive
+        logger.debug(f"[IRES] identity_resolution_observed write failed (non-fatal): {_ires_err}")
+
     # Identity Honesty Part C: onboard-triggered orphan sweep REMOVED.
     # It was the driver of 'agent archived almost immediately' — catching
     # siblings of fresh onboards via the 2h zero_update_hours heuristic.

--- a/src/mcp_handlers/identity/session.py
+++ b/src/mcp_handlers/identity/session.py
@@ -147,13 +147,15 @@ def create_continuity_token(
     return f"v1.{payload_b64}.{sig_b64}"
 
 
-def extract_token_iat(token: str) -> Optional[int]:
-    """Extract the `iat` (issued-at) claim from a continuity token.
+def _decode_token_payload(token: str) -> Optional[Dict[str, Any]]:
+    """Verify a continuity token's HMAC and return its decoded payload.
 
-    Signature-verified like `extract_token_agent_uuid`; does NOT check expiry.
-    Returned for grace-period telemetry under S1-a (docs/ontology/
-    s1-continuity-token-retirement.md §6) — callers need `iat` to compute
-    token lifetime at accept-time.
+    Single source of truth for token decoding. `extract_token_iat` and
+    `extract_token_exp` go through this so a token presented to both
+    accessors is signature-verified exactly once per call.
+
+    Does NOT check expiry — callers needing freshness must consult the
+    `exp` claim themselves (or use `resolve_continuity_token`).
     """
     if not token or not isinstance(token, str):
         return None
@@ -168,11 +170,51 @@ def extract_token_iat(token: str) -> Optional[int]:
         if not hmac.compare_digest(expected_sig, sig_b64):
             return None
         payload = json.loads(_b64url_decode(payload_b64).decode())
-        iat = payload.get("iat")
-        if iat is None:
+        if not isinstance(payload, dict):
             return None
-        return int(iat)
+        return payload
     except Exception:
+        return None
+
+
+def extract_token_iat(token: str) -> Optional[int]:
+    """Extract the `iat` (issued-at) claim from a continuity token.
+
+    Signature-verified like `extract_token_agent_uuid`; does NOT check expiry.
+    Returned for grace-period telemetry under S1-a (docs/ontology/
+    s1-continuity-token-retirement.md §6) — callers need `iat` to compute
+    token lifetime at accept-time.
+    """
+    payload = _decode_token_payload(token)
+    if payload is None:
+        return None
+    iat = payload.get("iat")
+    if iat is None:
+        return None
+    try:
+        return int(iat)
+    except (TypeError, ValueError):
+        return None
+
+
+def extract_token_exp(token: str) -> Optional[int]:
+    """Extract the `exp` (expiry) claim from a continuity token.
+
+    Symmetric with `extract_token_iat`: signature-verified, does NOT check
+    whether the token has actually expired. Callers wanting that should use
+    `resolve_continuity_token`. This accessor exists so observation-only
+    instrumentation can record token lifetime / observed-staleness even on
+    tokens that resolution rejected.
+    """
+    payload = _decode_token_payload(token)
+    if payload is None:
+        return None
+    exp = payload.get("exp")
+    if exp is None:
+        return None
+    try:
+        return int(exp)
+    except (TypeError, ValueError):
         return None
 
 
@@ -340,6 +382,114 @@ async def derive_session_key(
     signals: "Optional[SessionSignals]" = None,
     arguments: Optional[Dict[str, Any]] = None,
 ) -> str:
+    """Resolve a session key from transport signals and call arguments.
+
+    Thin wrapper around :func:`_derive_session_key_impl` that — after the
+    winning path is decided — fires an observation-only shadow pin lookup
+    when the IP/UA pin path *didn't* win but the request carried an IP/UA
+    fingerprint signal. The shadow lookup answers "would the pin have hit
+    if we'd checked it?" without altering resolution order, and exists so
+    later analysis can distinguish (a) pin expired absolutely from
+    (b) pin alive but bypassed by ordering / fingerprint shift.
+    """
+    arguments = arguments or {}
+    resolved = await _derive_session_key_impl(signals, arguments)
+    try:
+        from ..context import get_session_resolution_source
+        # Skip the shadow lookup when the pin path either won
+        # ("pinned_onboard_session") or already ran and missed
+        # ("ip_ua_fingerprint" — fingerprint signal present but no pin
+        # candidate matched). In both cases re-running it tells us nothing
+        # new and just spends a Redis call.
+        source = get_session_resolution_source()
+        if source not in ("pinned_onboard_session", "ip_ua_fingerprint"):
+            await _shadow_pin_observe(signals, arguments, resolved)
+    except Exception:
+        # Shadow lookup is best-effort and never fatal — its job is
+        # observation, not resolution. Failure leaves the shadow
+        # contextvars at default (all None).
+        pass
+    return resolved
+
+
+async def _shadow_pin_observe(
+    signals: "Optional[SessionSignals]",
+    arguments: Dict[str, Any],
+    resolved_key: str,
+) -> None:
+    """Run an observation-only pin lookup and record the result on contextvars.
+
+    No TTL refresh, never alters resolution. Reuses the same candidate
+    construction as PATH 7 so the lookup probes exactly the keys the live
+    path would have probed. Bound by the same 500ms Redis timeout; on
+    failure or absence of fingerprint signal, the contextvars stay at
+    their defaults.
+    """
+    if not signals or not signals.ip_ua_fingerprint:
+        return
+    base_fp = _extract_base_fingerprint(signals.ip_ua_fingerprint)
+    if not base_fp:
+        return
+    hint = (arguments.get("client_hint") if arguments else None) or signals.client_hint
+    model = arguments.get("model_type") if arguments else None
+    candidates = _build_pin_fingerprint_candidates(
+        base_fp,
+        client_hint=hint,
+        model_type=model,
+        user_agent=signals.user_agent,
+        include_unscoped_fallback=not bool(hint or model),
+    )
+    if not candidates:
+        return
+    try:
+        await asyncio.wait_for(
+            _shadow_pin_observe_inner(candidates, resolved_key),
+            timeout=_PIN_REDIS_TIMEOUT,
+        )
+    except asyncio.TimeoutError:
+        logger.debug("[SHADOW_PIN] observation lookup timed out")
+    except Exception as e:  # noqa: BLE001 — best-effort observation
+        logger.debug(f"[SHADOW_PIN] observation lookup failed: {e}")
+
+
+async def _shadow_pin_observe_inner(
+    candidates: list,
+    resolved_key: str,
+) -> None:
+    from src.cache.redis_client import get_redis
+    from ..context import set_shadow_pin_observation
+    import json as _json
+
+    raw = await get_redis()
+    if not raw:
+        return
+    for fp in candidates:
+        pin_key = f"recent_onboard:{fp}"
+        pin_data = await raw.get(pin_key)
+        if not pin_data:
+            continue
+        ttl_remaining = await raw.ttl(pin_key)
+        try:
+            pin = _json.loads(pin_data if isinstance(pin_data, str) else pin_data.decode())
+        except Exception:
+            continue
+        pinned_session_id = pin.get("client_session_id")
+        age: Optional[int] = None
+        if isinstance(ttl_remaining, int) and ttl_remaining > 0:
+            age = max(0, _PIN_TTL - ttl_remaining)
+        set_shadow_pin_observation(
+            present=True,
+            match=(pinned_session_id == resolved_key),
+            age_seconds=age,
+        )
+        return
+    set_shadow_pin_observation(present=False, match=False, age_seconds=None)
+
+
+async def _derive_session_key_impl(
+    signals: "Optional[SessionSignals]" = None,
+    arguments: Optional[Dict[str, Any]] = None,
+) -> str:
     """Single source of truth for session key derivation.
 
     Priority (highest to lowest):
@@ -356,6 +506,40 @@ async def derive_session_key(
     from ..context import SessionSignals  # type hint import
 
     arguments = arguments or {}
+
+    def _mark_pin_scope(
+        candidate: str,
+        base_fp: str,
+        client_hint: Optional[str],
+        model_type: Optional[str],
+        user_agent: Optional[str],
+    ) -> None:
+        """Identify which scoped pin form matched and record it on a
+        side-channel contextvar. Kept off ``session_resolution_source`` so the
+        load-bearing exact-match comparison at handlers.py:128 is not affected.
+
+        Normalizes ``client_hint``/``model_type`` the same way
+        ``_build_pin_fingerprint_candidates`` does so the comparison matches
+        the candidates that were actually probed.
+        """
+        try:
+            from ..context import set_pin_match_scope
+            client_norm = _normalize_pin_client_hint(client_hint)
+            model_norm = _normalize_pin_model_type(model_type, user_agent)
+            scope: Optional[str]
+            if client_norm and model_norm and candidate == f"{base_fp}|{client_norm}|{model_norm}":
+                scope = "client_model"
+            elif client_norm and candidate == f"{base_fp}|{client_norm}":
+                scope = "client"
+            elif model_norm and candidate == f"{base_fp}|{model_norm}":
+                scope = "model"
+            elif candidate == base_fp:
+                scope = "unscoped"
+            else:
+                scope = None
+            set_pin_match_scope(scope)
+        except Exception:
+            pass
 
     def _mark(source: str) -> None:
         try:
@@ -440,6 +624,7 @@ async def derive_session_key(
                 pinned = await lookup_onboard_pin(candidate)
                 if pinned:
                     _mark("pinned_onboard_session")
+                    _mark_pin_scope(candidate, base_fp, hint, model, signals.user_agent)
                     # S13: emit passive observation event distinct from the
                     # active-alert identity_hijack_suspected. Caller may still
                     # have proof signals; this fires regardless to build the

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -109,6 +109,65 @@ class TestAuditEntry:
 
 
 # ===========================================================================
+# log_identity_resolution_observed
+# ===========================================================================
+class TestLogIdentityResolutionObserved:
+    def test_writes_full_event(self, tmp_path):
+        logger = _make_logger(tmp_path)
+        logger.log_identity_resolution_observed(
+            agent_uuid="11111111-2222-3333-4444-555555555555",
+            resolution_source="continuity_token",
+            pin_match_scope=None,
+            pin_entry_present=True,
+            pin_fingerprint_match=False,
+            pin_entry_age_seconds=420,
+            token_iat=1700_000_000,
+            token_exp=1700_003_600,
+            token_age_seconds=900,
+        )
+        entries = _read_jsonl(logger.log_file)
+        assert len(entries) == 1
+        e = entries[0]
+        assert e["event_type"] == "identity_resolution_observed"
+        assert e["agent_id"] == "11111111-2222-3333-4444-555555555555"
+        d = e["details"]
+        assert d["resolution_source"] == "continuity_token"
+        assert d["pin_entry_present"] is True
+        assert d["pin_fingerprint_match"] is False
+        assert d["pin_entry_age_seconds"] == 420
+        assert d["token_iat"] == 1700_000_000
+        assert d["token_exp"] == 1700_003_600
+        assert d["token_age_seconds"] == 900
+
+    def test_accepts_none_agent_uuid(self, tmp_path):
+        """Resolutions that don't bind to an agent (pre-bind diagnostic paths)
+        must not crash on None — verifies the AuditEntry.agent_id Optional fix."""
+        logger = _make_logger(tmp_path)
+        logger.log_identity_resolution_observed(
+            agent_uuid=None,
+            resolution_source="ip_ua_fingerprint",
+        )
+        entries = _read_jsonl(logger.log_file)
+        assert entries[0]["agent_id"] is None
+        assert entries[0]["event_type"] == "identity_resolution_observed"
+
+    def test_pin_only_event(self, tmp_path):
+        """When PATH 7 wins, only pin_match_scope is meaningful — token fields stay None."""
+        logger = _make_logger(tmp_path)
+        logger.log_identity_resolution_observed(
+            agent_uuid="agent-pin",
+            resolution_source="pinned_onboard_session",
+            pin_match_scope="client_model",
+        )
+        entries = _read_jsonl(logger.log_file)
+        d = entries[0]["details"]
+        assert d["resolution_source"] == "pinned_onboard_session"
+        assert d["pin_match_scope"] == "client_model"
+        assert d["token_iat"] is None
+        assert d["token_exp"] is None
+
+
+# ===========================================================================
 # AuditLogger.__init__ and internal flags
 # ===========================================================================
 class TestAuditLoggerInit:

--- a/tests/test_identity_handlers.py
+++ b/tests/test_identity_handlers.py
@@ -2001,6 +2001,42 @@ class TestHandleOnboardV2:
         assert data["is_new"] is True  # force_new_applied moved behind verbose=true
 
     @pytest.mark.asyncio
+    async def test_onboard_emits_identity_resolution_observed(
+        self, patch_onboard_deps, mock_db, mock_redis,
+    ):
+        """A successful onboard must emit one identity_resolution_observed audit event
+        carrying the resolved agent_uuid and the captured resolution_source."""
+        from src.mcp_handlers.identity.handlers import handle_onboard_v2
+
+        mock_redis.get.return_value = None
+        mock_db.get_session.return_value = None
+        mock_db.find_agent_by_label.return_value = None
+        mock_db.get_identity.return_value = SimpleNamespace(identity_id="new-ident", metadata={})
+
+        with patch(
+            "src.audit_log.audit_logger.log_identity_resolution_observed",
+        ) as audit_call:
+            result = await handle_onboard_v2({
+                "client_session_id": "onboard-emit-ires",
+                "force_new": True,
+            })
+        data = parse_result(result)
+
+        assert data["success"] is True
+        audit_call.assert_called_once()
+        kwargs = audit_call.call_args.kwargs
+        assert kwargs["agent_uuid"] == data["uuid"]
+        assert "resolution_source" in kwargs
+        assert "pin_match_scope" in kwargs
+        assert "pin_entry_present" in kwargs
+        assert "token_iat" in kwargs
+        assert "token_exp" in kwargs
+        # No continuity_token presented → token fields stay None.
+        assert kwargs["token_iat"] is None
+        assert kwargs["token_exp"] is None
+        assert kwargs["token_age_seconds"] is None
+
+    @pytest.mark.asyncio
     async def test_onboard_force_new_with_model_type(self, patch_onboard_deps, mock_db, mock_redis):
         """onboard(force_new=true, model_type='claude') uses model-suffixed key."""
         from src.mcp_handlers.identity.handlers import handle_onboard_v2

--- a/tests/test_identity_helpers.py
+++ b/tests/test_identity_helpers.py
@@ -20,6 +20,11 @@ from src.mcp_handlers.identity.handlers import (
     create_continuity_token,
     resolve_continuity_token,
 )
+from src.mcp_handlers.identity.session import (
+    extract_token_iat,
+    extract_token_exp,
+    _decode_token_payload,
+)
 
 
 # ============================================================================
@@ -225,3 +230,91 @@ class TestContinuityToken:
                 client_hint="claude_desktop",
             )
             assert resolve_continuity_token(token, model_type="gpt-5-codex") is None
+
+
+class TestTokenPayloadAccessors:
+    """`_decode_token_payload`, `extract_token_iat`, `extract_token_exp` share a single
+    HMAC verification — these tests pin both the shared shape and the per-claim accessors.
+    """
+
+    AGENT_UUID = "11111111-2222-3333-4444-555555555555"
+    SESSION_ID = "agent-decode-test:claude"
+
+    def _make_token(self):
+        return create_continuity_token(
+            self.AGENT_UUID,
+            self.SESSION_ID,
+            model_type="claude-opus-4-5",
+            client_hint="claude_desktop",
+        )
+
+    def test_decode_payload_returns_full_dict(self):
+        with patch.dict("os.environ", {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-secret"}, clear=False):
+            token = self._make_token()
+            payload = _decode_token_payload(token)
+            assert isinstance(payload, dict)
+            assert payload["aid"] == self.AGENT_UUID
+            assert payload["sid"] == self.SESSION_ID
+            assert isinstance(payload["iat"], int)
+            assert isinstance(payload["exp"], int)
+            assert payload["exp"] > payload["iat"]
+
+    def test_decode_payload_rejects_bad_signature(self):
+        with patch.dict("os.environ", {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-secret"}, clear=False):
+            token = self._make_token()
+            assert token is not None
+            tampered = token[:-4] + ("AAAA" if not token.endswith("AAAA") else "BBBB")
+            assert _decode_token_payload(tampered) is None
+
+    def test_decode_payload_rejects_wrong_version(self):
+        with patch.dict("os.environ", {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-secret"}, clear=False):
+            token = self._make_token()
+            assert token is not None
+            _, payload_b64, sig_b64 = token.split(".", 2)
+            forged = f"v9.{payload_b64}.{sig_b64}"
+            assert _decode_token_payload(forged) is None
+
+    def test_decode_payload_returns_none_without_secret(self):
+        with patch.dict("os.environ", {}, clear=True):
+            assert _decode_token_payload("v1.aaa.bbb") is None
+
+    def test_extract_iat_matches_decode(self):
+        with patch.dict("os.environ", {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-secret"}, clear=False):
+            token = self._make_token()
+            payload = _decode_token_payload(token)
+            assert extract_token_iat(token) == payload["iat"]
+
+    def test_extract_exp_matches_decode(self):
+        with patch.dict("os.environ", {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-secret"}, clear=False):
+            token = self._make_token()
+            payload = _decode_token_payload(token)
+            assert extract_token_exp(token) == payload["exp"]
+
+    def test_extract_exp_does_not_check_expiry(self):
+        """Symmetric with extract_token_iat: returns exp claim even on expired tokens
+        so callers can compute lifetime/observed-staleness telemetry."""
+        with patch.dict("os.environ", {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-secret"}, clear=False):
+            token = create_continuity_token(
+                self.AGENT_UUID,
+                self.SESSION_ID,
+                model_type="claude-opus-4-5",
+                ttl_seconds=60,
+            )
+            assert resolve_continuity_token(token, model_type="claude-opus-4-5") == self.SESSION_ID
+            # Past the exp boundary, resolve_continuity_token rejects but exp accessor still reports.
+            import time
+            with patch("src.mcp_handlers.identity.session.time.time", return_value=time.time() + 3600):
+                assert resolve_continuity_token(token, model_type="claude-opus-4-5") is None
+                assert extract_token_exp(token) is not None
+
+    def test_extract_iat_returns_none_for_garbage(self):
+        with patch.dict("os.environ", {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-secret"}, clear=False):
+            assert extract_token_iat("not-a-token") is None
+            assert extract_token_iat("") is None
+            assert extract_token_iat(None) is None  # type: ignore[arg-type]
+
+    def test_extract_exp_returns_none_for_garbage(self):
+        with patch.dict("os.environ", {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-secret"}, clear=False):
+            assert extract_token_exp("not-a-token") is None
+            assert extract_token_exp("") is None
+            assert extract_token_exp(None) is None  # type: ignore[arg-type]

--- a/tests/test_identity_session.py
+++ b/tests/test_identity_session.py
@@ -360,6 +360,336 @@ class TestUnifiedDeriveSessionKey:
         assert result == "agent-scoped123"
 
     @pytest.mark.asyncio
+    async def test_pin_scope_recorded_client_model(self):
+        """When the most-specific (client+model) candidate matches, scope is `client_model`."""
+        from src.mcp_handlers.identity.handlers import derive_session_key
+        from src.mcp_handlers.context import SessionSignals, get_pin_match_scope, set_pin_match_scope
+
+        set_pin_match_scope(None)
+        signals = SessionSignals(
+            ip_ua_fingerprint="1.2.3.4:abc123",
+            client_hint="chatgpt",
+            user_agent="Codex/CLI",
+        )
+
+        async def lookup_side_effect(key, refresh_ttl=True):
+            return "agent-cm123" if key == "ua:abc123|chatgpt|gpt" else None
+
+        with patch(
+            "src.mcp_handlers.identity.session.lookup_onboard_pin",
+            new_callable=AsyncMock,
+            side_effect=lookup_side_effect,
+        ):
+            await derive_session_key(signals, {"model_type": "gpt-5-codex"})
+
+        assert get_pin_match_scope() == "client_model"
+
+    @pytest.mark.asyncio
+    async def test_pin_scope_recorded_client_only(self):
+        """When the client-only candidate matches (model fallback), scope is `client`."""
+        from src.mcp_handlers.identity.handlers import derive_session_key
+        from src.mcp_handlers.context import SessionSignals, get_pin_match_scope, set_pin_match_scope
+
+        set_pin_match_scope(None)
+        signals = SessionSignals(
+            ip_ua_fingerprint="1.2.3.4:abc123",
+            client_hint="chatgpt",
+            user_agent="Codex/CLI",
+        )
+
+        async def lookup_side_effect(key, refresh_ttl=True):
+            return "agent-c123" if key == "ua:abc123|chatgpt" else None
+
+        with patch(
+            "src.mcp_handlers.identity.session.lookup_onboard_pin",
+            new_callable=AsyncMock,
+            side_effect=lookup_side_effect,
+        ):
+            await derive_session_key(signals, {"model_type": "gpt-5-codex"})
+
+        assert get_pin_match_scope() == "client"
+
+    @pytest.mark.asyncio
+    async def test_pin_scope_recorded_unscoped(self):
+        """Unscoped fallback match (no hint, no model) records `unscoped`."""
+        from src.mcp_handlers.identity.handlers import derive_session_key
+        from src.mcp_handlers.context import SessionSignals, get_pin_match_scope, set_pin_match_scope
+
+        set_pin_match_scope(None)
+        signals = SessionSignals(ip_ua_fingerprint="1.2.3.4:abc123")
+
+        async def lookup_side_effect(key, refresh_ttl=True):
+            return "agent-u123" if key == "ua:abc123" else None
+
+        with patch(
+            "src.mcp_handlers.identity.session.lookup_onboard_pin",
+            new_callable=AsyncMock,
+            side_effect=lookup_side_effect,
+        ):
+            await derive_session_key(signals, {})
+
+        assert get_pin_match_scope() == "unscoped"
+
+    @pytest.mark.asyncio
+    async def test_pin_scope_unset_when_pin_misses(self):
+        """When no pin matches, the scope contextvar is left at its default (None)."""
+        from src.mcp_handlers.identity.handlers import derive_session_key
+        from src.mcp_handlers.context import SessionSignals, get_pin_match_scope, set_pin_match_scope
+
+        set_pin_match_scope(None)
+        signals = SessionSignals(ip_ua_fingerprint="1.2.3.4:abc123")
+
+        with patch(
+            "src.mcp_handlers.identity.session.lookup_onboard_pin",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            await derive_session_key(signals, {})
+
+        assert get_pin_match_scope() is None
+
+    @pytest.mark.asyncio
+    async def test_shadow_lookup_runs_when_continuity_token_wins(self):
+        """When continuity_token wins but a fingerprint signal exists, the shadow
+        lookup runs and reports whether a pin would have been viable."""
+        from src.mcp_handlers.identity.handlers import derive_session_key, create_continuity_token
+        from src.mcp_handlers.context import (
+            SessionSignals,
+            get_shadow_pin_observation,
+            set_shadow_pin_observation,
+        )
+
+        set_shadow_pin_observation(present=None, match=None, age_seconds=None)
+
+        with patch.dict("os.environ", {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-secret"}, clear=False):
+            token = create_continuity_token(
+                "11111111-2222-3333-4444-555555555555",
+                "agent-shadow-test:claude",
+                model_type="claude-opus-4-7",
+            )
+            signals = SessionSignals(
+                ip_ua_fingerprint="1.2.3.4:abc123",
+                user_agent="claude-cli/1",
+            )
+
+            mock_redis_client = AsyncMock()
+            mock_redis_client.get = AsyncMock(return_value='{"client_session_id": "agent-shadow-test:claude"}')
+            mock_redis_client.ttl = AsyncMock(return_value=1500)
+
+            with patch(
+                "src.cache.redis_client.get_redis",
+                new_callable=AsyncMock,
+                return_value=mock_redis_client,
+            ):
+                result = await derive_session_key(
+                    signals,
+                    {"continuity_token": token, "model_type": "claude-opus-4-7"},
+                )
+
+        assert result == "agent-shadow-test:claude"
+        obs = get_shadow_pin_observation()
+        assert obs["pin_entry_present"] is True
+        assert obs["pin_fingerprint_match"] is True
+        # _PIN_TTL is 1800; ttl_remaining 1500 → age 300
+        assert obs["pin_entry_age_seconds"] == 300
+
+    @pytest.mark.asyncio
+    async def test_shadow_lookup_records_mismatch(self):
+        """A pin that exists but points to a different identity records match=False."""
+        from src.mcp_handlers.identity.handlers import derive_session_key, create_continuity_token
+        from src.mcp_handlers.context import (
+            SessionSignals,
+            get_shadow_pin_observation,
+            set_shadow_pin_observation,
+        )
+
+        set_shadow_pin_observation(present=None, match=None, age_seconds=None)
+
+        with patch.dict("os.environ", {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-secret"}, clear=False):
+            token = create_continuity_token(
+                "11111111-2222-3333-4444-555555555555",
+                "agent-A:claude",
+                model_type="claude-opus-4-7",
+            )
+            signals = SessionSignals(ip_ua_fingerprint="1.2.3.4:abc123", user_agent="claude-cli/1")
+
+            mock_redis_client = AsyncMock()
+            mock_redis_client.get = AsyncMock(return_value='{"client_session_id": "agent-B:codex"}')
+            mock_redis_client.ttl = AsyncMock(return_value=900)
+
+            with patch(
+                "src.cache.redis_client.get_redis",
+                new_callable=AsyncMock,
+                return_value=mock_redis_client,
+            ):
+                await derive_session_key(
+                    signals,
+                    {"continuity_token": token, "model_type": "claude-opus-4-7"},
+                )
+
+        obs = get_shadow_pin_observation()
+        assert obs["pin_entry_present"] is True
+        assert obs["pin_fingerprint_match"] is False
+        assert obs["pin_entry_age_seconds"] == 900  # 1800 - 900
+
+    @pytest.mark.asyncio
+    async def test_shadow_lookup_records_absent(self):
+        """When no pin exists, present=False / match=False / age=None."""
+        from src.mcp_handlers.identity.handlers import derive_session_key, create_continuity_token
+        from src.mcp_handlers.context import (
+            SessionSignals,
+            get_shadow_pin_observation,
+            set_shadow_pin_observation,
+        )
+
+        set_shadow_pin_observation(present=None, match=None, age_seconds=None)
+
+        with patch.dict("os.environ", {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-secret"}, clear=False):
+            token = create_continuity_token(
+                "11111111-2222-3333-4444-555555555555",
+                "agent-A:claude",
+                model_type="claude-opus-4-7",
+            )
+            signals = SessionSignals(ip_ua_fingerprint="1.2.3.4:abc123", user_agent="claude-cli/1")
+
+            mock_redis_client = AsyncMock()
+            mock_redis_client.get = AsyncMock(return_value=None)
+
+            with patch(
+                "src.cache.redis_client.get_redis",
+                new_callable=AsyncMock,
+                return_value=mock_redis_client,
+            ):
+                await derive_session_key(
+                    signals,
+                    {"continuity_token": token, "model_type": "claude-opus-4-7"},
+                )
+
+        obs = get_shadow_pin_observation()
+        assert obs["pin_entry_present"] is False
+        assert obs["pin_fingerprint_match"] is False
+        assert obs["pin_entry_age_seconds"] is None
+
+    @pytest.mark.asyncio
+    async def test_shadow_lookup_skipped_when_pin_won(self):
+        """If PATH 7 already won, the shadow lookup must NOT run — we already know the answer."""
+        from src.mcp_handlers.identity.handlers import derive_session_key
+        from src.mcp_handlers.context import SessionSignals, set_shadow_pin_observation, get_shadow_pin_observation
+
+        set_shadow_pin_observation(present=None, match=None, age_seconds=None)
+
+        signals = SessionSignals(ip_ua_fingerprint="1.2.3.4:abc123")
+        get_redis_mock = AsyncMock()  # would observe a call if shadow ran
+
+        with patch(
+            "src.mcp_handlers.identity.session.lookup_onboard_pin",
+            new_callable=AsyncMock,
+            return_value="agent-pin-won",
+        ), patch(
+            "src.cache.redis_client.get_redis",
+            new=get_redis_mock,
+        ):
+            result = await derive_session_key(signals, {})
+
+        assert result == "agent-pin-won"
+        get_redis_mock.assert_not_called()
+        obs = get_shadow_pin_observation()
+        # Shadow contextvars stay at the explicit None we set above.
+        assert obs == {"pin_entry_present": None, "pin_fingerprint_match": None, "pin_entry_age_seconds": None}
+
+    @pytest.mark.asyncio
+    async def test_shadow_lookup_skipped_when_pin_already_missed(self):
+        """If PATH 7 ran and missed (source=ip_ua_fingerprint), don't re-probe Redis."""
+        from src.mcp_handlers.identity.handlers import derive_session_key
+        from src.mcp_handlers.context import SessionSignals, set_shadow_pin_observation, get_shadow_pin_observation
+
+        set_shadow_pin_observation(present=None, match=None, age_seconds=None)
+
+        signals = SessionSignals(ip_ua_fingerprint="1.2.3.4:abc123")
+        get_redis_mock = AsyncMock()
+
+        with patch(
+            "src.mcp_handlers.identity.session.lookup_onboard_pin",
+            new_callable=AsyncMock,
+            return_value=None,
+        ), patch(
+            "src.cache.redis_client.get_redis",
+            new=get_redis_mock,
+        ):
+            await derive_session_key(signals, {})
+
+        get_redis_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_shadow_lookup_skipped_without_fingerprint(self):
+        """No IP/UA fingerprint signal → no shadow lookup."""
+        from src.mcp_handlers.identity.handlers import derive_session_key
+        from src.mcp_handlers.context import SessionSignals, set_shadow_pin_observation, get_shadow_pin_observation
+
+        set_shadow_pin_observation(present=None, match=None, age_seconds=None)
+
+        signals = SessionSignals(mcp_session_id="mcp-stable-1")
+        get_redis_mock = AsyncMock()
+
+        with patch("src.cache.redis_client.get_redis", new=get_redis_mock):
+            await derive_session_key(signals, {})
+
+        get_redis_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_shadow_lookup_failure_is_non_fatal(self):
+        """Redis exception inside shadow must not break resolution."""
+        from src.mcp_handlers.identity.handlers import derive_session_key, create_continuity_token
+        from src.mcp_handlers.context import SessionSignals
+
+        with patch.dict("os.environ", {"UNITARES_CONTINUITY_TOKEN_SECRET": "test-secret"}, clear=False):
+            token = create_continuity_token(
+                "11111111-2222-3333-4444-555555555555",
+                "agent-A:claude",
+                model_type="claude-opus-4-7",
+            )
+            signals = SessionSignals(ip_ua_fingerprint="1.2.3.4:abc123", user_agent="claude-cli/1")
+
+            failing = AsyncMock(side_effect=RuntimeError("redis exploded"))
+
+            with patch(
+                "src.cache.redis_client.get_redis",
+                new=failing,
+            ):
+                result = await derive_session_key(
+                    signals,
+                    {"continuity_token": token, "model_type": "claude-opus-4-7"},
+                )
+
+        assert result == "agent-A:claude"
+
+    @pytest.mark.asyncio
+    async def test_pin_match_does_not_split_resolution_source(self):
+        """Splitting `pinned_onboard_session` into prefixed forms would silently
+        bypass the gate at handlers.py:128. Pin scope is a side-channel ONLY;
+        the resolution source string stays exact-match."""
+        from src.mcp_handlers.identity.handlers import derive_session_key
+        from src.mcp_handlers.context import SessionSignals, get_session_resolution_source
+
+        signals = SessionSignals(
+            ip_ua_fingerprint="1.2.3.4:abc123",
+            client_hint="chatgpt",
+            user_agent="Codex/CLI",
+        )
+
+        async def lookup_side_effect(key, refresh_ttl=True):
+            return "agent-x" if key == "ua:abc123|chatgpt|gpt" else None
+
+        with patch(
+            "src.mcp_handlers.identity.session.lookup_onboard_pin",
+            new_callable=AsyncMock,
+            side_effect=lookup_side_effect,
+        ):
+            await derive_session_key(signals, {"model_type": "gpt-5-codex"})
+
+        assert get_session_resolution_source() == "pinned_onboard_session"
+
+    @pytest.mark.asyncio
     async def test_priority_6_scoped_pin_does_not_fallback_to_unscoped(self):
         """When scoped signals exist, unscoped pin fallback is intentionally skipped."""
         from src.mcp_handlers.identity.handlers import derive_session_key


### PR DESCRIPTION
## Summary

Audit-log-based observability so we can later answer **"is the 30-min sliding onboard pin TTL bleeding into continuity-token-only resumes between minutes 30–60?"** without changing resolution behavior.

The original question came up while reviewing identity-continuity TTLs. Council review (general-purpose verifier + feature-dev:code-reviewer + dialectic-knowledge-architect) before writing code surfaced three must-changes that are folded in: don't make ``_mark`` an accumulator (emit from onboard handler instead); don't split the load-bearing ``pinned_onboard_session`` source string (use a side-channel contextvar instead); add observation-only shadow pin lookup so the resulting data can discriminate the masking hypothesis from "pin expired" vs "pin alive but bypassed."

## Changes

- **``_decode_token_payload``** helper: single HMAC verification shared by the iat/exp accessors. ``extract_token_iat`` refactored to use it.
- **``extract_token_exp``** accessor symmetric with ``extract_token_iat``; no expiry check, so observation can record token lifetime even on tokens resolution rejected.
- **``_pin_match_scope`` contextvar** (``client_model`` | ``client`` | ``model`` | ``unscoped``) — side-channel only. ``pinned_onboard_session`` source string left exact-match so the fail-closed gate at ``handlers.py:128`` is unaffected.
- **Shadow pin lookup** at end of ``derive_session_key``, gated to ``source not in {pinned_onboard_session, ip_ua_fingerprint}`` AND ip_ua_fingerprint signal present. Observation-only, no TTL refresh, bound by ``_PIN_REDIS_TIMEOUT``, failure leaves contextvars at ``None``.
- **``audit_logger.log_identity_resolution_observed``** — kw-only, fields ``resolution_source`` / ``pin_match_scope`` / ``pin_entry_present`` / ``pin_fingerprint_match`` / ``pin_entry_age_seconds`` / ``token_iat`` / ``token_exp`` / ``token_age_seconds`` / ``agent_uuid_resolved``.
- Single emission point in ``handle_onboard_v2`` after the ``[ONBOARD]`` success log; non-fatal try/except mirrors the S1-a deprecation block above.
- ``AuditEntry.agent_id`` typed ``Optional[str]`` (already accepted ``None`` via ``log_concurrent_session_binding_observed``).

## Out of scope

- No TTL changes, no pin-key construction changes, no behavior change.
- No metrics catalog / Chronicler series — audit-log SQL is enough for a one-week analysis.
- No dashboard panel.

## Known

- Sync ``fcntl.flock`` + ``fsync`` in ``_write_entry`` is an event-loop latency risk shared with existing audit writes; not addressed here. New event fires once per onboard.

## Test plan

- [x] 17 new tests (decode helper / extract_exp / pin scope per candidate / shadow lookup gating + non-interference / audit event shape / onboard emission integration)
- [x] Full suite: 7523 passed, 33 skipped, 0 failures, 77.87% coverage
- [ ] After merge + ~7 days production traffic: query ``audit_log`` for ``identity_resolution_observed`` and analyze the source × pin-shadow distribution to evaluate the masking hypothesis