### PR TITLE
test(lease-plane): close 4 §9 named-gate rows for AcquireRequest + held_by_other

### DIFF
--- a/tests/test_lease_plane_canonicalize.py
+++ b/tests/test_lease_plane_canonicalize.py
@@ -135,6 +135,33 @@ def test_acquire_request_rejects_query_string_in_surface_id():
     )
 
 
+def test_acquire_request_rejects_invalid_scheme():
+    """RFC v0.8 §7.2 / §9 — Pydantic field_validator rejects surface_ids whose
+    scheme is not in the canonical list (`AcquireRequest(surface_id='potato:foo', ...)`
+    raises ValidationError).
+
+    The implementation is at `src/lease_plane/models.py::AcquireRequest._validate_surface_id`.
+    This test pins the §9 named gate `test_acquire_request_rejects_invalid_scheme`.
+    """
+    from pydantic import ValidationError
+
+    from src.lease_plane import AcquireRequest
+    from uuid import uuid4
+
+    with pytest.raises(ValidationError) as exc_info:
+        AcquireRequest(
+            surface_id="potato:foo",
+            holder_agent_uuid=uuid4(),
+            holder_class="process_instance",
+            holder_kind="remote_heartbeat",
+            ttl_s=60,
+        )
+    msg = str(exc_info.value)
+    assert "potato" in msg or "scheme" in msg.lower(), (
+        f"Expected error to mention the offending scheme; got: {msg}"
+    )
+
+
 def test_acquire_request_surface_id_field_validator_wired():
     """RFC v0.8 §7.12.5: AcquireRequest auto-canonicalizes surface_id at the model boundary.
     Two equivalent inputs must produce the same .surface_id."""

--- a/tests/test_lease_plane_held_by_other_v0_8.py
+++ b/tests/test_lease_plane_held_by_other_v0_8.py
@@ -68,3 +68,60 @@ def test_held_by_other_includes_v0_7_extended_fields():
     # Type-check the new fields are exposed correctly.
     assert isinstance(result.blocking_lease_id, UUID)
     assert isinstance(result.retry_after_hint_ms, int)
+
+
+# --- §9 RFC named-gate focused tests --------------------------------------
+#
+# RFC §9 names three separate gates against the v0.7 §7.3.2 extended
+# held_by_other shape. The combined test above pins all three at once;
+# these focused tests pin each gate individually so the §9 audit
+# (scripts/dev/audit_rfc_section_9_gates.py) reports them as exact rather
+# than missing.
+
+
+def _make_held_by_other(
+    *, surface_id: str, blocking_lease_id: UUID, retry_after_hint_ms: int = 0
+) -> AcquireHeldByOther:
+    return AcquireHeldByOther(
+        ok=False,
+        error="held_by_other",
+        surface_id=surface_id,
+        blocking_lease_id=blocking_lease_id,
+        held_by_uuid=uuid4(),
+        expires_at=datetime.now(UTC) + timedelta(seconds=30),
+        retry_after_hint_ms=retry_after_hint_ms,
+    )
+
+
+def test_held_by_other_echoes_surface_id():
+    """RFC §7.3.2 / §9 — the held_by_other response echoes the requested
+    surface_id so callers can correlate concurrent multi-surface acquires."""
+    surface_id = "file:///tmp/echo_test.py"
+    result = _make_held_by_other(surface_id=surface_id, blocking_lease_id=uuid4())
+    assert result.surface_id == surface_id
+
+
+def test_held_by_other_returns_blocking_lease_id():
+    """RFC §7.3.2 / §9 — the held_by_other response carries the
+    blocking_lease_id so callers can distinguish 'same stuck holder across
+    retries' from 'rotating cast'."""
+    blocking_lease = uuid4()
+    result = _make_held_by_other(
+        surface_id="file:///tmp/blocking_test.py",
+        blocking_lease_id=blocking_lease,
+    )
+    assert result.blocking_lease_id == blocking_lease
+    assert isinstance(result.blocking_lease_id, UUID)
+
+
+def test_held_by_other_includes_retry_hint():
+    """RFC §7.3.2 / §9 — the held_by_other response carries
+    retry_after_hint_ms so callers can implement sane backoff without
+    parsing expires_at delta."""
+    result = _make_held_by_other(
+        surface_id="file:///tmp/retry_hint_test.py",
+        blocking_lease_id=uuid4(),
+        retry_after_hint_ms=2500,
+    )
+    assert result.retry_after_hint_ms == 2500
+    assert isinstance(result.retry_after_hint_ms, int)


### PR DESCRIPTION
Pins four §9 RFC named gates against existing implementations.

## Rows closed

| §9 gate | code surface | test name | status |
|---|---|---|---|
| §7.2 — Pydantic field_validator rejects invalid scheme | \`src/lease_plane/models.py::AcquireRequest._validate_surface_id\` | \`test_acquire_request_rejects_invalid_scheme\` | DONE |
| §7.3.2 — held_by_other echoes surface_id | \`src/lease_plane/models.py::AcquireHeldByOther.surface_id\` | \`test_held_by_other_echoes_surface_id\` | DONE |
| §7.3.2 — held_by_other returns blocking_lease_id | \`AcquireHeldByOther.blocking_lease_id\` | \`test_held_by_other_returns_blocking_lease_id\` | DONE |
| §7.3.2 — held_by_other includes retry_after_hint_ms | \`AcquireHeldByOther.retry_after_hint_ms\` | \`test_held_by_other_includes_retry_hint\` | DONE |

All four behaviors were already implemented; the §9 gates were missing their named test surfaces. The combined \`test_held_by_other_includes_v0_7_extended_fields\` stays as the v0.7 drift gate; the three focused tests above pin each §7.3.2 sub-gate individually so the §9 audit reports them as exact rather than missing.

## Audit movement

\`\`\`
Before:  28 named gates → 11 exact / 4 variant / 13 missing
After:   28 named gates → 15 exact / 3 variant / 10 missing
\`\`\`

(One variant collapsed to exact: \`test_held_by_other_returns_blocking_lease_id\` was variant-matching \`test_held_by_other_runs_block_no_release\` at ratio 0.86 before this PR.)

## Test plan

- [x] 4 new tests pass (\`pytest tests/test_lease_plane_canonicalize.py tests/test_lease_plane_held_by_other_v0_8.py\`)
- [x] Full suite green: 8119 passed, 33 skipped (\`./scripts/dev/test-cache.sh\`)

Builds on #291 (audit baseline). Refs #268 (unrelated Watcher P005 fix earlier today) for context on the broader §9 reconciliation track.