### PR TITLE
ops(lease-plane): launchd plist template + start.sh wrapper for persistent service

### DIFF
--- a/elixir/lease_plane/scripts/start.sh
+++ b/elixir/lease_plane/scripts/start.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Launchd entrypoint for the Surface Lease Plane (Elixir/OTP).
+#
+# Sources LEASE_PLANE_BEARER_TOKEN + LEASE_FORCE_RELEASE_TOKEN from
+# ~/.config/cirwel/secrets.env (mode 600 — not keychain), then execs
+# `mix run --no-halt`. Bind defaults to 127.0.0.1:8788; override via
+# the :lease_plane runtime config or env (see application.ex).
+#
+# Used by: scripts/ops/com.unitares.lease-plane.plist
+# Manual invocation: `./elixir/lease_plane/scripts/start.sh`
+#
+# Fail-closed posture: if secrets.env is missing or the bearer is
+# unset, the application starts but HTTPAuth returns 503 on every
+# request — never silently open. See application.ex:43.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+LEASE_PLANE_DIR="$REPO_ROOT/elixir/lease_plane"
+SECRETS_FILE="$HOME/.config/cirwel/secrets.env"
+
+if [[ -f "$SECRETS_FILE" ]]; then
+    # shellcheck disable=SC1090
+    source "$SECRETS_FILE"
+else
+    echo "[lease-plane] WARNING: $SECRETS_FILE missing — starting fail-closed (HTTPAuth → 503)" >&2
+fi
+
+# Homebrew Elixir lives at /opt/homebrew/bin on Apple Silicon. PATH inherited
+# from launchd's user environment is sparse, so we set it explicitly.
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+cd "$LEASE_PLANE_DIR"
+exec mix run --no-halt

--- a/scripts/ops/com.unitares.lease-plane.plist.template
+++ b/scripts/ops/com.unitares.lease-plane.plist.template
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  launchd manifest for the Surface Lease Plane (Elixir/OTP, port 8788).
+
+  Phase A advisory service for shared-surface coordination across the fleet
+  (Watcher, Vigil, Sentinel, Chronicler, Steward, ship.sh, dispatch). Bind
+  defaults to 127.0.0.1:8788; bearer-auth is fail-closed (HTTPAuth → 503
+  if LEASE_PLANE_BEARER_TOKEN is unset). See docs/proposals/surface-lease-plane-v0.md.
+
+  Install (render __VARS__ then load):
+    sed -e "s|__UNITARES_ROOT__|$HOME/projects/unitares|g" \
+        -e "s|__HOME__|$HOME|g" \
+        scripts/ops/com.unitares.lease-plane.plist.template \
+        > ~/Library/LaunchAgents/com.unitares.lease-plane.plist
+    launchctl load ~/Library/LaunchAgents/com.unitares.lease-plane.plist
+
+  Verify (with $LEASE_PLANE_BEARER_TOKEN sourced from ~/.config/cirwel/secrets.env):
+    launchctl list | grep com.unitares.lease-plane
+    tail -f ~/Library/Logs/unitares-lease-plane.log
+    curl -s -H "Authorization: Bearer $LEASE_PLANE_BEARER_TOKEN" \
+         "http://127.0.0.1:8788/v1/lease/status?surface_id=file:///tmp/probe"
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.unitares.lease-plane</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__UNITARES_ROOT__/elixir/lease_plane/scripts/start.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__UNITARES_ROOT__/elixir/lease_plane</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/Library/Logs/unitares-lease-plane.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__HOME__/Library/Logs/unitares-lease-plane.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>LANG</key>
+        <string>en_US.UTF-8</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Persistent-service wiring for the Surface Lease Plane (Phase A). Loaded locally as `com.unitares.lease-plane` and validated end-to-end against the just-merged dispatch preflight (PR CIRWEL/discord-dispatch#5) — three smoke calls produced \`acquired_new\` → \`acquired_idempotent\` → \`held_by_other\` with all events durable in \`lease_plane.surface_leases\` + \`lease_plane.lease_plane_events\`.

## What this adds

- **\`scripts/ops/com.unitares.lease-plane.plist.template\`** — render-and-load template following the existing \`com.unitares.gateway-mcp.plist.template\` pattern (\`__UNITARES_ROOT__\` + \`__HOME__\` substitutions). \`KeepAlive: true\`, \`ThrottleInterval: 10\`, logs to \`~/Library/Logs/unitares-lease-plane.log\`. Plist copies stay gitignored per existing \`.gitignore:149\`.
- **\`elixir/lease_plane/scripts/start.sh\`** — launchd entrypoint. Sources \`~/.config/cirwel/secrets.env\` (mode 600) for \`LEASE_PLANE_BEARER_TOKEN\` + \`LEASE_FORCE_RELEASE_TOKEN\`, exports a sane PATH (Homebrew Elixir at \`/opt/homebrew/bin\` is not in launchd's default PATH), and execs \`mix run --no-halt\`. Fail-closed: missing secrets file logs a warning but starts the application; HTTPAuth then returns 503 on every request — never silently open. Matches the policy at \`application.ex:43\`.

## Production verification

- Service loaded: \`launchctl list | grep lease-plane\` → PID 24722 → restart picked up new code as PID 24924/24926 for dispatch peers
- Bandit binding: \`Running UnitaresLeasePlane.HTTPRouter with Bandit 1.10.4 at 127.0.0.1:8788 (http)\`
- Acquire smoke: \`POST /v1/lease/acquire\` → \`{ok: true, idempotent: false, lease_id: dbc2fa67…}\`
- Three-call preflight (different threads, contended surface): \`acquired_new → acquired_idempotent → held_by_other\` — first observed automated cross-thread conflict event for Plexus

## Why this PR is small on purpose

Per \`docs/proposals/plexus-scope.md\` stop signs, the scope is intentionally narrow: launch the lease plane, no force-release token (defer until operator opt-in), no off-host exposure, no Reaper-interval tuning, no force-release authority for dispatch. The Phase A advisory wrappers across the fleet (Watcher, Vigil, Sentinel, Chronicler, Steward, ship.sh, dispatch) start emitting evidence the moment this lands; that evidence drives the Phase B promotion decision, not this PR.

## Test plan

- [x] \`./scripts/dev/test-cache.sh\` — 8137 passed, 33 skipped, coverage 78.91% (no test changes; ran for the pre-push gate)
- [x] \`launchctl load\` succeeds and Bandit binds 127.0.0.1:8788
- [x] Smoke acquire returns 200 + lease_id with bearer; \`curl -s http://127.0.0.1:8788/health\` returns 401 without (fail-closed posture confirmed)
- [x] Cross-repo end-to-end: discord-dispatch \`acquireDispatchPreflight\` against the live launchd service produced \`acquired_new\`, \`acquired_idempotent\`, and \`held_by_other\` outcomes; all events durable in \`lease_plane.surface_leases\` + \`lease_plane.lease_plane_events\`

## Surface-collision check

\`gh pr list --search "lease-plane plist"\` and \`--search "launchd"\` → no parallel PRs. Per memory \`feedback_decisive-defaults-over-tooling-forks.md\` and the Phase A reviewer-checklist gate, no other Phase A code paths touched.