### PR TITLE
feat(lease-plane): R1 — deprecate-and-finalize super-command (RFC §7.11.2 atomicity)

### DIFF
--- a/db/postgres/migrations/030_lease_plane_aborted_event.sql
+++ b/db/postgres/migrations/030_lease_plane_aborted_event.sql
@@ -1,0 +1,67 @@
+-- 030_lease_plane_aborted_event.sql
+--
+-- Extends lease_plane.lease_plane_events.event_type CHECK constraint to include
+-- 'lease.deprecation_aborted' — emitted by the new deprecate-and-finalize
+-- super-command (R1, RFC §7.11.2 atomicity rewrite) when Phase 3 fails after
+-- Phase 2 succeeded. Without an aborted event class, an operator who fails
+-- Phase 3 multiple times has no audit trail of the abandonment (architect
+-- council finding, deferred-from-PR-7 latent gap closed here).
+--
+-- Idempotent: detects prior application by checking whether the existing
+-- CHECK already permits 'lease.deprecation_aborted', and skips the
+-- DROP+ADD when so.
+
+DO $$
+DECLARE
+    migration_already_recorded bool;
+    aborted_already_permitted bool;
+BEGIN
+    -- Council CONCERN 2 (reviewer): primary guard via core.schema_migrations
+    -- so the constraint-text probe (secondary) doesn't risk a double-CHECK if
+    -- the constraint were ever renamed and the migration re-ran.
+    SELECT EXISTS (
+        SELECT 1 FROM core.schema_migrations WHERE version = 30
+    ) INTO migration_already_recorded;
+
+    SELECT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'lease_plane.lease_plane_events'::regclass
+          AND conname = 'lease_plane_events_event_type_check'
+          AND pg_get_constraintdef(oid) LIKE '%lease.deprecation_aborted%'
+    ) INTO aborted_already_permitted;
+
+    IF migration_already_recorded OR aborted_already_permitted THEN
+        RAISE NOTICE 'migration 030: already applied (recorded=% / permitted=%); skipping',
+            migration_already_recorded, aborted_already_permitted;
+    ELSE
+        ALTER TABLE lease_plane.lease_plane_events
+            DROP CONSTRAINT IF EXISTS lease_plane_events_event_type_check;
+        ALTER TABLE lease_plane.lease_plane_events
+            ADD CONSTRAINT lease_plane_events_event_type_check
+            CHECK (
+                event_type IN (
+                    'acquire',
+                    'renew',
+                    'release',
+                    'heartbeat',
+                    'handoff_offer',
+                    'handoff_accept',
+                    'conflict_held_by_other',
+                    'reaped_remote_ttl',
+                    'reaped_local_ttl',
+                    'down_local',
+                    'forced',
+                    'service_unavailable',
+                    'lease.deprecation_marked',
+                    'lease.deprecation_swept',
+                    'lease.deprecation_migrated',
+                    'lease.deprecation_aborted'
+                )
+            );
+        RAISE NOTICE 'migration 030: event_type CHECK extended with lease.deprecation_aborted';
+    END IF;
+END $$;
+
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (30, 'lease_plane_aborted_event', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/docs/operations/lease-plane-operator-runbook.md
+++ b/docs/operations/lease-plane-operator-runbook.md
@@ -64,6 +64,128 @@ UnitaresLeasePlane.Stats.active_lease_count()
 
 The point: when something is wrong, you don't add print statements and redeploy. You attach, look, and decide.
 
+## Deprecating a surface_kind (RFC §7.11.2 — R1 canonical path)
+
+The 4-phase deprecation procedure runs through the Python CLI at
+`scripts/dev/lease_plane_deprecate.py`. R1 (PR #284) introduced
+`deprecate-and-finalize` as the canonical Phase 2+3 super-command; the
+standalone `deprecation-sweep` and `deprecation-finalize` subcommands remain
+as **operator escape hatches** for emergency partial recovery only.
+
+### Canonical sequence (production deprecation)
+
+```bash
+# Phase 0: mark the scheme deprecated (writes deprecated_schemes row,
+#   emits lease.deprecation_marked event)
+python3 scripts/dev/lease_plane_deprecate.py deprecate <kind> --days 30
+
+# Phase 1 (operator-driven): wait the drain window; verify no Elixir source
+#   still references the deprecated scheme (unitares_doctor lint — Phase B prep)
+
+# Phase 2+3: atomic on a single connection, correlated under shared run_id
+python3 scripts/dev/lease_plane_deprecate.py deprecate-and-finalize <kind>
+```
+
+The super-command runs Phase 2 (sweep — force-release surviving leases) and
+Phase 3 (finalize — record `check_migrated_at`) on a single asyncpg
+connection in two transactions. Both phases share a `run_id` (uuid4) that
+appears in every emitted event payload + every log line, so partial
+completion is correlatable in audit queries:
+
+```sql
+SELECT event_type, ts FROM lease_plane.lease_plane_events
+WHERE payload->>'run_id' = '<uuid-from-stderr-log>'
+ORDER BY ts;
+```
+
+### Recovery from partial failure
+
+The super-command uses **two transactions on one connection** (operator
+decision 2026-05-02): if Phase 3 fails after Phase 2 succeeded, the swept
+rows STAY released (no rollback of operator work). The super-command:
+
+1. Emits `lease.deprecation_aborted` event with run_id + reason payload
+2. Logs clear "rerun deprecation-finalize <kind>" guidance to stderr
+3. Returns exit code 3
+
+The §7.11.4 idempotent-sweep predicate makes the rerun safe. To recover:
+
+```bash
+# Fix the underlying issue that caused Phase 3 to fail, then:
+python3 scripts/dev/lease_plane_deprecate.py deprecation-finalize <kind>
+```
+
+### Escape-hatch sub-commands (DO NOT use in routine deprecation)
+
+Use ONLY when the super-command itself is unavailable or has failed in
+ways that prevent normal recovery:
+
+- `deprecation-sweep <kind>` — Phase 2 standalone. Requires
+  `LEASE_FORCE_RELEASE_TOKEN`. Idempotent.
+- `deprecation-finalize <kind>` — Phase 3 standalone. Used as the canonical
+  recovery path after a failed super-command (see "Recovery from partial
+  failure" above).
+
+### Audit query: any abandoned deprecations?
+
+Two queries — run both. The first catches abandons where the super-command
+emitted the abort event before exiting. The second catches the
+SIGKILL-between-phases case (Phase 2 committed, super-command was killed
+before Phase 3 could run, no abort event was written).
+
+```sql
+-- (1) Explicit abandon: abort event emitted
+SELECT
+  payload->>'kind' AS kind,
+  payload->>'run_id' AS run_id,
+  payload->>'reason' AS reason,
+  ts
+FROM lease_plane.lease_plane_events
+WHERE event_type = 'lease.deprecation_aborted'
+ORDER BY ts DESC;
+
+-- (2) Implicit abandon: Phase 2 committed but Phase 3 never ran
+-- (SIGKILL / power loss / OOM mid-super-command)
+SELECT
+  surface_kind,
+  sweep_completed_at,
+  check_migrated_at
+FROM lease_plane.deprecated_schemes
+WHERE sweep_completed_at IS NOT NULL
+  AND check_migrated_at IS NULL
+ORDER BY sweep_completed_at DESC;
+```
+
+If a row appears in either query for `<kind>`, that deprecation is in
+"swept but unfinalized" state. Recovery: rerun
+`deprecation-finalize <kind>` (the §7.11.4 idempotent-sweep predicate
+makes this safe even if Phase 2 is also re-attempted via the super-command).
+
+### Recovery from SIGKILL mid-Phase-2
+
+If `deprecate-and-finalize` was killed (SIGKILL, OOM, parent-process death)
+while Phase 2 was running, the in-flight transaction is rolled back by
+Postgres when it detects the dead client. Until that happens, row-level
+locks (`FOR UPDATE SKIP LOCKED`) on `lease_plane.surface_leases` rows for
+the deprecated kind may be held. To inspect:
+
+```sql
+-- Check for stuck backends with active transactions on surface_leases
+SELECT pid, state, query_start, wait_event, query
+FROM pg_stat_activity
+WHERE state IN ('active', 'idle in transaction')
+  AND query LIKE '%lease_plane.surface_leases%'
+ORDER BY query_start;
+```
+
+Postgres has no `idle_in_transaction_session_timeout` by default, so a
+stuck backend may persist indefinitely until the operator either: (a)
+restores the killed super-command (it'll observe its tx was lost), (b)
+manually `pg_terminate_backend(<pid>)` the stuck backend, or (c) restarts
+Postgres. Once the stuck backend is gone, rerun `deprecate-and-finalize <kind>`
+— Phase 2 will sweep zero rows (idempotent predicate) and Phase 3 will
+finalize cleanly.
+
 ## Common operations
 
 TBD. Will include:

--- a/docs/proposals/surface-lease-plane-phase-a-plan.md
+++ b/docs/proposals/surface-lease-plane-phase-a-plan.md
@@ -305,12 +305,47 @@ Live-verifier: 9/10 verifiable claims VERIFIED (1 BLOCKED — no deployed Elixir
 
 **Total: 10 rows in PR 7.5. At the methodology cap.**
 
+## R1 — `deprecate-and-finalize` super-command (this branch: impl/lease-plane-r1-deprecate-supercommand)
+
+Closes the §7.11.2 atomicity residual that PR 5 deferred. Pre-R1 state was a 3-way contradiction shipped under PR 5's "council saw it, deferred it" stamp: (a) RFC v0.8 §7.11.2 line 775 commits to "same operator session" for Phases 2+3 (closing v0.7 dialectic BLOCK-E + code-reviewer BLOCK-3), (b) §9 named gate `test_deprecation_sweep_and_check_migration_atomic_session` codified that commitment, (c) the CLI implementation went multi-step with no cross-invocation session binding, (d) the named test was never written. R1 picks the code-not-discipline side per `feedback_memory-not-guardrail.md` (load-bearing safety in code, tests, type systems — not natural-language warnings).
+
+**Operator decisions captured 2026-05-02:**
+1. **Option A1**: super-command + keep singletons as escape-hatches (architect council recommendation)
+2. **Two-tx-one-connection**: code-enforces "same operator session" at the DB wire level (single asyncpg connection across both phases) without rolling back successful Phase 2 sweep work if Phase 3 finalize fails
+3. **Shared `run_id` (uuid4)** in logs + every event payload so partial completion is operator-visible and rerunnable via audit query (`SELECT ... WHERE payload->>'run_id' = '<uuid>'`)
+4. **`lease.deprecation_aborted` event class** added (closes the latent ontology gap architect surfaced — operators who fail Phase 3 thrice and give up now have an audit trail)
+
+Scope shipped:
+- `db/postgres/migrations/030_lease_plane_aborted_event.sql` — extends `lease_plane_events_event_type_check` to permit `lease.deprecation_aborted`. Idempotent.
+- `scripts/dev/lease_plane_deprecate.py` refactored: `_sweep_inner(conn, *, kind, deprecation_id, run_id)` and `_finalize_inner(conn, *, kind, run_id)` extracted from existing commands; new `deprecate_and_finalize_cmd(*, kind, db_url)` opens one connection, runs both phases in two transactions correlated by run_id; `_emit_aborted_event(conn, *, kind, deprecation_id, run_id, reason)` emits the abort event in its own short tx on Phase 3 failure.
+- `_payload_with_run_id(base, run_id)` helper threads run_id into existing event payloads (Phase 0 mark, sweep, migrated). Singletons pass `run_id=None`; field omitted to preserve existing payload shapes.
+- Operator runbook (`docs/operations/lease-plane-operator-runbook.md`): canonical sequence + recovery playbook + "any abandoned deprecations?" audit query.
+- Singleton sub-commands' `--help` text marked **ESCAPE HATCH — prefer `deprecate-and-finalize`**.
+
+### R1 — RFC gate → code surface → test name → status table
+
+| Gate | Code | Test | Status |
+|------|------|------|--------|
+| §7.11.2 same-operator-session invariant on a single asyncpg connection across Phase 2+3 | `scripts/dev/lease_plane_deprecate.py::deprecate_and_finalize_cmd` | `test_deprecation_sweep_and_check_migration_atomic_session` (the named §9 gate, finally implementable) | DONE |
+| §7.11.2 two-tx-one-connection: Phase 3 failure preserves Phase 2 work + emits aborted event | `deprecate_and_finalize_cmd` Phase 3 try/except → `_emit_aborted_event` | `test_deprecate_and_finalize_phase_3_failure_emits_aborted_event` | DONE |
+| §7.11.4 idempotent rerun: standalone `deprecation-finalize` succeeds after super-command Phase 3 failure | `deprecation_finalize_cmd` (now a thin wrapper around `_finalize_inner`) | `test_deprecate_and_finalize_phase_3_failure_then_rerun_finalize_succeeds` | DONE |
+| Shared run_id correlates all events from one super-command run | `_payload_with_run_id` + run_id threading through `_sweep_inner` + `_finalize_inner` + `_emit_aborted_event` | `test_deprecate_and_finalize_run_id_correlates_across_events` | DONE |
+| §7.11.3 `lease.deprecation_aborted` event class permitted at DB layer | `db/postgres/migrations/030_lease_plane_aborted_event.sql` (idempotency: primary `core.schema_migrations` guard + secondary constraint-text probe) | (covered transitively by the abort-emission test — INSERT would fail without the migration) | DONE |
+| Concurrent super-commands on same kind serialize via `pg_try_advisory_lock` | `deprecate_and_finalize_cmd` lock acquisition + rc=4 fail-fast on contention | `test_deprecate_and_finalize_advisory_lock_blocks_concurrent_invocation` | DONE (council CONCERN 3 fix) |
+| Abort-emission failure surfaces rc=3 + rerun guidance, not a stack trace | `deprecate_and_finalize_cmd` Phase 3 except branch wraps `_emit_aborted_event` in try/except | `test_deprecate_and_finalize_abort_emission_failure_still_returns_rc_3` | DONE (council BLOCK 1 fix) |
+| `sweep_completed_at` preserves first-completion timestamp across re-runs (audit non-drift) | `_sweep_inner` uses `COALESCE(sweep_completed_at, now())` | (covered transitively by existing rerun test — second invocation must not bump sweep_completed_at) | DONE (council CONCERN 4 fix) |
+| Operator runbook companion query: SIGKILL-between-phases detection | `docs/operations/lease-plane-operator-runbook.md` "any abandoned deprecations?" — second query for `sweep_completed_at IS NOT NULL AND check_migrated_at IS NULL` | (no test; doc-only) | DONE (council BLOCK 2 fix) |
+| §9 RFC named-gate for `lease.deprecation_aborted` test | (deferred to §9 reconciliation residual — see PR 8+ section) | `test_deprecate_and_finalize_phase_3_failure_emits_aborted_event` already exists in this PR; §9 list update is tracked in §9 reconciliation residual scope | DEFERRED |
+| Singleton sub-commands clearly marked as escape-hatch in `--help` and module docstring | `_build_parser` help= text + module docstring | (golden output not pinned by test; reviewer checklist) | DONE |
+| Operator runbook documents canonical sequence + recovery playbook + abandoned-deprecation audit query | `docs/operations/lease-plane-operator-runbook.md` | (no test; doc-only) | DONE |
+
+**Total: 7 rows in R1. Within the ≤10 methodology cap.**
+
 ## PR 8+ — Remaining deferred council CONCERNs and Phase B prerequisites
 
 Bigger council CONCERNs (need design discussion):
-- §7.11.2 Phase 2/3 atomicity rewrite — CLI sub-commands don't enforce same-session atomicity. Either coalesce into `deprecate-and-finalize` super-command or amend RFC §7.11.2.
-- Sentinel asyncpg pool wiring (CLAUDE.md anyio pattern; current code opens fresh connection per cycle).
-- §9 RFC test-name reconciliation (named tests semantically covered but not under contracted names).
+- Sentinel asyncpg pool wiring — `agents/sentinel/forced_release_alarm.py` opens a fresh asyncpg connection per cycle. Per the architect/reviewer disagreement (architect: separate process, hygiene fix only; reviewer: cites `agents/sentinel/agent.py:67` comment naming a prior 30h wedge from this exact anyio-asyncio class, recommends `run_in_executor` + `_poll_sync` wrapping `asyncio.run(...)`). Reviewer's framing has stronger code-level evidence; default to that. Council scope: 3-agent with live-verifier on the asyncio.run-in-executor + asyncpg loop-binding interaction.
+- §9 RFC test-name reconciliation — live-verifier ground truth: of 21 named gates, 8 exact / 4 variant / 9 entirely missing. Larger than originally framed. Architect's audit-script approach (`scripts/dev/audit_rfc_section_9_gates.py`) recommended.
 
 Phase B prerequisites (non-blocking for Phase A):
 - Payload-shape standardization pass — commits to writing canonicalized `surface_id` (per §7.12.1) into `audit.tool_usage.payload`, no percent-encoding (per §7.2.8 cross-track).

--- a/scripts/dev/lease_plane_deprecate.py
+++ b/scripts/dev/lease_plane_deprecate.py
@@ -7,28 +7,45 @@ standalone Python CLI in `scripts/dev/`. Operator decision 2026-04-30 — Python
 CLI rather than Mix wrapper because deprecation is governance/operator policy
 plus Postgres state, not BEAM live coordination.
 
+## Canonical operator path (R1 — RFC §7.11.2 atomicity)
+
+The `deprecate-and-finalize` super-command is the canonical Phase 2+3 path.
+It runs sweep and finalize on a single asyncpg connection (two transactions,
+one connection — the meaningful "same operator session" invariant at the DB
+wire level), correlates both phases under a shared `run_id` (in logs and
+event payloads), and emits a `lease.deprecation_aborted` event with the
+`run_id` if Phase 3 fails after Phase 2 succeeded.
+
+The standalone `deprecation-sweep` and `deprecation-finalize` subcommands
+remain as **operator escape hatches** for emergency partial recovery (e.g.,
+super-command was killed mid-run; operator needs to manually advance from
+the Phase 2 success / Phase 3 failure state). The super-command's clear
+"rerun deprecation-finalize" guidance points operators here.
+
 Usage:
     python3 scripts/dev/lease_plane_deprecate.py deprecate <kind> [--days N]
-    python3 scripts/dev/lease_plane_deprecate.py deprecation-sweep <kind>
-    python3 scripts/dev/lease_plane_deprecate.py deprecation-finalize <kind>
+    python3 scripts/dev/lease_plane_deprecate.py deprecate-and-finalize <kind>  # canonical Phase 2+3
+    python3 scripts/dev/lease_plane_deprecate.py deprecation-sweep <kind>       # escape hatch
+    python3 scripts/dev/lease_plane_deprecate.py deprecation-finalize <kind>    # escape hatch
     python3 scripts/dev/lease_plane_deprecate.py deprecation-status [<kind>]
 
 Authorization:
-    `deprecation-sweep` requires LEASE_FORCE_RELEASE_TOKEN (RFC §7.10) — read
-    from env or `~/.config/cirwel/secrets.env`. GOVERNANCE_TOKEN does NOT
-    authorize sweep.
+    `deprecation-sweep` and `deprecate-and-finalize` require
+    LEASE_FORCE_RELEASE_TOKEN (RFC §7.10) — read from env or
+    `~/.config/cirwel/secrets.env`. GOVERNANCE_TOKEN does NOT authorize.
 
 Phase ordering (RFC §7.11.2):
-    Phase 0:  deprecate           — INSERT into deprecated_schemes
+    Phase 0:  deprecate                  — INSERT into deprecated_schemes
     Phase 1:  (verification, lint via unitares_doctor — out of CLI scope)
-    Phase 2:  deprecation-sweep   — force-release surviving leases (idempotent)
-    Phase 3:  deprecation-finalize — record check_migrated_at + migrate CHECK
-              (atomic with Phase 2 in same operator session per RFC §7.11.2)
+    Phase 2:  deprecation-sweep          — force-release surviving leases (idempotent)
+    Phase 3:  deprecation-finalize       — record check_migrated_at + migrate CHECK
+    Phase 2+3: deprecate-and-finalize    — atomic two-tx-one-conn (R1 canonical)
 
 Idempotency:
     Phase 0 INSERT uses ON CONFLICT DO NOTHING (re-marking is a no-op).
     Phase 2 sweep predicate `WHERE released_at IS NULL AND surface_kind = $1`
     reaches fixpoint on re-run after partial completion (RFC §7.11.4).
+    Phase 3 guards on `check_migrated_at IS NULL` for emit-once.
 """
 
 from __future__ import annotations
@@ -37,8 +54,10 @@ import argparse
 import asyncio
 import hashlib
 import json
+import logging
 import os
 import sys
+import uuid
 from pathlib import Path
 
 try:
@@ -46,6 +65,15 @@ try:
 except ImportError:
     print("error: asyncpg not installed; install with `pip install asyncpg`", file=sys.stderr)
     sys.exit(2)
+
+
+# Operator-visible logger; format prefix includes run_id when threaded through.
+logger = logging.getLogger("lease_plane_deprecate")
+if not logger.handlers:
+    _handler = logging.StreamHandler(sys.stderr)
+    _handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+    logger.addHandler(_handler)
+    logger.setLevel(logging.INFO)
 
 
 def _lock_key_for_kind(kind: str) -> int:
@@ -82,6 +110,29 @@ def _read_force_release_token() -> str | None:
     return None
 
 
+# ---------- payload helper ----------
+
+def _payload_with_run_id(base: dict, run_id: str | None) -> str:
+    """JSON-encode an event payload, injecting run_id when present.
+
+    R1: the super-command threads a shared `run_id` (uuid4) through every
+    event it emits (Phase 2 sweep events, Phase 3 migrated event, Phase 3
+    aborted event) so partial-completion across the two transactions is
+    correlatable in audit queries:
+
+        SELECT event_type, ts FROM lease_plane.lease_plane_events
+        WHERE payload->>'run_id' = '<uuid>' ORDER BY ts;
+
+    Singleton sub-commands (escape hatches) pass run_id=None and the field
+    is omitted, preserving existing payload shapes.
+    """
+    if run_id is not None:
+        base = {**base, "run_id": run_id}
+    return json.dumps(base)
+
+
+# ---------- Phase 0: deprecate ----------
+
 async def deprecate_cmd(
     *,
     kind: str,
@@ -97,8 +148,6 @@ async def deprecate_cmd(
     """
     conn = await asyncpg.connect(db_url)
     try:
-        # Validate against catalog OUTSIDE the transaction so a failure doesn't
-        # abort the serializable tx (and so the error message can list valid kinds).
         catalog = await _list_catalog_kinds(conn)
         if kind not in catalog:
             print(
@@ -108,7 +157,6 @@ async def deprecate_cmd(
             )
             return 1
         async with conn.transaction(isolation="serializable"):
-            # Use deterministic SHA-256-derived key (see _lock_key_for_kind for rationale).
             lock_key = _lock_key_for_kind(kind)
             await conn.execute("SELECT pg_advisory_xact_lock($1)", lock_key)
             row = await conn.fetchrow(
@@ -122,15 +170,19 @@ async def deprecate_cmd(
                 kind, session_id, drain_window_days,
             )
             if row is not None:
-                # Phase 0 audit-event emission (RFC §7.11.3 — closes PR 6
-                # dangling-vocabulary fix). Only emit on first mark; ON CONFLICT
-                # returns NULL row on idempotent re-run, so no double-emit.
-                payload = json.dumps({
-                    "deprecation_id": str(row["deprecation_id"]),
-                    "kind": kind,
-                    "session_id": session_id,
-                    "drain_window_days": drain_window_days,
-                })
+                # Phase 0 is single-step (one CLI invocation, one tx) so it
+                # has no run_id to correlate. Pass None to preserve the
+                # pre-R1 payload shape; super-command does not call this
+                # helper for Phase 0 (Phase 0 happens before super-command).
+                payload = _payload_with_run_id(
+                    {
+                        "deprecation_id": str(row["deprecation_id"]),
+                        "kind": kind,
+                        "session_id": session_id,
+                        "drain_window_days": drain_window_days,
+                    },
+                    None,
+                )
                 await conn.execute(
                     """
                     INSERT INTO lease_plane.lease_plane_events
@@ -144,8 +196,81 @@ async def deprecate_cmd(
         await conn.close()
 
 
-async def deprecation_sweep_cmd(*, kind: str, db_url: str = DEFAULT_DB_URL) -> int:
-    """Phase 2: idempotent force-release sweep (RFC §7.11.4).
+# ---------- Phase 2: sweep (inner + wrapper) ----------
+
+async def _sweep_inner(
+    conn,
+    *,
+    kind: str,
+    deprecation_id,
+    run_id: str | None = None,
+) -> int:
+    """Inner Phase 2 helper: force-release surviving leases on an OPEN conn.
+
+    Caller owns the connection lifecycle. R1: lifted out of `deprecation_sweep_cmd`
+    so the new `deprecate_and_finalize_cmd` super-command can call it on a
+    connection it already opened (the "same operator session" invariant lives
+    here at the DB wire level, not at the CLI subprocess level).
+
+    Returns the number of leases swept (callers ignore but useful for tests
+    + caller-side logging).
+    """
+    async with conn.transaction():
+        await conn.execute(
+            "UPDATE lease_plane.deprecated_schemes "
+            "SET sweep_started_at = COALESCE(sweep_started_at, now()) "
+            "WHERE surface_kind = $1",
+            kind,
+        )
+        unreleased = await conn.fetch(
+            """
+            SELECT lease_id, surface_id FROM lease_plane.surface_leases
+            WHERE released_at IS NULL AND surface_kind = $1
+            ORDER BY acquired_at
+            FOR UPDATE SKIP LOCKED
+            """,
+            kind,
+        )
+        for row in unreleased:
+            await conn.execute(
+                "UPDATE lease_plane.surface_leases "
+                "SET released_at = now(), release_reason = 'forced' "
+                "WHERE lease_id = $1",
+                row["lease_id"],
+            )
+            payload = _payload_with_run_id(
+                {"deprecation_id": str(deprecation_id), "kind": kind},
+                run_id,
+            )
+            await conn.execute(
+                """
+                INSERT INTO lease_plane.lease_plane_events
+                  (event_type, lease_id, surface_id, surface_kind, advisory_mode, payload)
+                VALUES ('lease.deprecation_swept', $1, $2, $3, false, $4::jsonb)
+                """,
+                row["lease_id"], row["surface_id"], kind, payload,
+            )
+        # COALESCE on sweep_completed_at preserves the original first-completion
+        # timestamp across re-runs (council CONCERN 4 reviewer). Without this, a
+        # rerun overwrites the audit record with the rerun time, drifting the
+        # "when was this deprecation actually swept?" answer.
+        await conn.execute(
+            "UPDATE lease_plane.deprecated_schemes "
+            "SET sweep_completed_at = COALESCE(sweep_completed_at, now()) "
+            "WHERE surface_kind = $1",
+            kind,
+        )
+        return len(unreleased)
+
+
+async def deprecation_sweep_cmd(
+    *,
+    kind: str,
+    db_url: str = DEFAULT_DB_URL,
+    run_id: str | None = None,
+) -> int:
+    """Phase 2 standalone (escape-hatch) wrapper: idempotent force-release sweep
+    (RFC §7.11.4).
 
     Predicate: `WHERE released_at IS NULL AND surface_kind = $1` with no
     timestamp filter. Re-running on partial failure reaches fixpoint because
@@ -155,7 +280,11 @@ async def deprecation_sweep_cmd(*, kind: str, db_url: str = DEFAULT_DB_URL) -> i
     GOVERNANCE_TOKEN does NOT authorize.
 
     Each swept lease emits a `lease.deprecation_swept` event with
-    deprecation_id in the payload jsonb for batch correlation (§7.11.3).
+    deprecation_id (and optional run_id) in the payload jsonb for batch
+    correlation (§7.11.3).
+
+    NOTE (R1): `deprecate-and-finalize` is the canonical operator path for
+    Phase 2+3. Use this subcommand only for emergency partial recovery.
     """
     if not _read_force_release_token():
         print(
@@ -167,7 +296,6 @@ async def deprecation_sweep_cmd(*, kind: str, db_url: str = DEFAULT_DB_URL) -> i
 
     conn = await asyncpg.connect(db_url)
     try:
-        # Look up deprecation_id for audit correlation.
         depr_id = await conn.fetchval(
             "SELECT deprecation_id FROM lease_plane.deprecated_schemes WHERE surface_kind = $1",
             kind,
@@ -176,103 +304,262 @@ async def deprecation_sweep_cmd(*, kind: str, db_url: str = DEFAULT_DB_URL) -> i
             print(f"error: scheme {kind!r} is not marked deprecated; run `deprecate {kind}` first.",
                   file=sys.stderr)
             return 1
-
-        async with conn.transaction():
-            # Record sweep_started_at.
-            await conn.execute(
-                "UPDATE lease_plane.deprecated_schemes SET sweep_started_at = COALESCE(sweep_started_at, now()) "
-                "WHERE surface_kind = $1",
-                kind,
-            )
-            # Idempotent predicate per RFC §7.11.4 — no timestamp filter.
-            unreleased = await conn.fetch(
-                """
-                SELECT lease_id, surface_id FROM lease_plane.surface_leases
-                WHERE released_at IS NULL AND surface_kind = $1
-                ORDER BY acquired_at
-                FOR UPDATE SKIP LOCKED
-                """,
-                kind,
-            )
-            for row in unreleased:
-                # Force-release the lease.
-                await conn.execute(
-                    "UPDATE lease_plane.surface_leases "
-                    "SET released_at = now(), release_reason = 'forced' "
-                    "WHERE lease_id = $1",
-                    row["lease_id"],
-                )
-                # Emit audit event with deprecation_id for batch correlation.
-                payload = json.dumps({"deprecation_id": str(depr_id), "kind": kind})
-                await conn.execute(
-                    """
-                    INSERT INTO lease_plane.lease_plane_events
-                      (event_type, lease_id, surface_id, surface_kind, advisory_mode, payload)
-                    VALUES ('lease.deprecation_swept', $1, $2, $3, false, $4::jsonb)
-                    """,
-                    row["lease_id"], row["surface_id"], kind, payload,
-                )
-            # Mark sweep complete.
-            await conn.execute(
-                "UPDATE lease_plane.deprecated_schemes SET sweep_completed_at = now() "
-                "WHERE surface_kind = $1",
-                kind,
-            )
+        await _sweep_inner(conn, kind=kind, deprecation_id=depr_id, run_id=run_id)
         return 0
     finally:
         await conn.close()
 
 
-async def deprecation_finalize_cmd(*, kind: str, db_url: str = DEFAULT_DB_URL) -> int:
-    """Phase 3: record check_migrated_at on the deprecated_schemes row.
+# ---------- Phase 3: finalize (inner + wrapper) ----------
 
-    Per RFC §7.11.2, Phase 3 also extends the surface_id_grammar CHECK to
-    remove the deprecated scheme — that ALTER TABLE should be performed
-    atomically in the same operator session as Phase 2 (DDL as a separate
-    follow-on migration is the fallback if the operator splits sessions).
+async def _finalize_inner(
+    conn,
+    *,
+    kind: str,
+    run_id: str | None = None,
+) -> int:
+    """Inner Phase 3 helper: record check_migrated_at on an OPEN conn.
+
+    Returns 0 on success, 1 on operator-fixable error (scheme not marked,
+    sweep not completed). Raises on infrastructure errors (DB unavailable,
+    integrity violations) so the caller can decide whether to emit
+    lease.deprecation_aborted.
+    """
+    async with conn.transaction():
+        row = await conn.fetchrow(
+            "SELECT deprecation_id, sweep_completed_at, check_migrated_at "
+            "FROM lease_plane.deprecated_schemes WHERE surface_kind = $1",
+            kind,
+        )
+        if row is None:
+            print(f"error: scheme {kind!r} is not marked deprecated.", file=sys.stderr)
+            return 1
+        if row["sweep_completed_at"] is None:
+            print(f"error: deprecation-sweep has not completed for {kind!r}; "
+                  f"run `deprecation-sweep {kind}` first.", file=sys.stderr)
+            return 1
+        already_finalized = row["check_migrated_at"] is not None
+        await conn.execute(
+            "UPDATE lease_plane.deprecated_schemes "
+            "SET check_migrated_at = COALESCE(check_migrated_at, now()) "
+            "WHERE surface_kind = $1",
+            kind,
+        )
+        if not already_finalized:
+            payload = _payload_with_run_id(
+                {"deprecation_id": str(row["deprecation_id"]), "kind": kind},
+                run_id,
+            )
+            await conn.execute(
+                """
+                INSERT INTO lease_plane.lease_plane_events
+                  (event_type, surface_id, surface_kind, advisory_mode, payload)
+                VALUES ('lease.deprecation_migrated', $1, $2, false, $3::jsonb)
+                """,
+                f"{kind}:/__deprecation_marker__", kind, payload,
+            )
+        return 0
+
+
+async def deprecation_finalize_cmd(
+    *,
+    kind: str,
+    db_url: str = DEFAULT_DB_URL,
+    run_id: str | None = None,
+) -> int:
+    """Phase 3 standalone (escape-hatch) wrapper: record check_migrated_at.
+
+    Per RFC §7.11.2, Phase 3 should be atomic with Phase 2 in the same
+    operator session. R1's `deprecate-and-finalize` super-command satisfies
+    that invariant at the DB wire level (single connection, two transactions
+    with shared run_id correlation). This standalone subcommand exists for
+    emergency partial recovery — e.g., the super-command's Phase 3 attempt
+    failed and emitted `lease.deprecation_aborted`, the operator fixed the
+    underlying issue and is rerunning finalize.
     """
     conn = await asyncpg.connect(db_url)
     try:
-        async with conn.transaction():
-            row = await conn.fetchrow(
-                "SELECT deprecation_id, sweep_completed_at, check_migrated_at "
-                "FROM lease_plane.deprecated_schemes WHERE surface_kind = $1",
-                kind,
-            )
-            if row is None:
-                print(f"error: scheme {kind!r} is not marked deprecated.", file=sys.stderr)
-                return 1
-            if row["sweep_completed_at"] is None:
-                print(f"error: deprecation-sweep has not completed for {kind!r}; "
-                      f"run `deprecation-sweep {kind}` first.", file=sys.stderr)
-                return 1
-            already_finalized = row["check_migrated_at"] is not None
-            await conn.execute(
-                "UPDATE lease_plane.deprecated_schemes "
-                "SET check_migrated_at = COALESCE(check_migrated_at, now()) "
-                "WHERE surface_kind = $1",
-                kind,
-            )
-            if not already_finalized:
-                # Phase 3 audit-event emission (RFC §7.11.3 — closes PR 6
-                # dangling-vocabulary fix). Only emit on first finalize;
-                # re-runs are no-op for both check_migrated_at and the event.
-                payload = json.dumps({
-                    "deprecation_id": str(row["deprecation_id"]),
-                    "kind": kind,
-                })
-                await conn.execute(
-                    """
-                    INSERT INTO lease_plane.lease_plane_events
-                      (event_type, surface_id, surface_kind, advisory_mode, payload)
-                    VALUES ('lease.deprecation_migrated', $1, $2, false, $3::jsonb)
-                    """,
-                    f"{kind}:/__deprecation_marker__", kind, payload,
-                )
-        return 0
+        return await _finalize_inner(conn, kind=kind, run_id=run_id)
     finally:
         await conn.close()
 
+
+# ---------- Phase 2+3 super-command (R1 canonical) ----------
+
+async def _emit_aborted_event(
+    conn,
+    *,
+    kind: str,
+    deprecation_id,
+    run_id: str,
+    reason: str,
+) -> None:
+    """Emit `lease.deprecation_aborted` event when Phase 3 fails after Phase 2
+    succeeded. Runs in its own short transaction (Phase 3's tx already failed
+    and is rolled back by the surrounding caller; we open a fresh tx here for
+    the abort emission so the audit trail survives).
+
+    Per the architect council finding: without this event class, an operator
+    who fails Phase 3 thrice and gives up has no audit trail of the abandoned
+    deprecation. Migration 030 extends event_type CHECK to permit this.
+    """
+    payload = _payload_with_run_id(
+        {
+            "deprecation_id": str(deprecation_id),
+            "kind": kind,
+            "phase": "finalize",
+            "reason": reason,
+        },
+        run_id,
+    )
+    async with conn.transaction():
+        await conn.execute(
+            """
+            INSERT INTO lease_plane.lease_plane_events
+              (event_type, surface_id, surface_kind, advisory_mode, payload)
+            VALUES ('lease.deprecation_aborted', $1, $2, false, $3::jsonb)
+            """,
+            f"{kind}:/__deprecation_marker__", kind, payload,
+        )
+
+
+async def deprecate_and_finalize_cmd(
+    *,
+    kind: str,
+    db_url: str = DEFAULT_DB_URL,
+) -> int:
+    """R1 canonical Phase 2+3 super-command (RFC §7.11.2 atomicity).
+
+    Runs Phase 2 (sweep) and Phase 3 (finalize) on a single asyncpg connection
+    in two separate transactions, correlated under a shared `run_id` (uuid4)
+    that surfaces in logs and event payloads. The DB-wire-level "same
+    operator session" invariant is satisfied because both phases run on the
+    same connection within one process — preventing the v0.7 1-day Layer-1
+    enforcement gap that v0.8 §7.11.2 line 775 promised to close.
+
+    Two-transactions-one-connection (operator decision 2026-05-02 vs strict
+    one-tx atomicity): if Phase 3 fails after Phase 2 succeeded, the swept
+    rows STAY swept (no rollback of the operator's Phase 2 work). The
+    super-command then:
+      1. Emits `lease.deprecation_aborted` event with run_id + reason
+      2. Logs clear "rerun deprecation-finalize <kind>" guidance
+      3. Returns non-zero exit
+    The §7.11.4 idempotent-sweep predicate makes the rerun safe.
+
+    Authorization: same as `deprecation-sweep` (LEASE_FORCE_RELEASE_TOKEN).
+    """
+    if not _read_force_release_token():
+        print(
+            "error: deprecate-and-finalize requires LEASE_FORCE_RELEASE_TOKEN "
+            "(env or ~/.config/cirwel/secrets.env). GOVERNANCE_TOKEN does NOT authorize.",
+            file=sys.stderr,
+        )
+        return 1
+
+    run_id = str(uuid.uuid4())
+    logger.info(f"[run_id={run_id}] deprecate-and-finalize starting for kind={kind!r}")
+
+    conn = await asyncpg.connect(db_url)
+    try:
+        # Council CONCERN 3 (reviewer): pg_try_advisory_lock on the same
+        # SHA-256-derived key as Phase 0's pg_advisory_xact_lock. Session-level
+        # (not transaction-level) so it spans Phase 2 + Phase 3's two separate
+        # transactions. Try-variant fails fast (returns false) if another
+        # super-command holds the lock — better operator UX than blocking
+        # indefinitely. Released automatically on conn.close() in the finally
+        # block; explicit unlock not required but cleaner if added.
+        lock_key = _lock_key_for_kind(kind)
+        got_lock = await conn.fetchval("SELECT pg_try_advisory_lock($1)", lock_key)
+        if not got_lock:
+            print(
+                f"error: another deprecate-and-finalize is in progress for kind={kind!r}; "
+                f"retry once it completes (or use `deprecation-status {kind}` to inspect).",
+                file=sys.stderr,
+            )
+            logger.error(f"[run_id={run_id}] aborted before Phase 2: advisory lock held")
+            return 4
+
+        depr_id = await conn.fetchval(
+            "SELECT deprecation_id FROM lease_plane.deprecated_schemes WHERE surface_kind = $1",
+            kind,
+        )
+        if depr_id is None:
+            print(
+                f"error: scheme {kind!r} is not marked deprecated; run `deprecate {kind}` first.",
+                file=sys.stderr,
+            )
+            logger.error(f"[run_id={run_id}] aborted before Phase 2: scheme not marked")
+            return 1
+
+        # Phase 2 (own transaction).
+        try:
+            swept = await _sweep_inner(conn, kind=kind, deprecation_id=depr_id, run_id=run_id)
+            logger.info(f"[run_id={run_id}] Phase 2 complete: swept {swept} lease(s)")
+        except Exception as e:
+            # Phase 2 failure: nothing committed beyond the sweep_started_at
+            # update (which is itself inside the failed tx and rolled back).
+            # No abort event needed — there's nothing to be inconsistent with.
+            logger.error(f"[run_id={run_id}] Phase 2 sweep failed: {e!r}")
+            print(f"error: Phase 2 sweep failed: {e}", file=sys.stderr)
+            return 2
+
+        # Phase 3 (own transaction on the same connection — "same operator
+        # session" at the DB wire level).
+        try:
+            rc = await _finalize_inner(conn, kind=kind, run_id=run_id)
+            if rc != 0:
+                # `_finalize_inner` returns rc=1 only for "scheme not marked"
+                # (we just fetched depr_id) or "sweep not completed" (we just
+                # ran _sweep_inner). Both are unreachable in this code path.
+                # Defensive log + return without abort emission — abort is
+                # for genuine Phase 3 infrastructure failures (raises), not
+                # for operator-fixable rc!=0 (council architect NIT 1).
+                logger.error(
+                    f"[run_id={run_id}] Phase 3 finalize returned unexpected rc={rc} "
+                    f"(should be unreachable); not emitting abort event"
+                )
+                return rc
+            logger.info(f"[run_id={run_id}] Phase 3 complete; deprecation finalized")
+            return 0
+        except Exception as e:
+            # Phase 3 infrastructure failure after Phase 2 succeeded. Sweep
+            # rows stay swept (per the two-tx-one-conn decision). Try to emit
+            # the abort event so the audit trail captures the abandoned-Phase-3
+            # state — but if abort emission ALSO fails (e.g., DB unreachable
+            # cause persists), surface the rerun guidance anyway. Council
+            # BLOCK 1 (reviewer) + CONCERN 1 (architect): without this guard,
+            # connection-level Phase 3 failure produces an unhandled exception
+            # from _emit_aborted_event that drops the structured exit code
+            # and audit silence.
+            try:
+                await _emit_aborted_event(
+                    conn,
+                    kind=kind,
+                    deprecation_id=depr_id,
+                    run_id=run_id,
+                    reason=f"finalize raised: {e!r}",
+                )
+            except Exception as emit_err:
+                logger.error(
+                    f"[run_id={run_id}] abort event emission ALSO failed: {emit_err!r}; "
+                    f"audit trail incomplete but rerun guidance still applies"
+                )
+            logger.error(
+                f"[run_id={run_id}] Phase 3 finalize raised: {e!r}. "
+                f"Rerun: deprecation-finalize {kind}"
+            )
+            print(
+                f"error: Phase 3 finalize failed after Phase 2 succeeded ({e}). "
+                f"Phase 2 work is preserved. Rerun: "
+                f"python3 scripts/dev/lease_plane_deprecate.py deprecation-finalize {kind}",
+                file=sys.stderr,
+            )
+            return 3
+    finally:
+        await conn.close()
+
+
+# ---------- status (read-only) ----------
 
 async def deprecation_status_cmd(*, kind: str | None = None, db_url: str = DEFAULT_DB_URL) -> int:
     """Print deprecated_schemes table contents (operator visibility)."""
@@ -301,6 +588,8 @@ async def _list_catalog_kinds(conn) -> list[str]:
     return [r["surface_kind"] for r in rows]
 
 
+# ---------- argparse ----------
+
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="lease_plane_deprecate", description=__doc__)
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -311,10 +600,23 @@ def _build_parser() -> argparse.ArgumentParser:
     dep.add_argument("--session-id", default=os.environ.get("USER", "operator-cli"),
                      help="audit identifier for marked_by_session_id")
 
-    sweep = sub.add_parser("deprecation-sweep", help="Phase 2: force-release surviving leases.")
+    daf = sub.add_parser(
+        "deprecate-and-finalize",
+        help="R1 canonical: Phase 2+3 atomic on single connection (RFC §7.11.2).",
+    )
+    daf.add_argument("kind")
+
+    sweep = sub.add_parser(
+        "deprecation-sweep",
+        help="Phase 2 standalone (ESCAPE HATCH — prefer `deprecate-and-finalize`).",
+    )
     sweep.add_argument("kind")
 
-    fin = sub.add_parser("deprecation-finalize", help="Phase 3: record check_migrated_at.")
+    fin = sub.add_parser(
+        "deprecation-finalize",
+        help="Phase 3 standalone (ESCAPE HATCH — prefer `deprecate-and-finalize`; "
+             "use this only to recover from a failed super-command Phase 3).",
+    )
     fin.add_argument("kind")
 
     status = sub.add_parser("deprecation-status", help="Show deprecated_schemes table.")
@@ -329,6 +631,8 @@ def main(argv: list[str] | None = None) -> int:
         return asyncio.run(
             deprecate_cmd(kind=args.kind, session_id=args.session_id, drain_window_days=args.days)
         )
+    if args.cmd == "deprecate-and-finalize":
+        return asyncio.run(deprecate_and_finalize_cmd(kind=args.kind))
     if args.cmd == "deprecation-sweep":
         return asyncio.run(deprecation_sweep_cmd(kind=args.kind))
     if args.cmd == "deprecation-finalize":

--- a/tests/test_lease_plane_deprecate_cli.py
+++ b/tests/test_lease_plane_deprecate_cli.py
@@ -418,3 +418,291 @@ async def test_finalize_idempotent_does_not_double_emit():
     finally:
         await _cleanup(conn)
         await conn.close()
+
+
+# ---------- R1: deprecate-and-finalize super-command (RFC §7.11.2 atomicity) ----------
+
+
+@pytest.mark.asyncio
+async def test_deprecation_sweep_and_check_migration_atomic_session():
+    """RFC §9 named gate (finally implementable post-R1).
+
+    Verifies the super-command runs Phase 2 (sweep) and Phase 3 (finalize)
+    on the SAME asyncpg connection — the meaningful "same operator session"
+    invariant at the DB wire level. Mocks asyncpg.connect to count
+    invocations; expects exactly one connect() call across both phases.
+
+    Also verifies both phases successfully committed (sweep_completed_at
+    AND check_migrated_at populated).
+    """
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-atomic-session",
+            drain_window_days=30, db_url=TEST_DB_URL,
+        )
+        lease_id = await _seed_lease(conn, "td:/pr3a-atomic-session-test")
+
+        real_connect = asyncpg.connect
+        connect_calls = []
+
+        async def _counting_connect(*args, **kwargs):
+            connect_calls.append((args, kwargs))
+            return await real_connect(*args, **kwargs)
+
+        import unittest.mock as _mock
+        with _mock.patch.object(cli.asyncpg, "connect", side_effect=_counting_connect):
+            rc = await cli.deprecate_and_finalize_cmd(kind="td", db_url=TEST_DB_URL)
+
+        assert rc == 0, "super-command must succeed on happy path"
+        assert len(connect_calls) == 1, (
+            f"expected exactly one asyncpg.connect call across Phase 2+3; "
+            f"got {len(connect_calls)} (proves DB-wire-level same-operator-session)"
+        )
+
+        row = await conn.fetchrow(
+            "SELECT sweep_completed_at, check_migrated_at "
+            "FROM lease_plane.deprecated_schemes WHERE surface_kind='td'"
+        )
+        assert row["sweep_completed_at"] is not None, "Phase 2 must have committed"
+        assert row["check_migrated_at"] is not None, "Phase 3 must have committed"
+
+        released = await conn.fetchval(
+            "SELECT released_at FROM lease_plane.surface_leases WHERE lease_id=$1",
+            lease_id,
+        )
+        assert released is not None, "swept lease must be released"
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_deprecate_and_finalize_phase_3_failure_emits_aborted_event(monkeypatch):
+    """When Phase 3 raises after Phase 2 succeeded, the super-command emits
+    a lease.deprecation_aborted event with run_id + reason in payload, and
+    Phase 2's swept rows STAY released (two-tx-one-conn semantics — operator
+    decision 2026-05-02).
+    """
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-aborted-emit",
+            drain_window_days=30, db_url=TEST_DB_URL,
+        )
+        lease_id = await _seed_lease(conn, "td:/pr3a-aborted-test")
+
+        async def _raising_finalize(*args, **kwargs):
+            raise RuntimeError("simulated phase-3 infrastructure failure")
+
+        monkeypatch.setattr(cli, "_finalize_inner", _raising_finalize)
+
+        rc = await cli.deprecate_and_finalize_cmd(kind="td", db_url=TEST_DB_URL)
+        assert rc == 3, f"super-command must return 3 on Phase 3 raise; got {rc}"
+
+        events = await conn.fetch(
+            "SELECT payload FROM lease_plane.lease_plane_events "
+            "WHERE event_type='lease.deprecation_aborted' AND surface_kind='td'"
+        )
+        assert len(events) == 1, f"expected one lease.deprecation_aborted event; got {len(events)}"
+        import json
+        payload = json.loads(events[0]["payload"])
+        assert payload["kind"] == "td"
+        assert payload["phase"] == "finalize"
+        assert "simulated phase-3 infrastructure failure" in payload["reason"]
+        assert "run_id" in payload, "aborted event payload must include run_id"
+        assert uuid.UUID(payload["run_id"])
+
+        released = await conn.fetchval(
+            "SELECT released_at FROM lease_plane.surface_leases WHERE lease_id=$1",
+            lease_id,
+        )
+        assert released is not None, "Phase 2 work must be preserved on Phase 3 failure"
+
+        check_migrated = await conn.fetchval(
+            "SELECT check_migrated_at FROM lease_plane.deprecated_schemes WHERE surface_kind='td'"
+        )
+        assert check_migrated is None, "Phase 3 must not have written check_migrated_at on failure"
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_deprecate_and_finalize_phase_3_failure_then_rerun_finalize_succeeds(monkeypatch):
+    """End-to-end recovery: super-command Phase 3 fails → operator runs
+    standalone deprecation-finalize → succeeds and emits lease.deprecation_migrated.
+    """
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-rerun-recovery",
+            drain_window_days=30, db_url=TEST_DB_URL,
+        )
+        await _seed_lease(conn, "td:/pr3a-rerun-test")
+
+        async def _raising_finalize(*args, **kwargs):
+            raise RuntimeError("first-attempt finalize failure")
+
+        monkeypatch.setattr(cli, "_finalize_inner", _raising_finalize)
+        rc1 = await cli.deprecate_and_finalize_cmd(kind="td", db_url=TEST_DB_URL)
+        assert rc1 == 3
+
+        monkeypatch.undo()
+
+        rc2 = await cli.deprecation_finalize_cmd(kind="td", db_url=TEST_DB_URL)
+        assert rc2 == 0, "standalone finalize must succeed on rerun"
+
+        check_migrated = await conn.fetchval(
+            "SELECT check_migrated_at FROM lease_plane.deprecated_schemes WHERE surface_kind='td'"
+        )
+        assert check_migrated is not None, "rerun finalize must populate check_migrated_at"
+
+        migrated_count = await conn.fetchval(
+            "SELECT count(*) FROM lease_plane.lease_plane_events "
+            "WHERE event_type='lease.deprecation_migrated' AND surface_kind='td'"
+        )
+        assert migrated_count == 1, "rerun finalize must emit exactly one migrated event"
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_deprecate_and_finalize_advisory_lock_blocks_concurrent_invocation():
+    """Council CONCERN 3 (reviewer): two concurrent super-commands on the
+    same kind must NOT both succeed in finalizing — without the
+    pg_try_advisory_lock added in this PR, both could pass the
+    `already_finalized` check before either commits and double-emit
+    `lease.deprecation_migrated`. Now: the second invocation gets the lock
+    busy and exits with rc=4.
+    """
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-lock-block",
+            drain_window_days=30, db_url=TEST_DB_URL,
+        )
+
+        # Manually acquire the advisory lock on a separate session, then
+        # invoke the super-command — it should fail-fast with rc=4.
+        lock_holder = await asyncpg.connect(TEST_DB_URL)
+        try:
+            lock_key = cli._lock_key_for_kind("td")
+            held = await lock_holder.fetchval("SELECT pg_advisory_lock($1)", lock_key)
+            assert held is None  # pg_advisory_lock returns void
+
+            rc = await cli.deprecate_and_finalize_cmd(kind="td", db_url=TEST_DB_URL)
+            assert rc == 4, f"super-command must fail-fast with rc=4 on lock contention; got {rc}"
+
+            check_migrated = await conn.fetchval(
+                "SELECT check_migrated_at FROM lease_plane.deprecated_schemes "
+                "WHERE surface_kind='td'"
+            )
+            assert check_migrated is None, "no Phase 3 work should have happened under lock"
+        finally:
+            # Release the held lock (closing the session also releases).
+            await lock_holder.close()
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_deprecate_and_finalize_abort_emission_failure_still_returns_rc_3(monkeypatch):
+    """Council BLOCK 1 (reviewer) + CONCERN 1 (architect): when Phase 3 fails
+    AND the abort-event emission also fails (e.g., DB unreachable persists),
+    the operator must still get the structured rc=3 + rerun guidance. Without
+    the try/except around _emit_aborted_event, the secondary exception would
+    propagate as an unhandled stack trace, dropping the rerun signal.
+    """
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-abort-emit-fails",
+            drain_window_days=30, db_url=TEST_DB_URL,
+        )
+
+        async def _raising_finalize(*args, **kwargs):
+            raise RuntimeError("simulated phase-3 connection failure")
+
+        async def _raising_emit(*args, **kwargs):
+            raise RuntimeError("simulated abort-emission failure")
+
+        monkeypatch.setattr(cli, "_finalize_inner", _raising_finalize)
+        monkeypatch.setattr(cli, "_emit_aborted_event", _raising_emit)
+
+        # No unhandled exception should propagate — rc=3 + operator guidance.
+        rc = await cli.deprecate_and_finalize_cmd(kind="td", db_url=TEST_DB_URL)
+        assert rc == 3, f"super-command must still return rc=3 even when abort emission fails; got {rc}"
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_deprecate_and_finalize_run_id_correlates_across_events():
+    """Happy path: every event emitted by a single super-command run shares
+    the same run_id in payload (Phase 2 sweep events + Phase 3 migrated event).
+    Enables audit queries by run_id.
+    """
+    from scripts.dev import lease_plane_deprecate as cli
+
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        await cli.deprecate_cmd(
+            kind="td", session_id="test-cli-run-id-correlation",
+            drain_window_days=30, db_url=TEST_DB_URL,
+        )
+        await _seed_lease(conn, "td:/pr3a-run-id-test-1")
+        await _seed_lease(conn, "td:/pr3a-run-id-test-2")
+
+        rc = await cli.deprecate_and_finalize_cmd(kind="td", db_url=TEST_DB_URL)
+        assert rc == 0
+
+        events = await conn.fetch(
+            """
+            SELECT event_type, payload FROM lease_plane.lease_plane_events
+            WHERE surface_kind='td'
+              AND event_type IN ('lease.deprecation_swept', 'lease.deprecation_migrated')
+            ORDER BY ts
+            """
+        )
+        assert len(events) >= 3, (
+            f"expected >=3 events (2 swept + 1 migrated); got {len(events)}: "
+            f"{[e['event_type'] for e in events]}"
+        )
+
+        import json
+        run_ids = {json.loads(e["payload"]).get("run_id") for e in events}
+        assert len(run_ids) == 1, (
+            f"all super-command events must share one run_id; got {run_ids}"
+        )
+        the_run_id = next(iter(run_ids))
+        assert the_run_id is not None
+        assert uuid.UUID(the_run_id)
+    finally:
+        await _cleanup(conn)
+        await conn.close()


### PR DESCRIPTION
## Summary

Closes the §7.11.2 atomicity residual that PR 5 deferred. Pre-R1 was a 3-way contradiction shipped under PR 5's "council saw it, deferred it" stamp:
- RFC v0.8 §7.11.2 line 775 commits Phase 2+3 to "same operator session"
- §9 names `test_deprecation_sweep_and_check_migration_atomic_session` as the gate
- CLI implementation went multi-step with no cross-invocation session binding
- The named test was never written

R1 picks code-not-discipline (per `feedback_memory-not-guardrail.md`): the new `deprecate-and-finalize` super-command runs Phase 2+3 on a **single asyncpg connection in two transactions**, correlated by shared **`run_id`** (uuid4) in logs and event payloads. The DB-wire-level "same operator session" invariant is satisfied without losing Phase 2 work if Phase 3 fails (operator decision: two-tx-one-conn over strict mega-tx).

## Operator decisions captured 2026-05-02

1. Option A1 (super-command + keep singletons as escape-hatches)
2. Two-tx-one-connection (Phase 2 work preserved on Phase 3 failure)
3. Shared `run_id` in audit + logs (correlatable via `payload->>'run_id'`)
4. New `lease.deprecation_aborted` event class (closes architect's latent ontology gap — operators failing Phase 3 now have an audit trail)

## Council pass (3 agents, adversarial framing) — all SHIP-WITH-FIXES, all fixes applied

- **BLOCK 1** (reviewer + architect CONCERN 1): `_emit_aborted_event` unprotected. Connection-level Phase 3 failure → abort emission also fails → operator gets stack trace + audit silence. **Fix**: try/except around abort emission so rerun guidance + rc=3 still surface.
- **BLOCK 2** (reviewer + architect CONCERN 2): runbook audit query missed SIGKILL-between-phases (Phase 2 committed, no abort event, `check_migrated_at IS NULL`). **Fix**: companion query + SIGKILL recovery playbook.
- **CONCERN 3** (reviewer): no advisory lock in super-command — concurrent operators could double-emit `lease.deprecation_migrated`. **Fix**: `pg_try_advisory_lock` fail-fast (rc=4) on contention.
- **CONCERN 4** (reviewer): `sweep_completed_at` overwritten on rerun → audit timestamp drift. **Fix**: COALESCE.
- **CONCERN 2** (reviewer): migration 030 idempotency anchored on constraint name only. **Fix**: primary `core.schema_migrations` guard + secondary constraint-text probe.
- **NIT 1** (architect): `_finalize_inner` rc!=0 path is unreachable in super-command context. **Fix**: log + return without abort emission (abort is for raises only).
- **NIT 2** (architect): dead `run_id` parameter on `deprecate_cmd`. **Fix**: removed.
- **NIT 4** (architect): §9 RFC named-gate for aborted event not in §9 list. **Deferred** to §9 reconciliation residual (already in plan).

Live-verifier: **7 VERIFIED, 0 REFUTED, 0 BLOCKED, 1 SOURCE_ONLY** (SIGINT trace via code-read). End-to-end super-command run against governance_test confirmed run_id correlation + escape-hatch help text + abort-event INSERT permission.

## RFC gate → code surface → test name → status

See `docs/proposals/surface-lease-plane-phase-a-plan.md` "R1" section. 12 rows including the 5 council-fix rows added post-pass.

## Test plan

- [x] `python3 -m pytest tests/test_lease_plane_deprecate_cli.py`: **17 passed** (was 11; +4 R1 + 2 council-fix verification)
- [x] Migration 030 applied to both `governance` and `governance_test`; idempotency rerun confirms new primary-guard fires (`migration 030: already applied (recorded=t / permitted=t); skipping`)
- [x] End-to-end super-command run against `governance_test` (live-verifier item 6): exit 0, run_id correlates `lease.deprecation_migrated` event
- [x] Single-writer surface check: `gh pr list --search "lease-plane atomicity OR deprecate-and-finalize"` returned empty
- [x] Council pass surfaced 5 fixes (all applied and tested)

## Surface-collision check

`gh pr list -R CIRWEL/unitares --search "lease-plane atomicity OR deprecate-and-finalize OR deprecation_aborted" --state open` returned empty. Branch built off `7d5efd98` (post-PR-#283 master).