### PR TITLE
fix(lease-plane): idempotent acquire UPDATEs substrate when caller provides it

### DIFF
--- a/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
@@ -77,7 +77,31 @@ defmodule UnitaresLeasePlane.Repo do
   defp acquire_step(conn, p, %{holder_agent_uuid: held} = existing)
        when is_binary(held) do
     if held == p.holder_agent_uuid do
-      {:ok, {:ok, existing, :idempotent}}
+      # RFC §7.13: idempotent re-acquire from the same holder MUST update
+      # substrate_state when caller provided new substrate fields. Without
+      # this, SDK-based residents (Vigil/Sentinel/Watcher/Chronicler) using
+      # run_once never see substrate updates: each cycle creates a fresh
+      # GovernanceClient → fresh _LeaseCache → always calls acquire (not
+      # renew) → idempotent-acquire returned the existing row unchanged.
+      # Only Steward avoided this because PR #4's lease_substrate.py uses
+      # a module-global cache that persists across cycles. Caught
+      # 2026-05-04 multi-resident canary debug: Sentinel had a substrate
+      # row from cycle 1 stuck at 23:52:05 even though subsequent cycles
+      # ran successfully. Substrate-less acquires (legacy callers + tests)
+      # are unchanged: skip the UPDATE and return existing as before.
+      substrate_state = Map.get(p, :substrate_state)
+      substrate_observed_at = Map.get(p, :substrate_state_observed_at)
+
+      if not is_nil(substrate_state) or not is_nil(substrate_observed_at) do
+        update_substrate_on_idempotent(
+          conn,
+          existing,
+          substrate_state,
+          substrate_observed_at
+        )
+      else
+        {:ok, {:ok, existing, :idempotent}}
+      end
     else
       # PR 5 council BLOCK fix: include surface_id + blocking_lease_id so the
       # 409 response carries every field the v0.7 §7.3.2 AcquireHeldByOther shape
@@ -199,6 +223,63 @@ defmodule UnitaresLeasePlane.Repo do
       {:ok, nil} -> acquire_step_nil(conn, p, depth + 1)
       {:error, e} -> {:error, e}
     end
+  end
+
+  # Idempotent re-acquire from same holder + caller-provided substrate fields:
+  # COALESCE-update substrate columns on the existing row. Mirrors the
+  # COALESCE pattern in renew/3 — caller-omitted fields preserve existing
+  # values; caller-provided fields overwrite. Returns the refreshed lease
+  # with `:idempotent` so the caller-side response shape stays the same.
+  defp update_substrate_on_idempotent(conn, existing, substrate_state, substrate_observed_at) do
+    sql = """
+    UPDATE lease_plane.surface_leases
+    SET substrate_state =
+          COALESCE($2::jsonb, substrate_state),
+        substrate_state_observed_at =
+          COALESCE($3::timestamptz, substrate_state_observed_at)
+    WHERE lease_id = $1 AND released_at IS NULL
+    RETURNING #{@select_lease_columns}
+    """
+
+    args = [
+      uuid_to_binary(existing.lease_id),
+      substrate_state,
+      substrate_observed_at
+    ]
+
+    case Postgrex.query(conn, sql, args) do
+      {:ok, %{rows: [row], columns: cols}} ->
+        refreshed = row_to_map(cols, row)
+        {:ok, {:ok, refreshed, :idempotent}}
+
+      # Lease was released between the maybe_existing_active read and our UPDATE
+      # (race against the reaper). Fall through to acquire_step_nil so the
+      # caller still gets a fresh acquire instead of a confusing :not_found.
+      {:ok, %{rows: []}} ->
+        acquire_step_nil(conn, p_from_existing(existing, substrate_state, substrate_observed_at), 0)
+
+      {:error, e} ->
+        {:error, e}
+    end
+  end
+
+  # Reconstruct the acquire params map from an existing-lease snapshot when
+  # the idempotent UPDATE races against a release. The original acquire `p`
+  # isn't in scope here, so synthesize from the existing row + caller fields.
+  # Only used in the rare race-recovery path above.
+  defp p_from_existing(existing, substrate_state, substrate_observed_at) do
+    %{
+      surface_id: existing.surface_id,
+      holder_agent_uuid: existing.holder_agent_uuid,
+      holder_class: existing.holder_class,
+      holder_kind: existing.holder_kind,
+      holder_pid: existing.holder_pid,
+      ttl_s: existing.original_ttl_s,
+      intent: existing.intent,
+      audit_session: existing.audit_session,
+      substrate_state: substrate_state,
+      substrate_state_observed_at: substrate_observed_at
+    }
   end
 
   # ---------- status ----------

--- a/elixir/lease_plane/test/unitares_lease_plane_test.exs
+++ b/elixir/lease_plane/test/unitares_lease_plane_test.exs
@@ -194,6 +194,78 @@ defmodule UnitaresLeasePlaneTest do
       # Substrate stays nil — substrate-less renew doesn't write substrate columns.
       assert refreshed.substrate_state == nil
     end
+
+    test "idempotent re-acquire with substrate UPDATEs the existing row (regression for SDK-resident multi-cycle path)" do
+      # SDK-based residents (Vigil/Sentinel/Watcher/Chronicler) use run_once
+      # which builds a fresh GovernanceClient per cycle. The client's
+      # _substrate_lease_cache resets each cycle, so substrate emission
+      # always calls acquire — never renew. Pre-fix, idempotent acquire
+      # returned the existing row unchanged, so subsequent cycles' substrate
+      # observations were silently dropped. Caught 2026-05-04 multi-resident
+      # canary debug: Sentinel had a substrate row from cycle 1 stuck while
+      # subsequent cycles ran. Fix: idempotent acquire COALESCE-updates
+      # substrate columns when caller provided them.
+
+      surface = "resident:/test_elixir_idempotent_substrate_#{:erlang.unique_integer([:positive])}"
+      on_exit(fn -> cleanup_surface(surface) end)
+
+      params = local_beam_params(surface, ttl_s: 60)
+      params_with_substrate_v1 = Map.merge(params, %{
+        substrate_state: %{
+          "E" => 0.5,
+          "I" => 0.5,
+          "S" => 0.0,
+          "V" => 0.05,
+          "sensor" => %{"status" => "healthy"}
+        },
+        substrate_state_observed_at: DateTime.utc_now()
+      })
+
+      assert {:ok, lease, :new} =
+               UnitaresLeasePlane.acquire_local_beam(params_with_substrate_v1)
+      first_observed_at = lease.substrate_state_observed_at
+      assert lease.substrate_state["V"] == 0.05
+
+      # Cycle 2: same holder, same surface, NEW substrate values.
+      observed_at_2 = DateTime.add(DateTime.utc_now(), 1, :second)
+      params_with_substrate_v2 = Map.merge(params, %{
+        substrate_state: %{
+          "E" => 0.7,
+          "I" => 0.3,
+          "S" => 0.2,
+          "V" => 0.15,
+          "sensor" => %{"status" => "degraded"}
+        },
+        substrate_state_observed_at: observed_at_2
+      })
+
+      assert {:ok, refreshed, :idempotent} =
+               UnitaresLeasePlane.acquire_local_beam(params_with_substrate_v2)
+      # New substrate values overwrote the old (THE BUG WAS: refreshed.substrate_state["V"] == 0.05)
+      assert refreshed.substrate_state["V"] == 0.15
+      assert refreshed.substrate_state["sensor"]["status"] == "degraded"
+      # observed_at advanced
+      assert DateTime.compare(refreshed.substrate_state_observed_at, first_observed_at) == :gt
+
+      # SELECT confirms the row in DB matches the response (not a phantom in-memory update)
+      {:ok, from_db} = UnitaresLeasePlane.status(surface)
+      assert from_db.substrate_state["V"] == 0.15
+    end
+
+    test "idempotent re-acquire WITHOUT substrate is unchanged (legacy callers preserved)" do
+      surface = "resident:/test_elixir_idempotent_no_substrate_#{:erlang.unique_integer([:positive])}"
+      on_exit(fn -> cleanup_surface(surface) end)
+
+      params = local_beam_params(surface, ttl_s: 60)
+      assert {:ok, _lease, :new} = UnitaresLeasePlane.acquire_local_beam(params)
+
+      # Re-acquire WITHOUT substrate fields — must take the legacy idempotent
+      # path that returns the existing row unchanged (no UPDATE, no observable
+      # behavior change for callers that never used substrate).
+      assert {:ok, refreshed, :idempotent} = UnitaresLeasePlane.acquire_local_beam(params)
+      assert refreshed.substrate_state == nil
+      assert refreshed.substrate_state_observed_at == nil
+    end
   end
 
   describe "handoff" do


### PR DESCRIPTION
SDK residents (Vigil/Sentinel/Watcher/Chronicler) use run_once → fresh GovernanceClient per cycle → fresh _substrate_lease_cache → always acquire (never renew). Pre-fix idempotent acquire returned existing row unchanged → Sentinel substrate stuck at cycle 1 timestamp despite hours of successful cycles. Steward unaffected (PR #4 uses module-global cache).

Fix: idempotent path COALESCE-UPDATEs substrate when caller provides fields. Mirror of PR #322/#331 'caller-sourced writes always land' pattern. 19 Elixir tests pass (2 new). Hot-patched + verified live across 2 Sentinel cycles (substrate observed_at: 23:52:05 stuck → 00:13:36 → 00:18:53). Multi-resident canary fully active.