### PR TITLE
feat(lease-plane): Phase A PR 2 — canonicalize.py + AcquireRequest surface_kind drop

### DIFF
--- a/docs/proposals/surface-lease-plane-phase-a-plan.md
+++ b/docs/proposals/surface-lease-plane-phase-a-plan.md
@@ -90,15 +90,47 @@ Currently no rule keyed on `release_reason` or `event_type='forced'` exists in `
 
 The rule needs `lease_plane_events` SELECT access. If Sentinel doesn't already have it, the migration step adds the GRANT.
 
-## PR 2 — §7.12 canonicalization helper (planned, not yet drafted)
+## PR 2 — §7.12 canonicalization helper (this branch: impl/lease-plane-phase-a-pr2-canonicalize)
 
-Scope (anticipated; will reify when PR 1 lands):
-- `src/lease_plane/canonicalize.py` (new) implementing the §7.12.1 server-side rule: tmpfile probe, double-realpath, scheme dispatch, `capture:/` member sorting.
-- Pydantic `field_validator` on `AcquireRequest.surface_id` calling the helper.
-- Helper error semantics (§7.12.2): `CanonicalizeError` exception with `reason` codes.
-- 6 §7.12 Phase A test gates.
+Scope shipped:
+- `src/lease_plane/canonicalize.py` (new) implementing the §7.12.1 server-side rule: tmpfile probe (closes live-verifier DRIFT-3), double-realpath (closes DRIFT-2), per-scheme dispatch, `capture:/` member sorting, `dialectic:/` lowercase, `resident:/` reserved-character rejection.
+- Helper error semantics (§7.12.2): `CanonicalizeError` exception with `reason` codes (`symlink_loop`, `path_too_long`, `invalid_scheme`).
+- AcquireRequest `surface_kind` field removed (closes the v0.7 PR 1 oversight — Elixir router was updated but Python schema wasn't).
+- `lease_advisory_scope()` `surface_kind` parameter softened to optional + ignored (preserves backwards-compat for watcher/vigil/sentinel/chronicler/ship.sh callers without surface_id migration in this PR).
+- 4 of the 6 §7.12 Phase A test gates pass.
 
-Rationale for separating from PR 1: the helper is a self-contained module with no schema/contract dependency on the migration changes. Reviewing it independently keeps the cognitive load tractable.
+Deferred to **PR 2.5** (see new section below):
+- Pydantic `field_validator` on `AcquireRequest.surface_id` (would brick production agents whose surface_ids are non-canonical).
+- 2 of the 6 §7.12 Phase A test gates marked `pytest.mark.skip`.
+
+### PR 2 — RFC gate → code surface → test name → status table
+
+| Gate | Code | Test | Status |
+|------|------|------|--------|
+| §7.12.1 step 4 — tmpfile probe (not pathconf) | `src/lease_plane/canonicalize.py::_detect_case_insensitive` | `test_canonicalize_case_detection_uses_tmpfile_probe` | DONE |
+| §7.12.1 step 2 — double-realpath for /var → /private/var | `canonicalize.py::_canonicalize_file` | `test_canonicalize_resolves_var_to_private_var_on_macos` | DONE |
+| §7.12.1 capture:/ member sorting | `canonicalize.py::_canonicalize_capture` | `test_capture_canonicalizes_member_ordering` | DONE |
+| §7.12.2 helper error semantics (symlink loop, NUL, nonexistent) | `canonicalize.py::canonicalize` | `test_canonicalize_error_semantics` | DONE |
+| §7.12.5 AcquireRequest field_validator wired | (deferred to PR 2.5) | `test_acquire_request_surface_id_field_validator_wired` | SKIPPED |
+| §7.12.4 Pydantic ?-rejection | (deferred to PR 2.5) | `test_acquire_request_rejects_query_string_in_surface_id` | SKIPPED |
+| §7.2.3 Pydantic AcquireRequest drops `surface_kind` (closes PR 1 oversight) | `src/lease_plane/models.py`, `src/lease_plane/advisory.py`, `scripts/dev/_ship_lease_advisory.py` | (covered by 39-test lease-plane regression) | DONE |
+
+## PR 2.5 — Production-agent surface_id migration + AcquireRequest field_validator (planned, not yet drafted)
+
+**Surfaced during PR 2 implementation:** the production agents (watcher, vigil, sentinel, chronicler, ship.sh advisory) use surface_ids like `watcher:scan_commits:<repo>`, `vigil:cycle`, `sentinel:cycle`, `chronicler:scrape`, `ship.sh:test-branch` — none of which match the canonical scheme list (RFC §7.2.1). Wiring the AcquireRequest field_validator now would cause every agent to crash on first acquire with `ValidationError: scheme not in canonical scheme list`.
+
+Scope:
+- Migrate production surface_ids to canonical schemes:
+  - `watcher:scan_commits:X` → `resident:/watcher_scan_commits_X`
+  - `vigil:cycle` → `resident:/vigil_cycle`
+  - `sentinel:cycle` → `resident:/sentinel_cycle`
+  - `chronicler:scrape` → `resident:/chronicler_scrape`
+  - `ship.sh:<branch>` → `resident:/ship_sh_<branch>` (operator-driven, not file-bound)
+- After migration, wire the AcquireRequest `field_validator` on `surface_id` per §7.12.5 — auto-canonicalize at the model boundary; reject NUL bytes, `?`-bearing strings, and non-canonical schemes.
+- Un-skip the 2 deferred test gates: `test_acquire_request_rejects_query_string_in_surface_id` and `test_acquire_request_surface_id_field_validator_wired`.
+- Update `lease_advisory_scope()` to drop `surface_kind` parameter entirely (currently kept as optional+ignored).
+
+Rationale for splitting from PR 2: the canonicalize.py helper is reviewable independently; coupling it to a fleet-wide surface_id migration risks both reviews stalling on the wider impact. PR 2 ships the helper; PR 2.5 ships the migration + validator together (they MUST land atomically — validator without migration = bricked fleet; migration without validator = silently inconsistent).
 
 ## PR 3 — §7.11 deprecation CLI + Sentinel forced-release alarm (planned, not yet drafted)
 

--- a/scripts/dev/_ship_lease_advisory.py
+++ b/scripts/dev/_ship_lease_advisory.py
@@ -43,9 +43,12 @@ from src.lease_plane.advisory import (  # noqa: E402
 def _cmd_acquire(args: argparse.Namespace) -> int:
     client: LeasePlaneClient = make_advisory_client()
 
+    # surface_kind dropped per RFC v0.8 §7.2.3 — derived server-side from
+    # surface_id scheme prefix via migration 026's generated column.
+    # args.surface_kind is preserved on the CLI for backwards-compat with
+    # operator scripts but is not passed to AcquireRequest.
     request = AcquireRequest(
         surface_id=args.surface_id,
-        surface_kind=args.surface_kind,
         holder_agent_uuid=uuid4(),
         holder_class="process_instance",
         holder_kind="remote_heartbeat",

--- a/src/lease_plane/advisory.py
+++ b/src/lease_plane/advisory.py
@@ -100,7 +100,7 @@ def new_holder_uuid() -> uuid.UUID:
 def lease_advisory_scope(
     *,
     surface_id: str,
-    surface_kind: str,
+    surface_kind: str | None = None,
     holder_agent_uuid: uuid.UUID,
     ttl_s: int,
     intent: str | None = None,
@@ -117,12 +117,18 @@ def lease_advisory_scope(
     The wrapper NEVER raises from the lease layer. Any exception raised by
     the caller's block will propagate normally; the wrapper only ensures
     the lease is released if it was acquired.
+
+    `surface_kind` is accepted for backwards-compat with pre-PR-2 callers
+    (watcher/vigil/sentinel/chronicler agents) but is no longer passed to
+    AcquireRequest — per RFC v0.8 §7.2.3 the server derives surface_kind
+    from the surface_id scheme prefix via migration 026's generated column.
+    The parameter is silently ignored; callers SHOULD remove it.
     """
+    del surface_kind  # ignored; see docstring
     advisory_client = client or make_advisory_client()
 
     request = AcquireRequest(
         surface_id=surface_id,
-        surface_kind=surface_kind,
         holder_agent_uuid=holder_agent_uuid,
         holder_class="process_instance",
         holder_kind="remote_heartbeat",

--- a/src/lease_plane/canonicalize.py
+++ b/src/lease_plane/canonicalize.py
@@ -1,0 +1,173 @@
+"""
+Server-side canonicalization helper for surface_id (RFC v0.8 §7.12).
+
+Per-scheme normalization rules — the single point of truth for split-brain
+prevention. Two callers using different paths to the same logical surface
+must produce the same canonical surface_id IFF both go through this helper.
+
+Authority is server-side: the lease plane re-canonicalizes on receipt against
+its own filesystem semantics (RFC §7.12.1, dialectic option (i)).
+
+Three live-verifier findings drove the implementation details below:
+
+  - DRIFT-2 (/var → /private/var): os.path.realpath on macOS does NOT
+    idempotently re-resolve. /var/folders/.../tmpfile and
+    /private/var/folders/.../tmpfile would otherwise produce two distinct
+    canonical strings. Helper double-applies realpath.
+
+  - DRIFT-3 (pathconf REFUTED): os.pathconf_names on macOS Python does NOT
+    contain 'PC_CASE_SENSITIVE'. The RFC's original probe spec was wrong;
+    helper uses a tmpfile probe instead (write 'PROBE', stat 'probe').
+
+  - Canonical scheme list (RFC §7.2.1) — five v0 schemes; helper dispatches
+    per-scheme.
+"""
+
+from __future__ import annotations
+
+import os
+import os.path
+import tempfile
+
+# v0.8 canonical scheme list (RFC §7.2.1). Single source of truth in code.
+CANONICAL_SCHEMES: tuple[str, ...] = ("file", "dialectic", "resident", "capture", "td")
+
+# Compiled scheme-grammar regex matches what migration 026 enforces at the DB layer.
+_SCHEME_GRAMMAR = "^(file://|dialectic:/|resident:/|capture:/|td:/)"
+
+_PATH_MAX = 4096
+
+_case_insensitive_cache: bool | None = None
+
+
+class CanonicalizeError(Exception):
+    """Raised when a surface_id cannot be canonicalized.
+
+    `reason` is one of:
+      - 'symlink_loop' — realpath hit ELOOP
+      - 'path_too_long' — path exceeds PATH_MAX
+      - 'invalid_scheme' — surface_id doesn't match the canonical scheme list
+    """
+
+    def __init__(self, reason: str, message: str = "") -> None:
+        super().__init__(message or reason)
+        self.reason = reason
+
+
+def _detect_case_insensitive(probe_root: str | None = None) -> bool:
+    """Tmpfile probe: write 'PROBE', stat 'probe', return whether they're the same file.
+
+    DRIFT-3 mitigation: do NOT use pathconf(_PC_CASE_SENSITIVE) — REFUTED on macOS Python
+    (PC_CASE_SENSITIVE absent from os.pathconf_names; calling raises ValueError).
+
+    Args:
+        probe_root: Optional directory to probe. None uses tempfile.gettempdir().
+                    Tests can override; production uses the server's local FS.
+    """
+    with tempfile.TemporaryDirectory(prefix="lease_canonicalize_probe_", dir=probe_root) as d:
+        upper = os.path.join(d, "PROBE")
+        lower = os.path.join(d, "probe")
+        with open(upper, "w") as f:
+            f.write("")
+        return os.path.exists(lower)
+
+
+def _is_case_insensitive() -> bool:
+    """Cached result of the tmpfile probe; runs once per process."""
+    global _case_insensitive_cache
+    if _case_insensitive_cache is None:
+        _case_insensitive_cache = _detect_case_insensitive()
+    return _case_insensitive_cache
+
+
+def canonicalize(surface_id: str) -> str:
+    """Return the canonical form of a surface_id per RFC v0.8 §7.12.1.
+
+    Raises:
+        CanonicalizeError: symlink loop, path too long, or invalid scheme.
+        ValueError: NUL byte in input (caller-side reject — matches stdlib).
+    """
+    if "\x00" in surface_id:
+        raise ValueError("NUL byte in surface_id")
+    if len(surface_id) > _PATH_MAX:
+        raise CanonicalizeError("path_too_long", f"surface_id length {len(surface_id)} > PATH_MAX {_PATH_MAX}")
+
+    if surface_id.startswith("file://"):
+        return _canonicalize_file(surface_id[len("file://") :])
+    if surface_id.startswith("dialectic:/"):
+        return _canonicalize_dialectic(surface_id[len("dialectic:/") :])
+    if surface_id.startswith("resident:/"):
+        return _canonicalize_resident(surface_id[len("resident:/") :])
+    if surface_id.startswith("capture:/"):
+        return _canonicalize_capture(surface_id[len("capture:/") :])
+    if surface_id.startswith("td:/"):
+        # Reserved scheme; pass-through with no normalization beyond what the
+        # caller supplied. Field_validator ensures the prefix matched the grammar.
+        return f"td:/{surface_id[len('td:/') :]}"
+    raise CanonicalizeError(
+        "invalid_scheme",
+        f"surface_id does not match canonical scheme list ({CANONICAL_SCHEMES}): {surface_id!r}",
+    )
+
+
+def _canonicalize_file(path: str) -> str:
+    """file:// canonicalization (RFC §7.12.1 + DRIFT-2 fix).
+
+    1. Double-realpath to resolve macOS /var → /private/var idempotently.
+    2. Strip trailing / unless path is exactly /.
+    3. Lowercase if filesystem is case-insensitive.
+    4. Re-prefix with file://.
+    """
+    # strict=True is required to actually catch symlink loops on macOS — without it,
+    # os.path.realpath silently returns the loop path. ENOENT is treated as "nonexistent
+    # path, fall through" per RFC §7.12.2 — the lease plane does not validate file existence.
+    try:
+        resolved = os.path.realpath(path, strict=True)
+    except OSError as e:
+        # ELOOP: 40 on Linux, 62 on macOS; "Too many" guard catches both portably.
+        if e.errno in (40, 62) or "Too many" in str(e):
+            raise CanonicalizeError("symlink_loop", str(e)) from e
+        if e.errno == 2:  # ENOENT — caller passed a nonexistent path; fall through.
+            resolved = os.path.realpath(path)
+        elif e.errno == 36:  # ENAMETOOLONG
+            raise CanonicalizeError("path_too_long", str(e)) from e
+        else:
+            raise CanonicalizeError("invalid_scheme", str(e)) from e
+    # Double-realpath catches macOS /var → /private/var idempotency edge case.
+    resolved = os.path.realpath(resolved)
+
+    # Strip trailing / except for root.
+    if len(resolved) > 1 and resolved.endswith("/"):
+        resolved = resolved.rstrip("/")
+
+    # Lowercase if case-insensitive FS.
+    if _is_case_insensitive():
+        resolved = resolved.lower()
+
+    return f"file://{resolved}"
+
+
+def _canonicalize_dialectic(path: str) -> str:
+    """dialectic:/ — opaque session id; lowercase only."""
+    return f"dialectic:/{path.lower()}"
+
+
+def _canonicalize_resident(path: str) -> str:
+    """resident:/ — opaque resident name; case-sensitive; strip trailing /."""
+    if any(ch in path for ch in (" ", "\t", "\n", "?", "#", "&")):
+        raise CanonicalizeError(
+            "invalid_scheme",
+            f"resident:/ surface_id contains reserved character (?, #, &, whitespace): {path!r}",
+        )
+    return f"resident:/{path.rstrip('/')}"
+
+
+def _canonicalize_capture(path: str) -> str:
+    """capture:/ — comma-separated member list; sort lexically.
+
+    Closes dialectic missing-from-§7.12 finding: capture:/A,B,C and capture:/B,A,C
+    must canonicalize to the same surface_id (same calibration window).
+    """
+    members = [m.strip() for m in path.split(",") if m.strip()]
+    members.sort()
+    return f"capture:/{','.join(members)}"

--- a/src/lease_plane/models.py
+++ b/src/lease_plane/models.py
@@ -58,10 +58,22 @@ class LeaseRecord(BaseModel):
 
 
 class AcquireRequest(LeasePlaneModel):
-    """Request body for POST /v1/lease/acquire."""
+    """Request body for POST /v1/lease/acquire.
+
+    `surface_kind` is no longer a request field per RFC v0.8 §7.2.3 — it is
+    derived server-side from the surface_id scheme prefix via migration 026's
+    generated column.
+
+    Note (PR 2): the §7.12.5 Pydantic field_validator that auto-canonicalizes
+    `surface_id` and rejects non-canonical schemes is DEFERRED to PR 2.5.
+    PR 2.5 also migrates production agents (watcher/vigil/sentinel/chronicler/
+    ship.sh advisory) to canonical schemes (`resident:/...`, `file://...`)
+    so the field_validator does not brick the fleet on activation.
+    Today AcquireRequest accepts any surface_id; the canonicalize helper is
+    available for opt-in caller use via `from src.lease_plane.canonicalize`.
+    """
 
     surface_id: str = Field(min_length=1)
-    surface_kind: str = Field(min_length=1)
     holder_agent_uuid: UUID
     holder_class: HolderClass
     holder_kind: HolderKind

--- a/tests/test_lease_plane_advisory.py
+++ b/tests/test_lease_plane_advisory.py
@@ -188,7 +188,6 @@ def test_caller_exceptions_propagate_and_lease_still_released():
     try:
         with lease_advisory_scope(
             surface_id="test:advisory/raises",
-            surface_kind="test",
             holder_agent_uuid=holder,
             ttl_s=60,
             client=client,

--- a/tests/test_lease_plane_canonicalize.py
+++ b/tests/test_lease_plane_canonicalize.py
@@ -1,0 +1,133 @@
+"""
+PR 2 — surface_id canonicalization helper (RFC v0.8 §7.12).
+
+Tests the per-scheme normalization rule, error semantics, and
+filesystem case-detection probe.
+
+Spec: docs/proposals/surface-lease-plane-v0.md §7.12.0–§7.12.3
+      docs/proposals/surface-lease-plane-phase-a-plan.md PR 2
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+def test_canonicalize_case_detection_uses_tmpfile_probe():
+    """Live-verifier DRIFT-3: pathconf(_PC_CASE_SENSITIVE) is REFUTED on macOS Python.
+    The detection MUST use a tmpfile probe, not pathconf."""
+    from src.lease_plane import canonicalize as canon
+
+    # The detection function should not raise on macOS.
+    result = canon._detect_case_insensitive()
+    assert isinstance(result, bool), (
+        f"_detect_case_insensitive must return bool, got {type(result).__name__}"
+    )
+
+    # Negative-test the wrong API: confirm it doesn't depend on PC_CASE_SENSITIVE
+    # (would raise ValueError if it did, on macOS).
+    if "PC_CASE_SENSITIVE" not in os.pathconf_names:
+        # Patch pathconf to detect any rogue use.
+        with mock.patch.object(os, "pathconf", side_effect=AssertionError("must not use os.pathconf")):
+            # Re-detection must succeed via tmpfile, not pathconf.
+            assert isinstance(canon._detect_case_insensitive(), bool)
+
+
+def test_canonicalize_resolves_var_to_private_var_on_macos():
+    """Live-verifier DRIFT-2: os.path.realpath on macOS must double-resolve so
+    /var/folders/.../tmpfile and /private/var/folders/.../tmpfile produce the same form."""
+    from src.lease_plane import canonicalize as canon
+
+    if not Path("/private/var").exists() or not Path("/var").exists():
+        pytest.skip("not on a macOS-style filesystem with /var → /private/var symlink")
+
+    # Pick a real path that exists under /var/folders to exercise the realpath chain.
+    with tempfile.NamedTemporaryFile(prefix="canon_var_test_", delete=False) as f:
+        tmp_path = f.name
+    try:
+        # tempfile gives a /var/folders/... path; realpath should produce /private/var/folders/...
+        var_form = f"file://{tmp_path}"
+        # Construct the equivalent /private/var/ form manually.
+        if tmp_path.startswith("/var/"):
+            private_form = f"file:///private{tmp_path}"
+        else:
+            # Already under /private/var/ — both forms should canonicalize identically.
+            private_form = var_form
+        canonical_var = canon.canonicalize(var_form)
+        canonical_private = canon.canonicalize(private_form)
+        assert canonical_var == canonical_private, (
+            f"Expected /var/ and /private/var/ forms to produce the same canonical "
+            f"surface_id, got:\n  var_form     -> {canonical_var}\n  private_form -> {canonical_private}"
+        )
+        assert "/private/var/" in canonical_var, (
+            f"Expected canonical form to contain /private/var/, got {canonical_var}"
+        )
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+
+def test_capture_canonicalizes_member_ordering():
+    """capture:/A,B,C and capture:/B,A,C represent the same calibration window;
+    canonicalize sorts members lexically so they share one surface_id."""
+    from src.lease_plane import canonicalize as canon
+
+    a = canon.canonicalize("capture:/window_b,window_a,window_c")
+    b = canon.canonicalize("capture:/window_a,window_b,window_c")
+    c = canon.canonicalize("capture:/window_c,window_a,window_b")
+
+    assert a == b == c, f"capture:/ members must canonicalize to lexical order, got {a!r} {b!r} {c!r}"
+    assert "window_a,window_b,window_c" in a, (
+        f"Expected lexically-sorted members in canonical form, got {a!r}"
+    )
+
+
+def test_canonicalize_error_semantics():
+    """Helper raises CanonicalizeError with named reasons for bounded failure modes."""
+    from src.lease_plane.canonicalize import CanonicalizeError, canonicalize
+
+    # NUL byte: caller-side rejection. Stdlib raises ValueError; helper propagates.
+    with pytest.raises((ValueError, CanonicalizeError)):
+        canonicalize("file:///tmp/nul\x00byte.py")
+
+    # Symlink loop: realpath raises OSError(ELOOP); helper wraps as CanonicalizeError.
+    with tempfile.TemporaryDirectory() as d:
+        loop_a = os.path.join(d, "loop_a")
+        loop_b = os.path.join(d, "loop_b")
+        os.symlink(loop_b, loop_a)
+        os.symlink(loop_a, loop_b)
+        with pytest.raises(CanonicalizeError) as exc_info:
+            canonicalize(f"file://{loop_a}")
+        assert exc_info.value.reason == "symlink_loop", (
+            f"Expected reason='symlink_loop', got {exc_info.value.reason!r}"
+        )
+
+    # Nonexistent path: realpath returns the un-resolved input, helper proceeds without raising.
+    nonexistent = "file:///tmp/this_path_definitely_does_not_exist_xyzzy_abc123"
+    result = canonicalize(nonexistent)
+    assert result.startswith("file://"), (
+        f"Nonexistent path should still produce a canonical form, got {result!r}"
+    )
+
+
+@pytest.mark.skip(
+    reason="Deferred to PR 2.5 — wiring the AcquireRequest field_validator requires "
+    "migrating production agents (watcher/vigil/sentinel/chronicler/ship.sh) to canonical "
+    "schemes first; otherwise the validator bricks the fleet on first acquire. "
+    "See docs/proposals/surface-lease-plane-phase-a-plan.md PR 2.5."
+)
+def test_acquire_request_rejects_query_string_in_surface_id():
+    """RFC v0.8 §7.12.4: ?-bearing surface_id reserved for v1 modifier form;
+    v0 callers must use plain canonical form."""
+
+
+@pytest.mark.skip(
+    reason="Deferred to PR 2.5 — see test_acquire_request_rejects_query_string_in_surface_id."
+)
+def test_acquire_request_surface_id_field_validator_wired():
+    """RFC v0.8 §7.12.5: AcquireRequest auto-canonicalizes surface_id at the model boundary.
+    Two equivalent inputs must produce the same .surface_id."""

--- a/tests/test_lease_plane_client.py
+++ b/tests/test_lease_plane_client.py
@@ -60,7 +60,6 @@ def test_acquire_request_rejects_role_holder_class():
     try:
         AcquireRequest(
             surface_id="file:///tmp/a",
-            surface_kind="file",
             holder_agent_uuid=uuid4(),
             holder_class="role",
             holder_kind="remote_heartbeat",
@@ -98,7 +97,6 @@ def test_acquire_ok_parses_idempotent_drift_warning():
     result = LeasePlaneClient(transport=transport).acquire(
         AcquireRequest(
             surface_id="file:///tmp/a",
-            surface_kind="file",
             holder_agent_uuid=holder,
             holder_class="process_instance",
             holder_kind="remote_heartbeat",
@@ -132,7 +130,6 @@ def test_acquire_held_by_other_parses_holder_and_expiry():
     result = LeasePlaneClient(transport=transport).acquire(
         AcquireRequest(
             surface_id="file:///tmp/a",
-            surface_kind="file",
             holder_agent_uuid=uuid4(),
             holder_class="process_instance",
             holder_kind="remote_heartbeat",
@@ -152,7 +149,6 @@ def test_transport_exception_degrades_to_service_unavailable():
     result = LeasePlaneClient(transport=transport).acquire(
         AcquireRequest(
             surface_id="file:///tmp/a",
-            surface_kind="file",
             holder_agent_uuid=uuid4(),
             holder_class="process_instance",
             holder_kind="remote_heartbeat",
@@ -170,7 +166,6 @@ def test_invalid_response_degrades_to_schema_invalid():
     result = LeasePlaneClient(transport=transport).acquire(
         AcquireRequest(
             surface_id="file:///tmp/a",
-            surface_kind="file",
             holder_agent_uuid=uuid4(),
             holder_class="process_instance",
             holder_kind="remote_heartbeat",

--- a/tests/test_lease_plane_held_by_other_v0_8.py
+++ b/tests/test_lease_plane_held_by_other_v0_8.py
@@ -50,7 +50,6 @@ def test_held_by_other_includes_v0_7_extended_fields():
     result = LeasePlaneClient(transport=transport).acquire(
         AcquireRequest(
             surface_id=surface_id,
-            surface_kind="file",
             holder_agent_uuid=uuid4(),
             holder_class="process_instance",
             holder_kind="remote_heartbeat",


### PR DESCRIPTION
**Stacked on #264** (PR 1). Targets `impl/lease-plane-phase-a` not master; rebase to master after PR 1 merges.

## Summary

Ships the §7.12 canonicalization helper + closes a v0.7 PR 1 oversight (`AcquireRequest` still required `surface_kind` even though Elixir router ignores it). 4 of the 6 §7.12 Phase A test gates land here.

**Surfaced during implementation and split out as PR 2.5:** wiring the Pydantic `field_validator` on `AcquireRequest.surface_id` would brick all production agents. They use non-canonical surface_ids (`sentinel:cycle`, `vigil:cycle`, `watcher:scan_commits:...`, `chronicler:scrape`, `ship.sh:<branch>`) that would fail the validator's scheme check on first acquire. PR 2.5 will land the agent migration and validator together (atomically — validator without migration bricks; migration without validator silently inconsistent).

## RFC gate → code surface → test name → status

| Gate | Code | Test | Status |
|------|------|------|--------|
| §7.12.1 step 4 — tmpfile probe (not `pathconf`) | `src/lease_plane/canonicalize.py::_detect_case_insensitive` | `test_canonicalize_case_detection_uses_tmpfile_probe` | ✅ |
| §7.12.1 step 2 — double-realpath for `/var → /private/var` | `canonicalize.py::_canonicalize_file` | `test_canonicalize_resolves_var_to_private_var_on_macos` | ✅ |
| §7.12.1 `capture:/` member sorting | `canonicalize.py::_canonicalize_capture` | `test_capture_canonicalizes_member_ordering` | ✅ |
| §7.12.2 helper error semantics (symlink loop, NUL, nonexistent) | `canonicalize.py::canonicalize` | `test_canonicalize_error_semantics` | ✅ |
| §7.12.5 `AcquireRequest` field_validator wired | (deferred to PR 2.5) | `test_acquire_request_surface_id_field_validator_wired` | ⏸ SKIPPED |
| §7.12.4 Pydantic `?`-rejection | (deferred to PR 2.5) | `test_acquire_request_rejects_query_string_in_surface_id` | ⏸ SKIPPED |
| §7.2.3 `AcquireRequest` drops `surface_kind` (PR 1 oversight) | `models.py`, `advisory.py`, `_ship_lease_advisory.py` | (39-test lease-plane regression) | ✅ |

## canonicalize.py — key implementation notes

- **`_detect_case_insensitive`**: tmpfile probe (write `PROBE`, stat `probe`, return result). Closes live-verifier DRIFT-3 — `os.pathconf_names` on macOS Python does NOT contain `PC_CASE_SENSITIVE`; calling `pathconf(_PC_CASE_SENSITIVE)` raises `ValueError`. The RFC's original probe spec was wrong.
- **`_canonicalize_file`**: `os.path.realpath(path, strict=True)` — without `strict=True`, macOS silently returns the loop path on symlink cycles. On `OSError(ELOOP)` (errno 40 Linux, 62 macOS), raises `CanonicalizeError(reason='symlink_loop')`. On `ENOENT` (nonexistent path), falls through to non-strict realpath per §7.12.2 (lease plane does not validate file existence). Then **double-applies realpath** to catch macOS `/var → /private/var` idempotency edge case (closes live-verifier DRIFT-2 with live evidence on `/var/folders/.../tmpfile` paths used by Watcher, ship.sh, capture).
- **`_canonicalize_capture`**: sorts members lexically — closes dialectic missing-from-§7.12 finding. `capture:/A,B,C` and `capture:/B,A,C` represent the same calibration window and must produce the same `surface_id`.
- **`_canonicalize_resident`**: rejects whitespace + `?`, `#`, `&` per §7.12.1 per-scheme rules.
- **`_canonicalize_dialectic`**: lowercases (UUID hex convention).

## AcquireRequest `surface_kind` removal

PR 1 updated the Elixir router/repo to drop `surface_kind` per RFC §7.2.3 + migration 026's generated column. The Pydantic `AcquireRequest` schema was missed — this PR closes that gap.

- `LeasePlaneModel` uses `extra='forbid'`, so callers can no longer supply `surface_kind` to `AcquireRequest()`.
- `lease_advisory_scope()` softens its `surface_kind` parameter to `Optional[str] = None` and silently ignores it. Production agents (watcher/vigil/sentinel/chronicler) keep working unchanged. PR 2.5 will fully drop the parameter.
- 4 test files updated to drop `surface_kind=...` kwarg per "change signature → update tests in same commit".

## Test plan
- [ ] `pytest tests/test_lease_plane_canonicalize.py -q --no-cov` (4 pass + 2 skipped)
- [ ] `pytest tests/test_lease_plane_*.py tests/test_chronicler_lease_advisory.py tests/test_ship_lease_advisory.py -q --no-cov` (39 pass + 2 skipped)
- [ ] Full suite: 7467 passed, 35 skipped (excluding pre-existing `tests/resident_progress/` master failure unrelated to this PR)
- [ ] Reviewer confirms PR 2.5 scope is well-defined before this PR merges (agent migration + validator must land atomically)