### PR TITLE
feat(r1): PR 1 foundation — migration 031 + reconstruct_eisv_series + epoch backport (R1 v3.3 §A,D,E,F,I)

### DIFF
--- a/db/postgres/knowledge_schema.sql
+++ b/db/postgres/knowledge_schema.sql
@@ -52,6 +52,10 @@ CREATE TABLE IF NOT EXISTS knowledge.discoveries (
     provenance          JSONB,
     provenance_chain    JSONB,
 
+    -- Epoch (added by migration 007; backported here so base DDL is honest
+    -- under R1 v3.3-F.)
+    epoch               INTEGER NOT NULL DEFAULT 1,
+
     -- Full-text search vector (auto-generated)
     search_vector       TSVECTOR GENERATED ALWAYS AS (
         setweight(to_tsvector('english', coalesce(summary, '')), 'A') ||
@@ -65,6 +69,7 @@ CREATE INDEX IF NOT EXISTS idx_knowledge_discoveries_type ON knowledge.discoveri
 CREATE INDEX IF NOT EXISTS idx_knowledge_discoveries_status ON knowledge.discoveries(status);
 CREATE INDEX IF NOT EXISTS idx_knowledge_discoveries_created ON knowledge.discoveries(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_knowledge_discoveries_response_to ON knowledge.discoveries(response_to_id) WHERE response_to_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_discoveries_epoch ON knowledge.discoveries(epoch);
 
 -- GIN indexes for array and FTS
 CREATE INDEX IF NOT EXISTS idx_knowledge_discoveries_tags ON knowledge.discoveries USING GIN (tags);

--- a/db/postgres/migrations/031_r1_provisional_lineage.sql
+++ b/db/postgres/migrations/031_r1_provisional_lineage.sql
@@ -1,0 +1,258 @@
+-- Migration 031: R1 provisional-lineage columns on core.identities + audit.r1_score_audit
+--
+-- Adds the SQL source-of-truth for the R1 v3.3 provisional-lineage lifecycle
+-- and the audit-only persistence target for full per-score records. Public KG
+-- carries only the redacted projection (verdict + calibration_status +
+-- n_dims_used + score_id per v3.3-A); this audit table holds the rest.
+--
+-- See: docs/ontology/r1-verify-lineage-claim.md §v3.3-D (storage decision)
+--      docs/ontology/r1-verify-lineage-claim.md §v3.3-E (table name + retention)
+
+-- =============================================================================
+-- core.identities — provisional-lineage columns
+-- =============================================================================
+
+ALTER TABLE core.identities
+    ADD COLUMN IF NOT EXISTS provisional_lineage     BOOLEAN     NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS provisional_score_id    UUID        NULL,
+    ADD COLUMN IF NOT EXISTS provisional_recorded_at TIMESTAMPTZ NULL,
+    ADD COLUMN IF NOT EXISTS confirmed_at            TIMESTAMPTZ NULL;
+
+COMMENT ON COLUMN core.identities.provisional_lineage     IS 'R1 v3.3-D: TRUE when most recent score returned inconclusive and call-site policy was marks';
+COMMENT ON COLUMN core.identities.provisional_score_id    IS 'R1 v3.3-D: references audit.r1_score_audit.score_id of the score that justified the current state';
+COMMENT ON COLUMN core.identities.provisional_recorded_at IS 'R1 v3.3-D: when the current provisional_lineage value was last set';
+COMMENT ON COLUMN core.identities.confirmed_at            IS 'R1 v3.3-D: stamped on provisional → confirmed transition';
+
+-- No new indexes at v0. Provisional rows expected to be a tiny fraction of
+-- core.identities; index decisions deferred until a query motivates them.
+
+-- =============================================================================
+-- audit.r1_score_audit — full per-score record (audit-only persistence)
+-- =============================================================================
+--
+-- Partitioning: monthly RANGE on recorded_at, mirroring audit.events.
+-- Retention: 180 days (per v3.3-E operator decision; calibration analysis
+-- needs long enough windows to diagnose separation failure, especially for
+-- low-volume class partitions like subagent declared-lineage pairs).
+
+CREATE TABLE IF NOT EXISTS audit.r1_score_audit (
+    score_id            UUID        NOT NULL DEFAULT gen_random_uuid(),
+    parent_id           TEXT        NOT NULL,
+    successor_id        TEXT        NOT NULL,
+    recorded_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    plausibility        REAL        NOT NULL,
+    components          JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    observations        JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    parent_mature       BOOLEAN     NOT NULL DEFAULT FALSE,
+    reasons             TEXT[]      NOT NULL DEFAULT ARRAY[]::TEXT[],
+    class_tag           TEXT        NULL,
+    calibration_status  TEXT        NOT NULL DEFAULT 'seeded'
+                        CHECK (calibration_status IN ('seeded', 'earned', 'calibration_failed')),
+    PRIMARY KEY (score_id, recorded_at)
+) PARTITION BY RANGE (recorded_at);
+
+CREATE INDEX IF NOT EXISTS idx_r1_score_audit_pair_time
+    ON audit.r1_score_audit (parent_id, successor_id, recorded_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_r1_score_audit_class_status
+    ON audit.r1_score_audit (class_tag, calibration_status)
+    WHERE class_tag IS NOT NULL;
+
+COMMENT ON TABLE audit.r1_score_audit IS 'R1 v3.3-A: full per-score record (audit-only); public KG carries only the redacted projection joined via score_id';
+
+-- =============================================================================
+-- Partition management — mirrors audit.create_events_partition pattern
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION audit.create_r1_score_audit_partition(
+    p_year  INTEGER,
+    p_month INTEGER
+)
+RETURNS TEXT AS $$
+DECLARE
+    v_partition_name TEXT;
+    v_start_date     DATE;
+    v_end_date       DATE;
+BEGIN
+    v_partition_name := format('r1_score_audit_%s_%s', p_year, lpad(p_month::text, 2, '0'));
+    v_start_date := make_date(p_year, p_month, 1);
+    v_end_date   := v_start_date + INTERVAL '1 month';
+
+    IF EXISTS (
+        SELECT 1 FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid
+        WHERE n.nspname = 'audit' AND c.relname = v_partition_name
+    ) THEN
+        RETURN format('Partition %s already exists', v_partition_name);
+    END IF;
+
+    EXECUTE format(
+        'CREATE TABLE IF NOT EXISTS audit.%I PARTITION OF audit.r1_score_audit
+         FOR VALUES FROM (%L) TO (%L)',
+        v_partition_name,
+        v_start_date,
+        v_end_date
+    );
+
+    RETURN format('Created partition %s', v_partition_name);
+END;
+$$ LANGUAGE plpgsql;
+
+-- Mirrors audit.drop_old_events_partitions: read partition_bound via
+-- pg_get_expr and regex-extract the end date. Matches existing function
+-- shape (partition_name TEXT, action TEXT) for consistent jsonb_agg.
+--
+-- DROP first because Postgres CREATE OR REPLACE cannot change RETURNS
+-- signature; defensive against any prior version of this function.
+DROP FUNCTION IF EXISTS audit.drop_old_r1_score_audit_partitions(INTEGER);
+
+CREATE OR REPLACE FUNCTION audit.drop_old_r1_score_audit_partitions(
+    p_retention_days INTEGER DEFAULT 180
+)
+RETURNS TABLE (partition_name TEXT, action TEXT) AS $$
+DECLARE
+    v_cutoff DATE;
+    v_rec    RECORD;
+BEGIN
+    v_cutoff := current_date - (p_retention_days || ' days')::INTERVAL;
+
+    FOR v_rec IN
+        SELECT c.relname AS pname,
+               pg_get_expr(c.relpartbound, c.oid) AS partition_bound
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN pg_inherits inh ON inh.inhrelid = c.oid
+        JOIN pg_class parent ON parent.oid = inh.inhparent
+        WHERE n.nspname = 'audit'
+          AND parent.relname = 'r1_score_audit'
+          AND c.relkind = 'r'
+    LOOP
+        IF v_rec.partition_bound ~ 'TO \(''(\d{4}-\d{2}-\d{2})' THEN
+            DECLARE
+                v_end_date DATE;
+            BEGIN
+                v_end_date := (regexp_match(v_rec.partition_bound, 'TO \(''(\d{4}-\d{2}-\d{2})'))[1]::DATE;
+                IF v_end_date < v_cutoff THEN
+                    EXECUTE format('DROP TABLE IF EXISTS audit.%I', v_rec.pname);
+                    partition_name := v_rec.pname;
+                    action := 'dropped';
+                    RETURN NEXT;
+                END IF;
+            END;
+        END IF;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+-- =============================================================================
+-- Initial partitions — current + next 2 months
+-- =============================================================================
+
+DO $$
+DECLARE
+    v_now DATE := CURRENT_DATE;
+BEGIN
+    PERFORM audit.create_r1_score_audit_partition(EXTRACT(YEAR  FROM v_now)::INTEGER,
+                                                  EXTRACT(MONTH FROM v_now)::INTEGER);
+    PERFORM audit.create_r1_score_audit_partition(EXTRACT(YEAR  FROM v_now + INTERVAL '1 month')::INTEGER,
+                                                  EXTRACT(MONTH FROM v_now + INTERVAL '1 month')::INTEGER);
+    PERFORM audit.create_r1_score_audit_partition(EXTRACT(YEAR  FROM v_now + INTERVAL '2 months')::INTEGER,
+                                                  EXTRACT(MONTH FROM v_now + INTERVAL '2 months')::INTEGER);
+END $$;
+
+-- =============================================================================
+-- audit.partition_maintenance — extend to cover r1_score_audit
+-- =============================================================================
+--
+-- Mirrors the existing function body (db/postgres/partitions.sql:280) and
+-- splices in r1_score_audit create_current/next + drop_old_180d. Keeping the
+-- r1 lifecycle wired into the same maintenance entrypoint avoids a parallel
+-- cron schedule and matches the events / tool_usage / outcome_events pattern.
+
+CREATE OR REPLACE FUNCTION audit.partition_maintenance()
+RETURNS JSONB AS $$
+DECLARE
+    v_result JSONB := '{}'::jsonb;
+    v_current_year INTEGER;
+    v_current_month INTEGER;
+    v_next_year INTEGER;
+    v_next_month INTEGER;
+    v_msg TEXT;
+BEGIN
+    v_current_year := EXTRACT(YEAR FROM current_date)::INTEGER;
+    v_current_month := EXTRACT(MONTH FROM current_date)::INTEGER;
+
+    IF v_current_month = 12 THEN
+        v_next_year := v_current_year + 1;
+        v_next_month := 1;
+    ELSE
+        v_next_year := v_current_year;
+        v_next_month := v_current_month + 1;
+    END IF;
+
+    -- Ensure current month partitions exist
+    v_msg := audit.create_events_partition(v_current_year, v_current_month);
+    v_result := v_result || jsonb_build_object('events_current', v_msg);
+
+    v_msg := audit.create_tool_usage_partition(v_current_year, v_current_month);
+    v_result := v_result || jsonb_build_object('tool_usage_current', v_msg);
+
+    v_msg := audit.create_outcome_partition(v_current_year, v_current_month);
+    v_result := v_result || jsonb_build_object('outcome_events_current', v_msg);
+
+    v_msg := audit.create_r1_score_audit_partition(v_current_year, v_current_month);
+    v_result := v_result || jsonb_build_object('r1_score_audit_current', v_msg);
+
+    -- Create next month partitions (look-ahead)
+    v_msg := audit.create_events_partition(v_next_year, v_next_month);
+    v_result := v_result || jsonb_build_object('events_next', v_msg);
+
+    v_msg := audit.create_tool_usage_partition(v_next_year, v_next_month);
+    v_result := v_result || jsonb_build_object('tool_usage_next', v_msg);
+
+    v_msg := audit.create_outcome_partition(v_next_year, v_next_month);
+    v_result := v_result || jsonb_build_object('outcome_events_next', v_msg);
+
+    v_msg := audit.create_r1_score_audit_partition(v_next_year, v_next_month);
+    v_result := v_result || jsonb_build_object('r1_score_audit_next', v_msg);
+
+    -- Clean up old partitions
+    v_result := v_result || jsonb_build_object(
+        'events_dropped',
+        (SELECT jsonb_agg(partition_name) FROM audit.drop_old_events_partitions(180))
+    );
+    v_result := v_result || jsonb_build_object(
+        'tool_usage_dropped',
+        (SELECT jsonb_agg(partition_name) FROM audit.drop_old_tool_usage_partitions(90))
+    );
+    v_result := v_result || jsonb_build_object(
+        'outcome_events_dropped',
+        (SELECT jsonb_agg(partition_name) FROM audit.drop_old_outcome_partitions(365))
+    );
+    v_result := v_result || jsonb_build_object(
+        'r1_score_audit_dropped',
+        (SELECT jsonb_agg(partition_name) FROM audit.drop_old_r1_score_audit_partitions(180))
+    );
+
+    -- Clean up expired sessions
+    v_result := v_result || jsonb_build_object(
+        'sessions_cleaned',
+        core.cleanup_expired_sessions()
+    );
+
+    -- Clean up old agent_state rows (keep last 90 days)
+    v_result := v_result || jsonb_build_object(
+        'agent_state_cleaned',
+        core.cleanup_old_agent_state(90)
+    );
+
+    RETURN v_result;
+END;
+$$ LANGUAGE plpgsql;
+
+-- =============================================================================
+-- Register migration
+-- =============================================================================
+
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (31, 'r1_provisional_lineage', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/db/postgres/schema.sql
+++ b/db/postgres/schema.sql
@@ -162,12 +162,18 @@ CREATE TABLE IF NOT EXISTS core.agent_state (
     -- Full state snapshot (for complex queries)
     state_json          JSONB NOT NULL DEFAULT '{}'::jsonb,
 
+    -- Epoch (added by migration 007; backported here so base DDL is honest
+    -- under R1 v3.3-F. Bumped when EISV coupling constants, coherence formulas,
+    -- or calibration logic change in a way that invalidates existing rows.)
+    epoch               INTEGER NOT NULL DEFAULT 1,
+
     -- Unique constraint: one state per identity per timestamp
     UNIQUE (identity_id, recorded_at)
 );
 
 CREATE INDEX IF NOT EXISTS idx_agent_state_identity_time ON core.agent_state(identity_id, recorded_at DESC);
 CREATE INDEX IF NOT EXISTS idx_agent_state_regime ON core.agent_state(regime) WHERE regime != 'nominal';
+CREATE INDEX IF NOT EXISTS idx_agent_state_epoch ON core.agent_state(epoch);
 
 -- -----------------------------------------------------------------------------
 -- Schema Migrations (track applied migrations)

--- a/src/db/mixins/state.py
+++ b/src/db/mixins/state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import timedelta
 from typing import Any, Dict, List, Optional
 
 from ..base import AgentStateRecord
@@ -313,6 +314,67 @@ class StateMixin:
                     GovernanceConfig.CURRENT_EPOCH,
                 )
             return [self._row_to_agent_state(r) for r in rows]
+
+    async def reconstruct_eisv_series(
+        self,
+        agent_id: str,
+        window: timedelta,
+        *,
+        epoch: Optional[int] = None,
+    ) -> Dict[str, List[float]]:
+        """Reconstruct per-dimension EISV series for an agent over a window.
+
+        R1 helper consumed by `score_trajectory_continuity` (PR 2). Returns
+        `{'E': [...], 'I': [...], 'S': [...], 'V': [...]}` ordered by
+        `recorded_at` ascending. Empty list per dimension when no rows in
+        window — caller (the score primitive) handles exclusion-from-average
+        per design doc §v3.3-H.C4.
+
+        Filters:
+        - `epoch = GovernanceConfig.CURRENT_EPOCH` (default; pass explicitly to
+          override for replay/historical analysis). Mirrors the same filter
+          shape used in `get_latest_agent_state` and `get_all_latest_agent_states`.
+        - `synthetic = false` — bootstrap rows are claimed-genesis anchors, not
+          earned trajectory. R1 plausibility is about earned trajectory shape,
+          so synthetic anchors must not inflate similarity scores. (Same posture
+          as `get_all_latest_agent_states` per onboard-bootstrap-checkin §4.1.)
+
+        Dimension key 'V' maps to SQL column 'volatility' per the project
+        convention; see `_row_to_agent_state` for the analogous Python field
+        name 'void' ↔ SQL 'volatility'. R1 uses the user-facing 'V' label
+        (matches paper terminology and identity.md ontology lexicon).
+
+        See: docs/ontology/r1-verify-lineage-claim.md §v3.1 'New helper',
+             §v3.3-A 'audit-only persistence' (consumes this output),
+             §v3.3-F 'epoch column reference'.
+        """
+        if epoch is None:
+            from config.governance_config import GovernanceConfig
+            epoch = GovernanceConfig.CURRENT_EPOCH
+
+        async with self.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT s.entropy, s.integrity, s.stability_index, s.volatility,
+                       s.recorded_at
+                FROM core.agent_state s
+                JOIN core.identities i ON i.identity_id = s.identity_id
+                WHERE i.agent_id = $1
+                  AND s.epoch = $2
+                  AND s.synthetic = false
+                  AND s.recorded_at >= NOW() - $3::interval
+                ORDER BY s.recorded_at ASC
+                """,
+                agent_id, epoch, window,
+            )
+
+        series: Dict[str, List[float]] = {"E": [], "I": [], "S": [], "V": []}
+        for row in rows:
+            series["E"].append(float(row["entropy"]))
+            series["I"].append(float(row["integrity"]))
+            series["S"].append(float(row["stability_index"]))
+            series["V"].append(float(row["volatility"]))
+        return series
 
     async def get_recent_cross_agent_activity(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,6 +119,9 @@ def _isolate_db_backend(monkeypatch):
     mock_backend.record_agent_state.return_value = 1
     mock_backend.get_latest_agent_state.return_value = None
     mock_backend.get_agent_state_history.return_value = []
+    mock_backend.reconstruct_eisv_series.return_value = {
+        "E": [], "I": [], "S": [], "V": [],
+    }
     # Audit/tool operations
     mock_backend.append_audit_event.return_value = True
     mock_backend.query_audit_events.return_value = []

--- a/tests/test_lineage_continuity_helper.py
+++ b/tests/test_lineage_continuity_helper.py
@@ -1,0 +1,156 @@
+"""Tests for reconstruct_eisv_series — the StateMixin method that R1's
+score_trajectory_continuity primitive (PR 2) consumes.
+
+Per docs/ontology/r1-verify-lineage-claim.md §v3.1 ("New helper") and §v3.3-I
+(table name + column corrections). The helper is a normal async mixin method
+using the existing self.acquire() pool pattern; the anyio safety wrapper lives
+at the handler layer, not here (consistent with sibling methods like
+get_latest_agent_state and record_agent_state).
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def test_reconstruct_eisv_series_exists_on_state_mixin():
+    """Contract: StateMixin exposes reconstruct_eisv_series.
+
+    Fails (AttributeError) until the method is added in src/db/mixins/state.py.
+    """
+    from src.db.mixins.state import StateMixin
+    assert hasattr(StateMixin, "reconstruct_eisv_series"), (
+        "StateMixin must expose reconstruct_eisv_series for R1 score_trajectory_continuity"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_eisv_series_maps_rows_to_per_dim_lists():
+    """Behavior: rows in window get bucketed into {E, I, S, V} → list[float]
+    in recorded_at-ascending order.
+
+    Mocks self.acquire() context manager returning a connection whose fetch()
+    returns three synthetic rows. Verifies dimension-key mapping
+    (entropy→E, integrity→I, stability_index→S, volatility→V) and order.
+    """
+    from src.db.mixins.state import StateMixin
+
+    class _Stub(StateMixin):
+        def acquire(self):
+            return _AcquireCtx()
+
+    class _AcquireCtx:
+        async def __aenter__(self):
+            conn = AsyncMock()
+            # Three rows ordered ascending by recorded_at; columns match the
+            # SQL projection in the helper.
+            conn.fetch = AsyncMock(return_value=[
+                _row(entropy=0.5, integrity=0.6, stability_index=0.4, volatility=0.1),
+                _row(entropy=0.6, integrity=0.7, stability_index=0.4, volatility=0.2),
+                _row(entropy=0.7, integrity=0.8, stability_index=0.5, volatility=0.3),
+            ])
+            return conn
+
+        async def __aexit__(self, *args):
+            return None
+
+    backend = _Stub()
+    result = await backend.reconstruct_eisv_series(
+        agent_id="test-uuid",
+        window=timedelta(days=30),
+        epoch=3,
+    )
+
+    assert set(result.keys()) == {"E", "I", "S", "V"}
+    assert result["E"] == [0.5, 0.6, 0.7]
+    assert result["I"] == [0.6, 0.7, 0.8]
+    assert result["S"] == [0.4, 0.4, 0.5]
+    assert result["V"] == [0.1, 0.2, 0.3]
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_eisv_series_empty_when_no_rows():
+    """Behavior: empty per-dim lists when no rows in window.
+
+    Caller (score_trajectory_continuity, PR 2) treats empty as 'skip dimension
+    from average' per v3.3-H.C4. Empty here is the helper's responsibility to
+    return; the skip-from-average decision is the caller's.
+    """
+    from src.db.mixins.state import StateMixin
+
+    class _Stub(StateMixin):
+        def acquire(self):
+            return _EmptyAcquire()
+
+    class _EmptyAcquire:
+        async def __aenter__(self):
+            conn = AsyncMock()
+            conn.fetch = AsyncMock(return_value=[])
+            return conn
+
+        async def __aexit__(self, *args):
+            return None
+
+    backend = _Stub()
+    result = await backend.reconstruct_eisv_series(
+        agent_id="no-rows-uuid",
+        window=timedelta(days=30),
+        epoch=3,
+    )
+
+    assert set(result.keys()) == {"E", "I", "S", "V"}
+    assert all(v == [] for v in result.values())
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_eisv_series_uses_current_epoch_when_unspecified():
+    """Behavior: epoch defaults to GovernanceConfig.CURRENT_EPOCH when not passed.
+
+    Verifies the SQL receives the current-epoch param (not a literal/wrong value).
+    """
+    from src.db.mixins.state import StateMixin
+    from config.governance_config import GovernanceConfig
+
+    captured_args: list = []
+
+    class _Stub(StateMixin):
+        def acquire(self):
+            return _CapturingAcquire(captured_args)
+
+    class _CapturingAcquire:
+        def __init__(self, sink):
+            self._sink = sink
+
+        async def __aenter__(self):
+            conn = AsyncMock()
+
+            async def _fetch(sql, *args):
+                self._sink.append(args)
+                return []
+
+            conn.fetch = _fetch
+            return conn
+
+        async def __aexit__(self, *args):
+            return None
+
+    backend = _Stub()
+    await backend.reconstruct_eisv_series(
+        agent_id="test-uuid",
+        window=timedelta(days=30),
+        # epoch not passed
+    )
+
+    assert len(captured_args) == 1
+    args = captured_args[0]
+    # Args order per helper SQL: (agent_id, epoch, window)
+    assert args[0] == "test-uuid"
+    assert args[1] == GovernanceConfig.CURRENT_EPOCH
+
+
+def _row(**fields):
+    """Build a dict-like row stub matching asyncpg.Record attribute access."""
+    return fields

--- a/tests/test_lineage_continuity_helper.py
+++ b/tests/test_lineage_continuity_helper.py
@@ -146,11 +146,20 @@ async def test_reconstruct_eisv_series_uses_current_epoch_when_unspecified():
 
     assert len(captured_args) == 1
     args = captured_args[0]
-    # Args order per helper SQL: (agent_id, epoch, window)
+    # Args order per helper SQL: (agent_id, epoch, window). Lock all three
+    # positions so a parameter-order refactor surfaces in this test.
     assert args[0] == "test-uuid"
     assert args[1] == GovernanceConfig.CURRENT_EPOCH
+    assert args[2] == timedelta(days=30)
 
 
 def _row(**fields):
-    """Build a dict-like row stub matching asyncpg.Record attribute access."""
+    """Build a dict-like row stub.
+
+    Returns a plain dict supporting subscript access (`row["entropy"]`) only,
+    which matches how `reconstruct_eisv_series` reads asyncpg Records. asyncpg
+    Records also support attribute-style access (`row.entropy`); if a future
+    author adds attribute-style access to the production code, this helper
+    must change accordingly.
+    """
     return fields


### PR DESCRIPTION
## Summary

R1 implementation row, PR 1 of 3. Strictly additive — no consumer impact. Foundation for `score_trajectory_continuity` (PR 2) and the lifecycle/consumer patches (PR 3).

**Per design doc:** `docs/ontology/r1-verify-lineage-claim.md` v3.3 amendment, sections A, D, E, F, I.

## What landed

**Migration 031 (`db/postgres/migrations/031_r1_provisional_lineage.sql`):**
- 4 columns on `core.identities` per v3.3-D: `provisional_lineage` BOOL NOT NULL DEFAULT FALSE, `provisional_score_id` UUID, `provisional_recorded_at` TIMESTAMPTZ, `confirmed_at` TIMESTAMPTZ
- New partitioned table `audit.r1_score_audit` per v3.3-A + v3.3-E (RANGE on recorded_at, monthly cadence, 180d retention) — full audit-only persistence target for v3.3-A's strict public redaction split
- 2 new audit functions: `audit.create_r1_score_audit_partition`, `audit.drop_old_r1_score_audit_partitions` mirroring existing `events`/`tool_usage`/`outcome_events` patterns
- `audit.partition_maintenance` extended to wire r1_score_audit lifecycle into the existing scheduled job
- 3 initial monthly partitions seeded (current + 2 ahead)
- Registered as `core.schema_migrations` version 31

**Schema backport (v3.3-F):**
- `epoch INTEGER NOT NULL DEFAULT 1` + index added to `core.agent_state` in `db/postgres/schema.sql`
- Same in `knowledge.discoveries` in `db/postgres/knowledge_schema.sql`
- Live schemas unaffected; this only makes base DDL files honest as a bootstrap reference. Other 2 tables migration 007 touches (`core.agent_baselines`, `audit.outcome_events`) live only in migrations 005/004, not in base DDL — backport doesn't apply there.

**Backend method (`src/db/mixins/state.py`):**
- `reconstruct_eisv_series(agent_id, window, *, epoch=None) -> Dict[str, List[float]]`
- Pattern matches sibling methods (`get_latest_agent_state`, `get_all_latest_agent_states`): `async with self.acquire() as conn`, `JOIN core.identities`, filters `s.epoch` + `s.synthetic = false` (bootstrap rows are claimed-genesis anchors, not earned trajectory)
- 4 unit tests + conftest stub for `mock_backend.reconstruct_eisv_series`

## Council review

3 agents in parallel (architect + reviewer + live-verifier), all returned PROCEED:

- **Live-verifier** verified all 10 claims including end-to-end INSERT/SELECT/DELETE smoke test against live `audit.r1_score_audit` partition routing
- **Architect** found 3 minor flags (no FK on `provisional_score_id` defensible due to composite PK on partitioned table; TEXT not FK on parent_id/successor_id consistent with existing pattern; synthetic filter not regression-locked but defers to PR 2/3 integration)
- **Code-reviewer** found 3 flags; one (test args[2] not asserted) folded into commit `cc0513d`. Issues 2 (docstring honesty) folded same commit. Issue 3 (exception coverage) deferred to PR 2 where exception handling becomes load-bearing.

Migration applied to dev DB cleanly; doctor passes at version 31; full suite 8136 passed, 33 skipped, 0 fail, 78.91% coverage.

## Test plan

- [x] Migration applies idempotently (re-applied with DROP FUNCTION IF EXISTS guard for return-signature change)
- [x] All 4 columns + table + partitions + functions verified via `\d` and `\df` against live DB
- [x] `audit.partition_maintenance()` runs without error and emits `r1_score_audit_*` keys
- [x] Migration registered as version 31, doctor verifies registry match
- [x] 4 unit tests for `reconstruct_eisv_series` (existence, row mapping, empty-no-rows, CURRENT_EPOCH default)
- [x] Full suite green, no regressions