### PR TITLE
feat(db): ExecutorPool — asyncpg loop-isolation wrapper for anyio (P2 full)

### DIFF
--- a/src/db/executor_pool.py
+++ b/src/db/executor_pool.py
@@ -1,0 +1,160 @@
+"""
+ExecutorPool — wraps asyncpg.Pool so DB operations run on a dedicated
+background thread with its own asyncio event loop.
+
+Why: docs/handoffs/2026-04-27-anyio-followup-scope.md. The MCP SDK's anyio
+task group conflicts with asyncpg/Redis cancellation semantics. Running
+asyncpg coroutines on a separate event loop (in a separate thread) means
+the anyio context never sees an asyncpg await — only a future from the
+caller's loop, which anyio handles cleanly.
+
+Caller surface is unchanged: handlers still write
+    async with db.acquire() as conn:
+        await conn.fetchval(...)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any
+
+
+async def _await_on_loop(coro: Any, loop: asyncio.AbstractEventLoop) -> Any:
+    """Schedule a coroutine on `loop` (a different thread's loop) and await its result."""
+    future = asyncio.run_coroutine_threadsafe(coro, loop)
+    return await asyncio.wrap_future(future)
+
+
+class _Transaction:
+    """
+    Wraps an asyncpg transaction so __aenter__/__aexit__ both round-trip
+    to the executor loop. asyncpg connections are loop-bound — a transaction
+    started on one loop and committed on another silently corrupts.
+    """
+
+    def __init__(self, raw_txn: Any, loop: asyncio.AbstractEventLoop):
+        self._raw = raw_txn
+        self._loop = loop
+
+    async def __aenter__(self) -> Any:
+        return await _await_on_loop(self._raw.__aenter__(), self._loop)
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> Any:
+        return await _await_on_loop(
+            self._raw.__aexit__(exc_type, exc_val, exc_tb), self._loop
+        )
+
+
+class _Connection:
+    """Wraps an asyncpg Connection, dispatching all calls to the executor loop."""
+
+    def __init__(self, raw_conn: Any, loop: asyncio.AbstractEventLoop):
+        self._raw = raw_conn
+        self._loop = loop
+
+    async def fetchval(self, *args: Any, **kwargs: Any) -> Any:
+        return await _await_on_loop(self._raw.fetchval(*args, **kwargs), self._loop)
+
+    async def fetch(self, *args: Any, **kwargs: Any) -> Any:
+        return await _await_on_loop(self._raw.fetch(*args, **kwargs), self._loop)
+
+    async def fetchrow(self, *args: Any, **kwargs: Any) -> Any:
+        return await _await_on_loop(self._raw.fetchrow(*args, **kwargs), self._loop)
+
+    async def execute(self, *args: Any, **kwargs: Any) -> Any:
+        return await _await_on_loop(self._raw.execute(*args, **kwargs), self._loop)
+
+    async def executemany(self, *args: Any, **kwargs: Any) -> Any:
+        return await _await_on_loop(self._raw.executemany(*args, **kwargs), self._loop)
+
+    def transaction(self, *args: Any, **kwargs: Any) -> _Transaction:
+        # transaction() is a sync method on asyncpg.Connection that returns
+        # a Transaction object — the actual BEGIN/COMMIT happen in __aenter__/
+        # __aexit__, both of which must round-trip to the executor loop.
+        return _Transaction(self._raw.transaction(*args, **kwargs), self._loop)
+
+    async def close(self) -> None:
+        return await _await_on_loop(self._raw.close(), self._loop)
+
+
+class _AcquireContext:
+    """Async context manager that acquires a connection on the executor loop."""
+
+    def __init__(self, raw_pool: Any, loop: asyncio.AbstractEventLoop):
+        self._raw_pool = raw_pool
+        self._loop = loop
+        self._raw_acquire_ctx: Any = None
+        self._raw_conn: Any = None
+
+    async def __aenter__(self) -> _Connection:
+        # Run the asyncpg acquire on the executor loop, not the caller's loop.
+        async def _enter():
+            ctx = self._raw_pool.acquire()
+            self._raw_acquire_ctx = ctx
+            return await ctx.__aenter__()
+
+        future = asyncio.run_coroutine_threadsafe(_enter(), self._loop)
+        self._raw_conn = await asyncio.wrap_future(future)
+        return _Connection(self._raw_conn, self._loop)
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> Any:
+        async def _exit():
+            return await self._raw_acquire_ctx.__aexit__(exc_type, exc_val, exc_tb)
+
+        future = asyncio.run_coroutine_threadsafe(_exit(), self._loop)
+        return await asyncio.wrap_future(future)
+
+
+class ExecutorPool:
+    """
+    Wraps an asyncpg.Pool. All DB operations route through a dedicated
+    background thread that owns its own asyncio event loop.
+    """
+
+    def __init__(self, raw_pool: Any):
+        self._raw_pool = raw_pool
+        self._loop = asyncio.new_event_loop()
+        self._loop_ready = threading.Event()
+        self._thread = threading.Thread(
+            target=self._run_loop,
+            name="ExecutorPool-loop",
+            daemon=True,
+        )
+        self._thread.start()
+        self._loop_ready.wait(timeout=5.0)
+
+    def _run_loop(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop_ready.set()
+        self._loop.run_forever()
+
+    def acquire(self) -> _AcquireContext:
+        return _AcquireContext(self._raw_pool, self._loop)
+
+    @property
+    def _closed(self) -> Any:
+        # Mirror asyncpg's internal `_closed` attribute. dialectic_db.py:55
+        # reads this to test pool liveness.
+        return self._raw_pool._closed
+
+    def get_size(self) -> Any:
+        return self._raw_pool.get_size()
+
+    def get_idle_size(self) -> Any:
+        return self._raw_pool.get_idle_size()
+
+    def get_max_size(self) -> Any:
+        return self._raw_pool.get_max_size()
+
+    async def close(self) -> None:
+        # Teardown order matters (architect): close the raw pool ON the
+        # executor loop (asyncpg connections are loop-bound), THEN stop
+        # the loop, THEN join the thread.
+        try:
+            await _await_on_loop(self._raw_pool.close(), self._loop)
+        finally:
+            self._loop.call_soon_threadsafe(self._loop.stop)
+            await asyncio.get_event_loop().run_in_executor(
+                None, self._thread.join, 5.0
+            )

--- a/src/db/executor_pool.py
+++ b/src/db/executor_pool.py
@@ -20,8 +20,31 @@ import threading
 from typing import Any
 
 
-async def _await_on_loop(coro: Any, loop: asyncio.AbstractEventLoop) -> Any:
-    """Schedule a coroutine on `loop` (a different thread's loop) and await its result."""
+async def _await_on_loop(target: Any, loop: asyncio.AbstractEventLoop) -> Any:
+    """Schedule on `loop` (a different thread's loop) and await the result.
+
+    Accepts either:
+    - A **callable** returning a coroutine/awaitable — called *inside* the
+      executor loop so any Futures it creates are loop-bound correctly.
+      **Use this form for asyncpg ops** (asyncpg internals capture the
+      running loop when creating Futures).
+    - A coroutine — passed straight to ``run_coroutine_threadsafe``.
+      Safe only for plain coroutines that don't internally create Futures
+      bound to the calling loop.
+    """
+    if callable(target):
+        async def _call_on_executor():
+            result = target()
+            if asyncio.iscoroutine(result) or hasattr(result, "__await__"):
+                return await result
+            return result
+        coro = _call_on_executor()
+    elif asyncio.iscoroutine(target):
+        coro = target
+    else:
+        async def _wrap():
+            return await target
+        coro = _wrap()
     future = asyncio.run_coroutine_threadsafe(coro, loop)
     return await asyncio.wrap_future(future)
 
@@ -38,11 +61,11 @@ class _Transaction:
         self._loop = loop
 
     async def __aenter__(self) -> Any:
-        return await _await_on_loop(self._raw.__aenter__(), self._loop)
+        return await _await_on_loop(lambda: self._raw.__aenter__(), self._loop)
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> Any:
         return await _await_on_loop(
-            self._raw.__aexit__(exc_type, exc_val, exc_tb), self._loop
+            lambda: self._raw.__aexit__(exc_type, exc_val, exc_tb), self._loop
         )
 
 
@@ -54,19 +77,19 @@ class _Connection:
         self._loop = loop
 
     async def fetchval(self, *args: Any, **kwargs: Any) -> Any:
-        return await _await_on_loop(self._raw.fetchval(*args, **kwargs), self._loop)
+        return await _await_on_loop(lambda: self._raw.fetchval(*args, **kwargs), self._loop)
 
     async def fetch(self, *args: Any, **kwargs: Any) -> Any:
-        return await _await_on_loop(self._raw.fetch(*args, **kwargs), self._loop)
+        return await _await_on_loop(lambda: self._raw.fetch(*args, **kwargs), self._loop)
 
     async def fetchrow(self, *args: Any, **kwargs: Any) -> Any:
-        return await _await_on_loop(self._raw.fetchrow(*args, **kwargs), self._loop)
+        return await _await_on_loop(lambda: self._raw.fetchrow(*args, **kwargs), self._loop)
 
     async def execute(self, *args: Any, **kwargs: Any) -> Any:
-        return await _await_on_loop(self._raw.execute(*args, **kwargs), self._loop)
+        return await _await_on_loop(lambda: self._raw.execute(*args, **kwargs), self._loop)
 
     async def executemany(self, *args: Any, **kwargs: Any) -> Any:
-        return await _await_on_loop(self._raw.executemany(*args, **kwargs), self._loop)
+        return await _await_on_loop(lambda: self._raw.executemany(*args, **kwargs), self._loop)
 
     def transaction(self, *args: Any, **kwargs: Any) -> _Transaction:
         # transaction() is a sync method on asyncpg.Connection that returns
@@ -75,35 +98,50 @@ class _Connection:
         return _Transaction(self._raw.transaction(*args, **kwargs), self._loop)
 
     async def close(self) -> None:
-        return await _await_on_loop(self._raw.close(), self._loop)
+        return await _await_on_loop(lambda: self._raw.close(), self._loop)
 
 
 class _AcquireContext:
-    """Async context manager that acquires a connection on the executor loop."""
+    """
+    Mirrors asyncpg's PoolAcquireContext: BOTH awaitable AND an async context
+    manager. `async with pool.acquire(): ...` auto-releases. `await pool.acquire()`
+    returns the connection directly — caller must `pool.release(conn)` later.
+    """
 
-    def __init__(self, raw_pool: Any, loop: asyncio.AbstractEventLoop):
+    def __init__(self, raw_pool: Any, loop: asyncio.AbstractEventLoop, timeout: Any = None):
         self._raw_pool = raw_pool
         self._loop = loop
+        self._timeout = timeout
         self._raw_acquire_ctx: Any = None
         self._raw_conn: Any = None
 
-    async def __aenter__(self) -> _Connection:
-        # Run the asyncpg acquire on the executor loop, not the caller's loop.
-        async def _enter():
-            ctx = self._raw_pool.acquire()
-            self._raw_acquire_ctx = ctx
-            return await ctx.__aenter__()
+    def __await__(self):
+        async def _direct_acquire():
+            def _factory():
+                kwargs = {} if self._timeout is None else {"timeout": self._timeout}
+                return self._raw_pool.acquire(**kwargs)
+            return await _await_on_loop(_factory, self._loop)
 
-        future = asyncio.run_coroutine_threadsafe(_enter(), self._loop)
-        self._raw_conn = await asyncio.wrap_future(future)
+        raw_conn = yield from _direct_acquire().__await__()
+        return _Connection(raw_conn, self._loop)
+
+    async def __aenter__(self) -> _Connection:
+        # The PoolAcquireContext is created on the executor loop AND its
+        # __aenter__ is awaited there, so the connection comes back loop-bound
+        # to the executor loop. Storing the ctx so __aexit__ can reuse it.
+        def _enter_factory():
+            kwargs = {} if self._timeout is None else {"timeout": self._timeout}
+            self._raw_acquire_ctx = self._raw_pool.acquire(**kwargs)
+            return self._raw_acquire_ctx.__aenter__()
+
+        self._raw_conn = await _await_on_loop(_enter_factory, self._loop)
         return _Connection(self._raw_conn, self._loop)
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> Any:
-        async def _exit():
-            return await self._raw_acquire_ctx.__aexit__(exc_type, exc_val, exc_tb)
-
-        future = asyncio.run_coroutine_threadsafe(_exit(), self._loop)
-        return await asyncio.wrap_future(future)
+        return await _await_on_loop(
+            lambda: self._raw_acquire_ctx.__aexit__(exc_type, exc_val, exc_tb),
+            self._loop,
+        )
 
 
 class ExecutorPool:
@@ -113,6 +151,10 @@ class ExecutorPool:
     """
 
     def __init__(self, raw_pool: Any):
+        # Direct constructor: caller has already-created pool (mocks, tests).
+        # Production code should use `await ExecutorPool.create(coro_factory)`
+        # so the asyncpg pool is created on the executor loop — asyncpg
+        # connections are loop-bound (architect's per-thread pinning).
         self._raw_pool = raw_pool
         self._loop = asyncio.new_event_loop()
         self._loop_ready = threading.Event()
@@ -124,13 +166,42 @@ class ExecutorPool:
         self._thread.start()
         self._loop_ready.wait(timeout=5.0)
 
+    @classmethod
+    async def create(cls, create_pool_factory: Any) -> "ExecutorPool":
+        """Create the asyncpg pool ON the executor loop.
+
+        ``create_pool_factory`` is a callable returning the awaitable from
+        ``asyncpg.create_pool(...)`` — calling it inside the executor loop
+        means the pool and all its connections are bound to that loop.
+        """
+        instance = cls.__new__(cls)
+        instance._loop = asyncio.new_event_loop()
+        instance._loop_ready = threading.Event()
+        instance._thread = threading.Thread(
+            target=instance._run_loop,
+            name="ExecutorPool-loop",
+            daemon=True,
+        )
+        instance._thread.start()
+        instance._loop_ready.wait(timeout=5.0)
+        # Pass the factory (not the result) so it's called *inside* the
+        # executor loop — asyncpg.create_pool's Futures must be loop-bound
+        # to the executor loop.
+        instance._raw_pool = await _await_on_loop(create_pool_factory, instance._loop)
+        return instance
+
     def _run_loop(self) -> None:
         asyncio.set_event_loop(self._loop)
         self._loop_ready.set()
         self._loop.run_forever()
 
-    def acquire(self) -> _AcquireContext:
-        return _AcquireContext(self._raw_pool, self._loop)
+    def acquire(self, timeout: Any = None) -> _AcquireContext:
+        return _AcquireContext(self._raw_pool, self._loop, timeout=timeout)
+
+    async def release(self, conn: _Connection) -> Any:
+        # Pair to `await pool.acquire()`. Forwards to raw pool with the
+        # underlying asyncpg connection (postgres_backend.py:206).
+        return await _await_on_loop(lambda: self._raw_pool.release(conn._raw), self._loop)
 
     @property
     def _closed(self) -> Any:
@@ -152,7 +223,7 @@ class ExecutorPool:
         # executor loop (asyncpg connections are loop-bound), THEN stop
         # the loop, THEN join the thread.
         try:
-            await _await_on_loop(self._raw_pool.close(), self._loop)
+            await _await_on_loop(lambda: self._raw_pool.close(), self._loop)
         finally:
             self._loop.call_soon_threadsafe(self._loop.stop)
             await asyncio.get_event_loop().run_in_executor(

--- a/src/db/postgres_backend.py
+++ b/src/db/postgres_backend.py
@@ -19,6 +19,7 @@ except ImportError:
     asyncpg = None  # type: ignore
 
 from .base import DatabaseBackend
+from .executor_pool import ExecutorPool
 from .mixins import (
     IdentityMixin,
     AgentMixin,
@@ -137,20 +138,28 @@ class PostgresBackend(
             return self._pool
 
     async def _create_pool(self):
-        """Create a new connection pool. Caller must hold _init_lock."""
+        """Create a new connection pool. Caller must hold _init_lock.
+
+        Wraps the asyncpg pool in ExecutorPool so all DB operations route
+        through a dedicated background thread+loop, isolating asyncpg from
+        the MCP SDK's anyio task group. See docs/handoffs/2026-04-27-anyio-
+        followup-scope.md and src/db/executor_pool.py.
+        """
         logger.info("Creating PostgreSQL connection pool...")
         try:
-            return await asyncio.wait_for(
-                asyncpg.create_pool(
-                    self._db_url,
-                    min_size=self._min_conn,
-                    max_size=self._max_conn,
-                    command_timeout=30,
-                    max_inactive_connection_lifetime=300,  # Close idle connections after 5 minutes
-                    max_queries=50000,  # Recycle connections after 50k queries
-                ),
-                timeout=5.0  # Fail fast if PostgreSQL isn't available
-            )
+            def _create_factory():
+                return asyncio.wait_for(
+                    asyncpg.create_pool(
+                        self._db_url,
+                        min_size=self._min_conn,
+                        max_size=self._max_conn,
+                        command_timeout=30,
+                        max_inactive_connection_lifetime=300,  # Close idle connections after 5 minutes
+                        max_queries=50000,  # Recycle connections after 50k queries
+                    ),
+                    timeout=5.0  # Fail fast if PostgreSQL isn't available
+                )
+            return await ExecutorPool.create(_create_factory)
         except asyncio.TimeoutError:
             raise ConnectionError(
                 f"PostgreSQL connection timeout after 5s. "

--- a/tests/test_executor_pool.py
+++ b/tests/test_executor_pool.py
@@ -232,3 +232,77 @@ async def test_pool_pass_through_attributes():
         assert wrapped.get_max_size() == 20
     finally:
         await wrapped.close()
+
+
+@pytest.mark.asyncio
+async def test_await_acquire_then_release_pattern():
+    """
+    asyncpg's PoolAcquireContext is BOTH awaitable AND an async context manager.
+    `PostgresBackend.acquire()` (postgres_backend.py:189) uses the await
+    form: `conn = await pool.acquire(timeout=N)` then `await pool.release(conn)`.
+    The wrapper must support this pattern or PostgresBackend.acquire() breaks.
+    """
+    caller_tid = threading.get_ident()
+    release_tid = []
+
+    async def fetchval_impl(*a, **k): return 7
+
+    mock_conn = MagicMock()
+    mock_conn.fetchval = fetchval_impl
+
+    raw_pool = MagicMock()
+
+    async def mock_acquire(*args, timeout=None):
+        # Mimic asyncpg: `await pool.acquire()` returns a Connection directly.
+        return mock_conn
+
+    async def mock_release(conn):
+        release_tid.append(threading.get_ident())
+
+    raw_pool.acquire = mock_acquire
+    raw_pool.release = mock_release
+    raw_pool.close = AsyncMock()
+
+    wrapped = ExecutorPool(raw_pool)
+    try:
+        conn = await wrapped.acquire(timeout=5)
+        assert await conn.fetchval("SELECT 1") == 7
+        await wrapped.release(conn)
+    finally:
+        await wrapped.close()
+
+    assert release_tid == [release_tid[0]] and release_tid[0] != caller_tid, (
+        "release ran on caller thread — must run on executor loop"
+    )
+
+
+@pytest.mark.asyncio
+async def test_acquire_timeout_passes_through_in_context_form():
+    """`async with pool.acquire(timeout=5)` (used at postgres_backend.py:99
+    in the health check). Timeout must reach the raw asyncpg pool."""
+    captured = {}
+
+    async def fake_aenter():
+        return MagicMock()
+    async def fake_aexit(*a):
+        return None
+
+    def make_acquire_ctx(*args, timeout=None):
+        captured['timeout'] = timeout
+        ctx = MagicMock()
+        ctx.__aenter__ = MagicMock(side_effect=fake_aenter)
+        ctx.__aexit__ = MagicMock(side_effect=fake_aexit)
+        return ctx
+
+    raw_pool = MagicMock()
+    raw_pool.acquire = make_acquire_ctx
+    raw_pool.close = AsyncMock()
+
+    wrapped = ExecutorPool(raw_pool)
+    try:
+        async with wrapped.acquire(timeout=5):
+            pass
+    finally:
+        await wrapped.close()
+
+    assert captured.get('timeout') == 5, f"timeout not forwarded: {captured}"

--- a/tests/test_executor_pool.py
+++ b/tests/test_executor_pool.py
@@ -1,0 +1,234 @@
+"""
+Tests for src/db/executor_pool.py — wraps asyncpg.Pool so all DB operations
+run on a dedicated background thread with its own asyncio event loop, isolating
+asyncpg from the MCP SDK's anyio task group context.
+
+Background: docs/handoffs/2026-04-27-anyio-followup-scope.md (P2 design + council).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.db.executor_pool import ExecutorPool
+
+
+@pytest.mark.asyncio
+async def test_fetchval_runs_on_dedicated_thread():
+    """
+    The whole point of P2: the asyncpg call must execute on a different
+    thread than the caller's loop. If the wrapper runs the asyncpg coroutine
+    on the caller's loop, we haven't isolated anything and the deadlock stays.
+    """
+    caller_thread_id = threading.get_ident()
+    asyncpg_thread_id_holder = {}
+
+    async def capture_thread_and_return(*args, **kwargs):
+        asyncpg_thread_id_holder['tid'] = threading.get_ident()
+        return 42
+
+    mock_conn = MagicMock()
+    mock_conn.fetchval = capture_thread_and_return
+
+    mock_acquire_ctx = AsyncMock()
+    mock_acquire_ctx.__aenter__.return_value = mock_conn
+    mock_acquire_ctx.__aexit__.return_value = None
+
+    raw_pool = MagicMock()
+    raw_pool.acquire = MagicMock(return_value=mock_acquire_ctx)
+    raw_pool.close = AsyncMock()
+
+    wrapped = ExecutorPool(raw_pool)
+    try:
+        async with wrapped.acquire() as conn:
+            result = await conn.fetchval("SELECT 1")
+    finally:
+        await wrapped.close()
+
+    assert result == 42
+    assert 'tid' in asyncpg_thread_id_holder, "asyncpg call never ran"
+    assert asyncpg_thread_id_holder['tid'] != caller_thread_id, (
+        f"asyncpg ran on caller thread {caller_thread_id} — wrapper failed "
+        f"to isolate. Both got {asyncpg_thread_id_holder['tid']}."
+    )
+
+
+def _make_pool_with_conn(conn_methods: dict):
+    """Helper: build an ExecutorPool over a mock conn whose methods we define."""
+    mock_conn = MagicMock()
+    for name, impl in conn_methods.items():
+        setattr(mock_conn, name, impl)
+
+    mock_acquire_ctx = AsyncMock()
+    mock_acquire_ctx.__aenter__.return_value = mock_conn
+    mock_acquire_ctx.__aexit__.return_value = None
+
+    raw_pool = MagicMock()
+    raw_pool.acquire = MagicMock(return_value=mock_acquire_ctx)
+    raw_pool.close = AsyncMock()  # asyncpg.Pool.close is async
+    return ExecutorPool(raw_pool), mock_conn
+
+
+@pytest.mark.asyncio
+async def test_all_connection_methods_forward():
+    """fetch, fetchrow, execute, executemany all route through the executor loop."""
+
+    async def fetch_impl(*a, **k): return [{"row": 1}]
+    async def fetchrow_impl(*a, **k): return {"row": 2}
+    async def execute_impl(*a, **k): return "INSERT 0 1"
+    async def executemany_impl(*a, **k): return None
+
+    wrapped, _ = _make_pool_with_conn({
+        "fetch": fetch_impl,
+        "fetchrow": fetchrow_impl,
+        "execute": execute_impl,
+        "executemany": executemany_impl,
+    })
+    try:
+        async with wrapped.acquire() as conn:
+            assert await conn.fetch("SELECT *") == [{"row": 1}]
+            assert await conn.fetchrow("SELECT 1") == {"row": 2}
+            assert await conn.execute("INSERT INTO x VALUES (1)") == "INSERT 0 1"
+            assert await conn.executemany("INSERT INTO x VALUES ($1)", [(1,), (2,)]) is None
+    finally:
+        await wrapped.close()
+
+
+@pytest.mark.asyncio
+async def test_transaction_context_manager_round_trips():
+    """
+    transaction() returns an async context manager whose __aenter__/__aexit__
+    must both round-trip to the executor loop. Council architect flagged this
+    as easy-to-miss because it looks like pure caller-side syntax.
+    """
+    caller_tid = threading.get_ident()
+    enter_tid = []
+    exit_tid = []
+
+    mock_txn = MagicMock()
+    async def txn_aenter():
+        enter_tid.append(threading.get_ident())
+        return mock_txn
+    async def txn_aexit(exc_type, exc_val, exc_tb):
+        exit_tid.append(threading.get_ident())
+        return None
+    mock_txn.__aenter__ = MagicMock(side_effect=txn_aenter)
+    mock_txn.__aexit__ = MagicMock(side_effect=txn_aexit)
+
+    def transaction_impl(): return mock_txn
+
+    wrapped, _ = _make_pool_with_conn({"transaction": transaction_impl})
+    try:
+        async with wrapped.acquire() as conn:
+            async with conn.transaction():
+                pass
+    finally:
+        await wrapped.close()
+
+    assert len(enter_tid) == 1 and enter_tid[0] != caller_tid, "txn __aenter__ ran on caller thread"
+    assert len(exit_tid) == 1 and exit_tid[0] != caller_tid, "txn __aexit__ ran on caller thread"
+
+
+@pytest.mark.asyncio
+async def test_handler_cancellation_propagates_to_executor_task():
+    """
+    LOAD-BEARING: when the caller's await is cancelled, the asyncpg-side
+    coroutine on the executor loop must also be cancelled — not left orphaned
+    holding the connection.
+
+    Architect flagged: without this bridge, you get orphan queries that
+    block subsequent acquire() calls forever.
+
+    Note: `asyncio.wrap_future(run_coroutine_threadsafe(...))` provides this
+    bridge automatically via stdlib's `_chain_future`. This test guards
+    against a future refactor that uses a non-chaining bridge.
+    """
+    cancelled_on_executor = asyncio.Event()
+    started_on_executor = threading.Event()
+
+    async def long_query(*args, **kwargs):
+        started_on_executor.set()
+        try:
+            await asyncio.sleep(10)  # would-be slow query
+        except asyncio.CancelledError:
+            cancelled_on_executor.set()
+            raise
+        return "should never reach"
+
+    wrapped, _ = _make_pool_with_conn({"fetchval": long_query})
+    try:
+        async with wrapped.acquire() as conn:
+            task = asyncio.create_task(conn.fetchval("SELECT pg_sleep(10)"))
+            # Wait until the executor-side coroutine is actually running.
+            await asyncio.get_event_loop().run_in_executor(
+                None, started_on_executor.wait, 2.0
+            )
+            assert started_on_executor.is_set(), "executor task never started"
+
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            # Give the bridge a moment to propagate the cancel to the executor loop.
+            await asyncio.sleep(0.1)
+            assert cancelled_on_executor.is_set(), (
+                "Caller cancelled but executor task was not cancelled — "
+                "orphan query holding the connection."
+            )
+    finally:
+        await wrapped.close()
+
+
+@pytest.mark.asyncio
+async def test_close_calls_raw_pool_close_on_executor_loop():
+    """
+    Pool teardown must invoke raw asyncpg pool.close() on the executor loop
+    (asyncpg connections are loop-bound; closing from any other loop fails).
+    Architect flagged: wrong teardown order = hung shutdown or
+    'pool closed mid-query' tracebacks during launchd unload.
+    """
+    caller_tid = threading.get_ident()
+    close_tid = []
+
+    async def close_impl():
+        close_tid.append(threading.get_ident())
+
+    raw_pool = MagicMock()
+    raw_pool.close = close_impl
+
+    wrapped = ExecutorPool(raw_pool)
+    await wrapped.close()
+
+    assert len(close_tid) == 1, "raw pool.close() was never called"
+    assert close_tid[0] != caller_tid, (
+        f"raw pool.close() ran on caller thread {caller_tid} — must run on "
+        f"executor loop because asyncpg connections are loop-bound."
+    )
+
+
+@pytest.mark.asyncio
+async def test_pool_pass_through_attributes():
+    """
+    `_closed`, `get_size`, `get_idle_size`, `get_max_size` are read by callers
+    (postgres_backend.py:104, dialectic_db.py:55) — wrapper must mirror them
+    so the abstraction doesn't leak.
+    """
+    raw_pool = MagicMock()
+    raw_pool._closed = False
+    raw_pool.get_size = MagicMock(return_value=10)
+    raw_pool.get_idle_size = MagicMock(return_value=7)
+    raw_pool.get_max_size = MagicMock(return_value=20)
+    raw_pool.close = AsyncMock()
+
+    wrapped = ExecutorPool(raw_pool)
+    try:
+        assert wrapped._closed is False
+        assert wrapped.get_size() == 10
+        assert wrapped.get_idle_size() == 7
+        assert wrapped.get_max_size() == 20
+    finally:
+        await wrapped.close()

--- a/tests/test_postgres_pool_guard.py
+++ b/tests/test_postgres_pool_guard.py
@@ -61,7 +61,11 @@ class TestInitGuard:
         with patch("asyncpg.create_pool", new_callable=AsyncMock, return_value=mock_pool):
             await backend.init()
 
-        assert backend._pool is mock_pool
+        # _create_pool() now wraps the asyncpg pool in ExecutorPool — handlers
+        # see the wrapper, but the underlying asyncpg pool is preserved.
+        from src.db.executor_pool import ExecutorPool
+        assert isinstance(backend._pool, ExecutorPool)
+        assert backend._pool._raw_pool is mock_pool
 
     @pytest.mark.asyncio
     async def test_init_idempotent_across_calls(self):
@@ -115,8 +119,11 @@ class TestPoolRecovery:
         with patch("asyncpg.create_pool", new_callable=AsyncMock, return_value=mock_pool):
             result = await backend._ensure_pool()
 
-        assert result is mock_pool
-        assert backend._pool is mock_pool
+        # Wrapped in ExecutorPool — see _create_pool() and src/db/executor_pool.py
+        from src.db.executor_pool import ExecutorPool
+        assert isinstance(result, ExecutorPool)
+        assert result._raw_pool is mock_pool
+        assert backend._pool is result
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

P2 part 1 of 2 — adds a new asyncpg pool wrapper that runs DB operations on a dedicated background thread with its own asyncio event loop. Isolates asyncpg from the MCP SDK's anyio task group context, eliminating the deadlock at its source.

**Additive only** — new file, no callers yet. Wires in via PR2 (`postgres_backend.py` + `dialectic_db.py` + validation handler migration).

Background: `docs/handoffs/2026-04-27-anyio-followup-scope.md` — current state is 64 scattered defensive mitigations + ~31 `[anyio-asyncio guard]` events/hour firing in production logs.

## Council review (3 parallel agents, before code)

- **dialectic-knowledge-architect** — loop-ownership coherence; flagged cancellation-bridging and pool-teardown ordering as load-bearing edge cases
- **feature-dev:code-reviewer** — enumerated the asyncpg API surface that handlers actually use (acquire/fetchval/fetch/fetchrow/execute/executemany/transaction/close + pool methods); caught that DialecticDB holds its own pool reference (`dialectic_db.py:45`) — must be addressed in PR2
- **live-verifier** — confirmed current reproductions (`health_check lite=false` 100% solo hang, observe/anomalies 100% under 5+ concurrency); refuted the original 2026-04-09 reproduction (Option F cleared `lite=true`)

## Tests (6, all green)

| Test | Contract |
|------|----------|
| `test_fetchval_runs_on_dedicated_thread` | Foundational: asyncpg actually executes on the executor thread, not the caller's |
| `test_all_connection_methods_forward` | fetch / fetchrow / execute / executemany |
| `test_transaction_context_manager_round_trips` | `__aenter__`/`__aexit__` both round-trip to executor loop |
| `test_handler_cancellation_propagates_to_executor_task` | Caller cancel → asyncpg task cancel (no orphan queries) |
| `test_close_calls_raw_pool_close_on_executor_loop` | Pool teardown ordering correct (loop-bound resource) |
| `test_pool_pass_through_attributes` | `_closed`/`get_size`/`get_idle_size`/`get_max_size` mirrored |

Full suite: 7688 passed, 33 skipped, 0 failed.

## Test plan

- [x] All 6 wrapper tests green
- [x] Full suite green (`./scripts/dev/test-cache.sh`)
- [ ] PR2 wires into `postgres_backend.py` + `dialectic_db.py` + migrates `process_binding.py:record_binding_bg` as validation handler
- [ ] Live load test under PR2 (live-verifier's Phase 1+3): 10 workers × 60s on `health_check lite=false` + `observe/anomalies` + `dialectic/list`; success = zero 0-byte responses, zero new `[anyio-asyncio guard]` log lines