### PR TITLE
fix(lease-plane): route renew/3 with substrate through Repo, not LeaseHolder fast-path

### DIFF
--- a/elixir/lease_plane/lib/unitares_lease_plane.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane.ex
@@ -53,16 +53,28 @@ defmodule UnitaresLeasePlane do
   @spec renew(binary()) :: :ok | {:error, term()}
   @spec renew(binary(), map() | nil, DateTime.t() | nil) :: :ok | {:error, term()}
   def renew(lease_id, substrate_state \\ nil, substrate_observed_at \\ nil) do
-    case LeaseSupervisor.holder_for(lease_id) do
-      {:ok, pid} ->
-        # local_beam holder: substrate path not wired (PR 1 scope is
-        # remote_heartbeat-via-Repo). LeaseHolder.renew/1 ignores substrate
-        # arguments. RFC §7.13 PR 1 explicitly does not extend the local_beam
-        # path; future PRs will if a local_beam resident appears.
-        LeaseHolder.renew(pid)
-
-      :error ->
-        Repo.renew(lease_id, substrate_state, substrate_observed_at)
+    # When the caller supplies substrate fields, route through Repo.renew/3
+    # unconditionally — LeaseHolder.renew/1 has no path for substrate, and
+    # silently dropping substrate updates was a real bug caught by the
+    # 2026-05-04 canary smoke test (200 OK from renew but DB unchanged).
+    # The HTTP /v1/lease/acquire endpoint always spawns a local_beam holder
+    # via UnitaresLeasePlane.acquire_local_beam (per http_router.ex:70), so
+    # ALL HTTP-acquired leases (including SDK-emitted resident substrate
+    # updates from PR #330) hit the LeaseSupervisor.holder_for fast-path
+    # below and would otherwise drop substrate writes silently.
+    #
+    # The fast-path through LeaseHolder.renew remains for substrate-less
+    # renews — they extend expires_at via the holder's in-process timer
+    # logic rather than via a fresh DB UPDATE. Once all residents have
+    # ported and PR 8's call sites all carry substrate, the fast-path is
+    # dead code that the final cleanup PR can remove.
+    if not is_nil(substrate_state) or not is_nil(substrate_observed_at) do
+      Repo.renew(lease_id, substrate_state, substrate_observed_at)
+    else
+      case LeaseSupervisor.holder_for(lease_id) do
+        {:ok, pid} -> LeaseHolder.renew(pid)
+        :error -> Repo.renew(lease_id)
+      end
     end
   end
 

--- a/elixir/lease_plane/test/unitares_lease_plane_test.exs
+++ b/elixir/lease_plane/test/unitares_lease_plane_test.exs
@@ -133,6 +133,67 @@ defmodule UnitaresLeasePlaneTest do
 
       assert {:error, :not_found} = Repo.renew(lease.lease_id)
     end
+
+    test "renew/3 with substrate persists for local_beam-held leases (regression for 2026-05-04 canary)" do
+      # Bug caught by canary smoke test post-PR-322: HTTP /v1/lease/acquire
+      # always spawns a local_beam holder via acquire_local_beam, so every
+      # SDK-emitted resident substrate update hits LeaseSupervisor.holder_for
+      # and would dispatch to LeaseHolder.renew/1 — which has no substrate
+      # path. The substrate update was silently dropped (200 OK from renew,
+      # but DB unchanged). This test pins the fix: when substrate is
+      # provided, renew/3 routes through Repo.renew/3 unconditionally.
+      #
+      # Uses a fresh resident:/ surface (not ctx.surface, which is dialectic:/
+      # via the LeaseTestHelpers default) because migration-034's
+      # substrate_state_only_on_resident_kind CHECK forbids substrate writes
+      # on non-resident leases.
+      surface = "resident:/test_elixir_substrate_renew_#{:erlang.unique_integer([:positive])}"
+      on_exit(fn -> cleanup_surface(surface) end)
+
+      params = local_beam_params(surface, ttl_s: 60)
+      assert {:ok, _lease, :new} = UnitaresLeasePlane.acquire_local_beam(params)
+
+      {:ok, before} = UnitaresLeasePlane.status(surface)
+      assert before.substrate_state == nil
+      assert before.substrate_state_observed_at == nil
+
+      observed_at = DateTime.utc_now()
+      assert :ok =
+               UnitaresLeasePlane.renew(
+                 before.lease_id,
+                 %{
+                   "E" => 0.7,
+                   "I" => 0.3,
+                   "S" => 0.1,
+                   "V" => 0.4,
+                   "sensor" => %{"status" => "degraded"}
+                 },
+                 observed_at
+               )
+
+      {:ok, after_renew} = UnitaresLeasePlane.status(surface)
+      assert after_renew.substrate_state["E"] == 0.7
+      assert after_renew.substrate_state["sensor"]["status"] == "degraded"
+      assert DateTime.compare(after_renew.substrate_state_observed_at, observed_at) == :eq
+    end
+
+    test "renew/3 without substrate keeps fast-path (LeaseHolder.renew unchanged)", ctx do
+      # Sibling test to the regression above. Substrate-less renews continue
+      # to use the LeaseHolder fast-path so the existing in-process timer
+      # logic stays in effect — the fix only re-routes when substrate is
+      # provided.
+      params = local_beam_params(ctx.surface, ttl_s: 60)
+      assert {:ok, lease, :new} = UnitaresLeasePlane.acquire_local_beam(params)
+      original_expiry = lease.expires_at
+
+      Process.sleep(1100)
+      assert :ok = UnitaresLeasePlane.renew(lease.lease_id)
+
+      {:ok, refreshed} = UnitaresLeasePlane.status(ctx.surface)
+      assert DateTime.compare(refreshed.expires_at, original_expiry) == :gt
+      # Substrate stays nil — substrate-less renew doesn't write substrate columns.
+      assert refreshed.substrate_state == nil
+    end
   end
 
   describe "handoff" do


### PR DESCRIPTION
## Summary

**Real production bug caught by the 2026-05-04 canary smoke test.** PR #322's `renew/3` dispatched to `LeaseHolder.renew(pid)` for any lease with an in-process holder, but `LeaseHolder.renew/1` has no substrate path — substrate updates were silently dropped.

The HTTP `/v1/lease/acquire` endpoint always spawns a local_beam holder via `acquire_local_beam` (per `http_router.ex:70`), so **every** HTTP-acquired lease (Steward's substrate emission from PR pi-plugin#4 AND all SDK-emitted resident substrate updates from PR #330) hit this fast-path and lost its substrate write.

**Symptom:** renew returns 200 OK; `substrate_state` column unchanged in DB.

## Why this matters now

Was about to bite Steward's canary on unpause. PR pi-plugin#5's `AUDIT_EISV_SYNC_ENABLED_RESIDENTS` gate would have been flipped to remove "steward" after the §7.13.4 canary criterion was met — but **the criterion would never have been met** because `substrate_state` column would have been stuck on whatever Steward wrote at acquire time (`sensor.status: healthy`, EISV from first sync), never updating across the 7-day window. The §7.13.4 stddev(V) ≥ 0.005 criterion specifically needs variation across the window.

## Fix

When `substrate_state` or `substrate_observed_at` is non-nil, route through `Repo.renew/3` unconditionally — bypassing `LeaseSupervisor.holder_for`. The fast-path through `LeaseHolder.renew` remains for substrate-less renews (extends `expires_at` via the holder's in-process timer rather than a fresh DB UPDATE).

```elixir
def renew(lease_id, substrate_state \\ nil, substrate_observed_at \\ nil) do
  if not is_nil(substrate_state) or not is_nil(substrate_observed_at) do
    Repo.renew(lease_id, substrate_state, substrate_observed_at)
  else
    case LeaseSupervisor.holder_for(lease_id) do
      {:ok, pid} -> LeaseHolder.renew(pid)
      :error -> Repo.renew(lease_id)
    end
  end
end
```

## Smoke test sequence

**Before fix:**
```
acquire(substrate={E:0.5, status:healthy}) → row inserted ✓
renew(substrate={E:0.7, status:degraded})  → 200 OK
SELECT substrate_state                      → {E:0.5, status:healthy}  BUG
```

**After fix:**
```
acquire(substrate={E:0.5, status:healthy}) → row inserted ✓
renew(substrate={E:0.7, status:degraded})  → 200 OK
SELECT substrate_state                      → {E:0.7, status:degraded}  ✓
```

## Tests

- Elixir suite: **11 properties + 128 tests, 0 failures** (added 2 regression tests under `describe "renew/1"`):
  - `renew/3 with substrate persists for local_beam-held leases (regression for 2026-05-04 canary)` — pins the fix
  - `renew/3 without substrate keeps fast-path` — pins the un-touched path
- Pre-push smoke: 138 passed
- Live verification: hot-patched the running lease plane (`launchctl kickstart -k`) and re-ran the canary smoke test inline; substrate now persists end-to-end

## Operational steps

1. Merge this PR
2. Restart the running lease plane: `launchctl kickstart -k gui/$(id -u)/com.unitares.lease-plane` — already done in this session for verification
3. Smoke-test once more before unpausing Steward (commands in PR body of #322 / live-verifier doc)

## Related

- PR #322 (PR 1) introduced the bug
- Caught by the 2026-05-04 canary smoke test that this session ran post-restart per the operator's "do we need to reboot server?" check
- Per CLAUDE.md `feedback_post-deploy-verify-fleet-wire-ins.md`: "restart + canary, mocked-DB tests miss silent drift" — exactly this pattern. The Elixir test suite passed because tests called `Repo.renew/3` directly; only the HTTP path through the public `UnitaresLeasePlane.renew/3` exercised the buggy fast-path
