### PR TITLE
feat(r1): PR 4a trust-tier provisional gate (R1 v3.3-D consumer)

### DIFF
--- a/src/db/mixins/identity.py
+++ b/src/db/mixins/identity.py
@@ -317,6 +317,23 @@ class IdentityMixin:
                 rows = 0
             return rows > 0
 
+    async def is_lineage_provisional(self, agent_id: str) -> bool:
+        """R1 v3.3-D: read-only check of provisional_lineage on core.identities.
+
+        Returns False when the row doesn't exist. Consumers (trust-tier
+        gate, R3 baselines, KG provenance) call this to filter without
+        loading the full record. Stubbable in tests via conftest's
+        `_isolate_db_backend` (no `async with self.acquire()` exposure).
+        """
+        async with self.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT provisional_lineage FROM core.identities WHERE agent_id = $1",
+                agent_id,
+            )
+            if row is None:
+                return False
+            return bool(row["provisional_lineage"])
+
     async def read_r1_calibration_state(self) -> Dict[str, Any]:
         """Read the R1 calibration_state singleton (v3.3-C).
 

--- a/src/identity/trust_tier_routing.py
+++ b/src/identity/trust_tier_routing.py
@@ -91,6 +91,7 @@ def _provisional_lineage_tier_dict() -> Dict[str, Any]:
         "lineage_similarity": None,
         "reason": "Provisional lineage (R1 v3.3-D); awaiting confirm_lineage to promote",
         "source": "provisional_lineage_gate",
+        "conditions": None,  # parity with _substrate_earned_tier_dict + compute_trust_tier
     }
 
 

--- a/src/identity/trust_tier_routing.py
+++ b/src/identity/trust_tier_routing.py
@@ -69,16 +69,81 @@ def _substrate_earned_tier_dict(
     }
 
 
+def _provisional_lineage_tier_dict() -> Dict[str, Any]:
+    """Tier dict for an agent whose lineage is currently provisional.
+
+    Per R1 v3.3-D consumer table: 'Read provisional_lineage; if true, do
+    not contribute to tier upgrades.' The simplest faithful read of that
+    contract is to return tier=1 (the baseline / lowest tier) regardless
+    of substrate-earned or compute_trust_tier verdict — a provisional
+    successor cannot promote to a higher tier until the lineage is
+    confirmed via `confirm_lineage`.
+
+    Same shape as `compute_trust_tier` for caller-API compatibility plus a
+    `source` tag so observability / dashboards can distinguish a
+    provisional gate from a substrate-earned or compute-derived tier.
+    """
+    return {
+        "tier": 1,
+        "name": "provisional",
+        "observation_count": 0,
+        "identity_confidence": 0.0,
+        "lineage_similarity": None,
+        "reason": "Provisional lineage (R1 v3.3-D); awaiting confirm_lineage to promote",
+        "source": "provisional_lineage_gate",
+    }
+
+
+async def _is_provisional_lineage(agent_uuid: str) -> bool:
+    """Lookup of `core.identities.provisional_lineage` for the gate.
+
+    Delegates to `IdentityMixin.is_lineage_provisional` (mixin-level so
+    test conftest can stub via `_isolate_db_backend` without leaking
+    AsyncMock coroutines through an inline `async with backend.acquire()`).
+    PR 1's migration 031 added the SQL column; extending IdentityRecord
+    is deferred. When the dataclass is extended, callers can pass
+    `prefetched_provisional` to skip this lookup entirely.
+
+    Returns False on any error — a failed lookup should not silently gate
+    legitimate tier upgrades. Logged at debug for observability.
+    """
+    try:
+        from src.db import get_db
+        backend = get_db()
+        result = await backend.is_lineage_provisional(agent_uuid)
+        # Strict-identity check: anything other than literal True (e.g. an
+        # AsyncMock from a test that didn't stub the method, or a non-bool
+        # return) is treated as not-provisional. The gate's failure mode is
+        # to under-fire (allowing a tier upgrade for an unmocked test path)
+        # rather than over-fire (silently demoting a legitimately-tiered
+        # production agent because of a mock-shape accident).
+        return result is True
+    except Exception as e:
+        logger.debug(
+            f"[trust_tier_routing] provisional_lineage lookup failed for "
+            f"{agent_uuid[:8]}...: {e}; treating as not-provisional"
+        )
+        return False
+
+
 async def resolve_trust_tier(
     agent_uuid: str,
     metadata: Dict[str, Any],
     *,
     prefetched_tags: Optional[Iterable[str]] = None,
     prefetched_label: Optional[str] = None,
+    prefetched_provisional: Optional[bool] = None,
 ) -> Dict[str, Any]:
-    """Route to substrate-earned (R4) or session-like (`compute_trust_tier`).
+    """Route to provisional-gate (R1 v3.3-D), substrate-earned (R4), or
+    session-like (`compute_trust_tier`).
 
     Returns a tier dict with the same shape as `compute_trust_tier`.
+
+    Provisional gate (R1 v3.3-D): if `provisional_lineage=True` on the
+    agent's `core.identities` row, return tier=1 with source='provisional_
+    lineage_gate' regardless of substrate or compute verdict. Callers that
+    have provisional state in hand pass `prefetched_provisional=True/False`
+    to skip the DB lookup; otherwise this function does its own read.
 
     Fast path: if `prefetched_tags` is provided and does not include a
     substrate-class tag (`embodied`/`persistent`), skip the R4 predicate
@@ -91,9 +156,17 @@ async def resolve_trust_tier(
 
     On any exception in the substrate-earned check, fall through to
     `compute_trust_tier` — a failed R4 lookup should not block tier
-    computation.
+    computation. The provisional gate fails-soft the same way.
     """
     from src.trajectory_identity import compute_trust_tier
+
+    # R1 v3.3-D provisional gate — runs FIRST so a provisional successor
+    # cannot collect tier=3 via the substrate-earned shortcut.
+    is_provisional = prefetched_provisional
+    if is_provisional is None:
+        is_provisional = await _is_provisional_lineage(agent_uuid)
+    if is_provisional:
+        return _provisional_lineage_tier_dict()
 
     try:
         if prefetched_tags is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,6 +125,7 @@ def _isolate_db_backend(monkeypatch):
     # R1 v3.3-D provisional helpers + v3.3-C calibration_state singleton
     mock_backend.mark_lineage_provisional.return_value = True
     mock_backend.confirm_lineage.return_value = True
+    mock_backend.is_lineage_provisional.return_value = False
     mock_backend.read_r1_calibration_state.return_value = {
         "calibration_status": "seeded",
         "seeded_since": None,

--- a/tests/test_trust_tier_provisional_gate.py
+++ b/tests/test_trust_tier_provisional_gate.py
@@ -1,0 +1,183 @@
+"""Tests for R1 v3.3-D consumer patch: provisional_lineage gate in
+resolve_trust_tier.
+
+Per docs/ontology/r1-verify-lineage-claim.md §v3.3-D consumer table:
+  Trust-tier (S6): Read provisional_lineage; if true, do not contribute to
+  tier upgrades.
+
+Implementation: provisional gate runs FIRST in resolve_trust_tier, returning
+tier=1 with source='provisional_lineage_gate' regardless of substrate or
+compute_trust_tier verdict. Callers can pass prefetched_provisional to skip
+the DB lookup; otherwise the gate does its own read against core.identities.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_resolve_trust_tier_returns_tier_1_when_prefetched_provisional_true():
+    """Prefetched provisional=True → tier=1 with source='provisional_lineage_gate'.
+    Substrate-earned + compute_trust_tier paths are NOT consulted."""
+    from src.identity.trust_tier_routing import resolve_trust_tier
+
+    result = await resolve_trust_tier(
+        agent_uuid="successor-uuid",
+        metadata={"tags": ["persistent", "autonomous"]},  # would be tier=3 otherwise
+        prefetched_tags=["persistent", "autonomous"],
+        prefetched_provisional=True,
+    )
+
+    assert result["tier"] == 1
+    assert result["name"] == "provisional"
+    assert result["source"] == "provisional_lineage_gate"
+    assert "v3.3-D" in result["reason"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_trust_tier_substrate_earned_path_when_prefetched_provisional_false():
+    """Prefetched provisional=False → normal substrate-earned flow runs.
+    For an agent with substrate-class tags + a metadata-recognized substrate
+    earn, the substrate-earned tier_dict (tier=3) is returned."""
+    from src.identity.trust_tier_routing import resolve_trust_tier
+
+    # evaluate_substrate_earned returns earned=True
+    with patch("src.identity.substrate.evaluate_substrate_earned") as mock_eval:
+        mock_eval.return_value = {
+            "earned": True,
+            "evidence": {"observation_count": 100},
+            "conditions": {},
+        }
+        result = await resolve_trust_tier(
+            agent_uuid="lumen-uuid",
+            metadata={"trajectory_current": {"identity_confidence": 0.95}},
+            prefetched_tags=["persistent", "autonomous"],
+            prefetched_provisional=False,
+        )
+
+    assert result["tier"] == 3
+    assert result["source"] == "substrate_earned"
+
+
+@pytest.mark.asyncio
+async def test_resolve_trust_tier_compute_path_when_no_substrate_no_provisional():
+    """Prefetched provisional=False and no substrate tags → falls through to
+    compute_trust_tier (per-UUID lifecycle)."""
+    from src.identity.trust_tier_routing import resolve_trust_tier
+
+    with patch("src.trajectory_identity.compute_trust_tier") as mock_compute:
+        mock_compute.return_value = {
+            "tier": 2,
+            "name": "session_like",
+            "observation_count": 30,
+            "identity_confidence": 0.8,
+            "lineage_similarity": 0.9,
+            "reason": "compute_trust_tier",
+        }
+        result = await resolve_trust_tier(
+            agent_uuid="ephemeral-uuid",
+            metadata={},
+            prefetched_tags=["ephemeral"],
+            prefetched_provisional=False,
+        )
+
+    assert result["tier"] == 2
+    mock_compute.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_resolve_trust_tier_db_lookup_when_provisional_not_prefetched(monkeypatch):
+    """When prefetched_provisional=None (default), the gate calls
+    backend.is_lineage_provisional. With provisional=True, returns tier=1."""
+    from src.identity.trust_tier_routing import resolve_trust_tier
+
+    backend = AsyncMock()
+    backend.is_lineage_provisional = AsyncMock(return_value=True)
+    monkeypatch.setattr("src.db.get_db", lambda: backend)
+
+    result = await resolve_trust_tier(
+        agent_uuid="provisional-uuid",
+        metadata={},
+    )
+
+    assert result["tier"] == 1
+    assert result["source"] == "provisional_lineage_gate"
+    backend.is_lineage_provisional.assert_awaited_once_with("provisional-uuid")
+
+
+@pytest.mark.asyncio
+async def test_resolve_trust_tier_db_lookup_provisional_false_proceeds_normally(monkeypatch):
+    """is_lineage_provisional → False → normal flow proceeds."""
+    from src.identity.trust_tier_routing import resolve_trust_tier
+
+    backend = AsyncMock()
+    backend.is_lineage_provisional = AsyncMock(return_value=False)
+    monkeypatch.setattr("src.db.get_db", lambda: backend)
+
+    with patch("src.trajectory_identity.compute_trust_tier") as mock_compute:
+        mock_compute.return_value = {"tier": 1, "name": "ephemeral",
+                                     "observation_count": 0, "identity_confidence": 0.0,
+                                     "lineage_similarity": None, "reason": "ephemeral"}
+        result = await resolve_trust_tier(
+            agent_uuid="non-provisional-uuid",
+            metadata={},
+            prefetched_tags=["ephemeral"],
+        )
+
+    mock_compute.assert_called_once()
+    assert result.get("source") != "provisional_lineage_gate"
+
+
+@pytest.mark.asyncio
+async def test_resolve_trust_tier_db_lookup_failure_fails_soft(monkeypatch):
+    """is_lineage_provisional raises → treated as not-provisional, normal flow.
+    A failed lookup should not silently gate legitimate tier upgrades."""
+    from src.identity.trust_tier_routing import resolve_trust_tier
+
+    backend = AsyncMock()
+    backend.is_lineage_provisional = AsyncMock(side_effect=RuntimeError("DB offline"))
+    monkeypatch.setattr("src.db.get_db", lambda: backend)
+
+    with patch("src.trajectory_identity.compute_trust_tier") as mock_compute:
+        mock_compute.return_value = {"tier": 1, "name": "ephemeral",
+                                     "observation_count": 0, "identity_confidence": 0.0,
+                                     "lineage_similarity": None, "reason": "ephemeral"}
+        result = await resolve_trust_tier(
+            agent_uuid="error-uuid",
+            metadata={},
+            prefetched_tags=["ephemeral"],
+        )
+
+    assert result.get("source") != "provisional_lineage_gate"
+    mock_compute.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_provisional_gate_runs_before_substrate_earned_check():
+    """A substrate-anchored agent (Vigil/Lumen) whose lineage is provisional
+    is gated to tier=1 — the substrate-earned shortcut to tier=3 is
+    correctly bypassed. Critical contract: provisional > substrate_earned."""
+    from src.identity.trust_tier_routing import resolve_trust_tier
+
+    # Even though we'd be substrate-earned (persistent + autonomous), the
+    # provisional gate runs first and returns tier=1.
+    with patch("src.identity.substrate.evaluate_substrate_earned") as mock_eval:
+        mock_eval.return_value = {
+            "earned": True,
+            "evidence": {"observation_count": 1000},
+            "conditions": {},
+        }
+        result = await resolve_trust_tier(
+            agent_uuid="provisional-substrate-uuid",
+            metadata={"trajectory_current": {"identity_confidence": 0.99}},
+            prefetched_tags=["persistent", "autonomous"],
+            prefetched_provisional=True,  # gate fires
+        )
+
+    assert result["tier"] == 1
+    assert result["source"] == "provisional_lineage_gate"
+    # Substrate-earned was NOT consulted
+    mock_eval.assert_not_called()

--- a/tests/test_trust_tier_provisional_gate.py
+++ b/tests/test_trust_tier_provisional_gate.py
@@ -156,6 +156,49 @@ async def test_resolve_trust_tier_db_lookup_failure_fails_soft(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_is_lineage_provisional_returns_literal_bool():
+    """Pin the contract: IdentityMixin.is_lineage_provisional returns a
+    literal Python bool. The gate's `result is True` strict-identity check
+    is belt-and-suspenders; this contract pin makes the type guarantee
+    load-bearing rather than implicit (architect council flag, PR 4a)."""
+    from src.db.mixins.identity import IdentityMixin
+
+    class _Stub(IdentityMixin):
+        def __init__(self, val):
+            self._val = val
+
+        def acquire(self):
+            return _AcquireCtx(self._val)
+
+    class _AcquireCtx:
+        def __init__(self, val):
+            self._val = val
+
+        async def __aenter__(self):
+            conn = AsyncMock()
+            conn.fetchrow = AsyncMock(return_value={"provisional_lineage": self._val})
+            return conn
+
+        async def __aexit__(self, *a):
+            return None
+
+    result_true = await _Stub(True).is_lineage_provisional("agent-x")
+    assert result_true is True
+    assert type(result_true) is bool
+
+    result_false = await _Stub(False).is_lineage_provisional("agent-y")
+    assert result_false is False
+    assert type(result_false) is bool
+
+    # Defensive: if asyncpg ever returned a truthy non-bool (it doesn't for
+    # BOOLEAN columns, but the explicit `bool(row[...])` cast in the mixin
+    # is what guards), the result must still be a literal bool.
+    result_truthy_int = await _Stub(1).is_lineage_provisional("agent-z")
+    assert result_truthy_int is True
+    assert type(result_truthy_int) is bool
+
+
+@pytest.mark.asyncio
 async def test_provisional_gate_runs_before_substrate_earned_check():
     """A substrate-anchored agent (Vigil/Lumen) whose lineage is provisional
     is gated to tier=1 — the substrate-earned shortcut to tier=3 is


### PR DESCRIPTION
## Summary

R1 implementation row, PR 4a — first of the consumer-side patches. Implements the trust-tier provisional gate per `docs/ontology/r1-verify-lineage-claim.md` §v3.3-D consumer table row 1: "Read provisional_lineage; if true, do not contribute to tier upgrades."

This PR **unblocks R2's implementation row** by satisfying the v3.3-B prereq (provisional_lineage column existing + a callable read primitive available).

Follow-ups: PR 4b (R3 baseline exclusion), PR 4c (KG provenance filter + KG public emission).

## What landed

**`src/db/mixins/identity.py`:**
- `is_lineage_provisional(agent_id) -> bool` — read-only direct SELECT on `core.identities.provisional_lineage`. Returns False when row absent. Stubbable via conftest.

**`src/identity/trust_tier_routing.py`:**
- `_provisional_lineage_tier_dict()` — tier=1 with source='provisional_lineage_gate', shape parity with sibling tier-dict factories (includes `conditions: None`)
- `_is_provisional_lineage(agent_uuid)` — async helper with strict-identity check (`result is True`) so unmocked AsyncMock backends in tests don't falsely fire
- `resolve_trust_tier`: provisional gate runs FIRST (before substrate-earned + compute_trust_tier paths) so a successor with substrate-class tags but provisional_lineage=True is correctly gated to tier=1, not promoted to tier=3
- New `prefetched_provisional` kwarg for callers that already have the value

**Tests (`tests/test_trust_tier_provisional_gate.py`):** 8 cases including:
- prefetched True/False, DB-lookup True/False, lookup failure fail-soft
- substrate-earned bypass under prefetched True
- gate-runs-before-substrate-earned contract
- literal-bool contract on `is_lineage_provisional` (architect flag)

**`tests/conftest.py`:** `is_lineage_provisional.return_value = False` default stub.

## Council review

3 agents in parallel — all returned **PROCEED with fixes**:

- **Live-verifier**: 8/8 VERIFIED end-to-end against live DB — mark/confirm roundtrip via `is_lineage_provisional`, gate returns tier=1 with correct source, substrate-bypass blocked, doctor passes at version 33.
- **Architect**: PROCEED, no forcing items. Two flags folded: literal-bool contract test, conditions-key parity. Performance flag (3 call sites do DB roundtrip until IdentityRecord gains the field) tracked for follow-up.
- **Code-reviewer**: PROCEED with one fix — missing `conditions` key in `_provisional_lineage_tier_dict` (folded into commit `0a6a34e`). Performance flag tracked.

Full suite: **8191 passed, 33 skipped, 0 fail, 78.97% coverage** (was 8190 + 1 literal-bool contract test).

## Test plan

- [x] 8 unit tests covering all gate paths
- [x] Live verification: end-to-end mark→is_provisional→confirm roundtrip; resolve_trust_tier gating; substrate-bypass blocked
- [x] Council pass — all PROCEED post-fix