### PR TITLE
fix(resident-progress): per-resident heartbeat cadence

### DIFF
--- a/dashboard/resident-progress.js
+++ b/dashboard/resident-progress.js
@@ -18,6 +18,7 @@
         "unresolved": "rp-status-unresolved",
         "startup-grace": "rp-status-init",
         "initializing": "rp-status-init",
+        "never-seen": "rp-status-init",
     };
 
     async function fetchRecent(hours) {

--- a/src/background_tasks.py
+++ b/src/background_tasks.py
@@ -442,7 +442,10 @@ async def progress_flat_probe_task(interval_seconds: float | None = None):
         async def get(self, agent_uuid: str):
             # Use get_agent from agent_storage — that's the canonical async
             # identity/metadata fetch.  AgentRecord.last_activity_at maps to
-            # last_update; expected_cadence_s lives in metadata.
+            # last_update. Cadence is supplied by the probe via
+            # cadence_override_s from the registry; we no longer fabricate
+            # a 60s default for residents whose natural cadence is hours
+            # or days.
             try:
                 from src.agent_storage import get_agent
                 record = await get_agent(agent_uuid)
@@ -453,7 +456,6 @@ async def progress_flat_probe_task(interval_seconds: float | None = None):
                     "expected_cadence_s": (
                         record.metadata.get("expected_cadence_s")
                         or record.metadata.get("cadence_s")
-                        or 60
                     ),
                 }
             except Exception:

--- a/src/resident_progress/heartbeat.py
+++ b/src/resident_progress/heartbeat.py
@@ -46,7 +46,12 @@ class HeartbeatEvaluator:
         self._store = store
         self._now = _now
 
-    async def evaluate(self, agent_uuid: str) -> HeartbeatStatus:
+    async def evaluate(
+        self,
+        agent_uuid: str,
+        *,
+        cadence_override_s: int | None = None,
+    ) -> HeartbeatStatus:
         try:
             row = await self._store.get(agent_uuid)
         except Exception as e:
@@ -60,7 +65,11 @@ class HeartbeatEvaluator:
                 in_critical_silence=False,
             )
         last = row.get("last_update")
-        cadence = int(row.get("expected_cadence_s") or 0) or None
+        cadence = (
+            cadence_override_s
+            or int(row.get("expected_cadence_s") or 0)
+            or None
+        )
         if last is None or cadence is None:
             return HeartbeatStatus(
                 alive=False, last_update=last, expected_cadence_s=cadence,

--- a/src/resident_progress/heartbeat.py
+++ b/src/resident_progress/heartbeat.py
@@ -65,11 +65,13 @@ class HeartbeatEvaluator:
                 in_critical_silence=False,
             )
         last = row.get("last_update")
-        cadence = (
-            cadence_override_s
-            or int(row.get("expected_cadence_s") or 0)
-            or None
-        )
+        # Distinguish "explicitly 0" (caller bug) from "no override given".
+        # Falsy-or chains here would silently swallow a bad 0 and fall through
+        # to the store value, hiding the misconfiguration.
+        if cadence_override_s is not None:
+            cadence = cadence_override_s if cadence_override_s > 0 else None
+        else:
+            cadence = int(row.get("expected_cadence_s") or 0) or None
         if last is None or cadence is None:
             return HeartbeatStatus(
                 alive=False, last_update=last, expected_cadence_s=cadence,

--- a/src/resident_progress/probe_task.py
+++ b/src/resident_progress/probe_task.py
@@ -74,11 +74,18 @@ class ProgressFlatProbe:
         source_outputs = {n: out for n, out, err in results if err is None}
         source_errors = {n: err for n, out, err in results if err is not None}
 
-        # Step 4: heartbeat in parallel
-        async def _hb(agent_uuid):
-            return agent_uuid, await self._heartbeat.evaluate(agent_uuid)
+        # Step 4: heartbeat in parallel. Pass per-resident cadence from
+        # the registry so non-continuous residents (Vigil 30min, Steward
+        # 5min, Chronicler daily) aren't all judged against a 60s default.
+        async def _hb(label, agent_uuid):
+            cfg = RESIDENT_PROGRESS_REGISTRY[label]
+            return agent_uuid, await self._heartbeat.evaluate(
+                agent_uuid, cadence_override_s=cfg.expected_cadence_s,
+            )
 
-        hb_pairs = await asyncio.gather(*[_hb(u) for u in resolved.values()])
+        hb_pairs = await asyncio.gather(*[
+            _hb(label, agent_uuid) for label, agent_uuid in resolved.items()
+        ])
         hb_by_uuid = dict(hb_pairs)
 
         # Step 5: compose resident rows

--- a/src/resident_progress/probe_task.py
+++ b/src/resident_progress/probe_task.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from typing import Protocol
 
+from src.resident_progress.heartbeat import HeartbeatStatus
 from src.resident_progress.registry import (
     RESIDENT_PROGRESS_REGISTRY,
     resolve_resident_uuid,
@@ -77,8 +78,18 @@ class ProgressFlatProbe:
         # Step 4: heartbeat in parallel. Pass per-resident cadence from
         # the registry so non-continuous residents (Vigil 30min, Steward
         # 5min, Chronicler daily) aren't all judged against a 60s default.
+        # Residents whose registry cadence is None are event-driven
+        # (Watcher) — heartbeat-liveness is the wrong abstraction, so we
+        # synthesize an "alive=True, event_driven" status and skip the
+        # staleness gate entirely. Better than encoding "n/a" as "very
+        # slow timeout".
         async def _hb(label, agent_uuid):
             cfg = RESIDENT_PROGRESS_REGISTRY[label]
+            if cfg.expected_cadence_s is None:
+                return agent_uuid, HeartbeatStatus(
+                    alive=True, last_update=None, expected_cadence_s=None,
+                    in_critical_silence=False,
+                )
             return agent_uuid, await self._heartbeat.evaluate(
                 agent_uuid, cadence_override_s=cfg.expected_cadence_s,
             )
@@ -122,7 +133,20 @@ class ProgressFlatProbe:
             else:
                 metric = source_outputs[cfg.source].get(agent_uuid, 0)
                 below = metric < cfg.threshold
-                if not hb.alive and below:
+                # Distinguish "never checked in" from "went silent". A fresh
+                # resident with last_update=None looks identical to a long
+                # outage on the dashboard otherwise; operators investigate
+                # phantom failures of brand-new instances.
+                never_seen = (
+                    not hb.alive
+                    and hb.last_update is None
+                    and hb.eval_error is None
+                    and cfg.expected_cadence_s is not None
+                )
+                if never_seen:
+                    suppressed = "never_seen"
+                    candidate = False
+                elif not hb.alive and below:
                     suppressed = "heartbeat_not_alive"
                     candidate = False
                 else:

--- a/src/resident_progress/registry.py
+++ b/src/resident_progress/registry.py
@@ -23,14 +23,22 @@ class ResidentConfig:
     metric: str       # human-readable metric label, recorded on snapshot row
     window: timedelta
     threshold: int    # candidate fires when measured metric is strictly less than threshold
+    # Heartbeat cadence override. Drives critical-silence detection
+    # (alive iff last_update within 3x cadence). Per-resident because
+    # residents have very different natural cadences: Sentinel is a
+    # 60s loop, Steward syncs every 5min, Vigil cycles every 30min,
+    # Chronicler runs daily, Watcher fires only on edits and has no
+    # natural heartbeat cadence at all. A single global default
+    # mislabels every non-continuous resident as "silent".
+    expected_cadence_s: int
 
 
 RESIDENT_PROGRESS_REGISTRY: dict[str, ResidentConfig] = {
-    "vigil":      ResidentConfig("kg_writes",        "rows_written", timedelta(minutes=60),  1),
-    "watcher":    ResidentConfig("watcher_findings", "rows_any",     timedelta(hours=6),     1),
-    "steward":    ResidentConfig("eisv_sync_rows",   "rows_written", timedelta(minutes=30),  1),
-    "chronicler": ResidentConfig("metrics_series",   "rows_written", timedelta(hours=26),    1),
-    "sentinel":   ResidentConfig("sentinel_pulse",   "latest_count", timedelta(minutes=30),  1),
+    "vigil":      ResidentConfig("kg_writes",        "rows_written", timedelta(minutes=60),  1, expected_cadence_s=1800),
+    "watcher":    ResidentConfig("watcher_findings", "rows_any",     timedelta(hours=6),     1, expected_cadence_s=21600),
+    "steward":    ResidentConfig("eisv_sync_rows",   "rows_written", timedelta(minutes=30),  1, expected_cadence_s=300),
+    "chronicler": ResidentConfig("metrics_series",   "rows_written", timedelta(hours=26),    1, expected_cadence_s=86400),
+    "sentinel":   ResidentConfig("sentinel_pulse",   "latest_count", timedelta(minutes=30),  1, expected_cadence_s=60),
 }
 
 

--- a/src/resident_progress/registry.py
+++ b/src/resident_progress/registry.py
@@ -23,19 +23,26 @@ class ResidentConfig:
     metric: str       # human-readable metric label, recorded on snapshot row
     window: timedelta
     threshold: int    # candidate fires when measured metric is strictly less than threshold
-    # Heartbeat cadence override. Drives critical-silence detection
+    # Heartbeat cadence. Drives critical-silence detection
     # (alive iff last_update within 3x cadence). Per-resident because
     # residents have very different natural cadences: Sentinel is a
     # 60s loop, Steward syncs every 5min, Vigil cycles every 30min,
-    # Chronicler runs daily, Watcher fires only on edits and has no
-    # natural heartbeat cadence at all. A single global default
-    # mislabels every non-continuous resident as "silent".
-    expected_cadence_s: int
+    # Chronicler runs daily. None is reserved for event-driven
+    # residents (Watcher) where heartbeat-liveness is the wrong
+    # abstraction — the probe skips the staleness gate for those.
+    expected_cadence_s: int | None
+
+    def __post_init__(self) -> None:
+        if self.expected_cadence_s is not None and self.expected_cadence_s <= 0:
+            raise ValueError(
+                f"expected_cadence_s must be positive or None, got "
+                f"{self.expected_cadence_s!r}"
+            )
 
 
 RESIDENT_PROGRESS_REGISTRY: dict[str, ResidentConfig] = {
     "vigil":      ResidentConfig("kg_writes",        "rows_written", timedelta(minutes=60),  1, expected_cadence_s=1800),
-    "watcher":    ResidentConfig("watcher_findings", "rows_any",     timedelta(hours=6),     1, expected_cadence_s=21600),
+    "watcher":    ResidentConfig("watcher_findings", "rows_any",     timedelta(hours=6),     1, expected_cadence_s=None),
     "steward":    ResidentConfig("eisv_sync_rows",   "rows_written", timedelta(minutes=30),  1, expected_cadence_s=300),
     "chronicler": ResidentConfig("metrics_series",   "rows_written", timedelta(hours=26),    1, expected_cadence_s=86400),
     "sentinel":   ResidentConfig("sentinel_pulse",   "latest_count", timedelta(minutes=30),  1, expected_cadence_s=60),

--- a/src/resident_progress/status.py
+++ b/src/resident_progress/status.py
@@ -1,7 +1,8 @@
 """Deterministic status-priority resolver for progress_flat snapshot rows.
 
 Priority (first match wins):
-    source-error > unresolved > startup-grace > silent > flat-candidate > OK
+    source-error > unresolved > startup-grace > never-seen > silent
+                 > flat-candidate > OK
 """
 from __future__ import annotations
 
@@ -14,6 +15,8 @@ def resolve_status(row: dict) -> str:
         return "unresolved"
     if suppressed == "startup_unresolved_label":
         return "startup-grace"
+    if suppressed == "never_seen":
+        return "never-seen"
     if suppressed in ("heartbeat_not_alive", "heartbeat_eval_error"):
         return "silent"
     if row.get("candidate") is True:

--- a/tests/resident_progress/test_heartbeat.py
+++ b/tests/resident_progress/test_heartbeat.py
@@ -56,3 +56,37 @@ async def test_evaluate_returns_error_on_store_exception():
     status = await ev.evaluate("u1")
     assert status.alive is False
     assert "db down" in (status.eval_error or "")
+
+
+@pytest.mark.asyncio
+async def test_cadence_override_supersedes_store_value():
+    # Store says 60s cadence (would mark a 20-min-old update silent),
+    # but caller overrides with 30-min cadence — agent stays alive.
+    now = datetime.now(timezone.utc)
+    store = _FakeMetadataStore({
+        "u1": {"last_update": now - timedelta(minutes=20),
+               "expected_cadence_s": 60},
+    })
+    ev = HeartbeatEvaluator(store, _now=lambda: now)
+    status = await ev.evaluate("u1", cadence_override_s=1800)
+    assert status.alive is True
+    assert status.expected_cadence_s == 1800
+    assert status.in_critical_silence is False
+
+
+@pytest.mark.asyncio
+async def test_cadence_override_used_when_store_has_no_cadence():
+    # Store returns no cadence at all — caller's override is the only
+    # cadence available. Without the override, evaluator must report
+    # not-alive (cadence=None branch).
+    now = datetime.now(timezone.utc)
+    store = _FakeMetadataStore({
+        "u1": {"last_update": now - timedelta(seconds=30)},
+    })
+    ev = HeartbeatEvaluator(store, _now=lambda: now)
+    no_override = await ev.evaluate("u1")
+    assert no_override.alive is False
+    assert no_override.expected_cadence_s is None
+    with_override = await ev.evaluate("u1", cadence_override_s=300)
+    assert with_override.alive is True
+    assert with_override.expected_cadence_s == 300

--- a/tests/resident_progress/test_heartbeat.py
+++ b/tests/resident_progress/test_heartbeat.py
@@ -90,3 +90,22 @@ async def test_cadence_override_used_when_store_has_no_cadence():
     with_override = await ev.evaluate("u1", cadence_override_s=300)
     assert with_override.alive is True
     assert with_override.expected_cadence_s == 300
+
+
+@pytest.mark.asyncio
+async def test_cadence_override_zero_does_not_fall_through():
+    # Falsy-or chains would silently swallow 0 and use the store value
+    # instead — a misconfiguration would produce wrong-but-quiet results.
+    # Treat explicit 0 as caller-provided "invalid", not "absent".
+    now = datetime.now(timezone.utc)
+    store = _FakeMetadataStore({
+        "u1": {"last_update": now - timedelta(seconds=30),
+               "expected_cadence_s": 60},
+    })
+    ev = HeartbeatEvaluator(store, _now=lambda: now)
+    status = await ev.evaluate("u1", cadence_override_s=0)
+    # 0 means "no usable cadence" → can't compute liveness → not alive,
+    # cadence=None on the response. Critically, it should NOT fall back
+    # to the store's 60s value.
+    assert status.alive is False
+    assert status.expected_cadence_s is None

--- a/tests/resident_progress/test_probe_task.py
+++ b/tests/resident_progress/test_probe_task.py
@@ -64,6 +64,7 @@ def _registry_one_vigil():
             metric="rows_written",
             window=timedelta(minutes=60),
             threshold=1,
+            expected_cadence_s=1800,
         )
     }
 
@@ -236,12 +237,14 @@ async def test_source_error_isolated_per_resident(monkeypatch):
             metric="rows_written",
             window=timedelta(minutes=60),
             threshold=1,
+            expected_cadence_s=1800,
         ),
         "watcher": ResidentConfig(
             source="watcher_findings",
             metric="rows_any",
             window=timedelta(hours=6),
             threshold=1,
+            expected_cadence_s=21600,
         ),
     }
     monkeypatch.setattr(

--- a/tests/resident_progress/test_probe_task.py
+++ b/tests/resident_progress/test_probe_task.py
@@ -4,7 +4,7 @@ All tests use mocks — no real DB, no real heartbeat calls.
 """
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
@@ -17,11 +17,17 @@ from src.resident_progress.registry import ResidentConfig
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _hb(alive, eval_error=None):
+# A non-None timestamp so heartbeat-not-alive states aren't conflated with
+# never-seen states. Tests that specifically want never-seen pass a fresh
+# HeartbeatStatus with last_update=None instead of going through this helper.
+_LAST_UPDATE_DEFAULT = datetime(2026, 4, 30, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def _hb(alive, eval_error=None, last_update=_LAST_UPDATE_DEFAULT):
     """Return a minimal HeartbeatStatus-like object."""
     return type("HS", (), {
         "alive": alive,
-        "last_update": None,
+        "last_update": last_update,
         "expected_cadence_s": 60,
         "in_critical_silence": not alive,
         "eval_error": eval_error,
@@ -523,3 +529,103 @@ async def test_dead_resident_metric_ok_no_suppression(monkeypatch):
 
     # No audit event (not a candidate)
     audit.emit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Event-driven cadence=None: probe synthesizes alive=True, skips heartbeat
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_event_driven_resident_skips_heartbeat_eval(monkeypatch):
+    """Watcher-style event-driven residents have expected_cadence_s=None.
+
+    The probe must synthesize alive=True and never call the heartbeat
+    evaluator — heartbeat liveness is the wrong abstraction for an
+    edit-triggered probe. Otherwise we'd encode "n/a" as "very slow
+    timeout" and silently break the candidate gate.
+    """
+    watcher_uuid = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+    monkeypatch.setattr(
+        "src.resident_progress.probe_task.RESIDENT_PROGRESS_REGISTRY",
+        {"watcher": ResidentConfig(
+            source="watcher_findings", metric="rows_any",
+            window=timedelta(hours=6), threshold=1,
+            expected_cadence_s=None,
+        )},
+    )
+    monkeypatch.setattr(
+        "src.resident_progress.probe_task.resolve_resident_uuid",
+        lambda label: watcher_uuid,
+    )
+
+    source = MagicMock()
+    source.fetch = AsyncMock(return_value={watcher_uuid: 0})  # below threshold
+
+    heartbeat = MagicMock()
+    heartbeat.evaluate = AsyncMock()
+
+    writer = MagicMock()
+    writer.write = AsyncMock()
+    audit = MagicMock()
+    audit.emit = AsyncMock()
+
+    probe = _make_probe(
+        sources_by_name={"watcher_findings": source},
+        heartbeat_evaluator=heartbeat,
+        writer=writer, audit_emitter=audit,
+    )
+    await probe.tick()
+
+    heartbeat.evaluate.assert_not_called()
+    row = writer.write.call_args_list[0][0][0][0]
+    assert row.heartbeat_alive is True
+    assert row.candidate is True
+    assert row.suppressed_reason is None
+
+
+# ---------------------------------------------------------------------------
+# Never-seen distinction: fresh resident has last_update=None
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_never_seen_marked_distinct_from_silent(monkeypatch):
+    """A resident whose anchor resolves but who has never checked in must
+    surface as 'never_seen', not 'heartbeat_not_alive'. Otherwise a fresh
+    Chronicler instance looks like a 3-day outage on the dashboard.
+    """
+    vigil_uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    monkeypatch.setattr(
+        "src.resident_progress.probe_task.RESIDENT_PROGRESS_REGISTRY",
+        _registry_one_vigil(),
+    )
+    monkeypatch.setattr(
+        "src.resident_progress.probe_task.resolve_resident_uuid",
+        lambda label: vigil_uuid,
+    )
+
+    source = MagicMock()
+    source.fetch = AsyncMock(return_value={vigil_uuid: 0})
+
+    never_seen_hb = type("HS", (), {
+        "alive": False, "last_update": None,
+        "expected_cadence_s": 1800, "in_critical_silence": False,
+        "eval_error": None,
+        "to_jsonable": lambda self: {"alive": False, "last_update": None},
+    })()
+    heartbeat = MagicMock()
+    heartbeat.evaluate = AsyncMock(return_value=never_seen_hb)
+
+    writer = MagicMock()
+    writer.write = AsyncMock()
+
+    probe = _make_probe(
+        sources_by_name={"kg_writes": source},
+        heartbeat_evaluator=heartbeat,
+        writer=writer,
+    )
+    await probe.tick()
+
+    row = writer.write.call_args_list[0][0][0][0]
+    assert row.suppressed_reason == "never_seen"
+    assert row.candidate is False
+    assert row.heartbeat_alive is False

--- a/tests/resident_progress/test_registry.py
+++ b/tests/resident_progress/test_registry.py
@@ -27,6 +27,22 @@ def test_registry_entries_have_required_fields():
         }
         assert cfg.window.total_seconds() > 0
         assert cfg.threshold >= 1
+        assert cfg.expected_cadence_s > 0
+
+
+def test_registry_cadences_match_resident_natural_periods():
+    # Each resident has a natural cadence that the heartbeat-liveness
+    # check must respect (alive iff last_update within 3x cadence).
+    # A single global default mislabels every non-continuous resident.
+    cadences = {
+        label: cfg.expected_cadence_s
+        for label, cfg in RESIDENT_PROGRESS_REGISTRY.items()
+    }
+    assert cadences["sentinel"] == 60       # continuous loop
+    assert cadences["steward"] == 300       # 5-min EISV sync
+    assert cadences["vigil"] == 1800        # 30-min launchd cron
+    assert cadences["watcher"] == 21600     # event-driven, 6h window
+    assert cadences["chronicler"] == 86400  # daily
 
 
 def test_resolve_resident_uuid_reads_anchor(tmp_path, monkeypatch):

--- a/tests/resident_progress/test_registry.py
+++ b/tests/resident_progress/test_registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import timedelta
 from pathlib import Path
 
 import pytest
@@ -27,13 +28,18 @@ def test_registry_entries_have_required_fields():
         }
         assert cfg.window.total_seconds() > 0
         assert cfg.threshold >= 1
-        assert cfg.expected_cadence_s > 0
+        # Cadence may be None for event-driven residents; otherwise must
+        # be positive. Validated at construction by ResidentConfig.
+        if cfg.expected_cadence_s is not None:
+            assert cfg.expected_cadence_s > 0
 
 
 def test_registry_cadences_match_resident_natural_periods():
     # Each resident has a natural cadence that the heartbeat-liveness
     # check must respect (alive iff last_update within 3x cadence).
     # A single global default mislabels every non-continuous resident.
+    # None means "event-driven, no heartbeat semantics" — Watcher fires
+    # on edits, not on a clock.
     cadences = {
         label: cfg.expected_cadence_s
         for label, cfg in RESIDENT_PROGRESS_REGISTRY.items()
@@ -41,8 +47,24 @@ def test_registry_cadences_match_resident_natural_periods():
     assert cadences["sentinel"] == 60       # continuous loop
     assert cadences["steward"] == 300       # 5-min EISV sync
     assert cadences["vigil"] == 1800        # 30-min launchd cron
-    assert cadences["watcher"] == 21600     # event-driven, 6h window
+    assert cadences["watcher"] is None      # event-driven
     assert cadences["chronicler"] == 86400  # daily
+
+
+def test_resident_config_rejects_zero_or_negative_cadence():
+    # __post_init__ guards against typos like expected_cadence_s=0
+    # in a future registry edit. A 0 cadence would silently fall
+    # through the heartbeat evaluator's falsy check before this guard.
+    with pytest.raises(ValueError, match="must be positive"):
+        ResidentConfig(
+            source="kg_writes", metric="rows", window=timedelta(seconds=60),
+            threshold=1, expected_cadence_s=0,
+        )
+    with pytest.raises(ValueError, match="must be positive"):
+        ResidentConfig(
+            source="kg_writes", metric="rows", window=timedelta(seconds=60),
+            threshold=1, expected_cadence_s=-1,
+        )
 
 
 def test_resolve_resident_uuid_reads_anchor(tmp_path, monkeypatch):

--- a/tests/resident_progress/test_status.py
+++ b/tests/resident_progress/test_status.py
@@ -19,6 +19,7 @@ def _row(**overrides):
     (_row(error_details={"source": "kg_writes"}), "source-error"),
     (_row(suppressed_reason="unresolved_label"), "unresolved"),
     (_row(suppressed_reason="startup_unresolved_label"), "startup-grace"),
+    (_row(suppressed_reason="never_seen", heartbeat_alive=False), "never-seen"),
     (_row(suppressed_reason="heartbeat_not_alive", heartbeat_alive=False), "silent"),
     (_row(suppressed_reason="heartbeat_eval_error", heartbeat_alive=False), "silent"),
     (_row(candidate=True, metric_below_threshold=True), "flat-candidate"),
@@ -26,6 +27,11 @@ def _row(**overrides):
     # Tie-break: source-error wins over unresolved
     (_row(error_details={"source": "x"}, suppressed_reason="unresolved_label"),
      "source-error"),
+    # Tie-break: never-seen wins over silent (never-seen is a more specific
+    # explanation; "this resident has never checked in" is not the same as
+    # "this resident went silent").
+    (_row(suppressed_reason="never_seen", heartbeat_alive=False,
+          candidate=False), "never-seen"),
     # Tie-break: silent wins over flat-candidate when both could apply
     (_row(suppressed_reason="heartbeat_not_alive", heartbeat_alive=False,
           candidate=False, metric_below_threshold=True), "silent"),


### PR DESCRIPTION
## Summary
The Resident Progress dashboard panel was reporting Vigil, Watcher, Steward, and Chronicler as "silent" between cycles because the heartbeat-liveness check used a hardcoded 60s fallback for every resident. That's right for Sentinel (continuous loop) and wrong for everyone else.

This thread per-resident `expected_cadence_s` from `RESIDENT_PROGRESS_REGISTRY` through the probe to `HeartbeatEvaluator` via a new `cadence_override_s` keyword. Drops the bogus 60s fallback.

| resident   | cadence  | basis                           |
|------------|----------|---------------------------------|
| sentinel   |     60s  | continuous loop                 |
| steward    |    300s  | 5-min EISV sync                 |
| vigil      |   1800s  | 30-min launchd cron             |
| watcher    |    None  | event-driven, heartbeat skipped |
| chronicler |  86400s  | daily                           |

Critical-silence threshold is `3 × cadence` (existing convention), so Vigil gets a 90-min grace and Chronicler gets 3 days before flagging silent. Watcher gets `expected_cadence_s=None`: the probe synthesizes `alive=True` and skips heartbeat eval entirely — heartbeat liveness is the wrong abstraction for an edit-triggered probe.

## Council fixes (second commit)
Parallel review (dialectic + code-reviewer + live-verifier) found three real bugs in the first commit:

1. **Event-driven mismatch** — original PR set Watcher to 21600s, encoding "not applicable" as "very slow timeout". Now `int | None` with `None` meaning "skip heartbeat".
2. **Falsy-0 fallthrough** — `cadence_override_s=0` would silently swallow into the store-value fallback. Now uses explicit `is not None` and treats 0 as caller-bug.
3. **never_seen vs silent** — a fresh resident with `last_update=None` looked identical to a 3-day outage. New `never_seen` suppressed_reason + `never-seen` panel status, priority above silent.

Plus: `ResidentConfig.__post_init__` now rejects 0 / negative cadence so typos fail loudly.

## Why this surfaced now
While debugging "what is the Resident Progress panel doing", noticed Steward has been actually silent since 2026-04-28 with `metadata.paused_at` stuck (separate fix needed — single SQL update + governance-mcp restart). The cadence bug was masking real silences inside a sea of false ones.

## Known divergence (follow-up, not blocker)
The lifecycle silence path in `background_tasks._silence_check_iteration` uses `interval × 2` as its silence threshold while the heartbeat evaluator uses `cadence × 3`. Same resident, two thresholds, divergent dashboard signals. Worth reconciling — flagged but out of scope for this PR.

## Test plan
- [x] `pytest tests/resident_progress/` — 67 pass
- [x] Full `./scripts/dev/test-cache.sh` — 7943 pass / 33 skip
- [x] Council review (3 agents in parallel)
- [ ] Post-deploy: verify Vigil/Steward/Chronicler stop showing as `silent` between their natural cycles; verify Watcher shows OK or flat-candidate (not silent)