### PR TITLE
perf(locked_update): fire-and-forget thread-identity + purpose persist

### DIFF
--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -640,6 +640,45 @@ async def prepare_unlocked_inputs(ctx: UpdateContext) -> None:
             )
 
 
+async def _persist_thread_identity_async(agent_uuid: str, metadata: dict) -> None:
+    """Fire-and-forget thread-identity metadata persist. Eventual consistency
+    is fine: in-memory ctx.meta is the source of truth within this process,
+    PG copy is for cross-process visibility. Errors are swallowed because
+    failure here doesn't change governance correctness — next session will
+    re-derive thread_id/node_index from in-memory state.
+
+    Same shape as PR #360's `_hydrate_metadata_cache_async`: sequential
+    awaits in our own loop, moved out of the critical section so the agent
+    lock isn't held across a PG UPDATE roundtrip. Classification: NOT an
+    anyio/asyncio coupling pattern — just lock-holding-too-long. See
+    `docs/proposals/beam-footprint-roadmap-v0.md` v0.2 RESOLUTION.
+    """
+    try:
+        from src.db import get_db
+        db = get_db()
+        await db.update_identity_metadata(agent_uuid, metadata=metadata, merge=True)
+        logger.info(
+            f"Thread identity persisted (deferred) for {agent_uuid[:8]}... "
+            f"-> thread {metadata.get('thread_id', '')[:8]}... "
+            f"(node {metadata.get('node_index')})"
+        )
+    except Exception as e:
+        logger.debug(f"Could not persist thread identity (deferred): {e}")
+
+
+async def _persist_inferred_purpose_async(agent_id: str, purpose: str) -> None:
+    """Fire-and-forget purpose persist. Same rationale as
+    `_persist_thread_identity_async` — in-memory `meta.purpose` is the
+    process-local source of truth; PG copy is for cross-process visibility.
+    Failure here doesn't change governance correctness.
+    """
+    try:
+        await agent_storage.update_agent(agent_id, purpose=purpose)
+        logger.debug(f"Auto-inferred purpose '{purpose}' persisted (deferred) for {agent_id[:12]}...")
+    except Exception as e:
+        logger.debug(f"Could not persist inferred purpose (deferred): {e}")
+
+
 async def execute_locked_update(ctx: UpdateContext) -> Optional[Sequence[TextContent]]:
     """Ensure agent exists, run agent-state mutations, call ODE update.
 
@@ -765,21 +804,26 @@ async def execute_locked_update(ctx: UpdateContext) -> Optional[Sequence[TextCon
                 ctx.meta.node_index = (getattr(ctx.meta, "node_index", None) or 1) + 1
             ctx.meta.active_session_key = ctx.session_key
             
+            # Fire-and-forget: PG metadata persist doesn't need to hold the
+            # agent lock. In-memory ctx.meta has already been mutated above
+            # and is the process-local source of truth; PG copy is for
+            # cross-process visibility. Same pattern as PR #360.
             try:
-                from src.db import get_db
-                db = get_db()
-                await db.update_identity_metadata(
-                    ctx.agent_uuid,
-                    metadata={
-                        "thread_id": ctx.meta.thread_id,
-                        "node_index": ctx.meta.node_index,
-                        "active_session_key": ctx.meta.active_session_key
-                    },
-                    merge=True
+                _thread_metadata_snapshot = {
+                    "thread_id": ctx.meta.thread_id,
+                    "node_index": ctx.meta.node_index,
+                    "active_session_key": ctx.meta.active_session_key,
+                }
+                asyncio.create_task(
+                    _persist_thread_identity_async(ctx.agent_uuid, _thread_metadata_snapshot)
                 )
-                logger.info(f"Thread identity updated for {ctx.agent_uuid[:8]}... -> thread {ctx.meta.thread_id[:8]}... (node {ctx.meta.node_index})")
+            except RuntimeError:
+                # No running loop — extremely unusual for this code path
+                # since we're inside an async handler. Swallow per the
+                # PR #360 precedent.
+                pass
             except Exception as e:
-                logger.debug(f"Could not persist thread identity: {e}")
+                logger.debug(f"Could not schedule thread identity persist: {e}")
 
     # Per-agent anomaly detection: add entropy if current signals deviate from baseline
     try:
@@ -850,7 +894,10 @@ async def execute_locked_update(ctx: UpdateContext) -> Optional[Sequence[TextCon
     # Cache monitor reference for Phase 5 and Phase 6 (guaranteed to exist post-ODE)
     ctx.monitor = mcp_server.monitors.get(ctx.agent_id)
 
-    # Auto-infer purpose from response_text if agent has none
+    # Auto-infer purpose from response_text if agent has none.
+    # In-memory mutation stays inside the lock (cheap); PG persist moves
+    # to fire-and-forget so the agent lock isn't held across a PG UPDATE
+    # roundtrip. Same pattern as PR #360.
     try:
         meta = ctx.meta
         if meta and not getattr(meta, 'purpose', None) and ctx.response_text:
@@ -858,10 +905,13 @@ async def execute_locked_update(ctx: UpdateContext) -> Optional[Sequence[TextCon
             if inferred:
                 meta.purpose = inferred
                 try:
-                    await agent_storage.update_agent(ctx.agent_id, purpose=inferred)
-                    logger.debug(f"Auto-inferred purpose '{inferred}' for {ctx.agent_id[:12]}...")
+                    asyncio.create_task(
+                        _persist_inferred_purpose_async(ctx.agent_id, inferred)
+                    )
+                except RuntimeError:
+                    pass
                 except Exception as e:
-                    logger.debug(f"Could not persist inferred purpose: {e}")
+                    logger.debug(f"Could not schedule inferred purpose persist: {e}")
     except Exception as e:
         logger.debug(f"Purpose inference skipped: {e}")
 

--- a/tests/test_phases_fire_and_forget.py
+++ b/tests/test_phases_fire_and_forget.py
@@ -1,0 +1,120 @@
+"""Regression tests for the fire-and-forget helpers added to phases.py.
+
+The fire-and-forget pattern moves PG persistence (thread-identity metadata
+and auto-inferred purpose) out of the agent lock so `execute_locked_update`
+doesn't hold the lock across PG roundtrips. Same shape as PR #360's
+`_hydrate_metadata_cache_async`.
+
+These tests pin three invariants:
+1. The helpers call the underlying persist function with correct arguments
+2. Errors in the helpers are swallowed (no propagation to caller)
+3. The helpers are coroutines schedulable via asyncio.create_task
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.mcp_handlers.updates.phases import (
+    _persist_inferred_purpose_async,
+    _persist_thread_identity_async,
+)
+
+
+# ─── _persist_thread_identity_async ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_persist_thread_identity_calls_db_with_correct_args():
+    """Helper passes through to db.update_identity_metadata with merge=True."""
+    fake_db = AsyncMock()
+    metadata = {
+        "thread_id": "t-abc12345",
+        "node_index": 3,
+        "active_session_key": "session-xyz",
+    }
+
+    with patch("src.db.get_db", return_value=fake_db):
+        await _persist_thread_identity_async("agent-uuid-123", metadata)
+
+    fake_db.update_identity_metadata.assert_awaited_once_with(
+        "agent-uuid-123", metadata=metadata, merge=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_persist_thread_identity_swallows_db_errors():
+    """Helper logs and returns on db failure — does NOT raise."""
+    fake_db = AsyncMock()
+    fake_db.update_identity_metadata.side_effect = RuntimeError("PG offline")
+
+    with patch("src.db.get_db", return_value=fake_db):
+        # Must not raise
+        await _persist_thread_identity_async("agent-uuid-123", {"thread_id": "t-x"})
+
+
+@pytest.mark.asyncio
+async def test_persist_thread_identity_swallows_get_db_errors():
+    """Helper handles get_db itself failing (e.g., pool not initialized)."""
+    with patch("src.db.get_db", side_effect=RuntimeError("pool not ready")):
+        # Must not raise
+        await _persist_thread_identity_async("agent-uuid-123", {"thread_id": "t-x"})
+
+
+@pytest.mark.asyncio
+async def test_persist_thread_identity_schedulable_as_task():
+    """Caller pattern: asyncio.create_task(...) must be valid."""
+    fake_db = AsyncMock()
+
+    with patch("src.db.get_db", return_value=fake_db):
+        task = asyncio.create_task(
+            _persist_thread_identity_async("agent-uuid-123", {"thread_id": "t-x"})
+        )
+        await task  # Awaiting from test should not raise
+
+    assert task.done()
+    assert task.exception() is None
+
+
+# ─── _persist_inferred_purpose_async ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_persist_inferred_purpose_calls_storage_with_correct_args():
+    """Helper passes through to agent_storage.update_agent with purpose kwarg."""
+    with patch(
+        "src.mcp_handlers.updates.phases.agent_storage.update_agent",
+        new_callable=AsyncMock,
+    ) as mock_update:
+        await _persist_inferred_purpose_async("agent-id-abc", "refactoring")
+
+    mock_update.assert_awaited_once_with("agent-id-abc", purpose="refactoring")
+
+
+@pytest.mark.asyncio
+async def test_persist_inferred_purpose_swallows_errors():
+    """Helper logs and returns on storage failure — does NOT raise."""
+    with patch(
+        "src.mcp_handlers.updates.phases.agent_storage.update_agent",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("storage offline"),
+    ):
+        # Must not raise
+        await _persist_inferred_purpose_async("agent-id-abc", "refactoring")
+
+
+@pytest.mark.asyncio
+async def test_persist_inferred_purpose_schedulable_as_task():
+    """Caller pattern: asyncio.create_task(...) must be valid."""
+    with patch(
+        "src.mcp_handlers.updates.phases.agent_storage.update_agent",
+        new_callable=AsyncMock,
+    ):
+        task = asyncio.create_task(
+            _persist_inferred_purpose_async("agent-id-abc", "refactoring")
+        )
+        await task
+
+    assert task.done()
+    assert task.exception() is None


### PR DESCRIPTION
## Summary

`execute_locked_update` holds the agent lock across multiple sequential PG awaits. Per-phase timing on 2026-05-05 (the `[checkin_phases]` log line) showed `locked_update=6569ms` of `total=10684ms` — 61% of per-turn overhead is spent under the lock, which serializes concurrent calls.

Two awaits inside the lock have nothing to do with the ODE critical section: thread-identity metadata UPDATE and auto-inferred purpose UPDATE. Both are informational PG writes whose in-memory state is already mutated synchronously inside the lock; eventual consistency on the PG side is fine.

This PR moves both to `asyncio.create_task`-scheduled helpers (`_persist_thread_identity_async`, `_persist_inferred_purpose_async`) so the lock isn't held across PG roundtrips.

## Why

Same shape as PR #360's `_hydrate_metadata_cache_async` deferred-after-`_metadata_loaded=True` pattern. Per the v0.2 resolution in `docs/proposals/beam-footprint-roadmap-v0.md` (2026-05-05): this is sequential-awaits-in-our-own-loop, **NOT** an anyio/asyncio coupling pattern. CLAUDE.md substrate-tax framing therefore does not need an update.

Per-call total measured at ~11s p50 (mean ~14s, range 10-22s) under sustained self-traffic. Estimated `locked_update` reduction from this PR: ~1s (two ~500ms PG roundtrips removed from critical section). Larger fixes (baseline preload move, anomaly-read parallelization, new-agent setup pre-lock) follow as a second PR.

## Changes

`src/mcp_handlers/updates/phases.py`:
- Add `_persist_thread_identity_async(agent_uuid, metadata)` helper
- Add `_persist_inferred_purpose_async(agent_id, purpose)` helper
- Replace `await db.update_identity_metadata(...)` (line ~771) with `asyncio.create_task(_persist_thread_identity_async(...))`
- Replace `await agent_storage.update_agent(purpose=...)` (line ~861) with `asyncio.create_task(_persist_inferred_purpose_async(...))`

`tests/test_phases_fire_and_forget.py`:
- 7 new tests pinning: helpers call underlying persist with correct args, helpers swallow errors, helpers are coroutines schedulable via `asyncio.create_task`.

## Test plan

- [x] `pytest tests/test_phases_fire_and_forget.py -v` — 7 passed
- [x] Targeted regressions: `tests/test_phases_transform_inputs.py tests/test_thread_identity.py tests/test_core_update.py tests/test_update_workflow_service.py` — 110 passed
- [x] Full suite: `./scripts/dev/test-cache.sh` — 8414 passed, 34 skipped, 79.05% coverage (192s)
- [ ] Post-merge benchmark verification: re-run `/tmp/unitares_overhead_benchmark.py` after governance MCP restart; expect `locked_update` to drop from ~6.5s toward ~5.5s

## Falsifying evidence

If post-merge benchmark shows `locked_update >= 5s`, the bottleneck isn't these two awaits and the larger refactor (or the substrate question) is what's left. See `docs/proposals/beam-footprint-roadmap-v0.md` v0.2 RESOLUTION for the substrate-question framing this fix-shape preserves.

## Cross-references

- PR #350 (force=True audit on observe sub-handlers) — same fix-shape at different surface
- PR #360 (cold-start metadata load, fire-and-forget redis hydration) — most direct precedent
- v0.2 RESOLUTION block in `docs/proposals/beam-footprint-roadmap-v0.md` — the framework explicitly preserving the "Python-fixable first, substrate question stays open if residual is substrate-shaped" posture