### PR TITLE
feat(enrichment): lite_safe flag — skip response-shaping enrichments for response_mode=minimal

### DIFF
--- a/src/mcp_handlers/updates/enrichments.py
+++ b/src/mcp_handlers/updates/enrichments.py
@@ -413,7 +413,7 @@ def enrich_detected_patterns(ctx: UpdateContext) -> None:
 
 # ─── Knowledge Surfacing ───────────────────────────────────────────────
 
-@enrichment(order=130)
+@enrichment(order=130, lite_safe=True)
 async def enrich_knowledge_surfacing(ctx: UpdateContext) -> None:
     """Surface top 3 relevant discoveries based on agent tags."""
     try:
@@ -928,7 +928,7 @@ def enrich_eisv_validation(ctx: UpdateContext) -> None:
 
 # ─── Learning Context ──────────────────────────────────────────────────
 
-@enrichment(order=210)
+@enrichment(order=210, lite_safe=True)
 async def enrich_learning_context(ctx: UpdateContext) -> None:
     """Surface agent's own history for in-context learning."""
     try:
@@ -1189,7 +1189,7 @@ async def enrich_websocket_broadcast(ctx: UpdateContext) -> None:
 
 # ─── Mirror Signals ───────────────────────────────────────────────────
 
-@enrichment(order=240)
+@enrichment(order=240, lite_safe=True)
 async def enrich_mirror_signals(ctx: UpdateContext) -> None:
     """Build actionable self-awareness signals for mirror response mode.
 

--- a/src/mcp_handlers/updates/pipeline.py
+++ b/src/mcp_handlers/updates/pipeline.py
@@ -27,19 +27,28 @@ class _EnrichmentEntry(NamedTuple):
     order: int
     name: str
     is_async: bool
+    lite_safe: bool = False
 
 
 _ENRICHMENTS: List[_EnrichmentEntry] = []
 
 
-def enrichment(order: int):
-    """Register a function in the enrichment pipeline at *order*."""
+def enrichment(order: int, *, lite_safe: bool = False):
+    """Register a function in the enrichment pipeline at *order*.
+
+    lite_safe=True marks the enrichment as response-shaping only — safe to
+    skip when the caller requested response_mode='minimal' (the lite path
+    used by embedded brokers like anima-broker that read action+margin and
+    discard the rest). Default False keeps existing behavior for callers
+    that use non-lite modes.
+    """
     def decorator(fn: Callable) -> Callable:
         _ENRICHMENTS.append(_EnrichmentEntry(
             fn=fn,
             order=order,
             name=fn.__name__,
             is_async=inspect.iscoroutinefunction(fn),
+            lite_safe=lite_safe,
         ))
         _ENRICHMENTS.sort(key=lambda e: e.order)
         return fn
@@ -54,8 +63,12 @@ async def run_enrichment_pipeline(ctx) -> None:
     runs serially today; this instrumentation is the prerequisite for
     deciding which enrichments are safe to parallelize.
     """
+    is_lite = (getattr(ctx, "arguments", None) or {}).get("response_mode") == "minimal"
     timings: List[tuple[str, int]] = []
     for entry in _ENRICHMENTS:
+        if is_lite and entry.lite_safe:
+            timings.append((entry.name, -1))  # -1 sentinel = skipped (lite)
+            continue
         start = time.perf_counter()
         try:
             if entry.is_async:
@@ -67,7 +80,9 @@ async def run_enrichment_pipeline(ctx) -> None:
         timings.append((entry.name, int((time.perf_counter() - start) * 1000)))
 
     if timings:
-        rendered = " ".join(f"{name}={ms}ms" for name, ms in timings)
+        rendered = " ".join(
+            f"{name}={'skip' if ms < 0 else f'{ms}ms'}" for name, ms in timings
+        )
         logger.info(f"[enrichment_phases] {rendered}")
 
 

--- a/tests/test_enrichment_pipeline.py
+++ b/tests/test_enrichment_pipeline.py
@@ -105,3 +105,121 @@ class TestPipelineRunner:
         finally:
             _ENRICHMENTS.clear()
             _ENRICHMENTS.extend(original)
+
+
+class TestLiteModeSkipping:
+    """response_mode='minimal' callers (e.g. anima-broker) skip lite_safe enrichments.
+
+    The broker reads action+margin from the locked-update phase and discards the
+    rest of the response. Running expensive response-shaping enrichments for it
+    only inflates p95 latency past the broker's 5s client timeout. lite_safe=True
+    on an enrichment marks it as response-shaping-only — safe to skip in lite
+    mode, runs normally otherwise.
+    """
+
+    @pytest.mark.asyncio
+    async def test_lite_safe_runs_when_response_mode_is_full(self):
+        from src.mcp_handlers.updates.pipeline import (
+            _EnrichmentEntry,
+            _ENRICHMENTS,
+        )
+
+        call_log = []
+
+        def heavy(ctx):
+            call_log.append("heavy")
+
+        def cheap(ctx):
+            call_log.append("cheap")
+
+        original = list(_ENRICHMENTS)
+        _ENRICHMENTS.clear()
+        _ENRICHMENTS.extend([
+            _EnrichmentEntry(fn=cheap, order=1, name="cheap", is_async=False, lite_safe=False),
+            _EnrichmentEntry(fn=heavy, order=2, name="heavy", is_async=False, lite_safe=True),
+        ])
+
+        try:
+            ctx = MagicMock()
+            ctx.arguments = {"response_mode": "full"}
+            await run_enrichment_pipeline(ctx)
+            assert call_log == ["cheap", "heavy"]
+        finally:
+            _ENRICHMENTS.clear()
+            _ENRICHMENTS.extend(original)
+
+    @pytest.mark.asyncio
+    async def test_lite_safe_skipped_when_response_mode_is_minimal(self):
+        from src.mcp_handlers.updates.pipeline import (
+            _EnrichmentEntry,
+            _ENRICHMENTS,
+        )
+
+        call_log = []
+
+        def heavy(ctx):
+            call_log.append("heavy")
+
+        def cheap(ctx):
+            call_log.append("cheap")
+
+        original = list(_ENRICHMENTS)
+        _ENRICHMENTS.clear()
+        _ENRICHMENTS.extend([
+            _EnrichmentEntry(fn=cheap, order=1, name="cheap", is_async=False, lite_safe=False),
+            _EnrichmentEntry(fn=heavy, order=2, name="heavy", is_async=False, lite_safe=True),
+        ])
+
+        try:
+            ctx = MagicMock()
+            ctx.arguments = {"response_mode": "minimal"}
+            await run_enrichment_pipeline(ctx)
+            assert call_log == ["cheap"]
+        finally:
+            _ENRICHMENTS.clear()
+            _ENRICHMENTS.extend(original)
+
+    @pytest.mark.asyncio
+    async def test_non_lite_safe_runs_in_minimal_mode(self):
+        """Side-effect enrichments (websocket_broadcast, basin_tracking, etc.)
+        default lite_safe=False and must still run in minimal mode."""
+        from src.mcp_handlers.updates.pipeline import (
+            _EnrichmentEntry,
+            _ENRICHMENTS,
+        )
+
+        call_log = []
+
+        def side_effect(ctx):
+            call_log.append("side_effect")
+
+        original = list(_ENRICHMENTS)
+        _ENRICHMENTS.clear()
+        _ENRICHMENTS.extend([
+            _EnrichmentEntry(fn=side_effect, order=1, name="side_effect", is_async=False, lite_safe=False),
+        ])
+
+        try:
+            ctx = MagicMock()
+            ctx.arguments = {"response_mode": "minimal"}
+            await run_enrichment_pipeline(ctx)
+            assert call_log == ["side_effect"]
+        finally:
+            _ENRICHMENTS.clear()
+            _ENRICHMENTS.extend(original)
+
+    def test_marked_enrichments_are_lite_safe(self):
+        """Lock in which production enrichments are marked lite_safe so we don't
+        silently flip a non-lite_safe one to skip during refactors."""
+        names_to_lite_safe = {e.name: e.lite_safe for e in _ENRICHMENTS}
+        # Currently marked lite_safe — these are the dominant cost
+        # contributors per the [enrichment_phases] log analysis on 2026-05-04
+        # (learning_context 4-9s every call, knowledge_surfacing 2.5s tail,
+        # mirror_signals only meaningful for response_mode='mirror').
+        assert names_to_lite_safe.get("enrich_learning_context") is True
+        assert names_to_lite_safe.get("enrich_knowledge_surfacing") is True
+        assert names_to_lite_safe.get("enrich_mirror_signals") is True
+        # Side-effect enrichments must NOT be lite_safe — confirms intent.
+        assert names_to_lite_safe.get("enrich_websocket_broadcast") is False
+        assert names_to_lite_safe.get("enrich_basin_tracking") is False
+        assert names_to_lite_safe.get("enrich_identity_notifications") is False


### PR DESCRIPTION
Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.