### PR TITLE
feat(lease-plane): Phase A PR 2.5 — production surface_id migration + AcquireRequest field_validator

### DIFF
--- a/agents/chronicler/agent.py
+++ b/agents/chronicler/agent.py
@@ -172,9 +172,9 @@ class ChroniclerAgent(GovernanceAgent):
         """
         from src.lease_plane.advisory import lease_advisory_scope, new_holder_uuid
 
+        # Migrated from "chronicler:scrape" → "resident:/chronicler_scrape" per RFC v0.8 §7.2.1.
         with lease_advisory_scope(
-            surface_id="chronicler:scrape",
-            surface_kind="chronicler_scrape",
+            surface_id="resident:/chronicler_scrape",
             holder_agent_uuid=new_holder_uuid(),
             ttl_s=120,
             intent="chronicler daily scrape",

--- a/agents/sentinel/agent.py
+++ b/agents/sentinel/agent.py
@@ -497,9 +497,9 @@ class SentinelAgent(GovernanceAgent):
         """
         from src.lease_plane.advisory import lease_advisory_scope, new_holder_uuid
 
+        # Migrated from "sentinel:cycle" → "resident:/sentinel_cycle" per RFC v0.8 §7.2.1.
         with lease_advisory_scope(
-            surface_id="sentinel:cycle",
-            surface_kind="sentinel_cycle",
+            surface_id="resident:/sentinel_cycle",
             holder_agent_uuid=new_holder_uuid(),
             ttl_s=300,
             intent="sentinel analysis cycle",

--- a/agents/sentinel/tests/test_lease_advisory.py
+++ b/agents/sentinel/tests/test_lease_advisory.py
@@ -70,8 +70,10 @@ async def test_run_cycle_invokes_lease_advisory_with_expected_surface(
     with pytest.raises(_CycleStopMarker):
         await agent.run_cycle()
 
-    assert captured["surface_id"] == "sentinel:cycle"
-    assert captured["surface_kind"] == "sentinel_cycle"
+    assert captured["surface_id"] == "resident:/sentinel_cycle"
+    # surface_kind no longer passed (PR 2.5 — derived server-side from scheme prefix
+    # via migration 026's generated column).
+    assert "surface_kind" not in captured
     assert captured["ttl_s"] == 300
     assert captured.get("intent") == "sentinel analysis cycle"
 

--- a/agents/vigil/agent.py
+++ b/agents/vigil/agent.py
@@ -615,9 +615,9 @@ class VigilAgent(GovernanceAgent):
         """
         from src.lease_plane.advisory import lease_advisory_scope, new_holder_uuid
 
+        # Migrated from "vigil:cycle" → "resident:/vigil_cycle" per RFC v0.8 §7.2.1.
         with lease_advisory_scope(
-            surface_id="vigil:cycle",
-            surface_kind="vigil_cycle",
+            surface_id="resident:/vigil_cycle",
             holder_agent_uuid=new_holder_uuid(),
             ttl_s=300,
             intent="vigil heartbeat cycle",

--- a/agents/vigil/tests/test_lease_advisory.py
+++ b/agents/vigil/tests/test_lease_advisory.py
@@ -78,8 +78,10 @@ async def test_run_cycle_invokes_lease_advisory_with_expected_surface(
     with pytest.raises(_CycleStopMarker):
         await agent.run_cycle(client)
 
-    assert captured["surface_id"] == "vigil:cycle"
-    assert captured["surface_kind"] == "vigil_cycle"
+    assert captured["surface_id"] == "resident:/vigil_cycle"
+    # surface_kind no longer passed (PR 2.5 — derived server-side from scheme prefix
+    # via migration 026's generated column).
+    assert "surface_kind" not in captured
     assert captured["ttl_s"] == 300
     assert captured.get("intent") == "vigil heartbeat cycle"
 

--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -914,9 +914,11 @@ def scan_commits(since: str = "30 days ago", repo_path: Path | None = None) -> i
       - Ambiguous prefixes that match more than one fingerprint.
 
     Phase A lease-plane integration: each scan acquires an advisory-mode
-    lease at `surface_id=watcher:scan_commits:<repo_root>`. The lease is
-    *telemetry only* — Watcher proceeds whether the lease is acquired,
-    held by another scanner, or unavailable. RFC v0.5 §6.1.
+    lease at `surface_id=resident:/watcher_scan_commits_<repo_root_sanitized>`
+    (migrated from pre-canonical `watcher:scan_commits:<repo_root>` per RFC
+    v0.8 §7.2.1 canonical scheme list). The lease is *telemetry only* —
+    Watcher proceeds whether the lease is acquired, held by another
+    scanner, or unavailable. RFC v0.5 §6.1.
 
     Returns:
         The number of findings resolved this scan. Always returns 0 on git
@@ -926,10 +928,11 @@ def scan_commits(since: str = "30 days ago", repo_path: Path | None = None) -> i
 
     from src.lease_plane.advisory import lease_advisory_scope, new_holder_uuid
 
-    surface_id = f"watcher:scan_commits:{repo_root}"
+    # Sanitize repo path into a resident:/ surface_id (slashes → underscores).
+    sanitized = str(repo_root).replace("/", "_").strip("_")
+    surface_id = f"resident:/watcher_scan_commits_{sanitized}"
     with lease_advisory_scope(
         surface_id=surface_id,
-        surface_kind="watcher_scan_commits",
         holder_agent_uuid=new_holder_uuid(),
         ttl_s=60,
         intent=f"scan_commits since={since!r}",

--- a/agents/watcher/tests/test_scan_commits.py
+++ b/agents/watcher/tests/test_scan_commits.py
@@ -293,8 +293,10 @@ class TestScanCommitsLeaseAdvisory:
 
         assert result == 1, "Phase A advisory: body must run regardless of lease outcome"
 
-        assert captured["surface_kind"] == "watcher_scan_commits"
-        assert captured["surface_id"].startswith("watcher:scan_commits:")
+        # surface_kind no longer passed (PR 2.5 — derived server-side from scheme prefix
+        # via migration 026's generated column).
+        assert "surface_kind" not in captured
+        assert captured["surface_id"].startswith("resident:/watcher_scan_commits_")
         assert captured["ttl_s"] == 60
         assert "since=" in captured["intent"]
 

--- a/docs/proposals/surface-lease-plane-phase-a-plan.md
+++ b/docs/proposals/surface-lease-plane-phase-a-plan.md
@@ -115,22 +115,28 @@ Deferred to **PR 2.5** (see new section below):
 | §7.12.4 Pydantic ?-rejection | (deferred to PR 2.5) | `test_acquire_request_rejects_query_string_in_surface_id` | SKIPPED |
 | §7.2.3 Pydantic AcquireRequest drops `surface_kind` (closes PR 1 oversight) | `src/lease_plane/models.py`, `src/lease_plane/advisory.py`, `scripts/dev/_ship_lease_advisory.py` | (covered by 39-test lease-plane regression) | DONE |
 
-## PR 2.5 — Production-agent surface_id migration + AcquireRequest field_validator (planned, not yet drafted)
+## PR 2.5 — Production-agent surface_id migration + AcquireRequest field_validator (this branch: impl/lease-plane-phase-a-pr2-5-validator)
 
-**Surfaced during PR 2 implementation:** the production agents (watcher, vigil, sentinel, chronicler, ship.sh advisory) use surface_ids like `watcher:scan_commits:<repo>`, `vigil:cycle`, `sentinel:cycle`, `chronicler:scrape`, `ship.sh:test-branch` — none of which match the canonical scheme list (RFC §7.2.1). Wiring the AcquireRequest field_validator now would cause every agent to crash on first acquire with `ValidationError: scheme not in canonical scheme list`.
+**Surfaced during PR 2 implementation:** the production agents (watcher, vigil, sentinel, chronicler, ship.sh advisory) used surface_ids like `watcher:scan_commits:<repo>`, `vigil:cycle`, `sentinel:cycle`, `chronicler:scrape`, `ship.sh:test-branch` — none of which match the canonical scheme list (RFC §7.2.1). Wiring the AcquireRequest field_validator without first migrating these would cause every agent to crash on first acquire with `ValidationError: scheme not in canonical scheme list`. PR 2.5 lands migration + validator atomically.
 
-Scope:
-- Migrate production surface_ids to canonical schemes:
-  - `watcher:scan_commits:X` → `resident:/watcher_scan_commits_X`
-  - `vigil:cycle` → `resident:/vigil_cycle`
-  - `sentinel:cycle` → `resident:/sentinel_cycle`
-  - `chronicler:scrape` → `resident:/chronicler_scrape`
-  - `ship.sh:<branch>` → `resident:/ship_sh_<branch>` (operator-driven, not file-bound)
-- After migration, wire the AcquireRequest `field_validator` on `surface_id` per §7.12.5 — auto-canonicalize at the model boundary; reject NUL bytes, `?`-bearing strings, and non-canonical schemes.
-- Un-skip the 2 deferred test gates: `test_acquire_request_rejects_query_string_in_surface_id` and `test_acquire_request_surface_id_field_validator_wired`.
-- Update `lease_advisory_scope()` to drop `surface_kind` parameter entirely (currently kept as optional+ignored).
+### PR 2.5 — RFC gate → code surface → test name → status table
 
-Rationale for splitting from PR 2: the canonicalize.py helper is reviewable independently; coupling it to a fleet-wide surface_id migration risks both reviews stalling on the wider impact. PR 2 ships the helper; PR 2.5 ships the migration + validator together (they MUST land atomically — validator without migration = bricked fleet; migration without validator = silently inconsistent).
+| Gate | Code | Test | Status |
+|------|------|------|--------|
+| §7.12.5 AcquireRequest field_validator wired | `src/lease_plane/models.py::_validate_surface_id` | `test_acquire_request_surface_id_field_validator_wired` | DONE |
+| §7.12.4 Pydantic `?`-rejection | same field_validator | `test_acquire_request_rejects_query_string_in_surface_id` | DONE |
+| §7.2.1 production agents on canonical schemes | `agents/{watcher,vigil,sentinel,chronicler}/agent.py` + `scripts/dev/ship.sh` | `agents/{watcher,vigil,sentinel}/tests/test_lease_advisory.py`, `tests/test_chronicler_lease_advisory.py` (assertions updated to canonical surface_id + `surface_kind not in captured`) | DONE |
+| §7.2.3 `lease_advisory_scope()` drops `surface_kind` parameter | `src/lease_plane/advisory.py` | (lease-plane regression suite + 22 agent advisory tests) | DONE |
+| Test fixtures use canonical schemes | `tests/test_lease_plane_advisory.py`, `tests/test_ship_lease_advisory.py`, `tests/test_chronicler_lease_advisory.py` | (existing tests, surface_id values updated) | DONE |
+
+Per-agent migration mapping (committed):
+- `watcher:scan_commits:<repo>` → `resident:/watcher_scan_commits_<sanitized>` (slashes → underscores)
+- `vigil:cycle` → `resident:/vigil_cycle`
+- `sentinel:cycle` → `resident:/sentinel_cycle`
+- `chronicler:scrape` → `resident:/chronicler_scrape`
+- `ship.sh:<branch>` → `resident:/ship_sh_<branch>` (slashes preserved; branch names with `/` like `feat/foo` produce `resident:/ship_sh_feat/foo`)
+
+Rationale for splitting from PR 2: the canonicalize.py helper is reviewable independently; coupling it to a fleet-wide surface_id migration risked both reviews stalling on the wider impact. PR 2 shipped the helper; PR 2.5 ships the migration + validator together — atomic landing is the safety contract (validator without migration = bricked fleet; migration without validator = silently inconsistent).
 
 ## PR 3 — §7.11 deprecation CLI + Sentinel forced-release alarm (planned, not yet drafted)
 

--- a/scripts/dev/ship.sh
+++ b/scripts/dev/ship.sh
@@ -79,7 +79,7 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)
 # outcome and proceed regardless, and release on EXIT so the lease is
 # returned even if a downstream step (commit, push, PR create) fails.
 LEASE_RESULT=$(python3 "$PROJECT_ROOT/scripts/dev/_ship_lease_advisory.py" acquire \
-    --surface-id="ship.sh:$BRANCH" \
+    --surface-id="resident:/ship_sh_$BRANCH" \
     --surface-kind="ship_sh" \
     --intent="$MESSAGE" \
     --ttl-s=300 2>/dev/null || echo '{"outcome":"client_error","lease_id":null}')

--- a/src/lease_plane/advisory.py
+++ b/src/lease_plane/advisory.py
@@ -100,7 +100,6 @@ def new_holder_uuid() -> uuid.UUID:
 def lease_advisory_scope(
     *,
     surface_id: str,
-    surface_kind: str | None = None,
     holder_agent_uuid: uuid.UUID,
     ttl_s: int,
     intent: str | None = None,
@@ -118,13 +117,10 @@ def lease_advisory_scope(
     the caller's block will propagate normally; the wrapper only ensures
     the lease is released if it was acquired.
 
-    `surface_kind` is accepted for backwards-compat with pre-PR-2 callers
-    (watcher/vigil/sentinel/chronicler agents) but is no longer passed to
-    AcquireRequest — per RFC v0.8 §7.2.3 the server derives surface_kind
-    from the surface_id scheme prefix via migration 026's generated column.
-    The parameter is silently ignored; callers SHOULD remove it.
+    `surface_kind` was a parameter pre-PR-2.5 but has been fully removed —
+    per RFC v0.8 §7.2.3, surface_kind is derived server-side from the
+    surface_id scheme prefix via migration 026's generated column.
     """
-    del surface_kind  # ignored; see docstring
     advisory_client = client or make_advisory_client()
 
     request = AcquireRequest(

--- a/src/lease_plane/models.py
+++ b/src/lease_plane/models.py
@@ -6,7 +6,9 @@ from datetime import datetime
 from typing import Any, Literal, TypeAlias
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from src.lease_plane.canonicalize import CANONICAL_SCHEMES, canonicalize
 
 HolderClass: TypeAlias = Literal["process_instance", "substrate_earned"]
 HolderKind: TypeAlias = Literal["local_beam", "remote_heartbeat"]
@@ -64,13 +66,10 @@ class AcquireRequest(LeasePlaneModel):
     derived server-side from the surface_id scheme prefix via migration 026's
     generated column.
 
-    Note (PR 2): the §7.12.5 Pydantic field_validator that auto-canonicalizes
-    `surface_id` and rejects non-canonical schemes is DEFERRED to PR 2.5.
-    PR 2.5 also migrates production agents (watcher/vigil/sentinel/chronicler/
-    ship.sh advisory) to canonical schemes (`resident:/...`, `file://...`)
-    so the field_validator does not brick the fleet on activation.
-    Today AcquireRequest accepts any surface_id; the canonicalize helper is
-    available for opt-in caller use via `from src.lease_plane.canonicalize`.
+    `surface_id` auto-canonicalizes via field_validator per RFC v0.8 §7.12.5:
+    rejects NUL bytes, ?-bearing strings (reserved for v1 modifier form per
+    §7.12.4), non-canonical schemes (per §7.2.1 list); auto-canonicalizes
+    via `src.lease_plane.canonicalize`.
     """
 
     surface_id: str = Field(min_length=1)
@@ -81,6 +80,27 @@ class AcquireRequest(LeasePlaneModel):
     holder_pid: str | None = None
     intent: str | None = None
     audit_session: str | None = None
+
+    @field_validator("surface_id", mode="before")
+    @classmethod
+    def _validate_surface_id(cls, v: str) -> str:
+        """Reject invalid scheme, NUL bytes, ?-bearing values; auto-canonicalize."""
+        if not isinstance(v, str):
+            raise ValueError("surface_id must be a string")
+        if "\x00" in v:
+            raise ValueError("NUL byte in surface_id")
+        if "?" in v:
+            raise ValueError(
+                "query string in surface_id reserved for v1 modifier form (RFC §7.12.4); "
+                "use plain canonical form for v0"
+            )
+        scheme = v.split(":", 1)[0]
+        if scheme not in CANONICAL_SCHEMES:
+            raise ValueError(
+                f"surface_id scheme {scheme!r} not in canonical scheme list {CANONICAL_SCHEMES} "
+                f"(RFC §7.2.1)"
+            )
+        return canonicalize(v)
 
 
 class RenewRequest(LeasePlaneModel):

--- a/tests/test_chronicler_lease_advisory.py
+++ b/tests/test_chronicler_lease_advisory.py
@@ -48,8 +48,10 @@ async def test_run_cycle_invokes_lease_advisory_with_expected_surface(
     with pytest.raises(_CycleStopMarker):
         await agent.run_cycle(client=None)
 
-    assert captured["surface_id"] == "chronicler:scrape"
-    assert captured["surface_kind"] == "chronicler_scrape"
+    assert captured["surface_id"] == "resident:/chronicler_scrape"
+    # surface_kind no longer passed (PR 2.5 — derived server-side from scheme prefix
+    # via migration 026's generated column); should not appear in kwargs.
+    assert "surface_kind" not in captured
     assert captured["ttl_s"] == 120
     assert captured.get("intent") == "chronicler daily scrape"
 

--- a/tests/test_lease_plane_advisory.py
+++ b/tests/test_lease_plane_advisory.py
@@ -21,7 +21,7 @@ def _ok_lease_payload(holder_uuid: UUID) -> dict[str, Any]:
     now = datetime.now(UTC).replace(microsecond=0)
     return {
         "lease_id": str(uuid4()),
-        "surface_id": "test:advisory/x",
+        "surface_id": "dialectic:/test_advisory_x",
         "surface_kind": "test",
         "holder_agent_uuid": str(holder_uuid),
         "holder_class": "process_instance",
@@ -63,8 +63,7 @@ def test_acquired_new_runs_block_and_releases():
     block_ran = False
     seen_outcome = None
     with lease_advisory_scope(
-        surface_id="test:advisory/x",
-        surface_kind="test",
+        surface_id="dialectic:/test_advisory_x",
         holder_agent_uuid=holder,
         ttl_s=60,
         intent="unit-test",
@@ -93,8 +92,7 @@ def test_idempotent_outcome_classified_correctly():
     client = LeasePlaneClient(transport=transport)
 
     with lease_advisory_scope(
-        surface_id="test:advisory/x",
-        surface_kind="test",
+        surface_id="dialectic:/test_advisory_x",
         holder_agent_uuid=holder,
         ttl_s=60,
         client=client,
@@ -110,7 +108,7 @@ def test_held_by_other_runs_block_no_release():
             {
                 "ok": False,
                 "error": "held_by_other",
-                "surface_id": "test:advisory/contended",
+                "surface_id": "dialectic:/test_advisory_contended",
                 "blocking_lease_id": str(uuid4()),
                 "held_by_uuid": str(other_holder),
                 "expires_at": (datetime.now(UTC) + timedelta(seconds=30)).isoformat(),
@@ -122,8 +120,7 @@ def test_held_by_other_runs_block_no_release():
 
     block_ran = False
     with lease_advisory_scope(
-        surface_id="test:advisory/contended",
-        surface_kind="test",
+        surface_id="dialectic:/test_advisory_contended",
         holder_agent_uuid=uuid4(),
         ttl_s=60,
         client=client,
@@ -144,8 +141,7 @@ def test_service_unavailable_runs_block_no_release():
 
     block_ran = False
     with lease_advisory_scope(
-        surface_id="test:advisory/down",
-        surface_kind="test",
+        surface_id="dialectic:/test_advisory_down",
         holder_agent_uuid=uuid4(),
         ttl_s=60,
         client=client,
@@ -160,8 +156,7 @@ def test_service_unavailable_runs_block_no_release():
 def test_disabled_client_outcome_is_service_unavailable():
     block_ran = False
     with lease_advisory_scope(
-        surface_id="test:advisory/disabled",
-        surface_kind="test",
+        surface_id="dialectic:/test_advisory_disabled",
         holder_agent_uuid=uuid4(),
         ttl_s=60,
         client=LeasePlaneDisabledClient(),
@@ -187,7 +182,7 @@ def test_caller_exceptions_propagate_and_lease_still_released():
 
     try:
         with lease_advisory_scope(
-            surface_id="test:advisory/raises",
+            surface_id="dialectic:/test_advisory_raises",
             holder_agent_uuid=holder,
             ttl_s=60,
             client=client,
@@ -234,8 +229,7 @@ def test_acquire_raise_classified_as_client_error():
     block_ran = False
     seen_outcome: str | None = None
     with lease_advisory_scope(
-        surface_id="test:advisory/timeout",
-        surface_kind="test",
+        surface_id="dialectic:/test_advisory_timeout",
         holder_agent_uuid=uuid4(),
         ttl_s=60,
         client=client,

--- a/tests/test_lease_plane_canonicalize.py
+++ b/tests/test_lease_plane_canonicalize.py
@@ -114,20 +114,52 @@ def test_canonicalize_error_semantics():
     )
 
 
-@pytest.mark.skip(
-    reason="Deferred to PR 2.5 — wiring the AcquireRequest field_validator requires "
-    "migrating production agents (watcher/vigil/sentinel/chronicler/ship.sh) to canonical "
-    "schemes first; otherwise the validator bricks the fleet on first acquire. "
-    "See docs/proposals/surface-lease-plane-phase-a-plan.md PR 2.5."
-)
 def test_acquire_request_rejects_query_string_in_surface_id():
     """RFC v0.8 §7.12.4: ?-bearing surface_id reserved for v1 modifier form;
     v0 callers must use plain canonical form."""
+    from pydantic import ValidationError
+
+    from src.lease_plane import AcquireRequest
+    from uuid import uuid4
+
+    with pytest.raises(ValidationError) as exc_info:
+        AcquireRequest(
+            surface_id="file:///tmp/x.py?canon=inode",
+            holder_agent_uuid=uuid4(),
+            holder_class="process_instance",
+            holder_kind="remote_heartbeat",
+            ttl_s=60,
+        )
+    assert "?" in str(exc_info.value) or "query" in str(exc_info.value).lower(), (
+        f"Expected error message to mention query string, got: {exc_info.value}"
+    )
 
 
-@pytest.mark.skip(
-    reason="Deferred to PR 2.5 — see test_acquire_request_rejects_query_string_in_surface_id."
-)
 def test_acquire_request_surface_id_field_validator_wired():
     """RFC v0.8 §7.12.5: AcquireRequest auto-canonicalizes surface_id at the model boundary.
     Two equivalent inputs must produce the same .surface_id."""
+    from src.lease_plane import AcquireRequest
+    from uuid import uuid4
+
+    holder = uuid4()
+
+    def make(sid: str) -> AcquireRequest:
+        return AcquireRequest(
+            surface_id=sid,
+            holder_agent_uuid=holder,
+            holder_class="process_instance",
+            holder_kind="remote_heartbeat",
+            ttl_s=60,
+        )
+
+    a = make("capture:/win_b,win_a")
+    b = make("capture:/win_a,win_b")
+    assert a.surface_id == b.surface_id, (
+        f"AcquireRequest must auto-canonicalize via field_validator; "
+        f"got {a.surface_id!r} != {b.surface_id!r}"
+    )
+
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        make("not_a_real_scheme:foo")

--- a/tests/test_ship_lease_advisory.py
+++ b/tests/test_ship_lease_advisory.py
@@ -20,7 +20,7 @@ def _ok_lease_payload(holder_uuid: UUID) -> dict[str, Any]:
     now = datetime.now(UTC).replace(microsecond=0)
     return {
         "lease_id": str(uuid4()),
-        "surface_id": "ship.sh:test-branch",
+        "surface_id": "resident:/ship_sh_test-branch",
         "surface_kind": "ship_sh",
         "holder_agent_uuid": str(holder_uuid),
         "holder_class": "process_instance",
@@ -59,7 +59,7 @@ def test_acquire_emits_lease_id_on_acquired_new(capsys, monkeypatch):
     rc = shla.main(
         [
             "acquire",
-            "--surface-id=ship.sh:test-branch",
+            "--surface-id=resident:/ship_sh_test-branch",
             "--surface-kind=ship_sh",
             "--intent=test ship",
             "--ttl-s=300",
@@ -79,7 +79,7 @@ def test_acquire_emits_null_lease_on_held_by_other(capsys, monkeypatch):
             {
                 "ok": False,
                 "error": "held_by_other",
-                "surface_id": "ship.sh:contended",
+                "surface_id": "resident:/ship_sh_contended",
                 "blocking_lease_id": str(uuid4()),
                 "held_by_uuid": str(other),
                 "expires_at": (datetime.now(UTC) + timedelta(seconds=60)).isoformat(),
@@ -93,7 +93,7 @@ def test_acquire_emits_null_lease_on_held_by_other(capsys, monkeypatch):
     rc = shla.main(
         [
             "acquire",
-            "--surface-id=ship.sh:contended",
+            "--surface-id=resident:/ship_sh_contended",
             "--surface-kind=ship_sh",
         ]
     )
@@ -112,7 +112,7 @@ def test_acquire_emits_service_unavailable_on_disabled(capsys, monkeypatch):
     rc = shla.main(
         [
             "acquire",
-            "--surface-id=ship.sh:disabled",
+            "--surface-id=resident:/ship_sh_disabled",
             "--surface-kind=ship_sh",
         ]
     )


### PR DESCRIPTION
**Stacked on #266** (PR 2). Targets `impl/lease-plane-phase-a-pr2-canonicalize` not master; rebase to master after PR 1 + PR 2 merge.

## Summary

Lands the AcquireRequest.surface_id field_validator AND the production-agent surface_id migration **atomically** — required because validator without migration bricks the fleet, migration without validator leaves silent inconsistency.

Closes the 2 §7.12 Phase A test gates that PR 2 deferred (now un-skipped + green).

## Per-agent migration mapping

| Old surface_id | New surface_id |
|----------------|----------------|
| `watcher:scan_commits:<repo>` | `resident:/watcher_scan_commits_<sanitized>` (slashes → underscores) |
| `vigil:cycle` | `resident:/vigil_cycle` |
| `sentinel:cycle` | `resident:/sentinel_cycle` |
| `chronicler:scrape` | `resident:/chronicler_scrape` |
| `ship.sh:<branch>` | `resident:/ship_sh_<branch>` |

## RFC gate → code surface → test name → status

| Gate | Code | Test | Status |
|------|------|------|--------|
| §7.12.5 AcquireRequest field_validator wired | `src/lease_plane/models.py::_validate_surface_id` | `test_acquire_request_surface_id_field_validator_wired` | ✅ |
| §7.12.4 Pydantic `?`-rejection | same field_validator | `test_acquire_request_rejects_query_string_in_surface_id` | ✅ |
| §7.2.1 production agents on canonical schemes | `agents/{watcher,vigil,sentinel,chronicler}/agent.py` + `scripts/dev/ship.sh` | `agents/{watcher,vigil,sentinel}/tests/test_lease_advisory.py`, `tests/test_chronicler_lease_advisory.py` (assertions updated) | ✅ |
| §7.2.3 `lease_advisory_scope()` drops `surface_kind` parameter | `src/lease_plane/advisory.py` | (lease-plane regression suite + 22 agent advisory tests) | ✅ |
| Test fixtures use canonical schemes | `tests/test_lease_plane_advisory.py`, `tests/test_ship_lease_advisory.py`, `tests/test_chronicler_lease_advisory.py` | (existing tests, surface_id values updated) | ✅ |

## Implementation notes

**`AcquireRequest.surface_id` field_validator** (`models.py`):
- `mode='before'` — runs before Pydantic type coercion.
- Rejects: non-str inputs, NUL bytes, `?`-bearing strings (RFC §7.12.4 v1 modifier-form reservation), schemes outside `CANONICAL_SCHEMES` (RFC §7.2.1).
- Auto-canonicalizes via `canonicalize()` helper from PR 2.

**`lease_advisory_scope()`** (`advisory.py`):
- `surface_kind` parameter fully removed (was optional+ignored in PR 2; now gone).
- Docstring documents the removal and references RFC §7.2.3.

**Agent test assertions** updated to verify `surface_kind` no longer appears in captured kwargs (telemetry-drift sentinel — future refactors that re-add `surface_kind=` get a noisy test failure).

## Test verification

- **6/6 §7.12 Phase A test gates GREEN** (was 4/6 in PR 2; 2 un-skipped here).
- **41/41 lease-plane regression GREEN**.
- **22/22 agent advisory tests GREEN** (chronicler test, sentinel test, vigil test, watcher test_scan_commits).
- **7963/7963 full suite GREEN** (excluding `tests/resident_progress/` pre-existing master failure unrelated to this PR).

## Test plan
- [ ] `pytest tests/test_lease_plane_canonicalize.py -q --no-cov` — 6/6 pass (no skips)
- [ ] `pytest tests/test_lease_plane_*.py tests/test_chronicler_lease_advisory.py tests/test_ship_lease_advisory.py agents/watcher/tests/ agents/vigil/tests/ agents/sentinel/tests/ -q --no-cov` (41 + 22 = 63 pass)
- [ ] Reviewer applies migrations 026 + 027 (from PR 1) to live `governance` DB before any agent runs against this branch — otherwise the field_validator's grammar match works at the model layer but the storage layer is still pre-026.
- [ ] **Operator confirms ALL three PRs (1, 2, 2.5) merge as a stack — partial merge bricks the fleet.** Specifically, merging PR 2.5 without PR 2 means `canonicalize.py` doesn't exist; merging PR 2 without PR 1 means migration 026 isn't deployed.
- [ ] Reviewer confirms PR 3 (deprecation CLI + Sentinel forced-release alarm) scope is still tractable after this PR lands.

## Out of scope (deferred per Phase A plan)
- §7.11 deprecation CLI + 6 test gates + §7.10 force-release test + Sentinel forced-release alarm rule → PR 3
- §7.3.3 `acquire_with_retry` jittered backoff → PR 4+
- `_urllib_transport` HTTP-error body-parse coverage → PR 4+
- Phase B prerequisites (payload-shape standardization, `unitares_doctor` extension) → PR 4+