### PR TITLE
feat(r6): add episode fork kind to process update context

### DIFF
--- a/docs/ontology/r6-episode-fork-response-shape.md
+++ b/docs/ontology/r6-episode-fork-response-shape.md
@@ -42,7 +42,7 @@ The April 30 case was unambiguously (1). But the response field name and its boo
 
 | Field | Type | Semantics |
 |---|---|---|
-| `episode_fork_kind` | string enum: `none` / `sibling_locus` / `identity_lineage` | What kind of fork this event represents. **`none`** = first observation under this thread (position == 1). **`sibling_locus`** = same registry UUID, fresh process-instance (or position > 1), no child UUID minted under declared lineage. The April 30 case. **`identity_lineage`** = the current writer's UUID is distinct from a declared `parent_agent_id`, OR (sync-race fallback) `spawn_reason` is in the known-lineage set. |
+| `episode_fork_kind` | string enum: `none` / `sibling_locus` / `identity_lineage` | What kind of fork this event represents. **`none`** = no lineage declaration detected and first observation under this thread (position == 1). **`sibling_locus`** = same registry UUID, fresh process-instance (or position > 1), no child UUID minted under declared lineage. The April 30 case. **`identity_lineage`** = the current writer's UUID is distinct from a declared `parent_agent_id`, OR (sync-race fallback) `spawn_reason` is in the known-lineage set. |
 | `identity_lineage_fork` | boolean | True if and only if `episode_fork_kind == "identity_lineage"`. Redundant with the enum but kept as a fast scalar for callers that only need the boolean discrimination. False in every other case, including `sibling_locus`. |
 
 **v1 had 5 enum values.** v2 collapses to 3 because:
@@ -51,9 +51,9 @@ The April 30 case was unambiguously (1). But the response field name and its boo
 
 ### Deprecated (kept for compat, narrowed documented intent)
 
-`is_fork` (boolean) at `enrichments.py:1518`: currently `position > 1`. Value-equivalent under v2's classifier (proven below). Documented intent re-grounded: `is_fork` indicates "an event that is not the root node of this thread"; `episode_fork_kind` carries the actual ontology distinction. Future deferred decision (post-Phase 1): rename or retire `is_fork`.
+`is_fork` (boolean) at `enrichments.py:1518`: currently `position > 1`. Kept value-compatible. Documented intent re-grounded: `is_fork` indicates "an event that is not the root node of this thread"; `episode_fork_kind` carries the actual ontology distinction. Future deferred decision (post-Phase 1): rename or retire `is_fork`.
 
-**Equivalence proof.** v2's `_classify_fork` returns `"none"` if and only if `position == 1`. So `episode_fork_kind != "none"` ⟺ `position > 1` ⟺ current `is_fork` value. No caller behavior change. The narrowed-intent claim is purely documentary; the field's value is mathematically identical.
+**Compatibility boundary.** `is_fork` remains purely position-based. It is not equivalent to `episode_fork_kind != "none"` in the identity-lineage-at-root case: a fresh child UUID can be position 1 while still being a declared identity-lineage fork. This is exactly why `identity_lineage_fork` exists as a separate scalar. No caller behavior change occurs because `is_fork` keeps its old value.
 
 ## The classifier (v2)
 
@@ -205,7 +205,7 @@ For `_classify_fork` unit tests:
 For `enrich_thread_identity` integration:
 
 10. **Thin thread_context shape addition.** Call `process_agent_update` with a known fixture; assert response.thread_context contains `episode_fork_kind`, `identity_lineage_fork`, `honest_message`, plus preserved `thread_id`, `position`, `is_fork`.
-11. **`is_fork` value equivalence.** For each of cases 1–9, assert `thread_context["is_fork"] == (thread_context["episode_fork_kind"] != "none")`. Catches future regressions in the equivalence claim.
+11. **`is_fork` compatibility.** For each of cases 1–9, assert `thread_context["is_fork"] == (position > 1)`. Separately assert identity-lineage-at-root sets `identity_lineage_fork=true` while leaving legacy `is_fork=false`.
 
 ## Calibration / Phase 1 telemetry
 

--- a/src/mcp_handlers/updates/enrichments.py
+++ b/src/mcp_handlers/updates/enrichments.py
@@ -9,7 +9,7 @@ enrichment failure never crashes the update.
 import json
 import os
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Optional
 
 from src.logging_utils import get_logger
 
@@ -17,6 +17,8 @@ from .context import UpdateContext
 from .pipeline import enrichment
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 logger = get_logger(__name__)
+
+_LINEAGE_SPAWN_REASONS = frozenset({"new_session", "subagent", "explicit", "compaction"})
 
 # ─── Identity Reminder ─────────────────────────────────────────────────
 
@@ -1506,16 +1508,92 @@ async def enrich_identity_notifications(ctx: UpdateContext) -> None:
 
 # ─── Thread Identity ───────────────────────────────────────────────────
 
+def _classify_fork(
+    position: int,
+    agent_uuid: str,
+    parent_uuid: Optional[str],
+    spawn_reason: Optional[str],
+) -> tuple[str, bool]:
+    """Return the R6 episode-fork kind and identity-lineage boolean."""
+    has_child_uuid = bool(parent_uuid and agent_uuid and agent_uuid != parent_uuid)
+    if has_child_uuid:
+        return ("identity_lineage", True)
+
+    if spawn_reason in _LINEAGE_SPAWN_REASONS and not parent_uuid:
+        logger.warning(
+            "[R6_SYNC_RACE] spawn_reason=%s recognized as lineage but "
+            "parent_agent_id is None on ctx.meta - possible AgentMetadata sync "
+            "failure at handlers.py:1690-1698. Classifying as identity_lineage "
+            "anyway. agent_uuid=%s",
+            spawn_reason,
+            agent_uuid,
+        )
+        return ("identity_lineage", True)
+
+    if position > 1:
+        return ("sibling_locus", False)
+
+    return ("none", False)
+
+
+def _fork_honest_message(
+    episode_fork_kind: str,
+    parent_uuid: Optional[str],
+    spawn_reason: Optional[str],
+) -> str:
+    """Build the thin process_agent_update fork message from R6 v2."""
+    if episode_fork_kind == "sibling_locus":
+        return (
+            "You share a registry UUID with prior process-instances under this "
+            "thread, but you are a distinct subject - fresh process-instance, "
+            "no child UUID minted. Memory access (KG, project files, "
+            "harness-side caches) may be available; whether you have integrated "
+            "it is yours to demonstrate, not asserted."
+        )
+
+    if episode_fork_kind == "identity_lineage":
+        parent_display = parent_uuid or "unknown"
+        spawn_display = spawn_reason or "unknown"
+        return (
+            "You are a distinct subject (a fresh UUID under declared parent "
+            f"{parent_display}, spawn_reason {spawn_display}). Lineage was "
+            "declared at this fork event; whether it becomes confirmed is "
+            "governed by R2's protocol (see provisional_lineage flag and "
+            "downstream R1 evaluation)."
+        )
+
+    return "You are the first observation under this thread. No fork."
+
 @enrichment(order=230)
 def enrich_thread_identity(ctx: UpdateContext) -> None:
     """Provide thread continuity context across sessions (honest forking)."""
     try:
         if ctx.meta and getattr(ctx.meta, "thread_id", None):
-            position = getattr(ctx.meta, "node_index", 1)
+            position = int(getattr(ctx.meta, "node_index", 1) or 1)
+            parent_uuid = getattr(ctx.meta, "parent_agent_id", None)
+            spawn_reason = getattr(ctx.meta, "spawn_reason", None)
+            agent_uuid = (
+                ctx.agent_uuid
+                or getattr(ctx.meta, "agent_uuid", None)
+                or getattr(ctx.meta, "agent_id", "")
+            )
+            episode_fork_kind, identity_lineage_fork = _classify_fork(
+                position,
+                agent_uuid,
+                parent_uuid,
+                spawn_reason,
+            )
             ctx.response_data["thread_context"] = {
                 "thread_id": ctx.meta.thread_id,
                 "position": position,
                 "is_fork": position > 1,
+                "episode_fork_kind": episode_fork_kind,
+                "identity_lineage_fork": identity_lineage_fork,
+                "honest_message": _fork_honest_message(
+                    episode_fork_kind,
+                    parent_uuid,
+                    spawn_reason,
+                ),
             }
     except Exception as e:
         logger.debug(f"Could not enrich thread identity: {e}")

--- a/tests/test_r6_episode_fork_enrichment.py
+++ b/tests/test_r6_episode_fork_enrichment.py
@@ -1,0 +1,124 @@
+"""R6 process_agent_update fork-kind enrichment tests."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.mcp_handlers.updates.context import UpdateContext
+from src.mcp_handlers.updates.enrichments import _classify_fork, enrich_thread_identity
+
+
+@pytest.mark.parametrize(
+    (
+        "position",
+        "agent_uuid",
+        "parent_uuid",
+        "spawn_reason",
+        "expected_kind",
+        "expected_lineage",
+    ),
+    [
+        (1, "agent-1", None, None, "none", False),
+        (2, "agent-1", None, None, "sibling_locus", False),
+        (1, "child", "parent", "new_session", "identity_lineage", True),
+        (1, "child", "parent", "subagent", "identity_lineage", True),
+        (1, "child", "parent", "compaction", "identity_lineage", True),
+        (1, "child", "parent", "resident_observer", "identity_lineage", True),
+        (1, "agent-1", None, "dispatch_auto_mint", "none", False),
+        (2, "lumen", "lumen", "explicit", "sibling_locus", False),
+    ],
+)
+def test_classify_fork_r6_v2_cases(
+    position,
+    agent_uuid,
+    parent_uuid,
+    spawn_reason,
+    expected_kind,
+    expected_lineage,
+):
+    assert _classify_fork(position, agent_uuid, parent_uuid, spawn_reason) == (
+        expected_kind,
+        expected_lineage,
+    )
+
+
+def test_classify_fork_sync_race_fallback_warns(caplog):
+    kind, lineage = _classify_fork(
+        position=1,
+        agent_uuid="child",
+        parent_uuid=None,
+        spawn_reason="subagent",
+    )
+
+    assert (kind, lineage) == ("identity_lineage", True)
+    assert "[R6_SYNC_RACE]" in caplog.text
+
+
+def _ctx_for_thread(
+    *,
+    position,
+    agent_uuid="agent-1",
+    parent_uuid=None,
+    spawn_reason=None,
+):
+    return UpdateContext(
+        agent_uuid=agent_uuid,
+        meta=SimpleNamespace(
+            agent_id=agent_uuid,
+            agent_uuid=agent_uuid,
+            thread_id="thread-r6",
+            node_index=position,
+            parent_agent_id=parent_uuid,
+            spawn_reason=spawn_reason,
+        ),
+    )
+
+
+def test_enrich_thread_identity_adds_r6_thin_shape_for_sibling_locus():
+    ctx = _ctx_for_thread(position=2)
+
+    enrich_thread_identity(ctx)
+
+    thread_context = ctx.response_data["thread_context"]
+    assert thread_context["thread_id"] == "thread-r6"
+    assert thread_context["position"] == 2
+    assert thread_context["is_fork"] is True
+    assert thread_context["episode_fork_kind"] == "sibling_locus"
+    assert thread_context["identity_lineage_fork"] is False
+    assert thread_context["is_fork"] == (thread_context["episode_fork_kind"] != "none")
+    assert "registry UUID" in thread_context["honest_message"]
+    assert "whether you have integrated it is yours to demonstrate" in thread_context["honest_message"]
+
+
+def test_enrich_thread_identity_adds_r6_thin_shape_for_identity_lineage():
+    ctx = _ctx_for_thread(
+        position=1,
+        agent_uuid="child",
+        parent_uuid="parent",
+        spawn_reason="new_session",
+    )
+
+    enrich_thread_identity(ctx)
+
+    thread_context = ctx.response_data["thread_context"]
+    assert thread_context["is_fork"] is False
+    assert thread_context["episode_fork_kind"] == "identity_lineage"
+    assert thread_context["identity_lineage_fork"] is True
+    # Legacy is_fork remains position-based for backward compatibility; identity
+    # lineage at root position is now disambiguated by identity_lineage_fork.
+    assert thread_context["is_fork"] is False
+    assert "Lineage was declared" in thread_context["honest_message"]
+    assert "R2's protocol" in thread_context["honest_message"]
+
+
+def test_enrich_thread_identity_adds_r6_thin_shape_for_root():
+    ctx = _ctx_for_thread(position=1)
+
+    enrich_thread_identity(ctx)
+
+    thread_context = ctx.response_data["thread_context"]
+    assert thread_context["is_fork"] is False
+    assert thread_context["episode_fork_kind"] == "none"
+    assert thread_context["identity_lineage_fork"] is False
+    assert thread_context["is_fork"] == (thread_context["episode_fork_kind"] != "none")
+    assert thread_context["honest_message"] == "You are the first observation under this thread. No fork."


### PR DESCRIPTION
Adds the R6 thin process_agent_update thread_context fields: episode_fork_kind, identity_lineage_fork, and honest_message. Preserves legacy is_fork as position-based and documents the identity-lineage-at-root compatibility boundary.\n\nTests run:\n- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q -p no:cacheprovider tests/test_r6_episode_fork_enrichment.py tests/test_enrichment_pipeline.py tests/test_thread_identity.py\n- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q -p no:cacheprovider tests/test_update_workflow_service.py tests/test_core_update.py tests/test_response_formatter.py tests/test_grounding_enrichment.py tests/test_grounding_end_to_end.py\n- pre-push smoke: 138 passed, 7485 deselected\n\nNote: pre-push doc health reported one pre-existing warning in elixir/lease_plane/deps/bandit/README.md -> config/config.exs.