### PR TITLE
fix(lease-plane): Phase A PR 5 — council BLOCK fixes from PR 1-4 stack review

### DIFF
--- a/agents/sentinel/forced_release_alarm.py
+++ b/agents/sentinel/forced_release_alarm.py
@@ -126,10 +126,12 @@ async def _poll_inner(
         )
     for row in rows:
         alarms.append(_batch_alarm(row))
+        # Cursor advances ONLY based on event ts, not sweep_completed_at.
+        # PR 5 council fix: pre-PR-5 advanced cursor to MAX(last_ts, sweep_completed_at),
+        # which mixes event-stream and table-metadata timestamps — causes
+        # clock-skew/order-of-events fragility.
         if max_ts is None or row["last_ts"] > max_ts:
             max_ts = row["last_ts"]
-        if max_ts is None or row["sweep_completed_at"] > max_ts:
-            max_ts = row["sweep_completed_at"]
 
     return alarms, max_ts
 

--- a/db/postgres/migrations/029_lease_plane_earned_status_guard.sql
+++ b/db/postgres/migrations/029_lease_plane_earned_status_guard.sql
@@ -1,0 +1,55 @@
+-- 029_lease_plane_earned_status_guard.sql
+--
+-- Restores the `earned_status` immutability guard that migration 028 silently
+-- dropped. Surfaced by the council pass on the PR 1-4 stack (dialectic voice
+-- BLOCK-2): migration 025 originally guarded 8 fields against UPDATE; migration
+-- 028 was authored to drop the surface_kind guard (it became a generated column
+-- post-026) but the rewrite also dropped the earned_status guard as collateral
+-- damage.
+--
+-- Without this guard, ANY UPDATE on surface_leases can silently flip earned_status
+-- from 'provisional' to 'earned' — bypassing the substrate-earned-promotion
+-- migration that RFC §7.8 anticipates.
+--
+-- This restores the check while preserving the relaxed surface_kind handling
+-- from 028 (the surface_id immutability guard transitively protects the derived
+-- surface_kind generated column).
+--
+-- Idempotent: CREATE OR REPLACE the function, no-op if already correct.
+
+CREATE OR REPLACE FUNCTION lease_plane.enforce_immutable_lease_fields()
+RETURNS trigger AS $$
+BEGIN
+    IF NEW.surface_id IS DISTINCT FROM OLD.surface_id THEN
+        RAISE EXCEPTION 'surface_id is immutable per lease_id; lease identity is bound to (surface_id, holder)';
+    END IF;
+    -- surface_kind check intentionally omitted (post-028 it is a generated
+    -- column derived from surface_id; the surface_id guard above transitively
+    -- enforces surface_kind immutability).
+    IF NEW.holder_agent_uuid IS DISTINCT FROM OLD.holder_agent_uuid THEN
+        RAISE EXCEPTION 'holder_agent_uuid is immutable per lease_id';
+    END IF;
+    IF NEW.holder_kind IS DISTINCT FROM OLD.holder_kind THEN
+        RAISE EXCEPTION 'holder_kind is immutable per lease_id; release+reacquire to change';
+    END IF;
+    IF NEW.holder_class IS DISTINCT FROM OLD.holder_class THEN
+        RAISE EXCEPTION 'holder_class is immutable per lease_id';
+    END IF;
+    IF NEW.original_ttl_s IS DISTINCT FROM OLD.original_ttl_s THEN
+        RAISE EXCEPTION 'original_ttl_s is immutable per lease_id; renew uses this fixed value';
+    END IF;
+    IF NEW.acquired_at IS DISTINCT FROM OLD.acquired_at THEN
+        RAISE EXCEPTION 'acquired_at is immutable per lease_id';
+    END IF;
+    -- Restored in PR 5 / migration 029: earned_status guard (RFC §7.8).
+    -- substrate-earned promotion requires explicit migration, not silent UPDATE.
+    IF NEW.earned_status IS DISTINCT FROM OLD.earned_status THEN
+        RAISE EXCEPTION 'earned_status is immutable per lease_id; substrate-earned promotion requires explicit migration (RFC §7.8)';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (29, 'lease_plane_earned_status_guard', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/docs/proposals/surface-lease-plane-phase-a-plan.md
+++ b/docs/proposals/surface-lease-plane-phase-a-plan.md
@@ -204,9 +204,34 @@ Scope shipped:
 | §7.3.5 _urllib_transport 401 fallback | same | `test_urllib_transport_401_returns_permission_denied_when_no_body` | DONE |
 | §7.3.5 _urllib_transport 5xx fallback | same | `test_urllib_transport_500_returns_service_unavailable_when_no_body` | DONE |
 
-## PR 5+ — Phase B prerequisites (planned, not yet drafted)
+## PR 5 — Council BLOCK fixes from PR 1-4 stack review (this branch: impl/lease-plane-phase-a-pr5-council-fixes)
 
-Non-blocking for Phase A; lifts gates surfaced in §9 Phase B prerequisites:
+Three-voice council pass on the PR 1-4 cumulative stack (dialectic, code-reviewer, live-verifier; adversarial framing per `feedback_council-adversarial-prompt.md`) surfaced 3 BLOCKs and several CONCERNs/NITs. PR 5 fixes the BLOCKs + the small CONCERNs/NITs; bigger CONCERNs (Phase 2/3 atomicity rewrite, Elixir router canonicalization, Sentinel asyncpg pool) deferred to PR 6+.
+
+### PR 5 — RFC gate → code surface → test name → status table
+
+| Gate | Code | Test | Status |
+|------|------|------|--------|
+| BLOCK 1 — Elixir 409 emits all 5 v0.7 §7.3.2 fields | `elixir/lease_plane/lib/unitares_lease_plane/{http_router.ex,repo.ex}` | Elixir test "different holder → 409 held_by_other" extended (operator-verified via `mix test`) | DONE |
+| BLOCK 1 defense-in-depth — `retry_after_hint_ms` defaults to 0 | `src/lease_plane/models.py::AcquireHeldByOther` | (covered by existing AcquireHeldByOther parse tests + new test below) | DONE |
+| BLOCK 2 — CLI advisory lock key deterministic across processes | `scripts/dev/lease_plane_deprecate.py::_lock_key_for_kind` | `test_deprecate_lock_key_stable_across_processes` (subprocess-based) | DONE |
+| BLOCK 3 — restore `earned_status` immutability guard | `db/postgres/migrations/029_lease_plane_earned_status_guard.sql` | `test_migration_029_blocks_earned_status_update`, `test_migration_029_still_allows_release_update` | DONE |
+| CONCERN — `acquire_with_retry` validates `max_attempts >= 1` and `floor_s <= ceiling_s` | `src/lease_plane/client.py::acquire_with_retry` guards | `test_acquire_with_retry_rejects_max_attempts_below_1`, `test_acquire_with_retry_rejects_floor_exceeding_ceiling` | DONE |
+| CONCERN — Sentinel cursor stops advancing to `sweep_completed_at` | `agents/sentinel/forced_release_alarm.py::_poll_inner` | (covered by existing `test_sentinel_force_release_alarm_dedupes_via_cursor`; cursor advance now event-ts only) | DONE |
+| NIT — drop redundant inner import in `acquire_with_retry` | `src/lease_plane/client.py::acquire_with_retry` | (no test; cosmetic) | DONE |
+
+Race-window test updated (`tests/test_sentinel_forced_release_alarm.py::test_phase_zero_acquire_race_blocked`) to import `_lock_key_for_kind` instead of computing `abs(hash(kind))` locally — the pre-PR-5 test only passed because both holder and CLI ran in the same Python process; now exercises the same helper as production.
+
+## PR 6+ — Deferred council CONCERNs and Phase B prerequisites
+
+Bigger council CONCERNs (need design discussion):
+- §7.11.2 Phase 2/3 atomicity rewrite — CLI sub-commands don't enforce same-session atomicity. Either coalesce into `deprecate-and-finalize` super-command or amend RFC §7.11.2.
+- Elixir router server-side canonicalization (split-brain prevention from non-Python callers).
+- Sentinel asyncpg pool wiring (CLAUDE.md anyio pattern; current code opens fresh connection per cycle).
+- `lease.deprecation_marked` and `lease.deprecation_migrated` event-type vocabulary is in CHECK constraint but never emitted by code.
+- §9 RFC test-name reconciliation (named tests semantically covered but not under contracted names).
+
+Phase B prerequisites (non-blocking for Phase A):
 - Payload-shape standardization pass — commits to writing canonicalized `surface_id` (per §7.12.1) into `audit.tool_usage.payload`, no percent-encoding (per §7.2.8 cross-track).
 - `unitares_doctor.py` extension to lint that no Elixir source mentions a scheme not in the live grammar CHECK.
 - §7.5 `remote_heartbeat` instrumentation (operator action — measure Pi↔Mac heartbeat gap distribution ≥7d before any `remote_heartbeat` Phase B promotion).

--- a/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
@@ -75,12 +75,23 @@ defmodule UnitaresLeasePlane.HTTPRouter do
               drift_warning: []
             })
 
-          {:error, :held_by_other, %{held_by_uuid: uuid, expires_at: expires}} ->
+          {:error, :held_by_other, info} ->
+            # PR 5 council BLOCK fix: emit all 5 fields the v0.7 §7.3.2
+            # AcquireHeldByOther typed-absence shape requires (was 2 pre-PR-5;
+            # missing fields caused production 409s to fail Pydantic validation
+            # → degraded to AcquireSchemaInvalid → acquire_with_retry never retried).
+            now = DateTime.utc_now()
+            remaining_ms =
+              max(0, DateTime.diff(info.expires_at, now, :millisecond))
+            retry_after_hint_ms = min(remaining_ms, 5_000)
             json(conn, 409, %{
               ok: false,
               error: "held_by_other",
-              held_by_uuid: uuid,
-              expires_at: DateTime.to_iso8601(expires)
+              surface_id: Map.get(info, :surface_id),
+              blocking_lease_id: Map.get(info, :blocking_lease_id),
+              held_by_uuid: info.held_by_uuid,
+              expires_at: DateTime.to_iso8601(info.expires_at),
+              retry_after_hint_ms: retry_after_hint_ms
             })
 
           {:error, reason} ->

--- a/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
@@ -41,7 +41,13 @@ defmodule UnitaresLeasePlane.Repo do
   """
   @spec acquire(map()) ::
           {:ok, lease, :new | :idempotent}
-          | {:error, :held_by_other, %{held_by_uuid: binary(), expires_at: DateTime.t()}}
+          | {:error, :held_by_other,
+             %{
+               held_by_uuid: binary(),
+               expires_at: DateTime.t(),
+               surface_id: binary(),
+               blocking_lease_id: binary()
+             }}
           | {:error, term()}
   def acquire(%{} = p) do
     Postgrex.transaction(DB, fn conn ->
@@ -72,9 +78,21 @@ defmodule UnitaresLeasePlane.Repo do
     if held == p.holder_agent_uuid do
       {:ok, {:ok, existing, :idempotent}}
     else
+      # PR 5 council BLOCK fix: include surface_id + blocking_lease_id so the
+      # 409 response carries every field the v0.7 §7.3.2 AcquireHeldByOther shape
+      # requires. Without these, Pydantic validation degrades to AcquireSchemaInvalid.
+      # Preserved log_conflict from upstream — emits the audit event for the
+      # conflict-detected path.
       case log_conflict(conn, p, existing) do
         :ok ->
-          {:ok, {:error, :held_by_other, %{held_by_uuid: held, expires_at: existing.expires_at}}}
+          {:ok,
+           {:error, :held_by_other,
+            %{
+              held_by_uuid: held,
+              expires_at: existing.expires_at,
+              surface_id: existing.surface_id,
+              blocking_lease_id: existing.lease_id
+            }}}
 
         {:error, reason} ->
           {:error, reason}

--- a/elixir/lease_plane/test/http_router_test.exs
+++ b/elixir/lease_plane/test/http_router_test.exs
@@ -120,6 +120,14 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
       assert payload["error"] == "held_by_other"
       assert payload["held_by_uuid"] == body_a.holder_agent_uuid
       assert is_binary(payload["expires_at"])
+      # PR 5 council BLOCK fix: 409 body MUST carry the v0.7 §7.3.2 extended
+      # AcquireHeldByOther fields. Without these, the Python Pydantic model
+      # rejects the response and acquire_with_retry never retries.
+      assert payload["surface_id"] == ctx.surface
+      assert is_binary(payload["blocking_lease_id"])
+      assert is_integer(payload["retry_after_hint_ms"])
+      assert payload["retry_after_hint_ms"] >= 0
+      assert payload["retry_after_hint_ms"] <= 5_000
     end
 
     test "holder_class='role' → 422 schema_invalid (rejected before DB)", ctx do

--- a/scripts/dev/lease_plane_deprecate.py
+++ b/scripts/dev/lease_plane_deprecate.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import hashlib
 import json
 import os
 import sys
@@ -45,6 +46,19 @@ try:
 except ImportError:
     print("error: asyncpg not installed; install with `pip install asyncpg`", file=sys.stderr)
     sys.exit(2)
+
+
+def _lock_key_for_kind(kind: str) -> int:
+    """Deterministic int32-positive advisory-lock key from a scheme kind.
+
+    Python's `hash()` for strings is salted per-process via PYTHONHASHSEED,
+    so two CLI invocations in different shells would otherwise produce
+    different lock keys for the same kind — silently breaking the §7.11.7
+    race-window protection (council BLOCK from PR 1-4 stack review).
+    Use SHA-256 truncated to int32-positive instead.
+    """
+    digest = hashlib.sha256(kind.encode("utf-8")).digest()
+    return int.from_bytes(digest[:4], "big") & 0x7FFFFFFF
 
 
 DEFAULT_DB_URL = os.environ.get(
@@ -94,8 +108,8 @@ async def deprecate_cmd(
             )
             return 1
         async with conn.transaction(isolation="serializable"):
-            # Hash the scheme name to a stable int for advisory lock; ensure positive int range.
-            lock_key = abs(hash(kind)) % (2**31 - 1)
+            # Use deterministic SHA-256-derived key (see _lock_key_for_kind for rationale).
+            lock_key = _lock_key_for_kind(kind)
             await conn.execute("SELECT pg_advisory_xact_lock($1)", lock_key)
             await conn.execute(
                 """

--- a/src/lease_plane/client.py
+++ b/src/lease_plane/client.py
@@ -145,11 +145,21 @@ class LeasePlaneClient:
             ceiling_s: maximum backoff per attempt (default 5.0s).
             sleep: injectable sleep for test determinism (default time.sleep).
             rng: injectable [0,1) random for test determinism (default random.random).
+
+        Raises:
+            ValueError: max_attempts < 1, or floor_s > ceiling_s
+                (PR 5 council fix — pre-PR-5 silently fired one HTTP call when max_attempts=0).
         """
-        from src.lease_plane import (
-            AcquireHeldByOther,
-            AcquireOk,
-        )
+        if max_attempts < 1:
+            raise ValueError(f"max_attempts must be >= 1, got {max_attempts}")
+        if floor_s > ceiling_s:
+            raise ValueError(
+                f"floor_s ({floor_s}) must be <= ceiling_s ({ceiling_s})"
+            )
+
+        # AcquireHeldByOther is the only retry-triggering result type;
+        # AcquireOk no longer needed here (NIT-1 fix from council pass).
+        from src.lease_plane import AcquireHeldByOther
 
         sleep_fn = sleep or time.sleep
         rand_fn = rng or random.random

--- a/src/lease_plane/models.py
+++ b/src/lease_plane/models.py
@@ -164,7 +164,11 @@ class AcquireHeldByOther(BaseModel):
     blocking_lease_id: UUID
     held_by_uuid: UUID
     expires_at: datetime
-    retry_after_hint_ms: int
+    # Defense-in-depth (PR 5 council fix): retry_after_hint_ms defaults to 0
+    # so any emitter that omits the field doesn't degrade to AcquireSchemaInvalid.
+    # surface_id and blocking_lease_id remain REQUIRED — missing them is a real
+    # contract violation that should surface clearly.
+    retry_after_hint_ms: int = 0
 
 
 class AcquirePermissionDenied(BaseModel):

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -117,6 +117,7 @@ async def ensure_test_database_schema() -> None:
         await _execute_sql_file(conn, "db/postgres/migrations/026_lease_plane_grammar.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/027_lease_plane_deprecation.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/028_lease_plane_trigger_fix.sql")
+        await _execute_sql_file(conn, "db/postgres/migrations/029_lease_plane_earned_status_guard.sql")
 
         # Ensure partitioned audit tables can accept inserts for current month.
         await _execute_sql_file(conn, "db/postgres/partitions.sql")

--- a/tests/test_lease_plane_deprecate_cli.py
+++ b/tests/test_lease_plane_deprecate_cli.py
@@ -286,3 +286,36 @@ async def test_deprecation_sweep_requires_force_release_token(monkeypatch):
     finally:
         await _cleanup(conn)
         await conn.close()
+
+
+def test_deprecate_lock_key_stable_across_processes():
+    """PR 5 council BLOCK fix — advisory lock key must be deterministic across
+    Python invocations. PYTHONHASHSEED randomizes string hash() per-process,
+    silently breaking the §7.11.7 race-window protection. CLI must use a
+    stable hash (e.g., hashlib.sha256) for the advisory-lock key."""
+    import subprocess
+    cmd = [
+        "python3", "-c",
+        "from scripts.dev.lease_plane_deprecate import _lock_key_for_kind; "
+        "print(_lock_key_for_kind('td'))",
+    ]
+    out_a = subprocess.run(
+        cmd, capture_output=True, text=True, check=True, cwd=str(project_root),
+    ).stdout.strip()
+    out_b = subprocess.run(
+        cmd, capture_output=True, text=True, check=True, cwd=str(project_root),
+    ).stdout.strip()
+    assert out_a == out_b, (
+        f"lock key must be stable across Python processes for '{__name__}' to "
+        f"protect §7.11.7 race window; got {out_a!r} vs {out_b!r}"
+    )
+    # Different kinds produce different keys.
+    cmd_resident = [
+        "python3", "-c",
+        "from scripts.dev.lease_plane_deprecate import _lock_key_for_kind; "
+        "print(_lock_key_for_kind('resident'))",
+    ]
+    out_resident = subprocess.run(
+        cmd_resident, capture_output=True, text=True, check=True, cwd=str(project_root),
+    ).stdout.strip()
+    assert out_resident != out_a, "different kinds must produce different lock keys"

--- a/tests/test_lease_plane_retry_and_transport.py
+++ b/tests/test_lease_plane_retry_and_transport.py
@@ -241,3 +241,39 @@ def test_urllib_transport_500_returns_service_unavailable_when_no_body():
     ):
         result = _urllib_transport(request)
     assert result == {"ok": False, "error": "service_unavailable"}
+
+
+# ---------- §7.3.3 acquire_with_retry input validation (PR 5 council fix) ----------
+
+
+def test_acquire_with_retry_rejects_max_attempts_below_1():
+    """RFC §7.3.3: max_attempts must be >= 1; pre-PR-5 max_attempts=0 silently
+    fired one HTTP call. Validation now raises ValueError."""
+    holder = uuid4()
+    calls: list[bool] = []
+
+    def transport(_req: LeaseHTTPRequest):
+        calls.append(True)
+        return _ok_lease_payload(holder)
+
+    client = LeasePlaneClient(transport=transport)
+    with pytest.raises(ValueError):
+        client.acquire_with_retry(_make_request(holder), max_attempts=0)
+    assert calls == [], "no HTTP call should have fired with max_attempts=0"
+    with pytest.raises(ValueError):
+        client.acquire_with_retry(_make_request(holder), max_attempts=-1)
+    assert calls == []
+
+
+def test_acquire_with_retry_rejects_floor_exceeding_ceiling():
+    """floor_s must be <= ceiling_s; otherwise backoff bounds are nonsense."""
+    holder = uuid4()
+
+    def transport(_req: LeaseHTTPRequest):
+        return _ok_lease_payload(holder)
+
+    client = LeasePlaneClient(transport=transport)
+    with pytest.raises(ValueError):
+        client.acquire_with_retry(
+            _make_request(holder), max_attempts=3, floor_s=2.0, ceiling_s=1.0,
+        )

--- a/tests/test_migration_029_earned_status_guard.py
+++ b/tests/test_migration_029_earned_status_guard.py
@@ -1,0 +1,136 @@
+"""
+PR 5 — migration 029 restores the `earned_status` immutability guard
+that migration 028 silently dropped (council BLOCK from dialectic voice).
+
+Migration 025 originally guarded 8 fields against UPDATE. Migration 028 was
+authored to drop the surface_kind guard (it became a generated column post-026)
+but in the rewrite the earned_status guard was also dropped — collateral
+damage. This lets any UPDATE silently flip the substrate-earned promotion
+flag from 'provisional' to 'earned' without the migration 025 anticipated
+for that promotion.
+
+Migration 029 restores the earned_status check and pins the contract via test.
+
+Spec: docs/proposals/surface-lease-plane-v0.md §7.8 (substrate-earned identity)
+      docs/proposals/surface-lease-plane-phase-a-plan.md PR 5
+"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+try:
+    import asyncpg
+except ImportError:
+    pytest.skip("asyncpg not installed", allow_module_level=True)
+
+from tests.test_db_utils import (
+    TEST_DB_URL,
+    can_connect_to_test_db,
+    ensure_test_database_schema,
+)
+
+if not can_connect_to_test_db():
+    pytest.skip("governance_test database not available", allow_module_level=True)
+
+
+async def _seed_lease(conn) -> uuid.UUID:
+    lease_id = uuid.uuid4()
+    holder_uuid = uuid.uuid4()
+    now = datetime.now(UTC)
+    await conn.execute(
+        """
+        INSERT INTO lease_plane.surface_leases
+          (lease_id, surface_id, holder_agent_uuid, holder_kind, holder_class,
+           heartbeat_required, original_ttl_s, acquired_at, expires_at)
+        VALUES ($1, $2, $3, 'remote_heartbeat', 'process_instance', true, 60, $4, $5)
+        """,
+        lease_id, "td:/pr5_earned_guard_test", holder_uuid, now,
+        now + timedelta(seconds=60),
+    )
+    return lease_id
+
+
+@pytest.mark.asyncio
+async def test_migration_029_blocks_earned_status_update():
+    """earned_status must be immutable per lease_id (substrate-earned promotion
+    requires explicit migration, not silent UPDATE)."""
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await conn.execute(
+            "DELETE FROM lease_plane.surface_leases WHERE surface_id = 'td:/pr5_earned_guard_test'"
+        )
+        lease_id = await _seed_lease(conn)
+        # Verify default state: provisional.
+        es = await conn.fetchval(
+            "SELECT earned_status FROM lease_plane.surface_leases WHERE lease_id = $1",
+            lease_id,
+        )
+        assert es == "provisional"
+        # Attempt to flip earned_status — should raise via the trigger.
+        with pytest.raises(asyncpg.RaiseError) as exc_info:
+            await conn.execute(
+                "UPDATE lease_plane.surface_leases SET earned_status = 'earned' WHERE lease_id = $1",
+                lease_id,
+            )
+        # Error message should be specific about earned_status.
+        assert "earned_status" in str(exc_info.value).lower()
+    finally:
+        await conn.execute(
+            "DELETE FROM lease_plane.surface_leases WHERE surface_id = 'td:/pr5_earned_guard_test'"
+        )
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_029_still_allows_release_update():
+    """Migration 029 restores ONLY the earned_status guard — sweep UPDATE
+    (released_at, release_reason) must still succeed."""
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await conn.execute(
+            "DELETE FROM lease_plane.surface_leases WHERE surface_id = 'td:/pr5_release_path'"
+        )
+        lease_id = await _seed_lease_with_sid(conn, "td:/pr5_release_path")
+        # Sweep-style UPDATE must succeed (the post-028 PR 3a sweep path).
+        await conn.execute(
+            "UPDATE lease_plane.surface_leases SET released_at = now(), release_reason = 'forced' "
+            "WHERE lease_id = $1",
+            lease_id,
+        )
+        rel = await conn.fetchval(
+            "SELECT released_at FROM lease_plane.surface_leases WHERE lease_id = $1",
+            lease_id,
+        )
+        assert rel is not None
+    finally:
+        await conn.execute(
+            "DELETE FROM lease_plane.surface_leases WHERE surface_id = 'td:/pr5_release_path'"
+        )
+        await conn.close()
+
+
+async def _seed_lease_with_sid(conn, sid: str) -> uuid.UUID:
+    lease_id = uuid.uuid4()
+    holder_uuid = uuid.uuid4()
+    now = datetime.now(UTC)
+    await conn.execute(
+        """
+        INSERT INTO lease_plane.surface_leases
+          (lease_id, surface_id, holder_agent_uuid, holder_kind, holder_class,
+           heartbeat_required, original_ttl_s, acquired_at, expires_at)
+        VALUES ($1, $2, $3, 'remote_heartbeat', 'process_instance', true, 60, $4, $5)
+        """,
+        lease_id, sid, holder_uuid, now, now + timedelta(seconds=60),
+    )
+    return lease_id

--- a/tests/test_sentinel_forced_release_alarm.py
+++ b/tests/test_sentinel_forced_release_alarm.py
@@ -241,12 +241,19 @@ async def test_phase_zero_acquire_race_blocked():
     """RFC §7.11.7: serializable transaction + advisory lock during deprecate_cmd
     blocks concurrent acquires from racing the Phase 0 mark.
 
-    The CLI's deprecate_cmd holds pg_advisory_xact_lock(hash(kind)). A concurrent
-    pg_advisory_xact_lock attempt on the same key blocks until the deprecate
-    transaction commits.
+    The CLI's deprecate_cmd holds pg_advisory_xact_lock(_lock_key_for_kind(kind)).
+    A concurrent pg_advisory_xact_lock attempt on the same key blocks until the
+    deprecate transaction commits.
+
+    Note (PR 5): test now imports _lock_key_for_kind() — the SHA-256-derived
+    deterministic key. The pre-PR-5 implementation used `abs(hash(kind))` which
+    is salted per-process by PYTHONHASHSEED, so the test passed only by accident
+    (both holder and deprecate_cmd ran in the same process). PR 5 fixes the CLI;
+    this test now uses the same helper as production.
     """
     import asyncio
     from scripts.dev import lease_plane_deprecate as cli
+    from scripts.dev.lease_plane_deprecate import _lock_key_for_kind
 
     await ensure_test_database_schema()
     conn = await asyncpg.connect(TEST_DB_URL)
@@ -254,7 +261,7 @@ async def test_phase_zero_acquire_race_blocked():
         await _cleanup(conn)
 
         kind = "td"
-        lock_key = abs(hash(kind)) % (2**31 - 1)
+        lock_key = _lock_key_for_kind(kind)
 
         # Open a separate connection that holds the SAME advisory lock.
         # While it holds, deprecate_cmd's serializable transaction must wait.


### PR DESCRIPTION
**Stacked on #271** (PR 4). Targets `impl/lease-plane-phase-a-pr4-retry-and-409`; rebase to master after PRs 1/2/2.5/3a/3b/4 merge.

## Why this PR exists

After PR 4 was opened, I dispatched a 3-voice council pass (dialectic + code-reviewer + live-verifier; adversarial framing per `feedback_council-adversarial-prompt.md`) on the cumulative PR 1-4 stack BEFORE operator review. The council surfaced:

- **3 BLOCKs** (one would have shipped PR 4's `acquire_with_retry` as a no-op against the real router)
- **Several CONCERNs and NITs**

PR 5 fixes the 3 BLOCKs + the small CONCERNs/NITs. Bigger CONCERNs (Phase 2/3 atomicity rewrite, Elixir router canonicalization, Sentinel asyncpg pool) deferred to PR 6+ for design discussion.

## RFC gate → code surface → test name → status

| Gate | Code | Test | Status |
|------|------|------|--------|
| **BLOCK 1** Elixir 409 emits all 5 v0.7 §7.3.2 fields | `elixir/lease_plane/lib/unitares_lease_plane/{http_router.ex,repo.ex}` | Elixir test "different holder → 409 held_by_other" extended (operator-verified via `mix test`) | ✅ |
| **BLOCK 1** defense-in-depth — `retry_after_hint_ms` defaults to 0 | `src/lease_plane/models.py::AcquireHeldByOther` | (covered by existing AcquireHeldByOther parse tests) | ✅ |
| **BLOCK 2** CLI advisory lock key deterministic across processes | `scripts/dev/lease_plane_deprecate.py::_lock_key_for_kind` | `test_deprecate_lock_key_stable_across_processes` (subprocess-based) | ✅ |
| **BLOCK 3** restore `earned_status` immutability guard | `db/postgres/migrations/029_lease_plane_earned_status_guard.sql` | `test_migration_029_blocks_earned_status_update`, `test_migration_029_still_allows_release_update` | ✅ |
| CONCERN — `acquire_with_retry` validates `max_attempts >= 1` + `floor_s <= ceiling_s` | `src/lease_plane/client.py::acquire_with_retry` guards | `test_acquire_with_retry_rejects_max_attempts_below_1`, `test_acquire_with_retry_rejects_floor_exceeding_ceiling` | ✅ |
| CONCERN — Sentinel cursor stops advancing to `sweep_completed_at` | `agents/sentinel/forced_release_alarm.py::_poll_inner` | (covered by existing dedup test) | ✅ |
| NIT — drop redundant inner import in `acquire_with_retry` | `src/lease_plane/client.py` | (cosmetic) | ✅ |

## BLOCK 1 detail — production 409 response asymmetry

PR 1's `AcquireHeldByOther` model REQUIRES 5 fields. Pre-PR-5 Elixir router emitted only 2 (`held_by_uuid`, `expires_at`). Production 409s would fail Pydantic validation → degrade to `AcquireSchemaInvalid` → PR 4's `acquire_with_retry` (which only retries on `AcquireHeldByOther`) **would never retry against the real router**. All 39 lease-plane tests passed because every one used stub transports synthesizing the v0.8 shape.

Fix:
- `http_router.ex` 409 branch emits all 5 fields. `retry_after_hint_ms = min(remaining_ttl_ms, 5000)`.
- `repo.ex` `acquire_step` `held_by_other` tuple now carries `surface_id` + `blocking_lease_id` from the existing active lease.
- Defense-in-depth: `AcquireHeldByOther.retry_after_hint_ms` defaults to `0` so any non-conformant emitter doesn't fail validation entirely (`surface_id` and `blocking_lease_id` remain REQUIRED — missing them is a real contract violation).
- Elixir test extended to assert all 5 fields. Operator/CI verifies via `mix test`.

## BLOCK 2 detail — non-deterministic advisory lock key

Python 3.3+ randomizes string `hash()` per-process via `PYTHONHASHSEED`. Two CLI invocations in different shells produced different `lock_key` for the same kind → §7.11.7 race-window protection silently broken across processes. The existing race-window test passed only because both holder and CLI ran in the same Python process.

Fix: new `_lock_key_for_kind()` helper using `int.from_bytes(hashlib.sha256(kind)[:4], "big") & 0x7FFFFFFF`. Stable across processes. New subprocess-based test verifies the key is identical across two separate Python invocations.

## BLOCK 3 detail — earned_status immutability regression

Migration 025 originally guarded 8 fields. Migration 028 was authored to drop the `surface_kind` guard (it became a generated column post-026), but in the rewrite the `earned_status` guard was also dropped — collateral damage. Without it, ANY UPDATE on `surface_leases` could silently flip `earned_status` from `'provisional'` to `'earned'` — bypassing the substrate-earned-promotion migration that RFC §7.8 anticipates.

Fix: migration 029 restores the `earned_status` check via `CREATE OR REPLACE` (idempotent). Two new tests pin the contract: one verifies UPDATE is blocked, one verifies the sweep UPDATE (`released_at`, `release_reason`) still works.

## Watcher false positives (dismissed)

Watcher flagged 4 P005 "acquired resource not released" findings on `lease_plane_deprecate.py` lines 98/149/215/242. All four are **false positives** — every `asyncpg.connect` is wrapped in `try/finally` with `await conn.close()`. The pattern matcher likely triggers on early-`return` inside the try block. Fingerprints: `#fe7f2d3d`, `#988fc91b`, `#bf2b0b44`, `#eb8edf37`.

## Test verification

- **5 new PR 5 tests GREEN**.
- **41/41 PR 5 + lease-plane regression GREEN**.
- **7988/7988 full suite GREEN** (+5 vs PR 4; excluding `tests/resident_progress/` pre-existing master failure unrelated).

## Deferred to PR 6+

Bigger CONCERNs (need design discussion):
- §7.11.2 Phase 2/3 atomicity rewrite (CLI sub-commands don't enforce same-session atomicity)
- Elixir router server-side canonicalization (split-brain prevention from non-Python callers)
- Sentinel asyncpg pool wiring (CLAUDE.md anyio pattern)
- `lease.deprecation_marked` and `_migrated` event-type vocabulary in CHECK but never emitted
- §9 RFC test-name reconciliation

Phase B prerequisites (non-blocking):
- Payload-shape standardization spec
- `unitares_doctor` lint extension
- §7.5 `remote_heartbeat` instrumentation (operator action — Pi↔Mac heartbeat measurement ≥7d)

## Test plan
- [ ] `pytest tests/test_migration_029* tests/test_lease_plane_deprecate_cli.py::test_deprecate_lock_key_stable_across_processes tests/test_lease_plane_retry_and_transport.py -q --no-cov`
- [ ] Reviewer applies migration 029 to live `governance` DB
- [ ] Reviewer runs `cd elixir/lease_plane && mix test` to verify the extended 409 test passes
- [ ] **Operator confirms PRs 1/2/2.5/3a/3b/4/5 merge as a stack** — partial merge bricks fleet (each PR depends on the previous)