### PR TITLE
fix(migrations): seed epoch 3 in core.epochs (021)

### DIFF
--- a/db/postgres/migrations/021_seed_epoch_3.sql
+++ b/db/postgres/migrations/021_seed_epoch_3.sql
@@ -1,0 +1,23 @@
+-- Migration 021: Seed epoch 3 in core.epochs
+--
+-- Epoch 3 was introduced 2026-04-27 (PRs #219 / #220) when the tactical
+-- calibration truth channel was broadened (task_* outcome types added,
+-- per-channel surface in API). The bump was applied to the live governance
+-- DB via scripts/dev/bump_epoch.py, but the test DB (governance_test) and
+-- any other fresh PG instance need a migration to seed the registry row —
+-- otherwise tests/test_epoch_registry.py fails on baseline.
+--
+-- Pattern mirrors migration 014_seed_epoch_2.sql.
+
+INSERT INTO core.epochs (epoch, started_at, reason, started_by)
+VALUES (
+    3,
+    '2026-04-27 03:49:24.45921-06',
+    'broadened tactical calibration truth channel — task_* added; per-channel surface in API',
+    'manual'
+)
+ON CONFLICT (epoch) DO NOTHING;
+
+INSERT INTO core.schema_migrations (version, name)
+VALUES (21, 'seed_epoch_3')
+ON CONFLICT (version) DO NOTHING;

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -106,6 +106,7 @@ async def ensure_test_database_schema() -> None:
         await _execute_sql_file(conn, "db/postgres/migrations/018_bootstrap_synthetic_state.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/019_matview_measured_only.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/020_progress_flat_telemetry.sql")
+        await _execute_sql_file(conn, "db/postgres/migrations/021_seed_epoch_3.sql")
 
         # Ensure partitioned audit tables can accept inserts for current month.
         await _execute_sql_file(conn, "db/postgres/partitions.sql")


### PR DESCRIPTION
## Why

PR #220 (epoch 2→3 bump) updated \`GovernanceConfig.CURRENT_EPOCH\` and applied the row to the live \`governance\` DB via \`scripts/dev/bump_epoch.py\`, but didn't add a migration. Any fresh PG instance — CI, worktree, new dev machine — hits:

\`\`\`
FAILED tests/test_epoch_registry.py::test_current_epoch_has_registry_row
E   assert 2 >= 3
\`\`\`

This was the master baseline failure that was blocking S21-a-followup work this morning.

## What

- New migration \`021_seed_epoch_3.sql\` mirroring \`014_seed_epoch_2.sql\` — same backfill pattern, same start_at as the live row, same reason text
- \`tests/test_db_utils.py\` applies migration 021 in test bootstrap chain
- \`ON CONFLICT (epoch) DO NOTHING\` so re-running on the live DB is a no-op

## Verification

\`\`\`
psql governance_test -f db/postgres/migrations/021_seed_epoch_3.sql  # INSERT 0 1
pytest tests/test_epoch_registry.py                                  # 2 passed
./scripts/dev/test-cache.sh --fresh                                  # 7728 passed, 33 skipped
\`\`\`