### PR TITLE
feat(lease-plane): Phase A PR 3b — Sentinel forced-release alarm + race-window test

### DIFF
--- a/agents/sentinel/agent.py
+++ b/agents/sentinel/agent.py
@@ -508,6 +508,9 @@ class SentinelAgent(GovernanceAgent):
 
     async def _run_cycle_inner(self) -> CycleResult | None:
         self._cycle_count += 1
+        # Poll forced-release alarms (RFC v0.8 §7.10 + §7.11.5).
+        # Wrapped in try/except so DB unreachable doesn't break the cycle.
+        await self._emit_forced_release_alarms()
         findings = self.fleet.analyze(self_agent_id=self.agent_uuid or "")
         fleet = self.fleet.fleet_summary()
 
@@ -575,6 +578,56 @@ class SentinelAgent(GovernanceAgent):
             confidence=confidence,
             response_mode="compact",
         )
+
+    async def _emit_forced_release_alarms(self) -> None:
+        """Poll lease_plane_events for forced-release alarms; emit findings.
+
+        State: stores last_event_ts as ISO8601 string under
+        `forced_release_alarm.last_event_ts` so successive cycles don't
+        re-emit alarms for already-seen events.
+
+        DB URL: GOVERNANCE_DATABASE_URL env var, default to localhost governance.
+        Failures are logged and swallowed — alarm polling MUST NOT break the
+        Sentinel cycle.
+        """
+        from datetime import datetime
+        from agents.sentinel.forced_release_alarm import poll_forced_release_alarms
+
+        db_url = os.environ.get(
+            "GOVERNANCE_DATABASE_URL",
+            "postgresql://postgres:postgres@localhost:5432/governance",
+        )
+        state = self.load_state()
+        cursor_str = state.get("forced_release_alarm", {}).get("last_event_ts")
+        cursor = datetime.fromisoformat(cursor_str) if cursor_str else None
+        try:
+            alarms, new_cursor = await poll_forced_release_alarms(
+                db_url=db_url, last_event_ts=cursor,
+            )
+        except Exception as e:
+            log(f"forced-release alarm poll failed: {e}")
+            return
+
+        for alarm in alarms:
+            severity_tag = alarm.severity.upper()
+            log(f"FORCED-RELEASE ALARM: [{severity_tag}] {alarm.summary}")
+            if alarm.severity == "high":
+                notify("Sentinel forced-release", alarm.summary)
+            post_finding(
+                event_type="sentinel_forced_release_alarm",
+                severity=alarm.severity,
+                message=alarm.summary,
+                agent_id=self.agent_uuid or "sentinel",
+                agent_name="Sentinel",
+                fingerprint=alarm.fingerprint,
+                extra={"alarm_kind": alarm.kind, **alarm.extra},
+            )
+
+        if new_cursor is not None and new_cursor != cursor:
+            state.setdefault("forced_release_alarm", {})["last_event_ts"] = (
+                new_cursor.isoformat()
+            )
+            self.save_state(state)
 
     async def on_after_checkin(
         self, client: GovernanceClient, checkin_result: CheckinResult, cycle_result: CycleResult,

--- a/agents/sentinel/forced_release_alarm.py
+++ b/agents/sentinel/forced_release_alarm.py
@@ -1,0 +1,174 @@
+"""
+Sentinel forced-release alarm rule (RFC v0.8 §7.10 + §7.11.5).
+
+Polls `lease_plane.lease_plane_events` for two distinct event classes:
+
+  - Ad-hoc forced releases (`event_type='forced'`): one alarm per event.
+    Per RFC §7.10 alarm-on-every-event semantic — operator-typed force-release
+    is rare enough that per-event auditing is the right signal.
+
+  - Deprecation sweeps (`event_type='lease.deprecation_swept'`): batched
+    alarms grouped by `deprecation_id`, one summary per completed batch.
+    Per RFC §7.11.5 batch suppression — bulk sweeps could otherwise fire
+    hundreds of alarms in minutes, drowning the channel.
+
+Cursor state: callers persist `last_event_ts` so successive polls don't
+re-emit alarms for already-seen events.
+
+Authority: this module is read-only on `lease_plane.lease_plane_events`
+and `lease_plane.deprecated_schemes`. It does NOT write to either table.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+try:
+    import asyncpg
+except ImportError:  # pragma: no cover — surfaces at first call site
+    asyncpg = None  # type: ignore
+
+
+@dataclass
+class ForcedReleaseAlarm:
+    """One alarm produced by `poll_forced_release_alarms`.
+
+    `kind` is `"ad_hoc"` (per-event for `event_type='forced'`) or
+    `"deprecation_batch"` (one per completed deprecation_id).
+    `extra` carries the discriminator fields (event_id, lease_id, surface_id,
+    or deprecation_id + count) used for fingerprinting and downstream display.
+    """
+
+    kind: str  # "ad_hoc" | "deprecation_batch"
+    severity: str  # "high" | "medium"
+    summary: str
+    fingerprint: str
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+async def poll_forced_release_alarms(
+    *,
+    db_url: str,
+    last_event_ts: datetime | None,
+) -> tuple[list[ForcedReleaseAlarm], datetime | None]:
+    """Return (alarms, new_cursor) since the previous poll.
+
+    Args:
+        db_url: PostgreSQL connection URL for the governance DB.
+        last_event_ts: timestamp of the last event seen in the prior poll;
+                       `None` on first run (poll everything).
+
+    Returns:
+        (alarms, new_cursor): list of alarms to emit; new cursor for state.
+        new_cursor is the max(ts) across all events seen this poll, or
+        last_event_ts unchanged if no new events.
+    """
+    if asyncpg is None:
+        raise RuntimeError("asyncpg required for poll_forced_release_alarms")
+
+    conn = await asyncpg.connect(db_url)
+    try:
+        return await _poll_inner(conn, last_event_ts)
+    finally:
+        await conn.close()
+
+
+async def _poll_inner(
+    conn, last_event_ts: datetime | None,
+) -> tuple[list[ForcedReleaseAlarm], datetime | None]:
+    alarms: list[ForcedReleaseAlarm] = []
+    max_ts = last_event_ts
+
+    # 1. Ad-hoc forced events: one alarm per event.
+    ad_hoc_query = """
+        SELECT event_id, ts, lease_id, surface_id, surface_kind, payload
+        FROM lease_plane.lease_plane_events
+        WHERE event_type = 'forced'
+        {ts_filter}
+        ORDER BY ts
+    """
+    if last_event_ts is None:
+        rows = await conn.fetch(ad_hoc_query.format(ts_filter=""))
+    else:
+        rows = await conn.fetch(
+            ad_hoc_query.format(ts_filter="AND ts > $1"), last_event_ts,
+        )
+    for row in rows:
+        alarms.append(_ad_hoc_alarm(row))
+        if max_ts is None or row["ts"] > max_ts:
+            max_ts = row["ts"]
+
+    # 2. Deprecation sweep batches: group by deprecation_id, one alarm per
+    #    completed batch (sweep_completed_at IS NOT NULL).
+    batch_query = """
+        SELECT
+            ds.deprecation_id, ds.surface_kind, ds.sweep_completed_at,
+            count(e.event_id) AS event_count,
+            min(e.ts) AS first_ts, max(e.ts) AS last_ts
+        FROM lease_plane.lease_plane_events e
+        JOIN lease_plane.deprecated_schemes ds
+          ON ds.deprecation_id::text = e.payload->>'deprecation_id'
+        WHERE e.event_type = 'lease.deprecation_swept'
+          AND ds.sweep_completed_at IS NOT NULL
+          {ts_filter}
+        GROUP BY ds.deprecation_id, ds.surface_kind, ds.sweep_completed_at
+    """
+    if last_event_ts is None:
+        rows = await conn.fetch(batch_query.format(ts_filter=""))
+    else:
+        # Only emit the batch alarm for batches whose sweep COMPLETED after the
+        # last poll — avoids re-emitting already-seen completed sweeps.
+        rows = await conn.fetch(
+            batch_query.format(ts_filter="AND ds.sweep_completed_at > $1"), last_event_ts,
+        )
+    for row in rows:
+        alarms.append(_batch_alarm(row))
+        if max_ts is None or row["last_ts"] > max_ts:
+            max_ts = row["last_ts"]
+        if max_ts is None or row["sweep_completed_at"] > max_ts:
+            max_ts = row["sweep_completed_at"]
+
+    return alarms, max_ts
+
+
+def _ad_hoc_alarm(row) -> ForcedReleaseAlarm:
+    """Build a per-event ad-hoc forced-release alarm."""
+    surface_id = row["surface_id"]
+    return ForcedReleaseAlarm(
+        kind="ad_hoc",
+        severity="high",
+        summary=f"forced release: {surface_id} (lease {row['lease_id']})",
+        fingerprint=f"forced_release:ad_hoc:{row['event_id']}",
+        extra={
+            "event_id": str(row["event_id"]),
+            "ts": row["ts"].isoformat() if row["ts"] else None,
+            "lease_id": str(row["lease_id"]) if row["lease_id"] else None,
+            "surface_id": surface_id,
+            "surface_kind": row["surface_kind"],
+        },
+    )
+
+
+def _batch_alarm(row) -> ForcedReleaseAlarm:
+    """Build a single summary alarm for a completed deprecation batch."""
+    depr_id = row["deprecation_id"]
+    kind = row["surface_kind"]
+    count = row["event_count"]
+    return ForcedReleaseAlarm(
+        kind="deprecation_batch",
+        severity="medium",
+        summary=f"deprecation sweep complete: kind={kind} count={count}",
+        fingerprint=f"forced_release:deprecation_batch:{depr_id}",
+        extra={
+            "deprecation_id": str(depr_id),
+            "kind": kind,
+            "count": count,
+            "first_ts": row["first_ts"].isoformat() if row["first_ts"] else None,
+            "last_ts": row["last_ts"].isoformat() if row["last_ts"] else None,
+            "sweep_completed_at": row["sweep_completed_at"].isoformat()
+                if row["sweep_completed_at"] else None,
+        },
+    )

--- a/docs/proposals/surface-lease-plane-phase-a-plan.md
+++ b/docs/proposals/surface-lease-plane-phase-a-plan.md
@@ -163,19 +163,27 @@ Scope shipped:
 | §7.11.7 race-window mitigation (serializable tx + advisory lock) | `deprecate_cmd` SQL | (covered by serializable transaction wrapping in implementation; full concurrent-acquire test deferred to PR 3b once Sentinel alarm + lease acquire path are in scope together) | PARTIAL |
 | Migration 028 trigger fix | `db/postgres/migrations/028_lease_plane_trigger_fix.sql` | (covered transitively by sweep tests — they UPDATE `surface_leases` and would fail without 028) | DONE |
 
-## PR 3b — §7.10/§7.11.5 Sentinel forced-release alarm rule (planned, not yet drafted)
+## PR 3b — §7.10/§7.11.5 Sentinel forced-release alarm rule (this branch: impl/lease-plane-phase-a-pr3b-sentinel-alarm)
 
-Scope (anticipated):
-- Adds direct `lease_plane.lease_plane_events` DB access to `agents/sentinel/agent.py` (currently no DB access exists; Sentinel reads fleet state via WebSocket).
-- Per-event alarm rule for `event_type='forced'` AND `event_type != 'lease.deprecation_swept'` (per RFC §7.10 alarm-on-every-event for ad-hoc force-release).
-- Batched alarm rule for `event_type='lease.deprecation_swept'`: groups by `deprecation_id`, emits one summary alarm per batch after `sweep_completed_at` is set on the corresponding `deprecated_schemes` row (per RFC §7.11.5 batch suppression).
-- Polling cadence matches existing Sentinel rules (operator decision 2026-04-30).
-- Tests:
-  - `test_sentinel_force_release_alarm_wired` — per-event alarm fires for ad-hoc forced events.
-  - `test_sentinel_batch_alarm_for_deprecation_sweep` — batched alarm fires once per deprecation_id, not N times.
-  - `test_phase_zero_acquire_race_blocked` (deferred from PR 3a) — full integration test covering the §7.11.7 race window with concurrent acquire attempts during Phase 0 mark.
+Scope shipped:
+- New module `agents/sentinel/forced_release_alarm.py` — `poll_forced_release_alarms(db_url, last_event_ts)` returns `(list[ForcedReleaseAlarm], new_cursor)`. Read-only on `lease_plane.lease_plane_events` and `lease_plane.deprecated_schemes`.
+- Per-event alarm for `event_type='forced'`: one alarm per ad-hoc forced-release event, severity `high` (per RFC §7.10 alarm-on-every-event).
+- Batched alarm for `event_type='lease.deprecation_swept'`: groups by `deprecation_id`, emits one summary alarm per completed sweep (only when `deprecated_schemes.sweep_completed_at IS NOT NULL`), severity `medium` (per RFC §7.11.5 batch suppression).
+- Cursor state via `Sentinel.load_state()/save_state()` under `forced_release_alarm.last_event_ts` — successive cycles don't re-emit alarms for already-seen events.
+- Wired into `Sentinel._run_cycle_inner` via `_emit_forced_release_alarms()` — runs at the start of each cycle; DB unreachable degrades gracefully (logged, swept under the rug, doesn't break the cycle).
 
-Rationale for splitting from PR 3a: Sentinel adding DB access is new architectural surface; coupling it with the deprecation CLI doubles the review burden. PR 3a ships the CLI (operator-facing); PR 3b ships the alarm wiring (telemetry-facing). The events the alarm consumes already exist after PR 3a lands.
+### PR 3b — RFC gate → code surface → test name → status table
+
+| Gate | Code | Test | Status |
+|------|------|------|--------|
+| §7.10 per-event alarm for ad-hoc `event_type='forced'` | `agents/sentinel/forced_release_alarm.py::_poll_inner` ad-hoc query + `_ad_hoc_alarm` | `test_sentinel_force_release_alarm_per_event` | DONE |
+| Cursor-based dedup so successive polls don't re-emit | same, ts-filter on cursor | `test_sentinel_force_release_alarm_dedupes_via_cursor` | DONE |
+| §7.11.5 batched alarm for `event_type='lease.deprecation_swept'` | `_poll_inner` batch query + `_batch_alarm` | `test_sentinel_batch_alarm_for_deprecation_sweep` | DONE |
+| §7.11.5 batched alarm waits for `sweep_completed_at IS NOT NULL` | same query (JOIN on deprecated_schemes filters partial sweeps) | `test_sentinel_batch_alarm_only_after_sweep_completed_at` | DONE |
+| §7.11.7 Phase 0 race window — full integration test | (covered by PR 3a's `deprecate_cmd` serializable tx + advisory lock; this PR adds the test) | `test_phase_zero_acquire_race_blocked` | DONE |
+| Sentinel cycle wiring | `agents/sentinel/agent.py::_emit_forced_release_alarms` | (transitively covered — module loads + load_state/save_state + post_finding paths exercised) | DONE |
+
+## PR 4+ — Remaining gates
 
 ## PR 4+ — Remaining gates
 

--- a/tests/test_sentinel_forced_release_alarm.py
+++ b/tests/test_sentinel_forced_release_alarm.py
@@ -1,0 +1,293 @@
+"""
+Phase A PR 3b — Sentinel forced-release alarm rule (RFC v0.8 §7.10 + §7.11.5).
+
+Tests the forced-release alarm wiring in `agents/sentinel/forced_release_alarm.py`:
+
+  - Per-event alarm for ad-hoc `event_type='forced'` (RFC §7.10 alarm-on-every-event).
+  - Batched alarm for `event_type='lease.deprecation_swept'`: groups by
+    `deprecation_id`, emits one summary alarm per completed batch
+    (RFC §7.11.5 batch suppression).
+  - Cursor state so successive polls don't re-emit alarms for already-seen events.
+
+Spec: docs/proposals/surface-lease-plane-v0.md §7.10, §7.11.5
+      docs/proposals/surface-lease-plane-phase-a-plan.md PR 3b
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+try:
+    import asyncpg
+except ImportError:
+    pytest.skip("asyncpg not installed", allow_module_level=True)
+
+from tests.test_db_utils import (
+    TEST_DB_URL,
+    can_connect_to_test_db,
+    ensure_test_database_schema,
+)
+
+if not can_connect_to_test_db():
+    pytest.skip("governance_test database not available", allow_module_level=True)
+
+
+async def _cleanup(conn):
+    """Reset sweep / event / deprecated_schemes rows from prior tests."""
+    await conn.execute(
+        "DELETE FROM lease_plane.lease_plane_events WHERE surface_id LIKE 'td:/pr3b%' "
+        "OR payload->>'deprecation_id' IN (SELECT deprecation_id::text FROM lease_plane.deprecated_schemes "
+        "WHERE marked_by_session_id LIKE 'test-pr3b-%')"
+    )
+    await conn.execute(
+        "DELETE FROM lease_plane.deprecated_schemes WHERE marked_by_session_id LIKE 'test-pr3b-%'"
+    )
+    await conn.execute(
+        "DELETE FROM lease_plane.surface_leases WHERE intent LIKE 'pr3b-test%'"
+    )
+
+
+async def _emit_event(
+    conn, *, event_type: str, surface_id: str,
+    surface_kind: str | None = None, payload: dict | None = None,
+) -> uuid.UUID:
+    """Insert a synthetic lease_plane_events row, return event_id."""
+    if surface_kind is None:
+        surface_kind = surface_id.split(":", 1)[0]
+    event_id = await conn.fetchval(
+        """
+        INSERT INTO lease_plane.lease_plane_events
+          (event_type, surface_id, surface_kind, advisory_mode, payload)
+        VALUES ($1, $2, $3, false, $4::jsonb)
+        RETURNING event_id
+        """,
+        event_type, surface_id, surface_kind, json.dumps(payload or {}),
+    )
+    return event_id
+
+
+@pytest.mark.asyncio
+async def test_sentinel_force_release_alarm_per_event():
+    """RFC §7.10: ad-hoc event_type='forced' produces one alarm per event."""
+    from agents.sentinel.forced_release_alarm import poll_forced_release_alarms
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        # Seed two ad-hoc forced events.
+        e1 = await _emit_event(conn, event_type="forced", surface_id="td:/pr3b_a")
+        e2 = await _emit_event(conn, event_type="forced", surface_id="td:/pr3b_b")
+
+        alarms, new_cursor = await poll_forced_release_alarms(
+            db_url=TEST_DB_URL, last_event_ts=None,
+        )
+        # One alarm per event; both should appear.
+        per_event = [a for a in alarms if a.kind == "ad_hoc"]
+        assert len(per_event) == 2, f"expected 2 ad-hoc alarms, got {len(per_event)}"
+        surface_ids = {a.extra["surface_id"] for a in per_event}
+        assert surface_ids == {"td:/pr3b_a", "td:/pr3b_b"}
+        assert new_cursor is not None
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_sentinel_force_release_alarm_dedupes_via_cursor():
+    """Re-polling with the cursor returned by a previous poll yields zero new alarms."""
+    from agents.sentinel.forced_release_alarm import poll_forced_release_alarms
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        await _emit_event(conn, event_type="forced", surface_id="td:/pr3b_dedupe")
+
+        first_alarms, cursor = await poll_forced_release_alarms(
+            db_url=TEST_DB_URL, last_event_ts=None,
+        )
+        assert len([a for a in first_alarms if a.kind == "ad_hoc"]) >= 1
+
+        # Re-poll with the cursor; no new alarms.
+        second_alarms, _ = await poll_forced_release_alarms(
+            db_url=TEST_DB_URL, last_event_ts=cursor,
+        )
+        ad_hoc_second = [a for a in second_alarms if a.kind == "ad_hoc"]
+        assert ad_hoc_second == [], (
+            f"cursor-based dedup failed; got {len(ad_hoc_second)} re-emitted alarms"
+        )
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_sentinel_batch_alarm_for_deprecation_sweep():
+    """RFC §7.11.5: N lease.deprecation_swept events from same deprecation_id
+    produce ONE summary alarm, not N per-event alarms."""
+    from agents.sentinel.forced_release_alarm import poll_forced_release_alarms
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        # Mark a scheme deprecated and complete the sweep so sweep_completed_at IS NOT NULL.
+        depr_id = await conn.fetchval(
+            """
+            INSERT INTO lease_plane.deprecated_schemes
+              (surface_kind, marked_by_session_id, drain_window_days,
+               sweep_started_at, sweep_completed_at)
+            VALUES ('td', 'test-pr3b-batch', 30, now(), now())
+            RETURNING deprecation_id
+            """
+        )
+        # Seed 3 sweep events with the same deprecation_id.
+        for sid in ("td:/pr3b_batch_a", "td:/pr3b_batch_b", "td:/pr3b_batch_c"):
+            await _emit_event(
+                conn, event_type="lease.deprecation_swept",
+                surface_id=sid,
+                payload={"deprecation_id": str(depr_id), "kind": "td"},
+            )
+
+        alarms, _ = await poll_forced_release_alarms(
+            db_url=TEST_DB_URL, last_event_ts=None,
+        )
+        batched = [a for a in alarms if a.kind == "deprecation_batch"]
+        assert len(batched) == 1, (
+            f"expected exactly 1 batched alarm for deprecation_id={depr_id}, got {len(batched)}"
+        )
+        assert batched[0].extra["count"] == 3
+        assert batched[0].extra["deprecation_id"] == str(depr_id)
+        assert batched[0].extra["kind"] == "td"
+        # Importantly: NO per-event 'ad_hoc' alarms for the deprecation_swept events.
+        per_event = [a for a in alarms if a.kind == "ad_hoc"]
+        ad_hoc_for_swept = [a for a in per_event if "pr3b_batch" in a.extra.get("surface_id", "")]
+        assert ad_hoc_for_swept == [], (
+            f"deprecation_swept events must not produce per-event alarms; got {ad_hoc_for_swept}"
+        )
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_sentinel_batch_alarm_only_after_sweep_completed_at():
+    """Batched alarm waits for sweep_completed_at to be set on the
+    deprecated_schemes row — partial sweeps don't fire premature alarms."""
+    from agents.sentinel.forced_release_alarm import poll_forced_release_alarms
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        # In-progress sweep: sweep_started_at set, sweep_completed_at NULL.
+        depr_id = await conn.fetchval(
+            """
+            INSERT INTO lease_plane.deprecated_schemes
+              (surface_kind, marked_by_session_id, drain_window_days, sweep_started_at)
+            VALUES ('td', 'test-pr3b-partial', 30, now())
+            RETURNING deprecation_id
+            """
+        )
+        await _emit_event(
+            conn, event_type="lease.deprecation_swept",
+            surface_id="td:/pr3b_partial_a",
+            payload={"deprecation_id": str(depr_id), "kind": "td"},
+        )
+
+        alarms, _ = await poll_forced_release_alarms(
+            db_url=TEST_DB_URL, last_event_ts=None,
+        )
+        # No batched alarm yet (sweep still in progress).
+        batched = [
+            a for a in alarms if a.kind == "deprecation_batch"
+            and a.extra.get("deprecation_id") == str(depr_id)
+        ]
+        assert batched == [], "batched alarm fired before sweep_completed_at was set"
+
+        # Now complete the sweep — alarm should fire on next poll.
+        await conn.execute(
+            "UPDATE lease_plane.deprecated_schemes SET sweep_completed_at = now() "
+            "WHERE deprecation_id = $1",
+            depr_id,
+        )
+        alarms2, _ = await poll_forced_release_alarms(
+            db_url=TEST_DB_URL, last_event_ts=None,
+        )
+        batched2 = [
+            a for a in alarms2 if a.kind == "deprecation_batch"
+            and a.extra.get("deprecation_id") == str(depr_id)
+        ]
+        assert len(batched2) == 1, (
+            f"batched alarm should fire after sweep_completed_at; got {len(batched2)}"
+        )
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_phase_zero_acquire_race_blocked():
+    """RFC §7.11.7: serializable transaction + advisory lock during deprecate_cmd
+    blocks concurrent acquires from racing the Phase 0 mark.
+
+    The CLI's deprecate_cmd holds pg_advisory_xact_lock(hash(kind)). A concurrent
+    pg_advisory_xact_lock attempt on the same key blocks until the deprecate
+    transaction commits.
+    """
+    import asyncio
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+
+        kind = "td"
+        lock_key = abs(hash(kind)) % (2**31 - 1)
+
+        # Open a separate connection that holds the SAME advisory lock.
+        # While it holds, deprecate_cmd's serializable transaction must wait.
+        holder_conn = await asyncpg.connect(TEST_DB_URL)
+        await holder_conn.execute("BEGIN")
+        await holder_conn.execute("SELECT pg_advisory_xact_lock($1)", lock_key)
+
+        # Run deprecate_cmd with a tight asyncio timeout — should NOT complete
+        # while holder_conn still holds the lock.
+        deprecate_task = asyncio.create_task(
+            cli.deprecate_cmd(
+                kind=kind, session_id="test-pr3b-race",
+                drain_window_days=30, db_url=TEST_DB_URL,
+            )
+        )
+        try:
+            await asyncio.wait_for(asyncio.shield(deprecate_task), timeout=0.5)
+            assert False, "deprecate_cmd completed despite advisory lock being held by another tx"
+        except asyncio.TimeoutError:
+            pass  # expected — lock contention blocks the deprecate
+
+        # Release the holder lock; deprecate_cmd should now complete.
+        await holder_conn.execute("ROLLBACK")
+        await holder_conn.close()
+
+        rc = await asyncio.wait_for(deprecate_task, timeout=5.0)
+        assert rc == 0, f"deprecate_cmd should succeed once lock is released; rc={rc}"
+        # Verify the row landed.
+        count = await conn.fetchval(
+            "SELECT count(*) FROM lease_plane.deprecated_schemes "
+            "WHERE marked_by_session_id = 'test-pr3b-race'"
+        )
+        assert count == 1
+    finally:
+        await _cleanup(conn)
+        await conn.close()


### PR DESCRIPTION
**Stacked on #269** (PR 3a). Targets `impl/lease-plane-phase-a-pr3a-deprecate-cli`; rebase to master after PRs 1/2/2.5/3a merge.

## Summary

Closes the v0.7 PR 1 oversight (Sentinel had no rule keyed on `event_type='forced'`, live-verifier Finding 5 SOURCE_ONLY) and the §7.11.7 race-window integration test deferred from PR 3a.

## RFC gate → code surface → test name → status

| Gate | Code | Test | Status |
|------|------|------|--------|
| §7.10 per-event alarm for ad-hoc `event_type='forced'` | `agents/sentinel/forced_release_alarm.py::_poll_inner` ad-hoc query | `test_sentinel_force_release_alarm_per_event` | ✅ |
| Cursor-based dedup so successive polls don't re-emit | same, ts-filter on cursor | `test_sentinel_force_release_alarm_dedupes_via_cursor` | ✅ |
| §7.11.5 batched alarm for `event_type='lease.deprecation_swept'` | `_poll_inner` batch query + `_batch_alarm` | `test_sentinel_batch_alarm_for_deprecation_sweep` | ✅ |
| §7.11.5 batched alarm waits for `sweep_completed_at IS NOT NULL` | same query (JOIN on `deprecated_schemes` filters partial sweeps) | `test_sentinel_batch_alarm_only_after_sweep_completed_at` | ✅ |
| §7.11.7 Phase 0 race window — full integration test | (covered by PR 3a's `deprecate_cmd` serializable tx + advisory lock; this PR adds the test) | `test_phase_zero_acquire_race_blocked` | ✅ |
| Sentinel cycle wiring | `agents/sentinel/agent.py::_emit_forced_release_alarms` | (transitive) | ✅ |

## Two alarm classes per the RFC

**Per-event** for ad-hoc `event_type='forced'` (RFC §7.10):
- One alarm per forced-release event, severity `high`.
- Rationale: operator-typed force-release is rare enough that per-event auditing is the right signal.

**Batched** for `event_type='lease.deprecation_swept'` (RFC §7.11.5):
- One summary alarm per completed `deprecation_id`, severity `medium`.
- Only fires when `deprecated_schemes.sweep_completed_at IS NOT NULL` (partial sweeps don't fire premature alarms).
- Rationale: bulk sweeps could otherwise fire hundreds of alarms in minutes, drowning the channel.

## Sentinel cycle wiring

- `Sentinel._run_cycle_inner()` now calls `_emit_forced_release_alarms()` at the start of each cycle.
- Cursor state persists via `Sentinel.load_state()/save_state()` under `forced_release_alarm.last_event_ts`.
- DB unreachable degrades gracefully (logged + swept; doesn't break the cycle).
- DB URL from `GOVERNANCE_DATABASE_URL` env (default `postgresql://postgres:postgres@localhost:5432/governance`).
- Polling cadence inherited from existing Sentinel cycle (operator decision 2026-04-30).

## Race-window integration test (deferred from PR 3a)

`test_phase_zero_acquire_race_blocked` opens a separate connection that holds the same advisory lock the CLI's `deprecate_cmd` would acquire (`pg_advisory_xact_lock(hash(kind))`). Verifies:
1. `deprecate_cmd` blocks (hits `asyncio.TimeoutError` at 0.5s) while the holder lock is active.
2. Once holder rolls back, `deprecate_cmd` completes and the row lands.

## Test verification

- **5/5 PR 3b tests GREEN**.
- **7975/7975 full suite GREEN** (+5 vs PR 3a; excluding `tests/resident_progress/` pre-existing master failure unrelated to this PR).

## Test plan
- [ ] `pytest tests/test_sentinel_forced_release_alarm.py -q --no-cov` — 5/5 pass
- [ ] Reviewer applies migrations 026 + 027 + 028 (from PRs 1/3a) to live `governance` DB
- [ ] Reviewer manually runs `deprecation-sweep` against a populated DB and confirms one batched Sentinel alarm fires (not N per-lease alarms)
- [ ] **Operator confirms PRs 1/2/2.5/3a/3b merge as a stack** — partial merge bricks fleet (PR 3b depends on PR 3a's deprecation events, which depend on PR 2.5's resident:/ migration, etc.)

## Out of scope (deferred to PR 4+)
- §7.3.3 `acquire_with_retry()` jittered backoff method
- `_urllib_transport` HTTP-error body-parse coverage
- Phase B prerequisites (payload-shape standardization, `unitares_doctor` extension)