### PR TITLE
fix(tests): opt-in coverage; align CI, cache script, and README

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,9 @@ jobs:
 
     - name: Run tests with coverage
       run: |
-        python -m pytest tests/ -v --cov=src --cov-report=term-missing --cov-report=html
+        python -m pytest tests/ -v \
+          --cov=src --cov=agents/sdk/src/unitares_sdk --cov=agents \
+          --cov-report=term-missing --cov-report=html --cov-fail-under=25
 
     - name: Upload coverage report
       if: always()

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,9 @@ version-bump: ## Bump version (usage: make version-bump PART=patch)
 # ── Testing ──────────────────────────────────────────────
 
 test: ## Run full test suite with coverage
-	@python3 -m pytest
+	@python3 -m pytest \
+		--cov=src --cov=agents/sdk/src/unitares_sdk --cov=agents \
+		--cov-report=term-missing --cov-fail-under=25
 
 test-quick: ## Run tests without coverage
 	@python3 -m pytest -o addopts= -q

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Each check-in returns a verdict (`proceed` / `guide` / `pause` / `reject`) and g
 
 Circuit breakers and kill switches are still there — they're just the last line of defense, not the first.
 
-Running continuously in production since November 2025 with 6,200+ passing tests at 77% coverage. Long-run trajectories are stored in PostgreSQL + AGE; the state model is derived from what agents actually do (EMA-smoothed observations, not model predictions).
+Running continuously in production since November 2025 with 6,200+ passing tests; line coverage for the default `make test` / CI measurement (`src/`, `agents/sdk`, and `agents/`) is typically **~76%**. The project enforces a **25%** minimum (`--cov-fail-under=25`, passed by `make test`, `scripts/dev/test-cache.sh`, and CI — not by bare `pytest` defaults). Long-run trajectories are stored in PostgreSQL + AGE; the state model is derived from what agents actually do (EMA-smoothed observations, not model predictions).
 
 **Try it** (one command, no Postgres/AGE on the host required):
 
@@ -99,7 +99,7 @@ As of April 2026 (single-operator deployment — self-traffic, not external adop
 | Governance events processed | 94,000+ (≈51K in the last 7 days) |
 | Knowledge graph discoveries | 578 |
 | V operating range | Active agents often within [-0.1, 0.1] |
-| Tests | 6,200+ passing · 77% coverage |
+| Tests | 6,200+ passing · ~76% line coverage (25% min gate) |
 
 </details>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,16 +50,11 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 testpaths = ["tests", "agents"]
 pythonpath = [".", "agents/sdk/src"]
-addopts = [
-    "--cov=src",
-    "--cov=agents/sdk/src/unitares_sdk",
-    "--cov=agents",
-    "--cov-report=term-missing",
-    "--cov-fail-under=25",
-    "-v",
-]
-# HTML coverage: run manually with --cov-report=html when needed
-# (22MB per run was causing 2GB+ disk write storms during dev sessions)
+addopts = ["-v"]
+# Coverage is opt-in: `make test`, `scripts/dev/test-cache.sh`, and CI pass
+# `--cov=...` / `--cov-fail-under=25` explicitly. Enabling it in addopts caused
+# `pytest --collect-only` to measure ~14% and fail the gate (no tests run).
+# HTML: add `--cov-report=html` to a full run when needed (22MB+ per run).
 markers = [
     "smoke: Fast smoke tests for pre-push validation (target <60s)",
 ]

--- a/scripts/dev/test-cache.sh
+++ b/scripts/dev/test-cache.sh
@@ -12,6 +12,11 @@
 
 set -euo pipefail
 
+# Portable mtime in epoch seconds (macOS `stat -f` is not GNU `stat -c`)
+_cache_mtime() {
+  python3 -c 'import os, sys; print(int(os.path.getmtime(sys.argv[1])))' "$1"
+}
+
 CACHE_DIR=".test-cache"
 PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$PROJECT_ROOT"
@@ -33,7 +38,7 @@ CACHE_FILE="$CACHE_DIR/$TREE_HASH"
 
 # --- cache hit (fast path, no lock) ---
 if [[ "$FRESH" == false && -f "$CACHE_FILE" ]]; then
-    AGE_SECS=$(( $(date +%s) - $(stat -f %m "$CACHE_FILE") ))
+    AGE_SECS=$(( $(date +%s) - $(_cache_mtime "$CACHE_FILE") ))
     AGE_MIN=$(( AGE_SECS / 60 ))
     echo "[test-cache] HIT — tree $TREE_HASH (cached ${AGE_MIN}m ago)"
     cat "$CACHE_FILE"
@@ -77,7 +82,7 @@ trap 'rm -rf "$LOCK_DIR"' EXIT INT TERM
 # The holder ahead of us may have just populated the cache for this
 # tree hash; skip pytest if so.
 if [[ "$FRESH" == false && -f "$CACHE_FILE" ]]; then
-    AGE_SECS=$(( $(date +%s) - $(stat -f %m "$CACHE_FILE") ))
+    AGE_SECS=$(( $(date +%s) - $(_cache_mtime "$CACHE_FILE") ))
     AGE_MIN=$(( AGE_SECS / 60 ))
     echo "[test-cache] HIT (post-lock) — tree $TREE_HASH (cached ${AGE_MIN}m ago)"
     cat "$CACHE_FILE"
@@ -88,9 +93,12 @@ fi
 mkdir -p "$CACHE_DIR"
 echo "[test-cache] MISS — tree $TREE_HASH, running pytest..."
 
-# Use framework Python (has pytest + project deps installed)
-PYTHON="${UNITARES_PYTHON:-/Library/Frameworks/Python.framework/Versions/3.14/bin/python3}"
-PYTEST_CMD=("$PYTHON" -m pytest tests/ agents/ -q --tb=short -x ${PYTEST_EXTRA[@]+"${PYTEST_EXTRA[@]}"})
+# Prefer env override; otherwise `python3` on PATH (Linux CI + typical macOS).
+PYTHON="${UNITARES_PYTHON:-python3}"
+PYTEST_CMD=("$PYTHON" -m pytest tests/ agents/ -q --tb=short -x \
+	--cov=src --cov=agents/sdk/src/unitares_sdk --cov=agents \
+	--cov-report=term-missing --cov-fail-under=25 \
+	${PYTEST_EXTRA[@]+"${PYTEST_EXTRA[@]}"})
 TMPOUT=$(mktemp)
 set +e
 "${PYTEST_CMD[@]}" 2>&1 | tee "$TMPOUT"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The **~14.62%** total you can see from `pytest` with **coverage enabled in `addopts` but no tests executed** (e.g. `pytest --collect-only`) is **import-time “coverage”**, not a full-suite measurement. The **25%** `--cov-fail-under` is the project’s **enforced** floor, not 77%.

## Changes

- **Remove coverage from default `addopts`** so `pytest --collect-only` and other non-execution invocations do not run the coverage plugin and spuriously fail the 25% gate.
- **Move the same `--cov=...` / `--cov-fail-under=25` flags** to `make test`, `scripts/dev/test-cache.sh`, and **GitHub Actions** (CI previously only had `--cov=src` and no fail-under; now matches `make test` including `agents` + SDK).
- **README:** Replace outdated **77%** with **~76%** combined line coverage and note the **25%** minimum.
- **test-cache.sh:** Default `UNITARES_PYTHON` to `python3` (Linux/CI) instead of a macOS framework path; **portable cache mtime** (GNU `stat` is not macOS `stat`).

`make test` and a full `test-cache.sh --fresh` run were executed locally: **~75.9%** total for the same three tree roots, **25%** gate satisfied.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5f9c596-9fba-488b-8f02-53d626e4170b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5f9c596-9fba-488b-8f02-53d626e4170b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

