### PR TITLE
feat(r1): PR 3 score-side completion — calibration_state + class_tag + verdict degradation + provisional helpers (R1 v3.3 §C,D,G)

### DIFF
--- a/db/postgres/migrations/032_r1_calibration_state.sql
+++ b/db/postgres/migrations/032_r1_calibration_state.sql
@@ -1,0 +1,43 @@
+-- Migration 032: R1 calibration_state singleton
+--
+-- Per docs/ontology/r1-verify-lineage-claim.md §v3.3-C: every score record
+-- snapshots calibration_status at write time. This singleton holds the
+-- *current* status + lifecycle timestamps, read on each scoring call and
+-- written by explicit operator transitions.
+--
+-- Three states (CHECK constraint mirrors audit.r1_score_audit):
+--   seeded — synthetic-fixture-calibrated thresholds (default at first ship)
+--   earned — operator ran calibration analysis; cuts validated
+--   calibration_failed — distributions did not separate; verdict suppressed
+--
+-- Singleton enforced via PRIMARY KEY (id) + CHECK (id = 1) so any INSERT
+-- attempt with id != 1 fails, and the existing row is the only one consumers
+-- ever read.
+
+CREATE TABLE IF NOT EXISTS core.r1_calibration_state (
+    id                  INTEGER     PRIMARY KEY DEFAULT 1
+                        CHECK (id = 1),
+    calibration_status  TEXT        NOT NULL DEFAULT 'seeded'
+                        CHECK (calibration_status IN ('seeded', 'earned', 'calibration_failed')),
+    seeded_since        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    earned_at           TIMESTAMPTZ NULL,
+    failed_at           TIMESTAMPTZ NULL,
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE  core.r1_calibration_state IS 'R1 v3.3-C: singleton holding the current calibration lifecycle status; consumers under calibration_failed degrade verdict to inconclusive';
+COMMENT ON COLUMN core.r1_calibration_state.calibration_status IS 'R1 v3.3-C: current state — seeded (default at ship), earned (cuts validated), calibration_failed (distributions did not separate)';
+COMMENT ON COLUMN core.r1_calibration_state.seeded_since      IS 'R1 v3.3-C: stamped at first ship of the primitive; surfaced by operator runbook for stale-seeded visibility';
+COMMENT ON COLUMN core.r1_calibration_state.earned_at         IS 'R1 v3.3-C: stamped on seeded → earned transition';
+COMMENT ON COLUMN core.r1_calibration_state.failed_at         IS 'R1 v3.3-C: stamped on seeded → calibration_failed or earned → calibration_failed transition';
+
+-- Seed the singleton row. ON CONFLICT DO NOTHING so re-running the migration
+-- on an existing DB doesn't reset timestamps.
+INSERT INTO core.r1_calibration_state (id, calibration_status)
+VALUES (1, 'seeded')
+ON CONFLICT (id) DO NOTHING;
+
+-- Register migration
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (32, 'r1_calibration_state', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/db/postgres/migrations/033_r1_score_audit_verdict_cols.sql
+++ b/db/postgres/migrations/033_r1_score_audit_verdict_cols.sql
@@ -1,0 +1,34 @@
+-- Migration 033: Add raw_verdict + verdict columns to audit.r1_score_audit
+--
+-- PR 3 council (architect) found that audit.r1_score_audit (created in
+-- migration 031) has neither `verdict` nor `raw_verdict` — yet R1 v3.3-A
+-- audit-only persistence and §"Consumer behavior under calibration_failed"
+-- jointly require both: the score record must "retain the original verdict
+-- for forensic access" while the consumer-facing primitive returns the
+-- degraded one (per v3.3-C).
+--
+-- Without these columns:
+--   - reconstructing the verdict from `plausibility + parent_mature +
+--     n_dims_used` is lossy when threshold cuts move (which they will, per
+--     shadow-mode calibration);
+--   - `calibration_failed` degradation is only legible from the `reasons`
+--     text array, not as a structured anchor.
+--
+-- Both columns NULLable for backwards compatibility with the small number of
+-- audit rows that landed before this migration (the live-verifier's PR 2 +
+-- PR 3 test rows were all cleaned up; this is purely defensive). Production
+-- writes from `score_trajectory_continuity` always populate both.
+
+ALTER TABLE audit.r1_score_audit
+    ADD COLUMN IF NOT EXISTS raw_verdict TEXT NULL
+        CHECK (raw_verdict IS NULL OR raw_verdict IN ('plausible', 'inconclusive', 'unsupported')),
+    ADD COLUMN IF NOT EXISTS verdict     TEXT NULL
+        CHECK (verdict IS NULL OR verdict IN ('plausible', 'inconclusive', 'unsupported'));
+
+COMMENT ON COLUMN audit.r1_score_audit.raw_verdict IS 'R1 v3.3-A/v3.3-C: pre-degradation verdict from threshold cuts; preserved for forensic access when calibration_failed degrades the consumer-facing verdict to inconclusive';
+COMMENT ON COLUMN audit.r1_score_audit.verdict     IS 'R1 v3.3-A: consumer-facing verdict (potentially degraded under calibration_failed per v3.3-C)';
+
+-- Register migration
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (33, 'r1_score_audit_verdict_cols', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/src/db/mixins/audit.py
+++ b/src/db/mixins/audit.py
@@ -38,9 +38,10 @@ class AuditMixin:
                     INSERT INTO audit.r1_score_audit (
                         score_id, parent_id, successor_id, recorded_at,
                         plausibility, components, observations,
-                        parent_mature, reasons, class_tag, calibration_status
+                        parent_mature, reasons, class_tag, calibration_status,
+                        verdict, raw_verdict
                     )
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
                     """,
                     record["score_id"],
                     record["parent_id"],
@@ -53,6 +54,8 @@ class AuditMixin:
                     list(record["reasons"]),
                     record.get("class_tag"),
                     record["calibration_status"],
+                    record.get("verdict"),
+                    record.get("raw_verdict"),
                 )
                 return True
             except Exception as e:

--- a/src/db/mixins/identity.py
+++ b/src/db/mixins/identity.py
@@ -244,6 +244,142 @@ class IdentityMixin:
             )
             return bool(result)
 
+    # ------------------------------------------------------------------
+    # R1 v3.3-D: provisional-lineage helpers + v3.3-C calibration_state
+    # ------------------------------------------------------------------
+
+    async def mark_lineage_provisional(
+        self,
+        successor_id: str,
+        score_id: str,
+    ) -> bool:
+        """Stamp a successor's lineage as provisional after an inconclusive score.
+
+        Per v3.3-D: callers using `marks` policy (onboard-time scoring) invoke
+        this to record that the lineage edge is unconfirmed. Trust-tier (S6),
+        R3 baselines, KG provenance, and R2 (PR 4) read this flag and
+        exclude provisional rows from their respective aggregations.
+
+        score_id references the most recent audit.r1_score_audit row that
+        justified this state. provisional_recorded_at stamps now.
+        """
+        async with self.acquire() as conn:
+            result = await conn.execute(
+                """
+                UPDATE core.identities
+                SET provisional_lineage = TRUE,
+                    provisional_score_id = $1,
+                    provisional_recorded_at = now(),
+                    confirmed_at = NULL,
+                    updated_at = now()
+                WHERE agent_id = $2
+                """,
+                score_id, successor_id,
+            )
+            try:
+                rows = int((result or "UPDATE 0").split()[-1])
+            except Exception:
+                rows = 0
+            return rows > 0
+
+    async def confirm_lineage(self, successor_id: str) -> bool:
+        """Promote provisional → confirmed.
+
+        Called by the promotion policy site (per v3.1 §"Caller policy" —
+        promotion uses `blocks`; the promotion gate only fires on a re-score
+        returning `plausible`). Stamps confirmed_at, clears the provisional
+        flag and score_id reference.
+        """
+        async with self.acquire() as conn:
+            result = await conn.execute(
+                """
+                UPDATE core.identities
+                SET provisional_lineage = FALSE,
+                    provisional_score_id = NULL,
+                    confirmed_at = now(),
+                    updated_at = now()
+                WHERE agent_id = $1
+                """,
+                successor_id,
+            )
+            try:
+                rows = int((result or "UPDATE 0").split()[-1])
+            except Exception:
+                rows = 0
+            return rows > 0
+
+    async def read_r1_calibration_state(self) -> Dict[str, Any]:
+        """Read the R1 calibration_state singleton (v3.3-C).
+
+        Returns the current `calibration_status` and lifecycle timestamps.
+        The score primitive snapshots `calibration_status` onto every audit
+        record at write time; consumers under `calibration_failed` MUST
+        degrade verdict to `inconclusive` (degradation at the consumer
+        layer, but the state read here is what gates it).
+        """
+        async with self.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT id, calibration_status, seeded_since, earned_at,
+                       failed_at, updated_at
+                FROM core.r1_calibration_state
+                WHERE id = 1
+                """
+            )
+            if row is None:
+                # Pre-migration-032 caller fallback. After 032 is in
+                # production this branch is dead; keeping it avoids surprise
+                # crashes if a fresh DB is missing the seeded singleton.
+                from datetime import datetime, timezone
+                now = datetime.now(timezone.utc)
+                return {
+                    "calibration_status": "seeded",
+                    "seeded_since": now,
+                    "earned_at": None,
+                    "failed_at": None,
+                    "updated_at": now,
+                }
+            return dict(row)
+
+    async def transition_r1_calibration_state(self, new_status: str) -> Dict[str, Any]:
+        """Operator-only: transition the R1 calibration_state singleton.
+
+        Per v3.3-C: transitions are explicit operator actions. This method
+        does not validate operator authority — gate that at the call site
+        (e.g. an admin handler with `X-Anima-Admin` header check).
+
+        Stamps the appropriate timestamp:
+        - seeded → earned: stamps earned_at
+        - {seeded, earned} → calibration_failed: stamps failed_at
+        - earned → seeded or any rollback: stamps updated_at only
+
+        Returns the post-transition state.
+        """
+        if new_status not in {"seeded", "earned", "calibration_failed"}:
+            raise ValueError(
+                f"invalid calibration_status: {new_status!r} "
+                f"(must be one of: seeded, earned, calibration_failed)"
+            )
+        async with self.acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE core.r1_calibration_state
+                SET calibration_status = $1,
+                    earned_at = CASE
+                        WHEN $1 = 'earned' AND earned_at IS NULL THEN now()
+                        ELSE earned_at
+                    END,
+                    failed_at = CASE
+                        WHEN $1 = 'calibration_failed' THEN now()
+                        ELSE failed_at
+                    END,
+                    updated_at = now()
+                WHERE id = 1
+                """,
+                new_status,
+            )
+        return await self.read_r1_calibration_state()
+
     def _row_to_identity(self, row) -> IdentityRecord:
         return IdentityRecord(
             identity_id=row["identity_id"],

--- a/src/db/mixins/identity.py
+++ b/src/db/mixins/identity.py
@@ -289,6 +289,15 @@ class IdentityMixin:
         promotion uses `blocks`; the promotion gate only fires on a re-score
         returning `plausible`). Stamps confirmed_at, clears the provisional
         flag and score_id reference.
+
+        `provisional_recorded_at` is INTENTIONALLY preserved as an audit
+        anchor — it records *when the provisional window began*, which
+        survives confirmation. Consumers reading
+        `(provisional_lineage=False AND provisional_recorded_at IS NOT NULL
+        AND confirmed_at IS NOT NULL)` see "this lineage was once
+        provisional, was confirmed at confirmed_at, originally provisional
+        at provisional_recorded_at." Clearing it would erase that audit
+        trail. (PR 3 council code-reviewer flag — the explicit decision.)
         """
         async with self.acquire() as conn:
             result = await conn.execute(
@@ -330,6 +339,16 @@ class IdentityMixin:
                 # Pre-migration-032 caller fallback. After 032 is in
                 # production this branch is dead; keeping it avoids surprise
                 # crashes if a fresh DB is missing the seeded singleton.
+                # Logged at WARNING because in steady state this should not
+                # fire — if it does, an operator should investigate
+                # (singleton row deleted by hand, or migration 032 not
+                # applied).
+                logger.warning(
+                    "[R1] core.r1_calibration_state singleton missing — "
+                    "synthesizing fallback 'seeded' state. Either migration "
+                    "032 has not been applied or the singleton row was "
+                    "removed."
+                )
                 from datetime import datetime, timezone
                 now = datetime.now(timezone.utc)
                 return {
@@ -348,10 +367,25 @@ class IdentityMixin:
         does not validate operator authority — gate that at the call site
         (e.g. an admin handler with `X-Anima-Admin` header check).
 
-        Stamps the appropriate timestamp:
-        - seeded → earned: stamps earned_at
-        - {seeded, earned} → calibration_failed: stamps failed_at
-        - earned → seeded or any rollback: stamps updated_at only
+        Timestamp semantics:
+        - `earned_at` is **idempotent** — stamped only on the first
+          `seeded → earned` transition (`earned_at IS NULL` guard). A later
+          rollback through seeded and back to earned does NOT re-stamp.
+        - `failed_at` is **last-wins** — re-stamped on every transition
+          INTO `calibration_failed`. Recurring calibration loops are
+          expected and the most-recent failure is more useful than the
+          first; this matches the v3.3-C runbook framing of
+          calibration_failed as a recoverable state.
+        - Rollback paths (`earned → seeded`, `calibration_failed →
+          seeded`) update `calibration_status` + `updated_at` only;
+          `earned_at` and `failed_at` are append-only forensic anchors and
+          are never cleared by a rollback. (PR 3 council architect flag —
+          rollback is operator-decided, not in the spec, but defensible.)
+
+        Atomic write+read via `RETURNING *`: a separate read-back would
+        introduce a TOCTOU window where a concurrent operator transition
+        could replace the state between the UPDATE and the SELECT. The
+        returned dict is exactly what was written.
 
         Returns the post-transition state.
         """
@@ -361,7 +395,7 @@ class IdentityMixin:
                 f"(must be one of: seeded, earned, calibration_failed)"
             )
         async with self.acquire() as conn:
-            await conn.execute(
+            row = await conn.fetchrow(
                 """
                 UPDATE core.r1_calibration_state
                 SET calibration_status = $1,
@@ -375,10 +409,15 @@ class IdentityMixin:
                     END,
                     updated_at = now()
                 WHERE id = 1
+                RETURNING id, calibration_status, seeded_since, earned_at,
+                          failed_at, updated_at
                 """,
                 new_status,
             )
-        return await self.read_r1_calibration_state()
+        if row is None:
+            # Singleton missing — defer to the read fallback (which logs).
+            return await self.read_r1_calibration_state()
+        return dict(row)
 
     def _row_to_identity(self, row) -> IdentityRecord:
         return IdentityRecord(

--- a/src/identity/trajectory_continuity.py
+++ b/src/identity/trajectory_continuity.py
@@ -52,6 +52,20 @@ _DEFAULT_MIN_OBSERVATIONS = 5
 _DEFAULT_WINDOW = timedelta(days=30)
 _DIMENSIONS = ("E", "I", "S", "V")
 
+# Class tags recognized for R1's `class_tag` stamping (v3.3-G). Order matters
+# — most-specific first so calibration analyses can partition without
+# ambiguity. Substrate classes (embodied, persistent) are most specific;
+# session_like + engaged_ephemeral are S8a-specialized cohorts; ephemeral is
+# the default Phase-1 stamp. Mirrors src/identity/substrate.py and
+# src/grounding/class_promotion.py inventories.
+_CLASS_TAG_PRIORITY = (
+    "embodied",
+    "persistent",
+    "engaged_ephemeral",
+    "session_like",
+    "ephemeral",
+)
+
 
 # ---------------------------------------------------------------------------
 # Dataclass — full record returned to internal callers (v3.1 §"Input signature")
@@ -139,6 +153,17 @@ async def score_trajectory_continuity(
         agent_id=successor_id, window=window,
     )
 
+    # v3.3-C: snapshot calibration_state at scoring time. Consumers under
+    # `calibration_failed` degrade verdict to inconclusive (handled below
+    # before the dataclass is built so the audit record matches).
+    cal_state = await backend.read_r1_calibration_state()
+    calibration_status: CalibrationStatus = cal_state.get("calibration_status", "seeded")
+
+    # v3.3-G: read parent's class_tag from metadata at scoring time. Stored
+    # on the audit record so calibration analyses partition on the parent
+    # class state *at scoring time*, not at analysis time.
+    class_tag = await _read_parent_class_tag(backend, claimed_parent_id)
+
     parent_obs = {dim: len(parent_series[dim]) for dim in _DIMENSIONS}
     successor_obs = {dim: len(successor_series[dim]) for dim in _DIMENSIONS}
     observations = {"parent": parent_obs, "successor": successor_obs}
@@ -168,13 +193,26 @@ async def score_trajectory_continuity(
     n_dims_used = len(contributing)
     plausibility = (sum(contributing) / n_dims_used) if contributing else 0.0
 
-    verdict = _classify_verdict(
+    raw_verdict = _classify_verdict(
         plausibility=plausibility,
         successor_total=successor_total,
         parent_mature=parent_mature,
         n_dims_used=n_dims_used,
         min_observations=min_observations,
     )
+    # v3.3-C consumer-degradation: under calibration_failed, the verdict is
+    # forced to `inconclusive` regardless of plausibility. Stamping happens
+    # here (before dataclass + audit write) so the audit row matches what
+    # the consumer-facing primitive returns.
+    if calibration_status == "calibration_failed":
+        verdict = "inconclusive"
+        if raw_verdict != "inconclusive":
+            reasons.append(
+                f"verdict degraded from {raw_verdict!r} to 'inconclusive' "
+                f"because calibration_status='calibration_failed' (v3.3-C)"
+            )
+    else:
+        verdict = raw_verdict
     if not parent_mature:
         reasons.append(
             f"parent_mature=False (max parent rows in any dim "
@@ -194,7 +232,7 @@ async def score_trajectory_continuity(
         components=components,
         reasons=reasons,
         parent_mature=parent_mature,
-        calibration_status="seeded",  # v3.3-C: default until operator transitions
+        calibration_status=calibration_status,  # v3.3-C: snapshot at scoring time
         n_dims_used=n_dims_used,
     )
 
@@ -202,11 +240,12 @@ async def score_trajectory_continuity(
     # so the score_id is durably present before any caller publishes the
     # redacted KG payload that references it (v3.3-A join-semantics contract).
     # If the write fails, we MUST refuse to return a score whose audit row is
-    # absent — otherwise PR 3's KG emission could publish a dangling score_id.
+    # absent — otherwise PR 4's KG emission could publish a dangling score_id.
     persisted = await backend.record_r1_score_audit(_to_audit_record(
         score=score,
         parent_id=claimed_parent_id,
         successor_id=successor_id,
+        class_tag=class_tag,
     ))
     if not persisted:
         raise RuntimeError(
@@ -245,10 +284,11 @@ def _to_audit_record(
     score: TrajectoryContinuityScore,
     parent_id: str,
     successor_id: str,
+    class_tag: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Shape the full record for `record_r1_score_audit`. class_tag is left
-    None here; the v3.3-G class-tag stamp will be wired in PR 3 (it requires
-    reading parent's class metadata at scoring time)."""
+    """Shape the full record for `record_r1_score_audit`. class_tag is the
+    parent's class at scoring time (v3.3-G) or None when no recognized class
+    tag is present in the parent's metadata."""
     return {
         "score_id": score.score_id,
         "parent_id": parent_id,
@@ -259,6 +299,34 @@ def _to_audit_record(
         "observations": score.observations,
         "parent_mature": score.parent_mature,
         "reasons": score.reasons,
-        "class_tag": None,
+        "class_tag": class_tag,
         "calibration_status": score.calibration_status,
     }
+
+
+async def _read_parent_class_tag(backend, parent_agent_id: str) -> Optional[str]:
+    """Read the parent's class_tag from `core.identities.metadata.tags` at
+    scoring time (v3.3-G).
+
+    Returns the most-specific recognized class tag per `_CLASS_TAG_PRIORITY`,
+    or None when (a) the parent has no recognized class tag, or (b) the
+    parent identity row doesn't exist yet. Falls back to None on any error
+    so a missing class tag never blocks a score from being recorded.
+    """
+    try:
+        record = await backend.get_identity(parent_agent_id)
+    except Exception:
+        return None
+    if record is None:
+        return None
+    metadata = getattr(record, "metadata", None) or {}
+    if not isinstance(metadata, dict):
+        return None
+    tags = metadata.get("tags")
+    if not isinstance(tags, list):
+        return None
+    tag_set = {t for t in tags if isinstance(t, str)}
+    for candidate in _CLASS_TAG_PRIORITY:
+        if candidate in tag_set:
+            return candidate
+    return None

--- a/src/identity/trajectory_continuity.py
+++ b/src/identity/trajectory_continuity.py
@@ -55,14 +55,26 @@ _DIMENSIONS = ("E", "I", "S", "V")
 # Class tags recognized for R1's `class_tag` stamping (v3.3-G). Order matters
 # — most-specific first so calibration analyses can partition without
 # ambiguity. Substrate classes (embodied, persistent) are most specific;
-# session_like + engaged_ephemeral are S8a-specialized cohorts; ephemeral is
-# the default Phase-1 stamp. Mirrors src/identity/substrate.py and
-# src/grounding/class_promotion.py inventories.
+# engaged_ephemeral is S8a Phase-2's specialized cohort; ephemeral is the
+# Phase-1 default stamp.
+#
+# Stored tags only — `_CLASS_TAG_PRIORITY` mirrors the *atomic* tags written
+# by src/identity/substrate.py SUBSTRATE_CLASS_TAGS, src/grounding/
+# onboard_classifier.py defaults, and src/grounding/class_promotion.py
+# Phase-2 promotion. Derived class labels (e.g. `resident_persistent` =
+# `persistent` + `autonomous`, computed at analysis time) are NOT in this
+# tuple — calibration analyses partitioning by resident cohort must read
+# `class_tag='persistent'` AND join the parent's `metadata->'tags' @> ARRAY['autonomous']`.
+#
+# `session_like` is a *reserved* tag — named in the v3.3-F known-limitation
+# discussion + S8a Phase-2 plan, but no current stamp path emits it. Kept in
+# the priority order so when S8a Phase-2 grows the cohort, the stamp surface
+# is already correct. Until then, this branch is dead code (harmless).
 _CLASS_TAG_PRIORITY = (
     "embodied",
     "persistent",
     "engaged_ephemeral",
-    "session_like",
+    "session_like",  # reserved; no current stamp path — see comment above
     "ephemeral",
 )
 
@@ -203,7 +215,10 @@ async def score_trajectory_continuity(
     # v3.3-C consumer-degradation: under calibration_failed, the verdict is
     # forced to `inconclusive` regardless of plausibility. Stamping happens
     # here (before dataclass + audit write) so the audit row matches what
-    # the consumer-facing primitive returns.
+    # the consumer-facing primitive returns. raw_verdict is preserved on the
+    # audit row separately (migration 033) for forensic access — threshold
+    # drift in shadow-mode calibration would otherwise make verdict
+    # reconstruction lossy.
     if calibration_status == "calibration_failed":
         verdict = "inconclusive"
         if raw_verdict != "inconclusive":
@@ -246,6 +261,7 @@ async def score_trajectory_continuity(
         parent_id=claimed_parent_id,
         successor_id=successor_id,
         class_tag=class_tag,
+        raw_verdict=raw_verdict,
     ))
     if not persisted:
         raise RuntimeError(
@@ -285,10 +301,13 @@ def _to_audit_record(
     parent_id: str,
     successor_id: str,
     class_tag: Optional[str] = None,
+    raw_verdict: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Shape the full record for `record_r1_score_audit`. class_tag is the
     parent's class at scoring time (v3.3-G) or None when no recognized class
-    tag is present in the parent's metadata."""
+    tag is present in the parent's metadata. raw_verdict (migration 033) is
+    the pre-degradation verdict — preserved separately from `verdict` so
+    forensic access has both the original and the consumer-facing values."""
     return {
         "score_id": score.score_id,
         "parent_id": parent_id,
@@ -301,6 +320,8 @@ def _to_audit_record(
         "reasons": score.reasons,
         "class_tag": class_tag,
         "calibration_status": score.calibration_status,
+        "verdict": score.verdict,
+        "raw_verdict": raw_verdict if raw_verdict is not None else score.verdict,
     }
 
 
@@ -315,7 +336,15 @@ async def _read_parent_class_tag(backend, parent_agent_id: str) -> Optional[str]
     """
     try:
         record = await backend.get_identity(parent_agent_id)
-    except Exception:
+    except Exception as exc:
+        # Narrow swallow — class_tag is a forensic anchor, not a correctness
+        # gate. Log so a calibration-blocking pool issue is visible rather
+        # than silently producing class_tag=NULL on every score.
+        import logging
+        logging.getLogger(__name__).debug(
+            "[R1] _read_parent_class_tag get_identity failed for %s: %s (%s)",
+            parent_agent_id, type(exc).__name__, exc,
+        )
         return None
     if record is None:
         return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,6 +122,24 @@ def _isolate_db_backend(monkeypatch):
     mock_backend.reconstruct_eisv_series.return_value = {
         "E": [], "I": [], "S": [], "V": [],
     }
+    # R1 v3.3-D provisional helpers + v3.3-C calibration_state singleton
+    mock_backend.mark_lineage_provisional.return_value = True
+    mock_backend.confirm_lineage.return_value = True
+    mock_backend.read_r1_calibration_state.return_value = {
+        "calibration_status": "seeded",
+        "seeded_since": None,
+        "earned_at": None,
+        "failed_at": None,
+        "updated_at": None,
+    }
+    mock_backend.transition_r1_calibration_state.return_value = {
+        "calibration_status": "seeded",
+        "seeded_since": None,
+        "earned_at": None,
+        "failed_at": None,
+        "updated_at": None,
+    }
+    mock_backend.record_r1_score_audit.return_value = True
     # Audit/tool operations
     mock_backend.append_audit_event.return_value = True
     mock_backend.query_audit_events.return_value = []

--- a/tests/test_r1_identity_helpers.py
+++ b/tests/test_r1_identity_helpers.py
@@ -1,0 +1,294 @@
+"""Tests for R1 v3.3-D + v3.3-C backend helpers on IdentityMixin.
+
+mark_lineage_provisional / confirm_lineage update core.identities provisional
+columns. read_r1_calibration_state / transition_r1_calibration_state operate
+on the calibration_state singleton from migration 032.
+
+Live SQL behavior is covered by the live-verifier council pass at PR 3 ship;
+these tests pin contract + signature + branch coverage with mocked acquire().
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def test_mark_lineage_provisional_exists_on_identity_mixin():
+    from src.db.mixins.identity import IdentityMixin
+    assert hasattr(IdentityMixin, "mark_lineage_provisional")
+    assert hasattr(IdentityMixin, "confirm_lineage")
+    assert hasattr(IdentityMixin, "read_r1_calibration_state")
+    assert hasattr(IdentityMixin, "transition_r1_calibration_state")
+
+
+# ---------------------------------------------------------------------------
+# mark_lineage_provisional / confirm_lineage
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_mark_lineage_provisional_returns_true_on_update():
+    """UPDATE that affects 1 row → returns True."""
+    from src.db.mixins.identity import IdentityMixin
+
+    captured: list = []
+
+    class _Stub(IdentityMixin):
+        def acquire(self):
+            return _AcquireCtx(captured)
+
+    class _AcquireCtx:
+        def __init__(self, sink):
+            self._sink = sink
+
+        async def __aenter__(self):
+            conn = AsyncMock()
+
+            async def _execute(sql, *args):
+                self._sink.append((sql, args))
+                return "UPDATE 1"
+
+            conn.execute = _execute
+            return conn
+
+        async def __aexit__(self, *args):
+            return None
+
+    backend = _Stub()
+    ok = await backend.mark_lineage_provisional(
+        successor_id="successor-uuid",
+        score_id="score-uuid",
+    )
+
+    assert ok is True
+    assert len(captured) == 1
+    sql, args = captured[0]
+    assert "provisional_lineage = TRUE" in sql
+    assert "confirmed_at = NULL" in sql
+    assert args == ("score-uuid", "successor-uuid")
+
+
+@pytest.mark.asyncio
+async def test_mark_lineage_provisional_returns_false_when_no_match():
+    """UPDATE that affects 0 rows → returns False."""
+    from src.db.mixins.identity import IdentityMixin
+
+    class _Stub(IdentityMixin):
+        def acquire(self):
+            return _AcquireCtx()
+
+    class _AcquireCtx:
+        async def __aenter__(self):
+            conn = AsyncMock()
+            conn.execute = AsyncMock(return_value="UPDATE 0")
+            return conn
+
+        async def __aexit__(self, *args):
+            return None
+
+    backend = _Stub()
+    ok = await backend.mark_lineage_provisional(
+        successor_id="missing-uuid",
+        score_id="score-uuid",
+    )
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_confirm_lineage_clears_provisional_state():
+    from src.db.mixins.identity import IdentityMixin
+
+    captured: list = []
+
+    class _Stub(IdentityMixin):
+        def acquire(self):
+            return _AcquireCtx(captured)
+
+    class _AcquireCtx:
+        def __init__(self, sink):
+            self._sink = sink
+
+        async def __aenter__(self):
+            conn = AsyncMock()
+
+            async def _execute(sql, *args):
+                self._sink.append((sql, args))
+                return "UPDATE 1"
+
+            conn.execute = _execute
+            return conn
+
+        async def __aexit__(self, *args):
+            return None
+
+    backend = _Stub()
+    ok = await backend.confirm_lineage(successor_id="successor-uuid")
+
+    assert ok is True
+    sql, args = captured[0]
+    assert "provisional_lineage = FALSE" in sql
+    assert "provisional_score_id = NULL" in sql
+    assert "confirmed_at = now()" in sql
+    assert args == ("successor-uuid",)
+
+
+# ---------------------------------------------------------------------------
+# calibration_state singleton
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_read_r1_calibration_state_returns_singleton_row():
+    from src.db.mixins.identity import IdentityMixin
+    from datetime import datetime, timezone
+
+    expected_seeded_since = datetime(2026, 5, 3, 0, 0, tzinfo=timezone.utc)
+
+    class _Stub(IdentityMixin):
+        def acquire(self):
+            return _AcquireCtx()
+
+    class _AcquireCtx:
+        async def __aenter__(self):
+            conn = AsyncMock()
+            conn.fetchrow = AsyncMock(return_value={
+                "id": 1,
+                "calibration_status": "seeded",
+                "seeded_since": expected_seeded_since,
+                "earned_at": None,
+                "failed_at": None,
+                "updated_at": expected_seeded_since,
+            })
+            return conn
+
+        async def __aexit__(self, *args):
+            return None
+
+    backend = _Stub()
+    state = await backend.read_r1_calibration_state()
+
+    assert state["calibration_status"] == "seeded"
+    assert state["seeded_since"] == expected_seeded_since
+    assert state["earned_at"] is None
+    assert state["failed_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_read_r1_calibration_state_falls_back_when_singleton_missing():
+    """Pre-migration-032 fallback: returns a synthesized seeded state when
+    fetchrow returns None. Surface contract preserved so callers don't need
+    a separate check."""
+    from src.db.mixins.identity import IdentityMixin
+
+    class _Stub(IdentityMixin):
+        def acquire(self):
+            return _AcquireCtx()
+
+    class _AcquireCtx:
+        async def __aenter__(self):
+            conn = AsyncMock()
+            conn.fetchrow = AsyncMock(return_value=None)
+            return conn
+
+        async def __aexit__(self, *args):
+            return None
+
+    backend = _Stub()
+    state = await backend.read_r1_calibration_state()
+
+    assert state["calibration_status"] == "seeded"
+    assert state["earned_at"] is None
+    assert state["failed_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_transition_r1_calibration_state_rejects_invalid_status():
+    from src.db.mixins.identity import IdentityMixin
+
+    class _Stub(IdentityMixin):
+        def acquire(self):
+            raise AssertionError("acquire should not be called for invalid input")
+
+    backend = _Stub()
+    with pytest.raises(ValueError, match="invalid calibration_status"):
+        await backend.transition_r1_calibration_state("unknown")
+
+
+@pytest.mark.asyncio
+async def test_transition_r1_calibration_state_to_earned_writes_and_reads_back():
+    from src.db.mixins.identity import IdentityMixin
+
+    captured_executes: list = []
+
+    class _Stub(IdentityMixin):
+        def acquire(self):
+            return _AcquireCtx(captured_executes)
+
+    class _AcquireCtx:
+        def __init__(self, sink):
+            self._sink = sink
+
+        async def __aenter__(self):
+            conn = AsyncMock()
+
+            async def _execute(sql, *args):
+                self._sink.append((sql, args))
+                return "UPDATE 1"
+
+            conn.execute = _execute
+            conn.fetchrow = AsyncMock(return_value={
+                "id": 1,
+                "calibration_status": "earned",
+                "seeded_since": None,
+                "earned_at": "now-stamp",
+                "failed_at": None,
+                "updated_at": "now-stamp",
+            })
+            return conn
+
+        async def __aexit__(self, *args):
+            return None
+
+    backend = _Stub()
+    state = await backend.transition_r1_calibration_state("earned")
+
+    # Wrote the new status
+    assert len(captured_executes) == 1
+    sql, args = captured_executes[0]
+    assert "UPDATE core.r1_calibration_state" in sql
+    assert "calibration_status = $1" in sql
+    assert args == ("earned",)
+    # Read back the post-transition state
+    assert state["calibration_status"] == "earned"
+    assert state["earned_at"] == "now-stamp"
+
+
+@pytest.mark.asyncio
+async def test_transition_r1_calibration_state_accepts_calibration_failed():
+    from src.db.mixins.identity import IdentityMixin
+
+    class _Stub(IdentityMixin):
+        def acquire(self):
+            return _AcquireCtx()
+
+    class _AcquireCtx:
+        async def __aenter__(self):
+            conn = AsyncMock()
+            conn.execute = AsyncMock(return_value="UPDATE 1")
+            conn.fetchrow = AsyncMock(return_value={
+                "id": 1,
+                "calibration_status": "calibration_failed",
+                "seeded_since": None,
+                "earned_at": None,
+                "failed_at": "now-stamp",
+                "updated_at": "now-stamp",
+            })
+            return conn
+
+        async def __aexit__(self, *args):
+            return None
+
+    backend = _Stub()
+    state = await backend.transition_r1_calibration_state("calibration_failed")
+    assert state["calibration_status"] == "calibration_failed"
+    assert state["failed_at"] == "now-stamp"

--- a/tests/test_r1_identity_helpers.py
+++ b/tests/test_r1_identity_helpers.py
@@ -215,14 +215,19 @@ async def test_transition_r1_calibration_state_rejects_invalid_status():
 
 
 @pytest.mark.asyncio
-async def test_transition_r1_calibration_state_to_earned_writes_and_reads_back():
+async def test_transition_r1_calibration_state_to_earned_atomic_via_returning():
+    """Atomic write+read via UPDATE...RETURNING * (no separate read-back —
+    closes the TOCTOU window where a concurrent operator transition could
+    replace the state between UPDATE and SELECT). Datetime fields are
+    represented as strings in this mock-level pin; live datetime semantics
+    are exercised by the live-verifier council pass."""
     from src.db.mixins.identity import IdentityMixin
 
-    captured_executes: list = []
+    captured: list = []
 
     class _Stub(IdentityMixin):
         def acquire(self):
-            return _AcquireCtx(captured_executes)
+            return _AcquireCtx(captured)
 
     class _AcquireCtx:
         def __init__(self, sink):
@@ -231,19 +236,18 @@ async def test_transition_r1_calibration_state_to_earned_writes_and_reads_back()
         async def __aenter__(self):
             conn = AsyncMock()
 
-            async def _execute(sql, *args):
+            async def _fetchrow(sql, *args):
                 self._sink.append((sql, args))
-                return "UPDATE 1"
+                return {
+                    "id": 1,
+                    "calibration_status": "earned",
+                    "seeded_since": None,
+                    "earned_at": "now-stamp",
+                    "failed_at": None,
+                    "updated_at": "now-stamp",
+                }
 
-            conn.execute = _execute
-            conn.fetchrow = AsyncMock(return_value={
-                "id": 1,
-                "calibration_status": "earned",
-                "seeded_since": None,
-                "earned_at": "now-stamp",
-                "failed_at": None,
-                "updated_at": "now-stamp",
-            })
+            conn.fetchrow = _fetchrow
             return conn
 
         async def __aexit__(self, *args):
@@ -252,13 +256,11 @@ async def test_transition_r1_calibration_state_to_earned_writes_and_reads_back()
     backend = _Stub()
     state = await backend.transition_r1_calibration_state("earned")
 
-    # Wrote the new status
-    assert len(captured_executes) == 1
-    sql, args = captured_executes[0]
+    assert len(captured) == 1, "only one DB roundtrip — UPDATE + RETURNING * combined"
+    sql, args = captured[0]
     assert "UPDATE core.r1_calibration_state" in sql
-    assert "calibration_status = $1" in sql
+    assert "RETURNING" in sql
     assert args == ("earned",)
-    # Read back the post-transition state
     assert state["calibration_status"] == "earned"
     assert state["earned_at"] == "now-stamp"
 
@@ -274,7 +276,6 @@ async def test_transition_r1_calibration_state_accepts_calibration_failed():
     class _AcquireCtx:
         async def __aenter__(self):
             conn = AsyncMock()
-            conn.execute = AsyncMock(return_value="UPDATE 1")
             conn.fetchrow = AsyncMock(return_value={
                 "id": 1,
                 "calibration_status": "calibration_failed",
@@ -291,4 +292,40 @@ async def test_transition_r1_calibration_state_accepts_calibration_failed():
     backend = _Stub()
     state = await backend.transition_r1_calibration_state("calibration_failed")
     assert state["calibration_status"] == "calibration_failed"
+    assert state["failed_at"] == "now-stamp"
+
+
+@pytest.mark.asyncio
+async def test_transition_seeded_to_calibration_failed_skips_earned():
+    """Per v3.3-C: seeded → calibration_failed direct transition is supported
+    (operator can mark calibration_failed without first marking earned).
+    Pins the CASE-WHEN branch that fires on `$1 = 'calibration_failed'`
+    regardless of current state."""
+    from src.db.mixins.identity import IdentityMixin
+
+    class _Stub(IdentityMixin):
+        def acquire(self):
+            return _AcquireCtx()
+
+    class _AcquireCtx:
+        async def __aenter__(self):
+            conn = AsyncMock()
+            # Singleton was 'seeded' before; transition skips earned.
+            conn.fetchrow = AsyncMock(return_value={
+                "id": 1,
+                "calibration_status": "calibration_failed",
+                "seeded_since": "seeded-stamp",
+                "earned_at": None,         # never earned
+                "failed_at": "now-stamp",  # newly stamped
+                "updated_at": "now-stamp",
+            })
+            return conn
+
+        async def __aexit__(self, *args):
+            return None
+
+    backend = _Stub()
+    state = await backend.transition_r1_calibration_state("calibration_failed")
+    assert state["calibration_status"] == "calibration_failed"
+    assert state["earned_at"] is None  # skipped earned entirely
     assert state["failed_at"] == "now-stamp"

--- a/tests/test_trajectory_continuity.py
+++ b/tests/test_trajectory_continuity.py
@@ -40,12 +40,25 @@ def _stub_reconstruct(parent_series, successor_series):
 
 @pytest.fixture
 def mocked_db(monkeypatch):
-    """Patch get_db to return a backend whose reconstruct_eisv_series is settable."""
+    """Patch get_db to return a backend whose async methods are settable."""
     backend = AsyncMock()
     # Default to successful audit-write so the score primitive can return a
     # score; per-test overrides set return_value=False to exercise the
     # fail-loud join-key contract (test_score_raises_when_audit_write_fails).
     backend.record_r1_score_audit = AsyncMock(return_value=True)
+    # v3.3-C default: calibration_status='seeded'. Per-test overrides exercise
+    # the calibration_failed verdict-degradation path.
+    backend.read_r1_calibration_state = AsyncMock(return_value={
+        "calibration_status": "seeded",
+        "seeded_since": None,
+        "earned_at": None,
+        "failed_at": None,
+        "updated_at": None,
+    })
+    # v3.3-G default: parent has no class metadata → class_tag=None.
+    # Per-test overrides set get_identity to return a record with metadata.tags
+    # containing a recognized class tag.
+    backend.get_identity = AsyncMock(return_value=None)
 
     def _get_db():
         return backend
@@ -54,6 +67,12 @@ def mocked_db(monkeypatch):
     # anyio pattern lazy imports); patch the source module.
     monkeypatch.setattr("src.db.get_db", _get_db)
     return backend
+
+
+def _identity_with_tags(*tags):
+    """Build a minimal identity record stub for class_tag tests."""
+    from types import SimpleNamespace
+    return SimpleNamespace(metadata={"tags": list(tags)})
 
 
 # ---------------------------------------------------------------------------
@@ -300,6 +319,178 @@ async def test_score_raises_when_audit_write_fails(mocked_db):
             claimed_parent_id="parent-uuid",
             successor_id="successor-uuid",
         )
+
+
+@pytest.mark.asyncio
+async def test_score_calibration_failed_degrades_verdict_to_inconclusive(mocked_db):
+    """Per v3.3-C: when calibration_status='calibration_failed', the
+    consumer-facing verdict MUST be 'inconclusive' regardless of plausibility.
+    Even a genuine pair with plausibility >= 0.70 returns inconclusive.
+    The original would-be-verdict is captured in `reasons` for forensic
+    access; the audit row's `calibration_status` snapshots 'calibration_failed'
+    so analyses know which scoring window was under degraded calibration."""
+    from src.identity.trajectory_continuity import score_trajectory_continuity
+
+    parent, successor = synthetic_trajectory_pair(seed=60, kind="genuine")
+    mocked_db.reconstruct_eisv_series = AsyncMock(
+        side_effect=_stub_reconstruct(parent, successor)
+    )
+    # Operator has marked calibration as failed
+    mocked_db.read_r1_calibration_state = AsyncMock(return_value={
+        "calibration_status": "calibration_failed",
+        "seeded_since": None,
+        "earned_at": None,
+        "failed_at": None,
+        "updated_at": None,
+    })
+
+    result = await score_trajectory_continuity(
+        claimed_parent_id="parent-uuid",
+        successor_id="successor-uuid",
+    )
+
+    # Verdict degraded despite high plausibility
+    assert result.verdict == "inconclusive"
+    assert result.plausibility >= 0.70  # raw scoring still computed correctly
+    assert result.calibration_status == "calibration_failed"
+    # Reasons names the degradation explicitly
+    assert any("degraded" in r and "calibration_failed" in r for r in result.reasons)
+
+
+@pytest.mark.asyncio
+async def test_score_calibration_earned_does_not_degrade(mocked_db):
+    """Per v3.3-C: under `earned`, verdict is shown without caveat — no
+    degradation, no extra reason added."""
+    from src.identity.trajectory_continuity import score_trajectory_continuity
+
+    parent, successor = synthetic_trajectory_pair(seed=61, kind="genuine")
+    mocked_db.reconstruct_eisv_series = AsyncMock(
+        side_effect=_stub_reconstruct(parent, successor)
+    )
+    mocked_db.read_r1_calibration_state = AsyncMock(return_value={
+        "calibration_status": "earned",
+        "seeded_since": None,
+        "earned_at": None,
+        "failed_at": None,
+        "updated_at": None,
+    })
+
+    result = await score_trajectory_continuity(
+        claimed_parent_id="parent-uuid",
+        successor_id="successor-uuid",
+    )
+
+    assert result.verdict == "plausible"
+    assert result.calibration_status == "earned"
+    assert not any("degraded" in r for r in result.reasons)
+
+
+@pytest.mark.asyncio
+async def test_score_calibration_status_snapshots_at_scoring_time(mocked_db):
+    """The audit row's calibration_status equals the singleton's status at
+    scoring time (not the global current status at analysis time). This is
+    why v3.3-G also stamps class_tag at scoring time — both snapshots make
+    later calibration analyses partition correctly."""
+    from src.identity.trajectory_continuity import score_trajectory_continuity
+
+    parent, successor = synthetic_trajectory_pair(seed=62, kind="genuine")
+    mocked_db.reconstruct_eisv_series = AsyncMock(
+        side_effect=_stub_reconstruct(parent, successor)
+    )
+    mocked_db.read_r1_calibration_state = AsyncMock(return_value={
+        "calibration_status": "earned",
+        "seeded_since": None,
+        "earned_at": None,
+        "failed_at": None,
+        "updated_at": None,
+    })
+
+    result = await score_trajectory_continuity(
+        claimed_parent_id="parent-uuid",
+        successor_id="successor-uuid",
+    )
+
+    # Audit row carries the status that was current at scoring time
+    audit_call = mocked_db.record_r1_score_audit.await_args
+    audit_record = audit_call.kwargs if audit_call.kwargs else audit_call.args[0]
+    assert audit_record["calibration_status"] == "earned"
+    assert result.calibration_status == "earned"
+
+
+@pytest.mark.asyncio
+async def test_score_class_tag_stamped_from_parent_metadata(mocked_db):
+    """Per v3.3-G: the audit row carries the parent's class_tag at scoring
+    time. Reads from `core.identities.metadata.tags` and picks the most-
+    specific recognized tag per _CLASS_TAG_PRIORITY."""
+    from src.identity.trajectory_continuity import score_trajectory_continuity
+
+    parent, successor = synthetic_trajectory_pair(seed=63, kind="genuine")
+    mocked_db.reconstruct_eisv_series = AsyncMock(
+        side_effect=_stub_reconstruct(parent, successor)
+    )
+    # Parent is a substrate-anchored persistent agent (e.g. Vigil)
+    mocked_db.get_identity = AsyncMock(
+        return_value=_identity_with_tags("persistent", "autonomous")
+    )
+
+    await score_trajectory_continuity(
+        claimed_parent_id="parent-uuid",
+        successor_id="successor-uuid",
+    )
+
+    audit_call = mocked_db.record_r1_score_audit.await_args
+    audit_record = audit_call.kwargs if audit_call.kwargs else audit_call.args[0]
+    assert audit_record["class_tag"] == "persistent"
+
+
+@pytest.mark.asyncio
+async def test_score_class_tag_priority_picks_most_specific(mocked_db):
+    """Per v3.3-G ordering: when parent has multiple class tags, the most-
+    specific one is stamped. `engaged_ephemeral` wins over `ephemeral`."""
+    from src.identity.trajectory_continuity import score_trajectory_continuity
+
+    parent, successor = synthetic_trajectory_pair(seed=64, kind="genuine")
+    mocked_db.reconstruct_eisv_series = AsyncMock(
+        side_effect=_stub_reconstruct(parent, successor)
+    )
+    mocked_db.get_identity = AsyncMock(
+        return_value=_identity_with_tags("ephemeral", "engaged_ephemeral")
+    )
+
+    await score_trajectory_continuity(
+        claimed_parent_id="parent-uuid",
+        successor_id="successor-uuid",
+    )
+
+    audit_call = mocked_db.record_r1_score_audit.await_args
+    audit_record = audit_call.kwargs if audit_call.kwargs else audit_call.args[0]
+    assert audit_record["class_tag"] == "engaged_ephemeral"
+
+
+@pytest.mark.asyncio
+async def test_score_class_tag_none_when_parent_has_no_recognized_class(mocked_db):
+    """Parent identity has no recognized class tag (or no metadata.tags at
+    all) → class_tag=None on audit record. Per v3.3-G: NULL is the honest
+    answer when S8a Phase 2 backfill hasn't reached this agent yet."""
+    from src.identity.trajectory_continuity import score_trajectory_continuity
+
+    parent, successor = synthetic_trajectory_pair(seed=65, kind="genuine")
+    mocked_db.reconstruct_eisv_series = AsyncMock(
+        side_effect=_stub_reconstruct(parent, successor)
+    )
+    # Parent has tags but none are recognized class tags
+    mocked_db.get_identity = AsyncMock(
+        return_value=_identity_with_tags("autonomous")
+    )
+
+    await score_trajectory_continuity(
+        claimed_parent_id="parent-uuid",
+        successor_id="successor-uuid",
+    )
+
+    audit_call = mocked_db.record_r1_score_audit.await_args
+    audit_record = audit_call.kwargs if audit_call.kwargs else audit_call.args[0]
+    assert audit_record["class_tag"] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

R1 implementation row, PR 3 of 4 (split from original PR 3). Closes the score-side semantics. Builds on PR 1 (#306, foundation) + PR 2 (#309, primitive). PR 4 will land consumers (trust-tier, R3 baselines, KG provenance) + KG public emission.

**Per design doc:** `docs/ontology/r1-verify-lineage-claim.md` v3.3 §C (calibration_status), §D (provisional_lineage), §G (class_tag).

## What landed

**Migration 032 (`db/postgres/migrations/032_r1_calibration_state.sql`):**
- `core.r1_calibration_state` singleton (PK + CHECK id=1)
- Three-state enum: `seeded` / `earned` / `calibration_failed`
- Lifecycle timestamps: `seeded_since` (default now), `earned_at`, `failed_at`, `updated_at`
- Singleton row inserted at `seeded` on first apply
- Registered as schema_migrations version 32

**Migration 033 (`db/postgres/migrations/033_r1_score_audit_verdict_cols.sql`):**
- Added `raw_verdict` + `verdict` columns to `audit.r1_score_audit` (per PR 3 council architect forcing flag — spec line 366 requires retaining raw verdict for forensic access, missing in original 031)
- Both NULL-safe + CHECK enum guards

**`src/db/mixins/identity.py` — 4 new methods:**
- `mark_lineage_provisional(successor_id, score_id)` — sets the 4 v3.3-D columns
- `confirm_lineage(successor_id)` — flips provisional → confirmed; `provisional_recorded_at` preserved as audit anchor (explicit decision per council; documented)
- `read_r1_calibration_state()` — reads singleton with WARNING-logged pre-migration-032 fallback
- `transition_r1_calibration_state(new_status)` — operator-only state machine via atomic `UPDATE...RETURNING *` (eliminates TOCTOU window from pre-fix two-step UPDATE+SELECT)

**`src/identity/trajectory_continuity.py` updates:**
- Reads calibration_state at scoring time (snapshot semantics per v3.3-C); stamps on dataclass + audit row
- v3.3-C consumer-degradation: under `calibration_failed`, verdict forced to `inconclusive` regardless of plausibility; `raw_verdict` preserved on audit row separately
- v3.3-G class_tag stamped from parent's metadata.tags via `_CLASS_TAG_PRIORITY` (most-specific first; substrate > S8a Phase-2 > Phase-1)
- `session_like` annotated as reserved (no stamp path yet; ready for S8a Phase-2 promotion)

**Tests (`tests/test_trajectory_continuity.py` + `tests/test_r1_identity_helpers.py`):**
- 17 trajectory primitive tests (11 from PR 2 + 6 new for PR 3 lifecycle + class_tag)
- 10 identity-helper tests (existence contracts, mark/confirm UPDATE behavior, calibration read with fallback, transition atomicity via RETURNING *, direct seeded→failed transition, invalid-status rejection)

## Council review

3 agents in parallel — all returned **PROCEED with fixes**:

- **Live-verifier**: 8/8 VERIFIED including E2E roundtrip, CHECK enforcement, all three calibration transitions, score with calibration_failed yielding inconclusive, class_tag stamping from parent metadata. All test data cleaned up.
- **Architect**: 1 forcing (audit row missing raw_verdict/verdict) + 3 flags + 3 minors — all folded into commit `6156ea2`.
- **Code-reviewer**: 2 pre-merge fixes (TOCTOU + provisional_recorded_at decision) + 3 follow-up flags — all folded.

Full suite: **8164 passed, 33 skipped, 0 fail, 78.94% coverage** (was 8147 baseline + 17 new).

## Test plan

- [x] 27 new unit tests covering all PR 3 surfaces
- [x] Live verification: singleton CHECK enforcement, mark/confirm roundtrip, all 3 calibration transitions, score E2E with calibration_failed, class_tag stamping
- [x] Migration 032 + 033 applied cleanly to dev DB; doctor at version 33
- [x] Council pass — all PROCEED post-fix