### PR TITLE
S21-b item 3: auth consistency (gate + dict mirror + reconciler)

### DIFF
--- a/docs/ontology/s21b-auth-consistency.md
+++ b/docs/ontology/s21b-auth-consistency.md
@@ -1,0 +1,57 @@
+# S21-b — Auth Consistency (Item 3 of the S21-b backlog)
+
+**Status:** Implementation merged. Branch `s21b/auth-consistency`. Closes H14 from the S21-a pass-2 council review (`s21-fix-council-review.md`).
+
+**Origin.** Pass-2 H14 named `require_registered_agent` consulting only the in-memory `agent_metadata` dict as an axiom-#3 violation: post-S21-a `identity()` returns the resumed UUID correctly, but two calls later the auth check rejected the same UUID as "not registered" because the dict had not been hydrated. "The system presents a partial recovery that lies about its own state."
+
+## Pre-implementation council pivot
+
+Closed-set pre-impl framing offered two options:
+
+- **(a)** DB fallback in `require_registered_agent` via `run_in_executor` with a sync client.
+- **(b)** Eager-hydrate the dict at every fresh-identity write site.
+
+Council pivoted to **(b) + status gate + reconciler** because:
+
+1. **(a) was larger than it appeared.** No sync PG client exists in this repo (`src/db/__init__.py` returns `PostgresBackend` with all methods async). (a) would have required building a new sync client + connection pool just to be callable from `run_in_executor`.
+2. **The "missing from dict" framing was the wrong magnitude.** Live-verifier ground-truth: 1 row, not 67. The actual auth-relevant surface was the **67-row `core.identities.status='active'` / `core.agents.status='archived'` inversion** that neither (a) nor (b) addresses on its own. The dict is loaded from `core.agents`; without a status gate inside the auth check, a stale-active dict entry passes auth even when identity says archived.
+3. **Dialectic opened option (c)** — collapse to a single DB-fronted source with a read-through cache owned by the auth module — as the structural fix. **Explicitly deferred** to a follow-up PR with its own council. Rationale: (c) reproduces the dual-source problem at a different boundary unless the chokepoint is a single typed `set_agent_status(uuid, status)` that updates `core.identities`, `core.agents`, and the in-memory dict atomically. That refactor touches every status-write path and warrants its own scope.
+
+## What this PR ships
+
+**Code changes:**
+
+- `src/mcp_handlers/support/agent_auth.py` — allowlist gate inside `require_registered_agent` accepting only `{active, paused, waiting_input}` (council pass-2 dialectic: blocklist is fail-open on unknown future status).
+- `src/agent_metadata_persistence.py` — two new helpers:
+  - `register_minted_agent_in_dict(agent_uuid, ...)` — eager hydrate after a fresh `core.identities` mint, no-op if already present.
+  - `mirror_status_to_dict(agent_uuid, status)` — sync a PG status update into the in-memory dict so `update_identity_status` writes don't drift the dict away.
+- `src/mcp_handlers/identity/resolution.py:902-916` — eager hydrate after PATH 3 mint.
+- `src/mcp_handlers/updates/phases.py:1039-1046` — eager hydrate in the self-healing path after `agent_storage.create_agent`.
+- `src/agent_storage.py` — three status-write sites (`update_agent`, `archive_agent`, `delete_agent`) mirror status into the dict.
+- `src/mcp_handlers/identity/handlers.py:1417-1425` — auto-unarchive path during `onboard(resume=True)` now writes both `core.agents.status='active'` AND `core.identities.status='active'`. Pre-S21-b it wrote only `core.agents`, generating the 88-row identity='archived'/agent='active' inversion class the reconciler has to clean up.
+- `scripts/ops/s21b_reconcile_status_inversion.py` — operator dry-run reconciler. `--apply` requires explicit `--only {active-to-archived|archived-to-active}` direction. Surfaces orphan identities (`core.identities` rows with no `core.agents` peer) informationally.
+
+**Tests:** 11 new (4 status-rejection + 2 status-pass-through + 1 unknown-status-rejection + 4 helper unit tests). Full suite 7740/7740.
+
+## Live-verifier ground-truth at ship time (2026-04-27)
+
+- 67 active/archived inversions; **0** in last 7 days, **0** with unexpired sessions → safe to reconcile
+- 88 archived/active; 16 deleted/archived (the latter unreconcilable here — `core.agents.status` CHECK forbids `'deleted'`)
+- 406 orphan identities (no `core.agents` peer); 1 still `status='active'` — H12 ghost class, item-4 scope
+
+## What survives for follow-up
+
+These are NOT bugs in this PR; they are deferred design rows.
+
+1. **Option (c) chokepoint refactor.** Single `set_agent_status(agent_uuid, status)` that updates `core.identities`, `core.agents`, and `agent_metadata` atomically. Today the consistency is per-callsite (every status writer must remember to mirror). The mirror helpers reduce the surface but don't remove it. Memory rule: "memory captures context, not missing guardrails" — this convention will rot unless a typed chokepoint enforces it.
+
+2. **Orphan identity archival policy.** 406 `core.identities` rows have no `core.agents` peer. 1 is still `status='active'`. Pass-2 H12 named the reconciler shape (`status='archived' WHERE parent_agent_id IS NULL AND spawn_reason IS NULL AND status='active'`). That's S21-b item 4's scope.
+
+3. **`db.update_identity_status` is still callable directly** without going through `agent_storage`. Any future caller that doesn't know about the mirror will re-poison the dict. The chokepoint refactor (#1) closes this; until then, code review on new callers must check.
+
+4. **The phases.py keying convention.** `register_minted_agent_in_dict` is called with `agent_id` at `phases.py:1044`, which in current code paths is the same string written to PG (so the dict key matches the load path). Code-reviewer pass-2 flagged this as a long-term inconsistency: if a future caller passes a UUID where the dict was keyed by label, `mirror_status_to_dict(uuid)` misses. Documented in the helper docstring; rename to `agent_key` deferred.
+
+## Methodological notes
+
+- Pre-impl council framed as (a)/(b)/(c) — closed set. Pass-2 ran adversarial framing per memory rule "Council prompts must invite adversarial bug-hunting." Found the 67-row inversion + the no-sync-client constraint that pre-impl framing missed.
+- Post-impl council found two more real bugs (handlers.py:1419 auto-unarchive + blocklist-vs-allowlist) and fixed both before commit. Pattern reproduces the S21-a lesson: closed-set prompts under-cover; adversarial second-pass finds real bugs at low cost.

--- a/scripts/ops/s21b_reconcile_status_inversion.py
+++ b/scripts/ops/s21b_reconcile_status_inversion.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Reconcile core.identities.status against core.agents.status.
+
+S21-b §4. Live-verifier observed (council pass-2, 2026-04-27):
+  - 67 rows where core.identities.status='active' AND core.agents.status='archived'
+    (auth-relevant: with S21-b §2 status-gate, identity slips through as active
+    while the dict / agents view says archived)
+  - 88 rows the other direction (identity archived, agent active)
+  - 16 deleted/archived
+
+The two sides of an inversion encode different operator decisions:
+  - identity='archived' AND agent='active' (88) — usually an old identity
+    archive that was never propagated to agents; un-archiving via "trust
+    agents" would re-open intentional archives
+  - identity='active' AND agent='archived' (67) — Vigil/operator archived
+    the agent but identity wasn't updated; archiving identity matches operator
+    intent
+
+So this script does not pick a default direction. Run with --apply requires
+an explicit --only flag.
+
+Usage:
+    python3 scripts/ops/s21b_reconcile_status_inversion.py
+        # dry run, prints breakdown + sample
+
+    python3 scripts/ops/s21b_reconcile_status_inversion.py --apply --only active-to-archived
+        # safest direction: identity='active' & agent='archived' → archive identity (67 rows)
+
+    python3 scripts/ops/s21b_reconcile_status_inversion.py --apply --only archived-to-active
+        # identity='archived' & agent='active' → activate identity (88 rows). USE WITH CARE.
+
+The 16 deleted/archived rows cannot be reconciled here — core.agents.status
+CHECK constraint forbids 'deleted'. Handle separately if needed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+
+INVERSION_QUERY = """
+SELECT i.agent_id, i.status AS identity_status, a.status AS agent_status,
+       i.created_at, a.updated_at AS agent_updated_at
+FROM core.identities i
+JOIN core.agents a ON a.id = i.agent_id
+WHERE i.status IS DISTINCT FROM a.status
+ORDER BY a.updated_at DESC NULLS LAST, i.created_at DESC
+"""
+
+# Council pass-2 (code-reviewer #3): the INNER JOIN above silently excludes
+# identities with no matching core.agents row. Those are the H12 ghost
+# identities (PATH 3 minted via upsert_identity but no create_agent call) —
+# the most operationally interesting class. Surface them informationally.
+ORPHAN_IDENTITY_QUERY = """
+SELECT i.agent_id, i.status, i.created_at, i.parent_agent_id, i.spawn_reason
+FROM core.identities i
+LEFT JOIN core.agents a ON a.id = i.agent_id
+WHERE a.id IS NULL
+ORDER BY i.created_at DESC
+"""
+
+
+def _filter(rows, only: str | None):
+    if not only:
+        return rows
+    if only == "active-to-archived":
+        return [r for r in rows if r["identity_status"] == "active" and r["agent_status"] == "archived"]
+    if only == "archived-to-active":
+        return [r for r in rows if r["identity_status"] == "archived" and r["agent_status"] == "active"]
+    raise ValueError(f"unknown --only filter: {only!r}")
+
+
+async def _run(apply: bool, only: str | None) -> int:
+    from src.db import get_db, init_db
+
+    await init_db()
+    db = get_db()
+
+    async with db.acquire() as conn:
+        rows = [dict(r) for r in await conn.fetch(INVERSION_QUERY)]
+        orphans = [dict(r) for r in await conn.fetch(ORPHAN_IDENTITY_QUERY)]
+
+    if orphans and not apply:
+        # Informational only — the apply path does not touch orphan rows.
+        # H12 archival policy is item-4 scope; this surface is for visibility.
+        active_orphans = sum(1 for o in orphans if o["status"] == "active")
+        print(f"[orphan identities] {len(orphans)} core.identities rows have no core.agents peer "
+              f"(of which {active_orphans} are status='active' — would still pass auth gate). "
+              f"Out of scope for this script's --apply; see S21-b item 4.")
+
+    rows = _filter(rows, only)
+
+    by_pair: dict[tuple[str, str], int] = {}
+    for r in rows:
+        key = (r["identity_status"], r["agent_status"])
+        by_pair[key] = by_pair.get(key, 0) + 1
+
+    print(f"Found {len(rows)} status-inverted rows.")
+    for (i_s, a_s), count in sorted(by_pair.items(), key=lambda kv: -kv[1]):
+        print(f"  identities='{i_s}' / agents='{a_s}': {count}")
+
+    if not rows:
+        return 0
+
+    if not apply:
+        print()
+        print("Dry run — re-run with --apply to write.")
+        print("Sample (first 10):")
+        for r in rows[:10]:
+            uuid_short = (r["agent_id"] or "")[:12]
+            print(f"  {uuid_short}  i={r['identity_status']}  a={r['agent_status']}  agent_updated_at={r['agent_updated_at']}")
+        return 0
+
+    written = 0
+    async with db.acquire() as conn:
+        for r in rows:
+            agent_uuid = r["agent_id"]
+            new_status = r["agent_status"]
+            await conn.execute(
+                """
+                UPDATE core.identities
+                SET status = $2, updated_at = now()
+                WHERE agent_id = $1
+                """,
+                agent_uuid, new_status,
+            )
+            written += 1
+
+    print(f"Updated {written} core.identities rows to match core.agents.status.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--apply", action="store_true", help="Write changes (default: dry run)")
+    parser.add_argument(
+        "--only",
+        choices=["active-to-archived", "archived-to-active"],
+        default=None,
+        help="Restrict to one inversion direction (required with --apply)",
+    )
+    args = parser.parse_args()
+    if args.apply and not args.only:
+        parser.error(
+            "--apply requires --only {active-to-archived|archived-to-active} "
+            "— see module docstring for which direction matches operator intent"
+        )
+    return asyncio.run(_run(apply=args.apply, only=args.only))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent_metadata_persistence.py
+++ b/src/agent_metadata_persistence.py
@@ -406,3 +406,71 @@ def get_or_create_metadata(agent_id: str, **kwargs) -> AgentMetadata:
 
 # Alias for cleaner naming (backward compatible)
 register_agent = get_or_create_metadata
+
+
+def register_minted_agent_in_dict(
+    agent_uuid: str,
+    *,
+    status: str = "active",
+    label: str | None = None,
+    public_agent_id: str | None = None,
+    structured_id: str | None = None,
+    parent_agent_id: str | None = None,
+    spawn_reason: str | None = None,
+    api_key: str = "",
+) -> bool:
+    """Hydrate `agent_metadata` immediately after a fresh `core.identities` mint.
+
+    S21-b §1: closes the H14 axiom-#3 gap where freshly-minted identities
+    were invisible to `require_registered_agent` until the next bulk reload.
+    Any path that performs `db.upsert_identity` for a new UUID should call
+    this so the auth check sees the row in the same request that created it.
+
+    Returns True if a new entry was added, False if the UUID was already
+    present (no overwrite — `_load_metadata_from_postgres_async` and
+    label-update paths own existing entries).
+
+    Keying note: pass whatever string was used as the `agent_id` in the
+    preceding `db.upsert_agent` / `db.upsert_identity` call — that string
+    becomes the `core.agents.id` PK and is what `_load_metadata_from_postgres_async`
+    will key the dict by. Most call sites pass a UUID; the phases.py
+    self-healing path may pass a label. Consistency is per-callsite, not
+    enforced here.
+    """
+    if agent_uuid in agent_metadata:
+        return False
+    now = datetime.now(timezone.utc).isoformat()
+    agent_metadata[agent_uuid] = AgentMetadata(
+        agent_id=public_agent_id or label or agent_uuid,
+        status=status,
+        created_at=now,
+        last_update=now,
+        label=label,
+        public_agent_id=public_agent_id,
+        structured_id=structured_id,
+        agent_uuid=agent_uuid,
+        parent_agent_id=parent_agent_id,
+        spawn_reason=spawn_reason,
+        api_key=api_key,
+    )
+    return True
+
+
+def mirror_status_to_dict(agent_uuid: str, status: str) -> bool:
+    """Mirror a `core.identities.status` write into the in-memory dict.
+
+    S21-b §3: `db.update_identity_status` writes only PG. Without this
+    mirror, the in-memory copy stays at the prior status and
+    `require_registered_agent` returns stale-positive (live-verifier
+    observed 67 active/archived inversions).
+
+    Returns True if the in-memory entry was updated, False if the UUID
+    is not currently in the dict (nothing to mirror — the next bulk
+    reload will pick up the PG state).
+    """
+    meta = agent_metadata.get(agent_uuid)
+    if meta is None:
+        return False
+    meta.status = status
+    meta.last_update = datetime.now(timezone.utc).isoformat()
+    return True

--- a/src/agent_storage.py
+++ b/src/agent_storage.py
@@ -300,6 +300,14 @@ async def update_agent(
     if status is not None:
         disabled_at = datetime.now(timezone.utc) if status in ("archived", "deleted") else None
         await db.update_identity_status(agent_id, status, disabled_at)
+        # S21-b §3: mirror PG status into the in-memory dict so the auth
+        # check doesn't return stale-positive (live-verifier's 67-row
+        # active/archived inversion class).
+        try:
+            from src.agent_metadata_persistence import mirror_status_to_dict
+            mirror_status_to_dict(agent_id, status)
+        except Exception as e:
+            logger.debug(f"Status mirror failed for {agent_id}: {e}")
 
     return True
 
@@ -397,6 +405,13 @@ async def archive_agent(
     if hasattr(db, "update_agent_fields"):
         await db.update_agent_fields(agent_id=agent_id, status="archived")
 
+    # S21-b §3
+    try:
+        from src.agent_metadata_persistence import mirror_status_to_dict
+        mirror_status_to_dict(agent_id, "archived")
+    except Exception as e:
+        logger.debug(f"Status mirror failed for archive {agent_id}: {e}")
+
     logger.info(f"Archived agent: {agent_id}")
     return True
 
@@ -417,6 +432,12 @@ async def delete_agent(agent_id: str) -> bool:
         status="deleted",
         disabled_at=datetime.now(timezone.utc),
     )
+    # S21-b §3
+    try:
+        from src.agent_metadata_persistence import mirror_status_to_dict
+        mirror_status_to_dict(agent_id, "deleted")
+    except Exception as e:
+        logger.debug(f"Status mirror failed for delete {agent_id}: {e}")
 
     if hasattr(db, "update_agent_fields"):
         await db.update_agent_fields(agent_id=agent_id, status="deleted")

--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -1417,6 +1417,14 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
                     try:
                         db = get_db()
                         await db.update_agent_fields(agent_uuid, status="active")
+                        # S21-b §3: also write core.identities.status. The pre-S21-b
+                        # auto-unarchive only touched core.agents, generating the
+                        # 88-row identity='archived'/agent='active' inversion class
+                        # the reconciler has to clean up. Mirror both surfaces here.
+                        try:
+                            await db.update_identity_status(agent_uuid, "active", None)
+                        except Exception as _us_err:
+                            logger.warning(f"[ONBOARD] Could not sync core.identities.status: {_us_err}")
                         try:
                             srv = get_mcp_server()
                             if agent_uuid in srv.agent_metadata:

--- a/src/mcp_handlers/identity/resolution.py
+++ b/src/mcp_handlers/identity/resolution.py
@@ -899,6 +899,23 @@ async def resolve_session_identity(
                 metadata=identity_metadata,
             )
 
+            # S21-b §1: hydrate the in-memory dict so require_registered_agent
+            # sees this UUID in the same request that minted it. Without this,
+            # the caller's next tool call gets "not registered" until the next
+            # bulk reload (axiom-#3 violation H14, council pass-2).
+            try:
+                from src.agent_metadata_persistence import register_minted_agent_in_dict
+                register_minted_agent_in_dict(
+                    agent_uuid,
+                    status="active",
+                    label=label,
+                    public_agent_id=agent_id,
+                    parent_agent_id=parent_agent_id,
+                    spawn_reason=spawn_reason,
+                )
+            except Exception as e:
+                logger.warning(f"Eager dict hydration failed for {agent_uuid[:8]}: {e}")
+
             # Create session binding
             identity = await db.get_identity(agent_uuid)
             if identity:

--- a/src/mcp_handlers/support/agent_auth.py
+++ b/src/mcp_handlers/support/agent_auth.py
@@ -329,6 +329,33 @@ def require_registered_agent(arguments: Dict[str, Any]) -> Tuple[str, Optional[T
                 display_name = getattr(meta, 'display_name', None) or getattr(meta, 'label', None)
                 label = getattr(meta, 'label', None)
 
+        # S21-b §2: gate on meta.status. update_identity_status writes only PG,
+        # so the in-memory dict can hold a stale-active row for an agent that
+        # core.identities has marked archived/deleted/disabled. Without this
+        # gate, a stale-positive caller passes auth and writes against a row
+        # that downstream lifecycle code treats as terminal — the 67-row
+        # active/archived inversion observed in council pass-2 (live-verifier).
+        #
+        # Allowlist (not blocklist) so a future status value not enumerated
+        # below fails closed instead of silently passing through (council
+        # pass-2 dialectic finding #1: blocklist is fail-open on unknown).
+        if agent_found and actual_uuid in mcp_server.agent_metadata:
+            agent_status = getattr(
+                mcp_server.agent_metadata[actual_uuid], "status", "active"
+            )
+            if agent_status not in ("active", "paused", "waiting_input"):
+                # Map to the inferer's keyword so error_code lands in the
+                # right category (AGENT_ARCHIVED / AGENT_DELETED / etc.).
+                return None, error_response(
+                    f"Agent '{agent_id}' is {agent_status} and cannot accept calls.",
+                    recovery={
+                        "error_type": f"agent_{agent_status}",
+                        "agent_status": agent_status,
+                        "action": "Onboard a fresh identity with parent_agent_id set to this UUID to declare lineage.",
+                        "related_tools": ["onboard"],
+                    },
+                )
+
         if not agent_found:
             from .naming_helpers import (
                 detect_interface_context,

--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -1036,6 +1036,14 @@ async def execute_post_update_effects(ctx: UpdateContext) -> None:
                 api_key=ctx.api_key or "",
                 status='active',
             )
+            # S21-b §1: hydrate dict so require_registered_agent sees the new
+            # row immediately (axiom-#3 H14). Self-healing path: this branch
+            # fires when record_agent_state finds no PG row for this agent_id.
+            try:
+                from src.agent_metadata_persistence import register_minted_agent_in_dict
+                register_minted_agent_in_dict(agent_id, status='active')
+            except Exception as hyd_err:
+                logger.debug(f"Phase eager hydration failed for {agent_id}: {hyd_err}")
             await agent_storage.record_agent_state(
                 agent_id=agent_id,
                 E=ctx.metrics_dict.get('E', 0.7),

--- a/tests/test_agent_metadata.py
+++ b/tests/test_agent_metadata.py
@@ -288,3 +288,80 @@ class TestAddRecentUpdate:
         assert len(meta.recent_update_timestamps) == len(meta.recent_decisions)
         for ts, decision in zip(meta.recent_update_timestamps, meta.recent_decisions):
             assert ts.replace("t", "") == decision.replace("a", "")
+
+
+# ============================================================================
+# S21-b §1 / §3: register_minted_agent_in_dict + mirror_status_to_dict
+# ============================================================================
+# These helpers close the H14 axiom-#3 gap surfaced by S21-a council pass-2.
+# Without them, freshly-minted core.identities rows are invisible to
+# require_registered_agent, and update_identity_status writes silently drift
+# the dict away from PG (live-verifier observed 67 active/archived inversions).
+
+
+class TestRegisterMintedAgentInDict:
+    def setup_method(self):
+        from src.agent_metadata_model import agent_metadata
+        agent_metadata.clear()
+
+    def test_inserts_new_entry(self):
+        from src.agent_metadata_persistence import register_minted_agent_in_dict
+        from src.agent_metadata_model import agent_metadata
+        uid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+        added = register_minted_agent_in_dict(
+            uid,
+            label="claude_desktop-claude_aaaaaaaa",
+            public_agent_id="claude_desktop-claude-2026-04-27",
+            parent_agent_id="bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+            spawn_reason="dispatch_auto_mint",
+        )
+        assert added is True
+        assert uid in agent_metadata
+        meta = agent_metadata[uid]
+        assert meta.status == "active"
+        assert meta.label == "claude_desktop-claude_aaaaaaaa"
+        assert meta.public_agent_id == "claude_desktop-claude-2026-04-27"
+        assert meta.spawn_reason == "dispatch_auto_mint"
+        assert meta.parent_agent_id == "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+        assert meta.agent_uuid == uid
+
+    def test_does_not_clobber_existing(self):
+        # Existing entry (e.g., from bulk reload) wins. Mint helper is for
+        # the no-entry case only.
+        from src.agent_metadata_persistence import register_minted_agent_in_dict
+        from src.agent_metadata_model import agent_metadata, AgentMetadata
+        uid = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+        agent_metadata[uid] = AgentMetadata(
+            agent_id="prior", status="paused", created_at="2026-01-01",
+            last_update="2026-01-01", label="prior_label",
+        )
+        added = register_minted_agent_in_dict(
+            uid, label="overwrite_attempt", status="active",
+        )
+        assert added is False
+        # Existing meta unchanged.
+        assert agent_metadata[uid].label == "prior_label"
+        assert agent_metadata[uid].status == "paused"
+
+
+class TestMirrorStatusToDict:
+    def setup_method(self):
+        from src.agent_metadata_model import agent_metadata
+        agent_metadata.clear()
+
+    def test_updates_existing(self):
+        from src.agent_metadata_persistence import mirror_status_to_dict
+        from src.agent_metadata_model import agent_metadata, AgentMetadata
+        uid = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+        agent_metadata[uid] = AgentMetadata(
+            agent_id="X", status="active", created_at="2026-01-01",
+            last_update="2026-01-01",
+        )
+        ok = mirror_status_to_dict(uid, "archived")
+        assert ok is True
+        assert agent_metadata[uid].status == "archived"
+
+    def test_returns_false_when_missing(self):
+        from src.agent_metadata_persistence import mirror_status_to_dict
+        ok = mirror_status_to_dict("ffffffff-ffff-4fff-8fff-ffffffffffff", "deleted")
+        assert ok is False

--- a/tests/test_mcp_utils.py
+++ b/tests/test_mcp_utils.py
@@ -655,6 +655,128 @@ class TestRequireRegisteredAgent:
         u, e = require_registered_agent({"agent_id": "Bot"})
         assert u == "real-uuid" and e is None
 
+    # --- S21-b §3 status-check (council pass-2 stale-positive class) ---
+    # `update_identity_status` writes only PG, so the in-memory dict drifts
+    # (live-verifier observed 67 active/archived inversions). The auth check
+    # must gate on meta.status to refuse rows whose dict copy is stale-active.
+
+    @patch("src.mcp_handlers.validators.validate_agent_id_reserved_names",
+           return_value=("11111111-1111-4111-8111-111111111111", None))
+    @patch("src.mcp_handlers.validators.validate_agent_id_format",
+           return_value=("11111111-1111-4111-8111-111111111111", None))
+    @patch("src.mcp_handlers.context.get_context_agent_id", return_value=None)
+    @patch("src.mcp_handlers.shared.get_mcp_server")
+    def test_archived_agent_rejected(self, ms, mc, mf, mr):
+        uid = "11111111-1111-4111-8111-111111111111"
+        s = _mock_server({uid: _meta(status="archived", label="Old")})
+        s.ensure_metadata_loaded = MagicMock()
+        ms.return_value = s
+        with patch("src.mcp_handlers.support.agent_auth.compute_agent_signature",
+                   return_value={"uuid": None}):
+            u, e = require_registered_agent({"agent_id": uid})
+        assert u is None
+        err = _parse_tc(e)["error"]
+        assert "archived" in err.lower()
+
+    @patch("src.mcp_handlers.validators.validate_agent_id_reserved_names",
+           return_value=("22222222-2222-4222-8222-222222222222", None))
+    @patch("src.mcp_handlers.validators.validate_agent_id_format",
+           return_value=("22222222-2222-4222-8222-222222222222", None))
+    @patch("src.mcp_handlers.context.get_context_agent_id", return_value=None)
+    @patch("src.mcp_handlers.shared.get_mcp_server")
+    def test_deleted_agent_rejected(self, ms, mc, mf, mr):
+        uid = "22222222-2222-4222-8222-222222222222"
+        s = _mock_server({uid: _meta(status="deleted", label="Gone")})
+        s.ensure_metadata_loaded = MagicMock()
+        ms.return_value = s
+        with patch("src.mcp_handlers.support.agent_auth.compute_agent_signature",
+                   return_value={"uuid": None}):
+            u, e = require_registered_agent({"agent_id": uid})
+        assert u is None
+        err = _parse_tc(e)["error"]
+        assert "deleted" in err.lower()
+
+    @patch("src.mcp_handlers.validators.validate_agent_id_reserved_names",
+           return_value=("33333333-3333-4333-8333-333333333333", None))
+    @patch("src.mcp_handlers.validators.validate_agent_id_format",
+           return_value=("33333333-3333-4333-8333-333333333333", None))
+    @patch("src.mcp_handlers.context.get_context_agent_id", return_value=None)
+    @patch("src.mcp_handlers.shared.get_mcp_server")
+    def test_disabled_agent_rejected(self, ms, mc, mf, mr):
+        uid = "33333333-3333-4333-8333-333333333333"
+        s = _mock_server({uid: _meta(status="disabled", label="Off")})
+        s.ensure_metadata_loaded = MagicMock()
+        ms.return_value = s
+        with patch("src.mcp_handlers.support.agent_auth.compute_agent_signature",
+                   return_value={"uuid": None}):
+            u, e = require_registered_agent({"agent_id": uid})
+        assert u is None
+        err = _parse_tc(e)["error"]
+        assert "disabled" in err.lower()
+
+    @patch("src.mcp_handlers.validators.validate_agent_id_reserved_names",
+           return_value=("44444444-4444-4444-8444-444444444444", None))
+    @patch("src.mcp_handlers.validators.validate_agent_id_format",
+           return_value=("44444444-4444-4444-8444-444444444444", None))
+    @patch("src.mcp_handlers.context.get_context_agent_id", return_value=None)
+    @patch("src.mcp_handlers.shared.get_mcp_server")
+    def test_paused_agent_allowed(self, ms, mc, mf, mr):
+        # Paused is a recoverable state (council H6 — preserve binding).
+        uid = "44444444-4444-4444-8444-444444444444"
+        s = _mock_server({uid: _meta(status="paused", label="Wait")})
+        s.ensure_metadata_loaded = MagicMock()
+        ms.return_value = s
+        u, e = require_registered_agent({"agent_id": uid})
+        assert u == uid and e is None
+
+    @patch("src.mcp_handlers.validators.validate_agent_id_reserved_names",
+           return_value=("55555555-5555-4555-8555-555555555555", None))
+    @patch("src.mcp_handlers.validators.validate_agent_id_format",
+           return_value=("55555555-5555-4555-8555-555555555555", None))
+    @patch("src.mcp_handlers.context.get_context_agent_id", return_value=None)
+    @patch("src.mcp_handlers.shared.get_mcp_server")
+    def test_waiting_input_agent_allowed(self, ms, mc, mf, mr):
+        uid = "55555555-5555-4555-8555-555555555555"
+        s = _mock_server({uid: _meta(status="waiting_input", label="Q")})
+        s.ensure_metadata_loaded = MagicMock()
+        ms.return_value = s
+        u, e = require_registered_agent({"agent_id": uid})
+        assert u == uid and e is None
+
+    @patch("src.mcp_handlers.validators.validate_agent_id_reserved_names",
+           return_value=("66666666-6666-4666-8666-666666666666", None))
+    @patch("src.mcp_handlers.validators.validate_agent_id_format",
+           return_value=("66666666-6666-4666-8666-666666666666", None))
+    @patch("src.mcp_handlers.context.get_context_agent_id", return_value=None)
+    @patch("src.mcp_handlers.shared.get_mcp_server")
+    def test_unknown_status_rejected_fail_closed(self, ms, mc, mf, mr):
+        # Allowlist gate: any status outside {active,paused,waiting_input}
+        # fails closed (council pass-2 dialectic — blocklist was fail-open).
+        uid = "66666666-6666-4666-8666-666666666666"
+        s = _mock_server({uid: _meta(status="quarantined", label="Q")})
+        s.ensure_metadata_loaded = MagicMock()
+        ms.return_value = s
+        with patch("src.mcp_handlers.support.agent_auth.compute_agent_signature",
+                   return_value={"uuid": None}):
+            u, e = require_registered_agent({"agent_id": uid})
+        assert u is None
+        assert "quarantined" in _parse_tc(e)["error"].lower()
+
+    @patch("src.mcp_handlers.validators.validate_agent_id_reserved_names", return_value=("Old", None))
+    @patch("src.mcp_handlers.validators.validate_agent_id_format", return_value=("Old", None))
+    @patch("src.mcp_handlers.context.get_context_agent_id", return_value=None)
+    @patch("src.mcp_handlers.shared.get_mcp_server")
+    def test_archived_via_label_rejected(self, ms, mc, mf, mr):
+        # Same gate via label-based lookup path, not UUID.
+        s = _mock_server({"u-archived": _meta(status="archived", label="Old")})
+        s.ensure_metadata_loaded = MagicMock()
+        ms.return_value = s
+        with patch("src.mcp_handlers.support.agent_auth.compute_agent_signature",
+                   return_value={"uuid": None}):
+            u, e = require_registered_agent({"agent_id": "Old"})
+        assert u is None
+        assert "archived" in _parse_tc(e)["error"].lower()
+
 
 class TestVerifyAgentOwnership:
     @patch("src.mcp_handlers.shared.get_mcp_server")


### PR DESCRIPTION
Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.