### PR TITLE
vigil: stop test-log pollution leaking into production

### DIFF
--- a/agents/vigil/agent.py
+++ b/agents/vigil/agent.py
@@ -53,7 +53,10 @@ ANIMA_PROJECT = Path(os.getenv("ANIMA_PROJECT", str(project_root.parent / "anima
 SESSION_FILE = Path.home() / ".unitares" / "anchors" / "vigil.json"
 LEGACY_SESSION_FILE = project_root / ".vigil_session"
 STATE_FILE = project_root / ".vigil_state"
-LOG_FILE = Path.home() / "Library" / "Logs" / "unitares-vigil.log"
+LOG_FILE = Path(os.getenv(
+    "VIGIL_LOG_FILE",
+    str(Path.home() / "Library" / "Logs" / "unitares-vigil.log"),
+))
 MAX_LOG_LINES = 500
 
 # Test timeout

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,31 @@
 """
 Pytest configuration and fixtures for unitares tests.
 """
+import os
 import pytest
 import pytest_asyncio
+import tempfile
 import warnings
 import sys
 import asyncio
 from collections import defaultdict, deque
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
+
+# Redirect Vigil's log file to a temp path BEFORE any test imports the agent
+# module. The agent's LOG_FILE is resolved at module-import time from the
+# VIGIL_LOG_FILE env var, so this must happen before the first
+# `from agents.vigil.agent import …` anywhere in the test suite.
+#
+# Without this, tests that mock client.audit_knowledge to raise
+# (e.g. RuntimeError("boom")) and call _run_stale_opens_sweep through a real
+# VigilAgent log "stale-opens sweep failed (boom); continuing cycle" to the
+# operator's production Vigil log at ~/Library/Logs/unitares-vigil.log —
+# observed in the wild as a steady stream of test-injected noise.
+os.environ.setdefault(
+    "VIGIL_LOG_FILE",
+    str(Path(tempfile.gettempdir()) / "unitares-vigil-test.log"),
+)
 
 # Filter ResourceWarnings globally before any imports
 warnings.filterwarnings("ignore", category=ResourceWarning)


### PR DESCRIPTION
## Summary

The "funny virus bug" the operator spotted in the Vigil cron log — repeating \`stale-opens sweep failed (boom)\` and \`no matching baseline for config=bge_m3\` lines — was test pollution leaking into production. Tests in \`tests/test_vigil_stale_opens.py\` and \`tests/test_vigil_eval_step.py\` construct a real \`VigilAgent\`, mock errors, and call the cycle methods. Both methods log via the module-level \`LOG_FILE = Path.home()/Library/Logs/unitares-vigil.log\` — the operator's actual production log.

84 polluting lines had accumulated there since the tests were introduced. They were initially read as real Vigil cron-fire failures during the auto-archive activation review.

## Fix

- \`agents/vigil/agent.py\`: \`LOG_FILE\` becomes env-overridable via \`VIGIL_LOG_FILE\` (production behavior unchanged when env unset).
- \`tests/conftest.py\`: \`os.environ.setdefault("VIGIL_LOG_FILE", "/tmp/unitares-vigil-test.log")\` runs at conftest-import time, before any test imports the agent module.

\`agents/vigil/tests/test_groundskeeper.py\` already mitigated this for itself by mutating \`_hb_module.LOG_FILE\` post-import. The conftest approach protects all tests — current and future — regardless of import path.

## Test plan
- [x] 105/105 vigil tests pass (84 in \`agents/vigil/tests/\` + 17 in \`tests/test_vigil_*\` + the 4 new ones from PR #352).
- [x] Verified production log delta = 0 after running the polluting tests with the fix in place.
- [x] Verified temp log at \`/var/folders/.../T/unitares-vigil-test.log\` receives the test-injected lines.