### PR TITLE
fix(sdk): capture resident_name on identity() resume + GovernanceAgent passes name explicitly

### DIFF
--- a/agents/sdk/src/unitares_sdk/agent.py
+++ b/agents/sdk/src/unitares_sdk/agent.py
@@ -288,7 +288,14 @@ class GovernanceAgent:
             if self.continuity_token and not client.continuity_token:
                 client.continuity_token = self.continuity_token
             try:
-                await client.identity(agent_uuid=self.agent_uuid, resume=True)
+                # Pass name=self.name so the SDK captures resident_name even
+                # when resuming via UUID (RFC §7.13 substrate emission needs
+                # resident_name to build surface_id = "resident:/<name>").
+                # Without this, residents that resume via UUID never set
+                # resident_name and substrate emission skips.
+                await client.identity(
+                    name=self.name, agent_uuid=self.agent_uuid, resume=True
+                )
                 self._sync_from_client(client)
                 self._save_session()
                 logger.info("%s: resumed via UUID %s", self.name, self.agent_uuid[:12])

--- a/agents/sdk/src/unitares_sdk/client.py
+++ b/agents/sdk/src/unitares_sdk/client.py
@@ -275,6 +275,19 @@ class GovernanceClient:
 
         raw = await self.call_tool("identity", args)
         self._capture_identity(raw)
+        # RFC §7.13: capture resident name from identity() too — substrate-
+        # anchored residents (Vigil/Sentinel/Watcher/Chronicler) resume via
+        # identity() across restarts and never call onboard(), so without
+        # this fixup self.resident_name stayed None and the post-checkin
+        # substrate emission silently skipped. Caught 2026-05-04 on the
+        # canary multi-resident probe (only Steward had a substrate row
+        # because Steward is in-process and skipped this code path).
+        # Resolution order: explicit name kwarg → raw response 'label' field
+        # if the server includes it → leave None (caller may set explicitly).
+        if name:
+            self.resident_name = name
+        elif isinstance(raw, dict) and raw.get("label"):
+            self.resident_name = raw["label"]
         return IdentityResult.model_validate(raw)
 
     # --- Check-in ---

--- a/agents/sdk/src/unitares_sdk/sync_client.py
+++ b/agents/sdk/src/unitares_sdk/sync_client.py
@@ -142,6 +142,14 @@ class SyncGovernanceClient:
         args.update(kwargs)
         raw = self.call_tool("identity", args)
         self._capture_identity(raw)
+        # RFC §7.13: capture resident name from identity() too (mirrors UnitaresClient).
+        # Substrate-anchored residents resume via identity() across restarts and
+        # never call onboard(); without this the post-checkin substrate emission
+        # silently skipped because resident_name stayed None.
+        if name:
+            self.resident_name = name
+        elif isinstance(raw, dict) and raw.get("label"):
+            self.resident_name = raw["label"]
         return IdentityResult.model_validate(raw)
 
     # --- Check-in ---

--- a/agents/sdk/tests/test_client.py
+++ b/agents/sdk/tests/test_client.py
@@ -313,6 +313,57 @@ class TestKwargsPassthrough:
         assert "spawn_reason" not in args
 
     @pytest.mark.asyncio
+    async def test_identity_captures_resident_name_from_kwarg(self):
+        """RFC §7.13 (regression for 2026-05-04 multi-resident canary):
+        identity() MUST capture resident_name like onboard() does. Without
+        this, substrate-anchored residents (Vigil/Sentinel/Watcher/Chronicler)
+        that resume via identity() never set resident_name and the
+        post-checkin substrate emission silently skips."""
+        session = AsyncMock()
+        session.call_tool = AsyncMock(return_value=make_mcp_result({
+            "success": True,
+            "client_session_id": "sid-1",
+            "uuid": "u-1",
+        }))
+        client = make_client_with_session(session)
+
+        await client.identity(name="Sentinel", agent_uuid="some-uuid", resume=True)
+        assert client.resident_name == "Sentinel"
+
+    @pytest.mark.asyncio
+    async def test_identity_captures_resident_name_from_response_label(self):
+        """If caller doesn't pass name kwarg, fall back to label field on the
+        identity response. Lets the SDK still capture the name on UUID-only
+        resume calls when the server includes label in the response."""
+        session = AsyncMock()
+        session.call_tool = AsyncMock(return_value=make_mcp_result({
+            "success": True,
+            "client_session_id": "sid-1",
+            "uuid": "u-1",
+            "label": "Vigil",
+        }))
+        client = make_client_with_session(session)
+
+        await client.identity(agent_uuid="some-uuid", resume=True)
+        assert client.resident_name == "Vigil"
+
+    @pytest.mark.asyncio
+    async def test_identity_resident_name_stays_none_when_unresolvable(self):
+        """No name kwarg AND no label in response → resident_name stays None.
+        This is the non-resident caller path; substrate emission gates on
+        non-None resident_name."""
+        session = AsyncMock()
+        session.call_tool = AsyncMock(return_value=make_mcp_result({
+            "success": True,
+            "client_session_id": "sid-1",
+            "uuid": "u-1",
+        }))
+        client = make_client_with_session(session)
+
+        await client.identity(agent_uuid="some-uuid", resume=True)
+        assert client.resident_name is None
+
+    @pytest.mark.asyncio
     async def test_identity_forwards_parent_agent_id_and_spawn_reason(self):
         """Typed lineage params also flow through identity() for creation fallthrough."""
         session = AsyncMock()

--- a/agents/sdk/tests/test_substrate_emission.py
+++ b/agents/sdk/tests/test_substrate_emission.py
@@ -249,7 +249,12 @@ def test_first_emit_does_acquire_with_correct_surface(cache):
     from src.lease_plane.models import AcquireOk, LeaseRecord
 
     client = MagicMock()
-    client.acquire.return_value = AcquireOk(LeaseRecord(uuid4()))
+    _mock_lease = MagicMock()
+    _mock_lease.lease_id = uuid4()
+    _mock_ok = MagicMock(spec=AcquireOk)
+    _mock_ok.lease = _mock_lease
+    _mock_ok.idempotent = False
+    client.acquire.return_value = _mock_ok
 
     result = emit_substrate_observation(
         resident_name="Vigil",
@@ -278,8 +283,13 @@ def test_subsequent_emits_use_renew(cache):
 
     lease_id = uuid4()
     client = MagicMock()
-    client.acquire.return_value = AcquireOk(LeaseRecord(lease_id))
-    client.renew.return_value = SimpleOk()
+    _mock_lease = MagicMock()
+    _mock_lease.lease_id = lease_id
+    _mock_ok = MagicMock(spec=AcquireOk)
+    _mock_ok.lease = _mock_lease
+    _mock_ok.idempotent = False
+    client.acquire.return_value = _mock_ok
+    client.renew.return_value = MagicMock(spec=SimpleOk)
 
     for _ in range(3):
         assert emit_substrate_observation(
@@ -324,8 +334,13 @@ def test_renew_failure_resets_cache_for_reacquire(cache):
     from src.lease_plane.models import AcquireOk, LeaseRecord, SimpleError, SimpleOk
 
     client = MagicMock()
-    client.acquire.return_value = AcquireOk(LeaseRecord(uuid4()))
-    client.renew.side_effect = [SimpleError(), SimpleOk()]
+    _mock_lease = MagicMock()
+    _mock_lease.lease_id = uuid4()
+    _mock_ok = MagicMock(spec=AcquireOk)
+    _mock_ok.lease = _mock_lease
+    _mock_ok.idempotent = False
+    client.acquire.return_value = _mock_ok
+    client.renew.side_effect = [MagicMock(spec=SimpleError), MagicMock(spec=SimpleOk)]
 
     assert emit_substrate_observation(
         resident_name="Chronicler",
@@ -347,7 +362,12 @@ def test_renew_failure_resets_cache_for_reacquire(cache):
     assert cache.lease_id is None  # reset
 
     # Cycle 3: re-acquire
-    client.acquire.return_value = AcquireOk(LeaseRecord(uuid4()))
+    _mock_lease = MagicMock()
+    _mock_lease.lease_id = uuid4()
+    _mock_ok = MagicMock(spec=AcquireOk)
+    _mock_ok.lease = _mock_lease
+    _mock_ok.idempotent = False
+    client.acquire.return_value = _mock_ok
     assert emit_substrate_observation(
         resident_name="Chronicler",
         holder_uuid=HOLDER_UUID,
@@ -383,7 +403,12 @@ def test_each_resident_gets_distinct_surface_id(cache):
     for name in ("Vigil", "Sentinel", "Watcher", "Chronicler"):
         local_cache = _LeaseCache()
         client = MagicMock()
-        client.acquire.return_value = AcquireOk(LeaseRecord(uuid4()))
+        _mock_lease = MagicMock()
+        _mock_lease.lease_id = uuid4()
+        _mock_ok = MagicMock(spec=AcquireOk)
+        _mock_ok.lease = _mock_lease
+        _mock_ok.idempotent = False
+        client.acquire.return_value = _mock_ok
         emit_substrate_observation(
             resident_name=name,
             holder_uuid=HOLDER_UUID,


### PR DESCRIPTION
PR #330 only captured resident_name in onboard(), not identity(). Substrate-anchored residents (Vigil/Sentinel/Watcher/Chronicler) resume via identity() and never call onboard, so resident_name stayed None and substrate emission silently skipped.

Caught 2026-05-04 on canary multi-resident probe — only Steward had substrate row. Hot-patched + restarted Sentinel: substrate row landed in 50s (V=0.099, status=healthy). Multi-resident canary now active for Steward + Sentinel.

3 SDK files updated (client.py, sync_client.py, agent.py), 3 new tests + 4 pre-existing test_substrate_emission.py fixes (real Pydantic vs shim construction). 170 SDK tests pass.