### PR TITLE
fix(tests): point test_db_utils at renumbered migration slots (018/019→022/023)

### DIFF
--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -103,8 +103,10 @@ async def ensure_test_database_schema() -> None:
         await _execute_sql_file(conn, "db/postgres/migrations/013_metrics_series.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/014_seed_epoch_2.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/017_substrate_claims.sql")
-        await _execute_sql_file(conn, "db/postgres/migrations/018_bootstrap_synthetic_state.sql")
-        await _execute_sql_file(conn, "db/postgres/migrations/019_matview_measured_only.sql")
+        # Slots 018 and 019 were renumbered to 022 and 023 in PR #236
+        # (migration-drift triage); the old paths no longer exist.
+        await _execute_sql_file(conn, "db/postgres/migrations/022_bootstrap_synthetic_state.sql")
+        await _execute_sql_file(conn, "db/postgres/migrations/023_matview_measured_only.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/020_progress_flat_telemetry.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/021_seed_epoch_3.sql")
 


### PR DESCRIPTION
## Summary
Slots `018_bootstrap_synthetic_state` and `019_matview_measured_only` were renumbered to `022` and `023` in PR #236 (the migration-drift triage), but `tests/test_db_utils.py` was missed in that PR. Result: every test depending on the shared schema setup has been crashing with `FileNotFoundError` before any actual test code runs — broken on master since #236 merged.

Surfaced today by `./scripts/dev/test-cache.sh` against an unrelated branch (PR #243's pre-commit gate).

## Change
Pure rename. No new migrations applied; no schema change. The 2 lines (now with a comment pointing at #236 for context).

Slots `015` and `016` are still absent from this fixture — that predates the renumbering and is out of scope here.

## Test plan
- [x] `pytest tests/resident_progress/test_calibration_smoke.py` — was crashing with `FileNotFoundError` on `018_bootstrap_synthetic_state.sql`; now passes (1 passed, 1 skipped — the skip is the legitimate "no probe data in window" branch).