### PR TITLE
perf(metadata): close cold-start residual via batch provisional + deferred cache hydration

### DIFF
--- a/src/agent_metadata_persistence.py
+++ b/src/agent_metadata_persistence.py
@@ -86,8 +86,14 @@ async def _load_metadata_from_postgres_async() -> dict:
     """
     Load agent metadata from PostgreSQL into AgentMetadata dict.
 
-    PostgreSQL-native loading path for agent metadata.
-    Returns dict of agent_id -> AgentMetadata.
+    Cold-start path: shaped to avoid per-agent awaits. With ~3000 agents
+    the prior per-agent provisional-lineage fetch + per-agent
+    `metadata_cache.set` produced a ~17s first-call tax on observe (see
+    `docs/proposals/beam-footprint-roadmap-v0.md` v0.2 RESOLUTION). Now:
+    bulk PG reads up front (list_agents, get_identities_batch,
+    get_provisional_lineage_set), per-agent computation is sync
+    (compute_trust_tier with prefetched_provisional), and redis
+    hydration is fire-and-forget after the in-memory dict is ready.
     """
     from src import agent_storage
 
@@ -99,13 +105,6 @@ async def _load_metadata_from_postgres_async() -> dict:
 
     result = {}
     now = datetime.now(timezone.utc).isoformat()
-
-    metadata_cache = None
-    try:
-        from src.cache import get_metadata_cache
-        metadata_cache = get_metadata_cache()
-    except Exception:
-        pass
 
     for agent in agents:
         meta = AgentMetadata(
@@ -146,43 +145,46 @@ async def _load_metadata_from_postgres_async() -> dict:
         )
         result[agent.agent_id] = meta
 
-        if metadata_cache:
-            try:
-                await metadata_cache.set(agent.agent_id, meta.to_dict(), ttl=300)
-            except Exception as e:
-                logger.debug(f"Failed to cache metadata for {agent.agent_id[:8]}...: {e}")
+    agent_ids = list(result.keys())
 
-    # Hydrate agent profiles from stored identity metadata
+    # Single batch identity read shared by profile hydration + trust-tier
+    # resolution. Replaces two get_identities_batch calls and removes the
+    # per-agent provisional fetchrow that was the dominant cold-start cost.
+    identities: dict = {}
+    provisional_set: set = set()
     try:
-        from src.agent_profile import hydrate_profile
         from src.db import get_db
         db = get_db()
-        agent_ids = list(result.keys())
-        identities = await db.get_identities_batch(agent_ids)
-        if isinstance(identities, dict):
-            hydrated = 0
-            for aid, identity in identities.items():
-                if identity and identity.metadata and "profile" in identity.metadata:
-                    hydrate_profile(aid, identity.metadata["profile"])
-                    hydrated += 1
-            if hydrated:
-                logger.debug(f"Hydrated {hydrated} agent profiles from PostgreSQL")
-    except Exception as e:
-        logger.debug(f"Agent profile hydration skipped: {e}")
-
-    # Batch-load trust tiers (S6 Option B: substrate-earned routing)
-    try:
-        from src.identity.trust_tier_routing import resolve_trust_tier
-        from src.db import get_db
-        db = get_db()
-        agent_ids = list(result.keys())
-        identities = await db.get_identities_batch(agent_ids)
+        identities = await db.get_identities_batch(agent_ids) or {}
         if not isinstance(identities, dict):
             logger.debug(
-                "Batch trust tier load expected dict from get_identities_batch, got %s",
+                "get_identities_batch expected dict, got %s",
                 type(identities).__name__,
             )
             identities = {}
+        provisional_set = await db.get_provisional_lineage_set(agent_ids)
+    except Exception as e:
+        logger.debug(f"Identity batch read skipped: {e}")
+
+    # Profile hydration (sync in-memory writes once identities are fetched)
+    try:
+        from src.agent_profile import hydrate_profile
+        hydrated = 0
+        for aid, identity in identities.items():
+            if identity and identity.metadata and "profile" in identity.metadata:
+                hydrate_profile(aid, identity.metadata["profile"])
+                hydrated += 1
+        if hydrated:
+            logger.debug(f"Hydrated {hydrated} agent profiles from PostgreSQL")
+    except Exception as e:
+        logger.debug(f"Agent profile hydration skipped: {e}")
+
+    # Trust-tier resolution. With prefetched_provisional + prefetched_tags
+    # the resolve_trust_tier hot path is sync (compute_trust_tier or
+    # evaluate_substrate_earned), so the per-agent await yields one event
+    # loop tick each — no I/O blocking the cold-start.
+    try:
+        from src.identity.trust_tier_routing import resolve_trust_tier
         for aid, identity in identities.items():
             if identity and identity.metadata and "trajectory_current" in identity.metadata:
                 _meta = result.get(aid)
@@ -191,6 +193,7 @@ async def _load_metadata_from_postgres_async() -> dict:
                     identity.metadata,
                     prefetched_tags=getattr(_meta, "tags", None) if _meta else None,
                     prefetched_label=getattr(_meta, "label", None) if _meta else None,
+                    prefetched_provisional=(aid in provisional_set),
                 )
                 result[aid].trust_tier = tier_info.get("name", "unknown")
                 result[aid].trust_tier_num = tier_info.get("tier", 0)
@@ -198,6 +201,31 @@ async def _load_metadata_from_postgres_async() -> dict:
         logger.debug(f"Batch trust tier load skipped: {e}")
 
     return result
+
+
+async def _hydrate_metadata_cache_async(snapshot: dict) -> None:
+    """Fire-and-forget redis cache hydration after the in-memory dict is
+    populated. Sequential `await metadata_cache.set` for ~3000 agents was
+    the dominant cold-start cost; doing it after `_metadata_loaded=True`
+    means observe handlers don't block on it. Errors are swallowed —
+    redis is a cross-process optimization, not the source of truth.
+    """
+    try:
+        from src.cache import get_metadata_cache
+        metadata_cache = get_metadata_cache()
+    except Exception:
+        return
+    if metadata_cache is None:
+        return
+    set_count = 0
+    for agent_id, meta in snapshot.items():
+        try:
+            await metadata_cache.set(agent_id, meta.to_dict(), ttl=300)
+            set_count += 1
+        except Exception as e:
+            logger.debug(f"Failed to cache metadata for {agent_id[:8]}...: {e}")
+    if set_count:
+        logger.debug(f"Hydrated metadata cache for {set_count} agents (deferred)")
 
 
 def _parse_metadata_dict(data: dict) -> dict:
@@ -295,6 +323,14 @@ async def load_metadata_async(force: bool = False) -> None:
         _model._metadata_loaded = True
         _metadata_loaded_event.set()
         logger.debug(f"Loaded {len(agent_metadata)} agents from PostgreSQL (async)")
+        # Redis cache hydration is fire-and-forget — happens after the
+        # in-memory dict is ready and the loaded event is set, so cold-
+        # start observe calls don't block on it. Snapshot the dict so
+        # later mutations don't race the hydration loop.
+        try:
+            asyncio.create_task(_hydrate_metadata_cache_async(dict(result)))
+        except RuntimeError:
+            pass
     except Exception as e:
         logger.error(f"Could not load metadata from PostgreSQL: {e}", exc_info=True)
         _metadata_loaded_event.set()

--- a/src/db/mixins/identity.py
+++ b/src/db/mixins/identity.py
@@ -334,6 +334,27 @@ class IdentityMixin:
                 return False
             return bool(row["provisional_lineage"])
 
+    async def get_provisional_lineage_set(self, agent_ids: list[str]) -> set[str]:
+        """Batch counterpart of is_lineage_provisional.
+
+        Returns the subset of agent_ids whose `provisional_lineage = TRUE`.
+        One query for N agents instead of N queries — used by the
+        cold-start metadata load path so trust-tier resolution can pass
+        `prefetched_provisional` and skip per-agent fetchrow.
+        """
+        if not agent_ids:
+            return set()
+        async with self.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT agent_id FROM core.identities
+                WHERE agent_id = ANY($1::text[])
+                  AND provisional_lineage = TRUE
+                """,
+                agent_ids,
+            )
+            return {row["agent_id"] for row in rows}
+
     async def read_r1_calibration_state(self) -> Dict[str, Any]:
         """Read the R1 calibration_state singleton (v3.3-C).
 

--- a/tests/test_metadata_cold_start.py
+++ b/tests/test_metadata_cold_start.py
@@ -1,0 +1,163 @@
+"""
+Cold-start metadata load: regression tests for the v0.2 RESOLUTION fix.
+
+Pre-fix `_load_metadata_from_postgres_async` had two per-agent await loops
+(`metadata_cache.set` and `is_lineage_provisional` via `resolve_trust_tier`)
+that produced a ~17s first-call tax on observe with ~3000 agents. The fix
+batches the provisional check, makes per-agent trust-tier resolution sync
+via `prefetched_provisional`, and defers redis cache hydration until after
+`_metadata_loaded=True` is flipped. These tests pin those invariants.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+
+def _fake_agent_row(agent_id: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        agent_id=agent_id,
+        status="active",
+        created_at=None,
+        last_activity_at=None,
+        updated_at=None,
+        tags=[],
+        notes="",
+        purpose=None,
+        parent_agent_id=None,
+        spawn_reason=None,
+        health_status="unknown",
+        metadata={"api_key": "k", "agent_uuid": agent_id},
+    )
+
+
+def _fake_identity(agent_id: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        agent_id=agent_id,
+        metadata={"trajectory_current": {"E": 0.5}, "tags": []},
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_per_agent_provisional_fetch():
+    """is_lineage_provisional must NOT be called per agent during cold load.
+
+    Pre-fix this fired N times (N = agent count) — the dominant cold-start
+    cost. Post-fix the bulk get_provisional_lineage_set replaces it.
+    """
+    from src import agent_metadata_persistence
+    from src import agent_metadata_model
+
+    agent_ids = [f"agent-{i:04d}" for i in range(50)]
+    agents = [_fake_agent_row(aid) for aid in agent_ids]
+    identities = {aid: _fake_identity(aid) for aid in agent_ids}
+
+    fake_db = MagicMock()
+    fake_db.get_identities_batch = AsyncMock(return_value=identities)
+    fake_db.get_provisional_lineage_set = AsyncMock(return_value=set())
+    fake_db.is_lineage_provisional = AsyncMock(return_value=False)
+
+    with patch("src.agent_storage.list_agents", new=AsyncMock(return_value=agents)), \
+         patch("src.db.get_db", return_value=fake_db):
+        agent_metadata_model._metadata_loaded = False
+        agent_metadata_model.agent_metadata.clear()
+        await agent_metadata_persistence.load_metadata_async()
+
+    assert fake_db.get_provisional_lineage_set.await_count == 1, \
+        "expected exactly one batch provisional read"
+    assert fake_db.is_lineage_provisional.await_count == 0, \
+        "per-agent is_lineage_provisional must not fire on cold load"
+
+
+@pytest.mark.asyncio
+async def test_loaded_flag_flips_before_cache_hydration():
+    """`_metadata_loaded=True` must be set before metadata_cache.set runs.
+
+    The ordering is what makes observe handlers cold-start fast: they
+    `await load_metadata_async()`, hit the fast-path, and return without
+    waiting on per-agent redis writes.
+    """
+    from src import agent_metadata_persistence
+    from src import agent_metadata_model
+
+    agent_ids = [f"agent-{i:04d}" for i in range(20)]
+    agents = [_fake_agent_row(aid) for aid in agent_ids]
+    identities = {aid: _fake_identity(aid) for aid in agent_ids}
+
+    loaded_when_first_set: dict[str, Optional[bool]] = {"value": None}
+
+    fake_cache = MagicMock()
+
+    async def _tracking_set(agent_id: str, value: Any, ttl: int = 300) -> None:
+        if loaded_when_first_set["value"] is None:
+            loaded_when_first_set["value"] = bool(agent_metadata_model._metadata_loaded)
+
+    fake_cache.set = AsyncMock(side_effect=_tracking_set)
+
+    fake_db = MagicMock()
+    fake_db.get_identities_batch = AsyncMock(return_value=identities)
+    fake_db.get_provisional_lineage_set = AsyncMock(return_value=set())
+
+    with patch("src.agent_storage.list_agents", new=AsyncMock(return_value=agents)), \
+         patch("src.db.get_db", return_value=fake_db), \
+         patch("src.cache.get_metadata_cache", return_value=fake_cache):
+        agent_metadata_model._metadata_loaded = False
+        agent_metadata_model.agent_metadata.clear()
+        await agent_metadata_persistence.load_metadata_async()
+        # Let the fire-and-forget hydration task run.
+        for _ in range(3):
+            await asyncio.sleep(0)
+
+    assert loaded_when_first_set["value"] is True, \
+        "_metadata_loaded must be True before any metadata_cache.set call"
+    assert fake_cache.set.await_count == len(agent_ids), \
+        "all agents must still get cache hydration eventually"
+
+
+@pytest.mark.asyncio
+async def test_provisional_lineage_propagates_to_trust_tier():
+    """Agents in the provisional set must get the provisional-gate tier.
+
+    The batch provisional set is the input; resolve_trust_tier's
+    prefetched_provisional path is what consumes it. If the wiring breaks
+    the provisional gate silently fails open, which is the bug R1 v3.3-D
+    was added to prevent.
+    """
+    from src import agent_metadata_persistence
+    from src import agent_metadata_model
+
+    agent_ids = ["prov-agent", "regular-agent"]
+    agents = [_fake_agent_row(aid) for aid in agent_ids]
+    identities = {aid: _fake_identity(aid) for aid in agent_ids}
+
+    fake_db = MagicMock()
+    fake_db.get_identities_batch = AsyncMock(return_value=identities)
+    fake_db.get_provisional_lineage_set = AsyncMock(return_value={"prov-agent"})
+    fake_db.is_lineage_provisional = AsyncMock(return_value=False)
+
+    with patch("src.agent_storage.list_agents", new=AsyncMock(return_value=agents)), \
+         patch("src.db.get_db", return_value=fake_db):
+        agent_metadata_model._metadata_loaded = False
+        agent_metadata_model.agent_metadata.clear()
+        await agent_metadata_persistence.load_metadata_async()
+
+    prov = agent_metadata_model.agent_metadata.get("prov-agent")
+    regular = agent_metadata_model.agent_metadata.get("regular-agent")
+    assert prov is not None and regular is not None
+    assert prov.trust_tier_num == 1, \
+        "provisional agent must land at tier=1 via the gate"
+    # The regular agent's tier depends on compute_trust_tier of its
+    # metadata, but it must not be the provisional gate value with the
+    # provisional source — the only invariant we assert here is that the
+    # provisional gate did not apply to a non-provisional agent.
+    assert regular.trust_tier != "provisional_lineage_gate"


### PR DESCRIPTION
## Summary

Closes the 17,062ms cold-start residual on first `observe(aggregate)` after governance MCP restart, measured 2026-05-05 in the v0.2 verdict probe (`docs/proposals/beam-footprint-roadmap-v0.md` v0.2 RESOLUTION).

`_load_metadata_from_postgres_async` had two per-agent await loops on the cold-start path: `metadata_cache.set` (sequential redis writes) and `is_lineage_provisional` via `resolve_trust_tier` (per-agent fetchrow). With ~3000 agents that was the dominant cost. After PR #350 dropped `force=True` from observe handlers and PR #354 extended the same fix across 18 sites, this was the last remaining piece — and it only hits the FIRST call after restart, not steady state.

## Three changes

1. **New batch method** `IdentityMixin.get_provisional_lineage_set(agent_ids) -> set[str]` — one query for N agents, replaces N sequential `is_lineage_provisional` fetchrow calls.

2. **Refactor** `_load_metadata_from_postgres_async`:
   - Bulk PG reads up front (list_agents + get_identities_batch + get_provisional_lineage_set)
   - Merges the previously-duplicated `get_identities_batch` calls (profile + trust-tier hydration) into one
   - Passes `prefetched_provisional` to `resolve_trust_tier` so its hot path stays sync (`compute_trust_tier` or `evaluate_substrate_earned`)
   - Per-agent computation no longer does I/O

3. **Defer redis hydration**. Move per-agent `metadata_cache.set` into a fire-and-forget background task (`_hydrate_metadata_cache_async`), scheduled AFTER `agent_metadata` is populated and `_metadata_loaded=True` is flipped. Observe handlers that `await load_metadata_async()` now return as soon as the in-memory dict is ready. Cache misses fall back to in-memory (`lifecycle/query.py:553`) so eventual hydration is fine.

## Classification

This was sequential awaits in our own loop, **not** an anyio/asyncio coupling pattern. Same shape as the PR #350 fix on observe handlers — Python-fixable in place. The v0.2 memory note that called it a "4th anyio/N-await pattern" is technically misclassified; no `CLAUDE.md` substrate-tax update needed.

## Test plan

`tests/test_metadata_cold_start.py` pins three invariants:

- [x] `is_lineage_provisional` is **not** called per agent during cold load (batch-only)
- [x] `_metadata_loaded=True` flips **before** any `metadata_cache.set` call
- [x] Batch provisional set propagates correctly to the trust-tier gate (R1 v3.3-D)

Full suite green on this branch: 8330 passed, 34 skipped, 79.08% coverage.