### PR TITLE
feat(lease-plane): RFC §7.10 contract-layer force-release authority (PR 1 of 2)

### DIFF
--- a/elixir/lease_plane/lib/unitares_lease_plane.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane.ex
@@ -60,6 +60,26 @@ defmodule UnitaresLeasePlane do
     end
   end
 
+  @doc """
+  Force-release a lease — operator-typed `release_reason='forced'` per RFC §7.10.
+
+  Delegates to `release/2` so a live LeaseHolder is shut down gracefully when
+  one exists; falls through to a direct Repo update when the holder is gone.
+
+  ## Authority and trust boundary
+
+  The contract-layer gate is the HTTPAuth path-aware token check on the
+  `/v1/lease/force-release` route. This function is called only from the
+  router handler for that route. Adding a new in-process caller — including
+  any future OTP worker, Reaper extension, or scheduled job — requires an
+  RFC amendment (§7.10 commits force-release authority to operator-only,
+  contract-layer enforced). If you find yourself wanting to call this from
+  in-BEAM code, route through the HTTP endpoint with the elevated bearer
+  instead, even from inside the same OS process.
+  """
+  @spec force_release(binary()) :: :ok | {:error, term()}
+  def force_release(lease_id), do: release(lease_id, "forced")
+
   @doc "Offer a lease handoff to another holder UUID."
   @spec handoff_offer(binary(), binary(), pos_integer()) :: {:ok, binary()} | {:error, term()}
   def handoff_offer(lease_id, to_holder_agent_uuid, ttl_s) do

--- a/elixir/lease_plane/lib/unitares_lease_plane/application.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/application.ex
@@ -47,6 +47,15 @@ defmodule UnitaresLeasePlane.Application do
       Application.put_env(:lease_plane, :bearer_token, token)
     end
 
+    # RFC §7.10 — separate elevated bearer for force-release (operator-only).
+    # Distinct config key + env var so the regular bearer can't authorize
+    # force-release at the contract layer (HTTPAuth picks the right token by
+    # path). Same fail-closed posture: if absent, force-release endpoint
+    # returns 503.
+    if token = System.get_env("LEASE_FORCE_RELEASE_TOKEN") do
+      Application.put_env(:lease_plane, :force_release_token, token)
+    end
+
     children =
       [
         {Postgrex, postgrex_opts()},

--- a/elixir/lease_plane/lib/unitares_lease_plane/http_auth.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/http_auth.ex
@@ -1,15 +1,24 @@
 defmodule UnitaresLeasePlane.HTTPAuth do
   @moduledoc """
-  Bearer-token Plug. Reads the expected token at request time from
-  `Application.get_env(:lease_plane, :bearer_token)` (set at boot from the
-  `LEASE_PLANE_BEARER_TOKEN` env var, sourced from
-  `~/.config/cirwel/secrets.env`).
+  Bearer-token Plug, path-aware per RFC §7.10. Reads the expected token at
+  request time from one of two config keys depending on the route:
+
+    * `/v1/lease/force-release/*`  → `:force_release_token`
+      (sourced from `LEASE_FORCE_RELEASE_TOKEN` env var)
+    * everything else              → `:bearer_token`
+      (sourced from `LEASE_PLANE_BEARER_TOKEN` env var)
+
+  Both tokens come from `~/.config/cirwel/secrets.env`. Per RFC §7.10 line 731
+  ("standard bearer must NOT permit force-release"), the regular bearer cannot
+  authorize force-release, and the elevated force-release bearer cannot
+  authorize anything else. Mutual exclusion lives at this auth layer (the
+  contract layer), not at the application layer.
 
   Comparison is constant-time via `Plug.Crypto.secure_compare/2` so timing
   side-channels can't probe the token.
 
-  If no expected token is configured, the plug returns 503 — fails closed,
-  not silently open.
+  If the relevant expected token is not configured, the plug returns 503 —
+  fails closed, not silently open.
   """
 
   import Plug.Conn
@@ -21,14 +30,15 @@ defmodule UnitaresLeasePlane.HTTPAuth do
 
   @impl true
   def call(conn, _opts) do
-    expected = Application.get_env(:lease_plane, :bearer_token)
+    {token_key, audience} = required_token_for(conn.path_info)
+    expected = Application.get_env(:lease_plane, token_key)
 
     cond do
       is_nil(expected) or expected == "" ->
         send_json(conn, 503, %{
           ok: false,
           error: "service_unavailable",
-          reason: "bearer token not configured"
+          reason: "#{audience} token not configured"
         })
 
       authorized?(conn, expected) ->
@@ -38,15 +48,38 @@ defmodule UnitaresLeasePlane.HTTPAuth do
         send_json(conn, 401, %{
           ok: false,
           error: "permission_denied",
-          reason: "bearer token missing or invalid"
+          reason: "#{audience} token missing or invalid"
         })
     end
   end
 
+  # Per-path token mapping. Keep the /v1/lease/force-release/* match strict —
+  # anything that doesn't match falls back to the regular bearer, so a typo
+  # in the route never accidentally elevates.
+  defp required_token_for(["v1", "lease", "force-release" | _]),
+    do: {:force_release_token, "force-release"}
+
+  defp required_token_for(_), do: {:bearer_token, "bearer"}
+
   defp authorized?(conn, expected) do
     case get_req_header(conn, "authorization") do
-      ["Bearer " <> presented] -> Plug.Crypto.secure_compare(presented, expected)
+      [value] -> bearer_matches?(value, expected)
       _ -> false
+    end
+  end
+
+  # RFC 7235 §2.1: auth scheme tokens are case-insensitive ("Bearer", "bearer",
+  # "BEARER" are all valid). Several mainstream clients (Python httpx defaults,
+  # some Erlang libs) send lowercase. Match the scheme case-insensitively while
+  # comparing the token value with secure_compare.
+  defp bearer_matches?(value, expected) do
+    case String.split(value, " ", parts: 2) do
+      [scheme, presented] ->
+        String.downcase(scheme) == "bearer" and
+          Plug.Crypto.secure_compare(presented, expected)
+
+      _ ->
+        false
     end
   end
 

--- a/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
@@ -170,6 +170,36 @@ defmodule UnitaresLeasePlane.HTTPRouter do
             json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
         end
 
+      {:permission_denied, reason} ->
+        # RFC §7.10 — release_reason='forced' must arrive at /v1/lease/force-release
+        # so HTTPAuth gates it with the elevated token. Same envelope shape as
+        # other application-layer policy rejections (cf. holder_class='role').
+        json(conn, 200, %{ok: false, error: "permission_denied", reason: reason})
+
+      {:error, detail} ->
+        json(conn, 422, %{ok: false, error: "schema_invalid", detail: detail})
+    end
+  end
+
+  # ---------- /v1/lease/force-release (RFC §7.10) ----------
+  # Operator-only. Gated at the contract layer by HTTPAuth's per-path token
+  # check (`:force_release_token`, sourced from `LEASE_FORCE_RELEASE_TOKEN`).
+  # The regular bearer cannot reach this route — see http_auth.ex.
+  post "/v1/lease/force-release" do
+    case extract_force_release_params(conn.body_params) do
+      {:ok, lease_id} ->
+        case UnitaresLeasePlane.force_release(lease_id) do
+          :ok ->
+            json(conn, 200, %{ok: true})
+
+          {:error, :not_found} ->
+            json(conn, 404, %{ok: false, error: "not_found"})
+
+          {:error, reason_atom} ->
+            Logger.error("lease plane force-release failed: #{inspect(reason_atom)}")
+            json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
+        end
+
       {:error, detail} ->
         json(conn, 422, %{ok: false, error: "schema_invalid", detail: detail})
     end
@@ -315,22 +345,47 @@ defmodule UnitaresLeasePlane.HTTPRouter do
        when is_binary(lease_id) and byte_size(lease_id) > 0 do
     reason = Map.get(body, "release_reason", "normal")
 
-    if reason in [
-         "normal",
-         "down_local",
-         "reaped_after_supervisor_failed",
-         "reaped_local_ttl",
-         "reaped_remote_ttl",
-         "handoff",
-         "forced"
-       ] do
-      {:ok, lease_id, reason}
-    else
-      {:error, "invalid release_reason: #{inspect(reason)}"}
+    cond do
+      # RFC §7.10: force-release requires the elevated bearer at the contract
+      # layer. The /v1/lease/release endpoint is gated by the regular bearer
+      # (HTTPAuth), so accepting release_reason='forced' here would route
+      # around the operator-only authority check. Reject as application-layer
+      # permission_denied with a machine-readable reason that points the
+      # caller at the correct endpoint.
+      reason == "forced" ->
+        {:permission_denied, "forced_release_requires_force_release_endpoint"}
+
+      reason in [
+        "normal",
+        "down_local",
+        "reaped_after_supervisor_failed",
+        "reaped_local_ttl",
+        "reaped_remote_ttl",
+        "handoff"
+      ] ->
+        {:ok, lease_id, reason}
+
+      true ->
+        {:error, "invalid release_reason: #{inspect(reason)}"}
     end
   end
 
   defp extract_release_params(_), do: {:error, "lease_id required"}
+
+  # /v1/lease/force-release takes only lease_id. release_reason is implicit
+  # ('forced') so callers can't accidentally bypass the elevated-bearer gate
+  # by, e.g., passing release_reason='normal'.
+  defp extract_force_release_params(%{} = body) do
+    case Map.get(body, "lease_id") do
+      lease_id when is_binary(lease_id) and byte_size(lease_id) > 0 ->
+        {:ok, lease_id}
+
+      _ ->
+        {:error, "lease_id required"}
+    end
+  end
+
+  defp extract_force_release_params(_), do: {:error, "lease_id required"}
 
   defp extract_handoff_offer_params(%{} = body) do
     lease_id = Map.get(body, "lease_id")

--- a/elixir/lease_plane/test/http_router_test.exs
+++ b/elixir/lease_plane/test/http_router_test.exs
@@ -9,15 +9,20 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
 
   @opts HTTPRouter.init([])
   @bearer "test-bearer-token-do-not-use-in-prod"
+  @force_release_token "test-force-release-token-do-not-use-in-prod"
 
   setup do
     Application.put_env(:lease_plane, :bearer_token, @bearer)
+    Application.put_env(:lease_plane, :force_release_token, @force_release_token)
     surface = unique_surface_id("http")
     on_exit(fn -> cleanup_surface(surface) end)
     {:ok, surface: surface}
   end
 
   defp authed(conn), do: put_req_header(conn, "authorization", "Bearer #{@bearer}")
+
+  defp authed_force_release(conn),
+    do: put_req_header(conn, "authorization", "Bearer #{@force_release_token}")
 
   defp acquire_body(surface, opts \\ []) do
     %{
@@ -62,6 +67,22 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
         |> HTTPRouter.call(@opts)
 
       assert resp.status == 401
+    end
+
+    test "lowercase 'bearer' scheme accepted (RFC 7235 §2.1)", ctx do
+      # RFC 7235 says auth scheme tokens are case-insensitive. Several
+      # mainstream HTTP clients (e.g. Python httpx defaults) send lowercase
+      # "bearer". Reject those and you break interoperability for no security
+      # gain. The token value itself is still compared via secure_compare.
+      resp =
+        :post
+        |> conn("/v1/lease/acquire", Jason.encode!(acquire_body(ctx.surface)))
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "bearer #{@bearer}")
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 200
+      assert parsed(resp)["ok"] == true
     end
 
     test "no expected token configured → 503 fail-closed", ctx do
@@ -532,6 +553,144 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
 
       # Verify the leaky inspect string never made it to the wire.
       refute result.resp_body =~ "hunter2"
+    end
+  end
+
+  # ---------- /v1/lease/force-release (RFC §7.10) ----------
+  #
+  # Contract-layer enforcement of the elevated-bearer requirement. The regular
+  # LEASE_PLANE_BEARER_TOKEN cannot authorize force-release; only
+  # LEASE_FORCE_RELEASE_TOKEN succeeds. Mutual exclusion is enforced in
+  # HTTPAuth's per-path token mapping.
+
+  describe "POST /v1/lease/force-release — auth (RFC §7.10)" do
+    test "regular bearer → 401 permission_denied", _ctx do
+      resp =
+        :post
+        |> conn("/v1/lease/force-release", Jason.encode!(%{lease_id: random_uuid()}))
+        |> put_req_header("content-type", "application/json")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 401
+      payload = parsed(resp)
+      assert payload["error"] == "permission_denied"
+      assert payload["reason"] =~ "force-release"
+    end
+
+    test "missing Authorization header → 401 permission_denied", _ctx do
+      resp =
+        :post
+        |> conn("/v1/lease/force-release", Jason.encode!(%{lease_id: random_uuid()}))
+        |> put_req_header("content-type", "application/json")
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 401
+      assert parsed(resp)["error"] == "permission_denied"
+    end
+
+    test "force-release token → 200 happy path", ctx do
+      # Acquire a lease via the regular bearer, then force-release it with the
+      # elevated bearer. The acquire side proves the regular bearer's normal
+      # scope is unaffected; the force-release side proves the elevated path
+      # works end-to-end.
+      acq = post_json("/v1/lease/acquire", acquire_body(ctx.surface))
+      assert acq.status == 200
+      lease_id = parsed(acq)["lease"]["lease_id"]
+
+      resp =
+        :post
+        |> conn("/v1/lease/force-release", Jason.encode!(%{lease_id: lease_id}))
+        |> put_req_header("content-type", "application/json")
+        |> authed_force_release()
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 200
+      assert parsed(resp)["ok"] == true
+    end
+
+    test "force-release token cannot authorize /v1/lease/acquire (mutual exclusion)", ctx do
+      # The force-release bearer is operator-only; presenting it on a
+      # non-force-release route must fail. Otherwise the elevated token's
+      # exposure surface widens for no contract-layer reason.
+      resp =
+        :post
+        |> conn("/v1/lease/acquire", Jason.encode!(acquire_body(ctx.surface)))
+        |> put_req_header("content-type", "application/json")
+        |> authed_force_release()
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 401
+      assert parsed(resp)["error"] == "permission_denied"
+    end
+
+    test "force-release token unconfigured → 503 fail-closed", _ctx do
+      Application.put_env(:lease_plane, :force_release_token, nil)
+      on_exit(fn ->
+        Application.put_env(:lease_plane, :force_release_token, @force_release_token)
+      end)
+
+      resp =
+        :post
+        |> conn("/v1/lease/force-release", Jason.encode!(%{lease_id: random_uuid()}))
+        |> put_req_header("content-type", "application/json")
+        |> authed_force_release()
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 503
+      assert parsed(resp)["error"] == "service_unavailable"
+    end
+
+    test "missing lease_id → 422 schema_invalid", _ctx do
+      resp =
+        :post
+        |> conn("/v1/lease/force-release", Jason.encode!(%{}))
+        |> put_req_header("content-type", "application/json")
+        |> authed_force_release()
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 422
+      assert parsed(resp)["error"] == "schema_invalid"
+    end
+
+    test "nonexistent lease → 404 not_found", _ctx do
+      resp =
+        :post
+        |> conn("/v1/lease/force-release", Jason.encode!(%{lease_id: random_uuid()}))
+        |> put_req_header("content-type", "application/json")
+        |> authed_force_release()
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 404
+      assert parsed(resp)["error"] == "not_found"
+    end
+  end
+
+  describe "POST /v1/lease/release — release_reason='forced' rejected (RFC §7.10)" do
+    test "release_reason='forced' on /release → 200 permission_denied", ctx do
+      # release_reason='forced' must arrive at /v1/lease/force-release so the
+      # elevated bearer gates it at the contract layer. Accepting it on
+      # /release would route around the §7.10 authority check.
+      acq = post_json("/v1/lease/acquire", acquire_body(ctx.surface))
+      lease_id = parsed(acq)["lease"]["lease_id"]
+
+      resp = post_json("/v1/lease/release", %{lease_id: lease_id, release_reason: "forced"})
+
+      assert resp.status == 200
+      payload = parsed(resp)
+      assert payload["ok"] == false
+      assert payload["error"] == "permission_denied"
+      assert payload["reason"] == "forced_release_requires_force_release_endpoint"
+    end
+
+    test "regular release reasons still succeed on /release", ctx do
+      acq = post_json("/v1/lease/acquire", acquire_body(ctx.surface))
+      lease_id = parsed(acq)["lease"]["lease_id"]
+
+      resp = post_json("/v1/lease/release", %{lease_id: lease_id, release_reason: "normal"})
+
+      assert resp.status == 200
+      assert parsed(resp)["ok"] == true
     end
   end
 end


### PR DESCRIPTION
First half of the operator-chosen RFC alignment for §7.10 force-release authority. RFC §7.10 commits that force-release rejection lives at the contract layer, not just the application layer; prior to this PR force-release was application-layer-only (Python CLI gated locally then did direct SQL UPDATE).

## What changed

| Surface | Change |
|---|---|
| \`application.ex\` | Reads \`LEASE_FORCE_RELEASE_TOKEN\` env into \`:force_release_token\` config (parallel to existing \`:bearer_token\`) |
| \`http_auth.ex\` | Path-aware token selection. \`/v1/lease/force-release/*\` requires \`:force_release_token\`; everything else requires \`:bearer_token\`. Mutual exclusion lives here. Also: bearer scheme parsing is now case-insensitive per RFC 7235 §2.1 (council fix). |
| \`unitares_lease_plane.ex\` | New \`force_release/1\` action delegates to \`release/2\` with \`"forced"\` reason — graceful holder-process shutdown when alive; falls through to direct Repo update otherwise. |
| \`http_router.ex\` | New \`POST /v1/lease/force-release\` endpoint. \`/v1/lease/release\` now rejects \`release_reason='forced'\` with \`200 + permission_denied + reason='forced_release_requires_force_release_endpoint'\`. |
| \`http_router_test.exs\` | 10 new tests cover mutual exclusion both directions, fail-closed token unconfigured, missing/wrong/right tokens, /release-rejects-forced, case-insensitive bearer scheme. |

## Council review

3-agent council (architect, code-reviewer, live-verifier) reviewed the diff in parallel with adversarial framing. Two findings folded into this PR:

1. **HTTPAuth case-sensitive bearer scheme** (reviewer CONCERN, pre-existing) — fixed. \`bearer <token>\` and \`BEARER <token>\` now accepted; token value still compared via \`secure_compare\`.
2. **\`force_release/1\` ambient authority** (architect/reviewer CONCERN) — tightened docstring to declare the trust boundary explicitly: any new in-BEAM caller requires RFC amendment.

## Acknowledged-but-deferred BLOCK

**Architect BLOCK + live-verifier confirmed:** the Python deprecation CLI (\`scripts/dev/lease_plane_deprecate.py:237\`) still bypasses the contract layer via direct \`UPDATE … SET release_reason='forced'\` against Postgres. Live-verifier confirmed there is no DB-layer CHECK / trigger / RLS guard on \`release_reason='forced'\` — anyone with the \`postgres\` role can write it freely. **This is real and is exactly what PR 2 closes** by migrating the CLI to call \`/v1/lease/force-release\` with the elevated bearer + adding the §9-named integration test.

Until PR 2 lands the §9 audit row stays open. Calling Phase A done now would re-label application-layer enforcement as contract-layer enforcement, which is the failure mode #295's RFC alignment posture explicitly rejects.

## Sentinel alarm wiring (verified intact)

Live-verifier confirmed \`force_release/1 → release/2 "forced" → Repo.release → log_event(conn, "forced", lease)\` and \`agents/sentinel/forced_release_alarm.py:89\` queries \`WHERE event_type = 'forced'\`. The chain is unbroken — Sentinel still fires per RFC §7.10 line 727.

## §9 audit (unchanged in this PR)

\`\`\`
28 named gates → 26 exact / 1 variant / 1 missing
\`\`\`

The missing row is \`test_force_release_rejects_governance_token\` (Python integration test). It closes with PR 2.

## Test plan

- [x] 44 Elixir router tests pass (\`mix test test/http_router_test.exs\`)
- [x] Full Python suite green: 8128 passed, 33 skipped (\`./scripts/dev/test-cache.sh\`)
- [x] Council review (architect / reviewer / live-verifier in parallel)