### PR TITLE
feat(lease-plane): audit_rfc_section_9_gates.py — §9 reconciliation baseline

### DIFF
--- a/scripts/dev/audit_rfc_section_9_gates.py
+++ b/scripts/dev/audit_rfc_section_9_gates.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Audit RFC §9 named test gates against the live test suite.
+
+Mechanically reconciles every `Test name:` / `Test names:` reference in §9 of
+`docs/proposals/surface-lease-plane-v0.md` against the actual Python and
+Elixir test suites. For each gate, classifies as:
+
+  exact   — a test with the named symbol exists
+  variant — closest existing test name has difflib ratio >= VARIANT_THRESHOLD
+  missing — no plausible match found
+
+Architect-recommended starting move for §9 reconciliation
+(`docs/proposals/surface-lease-plane-phase-a-plan.md` line 348). The
+mechanical baseline lets follow-up PRs target specific missing/variant
+rows rather than relitigating the count each time.
+
+Usage:
+    python3 scripts/dev/audit_rfc_section_9_gates.py            # full table
+    python3 scripts/dev/audit_rfc_section_9_gates.py --missing  # missing only
+    python3 scripts/dev/audit_rfc_section_9_gates.py --json     # machine-readable
+
+Exit code: always 0. This is an audit, not a gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from difflib import SequenceMatcher
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+RFC_PATH = REPO_ROOT / "docs/proposals/surface-lease-plane-v0.md"
+PYTHON_TEST_DIRS = [REPO_ROOT / "tests"]
+ELIXIR_TEST_DIRS = [REPO_ROOT / "elixir/lease_plane/test"]
+
+VARIANT_THRESHOLD = 0.75
+
+_PY_TEST_NAME = re.compile(r"`(test_[a-zA-Z0-9_]+)`")
+_ELIXIR_TEST_NAME = re.compile(r"`(test [^`]+)`")
+_PY_DEF = re.compile(r"^\s*(?:async\s+)?def\s+(test_[a-zA-Z0-9_]+)\s*\(", re.MULTILINE)
+_EX_TEST = re.compile(r'^\s*test\s+"([^"]+)"', re.MULTILINE)
+
+
+def find_section_9(text: str) -> str:
+    start = text.find("## 9. Pre-implementation checklist")
+    if start < 0:
+        raise SystemExit("§9 not found in RFC")
+    end = text.find("\n## 10.", start)
+    return text[start:end] if end > start else text[start:]
+
+
+def _uniq(seq):
+    seen: set[str] = set()
+    out: list[str] = []
+    for s in seq:
+        if s not in seen:
+            seen.add(s)
+            out.append(s)
+    return out
+
+
+def parse_gates(section_text: str) -> tuple[list[str], list[str]]:
+    """Return (python_gates, elixir_gates) — names extracted from §9 lines
+    that contain a `Test name:` or `Test names:` reference. Backtick-quoted
+    `test_*` identifiers are Python; backtick-quoted `test "<desc>"`-style
+    strings are Elixir."""
+    py: list[str] = []
+    elx: list[str] = []
+    for line in section_text.splitlines():
+        if "Test name" not in line:
+            continue
+        py.extend(m.group(1) for m in _PY_TEST_NAME.finditer(line))
+        elx.extend(m.group(1) for m in _ELIXIR_TEST_NAME.finditer(line))
+    return _uniq(py), _uniq(elx)
+
+
+def collect_python_tests(dirs: list[Path]) -> dict[str, Path]:
+    found: dict[str, Path] = {}
+    for d in dirs:
+        if not d.exists():
+            continue
+        for p in d.rglob("*.py"):
+            try:
+                txt = p.read_text(errors="replace")
+            except OSError:
+                continue
+            for m in _PY_DEF.finditer(txt):
+                found.setdefault(m.group(1), p)
+    return found
+
+
+def collect_elixir_tests(dirs: list[Path]) -> dict[str, Path]:
+    found: dict[str, Path] = {}
+    for d in dirs:
+        if not d.exists():
+            continue
+        for p in d.rglob("*.exs"):
+            try:
+                txt = p.read_text(errors="replace")
+            except OSError:
+                continue
+            for m in _EX_TEST.finditer(txt):
+                found.setdefault(f"test {m.group(1)}", p)
+    return found
+
+
+def _rel(p: Path) -> str:
+    try:
+        return str(p.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(p)
+
+
+def classify(name: str, found: dict[str, Path]) -> tuple[str, str]:
+    """Return (status, evidence) where status is exact|variant|missing."""
+    if name in found:
+        return "exact", _rel(found[name])
+    best_name = ""
+    best_ratio = 0.0
+    for cand in found:
+        r = SequenceMatcher(None, name, cand).ratio()
+        if r > best_ratio:
+            best_name = cand
+            best_ratio = r
+    if best_ratio >= VARIANT_THRESHOLD:
+        return "variant", f"{best_name}  (ratio {best_ratio:.2f})"
+    return "missing", ""
+
+
+def audit() -> list[dict[str, str]]:
+    text = RFC_PATH.read_text()
+    section = find_section_9(text)
+    py_gates, elx_gates = parse_gates(section)
+    py_found = collect_python_tests(PYTHON_TEST_DIRS)
+    elx_found = collect_elixir_tests(ELIXIR_TEST_DIRS)
+
+    rows: list[dict[str, str]] = []
+    for name in py_gates:
+        status, evidence = classify(name, py_found)
+        rows.append({"lang": "python", "gate": name, "status": status, "evidence": evidence})
+    for name in elx_gates:
+        status, evidence = classify(name, elx_found)
+        rows.append({"lang": "elixir", "gate": name, "status": status, "evidence": evidence})
+    return rows
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--missing", action="store_true", help="show only missing gates")
+    p.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = p.parse_args(argv)
+
+    rows = audit()
+    if args.missing:
+        rows = [r for r in rows if r["status"] == "missing"]
+
+    if args.json:
+        print(json.dumps(rows, indent=2))
+        return 0
+
+    counts = {"exact": 0, "variant": 0, "missing": 0}
+    for r in rows:
+        counts[r["status"]] = counts.get(r["status"], 0) + 1
+
+    print(f"{'lang':<7}  {'gate':<72}  {'status':<8}  evidence")
+    print("-" * 7 + "  " + "-" * 72 + "  " + "-" * 8 + "  " + "-" * 40)
+    for r in rows:
+        print(f"{r['lang']:<7}  {r['gate']:<72}  {r['status']:<8}  {r['evidence']}")
+
+    total = sum(counts.values())
+    print()
+    print(
+        f"§9 audit: {total} named gates  →  "
+        f"{counts['exact']} exact  /  {counts['variant']} variant  /  {counts['missing']} missing"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_audit_rfc_section_9_gates.py
+++ b/tests/test_audit_rfc_section_9_gates.py
@@ -1,0 +1,182 @@
+"""Tests for `scripts/dev/audit_rfc_section_9_gates.py`.
+
+The audit script is the architect-recommended starting move for §9
+reconciliation. The reconciliation work itself depends on the audit being
+trustworthy, so the parser/classifier carries its own regression tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts/dev/audit_rfc_section_9_gates.py"
+
+
+@pytest.fixture(scope="module")
+def audit_module():
+    spec = importlib.util.spec_from_file_location("audit_rfc_section_9_gates", SCRIPT_PATH)
+    assert spec and spec.loader, "could not load audit script as module"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# --- find_section_9 --------------------------------------------------------
+
+
+def test_find_section_9_extracts_only_section_9(audit_module):
+    text = (
+        "## 8. Other section\n"
+        "irrelevant\n"
+        "## 9. Pre-implementation checklist\n"
+        "the meat\n"
+        "Test name: `test_a`.\n"
+        "## 10. Runway tradeoff\n"
+        "after the cut\n"
+    )
+    section = audit_module.find_section_9(text)
+    assert "the meat" in section
+    assert "after the cut" not in section
+    assert "irrelevant" not in section
+
+
+def test_find_section_9_raises_when_missing(audit_module):
+    with pytest.raises(SystemExit):
+        audit_module.find_section_9("no section nine here")
+
+
+# --- parse_gates -----------------------------------------------------------
+
+
+def test_parse_gates_single_python_test_name(audit_module):
+    section = "- [ ] **§7.2** — desc. Test name: `test_alpha_one`."
+    py, elx = audit_module.parse_gates(section)
+    assert py == ["test_alpha_one"]
+    assert elx == []
+
+
+def test_parse_gates_multiple_python_test_names(audit_module):
+    section = (
+        "- [ ] **§7.3** — desc. Test names: `test_a`, `test_b`, `test_c` (post-removal)."
+    )
+    py, elx = audit_module.parse_gates(section)
+    assert py == ["test_a", "test_b", "test_c"]
+    assert elx == []
+
+
+def test_parse_gates_elixir_test_names(audit_module):
+    section = (
+        "- [ ] **§7.3.5** — desc. Test names (Elixir-side): "
+        "`test http_router returns 409 on held_by_other`, "
+        "`test http_router returns 200 on permission_denied`."
+    )
+    py, elx = audit_module.parse_gates(section)
+    assert py == []
+    assert elx == [
+        "test http_router returns 409 on held_by_other",
+        "test http_router returns 200 on permission_denied",
+    ]
+
+
+def test_parse_gates_dedupes_repeated_names(audit_module):
+    section = (
+        "- [ ] **§A** — desc. Test name: `test_dup`.\n"
+        "- [ ] **§B** — desc. Test name: `test_dup`."
+    )
+    py, _ = audit_module.parse_gates(section)
+    assert py == ["test_dup"]
+
+
+def test_parse_gates_ignores_lines_without_test_name(audit_module):
+    section = (
+        "- [x] Council pass: dialectic — v0.8\n"
+        "- [ ] **§A** — desc. Test name: `test_only_this_one`."
+    )
+    py, _ = audit_module.parse_gates(section)
+    assert py == ["test_only_this_one"]
+
+
+# --- collect_python_tests / collect_elixir_tests ---------------------------
+
+
+def test_collect_python_tests_finds_async_and_sync_defs(audit_module, tmp_path):
+    f = tmp_path / "test_demo.py"
+    f.write_text(
+        "def test_sync_one():\n"
+        "    pass\n"
+        "\n"
+        "async def test_async_two():\n"
+        "    pass\n"
+        "\n"
+        "def helper_not_a_test():\n"
+        "    pass\n"
+    )
+    found = audit_module.collect_python_tests([tmp_path])
+    assert set(found.keys()) == {"test_sync_one", "test_async_two"}
+    assert found["test_sync_one"] == f
+
+
+def test_collect_elixir_tests_extracts_quoted_descriptions(audit_module, tmp_path):
+    f = tmp_path / "demo_test.exs"
+    f.write_text(
+        'defmodule Demo do\n'
+        '  use ExUnit.Case\n'
+        '  test "router returns 409" do\n'
+        '    :ok\n'
+        '  end\n'
+        '\n'
+        '  test "router accepts 200" do\n'
+        '    :ok\n'
+        '  end\n'
+        'end\n'
+    )
+    found = audit_module.collect_elixir_tests([tmp_path])
+    assert set(found.keys()) == {"test router returns 409", "test router accepts 200"}
+
+
+# --- classify --------------------------------------------------------------
+
+
+def test_classify_exact_match(audit_module, tmp_path):
+    found = {"test_foo_bar": tmp_path / "tests/test_x.py"}
+    status, evidence = audit_module.classify("test_foo_bar", found)
+    assert status == "exact"
+    assert "test_x.py" in evidence
+
+
+def test_classify_variant_above_threshold(audit_module, tmp_path):
+    # Both names share most tokens — difflib ratio comfortably above 0.75.
+    found = {"test_acquire_with_retry_jittered_backoff_within_bounds": tmp_path / "x.py"}
+    status, evidence = audit_module.classify(
+        "test_acquire_with_retry_jittered_backoff", found
+    )
+    assert status == "variant"
+    assert "within_bounds" in evidence
+    assert "ratio" in evidence
+
+
+def test_classify_missing_when_no_close_match(audit_module, tmp_path):
+    found = {"test_completely_different_subject": tmp_path / "x.py"}
+    status, evidence = audit_module.classify("test_phase_zero_acquire_race_blocked", found)
+    assert status == "missing"
+    assert evidence == ""
+
+
+# --- audit() end-to-end on the live RFC -----------------------------------
+
+
+def test_audit_runs_against_live_rfc_and_returns_rows(audit_module):
+    """Smoke test — make sure the audit doesn't crash on the real RFC and
+    that every row has the four expected keys."""
+    rows = audit_module.audit()
+    assert rows, "expected at least one §9 named gate"
+    expected_keys = {"lang", "gate", "status", "evidence"}
+    assert all(set(r) == expected_keys for r in rows)
+    statuses = {r["status"] for r in rows}
+    assert statuses <= {"exact", "variant", "missing"}


### PR DESCRIPTION
Architect-recommended starting move for the §9 RFC test-name reconciliation deferred from Phase A (`docs/proposals/surface-lease-plane-phase-a-plan.md:348`).

## Summary

Mechanical reconciliation script that parses every \`Test name:\` / \`Test names:\` reference in §9 of \`docs/proposals/surface-lease-plane-v0.md\`, walks the Python and Elixir test suites, and classifies each named gate as **exact** / **variant** / **missing**.

## Initial baseline

\`\`\`
§9 audit: 28 named gates  →  11 exact  /  4 variant  /  13 missing
\`\`\`

The 4 variants are all semantically real (existing test with extended/different name); difflib threshold is 0.75 to filter spurious token-overlap matches. The 13 missing rows are the work-list for follow-up reconciliation PRs.

## Why mechanical

The mechanical baseline lets follow-up PRs target specific missing/variant rows without relitigating the count each time. Architect's framing was that the §9 reconciliation is "larger than originally framed" — auditing-by-hand each session is the failure mode this script removes.

Audit, not a gate: exit code is always 0. Use \`--missing\` for work-list output, \`--json\` for machine-readable.

## Test plan

- [x] 13 new unit tests in \`tests/test_audit_rfc_section_9_gates.py\` cover section extraction, gate parsing (single name, multiple names, elixir, dedupe, ignores non-test-name lines), test-collection (sync/async Python defs, elixir quoted descriptions), classification (exact / variant / missing), and a live-RFC smoke test.
- [x] Full suite green: 8111 passed, 33 skipped (\`./scripts/dev/test-cache.sh\`)

## Methodology contract — four-column table

| RFC gate | code surface | test name | status |
|---|---|---|---|
| §9 reconciliation residual (PR 8+) | \`scripts/dev/audit_rfc_section_9_gates.py\` | \`tests/test_audit_rfc_section_9_gates.py::*\` (13 tests) | DONE — baseline established |

No other rows touched; this is the audit baseline only. Follow-up PRs will pick off specific missing rows from the script's output.