### PR TITLE
perf(kg-search): parallelize neighbor get_discovery in hybrid_rrf graph expansion

### DIFF
--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -986,8 +986,26 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
                     )
                     missing_ids = [did for did, _ in fused if did not in pool]
                     if missing_ids:
-                        for nid in missing_ids[:30]:
-                            doc = await graph.get_discovery(nid)
+                        # Parallel fetch of neighbor docs not already in the
+                        # semantic+FTS pool. Sequential `await` here was the
+                        # in-handler floor on the 60× KG-call amplification
+                        # measured 2026-05-04 (per-call 21–71ms, in-handler
+                        # ~4,464ms). Each get_discovery does 2 PG round-trips
+                        # (row + backlinks); 30 × 2 = 60 sequential awaits is
+                        # what asyncio.gather collapses to ~pool-size waves.
+                        # Same shape as PR #350/#360 — Python-fixable.
+                        capped = missing_ids[:30]
+                        results = await _asyncio.gather(
+                            *(graph.get_discovery(nid) for nid in capped),
+                            return_exceptions=True,
+                        )
+                        for nid, doc in zip(capped, results):
+                            if isinstance(doc, Exception):
+                                logger.debug(
+                                    f"[KG_SEARCH] neighbor fetch failed for "
+                                    f"{nid[:8]}...: {doc}"
+                                )
+                                continue
                             if doc is not None:
                                 pool[nid] = doc
 

--- a/tests/test_kg_search_neighbor_fetch.py
+++ b/tests/test_kg_search_neighbor_fetch.py
@@ -1,0 +1,138 @@
+"""
+Knowledge-search neighbor-fetch parallelism: regression test for the
+60× KG-call amplification fix.
+
+The hybrid_rrf graph-expansion path in `mcp_handlers/knowledge/handlers.py`
+fetches up to 30 neighbor docs not already in the semantic+FTS pool. Pre-fix
+this was a sequential `for nid in missing_ids: await graph.get_discovery(nid)`
+loop. With each get_discovery doing 2 PG round-trips (row + backlinks),
+30 neighbors meant 60 sequential awaits — the in-handler floor on the
+60× amplification measured 2026-05-04. Post-fix uses asyncio.gather so
+the connection pool determines wall time, not sequential ordering.
+
+This test pins the parallelism by making get_discovery sleep longer than
+the wall-clock budget would allow if calls were sequential.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+
+@pytest.mark.asyncio
+async def test_neighbor_fetch_runs_concurrently():
+    """30 neighbor get_discovery calls must be issued concurrently.
+
+    With a 50ms simulated per-call latency, sequential execution takes
+    ≥1500ms. Concurrent execution finishes in ~50ms (one wave). We
+    assert <500ms — generous enough to absorb event-loop noise but tight
+    enough to fail if the gather() were ever reverted to a sequential
+    `for await` loop.
+    """
+    from src.mcp_handlers.knowledge import handlers
+
+    fetched_ids: list[str] = []
+
+    class FakeDoc:
+        def __init__(self, did: str) -> None:
+            self.id = did
+            self.tags = []
+            self.related_to = []
+            self.responses_from = []
+            self.response_to = None
+
+    class FakeGraph:
+        async def get_discovery(self, nid: str) -> Any:
+            fetched_ids.append(nid)
+            await asyncio.sleep(0.05)
+            return FakeDoc(nid)
+
+    graph = FakeGraph()
+    missing_ids = [f"doc-{i:03d}" for i in range(30)]
+    pool: dict[str, Any] = {}
+
+    # Mirror the handler's gather call shape exactly. If the handler's
+    # implementation drifts back to sequential, this stays concurrent —
+    # so we also have the source-level assertion below.
+    t0 = time.perf_counter()
+    capped = missing_ids[:30]
+    results = await asyncio.gather(
+        *(graph.get_discovery(nid) for nid in capped),
+        return_exceptions=True,
+    )
+    for nid, doc in zip(capped, results):
+        if isinstance(doc, Exception):
+            continue
+        if doc is not None:
+            pool[nid] = doc
+    elapsed_ms = (time.perf_counter() - t0) * 1000
+
+    assert len(pool) == 30
+    assert elapsed_ms < 500, \
+        f"neighbor fetch took {elapsed_ms:.1f}ms — gather() not running concurrently?"
+
+    # Source-level pin: the handler must use asyncio.gather, not a plain
+    # for/await loop. If someone reverts the fix this assertion fires.
+    src = inspect.getsource(handlers)
+    # The fixed shape: gather(*(graph.get_discovery(nid) for nid in capped))
+    assert "asyncio.gather" in src or "_asyncio.gather" in src, \
+        "expected asyncio.gather usage in knowledge handlers"
+    # Find the missing_ids block specifically — the gather must live
+    # inside it, not just exist somewhere else in the file.
+    idx = src.find("missing_ids = [did for did, _ in fused if did not in pool]")
+    assert idx >= 0, "missing_ids fan-out block not located"
+    block = src[idx:idx + 1500]
+    assert "gather(" in block, \
+        "missing_ids fetch must use gather() — sequential await loop reverts the perf fix"
+
+
+@pytest.mark.asyncio
+async def test_neighbor_fetch_swallows_individual_failures():
+    """One failing get_discovery must not poison the others.
+
+    `return_exceptions=True` keeps successful neighbor fetches in the
+    pool while the failing id is logged and skipped. Without this, a
+    single AGE/PG hiccup would cancel the whole graph-expansion stage
+    of hybrid search.
+    """
+
+    class FakeDoc:
+        def __init__(self, did: str) -> None:
+            self.id = did
+
+    fail_id = "doc-bad"
+
+    class FakeGraph:
+        async def get_discovery(self, nid: str) -> Any:
+            if nid == fail_id:
+                raise RuntimeError("simulated AGE failure")
+            return FakeDoc(nid)
+
+    graph = FakeGraph()
+    missing_ids = ["doc-001", fail_id, "doc-002"]
+    pool: dict[str, Any] = {}
+
+    capped = missing_ids[:30]
+    results = await asyncio.gather(
+        *(graph.get_discovery(nid) for nid in capped),
+        return_exceptions=True,
+    )
+    for nid, doc in zip(capped, results):
+        if isinstance(doc, Exception):
+            continue
+        if doc is not None:
+            pool[nid] = doc
+
+    assert "doc-001" in pool
+    assert "doc-002" in pool
+    assert fail_id not in pool


### PR DESCRIPTION
## Summary

Closes the in-handler floor on the **60× KG-call amplification** measured 2026-05-04 (per-call 21–71ms standalone, ~4,464ms in-handler). The hybrid_rrf graph-expansion path in `mcp_handlers/knowledge/handlers.py` does up to 30 sequential `await graph.get_discovery(nid)` calls when neighbor docs aren't already in the semantic+FTS pool. Each `get_discovery` does 2 PG round-trips (row + backlinks), so 30 neighbors = 60 sequential awaits — same shape as the floors PR #350/#360 closed on observe + cold-start.

`asyncio.gather` (with `return_exceptions=True`) collapses this to ~pool-size waves. With pool=10 and ~50ms per call, expected wall time drops from ~3s to ~150-300ms.

## Honest scope note

The v0.2 memory's "60× number on KG calls" came from a parallel-Claude probe that didn't pin the specific handler surface — only that it was a KG call. This PR fixes a **specific** N-await pattern in `knowledge_search` that matches the symptom shape; whether it's the exact surface the probe hit needs post-deploy verification on the Wave 0 channel. If it's not, this is still a real perf win on a hot KG path; if it is, it closes the last load-bearing piece of v0.2's open evidence base.

## Classification

Sequential awaits in our own loop, **not** anyio/asyncio coupling. Same Python-fixable shape as #350 + #354 + #360. No CLAUDE.md substrate-tax update needed.

## Test plan

- [x] `tests/test_kg_search_neighbor_fetch.py::test_neighbor_fetch_runs_concurrently` — 30 calls × 50ms simulated latency complete in <500ms (sequential would be ≥1500ms). Includes a source-level pin so reverting to `for await` regresses the test.
- [x] `tests/test_kg_search_neighbor_fetch.py::test_neighbor_fetch_swallows_individual_failures` — `return_exceptions=True` ensures one bad neighbor fetch doesn't poison the whole expansion stage.
- [x] Full suite: 8329 passed, 34 skipped, 79.07% coverage.

## Files

- `src/mcp_handlers/knowledge/handlers.py` — replace the `for nid in missing_ids[:30]: await graph.get_discovery(nid)` loop with `await asyncio.gather(*(graph.get_discovery(nid) for nid in capped), return_exceptions=True)`.
- `tests/test_kg_search_neighbor_fetch.py` — new file, two tests.