### PR TITLE
fix(dialectic): accept conditions alias + early-fail on agrees+empty

### DIFF
--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -178,6 +178,30 @@ async def check_reviewer_stuck(session: DialecticSession) -> bool:
         return False  # Can't determine — don't kill the session
 
 
+def _read_proposed_conditions(arguments: Dict[str, Any]) -> List[str]:
+    """Read proposed_conditions, accepting `conditions` as an alias.
+
+    The dialectic tool surface exposes both `proposed_conditions` (used by
+    thesis/antithesis/synthesis) and `conditions` (used by vote). Callers
+    occasionally pass `conditions=[...]` to a synthesis call by mistake —
+    the field is silently dropped, which produces a synthesis message with
+    empty conditions, which trips check_hard_limits at finalize time and
+    leaves the session in a self-contradictory phase=failed /
+    resolution.action=resume terminal state.
+
+    Accept either name to prevent that silent-drop class of bug. A
+    falsy/missing `proposed_conditions` falls back to `conditions`; explicit
+    empty values are preserved as empty.
+    """
+    proposed = arguments.get('proposed_conditions')
+    if proposed:
+        return proposed
+    fallback = arguments.get('conditions')
+    if fallback:
+        return fallback
+    return [] if proposed is None else proposed
+
+
 def _meta_value(meta: Any, key: str, default: Any = None) -> Any:
     """Read a field from metadata regardless of object-vs-dict representation."""
     if meta is None:
@@ -910,13 +934,17 @@ async def handle_submit_thesis(arguments: Dict[str, Any]) -> Sequence[TextConten
                     recovery=session_not_found_recovery(),
                 )]
 
+        # Resolve proposed_conditions, accepting `conditions` as an alias
+        # to prevent silent data loss from parameter-name confusion.
+        proposed_conditions = _read_proposed_conditions(arguments)
+
         # Create thesis message
         message = DialecticMessage(
             phase="thesis",
             agent_id=agent_id,
             timestamp=datetime.now(timezone.utc).isoformat(),
             root_cause=arguments.get('root_cause'),
-            proposed_conditions=arguments.get('proposed_conditions', []),
+            proposed_conditions=proposed_conditions,
             reasoning=arguments.get('reasoning')
         )
 
@@ -933,7 +961,7 @@ async def handle_submit_thesis(arguments: Dict[str, Any]) -> Sequence[TextConten
                     agent_id=agent_id,
                     message_type="thesis",
                     root_cause=arguments.get('root_cause'),
-                    proposed_conditions=arguments.get('proposed_conditions', []),
+                    proposed_conditions=proposed_conditions,
                     reasoning=arguments.get('reasoning'),
                 )
                 await pg_update_phase(session_id, session.phase.value)
@@ -1192,12 +1220,45 @@ async def handle_submit_synthesis(arguments: Dict[str, Any]) -> Sequence[TextCon
         else:
             agrees = bool(raw_agrees)
 
+        # Resolve proposed_conditions, accepting `conditions` as an alias
+        # to prevent silent data loss from parameter-name confusion.
+        proposed_conditions = _read_proposed_conditions(arguments)
+
+        # Early-fail: synthesis with agrees=True must contribute conditions, OR
+        # there must already be a prior synthesis in transcript that did.
+        # Without this gate, the empty-conditions path slips through to
+        # check_hard_limits at finalize time and leaves the session in a
+        # phase=failed / resolution.action=resume inconsistent terminal state.
+        if agrees and not proposed_conditions:
+            prior_has_conditions = any(
+                getattr(msg, "phase", None) == "synthesis"
+                and getattr(msg, "proposed_conditions", None)
+                for msg in (session.transcript or [])
+            )
+            if not prior_has_conditions:
+                return [error_response(
+                    "Cannot agree (agrees=True) with empty proposed_conditions when no "
+                    "prior synthesis has supplied any. Either pass proposed_conditions=[...] "
+                    "(or its alias `conditions=[...]`) populated with the agreed terms, "
+                    "or set agrees=False to register disagreement instead.",
+                    error_code="EMPTY_AGREEMENT",
+                    error_category="validation_error",
+                    recovery={
+                        "action": (
+                            "Re-submit synthesis with proposed_conditions populated. "
+                            "If you intended to disagree, set agrees=false."
+                        ),
+                        "related_tools": ["dialectic"],
+                    },
+                    arguments=arguments,
+                )]
+
         # Create synthesis message
         message = DialecticMessage(
             phase="synthesis",
             agent_id=agent_id,
             timestamp=datetime.now(timezone.utc).isoformat(),
-            proposed_conditions=arguments.get('proposed_conditions', []),
+            proposed_conditions=proposed_conditions,
             root_cause=arguments.get('root_cause'),
             reasoning=arguments.get('reasoning'),
             agrees=agrees
@@ -1216,9 +1277,9 @@ async def handle_submit_synthesis(arguments: Dict[str, Any]) -> Sequence[TextCon
                     agent_id=agent_id,
                     message_type="synthesis",
                     root_cause=arguments.get('root_cause'),
-                    proposed_conditions=arguments.get('proposed_conditions', []),
+                    proposed_conditions=proposed_conditions,
                     reasoning=arguments.get('reasoning'),
-                    agrees=arguments.get('agrees', False),
+                    agrees=agrees,
                 )
                 if not result.get("converged"):
                     await pg_update_phase(session_id, session.phase.value)

--- a/tests/test_dialectic_handlers.py
+++ b/tests/test_dialectic_handlers.py
@@ -20,7 +20,7 @@ import sys
 from pathlib import Path
 from unittest.mock import patch, MagicMock, AsyncMock
 from types import SimpleNamespace
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 # Ensure project root is on sys.path
 project_root = Path(__file__).parent.parent
@@ -1118,6 +1118,195 @@ class TestHandleSubmitSynthesis:
         data = parse_result(result)
         assert data["success"] is True, (
             f"quorum reviewer must be accepted, got: {data}"
+        )
+
+    # ------------------------------------------------------------------
+    # Parameter-name aliasing (regression: silent data loss)
+    #
+    # Background: dialectic tool surface exposes both `proposed_conditions`
+    # (thesis/antithesis/synthesis) and `conditions` (vote). A caller passing
+    # `conditions=[...]` to synthesis got the field silently dropped; the
+    # synthesis message persisted with empty `proposed_conditions`, then
+    # finalize tripped check_hard_limits with "Resolution must include at
+    # least one condition", leaving the session in a self-contradictory
+    # phase=failed / resolution.action=resume terminal state.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_synthesis_accepts_conditions_alias(
+        self, mock_server, mock_pg_add_message, mock_pg_update_phase,
+        mock_save_session, mock_context_agent,
+    ):
+        """`conditions=[...]` is accepted as an alias for `proposed_conditions=[...]`.
+
+        The DialecticMessage and pg_add_message call must receive the
+        alias-resolved conditions, not an empty list.
+        """
+        from src.mcp_handlers.dialectic.handlers import handle_submit_synthesis
+
+        session = _make_session(phase=DialecticPhase.SYNTHESIS)
+        session.synthesis_round = 1
+
+        captured = {}
+
+        async def capture_add(**kwargs):
+            captured.update(kwargs)
+            return None
+
+        with patch(f"{DIALECTIC}.load_session", new_callable=AsyncMock,
+                   return_value=session), \
+             patch(f"{DIALECTIC}.pg_add_message", side_effect=capture_add), \
+             mock_pg_update_phase, mock_save_session, mock_context_agent:
+            result = await handle_submit_synthesis({
+                "session_id": session.session_id,
+                "agent_id": "agent-paused",
+                # Note: alias `conditions=...`, not `proposed_conditions=...`
+                "conditions": ["Aliased condition A", "Aliased condition B"],
+                "root_cause": "test alias",
+                "reasoning": "passing wrong-but-symmetric param name",
+                "agrees": False,  # avoid convergence path; just verify message persistence
+                "api_key": "key",
+            })
+
+        data = parse_result(result)
+        assert data["success"] is True, (
+            f"alias `conditions` must be accepted, got: {data}"
+        )
+        assert captured.get("proposed_conditions") == [
+            "Aliased condition A", "Aliased condition B"
+        ], (
+            f"pg_add_message must receive alias-resolved conditions, got: "
+            f"{captured.get('proposed_conditions')}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_thesis_accepts_conditions_alias(
+        self, mock_server, mock_pg_add_message, mock_pg_update_phase,
+        mock_save_session, mock_context_agent,
+    ):
+        """Same alias support on thesis (symmetric — same parameter-name confusion class)."""
+        from src.mcp_handlers.dialectic.handlers import handle_submit_thesis
+
+        session = _make_session(phase=DialecticPhase.THESIS)
+
+        captured = {}
+
+        async def capture_add(**kwargs):
+            captured.update(kwargs)
+            return None
+
+        with patch(f"{DIALECTIC}.load_session", new_callable=AsyncMock,
+                   return_value=session), \
+             patch(f"{DIALECTIC}.pg_add_message", side_effect=capture_add), \
+             mock_pg_update_phase, mock_save_session, mock_context_agent:
+            result = await handle_submit_thesis({
+                "session_id": session.session_id,
+                "agent_id": "agent-paused",
+                "conditions": ["Thesis condition via alias"],
+                "root_cause": "test alias on thesis",
+                "reasoning": "symmetric alias support",
+                "api_key": "key",
+            })
+
+        data = parse_result(result)
+        assert data["success"] is True
+        assert captured.get("proposed_conditions") == ["Thesis condition via alias"]
+
+    # ------------------------------------------------------------------
+    # Early-fail on agrees=True with empty conditions
+    #
+    # Without this gate, the empty-conditions case slipped through to
+    # check_hard_limits at finalize time and produced phase=failed with
+    # resolution.action=resume — internally inconsistent terminal state.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_synthesis_rejects_agrees_with_empty_conditions(
+        self, mock_server, mock_pg_add_message, mock_pg_update_phase,
+        mock_save_session, mock_context_agent,
+    ):
+        """`agrees=True` + empty conditions + no prior synthesis must fail before any DB write."""
+        from src.mcp_handlers.dialectic.handlers import handle_submit_synthesis
+
+        session = _make_session(phase=DialecticPhase.SYNTHESIS)
+        session.synthesis_round = 1
+        # Transcript has no prior synthesis with conditions.
+        session.transcript = []
+
+        add_called = []
+
+        async def capture_add(**kwargs):
+            add_called.append(kwargs)
+            return None
+
+        with patch(f"{DIALECTIC}.load_session", new_callable=AsyncMock,
+                   return_value=session), \
+             patch(f"{DIALECTIC}.pg_add_message", side_effect=capture_add), \
+             mock_pg_update_phase, mock_save_session, mock_context_agent:
+            result = await handle_submit_synthesis({
+                "session_id": session.session_id,
+                "agent_id": "agent-paused",
+                # Both empty / missing — confused-caller scenario
+                "agrees": True,
+                "api_key": "key",
+            })
+
+        data = parse_result(result)
+        assert data["success"] is False, (
+            f"agrees=True with empty conditions must be rejected, got: {data}"
+        )
+        assert data.get("error_code") == "EMPTY_AGREEMENT", (
+            f"expected EMPTY_AGREEMENT error_code, got: {data.get('error_code')}"
+        )
+        assert not add_called, (
+            "pg_add_message must NOT be called on early-fail; persisting the "
+            "broken message is what produced the original inconsistent state. "
+            f"Got calls: {add_called}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_synthesis_allows_agrees_when_prior_has_conditions(
+        self, mock_server, mock_pg_add_message, mock_pg_update_phase,
+        mock_save_session, mock_context_agent,
+    ):
+        """`agrees=True` with empty conditions is allowed if a prior synthesis supplied them.
+
+        This covers the legitimate convergence pattern: agent A files synthesis
+        with conditions, agent B files `agrees=True` with no new conditions to
+        signal acceptance of A's terms. The merge logic in finalize_resolution
+        pulls A's conditions forward — the early-fail must not block this.
+        """
+        from src.mcp_handlers.dialectic.handlers import handle_submit_synthesis
+
+        session = _make_session(phase=DialecticPhase.SYNTHESIS)
+        session.synthesis_round = 1
+        # Prior synthesis from the other agent supplies conditions
+        prior = DialecticMessage(
+            phase="synthesis",
+            agent_id="agent-reviewer",
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            proposed_conditions=["Prior condition"],
+            agrees=True,
+        )
+        session.transcript = [prior]
+
+        with patch(f"{DIALECTIC}.load_session", new_callable=AsyncMock,
+                   return_value=session), \
+             mock_pg_add_message, mock_pg_update_phase, mock_save_session, \
+             mock_context_agent:
+            result = await handle_submit_synthesis({
+                "session_id": session.session_id,
+                "agent_id": "agent-paused",
+                # No new conditions — accepting prior agent's terms
+                "agrees": True,
+                "api_key": "key",
+            })
+
+        data = parse_result(result)
+        # Either succeeds (convergence) or proceeds to next round — both valid.
+        # The point is we don't hit the EMPTY_AGREEMENT early-fail.
+        assert data.get("error_code") != "EMPTY_AGREEMENT", (
+            f"prior synthesis with conditions should bypass early-fail, got: {data}"
         )
 
 


### PR DESCRIPTION
## Summary

Two intertwined bugs verified on dialectic session `95c9ddfd6bb09308` (2026-04-30) where a synthesis call left the session in a self-contradictory terminal state: `phase=failed` AND `resolution.action=resume` AND `conditions=[]`.

### Bug 1: Parameter-name confusion

The dialectic tool surface exposes both `proposed_conditions` (used by thesis/antithesis/synthesis) and `conditions` (used by vote). Callers passing `conditions=[...]` to a synthesis call had the field silently dropped via `arguments.get('proposed_conditions', [])`. The empty list slipped through to `finalize_resolution`, which tripped `check_hard_limits` ("Resolution must include at least one condition") AFTER the synthesis message was already persisted to PostgreSQL — leaving the inconsistent terminal state.

**Fix:** thesis and synthesis handlers now accept either name via a small `_read_proposed_conditions` helper. Antithesis is unaffected (it reads `concerns`, no overlap).

### Bug 2: No early-fail on agrees=True with empty conditions

Even with the alias fix, an agent legitimately calling `synthesis(agrees=True, proposed_conditions=[])` produces the same inconsistent state.

**Fix:** synthesis handler now rejects this case BEFORE any PG write, with `error_code=EMPTY_AGREEMENT`, unless a prior synthesis in the transcript already supplied conditions (preserves the legitimate "agree to other agent's terms" pattern).

### Adjacent

`pg_add_message` in synthesis was being called with the raw `agrees` argument (could be a string from MCP transport) instead of the already-coerced bool. Switched to the coerced variable.

## Test plan

- [x] 3 new tests in `TestHandleSubmitSynthesis`: alias accepted, early-fail with no DB write, prior-synthesis bypasses early-fail
- [x] 1 new test in `TestHandleSubmitThesis` for symmetric alias support
- [x] All 219 existing dialectic tests pass
- [x] Full suite: `./scripts/dev/test-cache.sh` — 7938 passed, 33 skipped, 0 failed (78.73% coverage)

## Out of scope (separate PRs)

- Atomicity / transactional wrap of message + phase + resolution writes
- Self-review surfacing for design-review session_type
- Append-only transcript model simplification
- Third-party synthesizer topology for design-review dialectics

## References

- Bug filed in KG: discovery `2026-04-30T10:21:17.486053+00:00`
- Triggering session: `95c9ddfd6bb09308`
- Related operator-flagged design issue: discovery `2026-04-30T10:20:26.584546+00:00` (dialectic 2-mode distinction)