### PR TITLE
feat(watcher): --scan-commits closes the commit→finding loop

### DIFF
--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -879,6 +879,128 @@ def _post_resolution_event(
 
 
 # ---------------------------------------------------------------------------
+# Commit-trail scanner — close the loop between operator-side fixes and
+# Watcher's audit trail. CLAUDE.md asks for fingerprints in commit messages
+# but no machinery existed to consume them; clusters were drifting into
+# fixed-but-still-confirmed limbo. Scan recent commits, find fingerprint
+# references, transition matching findings to confirmed with the commit
+# subject as resolution_reason.
+# ---------------------------------------------------------------------------
+
+# Watcher fingerprints are 16 hex chars; accept 8+ to allow short references
+# in commit messages. Anchored at word boundaries so 8-char prefixes don't
+# collide with the start of a commit-SHA mention.
+_FINGERPRINT_RE = re.compile(r"\b([0-9a-f]{8,16})\b")
+
+# git log subject prefixes that indicate a revert. Skipped to avoid auto-
+# resolving a finding whose fix was just rolled back.
+_REVERT_PREFIXES = ("revert ", "revert:", 'revert "', "revert: ")
+
+
+def scan_commits(since: str = "30 days ago", repo_path: Path | None = None) -> int:
+    """Scan recent commits for fingerprint references and resolve matches.
+
+    For each commit in ``git log --since=<since>``, extracts 8-16 char hex
+    sequences from subject and body. Each unique-prefix match against an
+    existing finding is transitioned to ``confirmed`` with reason
+    ``referenced in <sha>: <subject>``.
+
+    Skips:
+      - Findings already with a ``resolution_reason`` set (idempotent).
+      - Findings already in terminal ``dismissed`` state (do not auto-
+        resurrect false positives).
+      - Revert commits (subject starts with ``revert``) — avoid auto-
+        resolving a finding whose fix was reverted.
+      - Ambiguous prefixes that match more than one fingerprint.
+
+    Returns:
+        The number of findings resolved this scan. Always returns 0 on git
+        failure rather than raising, so this is safe to call from a cron.
+    """
+    repo_root = repo_path or PROJECT_ROOT
+    try:
+        result = subprocess.run(
+            ["git", "log", f"--since={since}", "--format=%H%x00%s%x00%b%x1e"],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        log("scan_commits: git log timed out", "warning")
+        return 0
+    except FileNotFoundError:
+        log("scan_commits: git not on PATH", "warning")
+        return 0
+    if result.returncode != 0:
+        log(f"scan_commits: git log failed: {result.stderr.strip()}", "warning")
+        return 0
+
+    findings = _iter_findings_raw()
+    if not findings:
+        return 0
+
+    # Map full fingerprint → live status. Updated in-place after each
+    # successful resolve so subsequent commits in the same scan see the
+    # already-resolved state and skip re-emitting events. Only carries
+    # findings in the active queue — confirmed/dismissed/aged_out are
+    # terminal and a coincidental hex match must NOT re-stamp confirmed_at
+    # or re-emit a governance event on the next scan.
+    fp_state: dict[str, str] = {
+        f.get("fingerprint", ""): f.get("status", "open")
+        for f in findings
+        if f.get("fingerprint") and f.get("status", "open") in ("open", "surfaced")
+    }
+    if not fp_state:
+        return 0
+
+    resolved_count = 0
+    commits_seen = 0
+    for record in result.stdout.split("\x1e"):
+        record = record.strip()
+        if not record:
+            continue
+        parts = record.split("\x00", 2)
+        if len(parts) < 3:
+            continue
+        sha, subject, body = parts
+        commits_seen += 1
+        subject_l = subject.lstrip().lower()
+        if any(subject_l.startswith(p) for p in _REVERT_PREFIXES):
+            continue
+
+        text = subject + "\n" + body
+        # Dedup prefixes within a single commit so one mention per finding
+        seen_prefixes: set[str] = set()
+        for prefix in _FINGERPRINT_RE.findall(text):
+            if prefix in seen_prefixes:
+                continue
+            seen_prefixes.add(prefix)
+            matches = [fp for fp in fp_state if fp.startswith(prefix)]
+            if len(matches) != 1:
+                continue
+            full_fp = matches[0]
+            reason = f"referenced in {sha[:8]}: {subject[:80]}"
+            rc = update_finding_status(
+                full_fp,
+                "confirmed",
+                resolver_agent_id="watcher_scan_commits",
+                reason=reason,
+            )
+            if rc == 0:
+                # Drop from active map so a later commit-in-the-same-scan
+                # mentioning the same fingerprint doesn't re-stamp it.
+                del fp_state[full_fp]
+                resolved_count += 1
+
+    print(
+        f"scan complete: {resolved_count} finding(s) resolved across "
+        f"{commits_seen} commit(s) since {since}"
+    )
+    return resolved_count
+
+
+# ---------------------------------------------------------------------------
 # Surfacing coordinator — surface_pending stays here because it also triggers
 # a governance check-in (_do_checkin). The read-only print_unresolved, the
 # shared _format_findings_block, and sweep/compact/escalate all live in
@@ -1651,6 +1773,19 @@ def main() -> int:
         action="store_true",
         help="recompute pattern_floor.json from findings.jsonl and persist atomically",
     )
+    parser.add_argument(
+        "--scan-commits",
+        action="store_true",
+        help="scan recent git commits for fingerprint references and "
+             "auto-resolve matching open/surfaced findings; skips reverts, "
+             "dismissed findings, and findings that already have a resolution_reason",
+    )
+    parser.add_argument(
+        "--scan-since",
+        metavar="GIT_SINCE",
+        default="30 days ago",
+        help='git --since=<value> for --scan-commits (default: "30 days ago")',
+    )
     args = parser.parse_args()
 
     # --- Identity resolution (best-effort) ---
@@ -1680,6 +1815,8 @@ def main() -> int:
         return print_unresolved()
     if args.surface_pending:
         return surface_pending()
+    if args.scan_commits:
+        return 0 if scan_commits(since=args.scan_since) >= 0 else 1
     if args.recompute_floor:
         from agents.watcher.floor_state import recompute_floor
         state = recompute_floor()

--- a/agents/watcher/tests/test_scan_commits.py
+++ b/agents/watcher/tests/test_scan_commits.py
@@ -1,0 +1,251 @@
+"""Tests for ``scan_commits`` — the commit-trail → finding-resolution loop.
+
+The contract: walk ``git log --since=<since>``, extract fingerprint-shaped
+hex strings from each commit message, and resolve unique-prefix matches
+against the findings store with the commit subject as resolution_reason.
+
+Edge cases that need to stay locked down:
+  - Revert commits don't auto-undo a prior fix.
+  - Dismissed findings stay dismissed (no auto-resurrect of false positives).
+  - Findings that already have a resolution_reason are not re-resolved
+    (idempotent across repeated scans).
+  - Ambiguous prefixes (matches >1 fingerprint) are skipped silently.
+  - git log failures degrade to 0 — safe to call from cron.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import agents.watcher.agent as watcher_module
+
+
+@pytest.fixture(autouse=True)
+def _isolate_findings_file(tmp_path, monkeypatch):
+    """Per-test FINDINGS_FILE redirect. The autouse fixture in test_agent.py
+    isn't visible across test files, so without this each test would inherit
+    the previous test's findings.jsonl path and seed-data leaks across tests."""
+    from agents.watcher import findings as watcher_findings
+
+    tmp_state = tmp_path / "watcher-state"
+    tmp_state.mkdir()
+    findings_file = tmp_state / "findings.jsonl"
+
+    monkeypatch.setattr(watcher_findings, "STATE_DIR", tmp_state)
+    monkeypatch.setattr(watcher_findings, "FINDINGS_FILE", findings_file)
+    monkeypatch.setattr(watcher_module, "FINDINGS_FILE", findings_file)
+    # post_finding goes over the network — stub it out so resolution events
+    # don't fail (or worse, leak) during scan_commits' update_finding_status calls.
+    monkeypatch.setattr(watcher_findings, "post_finding", lambda **kw: True)
+    monkeypatch.setattr(watcher_module, "post_finding", lambda **kw: True)
+    yield
+
+
+def _seed(findings_file, *findings: dict) -> None:
+    findings_file.parent.mkdir(parents=True, exist_ok=True)
+    findings_file.write_text("\n".join(json.dumps(f) for f in findings) + "\n")
+
+
+def _read_findings(findings_file) -> list[dict]:
+    return [json.loads(line) for line in findings_file.read_text().splitlines() if line.strip()]
+
+
+def _git_log_record(sha: str, subject: str, body: str = "") -> str:
+    """Format one record the way ``git log --format=%H%x00%s%x00%b%x1e`` does."""
+    return f"{sha}\x00{subject}\x00{body}\x1e"
+
+
+@pytest.fixture
+def make_subprocess_run(monkeypatch):
+    """Patch subprocess.run inside agent.py to return a canned git log payload."""
+
+    def _install(stdout: str, returncode: int = 0, stderr: str = "") -> None:
+        class _Result:
+            def __init__(self):
+                self.stdout = stdout
+                self.stderr = stderr
+                self.returncode = returncode
+
+        def _fake(*args, **kwargs):
+            return _Result()
+
+        monkeypatch.setattr(watcher_module.subprocess, "run", _fake)
+
+    return _install
+
+
+def _seed_finding(fingerprint: str, status: str = "confirmed", **extra) -> dict:
+    return {
+        "fingerprint": fingerprint,
+        "pattern": extra.get("pattern", "P011"),
+        "file": extra.get("file", "/tmp/x.py"),
+        "line": extra.get("line", 1),
+        "hint": extra.get("hint", "h"),
+        "severity": extra.get("severity", "high"),
+        "violation_class": extra.get("violation_class", "INT"),
+        "status": status,
+        **{k: v for k, v in extra.items() if k not in ("pattern", "file", "line", "hint", "severity", "violation_class")},
+    }
+
+
+class TestScanCommitsResolves:
+    def test_resolves_fingerprint_referenced_in_commit_body(self, make_subprocess_run):
+        fp = "abcd1234ef005678"
+        _seed(watcher_module.FINDINGS_FILE, _seed_finding(fp, status="open"))
+        make_subprocess_run(
+            _git_log_record("deadbeef" * 5, "fix(thing): does the thing", f"resolves {fp}")
+        )
+
+        n = watcher_module.scan_commits(since="14 days ago")
+        assert n == 1
+        rows = _read_findings(watcher_module.FINDINGS_FILE)
+        assert len(rows) == 1
+        assert rows[0]["status"] == "confirmed"
+        assert rows[0].get("resolution_reason", "").startswith("referenced in deadbeef:")
+        assert "fix(thing): does the thing" in rows[0]["resolution_reason"]
+
+    def test_resolves_short_8_char_prefix(self, make_subprocess_run):
+        """8-char prefix is the floor — short SHAs and short fingerprints
+        often co-exist in commit bodies."""
+        fp = "1234567890abcdef"
+        _seed(watcher_module.FINDINGS_FILE, _seed_finding(fp, status="open"))
+        make_subprocess_run(_git_log_record("aaaaaaaa" * 5, "fix: thing", "fp 12345678"))
+        assert watcher_module.scan_commits() == 1
+
+    def test_resolves_full_16_char(self, make_subprocess_run):
+        fp = "1234567890abcdef"
+        _seed(watcher_module.FINDINGS_FILE, _seed_finding(fp, status="open"))
+        make_subprocess_run(_git_log_record("aaaaaaaa" * 5, "fix", fp))
+        assert watcher_module.scan_commits() == 1
+
+
+class TestScanCommitsSkips:
+    def test_skips_revert_commits(self, make_subprocess_run):
+        """A revert commit referencing a fingerprint must NOT auto-resolve —
+        the fix it referenced was just rolled back."""
+        fp = "abcd1234ef005678"
+        _seed(watcher_module.FINDINGS_FILE, _seed_finding(fp, status="open"))
+        make_subprocess_run(
+            _git_log_record(
+                "deadbeef" * 5,
+                'Revert "fix(thing): introduced regression"',
+                f"This reverts the fix referenced by {fp}",
+            )
+        )
+        assert watcher_module.scan_commits() == 0
+        rows = _read_findings(watcher_module.FINDINGS_FILE)
+        assert rows[0]["status"] == "open"
+
+    def test_skips_dismissed_findings(self, make_subprocess_run):
+        """Dismissed = false positive. A coincidental commit reference must
+        not flip it back to confirmed."""
+        fp = "abcd1234ef005678"
+        _seed(
+            watcher_module.FINDINGS_FILE,
+            _seed_finding(fp, status="dismissed", resolution_reason="fp"),
+        )
+        make_subprocess_run(_git_log_record("d" * 40, "fix something", fp))
+        assert watcher_module.scan_commits() == 0
+        rows = _read_findings(watcher_module.FINDINGS_FILE)
+        assert rows[0]["status"] == "dismissed"
+
+    def test_skips_already_resolved_findings(self, make_subprocess_run):
+        """Idempotent: re-running the scanner mustn't churn the resolution_reason
+        of findings already linked to a prior commit."""
+        fp = "abcd1234ef005678"
+        prior = "referenced in baadf00d: prior fix"
+        _seed(
+            watcher_module.FINDINGS_FILE,
+            _seed_finding(fp, status="confirmed", resolution_reason=prior),
+        )
+        make_subprocess_run(_git_log_record("d" * 40, "newer fix", fp))
+        assert watcher_module.scan_commits() == 0
+        rows = _read_findings(watcher_module.FINDINGS_FILE)
+        assert rows[0]["resolution_reason"] == prior
+
+    def test_skips_confirmed_without_resolution_reason(self, make_subprocess_run):
+        """An operator who ran ``--resolve <fp>`` without ``--reason`` left the
+        finding ``status=confirmed`` with no ``resolution_reason``. A later
+        coincidental fingerprint mention in a commit must not re-stamp
+        ``confirmed_at`` or emit a duplicate governance event. Active-queue-only
+        gating is what enforces this.
+        """
+        fp = "abcd1234ef005678"
+        original_ts = "2026-01-01T00:00:00Z"
+        _seed(
+            watcher_module.FINDINGS_FILE,
+            _seed_finding(fp, status="confirmed", confirmed_at=original_ts),
+        )
+        make_subprocess_run(_git_log_record("d" * 40, "fix", fp))
+        assert watcher_module.scan_commits() == 0
+        rows = _read_findings(watcher_module.FINDINGS_FILE)
+        # confirmed_at must not have been re-stamped, resolution_reason must
+        # still be absent (we didn't auto-fill anything).
+        assert rows[0]["confirmed_at"] == original_ts
+        assert "resolution_reason" not in rows[0]
+
+    def test_skips_aged_out_findings(self, make_subprocess_run):
+        """Same gating principle: aged_out is terminal, don't resurrect."""
+        fp = "abcd1234ef005678"
+        _seed(watcher_module.FINDINGS_FILE, _seed_finding(fp, status="aged_out"))
+        make_subprocess_run(_git_log_record("d" * 40, "fix", fp))
+        assert watcher_module.scan_commits() == 0
+        rows = _read_findings(watcher_module.FINDINGS_FILE)
+        assert rows[0]["status"] == "aged_out"
+
+    def test_skips_ambiguous_prefix(self, make_subprocess_run):
+        """An 8-char prefix matching two findings must not be resolved
+        — the operator's intent is unclear."""
+        fp1 = "abcd12340000aaaa"
+        fp2 = "abcd12340000bbbb"
+        _seed(
+            watcher_module.FINDINGS_FILE,
+            _seed_finding(fp1, status="open"),
+            _seed_finding(fp2, status="open"),
+        )
+        make_subprocess_run(_git_log_record("d" * 40, "fix", "abcd1234"))
+        assert watcher_module.scan_commits() == 0
+        rows = _read_findings(watcher_module.FINDINGS_FILE)
+        assert all(r["status"] == "open" for r in rows)
+
+    def test_skips_nonmatching_hex_strings(self, make_subprocess_run):
+        """Random hex like a SHA prefix that doesn't match any known
+        fingerprint must not raise or update anything."""
+        fp = "abcd1234ef005678"
+        _seed(watcher_module.FINDINGS_FILE, _seed_finding(fp, status="open"))
+        make_subprocess_run(_git_log_record("d" * 40, "fix", "see commit deadbeef"))
+        assert watcher_module.scan_commits() == 0
+
+
+class TestScanCommitsResilience:
+    def test_returns_zero_on_git_failure(self, make_subprocess_run):
+        fp = "abcd1234ef005678"
+        _seed(watcher_module.FINDINGS_FILE, _seed_finding(fp, status="open"))
+        make_subprocess_run("", returncode=128, stderr="not a git repository")
+        assert watcher_module.scan_commits() == 0
+
+    def test_returns_zero_when_git_missing(self, monkeypatch):
+        fp = "abcd1234ef005678"
+        _seed(watcher_module.FINDINGS_FILE, _seed_finding(fp, status="open"))
+
+        def _raise(*a, **kw):
+            raise FileNotFoundError("git not on PATH")
+
+        monkeypatch.setattr(watcher_module.subprocess, "run", _raise)
+        assert watcher_module.scan_commits() == 0
+
+    def test_returns_zero_on_empty_findings(self, make_subprocess_run):
+        # File never created — the iterator returns []
+        make_subprocess_run(_git_log_record("d" * 40, "fix", "abcd1234ef005678"))
+        assert watcher_module.scan_commits() == 0
+
+    def test_dedups_duplicate_fingerprint_in_same_commit(self, make_subprocess_run):
+        """One fingerprint mentioned twice in the same commit body should
+        result in exactly one resolve, not two events."""
+        fp = "abcd1234ef005678"
+        _seed(watcher_module.FINDINGS_FILE, _seed_finding(fp, status="open"))
+        body = f"fixes {fp}\nalso see {fp}"
+        make_subprocess_run(_git_log_record("d" * 40, "fix", body))
+        assert watcher_module.scan_commits() == 1


### PR DESCRIPTION
## Summary
CLAUDE.md asks operators to reference Watcher fingerprints in commit messages, but no machinery existed to consume them. Today's audit found 11 confirmed findings (P011 ×6, P004 ×2, P001 ×7, P002 ×2) that had sat in "fixed but never linked" limbo for ~2 weeks despite their fixes landing on master.

`scan_commits()` walks `git log --since=<window>`, extracts 8-16 char hex sequences from commit subject+body, and for each unique-prefix match against an **active-queue** finding (`open`/`surfaced`) calls the existing `update_finding_status` with reason `referenced in <sha>: <subject>`.

## Behavior

**Resolves** when a commit body or subject contains a unique fingerprint prefix matching an active finding.

**Skips:**
- Findings outside the active queue — `confirmed`/`dismissed`/`aged_out` are terminal. A coincidental hex match must NOT re-stamp `confirmed_at` or re-emit governance events on every scan. (Caught by adversarial review — see Test Plan #4.)
- Revert commits (subject starts with `revert`)
- Ambiguous prefixes that match more than one fingerprint

## CLI
- `--scan-commits` — run the scan
- `--scan-since GIT_SINCE` — git `--since=<value>` (default `"30 days ago"`)

Returns 0 on git failure rather than raising — safe for cron.

## Test plan
- [x] Active-queue finding referenced in commit body → resolved with correct reason
- [x] 8-char prefix and full 16-char fingerprint both match
- [x] Revert commits skipped (`Revert "fix..."` shape)
- [x] Dismissed findings stay dismissed
- [x] `confirmed` findings with prior `resolution_reason` not re-resolved
- [x] `confirmed` findings WITHOUT `resolution_reason` not re-stamped (the bug adversarial review caught — was re-stamping `confirmed_at` and emitting duplicate events)
- [x] `aged_out` findings not resurrected
- [x] Ambiguous 8-char prefix matching two findings → no resolve
- [x] Hex strings that don't prefix any known fingerprint → silent no-op
- [x] git log failure / missing git → returns 0 (cron-safe)
- [x] Empty findings file → returns 0
- [x] Same fingerprint mentioned twice in one commit body → exactly one resolve

14 tests in `agents/watcher/tests/test_scan_commits.py`. Full watcher suite: 225 passed.

## Follow-up (not in this PR)
- Wire to Vigil's 30min cycle so the loop closes automatically
- Investigate the 4 P004/P011 in-the-loop fingerprints that landed today and add them as a self-test