### PR TITLE
test(resident-progress): include never-seen status in endpoint allow-set

### DIFF
--- a/tests/resident_progress/test_http_endpoint.py
+++ b/tests/resident_progress/test_http_endpoint.py
@@ -77,6 +77,6 @@ async def test_endpoint_status_field_uses_priority_resolver(test_db, monkeypatch
     assert all(
         r["status"] in {
             "OK", "flat-candidate", "silent", "source-error",
-            "unresolved", "startup-grace",
+            "unresolved", "startup-grace", "never-seen",
         } for r in rows
     )


### PR DESCRIPTION
## Summary

- PR #248 (per-resident heartbeat cadence) added `never-seen` as a new return value in `src/resident_progress/status.py:resolve_status`, but the matching allow-set in `tests/resident_progress/test_http_endpoint.py:77` was never widened.
- One-line test fix: add `"never-seen"` to the allowed set. No production behavior change.

## Triage notes

- Misattributed at session-close as a #252 regression; actual root is #248. #252 doesn't touch resident_progress at all.
- Open question for follow-up: why did #248 land green in CI? Either CI fixture state didn't trigger the `never_seen` branch, or the test was effectively-skipped in that run. Worth checking `gh pr view 248 --json statusCheckRollup` if it matters; the fix here is correct regardless.

## Test plan

- [x] `pytest tests/resident_progress/test_http_endpoint.py` passes locally (was 1 failed, now 2 passed)
- [ ] CI green