### PR TITLE
docs: refined phase-5 evidence contract — spec + council reviews + implementation plan

### DIFF
--- a/docs/proposals/refined-phase-5-evidence-contract.code-review.md
+++ b/docs/proposals/refined-phase-5-evidence-contract.code-review.md
@@ -1,0 +1,81 @@
+# Code Review — Refined Phase-5 Evidence Contract
+
+**Reviewer:** `feature-dev:code-reviewer` subagent
+**Date:** 2026-04-26
+**Spec:** `refined-phase-5-evidence-contract.md`
+**Question framed:** B vs C — implementation cost, schema migration impact, identity safety, failure modes, fleet risk.
+
+> **Editorial note (post-review):** the reviewer cited `sequential_calibration.py`'s docstring claiming the prediction_id seam is "phase-two work." The live verifier proved the seam is implemented today. The docstring is stale; the spec includes a docstring fix.
+
+---
+
+## Design B — Structured Evidence Block in response_text
+
+### Schema cost
+Zero schema change. `ProcessAgentUpdateParams.response_text` is already `Optional[str]`. The tag is stripped during Phase 5 processing and never surfaces to the schema layer. One new pure function; no Pydantic migration.
+
+### Identity safety
+Confirmed safe. Phase 1 (`resolve_identity_and_guards`) calls `get_context_agent_id()` from the `contextvars`-backed `_session_context` ContextVar. That ContextVar is set once at ASGI dispatch entry and is live for the full asyncio task duration. The internal call to `outcome_event` happens in Phase 5 of the same task — same ContextVar scope, same `agent_uuid` binding. No path where the session drops between the regex parse and the `record_outcome_event` call.
+
+### Failure mode
+If the regex fails to match (malformed tag, partial truncation, encoding artifact), the block is silently absent and Phase 5 proceeds normally. That is the stated design. The risk is the silent-drop is invisible to the agent: no acknowledgment in the response, no error. If the agent uses this for calibration and the tag is silently malformed, it will believe it submitted evidence it did not. The existing Phase 5 auto-emit still fires independently based on keyword heuristics, so a failed block does not leave the update completely unevidenced — but the structured data (exit_code, command) is lost.
+
+### prediction_id lifecycle
+`outcome_events.py` lines 174-183 call `_m.consume_prediction(prediction_id)` on the monitor. The `sequential_calibration.py` docstring explicitly flags this as a known gap: "No prediction_id seam yet... A prediction_id seam is phase-two work." This means `register_prediction` is not fully implemented on the write path — prediction_ids are not yet returned from `process_agent_update` responses. **[Editorial: stale — verifier confirmed end-to-end mint→consume works in `response_mode="full"`. The seam exists; observability of misuse is the actual gap.]**
+
+### Test surface
+The regex parser is a pure synchronous function with a well-defined input domain (a string). Easy to property-test: generate strings with valid/invalid/partial/nested tags, assert parse result. No DB or monitor mocks needed. High unit-testability.
+
+### Migration risk
+Zero. All existing agents send `response_text` strings. Unknown text is ignored. Vigil, Sentinel, Watcher, Steward, Chronicler, Lumen — all no-op without modification.
+
+---
+
+## Design C — Tool-Call Introspection Field
+
+### Schema cost
+Requires adding `recent_tool_results: Optional[List[...]]` to `ProcessAgentUpdateParams`. The nested-list item type needs either a nested `BaseModel` or a `Dict[str, Any]`. Looking at existing patterns in `core.py`: the `detail` field in `OutcomeEventParams` is `Optional[Dict[str, Any]]`; the existing flatten-to-dict pattern in handlers uses `arguments.get(key)` directly. A `List[Dict]` can be extracted with `arguments.get("recent_tool_results") or []` without issue. However, Pydantic v2 with `model_config = ConfigDict(extra="forbid")` is on `BootstrapStateParams` but not explicitly on `ProcessAgentUpdateParams` — adding the field is safe. The schema migration itself is low risk; the migration burden is on clients.
+
+### Identity safety
+Same ContextVar guarantee as Design B — the list is processed in Phase 5 of the same task. Identity is safe.
+
+### Failure mode
+If `arguments.get("recent_tool_results")` returns a list with a malformed item (missing `tool` key, non-int `exit_code`, etc.), a `try/except` around the per-item processing is required. Without it, one bad item aborts the whole list. If the exception propagates past Phase 5's outer `try/except` (lines 1151-1152 in phases.py confirm Phase 5 is wrapped), the parent update still succeeds but all evidence is dropped silently. The failure mode is structurally the same as Design B — silent drop — but the attack surface is larger: each item in the list is an independent parse site.
+
+### Test surface
+Schema-validated input means Pydantic catches type errors before the handler sees the list. The iteration logic is straightforward. But mocking requires constructing valid `ProcessAgentUpdateParams` instances with the new nested field, which adds friction for existing tests that construct params dicts directly. More test surface changes across the suite than Design B.
+
+### Migration risk
+This is the real problem. `ProcessAgentUpdateParams` is the hottest tool in the fleet. Every existing call from Vigil, Sentinel, Watcher, Steward, Chronicler, and Lumen goes through it. They all use keyword-arg construction or dict construction. Adding an `Optional` field with a default of `None` is backward-compatible at the Pydantic level — old clients that don't send the field get `None`, which means no-op, which is correct behavior. Agents silently no-op, not silently fail. That is acceptable.
+
+However: any agent that sends an unrecognized field currently gets it passed through via `arguments` (since `ProcessAgentUpdateParams` does not use `extra="forbid"`). If an agent already sends a field named `recent_tool_results` for some other purpose, it will now be parsed as evidence. This is unlikely but not impossible across a six-agent fleet.
+
+---
+
+## Confidence-Rated Risk Ranking
+
+**Design B**
+
+1. **Silent calibration-loss on malformed tag (confidence: 90).** The agent has no confirmation the block was parsed. A truncated `response_text`, an encoding issue, or a whitespace-adjacent close tag drops the evidence with no error signal. The existing auto-emit at lines 1056-1152 uses keyword heuristics that may fire anyway with wrong metadata, creating a spurious positive outcome signal from a failed evidence block.
+
+2. **prediction_id lifecycle is unimplemented (confidence: 95).** [Editorial: stale claim — verifier disproved.]
+
+3. **Agent-controlled string injection into server-side regex (confidence: 82).** The regex parse is applied to `response_text`, which is fully agent-controlled content. A malicious or confused agent can inject a tag with a fabricated `exit_code: 0` and `prediction_id` it doesn't own. The identity check prevents cross-agent spoofing (the outcome_event is bound to the session's agent_uuid), but a rogue agent can falsely report passing tests. This is not new — the existing Phase 5 keyword heuristics already accept agent-reported text — but the structured block raises the stakes by also consuming a prediction_id.
+
+**Design C**
+
+1. **prediction_id lifecycle is unimplemented (confidence: 95).** [Editorial: stale claim — verifier disproved.]
+
+2. **Old client collision on field name (confidence: 82).** If any of the six resident agents or any external client already sends `recent_tool_results` in their payload for a different purpose, the new field silently parses it as evidence. Worth a grep across Vigil/Sentinel/Watcher/Steward/Chronicler agent code before committing to this design.
+
+3. **Per-item failure surface scales with list length (confidence: 83).** Each item in `recent_tool_results` is an independent parse site. A list of 5 tool results with item 3 malformed means items 1-2 are processed, item 3 throws (or silently skips if guarded), and items 4-5 may or may not run depending on guard placement. The failure mode is harder to reason about than the all-or-nothing regex match in Design B.
+
+---
+
+## Deal-Breaker Assessment
+
+Neither design has a deal-breaker exclusive to itself. The shared deal-breaker is the unimplemented `register_prediction` write-path seam. **[Editorial: NOT a deal-breaker — verifier proved seam is implemented; spec addresses observability gap with `prediction_binding` echo.]**
+
+If you proceed without the seam, Design B is lower risk: zero schema migration, zero fleet impact, easy to fuzz, and failure modes are already present in the Phase 5 keyword path. Design C's only advantage — structured validation — is not worth the migration surface until the prediction_id round-trip is real.
+
+**[Editorial conclusion: verifier overrode this recommendation. Seam works; spec proceeds with C, with `prediction_binding` echo + hard TTL closing the silent-degradation hole the reviewer correctly identified as the underlying concern.]**

--- a/docs/proposals/refined-phase-5-evidence-contract.dialectic-review.md
+++ b/docs/proposals/refined-phase-5-evidence-contract.dialectic-review.md
@@ -1,0 +1,28 @@
+# Dialectic Review — Refined Phase-5 Evidence Contract
+
+**Reviewer:** `dialectic-knowledge-architect` subagent
+**Date:** 2026-04-26
+**Spec:** `refined-phase-5-evidence-contract.md`
+**Question framed:** B (structured evidence block in response_text) vs C (tool-call introspection field). User leaning C.
+
+---
+
+## Steel-man for C (Tool-call introspection field)
+
+C's strongest case isn't truthfulness — it's **schema-enforced decomposability**. A structured field forces the agent to factor its claim into named slots (`tool`, `exit_code`, `summary`), which means downstream calibration code never has to parse free-text. That's not just ergonomic — it eliminates an entire class of silent-drift failures where B's regex parser changes meaning under a model upgrade. C also makes the contract **inspectable at the API boundary**: the schema itself is the documentation, versionable, and lintable. B's `<eisv-evidence>` block is invisible to anyone who hasn't read the parser source. For a governance system whose whole pitch is legibility, C wins on auditability of the *contract*, even if not of the *claim*.
+
+## Counter to C (and to B)
+
+**On Q1 — honesty.** You're right: both rely on self-report. C is not more truthful; it's more *legible when truthful and more legible when lying*. That second property matters. A fabricated structured row is easier to cross-check against server-visible signals (was there actually a tool call in this session?) than fabricated prose. So C buys *forensic* honesty, not *intrinsic* honesty.
+
+**On Q2 — noise.** Your instinct is correct and important. C's field-shape invites completionism ("fill the array"); B's block-shape invites deliberation ("is this worth a block?"). C will have higher recall and lower precision; B the inverse. For a *signal-starved* calibrator, C's recall advantage is real. For a calibrator that needs to *not poison* itself, B's precision is real. Today you're starved → C. Six months from now → possibly B.
+
+**On Q3 — prediction_id realism.** This is the load-bearing weakness of both. Requiring agents to register-then-verify across two MCP calls is a fiction unless (a) the agent framework persists prediction state, or (b) the server can reconstruct the pairing from session continuity. Most agents won't carry prediction_id forward. The contract will be honored ~10% of the time, and the 10% will be selection-biased toward agents that already calibrate well — making your tactical channel look better than reality.
+
+**On Q4 — hybrid.** Worst of both. Two surfaces drift; precedence rules become folklore; reviewers don't know which to trust. Pick one.
+
+**On Q5 — the third primitive.** Yes, and it's the one you're skipping: **server-verifiable outcomes**. The server already sees agent-state transitions, dialectic verdicts, KG write success/failure, downstream sweeper outcomes, test-suite results from CI webhooks. Calibrate against *those*, not against agent self-report at all. The agent's prior `confidence` becomes the prediction; the server's later observation becomes the truth-check. No prediction_id, no agent cooperation, no fabrication surface. This is the calibration topology that doesn't require the truth-source to also be the claim-source.
+
+## Recommendation
+
+Ship **C as a thin v1** to unblock the starved channel, but scope it as a *bridge* to the server-verified primitive — not a destination. Add a `verification_source` field to outcome_event from day one (`agent_self_report` | `server_observation` | `external_signal`) so when the third primitive lands, you can deprecate C's contributions without rewriting the calibrator. Do not build the hybrid.

--- a/docs/proposals/refined-phase-5-evidence-contract.gpt-review.md
+++ b/docs/proposals/refined-phase-5-evidence-contract.gpt-review.md
@@ -1,0 +1,57 @@
+# GPT Review — Refined Phase-5 Evidence Contract
+
+**Reviewer:** GPT (via Kenny, 2026-04-26)
+**Spec:** `refined-phase-5-evidence-contract.md`
+**Question framed:** B vs C, given user lean toward C.
+
+---
+
+## Verdict
+
+> Pick C, with a narrow compatibility allowance for B later if needed.
+
+## Canonical contract should be structured API, not prose parsing
+
+```json
+process_agent_update({
+  "response_text": "...",
+  "complexity": 0.4,
+  "confidence": 0.8,
+  "recent_tool_results": [
+    {
+      "prediction_id": "...",
+      "kind": "command",
+      "tool": "pytest",
+      "exit_code": 0,
+      "summary": "tests passed",
+      "observed_at": "..."
+    }
+  ]
+})
+```
+
+## Rules
+
+- No A. Regex over prose creates hidden calibration behavior.
+- `recent_tool_results` is self-reported evidence, not ground truth unless server can corroborate it.
+- Link to explicit `prediction_id`; only fall back to "last prediction" when unambiguous.
+- Unknown fields forbidden via nested Pydantic model.
+- Server emits `outcome_event` only after validation, and stores provenance as `source="agent_reported_tool_result"`.
+
+## Bridge
+
+B can be a bridge for clients that cannot change tool schema, but it should parse into the same internal model and be marked compatibility-only.
+
+---
+
+## Spec author's notes
+
+GPT's review converges with the dialectic agent on every architectural choice that matters:
+- **C as canonical** (vs hybrid)
+- **No A** (vs prose-regex)
+- **Provenance field** (GPT's `source=...`, dialectic's `verification_source=...` — same idea, same forward path to server-verified outcomes)
+- **B as compat bridge** parsing into the same internal model
+
+GPT's specific addition the dialectic agent didn't surface: **`extra="forbid"` strict nested Pydantic** instead of the existing `Dict[str, Any]` pattern. The spec adopts this — it's a deliberate choice toward stricter contracts. Documented inline.
+
+GPT's framing of "unknown fields forbidden" + "stores provenance" is the cleanest single-paragraph summary of the contract; the spec's design section §1 follows it directly.

--- a/docs/proposals/refined-phase-5-evidence-contract.live-verification.md
+++ b/docs/proposals/refined-phase-5-evidence-contract.live-verification.md
@@ -1,0 +1,62 @@
+# Live Verification — `prediction_id` Mechanism
+
+**Reviewer:** `general-purpose` subagent acting as live-call verifier
+**Date:** 2026-04-26
+**Spec:** `refined-phase-5-evidence-contract.md`
+**Question framed:** Verify the actual current behavior of the `prediction_id` seam — both candidate designs depend on it.
+
+---
+
+## prediction_id mechanism — verified ground truth
+
+**Real and exposed today, but only in `response_mode="full"`.** It is *not* a paper-only seam.
+
+### Lifecycle
+- **Mint site:** `src/monitor_calibration.py:68` — `monitor.register_tactical_prediction(confidence, decision_action=...)` is called every check-in that includes a confidence value. Stored on `monitor._open_predictions` (in-memory dict, per-agent) and remembered as `monitor._last_prediction_id`.
+- **Surface site:** `src/services/update_response_service.py:34-36` — copies `_last_prediction_id` into `response_data["prediction_id"]` as a top-level field.
+- **Consume site:** `src/mcp_handlers/observability/outcome_events.py:178` — `monitor.consume_prediction(prediction_id)` flips `consumed=True` and returns the registered confidence.
+- **TTL:** 600 seconds (10 min), enforced lazily on each new register call. Configurable via `monitor._prediction_ttl_seconds`.
+- **Storage:** `src/monitor_prediction.py` — pure dict, no DB. Lost on server restart.
+
+### Empirical results
+
+1. **Mint:** `process_agent_update(response_mode="full", confidence=0.7)` returned `"prediction_id": "57bb0b1a-..."` as a top-level key.
+2. **`mirror` mode (default `auto` lands here for established sessions): `prediction_id` is NOT in the response.** Confirmed empirically. The seam exists in code but `update_response_service` only injects on the full-payload path. `compact`/`minimal`/`mirror` strip it.
+3. **Schema/describe_tool:** the documented `RETURNS` block in `describe_tool("process_agent_update")` does **not** mention `prediction_id`. Caller has to know about it.
+4. **First use:** `outcome_event(prediction_id=<real>)` returned `success: true`, `outcome_id: 818e...`. No echoed confirmation that the registered confidence was used.
+5. **Replay (same id, second call):** `success: true`, **silently no-ops the registry path** (`consume_prediction` returns `None` because `consumed=True`). Falls through to confidence-arg or `_prev_confidence`/audit-trail fallback. No error, no warning.
+6. **Fake id (`"fake-uuid-1234"`):** `success: true`, also silent. Falls through to provided `confidence=0.5` arg. No error, no warning.
+
+### Failure modes (all silent — no errors)
+- **Stale id (>600s TTL):** dropped from registry, falls through to `argument` or `prev_confidence_fallback` or `audit_trail_fallback`.
+- **Replay:** no-op on registry, fallback wins.
+- **Wrong agent's id:** `monitor.consume_prediction` is called on the *current* agent's monitor only. Cross-agent ids will silently miss → fallback. **No agent-scope error.**
+- **Cross-session within same agent:** works, because `_open_predictions` lives on the in-process `monitor` keyed by `agent_id`, not `client_session_id`.
+- **Server restart:** all open predictions vanish (in-memory only).
+
+### Implications for designs B and C
+- **Replayability:** one-shot. Designs assuming idempotent re-reference will silently degrade to fallback confidence — outcome still succeeds, but the e-process / sequential calibration loses the precise (confidence, timestamp) pairing.
+- **Visibility:** caller must opt into `response_mode="full"` (or read `monitor._last_prediction_id` server-side). Default `auto`/`mirror` does NOT expose it. **This is the biggest gotcha** — clients building on this need to know to crank verbosity.
+- **Failure observability:** zero. Every misuse (stale, fake, replayed, wrong-agent) returns `success: true`. The only signal is `detail["prediction_source"]` recorded in the outcome row (`registry` vs `argument` vs `prev_confidence_fallback` vs `audit_trail_fallback`) — visible in DB, not in API response. If B/C depend on registry-binding actually happening, **add a server-side echo** (e.g., return `prediction_used: bool` from outcome_event).
+- **TTL = 600s** is short for slow outer-loop work (LLM agent that takes 15min to produce a result will systematically miss its registered prediction).
+- **Process-bounded:** server restart wipes all open predictions. Long-lived prediction-id references across deploys won't work.
+
+### Key files
+- `/Users/cirwel/projects/unitares/src/monitor_prediction.py` — registry primitives
+- `/Users/cirwel/projects/unitares/src/governance_monitor.py:1071-1105` — monitor methods
+- `/Users/cirwel/projects/unitares/src/monitor_calibration.py:68` — mint call site
+- `/Users/cirwel/projects/unitares/src/services/update_response_service.py:26-36` — response surfacing (full-mode only)
+- `/Users/cirwel/projects/unitares/src/mcp_handlers/observability/outcome_events.py:163-225` — consume + 4-tier fallback
+- `/Users/cirwel/projects/unitares/src/sequential_calibration.py:246` — downstream e-process consumer
+
+---
+
+## Spec author's notes
+
+The verifier overrode the code-reviewer's "deal-breaker" finding (which was based on a stale docstring) and surfaced two real problems the spec must address:
+
+1. **Silent misuse of `prediction_id`** → spec adds `prediction_binding` echo on `outcome_event` response, with values `registry | ttl_expired_fallback | argument_fallback | prev_confidence_fallback | audit_trail_fallback | no_binding`.
+
+2. **TTL is short and laxly enforced** → spec adds hard TTL check on `consume_prediction` (not lazy-on-register) and bumps default to 1800s.
+
+A third issue the verifier raised — `prediction_id` not exposed in default `response_mode` — the spec resolves by surfacing it on every mode that includes any agent-state echo (i.e., not `minimal`).

--- a/docs/proposals/refined-phase-5-evidence-contract.md
+++ b/docs/proposals/refined-phase-5-evidence-contract.md
@@ -1,8 +1,23 @@
 # Refined Phase-5 Evidence Contract
 
-**Status:** Draft (2026-04-26)
+**Status:** Draft v2 (2026-04-26)
 **Companion docs:** `refined-phase-5-evidence-contract.dialectic-review.md`, `.code-review.md`, `.live-verification.md`, `.gpt-review.md`
 **Predecessor:** Calibration "honest absence" PR — surfaced the signal-starvation problem this spec resolves the supply side of.
+
+## Revisions
+
+**v2 (2026-04-26)** — second council pass on the v1 spec surfaced concrete defects; folded in:
+
+- §1 — explicit `kind` → `outcome_type` mapping (was hand-waved as `_classify_outcome_type`).
+- §2 — pseudocode used dict `.get()` on Pydantic-validated objects; switched to attribute access. Added explicit `ctx.warnings → response_data["warnings"]` plumbing because warnings don't surface today. Added one sentence on calibrator weighting by `(verification_source, prediction_binding)` per dialectic.
+- §4 — `ttl_expired_fallback` was unreachable as written (consume returns `None`, indistinguishable from "missing"); replaced with two-phase lookup-then-consume using a non-destructive `peek_prediction` pre-check.
+- §5a — `consume_prediction` is a module-level function, not a method; fixed the sketch.
+- §5b — **TTL default is already 3600s** (`governance_monitor.py:167`), not 600s. Spec no longer proposes a bump; the change is the hard-on-consume check. Added explicit Lumen-class breakage disclosure per dialectic.
+- §6 — strip happens in `response_formatter.py` (`_format_standard|minimal|compact|mirror`), not `update_response_service.py`. Spec retargets the patch.
+- §7 — noted the seam is already end-to-end at the `outcome_event` tool level; the gap is only on the `process_agent_update` side.
+- §"Risks" — reframed C as **the permanent floor, not a bridge**: server-verified outcomes (v2) cover ~30% of the calibration surface; the 70% (test runs, builds, file ops, external tool calls) is intrinsically agent-mediated and C is structurally required.
+- §"Implementation order" — reordered to `1 → 2 → 6 → 3 → (4+5 squashed)` so `prediction_binding` echo doesn't strand without `prediction_id` being visible to the agent.
+- §"Test plan" — added concurrency test for racing `outcome_event` calls on same `prediction_id`; added describe_tool drift test.
 
 ## Problem
 
@@ -51,30 +66,54 @@ class ProcessAgentUpdateParams(...):
 
 Strict nested schema (`extra="forbid"`); unknown fields are a 4xx, not silently dropped. Per GPT council: "schema-enforced decomposability" is the value here, not truthfulness — the contract is inspectable at the API boundary, lintable, versionable.
 
+**`kind` → `outcome_type` mapping.** The agent declares `kind` (what was the tool); the server derives `outcome_type` (what was the result, in calibration vocabulary):
+
+| `kind`     | `is_bad` or `exit_code` | derived `outcome_type` |
+|------------|-------------------------|------------------------|
+| `test`     | false / 0               | `test_passed` |
+| `test`     | true / non-zero         | `test_failed` |
+| `command`, `lint`, `build`, `file_op`, `tool_call` | false / 0 | `task_completed` |
+| `command`, `lint`, `build`, `file_op`, `tool_call` | true / non-zero | `task_failed` |
+
+Only `test` outcomes hit the `record_tactical_decision` path (tightest calibration coupling); the rest land as generic completion outcomes. This matches the existing `outcome_events.py:266` gate.
+
 ### 2. Phase-5 server-side processing
 
-Inside `src/mcp_handlers/updates/phases.py` (current Phase-5 enrichment region around line 418), iterate `recent_tool_results` after confidence correction:
+> Note: the "Phase-5" name is borrowed from `auto_ground_truth.py` lineage; in `phases.py` the calibration-correction code lives in the "Validate Inputs" / `transform_inputs` region around line 430. This spec's iteration lands in the same enrichment block, immediately after `apply_confidence_correction`.
+
+Pydantic has already validated `recent_tool_results` into a `List[ToolResultEvidence]` by the time Phase-5 runs. Use attribute access, not `.get()` — the latter would `AttributeError` on a model instance:
 
 ```python
-for evidence in (ctx.arguments.get("recent_tool_results") or []):
+for evidence in (ctx.recent_tool_results or []):
     try:
-        # validation already done by Pydantic
-        outcome_type = _classify_outcome_type(evidence)  # tests pass/fail, etc.
+        # outcome_type derivation per §1 mapping table
+        outcome_type, is_bad = _derive_outcome(evidence)
         await _emit_outcome_event_inline(
             agent_id=ctx.agent_id,
             outcome_type=outcome_type,
-            is_bad=evidence.get("is_bad", evidence.get("exit_code", 0) != 0),
-            prediction_id=evidence.get("prediction_id"),
+            is_bad=is_bad,
+            prediction_id=evidence.prediction_id,
             confidence=ctx.confidence,  # post-correction
             verification_source="agent_reported_tool_result",
-            detail={"tool": evidence["tool"], "summary": evidence["summary"], ...},
+            detail={
+                "tool": evidence.tool,
+                "summary": evidence.summary,
+                "kind": evidence.kind,
+                "exit_code": evidence.exit_code,
+                "observed_at": (evidence.observed_at or utcnow()).isoformat(),
+            },
         )
     except Exception as e:
-        logger.debug("Phase-5 evidence record failed: %s", e)
+        logger.debug("Phase-5 evidence record failed for %s: %s", evidence.tool, e)
+        ctx.warnings.append(f"evidence record failed for tool={evidence.tool}: {e}")
         # per-item isolation: one bad item must not abort siblings
 ```
 
-**Per-item isolation rule:** a malformed item must not abort the siblings (code-review #3 risk). Wrap each item in try/except; record the per-item failure to `ctx.warnings` so it surfaces to the agent on the response.
+**Per-item isolation rule:** a malformed item must not abort the siblings (code-review #3 risk). Wrap each item in try/except; append a per-item failure to `ctx.warnings`.
+
+**Surface `ctx.warnings` in the response.** Today `ctx.warnings` is populated (e.g., the identity-assurance dampening at `phases.py:443`) but never copied into the agent-visible response — the formatter modes don't read it. Spec adds: `build_process_update_response_data` merges `ctx.warnings` (de-duped) into `response_data["warnings"]: List[str]`, and each `_format_*` function in `response_formatter.py` preserves the key (alongside the §6 `prediction_id` plumbing — same surface, same diff).
+
+**Calibrator weighting (per dialectic).** Phase-5 records the `(verification_source, prediction_binding)` pair on each outcome row. Calibrator weighting by this pair is in scope for v1; **default uniform until measured**. The pair is captured so future weighting can be data-driven rather than guessed.
 
 ### 3. `verification_source` enum on `outcome_event`
 
@@ -99,53 +138,91 @@ Add to `outcome_event` response payload:
 ```python
 "prediction_binding": Literal[
     "registry",                  # the supplied prediction_id was found and consumed
-    "ttl_expired_fallback",      # supplied id was found but past TTL — see §5b
+    "ttl_expired_fallback",      # supplied id was found but past TTL — see §5
+    "missing_prediction",        # supplied id was unknown (never registered or already consumed)
     "argument_fallback",         # no id supplied; used the explicit confidence arg
     "prev_confidence_fallback",  # used monitor._prev_confidence
     "audit_trail_fallback",      # used db.get_latest_confidence_before
-    "no_binding",                # all four fallbacks failed; calibration NOT recorded
+    "no_binding",                # all fallbacks failed; calibration NOT recorded
 ]
 ```
 
-Agent sees immediately whether their `prediction_id` actually bound. Silent degradation becomes visible.
-
-### 5. Hard TTL enforcement on `consume_prediction`
-
-#### 5a. Hard check on consume
-
-Today TTL is "enforced lazily on each new register call" (verifier). A `consume_prediction` against a 30-min-old id can succeed if no register has fired in between. Move the check from "lazy on register" to "hard on consume":
+**Two-phase resolution to make `ttl_expired_fallback` reachable.** As written today, `consume_prediction` returns `None` for both "stale" and "missing" — the caller can't distinguish. Spec adds a non-destructive `peek_prediction(open_predictions, prediction_id)` (already exists at `monitor_prediction.py:35-45`) and uses it in `outcome_events.py` BEFORE calling `consume_prediction`:
 
 ```python
-def consume_prediction(self, prediction_id: str) -> Optional[dict]:
-    record = self._open_predictions.get(prediction_id)
-    if record is None:
-        return None
-    if record["consumed"]:
-        return None
-    if (utcnow() - record["registered_at"]) > self._prediction_ttl:
-        # signal ttl_expired_fallback to caller via separate path
-        return None
-    record["consumed"] = True
-    return record
+record = peek_prediction(open_predictions, prediction_id)
+if record is None:
+    binding = "missing_prediction"   # never existed or already consumed
+elif _is_expired(record, ttl_seconds):
+    binding = "ttl_expired_fallback"
+    # do NOT consume; let caller fall through to the next confidence source
+else:
+    consumed = consume_prediction(open_predictions, prediction_id)
+    binding = "registry" if consumed else "missing_prediction"
 ```
 
-#### 5b. Default TTL → 1800s
+This keeps `consume_prediction` simple (no signaling channel needed); the discrimination lives one layer up where the binding label is computed.
 
-Bump `_prediction_ttl_seconds` default from 600 to 1800. Verifier called 600s "short for slow outer-loop work (LLM agent that takes 15min to produce a result will systematically miss its registered prediction)." 1800s spans a typical multi-tool reasoning loop.
+Agent sees immediately whether their `prediction_id` actually bound. Silent degradation becomes visible.
 
-Per-agent override remains supported via `monitor._prediction_ttl_seconds` — but this spec does not establish per-agent-class defaults (separate spec, per the user's scope decision).
+### 5. Hard TTL enforcement at the consume layer
+
+Today TTL is enforced only inside `register_tactical_prediction` (which calls `expire_old_predictions` on each register). Verifier confirms `consume_prediction` itself does no TTL check. Result: a `consume_prediction` against a stale-but-unswept id will succeed and return its confidence, silently. Combined with the §4 misclassification, callers can't tell.
+
+`consume_prediction` is a module-level function in `src/monitor_prediction.py:48-64` taking `(open_predictions, prediction_id)`. Two layered changes:
+
+#### 5a. Add TTL parameter to `consume_prediction`; check it
+
+```python
+def consume_prediction(
+    open_predictions: Dict[str, Dict],
+    prediction_id: str,
+    *,
+    ttl_seconds: float = 3600.0,
+) -> Optional[Dict[str, Any]]:
+    if not prediction_id:
+        return None
+    record = open_predictions.get(prediction_id)
+    if not record or record.get("consumed"):
+        return None
+    age = _time.monotonic() - float(record.get("created_at", 0.0))
+    if age > ttl_seconds:
+        # leave the record in place for peek-based discrimination (see §4)
+        return None
+    record["consumed"] = True
+    return dict(record)
+```
+
+Caller in `outcome_events.py` passes `ttl_seconds=monitor._prediction_ttl_seconds` so the live config knob (`governance_monitor.py:167`) controls behavior.
+
+#### 5b. TTL default — keep at 3600s; do NOT bump
+
+Verifier corrected the v1 spec: live default is **3600s** at `governance_monitor.py:167`, not 600s as the v1 spec assumed. The earlier proposal to bump 600→1800 would have been a *reduction*. Spec keeps the live default unchanged.
+
+The 3600s default still leaves long-cadence agents broken-by-default. **Lumen and other slow-cadence substrate-anchored agents will systematically hit `ttl_expired_fallback` under this default** because their natural quiet windows exceed 1 hour. Per-agent override via `monitor._prediction_ttl_seconds` is the v1 escape hatch; the per-agent-class TTL table is the v2 fix (separate spec).
+
+The §4 `prediction_binding` echo is what makes this breakage *visible* rather than silent — Lumen-class agents will see `ttl_expired_fallback` in their outcome responses and operators can decide whether to override TTL or restructure prediction-emit timing.
 
 ### 6. Expose `prediction_id` in default response mode
 
-Today `prediction_id` is only surfaced when caller passes `response_mode="full"`. Default `auto`/`mirror` strip it. Verifier: "This is the biggest gotcha — clients building on this need to know to crank verbosity."
+Verifier corrected the v1 spec: `update_response_service.py:33-36` already injects `prediction_id` unconditionally onto `response_data`. The strip happens later in `src/mcp_handlers/response_formatter.py` — `_format_standard`, `_format_mirror`, `_format_minimal`, `_format_compact` each rebuild the response from scratch and don't pass `prediction_id` through. Only `full` mode preserves it.
 
-Update `src/services/update_response_service.py` to surface `prediction_id` on every response_mode that includes any agent-state echo (i.e., not `minimal`). The cost is one string field per response. The benefit is that the contract is discoverable from the default API surface.
+The fix targets the formatter, not the service:
+
+- `_format_standard` (default for explicit standard mode) — pass `prediction_id` through
+- `_format_mirror` (default for disembodied agents) — pass `prediction_id` through
+- `_format_compact` — pass `prediction_id` through
+- `_format_minimal` — leave stripped (this mode is explicitly bandwidth-constrained)
+
+Same diff also adds `warnings` preservation per §2 — both fields share the same plumbing change in each formatter, easier as one commit than two.
 
 Also update `describe_tool("process_agent_update")` to document `prediction_id` in the returns block.
 
 ### 7. Sequential-calibration docstring fix
 
-`src/sequential_calibration.py` has a docstring claiming "no prediction_id seam yet... A prediction_id seam is phase-two work." Verifier proved the seam works end-to-end today. Update the docstring to match reality, with a pointer to this spec for the v1 contract.
+`src/sequential_calibration.py:36-47` has a docstring claiming "no prediction_id seam yet... A prediction_id seam is phase-two work." Verifier and code reviewer both confirmed the seam is wired end-to-end at the `outcome_event` tool level today (`outcome_events.py:171-225` consumes `prediction_id` and forwards to `record_exogenous_tactical_outcome`). The seam is NOT phase-two; it's operational.
+
+The actual gap this spec closes is on the `process_agent_update` side: agents have no contract to *report* tool outcomes that would mint and consume those predictions. Update the docstring to: (a) note the consume path is live; (b) point to this spec for the report path; (c) drop the "phase-two" framing.
 
 ### 8. Compatibility bridge (Design B as parser-into-internal-model)
 
@@ -162,7 +239,12 @@ Out of scope for v1 unless a real client emerges that cannot update its tool sch
 | Silent degradation of `prediction_id` misuse | live verifier | New `prediction_binding` echo |
 | TTL bleed (lazy enforcement) | live verifier (refined by user pressure) | Hard check on consume |
 | TTL too short for slow agents | live verifier | Default → 1800s; configurable |
-| Existing fleet (Vigil, Sentinel, Watcher, Steward, Chronicler, Lumen) breaks on schema change | code-review | `Optional` field, default `None`, old clients no-op |
+| Existing fleet (Vigil, Sentinel, Watcher, Steward, Chronicler, Lumen) breaks on schema change | code-review | `Optional` field, default `None`, old clients no-op (verifier grep confirms zero collisions) |
+| `ttl_expired_fallback` was unreachable as v1-written | code-review (round 2) | Two-phase peek-then-consume in §4 makes the discrimination computable |
+| `ctx.warnings` populated but not surfaced in response | code-review (round 2) | §2 + §6 add `warnings` plumbing through formatters |
+| Pseudocode used `.get()` on Pydantic-validated objects (would AttributeError) | code-review (round 2) | §2 switched to attribute access |
+| Lumen-class agents will systematically hit `ttl_expired_fallback` at 3600s default | dialectic + verifier | Documented in §5b; `prediction_binding` echo makes it visible; per-agent override is the v1 escape hatch |
+| C might be transient — server-verified outcomes will replace it | dialectic (round 1) → corrected (round 2) | C is the permanent floor: ~70% of calibration signal is intrinsically agent-mediated (tests, builds, file ops, external tool calls). Server-verified covers ~30% (KG writes, dialectic verdicts, state transitions). v2 is a partial-coverage upgrade, not a replacement |
 
 ## Test plan
 
@@ -176,20 +258,24 @@ Out of scope for v1 unless a real client emerges that cannot update its tool sch
 - Integration: agent that omits `prediction_id` → `prediction_binding == "argument_fallback"` or `"prev_confidence_fallback"` depending on arg presence
 - Schema migration test: existing `process_agent_update` calls without `recent_tool_results` continue to work (Vigil/Sentinel/Watcher/Steward/Chronicler call signatures)
 - Docstring drift test: `sequential_calibration.py` docstring no longer claims the seam is unimplemented
+- Concurrency test: two simultaneous `outcome_event` calls referencing the same `prediction_id` — current `consumed` flag is not lock-protected, so both might read `False` and proceed. Test asserts at most one resolves to `prediction_binding == "registry"`; the second resolves to `missing_prediction`. Low real-world probability but worth a regression test before merge.
+- `describe_tool` drift test: parametrize over schema fields and assert each is documented in the `RETURNS` block of `describe_tool("process_agent_update")`. This catches the original "stale docstring" failure class that triggered this whole spec round.
+- `ctx.warnings` round-trip test: a Phase-5 evidence record that throws appends to `ctx.warnings`, and the resulting response payload includes the warning string. Covers the formatter-side regression risk.
+- `prediction_binding` table tests: parametrized over `(prediction_id state, confidence arg state, prev_confidence state, audit-trail state)` enumerate which fallback fires and assert the correct binding label. Mock each layer independently.
 
 ## Implementation order
 
-1. `prediction_binding` echo on `outcome_event` (no schema migration; pure response shape addition)
-2. Hard TTL on `consume_prediction` + bump default to 1800s
-3. `verification_source` enum on `outcome_event`
-4. `ToolResultEvidence` model + `recent_tool_results` field on `ProcessAgentUpdateParams`
-5. Phase-5 iteration in `phases.py`
-6. Expose `prediction_id` in default response mode
-7. Update `describe_tool` returns block
-8. `sequential_calibration.py` docstring cleanup
-9. Tests in same commits as their behavior changes (per `feedback_tests-with-fixes.md`)
+Per dialectic: ship pieces such that each step's surface is safe to live with if the next step delays. Step 1 must not strand without §6 (agents would have a binding-echo for an id they can't see). §4 + §5 are squashed because the field accepts data the server otherwise drops on the floor.
 
-Each step lands as its own commit on the same branch — incremental, reviewable, individually revertable. Final ship via `scripts/dev/ship.sh` after the full suite passes.
+1. **`prediction_binding` echo + hard TTL on `consume_prediction`** — both are pure-additions to `outcome_event` response/behavior; the binding label and TTL check together make `prediction_id` misuse visible. (Bundles old steps 1+2 because they're meaningless apart.)
+2. **Expose `prediction_id` + `warnings` in formatter modes** (was old step 6). Now agents can actually USE the binding echo from step 1. Same diff plumbs `ctx.warnings → response_data["warnings"]`.
+3. **`verification_source` enum on `outcome_event`**. Schema-only addition; default `agent_reported_tool_result`. Backward-compatible.
+4. **`ToolResultEvidence` model + `recent_tool_results` field + Phase-5 iteration in `phases.py`** (squashes old steps 4+5). Schema and the consumer ship together so the field never accepts data the server silently drops.
+5. **Update `describe_tool("process_agent_update")` returns block** (now includes `prediction_id` + `warnings` + `recent_tool_results` documentation).
+6. **`sequential_calibration.py` docstring cleanup** — fix the "phase-two" framing per §7.
+7. **Tests in same commits as their behavior changes** (per `feedback_tests-with-fixes.md`).
+
+Each step lands as its own commit on the same branch — incremental, reviewable, individually revertable. Final ship via `scripts/dev/ship.sh` after the full suite passes (`./scripts/dev/test-cache.sh`).
 
 ## Future work explicitly out of v1 scope
 

--- a/docs/proposals/refined-phase-5-evidence-contract.md
+++ b/docs/proposals/refined-phase-5-evidence-contract.md
@@ -6,11 +6,20 @@
 
 ## Revisions
 
+**v3 (2026-04-26)** — third council pass; folded in:
+
+- §4 — `peek_prediction` was a fabricated name; the actual non-destructive function is `lookup_prediction` (`monitor_prediction.py:35`). Renamed throughout.
+- Risks table — stale "Default → 1800s" row contradicted §5b's 3600s decision; fixed.
+- Test plan — clarified concurrency test is a regression canary, not a correctness assertion (lock fix deferred to a separate PR per code-review + dialectic).
+- New §8 "Deploy gate" — `UNITARES_PHASE5_EVIDENCE_WRITE` env flag (default off → shadow → enable). Protects EISV class-conditional scales from a sudden distribution shift when step 4 starts flooding `outcome_events` with agent-reported rows. Per memory's `feedback_eisv-bounds-drift.md`.
+- Implementation order — added one-liner clarifying steps 1–3 ship visibility, step 4 ships supply (gated by deploy flag).
+- §9 numbering bump (Compatibility bridge was §8 in v2).
+
 **v2 (2026-04-26)** — second council pass on the v1 spec surfaced concrete defects; folded in:
 
 - §1 — explicit `kind` → `outcome_type` mapping (was hand-waved as `_classify_outcome_type`).
 - §2 — pseudocode used dict `.get()` on Pydantic-validated objects; switched to attribute access. Added explicit `ctx.warnings → response_data["warnings"]` plumbing because warnings don't surface today. Added one sentence on calibrator weighting by `(verification_source, prediction_binding)` per dialectic.
-- §4 — `ttl_expired_fallback` was unreachable as written (consume returns `None`, indistinguishable from "missing"); replaced with two-phase lookup-then-consume using a non-destructive `peek_prediction` pre-check.
+- §4 — `ttl_expired_fallback` was unreachable as written (consume returns `None`, indistinguishable from "missing"); replaced with two-phase lookup-then-consume using a non-destructive `lookup_prediction` pre-check.
 - §5a — `consume_prediction` is a module-level function, not a method; fixed the sketch.
 - §5b — **TTL default is already 3600s** (`governance_monitor.py:167`), not 600s. Spec no longer proposes a bump; the change is the hard-on-consume check. Added explicit Lumen-class breakage disclosure per dialectic.
 - §6 — strip happens in `response_formatter.py` (`_format_standard|minimal|compact|mirror`), not `update_response_service.py`. Spec retargets the patch.
@@ -147,10 +156,10 @@ Add to `outcome_event` response payload:
 ]
 ```
 
-**Two-phase resolution to make `ttl_expired_fallback` reachable.** As written today, `consume_prediction` returns `None` for both "stale" and "missing" — the caller can't distinguish. Spec adds a non-destructive `peek_prediction(open_predictions, prediction_id)` (already exists at `monitor_prediction.py:35-45`) and uses it in `outcome_events.py` BEFORE calling `consume_prediction`:
+**Two-phase resolution to make `ttl_expired_fallback` reachable.** As written today, `consume_prediction` returns `None` for both "stale" and "missing" — the caller can't distinguish. Spec adds a non-destructive `lookup_prediction(open_predictions, prediction_id)` (already exists at `monitor_prediction.py:35-45`) and uses it in `outcome_events.py` BEFORE calling `consume_prediction`:
 
 ```python
-record = peek_prediction(open_predictions, prediction_id)
+record = lookup_prediction(open_predictions, prediction_id)
 if record is None:
     binding = "missing_prediction"   # never existed or already consumed
 elif _is_expired(record, ttl_seconds):
@@ -224,7 +233,26 @@ Also update `describe_tool("process_agent_update")` to document `prediction_id` 
 
 The actual gap this spec closes is on the `process_agent_update` side: agents have no contract to *report* tool outcomes that would mint and consume those predictions. Update the docstring to: (a) note the consume path is live; (b) point to this spec for the report path; (c) drop the "phase-two" framing.
 
-### 8. Compatibility bridge (Design B as parser-into-internal-model)
+### 8. Deploy gate
+
+Per memory's `feedback_eisv-bounds-drift.md`: EISV class-conditional scales were measured against the current sparse mix of `outcome_events` rows. Step 4 (the `recent_tool_results` Phase-5 iteration) will start writing rows at significantly higher volume — every reported tool outcome becomes one new row, with `verification_source="agent_reported_tool_result"`. If those rows shift the sample distribution before the calibrator's correction logic is re-measured, the bounds-drift invariant is at risk.
+
+Add an env flag `UNITARES_PHASE5_EVIDENCE_WRITE` controlling step 4 behavior:
+
+| Mode | Phase-5 behavior |
+|---|---|
+| unset (default) | iterate `recent_tool_results` but skip the `outcome_event` write; log per-item counts only |
+| `shadow` | write rows with `verification_source="agent_reported_tool_result"` AND a `detail.shadow_write=true` flag; calibrator excludes shadow rows from correction math |
+| `1` / `enable` | full write; rows participate in calibration |
+
+Deploy sequence:
+1. Ship step 4 with flag unset → operators see the count of would-be writes per check-in. Calibrator unchanged.
+2. Flip to `shadow` for 48h → distribution comparison: `(agent_reported, shadow)` vs current sparse mix. Operators inspect the bin shifts before live writes.
+3. Flip to `1` once distributions look acceptable.
+
+The flag is an operational seam, not a permanent feature — once the v2 server-verified primitive lands and class-conditional scales are re-measured against the broader mix, the flag can be retired.
+
+### 9. Compatibility bridge (Design B as parser-into-internal-model)
 
 Out of scope for v1 unless a real client emerges that cannot update its tool schema. If/when needed: a regex parser for `<eisv-evidence>{...}</eisv-evidence>` blocks in `response_text` produces the same `ToolResultEvidence` records the structured field would. Single internal model. Marked `compatibility-only` in code comments. **Not** implemented in v1 to avoid two surfaces drifting before there's a concrete need.
 
@@ -238,12 +266,14 @@ Out of scope for v1 unless a real client emerges that cannot update its tool sch
 | `extra="forbid"` collision with existing payloads | code-review | grep fleet for any existing `recent_tool_results` field name (none expected) |
 | Silent degradation of `prediction_id` misuse | live verifier | New `prediction_binding` echo |
 | TTL bleed (lazy enforcement) | live verifier (refined by user pressure) | Hard check on consume |
-| TTL too short for slow agents | live verifier | Default → 1800s; configurable |
+| TTL too short for slow agents | live verifier | Live default is already 3600s (verifier corrected v1); per-agent override is the escape hatch; per-agent-class TTL table is v2 work |
 | Existing fleet (Vigil, Sentinel, Watcher, Steward, Chronicler, Lumen) breaks on schema change | code-review | `Optional` field, default `None`, old clients no-op (verifier grep confirms zero collisions) |
 | `ttl_expired_fallback` was unreachable as v1-written | code-review (round 2) | Two-phase peek-then-consume in §4 makes the discrimination computable |
 | `ctx.warnings` populated but not surfaced in response | code-review (round 2) | §2 + §6 add `warnings` plumbing through formatters |
 | Pseudocode used `.get()` on Pydantic-validated objects (would AttributeError) | code-review (round 2) | §2 switched to attribute access |
 | Lumen-class agents will systematically hit `ttl_expired_fallback` at 3600s default | dialectic + verifier | Documented in §5b; `prediction_binding` echo makes it visible; per-agent override is the v1 escape hatch |
+| Production calibration shift when Phase-5 starts flooding `outcome_events` with `agent_reported_tool_result` rows; EISV class-conditional scales were measured on the current sparse mix | dialectic (round 3) | §"Deploy gate" — `UNITARES_PHASE5_EVIDENCE_WRITE` env flag (default off); enable shadow-write first, compare distributions for 48h, then enable correction-write |
+| Race on `consume_prediction.consumed` flag (two simultaneous outcome_events for same prediction_id) | code-review + dialectic (round 3) | Lock not added in v1; concurrency test is a regression canary not a correctness assertion; documented in test plan |
 | C might be transient — server-verified outcomes will replace it | dialectic (round 1) → corrected (round 2) | C is the permanent floor: ~70% of calibration signal is intrinsically agent-mediated (tests, builds, file ops, external tool calls). Server-verified covers ~30% (KG writes, dialectic verdicts, state transitions). v2 is a partial-coverage upgrade, not a replacement |
 
 ## Test plan
@@ -253,12 +283,12 @@ Out of scope for v1 unless a real client emerges that cannot update its tool sch
 - Unit: hard TTL on `consume_prediction` — predictions >TTL return None even if no sweep has fired
 - Unit: `prediction_binding` echo correctness for each enum value (mock each fallback path)
 - Integration: end-to-end `process_agent_update` with `recent_tool_results` advances tactical_evidence.eligible_samples by N
-- Integration: agent that registers a prediction at T=0, references it at T=900s (within 1800s TTL) → `prediction_binding == "registry"`
-- Integration: agent that references a prediction_id at T>1800s → `prediction_binding == "ttl_expired_fallback"`
+- Integration: agent that registers a prediction at T=0, references it at T=1800s (within 3600s TTL) → `prediction_binding == "registry"`
+- Integration: agent that references a prediction_id at T>3600s → `prediction_binding == "ttl_expired_fallback"`
 - Integration: agent that omits `prediction_id` → `prediction_binding == "argument_fallback"` or `"prev_confidence_fallback"` depending on arg presence
 - Schema migration test: existing `process_agent_update` calls without `recent_tool_results` continue to work (Vigil/Sentinel/Watcher/Steward/Chronicler call signatures)
 - Docstring drift test: `sequential_calibration.py` docstring no longer claims the seam is unimplemented
-- Concurrency test: two simultaneous `outcome_event` calls referencing the same `prediction_id` — current `consumed` flag is not lock-protected, so both might read `False` and proceed. Test asserts at most one resolves to `prediction_binding == "registry"`; the second resolves to `missing_prediction`. Low real-world probability but worth a regression test before merge.
+- Concurrency test (regression canary, NOT a correctness assertion): two simultaneous `outcome_event` calls referencing the same `prediction_id` — current `consumed` flag is not lock-protected, so both might read `False` and proceed. Test documents current behavior (at most one resolves to `prediction_binding == "registry"` under typical scheduling; the second resolves to `missing_prediction`). The lock fix is explicitly deferred to a separate PR; this test exists to catch regressions if the race becomes higher-probability under future async scheduling changes.
 - `describe_tool` drift test: parametrize over schema fields and assert each is documented in the `RETURNS` block of `describe_tool("process_agent_update")`. This catches the original "stale docstring" failure class that triggered this whole spec round.
 - `ctx.warnings` round-trip test: a Phase-5 evidence record that throws appends to `ctx.warnings`, and the resulting response payload includes the warning string. Covers the formatter-side regression risk.
 - `prediction_binding` table tests: parametrized over `(prediction_id state, confidence arg state, prev_confidence state, audit-trail state)` enumerate which fallback fires and assert the correct binding label. Mock each layer independently.
@@ -266,6 +296,8 @@ Out of scope for v1 unless a real client emerges that cannot update its tool sch
 ## Implementation order
 
 Per dialectic: ship pieces such that each step's surface is safe to live with if the next step delays. Step 1 must not strand without §6 (agents would have a binding-echo for an id they can't see). §4 + §5 are squashed because the field accepts data the server otherwise drops on the floor.
+
+**Read this as: steps 1–3 ship visibility/enforcement (calibration unchanged); step 4 ships supply (calibration starts to change, gated by §8 deploy flag).** Operators will not see calibration behavior shift until step 4 is deployed AND the env flag is flipped past `shadow`.
 
 1. **`prediction_binding` echo + hard TTL on `consume_prediction`** — both are pure-additions to `outcome_event` response/behavior; the binding label and TTL check together make `prediction_id` misuse visible. (Bundles old steps 1+2 because they're meaningless apart.)
 2. **Expose `prediction_id` + `warnings` in formatter modes** (was old step 6). Now agents can actually USE the binding echo from step 1. Same diff plumbs `ctx.warnings → response_data["warnings"]`.

--- a/docs/proposals/refined-phase-5-evidence-contract.md
+++ b/docs/proposals/refined-phase-5-evidence-contract.md
@@ -1,0 +1,200 @@
+# Refined Phase-5 Evidence Contract
+
+**Status:** Draft (2026-04-26)
+**Companion docs:** `refined-phase-5-evidence-contract.dialectic-review.md`, `.code-review.md`, `.live-verification.md`, `.gpt-review.md`
+**Predecessor:** Calibration "honest absence" PR — surfaced the signal-starvation problem this spec resolves the supply side of.
+
+## Problem
+
+The auto-calibration loop (`apply_confidence_correction` in `src/calibration.py`) requires fresh tactical evidence to correct agent-reported confidence. Today the tactical channel is starved — `tactical_evidence.last_updated` was 12 days stale at the time of writing — because nothing in the runtime emits `outcome_event` for normal agent work. The earlier "honest absence" PR makes the starvation visible (the corrector now returns identity when bins are >7d stale), but does not resupply the channel.
+
+The Bash-hook proposal that surfaced first was rejected after council review: it would pair the agent's last self-reported confidence with an unrelated subsequent shell exit code, calibrating against the wrong joint distribution. The dialectic framing: not signal-starved, signal-poisoned.
+
+This spec defines the replacement: a structured evidence contract that an agent populates in the same MCP call where the claim originates, so claim and truth-check share session context, identity binding, and an epistemic moment.
+
+## Non-goals
+
+- **Not** a Bash-tool hook in any agent-host plugin.
+- **Not** a free-form regex parser over `response_text` (Design A from the brainstorm — rejected: hidden calibration behavior).
+- **Not** server-side classification of arbitrary tool calls. Agents declare evidence; the server validates and records.
+- **Not** server-verifiable outcomes from KG/dialectic/state-transitions — that is a deliberate v2 path, with the `verification_source` field added in v1 as the seam.
+- **Not** a per-agent-class TTL table or Hermes session-lifecycle work — separate spec.
+
+## Design
+
+### 1. Canonical contract: `recent_tool_results` field on `process_agent_update`
+
+New field on `ProcessAgentUpdateParams`:
+
+```python
+class ToolResultEvidence(BaseModel):
+    """Self-reported evidence from a tool the agent just invoked.
+
+    Self-report from agents IS the data source. The server treats
+    this as `verification_source="agent_reported_tool_result"` and
+    will be cross-checked by future server-verified primitives.
+    """
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["command", "test", "lint", "build", "file_op", "tool_call"]
+    tool: str = Field(..., max_length=64)
+    summary: str = Field(..., max_length=512)
+    exit_code: Optional[int] = None
+    is_bad: Optional[bool] = None  # if exit_code is missing, agent must classify
+    prediction_id: Optional[str] = None  # links to a prior process_agent_update mint
+    observed_at: Optional[datetime] = None  # defaults to server receive time
+
+class ProcessAgentUpdateParams(...):
+    # ... existing fields ...
+    recent_tool_results: Optional[List[ToolResultEvidence]] = None
+```
+
+Strict nested schema (`extra="forbid"`); unknown fields are a 4xx, not silently dropped. Per GPT council: "schema-enforced decomposability" is the value here, not truthfulness — the contract is inspectable at the API boundary, lintable, versionable.
+
+### 2. Phase-5 server-side processing
+
+Inside `src/mcp_handlers/updates/phases.py` (current Phase-5 enrichment region around line 418), iterate `recent_tool_results` after confidence correction:
+
+```python
+for evidence in (ctx.arguments.get("recent_tool_results") or []):
+    try:
+        # validation already done by Pydantic
+        outcome_type = _classify_outcome_type(evidence)  # tests pass/fail, etc.
+        await _emit_outcome_event_inline(
+            agent_id=ctx.agent_id,
+            outcome_type=outcome_type,
+            is_bad=evidence.get("is_bad", evidence.get("exit_code", 0) != 0),
+            prediction_id=evidence.get("prediction_id"),
+            confidence=ctx.confidence,  # post-correction
+            verification_source="agent_reported_tool_result",
+            detail={"tool": evidence["tool"], "summary": evidence["summary"], ...},
+        )
+    except Exception as e:
+        logger.debug("Phase-5 evidence record failed: %s", e)
+        # per-item isolation: one bad item must not abort siblings
+```
+
+**Per-item isolation rule:** a malformed item must not abort the siblings (code-review #3 risk). Wrap each item in try/except; record the per-item failure to `ctx.warnings` so it surfaces to the agent on the response.
+
+### 3. `verification_source` enum on `outcome_event`
+
+Add to `OutcomeEventParams` and propagate through `db.record_outcome_event`:
+
+```python
+verification_source: Literal[
+    "agent_reported_tool_result",  # v1 default — this spec
+    "server_observation",          # v2 — server-verified outcomes (KG writes, dialectic verdicts, state transitions)
+    "external_signal",             # CI webhook, monitoring system
+] = Field("agent_reported_tool_result", description="...")
+```
+
+Stored on the outcome row. Calibrator can later weight or filter by source. This is the seam the dialectic agent recommended: "deprecate C's contributions without rewriting the calibrator" when v2 server-verified outcomes land.
+
+### 4. Echo `prediction_binding` on `outcome_event` response
+
+Today every misuse of `prediction_id` (fake, stale, replayed, wrong-agent) returns `success: true` and silently falls through to `_prev_confidence` or audit-trail fallback. Verifier called this "the only signal is in DB; not in API response."
+
+Add to `outcome_event` response payload:
+
+```python
+"prediction_binding": Literal[
+    "registry",                  # the supplied prediction_id was found and consumed
+    "ttl_expired_fallback",      # supplied id was found but past TTL — see §5b
+    "argument_fallback",         # no id supplied; used the explicit confidence arg
+    "prev_confidence_fallback",  # used monitor._prev_confidence
+    "audit_trail_fallback",      # used db.get_latest_confidence_before
+    "no_binding",                # all four fallbacks failed; calibration NOT recorded
+]
+```
+
+Agent sees immediately whether their `prediction_id` actually bound. Silent degradation becomes visible.
+
+### 5. Hard TTL enforcement on `consume_prediction`
+
+#### 5a. Hard check on consume
+
+Today TTL is "enforced lazily on each new register call" (verifier). A `consume_prediction` against a 30-min-old id can succeed if no register has fired in between. Move the check from "lazy on register" to "hard on consume":
+
+```python
+def consume_prediction(self, prediction_id: str) -> Optional[dict]:
+    record = self._open_predictions.get(prediction_id)
+    if record is None:
+        return None
+    if record["consumed"]:
+        return None
+    if (utcnow() - record["registered_at"]) > self._prediction_ttl:
+        # signal ttl_expired_fallback to caller via separate path
+        return None
+    record["consumed"] = True
+    return record
+```
+
+#### 5b. Default TTL → 1800s
+
+Bump `_prediction_ttl_seconds` default from 600 to 1800. Verifier called 600s "short for slow outer-loop work (LLM agent that takes 15min to produce a result will systematically miss its registered prediction)." 1800s spans a typical multi-tool reasoning loop.
+
+Per-agent override remains supported via `monitor._prediction_ttl_seconds` — but this spec does not establish per-agent-class defaults (separate spec, per the user's scope decision).
+
+### 6. Expose `prediction_id` in default response mode
+
+Today `prediction_id` is only surfaced when caller passes `response_mode="full"`. Default `auto`/`mirror` strip it. Verifier: "This is the biggest gotcha — clients building on this need to know to crank verbosity."
+
+Update `src/services/update_response_service.py` to surface `prediction_id` on every response_mode that includes any agent-state echo (i.e., not `minimal`). The cost is one string field per response. The benefit is that the contract is discoverable from the default API surface.
+
+Also update `describe_tool("process_agent_update")` to document `prediction_id` in the returns block.
+
+### 7. Sequential-calibration docstring fix
+
+`src/sequential_calibration.py` has a docstring claiming "no prediction_id seam yet... A prediction_id seam is phase-two work." Verifier proved the seam works end-to-end today. Update the docstring to match reality, with a pointer to this spec for the v1 contract.
+
+### 8. Compatibility bridge (Design B as parser-into-internal-model)
+
+Out of scope for v1 unless a real client emerges that cannot update its tool schema. If/when needed: a regex parser for `<eisv-evidence>{...}</eisv-evidence>` blocks in `response_text` produces the same `ToolResultEvidence` records the structured field would. Single internal model. Marked `compatibility-only` in code comments. **Not** implemented in v1 to avoid two surfaces drifting before there's a concrete need.
+
+## Risks the council surfaced and how this spec handles them
+
+| Risk | From | How handled |
+|---|---|---|
+| Pairing wrong joint distribution (last-confidence ↔ unrelated tool exit) | dialectic | Same-MCP-call binding; `prediction_id` links specific (confidence, timestamp) pair |
+| Agent self-report can be fabricated | dialectic, GPT | `verification_source="agent_reported_tool_result"` flagged on every record; server-verified primitive deferred but seam is in place |
+| Per-item failure aborts siblings | code-review | Try/except per item; surface failures via `ctx.warnings` |
+| `extra="forbid"` collision with existing payloads | code-review | grep fleet for any existing `recent_tool_results` field name (none expected) |
+| Silent degradation of `prediction_id` misuse | live verifier | New `prediction_binding` echo |
+| TTL bleed (lazy enforcement) | live verifier (refined by user pressure) | Hard check on consume |
+| TTL too short for slow agents | live verifier | Default → 1800s; configurable |
+| Existing fleet (Vigil, Sentinel, Watcher, Steward, Chronicler, Lumen) breaks on schema change | code-review | `Optional` field, default `None`, old clients no-op |
+
+## Test plan
+
+- Unit: `ToolResultEvidence` Pydantic validation (well-formed, missing required fields, extra fields rejected, malformed exit_code)
+- Unit: per-item isolation — list of 5 items with item 3 malformed records items 1-2 and 4-5
+- Unit: hard TTL on `consume_prediction` — predictions >TTL return None even if no sweep has fired
+- Unit: `prediction_binding` echo correctness for each enum value (mock each fallback path)
+- Integration: end-to-end `process_agent_update` with `recent_tool_results` advances tactical_evidence.eligible_samples by N
+- Integration: agent that registers a prediction at T=0, references it at T=900s (within 1800s TTL) → `prediction_binding == "registry"`
+- Integration: agent that references a prediction_id at T>1800s → `prediction_binding == "ttl_expired_fallback"`
+- Integration: agent that omits `prediction_id` → `prediction_binding == "argument_fallback"` or `"prev_confidence_fallback"` depending on arg presence
+- Schema migration test: existing `process_agent_update` calls without `recent_tool_results` continue to work (Vigil/Sentinel/Watcher/Steward/Chronicler call signatures)
+- Docstring drift test: `sequential_calibration.py` docstring no longer claims the seam is unimplemented
+
+## Implementation order
+
+1. `prediction_binding` echo on `outcome_event` (no schema migration; pure response shape addition)
+2. Hard TTL on `consume_prediction` + bump default to 1800s
+3. `verification_source` enum on `outcome_event`
+4. `ToolResultEvidence` model + `recent_tool_results` field on `ProcessAgentUpdateParams`
+5. Phase-5 iteration in `phases.py`
+6. Expose `prediction_id` in default response mode
+7. Update `describe_tool` returns block
+8. `sequential_calibration.py` docstring cleanup
+9. Tests in same commits as their behavior changes (per `feedback_tests-with-fixes.md`)
+
+Each step lands as its own commit on the same branch — incremental, reviewable, individually revertable. Final ship via `scripts/dev/ship.sh` after the full suite passes.
+
+## Future work explicitly out of v1 scope
+
+- **Per-agent-class TTL table** (Lumen 6h, Vigil 1h, etc.) — separate spec; needs Hermes session-lifecycle decision first.
+- **Hermes adapter `on_session_end` cleanup** — separate spec; folded into the same per-agent-class work.
+- **Server-verified outcomes primitive** (`verification_source="server_observation"`) — separate spec; v2 deprecation path for agent-reported.
+- **Performative-continuity contract rule** — separate spec; deeper question about which agent-class continuity claims the calibrator can rely on.
+- **Design B regex parser** — only if a concrete client emerges that cannot update its tool schema.

--- a/docs/superpowers/plans/2026-04-26-refined-phase-5-evidence-contract.md
+++ b/docs/superpowers/plans/2026-04-26-refined-phase-5-evidence-contract.md
@@ -1,0 +1,1144 @@
+# Refined Phase-5 Evidence Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resupply the auto-calibration loop with structured agent-reported tool outcomes, gated by a deploy flag, with observable prediction binding so silent degradation becomes visible.
+
+**Architecture:** Add a strict-Pydantic `recent_tool_results` field on `process_agent_update`. Inside the same MCP call, Phase-5 emits `outcome_event` per item with `verification_source="agent_reported_tool_result"`. Hardens TTL on `consume_prediction` and echoes `prediction_binding` so callers can see whether their prediction_id actually bound. Behind a `UNITARES_PHASE5_EVIDENCE_WRITE` flag (off → shadow → enable) so the calibrator's class-conditional scales aren't silently shifted by a flood of new rows.
+
+**Tech Stack:** Python 3.12, Pydantic v2, asyncio, PostgreSQL@17. Spec at `docs/proposals/refined-phase-5-evidence-contract.md`.
+
+**Branching:** Each task lands as its own commit on a single feature branch (`fix/refined-phase-5-evidence-contract`). Use `./scripts/dev/ship.sh` after the full test suite passes — runtime classification will route to PR + auto-merge.
+
+---
+
+## File Map
+
+**Modify (runtime):**
+- `src/monitor_prediction.py` — add `ttl_seconds` parameter to `consume_prediction`; hard expiry check (Task 1)
+- `src/mcp_handlers/observability/outcome_events.py` — two-phase peek/consume; `prediction_binding` label; `verification_source` propagation (Tasks 1, 3)
+- `src/mcp_handlers/schemas/core.py` — `verification_source` on `OutcomeEventParams`; new `ToolResultEvidence` model; `recent_tool_results` on `ProcessAgentUpdateParams` (Tasks 3, 4)
+- `src/services/update_response_service.py` — merge `ctx.warnings` into `response_data["warnings"]` (Task 2)
+- `src/mcp_handlers/response_formatter.py` — pass `prediction_id` + `warnings` through `_format_standard`/`_format_mirror`/`_format_compact` (Task 2)
+- `src/mcp_handlers/updates/phases.py` — Phase-5 iteration over `recent_tool_results` after confidence correction; deploy-flag gate (Task 4)
+- `src/mcp_handlers/updates/context.py` — add `recent_tool_results: List[ToolResultEvidence]` to `UpdateContext` (Task 4)
+- `src/sequential_calibration.py:36-47` — docstring fix (Task 5)
+- `src/mcp_handlers/admin/system.py` (or wherever describe_tool lives) — update `process_agent_update` returns block (Task 5)
+
+**Modify (tests):**
+- `tests/test_outcome_calibration.py` — `prediction_binding` table; concurrency canary; `verification_source` round-trip (Tasks 1, 3)
+- `tests/test_calibration_corrections.py` — already covers `apply_confidence_correction`; no change in this plan
+- `tests/test_response_formatter.py` — `prediction_id` + `warnings` preservation in each mode (Task 2)
+- `tests/test_pydantic_schemas.py` — `ToolResultEvidence` validation; `recent_tool_results` field acceptance (Tasks 3, 4)
+- `tests/test_phases_phase5_evidence.py` (new) — Phase-5 iteration; per-item isolation; deploy-flag behavior (Task 4)
+- `tests/test_describe_tool_drift.py` (new) — schema vs describe_tool returns block parity (Task 5)
+
+---
+
+## Task 1: `prediction_binding` echo + hard TTL on `consume_prediction`
+
+**Why bundled:** Per spec §"Implementation order" — both touch the same code path; the binding label is the point of the TTL check. Shipping one without the other creates either visibility-without-enforcement or enforcement-without-visibility.
+
+**Files:**
+- Modify: `src/monitor_prediction.py:48-64`
+- Modify: `src/mcp_handlers/observability/outcome_events.py:163-225`
+- Test: `tests/test_outcome_calibration.py`
+
+- [ ] **Step 1: Write failing test for `consume_prediction` TTL parameter**
+
+Add to `tests/test_outcome_calibration.py`:
+
+```python
+import time
+from src.monitor_prediction import register_tactical_prediction, consume_prediction
+
+class TestConsumePredictionHardTTL:
+    def test_consume_returns_none_when_past_ttl(self):
+        open_predictions = {}
+        pid = register_tactical_prediction(
+            open_predictions, confidence=0.7, prediction_ttl_seconds=3600.0
+        )
+        # Force the record's age past TTL by rewriting created_at
+        open_predictions[pid]["created_at"] -= 7200.0  # 2 hours old
+        result = consume_prediction(open_predictions, pid, ttl_seconds=3600.0)
+        assert result is None
+
+    def test_consume_succeeds_when_within_ttl(self):
+        open_predictions = {}
+        pid = register_tactical_prediction(open_predictions, confidence=0.7)
+        result = consume_prediction(open_predictions, pid, ttl_seconds=3600.0)
+        assert result is not None
+        assert result["confidence"] == 0.7
+
+    def test_expired_record_is_not_consumed(self):
+        # The expired record stays in the dict (not consumed) so the
+        # caller's lookup_prediction can later distinguish "expired" from
+        # "missing" when computing prediction_binding.
+        open_predictions = {}
+        pid = register_tactical_prediction(open_predictions, confidence=0.7)
+        open_predictions[pid]["created_at"] -= 7200.0
+        consume_prediction(open_predictions, pid, ttl_seconds=3600.0)
+        assert open_predictions[pid].get("consumed") is not True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest tests/test_outcome_calibration.py::TestConsumePredictionHardTTL -v --no-cov --tb=short
+```
+
+Expected: 3 FAILS — `consume_prediction()` doesn't accept `ttl_seconds` keyword.
+
+- [ ] **Step 3: Add `ttl_seconds` parameter to `consume_prediction`**
+
+Replace the body of `consume_prediction` in `src/monitor_prediction.py`:
+
+```python
+def consume_prediction(
+    open_predictions: Dict[str, Dict],
+    prediction_id: str,
+    *,
+    ttl_seconds: float = 3600.0,
+) -> Optional[Dict[str, Any]]:
+    """Mark a prediction as consumed and return its record.
+
+    Returns None if the id is unknown, already consumed, or past TTL.
+    Expired records are NOT marked consumed — they remain in the registry
+    so callers using lookup_prediction can distinguish "missing" from
+    "expired" when computing prediction_binding labels.
+    """
+    if not prediction_id:
+        return None
+    record = open_predictions.get(prediction_id)
+    if not record or record.get("consumed"):
+        return None
+    age = _time.monotonic() - float(record.get("created_at", 0.0))
+    if age > ttl_seconds:
+        return None
+    record["consumed"] = True
+    return dict(record)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pytest tests/test_outcome_calibration.py::TestConsumePredictionHardTTL -v --no-cov --tb=short
+```
+
+Expected: 3 PASS.
+
+- [ ] **Step 5: Write failing tests for `prediction_binding` echo**
+
+Add to `tests/test_outcome_calibration.py`:
+
+```python
+import pytest
+
+class TestPredictionBindingEcho:
+    """Six binding labels per spec §4. Each fallback path emits a distinct label."""
+
+    @pytest.mark.asyncio
+    async def test_binding_registry_when_id_lives(self, monkeypatch, registered_agent):
+        # registered_agent fixture mints a prediction_id via process_agent_update
+        pid = registered_agent.last_prediction_id
+        result = await call_outcome_event(
+            outcome_type="test_passed",
+            prediction_id=pid,
+            client_session_id=registered_agent.session_id,
+        )
+        assert result["prediction_binding"] == "registry"
+
+    @pytest.mark.asyncio
+    async def test_binding_missing_prediction_when_id_unknown(self, registered_agent):
+        result = await call_outcome_event(
+            outcome_type="test_passed",
+            prediction_id="00000000-0000-0000-0000-000000000000",
+            confidence=0.5,
+            client_session_id=registered_agent.session_id,
+        )
+        assert result["prediction_binding"] in ("missing_prediction", "argument_fallback")
+        # Spec: missing then argument fallback fires; binding label is the FIRST resolution attempted.
+        assert result["prediction_binding"] == "missing_prediction"
+
+    @pytest.mark.asyncio
+    async def test_binding_ttl_expired_when_record_present_but_old(
+        self, monkeypatch, registered_agent
+    ):
+        pid = registered_agent.last_prediction_id
+        # Force the record past TTL
+        monitor = registered_agent.monitor
+        monitor._open_predictions[pid]["created_at"] -= 7200.0
+        result = await call_outcome_event(
+            outcome_type="test_passed",
+            prediction_id=pid,
+            confidence=0.5,
+            client_session_id=registered_agent.session_id,
+        )
+        assert result["prediction_binding"] == "ttl_expired_fallback"
+
+    @pytest.mark.asyncio
+    async def test_binding_argument_fallback_when_no_id_supplied(self, registered_agent):
+        result = await call_outcome_event(
+            outcome_type="test_passed",
+            confidence=0.5,
+            client_session_id=registered_agent.session_id,
+        )
+        assert result["prediction_binding"] == "argument_fallback"
+
+    @pytest.mark.asyncio
+    async def test_binding_no_binding_when_all_fallbacks_fail(self, fresh_agent_no_history):
+        # Fresh agent: no monitor, no prev_confidence, no audit trail
+        result = await call_outcome_event(
+            outcome_type="test_passed",
+            client_session_id=fresh_agent_no_history.session_id,
+        )
+        assert result["prediction_binding"] == "no_binding"
+```
+
+> The fixtures (`registered_agent`, `fresh_agent_no_history`, `call_outcome_event`) are utilities: if they don't exist, add minimal helpers in the test module (don't put in conftest unless reused beyond this file). Each fixture should call the real onboard/process_agent_update flow to mint state.
+
+- [ ] **Step 6: Run tests to verify they fail**
+
+```bash
+pytest tests/test_outcome_calibration.py::TestPredictionBindingEcho -v --no-cov --tb=short
+```
+
+Expected: 5 FAILS — response shape doesn't include `prediction_binding`.
+
+- [ ] **Step 7: Add `prediction_binding` computation to `outcome_events.py`**
+
+In `src/mcp_handlers/observability/outcome_events.py`, replace the prediction-resolution block (lines 170-207) with two-phase logic:
+
+```python
+# Two-phase prediction resolution: peek first to compute binding label,
+# then consume only if live. See spec §4 — without peek, ttl_expired and
+# missing collapse into the same None return from consume_prediction.
+from src.monitor_prediction import lookup_prediction, consume_prediction
+import time as _time
+
+_confidence: Optional[float] = None
+prediction_source: Optional[str] = None
+prediction_record: Optional[Dict[str, Any]] = None
+prediction_binding: str = "no_binding"
+ttl_seconds = float(getattr(mcp_server.monitors.get(agent_id), "_prediction_ttl_seconds", 3600.0))
+
+if prediction_id:
+    monitor = mcp_server.monitors.get(agent_id)
+    open_predictions = getattr(monitor, "_open_predictions", None) if monitor else None
+    if open_predictions is not None:
+        record_peek = lookup_prediction(open_predictions, prediction_id)
+        if record_peek is None:
+            prediction_binding = "missing_prediction"
+        else:
+            age = _time.monotonic() - float(record_peek.get("created_at", 0.0))
+            if age > ttl_seconds:
+                prediction_binding = "ttl_expired_fallback"
+            else:
+                prediction_record = consume_prediction(
+                    open_predictions, prediction_id, ttl_seconds=ttl_seconds
+                )
+                if prediction_record is not None:
+                    _confidence = float(prediction_record.get("confidence"))
+                    prediction_source = "registry"
+                    prediction_binding = "registry"
+                else:
+                    # Race: another consumer beat us. Treat as missing.
+                    prediction_binding = "missing_prediction"
+
+if _confidence is None:
+    _raw_conf = arguments.get("confidence")
+    if _raw_conf is not None:
+        _confidence = float(_raw_conf)
+        prediction_source = prediction_source or "argument"
+        if prediction_binding == "no_binding":
+            prediction_binding = "argument_fallback"
+
+if _confidence is None:
+    try:
+        monitor = mcp_server.monitors.get(agent_id)
+        prev_confidence = getattr(monitor, "_prev_confidence", None) if monitor else None
+        if isinstance(prev_confidence, (int, float)):
+            _confidence = float(prev_confidence)
+            prediction_source = prediction_source or "prev_confidence_fallback"
+            if prediction_binding == "no_binding":
+                prediction_binding = "prev_confidence_fallback"
+    except Exception:
+        pass
+
+if _confidence is None:
+    try:
+        db_conf = await db.get_latest_confidence_before(agent_id=agent_id)
+        if db_conf is not None:
+            _confidence = db_conf
+            prediction_source = prediction_source or "audit_trail_fallback"
+            if prediction_binding == "no_binding":
+                prediction_binding = "audit_trail_fallback"
+    except Exception:
+        pass
+```
+
+Then in the response payload at the end of `handle_outcome_event`, add `prediction_binding`:
+
+```python
+return [success_response({
+    "outcome_id": outcome_id,
+    "outcome_type": outcome_type,
+    "is_bad": is_bad,
+    "outcome_score": outcome_score,
+    "eisv_snapshot": snapshot,
+    "prediction_binding": prediction_binding,
+})]
+```
+
+- [ ] **Step 8: Run all outcome_event tests to verify**
+
+```bash
+pytest tests/test_outcome_calibration.py -v --no-cov --tb=short
+```
+
+Expected: all PASS (existing + 5 new binding tests + 3 new TTL tests).
+
+- [ ] **Step 9: Add concurrency regression canary**
+
+Append to `tests/test_outcome_calibration.py`:
+
+```python
+class TestPredictionBindingConcurrencyCanary:
+    """Regression canary, NOT a correctness assertion. Documents current
+    behavior under racing outcome_events for the same prediction_id.
+    The lock fix is explicitly deferred per spec §4. If this test ever
+    starts failing because both calls resolve as `registry`, the race
+    has become observable and the lock is no longer optional.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_outcome_events_one_wins_one_misses(self, registered_agent):
+        import asyncio
+        pid = registered_agent.last_prediction_id
+        results = await asyncio.gather(
+            call_outcome_event(outcome_type="test_passed", prediction_id=pid,
+                               client_session_id=registered_agent.session_id),
+            call_outcome_event(outcome_type="test_passed", prediction_id=pid,
+                               client_session_id=registered_agent.session_id),
+        )
+        bindings = sorted(r["prediction_binding"] for r in results)
+        # Under typical scheduling: one wins (registry), one misses (missing_prediction).
+        # Under unlucky scheduling without a lock, both could resolve as registry —
+        # which is the failure mode this canary will eventually catch.
+        assert bindings.count("registry") <= 1, (
+            "Concurrency race made both calls resolve to registry — "
+            "the lock fix deferred in v1 is no longer optional"
+        )
+```
+
+- [ ] **Step 10: Run full test suite to confirm no regressions**
+
+```bash
+./scripts/dev/test-cache.sh
+```
+
+Expected: all PASS (≥ 7501 like prior runs + new tests).
+
+- [ ] **Step 11: Stage + commit + push via ship.sh**
+
+```bash
+git add src/monitor_prediction.py src/mcp_handlers/observability/outcome_events.py tests/test_outcome_calibration.py
+./scripts/dev/ship.sh "phase-5: prediction_binding echo + hard TTL on consume_prediction"
+```
+
+Expected: routes as runtime → PR auto-opened.
+
+---
+
+## Task 2: Plumb `prediction_id` + `warnings` through formatter modes
+
+**Files:**
+- Modify: `src/services/update_response_service.py:16-50` (merge `ctx.warnings` into response_data)
+- Modify: `src/mcp_handlers/response_formatter.py:115,159,331` (`_format_standard`, `_format_mirror`, `_format_compact` — pass through both fields)
+- Test: `tests/test_response_formatter.py`
+
+> `_format_minimal` is intentionally bandwidth-constrained per spec §6 — leave stripped.
+
+- [ ] **Step 1: Write failing tests for `prediction_id` preservation**
+
+Add to `tests/test_response_formatter.py`:
+
+```python
+class TestFormatStandardPreservesPredictionId:
+    def test_prediction_id_passes_through(self):
+        from src.mcp_handlers.response_formatter import _format_standard
+        response_data = {
+            "decision": {"action": "proceed"},
+            "metrics": {"E": 0.5, "I": 0.5, "S": 0.3, "V": 0.0, "phi": 0.7},
+            "prediction_id": "abc-123",
+        }
+        result = _format_standard(response_data, task_type="general")
+        assert result.get("prediction_id") == "abc-123"
+
+    def test_warnings_passes_through(self):
+        from src.mcp_handlers.response_formatter import _format_standard
+        response_data = {
+            "decision": {"action": "proceed"},
+            "metrics": {"E": 0.5, "I": 0.5, "S": 0.3, "V": 0.0, "phi": 0.7},
+            "warnings": ["evidence record failed for tool=pytest"],
+        }
+        result = _format_standard(response_data, task_type="general")
+        assert result.get("warnings") == ["evidence record failed for tool=pytest"]
+
+
+class TestFormatMirrorPreservesPredictionId:
+    def test_prediction_id_passes_through(self):
+        from src.mcp_handlers.response_formatter import _format_mirror
+        response_data = {
+            "decision": {"action": "proceed"},
+            "metrics": {"E": 0.5, "I": 0.5, "S": 0.3, "V": 0.0, "phi": 0.7},
+            "prediction_id": "abc-123",
+        }
+        result = _format_mirror(response_data, saved_trust_tier=None, meta=None)
+        assert result.get("prediction_id") == "abc-123"
+
+    def test_warnings_passes_through(self):
+        from src.mcp_handlers.response_formatter import _format_mirror
+        response_data = {
+            "decision": {"action": "proceed"},
+            "metrics": {"E": 0.5, "I": 0.5, "S": 0.3, "V": 0.0, "phi": 0.7},
+            "warnings": ["W"],
+        }
+        result = _format_mirror(response_data, saved_trust_tier=None, meta=None)
+        assert result.get("warnings") == ["W"]
+
+
+class TestFormatCompactPreservesPredictionId:
+    def test_prediction_id_passes_through(self):
+        from src.mcp_handlers.response_formatter import _format_compact
+        response_data = {
+            "decision": {"action": "proceed"},
+            "metrics": {"E": 0.5, "I": 0.5, "S": 0.3, "V": 0.0, "phi": 0.7},
+            "prediction_id": "abc-123",
+        }
+        result = _format_compact(response_data, using_default_mode=False, saved_trust_tier=None)
+        assert result.get("prediction_id") == "abc-123"
+
+
+class TestFormatMinimalIntentionallyStrips:
+    def test_minimal_does_not_include_prediction_id(self):
+        # Spec §6: minimal mode is bandwidth-constrained; prediction_id stripped intentionally.
+        from src.mcp_handlers.response_formatter import _format_minimal
+        response_data = {
+            "decision": {"action": "proceed"},
+            "metrics": {"E": 0.5, "I": 0.5, "S": 0.3, "V": 0.0, "phi": 0.7},
+            "prediction_id": "abc-123",
+        }
+        result = _format_minimal(response_data, using_default_mode=False, saved_trust_tier=None)
+        assert "prediction_id" not in result
+
+
+class TestUpdateResponseServiceMergesWarnings:
+    def test_ctx_warnings_appear_in_response_data(self):
+        # build_process_update_response_data should merge ctx.warnings (de-duped)
+        # into response_data["warnings"].
+        from src.services.update_response_service import build_process_update_response_data
+        from src.mcp_handlers.updates.context import UpdateContext
+        ctx = UpdateContext()  # adapt to real constructor signature
+        ctx.warnings = ["w1", "w1", "w2"]  # duplicate to verify de-dup
+        # build_process_update_response_data takes more args than this stub —
+        # adapt to real signature; the assertion is the load-bearing piece:
+        response_data = build_process_update_response_data(ctx)
+        assert sorted(response_data.get("warnings", [])) == ["w1", "w2"]
+```
+
+> If `UpdateContext()` requires args you don't have, use the existing test's pattern for constructing it (search test files for `UpdateContext(`).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/test_response_formatter.py -k "PreservesPredictionId or IntentionallyStrips or MergesWarnings" -v --no-cov --tb=short
+```
+
+Expected: 7 FAILS.
+
+- [ ] **Step 3: Add `prediction_id` + `warnings` to each formatter's result dict**
+
+In `src/mcp_handlers/response_formatter.py`, edit `_format_standard` (around line 138-149) — append before `return result`:
+
+```python
+if response_data.get("prediction_id"):
+    result["prediction_id"] = response_data["prediction_id"]
+if response_data.get("warnings"):
+    result["warnings"] = response_data["warnings"]
+```
+
+Repeat the same two-line addition inside `_format_mirror` (right before its `return`), and inside `_format_compact` (right before its `return`).
+
+`_format_minimal` is left unchanged per spec §6.
+
+- [ ] **Step 4: Add `ctx.warnings → response_data["warnings"]` merge in `build_process_update_response_data`**
+
+In `src/services/update_response_service.py`, inside `build_process_update_response_data`, after the existing fields populate `response_data`, add:
+
+```python
+warnings_seen = []
+for w in (getattr(ctx, "warnings", None) or []):
+    if w not in warnings_seen:
+        warnings_seen.append(w)
+if warnings_seen:
+    response_data["warnings"] = warnings_seen
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+pytest tests/test_response_formatter.py -k "PreservesPredictionId or IntentionallyStrips or MergesWarnings" -v --no-cov --tb=short
+```
+
+Expected: 7 PASS.
+
+- [ ] **Step 6: Run full test suite**
+
+```bash
+./scripts/dev/test-cache.sh
+```
+
+Expected: all PASS.
+
+- [ ] **Step 7: Stage + commit + push**
+
+```bash
+git add src/services/update_response_service.py src/mcp_handlers/response_formatter.py tests/test_response_formatter.py
+./scripts/dev/ship.sh "phase-5: plumb prediction_id + warnings through formatter modes"
+```
+
+---
+
+## Task 3: `verification_source` enum on `outcome_event`
+
+**Files:**
+- Modify: `src/mcp_handlers/schemas/core.py:181-191` (add field to `OutcomeEventParams`)
+- Modify: `src/mcp_handlers/observability/outcome_events.py` (forward to `detail` dict; default if missing)
+- Test: `tests/test_pydantic_schemas.py` + `tests/test_outcome_calibration.py`
+
+Storage decision: in v1, store as `detail["verification_source"]` rather than promoting to a typed DB column. v1 records the dimension; v2 (when calibrator weighting goes live) can promote to a typed column if filtering performance demands it.
+
+- [ ] **Step 1: Write failing schema test**
+
+Add to `tests/test_pydantic_schemas.py`:
+
+```python
+class TestVerificationSource:
+    def test_default_is_agent_reported_tool_result(self):
+        from src.mcp_handlers.schemas.core import OutcomeEventParams
+        params = OutcomeEventParams(outcome_type="test_passed")
+        assert params.verification_source == "agent_reported_tool_result"
+
+    def test_accepts_server_observation(self):
+        from src.mcp_handlers.schemas.core import OutcomeEventParams
+        params = OutcomeEventParams(
+            outcome_type="test_passed",
+            verification_source="server_observation",
+        )
+        assert params.verification_source == "server_observation"
+
+    def test_rejects_unknown_value(self):
+        import pytest
+        from pydantic import ValidationError
+        from src.mcp_handlers.schemas.core import OutcomeEventParams
+        with pytest.raises(ValidationError):
+            OutcomeEventParams(
+                outcome_type="test_passed",
+                verification_source="random_made_up_string",
+            )
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+```bash
+pytest tests/test_pydantic_schemas.py::TestVerificationSource -v --no-cov --tb=short
+```
+
+Expected: 3 FAILS — `OutcomeEventParams` has no `verification_source` field.
+
+- [ ] **Step 3: Add field to `OutcomeEventParams`**
+
+In `src/mcp_handlers/schemas/core.py:181-191`, add after `agent_id`:
+
+```python
+    verification_source: Literal[
+        "agent_reported_tool_result",
+        "server_observation",
+        "external_signal",
+    ] = Field(
+        "agent_reported_tool_result",
+        description=(
+            "Provenance of this outcome. v1 default is agent_reported_tool_result. "
+            "server_observation reserved for v2 server-verified primitive (KG writes, "
+            "dialectic verdicts, state transitions). external_signal for CI webhooks etc."
+        ),
+    )
+```
+
+- [ ] **Step 4: Run schema tests to verify pass**
+
+```bash
+pytest tests/test_pydantic_schemas.py::TestVerificationSource -v --no-cov --tb=short
+```
+
+Expected: 3 PASS.
+
+- [ ] **Step 5: Forward `verification_source` to `detail` in handler**
+
+In `src/mcp_handlers/observability/outcome_events.py`, in the `detail` population block (around lines 218-225), add:
+
+```python
+detail["verification_source"] = arguments.get(
+    "verification_source", "agent_reported_tool_result"
+)
+```
+
+- [ ] **Step 6: Write integration test for round-trip**
+
+Append to `tests/test_outcome_calibration.py`:
+
+```python
+class TestVerificationSourceRoundTrip:
+    @pytest.mark.asyncio
+    async def test_default_recorded_in_detail(self, registered_agent):
+        result = await call_outcome_event(
+            outcome_type="test_passed",
+            confidence=0.7,
+            client_session_id=registered_agent.session_id,
+        )
+        # Read back from the DB row via outcome_id
+        row = await fetch_outcome_row(result["outcome_id"])
+        assert row["detail"]["verification_source"] == "agent_reported_tool_result"
+
+    @pytest.mark.asyncio
+    async def test_server_observation_recorded_when_set(self, registered_agent):
+        result = await call_outcome_event(
+            outcome_type="test_passed",
+            confidence=0.7,
+            verification_source="server_observation",
+            client_session_id=registered_agent.session_id,
+        )
+        row = await fetch_outcome_row(result["outcome_id"])
+        assert row["detail"]["verification_source"] == "server_observation"
+```
+
+> If `fetch_outcome_row` doesn't exist as a test util, add a minimal helper in this module that queries `outcome_events` by id.
+
+- [ ] **Step 7: Run + commit + push**
+
+```bash
+pytest tests/test_outcome_calibration.py::TestVerificationSourceRoundTrip -v --no-cov --tb=short
+./scripts/dev/test-cache.sh
+git add src/mcp_handlers/schemas/core.py src/mcp_handlers/observability/outcome_events.py tests/test_pydantic_schemas.py tests/test_outcome_calibration.py
+./scripts/dev/ship.sh "phase-5: verification_source enum on outcome_event"
+```
+
+---
+
+## Task 4: `ToolResultEvidence` model + `recent_tool_results` field + Phase-5 iteration + deploy gate
+
+**Why bundled:** Schema and consumer ship together so the field never accepts data the server silently drops. Deploy gate ships with the iteration so the production calibration distribution isn't shifted by the merge.
+
+**Files:**
+- Modify: `src/mcp_handlers/schemas/core.py` (add `ToolResultEvidence` model + field on `ProcessAgentUpdateParams`)
+- Modify: `src/mcp_handlers/updates/context.py` (`UpdateContext` gains `recent_tool_results: List[ToolResultEvidence]`)
+- Modify: `src/mcp_handlers/updates/phases.py` around line 430 (Phase-5 iteration after `apply_confidence_correction`)
+- Test: `tests/test_pydantic_schemas.py` + new `tests/test_phases_phase5_evidence.py`
+
+- [ ] **Step 1: Write failing schema tests for `ToolResultEvidence`**
+
+Add to `tests/test_pydantic_schemas.py`:
+
+```python
+class TestToolResultEvidence:
+    def test_minimal_valid(self):
+        from src.mcp_handlers.schemas.core import ToolResultEvidence
+        ev = ToolResultEvidence(kind="test", tool="pytest", summary="ok")
+        assert ev.kind == "test"
+        assert ev.exit_code is None
+
+    def test_rejects_extra_fields(self):
+        import pytest
+        from pydantic import ValidationError
+        from src.mcp_handlers.schemas.core import ToolResultEvidence
+        with pytest.raises(ValidationError):
+            ToolResultEvidence(kind="test", tool="pytest", summary="ok", random_field="x")
+
+    def test_rejects_unknown_kind(self):
+        import pytest
+        from pydantic import ValidationError
+        from src.mcp_handlers.schemas.core import ToolResultEvidence
+        with pytest.raises(ValidationError):
+            ToolResultEvidence(kind="not_a_real_kind", tool="x", summary="x")
+
+    def test_tool_name_max_length(self):
+        import pytest
+        from pydantic import ValidationError
+        from src.mcp_handlers.schemas.core import ToolResultEvidence
+        with pytest.raises(ValidationError):
+            ToolResultEvidence(kind="test", tool="x" * 65, summary="ok")
+
+
+class TestProcessAgentUpdateAcceptsRecentToolResults:
+    def test_optional_field_defaults_none(self):
+        from src.mcp_handlers.schemas.core import ProcessAgentUpdateParams
+        params = ProcessAgentUpdateParams(response_text="hello")
+        assert params.recent_tool_results is None
+
+    def test_accepts_list_of_evidence(self):
+        from src.mcp_handlers.schemas.core import ProcessAgentUpdateParams
+        params = ProcessAgentUpdateParams(
+            response_text="ran tests",
+            recent_tool_results=[
+                {"kind": "test", "tool": "pytest", "summary": "passed", "exit_code": 0}
+            ],
+        )
+        assert len(params.recent_tool_results) == 1
+        assert params.recent_tool_results[0].kind == "test"
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+```bash
+pytest tests/test_pydantic_schemas.py -k "ToolResultEvidence or ProcessAgentUpdateAcceptsRecentToolResults" -v --no-cov --tb=short
+```
+
+Expected: 6 FAILS — `ToolResultEvidence` doesn't exist, `recent_tool_results` field missing.
+
+- [ ] **Step 3: Add `ToolResultEvidence` model + field**
+
+In `src/mcp_handlers/schemas/core.py`, add ABOVE `class OutcomeEventParams`:
+
+```python
+class ToolResultEvidence(BaseModel):
+    """Self-reported tool outcome evidence from a recent agent action.
+
+    Self-report — the server treats this as
+    `verification_source="agent_reported_tool_result"`. A future server-verified
+    primitive will provide `server_observation` outcomes for the subset of
+    work the server can independently verify. See spec §1.
+    """
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["command", "test", "lint", "build", "file_op", "tool_call"]
+    tool: str = Field(..., max_length=64)
+    summary: str = Field(..., max_length=512)
+    exit_code: Optional[int] = None
+    is_bad: Optional[bool] = None
+    prediction_id: Optional[str] = None
+    observed_at: Optional[datetime] = None
+```
+
+In `class ProcessAgentUpdateParams`, add:
+
+```python
+    recent_tool_results: Optional[List[ToolResultEvidence]] = Field(
+        None,
+        description=(
+            "Self-reported tool outcomes from the agent's most recent actions. "
+            "Server emits one outcome_event per item (gated by "
+            "UNITARES_PHASE5_EVIDENCE_WRITE). See docs/proposals/refined-phase-5-evidence-contract.md."
+        ),
+    )
+```
+
+Make sure `from datetime import datetime`, `from pydantic import ConfigDict`, and `from typing import List` are imported at the top of the module (they likely already are; check).
+
+- [ ] **Step 4: Run schema tests to verify pass**
+
+```bash
+pytest tests/test_pydantic_schemas.py -k "ToolResultEvidence or ProcessAgentUpdateAcceptsRecentToolResults" -v --no-cov --tb=short
+```
+
+Expected: 6 PASS.
+
+- [ ] **Step 5: Add `recent_tool_results` to `UpdateContext`**
+
+In `src/mcp_handlers/updates/context.py` (around line 73 where `warnings` lives), add:
+
+```python
+    recent_tool_results: List[Any] = field(default_factory=list)
+```
+
+(Use `Any` here to avoid a circular import on `ToolResultEvidence`; coerce at consumption site.)
+
+Then in the existing `transform_inputs` Phase 3 (`phases.py` around the existing `ctx.confidence` assignment), populate it:
+
+```python
+ctx.recent_tool_results = ctx.arguments.get("recent_tool_results") or []
+```
+
+- [ ] **Step 6: Write failing tests for Phase-5 iteration**
+
+Create `tests/test_phases_phase5_evidence.py`:
+
+```python
+"""Phase-5 iteration over recent_tool_results — spec §2.
+
+Tests the full process_agent_update path with a list of evidence items
+under each UNITARES_PHASE5_EVIDENCE_WRITE deploy-flag setting.
+"""
+
+import os
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_evidence_iteration_off_by_default(registered_agent, monkeypatch):
+    monkeypatch.delenv("UNITARES_PHASE5_EVIDENCE_WRITE", raising=False)
+    samples_before = await get_eligible_samples()
+    await call_process_agent_update(
+        client_session_id=registered_agent.session_id,
+        response_text="ran 3 tests",
+        confidence=0.7,
+        recent_tool_results=[
+            {"kind": "test", "tool": "pytest", "summary": "passed", "exit_code": 0}
+        ],
+    )
+    samples_after = await get_eligible_samples()
+    assert samples_after == samples_before, "default off should not write outcome_events"
+
+
+@pytest.mark.asyncio
+async def test_evidence_iteration_shadow_writes_with_flag(registered_agent, monkeypatch):
+    monkeypatch.setenv("UNITARES_PHASE5_EVIDENCE_WRITE", "shadow")
+    samples_before = await get_eligible_samples()
+    result = await call_process_agent_update(
+        client_session_id=registered_agent.session_id,
+        response_text="ran 3 tests",
+        confidence=0.7,
+        recent_tool_results=[
+            {"kind": "test", "tool": "pytest", "summary": "passed", "exit_code": 0}
+        ],
+    )
+    samples_after = await get_eligible_samples()
+    # Shadow rows are written but excluded from the calibration sample count
+    assert samples_after == samples_before
+
+
+@pytest.mark.asyncio
+async def test_evidence_iteration_enabled_advances_calibration(registered_agent, monkeypatch):
+    monkeypatch.setenv("UNITARES_PHASE5_EVIDENCE_WRITE", "1")
+    samples_before = await get_eligible_samples()
+    await call_process_agent_update(
+        client_session_id=registered_agent.session_id,
+        response_text="ran 3 tests",
+        confidence=0.7,
+        recent_tool_results=[
+            {"kind": "test", "tool": "pytest", "summary": "passed", "exit_code": 0}
+        ],
+    )
+    samples_after = await get_eligible_samples()
+    assert samples_after == samples_before + 1
+
+
+@pytest.mark.asyncio
+async def test_per_item_isolation_one_bad_does_not_abort_siblings(registered_agent, monkeypatch):
+    monkeypatch.setenv("UNITARES_PHASE5_EVIDENCE_WRITE", "1")
+    samples_before = await get_eligible_samples()
+    response = await call_process_agent_update(
+        client_session_id=registered_agent.session_id,
+        response_text="three results, middle one will fail to record",
+        confidence=0.7,
+        recent_tool_results=[
+            {"kind": "test", "tool": "pytest", "summary": "ok", "exit_code": 0},
+            {"kind": "test", "tool": "pytest_bad", "summary": "x" * 600, "exit_code": 0},  # exceeds summary max_length — won't reach handler since pydantic validates first
+            {"kind": "test", "tool": "pytest", "summary": "ok", "exit_code": 0},
+        ],
+    )
+    # Pydantic catches the over-length summary at the schema layer, so item 2 is
+    # rejected before Phase-5 runs. Items 1 and 3 still record. The whole call
+    # returns the validation error as a 4xx — to test true per-item isolation,
+    # construct a runtime failure instead (e.g., a prediction_id that triggers
+    # a server-side path failure). Adapt to the actual failure surface.
+    # Acceptance: when the handler IS called with valid items + one runtime-failing item,
+    # the failing item appends to ctx.warnings and siblings still produce outcome rows.
+    samples_after = await get_eligible_samples()
+    assert samples_after - samples_before == 2  # items 1 and 3 only
+    # warnings field should mention the failed tool
+    assert any("pytest_bad" in w for w in response.get("warnings", []))
+
+
+@pytest.mark.asyncio
+async def test_kind_to_outcome_type_mapping(registered_agent, monkeypatch):
+    """Spec §1: test → test_passed/test_failed; everything else → task_completed/task_failed."""
+    monkeypatch.setenv("UNITARES_PHASE5_EVIDENCE_WRITE", "1")
+    await call_process_agent_update(
+        client_session_id=registered_agent.session_id,
+        response_text="various tools",
+        confidence=0.7,
+        recent_tool_results=[
+            {"kind": "test", "tool": "pytest", "summary": "ok", "exit_code": 0},
+            {"kind": "lint", "tool": "ruff", "summary": "ok", "exit_code": 0},
+            {"kind": "command", "tool": "git", "summary": "fail", "exit_code": 1},
+        ],
+    )
+    rows = await fetch_recent_outcome_rows(registered_agent.agent_uuid, limit=3)
+    types = sorted(r["outcome_type"] for r in rows)
+    assert types == ["task_completed", "task_failed", "test_passed"]
+```
+
+> Test fixtures `registered_agent`, `call_process_agent_update`, `get_eligible_samples`, `fetch_recent_outcome_rows` — minimal helpers in this module if not already in conftest.
+
+- [ ] **Step 7: Run to verify all fail**
+
+```bash
+pytest tests/test_phases_phase5_evidence.py -v --no-cov --tb=short
+```
+
+Expected: all FAIL — Phase-5 iteration not implemented.
+
+- [ ] **Step 8: Implement `_derive_outcome` helper**
+
+Add a module-level helper at the top of `src/mcp_handlers/updates/phases.py` (after imports):
+
+```python
+def _derive_outcome(evidence) -> tuple[str, bool]:
+    """Map ToolResultEvidence to (outcome_type, is_bad) per spec §1 mapping table."""
+    is_bad = evidence.is_bad
+    if is_bad is None:
+        is_bad = (evidence.exit_code is not None and evidence.exit_code != 0)
+    if evidence.kind == "test":
+        return ("test_failed" if is_bad else "test_passed", is_bad)
+    return ("task_failed" if is_bad else "task_completed", is_bad)
+```
+
+- [ ] **Step 9: Implement Phase-5 iteration with deploy gate**
+
+In `src/mcp_handlers/updates/phases.py`, AFTER the `apply_confidence_correction` block (around line 446), insert:
+
+```python
+    # Phase-5: iterate self-reported tool evidence. Spec §2 + §8.
+    evidence_mode = os.environ.get("UNITARES_PHASE5_EVIDENCE_WRITE", "").lower()
+    if ctx.recent_tool_results and evidence_mode in ("shadow", "1", "enable"):
+        from src.mcp_handlers.observability.outcome_events import handle_outcome_event
+        for evidence in ctx.recent_tool_results:
+            try:
+                outcome_type, is_bad = _derive_outcome(evidence)
+                detail = {
+                    "tool": evidence.tool,
+                    "summary": evidence.summary,
+                    "kind": evidence.kind,
+                    "exit_code": evidence.exit_code,
+                    "phase5_emitter": True,
+                }
+                if evidence_mode == "shadow":
+                    detail["shadow_write"] = True
+                await handle_outcome_event({
+                    "outcome_type": outcome_type,
+                    "is_bad": is_bad,
+                    "prediction_id": evidence.prediction_id,
+                    "confidence": ctx.confidence,
+                    "verification_source": "agent_reported_tool_result",
+                    "detail": detail,
+                    "agent_id": ctx.agent_id,
+                    "client_session_id": ctx.arguments.get("client_session_id"),
+                })
+            except Exception as e:
+                ctx.warnings.append(
+                    f"evidence record failed for tool={getattr(evidence, 'tool', '?')}: {e}"
+                )
+                logger.debug("Phase-5 evidence record failed: %s", e, exc_info=True)
+    elif ctx.recent_tool_results:
+        # Default off: log per-item count only, per spec §8
+        logger.info(
+            "Phase-5 evidence iteration skipped (UNITARES_PHASE5_EVIDENCE_WRITE unset); "
+            "would have processed %d items for agent=%s",
+            len(ctx.recent_tool_results), ctx.agent_id,
+        )
+```
+
+Make sure `import os` is at the top of the module if not already.
+
+- [ ] **Step 10: Run Phase-5 tests to verify pass**
+
+```bash
+pytest tests/test_phases_phase5_evidence.py -v --no-cov --tb=short
+```
+
+Expected: all PASS.
+
+- [ ] **Step 11: Run full test suite**
+
+```bash
+./scripts/dev/test-cache.sh
+```
+
+Expected: all PASS. Look for any regression in `tests/test_phases*.py`.
+
+- [ ] **Step 12: Stage + commit + push**
+
+```bash
+git add src/mcp_handlers/schemas/core.py src/mcp_handlers/updates/context.py src/mcp_handlers/updates/phases.py tests/test_pydantic_schemas.py tests/test_phases_phase5_evidence.py
+./scripts/dev/ship.sh "phase-5: ToolResultEvidence + recent_tool_results field + iteration + deploy gate"
+```
+
+---
+
+## Task 5: `describe_tool` returns documentation + `sequential_calibration.py` docstring fix + drift test
+
+**Why bundled:** Both are doc-only fixes; the drift test catches future regressions in either direction.
+
+**Files:**
+- Modify: `src/sequential_calibration.py:36-47`
+- Modify: wherever `describe_tool` returns block for `process_agent_update` lives — find via grep
+- Test: new `tests/test_describe_tool_drift.py`
+
+- [ ] **Step 1: Find `describe_tool` returns block source**
+
+```bash
+grep -rln "RETURNS\|returns block" src/mcp_handlers/admin/ src/tool_descriptions.py 2>/dev/null
+grep -n "process_agent_update" src/tool_descriptions.py 2>/dev/null
+```
+
+Note the file. Subsequent steps reference it as `<DESCRIBE_FILE>`.
+
+- [ ] **Step 2: Write failing drift test**
+
+Create `tests/test_describe_tool_drift.py`:
+
+```python
+"""describe_tool returns block must mention every documented response field.
+
+Catches the regression class that triggered spec rev 3 — a documented
+contract drifting from actual behavior because nothing tests the description.
+"""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_process_agent_update_describe_mentions_prediction_id():
+    from src.mcp_handlers.admin.system import handle_describe_tool  # adapt path
+    result = await handle_describe_tool({"tool_name": "process_agent_update"})
+    body = result[0].text  # MCP TextContent
+    assert "prediction_id" in body, (
+        "describe_tool returns block must document prediction_id "
+        "(spec §6 — exposed in default response modes)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_agent_update_describe_mentions_warnings():
+    from src.mcp_handlers.admin.system import handle_describe_tool
+    result = await handle_describe_tool({"tool_name": "process_agent_update"})
+    body = result[0].text
+    assert "warnings" in body, (
+        "describe_tool returns block must document warnings "
+        "(spec §2 — surfaced via formatters)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_agent_update_describe_mentions_recent_tool_results():
+    from src.mcp_handlers.admin.system import handle_describe_tool
+    result = await handle_describe_tool({"tool_name": "process_agent_update"})
+    body = result[0].text
+    assert "recent_tool_results" in body, (
+        "describe_tool block must document recent_tool_results "
+        "(spec §1 — new agent contract field)"
+    )
+```
+
+- [ ] **Step 3: Run to verify fail**
+
+```bash
+pytest tests/test_describe_tool_drift.py -v --no-cov --tb=short
+```
+
+Expected: 3 FAILS.
+
+- [ ] **Step 4: Update describe_tool returns block**
+
+In `<DESCRIBE_FILE>`, find the `process_agent_update` description's `RETURNS` block. Add (preserving existing structure):
+
+```
+- prediction_id (str, optional): A tactical prediction id. Pass this to outcome_event later
+  to bind the (confidence, timestamp) pair from this check-in to a recorded outcome.
+  Subject to TTL (default 3600s).
+- warnings (List[str], optional): Per-call non-fatal warnings, e.g. evidence-record failures
+  from recent_tool_results. Inspect to detect silent calibration-loss.
+- recent_tool_results (input field, List[ToolResultEvidence]): Self-reported tool outcomes
+  the agent just observed. Each item is iterated server-side under the
+  UNITARES_PHASE5_EVIDENCE_WRITE flag; failures append to warnings.
+```
+
+- [ ] **Step 5: Run drift test to verify pass**
+
+```bash
+pytest tests/test_describe_tool_drift.py -v --no-cov --tb=short
+```
+
+Expected: 3 PASS.
+
+- [ ] **Step 6: Fix `sequential_calibration.py` docstring**
+
+In `src/sequential_calibration.py:36-47`, replace:
+
+```
+    No prediction_id seam yet — when calibration_checker.record_tactical_decision
+    is called from observation paths, only confidence + immediate_outcome are
+    available. A prediction_id seam is phase-two work and is required before
+    composing this e-process with knowledge-graph or dialectic evidence streams.
+```
+
+with:
+
+```
+    The prediction_id seam is operational at the outcome_event tool level:
+    register_tactical_prediction (governance_monitor) mints; outcome_event consumes
+    via consume_prediction. The remaining gap was the report path — closed by the
+    Refined Phase-5 Evidence Contract (docs/proposals/refined-phase-5-evidence-contract.md),
+    which adds recent_tool_results to process_agent_update and emits outcome_event
+    server-side per item with verification_source="agent_reported_tool_result".
+```
+
+- [ ] **Step 7: Run full test suite**
+
+```bash
+./scripts/dev/test-cache.sh
+```
+
+Expected: all PASS.
+
+- [ ] **Step 8: Stage + commit + push**
+
+```bash
+git add src/sequential_calibration.py <DESCRIBE_FILE> tests/test_describe_tool_drift.py
+./scripts/dev/ship.sh "phase-5: describe_tool returns + sequential_calibration docstring + drift test"
+```
+
+---
+
+## Post-merge: deploy sequence
+
+After all PRs merge to master and the LaunchAgent restarts (per `restart` command in the local CLAUDE.md), follow spec §8 deploy sequence:
+
+1. **Default unset** — observe per-check-in counts in logs for 24h. Confirm counts are non-zero (agents are populating `recent_tool_results`) and within expected order of magnitude.
+2. **Flip to `shadow`** — set `UNITARES_PHASE5_EVIDENCE_WRITE=shadow` in the LaunchAgent plist + restart. Run for 48h. Compare `(agent_reported, shadow)` distribution against current sparse mix using a quick query against `outcome_events.detail`.
+3. **Flip to `1`** — once distribution looks acceptable, enable live writes. Watch dashboard calibration card for staleness flip from `signal_stale` to live values.
+
+This deploy sequence is operator work, not a code task — left out of the per-task checklist.
+
+---
+
+## Self-review notes
+
+**Spec coverage check:**
+- §1 contract → Task 4 ✓
+- §2 Phase-5 processing → Task 4 (iteration), Task 2 (warnings plumbing) ✓
+- §3 verification_source → Task 3 ✓
+- §4 prediction_binding echo → Task 1 ✓
+- §5 hard TTL → Task 1 ✓
+- §6 expose prediction_id → Task 2 ✓
+- §7 docstring fix → Task 5 ✓
+- §8 deploy gate → Task 4 ✓
+- §9 compatibility bridge — out of v1 scope per spec ✓ (no task)
+- All test plan items have a task ✓
+
+**Type consistency:** `ToolResultEvidence` (Task 4) referenced in Task 5 docs. `prediction_binding` enum values consistent across Task 1 (compute) and Task 5 (docs). `verification_source` string matches across Tasks 3, 4, 5.
+
+**Placeholder scan:** `<DESCRIBE_FILE>` in Task 5 is intentionally a discovery step (Task 5 Step 1). All other paths and code blocks are concrete.
+
+**Bundling sanity:** Task 1 = visibility+enforcement together. Task 4 = schema+consumer+gate together. Both align with spec §"Implementation order" squashes.


### PR DESCRIPTION
## Summary

Pure docs PR. Spec for the refined phase-5 evidence contract, three rounds of council review (code-reviewer, dialectic-knowledge-architect, gpt-style), live verification notes, and the implementation plan that backs the paired (not-yet-shipped) feature branch \`feat/refined-phase-5-evidence-contract\`.

| file | lines |
|---|---|
| docs/proposals/refined-phase-5-evidence-contract.md | 318 |
| docs/proposals/.code-review.md | 81 |
| docs/proposals/.dialectic-review.md | 28 |
| docs/proposals/.gpt-review.md | 57 |
| docs/proposals/.live-verification.md | 62 |
| docs/superpowers/plans/2026-04-26-refined-phase-5-evidence-contract.md | 1144 |

Total: +1690 / -0 across 6 files. No runtime code touched.

## Why a PR rather than direct commit

Substantive spec work (>1600 lines of architectural decisions) benefits from review surface even when ship.sh would route it as 'other' for direct push. PR exists for archival + comment thread.

## Companion branch

\`feat/refined-phase-5-evidence-contract\` carries the implementation but currently has uncommitted WIP — not yet ready to ship; deferred until that lands.