### PR TITLE
S21-a follow-up: persist spawn_reason on session_resolve_miss onboard

### DIFF
--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -1366,10 +1366,22 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
         # force_new value.
         if existing_identity.get("resume_failed"):
             if existing_identity.get("error") == "session_resolve_miss":
+                # If the caller didn't declare lineage, default the spawn
+                # reason to a legible label so the captured-fresh
+                # persistence path's ensure_agent_persisted call (~L1494)
+                # writes core.agents with a non-NULL spawn_reason. Without
+                # this fallback, every dispatch-time onboard with no prior
+                # session row lands in the no-lineage ghost population —
+                # the metric S21-a was supposed to move (council follow-up
+                # on the H4/lineage-decl gap, 2026-04-27 post-deploy
+                # canary refuted by 0 dispatch_auto_mint rows in
+                # core.agents). Caller-provided values are preserved.
+                if not _spawn_reason:
+                    _spawn_reason = "auto_onboard_no_session"
                 logger.info(
                     "[ONBOARD] No existing session for session_key=%s... "
-                    "minting fresh in-memory identity",
-                    base_session_key[:20],
+                    "minting fresh in-memory identity (spawn_reason=%s)",
+                    base_session_key[:20], _spawn_reason,
                 )
                 # Mint via persist=False + force_new=True so the captured-
                 # fresh branch below handles persistence + error surfacing

--- a/tests/test_identity_s21a.py
+++ b/tests/test_identity_s21a.py
@@ -296,3 +296,96 @@ class TestS21APath2FailClosed:
 
         assert result.get("created") is True
         assert result.get("agent_uuid")
+
+
+# ---------------------------------------------------------------------------
+# T5 — onboard session_resolve_miss must persist with non-NULL spawn_reason
+# (S21-a-followup, 2026-04-27 post-deploy canary)
+# ---------------------------------------------------------------------------
+
+class TestS21AFollowupSpawnReason:
+
+    @pytest.mark.asyncio
+    async def test_onboard_session_resolve_miss_persists_spawn_reason(self):
+        """T5: when onboard hits session_resolve_miss with no caller-provided
+        spawn_reason, the captured-fresh persistence path must write
+        core.agents with spawn_reason='auto_onboard_no_session'.
+
+        S21-a's load-bearing fix (mint_guard) prevents Redis ghost
+        ratification but did not move the no-lineage ghost-fork rate —
+        post-deploy canary on 2026-04-27 found 0 'dispatch_auto_mint' rows
+        in core.agents because the spawn_reason set on the resolve retry
+        was never plumbed to the eventual ensure_agent_persisted call.
+        Setting the OUTER `_spawn_reason` variable (consumed at
+        handlers.py:~L1497) is the actual fix.
+        """
+        from types import SimpleNamespace
+        from src.mcp_handlers.identity.handlers import handle_onboard_v2
+
+        # DB mocks: no prior session, no existing identity, then identity
+        # appears after upsert (mirrors the captured-fresh persistence flow).
+        db = AsyncMock()
+        db.init = AsyncMock()
+        db.get_session = AsyncMock(return_value=None)
+        db.find_agent_by_label = AsyncMock(return_value=None)
+        db.get_agent_label = AsyncMock(return_value=None)
+        db.update_session_activity = AsyncMock()
+        db.create_session = AsyncMock()
+        db.upsert_agent = AsyncMock()
+        db.upsert_identity = AsyncMock()
+        db.update_agent_fields = AsyncMock(return_value=True)
+        db.get_agent_thread_info = AsyncMock(return_value=None)
+        db.get_thread_nodes = AsyncMock(return_value=[])
+        db.create_or_get_thread = AsyncMock()
+        db.claim_thread_position = AsyncMock(return_value=0)
+        # ensure_agent_persisted: first lookup is None (not yet persisted),
+        # second lookup returns the upserted row.
+        db.get_identity = AsyncMock(side_effect=[
+            None,  # resolve_session_identity PG lookup
+            None,  # ensure_agent_persisted check
+            SimpleNamespace(identity_id=42, metadata={}),  # after upsert
+        ])
+        db.get_agent = AsyncMock(return_value=None)
+
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.bind = AsyncMock()
+
+        async def _get_raw():
+            r = AsyncMock()
+            r.get = AsyncMock(return_value=None)
+            r.setex = AsyncMock()
+            r.expire = AsyncMock()
+            return r
+
+        mock_server = MagicMock()
+        mock_server.agent_metadata = {}
+
+        with patch("src.mcp_handlers.identity.persistence._redis_cache", None), \
+             patch("src.cache.get_session_cache", return_value=mock_redis), \
+             patch("src.mcp_handlers.identity.handlers.get_db", return_value=db), \
+             patch("src.mcp_handlers.identity.resolution.get_db", return_value=db), \
+             patch("src.mcp_handlers.identity.persistence.get_db", return_value=db), \
+             patch("src.cache.redis_client.get_redis", new=_get_raw), \
+             patch("src.mcp_handlers.context.get_mcp_session_id", return_value=None), \
+             patch("src.mcp_handlers.context.get_context_session_key", return_value=None), \
+             patch("src.mcp_handlers.context.get_context_agent_id", return_value=None), \
+             patch("src.mcp_handlers.context.update_context_agent_id"), \
+             patch("src.mcp_handlers.shared.get_mcp_server", return_value=mock_server):
+            # client_session_id is a proof signal so S13's force_new gate
+            # does NOT fire. resume=True default → PATH 2 fail-closes →
+            # session_resolve_miss branch → captured-fresh path.
+            await handle_onboard_v2({"client_session_id": "agent-no-prior"})
+
+        # Inspect the upsert_agent calls. With the fix, the spawn_reason
+        # must be non-NULL — defaulted to "auto_onboard_no_session" when
+        # the caller didn't declare one.
+        assert db.upsert_agent.called, "upsert_agent never called — captured-fresh path didn't run"
+        call_kwargs = db.upsert_agent.call_args.kwargs
+        spawn_reason = call_kwargs.get("spawn_reason")
+        assert spawn_reason == "auto_onboard_no_session", (
+            f"expected spawn_reason='auto_onboard_no_session', got {spawn_reason!r}; "
+            f"the S21-a-followup outer-variable fix did not land. Without it, "
+            f"every session_resolve_miss-driven onboard mint persists with NULL "
+            f"spawn_reason and the no-lineage ghost-fork rate doesn't move."
+        )


### PR DESCRIPTION
**Closes the lineage-decl gap S21-a (PR #221) was supposed to address but didn't.**

Post-deploy canary on 2026-04-27 found 0 \`dispatch_auto_mint\` rows in \`core.agents\` despite \`PATH2_RESUME_MISS\` firing 27 times across 10 distinct session_keys. Root cause: the captured-fresh persistence path's \`ensure_agent_persisted\` call reads the OUTER \`_spawn_reason\` (sourced from \`arguments.spawn_reason\`), not the kwarg I passed to \`resolve_session_identity\` at the retry site. When the caller didn't declare lineage, the outer variable stayed \`None\` and \`upsert_agent\` wrote \`NULL\`.

## Change

One-site fix at \`handlers.py:1368\` (onboard \`session_resolve_miss\` branch): default \`_spawn_reason = \"auto_onboard_no_session\"\` when the caller didn't declare one. The captured-fresh path then carries the value through to the eventual PG write. Caller-provided values are preserved.

## Why not the naive \`persist=True\` approach (rejected by code-reviewer council)

- **Site 1 (middleware)** — anyio-asyncio deadlock risk. PATH 3 persist branch awaits asyncpg directly without exec-pool / wait_for / cached snapshot guard, violating CLAUDE.md \"Known Issue.\"
- **Site 2 (onboard)** — silently regresses \`test_onboard_persist_failure_returns_error\`. \`resolve(persist=True)\` swallows DB failures inside its own \`except\` (resolution.py:924) and returns memory_only, hiding the failure the test expects to surface as \`error_response\`.
- **Tool-spam write amplification** — every dispatch-time auto-mint becomes a permanent PG row.

## Council pass (parallel: dialectic-knowledge-architect + feature-dev:code-reviewer + live-verifier)

Split 1-1-1 on the original \`persist=True\` proposal:
- **Dialectic** said SHIP NOW (truth-in-claim parity, calibration corruption if deferred).
- **Code-reviewer** flagged three concrete blockers above (confidence 97/88/82) and identified that the actual gap is the OUTER \`_spawn_reason\` variable, not the kwarg.
- **Live-verifier** confirmed gap (zero \`dispatch_auto_mint\` rows ever) but flagged a separate concurrency exhaustion / metric-drift issue worth investigating independently.

This PR is the synthesis: addresses the ontology cost the conceptual reviewer named without the regressions code-reviewer flagged.

## Middleware dispatch ghost-mints

Stay memory-only ephemeral. The proper fix needs \`spawn_reason\` plumbing through \`_session_identities\` so downstream tool handlers' \`ensure_agent_persisted\` reads it. Defer to S21-b alongside the call-site consolidation work.

## Test

\`tests/test_identity_s21a.py::TestS21AFollowupSpawnReason\` adds T5 asserting that an onboard call hitting \`session_resolve_miss\` with no caller-provided spawn_reason results in \`db.upsert_agent\` being called with \`spawn_reason='auto_onboard_no_session'\`. Pre-fix the test would fail (kwarg=None). All 455 identity+dispatch tests pass.

## Environmental note

\`tests/test_epoch_registry.py::test_current_epoch_has_registry_row\` fails on master too — local DB needs \`scripts/dev/bump_epoch.py\` run after PR #220 (\`CURRENT_EPOCH 2→3\`). Not introduced here.

## Followups still on the table (not in this PR)

1. **Concurrency exhaustion** — uvicorn workers saturated on the running 4a53e65 process, \`/health/live\` returning 503 for ~5+ min before manual restart. Possibly an interaction with PR #218 (\`executor_pool\`, also today) under live load. Worth a separate investigation.
2. **Metric definition stabilization** — 30d no-lineage rate read 20% during diff-council, 93.3% on follow-up canary. Either column semantics or denominator drifted. Resolve before citing movement claims.
3. **Middleware spawn_reason plumbing** — S21-b territory.