### PR TITLE
test(kg): repair AGE get/update_discovery tests after PR #223 SQL fallback

### DIFF
--- a/tests/test_knowledge_graph_age.py
+++ b/tests/test_knowledge_graph_age.py
@@ -514,12 +514,19 @@ class TestGetDiscovery:
 
     @pytest.mark.asyncio
     async def test_returns_none_when_not_found(self):
-        """Should return None when graph_query returns empty results."""
+        """Should return None when neither AGE node nor SQL row exists.
+
+        After PR #223, get_discovery falls back to db.kg_get_discovery() when
+        the AGE MATCH returns nothing — so "not found" requires both layers
+        to be empty.
+        """
         kg, mock_db = make_kg_with_mock_db()
         mock_db.graph_query.return_value = []
+        mock_db.kg_get_discovery = AsyncMock(return_value=None)
 
         result = await kg.get_discovery("nonexistent")
         assert result is None
+        mock_db.kg_get_discovery.assert_awaited_once_with("nonexistent")
 
     @pytest.mark.asyncio
     async def test_returns_discovery_from_dict_result(self):
@@ -567,6 +574,7 @@ class TestGetDiscovery:
         """Should pass the correct discovery_id in the cypher params."""
         kg, mock_db = make_kg_with_mock_db()
         mock_db.graph_query.return_value = []
+        mock_db.kg_get_discovery = AsyncMock(return_value=None)
 
         await kg.get_discovery("test-id-123")
 
@@ -583,10 +591,15 @@ class TestGetResponseChain:
 
     @pytest.mark.asyncio
     async def test_returns_empty_when_graph_unavailable(self):
-        """Should fallback to single-node chain when graph unavailable."""
+        """Should return [] when graph unavailable and SQL has no row either.
+
+        After PR #223, the single-node fallback delegates to get_discovery,
+        which itself falls back to SQL. The chain is empty only when both
+        AGE and SQL are empty.
+        """
         kg, mock_db = make_kg_with_mock_db(graph_available=False)
-        # get_discovery will also use the same db
         mock_db.graph_query.return_value = []
+        mock_db.kg_get_discovery = AsyncMock(return_value=None)
 
         result = await kg.get_response_chain("disc-001")
         assert result == []
@@ -878,10 +891,17 @@ class TestUpdateDiscovery:
 
     @pytest.mark.asyncio
     async def test_returns_false_when_graph_unavailable(self):
-        """Should return False when graph is not available."""
+        """Should return False when graph unavailable AND SQL row is missing.
+
+        After PR #223, update_discovery falls back to _sql_update_discovery
+        when the graph is unavailable. The SQL fallback returns False iff
+        the UPDATE ... RETURNING id touches no row.
+        """
         kg, mock_db = make_kg_with_mock_db(graph_available=False)
+        mock_db._pool.fetchval = AsyncMock(return_value=None)
         result = await kg.update_discovery("disc-001", {"status": "resolved"})
         assert result is False
+        mock_db._pool.fetchval.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_updates_valid_fields(self):
@@ -929,21 +949,33 @@ class TestUpdateDiscovery:
 
     @pytest.mark.asyncio
     async def test_returns_false_on_error_result(self):
-        """Should return False when query returns error."""
+        """Should return False when AGE returns error AND SQL row is missing.
+
+        After PR #223, an AGE error result triggers SQL fallback for
+        SQL-only orphans. False is returned only when SQL also has no row.
+        """
         kg, mock_db = make_kg_with_mock_db()
         mock_db.graph_query.return_value = [{"error": "not found"}]
+        mock_db._pool.fetchval = AsyncMock(return_value=None)
 
         result = await kg.update_discovery("disc-001", {"status": "resolved"})
         assert result is False
+        mock_db._pool.fetchval.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_returns_false_on_empty_result(self):
-        """Should return False when query returns no results."""
+        """Should return False when AGE empty AND SQL row is missing.
+
+        After PR #223, an empty AGE result triggers SQL fallback. False is
+        returned only when SQL also has no row.
+        """
         kg, mock_db = make_kg_with_mock_db()
         mock_db.graph_query.return_value = []
+        mock_db._pool.fetchval = AsyncMock(return_value=None)
 
         result = await kg.update_discovery("disc-001", {"status": "resolved"})
         assert result is False
+        mock_db._pool.fetchval.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_returns_false_on_exception(self):


### PR DESCRIPTION
## Summary

PR #223 added a SQL fallback to `KnowledgeGraphAGE.get_discovery` and `update_discovery` for SQL-only orphan rows, but five tests in `tests/test_knowledge_graph_age.py` still asserted the old AGE-only contract (return `None`/`[]`/`False` as soon as Cypher returns nothing). After PR #223 landed, those five tests began failing in CI on master:

- `TestGetDiscovery::test_returns_none_when_not_found`
- `TestGetResponseChain::test_returns_empty_when_graph_unavailable`
- `TestUpdateDiscovery::test_returns_false_when_graph_unavailable`
- `TestUpdateDiscovery::test_returns_false_on_error_result`
- `TestUpdateDiscovery::test_returns_false_on_empty_result`

(plus one coroutine-leak in `test_passes_correct_cypher_and_params` from the same fallback)

This PR updates the tests to express the new contract: the empty/false sentinel is returned only when **both AGE and SQL** come up empty. Mocks now stub `kg_get_discovery -> None` and `_pool.fetchval -> None`, and assert that the SQL fallback was actually exercised.

Positive-path coverage of the SQL fallback already lives in `tests/test_age_sql_fallback.py` (26 tests added by PR #223), so this PR doesn't duplicate it — it just brings the original test file in sync.

## Test plan

- [x] `pytest tests/test_knowledge_graph_age.py` — 159 passed
- [x] `pytest tests/test_age_sql_fallback.py` — 26 passed
- [x] `./scripts/dev/test-cache.sh` — 7846 passed, 33 skipped