### PR TITLE
test(r6): close spec test plan items 10+11 — thin shape + is_fork invariant across all v2 cases

### DIFF
--- a/tests/test_r6_episode_fork_enrichment.py
+++ b/tests/test_r6_episode_fork_enrichment.py
@@ -122,3 +122,110 @@ def test_enrich_thread_identity_adds_r6_thin_shape_for_root():
     assert thread_context["identity_lineage_fork"] is False
     assert thread_context["is_fork"] == (thread_context["episode_fork_kind"] != "none")
     assert thread_context["honest_message"] == "You are the first observation under this thread. No fork."
+
+
+# Spec test plan items 10 + 11 from `docs/ontology/r6-episode-fork-response-shape.md`
+# §"Test plan" — every R6 v2 case must (10) populate the thin thread_context
+# shape (`thread_id`, `position`, `is_fork`, `episode_fork_kind`,
+# `identity_lineage_fork`, `honest_message`) and (11) preserve the legacy
+# `is_fork == (position > 1)` invariant. Spec §"Compatibility boundary" calls
+# out that `is_fork` is purely position-based and is NOT equivalent to
+# `episode_fork_kind != "none"` — the identity-lineage-at-root case is the
+# canonical counterexample (case 3 below).
+@pytest.mark.parametrize(
+    (
+        "spec_case",
+        "position",
+        "agent_uuid",
+        "parent_uuid",
+        "spawn_reason",
+        "expected_kind",
+        "expected_lineage",
+    ),
+    [
+        ("1 root node", 1, "agent-1", None, None, "none", False),
+        ("2 sibling-locus (April 30 case)", 2, "agent-1", None, None, "sibling_locus", False),
+        ("3 identity-lineage via has_child_uuid", 1, "child", "parent", "new_session", "identity_lineage", True),
+        ("4 subagent fork", 1, "child", "parent", "subagent", "identity_lineage", True),
+        ("5 compaction fork", 1, "child", "parent", "compaction", "identity_lineage", True),
+        ("7 dispatch_auto_mint no parent", 1, "agent-1", None, "dispatch_auto_mint", "none", False),
+        ("8 resident_observer with has_child_uuid", 1, "child", "parent", "resident_observer", "identity_lineage", True),
+        ("9 substrate-earned restart (Lumen)", 2, "lumen", "lumen", "explicit", "sibling_locus", False),
+    ],
+)
+def test_enrich_thread_identity_thin_shape_and_is_fork_invariant(
+    spec_case,
+    position,
+    agent_uuid,
+    parent_uuid,
+    spawn_reason,
+    expected_kind,
+    expected_lineage,
+):
+    """Spec test plan items 10 + 11. Case 6 (sync-race fallback) is covered
+    separately by `test_classify_fork_sync_race_fallback_warns` because it
+    asserts a side-effect (warning log) the parametrize harness can't see.
+    """
+    ctx = _ctx_for_thread(
+        position=position,
+        agent_uuid=agent_uuid,
+        parent_uuid=parent_uuid,
+        spawn_reason=spawn_reason,
+    )
+
+    enrich_thread_identity(ctx)
+
+    tc = ctx.response_data["thread_context"]
+
+    # Spec test 10 — thin shape contains all 6 keys.
+    assert set(tc.keys()) == {
+        "thread_id",
+        "position",
+        "is_fork",
+        "episode_fork_kind",
+        "identity_lineage_fork",
+        "honest_message",
+    }, f"unexpected thread_context keys for case {spec_case!r}: {set(tc.keys())}"
+
+    # Preserved fields.
+    assert tc["thread_id"] == "thread-r6"
+    assert tc["position"] == position
+
+    # R6 v2 fork classification.
+    assert tc["episode_fork_kind"] == expected_kind, f"case {spec_case!r}"
+    assert tc["identity_lineage_fork"] is expected_lineage, f"case {spec_case!r}"
+
+    # Spec test 11 — `is_fork` remains purely position-based.
+    assert tc["is_fork"] is (position > 1), (
+        f"case {spec_case!r}: is_fork ({tc['is_fork']}) must equal position > 1 "
+        f"({position > 1}); see spec §'Compatibility boundary'"
+    )
+
+    # Honest message is non-empty for every case (specific phrase asserted by
+    # the per-kind tests above; here we only require content).
+    assert isinstance(tc["honest_message"], str) and tc["honest_message"], (
+        f"case {spec_case!r}: honest_message must be non-empty"
+    )
+
+
+def test_enrich_thread_identity_identity_lineage_at_root_disambiguates_is_fork():
+    """Spec §'Compatibility boundary' canonical counterexample: a fresh child
+    UUID at position 1 is an identity-lineage fork by R6 ontology, but legacy
+    `is_fork` stays False because position == 1. The new
+    `identity_lineage_fork` scalar is what disambiguates."""
+    ctx = _ctx_for_thread(
+        position=1,
+        agent_uuid="child",
+        parent_uuid="parent",
+        spawn_reason="new_session",
+    )
+
+    enrich_thread_identity(ctx)
+
+    tc = ctx.response_data["thread_context"]
+    assert tc["is_fork"] is False, "legacy is_fork is purely position-based"
+    assert tc["identity_lineage_fork"] is True, (
+        "identity_lineage_fork must surface the lineage event that legacy "
+        "is_fork would miss"
+    )
+    assert tc["episode_fork_kind"] == "identity_lineage"


### PR DESCRIPTION
Closes the residual on R6's implementation row. PR #287 shipped the runtime classification (`_classify_fork`) + the enrichment (`enrich_thread_identity`); this PR systematically asserts the spec's test plan items 10 + 11 across all 9 R6 v2 cases.

## What was missing

\`docs/ontology/r6-episode-fork-response-shape.md\` §"Test plan" enumerates 11 items. Items 1–9 + the sync-race warning (item 6) are covered by PR #287's parametrize over \`_classify_fork\`. Items 10 + 11 — assert the full \`thread_context\` shape and \`is_fork == (position > 1)\` invariant across all cases — were only checked on 3 of the 9 cases (\`sibling_locus\`, \`identity_lineage\`, \`root\`). The other 6 cases tested \`_classify_fork\` directly without going through \`enrich_thread_identity\`, so the shape/invariant wasn't proven for them.

## What this PR adds

| Spec item | Coverage added | Test name |
|---|---|---|
| 10 — thin \`thread_context\` shape across all cases | New parametrize (8 cases; case 6 sync-race covered separately) — asserts exact key set is `{thread_id, position, is_fork, episode_fork_kind, identity_lineage_fork, honest_message}` and `honest_message` is non-empty | `test_enrich_thread_identity_thin_shape_and_is_fork_invariant` |
| 11 — \`is_fork == (position > 1)\` invariant across all cases | Same parametrize asserts the position-only invariant per case | `test_enrich_thread_identity_thin_shape_and_is_fork_invariant` |
| §"Compatibility boundary" canonical counterexample | Dedicated test for identity-lineage-at-root: \`is_fork=False\` AND \`identity_lineage_fork=True\` | `test_enrich_thread_identity_identity_lineage_at_root_disambiguates_is_fork` |

The case-6 sync-race fallback stays in its own test (`test_classify_fork_sync_race_fallback_warns`) because it asserts a side effect (warning log) the parametrize harness can't observe.

## Why this matters

The §"Compatibility boundary" disambiguation case is the load-bearing reason `identity_lineage_fork` exists as a separate scalar from `episode_fork_kind != "none"` — a fresh child UUID at position 1 is a lineage event but `is_fork` stays False. The new dedicated test pins that contract so a future refactor can't quietly collapse `identity_lineage_fork` into `is_fork`.

## Test plan

- [x] `pytest tests/test_r6_episode_fork_enrichment.py -v` — 21 pass / 0 fail (12 baseline + 9 new)
- [x] `./scripts/dev/test-cache.sh` — 8146 passed / 33 skipped / coverage 78.91%

## Surface-collision check

`gh pr list --search "R6"` and `--search "episode_fork"` → no parallel PRs. Runtime not touched (test-only); R6 `enrich_thread_identity` + `_classify_fork` shipped in PR #287 unchanged.