### PR TITLE
fix(lease-plane): SAVEPOINT race-recovery in acquire_step + concurrent test

### DIFF
--- a/elixir/lease_plane/config/test.exs
+++ b/elixir/lease_plane/config/test.exs
@@ -4,6 +4,10 @@ config :lease_plane,
   database_url:
     System.get_env("UNITARES_LEASE_PLANE_DATABASE_URL") ||
       "postgresql://postgres:postgres@localhost:5432/governance",
-  pool_size: 2,
+  # pool_size 10 (was 2) — concurrent-acquire tests
+  # (lease_acquire_concurrency_test.exs) need genuine in-flight transactions
+  # to surface the race window. With pool_size 2 the test could pass on
+  # bug-present code under serialization pressure (council CONCERN 1).
+  pool_size: 10,
   start_application: false,
   start_workers: false

--- a/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
@@ -100,7 +100,18 @@ defmodule UnitaresLeasePlane.Repo do
     end
   end
 
-  defp acquire_step(conn, p, nil) do
+  defp acquire_step(conn, p, nil), do: acquire_step_nil(conn, p, 0)
+
+  # Bounded recursion depth for the {:ok, nil} race-loop (council BLOCK C1).
+  # 3 iterations is well above the practical maximum for the triple-race
+  # (winner inserted, winner released, loser re-reads) — anything more
+  # is a flapping pathology and deserves a typed error rather than infinite
+  # recursion.
+  defp acquire_step_nil(_conn, _p, depth) when depth > 3 do
+    {:error, :race_storm}
+  end
+
+  defp acquire_step_nil(conn, p, depth) do
     # surface_kind dropped from INSERT column list per RFC v0.8 §7.2.3:
     # post-migration-026 it is a generated column derived from
     # split_part(surface_id, ':', 1). Including it here would raise
@@ -128,10 +139,54 @@ defmodule UnitaresLeasePlane.Repo do
       Map.get(p, :audit_session)
     ]
 
-    with {:ok, %{rows: [row], columns: cols}} <- Postgrex.query(conn, insert_lease_sql, args),
-         lease = row_to_map(cols, row),
-         :ok <- log_event(conn, "acquire", lease) do
-      {:ok, {:ok, lease, :new}}
+    # Unique savepoint name per call — defends against future refactors that
+    # could cause two acquire_step_nil calls on the same connection (which
+    # would silently rewind state on a shared savepoint name). Council BLOCK 1.
+    savepoint = "acquire_insert_#{:erlang.unique_integer([:positive])}"
+
+    # Savepoint isolates a unique_violation to the INSERT (not the whole tx),
+    # allowing race-recovery via re-read + re-dispatch. Without this,
+    # concurrent acquires on the same surface_id leak raw Postgrex.Error
+    # tuples instead of typed-absence responses — surfaced by
+    # lease_acquire_concurrency_test.exs.
+    Postgrex.query!(conn, "SAVEPOINT #{savepoint}", [])
+
+    case Postgrex.query(conn, insert_lease_sql, args) do
+      {:ok, %{rows: [row], columns: cols}} ->
+        Postgrex.query!(conn, "RELEASE SAVEPOINT #{savepoint}", [])
+        lease = row_to_map(cols, row)
+
+        case log_event(conn, "acquire", lease) do
+          :ok -> {:ok, {:ok, lease, :new}}
+          {:error, e} -> {:error, e}
+        end
+
+      # Match on :unique_violation alone (not constraint name) so a future
+      # rename of `surface_leases_active_unique` doesn't silently leak raw
+      # errors. The `surface_leases` table has only one unique index (the
+      # active-unique partial index from migration 024), so any
+      # unique_violation here is the same race. Council BLOCK 2.
+      {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} ->
+        Postgrex.query!(conn, "ROLLBACK TO SAVEPOINT #{savepoint}", [])
+        recover_race(conn, p, depth)
+
+      {:error, e} ->
+        Postgrex.query(conn, "ROLLBACK TO SAVEPOINT #{savepoint}", [])
+        {:error, e}
+    end
+  end
+
+  # Race recovery: re-read the winning row and re-dispatch through
+  # acquire_step/3 so the existing-row branch handles same-holder
+  # (idempotent) vs different-holder (held_by_other) uniformly.
+  # If the winner was released between the unique_violation and our
+  # re-read (extreme triple-race), loop the INSERT instead of bailing —
+  # the surface is now free, retry should succeed (council BLOCK C1).
+  defp recover_race(conn, p, depth) do
+    case maybe_existing_active(conn, p.surface_id) do
+      {:ok, %{} = winner} -> acquire_step(conn, p, winner)
+      {:ok, nil} -> acquire_step_nil(conn, p, depth + 1)
+      {:error, e} -> {:error, e}
     end
   end
 

--- a/elixir/lease_plane/test/lease_acquire_concurrency_test.exs
+++ b/elixir/lease_plane/test/lease_acquire_concurrency_test.exs
@@ -1,0 +1,154 @@
+defmodule UnitaresLeasePlane.AcquireConcurrencyTest do
+  @moduledoc """
+  Concurrent-acquire load tests for `UnitaresLeasePlane`.
+
+  Existing `unitares_lease_plane_test.exs` covers acquire/release/handoff
+  behavior serially: do A, then B, expect outcome. The lease plane's
+  load-bearing invariant — exactly-one-winner under concurrent acquire on
+  the same surface_id — only manifests under parallel pressure. Serial
+  tests can't catch it.
+
+  These tests spawn N tasks via `Task.async_stream` (default concurrency =
+  schedulers, so genuine parallelism on multi-core macOS), all racing the
+  same operation. They assert the contract holds:
+
+  - **Exactly one winner** (different holders racing same surface_id)
+  - **Idempotent winner** (same holder racing same surface_id — all return
+    the same lease)
+  - **Exactly one accept** (N tasks racing handoff_accept on same handoff_id)
+
+  `async: false` because every test reuses the same DB schema; concurrent
+  test files would interleave inserts/deletes and corrupt cleanup.
+  """
+
+  use ExUnit.Case, async: false
+
+  import LeaseTestHelpers
+
+  alias UnitaresLeasePlane
+
+  # 50 racers is enough to surface a race in the typical case without
+  # blowing up CI runtime. Each Task spawns a Postgrex connection request
+  # so we're bounded by the test pool size (configured pool_size: 2 per
+  # config/test.exs). Tasks that don't get a connection slot wait, which
+  # is fine — the race window is checkout-then-INSERT, not the spawn.
+  @racer_count 50
+
+  describe "concurrent acquire — different holders" do
+    @tag :capture_log
+    test "exactly one of #{@racer_count} racers wins; the rest get held_by_other" do
+      surface = unique_surface_id("conc_diff")
+      on_exit(fn -> cleanup_surface(surface) end)
+
+      results =
+        1..@racer_count
+        |> Task.async_stream(
+          fn _i ->
+            params = local_beam_params(surface)
+            UnitaresLeasePlane.acquire_local_beam(params)
+          end,
+          max_concurrency: System.schedulers_online() * 2,
+          timeout: 15_000
+        )
+        |> Enum.map(fn {:ok, result} -> result end)
+
+      winners = Enum.filter(results, &match?({:ok, _, :new}, &1))
+      held = Enum.filter(results, &match?({:error, :held_by_other, _}, &1))
+      other = results -- (winners ++ held)
+
+      assert length(winners) == 1,
+             "exactly-one-winner invariant violated: expected 1 winner, got #{length(winners)}.\n  results: #{inspect(results)}"
+
+      assert length(held) == @racer_count - 1,
+             "expected #{@racer_count - 1} held_by_other, got #{length(held)}.\n  unaccounted: #{inspect(other)}"
+
+      assert other == [],
+             "all responses must classify as winner or held_by_other; unclassified: #{inspect(other)}"
+    end
+  end
+
+  describe "concurrent acquire — same holder (idempotency)" do
+    test "all #{@racer_count} racers with same holder_uuid converge to one lease" do
+      surface = unique_surface_id("conc_same")
+      on_exit(fn -> cleanup_surface(surface) end)
+
+      holder = random_uuid()
+      params = local_beam_params(surface, holder_agent_uuid: holder)
+
+      results =
+        1..@racer_count
+        |> Task.async_stream(
+          fn _i -> UnitaresLeasePlane.acquire_local_beam(params) end,
+          max_concurrency: System.schedulers_online() * 2,
+          timeout: 15_000
+        )
+        |> Enum.map(fn {:ok, result} -> result end)
+
+      successes = Enum.filter(results, &match?({:ok, _, _}, &1))
+      failures = results -- successes
+
+      assert length(successes) == @racer_count,
+             "expected all #{@racer_count} same-holder acquires to succeed (idempotent). failures: #{inspect(failures)}"
+
+      lease_ids =
+        successes
+        |> Enum.map(fn {:ok, lease, _} -> lease.lease_id end)
+        |> Enum.uniq()
+
+      assert length(lease_ids) == 1,
+             "idempotent same-holder acquires must converge to a single lease_id. got: #{inspect(lease_ids)}"
+
+      kinds = successes |> Enum.map(fn {:ok, _, kind} -> kind end) |> Enum.frequencies()
+
+      # Exactly one :new is the winner; the rest are :idempotent. We don't
+      # assert order (race is real), just the cardinality.
+      assert kinds[:new] == 1,
+             "exactly one :new is expected (the racer that won the create); got #{inspect(kinds)}"
+
+      assert kinds[:idempotent] == @racer_count - 1,
+             "the remaining #{@racer_count - 1} acquires must be :idempotent; got #{inspect(kinds)}"
+    end
+  end
+
+  describe "concurrent handoff_accept (GenServer.call serialization)" do
+    # Council NIT 1: HandoffServer is a single named GenServer; all accepts
+    # serialize through its mailbox. This test verifies the contract (exactly
+    # one accept honored, rest get :not_found) but does NOT exercise a DB-level
+    # race — the GenServer's serial dispatch makes that impossible by
+    # construction. Kept as a contract test.
+    test "exactly one of N racers wins handoff_accept; the rest get not_found" do
+      surface = unique_surface_id("conc_handoff")
+      on_exit(fn -> cleanup_surface(surface) end)
+
+      holder_a = random_uuid()
+      holder_b = random_uuid()
+
+      {:ok, lease, :new} =
+        UnitaresLeasePlane.acquire_local_beam(
+          local_beam_params(surface, holder_agent_uuid: holder_a, intent: "handoff race source")
+        )
+
+      {:ok, handoff_id} = UnitaresLeasePlane.handoff_offer(lease.lease_id, holder_b, 30)
+
+      racers = 20
+
+      results =
+        1..racers
+        |> Task.async_stream(
+          fn _i -> UnitaresLeasePlane.handoff_accept(handoff_id) end,
+          max_concurrency: System.schedulers_online() * 2,
+          timeout: 15_000
+        )
+        |> Enum.map(fn {:ok, result} -> result end)
+
+      oks = Enum.count(results, &(&1 == :ok))
+      not_found = Enum.count(results, &match?({:error, :not_found}, &1))
+
+      assert oks == 1,
+             "exactly-one-handoff-accept invariant violated: expected 1 :ok, got #{oks}.\n  results: #{inspect(results)}"
+
+      assert oks + not_found == racers,
+             "all responses must be :ok or {:error, :not_found}; unclassified: #{inspect(results -- List.duplicate(:ok, oks))}"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Concurrent acquire on the same `surface_id` was leaking raw `Postgrex.Error{constraint: \"surface_leases_active_unique\"}` instead of returning typed-absence (`:held_by_other` for different holder, `:idempotent` for same holder). In production this manifested as 503 service_unavailable instead of correct 409 / 200. This is the exact split-brain class the lease plane is designed to prevent.

Fix: Postgres SAVEPOINT inside the existing `Postgrex.transaction` wrapper. On `unique_violation`, ROLLBACK TO SAVEPOINT, re-read the winning row, and re-dispatch through `acquire_step/3` so the existing-row branch handles same-holder vs different-holder uniformly.

## Council pass (3 agents, adversarial framing)

Architect + reviewer both verdict SHIP-WITH-FIXES. Live-verifier proved detection by stashing the fix → reproduced `unique_violation` → unstashed.

All applied:

- **BLOCK 1** (reviewer): savepoint name `\"acquire_insert\"` → `\"acquire_insert_#{:erlang.unique_integer([:positive])}\"` so future refactors that recurse through the nil-branch can't silently rewind shared savepoint state
- **BLOCK 2** (reviewer + architect C2): constraint-name match dropped — match on `:unique_violation` alone. `surface_leases` has one unique index; broader match defends against future constraint rename
- **BLOCK C1** (architect + reviewer CONCERN 2): `{:ok, nil}` race-winner-released branch loops `acquire_step_nil` with depth guard (≤3) instead of bailing to 503
- **CONCERN 1** (reviewer): `pool_size: 2 → 10` in `config/test.exs`. With pool_size 2 the test could pass on bug-present code under pool serialization pressure
- **NIT 1** (reviewer): handoff_accept describe block renamed to clarify it's a GenServer-serialization test
- **NIT 4** (reviewer): `@tag :capture_log` on different-holder test to quiet log_conflict noise

## Test plan

- [x] `mix test`: **11 properties + 103 tests, 0 failures** (was 100; +3 from this PR)
- [x] Live-verifier reproduced bug on stashed-fix code; restored after
- [x] Single-writer surface check: `gh pr list --search \"concurrent OR savepoint OR acquire\"` returned empty for `lease-plane`
- [x] PR #280 / #281 / #282 already on master; this branch built off latest

## What this changes

- `lib/unitares_lease_plane/repo.ex::acquire_step/3` — refactored into `acquire_step_nil/3` + `recover_race/3` helpers, with depth guard + unique savepoint name + broader unique_violation match
- `test/lease_acquire_concurrency_test.exs` (new) — 50-racer different-holder, 50-racer same-holder idempotency, 20-racer handoff_accept (GenServer serialization)
- `config/test.exs` — `pool_size: 2 → 10` for genuine in-flight concurrency

## Surface-collision check

`gh pr list -R CIRWEL/unitares --search \"concurrent OR savepoint OR acquire\" --state open` returned empty.