### PR TITLE
feat(lease-plane): align role-holder rejection with RFC §4.4 + §7.3.5 — 200 permission_denied

### DIFF
--- a/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
@@ -100,6 +100,15 @@ defmodule UnitaresLeasePlane.HTTPRouter do
             json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
         end
 
+      {:permission_denied, reason} ->
+        # RFC §4.4 / §7.3.5 — application-layer typed-absence for policy
+        # rejection (e.g. holder_class="role"). Distinct from the auth-layer
+        # 401 (http_auth.ex) by carrying a machine-readable reason atom and
+        # using the 200 + ok:false envelope per §7.3.5 ("HTTP 409 on
+        # held_by_other; 200 + ok:false otherwise"). The reason field is the
+        # discriminator (e.g. "role_holders_unsupported").
+        json(conn, 200, %{ok: false, error: "permission_denied", reason: reason})
+
       {:error, detail} ->
         json(conn, 422, %{ok: false, error: "schema_invalid", detail: detail})
     end
@@ -263,9 +272,18 @@ defmodule UnitaresLeasePlane.HTTPRouter do
         {:error, reason} = canonical_or_error
         {:error, "surface_id canonicalization failed: #{reason}"}
 
+      Map.get(body, "holder_class") == "role" ->
+        # RFC §4.4 line 481: roles cannot hold leases — surface this as
+        # application-layer permission_denied with a machine-readable reason,
+        # NOT as schema_invalid. holder_class is structurally valid; the
+        # rejection is a policy decision, not a malformed request. Closes
+        # §9 gate `test http_router returns 200 on permission_denied`.
+        {:permission_denied, "role_holders_unsupported"}
+
       Map.get(body, "holder_class") not in [nil, "process_instance", "substrate_earned"] ->
-        # 'role' and other classes are rejected before the DB CHECK — surface this
-        # as schema_invalid so the typed-absence error class is precise.
+        # Unknown/unsupported holder_class values (anything that isn't
+        # process_instance, substrate_earned, or the policy-rejected "role")
+        # remain schema_invalid — they're genuinely malformed input.
         {:error, "holder_class must be process_instance or substrate_earned (RFC §7.1)"}
 
       not is_integer(Map.get(body, "ttl_s")) ->

--- a/elixir/lease_plane/test/http_router_test.exs
+++ b/elixir/lease_plane/test/http_router_test.exs
@@ -130,8 +130,26 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
       assert payload["retry_after_hint_ms"] <= 5_000
     end
 
-    test "holder_class='role' → 422 schema_invalid (rejected before DB)", ctx do
+    test "holder_class='role' → 200 permission_denied (RFC §4.4)", ctx do
+      # RFC §4.4 line 481 + §7.3.5: roles cannot hold leases — application-
+      # layer policy rejection, not schema_invalid. Per §7.3.5 the typed-
+      # absence shape is 200 + ok:false. The previous behavior (422
+      # schema_invalid) was deliberate implementation drift that the §9 gate
+      # `test http_router returns 200 on permission_denied` now closes.
       body = acquire_body(ctx.surface, holder_class: "role")
+      resp = post_json("/v1/lease/acquire", body)
+      assert resp.status == 200
+      payload = parsed(resp)
+      assert payload["ok"] == false
+      assert payload["error"] == "permission_denied"
+      assert payload["reason"] == "role_holders_unsupported"
+    end
+
+    test "holder_class='unknown_class' → 422 schema_invalid", ctx do
+      # Unknown holder_class values that aren't the policy-rejected "role"
+      # remain schema_invalid — they're structurally malformed input, not a
+      # recognized but unsupported policy case.
+      body = acquire_body(ctx.surface, holder_class: "unknown_class")
       resp = post_json("/v1/lease/acquire", body)
       assert resp.status == 422
       assert parsed(resp)["error"] == "schema_invalid"
@@ -172,6 +190,21 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
     # than missing. Coverage overlaps with the in-house tests above; keeping
     # both makes the §9 audit trustworthy without losing the more descriptive
     # names that aid local debugging.
+
+    test "http_router returns 200 on permission_denied", ctx do
+      # RFC §7.3.5 / §9 gate: 200 + ok:false on application-layer
+      # permission_denied. The role-holder rejection path (RFC §4.4) is
+      # the canonical trigger; any future application-layer permission_denied
+      # must follow the same envelope shape.
+      body = acquire_body(ctx.surface, holder_class: "role")
+      resp = post_json("/v1/lease/acquire", body)
+      assert resp.status == 200
+      payload = parsed(resp)
+      assert payload["ok"] == false
+      assert payload["error"] == "permission_denied"
+      assert is_binary(payload["reason"])
+      assert payload["reason"] != ""
+    end
 
     test "http_router returns 409 on held_by_other", ctx do
       # RFC §7.3.5 / §9 gate: HTTP 409 on held_by_other.


### PR DESCRIPTION
Closes the last §9 RFC named-gate row for the lease-plane Elixir router.

## What changed

Roles cannot hold leases (RFC §4.4 line 481). The router previously emitted **422 schema_invalid** for \`holder_class='role'\` — deliberate implementation drift from the RFC §7.3.5 typed-absence contract ("HTTP 409 on held_by_other; 200 + ok:false otherwise"). This PR aligns implementation with spec per the operator decision recorded against §9 reconciliation.

### Wire contract

\`holder_class='role'\` now produces:

\`\`\`
200 OK
{
  "ok": false,
  "error": "permission_denied",
  "reason": "role_holders_unsupported"
}
\`\`\`

### What's unchanged

- **Auth-layer 401** (\`http_auth.ex\`) for missing/wrong bearer token — that's authentication failure, not application-layer policy.
- **Other unsupported \`holder_class\` values** (e.g. \`"unknown_class"\`) remain 422 schema_invalid — they're structurally malformed input, not policy-rejected.
- **Python \`AcquireRequest\` model** still rejects \`role\` at validation time — defense-in-depth, the Python caller never sends role over the wire.

## Implementation

- \`extract_acquire_params/1\` returns \`{:permission_denied, "role_holders_unsupported"}\` for the role case (vs the prior \`{:error, ...}\` schema_invalid).
- New case-arm in \`POST /v1/lease/acquire\` maps \`{:permission_denied, reason}\` to the 200 + ok:false envelope.
- Existing test \`holder_class='role' → 422 schema_invalid (rejected before DB)\` updated and renamed to \`holder_class='role' → 200 permission_denied (RFC §4.4)\`.
- Added regression test \`holder_class='unknown_class' → 422 schema_invalid\` to keep the structurally-malformed branch covered.
- Added §9-named test \`http_router returns 200 on permission_denied\`.

## §9 audit movement

\`\`\`
Before:  28 named gates → 25 exact / 1 variant / 2 missing
After:   28 named gates → 26 exact / 1 variant / 1 missing
\`\`\`

Only one §9 row remains: \`test_force_release_rejects_governance_token\` (contract-layer integration, separate scope).

## Test plan

- [x] All 34 Elixir router tests pass (\`mix test test/http_router_test.exs\`)
- [x] Full Python suite green: 8128 passed, 33 skipped (\`./scripts/dev/test-cache.sh\`)