### PR TITLE
feat(wave-0): step 2B — sync coordination_failure emit at asyncpg connect-error sites

### DIFF
--- a/src/db/postgres_backend.py
+++ b/src/db/postgres_backend.py
@@ -45,6 +45,97 @@ logger = get_logger(__name__)
 POOL_CLOSE_TIMEOUT_SECONDS = 10.0
 
 
+def _hash_db_url(db_url: str) -> str:
+    """Short non-reversible tag for the connection target. Hashes the full
+    URL — including any embedded credentials — so the emitted payload never
+    leaks the password/user/host that observers could replay."""
+    import hashlib
+    return hashlib.sha256(db_url.encode("utf-8")).hexdigest()[:12]
+
+
+def _emit_bootstrap_coord_failure(
+    db_url: str,
+    error_class: str,
+    *,
+    timeout_s: float,
+) -> None:
+    """Wave 0 step 2B (RFC roadmap §86): emit
+    `coordination_failure.asyncpg_connect_error.bootstrap` when `_create_pool`
+    fails to bring up the asyncpg pool.
+
+    Failure-safe by contract — a raising emit must NOT mask the original
+    ConnectionError that the caller is about to raise. `emit_coordination_
+    failure_sync` swallows its own errors, but we wrap defensively so a
+    surprise ImportError or environment hiccup at this site can never
+    swap the user-facing exception."""
+    try:
+        from uuid import uuid4
+
+        from src.coordination_failure_emit import emit_coordination_failure_sync
+
+        emit_coordination_failure_sync(
+            service="governance_mcp",
+            event_type="coordination_failure.asyncpg_connect_error.bootstrap",
+            payload={
+                "error_class": error_class,
+                "db_url_hash": _hash_db_url(db_url),
+                "timeout_s": timeout_s,
+                "attempt": 1,
+                "incident_id": str(uuid4()),
+            },
+            agent_id=None,
+        )
+    except Exception as exc:  # noqa: BLE001 — observability MUST NOT mask the real bug
+        logger.warning(
+            "[coord-events] bootstrap emit raised — original ConnectionError "
+            "will still propagate: %r",
+            exc,
+        )
+
+
+def _emit_runtime_coord_failure(
+    *,
+    error_class: str,
+    pool_size: int,
+    pool_max: int,
+    pool_idle: int,
+    timeout_s: float,
+) -> None:
+    """Wave 0 step 2B (RFC roadmap §86): emit
+    `coordination_failure.asyncpg_connect_error.runtime` when an established
+    pool fails to deliver a connection. Same failure-safety contract as the
+    bootstrap helper above."""
+    try:
+        from uuid import uuid4
+
+        from src.coordination_failure_emit import emit_coordination_failure_sync
+        from src.mcp_handlers.context import (
+            get_context_agent_id,
+            get_context_session_key,
+        )
+
+        emit_coordination_failure_sync(
+            service="governance_mcp",
+            event_type="coordination_failure.asyncpg_connect_error.runtime",
+            payload={
+                "error_class": error_class,
+                "pool_size": pool_size,
+                "pool_max": pool_max,
+                "pool_idle": pool_idle,
+                "timeout_s": timeout_s,
+                "incident_id": str(uuid4()),
+            },
+            agent_id=get_context_agent_id(),
+            session_id=get_context_session_key(),
+        )
+    except Exception as exc:  # noqa: BLE001 — observability MUST NOT mask the real bug
+        logger.warning(
+            "[coord-events] runtime emit raised — original ConnectionError "
+            "will still propagate: %r",
+            exc,
+        )
+
+
 class PostgresBackend(
     IdentityMixin,
     AgentMixin,
@@ -201,12 +292,14 @@ class PostgresBackend(
                 )
             return await ExecutorPool.create(_create_factory)
         except asyncio.TimeoutError:
+            _emit_bootstrap_coord_failure(self._db_url, "TimeoutError", timeout_s=5.0)
             raise ConnectionError(
                 f"PostgreSQL connection timeout after 5s. "
                 f"Is PostgreSQL running on {self._db_url}? "
                 f"Check: psql -d {self._db_url.split('/')[-1]}"
             )
         except Exception as e:
+            _emit_bootstrap_coord_failure(self._db_url, type(e).__name__, timeout_s=5.0)
             raise ConnectionError(
                 f"Failed to connect to PostgreSQL at {self._db_url}: {e}. "
                 f"Is PostgreSQL running?"
@@ -239,6 +332,13 @@ class PostgresBackend(
                     return ctx_self.conn
                 except asyncio.TimeoutError:
                     logger.error(f"Connection pool timeout after {acquire_timeout}s. Pool size: {pool.get_size()}, free: {pool.get_idle_size()}")
+                    _emit_runtime_coord_failure(
+                        error_class="TimeoutError",
+                        pool_size=pool.get_size(),
+                        pool_max=pool.get_max_size(),
+                        pool_idle=pool.get_idle_size(),
+                        timeout_s=acquire_timeout,
+                    )
                     raise ConnectionError(
                         f"PostgreSQL connection pool exhausted. "
                         f"Current pool: {pool.get_size()}/{pool.get_max_size()}. "

--- a/tests/test_wave_0_2b_asyncpg_connect_error.py
+++ b/tests/test_wave_0_2b_asyncpg_connect_error.py
@@ -1,0 +1,224 @@
+"""Wave 0 step 2B — coordination_failure.asyncpg_connect_error wires.
+
+Two sub-types per the v0.2 scoping doc §1, post-2A pivot adapter:
+
+  - bootstrap : `_create_pool` raise paths in src/db/postgres_backend.py
+  - runtime   : `_AcquireContext.__aenter__` TimeoutError path in same file
+
+Both routes emit via `emit_coordination_failure_sync` (the 2A sync path) —
+NOT via direct asyncpg-on-the-anyio-loop, which the 3-agent council BLOCKED
+on PR #342's v0.2 doc. The bootstrap site has no pool to write to anyway;
+the JSONL fallback in `audit_logger._write_entry` is the durable surface.
+
+Pins:
+  - Each emit fires with the documented event_type sub-namespace
+  - payload carries incident_id (UUID string), error_class, db_url_hash,
+    timeout_s, plus runtime-specific pool-size fields
+  - emit failure (mocked to raise) does NOT mask the original ConnectionError
+    — `emit_coordination_failure_sync` is failure-safe by contract; this
+    test pins the contract holds at the wire-up site too.
+  - Drift guards: event_type strings match the documented constants
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+
+BOOTSTRAP_EVENT_TYPE = "coordination_failure.asyncpg_connect_error.bootstrap"
+RUNTIME_EVENT_TYPE = "coordination_failure.asyncpg_connect_error.runtime"
+
+
+# ============================================================================
+# Bootstrap site — _create_pool raise paths
+# ============================================================================
+
+
+class TestBootstrapEmit:
+    """`_create_pool` raises ConnectionError when asyncpg.create_pool times out
+    (asyncio.TimeoutError) or fails for any other reason. Both raise paths
+    MUST emit `coordination_failure.asyncpg_connect_error.bootstrap` before
+    re-raising the ConnectionError."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_path_emits_bootstrap(self):
+        """When ExecutorPool.create() times out (asyncio.TimeoutError), the
+        bootstrap emit fires with error_class='TimeoutError' and the
+        ConnectionError still reaches the caller."""
+        from src.db.postgres_backend import PostgresBackend
+
+        backend = PostgresBackend()
+
+        # Force the slow path by ensuring no pool exists
+        backend._pool = None
+
+        with patch(
+            "src.db.postgres_backend.ExecutorPool.create",
+            new=AsyncMock(side_effect=asyncio.TimeoutError()),
+        ), patch(
+            "src.coordination_failure_emit.emit_coordination_failure_sync"
+        ) as mock_emit:
+            with pytest.raises(ConnectionError, match="connection timeout"):
+                await backend._create_pool()
+
+        mock_emit.assert_called_once()
+        kwargs = mock_emit.call_args.kwargs
+        assert kwargs["service"] == "governance_mcp"
+        assert kwargs["event_type"] == BOOTSTRAP_EVENT_TYPE
+        assert kwargs["payload"]["error_class"] == "TimeoutError"
+        assert kwargs["payload"]["timeout_s"] == 5.0
+        assert "db_url_hash" in kwargs["payload"]
+        assert isinstance(kwargs["payload"]["db_url_hash"], str)
+        assert len(kwargs["payload"]["db_url_hash"]) > 0
+        # incident_id is a UUID-shaped string
+        assert "incident_id" in kwargs["payload"]
+        assert isinstance(kwargs["payload"]["incident_id"], str)
+        # uuid4 is 36 chars with hyphens
+        assert len(kwargs["payload"]["incident_id"]) == 36
+        # No agent context at bootstrap time — pool creation is system-level
+        assert kwargs["agent_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_path_emits_bootstrap(self):
+        """Any non-Timeout exception during pool creation also emits the
+        bootstrap event — error_class reflects the original type."""
+        from src.db.postgres_backend import PostgresBackend
+
+        backend = PostgresBackend()
+        backend._pool = None
+
+        with patch(
+            "src.db.postgres_backend.ExecutorPool.create",
+            new=AsyncMock(side_effect=OSError("connection refused")),
+        ), patch(
+            "src.coordination_failure_emit.emit_coordination_failure_sync"
+        ) as mock_emit:
+            with pytest.raises(ConnectionError, match="Failed to connect"):
+                await backend._create_pool()
+
+        mock_emit.assert_called_once()
+        kwargs = mock_emit.call_args.kwargs
+        assert kwargs["event_type"] == BOOTSTRAP_EVENT_TYPE
+        assert kwargs["payload"]["error_class"] == "OSError"
+
+    @pytest.mark.asyncio
+    async def test_emit_does_not_mask_original_connection_error(self):
+        """If `emit_coordination_failure_sync` itself raises (it is
+        contractually failure-safe, but defense-in-depth: the wire MUST
+        also tolerate a raising emit), the caller still receives the
+        original ConnectionError — not the emit-failure traceback."""
+        from src.db.postgres_backend import PostgresBackend
+
+        backend = PostgresBackend()
+        backend._pool = None
+
+        with patch(
+            "src.db.postgres_backend.ExecutorPool.create",
+            new=AsyncMock(side_effect=asyncio.TimeoutError()),
+        ), patch(
+            "src.coordination_failure_emit.emit_coordination_failure_sync",
+            side_effect=RuntimeError("emit blew up"),
+        ):
+            # The original ConnectionError must propagate, not RuntimeError
+            with pytest.raises(ConnectionError, match="connection timeout"):
+                await backend._create_pool()
+
+    @pytest.mark.asyncio
+    async def test_db_url_hash_does_not_leak_credentials(self):
+        """The payload's db_url_hash must NOT contain the raw connection string
+        (which often embeds password). Hash discipline matches the v0.2 spec."""
+        from src.db.postgres_backend import PostgresBackend
+
+        backend = PostgresBackend()
+        backend._pool = None
+        backend._db_url = "postgresql://admin:supersecretpw@example.test:5432/mydb"
+
+        with patch(
+            "src.db.postgres_backend.ExecutorPool.create",
+            new=AsyncMock(side_effect=asyncio.TimeoutError()),
+        ), patch(
+            "src.coordination_failure_emit.emit_coordination_failure_sync"
+        ) as mock_emit:
+            with pytest.raises(ConnectionError):
+                await backend._create_pool()
+
+        payload = mock_emit.call_args.kwargs["payload"]
+        hash_value = payload["db_url_hash"]
+        assert "supersecretpw" not in hash_value
+        assert "admin" not in hash_value
+        assert "example.test" not in hash_value
+
+
+# ============================================================================
+# Runtime site — _AcquireContext.__aenter__ TimeoutError path
+# ============================================================================
+
+
+class TestRuntimeEmit:
+    """When pool exists and `pool.acquire(timeout=...)` times out, the
+    backend translates to a `ConnectionError("pool exhausted")`. That
+    branch MUST also emit `coordination_failure.asyncpg_connect_error.runtime`
+    before raising."""
+
+    @pytest.mark.asyncio
+    async def test_acquire_timeout_emits_runtime_event(self):
+        from src.db.postgres_backend import PostgresBackend
+
+        backend = PostgresBackend()
+        mock_pool = AsyncMock()
+        mock_pool.acquire = AsyncMock(side_effect=asyncio.TimeoutError())
+        mock_pool.release = AsyncMock()
+        mock_pool.get_size = MagicMock(return_value=25)
+        mock_pool.get_max_size = MagicMock(return_value=25)
+        mock_pool.get_idle_size = MagicMock(return_value=0)
+        backend._pool = mock_pool
+
+        with patch(
+            "src.coordination_failure_emit.emit_coordination_failure_sync"
+        ) as mock_emit:
+            with pytest.raises(ConnectionError, match="pool exhausted"):
+                async with backend.acquire():
+                    pytest.fail("body must not execute")
+
+        mock_emit.assert_called_once()
+        kwargs = mock_emit.call_args.kwargs
+        assert kwargs["service"] == "governance_mcp"
+        assert kwargs["event_type"] == RUNTIME_EVENT_TYPE
+        payload = kwargs["payload"]
+        assert payload["error_class"] == "TimeoutError"
+        assert payload["pool_size"] == 25
+        assert payload["pool_max"] == 25
+        assert payload["pool_idle"] == 0
+        assert "incident_id" in payload
+        assert len(payload["incident_id"]) == 36
+
+    @pytest.mark.asyncio
+    async def test_runtime_emit_does_not_mask_connection_error(self):
+        """Defense-in-depth: a raising emit at the runtime wire-up site
+        MUST NOT replace the user-facing ConnectionError."""
+        from src.db.postgres_backend import PostgresBackend
+
+        backend = PostgresBackend()
+        mock_pool = AsyncMock()
+        mock_pool.acquire = AsyncMock(side_effect=asyncio.TimeoutError())
+        mock_pool.release = AsyncMock()
+        mock_pool.get_size = MagicMock(return_value=10)
+        mock_pool.get_max_size = MagicMock(return_value=10)
+        mock_pool.get_idle_size = MagicMock(return_value=0)
+        backend._pool = mock_pool
+
+        with patch(
+            "src.coordination_failure_emit.emit_coordination_failure_sync",
+            side_effect=RuntimeError("emit blew up"),
+        ):
+            with pytest.raises(ConnectionError, match="pool exhausted"):
+                async with backend.acquire():
+                    pytest.fail("body must not execute")


### PR DESCRIPTION
## Summary

Wave 0 step 2B of the BEAM footprint roadmap (RFC §86), following the 2A pivot (#345). Wires `coordination_failure.asyncpg_connect_error.{bootstrap,runtime}` into the two asyncpg connect-error raise sites in `src/db/postgres_backend.py`.

- **`.bootstrap`** — `_create_pool` (both `asyncio.TimeoutError` and generic-Exception branches). Payload: `error_class + db_url_hash + timeout_s + attempt + incident_id`. `agent_id=None` (system-level).
- **`.runtime`** — `_AcquireContext.__aenter__` `asyncio.TimeoutError` branch. Payload adds `pool_size / pool_max / pool_idle` so dashboards can distinguish exhaustion from intermittent failure. `agent_id`/`session_id` fall back to session contextvars (same pattern as 2A).

## Pivot inheritance from 2A

The v0.2 scoping doc prescribed direct asyncpg → `audit.coordination_events` for `§1.runtime` and a stderr+Chronicler-sweeper path for `§1.bootstrap`. The 2A council BLOCKED the direct-asyncpg path (anyio task-group deadlock), and `audit_logger._write_entry`'s JSONL fallback already covers the bootstrap-no-pool case naturally — so 2B uses `emit_coordination_failure_sync` for both sub-types. The dedicated `audit.coordination_events` table from #342 remains available for future Wave 0 step 3.

## Failure-safety

The helpers wrap `emit_coordination_failure_sync` in `try/except` defensively (the inner function is already failure-safe by contract; the outer wrapper protects against `ImportError` or environment hiccups at the wire-up site). Tests pin that even a raising emit MUST NOT mask the user-facing `ConnectionError`.

## Credentials hygiene

`db_url_hash = sha256(db_url)[:12]`; password / user / host are not in the payload. Test asserts the hash does not contain `admin`/`supersecretpw`/`example.test` substrings.

## Wave 1 readiness

2 of 4 event_type families wired (`mcp_handler_timeout` in 2A, `asyncpg_connect_error` in this PR). 2 remain (`anyio_cancellation`, `executor_pool_exhaustion`) before the §129 14-day clock can start.

## Test plan

- [x] `tests/test_wave_0_2b_asyncpg_connect_error.py` (6 tests) — bootstrap timeout / generic-exception / emit-mask resilience / `db_url_hash` credentials guard / runtime acquire-timeout / runtime emit-mask resilience
- [x] Full suite via `scripts/dev/test-cache.sh`: **8422 passed, 34 skipped, 0 failures**
- [x] No regression in `test_postgres_pool_guard.py` / `test_postgres_backend_integration.py` / `test_decorators.py` / `test_coordination_failure_emit.py` (165 passed)

| Wave 1 readiness | This PR contributes **1** event_type family. **2** remain before the clock can start. |

## Stack

- #333 (BEAM roadmap) — merged
- #342 (Wave 0 step 1: foundation + scoping doc v0.2) — merged
- #345 (Wave 0 step 2A: decorator timeout chokepoint) — merged
- **THIS PR** (Wave 0 step 2B: asyncpg connect-error wires)
- 2C (`anyio_cancellation` + `executor_pool_exhaustion`) — next gate