### PR TITLE
feat(watcher): Phase A advisory-mode lease-plane wiring on scan_commits

### DIFF
--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -913,11 +913,31 @@ def scan_commits(since: str = "30 days ago", repo_path: Path | None = None) -> i
         resolving a finding whose fix was reverted.
       - Ambiguous prefixes that match more than one fingerprint.
 
+    Phase A lease-plane integration: each scan acquires an advisory-mode
+    lease at `surface_id=watcher:scan_commits:<repo_root>`. The lease is
+    *telemetry only* — Watcher proceeds whether the lease is acquired,
+    held by another scanner, or unavailable. RFC v0.5 §6.1.
+
     Returns:
         The number of findings resolved this scan. Always returns 0 on git
         failure rather than raising, so this is safe to call from a cron.
     """
     repo_root = repo_path or PROJECT_ROOT
+
+    from src.lease_plane.advisory import lease_advisory_scope, new_holder_uuid
+
+    surface_id = f"watcher:scan_commits:{repo_root}"
+    with lease_advisory_scope(
+        surface_id=surface_id,
+        surface_kind="watcher_scan_commits",
+        holder_agent_uuid=new_holder_uuid(),
+        ttl_s=60,
+        intent=f"scan_commits since={since!r}",
+    ):
+        return _scan_commits_inner(since, repo_root)
+
+
+def _scan_commits_inner(since: str, repo_root: Path) -> int:
     try:
         result = subprocess.run(
             ["git", "log", f"--since={since}", "--format=%H%x00%s%x00%b%x1e"],

--- a/agents/watcher/tests/test_scan_commits.py
+++ b/agents/watcher/tests/test_scan_commits.py
@@ -15,6 +15,7 @@ Edge cases that need to stay locked down:
 
 from __future__ import annotations
 
+import contextlib
 import json
 
 import pytest
@@ -248,4 +249,71 @@ class TestScanCommitsResilience:
         _seed(watcher_module.FINDINGS_FILE, _seed_finding(fp, status="open"))
         body = f"fixes {fp}\nalso see {fp}"
         make_subprocess_run(_git_log_record("d" * 40, "fix", body))
+        assert watcher_module.scan_commits() == 1
+
+
+class TestScanCommitsLeaseAdvisory:
+    """Phase A advisory lease wiring (RFC v0.5 §6.1).
+
+    These tests verify that `scan_commits` routes through the lease plane's
+    advisory scope, but DO NOT enforce any lease-related behavior — Phase A
+    is telemetry-only. The body of `scan_commits` must run identically
+    whether the lease is acquired, contended, or unavailable.
+    """
+
+    def test_scan_commits_invokes_lease_advisory_with_expected_surface(
+        self, make_subprocess_run, monkeypatch
+    ):
+        """Surface_id must be stable across runs so Phase A telemetry can be
+        correlated. Locking the shape down here so a future refactor that
+        renames the surface gets a noisy test failure instead of silent
+        telemetry drift."""
+        from src.lease_plane import advisory as advisory_module
+
+        captured: dict = {}
+        original_scope = advisory_module.lease_advisory_scope
+
+        @contextlib.contextmanager
+        def _capturing_scope(*args, **kwargs):
+            captured.update(kwargs)
+            with original_scope(*args, **kwargs) as ret:
+                yield ret
+
+        monkeypatch.setattr(advisory_module, "lease_advisory_scope", _capturing_scope)
+
+        fp = "abcd1234ef005678"
+        _seed(watcher_module.FINDINGS_FILE, _seed_finding(fp, status="open"))
+        make_subprocess_run(_git_log_record("d" * 40, "fix", fp))
+
+        # No bearer token in test env, so the wrapper falls back to disabled
+        # client (every acquire → service_unavailable). The body MUST still
+        # run end-to-end.
+        monkeypatch.delenv("LEASE_PLANE_BEARER_TOKEN", raising=False)
+        result = watcher_module.scan_commits()
+
+        assert result == 1, "Phase A advisory: body must run regardless of lease outcome"
+
+        assert captured["surface_kind"] == "watcher_scan_commits"
+        assert captured["surface_id"].startswith("watcher:scan_commits:")
+        assert captured["ttl_s"] == 60
+        assert "since=" in captured["intent"]
+
+    def test_scan_commits_runs_when_lease_held_by_other(
+        self, make_subprocess_run, monkeypatch
+    ):
+        """held_by_other MUST NOT block Phase A — body still runs."""
+        from src.lease_plane import advisory as advisory_module
+
+        @contextlib.contextmanager
+        def _held_by_other_scope(**_kwargs):
+            yield "held_by_other", None
+
+        monkeypatch.setattr(
+            advisory_module, "lease_advisory_scope", _held_by_other_scope
+        )
+
+        fp = "abcd1234ef005678"
+        _seed(watcher_module.FINDINGS_FILE, _seed_finding(fp, status="open"))
+        make_subprocess_run(_git_log_record("d" * 40, "fix", fp))
+
         assert watcher_module.scan_commits() == 1

--- a/src/lease_plane/advisory.py
+++ b/src/lease_plane/advisory.py
@@ -1,0 +1,216 @@
+"""Phase A advisory-mode wrappers around the lease plane.
+
+Per RFC v0.5 §6.1, Phase A integrations call the lease plane for
+*telemetry only* — never enforcement. A failed acquire (held_by_other,
+service_unavailable, network error, missing bearer token) MUST NOT block
+the caller's normal operation. The point of Phase A is to discover
+whether leases would have prevented real collisions, not to actually
+prevent them yet.
+
+This module is the recommended on-ramp for Python residents (Watcher,
+Steward, ship.sh, dispatch). Each resident imports `lease_advisory_scope`
+and wraps its unit-of-work without changing behavior on lease outcome.
+
+Environment:
+    LEASE_PLANE_BEARER_TOKEN — bearer token (sourced from
+        ~/.config/cirwel/secrets.env). If unset, the helper returns a
+        disabled client and every acquire surfaces as service_unavailable
+        in the log; the caller proceeds normally.
+    LEASE_PLANE_BASE_URL — defaults to http://127.0.0.1:8788.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import uuid
+from collections.abc import Iterator
+from typing import Literal
+
+from . import (
+    AcquireHeldByOther,
+    AcquireOk,
+    AcquirePermissionDenied,
+    AcquireRequest,
+    AcquireSchemaInvalid,
+    AcquireServiceUnavailable,
+    LeasePlaneClient,
+    LeasePlaneClientConfig,
+    LeasePlaneDisabledClient,
+    ReleaseRequest,
+)
+
+__all__ = [
+    "AdvisoryOutcome",
+    "lease_advisory_scope",
+    "make_advisory_client",
+    "new_holder_uuid",
+]
+
+logger = logging.getLogger(__name__)
+
+
+AdvisoryOutcome = Literal[
+    "acquired_new",
+    "acquired_idempotent",
+    "held_by_other",
+    "service_unavailable",
+    "permission_denied",
+    "schema_invalid",
+    "client_error",
+]
+
+
+def make_advisory_client() -> LeasePlaneClient:
+    """Construct the advisory-mode client.
+
+    If `LEASE_PLANE_BEARER_TOKEN` is unset or empty, returns a
+    `LeasePlaneDisabledClient` — every call returns `service_unavailable`,
+    which is exactly what Phase A wants for unconfigured environments.
+    """
+    token = os.environ.get("LEASE_PLANE_BEARER_TOKEN", "").strip()
+    base_url = os.environ.get("LEASE_PLANE_BASE_URL", "http://127.0.0.1:8788").strip()
+
+    if not token:
+        return LeasePlaneDisabledClient()
+
+    return LeasePlaneClient(
+        LeasePlaneClientConfig(
+            base_url=base_url,
+            bearer_token=token,
+            timeout_s=2.0,
+        )
+    )
+
+
+def new_holder_uuid() -> uuid.UUID:
+    """Fresh UUID for a Phase A holder.
+
+    Phase A treats every Python invocation as a fresh process_instance —
+    `force_new` semantics from `docs/ontology/identity.md`. Long-lived
+    residents that want substrate-earned continuity will graduate later.
+    """
+    return uuid.uuid4()
+
+
+@contextlib.contextmanager
+def lease_advisory_scope(
+    *,
+    surface_id: str,
+    surface_kind: str,
+    holder_agent_uuid: uuid.UUID,
+    ttl_s: int,
+    intent: str | None = None,
+    audit_session: str | None = None,
+    client: LeasePlaneClient | None = None,
+) -> Iterator[tuple[AdvisoryOutcome, uuid.UUID | None]]:
+    """Phase A advisory wrapper.
+
+    Yields `(outcome, lease_id_or_none)`. The yielded lease_id is set only
+    on `acquired_new` or `acquired_idempotent`; on every other outcome the
+    block still runs (Phase A is non-enforcing), but no release is issued
+    on exit.
+
+    The wrapper NEVER raises from the lease layer. Any exception raised by
+    the caller's block will propagate normally; the wrapper only ensures
+    the lease is released if it was acquired.
+    """
+    advisory_client = client or make_advisory_client()
+
+    request = AcquireRequest(
+        surface_id=surface_id,
+        surface_kind=surface_kind,
+        holder_agent_uuid=holder_agent_uuid,
+        holder_class="process_instance",
+        holder_kind="remote_heartbeat",
+        ttl_s=ttl_s,
+        intent=intent,
+        audit_session=audit_session,
+    )
+
+    outcome, lease_id = _acquire_and_classify(advisory_client, request)
+
+    try:
+        yield outcome, lease_id
+    finally:
+        if lease_id is not None:
+            _release_quiet(advisory_client, lease_id)
+
+
+def _acquire_and_classify(
+    client: LeasePlaneClient, request: AcquireRequest
+) -> tuple[AdvisoryOutcome, uuid.UUID | None]:
+    try:
+        result = client.acquire(request)
+    except Exception as exc:  # defensive — client is supposed to be no-raise
+        logger.warning(
+            "lease_advisory: acquire raised unexpectedly surface=%s err=%r",
+            request.surface_id,
+            exc,
+        )
+        return "client_error", None
+
+    if isinstance(result, AcquireOk):
+        outcome: AdvisoryOutcome = "acquired_idempotent" if result.idempotent else "acquired_new"
+        logger.info(
+            "lease_advisory: %s surface=%s lease_id=%s drift=%s",
+            outcome,
+            request.surface_id,
+            result.lease.lease_id,
+            result.drift_warning,
+        )
+        return outcome, result.lease.lease_id
+
+    if isinstance(result, AcquireHeldByOther):
+        logger.info(
+            "lease_advisory: held_by_other surface=%s held_by=%s expires=%s "
+            "(Phase A: proceeding regardless)",
+            request.surface_id,
+            result.held_by_uuid,
+            result.expires_at.isoformat(),
+        )
+        return "held_by_other", None
+
+    if isinstance(result, AcquireServiceUnavailable):
+        logger.info(
+            "lease_advisory: service_unavailable surface=%s "
+            "(lease plane down or unconfigured)",
+            request.surface_id,
+        )
+        return "service_unavailable", None
+
+    if isinstance(result, AcquirePermissionDenied):
+        logger.warning(
+            "lease_advisory: permission_denied surface=%s reason=%s",
+            request.surface_id,
+            result.reason,
+        )
+        return "permission_denied", None
+
+    if isinstance(result, AcquireSchemaInvalid):
+        logger.warning(
+            "lease_advisory: schema_invalid surface=%s detail=%s",
+            request.surface_id,
+            result.detail,
+        )
+        return "schema_invalid", None
+
+    logger.warning(
+        "lease_advisory: unrecognized result surface=%s result=%r",
+        request.surface_id,
+        result,
+    )
+    return "client_error", None
+
+
+def _release_quiet(client: LeasePlaneClient, lease_id: uuid.UUID) -> None:
+    try:
+        result = client.release(ReleaseRequest(lease_id=lease_id, release_reason="normal"))
+        logger.info(
+            "lease_advisory: released lease_id=%s ok=%s",
+            lease_id,
+            getattr(result, "ok", None),
+        )
+    except Exception as exc:
+        logger.warning("lease_advisory: release raised lease_id=%s err=%r", lease_id, exc)

--- a/tests/test_lease_plane_advisory.py
+++ b/tests/test_lease_plane_advisory.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID, uuid4
+
+from src.lease_plane import (
+    AcquireHeldByOther,
+    AcquireOk,
+    AcquireRequest,
+    AcquireServiceUnavailable,
+    LeasePlaneClient,
+    LeasePlaneClientConfig,
+    LeasePlaneDisabledClient,
+    SimpleOk,
+)
+from src.lease_plane.advisory import lease_advisory_scope, make_advisory_client
+
+
+def _ok_lease_payload(holder_uuid: UUID) -> dict[str, Any]:
+    now = datetime.now(UTC).replace(microsecond=0)
+    return {
+        "lease_id": str(uuid4()),
+        "surface_id": "test:advisory/x",
+        "surface_kind": "test",
+        "holder_agent_uuid": str(holder_uuid),
+        "holder_class": "process_instance",
+        "holder_kind": "remote_heartbeat",
+        "holder_pid": None,
+        "heartbeat_required": True,
+        "intent": "test",
+        "acquired_at": now.isoformat(),
+        "expires_at": (now + timedelta(seconds=60)).isoformat(),
+        "last_heartbeat_at": now.isoformat(),
+        "released_at": None,
+        "release_reason": None,
+        "audit_session": None,
+        "original_ttl_s": 60,
+        "earned_status": "provisional",
+    }
+
+
+def _scripted_transport(responses: list[dict[str, Any]]):
+    calls: list[tuple[str, str, dict[str, Any] | None]] = []
+
+    def transport(req):
+        calls.append((req.method, req.url, req.json_body))
+        return responses.pop(0)
+
+    return transport, calls
+
+
+def test_acquired_new_runs_block_and_releases():
+    holder = uuid4()
+    transport, calls = _scripted_transport(
+        [
+            {"ok": True, "lease": _ok_lease_payload(holder), "idempotent": False, "drift_warning": []},
+            {"ok": True},
+        ]
+    )
+    client = LeasePlaneClient(transport=transport)
+
+    block_ran = False
+    seen_outcome = None
+    with lease_advisory_scope(
+        surface_id="test:advisory/x",
+        surface_kind="test",
+        holder_agent_uuid=holder,
+        ttl_s=60,
+        intent="unit-test",
+        client=client,
+    ) as (outcome, lease_id):
+        block_ran = True
+        seen_outcome = outcome
+        assert lease_id is not None
+
+    assert block_ran is True
+    assert seen_outcome == "acquired_new"
+    # acquire + release ⇒ exactly two HTTP calls
+    assert len(calls) == 2
+    assert calls[0][1].endswith("/v1/lease/acquire")
+    assert calls[1][1].endswith("/v1/lease/release")
+
+
+def test_idempotent_outcome_classified_correctly():
+    holder = uuid4()
+    transport, _ = _scripted_transport(
+        [
+            {"ok": True, "lease": _ok_lease_payload(holder), "idempotent": True, "drift_warning": ["intent"]},
+            {"ok": True},
+        ]
+    )
+    client = LeasePlaneClient(transport=transport)
+
+    with lease_advisory_scope(
+        surface_id="test:advisory/x",
+        surface_kind="test",
+        holder_agent_uuid=holder,
+        ttl_s=60,
+        client=client,
+    ) as (outcome, lease_id):
+        assert outcome == "acquired_idempotent"
+        assert lease_id is not None
+
+
+def test_held_by_other_runs_block_no_release():
+    other_holder = uuid4()
+    transport, calls = _scripted_transport(
+        [
+            {
+                "ok": False,
+                "error": "held_by_other",
+                "held_by_uuid": str(other_holder),
+                "expires_at": (datetime.now(UTC) + timedelta(seconds=30)).isoformat(),
+            }
+        ]
+    )
+    client = LeasePlaneClient(transport=transport)
+
+    block_ran = False
+    with lease_advisory_scope(
+        surface_id="test:advisory/contended",
+        surface_kind="test",
+        holder_agent_uuid=uuid4(),
+        ttl_s=60,
+        client=client,
+    ) as (outcome, lease_id):
+        block_ran = True
+        assert outcome == "held_by_other"
+        assert lease_id is None
+
+    # Phase A advisory: block must run regardless of held_by_other.
+    assert block_ran is True
+    # No release call because we never held the lease.
+    assert len(calls) == 1
+
+
+def test_service_unavailable_runs_block_no_release():
+    transport, calls = _scripted_transport([{"ok": False, "error": "service_unavailable"}])
+    client = LeasePlaneClient(transport=transport)
+
+    block_ran = False
+    with lease_advisory_scope(
+        surface_id="test:advisory/down",
+        surface_kind="test",
+        holder_agent_uuid=uuid4(),
+        ttl_s=60,
+        client=client,
+    ) as (outcome, _lease_id):
+        block_ran = True
+        assert outcome == "service_unavailable"
+
+    assert block_ran is True
+    assert len(calls) == 1
+
+
+def test_disabled_client_outcome_is_service_unavailable():
+    block_ran = False
+    with lease_advisory_scope(
+        surface_id="test:advisory/disabled",
+        surface_kind="test",
+        holder_agent_uuid=uuid4(),
+        ttl_s=60,
+        client=LeasePlaneDisabledClient(),
+    ) as (outcome, _lease_id):
+        block_ran = True
+        assert outcome == "service_unavailable"
+
+    assert block_ran is True
+
+
+def test_caller_exceptions_propagate_and_lease_still_released():
+    holder = uuid4()
+    transport, calls = _scripted_transport(
+        [
+            {"ok": True, "lease": _ok_lease_payload(holder), "idempotent": False, "drift_warning": []},
+            {"ok": True},
+        ]
+    )
+    client = LeasePlaneClient(transport=transport)
+
+    class BlockError(RuntimeError):
+        pass
+
+    try:
+        with lease_advisory_scope(
+            surface_id="test:advisory/raises",
+            surface_kind="test",
+            holder_agent_uuid=holder,
+            ttl_s=60,
+            client=client,
+        ) as (outcome, lease_id):
+            assert outcome == "acquired_new"
+            assert lease_id is not None
+            raise BlockError("boom")
+    except BlockError:
+        pass
+    else:
+        raise AssertionError("BlockError must propagate")
+
+    # Even on caller raise, the lease must be released (cleanup contract).
+    assert len(calls) == 2
+    assert calls[1][1].endswith("/v1/lease/release")
+
+
+def test_make_advisory_client_returns_disabled_when_no_token(monkeypatch):
+    monkeypatch.delenv("LEASE_PLANE_BEARER_TOKEN", raising=False)
+    client = make_advisory_client()
+    assert isinstance(client, LeasePlaneDisabledClient)
+
+
+def test_make_advisory_client_returns_real_client_when_token_set(monkeypatch):
+    monkeypatch.setenv("LEASE_PLANE_BEARER_TOKEN", "test-token")
+    monkeypatch.setenv("LEASE_PLANE_BASE_URL", "http://127.0.0.1:9999")
+    client = make_advisory_client()
+    assert isinstance(client, LeasePlaneClient)
+    assert not isinstance(client, LeasePlaneDisabledClient)
+    assert client.config.base_url == "http://127.0.0.1:9999"
+    assert client.config.bearer_token == "test-token"
+
+
+def test_acquire_raise_classified_as_client_error():
+    """The advisory client SHOULD never raise (that's the whole pattern), but
+    if a custom transport accidentally does, the wrapper must still run the
+    block and surface client_error so Phase A telemetry stays honest."""
+
+    def boom_transport(_req):
+        raise TimeoutError("network gone")
+
+    client = LeasePlaneClient(transport=boom_transport)
+
+    block_ran = False
+    seen_outcome: str | None = None
+    with lease_advisory_scope(
+        surface_id="test:advisory/timeout",
+        surface_kind="test",
+        holder_agent_uuid=uuid4(),
+        ttl_s=60,
+        client=client,
+    ) as (outcome, _lease_id):
+        block_ran = True
+        seen_outcome = outcome
+
+    assert block_ran is True
+    # The standard LeasePlaneClient catches transport raises and returns
+    # AcquireServiceUnavailable internally — verify the outcome maps cleanly.
+    assert seen_outcome == "service_unavailable"


### PR DESCRIPTION
## Summary

First Python resident wired to the lease plane per operator brief step #3 — Phase A semantics from RFC v0.5 §6.1: **the lease plane is called for telemetry only; failed acquire MUST NOT block normal operation**.

Watcher chosen as the first surface because it's the lowest-risk: pure-Python, event-driven, single clean unit-of-work, and a real near-collision precedent exists in operator memory (`feedback_running-process-vs-master-commit.md`).

## What this adds

**`src/lease_plane/advisory.py`** — reusable on-ramp for all Python residents (not just Watcher). Steward, ship.sh, dispatch will import the same primitives.

| Primitive | Purpose |
|---|---|
| `lease_advisory_scope(...)` | Context manager wrapping a unit-of-work. Yields `(outcome, lease_id_or_none)`. Block runs regardless of outcome. |
| `make_advisory_client()` | Returns real client when `LEASE_PLANE_BEARER_TOKEN` is set, `LeasePlaneDisabledClient` (every call → service_unavailable) when unset — Phase A's correct posture for unconfigured environments. |
| `new_holder_uuid()` | Fresh UUID per Python invocation (`process_instance` posture from identity.md v2). |

Outcomes: `acquired_new`, `acquired_idempotent`, `held_by_other`, `service_unavailable`, `permission_denied`, `schema_invalid`, `client_error`.

**`agents/watcher/agent.py`** — `scan_commits` split into a thin lease-wrapped shell + `_scan_commits_inner` with the unchanged scan logic. Surface: `watcher:scan_commits:<repo_root>`, kind `watcher_scan_commits`, ttl=60s, holder_kind=`remote_heartbeat`.

## Hard invariants

- **Existing behavior unchanged** when `LEASE_PLANE_BEARER_TOKEN` is unset: every acquire returns `service_unavailable` and the scan body runs identically to pre-PR.
- **Phase A non-enforcing**: `held_by_other` and `service_unavailable` both result in the body running. Locked down by the new `test_scan_commits_runs_when_lease_held_by_other` regression.
- **Surface_id stable**: `test_scan_commits_invokes_lease_advisory_with_expected_surface` will fail noisily if a future refactor renames the surface, preventing silent telemetry drift.

## Test plan

- [x] `pytest agents/watcher/tests/test_scan_commits.py` — 16/16 pass (14 prior + 2 new)
- [x] `pytest tests/test_lease_plane_advisory.py` — 9/9 pass (acquired_new, acquired_idempotent, held_by_other, service_unavailable, disabled client, caller-exception cleanup, env factory variants, transport raise)
- [x] `pytest tests/test_lease_plane_client.py` — 15/15 pass (no regression on contract anchor)

### Phase A telemetry will surface in Watcher's stdout/log via the standard logger:
```
INFO  lease_advisory: acquired_new surface=watcher:scan_commits:/Users/cirwel/projects/unitares lease_id=...
INFO  lease_advisory: released lease_id=... ok=True
```
Or, when the lease plane isn't running:
```
INFO  lease_advisory: service_unavailable surface=watcher:scan_commits:... (lease plane down or unconfigured)
```

## Note on the Python test suite

`./scripts/dev/test-cache.sh` shows the same master-baseline failure as PRs #251/#253: `tests/resident_progress/test_http_endpoint.py::test_endpoint_status_field_uses_priority_resolver`. Introduced by #252 (s8a Phase-2), verified to fail on master with my changes stashed. Not blocking; needs separate triage.

## What's next (separate PRs)

- Council follow-ups for #253: `parse_url` URI.decode, IPv6 dual-bind doc, `plug ~> 1.18` pin tightening (small Elixir-only PR).
- Steward, ship.sh, dispatch wired the same way (each its own PR — they have different concurrency models worth thinking through individually).
- Then handoff state-machine on the BEAM side + Oban reaper + audit-outbox forwarder.