### PR TITLE
analysis: pin-TTL bleed SQL + report script (PR #203 follow-up)

### DIFF
--- a/scripts/analysis/pin_ttl_bleed_analysis.sql
+++ b/scripts/analysis/pin_ttl_bleed_analysis.sql
@@ -1,0 +1,189 @@
+-- Pin-TTL Masking Hypothesis — audit.events analysis
+--
+-- Investigates whether the 30-minute sliding onboard pin TTL (_PIN_TTL=1800 in
+-- src/mcp_handlers/identity/session.py) silently lets clients fall through to
+-- continuity-token-only resumes between minutes 30-60 of a session.
+--
+-- Context: PR #203 shipped identity_resolution_observed instrumentation. One
+-- event fires per onboard/resume call. The payload JSONB carries:
+--   resolution_source       -- winning path (continuity_token, pinned_onboard_session, …)
+--   pin_match_scope         -- client_model | client | model | unscoped | NULL
+--   pin_entry_present       -- bool: did shadow pin lookup find an entry?
+--   pin_fingerprint_match   -- bool: did that entry point at the resolved identity?
+--   pin_entry_age_seconds   -- int: _PIN_TTL - TTL_remaining (age since last refresh)
+--   token_iat / token_exp / token_age_seconds  -- continuity token metadata when present
+--
+-- Masking signal: continuity_token wins where pin_entry_present=true AND
+-- pin_fingerprint_match=true mean a pin would have resolved the same agent but
+-- token ordering shadowed it. Concentrated in the 0-1500s age band = bleed.
+--
+-- Usage via psql:
+--   psql $GOVERNANCE_DATABASE_URL \
+--     -v start_ts="'2026-04-26 00:00:00+00'" \
+--     -v end_ts="'2026-05-03 23:59:59+00'" \
+--     -f scripts/analysis/pin_ttl_bleed_analysis.sql
+--
+-- Usage via Python runner (preferred):
+--   python3 scripts/analysis/pin_ttl_bleed_report.py [--days 7]
+--
+-- asyncpg placeholder form used by the Python runner: $1 = start_ts, $2 = end_ts
+
+-- =============================================================================
+-- Q1: Total event count
+-- =============================================================================
+SELECT
+    count(*)::int AS total_events,
+    min(ts)       AS window_start,
+    max(ts)       AS window_end
+FROM audit.events
+WHERE event_type = 'identity_resolution_observed'
+  AND ts >= $1::timestamptz
+  AND ts <  $2::timestamptz;
+
+-- =============================================================================
+-- Q2: Resolution source distribution
+-- =============================================================================
+SELECT
+    coalesce(payload->>'resolution_source', '(null)') AS resolution_source,
+    count(*)::int                                       AS n
+FROM audit.events
+WHERE event_type = 'identity_resolution_observed'
+  AND ts >= $1::timestamptz
+  AND ts <  $2::timestamptz
+GROUP BY 1
+ORDER BY 2 DESC;
+
+-- =============================================================================
+-- Q3: Shadow-pin breakdown by resolution_source (all non-pin-path winners)
+-- =============================================================================
+SELECT
+    coalesce(payload->>'resolution_source', '(null)')  AS resolution_source,
+    count(*)::int                                        AS n,
+    -- shadow ran and found an entry
+    count(*) FILTER (
+        WHERE (payload->>'pin_entry_present')::boolean IS TRUE
+    )::int AS pin_present,
+    -- pin entry present AND fingerprint matched (masking candidate)
+    count(*) FILTER (
+        WHERE (payload->>'pin_entry_present')::boolean IS TRUE
+          AND (payload->>'pin_fingerprint_match')::boolean IS TRUE
+    )::int AS present_and_match,
+    -- pin entry present but fingerprint changed (legitimate divergence)
+    count(*) FILTER (
+        WHERE (payload->>'pin_entry_present')::boolean IS TRUE
+          AND (payload->>'pin_fingerprint_match')::boolean IS FALSE
+    )::int AS present_but_mismatch,
+    -- shadow ran, no entry found (pin expired or never set)
+    count(*) FILTER (
+        WHERE (payload->>'pin_entry_present')::boolean IS FALSE
+    )::int AS pin_absent,
+    -- shadow did not run (NULL field)
+    count(*) FILTER (
+        WHERE payload->>'pin_entry_present' IS NULL
+    )::int AS shadow_not_run
+FROM audit.events
+WHERE event_type = 'identity_resolution_observed'
+  AND ts >= $1::timestamptz
+  AND ts <  $2::timestamptz
+  AND coalesce(payload->>'resolution_source', '') != 'pinned_onboard_session'
+GROUP BY 1
+ORDER BY 2 DESC;
+
+-- =============================================================================
+-- Q4: Pin-age-bucketed match rate — continuity_token wins where shadow ran
+--
+-- Buckets mirror quarter-TTL boundaries (1800s / 4 = 450s each):
+--   0–449s   → pin very fresh (should always win if ordering matched)
+--   450–899s → pin moderately aged
+--   900–1499s→ pin approaching half-life
+--   1500–1800s→ pin in final quarter, expiry imminent
+--
+-- High match rate in 0-1499s band with token winning = bleed evidence.
+-- =============================================================================
+SELECT
+    CASE
+        WHEN (payload->>'pin_entry_age_seconds')::int < 450   THEN '0–449s'
+        WHEN (payload->>'pin_entry_age_seconds')::int < 900   THEN '450–899s'
+        WHEN (payload->>'pin_entry_age_seconds')::int < 1500  THEN '900–1499s'
+        WHEN (payload->>'pin_entry_age_seconds')::int <= 1800 THEN '1500–1800s'
+        ELSE                                                        '>1800s (stale?)'
+    END AS age_bucket,
+    count(*)::int AS n,
+    count(*) FILTER (
+        WHERE (payload->>'pin_fingerprint_match')::boolean IS TRUE
+    )::int AS pin_match,
+    count(*) FILTER (
+        WHERE (payload->>'pin_fingerprint_match')::boolean IS FALSE
+    )::int AS pin_mismatch,
+    round(
+        100.0 * count(*) FILTER (
+            WHERE (payload->>'pin_fingerprint_match')::boolean IS TRUE
+        ) / nullif(count(*), 0),
+        1
+    ) AS match_pct
+FROM audit.events
+WHERE event_type = 'identity_resolution_observed'
+  AND ts >= $1::timestamptz
+  AND ts <  $2::timestamptz
+  AND payload->>'resolution_source' = 'continuity_token'
+  AND (payload->>'pin_entry_present')::boolean IS TRUE
+GROUP BY 1
+ORDER BY
+    CASE
+        WHEN (payload->>'pin_entry_age_seconds')::int < 450   THEN 1
+        WHEN (payload->>'pin_entry_age_seconds')::int < 900   THEN 2
+        WHEN (payload->>'pin_entry_age_seconds')::int < 1500  THEN 3
+        WHEN (payload->>'pin_entry_age_seconds')::int <= 1800 THEN 4
+        ELSE                                                        5
+    END;
+
+-- =============================================================================
+-- Q5: Token-age × pin-state cross-tab (continuity_token wins with token present)
+--
+-- Shows whether token age (time since issue) correlates with pin-entry state.
+-- If bleed is active, sessions with small token_age (fresh token, early in
+-- session) should skew toward pin_present=true + pin_match=true because the
+-- pin is still alive and would have resolved the same agent.
+-- =============================================================================
+SELECT
+    CASE
+        WHEN (payload->>'token_age_seconds')::int <  1800 THEN 'token<30m'
+        WHEN (payload->>'token_age_seconds')::int <  3600 THEN 'token_30-60m'
+        WHEN (payload->>'token_age_seconds')::int <  7200 THEN 'token_1h-2h'
+        WHEN (payload->>'token_age_seconds')::int < 86400 THEN 'token_2h-24h'
+        ELSE                                                    'token>24h'
+    END                                        AS token_age_bucket,
+    coalesce(payload->>'pin_entry_present', 'null')   AS pin_present,
+    coalesce(payload->>'pin_fingerprint_match', 'null') AS pin_match,
+    count(*)::int                              AS n
+FROM audit.events
+WHERE event_type = 'identity_resolution_observed'
+  AND ts >= $1::timestamptz
+  AND ts <  $2::timestamptz
+  AND payload->>'resolution_source' = 'continuity_token'
+  AND payload->>'token_age_seconds' IS NOT NULL
+GROUP BY 1, 2, 3
+ORDER BY 1, 2, 3;
+
+-- =============================================================================
+-- Q6: Raw masking-candidate rows (top 20 by recency)
+--
+-- Rows where continuity_token won despite pin being present and matching.
+-- The strongest direct evidence for the masking hypothesis.
+-- =============================================================================
+SELECT
+    ts,
+    payload->>'agent_id'               AS agent_id,
+    payload->>'resolution_source'       AS resolution_source,
+    payload->>'pin_match_scope'         AS pin_match_scope,
+    (payload->>'pin_entry_age_seconds')::int AS pin_age_s,
+    (payload->>'token_age_seconds')::int     AS token_age_s
+FROM audit.events
+WHERE event_type = 'identity_resolution_observed'
+  AND ts >= $1::timestamptz
+  AND ts <  $2::timestamptz
+  AND payload->>'resolution_source' = 'continuity_token'
+  AND (payload->>'pin_entry_present')::boolean IS TRUE
+  AND (payload->>'pin_fingerprint_match')::boolean IS TRUE
+ORDER BY ts DESC
+LIMIT 20;

--- a/scripts/analysis/pin_ttl_bleed_report.py
+++ b/scripts/analysis/pin_ttl_bleed_report.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Pin-TTL masking hypothesis report — queries audit.events, prints markdown.
+
+Tests whether the 30-minute sliding onboard pin TTL (_PIN_TTL=1800 in
+src/mcp_handlers/identity/session.py) silently lets clients fall through to
+continuity-token-only resumes between minutes 30-60 of a session.
+
+Instrumentation was added in PR #203 (identity_resolution_observed events).
+
+Usage:
+    python3 scripts/analysis/pin_ttl_bleed_report.py
+    python3 scripts/analysis/pin_ttl_bleed_report.py --days 14
+    python3 scripts/analysis/pin_ttl_bleed_report.py --output report.md
+
+Env:
+    GOVERNANCE_DATABASE_URL  (default: postgresql://postgres:postgres@localhost:5432/governance)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+DEFAULT_DB_URL = os.environ.get(
+    "GOVERNANCE_DATABASE_URL",
+    "postgresql://postgres:postgres@localhost:5432/governance",
+)
+
+ANALYSIS_SQL = Path(__file__).with_name("pin_ttl_bleed_analysis.sql")
+
+MASKING_CANDIDATE_THRESHOLD = 10  # min continuity_token wins with present+match to call supported
+MIN_TOTAL_FOR_VERDICT = 50        # below this → inconclusive regardless
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+async def run_queries(db_url: str, start_ts: datetime, end_ts: datetime) -> dict[str, Any]:
+    try:
+        import asyncpg
+    except ImportError:
+        print("error: asyncpg not installed — pip install asyncpg", file=sys.stderr)
+        sys.exit(1)
+
+    conn = await asyncpg.connect(db_url)
+    try:
+        results: dict[str, Any] = {}
+
+        # Q1: total count
+        row = await conn.fetchrow(
+            """
+            SELECT count(*)::int AS total_events, min(ts) AS window_start, max(ts) AS window_end
+            FROM audit.events
+            WHERE event_type = 'identity_resolution_observed'
+              AND ts >= $1::timestamptz AND ts < $2::timestamptz
+            """,
+            start_ts, end_ts,
+        )
+        results["q1"] = dict(row) if row else {"total_events": 0}
+
+        # Q2: source distribution
+        rows = await conn.fetch(
+            """
+            SELECT coalesce(payload->>'resolution_source', '(null)') AS resolution_source,
+                   count(*)::int AS n
+            FROM audit.events
+            WHERE event_type = 'identity_resolution_observed'
+              AND ts >= $1::timestamptz AND ts < $2::timestamptz
+            GROUP BY 1 ORDER BY 2 DESC
+            """,
+            start_ts, end_ts,
+        )
+        results["q2"] = [dict(r) for r in rows]
+
+        # Q3: shadow-pin breakdown by source (non-pin winners)
+        rows = await conn.fetch(
+            """
+            SELECT
+                coalesce(payload->>'resolution_source', '(null)') AS resolution_source,
+                count(*)::int AS n,
+                count(*) FILTER (WHERE (payload->>'pin_entry_present')::boolean IS TRUE)::int AS pin_present,
+                count(*) FILTER (
+                    WHERE (payload->>'pin_entry_present')::boolean IS TRUE
+                      AND (payload->>'pin_fingerprint_match')::boolean IS TRUE)::int AS present_and_match,
+                count(*) FILTER (
+                    WHERE (payload->>'pin_entry_present')::boolean IS TRUE
+                      AND (payload->>'pin_fingerprint_match')::boolean IS FALSE)::int AS present_but_mismatch,
+                count(*) FILTER (WHERE (payload->>'pin_entry_present')::boolean IS FALSE)::int AS pin_absent,
+                count(*) FILTER (WHERE payload->>'pin_entry_present' IS NULL)::int AS shadow_not_run
+            FROM audit.events
+            WHERE event_type = 'identity_resolution_observed'
+              AND ts >= $1::timestamptz AND ts < $2::timestamptz
+              AND coalesce(payload->>'resolution_source', '') != 'pinned_onboard_session'
+            GROUP BY 1 ORDER BY 2 DESC
+            """,
+            start_ts, end_ts,
+        )
+        results["q3"] = [dict(r) for r in rows]
+
+        # Q4: pin-age-bucketed match rate for continuity_token wins where shadow ran
+        rows = await conn.fetch(
+            """
+            SELECT
+                CASE
+                    WHEN (payload->>'pin_entry_age_seconds')::int < 450   THEN '0–449s'
+                    WHEN (payload->>'pin_entry_age_seconds')::int < 900   THEN '450–899s'
+                    WHEN (payload->>'pin_entry_age_seconds')::int < 1500  THEN '900–1499s'
+                    WHEN (payload->>'pin_entry_age_seconds')::int <= 1800 THEN '1500–1800s'
+                    ELSE                                                        '>1800s (stale?)'
+                END AS age_bucket,
+                count(*)::int AS n,
+                count(*) FILTER (WHERE (payload->>'pin_fingerprint_match')::boolean IS TRUE)::int AS pin_match,
+                count(*) FILTER (WHERE (payload->>'pin_fingerprint_match')::boolean IS FALSE)::int AS pin_mismatch,
+                round(
+                    100.0 * count(*) FILTER (WHERE (payload->>'pin_fingerprint_match')::boolean IS TRUE)
+                    / nullif(count(*), 0), 1
+                ) AS match_pct
+            FROM audit.events
+            WHERE event_type = 'identity_resolution_observed'
+              AND ts >= $1::timestamptz AND ts < $2::timestamptz
+              AND payload->>'resolution_source' = 'continuity_token'
+              AND (payload->>'pin_entry_present')::boolean IS TRUE
+            GROUP BY 1
+            ORDER BY
+                CASE
+                    WHEN (payload->>'pin_entry_age_seconds')::int < 450   THEN 1
+                    WHEN (payload->>'pin_entry_age_seconds')::int < 900   THEN 2
+                    WHEN (payload->>'pin_entry_age_seconds')::int < 1500  THEN 3
+                    WHEN (payload->>'pin_entry_age_seconds')::int <= 1800 THEN 4
+                    ELSE 5
+                END
+            """,
+            start_ts, end_ts,
+        )
+        results["q4"] = [dict(r) for r in rows]
+
+        # Q5: token-age × pin-state cross-tab for continuity_token wins
+        rows = await conn.fetch(
+            """
+            SELECT
+                CASE
+                    WHEN (payload->>'token_age_seconds')::int <  1800 THEN 'token<30m'
+                    WHEN (payload->>'token_age_seconds')::int <  3600 THEN 'token_30-60m'
+                    WHEN (payload->>'token_age_seconds')::int <  7200 THEN 'token_1h-2h'
+                    WHEN (payload->>'token_age_seconds')::int < 86400 THEN 'token_2h-24h'
+                    ELSE                                                    'token>24h'
+                END AS token_age_bucket,
+                coalesce(payload->>'pin_entry_present', 'null')    AS pin_present,
+                coalesce(payload->>'pin_fingerprint_match', 'null') AS pin_match,
+                count(*)::int AS n
+            FROM audit.events
+            WHERE event_type = 'identity_resolution_observed'
+              AND ts >= $1::timestamptz AND ts < $2::timestamptz
+              AND payload->>'resolution_source' = 'continuity_token'
+              AND payload->>'token_age_seconds' IS NOT NULL
+            GROUP BY 1, 2, 3 ORDER BY 1, 2, 3
+            """,
+            start_ts, end_ts,
+        )
+        results["q5"] = [dict(r) for r in rows]
+
+        return results
+    finally:
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Report formatting
+# ---------------------------------------------------------------------------
+
+def _pct(n: int, total: int) -> str:
+    if total == 0:
+        return "—"
+    return f"{100 * n / total:.1f}%"
+
+
+def build_report(results: dict[str, Any], start_ts: datetime, end_ts: datetime, days: int) -> str:
+    now_str = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    q1 = results["q1"]
+    total = q1.get("total_events", 0)
+
+    lines: list[str] = []
+    a = lines.append
+
+    a("# Pin-TTL Masking Hypothesis — Audit Report")
+    a("")
+    a(f"**Window:** {start_ts.strftime('%Y-%m-%d %H:%M UTC')} → {end_ts.strftime('%Y-%m-%d %H:%M UTC')}  ")
+    a(f"**Generated:** {now_str}  ")
+    a(f"**Instrumentation:** PR #203 `identity_resolution_observed` events  ")
+    a(f"**Hypothesis:** 30-min sliding pin TTL masks continuity-token resumes in minutes 30–60 of a session")
+    a("")
+    a("---")
+    a("")
+
+    # ── Section 1: Total ─────────────────────────────────────────────────────
+    a("## 1. Total Events")
+    a("")
+    a("| Metric | Value |")
+    a("|--------|-------|")
+    a(f"| `identity_resolution_observed` events in window | **{total}** |")
+    if total == 0:
+        a(f"| Window start (actual) | — |")
+        a(f"| Window end (actual) | — |")
+    else:
+        ws = q1.get("window_start")
+        we = q1.get("window_end")
+        a(f"| Window start (actual) | {ws} |")
+        a(f"| Window end (actual) | {we} |")
+    a("")
+    if total < MIN_TOTAL_FOR_VERDICT:
+        a(f"> **Sample too small** — only {total} events (threshold: {MIN_TOTAL_FOR_VERDICT}).")
+        a("> Verdict below is inconclusive regardless of observed ratios.")
+    a("")
+    a("---")
+    a("")
+
+    # ── Section 2: Source distribution ───────────────────────────────────────
+    a("## 2. Resolution Source Distribution")
+    a("")
+    a("| resolution_source | n | % of total |")
+    a("|---|---|---|")
+    for r in results["q2"]:
+        a(f"| `{r['resolution_source']}` | {r['n']} | {_pct(r['n'], total)} |")
+    a("")
+    a("---")
+    a("")
+
+    # ── Section 3: Shadow-pin breakdown ──────────────────────────────────────
+    a("## 3. Shadow-Pin Observation (non-`pinned_onboard_session` wins)")
+    a("")
+    a("Masking candidates are rows where `pin_entry_present=true` **and** `pin_fingerprint_match=true` — "
+      "the pin would have resolved the same agent but token ordering shadowed it.")
+    a("")
+    a("| source | n | pin_present | present+match | present+mismatch | pin_absent | shadow_not_run |")
+    a("|---|---|---|---|---|---|---|")
+    for r in results["q3"]:
+        n = r["n"]
+        a(f"| `{r['resolution_source']}` | {n} "
+          f"| {r['pin_present']} ({_pct(r['pin_present'], n)}) "
+          f"| **{r['present_and_match']}** ({_pct(r['present_and_match'], n)}) "
+          f"| {r['present_but_mismatch']} ({_pct(r['present_but_mismatch'], n)}) "
+          f"| {r['pin_absent']} ({_pct(r['pin_absent'], n)}) "
+          f"| {r['shadow_not_run']} ({_pct(r['shadow_not_run'], n)}) |")
+    a("")
+    a("---")
+    a("")
+
+    # ── Section 4: Pin-age-bucketed match rate ────────────────────────────────
+    a("## 4. Pin-Age-Bucketed Match Rate (continuity_token wins, shadow ran)")
+    a("")
+    a("Buckets span quarter-TTL intervals (TTL=1800s, bucket width=450s). "
+      "A high match rate in the 0–1499s band — where the pin is still viable — is the bleed signal.")
+    a("")
+    if results["q4"]:
+        a("| age_bucket | n | pin_match | pin_mismatch | match_rate |")
+        a("|---|---|---|---|---|")
+        for r in results["q4"]:
+            a(f"| {r['age_bucket']} | {r['n']} | {r['pin_match']} | {r['pin_mismatch']} | {r['match_pct']}% |")
+    else:
+        a("_No continuity_token wins with shadow pin data found in this window._")
+    a("")
+    a("---")
+    a("")
+
+    # ── Section 5: Token-age × pin-state cross-tab ───────────────────────────
+    a("## 5. Token-Age × Pin-State Cross-Tab (continuity_token wins)")
+    a("")
+    a("If bleed is active, sessions with a fresh token (token<30m) should skew toward "
+      "`pin_present=true, pin_match=true` because the pin is still alive and would resolve the same agent.")
+    a("")
+    if results["q5"]:
+        a("| token_age_bucket | pin_present | pin_match | n |")
+        a("|---|---|---|---|")
+        for r in results["q5"]:
+            a(f"| {r['token_age_bucket']} | {r['pin_present']} | {r['pin_match']} | {r['n']} |")
+    else:
+        a("_No continuity_token wins with token_age data found in this window._")
+    a("")
+    a("---")
+    a("")
+
+    # ── Verdict ───────────────────────────────────────────────────────────────
+    a("## Verdict")
+    a("")
+
+    # Compute masking candidate count from Q3
+    masking_candidates = 0
+    ct_rows = [r for r in results["q3"] if r["resolution_source"] == "continuity_token"]
+    ct_present_and_match = ct_rows[0]["present_and_match"] if ct_rows else 0
+    ct_n = ct_rows[0]["n"] if ct_rows else 0
+
+    if total < MIN_TOTAL_FOR_VERDICT:
+        verdict = "INCONCLUSIVE — sample too small"
+        verdict_detail = (
+            f"Only {total} `identity_resolution_observed` events in the 7-day window "
+            f"(threshold for a non-inconclusive verdict: ≥{MIN_TOTAL_FOR_VERDICT}). "
+            "Cannot distinguish masking from noise at this sample size."
+        )
+    elif ct_present_and_match >= MASKING_CANDIDATE_THRESHOLD:
+        verdict = "SUPPORTED"
+        verdict_detail = (
+            f"{ct_present_and_match} of {ct_n} continuity_token wins had "
+            f"`pin_entry_present=true` AND `pin_fingerprint_match=true` "
+            f"({_pct(ct_present_and_match, ct_n)} of token wins, "
+            f"threshold: ≥{MASKING_CANDIDATE_THRESHOLD}). "
+            "The pin would have resolved the same agent in these cases, confirming that "
+            "resolution ordering — not pin expiry — is causing the fall-through."
+        )
+    elif ct_n > 0 and ct_present_and_match == 0:
+        # Check if pin_absent dominates (clean expiry explanation)
+        ct_absent = ct_rows[0]["pin_absent"] if ct_rows else 0
+        if ct_absent > ct_n * 0.7:
+            verdict = "NOT SUPPORTED (pin expiry explains the data)"
+            verdict_detail = (
+                f"Of {ct_n} continuity_token wins, {ct_absent} ({_pct(ct_absent, ct_n)}) "
+                "had `pin_entry_present=false` — the pin had already expired before the token won. "
+                "Zero masking candidates observed. Resolution ordering is not the proximate cause."
+            )
+        else:
+            verdict = "NOT SUPPORTED"
+            verdict_detail = (
+                f"Zero masking candidates (pin_present+match) among {ct_n} continuity_token wins "
+                f"(threshold: ≥{MASKING_CANDIDATE_THRESHOLD}). "
+                "The data does not support the masking hypothesis."
+            )
+    else:
+        verdict = "INCONCLUSIVE — insufficient continuity_token data"
+        verdict_detail = (
+            f"Only {ct_n} continuity_token wins observed in the window. "
+            f"Masking candidates: {ct_present_and_match}. "
+            f"Need ≥{MASKING_CANDIDATE_THRESHOLD} candidates or a clear zero to call the verdict."
+        )
+
+    a(f"**{verdict}**")
+    a("")
+    a(verdict_detail)
+    a("")
+    a(f"Thresholds: ≥{MASKING_CANDIDATE_THRESHOLD} `present+match` candidates among token wins = "
+      f"hypothesis supported; ≥{MIN_TOTAL_FOR_VERDICT} total events = non-inconclusive window.")
+    a("")
+    a("### Interpretation Key")
+    a("")
+    a("| Observation | Meaning |")
+    a("|---|---|")
+    a("| `pin_entry_present=false` on token wins | Pin expired before resolution — clean explanation, no masking |")
+    a("| `pin_entry_present=true, pin_match=false` on token wins | Fingerprint changed (IP/UA shift) — pin pointed stale identity |")
+    a("| `pin_entry_present=true, pin_match=true` on token wins | **Masking** — pin viable but token won due to ordering |")
+    a("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--days", type=int, default=7, help="Lookback window in days (default: 7)")
+    p.add_argument("--db", default=DEFAULT_DB_URL, help="PostgreSQL connection URL")
+    p.add_argument(
+        "--output",
+        help="Write report to this file (default: print to stdout). "
+             "Suffix .md recommended.",
+    )
+    p.add_argument(
+        "--json",
+        dest="json_output",
+        help="Also dump raw query results as JSON to this file.",
+    )
+    return p.parse_args()
+
+
+async def main() -> None:
+    args = parse_args()
+
+    end_ts = datetime.now(timezone.utc)
+    start_ts = end_ts - timedelta(days=args.days)
+
+    print(f"Connecting to {args.db} …", file=sys.stderr)
+    print(f"Window: {start_ts.isoformat()} → {end_ts.isoformat()}", file=sys.stderr)
+
+    results = await run_queries(args.db, start_ts, end_ts)
+
+    if args.json_output:
+        Path(args.json_output).write_text(json.dumps(results, default=str, indent=2))
+        print(f"Raw results written to {args.json_output}", file=sys.stderr)
+
+    report = build_report(results, start_ts, end_ts, args.days)
+
+    if args.output:
+        Path(args.output).write_text(report, encoding="utf-8")
+        print(f"Report written to {args.output}", file=sys.stderr)
+    else:
+        print(report)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

Follow-up to PR #203 (identity_resolution_observed instrumentation). Adds read-only analysis scripts to evaluate the **pin-TTL masking hypothesis**: whether the 30-minute sliding `_PIN_TTL=1800` in `src/mcp_handlers/identity/session.py` silently lets clients fall through to continuity-token-only resumes between minutes 30–60 of a session.

Triggered by a one-shot audit-agent run on 2026-05-03 that confirmed the UNITARES MCP does not expose a direct `audit_log` query path, so the analysis requires a local Postgres connection.

## Artifacts

- **`scripts/analysis/pin_ttl_bleed_analysis.sql`** — six parametrized queries against `audit.events` filtered to `identity_resolution_observed` events:
  1. Total event count + window bounds
  2. Source distribution by `resolution_source`
  3. Shadow-pin breakdown (pin_present / present+match / present+mismatch / absent / shadow_not_run) per source
  4. Pin-age-bucketed match rate for `continuity_token` wins where shadow ran (quarter-TTL buckets: 0–449s / 450–899s / 900–1499s / 1500–1800s)
  5. Token-age × pin-state cross-tab for `continuity_token` wins
  6. Raw masking-candidate rows (top 20 most recent)

- **`scripts/analysis/pin_ttl_bleed_report.py`** — asyncpg runner that executes those queries and emits a structured markdown report with a verdict. Verdict thresholds: ≥10 `present+match` candidates = hypothesis supported; <50 total events = inconclusive.

## Usage

```bash
# Default: 7-day lookback, print to stdout
python3 scripts/analysis/pin_ttl_bleed_report.py

# Write to file, also dump raw JSON
python3 scripts/analysis/pin_ttl_bleed_report.py --days 7 --output report.md --json raw.json

# Custom DB URL
GOVERNANCE_DATABASE_URL=postgresql://... python3 scripts/analysis/pin_ttl_bleed_report.py
```

Attach the `report.md` output to PR #203 as a comment.

## Test plan

- [ ] Run `python3 scripts/analysis/pin_ttl_bleed_report.py` against the production Postgres instance (requires `pg_isready` returning OK on port 5432)
- [ ] Verify report covers all six sections and emits a verdict
- [ ] Paste output as comment on PR #203
- [ ] If verdict is SUPPORTED: open a follow-up issue to evaluate pin-check ordering (check pin before continuity_token in resolution path)
- [ ] If verdict is INCONCLUSIVE (N < 50): wait for more instrumentation data and re-run in 7 days

https://claude.ai/code/session_014Lp32GfsppzzMaKxFC678a

---
_Generated by [Claude Code](https://claude.ai/code/session_014Lp32GfsppzzMaKxFC678a)_