### PR TITLE
feat(ship-sh): Phase A advisory-mode lease around ship operation

### DIFF
--- a/scripts/dev/_ship_lease_advisory.py
+++ b/scripts/dev/_ship_lease_advisory.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Helper for ship.sh: Phase A advisory-mode lease around the ship operation.
+
+Two subcommands:
+
+    acquire --surface-id <id> --surface-kind <kind> [--intent <s>] [--ttl-s <n>]
+        Always exits 0 (Phase A is non-fatal). Stdout is a single JSON line:
+            {"outcome": "...", "lease_id": "..." | null}
+        Outcomes: acquired_new, acquired_idempotent, held_by_other,
+                  service_unavailable, permission_denied, schema_invalid,
+                  client_error.
+
+    release --lease-id <uuid>
+        Always exits 0. Stdout: {"ok": true|false}.
+
+Per RFC v0.5 §6.1: failed acquire MUST NOT block the ship. ship.sh logs
+the outcome and proceeds regardless.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from uuid import UUID, uuid4
+
+# Ensure the project root is importable when this script is invoked directly
+# (e.g., from ship.sh as `python3 scripts/dev/_ship_lease_advisory.py ...`).
+# Pytest adds the rootdir to sys.path automatically; bash does not.
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from src.lease_plane import LeasePlaneClient, ReleaseRequest  # noqa: E402
+from src.lease_plane.advisory import (  # noqa: E402
+    AcquireRequest,
+    acquire_advisory,
+    make_advisory_client,
+)
+
+
+def _cmd_acquire(args: argparse.Namespace) -> int:
+    client: LeasePlaneClient = make_advisory_client()
+
+    request = AcquireRequest(
+        surface_id=args.surface_id,
+        surface_kind=args.surface_kind,
+        holder_agent_uuid=uuid4(),
+        holder_class="process_instance",
+        holder_kind="remote_heartbeat",
+        ttl_s=args.ttl_s,
+        intent=args.intent,
+    )
+
+    outcome, lease_id = acquire_advisory(client, request)
+
+    json.dump(
+        {"outcome": outcome, "lease_id": str(lease_id) if lease_id else None},
+        sys.stdout,
+    )
+    sys.stdout.write("\n")
+    return 0
+
+
+def _cmd_release(args: argparse.Namespace) -> int:
+    if not args.lease_id:
+        json.dump({"ok": False, "reason": "empty lease_id"}, sys.stdout)
+        sys.stdout.write("\n")
+        return 0
+
+    try:
+        lease_id = UUID(args.lease_id)
+    except ValueError:
+        json.dump({"ok": False, "reason": "invalid lease_id"}, sys.stdout)
+        sys.stdout.write("\n")
+        return 0
+
+    client = make_advisory_client()
+    try:
+        result = client.release(ReleaseRequest(lease_id=lease_id, release_reason="normal"))
+        ok = bool(getattr(result, "ok", False))
+    except Exception as exc:  # defensive
+        json.dump({"ok": False, "reason": f"release raised: {exc!r}"}, sys.stdout)
+        sys.stdout.write("\n")
+        return 0
+
+    json.dump({"ok": ok}, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    acq = sub.add_parser("acquire")
+    acq.add_argument("--surface-id", required=True)
+    acq.add_argument("--surface-kind", required=True)
+    acq.add_argument("--intent", default=None)
+    acq.add_argument("--ttl-s", type=int, default=300)
+    acq.set_defaults(func=_cmd_acquire)
+
+    rel = sub.add_parser("release")
+    rel.add_argument("--lease-id", required=True)
+    rel.set_defaults(func=_cmd_release)
+
+    args = parser.parse_args(argv)
+
+    # The advisory module logs to its own logger; ship.sh consumes JSON on
+    # stdout. Send any logger output to stderr so it doesn't pollute the
+    # JSON line bash will parse.
+    logging.basicConfig(level=logging.INFO, stream=sys.stderr, format="%(message)s")
+
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/ship.sh
+++ b/scripts/dev/ship.sh
@@ -74,6 +74,22 @@ fi
 KIND=$(classify)
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
+# Phase A advisory lease (RFC v0.5 §6.1). Telemetry-only: a held_by_other
+# or service_unavailable outcome MUST NOT block the ship. We log the
+# outcome and proceed regardless, and release on EXIT so the lease is
+# returned even if a downstream step (commit, push, PR create) fails.
+LEASE_RESULT=$(python3 "$PROJECT_ROOT/scripts/dev/_ship_lease_advisory.py" acquire \
+    --surface-id="ship.sh:$BRANCH" \
+    --surface-kind="ship_sh" \
+    --intent="$MESSAGE" \
+    --ttl-s=300 2>/dev/null || echo '{"outcome":"client_error","lease_id":null}')
+LEASE_OUTCOME=$(printf '%s' "$LEASE_RESULT" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("outcome",""))')
+LEASE_ID=$(printf '%s' "$LEASE_RESULT" | python3 -c 'import json,sys; v=json.load(sys.stdin).get("lease_id"); print(v if v else "")')
+echo "[ship] lease: $LEASE_OUTCOME"
+if [[ -n "$LEASE_ID" ]]; then
+    trap 'python3 "$PROJECT_ROOT/scripts/dev/_ship_lease_advisory.py" release --lease-id="$LEASE_ID" >/dev/null 2>&1 || true' EXIT
+fi
+
 # Append Watcher-Findings trailer if any unresolved findings touch staged files.
 # COMMIT_MESSAGE is what `git commit -m` sees; MESSAGE stays clean for PR title.
 WATCHER_FPS=$(collect_watcher_fingerprints || true)

--- a/src/lease_plane/advisory.py
+++ b/src/lease_plane/advisory.py
@@ -43,9 +43,11 @@ from . import (
 
 __all__ = [
     "AdvisoryOutcome",
+    "acquire_advisory",
     "lease_advisory_scope",
     "make_advisory_client",
     "new_holder_uuid",
+    "release_advisory",
 ]
 
 logger = logging.getLogger(__name__)
@@ -129,18 +131,24 @@ def lease_advisory_scope(
         audit_session=audit_session,
     )
 
-    outcome, lease_id = _acquire_and_classify(advisory_client, request)
+    outcome, lease_id = acquire_advisory(advisory_client, request)
 
     try:
         yield outcome, lease_id
     finally:
         if lease_id is not None:
-            _release_quiet(advisory_client, lease_id)
+            release_advisory(advisory_client, lease_id)
 
 
-def _acquire_and_classify(
+def acquire_advisory(
     client: LeasePlaneClient, request: AcquireRequest
 ) -> tuple[AdvisoryOutcome, uuid.UUID | None]:
+    """Acquire a Phase A advisory lease and classify the outcome.
+
+    Public counterpart to `lease_advisory_scope` for callers that need the
+    acquire-without-context-manager shape (e.g., bash glue calling a CLI).
+    Always non-fatal — never raises from the lease layer.
+    """
     try:
         result = client.acquire(request)
     except Exception as exc:  # defensive — client is supposed to be no-raise
@@ -204,7 +212,12 @@ def _acquire_and_classify(
     return "client_error", None
 
 
-def _release_quiet(client: LeasePlaneClient, lease_id: uuid.UUID) -> None:
+def release_advisory(client: LeasePlaneClient, lease_id: uuid.UUID) -> None:
+    """Release a Phase A advisory lease, swallowing any error.
+
+    Public counterpart to the context manager's exit-time release. Logs
+    the outcome but never raises — Phase A cleanup is best-effort.
+    """
     try:
         result = client.release(ReleaseRequest(lease_id=lease_id, release_reason="normal"))
         logger.info(

--- a/tests/test_ship_lease_advisory.py
+++ b/tests/test_ship_lease_advisory.py
@@ -1,0 +1,157 @@
+"""Tests for scripts/dev/_ship_lease_advisory.py — the ship.sh lease-plane helper."""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from uuid import UUID, uuid4
+
+# Wire the helper into sys.path so we can import it without installing it.
+HELPER_DIR = Path(__file__).resolve().parents[1] / "scripts" / "dev"
+sys.path.insert(0, str(HELPER_DIR))
+
+import _ship_lease_advisory as shla  # noqa: E402
+
+
+def _ok_lease_payload(holder_uuid: UUID) -> dict[str, Any]:
+    now = datetime.now(UTC).replace(microsecond=0)
+    return {
+        "lease_id": str(uuid4()),
+        "surface_id": "ship.sh:test-branch",
+        "surface_kind": "ship_sh",
+        "holder_agent_uuid": str(holder_uuid),
+        "holder_class": "process_instance",
+        "holder_kind": "remote_heartbeat",
+        "holder_pid": None,
+        "heartbeat_required": True,
+        "intent": "test ship",
+        "acquired_at": now.isoformat(),
+        "expires_at": (now + timedelta(seconds=300)).isoformat(),
+        "last_heartbeat_at": now.isoformat(),
+        "released_at": None,
+        "release_reason": None,
+        "audit_session": None,
+        "original_ttl_s": 300,
+        "earned_status": "provisional",
+    }
+
+
+def _scripted_client(responses: list[dict[str, Any]]):
+    from src.lease_plane import LeasePlaneClient
+
+    def transport(_req):
+        return responses.pop(0)
+
+    return LeasePlaneClient(transport=transport)
+
+
+def test_acquire_emits_lease_id_on_acquired_new(capsys, monkeypatch):
+    holder = uuid4()
+    client = _scripted_client(
+        [{"ok": True, "lease": _ok_lease_payload(holder), "idempotent": False, "drift_warning": []}]
+    )
+
+    monkeypatch.setattr(shla, "make_advisory_client", lambda: client)
+
+    rc = shla.main(
+        [
+            "acquire",
+            "--surface-id=ship.sh:test-branch",
+            "--surface-kind=ship_sh",
+            "--intent=test ship",
+            "--ttl-s=300",
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["outcome"] == "acquired_new"
+    assert UUID(payload["lease_id"])  # well-formed
+
+
+def test_acquire_emits_null_lease_on_held_by_other(capsys, monkeypatch):
+    other = uuid4()
+    client = _scripted_client(
+        [
+            {
+                "ok": False,
+                "error": "held_by_other",
+                "held_by_uuid": str(other),
+                "expires_at": (datetime.now(UTC) + timedelta(seconds=60)).isoformat(),
+            }
+        ]
+    )
+
+    monkeypatch.setattr(shla, "make_advisory_client", lambda: client)
+
+    rc = shla.main(
+        [
+            "acquire",
+            "--surface-id=ship.sh:contended",
+            "--surface-kind=ship_sh",
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["outcome"] == "held_by_other"
+    assert payload["lease_id"] is None
+
+
+def test_acquire_emits_service_unavailable_on_disabled(capsys, monkeypatch):
+    from src.lease_plane import LeasePlaneDisabledClient
+
+    monkeypatch.setattr(shla, "make_advisory_client", lambda: LeasePlaneDisabledClient())
+
+    rc = shla.main(
+        [
+            "acquire",
+            "--surface-id=ship.sh:disabled",
+            "--surface-kind=ship_sh",
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["outcome"] == "service_unavailable"
+    assert payload["lease_id"] is None
+
+
+def test_release_happy_path(capsys, monkeypatch):
+    client = _scripted_client([{"ok": True}])
+    monkeypatch.setattr(shla, "make_advisory_client", lambda: client)
+
+    rc = shla.main(["release", f"--lease-id={uuid4()}"])
+
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["ok"] is True
+
+
+def test_release_invalid_lease_id_does_not_raise(capsys):
+    """ship.sh calls release in a trap; if the captured lease_id was never
+    set (acquire returned null), we must not crash on a bad arg."""
+    rc = shla.main(["release", "--lease-id=not-a-uuid"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is False
+    assert "invalid" in out["reason"]
+
+
+def test_release_empty_lease_id_does_not_raise(capsys):
+    rc = shla.main(["release", "--lease-id="])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is False
+    assert "empty" in out["reason"]
+
+
+def test_release_failed_release_returns_ok_false(capsys, monkeypatch):
+    client = _scripted_client([{"ok": False, "error": "not_found"}])
+    monkeypatch.setattr(shla, "make_advisory_client", lambda: client)
+
+    rc = shla.main(["release", f"--lease-id={uuid4()}"])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["ok"] is False


### PR DESCRIPTION
## Summary

Second Python resident on the lease plane (after Watcher #256). `ship.sh` acquires an advisory lease on `ship.sh:<branch>` for the duration of the ship operation, releases on `EXIT` via bash trap, proceeds regardless of lease outcome.

**Stacking note:** this PR is stacked on #256 because both touch `src/lease_plane/advisory.py`. Will need rebase onto master after #256 merges (linear conflict-free; same module, additive changes).

## Why ship.sh

Concurrent `ship.sh` on the same branch is a real collision class — two agents both running `ship.sh "fix X"` could race on commit + push. Phase A telemetry will surface whether this happens in practice.

## What this adds

| File | Change |
|---|---|
| `src/lease_plane/advisory.py` | Promote `_acquire_and_classify` → `acquire_advisory` and `_release_quiet` → `release_advisory` to public API. No behavior change. The bash CLI needs them; the existing `lease_advisory_scope` continues to call the same primitives. |
| `scripts/dev/_ship_lease_advisory.py` | New CLI helper. Two argparse subcommands (`acquire`, `release`) emitting JSON on stdout, logging to stderr. Always exits 0 (Phase A non-fatal). Tolerates empty/invalid lease_id args so the trap-on-EXIT release never crashes. |
| `scripts/dev/ship.sh` | Acquire after classify, release in `trap ... EXIT`. Logs `[ship] lease: <outcome>` alongside existing `[ship] ...` lines. |

### Lease semantics

```
surface_id   = ship.sh:<branch>
surface_kind = ship_sh
intent       = <the commit message>
ttl_s        = 300   # covers slow pre-commit hooks + gh CLI flake
```

## Test plan

- [x] `pytest tests/test_ship_lease_advisory.py` — 7/7 (acquire happy path; held_by_other returns lease_id=null; disabled client → service_unavailable; release happy path; invalid lease_id; empty lease_id; failed release)
- [x] `pytest tests/test_lease_plane_advisory.py tests/test_lease_plane_client.py tests/test_ship_watcher_fingerprints.py agents/watcher/tests/test_scan_commits.py` — **55/55 pass** across the full lease+ship test set
- [x] Manual smoke: `python3 scripts/dev/_ship_lease_advisory.py acquire ...` returns valid JSON on stdout with no token configured (correct `service_unavailable` Phase A); release tolerates null lease_id case
- [x] `bash -n scripts/dev/ship.sh` — clean syntax

## Hard invariants

- Phase A non-fatal: `held_by_other` and `service_unavailable` both proceed. `client_error` (CLI itself crashed somehow) also proceeds — covered by `|| echo '{"outcome":"client_error","lease_id":null}'` fallback in the bash.
- Trap-on-EXIT cleanup: lease released even if commit/push/gh fails.
- Empty/invalid lease_id arg to release does NOT crash — covered by `test_release_invalid_lease_id_does_not_raise` and `test_release_empty_lease_id_does_not_raise`.

## Note on the Python suite

`./scripts/dev/test-cache.sh` continues to fail on the unrelated `tests/resident_progress/test_http_endpoint.py` master-baseline issue introduced by #252. Same red mark as #251/#253/#256. Not blocking.

## What's next

Steward — but it lives in `~/projects/unitares-pi-plugin/` (separate repo, editable install into governance-mcp's venv). Cross-repo PR; will tackle that next once #256 / #257 / this one are reviewed.