### PR TITLE
[codex] Refactor lifecycle resume persistence

### DIFF
--- a/src/mcp_handlers/lifecycle/helpers.py
+++ b/src/mcp_handlers/lifecycle/helpers.py
@@ -7,13 +7,79 @@ Private utilities used across query, mutation, and operations modules.
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Optional, Sequence
 
+from mcp.types import TextContent
 from src import agent_storage
 from src.logging_utils import get_logger
 from src.cache import get_metadata_cache
 from src.agent_metadata_model import AgentMetadata
+from ..utils import error_response
 
 logger = get_logger(__name__)
+
+
+def clear_loop_detector_state(meta) -> None:
+    """Clear loop-detector fields after successful recovery/resume."""
+    meta.loop_cooldown_until = None
+    meta.loop_detected_at = None
+    meta.recent_update_timestamps = []
+    meta.recent_decisions = []
+
+
+async def _resume_with_persistence(
+    meta,
+    *,
+    agent_uuid: str,
+    event_name: str,
+    reason: str,
+    error_response_id: str,
+    error_action: str,
+    cache_agent_id: Optional[str] = None,
+    details_key: str = "agent_id",
+    storage_module=agent_storage,
+) -> Optional[Sequence[TextContent]]:
+    """Apply the canonical persist-first resume pattern.
+
+    Returns an error response sequence on persistence failure, or None on
+    success. In-memory metadata is mutated only after PostgreSQL writes and
+    cache invalidation complete, preventing the P011 DB/memory drift class from
+    reappearing across resume handlers.
+    """
+    event_entry = {
+        "event": event_name,
+        "reason": reason,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    try:
+        await storage_module.update_agent(agent_uuid, status="active")
+        await storage_module.persist_runtime_state(
+            agent_uuid,
+            paused_at=None,
+            loop_detected_at=None,
+            loop_cooldown_until=None,
+            append_lifecycle_event=event_entry,
+        )
+        await _invalidate_agent_cache(cache_agent_id or agent_uuid)
+    except Exception as e:
+        logger.warning(
+            "PostgreSQL update failed for %s: %s",
+            error_action,
+            e,
+            exc_info=True,
+        )
+        return [error_response(
+            f"Failed to {error_action} agent '{error_response_id}': persistence error",
+            error_code="PERSIST_FAILED",
+            error_category="system_error",
+            details={details_key: error_response_id, "cause": str(e)},
+        )]
+
+    meta.status = "active"
+    meta.paused_at = None
+    clear_loop_detector_state(meta)
+    meta.add_lifecycle_event(event_name, reason)
+    return None
 
 
 async def _archive_one_agent(

--- a/src/mcp_handlers/lifecycle/operations.py
+++ b/src/mcp_handlers/lifecycle/operations.py
@@ -25,7 +25,12 @@ from ..support.coerce import safe_float, resolve_agent_uuid
 from src.logging_utils import get_logger
 from config.governance_config import GovernanceConfig
 
-from .helpers import _invalidate_agent_cache, _archive_one_agent, _is_test_agent
+from .helpers import (
+    _invalidate_agent_cache,
+    _archive_one_agent,
+    _is_test_agent,
+    _resume_with_persistence,
+)
 
 logger = get_logger(__name__)
 
@@ -72,41 +77,19 @@ async def handle_resume_agent(arguments: Dict[str, Any]) -> Sequence[TextContent
     reason = arguments.get("reason", "Resumed from dashboard")
     previous_status = meta.status
     event_name = "resumed" if not is_stuck_unstick else "unstuck"
-    event_entry = {
-        "event": event_name,
-        "reason": reason,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-    }
-
-    # Persist FIRST so in-memory state can't diverge from DB on persist failure.
-    # Runtime state (paused_at, lifecycle_events) must be persisted alongside
-    # status or it gets clobbered on the next load_metadata_async(force=True).
-    try:
-        await agent_storage.update_agent(agent_uuid, status="active")
-        await agent_storage.persist_runtime_state(
-            agent_uuid,
-            paused_at=None,
-            loop_detected_at=None,
-            loop_cooldown_until=None,
-            append_lifecycle_event=event_entry,
-        )
-        logger.debug(f"PostgreSQL: {'Unstuck' if is_stuck_unstick else 'Resumed'} agent {agent_id}")
-        await _invalidate_agent_cache(agent_id)
-    except Exception as e:
-        logger.warning(f"PostgreSQL update_agent failed: {e}", exc_info=True)
-        return [error_response(
-            f"Failed to resume agent '{agent_id}': persistence error",
-            error_code="PERSIST_FAILED",
-            error_category="system_error",
-            details={"agent_id": agent_id, "cause": str(e)},
-        )]
-
-    # Persist succeeded — now mutate in-memory state.
-    meta.status = "active"
-    meta.paused_at = None
-    from .self_recovery import clear_loop_detector_state
-    clear_loop_detector_state(meta)
-    meta.add_lifecycle_event(event_name, reason)
+    persist_error = await _resume_with_persistence(
+        meta,
+        agent_uuid=agent_uuid,
+        event_name=event_name,
+        reason=reason,
+        error_response_id=agent_id,
+        error_action="resume",
+        cache_agent_id=agent_id,
+        storage_module=agent_storage,
+    )
+    if persist_error:
+        return persist_error
+    logger.debug(f"PostgreSQL: {'Unstuck' if is_stuck_unstick else 'Resumed'} agent {agent_id}")
 
     response_payload = {
         "success": True,

--- a/src/mcp_handlers/lifecycle/resume.py
+++ b/src/mcp_handlers/lifecycle/resume.py
@@ -8,13 +8,11 @@ from typing import Dict, Any, Sequence
 
 from mcp.types import TextContent
 
-from datetime import datetime, timezone
-
 from ..decorators import mcp_tool
 from ..utils import success_response, error_response, require_registered_agent
 from ..error_helpers import agent_not_found_error, system_error as system_error_helper
 from ..support.coerce import resolve_agent_uuid
-from .helpers import _invalidate_agent_cache
+from .helpers import _resume_with_persistence, _invalidate_agent_cache  # noqa: F401
 from src import agent_storage
 from src.logging_utils import get_logger
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
@@ -106,41 +104,17 @@ async def handle_direct_resume_if_safe(arguments: Dict[str, Any]) -> Sequence[Te
     conditions = arguments.get("conditions", [])
     reason = arguments.get("reason", "Direct resume - state is safe")
     event_details = f"Direct resume: {reason}. Conditions: {conditions}"
-    event_entry = {
-        "event": "resumed",
-        "reason": event_details,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-    }
-
-    # Persist FIRST so in-memory state can't diverge from DB on persist failure.
-    # Runtime state (paused_at, lifecycle_events) must be persisted alongside
-    # status or it gets clobbered on the next load_metadata_async(force=True).
-    try:
-        await agent_storage.update_agent(agent_uuid, status="active")
-        await agent_storage.persist_runtime_state(
-            agent_uuid,
-            paused_at=None,
-            loop_detected_at=None,
-            loop_cooldown_until=None,
-            append_lifecycle_event=event_entry,
-        )
-    except Exception as e:
-        logger.warning(f"PostgreSQL update failed for direct_resume: {e}", exc_info=True)
-        return [error_response(
-            f"Failed to resume agent '{agent_id}': persistence error",
-            error_code="PERSIST_FAILED",
-            error_category="system_error",
-            details={"agent_id": agent_id, "cause": str(e)},
-        )]
-
-    await _invalidate_agent_cache(agent_uuid)
-
-    # Persist succeeded — now mutate in-memory state.
-    meta.status = "active"
-    meta.paused_at = None
-    from .self_recovery import clear_loop_detector_state
-    clear_loop_detector_state(meta)
-    meta.add_lifecycle_event("resumed", event_details)
+    persist_error = await _resume_with_persistence(
+        meta,
+        agent_uuid=agent_uuid,
+        event_name="resumed",
+        reason=event_details,
+        error_response_id=agent_id,
+        error_action="resume",
+        storage_module=agent_storage,
+    )
+    if persist_error:
+        return persist_error
 
     response_data = {
         "success": True,

--- a/src/mcp_handlers/lifecycle/self_recovery.py
+++ b/src/mcp_handlers/lifecycle/self_recovery.py
@@ -41,7 +41,11 @@ from ..utils import (
 )
 from ..decorators import mcp_tool
 from ..support.coerce import safe_float, resolve_agent_uuid
-from .helpers import _invalidate_agent_cache
+from .helpers import (
+    _resume_with_persistence,
+    clear_loop_detector_state,  # re-exported for legacy imports from this module
+)
+from src import agent_storage
 from src.logging_utils import get_logger
 from config.governance_config import GovernanceConfig
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
@@ -59,17 +63,6 @@ FORBIDDEN_CONDITIONS = [
 
 MAX_RISK_FOR_SELF_RECOVERY = 0.65  # Matches lifecycle.py review thresholds
 MIN_COHERENCE_FOR_SELF_RECOVERY = 0.35  # Matches lifecycle.py review thresholds
-
-def clear_loop_detector_state(meta) -> None:
-    """Clear loop detector state after successful recovery.
-
-    This prevents the stale pause history from immediately re-triggering
-    the loop detector after self_recovery succeeds.
-    """
-    meta.loop_cooldown_until = None
-    meta.loop_detected_at = None
-    meta.recent_update_timestamps = []
-    meta.recent_decisions = []
 
 def validate_recovery_conditions(conditions: List[str]) -> tuple[bool, Optional[str]]:
     """
@@ -368,7 +361,24 @@ async def handle_quick_resume(arguments: Dict[str, Any]) -> Sequence[TextContent
     # Set before safety checks so even failed attempts suppress Pattern 2/5/6.
     meta_early = mcp_server.agent_metadata.get(agent_uuid)
     if meta_early:
-        meta_early.recovery_attempt_at = datetime.now(timezone.utc).isoformat()
+        recovery_attempt_at = datetime.now(timezone.utc).isoformat()
+        try:
+            await agent_storage.persist_runtime_state(
+                agent_uuid,
+                recovery_attempt_at=recovery_attempt_at,
+            )
+        except Exception as e:
+            logger.warning(
+                f"PostgreSQL persist_runtime_state failed for quick_resume attempt: {e}",
+                exc_info=True,
+            )
+            return [error_response(
+                f"Failed to quick_resume agent '{agent_id}': persistence error",
+                error_code="PERSIST_FAILED",
+                error_category="system_error",
+                details={"agent_id": agent_id, "cause": str(e)},
+            )]
+        meta_early.recovery_attempt_at = recovery_attempt_at
 
     # Get current metrics (use safe_float for uninitialized agents)
     try:
@@ -465,40 +475,17 @@ async def handle_quick_resume(arguments: Dict[str, Any]) -> Sequence[TextContent
     
     previous_status = meta.status
     event_details = f"Quick resume: {reason}"
-    event_entry = {
-        "event": "quick_resumed",
-        "reason": event_details,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-    }
-
-    # Persist FIRST so in-memory state can't diverge from DB on persist failure.
-    # Runtime state (paused_at, lifecycle_events) must be persisted alongside
-    # status or it gets clobbered on the next load_metadata_async(force=True).
-    try:
-        from src import agent_storage
-        await agent_storage.update_agent(agent_uuid, status="active")
-        await agent_storage.persist_runtime_state(
-            agent_uuid,
-            paused_at=None,
-            loop_detected_at=None,
-            loop_cooldown_until=None,
-            append_lifecycle_event=event_entry,
-        )
-        await _invalidate_agent_cache(agent_uuid)
-    except Exception as e:
-        logger.warning(f"PostgreSQL update failed for quick_resume: {e}", exc_info=True)
-        return [error_response(
-            f"Failed to quick_resume agent '{agent_id}': persistence error",
-            error_code="PERSIST_FAILED",
-            error_category="system_error",
-            details={"agent_id": agent_id, "cause": str(e)},
-        )]
-
-    # Persist succeeded — now mutate in-memory state.
-    meta.status = "active"
-    meta.paused_at = None
-    clear_loop_detector_state(meta)
-    meta.add_lifecycle_event("quick_resumed", event_details)
+    persist_error = await _resume_with_persistence(
+        meta,
+        agent_uuid=agent_uuid,
+        event_name="quick_resumed",
+        reason=event_details,
+        error_response_id=agent_id,
+        error_action="quick_resume",
+        storage_module=agent_storage,
+    )
+    if persist_error:
+        return persist_error
 
     return success_response({
         "success": True,
@@ -680,40 +667,18 @@ async def handle_operator_resume_agent(arguments: Dict[str, Any]) -> Sequence[Te
     
     previous_status = target_meta.status
     event_details = f"Resumed by operator {caller_uuid}: {reason}"
-    event_entry = {
-        "event": "operator_resumed",
-        "reason": event_details,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-    }
-
-    # Persist FIRST so in-memory state can't diverge from DB on persist failure.
-    # Runtime state (paused_at, lifecycle_events) must be persisted alongside
-    # status or it gets clobbered on the next load_metadata_async(force=True).
-    try:
-        from src import agent_storage
-        await agent_storage.update_agent(target_agent_id, status="active")
-        await agent_storage.persist_runtime_state(
-            target_agent_id,
-            paused_at=None,
-            loop_detected_at=None,
-            loop_cooldown_until=None,
-            append_lifecycle_event=event_entry,
-        )
-        await _invalidate_agent_cache(target_agent_id)
-    except Exception as e:
-        logger.warning(f"PostgreSQL update failed for operator_resume: {e}", exc_info=True)
-        return [error_response(
-            f"Failed to operator_resume agent '{target_agent_id}': persistence error",
-            error_code="PERSIST_FAILED",
-            error_category="system_error",
-            details={"target_agent_id": target_agent_id, "cause": str(e)},
-        )]
-
-    # Persist succeeded — now mutate in-memory state.
-    target_meta.status = "active"
-    target_meta.paused_at = None
-    clear_loop_detector_state(target_meta)
-    target_meta.add_lifecycle_event("operator_resumed", event_details)
+    persist_error = await _resume_with_persistence(
+        target_meta,
+        agent_uuid=target_agent_id,
+        event_name="operator_resumed",
+        reason=event_details,
+        error_response_id=target_agent_id,
+        error_action="operator_resume",
+        details_key="target_agent_id",
+        storage_module=agent_storage,
+    )
+    if persist_error:
+        return persist_error
     
     return success_response({
         "success": True,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -265,6 +265,7 @@ _LIFECYCLE_MODULES = [
     "src.mcp_handlers.lifecycle.operations",
     "src.mcp_handlers.lifecycle.stuck",
     "src.mcp_handlers.lifecycle.resume",
+    "src.mcp_handlers.lifecycle.self_recovery",
 ]
 
 
@@ -294,6 +295,7 @@ def patch_agent_storage():
     with patch("src.mcp_handlers.lifecycle.handlers.agent_storage", shared), \
          patch("src.mcp_handlers.lifecycle.mutation.agent_storage", shared), \
          patch("src.mcp_handlers.lifecycle.operations.agent_storage", shared), \
+         patch("src.mcp_handlers.lifecycle.self_recovery.agent_storage", shared), \
          patch("src.mcp_handlers.lifecycle.helpers.agent_storage", shared):
         yield shared
 

--- a/tests/test_lifecycle_clobber.py
+++ b/tests/test_lifecycle_clobber.py
@@ -128,6 +128,67 @@ class TestSelfRecoveryReviewPersistsRecoveryAttempt:
                 "recovery_attempt_at must be persisted BEFORE the safety-check gate"
 
 
+class TestQuickResumePersistsRecoveryAttempt:
+    @pytest.mark.asyncio
+    async def test_recovery_attempt_at_persisted_before_safety_checks(self):
+        meta = make_agent_meta(status="paused", paused_at="2026-04-16T10:00:00+00:00")
+        server = _server_with_agent(meta)
+
+        with patch_agent_storage() as storage, \
+             patch("src.mcp_handlers.lifecycle.self_recovery.verify_agent_ownership",
+                   MagicMock(return_value=True)), \
+             patch_lifecycle_server(server,
+                                    require_registered=(AGENT_ID, None),
+                                    **{"src.mcp_handlers.lifecycle.self_recovery.resolve_agent_uuid":
+                                       MagicMock(return_value=AGENT_ID)}):
+            storage.update_agent = AsyncMock(return_value=True)
+            storage.persist_runtime_state = AsyncMock(return_value=True)
+
+            from src.mcp_handlers.lifecycle.self_recovery import handle_quick_resume
+            await handle_quick_resume({"agent_id": AGENT_ID})
+
+            assert storage.persist_runtime_state.await_count >= 1, \
+                "quick_resume must persist recovery_attempt_at before safety checks"
+            first_call = storage.persist_runtime_state.await_args_list[0].kwargs
+            assert first_call.get("recovery_attempt_at"), \
+                "recovery_attempt_at must be persisted BEFORE the safety-check gate"
+            assert meta.recovery_attempt_at == first_call["recovery_attempt_at"]
+
+
+class TestOperatorResumePersistsRuntimeState:
+    @pytest.mark.asyncio
+    async def test_operator_resume_persists_paused_at_and_lifecycle_event(self):
+        caller_id = "operator-under-test"
+        target_meta = make_agent_meta(status="paused", paused_at="2026-04-16T10:00:00+00:00")
+        caller_meta = make_agent_meta(label="Operator")
+        server = make_mock_server()
+        server.agent_metadata = {caller_id: caller_meta, AGENT_ID: target_meta}
+        server.monitors = {AGENT_ID: make_monitor()}
+        server.get_or_create_monitor = MagicMock(return_value=make_monitor())
+
+        with patch_agent_storage() as storage, \
+             patch_lifecycle_server(server,
+                                    require_registered=(caller_id, None),
+                                    **{"src.mcp_handlers.lifecycle.self_recovery.resolve_agent_uuid":
+                                       MagicMock(return_value=caller_id)}):
+            storage.update_agent = AsyncMock(return_value=True)
+            storage.persist_runtime_state = AsyncMock(return_value=True)
+
+            from src.mcp_handlers.lifecycle.self_recovery import handle_operator_resume_agent
+            await handle_operator_resume_agent({
+                "_agent_uuid": caller_id,
+                "target_agent_id": AGENT_ID,
+                "reason": "test operator recovery",
+            })
+
+            storage.update_agent.assert_awaited_once_with(AGENT_ID, status="active")
+            storage.persist_runtime_state.assert_awaited_once()
+            kwargs = storage.persist_runtime_state.await_args.kwargs
+            assert kwargs.get("paused_at") is None
+            event = kwargs.get("append_lifecycle_event")
+            assert event and event.get("event") == "operator_resumed"
+
+
 class TestPersistRuntimeStateContract:
     """Contract tests for the new agent_storage.persist_runtime_state helper."""
 

--- a/tests/test_self_recovery.py
+++ b/tests/test_self_recovery.py
@@ -490,8 +490,11 @@ class TestQuickResume:
             assert data.get("success") is True or data.get("recovered") is True
 
             mock_update.assert_awaited_once_with("test-uuid", status="active")
-            mock_persist.assert_awaited_once()
-            call = mock_persist.await_args
+            assert mock_persist.await_count == 2
+            attempt_call = mock_persist.await_args_list[0]
+            assert attempt_call.args[0] == "test-uuid"
+            assert attempt_call.kwargs["recovery_attempt_at"]
+            call = mock_persist.await_args_list[-1]
             assert call.args[0] == "test-uuid"
             assert call.kwargs["paused_at"] is None
             assert call.kwargs["loop_detected_at"] is None


### PR DESCRIPTION
## Summary

- Extract a shared `_resume_with_persistence` helper for lifecycle resume paths
- Use the helper from dashboard resume, direct resume, quick resume, and operator resume
- Persist `quick_resume` recovery attempts before safety checks
- Add quick/operator clobber regressions for the P011 runtime-state drift class

Fixes #209.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q -p no:cacheprovider tests/test_lifecycle_clobber.py tests/test_self_recovery.py tests/test_lifecycle_recovery.py tests/test_lifecycle_agents.py::TestResumeAgent`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q -p no:cacheprovider tests/test_lifecycle_agents.py tests/test_lifecycle_recovery.py tests/test_self_recovery.py tests/test_lifecycle_clobber.py tests/test_handlers_lifecycle.py tests/test_core_metrics.py`
- pre-push smoke: `138 passed, 7309 deselected`