### PR TITLE
feat(doctor): add elixir_deprecated_scheme_lint check (Phase B prep, RFC §7.11.8)

### DIFF
--- a/scripts/dev/unitares_doctor.py
+++ b/scripts/dev/unitares_doctor.py
@@ -235,6 +235,81 @@ def check_schema_migrations(db_url: str, repo_root: Path | None = None) -> Check
                        f"schema at version {version}; registry matches source manifest")
 
 
+def check_elixir_deprecated_scheme_lint(db_url: str, repo_root: Path) -> CheckResult:
+    """Phase B prep (RFC §7.11.8): WARN if any Elixir source mentions a
+    surface_kind currently in lease_plane.deprecated_schemes.
+
+    Phase 0 deprecation marks a kind, Phase 2 sweeps surviving leases, Phase 3
+    finalizes. Between Phase 0 and Phase 3 the operator (and CI) needs a way
+    to verify no Elixir source still bakes the deprecated scheme into pattern
+    matches or hardcoded strings — otherwise the post-Phase-3 grammar CHECK
+    migration breaks the Elixir router on first acquire.
+
+    Match heuristic: `f'"{kind}:'` matches double-quoted scheme prefix
+    literals (`"file:"`, `"dialectic:/"`, etc.) — covers both pattern-match
+    arms (`"dialectic:" <> rest -> ...`) and concatenated string literals.
+    Comments mentioning the kind are also flagged (acceptable false positive;
+    operator review is the recovery path).
+
+    SKIP if psql missing, deprecated_schemes table absent (lease plane not
+    installed), or no `elixir/` directory in the repo. PASS if no kinds are
+    deprecated. PASS if kinds are deprecated but no Elixir source mentions
+    them. WARN with a per-file detail listing if hits exist.
+    """
+    name, mode = "elixir_deprecated_scheme_lint", "local"
+
+    if shutil.which("psql") is None:
+        return CheckResult(name, mode, Status.SKIP, "psql not on PATH")
+
+    proc = subprocess.run(
+        ["psql", db_url, "-Atqc",
+         "SELECT surface_kind FROM lease_plane.deprecated_schemes ORDER BY surface_kind"],
+        capture_output=True, text=True, timeout=5,
+    )
+    if proc.returncode != 0:
+        return CheckResult(
+            name, mode, Status.SKIP,
+            "deprecated_schemes not queryable (lease plane not installed?)",
+        )
+
+    deprecated_kinds = [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+    if not deprecated_kinds:
+        return CheckResult(name, mode, Status.PASS, "no deprecated schemes")
+
+    elixir_root = repo_root / "elixir"
+    if not elixir_root.is_dir():
+        return CheckResult(name, mode, Status.SKIP, "no elixir/ directory")
+
+    hits: list[str] = []
+    for ex_file in sorted(elixir_root.glob("**/*.ex")):
+        # Skip vendored deps — they're third-party and out of scope.
+        # Path.parts is OS-neutral (council CONCERN 1: string-comparison on
+        # str(Path) breaks on Windows separators; not a live bug since the
+        # repo is macOS-only, but every other check in this file uses Path
+        # operations — keep style consistent).
+        if "deps" in ex_file.parts or "_build" in ex_file.parts:
+            continue
+        try:
+            text = ex_file.read_text(errors="replace")
+        except OSError:
+            continue
+        for kind in deprecated_kinds:
+            if f'"{kind}:' in text:
+                hits.append(f"{ex_file.relative_to(repo_root)}: mentions deprecated {kind!r}")
+
+    if hits:
+        return CheckResult(
+            name, mode, Status.WARN,
+            f"{len(hits)} Elixir source mention(s) of deprecated scheme(s) "
+            f"({', '.join(deprecated_kinds)})",
+            detail="\n".join(hits),
+        )
+    return CheckResult(
+        name, mode, Status.PASS,
+        f"no Elixir source mentions deprecated schemes ({', '.join(deprecated_kinds)})",
+    )
+
+
 def check_anchor_dir() -> CheckResult:
     name, mode = "anchor_directory", "local"
     if ANCHOR_DIR.is_dir():
@@ -387,6 +462,8 @@ def build_checks(repo_root: Path, db_url: str) -> list[Check]:
         Check("governance_database", "local", lambda: check_governance_database(db_url)),
         Check("pg_extensions", "local", lambda: check_pg_extensions(db_url)),
         Check("schema_migrations", "local", lambda: check_schema_migrations(db_url, repo_root)),
+        Check("elixir_deprecated_scheme_lint", "local",
+              lambda: check_elixir_deprecated_scheme_lint(db_url, repo_root)),
         Check("anchor_directory", "local", check_anchor_dir),
         Check("secrets_file", "local", check_secrets_file),
         Check("http_listening", "operator", check_http_listening),

--- a/tests/test_unitares_doctor_script.py
+++ b/tests/test_unitares_doctor_script.py
@@ -171,3 +171,115 @@ def test_main_returns_failure_when_check_fails(doctor, monkeypatch, capsys):
 
     rc = doctor.main(["--json", "--no-color"])
     assert rc == 1
+
+
+# ---------- elixir_deprecated_scheme_lint (RFC §7.11.8 — Phase B prep) ----------
+
+
+class _Proc:
+    """Tiny stand-in for subprocess.CompletedProcess. Tests pass returncode + stdout."""
+
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_elixir_lint_skips_when_psql_missing(doctor, monkeypatch, tmp_path):
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: None)
+    result = doctor.check_elixir_deprecated_scheme_lint("postgresql://example", tmp_path)
+    assert result.status == doctor.Status.SKIP
+    assert "psql not on PATH" in result.message
+
+
+def test_elixir_lint_skips_when_deprecated_schemes_table_absent(doctor, monkeypatch, tmp_path):
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: "/usr/bin/psql")
+    monkeypatch.setattr(doctor.subprocess, "run",
+                        lambda *a, **kw: _Proc(returncode=1, stderr="relation does not exist"))
+    result = doctor.check_elixir_deprecated_scheme_lint("postgresql://example", tmp_path)
+    assert result.status == doctor.Status.SKIP
+    assert "deprecated_schemes not queryable" in result.message
+
+
+def test_elixir_lint_passes_when_no_deprecated_schemes(doctor, monkeypatch, tmp_path):
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: "/usr/bin/psql")
+    monkeypatch.setattr(doctor.subprocess, "run",
+                        lambda *a, **kw: _Proc(returncode=0, stdout=""))
+    result = doctor.check_elixir_deprecated_scheme_lint("postgresql://example", tmp_path)
+    assert result.status == doctor.Status.PASS
+    assert "no deprecated schemes" in result.message
+
+
+def test_elixir_lint_passes_when_psql_returns_trailing_newline_only(doctor, monkeypatch, tmp_path):
+    """Council CONCERN 2: psql -Atq sometimes emits a trailing newline even
+    on zero-row results. The `if line.strip()` guard handles it correctly;
+    this test pins that behavior so a refactor doesn't break the PASS gate.
+    """
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: "/usr/bin/psql")
+    monkeypatch.setattr(doctor.subprocess, "run",
+                        lambda *a, **kw: _Proc(returncode=0, stdout="\n"))
+    result = doctor.check_elixir_deprecated_scheme_lint("postgresql://example", tmp_path)
+    assert result.status == doctor.Status.PASS
+    assert "no deprecated schemes" in result.message
+
+
+def test_elixir_lint_skips_when_no_elixir_directory(doctor, monkeypatch, tmp_path):
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: "/usr/bin/psql")
+    monkeypatch.setattr(doctor.subprocess, "run",
+                        lambda *a, **kw: _Proc(returncode=0, stdout="dialectic\n"))
+    result = doctor.check_elixir_deprecated_scheme_lint("postgresql://example", tmp_path)
+    assert result.status == doctor.Status.SKIP
+    assert "no elixir/ directory" in result.message
+
+
+def test_elixir_lint_passes_when_elixir_does_not_mention_deprecated_kind(doctor, monkeypatch, tmp_path):
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: "/usr/bin/psql")
+    monkeypatch.setattr(doctor.subprocess, "run",
+                        lambda *a, **kw: _Proc(returncode=0, stdout="dialectic\n"))
+    elixir_dir = tmp_path / "elixir" / "lease_plane" / "lib"
+    elixir_dir.mkdir(parents=True)
+    (elixir_dir / "router.ex").write_text(
+        '''defmodule Router do
+          def dispatch("file://" <> rest), do: rest
+          def dispatch("resident:/" <> rest), do: rest
+        end
+        '''
+    )
+    result = doctor.check_elixir_deprecated_scheme_lint("postgresql://example", tmp_path)
+    assert result.status == doctor.Status.PASS
+    assert "dialectic" in result.message
+
+
+def test_elixir_lint_warns_when_elixir_mentions_deprecated_kind(doctor, monkeypatch, tmp_path):
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: "/usr/bin/psql")
+    monkeypatch.setattr(doctor.subprocess, "run",
+                        lambda *a, **kw: _Proc(returncode=0, stdout="dialectic\n"))
+    elixir_dir = tmp_path / "elixir" / "lease_plane" / "lib"
+    elixir_dir.mkdir(parents=True)
+    (elixir_dir / "canonicalize.ex").write_text(
+        '''defmodule Canonicalize do
+          defp dispatch("dialectic:" <> rest), do: rest
+        end
+        '''
+    )
+    result = doctor.check_elixir_deprecated_scheme_lint("postgresql://example", tmp_path)
+    assert result.status == doctor.Status.WARN
+    assert "1 Elixir source mention" in result.message
+    assert "dialectic" in result.message
+    assert "canonicalize.ex" in result.detail
+
+
+def test_elixir_lint_excludes_deps_and_build_dirs(doctor, monkeypatch, tmp_path):
+    """Vendored deps + _build artifacts mention scheme strings (e.g., bandit
+    docs) but they're third-party; lint must skip them to avoid noise."""
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: "/usr/bin/psql")
+    monkeypatch.setattr(doctor.subprocess, "run",
+                        lambda *a, **kw: _Proc(returncode=0, stdout="dialectic\n"))
+    deps_dir = tmp_path / "elixir" / "lease_plane" / "deps" / "bandit"
+    deps_dir.mkdir(parents=True)
+    (deps_dir / "vendored.ex").write_text('"dialectic:" — incidental string in vendored dep')
+
+    result = doctor.check_elixir_deprecated_scheme_lint("postgresql://example", tmp_path)
+    assert result.status == doctor.Status.PASS, (
+        f"vendored deps/ mentions must not trigger WARN; got {result.status}: {result.message}"
+    )


### PR DESCRIPTION
## Summary

Phase B prep per RFC §7.11.8: WARN operator + CI when any first-party Elixir source still mentions a `surface_kind` currently in `lease_plane.deprecated_schemes`. Without this lint, the §7.11.1 Phase 1 verification step (between Phase 0 mark and Phase 3 finalize) is an honor system — a forgotten Elixir-side reference would brick the router on the post-Phase-3 grammar CHECK migration.

## Behavior

| State | Status | Message |
|-------|--------|---------|
| psql not on PATH | SKIP | `psql not on PATH` |
| `lease_plane.deprecated_schemes` not queryable (lease plane not installed) | SKIP | `deprecated_schemes not queryable` |
| No `elixir/` directory in repo | SKIP | `no elixir/ directory` |
| No kinds deprecated | PASS | `no deprecated schemes` |
| Kinds deprecated, no Elixir mentions | PASS | `no Elixir source mentions deprecated schemes (...)` |
| Kinds deprecated, Elixir mentions exist | WARN | `N Elixir source mention(s) of deprecated scheme(s) (...)` + per-file detail |

Match heuristic: `f'"{kind}:'` matches double-quoted scheme prefix literals — covers pattern-match arms (`"dialectic:" <> rest -> ...`) and concatenated string literals. Vendored `deps/` + `_build/` excluded via `Path.parts` membership test.

## Council pass (single reviewer agent — low blast radius script-level check)

Reviewer SHIP-WITH-FIXES. Both fixes applied:
- **CONCERN 1**: replaced `"/deps/" in str(ex_file)` string-comparison with `Path.parts` membership test (Windows-portable + consistent with rest of file's OS-neutral Path operations)
- **CONCERN 2**: added `test_elixir_lint_passes_when_psql_returns_trailing_newline_only` to pin the empty-line guard branch in PASS path

Reviewer answered all 8 specific failure modes — no other issues. Glob recursion walks `deps/` before per-file filter (cost negligible at typical Mix dep scale).

## Test plan

- [x] `python3 -m pytest tests/test_unitares_doctor_script.py`: **19 passed** (was 11; +7 new lint tests + 1 council-fix test)
- [x] **Live PASS path verified** against current `governance` DB (zero deprecated schemes): `✓ elixir_deprecated_scheme_lint: no deprecated schemes`
- [x] **Live WARN path verified** against `governance_test` after marking `dialectic` deprecated: correctly identified `canonicalize.ex` + `lease_test_helpers.ex`; cleanup confirmed
- [x] Single-writer surface check: `gh pr list --search "doctor OR scheme lint"` returned empty
- [x] Side-effect-free: read-only SELECT + read-only file scans; no DB or filesystem writes

## Surface-collision check

`gh pr list -R CIRWEL/unitares --search "doctor OR elixir scheme lint OR deprecated_scheme" --state open` returned empty.