### PR TITLE
fix(self_recovery): persist paused_at + lifecycle_event in quick_resume and operator_resume (Watcher P011)

### DIFF
--- a/src/mcp_handlers/lifecycle/self_recovery.py
+++ b/src/mcp_handlers/lifecycle/self_recovery.py
@@ -41,6 +41,7 @@ from ..utils import (
 )
 from ..decorators import mcp_tool
 from ..support.coerce import safe_float, resolve_agent_uuid
+from .helpers import _invalidate_agent_cache
 from src.logging_utils import get_logger
 from config.governance_config import GovernanceConfig
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
@@ -462,20 +463,43 @@ async def handle_quick_resume(arguments: Dict[str, Any]) -> Sequence[TextContent
     except Exception as e:
         logger.warning(f"Failed to log quick_resume: {e}")
     
-    # Resume
     previous_status = meta.status
-    meta.status = "active"
-    meta.paused_at = None
-    clear_loop_detector_state(meta)
-    meta.add_lifecycle_event("quick_resumed", f"Quick resume: {reason}")
-    
-    # Update PostgreSQL
+    event_details = f"Quick resume: {reason}"
+    event_entry = {
+        "event": "quick_resumed",
+        "reason": event_details,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+    # Persist FIRST so in-memory state can't diverge from DB on persist failure.
+    # Runtime state (paused_at, lifecycle_events) must be persisted alongside
+    # status or it gets clobbered on the next load_metadata_async(force=True).
     try:
         from src import agent_storage
         await agent_storage.update_agent(agent_uuid, status="active")
+        await agent_storage.persist_runtime_state(
+            agent_uuid,
+            paused_at=None,
+            loop_detected_at=None,
+            loop_cooldown_until=None,
+            append_lifecycle_event=event_entry,
+        )
+        await _invalidate_agent_cache(agent_uuid)
     except Exception as e:
-        logger.debug(f"PostgreSQL update failed: {e}")
-    
+        logger.warning(f"PostgreSQL update failed for quick_resume: {e}", exc_info=True)
+        return [error_response(
+            f"Failed to quick_resume agent '{agent_id}': persistence error",
+            error_code="PERSIST_FAILED",
+            error_category="system_error",
+            details={"agent_id": agent_id, "cause": str(e)},
+        )]
+
+    # Persist succeeded — now mutate in-memory state.
+    meta.status = "active"
+    meta.paused_at = None
+    clear_loop_detector_state(meta)
+    meta.add_lifecycle_event("quick_resumed", event_details)
+
     return success_response({
         "success": True,
         "recovered": True,
@@ -654,22 +678,42 @@ async def handle_operator_resume_agent(arguments: Dict[str, Any]) -> Sequence[Te
     except Exception as e:
         logger.warning(f"Failed to log operator intervention: {e}")
     
-    # Resume target agent
     previous_status = target_meta.status
-    target_meta.status = "active"
-    target_meta.paused_at = None
-    clear_loop_detector_state(target_meta)
-    target_meta.add_lifecycle_event(
-        "operator_resumed",
-        f"Resumed by operator {caller_uuid}: {reason}"
-    )
-    
-    # Update PostgreSQL
+    event_details = f"Resumed by operator {caller_uuid}: {reason}"
+    event_entry = {
+        "event": "operator_resumed",
+        "reason": event_details,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+    # Persist FIRST so in-memory state can't diverge from DB on persist failure.
+    # Runtime state (paused_at, lifecycle_events) must be persisted alongside
+    # status or it gets clobbered on the next load_metadata_async(force=True).
     try:
         from src import agent_storage
         await agent_storage.update_agent(target_agent_id, status="active")
+        await agent_storage.persist_runtime_state(
+            target_agent_id,
+            paused_at=None,
+            loop_detected_at=None,
+            loop_cooldown_until=None,
+            append_lifecycle_event=event_entry,
+        )
+        await _invalidate_agent_cache(target_agent_id)
     except Exception as e:
-        logger.debug(f"PostgreSQL update failed: {e}")
+        logger.warning(f"PostgreSQL update failed for operator_resume: {e}", exc_info=True)
+        return [error_response(
+            f"Failed to operator_resume agent '{target_agent_id}': persistence error",
+            error_code="PERSIST_FAILED",
+            error_category="system_error",
+            details={"target_agent_id": target_agent_id, "cause": str(e)},
+        )]
+
+    # Persist succeeded — now mutate in-memory state.
+    target_meta.status = "active"
+    target_meta.paused_at = None
+    clear_loop_detector_state(target_meta)
+    target_meta.add_lifecycle_event("operator_resumed", event_details)
     
     return success_response({
         "success": True,

--- a/tests/test_self_recovery.py
+++ b/tests/test_self_recovery.py
@@ -386,6 +386,9 @@ class TestQuickResume:
         ), patch(
             "src.agent_storage.update_agent",
             new_callable=AsyncMock,
+        ), patch(
+            "src.agent_storage.persist_runtime_state",
+            new_callable=AsyncMock,
         ):
             result = await handle_quick_resume({"_agent_uuid": "test-uuid"})
             text = json.loads(result[0].text)
@@ -445,6 +448,97 @@ class TestQuickResume:
             result = await handle_quick_resume({"_agent_uuid": "test-uuid"})
             text = json.loads(result[0].text)
             assert "error" in text or "Cannot" in str(text)
+
+    # =====================================================================
+    # Watcher P011 — persist_runtime_state must be called with the
+    # paused_at/loop_detector clears + lifecycle event, and a persist
+    # failure must NOT mutate in-memory state. Mirrors the fix-resume
+    # pattern from operations.py:80-109 / resume.py 3a0de6b.
+    # =====================================================================
+
+    @pytest.mark.asyncio
+    async def test_quick_resume_persists_runtime_state(self):
+        from src.mcp_handlers.lifecycle.self_recovery import handle_quick_resume
+        mock_server = self._make_mock_server()
+
+        with patch(
+            "src.mcp_handlers.lifecycle.self_recovery.require_registered_agent",
+            return_value=("test-agent", None),
+        ), patch(
+            "src.mcp_handlers.lifecycle.self_recovery.verify_agent_ownership",
+            return_value=True,
+        ), patch(
+            "src.mcp_handlers.lifecycle.self_recovery.mcp_server",
+            mock_server,
+        ), patch(
+            "src.mcp_handlers.lifecycle.self_recovery.store_discovery_internal",
+            new_callable=AsyncMock,
+            create=True,
+        ), patch(
+            "src.agent_storage.update_agent",
+            new_callable=AsyncMock,
+        ) as mock_update, patch(
+            "src.agent_storage.persist_runtime_state",
+            new_callable=AsyncMock,
+        ) as mock_persist:
+            result = await handle_quick_resume({
+                "_agent_uuid": "test-uuid",
+                "reason": "soak passed",
+            })
+            text = json.loads(result[0].text)
+            data = text.get("data", text)
+            assert data.get("success") is True or data.get("recovered") is True
+
+            mock_update.assert_awaited_once_with("test-uuid", status="active")
+            mock_persist.assert_awaited_once()
+            call = mock_persist.await_args
+            assert call.args[0] == "test-uuid"
+            assert call.kwargs["paused_at"] is None
+            assert call.kwargs["loop_detected_at"] is None
+            assert call.kwargs["loop_cooldown_until"] is None
+            event = call.kwargs["append_lifecycle_event"]
+            assert event["event"] == "quick_resumed"
+            assert "soak passed" in event["reason"]
+            assert "timestamp" in event
+
+    @pytest.mark.asyncio
+    async def test_quick_resume_persist_failure_returns_persist_failed(self):
+        """If update_agent raises, handler returns PERSIST_FAILED and meta is
+        NOT mutated to active — prevents in-memory/DB divergence."""
+        from src.mcp_handlers.lifecycle.self_recovery import handle_quick_resume
+        mock_server = self._make_mock_server(status="paused")
+        meta = mock_server.agent_metadata.get("test-uuid")
+
+        update_agent_mock = AsyncMock(side_effect=RuntimeError("db down"))
+
+        with patch(
+            "src.mcp_handlers.lifecycle.self_recovery.require_registered_agent",
+            return_value=("test-agent", None),
+        ), patch(
+            "src.mcp_handlers.lifecycle.self_recovery.verify_agent_ownership",
+            return_value=True,
+        ), patch(
+            "src.mcp_handlers.lifecycle.self_recovery.mcp_server",
+            mock_server,
+        ), patch(
+            "src.mcp_handlers.lifecycle.self_recovery.store_discovery_internal",
+            new_callable=AsyncMock,
+            create=True,
+        ), patch(
+            "src.agent_storage.update_agent",
+            update_agent_mock,
+        ), patch(
+            "src.agent_storage.persist_runtime_state",
+            new_callable=AsyncMock,
+        ):
+            result = await handle_quick_resume({"_agent_uuid": "test-uuid"})
+            text = json.loads(result[0].text)
+            assert "PERSIST_FAILED" in str(text)
+            # Critical: in-memory status was NOT flipped to active, and
+            # add_lifecycle_event was not called — proves no field above
+            # the try block was hoisted into a pre-persist mutation.
+            assert meta.status != "active"
+            meta.add_lifecycle_event.assert_not_called()
 
 
 # ============================================================================
@@ -506,6 +600,9 @@ class TestOperatorResumeAgent:
         ), patch(
             "src.agent_storage.update_agent",
             new_callable=AsyncMock,
+        ), patch(
+            "src.agent_storage.persist_runtime_state",
+            new_callable=AsyncMock,
         ):
             result = await handle_operator_resume_agent({
                 "_agent_uuid": "caller-uuid",
@@ -557,6 +654,9 @@ class TestOperatorResumeAgent:
             create=True,
         ), patch(
             "src.agent_storage.update_agent",
+            new_callable=AsyncMock,
+        ), patch(
+            "src.agent_storage.persist_runtime_state",
             new_callable=AsyncMock,
         ):
             result = await handle_operator_resume_agent({
@@ -649,6 +749,9 @@ class TestOperatorResumeAgent:
         ), patch(
             "src.agent_storage.update_agent",
             new_callable=AsyncMock,
+        ), patch(
+            "src.agent_storage.persist_runtime_state",
+            new_callable=AsyncMock,
         ):
             result = await handle_operator_resume_agent({
                 "_agent_uuid": "caller-uuid",
@@ -660,6 +763,98 @@ class TestOperatorResumeAgent:
             data = text.get("data", text)
             assert data.get("success") is True
             assert data.get("force_used") is True
+
+    # =====================================================================
+    # Watcher P011 — persist_runtime_state must be called with the
+    # paused_at/loop_detector clears + lifecycle event, and a persist
+    # failure must NOT mutate in-memory state. Mirrors the fix-resume
+    # pattern from operations.py:80-109 / resume.py 3a0de6b.
+    # =====================================================================
+
+    @pytest.mark.asyncio
+    async def test_operator_resume_persists_runtime_state(self):
+        from src.mcp_handlers.lifecycle.self_recovery import handle_operator_resume_agent
+        mock_server = self._make_mock_server()
+
+        with patch(
+            "src.mcp_handlers.lifecycle.self_recovery.require_registered_agent",
+            return_value=("caller-agent", None),
+        ), patch(
+            "src.mcp_handlers.lifecycle.self_recovery.mcp_server",
+            mock_server,
+        ), patch(
+            "src.mcp_handlers.lifecycle.self_recovery.store_discovery_internal",
+            new_callable=AsyncMock,
+            create=True,
+        ), patch(
+            "src.agent_storage.update_agent",
+            new_callable=AsyncMock,
+        ) as mock_update, patch(
+            "src.agent_storage.persist_runtime_state",
+            new_callable=AsyncMock,
+        ) as mock_persist:
+            result = await handle_operator_resume_agent({
+                "_agent_uuid": "caller-uuid",
+                "target_agent_id": "target-uuid",
+                "reason": "Stuck agent recovery",
+            })
+            text = json.loads(result[0].text)
+            data = text.get("data", text)
+            assert data.get("success") is True
+
+            mock_update.assert_awaited_once_with("target-uuid", status="active")
+            mock_persist.assert_awaited_once()
+            # First positional arg is the agent UUID; the rest are kwargs.
+            call = mock_persist.await_args
+            assert call.args[0] == "target-uuid"
+            assert call.kwargs["paused_at"] is None
+            assert call.kwargs["loop_detected_at"] is None
+            assert call.kwargs["loop_cooldown_until"] is None
+            event = call.kwargs["append_lifecycle_event"]
+            assert event["event"] == "operator_resumed"
+            assert "caller-uuid" in event["reason"]
+            assert "Stuck agent recovery" in event["reason"]
+            assert "timestamp" in event
+
+    @pytest.mark.asyncio
+    async def test_operator_resume_persist_failure_returns_persist_failed(self):
+        """If update_agent raises, handler returns PERSIST_FAILED and target_meta
+        is NOT mutated to active — prevents in-memory/DB divergence."""
+        from src.mcp_handlers.lifecycle.self_recovery import handle_operator_resume_agent
+        mock_server = self._make_mock_server(target_status="paused")
+        target_meta = mock_server.agent_metadata.get("target-uuid")
+
+        update_agent_mock = AsyncMock(side_effect=RuntimeError("db down"))
+
+        with patch(
+            "src.mcp_handlers.lifecycle.self_recovery.require_registered_agent",
+            return_value=("caller-agent", None),
+        ), patch(
+            "src.mcp_handlers.lifecycle.self_recovery.mcp_server",
+            mock_server,
+        ), patch(
+            "src.mcp_handlers.lifecycle.self_recovery.store_discovery_internal",
+            new_callable=AsyncMock,
+            create=True,
+        ), patch(
+            "src.agent_storage.update_agent",
+            update_agent_mock,
+        ), patch(
+            "src.agent_storage.persist_runtime_state",
+            new_callable=AsyncMock,
+        ):
+            result = await handle_operator_resume_agent({
+                "_agent_uuid": "caller-uuid",
+                "target_agent_id": "target-uuid",
+                "reason": "Stuck",
+            })
+            text = json.loads(result[0].text)
+            assert "PERSIST_FAILED" in str(text)
+            # Critical: in-memory status was NOT flipped to active, and
+            # add_lifecycle_event was not called — proves no field above
+            # the try block was hoisted into a pre-persist mutation.
+            assert target_meta.status != "active"
+            target_meta.add_lifecycle_event.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_missing_target_agent_id(self):


### PR DESCRIPTION
## Summary

Watcher P011 fix for two recovery handlers in `src/mcp_handlers/lifecycle/self_recovery.py`. Both handlers mutated `meta.paused_at`, the loop-detector fields, and added a lifecycle event in memory but only persisted `status` via `update_agent` — paused_at and the resumed event were clobbered on the next `load_metadata_async(force=True)`, and persist failures were swallowed at `logger.debug` so memory could silently diverge from DB.

The third site of the same bug class (`handle_direct_resume_if_safe` / `resume.py:110`, fingerprint `d279cc89`) is fixed on the sibling branch `fix/resume-paused-persistence` (commit `3a0de6b`) — out of scope here, two PRs intentional.

Applies the persist-first pattern from `operations.py:80-109`:
- `update_agent(uuid, status='active')` + `persist_runtime_state(paused_at=None, loop_detected_at=None, loop_cooldown_until=None, append_lifecycle_event=event_entry)` before any in-memory mutation
- `_invalidate_agent_cache(uuid)` parity with `handle_resume_agent` — closes the post-persist cache-staleness window
- on persist failure, returns `PERSIST_FAILED` instead of silently logging; meta is not mutated

## Behavior change to flag

Callers that previously got `success` on persist failure now get `PERSIST_FAILED`. The Operator agent uses `operator_resume_agent` for fleet recovery — its retry policy should treat `PERSIST_FAILED` as transient (backoff + retry), not as a governance violation. Worth eyes from anyone owning Operator retry semantics before merge.

## Tests

- 47 tests in `test_self_recovery.py` pass; full suite (7502 / 33 skipped) green via `test-cache.sh`
- 4 new tests assert (1) the kwargs and event_entry shape passed to `persist_runtime_state`, (2) on persist failure, status is not flipped to active AND `add_lifecycle_event` is not called — proves no field above the try block was hoisted into a pre-persist mutation
- existing tests updated to also patch `persist_runtime_state` (would have broken otherwise)

## Council review

Three-reviewer council (code-reviewer + dialectic-architect + live-verifier). Verdict: SHIP-WITH-CHANGES — addressed in this branch:
- code-reviewer: strengthened persist-failure tests with `add_lifecycle_event.assert_not_called()`
- dialectic-architect: added `_invalidate_agent_cache` parity
- live-verifier: confirmed the 4 R000 self_recovery findings on master are pre-existing and unrelated to P011; my branch introduces zero new Watcher findings

## Follow-ups (non-blocking)

1. **`recovery_attempt_at` at line 370** is the same bug class — mutation before persist. Preserved as-is in this PR (not regressed). The 120s loop-detector grace period evaporates if a `force=True` reload happens within the window. Worth a separate PR.
2. **End-to-end clobber-test mirrors** for these two handlers in `test_lifecycle_clobber.py` — current tests are mock-only; `test_lifecycle_clobber.py` covers `handle_resume_agent` end-to-end but has no quick_resume / operator_resume mirrors.
3. **`fix/resume-paused-persistence`** has unpushed commits + unrelated WIP (`governance_state.py` adding `verdict_history`). The resume.py fix there should land too — `d279cc89` won't be resolved until it merges to master.

## Test plan

- [x] `pytest tests/test_self_recovery.py` — 47 pass
- [x] `pytest tests/test_self_recovery_review.py tests/test_lifecycle_recovery.py tests/test_lifecycle_clobber.py tests/test_handlers_lifecycle.py tests/test_loop_detection.py tests/test_operator_auth.py` — 180 pass
- [x] `./scripts/dev/test-cache.sh` — 7502 passed, 33 skipped
- [ ] CI green (auto)