### PR TITLE
feat(lease-plane): Phase A PR 4 — acquire_with_retry + _urllib_transport HTTP-error coverage

### DIFF
--- a/docs/proposals/surface-lease-plane-phase-a-plan.md
+++ b/docs/proposals/surface-lease-plane-phase-a-plan.md
@@ -183,15 +183,33 @@ Scope shipped:
 | §7.11.7 Phase 0 race window — full integration test | (covered by PR 3a's `deprecate_cmd` serializable tx + advisory lock; this PR adds the test) | `test_phase_zero_acquire_race_blocked` | DONE |
 | Sentinel cycle wiring | `agents/sentinel/agent.py::_emit_forced_release_alarms` | (transitively covered — module loads + load_state/save_state + post_finding paths exercised) | DONE |
 
-## PR 4+ — Remaining gates
+## PR 4 — `acquire_with_retry` + `_urllib_transport` HTTP-error coverage (this branch: impl/lease-plane-phase-a-pr4-retry-and-409)
 
-## PR 4+ — Remaining gates
+Closes the last two RFC §9 Phase A test gates that don't depend on Phase B work.
 
-- §7.3.3 `acquire_with_retry()` jittered backoff method
-- §7.3.5 HTTP 409 body-parse test (`test_urllib_transport_parses_409_body`)
-- Phase B prerequisites (payload-shape standardization spec, `unitares_doctor` extension)
+Scope shipped:
+- `LeasePlaneClient.acquire_with_retry()` convenience method (RFC §7.3.3): jittered exponential backoff (floor 100ms, ceiling 5s, full jitter per AWS convention). Honors `retry_after_hint_ms` from the v0.7 §7.3.2 extended `held_by_other` shape as a per-attempt floor. Only `held_by_other` triggers retry; `service_unavailable` / `permission_denied` / `schema_invalid` are terminal.
+- `_urllib_transport` HTTP-error body-parse coverage (RFC §7.3.5): closes live-verifier Finding 9 test-coverage gap. The implementation already correctly parses 409 + body, falls back to `permission_denied` on empty 401/403, and `service_unavailable` on empty 5xx — this PR adds tests proving so.
 
-These are mostly self-contained; pick up after PR 1-3 land.
+### PR 4 — RFC gate → code surface → test name → status table
+
+| Gate | Code | Test | Status |
+|------|------|------|--------|
+| §7.3.3 acquire_with_retry returns OK on first attempt | `src/lease_plane/client.py::LeasePlaneClient.acquire_with_retry` | `test_acquire_with_retry_returns_ok_on_first_attempt` | DONE |
+| §7.3.3 retry on held_by_other until OK | same | `test_acquire_with_retry_retries_on_held_by_other_until_ok` | DONE |
+| §7.3.3 jittered backoff in [100ms, 5s] full jitter | same | `test_acquire_with_retry_jittered_backoff_within_bounds` | DONE |
+| §7.3.3 honors retry_after_hint_ms as per-attempt floor | same | `test_acquire_with_retry_honors_retry_after_hint_as_floor` | DONE |
+| §7.3.3 service_unavailable terminal (no retry) | same | `test_acquire_with_retry_returns_service_unavailable_without_retry` | DONE |
+| §7.3.5 _urllib_transport parses 409 body | `src/lease_plane/client.py::_urllib_transport` HTTPError branch | `test_urllib_transport_parses_409_body` | DONE |
+| §7.3.5 _urllib_transport 401 fallback | same | `test_urllib_transport_401_returns_permission_denied_when_no_body` | DONE |
+| §7.3.5 _urllib_transport 5xx fallback | same | `test_urllib_transport_500_returns_service_unavailable_when_no_body` | DONE |
+
+## PR 5+ — Phase B prerequisites (planned, not yet drafted)
+
+Non-blocking for Phase A; lifts gates surfaced in §9 Phase B prerequisites:
+- Payload-shape standardization pass — commits to writing canonicalized `surface_id` (per §7.12.1) into `audit.tool_usage.payload`, no percent-encoding (per §7.2.8 cross-track).
+- `unitares_doctor.py` extension to lint that no Elixir source mentions a scheme not in the live grammar CHECK.
+- §7.5 `remote_heartbeat` instrumentation (operator action — measure Pi↔Mac heartbeat gap distribution ≥7d before any `remote_heartbeat` Phase B promotion).
 
 ## Reviewer checklist for any Phase A PR
 

--- a/src/lease_plane/client.py
+++ b/src/lease_plane/client.py
@@ -8,6 +8,8 @@ handler paths that would block the anyio task group.
 from __future__ import annotations
 
 import json
+import random
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -112,6 +114,60 @@ class LeasePlaneClient:
     def acquire(self, request: AcquireRequest) -> AcquireResult:
         payload = self._request_json("POST", "/v1/lease/acquire", request.model_dump(mode="json"))
         return _parse_acquire(payload)
+
+    def acquire_with_retry(
+        self,
+        request: AcquireRequest,
+        *,
+        max_attempts: int = 5,
+        floor_s: float = 0.1,
+        ceiling_s: float = 5.0,
+        sleep: Callable[[float], None] | None = None,
+        rng: Callable[[], float] | None = None,
+    ) -> AcquireResult:
+        """Acquire with jittered exponential backoff on `held_by_other`.
+
+        RFC v0.8 §7.3.3 contract: floor 100ms, ceiling 5s, full jitter
+        (per AWS Architecture Blog convention). `retry_after_hint_ms` from
+        the server (set in the §7.3.2 extended typed-absence shape) is
+        honored as a per-attempt floor — the wait is at least that long.
+
+        Terminal results (no retry):
+          - AcquireOk
+          - AcquireServiceUnavailable (advisory escape valve)
+          - AcquirePermissionDenied / AcquireSchemaInvalid (caller bug)
+        Only `held_by_other` triggers retry. After max_attempts, the final
+        held_by_other is returned to the caller.
+
+        Args:
+            max_attempts: total acquire attempts including the first (default 5).
+            floor_s: minimum backoff per attempt (default 0.1s = 100ms).
+            ceiling_s: maximum backoff per attempt (default 5.0s).
+            sleep: injectable sleep for test determinism (default time.sleep).
+            rng: injectable [0,1) random for test determinism (default random.random).
+        """
+        from src.lease_plane import (
+            AcquireHeldByOther,
+            AcquireOk,
+        )
+
+        sleep_fn = sleep or time.sleep
+        rand_fn = rng or random.random
+
+        result: AcquireResult = self.acquire(request)
+        attempt = 1
+        while attempt < max_attempts and isinstance(result, AcquireHeldByOther):
+            # Full-jitter exponential backoff. Cap exponent to avoid overflow.
+            exp_cap = min(2 ** min(attempt - 1, 10) * floor_s, ceiling_s)
+            backoff = rand_fn() * exp_cap
+            backoff = max(backoff, floor_s)
+            # retry_after_hint_ms (server-provided) raises the floor for THIS attempt only.
+            hint_floor = (result.retry_after_hint_ms or 0) / 1000.0
+            backoff = max(backoff, hint_floor)
+            sleep_fn(backoff)
+            result = self.acquire(request)
+            attempt += 1
+        return result
 
     def status(self, surface_id: str) -> StatusResult:
         payload = self._request_json("GET", "/v1/lease/status", None, query={"surface_id": surface_id})

--- a/tests/test_lease_plane_retry_and_transport.py
+++ b/tests/test_lease_plane_retry_and_transport.py
@@ -1,0 +1,243 @@
+"""
+Phase A PR 4 — `acquire_with_retry()` jittered backoff + `_urllib_transport`
+HTTP-error body-parse coverage.
+
+Closes RFC v0.8 §7.3.3 (caller-library retry contract: jittered exponential,
+floor 100ms, ceiling 5s, full jitter) and §7.3.5 (HTTP 409 on `held_by_other`
+with the typed-absence body in the response).
+
+Spec: docs/proposals/surface-lease-plane-v0.md §7.3.3, §7.3.5
+      docs/proposals/surface-lease-plane-phase-a-plan.md PR 4
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from datetime import UTC, datetime, timedelta
+from unittest import mock
+from uuid import UUID, uuid4
+
+import pytest
+
+from src.lease_plane import (
+    AcquireHeldByOther,
+    AcquireOk,
+    AcquireRequest,
+    AcquireServiceUnavailable,
+    LeasePlaneClient,
+)
+from src.lease_plane.client import LeaseHTTPRequest, _urllib_transport
+
+
+# ---------- §7.3.3 acquire_with_retry tests ----------
+
+
+def _ok_lease_payload(holder: UUID) -> dict:
+    """Minimum AcquireOk payload for a transport stub."""
+    now = datetime.now(UTC).replace(microsecond=0)
+    return {
+        "ok": True,
+        "idempotent": False,
+        "drift_warning": [],
+        "lease": {
+            "lease_id": str(uuid4()),
+            "surface_id": "dialectic:/pr4_retry_test",
+            "surface_kind": "dialectic",
+            "holder_agent_uuid": str(holder),
+            "holder_class": "process_instance",
+            "holder_kind": "remote_heartbeat",
+            "heartbeat_required": True,
+            "expires_at": (now + timedelta(seconds=60)).isoformat(),
+            "original_ttl_s": 60,
+            "earned_status": "provisional",
+        },
+    }
+
+
+def _held_by_other_payload(blocking_lease: UUID, hint_ms: int = 1234) -> dict:
+    return {
+        "ok": False,
+        "error": "held_by_other",
+        "surface_id": "dialectic:/pr4_retry_test",
+        "blocking_lease_id": str(blocking_lease),
+        "held_by_uuid": str(uuid4()),
+        "expires_at": (datetime.now(UTC) + timedelta(seconds=10)).isoformat(),
+        "retry_after_hint_ms": hint_ms,
+    }
+
+
+def _make_request(holder: UUID) -> AcquireRequest:
+    return AcquireRequest(
+        surface_id="dialectic:/pr4_retry_test",
+        holder_agent_uuid=holder,
+        holder_class="process_instance",
+        holder_kind="remote_heartbeat",
+        ttl_s=60,
+    )
+
+
+def test_acquire_with_retry_returns_ok_on_first_attempt():
+    """No retry needed when first acquire succeeds."""
+    holder = uuid4()
+    sleeps: list[float] = []
+    payload_iter = iter([_ok_lease_payload(holder)])
+
+    def transport(_req: LeaseHTTPRequest):
+        return next(payload_iter)
+
+    client = LeasePlaneClient(transport=transport)
+    result = client.acquire_with_retry(
+        _make_request(holder), max_attempts=3, sleep=lambda s: sleeps.append(s),
+    )
+    assert isinstance(result, AcquireOk)
+    assert sleeps == []  # no backoff needed
+
+
+def test_acquire_with_retry_retries_on_held_by_other_until_ok():
+    """Retries on held_by_other, eventually returning AcquireOk."""
+    holder = uuid4()
+    sleeps: list[float] = []
+    payloads = [
+        _held_by_other_payload(uuid4()),
+        _held_by_other_payload(uuid4()),
+        _ok_lease_payload(holder),
+    ]
+    payload_iter = iter(payloads)
+
+    def transport(_req: LeaseHTTPRequest):
+        return next(payload_iter)
+
+    client = LeasePlaneClient(transport=transport)
+    result = client.acquire_with_retry(
+        _make_request(holder), max_attempts=5, sleep=lambda s: sleeps.append(s),
+    )
+    assert isinstance(result, AcquireOk)
+    assert len(sleeps) == 2  # two backoffs before the third (successful) attempt
+
+
+def test_acquire_with_retry_jittered_backoff_within_bounds():
+    """Backoff is jittered exponential — floor 100ms, ceiling 5s, full jitter (RFC §7.3.3)."""
+    holder = uuid4()
+    sleeps: list[float] = []
+    # Always return held_by_other so we exhaust attempts and observe all sleeps.
+    payload = _held_by_other_payload(uuid4())
+
+    def transport(_req: LeaseHTTPRequest):
+        return payload
+
+    client = LeasePlaneClient(transport=transport)
+    result = client.acquire_with_retry(
+        _make_request(holder), max_attempts=6, sleep=lambda s: sleeps.append(s),
+    )
+    assert isinstance(result, AcquireHeldByOther), "exhausted retries returns final held_by_other"
+    # Each sleep must be in [0.1, 5.0] (full jitter floor=100ms, ceiling=5s).
+    assert all(0.1 <= s <= 5.0 for s in sleeps), (
+        f"backoff sleeps must be in [0.1, 5.0]; got {sleeps}"
+    )
+    # With max_attempts=6 we expect 5 sleeps (one before each retry).
+    assert len(sleeps) == 5
+
+
+def test_acquire_with_retry_honors_retry_after_hint_as_floor():
+    """retry_after_hint_ms is a server-provided lower bound on backoff."""
+    holder = uuid4()
+    sleeps: list[float] = []
+    payload = _held_by_other_payload(uuid4(), hint_ms=2000)  # server hints 2s minimum
+
+    def transport(_req: LeaseHTTPRequest):
+        return payload
+
+    client = LeasePlaneClient(transport=transport)
+    client.acquire_with_retry(
+        _make_request(holder), max_attempts=3, sleep=lambda s: sleeps.append(s),
+    )
+    # Each sleep should respect the server's 2s lower bound.
+    assert all(s >= 2.0 for s in sleeps), (
+        f"retry_after_hint_ms=2000 must serve as the floor; got {sleeps}"
+    )
+
+
+def test_acquire_with_retry_returns_service_unavailable_without_retry():
+    """service_unavailable is the advisory escape valve — don't retry on it."""
+    holder = uuid4()
+    sleeps: list[float] = []
+
+    def transport(_req: LeaseHTTPRequest):
+        return {"ok": False, "error": "service_unavailable"}
+
+    client = LeasePlaneClient(transport=transport)
+    result = client.acquire_with_retry(
+        _make_request(holder), max_attempts=5, sleep=lambda s: sleeps.append(s),
+    )
+    assert isinstance(result, AcquireServiceUnavailable)
+    assert sleeps == []  # no retries — service_unavailable is terminal for this method
+
+
+# ---------- §7.3.5 _urllib_transport HTTP-error body-parse tests ----------
+
+
+def _http_error(status: int, body_dict: dict | None) -> urllib.error.HTTPError:
+    """Construct a real HTTPError with a JSON body (the failure path
+    `_urllib_transport` was historically uncovered for; live-verifier finding)."""
+    body_bytes = json.dumps(body_dict).encode("utf-8") if body_dict is not None else b""
+    return urllib.error.HTTPError(
+        url="http://stub/v1/lease/acquire",
+        code=status,
+        msg="error",
+        hdrs={},  # type: ignore[arg-type]
+        fp=io.BytesIO(body_bytes),
+    )
+
+
+def test_urllib_transport_parses_409_body():
+    """RFC §7.3.5: HTTP 409 + held_by_other body is parsed and returned as the typed payload."""
+    held_payload = {
+        "ok": False,
+        "error": "held_by_other",
+        "surface_id": "dialectic:/pr4_409_probe",
+        "blocking_lease_id": str(uuid4()),
+        "held_by_uuid": str(uuid4()),
+        "expires_at": datetime.now(UTC).isoformat(),
+        "retry_after_hint_ms": 4500,
+    }
+    request = LeaseHTTPRequest(
+        method="POST", url="http://stub/v1/lease/acquire",
+        json_body={"surface_id": "dialectic:/pr4_409_probe"},
+        headers={}, timeout_s=1.0,
+    )
+    with mock.patch(
+        "urllib.request.urlopen", side_effect=_http_error(409, held_payload),
+    ):
+        result = _urllib_transport(request)
+    assert result == held_payload, (
+        f"_urllib_transport must parse the 409 body verbatim; got {result!r}"
+    )
+
+
+def test_urllib_transport_401_returns_permission_denied_when_no_body():
+    """Empty 401 body falls back to permission_denied envelope."""
+    request = LeaseHTTPRequest(
+        method="POST", url="http://stub/v1/lease/acquire",
+        json_body={}, headers={}, timeout_s=1.0,
+    )
+    with mock.patch(
+        "urllib.request.urlopen", side_effect=_http_error(401, None),
+    ):
+        result = _urllib_transport(request)
+    assert result["ok"] is False
+    assert result["error"] == "permission_denied"
+
+
+def test_urllib_transport_500_returns_service_unavailable_when_no_body():
+    """Empty 5xx body falls back to service_unavailable (advisory escape valve)."""
+    request = LeaseHTTPRequest(
+        method="POST", url="http://stub/v1/lease/acquire",
+        json_body={}, headers={}, timeout_s=1.0,
+    )
+    with mock.patch(
+        "urllib.request.urlopen", side_effect=_http_error(500, None),
+    ):
+        result = _urllib_transport(request)
+    assert result == {"ok": False, "error": "service_unavailable"}


### PR DESCRIPTION
**Stacked on #270** (PR 3b). Targets `impl/lease-plane-phase-a-pr3b-sentinel-alarm`; rebase to master after PRs 1/2/2.5/3a/3b merge.

## Summary

Closes the last two RFC §9 Phase A test gates that don't depend on Phase B work.

## RFC gate → code surface → test name → status

| Gate | Code | Test | Status |
|------|------|------|--------|
| §7.3.3 acquire_with_retry returns OK on first attempt | `LeasePlaneClient.acquire_with_retry` | `test_acquire_with_retry_returns_ok_on_first_attempt` | ✅ |
| §7.3.3 retry on `held_by_other` until OK | same | `test_acquire_with_retry_retries_on_held_by_other_until_ok` | ✅ |
| §7.3.3 jittered backoff in [100ms, 5s] full jitter | same | `test_acquire_with_retry_jittered_backoff_within_bounds` | ✅ |
| §7.3.3 honors `retry_after_hint_ms` as per-attempt floor | same | `test_acquire_with_retry_honors_retry_after_hint_as_floor` | ✅ |
| §7.3.3 `service_unavailable` terminal (no retry) | same | `test_acquire_with_retry_returns_service_unavailable_without_retry` | ✅ |
| §7.3.5 `_urllib_transport` parses 409 body | `_urllib_transport` HTTPError branch | `test_urllib_transport_parses_409_body` | ✅ |
| §7.3.5 401 fallback to `permission_denied` | same | `test_urllib_transport_401_returns_permission_denied_when_no_body` | ✅ |
| §7.3.5 5xx fallback to `service_unavailable` | same | `test_urllib_transport_500_returns_service_unavailable_when_no_body` | ✅ |

## §7.3.3 acquire_with_retry — caller-library jittered exponential backoff

- **Floor 100ms, ceiling 5s, full jitter** (per AWS Architecture Blog convention).
- Honors `retry_after_hint_ms` from v0.7 §7.3.2 extended `held_by_other` shape as a per-attempt floor.
- Only `held_by_other` triggers retry. `service_unavailable` / `permission_denied` / `schema_invalid` are terminal.
- After `max_attempts`, returns the final `held_by_other`.
- Injectable `sleep` + `rng` for test determinism.

## §7.3.5 _urllib_transport HTTP-error body-parse coverage

Closes live-verifier Finding 9 test-coverage gap. The implementation already correctly parses 409 + body, falls back to `permission_denied` on empty 401/403, and `service_unavailable` on empty 5xx — this PR adds tests proving so (3 tests using mocked `urllib.request.urlopen` with real `urllib.error.HTTPError` instances).

## Test verification

- **8/8 PR 4 tests GREEN**.
- **7983/7983 full suite GREEN** (+8 vs PR 3b; excluding `tests/resident_progress/` pre-existing master failure unrelated to this PR).

## Phase A test-gate scoreboard after PR 4

All v0.8 §9 named test gates that don't depend on Phase B prereqs are now **DONE**. PR 5+ covers Phase B prerequisites:
- Payload-shape standardization spec (writes canonicalized `surface_id` to `audit.tool_usage.payload`)
- `unitares_doctor.py` extension to lint that no Elixir source mentions a scheme not in the live grammar CHECK
- §7.5 `remote_heartbeat` instrumentation (operator action — measure Pi↔Mac heartbeat gap distribution ≥7d)

## Test plan
- [ ] `pytest tests/test_lease_plane_retry_and_transport.py -q --no-cov` — 8/8 pass
- [ ] Reviewer manually verifies `acquire_with_retry` honors `retry_after_hint_ms` against a live lease plane (once PR 1/2/2.5 are deployed)
- [ ] **Operator confirms PRs 1/2/2.5/3a/3b/4 merge as a stack** — partial merge is safe for PR 4 (no schema dependency) but the earlier stack still requires atomic landing

## Out of scope (deferred to PR 5+)
- §7.2.8 payload-shape standardization spec
- §7.2.9 `unitares_doctor` lint extension
- §7.5 `remote_heartbeat` instrumentation