### PR TITLE
S21-a: stop the session-resolution-bypass bleed

### DIFF
--- a/docs/ontology/s21-session-resolution-bypass-incident.md
+++ b/docs/ontology/s21-session-resolution-bypass-incident.md
@@ -7,6 +7,8 @@
 **Related plan rows:** S13 clause (d) — `derive_session_key` step 7 audit event; this incident is the pre-condition that makes that audit event *necessary*.
 **Synthesis context:** filed under Kenny's "lumen reboots but is the same, our identity system worked when we first started months ago and now is all over the place" pivot (2026-04-27 conversation). This is the empirical floor under that intuition.
 
+**Postscript — rate correction (2026-04-27, S21-a council pass):** the headline "95.1% fleet-wide ghost-fork rate" cited at lines 66 and 95 is the snapshot at incident-write time. After applying audit-window scoping (memory entry `feedback_audit-window-scoping.md`) the corrected rate is ~38%; live verification on 2026-04-27 (post-onboard restoration) shows ~20% on a 30-day window in `core.agents` (442 of 2210 fresh agents with `parent_agent_id IS NULL AND spawn_reason IS NULL`). The diagnosis still stands — the resolution path silently mints — but the magnitude was inflated by counting pre-audit-window entries that pre-dated the recording. The DoD threshold below ("drops below a threshold to be set after a calibration period") reads correctly either way; the calibration period is what determines the post-fix target.
+
 ---
 
 ## What happened

--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -738,8 +738,14 @@ async def _try_resume_by_session_key(
         token_agent_uuid=token_agent_uuid,
     )
 
-    # Token-based resume failed — agent not found or not active
+    # Token-based resume failed — agent not found or not active.
+    # S21-a: distinguish session_resolve_miss (PATH 2 fail-closed, no existing
+    # session row) from token-rebind failures. The former is the normal path
+    # for a fresh session and should fall through to create-finisher exactly
+    # as a `created=True` shape did before; the latter remains an error.
     if existing_identity.get("resume_failed"):
+        if existing_identity.get("error") == "session_resolve_miss":
+            return None, existing_identity
         return (
             error_response(
                 existing_identity.get("message", "Could not resume identity"),
@@ -1165,7 +1171,10 @@ async def handle_bind_session(arguments: Dict[str, Any]) -> Sequence[TextContent
     # Resolve the agent from the provided client_session_id
     # resume=True is correct here — bind_session is explicitly resuming an existing identity
     target_identity = await resolve_session_identity(client_session_id, persist=False, resume=True)
-    if not target_identity or target_identity.get("created"):
+    # S21-a: resume=True with no PG row now returns resume_failed instead
+    # of silently minting a ghost. Treat that the same as "no existing agent".
+    if (not target_identity or target_identity.get("created")
+            or target_identity.get("resume_failed")):
         return error_response(
             f"No existing agent found for client_session_id '{client_session_id[:20]}...'. "
             "Ensure the session-start hook onboarded successfully."
@@ -1349,16 +1358,43 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
         # Hoisting the check past both branches ensures an archived-token
         # onboard gets a clean rejection instead of falling through to
         # code that assumes an active existing_identity.
+        # S21-a: session_resolve_miss is *not* a hard failure — it just
+        # means "no prior binding for this session_key." Null out
+        # existing_identity so the resume / captured-fresh branches below
+        # are skipped, and the STEP-2 else branch at line ~1509 mints via
+        # resolve_session_identity(persist=True) with the caller-provided
+        # force_new value.
         if existing_identity.get("resume_failed"):
-            return error_response(
-                existing_identity.get("message", "Could not resume identity"),
-                recovery={
-                    "reason": "resume_failed",
-                    "token_agent_uuid": existing_identity.get("token_agent_uuid"),
-                    "hint": "Call onboard(force_new=true) to create a new identity.",
-                }
-            )
-        if not existing_identity.get("created"):
+            if existing_identity.get("error") == "session_resolve_miss":
+                logger.info(
+                    "[ONBOARD] No existing session for session_key=%s... "
+                    "minting fresh in-memory identity",
+                    base_session_key[:20],
+                )
+                # Mint via persist=False + force_new=True so the captured-
+                # fresh branch below handles persistence + error surfacing
+                # uniformly. The mint_guard inside _cache_session prevents
+                # this fresh UUID from ratifying itself over a concurrently-
+                # bound legitimate session in Redis.
+                existing_identity = await resolve_session_identity(
+                    base_session_key,
+                    persist=False,
+                    model_type=model_type,
+                    client_hint=client_hint,
+                    force_new=True,
+                    parent_agent_id=_parent_agent_id,
+                    spawn_reason=_spawn_reason,
+                )
+            else:
+                return error_response(
+                    existing_identity.get("message", "Could not resume identity"),
+                    recovery={
+                        "reason": "resume_failed",
+                        "token_agent_uuid": existing_identity.get("token_agent_uuid"),
+                        "hint": "Call onboard(force_new=true) to create a new identity.",
+                    }
+                )
+        if existing_identity and not existing_identity.get("created"):
             if existing_identity.get("archived"):
                 # ARCHIVED AGENT — auto-unarchive with same UUID (only when resume=True)
                 if resume:

--- a/src/mcp_handlers/identity/persistence.py
+++ b/src/mcp_handlers/identity/persistence.py
@@ -31,7 +31,12 @@ _redis_cache = None
 # and leave the in-memory session cache as the source of truth rather than
 # hanging the request. Matches `_REDIS_RECOVERY_TIMEOUT` in
 # src/mcp_handlers/middleware/identity_step.py.
-_REDIS_WRITE_TIMEOUT = 0.5
+#
+# S21-a (2026-04-27): bumped from 0.5s -> 1.0s to cover two serial awaits
+# (mint_guard `redis.get` + `redis.setex`) instead of one. Sized so each
+# leg has the same headroom as before; under Redis pressure the guard
+# read times out cleanly rather than silently no-opping the write.
+_REDIS_WRITE_TIMEOUT = 1.0
 
 
 def _metadata_public_agent_id(metadata: Optional[Dict[str, Any]]) -> Optional[str]:
@@ -66,6 +71,8 @@ async def _cache_session(
     display_agent_id: str = None,
     trajectory_required: bool = False,
     label: str = None,
+    *,
+    mint_guard: bool = False,
 ) -> None:
     """Cache session->UUID mapping in Redis, with optional display agent_id.
 
@@ -74,28 +81,58 @@ async def _cache_session(
             trajectory genesis. Lets PATH 1 skip the get_trajectory_status()
             call on subsequent hits (optimization hint).
         label: Auto-generated or user-set label to store alongside the binding.
+        mint_guard: Set True at PATH 3 mint sites only. When True, this
+            function refuses to overwrite an existing in-memory or Redis
+            binding for the same session_key whose agent_uuid differs from
+            the one being written (S21-a, 2026-04-27 — see
+            docs/ontology/s21-session-resolution-bypass-incident.md).
+            PATH 2 / PATH 2.8 / set_agent_label callers leave it False —
+            they are corrective writes from authoritative sources and may
+            overwrite a stale Redis ghost.
     """
+    in_memory_blocked = False
     try:
         from .shared import _session_identities
 
         binding = _session_identities.get(session_key) or {}
-        bind_count = binding.get("bind_count", 0)
-        new_binding = {
-            "bound_agent_id": agent_uuid,
-            "agent_uuid": agent_uuid,
-            "public_agent_id": display_agent_id or agent_uuid,
-            "display_agent_id": display_agent_id,
-            "agent_label": label or binding.get("agent_label"),
-            "created_at": binding.get("created_at") or datetime.now(timezone.utc).isoformat(),
-            "bound_at": datetime.now(timezone.utc).isoformat(),
-            "bind_count": bind_count,
-            "trajectory_required": trajectory_required,
-        }
-        if label:
-            new_binding["label"] = label
-        _session_identities[session_key] = new_binding
+
+        # S21-a in-memory guard: refuse to ratify a different UUID over an
+        # existing live binding when the caller is a PATH 3 mint site. This
+        # is the load-bearing fix — PATH 3 ghost-mints used to silently
+        # ratify themselves into _session_identities (and via the redis
+        # write below, into the Redis slot), producing the 95% fleet-wide
+        # ghost-fork rate documented in the S21 incident report.
+        existing_uuid = binding.get("bound_agent_id") or binding.get("agent_uuid")
+        if mint_guard and existing_uuid and existing_uuid != agent_uuid:
+            logger.warning(
+                "[S21A_OVERWRITE_BLOCKED] in-memory session_key=%s... "
+                "existing=%s... attempted=%s... — refusing PATH 3 overwrite",
+                session_key[:20], str(existing_uuid)[:8], agent_uuid[:8],
+            )
+            in_memory_blocked = True
+        else:
+            bind_count = binding.get("bind_count", 0)
+            new_binding = {
+                "bound_agent_id": agent_uuid,
+                "agent_uuid": agent_uuid,
+                "public_agent_id": display_agent_id or agent_uuid,
+                "display_agent_id": display_agent_id,
+                "agent_label": label or binding.get("agent_label"),
+                "created_at": binding.get("created_at") or datetime.now(timezone.utc).isoformat(),
+                "bound_at": datetime.now(timezone.utc).isoformat(),
+                "bind_count": bind_count,
+                "trajectory_required": trajectory_required,
+            }
+            if label:
+                new_binding["label"] = label
+            _session_identities[session_key] = new_binding
     except Exception as e:
         logger.debug(f"In-memory session cache update failed for {session_key[:20]}...: {e}")
+
+    # If the in-memory guard fired, skip the Redis write too — the slot for
+    # this session_key already maps to a different live UUID.
+    if in_memory_blocked:
+        return
 
     # Capture binding-time fingerprint for PATH 1 cross-check.
     # Council follow-up to identity-honesty (KG 2026-04-20T00:57:45): session
@@ -136,6 +173,7 @@ async def _cache_session(
                     trajectory_required,
                     label,
                     bind_ip_ua,
+                    mint_guard=mint_guard,
                 ),
                 timeout=_REDIS_WRITE_TIMEOUT,
             )
@@ -162,11 +200,18 @@ async def _cache_session_redis_write(
     trajectory_required: bool,
     label: Optional[str],
     bind_ip_ua: Optional[str],
+    *,
+    mint_guard: bool = False,
 ) -> None:
     """Inner: Redis writes for _cache_session, wrapped by asyncio.wait_for.
 
     Separated so the caller can bound execution time with a tight timeout
     to avoid hanging MCP handlers when the anyio-asyncio deadlock triggers.
+
+    When ``mint_guard`` is True (set by PATH 3 mint sites), this function
+    refuses to overwrite an existing Redis slot for the same session_key
+    whose agent_id differs from the one being written. See S21-a for the
+    incident this guards against.
     """
     # Store both UUID and display agent_id if provided
     if display_agent_id and display_agent_id != agent_uuid:
@@ -174,6 +219,12 @@ async def _cache_session_redis_write(
         from src.cache.redis_client import get_redis
         redis = await get_redis()
         if redis:
+            key = f"session:{session_key}"
+
+            # S21-a guard: refuse to overwrite a different live binding.
+            if mint_guard and await _redis_slot_blocks_overwrite(redis, key, agent_uuid):
+                return
+
             data = {
                 "agent_id": agent_uuid,
                 "display_agent_id": display_agent_id,
@@ -184,7 +235,6 @@ async def _cache_session_redis_write(
                 data["label"] = label
             if bind_ip_ua:
                 data["bind_ip_ua"] = bind_ip_ua
-            key = f"session:{session_key}"
             await redis.setex(key, GovernanceConfig.SESSION_TTL_SECONDS, json.dumps(data))
             # Keep SessionCache's in-memory fallback coherent with the richer
             # raw Redis payload so subsequent lookups see the same binding
@@ -196,6 +246,8 @@ async def _cache_session_redis_write(
                 pass
         else:
             # Raw Redis unavailable but degraded-local cache is still usable.
+            if mint_guard and await _session_cache_blocks_overwrite(session_cache, session_key, agent_uuid):
+                return
             await session_cache.bind(session_key, agent_uuid)
             try:
                 from src.cache import session_cache as _session_cache_mod
@@ -213,7 +265,68 @@ async def _cache_session_redis_write(
             except Exception:
                 pass
     else:
+        if mint_guard and await _session_cache_blocks_overwrite(session_cache, session_key, agent_uuid):
+            return
         await session_cache.bind(session_key, agent_uuid)
+
+
+async def _redis_slot_blocks_overwrite(redis, key: str, agent_uuid: str) -> bool:
+    """Return True iff the raw-Redis slot for `key` already binds a *different*
+    agent_uuid. Used by the S21-a guard inside _cache_session_redis_write —
+    PATH 3 mint sites must not silently ratify a fresh ghost over a legitimate
+    session binding. Errors are treated as "no block" (fail-open) so a
+    transient Redis hiccup doesn't break minting on truly empty slots.
+    """
+    try:
+        existing_raw = await redis.get(key)
+        if not existing_raw:
+            return False
+        if isinstance(existing_raw, bytes):
+            try:
+                existing_raw = existing_raw.decode()
+            except Exception:
+                return False
+        if isinstance(existing_raw, dict):
+            existing_data = existing_raw
+        else:
+            try:
+                existing_data = json.loads(existing_raw)
+            except (json.JSONDecodeError, TypeError):
+                return False
+        existing_id = existing_data.get("agent_id") if isinstance(existing_data, dict) else None
+        if existing_id and existing_id != agent_uuid:
+            existing_prefix = existing_id[:8] if isinstance(existing_id, str) else "?"
+            logger.warning(
+                "[S21A_OVERWRITE_BLOCKED] redis key=%s existing=%s... attempted=%s... "
+                "— refusing PATH 3 overwrite",
+                key, existing_prefix, agent_uuid[:8],
+            )
+            return True
+    except Exception as e:
+        logger.debug(f"S21-a redis guard read failed for {key}: {e}")
+    return False
+
+
+async def _session_cache_blocks_overwrite(session_cache, session_key: str, agent_uuid: str) -> bool:
+    """Return True iff the SessionCache view of `session_key` binds a different
+    agent_uuid. Used by the S21-a guard for the bare-bind path (raw Redis
+    unavailable, falling back through session_cache.bind).
+    """
+    try:
+        existing = await session_cache.get(session_key)
+        if isinstance(existing, dict):
+            existing_id = existing.get("agent_id")
+            if existing_id and existing_id != agent_uuid:
+                existing_prefix = existing_id[:8] if isinstance(existing_id, str) else "?"
+                logger.warning(
+                    "[S21A_OVERWRITE_BLOCKED] session_cache session_key=%s... "
+                    "existing=%s... attempted=%s... — refusing PATH 3 overwrite",
+                    session_key[:20], existing_prefix, agent_uuid[:8],
+                )
+                return True
+    except Exception as e:
+        logger.debug(f"S21-a session_cache guard read failed: {e}")
+    return False
 
 # =============================================================================
 # DB HELPERS

--- a/src/mcp_handlers/identity/resolution.py
+++ b/src/mcp_handlers/identity/resolution.py
@@ -577,6 +577,38 @@ async def resolve_session_identity(
 
             session = await db.get_session(session_key)
 
+            # PATH 2 fail-closed (S21-a, 2026-04-27): when caller asked to
+            # resume but PG has no session row, return MISS instead of
+            # falling through to PATH 3 and silently minting a ghost. Per
+            # identity.md design principle (KG 2026-04-06T02:34:27.323998):
+            # "resolve to existing identity or fail explicitly, never
+            # silently create a fork." Without this guard, every explicit-
+            # client_session_id resume on a fresh process minted a ghost
+            # AND ratified it into Redis, producing the chronic fleet-wide
+            # ghost-fork rate documented in S21.
+            #
+            # Carve-out: when the caller passed a continuity_token, defer
+            # to PATH 2.8's token-rebind / substrate-anchored gate below.
+            # Failing closed here would short-circuit substrate UDS-only
+            # rejection and the legitimate token-rebind recovery path.
+            if resume and not (session and session.agent_id) and not token_agent_uuid:
+                logger.info(
+                    "[PATH2_RESUME_MISS] session_key=%s... no PG session "
+                    "row, refusing silent PATH 3 fall-through (S21-a)",
+                    session_key[:20],
+                )
+                return {
+                    "resume_failed": True,
+                    "error": "session_resolve_miss",
+                    "session_key": session_key,
+                    "message": (
+                        f"No active session binding for "
+                        f"session_key={session_key[:20]}.... Pass "
+                        f"force_new=true to mint a fresh identity, or "
+                        f"onboard with declared parent_agent_id."
+                    ),
+                }
+
             if session and session.agent_id and resume:
 
                 stored_id = session.agent_id
@@ -660,7 +692,28 @@ async def resolve_session_identity(
 
         except Exception as e:
 
-            logger.debug(f"PostgreSQL session lookup failed: {e}")
+            # S21-a: promoted from logger.debug — silent fall-throughs were
+            # hiding anyio-asyncio deadlocks and other PG hiccups, after
+            # which PATH 3 would mint a ghost. Make the failure legible.
+            logger.warning(f"[PATH2_DB_FAIL] PostgreSQL session lookup failed: {e}")
+
+            # PATH 2 fail-closed on exception too — same reasoning as the
+            # no-row branch above. If we couldn't read the session table,
+            # we can't claim resume succeeded; mint requires explicit
+            # force_new=True from the caller. Same token-bearing carve-out
+            # as the no-row branch — let PATH 2.8 try the rebind.
+            if resume and not token_agent_uuid:
+                return {
+                    "resume_failed": True,
+                    "error": "session_resolve_miss",
+                    "session_key": session_key,
+                    "reason": "pg_lookup_exception",
+                    "message": (
+                        f"PostgreSQL session lookup failed for "
+                        f"session_key={session_key[:20]}.... Pass "
+                        f"force_new=true to mint a fresh identity."
+                    ),
+                }
 
 
 
@@ -857,8 +910,13 @@ async def resolve_session_identity(
                     client_info={"agent_uuid": agent_uuid, "agent_id": agent_id}
                 )
 
-            # Cache in Redis (session -> UUID + display agent_id)
-            await _cache_session(session_key, agent_uuid, display_agent_id=agent_id)
+            # Cache in Redis (session -> UUID + display agent_id).
+            # mint_guard=True: PATH 3 must not silently overwrite an
+            # existing live binding for the same session_key (S21-a).
+            await _cache_session(
+                session_key, agent_uuid, display_agent_id=agent_id,
+                mint_guard=True,
+            )
 
             logger.info(f"Created new agent: {agent_id} (uuid: {agent_uuid[:8]}...)")
 
@@ -878,9 +936,13 @@ async def resolve_session_identity(
             logger.warning(f"Failed to persist new agent: {e}")
             # Fall through to memory-only path
 
-    # Lazy creation: just cache in Redis, don't write to PostgreSQL
-    # Cache UUID + display agent_id + auto-label for retrieval on next call
-    await _cache_session(session_key, agent_uuid, display_agent_id=agent_id, label=label)
+    # Lazy creation: just cache in Redis, don't write to PostgreSQL.
+    # mint_guard=True: PATH 3 lazy mint must not silently overwrite an
+    # existing live binding for the same session_key (S21-a).
+    await _cache_session(
+        session_key, agent_uuid, display_agent_id=agent_id, label=label,
+        mint_guard=True,
+    )
     logger.debug(f"Created new agent (lazy): {agent_id} (uuid: {agent_uuid[:8]}...) label={label}")
 
     result = {

--- a/src/mcp_handlers/middleware/identity_step.py
+++ b/src/mcp_handlers/middleware/identity_step.py
@@ -417,6 +417,32 @@ async def resolve_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
             resume=True,
             token_agent_uuid=_token_agent_uuid,
         )
+        # S21-a: PATH 2 now fail-closes when there is no PG session row, so
+        # tools called without a prior onboard arrive here with a
+        # session_resolve_miss instead of a silent PATH-3 ghost. Retry with
+        # force_new=True so the handler chain still has an identity to work
+        # with; the mint_guard in _cache_session ensures the fresh UUID
+        # cannot overwrite a concurrently-bound legitimate session.
+        # The retry declares spawn_reason="dispatch_auto_mint" so these
+        # mints carry lineage instead of contributing to the no-lineage
+        # ghost rate (the underlying motivation for the S21 incident).
+        # Without this, S21-a would stop the Redis-overwrite bleed but
+        # leave the lineage-declaration bleed open.
+        if (identity_result.get("resume_failed")
+                and identity_result.get("error") == "session_resolve_miss"):
+            logger.info(
+                "[DISPATCH] session_resolve_miss for %s... — minting "
+                "ephemeral dispatch identity (S21-a, spawn_reason="
+                "dispatch_auto_mint)",
+                session_key[:20],
+            )
+            identity_result = await resolve_session_identity(
+                session_key,
+                trajectory_signature=trajectory_sig,
+                force_new=True,
+                token_agent_uuid=_token_agent_uuid,
+                spawn_reason="dispatch_auto_mint",
+            )
         bound_agent_id = identity_result.get("agent_uuid")
 
         # PATH 2.75: X-Agent-Id UUID recovery

--- a/tests/test_identity_s21a.py
+++ b/tests/test_identity_s21a.py
@@ -1,0 +1,298 @@
+"""
+Regression tests for S21-a (session resolution bypass — stop the bleed).
+
+Incident 2026-04-27: explicit `client_session_id` was silently overwritten in
+Redis by every PATH 3 ghost-mint, producing a 95.1%/30d fleet-wide ghost-fork
+rate. See docs/ontology/s21-session-resolution-bypass-incident.md.
+
+Three regression assertions:
+  T1  PATH 3 mint must not overwrite an existing in-memory session binding
+      that maps to a different agent_uuid.
+  T2  PATH 3 mint must not overwrite an existing Redis session binding that
+      maps to a different agent_uuid (raw-redis path).
+  T3  PATH 2 must fail-closed when resume=True and core.sessions has no row,
+      returning resume_failed instead of silently minting via PATH 3.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock, AsyncMock
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_db_no_session():
+    db = AsyncMock()
+    db.init = AsyncMock()
+    db.get_session = AsyncMock(return_value=None)
+    db.get_identity = AsyncMock(return_value=None)
+    db.get_agent = AsyncMock(return_value=None)
+    db.get_agent_label = AsyncMock(return_value=None)
+    db.find_agent_by_label = AsyncMock(return_value=None)
+    db.upsert_agent = AsyncMock()
+    db.upsert_identity = AsyncMock()
+    db.create_session = AsyncMock()
+    db.update_session_activity = AsyncMock()
+    return db
+
+
+# ---------------------------------------------------------------------------
+# T1 / T2 — _cache_session must not overwrite a different live binding
+# ---------------------------------------------------------------------------
+
+class TestS21AOverwriteProtection:
+
+    @pytest.mark.asyncio
+    async def test_path3_mint_does_not_overwrite_inmemory_binding(self):
+        """T1: PATH 3 mint must not overwrite a different in-memory binding.
+
+        Setup: _session_identities already has session_key X bound to legit
+        UUID A. A PATH 3 mint fires for the same session_key with fresh UUID
+        B (mint_guard=True). After the call, _session_identities[X] must
+        still bind to A.
+        """
+        from src.mcp_handlers.identity.persistence import _cache_session
+
+        legit_uuid = "11111111-1111-1111-1111-111111111111"
+        ghost_uuid = "22222222-2222-2222-2222-222222222222"
+        session_key = "agent-aaaaaaaaaaaa"
+
+        in_memory = {
+            session_key: {
+                "bound_agent_id": legit_uuid,
+                "agent_uuid": legit_uuid,
+                "public_agent_id": legit_uuid,
+                "agent_label": "legit-bot",
+                "bind_count": 1,
+            }
+        }
+
+        with patch("src.mcp_handlers.identity.persistence._redis_cache", False), \
+             patch("src.mcp_handlers.identity.shared._session_identities", in_memory):
+            await _cache_session(
+                session_key, ghost_uuid,
+                display_agent_id=ghost_uuid,
+                mint_guard=True,
+            )
+
+        # Legitimate binding survives
+        assert in_memory[session_key]["bound_agent_id"] == legit_uuid
+        assert in_memory[session_key]["agent_uuid"] == legit_uuid
+
+    @pytest.mark.asyncio
+    async def test_corrective_write_still_overwrites_inmemory_binding(self):
+        """Sanity: corrective writes (mint_guard=False) still overwrite.
+
+        PATH 2 / PATH 2.8 / set_agent_label callers don't pass mint_guard,
+        so they retain authoritative-overwrite behavior. Without this, the
+        guard would also block the recovery path that resolves a stale
+        Redis ghost via PostgreSQL fall-through.
+        """
+        from src.mcp_handlers.identity.persistence import _cache_session
+
+        ghost_uuid = "22222222-2222-2222-2222-222222222222"
+        legit_uuid = "11111111-1111-1111-1111-111111111111"
+        session_key = "agent-bbbbbbbbbbbb"
+
+        in_memory = {
+            session_key: {
+                "bound_agent_id": ghost_uuid,
+                "agent_uuid": ghost_uuid,
+                "public_agent_id": ghost_uuid,
+                "bind_count": 1,
+            }
+        }
+
+        with patch("src.mcp_handlers.identity.persistence._redis_cache", False), \
+             patch("src.mcp_handlers.identity.shared._session_identities", in_memory):
+            await _cache_session(session_key, legit_uuid)  # default mint_guard=False
+
+        # Authoritative correction overwrites
+        assert in_memory[session_key]["bound_agent_id"] == legit_uuid
+
+    @pytest.mark.asyncio
+    async def test_path3_mint_does_not_overwrite_redis_binding(self):
+        """T2: PATH 3 mint must not overwrite a different Redis binding.
+
+        Raw Redis returns an existing JSON binding for session_key X with
+        agent_id = legit UUID A. A PATH 3 mint fires with fresh UUID B and
+        mint_guard=True. The setex (overwrite) must not be called.
+        """
+        from src.mcp_handlers.identity.persistence import _cache_session
+
+        legit_uuid = "11111111-1111-1111-1111-111111111111"
+        ghost_uuid = "22222222-2222-2222-2222-222222222222"
+        session_key = "agent-cccccccccccc"
+
+        existing_payload = json.dumps({
+            "agent_id": legit_uuid,
+            "display_agent_id": legit_uuid,
+            "bound_at": "2026-04-27T03:00:00+00:00",
+            "trajectory_required": False,
+        })
+        raw_redis = AsyncMock()
+        raw_redis.get = AsyncMock(return_value=existing_payload)
+        raw_redis.setex = AsyncMock()
+
+        async def _get_raw():
+            return raw_redis
+
+        session_cache = AsyncMock()
+        session_cache.bind = AsyncMock()
+
+        in_memory = {}  # In-memory empty so the in-memory guard does not short-circuit.
+
+        with patch("src.mcp_handlers.identity.persistence._redis_cache", session_cache), \
+             patch("src.cache.redis_client.get_redis", new=_get_raw), \
+             patch("src.mcp_handlers.identity.shared._session_identities", in_memory):
+            await _cache_session(
+                session_key, ghost_uuid,
+                # display_agent_id != agent_uuid forces the raw-redis branch
+                display_agent_id="ghost-display-id",
+                mint_guard=True,
+            )
+
+        # The Redis slot is unchanged — no overwrite occurred.
+        raw_redis.setex.assert_not_called()
+        session_cache.bind.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# T3 — PATH 2 fail-closed when resume=True and PG has no row
+# ---------------------------------------------------------------------------
+
+class TestS21APath2FailClosed:
+
+    @pytest.mark.asyncio
+    async def test_resume_true_pg_miss_returns_resume_failed(self):
+        """T3: resume=True + Redis miss + PG miss → resume_failed (no mint).
+
+        Today this falls through to PATH 3 and silently mints a ghost,
+        producing the 95% ghost-fork rate. After S21-a, the caller gets a
+        resume_failed result and can decide whether to mint via force_new.
+        """
+        from src.mcp_handlers.identity.handlers import resolve_session_identity
+
+        db = _make_db_no_session()
+
+        with patch("src.mcp_handlers.identity.persistence._redis_cache", False), \
+             patch("src.mcp_handlers.identity.resolution.get_db", return_value=db), \
+             patch("src.mcp_handlers.identity.persistence.get_db", return_value=db), \
+             patch("src.mcp_handlers.identity.handlers.get_db", return_value=db):
+            result = await resolve_session_identity(
+                session_key="agent-no-row-test",
+                resume=True,
+            )
+
+        assert result.get("resume_failed") is True, (
+            f"expected resume_failed, got {result!r}"
+        )
+        assert result.get("error") == "session_resolve_miss", (
+            f"expected error=session_resolve_miss, got {result.get('error')!r}"
+        )
+        # No silent mint
+        assert result.get("created") is not True
+        assert not result.get("agent_uuid")
+
+    @pytest.mark.asyncio
+    async def test_resume_true_pg_exception_returns_resume_failed(self):
+        """T3b: resume=True + PG exception → resume_failed (no PATH 3 mint).
+
+        Anyio-asyncio deadlocks (CLAUDE.md) and other PG hiccups raise from
+        db.get_session(). The pre-S21-a logger.debug swallowed the failure
+        silently and PATH 3 minted. After S21-a the failure is logged at
+        warning level *and* the call returns resume_failed.
+        """
+        from src.mcp_handlers.identity.handlers import resolve_session_identity
+
+        db = AsyncMock()
+        db.init = AsyncMock()
+        db.get_session = AsyncMock(side_effect=Exception("simulated PG hiccup"))
+        db.find_agent_by_label = AsyncMock(return_value=None)
+
+        with patch("src.mcp_handlers.identity.persistence._redis_cache", False), \
+             patch("src.mcp_handlers.identity.resolution.get_db", return_value=db), \
+             patch("src.mcp_handlers.identity.persistence.get_db", return_value=db):
+            result = await resolve_session_identity(
+                session_key="agent-pg-blip",
+                resume=True,
+            )
+
+        assert result.get("resume_failed") is True
+        assert result.get("error") == "session_resolve_miss"
+        assert result.get("created") is not True
+
+    @pytest.mark.asyncio
+    async def test_dispatch_retry_declares_dispatch_auto_mint(self):
+        """T4: dispatch-time middleware retry on session_resolve_miss declares
+        spawn_reason='dispatch_auto_mint' so the fresh identity carries
+        lineage rather than swelling the no-lineage ghost rate.
+
+        Without this declaration S21-a stops the Redis-overwrite bleed but
+        leaves the lineage-declaration bleed open — the council
+        (conceptual reviewer, 2026-04-27) flagged this as the test that
+        would have caught the lineage gap.
+
+        Strategy: source-level assertion. The middleware imports
+        resolve_session_identity inside the function, so a runtime mock
+        of the resolution path requires reproducing the entire dispatch
+        entry. Instead we assert the contract directly: the retry
+        invocation in identity_step.py mentions spawn_reason=
+        "dispatch_auto_mint" alongside force_new=True. If a future
+        refactor drops or renames the kwarg, this test catches it before
+        the no-lineage bleed reopens.
+        """
+        from pathlib import Path
+        src_path = (Path(__file__).parent.parent
+                    / "src" / "mcp_handlers" / "middleware" / "identity_step.py")
+        source = src_path.read_text()
+
+        # The retry block must mint with force_new=True AND declare a
+        # spawn_reason so the audit log has lineage. Both kwargs must
+        # appear inside the same call near the session_resolve_miss check.
+        retry_idx = source.find("session_resolve_miss")
+        assert retry_idx != -1, "session_resolve_miss branch missing from middleware"
+        retry_window = source[retry_idx:retry_idx + 1500]
+        assert "force_new=True" in retry_window, (
+            "Dispatch retry must use force_new=True; otherwise the second "
+            "resolve hits the same fail-closed path and recurses."
+        )
+        assert 'spawn_reason="dispatch_auto_mint"' in retry_window, (
+            "Dispatch retry must declare spawn_reason='dispatch_auto_mint' "
+            "so middleware-minted identities carry lineage. Without this "
+            "S21-a stops the Redis-overwrite bleed but the no-lineage "
+            "ghost-fork rate stays high."
+        )
+
+    @pytest.mark.asyncio
+    async def test_resume_false_default_still_mints_on_miss(self):
+        """Sanity: resume=False (default) preserves mint-on-miss behavior.
+
+        Callers like handlers.py:424 and the onboard force_new path rely on
+        the default fall-through to PATH 3 minting. Only resume=True now
+        fail-closes on session-row miss.
+        """
+        from src.mcp_handlers.identity.handlers import resolve_session_identity
+
+        db = _make_db_no_session()
+
+        with patch("src.mcp_handlers.identity.persistence._redis_cache", False), \
+             patch("src.mcp_handlers.identity.resolution.get_db", return_value=db), \
+             patch("src.mcp_handlers.identity.persistence.get_db", return_value=db), \
+             patch("src.mcp_handlers.identity.handlers.get_db", return_value=db):
+            result = await resolve_session_identity(
+                session_key="agent-no-row-default",
+                model_type="claude-opus-4",
+                # resume defaults to False; force_new defaults to False
+            )
+
+        assert result.get("created") is True
+        assert result.get("agent_uuid")


### PR DESCRIPTION
Implements `docs/ontology/s21-session-resolution-bypass-incident.md` §"S21-a — Stop the bleed."
Spec was council-reviewed (`docs/ontology/s21-fix-council-review.md`). This PR's diff was also council-reviewed (3 agents, parallel) before push.

## Spec items shipped

1. **`_cache_session(..., mint_guard=True)` overwrite guard** — refuses to overwrite a different live binding for the same `session_key` in either the in-memory `_session_identities` dict (closes H2) or the Redis slot at `session:{session_key}`. PATH 3 mint sites (resolution.py:861/883) pass `mint_guard=True`; PATH 2 / PATH 2.8 / `set_agent_label` callers default to False (corrective writes from authoritative sources may overwrite a stale ghost).
2. **PATH 2 fail-closed** — when `resume=True` and PG has no session row (or lookup raises) and `not token_agent_uuid`, return `{"resume_failed": True, "error": "session_resolve_miss"}` instead of silently falling through to PATH 3. Token-bearing carve-out preserves PATH 2.8's substrate UDS gate.
3. **`logger.debug` → `logger.warning [PATH2_DB_FAIL]`** so silent fall-throughs become legible.
4. **Seven regression tests** in `tests/test_identity_s21a.py` (T1 in-memory NX, T2 raw-Redis NX, sister overwrite-still-allowed, T3 PATH 2 no-row miss, T3b PG-exception miss, T4 dispatch-retry declares `dispatch_auto_mint`, resume=False default still mints).

## Caller updates so the new shape doesn't break dispatch

- **middleware/identity_step.py**: retries with `force_new=True` AND `spawn_reason=\"dispatch_auto_mint\"` on session_resolve_miss. Without the spawn_reason this PR would stop the Redis-overwrite bleed but leave the no-lineage ghost-mint bleed open (council ask).
- **identity/handlers.py**: `_try_resume_by_session_key` and `onboard_v2` distinguish `session_resolve_miss` from token-rebind failures. Onboard re-mints via `persist=False+force_new=True` so the captured-fresh persistence path (which surfaces persist failures via `ensure_agent_persisted`) still runs.
- **bind_session**: treats session_resolve_miss as \"no existing agent.\"
- **`_REDIS_WRITE_TIMEOUT`**: 0.5s → 1.0s to cover two serial awaits (`mint_guard.get` + `setex`).

## Spec-council findings — addressed vs. deferred

Per `docs/ontology/s21-fix-council-review.md`:

- **H1 anyio-asyncio**: simplified — the guard checks for a *different* `agent_uuid`, not for `status='active'`. No new `await asyncpg`. The agent-status-aware variant (proposed `agent_status` plumbing) is deferred to S21-b's evict-then-bind work.
- **H2 in-memory dict overwrite**: closed — both `_session_identities` and Redis are gated.
- **H3 no eviction of installed ghosts**: deferred — relies on Redis 24h TTL drain. Existing pollution will age out within one TTL cycle.
- **H4 `resume=True` default brick risk**: closed via middleware retry + onboard re-mint + token-bearing carve-out. External callers (dashboard, discord-bridge, HTTP scripts) that go through MCP dispatch are auto-recovered by the middleware retry. Callers that bypass dispatch and call `resolve_session_identity` directly with `resume=True` will get `resume_failed` and need to retry with `force_new=True`.
- **H5 plan-doc schema description wrong**: not addressed in this PR (doc-only fix; out of scope).
- **H6 status enum has six values**: not addressed — the simplified guard ignores status entirely (no DB call). evict-then-bind for archived/deleted agents is S21-b territory.
- **M2 rate correction**: postscript on the incident doc notes 95.1% (incident snapshot) → ~38% (audit-window-scoped) → ~20% (live verification 2026-04-27, 30-day window). Spec-council saw 92.3%; live numbers vary by window.
- **M3 archived-agent in Redis**: deferred to S21-b. The simplified guard refuses overwrite even when the existing UUID is archived; the legitimate re-bind would have to wait for TTL drain or come through `onboard()`'s auto-unarchive path.
- **M4 `require_registered_agent` honesty gap**: NOT addressed. After this PR, dogfood may still see \"Agent X is not registered\" errors when in-memory metadata diverges from `core.identities`. That's S21-b §6. Calling it out explicitly so the PR doesn't claim to close more than it does.
- **M5 NX implicitly grants cross-process continuity**: comments at `_cache_session` mint_guard sites name the principle (\"refuse PATH 3 ghost ratification over a legitimate session\").

## Test gaps from spec-council

1. **Archived-agent-in-Redis** — not added (covers a deferred behavior; S21-b).
2. **In-memory `_session_identities` overwrite** — covered by T1.
3. **Middleware + handler double-resolution** — partially covered by T4 (asserts middleware retry kwargs); full middleware↔handler interaction test deferred to S21-b's call-site consolidation.

## Diff-council pre-merge fixes (parallel pass before push)

- **dispatch retry must declare `spawn_reason`** — applied. Otherwise S21-a stops Redis bleed but no-lineage ghost rate stays high.
- **`_REDIS_WRITE_TIMEOUT` bump** — applied (0.5s → 1.0s for two serial awaits).
- **Doc rate postscript** — applied.
- **T4 spawn_reason assertion** — applied.

## Deferred to S21-b (per spec)

- TOCTOU race in mint_guard read-then-write (atomic `SET NX` / Lua).
- Double-resolve consolidation (middleware + handler both call resolve_session_identity).
- `require_registered_agent` consults `core.identities` (M4).
- Archived-agent eviction logic (H3 / M3).
- Honest `identity_resolution_outcome` field.

## Tests

`./scripts/dev/test-cache.sh --fresh`: **7720 passed, 33 skipped**, coverage 78.09%.

## Verification

- New regression tests fail before the fix (red phase verified) and pass after.
- Live verification (council pass): identity() response shape preserved; DB liveness OK; Redis schema OK; mint_guard logic correct in code-trace.
- Identity-related test suite (test_identity_*.py + test_session_cache.py + test_path28_substrate_http_reject.py): 336+ tests pass.