### PR TITLE
calibration: bump CURRENT_EPOCH 2→3 (commit applied bump)

### DIFF
--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -675,7 +675,7 @@ class GovernanceConfig:
     # Most changes (bug fixes, new tools, docs) do NOT bump the epoch.
     # Only changes to EISV coupling, coherence formulas, or calibration
     # logic that make existing data wrong require a bump.
-    CURRENT_EPOCH = 2
+    CURRENT_EPOCH = 3
 
     # =================================================================
     # Temporal Narrator Configuration


### PR DESCRIPTION
The \`scripts/dev/bump_epoch.py\` run earlier today modified \`config/governance_config.py::CURRENT_EPOCH\` from 2 to 3, inserted the corresponding \`core.epochs\` row, and cleared old-epoch baselines. The DB and live process are at epoch 3; this commit brings the file back into sync with master.

Reason carried in \`core.epochs\`: "broadened tactical calibration truth channel — task_* added; per-channel surface in API"

## Summary
- Committing the in-place edit \`bump_epoch.py\` made.
- Without this PR, anyone pulling master would have CURRENT_EPOCH=2 in their config but the DB at epoch 3 — divergence between code and the running system.

## Test plan
- [x] DB \`core.epochs\` already shows epoch 3 row.
- [x] \`SequentialCalibrationTracker\` migrated state file on the restart that picked up the bump.
- [x] \`check_calibration\` now returns \`per_channel_calibration\` and \`per_channel_health\` populated from the broadened tactical channel.