### PR TITLE
fix(watcher): P005 — drop false positives on acquire-then-try idiom

### DIFF
--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -1234,6 +1234,47 @@ def _is_acquire_inside_try_with_none_init(
     return False
 
 
+def _is_acquire_then_try_with_unconditional_close(
+    flagged_line: int,
+    snippet_lines_by_num: dict[int, str],
+    lookahead: int = 4,
+) -> bool:
+    """Detect the canonical `acquire-then-try` idiom.
+
+    Shape:
+        <var> = await <expr>.(acquire|cursor|connect|lock)(...)
+        try:
+            ...
+        finally:
+            await <var>.close()  # or .release()
+
+    The flagged line must be the acquire itself. We walk forward up to
+    ``lookahead`` lines, skipping blanks and comments; the first real line
+    must be ``try:``. Mirrors `_is_acquire_inside_try_with_none_init` in
+    only verifying the structural cue — the matching `finally:` is not
+    separately checked. Once the operator wrote `<var> = await ... ; try:`,
+    the only failure mode is "forgot the close inside finally", which is
+    a different bug class than P005 catches.
+
+    Caught when qwen3-coder-next flagged 4 sites in
+    `scripts/dev/lease_plane_deprecate.py` on 2026-05-01 (issue #268,
+    fingerprints ab83f5e0, f67aebf6, 0f4ceac4, 4ba2a281).
+    """
+    src_line = snippet_lines_by_num.get(flagged_line, "")
+    if not _P005_VAR_AWAIT_ACQUIRE.match(src_line):
+        return False
+    for line_no in range(flagged_line + 1, flagged_line + lookahead + 1):
+        line = snippet_lines_by_num.get(line_no, "")
+        if not line.strip() or _looks_like_comment(line):
+            continue
+        # Function boundary: a new def header before try: means the acquire
+        # was the last stmt of its function — not the canonical idiom.
+        if _P003_OTHER_DEF.match(line) or _P003_CACHE_FUNC_HEADER.match(line):
+            return False
+        return bool(_P005_TRY_HEADER.match(line))
+    return False
+
+
 def _is_wait_for_guarded_onboard_pin_helper(
     flagged_line: int,
     snippet_lines_by_num: dict[int, str],
@@ -1425,6 +1466,19 @@ def _verify_finding_against_source(
         log(
             f"drop P005 {finding.file}:{finding.line} — acquire inside try with "
             f"<var> = None pre-init: {src_line.strip()[:80]}",
+            "warning",
+        )
+        return False
+    # P005 specifically: `<var> = await X.connect(...); try: ...; finally:
+    # await <var>.close()` is the canonical asyncpg idiom for resources
+    # without async-context-manager support. Release is unconditional, so
+    # this is not a leak even though `acquire`/`connect` appears.
+    if finding.pattern == "P005" and _is_acquire_then_try_with_unconditional_close(
+        finding.line, snippet_lines_by_num
+    ):
+        log(
+            f"drop P005 {finding.file}:{finding.line} — acquire-then-try idiom "
+            f"with unconditional close: {src_line.strip()[:80]}",
             "warning",
         )
         return False

--- a/agents/watcher/tests/test_agent.py
+++ b/agents/watcher/tests/test_agent.py
@@ -1990,6 +1990,129 @@ def test_p001_dropped_on_comment_line(watcher_module):
     )
 
 
+def test_p005_dropped_for_acquire_then_try_with_unconditional_close(watcher_module):
+    """P005 must not fire on the canonical asyncpg `acquire-then-try` idiom:
+
+        conn = await asyncpg.connect(db_url)
+        try:
+            ...
+        finally:
+            await conn.close()
+
+    Release is unconditional. Caught when qwen3-coder-next flagged four
+    sites in scripts/dev/lease_plane_deprecate.py on 2026-05-01 (issue #268,
+    fingerprints ab83f5e0, f67aebf6, 0f4ceac4, 4ba2a281).
+    """
+    f = watcher_module.Finding(
+        pattern="P005",
+        file="/repo/scripts/dev/lease_plane_deprecate.py",
+        line=98,
+        hint="t",
+        severity="high",
+        detected_at="2026-05-01T00:00:00Z",
+        model_used="t",
+    )
+    snippet = {
+        97: "    \"\"\"Phase 0: mark scheme deprecated.\"\"\"",
+        98: "    conn = await asyncpg.connect(db_url)",
+        99: "    try:",
+        100: "        catalog = await _list_catalog_kinds(conn)",
+        101: "        ...",
+        102: "    finally:",
+        103: "        await conn.close()",
+    }
+    assert not watcher_module._verify_finding_against_source(f, "", snippet)
+
+
+def test_p005_dropped_for_acquire_then_try_with_blank_line_between(watcher_module):
+    """A blank line between the acquire and the try header doesn't change
+    the operator's intent — same idiom, just spaced out."""
+    f = watcher_module.Finding(
+        pattern="P005",
+        file="/repo/scripts/dev/x.py",
+        line=10,
+        hint="t",
+        severity="high",
+        detected_at="2026-05-01T00:00:00Z",
+        model_used="t",
+    )
+    snippet = {
+        10: "    conn = await asyncpg.connect(db_url)",
+        11: "",
+        12: "    try:",
+        13: "        await conn.execute('SELECT 1')",
+        14: "    finally:",
+        15: "        await conn.close()",
+    }
+    assert not watcher_module._verify_finding_against_source(f, "", snippet)
+
+
+def test_p005_dropped_for_acquire_then_try_acquire_variant(watcher_module):
+    """The `.acquire(` variant (e.g. pool.acquire()) inside the same shape
+    is equally safe — same try/finally guarantees release."""
+    f = watcher_module.Finding(
+        pattern="P005",
+        file="/repo/src/x.py",
+        line=20,
+        hint="t",
+        severity="high",
+        detected_at="2026-05-01T00:00:00Z",
+        model_used="t",
+    )
+    snippet = {
+        20: "    conn = await pool.acquire()",
+        21: "    try:",
+        22: "        await conn.fetch('SELECT 1')",
+        23: "    finally:",
+        24: "        await pool.release(conn)",
+    }
+    assert not watcher_module._verify_finding_against_source(f, "", snippet)
+
+
+def test_p005_kept_when_acquire_not_followed_by_try(watcher_module):
+    """Negative case: a bare acquire with no try wrapper at all is still a
+    real leak risk and must survive verification."""
+    f = watcher_module.Finding(
+        pattern="P005",
+        file="/repo/src/x.py",
+        line=10,
+        hint="t",
+        severity="high",
+        detected_at="2026-05-01T00:00:00Z",
+        model_used="t",
+    )
+    snippet = {
+        10: "    conn = await asyncpg.connect(db_url)",
+        11: "    rows = await conn.fetch('SELECT 1')",
+        12: "    return rows",
+    }
+    assert watcher_module._verify_finding_against_source(f, "", snippet)
+
+
+def test_p005_kept_when_intervening_statement_between_acquire_and_try(watcher_module):
+    """Negative case: if real code sits between the acquire and the try, the
+    cancel-between-acquire-and-try window is wider AND the operator's intent
+    is no longer the canonical idiom. Keep the finding."""
+    f = watcher_module.Finding(
+        pattern="P005",
+        file="/repo/src/x.py",
+        line=10,
+        hint="t",
+        severity="high",
+        detected_at="2026-05-01T00:00:00Z",
+        model_used="t",
+    )
+    snippet = {
+        10: "    conn = await asyncpg.connect(db_url)",
+        11: "    log.info('connected')",
+        12: "    try:",
+        13: "        await conn.fetch('SELECT 1')",
+        14: "    finally:",
+        15: "        await conn.close()",
+    }
+    assert watcher_module._verify_finding_against_source(f, "", snippet)
+
+
 def test_p016_dropped_on_typed_attribute_access(watcher_module):
     """P016 is the double-envelope dict-parsing bug. Pure attribute access
     on a typed pydantic model — `if audit_result.success:` — is by

--- a/tests/test_watcher_p005_async_with.py
+++ b/tests/test_watcher_p005_async_with.py
@@ -169,9 +169,14 @@ class TestP005PreInitTryFinally:
         }
         assert _verify_finding_against_source(_make(15), "", snippet) is False
 
-    def test_acquire_outside_try_with_pre_init_kept(self):
-        # `<var> = None` then bare acquire OUTSIDE any try block is the
-        # original buggy shape — must NOT drop.
+    def test_acquire_outside_try_dropped_by_acquire_then_try_filter(self):
+        # `<var> = await X.acquire(); try:` is the canonical asyncpg idiom
+        # under the policy from issue #268 — the cancel-between-acquire-
+        # and-try window is theoretical and the operator's intent is
+        # unambiguous, so the third P005 filter
+        # (`_is_acquire_then_try_with_unconditional_close`) drops it.
+        # The `conn = None` pre-init above is incidental — it does not
+        # change the acquire-then-try shape on lines 12-13.
         snippet = {
             10: "async def f():",
             11: "conn = None",
@@ -179,4 +184,4 @@ class TestP005PreInitTryFinally:
             13: "try:",
             14: "    pass",
         }
-        assert _verify_finding_against_source(_make(12), "", snippet) is True
+        assert _verify_finding_against_source(_make(12), "", snippet) is False


### PR DESCRIPTION
Closes #268.

## Summary

Adds `_is_acquire_then_try_with_unconditional_close` as a third P005 false-positive filter, alongside `_P005_CONTEXT_MANAGED` (async with) and `_is_acquire_inside_try_with_none_init` (None pre-init + in-try acquire).

Detects the canonical asyncpg shape:

```python
conn = await asyncpg.connect(db_url)
try:
    ...
finally:
    await conn.close()
```

Mirrors the existing filter's posture — structural cue (acquire line followed, within a 4-line lookahead skipping blanks/comments, by `try:`) is sufficient; the matching finally body is not separately verified. The cancel-between-acquire-and-try window is theoretical and is a different bug class than P005 catches; HIGH severity for it is wrong.

## Test plan

- [x] 5 new unit tests in `agents/watcher/tests/test_agent.py` (canonical shape, blank-line variant, `pool.acquire()` variant, two negative cases: bare acquire without try, intervening statement between acquire and try)
- [x] 1 existing test (`test_acquire_outside_try_with_pre_init_kept` in `tests/test_watcher_p005_async_with.py`) renamed and inverted — that exact shape is what #268 reclassifies as the canonical idiom
- [x] Full suite green: 8071 passed, 33 skipped (`./scripts/dev/test-cache.sh`)

## Watcher fingerprints

Resolves Watcher fingerprints `ab83f5e0`, `f67aebf6`, `0f4ceac4`, `4ba2a281` — false positives on `scripts/dev/lease_plane_deprecate.py` (2026-05-01).