### PR TITLE
fix(observe+resume): persist runtime state — paused_at, decision/verdict history

### DIFF
--- a/src/agent_monitor_state.py
+++ b/src/agent_monitor_state.py
@@ -295,6 +295,20 @@ async def hydrate_from_db_if_fresh(monitor: UNITARESMonitor, agent_id: str) -> b
         monitor.state.coherence_history = [float(r.coherence) for r in chrono]
         monitor.state.regime_history = [str(r.regime) for r in chrono]
 
+        # decision_history rebuilt from state_json.action when present.
+        # Rows written before record_agent_state's `action` parameter shipped
+        # carry no action key — those rows are skipped, preserving a partial
+        # replay rather than padding with placeholders. Pre-action-write rows
+        # leave decision_history empty until the next live process_update
+        # populates it, which observe surfaces as zero counts.
+        actions: list[str] = []
+        for r in chrono:
+            sj = getattr(r, "state_json", None) or {}
+            action = sj.get("action") if isinstance(sj, dict) else None
+            if isinstance(action, str) and action:
+                actions.append(action)
+        monitor.state.decision_history = actions
+
         # update_count gates the "uninitialized" display. Using len(chrono) is
         # a floor (true count may be higher — we only fetched 50); that's fine
         # since the gate is >0, and downstream consumers of update_count treat

--- a/src/agent_monitor_state.py
+++ b/src/agent_monitor_state.py
@@ -301,13 +301,21 @@ async def hydrate_from_db_if_fresh(monitor: UNITARESMonitor, agent_id: str) -> b
         # replay rather than padding with placeholders. Pre-action-write rows
         # leave decision_history empty until the next live process_update
         # populates it, which observe surfaces as zero counts.
+        # verdict_history rebuilt from state_json.verdict — that key has been
+        # persisted since long before this change, so legacy rows DO replay.
         actions: list[str] = []
+        verdicts: list[str] = []
         for r in chrono:
             sj = getattr(r, "state_json", None) or {}
-            action = sj.get("action") if isinstance(sj, dict) else None
-            if isinstance(action, str) and action:
-                actions.append(action)
+            if isinstance(sj, dict):
+                action = sj.get("action")
+                if isinstance(action, str) and action:
+                    actions.append(action)
+                verdict = sj.get("verdict")
+                if isinstance(verdict, str) and verdict:
+                    verdicts.append(verdict)
         monitor.state.decision_history = actions
+        monitor.state.verdict_history = verdicts
 
         # update_count gates the "uninitialized" display. Using len(chrono) is
         # a floor (true count may be higher — we only fetched 50); that's fine

--- a/src/agent_storage.py
+++ b/src/agent_storage.py
@@ -510,9 +510,17 @@ async def record_agent_state(
     risk_score: Optional[float] = None,
     phi: Optional[float] = None,
     verdict: Optional[str] = None,
+    action: Optional[str] = None,
 ) -> int:
     """
     Record agent EISV state to PostgreSQL.
+
+    `action` is the governance decision sub_action / action vocabulary
+    ('proceed' | 'pause' | 'approve' | 'reflect' | 'revise' | 'reject') —
+    distinct from `verdict` ('safe' | 'caution' | 'high-risk') which is the
+    EISV verdict tier. Both are persisted into state_json; hydrate_from_db
+    uses `action` to reconstruct decision_history so observe summary's
+    decision_distribution survives a JSON-snapshot loss.
 
     Returns the state_id of the created record.
     """
@@ -542,6 +550,8 @@ async def record_agent_state(
         state_json["phi"] = phi
     if verdict is not None:
         state_json["verdict"] = verdict
+    if action is not None:
+        state_json["action"] = action
 
     state_id = await db.record_agent_state(
         identity_id=identity.identity_id,

--- a/src/governance_monitor.py
+++ b/src/governance_monitor.py
@@ -989,6 +989,15 @@ class UNITARESMonitor:
         self.state.decision_history.append(decision.get('sub_action', decision['action']))
         if len(self.state.decision_history) > config.HISTORY_WINDOW:
             self.state.decision_history = self.state.decision_history[-config.HISTORY_WINDOW:]
+
+        # Track verdict tier history (safe/caution/high-risk) — separate vocabulary
+        # from decision_history's actions; both surface in observe summary so users
+        # see governance verdicts even on agents whose only persisted history is
+        # core.agent_state (DB-hydrated post PR #200).
+        if isinstance(unitares_verdict, str) and unitares_verdict:
+            self.state.verdict_history.append(unitares_verdict)
+            if len(self.state.verdict_history) > config.HISTORY_WINDOW:
+                self.state.verdict_history = self.state.verdict_history[-config.HISTORY_WINDOW:]
         
         # Determine overall status using health thresholds (aligned with health_checker)
         # Use same thresholds as health_checker for consistency: risk_healthy_max=0.35, risk_moderate_max=0.60

--- a/src/governance_state.py
+++ b/src/governance_state.py
@@ -54,6 +54,7 @@ class GovernanceState:
     coherence_history: List[float] = field(default_factory=list)
     risk_history: List[float] = field(default_factory=list)
     decision_history: List[str] = field(default_factory=list)  # Track approve/reflect/reject decisions
+    verdict_history: List[str] = field(default_factory=list)  # Track safe/caution/high-risk EISV verdict tier
     timestamp_history: List[str] = field(default_factory=list)  # Track timestamps for each update
     lambda1_history: List[float] = field(default_factory=list)  # Track lambda1 adaptation over time
     
@@ -168,6 +169,7 @@ class GovernanceState:
             'risk_history': [float(r) for r in cap_history(self.risk_history)],
             'lambda1_history': [float(l) for l in cap_history(getattr(self, 'lambda1_history', []))],  # Lambda1 adaptation history
             'decision_history': list(cap_history(self.decision_history)),
+            'verdict_history': list(cap_history(self.verdict_history)),
             'timestamp_history': list(cap_history(self.timestamp_history)),  # Timestamps for each update
             'pi_integral': float(getattr(self, 'pi_integral', 0.0)),  # PI controller integral state
             # HCK v3.0 metrics
@@ -245,6 +247,7 @@ class GovernanceState:
         state.coherence_history = [float(c) for c in data.get('coherence_history', [])]
         state.risk_history = [float(r) for r in data.get('risk_history', [])]
         state.decision_history = list(data.get('decision_history', []))
+        state.verdict_history = list(data.get('verdict_history', []))
         state.timestamp_history = list(data.get('timestamp_history', []))  # Load timestamps
         state.lambda1_history = [float(l) for l in data.get('lambda1_history', [])]  # Load lambda1 history
         

--- a/src/mcp_handlers/lifecycle/resume.py
+++ b/src/mcp_handlers/lifecycle/resume.py
@@ -4,6 +4,7 @@ Direct resume handler (deprecated).
 Extracted from lifecycle.py for maintainability.
 """
 
+from datetime import datetime, timezone
 from typing import Dict, Any, Sequence
 
 from mcp.types import TextContent
@@ -102,20 +103,40 @@ async def handle_direct_resume_if_safe(arguments: Dict[str, Any]) -> Sequence[Te
     # Get conditions if provided
     conditions = arguments.get("conditions", [])
     reason = arguments.get("reason", "Direct resume - state is safe")
+    event_details = f"Direct resume: {reason}. Conditions: {conditions}"
+    event_entry = {
+        "event": "resumed",
+        "reason": event_details,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
 
-    # Resume agent
+    # Persist FIRST so in-memory state can't diverge from DB on persist failure.
+    # Runtime state (paused_at, lifecycle_events) must be persisted alongside
+    # status or it gets clobbered on the next load_metadata_async(force=True).
+    try:
+        await agent_storage.update_agent(agent_uuid, status="active")
+        await agent_storage.persist_runtime_state(
+            agent_uuid,
+            paused_at=None,
+            loop_detected_at=None,
+            loop_cooldown_until=None,
+            append_lifecycle_event=event_entry,
+        )
+    except Exception as e:
+        logger.warning(f"PostgreSQL update failed for direct_resume: {e}", exc_info=True)
+        return [error_response(
+            f"Failed to resume agent '{agent_id}': persistence error",
+            error_code="PERSIST_FAILED",
+            error_category="system_error",
+            details={"agent_id": agent_id, "cause": str(e)},
+        )]
+
+    # Persist succeeded — now mutate in-memory state.
     meta.status = "active"
     meta.paused_at = None
-    # Clear loop detector state to prevent immediate re-pause
     from .self_recovery import clear_loop_detector_state
     clear_loop_detector_state(meta)
-    meta.add_lifecycle_event("resumed", f"Direct resume: {reason}. Conditions: {conditions}")
-
-    # PostgreSQL: Update status (single source of truth)
-    try:
-        await agent_storage.update_agent(agent_id, status="active")
-    except Exception as e:
-        logger.debug(f"PostgreSQL status update failed: {e}")
+    meta.add_lifecycle_event("resumed", event_details)
 
     response_data = {
         "success": True,

--- a/src/mcp_handlers/observability/handlers.py
+++ b/src/mcp_handlers/observability/handlers.py
@@ -428,12 +428,15 @@ async def handle_compare_me_to_similar(arguments: Dict[str, Any]) -> Sequence[Te
     if most_common_verdict and verdict_counts[most_common_verdict] == len(all_verdicts):
         pattern_insights.append(f"All similar agents share '{most_common_verdict}' verdict - this is a common pattern")
     
-    # Check for regime patterns (if regime available)
+    # Check for regime patterns. The similarity loop above already
+    # hydrated each candidate's monitor via ensure_hydrated; reuse from
+    # mcp_server.monitors instead of re-hydrating.
     all_regimes = []
     for similar in top_similar:
         try:
-            other_monitor = mcp_server.get_or_create_monitor(similar["agent_id"])
-            await ensure_hydrated(other_monitor, similar["agent_id"])
+            other_monitor = mcp_server.monitors.get(similar["agent_id"])
+            if other_monitor is None:
+                continue
             other_metrics = other_monitor.get_metrics()
             regime = other_metrics.get('regime', 'nominal')
             all_regimes.append(regime)

--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -1002,6 +1002,8 @@ async def execute_post_update_effects(ctx: UpdateContext) -> None:
             risk_score=ctx.risk_score,
             phi=ctx.metrics_dict.get('phi', 0.0),
             verdict=ctx.metrics_dict.get('verdict', 'continue'),
+            action=(ctx.result.get('decision') or {}).get('sub_action')
+                or (ctx.result.get('decision') or {}).get('action'),
         )
         logger.debug(f"PostgreSQL: Recorded state for {agent_id}")
     except ValueError:
@@ -1024,6 +1026,8 @@ async def execute_post_update_effects(ctx: UpdateContext) -> None:
                 risk_score=ctx.risk_score,
                 phi=ctx.metrics_dict.get('phi', 0.0),
                 verdict=ctx.metrics_dict.get('verdict', 'continue'),
+                action=(ctx.result.get('decision') or {}).get('sub_action')
+                    or (ctx.result.get('decision') or {}).get('action'),
             )
             logger.debug(f"PostgreSQL: Created agent and recorded state for {agent_id}")
         except Exception as create_error:

--- a/src/pattern_analysis.py
+++ b/src/pattern_analysis.py
@@ -195,6 +195,12 @@ def analyze_agent_patterns(
     # Summary statistics
     decision_history = getattr(state, 'decision_history', [])
     decision_counts = Counter(decision_history)
+    # verdict_history (safe/caution/high-risk) is a separate vocabulary from
+    # decision_history (proceed/pause/...) — both surfaced so DB-hydrated
+    # agents whose state_json rows lack the (newer) action key still expose a
+    # non-empty governance signal via verdict_distribution.
+    verdict_history = getattr(state, 'verdict_history', [])
+    verdict_counts = Counter(verdict_history)
 
     summary = {
         "total_updates": state.update_count,
@@ -206,8 +212,14 @@ def analyze_agent_patterns(
             # Backward compatibility
             "approve": decision_counts.get("approve", 0),
             "reflect": decision_counts.get("reflect", 0) + decision_counts.get("revise", 0),
-            "reject": decision_counts.get("reject", 0)
-        }
+            "reject": decision_counts.get("reject", 0),
+        },
+        "verdict_distribution": {
+            "safe": verdict_counts.get("safe", 0),
+            "caution": verdict_counts.get("caution", 0),
+            "high-risk": verdict_counts.get("high-risk", 0),
+            "total": sum(verdict_counts.values()),
+        },
     }
 
     result = {

--- a/tests/test_monitor_hydration.py
+++ b/tests/test_monitor_hydration.py
@@ -144,6 +144,8 @@ async def test_hydrate_rebuilds_decision_history_from_state_json_action():
     assert applied is True
     # Chronological (oldest → newest)
     assert monitor.state.decision_history == ["proceed", "reflect", "proceed"]
+    # verdict_history hydrated from the same rows
+    assert monitor.state.verdict_history == ["safe", "caution", "safe"]
 
 
 @pytest.mark.asyncio
@@ -173,6 +175,10 @@ async def test_hydrate_skips_legacy_rows_missing_action_key():
 
     assert applied is True
     assert monitor.state.decision_history == []
+    # verdict_history DOES populate from legacy rows — the verdict key
+    # has been persisted since long before the action-write change, so
+    # observe summary still surfaces a non-empty verdict_distribution.
+    assert monitor.state.verdict_history == ["caution", "safe"]
     # Histories that should populate still do
     assert monitor.state.regime_history == ["CONVERGENCE", "DIVERGENCE"]
 

--- a/tests/test_monitor_hydration.py
+++ b/tests/test_monitor_hydration.py
@@ -34,13 +34,14 @@ from src.agent_monitor_state import (
 class _FakeStateRow:
     """Shape of AgentStateRecord returned by db.get_agent_state_history."""
 
-    def __init__(self, *, E, I, S, V, coherence, regime):
+    def __init__(self, *, E, I, S, V, coherence, regime, state_json=None):
         self.energy = E
         self.integrity = I
         self.entropy = S
         self.void = V
         self.coherence = coherence
         self.regime = regime
+        self.state_json = state_json or {}
 
 
 def _make_fresh_monitor(agent_id="test-agent"):
@@ -111,6 +112,100 @@ async def test_hydrate_from_db_if_fresh_returns_false_when_no_identity():
 
     assert applied is False
     assert monitor.state.update_count == 0
+
+
+@pytest.mark.asyncio
+async def test_hydrate_rebuilds_decision_history_from_state_json_action():
+    """state_json.action on each row → decision_history (chronological)."""
+    monitor = _make_fresh_monitor("hydrate-actions")
+    fake_identity = MagicMock(identity_id=7)
+    # Most-recent-first per DB DESC ordering.
+    fake_rows_desc = [
+        _FakeStateRow(
+            E=0.7, I=0.8, S=0.1, V=-0.05, coherence=0.55, regime="DIVERGENCE",
+            state_json={"action": "proceed", "verdict": "safe"},
+        ),
+        _FakeStateRow(
+            E=0.65, I=0.78, S=0.12, V=-0.03, coherence=0.52, regime="CONVERGENCE",
+            state_json={"action": "reflect", "verdict": "caution"},
+        ),
+        _FakeStateRow(
+            E=0.6, I=0.75, S=0.15, V=0.0, coherence=0.5, regime="EXPLORATION",
+            state_json={"action": "proceed", "verdict": "safe"},
+        ),
+    ]
+    fake_db = MagicMock()
+    fake_db.get_identity = AsyncMock(return_value=fake_identity)
+    fake_db.get_agent_state_history = AsyncMock(return_value=fake_rows_desc)
+
+    with patch("src.db.get_db", return_value=fake_db):
+        applied = await hydrate_from_db_if_fresh(monitor, "hydrate-actions")
+
+    assert applied is True
+    # Chronological (oldest → newest)
+    assert monitor.state.decision_history == ["proceed", "reflect", "proceed"]
+
+
+@pytest.mark.asyncio
+async def test_hydrate_skips_legacy_rows_missing_action_key():
+    """Pre-action-write rows leave decision_history empty rather than crashing
+    or polluting with verdict-vocabulary strings (the {safe,caution,high-risk}
+    domain that pattern_analysis.py:204 doesn't bucket)."""
+    monitor = _make_fresh_monitor("hydrate-legacy")
+    fake_identity = MagicMock(identity_id=8)
+    fake_rows_desc = [
+        # Legacy rows: only verdict, no action — must not be promoted to actions.
+        _FakeStateRow(
+            E=0.7, I=0.8, S=0.1, V=-0.05, coherence=0.55, regime="DIVERGENCE",
+            state_json={"verdict": "safe"},
+        ),
+        _FakeStateRow(
+            E=0.65, I=0.78, S=0.12, V=-0.03, coherence=0.52, regime="CONVERGENCE",
+            state_json={"verdict": "caution"},
+        ),
+    ]
+    fake_db = MagicMock()
+    fake_db.get_identity = AsyncMock(return_value=fake_identity)
+    fake_db.get_agent_state_history = AsyncMock(return_value=fake_rows_desc)
+
+    with patch("src.db.get_db", return_value=fake_db):
+        applied = await hydrate_from_db_if_fresh(monitor, "hydrate-legacy")
+
+    assert applied is True
+    assert monitor.state.decision_history == []
+    # Histories that should populate still do
+    assert monitor.state.regime_history == ["CONVERGENCE", "DIVERGENCE"]
+
+
+@pytest.mark.asyncio
+async def test_hydrate_partial_action_coverage_keeps_only_present_rows():
+    """Mixed legacy + new rows: only the rows with action are replayed."""
+    monitor = _make_fresh_monitor("hydrate-partial")
+    fake_identity = MagicMock(identity_id=9)
+    fake_rows_desc = [
+        _FakeStateRow(
+            E=0.7, I=0.8, S=0.1, V=-0.05, coherence=0.55, regime="DIVERGENCE",
+            state_json={"action": "pause", "verdict": "high-risk"},
+        ),
+        _FakeStateRow(  # legacy
+            E=0.65, I=0.78, S=0.12, V=-0.03, coherence=0.52, regime="CONVERGENCE",
+            state_json={"verdict": "caution"},
+        ),
+        _FakeStateRow(
+            E=0.6, I=0.75, S=0.15, V=0.0, coherence=0.5, regime="EXPLORATION",
+            state_json={"action": "proceed"},
+        ),
+    ]
+    fake_db = MagicMock()
+    fake_db.get_identity = AsyncMock(return_value=fake_identity)
+    fake_db.get_agent_state_history = AsyncMock(return_value=fake_rows_desc)
+
+    with patch("src.db.get_db", return_value=fake_db):
+        applied = await hydrate_from_db_if_fresh(monitor, "hydrate-partial")
+
+    assert applied is True
+    # Chronological — legacy row in the middle is skipped.
+    assert monitor.state.decision_history == ["proceed", "pause"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Bundle of 4 commits closing one watcher-cluster + one observability bug surfaced after PR #200 (#f13c39d, fleet-wide DB hydration).

| # | commit | what |
|---|---|---|
| 1 | 3a0de6b | `fix(resume)` apply persist-first pattern from `operations.py:80-109` to deprecated `direct_resume_if_safe`; `meta.paused_at` + lifecycle event were mutated in-memory but only `status` was persisted, so reload-from-DB clobbered the unstuck flag |
| 2 | 2a34f3b | `chore(observability)` drop redundant `get_or_create_monitor` + `ensure_hydrated` calls in `compare_me_to_similar`'s regime loop — the similarity loop above already hydrated those monitors, ensure_hydrated is idempotent (single-shot drain) |
| 3 | 533aa1a | `fix(observe)` persist decision sub_action into `state_json["action"]`; rebuild `decision_history` from it on hydrate. Fixes the ~99.7%-missing observed by a council verifier on agent `69a1a4f7` (104,513 total_updates, decision_distribution showing 166/166) |
| 4 | a326e87 | `feat(observe)` add `verdict_history` field + serialize it; hydrate from `state_json["verdict"]` (which legacy rows DO carry); surface `verdict_distribution` alongside `decision_distribution` in observe summary so the ~70% DB-hydrated fleet shows non-empty governance signal immediately |

## Watcher findings closed

Resolved (P011 mutation-before-persistence, all in resume.py):
- #84df3685 `meta.status = "active"`
- #70f44e81 `meta.paused_at = None`
- #ebf674d4 `meta.add_lifecycle_event("resumed", ...)`

Dismissed with reasons (false positives):
- #d35dc009 P003 core.py:163 — intentional simulation placeholder `_simulation_temp_`
- #4a77cbb0 P003 coherence.py:164 — frozen target_monitor for read-only similarity
- #fc0190b5 P011 governance_action.py:164 — `_get_governance_action` returns reference to in-memory buffer; mutation IS persistence
- #1fc2b59e P011 governance_action.py:172 — buffer reassignment is no-op (same reference)
- #e3c3f119 P016 export.py:64 — `history_data` is a plain history dict, no nested `.success` envelope to mask

## Verification

- Full suite: 7501 passed, 33 skipped, 0 failures (was 7498; +3 new hydration tests)
- New tests in `tests/test_monitor_hydration.py`:
  - `test_hydrate_rebuilds_decision_history_from_state_json_action` — covers go-forward replay
  - `test_hydrate_skips_legacy_rows_missing_action_key` — pre-fix rows leave decision_history empty (no vocabulary contamination), verdict_history populates
  - `test_hydrate_partial_action_coverage_keeps_only_present_rows` — mixed legacy/new rows preserve order
- Council reviewed: dialectic-knowledge-architect + feature-dev:code-reviewer + general-purpose live verifier (caught the verdict-vs-action vocabulary mismatch a one-shot read of the task wording would have missed)

## Test plan

- [ ] CI green
- [ ] After deploy: spot-check `observe(target_agent_id=<DB-hydrated agent>)` returns non-zero `verdict_distribution`
- [ ] After a few process_update cycles on a hydrated agent: `decision_distribution` starts populating from new rows

## Residual / follow-up

The 235k legacy `core.agent_state` rows have no `action` key. Their `decision_distribution` stays empty until the agent gets a new process_update; `verdict_distribution` populates immediately from the same rows.