### PR TITLE
[codex] add BEAM lease-plane workers

### DIFF
--- a/elixir/lease_plane/config/test.exs
+++ b/elixir/lease_plane/config/test.exs
@@ -5,4 +5,5 @@ config :lease_plane,
     System.get_env("UNITARES_LEASE_PLANE_DATABASE_URL") ||
       "postgresql://postgres:postgres@localhost:5432/governance",
   pool_size: 2,
-  start_application: false
+  start_application: false,
+  start_workers: false

--- a/elixir/lease_plane/lib/unitares_lease_plane.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane.ex
@@ -10,7 +10,7 @@ defmodule UnitaresLeasePlane do
   become source of truth for identity, EISV, KG, or calibration.
   """
 
-  alias UnitaresLeasePlane.{LeaseHolder, LeaseSupervisor, Repo}
+  alias UnitaresLeasePlane.{HandoffServer, LeaseHolder, LeaseSupervisor, Repo}
 
   @doc """
   Acquire a lease for a `local_beam` surface — spawns a `LeaseHolder`
@@ -58,5 +58,17 @@ defmodule UnitaresLeasePlane do
       {:ok, pid} -> LeaseHolder.release(pid, release_reason)
       :error -> Repo.release(lease_id, release_reason)
     end
+  end
+
+  @doc "Offer a lease handoff to another holder UUID."
+  @spec handoff_offer(binary(), binary(), pos_integer()) :: {:ok, binary()} | {:error, term()}
+  def handoff_offer(lease_id, to_holder_agent_uuid, ttl_s) do
+    HandoffServer.offer(lease_id, to_holder_agent_uuid, ttl_s)
+  end
+
+  @doc "Accept a pending handoff by id."
+  @spec handoff_accept(binary()) :: :ok | {:error, term()}
+  def handoff_accept(handoff_id) do
+    HandoffServer.accept(handoff_id)
   end
 end

--- a/elixir/lease_plane/lib/unitares_lease_plane/application.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/application.ex
@@ -51,8 +51,9 @@ defmodule UnitaresLeasePlane.Application do
       [
         {Postgrex, postgrex_opts()},
         {Registry, keys: :unique, name: UnitaresLeasePlane.HolderRegistry},
-        UnitaresLeasePlane.LeaseSupervisor
-      ] ++ http_children()
+        UnitaresLeasePlane.LeaseSupervisor,
+        UnitaresLeasePlane.HandoffServer
+      ] ++ worker_children() ++ http_children()
 
     opts = [strategy: :one_for_one, name: UnitaresLeasePlane.Supervisor]
     Supervisor.start_link(children, opts)
@@ -65,6 +66,35 @@ defmodule UnitaresLeasePlane.Application do
 
       [
         {Bandit, plug: UnitaresLeasePlane.HTTPRouter, ip: ip, port: port}
+      ]
+    else
+      []
+    end
+  end
+
+  defp worker_children do
+    if Application.get_env(:lease_plane, :start_workers, true) do
+      [
+        {UnitaresLeasePlane.PeriodicWorker,
+         id: UnitaresLeasePlane.Reaper,
+         name: UnitaresLeasePlane.ReaperScheduler,
+         worker: UnitaresLeasePlane.Reaper,
+         interval_ms: Application.get_env(:lease_plane, :reaper_interval_ms, 30_000),
+         initial_delay_ms: Application.get_env(:lease_plane, :reaper_initial_delay_ms, 1_000)},
+        {UnitaresLeasePlane.PeriodicWorker,
+         id: UnitaresLeasePlane.HandoffTimeout,
+         name: UnitaresLeasePlane.HandoffTimeoutScheduler,
+         worker: UnitaresLeasePlane.HandoffTimeout,
+         interval_ms: Application.get_env(:lease_plane, :handoff_timeout_interval_ms, 5_000),
+         initial_delay_ms:
+           Application.get_env(:lease_plane, :handoff_timeout_initial_delay_ms, 1_000)},
+        {UnitaresLeasePlane.PeriodicWorker,
+         id: UnitaresLeasePlane.AuditOutboxForwarder,
+         name: UnitaresLeasePlane.AuditOutboxForwarderScheduler,
+         worker: UnitaresLeasePlane.AuditOutboxForwarder,
+         interval_ms: Application.get_env(:lease_plane, :audit_outbox_forward_interval_ms, 30_000),
+         initial_delay_ms:
+           Application.get_env(:lease_plane, :audit_outbox_forward_initial_delay_ms, 2_000)}
       ]
     else
       []

--- a/elixir/lease_plane/lib/unitares_lease_plane/audit_outbox_forwarder.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/audit_outbox_forwarder.ex
@@ -1,0 +1,66 @@
+defmodule UnitaresLeasePlane.AuditOutboxForwarder do
+  @moduledoc """
+  Projects lease-plane outbox rows into `audit.tool_usage`.
+
+  `lease_plane.lease_plane_events` remains the canonical outbox. This worker is
+  retry-safe at the row level: each event is forwarded inside a transaction and
+  then marked with `forwarded_at`.
+  """
+
+  require Logger
+
+  alias UnitaresLeasePlane.Repo
+
+  @spec perform(map()) ::
+          {:ok, %{forwarded: non_neg_integer(), failed: non_neg_integer()}} | {:error, term()}
+  def perform(args \\ %{}) when is_map(args) do
+    limit =
+      positive_arg(
+        args,
+        "limit",
+        :limit,
+        Application.get_env(:lease_plane, :audit_outbox_forward_limit, 100)
+      )
+
+    opts =
+      case Map.get(args, "surface_id", Map.get(args, :surface_id)) do
+        surface_id when is_binary(surface_id) and byte_size(surface_id) > 0 ->
+          [surface_id: surface_id]
+
+        _ ->
+          []
+      end
+
+    with {:ok, events} <- Repo.unforwarded_events(limit, opts) do
+      {forwarded, failed} =
+        Enum.reduce(events, {0, 0}, fn event, {ok_count, fail_count} ->
+          case Repo.forward_outbox_event(event.event_id) do
+            :ok ->
+              {ok_count + 1, fail_count}
+
+            {:error, :not_found} ->
+              {ok_count, fail_count}
+
+            {:error, reason} ->
+              Logger.warning(
+                "lease_plane audit forward failed for #{event.event_id}: #{inspect(reason)}"
+              )
+
+              {ok_count, fail_count + 1}
+          end
+        end)
+
+      {:ok, %{forwarded: forwarded, failed: failed}}
+    end
+  end
+
+  defp positive_arg(args, string_key, atom_key, default) do
+    value = Map.get(args, string_key, Map.get(args, atom_key, default))
+
+    if is_integer(value) and value > 0 do
+      value
+    else
+      default
+    end
+  end
+end

--- a/elixir/lease_plane/lib/unitares_lease_plane/handoff_server.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/handoff_server.ex
@@ -1,0 +1,163 @@
+defmodule UnitaresLeasePlane.HandoffServer do
+  @moduledoc """
+  In-node handoff state machine.
+
+  Handoff is release-and-reacquire: an offer reserves intent in BEAM memory and
+  audit outbox, then accept closes the old lease row with `release_reason='handoff'`
+  and creates a new remote-heartbeat lease for the receiving holder.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias UnitaresLeasePlane.{LeaseSupervisor, Repo}
+
+  defmodule Pending do
+    @moduledoc false
+    defstruct [
+      :handoff_id,
+      :lease_id,
+      :to_holder_agent_uuid,
+      :ttl_s,
+      :offered_at,
+      :expires_at
+    ]
+  end
+
+  @type pending :: %Pending{
+          handoff_id: binary(),
+          lease_id: binary(),
+          to_holder_agent_uuid: binary(),
+          ttl_s: pos_integer(),
+          offered_at: DateTime.t(),
+          expires_at: DateTime.t()
+        }
+
+  # ---------- public API ----------
+
+  def start_link(_args), do: GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+
+  @spec offer(binary(), binary(), pos_integer()) :: {:ok, binary()} | {:error, term()}
+  def offer(lease_id, to_holder_agent_uuid, ttl_s)
+      when is_binary(lease_id) and is_binary(to_holder_agent_uuid) and is_integer(ttl_s) and
+             ttl_s > 0 do
+    GenServer.call(__MODULE__, {:offer, lease_id, to_holder_agent_uuid, ttl_s})
+  end
+
+  @spec accept(binary()) :: :ok | {:error, term()}
+  def accept(handoff_id) when is_binary(handoff_id) do
+    GenServer.call(__MODULE__, {:accept, handoff_id})
+  end
+
+  @spec expire_stale :: non_neg_integer()
+  def expire_stale do
+    GenServer.call(__MODULE__, :expire_stale)
+  end
+
+  # ---------- callbacks ----------
+
+  @impl true
+  def init(_args), do: {:ok, %{pending: %{}}}
+
+  @impl true
+  def handle_call({:offer, lease_id, to_holder_agent_uuid, ttl_s}, _from, state) do
+    with {:ok, lease} <- Repo.active_lease(lease_id),
+         pending = new_pending(lease_id, to_holder_agent_uuid, ttl_s),
+         :ok <- Repo.log_handoff_offer(lease, pending) do
+      ms = max(DateTime.diff(pending.expires_at, DateTime.utc_now(), :millisecond), 1)
+      Process.send_after(self(), {:expire, pending.handoff_id}, ms)
+      state = put_in(state, [:pending, pending.handoff_id], pending)
+      {:reply, {:ok, pending.handoff_id}, state}
+    else
+      {:error, reason} ->
+        Logger.warning("lease_plane handoff offer failed: #{inspect(reason)}")
+        {:reply, {:error, reason}, state}
+    end
+  end
+
+  def handle_call({:accept, handoff_id}, _from, state) do
+    case Map.fetch(state.pending, handoff_id) do
+      {:ok, pending} ->
+        accept_pending(pending, state)
+
+      :error ->
+        {:reply, {:error, :not_found}, state}
+    end
+  end
+
+  def handle_call(:expire_stale, _from, state) do
+    {count, pending} = drop_expired(state.pending)
+    {:reply, count, %{state | pending: pending}}
+  end
+
+  @impl true
+  def handle_info({:expire, handoff_id}, state) do
+    case Map.fetch(state.pending, handoff_id) do
+      {:ok, pending} ->
+        if expired?(pending) do
+          {:noreply, %{state | pending: Map.delete(state.pending, handoff_id)}}
+        else
+          {:noreply, state}
+        end
+
+      :error ->
+        {:noreply, state}
+    end
+  end
+
+  defp accept_pending(pending, state) do
+    cond do
+      expired?(pending) ->
+        state = %{state | pending: Map.delete(state.pending, pending.handoff_id)}
+        {:reply, {:error, :expired}, state}
+
+      true ->
+        case Repo.accept_handoff(pending) do
+          {:ok, _new_lease} ->
+            LeaseSupervisor.stop_after_handoff(pending.lease_id)
+            state = %{state | pending: Map.delete(state.pending, pending.handoff_id)}
+            {:reply, :ok, state}
+
+          {:error, reason} ->
+            Logger.warning("lease_plane handoff accept failed: #{inspect(reason)}")
+            {:reply, {:error, reason}, state}
+        end
+    end
+  end
+
+  defp new_pending(lease_id, to_holder_agent_uuid, ttl_s) do
+    now = DateTime.utc_now()
+    offer_window_s = Application.get_env(:lease_plane, :handoff_offer_window_s, 30)
+
+    %Pending{
+      handoff_id: uuid4(),
+      lease_id: lease_id,
+      to_holder_agent_uuid: to_holder_agent_uuid,
+      ttl_s: ttl_s,
+      offered_at: now,
+      expires_at: DateTime.add(now, offer_window_s, :second)
+    }
+  end
+
+  defp drop_expired(pending) do
+    Enum.reduce(pending, {0, %{}}, fn {handoff_id, offer}, {count, acc} ->
+      if expired?(offer) do
+        {count + 1, acc}
+      else
+        {count, Map.put(acc, handoff_id, offer)}
+      end
+    end)
+  end
+
+  defp expired?(%Pending{expires_at: expires_at}) do
+    DateTime.compare(DateTime.utc_now(), expires_at) != :lt
+  end
+
+  defp uuid4 do
+    <<a::32, b::16, c::16, d::16, e::48>> = :crypto.strong_rand_bytes(16)
+
+    [<<a::32>>, <<b::16>>, <<c::16>>, <<d::16>>, <<e::48>>]
+    |> Enum.map_join("-", &Base.encode16(&1, case: :lower))
+  end
+end

--- a/elixir/lease_plane/lib/unitares_lease_plane/handoff_timeout.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/handoff_timeout.ex
@@ -1,0 +1,15 @@
+defmodule UnitaresLeasePlane.HandoffTimeout do
+  @moduledoc """
+  Periodic handoff-offer timeout worker.
+
+  Timers inside `HandoffServer` expire offers promptly; this worker is the
+  scheduled safety sweep for delayed messages or hot-code reload windows.
+  """
+
+  alias UnitaresLeasePlane.HandoffServer
+
+  @spec perform(map()) :: {:ok, %{expired: non_neg_integer()}}
+  def perform(_args \\ %{}) do
+    {:ok, %{expired: HandoffServer.expire_stale()}}
+  end
+end

--- a/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
@@ -9,9 +9,9 @@ defmodule UnitaresLeasePlane.HTTPRouter do
   `schema_invalid` per the typed-absence protocol — there is no leaky 400
   HTML page.
 
-  Handoff (`/v1/lease/handoff/{offer,accept}`) is intentionally not wired
-  here — that work lands in a separate PR (release-and-reacquire pattern,
-  Oban offer-window timer).
+  Handoff (`/v1/lease/handoff/{offer,accept}`) uses the release-and-reacquire
+  pattern: accepting closes the old lease with `release_reason='handoff'` and
+  creates a new remote-heartbeat lease for the recipient.
   """
 
   use Plug.Router
@@ -141,23 +141,47 @@ defmodule UnitaresLeasePlane.HTTPRouter do
     end
   end
 
-  # ---------- /v1/lease/handoff/{offer,accept} ----------
-  # Wired in the next PR. Returns service_unavailable so callers see typed-absence,
-  # not a 404 HTML page.
   post "/v1/lease/handoff/offer" do
-    json(conn, 501, %{
-      ok: false,
-      error: "service_unavailable",
-      reason: "handoff not implemented in this build"
-    })
+    case extract_handoff_offer_params(conn.body_params) do
+      {:ok, lease_id, to_holder_agent_uuid, ttl_s} ->
+        case UnitaresLeasePlane.handoff_offer(lease_id, to_holder_agent_uuid, ttl_s) do
+          {:ok, handoff_id} ->
+            json(conn, 200, %{ok: true, handoff_id: handoff_id})
+
+          {:error, :not_found} ->
+            json(conn, 404, %{ok: false, error: "not_found"})
+
+          {:error, reason} ->
+            Logger.error("lease plane handoff offer failed: #{inspect(reason)}")
+            json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
+        end
+
+      {:error, detail} ->
+        json(conn, 422, %{ok: false, error: "schema_invalid", detail: detail})
+    end
   end
 
   post "/v1/lease/handoff/accept" do
-    json(conn, 501, %{
-      ok: false,
-      error: "service_unavailable",
-      reason: "handoff not implemented in this build"
-    })
+    case extract_handoff_accept_params(conn.body_params) do
+      {:ok, handoff_id} ->
+        case UnitaresLeasePlane.handoff_accept(handoff_id) do
+          :ok ->
+            json(conn, 200, %{ok: true})
+
+          {:error, :not_found} ->
+            json(conn, 404, %{ok: false, error: "not_found"})
+
+          {:error, :expired} ->
+            json(conn, 409, %{ok: false, error: "expired"})
+
+          {:error, reason} ->
+            Logger.error("lease plane handoff accept failed: #{inspect(reason)}")
+            json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
+        end
+
+      {:error, detail} ->
+        json(conn, 422, %{ok: false, error: "schema_invalid", detail: detail})
+    end
   end
 
   # ---------- catch-all ----------
@@ -244,6 +268,38 @@ defmodule UnitaresLeasePlane.HTTPRouter do
   end
 
   defp extract_release_params(_), do: {:error, "lease_id required"}
+
+  defp extract_handoff_offer_params(%{} = body) do
+    lease_id = Map.get(body, "lease_id")
+    to_holder_agent_uuid = Map.get(body, "to_holder_agent_uuid")
+    ttl_s = Map.get(body, "ttl_s")
+
+    cond do
+      not (is_binary(lease_id) and byte_size(lease_id) > 0) ->
+        {:error, "lease_id required"}
+
+      not (is_binary(to_holder_agent_uuid) and byte_size(to_holder_agent_uuid) > 0) ->
+        {:error, "to_holder_agent_uuid required"}
+
+      not is_integer(ttl_s) ->
+        {:error, "ttl_s must be an integer"}
+
+      ttl_s <= 0 or ttl_s > 3600 ->
+        {:error, "ttl_s must be in (0, 3600]"}
+
+      true ->
+        {:ok, lease_id, to_holder_agent_uuid, ttl_s}
+    end
+  end
+
+  defp extract_handoff_offer_params(_), do: {:error, "body must be a JSON object"}
+
+  defp extract_handoff_accept_params(%{"handoff_id" => handoff_id})
+       when is_binary(handoff_id) and byte_size(handoff_id) > 0 do
+    {:ok, handoff_id}
+  end
+
+  defp extract_handoff_accept_params(_), do: {:error, "handoff_id required"}
 
   defp present_lease(%{} = lease) do
     %{

--- a/elixir/lease_plane/lib/unitares_lease_plane/lease_holder.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/lease_holder.ex
@@ -37,6 +37,9 @@ defmodule UnitaresLeasePlane.LeaseHolder do
   @spec lease(pid()) :: map()
   def lease(pid), do: GenServer.call(pid, :lease)
 
+  @spec handoff_released(pid()) :: :ok
+  def handoff_released(pid), do: GenServer.cast(pid, :handoff_released)
+
   defp via(lease_id), do: {:via, Registry, {HolderRegistry, {:lease, lease_id}}}
 
   # ---------- callbacks ----------
@@ -55,7 +58,7 @@ defmodule UnitaresLeasePlane.LeaseHolder do
   def handle_call(:renew, _from, state) do
     case Repo.renew(state.lease.lease_id) do
       :ok -> {:reply, :ok, state}
-      {:error, :not_found} -> {:stop, :ttl_expired, {:error, :not_found}, state}
+      {:error, :not_found} -> {:stop, :normal, {:error, :not_found}, mark_released(state)}
       err -> {:reply, err, state}
     end
   end
@@ -68,6 +71,11 @@ defmodule UnitaresLeasePlane.LeaseHolder do
   end
 
   @impl true
+  def handle_cast(:handoff_released, state) do
+    {:stop, :normal, %{state | lease: %{state.lease | released_at: :released}}}
+  end
+
+  @impl true
   def handle_info(:tick, state) do
     case Repo.renew(state.lease.lease_id) do
       :ok ->
@@ -77,7 +85,7 @@ defmodule UnitaresLeasePlane.LeaseHolder do
       {:error, :not_found} ->
         # DB-side release happened (reaper, force-release, manual close) — the
         # canonical truth says we no longer hold this lease. Exit cleanly.
-        {:stop, :ttl_expired, state}
+        {:stop, :normal, mark_released(state)}
 
       {:error, reason} ->
         Logger.warning("lease_plane renew tick failed: #{inspect(reason)}; will retry next tick")
@@ -100,6 +108,8 @@ defmodule UnitaresLeasePlane.LeaseHolder do
     :ok
   end
 
+  def terminate(:ttl_expired, _state), do: :ok
+
   def terminate(reason, %{lease: lease}) do
     # Process is going down without an explicit release — record it.
     case Repo.release(lease.lease_id, "down_local") do
@@ -116,4 +126,6 @@ defmodule UnitaresLeasePlane.LeaseHolder do
   end
 
   defp schedule_tick(ms), do: Process.send_after(self(), :tick, ms)
+
+  defp mark_released(state), do: %{state | lease: %{state.lease | released_at: :released}}
 end

--- a/elixir/lease_plane/lib/unitares_lease_plane/lease_supervisor.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/lease_supervisor.ex
@@ -71,6 +71,15 @@ defmodule UnitaresLeasePlane.LeaseSupervisor do
     end
   end
 
+  @doc "Stop a local holder after DB-side handoff accepted the lease."
+  @spec stop_after_handoff(binary()) :: :ok
+  def stop_after_handoff(lease_id) when is_binary(lease_id) do
+    case holder_for(lease_id) do
+      {:ok, pid} -> LeaseHolder.handoff_released(pid)
+      :error -> :ok
+    end
+  end
+
   @doc "How many local_beam holders are currently alive."
   @spec count_holders() :: non_neg_integer()
   def count_holders, do: DynamicSupervisor.count_children(__MODULE__).active

--- a/elixir/lease_plane/lib/unitares_lease_plane/periodic_worker.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/periodic_worker.ex
@@ -1,0 +1,68 @@
+defmodule UnitaresLeasePlane.PeriodicWorker do
+  @moduledoc """
+  Lightweight scheduler for worker modules with a `perform/1` callback.
+
+  The production shape matches the Oban worker boundary (`perform(args)`), while
+  keeping this v0 lease-plane app on its existing Postgrex-only dependency set.
+  """
+
+  use GenServer
+
+  require Logger
+
+  def child_spec(opts) do
+    id = Keyword.fetch!(opts, :id)
+
+    %{
+      id: id,
+      start: {__MODULE__, :start_link, [opts]},
+      restart: :permanent,
+      type: :worker
+    }
+  end
+
+  def start_link(opts) do
+    name = Keyword.get(opts, :name)
+
+    if name do
+      GenServer.start_link(__MODULE__, opts, name: name)
+    else
+      GenServer.start_link(__MODULE__, opts)
+    end
+  end
+
+  @impl true
+  def init(opts) do
+    state = %{
+      worker: Keyword.fetch!(opts, :worker),
+      args: Keyword.get(opts, :args, %{}),
+      interval_ms: Keyword.fetch!(opts, :interval_ms)
+    }
+
+    Process.send_after(self(), :run, Keyword.get(opts, :initial_delay_ms, 0))
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info(:run, state) do
+    run_worker(state.worker, state.args)
+    Process.send_after(self(), :run, state.interval_ms)
+    {:noreply, state}
+  end
+
+  defp run_worker(worker, args) do
+    case worker.perform(args) do
+      {:ok, _summary} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("lease_plane worker #{inspect(worker)} failed: #{inspect(reason)}")
+
+      other ->
+        Logger.warning("lease_plane worker #{inspect(worker)} returned #{inspect(other)}")
+    end
+  rescue
+    error ->
+      Logger.error("lease_plane worker #{inspect(worker)} raised: #{Exception.message(error)}")
+  end
+end

--- a/elixir/lease_plane/lib/unitares_lease_plane/reaper.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/reaper.ex
@@ -1,0 +1,60 @@
+defmodule UnitaresLeasePlane.Reaper do
+  @moduledoc """
+  Periodic lease reaper worker.
+
+  The worker is intentionally small and idempotent: it only releases rows that
+  are still active and still expired at update time, so an in-flight heartbeat
+  that already extended `expires_at` wins.
+  """
+
+  require Logger
+
+  alias UnitaresLeasePlane.{LeaseSupervisor, Repo}
+
+  @spec perform(map()) :: {:ok, %{reaped: non_neg_integer()}} | {:error, term()}
+  def perform(args \\ %{}) when is_map(args) do
+    limit =
+      positive_arg(args, "limit", :limit, Application.get_env(:lease_plane, :reaper_limit, 100))
+
+    with {:ok, leases} <- Repo.expired_active_leases(limit) do
+      reaped =
+        Enum.reduce(leases, 0, fn lease, count ->
+          case Repo.release_if_expired(lease.lease_id, release_reason(lease)) do
+            :ok ->
+              count + 1
+
+            {:error, :not_found} ->
+              count
+
+            {:error, reason} ->
+              Logger.warning(
+                "lease_plane reaper could not release #{lease.lease_id}: #{inspect(reason)}"
+              )
+
+              count
+          end
+        end)
+
+      {:ok, %{reaped: reaped}}
+    end
+  end
+
+  defp release_reason(%{holder_kind: "remote_heartbeat"}), do: "reaped_remote_ttl"
+
+  defp release_reason(%{holder_kind: "local_beam", lease_id: lease_id}) do
+    case LeaseSupervisor.holder_for(lease_id) do
+      {:ok, pid} when is_pid(pid) -> "reaped_local_ttl"
+      :error -> "reaped_after_supervisor_failed"
+    end
+  end
+
+  defp positive_arg(args, string_key, atom_key, default) do
+    value = Map.get(args, string_key, Map.get(args, atom_key, default))
+
+    if is_integer(value) and value > 0 do
+      value
+    else
+      default
+    end
+  end
+end

--- a/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
@@ -9,15 +9,16 @@ defmodule UnitaresLeasePlane.Repo do
     {:ok, lease_map | nil}                   # status
     :ok | {:error, reason}                   # renew/release/heartbeat
 
-  All writes also append a row to `lease_plane.lease_plane_events`
+  All lease writes also append a row to `lease_plane.lease_plane_events`
   (audit-outbox) inside the same transaction so durable truth and audit
-  trail cannot diverge. Forwarding to Python-side `audit.tool_usage`
-  happens in a separate Oban job (Phase A — not yet wired).
+  trail cannot diverge. The forwarder projects those rows into
+  `audit.tool_usage` after the fact.
   """
 
   alias UnitaresLeasePlane.DB
 
   @typep lease :: map()
+  @typep event :: map()
 
   # Cast uuid columns to text on the boundary so callers don't have to
   # know whether Postgrex returned 16-byte raw binaries or 36-char strings.
@@ -66,12 +67,18 @@ defmodule UnitaresLeasePlane.Repo do
     end
   end
 
-  defp acquire_step(_conn, p, %{holder_agent_uuid: held} = existing)
+  defp acquire_step(conn, p, %{holder_agent_uuid: held} = existing)
        when is_binary(held) do
     if held == p.holder_agent_uuid do
       {:ok, {:ok, existing, :idempotent}}
     else
-      {:ok, {:error, :held_by_other, %{held_by_uuid: held, expires_at: existing.expires_at}}}
+      case log_conflict(conn, p, existing) do
+        :ok ->
+          {:ok, {:error, :held_by_other, %{held_by_uuid: held, expires_at: existing.expires_at}}}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
     end
   end
 
@@ -170,7 +177,7 @@ defmodule UnitaresLeasePlane.Repo do
            with {:ok, %{rows: [row], columns: cols}} <-
                   Postgrex.query(conn, sql, [uuid_to_binary(lease_id), release_reason]),
                 lease = row_to_map(cols, row),
-                :ok <- log_event(conn, "release", lease) do
+                :ok <- log_event(conn, release_event_type(release_reason), lease) do
              :ok
            else
              {:ok, %{rows: []}} -> Postgrex.rollback(conn, :not_found)
@@ -182,15 +189,279 @@ defmodule UnitaresLeasePlane.Repo do
     end
   end
 
+  # ---------- handoff ----------
+
+  @spec active_lease(binary()) :: {:ok, lease} | {:error, :not_found | term()}
+  def active_lease(lease_id) when is_binary(lease_id) do
+    sql =
+      "SELECT #{@select_lease_columns} FROM lease_plane.surface_leases " <>
+        "WHERE lease_id = $1 AND released_at IS NULL"
+
+    case Postgrex.query(DB, sql, [uuid_to_binary(lease_id)]) do
+      {:ok, %{rows: [row], columns: cols}} -> {:ok, row_to_map(cols, row)}
+      {:ok, %{rows: []}} -> {:error, :not_found}
+      {:error, e} -> {:error, e}
+    end
+  end
+
+  @spec log_handoff_offer(lease, map()) :: :ok | {:error, term()}
+  def log_handoff_offer(%{} = lease, %{} = handoff) do
+    payload = %{
+      handoff_id: handoff.handoff_id,
+      from_lease_id: lease.lease_id,
+      from_holder_agent_uuid: lease.holder_agent_uuid,
+      to_holder_agent_uuid: handoff.to_holder_agent_uuid,
+      new_ttl_s: handoff.ttl_s,
+      offer_expires_at: iso(handoff.expires_at),
+      audit_session: lease.audit_session
+    }
+
+    log_event(DB, "handoff_offer", lease, payload)
+  end
+
+  @spec accept_handoff(map()) :: {:ok, lease} | {:error, term()}
+  def accept_handoff(%{} = handoff) do
+    Postgrex.transaction(DB, fn conn ->
+      with {:ok, old_lease} <- lock_active_lease(conn, handoff.lease_id),
+           {:ok, new_lease} <- transition_handoff(conn, old_lease, handoff) do
+        new_lease
+      else
+        {:error, reason} -> Postgrex.rollback(conn, reason)
+      end
+    end)
+    |> case do
+      {:ok, lease} -> {:ok, lease}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp lock_active_lease(conn, lease_id) do
+    sql =
+      "SELECT #{@select_lease_columns} FROM lease_plane.surface_leases " <>
+        "WHERE lease_id = $1 AND released_at IS NULL FOR UPDATE"
+
+    case Postgrex.query(conn, sql, [uuid_to_binary(lease_id)]) do
+      {:ok, %{rows: [row], columns: cols}} -> {:ok, row_to_map(cols, row)}
+      {:ok, %{rows: []}} -> {:error, :not_found}
+      {:error, e} -> {:error, e}
+    end
+  end
+
+  defp transition_handoff(conn, old_lease, handoff) do
+    release_sql = """
+    UPDATE lease_plane.surface_leases
+    SET released_at = now(), release_reason = 'handoff'
+    WHERE lease_id = $1 AND released_at IS NULL
+    """
+
+    insert_sql = """
+    INSERT INTO lease_plane.surface_leases
+      (surface_id, surface_kind, holder_agent_uuid, holder_class,
+       holder_kind, holder_pid, heartbeat_required, intent,
+       expires_at, original_ttl_s, audit_session, earned_status)
+    VALUES
+      ($1, $2, $3, $4, 'remote_heartbeat', NULL, true, $5,
+       now() + make_interval(secs => $6), $6, $7, 'provisional')
+    RETURNING #{@select_lease_columns}
+    """
+
+    intent = old_lease.intent || "handoff from #{old_lease.lease_id}"
+    audit_session = old_lease.audit_session
+
+    args = [
+      old_lease.surface_id,
+      old_lease.surface_kind,
+      uuid_to_binary(handoff.to_holder_agent_uuid),
+      old_lease.holder_class,
+      intent,
+      handoff.ttl_s,
+      audit_session
+    ]
+
+    with {:ok, _} <- Postgrex.query(conn, release_sql, [uuid_to_binary(old_lease.lease_id)]),
+         {:ok, %{rows: [row], columns: cols}} <- Postgrex.query(conn, insert_sql, args),
+         new_lease = row_to_map(cols, row),
+         payload = %{
+           handoff_id: handoff.handoff_id,
+           from_lease_id: old_lease.lease_id,
+           from_holder_agent_uuid: old_lease.holder_agent_uuid,
+           to_holder_agent_uuid: handoff.to_holder_agent_uuid,
+           audit_session: audit_session
+         },
+         :ok <- log_event(conn, "handoff_accept", new_lease, payload) do
+      {:ok, new_lease}
+    end
+  end
+
+  # ---------- reaper ----------
+
+  @spec expired_active_leases(pos_integer()) :: {:ok, [lease]} | {:error, term()}
+  def expired_active_leases(limit) when is_integer(limit) and limit > 0 do
+    sql =
+      "SELECT #{@select_lease_columns} FROM lease_plane.surface_leases " <>
+        "WHERE released_at IS NULL AND expires_at < now() " <>
+        "ORDER BY expires_at ASC LIMIT $1"
+
+    case Postgrex.query(DB, sql, [limit]) do
+      {:ok, %{rows: rows, columns: cols}} -> {:ok, Enum.map(rows, &row_to_map(cols, &1))}
+      {:error, e} -> {:error, e}
+    end
+  end
+
+  @spec release_if_expired(binary(), String.t()) :: :ok | {:error, term()}
+  def release_if_expired(lease_id, release_reason) when is_binary(release_reason) do
+    sql = """
+    UPDATE lease_plane.surface_leases
+    SET released_at = now(), release_reason = $2
+    WHERE lease_id = $1 AND released_at IS NULL AND expires_at < now()
+    RETURNING #{@select_lease_columns}
+    """
+
+    case Postgrex.transaction(DB, fn conn ->
+           with {:ok, %{rows: [row], columns: cols}} <-
+                  Postgrex.query(conn, sql, [uuid_to_binary(lease_id), release_reason]),
+                lease = row_to_map(cols, row),
+                :ok <- log_event(conn, release_event_type(release_reason), lease) do
+             :ok
+           else
+             {:ok, %{rows: []}} -> Postgrex.rollback(conn, :not_found)
+             {:error, e} -> Postgrex.rollback(conn, e)
+           end
+         end) do
+      {:ok, :ok} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # ---------- audit outbox ----------
+
+  @spec unforwarded_events(pos_integer(), keyword()) :: {:ok, [event]} | {:error, term()}
+  def unforwarded_events(limit, opts \\ []) when is_integer(limit) and limit > 0 do
+    {where, args} =
+      case Keyword.fetch(opts, :surface_id) do
+        {:ok, surface_id} -> {"forwarded_at IS NULL AND surface_id = $2", [limit, surface_id]}
+        :error -> {"forwarded_at IS NULL", [limit]}
+      end
+
+    sql = """
+    SELECT
+      event_id::text AS event_id,
+      ts, event_type, lease_id::text AS lease_id,
+      surface_id, surface_kind,
+      holder_agent_uuid::text AS holder_agent_uuid,
+      holder_class, advisory_mode, payload, earned_status
+    FROM lease_plane.lease_plane_events
+    WHERE #{where}
+    ORDER BY ts ASC
+    LIMIT $1
+    """
+
+    case Postgrex.query(DB, sql, args) do
+      {:ok, %{rows: rows, columns: cols}} -> {:ok, Enum.map(rows, &row_to_map(cols, &1))}
+      {:error, e} -> {:error, e}
+    end
+  end
+
+  @spec forward_outbox_event(binary()) :: :ok | {:error, term()}
+  def forward_outbox_event(event_id) when is_binary(event_id) do
+    result =
+      Postgrex.transaction(DB, fn conn ->
+        with {:ok, event} <- lock_unforwarded_event(conn, event_id),
+             :ok <- insert_tool_usage(conn, event),
+             :ok <- mark_forwarded(conn, event.event_id) do
+          :ok
+        else
+          {:error, reason} -> Postgrex.rollback(conn, reason)
+        end
+      end)
+
+    case result do
+      {:ok, :ok} ->
+        :ok
+
+      {:error, reason} ->
+        _ = bump_forward_attempts(event_id)
+        {:error, reason}
+    end
+  end
+
+  defp lock_unforwarded_event(conn, event_id) do
+    sql = """
+    SELECT
+      event_id::text AS event_id,
+      ts, event_type, lease_id::text AS lease_id,
+      surface_id, surface_kind,
+      holder_agent_uuid::text AS holder_agent_uuid,
+      holder_class, advisory_mode, payload, earned_status
+    FROM lease_plane.lease_plane_events
+    WHERE event_id = $1 AND forwarded_at IS NULL
+    FOR UPDATE
+    """
+
+    case Postgrex.query(conn, sql, [uuid_to_binary(event_id)]) do
+      {:ok, %{rows: [row], columns: cols}} -> {:ok, row_to_map(cols, row)}
+      {:ok, %{rows: []}} -> {:error, :not_found}
+      {:error, e} -> {:error, e}
+    end
+  end
+
+  defp insert_tool_usage(conn, event) do
+    sql = """
+    INSERT INTO audit.tool_usage
+      (ts, agent_id, session_id, tool_name, latency_ms, success, error_type, payload)
+    VALUES ($1, $2, $3, $4, NULL, $5, $6, ($7::text)::jsonb)
+    """
+
+    success = event.event_type != "service_unavailable"
+    error_type = if success, do: nil, else: "service_unavailable"
+    payload = tool_usage_payload(event)
+
+    args = [
+      event.ts,
+      event.holder_agent_uuid,
+      Map.get(payload, "audit_session"),
+      "lease.#{event.event_type}",
+      success,
+      error_type,
+      Jason.encode!(payload)
+    ]
+
+    case Postgrex.query(conn, sql, args) do
+      {:ok, _} -> :ok
+      {:error, e} -> {:error, e}
+    end
+  end
+
+  defp mark_forwarded(conn, event_id) do
+    sql = """
+    UPDATE lease_plane.lease_plane_events
+    SET forwarded_at = now(), forward_attempts = forward_attempts + 1
+    WHERE event_id = $1
+    """
+
+    case Postgrex.query(conn, sql, [uuid_to_binary(event_id)]) do
+      {:ok, _} -> :ok
+      {:error, e} -> {:error, e}
+    end
+  end
+
+  defp bump_forward_attempts(event_id) do
+    Postgrex.query(
+      DB,
+      "UPDATE lease_plane.lease_plane_events SET forward_attempts = forward_attempts + 1 WHERE event_id = $1",
+      [uuid_to_binary(event_id)]
+    )
+  end
+
   # ---------- helpers ----------
 
-  defp log_event(conn, event_type, lease) do
+  defp log_event(conn, event_type, lease, payload \\ nil) do
     sql = """
     INSERT INTO lease_plane.lease_plane_events
       (event_type, lease_id, surface_id, surface_kind,
        holder_agent_uuid, holder_class, advisory_mode,
        payload, earned_status)
-    VALUES ($1, $2, $3, $4, $5, $6, true, $7::jsonb, $8)
+    VALUES ($1, $2, $3, $4, $5, $6, true, ($7::text)::jsonb, $8)
     """
 
     args = [
@@ -200,7 +471,7 @@ defmodule UnitaresLeasePlane.Repo do
       lease.surface_kind,
       uuid_to_binary(lease.holder_agent_uuid),
       lease.holder_class,
-      Jason.encode!(%{}),
+      Jason.encode!(payload || lease_payload(lease)),
       lease.earned_status
     ]
 
@@ -209,6 +480,105 @@ defmodule UnitaresLeasePlane.Repo do
       {:error, e} -> {:error, e}
     end
   end
+
+  defp log_conflict(conn, p, existing) do
+    sql = """
+    INSERT INTO lease_plane.lease_plane_events
+      (event_type, lease_id, surface_id, surface_kind,
+       holder_agent_uuid, holder_class, advisory_mode,
+       payload, earned_status)
+    VALUES ($1, $2, $3, $4, $5, $6, true, ($7::text)::jsonb, $8)
+    """
+
+    payload = %{
+      requested_holder_agent_uuid: p.holder_agent_uuid,
+      held_by_uuid: existing.holder_agent_uuid,
+      expires_at: iso(existing.expires_at),
+      audit_session: Map.get(p, :audit_session)
+    }
+
+    args = [
+      "conflict_held_by_other",
+      uuid_to_binary(existing.lease_id),
+      existing.surface_id,
+      existing.surface_kind,
+      uuid_to_binary(p.holder_agent_uuid),
+      Map.get(p, :holder_class, "process_instance"),
+      Jason.encode!(payload),
+      existing.earned_status
+    ]
+
+    case Postgrex.query(conn, sql, args) do
+      {:ok, _} -> :ok
+      {:error, e} -> {:error, e}
+    end
+  end
+
+  defp lease_payload(lease) do
+    %{
+      "lease_id" => lease.lease_id,
+      "surface_id" => lease.surface_id,
+      "surface_kind" => lease.surface_kind,
+      "holder_agent_uuid" => lease.holder_agent_uuid,
+      "holder_class" => lease.holder_class,
+      "holder_kind" => lease.holder_kind,
+      "holder_pid" => lease.holder_pid,
+      "heartbeat_required" => lease.heartbeat_required,
+      "intent" => lease.intent,
+      "acquired_at" => iso(lease.acquired_at),
+      "expires_at" => iso(lease.expires_at),
+      "last_heartbeat_at" => iso(lease.last_heartbeat_at),
+      "released_at" => iso(lease.released_at),
+      "release_reason" => lease.release_reason,
+      "audit_session" => lease.audit_session,
+      "original_ttl_s" => lease.original_ttl_s,
+      "earned_status" => lease.earned_status
+    }
+  end
+
+  defp tool_usage_payload(event) do
+    event_payload = decode_payload(event.payload)
+
+    %{
+      "lease_event_id" => event.event_id,
+      "lease_id" => event.lease_id,
+      "surface_id" => event.surface_id,
+      "surface_kind" => event.surface_kind,
+      "holder_agent_uuid" => event.holder_agent_uuid,
+      "holder_class" => event.holder_class,
+      "advisory_mode" => event.advisory_mode,
+      "earned_status" => event.earned_status,
+      "audit_session" => Map.get(event_payload, "audit_session"),
+      "lease_payload" => event_payload
+    }
+  end
+
+  defp decode_payload(%{} = payload), do: stringify_keys(payload)
+
+  defp decode_payload(payload) when is_binary(payload) do
+    case Jason.decode(payload) do
+      {:ok, %{} = decoded} -> stringify_keys(decoded)
+      _ -> %{"raw_payload" => payload}
+    end
+  end
+
+  defp decode_payload(_), do: %{}
+
+  defp stringify_keys(map) do
+    Map.new(map, fn
+      {key, value} when is_atom(key) -> {Atom.to_string(key), value}
+      {key, value} -> {key, value}
+    end)
+  end
+
+  defp release_event_type(reason)
+       when reason in ["reaped_remote_ttl", "reaped_local_ttl", "down_local", "forced"],
+       do: reason
+
+  defp release_event_type(_reason), do: "release"
+
+  defp iso(nil), do: nil
+  defp iso(%DateTime{} = dt), do: DateTime.to_iso8601(dt)
 
   defp row_to_map(columns, row) do
     columns

--- a/elixir/lease_plane/test/http_router_test.exs
+++ b/elixir/lease_plane/test/http_router_test.exs
@@ -240,22 +240,59 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
     end
   end
 
-  describe "POST /v1/lease/handoff/{offer,accept} (stubbed)" do
-    test "offer returns 501 service_unavailable until implemented", _ctx do
+  describe "POST /v1/lease/handoff/{offer,accept}" do
+    test "offer returns a handoff_id for an active lease", ctx do
+      acquire = post_json("/v1/lease/acquire", acquire_body(ctx.surface))
+      lease_id = parsed(acquire)["lease"]["lease_id"]
+
       resp =
         post_json("/v1/lease/handoff/offer", %{
-          lease_id: random_uuid(),
+          lease_id: lease_id,
           to_holder_agent_uuid: random_uuid(),
           ttl_s: 30
         })
 
-      assert resp.status == 501
-      assert parsed(resp)["error"] == "service_unavailable"
+      assert resp.status == 200
+      body = parsed(resp)
+      assert body["ok"] == true
+      assert is_binary(body["handoff_id"])
     end
 
-    test "accept returns 501 service_unavailable until implemented", _ctx do
+    test "accept closes the old lease and reacquires for the recipient", ctx do
+      acquire = post_json("/v1/lease/acquire", acquire_body(ctx.surface))
+      old_lease_id = parsed(acquire)["lease"]["lease_id"]
+      to_holder = random_uuid()
+
+      offer =
+        post_json("/v1/lease/handoff/offer", %{
+          lease_id: old_lease_id,
+          to_holder_agent_uuid: to_holder,
+          ttl_s: 45
+        })
+
+      handoff_id = parsed(offer)["handoff_id"]
+      accept = post_json("/v1/lease/handoff/accept", %{handoff_id: handoff_id})
+      assert accept.status == 200
+      assert parsed(accept) == %{"ok" => true}
+
+      status =
+        :get
+        |> conn("/v1/lease/status?surface_id=#{URI.encode_www_form(ctx.surface)}")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      lease = parsed(status)["lease"]
+      assert lease["holder_agent_uuid"] == to_holder
+      assert lease["holder_kind"] == "remote_heartbeat"
+      assert lease["heartbeat_required"] == true
+      assert lease["original_ttl_s"] == 45
+      refute lease["lease_id"] == old_lease_id
+    end
+
+    test "accept of an unknown handoff returns 404", _ctx do
       resp = post_json("/v1/lease/handoff/accept", %{handoff_id: random_uuid()})
-      assert resp.status == 501
+      assert resp.status == 404
+      assert parsed(resp)["error"] == "not_found"
     end
   end
 

--- a/elixir/lease_plane/test/support/lease_test_helpers.ex
+++ b/elixir/lease_plane/test/support/lease_test_helpers.ex
@@ -13,8 +13,14 @@ defmodule LeaseTestHelpers do
     "test:elixir/#{label}/#{rand}"
   end
 
-  @doc "Cleanup hook — DELETEs rows for a given surface_id from both tables."
+  @doc "Cleanup hook — DELETEs rows for a given surface_id from lease/audit tables."
   def cleanup_surface(surface_id) when is_binary(surface_id) do
+    Postgrex.query!(
+      DB,
+      "DELETE FROM audit.tool_usage WHERE payload->>'surface_id' = $1",
+      [surface_id]
+    )
+
     Postgrex.query!(
       DB,
       "DELETE FROM lease_plane.lease_plane_events WHERE surface_id = $1",

--- a/elixir/lease_plane/test/test_helper.exs
+++ b/elixir/lease_plane/test/test_helper.exs
@@ -41,3 +41,4 @@ parsed =
 
 {:ok, _} = Registry.start_link(keys: :unique, name: UnitaresLeasePlane.HolderRegistry)
 {:ok, _} = UnitaresLeasePlane.LeaseSupervisor.start_link(:ok)
+{:ok, _} = UnitaresLeasePlane.HandoffServer.start_link(:ok)

--- a/elixir/lease_plane/test/unitares_lease_plane_test.exs
+++ b/elixir/lease_plane/test/unitares_lease_plane_test.exs
@@ -3,7 +3,7 @@ defmodule UnitaresLeasePlaneTest do
 
   import LeaseTestHelpers
 
-  alias UnitaresLeasePlane.{LeaseHolder, LeaseSupervisor, Repo}
+  alias UnitaresLeasePlane.{AuditOutboxForwarder, LeaseHolder, LeaseSupervisor, Reaper, Repo}
 
   setup do
     surface = unique_surface_id("api")
@@ -135,6 +135,90 @@ defmodule UnitaresLeasePlaneTest do
     end
   end
 
+  describe "handoff" do
+    test "offer and accept transfer active lease to a remote-heartbeat holder", ctx do
+      params = local_beam_params(ctx.surface)
+      assert {:ok, lease, :new} = UnitaresLeasePlane.acquire_local_beam(params)
+      to_holder = random_uuid()
+
+      assert {:ok, handoff_id} = UnitaresLeasePlane.handoff_offer(lease.lease_id, to_holder, 45)
+      assert :ok = UnitaresLeasePlane.handoff_accept(handoff_id)
+
+      assert {:ok, transferred} = UnitaresLeasePlane.status(ctx.surface)
+      assert transferred.lease_id != lease.lease_id
+      assert transferred.holder_agent_uuid == to_holder
+      assert transferred.holder_kind == "remote_heartbeat"
+      assert transferred.heartbeat_required == true
+      assert transferred.original_ttl_s == 45
+
+      sql =
+        "SELECT release_reason FROM lease_plane.surface_leases " <>
+          "WHERE lease_id = $1 AND released_at IS NOT NULL"
+
+      {:ok, %{rows: [[reason]]}} =
+        Postgrex.query(UnitaresLeasePlane.DB, sql, [uuid_to_binary(lease.lease_id)])
+
+      assert reason == "handoff"
+    end
+
+    test "unknown handoff returns not_found" do
+      assert {:error, :not_found} = UnitaresLeasePlane.handoff_accept(random_uuid())
+    end
+  end
+
+  describe "reaper" do
+    test "releases expired remote heartbeat leases with reaped_remote_ttl", ctx do
+      params = local_beam_params(ctx.surface, ttl_s: 1)
+      assert {:ok, lease, :new} = UnitaresLeasePlane.acquire_remote_heartbeat(params)
+
+      Process.sleep(1100)
+      assert {:ok, %{reaped: reaped}} = Reaper.perform(%{limit: 100})
+      assert reaped >= 1
+      assert {:ok, nil} = UnitaresLeasePlane.status(ctx.surface)
+
+      sql =
+        "SELECT release_reason FROM lease_plane.surface_leases " <>
+          "WHERE lease_id = $1 AND released_at IS NOT NULL"
+
+      {:ok, %{rows: [[reason]]}} =
+        Postgrex.query(UnitaresLeasePlane.DB, sql, [uuid_to_binary(lease.lease_id)])
+
+      assert reason == "reaped_remote_ttl"
+    end
+  end
+
+  describe "audit outbox forwarder" do
+    test "projects lease events into audit.tool_usage and marks them forwarded", ctx do
+      params = local_beam_params(ctx.surface)
+      assert {:ok, _lease, :new} = UnitaresLeasePlane.acquire_local_beam(params)
+
+      event_id = acquire_event_id(ctx.surface)
+
+      assert {:ok, %{forwarded: 1, failed: 0}} =
+               AuditOutboxForwarder.perform(%{limit: 10, surface_id: ctx.surface})
+
+      sql = """
+      SELECT tool_name, payload->>'surface_id'
+      FROM audit.tool_usage
+      WHERE payload->>'lease_event_id' = $1
+      """
+
+      {:ok, %{rows: [["lease.acquire", surface_id]]}} =
+        Postgrex.query(UnitaresLeasePlane.DB, sql, [event_id])
+
+      assert surface_id == ctx.surface
+
+      {:ok, %{rows: [[forwarded_at]]}} =
+        Postgrex.query(
+          UnitaresLeasePlane.DB,
+          "SELECT forwarded_at FROM lease_plane.lease_plane_events WHERE event_id = $1",
+          [uuid_to_binary(event_id)]
+        )
+
+      assert %DateTime{} = forwarded_at
+    end
+  end
+
   describe "status/1" do
     test "returns nil for unknown surface" do
       assert {:ok, nil} = UnitaresLeasePlane.status("test:elixir/never-acquired")
@@ -149,5 +233,23 @@ defmodule UnitaresLeasePlaneTest do
       assert fetched.holder_agent_uuid == lease.holder_agent_uuid
       assert fetched.earned_status == "provisional"
     end
+  end
+
+  defp acquire_event_id(surface_id) do
+    {:ok, %{rows: [[event_id]]}} =
+      Postgrex.query(
+        UnitaresLeasePlane.DB,
+        "SELECT event_id::text FROM lease_plane.lease_plane_events WHERE surface_id = $1 AND event_type = 'acquire' ORDER BY ts DESC LIMIT 1",
+        [surface_id]
+      )
+
+    event_id
+  end
+
+  defp uuid_to_binary(
+         <<a::binary-size(8), "-", b::binary-size(4), "-", c::binary-size(4), "-",
+           d::binary-size(4), "-", e::binary-size(12)>>
+       ) do
+    Base.decode16!(a <> b <> c <> d <> e, case: :mixed)
   end
 end


### PR DESCRIPTION
## Summary
- implement BEAM handoff offer/accept as release-and-reacquire
- add periodic workers for expired-lease reaping, handoff timeout cleanup, and audit-outbox forwarding
- project lease-plane events into audit.tool_usage and cover the new state-machine paths with Elixir tests

## Validation
- mix format
- git diff --check
- mix test: 48 tests, 0 failures
- pre-push smoke: 138 passed, 7421 deselected

## Notes
- PR intentionally excludes unrelated local Python changes in background task tests.
- Pre-push doc health reported one warning from the locally fetched ignored dependency docs under elixir/lease_plane/deps/bandit/README.md.