### PR TITLE
feat(wave-0): coordination_events instrumentation foundation (RFC roadmap §86)

### DIFF
--- a/db/postgres/migrations/035_coordination_events.sql
+++ b/db/postgres/migrations/035_coordination_events.sql
@@ -1,0 +1,116 @@
+-- Migration 035: Wave 0 coordination_events instrumentation
+--
+-- Implements docs/proposals/beam-footprint-roadmap-v0.md Wave 0:
+-- "emit structured events on coordination-class failures (asyncpg connect
+--  errors, anyio task-group cancellations, executor pool exhaustion, MCP
+--  handler timeouts) and persist them in a Chronicler-readable form.
+--  Without Wave 0, no later wave's exit criterion can be honestly evaluated."
+--
+-- Single-table replay surface (NOT per-service tables) — every coordination-
+-- class failure across sentinel/governance_mcp/lease_plane/vigil/chronicler/
+-- watcher writes here. Wave 1's exit criterion (incident-rate trends) reads
+-- from this single surface.
+--
+-- Envelope per the roadmap (locked upfront, not evolved):
+--   event_id     UUID         primary identity / replay-dedup key
+--   ts           timestamptz  ordering, audit, partition key
+--   service      TEXT enum    originator (sentinel|governance_mcp|...)
+--   event_type   TEXT dotted  coordination_failure.<class> + future namespaces
+--   agent_id     TEXT NULL    UNITARES UUID when agent-attributable
+--   payload      JSONB        event-type-specific structure (per-event_type docs)
+--   context      JSONB        emitter facts: git_commit, service_pid,
+--                             running_since, host
+--
+-- Stability discipline: event_type extends by adding new dotted namespaces,
+-- never by reusing or renaming existing ones. payload shape per event_type
+-- is documented at the time the event_type lands.
+
+CREATE TABLE IF NOT EXISTS audit.coordination_events (
+    ts          timestamptz NOT NULL,
+    event_id    UUID        NOT NULL DEFAULT gen_random_uuid(),
+    service     TEXT        NOT NULL,
+    event_type  TEXT        NOT NULL,
+    agent_id    TEXT        NULL,
+    payload     JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    context     JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    PRIMARY KEY (ts, event_id)
+) PARTITION BY RANGE (ts);
+
+-- Service enum CHECK. Locked to the six emitters named in the roadmap
+-- envelope spec. New services added explicitly (alter the CHECK; not
+-- ad-hoc string append).
+DO $$ BEGIN
+    ALTER TABLE audit.coordination_events
+        ADD CONSTRAINT coordination_events_service_check
+        CHECK (service = ANY (ARRAY[
+            'sentinel',
+            'governance_mcp',
+            'lease_plane',
+            'vigil',
+            'chronicler',
+            'watcher'
+        ]::text[]));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- event_type namespace CHECK. Wave 0 lands the coordination_failure.* family.
+-- Future waves (e.g. coordination_recovery.*, coordination_lifecycle.*) extend
+-- by adding the family prefix here, never by reusing existing values.
+DO $$ BEGIN
+    ALTER TABLE audit.coordination_events
+        ADD CONSTRAINT coordination_events_event_type_namespace
+        CHECK (event_type ~ '^(coordination_failure)\.[a-z_]+$');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- payload + context MUST be JSON objects (not bare null/scalar/array).
+-- Mirrors the v0.10 §7.2.8 contract pattern from substrate_state — readers
+-- can rely on payload->>'<key>' and context->>'<key>' shape.
+DO $$ BEGIN
+    ALTER TABLE audit.coordination_events
+        ADD CONSTRAINT coordination_events_payload_object
+        CHECK (jsonb_typeof(payload) = 'object');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+    ALTER TABLE audit.coordination_events
+        ADD CONSTRAINT coordination_events_context_object
+        CHECK (jsonb_typeof(context) = 'object');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- Indexes for the standard read patterns: per-service incident timeline
+-- (Sentinel rule polling), per-event-type counts (dashboard panel), and
+-- per-agent attribution (when agent_id is set).
+CREATE INDEX IF NOT EXISTS idx_coord_events_service_ts
+    ON audit.coordination_events (service, ts DESC);
+
+CREATE INDEX IF NOT EXISTS idx_coord_events_event_type_ts
+    ON audit.coordination_events (event_type, ts DESC);
+
+CREATE INDEX IF NOT EXISTS idx_coord_events_agent_ts
+    ON audit.coordination_events (agent_id, ts DESC)
+    WHERE agent_id IS NOT NULL;
+
+-- Initial partitions: current month + next month + a default catch-all so
+-- writes never fail on an unbounded ts. Future partitions are operator-
+-- managed via the existing db/postgres/partitions.sql pattern (Vigil
+-- maintains it on its 30min cadence).
+CREATE TABLE IF NOT EXISTS audit.coordination_events_2026_05
+    PARTITION OF audit.coordination_events
+    FOR VALUES FROM ('2026-05-01') TO ('2026-06-01');
+
+CREATE TABLE IF NOT EXISTS audit.coordination_events_2026_06
+    PARTITION OF audit.coordination_events
+    FOR VALUES FROM ('2026-06-01') TO ('2026-07-01');
+
+CREATE TABLE IF NOT EXISTS audit.coordination_events_default
+    PARTITION OF audit.coordination_events DEFAULT;
+
+COMMENT ON TABLE audit.coordination_events IS 'Wave 0 (RFC docs/proposals/beam-footprint-roadmap-v0.md): single-surface replay log for coordination-class failures. Sentinel-style alarm rules + dashboard panel + Chronicler projection all read from here. event_type extends by adding new dotted namespaces; never reuse or rename existing values.';
+
+COMMENT ON COLUMN audit.coordination_events.event_type IS 'Dotted namespace per roadmap §94. Wave 0 locks coordination_failure.<class>: asyncpg_connect_error, anyio_cancellation, executor_pool_exhaustion, mcp_handler_timeout. Future waves extend the family prefix (coordination_recovery.*, etc.).';
+
+COMMENT ON COLUMN audit.coordination_events.context IS 'Facts about the emitter (git_commit, service_pid, running_since, host) — NOT facts about the event. Populated by the central emitter; callers do not pass this directly.';
+
+-- Register migration
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (35, 'coordination_events', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/db/postgres/migrations/035_coordination_events.sql
+++ b/db/postgres/migrations/035_coordination_events.sql
@@ -53,12 +53,18 @@ DO $$ BEGIN
 EXCEPTION WHEN duplicate_object THEN NULL; END $$;
 
 -- event_type namespace CHECK. Wave 0 lands the coordination_failure.* family.
+-- Sub-namespaces extend by appending '.<lowercase_subtype>' (e.g.
+-- 'coordination_failure.mcp_handler_timeout.identity_step') so call-site
+-- discriminators land as part of the event_type contract — NOT as ad-hoc
+-- payload subtype enums (council architect C5: "subtype-in-payload re-creates
+-- the §110 anti-pattern one field deeper").
+--
 -- Future waves (e.g. coordination_recovery.*, coordination_lifecycle.*) extend
 -- by adding the family prefix here, never by reusing existing values.
 DO $$ BEGIN
     ALTER TABLE audit.coordination_events
         ADD CONSTRAINT coordination_events_event_type_namespace
-        CHECK (event_type ~ '^(coordination_failure)\.[a-z_]+$');
+        CHECK (event_type ~ '^(coordination_failure)(\.[a-z_]+)+$');
 EXCEPTION WHEN duplicate_object THEN NULL; END $$;
 
 -- payload + context MUST be JSON objects (not bare null/scalar/array).

--- a/docs/proposals/wave-0-step-2-call-site-scoping.md
+++ b/docs/proposals/wave-0-step-2-call-site-scoping.md
@@ -1,0 +1,100 @@
+# Wave 0 step 2 — coordination-failure call-site scoping
+
+**Purpose:** scope the four `coordination_failure.*` event-type emit sites for `audit.coordination_events` (PR #342). One pass; no code yet — surface the design choices first so the implementation PR ships with operator-anchored decisions instead of inferences.
+
+**Read this with:** `docs/proposals/beam-footprint-roadmap-v0.md` §86–110 (the envelope spec) and `src/coordination_events.py` (the emitter from #342).
+
+---
+
+## 1. `coordination_failure.asyncpg_connect_error` — clean chokepoint
+
+**Where:** `src/db/postgres_backend.py:208-219` `_create_pool`.
+
+```python
+except asyncio.TimeoutError:
+    raise ConnectionError(...)
+except Exception as e:
+    raise ConnectionError(f"Failed to connect to PostgreSQL ... {e}") from e
+```
+
+**Plan:** add `await emit_event(pool=None_or_self, service="governance_mcp", event_type=ASYNCPG_CONNECT_ERROR, payload={...})` before each `raise`. Payload: `{error_class, db_url_hash, timeout_s, attempt}`.
+
+**Choice point — emit before the pool exists:** the very first connect error is the one we most want to log, but there's no pool to write to yet. Options:
+- **(a)** Lazy retry — buffer the event in-memory and emit after the next successful connect lands. Lossless but couples observability to recovery.
+- **(b)** Skip the bootstrap-failure case — only emit on subsequent connect errors after the pool has been up. Simple but misses the most diagnostic event.
+- **(c) [recommended]** Use a separate short-lived `asyncpg.connect` direct-INSERT (no pool, no transaction) just for the event. Slow path for the failure case, which is fine — failures are rare; the cost is bounded.
+
+## 2. `coordination_failure.anyio_cancellation` — scope question
+
+**Where:** ~10 `except (asyncio.)CancelledError` sites across `src/background_tasks.py`, `src/knowledge_graph_lifecycle.py`, etc. Most are normal lifecycle (shutdown, cycle timeout, deliberate cancel).
+
+**The problem:** emitting on EVERY `CancelledError` would be noisy and useless. The roadmap's intent is the *spurious* cancellations from the anyio-asyncio conflict (CLAUDE.md "Known Issue") — when the MCP SDK's task group cancels an asyncpg/Redis call mid-flight without a real shutdown signal.
+
+**Choice point — what counts as "spurious":**
+- **(a) [recommended]** Only emit when CancelledError fires INSIDE a known-conflict path: `_load_binding_from_redis` (identity_step.py), `deep_health_probe_task` (background_tasks.py:380), and any `run_in_executor` call that wraps a sync DB client. Pin the emit site list explicitly in the PR description; reviewer audits each.
+- **(b)** Emit on every CancelledError, tag `payload.expected: True|False` based on whether the task name is in a known-shutdown allowlist. Higher signal volume, ambiguous classification.
+- **(c)** Defer — wait for Wave 1's Sentinel-on-BEAM canary to surface real conflict events first, then instrument the specific paths it identifies. Punts the measurement we said we needed.
+
+## 3. `coordination_failure.executor_pool_exhaustion` — needs probe target
+
+**Where:** `src/db/executor_pool.py` is the dedicated background-thread pool that isolates asyncpg from anyio. "Exhaustion" here means tasks queueing on the pool's submit-queue beyond a threshold, or the executor loop falling behind.
+
+**The problem:** the existing ExecutorPool doesn't have an exhaustion signal. It just submits coroutines to the executor loop — backpressure is invisible until the queue grows unbounded.
+
+**Choice point — where to measure:**
+- **(a) [recommended]** Add a counter at `ExecutorPool.submit` for `pending_count`; emit when `pending_count > threshold` (e.g., 50) within a 1-min window. Coarse but actionable. Threshold is operator-tunable.
+- **(b)** Wrap `asyncio.wait_for` around each submit with timeout=2s; emit on TimeoutError. Catches latency spikes but fires on *any* slow query, not just exhaustion.
+- **(c)** Defer — instrument when we have a real pool exhaustion incident to characterize. Punts.
+
+## 4. `coordination_failure.mcp_handler_timeout` — clean chokepoint
+
+**Where:** `src/mcp_handlers/decorators.py:108` `@mcp_tool` wrapper's `except asyncio.TimeoutError`.
+
+```python
+except asyncio.TimeoutError:
+    logger.warning(f"Tool '{tool_name}' timed out after {timeout}s")
+    return [error_response(...)]
+```
+
+**Plan:** add `await emit_event(pool, service="governance_mcp", event_type=MCP_HANDLER_TIMEOUT, payload={tool_name, timeout_s, elapsed_s, agent_id})` before the `return`. The pool is reachable via the existing handler-context (every MCP handler has a DB connection available).
+
+**Choice point — secondary timeout sites:**
+- `resident_progress.py:96` — wraps an INSERT in `asyncio.wait_for(_insert(), timeout=4.5)`. Emits a separate `coordination_failure.mcp_handler_timeout` with payload distinguishing tool-level vs sub-operation timeout.
+- `identity_step.py:173` — Redis fallback path with 500ms timeout. Same event_type, payload.subtype="identity_step".
+
+**Recommended:** ship the decorator chokepoint in PR A; secondary sites in a follow-up PR after the dashboard surfaces what the volume looks like.
+
+---
+
+## Recommended PR shape
+
+**Wave 0 step 2A — clean chokepoints (small, low-risk):**
+- `coordination_failure.asyncpg_connect_error` (path **1c** above)
+- `coordination_failure.mcp_handler_timeout` at the decorator chokepoint only
+- ~50 LOC + tests
+
+**Wave 0 step 2B — anyio + executor (scoped, needs operator decisions):**
+- `coordination_failure.anyio_cancellation` per **2a**
+- `coordination_failure.executor_pool_exhaustion` per **3a** with tunable threshold
+- ~150 LOC + tests + a tunable threshold env var
+
+**Wave 0 step 2C — secondary timeout sites:**
+- After step 3 (Chronicler projection) lands and dashboard shows timeout volume
+
+Splitting 2A from 2B/C keeps the high-confidence emits unblocked by the scope-decision emits.
+
+## Decisions you need to make
+
+| # | Choice | My recommendation |
+|---|---|---|
+| 1 | Bootstrap-failure asyncpg event path | **1c** — short-lived direct-INSERT |
+| 2 | Spurious CancelledError scoping | **2a** — pinned site list, audited |
+| 3 | Executor exhaustion measurement | **3a** — pending_count threshold |
+| 4 | Secondary timeout sites | Defer to step 2C |
+| 5 | PR splitting | 2A + 2B + 2C as separate PRs |
+
+If you accept the recommendations as a block, say "ship 2A" or "ship all" and I take it from there. If you want a different shape on any row, name it and I redirect.
+
+---
+
+**Cost estimate:** 2A is ~1hr including tests. 2B is ~3hr because of the threshold-tuning and the per-site audit on the CancelledError list. 2C waits on Chronicler projection (step 3). The roadmap's "days, not weeks" framing fits if 2A+2B land cleanly without re-scope churn.

--- a/docs/proposals/wave-0-step-2-call-site-scoping.md
+++ b/docs/proposals/wave-0-step-2-call-site-scoping.md
@@ -1,100 +1,210 @@
-# Wave 0 step 2 — coordination-failure call-site scoping
+# Wave 0 step 2 — coordination-failure call-site scoping (v0.2 post-council)
 
-**Purpose:** scope the four `coordination_failure.*` event-type emit sites for `audit.coordination_events` (PR #342). One pass; no code yet — surface the design choices first so the implementation PR ships with operator-anchored decisions instead of inferences.
+**Purpose:** scope the four `coordination_failure.*` emit families for `audit.coordination_events` (PR #342). v0.1 of this doc went out for council review (3-agent: dialectic-knowledge-architect, feature-dev:code-reviewer, live-verifier in parallel, adversarial framing). Council returned **1 BLOCK + 2 CONCERN-ONLY with near-BLOCK items** plus 4 factual REFUTED claims. v0.2 folds every finding.
 
-**Read this with:** `docs/proposals/beam-footprint-roadmap-v0.md` §86–110 (the envelope spec) and `src/coordination_events.py` (the emitter from #342).
+**Read this with:** `docs/proposals/beam-footprint-roadmap-v0.md` §86–110 (envelope spec), `src/coordination_events.py` (emitter from #342), the v0.1 council reports (in PR #342 thread).
+
+## v0.1 → v0.2 council changes
+
+| Finding | Origin | v0.2 fix |
+|---|---|---|
+| **BLOCK**: 1c "lossless" framing wrong — auth/refused/DNS fail same way on retry | code-reviewer | **Dropped 1c.** Bootstrap-failure path now writes a structured stderr line; Chronicler sweeps stderr into the table on next healthy connect. §1 below. |
+| **BLOCK**: emitter raises inside `except` clauses → masks original exception | code-reviewer | **Mandatory** `try/except Exception: logger.warning(...)` wrapper at every wired site. Pattern locked in §"Mandatory wrapper pattern" below. |
+| **REFUTED**: `_load_binding_from_redis` has NO `CancelledError` site — only `TimeoutError` | live-verifier | **Phantom site removed.** Real CancelledError sites in `background_tasks.py` substituted (verified: lines 415 + 423). §2. |
+| **REFUTED**: `ExecutorPool` has no `submit()` method, no pending-count metric | live-verifier | **3a re-scoped** as "build the metric, then wire it." LOC estimate revised ~50→~120. §3. |
+| **REFUTED**: `@mcp_tool` wrapper has no `agent_id` or pool reference | live-verifier | **Pool/agent_id source explicit** — wrapper extracts agent_id from `arguments`; pool fetched via module-level `get_pool()`. §4. |
+| **REFUTED**: line anchors drifted (203-213 not 208-219; 193 not 173; 4 indexes not 3) | live-verifier | All anchors corrected throughout. |
+| **C5 (near-BLOCK)**: `payload.subtype` violates §110 spirit — same anti-pattern one field deeper | architect | **Migration 035 regex bumped to `^(coordination_failure)(\.[a-z_]+)+$`** (sub-namespace allowed). All sub-discriminators land in event_type: `coordination_failure.mcp_handler_timeout.identity_step`, etc. |
+| **C3 (CONCERN)**: mcp_handler_timeout + anyio_cancellation co-occur — no dedup story | architect | **`incident_id` UUID** added to payload contract. All events fired from one root cause share an incident_id. Dashboard-side aggregation does the dedup; no special server logic. §"Dedup contract" below. |
+| **C1 (near-BLOCK)**: "spurious CancelledError" lacks structural discriminator | architect | Replaced pinned-list scoping with **explicit named sub-types per call site** (`coordination_failure.anyio_cancellation.background_task`, `.executor_loop`, etc.). Each site documents its discriminator at landing time; no implicit "spurious vs expected" classification. §2. |
+| **C2 (near-BLOCK)**: Wave 1 exit criterion evaluable on incomplete data during 2A→2B→2C window | architect | **Wave 1 clock starts only when 2C lands**, per the new §"Wave 1 readiness gate" below. PR descriptions enforce this. |
+| **N1 (architect)**: ~7 silent commitments not on decisions list | architect | All promoted. Decisions table now has 12 rows. |
+
+## The four event_type families (v0.2)
+
+Migration 035's regex now allows sub-namespaces (post-council change above). Wave 0 step 2 wires these specific event_types — all start with `coordination_failure.`:
+
+| Family | Sub-types in Wave 0 step 2 | Source |
+|---|---|---|
+| `asyncpg_connect_error` | bootstrap, runtime | §1 |
+| `anyio_cancellation` | background_task, executor_loop | §2 |
+| `executor_pool_exhaustion` | acquire_pending_high_water | §3 |
+| `mcp_handler_timeout` | tool_decorator, resident_progress, identity_step | §4 |
+
+## Mandatory wrapper pattern (every wired site)
+
+Every `await emit_event(...)` call MUST be wrapped:
+
+```python
+try:
+    await emit_event(
+        pool,
+        service=...,
+        event_type=...,
+        payload={"incident_id": str(incident_id), ...},
+    )
+except Exception as emit_exc:  # noqa: BLE001 — observability MUST NOT mask the real bug
+    logger.warning(
+        "coordination_events emit failed (event_type=%s): %r — original exception preserved",
+        event_type,
+        emit_exc,
+    )
+```
+
+Per code-reviewer BLOCK-2: every wired site is inside an `except` clause; an emitter that raises would replace the original `ConnectionError`/`TimeoutError`/`CancelledError` with the emit-failure traceback. The wrapper makes that impossible by structural discipline. Reviewers MUST reject any PR that emits without this wrapper.
+
+## Dedup contract (incident_id)
+
+When multiple event_type rows fire from one root cause (e.g., MCP handler timeout caused by anyio task-group cancellation that cancelled an asyncpg query), each emit's `payload.incident_id` MUST be the same UUID. Generated at the outermost emit site of the cluster; passed down via the exception chain (or via a contextvar if the chain is broken).
+
+Dashboard / Sentinel rules aggregate by `incident_id` for true incident counts. Raw event_type counts remain useful for "which class fires most" but are explicitly NOT incident counts.
+
+This is the only protection against double-counting that the doc commits to. Roadmap §129's "zero coordination-class incidents" is evaluated against `COUNT(DISTINCT payload->>'incident_id')`, not raw row count.
+
+## Wave 1 readiness gate
+
+Wave 1's exit criterion (roadmap §129: "the 14-day window AND the Wave 0 incident-feed must both hold") is now formally **gated on Wave 0 step 2C landing**. The 14-day window cannot start counting before all four event_type families have a wired emitter. Otherwise Wave 1 would pass on under-counted data — exactly what architect C2 surfaced.
+
+PR descriptions for 2A and 2B MUST include a row in the test plan table:
+
+| Wave 1 readiness | This PR contributes _______ event_type families. _______ remain before clock can start. |
 
 ---
 
-## 1. `coordination_failure.asyncpg_connect_error` — clean chokepoint
+## §1. `coordination_failure.asyncpg_connect_error`
 
-**Where:** `src/db/postgres_backend.py:208-219` `_create_pool`.
+**Two sub-types per call-site:**
 
-```python
-except asyncio.TimeoutError:
-    raise ConnectionError(...)
-except Exception as e:
-    raise ConnectionError(f"Failed to connect to PostgreSQL ... {e}") from e
+### 1.bootstrap
+
+**Where:** `src/db/postgres_backend.py:203-213` `_create_pool` (line range corrected post-live-verifier).
+
+**Status of pool at raise:** None. `_create_pool` returns the pool to `_ensure_pool` (line 175); the assignment to `self._pool` happens after return. So at raise time, `self._pool is None`.
+
+**Path:** stderr structured-log line, NOT a separate `asyncpg.connect`. Reasoning per architect C4 + code-reviewer BLOCK-1: a fresh connect with the same credentials would fail the same way for the most-diagnostic cases (auth, refused, DNS). The architecturally honest answer is "we cannot reach the table when the table's substrate is down."
+
+**Stderr line format** (single-line JSON, parseable by Chronicler sweeper):
+
+```json
+{"_coord_event":true,"service":"governance_mcp","event_type":"coordination_failure.asyncpg_connect_error.bootstrap","payload":{"error_class":"OSError","db_url_hash":"abc123","timeout_s":5.0,"attempt":1,"incident_id":"<uuid>"},"context":{...}}
 ```
 
-**Plan:** add `await emit_event(pool=None_or_self, service="governance_mcp", event_type=ASYNCPG_CONNECT_ERROR, payload={...})` before each `raise`. Payload: `{error_class, db_url_hash, timeout_s, attempt}`.
+**Chronicler sweeper** (separate Wave 0 step 3 work — runs on its existing daily cadence): `tail -F /Users/cirwel/Library/Logs/governance-mcp-stderr.log | grep '_coord_event' | jq | INSERT into audit.coordination_events`. Buffered between sweeps; loss bounded to "events from windows where governance-mcp was down AND Chronicler hadn't run yet" — a small tail.
 
-**Choice point — emit before the pool exists:** the very first connect error is the one we most want to log, but there's no pool to write to yet. Options:
-- **(a)** Lazy retry — buffer the event in-memory and emit after the next successful connect lands. Lossless but couples observability to recovery.
-- **(b)** Skip the bootstrap-failure case — only emit on subsequent connect errors after the pool has been up. Simple but misses the most diagnostic event.
-- **(c) [recommended]** Use a separate short-lived `asyncpg.connect` direct-INSERT (no pool, no transaction) just for the event. Slow path for the failure case, which is fine — failures are rare; the cost is bounded.
+### 1.runtime
 
-## 2. `coordination_failure.anyio_cancellation` — scope question
+**Where:** every connection-acquire failure within an established pool (e.g., `asyncpg.InterfaceError` on `pool.acquire()`). Wired at the `ExecutorPool.acquire` failure path in `src/db/executor_pool.py`.
 
-**Where:** ~10 `except (asyncio.)CancelledError` sites across `src/background_tasks.py`, `src/knowledge_graph_lifecycle.py`, etc. Most are normal lifecycle (shutdown, cycle timeout, deliberate cancel).
+**Path:** normal `await emit_event(pool=self_or_global, ...)` — pool is established, table is reachable. Use the mandatory wrapper.
 
-**The problem:** emitting on EVERY `CancelledError` would be noisy and useless. The roadmap's intent is the *spurious* cancellations from the anyio-asyncio conflict (CLAUDE.md "Known Issue") — when the MCP SDK's task group cancels an asyncpg/Redis call mid-flight without a real shutdown signal.
+---
 
-**Choice point — what counts as "spurious":**
-- **(a) [recommended]** Only emit when CancelledError fires INSIDE a known-conflict path: `_load_binding_from_redis` (identity_step.py), `deep_health_probe_task` (background_tasks.py:380), and any `run_in_executor` call that wraps a sync DB client. Pin the emit site list explicitly in the PR description; reviewer audits each.
-- **(b)** Emit on every CancelledError, tag `payload.expected: True|False` based on whether the task name is in a known-shutdown allowlist. Higher signal volume, ambiguous classification.
-- **(c)** Defer — wait for Wave 1's Sentinel-on-BEAM canary to surface real conflict events first, then instrument the specific paths it identifies. Punts the measurement we said we needed.
+## §2. `coordination_failure.anyio_cancellation`
 
-## 3. `coordination_failure.executor_pool_exhaustion` — needs probe target
+**Sub-types in Wave 0 step 2:**
 
-**Where:** `src/db/executor_pool.py` is the dedicated background-thread pool that isolates asyncpg from anyio. "Exhaustion" here means tasks queueing on the pool's submit-queue beyond a threshold, or the executor loop falling behind.
+### 2.background_task
 
-**The problem:** the existing ExecutorPool doesn't have an exhaustion signal. It just submits coroutines to the executor loop — backpressure is invisible until the queue grows unbounded.
+**Where:** `src/background_tasks.py` — verified CancelledError catch sites at:
+- line 78 (in `_supervised_create_task` outer guard)
+- line 147 (in `wait_for` timeout-and-cancel path)
+- line 172, line 178, line 213 (per-task except)
+- line 415 + 423 in `deep_health_probe_task`
 
-**Choice point — where to measure:**
-- **(a) [recommended]** Add a counter at `ExecutorPool.submit` for `pending_count`; emit when `pending_count > threshold` (e.g., 50) within a 1-min window. Coarse but actionable. Threshold is operator-tunable.
-- **(b)** Wrap `asyncio.wait_for` around each submit with timeout=2s; emit on TimeoutError. Catches latency spikes but fires on *any* slow query, not just exhaustion.
-- **(c)** Defer — instrument when we have a real pool exhaustion incident to characterize. Punts.
+**Approach:** instrument the OUTER supervisor (`_supervised_create_task` line 78 area). Single emit point; payload carries `task_name` so per-task attribution lands without per-site instrumentation. Per architect C1 — explicit-named sub-type means future maintainers see the contract in the event_type, not in implicit "is this spurious" judgment.
 
-## 4. `coordination_failure.mcp_handler_timeout` — clean chokepoint
+### 2.executor_loop
+
+**Where:** `src/db/executor_pool.py` — when the executor loop's main task receives a CancelledError that wasn't operator-initiated (e.g., GC cancelled the pool's lifecycle task during anyio teardown).
+
+**Approach:** wrap the executor loop's main coroutine in a try/except that distinguishes shutdown-initiated cancel (a flag the operator sets) from external cancel.
+
+**NOT a Wave 0 step 2 wired site:** `_load_binding_from_redis` (live-verifier REFUTED — function has no CancelledError catch, only TimeoutError; would require ADDING a behavior change to instrument). Re-evaluate after the dashboard surfaces actual anyio incident volume.
+
+---
+
+## §3. `coordination_failure.executor_pool_exhaustion`
+
+### 3.acquire_pending_high_water
+
+**Where:** `src/db/executor_pool.py`. Live-verified state: NO `submit()` method. Operations go through `acquire() -> _AcquireContext -> _await_on_loop`.
+
+**Implementation shape (re-scoped post-council):**
+- Add `self._pending = 0` + `threading.Lock` to `ExecutorPool.__init__`
+- Increment in `_AcquireContext.__aenter__`, decrement in `__aexit__` (need to thread the counter ref into the context)
+- Add `pending_count` property
+- Periodic check task on the main loop: every 30s, if `pending_count > THRESHOLD` (env-tunable, default 50), emit ONCE per high-water episode (debounced — re-emit only after pending drops below threshold and rises again)
+
+**LOC estimate (revised):** ~120 LOC + tests, NOT ~50. Includes `_AcquireContext` refactor to carry a counter ref.
+
+**Re-evaluation gate:** if the implementation lift is genuinely > 200 LOC (e.g., `_AcquireContext` lifecycle is more entangled than the live-verifier surfaced), defer to "deferred-pending-real-incident" rather than ship a half-baked metric.
+
+---
+
+## §4. `coordination_failure.mcp_handler_timeout`
+
+**Sub-types in Wave 0 step 2:**
+
+### 4.tool_decorator
 
 **Where:** `src/mcp_handlers/decorators.py:108` `@mcp_tool` wrapper's `except asyncio.TimeoutError`.
 
-```python
-except asyncio.TimeoutError:
-    logger.warning(f"Tool '{tool_name}' timed out after {timeout}s")
-    return [error_response(...)]
-```
+**Pool source (corrected post-live-verifier):** wrapper has NO context-injected pool. Use module-level `from src.db import get_pool` and call `get_pool()` inside the except path. CLAUDE.md anyio caveat applies — `get_pool()` MUST be already-initialized at this point (it is — handlers fire after pool init). Document this as a load-order assumption.
 
-**Plan:** add `await emit_event(pool, service="governance_mcp", event_type=MCP_HANDLER_TIMEOUT, payload={tool_name, timeout_s, elapsed_s, agent_id})` before the `return`. The pool is reachable via the existing handler-context (every MCP handler has a DB connection available).
+**agent_id source:** extract from `arguments.get("agent_id")` or `arguments.get("client_session_id")` if the tool injected it. May be None — that's fine, the column is nullable.
 
-**Choice point — secondary timeout sites:**
-- `resident_progress.py:96` — wraps an INSERT in `asyncio.wait_for(_insert(), timeout=4.5)`. Emits a separate `coordination_failure.mcp_handler_timeout` with payload distinguishing tool-level vs sub-operation timeout.
-- `identity_step.py:173` — Redis fallback path with 500ms timeout. Same event_type, payload.subtype="identity_step".
+### 4.resident_progress
 
-**Recommended:** ship the decorator chokepoint in PR A; secondary sites in a follow-up PR after the dashboard surfaces what the volume looks like.
+**Where:** `src/mcp_handlers/resident_progress.py:95` `await asyncio.wait_for(_insert(), timeout=4.5)` (line 95 not 96 — except clause is 96).
+
+### 4.identity_step
+
+**Where:** `src/mcp_handlers/middleware/identity_step.py:193` `_load_binding_from_redis` 500ms `wait_for` (line 193 not 173 per live-verifier REFUTED).
 
 ---
 
-## Recommended PR shape
+## Recommended PR shape (v0.2)
 
-**Wave 0 step 2A — clean chokepoints (small, low-risk):**
-- `coordination_failure.asyncpg_connect_error` (path **1c** above)
-- `coordination_failure.mcp_handler_timeout` at the decorator chokepoint only
-- ~50 LOC + tests
+**Wave 0 step 2A — clean chokepoints:**
+- 1.bootstrap (stderr structured log, no DB write)
+- 1.runtime (ExecutorPool.acquire failure path)
+- 4.tool_decorator
+- ~80 LOC + tests + module-level `get_pool` documentation
+- Wave 1 readiness: contributes 2/4 families (asyncpg_connect_error, mcp_handler_timeout)
 
-**Wave 0 step 2B — anyio + executor (scoped, needs operator decisions):**
-- `coordination_failure.anyio_cancellation` per **2a**
-- `coordination_failure.executor_pool_exhaustion` per **3a** with tunable threshold
-- ~150 LOC + tests + a tunable threshold env var
+**Wave 0 step 2B — anyio + executor:**
+- 2.background_task (supervisor-level)
+- 2.executor_loop
+- 3.acquire_pending_high_water (with the counter refactor)
+- ~150-200 LOC + tests
+- Wave 1 readiness: contributes 2/4 families (anyio_cancellation, executor_pool_exhaustion)
+- After 2B lands, Wave 1's 14-day clock can start
 
-**Wave 0 step 2C — secondary timeout sites:**
-- After step 3 (Chronicler projection) lands and dashboard shows timeout volume
+**Wave 0 step 2C — secondary timeout sub-types + Chronicler stderr sweeper:**
+- 4.resident_progress, 4.identity_step
+- Chronicler stderr-line → audit.coordination_events sweeper (carries 1.bootstrap events into the table)
+- ~80 LOC + tests
+- Wave 1 readiness: complete; dashboard panel can land in step 4
 
-Splitting 2A from 2B/C keeps the high-confidence emits unblocked by the scope-decision emits.
-
-## Decisions you need to make
+## Decisions you need to make (v0.2 — 12 rows)
 
 | # | Choice | My recommendation |
 |---|---|---|
-| 1 | Bootstrap-failure asyncpg event path | **1c** — short-lived direct-INSERT |
-| 2 | Spurious CancelledError scoping | **2a** — pinned site list, audited |
-| 3 | Executor exhaustion measurement | **3a** — pending_count threshold |
-| 4 | Secondary timeout sites | Defer to step 2C |
-| 5 | PR splitting | 2A + 2B + 2C as separate PRs |
+| 1 | Bootstrap-failure asyncpg event path | Stderr structured-log + Chronicler sweep (post-council pivot) |
+| 2 | Spurious CancelledError scoping | Per-site explicit sub-types; no implicit "spurious vs expected" classification |
+| 3 | Executor exhaustion measurement | `pending_count` counter via `_AcquireContext` refactor (~120 LOC, not ~50) |
+| 4 | Sub-namespace `event_type` instead of `payload.subtype` | Migration 035 regex amended (this PR); all sub-discriminators in event_type |
+| 5 | Dedup of co-occurring events | `payload.incident_id` UUID; dashboard aggregates by it |
+| 6 | Wave 1 readiness gate | 14-day clock starts only when 2C lands; PR descriptions enforce |
+| 7 | Mandatory wrapper at emit sites | Yes — locked pattern, reviewer BLOCK if missing |
+| 8 | Emit timing relative to original `raise` | After the `raise` would lose the event on process death; before the `raise` adds latency. **Recommendation: before** — observability beats latency in the failure path |
+| 9 | Pool source at decorator chokepoint | Module-level `from src.db import get_pool`; load-order assumption documented |
+| 10 | Sentinel rule design timing | Wait until 2C lands so rules can reference all 4 families |
+| 11 | PR splitting | 2A (clean) + 2B (counter refactor) + 2C (secondary + sweeper) |
+| 12 | Counter-refactor risk threshold | If 2B implementation crosses 200 LOC, defer 3 to "wait for real incident" rather than over-build |
 
-If you accept the recommendations as a block, say "ship 2A" or "ship all" and I take it from there. If you want a different shape on any row, name it and I redirect.
+If you accept the v0.2 recommendations as a block: "ship 2A". If you want to redirect any row, name it. If you want a third council pass on this revision, say so — the architect lane explicitly noted this is a "fold then re-pass" situation.
 
 ---
 
-**Cost estimate:** 2A is ~1hr including tests. 2B is ~3hr because of the threshold-tuning and the per-site audit on the CancelledError list. 2C waits on Chronicler projection (step 3). The roadmap's "days, not weeks" framing fits if 2A+2B land cleanly without re-scope churn.
+**Cost estimate (revised):** 2A is ~2hr including tests + Chronicler-sweeper-stub. 2B is ~5hr (the counter refactor is the variable). 2C is ~3hr. Roadmap's "days, not weeks" framing still fits if 2A+2B+2C land in sequence without re-scope churn.

--- a/src/coordination_events.py
+++ b/src/coordination_events.py
@@ -1,0 +1,210 @@
+"""Wave 0 coordination-event emitter (RFC docs/proposals/beam-footprint-roadmap-v0.md).
+
+Single-surface replay log for coordination-class failures across all services
+(sentinel, governance_mcp, lease_plane, vigil, chronicler, watcher). Wave 1's
+exit criterion (incident-rate trends, the "stop or proceed to BEAM port"
+signal) reads from `audit.coordination_events`.
+
+Wave 0 lands the foundation:
+  - Migration 035 (the table)
+  - This module (the emitter)
+  - Tests pinning the envelope contract
+
+Wave 0 step 2 wires actual call sites (asyncpg connect errors, anyio task-
+group cancellations, executor pool exhaustion, MCP handler timeouts). Wave 0
+step 3 lands the Chronicler projection. Wave 0 step 4 lands the dashboard panel.
+
+Stability discipline: `event_type` extends ONLY by adding new dotted
+namespaces (coordination_recovery.*, coordination_lifecycle.*, ...). Never
+reuse or rename an existing event_type. The migration's CHECK constraint
+enforces the regex `^(coordination_failure)\\.[a-z_]+$` today; new families
+extend the alternation in a follow-up migration, never silently in caller code.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import socket
+import subprocess
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+from uuid import UUID, uuid4
+
+logger = logging.getLogger(__name__)
+
+# Service enum mirrors migration 035's coordination_events_service_check.
+# Drift caught by test_emit_rejects_unknown_service.
+Service = Literal[
+    "sentinel",
+    "governance_mcp",
+    "lease_plane",
+    "vigil",
+    "chronicler",
+    "watcher",
+]
+
+# Wave 0 event_type values. Future families extend the regex in a follow-up
+# migration AND add their values here in the same PR. Drift caught by
+# test_event_type_constants_match_documented_set.
+COORDINATION_FAILURE_ASYNCPG_CONNECT_ERROR = "coordination_failure.asyncpg_connect_error"
+COORDINATION_FAILURE_ANYIO_CANCELLATION = "coordination_failure.anyio_cancellation"
+COORDINATION_FAILURE_EXECUTOR_POOL_EXHAUSTION = "coordination_failure.executor_pool_exhaustion"
+COORDINATION_FAILURE_MCP_HANDLER_TIMEOUT = "coordination_failure.mcp_handler_timeout"
+
+WAVE_0_EVENT_TYPES: frozenset[str] = frozenset({
+    COORDINATION_FAILURE_ASYNCPG_CONNECT_ERROR,
+    COORDINATION_FAILURE_ANYIO_CANCELLATION,
+    COORDINATION_FAILURE_EXECUTOR_POOL_EXHAUSTION,
+    COORDINATION_FAILURE_MCP_HANDLER_TIMEOUT,
+})
+
+# Cached emitter context — git_commit and host don't change at runtime.
+# service_pid and running_since are per-process; the rest are per-host.
+_CONTEXT_CACHE: dict[str, Any] | None = None
+
+
+def _git_commit_short() -> str:
+    """Return the short git SHA of the running deploy, or 'unknown' on failure.
+
+    Captured once at first emit and cached. The captured value is the SHA at
+    process startup — long-running services that survive across deploys will
+    still report their original startup SHA, which is the correct attribution
+    semantics (the running binary IS that SHA, regardless of what's checked
+    out on disk now). Per memory `feedback_running-process-vs-master-commit`.
+    """
+    try:
+        repo_root = Path(__file__).resolve().parent.parent
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+            check=False,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip() or "unknown"
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.debug("[coord-events] git_commit lookup failed: %r", exc)
+    return "unknown"
+
+
+def _build_context() -> dict[str, Any]:
+    """Build the emitter context envelope. Cached after first call.
+
+    Per the roadmap envelope spec: `{git_commit, service_pid, running_since, host}`.
+    These are facts about the emitter, not the event — callers don't pass this.
+    """
+    global _CONTEXT_CACHE
+    if _CONTEXT_CACHE is not None:
+        return _CONTEXT_CACHE
+
+    _CONTEXT_CACHE = {
+        "git_commit": _git_commit_short(),
+        "service_pid": os.getpid(),
+        "running_since": datetime.now(UTC).isoformat(),
+        "host": socket.gethostname(),
+    }
+    return _CONTEXT_CACHE
+
+
+def _validate_event_type(event_type: str) -> None:
+    """Mirror of migration 035's regex CHECK on event_type, raised client-side
+    so callers get a precise typed error before the DB rejects."""
+    if not isinstance(event_type, str):
+        raise ValueError(f"event_type must be a string, got {type(event_type).__name__}")
+    parts = event_type.split(".")
+    if len(parts) != 2:
+        raise ValueError(
+            f"event_type {event_type!r} must be 'family.subtype' (RFC roadmap §94)"
+        )
+    family, subtype = parts
+    if family != "coordination_failure":
+        raise ValueError(
+            f"event_type {event_type!r}: family {family!r} not in Wave 0 set "
+            f"({{'coordination_failure'}}). Add via migration when extending."
+        )
+    if not subtype or not all(c.islower() or c == "_" for c in subtype):
+        raise ValueError(
+            f"event_type {event_type!r}: subtype must be lowercase + underscores"
+        )
+
+
+async def emit_event(
+    pool,
+    *,
+    service: Service,
+    event_type: str,
+    payload: dict[str, Any] | None = None,
+    agent_id: str | None = None,
+    ts: datetime | None = None,
+) -> UUID:
+    """Emit a coordination event into `audit.coordination_events`.
+
+    Args:
+        pool: an asyncpg connection pool. Caller-supplied so this module
+              doesn't take a hard dependency on a specific pool helper.
+        service: emitter identity, must be in the migration-035 service enum.
+        event_type: dotted family.subtype, validated client-side here AND
+                    server-side by the namespace CHECK constraint.
+        payload: event-type-specific structure. MUST be a dict (mirrors the
+                 jsonb_typeof = 'object' CHECK). Empty dict is valid.
+        agent_id: optional UNITARES UUID when the event is agent-attributable.
+        ts: optional override; defaults to now() in UTC. Pass-through for
+            tests and for events captured asynchronously where the emit
+            happens later than the event itself.
+
+    Returns the event_id UUID (server-generated; useful for tests and replay).
+
+    Failure semantics: this is observability infrastructure for OTHER bugs.
+    A failure to emit MUST NOT crash the caller — but the caller is also
+    not expected to wrap this in try/except. Errors here are logged at
+    WARNING and re-raised so that test infrastructure can catch them; the
+    individual call-site wrapping (Wave 0 step 2) controls swallow vs
+    propagate per-site based on whether the emitter caller can afford to
+    fail (most can't — they're already in an error path).
+    """
+    _validate_event_type(event_type)
+    if payload is not None and not isinstance(payload, dict):
+        raise ValueError(f"payload must be a dict, got {type(payload).__name__}")
+
+    event_id = uuid4()
+    effective_ts = ts or datetime.now(UTC)
+    context = _build_context()
+    payload_to_write = payload or {}
+
+    sql = """
+    INSERT INTO audit.coordination_events
+        (ts, event_id, service, event_type, agent_id, payload, context)
+    VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb)
+    """
+
+    import json
+    async with pool.acquire() as conn:
+        await conn.execute(
+            sql,
+            effective_ts,
+            event_id,
+            service,
+            event_type,
+            agent_id,
+            json.dumps(payload_to_write),
+            json.dumps(context),
+        )
+
+    logger.debug(
+        "[coord-events] emitted %s/%s event_id=%s agent_id=%s",
+        service,
+        event_type,
+        event_id,
+        agent_id,
+    )
+    return event_id
+
+
+def reset_context_cache_for_tests() -> None:
+    """Clear the cached context so tests can re-derive without process reload."""
+    global _CONTEXT_CACHE
+    _CONTEXT_CACHE = None

--- a/src/coordination_events.py
+++ b/src/coordination_events.py
@@ -112,24 +112,33 @@ def _build_context() -> dict[str, Any]:
 
 def _validate_event_type(event_type: str) -> None:
     """Mirror of migration 035's regex CHECK on event_type, raised client-side
-    so callers get a precise typed error before the DB rejects."""
+    so callers get a precise typed error before the DB rejects.
+
+    Sub-namespaces are ALLOWED — `coordination_failure.mcp_handler_timeout` and
+    `coordination_failure.mcp_handler_timeout.identity_step` both pass. Per the
+    council architect C5 finding (post-v0.1 review): subtype discrimination
+    belongs in the event_type contract, not in a payload subtype enum.
+    """
     if not isinstance(event_type, str):
         raise ValueError(f"event_type must be a string, got {type(event_type).__name__}")
     parts = event_type.split(".")
-    if len(parts) != 2:
+    if len(parts) < 2:
         raise ValueError(
-            f"event_type {event_type!r} must be 'family.subtype' (RFC roadmap §94)"
+            f"event_type {event_type!r} must be 'family.subtype' or "
+            f"'family.subtype.subsubtype' (RFC roadmap §94)"
         )
-    family, subtype = parts
+    family = parts[0]
     if family != "coordination_failure":
         raise ValueError(
             f"event_type {event_type!r}: family {family!r} not in Wave 0 set "
             f"({{'coordination_failure'}}). Add via migration when extending."
         )
-    if not subtype or not all(c.islower() or c == "_" for c in subtype):
-        raise ValueError(
-            f"event_type {event_type!r}: subtype must be lowercase + underscores"
-        )
+    for segment in parts[1:]:
+        if not segment or not all(c.islower() or c == "_" for c in segment):
+            raise ValueError(
+                f"event_type {event_type!r}: every segment must be "
+                f"lowercase + underscores (failed segment: {segment!r})"
+            )
 
 
 async def emit_event(

--- a/tests/test_coordination_events.py
+++ b/tests/test_coordination_events.py
@@ -1,0 +1,324 @@
+"""Tests for src/coordination_events.py — Wave 0 emitter.
+
+Pins the migration-035 envelope contract:
+  - Service enum (6 names; rejection of unknowns)
+  - event_type namespace (regex coordination_failure.<lowercase_subtype>)
+  - payload + context MUST be JSON objects
+  - context auto-populated by emitter (caller doesn't pass)
+  - event_id returned for replay/dedup
+  - agent_id optional, indexed for per-agent attribution
+
+Live DB integration tests against governance_test (mirrors the
+test_lease_plane_substrate_state.py pattern).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+try:
+    import asyncpg
+except ImportError:
+    pytest.skip("asyncpg not installed", allow_module_level=True)
+
+from tests.test_db_utils import (
+    TEST_DB_URL,
+    can_connect_to_test_db,
+    ensure_test_database_schema,
+)
+
+if not can_connect_to_test_db():
+    pytest.skip("governance_test database not available", allow_module_level=True)
+
+from src.coordination_events import (  # noqa: E402
+    COORDINATION_FAILURE_ANYIO_CANCELLATION,
+    COORDINATION_FAILURE_ASYNCPG_CONNECT_ERROR,
+    COORDINATION_FAILURE_EXECUTOR_POOL_EXHAUSTION,
+    COORDINATION_FAILURE_MCP_HANDLER_TIMEOUT,
+    WAVE_0_EVENT_TYPES,
+    _validate_event_type,
+    emit_event,
+    reset_context_cache_for_tests,
+)
+
+
+_TEST_AGENT_ID = "00000000-0000-4000-8000-000000000001"
+
+
+@pytest_asyncio.fixture
+async def pool():
+    await ensure_test_database_schema()
+    pool = await asyncpg.create_pool(TEST_DB_URL, min_size=1, max_size=2)
+    try:
+        yield pool
+    finally:
+        await pool.close()
+
+
+@pytest.fixture(autouse=True)
+def _reset_context_cache():
+    reset_context_cache_for_tests()
+    yield
+    reset_context_cache_for_tests()
+
+
+async def _cleanup(pool, agent_id: str = _TEST_AGENT_ID) -> None:
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "DELETE FROM audit.coordination_events WHERE agent_id = $1 OR "
+            "context->>'host' = 'pytest-test-host'",
+            agent_id,
+        )
+
+
+# ---------- event_type validation (client-side mirror of CHECK regex) ----------
+
+
+def test_validate_event_type_accepts_all_wave_0_constants():
+    """Every documented Wave 0 event_type passes client-side validation."""
+    for et in WAVE_0_EVENT_TYPES:
+        _validate_event_type(et)  # must not raise
+
+
+def test_event_type_constants_match_documented_set():
+    """Drift guard: WAVE_0_EVENT_TYPES MUST equal the four documented values.
+    If you add a new event_type to the module, also extend the migration's
+    regex CHECK and the dashboard panel — drift between code and DB CHECK
+    becomes silent rejection."""
+    expected = {
+        "coordination_failure.asyncpg_connect_error",
+        "coordination_failure.anyio_cancellation",
+        "coordination_failure.executor_pool_exhaustion",
+        "coordination_failure.mcp_handler_timeout",
+    }
+    assert WAVE_0_EVENT_TYPES == expected
+
+
+def test_validate_event_type_rejects_unknown_family():
+    """Family must be 'coordination_failure' (Wave 0). Wave 1+ extend the
+    regex via migration AND register the new family here in the same PR."""
+    with pytest.raises(ValueError, match="not in Wave 0 set"):
+        _validate_event_type("coordination_recovery.something")
+
+
+def test_validate_event_type_rejects_missing_subtype():
+    with pytest.raises(ValueError, match="family.subtype"):
+        _validate_event_type("coordination_failure")
+
+
+def test_validate_event_type_rejects_uppercase_subtype():
+    """Migration regex pins lowercase + underscores. Validate client-side too
+    so callers get a clear error before the DB rejects."""
+    with pytest.raises(ValueError, match="lowercase"):
+        _validate_event_type("coordination_failure.AsyncpgConnectError")
+
+
+def test_validate_event_type_rejects_empty_string():
+    with pytest.raises(ValueError):
+        _validate_event_type("")
+
+
+# ---------- live DB emit + read-back ----------
+
+
+@pytest.mark.asyncio
+async def test_emit_event_writes_row_with_envelope_fields(pool):
+    """The full envelope contract: emit returns event_id; row in DB has all
+    seven required columns populated correctly; context is auto-set."""
+    await _cleanup(pool)
+
+    payload = {"error_class": "ConnectionRefused", "retries": 3}
+    event_id = await emit_event(
+        pool,
+        service="lease_plane",
+        event_type=COORDINATION_FAILURE_ASYNCPG_CONNECT_ERROR,
+        payload=payload,
+        agent_id=_TEST_AGENT_ID,
+    )
+    assert isinstance(event_id, uuid.UUID)
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT ts, event_id, service, event_type, agent_id, "
+            "       payload, context "
+            "FROM audit.coordination_events WHERE event_id = $1",
+            event_id,
+        )
+    assert row is not None
+    assert row["service"] == "lease_plane"
+    assert row["event_type"] == COORDINATION_FAILURE_ASYNCPG_CONNECT_ERROR
+    assert row["agent_id"] == _TEST_AGENT_ID
+
+    payload_back = json.loads(row["payload"])
+    assert payload_back["error_class"] == "ConnectionRefused"
+    assert payload_back["retries"] == 3
+
+    context_back = json.loads(row["context"])
+    # Context auto-populated by emitter — caller did NOT pass these.
+    assert "git_commit" in context_back
+    assert "service_pid" in context_back
+    assert "running_since" in context_back
+    assert "host" in context_back
+
+    await _cleanup(pool)
+
+
+@pytest.mark.asyncio
+async def test_emit_event_omits_agent_id_when_none(pool):
+    """agent_id is optional. When None, the row stores NULL (the partial
+    index idx_coord_events_agent_ts WHERE agent_id IS NOT NULL skips it)."""
+    await _cleanup(pool)
+
+    event_id = await emit_event(
+        pool,
+        service="governance_mcp",
+        event_type=COORDINATION_FAILURE_MCP_HANDLER_TIMEOUT,
+        payload={"tool": "process_agent_update", "timeout_ms": 45000},
+    )
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT agent_id FROM audit.coordination_events WHERE event_id = $1",
+            event_id,
+        )
+    assert row["agent_id"] is None
+
+    async with pool.acquire() as conn:
+        await conn.execute("DELETE FROM audit.coordination_events WHERE event_id = $1", event_id)
+
+
+@pytest.mark.asyncio
+async def test_emit_event_empty_payload_uses_default_object(pool):
+    """Caller may pass payload=None; emitter substitutes empty dict, which
+    satisfies the jsonb_typeof = 'object' CHECK."""
+    await _cleanup(pool)
+
+    event_id = await emit_event(
+        pool,
+        service="vigil",
+        event_type=COORDINATION_FAILURE_ANYIO_CANCELLATION,
+    )
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT payload FROM audit.coordination_events WHERE event_id = $1",
+            event_id,
+        )
+    assert json.loads(row["payload"]) == {}
+    async with pool.acquire() as conn:
+        await conn.execute("DELETE FROM audit.coordination_events WHERE event_id = $1", event_id)
+
+
+@pytest.mark.asyncio
+async def test_emit_event_rejects_non_dict_payload(pool):
+    """payload MUST be a dict — emitter rejects client-side. Mirrors the
+    jsonb_typeof = 'object' CHECK so the error message names the field
+    rather than surfacing as a Postgres CHECK violation."""
+    with pytest.raises(ValueError, match="payload must be a dict"):
+        await emit_event(
+            pool,
+            service="watcher",
+            event_type=COORDINATION_FAILURE_EXECUTOR_POOL_EXHAUSTION,
+            payload="not a dict",  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.asyncio
+async def test_emit_event_rejects_unknown_service_via_db(pool):
+    """Service enum is enforced server-side by CHECK. The Service Literal
+    type catches it at the type-checker level; here we exercise the DB
+    rejection path (the type system isn't enforced at runtime)."""
+    with pytest.raises(asyncpg.exceptions.CheckViolationError) as exc_info:
+        await emit_event(
+            pool,
+            service="not_a_real_service",  # type: ignore[arg-type]
+            event_type=COORDINATION_FAILURE_ASYNCPG_CONNECT_ERROR,
+        )
+    assert "service" in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_emit_event_rejects_unknown_event_type_namespace_via_validator(pool):
+    """Client-side validator catches unknown families before the DB does.
+    Faster failure + clearer error message than the regex CHECK."""
+    with pytest.raises(ValueError, match="not in Wave 0 set"):
+        await emit_event(
+            pool,
+            service="sentinel",
+            event_type="coordination_recovery.healing",
+        )
+
+
+@pytest.mark.asyncio
+async def test_emit_event_returns_distinct_event_ids(pool):
+    """Each emit gets a fresh UUID — no event_id collision under rapid emit."""
+    await _cleanup(pool)
+
+    ids = []
+    for _ in range(5):
+        eid = await emit_event(
+            pool,
+            service="sentinel",
+            event_type=COORDINATION_FAILURE_ANYIO_CANCELLATION,
+            payload={"task_name": "fleet_cycle"},
+            agent_id=_TEST_AGENT_ID,
+        )
+        ids.append(eid)
+    assert len(set(ids)) == 5  # all distinct
+
+    await _cleanup(pool)
+
+
+@pytest.mark.asyncio
+async def test_emit_event_explicit_ts_passes_through(pool):
+    """Caller may pass ts override (for events captured asynchronously where
+    emit happens later than the event itself)."""
+    await _cleanup(pool)
+    event_ts = datetime.now(UTC) - timedelta(seconds=120)
+
+    event_id = await emit_event(
+        pool,
+        service="chronicler",
+        event_type=COORDINATION_FAILURE_ASYNCPG_CONNECT_ERROR,
+        payload={},
+        ts=event_ts,
+    )
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT ts FROM audit.coordination_events WHERE event_id = $1",
+            event_id,
+        )
+    # tolerance for timestamptz round-trip jitter
+    assert abs((row["ts"] - event_ts).total_seconds()) < 0.001
+    async with pool.acquire() as conn:
+        await conn.execute("DELETE FROM audit.coordination_events WHERE event_id = $1", event_id)
+
+
+@pytest.mark.asyncio
+async def test_context_cache_returns_same_values_across_emits(pool):
+    """Per the module docstring: context is captured once at first emit and
+    cached. Two emits in the same process must report the same git_commit,
+    pid, host, running_since (the running process IS that triple)."""
+    await _cleanup(pool)
+    e1 = await emit_event(pool, service="vigil", event_type=COORDINATION_FAILURE_ANYIO_CANCELLATION)
+    e2 = await emit_event(pool, service="vigil", event_type=COORDINATION_FAILURE_ANYIO_CANCELLATION)
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT context FROM audit.coordination_events WHERE event_id IN ($1, $2)",
+            e1, e2,
+        )
+    contexts = [json.loads(r["context"]) for r in rows]
+    assert contexts[0] == contexts[1]
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "DELETE FROM audit.coordination_events WHERE event_id IN ($1, $2)", e1, e2
+        )

--- a/tests/test_coordination_events.py
+++ b/tests/test_coordination_events.py
@@ -111,6 +111,20 @@ def test_validate_event_type_rejects_unknown_family():
         _validate_event_type("coordination_recovery.something")
 
 
+def test_validate_event_type_accepts_sub_namespace():
+    """Sub-namespaces extend the event_type contract (council C5): subtype
+    discrimination lives in event_type, NOT in payload.subtype.
+
+    Examples that MUST pass:
+      coordination_failure.mcp_handler_timeout                    (one segment)
+      coordination_failure.mcp_handler_timeout.identity_step      (two segments)
+      coordination_failure.mcp_handler_timeout.resident_progress  (alt subtype)
+    """
+    _validate_event_type("coordination_failure.mcp_handler_timeout.identity_step")
+    _validate_event_type("coordination_failure.mcp_handler_timeout.resident_progress")
+    _validate_event_type("coordination_failure.anyio_cancellation.background_task")
+
+
 def test_validate_event_type_rejects_missing_subtype():
     with pytest.raises(ValueError, match="family.subtype"):
         _validate_event_type("coordination_failure")

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -128,6 +128,9 @@ async def ensure_test_database_schema() -> None:
         # Migration 034: substrate_state columns for §7.13 resident heartbeat surface
         # (RFC v0.11). Adds 2 NULLABLE columns + 4 CHECK constraints + freshness index.
         await _execute_sql_file(conn, "db/postgres/migrations/034_lease_plane_substrate_state.sql")
+        # Migration 035: Wave 0 coordination_events instrumentation table.
+        # See docs/proposals/beam-footprint-roadmap-v0.md.
+        await _execute_sql_file(conn, "db/postgres/migrations/035_coordination_events.sql")
 
         # Ensure partitioned audit tables can accept inserts for current month.
         await _execute_sql_file(conn, "db/postgres/partitions.sql")


### PR DESCRIPTION
## Summary

**Wave 0 step 1 of 4.** First gate of the BEAM footprint roadmap (#333). Per the roadmap, no later wave's exit criterion can be honestly evaluated without coordination-class incident-rate measurement infrastructure — Wave 0 lands the foundation (table + emitter + tests) before any port begins.

**Foundation only — no callers wired yet.** Wave 0 step 2 wires the four named coordination-failure points (asyncpg connect errors, anyio task-group cancellations, executor pool exhaustion, MCP handler timeouts) in a follow-up PR. Step 3 lands Chronicler projection. Step 4 lands the dashboard panel.

## What landed

### Migration 035 (`db/postgres/migrations/035_coordination_events.sql`)
- `audit.coordination_events` table partitioned by ts (mirrors existing `audit.outcome_events` / `audit.tool_usage` pattern)
- 7-column envelope per roadmap §94: `ts, event_id, service, event_type, agent_id, payload (jsonb), context (jsonb)`
- 4 CHECK constraints (DO/EXCEPTION-wrapped for idempotent re-run):
  - service enum (sentinel|governance_mcp|lease_plane|vigil|chronicler|watcher)
  - event_type namespace regex `^coordination_failure\.[a-z_]+$`
  - payload MUST be jsonb object
  - context MUST be jsonb object
- 3 indexes (service+ts, event_type+ts, agent+ts partial WHERE agent_id IS NOT NULL)
- Initial partitions for 2026-05/06 + default catch-all

### Emitter (`src/coordination_events.py`)
- `emit_event(pool, *, service, event_type, payload=None, agent_id=None, ts=None) -> UUID`
- `Service` Literal type matches migration enum (drift caught by tests)
- `WAVE_0_EVENT_TYPES` frozenset matches migration regex (drift caught by tests)
- Client-side `_validate_event_type` mirrors the regex CHECK so callers get precise typed errors before the DB rejects
- Context auto-populated (`git_commit, service_pid, running_since, host`) and cached after first emit — facts about the emitter, not the event, per roadmap §94
- Returns `event_id` UUID (server-generated; useful for replay/dedup)
- Failure semantics: `emit_event` raises on validation/DB errors. Per-call-site wrapping in Wave 0 step 2 controls swallow vs propagate based on whether the emitter caller can afford to fail (most can't — they're already in an error path)

### Tests (`tests/test_coordination_events.py` — 15 new)

| Coverage | Tests |
|---|---|
| Drift guards | `WAVE_0_EVENT_TYPES` matches documented set; service Literal matches DB CHECK |
| Client-side validator | Accepts all Wave 0 constants; rejects unknown family/missing subtype/uppercase/empty |
| Live-DB round-trip | All 7 envelope columns populated; context auto-set; agent_id NULL when omitted |
| Schema invariants | Empty payload → `{}`; non-dict payload rejected client-side; unknown service rejected by DB CHECK |
| Replay/dedup | Distinct `event_id` across rapid emit |
| Async semantics | Explicit `ts` override; context cache stable across emits |

### `tests/test_db_utils.py`
- `ensure_test_database_schema` applies migration 035

## Stability discipline (per roadmap §110)

`event_type` extends ONLY by adding new dotted families (`coordination_recovery.*`, `coordination_lifecycle.*`) via a follow-up migration AND a same-PR registration in `WAVE_0_EVENT_TYPES`. Never reuse or rename existing values. The migration's regex CHECK enforces the contract today.

## Test plan

- [x] `./scripts/dev/test-cache.sh` — **8263 passed, 34 skipped, 0 failures**
- [x] 15 new coordination-event tests pass
- [x] Migration applied cleanly to `governance` AND `governance_test`
- [x] Pre-push smoke: 138 passed
- [x] No production behavior change — no callers wired yet

## Wave 0 stack ahead

| Step | Scope | Status |
|---|---|---|
| 1 | Migration + emitter + tests (this PR) | 🔵 open |
| 2 | Wire the 4 named coordination-failure points | next |
| 3 | Chronicler projection into `metrics.series` | follows step 2 |
| 4 | Dashboard panel | follows step 3 |

After Wave 0 closes, Wave 1's exit criterion (incident-rate trend over 14-day window) becomes evaluable from this single replay surface.

🤖 Implements roadmap §86 Wave 0 step 1.
