### PR TITLE
feat(lease-plane): Phase A PR 3a — deprecation CLI + migration 028 trigger fix

### DIFF
--- a/db/postgres/migrations/028_lease_plane_trigger_fix.sql
+++ b/db/postgres/migrations/028_lease_plane_trigger_fix.sql
@@ -1,0 +1,51 @@
+-- 028_lease_plane_trigger_fix.sql
+--
+-- Fixes a PR 1 oversight surfaced during PR 3a TDD:
+-- migration 025's enforce_immutable_lease_fields() trigger guards
+-- NEW.surface_kind IS DISTINCT FROM OLD.surface_kind, but after migration 026
+-- converted surface_kind to a STORED generated column, BEFORE UPDATE triggers
+-- see NULL for the generated column (it's computed AFTER the trigger fires).
+--
+-- Result: ANY UPDATE on surface_leases (including the §7.11 deprecation sweep)
+-- raises 'surface_kind is immutable per lease_id' even though surface_kind
+-- isn't actually changing.
+--
+-- Fix: drop the surface_kind check from the trigger. surface_id is already
+-- guarded for immutability; since surface_kind is now derived from
+-- split_part(surface_id, ':', 1), guarding surface_id transitively guards
+-- surface_kind.
+--
+-- The check on holder_kind, holder_class, original_ttl_s, holder_agent_uuid,
+-- and acquired_at remains.
+
+CREATE OR REPLACE FUNCTION lease_plane.enforce_immutable_lease_fields()
+RETURNS trigger AS $$
+BEGIN
+    IF NEW.surface_id IS DISTINCT FROM OLD.surface_id THEN
+        RAISE EXCEPTION 'surface_id is immutable per lease_id; lease identity is bound to (surface_id, holder)';
+    END IF;
+    -- surface_kind check removed (PR 3a / migration 028): post-026 it is a
+    -- generated column derived from surface_id; the surface_id guard above
+    -- transitively enforces surface_kind immutability.
+    IF NEW.holder_agent_uuid IS DISTINCT FROM OLD.holder_agent_uuid THEN
+        RAISE EXCEPTION 'holder_agent_uuid is immutable per lease_id';
+    END IF;
+    IF NEW.holder_kind IS DISTINCT FROM OLD.holder_kind THEN
+        RAISE EXCEPTION 'holder_kind is immutable per lease_id; release+reacquire to change';
+    END IF;
+    IF NEW.holder_class IS DISTINCT FROM OLD.holder_class THEN
+        RAISE EXCEPTION 'holder_class is immutable per lease_id';
+    END IF;
+    IF NEW.original_ttl_s IS DISTINCT FROM OLD.original_ttl_s THEN
+        RAISE EXCEPTION 'original_ttl_s is immutable per lease_id; renew uses this fixed value';
+    END IF;
+    IF NEW.acquired_at IS DISTINCT FROM OLD.acquired_at THEN
+        RAISE EXCEPTION 'acquired_at is immutable per lease_id';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (28, 'lease_plane_trigger_fix', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/docs/proposals/surface-lease-plane-phase-a-plan.md
+++ b/docs/proposals/surface-lease-plane-phase-a-plan.md
@@ -138,17 +138,44 @@ Per-agent migration mapping (committed):
 
 Rationale for splitting from PR 2: the canonicalize.py helper is reviewable independently; coupling it to a fleet-wide surface_id migration risked both reviews stalling on the wider impact. PR 2 shipped the helper; PR 2.5 ships the migration + validator together — atomic landing is the safety contract (validator without migration = bricked fleet; migration without validator = silently inconsistent).
 
-## PR 3 — §7.11 deprecation CLI + Sentinel forced-release alarm (planned, not yet drafted)
+## PR 3a — §7.11 deprecation CLI (this branch: impl/lease-plane-phase-a-pr3a-deprecate-cli)
+
+Scope shipped:
+- `scripts/dev/lease_plane_deprecate.py` standalone Python CLI implementing the 4-phase operator-driven deprecation procedure (RFC §7.11.2):
+  - `deprecate <kind>` — Phase 0: serializable transaction + advisory lock + INSERT into `deprecated_schemes` (idempotent via `ON CONFLICT DO NOTHING`).
+  - `deprecation-sweep <kind>` — Phase 2: idempotent force-release of surviving leases per RFC §7.11.4 predicate (`WHERE released_at IS NULL AND surface_kind = $1 FOR UPDATE SKIP LOCKED`); emits `lease.deprecation_swept` events with `deprecation_id` payload for batch correlation.
+  - `deprecation-finalize <kind>` — Phase 3: records `check_migrated_at` (the actual ALTER TABLE drop is operator-issued in same session per §7.11.2).
+  - `deprecation-status [<kind>]` — operator visibility into `deprecated_schemes` table.
+- Force-release authorization gated on `LEASE_FORCE_RELEASE_TOKEN` from env or `~/.config/cirwel/secrets.env`. `GOVERNANCE_TOKEN` does NOT authorize (RFC §7.10).
+- Migration 028 (`db/postgres/migrations/028_lease_plane_trigger_fix.sql`): drops the now-redundant `surface_kind IS DISTINCT FROM` check from `lease_plane.enforce_immutable_lease_fields()`. Surfaced during PR 3a TDD — after migration 026 made `surface_kind` a generated column, the BEFORE UPDATE trigger sees `NEW.surface_kind = NULL` (generated values populate AFTER triggers fire), bricking ANY UPDATE on `surface_leases` including the §7.11 sweep. `surface_id` immutability is unchanged and transitively guards the derived `surface_kind`.
+
+### PR 3a — RFC gate → code surface → test name → status table
+
+| Gate | Code | Test | Status |
+|------|------|------|--------|
+| §7.11 Phase 0 INSERT into deprecated_schemes | `scripts/dev/lease_plane_deprecate.py::deprecate_cmd` | `test_deprecate_cli_phase_0_inserts_row` | DONE |
+| §7.11 Phase 0 idempotent (ON CONFLICT DO NOTHING) | same | `test_deprecate_cli_idempotent_no_duplicate_row` | DONE |
+| §7.11.1 Phase 0 unknown-kind rejected at catalog FK | same | `test_deprecate_cli_unknown_kind_rejected` | DONE |
+| §7.11.4 sweep predicate idempotent on partial-failure re-run | `deprecation_sweep_cmd` | `test_deprecation_sweep_predicate_idempotent` | DONE |
+| §7.11.3 sweep emits `lease.deprecation_swept` events with deprecation_id | same | `test_deprecation_sweep_emits_lease_deprecation_swept_events` | DONE |
+| §7.11.2 Phase 3 records check_migrated_at | `deprecation_finalize_cmd` | `test_deprecation_finalize_records_check_migrated_at` | DONE |
+| §7.10 sweep requires `LEASE_FORCE_RELEASE_TOKEN`; rejects `GOVERNANCE_TOKEN` | sweep auth path | `test_deprecation_sweep_requires_force_release_token` | DONE |
+| §7.11.7 race-window mitigation (serializable tx + advisory lock) | `deprecate_cmd` SQL | (covered by serializable transaction wrapping in implementation; full concurrent-acquire test deferred to PR 3b once Sentinel alarm + lease acquire path are in scope together) | PARTIAL |
+| Migration 028 trigger fix | `db/postgres/migrations/028_lease_plane_trigger_fix.sql` | (covered transitively by sweep tests — they UPDATE `surface_leases` and would fail without 028) | DONE |
+
+## PR 3b — §7.10/§7.11.5 Sentinel forced-release alarm rule (planned, not yet drafted)
 
 Scope (anticipated):
-- `lease-plane` CLI commands: `deprecate`, `deprecation-sweep`, `deprecation-finalize` (standalone Python CLI in `scripts/dev/`, per operator decision 2026-04-30).
-- `LEASE_FORCE_RELEASE_TOKEN` integration test (covers §7.10 + §7.11 force-release wiring).
-- Phase 2 sweep job with idempotent predicate.
-- Phase 0 race-window mitigation (serializable-tx + advisory lock).
-- **Sentinel forced-release alarm rule** (deferred from PR 1): adds direct lease_plane_events DB access to Sentinel; per-event alarm for ad-hoc `event_type='forced'`, batched-by-`deprecation_id` for `event_type='lease.deprecation_swept'`. Default Sentinel cadence per operator decision 2026-04-30.
-- 6 §7.11 Phase A test gates + 1 §7.10 force-release test + 1 Sentinel alarm wiring test.
+- Adds direct `lease_plane.lease_plane_events` DB access to `agents/sentinel/agent.py` (currently no DB access exists; Sentinel reads fleet state via WebSocket).
+- Per-event alarm rule for `event_type='forced'` AND `event_type != 'lease.deprecation_swept'` (per RFC §7.10 alarm-on-every-event for ad-hoc force-release).
+- Batched alarm rule for `event_type='lease.deprecation_swept'`: groups by `deprecation_id`, emits one summary alarm per batch after `sweep_completed_at` is set on the corresponding `deprecated_schemes` row (per RFC §7.11.5 batch suppression).
+- Polling cadence matches existing Sentinel rules (operator decision 2026-04-30).
+- Tests:
+  - `test_sentinel_force_release_alarm_wired` — per-event alarm fires for ad-hoc forced events.
+  - `test_sentinel_batch_alarm_for_deprecation_sweep` — batched alarm fires once per deprecation_id, not N times.
+  - `test_phase_zero_acquire_race_blocked` (deferred from PR 3a) — full integration test covering the §7.11.7 race window with concurrent acquire attempts during Phase 0 mark.
 
-Rationale: depends on PR 1 (catalog + deprecated_schemes tables must exist) and on operator-runbook content for the CLI documentation. Lands after both.
+Rationale for splitting from PR 3a: Sentinel adding DB access is new architectural surface; coupling it with the deprecation CLI doubles the review burden. PR 3a ships the CLI (operator-facing); PR 3b ships the alarm wiring (telemetry-facing). The events the alarm consumes already exist after PR 3a lands.
 
 ## PR 4+ — Remaining gates
 

--- a/scripts/dev/lease_plane_deprecate.py
+++ b/scripts/dev/lease_plane_deprecate.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""
+Lease-plane deprecation CLI (RFC v0.8 §7.11).
+
+Implements the 4-phase operator-driven scheme deprecation procedure as a
+standalone Python CLI in `scripts/dev/`. Operator decision 2026-04-30 — Python
+CLI rather than Mix wrapper because deprecation is governance/operator policy
+plus Postgres state, not BEAM live coordination.
+
+Usage:
+    python3 scripts/dev/lease_plane_deprecate.py deprecate <kind> [--days N]
+    python3 scripts/dev/lease_plane_deprecate.py deprecation-sweep <kind>
+    python3 scripts/dev/lease_plane_deprecate.py deprecation-finalize <kind>
+    python3 scripts/dev/lease_plane_deprecate.py deprecation-status [<kind>]
+
+Authorization:
+    `deprecation-sweep` requires LEASE_FORCE_RELEASE_TOKEN (RFC §7.10) — read
+    from env or `~/.config/cirwel/secrets.env`. GOVERNANCE_TOKEN does NOT
+    authorize sweep.
+
+Phase ordering (RFC §7.11.2):
+    Phase 0:  deprecate           — INSERT into deprecated_schemes
+    Phase 1:  (verification, lint via unitares_doctor — out of CLI scope)
+    Phase 2:  deprecation-sweep   — force-release surviving leases (idempotent)
+    Phase 3:  deprecation-finalize — record check_migrated_at + migrate CHECK
+              (atomic with Phase 2 in same operator session per RFC §7.11.2)
+
+Idempotency:
+    Phase 0 INSERT uses ON CONFLICT DO NOTHING (re-marking is a no-op).
+    Phase 2 sweep predicate `WHERE released_at IS NULL AND surface_kind = $1`
+    reaches fixpoint on re-run after partial completion (RFC §7.11.4).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+try:
+    import asyncpg
+except ImportError:
+    print("error: asyncpg not installed; install with `pip install asyncpg`", file=sys.stderr)
+    sys.exit(2)
+
+
+DEFAULT_DB_URL = os.environ.get(
+    "GOVERNANCE_DATABASE_URL",
+    "postgresql://postgres:postgres@localhost:5432/governance",
+)
+
+
+def _read_force_release_token() -> str | None:
+    """Read LEASE_FORCE_RELEASE_TOKEN from env or ~/.config/cirwel/secrets.env."""
+    tok = os.environ.get("LEASE_FORCE_RELEASE_TOKEN")
+    if tok:
+        return tok
+    secrets_path = Path.home() / ".config" / "cirwel" / "secrets.env"
+    if not secrets_path.exists():
+        return None
+    for line in secrets_path.read_text().splitlines():
+        line = line.strip()
+        if line.startswith("LEASE_FORCE_RELEASE_TOKEN="):
+            return line.split("=", 1)[1].strip().strip('"').strip("'")
+    return None
+
+
+async def deprecate_cmd(
+    *,
+    kind: str,
+    session_id: str,
+    drain_window_days: int,
+    db_url: str = DEFAULT_DB_URL,
+) -> int:
+    """Phase 0: mark scheme deprecated. Idempotent via ON CONFLICT.
+
+    Per RFC §7.11.7 race-window mitigation, the INSERT runs inside a
+    serializable transaction with a session-level advisory lock so concurrent
+    acquires racing the mark transaction see a consistent state.
+    """
+    conn = await asyncpg.connect(db_url)
+    try:
+        # Validate against catalog OUTSIDE the transaction so a failure doesn't
+        # abort the serializable tx (and so the error message can list valid kinds).
+        catalog = await _list_catalog_kinds(conn)
+        if kind not in catalog:
+            print(
+                f"error: scheme {kind!r} not in lease_plane.surface_kind_catalog. "
+                f"Valid kinds: {catalog}",
+                file=sys.stderr,
+            )
+            return 1
+        async with conn.transaction(isolation="serializable"):
+            # Hash the scheme name to a stable int for advisory lock; ensure positive int range.
+            lock_key = abs(hash(kind)) % (2**31 - 1)
+            await conn.execute("SELECT pg_advisory_xact_lock($1)", lock_key)
+            await conn.execute(
+                """
+                INSERT INTO lease_plane.deprecated_schemes
+                  (surface_kind, marked_by_session_id, drain_window_days)
+                VALUES ($1, $2, $3)
+                ON CONFLICT (surface_kind) DO NOTHING
+                """,
+                kind, session_id, drain_window_days,
+            )
+        return 0
+    finally:
+        await conn.close()
+
+
+async def deprecation_sweep_cmd(*, kind: str, db_url: str = DEFAULT_DB_URL) -> int:
+    """Phase 2: idempotent force-release sweep (RFC §7.11.4).
+
+    Predicate: `WHERE released_at IS NULL AND surface_kind = $1` with no
+    timestamp filter. Re-running on partial failure reaches fixpoint because
+    already-released leases are excluded by the released_at IS NULL clause.
+
+    Authorization: requires LEASE_FORCE_RELEASE_TOKEN (RFC §7.10).
+    GOVERNANCE_TOKEN does NOT authorize.
+
+    Each swept lease emits a `lease.deprecation_swept` event with
+    deprecation_id in the payload jsonb for batch correlation (§7.11.3).
+    """
+    if not _read_force_release_token():
+        print(
+            "error: deprecation-sweep requires LEASE_FORCE_RELEASE_TOKEN "
+            "(env or ~/.config/cirwel/secrets.env). GOVERNANCE_TOKEN does NOT authorize.",
+            file=sys.stderr,
+        )
+        return 1
+
+    conn = await asyncpg.connect(db_url)
+    try:
+        # Look up deprecation_id for audit correlation.
+        depr_id = await conn.fetchval(
+            "SELECT deprecation_id FROM lease_plane.deprecated_schemes WHERE surface_kind = $1",
+            kind,
+        )
+        if depr_id is None:
+            print(f"error: scheme {kind!r} is not marked deprecated; run `deprecate {kind}` first.",
+                  file=sys.stderr)
+            return 1
+
+        async with conn.transaction():
+            # Record sweep_started_at.
+            await conn.execute(
+                "UPDATE lease_plane.deprecated_schemes SET sweep_started_at = COALESCE(sweep_started_at, now()) "
+                "WHERE surface_kind = $1",
+                kind,
+            )
+            # Idempotent predicate per RFC §7.11.4 — no timestamp filter.
+            unreleased = await conn.fetch(
+                """
+                SELECT lease_id, surface_id FROM lease_plane.surface_leases
+                WHERE released_at IS NULL AND surface_kind = $1
+                ORDER BY acquired_at
+                FOR UPDATE SKIP LOCKED
+                """,
+                kind,
+            )
+            for row in unreleased:
+                # Force-release the lease.
+                await conn.execute(
+                    "UPDATE lease_plane.surface_leases "
+                    "SET released_at = now(), release_reason = 'forced' "
+                    "WHERE lease_id = $1",
+                    row["lease_id"],
+                )
+                # Emit audit event with deprecation_id for batch correlation.
+                payload = json.dumps({"deprecation_id": str(depr_id), "kind": kind})
+                await conn.execute(
+                    """
+                    INSERT INTO lease_plane.lease_plane_events
+                      (event_type, lease_id, surface_id, surface_kind, advisory_mode, payload)
+                    VALUES ('lease.deprecation_swept', $1, $2, $3, false, $4::jsonb)
+                    """,
+                    row["lease_id"], row["surface_id"], kind, payload,
+                )
+            # Mark sweep complete.
+            await conn.execute(
+                "UPDATE lease_plane.deprecated_schemes SET sweep_completed_at = now() "
+                "WHERE surface_kind = $1",
+                kind,
+            )
+        return 0
+    finally:
+        await conn.close()
+
+
+async def deprecation_finalize_cmd(*, kind: str, db_url: str = DEFAULT_DB_URL) -> int:
+    """Phase 3: record check_migrated_at on the deprecated_schemes row.
+
+    Per RFC §7.11.2, Phase 3 also extends the surface_id_grammar CHECK to
+    remove the deprecated scheme — that ALTER TABLE should be performed
+    atomically in the same operator session as Phase 2 (DDL as a separate
+    follow-on migration is the fallback if the operator splits sessions).
+    """
+    conn = await asyncpg.connect(db_url)
+    try:
+        async with conn.transaction():
+            row = await conn.fetchrow(
+                "SELECT sweep_completed_at FROM lease_plane.deprecated_schemes WHERE surface_kind = $1",
+                kind,
+            )
+            if row is None:
+                print(f"error: scheme {kind!r} is not marked deprecated.", file=sys.stderr)
+                return 1
+            if row["sweep_completed_at"] is None:
+                print(f"error: deprecation-sweep has not completed for {kind!r}; "
+                      f"run `deprecation-sweep {kind}` first.", file=sys.stderr)
+                return 1
+            await conn.execute(
+                "UPDATE lease_plane.deprecated_schemes "
+                "SET check_migrated_at = COALESCE(check_migrated_at, now()) "
+                "WHERE surface_kind = $1",
+                kind,
+            )
+        return 0
+    finally:
+        await conn.close()
+
+
+async def deprecation_status_cmd(*, kind: str | None = None, db_url: str = DEFAULT_DB_URL) -> int:
+    """Print deprecated_schemes table contents (operator visibility)."""
+    conn = await asyncpg.connect(db_url)
+    try:
+        if kind:
+            rows = await conn.fetch(
+                "SELECT * FROM lease_plane.deprecated_schemes WHERE surface_kind = $1",
+                kind,
+            )
+        else:
+            rows = await conn.fetch(
+                "SELECT * FROM lease_plane.deprecated_schemes ORDER BY marked_deprecated_at"
+            )
+        for row in rows:
+            print(json.dumps({k: str(v) for k, v in dict(row).items()}, indent=2))
+        if not rows:
+            print("(no deprecated schemes)")
+        return 0
+    finally:
+        await conn.close()
+
+
+async def _list_catalog_kinds(conn) -> list[str]:
+    rows = await conn.fetch("SELECT surface_kind FROM lease_plane.surface_kind_catalog ORDER BY surface_kind")
+    return [r["surface_kind"] for r in rows]
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="lease_plane_deprecate", description=__doc__)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    dep = sub.add_parser("deprecate", help="Phase 0: mark scheme deprecated.")
+    dep.add_argument("kind", help="surface_kind to deprecate (must be in surface_kind_catalog)")
+    dep.add_argument("--days", type=int, default=30, help="drain window in days (default 30, max 90)")
+    dep.add_argument("--session-id", default=os.environ.get("USER", "operator-cli"),
+                     help="audit identifier for marked_by_session_id")
+
+    sweep = sub.add_parser("deprecation-sweep", help="Phase 2: force-release surviving leases.")
+    sweep.add_argument("kind")
+
+    fin = sub.add_parser("deprecation-finalize", help="Phase 3: record check_migrated_at.")
+    fin.add_argument("kind")
+
+    status = sub.add_parser("deprecation-status", help="Show deprecated_schemes table.")
+    status.add_argument("kind", nargs="?", default=None)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.cmd == "deprecate":
+        return asyncio.run(
+            deprecate_cmd(kind=args.kind, session_id=args.session_id, drain_window_days=args.days)
+        )
+    if args.cmd == "deprecation-sweep":
+        return asyncio.run(deprecation_sweep_cmd(kind=args.kind))
+    if args.cmd == "deprecation-finalize":
+        return asyncio.run(deprecation_finalize_cmd(kind=args.kind))
+    if args.cmd == "deprecation-status":
+        return asyncio.run(deprecation_status_cmd(kind=args.kind))
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -116,6 +116,7 @@ async def ensure_test_database_schema() -> None:
         await _execute_sql_file(conn, "db/postgres/migrations/025_lease_plane_invariants.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/026_lease_plane_grammar.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/027_lease_plane_deprecation.sql")
+        await _execute_sql_file(conn, "db/postgres/migrations/028_lease_plane_trigger_fix.sql")
 
         # Ensure partitioned audit tables can accept inserts for current month.
         await _execute_sql_file(conn, "db/postgres/partitions.sql")

--- a/tests/test_lease_plane_deprecate_cli.py
+++ b/tests/test_lease_plane_deprecate_cli.py
@@ -1,0 +1,288 @@
+"""
+Phase A PR 3a — deprecation CLI for surface-lease-plane.
+
+Tests the `scripts/dev/lease_plane_deprecate.py` CLI which implements the
+4-phase operator-driven scheme deprecation procedure (RFC v0.8 §7.11.2):
+
+  Phase 0 (`deprecate`)              — mark scheme deprecated, INSERT into deprecated_schemes
+  Phase 1 (automatic verification)   — unitares_doctor lint (out of CLI scope)
+  Phase 2 (`deprecation-sweep`)      — force-release surviving leases, idempotent predicate
+  Phase 3 (`deprecation-finalize`)   — extend grammar CHECK, atomic with sweep
+
+Spec: docs/proposals/surface-lease-plane-v0.md §7.11
+      docs/proposals/surface-lease-plane-phase-a-plan.md PR 3a
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+try:
+    import asyncpg
+except ImportError:
+    pytest.skip("asyncpg not installed", allow_module_level=True)
+
+from tests.test_db_utils import (
+    TEST_DB_URL,
+    can_connect_to_test_db,
+    ensure_test_database_schema,
+)
+
+if not can_connect_to_test_db():
+    pytest.skip("governance_test database not available", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def _set_force_release_token(monkeypatch):
+    """Provide LEASE_FORCE_RELEASE_TOKEN for Phase 2 sweep authorization (RFC §7.10)."""
+    monkeypatch.setenv("LEASE_FORCE_RELEASE_TOKEN", "test-force-release-token-do-not-use-in-prod")
+
+
+async def _cleanup(conn):
+    """Reset deprecated_schemes + surface_leases between tests."""
+    await conn.execute(
+        "DELETE FROM lease_plane.deprecated_schemes WHERE marked_by_session_id LIKE 'test-cli-%'"
+    )
+    await conn.execute(
+        "DELETE FROM lease_plane.surface_leases WHERE intent LIKE 'pr3a-cli-test%'"
+    )
+    await conn.execute(
+        "DELETE FROM lease_plane.lease_plane_events WHERE surface_id LIKE 'td:/pr3a%' "
+        "OR surface_id LIKE 'capture:/pr3a%'"
+    )
+
+
+async def _seed_lease(conn, surface_id: str, ttl_s: int = 60) -> uuid.UUID:
+    """Insert an active lease to be swept."""
+    lease_id = uuid.uuid4()
+    holder_uuid = uuid.uuid4()
+    now = datetime.now(UTC)
+    await conn.execute(
+        """
+        INSERT INTO lease_plane.surface_leases
+          (lease_id, surface_id, holder_agent_uuid, holder_kind, holder_class,
+           heartbeat_required, original_ttl_s, acquired_at, expires_at, intent)
+        VALUES ($1, $2, $3, 'remote_heartbeat', 'process_instance', true, $4, $5, $6, $7)
+        """,
+        lease_id, surface_id, holder_uuid, ttl_s, now,
+        now + timedelta(seconds=ttl_s), "pr3a-cli-test-seed",
+    )
+    return lease_id
+
+
+@pytest.mark.asyncio
+async def test_deprecate_cli_phase_0_inserts_row():
+    """`deprecate <kind>` writes a row to lease_plane.deprecated_schemes."""
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        rc = await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-phase-0", drain_window_days=7,
+            db_url=TEST_DB_URL,
+        )
+        assert rc == 0
+        rows = await conn.fetch(
+            "SELECT surface_kind, drain_window_days, marked_by_session_id "
+            "FROM lease_plane.deprecated_schemes WHERE surface_kind = 'td'"
+        )
+        assert len(rows) == 1
+        assert rows[0]["surface_kind"] == "td"
+        assert rows[0]["drain_window_days"] == 7
+        assert rows[0]["marked_by_session_id"] == "test-cli-phase-0"
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_deprecate_cli_idempotent_no_duplicate_row():
+    """Re-marking an already-deprecated scheme returns 0 with no duplicate row."""
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        rc1 = await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-idem", drain_window_days=30,
+            db_url=TEST_DB_URL,
+        )
+        rc2 = await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-idem", drain_window_days=30,
+            db_url=TEST_DB_URL,
+        )
+        assert rc1 == 0 and rc2 == 0
+        count = await conn.fetchval(
+            "SELECT count(*) FROM lease_plane.deprecated_schemes WHERE surface_kind = 'td'"
+        )
+        assert count == 1
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_deprecate_cli_unknown_kind_rejected():
+    """Marking a scheme not in surface_kind_catalog returns nonzero rc."""
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        rc = await cli.deprecate_cmd(
+            kind="not_a_real_scheme",
+            session_id="test-cli-unknown",
+            drain_window_days=30,
+            db_url=TEST_DB_URL,
+        )
+        assert rc != 0, "Unknown scheme should not succeed"
+        count = await conn.fetchval(
+            "SELECT count(*) FROM lease_plane.deprecated_schemes "
+            "WHERE marked_by_session_id = 'test-cli-unknown'"
+        )
+        assert count == 0
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_deprecation_sweep_predicate_idempotent():
+    """RFC §7.11.4: sweep predicate `WHERE released_at IS NULL AND surface_kind = $1`
+    reaches fixpoint on re-run after partial completion."""
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        # Seed 3 active leases on td:/ scheme.
+        await _seed_lease(conn, "td:/pr3a_a")
+        await _seed_lease(conn, "td:/pr3a_b")
+        await _seed_lease(conn, "td:/pr3a_c")
+        # Mark deprecated.
+        await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-sweep-idem", drain_window_days=30,
+            db_url=TEST_DB_URL,
+        )
+        # First sweep: releases all 3.
+        rc1 = await cli.deprecation_sweep_cmd(kind="td", db_url=TEST_DB_URL)
+        assert rc1 == 0
+        unreleased1 = await conn.fetchval(
+            "SELECT count(*) FROM lease_plane.surface_leases "
+            "WHERE surface_kind = 'td' AND released_at IS NULL"
+        )
+        assert unreleased1 == 0
+        # Re-run: idempotent fixpoint (zero rows to release).
+        rc2 = await cli.deprecation_sweep_cmd(kind="td", db_url=TEST_DB_URL)
+        assert rc2 == 0
+        # Verify all 3 leases have release_reason='forced'.
+        forced_count = await conn.fetchval(
+            "SELECT count(*) FROM lease_plane.surface_leases "
+            "WHERE surface_kind = 'td' AND release_reason = 'forced'"
+        )
+        assert forced_count == 3
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_deprecation_sweep_emits_lease_deprecation_swept_events():
+    """RFC §7.11.3: each swept lease emits an event_type='lease.deprecation_swept'
+    row in lease_plane_events with the deprecation_id for audit correlation."""
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        await _seed_lease(conn, "td:/pr3a_event_a")
+        await _seed_lease(conn, "td:/pr3a_event_b")
+        await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-events", drain_window_days=30,
+            db_url=TEST_DB_URL,
+        )
+        depr_id = await conn.fetchval(
+            "SELECT deprecation_id FROM lease_plane.deprecated_schemes WHERE surface_kind = 'td'"
+        )
+        assert depr_id is not None
+
+        await cli.deprecation_sweep_cmd(kind="td", db_url=TEST_DB_URL)
+        # Two events emitted with the matching deprecation_id in payload.
+        events = await conn.fetch(
+            "SELECT event_type, payload FROM lease_plane.lease_plane_events "
+            "WHERE event_type = 'lease.deprecation_swept' AND surface_kind = 'td' "
+            "ORDER BY ts"
+        )
+        assert len(events) == 2
+        for ev in events:
+            assert ev["event_type"] == "lease.deprecation_swept"
+            # payload jsonb stores deprecation_id for batch correlation.
+            import json
+            payload = json.loads(ev["payload"])
+            assert payload.get("deprecation_id") == str(depr_id)
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_deprecation_finalize_records_check_migrated_at():
+    """`deprecation-finalize` records check_migrated_at on the deprecated_schemes row."""
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-finalize", drain_window_days=30,
+            db_url=TEST_DB_URL,
+        )
+        await cli.deprecation_sweep_cmd(kind="td", db_url=TEST_DB_URL)
+        rc = await cli.deprecation_finalize_cmd(kind="td", db_url=TEST_DB_URL)
+        assert rc == 0
+        check_migrated_at = await conn.fetchval(
+            "SELECT check_migrated_at FROM lease_plane.deprecated_schemes WHERE surface_kind = 'td'"
+        )
+        assert check_migrated_at is not None
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_deprecation_sweep_requires_force_release_token(monkeypatch):
+    """RFC §7.10: only LEASE_FORCE_RELEASE_TOKEN authorizes the sweep, not GOVERNANCE_TOKEN."""
+    from scripts.dev import lease_plane_deprecate as cli
+
+    monkeypatch.delenv("LEASE_FORCE_RELEASE_TOKEN", raising=False)
+    monkeypatch.setenv("GOVERNANCE_TOKEN", "should-not-authorize")
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-token", drain_window_days=30,
+            db_url=TEST_DB_URL,
+        )
+        rc = await cli.deprecation_sweep_cmd(kind="td", db_url=TEST_DB_URL)
+        assert rc != 0, "Sweep without LEASE_FORCE_RELEASE_TOKEN must fail"
+    finally:
+        await _cleanup(conn)
+        await conn.close()


### PR DESCRIPTION
**Stacked on #267** (PR 2.5). Targets `impl/lease-plane-phase-a-pr2-5-validator`; rebase to master after PRs 1/2/2.5 merge.

## Summary

Ships the §7.11 4-phase operator-driven scheme deprecation procedure as a standalone Python CLI in `scripts/dev/`. Plus migration 028 fixing a PR 1 oversight (immutability trigger vs generated column collision).

## RFC gate → code surface → test name → status

| Gate | Code | Test | Status |
|------|------|------|--------|
| §7.11 Phase 0 INSERT into `deprecated_schemes` | `scripts/dev/lease_plane_deprecate.py::deprecate_cmd` | `test_deprecate_cli_phase_0_inserts_row` | ✅ |
| §7.11 Phase 0 idempotent (`ON CONFLICT DO NOTHING`) | same | `test_deprecate_cli_idempotent_no_duplicate_row` | ✅ |
| §7.11.1 Phase 0 unknown-kind rejected at catalog FK | same | `test_deprecate_cli_unknown_kind_rejected` | ✅ |
| §7.11.4 sweep predicate idempotent on partial-failure re-run | `deprecation_sweep_cmd` | `test_deprecation_sweep_predicate_idempotent` | ✅ |
| §7.11.3 sweep emits `lease.deprecation_swept` events with `deprecation_id` | same | `test_deprecation_sweep_emits_lease_deprecation_swept_events` | ✅ |
| §7.11.2 Phase 3 records `check_migrated_at` | `deprecation_finalize_cmd` | `test_deprecation_finalize_records_check_migrated_at` | ✅ |
| §7.10 sweep requires `LEASE_FORCE_RELEASE_TOKEN`; rejects `GOVERNANCE_TOKEN` | sweep auth path | `test_deprecation_sweep_requires_force_release_token` | ✅ |
| Migration 028 trigger fix | `db/postgres/migrations/028_lease_plane_trigger_fix.sql` | (covered transitively by sweep tests) | ✅ |
| §7.11.7 race-window mitigation (full integration test) | (deferred to PR 3b) | `test_phase_zero_acquire_race_blocked` | ⏸ DEFERRED |

## Migration 028 — trigger fix surfaced during PR 3a TDD

Live-verified bug: migration 025's `enforce_immutable_lease_fields()` trigger guards `NEW.surface_kind IS DISTINCT FROM OLD.surface_kind`, but after migration 026 made `surface_kind` a `STORED GENERATED` column, BEFORE UPDATE triggers see `NEW.surface_kind = NULL` (generated values populate AFTER triggers fire). Result: ANY `UPDATE` on `surface_leases` (including the §7.11 sweep) raises `'surface_kind is immutable per lease_id'` — even when surface_kind isn't actually changing.

Fix: drop the `surface_kind` check from the trigger. `surface_id` immutability is unchanged; since `surface_kind = split_part(surface_id, ':', 1)`, guarding `surface_id` transitively guards `surface_kind`.

Could have been folded into PR 1's migration 026 if discovered earlier — surfaced here because the sweep is the first code path to UPDATE `surface_leases` post-026.

## CLI commands

- `deprecate <kind> [--days N]` — Phase 0: serializable transaction + advisory lock + INSERT into `deprecated_schemes`. Idempotent via `ON CONFLICT DO NOTHING`.
- `deprecation-sweep <kind>` — Phase 2: idempotent force-release of surviving leases per RFC §7.11.4 predicate (`WHERE released_at IS NULL AND surface_kind = $1 FOR UPDATE SKIP LOCKED`). Records `sweep_started_at` then `sweep_completed_at`. Emits `lease.deprecation_swept` events with `deprecation_id` payload for batch correlation.
- `deprecation-finalize <kind>` — Phase 3: records `check_migrated_at` (the actual ALTER TABLE drop is operator-issued in same session per §7.11.2).
- `deprecation-status [<kind>]` — operator visibility.

## Authorization (RFC §7.10)

- `LEASE_FORCE_RELEASE_TOKEN` read from env or `~/.config/cirwel/secrets.env`.
- `GOVERNANCE_TOKEN` does NOT authorize sweep — explicit reject path tested.

## What's deferred to PR 3b

- Sentinel forced-release alarm rule (per-event for ad-hoc, batched-by-`deprecation_id` for sweeps).
- `test_phase_zero_acquire_race_blocked` — full integration test with concurrent acquire attempts during Phase 0 mark. The CLI's serializable transaction + advisory lock implementation IS in place; PR 3b adds the test that exercises a real race.
- Adding direct `lease_plane_events` DB access to Sentinel.

Splitting rationale: Sentinel adding DB access is new architectural surface; coupling with the CLI doubles review burden.

## Test verification

- **7/7 PR 3a tests GREEN**.
- **7970/7970 full suite GREEN** (+7 vs PR 2.5; excluding `tests/resident_progress/` pre-existing master failure unrelated to this PR).

## Test plan
- [ ] `pytest tests/test_lease_plane_deprecate_cli.py -q --no-cov` — 7/7 pass
- [ ] Reviewer applies migrations 026 + 027 + 028 (from PRs 1 + 3a) to live `governance` DB before any agent runs against this branch
- [ ] **Operator confirms PRs 1/2/2.5/3a merge as a stack** — partial merge bricks fleet (PR 3a depends on PR 2.5's `resident:/` migration, which depends on PR 2's canonicalize.py, which depends on PR 1's migrations)
- [ ] Reviewer runs the CLI manually against a test instance to verify the operator-facing UX