### PR TITLE
fix(grounding): persist tags before in-memory mutation (P011)

### DIFF
--- a/src/grounding/onboard_classifier.py
+++ b/src/grounding/onboard_classifier.py
@@ -116,7 +116,7 @@ async def stamp_default_class_tags(
     if default_tags is None:
         return None
 
+    await agent_storage.update_agent(agent_id=agent_uuid, tags=default_tags)
     if meta is not None:
         meta.tags = default_tags
-    await agent_storage.update_agent(agent_id=agent_uuid, tags=default_tags)
     return default_tags

--- a/tests/test_onboard_classifier.py
+++ b/tests/test_onboard_classifier.py
@@ -160,6 +160,22 @@ async def test_explicit_name_takes_precedence_over_meta_label():
 
 
 @pytest.mark.asyncio
+async def test_stamp_does_not_mutate_meta_when_persist_fails():
+    """P011 regression: persist must come before in-memory mutation, so a
+    failed DB write does not leave meta.tags pointing at a value the DB has
+    no record of (which would be clobbered on the next metadata reload).
+    """
+    meta = _make_meta(tags=None)
+    fake_update = AsyncMock(side_effect=RuntimeError("PG unavailable"))
+    with patch("src.agent_storage.update_agent", fake_update):
+        from src.grounding.onboard_classifier import stamp_default_class_tags
+        with pytest.raises(RuntimeError):
+            await stamp_default_class_tags("uuid-1234", "Sentinel", meta=meta)
+    assert meta.tags is None
+    fake_update.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_onboard_wrapper_still_calls_through():
     """The thin ``_stamp_default_tags_on_onboard`` wrapper in identity/handlers.py
     must still produce the same end-state for backward compat."""


### PR DESCRIPTION
## Summary

- Swap two lines in `stamp_default_class_tags` so `agent_storage.update_agent(...)` is awaited **before** `meta.tags = default_tags`.
- The function's own docstring already specifies this ordering ("`meta.tags` is updated in place after the DB write"); the implementation didn't match.
- Add a regression test that asserts `meta.tags` stays `None` when `update_agent` raises.

## Why it matters

If the DB write failed, the in-memory metadata was already mutated to a tag list the database had no record of. The next metadata reload would clobber the in-memory copy with the empty DB row, silently reverting the classification.

The window for this in production is narrow (the caller in `phases.py` wraps the whole call in a `try/except` that logs at `debug` level), but the failure mode is exactly the kind that would degrade silently across a restart and only surface as "why is this agent untagged again."

Watcher flagged this under P011 (`mutation before persistence — will be clobbered on next load`) — fingerprint `b9ab68a0`.

## Test plan

- [x] `pytest tests/test_onboard_classifier.py` — 20 passed (1 new regression test)
- [x] Pre-push smoke suite — 138 passed
- [ ] Maintainer: spot-check that the stamp still appears in metadata after a successful `process_agent_update` against a real DB