### PR TITLE
fix(updates): preserve api_key when PG insert succeeds but meta setup fails

### DIFF
--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -632,6 +632,7 @@ async def execute_locked_update(ctx: UpdateContext) -> Optional[Sequence[TextCon
         purpose_str = purpose.strip() if purpose and isinstance(purpose, str) else None
         ctx.api_key = secrets.token_urlsafe(32)
 
+        pg_create_succeeded = False
         try:
             agent_record, created_agent = await agent_storage.get_or_create_agent(
                 agent_id=ctx.agent_id,
@@ -639,6 +640,7 @@ async def execute_locked_update(ctx: UpdateContext) -> Optional[Sequence[TextCon
                 status='active',
                 purpose=purpose_str,
             )
+            pg_create_succeeded = True
             logger.debug(f"PostgreSQL: Created agent {ctx.agent_id}")
             await ctx.loop.run_in_executor(
                 None,
@@ -677,7 +679,17 @@ async def execute_locked_update(ctx: UpdateContext) -> Optional[Sequence[TextCon
                 None,
                 lambda: mcp_server.get_or_create_metadata(ctx.agent_id, purpose=purpose_str)
             )
-            ctx.api_key = ctx.meta.api_key if ctx.meta else None
+            if pg_create_succeeded:
+                # PG already has the freshly-generated ctx.api_key — sync the
+                # fallback metadata to match instead of overwriting ctx with a
+                # stale value from the cache. Without this, ctx.api_key gets
+                # silently replaced and the agent's auth desyncs from PG.
+                if ctx.meta:
+                    ctx.meta.api_key = ctx.api_key
+            else:
+                # PG insert never happened; the metadata cache is source of
+                # truth for whatever credential downstream code will see.
+                ctx.api_key = ctx.meta.api_key if ctx.meta else None
     else:
         try:
             agent_record = await agent_storage.get_agent(ctx.agent_id)

--- a/tests/test_core_update.py
+++ b/tests/test_core_update.py
@@ -1088,6 +1088,53 @@ class TestProcessAgentUpdateExtended:
             mock_server.get_or_create_metadata.assert_called()
 
     # ------------------------------------------------------------------
+    # New agent creation: PG insert succeeds but metadata setup raises.
+    # The freshly-generated api_key (already persisted to PG) must NOT be
+    # silently replaced by the metadata-cache fallback in the except branch.
+    # ------------------------------------------------------------------
+    @pytest.mark.asyncio
+    async def test_new_agent_pg_insert_succeeds_but_meta_setup_fails_keeps_apikey(
+        self, mock_server, mock_monitor,
+    ):
+        """If get_or_create_agent succeeded (api_key is in PG), but a later
+        step in the same try block raised, the recovery branch must preserve
+        the api_key that was just persisted — not overwrite it with whatever
+        api_key the in-memory metadata cache happens to hold.
+        """
+        agent_uuid = "test-uuid-meta-fail"
+        mock_server.agent_metadata = {}
+        mock_server.get_or_create_monitor.return_value = mock_monitor
+        mock_server.monitors = {}
+
+        fallback_meta = _make_metadata(total_updates=1, api_key="stale-cached-key")
+        mock_server.get_or_create_metadata = MagicMock(
+            side_effect=[RuntimeError("metadata setup blew up"), fallback_meta]
+        )
+
+        p = self._common_patches(mock_server, agent_uuid=agent_uuid)
+        # PG insert succeeds — return a real record.
+        p["storage"].get_or_create_agent = AsyncMock(
+            return_value=(MagicMock(api_key="test-key"), True)
+        )
+
+        with self._apply_patches(p):
+            from src.mcp_handlers.core import handle_process_agent_update
+            await handle_process_agent_update({
+                "response_text": "first update",
+                "complexity": 0.5,
+            })
+
+        # PG was given the freshly-generated api_key — capture what we wrote.
+        pg_apikey = p["storage"].get_or_create_agent.call_args.kwargs["api_key"]
+        assert pg_apikey  # sanity: we did pass one
+
+        # The fallback metadata's api_key was "stale-cached-key" before the
+        # call. After recovery, it must be re-stamped to match what's in PG,
+        # so downstream code (and the in-memory cache) agree on the credential.
+        assert fallback_meta.api_key == pg_apikey
+        assert fallback_meta.api_key != "stale-cached-key"
+
+    # ------------------------------------------------------------------
     # Lines 979, 982: Existing agent sync to cache
     # ------------------------------------------------------------------
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

In the auto-create branch of `process_update` (the path where a new agent appears via `process_agent_update` rather than `onboard`), `ctx.api_key` is generated fresh on line 633 and passed to `agent_storage.get_or_create_agent`. If the PG insert succeeded but a later step in the same try block raised, the recovery branch silently overwrote `ctx.api_key` with whatever the in-memory metadata cache happened to hold — desyncing the live credential from what was just persisted.

Track whether the PG insert completed and split the recovery:

- **PG insert succeeded** → sync the fallback meta's api_key to match `ctx.api_key`. Keep the freshly-persisted credential as the source of truth.
- **PG insert failed** → fall back to the metadata cache's api_key as before (no PG row exists, so the cache is the only available source of truth).

## Origin

Watcher R000 (fingerprint `442fb5bc`) flagged this region with the wrong word ("race condition" — there's no concurrency here), but careful re-reading of the flagged block surfaced this real edge case underneath. Watcher finding has been dismissed as the literal claim was incorrect; this PR addresses the actual bug.

## Test plan

- [x] New regression test `test_new_agent_pg_insert_succeeds_but_meta_setup_fails_keeps_apikey` — passes
- [x] Existing PG-failure-fallback test still passes (no regression in the `pg_create_succeeded == False` path)
- [x] Full `tests/test_core_update.py` — 75 passed
- [x] Pre-push smoke suite — 138 passed
- [ ] Maintainer: spot-check that recovery from a real metadata-cache exception keeps the auth credential consistent