### PR TITLE
feat(lease-plane): Elixir/OTP coordination kernel scaffold (no HTTP yet)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+/lib/
+/lib64/
 parts/
 sdist/
 var/

--- a/elixir/lease_plane/.formatter.exs
+++ b/elixir/lease_plane/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/elixir/lease_plane/.gitignore
+++ b/elixir/lease_plane/.gitignore
@@ -1,0 +1,24 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Temporary files, for example, from tests.
+/tmp/
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+lease_plane-*.tar
+

--- a/elixir/lease_plane/config/config.exs
+++ b/elixir/lease_plane/config/config.exs
@@ -1,0 +1,11 @@
+import Config
+
+config :lease_plane,
+  database_url:
+    System.get_env("UNITARES_LEASE_PLANE_DATABASE_URL") ||
+      "postgresql://postgres:postgres@localhost:5432/governance",
+  pool_size: 4
+
+if File.exists?("config/#{config_env()}.exs") do
+  import_config "#{config_env()}.exs"
+end

--- a/elixir/lease_plane/config/test.exs
+++ b/elixir/lease_plane/config/test.exs
@@ -1,0 +1,8 @@
+import Config
+
+config :lease_plane,
+  database_url:
+    System.get_env("UNITARES_LEASE_PLANE_DATABASE_URL") ||
+      "postgresql://postgres:postgres@localhost:5432/governance",
+  pool_size: 2,
+  start_application: false

--- a/elixir/lease_plane/lib/unitares_lease_plane.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane.ex
@@ -1,0 +1,62 @@
+defmodule UnitaresLeasePlane do
+  @moduledoc """
+  Surface lease plane v0 — Elixir/OTP coordination kernel.
+
+  Public-API wrappers live here. The contract is documented in
+  `docs/proposals/surface-lease-plane-v0.md` (RFC v0.5).
+
+  Top-level invariant: BEAM owns live coordination, Python owns governance
+  truth, Postgres owns durable truth. Nothing in this module may silently
+  become source of truth for identity, EISV, KG, or calibration.
+  """
+
+  alias UnitaresLeasePlane.{LeaseHolder, LeaseSupervisor, Repo}
+
+  @doc """
+  Acquire a lease for a `local_beam` surface — spawns a `LeaseHolder`
+  GenServer that owns the lease for the lifetime of its process.
+
+  Returns `{:ok, lease, idempotent_flag}` where `idempotent_flag` is `:new`
+  or `:idempotent`, or `{:error, reason}` matching the typed-absence shapes
+  from RFC §4.5.
+  """
+  @spec acquire_local_beam(map()) :: {:ok, map(), :new | :idempotent} | {:error, term()}
+  def acquire_local_beam(%{} = params) do
+    LeaseSupervisor.start_holder(params)
+  end
+
+  @doc """
+  Acquire a lease for a `remote_heartbeat` surface — no BEAM process is
+  spawned; the row is written and the remote client must HTTP-heartbeat
+  before `expires_at` or be reaped.
+  """
+  @spec acquire_remote_heartbeat(map()) :: {:ok, map(), :new | :idempotent} | {:error, term()}
+  def acquire_remote_heartbeat(%{} = params) do
+    Repo.acquire(Map.put(params, :holder_kind, "remote_heartbeat"))
+  end
+
+  @doc "Status by `surface_id`. Returns `{:ok, lease | nil}` or `{:error, reason}`."
+  @spec status(String.t()) :: {:ok, map() | nil} | {:error, term()}
+  def status(surface_id) when is_binary(surface_id), do: Repo.status(surface_id)
+
+  @doc "Renew a lease — extends `expires_at` by the immutable `original_ttl_s`."
+  @spec renew(binary()) :: :ok | {:error, term()}
+  def renew(lease_id) do
+    case LeaseSupervisor.holder_for(lease_id) do
+      {:ok, pid} -> LeaseHolder.renew(pid)
+      :error -> Repo.renew(lease_id)
+    end
+  end
+
+  @doc """
+  Release a lease. Local-BEAM holders should normally let process death do
+  this; calling release/2 directly is the explicit-shutdown path.
+  """
+  @spec release(binary(), String.t()) :: :ok | {:error, term()}
+  def release(lease_id, release_reason \\ "normal") do
+    case LeaseSupervisor.holder_for(lease_id) do
+      {:ok, pid} -> LeaseHolder.release(pid, release_reason)
+      :error -> Repo.release(lease_id, release_reason)
+    end
+  end
+end

--- a/elixir/lease_plane/lib/unitares_lease_plane/application.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/application.ex
@@ -1,0 +1,58 @@
+defmodule UnitaresLeasePlane.Application do
+  @moduledoc false
+
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    if Application.get_env(:lease_plane, :start_application, true) do
+      start_full()
+    else
+      Supervisor.start_link([], strategy: :one_for_one, name: UnitaresLeasePlane.Supervisor)
+    end
+  end
+
+  defp start_full do
+    children = [
+      {Postgrex, postgrex_opts()},
+      {Registry, keys: :unique, name: UnitaresLeasePlane.HolderRegistry},
+      UnitaresLeasePlane.LeaseSupervisor
+    ]
+
+    opts = [strategy: :one_for_one, name: UnitaresLeasePlane.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+
+  defp postgrex_opts do
+    url =
+      Application.get_env(:lease_plane, :database_url) ||
+        raise "UNITARES_LEASE_PLANE_DATABASE_URL or :lease_plane database_url config required"
+
+    pool_size = Application.get_env(:lease_plane, :pool_size, 4)
+    parsed = parse_url(url)
+
+    [
+      hostname: parsed.host,
+      port: parsed.port,
+      username: parsed.username,
+      password: parsed.password,
+      database: parsed.database,
+      pool_size: pool_size,
+      name: UnitaresLeasePlane.DB
+    ]
+  end
+
+  defp parse_url("postgresql://" <> rest) do
+    [creds_host, db] = String.split(rest, "/", parts: 2)
+    [creds, host_port] = String.split(creds_host, "@", parts: 2)
+    [user, pass] = String.split(creds, ":", parts: 2)
+
+    {host, port} =
+      case String.split(host_port, ":", parts: 2) do
+        [h, p] -> {h, String.to_integer(p)}
+        [h] -> {h, 5432}
+      end
+
+    %{username: user, password: pass, host: host, port: port, database: db}
+  end
+end

--- a/elixir/lease_plane/lib/unitares_lease_plane/lease_holder.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/lease_holder.ex
@@ -1,0 +1,119 @@
+defmodule UnitaresLeasePlane.LeaseHolder do
+  @moduledoc """
+  GenServer that owns a single `local_beam` lease for the lifetime of its
+  process. Runs an in-process renew timer at `original_ttl_s / 3` cadence
+  (RFC §4.4.2) so that a supervisor crash leaves a corpse lease for at
+  most `original_ttl_s` before the reaper sweeps it.
+
+  Process death paths:
+    - normal stop / `release/2` → updates `released_at` with the given reason
+    - abnormal exit              → terminate/2 records `release_reason='down_local'`
+    - reaper sweep (TTL expiry)  → DB row is closed externally; this process
+                                   detects the now-released row at next renew
+                                   and exits cleanly with `:ttl_expired`
+  """
+
+  use GenServer
+
+  require Logger
+  alias UnitaresLeasePlane.{HolderRegistry, Repo}
+
+  defstruct [:lease, :tick_ms]
+
+  # ---------- public API ----------
+
+  def start_link(%{lease_id: lease_id} = lease) do
+    GenServer.start_link(__MODULE__, lease, name: via(lease_id))
+  end
+
+  @spec renew(pid()) :: :ok | {:error, term()}
+  def renew(pid), do: GenServer.call(pid, :renew)
+
+  @spec release(pid(), String.t()) :: :ok | {:error, term()}
+  def release(pid, reason) when is_binary(reason) do
+    GenServer.call(pid, {:release, reason})
+  end
+
+  @spec lease(pid()) :: map()
+  def lease(pid), do: GenServer.call(pid, :lease)
+
+  defp via(lease_id), do: {:via, Registry, {HolderRegistry, {:lease, lease_id}}}
+
+  # ---------- callbacks ----------
+
+  @impl true
+  def init(%{original_ttl_s: ttl_s} = lease) do
+    Process.flag(:trap_exit, true)
+    tick_ms = max(div(ttl_s * 1000, 3), 1_000)
+    schedule_tick(tick_ms)
+    {:ok, %__MODULE__{lease: lease, tick_ms: tick_ms}}
+  end
+
+  @impl true
+  def handle_call(:lease, _from, state), do: {:reply, state.lease, state}
+
+  def handle_call(:renew, _from, state) do
+    case Repo.renew(state.lease.lease_id) do
+      :ok -> {:reply, :ok, state}
+      {:error, :not_found} -> {:stop, :ttl_expired, {:error, :not_found}, state}
+      err -> {:reply, err, state}
+    end
+  end
+
+  def handle_call({:release, reason}, _from, state) do
+    case Repo.release(state.lease.lease_id, reason) do
+      :ok -> {:stop, :normal, :ok, %{state | lease: %{state.lease | released_at: :released}}}
+      err -> {:reply, err, state}
+    end
+  end
+
+  @impl true
+  def handle_info(:tick, state) do
+    case Repo.renew(state.lease.lease_id) do
+      :ok ->
+        schedule_tick(state.tick_ms)
+        {:noreply, state}
+
+      {:error, :not_found} ->
+        # DB-side release happened (reaper, force-release, manual close) — the
+        # canonical truth says we no longer hold this lease. Exit cleanly.
+        {:stop, :ttl_expired, state}
+
+      {:error, reason} ->
+        Logger.warning("lease_plane renew tick failed: #{inspect(reason)}; will retry next tick")
+
+        schedule_tick(state.tick_ms)
+        {:noreply, state}
+    end
+  end
+
+  # trap_exit is on so we can run terminate/2 on abnormal shutdowns. EXIT
+  # signals (Process.exit, supervisor shutdown) land here and we forward to
+  # {:stop, reason, state} so terminate/2 gets a chance to write release rows.
+  def handle_info({:EXIT, _from, reason}, state) do
+    {:stop, reason, state}
+  end
+
+  @impl true
+  def terminate(reason, %{lease: %{released_at: :released}})
+      when reason in [:normal, :shutdown] do
+    :ok
+  end
+
+  def terminate(reason, %{lease: lease}) do
+    # Process is going down without an explicit release — record it.
+    case Repo.release(lease.lease_id, "down_local") do
+      :ok ->
+        :ok
+
+      err ->
+        Logger.warning(
+          "lease_plane terminate could not write down_local for #{lease.lease_id} reason=#{inspect(reason)}: #{inspect(err)}"
+        )
+
+        :ok
+    end
+  end
+
+  defp schedule_tick(ms), do: Process.send_after(self(), :tick, ms)
+end

--- a/elixir/lease_plane/lib/unitares_lease_plane/lease_supervisor.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/lease_supervisor.ex
@@ -1,0 +1,77 @@
+defmodule UnitaresLeasePlane.LeaseSupervisor do
+  @moduledoc """
+  DynamicSupervisor over `LeaseHolder` GenServers — one process per active
+  `local_beam` lease. The Registry maps lease_id → pid for lookup.
+
+  Remote-heartbeat leases do NOT live here; they are pure DB rows reaped
+  by TTL via the Reaper (Oban job, separate module).
+  """
+
+  use DynamicSupervisor
+
+  alias UnitaresLeasePlane.{LeaseHolder, Repo}
+
+  def start_link(_args), do: DynamicSupervisor.start_link(__MODULE__, [], name: __MODULE__)
+
+  @impl true
+  def init(_), do: DynamicSupervisor.init(strategy: :one_for_one)
+
+  @doc """
+  Acquire a `local_beam` lease and spawn its `LeaseHolder` process.
+  Returns `{:ok, lease, :new | :idempotent}` on success.
+  """
+  @spec start_holder(map()) ::
+          {:ok, map(), :new | :idempotent}
+          | {:error, :held_by_other, map()}
+          | {:error, term()}
+  def start_holder(%{} = params) do
+    params = Map.put(params, :holder_kind, "local_beam")
+
+    case Repo.acquire(params) do
+      {:ok, lease, kind} ->
+        case spawn_holder(lease) do
+          {:ok, _pid} -> {:ok, lease, kind}
+          {:error, :already_started} -> {:ok, lease, :idempotent}
+          err -> err
+        end
+
+      err ->
+        err
+    end
+  end
+
+  defp spawn_holder(%{lease_id: lease_id} = lease) do
+    spec = %{
+      id: LeaseHolder,
+      start: {LeaseHolder, :start_link, [lease]},
+      restart: :temporary
+    }
+
+    case DynamicSupervisor.start_child(__MODULE__, spec) do
+      {:ok, pid} ->
+        {:ok, pid}
+
+      {:error, {:already_started, _pid}} ->
+        {:error, :already_started}
+
+      {:error, _reason} = err ->
+        # Lease persisted but holder process refused to spawn — release the
+        # row so the surface isn't left ghost-held with no process to renew it.
+        _ = Repo.release(lease_id, "reaped_after_supervisor_failed")
+        err
+    end
+  end
+
+  @doc "Look up the holder pid for a given `lease_id`."
+  @spec holder_for(binary()) :: {:ok, pid()} | :error
+  def holder_for(lease_id) when is_binary(lease_id) do
+    case Registry.lookup(UnitaresLeasePlane.HolderRegistry, {:lease, lease_id}) do
+      [{pid, _}] -> {:ok, pid}
+      [] -> :error
+    end
+  end
+
+  @doc "How many local_beam holders are currently alive."
+  @spec count_holders() :: non_neg_integer()
+  def count_holders, do: DynamicSupervisor.count_children(__MODULE__).active
+end

--- a/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
@@ -1,0 +1,235 @@
+defmodule UnitaresLeasePlane.Repo do
+  @moduledoc """
+  Postgrex-backed durable mirror for `lease_plane.surface_leases` and
+  `lease_plane.lease_plane_events`. Intentionally not Ecto — keeping the
+  surface area minimal until v1.
+
+  Returns shapes mirror RFC §4.5 typed-absence:
+    {:ok, lease_map, :new | :idempotent}     # acquire
+    {:ok, lease_map | nil}                   # status
+    :ok | {:error, reason}                   # renew/release/heartbeat
+
+  All writes also append a row to `lease_plane.lease_plane_events`
+  (audit-outbox) inside the same transaction so durable truth and audit
+  trail cannot diverge. Forwarding to Python-side `audit.tool_usage`
+  happens in a separate Oban job (Phase A — not yet wired).
+  """
+
+  alias UnitaresLeasePlane.DB
+
+  @typep lease :: map()
+
+  # Cast uuid columns to text on the boundary so callers don't have to
+  # know whether Postgrex returned 16-byte raw binaries or 36-char strings.
+  @select_lease_columns """
+  lease_id::text AS lease_id,
+  surface_id, surface_kind,
+  holder_agent_uuid::text AS holder_agent_uuid,
+  holder_class, holder_kind, holder_pid, heartbeat_required, intent,
+  acquired_at, expires_at, last_heartbeat_at, released_at, release_reason,
+  audit_session, original_ttl_s, earned_status
+  """
+
+  # ---------- acquire ----------
+
+  @doc """
+  Idempotent acquire on `(surface_id, holder_agent_uuid)`. Returns the
+  existing active row with `:idempotent` if the requester already holds
+  a non-released lease for this surface; only when a different holder
+  is active do we return `{:error, :held_by_other, ...}`.
+  """
+  @spec acquire(map()) ::
+          {:ok, lease, :new | :idempotent}
+          | {:error, :held_by_other, %{held_by_uuid: binary(), expires_at: DateTime.t()}}
+          | {:error, term()}
+  def acquire(%{} = p) do
+    Postgrex.transaction(DB, fn conn ->
+      with {:ok, existing} <- maybe_existing_active(conn, p.surface_id),
+           {:ok, result} <- acquire_step(conn, p, existing) do
+        result
+      else
+        {:error, reason} -> Postgrex.rollback(conn, reason)
+      end
+    end)
+    |> normalize_tx_result()
+  end
+
+  defp maybe_existing_active(conn, surface_id) do
+    sql =
+      "SELECT #{@select_lease_columns} FROM lease_plane.surface_leases " <>
+        "WHERE surface_id = $1 AND released_at IS NULL"
+
+    case Postgrex.query(conn, sql, [surface_id]) do
+      {:ok, %{rows: []}} -> {:ok, nil}
+      {:ok, %{rows: [row], columns: cols}} -> {:ok, row_to_map(cols, row)}
+      {:error, e} -> {:error, e}
+    end
+  end
+
+  defp acquire_step(_conn, p, %{holder_agent_uuid: held} = existing)
+       when is_binary(held) do
+    if held == p.holder_agent_uuid do
+      {:ok, {:ok, existing, :idempotent}}
+    else
+      {:ok, {:error, :held_by_other, %{held_by_uuid: held, expires_at: existing.expires_at}}}
+    end
+  end
+
+  defp acquire_step(conn, p, nil) do
+    insert_lease_sql = """
+    INSERT INTO lease_plane.surface_leases
+      (surface_id, surface_kind, holder_agent_uuid, holder_class,
+       holder_kind, holder_pid, heartbeat_required, intent,
+       expires_at, original_ttl_s, audit_session, earned_status)
+    VALUES
+      ($1, $2, $3, $4, $5, $6, $7, $8,
+       now() + make_interval(secs => $9), $9, $10, 'provisional')
+    RETURNING #{@select_lease_columns}
+    """
+
+    args = [
+      p.surface_id,
+      p.surface_kind,
+      uuid_to_binary(p.holder_agent_uuid),
+      Map.get(p, :holder_class, "process_instance"),
+      p.holder_kind,
+      Map.get(p, :holder_pid),
+      p.holder_kind == "remote_heartbeat",
+      Map.get(p, :intent),
+      p.ttl_s,
+      Map.get(p, :audit_session)
+    ]
+
+    with {:ok, %{rows: [row], columns: cols}} <- Postgrex.query(conn, insert_lease_sql, args),
+         lease = row_to_map(cols, row),
+         :ok <- log_event(conn, "acquire", lease) do
+      {:ok, {:ok, lease, :new}}
+    end
+  end
+
+  # ---------- status ----------
+
+  @spec status(String.t()) :: {:ok, lease | nil} | {:error, term()}
+  def status(surface_id) when is_binary(surface_id) do
+    sql =
+      "SELECT #{@select_lease_columns} FROM lease_plane.surface_leases " <>
+        "WHERE surface_id = $1 AND released_at IS NULL"
+
+    case Postgrex.query(DB, sql, [surface_id]) do
+      {:ok, %{rows: []}} -> {:ok, nil}
+      {:ok, %{rows: [row], columns: cols}} -> {:ok, row_to_map(cols, row)}
+      {:error, e} -> {:error, e}
+    end
+  end
+
+  # ---------- renew / heartbeat ----------
+
+  @doc """
+  Aliases renew + heartbeat per RFC §4.4.2. Always extends by the
+  immutable `original_ttl_s`; never accepts caller-supplied ttl.
+  """
+  @spec renew(binary()) :: :ok | {:error, term()}
+  def renew(lease_id) do
+    sql = """
+    UPDATE lease_plane.surface_leases
+    SET expires_at = now() + make_interval(secs => original_ttl_s),
+        last_heartbeat_at = CASE WHEN heartbeat_required THEN now()
+                                 ELSE last_heartbeat_at END
+    WHERE lease_id = $1 AND released_at IS NULL
+    RETURNING #{@select_lease_columns}
+    """
+
+    case Postgrex.transaction(DB, fn conn ->
+           with {:ok, %{rows: [row], columns: cols}} <-
+                  Postgrex.query(conn, sql, [uuid_to_binary(lease_id)]),
+                lease = row_to_map(cols, row),
+                :ok <- log_event(conn, "renew", lease) do
+             :ok
+           else
+             {:ok, %{rows: []}} -> Postgrex.rollback(conn, :not_found)
+             {:error, e} -> Postgrex.rollback(conn, e)
+           end
+         end) do
+      {:ok, :ok} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # ---------- release ----------
+
+  @spec release(binary(), String.t()) :: :ok | {:error, term()}
+  def release(lease_id, release_reason) when is_binary(release_reason) do
+    sql = """
+    UPDATE lease_plane.surface_leases
+    SET released_at = now(), release_reason = $2
+    WHERE lease_id = $1 AND released_at IS NULL
+    RETURNING #{@select_lease_columns}
+    """
+
+    case Postgrex.transaction(DB, fn conn ->
+           with {:ok, %{rows: [row], columns: cols}} <-
+                  Postgrex.query(conn, sql, [uuid_to_binary(lease_id), release_reason]),
+                lease = row_to_map(cols, row),
+                :ok <- log_event(conn, "release", lease) do
+             :ok
+           else
+             {:ok, %{rows: []}} -> Postgrex.rollback(conn, :not_found)
+             {:error, e} -> Postgrex.rollback(conn, e)
+           end
+         end) do
+      {:ok, :ok} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # ---------- helpers ----------
+
+  defp log_event(conn, event_type, lease) do
+    sql = """
+    INSERT INTO lease_plane.lease_plane_events
+      (event_type, lease_id, surface_id, surface_kind,
+       holder_agent_uuid, holder_class, advisory_mode,
+       payload, earned_status)
+    VALUES ($1, $2, $3, $4, $5, $6, true, $7::jsonb, $8)
+    """
+
+    args = [
+      event_type,
+      uuid_to_binary(lease.lease_id),
+      lease.surface_id,
+      lease.surface_kind,
+      uuid_to_binary(lease.holder_agent_uuid),
+      lease.holder_class,
+      Jason.encode!(%{}),
+      lease.earned_status
+    ]
+
+    case Postgrex.query(conn, sql, args) do
+      {:ok, _} -> :ok
+      {:error, e} -> {:error, e}
+    end
+  end
+
+  defp row_to_map(columns, row) do
+    columns
+    |> Enum.zip(row)
+    |> Enum.into(%{}, fn {col, val} -> {String.to_atom(col), val} end)
+  end
+
+  # SELECT casts uuid columns to text so the boundary always sees 36-char strings.
+  # For parameter binding (INSERT/UPDATE/WHERE), Postgrex requires the canonical
+  # 16-byte binary form — uuid_to_binary/1 handles the conversion.
+
+  defp uuid_to_binary(uuid) when is_binary(uuid) and byte_size(uuid) == 16, do: uuid
+
+  defp uuid_to_binary(
+         <<a::binary-size(8), "-", b::binary-size(4), "-", c::binary-size(4), "-",
+           d::binary-size(4), "-", e::binary-size(12)>>
+       ) do
+    Base.decode16!(a <> b <> c <> d <> e, case: :mixed)
+  end
+
+  defp normalize_tx_result({:ok, {:ok, lease, kind}}), do: {:ok, lease, kind}
+  defp normalize_tx_result({:ok, {:error, code, detail}}), do: {:error, code, detail}
+  defp normalize_tx_result({:error, reason}), do: {:error, reason}
+end

--- a/elixir/lease_plane/mix.exs
+++ b/elixir/lease_plane/mix.exs
@@ -1,0 +1,34 @@
+defmodule UnitaresLeasePlane.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :lease_plane,
+      version: "0.1.0",
+      elixir: "~> 1.19",
+      start_permanent: Mix.env() == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger],
+      mod: {UnitaresLeasePlane.Application, []}
+    ]
+  end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
+
+  defp deps do
+    [
+      {:postgrex, "~> 0.20"},
+      {:jason, "~> 1.4"}
+      # HTTP layer in the next iteration:
+      # {:plug, "~> 1.16"},
+      # {:bandit, "~> 1.6"}
+    ]
+  end
+end

--- a/elixir/lease_plane/test/support/lease_test_helpers.ex
+++ b/elixir/lease_plane/test/support/lease_test_helpers.ex
@@ -1,0 +1,52 @@
+defmodule LeaseTestHelpers do
+  @moduledoc """
+  Test fixtures + cleanup. Tests use distinct `surface_id` values prefixed
+  with `test:elixir/<random>` so they cannot collide with real workloads or
+  each other.
+  """
+
+  alias UnitaresLeasePlane.DB
+
+  @doc "Generate a unique surface_id for a single test."
+  def unique_surface_id(label) when is_binary(label) do
+    rand = :crypto.strong_rand_bytes(6) |> Base.url_encode64(padding: false)
+    "test:elixir/#{label}/#{rand}"
+  end
+
+  @doc "Cleanup hook — DELETEs rows for a given surface_id from both tables."
+  def cleanup_surface(surface_id) when is_binary(surface_id) do
+    Postgrex.query!(
+      DB,
+      "DELETE FROM lease_plane.lease_plane_events WHERE surface_id = $1",
+      [surface_id]
+    )
+
+    Postgrex.query!(
+      DB,
+      "DELETE FROM lease_plane.surface_leases WHERE surface_id = $1",
+      [surface_id]
+    )
+
+    :ok
+  end
+
+  @doc "Stable random UUID-as-string for holder_agent_uuid in fixtures."
+  def random_uuid do
+    <<a::32, b::16, c::16, d::16, e::48>> = :crypto.strong_rand_bytes(16)
+    parts = [<<a::32>>, <<b::16>>, <<c::16>>, <<d::16>>, <<e::48>>]
+    parts |> Enum.map_join("-", &Base.encode16(&1, case: :lower))
+  end
+
+  @doc "Standard local_beam acquire fixture, returns the params map."
+  def local_beam_params(surface_id, opts \\ []) do
+    %{
+      surface_id: surface_id,
+      surface_kind: Keyword.get(opts, :surface_kind, "test"),
+      holder_agent_uuid: Keyword.get(opts, :holder_agent_uuid, random_uuid()),
+      holder_class: "process_instance",
+      ttl_s: Keyword.get(opts, :ttl_s, 30),
+      intent: Keyword.get(opts, :intent, "test"),
+      audit_session: Keyword.get(opts, :audit_session, "test-session")
+    }
+  end
+end

--- a/elixir/lease_plane/test/test_helper.exs
+++ b/elixir/lease_plane/test/test_helper.exs
@@ -1,0 +1,43 @@
+ExUnit.start()
+
+# Tests in this suite hit a real Postgres governance DB. Boot only the pieces
+# we need; the Application module is started in :test mode with no children
+# (see config/test.exs and Application.start/2's start_application gate).
+url =
+  System.get_env("UNITARES_LEASE_PLANE_DATABASE_URL") ||
+    Application.get_env(:lease_plane, :database_url)
+
+unless url do
+  raise "test_helper: UNITARES_LEASE_PLANE_DATABASE_URL or :lease_plane database_url required"
+end
+
+parsed =
+  url
+  |> String.replace_prefix("postgresql://", "")
+  |> then(fn rest ->
+    [creds_host, db] = String.split(rest, "/", parts: 2)
+    [creds, host_port] = String.split(creds_host, "@", parts: 2)
+    [user, pass] = String.split(creds, ":", parts: 2)
+
+    {host, port} =
+      case String.split(host_port, ":", parts: 2) do
+        [h, p] -> {h, String.to_integer(p)}
+        [h] -> {h, 5432}
+      end
+
+    %{username: user, password: pass, host: host, port: port, database: db}
+  end)
+
+{:ok, _} =
+  Postgrex.start_link(
+    name: UnitaresLeasePlane.DB,
+    hostname: parsed.host,
+    port: parsed.port,
+    username: parsed.username,
+    password: parsed.password,
+    database: parsed.database,
+    pool_size: 2
+  )
+
+{:ok, _} = Registry.start_link(keys: :unique, name: UnitaresLeasePlane.HolderRegistry)
+{:ok, _} = UnitaresLeasePlane.LeaseSupervisor.start_link(:ok)

--- a/elixir/lease_plane/test/unitares_lease_plane_test.exs
+++ b/elixir/lease_plane/test/unitares_lease_plane_test.exs
@@ -1,0 +1,153 @@
+defmodule UnitaresLeasePlaneTest do
+  use ExUnit.Case, async: false
+
+  import LeaseTestHelpers
+
+  alias UnitaresLeasePlane.{LeaseHolder, LeaseSupervisor, Repo}
+
+  setup do
+    surface = unique_surface_id("api")
+    on_exit(fn -> cleanup_surface(surface) end)
+    {:ok, surface: surface}
+  end
+
+  defp wait_until(fun, deadline_ms \\ 1_000, step_ms \\ 20)
+
+  defp wait_until(_fun, deadline_ms, _step_ms) when deadline_ms <= 0, do: false
+
+  defp wait_until(fun, deadline_ms, step_ms) do
+    if fun.() do
+      true
+    else
+      Process.sleep(step_ms)
+      wait_until(fun, deadline_ms - step_ms, step_ms)
+    end
+  end
+
+  describe "acquire_local_beam/1" do
+    test "spawns a holder, persists the row, and indexes by lease_id", ctx do
+      params = local_beam_params(ctx.surface)
+      assert {:ok, lease, :new} = UnitaresLeasePlane.acquire_local_beam(params)
+
+      assert lease.surface_id == ctx.surface
+      assert lease.holder_kind == "local_beam"
+      assert lease.heartbeat_required == false
+      assert lease.original_ttl_s == params.ttl_s
+      assert lease.earned_status == "provisional"
+      assert lease.released_at == nil
+
+      assert {:ok, pid} = LeaseSupervisor.holder_for(lease.lease_id)
+      assert Process.alive?(pid)
+      assert ^lease = LeaseHolder.lease(pid)
+    end
+
+    test "idempotent on retry from the same holder", ctx do
+      params = local_beam_params(ctx.surface)
+      assert {:ok, _lease1, :new} = UnitaresLeasePlane.acquire_local_beam(params)
+      assert {:ok, _lease2, :idempotent} = UnitaresLeasePlane.acquire_local_beam(params)
+    end
+
+    test "held_by_other when a different holder is active", ctx do
+      params_a = local_beam_params(ctx.surface)
+      params_b = local_beam_params(ctx.surface, holder_agent_uuid: random_uuid())
+
+      assert {:ok, _lease_a, :new} = UnitaresLeasePlane.acquire_local_beam(params_a)
+
+      assert {:error, :held_by_other, %{held_by_uuid: held_uuid}} =
+               UnitaresLeasePlane.acquire_local_beam(params_b)
+
+      assert held_uuid == params_a.holder_agent_uuid
+    end
+  end
+
+  describe "release/2" do
+    test "release via the holder pid stops the GenServer and writes released_at", ctx do
+      params = local_beam_params(ctx.surface)
+      assert {:ok, lease, :new} = UnitaresLeasePlane.acquire_local_beam(params)
+      assert {:ok, pid} = LeaseSupervisor.holder_for(lease.lease_id)
+
+      ref = Process.monitor(pid)
+      assert :ok = UnitaresLeasePlane.release(lease.lease_id, "normal")
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1_000
+
+      assert {:ok, nil} = UnitaresLeasePlane.status(ctx.surface)
+    end
+
+    test "kill bypasses terminate/2 — reaper covers the abnormal-exit path", ctx do
+      params = local_beam_params(ctx.surface)
+      assert {:ok, lease, :new} = UnitaresLeasePlane.acquire_local_beam(params)
+      assert {:ok, pid} = LeaseSupervisor.holder_for(lease.lease_id)
+
+      ref = Process.monitor(pid)
+      Process.exit(pid, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^pid, :killed}, 1_000
+
+      # Registry cleanup of dead-pid entries is async relative to our :DOWN —
+      # poll briefly until it catches up.
+      assert wait_until(fn -> LeaseSupervisor.holder_for(lease.lease_id) == :error end)
+    end
+
+    test "graceful exit (:shutdown) writes down_local via terminate/2", ctx do
+      params = local_beam_params(ctx.surface)
+      assert {:ok, lease, :new} = UnitaresLeasePlane.acquire_local_beam(params)
+      assert {:ok, pid} = LeaseSupervisor.holder_for(lease.lease_id)
+
+      ref = Process.monitor(pid)
+      Process.exit(pid, :shutdown)
+      assert_receive {:DOWN, ^ref, :process, ^pid, :shutdown}, 1_000
+
+      assert {:ok, nil} = UnitaresLeasePlane.status(ctx.surface)
+
+      # Inspect the closed row directly — query by surface_id so we don't
+      # have to round-trip the lease_id through Postgrex's UUID encoder.
+      sql =
+        "SELECT release_reason FROM lease_plane.surface_leases " <>
+          "WHERE surface_id = $1 AND released_at IS NOT NULL " <>
+          "ORDER BY released_at DESC LIMIT 1"
+
+      {:ok, %{rows: [[reason]]}} = Postgrex.query(UnitaresLeasePlane.DB, sql, [ctx.surface])
+      assert reason == "down_local"
+      _ = lease
+    end
+  end
+
+  describe "renew/1" do
+    test "extends expires_at by original_ttl_s", ctx do
+      params = local_beam_params(ctx.surface, ttl_s: 60)
+      assert {:ok, lease, :new} = UnitaresLeasePlane.acquire_local_beam(params)
+      original_expiry = lease.expires_at
+
+      Process.sleep(1100)
+      assert :ok = UnitaresLeasePlane.renew(lease.lease_id)
+
+      {:ok, refreshed} = UnitaresLeasePlane.status(ctx.surface)
+      assert DateTime.compare(refreshed.expires_at, original_expiry) == :gt
+      assert refreshed.original_ttl_s == 60
+    end
+
+    test "renew on a released lease returns :not_found", ctx do
+      params = local_beam_params(ctx.surface)
+      assert {:ok, lease, :new} = UnitaresLeasePlane.acquire_local_beam(params)
+      assert :ok = UnitaresLeasePlane.release(lease.lease_id, "normal")
+      Process.sleep(50)
+
+      assert {:error, :not_found} = Repo.renew(lease.lease_id)
+    end
+  end
+
+  describe "status/1" do
+    test "returns nil for unknown surface" do
+      assert {:ok, nil} = UnitaresLeasePlane.status("test:elixir/never-acquired")
+    end
+
+    test "returns the active lease record", ctx do
+      params = local_beam_params(ctx.surface)
+      assert {:ok, lease, :new} = UnitaresLeasePlane.acquire_local_beam(params)
+
+      {:ok, fetched} = UnitaresLeasePlane.status(ctx.surface)
+      assert fetched.lease_id == lease.lease_id
+      assert fetched.holder_agent_uuid == lease.holder_agent_uuid
+      assert fetched.earned_status == "provisional"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

First implementation slice of the BEAM coordination kernel per RFC v0.5 (`docs/proposals/surface-lease-plane-v0.md`). Per the operator brief: build the in-process machinery first, HTTP last — so this PR has zero exposed network surface; Python callers cannot use it end-to-end yet, but the Elixir-side contract is in place and tested.

Continues the BEAM coordination work after PR #250 closed council-found gaps in the Python contract anchor.

## Scope

**In:**
- Mix project at `elixir/lease_plane/` (single-node BEAM, no distributed Erlang per hard invariants)
- `UnitaresLeasePlane.Application` supervisor: Postgrex pool + `Registry` (unique keys) + `LeaseSupervisor` (DynamicSupervisor)
- `UnitaresLeasePlane.Repo` — thin Postgrex wrapper. Acquire / status / renew / release. Idempotent acquire on `(surface_id, holder_agent_uuid)`. Atomic acquire+event-log via `Postgrex.transaction`. UUID columns cast `::text` on the SELECT boundary; parameter binding uses 16-byte binaries via `uuid_to_binary/1`.
- `UnitaresLeasePlane.LeaseHolder` GenServer — one process per active `local_beam` lease. In-process renew tick at `original_ttl_s/3`. `trap_exit` is on so terminate/2 runs on graceful shutdowns and writes `release_reason='down_local'`. `:kill` bypasses terminate (Erlang invariant) — reaper will catch those.
- `UnitaresLeasePlane.LeaseSupervisor` DynamicSupervisor — spawns `LeaseHolder` per acquire; if `start_child` fails after the row was persisted, releases with `reaped_after_supervisor_failed` so no surface gets ghost-held.

**Out** (next PRs):
- HTTP endpoint (Plug + Bandit on `127.0.0.1:8788`)
- Handoff offer/accept (release-and-reacquire per RFC §5)
- Reaper (Oban job sweeping expired `remote_heartbeat` leases)
- Audit-outbox forwarder to `audit.tool_usage`

## Hard invariants respected

- BEAM owns live coordination, Python owns governance truth, Postgres owns durable truth. `Repo` writes only to `lease_plane.*` schema.
- Single-node BEAM. No distributed Erlang clustering.
- `earned_status` defaults to `'provisional'` on every acquire; promotion is a future migration, never an in-place UPDATE (immutability trigger from migration 025 enforces this).

## .gitignore note

Top-level `.gitignore` had `lib/` and `lib64/` from the standard Python-venv-install pattern, which was catching `elixir/lease_plane/lib/`. Anchored both to root (`/lib/`, `/lib64/`). No other `lib/` directories exist in the repo, so this is safe.

## Test plan

- [x] `cd elixir/lease_plane && mix compile` — clean, no warnings
- [x] `cd elixir/lease_plane && mix test` — 10/10 pass (3 consecutive runs)
- [x] `cd elixir/lease_plane && mix format --check-formatted`
- [x] `./scripts/dev/test-cache.sh` — Python suite 7962 passed, 33 skipped, 0 failed
- [x] Tests run against the live `governance` DB with `test:elixir/api/<rand>` surface_ids and `on_exit` cleanup — no leftover rows

## Test coverage

- `acquire_local_beam`: spawns + persists + registers correctly
- Idempotent acquire on same holder
- `held_by_other` on different holder
- `release/2` via pid stops the GenServer + writes `released_at`
- `:kill` bypasses terminate (Registry catches up)
- `:shutdown` writes `down_local` via `terminate/2`
- `renew/1` extends `expires_at` by `original_ttl_s`
- `renew/1` on released lease returns `:not_found`
- `status/1` returns nil for unknown surface
- `status/1` returns active row with `earned_status: "provisional"`

## Toolchain

Erlang/OTP 28 + Elixir 1.19.5 installed via Homebrew (was a real prereq blocker — no `mix`/`elixir`/`erl` on PATH before this session).

Deps: `postgrex 0.22.0`, `jason 1.4.4`, `db_connection 2.10.0`. Plug/Bandit are commented out in `mix.exs`, ready to flip on for the HTTP iteration.