### PR TITLE
fix(error-handling): order TIMEOUT before auth patterns so tool names containing 'session' don't miscategorize

### DIFF
--- a/src/mcp_handlers/error_handling.py
+++ b/src/mcp_handlers/error_handling.py
@@ -28,6 +28,12 @@ def _infer_error_code_and_category(message: str) -> Tuple[Optional[str], Optiona
         (["too short", "too small", "minimum"], "VALUE_TOO_SMALL", "validation_error"),
         (["empty", "cannot be empty"], "EMPTY_VALUE", "validation_error"),
 
+        # High-priority system errors.
+        # Keep these after validation so explicit parameter problems still win,
+        # but before broad auth patterns like "session"; otherwise tool names
+        # such as list_dialectic_sessions make timeout failures look like auth.
+        (["timeout", "timed out"], "TIMEOUT", "system_error"),
+
         # Auth errors
         (["permission", "not authorized", "forbidden", "access denied"], "PERMISSION_DENIED", "auth_error"),
         (["api key", "apikey"], "API_KEY_ERROR", "auth_error"),
@@ -40,7 +46,6 @@ def _infer_error_code_and_category(message: str) -> Tuple[Optional[str], Optiona
         (["locked", "already locked"], "RESOURCE_LOCKED", "state_error"),
 
         # System errors
-        (["timeout", "timed out"], "TIMEOUT", "system_error"),
         (["connection", "connect"], "CONNECTION_ERROR", "system_error"),
         (["database", "postgres", "db error"], "DATABASE_ERROR", "system_error"),
         (["failed to", "could not", "unable to"], "OPERATION_FAILED", "system_error"),

--- a/tests/test_utils_pure.py
+++ b/tests/test_utils_pure.py
@@ -203,6 +203,13 @@ class TestInferErrorCodeAndCategory:
         assert code == "TIMEOUT"
         assert cat == "system_error"
 
+    def test_tool_timeout_with_session_tool_name_is_system_error(self):
+        code, cat = _infer_error_code_and_category(
+            "Tool 'list_dialectic_sessions' timed out after 15.0 seconds."
+        )
+        assert code == "TIMEOUT"
+        assert cat == "system_error"
+
     def test_connection(self):
         code, cat = _infer_error_code_and_category("Connection refused by server")
         assert code == "CONNECTION_ERROR"


### PR DESCRIPTION
Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.