### PR TITLE
Drop EISV diamond from README hero

### DIFF
--- a/docs/assets/hero.svg
+++ b/docs/assets/hero.svg
@@ -44,43 +44,7 @@
   <rect width="900" height="280" rx="12" fill="url(#bg)"/>
   <rect width="900" height="280" rx="12" fill="none" stroke="#30363d" stroke-width="1"/>
 
-  <!-- EISV Network Visualization (right side) -->
-  <g transform="translate(660, 140)" filter="url(#soft-glow)">
-    <!-- Connection lines -->
-    <line x1="0" y1="-60" x2="-65" y2="20" stroke="#30363d" stroke-width="1.5" opacity="0.6"/>
-    <line x1="0" y1="-60" x2="65" y2="20" stroke="#30363d" stroke-width="1.5" opacity="0.6"/>
-    <line x1="-65" y1="20" x2="0" y2="70" stroke="#30363d" stroke-width="1.5" opacity="0.6"/>
-    <line x1="65" y1="20" x2="0" y2="70" stroke="#30363d" stroke-width="1.5" opacity="0.6"/>
-    <line x1="-65" y1="20" x2="65" y2="20" stroke="#30363d" stroke-width="1.5" opacity="0.4"/>
-    <line x1="0" y1="-60" x2="0" y2="70" stroke="#30363d" stroke-width="1.5" opacity="0.3"/>
-
-    <!-- Orbital ring -->
-    <ellipse cx="0" cy="10" rx="85" ry="75" fill="none" stroke="#30363d" stroke-width="0.5" opacity="0.3" stroke-dasharray="4 4"/>
-
-    <!-- E node (top) - Energy -->
-    <circle cx="0" cy="-60" r="18" fill="url(#node-e)" opacity="0.9" filter="url(#glow)"/>
-    <text x="0" y="-55" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="700" fill="#ffffff">E</text>
-
-    <!-- I node (left) - Information -->
-    <circle cx="-65" cy="20" r="18" fill="url(#node-i)" opacity="0.9" filter="url(#glow)"/>
-    <text x="-65" y="25" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="700" fill="#ffffff">I</text>
-
-    <!-- S node (right) - Entropy -->
-    <circle cx="65" cy="20" r="18" fill="url(#node-s)" opacity="0.9" filter="url(#glow)"/>
-    <text x="65" y="25" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="700" fill="#ffffff">S</text>
-
-    <!-- V node (bottom) - Valence -->
-    <circle cx="0" cy="70" r="18" fill="url(#node-v)" opacity="0.9" filter="url(#glow)"/>
-    <text x="0" y="75" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="700" fill="#ffffff">V</text>
-
-    <!-- Labels -->
-    <text x="0" y="-86" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#8b949e" letter-spacing="0.5">ENERGY</text>
-    <text x="-65" y="50" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#8b949e" letter-spacing="0.5">INTEGRITY</text>
-    <text x="65" y="50" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#8b949e" letter-spacing="0.5">ENTROPY</text>
-    <text x="0" y="100" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#8b949e" letter-spacing="0.5">VALENCE</text>
-  </g>
-
-  <!-- Text content (left side) -->
+  <!-- Text content -->
   <g transform="translate(60, 0)">
     <!-- UNITARES wordmark -->
     <text y="100" font-family="system-ui, -apple-system, sans-serif" font-size="42" font-weight="800" fill="#e6edf3" letter-spacing="3">UNITARES</text>


### PR DESCRIPTION
The hero SVG carried a prominent E/I/S/V diamond visualization on the right side. With the README front-matter polish in #323, EISV is now defined inline on first use as plain words ('energy, integrity, entropy, valence'). Showing the same vocabulary as a high-prominence visual mnemonic above the fold front-loads the acronym before the reader hits the inline definition.

Removes the diamond. The wordmark, tagline, and descriptor line carry the hero on their own — same trajectory as the CIRWEL profile header (which dropped its analogous diamond) and the cirwel.org homepage thesis (which dropped the vocabulary-stack from the §01 paragraph).