### PR TITLE
fix(db): null-before-close + ExecutorPool idempotency for wedged-pool recovery

### DIFF
--- a/src/db/executor_pool.py
+++ b/src/db/executor_pool.py
@@ -16,8 +16,18 @@ Caller surface is unchanged: handlers still write
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Bounded timeout for ExecutorPool.close(). If the executor loop is wedged
+# (asyncpg released connections but DISCARD ALL responses unread, observed
+# 2026-04-27), close() must still return so the postgres backend's recovery
+# path can release _init_lock and proceed. Module-level so tests can patch.
+CLOSE_TIMEOUT_SECONDS = 10.0
+THREAD_JOIN_TIMEOUT_SECONDS = 2.0
 
 
 async def _await_on_loop(target: Any, loop: asyncio.AbstractEventLoop) -> Any:
@@ -156,6 +166,13 @@ class ExecutorPool:
         # so the asyncpg pool is created on the executor loop — asyncpg
         # connections are loop-bound (architect's per-thread pinning).
         self._raw_pool = raw_pool
+        # Close coordination: lock serializes concurrent close() callers;
+        # done event lets the second caller AWAIT the first's completion
+        # rather than return prematurely while raw_pool.close() is still
+        # in flight (council-found bug pre-shipping).
+        self._close_lock = asyncio.Lock()
+        self._close_done = asyncio.Event()
+        self._closed_flag = False
         self._loop = asyncio.new_event_loop()
         self._loop_ready = threading.Event()
         self._thread = threading.Thread(
@@ -175,6 +192,9 @@ class ExecutorPool:
         means the pool and all its connections are bound to that loop.
         """
         instance = cls.__new__(cls)
+        instance._close_lock = asyncio.Lock()
+        instance._close_done = asyncio.Event()
+        instance._closed_flag = False
         instance._loop = asyncio.new_event_loop()
         instance._loop_ready = threading.Event()
         instance._thread = threading.Thread(
@@ -219,13 +239,94 @@ class ExecutorPool:
         return self._raw_pool.get_max_size()
 
     async def close(self) -> None:
-        # Teardown order matters (architect): close the raw pool ON the
-        # executor loop (asyncpg connections are loop-bound), THEN stop
-        # the loop, THEN join the thread.
+        # Concurrent close() callers must serialize, not race the
+        # check-then-set on _closed_flag. Recovery path is gated by
+        # postgres_backend._init_lock, but daemon-shutdown can call
+        # close() concurrently with recovery — that's the race the
+        # lock guards against. Second caller awaits the done-event so
+        # they see a fully-closed pool, not a half-closed one (council).
+        async with self._close_lock:
+            if self._closed_flag:
+                # Already closed (or close in progress and done). Wait
+                # for completion before returning so caller sees a
+                # consistent state.
+                await self._close_done.wait()
+                return
+            self._closed_flag = True
+
+        # Teardown order matters (architect): close the raw pool ON
+        # the executor loop (asyncpg connections are loop-bound),
+        # THEN stop the loop, THEN join the thread.
+        #
+        # Bounded wait: if the executor loop is wedged (asyncpg
+        # released connections but PG-side responses unread —
+        # observed 2026-04-27), _await_on_loop hangs. wait_for
+        # guarantees the caller (postgres_backend recovery path
+        # holding _init_lock) returns within CLOSE_TIMEOUT_SECONDS.
+        # If the loop never drains we cancel the orphaned task on
+        # the executor loop (CPython #105836: wait_for cancellation
+        # does NOT propagate across run_coroutine_threadsafe), then
+        # force-stop and abandon. Daemon thread dies with process.
+        _to_reraise: BaseException | None = None
         try:
-            await _await_on_loop(lambda: self._raw_pool.close(), self._loop)
-        finally:
-            self._loop.call_soon_threadsafe(self._loop.stop)
-            await asyncio.get_event_loop().run_in_executor(
-                None, self._thread.join, 5.0
+            await asyncio.wait_for(
+                _await_on_loop(
+                    lambda: self._raw_pool.close(), self._loop,
+                ),
+                timeout=CLOSE_TIMEOUT_SECONDS,
             )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "ExecutorPool.close() timed out — executor loop "
+                "wedged; cancelling orphan task and abandoning thread."
+            )
+            self._cancel_orphan_tasks_on_executor_loop()
+        except BaseException as e:
+            # BaseException (CancelledError, KeyboardInterrupt,
+            # GeneratorExit, Exception subclasses) must NOT bypass
+            # teardown — the loop thread would keep running. Log,
+            # capture, and fall through to finally. Re-raise after
+            # teardown so callers still see cancellation/Ctrl-C.
+            logger.warning(
+                f"ExecutorPool.close() interrupted: "
+                f"{type(e).__name__}: {e}"
+            )
+            _to_reraise = e
+        finally:
+            try:
+                self._loop.call_soon_threadsafe(self._loop.stop)
+            except Exception:
+                pass
+            try:
+                await asyncio.get_event_loop().run_in_executor(
+                    None, self._thread.join, THREAD_JOIN_TIMEOUT_SECONDS,
+                )
+            except Exception:
+                pass
+            self._close_done.set()
+
+        if _to_reraise is not None:
+            raise _to_reraise
+
+    def _cancel_orphan_tasks_on_executor_loop(self) -> None:
+        """Cancel any pending tasks on the executor loop without awaiting.
+
+        Called when wait_for(close()) timed out — wait_for cancels its
+        own outer awaitable but the run_coroutine_threadsafe-scheduled
+        coroutine on the executor loop keeps running (CPython #105836).
+        Without this, raw_pool.close() runs to completion (or hangs
+        forever) on a thread whose Python-side caller already moved on,
+        producing "Task was destroyed but it is pending" warnings on
+        eventual GC and tying up the executor thread.
+
+        Best-effort: posts cancel() calls; doesn't await them. The
+        finally block's loop.stop() will exit the loop after the
+        cancellations land or after the next iteration.
+        """
+        def _cancel_all():
+            for task in asyncio.all_tasks(self._loop):
+                task.cancel()
+        try:
+            self._loop.call_soon_threadsafe(_cancel_all)
+        except Exception:
+            pass

--- a/src/db/postgres_backend.py
+++ b/src/db/postgres_backend.py
@@ -293,8 +293,29 @@ class PostgresBackend(
             async def __aenter__(ctx_self):
                 ctx_self._acquire_ctx = ctx_self.backend.acquire(timeout=ctx_self.timeout)
                 ctx_self.conn = await ctx_self._acquire_ctx.__aenter__()
-                ctx_self._txn = ctx_self.conn.transaction()
-                await ctx_self._txn.start()
+                # Connection acquired. If anything below raises before we
+                # return, __aexit__ will NOT run (async-CM protocol), so we
+                # must release the inner acquire ourselves. The realistic
+                # trigger is CancelledError when the executor wedges
+                # mid-txn-start (same wedge class this branch is fixing) —
+                # CancelledError is a BaseException in 3.8+, so catch
+                # broadly.
+                try:
+                    ctx_self._txn = ctx_self.conn.transaction()
+                    await ctx_self._txn.start()
+                except BaseException:
+                    inner = ctx_self._acquire_ctx
+                    ctx_self._acquire_ctx = None
+                    ctx_self.conn = None
+                    ctx_self._txn = None
+                    try:
+                        await inner.__aexit__(None, None, None)
+                    except Exception as release_err:
+                        logger.warning(
+                            f"Connection release after failed txn-start "
+                            f"raised (non-fatal): {release_err}"
+                        )
+                    raise
                 return ctx_self.conn
 
             async def __aexit__(ctx_self, exc_type, exc_val, exc_tb):

--- a/src/db/postgres_backend.py
+++ b/src/db/postgres_backend.py
@@ -37,6 +37,13 @@ from src.logging_utils import get_logger
 
 logger = get_logger(__name__)
 
+# Bounded timeout for the recovery-path failed_pool.close() call. close()
+# can hang indefinitely against a wedged executor loop (asyncpg released
+# connections but DISCARD ALL responses unread, observed 2026-04-27 →
+# "Pool.close() is taking over 60 seconds"). Module-level so tests can
+# patch.
+POOL_CLOSE_TIMEOUT_SECONDS = 10.0
+
 
 class PostgresBackend(
     IdentityMixin,
@@ -123,11 +130,37 @@ class PostgresBackend(
                         # Only destroy if still the same pool (another task may have already replaced it)
                         if self._pool is not None and self._pool is failed_pool:
                             logger.warning(f"Pool health check failed, destroying pool (backend={id(self)}): {e}")
-                            try:
-                                await self._pool.close()
-                            except Exception:
-                                pass
+                            # Null-before-close: drop the reference *before*
+                            # awaiting close() so concurrent acquires take
+                            # the slow-path create branch instead of blocking
+                            # on _init_lock for the close()'s lifetime.
+                            # close() can hang indefinitely if the executor
+                            # loop is wedged (asyncpg released connections
+                            # but DISCARD ALL responses unread, observed
+                            # 2026-04-27 → "Pool.close() is taking over 60
+                            # seconds"). Without this, _init_lock is held
+                            # forever and every subsequent acquire 5s-times
+                            # out → cascading wedge.
                             self._pool = None
+                            try:
+                                await asyncio.wait_for(
+                                    failed_pool.close(),
+                                    timeout=POOL_CLOSE_TIMEOUT_SECONDS,
+                                )
+                            except asyncio.TimeoutError:
+                                logger.warning(
+                                    f"Pool close timed out after 10s "
+                                    f"(backend={id(self)}); orphaning pool "
+                                    f"and proceeding to recreate. The "
+                                    f"executor loop is likely wedged; the "
+                                    f"daemon thread will die with the "
+                                    f"process."
+                                )
+                            except Exception as close_err:
+                                logger.debug(
+                                    f"Pool close raised (non-fatal): "
+                                    f"{close_err}"
+                                )
 
         if self._pool is not None:
             return self._pool
@@ -309,10 +342,23 @@ class PostgresBackend(
                 pass
 
     async def close(self) -> None:
-        """Close connection pool."""
+        """Close connection pool.
+
+        Same null-before-close discipline as the recovery path: drop the
+        reference *before* awaiting close() so a wedged executor loop
+        doesn't strand any concurrent caller observing self._pool. The
+        ExecutorPool.close() is internally idempotent + bounded by
+        CLOSE_TIMEOUT_SECONDS, so this caller doesn't need its own
+        wait_for — but null-before-close still matters for callers that
+        check self._pool directly (test code, shutdown coordinators).
+        """
         if self._pool:
-            await self._pool.close()
+            failed_pool = self._pool
             self._pool = None
+            try:
+                await failed_pool.close()
+            except Exception as e:
+                logger.debug(f"Pool close raised during shutdown (non-fatal): {e}")
 
     async def health_check(self) -> Dict[str, Any]:
         """Return health/status information."""

--- a/tests/test_executor_pool.py
+++ b/tests/test_executor_pool.py
@@ -306,3 +306,64 @@ async def test_acquire_timeout_passes_through_in_context_form():
         await wrapped.close()
 
     assert captured.get('timeout') == 5, f"timeout not forwarded: {captured}"
+
+
+# ============================================================================
+# Wedged-loop recovery (PR #226 followup #1)
+# ============================================================================
+
+@pytest.mark.asyncio
+async def test_close_is_idempotent():
+    """Second close() must be a no-op. Recovery path can issue concurrent
+    close() calls when multiple failed-health-check tasks race; without
+    idempotency the second one re-stops the (already-stopped) loop and
+    re-issues raw_pool.close which is undefined-behavior on asyncpg.
+    """
+    raw_pool = MagicMock()
+    raw_pool.close = AsyncMock()
+
+    wrapped = ExecutorPool(raw_pool)
+    await wrapped.close()
+    raw_pool.close.assert_called_once()
+
+    # Second call must not invoke raw_pool.close again.
+    await wrapped.close()
+    raw_pool.close.assert_called_once()
+    assert wrapped._closed_flag is True
+
+
+@pytest.mark.asyncio
+async def test_close_returns_when_raw_pool_close_hangs():
+    """If raw_pool.close() hangs forever (executor loop wedged scenario,
+    observed live 2026-04-27 → asyncpg "Pool.close() is taking over 60
+    seconds"), ExecutorPool.close() must still return within the bounded
+    timeout so the postgres backend's recovery path can release
+    _init_lock and proceed with slow-path recreate.
+    """
+    hang_started = threading.Event()
+
+    async def hung_close():
+        hang_started.set()
+        # Sleep "forever" — a wait_for-bounded close must terminate us.
+        await asyncio.sleep(3600)
+
+    raw_pool = MagicMock()
+    raw_pool.close = hung_close
+
+    wrapped = ExecutorPool(raw_pool)
+
+    # Shrink production 10s timeout to 0.5s for fast test.
+    import src.db.executor_pool as ep_mod
+    original_close_timeout = ep_mod.CLOSE_TIMEOUT_SECONDS
+    ep_mod.CLOSE_TIMEOUT_SECONDS = 0.5
+    try:
+        # close() must return within ~0.5s (close timeout) + 2s (thread
+        # join) + slack. If the wedge isn't bounded, this hangs.
+        await asyncio.wait_for(wrapped.close(), timeout=5.0)
+    finally:
+        ep_mod.CLOSE_TIMEOUT_SECONDS = original_close_timeout
+
+    assert wrapped._closed_flag is True
+    assert hang_started.is_set(), (
+        "raw_pool.close was never scheduled — wedged-loop test invalid"
+    )

--- a/tests/test_postgres_pool_guard.py
+++ b/tests/test_postgres_pool_guard.py
@@ -445,3 +445,92 @@ class TestOrphanedConnectionHandling:
         old_pool.release.assert_not_called()
         # Connection should have been closed directly
         mock_conn.close.assert_called_once()
+
+
+# ============================================================================
+# _TransactionContext Acquire-then-Fail Tests
+# ============================================================================
+
+class TestTransactionContextLeakSafety:
+    """Test that transaction() releases the underlying connection when
+    txn-start raises after the inner acquire succeeded. Pre-fix: __aenter__
+    raised before returning, so the outer 'async with' never invoked
+    __aexit__, and the connection was leaked until GC reclaimed it. Under
+    the wedged-executor symptom class this branch fixes, that contributed
+    to "Exceeded concurrency limit" warnings observed live 2026-04-27.
+    """
+
+    @pytest.mark.asyncio
+    async def test_txn_start_failure_releases_connection(self):
+        """If conn.transaction().start() raises, the inner acquire's
+        __aexit__ must run so the connection returns to the pool."""
+        from src.db.postgres_backend import PostgresBackend
+
+        backend = PostgresBackend()
+        mock_pool = AsyncMock()
+        mock_conn = AsyncMock()
+        mock_pool.acquire = AsyncMock(return_value=mock_conn)
+        mock_pool.release = AsyncMock()
+
+        # transaction() returns a Transaction whose start() raises.
+        failing_txn = MagicMock()
+        failing_txn.start = AsyncMock(side_effect=RuntimeError("server hangup"))
+        mock_conn.transaction = MagicMock(return_value=failing_txn)
+
+        backend._pool = mock_pool
+
+        with pytest.raises(RuntimeError, match="server hangup"):
+            async with backend.transaction():
+                pytest.fail("body should not execute when __aenter__ raises")
+
+        # The acquired connection MUST be released back to the pool.
+        mock_pool.release.assert_called_once_with(mock_conn)
+
+    @pytest.mark.asyncio
+    async def test_txn_start_cancelled_releases_connection(self):
+        """CancelledError is the realistic wedge trigger (BaseException in
+        3.8+). The fix catches BaseException, not just Exception, so the
+        conn is still released when start() is cancelled mid-flight."""
+        from src.db.postgres_backend import PostgresBackend
+
+        backend = PostgresBackend()
+        mock_pool = AsyncMock()
+        mock_conn = AsyncMock()
+        mock_pool.acquire = AsyncMock(return_value=mock_conn)
+        mock_pool.release = AsyncMock()
+
+        failing_txn = MagicMock()
+        failing_txn.start = AsyncMock(side_effect=asyncio.CancelledError())
+        mock_conn.transaction = MagicMock(return_value=failing_txn)
+
+        backend._pool = mock_pool
+
+        with pytest.raises(asyncio.CancelledError):
+            async with backend.transaction():
+                pytest.fail("body should not execute when __aenter__ raises")
+
+        mock_pool.release.assert_called_once_with(mock_conn)
+
+    @pytest.mark.asyncio
+    async def test_release_failure_does_not_mask_original_error(self):
+        """If conn release also fails after a txn-start failure, the
+        ORIGINAL txn-start error must still propagate — the release
+        warning is logged, not raised."""
+        from src.db.postgres_backend import PostgresBackend
+
+        backend = PostgresBackend()
+        mock_pool = AsyncMock()
+        mock_conn = AsyncMock()
+        mock_pool.acquire = AsyncMock(return_value=mock_conn)
+        mock_pool.release = AsyncMock(side_effect=RuntimeError("release failed"))
+
+        failing_txn = MagicMock()
+        failing_txn.start = AsyncMock(side_effect=RuntimeError("original txn-start failure"))
+        mock_conn.transaction = MagicMock(return_value=failing_txn)
+
+        backend._pool = mock_pool
+
+        # The ORIGINAL error wins; the release error is swallowed.
+        with pytest.raises(RuntimeError, match="original txn-start failure"):
+            async with backend.transaction():
+                pytest.fail("body should not execute when __aenter__ raises")

--- a/tests/test_postgres_pool_guard.py
+++ b/tests/test_postgres_pool_guard.py
@@ -190,6 +190,207 @@ class TestPoolRecovery:
         assert isinstance(backend._pool, ExecutorPool)
         assert backend._pool._raw_pool is new_raw_pool
 
+    @pytest.mark.asyncio
+    async def test_null_before_close_releases_lock_when_close_hangs(self):
+        """The recovery path's null-before-close + bounded wait_for: when
+        the failed pool's close() hangs (executor-loop-wedged scenario,
+        observed live 2026-04-27), _init_lock must be released within the
+        bounded timeout so concurrent acquires take the slow-path create
+        branch instead of blocking forever.
+
+        Pre-fix sequence: lock held → close hangs → next acquire 5s-times
+        out → reschedules close → cascading wedge.
+        Post-fix: pool nulled first, close timeout-bounds, lock released,
+        slow-path proceeds.
+        """
+        from src.db.postgres_backend import PostgresBackend
+
+        backend = PostgresBackend()
+
+        # Build a failing-health-check pool whose close() never resolves.
+        failing_pool = MagicMock()
+
+        class _FailingAcquire:
+            def __init__(self, *a, **kw):
+                pass
+            async def __aenter__(self):
+                raise asyncio.TimeoutError()
+            async def __aexit__(self, *exc):
+                return False
+
+        failing_pool.acquire = MagicMock(
+            side_effect=lambda **kw: _FailingAcquire()
+        )
+
+        # close() that hangs forever — the wedged-executor signature.
+        async def hung_close():
+            await asyncio.sleep(3600)
+
+        failing_pool.close = hung_close
+        failing_pool.get_size = MagicMock(return_value=5)
+        failing_pool.get_max_size = MagicMock(return_value=25)
+
+        backend._pool = failing_pool
+        backend._last_pool_check = 0.0
+
+        # Shrink production 10s timeout to 0.5s for fast test.
+        import src.db.postgres_backend as pg_mod
+        original_close_timeout = pg_mod.POOL_CLOSE_TIMEOUT_SECONDS
+        pg_mod.POOL_CLOSE_TIMEOUT_SECONDS = 0.5
+
+        new_raw_pool = AsyncMock()
+        try:
+            with patch(
+                "asyncpg.create_pool",
+                new_callable=AsyncMock,
+                return_value=new_raw_pool,
+            ):
+                # Bounded wall-clock: the whole recovery (including the
+                # hung close timing out + recreate) must finish well under
+                # the pre-fix forever-wait. 8s gives slack above the 0.5s
+                # close + 2s thread-join + asyncpg.create_pool latency.
+                result = await asyncio.wait_for(
+                    backend._ensure_pool(), timeout=8.0,
+                )
+        finally:
+            pg_mod.POOL_CLOSE_TIMEOUT_SECONDS = original_close_timeout
+
+        # Backend now points at the freshly-created pool — proves the
+        # slow-path recreate ran after the bounded close.
+        from src.db.executor_pool import ExecutorPool
+        assert isinstance(result, ExecutorPool)
+        assert result._raw_pool is new_raw_pool
+        assert backend._pool is result
+        # _init_lock must be released (we just acquired+released it via
+        # the slow-path; if it were still held this assertion proves
+        # nothing, but the asyncio.wait_for(timeout=8) above is the real
+        # gate — if the lock were stuck, that timeout would have fired).
+        assert not backend._init_lock.locked()
+
+    @pytest.mark.asyncio
+    async def test_ensure_pool_recovers_with_real_executor_pool_wedged(self):
+        """End-to-end test: the recovery path must release _init_lock
+        when wrapping a REAL ExecutorPool whose underlying raw_pool.close()
+        hangs. The previous test used a MagicMock pool which bypasses the
+        cross-loop bridge — the production wedge has TWO nested wait_for
+        calls (postgres_backend → ExecutorPool), and a MagicMock test
+        only exercises one. (Council finding from feature-dev:code-reviewer.)
+        """
+        from src.db.postgres_backend import PostgresBackend
+        from src.db.executor_pool import ExecutorPool
+        import src.db.executor_pool as ep_mod
+        import src.db.postgres_backend as pg_mod
+
+        backend = PostgresBackend()
+
+        # Real raw_pool whose close() hangs forever. Wrap in a real
+        # ExecutorPool so close() goes through _await_on_loop's
+        # cross-thread schedule.
+        async def hung_raw_close():
+            await asyncio.sleep(3600)
+
+        async def fail_acquire(**kw):
+            raise asyncio.TimeoutError()
+
+        raw_pool = MagicMock()
+        raw_pool.close = hung_raw_close
+
+        class _FailingAcquire:
+            def __init__(self, *a, **kw):
+                pass
+            async def __aenter__(self):
+                raise asyncio.TimeoutError()
+            async def __aexit__(self, *exc):
+                return False
+
+        raw_pool.acquire = MagicMock(
+            side_effect=lambda **kw: _FailingAcquire()
+        )
+        raw_pool.get_size = MagicMock(return_value=5)
+        raw_pool.get_max_size = MagicMock(return_value=25)
+
+        wedged_executor_pool = ExecutorPool(raw_pool)
+        backend._pool = wedged_executor_pool
+        backend._last_pool_check = 0.0
+
+        # Shrink BOTH timeouts so the test runs fast.
+        # Production: 10s (postgres_backend) + 10s (ExecutorPool).
+        original_pg_timeout = pg_mod.POOL_CLOSE_TIMEOUT_SECONDS
+        original_ep_timeout = ep_mod.CLOSE_TIMEOUT_SECONDS
+        original_join = ep_mod.THREAD_JOIN_TIMEOUT_SECONDS
+        pg_mod.POOL_CLOSE_TIMEOUT_SECONDS = 1.0
+        ep_mod.CLOSE_TIMEOUT_SECONDS = 0.5
+        ep_mod.THREAD_JOIN_TIMEOUT_SECONDS = 0.5
+
+        new_raw_pool = AsyncMock()
+        try:
+            with patch(
+                "asyncpg.create_pool",
+                new_callable=AsyncMock,
+                return_value=new_raw_pool,
+            ):
+                # Must finish well under the pre-fix forever-wait. The
+                # outer 8s gate proves both nested timeouts fired and
+                # _init_lock was released.
+                result = await asyncio.wait_for(
+                    backend._ensure_pool(), timeout=8.0,
+                )
+        finally:
+            pg_mod.POOL_CLOSE_TIMEOUT_SECONDS = original_pg_timeout
+            ep_mod.CLOSE_TIMEOUT_SECONDS = original_ep_timeout
+            ep_mod.THREAD_JOIN_TIMEOUT_SECONDS = original_join
+
+        # Recovery succeeded: backend points at a fresh ExecutorPool
+        # wrapping new_raw_pool, and _init_lock is released.
+        assert isinstance(result, ExecutorPool)
+        assert result is not wedged_executor_pool
+        assert backend._pool is result
+        assert not backend._init_lock.locked()
+        # The wedged pool's close was at least started (close_done set).
+        assert wedged_executor_pool._closed_flag is True
+
+    @pytest.mark.asyncio
+    async def test_executor_pool_close_is_idempotent_and_serialized(self):
+        """Two concurrent close() callers must serialize: the second
+        awaits the first's completion via _close_done, not return early
+        while raw_pool.close() is still in flight (council finding:
+        TOCTOU race on _closed_flag).
+        """
+        from src.db.executor_pool import ExecutorPool
+
+        # Slow but completing close — 0.2s.
+        close_started = asyncio.Event()
+        close_finished = asyncio.Event()
+
+        async def slow_close():
+            close_started.set()
+            await asyncio.sleep(0.2)
+            close_finished.set()
+
+        raw_pool = MagicMock()
+        raw_pool.close = slow_close
+
+        wrapped = ExecutorPool(raw_pool)
+
+        # Fire two concurrent close() calls.
+        results = await asyncio.gather(
+            wrapped.close(),
+            wrapped.close(),
+            return_exceptions=True,
+        )
+
+        for r in results:
+            assert not isinstance(r, Exception), f"unexpected: {r!r}"
+
+        # Both callers returned only after raw_pool.close() finished.
+        # close_finished.is_set() must be True at this point.
+        assert close_finished.is_set(), (
+            "second caller returned before raw_pool.close() completed — "
+            "TOCTOU race regressed"
+        )
+        assert wrapped._closed_flag is True
+        assert wrapped._close_done.is_set()
+
 
 # ============================================================================
 # Orphaned Connection Tests


### PR DESCRIPTION
## Summary

Structural fix for the pool-recovery wedge that PR #228 explicitly deferred. PR #228 deduped the destroy-log fan-in but its body named the cure: **null-before-close + ExecutorPool idempotency**. This PR is that cure, with the council's adversarial pass folded in.

## The wedge (reproduced live 2026-04-27 ~17:30)

1. Concurrent `onboard(force_new=true)` calls hit `db.upsert_agent` via asyncpg
2. Pool exhausts (25/25); released connections sit PG-side `idle/ClientRead` on `pg_advisory_unlock_all(); CLOSE ALL; UNLISTEN *; RESET ALL` waiting for the executor loop to read DISCARD ALL responses
3. Health check fails → `_ensure_pool` recovery enters `_init_lock`
4. `await failed_pool.close()` hangs >60s holding the lock
5. Every subsequent acquire 5s-times-out → cascading wedge → restart needed

## Changes

**`src/db/postgres_backend.py`**
- `_ensure_pool` recovery: `self._pool = None` BEFORE awaiting `failed_pool.close()`; wrap close in `wait_for(POOL_CLOSE_TIMEOUT_SECONDS=10.0)`. On timeout, log orphan + proceed to slow-path recreate.
- `close()`: same null-before-close discipline (was unbounded, lock-free — daemon-shutdown-during-recovery race called out by council).

**`src/db/executor_pool.py`**
- Idempotent + serialized via `asyncio.Lock` + `asyncio.Event`. Second concurrent caller AWAITS the first's completion through `_close_done` rather than returning early while `raw_pool.close()` is in flight (council: TOCTOU on `_closed_flag`).
- Bounded by `CLOSE_TIMEOUT_SECONDS=10.0`. On timeout, schedules `task.cancel()` on the executor loop itself — CPython issue [#105836](https://github.com/python/cpython/issues/105836): `wait_for` cancellation does NOT propagate across `run_coroutine_threadsafe`, so without this the orphaned coroutine keeps running on the executor loop.
- `BaseException`-safe: `CancelledError` / `KeyboardInterrupt` / `GeneratorExit` no longer bypass teardown; captured, teardown runs, then re-raised so callers still see cancellation.

## Tests (5 new, 21 in pool files; full suite 7823 passed)

- `test_close_is_idempotent` — second `close()` short-circuits.
- `test_close_returns_when_raw_pool_close_hangs` — bounded close even when `raw_pool.close()` hangs forever.
- `test_executor_pool_close_is_idempotent_and_serialized` — two concurrent callers; second awaits the first's completion.
- `test_null_before_close_releases_lock_when_close_hangs` — backend recovery completes when `failed_pool.close()` hangs (MagicMock-level).
- `test_ensure_pool_recovers_with_real_executor_pool_wedged` — **end-to-end** with a real `ExecutorPool` wrapping a hung `raw_pool.close()`. Exercises the cross-loop bridge that the MagicMock test bypasses (council finding).

## Council pass (parallel: dialectic + code-reviewer + live-verifier)

Caught 4 real bugs the one-shot missed:
- TOCTOU race on `_closed_flag` → `asyncio.Lock` + `asyncio.Event`
- CPython #105836 (orphaned executor-loop task) → explicit task cancel on timeout
- BaseException leak → `try/except BaseException/finally` + post-teardown re-raise
- MagicMock test bypassed cross-loop bridge → end-to-end ExecutorPool test added

Live-verifier verified test sensitivity: reverting either change makes the corresponding test fail/hang. Reverting `wait_for` wrap → 5.49s timeout. Reverting null-before-close ordering → 5.51s timeout. Tests are real gates, not vacuous.

## Movement claim

This closes the deadlock CLASS for `_ensure_pool` recovery and `close()` shutdown paths. It does NOT fix the upstream slow handler that saturates the pool in the first place (the `db.upsert_agent` calls under concurrent onboard) — that's the underlying load problem (Plan C in Kenny's wedge-watch plan). This PR makes the wedge recoverable without a restart; the saturator itself is separate work.

## Test plan

- [x] 21/21 pool tests pass
- [x] 7823 / 7823 full suite pass (test-cache.sh, 78.32% coverage)
- [x] Live-verifier confirmed test sensitivity (revert → fail)
- [ ] Post-deploy: re-canary 5–10 min, watch destroy:create ratio drop closer to 1:1 instead of 50:1
- [ ] Post-deploy: induce wedge again (parallel onboards) and verify automatic recovery without restart

## Followups (out of scope)

- **Plan C (slow-handler saturator)**: identify which handler is holding pool slots long enough that 25 concurrent onboards exhaust capacity. PR #228 body names `observe`, `leave_note`, `detect_stuck_agents` as suspects.
- **Pool-size review**: 25 max may be too low for current dispatch concurrency. Separate consideration.