### PR TITLE
feat(coord-failure): context fallback for caller agent_id + session_id

### DIFF
--- a/src/coordination_failure_emit.py
+++ b/src/coordination_failure_emit.py
@@ -54,6 +54,7 @@ def emit_coordination_failure_sync(
     event_type: str,
     payload: dict[str, Any] | None = None,
     agent_id: str | None = None,
+    session_id: str | None = None,
 ) -> None:
     """Emit a coordination-failure event via the sync `audit_logger._write_entry` path.
 
@@ -73,6 +74,9 @@ def emit_coordination_failure_sync(
                     documented sub-namespaces.
         payload: event-specific structure. Stored under details.payload.
         agent_id: optional UNITARES UUID when agent-attributable.
+        session_id: optional session_key for cross-event correlation. Persists to
+                    audit.events.session_id column (text, indexed via session
+                    pattern). Decorator passes get_context_session_key().
     """
     if not isinstance(event_type, str) or not event_type.startswith("coordination_failure."):
         logger.warning(
@@ -99,6 +103,7 @@ def emit_coordination_failure_sync(
                 "service": effective_service,
                 "payload": payload or {},
             },
+            session_id=session_id,
         )
         audit_logger._write_entry(entry)
     except Exception as exc:  # noqa: BLE001 — observability MUST NOT mask the real bug

--- a/src/mcp_handlers/decorators.py
+++ b/src/mcp_handlers/decorators.py
@@ -117,15 +117,36 @@ def mcp_tool(
                 from src.coordination_failure_emit import (
                     emit_coordination_failure_sync,
                 )
+                from src.mcp_handlers.context import (
+                    get_context_agent_id,
+                    get_context_session_key,
+                )
+
+                # Caller agent_id: prefer arguments-supplied (target/explicit) but
+                # fall back to the session contextvar so consolidated tools like
+                # observe(action=aggregate) — which carry no agent_id arg — still
+                # attribute to the bound caller. Without the fallback, ~100% of
+                # observed timeouts since 2A merged had agent_id NULL.
+                args_agent_id = (
+                    arguments.get("agent_id") if isinstance(arguments, dict) else None
+                )
+                effective_agent_id = args_agent_id or get_context_agent_id()
+                session_id = get_context_session_key()
+
+                emit_payload: Dict[str, Any] = {
+                    "tool_name": tool_name,
+                    "timeout_s": timeout,
+                    "elapsed_s": round(time.time() - start_time, 3),
+                }
+                if isinstance(arguments, dict) and arguments.get("action"):
+                    emit_payload["action"] = arguments["action"]
+
                 emit_coordination_failure_sync(
                     service="governance_mcp",
                     event_type="coordination_failure.mcp_handler_timeout.tool_decorator",
-                    payload={
-                        "tool_name": tool_name,
-                        "timeout_s": timeout,
-                        "elapsed_s": round(time.time() - start_time, 3),
-                    },
-                    agent_id=arguments.get("agent_id") if isinstance(arguments, dict) else None,
+                    payload=emit_payload,
+                    agent_id=effective_agent_id,
+                    session_id=session_id,
                 )
                 return [error_response(
                     f"Tool '{tool_name}' timed out after {timeout} seconds.",

--- a/tests/test_coordination_failure_emit.py
+++ b/tests/test_coordination_failure_emit.py
@@ -151,3 +151,34 @@ def test_emit_handles_none_agent_id():
             agent_id=None,
         )
     assert fake_entry_cls.call_args.kwargs["agent_id"] is None
+
+
+def test_emit_passes_session_id_to_audit_entry():
+    """session_id flows through to AuditEntry so it lands on audit.events.session_id.
+    Without this, every coord-failure event has a NULL session column and cross-event
+    correlation in the same caller session is impossible."""
+    fake_logger = MagicMock()
+    with patch("src.audit_log.audit_logger", fake_logger), \
+         patch("src.audit_log.AuditEntry") as fake_entry_cls:
+        emit_coordination_failure_sync(
+            service="governance_mcp",
+            event_type="coordination_failure.mcp_handler_timeout.tool_decorator",
+            payload={"tool_name": "x"},
+            agent_id="some-uuid",
+            session_id="session-key-abc",
+        )
+    assert fake_entry_cls.call_args.kwargs["session_id"] == "session-key-abc"
+
+
+def test_emit_session_id_defaults_to_none():
+    """When caller omits session_id (e.g., out-of-context emit path), AuditEntry
+    receives session_id=None — column is nullable."""
+    fake_logger = MagicMock()
+    with patch("src.audit_log.audit_logger", fake_logger), \
+         patch("src.audit_log.AuditEntry") as fake_entry_cls:
+        emit_coordination_failure_sync(
+            service="governance_mcp",
+            event_type="coordination_failure.mcp_handler_timeout.tool_decorator",
+            payload={"tool_name": "x"},
+        )
+    assert fake_entry_cls.call_args.kwargs["session_id"] is None

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -231,7 +231,8 @@ class TestDecoratorExecution:
 
     @pytest.mark.asyncio
     async def test_timeout_emit_handles_arguments_without_agent_id(self):
-        """When arguments dict has no agent_id, emit passes None — column is nullable."""
+        """When arguments dict has no agent_id and no session context, emit
+        passes None — column is nullable."""
         from unittest.mock import patch
 
         @mcp_tool("test_no_agent_id_on_timeout", timeout=0.05)
@@ -244,6 +245,99 @@ class TestDecoratorExecution:
 
         mock_emit.assert_called_once()
         assert mock_emit.call_args.kwargs["agent_id"] is None
+        assert mock_emit.call_args.kwargs["session_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_timeout_emit_falls_back_to_context_agent_id(self):
+        """For consolidated tools like observe(action=aggregate) that carry no
+        agent_id arg, the decorator MUST fall back to the session contextvar.
+        Without this, ~100% of timeouts attribute to NULL agent_id (observed
+        empirically across 6 events post-2A merge)."""
+        from unittest.mock import patch
+        from src.mcp_handlers.context import set_session_context, reset_session_context
+
+        @mcp_tool("test_ctx_fallback", timeout=0.05)
+        async def handle_test_ctx_fallback(arguments):
+            await asyncio.sleep(5)
+            return []
+
+        token = set_session_context(
+            session_key="caller-session-key",
+            client_session_id="client-1",
+            agent_id="caller-uuid-from-ctx",
+        )
+        try:
+            with patch("src.coordination_failure_emit.emit_coordination_failure_sync") as mock_emit:
+                await handle_test_ctx_fallback({})  # no agent_id in args
+        finally:
+            reset_session_context(token)
+
+        mock_emit.assert_called_once()
+        assert mock_emit.call_args.kwargs["agent_id"] == "caller-uuid-from-ctx"
+        assert mock_emit.call_args.kwargs["session_id"] == "caller-session-key"
+
+    @pytest.mark.asyncio
+    async def test_timeout_emit_arguments_agent_id_wins_over_context(self):
+        """When arguments dict supplies an explicit agent_id, it takes precedence
+        over the contextvar — the explicit target trumps the bound caller."""
+        from unittest.mock import patch
+        from src.mcp_handlers.context import set_session_context, reset_session_context
+
+        @mcp_tool("test_args_wins", timeout=0.05)
+        async def handle_test_args_wins(arguments):
+            await asyncio.sleep(5)
+            return []
+
+        token = set_session_context(
+            session_key="caller-session",
+            client_session_id="client-1",
+            agent_id="caller-uuid",
+        )
+        try:
+            with patch("src.coordination_failure_emit.emit_coordination_failure_sync") as mock_emit:
+                await handle_test_args_wins({"agent_id": "explicit-target-uuid"})
+        finally:
+            reset_session_context(token)
+
+        mock_emit.assert_called_once()
+        assert mock_emit.call_args.kwargs["agent_id"] == "explicit-target-uuid"
+        # session_id still comes from context regardless
+        assert mock_emit.call_args.kwargs["session_id"] == "caller-session"
+
+    @pytest.mark.asyncio
+    async def test_timeout_emit_surfaces_action_in_payload(self):
+        """Consolidated tools dispatch via arguments['action']; surfacing it in
+        payload lets downstream filters distinguish observe(action=aggregate)
+        timeouts from observe(action=agent) timeouts without payload archaeology."""
+        from unittest.mock import patch
+
+        @mcp_tool("test_action_payload", timeout=0.05)
+        async def handle_test_action_payload(arguments):
+            await asyncio.sleep(5)
+            return []
+
+        with patch("src.coordination_failure_emit.emit_coordination_failure_sync") as mock_emit:
+            await handle_test_action_payload({"action": "aggregate"})
+
+        mock_emit.assert_called_once()
+        assert mock_emit.call_args.kwargs["payload"]["action"] == "aggregate"
+
+    @pytest.mark.asyncio
+    async def test_timeout_emit_omits_action_key_when_absent(self):
+        """Non-consolidated tools (no 'action' arg) don't leak a phantom action
+        key — payload stays minimal."""
+        from unittest.mock import patch
+
+        @mcp_tool("test_no_action_key", timeout=0.05)
+        async def handle_test_no_action_key(arguments):
+            await asyncio.sleep(5)
+            return []
+
+        with patch("src.coordination_failure_emit.emit_coordination_failure_sync") as mock_emit:
+            await handle_test_no_action_key({"some_other_arg": "x"})
+
+        mock_emit.assert_called_once()
+        assert "action" not in mock_emit.call_args.kwargs["payload"]
 
 
 class TestGetToolMetadata:


### PR DESCRIPTION
Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.