### PR TITLE
test(lease-plane): close 2 §9 storage-layer rows (CHECK + generated column)

### DIFF
--- a/tests/test_lease_plane_storage_constraints.py
+++ b/tests/test_lease_plane_storage_constraints.py
@@ -1,0 +1,121 @@
+"""Storage-layer gate tests for surface_leases (RFC v0.8 §7.2 / §9).
+
+Pins two §9 named gates against the live `lease_plane.surface_leases`
+table — both are storage-layer behaviors set up by migration 026:
+
+  - `surface_id_grammar` CHECK constraint rejects unknown schemes.
+  - `surface_kind` generated column derives from the surface_id prefix.
+
+Spec: docs/proposals/surface-lease-plane-v0.md §7.2.2, §7.2.3
+      db/postgres/migrations/026_lease_plane_grammar.sql
+"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+try:
+    import asyncpg
+except ImportError:
+    pytest.skip("asyncpg not installed", allow_module_level=True)
+
+from tests.test_db_utils import (
+    TEST_DB_URL,
+    can_connect_to_test_db,
+    ensure_test_database_schema,
+)
+
+if not can_connect_to_test_db():
+    pytest.skip("governance_test database not available", allow_module_level=True)
+
+
+_INSERT = """
+INSERT INTO lease_plane.surface_leases
+  (lease_id, surface_id, holder_agent_uuid, holder_kind, holder_class,
+   heartbeat_required, original_ttl_s, acquired_at, expires_at, intent)
+VALUES ($1, $2, $3, 'remote_heartbeat', 'process_instance', true, $4, $5, $6, $7)
+"""
+
+
+async def _cleanup(conn) -> None:
+    await conn.execute(
+        "DELETE FROM lease_plane.surface_leases WHERE intent LIKE 'storage-gate-test%'"
+    )
+
+
+async def _insert_lease(conn, *, surface_id: str, intent: str) -> uuid.UUID:
+    lease_id = uuid.uuid4()
+    now = datetime.now(UTC)
+    await conn.execute(
+        _INSERT,
+        lease_id, surface_id, uuid.uuid4(), 60, now,
+        now + timedelta(seconds=60), intent,
+    )
+    return lease_id
+
+
+@pytest.mark.asyncio
+async def test_invalid_uri_scheme_rejected_at_storage():
+    """RFC §7.2 / §9 — INSERT with `surface_id='not_a_scheme:foo'` raises a
+    CHECK violation against the `surface_id_grammar` constraint added by
+    migration 026.
+
+    Pins the §9 named gate `test_invalid_uri_scheme_rejected_at_storage`."""
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        with pytest.raises(asyncpg.exceptions.CheckViolationError) as exc_info:
+            await _insert_lease(
+                conn,
+                surface_id="not_a_scheme:foo",
+                intent="storage-gate-test-invalid-scheme",
+            )
+        assert "surface_id_grammar" in str(exc_info.value), (
+            f"Expected CHECK violation to name surface_id_grammar; got: {exc_info.value}"
+        )
+    finally:
+        await _cleanup(conn)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_surface_kind_derived_from_scheme():
+    """RFC §7.2.3 / §9 — `surface_kind` is a generated column. INSERT with
+    `surface_id='file:///x.py'` produces `surface_kind='file'` automatically;
+    the caller cannot supply a conflicting value because `surface_kind` is
+    no longer a writable column.
+
+    Pins the §9 named gate `test_surface_kind_derived_from_scheme`."""
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await _cleanup(conn)
+        cases = [
+            ("file:///tmp/storage_gate_x.py", "file"),
+            ("dialectic:/storage-gate-y", "dialectic"),
+            ("td:/storage-gate-z", "td"),
+        ]
+        for sid, expected_kind in cases:
+            lease_id = await _insert_lease(
+                conn, surface_id=sid, intent=f"storage-gate-test-derived-{expected_kind}",
+            )
+            row = await conn.fetchrow(
+                "SELECT surface_kind FROM lease_plane.surface_leases WHERE lease_id = $1",
+                lease_id,
+            )
+            assert row is not None, f"row not found for {sid!r}"
+            assert row["surface_kind"] == expected_kind, (
+                f"surface_kind for {sid!r} expected {expected_kind!r}, got {row['surface_kind']!r}"
+            )
+    finally:
+        await _cleanup(conn)
+        await conn.close()


### PR DESCRIPTION
Continues the §9 reconciliation track from #291 / #292 / #293.

## Rows closed

| §9 gate | code surface | test name | status |
|---|---|---|---|
| §7.2 — invalid scheme rejected at storage | \`db/postgres/migrations/026::surface_id_grammar CHECK\` | \`test_invalid_uri_scheme_rejected_at_storage\` | DONE |
| §7.2.3 — surface_kind drift impossible (generated column) | \`db/postgres/migrations/026::surface_kind GENERATED ALWAYS AS\` | \`test_surface_kind_derived_from_scheme\` | DONE |

Both behaviors were already shipped by migration 026; the §9 gates were missing their named test surfaces. Tests live in a new \`tests/test_lease_plane_storage_constraints.py\` to keep storage-layer gates separate from CLI / canonicalize / advisory tests.

## Audit movement

\`\`\`
Before:  28 named gates → 18 exact / 3 variant / 7 missing
After:   28 named gates → 20 exact / 3 variant / 5 missing
\`\`\`

## Test plan

- [x] Both new tests pass against the live \`governance_test\` DB
- [x] Full suite green: 8124 passed, 33 skipped (\`./scripts/dev/test-cache.sh\`)
- [x] Existing patterns followed: \`tests/test_db_utils.py\` harness, module-level skip when DB unavailable, intent-prefix cleanup

## Remaining 5 missing rows

- \`test_force_release_rejects_governance_token\` — contract-layer (Elixir router or HTTP integration)
- \`test_deprecation_sweep_idempotent_on_partial_failure\` — DB sweep mid-failure simulation
- 3 Elixir-side rows (\`test http_router ...\`)