### PR TITLE
fix(lease-plane): polish — URL decode, IPv6 doc, plug 1.18 pin

### DIFF
--- a/elixir/lease_plane/lib/unitares_lease_plane/application.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/application.ex
@@ -1,5 +1,33 @@
 defmodule UnitaresLeasePlane.Application do
-  @moduledoc false
+  @moduledoc """
+  OTP entry point for the lease plane.
+
+  ## HTTP bind discipline
+
+  Defaults to IPv4 `127.0.0.1:8788`. The Python contract anchor uses the
+  same dotted-quad literal (`http://127.0.0.1:8788`) so the round-trip is
+  consistent without DNS in the path.
+
+  Note: on macOS Sonoma+ with the default `/etc/hosts`, `localhost`
+  resolves to `::1` (IPv6) before `127.0.0.1`. A client that uses
+  `http://localhost:8788` instead of the dotted-quad will fail with
+  connection refused — Bandit binds the IPv4 socket only.
+
+  Operators who need the IPv6 path can override:
+
+      config :lease_plane, http_ip: {0, 0, 0, 0, 0, 0, 0, 1}
+
+  Or run a second listener on the same port via custom supervision —
+  Bandit child specs are independent. Off-host exposure is intentionally
+  not a built-in option in v0; the bearer-auth fail-closed posture
+  assumes a single trust boundary at `localhost`.
+
+  ## Database URL
+
+  `parse_database_url/1` uses `URI.parse/1` plus `URI.decode/1` on the
+  username and password components so percent-encoded credentials
+  (e.g., `p%40ss` for `p@ss`) survive the round-trip into Postgrex.
+  """
 
   use Application
 
@@ -49,7 +77,7 @@ defmodule UnitaresLeasePlane.Application do
         raise "UNITARES_LEASE_PLANE_DATABASE_URL or :lease_plane database_url config required"
 
     pool_size = Application.get_env(:lease_plane, :pool_size, 4)
-    parsed = parse_url(url)
+    parsed = parse_database_url(url)
 
     [
       hostname: parsed.host,
@@ -62,17 +90,35 @@ defmodule UnitaresLeasePlane.Application do
     ]
   end
 
-  defp parse_url("postgresql://" <> rest) do
-    [creds_host, db] = String.split(rest, "/", parts: 2)
-    [creds, host_port] = String.split(creds_host, "@", parts: 2)
-    [user, pass] = String.split(creds, ":", parts: 2)
+  @doc false
+  # Public for testing only. Parses a libpq-style URL into a Postgrex opts
+  # map, with URI.decode/1 applied to user and password so percent-encoded
+  # credentials (e.g., "p%40ss" for "p@ss") survive into the driver.
+  def parse_database_url("postgresql://" <> _ = url), do: parse_database_url(URI.parse(url))
+  def parse_database_url("postgres://" <> _ = url), do: parse_database_url(URI.parse(url))
 
-    {host, port} =
-      case String.split(host_port, ":", parts: 2) do
-        [h, p] -> {h, String.to_integer(p)}
-        [h] -> {h, 5432}
+  def parse_database_url(%URI{scheme: scheme} = uri) when scheme in ["postgresql", "postgres"] do
+    {user, pass} =
+      case uri.userinfo do
+        nil ->
+          raise ArgumentError, "database_url must include user:password@host"
+
+        userinfo ->
+          case String.split(userinfo, ":", parts: 2) do
+            [u, p] -> {URI.decode(u), URI.decode(p)}
+            [u] -> {URI.decode(u), ""}
+          end
       end
 
-    %{username: user, password: pass, host: host, port: port, database: db}
+    host = uri.host || raise(ArgumentError, "database_url missing host")
+    port = uri.port || 5432
+
+    database =
+      case uri.path do
+        "/" <> db when db != "" -> db
+        _ -> raise ArgumentError, "database_url missing database name"
+      end
+
+    %{username: user, password: pass, host: host, port: port, database: database}
   end
 end

--- a/elixir/lease_plane/mix.exs
+++ b/elixir/lease_plane/mix.exs
@@ -26,7 +26,9 @@ defmodule UnitaresLeasePlane.MixProject do
     [
       {:postgrex, "~> 0.20"},
       {:jason, "~> 1.4"},
-      {:plug, "~> 1.16"},
+      # Plug 1.18+ — depends on the Plug.Parsers.ParseError shape that
+      # SafeParsers / HTTPRouter both rely on (PR #253 council).
+      {:plug, "~> 1.18"},
       {:bandit, "~> 1.6"}
     ]
   end

--- a/elixir/lease_plane/test/http_router_test.exs
+++ b/elixir/lease_plane/test/http_router_test.exs
@@ -328,7 +328,13 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
 
       assert result.status == 503
       body = Jason.decode!(result.resp_body)
-      assert body == %{"ok" => false, "error" => "service_unavailable", "reason" => "internal error"}
+
+      assert body == %{
+               "ok" => false,
+               "error" => "service_unavailable",
+               "reason" => "internal error"
+             }
+
       # Verify the leaky inspect string never made it to the wire.
       refute result.resp_body =~ "hunter2"
     end

--- a/elixir/lease_plane/test/parse_database_url_test.exs
+++ b/elixir/lease_plane/test/parse_database_url_test.exs
@@ -1,0 +1,64 @@
+defmodule UnitaresLeasePlane.ParseDatabaseUrlTest do
+  use ExUnit.Case, async: true
+
+  alias UnitaresLeasePlane.Application, as: App
+
+  describe "parse_database_url/1" do
+    test "parses a vanilla libpq URL" do
+      assert %{
+               username: "postgres",
+               password: "postgres",
+               host: "localhost",
+               port: 5432,
+               database: "governance"
+             } =
+               App.parse_database_url("postgresql://postgres:postgres@localhost:5432/governance")
+    end
+
+    test "accepts the postgres:// scheme alias" do
+      assert %{username: "u", database: "g"} =
+               App.parse_database_url("postgres://u:p@localhost:5432/g")
+    end
+
+    test "defaults to port 5432 when omitted" do
+      assert %{port: 5432} =
+               App.parse_database_url("postgresql://u:p@localhost/g")
+    end
+
+    test "URI-decodes percent-encoded password (council finding from #253)" do
+      # Real-world: a password like 'p@ss/word' must be encoded as
+      # 'p%40ss%2Fword' in the URL, then decoded back into Postgrex.
+      assert %{username: "u", password: "p@ss/word"} =
+               App.parse_database_url("postgresql://u:p%40ss%2Fword@localhost:5432/g")
+    end
+
+    test "URI-decodes percent-encoded username" do
+      assert %{username: "weird user"} =
+               App.parse_database_url("postgresql://weird%20user:p@localhost:5432/g")
+    end
+
+    test "raises on missing userinfo" do
+      assert_raise ArgumentError, ~r/user:password@host/, fn ->
+        App.parse_database_url("postgresql://localhost:5432/g")
+      end
+    end
+
+    test "raises on missing host" do
+      assert_raise ArgumentError, ~r/missing host/, fn ->
+        App.parse_database_url("postgresql://u:p@/g")
+      end
+    end
+
+    test "raises on missing database name" do
+      assert_raise ArgumentError, ~r/missing database name/, fn ->
+        App.parse_database_url("postgresql://u:p@localhost:5432/")
+      end
+    end
+
+    test "raises on unknown scheme" do
+      assert_raise FunctionClauseError, fn ->
+        App.parse_database_url("mysql://u:p@localhost/g")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Three #253 council follow-ups, all latents (no live blocker), small review surface, single Elixir-only PR.

## What this fixes

1. **`parse_database_url/1` uses `URI.parse` + `URI.decode`** — the hand-rolled split-on-`:` parser didn't handle percent-encoded credentials. Real-world: `p@ss/word` → `p%40ss%2Fword` in the URL would arrive at Postgrex still encoded and fail auth mysteriously. Now: `URI.parse/1` on `postgresql://` or `postgres://` schemes, `URI.decode/1` on user + password, loud `ArgumentError` on missing host/userinfo/database.

2. **IPv6 `localhost` gotcha documented** — default Bandit bind `{127, 0, 0, 1}` is IPv4-only. On macOS Sonoma+ with default `/etc/hosts`, `localhost` resolves to `::1` first, so any client using `http://localhost:8788` would fail with connection refused (the default `LeasePlaneClientConfig.base_url` uses dotted-quad and is fine today, but a future caller switching to `localhost` would trip). Added moduledoc explaining the trap, the override (`config :lease_plane, http_ip: {0, 0, 0, 0, 0, 0, 0, 1}`), and why off-host exposure isn't built-in. No code change — the latent stays latent, but in-tree explanation now exists.

3. **`plug ~> 1.16` → `~> 1.18`** — PR #253's `SafeParsers` + `HTTPRouter` both depend on Plug 1.18+'s `Plug.Parsers.ParseError` shape. Tightened with a back-reference comment.

## Test plan

- [x] `mix compile` — clean, no warnings
- [x] `mix test` — **43/43 pass × 3 runs** (34 prior + 9 new `parse_database_url` tests)
- [x] `mix format --check-formatted`

### New test coverage

| Test | Asserts |
|---|---|
| Vanilla libpq URL | full struct shape |
| `postgres://` scheme alias | accepted same as `postgresql://` |
| Port omitted | defaults to 5432 |
| `p%40ss%2Fword` password | decodes to `p@ss/word` |
| `weird%20user` username | decodes to `weird user` |
| Missing userinfo | raises `ArgumentError ~r/user:password@host/` |
| Missing host | raises `ArgumentError ~r/missing host/` |
| Missing database name | raises `ArgumentError ~r/missing database name/` |
| `mysql://` scheme | raises `FunctionClauseError` (correct — only postgres) |

## Punted (separate decision, not blocking)

- **Dual-bind IPv4 + IPv6 by default.** The doc explains the trap; the config override exists. Adding a second Bandit listener by default is a runtime-complexity decision that belongs in its own PR if the trap actually trips an operator.