### PR TITLE
fix: drop hardcoded /Users/cirwel default in vigil_hygiene --repo

The --repo argparse default fell back to the original operator's
absolute path when UNITARES_REPO wasn't set. Anyone else running
the agent (or anyone reading the public source) saw a personal
checkout path. Use Path(__file__).resolve().parents[2] so the
default resolves to whichever checkout the agent is running from.

### DIFF
--- a/agents/vigil_hygiene/agent.py
+++ b/agents/vigil_hygiene/agent.py
@@ -282,7 +282,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="vigil-hygiene weekly branch sweep")
     parser.add_argument(
         "--repo",
-        default=os.environ.get("UNITARES_REPO", str(Path("/Users/cirwel/projects/unitares"))),
+        default=os.environ.get("UNITARES_REPO", str(Path(__file__).resolve().parents[2])),
         help="path to git repo",
     )
     parser.add_argument("--live", action="store_true", help="actually delete (default: dry-run)")


### PR DESCRIPTION
Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.