### PR TITLE
feat(doctor): elixir_scheme_grammar_lint — fail on Elixir scheme not in grammar CHECK

### DIFF
--- a/scripts/dev/unitares_doctor.py
+++ b/scripts/dev/unitares_doctor.py
@@ -310,6 +310,112 @@ def check_elixir_deprecated_scheme_lint(db_url: str, repo_root: Path) -> CheckRe
     )
 
 
+def check_elixir_scheme_grammar_lint(db_url: str, repo_root: Path) -> CheckResult:
+    """Phase B prep (RFC §7.11.8 inverse): FAIL if canonicalize.ex mentions a
+    surface scheme NOT in the live `surface_id_grammar` CHECK constraint.
+
+    Catches the inverse drift from `elixir_deprecated_scheme_lint`. That lint
+    catches schemes deprecated-but-still-mentioned in Elixir; this one catches
+    schemes mentioned-by-Elixir-but-not-in-grammar. If Elixir ships a
+    `dispatch("foo:/" <> rest)` arm but the migration-026 CHECK doesn't allow
+    `foo:/`, every acquire of that scheme fails the storage-layer constraint
+    and the Elixir router 422s on first traffic — silent until then.
+
+    Sources of truth:
+      - Grammar: live `pg_constraint.surface_id_grammar` regex, parsed for
+        the alternation list and reduced to scheme names.
+      - Elixir mentions: `elixir/lease_plane/lib/unitares_lease_plane/canonicalize.ex`.
+        Extracts both the `@canonical_schemes ~w(...)` wordlist and `defp
+        dispatch("<scheme>:..." <> rest)` arms.
+
+    SKIP if psql missing, surface_id_grammar absent (lease plane not
+    installed), or canonicalize.ex absent. PASS if Elixir-mentioned schemes
+    are a subset of grammar schemes. FAIL with the offending scheme(s)
+    otherwise.
+    """
+    name, mode = "elixir_scheme_grammar_lint", "local"
+
+    if shutil.which("psql") is None:
+        return CheckResult(name, mode, Status.SKIP, "psql not on PATH")
+
+    proc = subprocess.run(
+        ["psql", db_url, "-Atqc",
+         "SELECT pg_get_constraintdef(oid) FROM pg_constraint "
+         "WHERE conname = 'surface_id_grammar'"],
+        capture_output=True, text=True, timeout=5,
+    )
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return CheckResult(
+            name, mode, Status.SKIP,
+            "surface_id_grammar constraint not queryable (lease plane not installed?)",
+        )
+
+    constraint_def = proc.stdout.strip()
+    # Extract the alternation body, e.g. `file://|dialectic:/|resident:/|capture:/|td:/`.
+    m = re.search(r"\^\(([^)]+)\)", constraint_def)
+    if not m:
+        return CheckResult(
+            name, mode, Status.SKIP,
+            "could not parse scheme list from surface_id_grammar constraint",
+            detail=constraint_def,
+        )
+    grammar_schemes: set[str] = set()
+    for alt in m.group(1).split("|"):
+        scheme = alt.split(":", 1)[0].strip()
+        if scheme:
+            grammar_schemes.add(scheme)
+
+    canonicalize_path = (
+        repo_root / "elixir" / "lease_plane" / "lib"
+        / "unitares_lease_plane" / "canonicalize.ex"
+    )
+    if not canonicalize_path.is_file():
+        return CheckResult(name, mode, Status.SKIP, "canonicalize.ex not present")
+
+    try:
+        text = canonicalize_path.read_text(errors="replace")
+    except OSError as exc:
+        return CheckResult(name, mode, Status.SKIP,
+                           "canonicalize.ex unreadable", detail=str(exc))
+
+    # scheme -> short site descriptor used in FAIL detail.
+    elixir_mentions: dict[str, str] = {}
+
+    # 1. Wordlist: `@canonical_schemes ~w(file dialectic resident capture td)`.
+    for match in re.finditer(r"@canonical_schemes\s+~w\(([^)]+)\)", text):
+        for scheme in match.group(1).split():
+            if scheme:
+                elixir_mentions.setdefault(scheme, "@canonical_schemes wordlist")
+
+    # 2. Dispatch arms: `defp dispatch("<scheme>:..." <> rest)`. Scheme name is
+    #    everything before the first `:`. Covers `"file://"`, `"dialectic:/"`,
+    #    `"resident:/"`, `"capture:/"`, `"td:/"` consistently.
+    for match in re.finditer(
+        r'defp\s+dispatch\(\s*"([a-z][a-z0-9_-]*):', text
+    ):
+        scheme = match.group(1)
+        elixir_mentions.setdefault(scheme, f'defp dispatch("{scheme}:..." <> rest)')
+
+    drift = sorted(s for s in elixir_mentions if s not in grammar_schemes)
+    if drift:
+        detail_lines = [f"  {s}: {elixir_mentions[s]}" for s in drift]
+        detail_lines.append(
+            f"\nGrammar allows: {', '.join(sorted(grammar_schemes))}"
+        )
+        return CheckResult(
+            name, mode, Status.FAIL,
+            f"{len(drift)} Elixir scheme(s) not in grammar CHECK: "
+            f"{', '.join(drift)}",
+            detail="\n".join(detail_lines),
+        )
+
+    return CheckResult(
+        name, mode, Status.PASS,
+        f"canonicalize.ex schemes match grammar "
+        f"({', '.join(sorted(grammar_schemes))})",
+    )
+
+
 def check_anchor_dir() -> CheckResult:
     name, mode = "anchor_directory", "local"
     if ANCHOR_DIR.is_dir():
@@ -464,6 +570,8 @@ def build_checks(repo_root: Path, db_url: str) -> list[Check]:
         Check("schema_migrations", "local", lambda: check_schema_migrations(db_url, repo_root)),
         Check("elixir_deprecated_scheme_lint", "local",
               lambda: check_elixir_deprecated_scheme_lint(db_url, repo_root)),
+        Check("elixir_scheme_grammar_lint", "local",
+              lambda: check_elixir_scheme_grammar_lint(db_url, repo_root)),
         Check("anchor_directory", "local", check_anchor_dir),
         Check("secrets_file", "local", check_secrets_file),
         Check("http_listening", "operator", check_http_listening),

--- a/tests/test_unitares_doctor_script.py
+++ b/tests/test_unitares_doctor_script.py
@@ -283,3 +283,114 @@ def test_elixir_lint_excludes_deps_and_build_dirs(doctor, monkeypatch, tmp_path)
     assert result.status == doctor.Status.PASS, (
         f"vendored deps/ mentions must not trigger WARN; got {result.status}: {result.message}"
     )
+
+
+# ---------- elixir_scheme_grammar_lint (RFC §7.11.8 inverse — Phase B prep) ----------
+
+
+_GRAMMAR_CHECK_DEF = (
+    "CHECK ((surface_id ~ '^(file://|dialectic:/|resident:/|capture:/|td:/)'::text))"
+)
+
+
+def _write_canonicalize(tmp_path: Path, body: str) -> None:
+    canonicalize = (
+        tmp_path / "elixir" / "lease_plane" / "lib"
+        / "unitares_lease_plane" / "canonicalize.ex"
+    )
+    canonicalize.parent.mkdir(parents=True)
+    canonicalize.write_text(body)
+
+
+def test_grammar_lint_skips_when_psql_missing(doctor, monkeypatch, tmp_path):
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: None)
+    result = doctor.check_elixir_scheme_grammar_lint("postgresql://example", tmp_path)
+    assert result.status == doctor.Status.SKIP
+    assert "psql not on PATH" in result.message
+
+
+def test_grammar_lint_skips_when_constraint_absent(doctor, monkeypatch, tmp_path):
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: "/usr/bin/psql")
+    monkeypatch.setattr(doctor.subprocess, "run",
+                        lambda *a, **kw: _Proc(returncode=0, stdout=""))
+    result = doctor.check_elixir_scheme_grammar_lint("postgresql://example", tmp_path)
+    assert result.status == doctor.Status.SKIP
+    assert "surface_id_grammar" in result.message
+
+
+def test_grammar_lint_skips_when_canonicalize_ex_missing(doctor, monkeypatch, tmp_path):
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: "/usr/bin/psql")
+    monkeypatch.setattr(doctor.subprocess, "run",
+                        lambda *a, **kw: _Proc(returncode=0, stdout=_GRAMMAR_CHECK_DEF))
+    result = doctor.check_elixir_scheme_grammar_lint("postgresql://example", tmp_path)
+    assert result.status == doctor.Status.SKIP
+    assert "canonicalize.ex" in result.message
+
+
+def test_grammar_lint_passes_when_elixir_matches_grammar(doctor, monkeypatch, tmp_path):
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: "/usr/bin/psql")
+    monkeypatch.setattr(doctor.subprocess, "run",
+                        lambda *a, **kw: _Proc(returncode=0, stdout=_GRAMMAR_CHECK_DEF))
+    _write_canonicalize(tmp_path, '''defmodule Canonicalize do
+      @canonical_schemes ~w(file dialectic resident capture td)
+      defp dispatch("file://" <> rest), do: rest
+      defp dispatch("dialectic:/" <> rest), do: rest
+      defp dispatch("resident:/" <> rest), do: rest
+      defp dispatch("capture:/" <> rest), do: rest
+      defp dispatch("td:/" <> rest), do: rest
+    end
+    ''')
+    result = doctor.check_elixir_scheme_grammar_lint("postgresql://example", tmp_path)
+    assert result.status == doctor.Status.PASS, result.message
+    for scheme in ("file", "dialectic", "resident", "capture", "td"):
+        assert scheme in result.message
+
+
+def test_grammar_lint_fails_when_dispatch_arm_not_in_grammar(doctor, monkeypatch, tmp_path):
+    """Inverse drift: Elixir ships a dispatch arm for `foo:/` but the
+    migration-026 CHECK doesn't allow it. Every acquire would 422 in prod."""
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: "/usr/bin/psql")
+    monkeypatch.setattr(doctor.subprocess, "run",
+                        lambda *a, **kw: _Proc(returncode=0, stdout=_GRAMMAR_CHECK_DEF))
+    _write_canonicalize(tmp_path, '''defmodule Canonicalize do
+      @canonical_schemes ~w(file dialectic resident capture td)
+      defp dispatch("file://" <> rest), do: rest
+      defp dispatch("foo:/" <> rest), do: rest
+    end
+    ''')
+    result = doctor.check_elixir_scheme_grammar_lint("postgresql://example", tmp_path)
+    assert result.status == doctor.Status.FAIL
+    assert "foo" in result.message
+    assert "foo" in result.detail
+    assert "Grammar allows" in result.detail
+
+
+def test_grammar_lint_fails_when_wordlist_has_extra_scheme(doctor, monkeypatch, tmp_path):
+    """The `@canonical_schemes ~w(...)` wordlist is itself a scheme declaration
+    surface — adding a scheme there without a matching grammar update is the
+    same drift class as adding a dispatch arm."""
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: "/usr/bin/psql")
+    monkeypatch.setattr(doctor.subprocess, "run",
+                        lambda *a, **kw: _Proc(returncode=0, stdout=_GRAMMAR_CHECK_DEF))
+    _write_canonicalize(tmp_path, '''defmodule Canonicalize do
+      @canonical_schemes ~w(file dialectic resident capture td bar)
+    end
+    ''')
+    result = doctor.check_elixir_scheme_grammar_lint("postgresql://example", tmp_path)
+    assert result.status == doctor.Status.FAIL
+    assert "bar" in result.message
+
+
+def test_grammar_lint_reports_all_drifting_schemes_sorted(doctor, monkeypatch, tmp_path):
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: "/usr/bin/psql")
+    monkeypatch.setattr(doctor.subprocess, "run",
+                        lambda *a, **kw: _Proc(returncode=0, stdout=_GRAMMAR_CHECK_DEF))
+    _write_canonicalize(tmp_path, '''defmodule Canonicalize do
+      defp dispatch("zeta:/" <> rest), do: rest
+      defp dispatch("alpha:/" <> rest), do: rest
+    end
+    ''')
+    result = doctor.check_elixir_scheme_grammar_lint("postgresql://example", tmp_path)
+    assert result.status == doctor.Status.FAIL
+    # Sorted: alpha before zeta.
+    assert result.message.index("alpha") < result.message.index("zeta")


### PR DESCRIPTION
## Summary

Phase B prep — extends `scripts/dev/unitares_doctor.py` with `elixir_scheme_grammar_lint`, the inverse of the existing `elixir_deprecated_scheme_lint` (PR #286).

- **Existing lint** catches schemes deprecated-but-still-mentioned in Elixir.
- **This lint** catches schemes mentioned-by-Elixir-but-not-in-grammar.

If `elixir/lease_plane/lib/unitares_lease_plane/canonicalize.ex` ships a `dispatch("foo:/" <> rest)` arm but the migration-026 `surface_id_grammar` CHECK doesn't allow `foo:/`, every acquire of that scheme fails the storage-layer constraint and the Elixir router 422s on first traffic — silent drift until then.

## Sources of truth

- **Grammar**: live `pg_constraint.surface_id_grammar` regex, parsed for the alternation list.
- **Elixir mentions**: `canonicalize.ex` only — extracts both the `@canonical_schemes ~w(...)` wordlist and `defp dispatch("<scheme>:..." <> rest)` arms. Scoped to one file (per Phase A plan §"Phase B prerequisites") to avoid URL-in-comment false positives.

## Status semantics

| Condition | Status |
|---|---|
| psql missing / constraint absent / canonicalize.ex absent | SKIP |
| Elixir-mentioned schemes are a subset of grammar | PASS |
| Otherwise | FAIL with offending scheme(s) listed |

`FAIL` (not WARN) because this drift is a hard regression — the original lint is WARN because deprecation is graceful, but here the Elixir router is broken in production from first traffic.

## Verified live

```
✓ elixir_scheme_grammar_lint: canonicalize.ex schemes match grammar (capture, dialectic, file, resident, td)
```

## Test plan

- [x] 7 new tests in `tests/test_unitares_doctor_script.py` — SKIP paths, PASS path, FAIL on extra dispatch arm, FAIL on extra wordlist scheme, multi-drift sorted reporting
- [x] `./scripts/dev/test-cache.sh` — 8144 passed
- [x] Live doctor run against current install — new check PASSes

## Notes

- Truly non-blocking; Phase B lands later. This catches the inverse of #286's drift class.
- Pattern follows `elixir_deprecated_scheme_lint` exactly (psql shellout + Path-based source scan + tmp_path-based unit tests with `_Proc` stub).