### PR TITLE
dashboard: cap vigil + sentinel panel width at 1400px

### DIFF
--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -5005,7 +5005,9 @@ main {
    Match the 1400px column used by .main-content above. */
 #activity-timeline-section,
 #fleet-metrics-section,
-#watcher-section {
+#watcher-section,
+#sentinel-section,
+#vigil-section {
     max-width: 1400px;
     margin-left: auto;
     margin-right: auto;


### PR DESCRIPTION
On displays wider than 1400px, the Vigil and Sentinel panels were rendering wider than peer panels (Activity Timeline, Chronicler / Fleet Metrics, Watcher) because they were not in the existing max-width-1400px selector list at \`dashboard/styles.css:4937-4943\`.

## Summary
- Add \`#sentinel-section\` and \`#vigil-section\` to the same rule that already constrains \`#watcher-section\`, \`#activity-timeline-section\`, and \`#fleet-metrics-section\`.

## Test plan
- [ ] Hard-refresh dashboard on a >1400px viewport
- [ ] Confirm Vigil + Sentinel panels render at the same width as Watcher