### PR TITLE
fix(lease-plane): Phase A PR 6 — emit lease.deprecation_marked + _migrated events

### DIFF
--- a/agents/chronicler/agent.py
+++ b/agents/chronicler/agent.py
@@ -172,9 +172,9 @@ class ChroniclerAgent(GovernanceAgent):
         """
         from src.lease_plane.advisory import lease_advisory_scope, new_holder_uuid
 
+        # Migrated from "chronicler:scrape" → "resident:/chronicler_scrape" per RFC v0.8 §7.2.1.
         with lease_advisory_scope(
-            surface_id="chronicler:scrape",
-            surface_kind="chronicler_scrape",
+            surface_id="resident:/chronicler_scrape",
             holder_agent_uuid=new_holder_uuid(),
             ttl_s=120,
             intent="chronicler daily scrape",

--- a/agents/sentinel/agent.py
+++ b/agents/sentinel/agent.py
@@ -497,9 +497,9 @@ class SentinelAgent(GovernanceAgent):
         """
         from src.lease_plane.advisory import lease_advisory_scope, new_holder_uuid
 
+        # Migrated from "sentinel:cycle" → "resident:/sentinel_cycle" per RFC v0.8 §7.2.1.
         with lease_advisory_scope(
-            surface_id="sentinel:cycle",
-            surface_kind="sentinel_cycle",
+            surface_id="resident:/sentinel_cycle",
             holder_agent_uuid=new_holder_uuid(),
             ttl_s=300,
             intent="sentinel analysis cycle",

--- a/agents/sentinel/agent.py
+++ b/agents/sentinel/agent.py
@@ -508,6 +508,9 @@ class SentinelAgent(GovernanceAgent):
 
     async def _run_cycle_inner(self) -> CycleResult | None:
         self._cycle_count += 1
+        # Poll forced-release alarms (RFC v0.8 §7.10 + §7.11.5).
+        # Wrapped in try/except so DB unreachable doesn't break the cycle.
+        await self._emit_forced_release_alarms()
         findings = self.fleet.analyze(self_agent_id=self.agent_uuid or "")
         fleet = self.fleet.fleet_summary()
 
@@ -575,6 +578,56 @@ class SentinelAgent(GovernanceAgent):
             confidence=confidence,
             response_mode="compact",
         )
+
+    async def _emit_forced_release_alarms(self) -> None:
+        """Poll lease_plane_events for forced-release alarms; emit findings.
+
+        State: stores last_event_ts as ISO8601 string under
+        `forced_release_alarm.last_event_ts` so successive cycles don't
+        re-emit alarms for already-seen events.
+
+        DB URL: GOVERNANCE_DATABASE_URL env var, default to localhost governance.
+        Failures are logged and swallowed — alarm polling MUST NOT break the
+        Sentinel cycle.
+        """
+        from datetime import datetime
+        from agents.sentinel.forced_release_alarm import poll_forced_release_alarms
+
+        db_url = os.environ.get(
+            "GOVERNANCE_DATABASE_URL",
+            "postgresql://postgres:postgres@localhost:5432/governance",
+        )
+        state = self.load_state()
+        cursor_str = state.get("forced_release_alarm", {}).get("last_event_ts")
+        cursor = datetime.fromisoformat(cursor_str) if cursor_str else None
+        try:
+            alarms, new_cursor = await poll_forced_release_alarms(
+                db_url=db_url, last_event_ts=cursor,
+            )
+        except Exception as e:
+            log(f"forced-release alarm poll failed: {e}")
+            return
+
+        for alarm in alarms:
+            severity_tag = alarm.severity.upper()
+            log(f"FORCED-RELEASE ALARM: [{severity_tag}] {alarm.summary}")
+            if alarm.severity == "high":
+                notify("Sentinel forced-release", alarm.summary)
+            post_finding(
+                event_type="sentinel_forced_release_alarm",
+                severity=alarm.severity,
+                message=alarm.summary,
+                agent_id=self.agent_uuid or "sentinel",
+                agent_name="Sentinel",
+                fingerprint=alarm.fingerprint,
+                extra={"alarm_kind": alarm.kind, **alarm.extra},
+            )
+
+        if new_cursor is not None and new_cursor != cursor:
+            state.setdefault("forced_release_alarm", {})["last_event_ts"] = (
+                new_cursor.isoformat()
+            )
+            self.save_state(state)
 
     async def on_after_checkin(
         self, client: GovernanceClient, checkin_result: CheckinResult, cycle_result: CycleResult,

--- a/agents/sentinel/forced_release_alarm.py
+++ b/agents/sentinel/forced_release_alarm.py
@@ -126,10 +126,12 @@ async def _poll_inner(
         )
     for row in rows:
         alarms.append(_batch_alarm(row))
+        # Cursor advances ONLY based on event ts, not sweep_completed_at.
+        # PR 5 council fix: pre-PR-5 advanced cursor to MAX(last_ts, sweep_completed_at),
+        # which mixes event-stream and table-metadata timestamps — causes
+        # clock-skew/order-of-events fragility.
         if max_ts is None or row["last_ts"] > max_ts:
             max_ts = row["last_ts"]
-        if max_ts is None or row["sweep_completed_at"] > max_ts:
-            max_ts = row["sweep_completed_at"]
 
     return alarms, max_ts
 

--- a/agents/sentinel/forced_release_alarm.py
+++ b/agents/sentinel/forced_release_alarm.py
@@ -1,0 +1,174 @@
+"""
+Sentinel forced-release alarm rule (RFC v0.8 §7.10 + §7.11.5).
+
+Polls `lease_plane.lease_plane_events` for two distinct event classes:
+
+  - Ad-hoc forced releases (`event_type='forced'`): one alarm per event.
+    Per RFC §7.10 alarm-on-every-event semantic — operator-typed force-release
+    is rare enough that per-event auditing is the right signal.
+
+  - Deprecation sweeps (`event_type='lease.deprecation_swept'`): batched
+    alarms grouped by `deprecation_id`, one summary per completed batch.
+    Per RFC §7.11.5 batch suppression — bulk sweeps could otherwise fire
+    hundreds of alarms in minutes, drowning the channel.
+
+Cursor state: callers persist `last_event_ts` so successive polls don't
+re-emit alarms for already-seen events.
+
+Authority: this module is read-only on `lease_plane.lease_plane_events`
+and `lease_plane.deprecated_schemes`. It does NOT write to either table.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+try:
+    import asyncpg
+except ImportError:  # pragma: no cover — surfaces at first call site
+    asyncpg = None  # type: ignore
+
+
+@dataclass
+class ForcedReleaseAlarm:
+    """One alarm produced by `poll_forced_release_alarms`.
+
+    `kind` is `"ad_hoc"` (per-event for `event_type='forced'`) or
+    `"deprecation_batch"` (one per completed deprecation_id).
+    `extra` carries the discriminator fields (event_id, lease_id, surface_id,
+    or deprecation_id + count) used for fingerprinting and downstream display.
+    """
+
+    kind: str  # "ad_hoc" | "deprecation_batch"
+    severity: str  # "high" | "medium"
+    summary: str
+    fingerprint: str
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+async def poll_forced_release_alarms(
+    *,
+    db_url: str,
+    last_event_ts: datetime | None,
+) -> tuple[list[ForcedReleaseAlarm], datetime | None]:
+    """Return (alarms, new_cursor) since the previous poll.
+
+    Args:
+        db_url: PostgreSQL connection URL for the governance DB.
+        last_event_ts: timestamp of the last event seen in the prior poll;
+                       `None` on first run (poll everything).
+
+    Returns:
+        (alarms, new_cursor): list of alarms to emit; new cursor for state.
+        new_cursor is the max(ts) across all events seen this poll, or
+        last_event_ts unchanged if no new events.
+    """
+    if asyncpg is None:
+        raise RuntimeError("asyncpg required for poll_forced_release_alarms")
+
+    conn = await asyncpg.connect(db_url)
+    try:
+        return await _poll_inner(conn, last_event_ts)
+    finally:
+        await conn.close()
+
+
+async def _poll_inner(
+    conn, last_event_ts: datetime | None,
+) -> tuple[list[ForcedReleaseAlarm], datetime | None]:
+    alarms: list[ForcedReleaseAlarm] = []
+    max_ts = last_event_ts
+
+    # 1. Ad-hoc forced events: one alarm per event.
+    ad_hoc_query = """
+        SELECT event_id, ts, lease_id, surface_id, surface_kind, payload
+        FROM lease_plane.lease_plane_events
+        WHERE event_type = 'forced'
+        {ts_filter}
+        ORDER BY ts
+    """
+    if last_event_ts is None:
+        rows = await conn.fetch(ad_hoc_query.format(ts_filter=""))
+    else:
+        rows = await conn.fetch(
+            ad_hoc_query.format(ts_filter="AND ts > $1"), last_event_ts,
+        )
+    for row in rows:
+        alarms.append(_ad_hoc_alarm(row))
+        if max_ts is None or row["ts"] > max_ts:
+            max_ts = row["ts"]
+
+    # 2. Deprecation sweep batches: group by deprecation_id, one alarm per
+    #    completed batch (sweep_completed_at IS NOT NULL).
+    batch_query = """
+        SELECT
+            ds.deprecation_id, ds.surface_kind, ds.sweep_completed_at,
+            count(e.event_id) AS event_count,
+            min(e.ts) AS first_ts, max(e.ts) AS last_ts
+        FROM lease_plane.lease_plane_events e
+        JOIN lease_plane.deprecated_schemes ds
+          ON ds.deprecation_id::text = e.payload->>'deprecation_id'
+        WHERE e.event_type = 'lease.deprecation_swept'
+          AND ds.sweep_completed_at IS NOT NULL
+          {ts_filter}
+        GROUP BY ds.deprecation_id, ds.surface_kind, ds.sweep_completed_at
+    """
+    if last_event_ts is None:
+        rows = await conn.fetch(batch_query.format(ts_filter=""))
+    else:
+        # Only emit the batch alarm for batches whose sweep COMPLETED after the
+        # last poll — avoids re-emitting already-seen completed sweeps.
+        rows = await conn.fetch(
+            batch_query.format(ts_filter="AND ds.sweep_completed_at > $1"), last_event_ts,
+        )
+    for row in rows:
+        alarms.append(_batch_alarm(row))
+        if max_ts is None or row["last_ts"] > max_ts:
+            max_ts = row["last_ts"]
+        if max_ts is None or row["sweep_completed_at"] > max_ts:
+            max_ts = row["sweep_completed_at"]
+
+    return alarms, max_ts
+
+
+def _ad_hoc_alarm(row) -> ForcedReleaseAlarm:
+    """Build a per-event ad-hoc forced-release alarm."""
+    surface_id = row["surface_id"]
+    return ForcedReleaseAlarm(
+        kind="ad_hoc",
+        severity="high",
+        summary=f"forced release: {surface_id} (lease {row['lease_id']})",
+        fingerprint=f"forced_release:ad_hoc:{row['event_id']}",
+        extra={
+            "event_id": str(row["event_id"]),
+            "ts": row["ts"].isoformat() if row["ts"] else None,
+            "lease_id": str(row["lease_id"]) if row["lease_id"] else None,
+            "surface_id": surface_id,
+            "surface_kind": row["surface_kind"],
+        },
+    )
+
+
+def _batch_alarm(row) -> ForcedReleaseAlarm:
+    """Build a single summary alarm for a completed deprecation batch."""
+    depr_id = row["deprecation_id"]
+    kind = row["surface_kind"]
+    count = row["event_count"]
+    return ForcedReleaseAlarm(
+        kind="deprecation_batch",
+        severity="medium",
+        summary=f"deprecation sweep complete: kind={kind} count={count}",
+        fingerprint=f"forced_release:deprecation_batch:{depr_id}",
+        extra={
+            "deprecation_id": str(depr_id),
+            "kind": kind,
+            "count": count,
+            "first_ts": row["first_ts"].isoformat() if row["first_ts"] else None,
+            "last_ts": row["last_ts"].isoformat() if row["last_ts"] else None,
+            "sweep_completed_at": row["sweep_completed_at"].isoformat()
+                if row["sweep_completed_at"] else None,
+        },
+    )

--- a/agents/sentinel/tests/test_lease_advisory.py
+++ b/agents/sentinel/tests/test_lease_advisory.py
@@ -70,8 +70,10 @@ async def test_run_cycle_invokes_lease_advisory_with_expected_surface(
     with pytest.raises(_CycleStopMarker):
         await agent.run_cycle()
 
-    assert captured["surface_id"] == "sentinel:cycle"
-    assert captured["surface_kind"] == "sentinel_cycle"
+    assert captured["surface_id"] == "resident:/sentinel_cycle"
+    # surface_kind no longer passed (PR 2.5 — derived server-side from scheme prefix
+    # via migration 026's generated column).
+    assert "surface_kind" not in captured
     assert captured["ttl_s"] == 300
     assert captured.get("intent") == "sentinel analysis cycle"
 

--- a/agents/vigil/agent.py
+++ b/agents/vigil/agent.py
@@ -615,9 +615,9 @@ class VigilAgent(GovernanceAgent):
         """
         from src.lease_plane.advisory import lease_advisory_scope, new_holder_uuid
 
+        # Migrated from "vigil:cycle" → "resident:/vigil_cycle" per RFC v0.8 §7.2.1.
         with lease_advisory_scope(
-            surface_id="vigil:cycle",
-            surface_kind="vigil_cycle",
+            surface_id="resident:/vigil_cycle",
             holder_agent_uuid=new_holder_uuid(),
             ttl_s=300,
             intent="vigil heartbeat cycle",

--- a/agents/vigil/tests/test_lease_advisory.py
+++ b/agents/vigil/tests/test_lease_advisory.py
@@ -78,8 +78,10 @@ async def test_run_cycle_invokes_lease_advisory_with_expected_surface(
     with pytest.raises(_CycleStopMarker):
         await agent.run_cycle(client)
 
-    assert captured["surface_id"] == "vigil:cycle"
-    assert captured["surface_kind"] == "vigil_cycle"
+    assert captured["surface_id"] == "resident:/vigil_cycle"
+    # surface_kind no longer passed (PR 2.5 — derived server-side from scheme prefix
+    # via migration 026's generated column).
+    assert "surface_kind" not in captured
     assert captured["ttl_s"] == 300
     assert captured.get("intent") == "vigil heartbeat cycle"
 

--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -914,9 +914,11 @@ def scan_commits(since: str = "30 days ago", repo_path: Path | None = None) -> i
       - Ambiguous prefixes that match more than one fingerprint.
 
     Phase A lease-plane integration: each scan acquires an advisory-mode
-    lease at `surface_id=watcher:scan_commits:<repo_root>`. The lease is
-    *telemetry only* — Watcher proceeds whether the lease is acquired,
-    held by another scanner, or unavailable. RFC v0.5 §6.1.
+    lease at `surface_id=resident:/watcher_scan_commits_<repo_root_sanitized>`
+    (migrated from pre-canonical `watcher:scan_commits:<repo_root>` per RFC
+    v0.8 §7.2.1 canonical scheme list). The lease is *telemetry only* —
+    Watcher proceeds whether the lease is acquired, held by another
+    scanner, or unavailable. RFC v0.5 §6.1.
 
     Returns:
         The number of findings resolved this scan. Always returns 0 on git
@@ -926,10 +928,11 @@ def scan_commits(since: str = "30 days ago", repo_path: Path | None = None) -> i
 
     from src.lease_plane.advisory import lease_advisory_scope, new_holder_uuid
 
-    surface_id = f"watcher:scan_commits:{repo_root}"
+    # Sanitize repo path into a resident:/ surface_id (slashes → underscores).
+    sanitized = str(repo_root).replace("/", "_").strip("_")
+    surface_id = f"resident:/watcher_scan_commits_{sanitized}"
     with lease_advisory_scope(
         surface_id=surface_id,
-        surface_kind="watcher_scan_commits",
         holder_agent_uuid=new_holder_uuid(),
         ttl_s=60,
         intent=f"scan_commits since={since!r}",

--- a/agents/watcher/tests/test_scan_commits.py
+++ b/agents/watcher/tests/test_scan_commits.py
@@ -293,8 +293,10 @@ class TestScanCommitsLeaseAdvisory:
 
         assert result == 1, "Phase A advisory: body must run regardless of lease outcome"
 
-        assert captured["surface_kind"] == "watcher_scan_commits"
-        assert captured["surface_id"].startswith("watcher:scan_commits:")
+        # surface_kind no longer passed (PR 2.5 — derived server-side from scheme prefix
+        # via migration 026's generated column).
+        assert "surface_kind" not in captured
+        assert captured["surface_id"].startswith("resident:/watcher_scan_commits_")
         assert captured["ttl_s"] == 60
         assert "since=" in captured["intent"]
 

--- a/db/postgres/migrations/026_lease_plane_grammar.sql
+++ b/db/postgres/migrations/026_lease_plane_grammar.sql
@@ -1,0 +1,76 @@
+-- 026_lease_plane_grammar.sql
+--
+-- Phase A storage-layer enforcement for surface-lease-plane.
+--
+-- Implements RFC v0.8:
+--   §7.2.2 — Postgres CHECK constraint on surface_id scheme grammar
+--            (closes three-voice convergence: dialectic BLOCK-2 + code-reviewer
+--             BLOCK-1 + live-verifier DRIFT-A).
+--   §7.2.3 — surface_kind becomes a generated column derived from surface_id
+--            (closes code-reviewer CONCERN-2 + live-verifier DRIFT-B).
+--
+-- Pre-flight rule (operator decision 2026-04-30, see Phase A plan):
+-- aborts with a clear remediation error if lease_plane.surface_leases
+-- contains rows when 026 runs against a fresh schema. Avoids silent
+-- destructive DROP COLUMN against populated data.
+--
+-- Idempotent: safe to re-run; the DO block detects post-migration state
+-- (surface_kind already generated) and skips both the pre-flight abort and
+-- the redundant ALTER TABLE.
+
+DO $$
+DECLARE
+    row_count int;
+    grammar_constraint_exists bool;
+    surface_kind_is_generated bool;
+BEGIN
+    -- Detect prior application of this migration: surface_kind = generated column.
+    SELECT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'lease_plane'
+          AND table_name = 'surface_leases'
+          AND column_name = 'surface_kind'
+          AND is_generated = 'ALWAYS'
+    ) INTO surface_kind_is_generated;
+
+    -- Pre-flight: bail if rows exist AND this is a fresh application
+    -- (re-run against a populated, already-migrated table is safe).
+    IF NOT surface_kind_is_generated THEN
+        SELECT count(*) INTO row_count FROM lease_plane.surface_leases;
+        IF row_count > 0 THEN
+            RAISE EXCEPTION
+              'Migration 026 aborted: lease_plane.surface_leases contains % row(s). '
+              'This migration drops and re-adds surface_kind as a generated column, '
+              'which is not safe against existing rows. Remediate by either: '
+              '(a) draining existing leases (release + verify released_at IS NOT NULL on every row), '
+              'or (b) running a separate data-migration step that re-INSERTs each row into the '
+              'post-026 schema. See docs/proposals/surface-lease-plane-v0.md §7.2.3.',
+              row_count;
+        END IF;
+    END IF;
+
+    -- Grammar CHECK on surface_id (idempotent via existence check).
+    SELECT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'surface_id_grammar'
+          AND conrelid = 'lease_plane.surface_leases'::regclass
+    ) INTO grammar_constraint_exists;
+
+    IF NOT grammar_constraint_exists THEN
+        ALTER TABLE lease_plane.surface_leases
+            ADD CONSTRAINT surface_id_grammar
+            CHECK (surface_id ~ '^(file://|dialectic:/|resident:/|capture:/|td:/)');
+    END IF;
+
+    -- Convert surface_kind to generated column (idempotent).
+    IF NOT surface_kind_is_generated THEN
+        ALTER TABLE lease_plane.surface_leases DROP COLUMN surface_kind;
+        ALTER TABLE lease_plane.surface_leases
+            ADD COLUMN surface_kind text
+            GENERATED ALWAYS AS (split_part(surface_id, ':', 1)) STORED;
+    END IF;
+END $$;
+
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (26, 'lease_plane_grammar', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/db/postgres/migrations/027_lease_plane_deprecation.sql
+++ b/db/postgres/migrations/027_lease_plane_deprecation.sql
@@ -1,0 +1,99 @@
+-- 027_lease_plane_deprecation.sql
+--
+-- Phase A persistence substrate for surface-kind deprecation per RFC v0.8 §7.11.1.
+--
+-- Adds two tables:
+--   lease_plane.surface_kind_catalog — canonical registry of allowed scheme prefixes.
+--                                       Seeded with the 5 v0 schemes.
+--   lease_plane.deprecated_schemes  — first-class state for the §7.11 4-phase
+--                                      deprecation procedure. FK to catalog so
+--                                      deprecation can only target a registered kind.
+--
+-- The migration also extends lease_plane.lease_plane_events.event_type CHECK to
+-- accept the three new deprecation event types ('lease.deprecation_marked',
+-- 'lease.deprecation_swept', 'lease.deprecation_migrated') per §7.11.3.
+--
+-- Idempotent: tables guarded by IF NOT EXISTS; INSERT seed via ON CONFLICT;
+-- event_type CHECK rebuilt via DROP+ADD inside a DO block.
+
+CREATE TABLE IF NOT EXISTS lease_plane.surface_kind_catalog (
+    surface_kind text PRIMARY KEY,
+    description  text,
+    added_at     timestamptz NOT NULL DEFAULT now()
+);
+
+INSERT INTO lease_plane.surface_kind_catalog (surface_kind, description)
+VALUES
+    ('file',      'repo file paths; canonicalization rules in RFC §7.12.1'),
+    ('dialectic', 'dialectic session IDs (lowercase hex UUID)'),
+    ('resident',  'resident lifecycle handles'),
+    ('capture',   'calibration capture windows; member list canonicalized lexically'),
+    ('td',        'TouchDesigner regions; reserved, not implemented v0')
+ON CONFLICT (surface_kind) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS lease_plane.deprecated_schemes (
+    surface_kind          text PRIMARY KEY
+        REFERENCES lease_plane.surface_kind_catalog(surface_kind)
+        ON DELETE RESTRICT,
+    deprecation_id        uuid NOT NULL DEFAULT gen_random_uuid(),
+    marked_deprecated_at  timestamptz NOT NULL DEFAULT now(),
+    marked_by_session_id  text NOT NULL,
+    drain_window_days     int NOT NULL DEFAULT 30
+        CHECK (drain_window_days > 0 AND drain_window_days <= 90),
+    sweep_started_at      timestamptz,
+    sweep_completed_at    timestamptz,
+    check_migrated_at     timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS deprecated_schemes_in_progress
+    ON lease_plane.deprecated_schemes (surface_kind)
+    WHERE check_migrated_at IS NULL;
+
+-- Extend lease_plane_events.event_type CHECK to include §7.11.3 deprecation events.
+DO $$
+DECLARE
+    has_deprecation_marked bool;
+BEGIN
+    -- Detect prior application: try inserting and rolling back is one option,
+    -- but cleaner is to inspect the constraint's check clause.
+    SELECT EXISTS (
+        SELECT 1 FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        WHERE n.nspname = 'lease_plane'
+          AND t.relname = 'lease_plane_events'
+          AND c.contype = 'c'
+          AND pg_get_constraintdef(c.oid) LIKE '%lease.deprecation_marked%'
+    ) INTO has_deprecation_marked;
+
+    IF NOT has_deprecation_marked THEN
+        -- Drop the existing event_type CHECK; rebuild with deprecation events added.
+        ALTER TABLE lease_plane.lease_plane_events
+            DROP CONSTRAINT IF EXISTS lease_plane_events_event_type_check;
+        ALTER TABLE lease_plane.lease_plane_events
+            ADD CONSTRAINT lease_plane_events_event_type_check
+            CHECK (
+                event_type IN (
+                    'acquire',
+                    'renew',
+                    'release',
+                    'heartbeat',
+                    'handoff_offer',
+                    'handoff_accept',
+                    'conflict_held_by_other',
+                    'reaped_remote_ttl',
+                    'reaped_local_ttl',
+                    'down_local',
+                    'forced',
+                    'service_unavailable',
+                    'lease.deprecation_marked',
+                    'lease.deprecation_swept',
+                    'lease.deprecation_migrated'
+                )
+            );
+    END IF;
+END $$;
+
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (27, 'lease_plane_deprecation', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/db/postgres/migrations/028_lease_plane_trigger_fix.sql
+++ b/db/postgres/migrations/028_lease_plane_trigger_fix.sql
@@ -1,0 +1,51 @@
+-- 028_lease_plane_trigger_fix.sql
+--
+-- Fixes a PR 1 oversight surfaced during PR 3a TDD:
+-- migration 025's enforce_immutable_lease_fields() trigger guards
+-- NEW.surface_kind IS DISTINCT FROM OLD.surface_kind, but after migration 026
+-- converted surface_kind to a STORED generated column, BEFORE UPDATE triggers
+-- see NULL for the generated column (it's computed AFTER the trigger fires).
+--
+-- Result: ANY UPDATE on surface_leases (including the §7.11 deprecation sweep)
+-- raises 'surface_kind is immutable per lease_id' even though surface_kind
+-- isn't actually changing.
+--
+-- Fix: drop the surface_kind check from the trigger. surface_id is already
+-- guarded for immutability; since surface_kind is now derived from
+-- split_part(surface_id, ':', 1), guarding surface_id transitively guards
+-- surface_kind.
+--
+-- The check on holder_kind, holder_class, original_ttl_s, holder_agent_uuid,
+-- and acquired_at remains.
+
+CREATE OR REPLACE FUNCTION lease_plane.enforce_immutable_lease_fields()
+RETURNS trigger AS $$
+BEGIN
+    IF NEW.surface_id IS DISTINCT FROM OLD.surface_id THEN
+        RAISE EXCEPTION 'surface_id is immutable per lease_id; lease identity is bound to (surface_id, holder)';
+    END IF;
+    -- surface_kind check removed (PR 3a / migration 028): post-026 it is a
+    -- generated column derived from surface_id; the surface_id guard above
+    -- transitively enforces surface_kind immutability.
+    IF NEW.holder_agent_uuid IS DISTINCT FROM OLD.holder_agent_uuid THEN
+        RAISE EXCEPTION 'holder_agent_uuid is immutable per lease_id';
+    END IF;
+    IF NEW.holder_kind IS DISTINCT FROM OLD.holder_kind THEN
+        RAISE EXCEPTION 'holder_kind is immutable per lease_id; release+reacquire to change';
+    END IF;
+    IF NEW.holder_class IS DISTINCT FROM OLD.holder_class THEN
+        RAISE EXCEPTION 'holder_class is immutable per lease_id';
+    END IF;
+    IF NEW.original_ttl_s IS DISTINCT FROM OLD.original_ttl_s THEN
+        RAISE EXCEPTION 'original_ttl_s is immutable per lease_id; renew uses this fixed value';
+    END IF;
+    IF NEW.acquired_at IS DISTINCT FROM OLD.acquired_at THEN
+        RAISE EXCEPTION 'acquired_at is immutable per lease_id';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (28, 'lease_plane_trigger_fix', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/db/postgres/migrations/029_lease_plane_earned_status_guard.sql
+++ b/db/postgres/migrations/029_lease_plane_earned_status_guard.sql
@@ -1,0 +1,55 @@
+-- 029_lease_plane_earned_status_guard.sql
+--
+-- Restores the `earned_status` immutability guard that migration 028 silently
+-- dropped. Surfaced by the council pass on the PR 1-4 stack (dialectic voice
+-- BLOCK-2): migration 025 originally guarded 8 fields against UPDATE; migration
+-- 028 was authored to drop the surface_kind guard (it became a generated column
+-- post-026) but the rewrite also dropped the earned_status guard as collateral
+-- damage.
+--
+-- Without this guard, ANY UPDATE on surface_leases can silently flip earned_status
+-- from 'provisional' to 'earned' — bypassing the substrate-earned-promotion
+-- migration that RFC §7.8 anticipates.
+--
+-- This restores the check while preserving the relaxed surface_kind handling
+-- from 028 (the surface_id immutability guard transitively protects the derived
+-- surface_kind generated column).
+--
+-- Idempotent: CREATE OR REPLACE the function, no-op if already correct.
+
+CREATE OR REPLACE FUNCTION lease_plane.enforce_immutable_lease_fields()
+RETURNS trigger AS $$
+BEGIN
+    IF NEW.surface_id IS DISTINCT FROM OLD.surface_id THEN
+        RAISE EXCEPTION 'surface_id is immutable per lease_id; lease identity is bound to (surface_id, holder)';
+    END IF;
+    -- surface_kind check intentionally omitted (post-028 it is a generated
+    -- column derived from surface_id; the surface_id guard above transitively
+    -- enforces surface_kind immutability).
+    IF NEW.holder_agent_uuid IS DISTINCT FROM OLD.holder_agent_uuid THEN
+        RAISE EXCEPTION 'holder_agent_uuid is immutable per lease_id';
+    END IF;
+    IF NEW.holder_kind IS DISTINCT FROM OLD.holder_kind THEN
+        RAISE EXCEPTION 'holder_kind is immutable per lease_id; release+reacquire to change';
+    END IF;
+    IF NEW.holder_class IS DISTINCT FROM OLD.holder_class THEN
+        RAISE EXCEPTION 'holder_class is immutable per lease_id';
+    END IF;
+    IF NEW.original_ttl_s IS DISTINCT FROM OLD.original_ttl_s THEN
+        RAISE EXCEPTION 'original_ttl_s is immutable per lease_id; renew uses this fixed value';
+    END IF;
+    IF NEW.acquired_at IS DISTINCT FROM OLD.acquired_at THEN
+        RAISE EXCEPTION 'acquired_at is immutable per lease_id';
+    END IF;
+    -- Restored in PR 5 / migration 029: earned_status guard (RFC §7.8).
+    -- substrate-earned promotion requires explicit migration, not silent UPDATE.
+    IF NEW.earned_status IS DISTINCT FROM OLD.earned_status THEN
+        RAISE EXCEPTION 'earned_status is immutable per lease_id; substrate-earned promotion requires explicit migration (RFC §7.8)';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (29, 'lease_plane_earned_status_guard', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/docs/proposals/surface-lease-plane-phase-a-plan.md
+++ b/docs/proposals/surface-lease-plane-phase-a-plan.md
@@ -183,15 +183,33 @@ Scope shipped:
 | §7.11.7 Phase 0 race window — full integration test | (covered by PR 3a's `deprecate_cmd` serializable tx + advisory lock; this PR adds the test) | `test_phase_zero_acquire_race_blocked` | DONE |
 | Sentinel cycle wiring | `agents/sentinel/agent.py::_emit_forced_release_alarms` | (transitively covered — module loads + load_state/save_state + post_finding paths exercised) | DONE |
 
-## PR 4+ — Remaining gates
+## PR 4 — `acquire_with_retry` + `_urllib_transport` HTTP-error coverage (this branch: impl/lease-plane-phase-a-pr4-retry-and-409)
 
-## PR 4+ — Remaining gates
+Closes the last two RFC §9 Phase A test gates that don't depend on Phase B work.
 
-- §7.3.3 `acquire_with_retry()` jittered backoff method
-- §7.3.5 HTTP 409 body-parse test (`test_urllib_transport_parses_409_body`)
-- Phase B prerequisites (payload-shape standardization spec, `unitares_doctor` extension)
+Scope shipped:
+- `LeasePlaneClient.acquire_with_retry()` convenience method (RFC §7.3.3): jittered exponential backoff (floor 100ms, ceiling 5s, full jitter per AWS convention). Honors `retry_after_hint_ms` from the v0.7 §7.3.2 extended `held_by_other` shape as a per-attempt floor. Only `held_by_other` triggers retry; `service_unavailable` / `permission_denied` / `schema_invalid` are terminal.
+- `_urllib_transport` HTTP-error body-parse coverage (RFC §7.3.5): closes live-verifier Finding 9 test-coverage gap. The implementation already correctly parses 409 + body, falls back to `permission_denied` on empty 401/403, and `service_unavailable` on empty 5xx — this PR adds tests proving so.
 
-These are mostly self-contained; pick up after PR 1-3 land.
+### PR 4 — RFC gate → code surface → test name → status table
+
+| Gate | Code | Test | Status |
+|------|------|------|--------|
+| §7.3.3 acquire_with_retry returns OK on first attempt | `src/lease_plane/client.py::LeasePlaneClient.acquire_with_retry` | `test_acquire_with_retry_returns_ok_on_first_attempt` | DONE |
+| §7.3.3 retry on held_by_other until OK | same | `test_acquire_with_retry_retries_on_held_by_other_until_ok` | DONE |
+| §7.3.3 jittered backoff in [100ms, 5s] full jitter | same | `test_acquire_with_retry_jittered_backoff_within_bounds` | DONE |
+| §7.3.3 honors retry_after_hint_ms as per-attempt floor | same | `test_acquire_with_retry_honors_retry_after_hint_as_floor` | DONE |
+| §7.3.3 service_unavailable terminal (no retry) | same | `test_acquire_with_retry_returns_service_unavailable_without_retry` | DONE |
+| §7.3.5 _urllib_transport parses 409 body | `src/lease_plane/client.py::_urllib_transport` HTTPError branch | `test_urllib_transport_parses_409_body` | DONE |
+| §7.3.5 _urllib_transport 401 fallback | same | `test_urllib_transport_401_returns_permission_denied_when_no_body` | DONE |
+| §7.3.5 _urllib_transport 5xx fallback | same | `test_urllib_transport_500_returns_service_unavailable_when_no_body` | DONE |
+
+## PR 5+ — Phase B prerequisites (planned, not yet drafted)
+
+Non-blocking for Phase A; lifts gates surfaced in §9 Phase B prerequisites:
+- Payload-shape standardization pass — commits to writing canonicalized `surface_id` (per §7.12.1) into `audit.tool_usage.payload`, no percent-encoding (per §7.2.8 cross-track).
+- `unitares_doctor.py` extension to lint that no Elixir source mentions a scheme not in the live grammar CHECK.
+- §7.5 `remote_heartbeat` instrumentation (operator action — measure Pi↔Mac heartbeat gap distribution ≥7d before any `remote_heartbeat` Phase B promotion).
 
 ## Reviewer checklist for any Phase A PR
 

--- a/docs/proposals/surface-lease-plane-phase-a-plan.md
+++ b/docs/proposals/surface-lease-plane-phase-a-plan.md
@@ -163,19 +163,27 @@ Scope shipped:
 | §7.11.7 race-window mitigation (serializable tx + advisory lock) | `deprecate_cmd` SQL | (covered by serializable transaction wrapping in implementation; full concurrent-acquire test deferred to PR 3b once Sentinel alarm + lease acquire path are in scope together) | PARTIAL |
 | Migration 028 trigger fix | `db/postgres/migrations/028_lease_plane_trigger_fix.sql` | (covered transitively by sweep tests — they UPDATE `surface_leases` and would fail without 028) | DONE |
 
-## PR 3b — §7.10/§7.11.5 Sentinel forced-release alarm rule (planned, not yet drafted)
+## PR 3b — §7.10/§7.11.5 Sentinel forced-release alarm rule (this branch: impl/lease-plane-phase-a-pr3b-sentinel-alarm)
 
-Scope (anticipated):
-- Adds direct `lease_plane.lease_plane_events` DB access to `agents/sentinel/agent.py` (currently no DB access exists; Sentinel reads fleet state via WebSocket).
-- Per-event alarm rule for `event_type='forced'` AND `event_type != 'lease.deprecation_swept'` (per RFC §7.10 alarm-on-every-event for ad-hoc force-release).
-- Batched alarm rule for `event_type='lease.deprecation_swept'`: groups by `deprecation_id`, emits one summary alarm per batch after `sweep_completed_at` is set on the corresponding `deprecated_schemes` row (per RFC §7.11.5 batch suppression).
-- Polling cadence matches existing Sentinel rules (operator decision 2026-04-30).
-- Tests:
-  - `test_sentinel_force_release_alarm_wired` — per-event alarm fires for ad-hoc forced events.
-  - `test_sentinel_batch_alarm_for_deprecation_sweep` — batched alarm fires once per deprecation_id, not N times.
-  - `test_phase_zero_acquire_race_blocked` (deferred from PR 3a) — full integration test covering the §7.11.7 race window with concurrent acquire attempts during Phase 0 mark.
+Scope shipped:
+- New module `agents/sentinel/forced_release_alarm.py` — `poll_forced_release_alarms(db_url, last_event_ts)` returns `(list[ForcedReleaseAlarm], new_cursor)`. Read-only on `lease_plane.lease_plane_events` and `lease_plane.deprecated_schemes`.
+- Per-event alarm for `event_type='forced'`: one alarm per ad-hoc forced-release event, severity `high` (per RFC §7.10 alarm-on-every-event).
+- Batched alarm for `event_type='lease.deprecation_swept'`: groups by `deprecation_id`, emits one summary alarm per completed sweep (only when `deprecated_schemes.sweep_completed_at IS NOT NULL`), severity `medium` (per RFC §7.11.5 batch suppression).
+- Cursor state via `Sentinel.load_state()/save_state()` under `forced_release_alarm.last_event_ts` — successive cycles don't re-emit alarms for already-seen events.
+- Wired into `Sentinel._run_cycle_inner` via `_emit_forced_release_alarms()` — runs at the start of each cycle; DB unreachable degrades gracefully (logged, swept under the rug, doesn't break the cycle).
 
-Rationale for splitting from PR 3a: Sentinel adding DB access is new architectural surface; coupling it with the deprecation CLI doubles the review burden. PR 3a ships the CLI (operator-facing); PR 3b ships the alarm wiring (telemetry-facing). The events the alarm consumes already exist after PR 3a lands.
+### PR 3b — RFC gate → code surface → test name → status table
+
+| Gate | Code | Test | Status |
+|------|------|------|--------|
+| §7.10 per-event alarm for ad-hoc `event_type='forced'` | `agents/sentinel/forced_release_alarm.py::_poll_inner` ad-hoc query + `_ad_hoc_alarm` | `test_sentinel_force_release_alarm_per_event` | DONE |
+| Cursor-based dedup so successive polls don't re-emit | same, ts-filter on cursor | `test_sentinel_force_release_alarm_dedupes_via_cursor` | DONE |
+| §7.11.5 batched alarm for `event_type='lease.deprecation_swept'` | `_poll_inner` batch query + `_batch_alarm` | `test_sentinel_batch_alarm_for_deprecation_sweep` | DONE |
+| §7.11.5 batched alarm waits for `sweep_completed_at IS NOT NULL` | same query (JOIN on deprecated_schemes filters partial sweeps) | `test_sentinel_batch_alarm_only_after_sweep_completed_at` | DONE |
+| §7.11.7 Phase 0 race window — full integration test | (covered by PR 3a's `deprecate_cmd` serializable tx + advisory lock; this PR adds the test) | `test_phase_zero_acquire_race_blocked` | DONE |
+| Sentinel cycle wiring | `agents/sentinel/agent.py::_emit_forced_release_alarms` | (transitively covered — module loads + load_state/save_state + post_finding paths exercised) | DONE |
+
+## PR 4+ — Remaining gates
 
 ## PR 4+ — Remaining gates
 

--- a/docs/proposals/surface-lease-plane-phase-a-plan.md
+++ b/docs/proposals/surface-lease-plane-phase-a-plan.md
@@ -222,13 +222,28 @@ Three-voice council pass on the PR 1-4 cumulative stack (dialectic, code-reviewe
 
 Race-window test updated (`tests/test_sentinel_forced_release_alarm.py::test_phase_zero_acquire_race_blocked`) to import `_lock_key_for_kind` instead of computing `abs(hash(kind))` locally — the pre-PR-5 test only passed because both holder and CLI ran in the same Python process; now exercises the same helper as production.
 
-## PR 6+ — Deferred council CONCERNs and Phase B prerequisites
+## PR 6 — Deprecation event-vocabulary completeness (this branch: impl/lease-plane-phase-a-pr6-deprecation-events)
+
+Closes the dangling-vocabulary council NIT: migration 027 added `lease.deprecation_marked` and `lease.deprecation_migrated` to the `event_type` CHECK constraint, but no code path emitted them. PR 6 wires both emissions in the CLI, with idempotent guards so re-runs don't double-emit.
+
+### PR 6 — RFC gate → code surface → test name → status table
+
+| Gate | Code | Test | Status |
+|------|------|------|--------|
+| §7.11.3 Phase 0 emits `lease.deprecation_marked` | `scripts/dev/lease_plane_deprecate.py::deprecate_cmd` | `test_deprecate_emits_lease_deprecation_marked_event` | DONE |
+| §7.11.3 Phase 3 emits `lease.deprecation_migrated` | `deprecation_finalize_cmd` | `test_finalize_emits_lease_deprecation_migrated_event` | DONE |
+| Idempotent re-runs do NOT double-emit `lease.deprecation_migrated` | finalize early-return on already-finalized | `test_finalize_idempotent_does_not_double_emit` | DONE |
+
+Phase 0 emission uses `INSERT ... RETURNING deprecation_id` so the `ON CONFLICT DO NOTHING` path correctly returns NULL on idempotent re-marks → no double-emit. Phase 3 captures `check_migrated_at` BEFORE the UPDATE and only emits if it was previously NULL.
+
+The marker events use surface_id `f"{kind}:/__deprecation_marker__"` — distinct from any real lease's surface_id, makes them easy to filter in audit queries.
+
+## PR 7+ — Remaining deferred council CONCERNs and Phase B prerequisites
 
 Bigger council CONCERNs (need design discussion):
 - §7.11.2 Phase 2/3 atomicity rewrite — CLI sub-commands don't enforce same-session atomicity. Either coalesce into `deprecate-and-finalize` super-command or amend RFC §7.11.2.
 - Elixir router server-side canonicalization (split-brain prevention from non-Python callers).
 - Sentinel asyncpg pool wiring (CLAUDE.md anyio pattern; current code opens fresh connection per cycle).
-- `lease.deprecation_marked` and `lease.deprecation_migrated` event-type vocabulary is in CHECK constraint but never emitted by code.
 - §9 RFC test-name reconciliation (named tests semantically covered but not under contracted names).
 
 Phase B prerequisites (non-blocking for Phase A):

--- a/docs/proposals/surface-lease-plane-phase-a-plan.md
+++ b/docs/proposals/surface-lease-plane-phase-a-plan.md
@@ -90,15 +90,47 @@ Currently no rule keyed on `release_reason` or `event_type='forced'` exists in `
 
 The rule needs `lease_plane_events` SELECT access. If Sentinel doesn't already have it, the migration step adds the GRANT.
 
-## PR 2 — §7.12 canonicalization helper (planned, not yet drafted)
+## PR 2 — §7.12 canonicalization helper (this branch: impl/lease-plane-phase-a-pr2-canonicalize)
 
-Scope (anticipated; will reify when PR 1 lands):
-- `src/lease_plane/canonicalize.py` (new) implementing the §7.12.1 server-side rule: tmpfile probe, double-realpath, scheme dispatch, `capture:/` member sorting.
-- Pydantic `field_validator` on `AcquireRequest.surface_id` calling the helper.
-- Helper error semantics (§7.12.2): `CanonicalizeError` exception with `reason` codes.
-- 6 §7.12 Phase A test gates.
+Scope shipped:
+- `src/lease_plane/canonicalize.py` (new) implementing the §7.12.1 server-side rule: tmpfile probe (closes live-verifier DRIFT-3), double-realpath (closes DRIFT-2), per-scheme dispatch, `capture:/` member sorting, `dialectic:/` lowercase, `resident:/` reserved-character rejection.
+- Helper error semantics (§7.12.2): `CanonicalizeError` exception with `reason` codes (`symlink_loop`, `path_too_long`, `invalid_scheme`).
+- AcquireRequest `surface_kind` field removed (closes the v0.7 PR 1 oversight — Elixir router was updated but Python schema wasn't).
+- `lease_advisory_scope()` `surface_kind` parameter softened to optional + ignored (preserves backwards-compat for watcher/vigil/sentinel/chronicler/ship.sh callers without surface_id migration in this PR).
+- 4 of the 6 §7.12 Phase A test gates pass.
 
-Rationale for separating from PR 1: the helper is a self-contained module with no schema/contract dependency on the migration changes. Reviewing it independently keeps the cognitive load tractable.
+Deferred to **PR 2.5** (see new section below):
+- Pydantic `field_validator` on `AcquireRequest.surface_id` (would brick production agents whose surface_ids are non-canonical).
+- 2 of the 6 §7.12 Phase A test gates marked `pytest.mark.skip`.
+
+### PR 2 — RFC gate → code surface → test name → status table
+
+| Gate | Code | Test | Status |
+|------|------|------|--------|
+| §7.12.1 step 4 — tmpfile probe (not pathconf) | `src/lease_plane/canonicalize.py::_detect_case_insensitive` | `test_canonicalize_case_detection_uses_tmpfile_probe` | DONE |
+| §7.12.1 step 2 — double-realpath for /var → /private/var | `canonicalize.py::_canonicalize_file` | `test_canonicalize_resolves_var_to_private_var_on_macos` | DONE |
+| §7.12.1 capture:/ member sorting | `canonicalize.py::_canonicalize_capture` | `test_capture_canonicalizes_member_ordering` | DONE |
+| §7.12.2 helper error semantics (symlink loop, NUL, nonexistent) | `canonicalize.py::canonicalize` | `test_canonicalize_error_semantics` | DONE |
+| §7.12.5 AcquireRequest field_validator wired | (deferred to PR 2.5) | `test_acquire_request_surface_id_field_validator_wired` | SKIPPED |
+| §7.12.4 Pydantic ?-rejection | (deferred to PR 2.5) | `test_acquire_request_rejects_query_string_in_surface_id` | SKIPPED |
+| §7.2.3 Pydantic AcquireRequest drops `surface_kind` (closes PR 1 oversight) | `src/lease_plane/models.py`, `src/lease_plane/advisory.py`, `scripts/dev/_ship_lease_advisory.py` | (covered by 39-test lease-plane regression) | DONE |
+
+## PR 2.5 — Production-agent surface_id migration + AcquireRequest field_validator (planned, not yet drafted)
+
+**Surfaced during PR 2 implementation:** the production agents (watcher, vigil, sentinel, chronicler, ship.sh advisory) use surface_ids like `watcher:scan_commits:<repo>`, `vigil:cycle`, `sentinel:cycle`, `chronicler:scrape`, `ship.sh:test-branch` — none of which match the canonical scheme list (RFC §7.2.1). Wiring the AcquireRequest field_validator now would cause every agent to crash on first acquire with `ValidationError: scheme not in canonical scheme list`.
+
+Scope:
+- Migrate production surface_ids to canonical schemes:
+  - `watcher:scan_commits:X` → `resident:/watcher_scan_commits_X`
+  - `vigil:cycle` → `resident:/vigil_cycle`
+  - `sentinel:cycle` → `resident:/sentinel_cycle`
+  - `chronicler:scrape` → `resident:/chronicler_scrape`
+  - `ship.sh:<branch>` → `resident:/ship_sh_<branch>` (operator-driven, not file-bound)
+- After migration, wire the AcquireRequest `field_validator` on `surface_id` per §7.12.5 — auto-canonicalize at the model boundary; reject NUL bytes, `?`-bearing strings, and non-canonical schemes.
+- Un-skip the 2 deferred test gates: `test_acquire_request_rejects_query_string_in_surface_id` and `test_acquire_request_surface_id_field_validator_wired`.
+- Update `lease_advisory_scope()` to drop `surface_kind` parameter entirely (currently kept as optional+ignored).
+
+Rationale for splitting from PR 2: the canonicalize.py helper is reviewable independently; coupling it to a fleet-wide surface_id migration risks both reviews stalling on the wider impact. PR 2 ships the helper; PR 2.5 ships the migration + validator together (they MUST land atomically — validator without migration = bricked fleet; migration without validator = silently inconsistent).
 
 ## PR 3 — §7.11 deprecation CLI + Sentinel forced-release alarm (planned, not yet drafted)
 

--- a/docs/proposals/surface-lease-plane-phase-a-plan.md
+++ b/docs/proposals/surface-lease-plane-phase-a-plan.md
@@ -35,9 +35,9 @@ Scope: the two migrations + the three v0.7 drift fixes + the tests that prove on
 | §7.11.1 catalog seeded with 5 schemes (file/dialectic/resident/capture/td) | same migration 027 (`INSERT INTO surface_kind_catalog ...`) | `test_migration_027_surface_kind_catalog_seeded` | TODO |
 | §7.3.2 `AcquireHeldByOther` extended typed-absence shape (v0.7 drift fix 1) | `src/lease_plane/models.py` — add `surface_id`, `blocking_lease_id`, `retry_after_hint_ms` fields | `test_held_by_other_includes_v0_7_extended_fields` | TODO |
 | §7.2.3 router does not accept `surface_kind` in acquire body (v0.7 drift fix 2) | `elixir/lease_plane/lib/unitares_lease_plane/http_router.ex` — drop `"surface_kind"` from required + params map in `extract_acquire_params` | Elixir-side: `test http_router rejects surface_kind in acquire body after migration 026` | TODO |
-| §7.10 + §7.11.5 Sentinel `event_type='forced'` alarm rule wired (v0.7 drift fix 3) | `agents/sentinel/agent.py` — add alarm rule reading `lease_plane_events` for `event_type='forced'`; per-event for ad-hoc, batched-by-`deprecation_id` for `event_type='lease.deprecation_swept'` | `test_sentinel_force_release_alarm_wired` (covers both per-event + batched paths) | TODO |
+| §7.10 + §7.11.5 Sentinel `event_type='forced'` alarm rule wired (v0.7 drift fix 3) | (deferred to PR 3) | (deferred) | DEFERRED — depends on PR 3 force-release CLI to have something to fire on, and on adding direct DB access to Sentinel which is new architectural surface |
 
-**Total: 8 rows. Within ~10-row guidance.**
+**Total: 7 rows in PR 1; one row deferred to PR 3.**
 
 ### Specific implementation notes
 
@@ -100,14 +100,15 @@ Scope (anticipated; will reify when PR 1 lands):
 
 Rationale for separating from PR 1: the helper is a self-contained module with no schema/contract dependency on the migration changes. Reviewing it independently keeps the cognitive load tractable.
 
-## PR 3 — §7.11 deprecation CLI (planned, not yet drafted)
+## PR 3 — §7.11 deprecation CLI + Sentinel forced-release alarm (planned, not yet drafted)
 
 Scope (anticipated):
-- `lease-plane` CLI commands: `deprecate`, `deprecation-sweep`, `deprecation-finalize` (Elixir Mix tasks or Python script — TBD).
+- `lease-plane` CLI commands: `deprecate`, `deprecation-sweep`, `deprecation-finalize` (standalone Python CLI in `scripts/dev/`, per operator decision 2026-04-30).
 - `LEASE_FORCE_RELEASE_TOKEN` integration test (covers §7.10 + §7.11 force-release wiring).
-- Phase 2 sweep Oban job with idempotent predicate.
+- Phase 2 sweep job with idempotent predicate.
 - Phase 0 race-window mitigation (serializable-tx + advisory lock).
-- 6 §7.11 Phase A test gates + 1 §7.10 force-release test.
+- **Sentinel forced-release alarm rule** (deferred from PR 1): adds direct lease_plane_events DB access to Sentinel; per-event alarm for ad-hoc `event_type='forced'`, batched-by-`deprecation_id` for `event_type='lease.deprecation_swept'`. Default Sentinel cadence per operator decision 2026-04-30.
+- 6 §7.11 Phase A test gates + 1 §7.10 force-release test + 1 Sentinel alarm wiring test.
 
 Rationale: depends on PR 1 (catalog + deprecated_schemes tables must exist) and on operator-runbook content for the CLI documentation. Lands after both.
 

--- a/docs/proposals/surface-lease-plane-phase-a-plan.md
+++ b/docs/proposals/surface-lease-plane-phase-a-plan.md
@@ -115,22 +115,28 @@ Deferred to **PR 2.5** (see new section below):
 | §7.12.4 Pydantic ?-rejection | (deferred to PR 2.5) | `test_acquire_request_rejects_query_string_in_surface_id` | SKIPPED |
 | §7.2.3 Pydantic AcquireRequest drops `surface_kind` (closes PR 1 oversight) | `src/lease_plane/models.py`, `src/lease_plane/advisory.py`, `scripts/dev/_ship_lease_advisory.py` | (covered by 39-test lease-plane regression) | DONE |
 
-## PR 2.5 — Production-agent surface_id migration + AcquireRequest field_validator (planned, not yet drafted)
+## PR 2.5 — Production-agent surface_id migration + AcquireRequest field_validator (this branch: impl/lease-plane-phase-a-pr2-5-validator)
 
-**Surfaced during PR 2 implementation:** the production agents (watcher, vigil, sentinel, chronicler, ship.sh advisory) use surface_ids like `watcher:scan_commits:<repo>`, `vigil:cycle`, `sentinel:cycle`, `chronicler:scrape`, `ship.sh:test-branch` — none of which match the canonical scheme list (RFC §7.2.1). Wiring the AcquireRequest field_validator now would cause every agent to crash on first acquire with `ValidationError: scheme not in canonical scheme list`.
+**Surfaced during PR 2 implementation:** the production agents (watcher, vigil, sentinel, chronicler, ship.sh advisory) used surface_ids like `watcher:scan_commits:<repo>`, `vigil:cycle`, `sentinel:cycle`, `chronicler:scrape`, `ship.sh:test-branch` — none of which match the canonical scheme list (RFC §7.2.1). Wiring the AcquireRequest field_validator without first migrating these would cause every agent to crash on first acquire with `ValidationError: scheme not in canonical scheme list`. PR 2.5 lands migration + validator atomically.
 
-Scope:
-- Migrate production surface_ids to canonical schemes:
-  - `watcher:scan_commits:X` → `resident:/watcher_scan_commits_X`
-  - `vigil:cycle` → `resident:/vigil_cycle`
-  - `sentinel:cycle` → `resident:/sentinel_cycle`
-  - `chronicler:scrape` → `resident:/chronicler_scrape`
-  - `ship.sh:<branch>` → `resident:/ship_sh_<branch>` (operator-driven, not file-bound)
-- After migration, wire the AcquireRequest `field_validator` on `surface_id` per §7.12.5 — auto-canonicalize at the model boundary; reject NUL bytes, `?`-bearing strings, and non-canonical schemes.
-- Un-skip the 2 deferred test gates: `test_acquire_request_rejects_query_string_in_surface_id` and `test_acquire_request_surface_id_field_validator_wired`.
-- Update `lease_advisory_scope()` to drop `surface_kind` parameter entirely (currently kept as optional+ignored).
+### PR 2.5 — RFC gate → code surface → test name → status table
 
-Rationale for splitting from PR 2: the canonicalize.py helper is reviewable independently; coupling it to a fleet-wide surface_id migration risks both reviews stalling on the wider impact. PR 2 ships the helper; PR 2.5 ships the migration + validator together (they MUST land atomically — validator without migration = bricked fleet; migration without validator = silently inconsistent).
+| Gate | Code | Test | Status |
+|------|------|------|--------|
+| §7.12.5 AcquireRequest field_validator wired | `src/lease_plane/models.py::_validate_surface_id` | `test_acquire_request_surface_id_field_validator_wired` | DONE |
+| §7.12.4 Pydantic `?`-rejection | same field_validator | `test_acquire_request_rejects_query_string_in_surface_id` | DONE |
+| §7.2.1 production agents on canonical schemes | `agents/{watcher,vigil,sentinel,chronicler}/agent.py` + `scripts/dev/ship.sh` | `agents/{watcher,vigil,sentinel}/tests/test_lease_advisory.py`, `tests/test_chronicler_lease_advisory.py` (assertions updated to canonical surface_id + `surface_kind not in captured`) | DONE |
+| §7.2.3 `lease_advisory_scope()` drops `surface_kind` parameter | `src/lease_plane/advisory.py` | (lease-plane regression suite + 22 agent advisory tests) | DONE |
+| Test fixtures use canonical schemes | `tests/test_lease_plane_advisory.py`, `tests/test_ship_lease_advisory.py`, `tests/test_chronicler_lease_advisory.py` | (existing tests, surface_id values updated) | DONE |
+
+Per-agent migration mapping (committed):
+- `watcher:scan_commits:<repo>` → `resident:/watcher_scan_commits_<sanitized>` (slashes → underscores)
+- `vigil:cycle` → `resident:/vigil_cycle`
+- `sentinel:cycle` → `resident:/sentinel_cycle`
+- `chronicler:scrape` → `resident:/chronicler_scrape`
+- `ship.sh:<branch>` → `resident:/ship_sh_<branch>` (slashes preserved; branch names with `/` like `feat/foo` produce `resident:/ship_sh_feat/foo`)
+
+Rationale for splitting from PR 2: the canonicalize.py helper is reviewable independently; coupling it to a fleet-wide surface_id migration risked both reviews stalling on the wider impact. PR 2 shipped the helper; PR 2.5 ships the migration + validator together — atomic landing is the safety contract (validator without migration = bricked fleet; migration without validator = silently inconsistent).
 
 ## PR 3 — §7.11 deprecation CLI + Sentinel forced-release alarm (planned, not yet drafted)
 

--- a/docs/proposals/surface-lease-plane-phase-a-plan.md
+++ b/docs/proposals/surface-lease-plane-phase-a-plan.md
@@ -204,9 +204,34 @@ Scope shipped:
 | §7.3.5 _urllib_transport 401 fallback | same | `test_urllib_transport_401_returns_permission_denied_when_no_body` | DONE |
 | §7.3.5 _urllib_transport 5xx fallback | same | `test_urllib_transport_500_returns_service_unavailable_when_no_body` | DONE |
 
-## PR 5+ — Phase B prerequisites (planned, not yet drafted)
+## PR 5 — Council BLOCK fixes from PR 1-4 stack review (this branch: impl/lease-plane-phase-a-pr5-council-fixes)
 
-Non-blocking for Phase A; lifts gates surfaced in §9 Phase B prerequisites:
+Three-voice council pass on the PR 1-4 cumulative stack (dialectic, code-reviewer, live-verifier; adversarial framing per `feedback_council-adversarial-prompt.md`) surfaced 3 BLOCKs and several CONCERNs/NITs. PR 5 fixes the BLOCKs + the small CONCERNs/NITs; bigger CONCERNs (Phase 2/3 atomicity rewrite, Elixir router canonicalization, Sentinel asyncpg pool) deferred to PR 6+.
+
+### PR 5 — RFC gate → code surface → test name → status table
+
+| Gate | Code | Test | Status |
+|------|------|------|--------|
+| BLOCK 1 — Elixir 409 emits all 5 v0.7 §7.3.2 fields | `elixir/lease_plane/lib/unitares_lease_plane/{http_router.ex,repo.ex}` | Elixir test "different holder → 409 held_by_other" extended (operator-verified via `mix test`) | DONE |
+| BLOCK 1 defense-in-depth — `retry_after_hint_ms` defaults to 0 | `src/lease_plane/models.py::AcquireHeldByOther` | (covered by existing AcquireHeldByOther parse tests + new test below) | DONE |
+| BLOCK 2 — CLI advisory lock key deterministic across processes | `scripts/dev/lease_plane_deprecate.py::_lock_key_for_kind` | `test_deprecate_lock_key_stable_across_processes` (subprocess-based) | DONE |
+| BLOCK 3 — restore `earned_status` immutability guard | `db/postgres/migrations/029_lease_plane_earned_status_guard.sql` | `test_migration_029_blocks_earned_status_update`, `test_migration_029_still_allows_release_update` | DONE |
+| CONCERN — `acquire_with_retry` validates `max_attempts >= 1` and `floor_s <= ceiling_s` | `src/lease_plane/client.py::acquire_with_retry` guards | `test_acquire_with_retry_rejects_max_attempts_below_1`, `test_acquire_with_retry_rejects_floor_exceeding_ceiling` | DONE |
+| CONCERN — Sentinel cursor stops advancing to `sweep_completed_at` | `agents/sentinel/forced_release_alarm.py::_poll_inner` | (covered by existing `test_sentinel_force_release_alarm_dedupes_via_cursor`; cursor advance now event-ts only) | DONE |
+| NIT — drop redundant inner import in `acquire_with_retry` | `src/lease_plane/client.py::acquire_with_retry` | (no test; cosmetic) | DONE |
+
+Race-window test updated (`tests/test_sentinel_forced_release_alarm.py::test_phase_zero_acquire_race_blocked`) to import `_lock_key_for_kind` instead of computing `abs(hash(kind))` locally — the pre-PR-5 test only passed because both holder and CLI ran in the same Python process; now exercises the same helper as production.
+
+## PR 6+ — Deferred council CONCERNs and Phase B prerequisites
+
+Bigger council CONCERNs (need design discussion):
+- §7.11.2 Phase 2/3 atomicity rewrite — CLI sub-commands don't enforce same-session atomicity. Either coalesce into `deprecate-and-finalize` super-command or amend RFC §7.11.2.
+- Elixir router server-side canonicalization (split-brain prevention from non-Python callers).
+- Sentinel asyncpg pool wiring (CLAUDE.md anyio pattern; current code opens fresh connection per cycle).
+- `lease.deprecation_marked` and `lease.deprecation_migrated` event-type vocabulary is in CHECK constraint but never emitted by code.
+- §9 RFC test-name reconciliation (named tests semantically covered but not under contracted names).
+
+Phase B prerequisites (non-blocking for Phase A):
 - Payload-shape standardization pass — commits to writing canonicalized `surface_id` (per §7.12.1) into `audit.tool_usage.payload`, no percent-encoding (per §7.2.8 cross-track).
 - `unitares_doctor.py` extension to lint that no Elixir source mentions a scheme not in the live grammar CHECK.
 - §7.5 `remote_heartbeat` instrumentation (operator action — measure Pi↔Mac heartbeat gap distribution ≥7d before any `remote_heartbeat` Phase B promotion).

--- a/docs/proposals/surface-lease-plane-phase-a-plan.md
+++ b/docs/proposals/surface-lease-plane-phase-a-plan.md
@@ -138,17 +138,44 @@ Per-agent migration mapping (committed):
 
 Rationale for splitting from PR 2: the canonicalize.py helper is reviewable independently; coupling it to a fleet-wide surface_id migration risked both reviews stalling on the wider impact. PR 2 shipped the helper; PR 2.5 ships the migration + validator together — atomic landing is the safety contract (validator without migration = bricked fleet; migration without validator = silently inconsistent).
 
-## PR 3 — §7.11 deprecation CLI + Sentinel forced-release alarm (planned, not yet drafted)
+## PR 3a — §7.11 deprecation CLI (this branch: impl/lease-plane-phase-a-pr3a-deprecate-cli)
+
+Scope shipped:
+- `scripts/dev/lease_plane_deprecate.py` standalone Python CLI implementing the 4-phase operator-driven deprecation procedure (RFC §7.11.2):
+  - `deprecate <kind>` — Phase 0: serializable transaction + advisory lock + INSERT into `deprecated_schemes` (idempotent via `ON CONFLICT DO NOTHING`).
+  - `deprecation-sweep <kind>` — Phase 2: idempotent force-release of surviving leases per RFC §7.11.4 predicate (`WHERE released_at IS NULL AND surface_kind = $1 FOR UPDATE SKIP LOCKED`); emits `lease.deprecation_swept` events with `deprecation_id` payload for batch correlation.
+  - `deprecation-finalize <kind>` — Phase 3: records `check_migrated_at` (the actual ALTER TABLE drop is operator-issued in same session per §7.11.2).
+  - `deprecation-status [<kind>]` — operator visibility into `deprecated_schemes` table.
+- Force-release authorization gated on `LEASE_FORCE_RELEASE_TOKEN` from env or `~/.config/cirwel/secrets.env`. `GOVERNANCE_TOKEN` does NOT authorize (RFC §7.10).
+- Migration 028 (`db/postgres/migrations/028_lease_plane_trigger_fix.sql`): drops the now-redundant `surface_kind IS DISTINCT FROM` check from `lease_plane.enforce_immutable_lease_fields()`. Surfaced during PR 3a TDD — after migration 026 made `surface_kind` a generated column, the BEFORE UPDATE trigger sees `NEW.surface_kind = NULL` (generated values populate AFTER triggers fire), bricking ANY UPDATE on `surface_leases` including the §7.11 sweep. `surface_id` immutability is unchanged and transitively guards the derived `surface_kind`.
+
+### PR 3a — RFC gate → code surface → test name → status table
+
+| Gate | Code | Test | Status |
+|------|------|------|--------|
+| §7.11 Phase 0 INSERT into deprecated_schemes | `scripts/dev/lease_plane_deprecate.py::deprecate_cmd` | `test_deprecate_cli_phase_0_inserts_row` | DONE |
+| §7.11 Phase 0 idempotent (ON CONFLICT DO NOTHING) | same | `test_deprecate_cli_idempotent_no_duplicate_row` | DONE |
+| §7.11.1 Phase 0 unknown-kind rejected at catalog FK | same | `test_deprecate_cli_unknown_kind_rejected` | DONE |
+| §7.11.4 sweep predicate idempotent on partial-failure re-run | `deprecation_sweep_cmd` | `test_deprecation_sweep_predicate_idempotent` | DONE |
+| §7.11.3 sweep emits `lease.deprecation_swept` events with deprecation_id | same | `test_deprecation_sweep_emits_lease_deprecation_swept_events` | DONE |
+| §7.11.2 Phase 3 records check_migrated_at | `deprecation_finalize_cmd` | `test_deprecation_finalize_records_check_migrated_at` | DONE |
+| §7.10 sweep requires `LEASE_FORCE_RELEASE_TOKEN`; rejects `GOVERNANCE_TOKEN` | sweep auth path | `test_deprecation_sweep_requires_force_release_token` | DONE |
+| §7.11.7 race-window mitigation (serializable tx + advisory lock) | `deprecate_cmd` SQL | (covered by serializable transaction wrapping in implementation; full concurrent-acquire test deferred to PR 3b once Sentinel alarm + lease acquire path are in scope together) | PARTIAL |
+| Migration 028 trigger fix | `db/postgres/migrations/028_lease_plane_trigger_fix.sql` | (covered transitively by sweep tests — they UPDATE `surface_leases` and would fail without 028) | DONE |
+
+## PR 3b — §7.10/§7.11.5 Sentinel forced-release alarm rule (planned, not yet drafted)
 
 Scope (anticipated):
-- `lease-plane` CLI commands: `deprecate`, `deprecation-sweep`, `deprecation-finalize` (standalone Python CLI in `scripts/dev/`, per operator decision 2026-04-30).
-- `LEASE_FORCE_RELEASE_TOKEN` integration test (covers §7.10 + §7.11 force-release wiring).
-- Phase 2 sweep job with idempotent predicate.
-- Phase 0 race-window mitigation (serializable-tx + advisory lock).
-- **Sentinel forced-release alarm rule** (deferred from PR 1): adds direct lease_plane_events DB access to Sentinel; per-event alarm for ad-hoc `event_type='forced'`, batched-by-`deprecation_id` for `event_type='lease.deprecation_swept'`. Default Sentinel cadence per operator decision 2026-04-30.
-- 6 §7.11 Phase A test gates + 1 §7.10 force-release test + 1 Sentinel alarm wiring test.
+- Adds direct `lease_plane.lease_plane_events` DB access to `agents/sentinel/agent.py` (currently no DB access exists; Sentinel reads fleet state via WebSocket).
+- Per-event alarm rule for `event_type='forced'` AND `event_type != 'lease.deprecation_swept'` (per RFC §7.10 alarm-on-every-event for ad-hoc force-release).
+- Batched alarm rule for `event_type='lease.deprecation_swept'`: groups by `deprecation_id`, emits one summary alarm per batch after `sweep_completed_at` is set on the corresponding `deprecated_schemes` row (per RFC §7.11.5 batch suppression).
+- Polling cadence matches existing Sentinel rules (operator decision 2026-04-30).
+- Tests:
+  - `test_sentinel_force_release_alarm_wired` — per-event alarm fires for ad-hoc forced events.
+  - `test_sentinel_batch_alarm_for_deprecation_sweep` — batched alarm fires once per deprecation_id, not N times.
+  - `test_phase_zero_acquire_race_blocked` (deferred from PR 3a) — full integration test covering the §7.11.7 race window with concurrent acquire attempts during Phase 0 mark.
 
-Rationale: depends on PR 1 (catalog + deprecated_schemes tables must exist) and on operator-runbook content for the CLI documentation. Lands after both.
+Rationale for splitting from PR 3a: Sentinel adding DB access is new architectural surface; coupling it with the deprecation CLI doubles the review burden. PR 3a ships the CLI (operator-facing); PR 3b ships the alarm wiring (telemetry-facing). The events the alarm consumes already exist after PR 3a lands.
 
 ## PR 4+ — Remaining gates
 

--- a/docs/proposals/surface-lease-plane-phase-a-plan.md
+++ b/docs/proposals/surface-lease-plane-phase-a-plan.md
@@ -1,0 +1,142 @@
+---
+status: PLANNING (PR 1 scope frozen)
+target_branch: impl/lease-plane-phase-a
+based_on: docs/lease-plane-v0.8 (commit 31ada78)
+rfc_baseline: docs/proposals/surface-lease-plane-v0.md @ v0.8
+authored: 2026-04-30
+---
+
+# Surface Lease Plane — Phase A Implementation Plan
+
+The v0.8 RFC names **27 Phase A test gates + 3 v0.7 implementation drift items + 2 migrations (026, 027)**. Landing all of those in one PR would produce an unreviewable blob. This plan groups them into focused PRs so each one has a tight RFC↔code mapping that a reviewer can audit row-by-row.
+
+**Methodology commitment:** every Phase A PR description MUST include the four-column table below — `RFC gate → code surface → test name → status` — for exactly the rows it implements. Other rows must be marked `(deferred to PR N)`. No PR may exceed ~10 rows in this table without operator approval.
+
+## PR 1 — Storage + model drift (this PR)
+
+Scope: the two migrations + the three v0.7 drift fixes + the tests that prove only those changes. Everything else is deferred to PR 2+. The reason this group lands first: migration 026's generated-column conversion will hard-fail the Elixir router unless drift fix 2 lands in the same PR; the v0.8 RFC §11 explicitly names this coupling. Drift fix 1 (extended `AcquireHeldByOther`) and drift fix 3 (Sentinel alarm rule) are bundled because they are small, isolated, and otherwise risk being forgotten.
+
+### Out of scope for PR 1 (deferred)
+
+- The §7.12 canonicalization helper (`src/lease_plane/canonicalize.py`) and its 6 test gates.
+- The §7.11 deprecation CLI (`lease-plane deprecate / deprecation-sweep / deprecation-finalize`) and its 6 test gates.
+- The §7.3.2 retry-with-backoff client method (`acquire_with_retry`).
+- The HTTP transport HTTP-409 body-parse test (`test_urllib_transport_parses_409_body`).
+- The §7.10 `LEASE_FORCE_RELEASE_TOKEN` integration test (already named in §9; lands with the deprecation CLI in PR 3).
+
+### PR 1 — RFC gate → code surface → test name → status table
+
+| RFC gate | Code surface | Test name | Status |
+|----------|--------------|-----------|--------|
+| §7.2.2 storage CHECK on `surface_id` scheme grammar | `db/postgres/migrations/026_lease_plane_grammar.sql` (new) | `test_migration_026_grammar_check_rejects_invalid_scheme` (Python pytest hitting live DB) | TODO |
+| §7.2.3 generated `surface_kind` column | same migration 026 (DROP COLUMN + ADD COLUMN ... GENERATED ALWAYS AS STORED) | `test_migration_026_surface_kind_is_generated_column` | TODO |
+| §7.2.3 caller cannot supply conflicting `surface_kind` | same migration 026 (generated column is read-only at INSERT) | `test_surface_kind_insert_with_conflicting_value_raises` | TODO |
+| §7.11.1 `deprecated_schemes` + `surface_kind_catalog` tables | `db/postgres/migrations/027_lease_plane_deprecation.sql` (new) | `test_migration_027_deprecated_schemes_table_exists` | TODO |
+| §7.11.1 catalog seeded with 5 schemes (file/dialectic/resident/capture/td) | same migration 027 (`INSERT INTO surface_kind_catalog ...`) | `test_migration_027_surface_kind_catalog_seeded` | TODO |
+| §7.3.2 `AcquireHeldByOther` extended typed-absence shape (v0.7 drift fix 1) | `src/lease_plane/models.py` — add `surface_id`, `blocking_lease_id`, `retry_after_hint_ms` fields | `test_held_by_other_includes_v0_7_extended_fields` | TODO |
+| §7.2.3 router does not accept `surface_kind` in acquire body (v0.7 drift fix 2) | `elixir/lease_plane/lib/unitares_lease_plane/http_router.ex` — drop `"surface_kind"` from required + params map in `extract_acquire_params` | Elixir-side: `test http_router rejects surface_kind in acquire body after migration 026` | TODO |
+| §7.10 + §7.11.5 Sentinel `event_type='forced'` alarm rule wired (v0.7 drift fix 3) | `agents/sentinel/agent.py` — add alarm rule reading `lease_plane_events` for `event_type='forced'`; per-event for ad-hoc, batched-by-`deprecation_id` for `event_type='lease.deprecation_swept'` | `test_sentinel_force_release_alarm_wired` (covers both per-event + batched paths) | TODO |
+
+**Total: 8 rows. Within ~10-row guidance.**
+
+### Specific implementation notes
+
+#### Migration 026 sequencing concern
+
+The v0.8 RFC §7.2.3 names migration 026 as `ALTER TABLE ... DROP COLUMN surface_kind; ALTER TABLE ... ADD COLUMN surface_kind text GENERATED ALWAYS AS (split_part(surface_id, ':', 1)) STORED`. Live-verifier confirmed `surface_leases` is empty in production, so the DROP is safe. **Pre-flight check the migration MUST do:** if any rows exist, abort with a clear error pointing at the v0.8 RFC §7.2.3 fallback (CHECK-pair option). Do not silently DROP a populated column.
+
+The grammar CHECK regex from v0.8 §7.2.2: `surface_id ~ '^(file://|dialectic:/|resident:/|capture:/|td:/)'`. Note the `file://` is double-slash; others are single-slash. This is intentional per §7.2.1 (file:// preserved for filesystem-URI tradition).
+
+#### Migration 027 schema
+
+`surface_kind_catalog` is the first-class registry; `deprecated_schemes.surface_kind` FKs into it. The v0.8 RFC §7.11.1 sketches the table; reviewer should compare the migration to that sketch row-by-row. Note `drain_window_days` CHECK constraint: `> 0 AND <= 90`.
+
+#### `AcquireHeldByOther` model change
+
+Currently in `src/lease_plane/models.py`:
+```python
+class AcquireHeldByOther(BaseModel):
+    ok: Literal[False]
+    error: Literal["held_by_other"]
+    held_by_uuid: UUID
+    expires_at: datetime
+```
+
+After this PR (per v0.8 §7.3.2 contract):
+```python
+class AcquireHeldByOther(BaseModel):
+    ok: Literal[False]
+    error: Literal["held_by_other"]
+    surface_id: str
+    blocking_lease_id: UUID
+    held_by_uuid: UUID
+    expires_at: datetime
+    retry_after_hint_ms: int
+```
+
+The Elixir router must populate the new fields; that's a separate small router edit in this PR. `_parse_acquire` in `client.py` does not need changes — Pydantic's `model_validate` will pick up the new fields automatically.
+
+#### `extract_acquire_params` change
+
+Today (per `http_router.ex` line 191): `required = ["surface_id", "surface_kind", "holder_agent_uuid", "holder_kind", "ttl_s"]`. After PR 1: drop `"surface_kind"` from required and from the params map at line 216. The Repo INSERT relies on the generated column; supplying `surface_kind` would raise `ERROR: column "surface_kind" is a generated column`.
+
+#### Sentinel alarm rule
+
+Currently no rule keyed on `release_reason` or `event_type='forced'` exists in `agents/sentinel/agent.py` (live-verifier Finding 5 SOURCE_ONLY). Add a rule that:
+
+1. Polls `lease_plane.lease_plane_events` for `event_type='forced'` since last poll.
+2. For events where the corresponding lease's `release_reason='forced'` AND `event_type != 'lease.deprecation_swept'`: emit one alarm per event (per §7.10 alarm-on-every-event rule).
+3. For events where `event_type='lease.deprecation_swept'`: group by `deprecation_id`, emit one summary alarm per `deprecation_id` after `sweep_completed_at` is set on the corresponding `deprecated_schemes` row (per §7.11.5 batch suppression).
+
+The rule needs `lease_plane_events` SELECT access. If Sentinel doesn't already have it, the migration step adds the GRANT.
+
+## PR 2 — §7.12 canonicalization helper (planned, not yet drafted)
+
+Scope (anticipated; will reify when PR 1 lands):
+- `src/lease_plane/canonicalize.py` (new) implementing the §7.12.1 server-side rule: tmpfile probe, double-realpath, scheme dispatch, `capture:/` member sorting.
+- Pydantic `field_validator` on `AcquireRequest.surface_id` calling the helper.
+- Helper error semantics (§7.12.2): `CanonicalizeError` exception with `reason` codes.
+- 6 §7.12 Phase A test gates.
+
+Rationale for separating from PR 1: the helper is a self-contained module with no schema/contract dependency on the migration changes. Reviewing it independently keeps the cognitive load tractable.
+
+## PR 3 — §7.11 deprecation CLI (planned, not yet drafted)
+
+Scope (anticipated):
+- `lease-plane` CLI commands: `deprecate`, `deprecation-sweep`, `deprecation-finalize` (Elixir Mix tasks or Python script — TBD).
+- `LEASE_FORCE_RELEASE_TOKEN` integration test (covers §7.10 + §7.11 force-release wiring).
+- Phase 2 sweep Oban job with idempotent predicate.
+- Phase 0 race-window mitigation (serializable-tx + advisory lock).
+- 6 §7.11 Phase A test gates + 1 §7.10 force-release test.
+
+Rationale: depends on PR 1 (catalog + deprecated_schemes tables must exist) and on operator-runbook content for the CLI documentation. Lands after both.
+
+## PR 4+ — Remaining gates
+
+- §7.3.3 `acquire_with_retry()` jittered backoff method
+- §7.3.5 HTTP 409 body-parse test (`test_urllib_transport_parses_409_body`)
+- Phase B prerequisites (payload-shape standardization spec, `unitares_doctor` extension)
+
+These are mostly self-contained; pick up after PR 1-3 land.
+
+## Reviewer checklist for any Phase A PR
+
+A Phase A PR is reviewable iff:
+
+- [ ] PR description includes the four-column RFC↔code table for the rows it implements.
+- [ ] Every code change in the diff is referenced by exactly one row in the table (or explicitly called out as a refactor / cleanup).
+- [ ] Every test added in the diff is named in the table.
+- [ ] Out-of-scope rows are marked `(deferred to PR N)` so reviewers don't ask "where's gate X?".
+- [ ] If the PR touches a runtime surface listed in `CLAUDE.md` "Before Starting Work on a Single-Writer Surface", the surface-collision check (`gh pr list ... --search`) was run; result included in the description.
+
+## Migration-window and ship-order constraints
+
+- Migration 026 must ship before any caller starts populating `surface_leases`. Live-verifier confirmed the table is empty as of v0.8 council pass; this remains true iff no Phase A code lands between v0.8 RFC freeze and PR 1 merge. Do not start any other lease-plane code work in parallel.
+- Migration 027 ships in the same PR as 026 to avoid a window where `surface_kind_catalog` doesn't exist but PR 3's CLI tries to FK against it.
+- The v0.7 drift fix to `http_router.ex` MUST land in the same merge as migration 026 — partial deploy where 026 lands but the router still requires `surface_kind` from the body causes hard runtime failure on every acquire.
+
+## Open questions for operator before PR 1 starts
+
+1. **CLI ergonomics for `lease-plane deprecate ...`** — Mix task in the Elixir app, or standalone Python CLI in `scripts/dev/`? (Defer to PR 3, but flag now so the CLI doesn't surprise.)
+2. **Sentinel polling interval for the new alarm rule** — current Sentinel has its own cadence; should the lease-plane events poll be more aggressive, given §7.10's "rare events" framing? (Default: same cadence as existing Sentinel rules.)
+3. **Migration 026 pre-flight check** — abort with error if `surface_leases` is non-empty (safe; matches v0.8 RFC §7.2.3 caveat), or proceed with DROP COLUMN regardless (faster but risks data loss)? (Default: abort if non-empty.)

--- a/docs/proposals/surface-lease-plane-v0.md
+++ b/docs/proposals/surface-lease-plane-v0.md
@@ -1,7 +1,7 @@
 ---
-status: DRAFT-v0.4 (council-clean; cross-linked with parallel ontology-track plan; implementation skeleton captured)
+status: DRAFT-v0.6 (§7.9 + §7.10 promoted Tentative → Resolved; council pass queued on §7.2/§7.3)
 authored: 2026-04-30
-amended: 2026-04-30 (v0.1, v0.2, v0.3, v0.4 same session)
+amended: 2026-04-30 (v0.1, v0.2, v0.3, v0.4, v0.5, v0.6 same session)
 council_pass_1: 2026-04-30
 ack_pass_1: 2026-04-30
 author_session: agent-68437d77-65c (claude_code-claude_68437d77)
@@ -567,23 +567,27 @@ Three options:
 
 **Anti-recursion guard:** the lease plane MUST NOT acquire leases for its own outbox writes (would be a self-deadlock at startup). This is enforced by code: the lease-plane-internal Postgres role does not have `INSERT` privilege on `surface_leases` for `surface_kind='lease_plane'`. Belt-and-braces.
 
-### 7.9 Surface_id renames / re-keying (council finding 4.2)
+### 7.9 Surface_id renames / re-keying (council finding 4.2) — RESOLVED in v0.6
 
 A file rename, dialectic-session ID rotation, or resident relabel changes a surface's canonical ID. Active leases keyed on the old ID become orphans; new acquires on the new ID succeed; the "same surface" is double-leased semantically while the index thinks each entry is unique.
 
-**Tentative:** v0 does not handle this. Active leases on a renamed surface must be explicitly released by the holder and re-acquired against the new ID. If the holder is unaware of the rename (e.g., another agent renamed the file), the orphan lease ages out via TTL. Document the gap in the operator runbook; revisit in a v1 if it becomes a real-world incident.
+**Resolution:** v0 explicitly does not handle rename-aware relocation. Active leases on a renamed surface must be explicitly released by the holder and re-acquired against the new ID. If the holder is unaware of the rename (e.g., another agent renamed the file out from under it), the orphan lease ages out via TTL on its `original_ttl_s` clock — at most 1h per the §4.4 hard cap. The "double-leased semantically" window is bounded by `original_ttl_s` and not surfaced as a caller-facing error.
 
-**Open question:** should `surface_id` be a *content-derived hash* (e.g., file inode + creation timestamp) instead of the literal path, to make renames invisible to the lease layer? This trades simplicity for robustness and probably belongs in v1, not v0.
+**Operator-runbook commitment:** `docs/operations/lease-plane-operator-runbook.md` MUST document the rename-orphan failure mode and the manual-release procedure before Phase A ships. Tracked in §9 checklist.
 
-### 7.10 Force-release authority (council finding 4.3)
+**Deferred to v1 (not v0):** content-derived `surface_id` (e.g., file inode + ctime, dialectic-session content-hash) to make renames invisible to the lease layer. Trades simplicity for robustness; warrants its own RFC. Until then, the rename gap is a *known and bounded* operational hazard, not an unresolved design question.
+
+### 7.10 Force-release authority (council finding 4.3) — RESOLVED in v0.6
 
 `release_reason='forced'` exists in §4.4.1 vocabulary but the RFC didn't specify *who can issue it*. Force-release is a privilege-escalation surface: any caller who can force-release can free another agent's lease and acquire it themselves.
 
-**Tentative:** force-release requires a separate elevated bearer token. Token name conforms to the existing `~/.config/cirwel/secrets.env` convention (noun-first, `_TOKEN` suffix; cf. `ZENODO_TOKEN`, `CLOUDFLARE_API_TOKEN`, `WORKERS_API_TOKEN`): **`LEASE_FORCE_RELEASE_TOKEN`** (closes ack-pass DRIFT: prior `OPERATOR_FORCE_RELEASE_TOKEN` broke the pattern). Operator-only. Logged to `lease_plane_events` with `event_type='forced'` and the operator's session_id, projected to `audit.tool_usage` like any other event. Sentinel alarm fires on every force-release event regardless of context — this is rare enough that an alarm-on-every-event is appropriate, not noisy.
+**Resolution:** force-release requires a separate elevated bearer token. Token name conforms to the existing `~/.config/cirwel/secrets.env` convention (noun-first, `_TOKEN` suffix; cf. `ZENODO_TOKEN`, `CLOUDFLARE_API_TOKEN`, `WORKERS_API_TOKEN`): **`LEASE_FORCE_RELEASE_TOKEN`**. Operator-only. Logged to `lease_plane_events` with `event_type='forced'` and the operator's session_id, projected to `audit.tool_usage` like any other event. Sentinel alarm fires on every force-release event regardless of context — this is rare enough that an alarm-on-every-event is appropriate, not noisy.
 
-**Scope (v0): force-release is local-Mac-only, by design** (closes ack-pass CONCERN: token distribution for remote operator sessions). The token lives at `~/.config/cirwel/secrets.env` mode 600 on the governance MCP host. Off-host force-release (laptop while traveling, remote `:observer` session) is *not supported in v0*; the operator either SSHes to the Mac or waits for the lease's TTL. v1 may revisit this with the Cloudflare-tunnel + `X-Anima-Admin` pattern (cf. `anima-admin-gate.md`) if real-world incidents justify the token-distribution complexity.
+**Scope (v0): force-release is local-Mac-only, by design.** The token lives at `~/.config/cirwel/secrets.env` mode 600 on the governance MCP host. Off-host force-release (laptop while traveling, remote `:observer` session) is *not supported in v0*; the operator either SSHes to the Mac or waits for the lease's TTL. v1 may revisit this with the Cloudflare-tunnel + `X-Anima-Admin` pattern (cf. `anima-admin-gate.md`) if real-world incidents justify the token-distribution complexity.
 
-**Anti-pattern:** the standard MCP bearer token (`GOVERNANCE_TOKEN`) must NOT permit force-release. Confirmed via integration test before Phase A ships.
+**Anti-pattern (test-gated):** the standard MCP bearer token (`GOVERNANCE_TOKEN`) must NOT permit force-release. **Phase A ships only after** an integration test confirms that a force-release request authenticated with `GOVERNANCE_TOKEN` (and any token *other than* `LEASE_FORCE_RELEASE_TOKEN`) is rejected at the contract layer, not just the application layer. This test is a §9 checklist gate.
+
+**Token-rotation note:** `LEASE_FORCE_RELEASE_TOKEN` follows the same rotation cadence as other operator-scoped tokens at `~/.config/cirwel/secrets.env`. No special rotation infrastructure required for v0; rotation is manual operator action followed by `launchctl kickstart` of the lease-plane LaunchAgent to reload the secrets.env.
 
 ## 8. Concerns / counter-arguments / minority views
 
@@ -619,11 +623,12 @@ A Python reference implementation of every endpoint in §5 (`asyncio.Lock` per-s
 
 Required before any `.ex` file is written:
 
-- [ ] Council pass: dialectic-knowledge-architect, feature-dev:code-reviewer, live-verifier (parallel)
-- [ ] §7 open questions all answered (RFC tentative -> RFC committed)
-- [ ] Shelf-Python sketch checked in alongside the Elixir spec — same schema, same API, same return shapes
-- [ ] Operational runbook draft: `docs/operations/lease-plane-operator-runbook.md` (stub created alongside this RFC; needs concrete commands once the service exists)
+- [x] Council pass: dialectic-knowledge-architect, feature-dev:code-reviewer, live-verifier (parallel) — v0.2/v0.3/v0.5
+- [ ] §7 open questions all answered (RFC tentative -> RFC committed) — §7.1/7.4/7.6/7.8 resolved v0.2; §7.5/7.7 resolved v0.2 with operator-action carve-out; **§7.9/7.10 resolved v0.6**; §7.2/7.3 council pass queued v0.6
+- [x] Shelf-Python sketch checked in alongside the Elixir spec — same schema, same API, same return shapes (v0.4)
+- [ ] Operational runbook draft: `docs/operations/lease-plane-operator-runbook.md` (stub created alongside this RFC; needs concrete commands once the service exists). **v0.6 commitment:** runbook MUST cover (a) §7.9 rename-orphan manual-release procedure, and (b) §7.10 `LEASE_FORCE_RELEASE_TOKEN` provisioning + rotation steps.
 - [ ] Sentinel monitoring spec for `/v1/lease/status?surface_id=__healthcheck__`
+- [ ] **Integration test (§7.10 gate):** confirm `GOVERNANCE_TOKEN` cannot force-release; only `LEASE_FORCE_RELEASE_TOKEN` succeeds. Rejection at contract layer, not application layer.
 - [ ] Decision: which exact surface_kind goes first into advisory (probably `dialectic:/`)
 - [ ] Decision on §6.1 promotion-gate criteria — what specifically counts as "the conflict log says 'we would have prevented a real bug here'"
 
@@ -639,6 +644,30 @@ This is a 4-8 week spike. It trades against:
 The technical case is strong (three independent reviewers converged). The strategic case is the operator's call. If shelved, file this RFC as captured-decision so the next session doesn't re-litigate the substrate question from scratch.
 
 ## 11. Versions / changelog
+
+- **v0.6 (2026-04-30, same session):** Promoted §7.9 (surface_id renames) and §7.10 (force-release authority) from *Tentative* to *Resolved*, locking in the v0.2/v0.3 text as committed contract. Council pass queued in parallel on the two remaining open questions (§7.2 surface ID schema; §7.3 conflict semantics on `held_by_other`). Material changes:
+
+  *§7.9 — Resolved:*
+  - "v0 does not handle this" promoted from tentative to *committed scope*. The orphan window is now characterized as bounded (≤ `original_ttl_s`, hard-capped at 1h per §4.4); it is a *known and bounded* operational hazard, not an unresolved design question.
+  - Operator-runbook commitment surfaced explicitly: rename-orphan failure mode + manual-release procedure must land before Phase A. Tracked in §9 checklist.
+  - Content-derived `surface_id` (inode + ctime, dialectic-session content-hash) deferred to v1 RFC; called out by name so future readers don't re-litigate.
+
+  *§7.10 — Resolved:*
+  - `LEASE_FORCE_RELEASE_TOKEN` at `~/.config/cirwel/secrets.env` (mode 600, local-Mac-only, Sentinel-alarm-on-every-event) is the committed mechanism.
+  - Anti-pattern test promoted from "Confirmed via integration test before Phase A ships" prose to a §9 checklist gate: `GOVERNANCE_TOKEN` cannot force-release; only `LEASE_FORCE_RELEASE_TOKEN` succeeds; rejection at the contract layer, not application layer. Phase A blocks on this test passing.
+  - Token-rotation note added: manual operator action + `launchctl kickstart` of the lease-plane LaunchAgent. No special rotation infrastructure for v0.
+
+  *§9 checklist:*
+  - Council-pass and shelf-Python items marked complete with backreferences.
+  - §7-open-questions item annotated with per-§ resolution status; §7.2/§7.3 explicitly named as the remaining queue.
+  - New checklist row added for the §7.10 integration-test gate.
+
+  *Council queue (not yet executed):*
+  - §7.2 (Surface ID schema — typed scheme `file:///`, `dialectic:/`, `td:/`, `resident:/` vs opaque; per-holder cardinality)
+  - §7.3 (Conflict semantics on `held_by_other` — abort default vs wait-with-timeout vs auto-handoff)
+  - Council to be dispatched in parallel: `dialectic-knowledge-architect` + `feature-dev:code-reviewer` + `live-verifier`, adversarial framing per `feedback_council-adversarial-prompt.md`.
+
+  *No schema, contract, or implementation changes.* This version is purely status promotion and council scheduling; no new technical claims beyond what was already in v0.2/v0.3.
 
 - **v0.5 (2026-04-30, same session):** Implementation council on the captured `src/lease_plane/` skeleton (parallel: dialectic-knowledge-architect / feature-dev:code-reviewer / live-verifier; adversarial framing per `feedback_council-adversarial-prompt.md`). One critical bug + four contract-staleness items found and addressed in this revision. Material changes:
 

--- a/docs/proposals/surface-lease-plane-v0.md
+++ b/docs/proposals/surface-lease-plane-v0.md
@@ -1,7 +1,7 @@
 ---
-status: DRAFT-v0.6 (§7.9 + §7.10 promoted Tentative → Resolved; council pass queued on §7.2/§7.3)
+status: DRAFT-v0.7 (§7.2 + §7.3 resolved; §7.11 + §7.12 added as Tentative; Phase A test gates bundled in §9)
 authored: 2026-04-30
-amended: 2026-04-30 (v0.1, v0.2, v0.3, v0.4, v0.5, v0.6 same session)
+amended: 2026-04-30 (v0.1–v0.7 same session)
 council_pass_1: 2026-04-30
 ack_pass_1: 2026-04-30
 author_session: agent-68437d77-65c (claude_code-claude_68437d77)
@@ -482,28 +482,171 @@ Council finding 1.1 (dialectic-knowledge-architect) flagged that keying leases o
 
 `holder_kind` is **immutable per `lease_id`** — switching from `remote_heartbeat` to `local_beam` mid-life requires release+reacquire (council finding 3.1). Postgres CHECK constraint enforces the (heartbeat_required, holder_kind) pair coherence.
 
-### 7.2 Surface ID schema
+### 7.2 Surface ID schema — RESOLVED in v0.7
 
-Opaque string, or typed scheme?
+Opaque string, or typed scheme? Council pass v0.7 (parallel: dialectic-knowledge-architect, feature-dev:code-reviewer, live-verifier) found three-voice convergence on "no storage-layer CHECK on `surface_id` despite RFC framing it as 'validatable'", plus a self-contradiction between §3.3's enumerated surfaces (5 schemes including `capture:/`) and §7.2's tentative grammar (4 schemes, no `capture:`).
 
-- Opaque: simplest, but no validation, no namespace discipline, surface-kind detection is by-convention.
-- Typed scheme (`file:///...`, `dialectic:/...`, `td:/...`, `resident:/...`): namespaced, validatable, surface_kind is derivable. Bounded grammar.
+**Resolution: typed scheme, defense-in-depth, with canonical scheme list.**
 
-**Tentative:** typed scheme. `surface_kind` is the parsed scheme prefix; `surface_id` is the full canonical URI. Document the grammar in this RFC §4.4 once chosen.
+#### 7.2.1 Canonical scheme list (v0)
 
-Cardinality bound on active leases per surface: 1 (the unique partial index). Cardinality bound per holder: open question — should one agent UUID be allowed to hold N leases concurrently? Hermes-style multi-file edits will need this.
+Authored once here; §3.3 surface enumeration MUST stay consistent with this list.
 
-**Tentative:** unbounded per holder; bounded per surface. Telemetry alerts if any single UUID exceeds a soft threshold (signals stuck/leaking holder).
+| Scheme | Surface_kind | Status v0 | Notes |
+|--------|--------------|-----------|-------|
+| `file://` | `file` | active | repo file paths; canonicalization rules in §7.2.4 |
+| `dialectic:/` | `dialectic` | active | dialectic session IDs |
+| `resident:/` | `resident` | active | resident lifecycle handles |
+| `capture:/` | `capture` | active | calibration capture windows |
+| `td:/` | `td` | reserved | TouchDesigner regions; not implemented v0 |
 
-### 7.3 Conflict semantics on `held_by_other`
+Single-slash form (`scheme:/path`) is canonical for all schemes *except* `file://` (kept double-slash for `file://` filesystem-URI tradition; the trailing `/` of an absolute path provides the third slash, e.g., `file:///Users/cirwel/...`).
 
-What's the caller default behavior?
+#### 7.2.2 Grammar enforcement (defense-in-depth)
 
-- **Wait** (with timeout) until the lease frees: friendly, but creates queueing pressure inside callers and reintroduces the asyncio.Lock bug class one altitude up.
-- **Abort** (return failure to operator): honest, but every caller now has retry logic.
-- **Auto-request handoff:** clean, but requires a holder that responds to handoff offers, which not all holder classes do (Hermes doesn't, Claude Code doesn't, only deliberate residents would).
+Three layers, each named:
 
-**Tentative:** abort by default. Caller decides whether to retry. Handoff is opt-in, used for specific surface kinds (resident:/ during planned restart, dialectic:/ during reviewer reassignment).
+1. **Postgres CHECK constraint** (migration 026 — required before Phase A): `CHECK (surface_id ~ '^(file://|dialectic:/|resident:/|capture:/|td:/)')`. Storage-layer rejection of malformed values. Live-verifier DRIFT-A confirmed migration 024 has no such CHECK today; this closes the gap.
+2. **Pydantic field_validator** on `AcquireRequest.surface_id` and `LeaseRecord.surface_id`: regex match against the canonical scheme list. Caller-side rejection before HTTP. Live-verifier confirmed today's `Field(min_length=1)` is the only enforcement on the Python side.
+3. **Elixir Ecto changeset validation**: enum-based scheme parser, compile-time exhaustive over the `@surface_schemes` module attribute. Server-side rejection before transaction starts.
+
+Layers (1) and (2) are required Phase A gates (§9 checklist). Layer (3) is Elixir-side and lands with the BEAM service implementation.
+
+#### 7.2.3 surface_kind ↔ surface_id consistency — DB-enforced via generated column
+
+surface_kind MUST NOT be application-only. Three options were considered:
+
+- (a) **Generated column** (chosen v0.7): `surface_kind text GENERATED ALWAYS AS (split_part(surface_id, ':', 1)) STORED`. Single source of truth, derived from surface_id at storage time, impossible to drift. Caller-supplied `surface_kind` becomes redundant and SHALL be removed from `AcquireRequest` and the §5 endpoint body. Live-verifier confirmed `surface_leases` is empty in production, so the migration-026 conversion (DROP COLUMN + ADD COLUMN ... GENERATED) is safe.
+- (b) **DB CHECK pair** (fallback if (a) is too disruptive at migration time): keep `surface_kind` as a regular column, add a CHECK constraint in migration 026 binding scheme prefix to surface_kind. Caller still supplies both; server-side enforcement is at the storage layer, not the application layer. Mismatch rejected with `schema_invalid`.
+- (c) ~~Application-only~~ — REJECTED. surface_kind enforcement at the application layer alone is insufficient because any direct SQL writer (governance-side projection, future operational scripts) bypasses it.
+
+**Adopted (v0.7): option (a) generated column.** Migration 026:
+
+```sql
+ALTER TABLE lease_plane.surface_leases DROP COLUMN surface_kind;
+ALTER TABLE lease_plane.surface_leases
+  ADD COLUMN surface_kind text
+  GENERATED ALWAYS AS (split_part(surface_id, ':', 1)) STORED;
+
+-- The grammar CHECK on surface_id (§7.2.2) keeps surface_kind in the canonical
+-- vocabulary; no separate surface_kind CHECK needed since the value is derived.
+ALTER TABLE lease_plane.surface_leases
+  ADD CONSTRAINT surface_id_grammar
+  CHECK (surface_id ~ '^(file://|dialectic:/|resident:/|capture:/|td:/)');
+```
+
+If the empty-table assumption changes between now and migration 026 ship time (i.e., Phase A advisory traffic lands first), fall back to option (b): keep the column, add the CHECK-pair binding scheme→kind, and treat caller-supplied surface_kind as a redundant input that the server validates against the parsed prefix. Either way, **the storage layer is authoritative** — application-only enforcement is not on the table.
+
+Cross-API impact (option a): `AcquireRequest.surface_kind` is removed from §5 `/v1/lease/acquire` body. `LeaseRecord.surface_kind` remains in responses (read-only echo of the stored generated value).
+
+#### 7.2.4 file:// canonicalization
+
+See **§7.12** for the v0 canonicalization rule and the v1 forward-compat path with §7.9 content-addressing. §7.2 commits that callers MUST use the canonicalization helper before acquire/status/release; §7.12 specifies the helper.
+
+#### 7.2.5 Cardinality bounds (closes dialectic CONCERN-4)
+
+- **Per surface:** exactly 1 active lease, enforced by the partial unique index `surface_leases_active_unique`. Live-verifier confirmed.
+- **Per holder:** unbounded by design. Hermes-style multi-file edits need it; capping per-holder would block a real workload.
+
+**Threat model (v0):** callers are authenticated holders; runaway-acquisition is a holder-bug class, not an external-attacker class. Mitigation:
+
+```sql
+-- Sentinel alarm threshold: 100 concurrent leases per holder
+SELECT count(*) FROM lease_plane.surface_leases
+WHERE holder_agent_uuid = $1 AND released_at IS NULL > 100
+```
+
+Threshold of 100 is initial; tunable via Sentinel config. The alert is **reactive** — it fires after a holder is already at threshold. Per-holder rate-limiting (acquires/sec) is **deferred to v1** and is the correct response if telemetry shows real-world holders crossing 100 concurrent leases routinely. v0 ships the alert without the throttle, with explicit acknowledgement that it is reactive — not a defense against adversarial fan-out, only an early-warning for holder-bug fan-out.
+
+#### 7.2.6 Pruning policy for `surface_leases` (closes code-reviewer CONCERN-3)
+
+Released rows accumulate indefinitely without explicit pruning. Migration 024 has no DELETE trigger. The partial unique index continues to work efficiently (released rows are excluded from the index), but the table itself grows unbounded.
+
+**v0 pruning:** Oban-scheduled job runs daily and DELETEs `surface_leases` rows where `released_at < now() - interval '30 days'`. Audit history is preserved via `lease_plane_events` (which has its own 30-day-after-`forwarded_at` pruning, §7.6) and via the projection into `audit.tool_usage` (canonical, never pruned by lease-plane code).
+
+#### 7.2.7 Status/release path normalization (closes code-reviewer CONCERN-4)
+
+`/v1/lease/status?surface_id=...` and `/v1/lease/release` body must apply the same canonicalization rules as acquire. The Python client helper SHALL apply normalization at the `LeasePlaneClient` method boundary, not at the transport boundary, so all three call paths (acquire/status/release) share the same normalization.
+
+#### 7.2.8 §6.1 promotion-gate criterion 5 cross-reference
+
+§6.1 criterion 5's `payload->>'surface_id' LIKE $1 || ':%'` predicate assumes un-encoded `surface_id` in the audit payload. The payload-shape standardization pass (named in §6.1 as a Phase B prerequisite) MUST commit to writing canonicalized `surface_id` (per §7.2.4) into `audit.tool_usage.payload`, with no percent-encoding. Cross-tracked in §9 checklist.
+
+#### 7.2.9 Forward-compat for unknown schemes
+
+Per dialectic CONCERN-3, scheme additions are migrations: a new `surface_kind` requires (a) Postgres migration extending the CHECK constraint, deployed before (b) the BEAM module rollout that begins INSERTing the new scheme. The `unitares_doctor.py` script SHALL be extended to lint that no Elixir source mentions a scheme not in the live CHECK. Tracked in §9 checklist as a Phase B prerequisite, not Phase A.
+
+Scheme deprecation/migration: see §7.11.
+
+### 7.3 Conflict semantics on `held_by_other` — RESOLVED in v0.7
+
+What's the caller default behavior? Council pass v0.7 reframed this from a single global default to a default-with-per-surface-kind-override slot. Three voices converged that "abort everywhere" is the *safe* default but not universally correct: file edits want loud-fail-on-collision, dialectic-reviewer assignment is friendlier with bounded queueing, resident lifecycle wants loud-fail, capture is too long to wait for. Council also flagged that abort-by-default with no backoff guidance ships a thundering-herd vector at the Postgres index-contention layer, and that the current `AcquireHeldByOther` shape gives callers insufficient information for sane retry logic.
+
+**Resolution: abort by default, with per-surface-kind override slot for Phase B promotion. Extended `held_by_other` shape. Mandatory backoff guidance for callers.**
+
+#### 7.3.1 Global default and override slot
+
+**v0 ships abort-only globally.** All surface_kinds default to `conflict_default = "abort"`. Per-surface-kind override is a Phase B promotion-time configuration, not a v0 deployment-time flag.
+
+| surface_kind | v0 default | Anticipated Phase B target | Rationale |
+|--------------|------------|----------------------------|-----------|
+| `file` | `abort` | `abort` | Concurrent edit → merge conflict → loud failure is correct semantic |
+| `dialectic` | `abort` | `wait_with_deadline=2s` | Reviewer assignment is fast; queueing friendlier than retry-loop |
+| `resident` | `abort` | `abort` | Only one restart at a time; loud-fail correct |
+| `capture` | `abort` | `abort` | Capture is long (~minutes); wait blocks calibration substrate |
+| `td` | `abort` | TBD | Reserved; not implemented v0 |
+
+Override values for Phase B: `{abort, wait_with_deadline=Nms, handoff_offer}`. The Phase B promotion config (§6.2) gains a `conflict_default` field per surface_kind. Promoting `dialectic:/` to `wait_with_deadline=2000` is anticipated but not committed in v0.
+
+**Out of scope for v0:** queue-with-bounded-depth and speculative-wait-with-deadline-per-call (per dialectic CONCERN-7). Both are coherent extensions; deferred to v1 if real-world telemetry indicates the abort+per-kind-override matrix is insufficient.
+
+#### 7.3.2 Extended `AcquireHeldByOther` typed-absence shape
+
+Council code-reviewer BLOCK-3 + CONCERN-6: callers currently cannot (a) distinguish "same stuck holder across retries" from "rotating cast of short-lived holders", or (b) correlate concurrent multi-surface acquires with which surface is blocked. v0.7 extends the §4.5 shape:
+
+```
+{ok: false, error: "held_by_other",
+ surface_id,                  -- echo of the requested surface (multi-acquire correlation)
+ blocking_lease_id,           -- which lease is blocking (retry-discrimination)
+ held_by_uuid,
+ expires_at,
+ retry_after_hint_ms}         -- min(remaining_ttl_ms, 5000); advisory, not enforced
+```
+
+`retry_after_hint_ms` is server-computed at conflict time. Callers MAY ignore it. The hint exists so well-behaved callers can rate-limit themselves without parsing `expires_at` and computing the delta.
+
+§4.5 typed-absence spec, §5 endpoint table, and `src/lease_plane/models.py` `AcquireHeldByOther` Pydantic model all need updating to match. Tracked in §9 checklist.
+
+#### 7.3.3 Backoff guidance (closes dialectic BLOCK-6 — thundering-herd)
+
+"Caller decides whether to retry" with no rate-limit guidance is a thundering-herd vector. Concrete data path: ship.sh fans out N parallel session worktrees, all attempting `lease_acquire('file:///<path>')`. One wins; N-1 receive `held_by_other`. If they retry immediately, they convoy on `surface_leases_active_unique` — O(N) acquires per contention window, each one a row INSERT-or-409 against the same partial unique index.
+
+**Caller library contract (v0.7):**
+
+- The `LeasePlaneClient` Python helper SHALL implement jittered exponential backoff if its `acquire_with_retry()` convenience method is used: floor 100ms, ceiling 5s, full jitter (per AWS Architecture Blog convention).
+- If the caller wraps `acquire()` with custom retry, they SHOULD honor `retry_after_hint_ms` as a lower bound, then add their own jitter.
+- The lease plane itself does NOT enforce backoff server-side; this is a contract on caller libraries.
+
+The bare `acquire()` method remains single-shot (no built-in retry) so callers who genuinely want immediate-fail-on-conflict (e.g., interactive operator commands) keep that semantic.
+
+#### 7.3.4 Handoff opt-in semantics
+
+Handoff is opt-in per-surface-kind, used for specific surface kinds where the holder participates in lifecycle coordination. Anticipated v1 wiring:
+
+- `resident:/` during planned restart: outgoing resident issues handoff_offer to incoming resident before exiting.
+- `dialectic:/` during reviewer reassignment: facilitator issues handoff_offer to new reviewer before tearing down the dialectic session.
+
+Hermes, Claude Code, Codex sessions, and most ephemeral holders do NOT respond to handoff offers — for them, handoff is undefined behavior. v0 ships handoff endpoints (per §5) but no holder classes wire handoff acceptance; first wiring lands with the first resident-class promotion to enforcement.
+
+#### 7.3.5 HTTP status convention (closes code-reviewer NIT-1)
+
+Live-verifier confirmed Elixir router returns HTTP 409 on `held_by_other` with the typed-absence body. v0.7 commits this:
+
+- `/v1/lease/acquire` returns HTTP 409 with the §7.3.2 body on `held_by_other`.
+- All other typed-absence error shapes return HTTP 200 with `ok: false` in the body (transport-level success, application-level failure).
+- HTTP 409 is reserved for `held_by_other`; HTTP 4xx other than 409 indicates transport-level failure (auth, malformed request, route not found).
+
+The Python `_urllib_transport` already handles HTTP 409 by parsing the body as JSON and returning it; this convention is now a contract requirement, not an implementation detail. §5 endpoint table updated to note "409 on held_by_other; 200 + ok:false otherwise".
 
 ### 7.4 Reaper authority on local-holder death — RESOLVED in v0.2
 
@@ -589,6 +732,56 @@ A file rename, dialectic-session ID rotation, or resident relabel changes a surf
 
 **Token-rotation note:** `LEASE_FORCE_RELEASE_TOKEN` follows the same rotation cadence as other operator-scoped tokens at `~/.config/cirwel/secrets.env`. No special rotation infrastructure required for v0; rotation is manual operator action followed by `launchctl kickstart` of the lease-plane LaunchAgent to reload the secrets.env.
 
+### 7.11 Surface-kind deprecation / migration (council finding v0.7) — Tentative
+
+**Question:** how does the lease plane retire a `surface_kind` (e.g., `td:/` deprecated in v3 because the TouchDesigner integration was abandoned)? What about migrating semantics within a kind (e.g., `resident:/` v0 = process PID, v1 = systemd unit name)?
+
+Without an answer, the §7.2 typed-scheme decision has no exit ramp — schemes become permanent surface area. With the §7.2.3 generated-column + grammar CHECK design, removing a scheme requires a coordinated DB-migration-then-app-deploy ordering that is identical to the migration-drift class CLAUDE.md flags as a single-writer surface. Without explicit deprecation procedure, a future operator either (a) drops the CHECK constraint at deploy time (loses storage-layer enforcement) or (b) leaves dead schemes in the CHECK forever (cruft).
+
+**Tentative:** scheme deprecation is a **30-day drain procedure**:
+
+1. **T+0:** mark scheme deprecated. New acquires return `permission_denied` with reason `surface_kind_deprecated`. Existing leases on the deprecated kind continue to renew/release normally.
+2. **T+30 days:** all leases on the deprecated kind are forced via `LEASE_FORCE_RELEASE_TOKEN` (per §7.10) with `release_reason='forced_deprecation'`. Sentinel alarm fires per §7.10's blanket force-release alarm; expected event class.
+3. **T+30 days + 1 day:** migration extending the CHECK constraint to remove the scheme ships. `unitares_doctor.py` lints that no Elixir source mentions the deprecated scheme.
+
+**Tentative — semantics migration within a kind is forbidden:** if `resident:/` semantics change between versions (PID → systemd unit name), introduce a new kind (`resident_v2:/`) and dual-run during a deprecation window. Renaming surface_id format within a kind would orphan existing leases mid-flight; banning this case keeps the lease table semantically consistent.
+
+Open subquestion: does scheme deprecation need its own first-class `deprecated_schemes` table for telemetry, or is the `unitares_doctor.py` check + Sentinel alarm sufficient? Defer to council pass on §7.11.
+
+### 7.12 Surface_id canonicalization / content-addressing forward-compat (council finding v0.7) — Tentative
+
+**Question:** the §7.9 "v0 doesn't handle renames" deferral and the §7.2 typed-scheme commitment together require a canonicalization story. Two layers:
+
+1. **v0 (committed):** how do callers turn raw `surface_id` strings into the canonical form the partial unique index assumes? (Closes code-reviewer BLOCK-2: case-insensitive APFS, `..`-paths, percent-encoding ambiguity.)
+2. **v1 (forward-compat tentative):** how does §7.2 not foreclose §7.9's content-derived `surface_id` (file inode + ctime, dialectic content-hash) as a future v1 RFC?
+
+#### 7.12.1 v0 canonicalization rule (committed via §7.2 cross-reference)
+
+Before any acquire/status/release call involving a `file://` surface_id, the caller MUST canonicalize:
+
+1. Resolve to absolute path: `os.path.realpath(path)` (Python) / `Path.expand` then `:filename.absname/1` (Elixir).
+2. Eliminate `.`, `..`, double-slashes (handled by realpath/absname).
+3. On case-insensitive filesystems (default macOS APFS/HFS+), lowercase the path. Detection: check filesystem case-sensitivity at startup (probe via `pathconf(_PC_CASE_SENSITIVE)` on macOS / mount-options on Linux); cache the answer per-startup.
+4. Strip trailing `/` unless the path is exactly `/`.
+5. Re-prefix with `file://`.
+
+For non-`file://` schemes (`dialectic:/`, `resident:/`, `capture:/`, `td:/`), the v0 rule is "the path portion is opaque to the lease plane; callers are responsible for pre-canonicalization within their own scheme conventions." This may need tightening per scheme as Phase B proceeds.
+
+A canonicalization helper SHALL ship in `src/lease_plane/canonicalize.py` (Python) with the same logic mirrored in the Elixir client. Callers using the helper get correct behavior for free; callers bypassing it carry the consequence of split-brain leases on the same physical surface.
+
+#### 7.12.2 v1 forward-compat with content-addressing
+
+§7.9 deferred content-derived `surface_id` (file inode + ctime, dialectic-session content-hash) to a v1 RFC. §7.2's typed-scheme grammar must not foreclose this. Two tentative options for v1:
+
+- **(a) New scheme.** `file-inode://<inode>:<ctime>` is a separate scheme (per §7.11 deprecation procedure, eventually `file://` is deprecated and content-addressed `file-inode://` replaces it). Pro: clean separation, follows the scheme-as-vocabulary discipline. Con: callers must migrate.
+- **(b) Modifier on existing scheme.** `file:///x.py?canon=inode` adds a query-string modifier. Pro: gradual rollout, no caller migration. Con: query-string parsing in `surface_id` is unusual; complicates the partial unique index normalization.
+
+**Tentative for v1:** option (a). Cleaner. v1 RFC will commit; this RFC just notes the design space is open.
+
+**v0 invariant (must not break v1):** within a v0 scheme, the path portion is opaque to lease identity. The partial unique index keys on the literal `surface_id` string after caller canonicalization. Query-string parameters (if any caller adds them) are NOT stripped before indexing — `file:///x.py` and `file:///x.py?canon=inode` are distinct leases v0-side. This forecloses the split-brain bug where v1-aware callers and v1-naive callers race on the same file via different `?canon=` values: in v0 they're just two different surfaces. v1 either deprecates the unmodified form (per §7.11) or specifies a normalization rule for the modifier.
+
+Open subquestion: does v0 need a stronger rule banning `?` in `surface_id` to keep the v1 modifier-form open? Adding `CHECK (surface_id !~ '\\?')` to migration 026 would force v1 to choose option (a) by construction. Defer to council pass on §7.12.
+
 ## 8. Concerns / counter-arguments / minority views
 
 ### 8.1 "BEAM has nil too. Null bugs aren't OTP-shaped."
@@ -623,14 +816,36 @@ A Python reference implementation of every endpoint in §5 (`asyncio.Lock` per-s
 
 Required before any `.ex` file is written:
 
-- [x] Council pass: dialectic-knowledge-architect, feature-dev:code-reviewer, live-verifier (parallel) — v0.2/v0.3/v0.5
-- [ ] §7 open questions all answered (RFC tentative -> RFC committed) — §7.1/7.4/7.6/7.8 resolved v0.2; §7.5/7.7 resolved v0.2 with operator-action carve-out; **§7.9/7.10 resolved v0.6**; §7.2/7.3 council pass queued v0.6
+- [x] Council pass: dialectic-knowledge-architect, feature-dev:code-reviewer, live-verifier (parallel) — v0.2/v0.3/v0.5/v0.7
+- [x] §7 open questions all answered (RFC tentative -> RFC committed) — §7.1/7.4/7.6/7.8 resolved v0.2; §7.5/7.7 resolved v0.2 with operator-action carve-out; §7.9/7.10 resolved v0.6; **§7.2/7.3 resolved v0.7**; §7.11/7.12 newly added as Tentative v0.7 (separate council pass before commit)
 - [x] Shelf-Python sketch checked in alongside the Elixir spec — same schema, same API, same return shapes (v0.4)
-- [ ] Operational runbook draft: `docs/operations/lease-plane-operator-runbook.md` (stub created alongside this RFC; needs concrete commands once the service exists). **v0.6 commitment:** runbook MUST cover (a) §7.9 rename-orphan manual-release procedure, and (b) §7.10 `LEASE_FORCE_RELEASE_TOKEN` provisioning + rotation steps.
+- [ ] Operational runbook draft: `docs/operations/lease-plane-operator-runbook.md` (stub created alongside this RFC; needs concrete commands once the service exists). **v0.6 commitment:** runbook MUST cover (a) §7.9 rename-orphan manual-release procedure, and (b) §7.10 `LEASE_FORCE_RELEASE_TOKEN` provisioning + rotation steps. **v0.7 addition:** (c) §7.11 scheme-deprecation 30-day drain procedure.
 - [ ] Sentinel monitoring spec for `/v1/lease/status?surface_id=__healthcheck__`
-- [ ] **Integration test (§7.10 gate):** confirm `GOVERNANCE_TOKEN` cannot force-release; only `LEASE_FORCE_RELEASE_TOKEN` succeeds. Rejection at contract layer, not application layer.
 - [ ] Decision: which exact surface_kind goes first into advisory (probably `dialectic:/`)
 - [ ] Decision on §6.1 promotion-gate criteria — what specifically counts as "the conflict log says 'we would have prevented a real bug here'"
+
+#### Phase A test gates (v0.7 — bundles council BLOCKs)
+
+Each row below is a Phase A blocker. All tests live under `tests/test_lease_plane_*.py` (Python) and `elixir/lease_plane/test/` (Elixir).
+
+- [ ] **Migration 026 ships and is verified** — generated `surface_kind` column (§7.2.3) + `surface_id_grammar` CHECK constraint (§7.2.2) live in the `governance` DB. Verified via `\d lease_plane.surface_leases` showing both.
+- [ ] **§7.2 — invalid scheme rejected at storage layer** — INSERT with `surface_id='not_a_scheme:foo'` raises CHECK violation. Test name: `test_invalid_uri_scheme_rejected_at_storage`.
+- [ ] **§7.2 — Pydantic field_validator rejects invalid scheme** — `AcquireRequest(surface_id='potato:foo', ...)` raises ValidationError. Test name: `test_acquire_request_rejects_invalid_scheme`.
+- [ ] **§7.2.3 — surface_kind drift impossible** — INSERT with `surface_id='file:///x.py'` produces `surface_kind='file'` automatically (generated column); caller cannot supply a conflicting value. Test names: `test_surface_kind_derived_from_scheme`, `test_acquire_request_has_no_surface_kind_field` (post-removal).
+- [ ] **§7.12.1 — case-insensitive file:// canonicalization** — `acquire(file:///Users/cirwel/X.py)` and `acquire(file:///Users/cirwel/x.py)` produce identical canonical form on case-insensitive APFS; second acquire returns `held_by_other` (or `idempotent: true` if same holder). Test name: `test_file_canonicalization_case_insensitive_apfs`.
+- [ ] **§7.12.1 — `..`-path canonicalization** — `acquire(file:///x/../y/z.py)` canonicalizes to `file:///y/z.py`. Test name: `test_file_canonicalization_relative_components`.
+- [ ] **§7.3.2 — extended `held_by_other` shape** — response includes `surface_id`, `blocking_lease_id`, `retry_after_hint_ms`. Test names: `test_held_by_other_echoes_surface_id`, `test_held_by_other_returns_blocking_lease_id`, `test_held_by_other_includes_retry_hint`.
+- [ ] **§7.3.3 — `acquire_with_retry()` honors backoff** — jittered exponential, floor 100ms, ceiling 5s. Test name: `test_acquire_with_retry_jittered_backoff`.
+- [ ] **§7.3.5 — HTTP 409 on `held_by_other`; 200 + ok:false otherwise** — Elixir router behavior. Test names (Elixir-side): `test http_router returns 409 on held_by_other`, `test http_router returns 200 on permission_denied`.
+- [ ] **§7.3.5 — `_urllib_transport` HTTP-error body-parse path** — currently uncovered (live-verifier finding). Test name: `test_urllib_transport_parses_409_body`.
+- [ ] **§7.10 — `GOVERNANCE_TOKEN` cannot force-release** (already gated v0.6; restated): only `LEASE_FORCE_RELEASE_TOKEN` succeeds; rejection at contract layer. Test name: `test_force_release_rejects_governance_token`.
+
+#### Phase B prerequisites (v0.7 — non-blocking for Phase A)
+
+- [ ] **§7.2.8** — payload-shape standardization pass spec authored before any surface_kind reaches Phase B candidate status; commits to writing canonicalized `surface_id` (per §7.12.1) into `audit.tool_usage.payload`, no percent-encoding.
+- [ ] **§7.2.9** — `unitares_doctor.py` extended to lint that no Elixir source mentions a scheme not in the live DB CHECK.
+- [ ] **§7.11** council pass on the 30-day-drain tentative before any production scheme is deprecated.
+- [ ] **§7.12** council pass on the v1 forward-compat option (a) vs (b) before v1 RFC opens; consider whether to ship `CHECK (surface_id !~ '\\?')` in migration 026 to force option (a) by construction.
 
 ## 10. Runway tradeoff (operator decision, not technical)
 
@@ -644,6 +859,34 @@ This is a 4-8 week spike. It trades against:
 The technical case is strong (three independent reviewers converged). The strategic case is the operator's call. If shelved, file this RFC as captured-decision so the next session doesn't re-litigate the substrate question from scratch.
 
 ## 11. Versions / changelog
+
+- **v0.7 (2026-04-30, same session):** §7.2 (Surface ID schema) and §7.3 (Conflict semantics on `held_by_other`) promoted Tentative → Resolved. Council pass run in parallel (dialectic-knowledge-architect / feature-dev:code-reviewer / live-verifier; adversarial framing per `feedback_council-adversarial-prompt.md`). Operator-decision pass landed before commit; four operator-choice points resolved per codex direction. Material changes:
+
+  *§7.2 — Resolved with defense-in-depth:*
+  - Canonical scheme list authored once in §7.2.1 (5 schemes: `file://`, `dialectic:/`, `resident:/`, `capture:/`, `td:/`); §3.3/§7.2 self-contradiction (dialectic BLOCK-1) resolved by adding `capture:` to §7.2 grammar.
+  - Three-layer enforcement (§7.2.2): Postgres CHECK on scheme grammar (migration 026), Pydantic field_validator, Elixir Ecto enum. Closes three-voice consensus on missing storage-layer CHECK (dialectic BLOCK-2 + code-reviewer BLOCK-1 + live-verifier DRIFT-A).
+  - **DB-enforced surface_kind via generated column** (§7.2.3, operator decision per codex): `surface_kind text GENERATED ALWAYS AS (split_part(surface_id, ':', 1)) STORED`. Caller-supplied `surface_kind` removed from `AcquireRequest`. Fallback to CHECK-pair documented if generated-column conversion is too disruptive at migration time. Application-only enforcement explicitly REJECTED. Closes code-reviewer CONCERN-2 + live-verifier DRIFT-B.
+  - Per-holder cardinality bound: unbounded by design with named soft-threshold alert at 100 concurrent leases (§7.2.5). Threat model explicitly stated: caller-bug class, not external-attacker class; alert is reactive. Closes dialectic CONCERN-4.
+  - 30-day pruning policy for `surface_leases.released_at` via Oban (§7.2.6). Closes code-reviewer CONCERN-3.
+  - Status/release path normalization commitment (§7.2.7). Closes code-reviewer CONCERN-4.
+  - §6.1 criterion-5 percent-encoding gotcha cross-tracked into payload-shape standardization pass (§7.2.8). Closes code-reviewer CONCERN-5.
+  - Forward-compat for unknown schemes deferred to §7.11 deprecation procedure (§7.2.9).
+  - file:// canonicalization details delegated to **new §7.12** rather than buried in §7.2.
+
+  *§7.3 — Resolved with per-surface-kind override slot:*
+  - Global default remains `abort`; per-surface-kind `conflict_default` override slot added for Phase B promotion (§7.3.1). Anticipated targets named per surface_kind. Closes dialectic CONCERN-8.
+  - Extended `AcquireHeldByOther` typed-absence shape (§7.3.2): adds `surface_id`, `blocking_lease_id`, `retry_after_hint_ms`. Closes code-reviewer BLOCK-3 + CONCERN-6.
+  - Mandatory backoff guidance for caller libraries (§7.3.3): `acquire_with_retry()` convenience method implements jittered exponential (floor 100ms, ceiling 5s, full jitter). Bare `acquire()` remains single-shot. Closes dialectic BLOCK-6 (thundering-herd).
+  - Handoff opt-in semantics clarified (§7.3.4): v0 ships endpoints, no holder classes wire acceptance until first resident-class enforcement promotion.
+  - HTTP 409 on `held_by_other`; HTTP 200 + `ok:false` on all other typed-absence errors (§7.3.5). Live-verifier confirmed Elixir router already implements this; v0.7 promotes from implementation detail to contract requirement.
+
+  *New §7.11 — Tentative:* Surface-kind deprecation/migration procedure. 30-day drain (mark deprecated → existing leases age out → force-release survivors → migrate CHECK constraint). Semantics-migration-within-a-kind forbidden; introduce a new kind and dual-run instead. Council pass before any production scheme is deprecated.
+
+  *New §7.12 — Tentative:* Surface_id canonicalization and v1 content-addressing forward-compat. v0 canonicalization rule committed via §7.2 cross-reference (case-insensitive APFS lowercase, realpath, trailing-slash strip). v1 forward-compat path: tentative is option (a) new scheme `file-inode://`, with option (b) query-string modifier as alternative. v0 invariant explicitly stated: query-string in `surface_id` is NOT stripped before indexing, foreclosing the v1 split-brain bug class. Council pass before v1 RFC opens.
+
+  *§9 checklist — Phase A test gates bundled* (per codex direction): 11 named test gates covering migration 026 verification, scheme rejection at storage + Pydantic layers, surface_kind generated-column behavior, file canonicalization (case-insensitive + relative components), extended `held_by_other` shape (3 sub-tests for the 3 new fields), `acquire_with_retry()` backoff, HTTP 409 convention, `_urllib_transport` HTTP-error path coverage (closes live-verifier test-coverage gap), and the v0.6 §7.10 force-release test (restated). 4 Phase B prerequisites separated as non-blocking.
+
+  *Council reports archived in session transcript.* Three-voice convergence pattern (BLOCKs found by 2+ voices) handled separately from single-voice findings. No findings rejected; one (Elixir GenServer start-after-commit invariant, code-reviewer CONCERN-1) tracked as Elixir-implementation contract rather than RFC-text amendment, since it lands with the BEAM service code.
 
 - **v0.6 (2026-04-30, same session):** Promoted §7.9 (surface_id renames) and §7.10 (force-release authority) from *Tentative* to *Resolved*, locking in the v0.2/v0.3 text as committed contract. Council pass queued in parallel on the two remaining open questions (§7.2 surface ID schema; §7.3 conflict semantics on `held_by_other`). Material changes:
 

--- a/docs/proposals/surface-lease-plane-v0.md
+++ b/docs/proposals/surface-lease-plane-v0.md
@@ -1,7 +1,7 @@
 ---
-status: DRAFT-v0.7 (§7.2 + §7.3 resolved; §7.11 + §7.12 added as Tentative; Phase A test gates bundled in §9)
+status: DRAFT-v0.8 (§7.11 + §7.12 resolved; v1 forward-compat for content-addressing left Open by design; pre-existing v0.7 implementation drift surfaced as named §9 gates)
 authored: 2026-04-30
-amended: 2026-04-30 (v0.1–v0.7 same session)
+amended: 2026-04-30 (v0.1–v0.8 same session)
 council_pass_1: 2026-04-30
 ack_pass_1: 2026-04-30
 author_session: agent-68437d77-65c (claude_code-claude_68437d77)
@@ -732,55 +732,184 @@ A file rename, dialectic-session ID rotation, or resident relabel changes a surf
 
 **Token-rotation note:** `LEASE_FORCE_RELEASE_TOKEN` follows the same rotation cadence as other operator-scoped tokens at `~/.config/cirwel/secrets.env`. No special rotation infrastructure required for v0; rotation is manual operator action followed by `launchctl kickstart` of the lease-plane LaunchAgent to reload the secrets.env.
 
-### 7.11 Surface-kind deprecation / migration (council finding v0.7) — Tentative
+### 7.11 Surface-kind deprecation / migration — RESOLVED in v0.8
 
 **Question:** how does the lease plane retire a `surface_kind` (e.g., `td:/` deprecated in v3 because the TouchDesigner integration was abandoned)? What about migrating semantics within a kind (e.g., `resident:/` v0 = process PID, v1 = systemd unit name)?
 
-Without an answer, the §7.2 typed-scheme decision has no exit ramp — schemes become permanent surface area. With the §7.2.3 generated-column + grammar CHECK design, removing a scheme requires a coordinated DB-migration-then-app-deploy ordering that is identical to the migration-drift class CLAUDE.md flags as a single-writer surface. Without explicit deprecation procedure, a future operator either (a) drops the CHECK constraint at deploy time (loses storage-layer enforcement) or (b) leaves dead schemes in the CHECK forever (cruft).
+Council pass v0.8 (parallel: dialectic-knowledge-architect, feature-dev:code-reviewer, live-verifier) found three-voice convergence on `'forced_deprecation'` violating the deployed `release_reason` CHECK; two-voice convergence on Phase 2/3 race window leaving a Layer-1 enforcement gap, on the Sentinel alarm-storm collision with §7.10, and on the missing persistence substrate; plus four single-voice findings on operator-confirmation, sweep idempotency, 30-day window justification, and primitive-scheme evolution foreclosure.
 
-**Tentative:** scheme deprecation is a **30-day drain procedure**:
+**Resolution: 4-phase operator-driven procedure with `deprecated_schemes` table, CHECK-migration-before-sweep ordering, batch-suppressed Sentinel alarms, primitive-scheme strictly-stronger carve-out.**
 
-1. **T+0:** mark scheme deprecated. New acquires return `permission_denied` with reason `surface_kind_deprecated`. Existing leases on the deprecated kind continue to renew/release normally.
-2. **T+30 days:** all leases on the deprecated kind are forced via `LEASE_FORCE_RELEASE_TOKEN` (per §7.10) with `release_reason='forced_deprecation'`. Sentinel alarm fires per §7.10's blanket force-release alarm; expected event class.
-3. **T+30 days + 1 day:** migration extending the CHECK constraint to remove the scheme ships. `unitares_doctor.py` lints that no Elixir source mentions the deprecated scheme.
+#### 7.11.1 Persistence substrate — `deprecated_schemes` table
 
-**Tentative — semantics migration within a kind is forbidden:** if `resident:/` semantics change between versions (PID → systemd unit name), introduce a new kind (`resident_v2:/`) and dual-run during a deprecation window. Renaming surface_id format within a kind would orphan existing leases mid-flight; banning this case keeps the lease table semantically consistent.
+The "deprecated" flag MUST be a first-class schema object, not application config. Migration 027:
 
-Open subquestion: does scheme deprecation need its own first-class `deprecated_schemes` table for telemetry, or is the `unitares_doctor.py` check + Sentinel alarm sufficient? Defer to council pass on §7.11.
+```sql
+CREATE TABLE lease_plane.deprecated_schemes (
+  surface_kind        text PRIMARY KEY REFERENCES lease_plane.surface_kind_catalog(surface_kind),
+  deprecation_id      uuid NOT NULL DEFAULT gen_random_uuid(),
+  marked_deprecated_at timestamptz NOT NULL DEFAULT now(),
+  marked_by_session_id text NOT NULL,
+  drain_window_days   int NOT NULL DEFAULT 30 CHECK (drain_window_days > 0 AND drain_window_days <= 90),
+  sweep_started_at    timestamptz,
+  sweep_completed_at  timestamptz,
+  check_migrated_at   timestamptz
+);
+```
 
-### 7.12 Surface_id canonicalization / content-addressing forward-compat (council finding v0.7) — Tentative
+`surface_kind_catalog` is the canonical scheme registry (also added in migration 027); foreign-key-referenced so deprecation can only target a registered kind. `deprecation_id` is the audit-correlation key linking `marked` → `swept` → `migrated` events. Resumability invariant: a sweep is resumable if `sweep_started_at IS NOT NULL AND sweep_completed_at IS NULL`; idempotent re-run reaches fixpoint via the predicate in §7.11.4.
 
-**Question:** the §7.9 "v0 doesn't handle renames" deferral and the §7.2 typed-scheme commitment together require a canonicalization story. Two layers:
+The acquire path consults `deprecated_schemes` at the Elixir router layer (and the Pydantic field_validator on the Python side, fed via the lease-plane health endpoint's deprecated-kind list). T+0 acquire-block is a query against this table, not application config.
 
-1. **v0 (committed):** how do callers turn raw `surface_id` strings into the canonical form the partial unique index assumes? (Closes code-reviewer BLOCK-2: case-insensitive APFS, `..`-paths, percent-encoding ambiguity.)
-2. **v1 (forward-compat tentative):** how does §7.2 not foreclose §7.9's content-derived `surface_id` (file inode + ctime, dialectic content-hash) as a future v1 RFC?
+#### 7.11.2 4-phase operator-driven procedure
+
+`# OPERATOR_NOTE 1`: Phase ordering reverses the v0.7 tentative — CHECK migration lands BEFORE sweep, not after, to preserve §7.2.2 three-layer enforcement throughout the drain window. Each phase is operator-typed (not Oban-scheduled); operator presence at Phase 0 mark and Phase 2 sweep is required, matching §7.10's operator-only force-release semantic.
+
+| Phase | Time | Operator action | Effect |
+|-------|------|-----------------|--------|
+| 0 | T+0 | `lease-plane deprecate <kind>` CLI | INSERT row into `deprecated_schemes`. From this moment, acquire on the kind returns `permission_denied` reason `surface_kind_deprecated` (Elixir router gate + Pydantic field_validator). Existing leases continue to renew/release normally. |
+| 1 | T+1 day | (automatic verification) | `unitares_doctor.py` runs nightly, confirms no Elixir source mentions the deprecated scheme. If lint fails, operator alerted; deprecation pauses. |
+| 2 | T+`drain_window_days` (default T+30) | `lease-plane deprecation-sweep <kind>` CLI | Operator-issued; requires `LEASE_FORCE_RELEASE_TOKEN` (per §7.10). Sweeps surviving leases (idempotent — see §7.11.4). Records `sweep_started_at` then `sweep_completed_at` on the `deprecated_schemes` row. |
+| 3 | T+`drain_window_days` + 0 (same maintenance window) | `lease-plane deprecation-finalize <kind>` CLI | Migration extends `surface_id_grammar` CHECK to remove the scheme. Records `check_migrated_at`. After this point, INSERTs of the deprecated scheme fail at the storage layer. |
+
+Phase 2 and Phase 3 land in the **same operator session** to close the v0.7 1-day Layer-1 enforcement gap (closes dialectic BLOCK-E + code-reviewer BLOCK-3). The `deprecated_schemes` Phase 0 entry continues to gate the application layer regardless, but having both layers up simultaneously is the v0.8 commitment.
+
+#### 7.11.3 Audit event vocabulary
+
+`# OPERATOR_NOTE 2`: Council DRIFT-1 (live-verified) — `'forced_deprecation'` is not in the deployed `release_reason` CHECK. Two corrective options were considered:
+
+- (i) Add `'forced_deprecation'` to migration 026/027 CHECK + `models.py ReleaseReason` TypeAlias + `extract_release_params` in `http_router.ex`. Schema churn but explicit semantics.
+- (ii) **Adopted:** Use existing `release_reason='forced'` (already in CHECK) with semantic distinction in `lease_plane_events.event_type`. Phase 0 marks emit `event_type='lease.deprecation_marked'`; Phase 2 sweep events emit `event_type='lease.deprecation_swept'` with `release_reason='forced'`; Phase 3 emits `event_type='lease.deprecation_migrated'`. No `release_reason` schema change required. Audit consumers discriminate on `event_type`, not `release_reason`.
+
+Adopted option (ii) on the basis that (a) `release_reason` already has natural-language overflow into `event_type`, (b) preserves §7.10 Sentinel alarm-on-`release_reason='forced'` semantic without re-wiring (deprecation events ARE forced events; they just carry a discriminator), and (c) avoids a 4-site schema change for a vocabulary expansion. Cost: downstream consumers who want to filter "non-deprecation forced releases" must filter on `event_type NOT LIKE 'lease.deprecation_%'` rather than `release_reason != 'forced_deprecation'`.
+
+`tool_name` projection into `audit.tool_usage`: `'lease.deprecation_marked'`, `'lease.deprecation_swept'`, `'lease.deprecation_migrated'` respectively. Dashboard/KG consumers see deprecation as a first-class event class via `tool_name` discriminator.
+
+#### 7.11.4 Sweep predicate (idempotent, no timestamp filter)
+
+The Phase 2 sweep query is canonical — implementations MUST use exactly this predicate:
+
+```sql
+SELECT lease_id FROM lease_plane.surface_leases
+WHERE released_at IS NULL AND surface_kind = $1
+ORDER BY acquired_at
+FOR UPDATE SKIP LOCKED;
+```
+
+No timestamp filter (no `acquired_at < $deprecation_start`). Re-running on partial failure reaches fixpoint because already-released leases are excluded by `released_at IS NULL`. `FOR UPDATE SKIP LOCKED` lets multiple sweep workers (if ever needed) parallelize without conflict. `ORDER BY acquired_at` provides deterministic sweep order for audit reconstruction.
+
+The Oban implementation wraps this in a job that records `deprecation_id` on each emitted event so the entire sweep is reconstructable from `lease_plane_events` after the fact.
+
+#### 7.11.5 Sentinel batch suppression
+
+§7.10's "alarm-on-every-force-release" rule was justified for *rare* operator-typed force-release. A deprecation sweep over a high-cardinality kind could fire hundreds of alarms in minutes, training operators to mute the channel. v0.8 amendment to §7.10:
+
+> Sentinel alarm-on-every-event applies to `event_type='forced'`. Bulk deprecation sweeps emit `event_type='lease.deprecation_swept'` and are excluded from per-event alarming. Instead, Sentinel emits **one** alarm per `deprecation_id` summarizing `(kind, count_swept, started_at, completed_at)` after `sweep_completed_at` is set.
+
+This preserves the §7.10 design intent (every individual force-release is auditable and visible) while keeping the deprecation case from drowning the channel. The audit trail is fully preserved in `lease_plane_events` — the suppression is alarm-only.
+
+#### 7.11.6 Within-kind semantics evolution — strictly-stronger carve-out for primitives
+
+v0.7 tentative said within-kind semantics migration is *forbidden*. v0.8 relaxes for primitive schemes:
+
+- **Composite/owned schemes** (`dialectic:/`, `resident:/`, `capture:/`, `td:/`): semantics-migration-within-kind is forbidden; introduce a new kind (`resident_v2:/`) and dual-run during a 30-day drain.
+- **Primitive schemes** (`file://`): semantics evolution is allowed iff the new canonicalization rule is *strictly stronger* than the old (i.e., the new canonical form is a subset-of relation with the old form — every old canonical form maps deterministically to a new canonical form, and no two distinct old forms collide at the new form). Such migrations announce via the same 30-day drain (Phase 0 marks the *old* canonicalization deprecated; Phase 2 sweeps leases keyed on the old form; Phase 3 deploys the new canonicalization rule).
+
+The strictly-stronger condition is the safety invariant: it forecloses split-brain where an old-canonical and new-canonical key for the same physical surface coexist as two distinct leases. For `file://`, examples of strictly-stronger evolution include adding Unicode NFC normalization (NFC is canonical, NFD inputs map deterministically to NFC) or adding additional symlink-resolution depth. Examples that are NOT strictly stronger (and therefore require new-kind migration): inode-addressing (different identity model entirely) — handled per §7.12.
+
+#### 7.11.7 Adversarial-input — Phase 0 race window
+
+Council code-reviewer BLOCK-2 second-issue: a holder racing the Phase 0 mark transaction grabs a fresh 1h-TTL lease just before T+0. v0.8 mitigation: Phase 0 INSERT into `deprecated_schemes` is wrapped in a serializable transaction that ALSO sets a session-level advisory lock blocking new acquires on the kind for the transaction duration. The race window is reduced from "between operator command and Elixir router cache refresh" to "single Postgres transaction" (~ms).
+
+Belt-and-braces for very-long-TTL leases: the Phase 2 sweep, by §7.11.4 predicate, captures *all* unreleased leases regardless of when they were acquired. So a racer's lease is swept at T+30 like any other.
+
+#### 7.11.8 unitares_doctor lint polarity
+
+During T+0..T+30 (drain window), the deprecated scheme IS in the live grammar CHECK but SHOULD NOT be in active Elixir source (per §7.2.9). The `unitares_doctor.py` lint rule MUST be polarity-aware:
+
+- Schemes in `deprecated_schemes` table: lint REQUIRES that no Elixir source mentions them (warns operator if they do).
+- Schemes in grammar CHECK but NOT in `deprecated_schemes`: standard rule (Elixir source MAY reference; doctor doesn't lint).
+
+After Phase 3 (CHECK migration), the deprecated scheme falls out of the CHECK; standard polarity resumes (Elixir source mentioning the now-removed scheme would fail compile or lint).
+
+### 7.12 Surface_id canonicalization / content-addressing forward-compat — RESOLVED in v0.8 (v1 forward-compat remains Open)
+
+Council pass v0.8 found three-voice ground-truth findings that the v0.7 tentative was wrong about its Python stdlib API (`pathconf(_PC_CASE_SENSITIVE)` raises `ValueError` on macOS — REFUTED) and silently broken on `/var → /private/var` symlink resolution (live evidence). Plus two-voice convergence on the missing cross-platform/server-vs-target-filesystem authority commitment, and a code-reviewer-flagged `?`-ban decision deferral that blocked the §9 Phase A test gate.
+
+**Resolution: server-side canonicalization authority. Tmpfile probe (not pathconf). Double-realpath for /var. Symlink behavior surfaced as contract. v1 forward-compat downgraded from Tentative-option-(a) to Open. v0 explicitly does NOT add `?`-banning CHECK.**
+
+#### 7.12.0 Vocabulary disambiguation
+
+"Canonicalize" (verb) and "canonical form" (noun) in this section refer to the per-scheme string-normalization procedure below. This is **distinct** from §7.2.1's "canonical scheme list" (the vocabulary of allowed scheme prefixes). The two share the word "canonical" but operate at different levels: §7.2.1 enumerates allowed schemes; §7.12 normalizes the path within a scheme.
 
 #### 7.12.1 v0 canonicalization rule (committed via §7.2 cross-reference)
 
-Before any acquire/status/release call involving a `file://` surface_id, the caller MUST canonicalize:
+**Authority: server-side.** The lease plane re-canonicalizes on receipt against its own filesystem semantics. Caller-side canonicalization (via the helper) is a perf optimization, not load-bearing. This commits to (i) per the council BLOCK-G options.
 
-1. Resolve to absolute path: `os.path.realpath(path)` (Python) / `Path.expand` then `:filename.absname/1` (Elixir).
-2. Eliminate `.`, `..`, double-slashes (handled by realpath/absname).
-3. On case-insensitive filesystems (default macOS APFS/HFS+), lowercase the path. Detection: check filesystem case-sensitivity at startup (probe via `pathconf(_PC_CASE_SENSITIVE)` on macOS / mount-options on Linux); cache the answer per-startup.
-4. Strip trailing `/` unless the path is exactly `/`.
-5. Re-prefix with `file://`.
+Multi-host implication: if a caller on Linux (case-sensitive FS) sends `file:///Users/cirwel/Foo.py` and the Mac-hosted server canonicalizes against APFS (case-insensitive), the server-side lowercase produces `file:///users/cirwel/foo.py`. Both Linux and Mac callers see the same canonical form. The cost: on a future v1 with multi-server deployment, server-side authority requires all servers to share the same canonicalization rules; this is acceptable for v0 (single Mac BEAM node per §2 invariant).
 
-For non-`file://` schemes (`dialectic:/`, `resident:/`, `capture:/`, `td:/`), the v0 rule is "the path portion is opaque to the lease plane; callers are responsible for pre-canonicalization within their own scheme conventions." This may need tightening per scheme as Phase B proceeds.
+For `file://` surfaces, the server-side canonicalization steps (in order):
 
-A canonicalization helper SHALL ship in `src/lease_plane/canonicalize.py` (Python) with the same logic mirrored in the Elixir client. Callers using the helper get correct behavior for free; callers bypassing it carry the consequence of split-brain leases on the same physical surface.
+1. **Strip `file://` prefix** to get the raw path.
+2. **Resolve symlinks twice** (closes live-verifier DRIFT-2): `os.path.realpath(os.path.realpath(path))`. The double-realpath is required on macOS because `os.path.realpath` resolves `/var` → `/private/var` (system symlink) but does NOT idempotently re-resolve. Running realpath twice catches `/var/folders/.../tmpfile`-style paths that agents (Watcher, ship.sh, capture) use heavily and would otherwise split-brain.
+3. **Eliminate `.`, `..`, double-slashes** (handled implicitly by realpath on existing paths; if path doesn't exist, fall through to `os.path.normpath`).
+4. **Lowercase on case-insensitive filesystems.** Detection: tmpfile probe at startup (closes live-verifier DRIFT-3 — `pathconf(_PC_CASE_SENSITIVE)` is REFUTED on macOS Python). Implementation:
+   ```python
+   def _detect_case_insensitive() -> bool:
+       with tempfile.TemporaryDirectory() as d:
+           upper = os.path.join(d, "PROBE")
+           lower = os.path.join(d, "probe")
+           open(upper, 'w').close()
+           return os.path.exists(lower)
+   ```
+   Cached per-startup. The lease-plane server runs this at boot; the cached answer applies to all incoming `file://` canonicalization.
+5. **Strip trailing `/`** unless the path is exactly `/`.
+6. **Re-prefix with `file://`**.
 
-#### 7.12.2 v1 forward-compat with content-addressing
+For non-`file://` schemes, the v0 per-scheme rules are:
 
-§7.9 deferred content-derived `surface_id` (file inode + ctime, dialectic-session content-hash) to a v1 RFC. §7.2's typed-scheme grammar must not foreclose this. Two tentative options for v1:
+- **`dialectic:/`** — opaque hash. No normalization. Path portion is the dialectic-session UUID; case-sensitive (UUIDs are hex, lowercase-only by convention; reject mixed case at the field_validator).
+- **`resident:/`** — opaque resident-name. Case-sensitive. Reject whitespace, `?`, `#`, `&`. Trailing `/` stripped.
+- **`capture:/`** — composite member list of form `capture:/<id1>,<id2>,...,<idN>`. Members MUST be sorted lexically before canonicalization (closes dialectic missing-from-§7.12 finding: `capture:/A,B,C` and `capture:/B,A,C` would otherwise split-brain on the same calibration window). Helper sorts.
+- **`td:/`** — reserved; no canonicalization rule (not implemented v0).
 
-- **(a) New scheme.** `file-inode://<inode>:<ctime>` is a separate scheme (per §7.11 deprecation procedure, eventually `file://` is deprecated and content-addressed `file-inode://` replaces it). Pro: clean separation, follows the scheme-as-vocabulary discipline. Con: callers must migrate.
-- **(b) Modifier on existing scheme.** `file:///x.py?canon=inode` adds a query-string modifier. Pro: gradual rollout, no caller migration. Con: query-string parsing in `surface_id` is unusual; complicates the partial unique index normalization.
+#### 7.12.2 Helper error semantics
 
-**Tentative for v1:** option (a). Cleaner. v1 RFC will commit; this RFC just notes the design space is open.
+The `src/lease_plane/canonicalize.py` helper is the single point of truth for split-brain prevention. Error semantics MUST be unambiguous:
 
-**v0 invariant (must not break v1):** within a v0 scheme, the path portion is opaque to lease identity. The partial unique index keys on the literal `surface_id` string after caller canonicalization. Query-string parameters (if any caller adds them) are NOT stripped before indexing — `file:///x.py` and `file:///x.py?canon=inode` are distinct leases v0-side. This forecloses the split-brain bug where v1-aware callers and v1-naive callers race on the same file via different `?canon=` values: in v0 they're just two different surfaces. v1 either deprecates the unmodified form (per §7.11) or specifies a normalization rule for the modifier.
+- **Path doesn't exist** (no symlink target, no file): `os.path.realpath` returns the un-resolved input on macOS/Linux. Helper does not raise; canonicalization proceeds on the un-resolved form. Caller's responsibility to know whether the surface is supposed to exist; lease plane does not validate file existence.
+- **Symlink loop**: `os.path.realpath` raises `OSError` (ELOOP). Helper propagates as `CanonicalizeError` with `reason="symlink_loop"`. Caller MUST catch and either retry (after fixing the loop) or fall through to `service_unavailable`.
+- **NUL byte in path**: helper rejects at field_validator level with `ValidationError`; the underlying `os.path.realpath` would raise `ValueError` if reached. Caller-side rejection is preferred — fail at the model boundary, not deep in the canonicalize call.
+- **Path too long** (`PATH_MAX` exceeded): helper raises `CanonicalizeError(reason="path_too_long")`. Pre-Phase-A gate: ensure `surface_id` Pydantic field has `max_length` consistent with caller-side path-length expectations.
 
-Open subquestion: does v0 need a stronger rule banning `?` in `surface_id` to keep the v1 modifier-form open? Adding `CHECK (surface_id !~ '\\?')` to migration 026 would force v1 to choose option (a) by construction. Defer to council pass on §7.12.
+#### 7.12.3 Symlink behavioral commitment (closes code-reviewer CONCERN-3)
+
+`os.path.realpath` resolves symlinks to physical paths. **Behavioral commitment:** two callers using different symlink-paths to the same physical file will produce the same canonical `surface_id` IFF both use the helper. A caller bypassing the helper and passing a symlink path directly creates a lease whose `surface_id` is the symlink form; a second caller using the helper creates a lease on the physical form. The partial unique index sees them as distinct surfaces.
+
+**Worktree implication:** UNITARES uses `git worktree`s heavily. Worktrees are regular directories (not symlinks), so `realpath` does NOT collapse worktree paths to a canonical "main repo" path. A lease on `file:///.../unitares/src/x.py` and a lease on `file:///.../unitares/.worktrees/foo/src/x.py` are distinct leases by design — different physical files even though they're "the same logical source." This is correct and intended.
+
+#### 7.12.4 v1 forward-compat for content-addressing — Open (downgraded from v0.7 Tentative)
+
+v0.7 tentatively chose option (a) (new scheme `file-inode://`). v0.8 council CONCERN-H surfaced that option (a) commits §7.11 to fire on `file://` someday — running a 30-day drain across every Hermes/Claude/Codex/capture caller in the fleet, requiring fleet-wide caller-library upgrade as a precondition. This was not weighed in v0.7's choice.
+
+**v0.8 reframe — Open:** v1 RFC must explicitly weigh the asymmetric costs. Both options remain viable:
+
+- **Option (a) new scheme `file-inode://`.** Cleaner separation. Forces §7.11 drain on `file://`. Acceptable iff operator accepts fleet-wide caller migration as v1 precondition.
+- **Option (b) modifier on existing scheme `file:///x.py?canon=inode`.** Keeps `file://` permanent. Costs in-scheme normalization complexity (the partial unique index must be aware of the modifier; `?canon=inode` and the unmodified form are semantically the same surface but textually distinct).
+
+**v0 invariant preserved (closes code-reviewer CONCERN-4):** the open subquestion of "do we add `CHECK (surface_id !~ '\\?')` to migration 026 to force option (a) by construction" is **resolved as NO**. We explicitly do NOT add the `?`-banning CHECK. Doing so would foreclose option (b) and lock in option (a)'s fleet-upgrade cost without v1 having weighed it. v0 stores `?`-bearing `surface_id` values verbatim (live-verifier Finding 13 confirmed); v1 RFC chooses how to interpret them.
+
+`# OPERATOR_NOTE 3`: This means v0 callers MAY (accidentally or intentionally) write `?`-bearing `surface_id` values today, and the lease plane will accept them. The §7.12.1 helper SHOULD reject them via field_validator with `ValidationError("query string in surface_id reserved for v1; use plain canonical form for v0")` to keep v0 traffic clean. This is caller-side rejection only; the storage layer accepts.
+
+#### 7.12.5 Pydantic field_validator commitment (closes code-reviewer CONCERN-4)
+
+`AcquireRequest.surface_id` MUST gain a `field_validator` before Phase A ships. The validator:
+
+1. Matches against the canonical scheme list regex (§7.2.1).
+2. Calls the canonicalize helper on `file://` paths (so the model boundary enforces canonicalization).
+3. Rejects `?`-bearing values per §7.12.4.
+4. Rejects NUL bytes per §7.12.2.
+5. Returns the canonical form (Pydantic auto-canonicalizes; this trades visibility-of-drift for caller convenience). Operator note: this hides bugs where callers pass non-canonical and don't realize. v0.8 picks auto-canonicalize for UX; if drift becomes a debug problem, switch to validate-only-and-reject in v1.
 
 ## 8. Concerns / counter-arguments / minority views
 
@@ -816,8 +945,8 @@ A Python reference implementation of every endpoint in §5 (`asyncio.Lock` per-s
 
 Required before any `.ex` file is written:
 
-- [x] Council pass: dialectic-knowledge-architect, feature-dev:code-reviewer, live-verifier (parallel) — v0.2/v0.3/v0.5/v0.7
-- [x] §7 open questions all answered (RFC tentative -> RFC committed) — §7.1/7.4/7.6/7.8 resolved v0.2; §7.5/7.7 resolved v0.2 with operator-action carve-out; §7.9/7.10 resolved v0.6; **§7.2/7.3 resolved v0.7**; §7.11/7.12 newly added as Tentative v0.7 (separate council pass before commit)
+- [x] Council pass: dialectic-knowledge-architect, feature-dev:code-reviewer, live-verifier (parallel) — v0.2/v0.3/v0.5/v0.7/v0.8
+- [x] §7 open questions all answered (RFC tentative -> RFC committed) — §7.1/7.4/7.6/7.8 resolved v0.2; §7.5/7.7 resolved v0.2 with operator-action carve-out; §7.9/7.10 resolved v0.6; §7.2/7.3 resolved v0.7; **§7.11/7.12 resolved v0.8** (v0.8 §7.12.4 leaves v1 forward-compat option (a) vs (b) Open, by design)
 - [x] Shelf-Python sketch checked in alongside the Elixir spec — same schema, same API, same return shapes (v0.4)
 - [ ] Operational runbook draft: `docs/operations/lease-plane-operator-runbook.md` (stub created alongside this RFC; needs concrete commands once the service exists). **v0.6 commitment:** runbook MUST cover (a) §7.9 rename-orphan manual-release procedure, and (b) §7.10 `LEASE_FORCE_RELEASE_TOKEN` provisioning + rotation steps. **v0.7 addition:** (c) §7.11 scheme-deprecation 30-day drain procedure.
 - [ ] Sentinel monitoring spec for `/v1/lease/status?surface_id=__healthcheck__`
@@ -840,12 +969,33 @@ Each row below is a Phase A blocker. All tests live under `tests/test_lease_plan
 - [ ] **§7.3.5 — `_urllib_transport` HTTP-error body-parse path** — currently uncovered (live-verifier finding). Test name: `test_urllib_transport_parses_409_body`.
 - [ ] **§7.10 — `GOVERNANCE_TOKEN` cannot force-release** (already gated v0.6; restated): only `LEASE_FORCE_RELEASE_TOKEN` succeeds; rejection at contract layer. Test name: `test_force_release_rejects_governance_token`.
 
+#### Phase A test gates (v0.8 — bundles §7.11 + §7.12 council BLOCKs)
+
+- [ ] **Migration 027 ships and is verified** — `lease_plane.deprecated_schemes` table created; `surface_kind_catalog` registry created. Verified via `\d lease_plane.deprecated_schemes`.
+- [ ] **§7.11.3 — `release_reason='forced'` reused for deprecation events; vocabulary unchanged** — Phase 2 sweep events emit with existing `'forced'` value, distinguished by `event_type='lease.deprecation_swept'`. Closes live-verifier DRIFT-1. Test name: `test_deprecation_sweep_uses_forced_release_reason`.
+- [ ] **§7.11.2 — Phase 2 + Phase 3 land in same operator session** — Layer-1 enforcement gap closed. Test name: `test_deprecation_sweep_and_check_migration_atomic_session`.
+- [ ] **§7.11.4 — sweep predicate idempotent on partial-failure re-run** — operator interrupts mid-sweep, re-runs, completes without double-emitting events. Test name: `test_deprecation_sweep_idempotent_on_partial_failure`.
+- [ ] **§7.11.5 — Sentinel batch suppression** — bulk deprecation sweep emits one summary alarm per `deprecation_id`, not N per-lease alarms. Closes Sentinel alarm-storm CONCERN. Test name: `test_sentinel_batch_alarm_for_deprecation_sweep`.
+- [ ] **§7.11.7 — Phase 0 race window** — concurrent acquire racing the Phase 0 mark transaction is blocked by serializable-tx + advisory-lock. Test name: `test_phase_zero_acquire_race_blocked`.
+- [ ] **§7.12.1 — tmpfile probe replaces `pathconf(_PC_CASE_SENSITIVE)`** — startup detection works on macOS Python (live-verifier REFUTED pathconf). Test name: `test_canonicalize_case_detection_uses_tmpfile_probe`.
+- [ ] **§7.12.1 — `/var → /private/var` double-realpath** — `/var/folders/.../tmpfile` and `/private/var/folders/.../tmpfile` produce same canonical form. Closes live-verifier DRIFT-2. Test name: `test_canonicalize_resolves_var_to_private_var_on_macos`.
+- [ ] **§7.12.1 — `capture:/` member ordering** — `capture:/A,B,C` and `capture:/B,A,C` canonicalize to same `surface_id`. Test name: `test_capture_canonicalizes_member_ordering`.
+- [ ] **§7.12.2 — helper error semantics** — symlink loop raises `CanonicalizeError(reason="symlink_loop")`; NUL byte rejected at field_validator; nonexistent path falls through cleanly. Test name: `test_canonicalize_error_semantics`.
+- [ ] **§7.12.4 — `?`-bearing `surface_id` rejected by Pydantic field_validator** — caller-side rejection; storage layer remains permissive (v1 option-(b) keep-open). Test name: `test_acquire_request_rejects_query_string_in_surface_id`.
+- [ ] **§7.12.5 — `AcquireRequest.surface_id` field_validator wired** — closes the v0.7 implementation gap (currently only `min_length=1`). Test name: `test_acquire_request_surface_id_field_validator_wired`.
+
+#### Pre-existing v0.7 implementation drift (surfaced by v0.8 council; needs code, not RFC)
+
+- [ ] **`models.py AcquireHeldByOther`** — extend with `surface_id`, `blocking_lease_id`, `retry_after_hint_ms` per §7.3.2 (committed in v0.7; not yet in code). Test name: `test_held_by_other_includes_v0_7_extended_fields`.
+- [ ] **`http_router.ex extract_acquire_params`** — remove `"surface_kind"` from required fields and from params map per §7.2.3 (will hard-fail against migration 026 generated column otherwise). Test name (Elixir-side): `test http_router rejects surface_kind in acquire body after migration 026`.
+- [ ] **`agents/sentinel/agent.py`** — add alarm rule keyed on `event_type='forced'` from `lease_plane_events`. Live-verifier confirmed no such rule exists today (Finding 5 SOURCE_ONLY). Per §7.10 + §7.11.5, the rule fires per-event for ad-hoc force-release, batched for deprecation sweeps. Test name: `test_sentinel_force_release_alarm_wired`.
+
 #### Phase B prerequisites (v0.7 — non-blocking for Phase A)
 
 - [ ] **§7.2.8** — payload-shape standardization pass spec authored before any surface_kind reaches Phase B candidate status; commits to writing canonicalized `surface_id` (per §7.12.1) into `audit.tool_usage.payload`, no percent-encoding.
 - [ ] **§7.2.9** — `unitares_doctor.py` extended to lint that no Elixir source mentions a scheme not in the live DB CHECK.
 - [ ] **§7.11** council pass on the 30-day-drain tentative before any production scheme is deprecated.
-- [ ] **§7.12** council pass on the v1 forward-compat option (a) vs (b) before v1 RFC opens; consider whether to ship `CHECK (surface_id !~ '\\?')` in migration 026 to force option (a) by construction.
+- [ ] **§7.12.4** v1 RFC opening: weigh option (a) new scheme `file-inode://` vs option (b) modifier `?canon=inode` explicitly with the asymmetric-cost framing v0.8 surfaces. v0.8 explicitly does NOT add `?`-banning CHECK in migration 026 — both options remain viable for v1.
 
 ## 10. Runway tradeoff (operator decision, not technical)
 
@@ -859,6 +1009,38 @@ This is a 4-8 week spike. It trades against:
 The technical case is strong (three independent reviewers converged). The strategic case is the operator's call. If shelved, file this RFC as captured-decision so the next session doesn't re-litigate the substrate question from scratch.
 
 ## 11. Versions / changelog
+
+- **v0.8 (2026-04-30, same session):** §7.11 (deprecation procedure) and §7.12 (canonicalization + v1 content-addressing forward-compat) promoted Tentative → Resolved. Council pass run in parallel (dialectic-knowledge-architect / feature-dev:code-reviewer / live-verifier; adversarial framing per `feedback_council-adversarial-prompt.md`). Three-voice convergence on three top issues; multiple two-voice and single-voice findings folded in. Material changes:
+
+  *§7.11 — Resolved (4-phase operator-driven, with persistence substrate):*
+  - **`deprecated_schemes` table** added (§7.11.1, migration 027) — first-class schema object, not application config. Includes `deprecation_id` for audit-correlation across mark/sweep/migrate events; `surface_kind_catalog` registry referenced via FK. Closes code-reviewer BLOCK-2 + NIT-1 (the v0.7 open subquestion is load-bearing, not deferrable).
+  - **Phase ordering reversed** (§7.11.2): CHECK migration lands BEFORE sweep, both in same operator session. Closes dialectic BLOCK-E + code-reviewer BLOCK-3 — the v0.7 1-day Layer-1 enforcement gap is gone.
+  - **`'forced_deprecation'` REJECTED in favor of `release_reason='forced'` + `event_type='lease.deprecation_*'`** (§7.11.3): three-voice convergence (dialectic BLOCK-A + code-reviewer BLOCK-1 + live-verifier DRIFT-1) confirmed `'forced_deprecation'` is not in deployed CHECK. Avoids 4-site schema change; preserves §7.10 Sentinel `release_reason='forced'` alarm wiring.
+  - **Idempotent sweep predicate explicit** (§7.11.4): `WHERE released_at IS NULL AND surface_kind = $1`, no timestamp filter, `FOR UPDATE SKIP LOCKED`. Closes code-reviewer BLOCK-4.
+  - **Sentinel batch suppression** (§7.11.5): bulk deprecation sweeps emit one summary alarm per `deprecation_id` rather than N per-event alarms. §7.10 alarm-on-every-event semantic preserved for ad-hoc force-release. Closes dialectic BLOCK-D + code-reviewer CONCERN-1.
+  - **Within-kind primitive-scheme evolution carve-out** (§7.11.6): `file://` may evolve via "strictly stronger" canonicalization (subset-of relation) without forcing a new-kind migration. `dialectic:/`, `resident:/`, `capture:/`, `td:/` remain forbidden-within-kind. Closes dialectic CONCERN-C — primitive-scheme foreclosure resolved.
+  - **Phase 0 race window** mitigated (§7.11.7): serializable transaction + session-level advisory lock during the mark-deprecated INSERT. Belt-and-braces: §7.11.4 sweep predicate captures all unreleased leases regardless of acquire timestamp.
+  - **`unitares_doctor.py` lint polarity** (§7.11.8): polarity-aware during T+0..T+30 drain window — deprecated schemes REQUIRE no Elixir source mention; non-deprecated schemes are unconstrained.
+  - **Audit signal contract**: `tool_name` in `audit.tool_usage` projects as `'lease.deprecation_marked'`/`'lease.deprecation_swept'`/`'lease.deprecation_migrated'`. Dashboard/KG consumers see deprecation as first-class event class.
+  - **30-day default constant**: `drain_window_days` is a column on `deprecated_schemes` (default 30, max 90); per-deprecation override possible. Cross-references §7.6 outbox-prune and §7.2.6 lease-prune as collinear operational windows.
+
+  *§7.12 — Resolved (with v1 forward-compat explicitly Open):*
+  - **Server-side canonicalization authority** (§7.12.1, option (i)): lease plane re-canonicalizes on receipt against its own filesystem semantics; caller-side helper is a perf optimization, not load-bearing. Closes dialectic BLOCK-G + code-reviewer CONCERN-6 — cross-platform/multi-host split-brain hazard resolved for v0 (single Mac BEAM node per §2 invariant).
+  - **Tmpfile probe REPLACES `pathconf(_PC_CASE_SENSITIVE)`** (§7.12.1 step 4): three-voice ground-truth — live-verifier REFUTED `PC_CASE_SENSITIVE` availability on macOS Python; calling it raises `ValueError`. v0.7 spec was wrong. Helper code sample provided; cached per-startup.
+  - **Double-realpath for `/var → /private/var`** (§7.12.1 step 2): closes live-verifier DRIFT-2. `os.path.realpath(os.path.realpath(path))` catches the macOS system-symlink hop that single-realpath misses; matters for `/var/folders/.../tmpfile`-style paths heavily used by Watcher, ship.sh, capture.
+  - **Per-scheme canonicalization rules** (§7.12.1 for non-`file://` schemes): explicit per-kind handling. Notably **`capture:/A,B,C` member ordering** — sorted lexically before canonicalization to prevent split-brain on the same calibration window with reordered members. Closes dialectic missing-from-§7.12 finding.
+  - **Helper error semantics** (§7.12.2): symlink loop, NUL byte, path-too-long, nonexistent-path all named with explicit error/no-error contracts. The helper is the single point of truth for split-brain prevention; ambiguous errors are themselves a split-brain risk.
+  - **Symlink + worktree behavioral commitment** (§7.12.3): explicit contract that `os.path.realpath` resolves symlinks to physical paths; bypassing the helper produces split-brain. Worktree paths are NOT collapsed (worktrees are regular directories, not symlinks) — leases on a file via main-repo path vs `.worktrees/foo/...` path are distinct by design.
+  - **v1 forward-compat downgraded from Tentative-(a) to Open** (§7.12.4): closes dialectic CONCERN-H — option (a) commits §7.11 to fire on `file://` (fleet-wide caller migration as v1 precondition). Both options remain viable; v1 RFC must explicitly weigh asymmetric costs. **v0 explicitly does NOT add `?`-banning CHECK in migration 026** — preserves option (b) viability.
+  - **Vocabulary disambiguation** (§7.12.0): "canonicalize"/"canonical form" (§7.12 string normalization) distinguished from "canonical scheme list" (§7.2.1 vocabulary). Closes dialectic NIT-I.
+  - **Pydantic field_validator wired** (§7.12.5): closes code-reviewer CONCERN-4 — auto-canonicalize at the model boundary (UX over visibility-of-drift; flagged for revisit if drift becomes a debug problem in v1).
+
+  *§9 checklist — three new categories:*
+  - 6 §7.11 Phase A test gates (deprecated_schemes migration, sweep predicate, idempotency, batch alarm, race window).
+  - 6 §7.12 Phase A test gates (tmpfile probe, /var double-realpath, capture: member ordering, error semantics, ?-rejection, field_validator wired).
+  - **3 pre-existing v0.7 implementation drift items surfaced as named §9 gates**: `models.py AcquireHeldByOther` extended fields missing (closes v0.7 commitment §7.3.2 vs reality); `http_router.ex extract_acquire_params` still requires `surface_kind` (will hard-fail against migration 026); `agents/sentinel/agent.py` has no `event_type='forced'` alarm rule (live-verifier Finding 5 SOURCE_ONLY). These are runtime-code work, not RFC-text changes.
+
+  *Council reports archived in session transcript.* Three-voice convergence pattern (3+ voices agree → unconditional fix) handled separately from two-voice (most CONCERNs) and single-voice (additions). Three findings reframed as v0.7 implementation gaps to be tracked-not-litigated. Two operator decisions surfaced inline as `OPERATOR_NOTE` markers (Phase ordering reversal; `release_reason='forced'` reuse).
 
 - **v0.7 (2026-04-30, same session):** §7.2 (Surface ID schema) and §7.3 (Conflict semantics on `held_by_other`) promoted Tentative → Resolved. Council pass run in parallel (dialectic-knowledge-architect / feature-dev:code-reviewer / live-verifier; adversarial framing per `feedback_council-adversarial-prompt.md`). Operator-decision pass landed before commit; four operator-choice points resolved per codex direction. Material changes:
 

--- a/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
@@ -188,7 +188,12 @@ defmodule UnitaresLeasePlane.HTTPRouter do
   end
 
   defp extract_acquire_params(%{} = body) do
-    required = ["surface_id", "surface_kind", "holder_agent_uuid", "holder_kind", "ttl_s"]
+    # surface_kind dropped from required + params map per RFC v0.8 §7.2.3:
+    # post-migration-026, surface_kind is a generated column derived from
+    # split_part(surface_id, ':', 1). Including it in the Repo INSERT params
+    # would raise `ERROR: column "surface_kind" is a generated column`.
+    # Caller-supplied surface_kind in the body is silently ignored.
+    required = ["surface_id", "holder_agent_uuid", "holder_kind", "ttl_s"]
     missing = Enum.filter(required, fn k -> is_nil(Map.get(body, k)) end)
 
     cond do
@@ -210,7 +215,6 @@ defmodule UnitaresLeasePlane.HTTPRouter do
         {:ok,
          %{
            surface_id: body["surface_id"],
-           surface_kind: body["surface_kind"],
            holder_agent_uuid: body["holder_agent_uuid"],
            holder_class: Map.get(body, "holder_class", "process_instance"),
            holder_kind: body["holder_kind"],

--- a/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
@@ -75,12 +75,23 @@ defmodule UnitaresLeasePlane.HTTPRouter do
               drift_warning: []
             })
 
-          {:error, :held_by_other, %{held_by_uuid: uuid, expires_at: expires}} ->
+          {:error, :held_by_other, info} ->
+            # PR 5 council BLOCK fix: emit all 5 fields the v0.7 §7.3.2
+            # AcquireHeldByOther typed-absence shape requires (was 2 pre-PR-5;
+            # missing fields caused production 409s to fail Pydantic validation
+            # → degraded to AcquireSchemaInvalid → acquire_with_retry never retried).
+            now = DateTime.utc_now()
+            remaining_ms =
+              max(0, DateTime.diff(info.expires_at, now, :millisecond))
+            retry_after_hint_ms = min(remaining_ms, 5_000)
             json(conn, 409, %{
               ok: false,
               error: "held_by_other",
-              held_by_uuid: uuid,
-              expires_at: DateTime.to_iso8601(expires)
+              surface_id: Map.get(info, :surface_id),
+              blocking_lease_id: Map.get(info, :blocking_lease_id),
+              held_by_uuid: info.held_by_uuid,
+              expires_at: DateTime.to_iso8601(info.expires_at),
+              retry_after_hint_ms: retry_after_hint_ms
             })
 
           {:error, reason} ->

--- a/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
@@ -76,20 +76,23 @@ defmodule UnitaresLeasePlane.Repo do
   end
 
   defp acquire_step(conn, p, nil) do
+    # surface_kind dropped from INSERT column list per RFC v0.8 §7.2.3:
+    # post-migration-026 it is a generated column derived from
+    # split_part(surface_id, ':', 1). Including it here would raise
+    # `ERROR: column "surface_kind" is a generated column`.
     insert_lease_sql = """
     INSERT INTO lease_plane.surface_leases
-      (surface_id, surface_kind, holder_agent_uuid, holder_class,
+      (surface_id, holder_agent_uuid, holder_class,
        holder_kind, holder_pid, heartbeat_required, intent,
        expires_at, original_ttl_s, audit_session, earned_status)
     VALUES
-      ($1, $2, $3, $4, $5, $6, $7, $8,
-       now() + make_interval(secs => $9), $9, $10, 'provisional')
+      ($1, $2, $3, $4, $5, $6, $7,
+       now() + make_interval(secs => $8), $8, $9, 'provisional')
     RETURNING #{@select_lease_columns}
     """
 
     args = [
       p.surface_id,
-      p.surface_kind,
       uuid_to_binary(p.holder_agent_uuid),
       Map.get(p, :holder_class, "process_instance"),
       p.holder_kind,

--- a/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
@@ -40,7 +40,13 @@ defmodule UnitaresLeasePlane.Repo do
   """
   @spec acquire(map()) ::
           {:ok, lease, :new | :idempotent}
-          | {:error, :held_by_other, %{held_by_uuid: binary(), expires_at: DateTime.t()}}
+          | {:error, :held_by_other,
+             %{
+               held_by_uuid: binary(),
+               expires_at: DateTime.t(),
+               surface_id: binary(),
+               blocking_lease_id: binary()
+             }}
           | {:error, term()}
   def acquire(%{} = p) do
     Postgrex.transaction(DB, fn conn ->
@@ -71,7 +77,17 @@ defmodule UnitaresLeasePlane.Repo do
     if held == p.holder_agent_uuid do
       {:ok, {:ok, existing, :idempotent}}
     else
-      {:ok, {:error, :held_by_other, %{held_by_uuid: held, expires_at: existing.expires_at}}}
+      # PR 5 council BLOCK fix: include surface_id + blocking_lease_id so the
+      # 409 response carries every field the v0.7 §7.3.2 AcquireHeldByOther shape
+      # requires. Without these, Pydantic validation degrades to AcquireSchemaInvalid.
+      {:ok,
+       {:error, :held_by_other,
+        %{
+          held_by_uuid: held,
+          expires_at: existing.expires_at,
+          surface_id: existing.surface_id,
+          blocking_lease_id: existing.lease_id
+        }}}
     end
   end
 

--- a/elixir/lease_plane/test/http_router_test.exs
+++ b/elixir/lease_plane/test/http_router_test.exs
@@ -141,6 +141,21 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
       assert post_json("/v1/lease/acquire", acquire_body(ctx.surface, ttl_s: 4000)).status ==
                422
     end
+
+    test "acquire succeeds without surface_kind in body (v0.7 drift fix; RFC §7.2.3)", ctx do
+      # Post-migration-026, surface_kind is a generated column derived from
+      # split_part(surface_id, ':', 1). The router silently ignores caller-supplied
+      # surface_kind and never includes it in the Repo INSERT. This test verifies
+      # acquire succeeds with surface_kind absent from the body entirely.
+      body = ctx.surface |> acquire_body() |> Map.delete(:surface_kind)
+      resp = post_json("/v1/lease/acquire", body)
+
+      assert resp.status == 200
+      payload = parsed(resp)
+      assert payload["ok"] == true
+      # Server echoes surface_kind from the generated column on the lease record.
+      assert payload["lease"]["surface_kind"] == "dialectic"
+    end
   end
 
   describe "GET /v1/lease/status" do

--- a/elixir/lease_plane/test/http_router_test.exs
+++ b/elixir/lease_plane/test/http_router_test.exs
@@ -120,6 +120,14 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
       assert payload["error"] == "held_by_other"
       assert payload["held_by_uuid"] == body_a.holder_agent_uuid
       assert is_binary(payload["expires_at"])
+      # PR 5 council BLOCK fix: 409 body MUST carry the v0.7 §7.3.2 extended
+      # AcquireHeldByOther fields. Without these, the Python Pydantic model
+      # rejects the response and acquire_with_retry never retries.
+      assert payload["surface_id"] == ctx.surface
+      assert is_binary(payload["blocking_lease_id"])
+      assert is_integer(payload["retry_after_hint_ms"])
+      assert payload["retry_after_hint_ms"] >= 0
+      assert payload["retry_after_hint_ms"] <= 5_000
     end
 
     test "holder_class='role' → 422 schema_invalid (rejected before DB)", ctx do

--- a/elixir/lease_plane/test/support/lease_test_helpers.ex
+++ b/elixir/lease_plane/test/support/lease_test_helpers.ex
@@ -7,10 +7,17 @@ defmodule LeaseTestHelpers do
 
   alias UnitaresLeasePlane.DB
 
-  @doc "Generate a unique surface_id for a single test."
+  @doc """
+  Generate a unique surface_id for a single test.
+
+  Uses the `dialectic:/` canonical scheme (RFC v0.8 §7.2.1) so the surface_id
+  passes migration 026's `surface_id_grammar` CHECK constraint. The label
+  + random suffix become the opaque path portion. Pre-026 callers used
+  `test:elixir/...` which the grammar CHECK rejects.
+  """
   def unique_surface_id(label) when is_binary(label) do
     rand = :crypto.strong_rand_bytes(6) |> Base.url_encode64(padding: false)
-    "test:elixir/#{label}/#{rand}"
+    "dialectic:/test_elixir_#{label}_#{rand}"
   end
 
   @doc "Cleanup hook — DELETEs rows for a given surface_id from both tables."

--- a/scripts/dev/_ship_lease_advisory.py
+++ b/scripts/dev/_ship_lease_advisory.py
@@ -43,9 +43,12 @@ from src.lease_plane.advisory import (  # noqa: E402
 def _cmd_acquire(args: argparse.Namespace) -> int:
     client: LeasePlaneClient = make_advisory_client()
 
+    # surface_kind dropped per RFC v0.8 §7.2.3 — derived server-side from
+    # surface_id scheme prefix via migration 026's generated column.
+    # args.surface_kind is preserved on the CLI for backwards-compat with
+    # operator scripts but is not passed to AcquireRequest.
     request = AcquireRequest(
         surface_id=args.surface_id,
-        surface_kind=args.surface_kind,
         holder_agent_uuid=uuid4(),
         holder_class="process_instance",
         holder_kind="remote_heartbeat",

--- a/scripts/dev/lease_plane_deprecate.py
+++ b/scripts/dev/lease_plane_deprecate.py
@@ -111,15 +111,34 @@ async def deprecate_cmd(
             # Use deterministic SHA-256-derived key (see _lock_key_for_kind for rationale).
             lock_key = _lock_key_for_kind(kind)
             await conn.execute("SELECT pg_advisory_xact_lock($1)", lock_key)
-            await conn.execute(
+            row = await conn.fetchrow(
                 """
                 INSERT INTO lease_plane.deprecated_schemes
                   (surface_kind, marked_by_session_id, drain_window_days)
                 VALUES ($1, $2, $3)
                 ON CONFLICT (surface_kind) DO NOTHING
+                RETURNING deprecation_id
                 """,
                 kind, session_id, drain_window_days,
             )
+            if row is not None:
+                # Phase 0 audit-event emission (RFC §7.11.3 — closes PR 6
+                # dangling-vocabulary fix). Only emit on first mark; ON CONFLICT
+                # returns NULL row on idempotent re-run, so no double-emit.
+                payload = json.dumps({
+                    "deprecation_id": str(row["deprecation_id"]),
+                    "kind": kind,
+                    "session_id": session_id,
+                    "drain_window_days": drain_window_days,
+                })
+                await conn.execute(
+                    """
+                    INSERT INTO lease_plane.lease_plane_events
+                      (event_type, surface_id, surface_kind, advisory_mode, payload)
+                    VALUES ('lease.deprecation_marked', $1, $2, false, $3::jsonb)
+                    """,
+                    f"{kind}:/__deprecation_marker__", kind, payload,
+                )
         return 0
     finally:
         await conn.close()
@@ -216,7 +235,8 @@ async def deprecation_finalize_cmd(*, kind: str, db_url: str = DEFAULT_DB_URL) -
     try:
         async with conn.transaction():
             row = await conn.fetchrow(
-                "SELECT sweep_completed_at FROM lease_plane.deprecated_schemes WHERE surface_kind = $1",
+                "SELECT deprecation_id, sweep_completed_at, check_migrated_at "
+                "FROM lease_plane.deprecated_schemes WHERE surface_kind = $1",
                 kind,
             )
             if row is None:
@@ -226,12 +246,29 @@ async def deprecation_finalize_cmd(*, kind: str, db_url: str = DEFAULT_DB_URL) -
                 print(f"error: deprecation-sweep has not completed for {kind!r}; "
                       f"run `deprecation-sweep {kind}` first.", file=sys.stderr)
                 return 1
+            already_finalized = row["check_migrated_at"] is not None
             await conn.execute(
                 "UPDATE lease_plane.deprecated_schemes "
                 "SET check_migrated_at = COALESCE(check_migrated_at, now()) "
                 "WHERE surface_kind = $1",
                 kind,
             )
+            if not already_finalized:
+                # Phase 3 audit-event emission (RFC §7.11.3 — closes PR 6
+                # dangling-vocabulary fix). Only emit on first finalize;
+                # re-runs are no-op for both check_migrated_at and the event.
+                payload = json.dumps({
+                    "deprecation_id": str(row["deprecation_id"]),
+                    "kind": kind,
+                })
+                await conn.execute(
+                    """
+                    INSERT INTO lease_plane.lease_plane_events
+                      (event_type, surface_id, surface_kind, advisory_mode, payload)
+                    VALUES ('lease.deprecation_migrated', $1, $2, false, $3::jsonb)
+                    """,
+                    f"{kind}:/__deprecation_marker__", kind, payload,
+                )
         return 0
     finally:
         await conn.close()

--- a/scripts/dev/lease_plane_deprecate.py
+++ b/scripts/dev/lease_plane_deprecate.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import hashlib
 import json
 import os
 import sys
@@ -45,6 +46,19 @@ try:
 except ImportError:
     print("error: asyncpg not installed; install with `pip install asyncpg`", file=sys.stderr)
     sys.exit(2)
+
+
+def _lock_key_for_kind(kind: str) -> int:
+    """Deterministic int32-positive advisory-lock key from a scheme kind.
+
+    Python's `hash()` for strings is salted per-process via PYTHONHASHSEED,
+    so two CLI invocations in different shells would otherwise produce
+    different lock keys for the same kind — silently breaking the §7.11.7
+    race-window protection (council BLOCK from PR 1-4 stack review).
+    Use SHA-256 truncated to int32-positive instead.
+    """
+    digest = hashlib.sha256(kind.encode("utf-8")).digest()
+    return int.from_bytes(digest[:4], "big") & 0x7FFFFFFF
 
 
 DEFAULT_DB_URL = os.environ.get(
@@ -94,8 +108,8 @@ async def deprecate_cmd(
             )
             return 1
         async with conn.transaction(isolation="serializable"):
-            # Hash the scheme name to a stable int for advisory lock; ensure positive int range.
-            lock_key = abs(hash(kind)) % (2**31 - 1)
+            # Use deterministic SHA-256-derived key (see _lock_key_for_kind for rationale).
+            lock_key = _lock_key_for_kind(kind)
             await conn.execute("SELECT pg_advisory_xact_lock($1)", lock_key)
             await conn.execute(
                 """

--- a/scripts/dev/lease_plane_deprecate.py
+++ b/scripts/dev/lease_plane_deprecate.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""
+Lease-plane deprecation CLI (RFC v0.8 §7.11).
+
+Implements the 4-phase operator-driven scheme deprecation procedure as a
+standalone Python CLI in `scripts/dev/`. Operator decision 2026-04-30 — Python
+CLI rather than Mix wrapper because deprecation is governance/operator policy
+plus Postgres state, not BEAM live coordination.
+
+Usage:
+    python3 scripts/dev/lease_plane_deprecate.py deprecate <kind> [--days N]
+    python3 scripts/dev/lease_plane_deprecate.py deprecation-sweep <kind>
+    python3 scripts/dev/lease_plane_deprecate.py deprecation-finalize <kind>
+    python3 scripts/dev/lease_plane_deprecate.py deprecation-status [<kind>]
+
+Authorization:
+    `deprecation-sweep` requires LEASE_FORCE_RELEASE_TOKEN (RFC §7.10) — read
+    from env or `~/.config/cirwel/secrets.env`. GOVERNANCE_TOKEN does NOT
+    authorize sweep.
+
+Phase ordering (RFC §7.11.2):
+    Phase 0:  deprecate           — INSERT into deprecated_schemes
+    Phase 1:  (verification, lint via unitares_doctor — out of CLI scope)
+    Phase 2:  deprecation-sweep   — force-release surviving leases (idempotent)
+    Phase 3:  deprecation-finalize — record check_migrated_at + migrate CHECK
+              (atomic with Phase 2 in same operator session per RFC §7.11.2)
+
+Idempotency:
+    Phase 0 INSERT uses ON CONFLICT DO NOTHING (re-marking is a no-op).
+    Phase 2 sweep predicate `WHERE released_at IS NULL AND surface_kind = $1`
+    reaches fixpoint on re-run after partial completion (RFC §7.11.4).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+try:
+    import asyncpg
+except ImportError:
+    print("error: asyncpg not installed; install with `pip install asyncpg`", file=sys.stderr)
+    sys.exit(2)
+
+
+DEFAULT_DB_URL = os.environ.get(
+    "GOVERNANCE_DATABASE_URL",
+    "postgresql://postgres:postgres@localhost:5432/governance",
+)
+
+
+def _read_force_release_token() -> str | None:
+    """Read LEASE_FORCE_RELEASE_TOKEN from env or ~/.config/cirwel/secrets.env."""
+    tok = os.environ.get("LEASE_FORCE_RELEASE_TOKEN")
+    if tok:
+        return tok
+    secrets_path = Path.home() / ".config" / "cirwel" / "secrets.env"
+    if not secrets_path.exists():
+        return None
+    for line in secrets_path.read_text().splitlines():
+        line = line.strip()
+        if line.startswith("LEASE_FORCE_RELEASE_TOKEN="):
+            return line.split("=", 1)[1].strip().strip('"').strip("'")
+    return None
+
+
+async def deprecate_cmd(
+    *,
+    kind: str,
+    session_id: str,
+    drain_window_days: int,
+    db_url: str = DEFAULT_DB_URL,
+) -> int:
+    """Phase 0: mark scheme deprecated. Idempotent via ON CONFLICT.
+
+    Per RFC §7.11.7 race-window mitigation, the INSERT runs inside a
+    serializable transaction with a session-level advisory lock so concurrent
+    acquires racing the mark transaction see a consistent state.
+    """
+    conn = await asyncpg.connect(db_url)
+    try:
+        # Validate against catalog OUTSIDE the transaction so a failure doesn't
+        # abort the serializable tx (and so the error message can list valid kinds).
+        catalog = await _list_catalog_kinds(conn)
+        if kind not in catalog:
+            print(
+                f"error: scheme {kind!r} not in lease_plane.surface_kind_catalog. "
+                f"Valid kinds: {catalog}",
+                file=sys.stderr,
+            )
+            return 1
+        async with conn.transaction(isolation="serializable"):
+            # Hash the scheme name to a stable int for advisory lock; ensure positive int range.
+            lock_key = abs(hash(kind)) % (2**31 - 1)
+            await conn.execute("SELECT pg_advisory_xact_lock($1)", lock_key)
+            await conn.execute(
+                """
+                INSERT INTO lease_plane.deprecated_schemes
+                  (surface_kind, marked_by_session_id, drain_window_days)
+                VALUES ($1, $2, $3)
+                ON CONFLICT (surface_kind) DO NOTHING
+                """,
+                kind, session_id, drain_window_days,
+            )
+        return 0
+    finally:
+        await conn.close()
+
+
+async def deprecation_sweep_cmd(*, kind: str, db_url: str = DEFAULT_DB_URL) -> int:
+    """Phase 2: idempotent force-release sweep (RFC §7.11.4).
+
+    Predicate: `WHERE released_at IS NULL AND surface_kind = $1` with no
+    timestamp filter. Re-running on partial failure reaches fixpoint because
+    already-released leases are excluded by the released_at IS NULL clause.
+
+    Authorization: requires LEASE_FORCE_RELEASE_TOKEN (RFC §7.10).
+    GOVERNANCE_TOKEN does NOT authorize.
+
+    Each swept lease emits a `lease.deprecation_swept` event with
+    deprecation_id in the payload jsonb for batch correlation (§7.11.3).
+    """
+    if not _read_force_release_token():
+        print(
+            "error: deprecation-sweep requires LEASE_FORCE_RELEASE_TOKEN "
+            "(env or ~/.config/cirwel/secrets.env). GOVERNANCE_TOKEN does NOT authorize.",
+            file=sys.stderr,
+        )
+        return 1
+
+    conn = await asyncpg.connect(db_url)
+    try:
+        # Look up deprecation_id for audit correlation.
+        depr_id = await conn.fetchval(
+            "SELECT deprecation_id FROM lease_plane.deprecated_schemes WHERE surface_kind = $1",
+            kind,
+        )
+        if depr_id is None:
+            print(f"error: scheme {kind!r} is not marked deprecated; run `deprecate {kind}` first.",
+                  file=sys.stderr)
+            return 1
+
+        async with conn.transaction():
+            # Record sweep_started_at.
+            await conn.execute(
+                "UPDATE lease_plane.deprecated_schemes SET sweep_started_at = COALESCE(sweep_started_at, now()) "
+                "WHERE surface_kind = $1",
+                kind,
+            )
+            # Idempotent predicate per RFC §7.11.4 — no timestamp filter.
+            unreleased = await conn.fetch(
+                """
+                SELECT lease_id, surface_id FROM lease_plane.surface_leases
+                WHERE released_at IS NULL AND surface_kind = $1
+                ORDER BY acquired_at
+                FOR UPDATE SKIP LOCKED
+                """,
+                kind,
+            )
+            for row in unreleased:
+                # Force-release the lease.
+                await conn.execute(
+                    "UPDATE lease_plane.surface_leases "
+                    "SET released_at = now(), release_reason = 'forced' "
+                    "WHERE lease_id = $1",
+                    row["lease_id"],
+                )
+                # Emit audit event with deprecation_id for batch correlation.
+                payload = json.dumps({"deprecation_id": str(depr_id), "kind": kind})
+                await conn.execute(
+                    """
+                    INSERT INTO lease_plane.lease_plane_events
+                      (event_type, lease_id, surface_id, surface_kind, advisory_mode, payload)
+                    VALUES ('lease.deprecation_swept', $1, $2, $3, false, $4::jsonb)
+                    """,
+                    row["lease_id"], row["surface_id"], kind, payload,
+                )
+            # Mark sweep complete.
+            await conn.execute(
+                "UPDATE lease_plane.deprecated_schemes SET sweep_completed_at = now() "
+                "WHERE surface_kind = $1",
+                kind,
+            )
+        return 0
+    finally:
+        await conn.close()
+
+
+async def deprecation_finalize_cmd(*, kind: str, db_url: str = DEFAULT_DB_URL) -> int:
+    """Phase 3: record check_migrated_at on the deprecated_schemes row.
+
+    Per RFC §7.11.2, Phase 3 also extends the surface_id_grammar CHECK to
+    remove the deprecated scheme — that ALTER TABLE should be performed
+    atomically in the same operator session as Phase 2 (DDL as a separate
+    follow-on migration is the fallback if the operator splits sessions).
+    """
+    conn = await asyncpg.connect(db_url)
+    try:
+        async with conn.transaction():
+            row = await conn.fetchrow(
+                "SELECT sweep_completed_at FROM lease_plane.deprecated_schemes WHERE surface_kind = $1",
+                kind,
+            )
+            if row is None:
+                print(f"error: scheme {kind!r} is not marked deprecated.", file=sys.stderr)
+                return 1
+            if row["sweep_completed_at"] is None:
+                print(f"error: deprecation-sweep has not completed for {kind!r}; "
+                      f"run `deprecation-sweep {kind}` first.", file=sys.stderr)
+                return 1
+            await conn.execute(
+                "UPDATE lease_plane.deprecated_schemes "
+                "SET check_migrated_at = COALESCE(check_migrated_at, now()) "
+                "WHERE surface_kind = $1",
+                kind,
+            )
+        return 0
+    finally:
+        await conn.close()
+
+
+async def deprecation_status_cmd(*, kind: str | None = None, db_url: str = DEFAULT_DB_URL) -> int:
+    """Print deprecated_schemes table contents (operator visibility)."""
+    conn = await asyncpg.connect(db_url)
+    try:
+        if kind:
+            rows = await conn.fetch(
+                "SELECT * FROM lease_plane.deprecated_schemes WHERE surface_kind = $1",
+                kind,
+            )
+        else:
+            rows = await conn.fetch(
+                "SELECT * FROM lease_plane.deprecated_schemes ORDER BY marked_deprecated_at"
+            )
+        for row in rows:
+            print(json.dumps({k: str(v) for k, v in dict(row).items()}, indent=2))
+        if not rows:
+            print("(no deprecated schemes)")
+        return 0
+    finally:
+        await conn.close()
+
+
+async def _list_catalog_kinds(conn) -> list[str]:
+    rows = await conn.fetch("SELECT surface_kind FROM lease_plane.surface_kind_catalog ORDER BY surface_kind")
+    return [r["surface_kind"] for r in rows]
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="lease_plane_deprecate", description=__doc__)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    dep = sub.add_parser("deprecate", help="Phase 0: mark scheme deprecated.")
+    dep.add_argument("kind", help="surface_kind to deprecate (must be in surface_kind_catalog)")
+    dep.add_argument("--days", type=int, default=30, help="drain window in days (default 30, max 90)")
+    dep.add_argument("--session-id", default=os.environ.get("USER", "operator-cli"),
+                     help="audit identifier for marked_by_session_id")
+
+    sweep = sub.add_parser("deprecation-sweep", help="Phase 2: force-release surviving leases.")
+    sweep.add_argument("kind")
+
+    fin = sub.add_parser("deprecation-finalize", help="Phase 3: record check_migrated_at.")
+    fin.add_argument("kind")
+
+    status = sub.add_parser("deprecation-status", help="Show deprecated_schemes table.")
+    status.add_argument("kind", nargs="?", default=None)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.cmd == "deprecate":
+        return asyncio.run(
+            deprecate_cmd(kind=args.kind, session_id=args.session_id, drain_window_days=args.days)
+        )
+    if args.cmd == "deprecation-sweep":
+        return asyncio.run(deprecation_sweep_cmd(kind=args.kind))
+    if args.cmd == "deprecation-finalize":
+        return asyncio.run(deprecation_finalize_cmd(kind=args.kind))
+    if args.cmd == "deprecation-status":
+        return asyncio.run(deprecation_status_cmd(kind=args.kind))
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/ship.sh
+++ b/scripts/dev/ship.sh
@@ -79,7 +79,7 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)
 # outcome and proceed regardless, and release on EXIT so the lease is
 # returned even if a downstream step (commit, push, PR create) fails.
 LEASE_RESULT=$(python3 "$PROJECT_ROOT/scripts/dev/_ship_lease_advisory.py" acquire \
-    --surface-id="ship.sh:$BRANCH" \
+    --surface-id="resident:/ship_sh_$BRANCH" \
     --surface-kind="ship_sh" \
     --intent="$MESSAGE" \
     --ttl-s=300 2>/dev/null || echo '{"outcome":"client_error","lease_id":null}')

--- a/src/lease_plane/advisory.py
+++ b/src/lease_plane/advisory.py
@@ -100,7 +100,6 @@ def new_holder_uuid() -> uuid.UUID:
 def lease_advisory_scope(
     *,
     surface_id: str,
-    surface_kind: str | None = None,
     holder_agent_uuid: uuid.UUID,
     ttl_s: int,
     intent: str | None = None,
@@ -118,13 +117,10 @@ def lease_advisory_scope(
     the caller's block will propagate normally; the wrapper only ensures
     the lease is released if it was acquired.
 
-    `surface_kind` is accepted for backwards-compat with pre-PR-2 callers
-    (watcher/vigil/sentinel/chronicler agents) but is no longer passed to
-    AcquireRequest — per RFC v0.8 §7.2.3 the server derives surface_kind
-    from the surface_id scheme prefix via migration 026's generated column.
-    The parameter is silently ignored; callers SHOULD remove it.
+    `surface_kind` was a parameter pre-PR-2.5 but has been fully removed —
+    per RFC v0.8 §7.2.3, surface_kind is derived server-side from the
+    surface_id scheme prefix via migration 026's generated column.
     """
-    del surface_kind  # ignored; see docstring
     advisory_client = client or make_advisory_client()
 
     request = AcquireRequest(

--- a/src/lease_plane/advisory.py
+++ b/src/lease_plane/advisory.py
@@ -100,7 +100,7 @@ def new_holder_uuid() -> uuid.UUID:
 def lease_advisory_scope(
     *,
     surface_id: str,
-    surface_kind: str,
+    surface_kind: str | None = None,
     holder_agent_uuid: uuid.UUID,
     ttl_s: int,
     intent: str | None = None,
@@ -117,12 +117,18 @@ def lease_advisory_scope(
     The wrapper NEVER raises from the lease layer. Any exception raised by
     the caller's block will propagate normally; the wrapper only ensures
     the lease is released if it was acquired.
+
+    `surface_kind` is accepted for backwards-compat with pre-PR-2 callers
+    (watcher/vigil/sentinel/chronicler agents) but is no longer passed to
+    AcquireRequest — per RFC v0.8 §7.2.3 the server derives surface_kind
+    from the surface_id scheme prefix via migration 026's generated column.
+    The parameter is silently ignored; callers SHOULD remove it.
     """
+    del surface_kind  # ignored; see docstring
     advisory_client = client or make_advisory_client()
 
     request = AcquireRequest(
         surface_id=surface_id,
-        surface_kind=surface_kind,
         holder_agent_uuid=holder_agent_uuid,
         holder_class="process_instance",
         holder_kind="remote_heartbeat",

--- a/src/lease_plane/canonicalize.py
+++ b/src/lease_plane/canonicalize.py
@@ -1,0 +1,173 @@
+"""
+Server-side canonicalization helper for surface_id (RFC v0.8 §7.12).
+
+Per-scheme normalization rules — the single point of truth for split-brain
+prevention. Two callers using different paths to the same logical surface
+must produce the same canonical surface_id IFF both go through this helper.
+
+Authority is server-side: the lease plane re-canonicalizes on receipt against
+its own filesystem semantics (RFC §7.12.1, dialectic option (i)).
+
+Three live-verifier findings drove the implementation details below:
+
+  - DRIFT-2 (/var → /private/var): os.path.realpath on macOS does NOT
+    idempotently re-resolve. /var/folders/.../tmpfile and
+    /private/var/folders/.../tmpfile would otherwise produce two distinct
+    canonical strings. Helper double-applies realpath.
+
+  - DRIFT-3 (pathconf REFUTED): os.pathconf_names on macOS Python does NOT
+    contain 'PC_CASE_SENSITIVE'. The RFC's original probe spec was wrong;
+    helper uses a tmpfile probe instead (write 'PROBE', stat 'probe').
+
+  - Canonical scheme list (RFC §7.2.1) — five v0 schemes; helper dispatches
+    per-scheme.
+"""
+
+from __future__ import annotations
+
+import os
+import os.path
+import tempfile
+
+# v0.8 canonical scheme list (RFC §7.2.1). Single source of truth in code.
+CANONICAL_SCHEMES: tuple[str, ...] = ("file", "dialectic", "resident", "capture", "td")
+
+# Compiled scheme-grammar regex matches what migration 026 enforces at the DB layer.
+_SCHEME_GRAMMAR = "^(file://|dialectic:/|resident:/|capture:/|td:/)"
+
+_PATH_MAX = 4096
+
+_case_insensitive_cache: bool | None = None
+
+
+class CanonicalizeError(Exception):
+    """Raised when a surface_id cannot be canonicalized.
+
+    `reason` is one of:
+      - 'symlink_loop' — realpath hit ELOOP
+      - 'path_too_long' — path exceeds PATH_MAX
+      - 'invalid_scheme' — surface_id doesn't match the canonical scheme list
+    """
+
+    def __init__(self, reason: str, message: str = "") -> None:
+        super().__init__(message or reason)
+        self.reason = reason
+
+
+def _detect_case_insensitive(probe_root: str | None = None) -> bool:
+    """Tmpfile probe: write 'PROBE', stat 'probe', return whether they're the same file.
+
+    DRIFT-3 mitigation: do NOT use pathconf(_PC_CASE_SENSITIVE) — REFUTED on macOS Python
+    (PC_CASE_SENSITIVE absent from os.pathconf_names; calling raises ValueError).
+
+    Args:
+        probe_root: Optional directory to probe. None uses tempfile.gettempdir().
+                    Tests can override; production uses the server's local FS.
+    """
+    with tempfile.TemporaryDirectory(prefix="lease_canonicalize_probe_", dir=probe_root) as d:
+        upper = os.path.join(d, "PROBE")
+        lower = os.path.join(d, "probe")
+        with open(upper, "w") as f:
+            f.write("")
+        return os.path.exists(lower)
+
+
+def _is_case_insensitive() -> bool:
+    """Cached result of the tmpfile probe; runs once per process."""
+    global _case_insensitive_cache
+    if _case_insensitive_cache is None:
+        _case_insensitive_cache = _detect_case_insensitive()
+    return _case_insensitive_cache
+
+
+def canonicalize(surface_id: str) -> str:
+    """Return the canonical form of a surface_id per RFC v0.8 §7.12.1.
+
+    Raises:
+        CanonicalizeError: symlink loop, path too long, or invalid scheme.
+        ValueError: NUL byte in input (caller-side reject — matches stdlib).
+    """
+    if "\x00" in surface_id:
+        raise ValueError("NUL byte in surface_id")
+    if len(surface_id) > _PATH_MAX:
+        raise CanonicalizeError("path_too_long", f"surface_id length {len(surface_id)} > PATH_MAX {_PATH_MAX}")
+
+    if surface_id.startswith("file://"):
+        return _canonicalize_file(surface_id[len("file://") :])
+    if surface_id.startswith("dialectic:/"):
+        return _canonicalize_dialectic(surface_id[len("dialectic:/") :])
+    if surface_id.startswith("resident:/"):
+        return _canonicalize_resident(surface_id[len("resident:/") :])
+    if surface_id.startswith("capture:/"):
+        return _canonicalize_capture(surface_id[len("capture:/") :])
+    if surface_id.startswith("td:/"):
+        # Reserved scheme; pass-through with no normalization beyond what the
+        # caller supplied. Field_validator ensures the prefix matched the grammar.
+        return f"td:/{surface_id[len('td:/') :]}"
+    raise CanonicalizeError(
+        "invalid_scheme",
+        f"surface_id does not match canonical scheme list ({CANONICAL_SCHEMES}): {surface_id!r}",
+    )
+
+
+def _canonicalize_file(path: str) -> str:
+    """file:// canonicalization (RFC §7.12.1 + DRIFT-2 fix).
+
+    1. Double-realpath to resolve macOS /var → /private/var idempotently.
+    2. Strip trailing / unless path is exactly /.
+    3. Lowercase if filesystem is case-insensitive.
+    4. Re-prefix with file://.
+    """
+    # strict=True is required to actually catch symlink loops on macOS — without it,
+    # os.path.realpath silently returns the loop path. ENOENT is treated as "nonexistent
+    # path, fall through" per RFC §7.12.2 — the lease plane does not validate file existence.
+    try:
+        resolved = os.path.realpath(path, strict=True)
+    except OSError as e:
+        # ELOOP: 40 on Linux, 62 on macOS; "Too many" guard catches both portably.
+        if e.errno in (40, 62) or "Too many" in str(e):
+            raise CanonicalizeError("symlink_loop", str(e)) from e
+        if e.errno == 2:  # ENOENT — caller passed a nonexistent path; fall through.
+            resolved = os.path.realpath(path)
+        elif e.errno == 36:  # ENAMETOOLONG
+            raise CanonicalizeError("path_too_long", str(e)) from e
+        else:
+            raise CanonicalizeError("invalid_scheme", str(e)) from e
+    # Double-realpath catches macOS /var → /private/var idempotency edge case.
+    resolved = os.path.realpath(resolved)
+
+    # Strip trailing / except for root.
+    if len(resolved) > 1 and resolved.endswith("/"):
+        resolved = resolved.rstrip("/")
+
+    # Lowercase if case-insensitive FS.
+    if _is_case_insensitive():
+        resolved = resolved.lower()
+
+    return f"file://{resolved}"
+
+
+def _canonicalize_dialectic(path: str) -> str:
+    """dialectic:/ — opaque session id; lowercase only."""
+    return f"dialectic:/{path.lower()}"
+
+
+def _canonicalize_resident(path: str) -> str:
+    """resident:/ — opaque resident name; case-sensitive; strip trailing /."""
+    if any(ch in path for ch in (" ", "\t", "\n", "?", "#", "&")):
+        raise CanonicalizeError(
+            "invalid_scheme",
+            f"resident:/ surface_id contains reserved character (?, #, &, whitespace): {path!r}",
+        )
+    return f"resident:/{path.rstrip('/')}"
+
+
+def _canonicalize_capture(path: str) -> str:
+    """capture:/ — comma-separated member list; sort lexically.
+
+    Closes dialectic missing-from-§7.12 finding: capture:/A,B,C and capture:/B,A,C
+    must canonicalize to the same surface_id (same calibration window).
+    """
+    members = [m.strip() for m in path.split(",") if m.strip()]
+    members.sort()
+    return f"capture:/{','.join(members)}"

--- a/src/lease_plane/client.py
+++ b/src/lease_plane/client.py
@@ -8,6 +8,8 @@ handler paths that would block the anyio task group.
 from __future__ import annotations
 
 import json
+import random
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -112,6 +114,60 @@ class LeasePlaneClient:
     def acquire(self, request: AcquireRequest) -> AcquireResult:
         payload = self._request_json("POST", "/v1/lease/acquire", request.model_dump(mode="json"))
         return _parse_acquire(payload)
+
+    def acquire_with_retry(
+        self,
+        request: AcquireRequest,
+        *,
+        max_attempts: int = 5,
+        floor_s: float = 0.1,
+        ceiling_s: float = 5.0,
+        sleep: Callable[[float], None] | None = None,
+        rng: Callable[[], float] | None = None,
+    ) -> AcquireResult:
+        """Acquire with jittered exponential backoff on `held_by_other`.
+
+        RFC v0.8 §7.3.3 contract: floor 100ms, ceiling 5s, full jitter
+        (per AWS Architecture Blog convention). `retry_after_hint_ms` from
+        the server (set in the §7.3.2 extended typed-absence shape) is
+        honored as a per-attempt floor — the wait is at least that long.
+
+        Terminal results (no retry):
+          - AcquireOk
+          - AcquireServiceUnavailable (advisory escape valve)
+          - AcquirePermissionDenied / AcquireSchemaInvalid (caller bug)
+        Only `held_by_other` triggers retry. After max_attempts, the final
+        held_by_other is returned to the caller.
+
+        Args:
+            max_attempts: total acquire attempts including the first (default 5).
+            floor_s: minimum backoff per attempt (default 0.1s = 100ms).
+            ceiling_s: maximum backoff per attempt (default 5.0s).
+            sleep: injectable sleep for test determinism (default time.sleep).
+            rng: injectable [0,1) random for test determinism (default random.random).
+        """
+        from src.lease_plane import (
+            AcquireHeldByOther,
+            AcquireOk,
+        )
+
+        sleep_fn = sleep or time.sleep
+        rand_fn = rng or random.random
+
+        result: AcquireResult = self.acquire(request)
+        attempt = 1
+        while attempt < max_attempts and isinstance(result, AcquireHeldByOther):
+            # Full-jitter exponential backoff. Cap exponent to avoid overflow.
+            exp_cap = min(2 ** min(attempt - 1, 10) * floor_s, ceiling_s)
+            backoff = rand_fn() * exp_cap
+            backoff = max(backoff, floor_s)
+            # retry_after_hint_ms (server-provided) raises the floor for THIS attempt only.
+            hint_floor = (result.retry_after_hint_ms or 0) / 1000.0
+            backoff = max(backoff, hint_floor)
+            sleep_fn(backoff)
+            result = self.acquire(request)
+            attempt += 1
+        return result
 
     def status(self, surface_id: str) -> StatusResult:
         payload = self._request_json("GET", "/v1/lease/status", None, query={"surface_id": surface_id})

--- a/src/lease_plane/client.py
+++ b/src/lease_plane/client.py
@@ -145,11 +145,21 @@ class LeasePlaneClient:
             ceiling_s: maximum backoff per attempt (default 5.0s).
             sleep: injectable sleep for test determinism (default time.sleep).
             rng: injectable [0,1) random for test determinism (default random.random).
+
+        Raises:
+            ValueError: max_attempts < 1, or floor_s > ceiling_s
+                (PR 5 council fix — pre-PR-5 silently fired one HTTP call when max_attempts=0).
         """
-        from src.lease_plane import (
-            AcquireHeldByOther,
-            AcquireOk,
-        )
+        if max_attempts < 1:
+            raise ValueError(f"max_attempts must be >= 1, got {max_attempts}")
+        if floor_s > ceiling_s:
+            raise ValueError(
+                f"floor_s ({floor_s}) must be <= ceiling_s ({ceiling_s})"
+            )
+
+        # AcquireHeldByOther is the only retry-triggering result type;
+        # AcquireOk no longer needed here (NIT-1 fix from council pass).
+        from src.lease_plane import AcquireHeldByOther
 
         sleep_fn = sleep or time.sleep
         rand_fn = rng or random.random

--- a/src/lease_plane/models.py
+++ b/src/lease_plane/models.py
@@ -58,10 +58,22 @@ class LeaseRecord(BaseModel):
 
 
 class AcquireRequest(LeasePlaneModel):
-    """Request body for POST /v1/lease/acquire."""
+    """Request body for POST /v1/lease/acquire.
+
+    `surface_kind` is no longer a request field per RFC v0.8 §7.2.3 — it is
+    derived server-side from the surface_id scheme prefix via migration 026's
+    generated column.
+
+    Note (PR 2): the §7.12.5 Pydantic field_validator that auto-canonicalizes
+    `surface_id` and rejects non-canonical schemes is DEFERRED to PR 2.5.
+    PR 2.5 also migrates production agents (watcher/vigil/sentinel/chronicler/
+    ship.sh advisory) to canonical schemes (`resident:/...`, `file://...`)
+    so the field_validator does not brick the fleet on activation.
+    Today AcquireRequest accepts any surface_id; the canonicalize helper is
+    available for opt-in caller use via `from src.lease_plane.canonicalize`.
+    """
 
     surface_id: str = Field(min_length=1)
-    surface_kind: str = Field(min_length=1)
     holder_agent_uuid: UUID
     holder_class: HolderClass
     holder_kind: HolderKind

--- a/src/lease_plane/models.py
+++ b/src/lease_plane/models.py
@@ -6,7 +6,9 @@ from datetime import datetime
 from typing import Any, Literal, TypeAlias
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from src.lease_plane.canonicalize import CANONICAL_SCHEMES, canonicalize
 
 HolderClass: TypeAlias = Literal["process_instance", "substrate_earned"]
 HolderKind: TypeAlias = Literal["local_beam", "remote_heartbeat"]
@@ -64,13 +66,10 @@ class AcquireRequest(LeasePlaneModel):
     derived server-side from the surface_id scheme prefix via migration 026's
     generated column.
 
-    Note (PR 2): the §7.12.5 Pydantic field_validator that auto-canonicalizes
-    `surface_id` and rejects non-canonical schemes is DEFERRED to PR 2.5.
-    PR 2.5 also migrates production agents (watcher/vigil/sentinel/chronicler/
-    ship.sh advisory) to canonical schemes (`resident:/...`, `file://...`)
-    so the field_validator does not brick the fleet on activation.
-    Today AcquireRequest accepts any surface_id; the canonicalize helper is
-    available for opt-in caller use via `from src.lease_plane.canonicalize`.
+    `surface_id` auto-canonicalizes via field_validator per RFC v0.8 §7.12.5:
+    rejects NUL bytes, ?-bearing strings (reserved for v1 modifier form per
+    §7.12.4), non-canonical schemes (per §7.2.1 list); auto-canonicalizes
+    via `src.lease_plane.canonicalize`.
     """
 
     surface_id: str = Field(min_length=1)
@@ -81,6 +80,27 @@ class AcquireRequest(LeasePlaneModel):
     holder_pid: str | None = None
     intent: str | None = None
     audit_session: str | None = None
+
+    @field_validator("surface_id", mode="before")
+    @classmethod
+    def _validate_surface_id(cls, v: str) -> str:
+        """Reject invalid scheme, NUL bytes, ?-bearing values; auto-canonicalize."""
+        if not isinstance(v, str):
+            raise ValueError("surface_id must be a string")
+        if "\x00" in v:
+            raise ValueError("NUL byte in surface_id")
+        if "?" in v:
+            raise ValueError(
+                "query string in surface_id reserved for v1 modifier form (RFC §7.12.4); "
+                "use plain canonical form for v0"
+            )
+        scheme = v.split(":", 1)[0]
+        if scheme not in CANONICAL_SCHEMES:
+            raise ValueError(
+                f"surface_id scheme {scheme!r} not in canonical scheme list {CANONICAL_SCHEMES} "
+                f"(RFC §7.2.1)"
+            )
+        return canonicalize(v)
 
 
 class RenewRequest(LeasePlaneModel):

--- a/src/lease_plane/models.py
+++ b/src/lease_plane/models.py
@@ -164,7 +164,11 @@ class AcquireHeldByOther(BaseModel):
     blocking_lease_id: UUID
     held_by_uuid: UUID
     expires_at: datetime
-    retry_after_hint_ms: int
+    # Defense-in-depth (PR 5 council fix): retry_after_hint_ms defaults to 0
+    # so any emitter that omits the field doesn't degrade to AcquireSchemaInvalid.
+    # surface_id and blocking_lease_id remain REQUIRED — missing them is a real
+    # contract violation that should surface clearly.
+    retry_after_hint_ms: int = 0
 
 
 class AcquirePermissionDenied(BaseModel):

--- a/src/lease_plane/models.py
+++ b/src/lease_plane/models.py
@@ -128,8 +128,11 @@ class AcquireOk(BaseModel):
 class AcquireHeldByOther(BaseModel):
     ok: Literal[False]
     error: Literal["held_by_other"]
+    surface_id: str
+    blocking_lease_id: UUID
     held_by_uuid: UUID
     expires_at: datetime
+    retry_after_hint_ms: int
 
 
 class AcquirePermissionDenied(BaseModel):

--- a/tests/test_chronicler_lease_advisory.py
+++ b/tests/test_chronicler_lease_advisory.py
@@ -48,8 +48,10 @@ async def test_run_cycle_invokes_lease_advisory_with_expected_surface(
     with pytest.raises(_CycleStopMarker):
         await agent.run_cycle(client=None)
 
-    assert captured["surface_id"] == "chronicler:scrape"
-    assert captured["surface_kind"] == "chronicler_scrape"
+    assert captured["surface_id"] == "resident:/chronicler_scrape"
+    # surface_kind no longer passed (PR 2.5 — derived server-side from scheme prefix
+    # via migration 026's generated column); should not appear in kwargs.
+    assert "surface_kind" not in captured
     assert captured["ttl_s"] == 120
     assert captured.get("intent") == "chronicler daily scrape"
 

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -117,6 +117,7 @@ async def ensure_test_database_schema() -> None:
         await _execute_sql_file(conn, "db/postgres/migrations/026_lease_plane_grammar.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/027_lease_plane_deprecation.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/028_lease_plane_trigger_fix.sql")
+        await _execute_sql_file(conn, "db/postgres/migrations/029_lease_plane_earned_status_guard.sql")
 
         # Ensure partitioned audit tables can accept inserts for current month.
         await _execute_sql_file(conn, "db/postgres/partitions.sql")

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -116,6 +116,7 @@ async def ensure_test_database_schema() -> None:
         await _execute_sql_file(conn, "db/postgres/migrations/025_lease_plane_invariants.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/026_lease_plane_grammar.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/027_lease_plane_deprecation.sql")
+        await _execute_sql_file(conn, "db/postgres/migrations/028_lease_plane_trigger_fix.sql")
 
         # Ensure partitioned audit tables can accept inserts for current month.
         await _execute_sql_file(conn, "db/postgres/partitions.sql")

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -109,6 +109,13 @@ async def ensure_test_database_schema() -> None:
         await _execute_sql_file(conn, "db/postgres/migrations/023_matview_measured_only.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/020_progress_flat_telemetry.sql")
         await _execute_sql_file(conn, "db/postgres/migrations/021_seed_epoch_3.sql")
+        # Surface lease plane (RFC docs/proposals/surface-lease-plane-v0.md):
+        # 024 + 025 build the lease_plane schema + immutability triggers; 026 adds
+        # storage-layer grammar CHECK + generated surface_kind column (PR 1, this branch).
+        await _execute_sql_file(conn, "db/postgres/migrations/024_lease_plane.sql")
+        await _execute_sql_file(conn, "db/postgres/migrations/025_lease_plane_invariants.sql")
+        await _execute_sql_file(conn, "db/postgres/migrations/026_lease_plane_grammar.sql")
+        await _execute_sql_file(conn, "db/postgres/migrations/027_lease_plane_deprecation.sql")
 
         # Ensure partitioned audit tables can accept inserts for current month.
         await _execute_sql_file(conn, "db/postgres/partitions.sql")

--- a/tests/test_lease_plane_advisory.py
+++ b/tests/test_lease_plane_advisory.py
@@ -188,7 +188,6 @@ def test_caller_exceptions_propagate_and_lease_still_released():
     try:
         with lease_advisory_scope(
             surface_id="test:advisory/raises",
-            surface_kind="test",
             holder_agent_uuid=holder,
             ttl_s=60,
             client=client,

--- a/tests/test_lease_plane_advisory.py
+++ b/tests/test_lease_plane_advisory.py
@@ -21,7 +21,7 @@ def _ok_lease_payload(holder_uuid: UUID) -> dict[str, Any]:
     now = datetime.now(UTC).replace(microsecond=0)
     return {
         "lease_id": str(uuid4()),
-        "surface_id": "test:advisory/x",
+        "surface_id": "dialectic:/test_advisory_x",
         "surface_kind": "test",
         "holder_agent_uuid": str(holder_uuid),
         "holder_class": "process_instance",
@@ -63,8 +63,7 @@ def test_acquired_new_runs_block_and_releases():
     block_ran = False
     seen_outcome = None
     with lease_advisory_scope(
-        surface_id="test:advisory/x",
-        surface_kind="test",
+        surface_id="dialectic:/test_advisory_x",
         holder_agent_uuid=holder,
         ttl_s=60,
         intent="unit-test",
@@ -93,8 +92,7 @@ def test_idempotent_outcome_classified_correctly():
     client = LeasePlaneClient(transport=transport)
 
     with lease_advisory_scope(
-        surface_id="test:advisory/x",
-        surface_kind="test",
+        surface_id="dialectic:/test_advisory_x",
         holder_agent_uuid=holder,
         ttl_s=60,
         client=client,
@@ -110,7 +108,7 @@ def test_held_by_other_runs_block_no_release():
             {
                 "ok": False,
                 "error": "held_by_other",
-                "surface_id": "test:advisory/contended",
+                "surface_id": "dialectic:/test_advisory_contended",
                 "blocking_lease_id": str(uuid4()),
                 "held_by_uuid": str(other_holder),
                 "expires_at": (datetime.now(UTC) + timedelta(seconds=30)).isoformat(),
@@ -122,8 +120,7 @@ def test_held_by_other_runs_block_no_release():
 
     block_ran = False
     with lease_advisory_scope(
-        surface_id="test:advisory/contended",
-        surface_kind="test",
+        surface_id="dialectic:/test_advisory_contended",
         holder_agent_uuid=uuid4(),
         ttl_s=60,
         client=client,
@@ -144,8 +141,7 @@ def test_service_unavailable_runs_block_no_release():
 
     block_ran = False
     with lease_advisory_scope(
-        surface_id="test:advisory/down",
-        surface_kind="test",
+        surface_id="dialectic:/test_advisory_down",
         holder_agent_uuid=uuid4(),
         ttl_s=60,
         client=client,
@@ -160,8 +156,7 @@ def test_service_unavailable_runs_block_no_release():
 def test_disabled_client_outcome_is_service_unavailable():
     block_ran = False
     with lease_advisory_scope(
-        surface_id="test:advisory/disabled",
-        surface_kind="test",
+        surface_id="dialectic:/test_advisory_disabled",
         holder_agent_uuid=uuid4(),
         ttl_s=60,
         client=LeasePlaneDisabledClient(),
@@ -187,7 +182,7 @@ def test_caller_exceptions_propagate_and_lease_still_released():
 
     try:
         with lease_advisory_scope(
-            surface_id="test:advisory/raises",
+            surface_id="dialectic:/test_advisory_raises",
             holder_agent_uuid=holder,
             ttl_s=60,
             client=client,
@@ -234,8 +229,7 @@ def test_acquire_raise_classified_as_client_error():
     block_ran = False
     seen_outcome: str | None = None
     with lease_advisory_scope(
-        surface_id="test:advisory/timeout",
-        surface_kind="test",
+        surface_id="dialectic:/test_advisory_timeout",
         holder_agent_uuid=uuid4(),
         ttl_s=60,
         client=client,

--- a/tests/test_lease_plane_advisory.py
+++ b/tests/test_lease_plane_advisory.py
@@ -110,8 +110,11 @@ def test_held_by_other_runs_block_no_release():
             {
                 "ok": False,
                 "error": "held_by_other",
+                "surface_id": "test:advisory/contended",
+                "blocking_lease_id": str(uuid4()),
                 "held_by_uuid": str(other_holder),
                 "expires_at": (datetime.now(UTC) + timedelta(seconds=30)).isoformat(),
+                "retry_after_hint_ms": 5000,
             }
         ]
     )

--- a/tests/test_lease_plane_canonicalize.py
+++ b/tests/test_lease_plane_canonicalize.py
@@ -1,0 +1,133 @@
+"""
+PR 2 — surface_id canonicalization helper (RFC v0.8 §7.12).
+
+Tests the per-scheme normalization rule, error semantics, and
+filesystem case-detection probe.
+
+Spec: docs/proposals/surface-lease-plane-v0.md §7.12.0–§7.12.3
+      docs/proposals/surface-lease-plane-phase-a-plan.md PR 2
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+def test_canonicalize_case_detection_uses_tmpfile_probe():
+    """Live-verifier DRIFT-3: pathconf(_PC_CASE_SENSITIVE) is REFUTED on macOS Python.
+    The detection MUST use a tmpfile probe, not pathconf."""
+    from src.lease_plane import canonicalize as canon
+
+    # The detection function should not raise on macOS.
+    result = canon._detect_case_insensitive()
+    assert isinstance(result, bool), (
+        f"_detect_case_insensitive must return bool, got {type(result).__name__}"
+    )
+
+    # Negative-test the wrong API: confirm it doesn't depend on PC_CASE_SENSITIVE
+    # (would raise ValueError if it did, on macOS).
+    if "PC_CASE_SENSITIVE" not in os.pathconf_names:
+        # Patch pathconf to detect any rogue use.
+        with mock.patch.object(os, "pathconf", side_effect=AssertionError("must not use os.pathconf")):
+            # Re-detection must succeed via tmpfile, not pathconf.
+            assert isinstance(canon._detect_case_insensitive(), bool)
+
+
+def test_canonicalize_resolves_var_to_private_var_on_macos():
+    """Live-verifier DRIFT-2: os.path.realpath on macOS must double-resolve so
+    /var/folders/.../tmpfile and /private/var/folders/.../tmpfile produce the same form."""
+    from src.lease_plane import canonicalize as canon
+
+    if not Path("/private/var").exists() or not Path("/var").exists():
+        pytest.skip("not on a macOS-style filesystem with /var → /private/var symlink")
+
+    # Pick a real path that exists under /var/folders to exercise the realpath chain.
+    with tempfile.NamedTemporaryFile(prefix="canon_var_test_", delete=False) as f:
+        tmp_path = f.name
+    try:
+        # tempfile gives a /var/folders/... path; realpath should produce /private/var/folders/...
+        var_form = f"file://{tmp_path}"
+        # Construct the equivalent /private/var/ form manually.
+        if tmp_path.startswith("/var/"):
+            private_form = f"file:///private{tmp_path}"
+        else:
+            # Already under /private/var/ — both forms should canonicalize identically.
+            private_form = var_form
+        canonical_var = canon.canonicalize(var_form)
+        canonical_private = canon.canonicalize(private_form)
+        assert canonical_var == canonical_private, (
+            f"Expected /var/ and /private/var/ forms to produce the same canonical "
+            f"surface_id, got:\n  var_form     -> {canonical_var}\n  private_form -> {canonical_private}"
+        )
+        assert "/private/var/" in canonical_var, (
+            f"Expected canonical form to contain /private/var/, got {canonical_var}"
+        )
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+
+def test_capture_canonicalizes_member_ordering():
+    """capture:/A,B,C and capture:/B,A,C represent the same calibration window;
+    canonicalize sorts members lexically so they share one surface_id."""
+    from src.lease_plane import canonicalize as canon
+
+    a = canon.canonicalize("capture:/window_b,window_a,window_c")
+    b = canon.canonicalize("capture:/window_a,window_b,window_c")
+    c = canon.canonicalize("capture:/window_c,window_a,window_b")
+
+    assert a == b == c, f"capture:/ members must canonicalize to lexical order, got {a!r} {b!r} {c!r}"
+    assert "window_a,window_b,window_c" in a, (
+        f"Expected lexically-sorted members in canonical form, got {a!r}"
+    )
+
+
+def test_canonicalize_error_semantics():
+    """Helper raises CanonicalizeError with named reasons for bounded failure modes."""
+    from src.lease_plane.canonicalize import CanonicalizeError, canonicalize
+
+    # NUL byte: caller-side rejection. Stdlib raises ValueError; helper propagates.
+    with pytest.raises((ValueError, CanonicalizeError)):
+        canonicalize("file:///tmp/nul\x00byte.py")
+
+    # Symlink loop: realpath raises OSError(ELOOP); helper wraps as CanonicalizeError.
+    with tempfile.TemporaryDirectory() as d:
+        loop_a = os.path.join(d, "loop_a")
+        loop_b = os.path.join(d, "loop_b")
+        os.symlink(loop_b, loop_a)
+        os.symlink(loop_a, loop_b)
+        with pytest.raises(CanonicalizeError) as exc_info:
+            canonicalize(f"file://{loop_a}")
+        assert exc_info.value.reason == "symlink_loop", (
+            f"Expected reason='symlink_loop', got {exc_info.value.reason!r}"
+        )
+
+    # Nonexistent path: realpath returns the un-resolved input, helper proceeds without raising.
+    nonexistent = "file:///tmp/this_path_definitely_does_not_exist_xyzzy_abc123"
+    result = canonicalize(nonexistent)
+    assert result.startswith("file://"), (
+        f"Nonexistent path should still produce a canonical form, got {result!r}"
+    )
+
+
+@pytest.mark.skip(
+    reason="Deferred to PR 2.5 — wiring the AcquireRequest field_validator requires "
+    "migrating production agents (watcher/vigil/sentinel/chronicler/ship.sh) to canonical "
+    "schemes first; otherwise the validator bricks the fleet on first acquire. "
+    "See docs/proposals/surface-lease-plane-phase-a-plan.md PR 2.5."
+)
+def test_acquire_request_rejects_query_string_in_surface_id():
+    """RFC v0.8 §7.12.4: ?-bearing surface_id reserved for v1 modifier form;
+    v0 callers must use plain canonical form."""
+
+
+@pytest.mark.skip(
+    reason="Deferred to PR 2.5 — see test_acquire_request_rejects_query_string_in_surface_id."
+)
+def test_acquire_request_surface_id_field_validator_wired():
+    """RFC v0.8 §7.12.5: AcquireRequest auto-canonicalizes surface_id at the model boundary.
+    Two equivalent inputs must produce the same .surface_id."""

--- a/tests/test_lease_plane_canonicalize.py
+++ b/tests/test_lease_plane_canonicalize.py
@@ -114,20 +114,52 @@ def test_canonicalize_error_semantics():
     )
 
 
-@pytest.mark.skip(
-    reason="Deferred to PR 2.5 — wiring the AcquireRequest field_validator requires "
-    "migrating production agents (watcher/vigil/sentinel/chronicler/ship.sh) to canonical "
-    "schemes first; otherwise the validator bricks the fleet on first acquire. "
-    "See docs/proposals/surface-lease-plane-phase-a-plan.md PR 2.5."
-)
 def test_acquire_request_rejects_query_string_in_surface_id():
     """RFC v0.8 §7.12.4: ?-bearing surface_id reserved for v1 modifier form;
     v0 callers must use plain canonical form."""
+    from pydantic import ValidationError
+
+    from src.lease_plane import AcquireRequest
+    from uuid import uuid4
+
+    with pytest.raises(ValidationError) as exc_info:
+        AcquireRequest(
+            surface_id="file:///tmp/x.py?canon=inode",
+            holder_agent_uuid=uuid4(),
+            holder_class="process_instance",
+            holder_kind="remote_heartbeat",
+            ttl_s=60,
+        )
+    assert "?" in str(exc_info.value) or "query" in str(exc_info.value).lower(), (
+        f"Expected error message to mention query string, got: {exc_info.value}"
+    )
 
 
-@pytest.mark.skip(
-    reason="Deferred to PR 2.5 — see test_acquire_request_rejects_query_string_in_surface_id."
-)
 def test_acquire_request_surface_id_field_validator_wired():
     """RFC v0.8 §7.12.5: AcquireRequest auto-canonicalizes surface_id at the model boundary.
     Two equivalent inputs must produce the same .surface_id."""
+    from src.lease_plane import AcquireRequest
+    from uuid import uuid4
+
+    holder = uuid4()
+
+    def make(sid: str) -> AcquireRequest:
+        return AcquireRequest(
+            surface_id=sid,
+            holder_agent_uuid=holder,
+            holder_class="process_instance",
+            holder_kind="remote_heartbeat",
+            ttl_s=60,
+        )
+
+    a = make("capture:/win_b,win_a")
+    b = make("capture:/win_a,win_b")
+    assert a.surface_id == b.surface_id, (
+        f"AcquireRequest must auto-canonicalize via field_validator; "
+        f"got {a.surface_id!r} != {b.surface_id!r}"
+    )
+
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        make("not_a_real_scheme:foo")

--- a/tests/test_lease_plane_client.py
+++ b/tests/test_lease_plane_client.py
@@ -115,14 +115,18 @@ def test_acquire_ok_parses_idempotent_drift_warning():
 
 def test_acquire_held_by_other_parses_holder_and_expiry():
     holder = uuid4()
+    blocking_lease = uuid4()
     expires_at = datetime.now(UTC).replace(microsecond=0) + timedelta(seconds=30)
 
     def transport(_request: LeaseHTTPRequest):
         return {
             "ok": False,
             "error": "held_by_other",
+            "surface_id": "file:///tmp/a",
+            "blocking_lease_id": str(blocking_lease),
             "held_by_uuid": str(holder),
             "expires_at": expires_at.isoformat(),
+            "retry_after_hint_ms": 5000,
         }
 
     result = LeasePlaneClient(transport=transport).acquire(

--- a/tests/test_lease_plane_client.py
+++ b/tests/test_lease_plane_client.py
@@ -60,7 +60,6 @@ def test_acquire_request_rejects_role_holder_class():
     try:
         AcquireRequest(
             surface_id="file:///tmp/a",
-            surface_kind="file",
             holder_agent_uuid=uuid4(),
             holder_class="role",
             holder_kind="remote_heartbeat",
@@ -98,7 +97,6 @@ def test_acquire_ok_parses_idempotent_drift_warning():
     result = LeasePlaneClient(transport=transport).acquire(
         AcquireRequest(
             surface_id="file:///tmp/a",
-            surface_kind="file",
             holder_agent_uuid=holder,
             holder_class="process_instance",
             holder_kind="remote_heartbeat",
@@ -132,7 +130,6 @@ def test_acquire_held_by_other_parses_holder_and_expiry():
     result = LeasePlaneClient(transport=transport).acquire(
         AcquireRequest(
             surface_id="file:///tmp/a",
-            surface_kind="file",
             holder_agent_uuid=uuid4(),
             holder_class="process_instance",
             holder_kind="remote_heartbeat",
@@ -152,7 +149,6 @@ def test_transport_exception_degrades_to_service_unavailable():
     result = LeasePlaneClient(transport=transport).acquire(
         AcquireRequest(
             surface_id="file:///tmp/a",
-            surface_kind="file",
             holder_agent_uuid=uuid4(),
             holder_class="process_instance",
             holder_kind="remote_heartbeat",
@@ -170,7 +166,6 @@ def test_invalid_response_degrades_to_schema_invalid():
     result = LeasePlaneClient(transport=transport).acquire(
         AcquireRequest(
             surface_id="file:///tmp/a",
-            surface_kind="file",
             holder_agent_uuid=uuid4(),
             holder_class="process_instance",
             holder_kind="remote_heartbeat",

--- a/tests/test_lease_plane_deprecate_cli.py
+++ b/tests/test_lease_plane_deprecate_cli.py
@@ -286,3 +286,36 @@ async def test_deprecation_sweep_requires_force_release_token(monkeypatch):
     finally:
         await _cleanup(conn)
         await conn.close()
+
+
+def test_deprecate_lock_key_stable_across_processes():
+    """PR 5 council BLOCK fix — advisory lock key must be deterministic across
+    Python invocations. PYTHONHASHSEED randomizes string hash() per-process,
+    silently breaking the §7.11.7 race-window protection. CLI must use a
+    stable hash (e.g., hashlib.sha256) for the advisory-lock key."""
+    import subprocess
+    cmd = [
+        "python3", "-c",
+        "from scripts.dev.lease_plane_deprecate import _lock_key_for_kind; "
+        "print(_lock_key_for_kind('td'))",
+    ]
+    out_a = subprocess.run(
+        cmd, capture_output=True, text=True, check=True, cwd=str(project_root),
+    ).stdout.strip()
+    out_b = subprocess.run(
+        cmd, capture_output=True, text=True, check=True, cwd=str(project_root),
+    ).stdout.strip()
+    assert out_a == out_b, (
+        f"lock key must be stable across Python processes for '{__name__}' to "
+        f"protect §7.11.7 race window; got {out_a!r} vs {out_b!r}"
+    )
+    # Different kinds produce different keys.
+    cmd_resident = [
+        "python3", "-c",
+        "from scripts.dev.lease_plane_deprecate import _lock_key_for_kind; "
+        "print(_lock_key_for_kind('resident'))",
+    ]
+    out_resident = subprocess.run(
+        cmd_resident, capture_output=True, text=True, check=True, cwd=str(project_root),
+    ).stdout.strip()
+    assert out_resident != out_a, "different kinds must produce different lock keys"

--- a/tests/test_lease_plane_deprecate_cli.py
+++ b/tests/test_lease_plane_deprecate_cli.py
@@ -1,0 +1,288 @@
+"""
+Phase A PR 3a — deprecation CLI for surface-lease-plane.
+
+Tests the `scripts/dev/lease_plane_deprecate.py` CLI which implements the
+4-phase operator-driven scheme deprecation procedure (RFC v0.8 §7.11.2):
+
+  Phase 0 (`deprecate`)              — mark scheme deprecated, INSERT into deprecated_schemes
+  Phase 1 (automatic verification)   — unitares_doctor lint (out of CLI scope)
+  Phase 2 (`deprecation-sweep`)      — force-release surviving leases, idempotent predicate
+  Phase 3 (`deprecation-finalize`)   — extend grammar CHECK, atomic with sweep
+
+Spec: docs/proposals/surface-lease-plane-v0.md §7.11
+      docs/proposals/surface-lease-plane-phase-a-plan.md PR 3a
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+try:
+    import asyncpg
+except ImportError:
+    pytest.skip("asyncpg not installed", allow_module_level=True)
+
+from tests.test_db_utils import (
+    TEST_DB_URL,
+    can_connect_to_test_db,
+    ensure_test_database_schema,
+)
+
+if not can_connect_to_test_db():
+    pytest.skip("governance_test database not available", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def _set_force_release_token(monkeypatch):
+    """Provide LEASE_FORCE_RELEASE_TOKEN for Phase 2 sweep authorization (RFC §7.10)."""
+    monkeypatch.setenv("LEASE_FORCE_RELEASE_TOKEN", "test-force-release-token-do-not-use-in-prod")
+
+
+async def _cleanup(conn):
+    """Reset deprecated_schemes + surface_leases between tests."""
+    await conn.execute(
+        "DELETE FROM lease_plane.deprecated_schemes WHERE marked_by_session_id LIKE 'test-cli-%'"
+    )
+    await conn.execute(
+        "DELETE FROM lease_plane.surface_leases WHERE intent LIKE 'pr3a-cli-test%'"
+    )
+    await conn.execute(
+        "DELETE FROM lease_plane.lease_plane_events WHERE surface_id LIKE 'td:/pr3a%' "
+        "OR surface_id LIKE 'capture:/pr3a%'"
+    )
+
+
+async def _seed_lease(conn, surface_id: str, ttl_s: int = 60) -> uuid.UUID:
+    """Insert an active lease to be swept."""
+    lease_id = uuid.uuid4()
+    holder_uuid = uuid.uuid4()
+    now = datetime.now(UTC)
+    await conn.execute(
+        """
+        INSERT INTO lease_plane.surface_leases
+          (lease_id, surface_id, holder_agent_uuid, holder_kind, holder_class,
+           heartbeat_required, original_ttl_s, acquired_at, expires_at, intent)
+        VALUES ($1, $2, $3, 'remote_heartbeat', 'process_instance', true, $4, $5, $6, $7)
+        """,
+        lease_id, surface_id, holder_uuid, ttl_s, now,
+        now + timedelta(seconds=ttl_s), "pr3a-cli-test-seed",
+    )
+    return lease_id
+
+
+@pytest.mark.asyncio
+async def test_deprecate_cli_phase_0_inserts_row():
+    """`deprecate <kind>` writes a row to lease_plane.deprecated_schemes."""
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        rc = await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-phase-0", drain_window_days=7,
+            db_url=TEST_DB_URL,
+        )
+        assert rc == 0
+        rows = await conn.fetch(
+            "SELECT surface_kind, drain_window_days, marked_by_session_id "
+            "FROM lease_plane.deprecated_schemes WHERE surface_kind = 'td'"
+        )
+        assert len(rows) == 1
+        assert rows[0]["surface_kind"] == "td"
+        assert rows[0]["drain_window_days"] == 7
+        assert rows[0]["marked_by_session_id"] == "test-cli-phase-0"
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_deprecate_cli_idempotent_no_duplicate_row():
+    """Re-marking an already-deprecated scheme returns 0 with no duplicate row."""
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        rc1 = await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-idem", drain_window_days=30,
+            db_url=TEST_DB_URL,
+        )
+        rc2 = await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-idem", drain_window_days=30,
+            db_url=TEST_DB_URL,
+        )
+        assert rc1 == 0 and rc2 == 0
+        count = await conn.fetchval(
+            "SELECT count(*) FROM lease_plane.deprecated_schemes WHERE surface_kind = 'td'"
+        )
+        assert count == 1
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_deprecate_cli_unknown_kind_rejected():
+    """Marking a scheme not in surface_kind_catalog returns nonzero rc."""
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        rc = await cli.deprecate_cmd(
+            kind="not_a_real_scheme",
+            session_id="test-cli-unknown",
+            drain_window_days=30,
+            db_url=TEST_DB_URL,
+        )
+        assert rc != 0, "Unknown scheme should not succeed"
+        count = await conn.fetchval(
+            "SELECT count(*) FROM lease_plane.deprecated_schemes "
+            "WHERE marked_by_session_id = 'test-cli-unknown'"
+        )
+        assert count == 0
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_deprecation_sweep_predicate_idempotent():
+    """RFC §7.11.4: sweep predicate `WHERE released_at IS NULL AND surface_kind = $1`
+    reaches fixpoint on re-run after partial completion."""
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        # Seed 3 active leases on td:/ scheme.
+        await _seed_lease(conn, "td:/pr3a_a")
+        await _seed_lease(conn, "td:/pr3a_b")
+        await _seed_lease(conn, "td:/pr3a_c")
+        # Mark deprecated.
+        await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-sweep-idem", drain_window_days=30,
+            db_url=TEST_DB_URL,
+        )
+        # First sweep: releases all 3.
+        rc1 = await cli.deprecation_sweep_cmd(kind="td", db_url=TEST_DB_URL)
+        assert rc1 == 0
+        unreleased1 = await conn.fetchval(
+            "SELECT count(*) FROM lease_plane.surface_leases "
+            "WHERE surface_kind = 'td' AND released_at IS NULL"
+        )
+        assert unreleased1 == 0
+        # Re-run: idempotent fixpoint (zero rows to release).
+        rc2 = await cli.deprecation_sweep_cmd(kind="td", db_url=TEST_DB_URL)
+        assert rc2 == 0
+        # Verify all 3 leases have release_reason='forced'.
+        forced_count = await conn.fetchval(
+            "SELECT count(*) FROM lease_plane.surface_leases "
+            "WHERE surface_kind = 'td' AND release_reason = 'forced'"
+        )
+        assert forced_count == 3
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_deprecation_sweep_emits_lease_deprecation_swept_events():
+    """RFC §7.11.3: each swept lease emits an event_type='lease.deprecation_swept'
+    row in lease_plane_events with the deprecation_id for audit correlation."""
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        await _seed_lease(conn, "td:/pr3a_event_a")
+        await _seed_lease(conn, "td:/pr3a_event_b")
+        await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-events", drain_window_days=30,
+            db_url=TEST_DB_URL,
+        )
+        depr_id = await conn.fetchval(
+            "SELECT deprecation_id FROM lease_plane.deprecated_schemes WHERE surface_kind = 'td'"
+        )
+        assert depr_id is not None
+
+        await cli.deprecation_sweep_cmd(kind="td", db_url=TEST_DB_URL)
+        # Two events emitted with the matching deprecation_id in payload.
+        events = await conn.fetch(
+            "SELECT event_type, payload FROM lease_plane.lease_plane_events "
+            "WHERE event_type = 'lease.deprecation_swept' AND surface_kind = 'td' "
+            "ORDER BY ts"
+        )
+        assert len(events) == 2
+        for ev in events:
+            assert ev["event_type"] == "lease.deprecation_swept"
+            # payload jsonb stores deprecation_id for batch correlation.
+            import json
+            payload = json.loads(ev["payload"])
+            assert payload.get("deprecation_id") == str(depr_id)
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_deprecation_finalize_records_check_migrated_at():
+    """`deprecation-finalize` records check_migrated_at on the deprecated_schemes row."""
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-finalize", drain_window_days=30,
+            db_url=TEST_DB_URL,
+        )
+        await cli.deprecation_sweep_cmd(kind="td", db_url=TEST_DB_URL)
+        rc = await cli.deprecation_finalize_cmd(kind="td", db_url=TEST_DB_URL)
+        assert rc == 0
+        check_migrated_at = await conn.fetchval(
+            "SELECT check_migrated_at FROM lease_plane.deprecated_schemes WHERE surface_kind = 'td'"
+        )
+        assert check_migrated_at is not None
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_deprecation_sweep_requires_force_release_token(monkeypatch):
+    """RFC §7.10: only LEASE_FORCE_RELEASE_TOKEN authorizes the sweep, not GOVERNANCE_TOKEN."""
+    from scripts.dev import lease_plane_deprecate as cli
+
+    monkeypatch.delenv("LEASE_FORCE_RELEASE_TOKEN", raising=False)
+    monkeypatch.setenv("GOVERNANCE_TOKEN", "should-not-authorize")
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-token", drain_window_days=30,
+            db_url=TEST_DB_URL,
+        )
+        rc = await cli.deprecation_sweep_cmd(kind="td", db_url=TEST_DB_URL)
+        assert rc != 0, "Sweep without LEASE_FORCE_RELEASE_TOKEN must fail"
+    finally:
+        await _cleanup(conn)
+        await conn.close()

--- a/tests/test_lease_plane_deprecate_cli.py
+++ b/tests/test_lease_plane_deprecate_cli.py
@@ -57,7 +57,8 @@ async def _cleanup(conn):
     )
     await conn.execute(
         "DELETE FROM lease_plane.lease_plane_events WHERE surface_id LIKE 'td:/pr3a%' "
-        "OR surface_id LIKE 'capture:/pr3a%'"
+        "OR surface_id LIKE 'capture:/pr3a%' "
+        "OR surface_id LIKE '%__deprecation_marker__'"
     )
 
 
@@ -319,3 +320,101 @@ def test_deprecate_lock_key_stable_across_processes():
         cmd_resident, capture_output=True, text=True, check=True, cwd=str(project_root),
     ).stdout.strip()
     assert out_resident != out_a, "different kinds must produce different lock keys"
+
+
+@pytest.mark.asyncio
+async def test_deprecate_emits_lease_deprecation_marked_event():
+    """RFC §7.11.3 audit signal contract: Phase 0 mark must emit
+    event_type='lease.deprecation_marked' with deprecation_id payload.
+
+    Pre-PR-6, the migration 027 CHECK accepted this event_type but no code
+    path emitted it — dangling vocabulary surfaced by council NIT."""
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        rc = await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-marked-event",
+            drain_window_days=30, db_url=TEST_DB_URL,
+        )
+        assert rc == 0
+        depr_id = await conn.fetchval(
+            "SELECT deprecation_id FROM lease_plane.deprecated_schemes WHERE surface_kind='td'"
+        )
+        events = await conn.fetch(
+            "SELECT event_type, payload FROM lease_plane.lease_plane_events "
+            "WHERE event_type='lease.deprecation_marked' AND surface_kind='td'"
+        )
+        assert len(events) == 1, f"Phase 0 must emit one lease.deprecation_marked event; got {len(events)}"
+        import json
+        payload = json.loads(events[0]["payload"])
+        assert payload.get("deprecation_id") == str(depr_id)
+        assert payload.get("kind") == "td"
+        assert payload.get("session_id") == "test-cli-marked-event"
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_finalize_emits_lease_deprecation_migrated_event():
+    """RFC §7.11.3: Phase 3 finalize must emit event_type='lease.deprecation_migrated'
+    with deprecation_id payload (audit signal that the CHECK migration completed)."""
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-migrated-event",
+            drain_window_days=30, db_url=TEST_DB_URL,
+        )
+        depr_id = await conn.fetchval(
+            "SELECT deprecation_id FROM lease_plane.deprecated_schemes WHERE surface_kind='td'"
+        )
+        await cli.deprecation_sweep_cmd(kind="td", db_url=TEST_DB_URL)
+        rc = await cli.deprecation_finalize_cmd(kind="td", db_url=TEST_DB_URL)
+        assert rc == 0
+        events = await conn.fetch(
+            "SELECT event_type, payload FROM lease_plane.lease_plane_events "
+            "WHERE event_type='lease.deprecation_migrated' AND surface_kind='td'"
+        )
+        assert len(events) == 1, f"Phase 3 must emit one lease.deprecation_migrated event; got {len(events)}"
+        import json
+        payload = json.loads(events[0]["payload"])
+        assert payload.get("deprecation_id") == str(depr_id)
+        assert payload.get("kind") == "td"
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_finalize_idempotent_does_not_double_emit():
+    """Re-running finalize on an already-finalized scheme does NOT emit a
+    second lease.deprecation_migrated event (audit-trail clarity)."""
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-finalize-idem",
+            drain_window_days=30, db_url=TEST_DB_URL,
+        )
+        await cli.deprecation_sweep_cmd(kind="td", db_url=TEST_DB_URL)
+        rc1 = await cli.deprecation_finalize_cmd(kind="td", db_url=TEST_DB_URL)
+        rc2 = await cli.deprecation_finalize_cmd(kind="td", db_url=TEST_DB_URL)
+        assert rc1 == 0 and rc2 == 0
+        count = await conn.fetchval(
+            "SELECT count(*) FROM lease_plane.lease_plane_events "
+            "WHERE event_type='lease.deprecation_migrated' AND surface_kind='td'"
+        )
+        assert count == 1, f"finalize must be event-idempotent; got {count} events"
+    finally:
+        await _cleanup(conn)
+        await conn.close()

--- a/tests/test_lease_plane_held_by_other_v0_8.py
+++ b/tests/test_lease_plane_held_by_other_v0_8.py
@@ -50,7 +50,6 @@ def test_held_by_other_includes_v0_7_extended_fields():
     result = LeasePlaneClient(transport=transport).acquire(
         AcquireRequest(
             surface_id=surface_id,
-            surface_kind="file",
             holder_agent_uuid=uuid4(),
             holder_class="process_instance",
             holder_kind="remote_heartbeat",

--- a/tests/test_lease_plane_held_by_other_v0_8.py
+++ b/tests/test_lease_plane_held_by_other_v0_8.py
@@ -1,0 +1,71 @@
+"""
+v0.7 model drift fix: AcquireHeldByOther carries the v0.7 §7.3.2 extended fields.
+
+The v0.7 RFC committed to extending the typed-absence shape with three new
+fields (surface_id, blocking_lease_id, retry_after_hint_ms) so callers can:
+  - correlate concurrent multi-surface acquires (surface_id echo)
+  - distinguish "same stuck holder across retries" from "rotating cast"
+    (blocking_lease_id)
+  - implement sane backoff without parsing expires_at delta
+    (retry_after_hint_ms)
+
+The model in src/lease_plane/models.py was not updated when v0.7 shipped.
+This test pins the v0.7 contract; the implementation lands in this PR.
+
+Spec: docs/proposals/surface-lease-plane-v0.md §7.3.2
+      docs/proposals/surface-lease-plane-phase-a-plan.md PR 1 row 6
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+from src.lease_plane import (
+    AcquireHeldByOther,
+    AcquireRequest,
+    LeasePlaneClient,
+)
+from src.lease_plane.client import LeaseHTTPRequest
+
+
+def test_held_by_other_includes_v0_7_extended_fields():
+    """AcquireHeldByOther carries surface_id, blocking_lease_id, retry_after_hint_ms."""
+    holder = uuid4()
+    blocking_lease = uuid4()
+    surface_id = "file:///tmp/v0_8_drift_check.py"
+    expires_at = datetime.now(UTC).replace(microsecond=0) + timedelta(seconds=30)
+
+    def transport(_request: LeaseHTTPRequest):
+        return {
+            "ok": False,
+            "error": "held_by_other",
+            "surface_id": surface_id,
+            "blocking_lease_id": str(blocking_lease),
+            "held_by_uuid": str(holder),
+            "expires_at": expires_at.isoformat(),
+            "retry_after_hint_ms": 4500,
+        }
+
+    result = LeasePlaneClient(transport=transport).acquire(
+        AcquireRequest(
+            surface_id=surface_id,
+            surface_kind="file",
+            holder_agent_uuid=uuid4(),
+            holder_class="process_instance",
+            holder_kind="remote_heartbeat",
+            ttl_s=90,
+        )
+    )
+
+    assert isinstance(result, AcquireHeldByOther)
+    # Pre-existing fields still parse.
+    assert result.held_by_uuid == holder
+    assert result.expires_at == expires_at
+    # v0.7 §7.3.2 extended fields.
+    assert result.surface_id == surface_id
+    assert result.blocking_lease_id == blocking_lease
+    assert result.retry_after_hint_ms == 4500
+    # Type-check the new fields are exposed correctly.
+    assert isinstance(result.blocking_lease_id, UUID)
+    assert isinstance(result.retry_after_hint_ms, int)

--- a/tests/test_lease_plane_retry_and_transport.py
+++ b/tests/test_lease_plane_retry_and_transport.py
@@ -241,3 +241,39 @@ def test_urllib_transport_500_returns_service_unavailable_when_no_body():
     ):
         result = _urllib_transport(request)
     assert result == {"ok": False, "error": "service_unavailable"}
+
+
+# ---------- §7.3.3 acquire_with_retry input validation (PR 5 council fix) ----------
+
+
+def test_acquire_with_retry_rejects_max_attempts_below_1():
+    """RFC §7.3.3: max_attempts must be >= 1; pre-PR-5 max_attempts=0 silently
+    fired one HTTP call. Validation now raises ValueError."""
+    holder = uuid4()
+    calls: list[bool] = []
+
+    def transport(_req: LeaseHTTPRequest):
+        calls.append(True)
+        return _ok_lease_payload(holder)
+
+    client = LeasePlaneClient(transport=transport)
+    with pytest.raises(ValueError):
+        client.acquire_with_retry(_make_request(holder), max_attempts=0)
+    assert calls == [], "no HTTP call should have fired with max_attempts=0"
+    with pytest.raises(ValueError):
+        client.acquire_with_retry(_make_request(holder), max_attempts=-1)
+    assert calls == []
+
+
+def test_acquire_with_retry_rejects_floor_exceeding_ceiling():
+    """floor_s must be <= ceiling_s; otherwise backoff bounds are nonsense."""
+    holder = uuid4()
+
+    def transport(_req: LeaseHTTPRequest):
+        return _ok_lease_payload(holder)
+
+    client = LeasePlaneClient(transport=transport)
+    with pytest.raises(ValueError):
+        client.acquire_with_retry(
+            _make_request(holder), max_attempts=3, floor_s=2.0, ceiling_s=1.0,
+        )

--- a/tests/test_lease_plane_retry_and_transport.py
+++ b/tests/test_lease_plane_retry_and_transport.py
@@ -1,0 +1,243 @@
+"""
+Phase A PR 4 — `acquire_with_retry()` jittered backoff + `_urllib_transport`
+HTTP-error body-parse coverage.
+
+Closes RFC v0.8 §7.3.3 (caller-library retry contract: jittered exponential,
+floor 100ms, ceiling 5s, full jitter) and §7.3.5 (HTTP 409 on `held_by_other`
+with the typed-absence body in the response).
+
+Spec: docs/proposals/surface-lease-plane-v0.md §7.3.3, §7.3.5
+      docs/proposals/surface-lease-plane-phase-a-plan.md PR 4
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from datetime import UTC, datetime, timedelta
+from unittest import mock
+from uuid import UUID, uuid4
+
+import pytest
+
+from src.lease_plane import (
+    AcquireHeldByOther,
+    AcquireOk,
+    AcquireRequest,
+    AcquireServiceUnavailable,
+    LeasePlaneClient,
+)
+from src.lease_plane.client import LeaseHTTPRequest, _urllib_transport
+
+
+# ---------- §7.3.3 acquire_with_retry tests ----------
+
+
+def _ok_lease_payload(holder: UUID) -> dict:
+    """Minimum AcquireOk payload for a transport stub."""
+    now = datetime.now(UTC).replace(microsecond=0)
+    return {
+        "ok": True,
+        "idempotent": False,
+        "drift_warning": [],
+        "lease": {
+            "lease_id": str(uuid4()),
+            "surface_id": "dialectic:/pr4_retry_test",
+            "surface_kind": "dialectic",
+            "holder_agent_uuid": str(holder),
+            "holder_class": "process_instance",
+            "holder_kind": "remote_heartbeat",
+            "heartbeat_required": True,
+            "expires_at": (now + timedelta(seconds=60)).isoformat(),
+            "original_ttl_s": 60,
+            "earned_status": "provisional",
+        },
+    }
+
+
+def _held_by_other_payload(blocking_lease: UUID, hint_ms: int = 1234) -> dict:
+    return {
+        "ok": False,
+        "error": "held_by_other",
+        "surface_id": "dialectic:/pr4_retry_test",
+        "blocking_lease_id": str(blocking_lease),
+        "held_by_uuid": str(uuid4()),
+        "expires_at": (datetime.now(UTC) + timedelta(seconds=10)).isoformat(),
+        "retry_after_hint_ms": hint_ms,
+    }
+
+
+def _make_request(holder: UUID) -> AcquireRequest:
+    return AcquireRequest(
+        surface_id="dialectic:/pr4_retry_test",
+        holder_agent_uuid=holder,
+        holder_class="process_instance",
+        holder_kind="remote_heartbeat",
+        ttl_s=60,
+    )
+
+
+def test_acquire_with_retry_returns_ok_on_first_attempt():
+    """No retry needed when first acquire succeeds."""
+    holder = uuid4()
+    sleeps: list[float] = []
+    payload_iter = iter([_ok_lease_payload(holder)])
+
+    def transport(_req: LeaseHTTPRequest):
+        return next(payload_iter)
+
+    client = LeasePlaneClient(transport=transport)
+    result = client.acquire_with_retry(
+        _make_request(holder), max_attempts=3, sleep=lambda s: sleeps.append(s),
+    )
+    assert isinstance(result, AcquireOk)
+    assert sleeps == []  # no backoff needed
+
+
+def test_acquire_with_retry_retries_on_held_by_other_until_ok():
+    """Retries on held_by_other, eventually returning AcquireOk."""
+    holder = uuid4()
+    sleeps: list[float] = []
+    payloads = [
+        _held_by_other_payload(uuid4()),
+        _held_by_other_payload(uuid4()),
+        _ok_lease_payload(holder),
+    ]
+    payload_iter = iter(payloads)
+
+    def transport(_req: LeaseHTTPRequest):
+        return next(payload_iter)
+
+    client = LeasePlaneClient(transport=transport)
+    result = client.acquire_with_retry(
+        _make_request(holder), max_attempts=5, sleep=lambda s: sleeps.append(s),
+    )
+    assert isinstance(result, AcquireOk)
+    assert len(sleeps) == 2  # two backoffs before the third (successful) attempt
+
+
+def test_acquire_with_retry_jittered_backoff_within_bounds():
+    """Backoff is jittered exponential — floor 100ms, ceiling 5s, full jitter (RFC §7.3.3)."""
+    holder = uuid4()
+    sleeps: list[float] = []
+    # Always return held_by_other so we exhaust attempts and observe all sleeps.
+    payload = _held_by_other_payload(uuid4())
+
+    def transport(_req: LeaseHTTPRequest):
+        return payload
+
+    client = LeasePlaneClient(transport=transport)
+    result = client.acquire_with_retry(
+        _make_request(holder), max_attempts=6, sleep=lambda s: sleeps.append(s),
+    )
+    assert isinstance(result, AcquireHeldByOther), "exhausted retries returns final held_by_other"
+    # Each sleep must be in [0.1, 5.0] (full jitter floor=100ms, ceiling=5s).
+    assert all(0.1 <= s <= 5.0 for s in sleeps), (
+        f"backoff sleeps must be in [0.1, 5.0]; got {sleeps}"
+    )
+    # With max_attempts=6 we expect 5 sleeps (one before each retry).
+    assert len(sleeps) == 5
+
+
+def test_acquire_with_retry_honors_retry_after_hint_as_floor():
+    """retry_after_hint_ms is a server-provided lower bound on backoff."""
+    holder = uuid4()
+    sleeps: list[float] = []
+    payload = _held_by_other_payload(uuid4(), hint_ms=2000)  # server hints 2s minimum
+
+    def transport(_req: LeaseHTTPRequest):
+        return payload
+
+    client = LeasePlaneClient(transport=transport)
+    client.acquire_with_retry(
+        _make_request(holder), max_attempts=3, sleep=lambda s: sleeps.append(s),
+    )
+    # Each sleep should respect the server's 2s lower bound.
+    assert all(s >= 2.0 for s in sleeps), (
+        f"retry_after_hint_ms=2000 must serve as the floor; got {sleeps}"
+    )
+
+
+def test_acquire_with_retry_returns_service_unavailable_without_retry():
+    """service_unavailable is the advisory escape valve — don't retry on it."""
+    holder = uuid4()
+    sleeps: list[float] = []
+
+    def transport(_req: LeaseHTTPRequest):
+        return {"ok": False, "error": "service_unavailable"}
+
+    client = LeasePlaneClient(transport=transport)
+    result = client.acquire_with_retry(
+        _make_request(holder), max_attempts=5, sleep=lambda s: sleeps.append(s),
+    )
+    assert isinstance(result, AcquireServiceUnavailable)
+    assert sleeps == []  # no retries — service_unavailable is terminal for this method
+
+
+# ---------- §7.3.5 _urllib_transport HTTP-error body-parse tests ----------
+
+
+def _http_error(status: int, body_dict: dict | None) -> urllib.error.HTTPError:
+    """Construct a real HTTPError with a JSON body (the failure path
+    `_urllib_transport` was historically uncovered for; live-verifier finding)."""
+    body_bytes = json.dumps(body_dict).encode("utf-8") if body_dict is not None else b""
+    return urllib.error.HTTPError(
+        url="http://stub/v1/lease/acquire",
+        code=status,
+        msg="error",
+        hdrs={},  # type: ignore[arg-type]
+        fp=io.BytesIO(body_bytes),
+    )
+
+
+def test_urllib_transport_parses_409_body():
+    """RFC §7.3.5: HTTP 409 + held_by_other body is parsed and returned as the typed payload."""
+    held_payload = {
+        "ok": False,
+        "error": "held_by_other",
+        "surface_id": "dialectic:/pr4_409_probe",
+        "blocking_lease_id": str(uuid4()),
+        "held_by_uuid": str(uuid4()),
+        "expires_at": datetime.now(UTC).isoformat(),
+        "retry_after_hint_ms": 4500,
+    }
+    request = LeaseHTTPRequest(
+        method="POST", url="http://stub/v1/lease/acquire",
+        json_body={"surface_id": "dialectic:/pr4_409_probe"},
+        headers={}, timeout_s=1.0,
+    )
+    with mock.patch(
+        "urllib.request.urlopen", side_effect=_http_error(409, held_payload),
+    ):
+        result = _urllib_transport(request)
+    assert result == held_payload, (
+        f"_urllib_transport must parse the 409 body verbatim; got {result!r}"
+    )
+
+
+def test_urllib_transport_401_returns_permission_denied_when_no_body():
+    """Empty 401 body falls back to permission_denied envelope."""
+    request = LeaseHTTPRequest(
+        method="POST", url="http://stub/v1/lease/acquire",
+        json_body={}, headers={}, timeout_s=1.0,
+    )
+    with mock.patch(
+        "urllib.request.urlopen", side_effect=_http_error(401, None),
+    ):
+        result = _urllib_transport(request)
+    assert result["ok"] is False
+    assert result["error"] == "permission_denied"
+
+
+def test_urllib_transport_500_returns_service_unavailable_when_no_body():
+    """Empty 5xx body falls back to service_unavailable (advisory escape valve)."""
+    request = LeaseHTTPRequest(
+        method="POST", url="http://stub/v1/lease/acquire",
+        json_body={}, headers={}, timeout_s=1.0,
+    )
+    with mock.patch(
+        "urllib.request.urlopen", side_effect=_http_error(500, None),
+    ):
+        result = _urllib_transport(request)
+    assert result == {"ok": False, "error": "service_unavailable"}

--- a/tests/test_migration_026_lease_plane_grammar.py
+++ b/tests/test_migration_026_lease_plane_grammar.py
@@ -1,0 +1,180 @@
+"""
+Phase A schema tests for surface-lease-plane migration 026.
+
+Migration 026 (per RFC v0.8 §7.2.2 + §7.2.3) does three things to
+lease_plane.surface_leases:
+
+  1. Adds CHECK (surface_id ~ '^(file://|dialectic:/|resident:/|capture:/|td:/)')
+     — storage-layer rejection of malformed scheme prefixes.
+  2. Drops the regular `surface_kind` column.
+  3. Re-adds `surface_kind` as GENERATED ALWAYS AS (split_part(surface_id, ':', 1)) STORED
+     — surface_kind is now derived, not caller-supplied.
+
+Pre-flight rule (per operator decision 2026-04-30, see Phase A plan):
+the migration aborts with an explicit error message if surface_leases
+contains any rows when 026 runs. This avoids silent destructive
+DROP COLUMN against populated data.
+
+Spec: docs/proposals/surface-lease-plane-v0.md §7.2.2, §7.2.3
+      docs/proposals/surface-lease-plane-phase-a-plan.md PR 1 row 1-3
+"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+try:
+    import asyncpg
+except ImportError:
+    pytest.skip("asyncpg not installed", allow_module_level=True)
+
+from tests.test_db_utils import (
+    TEST_DB_URL,
+    can_connect_to_test_db,
+    ensure_test_database_schema,
+)
+
+if not can_connect_to_test_db():
+    pytest.skip("governance_test database not available", allow_module_level=True)
+
+
+async def _insert_lease(
+    conn,
+    *,
+    surface_id: str,
+    surface_kind: str | None = None,
+    holder_kind: str = "remote_heartbeat",
+    holder_class: str = "process_instance",
+    heartbeat_required: bool = True,
+    ttl_s: int = 60,
+) -> uuid.UUID:
+    """Insert a lease row directly. Returns the generated lease_id."""
+    holder_uuid = uuid.uuid4()
+    now = datetime.now(UTC)
+    expires = now + timedelta(seconds=ttl_s)
+    lease_id = uuid.uuid4()
+    # When surface_kind is None, omit it from the INSERT (post-026 generated column case).
+    if surface_kind is None:
+        await conn.execute(
+            """
+            INSERT INTO lease_plane.surface_leases
+              (lease_id, surface_id, holder_agent_uuid, holder_kind,
+               holder_class, heartbeat_required, original_ttl_s,
+               acquired_at, expires_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            """,
+            lease_id, surface_id, holder_uuid, holder_kind,
+            holder_class, heartbeat_required, ttl_s, now, expires,
+        )
+    else:
+        await conn.execute(
+            """
+            INSERT INTO lease_plane.surface_leases
+              (lease_id, surface_id, surface_kind, holder_agent_uuid, holder_kind,
+               holder_class, heartbeat_required, original_ttl_s,
+               acquired_at, expires_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            """,
+            lease_id, surface_id, surface_kind, holder_uuid, holder_kind,
+            holder_class, heartbeat_required, ttl_s, now, expires,
+        )
+    return lease_id
+
+
+@pytest.mark.asyncio
+async def test_migration_026_grammar_check_rejects_invalid_scheme():
+    """surface_id with a non-canonical scheme prefix is rejected at storage."""
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await conn.execute("DELETE FROM lease_plane.surface_leases")
+        with pytest.raises(asyncpg.CheckViolationError):
+            await _insert_lease(conn, surface_id="potato:/not_a_real_scheme")
+    finally:
+        await conn.execute("DELETE FROM lease_plane.surface_leases")
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_026_grammar_check_accepts_canonical_schemes():
+    """All five canonical schemes (file://, dialectic:/, resident:/, capture:/, td:/) are accepted."""
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await conn.execute("DELETE FROM lease_plane.surface_leases")
+        # Each scheme should INSERT cleanly.
+        canonical = [
+            "file:///tmp/test_grammar_file.py",
+            "dialectic:/abcdef0123456789",
+            "resident:/sentinel",
+            "capture:/window_a,window_b",
+            "td:/network/op1",
+        ]
+        for surface_id in canonical:
+            await _insert_lease(conn, surface_id=surface_id)
+        count = await conn.fetchval("SELECT count(*) FROM lease_plane.surface_leases")
+        assert count == 5, f"Expected 5 rows after canonical inserts, got {count}"
+    finally:
+        await conn.execute("DELETE FROM lease_plane.surface_leases")
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_026_surface_kind_is_generated_column():
+    """surface_kind is a generated column derived from surface_id scheme prefix."""
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        # Verify is_generated metadata.
+        is_gen = await conn.fetchval(
+            """
+            SELECT is_generated FROM information_schema.columns
+            WHERE table_schema='lease_plane' AND table_name='surface_leases'
+              AND column_name='surface_kind'
+            """
+        )
+        assert is_gen == "ALWAYS", (
+            f"surface_kind should be GENERATED ALWAYS after migration 026, got is_generated={is_gen!r}"
+        )
+        # Verify derivation: insert without surface_kind, read it back.
+        await conn.execute("DELETE FROM lease_plane.surface_leases")
+        lease_id = await _insert_lease(conn, surface_id="dialectic:/derivation_check")
+        derived_kind = await conn.fetchval(
+            "SELECT surface_kind FROM lease_plane.surface_leases WHERE lease_id = $1",
+            lease_id,
+        )
+        assert derived_kind == "dialectic", (
+            f"surface_kind should derive to 'dialectic' for 'dialectic:/...', got {derived_kind!r}"
+        )
+    finally:
+        await conn.execute("DELETE FROM lease_plane.surface_leases")
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_026_surface_kind_insert_with_explicit_value_raises():
+    """Generated column rejects caller-supplied surface_kind at INSERT."""
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await conn.execute("DELETE FROM lease_plane.surface_leases")
+        # Generated columns reject INSERT with explicit value (Postgres error 42601 / 428C9).
+        with pytest.raises(
+            (asyncpg.GeneratedAlwaysError, asyncpg.PostgresSyntaxError, asyncpg.InvalidColumnReferenceError),
+        ):
+            await _insert_lease(
+                conn,
+                surface_id="file:///tmp/conflict_check.py",
+                surface_kind="dialectic",  # caller tries to override; should fail
+            )
+    finally:
+        await conn.execute("DELETE FROM lease_plane.surface_leases")
+        await conn.close()

--- a/tests/test_migration_027_lease_plane_deprecation.py
+++ b/tests/test_migration_027_lease_plane_deprecation.py
@@ -1,0 +1,123 @@
+"""
+Phase A schema tests for surface-lease-plane migration 027.
+
+Migration 027 (per RFC v0.8 §7.11.1) adds two tables:
+
+  1. lease_plane.surface_kind_catalog — canonical registry of allowed scheme prefixes.
+     Seeded with the 5 v0 schemes (file, dialectic, resident, capture, td).
+  2. lease_plane.deprecated_schemes — first-class persistence substrate for
+     §7.11 deprecation procedure. FK to surface_kind_catalog so deprecation
+     can only target a registered kind.
+
+Spec: docs/proposals/surface-lease-plane-v0.md §7.11.1
+      docs/proposals/surface-lease-plane-phase-a-plan.md PR 1 row 4-5
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+try:
+    import asyncpg
+except ImportError:
+    pytest.skip("asyncpg not installed", allow_module_level=True)
+
+from tests.test_db_utils import (
+    TEST_DB_URL,
+    can_connect_to_test_db,
+    ensure_test_database_schema,
+)
+
+if not can_connect_to_test_db():
+    pytest.skip("governance_test database not available", allow_module_level=True)
+
+
+@pytest.mark.asyncio
+async def test_migration_027_surface_kind_catalog_seeded():
+    """Migration 027 creates surface_kind_catalog and seeds the 5 canonical schemes."""
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        rows = await conn.fetch(
+            "SELECT surface_kind FROM lease_plane.surface_kind_catalog ORDER BY surface_kind"
+        )
+        kinds = [r["surface_kind"] for r in rows]
+        assert kinds == ["capture", "dialectic", "file", "resident", "td"], (
+            f"Expected 5 canonical schemes seeded, got {kinds}"
+        )
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_027_deprecated_schemes_table_exists():
+    """deprecated_schemes table exists with the v0.8 §7.11.1 schema."""
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        # Required columns per RFC v0.8 §7.11.1.
+        cols = await conn.fetch(
+            """
+            SELECT column_name, data_type, is_nullable, column_default
+            FROM information_schema.columns
+            WHERE table_schema = 'lease_plane'
+              AND table_name = 'deprecated_schemes'
+            ORDER BY ordinal_position
+            """
+        )
+        col_names = [c["column_name"] for c in cols]
+        required = {
+            "surface_kind",
+            "deprecation_id",
+            "marked_deprecated_at",
+            "marked_by_session_id",
+            "drain_window_days",
+            "sweep_started_at",
+            "sweep_completed_at",
+            "check_migrated_at",
+        }
+        missing = required - set(col_names)
+        assert not missing, (
+            f"deprecated_schemes missing required columns from RFC v0.8 §7.11.1: {missing}"
+        )
+
+        # surface_kind is the PK and FK to surface_kind_catalog.
+        # Verify FK by attempting an INSERT with an unknown kind — should raise FK violation.
+        with pytest.raises(asyncpg.ForeignKeyViolationError):
+            await conn.execute(
+                """
+                INSERT INTO lease_plane.deprecated_schemes
+                  (surface_kind, marked_by_session_id)
+                VALUES ('not_a_real_scheme', 'test-session-fk-check')
+                """
+            )
+
+        # drain_window_days CHECK: > 0 AND <= 90.
+        with pytest.raises(asyncpg.CheckViolationError):
+            await conn.execute(
+                """
+                INSERT INTO lease_plane.deprecated_schemes
+                  (surface_kind, marked_by_session_id, drain_window_days)
+                VALUES ('td', 'test-session-window-check', 0)
+                """
+            )
+        with pytest.raises(asyncpg.CheckViolationError):
+            await conn.execute(
+                """
+                INSERT INTO lease_plane.deprecated_schemes
+                  (surface_kind, marked_by_session_id, drain_window_days)
+                VALUES ('td', 'test-session-window-check', 91)
+                """
+            )
+    finally:
+        # Cleanup: remove any test rows we inserted (FK + CHECK violations roll back, but be safe).
+        await conn.execute(
+            "DELETE FROM lease_plane.deprecated_schemes WHERE marked_by_session_id LIKE 'test-session-%'"
+        )
+        await conn.close()

--- a/tests/test_migration_029_earned_status_guard.py
+++ b/tests/test_migration_029_earned_status_guard.py
@@ -1,0 +1,136 @@
+"""
+PR 5 — migration 029 restores the `earned_status` immutability guard
+that migration 028 silently dropped (council BLOCK from dialectic voice).
+
+Migration 025 originally guarded 8 fields against UPDATE. Migration 028 was
+authored to drop the surface_kind guard (it became a generated column post-026)
+but in the rewrite the earned_status guard was also dropped — collateral
+damage. This lets any UPDATE silently flip the substrate-earned promotion
+flag from 'provisional' to 'earned' without the migration 025 anticipated
+for that promotion.
+
+Migration 029 restores the earned_status check and pins the contract via test.
+
+Spec: docs/proposals/surface-lease-plane-v0.md §7.8 (substrate-earned identity)
+      docs/proposals/surface-lease-plane-phase-a-plan.md PR 5
+"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+try:
+    import asyncpg
+except ImportError:
+    pytest.skip("asyncpg not installed", allow_module_level=True)
+
+from tests.test_db_utils import (
+    TEST_DB_URL,
+    can_connect_to_test_db,
+    ensure_test_database_schema,
+)
+
+if not can_connect_to_test_db():
+    pytest.skip("governance_test database not available", allow_module_level=True)
+
+
+async def _seed_lease(conn) -> uuid.UUID:
+    lease_id = uuid.uuid4()
+    holder_uuid = uuid.uuid4()
+    now = datetime.now(UTC)
+    await conn.execute(
+        """
+        INSERT INTO lease_plane.surface_leases
+          (lease_id, surface_id, holder_agent_uuid, holder_kind, holder_class,
+           heartbeat_required, original_ttl_s, acquired_at, expires_at)
+        VALUES ($1, $2, $3, 'remote_heartbeat', 'process_instance', true, 60, $4, $5)
+        """,
+        lease_id, "td:/pr5_earned_guard_test", holder_uuid, now,
+        now + timedelta(seconds=60),
+    )
+    return lease_id
+
+
+@pytest.mark.asyncio
+async def test_migration_029_blocks_earned_status_update():
+    """earned_status must be immutable per lease_id (substrate-earned promotion
+    requires explicit migration, not silent UPDATE)."""
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await conn.execute(
+            "DELETE FROM lease_plane.surface_leases WHERE surface_id = 'td:/pr5_earned_guard_test'"
+        )
+        lease_id = await _seed_lease(conn)
+        # Verify default state: provisional.
+        es = await conn.fetchval(
+            "SELECT earned_status FROM lease_plane.surface_leases WHERE lease_id = $1",
+            lease_id,
+        )
+        assert es == "provisional"
+        # Attempt to flip earned_status — should raise via the trigger.
+        with pytest.raises(asyncpg.RaiseError) as exc_info:
+            await conn.execute(
+                "UPDATE lease_plane.surface_leases SET earned_status = 'earned' WHERE lease_id = $1",
+                lease_id,
+            )
+        # Error message should be specific about earned_status.
+        assert "earned_status" in str(exc_info.value).lower()
+    finally:
+        await conn.execute(
+            "DELETE FROM lease_plane.surface_leases WHERE surface_id = 'td:/pr5_earned_guard_test'"
+        )
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_029_still_allows_release_update():
+    """Migration 029 restores ONLY the earned_status guard — sweep UPDATE
+    (released_at, release_reason) must still succeed."""
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await conn.execute(
+            "DELETE FROM lease_plane.surface_leases WHERE surface_id = 'td:/pr5_release_path'"
+        )
+        lease_id = await _seed_lease_with_sid(conn, "td:/pr5_release_path")
+        # Sweep-style UPDATE must succeed (the post-028 PR 3a sweep path).
+        await conn.execute(
+            "UPDATE lease_plane.surface_leases SET released_at = now(), release_reason = 'forced' "
+            "WHERE lease_id = $1",
+            lease_id,
+        )
+        rel = await conn.fetchval(
+            "SELECT released_at FROM lease_plane.surface_leases WHERE lease_id = $1",
+            lease_id,
+        )
+        assert rel is not None
+    finally:
+        await conn.execute(
+            "DELETE FROM lease_plane.surface_leases WHERE surface_id = 'td:/pr5_release_path'"
+        )
+        await conn.close()
+
+
+async def _seed_lease_with_sid(conn, sid: str) -> uuid.UUID:
+    lease_id = uuid.uuid4()
+    holder_uuid = uuid.uuid4()
+    now = datetime.now(UTC)
+    await conn.execute(
+        """
+        INSERT INTO lease_plane.surface_leases
+          (lease_id, surface_id, holder_agent_uuid, holder_kind, holder_class,
+           heartbeat_required, original_ttl_s, acquired_at, expires_at)
+        VALUES ($1, $2, $3, 'remote_heartbeat', 'process_instance', true, 60, $4, $5)
+        """,
+        lease_id, sid, holder_uuid, now, now + timedelta(seconds=60),
+    )
+    return lease_id

--- a/tests/test_sentinel_forced_release_alarm.py
+++ b/tests/test_sentinel_forced_release_alarm.py
@@ -1,0 +1,293 @@
+"""
+Phase A PR 3b — Sentinel forced-release alarm rule (RFC v0.8 §7.10 + §7.11.5).
+
+Tests the forced-release alarm wiring in `agents/sentinel/forced_release_alarm.py`:
+
+  - Per-event alarm for ad-hoc `event_type='forced'` (RFC §7.10 alarm-on-every-event).
+  - Batched alarm for `event_type='lease.deprecation_swept'`: groups by
+    `deprecation_id`, emits one summary alarm per completed batch
+    (RFC §7.11.5 batch suppression).
+  - Cursor state so successive polls don't re-emit alarms for already-seen events.
+
+Spec: docs/proposals/surface-lease-plane-v0.md §7.10, §7.11.5
+      docs/proposals/surface-lease-plane-phase-a-plan.md PR 3b
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+try:
+    import asyncpg
+except ImportError:
+    pytest.skip("asyncpg not installed", allow_module_level=True)
+
+from tests.test_db_utils import (
+    TEST_DB_URL,
+    can_connect_to_test_db,
+    ensure_test_database_schema,
+)
+
+if not can_connect_to_test_db():
+    pytest.skip("governance_test database not available", allow_module_level=True)
+
+
+async def _cleanup(conn):
+    """Reset sweep / event / deprecated_schemes rows from prior tests."""
+    await conn.execute(
+        "DELETE FROM lease_plane.lease_plane_events WHERE surface_id LIKE 'td:/pr3b%' "
+        "OR payload->>'deprecation_id' IN (SELECT deprecation_id::text FROM lease_plane.deprecated_schemes "
+        "WHERE marked_by_session_id LIKE 'test-pr3b-%')"
+    )
+    await conn.execute(
+        "DELETE FROM lease_plane.deprecated_schemes WHERE marked_by_session_id LIKE 'test-pr3b-%'"
+    )
+    await conn.execute(
+        "DELETE FROM lease_plane.surface_leases WHERE intent LIKE 'pr3b-test%'"
+    )
+
+
+async def _emit_event(
+    conn, *, event_type: str, surface_id: str,
+    surface_kind: str | None = None, payload: dict | None = None,
+) -> uuid.UUID:
+    """Insert a synthetic lease_plane_events row, return event_id."""
+    if surface_kind is None:
+        surface_kind = surface_id.split(":", 1)[0]
+    event_id = await conn.fetchval(
+        """
+        INSERT INTO lease_plane.lease_plane_events
+          (event_type, surface_id, surface_kind, advisory_mode, payload)
+        VALUES ($1, $2, $3, false, $4::jsonb)
+        RETURNING event_id
+        """,
+        event_type, surface_id, surface_kind, json.dumps(payload or {}),
+    )
+    return event_id
+
+
+@pytest.mark.asyncio
+async def test_sentinel_force_release_alarm_per_event():
+    """RFC §7.10: ad-hoc event_type='forced' produces one alarm per event."""
+    from agents.sentinel.forced_release_alarm import poll_forced_release_alarms
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        # Seed two ad-hoc forced events.
+        e1 = await _emit_event(conn, event_type="forced", surface_id="td:/pr3b_a")
+        e2 = await _emit_event(conn, event_type="forced", surface_id="td:/pr3b_b")
+
+        alarms, new_cursor = await poll_forced_release_alarms(
+            db_url=TEST_DB_URL, last_event_ts=None,
+        )
+        # One alarm per event; both should appear.
+        per_event = [a for a in alarms if a.kind == "ad_hoc"]
+        assert len(per_event) == 2, f"expected 2 ad-hoc alarms, got {len(per_event)}"
+        surface_ids = {a.extra["surface_id"] for a in per_event}
+        assert surface_ids == {"td:/pr3b_a", "td:/pr3b_b"}
+        assert new_cursor is not None
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_sentinel_force_release_alarm_dedupes_via_cursor():
+    """Re-polling with the cursor returned by a previous poll yields zero new alarms."""
+    from agents.sentinel.forced_release_alarm import poll_forced_release_alarms
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        await _emit_event(conn, event_type="forced", surface_id="td:/pr3b_dedupe")
+
+        first_alarms, cursor = await poll_forced_release_alarms(
+            db_url=TEST_DB_URL, last_event_ts=None,
+        )
+        assert len([a for a in first_alarms if a.kind == "ad_hoc"]) >= 1
+
+        # Re-poll with the cursor; no new alarms.
+        second_alarms, _ = await poll_forced_release_alarms(
+            db_url=TEST_DB_URL, last_event_ts=cursor,
+        )
+        ad_hoc_second = [a for a in second_alarms if a.kind == "ad_hoc"]
+        assert ad_hoc_second == [], (
+            f"cursor-based dedup failed; got {len(ad_hoc_second)} re-emitted alarms"
+        )
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_sentinel_batch_alarm_for_deprecation_sweep():
+    """RFC §7.11.5: N lease.deprecation_swept events from same deprecation_id
+    produce ONE summary alarm, not N per-event alarms."""
+    from agents.sentinel.forced_release_alarm import poll_forced_release_alarms
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        # Mark a scheme deprecated and complete the sweep so sweep_completed_at IS NOT NULL.
+        depr_id = await conn.fetchval(
+            """
+            INSERT INTO lease_plane.deprecated_schemes
+              (surface_kind, marked_by_session_id, drain_window_days,
+               sweep_started_at, sweep_completed_at)
+            VALUES ('td', 'test-pr3b-batch', 30, now(), now())
+            RETURNING deprecation_id
+            """
+        )
+        # Seed 3 sweep events with the same deprecation_id.
+        for sid in ("td:/pr3b_batch_a", "td:/pr3b_batch_b", "td:/pr3b_batch_c"):
+            await _emit_event(
+                conn, event_type="lease.deprecation_swept",
+                surface_id=sid,
+                payload={"deprecation_id": str(depr_id), "kind": "td"},
+            )
+
+        alarms, _ = await poll_forced_release_alarms(
+            db_url=TEST_DB_URL, last_event_ts=None,
+        )
+        batched = [a for a in alarms if a.kind == "deprecation_batch"]
+        assert len(batched) == 1, (
+            f"expected exactly 1 batched alarm for deprecation_id={depr_id}, got {len(batched)}"
+        )
+        assert batched[0].extra["count"] == 3
+        assert batched[0].extra["deprecation_id"] == str(depr_id)
+        assert batched[0].extra["kind"] == "td"
+        # Importantly: NO per-event 'ad_hoc' alarms for the deprecation_swept events.
+        per_event = [a for a in alarms if a.kind == "ad_hoc"]
+        ad_hoc_for_swept = [a for a in per_event if "pr3b_batch" in a.extra.get("surface_id", "")]
+        assert ad_hoc_for_swept == [], (
+            f"deprecation_swept events must not produce per-event alarms; got {ad_hoc_for_swept}"
+        )
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_sentinel_batch_alarm_only_after_sweep_completed_at():
+    """Batched alarm waits for sweep_completed_at to be set on the
+    deprecated_schemes row — partial sweeps don't fire premature alarms."""
+    from agents.sentinel.forced_release_alarm import poll_forced_release_alarms
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        # In-progress sweep: sweep_started_at set, sweep_completed_at NULL.
+        depr_id = await conn.fetchval(
+            """
+            INSERT INTO lease_plane.deprecated_schemes
+              (surface_kind, marked_by_session_id, drain_window_days, sweep_started_at)
+            VALUES ('td', 'test-pr3b-partial', 30, now())
+            RETURNING deprecation_id
+            """
+        )
+        await _emit_event(
+            conn, event_type="lease.deprecation_swept",
+            surface_id="td:/pr3b_partial_a",
+            payload={"deprecation_id": str(depr_id), "kind": "td"},
+        )
+
+        alarms, _ = await poll_forced_release_alarms(
+            db_url=TEST_DB_URL, last_event_ts=None,
+        )
+        # No batched alarm yet (sweep still in progress).
+        batched = [
+            a for a in alarms if a.kind == "deprecation_batch"
+            and a.extra.get("deprecation_id") == str(depr_id)
+        ]
+        assert batched == [], "batched alarm fired before sweep_completed_at was set"
+
+        # Now complete the sweep — alarm should fire on next poll.
+        await conn.execute(
+            "UPDATE lease_plane.deprecated_schemes SET sweep_completed_at = now() "
+            "WHERE deprecation_id = $1",
+            depr_id,
+        )
+        alarms2, _ = await poll_forced_release_alarms(
+            db_url=TEST_DB_URL, last_event_ts=None,
+        )
+        batched2 = [
+            a for a in alarms2 if a.kind == "deprecation_batch"
+            and a.extra.get("deprecation_id") == str(depr_id)
+        ]
+        assert len(batched2) == 1, (
+            f"batched alarm should fire after sweep_completed_at; got {len(batched2)}"
+        )
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_phase_zero_acquire_race_blocked():
+    """RFC §7.11.7: serializable transaction + advisory lock during deprecate_cmd
+    blocks concurrent acquires from racing the Phase 0 mark.
+
+    The CLI's deprecate_cmd holds pg_advisory_xact_lock(hash(kind)). A concurrent
+    pg_advisory_xact_lock attempt on the same key blocks until the deprecate
+    transaction commits.
+    """
+    import asyncio
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+
+        kind = "td"
+        lock_key = abs(hash(kind)) % (2**31 - 1)
+
+        # Open a separate connection that holds the SAME advisory lock.
+        # While it holds, deprecate_cmd's serializable transaction must wait.
+        holder_conn = await asyncpg.connect(TEST_DB_URL)
+        await holder_conn.execute("BEGIN")
+        await holder_conn.execute("SELECT pg_advisory_xact_lock($1)", lock_key)
+
+        # Run deprecate_cmd with a tight asyncio timeout — should NOT complete
+        # while holder_conn still holds the lock.
+        deprecate_task = asyncio.create_task(
+            cli.deprecate_cmd(
+                kind=kind, session_id="test-pr3b-race",
+                drain_window_days=30, db_url=TEST_DB_URL,
+            )
+        )
+        try:
+            await asyncio.wait_for(asyncio.shield(deprecate_task), timeout=0.5)
+            assert False, "deprecate_cmd completed despite advisory lock being held by another tx"
+        except asyncio.TimeoutError:
+            pass  # expected — lock contention blocks the deprecate
+
+        # Release the holder lock; deprecate_cmd should now complete.
+        await holder_conn.execute("ROLLBACK")
+        await holder_conn.close()
+
+        rc = await asyncio.wait_for(deprecate_task, timeout=5.0)
+        assert rc == 0, f"deprecate_cmd should succeed once lock is released; rc={rc}"
+        # Verify the row landed.
+        count = await conn.fetchval(
+            "SELECT count(*) FROM lease_plane.deprecated_schemes "
+            "WHERE marked_by_session_id = 'test-pr3b-race'"
+        )
+        assert count == 1
+    finally:
+        await _cleanup(conn)
+        await conn.close()

--- a/tests/test_sentinel_forced_release_alarm.py
+++ b/tests/test_sentinel_forced_release_alarm.py
@@ -241,12 +241,19 @@ async def test_phase_zero_acquire_race_blocked():
     """RFC §7.11.7: serializable transaction + advisory lock during deprecate_cmd
     blocks concurrent acquires from racing the Phase 0 mark.
 
-    The CLI's deprecate_cmd holds pg_advisory_xact_lock(hash(kind)). A concurrent
-    pg_advisory_xact_lock attempt on the same key blocks until the deprecate
-    transaction commits.
+    The CLI's deprecate_cmd holds pg_advisory_xact_lock(_lock_key_for_kind(kind)).
+    A concurrent pg_advisory_xact_lock attempt on the same key blocks until the
+    deprecate transaction commits.
+
+    Note (PR 5): test now imports _lock_key_for_kind() — the SHA-256-derived
+    deterministic key. The pre-PR-5 implementation used `abs(hash(kind))` which
+    is salted per-process by PYTHONHASHSEED, so the test passed only by accident
+    (both holder and deprecate_cmd ran in the same process). PR 5 fixes the CLI;
+    this test now uses the same helper as production.
     """
     import asyncio
     from scripts.dev import lease_plane_deprecate as cli
+    from scripts.dev.lease_plane_deprecate import _lock_key_for_kind
 
     await ensure_test_database_schema()
     conn = await asyncpg.connect(TEST_DB_URL)
@@ -254,7 +261,7 @@ async def test_phase_zero_acquire_race_blocked():
         await _cleanup(conn)
 
         kind = "td"
-        lock_key = abs(hash(kind)) % (2**31 - 1)
+        lock_key = _lock_key_for_kind(kind)
 
         # Open a separate connection that holds the SAME advisory lock.
         # While it holds, deprecate_cmd's serializable transaction must wait.

--- a/tests/test_ship_lease_advisory.py
+++ b/tests/test_ship_lease_advisory.py
@@ -79,8 +79,11 @@ def test_acquire_emits_null_lease_on_held_by_other(capsys, monkeypatch):
             {
                 "ok": False,
                 "error": "held_by_other",
+                "surface_id": "ship.sh:contended",
+                "blocking_lease_id": str(uuid4()),
                 "held_by_uuid": str(other),
                 "expires_at": (datetime.now(UTC) + timedelta(seconds=60)).isoformat(),
+                "retry_after_hint_ms": 5000,
             }
         ]
     )

--- a/tests/test_ship_lease_advisory.py
+++ b/tests/test_ship_lease_advisory.py
@@ -20,7 +20,7 @@ def _ok_lease_payload(holder_uuid: UUID) -> dict[str, Any]:
     now = datetime.now(UTC).replace(microsecond=0)
     return {
         "lease_id": str(uuid4()),
-        "surface_id": "ship.sh:test-branch",
+        "surface_id": "resident:/ship_sh_test-branch",
         "surface_kind": "ship_sh",
         "holder_agent_uuid": str(holder_uuid),
         "holder_class": "process_instance",
@@ -59,7 +59,7 @@ def test_acquire_emits_lease_id_on_acquired_new(capsys, monkeypatch):
     rc = shla.main(
         [
             "acquire",
-            "--surface-id=ship.sh:test-branch",
+            "--surface-id=resident:/ship_sh_test-branch",
             "--surface-kind=ship_sh",
             "--intent=test ship",
             "--ttl-s=300",
@@ -79,7 +79,7 @@ def test_acquire_emits_null_lease_on_held_by_other(capsys, monkeypatch):
             {
                 "ok": False,
                 "error": "held_by_other",
-                "surface_id": "ship.sh:contended",
+                "surface_id": "resident:/ship_sh_contended",
                 "blocking_lease_id": str(uuid4()),
                 "held_by_uuid": str(other),
                 "expires_at": (datetime.now(UTC) + timedelta(seconds=60)).isoformat(),
@@ -93,7 +93,7 @@ def test_acquire_emits_null_lease_on_held_by_other(capsys, monkeypatch):
     rc = shla.main(
         [
             "acquire",
-            "--surface-id=ship.sh:contended",
+            "--surface-id=resident:/ship_sh_contended",
             "--surface-kind=ship_sh",
         ]
     )
@@ -112,7 +112,7 @@ def test_acquire_emits_service_unavailable_on_disabled(capsys, monkeypatch):
     rc = shla.main(
         [
             "acquire",
-            "--surface-id=ship.sh:disabled",
+            "--surface-id=resident:/ship_sh_disabled",
             "--surface-kind=ship_sh",
         ]
     )


### PR DESCRIPTION
**Stacked on #273** (PR 5). Targets `impl/lease-plane-phase-a-pr5-council-fixes`; rebase to master after PRs 1/2/2.5/3a/3b/4/5 merge.

## Summary

Closes the dangling-vocabulary council NIT from the PR 1-4 stack review: migration 027 added `lease.deprecation_marked` and `lease.deprecation_migrated` to the `lease_plane_events.event_type` CHECK constraint, but no code path emitted them. Audit consumers (Sentinel batched alarm from PR 3b, KG, dashboard) had no way to observe Phase 0 mark or Phase 3 finalize as first-class events.

PR 6 wires both emissions in the CLI with idempotent guards.

## RFC gate → code surface → test name → status

| Gate | Code | Test | Status |
|------|------|------|--------|
| §7.11.3 Phase 0 emits `lease.deprecation_marked` | `scripts/dev/lease_plane_deprecate.py::deprecate_cmd` | `test_deprecate_emits_lease_deprecation_marked_event` | ✅ |
| §7.11.3 Phase 3 emits `lease.deprecation_migrated` | `deprecation_finalize_cmd` | `test_finalize_emits_lease_deprecation_migrated_event` | ✅ |
| Idempotent re-runs do NOT double-emit `lease.deprecation_migrated` | finalize early-return on already-finalized | `test_finalize_idempotent_does_not_double_emit` | ✅ |

## Implementation

**Phase 0 emission** (`deprecate_cmd`): `INSERT INTO deprecated_schemes ... ON CONFLICT DO NOTHING RETURNING deprecation_id`. The `RETURNING` clause yields NULL on idempotent re-mark (the `ON CONFLICT` path), so the event emission only fires on the FIRST mark.

**Phase 3 emission** (`deprecation_finalize_cmd`): captures `check_migrated_at` BEFORE the UPDATE; only emits the `lease.deprecation_migrated` event if it was previously NULL. Re-running finalize on an already-finalized scheme is no-op for both `check_migrated_at` and the event.

**Marker events** use `surface_id = f"{kind}:/__deprecation_marker__"` — distinct from any real lease's surface_id, makes them easy to filter in audit queries (e.g., "all marker events for scheme X across deprecation history" is a single LIKE clause).

**Test infrastructure**: `_cleanup()` extended to delete events with `surface_id LIKE '%__deprecation_marker__'` so tests don't accumulate marker events across runs.

## Test verification

- **3 new PR 6 tests GREEN**.
- **11/11 deprecate-CLI tests GREEN** (8 pre-existing from PR 3a/PR 5 + 3 new).
- **7991/7991 full suite GREEN** (+3 vs PR 5; excluding `tests/resident_progress/` pre-existing master failure unrelated).

## Test plan
- [ ] `pytest tests/test_lease_plane_deprecate_cli.py -q --no-cov` — 11/11 pass
- [ ] Reviewer manually runs the CLI flow and confirms 3 events land in `lease_plane_events` (one mark, N swept, one migrated)

## Out of scope (deferred to PR 7+)
- §7.11.2 Phase 2/3 atomicity rewrite (CLI sub-command coupling)
- Elixir router server-side canonicalization
- Sentinel asyncpg pool wiring
- §9 RFC test-name reconciliation
- Phase B prerequisites (payload-shape standardization, `unitares_doctor` extension, §7.5 instrumentation)