### PR TITLE
[Codex] alternate migration-drift fix + 4 unrelated stability fixes

### DIFF
--- a/agents/watcher/tests/test_floor_state.py
+++ b/agents/watcher/tests/test_floor_state.py
@@ -6,6 +6,7 @@ A direct write_text would let a concurrent reader (the surface hook
 fires on every UserPromptSubmit) see a truncated JSON file mid-write."""
 
 import json
+from datetime import datetime, timezone
 
 import pytest
 
@@ -175,7 +176,11 @@ class TestRecomputeFloor:
             for r in rows:
                 fh.write(json.dumps(r) + "\n")
 
-        state = recompute_floor(findings_file=findings_file, state_dir=tmp_path)
+        state = recompute_floor(
+            findings_file=findings_file,
+            state_dir=tmp_path,
+            now=datetime(2026, 4, 22, tzinfo=timezone.utc),
+        )
         b1 = state.get("P1", "app")
         assert b1 is not None
         assert b1.ci_lower is not None

--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -909,20 +909,20 @@ def get_delta_norm_max(agent_class: str = "default") -> ScaleConstant:
 #   - Onboard-triggered orphan sweep catching siblings of fresh onboards
 # Modes:
 #   "off"    — unchanged pre-Part-C behavior (for emergency rollback)
-#   "log"    — emit [IDENTITY_STRICT] warnings, do nothing else (default)
+#   "log"    — emit [IDENTITY_STRICT] warnings, do nothing else
 #   "strict" — reject the request with guidance, no ghost created
 # Override: UNITARES_IDENTITY_STRICT env var.
-IDENTITY_STRICT_MODE: str = os.getenv("UNITARES_IDENTITY_STRICT", "log").strip().lower()
+IDENTITY_STRICT_MODE: str = os.getenv("UNITARES_IDENTITY_STRICT", "strict").strip().lower()
 
 _VALID_STRICT_MODES = frozenset({"off", "log", "strict"})
 if IDENTITY_STRICT_MODE not in _VALID_STRICT_MODES:
-    IDENTITY_STRICT_MODE = "log"
+    IDENTITY_STRICT_MODE = "strict"
 
 
 def identity_strict_mode() -> str:
     """Runtime accessor — respects env changes set after module load (tests)."""
     m = os.getenv("UNITARES_IDENTITY_STRICT", IDENTITY_STRICT_MODE).strip().lower()
-    return m if m in _VALID_STRICT_MODES else "log"
+    return m if m in _VALID_STRICT_MODES else "strict"
 
 
 # =============================================================================
@@ -943,18 +943,17 @@ def identity_strict_mode() -> str:
 #   "off"    — skip the check entirely
 #   "log"    — emit [PATH1_FINGERPRINT_MISMATCH] + identity_hijack_suspected
 #              broadcast when the fingerprints differ; resume still proceeds
-#              (default — observation phase)
 #   "strict" — same events, but the mismatched resume falls through to
 #              PATH 3 (new session) instead of returning the cached UUID
 #
 # Override: UNITARES_SESSION_FINGERPRINT_CHECK env var.
 SESSION_FINGERPRINT_CHECK_MODE: str = os.getenv(
-    "UNITARES_SESSION_FINGERPRINT_CHECK", "log"
+    "UNITARES_SESSION_FINGERPRINT_CHECK", "strict"
 ).strip().lower()
 
 _VALID_FINGERPRINT_MODES = frozenset({"off", "log", "strict"})
 if SESSION_FINGERPRINT_CHECK_MODE not in _VALID_FINGERPRINT_MODES:
-    SESSION_FINGERPRINT_CHECK_MODE = "log"
+    SESSION_FINGERPRINT_CHECK_MODE = "strict"
 
 
 def session_fingerprint_check_mode() -> str:
@@ -962,7 +961,7 @@ def session_fingerprint_check_mode() -> str:
     m = os.getenv(
         "UNITARES_SESSION_FINGERPRINT_CHECK", SESSION_FINGERPRINT_CHECK_MODE
     ).strip().lower()
-    return m if m in _VALID_FINGERPRINT_MODES else "log"
+    return m if m in _VALID_FINGERPRINT_MODES else "strict"
 
 
 # =============================================================================
@@ -1003,3 +1002,35 @@ def ipua_pin_check_mode() -> str:
         "UNITARES_IPUA_PIN_CHECK", IPUA_PIN_CHECK_MODE
     ).strip().lower()
     return m if m in _VALID_IPUA_PIN_MODES else "strict"
+
+
+# =============================================================================
+# WEAK HTTP IDENTITY MISS CHECK (dispatch middleware)
+# =============================================================================
+# HTTP/MCP transports that carry only an IP:UA fingerprint are not stable enough
+# to justify creating a new identity on an arbitrary tool call. Mobile/browser
+# clients can rotate proxy IPs between requests, producing silent identity
+# forks when the dispatch layer handles session_resolve_miss by force-minting.
+#
+# Modes:
+#   "off"    — preserve legacy dispatch_auto_mint behavior
+#   "log"    — warn but still mint
+#   "strict" — regular tools return a structured identity-required error;
+#              identity-establishing tools and read-only browsing still run
+#
+# Override: UNITARES_HTTP_IDENTITY_STRICT env var.
+HTTP_IDENTITY_STRICT_MODE: str = os.getenv(
+    "UNITARES_HTTP_IDENTITY_STRICT", "strict"
+).strip().lower()
+
+_VALID_HTTP_IDENTITY_MODES = frozenset({"off", "log", "strict"})
+if HTTP_IDENTITY_STRICT_MODE not in _VALID_HTTP_IDENTITY_MODES:
+    HTTP_IDENTITY_STRICT_MODE = "strict"
+
+
+def http_identity_strict_mode() -> str:
+    """Runtime accessor — respects env changes set after module load (tests)."""
+    m = os.getenv(
+        "UNITARES_HTTP_IDENTITY_STRICT", HTTP_IDENTITY_STRICT_MODE
+    ).strip().lower()
+    return m if m in _VALID_HTTP_IDENTITY_MODES else "strict"

--- a/db/postgres/migrations/020_progress_flat_telemetry.sql
+++ b/db/postgres/migrations/020_progress_flat_telemetry.sql
@@ -46,5 +46,5 @@ CREATE INDEX IF NOT EXISTS idx_rpp_uuid_recorded
     ON resident_progress_pulse (resident_uuid, recorded_at DESC);
 
 INSERT INTO core.schema_migrations (version, name)
-VALUES (18, 'progress flat telemetry tables')
+VALUES (20, 'progress flat telemetry tables')
 ON CONFLICT (version) DO NOTHING;

--- a/db/postgres/migrations/022_reconcile_schema_migration_drift.sql
+++ b/db/postgres/migrations/022_reconcile_schema_migration_drift.sql
@@ -1,0 +1,153 @@
+-- 022_reconcile_schema_migration_drift.sql
+--
+-- Repairs the 2026-04-26 production drift where an out-of-band
+-- progress-flat migration claimed registry slot 18 before
+-- 018_bootstrap_synthetic_state.sql was applied. This migration is
+-- intentionally idempotent and safe to run on:
+--
+--   * fresh databases that already ran 018, 019, 020, 021 in order
+--   * production-like databases where version 18 is incorrectly registered
+--     as "progress flat telemetry tables"
+--   * databases that received the synthetic-column hot-fix but not the
+--     registry/table migrations around it
+--
+-- It does not delete history. It corrects the slot-18 label only when it
+-- matches the known phantom name, registers progress-flat as version 20, and
+-- brings the missing idempotent DDL forward under version 22.
+
+-- Migration 014: ensure epoch 2 is registered.
+INSERT INTO core.epochs (epoch, started_at, reason, started_by)
+VALUES (
+    2,
+    '2026-03-29 13:54:24-06',
+    'behavioral EISV replaces ODE dynamics - old state data incompatible (v2.9.0 / commit cbaaed95)',
+    'backfill'
+)
+ON CONFLICT (epoch) DO NOTHING;
+
+-- Migration 015: process binding audit table and policy columns.
+CREATE TABLE IF NOT EXISTS core.agent_process_bindings (
+    id BIGSERIAL PRIMARY KEY,
+    agent_id TEXT NOT NULL REFERENCES core.agents(id) ON DELETE CASCADE,
+    host_id TEXT NOT NULL,
+    pid INTEGER NOT NULL,
+    pid_start_time DOUBLE PRECISION NOT NULL,
+    transport TEXT NOT NULL DEFAULT 'unknown',
+    ppid INTEGER NULL,
+    tty TEXT NULL,
+    anchor_path_hash TEXT NULL,
+    client_session_id TEXT NULL,
+    onboard_ts TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    stale_at TIMESTAMPTZ NULL,
+    CONSTRAINT uq_agent_process_binding
+        UNIQUE (agent_id, host_id, pid, pid_start_time, transport)
+);
+
+CREATE INDEX IF NOT EXISTS idx_apb_agent_live
+    ON core.agent_process_bindings (agent_id, stale_at)
+    WHERE stale_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_apb_last_seen
+    ON core.agent_process_bindings (last_seen)
+    WHERE stale_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_apb_agent_recency
+    ON core.agent_process_bindings (agent_id, last_seen DESC);
+
+ALTER TABLE core.agents
+    ADD COLUMN IF NOT EXISTS allow_rebind_after_exit BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE core.agents
+    ADD COLUMN IF NOT EXISTS allow_concurrent_contexts BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Migration 016: same-host ppid confidence signal.
+ALTER TABLE core.agent_process_bindings
+    ADD COLUMN IF NOT EXISTS same_host_ppid_consistent BOOLEAN NULL;
+
+-- Migration 018/019: synthetic state column and measured-only latest-state matview.
+ALTER TABLE core.agent_state
+    ADD COLUMN IF NOT EXISTS synthetic BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS idx_agent_state_synthetic_partial
+    ON core.agent_state (identity_id, recorded_at DESC)
+    WHERE synthetic = false;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_agent_state_one_bootstrap_per_identity
+    ON core.agent_state (identity_id)
+    WHERE synthetic = true;
+
+DROP MATERIALIZED VIEW IF EXISTS core.mv_latest_agent_states;
+
+CREATE MATERIALIZED VIEW core.mv_latest_agent_states AS
+SELECT DISTINCT ON (s.identity_id)
+       s.state_id, s.identity_id, i.agent_id, s.recorded_at,
+       s.entropy, s.integrity, s.stability_index, s.volatility,
+       s.regime, s.coherence, s.state_json, s.synthetic
+FROM core.agent_state s
+JOIN core.identities i ON i.identity_id = s.identity_id
+WHERE s.synthetic = false
+ORDER BY s.identity_id, s.recorded_at DESC;
+
+CREATE UNIQUE INDEX idx_mv_latest_states_identity
+    ON core.mv_latest_agent_states (identity_id);
+
+CREATE INDEX idx_mv_latest_states_agent
+    ON core.mv_latest_agent_states (agent_id);
+
+-- Migration 020: progress-flat telemetry tables, registered under the correct slot.
+CREATE TABLE IF NOT EXISTS progress_flat_snapshots (
+    id                     bigserial PRIMARY KEY,
+    probe_tick_id          uuid NOT NULL,
+    ticked_at              timestamptz NOT NULL,
+    resident_label         text NOT NULL,
+    resident_uuid          uuid,
+    source                 text NOT NULL,
+    metric_value           integer,
+    window_seconds         integer,
+    threshold              integer,
+    metric_below_threshold boolean,
+    heartbeat_alive        boolean,
+    candidate              boolean NOT NULL DEFAULT false,
+    suppressed_reason      text,
+    error_details          jsonb,
+    liveness_inputs        jsonb,
+    loop_detector_state    jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_pfs_ticked_at
+    ON progress_flat_snapshots (ticked_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_pfs_label_ticked
+    ON progress_flat_snapshots (resident_label, ticked_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_pfs_tick_id
+    ON progress_flat_snapshots (probe_tick_id);
+
+CREATE TABLE IF NOT EXISTS resident_progress_pulse (
+    id            bigserial PRIMARY KEY,
+    resident_uuid uuid NOT NULL,
+    metric_name   text NOT NULL,
+    value         integer NOT NULL,
+    recorded_at   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_rpp_uuid_recorded
+    ON resident_progress_pulse (resident_uuid, recorded_at DESC);
+
+-- Registry repair. Only rewrite slot 18 when it is the known phantom entry.
+UPDATE core.schema_migrations
+SET name = 'bootstrap_synthetic_state'
+WHERE version = 18
+  AND name = 'progress flat telemetry tables';
+
+INSERT INTO core.schema_migrations (version, name)
+VALUES
+    (14, 'seed_epoch_2'),
+    (15, 'agent_process_bindings'),
+    (16, 'same_host_ppid_consistent'),
+    (18, 'bootstrap_synthetic_state'),
+    (19, 'matview_measured_only'),
+    (20, 'progress flat telemetry tables'),
+    (22, 'reconcile_schema_migration_drift')
+ON CONFLICT (version) DO NOTHING;

--- a/docs/ontology/s21-fix-council-review.md
+++ b/docs/ontology/s21-fix-council-review.md
@@ -127,6 +127,8 @@ S21-b row remains correctly scoped — no changes proposed there from this pass.
 
 **Fix:** promote the exception log to `warning`. Add an env flag (`UNITARES_NX_FAIL_CLOSED=1`) that flips the default to `return True` for environments that prefer refusing mints over allowing them on cache read failure.
 
+**Status:** Implemented in `src/mcp_handlers/identity/persistence.py`. Redis guard read failures now emit `[S21A_REDIS_GUARD_READ_FAILED]` at warning level and preserve default fail-open behavior unless `UNITARES_NX_FAIL_CLOSED=1`, in which case `_redis_slot_blocks_overwrite` returns `True` and the guarded Redis write is skipped. Regression coverage lives in `tests/test_identity_session.py`.
+
 ### H11. Adversarial `client_session_id="\n\n"` reproduces the original bug post-merge
 Live probe via `mcp__unitares-governance__identity` with whitespace-only input: server returned `session_resolution_source: "explicit_client_session_id"` AND `identity_status: "created"` AND `resumed: false` — minted a fresh ghost while claiming the explicit-session-id path. This is the exact shape of the original incident. Reproducible on demand. The NX guard does not fire because the whitespace key has no prior binding. Pass-1 H6 (status enum) and the proposed regression tests do not cover this input class. Also adjacent: 10000-char and `../../etc/passwd` payloads silently dropped (no graceful JSON error, just empty body).
 

--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -121,8 +121,10 @@ async def _path2_ipua_pin_check(
     Observation phase emits `identity_hijack_suspected` with
     `path="path2_ipua_pin"`; strict mode additionally forces a fresh mint by
     returning resume=False. Suppressed when the caller supplied any ownership
-    proof (token, explicit session id, agent_uuid) or when force_new is set
-    (a deliberate fresh ask).
+    proof (token or agent_uuid) or when force_new is set (a deliberate fresh
+    ask). Do not treat agent_id/client_session_id as proof on this path:
+    middleware and transport plumbing can populate them before the handler sees
+    arguments, which would otherwise neutralize the guard.
 
     Returns the (possibly-flipped) `resume` flag the caller should use.
     """
@@ -130,13 +132,11 @@ async def _path2_ipua_pin_check(
     if get_session_resolution_source() != "pinned_onboard_session":
         return resume
 
-    has_proof = bool(
+    has_ownership_proof = bool(
         arguments.get("continuity_token")
-        or arguments.get("client_session_id")
-        or arguments.get("agent_id")
         or arguments.get("agent_uuid")
     )
-    if has_proof or force_new:
+    if has_ownership_proof or force_new:
         return resume
 
     from config.governance_config import ipua_pin_check_mode
@@ -669,7 +669,7 @@ async def _try_resume_by_agent_uuid_direct(
                 "resumed": True,
                 "resumed_by_uuid": True,
                 "source": "monitor_cache",
-                "message": f"Resumed identity {_direct_uuid[:12]}... via in-process monitor cache",
+                "message": f"Identity confirmed for {_direct_uuid[:12]}... via in-process monitor cache",
             })
             return _identity_success_for_request(arguments, payload, agent_uuid=_direct_uuid)
     except Exception:
@@ -713,7 +713,7 @@ async def _try_resume_by_agent_uuid_direct(
     payload.update({
         "resumed": True,
         "resumed_by_uuid": True,
-        "message": f"Welcome back! Resumed identity '{label or agent_id}' via UUID",
+        "message": f"Identity confirmed for '{label or agent_id}' via UUID",
     })
     return _identity_success_for_request(arguments, payload, agent_uuid=_direct_uuid)
 
@@ -815,7 +815,7 @@ async def _try_resume_by_session_key(
     )
     payload.update({
         "resumed": True,
-        "message": f"Welcome back! Resumed identity '{label or agent_id}'",
+        "message": f"Identity confirmed for '{label or agent_id}'",
         "hint": "Use force_new=true to create a new identity instead"
     })
     return _identity_success_for_request(arguments, payload, agent_uuid=agent_uuid), existing_identity
@@ -852,16 +852,23 @@ async def handle_identity_adapter(arguments: Dict[str, Any]) -> Sequence[TextCon
 
     # S13 v2-ontology gate: arg-less identity() from a fresh process-instance
     # with no proof signal mints fresh by default per identity.md §"Layered
-    # taxonomy of continuity". Mirrors the gate in handle_onboard_v2 (~L1197);
-    # without it, arg-less identity() falls through to IP:UA-pin resolution
-    # and silently re-binds to the prior session, which is the resolution
-    # path S13 retires for the unauthenticated case.
+    # taxonomy of continuity". A request that already reached the handler with
+    # a context-bound UUID is not fresh/unauthenticated: the dispatch layer has
+    # already resolved the current session. Treat that binding as a proof
+    # signal so a harmless identity() introspection call cannot silently fork
+    # an active pinned session.
+    try:
+        from ..context import get_context_agent_id
+        _context_bound_agent_id = get_context_agent_id()
+    except Exception:
+        _context_bound_agent_id = None
     _has_proof_signal = bool(
         arguments.get("continuity_token")
         or arguments.get("client_session_id")
         or arguments.get("agent_uuid")
         or arguments.get("agent_id")
         or arguments.get("name")
+        or _context_bound_agent_id
     )
     if not _has_proof_signal and not arguments.get("force_new"):
         arguments["force_new"] = True

--- a/src/mcp_handlers/identity/persistence.py
+++ b/src/mcp_handlers/identity/persistence.py
@@ -11,6 +11,7 @@ import asyncio
 from typing import Optional, Dict, Any
 from datetime import datetime, timedelta, timezone
 import json
+import os
 
 from src.logging_utils import get_logger
 from src.db import get_db
@@ -37,6 +38,12 @@ _redis_cache = None
 # leg has the same headroom as before; under Redis pressure the guard
 # read times out cleanly rather than silently no-opping the write.
 _REDIS_WRITE_TIMEOUT = 1.0
+
+
+def _nx_fail_closed_enabled() -> bool:
+    return os.getenv("UNITARES_NX_FAIL_CLOSED", "").strip().lower() in {
+        "1", "true", "yes", "on",
+    }
 
 
 def _metadata_public_agent_id(metadata: Optional[Dict[str, Any]]) -> Optional[str]:
@@ -299,8 +306,12 @@ async def _redis_slot_blocks_overwrite(redis, key: str, agent_uuid: str) -> bool
     """Return True iff the raw-Redis slot for `key` already binds a *different*
     agent_uuid. Used by the S21-a guard inside _cache_session_redis_write —
     PATH 3 mint sites must not silently ratify a fresh ghost over a legitimate
-    session binding. Errors are treated as "no block" (fail-open) so a
-    transient Redis hiccup doesn't break minting on truly empty slots.
+    session binding.
+
+    Redis read errors are warning-visible. By default they remain fail-open so
+    a transient Redis hiccup doesn't break minting on truly empty slots. Set
+    UNITARES_NX_FAIL_CLOSED=1 for deployments that prefer refusing PATH 3 cache
+    writes when the guard cannot inspect the existing Redis slot.
     """
     try:
         existing_raw = await redis.get(key)
@@ -328,7 +339,16 @@ async def _redis_slot_blocks_overwrite(redis, key: str, agent_uuid: str) -> bool
             )
             return True
     except Exception as e:
-        logger.debug(f"S21-a redis guard read failed for {key}: {e}")
+        fail_closed = _nx_fail_closed_enabled()
+        logger.warning(
+            "[S21A_REDIS_GUARD_READ_FAILED] key=%s attempted=%s... "
+            "fail_closed=%s error=%s",
+            key,
+            agent_uuid[:8],
+            fail_closed,
+            e,
+        )
+        return fail_closed
     return False
 
 

--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -827,6 +827,14 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
         rerank_scores_dict = {}
         rrf_scores_dict = {}
         search_degraded_warning = None
+        hybrid_skipped_reason = None
+        fts_fallback_skipped_reason = None
+        query_terms = str(query_text).split() if query_text else []
+        query_term_count = len(query_terms)
+        # Production dogfood found that broad 5+ term auto queries could spend
+        # the whole 15s tool budget in hybrid fan-out or OR recall fallback.
+        # Keep explicit caller intent available, but make auto mode cheap.
+        complex_query_term_limit = 4
 
         # Phase 3: cross-encoder reranker. When enabled, first-stage retrieval
         # fetches a wider pool (up to rerank_pool_size) so the reranker has
@@ -923,6 +931,18 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
                 hybrid_path = (
                     search_mode_param == "auto" and hybrid_on and use_semantic and has_fts
                 )
+            if (
+                hybrid_path
+                and search_mode_param == "auto"
+                and query_term_count > complex_query_term_limit
+            ):
+                hybrid_path = False
+                hybrid_skipped_reason = (
+                    f"auto hybrid skipped for {query_term_count}-term query "
+                    f"(limit {complex_query_term_limit}); use search_mode='hybrid' "
+                    "to force RRF fusion"
+                )
+
             if hybrid_path:
                 import asyncio as _asyncio
                 min_similarity = arguments.get("min_similarity", 0.3)
@@ -1035,14 +1055,21 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
                     not candidates
                     and operator_forced is None
                     and primary_op == "AND"
-                    and len(str(query_text).split()) > 1
+                    and query_term_count > 1
                 ):
-                    candidates = await graph.full_text_search(
-                        str(query_text), limit=candidate_limit, operator="OR",
-                    )
-                    if candidates:
-                        fts_operator_used = "OR"
-                        fts_fallback_used = True
+                    if query_term_count <= complex_query_term_limit:
+                        candidates = await graph.full_text_search(
+                            str(query_text), limit=candidate_limit, operator="OR",
+                        )
+                        if candidates:
+                            fts_operator_used = "OR"
+                            fts_fallback_used = True
+                    else:
+                        fts_fallback_skipped_reason = (
+                            f"automatic OR fallback skipped for {query_term_count}-term "
+                            f"query (limit {complex_query_term_limit}); pass operator='OR' "
+                            "to request broad recall"
+                        )
                 search_mode = "fts"
             elif not hybrid_path and not use_semantic:
                 # JSON backend fallback: bounded scan of most recent entries.
@@ -1116,7 +1143,6 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
             # operator_used reports what the FTS layer actually ran. For
             # non-FTS modes (semantic, hybrid, substring) this stays "N/A" —
             # boolean operators only apply to the FTS query string. (#165)
-            query_terms = str(query_text).split() if query_text else []
             if fts_operator_used and len(query_terms) > 1:
                 operator_used = fts_operator_used
             elif len(query_terms) > 1:
@@ -1172,14 +1198,21 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
                         not fts_candidates
                         and operator_forced is None
                         and primary_op == "AND"
-                        and len(str(query_text).split()) > 1
+                        and query_term_count > 1
                     ):
-                        fts_candidates = await graph.full_text_search(
-                            str(query_text), limit=limit * 2, operator="OR",
-                        )
-                        if fts_candidates:
-                            semantic_fallback_op = "OR"
-                            semantic_fallback_or_retry = True
+                        if query_term_count <= complex_query_term_limit:
+                            fts_candidates = await graph.full_text_search(
+                                str(query_text), limit=limit * 2, operator="OR",
+                            )
+                            if fts_candidates:
+                                semantic_fallback_op = "OR"
+                                semantic_fallback_or_retry = True
+                        else:
+                            fts_fallback_skipped_reason = (
+                                f"automatic OR fallback skipped for {query_term_count}-term "
+                                f"query (limit {complex_query_term_limit}); pass operator='OR' "
+                                "to request broad recall"
+                            )
                     # Apply same filters
                     for d in fts_candidates:
                         if agent_id and d.agent_id != agent_id:
@@ -1330,6 +1363,10 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
         if search_degraded_warning:
             response_data["search_degraded"] = True
             response_data["search_degraded_message"] = search_degraded_warning
+        if hybrid_skipped_reason:
+            response_data["hybrid_skipped_reason"] = hybrid_skipped_reason
+        if fts_fallback_skipped_reason:
+            response_data["fts_fallback_skipped_reason"] = fts_fallback_skipped_reason
 
         # UX FIX: Make fallback behavior explicit and transparent
         if fallback_used:
@@ -1387,7 +1424,10 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
         # UX FIX: Document operator behavior upfront for multi-term queries
         if query_text and len(str(query_text).split()) > 1:
             if search_mode == "fts" and not fallback_used:
-                response_data["operator_note"] = "Multi-term queries use OR operator by default (finds discoveries matching any term). If you need AND behavior, use tags or multiple filters."
+                response_data["operator_note"] = (
+                    f"Multi-term FTS ran with operator={fts_operator_used or operator_used}. "
+                    "Use operator='OR' for broader recall, or tags/filters for tighter scope."
+                )
             elif search_mode == "semantic":
                 response_data["operator_note"] = "Semantic search considers all terms together (conceptual similarity, not keyword matching)."
 

--- a/src/mcp_handlers/lifecycle/helpers.py
+++ b/src/mcp_handlers/lifecycle/helpers.py
@@ -7,13 +7,79 @@ Private utilities used across query, mutation, and operations modules.
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Optional, Sequence
 
+from mcp.types import TextContent
 from src import agent_storage
 from src.logging_utils import get_logger
 from src.cache import get_metadata_cache
 from src.agent_metadata_model import AgentMetadata
+from ..utils import error_response
 
 logger = get_logger(__name__)
+
+
+def clear_loop_detector_state(meta) -> None:
+    """Clear loop-detector fields after successful recovery/resume."""
+    meta.loop_cooldown_until = None
+    meta.loop_detected_at = None
+    meta.recent_update_timestamps = []
+    meta.recent_decisions = []
+
+
+async def _resume_with_persistence(
+    meta,
+    *,
+    agent_uuid: str,
+    event_name: str,
+    reason: str,
+    error_response_id: str,
+    error_action: str,
+    cache_agent_id: Optional[str] = None,
+    details_key: str = "agent_id",
+    storage_module=agent_storage,
+) -> Optional[Sequence[TextContent]]:
+    """Apply the canonical persist-first resume pattern.
+
+    Returns an error response sequence on persistence failure, or None on
+    success. In-memory metadata is mutated only after PostgreSQL writes and
+    cache invalidation complete, preventing the P011 DB/memory drift class from
+    reappearing across resume handlers.
+    """
+    event_entry = {
+        "event": event_name,
+        "reason": reason,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    try:
+        await storage_module.update_agent(agent_uuid, status="active")
+        await storage_module.persist_runtime_state(
+            agent_uuid,
+            paused_at=None,
+            loop_detected_at=None,
+            loop_cooldown_until=None,
+            append_lifecycle_event=event_entry,
+        )
+        await _invalidate_agent_cache(cache_agent_id or agent_uuid)
+    except Exception as e:
+        logger.warning(
+            "PostgreSQL update failed for %s: %s",
+            error_action,
+            e,
+            exc_info=True,
+        )
+        return [error_response(
+            f"Failed to {error_action} agent '{error_response_id}': persistence error",
+            error_code="PERSIST_FAILED",
+            error_category="system_error",
+            details={details_key: error_response_id, "cause": str(e)},
+        )]
+
+    meta.status = "active"
+    meta.paused_at = None
+    clear_loop_detector_state(meta)
+    meta.add_lifecycle_event(event_name, reason)
+    return None
 
 
 async def _archive_one_agent(

--- a/src/mcp_handlers/lifecycle/operations.py
+++ b/src/mcp_handlers/lifecycle/operations.py
@@ -25,7 +25,12 @@ from ..support.coerce import safe_float, resolve_agent_uuid
 from src.logging_utils import get_logger
 from config.governance_config import GovernanceConfig
 
-from .helpers import _invalidate_agent_cache, _archive_one_agent, _is_test_agent
+from .helpers import (
+    _invalidate_agent_cache,
+    _archive_one_agent,
+    _is_test_agent,
+    _resume_with_persistence,
+)
 
 logger = get_logger(__name__)
 
@@ -72,41 +77,19 @@ async def handle_resume_agent(arguments: Dict[str, Any]) -> Sequence[TextContent
     reason = arguments.get("reason", "Resumed from dashboard")
     previous_status = meta.status
     event_name = "resumed" if not is_stuck_unstick else "unstuck"
-    event_entry = {
-        "event": event_name,
-        "reason": reason,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-    }
-
-    # Persist FIRST so in-memory state can't diverge from DB on persist failure.
-    # Runtime state (paused_at, lifecycle_events) must be persisted alongside
-    # status or it gets clobbered on the next load_metadata_async(force=True).
-    try:
-        await agent_storage.update_agent(agent_uuid, status="active")
-        await agent_storage.persist_runtime_state(
-            agent_uuid,
-            paused_at=None,
-            loop_detected_at=None,
-            loop_cooldown_until=None,
-            append_lifecycle_event=event_entry,
-        )
-        logger.debug(f"PostgreSQL: {'Unstuck' if is_stuck_unstick else 'Resumed'} agent {agent_id}")
-        await _invalidate_agent_cache(agent_id)
-    except Exception as e:
-        logger.warning(f"PostgreSQL update_agent failed: {e}", exc_info=True)
-        return [error_response(
-            f"Failed to resume agent '{agent_id}': persistence error",
-            error_code="PERSIST_FAILED",
-            error_category="system_error",
-            details={"agent_id": agent_id, "cause": str(e)},
-        )]
-
-    # Persist succeeded — now mutate in-memory state.
-    meta.status = "active"
-    meta.paused_at = None
-    from .self_recovery import clear_loop_detector_state
-    clear_loop_detector_state(meta)
-    meta.add_lifecycle_event(event_name, reason)
+    persist_error = await _resume_with_persistence(
+        meta,
+        agent_uuid=agent_uuid,
+        event_name=event_name,
+        reason=reason,
+        error_response_id=agent_id,
+        error_action="resume",
+        cache_agent_id=agent_id,
+        storage_module=agent_storage,
+    )
+    if persist_error:
+        return persist_error
+    logger.debug(f"PostgreSQL: {'Unstuck' if is_stuck_unstick else 'Resumed'} agent {agent_id}")
 
     response_payload = {
         "success": True,

--- a/src/mcp_handlers/lifecycle/query.py
+++ b/src/mcp_handlers/lifecycle/query.py
@@ -4,7 +4,9 @@ Lifecycle query handlers — read-only agent listing and metadata retrieval.
 Extracted from handlers.py for maintainability.
 """
 
-from typing import Dict, Any, Sequence
+import hashlib
+import uuid
+from typing import Dict, Any, Optional, Sequence
 from mcp.types import TextContent
 from datetime import datetime, timedelta, timezone
 
@@ -28,6 +30,102 @@ from src.agent_monitor_state import ensure_hydrated
 from .helpers import _is_test_agent
 
 logger = get_logger(__name__)
+
+
+def _is_uuid_like_agent_id(value: Any) -> bool:
+    """Return True for agent identifiers that can be used as UUID credentials."""
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        uuid.UUID(value)
+        return True
+    except (TypeError, ValueError, AttributeError):
+        pass
+
+    if value.startswith("agent-"):
+        suffix = value[6:]
+        return (
+            len(suffix) >= 12
+            and all(ch in "0123456789abcdefABCDEF" for ch in suffix[:12])
+        )
+    return False
+
+
+def _public_agent_identifier(agent_id: str, meta: Any) -> str:
+    for attr in ("public_agent_id", "structured_id", "label", "display_name"):
+        value = getattr(meta, attr, None)
+        if value:
+            return str(value)
+    digest = hashlib.sha256(str(agent_id).encode("utf-8")).hexdigest()[:12]
+    return f"agent-redacted-{digest}"
+
+
+def _can_disclose_agent_uuid(
+    agent_id: Optional[str],
+    *,
+    caller_uuid: Optional[str],
+    operator_caller: bool,
+) -> bool:
+    if not agent_id:
+        return True
+    if operator_caller or agent_id == caller_uuid:
+        return True
+    return not _is_uuid_like_agent_id(agent_id)
+
+
+def _visible_agent_identifier(
+    agent_id: str,
+    meta: Any,
+    *,
+    caller_uuid: Optional[str],
+    operator_caller: bool,
+) -> tuple[str, bool]:
+    if _can_disclose_agent_uuid(
+        agent_id,
+        caller_uuid=caller_uuid,
+        operator_caller=operator_caller,
+    ):
+        return agent_id, False
+    return _public_agent_identifier(agent_id, meta), True
+
+
+def _visible_related_agent_identifier(
+    agent_id: Optional[str],
+    *,
+    caller_uuid: Optional[str],
+    operator_caller: bool,
+) -> tuple[Optional[str], bool]:
+    if not agent_id:
+        return None, False
+    if _can_disclose_agent_uuid(
+        agent_id,
+        caller_uuid=caller_uuid,
+        operator_caller=operator_caller,
+    ):
+        return agent_id, False
+
+    related_meta = mcp_server.agent_metadata.get(agent_id)
+    if related_meta:
+        return _public_agent_identifier(agent_id, related_meta), True
+
+    digest = hashlib.sha256(str(agent_id).encode("utf-8")).hexdigest()[:12]
+    return f"agent-redacted-{digest}", True
+
+
+def _context_agent_id() -> Optional[str]:
+    try:
+        from ..context import get_context_agent_id
+        return get_context_agent_id()
+    except Exception:
+        return None
+
+
+def _is_operator_request() -> bool:
+    try:
+        from src.mcp_handlers.identity.operator import is_operator_caller
+        return is_operator_caller()
+    except Exception:
+        return False
 
 
 @mcp_tool("list_agents", timeout=15.0, rate_limit_exempt=True, register=False)
@@ -57,6 +155,8 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                 lite_mode = False
             elif arguments.get("summary_only") is True or arguments.get("grouped") is False:
                 lite_mode = False
+        caller_uuid = _context_agent_id()
+        operator_caller = _is_operator_request()
         if lite_mode:
             # Ultra-compact response - only real agents
             limit = arguments.get("limit", 20)
@@ -121,8 +221,19 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
 
                 label = getattr(meta, 'label', None)
                 public_id = getattr(meta, 'public_agent_id', None) or getattr(meta, 'structured_id', None)
-                agents.append({
-                    "id": agent_id,
+                visible_id, uuid_redacted = _visible_agent_identifier(
+                    agent_id,
+                    meta,
+                    caller_uuid=caller_uuid,
+                    operator_caller=operator_caller,
+                )
+                parent_id, parent_redacted = _visible_related_agent_identifier(
+                    getattr(meta, 'parent_agent_id', None),
+                    caller_uuid=caller_uuid,
+                    operator_caller=operator_caller,
+                )
+                agent_entry = {
+                    "id": visible_id,
                     # display_name (user-chosen) takes precedence; agent_id is fallback
                     "label": label or public_id,
                     "status": meta.status,
@@ -131,25 +242,29 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                     "last": meta.last_update[:10] if meta.last_update else None,
                     "last_update": meta.last_update,
                     "trust_tier": getattr(meta, 'trust_tier', None),
-                    "parent_agent_id": getattr(meta, 'parent_agent_id', None),
+                    "parent_agent_id": parent_id,
                     "spawn_reason": getattr(meta, 'spawn_reason', None),
-                })
+                }
+                if uuid_redacted:
+                    agent_entry["uuid_redacted"] = True
+                if parent_redacted:
+                    agent_entry["parent_agent_id_redacted"] = True
+                agents.append(agent_entry)
             # Sort: labeled first, then by most recent activity
             agents.sort(key=lambda x: (0 if x.get("label") else 1, -(x.get("updates") or 0), x.get("last_update", "") or ""), reverse=False)
 
             # Always include the requesting agent even if filtered out
-            caller_uuid = None
-            try:
-                from ..context import get_context_agent_id
-                caller_uuid = get_context_agent_id()
-            except Exception:
-                pass
             caller_in_list = caller_uuid and any(a["id"] == caller_uuid for a in agents)
             if caller_uuid and not caller_in_list:
                 caller_meta = mcp_server.agent_metadata.get(caller_uuid)
                 if caller_meta:
                     caller_label = getattr(caller_meta, 'label', None)
                     caller_public = getattr(caller_meta, 'public_agent_id', None) or getattr(caller_meta, 'structured_id', None)
+                    parent_id, parent_redacted = _visible_related_agent_identifier(
+                        getattr(caller_meta, 'parent_agent_id', None),
+                        caller_uuid=caller_uuid,
+                        operator_caller=operator_caller,
+                    )
                     agents.append({
                         "id": caller_uuid,
                         "label": caller_label or caller_public,
@@ -159,10 +274,12 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                         "last": caller_meta.last_update[:10] if caller_meta.last_update else None,
                         "last_update": caller_meta.last_update,
                         "trust_tier": getattr(caller_meta, 'trust_tier', None),
-                        "parent_agent_id": getattr(caller_meta, 'parent_agent_id', None),
+                        "parent_agent_id": parent_id,
                         "spawn_reason": getattr(caller_meta, 'spawn_reason', None),
                         "you": True,
                     })
+                    if parent_redacted:
+                        agents[-1]["parent_agent_id_redacted"] = True
 
             for a in agents:
                 # Mark the requesting agent
@@ -275,8 +392,20 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                 else:
                     inferred_status = "archived"  # Old activity = archived
 
+            visible_agent_id, uuid_redacted = _visible_agent_identifier(
+                agent_id,
+                meta,
+                caller_uuid=caller_uuid,
+                operator_caller=operator_caller,
+            )
+            parent_id, parent_redacted = _visible_related_agent_identifier(
+                getattr(meta, 'parent_agent_id', None),
+                caller_uuid=caller_uuid,
+                operator_caller=operator_caller,
+            )
+
             agent_info = {
-                "agent_id": agent_id,
+                "agent_id": visible_agent_id,
                 "label": getattr(meta, 'label', None),
                 "purpose": getattr(meta, 'purpose', None),
                 "lifecycle_status": inferred_status,
@@ -285,9 +414,13 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                 "total_updates": meta.total_updates,
                 "tags": meta.tags.copy() if meta.tags else [],
                 "notes": meta.notes if meta.notes else "",
-                "parent_agent_id": getattr(meta, 'parent_agent_id', None),
+                "parent_agent_id": parent_id,
                 "spawn_reason": getattr(meta, 'spawn_reason', None),
             }
+            if uuid_redacted:
+                agent_info["agent_id_redacted"] = True
+            if parent_redacted:
+                agent_info["parent_agent_id_redacted"] = True
 
             # Lazy load metrics only if requested (optimization)
             if include_metrics:
@@ -415,6 +548,7 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
             # Trust tier from cached trajectory data (DB fallback done in batch below)
             cached_tier = getattr(meta, 'trust_tier', None)
             agent_info["trust_tier"] = cached_tier
+            agent_info["_agent_uuid"] = agent_id
 
             agents_list.append(agent_info)
 
@@ -426,10 +560,10 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                 from src.identity.trust_tier_routing import resolve_trust_tier
                 from src.db import get_db as _get_db
                 db = _get_db()
-                ids_to_fetch = [a["agent_id"] for a in agents_needing_tiers]
+                ids_to_fetch = [a["_agent_uuid"] for a in agents_needing_tiers]
                 identities = await db.get_identities_batch(ids_to_fetch)
                 for agent_info in agents_needing_tiers:
-                    aid = agent_info["agent_id"]
+                    aid = agent_info["_agent_uuid"]
                     identity = identities.get(aid)
                     if identity and identity.metadata:
                         meta_obj = mcp_server.agent_metadata.get(aid)
@@ -466,6 +600,8 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
             agents_list = agents_list[offset:offset + limit]
         elif offset > 0:
             agents_list = agents_list[offset:]
+        for agent_info in agents_list:
+            agent_info.pop("_agent_uuid", None)
 
         # Group by status if requested (for returned agents only)
         if grouped and not summary_only:

--- a/src/mcp_handlers/lifecycle/resume.py
+++ b/src/mcp_handlers/lifecycle/resume.py
@@ -8,13 +8,11 @@ from typing import Dict, Any, Sequence
 
 from mcp.types import TextContent
 
-from datetime import datetime, timezone
-
 from ..decorators import mcp_tool
 from ..utils import success_response, error_response, require_registered_agent
 from ..error_helpers import agent_not_found_error, system_error as system_error_helper
 from ..support.coerce import resolve_agent_uuid
-from .helpers import _invalidate_agent_cache
+from .helpers import _resume_with_persistence, _invalidate_agent_cache  # noqa: F401
 from src import agent_storage
 from src.logging_utils import get_logger
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
@@ -106,41 +104,17 @@ async def handle_direct_resume_if_safe(arguments: Dict[str, Any]) -> Sequence[Te
     conditions = arguments.get("conditions", [])
     reason = arguments.get("reason", "Direct resume - state is safe")
     event_details = f"Direct resume: {reason}. Conditions: {conditions}"
-    event_entry = {
-        "event": "resumed",
-        "reason": event_details,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-    }
-
-    # Persist FIRST so in-memory state can't diverge from DB on persist failure.
-    # Runtime state (paused_at, lifecycle_events) must be persisted alongside
-    # status or it gets clobbered on the next load_metadata_async(force=True).
-    try:
-        await agent_storage.update_agent(agent_uuid, status="active")
-        await agent_storage.persist_runtime_state(
-            agent_uuid,
-            paused_at=None,
-            loop_detected_at=None,
-            loop_cooldown_until=None,
-            append_lifecycle_event=event_entry,
-        )
-    except Exception as e:
-        logger.warning(f"PostgreSQL update failed for direct_resume: {e}", exc_info=True)
-        return [error_response(
-            f"Failed to resume agent '{agent_id}': persistence error",
-            error_code="PERSIST_FAILED",
-            error_category="system_error",
-            details={"agent_id": agent_id, "cause": str(e)},
-        )]
-
-    await _invalidate_agent_cache(agent_uuid)
-
-    # Persist succeeded — now mutate in-memory state.
-    meta.status = "active"
-    meta.paused_at = None
-    from .self_recovery import clear_loop_detector_state
-    clear_loop_detector_state(meta)
-    meta.add_lifecycle_event("resumed", event_details)
+    persist_error = await _resume_with_persistence(
+        meta,
+        agent_uuid=agent_uuid,
+        event_name="resumed",
+        reason=event_details,
+        error_response_id=agent_id,
+        error_action="resume",
+        storage_module=agent_storage,
+    )
+    if persist_error:
+        return persist_error
 
     response_data = {
         "success": True,

--- a/src/mcp_handlers/lifecycle/self_recovery.py
+++ b/src/mcp_handlers/lifecycle/self_recovery.py
@@ -41,7 +41,11 @@ from ..utils import (
 )
 from ..decorators import mcp_tool
 from ..support.coerce import safe_float, resolve_agent_uuid
-from .helpers import _invalidate_agent_cache
+from .helpers import (
+    _resume_with_persistence,
+    clear_loop_detector_state,  # re-exported for legacy imports from this module
+)
+from src import agent_storage
 from src.logging_utils import get_logger
 from config.governance_config import GovernanceConfig
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
@@ -59,17 +63,6 @@ FORBIDDEN_CONDITIONS = [
 
 MAX_RISK_FOR_SELF_RECOVERY = 0.65  # Matches lifecycle.py review thresholds
 MIN_COHERENCE_FOR_SELF_RECOVERY = 0.35  # Matches lifecycle.py review thresholds
-
-def clear_loop_detector_state(meta) -> None:
-    """Clear loop detector state after successful recovery.
-
-    This prevents the stale pause history from immediately re-triggering
-    the loop detector after self_recovery succeeds.
-    """
-    meta.loop_cooldown_until = None
-    meta.loop_detected_at = None
-    meta.recent_update_timestamps = []
-    meta.recent_decisions = []
 
 def validate_recovery_conditions(conditions: List[str]) -> tuple[bool, Optional[str]]:
     """
@@ -368,7 +361,24 @@ async def handle_quick_resume(arguments: Dict[str, Any]) -> Sequence[TextContent
     # Set before safety checks so even failed attempts suppress Pattern 2/5/6.
     meta_early = mcp_server.agent_metadata.get(agent_uuid)
     if meta_early:
-        meta_early.recovery_attempt_at = datetime.now(timezone.utc).isoformat()
+        recovery_attempt_at = datetime.now(timezone.utc).isoformat()
+        try:
+            await agent_storage.persist_runtime_state(
+                agent_uuid,
+                recovery_attempt_at=recovery_attempt_at,
+            )
+        except Exception as e:
+            logger.warning(
+                f"PostgreSQL persist_runtime_state failed for quick_resume attempt: {e}",
+                exc_info=True,
+            )
+            return [error_response(
+                f"Failed to quick_resume agent '{agent_id}': persistence error",
+                error_code="PERSIST_FAILED",
+                error_category="system_error",
+                details={"agent_id": agent_id, "cause": str(e)},
+            )]
+        meta_early.recovery_attempt_at = recovery_attempt_at
 
     # Get current metrics (use safe_float for uninitialized agents)
     try:
@@ -465,40 +475,17 @@ async def handle_quick_resume(arguments: Dict[str, Any]) -> Sequence[TextContent
     
     previous_status = meta.status
     event_details = f"Quick resume: {reason}"
-    event_entry = {
-        "event": "quick_resumed",
-        "reason": event_details,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-    }
-
-    # Persist FIRST so in-memory state can't diverge from DB on persist failure.
-    # Runtime state (paused_at, lifecycle_events) must be persisted alongside
-    # status or it gets clobbered on the next load_metadata_async(force=True).
-    try:
-        from src import agent_storage
-        await agent_storage.update_agent(agent_uuid, status="active")
-        await agent_storage.persist_runtime_state(
-            agent_uuid,
-            paused_at=None,
-            loop_detected_at=None,
-            loop_cooldown_until=None,
-            append_lifecycle_event=event_entry,
-        )
-        await _invalidate_agent_cache(agent_uuid)
-    except Exception as e:
-        logger.warning(f"PostgreSQL update failed for quick_resume: {e}", exc_info=True)
-        return [error_response(
-            f"Failed to quick_resume agent '{agent_id}': persistence error",
-            error_code="PERSIST_FAILED",
-            error_category="system_error",
-            details={"agent_id": agent_id, "cause": str(e)},
-        )]
-
-    # Persist succeeded — now mutate in-memory state.
-    meta.status = "active"
-    meta.paused_at = None
-    clear_loop_detector_state(meta)
-    meta.add_lifecycle_event("quick_resumed", event_details)
+    persist_error = await _resume_with_persistence(
+        meta,
+        agent_uuid=agent_uuid,
+        event_name="quick_resumed",
+        reason=event_details,
+        error_response_id=agent_id,
+        error_action="quick_resume",
+        storage_module=agent_storage,
+    )
+    if persist_error:
+        return persist_error
 
     return success_response({
         "success": True,
@@ -680,40 +667,18 @@ async def handle_operator_resume_agent(arguments: Dict[str, Any]) -> Sequence[Te
     
     previous_status = target_meta.status
     event_details = f"Resumed by operator {caller_uuid}: {reason}"
-    event_entry = {
-        "event": "operator_resumed",
-        "reason": event_details,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-    }
-
-    # Persist FIRST so in-memory state can't diverge from DB on persist failure.
-    # Runtime state (paused_at, lifecycle_events) must be persisted alongside
-    # status or it gets clobbered on the next load_metadata_async(force=True).
-    try:
-        from src import agent_storage
-        await agent_storage.update_agent(target_agent_id, status="active")
-        await agent_storage.persist_runtime_state(
-            target_agent_id,
-            paused_at=None,
-            loop_detected_at=None,
-            loop_cooldown_until=None,
-            append_lifecycle_event=event_entry,
-        )
-        await _invalidate_agent_cache(target_agent_id)
-    except Exception as e:
-        logger.warning(f"PostgreSQL update failed for operator_resume: {e}", exc_info=True)
-        return [error_response(
-            f"Failed to operator_resume agent '{target_agent_id}': persistence error",
-            error_code="PERSIST_FAILED",
-            error_category="system_error",
-            details={"target_agent_id": target_agent_id, "cause": str(e)},
-        )]
-
-    # Persist succeeded — now mutate in-memory state.
-    target_meta.status = "active"
-    target_meta.paused_at = None
-    clear_loop_detector_state(target_meta)
-    target_meta.add_lifecycle_event("operator_resumed", event_details)
+    persist_error = await _resume_with_persistence(
+        target_meta,
+        agent_uuid=target_agent_id,
+        event_name="operator_resumed",
+        reason=event_details,
+        error_response_id=target_agent_id,
+        error_action="operator_resume",
+        details_key="target_agent_id",
+        storage_module=agent_storage,
+    )
+    if persist_error:
+        return persist_error
     
     return success_response({
         "success": True,

--- a/src/mcp_handlers/lifecycle/stuck.py
+++ b/src/mcp_handlers/lifecycle/stuck.py
@@ -472,9 +472,6 @@ async def handle_detect_stuck_agents(arguments: Dict[str, Any]) -> Sequence:
         List of stuck agents with detection reasons and recovery status
     """
     try:
-        # Reload metadata to ensure we have latest state (async for PostgreSQL)
-        await mcp_server.load_metadata_async()
-
         max_age_minutes = float(arguments.get("max_age_minutes", 30.0))
         critical_timeout = float(arguments.get("critical_margin_timeout_minutes", 5.0))
         tight_timeout = float(arguments.get("tight_margin_timeout_minutes", 15.0))

--- a/src/mcp_handlers/middleware/identity_step.py
+++ b/src/mcp_handlers/middleware/identity_step.py
@@ -67,6 +67,69 @@ def _transport_cache_key(signals) -> Optional[str]:
     return f"sticky:{signals.ip_ua_fingerprint}"
 
 
+def _has_explicit_identity_signal(arguments: Dict[str, Any]) -> bool:
+    """Caller presented an identity or session proof, not just transport hints."""
+    return bool(
+        arguments.get("continuity_token")
+        or arguments.get("client_session_id")
+        or arguments.get("agent_uuid")
+        or arguments.get("agent_id")
+        or arguments.get("force_new")
+    )
+
+
+def _is_weak_http_identity_miss(signals, arguments: Dict[str, Any]) -> bool:
+    """True when dispatch would mint from fingerprint-only HTTP/MCP signals."""
+    if not signals or _has_explicit_identity_signal(arguments):
+        return False
+    if getattr(signals, "transport", None) not in {"http", "rest", "sse", "mcp"}:
+        return False
+    if (
+        getattr(signals, "mcp_session_id", None)
+        or getattr(signals, "x_session_id", None)
+        or getattr(signals, "x_client_id", None)
+        or getattr(signals, "oauth_client_id", None)
+    ):
+        return False
+    return bool(getattr(signals, "ip_ua_fingerprint", None))
+
+
+def _allows_unbound_session_miss(name: str, arguments: Dict[str, Any]) -> bool:
+    """Read-only/browsing tools may run without minting an identity."""
+    read_only_tools = {
+        "health_check",
+        "get_server_info",
+        "list_tools",
+        "describe_tool",
+        "get_governance_metrics",
+        "skills",
+        "search_knowledge_graph",
+        "query_knowledge_graph",
+        "list_knowledge_graph",
+        "get_knowledge_graph",
+        "get_discovery_details",
+        "list_dialectic_sessions",
+        "get_dialectic_session",
+        "dialectic",
+    }
+    if name in read_only_tools:
+        return True
+
+    action = arguments.get("action")
+    if name == "knowledge" and action in {"search", "list", "stats", "details", "get"}:
+        return True
+    if name == "agent" and action in {"list", "get"}:
+        return True
+    if name == "observe" and action in {"agent", "compare", "anomalies", "aggregate", "telemetry"}:
+        return True
+    return False
+
+
+def _is_identity_establishing_tool(name: str) -> bool:
+    """Tools that intentionally create, resume, or bind identity."""
+    return name in {"identity", "onboard", "bind_session", "status"}
+
+
 def update_transport_binding(key: str, agent_uuid: str, session_key: str, source: str) -> None:
     """Set or update a sticky transport binding (in-memory + Redis)."""
     _transport_identity_cache[key] = TransportBinding(
@@ -430,20 +493,58 @@ async def resolve_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
         # leave the lineage-declaration bleed open.
         if (identity_result.get("resume_failed")
                 and identity_result.get("error") == "session_resolve_miss"):
-            read_only_diagnostic_tools = {
-                "health_check",
-                "get_server_info",
-                "list_tools",
-                "describe_tool",
-                "get_governance_metrics",
-                "skills",
-            }
-            if name in read_only_diagnostic_tools:
+            weak_http_miss = _is_weak_http_identity_miss(signals, arguments)
+            if _allows_unbound_session_miss(name, arguments):
                 logger.info(
-                    "[DISPATCH] session_resolve_miss for read-only tool %s "
+                    "[DISPATCH] session_resolve_miss for unbound read-only tool %s "
                     "under %s... — leaving request unbound (no auto-mint)",
                     name, session_key[:20],
                 )
+            elif weak_http_miss and not _is_identity_establishing_tool(name):
+                from config.governance_config import http_identity_strict_mode
+                http_mode = http_identity_strict_mode()
+                msg = (
+                    f"[HTTP_IDENTITY_STRICT] fingerprint-only {signals.transport} "
+                    f"session_resolve_miss for tool {name}; explicit identity required"
+                )
+                if http_mode == "strict":
+                    from ..error_handling import error_response
+                    logger.warning(msg)
+                    return [error_response(
+                        (
+                            "No stable HTTP identity for this request. "
+                            "Pass continuity_token or client_session_id, or call "
+                            "onboard(force_new=true, spawn_reason='new_session') "
+                            "before using this tool."
+                        ),
+                        recovery={
+                            "reason": "weak_http_identity_missing",
+                            "transport": getattr(signals, "transport", None),
+                            "related_tools": ["onboard", "identity", "bind_session"],
+                            "workflow": [
+                                "1. Call onboard(force_new=true, spawn_reason='new_session') to establish this process-instance.",
+                                "2. Save the returned continuity_token or client_session_id.",
+                                "3. Include that proof on subsequent HTTP/MCP tool calls.",
+                            ],
+                        },
+                    )]
+                if http_mode == "log":
+                    logger.warning(msg + " (log mode; dispatch_auto_mint proceeds)")
+                # off/log fall through to legacy dispatch_auto_mint below.
+                if http_mode in {"off", "log"}:
+                    logger.info(
+                        "[DISPATCH] session_resolve_miss for %s... — minting "
+                        "ephemeral dispatch identity (S21-a, spawn_reason="
+                        "dispatch_auto_mint)",
+                        session_key[:20],
+                    )
+                    identity_result = await resolve_session_identity(
+                        session_key,
+                        trajectory_signature=trajectory_sig,
+                        force_new=True,
+                        token_agent_uuid=_token_agent_uuid,
+                        spawn_reason="dispatch_auto_mint",
+                    )
             else:
                 logger.info(
                     "[DISPATCH] session_resolve_miss for %s... — minting "

--- a/src/mcp_handlers/observability/handlers.py
+++ b/src/mcp_handlers/observability/handlers.py
@@ -16,6 +16,16 @@ logger = get_logger(__name__)
 # Import from mcp_server_std module (using shared utility)
 
 
+def _coerce_float_metric(value: Any, default: float) -> float:
+    """Return a finite-ish float for optional metric fields."""
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def _agent_display_name(agent_id: str) -> str | None:
     """Best-effort display label for event payloads."""
     meta = mcp_server.agent_metadata.get(agent_id)
@@ -26,6 +36,45 @@ def _agent_display_name(agent_id: str) -> str | None:
         if value:
             return str(value)
     return None
+
+
+def _resolve_agent_from_memory(target: str) -> str | None:
+    """Resolve a UUID/public label using only the in-memory metadata snapshot."""
+    if len(target) == 36 and target.count('-') == 4:
+        return target if target in mcp_server.agent_metadata else None
+
+    for candidate_uuid, meta in mcp_server.agent_metadata.items():
+        if target in (
+            getattr(meta, 'label', None),
+            getattr(meta, 'display_name', None),
+            getattr(meta, 'structured_id', None),
+            getattr(meta, 'public_agent_id', None),
+        ):
+            return candidate_uuid
+    return None
+
+
+def _get_observable_monitor(agent_id: str):
+    """Return an in-memory/sync-loaded monitor without awaiting DB hydration."""
+    monitor = mcp_server.monitors.get(agent_id)
+    if monitor is not None:
+        return monitor
+
+    try:
+        persisted_state = mcp_server.load_monitor_state(agent_id)
+    except Exception as e:
+        logger.debug(f"Could not load monitor snapshot for {agent_id}: {e}")
+        persisted_state = None
+
+    if not persisted_state:
+        return None
+
+    monitor = mcp_server.get_or_create_monitor(agent_id)
+    try:
+        monitor.state = persisted_state
+    except Exception:
+        pass
+    return monitor
 
 
 @mcp_tool("observe_agent", timeout=15.0, register=False)
@@ -64,35 +113,11 @@ async def handle_observe_agent(arguments: Dict[str, Any]) -> Sequence[TextConten
                 "example": "observe(action='agent', target_agent_id='<agent-label>')"
             }
         )]
-    # Resolve label to UUID if needed
-    agent_id = target
-    if not (len(target) == 36 and target.count('-') == 4):
-        # Looks like a label, resolve to UUID
-        resolved = None
-        try:
-            from src.mcp_handlers.identity.handlers import _find_agent_by_label
-            resolved = await _find_agent_by_label(target)
-        except Exception as e:
-            logger.debug(f"Label DB lookup failed for '{target}': {e}")
-
-        if not resolved:
-            # Fallback: search in-memory metadata by label
-            await mcp_server.load_metadata_async(force=True)
-            for uuid, meta in mcp_server.agent_metadata.items():
-                if getattr(meta, 'label', None) == target:
-                    resolved = uuid
-                    break
-
-        if resolved:
-            agent_id = resolved
-        else:
-            return [error_response(
-                f"Agent '{target}' not found. Use list_agents to see available agents.",
-                recovery={"related_tools": ["list_agents"]}
-            )]
-    # Reload metadata from PostgreSQL (async) and verify agent exists
-    await mcp_server.load_metadata_async(force=True)
-    if agent_id not in mcp_server.agent_metadata:
+    # Resolve label/UUID from the in-memory metadata snapshot only. Avoid
+    # async DB lookups here: MCP/anyio request handlers can deadlock when they
+    # await asyncpg/Redis operations. Background loaders keep this snapshot fresh.
+    agent_id = _resolve_agent_from_memory(target)
+    if not agent_id:
         return [error_response(
             f"Agent '{target}' not found in active metadata. They may need to check in first.",
             recovery={"related_tools": ["list_agents"]}
@@ -101,9 +126,18 @@ async def handle_observe_agent(arguments: Dict[str, Any]) -> Sequence[TextConten
     include_history = arguments.get("include_history", True)
     analyze_patterns_flag = arguments.get("analyze_patterns", True)
     
-    # Load monitor state from disk if not in memory (consistent with get_governance_metrics)
-    monitor = mcp_server.get_or_create_monitor(agent_id)
-    await ensure_hydrated(monitor, agent_id)
+    # Read a monitor snapshot without DB hydration. If no in-memory/sync-loaded
+    # snapshot exists yet, return a clear cache-miss response instead of doing a
+    # request-time async DB fetch.
+    monitor = _get_observable_monitor(agent_id)
+    if monitor is None:
+        return [error_response(
+            f"Observation snapshot for agent '{target}' is not available yet.",
+            recovery={
+                "related_tools": ["get_governance_metrics", "list_agents"],
+                "hint": "Have the agent check in, or retry after background metadata/state loading catches up."
+            }
+        )]
 
     # Perform pattern analysis
     if analyze_patterns_flag:
@@ -317,11 +351,11 @@ async def handle_compare_me_to_similar(arguments: Dict[str, Any]) -> Sequence[Te
     my_metrics = monitor.get_metrics()
     my_meta = mcp_server.agent_metadata.get(agent_id)
     
-    my_E = float(my_metrics.get('E', 0.7))
-    my_I = float(my_metrics.get('I', 0.8))
-    my_S = float(my_metrics.get('S', 0.2))
-    my_coherence = float(my_metrics.get('coherence', 0.5))
-    my_phi = my_metrics.get('phi', 0.0)
+    my_E = _coerce_float_metric(my_metrics.get('E'), 0.7)
+    my_I = _coerce_float_metric(my_metrics.get('I'), 0.8)
+    my_S = _coerce_float_metric(my_metrics.get('S'), 0.2)
+    my_coherence = _coerce_float_metric(my_metrics.get('coherence'), 0.5)
+    my_phi = _coerce_float_metric(my_metrics.get('phi'), 0.0)
     my_verdict = my_metrics.get('verdict', 'caution')
     my_regime = my_metrics.get('regime', 'nominal')
     my_total_updates = my_meta.total_updates if my_meta else 0
@@ -339,10 +373,12 @@ async def handle_compare_me_to_similar(arguments: Dict[str, Any]) -> Sequence[Te
             await ensure_hydrated(other_monitor, other_id)
             other_metrics = other_monitor.get_metrics()
 
-            other_E = float(other_metrics.get('E', 0.7))
-            other_I = float(other_metrics.get('I', 0.8))
-            other_S = float(other_metrics.get('S', 0.2))
-            other_coherence = float(other_metrics.get('coherence', 0.5))
+            other_E = _coerce_float_metric(other_metrics.get('E'), 0.7)
+            other_I = _coerce_float_metric(other_metrics.get('I'), 0.8)
+            other_S = _coerce_float_metric(other_metrics.get('S'), 0.2)
+            other_coherence = _coerce_float_metric(other_metrics.get('coherence'), 0.5)
+            other_phi = _coerce_float_metric(other_metrics.get('phi'), 0.0)
+            other_risk = _coerce_float_metric(other_metrics.get('risk_score'), 0.4)
             
             # Calculate similarity (Euclidean distance in EISV space)
             E_diff = abs(my_E - other_E)
@@ -364,9 +400,9 @@ async def handle_compare_me_to_similar(arguments: Dict[str, Any]) -> Sequence[Te
                         "I": other_I,
                         "S": other_S,
                         "coherence": other_coherence,
-                        "phi": other_metrics.get('phi', 0.0),
+                        "phi": other_phi,
                         "verdict": other_metrics.get('verdict', 'caution'),
-                        "risk_score": other_metrics.get('risk_score', 0.4)
+                        "risk_score": other_risk
                     },
                     "differences": {
                         "E": other_E - my_E,
@@ -412,7 +448,7 @@ async def handle_compare_me_to_similar(arguments: Dict[str, Any]) -> Sequence[Te
             "coherence": my_coherence,
             "phi": my_phi,
             "verdict": my_verdict,
-            "risk_score": my_metrics.get('risk_score', 0.4)
+            "risk_score": _coerce_float_metric(my_metrics.get('risk_score'), 0.4)
         },
         "similar_agents": top_similar,
         "message": f"Found {len(top_similar)} similar agent(s). Here's how you compare:",

--- a/src/mcp_handlers/support/agent_auth.py
+++ b/src/mcp_handlers/support/agent_auth.py
@@ -219,12 +219,23 @@ def require_agent_id(arguments: Dict[str, Any]) -> Tuple[str, Optional[TextConte
         from config.governance_config import identity_strict_mode
         _partc_mode = identity_strict_mode()
         if _partc_mode == "strict":
-            return None, (
-                "No agent_id provided and no session-bound identity. "
-                "Call onboard(force_new=true, parent_agent_id='<prior UUID>' if continuing, "
-                "spawn_reason='new_session') per v2 ontology — declare lineage rather than "
-                "resume via token. Resume by proof requires identity(agent_uuid=X, "
-                "continuity_token=Y) with both signals."
+            from ..error_handling import error_response
+            return None, error_response(
+                (
+                    "No agent_id provided and no session-bound identity. "
+                    "Call onboard(force_new=true, parent_agent_id='<prior UUID>' if continuing, "
+                    "spawn_reason='new_session') per v2 ontology - declare lineage rather than "
+                    "resume via token. Resume by proof requires identity(agent_uuid=X, "
+                    "continuity_token=Y) with both signals."
+                ),
+                recovery={
+                    "reason": "missing_agent_identity",
+                    "related_tools": ["onboard", "identity"],
+                    "hint": (
+                        "Call onboard(force_new=true) for a new process-instance, "
+                        "or pass agent_uuid with a matching continuity_token to resume."
+                    ),
+                },
             )
         elif _partc_mode == "log":
             logger.warning(

--- a/src/services/runtime_queries.py
+++ b/src/services/runtime_queries.py
@@ -29,6 +29,23 @@ def _resolve_agent_identity_view(agent_uuid: str, meta: Any) -> tuple[str, str |
     return public_agent_id, display_name
 
 
+def _metadata_total_updates(meta: Any) -> int:
+    """Return metadata total_updates without letting mock/opaque attrs look truthy."""
+    if meta is None:
+        return 0
+    raw_value = getattr(meta, "total_updates", 0)
+    if isinstance(raw_value, bool):
+        return int(raw_value)
+    if isinstance(raw_value, Real):
+        return int(raw_value)
+    if isinstance(raw_value, str):
+        try:
+            return int(raw_value)
+        except ValueError:
+            return 0
+    return 0
+
+
 def _build_eisv_semantics(metrics: Dict[str, Any], monitor: Any) -> Dict[str, Any]:
     """Attach explicit primary/behavioral/ODE EISV views for read APIs."""
     primary_eisv = {
@@ -146,11 +163,19 @@ async def get_governance_metrics_data(agent_id: str, arguments: Dict[str, Any], 
         verbosity = "minimal" if lite else "full"
 
     monitor = server.get_or_create_monitor(agent_id)
-    # Heal the DB ↔ file persistence split: if the on-disk state file was
-    # dropped (anyio executor stall, crash mid-write, etc.) but core.agent_state
-    # has history, the monitor would otherwise report "uninitialized" forever.
-    from src.agent_monitor_state import hydrate_from_db_if_fresh
-    await hydrate_from_db_if_fresh(monitor, agent_id)
+    meta = server.agent_metadata.get(agent_id)
+
+    # Heal the DB ↔ file persistence split only when there is evidence that
+    # history should exist. Fresh agents with zero updates should return the
+    # uninitialized guidance immediately instead of probing core.agent_state.
+    from src.agent_monitor_state import ensure_hydrated
+    needs_hydration = getattr(monitor, "_needs_hydration", False) is True
+    has_recorded_updates = _metadata_total_updates(meta) > 0
+    if needs_hydration or has_recorded_updates:
+        if not needs_hydration and getattr(monitor.state, "update_count", 0) == 0:
+            monitor._needs_hydration = True
+        await ensure_hydrated(monitor, agent_id)
+
     include_state = arguments.get("include_state", False)
     metrics = monitor.get_metrics(include_state=include_state)
 
@@ -172,7 +197,6 @@ async def get_governance_metrics_data(agent_id: str, arguments: Dict[str, Any], 
     except Exception:
         pass
 
-    meta = server.agent_metadata.get(agent_id)
     public_agent_id, display_name = _resolve_agent_identity_view(agent_id, meta)
     # display_name (user-chosen) takes precedence over agent_id (auto-generated)
     standardized_metrics["agent_id"] = display_name or public_agent_id

--- a/src/trajectory_identity.py
+++ b/src/trajectory_identity.py
@@ -22,6 +22,13 @@ from src.logging_utils import get_logger
 
 logger = get_logger(__name__)
 
+_TRUST_TIER_NAMES = {
+    0: "unknown",
+    1: "emerging",
+    2: "established",
+    3: "verified",
+}
+
 # Paper Definition 2.2: Viability Envelope (EISV bounds)
 VIABILITY_BOUNDS = {
     "E": (0.1, 0.9),
@@ -657,9 +664,36 @@ async def update_current_signature(
             metadata["trajectory_genesis"] = signature.to_dict()
             metadata["trajectory_genesis_at"] = datetime.now(timezone.utc).isoformat()
 
-        # Compute and store trust tier before saving
+        # Compute and store trust tier before saving. Use the substrate-aware
+        # resolver here; otherwise resident agents can be demoted by the raw
+        # session-like trajectory thresholds before the canonical routing gets
+        # a chance to recognize substrate-earned identity.
         old_tier = metadata.get("trust_tier", {}).get("tier", 0) if isinstance(metadata.get("trust_tier"), dict) else 0
-        trust_tier = compute_trust_tier(metadata)
+        try:
+            from src.identity.trust_tier_routing import resolve_trust_tier
+
+            prefetched_tags = metadata.get("tags")
+            prefetched_label = metadata.get("label")
+            if (prefetched_tags is None or prefetched_label is None) and hasattr(db, "get_agent"):
+                agent_record = await db.get_agent(agent_id)
+                if isinstance(agent_record, dict):
+                    if prefetched_tags is None:
+                        prefetched_tags = agent_record.get("tags")
+                    if prefetched_label is None:
+                        prefetched_label = agent_record.get("label")
+
+            if prefetched_tags is not None and prefetched_label is not None:
+                trust_tier = await resolve_trust_tier(
+                    agent_id,
+                    metadata,
+                    prefetched_tags=prefetched_tags,
+                    prefetched_label=prefetched_label,
+                )
+            else:
+                trust_tier = await resolve_trust_tier(agent_id, metadata)
+        except Exception as e:
+            logger.debug(f"Trust tier routing failed, using trajectory-only tier: {e}")
+            trust_tier = compute_trust_tier(metadata)
         metadata["trust_tier"] = trust_tier
         result["trust_tier"] = trust_tier
 
@@ -740,6 +774,24 @@ def compute_trust_tier(metadata: Dict[str, Any]) -> Dict[str, Any]:
     prev_tier = metadata.get("trust_tier", {})
     current_tier = prev_tier.get("tier", 0) if isinstance(prev_tier, dict) else 0
 
+    def stabilize_demoted_tier(result: Dict[str, Any]) -> Dict[str, Any]:
+        """Avoid tier-1 reseed churn for established resident identities."""
+        if (
+            current_tier >= 2
+            and result.get("tier", 0) < 2
+            and result.get("observation_count", 0) >= 50
+            and result.get("identity_confidence", 0.0) >= 0.45
+        ):
+            stabilized = dict(result)
+            stabilized["tier"] = 2
+            stabilized["name"] = _TRUST_TIER_NAMES[2]
+            stabilized["reason"] = (
+                "Retaining established identity assurance; lineage drift is "
+                "reported separately instead of resetting earned trust."
+            )
+            return stabilized
+        return result
+
     # Hysteresis margins: demotion thresholds are 5% below promotion thresholds
     conf_3 = 0.70 if current_tier < 3 else 0.65   # promote at 0.70, demote at 0.65
     lin_3 = 0.80 if current_tier < 3 else 0.75
@@ -776,7 +828,7 @@ def compute_trust_tier(metadata: Dict[str, Any]) -> Dict[str, Any]:
         }
 
     # Tier 1: emerging (has genesis but doesn't meet tier 2)
-    return {
+    return stabilize_demoted_tier({
         "tier": 1,
         "name": "emerging",
         "observation_count": observation_count,
@@ -784,7 +836,7 @@ def compute_trust_tier(metadata: Dict[str, Any]) -> Dict[str, Any]:
         "lineage_similarity": lineage_similarity,
         "reason": f"Building identity ({observation_count} obs, "
                   f"confidence={identity_confidence:.2f})",
-    }
+    })
 
 
 async def get_trajectory_status(agent_id: str) -> Dict[str, Any]:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -265,6 +265,7 @@ _LIFECYCLE_MODULES = [
     "src.mcp_handlers.lifecycle.operations",
     "src.mcp_handlers.lifecycle.stuck",
     "src.mcp_handlers.lifecycle.resume",
+    "src.mcp_handlers.lifecycle.self_recovery",
 ]
 
 
@@ -294,6 +295,7 @@ def patch_agent_storage():
     with patch("src.mcp_handlers.lifecycle.handlers.agent_storage", shared), \
          patch("src.mcp_handlers.lifecycle.mutation.agent_storage", shared), \
          patch("src.mcp_handlers.lifecycle.operations.agent_storage", shared), \
+         patch("src.mcp_handlers.lifecycle.self_recovery.agent_storage", shared), \
          patch("src.mcp_handlers.lifecycle.helpers.agent_storage", shared):
         yield shared
 

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -102,11 +102,14 @@ async def ensure_test_database_schema() -> None:
         await _execute_sql_file(conn, "db/postgres/migrations/012_identity_last_activity_at.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/013_metrics_series.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/014_seed_epoch_2.sql")
+        await _execute_sql_file(conn, "db/postgres/migrations/015_agent_process_bindings.sql")
+        await _execute_sql_file(conn, "db/postgres/migrations/016_same_host_ppid_consistent.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/017_substrate_claims.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/018_bootstrap_synthetic_state.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/019_matview_measured_only.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/020_progress_flat_telemetry.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/021_seed_epoch_3.sql")
+        await _execute_sql_file(conn, "db/postgres/migrations/022_reconcile_schema_migration_drift.sql")
 
         # Ensure partitioned audit tables can accept inserts for current month.
         await _execute_sql_file(conn, "db/postgres/partitions.sql")

--- a/tests/test_dispatch_ephemeral_identity.py
+++ b/tests/test_dispatch_ephemeral_identity.py
@@ -13,6 +13,7 @@ Key behavior:
 """
 
 import asyncio
+import json
 import pytest
 import sys
 from pathlib import Path
@@ -181,6 +182,88 @@ class TestEphemeralIdentityMarking:
         assert resolve_mock.await_count == 1
         assert ctx.bound_agent_id is None
         assert ctx.identity_result is identity_result
+        mock_db.update_session_activity.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_weak_http_session_miss_rejects_regular_tool(self, mock_db, monkeypatch):
+        """Fingerprint-only HTTP/MCP misses require explicit identity proof."""
+        monkeypatch.setenv("UNITARES_HTTP_IDENTITY_STRICT", "strict")
+        identity_result = {
+            "resume_failed": True,
+            "error": "session_resolve_miss",
+            "session_key": "198.51.100.1:ua123",
+        }
+        resolve_mock = AsyncMock(return_value=identity_result)
+        signals = MagicMock(
+            transport="mcp",
+            ip_ua_fingerprint="198.51.100.1:ua123",
+            mcp_session_id=None,
+            x_session_id=None,
+            x_client_id=None,
+            oauth_client_id=None,
+        )
+        patches = [
+            patch("src.mcp_handlers.context.get_session_signals", return_value=signals),
+            patch("src.mcp_handlers.identity.handlers.derive_session_key", new_callable=AsyncMock, return_value="198.51.100.1:ua123"),
+            patch("src.mcp_handlers.identity.handlers.resolve_session_identity", resolve_mock),
+            patch("src.mcp_handlers.context.set_session_context", return_value=MagicMock()),
+            patch("src.db.get_db", return_value=mock_db),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            ctx = DispatchContext()
+            result = await resolve_identity("process_agent_update", {}, ctx)
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        assert isinstance(result, list)
+        data = json.loads(result[0].text)
+        assert data["success"] is False
+        assert data["recovery"]["reason"] == "weak_http_identity_missing"
+        assert resolve_mock.await_count == 1
+        mock_db.update_session_activity.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_weak_http_read_only_session_miss_does_not_auto_mint(self, mock_db, monkeypatch):
+        """Read-only browse tools stay unbound instead of creating ghosts."""
+        monkeypatch.setenv("UNITARES_HTTP_IDENTITY_STRICT", "strict")
+        identity_result = {
+            "resume_failed": True,
+            "error": "session_resolve_miss",
+            "session_key": "203.0.113.8:ua456",
+        }
+        resolve_mock = AsyncMock(return_value=identity_result)
+        signals = MagicMock(
+            transport="mcp",
+            ip_ua_fingerprint="203.0.113.8:ua456",
+            mcp_session_id=None,
+            x_session_id=None,
+            x_client_id=None,
+            oauth_client_id=None,
+        )
+        patches = [
+            patch("src.mcp_handlers.context.get_session_signals", return_value=signals),
+            patch("src.mcp_handlers.identity.handlers.derive_session_key", new_callable=AsyncMock, return_value="203.0.113.8:ua456"),
+            patch("src.mcp_handlers.identity.handlers.resolve_session_identity", resolve_mock),
+            patch("src.mcp_handlers.context.set_session_context", return_value=MagicMock()),
+            patch("src.db.get_db", return_value=mock_db),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            ctx = DispatchContext()
+            result = await resolve_identity("search_knowledge_graph", {"query": "identity bugs"}, ctx)
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        assert not isinstance(result, list)
+        _, _, out_ctx = result
+        assert out_ctx.bound_agent_id is None
+        assert out_ctx.identity_result is identity_result
+        assert resolve_mock.await_count == 1
         mock_db.update_session_activity.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/test_governance_monitor.py
+++ b/tests/test_governance_monitor.py
@@ -1569,13 +1569,15 @@ class TestDriftFloor:
 
 class TestHistoryTrimming:
 
-    def test_history_trimmed_to_window(self):
+    def test_history_trimmed_to_window(self, monkeypatch):
         """Histories should be trimmed to HISTORY_WINDOW."""
         from config.governance_config import config
+        monkeypatch.setattr(config, "HISTORY_WINDOW", 5)
+
         mon = UNITARESMonitor("test-trim", load_state=False)
 
         # Run more updates than the history window
-        num_updates = config.HISTORY_WINDOW + 50
+        num_updates = config.HISTORY_WINDOW + 3
         for _ in range(num_updates):
             mon.update_dynamics({'complexity': 0.5})
 
@@ -1804,5 +1806,3 @@ class TestTacticalPredictionRegistry:
         monitor._open_predictions[pid]["created_at"] = time.monotonic() - 7200.0
         monitor.expire_old_predictions(ttl_seconds=3600.0)
         assert monitor._last_prediction_id is None
-
-

--- a/tests/test_governance_monitor_core.py
+++ b/tests/test_governance_monitor_core.py
@@ -520,15 +520,16 @@ class TestLambda1Update:
         """Lambda1 should stay within configured bounds."""
         monitor = UNITARESMonitor(agent_id="test_lambda1_1", load_state=False)
 
-        # Run many updates to stress test the PI controller
-        for i in range(50):
-            monitor.process_update({
+        # Run enough updates to exercise the PI controller without making the
+        # core unit suite depend on the full process_update pipeline.
+        for i in range(12):
+            monitor.update_dynamics({
                 "response_text": f"Update {i}",
                 "complexity": 0.9 if i % 2 == 0 else 0.1,
                 "parameters": [0.5] * 128,
             })
             # Update lambda1 every few iterations
-            if i % 5 == 0:
+            if i % 3 == 0:
                 monitor.update_lambda1()
 
         from config.governance_config import config
@@ -539,9 +540,9 @@ class TestLambda1Update:
         """Lambda1 should respond to void frequency deviations."""
         monitor = UNITARESMonitor(agent_id="test_lambda1_2", load_state=False)
 
-        # Build up some history first
-        for i in range(20):
-            monitor.process_update({
+        # Build up some history first without invoking the full handler path.
+        for i in range(8):
+            monitor.update_dynamics({
                 "response_text": f"Update {i}",
                 "complexity": 0.5,
                 "parameters": [0.5] * 128,
@@ -817,16 +818,17 @@ class TestUpdateDynamics:
 class TestHistoryTrimming:
     """Tests for history trimming behavior."""
 
-    def test_history_stays_bounded(self):
+    def test_history_stays_bounded(self, monkeypatch):
         """History should not grow unbounded."""
-        monitor = UNITARESMonitor(agent_id="test_history_1", load_state=False)
-
         from config.governance_config import config
+        monkeypatch.setattr(config, "HISTORY_WINDOW", 5)
+
+        monitor = UNITARESMonitor(agent_id="test_history_1", load_state=False)
         max_window = config.HISTORY_WINDOW
 
         # Run many updates
-        for i in range(max_window + 50):
-            monitor.process_update({
+        for i in range(max_window + 3):
+            monitor.update_dynamics({
                 "response_text": f"Update {i}",
                 "complexity": 0.5,
                 "parameters": [0.5] * 128,

--- a/tests/test_handlers_core.py
+++ b/tests/test_handlers_core.py
@@ -390,6 +390,7 @@ class TestGetGovernanceMetrics:
 
         with patch("src.mcp_handlers.core.mcp_server", mock_mcp_server), \
              patch("src.mcp_handlers.core.require_agent_id", return_value=("agent-1", None)), \
+             patch("src.agent_monitor_state.ensure_hydrated", new_callable=AsyncMock) as ensure_hydrated, \
              patch("src.governance_monitor.UNITARESMonitor") as MockMonitorClass:
 
             MockMonitorClass.get_eisv_labels.return_value = {
@@ -401,6 +402,42 @@ class TestGetGovernanceMetrics:
 
             data = json.loads(result[0].text)
             assert "uninitialized" in data["status"]
+            ensure_hydrated.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_get_metrics_hydrates_when_metadata_has_prior_updates(self, mock_mcp_server):
+        """Agents with recorded updates still heal a missing state snapshot."""
+        state = SimpleNamespace(
+            interpret_state=MagicMock(return_value={"health": "unknown", "mode": "unknown", "basin": "unknown"}),
+            unitaires_state=None,
+        )
+        monitor = MagicMock()
+        monitor.state = state
+        monitor._needs_hydration = False
+        monitor.get_metrics.return_value = {
+            "E": 0.5, "I": 0.5, "S": 0.5, "V": 0.0,
+            "coherence": None, "risk_score": None,
+            "initialized": False, "status": "uninitialized",
+        }
+        mock_mcp_server.agent_metadata = {
+            "agent-1": SimpleNamespace(purpose=None, total_updates=3)
+        }
+        mock_mcp_server.get_or_create_monitor.return_value = monitor
+
+        with patch("src.mcp_handlers.core.mcp_server", mock_mcp_server), \
+             patch("src.mcp_handlers.core.require_agent_id", return_value=("agent-1", None)), \
+             patch("src.agent_monitor_state.ensure_hydrated", new_callable=AsyncMock) as ensure_hydrated, \
+             patch("src.governance_monitor.UNITARESMonitor") as MockMonitorClass:
+
+            MockMonitorClass.get_eisv_labels.return_value = {
+                "E": "Energy", "I": "Information", "S": "Entropy", "V": "Void"
+            }
+
+            from src.mcp_handlers.core import handle_get_governance_metrics
+            await handle_get_governance_metrics({"lite": True})
+
+            assert monitor._needs_hydration is True
+            ensure_hydrated.assert_awaited_once_with(monitor, "agent-1")
 
     @pytest.mark.asyncio
     async def test_get_metrics_includes_calibration_feedback(self, mock_mcp_server, mock_monitor):

--- a/tests/test_identity_handlers.py
+++ b/tests/test_identity_handlers.py
@@ -1045,6 +1045,8 @@ class TestHandleIdentityAdapter:
         assert data["uuid"] == test_uuid
         assert data.get("resumed") is True
         assert data["identity_resolution_outcome"] == "resumed"
+        assert data["message"] == "Identity confirmed for 'ExistingAgent'"
+        assert "Welcome back" not in data["message"]
         assert "agent_signature" not in data
 
     @pytest.mark.asyncio
@@ -1438,6 +1440,8 @@ class TestHandleIdentityAdapter:
         assert data.get("resumed") is True
         assert data.get("resumed_by_uuid") is True
         assert data.get("source") != "monitor_cache", "Slow path must not claim monitor_cache"
+        assert data["message"] == "Identity confirmed for 'SlowPathLabel' via UUID"
+        assert "Welcome back" not in data["message"]
         assert db_spy.await_count == 1, "Slow path must verify existence in DB"
         assert status_spy.await_count == 1, "Slow path must verify agent is active"
 
@@ -1744,6 +1748,36 @@ class TestHandleOnboardV2:
             and "identity()" in record.getMessage()
             for record in caplog.records
         ), "v2 gate should emit [FRESH_INSTANCE] log line for arg-less identity()"
+
+    @pytest.mark.asyncio
+    async def test_arg_less_identity_with_context_binding_does_not_fork(self, patch_onboard_deps, mock_db, mock_redis, caplog):
+        """A session-bound identity() call is introspection, not a fresh-process mint."""
+        import logging
+        from src.mcp_handlers.identity.handlers import handle_identity_adapter
+
+        existing_uuid = str(uuid.uuid4())
+        mock_redis.get.return_value = {
+            "agent_id": existing_uuid,
+            "display_agent_id": "Codex_20260429",
+        }
+        mock_db.get_identity.return_value = SimpleNamespace(
+            identity_id="existing-ident",
+            metadata={"agent_id": "Codex_20260429", "label": "Codex"},
+        )
+
+        with patch("src.mcp_handlers.context.get_context_agent_id", return_value=existing_uuid), \
+             caplog.at_level(logging.INFO, logger="src.mcp_handlers.identity.handlers"):
+            result = await handle_identity_adapter({})
+
+        data = parse_result(result)
+        assert data["success"] is True
+        assert data["uuid"] == existing_uuid
+        assert data["identity_status"] == "resumed"
+        assert not any(
+            "[FRESH_INSTANCE]" in record.getMessage()
+            and "identity()" in record.getMessage()
+            for record in caplog.records
+        ), "session-bound identity() must not fire the fresh-instance gate"
 
     @pytest.mark.asyncio
     async def test_proof_signal_bypasses_identity_v2_gate(self, patch_onboard_deps, mock_db, mock_redis, caplog):

--- a/tests/test_identity_path1_fingerprint.py
+++ b/tests/test_identity_path1_fingerprint.py
@@ -11,8 +11,8 @@ added at the PATH 1 cache-hit site:
   - `resolve_session_identity` PATH 1 reads `bind_ip_ua`; on mismatch with
     the current request's fingerprint, fires `identity_hijack_suspected`
     with `path="path1_session_id"`.
-  - In `log` mode (default) the resume still proceeds after emission.
-  - In `strict` mode, mismatched resumes fall through to a fresh session.
+  - In `log` mode the resume still proceeds after emission.
+  - In `strict` mode (default), mismatched resumes fall through to a fresh session.
   - In `off` mode, no check runs — no event, no fall-through.
   - Legacy cache entries without `bind_ip_ua` are treated as unknown
     (no event — preserves backward compat).

--- a/tests/test_identity_path2_ipua_pin.py
+++ b/tests/test_identity_path2_ipua_pin.py
@@ -13,13 +13,13 @@ This module locks in the observation-phase behavior of the helper
   - Fires `identity_hijack_suspected` with `path="path2_ipua_pin"` when the
     session-derivation source is `pinned_onboard_session` and the caller
     supplied no ownership proof.
-  - In `log` mode (default) the resume still proceeds after emission.
+  - In `log` mode the resume still proceeds after emission.
   - In `strict` mode the helper additionally returns `resume=False` so the
     caller mints a fresh identity.
   - In `off` mode, no check runs — no event, no resume flip.
-  - Suppressed when the caller passes continuity_token, client_session_id,
-    agent_id, agent_uuid, or force_new — any of those is treated as proof
-    or a deliberate fresh-ask.
+  - Suppressed when the caller passes continuity_token, agent_uuid, or
+    force_new. agent_id/client_session_id are deliberately not proof on this
+    path because middleware/transport plumbing can populate them.
 """
 from __future__ import annotations
 
@@ -220,8 +220,6 @@ class TestPath2IpuaPinCheck:
         "proof_arg",
         [
             "continuity_token",
-            "client_session_id",
-            "agent_id",
             "agent_uuid",
         ],
     )
@@ -248,6 +246,45 @@ class TestPath2IpuaPinCheck:
 
         assert new_resume is True
         assert captured_events == []
+
+    @pytest.mark.parametrize(
+        "injected_arg",
+        [
+            "agent_id",
+            "client_session_id",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_middleware_injectable_args_do_not_suppress_check(
+        self, monkeypatch, captured_events, broadcaster_stub, injected_arg
+    ):
+        """Middleware/transport-populated values must not neutralize strict mode.
+
+        PR #98 regression: inject_identity populated arguments["agent_id"]
+        before onboard's PATH 2 pin check, so the helper treated an arg-less
+        onboard() as proof-bearing and resumed the pinned UUID.
+        """
+        monkeypatch.setenv("UNITARES_IPUA_PIN_CHECK", "strict")
+
+        from src.mcp_handlers.identity import handlers as h_mod
+
+        with patch(
+            "src.mcp_handlers.context.get_session_resolution_source",
+            return_value="pinned_onboard_session",
+        ), patch.object(h_mod, "_broadcaster", return_value=broadcaster_stub):
+            new_resume = await h_mod._path2_ipua_pin_check(
+                arguments={injected_arg: "some-value"},
+                base_session_key="fp-ipua-abcdef:claude",
+                force_new=False,
+                resume=True,
+            )
+
+        assert new_resume is False
+        hijack_events = [
+            e for e in captured_events
+            if e.get("event_type") == "identity_hijack_suspected"
+        ]
+        assert hijack_events
 
     @pytest.mark.asyncio
     async def test_force_new_suppresses_check(

--- a/tests/test_identity_session.py
+++ b/tests/test_identity_session.py
@@ -1392,6 +1392,54 @@ class TestCacheSession:
             _fallback_cache.clear()
 
     @pytest.mark.asyncio
+    async def test_redis_guard_exception_warns_and_fails_open_by_default(self):
+        """H10: guard read errors must be visible but preserve default behavior."""
+        from src.mcp_handlers.identity.persistence import _redis_slot_blocks_overwrite
+
+        raw_redis = AsyncMock()
+        raw_redis.get = AsyncMock(side_effect=RuntimeError("WRONGTYPE Operation"))
+
+        with patch.dict(os.environ, {"UNITARES_NX_FAIL_CLOSED": "0"}, clear=False), \
+             patch("src.mcp_handlers.identity.persistence.logger.warning") as log_warning:
+            blocked = await _redis_slot_blocks_overwrite(
+                raw_redis,
+                "session:sess-guard-error",
+                "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            )
+
+        assert blocked is False
+        log_warning.assert_called_once()
+        assert "S21A_REDIS_GUARD_READ_FAILED" in log_warning.call_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_redis_guard_exception_can_fail_closed(self, mock_raw_redis):
+        """H10: UNITARES_NX_FAIL_CLOSED=1 refuses writes when guard read fails."""
+        from src.mcp_handlers.identity.handlers import _cache_session
+
+        mock_raw_redis.get = AsyncMock(side_effect=RuntimeError("connection reset"))
+        mock_raw_redis.setex = AsyncMock()
+
+        async def _get_raw():
+            return mock_raw_redis
+
+        mock_cache = AsyncMock()
+        mock_cache.bind = AsyncMock()
+
+        with patch.dict(os.environ, {"UNITARES_NX_FAIL_CLOSED": "1"}, clear=False), \
+             patch("src.mcp_handlers.identity.persistence._redis_cache", None), \
+             patch("src.cache.get_session_cache", return_value=mock_cache), \
+             patch("src.cache.redis_client.get_redis", new=_get_raw):
+            await _cache_session(
+                "sess-guard-fail-closed",
+                "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+                display_agent_id="GuardFailure",
+                mint_guard=True,
+            )
+
+        mock_raw_redis.setex.assert_not_called()
+        mock_cache.bind.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_cache_without_display_id_uses_bind(self):
         """Without display_agent_id, uses SessionCache.bind()."""
         from src.mcp_handlers.identity.handlers import _cache_session

--- a/tests/test_identity_strict_defaults.py
+++ b/tests/test_identity_strict_defaults.py
@@ -1,0 +1,33 @@
+"""Strict-by-default identity gate configuration."""
+
+
+def test_identity_strict_mode_defaults_to_strict(monkeypatch):
+    monkeypatch.delenv("UNITARES_IDENTITY_STRICT", raising=False)
+
+    from config.governance_config import identity_strict_mode
+
+    assert identity_strict_mode() == "strict"
+
+
+def test_identity_strict_mode_invalid_env_falls_back_to_strict(monkeypatch):
+    monkeypatch.setenv("UNITARES_IDENTITY_STRICT", "bogus")
+
+    from config.governance_config import identity_strict_mode
+
+    assert identity_strict_mode() == "strict"
+
+
+def test_session_fingerprint_check_defaults_to_strict(monkeypatch):
+    monkeypatch.delenv("UNITARES_SESSION_FINGERPRINT_CHECK", raising=False)
+
+    from config.governance_config import session_fingerprint_check_mode
+
+    assert session_fingerprint_check_mode() == "strict"
+
+
+def test_session_fingerprint_invalid_env_falls_back_to_strict(monkeypatch):
+    monkeypatch.setenv("UNITARES_SESSION_FINGERPRINT_CHECK", "bogus")
+
+    from config.governance_config import session_fingerprint_check_mode
+
+    assert session_fingerprint_check_mode() == "strict"

--- a/tests/test_kg_search.py
+++ b/tests/test_kg_search.py
@@ -1757,6 +1757,52 @@ class TestIssue165FtsOperator:
         assert "Invalid operator" in data["error"]
 
 
+class TestKgSearchComplexityCeiling:
+    """Broad auto queries stay inside the MCP tool budget."""
+
+    @pytest.mark.asyncio
+    async def test_auto_hybrid_skips_long_query_unless_forced(self, patch_common, monkeypatch):
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        monkeypatch.setenv("UNITARES_ENABLE_HYBRID", "1")
+        disc = make_discovery(id="sem-1", summary="Semantic match")
+        mock_graph.semantic_search = AsyncMock(return_value=[(disc, 0.82)])
+        mock_graph.full_text_search = AsyncMock(return_value=[disc])
+
+        result = await handle_search_knowledge_graph({
+            "query": "one two three four five six",
+        })
+        data = parse_result(result)
+
+        assert data["success"] is True
+        assert data["search_mode_used"] == "semantic"
+        assert "hybrid_skipped_reason" in data
+        mock_graph.semantic_search.assert_awaited_once()
+        mock_graph.full_text_search.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_long_fts_query_skips_automatic_or_fallback(self, patch_common):
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        del mock_graph.semantic_search
+        mock_graph.full_text_search = AsyncMock(return_value=[])
+
+        result = await handle_search_knowledge_graph({
+            "query": "one two three four five six",
+        })
+        data = parse_result(result)
+
+        assert data["success"] is True
+        assert data["search_mode_used"] == "fts"
+        assert data["fts_operator_used"] == "AND"
+        assert data["fts_fallback_used"] is False
+        assert "fts_fallback_skipped_reason" in data
+        assert mock_graph.full_text_search.await_count == 1
+        assert mock_graph.full_text_search.await_args.kwargs["operator"] == "AND"
+
+
 class TestIssue165ListScope:
     """list response declares its scope and accepts epoch_scope/including_cold."""
 
@@ -1864,6 +1910,5 @@ class TestIssue165Provenance:
         mock_graph.add_discovery.assert_awaited()
         node = mock_graph.add_discovery.await_args.args[0]
         assert node.provenance["source"] == "self_recovery_quick_resume"
-
 
 

--- a/tests/test_lifecycle_agents.py
+++ b/tests/test_lifecycle_agents.py
@@ -197,6 +197,88 @@ class TestListAgentsLite:
             assert by_id["parent-agent"]["spawn_reason"] is None
             assert by_id["orphan-agent"]["parent_agent_id"] is None
 
+    @pytest.mark.asyncio
+    async def test_lite_redacts_uuid_ids_for_non_operator(self, server):
+        parent_uuid = "11111111-2222-3333-4444-555555555555"
+        child_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        server.agent_metadata = {
+            parent_uuid: make_agent_meta(label="Parent", total_updates=20),
+            child_uuid: make_agent_meta(
+                label="Child",
+                total_updates=3,
+                parent_agent_id=parent_uuid,
+                spawn_reason="new_session",
+            ),
+        }
+        with patch_lifecycle_server(server):
+            from src.mcp_handlers.lifecycle.handlers import handle_list_agents
+            result = await handle_list_agents({"lite": True})
+            data = _parse(result)
+
+            by_label = {a["label"]: a for a in data["agents"]}
+            assert by_label["Child"]["id"] == "Child"
+            assert by_label["Child"]["uuid_redacted"] is True
+            assert by_label["Child"]["parent_agent_id"] == "Parent"
+            assert by_label["Child"]["parent_agent_id_redacted"] is True
+            assert by_label["Parent"]["id"] == "Parent"
+
+    @pytest.mark.asyncio
+    async def test_lite_operator_can_see_uuid_ids(self, server, monkeypatch):
+        parent_uuid = "11111111-2222-3333-4444-555555555555"
+        child_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        server.agent_metadata = {
+            parent_uuid: make_agent_meta(label="Parent", total_updates=20),
+            child_uuid: make_agent_meta(
+                label="Child",
+                total_updates=3,
+                parent_agent_id=parent_uuid,
+            ),
+        }
+        monkeypatch.setenv("UNITARES_OPERATOR_TOKENS", "test-operator-token")
+
+        from src.mcp_handlers.context import (
+            SessionSignals,
+            reset_session_signals,
+            set_session_signals,
+        )
+
+        token = set_session_signals(
+            SessionSignals(unitares_operator_token="test-operator-token")
+        )
+        try:
+            with patch_lifecycle_server(server):
+                from src.mcp_handlers.lifecycle.handlers import handle_list_agents
+                result = await handle_list_agents({"lite": True})
+                data = _parse(result)
+        finally:
+            reset_session_signals(token)
+
+        by_label = {a["label"]: a for a in data["agents"]}
+        assert by_label["Child"]["id"] == child_uuid
+        assert by_label["Child"]["parent_agent_id"] == parent_uuid
+        assert "uuid_redacted" not in by_label["Child"]
+        assert by_label["Parent"]["id"] == parent_uuid
+
+    @pytest.mark.asyncio
+    async def test_lite_non_operator_still_sees_own_uuid(self, server):
+        self_uuid = "11111111-2222-3333-4444-555555555555"
+        other_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        server.agent_metadata = {
+            self_uuid: make_agent_meta(label="Self", total_updates=20),
+            other_uuid: make_agent_meta(label="Other", total_updates=3),
+        }
+        with patch_lifecycle_server(server), \
+             patch("src.mcp_handlers.context.get_context_agent_id", return_value=self_uuid):
+            from src.mcp_handlers.lifecycle.handlers import handle_list_agents
+            result = await handle_list_agents({"lite": True})
+            data = _parse(result)
+
+        by_label = {a["label"]: a for a in data["agents"]}
+        assert by_label["Self"]["id"] == self_uuid
+        assert by_label["Self"]["you"] is True
+        assert by_label["Other"]["id"] == "Other"
+        assert by_label["Other"]["uuid_redacted"] is True
+
 
 # ============================================================================
 # handle_list_agents - Non-Lite (Full) Mode
@@ -337,6 +419,44 @@ class TestListAgentsFull:
             assert by_id["child-agent"]["parent_agent_id"] == "parent-agent"
             assert by_id["child-agent"]["spawn_reason"] == "new_session"
             assert by_id["parent-agent"]["parent_agent_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_full_mode_redacts_uuid_ids_for_non_operator(self, server):
+        parent_uuid = "11111111-2222-3333-4444-555555555555"
+        child_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        server.agent_metadata = {
+            parent_uuid: make_agent_meta(
+                status="active", label="Parent", total_updates=20, notes="", trust_tier="known"
+            ),
+            child_uuid: make_agent_meta(
+                status="active",
+                label="Child",
+                total_updates=3,
+                notes="",
+                parent_agent_id=parent_uuid,
+                spawn_reason="new_session",
+                trust_tier="known",
+            ),
+        }
+        health_status = MagicMock()
+        health_status.value = "healthy"
+        server.health_checker = MagicMock()
+        server.health_checker.get_health_status.return_value = (health_status, {})
+        server.monitors = {}
+
+        with patch_lifecycle_server(server):
+            from src.mcp_handlers.lifecycle.handlers import handle_list_agents
+            result = await handle_list_agents({
+                "lite": False, "grouped": False, "include_metrics": False,
+            })
+            data = _parse(result)
+
+        by_label = {a["label"]: a for a in data["agents"]}
+        assert by_label["Child"]["agent_id"] == "Child"
+        assert by_label["Child"]["agent_id_redacted"] is True
+        assert by_label["Child"]["parent_agent_id"] == "Parent"
+        assert by_label["Child"]["parent_agent_id_redacted"] is True
+        assert by_label["Parent"]["agent_id"] == "Parent"
 
     @pytest.mark.asyncio
     async def test_full_mode_status_filter_all(self, server):
@@ -2389,4 +2509,3 @@ class TestMarkResponseCompleteEdgeCases:
 # ============================================================================
 # handle_direct_resume_if_safe - edge cases (lines 1317, 1355-1356, 1391-1392)
 # ============================================================================
-

--- a/tests/test_lifecycle_clobber.py
+++ b/tests/test_lifecycle_clobber.py
@@ -128,6 +128,67 @@ class TestSelfRecoveryReviewPersistsRecoveryAttempt:
                 "recovery_attempt_at must be persisted BEFORE the safety-check gate"
 
 
+class TestQuickResumePersistsRecoveryAttempt:
+    @pytest.mark.asyncio
+    async def test_recovery_attempt_at_persisted_before_safety_checks(self):
+        meta = make_agent_meta(status="paused", paused_at="2026-04-16T10:00:00+00:00")
+        server = _server_with_agent(meta)
+
+        with patch_agent_storage() as storage, \
+             patch("src.mcp_handlers.lifecycle.self_recovery.verify_agent_ownership",
+                   MagicMock(return_value=True)), \
+             patch_lifecycle_server(server,
+                                    require_registered=(AGENT_ID, None),
+                                    **{"src.mcp_handlers.lifecycle.self_recovery.resolve_agent_uuid":
+                                       MagicMock(return_value=AGENT_ID)}):
+            storage.update_agent = AsyncMock(return_value=True)
+            storage.persist_runtime_state = AsyncMock(return_value=True)
+
+            from src.mcp_handlers.lifecycle.self_recovery import handle_quick_resume
+            await handle_quick_resume({"agent_id": AGENT_ID})
+
+            assert storage.persist_runtime_state.await_count >= 1, \
+                "quick_resume must persist recovery_attempt_at before safety checks"
+            first_call = storage.persist_runtime_state.await_args_list[0].kwargs
+            assert first_call.get("recovery_attempt_at"), \
+                "recovery_attempt_at must be persisted BEFORE the safety-check gate"
+            assert meta.recovery_attempt_at == first_call["recovery_attempt_at"]
+
+
+class TestOperatorResumePersistsRuntimeState:
+    @pytest.mark.asyncio
+    async def test_operator_resume_persists_paused_at_and_lifecycle_event(self):
+        caller_id = "operator-under-test"
+        target_meta = make_agent_meta(status="paused", paused_at="2026-04-16T10:00:00+00:00")
+        caller_meta = make_agent_meta(label="Operator")
+        server = make_mock_server()
+        server.agent_metadata = {caller_id: caller_meta, AGENT_ID: target_meta}
+        server.monitors = {AGENT_ID: make_monitor()}
+        server.get_or_create_monitor = MagicMock(return_value=make_monitor())
+
+        with patch_agent_storage() as storage, \
+             patch_lifecycle_server(server,
+                                    require_registered=(caller_id, None),
+                                    **{"src.mcp_handlers.lifecycle.self_recovery.resolve_agent_uuid":
+                                       MagicMock(return_value=caller_id)}):
+            storage.update_agent = AsyncMock(return_value=True)
+            storage.persist_runtime_state = AsyncMock(return_value=True)
+
+            from src.mcp_handlers.lifecycle.self_recovery import handle_operator_resume_agent
+            await handle_operator_resume_agent({
+                "_agent_uuid": caller_id,
+                "target_agent_id": AGENT_ID,
+                "reason": "test operator recovery",
+            })
+
+            storage.update_agent.assert_awaited_once_with(AGENT_ID, status="active")
+            storage.persist_runtime_state.assert_awaited_once()
+            kwargs = storage.persist_runtime_state.await_args.kwargs
+            assert kwargs.get("paused_at") is None
+            event = kwargs.get("append_lifecycle_event")
+            assert event and event.get("event") == "operator_resumed"
+
+
 class TestPersistRuntimeStateContract:
     """Contract tests for the new agent_storage.persist_runtime_state helper."""
 

--- a/tests/test_lifecycle_recovery.py
+++ b/tests/test_lifecycle_recovery.py
@@ -368,6 +368,7 @@ class TestDetectStuckAgents:
             data = _parse(result)
             assert data["summary"]["total_stuck"] >= 1
             assert len(data["stuck_agents"]) >= 1
+            server.load_metadata_async.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_no_stuck_agents(self, server):
@@ -1077,13 +1078,13 @@ class TestDetectStuckAgentsException:
     @pytest.fixture
     def server(self):
         server = make_mock_server()
-        server.load_metadata_async = AsyncMock(side_effect=RuntimeError("DB down"))
         return server
 
     @pytest.mark.asyncio
     async def test_top_level_exception_returns_error(self, server):
         """Lines 2243-2245: top-level exception returns error response."""
-        with patch_lifecycle_server(server):
+        with patch_lifecycle_server(server), \
+             patch("src.mcp_handlers.lifecycle.stuck._detect_stuck_agents", side_effect=RuntimeError("detector down")):
             from src.mcp_handlers.lifecycle.handlers import handle_detect_stuck_agents
             result = await handle_detect_stuck_agents({})
             text = result[0].text

--- a/tests/test_migration_registry_versions.py
+++ b/tests/test_migration_registry_versions.py
@@ -1,0 +1,50 @@
+"""Static checks for PostgreSQL migration registry metadata."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+MIGRATIONS_DIR = Path(__file__).resolve().parent.parent / "db" / "postgres" / "migrations"
+
+
+def test_migration_registry_versions_match_filenames():
+    """Files that register a migration must claim their filename version."""
+    mismatches = []
+    missing_registry = []
+
+    for path in sorted(MIGRATIONS_DIR.glob("[0-9][0-9][0-9]_*.sql")):
+        file_version = int(path.name.split("_", 1)[0])
+        text = path.read_text()
+        if "INSERT INTO core.schema_migrations" not in text:
+            continue
+
+        insert_blocks = re.findall(
+            r"INSERT\s+INTO\s+core\.schema_migrations\s*\([^)]*version[^)]*\)"
+            r"\s*VALUES\s*(.*?)(?:ON\s+CONFLICT|;)",
+            text,
+            re.IGNORECASE | re.DOTALL,
+        )
+        registered_versions = {
+            int(v)
+            for block in insert_blocks
+            for v in re.findall(r"\(\s*(\d+)\s*,", block)
+        }
+        if not registered_versions:
+            missing_registry.append(path.name)
+            continue
+
+        if file_version not in registered_versions:
+            mismatches.append(
+                f"{path.name} registers {sorted(registered_versions)}, missing {file_version}"
+            )
+        if path.name != "022_reconcile_schema_migration_drift.sql":
+            extra_versions = registered_versions - {file_version}
+            if extra_versions:
+                mismatches.append(
+                    f"{path.name} also registers {sorted(extra_versions)}, expected only {file_version}"
+                )
+
+    assert not missing_registry, "Could not parse migration registry inserts: " + ", ".join(missing_registry)
+    assert not mismatches, "Migration version mismatch: " + "; ".join(mismatches)

--- a/tests/test_observability_handlers.py
+++ b/tests/test_observability_handlers.py
@@ -208,6 +208,7 @@ class TestHandleObserveAgent:
         assert data["success"] is True
         assert data["agent_id"] == uuid
         assert "observation" in data
+        server.load_metadata_async.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_happy_path_without_pattern_analysis(self):
@@ -292,27 +293,27 @@ class TestHandleObserveAgent:
 
     @pytest.mark.asyncio
     async def test_label_resolution(self):
-        """When target is a label (not UUID format), resolve via _find_agent_by_label."""
+        """When target is a label (not UUID format), resolve from in-memory metadata."""
         uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-        server = _build_mock_server(agent_ids=[uuid])
+        meta = _make_metadata(uuid, label="Lumen")
+        server = _build_mock_server(
+            monitors_dict={uuid: _make_monitor(uuid)},
+            metadata_dict={uuid: meta},
+        )
 
         with patch(_PATCH_SERVER, server), \
-             patch(_PATCH_CTX, return_value="caller-uuid"), \
-             patch(
-                 "src.mcp_handlers.identity.handlers._find_agent_by_label",
-                 new_callable=AsyncMock,
-                 return_value=uuid,
-             ):
+             patch(_PATCH_CTX, return_value="caller-uuid"):
             from src.mcp_handlers.observability.handlers import handle_observe_agent
             result = await handle_observe_agent({"target_agent_id": "Lumen"})
 
         data = parse_result(result)
         assert data["success"] is True
         assert data["agent_id"] == uuid
+        server.load_metadata_async.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_label_resolution_metadata_fallback(self):
-        """When _find_agent_by_label returns None, fall back to metadata label search."""
+        """Observe does not call async label lookup; metadata label search is enough."""
         uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
         meta = _make_metadata(uuid, label="Lumen")
         server = _build_mock_server(
@@ -322,17 +323,19 @@ class TestHandleObserveAgent:
 
         with patch(_PATCH_SERVER, server), \
              patch(_PATCH_CTX, return_value="caller-uuid"), \
-             patch(
-                 "src.mcp_handlers.identity.handlers._find_agent_by_label",
-                 new_callable=AsyncMock,
-                 return_value=None,
-             ):
+            patch(
+                "src.mcp_handlers.identity.handlers._find_agent_by_label",
+                new_callable=AsyncMock,
+                return_value=None,
+            ) as mock_find:
             from src.mcp_handlers.observability.handlers import handle_observe_agent
             result = await handle_observe_agent({"target_agent_id": "Lumen"})
 
         data = parse_result(result)
         assert data["success"] is True
         assert data["agent_id"] == uuid
+        mock_find.assert_not_awaited()
+        server.load_metadata_async.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_label_not_found(self):
@@ -601,6 +604,43 @@ class TestHandleCompareMeToSimilar:
         assert len(data["similar_agents"]) >= 1
 
     @pytest.mark.asyncio
+    async def test_none_metrics_use_defaults_instead_of_crashing(self):
+        """Sparse hydrated state can return explicit None values for metrics."""
+        my_uuid = "aaaaaaaa-bbbb-cccc-dddd-000000000000"
+        other_uuid = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
+        none_metrics = {
+            "E": None,
+            "I": None,
+            "S": None,
+            "coherence": None,
+            "phi": None,
+            "risk_score": None,
+        }
+        monitors = {
+            my_uuid: _make_monitor(my_uuid, metrics=none_metrics),
+            other_uuid: _make_monitor(other_uuid, metrics=none_metrics),
+        }
+        metadata = {
+            my_uuid: _make_metadata(my_uuid, status="active", total_updates=1),
+            other_uuid: _make_metadata(other_uuid, status="active", total_updates=1),
+        }
+        server = _build_mock_server(monitors_dict=monitors, metadata_dict=metadata)
+
+        with self._patches(server, my_uuid):
+            from src.mcp_handlers.observability.handlers import handle_compare_me_to_similar
+            result = await handle_compare_me_to_similar({"agent_id": my_uuid})
+
+        data = parse_result(result)
+        assert data["success"] is True
+        assert data["my_metrics"]["E"] == 0.7
+        assert data["my_metrics"]["I"] == 0.8
+        assert data["my_metrics"]["S"] == 0.2
+        assert data["my_metrics"]["coherence"] == 0.5
+        assert data["my_metrics"]["phi"] == 0.0
+        assert data["my_metrics"]["risk_score"] == 0.4
+        assert data["similar_agents"][0]["metrics"]["risk_score"] == 0.4
+
+    @pytest.mark.asyncio
     async def test_no_similar_agents(self):
         """No other agents match -> returns message about no similar agents."""
         my_uuid = "aaaaaaaa-bbbb-cccc-dddd-000000000000"
@@ -722,6 +762,26 @@ class TestHandleCompareMeToSimilar:
 
         data = parse_result(result)
         assert data["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_consolidated_similar_uses_session_bound_identity(self):
+        """observe(action='similar') works without explicit agent_id when context is bound."""
+        my_uuid = "aaaaaaaa-bbbb-cccc-dddd-000000000000"
+        others = {
+            "aaaaaaaa-bbbb-cccc-dddd-111111111111": {
+                "E": 0.76, "I": 0.84, "S": 0.16, "coherence": 0.64,
+                "total_updates": 8,
+            },
+        }
+        server = self._setup_server_with_similar(my_uuid, others)
+
+        with self._patches(server, my_uuid):
+            from src.mcp_handlers.consolidated import handle_observe
+            result = await handle_observe({"action": "similar"})
+
+        data = parse_result(result)
+        assert data["success"] is True
+        assert data["agent_id"] == my_uuid
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_self_recovery.py
+++ b/tests/test_self_recovery.py
@@ -490,8 +490,11 @@ class TestQuickResume:
             assert data.get("success") is True or data.get("recovered") is True
 
             mock_update.assert_awaited_once_with("test-uuid", status="active")
-            mock_persist.assert_awaited_once()
-            call = mock_persist.await_args
+            assert mock_persist.await_count == 2
+            attempt_call = mock_persist.await_args_list[0]
+            assert attempt_call.args[0] == "test-uuid"
+            assert attempt_call.kwargs["recovery_attempt_at"]
+            call = mock_persist.await_args_list[-1]
             assert call.args[0] == "test-uuid"
             assert call.kwargs["paused_at"] is None
             assert call.kwargs["loop_detected_at"] is None

--- a/tests/test_trajectory_integration.py
+++ b/tests/test_trajectory_integration.py
@@ -348,6 +348,97 @@ class TestUpdateCurrentSignature:
             assert "warning" in result
             assert result["lineage_similarity"] < 0.6
 
+    @pytest.mark.asyncio
+    async def test_established_drift_does_not_demote_or_reseed(self):
+        """Lineage drift should not reset earned trust into a reseed/promotion loop."""
+        from src.trajectory_identity import update_current_signature, TrajectorySignature
+
+        current_sig = TrajectorySignature(
+            attractor={"center": [0.9, 0.9, 0.9, 0.9]},
+            beliefs={"values": [0.9, 0.9, 0.9]},
+            recovery={"tau_estimate": 100.0},
+            stability_score=0.95,
+            observation_count=300,
+            identity_confidence=0.9,
+        )
+
+        with patch('src.db.get_db') as mock_db, \
+             patch('src.trajectory_identity.store_genesis_signature',
+                   new_callable=AsyncMock) as mock_store, \
+             patch('src.broadcaster.broadcaster_instance') as mock_bc:
+            mock_identity = MagicMock()
+            mock_identity.metadata = {
+                "trajectory_genesis": {
+                    "attractor": {"center": [0.1, 0.1, 0.1, 0.1]},
+                    "beliefs": {"values": [0.1, 0.1, 0.1]},
+                    "recovery": {"tau_estimate": 5.0},
+                    "stability_score": 0.2,
+                    "observation_count": 10,
+                    "identity_confidence": 0.4,
+                },
+                "trust_tier": {"tier": 2, "name": "established"},
+            }
+
+            mock_db_instance = AsyncMock()
+            mock_db_instance.get_identity = AsyncMock(return_value=mock_identity)
+            mock_db_instance.update_identity_metadata = AsyncMock()
+            mock_db.return_value = mock_db_instance
+
+            result = await update_current_signature("test-uuid", current_sig)
+
+            assert result["is_anomaly"] is True
+            assert result["trust_tier"]["tier"] == 2
+            mock_store.assert_not_called()
+            for call in mock_bc.broadcast_event.call_args_list:
+                assert call.args[0] != "identity_assurance_change"
+
+    @pytest.mark.asyncio
+    async def test_substrate_earned_drift_keeps_verified_assurance(self):
+        """Resident substrate routing should keep verified trust separate from drift alerts."""
+        from src.trajectory_identity import update_current_signature, TrajectorySignature
+
+        current_sig = TrajectorySignature(
+            attractor={"center": [0.9, 0.9, 0.9, 0.9]},
+            beliefs={"values": [0.9, 0.9, 0.9]},
+            recovery={"tau_estimate": 100.0},
+            stability_score=0.95,
+            observation_count=300,
+            identity_confidence=0.9,
+        )
+
+        with patch('src.db.get_db') as mock_db, \
+             patch('src.trajectory_identity.store_genesis_signature',
+                   new_callable=AsyncMock) as mock_store, \
+             patch('src.broadcaster.broadcaster_instance') as mock_bc:
+            mock_identity = MagicMock()
+            mock_identity.metadata = {
+                "tags": ["embodied"],
+                "label": "Sentinel",
+                "trajectory_genesis": {
+                    "attractor": {"center": [0.1, 0.1, 0.1, 0.1]},
+                    "beliefs": {"values": [0.1, 0.1, 0.1]},
+                    "recovery": {"tau_estimate": 5.0},
+                    "stability_score": 0.2,
+                    "observation_count": 10,
+                    "identity_confidence": 0.4,
+                },
+                "trust_tier": {"tier": 3, "name": "verified"},
+            }
+
+            mock_db_instance = AsyncMock()
+            mock_db_instance.get_identity = AsyncMock(return_value=mock_identity)
+            mock_db_instance.update_identity_metadata = AsyncMock()
+            mock_db.return_value = mock_db_instance
+
+            result = await update_current_signature("test-uuid", current_sig)
+
+            assert result["is_anomaly"] is True
+            assert result["trust_tier"]["tier"] == 3
+            assert result["trust_tier"]["name"] == "verified"
+            assert result["trust_tier"]["source"] == "substrate_earned"
+            mock_store.assert_not_called()
+            for call in mock_bc.broadcast_event.call_args_list:
+                assert call.args[0] != "identity_assurance_change"
 
     @pytest.mark.asyncio
     async def test_reseed_preserves_trust_tier_no_spurious_broadcast(self):
@@ -749,6 +840,35 @@ class TestComputeTrustTier:
         assert result["tier"] <= 1
         assert result["lineage_similarity"] is not None
         assert result["lineage_similarity"] < 0.7
+
+    def test_established_identity_does_not_fall_back_to_emerging_on_lineage_drift(self):
+        """Earned trust should not churn through tier 1 and trigger reseed cycles."""
+        from src.trajectory_identity import compute_trust_tier
+        metadata = {
+            "trajectory_genesis": {
+                "attractor": {"center": [0.1, 0.1, 0.1, 0.1]},
+                "beliefs": {"values": [0.1, 0.1, 0.1]},
+                "recovery": {"tau_estimate": 5.0},
+                "stability_score": 0.2,
+                "observation_count": 10,
+                "identity_confidence": 0.4,
+            },
+            "trajectory_current": {
+                "attractor": {"center": [0.9, 0.9, 0.9, 0.9]},
+                "beliefs": {"values": [0.9, 0.9, 0.9]},
+                "recovery": {"tau_estimate": 100.0},
+                "stability_score": 0.95,
+                "observation_count": 300,
+                "identity_confidence": 0.9,
+            },
+            "trust_tier": {"tier": 2, "name": "established"},
+        }
+        result = compute_trust_tier(metadata)
+        assert result["tier"] == 2
+        assert result["name"] == "established"
+        assert result["lineage_similarity"] is not None
+        assert result["lineage_similarity"] < 0.7
+        assert "Retaining established" in result["reason"]
 
     def test_result_has_all_fields(self):
         """Every tier result should include required fields."""

--- a/tests/test_unitares_cli_script.py
+++ b/tests/test_unitares_cli_script.py
@@ -149,7 +149,7 @@ def cli_env(tmp_path, mcp_test_server):
     agent_name = _unique_agent_name()
     env["UNITARES_AGENT"] = agent_name
     env["UNITARES_SESSION_FILE"] = str(tmp_path / "session.json")
-    env["UNITARES_TIMEOUT"] = "15"
+    env["UNITARES_TIMEOUT"] = "30"
     yield env
     try:
         req = urllib.request.Request(
@@ -171,7 +171,7 @@ def _run(env, *args, check=True):
         env=env,
         capture_output=True,
         text=True,
-        timeout=30,
+        timeout=60,
     )
     if check and result.returncode != 0:
         raise AssertionError(


### PR DESCRIPTION
**Conflict with #236 — pick one.**

Both this branch and PR #236 fix the same migration-drift problem (slot-18 phantom + missing 014/015/016 + synthetic-column hot-fix). Different strategies:

- **#236 (rename strategy)** — renames 018→022, 019→023, fixes latent bug in 020, ships handoff doc, requires manual psql apply of 014/015/016/020/021/022/023.
- **This PR (single-reconciliation strategy)** — adds `022_reconcile_schema_migration_drift.sql` that does the missing 014/015/016/018/019 DDL inline as idempotent `IF NOT EXISTS` / `ON CONFLICT DO NOTHING`. Auto-runs on next deploy. No manual psql ceremony, but also less reviewable before it touches the DB.

Migration slot 022 is claimed in both PRs with different content — they cannot both land.

## Commits in this branch

1. `34bc6718` Stabilize long-running test gates *(migration-clean)*
2. `59118ed9` refactor(lifecycle): share resume persistence helper *(migration-clean)*
3. `b0553d19` fix(identity): surface Redis guard read failures *(migration-clean)*
4. `cf5e1987` fix(identity): stabilize trust tier drift *(migration-clean)*
5. `55c69883` Fix KG bug backlog *(includes the 022 reconcile migration + 020 fix + KG/identity handler changes)*

The first 4 commits are independent of the migration question and want to land regardless. If you pick #236, those still need a home — cherry-pick them onto a fresh branch from master.

Both Codex sessions worked in parallel without seeing each other. Posting this as draft so you can pick one in the UI rather than have it stay an orphan branch.