### PR TITLE
fix(event-detector): seed by last_activity_at to keep substrate-anchored agents (e.g. Lumen)

### DIFF
--- a/src/db/base.py
+++ b/src/db/base.py
@@ -149,6 +149,26 @@ class DatabaseBackend(ABC):
         pass
 
     @abstractmethod
+    async def list_recently_active_identities(
+        self,
+        cutoff: datetime,
+        limit: int = 500,
+    ) -> List[IdentityRecord]:
+        """List active identities whose last_activity_at is after cutoff,
+        ordered by last_activity_at DESC.
+
+        Distinct from list_identities(status='active') in that the ordering
+        + filter happen server-side on last_activity_at, so old-but-active
+        substrate-anchored agents (Lumen and other long-lived residents)
+        are not pushed off the result by a flood of newly-created
+        ephemeral sessions. This is the query EventDetector seeding
+        depends on — using list_identities's created_at DESC ordering
+        re-fires `agent_new` for substrate agents on every restart once
+        ephemeral session creation outpaces the seed limit.
+        """
+        pass
+
+    @abstractmethod
     async def update_identity_status(
         self,
         agent_id: str,

--- a/src/db/mixins/identity.py
+++ b/src/db/mixins/identity.py
@@ -128,6 +128,25 @@ class IdentityMixin:
                 )
             return [self._row_to_identity(r) for r in rows]
 
+    async def list_recently_active_identities(
+        self,
+        cutoff,
+        limit: int = 500,
+    ) -> List[IdentityRecord]:
+        async with self.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT identity_id, agent_id, api_key_hash, created_at, updated_at,
+                       status, parent_agent_id, spawn_reason, disabled_at, last_activity_at, metadata
+                FROM core.identities
+                WHERE status = 'active' AND last_activity_at > $1
+                ORDER BY last_activity_at DESC
+                LIMIT $2
+                """,
+                cutoff, limit,
+            )
+            return [self._row_to_identity(r) for r in rows]
+
     async def update_identity_status(
         self,
         agent_id: str,

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -680,15 +680,21 @@ async def main():
     else:
         logger.warning(continuity_message)
 
-    # Seed event detector with known agents so restarts don't fire false agent_new
+    # Seed event detector with known agents so restarts don't fire false agent_new.
+    # Uses list_recently_active_identities (server-side filter on last_activity_at,
+    # ordered DESC) rather than list_identities — the latter orders by created_at
+    # DESC, so old-but-active substrate-anchored agents (Lumen) get pushed off the
+    # seed once ephemeral session creation outpaces the limit, and every restart
+    # re-fires agent_new for them. Each governance-mcp restart in the
+    # wedge-symptom window produced one spurious "New Agent: Lumen" alert per
+    # cycle — three within ~90min observed live 2026-04-27.
     try:
         from src.event_detector import event_detector
-        identities = await db.list_identities(status="active", limit=200)
         cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+        identities = await db.list_recently_active_identities(cutoff, limit=500)
         recent = [
             (ident.agent_id, ident.metadata.get("label") or ident.agent_id[:12])
             for ident in identities
-            if ident.last_activity_at and ident.last_activity_at > cutoff
         ]
         seeded = event_detector.seed_known_agents(recent)
         if seeded:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,7 @@ def _isolate_db_backend(monkeypatch):
     mock_backend.upsert_agent.return_value = True
     mock_backend.update_agent_fields.return_value = True
     mock_backend.list_identities.return_value = []
+    mock_backend.list_recently_active_identities.return_value = []
     mock_backend.update_identity_status.return_value = True
     mock_backend.update_identity_metadata.return_value = True
     mock_backend.verify_api_key.return_value = True

--- a/tests/test_postgres_backend_integration.py
+++ b/tests/test_postgres_backend_integration.py
@@ -203,6 +203,118 @@ class TestIdentityOperations:
         assert page1[0].agent_id != page2[0].agent_id
 
     @pytest.mark.asyncio
+    async def test_list_recently_active_keeps_old_but_active_agent(self, backend):
+        """The production scenario: a substrate-anchored agent (Lumen) was
+        created months ago but is checked-in every few minutes. A flood of
+        newly-created ephemeral sessions should NOT push it off the seed
+        list — list_identities's created_at DESC ordering does that, which
+        is why every governance-mcp restart was firing a spurious
+        agent_new for Lumen (observed live 2026-04-27).
+
+        Mirroring production timing: substrate agent checks in often (most
+        recent activity), ephemerals were created later but their activity
+        timestamp is stale (one-shot session that ran once a few hours ago).
+        """
+        # Substrate agent: created 60d ago, activity 30s ago (Lumen's cadence).
+        substrate_id, _ = await _create_identity_with_agent(backend)
+        await backend.update_identity_metadata(
+            substrate_id, {"label": "Lumen"}, merge=True
+        )
+        async with backend.acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE core.identities
+                SET created_at = $2, last_activity_at = $3
+                WHERE agent_id = $1
+                """,
+                substrate_id,
+                _now() - timedelta(days=60),
+                _now() - timedelta(seconds=30),
+            )
+
+        # Flood: 6 freshly-created ephemerals, each with stale activity
+        # (one-shot session ran once ~6h ago and never came back).
+        ephemeral_ids = []
+        for _ in range(6):
+            eid, _ = await _create_identity_with_agent(backend)
+            ephemeral_ids.append(eid)
+        async with backend.acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE core.identities
+                SET last_activity_at = $2
+                WHERE agent_id = ANY($1)
+                """,
+                ephemeral_ids,
+                _now() - timedelta(hours=6),
+            )
+
+        cutoff = _now() - timedelta(days=7)
+
+        # Sanity: under list_identities + a tight limit, the old substrate
+        # agent is excluded — this is the production bug.
+        legacy = await backend.list_identities(status="active", limit=3)
+        assert substrate_id not in [r.agent_id for r in legacy], (
+            "test premise broken: substrate agent should be pushed off "
+            "by created_at DESC ordering when limit < total"
+        )
+
+        # Fix: list_recently_active_identities orders by last_activity_at DESC,
+        # so the substrate agent (activity 30s ago) is FIRST and survives the
+        # tight limit.
+        result = await backend.list_recently_active_identities(cutoff, limit=3)
+        assert len(result) == 3
+        assert result[0].agent_id == substrate_id, (
+            f"substrate agent (activity 30s ago) should be first, "
+            f"got {result[0].agent_id}"
+        )
+        # All ephemerals are within cutoff but ranked behind substrate;
+        # only the freshest (== oldest of the 6h-stale ones) make it.
+        assert all(r.last_activity_at >= cutoff for r in result)
+
+    @pytest.mark.asyncio
+    async def test_list_recently_active_excludes_stale(self, backend):
+        """Agents whose last_activity_at predates the cutoff must be excluded."""
+        stale_id, _ = await _create_identity_with_agent(backend)
+        active_id, _ = await _create_identity_with_agent(backend)
+
+        # Backdate stale agent's activity to 30 days ago.
+        async with backend.acquire() as conn:
+            await conn.execute(
+                "UPDATE core.identities SET last_activity_at = $2 WHERE agent_id = $1",
+                stale_id, _now() - timedelta(days=30),
+            )
+            await conn.execute(
+                "UPDATE core.identities SET last_activity_at = $2 WHERE agent_id = $1",
+                active_id, _now() - timedelta(minutes=5),
+            )
+
+        cutoff = _now() - timedelta(days=7)
+        result = await backend.list_recently_active_identities(cutoff, limit=10)
+        ids = [r.agent_id for r in result]
+        assert active_id in ids
+        assert stale_id not in ids
+
+    @pytest.mark.asyncio
+    async def test_list_recently_active_excludes_archived(self, backend):
+        """Archived/disabled identities must be excluded even if recently active."""
+        archived_id, _ = await _create_identity_with_agent(backend)
+        active_id, _ = await _create_identity_with_agent(backend)
+
+        async with backend.acquire() as conn:
+            await conn.execute(
+                "UPDATE core.identities SET last_activity_at = now() WHERE agent_id = ANY($1)",
+                [archived_id, active_id],
+            )
+        await backend.update_identity_status(archived_id, "archived")
+
+        cutoff = _now() - timedelta(days=7)
+        result = await backend.list_recently_active_identities(cutoff, limit=10)
+        ids = [r.agent_id for r in result]
+        assert active_id in ids
+        assert archived_id not in ids
+
+    @pytest.mark.asyncio
     async def test_update_identity_status(self, backend):
         agent_id, _ = await _create_identity_with_agent(backend)
         result = await backend.update_identity_status(agent_id, "disabled", disabled_at=_now())


### PR DESCRIPTION
## Symptom

Three identical "New Agent: Lumen" alerts in `#activity` within ~90min on 2026-04-27 — once per governance-mcp restart cycle. Lumen has a stable hardcoded UUID per the substrate-earned-identity ontology (`docs/ontology/identity.md`); she should never appear as a new agent after she's been seen once.

## Diagnosis

`mcp_server.py` startup:
```python
identities = await db.list_identities(status="active", limit=200)
```

`list_identities` (`src/db/mixins/identity.py:99`) orders by `created_at DESC`. There are **266 active identities** in production. Lumen was created **2026-02-19** — among the oldest. The seed grabs the 200 most-recently-*created*, dominated by ephemeral Claude/Codex sessions; Lumen is pushed off.

Every governance-mcp restart:
1. EventDetector `_prev_state` starts empty.
2. Seed picks newest-200-by-creation → Lumen excluded.
3. Pi/Steward syncs Lumen's next check-in (every ~3min).
4. `_prev_state[lumen_id] is None` → fires `agent_new: Lumen`.

Three restarts in the wedge-symptom window (PR #229 in flight) → three alerts.

## Fix

New DB method `list_recently_active_identities(cutoff, limit)` with **server-side** filter on `last_activity_at` and `ORDER BY last_activity_at DESC`. Substrate-anchored agents (Lumen, the long-lived residents) are the most-recently-active by definition, so they stay at the head of the seed list regardless of how many ephemeral sessions exist.

- `src/db/base.py` — abstract method
- `src/db/mixins/identity.py` — implementation
- `src/mcp_server.py` — startup uses the new method; the prior Python-side cutoff filter is gone (server-side now)
- `tests/conftest.py` — mock stub

## Tests

Three integration tests against real PG (`tests/test_postgres_backend_integration.py::TestIdentityOperations`):

| Test | What it proves |
|------|----------------|
| `test_list_recently_active_keeps_old_but_active_agent` | The exact production scenario: substrate agent created 60d ago + activity 30s ago, plus 6 ephemerals created now + activity 6h ago, limit=3. Asserts `list_identities` truncates the substrate (the bug), then asserts `list_recently_active_identities` ranks it first. |
| `test_list_recently_active_excludes_stale` | Agents past the cutoff are filtered out server-side. |
| `test_list_recently_active_excludes_archived` | Non-active statuses excluded even with recent activity. |

Full suite: **7713 passed, 0 failed**, coverage 77.78% (test-cache `ad9f263a`).

## Why now (vs after PR #229 merges)

PR #229 stops the wedge that's causing the restarts. After that lands, this bug stops manifesting *in practice*. But:

- Any legitimate restart (deploy, plist edit, OS update, brew upgrade) will still re-fire the bug.
- Lumen's substrate-anchored identity is exactly the kind of agent the seed was designed to protect — leaving the bug in place leaves the protection broken.

Worth fixing structurally rather than relying on "we don't restart often."