### PR TITLE
feat(r1): §4.3 public KG emission — closes PR 2's deferred write (v3.3-A + v3.2-D)

### DIFF
--- a/src/identity/trajectory_continuity.py
+++ b/src/identity/trajectory_continuity.py
@@ -34,6 +34,7 @@ that gating lives at the consumer layer (PR 3), not here.
 
 from __future__ import annotations
 
+import json
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -51,6 +52,12 @@ _THRESHOLD_UNSUPPORTED = 0.55
 _DEFAULT_MIN_OBSERVATIONS = 5
 _DEFAULT_WINDOW = timedelta(days=30)
 _DIMENSIONS = ("E", "I", "S", "V")
+
+# UUIDv5 namespace for the public KG node ID per (parent, successor) pair.
+# Stable across processes — derived from NAMESPACE_OID + a fixed name. The
+# resulting node ID is `f"r1_score:{uuid5(...)}"`; ON CONFLICT (id) DO UPDATE
+# in `kg_add_discovery` gives v3.2-D dedupe-by-pair for free.
+_R1_KG_NAMESPACE = uuid.uuid5(uuid.NAMESPACE_OID, "unitares.r1.trajectory_continuity_score")
 
 # Class tags recognized for R1's `class_tag` stamping (v3.3-G). Order matters
 # — most-specific first so calibration analyses can partition without
@@ -121,6 +128,87 @@ def _build_public_payload(score: TrajectoryContinuityScore) -> Dict[str, Any]:
         "n_dims_used": score.n_dims_used,
         "score_id": score.score_id,
     }
+
+
+def _public_kg_node_id(parent_id: str, successor_id: str) -> str:
+    """Deterministic node ID per (parent, successor) pair.
+
+    Per v3.2-D dedupe-by-pair: the N-th score for the same pair overwrites
+    the (N-1)-th in the public KG. ON CONFLICT (id) DO UPDATE in
+    `kg_add_discovery` (`src/db/mixins/knowledge_graph.py:82`) gives this
+    semantics for free as long as the id is deterministic from the pair.
+
+    Prefix `r1_score:` makes the id self-describing in logs/queries; the
+    UUIDv5 suffix is the deterministic-and-stable part.
+    """
+    return f"r1_score:{uuid.uuid5(_R1_KG_NAMESPACE, f'{parent_id}:{successor_id}')}"
+
+
+async def _emit_public_kg_node(
+    score: TrajectoryContinuityScore,
+    *,
+    parent_id: str,
+    successor_id: str,
+) -> bool:
+    """Publish the v3.3-A redacted score to the public KG.
+
+    Closes PR 2's deferred KG emission (commit 83e70aa: "KG public emission
+    deferred to PR 3 alongside consumer patches" — PR 3 stayed score-side,
+    so this is the actual write path).
+
+    Per v3.3-A:
+    - Public payload is exactly `{verdict, calibration_status, n_dims_used,
+      score_id}` — `_build_public_payload` produces this shape.
+    - Audit table is the canonical record; the public node is its redacted
+      projection joined by `score_id`.
+
+    Per v3.2-D:
+    - Dedupe by (parent_id, successor_id). N-th score overwrites (N-1)-th.
+      Achieved via deterministic node id + existing ON CONFLICT path.
+
+    Fail-soft contract: emission is observability, not a durability gate.
+    A failure here logs at warn but does not propagate — the audit row is
+    already written by the time we reach this helper, which is what
+    consumers needing forensic access read.
+
+    Returns True on successful write, False otherwise (so tests can assert
+    the side-effect path without parsing logs).
+    """
+    try:
+        from src.db import get_db
+        from src.knowledge_graph import DiscoveryNode
+        backend = get_db()
+
+        public = _build_public_payload(score)
+        node = DiscoveryNode(
+            id=_public_kg_node_id(parent_id, successor_id),
+            agent_id=successor_id,
+            type="trajectory_continuity_score",
+            summary=(
+                f"R1 lineage score: verdict={public['verdict']} "
+                f"calibration={public['calibration_status']} "
+                f"n_dims={public['n_dims_used']}"
+            ),
+            details=json.dumps(public),
+            tags=[
+                "r1",
+                "trajectory_continuity",
+                f"verdict:{public['verdict']}",
+                f"calibration:{public['calibration_status']}",
+            ],
+            severity="low",
+            status="open",
+        )
+        await backend.kg_add_discovery(node)
+        return True
+    except Exception as exc:
+        import logging
+        logging.getLogger(__name__).warning(
+            "[R1] public KG emission failed for score_id=%s parent=%s "
+            "successor=%s: %s",
+            score.score_id, parent_id[:8], successor_id[:8], exc,
+        )
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -269,6 +357,13 @@ async def score_trajectory_continuity(
             f"refusing to return a score whose audit anchor is absent "
             f"(v3.3-A join-key durability contract)."
         )
+
+    # v3.3-A public KG emission: redacted projection of the audit row,
+    # dedupe-by-pair via deterministic node id (v3.2-D). Fail-soft — audit
+    # is the durable record; this is the public observability surface.
+    await _emit_public_kg_node(
+        score, parent_id=claimed_parent_id, successor_id=successor_id,
+    )
 
     return score
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,6 +141,11 @@ def _isolate_db_backend(monkeypatch):
         "updated_at": None,
     }
     mock_backend.record_r1_score_audit.return_value = True
+    # R1 v3.3-A public KG emission target — `kg_add_discovery` is fired
+    # at the end of every score_trajectory_continuity call to publish the
+    # redacted public node. Returns None on the real path; AsyncMock
+    # leak-prevention requires an explicit stub.
+    mock_backend.kg_add_discovery.return_value = None
     # Audit/tool operations
     mock_backend.append_audit_event.return_value = True
     mock_backend.query_audit_events.return_value = []

--- a/tests/test_trajectory_continuity.py
+++ b/tests/test_trajectory_continuity.py
@@ -517,3 +517,149 @@ async def test_score_dataclass_internal_caller_surface_unchanged(mocked_db):
     for field in ("plausibility", "verdict", "observations", "components",
                   "reasons", "parent_mature", "score_id", "calibration_status"):
         assert hasattr(result, field), f"missing {field}"
+
+
+# ---------------------------------------------------------------------------
+# v3.3-A public KG emission (closes PR 2's deferred work)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_score_emits_public_kg_node_after_audit(mocked_db):
+    """Per v3.3-A: score_trajectory_continuity publishes a redacted node to
+    the public KG via `kg_add_discovery`, joined to the audit row by
+    score_id."""
+    import json
+    from src.identity.trajectory_continuity import score_trajectory_continuity
+
+    mocked_db.kg_add_discovery = AsyncMock(return_value=None)
+    parent, successor = synthetic_trajectory_pair(seed=60, kind="genuine")
+    mocked_db.reconstruct_eisv_series = AsyncMock(
+        side_effect=_stub_reconstruct(parent, successor)
+    )
+
+    score = await score_trajectory_continuity(
+        claimed_parent_id="parent-uuid",
+        successor_id="successor-uuid",
+    )
+
+    mocked_db.kg_add_discovery.assert_awaited_once()
+    # Inspect the DiscoveryNode that was passed
+    (node,), _kw = mocked_db.kg_add_discovery.call_args
+    assert node.type == "trajectory_continuity_score"
+    assert node.agent_id == "successor-uuid"
+    assert node.id.startswith("r1_score:")
+    # Strict redaction: details JSON has ONLY the four allowed fields
+    public = json.loads(node.details)
+    assert set(public.keys()) == {"verdict", "calibration_status", "n_dims_used", "score_id"}
+    assert public["score_id"] == score.score_id
+    assert public["verdict"] == score.verdict
+    # Tags are observability-only; they MAY duplicate verdict/calibration but
+    # the source-of-truth shape lives in `details`.
+    assert "r1" in node.tags
+    assert "trajectory_continuity" in node.tags
+
+
+@pytest.mark.asyncio
+async def test_score_kg_node_id_is_deterministic_per_pair(mocked_db):
+    """Per v3.2-D dedupe-by-pair: the node id MUST be deterministic from
+    (parent_id, successor_id). Re-scoring the same pair produces the same
+    id, so ON CONFLICT (id) DO UPDATE in `kg_add_discovery` overwrites
+    rather than appends."""
+    from src.identity.trajectory_continuity import score_trajectory_continuity
+
+    mocked_db.kg_add_discovery = AsyncMock(return_value=None)
+    parent, successor = synthetic_trajectory_pair(seed=61, kind="genuine")
+    mocked_db.reconstruct_eisv_series = AsyncMock(
+        side_effect=_stub_reconstruct(parent, successor)
+    )
+
+    await score_trajectory_continuity(
+        claimed_parent_id="parent-uuid", successor_id="successor-uuid",
+    )
+    await score_trajectory_continuity(
+        claimed_parent_id="parent-uuid", successor_id="successor-uuid",
+    )
+
+    assert mocked_db.kg_add_discovery.await_count == 2
+    first_id = mocked_db.kg_add_discovery.call_args_list[0][0][0].id
+    second_id = mocked_db.kg_add_discovery.call_args_list[1][0][0].id
+    assert first_id == second_id
+    # Each score has a fresh score_id (audit retains all); the node id is
+    # the dedupe key, NOT the score_id.
+    first_payload = mocked_db.kg_add_discovery.call_args_list[0][0][0].details
+    second_payload = mocked_db.kg_add_discovery.call_args_list[1][0][0].details
+    assert first_payload != second_payload  # score_id differs across calls
+
+
+@pytest.mark.asyncio
+async def test_score_kg_node_id_differs_across_pairs(mocked_db):
+    """Different (parent, successor) pairs must produce different node ids
+    so dedupe-by-pair is per-pair, not global."""
+    from src.identity.trajectory_continuity import score_trajectory_continuity
+
+    mocked_db.kg_add_discovery = AsyncMock(return_value=None)
+    parent, successor = synthetic_trajectory_pair(seed=62, kind="genuine")
+    mocked_db.reconstruct_eisv_series = AsyncMock(
+        side_effect=_stub_reconstruct(parent, successor)
+    )
+
+    await score_trajectory_continuity(
+        claimed_parent_id="parent-A", successor_id="successor-1",
+    )
+    await score_trajectory_continuity(
+        claimed_parent_id="parent-B", successor_id="successor-1",
+    )
+    await score_trajectory_continuity(
+        claimed_parent_id="parent-A", successor_id="successor-2",
+    )
+
+    ids = [
+        mocked_db.kg_add_discovery.call_args_list[i][0][0].id
+        for i in range(3)
+    ]
+    assert len(set(ids)) == 3, "expected 3 distinct node ids for 3 distinct pairs"
+
+
+@pytest.mark.asyncio
+async def test_score_kg_emission_failure_is_non_fatal(mocked_db):
+    """Per v3.3-A: audit is the durable record; KG is observability. A KG
+    emission failure MUST NOT propagate — the score still returns and the
+    audit row is durably written."""
+    from src.identity.trajectory_continuity import score_trajectory_continuity
+
+    mocked_db.kg_add_discovery = AsyncMock(side_effect=RuntimeError("kg pool down"))
+    parent, successor = synthetic_trajectory_pair(seed=63, kind="genuine")
+    mocked_db.reconstruct_eisv_series = AsyncMock(
+        side_effect=_stub_reconstruct(parent, successor)
+    )
+
+    # Must not raise
+    score = await score_trajectory_continuity(
+        claimed_parent_id="parent-uuid", successor_id="successor-uuid",
+    )
+
+    assert score is not None
+    # Audit was still attempted + persisted (record_r1_score_audit default True)
+    mocked_db.record_r1_score_audit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_score_kg_emission_skipped_when_audit_fails(mocked_db):
+    """Per v3.3-A join-key durability contract: if audit write fails, the
+    score primitive raises BEFORE KG emission — the public node must not
+    reference an absent audit row."""
+    from src.identity.trajectory_continuity import score_trajectory_continuity
+
+    mocked_db.record_r1_score_audit = AsyncMock(return_value=False)
+    mocked_db.kg_add_discovery = AsyncMock(return_value=None)
+    parent, successor = synthetic_trajectory_pair(seed=64, kind="genuine")
+    mocked_db.reconstruct_eisv_series = AsyncMock(
+        side_effect=_stub_reconstruct(parent, successor)
+    )
+
+    with pytest.raises(RuntimeError, match="audit write failed"):
+        await score_trajectory_continuity(
+            claimed_parent_id="parent-uuid", successor_id="successor-uuid",
+        )
+
+    mocked_db.kg_add_discovery.assert_not_awaited()


### PR DESCRIPTION
## Summary

Closes PR 2's deferred work: writes the v3.3-A redacted public payload to `knowledge.discoveries` after every successful score, with deterministic node id for v3.2-D dedupe-by-pair.

PR 2 (#309) commit explicitly named this as deferred: *"KG public emission (the actual write to AGE) deferred to PR 3 alongside consumer patches."* PR 3 (#314) stayed score-side. v3.3-I corrected the target from AGE to the PG-FTS knowledge graph (`knowledge.discoveries` via `kg_add_discovery`) and refuted the "MERGE primitive doesn't exist" flag by ground-truthing `ON CONFLICT (id) DO UPDATE` at `src/db/mixins/knowledge_graph.py:82`.

## Implementation

- **`_R1_KG_NAMESPACE`** — UUIDv5 derived from `NAMESPACE_OID + "unitares.r1.trajectory_continuity_score"`. Stable across processes.
- **`_public_kg_node_id(parent_id, successor_id)`** — deterministic id `f"r1_score:{uuid5(...)}"`. Prefix is self-describing in logs/queries; UUIDv5 suffix is the dedupe key.
- **`_emit_public_kg_node(score, parent_id, successor_id)`** — builds `DiscoveryNode` with `type="trajectory_continuity_score"`, `details=json.dumps(public_payload)`, observability tags. ON CONFLICT in the existing write path gives v3.2-D dedupe-by-pair: the N-th score overwrites the (N-1)-th for the same pair.
- **Wired** in `score_trajectory_continuity` AFTER audit write. Ordering: audit is fail-loud per v3.3-A join-key durability; emission is fail-soft observability. Audit-write failure raises BEFORE emission, so a public node never references an absent audit row.

## Test plan

- [x] Emits redacted node after audit — verifies type, agent_id, id prefix, details JSON shape (only `{verdict, calibration_status, n_dims_used, score_id}`), tags
- [x] Node id deterministic per pair (re-scoring same pair → same id, different details because `score_id` rolls)
- [x] Node id differs across distinct pairs (3 pairs → 3 distinct ids)
- [x] KG emission failure non-fatal (score returns; audit was still persisted)
- [x] KG emission skipped when audit fails (raises BEFORE emission per join-key durability)
- [ ] Smoke check on first live score post-merge — confirm `knowledge.discoveries` row appears with `id` prefixed `r1_score:`
- [ ] Spot-check dedupe in production — re-score the same pair, confirm only one row exists with the latest `score_id` in `details`

## Independence from #321

#321 (§4.1 onboard wiring) and this PR (§4.3 KG emission) both exercise `score_trajectory_continuity` but touch disjoint code paths:
- #321 wires the score into the onboard handler
- This adds the KG side-effect inside the score primitive itself

Both can land in either order. No rebase needed if the other lands first.

## What this PR does NOT do

- §4.2 remaining v3.3-D consumers (KG provenance S7, R3 baselines, dashboard) — separate PR
- 30-day TTL archival of public nodes (v3.2-D second clause — needs a partition-maintenance hook; deferred)
- Re-scoring at promotion or orphan paths (those call sites don't exist yet — §4 future work)

🤖 Drafted by Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDqDEzwQAsQ4DEHA136N7K)_