### PR TITLE
feat(governance): PR 3 — class-aware void threshold (RFC §7.13.6 interim safety net)

### DIFF
--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -4,7 +4,7 @@ All concrete decision points implemented - no placeholders!
 """
 
 from dataclasses import dataclass
-from typing import Dict, Tuple, Optional, List
+from typing import ClassVar, Dict, Tuple, Optional, List
 class _LazyNumpy:
     def __getattr__(self, name):
         import numpy
@@ -214,23 +214,59 @@ class GovernanceConfig:
     # Adaptive threshold using rolling statistics
     VOID_ADAPTIVE_WINDOW = 100     # Last N observations for statistics
     VOID_THRESHOLD_SIGMA = 2.0     # Threshold = mean + 2σ
-    
+
+    # Class-aware void thresholds (RFC v0.11 §7.13.6 PR 3 — interim safety net).
+    # Closes the void-pause path for resident-class agents BEFORE all residents
+    # have ported to lease-plane substrate_state (PRs 4-7). Sunsets at PR 8 per
+    # §7.13.6 once no resident remains in the monitor_decision pipeline.
+    #
+    # The 2026-05-01 Steward auto-pause incident showed V_ss ≈ 0.19 was
+    # mathematically inevitable given Steward's substrate sample shape — past
+    # the standard 0.15 INITIAL threshold, easily into the void_active path.
+    # 0.30 (= VOID_THRESHOLD_MAX) for residents widens the gate enough to clear
+    # the observed substrate-asymmetry baseline while still being a real bound.
+    #
+    # Class names match `src/grounding/class_indicator.py::classify_agent`
+    # output. KNOWN_RESIDENT_LABELS plus tag-derived `embodied` and
+    # `resident_persistent` get the wider threshold; everything else (default,
+    # ephemeral, engaged_ephemeral) keeps standard behavior.
+    VOID_THRESHOLD_BY_CLASS: ClassVar[dict[str, float]] = {
+        "Lumen": 0.30,
+        "Vigil": 0.30,
+        "Sentinel": 0.30,
+        "Watcher": 0.30,
+        "Steward": 0.30,
+        "Chronicler": 0.30,
+        "embodied": 0.30,
+        "resident_persistent": 0.30,
+    }
+
     @staticmethod
-    def get_void_threshold(history: np.ndarray, 
-                          adaptive: bool = True) -> float:
+    def get_void_threshold(history: np.ndarray,
+                          adaptive: bool = True,
+                          agent_class: str | None = None) -> float:
         """
         Computes void detection threshold.
-        
-        If adaptive=True:
-            threshold = mean(|V|) + 2σ(|V|) over last 100 observations
-        Else:
-            threshold = VOID_THRESHOLD_INITIAL
-            
-        Clamped to [VOID_THRESHOLD_MIN, VOID_THRESHOLD_MAX]
+
+        If `agent_class` is in VOID_THRESHOLD_BY_CLASS (RFC §7.13.6 PR 3),
+        returns the class-specific override regardless of `adaptive`. The
+        override is a fixed value — not adaptive — because the residents this
+        targets have substrate-state baseline asymmetries that the adaptive
+        window would never widen enough to accommodate. Future readers MUST
+        understand: this is interim safety pinned at PR 3, scheduled for
+        sunset at PR 8 once residents no longer flow through monitor_decision.
+
+        Otherwise falls back to existing behavior:
+        - adaptive=True: mean(|V|) + 2σ(|V|) over last 100 obs, clamped
+          to [VOID_THRESHOLD_MIN, VOID_THRESHOLD_MAX]
+        - adaptive=False: VOID_THRESHOLD_INITIAL
         """
+        if agent_class and agent_class in GovernanceConfig.VOID_THRESHOLD_BY_CLASS:
+            return GovernanceConfig.VOID_THRESHOLD_BY_CLASS[agent_class]
+
         if not adaptive or len(history) < 10:
             return GovernanceConfig.VOID_THRESHOLD_INITIAL
-        
+
         # Use last N observations
         recent = np.abs(history[-GovernanceConfig.VOID_ADAPTIVE_WINDOW:])
         recent = recent[~np.isnan(recent)]
@@ -238,16 +274,16 @@ class GovernanceConfig:
             return GovernanceConfig.VOID_THRESHOLD_INITIAL
         mean_V = np.mean(recent)
         std_V = np.std(recent)
-        
+
         threshold = mean_V + GovernanceConfig.VOID_THRESHOLD_SIGMA * std_V
-        
+
         # Clamp to safe range
         threshold = np.clip(
             threshold,
             GovernanceConfig.VOID_THRESHOLD_MIN,
             GovernanceConfig.VOID_THRESHOLD_MAX
         )
-        
+
         return threshold
     
     # =================================================================

--- a/src/governance_monitor.py
+++ b/src/governance_monitor.py
@@ -619,8 +619,63 @@ class UNITARESMonitor:
         self.state.update_count += 1
     
     def check_void_state(self) -> bool:
-        """Checks if system is in void state: |V| > threshold."""
-        return _check_void_state(self.state)
+        """Checks if system is in void state: |V| > threshold.
+
+        RFC §7.13.6 PR 3 (interim safety net): resolves agent class once per
+        monitor instance and passes it through so resident-class agents get
+        the wider VOID_THRESHOLD_BY_CLASS override. Lookup is cached on the
+        instance after first call. Failure to resolve is non-fatal — falls
+        back to the default adaptive threshold.
+
+        This wiring is scheduled for sunset at PR 8 once all residents have
+        ported to lease-plane substrate_state and no resident remains in
+        the monitor_decision pipeline.
+        """
+        if not hasattr(self, "_resolved_agent_class"):
+            self._resolved_agent_class = self._resolve_agent_class()
+        return _check_void_state(self.state, agent_class=self._resolved_agent_class)
+
+    def _resolve_agent_class(self):
+        """Best-effort lookup of this agent's class for void-threshold override.
+
+        Returns None on any failure so the void-threshold falls back to
+        adaptive default. Lookup is cached by `check_void_state` after first
+        call to amortize the cost across check cycles.
+
+        Resolution order:
+          1. `state.agent_class` if pre-populated by an upstream loader.
+          2. `agent_id` literal match against KNOWN_RESIDENT_LABELS — catches
+             residents constructed with a label string as agent_id.
+          3. Synthetic meta from `state.label`/`state.tags` if upstream loaders
+             populated those fields.
+
+        For PR 3 this is intentionally narrow — full DB-backed lookup is a
+        future wiring item. The hot path stays sync.
+        """
+        explicit = getattr(self.state, "agent_class", None)
+        if explicit:
+            return explicit
+
+        try:
+            from src.grounding.class_indicator import (
+                KNOWN_RESIDENT_LABELS,
+                classify_agent,
+            )
+        except Exception:
+            return None
+
+        if self.agent_id in KNOWN_RESIDENT_LABELS:
+            return self.agent_id
+
+        synthetic_meta = type("StateMeta", (), {
+            "label": getattr(self.state, "label", None),
+            "tags": getattr(self.state, "tags", None) or [],
+        })()
+        try:
+            cls = classify_agent(synthetic_meta)
+            return cls if cls != "default" else None
+        except Exception:
+            return None
 
     def _calculate_void_frequency(self) -> float:
         """Calculate void frequency from V history."""

--- a/src/monitor_void.py
+++ b/src/monitor_void.py
@@ -5,20 +5,33 @@ import numpy as np
 from config.governance_config import config
 
 
-def check_void_state(state) -> bool:
+def check_void_state(state, agent_class: str | None = None) -> bool:
     """
-    Check if system is in void state: |V| > adaptive threshold.
+    Check if system is in void state: |V| > adaptive (or class-overridden) threshold.
 
     Updates state.void_active in place.
 
     Args:
         state: GovernanceState instance with V, V_history, void_active attrs.
+        agent_class: Optional agent class name (per
+            `src/grounding/class_indicator.py::classify_agent`). When provided
+            AND in `GovernanceConfig.VOID_THRESHOLD_BY_CLASS`, returns the
+            class-specific override threshold (RFC v0.11 §7.13.6 PR 3 — interim
+            safety net). Default `None` preserves prior behavior.
+
+            For convenience, callers may also leave this None and populate
+            `state.agent_class` instead — this function reads `state.agent_class`
+            via `getattr` as a fallback.
 
     Returns:
         True if system is in void state.
     """
     V_history = np.array(state.V_history) if state.V_history else np.array([state.V])
-    threshold = config.get_void_threshold(V_history, adaptive=True)
+
+    # Resolution order: explicit kwarg → state attribute → None.
+    resolved_class = agent_class or getattr(state, "agent_class", None)
+
+    threshold = config.get_void_threshold(V_history, adaptive=True, agent_class=resolved_class)
 
     void_active = bool(abs(state.V) > threshold)
     state.void_active = void_active
@@ -26,15 +39,18 @@ def check_void_state(state) -> bool:
     return void_active
 
 
-def calculate_void_frequency(state) -> float:
+def calculate_void_frequency(state, agent_class: str | None = None) -> float:
     """
     Calculate void frequency from V history.
 
     Returns fraction of time system was in void state (|V| > threshold).
-    Uses adaptive threshold for each historical point.
+    Uses adaptive (or class-overridden) threshold for each historical point.
 
     Args:
         state: GovernanceState instance with V_history attr.
+        agent_class: Optional agent class name. Same semantics as in
+            `check_void_state` — class override applies if provided and
+            registered in VOID_THRESHOLD_BY_CLASS.
     """
     if not state.V_history or len(state.V_history) < 10:
         return 0.0
@@ -42,7 +58,8 @@ def calculate_void_frequency(state) -> float:
     window = min(100, len(state.V_history))
     recent_V = np.array(state.V_history[-window:])
 
-    threshold = config.get_void_threshold(recent_V, adaptive=True)
+    resolved_class = agent_class or getattr(state, "agent_class", None)
+    threshold = config.get_void_threshold(recent_V, adaptive=True, agent_class=resolved_class)
 
     void_count = np.sum(np.abs(recent_V) > threshold)
     return float(void_count) / len(recent_V)

--- a/tests/test_lease_plane_substrate_state.py
+++ b/tests/test_lease_plane_substrate_state.py
@@ -319,26 +319,37 @@ async def test_substrate_state_visible_in_select_after_renew():
         await conn.close()
 
 
-# (g) class-aware void-threshold test — parked, marked xfail-strict until PR 3
-@pytest.mark.xfail(
-    strict=True,
-    reason="gates on PR 3 (VOID_THRESHOLD_BY_CLASS class-aware monitor_void.check_void_state); "
-    "RFC §7.13.6 PR 3. xfail-strict will flip to pass when PR 3 lands.",
-)
-@pytest.mark.asyncio
-async def test_resident_class_exempted_from_void_threshold():
+# (g) class-aware void-threshold test — flipped to live by PR 3
+def test_resident_class_exempted_from_void_threshold():
     """§7.13 gate (g): a resident-class agent with V_ss = 0.19 does NOT trip
     check_void_state, while a non-resident agent at the same V_ss DOES trip it.
-    Confirms the PR 3 class-aware threshold lookup wires through correctly."""
-    # Parked: requires PR 3's VOID_THRESHOLD_BY_CLASS implementation.
-    # The test body below is the assertion shape that PR 3 must satisfy.
-    from src.config.governance_config import config  # noqa: F401  (PR 3 import)
+    Confirms the PR 3 class-aware threshold lookup wires through correctly.
 
-    # PR 3 expectations (test body sketched, will live or fail strictly when PR 3 lands):
-    # threshold_resident = config.get_void_threshold_by_class("resident", history)
-    # threshold_default = config.get_void_threshold_by_class("agent", history)
-    # assert threshold_resident > threshold_default
-    raise NotImplementedError("PR 3 not yet landed")
+    Originally parked as xfail(strict=True) waiting on PR 3's
+    VOID_THRESHOLD_BY_CLASS map landing. PR 3 ships with this lit up.
+    Detailed PR 3 unit tests live in tests/test_void_threshold_class_aware.py;
+    this gate is the §9-checklist contract pin showing the class lookup
+    threads through end-to-end from the §7.13 RFC perspective."""
+    import numpy as np
+
+    from config.governance_config import config
+
+    # Standard adaptive path with low-variance history clamps to MIN (0.10).
+    # The 2026-05-01 incident showed Steward V_ss ≈ 0.19, well past 0.15
+    # INITIAL — would trip the void_pause path. Resident override (0.30)
+    # clears it.
+    history = np.array([0.05] * 100)
+    threshold_default = config.get_void_threshold(history, adaptive=True)
+    threshold_resident = config.get_void_threshold(
+        history, adaptive=True, agent_class="Steward"
+    )
+    assert threshold_resident > threshold_default
+    assert threshold_resident == 0.30
+    assert 0.19 < threshold_resident, "Steward V_ss must clear resident threshold"
+    assert 0.19 > threshold_default, (
+        "Steward V_ss must trip the default threshold — the whole point of the "
+        "interim safety net is the gap between these two"
+    )
 
 
 # (h) reader-side: degraded status with NULL last_healthy_observed_at handled

--- a/tests/test_void_threshold_class_aware.py
+++ b/tests/test_void_threshold_class_aware.py
@@ -1,0 +1,217 @@
+"""§7.13.6 PR 3 — class-aware void threshold (interim safety net).
+
+Pins the API surface added by PR 3:
+
+  - `config.get_void_threshold(history, adaptive=True, agent_class=None)`
+    returns the class-specific override when agent_class is in
+    VOID_THRESHOLD_BY_CLASS, else the existing adaptive/default behavior.
+
+  - `monitor_void.check_void_state(state, agent_class=None)` threads
+    agent_class through. Reads `state.agent_class` as a fallback.
+
+  - `governance_monitor.check_void_state` resolves the agent class lazily
+    via `_resolve_agent_class` and caches it. Defends against failures so
+    behavior degrades to default — never raises.
+
+The interim safety net's job: a resident-class agent with V_ss = 0.19 does
+NOT trip check_void_state, while a non-resident at the same V_ss DOES trip.
+0.19 = the live-measured Steward V_ss from the 2026-05-01 incident memory
+(`project_steward-paused.md`). 0.30 (the resident override) clears it;
+0.15 (default INITIAL) does not.
+
+Spec: docs/proposals/surface-lease-plane-v0.md §7.13.6 PR 3
+      memory: project_steward-paused.md
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from config.governance_config import config  # noqa: E402
+from src.monitor_void import check_void_state  # noqa: E402
+
+
+# ---------- get_void_threshold direct tests ----------
+
+
+def test_get_void_threshold_no_agent_class_uses_adaptive_default():
+    """No agent_class kwarg → existing adaptive behavior unchanged."""
+    history = np.array([0.05] * 100)
+    threshold = config.get_void_threshold(history, adaptive=True)
+    # Adaptive threshold for low-variance history clamps to MIN.
+    assert threshold == config.VOID_THRESHOLD_MIN
+
+
+def test_get_void_threshold_resident_class_returns_override():
+    """Each known resident class returns 0.30 regardless of history shape."""
+    history = np.array([0.05] * 100)
+    for cls in (
+        "Lumen", "Vigil", "Sentinel", "Watcher", "Steward", "Chronicler",
+        "embodied", "resident_persistent",
+    ):
+        threshold = config.get_void_threshold(history, adaptive=True, agent_class=cls)
+        assert threshold == 0.30, f"class {cls!r} should override to 0.30"
+
+
+def test_get_void_threshold_unknown_class_falls_through_to_adaptive():
+    """An agent_class not in VOID_THRESHOLD_BY_CLASS doesn't override."""
+    history = np.array([0.05] * 100)
+    threshold = config.get_void_threshold(history, adaptive=True, agent_class="default")
+    assert threshold == config.VOID_THRESHOLD_MIN  # adaptive path took over
+
+    threshold_eph = config.get_void_threshold(history, adaptive=True, agent_class="ephemeral")
+    assert threshold_eph == config.VOID_THRESHOLD_MIN
+
+
+def test_get_void_threshold_override_ignores_adaptive_flag():
+    """The class override returns the per-class value even when adaptive=False —
+    the override is intentional, not derived from the adaptive window."""
+    history = np.array([0.05] * 100)
+    assert config.get_void_threshold(history, adaptive=False, agent_class="Steward") == 0.30
+
+
+# ---------- check_void_state integration ----------
+
+
+class _FakeState:
+    """Minimal duck-type for monitor_void.check_void_state."""
+
+    def __init__(self, V: float, V_history: list[float] | None = None,
+                 agent_class: str | None = None):
+        self.V = V
+        self.V_history = V_history if V_history is not None else [V]
+        self.void_active = False
+        if agent_class is not None:
+            self.agent_class = agent_class
+
+
+def test_check_void_state_resident_class_kwarg_at_steward_v_ss_does_not_trip():
+    """The 2026-05-01 incident: Steward V_ss = 0.19 tripped void_active under the
+    standard 0.15 threshold. With agent_class='Steward' the threshold becomes
+    0.30 — V_ss = 0.19 no longer trips."""
+    state = _FakeState(V=0.19)
+    void = check_void_state(state, agent_class="Steward")
+    assert void is False
+    assert state.void_active is False
+
+
+def test_check_void_state_default_at_steward_v_ss_does_trip():
+    """Same V_ss without the class kwarg — proves the override is what
+    flips the outcome, not a baseline change."""
+    state = _FakeState(V=0.19)
+    void = check_void_state(state)  # no agent_class
+    assert void is True
+    assert state.void_active is True
+
+
+def test_check_void_state_resident_class_via_state_attribute_also_works():
+    """Per the resolution order in monitor_void: kwarg → state.agent_class → None.
+    Populating state.agent_class is equivalent to passing the kwarg."""
+    state = _FakeState(V=0.19, agent_class="Sentinel")
+    void = check_void_state(state)  # no kwarg
+    assert void is False
+
+
+def test_check_void_state_kwarg_takes_precedence_over_state_attribute():
+    """kwarg wins. State carries 'default' (no override); kwarg passes
+    'Steward'. Should use the resident threshold, not fall through."""
+    state = _FakeState(V=0.19, agent_class="default")
+    void = check_void_state(state, agent_class="Steward")
+    assert void is False
+
+
+def test_check_void_state_extreme_v_still_trips_for_resident():
+    """The override widens the threshold but doesn't disable it. V well past
+    0.30 still trips even for residents — the safety net is widening, not
+    removal."""
+    state = _FakeState(V=0.5)
+    void = check_void_state(state, agent_class="Steward")
+    assert void is True
+
+
+# ---------- governance_monitor wrapper integration ----------
+
+
+def test_governance_monitor_resolves_resident_agent_id_to_class():
+    """When agent_id is literally 'Steward' (the historical pattern for some
+    in-process residents), governance_monitor's _resolve_agent_class finds
+    it via the KNOWN_RESIDENT_LABELS short-circuit."""
+    from src.governance_monitor import UNITARESMonitor
+
+    monitor = UNITARESMonitor(agent_id="Steward", load_state=False)
+    resolved = monitor._resolve_agent_class()
+    assert resolved == "Steward"
+
+
+def test_governance_monitor_resolves_non_resident_to_none():
+    """Plain UUID / unrecognized agent_id with no state.agent_class → returns
+    None, which leaves the threshold on its default adaptive path."""
+    from src.governance_monitor import UNITARESMonitor
+
+    monitor = UNITARESMonitor(agent_id="abcdefab-cdef-4abc-8def-abcdefabcdef",
+                                load_state=False)
+    resolved = monitor._resolve_agent_class()
+    assert resolved is None
+
+
+def test_governance_monitor_state_agent_class_takes_precedence():
+    """If upstream loaders populate state.agent_class, that wins over the
+    agent_id-label fallback. Lets the real production wiring opt in to a
+    class without relying on agent_id == label."""
+    from src.governance_monitor import UNITARESMonitor
+
+    monitor = UNITARESMonitor(agent_id="some-uuid", load_state=False)
+    monitor.state.agent_class = "Vigil"
+    resolved = monitor._resolve_agent_class()
+    assert resolved == "Vigil"
+
+
+def test_governance_monitor_caches_resolved_class():
+    """_resolve_agent_class is called once and cached on the instance — the
+    hot path of check_void_state shouldn't re-import / re-derive each cycle."""
+    from src.governance_monitor import UNITARESMonitor
+
+    monitor = UNITARESMonitor(agent_id="Steward", load_state=False)
+    # GovernanceState's E/I/S/V are read-only properties backed by
+    # unitaires_state — set V via the underlying state directly. Keeping the
+    # test surgical (we're testing _resolve_agent_class caching, not the
+    # state-mutation API).
+    monitor.state.unitaires_state.V = 0.19
+    monitor.state.V_history = [0.19]
+    monitor.check_void_state()
+    assert monitor._resolved_agent_class == "Steward"
+    # Second call uses cache: changing agent_id post-init doesn't re-resolve.
+    monitor.agent_id = "DifferentName"
+    assert monitor._resolved_agent_class == "Steward"
+
+
+def test_governance_monitor_check_void_state_residents_exempt_at_steward_v_ss():
+    """End-to-end: a Steward-ish monitor instance with V_ss = 0.19 doesn't
+    trip void_active — the API surface ties through correctly."""
+    from src.governance_monitor import UNITARESMonitor
+
+    monitor = UNITARESMonitor(agent_id="Steward", load_state=False)
+    monitor.state.unitaires_state.V = 0.19
+    monitor.state.V_history = [0.19]
+    void = monitor.check_void_state()
+    assert void is False
+    assert monitor.state.void_active is False
+
+
+def test_governance_monitor_check_void_state_non_resident_trips_at_same_v_ss():
+    """Control: non-resident monitor at the same V_ss DOES trip."""
+    from src.governance_monitor import UNITARESMonitor
+
+    monitor = UNITARESMonitor(agent_id="abc-not-a-resident", load_state=False)
+    monitor.state.unitaires_state.V = 0.19
+    monitor.state.V_history = [0.19]
+    void = monitor.check_void_state()
+    assert void is True
+    assert monitor.state.void_active is True


### PR DESCRIPTION
## Summary

PR 3 of the §7.13 implementation arc. **Interim safety net** — closes the void-pause path for resident-class agents BEFORE all residents have ported to lease-plane substrate_state (PRs 4–7). Sunsets at PR 8 per RFC §7.13.6 once no resident remains in the `monitor_decision` pipeline.

Stack status: PR #319 (RFC), #322 (PR 1), unitares-pi-plugin#4 (PR 2 Steward port) all merged today. **This PR completes PR 3 of the arc.** PRs 4–7 (remaining residents port — Watcher, Sentinel, Vigil, Chronicler) and PR 8 (cleanup + sunset of this PR) remain.

## Why

The 2026-05-01 Steward auto-pause incident showed V_ss ≈ 0.19 was mathematically inevitable given Steward's substrate sample shape — past the standard 0.15 INITIAL threshold, easily into `monitor_decision.py:94` Priority 2 `void_active → pause`. PR 3 widens the threshold to 0.30 (= `VOID_THRESHOLD_MAX`) for resident-class agents while leaving non-residents on the existing adaptive path. Residents stop tripping `void_pause` until they migrate to substrate_state via PRs 4–8.

## What landed

### `config/governance_config.py`
- **`VOID_THRESHOLD_BY_CLASS`** map: KNOWN_RESIDENT_LABELS (Lumen/Vigil/Sentinel/Watcher/Steward/Chronicler) + `embodied` + `resident_persistent` all map to 0.30. Class names match `src/grounding/class_indicator.py::classify_agent` output.
- **`get_void_threshold(history, adaptive=True, agent_class=None)`** gains optional `agent_class` kwarg. When the class is in the map, returns the per-class override regardless of `adaptive` — the override is intentional, not derived from the adaptive window.

### `src/monitor_void.py`
- **`check_void_state(state, agent_class=None)`** and `calculate_void_frequency` same. Resolution order: explicit kwarg → `state.agent_class` → None.

### `src/governance_monitor.py`
- **`UNITARESMonitor.check_void_state`** lazy-resolves agent class via `_resolve_agent_class` (cached). Resolution fallbacks: `state.agent_class` → `agent_id` literal in KNOWN_RESIDENT_LABELS → synthetic-meta `classify_agent` → None. All failure modes degrade to None (default behavior, never raise).

### `tests/test_void_threshold_class_aware.py` (new, 15 tests)

| coverage | tests |
|---|---|
| `get_void_threshold` direct | no class→adaptive default, resident class→0.30, unknown class→fallthrough, override-ignores-adaptive-flag |
| `check_void_state` integration | kwarg path, state.agent_class fallback, kwarg-precedence, extreme-V-still-trips |
| `governance_monitor` wrapper | agent_id literal match, plain UUID→None, state.agent_class precedence, caching, end-to-end at Steward V_ss |

### PR 1 parked gate (g) flipped (`tests/test_lease_plane_substrate_state.py`)

Was `pytest.mark.xfail(strict=True, reason="gates on PR 3")` raising NotImplementedError. Now lit up: Steward V_ss = 0.19 clears resident threshold (0.30) but trips default threshold (0.10 adaptive floor) — the safety-net gap is the whole point.

## Test plan

- [x] `./scripts/dev/test-cache.sh` — Python: **4641 passed, 29 skipped** + 1 pre-existing master failure (`test_release_rejects_forced_reason_on_release_endpoint` from PR #313 — bearer-auth issue, NOT caused by this PR; documented in PR #319)
- [x] 16 new tests pass (15 in `test_void_threshold_class_aware.py` + 1 flipped gate (g))
- [x] Pre-push smoke: 138 passed
- [x] No production behavior change for non-resident agents (default fallback path unchanged)

## Sunset

Per RFC §7.13.6 architect N1: this PR's class-aware threshold logic **SHALL be removed in PR 8** once all residents are emitting `substrate_state` via the lease plane and no resident remains in the `monitor_decision` pipeline. Carrying it indefinitely encodes "residents have a different threshold for the same broken pipeline" as if that were the bug — the bug was the mapping, not the threshold. **Add removal-of-this-PR to the PR 8 checklist.**

🤖 Implements RFC §7.13.6 PR 3 per the §7.13.6 implementation arc.