### PR TITLE
test(lease-plane): close 3 more §9 named-gate rows (AcquireRequest + canonicalize)

### DIFF
--- a/tests/test_lease_plane_canonicalize.py
+++ b/tests/test_lease_plane_canonicalize.py
@@ -135,6 +135,68 @@ def test_acquire_request_rejects_query_string_in_surface_id():
     )
 
 
+def test_acquire_request_has_no_surface_kind_field():
+    """RFC v0.8 §7.2.3 / §9 — `surface_kind` was removed from AcquireRequest;
+    it is now derived server-side from the surface_id scheme via migration
+    026's generated column. Caller cannot supply a conflicting value because
+    the field doesn't exist on the request model.
+
+    Pins the §9 named gate `test_acquire_request_has_no_surface_kind_field`
+    (post-removal)."""
+    from src.lease_plane import AcquireRequest
+
+    assert "surface_kind" not in AcquireRequest.model_fields, (
+        "AcquireRequest must not carry a surface_kind field — RFC §7.2.3 "
+        "moved derivation to migration 026's generated column."
+    )
+
+
+def test_file_canonicalization_case_insensitive_apfs():
+    """RFC v0.8 §7.12.1 / §9 — on a case-insensitive filesystem (default macOS
+    APFS), two surface_ids that differ only by case canonicalize to the same
+    string. Skipped when the host filesystem is case-sensitive (e.g. Linux
+    ext4) since the gate's premise is filesystem-dependent.
+
+    Pins the §9 named gate `test_file_canonicalization_case_insensitive_apfs`."""
+    import tempfile
+
+    from src.lease_plane.canonicalize import canonicalize, _is_case_insensitive
+
+    if not _is_case_insensitive():
+        pytest.skip("filesystem is case-sensitive; gate premise N/A")
+
+    with tempfile.TemporaryDirectory() as d:
+        # Materialize both spellings — realpath(strict=True) needs the path
+        # to exist so we exercise the canonicalization path, not the ENOENT fallback.
+        upper = Path(d) / "X.py"
+        upper.write_text("")
+        a = canonicalize(f"file://{upper}")
+        b = canonicalize(f"file://{Path(d) / 'x.py'}")
+        assert a == b, f"case-insensitive APFS must canonicalize equal: {a!r} != {b!r}"
+
+
+def test_file_canonicalization_relative_components():
+    """RFC v0.8 §7.12.1 / §9 — `..`-bearing paths canonicalize to the same form
+    as the directly-spelled equivalent (`file:///x/../y/z.py` → `file:///y/z.py`).
+
+    Pins the §9 named gate `test_file_canonicalization_relative_components`."""
+    import tempfile
+
+    from src.lease_plane.canonicalize import canonicalize
+
+    with tempfile.TemporaryDirectory() as d:
+        sub = Path(d) / "y"
+        sub.mkdir()
+        target = sub / "z.py"
+        target.write_text("")
+        via_dotdot = canonicalize(f"file://{d}/x/../y/z.py")
+        direct = canonicalize(f"file://{target}")
+        assert via_dotdot == direct, (
+            f"`..`-component path must canonicalize to direct form: "
+            f"{via_dotdot!r} != {direct!r}"
+        )
+
+
 def test_acquire_request_rejects_invalid_scheme():
     """RFC v0.8 §7.2 / §9 — Pydantic field_validator rejects surface_ids whose
     scheme is not in the canonical list (`AcquireRequest(surface_id='potato:foo', ...)`


### PR DESCRIPTION
Continues the §9 reconciliation track from #291 / #292.

## Rows closed

| §9 gate | code surface | test name | status |
|---|---|---|---|
| §7.2.3 — surface_kind removed from AcquireRequest | \`src/lease_plane/models.py::AcquireRequest\` | \`test_acquire_request_has_no_surface_kind_field\` | DONE |
| §7.12.1 — case-insensitive APFS canonicalization | \`src/lease_plane/canonicalize.py::_canonicalize_file\` | \`test_file_canonicalization_case_insensitive_apfs\` | DONE |
| §7.12.1 — \`..\`-path canonicalization | \`src/lease_plane/canonicalize.py::_canonicalize_file\` | \`test_file_canonicalization_relative_components\` | DONE |

The case-insensitive test \`pytest.skip\`s on case-sensitive filesystems (Linux ext4) since the gate premise is filesystem-dependent.

## Audit movement

\`\`\`
Before:  28 named gates → 15 exact / 3 variant / 10 missing
After:   28 named gates → 18 exact / 3 variant /  7 missing
\`\`\`

## Test plan

- [x] All three new tests pass on macOS APFS
- [x] Full suite green: 8122 passed, 33 skipped (\`./scripts/dev/test-cache.sh\`)

## Remaining missing rows (7)

- \`test_invalid_uri_scheme_rejected_at_storage\` (DB CHECK constraint — needs live DB)
- \`test_surface_kind_derived_from_scheme\` (DB generated-column — needs live DB)
- \`test_force_release_rejects_governance_token\` (contract-layer — Elixir router or HTTP integration)
- \`test_held_by_other_includes_retry_hint\` ← already exact via #292; audit may be stale
- \`test_deprecation_sweep_idempotent_on_partial_failure\` (DB sweep simulation)
- 3 Elixir-side rows (\`test http_router ...\`)