### PR TITLE
test(lease-plane): close 2 §9 Elixir router rows (held_by_other 409 + surface_kind ignored)

### DIFF
--- a/elixir/lease_plane/test/http_router_test.exs
+++ b/elixir/lease_plane/test/http_router_test.exs
@@ -165,6 +165,46 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
       assert payload["lease"]["surface_kind"] == "dialectic"
     end
 
+    # --- §9 RFC named-gate tests (mirroring docs/proposals/surface-lease-plane-v0.md §9) ---
+    #
+    # These pin the gates by their §9-named description so the audit
+    # (scripts/dev/audit_rfc_section_9_gates.py) reports them as exact rather
+    # than missing. Coverage overlaps with the in-house tests above; keeping
+    # both makes the §9 audit trustworthy without losing the more descriptive
+    # names that aid local debugging.
+
+    test "http_router returns 409 on held_by_other", ctx do
+      # RFC §7.3.5 / §9 gate: HTTP 409 on held_by_other.
+      body_a = acquire_body(ctx.surface)
+      body_b = acquire_body(ctx.surface, holder_agent_uuid: random_uuid())
+
+      assert post_json("/v1/lease/acquire", body_a).status == 200
+      resp = post_json("/v1/lease/acquire", body_b)
+      assert resp.status == 409
+      assert parsed(resp)["error"] == "held_by_other"
+    end
+
+    test "http_router rejects surface_kind in acquire body after migration 026", ctx do
+      # RFC §7.2.3 / §9 gate: post-migration-026, surface_kind is a generated
+      # column derived from split_part(surface_id, ':', 1). The router silently
+      # ignores caller-supplied surface_kind in the body — the caller's value
+      # cannot override the generated column ("rejected" in the take-effect
+      # sense, even though no 4xx is returned). See http_router.ex:240-244.
+      body =
+        ctx.surface
+        |> acquire_body()
+        |> Map.put(:surface_kind, "lying_kind_does_not_match_scheme")
+
+      resp = post_json("/v1/lease/acquire", body)
+
+      assert resp.status == 200
+      payload = parsed(resp)
+      assert payload["ok"] == true
+      # The generated column wins; the body's "lying_kind_does_not_match_scheme"
+      # is dropped before the INSERT.
+      assert payload["lease"]["surface_kind"] == "dialectic"
+    end
+
     test "PR 7 — non-canonical scheme → 422 schema_invalid", _ctx do
       body = acquire_body("ftp://nope")
       resp = post_json("/v1/lease/acquire", body)


### PR DESCRIPTION
Continues the §9 reconciliation track from #291 / #292 / #293 / #294.

## Rows closed

| §9 gate | code surface | test name | status |
|---|---|---|---|
| §7.3.5 — HTTP 409 on held_by_other | \`elixir/lease_plane/lib/.../http_router.ex\` acquire→409 path | \`http_router returns 409 on held_by_other\` | DONE |
| §7.2.3 — surface_kind in body cannot override generated column | \`http_router.ex::extract_acquire_params\` (silent-ignore) | \`http_router rejects surface_kind in acquire body after migration 026\` | DONE |

Both behaviors were already covered by descriptively-named tests; this PR adds §9-named wrappers so the audit reports them as exact rather than missing. Coverage overlaps; keeping both names lets local debugging stay readable while the audit stays trustworthy.

For the surface_kind gate: the router silently ignores caller-supplied surface_kind (router.ex:240-244), and the generated column wins. The §9 gate name says \"rejects\"; the implementation rejects in the *take-effect* sense (caller's value is dropped before INSERT), even though no 4xx is returned. The test pins this current behavior with a deliberately wrong \"lying_kind_does_not_match_scheme\" body value and asserts the response carries the correctly-derived \`surface_kind=\"dialectic\"\`.

## Skipped: \`http_router returns 200 on permission_denied\`

The router has no application-layer \`permission_denied\` path today — every \`permission_denied\` is auth-failure returning **401** via \`http_auth.ex:38\`. RFC §7.3.5 commits to \"200 + ok:false otherwise\" but the implementation doesn't yet emit 200+permission_denied for any flow. Adding such a path (e.g. release-without-ownership) is a real engineering call, not a test-add. Left as a noted gap.

## Audit movement

\`\`\`
Before:  28 named gates → 20 exact / 3 variant / 5 missing
After:   28 named gates → 22 exact / 3 variant / 3 missing
\`\`\`

## Test plan

- [x] Both new Elixir tests pass (\`mix test test/http_router_test.exs\` — 32 tests, 0 failures)
- [x] Full Python suite green: 8124 passed, 33 skipped (\`./scripts/dev/test-cache.sh\`)