### PR TITLE
fix(kg): AGE backend get_discovery/update_discovery SQL fallback for SQL-only orphans

### DIFF
--- a/src/storage/knowledge_graph_age.py
+++ b/src/storage/knowledge_graph_age.py
@@ -493,9 +493,12 @@ class KnowledgeGraphAGE:
         """
         
         results = await db.graph_query(cypher, {"discovery_id": discovery_id})
-        
+
         if not results:
-            return None
+            # No AGE node — fall back to the SQL source-of-truth so SQL-only
+            # orphans (written while backend was postgres) are still readable.
+            row = await db.kg_get_discovery(discovery_id)
+            return self._dict_to_discovery(row)
 
         # Parse result (AGE returns agtype, need to convert)
         # graph_query returns parsed agtype directly
@@ -713,6 +716,34 @@ class KnowledgeGraphAGE:
 
         return parsed
 
+    def _dict_to_discovery(self, d: Optional[Dict[str, Any]]) -> Optional[DiscoveryNode]:
+        """Convert a knowledge.discoveries SQL row to DiscoveryNode."""
+        if not d:
+            return None
+        response_to = None
+        if d.get("response_to_id") and d.get("response_type"):
+            response_to = ResponseTo(
+                discovery_id=d["response_to_id"],
+                response_type=d["response_type"],
+            )
+        return DiscoveryNode(
+            id=d["id"],
+            agent_id=d["agent_id"],
+            type=d["type"],
+            summary=d["summary"],
+            details=d.get("details", ""),
+            tags=d.get("tags", []),
+            severity=d.get("severity"),
+            timestamp=d.get("timestamp", d.get("created_at", "")),
+            status=d.get("status", "open"),
+            related_to=d.get("related_to", []),
+            response_to=response_to,
+            references_files=d.get("references_files", []),
+            resolved_at=d.get("resolved_at"),
+            updated_at=d.get("updated_at"),
+            provenance=d.get("provenance"),
+        )
+
     def _node_to_discovery(self, node_data: Dict[str, Any]) -> Optional[DiscoveryNode]:
         """Convert AGE node data to DiscoveryNode."""
         if not node_data or "id" not in node_data:
@@ -764,17 +795,54 @@ class KnowledgeGraphAGE:
             provenance_chain=metadata.get("provenance_chain"),
         )
 
+    async def _sql_update_discovery(self, discovery_id: str, updates: Dict[str, Any]) -> bool:
+        """SQL UPDATE fallback for SQL-only discoveries that have no AGE node."""
+        from src.knowledge_graph import normalize_tags
+        db = await self._get_db()
+
+        set_parts: List[str] = []
+        params: List[Any] = []
+
+        for key in ("status", "severity", "type", "summary", "details", "last_referenced"):
+            if key in updates:
+                params.append(updates[key])
+                set_parts.append(f"{key} = ${len(params)}")
+
+        for key in ("resolved_at", "updated_at"):
+            if key in updates:
+                params.append(self._parse_optional_datetime(updates[key]))
+                set_parts.append(f"{key} = ${len(params)}")
+
+        if "tags" in updates:
+            tag_list = updates["tags"]
+            params.append(normalize_tags(tag_list) if isinstance(tag_list, list) else tag_list)
+            set_parts.append(f"tags = ${len(params)}")
+
+        if not set_parts:
+            return True
+
+        params.append(discovery_id)
+        result = await db._pool.fetchval(
+            f"UPDATE knowledge.discoveries SET {', '.join(set_parts)} WHERE id = ${len(params)} RETURNING id",
+            *params,
+        )
+        if result is not None and "tags" in updates:
+            async with db._pool.acquire() as conn:
+                await self._sync_discovery_tags(conn, discovery_id, updates.get("tags") or [])
+        return result is not None
+
     async def update_discovery(self, discovery_id: str, updates: Dict[str, Any]) -> bool:
         """Update discovery fields in AGE graph.
 
         Supports updating: status, resolved_at, updated_at, tags, severity, type,
         summary, details, and last_referenced.
+        Falls back to direct SQL UPDATE when the discovery has no AGE node.
         """
         db = await self._get_db()
 
         if not await db.graph_available():
-            logger.warning("AGE graph not available for update")
-            return False
+            logger.warning("AGE graph not available for update; falling back to SQL")
+            return await self._sql_update_discovery(discovery_id, updates)
 
         # Build SET clauses for Cypher
         set_parts = []
@@ -809,7 +877,8 @@ class KnowledgeGraphAGE:
             async with db.transaction() as conn:
                 result = await db.graph_query(cypher, params, conn=conn)
                 if not result or (isinstance(result[0], dict) and "error" in result[0]):
-                    return False
+                    # No AGE node — fall back to SQL for SQL-only orphans.
+                    return await self._sql_update_discovery(discovery_id, updates)
                 await self._sync_updated_discovery_row(conn, discovery_id, updates)
             if "summary" in updates or "details" in updates:
                 await self._refresh_embedding(discovery_id)

--- a/tests/test_age_sql_fallback.py
+++ b/tests/test_age_sql_fallback.py
@@ -1,0 +1,460 @@
+"""
+Unit tests for the AGE backend SQL fallback paths.
+
+Covers the regression where get_discovery and update_discovery only did
+Cypher MATCH lookups, silently returning None/False for SQL-only orphan
+discoveries (rows that exist in knowledge.discoveries but have no AGE node,
+written while UNITARES_KNOWLEDGE_BACKEND was postgres).
+
+KG bug ID: 2026-04-25T21:33:15.971499
+"""
+from __future__ import annotations
+
+import sys
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Pre-stub the mcp/pydantic import chain before loading the AGE backend.
+# src.storage.knowledge_graph_age imports src.mcp_handlers.knowledge.limits
+# which pulls in src/mcp_handlers/__init__.py → mcp.types → pydantic.RootModel.
+# On Python 3.14 + pydantic < 3.x, RootModel class creation fails with
+# "TypeError: _eval_type() got an unexpected keyword argument 'prefer_fwd_module'".
+# Stubbing at module level is safe because conftest.py does not import mcp.types.
+# ---------------------------------------------------------------------------
+_limits_stub = MagicMock()
+_limits_stub.EMBED_DETAILS_WINDOW = 200
+sys.modules.setdefault("src.mcp_handlers.knowledge.limits", _limits_stub)
+sys.modules.setdefault("src.mcp_handlers.knowledge", MagicMock())
+_mcp_types_stub = MagicMock()
+_mcp_types_stub.TextContent = MagicMock
+sys.modules.setdefault("mcp.types", _mcp_types_stub)
+sys.modules.setdefault("mcp.server", MagicMock())
+sys.modules.setdefault("mcp.server.fastmcp", MagicMock())
+_mcp_stub = MagicMock()
+_mcp_stub.types = _mcp_types_stub
+sys.modules.setdefault("mcp", _mcp_stub)
+
+# Only stub src.mcp_handlers if it has not already been imported as the real module.
+# (Avoids overwriting a partially-initialised real module that another conftest fixture
+# may have set up; our test doesn't call any handler code anyway.)
+if "src.mcp_handlers" not in sys.modules:
+    _mcp_handlers_stub = MagicMock()
+    _mcp_handlers_stub.knowledge = MagicMock()
+    sys.modules["src.mcp_handlers"] = _mcp_handlers_stub
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.storage.knowledge_graph_age import KnowledgeGraphAGE  # noqa: E402
+from src.knowledge_graph import DiscoveryNode, ResponseTo  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sql_row(
+    *,
+    discovery_id: str = "disc-sql-001",
+    agent_id: str = "agent-a",
+    type: str = "bug",
+    summary: str = "A SQL-only discovery",
+    status: str = "open",
+    severity: str = "medium",
+    tags: list | None = None,
+    created_at: str = "2026-04-24T01:03:00+00:00",
+    updated_at: str | None = None,
+    resolved_at: str | None = None,
+    response_to_id: str | None = None,
+    response_type: str | None = None,
+    references_files: list | None = None,
+    related_to: list | None = None,
+    provenance: dict | None = None,
+) -> dict:
+    return {
+        "id": discovery_id,
+        "agent_id": agent_id,
+        "type": type,
+        "summary": summary,
+        "details": "Some details",
+        "status": status,
+        "severity": severity,
+        "tags": tags or ["k8s", "regression"],
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "resolved_at": resolved_at,
+        "response_to_id": response_to_id,
+        "response_type": response_type,
+        "references_files": references_files or [],
+        "related_to": related_to or [],
+        "provenance": provenance,
+    }
+
+
+def _make_db(
+    *,
+    graph_available: bool = True,
+    graph_query_returns=None,
+    kg_get_discovery_returns=None,
+) -> MagicMock:
+    db = MagicMock()
+    db.graph_available = AsyncMock(return_value=graph_available)
+    db.graph_query = AsyncMock(return_value=graph_query_returns if graph_query_returns is not None else [])
+    db.kg_get_discovery = AsyncMock(return_value=kg_get_discovery_returns)
+
+    pool = MagicMock()
+    pool.fetchval = AsyncMock(return_value=None)
+    pool.execute = AsyncMock()
+    pool.executemany = AsyncMock()
+
+    @asynccontextmanager
+    async def fake_acquire():
+        yield pool
+
+    pool.acquire = fake_acquire
+    db._pool = pool
+
+    @asynccontextmanager
+    async def fake_transaction():
+        yield pool
+
+    db.transaction = fake_transaction
+    return db
+
+
+async def _make_kg(db: MagicMock) -> KnowledgeGraphAGE:
+    kg = KnowledgeGraphAGE()
+    kg._db = db
+
+    async def _get_db():
+        return db
+
+    kg._get_db = _get_db  # type: ignore[assignment]
+    return kg
+
+
+# ===========================================================================
+# _dict_to_discovery
+# ===========================================================================
+
+class TestDictToDiscovery:
+
+    def setup_method(self):
+        self.kg = KnowledgeGraphAGE()
+
+    def test_none_returns_none(self):
+        assert self.kg._dict_to_discovery(None) is None
+
+    def test_empty_dict_returns_none(self):
+        assert self.kg._dict_to_discovery({}) is None
+
+    def test_minimal_row(self):
+        row = _sql_row()
+        d = self.kg._dict_to_discovery(row)
+        assert d is not None
+        assert d.id == "disc-sql-001"
+        assert d.agent_id == "agent-a"
+        assert d.type == "bug"
+        assert d.summary == "A SQL-only discovery"
+        assert d.status == "open"
+        assert d.severity == "medium"
+
+    def test_tags_preserved(self):
+        row = _sql_row(tags=["perf", "db"])
+        d = self.kg._dict_to_discovery(row)
+        assert d.tags == ["perf", "db"]
+
+    def test_response_to_populated(self):
+        row = _sql_row(response_to_id="disc-parent", response_type="extend")
+        d = self.kg._dict_to_discovery(row)
+        assert d.response_to is not None
+        assert d.response_to.discovery_id == "disc-parent"
+        assert d.response_to.response_type == "extend"
+
+    def test_response_to_absent_when_no_id(self):
+        row = _sql_row(response_to_id=None, response_type="extend")
+        d = self.kg._dict_to_discovery(row)
+        assert d.response_to is None
+
+    def test_timestamps_passed_through(self):
+        row = _sql_row(
+            updated_at="2026-04-25T10:00:00+00:00",
+            resolved_at="2026-04-25T11:00:00+00:00",
+        )
+        d = self.kg._dict_to_discovery(row)
+        assert d.updated_at == "2026-04-25T10:00:00+00:00"
+        assert d.resolved_at == "2026-04-25T11:00:00+00:00"
+
+    def test_created_at_used_as_timestamp_fallback(self):
+        row = _sql_row(created_at="2026-04-24T01:03:00+00:00")
+        row.pop("timestamp", None)
+        d = self.kg._dict_to_discovery(row)
+        assert d.timestamp == "2026-04-24T01:03:00+00:00"
+
+    def test_provenance_passed_through(self):
+        prov = {"source": "claude", "session": "abc123"}
+        row = _sql_row(provenance=prov)
+        d = self.kg._dict_to_discovery(row)
+        assert d.provenance == prov
+
+
+# ===========================================================================
+# get_discovery — SQL fallback
+# ===========================================================================
+
+@pytest.mark.asyncio
+class TestGetDiscoverySQLFallback:
+
+    async def test_returns_sql_row_when_no_age_node(self):
+        """When graph_query returns [], fall back to kg_get_discovery."""
+        sql_row = _sql_row()
+        db = _make_db(graph_query_returns=[], kg_get_discovery_returns=sql_row)
+        kg = await _make_kg(db)
+
+        result = await kg.get_discovery("disc-sql-001")
+
+        db.kg_get_discovery.assert_awaited_once_with("disc-sql-001")
+        assert result is not None
+        assert result.id == "disc-sql-001"
+        assert result.type == "bug"
+
+    async def test_returns_none_when_missing_everywhere(self):
+        """No AGE node AND no SQL row → None."""
+        db = _make_db(graph_query_returns=[], kg_get_discovery_returns=None)
+        kg = await _make_kg(db)
+
+        result = await kg.get_discovery("nonexistent-id")
+
+        assert result is None
+
+    async def test_age_result_used_when_node_exists(self):
+        """When graph_query returns a node, SQL fallback is NOT called."""
+        age_node = {
+            "d": {
+                "properties": {
+                    "id": "disc-age-001",
+                    "agent_id": "agent-b",
+                    "summary": "AGE discovery",
+                    "type": "insight",
+                }
+            }
+        }
+        db = _make_db(graph_query_returns=[age_node])
+        kg = await _make_kg(db)
+
+        result = await kg.get_discovery("disc-age-001")
+
+        db.kg_get_discovery.assert_not_awaited()
+        assert result is not None
+        assert result.id == "disc-age-001"
+
+    async def test_fallback_returns_tags(self):
+        sql_row = _sql_row(tags=["timeout", "network"])
+        db = _make_db(graph_query_returns=[], kg_get_discovery_returns=sql_row)
+        kg = await _make_kg(db)
+
+        result = await kg.get_discovery("disc-sql-001")
+        assert result.tags == ["timeout", "network"]
+
+    async def test_fallback_returns_response_to(self):
+        sql_row = _sql_row(response_to_id="parent-disc", response_type="refute")
+        db = _make_db(graph_query_returns=[], kg_get_discovery_returns=sql_row)
+        kg = await _make_kg(db)
+
+        result = await kg.get_discovery("disc-sql-001")
+        assert result.response_to is not None
+        assert result.response_to.discovery_id == "parent-disc"
+        assert result.response_to.response_type == "refute"
+
+
+# ===========================================================================
+# _sql_update_discovery
+# ===========================================================================
+
+@pytest.mark.asyncio
+class TestSqlUpdateDiscovery:
+
+    async def test_status_update(self):
+        db = _make_db()
+        db._pool.fetchval = AsyncMock(return_value="disc-sql-001")
+        kg = await _make_kg(db)
+
+        ok = await kg._sql_update_discovery("disc-sql-001", {"status": "resolved"})
+
+        assert ok is True
+        db._pool.fetchval.assert_awaited_once()
+        query, *args = db._pool.fetchval.call_args[0]
+        assert "UPDATE knowledge.discoveries" in query
+        assert "status" in query
+        assert "RETURNING id" in query
+        assert "resolved" in args
+        assert "disc-sql-001" in args
+
+    async def test_returns_false_when_row_not_found(self):
+        db = _make_db()
+        db._pool.fetchval = AsyncMock(return_value=None)
+        kg = await _make_kg(db)
+
+        ok = await kg._sql_update_discovery("nonexistent", {"status": "archived"})
+        assert ok is False
+
+    async def test_empty_updates_returns_true(self):
+        db = _make_db()
+        kg = await _make_kg(db)
+
+        ok = await kg._sql_update_discovery("disc-sql-001", {})
+        assert ok is True
+        db._pool.fetchval.assert_not_awaited()
+
+    async def test_timestamp_coerced_to_datetime(self):
+        db = _make_db()
+        captured: list = []
+
+        async def record_fetchval(query, *args):
+            captured.append((query, args))
+            return "disc-sql-001"
+
+        db._pool.fetchval = AsyncMock(side_effect=record_fetchval)
+        kg = await _make_kg(db)
+
+        await kg._sql_update_discovery(
+            "disc-sql-001",
+            {"updated_at": "2026-04-25T21:33:15.971499+00:00"},
+        )
+
+        assert len(captured) == 1
+        _q, args = captured[0]
+        updated_at_arg = next(a for a in args if isinstance(a, datetime))
+        assert updated_at_arg.year == 2026
+
+    async def test_tags_sync_called_when_tags_updated(self):
+        db = _make_db()
+        db._pool.fetchval = AsyncMock(return_value="disc-sql-001")
+
+        sync_called: list = []
+
+        async def fake_sync_tags(conn, disc_id, tags):
+            sync_called.append((disc_id, tags))
+
+        kg = await _make_kg(db)
+        kg._sync_discovery_tags = fake_sync_tags  # type: ignore[assignment]
+
+        await kg._sql_update_discovery("disc-sql-001", {"tags": ["new-tag"]})
+        assert len(sync_called) == 1
+        assert sync_called[0][0] == "disc-sql-001"
+        assert "new-tag" in sync_called[0][1]
+
+    async def test_tags_sync_not_called_when_row_missing(self):
+        db = _make_db()
+        db._pool.fetchval = AsyncMock(return_value=None)
+        sync_called: list = []
+
+        async def fake_sync_tags(conn, disc_id, tags):
+            sync_called.append((disc_id, tags))
+
+        kg = await _make_kg(db)
+        kg._sync_discovery_tags = fake_sync_tags  # type: ignore[assignment]
+
+        await kg._sql_update_discovery("nonexistent", {"tags": ["t"]})
+        assert sync_called == []
+
+    async def test_multiple_fields(self):
+        db = _make_db()
+        captured: list = []
+
+        async def record_fetchval(query, *args):
+            captured.append((query, list(args)))
+            return "disc-sql-001"
+
+        db._pool.fetchval = AsyncMock(side_effect=record_fetchval)
+        kg = await _make_kg(db)
+
+        await kg._sql_update_discovery(
+            "disc-sql-001",
+            {"status": "resolved", "severity": "high", "summary": "Fixed"},
+        )
+
+        assert len(captured) == 1
+        query, args = captured[0]
+        assert "status" in query
+        assert "severity" in query
+        assert "summary" in query
+        assert "resolved" in args
+        assert "high" in args
+        assert "Fixed" in args
+
+
+# ===========================================================================
+# update_discovery — SQL fallback integration
+# ===========================================================================
+
+@pytest.mark.asyncio
+class TestUpdateDiscoverySQLFallback:
+
+    async def test_sql_fallback_when_no_age_node(self):
+        """Cypher MATCH returns [] → SQL UPDATE called."""
+        db = _make_db(graph_available=True, graph_query_returns=[])
+        db._pool.fetchval = AsyncMock(return_value="disc-sql-001")
+        kg = await _make_kg(db)
+
+        ok = await kg.update_discovery("disc-sql-001", {"status": "resolved"})
+
+        assert ok is True
+        db._pool.fetchval.assert_awaited_once()
+
+    async def test_sql_fallback_when_graph_unavailable(self):
+        """graph_available() False → directly calls SQL fallback."""
+        db = _make_db(graph_available=False)
+        db._pool.fetchval = AsyncMock(return_value="disc-sql-001")
+        kg = await _make_kg(db)
+
+        ok = await kg.update_discovery("disc-sql-001", {"status": "archived"})
+
+        assert ok is True
+        db._pool.fetchval.assert_awaited_once()
+        db.graph_query.assert_not_awaited()
+
+    async def test_returns_false_when_sql_row_also_missing(self):
+        """No AGE node AND no SQL row → False."""
+        db = _make_db(graph_available=True, graph_query_returns=[])
+        db._pool.fetchval = AsyncMock(return_value=None)
+        kg = await _make_kg(db)
+
+        ok = await kg.update_discovery("nonexistent", {"status": "archived"})
+        assert ok is False
+
+    async def test_age_path_not_sql_when_age_node_exists(self):
+        """When Cypher MATCH succeeds, SQL fallback pool.fetchval is NOT called."""
+        age_result = [{"d.id": "disc-age-001"}]
+        db = _make_db(graph_available=True, graph_query_returns=age_result)
+        db._pool.fetchval = AsyncMock(return_value=None)
+
+        sync_calls: list = []
+
+        kg = await _make_kg(db)
+
+        async def fake_sync(conn, disc_id, updates):
+            sync_calls.append(disc_id)
+
+        kg._sync_updated_discovery_row = fake_sync  # type: ignore[assignment]
+        kg._refresh_embedding = AsyncMock()  # type: ignore[assignment]
+
+        ok = await kg.update_discovery("disc-age-001", {"status": "resolved"})
+
+        assert ok is True
+        db._pool.fetchval.assert_not_awaited()
+        assert "disc-age-001" in sync_calls
+
+    async def test_empty_updates_skips_both_paths(self):
+        """No-op update returns True without DB round-trips."""
+        db = _make_db(graph_available=True)
+        kg = await _make_kg(db)
+
+        ok = await kg.update_discovery("disc-001", {})
+        assert ok is True
+        db.graph_query.assert_not_awaited()
+        db._pool.fetchval.assert_not_awaited()


### PR DESCRIPTION
## Summary

Fixes KG bug **2026-04-25T21:33:15.971499**: `knowledge(action="get"|"update"|"details")` silently fails for ~35 discoveries written to `knowledge.discoveries` while `UNITARES_KNOWLEDGE_BACKEND=postgres` (timestamp range 2026-04-24 01:03 → 2026-04-25 21:29). Those rows exist in the SQL source-of-truth but have no AGE Discovery node; the AGE backend's Cypher MATCH lookups return nothing for them, so `get_discovery` returns `None` and `update_discovery` returns `False`.

**Pre-fix verification:** UNITARES MCP server was offline (PostgreSQL not running) at the time of this session, so live re-verification of bug 2026-04-25T21:33:15.971499 was not possible. Diagnosis was confirmed via source-code inspection — `src/storage/knowledge_graph_age.py:486` and `:767` show the exact MATCH-only paths described in the bug report.

### Changes

- **`_dict_to_discovery` (new)** — Converts a `knowledge.discoveries` SQL row dict to `DiscoveryNode`, mirroring `KnowledgeGraphPostgres._dict_to_discovery`. Handles `response_to` reconstruction, provenance passthrough, and `created_at` → `timestamp` fallback.

- **`get_discovery` (patched)** — When Cypher `MATCH (d:Discovery {id: ...}) RETURN d` returns no rows, falls back to `db.kg_get_discovery(discovery_id)` and converts via `_dict_to_discovery`. Returns `None` only when neither AGE node nor SQL row exists.

- **`_sql_update_discovery` (new)** — Direct `UPDATE knowledge.discoveries SET ... WHERE id = $N RETURNING id` fallback covering all mutable fields (`status`, `severity`, `type`, `summary`, `details`, `last_referenced`, `resolved_at`, `updated_at`, `tags`). Syncs the `knowledge.discovery_tags` denorm table when tags are updated. Returns `False` if the row doesn't exist.

- **`update_discovery` (patched)** — Two fallback paths added: (1) when `graph_available()` is `False`, delegates immediately to `_sql_update_discovery` instead of returning `False`; (2) when the Cypher `MATCH ... SET ... RETURN d.id` returns no rows, delegates to `_sql_update_discovery` so SQL-only orphans can be mutated without requiring an AGE-node backfill.

### Tests

26 new unit tests in `tests/test_age_sql_fallback.py` (all passing):
- `TestDictToDiscovery` — conversion correctness for minimal rows, tags, `response_to`, timestamps, provenance
- `TestGetDiscoverySQLFallback` — fallback fires when graph empty, `None` returned when both layers miss, AGE path not bypassed when node exists
- `TestSqlUpdateDiscovery` — SQL UPDATE field mapping, timestamp coercion, tag sync lifecycle, returns-False-on-missing-row
- `TestUpdateDiscoverySQLFallback` — integration: SQL path taken on empty Cypher result and on graph unavailable; AGE path taken (not SQL) when AGE node present; no-op update skips both

## Test plan

- [ ] Run `tests/test_age_sql_fallback.py` — 26/26 pass (verified locally)
- [ ] Confirm no regressions in `tests/test_knowledge_graph_postgres_unit.py` — 6/6 pass (verified locally)
- [ ] Live smoke: `knowledge(action="get", discovery_id="<any id from 2026-04-24 01:03 to 2026-04-25 21:29>")` should return the discovery instead of null once PostgreSQL is available
- [ ] Live smoke: `knowledge(action="update", discovery_id="<sql-only id>", status="resolved")` should return success instead of false

> **Note on test environment:** The full test suite currently has a pre-existing Python 3.14 + pydantic incompatibility (`TypeError: _eval_type() got an unexpected keyword argument 'prefer_fwd_module'` in `pydantic/root_model.py`) that breaks `test-cache.sh` at `tests/integration/test_outcome_event_calibration_wiring.py` before reaching any KG tests. This failure is identical on `master` and on this branch — no new failures introduced.

https://claude.ai/code/session_01QXMkV2CNyKh9VcH4cUeT4n

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXMkV2CNyKh9VcH4cUeT4n)_