### PR TITLE
feat(lease-plane): HTTP endpoint (Plug + Bandit on 127.0.0.1:8788)

### DIFF
--- a/elixir/lease_plane/lib/unitares_lease_plane/application.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/application.ex
@@ -13,14 +13,34 @@ defmodule UnitaresLeasePlane.Application do
   end
 
   defp start_full do
-    children = [
-      {Postgrex, postgrex_opts()},
-      {Registry, keys: :unique, name: UnitaresLeasePlane.HolderRegistry},
-      UnitaresLeasePlane.LeaseSupervisor
-    ]
+    # Bearer token must be sourced from env at boot. Fails closed (HTTPAuth
+    # returns 503) if absent — never silently open.
+    if token = System.get_env("LEASE_PLANE_BEARER_TOKEN") do
+      Application.put_env(:lease_plane, :bearer_token, token)
+    end
+
+    children =
+      [
+        {Postgrex, postgrex_opts()},
+        {Registry, keys: :unique, name: UnitaresLeasePlane.HolderRegistry},
+        UnitaresLeasePlane.LeaseSupervisor
+      ] ++ http_children()
 
     opts = [strategy: :one_for_one, name: UnitaresLeasePlane.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  defp http_children do
+    if Application.get_env(:lease_plane, :start_http, true) do
+      port = Application.get_env(:lease_plane, :http_port, 8788)
+      ip = Application.get_env(:lease_plane, :http_ip, {127, 0, 0, 1})
+
+      [
+        {Bandit, plug: UnitaresLeasePlane.HTTPRouter, ip: ip, port: port}
+      ]
+    else
+      []
+    end
   end
 
   defp postgrex_opts do

--- a/elixir/lease_plane/lib/unitares_lease_plane/http_auth.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/http_auth.ex
@@ -1,0 +1,59 @@
+defmodule UnitaresLeasePlane.HTTPAuth do
+  @moduledoc """
+  Bearer-token Plug. Reads the expected token at request time from
+  `Application.get_env(:lease_plane, :bearer_token)` (set at boot from the
+  `LEASE_PLANE_BEARER_TOKEN` env var, sourced from
+  `~/.config/cirwel/secrets.env`).
+
+  Comparison is constant-time via `Plug.Crypto.secure_compare/2` so timing
+  side-channels can't probe the token.
+
+  If no expected token is configured, the plug returns 503 — fails closed,
+  not silently open.
+  """
+
+  import Plug.Conn
+
+  @behaviour Plug
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(conn, _opts) do
+    expected = Application.get_env(:lease_plane, :bearer_token)
+
+    cond do
+      is_nil(expected) or expected == "" ->
+        send_json(conn, 503, %{
+          ok: false,
+          error: "service_unavailable",
+          reason: "bearer token not configured"
+        })
+
+      authorized?(conn, expected) ->
+        conn
+
+      true ->
+        send_json(conn, 401, %{
+          ok: false,
+          error: "permission_denied",
+          reason: "bearer token missing or invalid"
+        })
+    end
+  end
+
+  defp authorized?(conn, expected) do
+    case get_req_header(conn, "authorization") do
+      ["Bearer " <> presented] -> Plug.Crypto.secure_compare(presented, expected)
+      _ -> false
+    end
+  end
+
+  defp send_json(conn, status, body) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(status, Jason.encode!(body))
+    |> halt()
+  end
+end

--- a/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
@@ -1,0 +1,249 @@
+defmodule UnitaresLeasePlane.HTTPRouter do
+  @moduledoc """
+  HTTP surface for the lease plane. Routes match RFC v0.5 §5 exactly so the
+  Python client at `src/lease_plane/` is the conformance target.
+
+  Bind is local-only (`127.0.0.1`); a single shared bearer token from
+  `~/.config/cirwel/secrets.env` (`LEASE_PLANE_BEARER_TOKEN`) gates every
+  route. Body shapes are validated by Pattern + JSON-decode errors map to
+  `schema_invalid` per the typed-absence protocol — there is no leaky 400
+  HTML page.
+
+  Handoff (`/v1/lease/handoff/{offer,accept}`) is intentionally not wired
+  here — that work lands in a separate PR (release-and-reacquire pattern,
+  Oban offer-window timer).
+  """
+
+  use Plug.Router
+
+  alias UnitaresLeasePlane
+
+  plug(:match)
+
+  plug(Plug.Parsers,
+    parsers: [:json],
+    pass: ["application/json"],
+    json_decoder: Jason
+  )
+
+  plug(UnitaresLeasePlane.HTTPAuth)
+  plug(:dispatch)
+
+  # ---------- /v1/lease/acquire ----------
+  post "/v1/lease/acquire" do
+    case extract_acquire_params(conn.body_params) do
+      {:ok, params} ->
+        case UnitaresLeasePlane.acquire_local_beam(params) do
+          {:ok, lease, kind} ->
+            json(conn, 200, %{
+              ok: true,
+              lease: present_lease(lease),
+              idempotent: kind == :idempotent,
+              drift_warning: []
+            })
+
+          {:error, :held_by_other, %{held_by_uuid: uuid, expires_at: expires}} ->
+            json(conn, 409, %{
+              ok: false,
+              error: "held_by_other",
+              held_by_uuid: uuid,
+              expires_at: DateTime.to_iso8601(expires)
+            })
+
+          {:error, reason} ->
+            json(conn, 503, %{
+              ok: false,
+              error: "service_unavailable",
+              reason: inspect(reason)
+            })
+        end
+
+      {:error, detail} ->
+        json(conn, 422, %{ok: false, error: "schema_invalid", detail: detail})
+    end
+  end
+
+  # ---------- /v1/lease/status ----------
+  get "/v1/lease/status" do
+    case Map.get(conn.query_params, "surface_id") do
+      nil ->
+        json(conn, 422, %{ok: false, error: "schema_invalid", detail: "surface_id required"})
+
+      surface_id ->
+        case UnitaresLeasePlane.status(surface_id) do
+          {:ok, nil} ->
+            json(conn, 200, %{ok: true, lease: nil})
+
+          {:ok, lease} ->
+            json(conn, 200, %{ok: true, lease: present_lease(lease)})
+
+          {:error, reason} ->
+            json(conn, 503, %{ok: false, error: "service_unavailable", reason: inspect(reason)})
+        end
+    end
+  end
+
+  # ---------- /v1/lease/renew ----------
+  post("/v1/lease/renew", do: renew_or_heartbeat(conn))
+
+  # ---------- /v1/lease/heartbeat ----------
+  post("/v1/lease/heartbeat", do: renew_or_heartbeat(conn))
+
+  # ---------- /v1/lease/release ----------
+  post "/v1/lease/release" do
+    case extract_release_params(conn.body_params) do
+      {:ok, lease_id, reason} ->
+        case UnitaresLeasePlane.release(lease_id, reason) do
+          :ok ->
+            json(conn, 200, %{ok: true})
+
+          {:error, :not_found} ->
+            json(conn, 404, %{ok: false, error: "not_found"})
+
+          {:error, reason_atom} ->
+            json(conn, 503, %{
+              ok: false,
+              error: "service_unavailable",
+              reason: inspect(reason_atom)
+            })
+        end
+
+      {:error, detail} ->
+        json(conn, 422, %{ok: false, error: "schema_invalid", detail: detail})
+    end
+  end
+
+  # ---------- /v1/lease/handoff/{offer,accept} ----------
+  # Wired in the next PR. Returns service_unavailable so callers see typed-absence,
+  # not a 404 HTML page.
+  post "/v1/lease/handoff/offer" do
+    json(conn, 501, %{
+      ok: false,
+      error: "service_unavailable",
+      reason: "handoff not implemented in this build"
+    })
+  end
+
+  post "/v1/lease/handoff/accept" do
+    json(conn, 501, %{
+      ok: false,
+      error: "service_unavailable",
+      reason: "handoff not implemented in this build"
+    })
+  end
+
+  # ---------- catch-all ----------
+  match _ do
+    json(conn, 404, %{ok: false, error: "not_found"})
+  end
+
+  # ---------- helpers ----------
+
+  defp renew_or_heartbeat(conn) do
+    case Map.get(conn.body_params, "lease_id") do
+      lease_id when is_binary(lease_id) and byte_size(lease_id) > 0 ->
+        case UnitaresLeasePlane.renew(lease_id) do
+          :ok ->
+            json(conn, 200, %{ok: true})
+
+          {:error, :not_found} ->
+            json(conn, 404, %{ok: false, error: "not_found"})
+
+          {:error, reason} ->
+            json(conn, 503, %{ok: false, error: "service_unavailable", reason: inspect(reason)})
+        end
+
+      _ ->
+        json(conn, 422, %{ok: false, error: "schema_invalid", detail: "lease_id required"})
+    end
+  end
+
+  defp extract_acquire_params(%{} = body) do
+    required = ["surface_id", "surface_kind", "holder_agent_uuid", "holder_kind", "ttl_s"]
+    missing = Enum.filter(required, fn k -> is_nil(Map.get(body, k)) end)
+
+    cond do
+      missing != [] ->
+        {:error, "missing required fields: #{Enum.join(missing, ", ")}"}
+
+      Map.get(body, "holder_class") not in [nil, "process_instance", "substrate_earned"] ->
+        # 'role' and other classes are rejected before the DB CHECK — surface this
+        # as schema_invalid so the typed-absence error class is precise.
+        {:error, "holder_class must be process_instance or substrate_earned (RFC §7.1)"}
+
+      not is_integer(Map.get(body, "ttl_s")) ->
+        {:error, "ttl_s must be an integer"}
+
+      Map.get(body, "ttl_s") <= 0 or Map.get(body, "ttl_s") > 3600 ->
+        {:error, "ttl_s must be in (0, 3600]"}
+
+      true ->
+        {:ok,
+         %{
+           surface_id: body["surface_id"],
+           surface_kind: body["surface_kind"],
+           holder_agent_uuid: body["holder_agent_uuid"],
+           holder_class: Map.get(body, "holder_class", "process_instance"),
+           holder_kind: body["holder_kind"],
+           ttl_s: body["ttl_s"],
+           intent: Map.get(body, "intent"),
+           audit_session: Map.get(body, "audit_session"),
+           holder_pid: Map.get(body, "holder_pid")
+         }}
+    end
+  end
+
+  defp extract_acquire_params(_), do: {:error, "body must be a JSON object"}
+
+  defp extract_release_params(%{"lease_id" => lease_id} = body)
+       when is_binary(lease_id) and byte_size(lease_id) > 0 do
+    reason = Map.get(body, "release_reason", "normal")
+
+    if reason in [
+         "normal",
+         "down_local",
+         "reaped_after_supervisor_failed",
+         "reaped_local_ttl",
+         "reaped_remote_ttl",
+         "handoff",
+         "forced"
+       ] do
+      {:ok, lease_id, reason}
+    else
+      {:error, "invalid release_reason: #{inspect(reason)}"}
+    end
+  end
+
+  defp extract_release_params(_), do: {:error, "lease_id required"}
+
+  defp present_lease(%{} = lease) do
+    %{
+      lease_id: lease.lease_id,
+      surface_id: lease.surface_id,
+      surface_kind: lease.surface_kind,
+      holder_agent_uuid: lease.holder_agent_uuid,
+      holder_class: lease.holder_class,
+      holder_kind: lease.holder_kind,
+      holder_pid: lease.holder_pid,
+      heartbeat_required: lease.heartbeat_required,
+      intent: lease.intent,
+      acquired_at: iso(lease.acquired_at),
+      expires_at: iso(lease.expires_at),
+      last_heartbeat_at: iso(lease.last_heartbeat_at),
+      released_at: iso(lease.released_at),
+      release_reason: lease.release_reason,
+      audit_session: lease.audit_session,
+      original_ttl_s: lease.original_ttl_s,
+      earned_status: lease.earned_status
+    }
+  end
+
+  defp iso(nil), do: nil
+  defp iso(%DateTime{} = dt), do: DateTime.to_iso8601(dt)
+
+  defp json(conn, status, body) do
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.send_resp(status, Jason.encode!(body))
+  end
+end

--- a/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
@@ -15,19 +15,52 @@ defmodule UnitaresLeasePlane.HTTPRouter do
   """
 
   use Plug.Router
+  use Plug.ErrorHandler
+
+  require Logger
 
   alias UnitaresLeasePlane
 
   plug(:match)
 
-  plug(Plug.Parsers,
+  # HTTPAuth runs BEFORE body parsing so an unauthenticated caller cannot
+  # probe endpoint existence by sending malformed JSON (which would otherwise
+  # raise inside Plug.Parsers and surface a generic 400 *before* auth ran).
+  # Bearer auth doesn't need the parsed body; it only reads the Authorization
+  # header.
+  plug(UnitaresLeasePlane.HTTPAuth)
+
+  # SafeParsers wraps Plug.Parsers so JSON / media-type errors become typed
+  # 422 / 415 schema_invalid responses instead of Bandit's default empty 400.
+  plug(UnitaresLeasePlane.SafeParsers,
     parsers: [:json],
     pass: ["application/json"],
     json_decoder: Jason
   )
 
-  plug(UnitaresLeasePlane.HTTPAuth)
   plug(:dispatch)
+
+  # Plug.ErrorHandler catches anything raised inside route handlers
+  # (Postgrex connection failures, unexpected nil dereferences, etc.) and
+  # converts them into a typed-absence 503 with a redacted reason. The full
+  # error is logged server-side; the wire body never carries inspect output.
+  @impl Plug.ErrorHandler
+  def handle_errors(conn, %{kind: kind, reason: reason, stack: _stack}) do
+    Logger.error(
+      "lease plane HTTP error: kind=#{kind} reason=#{Exception.format_banner(kind, reason)}"
+    )
+
+    body =
+      Jason.encode!(%{
+        ok: false,
+        error: "service_unavailable",
+        reason: "internal error"
+      })
+
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.send_resp(503, body)
+  end
 
   # ---------- /v1/lease/acquire ----------
   post "/v1/lease/acquire" do
@@ -51,11 +84,8 @@ defmodule UnitaresLeasePlane.HTTPRouter do
             })
 
           {:error, reason} ->
-            json(conn, 503, %{
-              ok: false,
-              error: "service_unavailable",
-              reason: inspect(reason)
-            })
+            Logger.error("lease plane acquire failed: #{inspect(reason)}")
+            json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
         end
 
       {:error, detail} ->
@@ -78,7 +108,8 @@ defmodule UnitaresLeasePlane.HTTPRouter do
             json(conn, 200, %{ok: true, lease: present_lease(lease)})
 
           {:error, reason} ->
-            json(conn, 503, %{ok: false, error: "service_unavailable", reason: inspect(reason)})
+            Logger.error("lease plane status failed: #{inspect(reason)}")
+            json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
         end
     end
   end
@@ -101,11 +132,8 @@ defmodule UnitaresLeasePlane.HTTPRouter do
             json(conn, 404, %{ok: false, error: "not_found"})
 
           {:error, reason_atom} ->
-            json(conn, 503, %{
-              ok: false,
-              error: "service_unavailable",
-              reason: inspect(reason_atom)
-            })
+            Logger.error("lease plane release failed: #{inspect(reason_atom)}")
+            json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
         end
 
       {:error, detail} ->
@@ -150,7 +178,8 @@ defmodule UnitaresLeasePlane.HTTPRouter do
             json(conn, 404, %{ok: false, error: "not_found"})
 
           {:error, reason} ->
-            json(conn, 503, %{ok: false, error: "service_unavailable", reason: inspect(reason)})
+            Logger.error("lease plane renew failed: #{inspect(reason)}")
+            json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
         end
 
       _ ->

--- a/elixir/lease_plane/lib/unitares_lease_plane/safe_parsers.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/safe_parsers.ex
@@ -1,0 +1,52 @@
+defmodule UnitaresLeasePlane.SafeParsers do
+  @moduledoc """
+  Wraps `Plug.Parsers` so a `Plug.Parsers.ParseError` (malformed JSON,
+  unsupported media type) becomes a typed-absence `schema_invalid` 422
+  instead of Bandit's default empty-body 400.
+
+  Why a shim instead of moving Plug.Parsers behind a try/rescue inline:
+  the router pipeline runs plugs in declaration order, and we want one
+  named site for the conversion so future contributors can find it.
+  """
+
+  @behaviour Plug
+
+  alias Plug.Parsers
+  alias Plug.Conn
+
+  @impl true
+  def init(opts), do: Parsers.init(opts)
+
+  @impl true
+  def call(conn, opts) do
+    try do
+      Parsers.call(conn, opts)
+    rescue
+      e in Parsers.ParseError ->
+        body =
+          Jason.encode!(%{
+            ok: false,
+            error: "schema_invalid",
+            detail: "malformed request body: #{Exception.message(e)}"
+          })
+
+        conn
+        |> Conn.put_resp_content_type("application/json")
+        |> Conn.send_resp(422, body)
+        |> Conn.halt()
+
+      e in Parsers.UnsupportedMediaTypeError ->
+        body =
+          Jason.encode!(%{
+            ok: false,
+            error: "schema_invalid",
+            detail: "unsupported media type: #{Exception.message(e)}"
+          })
+
+        conn
+        |> Conn.put_resp_content_type("application/json")
+        |> Conn.send_resp(415, body)
+        |> Conn.halt()
+    end
+  end
+end

--- a/elixir/lease_plane/mix.exs
+++ b/elixir/lease_plane/mix.exs
@@ -25,10 +25,9 @@ defmodule UnitaresLeasePlane.MixProject do
   defp deps do
     [
       {:postgrex, "~> 0.20"},
-      {:jason, "~> 1.4"}
-      # HTTP layer in the next iteration:
-      # {:plug, "~> 1.16"},
-      # {:bandit, "~> 1.6"}
+      {:jason, "~> 1.4"},
+      {:plug, "~> 1.16"},
+      {:bandit, "~> 1.6"}
     ]
   end
 end

--- a/elixir/lease_plane/test/http_router_test.exs
+++ b/elixir/lease_plane/test/http_router_test.exs
@@ -1,0 +1,274 @@
+defmodule UnitaresLeasePlane.HTTPRouterTest do
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  import LeaseTestHelpers
+
+  alias UnitaresLeasePlane.HTTPRouter
+
+  @opts HTTPRouter.init([])
+  @bearer "test-bearer-token-do-not-use-in-prod"
+
+  setup do
+    Application.put_env(:lease_plane, :bearer_token, @bearer)
+    surface = unique_surface_id("http")
+    on_exit(fn -> cleanup_surface(surface) end)
+    {:ok, surface: surface}
+  end
+
+  defp authed(conn), do: put_req_header(conn, "authorization", "Bearer #{@bearer}")
+
+  defp acquire_body(surface, opts \\ []) do
+    %{
+      surface_id: surface,
+      surface_kind: Keyword.get(opts, :surface_kind, "test"),
+      holder_agent_uuid: Keyword.get(opts, :holder_agent_uuid, random_uuid()),
+      holder_kind: Keyword.get(opts, :holder_kind, "local_beam"),
+      holder_class: Keyword.get(opts, :holder_class, "process_instance"),
+      ttl_s: Keyword.get(opts, :ttl_s, 30),
+      intent: "http test"
+    }
+  end
+
+  defp post_json(path, body) do
+    :post
+    |> conn(path, Jason.encode!(body))
+    |> put_req_header("content-type", "application/json")
+    |> authed()
+    |> HTTPRouter.call(@opts)
+  end
+
+  defp parsed(conn), do: Jason.decode!(conn.resp_body)
+
+  describe "bearer auth" do
+    test "missing Authorization header → 401 permission_denied", ctx do
+      resp =
+        :post
+        |> conn("/v1/lease/acquire", Jason.encode!(acquire_body(ctx.surface)))
+        |> put_req_header("content-type", "application/json")
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 401
+      assert parsed(resp)["error"] == "permission_denied"
+    end
+
+    test "wrong bearer → 401 permission_denied", ctx do
+      resp =
+        :post
+        |> conn("/v1/lease/acquire", Jason.encode!(acquire_body(ctx.surface)))
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "Bearer wrong-token")
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 401
+    end
+
+    test "no expected token configured → 503 fail-closed", ctx do
+      Application.put_env(:lease_plane, :bearer_token, nil)
+      on_exit(fn -> Application.put_env(:lease_plane, :bearer_token, @bearer) end)
+
+      resp = post_json("/v1/lease/acquire", acquire_body(ctx.surface))
+      assert resp.status == 503
+      assert parsed(resp)["error"] == "service_unavailable"
+    end
+  end
+
+  describe "POST /v1/lease/acquire" do
+    test "happy path returns ok=true with a fully-populated lease", ctx do
+      resp = post_json("/v1/lease/acquire", acquire_body(ctx.surface))
+
+      assert resp.status == 200
+      body = parsed(resp)
+      assert body["ok"] == true
+      assert body["idempotent"] == false
+      assert body["drift_warning"] == []
+
+      lease = body["lease"]
+      assert lease["surface_id"] == ctx.surface
+      assert lease["holder_kind"] == "local_beam"
+      assert lease["heartbeat_required"] == false
+      assert lease["original_ttl_s"] == 30
+      assert lease["earned_status"] == "provisional"
+      assert lease["released_at"] == nil
+      assert is_binary(lease["lease_id"])
+      assert is_binary(lease["expires_at"])
+    end
+
+    test "idempotent retry from same holder", ctx do
+      body = acquire_body(ctx.surface)
+
+      resp1 = post_json("/v1/lease/acquire", body)
+      assert resp1.status == 200
+      assert parsed(resp1)["idempotent"] == false
+
+      resp2 = post_json("/v1/lease/acquire", body)
+      assert resp2.status == 200
+      assert parsed(resp2)["idempotent"] == true
+    end
+
+    test "different holder → 409 held_by_other", ctx do
+      body_a = acquire_body(ctx.surface)
+      body_b = acquire_body(ctx.surface, holder_agent_uuid: random_uuid())
+
+      assert post_json("/v1/lease/acquire", body_a).status == 200
+
+      resp = post_json("/v1/lease/acquire", body_b)
+      assert resp.status == 409
+
+      payload = parsed(resp)
+      assert payload["error"] == "held_by_other"
+      assert payload["held_by_uuid"] == body_a.holder_agent_uuid
+      assert is_binary(payload["expires_at"])
+    end
+
+    test "holder_class='role' → 422 schema_invalid (rejected before DB)", ctx do
+      body = acquire_body(ctx.surface, holder_class: "role")
+      resp = post_json("/v1/lease/acquire", body)
+      assert resp.status == 422
+      assert parsed(resp)["error"] == "schema_invalid"
+    end
+
+    test "missing ttl_s → 422 schema_invalid", ctx do
+      body = ctx.surface |> acquire_body() |> Map.delete(:ttl_s)
+      resp = post_json("/v1/lease/acquire", body)
+      assert resp.status == 422
+    end
+
+    test "ttl_s out of (0, 3600] → 422", ctx do
+      assert post_json("/v1/lease/acquire", acquire_body(ctx.surface, ttl_s: 0)).status == 422
+
+      assert post_json("/v1/lease/acquire", acquire_body(ctx.surface, ttl_s: 4000)).status ==
+               422
+    end
+  end
+
+  describe "GET /v1/lease/status" do
+    test "unknown surface → ok with lease=nil" do
+      resp =
+        :get
+        |> conn("/v1/lease/status?surface_id=test:elixir/http/never-acquired")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 200
+      assert parsed(resp)["lease"] == nil
+    end
+
+    test "active surface → ok with lease record", ctx do
+      assert post_json("/v1/lease/acquire", acquire_body(ctx.surface)).status == 200
+
+      resp =
+        :get
+        |> conn("/v1/lease/status?surface_id=#{URI.encode_www_form(ctx.surface)}")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 200
+      assert parsed(resp)["lease"]["surface_id"] == ctx.surface
+    end
+
+    test "missing surface_id → 422", _ctx do
+      resp =
+        :get
+        |> conn("/v1/lease/status")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 422
+    end
+  end
+
+  describe "POST /v1/lease/renew + /heartbeat" do
+    test "extends expires_at on a held lease", ctx do
+      acquire = post_json("/v1/lease/acquire", acquire_body(ctx.surface, ttl_s: 60))
+      assert acquire.status == 200
+      lease_id = parsed(acquire)["lease"]["lease_id"]
+      original_expiry = parsed(acquire)["lease"]["expires_at"]
+
+      Process.sleep(1100)
+      renew = post_json("/v1/lease/renew", %{lease_id: lease_id})
+      assert renew.status == 200
+      assert parsed(renew) == %{"ok" => true}
+
+      status =
+        :get
+        |> conn("/v1/lease/status?surface_id=#{URI.encode_www_form(ctx.surface)}")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      new_expiry = parsed(status)["lease"]["expires_at"]
+      assert new_expiry > original_expiry
+    end
+
+    test "heartbeat alias works the same", ctx do
+      acquire = post_json("/v1/lease/acquire", acquire_body(ctx.surface))
+      lease_id = parsed(acquire)["lease"]["lease_id"]
+
+      hb = post_json("/v1/lease/heartbeat", %{lease_id: lease_id})
+      assert hb.status == 200
+    end
+
+    test "missing lease_id → 422" do
+      resp = post_json("/v1/lease/renew", %{})
+      assert resp.status == 422
+    end
+  end
+
+  describe "POST /v1/lease/release" do
+    test "release happy path returns ok=true", ctx do
+      acquire = post_json("/v1/lease/acquire", acquire_body(ctx.surface))
+      lease_id = parsed(acquire)["lease"]["lease_id"]
+
+      resp = post_json("/v1/lease/release", %{lease_id: lease_id, release_reason: "normal"})
+      assert resp.status == 200
+      assert parsed(resp) == %{"ok" => true}
+
+      # Subsequent status returns nil — released
+      status =
+        :get
+        |> conn("/v1/lease/status?surface_id=#{URI.encode_www_form(ctx.surface)}")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      assert parsed(status)["lease"] == nil
+    end
+
+    test "invalid release_reason → 422 schema_invalid", _ctx do
+      resp = post_json("/v1/lease/release", %{lease_id: random_uuid(), release_reason: "bogus"})
+      assert resp.status == 422
+    end
+  end
+
+  describe "POST /v1/lease/handoff/{offer,accept} (stubbed)" do
+    test "offer returns 501 service_unavailable until implemented", _ctx do
+      resp =
+        post_json("/v1/lease/handoff/offer", %{
+          lease_id: random_uuid(),
+          to_holder_agent_uuid: random_uuid(),
+          ttl_s: 30
+        })
+
+      assert resp.status == 501
+      assert parsed(resp)["error"] == "service_unavailable"
+    end
+
+    test "accept returns 501 service_unavailable until implemented", _ctx do
+      resp = post_json("/v1/lease/handoff/accept", %{handoff_id: random_uuid()})
+      assert resp.status == 501
+    end
+  end
+
+  describe "404" do
+    test "unknown route returns typed-absence not_found" do
+      resp =
+        :get
+        |> conn("/v1/lease/nope")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 404
+      assert parsed(resp)["error"] == "not_found"
+    end
+  end
+end

--- a/elixir/lease_plane/test/http_router_test.exs
+++ b/elixir/lease_plane/test/http_router_test.exs
@@ -271,4 +271,66 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
       assert parsed(resp)["error"] == "not_found"
     end
   end
+
+  describe "auth-bypass and parser hardening (council #253 fixes)" do
+    test "malformed JSON WITHOUT auth → 401, not 400 — auth gates first", _ctx do
+      resp =
+        :post
+        |> conn("/v1/lease/acquire", "not json {")
+        |> put_req_header("content-type", "application/json")
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 401
+      assert parsed(resp)["error"] == "permission_denied"
+    end
+
+    test "malformed JSON WITH auth → 422 typed-absence, not 400 empty", _ctx do
+      resp =
+        :post
+        |> conn("/v1/lease/acquire", "not json {")
+        |> put_req_header("content-type", "application/json")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 422
+      body = parsed(resp)
+      assert body["ok"] == false
+      assert body["error"] == "schema_invalid"
+      assert is_binary(body["detail"])
+    end
+
+    test "unsupported content-type → 415 typed-absence", _ctx do
+      resp =
+        :post
+        |> conn("/v1/lease/acquire", "<xml/>")
+        |> put_req_header("content-type", "application/xml")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 415
+      assert parsed(resp)["error"] == "schema_invalid"
+    end
+
+    test "handle_errors/2 emits typed 503 with redacted reason (no inspect leak)", _ctx do
+      # Plug.ErrorHandler sends the 503 response and *then re-raises* the original
+      # error so logging middleware further up the chain can record it. Testing
+      # the full path through Plug.Test is brittle (the WrapperError carries the
+      # pre-handler conn). Direct test of handle_errors/2 is the same coverage —
+      # what matters is the response shape, not which integration triggered it.
+      conn = conn(:post, "/v1/lease/renew")
+
+      result =
+        HTTPRouter.handle_errors(conn, %{
+          kind: :error,
+          reason: %RuntimeError{message: "postgresql password=hunter2 leaked"},
+          stack: []
+        })
+
+      assert result.status == 503
+      body = Jason.decode!(result.resp_body)
+      assert body == %{"ok" => false, "error" => "service_unavailable", "reason" => "internal error"}
+      # Verify the leaky inspect string never made it to the wire.
+      refute result.resp_body =~ "hunter2"
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Closes the loop between the Python contract anchor in `src/lease_plane/` and the Elixir lease plane (#251). With this PR merged, Python callers can talk end-to-end against the BEAM coordination kernel.

Routes match RFC v0.5 §5 byte-for-byte; the Pydantic shapes in `src/lease_plane/models.py` are the conformance target.

## What this adds

- **Deps:** `plug 1.18`, `bandit 1.8`.
- **`UnitaresLeasePlane.HTTPRouter`** (Plug.Router):
    | Route | Status |
    |-------|--------|
    | `POST /v1/lease/acquire` | implemented |
    | `GET  /v1/lease/status` | implemented |
    | `POST /v1/lease/renew` | implemented |
    | `POST /v1/lease/heartbeat` | implemented (aliased to renew per §4.4.2) |
    | `POST /v1/lease/release` | implemented |
    | `POST /v1/lease/handoff/offer` | **stubbed → 501 service_unavailable** (next PR) |
    | `POST /v1/lease/handoff/accept` | **stubbed → 501 service_unavailable** (next PR) |
- **`UnitaresLeasePlane.HTTPAuth`** (Plug): bearer-token gate from `LEASE_PLANE_BEARER_TOKEN` env (sourced at boot from `~/.config/cirwel/secrets.env`). `Plug.Crypto.secure_compare/2` for constant-time comparison. **Fails closed** — no expected token configured returns 503, never silently open.
- **Application supervisor:** starts Bandit on `127.0.0.1:8788` (configurable via `:http_port` and `:http_ip`). Gated by `:start_http` (default `true`; tests set `false`).

## Hard invariants respected

- Local-only bind. No off-host exposure in v0.
- Bearer auth fails closed.
- `holder_class='role'` rejected at the HTTP boundary with `schema_invalid` (RFC §7.1) — three layers: HTTP, Pydantic Literal, DB CHECK. Defense-in-depth.
- `ttl_s` validated to `(0, 3600]` at boundary, matching Pydantic + DB CHECK.
- No governance-domain writes (still only `lease_plane.*` schema).

## Out of scope (next PRs)

- Handoff offer/accept — release-and-reacquire pattern, Oban offer-window timer.
- Oban reaper for remote_heartbeat TTL expiry.
- Audit-outbox forwarder to `audit.tool_usage`.
- Python `lease_plane.client` round-trip integration test against the running server (the Elixir-side coverage already validates the same contract; can ride with the handoff PR).

## Test plan

- [x] `cd elixir/lease_plane && mix compile` — clean
- [x] `cd elixir/lease_plane && mix test` — **30/30 pass × 3 runs** (10 prior + 20 new HTTP via Plug.Test)
- [x] `cd elixir/lease_plane && mix format --check-formatted`

### HTTP test coverage breakdown

- **Bearer auth:** missing header → 401; wrong bearer → 401; no expected token → 503 fail-closed
- **`/v1/lease/acquire`:** happy path with full populated lease (earned_status=provisional); idempotent retry from same holder; different holder → 409 held_by_other w/ held_by_uuid + expires_at; `holder_class='role'` → 422; missing ttl_s → 422; ttl_s out of (0, 3600] → 422
- **`/v1/lease/status`:** unknown surface → ok+nil; active surface → ok+lease; missing surface_id → 422
- **`/v1/lease/renew` + `/heartbeat`:** extends expires_at (verified by re-reading status); heartbeat alias same path; missing lease_id → 422
- **`/v1/lease/release`:** happy path; subsequent status nil; invalid release_reason → 422
- **`/v1/lease/handoff/{offer,accept}`:** both → 501 service_unavailable until handoff PR
- **Catch-all:** unknown route → typed-absence not_found (no HTML 404 leak)

## Note on the Python test suite

`./scripts/dev/test-cache.sh` shows one failure in `tests/resident_progress/test_http_endpoint.py::test_endpoint_status_field_uses_priority_resolver`, which **I verified also fails on master** with my changes stashed. No Python files are touched by this PR; the failure is unrelated (resident_progress dashboard, not lease plane). Likely introduced by #252 (s8a Phase-2). Flagging for separate triage — not blocking this PR.