### PR TITLE
feat(lease-plane): Phase A PR 7 — Elixir router server-side canonicalization + transition_handoff INSERT fix

### DIFF
--- a/docs/proposals/surface-lease-plane-phase-a-plan.md
+++ b/docs/proposals/surface-lease-plane-phase-a-plan.md
@@ -238,11 +238,46 @@ Phase 0 emission uses `INSERT ... RETURNING deprecation_id` so the `ON CONFLICT 
 
 The marker events use surface_id `f"{kind}:/__deprecation_marker__"` — distinct from any real lease's surface_id, makes them easy to filter in audit queries.
 
-## PR 7+ — Remaining deferred council CONCERNs and Phase B prerequisites
+## PR 7 — Elixir router server-side canonicalization + transition_handoff INSERT fix (this branch: impl/lease-plane-phase-a-pr7-elixir-canonicalize)
+
+Closes the council CONCERN named in the prior PR 7+ section: split-brain prevention when non-Python callers (curl, future Hermes/Codex/Elixir clients) hit the lease plane HTTP API directly. Also bundles a one-line surgical fix to `transition_handoff` reacquire INSERT (PR 1 oversight that was masked because migrations 026-029 had never been applied to the live `governance` DB).
+
+**Discovered while running baseline:** migrations 026, 027, 028, 029 existed as files but had never been applied to the live `governance` DB despite being landed in PRs 1, 3a, 5. `core.schema_migrations` only had versions 24, 25. Operator authorized apply at 02:26 local on 2026-05-02; mix tests went from 22/49 failing to 0/49 with the migrations present. The PR 1 `surface_kind`-INSERT-drop fix had been correctly applied to the `acquire` path but missed the `transition_handoff` reacquire path (release-and-reacquire pattern); same RFC gate (§7.2.3) and same root cause, fixed surgically here. KG finding `2026-05-02T08:22:47.029541+00:00` filed for the migration-apply gap.
+
+Scope shipped:
+- `elixir/lease_plane/lib/unitares_lease_plane/canonicalize.ex` (new) — Elixir mirror of `src/lease_plane/canonicalize.py` for the four pure-logic schemes (`dialectic`, `resident`, `capture`, `td`). Top-level rejection for NUL, length > PATH_MAX, and `?` (per RFC §7.12.4 OPERATOR_NOTE 3, mirrors Python `_validate_surface_id`). Per-scheme rules audited against Python row-by-row.
+- `file://` canonicalization deferred — module emits a `Logger.warning` on every ingress as a deferral audit trail. PR 2.5 migrated all production agents (watcher, vigil, sentinel, chronicler, ship.sh) off `file://` to `resident:/`, verified via `grep`.
+- Wired into `http_router.ex::extract_acquire_params` (POST /v1/lease/acquire) and the GET /v1/lease/status query-param handler. On `{:error, reason}` → 422 schema_invalid with reason in body.
+- `repo.ex::transition_handoff` reacquire INSERT drops `surface_kind` from the column list (PR 1 oversight).
+- `lease_test_helpers.ex::unique_surface_id` switched from `Base.url_encode64` (mixed-case) to `Base.encode16(case: :lower)` so generated test surface_ids are already canonical for `dialectic:/` (lowercase) and don't trip round-trip-mismatch in incidental tests.
+
+Three-voice council pass (dialectic-knowledge-architect + feature-dev:code-reviewer + live-verifier) ran with adversarial framing per `feedback_council-adversarial-prompt.md`. Two BLOCKs surfaced and fixed:
+- **Architect B1**: top-level `?` rejection was missing (Elixir only rejected `?` inside `resident:/`; Python rejects at top level). Fixed by adding top-level `?` check with reason `:reserved_query_string`.
+- **Reviewer B1**: `~r/[\s?#&]/u` over-rejected — PCRE `\s` matches `\r`/`\f`/`\v` plus Unicode whitespace; Python rejects exactly `(' ', '\t', '\n')`. Fixed by replacing with `~r/[ \t\n#&]/` (exact mirror, no `u` flag).
+- **Reviewer B2**: HTTP capture test computed `surface_canonical` by hand in a correct-by-coincidence way; cleanup would target wrong row on assertion failure. Fixed by computing via `Canonicalize.canonicalize/1` directly.
+- Live-verifier: 5/5 verifiable claims VERIFIED (migrations applied, grammar CHECK rejects bad scheme, mix test 88 passing pre-fix / 91 post-fix, both surface_leases INSERT paths clean, no production `file://` use, no test-tree base64url remnants).
+
+Plus addressed CONCERNs: file:// `Logger.warning` audit trail (architect C4), `td:/` empty-path parity test (architect C5), byte_size-vs-len divergence doc note (architect C3), capture:/ comma-in-member doc note (architect C6), pattern-match prefix dispatch instead of `binary_part` (architect N2). Two CONCERNs explicitly noted but not coded: capture:/ empty-member-list passthrough (Python agrees, RFC silent — unchanged) and pre-PR-7 row backfill (live-verifier confirmed `surface_leases` is empty, no backfill needed).
+
+### PR 7 — RFC gate → code surface → test name → status table
+
+| Gate | Code | Test | Status |
+|------|------|------|--------|
+| §7.12.1 server-side canonicalization on Elixir router (closes split-brain from non-Python callers) | `elixir/lease_plane/lib/unitares_lease_plane/canonicalize.ex` (new) | `test/canonicalize_test.exs` (38 unit tests covering scheme dispatch, NUL/length/`?` guards, four implemented schemes, file:// deferral, cross-language parity) | DONE |
+| §7.12.4 OPERATOR_NOTE 3 — top-level `?`-rejection (parity with Python `_validate_surface_id`) | `canonicalize.ex::canonicalize/1` top-level guard, reason `:reserved_query_string` | `"rejects ? at top level across ALL schemes (parity with Python _validate_surface_id)"` | DONE |
+| §7.12.1 wire canonicalize into POST /v1/lease/acquire | `http_router.ex::extract_acquire_params` (canonicalize before assembling params; on error → 422 schema_invalid) | `test/http_router_test.exs::"PR 7 — non-canonical scheme → 422 schema_invalid"`, `"PR 7 — capture:/ unsorted members → server stores canonical (sorted)"`, `"PR 7 — dialectic:/ uppercase → server stores canonical (lowercased)"` | DONE |
+| §7.12.1 wire canonicalize into GET /v1/lease/status | `http_router.ex` status route (canonicalize query param; on error → 422) | `test/http_router_test.exs::"GET /v1/lease/status non-canonical scheme → 422 schema_invalid"` | DONE |
+| §7.12.1 step 4 — `file://` realpath/case-fold normalization on Elixir | (deferred — moduledoc + `Logger.warning` on every `file://` ingress as audit trail) | `test/canonicalize_test.exs::"file:// (deferred normalization)"` describe block | DEFERRED — to PR 7.5 (see PR 8+ section below) |
+| §7.2.3 `transition_handoff` reacquire INSERT drops `surface_kind` (PR 1 oversight surfaced when migrations 026-029 hit live DB 2026-05-02) | `repo.ex::transition_handoff` insert column list | `test/http_router_test.exs::"accept closes the old lease and reacquires for the recipient"` (turned green from baseline-failing post-migration) | DONE |
+| Operator: apply migrations 026-029 to live `governance` DB | `db/postgres/migrations/026|027|028|029_*.sql` (already merged in PRs 1, 3a, 5; never run) | `core.schema_migrations` shows versions 24-29; KG finding `2026-05-02T08:22:47.029541+00:00` | DONE (operator action, 2026-05-02 02:26-02:27 local) |
+
+**Total: 7 rows in PR 7. Within the ≤10 methodology cap.**
+
+## PR 8+ — Remaining deferred council CONCERNs and Phase B prerequisites
 
 Bigger council CONCERNs (need design discussion):
 - §7.11.2 Phase 2/3 atomicity rewrite — CLI sub-commands don't enforce same-session atomicity. Either coalesce into `deprecate-and-finalize` super-command or amend RFC §7.11.2.
-- Elixir router server-side canonicalization (split-brain prevention from non-Python callers).
+- §7.12.1 step 4 — `file://` realpath/case-fold normalization on Elixir (PR 7.5). Needs cross-language parity harness for filesystem-state-dependent behavior. PR 7 left a `Logger.warning` audit trail so a future production `file://` call surfaces the deferral.
 - Sentinel asyncpg pool wiring (CLAUDE.md anyio pattern; current code opens fresh connection per cycle).
 - §9 RFC test-name reconciliation (named tests semantically covered but not under contracted names).
 

--- a/elixir/lease_plane/lib/unitares_lease_plane/canonicalize.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/canonicalize.ex
@@ -1,0 +1,178 @@
+defmodule UnitaresLeasePlane.Canonicalize do
+  @moduledoc """
+  Server-side canonicalization for surface_id (RFC v0.8 §7.12).
+
+  Mirrors `src/lease_plane/canonicalize.py` so non-Python callers (curl, future
+  Hermes/Codex/Elixir clients) cannot bypass the Python field_validator and
+  produce split-brain rows in `lease_plane.surface_leases`. The Python and
+  Elixir helpers are the single point of truth — two callers using different
+  paths to the same logical surface MUST produce the same canonical surface_id
+  IFF both go through this helper.
+
+  Returns idiomatic `{:ok, canonical}` / `{:error, reason}` rather than raising;
+  the HTTP router maps `{:error, reason}` to 422 schema_invalid with the reason
+  surfaced in the body.
+
+  ## Cross-language parity notes
+
+  - `?` rejection is at the TOP level (before per-scheme dispatch) per RFC
+    §7.12.4 OPERATOR_NOTE 3 + Python `_validate_surface_id`. Keeps v0 traffic
+    clean while leaving v1 modifier-form Open.
+  - The `resident:/` reserved-character set is exactly Python's three
+    whitespace chars + `#` + `&` (`?` already caught at top level). Do NOT
+    use `\\s` here — `\\s` in PCRE matches `\\r`/`\\f`/`\\v` plus Unicode
+    whitespace, which would over-reject relative to Python.
+  - `byte_size/1` is byte-count (Elixir convention); Python `len/1` is
+    code-point count. For the canonical-scheme grammar (ASCII-only by RFC),
+    these match. A multi-byte UTF-8 surface_id would diverge but is rejected
+    by the DB grammar CHECK independently.
+
+  ## file:// — deferred normalization
+
+  This Phase A pass implements the four pure-logic schemes (`dialectic`,
+  `resident`, `capture`, `td`) that have deterministic cross-language behavior.
+  `file://` requires double-realpath (macOS /var → /private/var) and tmpfile
+  case-detection probing, both of which are filesystem-state-dependent and need
+  a more involved cross-language parity harness. PR 2.5 migrated all production
+  agents (watcher, vigil, sentinel, chronicler, ship.sh) off `file://` to
+  `resident:/`, so the deferral does not block production. Tracking note in
+  `docs/proposals/surface-lease-plane-phase-a-plan.md` PR 8+ section.
+
+  For `file://` in this PR: validate prefix + NUL + length only. Pass through
+  the path component unchanged. The DB grammar CHECK from migration 026 still
+  enforces the scheme prefix. A `Logger.warning` fires on every `file://`
+  ingress so the deferral leaves an audit trail when re-violated by a future
+  caller.
+
+  ## capture:/ — comma is the member separator
+
+  `capture:/` member names MUST NOT contain commas; the splitter has no escape
+  mechanism. A comma-bearing member would silently split into multiple members
+  and sort. Both Python and Elixir corrupt identically here; not a parity gap.
+  If RFC ever needs comma-bearing members, both implementations need a coupled
+  escape rule.
+  """
+
+  require Logger
+
+  # v0.8 canonical scheme list (RFC §7.2.1). Single source of truth in Elixir.
+  @canonical_schemes ~w(file dialectic resident capture td)
+
+  @path_max 4096
+
+  @typedoc """
+  Reasons returned by `canonicalize/1` on failure. Mirrors Python
+  `CanonicalizeError.reason` plus Python's top-level `?`-rejection in
+  `_validate_surface_id`.
+  """
+  @type reason :: :nul_byte | :path_too_long | :invalid_scheme | :reserved_query_string
+
+  @doc """
+  Returns `{:ok, canonical}` if `surface_id` matches the canonical scheme list
+  and per-scheme normalization succeeds; `{:error, reason}` otherwise.
+
+  ## Examples
+
+      iex> UnitaresLeasePlane.Canonicalize.canonicalize("dialectic:/SESSION-Abc")
+      {:ok, "dialectic:/session-abc"}
+
+      iex> UnitaresLeasePlane.Canonicalize.canonicalize("capture:/B,A,C")
+      {:ok, "capture:/A,B,C"}
+
+      iex> UnitaresLeasePlane.Canonicalize.canonicalize("resident:/watcher_cycle/")
+      {:ok, "resident:/watcher_cycle"}
+
+      iex> UnitaresLeasePlane.Canonicalize.canonicalize("td:/eisv_basin_v31")
+      {:ok, "td:/eisv_basin_v31"}
+
+      iex> UnitaresLeasePlane.Canonicalize.canonicalize("ftp://nope")
+      {:error, :invalid_scheme}
+  """
+  @spec canonicalize(String.t()) :: {:ok, String.t()} | {:error, reason()}
+  def canonicalize(surface_id) when is_binary(surface_id) do
+    cond do
+      String.contains?(surface_id, <<0>>) ->
+        {:error, :nul_byte}
+
+      byte_size(surface_id) > @path_max ->
+        {:error, :path_too_long}
+
+      # PR 7 council BLOCK B1 — Python `_validate_surface_id` rejects `?`
+      # bearing surface_ids at the top level (before per-scheme dispatch) per
+      # RFC §7.12.4 OPERATOR_NOTE 3. Mirror exactly here so non-Python
+      # callers can't slip `dialectic:/abc?x=1` past the Elixir router.
+      String.contains?(surface_id, "?") ->
+        {:error, :reserved_query_string}
+
+      true ->
+        dispatch(surface_id)
+    end
+  end
+
+  def canonicalize(_), do: {:error, :invalid_scheme}
+
+  defp dispatch("file://" <> rest), do: canonicalize_file(rest)
+  defp dispatch("dialectic:/" <> rest), do: canonicalize_dialectic(rest)
+  defp dispatch("resident:/" <> rest), do: canonicalize_resident(rest)
+  defp dispatch("capture:/" <> rest), do: canonicalize_capture(rest)
+  defp dispatch("td:/" <> rest), do: canonicalize_td(rest)
+  defp dispatch(_), do: {:error, :invalid_scheme}
+
+  @doc """
+  Returns the canonical scheme list. Useful for error messages and tests.
+  """
+  @spec canonical_schemes() :: [String.t()]
+  def canonical_schemes, do: @canonical_schemes
+
+  # ---------- per-scheme rules ----------
+
+  # file:// canonicalization deferred to a follow-up PR. See moduledoc.
+  # PR 2.5 moved all production agents off file://; the DB grammar CHECK still
+  # enforces the prefix. Pass-through preserves the path component verbatim.
+  # Logger.warning fires on every ingress so the deferral leaves an audit trail
+  # when re-violated by a future caller (per PR 7 council CONCERN C4).
+  defp canonicalize_file(path) do
+    Logger.warning(
+      "lease_plane canonicalize: file:// surface_id received without normalization (PR 7 deferred); path=#{inspect(path)}"
+    )
+
+    {:ok, "file://" <> path}
+  end
+
+  # dialectic:/ — opaque session id; lowercase only (matches Python).
+  defp canonicalize_dialectic(path) do
+    {:ok, "dialectic:/" <> String.downcase(path)}
+  end
+
+  # resident:/ — opaque resident name; case-sensitive; reject reserved chars.
+  # Per PR 7 council BLOCK 1 (reviewer): mirror Python's exact set — space,
+  # tab, newline, `#`, `&`. `?` is now caught at the top level. Do NOT use
+  # `\s` here — PCRE `\s` includes `\r`/`\f`/`\v` plus Unicode whitespace,
+  # which would over-reject relative to Python.
+  defp canonicalize_resident(path) do
+    if String.match?(path, ~r/[ \t\n#&]/) do
+      {:error, :invalid_scheme}
+    else
+      {:ok, "resident:/" <> String.trim_trailing(path, "/")}
+    end
+  end
+
+  # capture:/ — comma-separated member list; sort lexically. Drops empty
+  # members (blank between commas, or leading/trailing comma) before sorting,
+  # matching Python's `[m.strip() for m in path.split(",") if m.strip()]`.
+  defp canonicalize_capture(path) do
+    members =
+      path
+      |> String.split(",")
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
+      |> Enum.sort()
+
+    {:ok, "capture:/" <> Enum.join(members, ",")}
+  end
+
+  # td:/ — reserved scheme; pass-through with no normalization (matches Python).
+  defp canonicalize_td(path) do
+    {:ok, "td:/" <> path}
+  end
+end

--- a/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
@@ -20,6 +20,7 @@ defmodule UnitaresLeasePlane.HTTPRouter do
   require Logger
 
   alias UnitaresLeasePlane
+  alias UnitaresLeasePlane.Canonicalize
 
   plug(:match)
 
@@ -110,17 +111,30 @@ defmodule UnitaresLeasePlane.HTTPRouter do
       nil ->
         json(conn, 422, %{ok: false, error: "schema_invalid", detail: "surface_id required"})
 
-      surface_id ->
-        case UnitaresLeasePlane.status(surface_id) do
-          {:ok, nil} ->
-            json(conn, 200, %{ok: true, lease: nil})
-
-          {:ok, lease} ->
-            json(conn, 200, %{ok: true, lease: present_lease(lease)})
-
+      raw_surface_id ->
+        # PR 7 — server-side canonicalization (RFC v0.8 §7.12.1). Mirrors the
+        # Python field_validator so non-Python callers cannot bypass and
+        # produce split-brain rows.
+        case Canonicalize.canonicalize(raw_surface_id) do
           {:error, reason} ->
-            Logger.error("lease plane status failed: #{inspect(reason)}")
-            json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
+            json(conn, 422, %{
+              ok: false,
+              error: "schema_invalid",
+              detail: "surface_id canonicalization failed: #{reason}"
+            })
+
+          {:ok, surface_id} ->
+            case UnitaresLeasePlane.status(surface_id) do
+              {:ok, nil} ->
+                json(conn, 200, %{ok: true, lease: nil})
+
+              {:ok, lease} ->
+                json(conn, 200, %{ok: true, lease: present_lease(lease)})
+
+              {:error, reason} ->
+                Logger.error("lease plane status failed: #{inspect(reason)}")
+                json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
+            end
         end
     end
   end
@@ -230,10 +244,24 @@ defmodule UnitaresLeasePlane.HTTPRouter do
     # Caller-supplied surface_kind in the body is silently ignored.
     required = ["surface_id", "holder_agent_uuid", "holder_kind", "ttl_s"]
     missing = Enum.filter(required, fn k -> is_nil(Map.get(body, k)) end)
+    raw_surface_id = Map.get(body, "surface_id")
+
+    # PR 7 — server-side canonicalization (RFC v0.8 §7.12.1). Mirror of the
+    # Python field_validator on AcquireRequest.surface_id; prevents split-brain
+    # from non-Python callers (curl, future Hermes/Codex/Elixir clients).
+    canonical_or_error =
+      if is_binary(raw_surface_id), do: Canonicalize.canonicalize(raw_surface_id), else: nil
 
     cond do
       missing != [] ->
         {:error, "missing required fields: #{Enum.join(missing, ", ")}"}
+
+      not is_binary(raw_surface_id) ->
+        {:error, "surface_id must be a string"}
+
+      match?({:error, _}, canonical_or_error) ->
+        {:error, reason} = canonical_or_error
+        {:error, "surface_id canonicalization failed: #{reason}"}
 
       Map.get(body, "holder_class") not in [nil, "process_instance", "substrate_earned"] ->
         # 'role' and other classes are rejected before the DB CHECK — surface this
@@ -247,9 +275,11 @@ defmodule UnitaresLeasePlane.HTTPRouter do
         {:error, "ttl_s must be in (0, 3600]"}
 
       true ->
+        {:ok, canonical_surface_id} = canonical_or_error
+
         {:ok,
          %{
-           surface_id: body["surface_id"],
+           surface_id: canonical_surface_id,
            holder_agent_uuid: body["holder_agent_uuid"],
            holder_class: Map.get(body, "holder_class", "process_instance"),
            holder_kind: body["holder_kind"],

--- a/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
@@ -268,6 +268,9 @@ defmodule UnitaresLeasePlane.Repo do
     end
   end
 
+  # surface_kind dropped from reacquire INSERT per RFC v0.8 §7.2.3 — generated
+  # from surface_id post-026. PR 1 fixed this for acquire; the handoff path was
+  # missed and surfaced when 026-029 were applied to the live DB on 2026-05-02.
   defp transition_handoff(conn, old_lease, handoff) do
     release_sql = """
     UPDATE lease_plane.surface_leases
@@ -277,12 +280,12 @@ defmodule UnitaresLeasePlane.Repo do
 
     insert_sql = """
     INSERT INTO lease_plane.surface_leases
-      (surface_id, surface_kind, holder_agent_uuid, holder_class,
+      (surface_id, holder_agent_uuid, holder_class,
        holder_kind, holder_pid, heartbeat_required, intent,
        expires_at, original_ttl_s, audit_session, earned_status)
     VALUES
-      ($1, $2, $3, $4, 'remote_heartbeat', NULL, true, $5,
-       now() + make_interval(secs => $6), $6, $7, 'provisional')
+      ($1, $2, $3, 'remote_heartbeat', NULL, true, $4,
+       now() + make_interval(secs => $5), $5, $6, 'provisional')
     RETURNING #{@select_lease_columns}
     """
 
@@ -291,7 +294,6 @@ defmodule UnitaresLeasePlane.Repo do
 
     args = [
       old_lease.surface_id,
-      old_lease.surface_kind,
       uuid_to_binary(handoff.to_holder_agent_uuid),
       old_lease.holder_class,
       intent,

--- a/elixir/lease_plane/test/canonicalize_test.exs
+++ b/elixir/lease_plane/test/canonicalize_test.exs
@@ -1,0 +1,245 @@
+defmodule UnitaresLeasePlane.CanonicalizeTest do
+  use ExUnit.Case, async: true
+
+  alias UnitaresLeasePlane.Canonicalize
+
+  # ---------- scheme dispatch + invalid schemes ----------
+
+  describe "scheme dispatch" do
+    test "rejects unknown scheme" do
+      assert {:error, :invalid_scheme} = Canonicalize.canonicalize("ftp://example.com/path")
+    end
+
+    test "rejects bare path with no scheme" do
+      assert {:error, :invalid_scheme} = Canonicalize.canonicalize("/just/a/path")
+    end
+
+    test "rejects empty string" do
+      assert {:error, :invalid_scheme} = Canonicalize.canonicalize("")
+    end
+
+    test "rejects non-string input" do
+      assert {:error, :invalid_scheme} = Canonicalize.canonicalize(nil)
+      assert {:error, :invalid_scheme} = Canonicalize.canonicalize(:atom)
+      assert {:error, :invalid_scheme} = Canonicalize.canonicalize(123)
+    end
+
+    test "canonical_schemes/0 returns the v0.8 list" do
+      assert Canonicalize.canonical_schemes() == ~w(file dialectic resident capture td)
+    end
+  end
+
+  # ---------- NUL byte + length guards ----------
+
+  describe "input guards" do
+    test "rejects NUL byte" do
+      assert {:error, :nul_byte} = Canonicalize.canonicalize("dialectic:/with\0null")
+    end
+
+    test "rejects ? at top level across ALL schemes (parity with Python _validate_surface_id)" do
+      # PR 7 council BLOCK B1 (architect): Python rejects `?` BEFORE per-scheme
+      # dispatch per RFC §7.12.4 OPERATOR_NOTE 3. Elixir must too — otherwise
+      # `dialectic:/abc?x=1` flows through Elixir but gets rejected by Python,
+      # which is the exact split-brain class this module exists to prevent.
+      assert {:error, :reserved_query_string} =
+               Canonicalize.canonicalize("dialectic:/abc?x=1")
+
+      assert {:error, :reserved_query_string} =
+               Canonicalize.canonicalize("resident:/q?x=1")
+
+      assert {:error, :reserved_query_string} =
+               Canonicalize.canonicalize("capture:/A?,B")
+
+      assert {:error, :reserved_query_string} =
+               Canonicalize.canonicalize("td:/x?y")
+
+      assert {:error, :reserved_query_string} =
+               Canonicalize.canonicalize("file:///foo?bar")
+    end
+
+    test "rejects path longer than PATH_MAX (4096)" do
+      long = String.duplicate("x", 4090)
+      input = "resident:/" <> long
+      assert byte_size(input) > 4096
+      assert {:error, :path_too_long} = Canonicalize.canonicalize(input)
+    end
+
+    test "accepts path exactly at PATH_MAX" do
+      # "resident:/" is 10 bytes; pad to exactly 4096.
+      payload = String.duplicate("x", 4096 - 10)
+      input = "resident:/" <> payload
+      assert byte_size(input) == 4096
+      assert {:ok, _} = Canonicalize.canonicalize(input)
+    end
+  end
+
+  # ---------- dialectic:/ ----------
+
+  describe "dialectic:/" do
+    test "lowercases the path" do
+      assert {:ok, "dialectic:/session-abc"} =
+               Canonicalize.canonicalize("dialectic:/SESSION-Abc")
+    end
+
+    test "preserves an already-lowercase id" do
+      assert {:ok, "dialectic:/session-xyz-123"} =
+               Canonicalize.canonicalize("dialectic:/session-xyz-123")
+    end
+
+    test "is idempotent" do
+      input = "dialectic:/MIXED-Case-789"
+      {:ok, once} = Canonicalize.canonicalize(input)
+      {:ok, twice} = Canonicalize.canonicalize(once)
+      assert once == twice
+    end
+  end
+
+  # ---------- resident:/ ----------
+
+  describe "resident:/" do
+    test "preserves case (case-sensitive)" do
+      assert {:ok, "resident:/Watcher_Cycle"} =
+               Canonicalize.canonicalize("resident:/Watcher_Cycle")
+    end
+
+    test "strips trailing slash" do
+      assert {:ok, "resident:/watcher_cycle"} =
+               Canonicalize.canonicalize("resident:/watcher_cycle/")
+    end
+
+    test "rejects whitespace in path" do
+      assert {:error, :invalid_scheme} =
+               Canonicalize.canonicalize("resident:/with space")
+
+      assert {:error, :invalid_scheme} =
+               Canonicalize.canonicalize("resident:/with\ttab")
+
+      assert {:error, :invalid_scheme} =
+               Canonicalize.canonicalize("resident:/with\nnewline")
+    end
+
+    test "rejects # and & (URL reserved chars; ? is caught at top level)" do
+      assert {:error, :invalid_scheme} = Canonicalize.canonicalize("resident:/h#frag")
+      assert {:error, :invalid_scheme} = Canonicalize.canonicalize("resident:/a&b")
+    end
+
+    test "does NOT reject \\r/\\f/\\v (parity: only space/tab/newline are reserved per Python)" do
+      # PR 7 council BLOCK 1 (reviewer): Elixir's prior `~r/[\\s?#&]/u` rejected
+      # \\r/\\f/\\v plus Unicode whitespace, but Python only rejects (' ', '\\t',
+      # '\\n'). Lock in the parity so future regex edits don't silently
+      # over-reject.
+      assert {:ok, _} = Canonicalize.canonicalize("resident:/path\rwith_cr")
+      assert {:ok, _} = Canonicalize.canonicalize("resident:/path\fwith_ff")
+      assert {:ok, _} = Canonicalize.canonicalize("resident:/path\vwith_vt")
+    end
+
+    test "is idempotent" do
+      {:ok, once} = Canonicalize.canonicalize("resident:/watcher_scan_commits_repo/")
+      {:ok, twice} = Canonicalize.canonicalize(once)
+      assert once == twice
+    end
+  end
+
+  # ---------- capture:/ ----------
+
+  describe "capture:/" do
+    test "sorts member list lexically" do
+      assert {:ok, "capture:/A,B,C"} = Canonicalize.canonicalize("capture:/B,A,C")
+    end
+
+    test "preserves an already-sorted list" do
+      assert {:ok, "capture:/A,B,C"} = Canonicalize.canonicalize("capture:/A,B,C")
+    end
+
+    test "trims whitespace around members" do
+      assert {:ok, "capture:/A,B,C"} = Canonicalize.canonicalize("capture:/ B , A , C ")
+    end
+
+    test "drops empty members from leading/trailing/double commas" do
+      assert {:ok, "capture:/A,B"} = Canonicalize.canonicalize("capture:/,A,,B,")
+    end
+
+    test "single member is preserved" do
+      assert {:ok, "capture:/only"} = Canonicalize.canonicalize("capture:/only")
+    end
+
+    test "is idempotent" do
+      input = "capture:/zeta,alpha,gamma"
+      {:ok, once} = Canonicalize.canonicalize(input)
+      {:ok, twice} = Canonicalize.canonicalize(once)
+      assert once == twice
+      assert once == "capture:/alpha,gamma,zeta"
+    end
+  end
+
+  # ---------- td:/ ----------
+
+  describe "td:/" do
+    test "passes through unchanged (reserved scheme)" do
+      assert {:ok, "td:/eisv_basin_v31"} =
+               Canonicalize.canonicalize("td:/eisv_basin_v31")
+    end
+
+    test "preserves nested path components" do
+      assert {:ok, "td:/project/network/v1"} =
+               Canonicalize.canonicalize("td:/project/network/v1")
+    end
+
+    test "td:/ with empty path passes through (parity with Python)" do
+      # PR 7 council CONCERN C5 (architect): pin the empty-path behavior so
+      # neither implementation drifts. RFC v0.8 doesn't require validation
+      # beyond the prefix; both languages pass through.
+      assert {:ok, "td:/"} = Canonicalize.canonicalize("td:/")
+    end
+  end
+
+  # ---------- file:// (deferred normalization) ----------
+
+  describe "file:// (deferred normalization)" do
+    test "accepts prefix without realpath/case normalization" do
+      # Per moduledoc: file:// canonicalization is deferred to a follow-up PR.
+      # This pass validates the prefix and pass-through; the DB grammar CHECK
+      # still enforces the scheme.
+      assert {:ok, "file:///Users/X/foo"} =
+               Canonicalize.canonicalize("file:///Users/X/foo")
+    end
+
+    test "passes through case + trailing slash unchanged for now" do
+      # When file:// canonicalization lands, this case will need revisiting:
+      # macOS APFS is case-insensitive by default and would lowercase, plus
+      # strip trailing /.
+      assert {:ok, "file:///Users/X/foo/"} =
+               Canonicalize.canonicalize("file:///Users/X/foo/")
+    end
+
+    test "still rejects NUL byte even in file://" do
+      assert {:error, :nul_byte} =
+               Canonicalize.canonicalize("file:///has\0null")
+    end
+  end
+
+  # ---------- cross-language parity (Python ↔ Elixir) ----------
+
+  describe "cross-language parity with Python canonicalize.py" do
+    # These pairs MUST produce the same output as the Python helper at
+    # src/lease_plane/canonicalize.py for the four implemented schemes.
+    # Lock this in so future drift between the two implementations is caught
+    # by `mix test` in CI rather than at production split-brain time.
+    parity_cases = [
+      {"dialectic:/Session-ABC", "dialectic:/session-abc"},
+      {"dialectic:/already-lower", "dialectic:/already-lower"},
+      {"resident:/Watcher_Cycle/", "resident:/Watcher_Cycle"},
+      {"resident:/sentinel_cycle", "resident:/sentinel_cycle"},
+      {"capture:/B,A,C", "capture:/A,B,C"},
+      {"capture:/ x , y , z ", "capture:/x,y,z"},
+      {"capture:/,A,,B,", "capture:/A,B"},
+      {"td:/eisv_basin_v31", "td:/eisv_basin_v31"}
+    ]
+
+    for {input, expected} <- parity_cases do
+      test "matches Python output for #{inspect(input)}" do
+        assert {:ok, unquote(expected)} = Canonicalize.canonicalize(unquote(input))
+      end
+    end
+  end
+end

--- a/elixir/lease_plane/test/http_router_test.exs
+++ b/elixir/lease_plane/test/http_router_test.exs
@@ -164,18 +164,80 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
       # Server echoes surface_kind from the generated column on the lease record.
       assert payload["lease"]["surface_kind"] == "dialectic"
     end
+
+    test "PR 7 — non-canonical scheme → 422 schema_invalid", _ctx do
+      body = acquire_body("ftp://nope")
+      resp = post_json("/v1/lease/acquire", body)
+
+      assert resp.status == 422
+      payload = parsed(resp)
+      assert payload["error"] == "schema_invalid"
+      assert payload["detail"] =~ "canonicalization failed"
+      assert payload["detail"] =~ "invalid_scheme"
+    end
+
+    test "PR 7 — capture:/ unsorted members → server stores canonical (sorted)" do
+      # Per PR 7 council BLOCK 2 (reviewer): construct surface_canonical via
+      # the Canonicalize helper itself, not by hand. This eliminates the
+      # correct-by-coincidence alphabetical-ordering dependency and ensures
+      # cleanup targets the same row even if canonicalize ever changes.
+      rand = Base.encode16(:crypto.strong_rand_bytes(4), case: :lower)
+      surface_in = "capture:/test_zeta_#{rand},test_alpha,test_gamma"
+      {:ok, surface_canonical} = UnitaresLeasePlane.Canonicalize.canonicalize(surface_in)
+      on_exit(fn -> cleanup_surface(surface_canonical) end)
+
+      body = acquire_body(surface_in)
+      resp = post_json("/v1/lease/acquire", body)
+
+      assert resp.status == 200
+      lease = parsed(resp)["lease"]
+      # Canonicalization happened server-side: stored surface_id is sorted.
+      assert lease["surface_id"] == surface_canonical
+      # Ditto for the generated surface_kind column.
+      assert lease["surface_kind"] == "capture"
+    end
+
+    test "PR 7 — dialectic:/ uppercase → server stores canonical (lowercased)" do
+      rand = Base.encode16(:crypto.strong_rand_bytes(4), case: :lower)
+      surface_in = "dialectic:/Test_Elixir_PR7_#{rand}"
+      surface_canonical = String.downcase(surface_in)
+      on_exit(fn -> cleanup_surface(surface_canonical) end)
+
+      body = acquire_body(surface_in)
+      resp = post_json("/v1/lease/acquire", body)
+
+      assert resp.status == 200
+      assert parsed(resp)["lease"]["surface_id"] == surface_canonical
+    end
   end
 
   describe "GET /v1/lease/status" do
     test "unknown surface → ok with lease=nil" do
       resp =
         :get
-        |> conn("/v1/lease/status?surface_id=test:elixir/http/never-acquired")
+        |> conn("/v1/lease/status?surface_id=dialectic:/test_elixir_http_never_acquired")
         |> authed()
         |> HTTPRouter.call(@opts)
 
       assert resp.status == 200
       assert parsed(resp)["lease"] == nil
+    end
+
+    test "non-canonical scheme → 422 schema_invalid" do
+      # PR 7 — server-side canonicalization rejects schemes outside the v0.8
+      # canonical list. Pre-PR-7 this would have hit the underlying status
+      # query and returned nil; post-PR-7 it's a typed-absence error.
+      resp =
+        :get
+        |> conn("/v1/lease/status?surface_id=ftp://nope")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 422
+      body = parsed(resp)
+      assert body["error"] == "schema_invalid"
+      assert body["detail"] =~ "canonicalization failed"
+      assert body["detail"] =~ "invalid_scheme"
     end
 
     test "active surface → ok with lease record", ctx do

--- a/elixir/lease_plane/test/support/lease_test_helpers.ex
+++ b/elixir/lease_plane/test/support/lease_test_helpers.ex
@@ -16,7 +16,11 @@ defmodule LeaseTestHelpers do
   `test:elixir/...` which the grammar CHECK rejects.
   """
   def unique_surface_id(label) when is_binary(label) do
-    rand = :crypto.strong_rand_bytes(6) |> Base.url_encode64(padding: false)
+    # Lowercase hex so the generated surface_id is already in canonical form
+    # for the dialectic:/ scheme (which lowercases per RFC §7.12.1). Avoids
+    # spurious round-trip-mismatch failures in tests that don't intend to
+    # exercise canonicalization.
+    rand = :crypto.strong_rand_bytes(6) |> Base.encode16(case: :lower)
     "dialectic:/test_elixir_#{label}_#{rand}"
   end
 


### PR DESCRIPTION
## Summary

Adds server-side `surface_id` canonicalization on the Elixir HTTP router so non-Python callers (curl, future Hermes/Codex/Elixir clients) cannot bypass the Python `AcquireRequest` field_validator and produce split-brain rows in `lease_plane.surface_leases`. Mirrors `src/lease_plane/canonicalize.py` for the four pure-logic schemes (`dialectic`, `resident`, `capture`, `td`); `file://` canonicalization deferred (PR 2.5 migrated all production agents off `file://` to `resident:/`; `Logger.warning` emits on every `file://` ingress as deferral audit trail).

Bundles a one-line surgical fix to `repo.ex::transition_handoff` dropping `surface_kind` from the reacquire INSERT — same RFC §7.2.3 root cause as the PR 1 acquire-path fix; was missed and surfaced when migrations 026-029 hit the live `governance` DB.

## Migration-apply gap (operator action 2026-05-02 02:26 local)

KG finding [`2026-05-02T08:22:47.029541+00:00`](https://gov.cirwel.org/kg) documents that migrations 026-029 (lease_plane grammar + deprecation + trigger fix + earned_status guard) had never been applied to the live `governance` DB despite shipping in PRs #264, #269, #273. `core.schema_migrations` only had versions 24, 25. Operator authorized apply; baseline went from 22/49 mix tests failing to 0/49.

## Council pass (3 agents, adversarial framing per `feedback_council-adversarial-prompt.md`)

Two BLOCKs surfaced and fixed:

- **Architect B1**: top-level `?`-rejection (RFC §7.12.4 OPERATOR_NOTE 3) was missing — Elixir only rejected `?` inside `resident:/`. Added `:reserved_query_string` reason at top level.
- **Reviewer B1**: `~r/[\s?#&]/u` over-rejected — PCRE `\s` matches `\r`/`\f`/`\v` plus Unicode whitespace; Python rejects exactly `(' ', '\t', '\n')`. Replaced with `~r/[ \t\n#&]/`.
- **Reviewer B2**: HTTP capture test `surface_canonical` was correct-by-coincidence; refactored to use `Canonicalize.canonicalize/1` directly so cleanup targets the actual stored row.

Plus addressed CONCERNs: `file://` `Logger.warning` audit trail, `td:/` empty-path parity test, byte_size-vs-len divergence doc note, capture:/ comma-in-member doc note, pattern-match prefix dispatch instead of `binary_part`.

Live-verifier: 5/5 verifiable claims VERIFIED (migrations applied, grammar CHECK rejects bad scheme, mix test 91 passing, both `surface_leases` INSERT paths clean, no production `file://` use, no test-tree base64url remnants).

## RFC gate → code surface → test name → status

See `docs/proposals/surface-lease-plane-phase-a-plan.md` "PR 7" section. Seven rows (within ≤10 methodology cap).

## Test plan

- [x] `mix test` from `elixir/lease_plane/`: **91 tests, 0 failures** (was 49 with 22 failing on master pre-migration-apply)
- [x] `./scripts/dev/test-cache.sh`: 8064 Python passed, 34 skipped, 0 failed
- [x] Single-writer surface check: `gh pr list --search "canonicalize OR elixir router"` returned empty
- [ ] Operator: confirm migrations 026-029 visible on dashboard (`SELECT version FROM core.schema_migrations`)

## Surface-collision check

Migration 026-029 already applied (operator action 2026-05-02 02:26 local, pre-PR). Elixir lease_plane Canonicalize module is new code, no existing surface to collide with. http_router.ex changes are additive (extra `cond` branch + `case` wrapper) — preserve all existing behavior for canonical inputs.