### PR TITLE
fix(sentinel): wrap forced-release alarm poll in run_in_executor + asyncio.wait_for (anyio mitigation)

### DIFF
--- a/agents/sentinel/agent.py
+++ b/agents/sentinel/agent.py
@@ -404,6 +404,53 @@ class SitrepGenerator:
 
 
 # ---------------------------------------------------------------------------
+# anyio-asyncio mitigation for forced-release alarm polling
+# ---------------------------------------------------------------------------
+
+_POLL_TIMEOUT_S = 30.0
+
+
+def _poll_sync_forced_release(db_url: str, last_event_ts: "datetime | None"):
+    """Sync wrapper for `poll_forced_release_alarms` to be called via
+    `loop.run_in_executor` (CLAUDE.md anyio mitigation pattern 2).
+
+    Sentinel's cycle runs inside the GovernanceAgent SDK's anyio scope
+    (`unitares_sdk/client.py` wraps MCP calls in `anyio.fail_after`).
+    Awaiting `asyncpg.connect()` directly inside that scope can deadlock —
+    the prior 30h wedge cited at lines 63-69 was this exact pathology.
+    This wrapper runs the asyncpg work on a thread executor with
+    `asyncio.run()`, which creates a fresh inner event loop. Per memory
+    `feedback_asyncpg-loop-binding.md` ("pools/Futures bound to whichever
+    loop is running when awaitable is evaluated"), asyncpg binds to that
+    inner loop, runs to completion, and tears down inside `asyncio.run()` —
+    never crossing the outer anyio loop.
+
+    The inner `asyncio.wait_for(..., timeout=_POLL_TIMEOUT_S)` is
+    defense-in-depth (council CONCERN — architect + reviewer convergence):
+    `loop.run_in_executor` cannot cancel a running thread, so a CYCLE_TIMEOUT
+    cancellation in the outer loop frees the awaiting task but the executor
+    thread keeps running until asyncpg returns. With sustained DB outage
+    that's up to asyncpg's default 60s connect timeout — longer than
+    CYCLE_TIMEOUT (45s), so threads accumulate ~1/cycle and the default
+    ThreadPoolExecutor (~12-14 threads) eventually exhausts. The inner
+    wait_for forces the executor thread itself to release at 30s, well
+    inside CYCLE_TIMEOUT. asyncio.TimeoutError propagates through the
+    caller's existing try/except.
+
+    Returns the same `(alarms, new_cursor)` tuple as
+    `poll_forced_release_alarms`. Exceptions propagate unchanged.
+    """
+    from agents.sentinel.forced_release_alarm import poll_forced_release_alarms
+
+    return asyncio.run(
+        asyncio.wait_for(
+            poll_forced_release_alarms(db_url=db_url, last_event_ts=last_event_ts),
+            timeout=_POLL_TIMEOUT_S,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
 # Sentinel Agent
 # ---------------------------------------------------------------------------
 
@@ -589,10 +636,21 @@ class SentinelAgent(GovernanceAgent):
         DB URL: GOVERNANCE_DATABASE_URL env var, default to localhost governance.
         Failures are logged and swallowed — alarm polling MUST NOT break the
         Sentinel cycle.
-        """
-        from datetime import datetime
-        from agents.sentinel.forced_release_alarm import poll_forced_release_alarms
 
+        anyio-asyncio mitigation (CLAUDE.md "Known Issue"): the
+        `poll_forced_release_alarms` call does `asyncpg.connect()` + multiple
+        `await conn.fetch(...)`. Sentinel's `run_cycle` runs inside the
+        GovernanceAgent SDK's `run_once`, which is anyio-based. `await`-ing
+        asyncpg directly from inside the anyio task group can deadlock — the
+        prior wedge cited at line 67 (~30h) was this exact pathology.
+        Mitigation: pattern 2 from CLAUDE.md — push the asyncpg call to a
+        thread executor via `_poll_sync_forced_release`, which runs
+        `asyncio.run(...)` in the executor thread. asyncpg binds to that
+        fresh inner loop (per `feedback_asyncpg-loop-binding.md` —
+        loop-binding happens at create time, so a new loop scoped to the
+        executor call is safe), runs to completion, tears down. The outer
+        anyio task group is unblocked throughout.
+        """
         db_url = os.environ.get(
             "GOVERNANCE_DATABASE_URL",
             "postgresql://postgres:postgres@localhost:5432/governance",
@@ -600,9 +658,11 @@ class SentinelAgent(GovernanceAgent):
         state = self.load_state()
         cursor_str = state.get("forced_release_alarm", {}).get("last_event_ts")
         cursor = datetime.fromisoformat(cursor_str) if cursor_str else None
+
+        loop = asyncio.get_running_loop()
         try:
-            alarms, new_cursor = await poll_forced_release_alarms(
-                db_url=db_url, last_event_ts=cursor,
+            alarms, new_cursor = await loop.run_in_executor(
+                None, _poll_sync_forced_release, db_url, cursor,
             )
         except Exception as e:
             log(f"forced-release alarm poll failed: {e}")

--- a/tests/test_sentinel_forced_release_alarm.py
+++ b/tests/test_sentinel_forced_release_alarm.py
@@ -298,3 +298,98 @@ async def test_phase_zero_acquire_race_blocked():
     finally:
         await _cleanup(conn)
         await conn.close()
+
+
+# ---------- _poll_sync_forced_release: anyio-asyncio mitigation (CLAUDE.md pattern 2) ----------
+
+
+def test_poll_sync_forced_release_returns_same_tuple_shape_when_no_events():
+    """`_poll_sync_forced_release` must return the same `(alarms, new_cursor)`
+    tuple shape as the async `poll_forced_release_alarms` it wraps. Sync
+    callable so the GovernanceAgent SDK's anyio task group can dispatch it
+    via `loop.run_in_executor` without crossing event loops (per memory
+    `feedback_asyncpg-loop-binding.md`).
+    """
+    from agents.sentinel.agent import _poll_sync_forced_release
+
+    # Use TEST_DB_URL via env so the helper picks it up. Cursor=None to poll
+    # everything; with the 'forced' event_type query and a clean test DB this
+    # returns ([], None or whatever the latest ts is).
+    alarms, new_cursor = _poll_sync_forced_release(TEST_DB_URL, None)
+    assert isinstance(alarms, list)
+    # new_cursor is either None (no events ever) or a datetime (max ts seen).
+    from datetime import datetime as _dt
+    assert new_cursor is None or isinstance(new_cursor, _dt)
+
+
+def test_poll_sync_forced_release_loop_free_thread_succeeds_twice():
+    """Sanity: two consecutive calls from a loop-free thread (the pytest
+    main thread) succeed without leaving a running event loop between them.
+    Confirms `asyncio.run` teardown is clean per call.
+    """
+    from agents.sentinel.agent import _poll_sync_forced_release
+
+    alarms_1, cursor_1 = _poll_sync_forced_release(TEST_DB_URL, None)
+    alarms_2, cursor_2 = _poll_sync_forced_release(TEST_DB_URL, None)
+
+    assert isinstance(alarms_1, list)
+    assert isinstance(alarms_2, list)
+
+
+def test_poll_sync_forced_release_callable_via_run_in_executor():
+    """Council CONCERN 2 (reviewer): the production dispatch path runs
+    `_poll_sync_forced_release` inside a thread launched by
+    `loop.run_in_executor` from inside an `asyncio.run` context — NOT
+    directly from a loop-free pytest thread. This test exercises the
+    actual runtime shape: spin up an outer asyncio loop, dispatch to the
+    default ThreadPoolExecutor, await the result, and dispatch a SECOND
+    time from the same outer loop to verify no asyncpg loop-binding leak
+    between consecutive executor invocations.
+
+    Live-verifier confirmed this empirically pre-merge; this test pins the
+    behavior so a future refactor of `_poll_sync_forced_release` (e.g.,
+    accidentally capturing the outer loop reference) breaks loud.
+    """
+    import asyncio
+    from agents.sentinel.agent import _poll_sync_forced_release
+
+    async def driver():
+        loop = asyncio.get_running_loop()
+        alarms_1, _ = await loop.run_in_executor(
+            None, _poll_sync_forced_release, TEST_DB_URL, None,
+        )
+        alarms_2, _ = await loop.run_in_executor(
+            None, _poll_sync_forced_release, TEST_DB_URL, None,
+        )
+        return alarms_1, alarms_2
+
+    alarms_1, alarms_2 = asyncio.run(driver())
+    assert isinstance(alarms_1, list)
+    assert isinstance(alarms_2, list)
+
+
+def test_poll_sync_forced_release_timeout_propagates(monkeypatch):
+    """Council CONCERN 1 (architect + reviewer convergence): the wrapper
+    bounds executor-thread lifetime via `asyncio.wait_for(..., timeout=30s)`
+    so a wedged asyncpg call doesn't accumulate threads in the default
+    ThreadPoolExecutor. Inject a poll function that sleeps longer than
+    `_POLL_TIMEOUT_S` and verify TimeoutError propagates.
+    """
+    import asyncio
+    from agents.sentinel import agent as agent_mod
+
+    # Override the timeout for fast test execution.
+    monkeypatch.setattr(agent_mod, "_POLL_TIMEOUT_S", 0.2)
+
+    async def _wedged_poll(*, db_url, last_event_ts):
+        await asyncio.sleep(5.0)  # well over the test timeout
+        return [], None
+
+    # Patch the lazy import — the wrapper does
+    # `from agents.sentinel.forced_release_alarm import poll_forced_release_alarms`
+    # inside the function body, so we need to patch the source module.
+    from agents.sentinel import forced_release_alarm
+    monkeypatch.setattr(forced_release_alarm, "poll_forced_release_alarms", _wedged_poll)
+
+    with pytest.raises((asyncio.TimeoutError, TimeoutError)):
+        agent_mod._poll_sync_forced_release(TEST_DB_URL, None)


### PR DESCRIPTION
## Summary

Closes Phase A residual #2. Sentinel's `_emit_forced_release_alarms` was calling `await poll_forced_release_alarms(...)` directly. That function does `asyncpg.connect()` + multiple `await conn.fetch(...)`. Sentinel's `run_cycle` runs inside the GovernanceAgent SDK's anyio scope (`unitares_sdk/client.py` wraps MCP calls in `anyio.fail_after`), and awaiting asyncpg from that scope hits the deadlock pathology documented in `CLAUDE.md` "Known Issue: anyio-asyncio Conflict". The 30h wedge cited at `agent.py:67` was this exact class.

Fix per CLAUDE.md mitigation pattern 2 (`run_in_executor` with sync client). New module-level helper `_poll_sync_forced_release(db_url, last_event_ts)` wraps the async call in `asyncio.run`, which creates a fresh inner event loop that asyncpg binds to and tears down inside the executor thread — never crossing the outer anyio loop. Per memory `feedback_asyncpg-loop-binding.md`, this is the loop-binding-safe pattern.

## Council pass (3 agents, adversarial framing) — all SHIP-WITH-FIXES, all fixes applied

**Convergent CONCERN (architect + reviewer):** `loop.run_in_executor` cannot cancel a running thread. CYCLE_TIMEOUT=45s frees the awaiting task but the executor thread keeps running until asyncpg returns (default connect timeout 60s, longer than CYCLE_TIMEOUT). Under sustained DB outage, threads accumulate ~1/cycle and the default ThreadPoolExecutor (~12-14 threads) eventually exhausts. **Same failure class as the 30h wedge**, harder to detect (visible API succeeds, real work is stuck).

**Fix**: wrap the inner `asyncio.run` with `asyncio.wait_for(timeout=_POLL_TIMEOUT_S=30s)` — well inside CYCLE_TIMEOUT. Forces the executor thread itself to release on timeout. `asyncio.TimeoutError` propagates through the existing try/except.

**Reviewer CONCERN 2**: Test 2 didn't actually test the executor-dispatch path. New `test_poll_sync_forced_release_callable_via_run_in_executor` exercises the actual runtime shape. **Live-verifier confirmed empirically pre-merge** (their item 3): two consecutive `loop.run_in_executor` dispatches inside `asyncio.run` both succeeded with no hang, no exception, no asyncpg loop-binding leak. New `test_poll_sync_forced_release_timeout_propagates` monkeypatches the timeout to 0.2s + a wedged poll to verify TimeoutError propagates.

NITs applied: type hint `last_event_ts: datetime | None`; removed redundant inner imports.

## Adjacent finding (not addressed by this PR)

Production Sentinel (PID 722, master branch — pre-fix) is currently cycling on `process_agent_update` timeouts with CancelledError traces. **Different symptom than the silent 30h wedge** but related class. Restart-onto-fix-branch would help diagnose whether this PR removes a contributor.

## Test plan

- [x] `python3 -m pytest tests/test_sentinel_forced_release_alarm.py agents/sentinel/tests/`: **21 passed** (was 19 + new dispatch-path test + new timeout-propagation test)
- [x] Live-verifier ran the executor pattern end-to-end: two consecutive dispatches via `loop.run_in_executor` inside `asyncio.run` both returned cleanly
- [x] `forced_release_alarm.py` untouched per reviewer's read-only stance
- [x] Single-writer surface check: no in-flight PRs on `agents/sentinel/` or `forced_release_alarm.py`

## Surface-collision check

`gh pr list -R CIRWEL/unitares --search "sentinel asyncpg OR sentinel pool OR forced_release" --state open` returned empty.