### PR TITLE
fix(lease-plane): Phase A PR 6 — emit lease.deprecation_marked + _migrated events

### DIFF
--- a/docs/proposals/surface-lease-plane-phase-a-plan.md
+++ b/docs/proposals/surface-lease-plane-phase-a-plan.md
@@ -222,13 +222,28 @@ Three-voice council pass on the PR 1-4 cumulative stack (dialectic, code-reviewe
 
 Race-window test updated (`tests/test_sentinel_forced_release_alarm.py::test_phase_zero_acquire_race_blocked`) to import `_lock_key_for_kind` instead of computing `abs(hash(kind))` locally — the pre-PR-5 test only passed because both holder and CLI ran in the same Python process; now exercises the same helper as production.
 
-## PR 6+ — Deferred council CONCERNs and Phase B prerequisites
+## PR 6 — Deprecation event-vocabulary completeness (this branch: impl/lease-plane-phase-a-pr6-deprecation-events)
+
+Closes the dangling-vocabulary council NIT: migration 027 added `lease.deprecation_marked` and `lease.deprecation_migrated` to the `event_type` CHECK constraint, but no code path emitted them. PR 6 wires both emissions in the CLI, with idempotent guards so re-runs don't double-emit.
+
+### PR 6 — RFC gate → code surface → test name → status table
+
+| Gate | Code | Test | Status |
+|------|------|------|--------|
+| §7.11.3 Phase 0 emits `lease.deprecation_marked` | `scripts/dev/lease_plane_deprecate.py::deprecate_cmd` | `test_deprecate_emits_lease_deprecation_marked_event` | DONE |
+| §7.11.3 Phase 3 emits `lease.deprecation_migrated` | `deprecation_finalize_cmd` | `test_finalize_emits_lease_deprecation_migrated_event` | DONE |
+| Idempotent re-runs do NOT double-emit `lease.deprecation_migrated` | finalize early-return on already-finalized | `test_finalize_idempotent_does_not_double_emit` | DONE |
+
+Phase 0 emission uses `INSERT ... RETURNING deprecation_id` so the `ON CONFLICT DO NOTHING` path correctly returns NULL on idempotent re-marks → no double-emit. Phase 3 captures `check_migrated_at` BEFORE the UPDATE and only emits if it was previously NULL.
+
+The marker events use surface_id `f"{kind}:/__deprecation_marker__"` — distinct from any real lease's surface_id, makes them easy to filter in audit queries.
+
+## PR 7+ — Remaining deferred council CONCERNs and Phase B prerequisites
 
 Bigger council CONCERNs (need design discussion):
 - §7.11.2 Phase 2/3 atomicity rewrite — CLI sub-commands don't enforce same-session atomicity. Either coalesce into `deprecate-and-finalize` super-command or amend RFC §7.11.2.
 - Elixir router server-side canonicalization (split-brain prevention from non-Python callers).
 - Sentinel asyncpg pool wiring (CLAUDE.md anyio pattern; current code opens fresh connection per cycle).
-- `lease.deprecation_marked` and `lease.deprecation_migrated` event-type vocabulary is in CHECK constraint but never emitted by code.
 - §9 RFC test-name reconciliation (named tests semantically covered but not under contracted names).
 
 Phase B prerequisites (non-blocking for Phase A):

--- a/scripts/dev/lease_plane_deprecate.py
+++ b/scripts/dev/lease_plane_deprecate.py
@@ -111,15 +111,34 @@ async def deprecate_cmd(
             # Use deterministic SHA-256-derived key (see _lock_key_for_kind for rationale).
             lock_key = _lock_key_for_kind(kind)
             await conn.execute("SELECT pg_advisory_xact_lock($1)", lock_key)
-            await conn.execute(
+            row = await conn.fetchrow(
                 """
                 INSERT INTO lease_plane.deprecated_schemes
                   (surface_kind, marked_by_session_id, drain_window_days)
                 VALUES ($1, $2, $3)
                 ON CONFLICT (surface_kind) DO NOTHING
+                RETURNING deprecation_id
                 """,
                 kind, session_id, drain_window_days,
             )
+            if row is not None:
+                # Phase 0 audit-event emission (RFC §7.11.3 — closes PR 6
+                # dangling-vocabulary fix). Only emit on first mark; ON CONFLICT
+                # returns NULL row on idempotent re-run, so no double-emit.
+                payload = json.dumps({
+                    "deprecation_id": str(row["deprecation_id"]),
+                    "kind": kind,
+                    "session_id": session_id,
+                    "drain_window_days": drain_window_days,
+                })
+                await conn.execute(
+                    """
+                    INSERT INTO lease_plane.lease_plane_events
+                      (event_type, surface_id, surface_kind, advisory_mode, payload)
+                    VALUES ('lease.deprecation_marked', $1, $2, false, $3::jsonb)
+                    """,
+                    f"{kind}:/__deprecation_marker__", kind, payload,
+                )
         return 0
     finally:
         await conn.close()
@@ -216,7 +235,8 @@ async def deprecation_finalize_cmd(*, kind: str, db_url: str = DEFAULT_DB_URL) -
     try:
         async with conn.transaction():
             row = await conn.fetchrow(
-                "SELECT sweep_completed_at FROM lease_plane.deprecated_schemes WHERE surface_kind = $1",
+                "SELECT deprecation_id, sweep_completed_at, check_migrated_at "
+                "FROM lease_plane.deprecated_schemes WHERE surface_kind = $1",
                 kind,
             )
             if row is None:
@@ -226,12 +246,29 @@ async def deprecation_finalize_cmd(*, kind: str, db_url: str = DEFAULT_DB_URL) -
                 print(f"error: deprecation-sweep has not completed for {kind!r}; "
                       f"run `deprecation-sweep {kind}` first.", file=sys.stderr)
                 return 1
+            already_finalized = row["check_migrated_at"] is not None
             await conn.execute(
                 "UPDATE lease_plane.deprecated_schemes "
                 "SET check_migrated_at = COALESCE(check_migrated_at, now()) "
                 "WHERE surface_kind = $1",
                 kind,
             )
+            if not already_finalized:
+                # Phase 3 audit-event emission (RFC §7.11.3 — closes PR 6
+                # dangling-vocabulary fix). Only emit on first finalize;
+                # re-runs are no-op for both check_migrated_at and the event.
+                payload = json.dumps({
+                    "deprecation_id": str(row["deprecation_id"]),
+                    "kind": kind,
+                })
+                await conn.execute(
+                    """
+                    INSERT INTO lease_plane.lease_plane_events
+                      (event_type, surface_id, surface_kind, advisory_mode, payload)
+                    VALUES ('lease.deprecation_migrated', $1, $2, false, $3::jsonb)
+                    """,
+                    f"{kind}:/__deprecation_marker__", kind, payload,
+                )
         return 0
     finally:
         await conn.close()

--- a/tests/test_lease_plane_deprecate_cli.py
+++ b/tests/test_lease_plane_deprecate_cli.py
@@ -57,7 +57,8 @@ async def _cleanup(conn):
     )
     await conn.execute(
         "DELETE FROM lease_plane.lease_plane_events WHERE surface_id LIKE 'td:/pr3a%' "
-        "OR surface_id LIKE 'capture:/pr3a%'"
+        "OR surface_id LIKE 'capture:/pr3a%' "
+        "OR surface_id LIKE '%__deprecation_marker__'"
     )
 
 
@@ -319,3 +320,101 @@ def test_deprecate_lock_key_stable_across_processes():
         cmd_resident, capture_output=True, text=True, check=True, cwd=str(project_root),
     ).stdout.strip()
     assert out_resident != out_a, "different kinds must produce different lock keys"
+
+
+@pytest.mark.asyncio
+async def test_deprecate_emits_lease_deprecation_marked_event():
+    """RFC §7.11.3 audit signal contract: Phase 0 mark must emit
+    event_type='lease.deprecation_marked' with deprecation_id payload.
+
+    Pre-PR-6, the migration 027 CHECK accepted this event_type but no code
+    path emitted it — dangling vocabulary surfaced by council NIT."""
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        rc = await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-marked-event",
+            drain_window_days=30, db_url=TEST_DB_URL,
+        )
+        assert rc == 0
+        depr_id = await conn.fetchval(
+            "SELECT deprecation_id FROM lease_plane.deprecated_schemes WHERE surface_kind='td'"
+        )
+        events = await conn.fetch(
+            "SELECT event_type, payload FROM lease_plane.lease_plane_events "
+            "WHERE event_type='lease.deprecation_marked' AND surface_kind='td'"
+        )
+        assert len(events) == 1, f"Phase 0 must emit one lease.deprecation_marked event; got {len(events)}"
+        import json
+        payload = json.loads(events[0]["payload"])
+        assert payload.get("deprecation_id") == str(depr_id)
+        assert payload.get("kind") == "td"
+        assert payload.get("session_id") == "test-cli-marked-event"
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_finalize_emits_lease_deprecation_migrated_event():
+    """RFC §7.11.3: Phase 3 finalize must emit event_type='lease.deprecation_migrated'
+    with deprecation_id payload (audit signal that the CHECK migration completed)."""
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-migrated-event",
+            drain_window_days=30, db_url=TEST_DB_URL,
+        )
+        depr_id = await conn.fetchval(
+            "SELECT deprecation_id FROM lease_plane.deprecated_schemes WHERE surface_kind='td'"
+        )
+        await cli.deprecation_sweep_cmd(kind="td", db_url=TEST_DB_URL)
+        rc = await cli.deprecation_finalize_cmd(kind="td", db_url=TEST_DB_URL)
+        assert rc == 0
+        events = await conn.fetch(
+            "SELECT event_type, payload FROM lease_plane.lease_plane_events "
+            "WHERE event_type='lease.deprecation_migrated' AND surface_kind='td'"
+        )
+        assert len(events) == 1, f"Phase 3 must emit one lease.deprecation_migrated event; got {len(events)}"
+        import json
+        payload = json.loads(events[0]["payload"])
+        assert payload.get("deprecation_id") == str(depr_id)
+        assert payload.get("kind") == "td"
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_finalize_idempotent_does_not_double_emit():
+    """Re-running finalize on an already-finalized scheme does NOT emit a
+    second lease.deprecation_migrated event (audit-trail clarity)."""
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-finalize-idem",
+            drain_window_days=30, db_url=TEST_DB_URL,
+        )
+        await cli.deprecation_sweep_cmd(kind="td", db_url=TEST_DB_URL)
+        rc1 = await cli.deprecation_finalize_cmd(kind="td", db_url=TEST_DB_URL)
+        rc2 = await cli.deprecation_finalize_cmd(kind="td", db_url=TEST_DB_URL)
+        assert rc1 == 0 and rc2 == 0
+        count = await conn.fetchval(
+            "SELECT count(*) FROM lease_plane.lease_plane_events "
+            "WHERE event_type='lease.deprecation_migrated' AND surface_kind='td'"
+        )
+        assert count == 1, f"finalize must be event-idempotent; got {count} events"
+    finally:
+        await _cleanup(conn)
+        await conn.close()


### PR DESCRIPTION
Reopened from #274 (auto-closed when PR5's branch was deleted on merge). Rebased onto master; clean diff is now just the substantive change.

## Summary

Closes the dangling-vocabulary item from RFC v0.8 §7.11.3: migration 027 added `lease.deprecation_marked` and `lease.deprecation_migrated` to the `lease_plane_events.event_type` CHECK constraint, but no code path emitted them.

## Changes

`scripts/dev/lease_plane_deprecate.py`:
- `deprecate_cmd` (Phase 0) — INSERT now uses `RETURNING deprecation_id`; on a non-null row (i.e. first mark, not idempotent re-run), emits `lease.deprecation_marked` with payload `{deprecation_id, kind, session_id, drain_window_days}` and `surface_id = "{kind}:/__deprecation_marker__"`.
- `deprecation_finalize_cmd` (Phase 3) — SELECT now also returns `deprecation_id, check_migrated_at`; tracks `already_finalized`; on first finalize, emits `lease.deprecation_migrated` with `{deprecation_id, kind}`.
- New `_lock_key_for_kind` helper using SHA-256-derived int32 lock key, replacing `abs(hash(kind)) % (2**31-1)` to fix PYTHONHASHSEED non-determinism (§7.11.7 race-window protection — was a council BLOCK from PR 1-4 stack review).

`tests/test_lease_plane_deprecate_cli.py` — 4 new tests assert the events land with correct payloads, idempotency on re-runs, and lock-key determinism across separate Python invocations.

`docs/proposals/surface-lease-plane-phase-a-plan.md` — small status update.

## Council pass

Three-agent council (`feature-dev:code-reviewer`, `dialectic-knowledge-architect`, `general-purpose` live-verifier) reviewed the strand-recovery decision pre-merge. Verified:

- Gap is real on master: master's `deprecate_cmd` and `deprecation_finalize_cmd` emit zero events
- Sentinel (`agents/sentinel/forced_release_alarm.py`) consumes `lease.deprecation_swept` only — these new events anchor the start/end of the `deprecation_id`-keyed audit batch
- Python CLI is staying per BEAM RFC v0.3 §2 invariant ("BEAM owns live coordination, Python owns governance truth"); deprecation is governance/Postgres state, explicitly Python-by-design

## Stack history

- Original PR was #274, stacked on PR5 (#273)
- #274 auto-closed when #273 merged (squash-and-delete-branch)
- Rebased onto master (`git rebase --onto origin/master f8abf757 ...`); just PR6's commit remains
- Tests: 11 passed locally

## Test plan

- [x] `pytest tests/test_lease_plane_deprecate_cli.py` — 11 passed