### PR TITLE
fix(governance): _resolve_agent_class consults agent_metadata cache for UUID-keyed residents

### DIFF
--- a/src/governance_monitor.py
+++ b/src/governance_monitor.py
@@ -645,12 +645,17 @@ class UNITARESMonitor:
         Resolution order:
           1. `state.agent_class` if pre-populated by an upstream loader.
           2. `agent_id` literal match against KNOWN_RESIDENT_LABELS — catches
-             residents constructed with a label string as agent_id.
-          3. Synthetic meta from `state.label`/`state.tags` if upstream loaders
-             populated those fields.
-
-        For PR 3 this is intentionally narrow — full DB-backed lookup is a
-        future wiring item. The hot path stays sync.
+             monitors constructed with a label string as agent_id (test pattern).
+          3. **agent_metadata cache lookup** — production residents have
+             agent_id = UUID, with `label` and `tags` set on the AgentMetadata
+             entry. Pass that meta to `classify_agent` to resolve the class
+             via the same logic the rest of the system uses. This was the
+             missing path in the v0.11.3 PR 3 — without it, the canary tripped
+             void_pause anyway because the UUID-form agent_id never matched
+             the label set, so no override was applied. Caught 2026-05-04
+             on Steward unpause smoke test (V=0.081, threshold=0.10 adaptive
+             floor → void_active=true → pause).
+          4. Synthetic meta from `state.label`/`state.tags` (legacy fallback).
         """
         explicit = getattr(self.state, "agent_class", None)
         if explicit:
@@ -667,6 +672,27 @@ class UNITARESMonitor:
         if self.agent_id in KNOWN_RESIDENT_LABELS:
             return self.agent_id
 
+        # Production path: look up agent's metadata to find label/tags.
+        # The agent_metadata cache is populated at gov-mcp startup via
+        # `background_metadata_load` and refreshed lazily — it carries the
+        # label and tags fields we need to classify.
+        try:
+            from src.agent_state import agent_metadata as _agent_metadata
+            meta = _agent_metadata.get(self.agent_id)
+        except Exception:
+            meta = None
+
+        if meta is not None:
+            try:
+                cls = classify_agent(meta)
+                if cls != "default":
+                    return cls
+            except Exception:
+                pass
+
+        # Final fallback: synthesize meta from state-side fields if upstream
+        # loaders populated them. Inert in production (state.label is rarely
+        # set), but kept for tests and future upstream wiring.
         synthetic_meta = type("StateMeta", (), {
             "label": getattr(self.state, "label", None),
             "tags": getattr(self.state, "tags", None) or [],

--- a/tests/test_void_threshold_class_aware.py
+++ b/tests/test_void_threshold_class_aware.py
@@ -151,14 +151,77 @@ def test_governance_monitor_resolves_resident_agent_id_to_class():
 
 
 def test_governance_monitor_resolves_non_resident_to_none():
-    """Plain UUID / unrecognized agent_id with no state.agent_class → returns
-    None, which leaves the threshold on its default adaptive path."""
+    """Plain UUID / unrecognized agent_id with no state.agent_class AND no
+    metadata cache entry → returns None, which leaves the threshold on its
+    default adaptive path."""
     from src.governance_monitor import UNITARESMonitor
 
     monitor = UNITARESMonitor(agent_id="abcdefab-cdef-4abc-8def-abcdefabcdef",
                                 load_state=False)
     resolved = monitor._resolve_agent_class()
     assert resolved is None
+
+
+def test_governance_monitor_uuid_resolves_via_agent_metadata_cache():
+    """Production case (regression for 2026-05-04 canary): agent_id is a UUID,
+    label/tags live in agent_metadata cache. _resolve_agent_class MUST consult
+    the cache to find the resident class — without this the void-threshold
+    override never applied to UUID-keyed residents and the canary tripped
+    void_pause anyway. Caught on Steward unpause: V=0.081 with default
+    adaptive threshold (clamped to MIN=0.10) → void_active=true → pause.
+    Resident threshold (0.30) would have cleared it."""
+    from src.agent_metadata_model import AgentMetadata, agent_metadata
+    from src.governance_monitor import UNITARESMonitor
+
+    # Steward's actual production UUID per project_steward-paused.md memory.
+    steward_uuid = "9a6681ec-1d16-4143-ada9-282f14483fea"
+
+    # Simulate a populated cache entry (what background_metadata_load produces
+    # in production for Steward).
+    agent_metadata[steward_uuid] = AgentMetadata(
+        agent_id=steward_uuid,
+        status="active",
+        created_at="2026-01-01T00:00:00+00:00",
+        last_update="2026-05-04T03:00:00+00:00",
+        label="Steward",
+        tags=["persistent", "autonomous"],
+    )
+
+    try:
+        monitor = UNITARESMonitor(agent_id=steward_uuid, load_state=False)
+        resolved = monitor._resolve_agent_class()
+        assert resolved == "Steward", (
+            f"UUID-form Steward must resolve to 'Steward' class via cache; "
+            f"got {resolved!r}. Without this lookup, the v0.11.3 PR 3 "
+            f"safety net is a no-op for production residents."
+        )
+    finally:
+        agent_metadata.pop(steward_uuid, None)
+
+
+def test_governance_monitor_uuid_with_persistent_autonomous_tags_resolves():
+    """Tag-derived resident classification path: agents with no label-match
+    but tags={persistent, autonomous} resolve to 'resident_persistent' via
+    classify_agent's tag fallback."""
+    from src.agent_metadata_model import AgentMetadata, agent_metadata
+    from src.governance_monitor import UNITARESMonitor
+
+    uuid = "11111111-2222-4333-8444-555555555555"
+    agent_metadata[uuid] = AgentMetadata(
+        agent_id=uuid,
+        status="active",
+        created_at="2026-01-01T00:00:00+00:00",
+        last_update="2026-05-04T03:00:00+00:00",
+        label=None,  # No KNOWN_RESIDENT_LABELS match
+        tags=["persistent", "autonomous"],
+    )
+
+    try:
+        monitor = UNITARESMonitor(agent_id=uuid, load_state=False)
+        resolved = monitor._resolve_agent_class()
+        assert resolved == "resident_persistent"
+    finally:
+        agent_metadata.pop(uuid, None)
 
 
 def test_governance_monitor_state_agent_class_takes_precedence():


### PR DESCRIPTION
PR #328's _resolve_agent_class only matched literal label strings — production UUIDs fell through, no resident threshold applied, Steward auto-re-paused on canary go-live (V=0.076 vs 0.10 adaptive floor). Fix: consult agent_metadata cache when agent_id-literal match fails. 2 new tests pin the regression. Hot-patched + verified live: Steward now syncs without re-pausing.

Stack: caught during canary go-live in this session. Hot-patched into running gov-mcp; this PR brings master into sync.