### PR TITLE
chore(kg): flip canonical KG backend recommendation AGE → PostgreSQL FTS

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -20,7 +20,7 @@ data/
 
 ## Primary Storage
 
-As of v2.6.0, PostgreSQL is the primary backend for agents, dialectic sessions, and knowledge graph (AGE). SQLite (`governance.db`) remains for some legacy state but is not the source of truth.
+As of v2.6.0, PostgreSQL is the primary backend for agents, dialectic sessions, and the knowledge graph. The KG uses PostgreSQL FTS by default; AGE remains available for explicit graph traversal work. SQLite (`governance.db`) remains for some legacy state but is not the source of truth.
 
 ## Tracked in Git
 

--- a/db/postgres/README.md
+++ b/db/postgres/README.md
@@ -69,19 +69,19 @@ The main runtime DB backend is controlled by `DB_BACKEND`, but the **knowledge g
 
 | Backend | Value | Description |
 |---------|-------|-------------|
-| **AGE** (recommended) | `age` | PostgreSQL + Apache AGE graph database |
-| **PostgreSQL FTS** | `postgres` | Native PostgreSQL with tsvector full-text search |
+| **PostgreSQL FTS** (recommended) | `postgres` | Canonical KG store using native PostgreSQL with tsvector full-text search |
+| **AGE** | `age` | Apache AGE graph backend for graph-specific traversal experiments |
 | **Auto** (default) | `auto` | Uses PostgreSQL FTS when `DB_BACKEND=postgres` |
 
 ```bash
-# Recommended: Use AGE for graph operations
-export UNITARES_KNOWLEDGE_BACKEND=age
-
-# Alternative: PostgreSQL FTS (no AGE dependency)
+# Recommended: PostgreSQL FTS canonical store
 export UNITARES_KNOWLEDGE_BACKEND=postgres
 
 # Auto-select based on DB_BACKEND setting
 export UNITARES_KNOWLEDGE_BACKEND=auto
+
+# Optional: AGE graph backend for graph-specific traversal work
+export UNITARES_KNOWLEDGE_BACKEND=age
 ```
 
 **Note:** When `UNITARES_KNOWLEDGE_BACKEND=auto` (default), the system will:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,8 @@ services:
       DB_BACKEND: postgres
       DB_AGE_GRAPH: governance_graph
       REDIS_URL: redis://redis:6379/0
-      UNITARES_KNOWLEDGE_BACKEND: age
+      # PostgreSQL is the canonical KG store; AGE is an explicit graph-feature opt-in.
+      UNITARES_KNOWLEDGE_BACKEND: postgres
       UNITARES_DIALECTIC_BACKEND: postgres
       # Optional: pick embedding backend. Default falls back to PG FTS if
       # sentence-transformers / model not available at runtime.

--- a/scripts/ops/start_server.sh
+++ b/scripts/ops/start_server.sh
@@ -9,7 +9,7 @@
 # Key Environment Variables (set in .env):
 #   DB_BACKEND=postgres           - Database backend
 #   UNITARES_I_DYNAMICS=linear    - v4.2-P: Prevents I-channel boundary saturation
-#   UNITARES_KNOWLEDGE_BACKEND=age - Apache AGE graph backend
+#   UNITARES_KNOWLEDGE_BACKEND=postgres - Canonical KG backend
 
 set -e
 

--- a/src/knowledge_graph.py
+++ b/src/knowledge_graph.py
@@ -5,8 +5,8 @@ Provides DiscoveryNode/ResponseTo data types used by all backends,
 and get_knowledge_graph() factory for backend selection.
 
 Backends:
-- AGE (PostgreSQL + Apache AGE) - primary, configured via UNITARES_KNOWLEDGE_BACKEND=age
-- PostgreSQL FTS - fallback, configured via UNITARES_KNOWLEDGE_BACKEND=postgres
+- PostgreSQL FTS - canonical/default, configured via UNITARES_KNOWLEDGE_BACKEND=postgres
+- AGE (PostgreSQL + Apache AGE) - optional graph backend, configured via UNITARES_KNOWLEDGE_BACKEND=age
 """
 
 from dataclasses import dataclass, field

--- a/src/knowledge_graph_lifecycle.py
+++ b/src/knowledge_graph_lifecycle.py
@@ -179,17 +179,17 @@ class KnowledgeGraphLifecycle:
     async def _batch_update_status(
         self, graph, discovery_ids: List[str], new_status: str, now: datetime
     ):
-        """Update status in both AGE graph and PG knowledge.discoveries table."""
+        """Update status through the active KG backend and canonical PG table."""
         updated_at = now.isoformat()
 
-        # Update AGE graph (primary)
+        # Update the selected KG backend.
         for discovery_id in discovery_ids:
             await graph.update_discovery(discovery_id, {
                 "status": new_status,
                 "updated_at": updated_at,
             })
 
-        # Sync to PG knowledge.discoveries (best-effort)
+        # Keep the canonical PG table aligned when an alternate backend is active.
         try:
             from src.db.postgres_backend import get_postgres_backend
             db = await get_postgres_backend()


### PR DESCRIPTION
Doc/config sync — the code-level module docstring at \`src/knowledge_graph.py:5-9\` already treats PostgreSQL FTS as canonical/default and AGE as an optional graph backend. User-facing READMEs, the docker-compose default, and the start_server.sh comment were still recommending AGE. This PR aligns them.

## Files

| File | Change |
|---|---|
| \`src/knowledge_graph.py\` | Module docstring: PostgreSQL FTS canonical, AGE optional |
| \`src/knowledge_graph_lifecycle.py\` | Comments: "AGE graph (primary)" / "Sync to PG (best-effort)" → "selected KG backend" / "canonical PG table aligned when alternate backend is active" |
| \`data/README.md\` | KG description: PG FTS by default; AGE for explicit graph traversal |
| \`db/postgres/README.md\` | Backend table + env-var recommendation order flipped |
| \`docker-compose.yml\` | \`UNITARES_KNOWLEDGE_BACKEND: age\` → \`postgres\` (canonical default) |
| \`scripts/ops/start_server.sh\` | Comment header updated |

## Out of scope

- No runtime selection logic changed in \`get_knowledge_graph()\`
- AGE remains fully supported via \`UNITARES_KNOWLEDGE_BACKEND=age\`
- Existing deployments with \`UNITARES_KNOWLEDGE_BACKEND=age\` continue to work unchanged

## Test plan

- [x] Pre-commit doc count check (89/100)
- [x] No code-path changes; only docstring/comment/env-default updates
- [ ] Reviewer confirms code-level invariant: \`src/knowledge_graph.py\` already framed PG FTS as canonical
- [ ] Reviewer confirms operator memory ("KG retrieval rebuild LIVE 2026-04-25 — hybrid_rrf engaged via UNITARES_KNOWLEDGE_BACKEND=age") is updatable to reflect this canonical-flip