### PR TITLE
fix(test): lease-plane force-release contract test reads LEASE_PLANE_BEARER_TOKEN, not unset GOVERNANCE_TOKEN

### DIFF
--- a/tests/test_lease_plane_force_release_contract.py
+++ b/tests/test_lease_plane_force_release_contract.py
@@ -57,19 +57,32 @@ if not _router_reachable():
 
 # ---------- helpers ----------
 
-def _read_force_release_token() -> str | None:
-    """Read LEASE_FORCE_RELEASE_TOKEN from env or ~/.config/cirwel/secrets.env."""
-    tok = os.environ.get("LEASE_FORCE_RELEASE_TOKEN")
+def _read_secrets_var(var_name: str) -> str | None:
+    """Read VAR_NAME from env or ~/.config/cirwel/secrets.env."""
+    tok = os.environ.get(var_name)
     if tok:
         return tok
     secrets_path = Path.home() / ".config" / "cirwel" / "secrets.env"
     if not secrets_path.exists():
         return None
+    prefix = f"{var_name}="
     for line in secrets_path.read_text().splitlines():
         line = line.strip()
-        if line.startswith("LEASE_FORCE_RELEASE_TOKEN="):
+        if line.startswith("export "):
+            line = line[len("export "):]
+        if line.startswith(prefix):
             return line.split("=", 1)[1].strip().strip('"').strip("'")
     return None
+
+
+def _read_force_release_token() -> str | None:
+    """Read LEASE_FORCE_RELEASE_TOKEN from env or ~/.config/cirwel/secrets.env."""
+    return _read_secrets_var("LEASE_FORCE_RELEASE_TOKEN")
+
+
+def _read_lease_plane_bearer() -> str | None:
+    """Read LEASE_PLANE_BEARER_TOKEN — the regular bearer the router accepts."""
+    return _read_secrets_var("LEASE_PLANE_BEARER_TOKEN")
 
 
 def _router_url(path: str) -> str:
@@ -140,10 +153,17 @@ def test_force_release_rejects_governance_token(monkeypatch):
             "cannot complete sub-assertion 3 (elevated-token success path)"
         )
 
-    # We need a governance token to acquire a lease for sub-assertion 3.
-    # If it's not set, we can still test sub-assertions 1 and 2 against a
-    # synthetic lease_id — the auth check fires before the lease lookup.
-    governance_token = os.environ.get("GOVERNANCE_TOKEN", "some-non-elevated-token")
+    # We need the regular lease-plane bearer to acquire a lease for sub-assertion 3.
+    # The "GOVERNANCE_TOKEN" name in this module's prose is a label for the
+    # regular (non-elevated) bearer; the actual env var on the router side is
+    # LEASE_PLANE_BEARER_TOKEN. Sub-assertions 1 and 2 use a synthetic token
+    # since the auth check fires before the lease lookup.
+    lease_plane_bearer = _read_lease_plane_bearer()
+    if not lease_plane_bearer:
+        pytest.skip(
+            "LEASE_PLANE_BEARER_TOKEN not set (env or ~/.config/cirwel/secrets.env); "
+            "cannot acquire a real lease for sub-assertion 3"
+        )
 
     # Sub-assertion 1: non-elevated token is rejected at the path level.
     # The router's path-aware HTTPAuth rejects any token that is not
@@ -172,7 +192,7 @@ def test_force_release_rejects_governance_token(monkeypatch):
     )
 
     # Sub-assertion 3: elevated token + real lease → 200 ok:true.
-    lease_id = _acquire_lease(governance_token)
+    lease_id = _acquire_lease(lease_plane_bearer)
     status3, body3 = _post_json(
         _FORCE_RELEASE_PATH,
         {"lease_id": lease_id},
@@ -194,12 +214,21 @@ def test_release_rejects_forced_reason_on_release_endpoint():
 
     This test was added in PR 1 on the BEAM side. Re-verified here as
     a sanity check that the path routing is still correct after PR 2.
+
+    Requires the regular bearer (LEASE_PLANE_BEARER_TOKEN) to be valid;
+    skips cleanly otherwise so the auth-level rejection (401) doesn't
+    masquerade as a semantic failure.
     """
-    governance_token = os.environ.get("GOVERNANCE_TOKEN", "some-governance-token")
+    lease_plane_bearer = _read_lease_plane_bearer()
+    if not lease_plane_bearer:
+        pytest.skip(
+            "LEASE_PLANE_BEARER_TOKEN not set (env or ~/.config/cirwel/secrets.env); "
+            "cannot exercise the semantic-rejection path with a valid bearer"
+        )
     status, body = _post_json(
         _RELEASE_PATH,
         {"lease_id": str(uuid.uuid4()), "release_reason": "forced"},
-        authorization=f"Bearer {governance_token}",
+        authorization=f"Bearer {lease_plane_bearer}",
     )
     # The Elixir router returns 200 + ok:false + permission_denied for semantic
     # rejections (not a lease mismatch, not a missing route — a policy rejection).


### PR DESCRIPTION
\`test_release_rejects_forced_reason_on_release_endpoint\` (added in #313) failed locally with HTTP 401 instead of the expected 200 + semantic permission_denied.

## Root cause

The test pulled its bearer from \`os.environ.get(\"GOVERNANCE_TOKEN\", \"some-governance-token\")\`. But \`GOVERNANCE_TOKEN\` is a **prose-only label** for "the regular (non-elevated) bearer" — it's referenced in docstrings/comments across \`tests/\`, \`scripts/dev/lease_plane_deprecate.py\`, and \`src/lease_plane/client.py:203\`, but never actually set as an env var anywhere. The lease plane router's actual standard bearer is \`LEASE_PLANE_BEARER_TOKEN\` (per \`elixir/lease_plane/lib/unitares_lease_plane/{application,http_router,http_auth}.ex\`).

With \`GOVERNANCE_TOKEN\` unset, the literal fallback \`\"some-governance-token\"\` got rejected by the router's bearer gate (HTTP 401) before the semantic-rejection logic could fire — so the test asserted on the wrong layer's response.

## Fix

- Generalize the secrets.env reader: \`_read_secrets_var(var_name)\`. Also handles the \`export VAR=...\` form (which is what's actually in \`~/.config/cirwel/secrets.env\`).
- \`_read_force_release_token\` becomes a thin wrapper.
- New \`_read_lease_plane_bearer()\` for \`LEASE_PLANE_BEARER_TOKEN\`.
- Both failing tests now read the lease-plane bearer and skip cleanly when unset, instead of asserting against an invalid token.

## Verification

Locally with \`LEASE_PLANE_BEARER_TOKEN\` sourced from \`~/.config/cirwel/secrets.env\`:

\`\`\`
============= 1 passed, 1 skipped in 0.51s =============
\`\`\`

The skip is \`test_force_release_rejects_governance_token\`'s sub-assertion 3 (elevated-token success path) — \`LEASE_FORCE_RELEASE_TOKEN\` isn't provisioned in secrets.env. That's a separate operational decision; the skip predicate for that test was already correct, this PR just fixes the bearer-resolution path it depends on.

## Test plan

- [x] \`test_release_rejects_forced_reason_on_release_endpoint\` — was FAIL (401 not 200), now PASS
- [x] \`test_force_release_rejects_governance_token\` — was SKIP (correctly, force-release token unset), still SKIP, but the lease-acquire path it would take now reads the right bearer
- [ ] CI/remote: both tests still skip at module level when the BEAM router isn't reachable (\`_router_reachable()\` predicate); no behavior change on remote