### PR TITLE
fix(db): dedupe pool-recovery destroy log via in-lock identity re-check

### DIFF
--- a/src/db/postgres_backend.py
+++ b/src/db/postgres_backend.py
@@ -110,12 +110,19 @@ class PostgresBackend(
                             f"Consider increasing DB_POSTGRES_MAX_CONN or checking for connection leaks."
                         )
                 except Exception as e:
-                    # Health check failed — acquire lock before destroying pool
-                    # to prevent race with concurrent _ensure_pool / init calls
-                    logger.warning(f"Pool health check failed, destroying pool (backend={id(self)}): {e}")
+                    # Health check failed — acquire lock, re-check pool identity,
+                    # then log+destroy. The log MUST be inside the lock + after
+                    # the identity re-check; otherwise N concurrent failing
+                    # health-check tasks all log "destroying pool" before
+                    # queueing on the lock, but only one actually destroys.
+                    # That fan-in inflates the apparent destroy count by the
+                    # concurrency factor and makes the recovery path look
+                    # deadlocked when it isn't.
+                    failed_pool = self._pool
                     async with self._init_lock:
                         # Only destroy if still the same pool (another task may have already replaced it)
-                        if self._pool is not None:
+                        if self._pool is not None and self._pool is failed_pool:
+                            logger.warning(f"Pool health check failed, destroying pool (backend={id(self)}): {e}")
                             try:
                                 await self._pool.close()
                             except Exception:

--- a/tests/test_postgres_pool_guard.py
+++ b/tests/test_postgres_pool_guard.py
@@ -125,6 +125,71 @@ class TestPoolRecovery:
         assert result._raw_pool is mock_pool
         assert backend._pool is result
 
+    @pytest.mark.asyncio
+    async def test_concurrent_failing_health_checks_log_destroy_once(self, caplog):
+        """N concurrent failing health checks must produce ONE destroy log,
+        not N. The log must fire inside the lock + after a pool-identity
+        re-check, otherwise log fan-in misrepresents the destroy count by
+        the concurrency factor (observed 2026-04-27 as 1158:23 ratio).
+        """
+        import logging
+        from src.db.postgres_backend import PostgresBackend
+
+        backend = PostgresBackend()
+
+        # Mock pool whose health-check acquire raises (the production trigger
+        # is asyncio.TimeoutError when all conns are checked out by slow handlers).
+        failing_pool = MagicMock()
+
+        class _FailingAcquire:
+            def __init__(self, *a, **kw):
+                pass
+
+            async def __aenter__(self):
+                raise asyncio.TimeoutError()
+
+            async def __aexit__(self, *exc):
+                return False
+
+        failing_pool.acquire = MagicMock(side_effect=lambda **kw: _FailingAcquire())
+        failing_pool.close = AsyncMock()
+        failing_pool.get_size = MagicMock(return_value=5)
+        failing_pool.get_max_size = MagicMock(return_value=25)
+
+        backend._pool = failing_pool
+        # Force the health check to fire (last_pool_check older than 60s).
+        backend._last_pool_check = 0.0
+
+        # Mock asyncpg.create_pool so the slow path can recreate without a real DB.
+        new_raw_pool = AsyncMock()
+        with caplog.at_level(logging.WARNING, logger="src.db.postgres_backend"):
+            with patch("asyncpg.create_pool", new_callable=AsyncMock, return_value=new_raw_pool):
+                # Fire 8 concurrent health-check-failing _ensure_pool calls.
+                results = await asyncio.gather(
+                    *(backend._ensure_pool() for _ in range(8)),
+                    return_exceptions=True,
+                )
+
+        # All callers must have gotten the recreated pool back.
+        for r in results:
+            assert not isinstance(r, Exception), f"unexpected exception: {r!r}"
+
+        destroy_logs = [
+            rec for rec in caplog.records
+            if "Pool health check failed, destroying pool" in rec.message
+        ]
+        # Exactly one destroy event regardless of fan-in.
+        assert len(destroy_logs) == 1, (
+            f"expected exactly 1 destroy log, got {len(destroy_logs)}: "
+            f"{[r.message for r in destroy_logs]}"
+        )
+        # close() on the failing pool happened exactly once.
+        assert failing_pool.close.await_count == 1
+        # Backend now points at the freshly-created pool.
+        from src.db.executor_pool import ExecutorPool
+        assert isinstance(backend._pool, ExecutorPool)
+        assert backend._pool._raw_pool is new_raw_pool
+
 
 # ============================================================================
 # Orphaned Connection Tests


### PR DESCRIPTION
## Summary

Recovery path in `_ensure_pool()` logged `destroying pool` *before* acquiring `_init_lock`. N concurrent failing health-check tasks each emitted the warning, then queued on the lock; the first won and recreated, the rest saw `self._pool != None` (the recreated one) and silently skipped — but their warnings already wrote.

Observed live (10h53m run, governance-mcp PID 21525):
- 1,158 `Pool health check failed, destroying pool` events
- 23 `Creating PostgreSQL connection pool` events

The 1,158:23 ratio looked like a deadlock. Council review (dialectic-knowledge-architect) flagged it could be **log fan-in**, not real destroy events.

## Change

Move the warning inside the lock + after a `self._pool is failed_pool` identity re-check, so only the task that actually destroys logs.

Adds a regression test: 8 concurrent failing health checks → exactly 1 destroy log, exactly 1 `close()` call, exactly 1 recreate.

## Why this is the cheap-diagnostic step, not the full fix

Underlying wedge (separate fix):
1. Slow tool handlers (`observe`, `leave_note`, `detect_stuck_agents`) holding all 25 connections → asyncpg pool app-exhaustion
2. Health-check `pool.acquire(timeout=5)` times out
3. Recovery path's `await self._pool.close()` may hang against a wedged executor loop, holding `_init_lock`

This patch doesn't fix the wedge. It just makes post-canary numbers honest. If the next canary still shows ~1,158 destroys, the deadlock hypothesis stands and we ship the structural fix (null-before-close + ExecutorPool idempotency). If it drops to ~23, half the apparent symptom was the log itself.

## Test plan

- [x] New test passes
- [x] 7,730 / 7,763 full suite green (test-cache.sh)
- [ ] Restart governance-mcp, re-canary 5 min, report destroy:create ratio