### PR TITLE
dashboard: ambient aurora + grain overlay + HUD corner brackets

### DIFF
--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -127,14 +127,58 @@ body,
 body {
     font-family: var(--font-family);
     background-color: var(--bg-color);
-    background-image:
-        radial-gradient(circle at 15% 50%, rgba(0, 240, 255, 0.03), transparent 25%),
-        radial-gradient(circle at 85% 30%, rgba(157, 78, 221, 0.03), transparent 25%);
-    background-attachment: fixed;
     color: var(--text-primary);
     padding: 20px 40px 40px;
     line-height: 1.5;
     min-height: 100vh;
+    position: relative;
+    isolation: isolate;
+}
+
+/* ============================================
+   Ambient Aurora — drifting bioluminescent layer
+   Replaces the static radial gradients with a slow
+   parallax-feeling backdrop. Pure CSS, no JS.
+   ============================================ */
+body::before {
+    content: '';
+    position: fixed;
+    inset: -12vmax;
+    z-index: -2;
+    pointer-events: none;
+    background:
+        radial-gradient(circle at 22% 28%, rgba(0, 240, 255, 0.10), transparent 35%),
+        radial-gradient(circle at 78% 72%, rgba(157, 78, 221, 0.10), transparent 35%),
+        radial-gradient(circle at 50% 50%, rgba(0, 230, 118, 0.05), transparent 40%);
+    filter: blur(60px);
+    animation: aurora-drift 45s ease-in-out infinite alternate;
+}
+
+@keyframes aurora-drift {
+    0%   { transform: translate3d(0, 0, 0) scale(1); }
+    50%  { transform: translate3d(2vmax, -2vmax, 0) scale(1.05); }
+    100% { transform: translate3d(-2vmax, 2vmax, 0) scale(1); }
+}
+
+/* Grain overlay — subtle film noise for depth, ~1KB inline SVG */
+body::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    opacity: 0.045;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+    mix-blend-mode: overlay;
+}
+
+/* Light theme: tone the ambient layers down */
+[data-theme="light"] body::before { opacity: 0.35; }
+[data-theme="light"] body::after  { opacity: 0.025; }
+
+/* Honor reduced-motion preference — hold aurora still */
+@media (prefers-reduced-motion: reduce) {
+    body::before { animation: none; }
 }
 
 /* ============================================
@@ -854,6 +898,31 @@ main {
     box-shadow: 0 0 12px var(--panel-dot-color, var(--accent-cyan));
     border-radius: var(--radius-lg) var(--radius-lg) 0 0;
 }
+
+/* HUD corner brackets — sci-fi accent on every panel.
+   Eight stacked 1px linear-gradients form L-shaped ticks at each corner.
+   Inherits the panel's accent color from --panel-dot-color so per-section
+   tints (purple/yellow/green/orange) flow through automatically. */
+.panel::before {
+    content: '';
+    position: absolute;
+    inset: 6px;
+    pointer-events: none;
+    background:
+        linear-gradient(var(--panel-dot-color, var(--accent-cyan)), var(--panel-dot-color, var(--accent-cyan))) top    left  / 14px 1px no-repeat,
+        linear-gradient(var(--panel-dot-color, var(--accent-cyan)), var(--panel-dot-color, var(--accent-cyan))) top    left  / 1px 14px no-repeat,
+        linear-gradient(var(--panel-dot-color, var(--accent-cyan)), var(--panel-dot-color, var(--accent-cyan))) top    right / 14px 1px no-repeat,
+        linear-gradient(var(--panel-dot-color, var(--accent-cyan)), var(--panel-dot-color, var(--accent-cyan))) top    right / 1px 14px no-repeat,
+        linear-gradient(var(--panel-dot-color, var(--accent-cyan)), var(--panel-dot-color, var(--accent-cyan))) bottom left  / 14px 1px no-repeat,
+        linear-gradient(var(--panel-dot-color, var(--accent-cyan)), var(--panel-dot-color, var(--accent-cyan))) bottom left  / 1px 14px no-repeat,
+        linear-gradient(var(--panel-dot-color, var(--accent-cyan)), var(--panel-dot-color, var(--accent-cyan))) bottom right / 14px 1px no-repeat,
+        linear-gradient(var(--panel-dot-color, var(--accent-cyan)), var(--panel-dot-color, var(--accent-cyan))) bottom right / 1px 14px no-repeat;
+    opacity: 0.45;
+    transition: opacity var(--transition-standard);
+    z-index: 1;
+}
+
+.panel:hover::before { opacity: 0.85; }
 
 .panel-header {
     display: flex;


### PR DESCRIPTION
Tier 1 of dashboard "video-game polish" pass. CSS-only — no JS, no allowlist changes, no Chart.js options touched, no panel HTML restructured.

## Changes — `dashboard/styles.css` (+73/-4)

- **Aurora** (`body::before`): three drifting blurred radial gradients (cyan/purple/green), 45s ease-in-out cycle with `transform` translate+scale for slow parallax. Replaces the prior static 3% radial gradients on `body`.
- **Grain** (`body::after`): inline-SVG fractal noise at 4.5% opacity, `mix-blend-mode: overlay`. ~1KB, no extra request.
- **HUD corner brackets** (`.panel::before`): four 14px L-ticks at 6px inset, color-inheriting from `--panel-dot-color` so per-section tints (purple/yellow/green/orange) flow through automatically. Hover lifts opacity 0.45 → 0.85.
- **Reduced-motion**: aurora freezes for `prefers-reduced-motion: reduce`.
- **Light theme**: aurora and grain auto-tone-down via `[data-theme="light"]` overrides.

Animated stat counters were already present (`animateValue` in `eisv-charts.js:714`) — no work needed there.

## Test plan
- [ ] Hard-refresh `http://127.0.0.1:8767/dashboard` after merge
- [ ] Confirm aurora blobs slowly drift in the background
- [ ] Confirm grain texture is present but subtle
- [ ] Confirm panel corners brighten on hover, color-match section tint
- [ ] Toggle to light theme — confirm ambient layers tone down appropriately
- [ ] DevTools → set `prefers-reduced-motion: reduce` — confirm aurora stops moving