### PR TITLE
S20.3: harden onboard_helper cache write — atomic 0600 + drop continuity_token

### DIFF
--- a/scripts/client/onboard_helper.py
+++ b/scripts/client/onboard_helper.py
@@ -25,6 +25,7 @@ import argparse
 import json
 import os
 import sys
+import tempfile
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -97,9 +98,35 @@ def _read_cache(workspace: Path, slot: str | None = None) -> dict:
 
 
 def _write_cache(workspace: Path, payload: dict, slot: str | None = None) -> None:
+    """Atomic cache write with mode 0600.
+
+    Mirrors the write-path contract of ``unitares-governance-plugin/scripts/
+    session_cache.py:_write_json`` (S20.1b): atomic via ``mkstemp`` +
+    ``os.replace``, mode 0600 via ``fchmod`` on the temp fd before rename.
+    The default ``Path.write_text`` inherits umask 022 → mode 0644, leaving
+    cached identity world-readable on a typical macOS setup; any same-UID
+    process could read the file. S20.3.
+
+    On any write/chmod/replace failure, the temp file is unlinked rather
+    than left as a turd in ``.unitares/``.
+    """
     path = workspace / CACHE_DIR / _slot_filename(slot)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    data = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        try:
+            os.write(fd, data)
+            os.fchmod(fd, 0o600)
+        finally:
+            os.close(fd)
+        os.replace(tmp, str(path))
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 # --- Response unwrap -------------------------------------------------------
@@ -233,6 +260,12 @@ def run_onboard(
         }
 
     # Build fresh cache payload — never preserve stale fields.
+    # continuity_token / continuity_token_supported are intentionally NOT
+    # persisted: per identity.md v2 ontology and S1-a, lineage across
+    # process-instances is declared via parent_agent_id, not resumed via
+    # cached token. The fields stay in the in-process return value so a
+    # caller can use them transiently within the same process if needed.
+    # S20.3 — mirrors the plugin helper's v2 cache schema (session_cache.py).
     new_cache = {
         "server_url": server_url,
         "agent_name": agent_name,
@@ -240,9 +273,7 @@ def run_onboard(
         "uuid": parsed.get("uuid"),
         "agent_id": parsed.get("agent_id") or parsed.get("resolved_agent_id") or "",
         "client_session_id": parsed.get("client_session_id", ""),
-        "continuity_token": parsed.get("continuity_token", ""),
         "session_resolution_source": parsed.get("session_resolution_source", ""),
-        "continuity_token_supported": parsed.get("continuity_token_supported", False),
         "display_name": parsed.get("display_name", ""),
     }
     if parent_agent_id:
@@ -255,9 +286,9 @@ def run_onboard(
         "uuid": new_cache["uuid"],
         "agent_id": new_cache["agent_id"],
         "client_session_id": new_cache["client_session_id"],
-        "continuity_token": new_cache["continuity_token"],
+        "continuity_token": parsed.get("continuity_token", ""),
         "session_resolution_source": new_cache["session_resolution_source"],
-        "continuity_token_supported": new_cache["continuity_token_supported"],
+        "continuity_token_supported": parsed.get("continuity_token_supported", False),
         "display_name": new_cache["display_name"],
     }
 

--- a/tests/test_onboard_helper.py
+++ b/tests/test_onboard_helper.py
@@ -13,6 +13,8 @@ Covers the behavior described in `scripts/client/onboard_helper.py`:
 from __future__ import annotations
 
 import json
+import os
+import stat
 from pathlib import Path
 from typing import Any
 
@@ -157,7 +159,49 @@ class TestRunOnboard:
         written = json.loads(cache_path.read_text())
         assert written["uuid"] == "uuid-ok"
         assert written["client_session_id"] == "agent-ok"
-        assert written["continuity_token"] == "v1.token-ok"
+        # S20.3: continuity_token must NOT be persisted to the cache file.
+        # The field stays in the in-process return value (transient) so a
+        # caller can use it within the same process, but is never written
+        # to disk — lineage across process-instances is declared via
+        # parent_agent_id, not resumed via cached token.
+        assert "continuity_token" not in written
+        assert "continuity_token_supported" not in written
+        # Result still carries the transient token from the server response.
+        assert result["continuity_token"] == "v1.token-ok"
+
+    def test_cache_file_is_mode_0600(self, tmp_path: Path) -> None:
+        """S20.3: cache file must be readable only by the owner.
+
+        Default Path.write_text inherits umask 022 → mode 0644 (world-
+        readable on a typical macOS setup). The cache no longer carries
+        continuity_token, but client_session_id is still process-instance
+        identity — same-UID readability is still a siphon surface.
+        """
+        _, _, cache_path = self._call(tmp_path, [_success_response()])
+        assert cache_path.exists()
+        mode = stat.S_IMODE(os.stat(cache_path).st_mode)
+        assert mode == 0o600, f"expected mode 0600, got {oct(mode)}"
+
+    def test_write_failure_does_not_leave_tmp_file(self, tmp_path: Path, monkeypatch) -> None:
+        """S20.3: a failed atomic write unlinks the temp file rather than
+        leaving a .tmp turd in ``.unitares/``."""
+        from scripts.client import onboard_helper
+
+        real_replace = os.replace
+
+        def boom(*args, **kwargs):
+            raise OSError("simulated replace failure")
+
+        monkeypatch.setattr(onboard_helper.os, "replace", boom)
+        with pytest.raises(OSError):
+            onboard_helper._write_cache(tmp_path, {"uuid": "x"}, slot=None)
+
+        cache_dir = tmp_path / ".unitares"
+        if cache_dir.exists():
+            stragglers = [p for p in cache_dir.iterdir() if p.suffix == ".tmp"]
+            assert stragglers == [], f"temp file leaked: {stragglers}"
+        # Restore for other tests in the same session.
+        monkeypatch.setattr(onboard_helper.os, "replace", real_replace)
 
     def test_cached_uuid_declared_as_parent_on_startup(self, tmp_path: Path) -> None:
         initial = {


### PR DESCRIPTION
## Summary

Closes [S20.3](../docs/ontology/plan.md) — the `scripts/client/onboard_helper.py:_write_cache` parity gap with `session_cache.py`.

`Path.write_text` inherits umask 022 → mode 0644 on a typical macOS setup. Same-UID processes could read the cached identity (uuid + client_session_id + continuity_token).

## Changes

- **Atomic 0600 write:** `tempfile.mkstemp` + `os.fchmod(0o600)` + `os.replace`, mirroring `unitares-governance-plugin/scripts/session_cache.py:_write_json` (S20.1b). On any write/chmod/replace failure, the temp file is unlinked rather than left as a turd in `.unitares/`.
- **Drop tokens from cache:** `continuity_token` / `continuity_token_supported` no longer persisted. Per `identity.md` v2 + S1-a, lineage across process-instances is declared via `parent_agent_id`, not resumed via cached token. The fields stay in the in-process return value (transient, same-process use OK).

## Honesty caveat (axiom #14)

Convention-level, advisory per [s20-cache-scope-narrowing.md §9](../docs/ontology/s20-cache-scope-narrowing.md). A determined caller can still write JSON to the path directly, or capture the token from the return value. Earned defense is S1-A′ + S19. S20.3's job is to stop the helper from teaching the world-readable + bearer-token-at-rest pattern.

## Decision

§3c chose **C2** (mirror contract locally) over **C1** (route through plugin helper). C1 would introduce a runtime dependency from the unitares server repo on the plugin repo for ~30 lines of code. C2 keeps both helpers self-contained at the cost of two parity points; mode 0600 + token absence are both mechanically testable and visible.

## Council review

`feature-dev:code-reviewer` (adversarial) + `dialectic-knowledge-architect` (ontology) reviewed pre-commit. Findings folded:
- BUG (85): tempfile leak on `os.write` failure → fixed (BaseException unlink path, plus regression test)
- Honest-labeling: docstring "Mirrors the *contract enforced by*" → "Mirrors the *write-path contract of*" — this helper isn't an enforcement surface, just a write surface

## Paired commit

Plugin half: CIRWEL/unitares-governance-plugin#TBD (paired branch `s20-3-onboard-helper-cache-mode`).

## Test plan

- [x] `pytest tests/test_onboard_helper.py` — 30 passed, including 2 new tests (mode-0600 assertion + tempfile-leak regression)
- [x] Focused suite (`tests/test_onboard_helper.py tests/test_onboard_pin.py tests/test_onboard_classifier.py tests/test_client_session_cache_perms.py tests/test_identity_session.py`) — 249 passed
- [x] Pre-existing master failure on `test_no_resident_candidate_above_fifty_percent` (Watcher candidate rate 77%) is NOT introduced by this PR — verified against `master` tip