### PR TITLE
feat(wave-0): step 2C-2 — executor-pool saturation discriminator (council reshape)

### DIFF
--- a/docs/proposals/wave-0-step-2-call-site-scoping.md
+++ b/docs/proposals/wave-0-step-2-call-site-scoping.md
@@ -1,6 +1,27 @@
-# Wave 0 step 2 — coordination-failure call-site scoping (v0.2 post-council)
+# Wave 0 step 2 — coordination-failure call-site scoping (v0.3 post-2A-pivot)
 
 **Purpose:** scope the four `coordination_failure.*` emit families for `audit.coordination_events` (PR #342). v0.1 of this doc went out for council review (3-agent: dialectic-knowledge-architect, feature-dev:code-reviewer, live-verifier in parallel, adversarial framing). Council returned **1 BLOCK + 2 CONCERN-ONLY with near-BLOCK items** plus 4 factual REFUTED claims. v0.2 folds every finding.
+
+**v0.3 pivot inheritance (read this first if you're picking up 2C-2 or later):**
+
+The v0.2 prescriptions for §1.bootstrap (stderr + Chronicler sweeper), §1.runtime (direct asyncpg → `audit.coordination_events`), §3 (polling pending-counter on `ExecutorPool`), and §2.executor_loop (wrap a "main coroutine") are all **superseded by the 2A pivot** (PR #345) and downstream 3-agent council folds.
+
+What actually shipped:
+
+| Section | Original v0.2 design | What shipped (and where) |
+|---|---|---|
+| §1.bootstrap | stderr structured line + Chronicler sweeper (Wave 0 step 3) | Sync emit via `emit_coordination_failure_sync` → `audit_logger._write_entry` JSONL fallback (PR #366, Wave 0 step 2B) |
+| §1.runtime | direct asyncpg → `audit.coordination_events` | Sync emit via same path; **2C-2 carved saturation out of `runtime`** into `executor_pool_exhaustion.acquire_timeout` (post-council reshape) |
+| §2.background_task | wrap individual CancelledError catches | **Single emit at the OUTER supervisor done-callback** `_on_background_task_done` (PR #368, Wave 0 step 2C-1) |
+| §2.executor_loop | wrap "main coroutine" + shutdown-flag discriminator | **Deferred** — `ExecutorPool._run_loop` is `loop.run_forever()` with no main coroutine; anyio teardown cannot propagate cancel across `run_coroutine_threadsafe` (CPython #105836). If ever wired, the family should be **`executor_loop_died.*`**, not `anyio_cancellation.executor_loop` (different failure class — premature `run_forever()` return / uncaught exception in `_run_loop`, NOT cancellation) |
+| §3 | polling pending-counter + 30s check task | **Replaced** by event-driven saturation discriminator at the existing 2B wire site: when `pool_size == pool_max AND pool_idle == 0` at TimeoutError, emit `executor_pool_exhaustion.acquire_timeout`; otherwise stay on `asyncpg_connect_error.runtime` (PR for 2C-2). Drops the polling counter entirely — council BLOCKED it on counter-leak (production uses `__await__` path, `__aexit__` never fires; CancelledError in `__aenter__` strands the counter), threshold-unreachable (default `DB_POSTGRES_MAX_CONN=25` makes pending>50 structurally unreachable), and redundancy with 2B's already-shipped acquire-timeout emit |
+| §4.tool_decorator | direct asyncpg in decorator | Sync emit (PR #345, Wave 0 step 2A — original pivot) |
+
+The dedicated `audit.coordination_events` table from PR #342 stays unused for now; everything writes to `audit.events` with namespaced `event_type` strings. Wave 0 step 3 (Chronicler projection into the dedicated table) remains an option if/when a separate replay surface is genuinely needed.
+
+The body below documents the v0.2 prescriptions as historical context. **Do not implement them as written** without checking against the v0.3 table above.
+
+---
 
 **Read this with:** `docs/proposals/beam-footprint-roadmap-v0.md` §86–110 (envelope spec), `src/coordination_events.py` (emitter from #342), the v0.1 council reports (in PR #342 thread).
 

--- a/src/db/postgres_backend.py
+++ b/src/db/postgres_backend.py
@@ -101,10 +101,27 @@ def _emit_runtime_coord_failure(
     pool_idle: int,
     timeout_s: float,
 ) -> None:
-    """Wave 0 step 2B (RFC roadmap §86): emit
-    `coordination_failure.asyncpg_connect_error.runtime` when an established
-    pool fails to deliver a connection. Same failure-safety contract as the
-    bootstrap helper above."""
+    """Wave 0 steps 2B + 2C-2 (RFC roadmap §86): emit a coordination_failure
+    when an established pool fails to deliver a connection. Picks the
+    event_type by the saturation discriminator (post-council reshape):
+
+      pool_size == pool_max AND pool_idle == 0
+        → `coordination_failure.executor_pool_exhaustion.acquire_timeout`
+          (the pool is full and nothing's coming back — true saturation)
+
+      otherwise
+        → `coordination_failure.asyncpg_connect_error.runtime`
+          (idle capacity exists OR pool can grow — the timeout is
+          substrate-side, not saturation; reserves the asyncpg_connect_error
+          family for substrate-unreachable semantics per architect F10)
+
+    Same failure-safety contract as the bootstrap helper above."""
+    saturated = pool_size == pool_max and pool_idle == 0
+    event_type = (
+        "coordination_failure.executor_pool_exhaustion.acquire_timeout"
+        if saturated
+        else "coordination_failure.asyncpg_connect_error.runtime"
+    )
     try:
         from uuid import uuid4
 
@@ -116,7 +133,7 @@ def _emit_runtime_coord_failure(
 
         emit_coordination_failure_sync(
             service="governance_mcp",
-            event_type="coordination_failure.asyncpg_connect_error.runtime",
+            event_type=event_type,
             payload={
                 "error_class": error_class,
                 "pool_size": pool_size,

--- a/tests/test_wave_0_2b_asyncpg_connect_error.py
+++ b/tests/test_wave_0_2b_asyncpg_connect_error.py
@@ -165,8 +165,10 @@ class TestBootstrapEmit:
 class TestRuntimeEmit:
     """When pool exists and `pool.acquire(timeout=...)` times out, the
     backend translates to a `ConnectionError("pool exhausted")`. That
-    branch MUST also emit `coordination_failure.asyncpg_connect_error.runtime`
-    before raising."""
+    branch emits a coordination_failure event before raising. Wave 0 step
+    2C-2 (post-council) splits the event_type by saturation: this test
+    pins the substrate-side path (idle capacity OR pool not at max) — the
+    saturation case lives in tests/test_wave_0_2c_2_executor_pool_exhaustion.py."""
 
     @pytest.mark.asyncio
     async def test_acquire_timeout_emits_runtime_event(self):
@@ -176,9 +178,12 @@ class TestRuntimeEmit:
         mock_pool = AsyncMock()
         mock_pool.acquire = AsyncMock(side_effect=asyncio.TimeoutError())
         mock_pool.release = AsyncMock()
-        mock_pool.get_size = MagicMock(return_value=25)
+        # Non-saturation: idle > 0 means a connection should have been
+        # available — the timeout is substrate-side, not pool exhaustion.
+        # Keeps this test on the asyncpg_connect_error.runtime contract.
+        mock_pool.get_size = MagicMock(return_value=10)
         mock_pool.get_max_size = MagicMock(return_value=25)
-        mock_pool.get_idle_size = MagicMock(return_value=0)
+        mock_pool.get_idle_size = MagicMock(return_value=3)
         backend._pool = mock_pool
 
         with patch(
@@ -194,9 +199,9 @@ class TestRuntimeEmit:
         assert kwargs["event_type"] == RUNTIME_EVENT_TYPE
         payload = kwargs["payload"]
         assert payload["error_class"] == "TimeoutError"
-        assert payload["pool_size"] == 25
+        assert payload["pool_size"] == 10
         assert payload["pool_max"] == 25
-        assert payload["pool_idle"] == 0
+        assert payload["pool_idle"] == 3
         assert "incident_id" in payload
         assert len(payload["incident_id"]) == 36
 

--- a/tests/test_wave_0_2c_2_executor_pool_exhaustion.py
+++ b/tests/test_wave_0_2c_2_executor_pool_exhaustion.py
@@ -1,0 +1,152 @@
+"""Wave 0 step 2C-2 — `coordination_failure.executor_pool_exhaustion.acquire_timeout`.
+
+The 3-agent council on the v0.2 doc's polling-counter design returned BLOCK on
+all three lanes (counter leak on the production `__await__` path; counter leak
+on CancelledError; threshold structurally unreachable; redundant with 2B's
+already-shipped acquire-timeout emit).
+
+Reshape: drop the polling counter entirely. At the same `_AcquireContext.__aenter__`
+TimeoutError site already wired in 2B, choose the event_type based on a
+saturation discriminator (`pool_size == pool_max AND pool_idle == 0`):
+  - saturation        → `coordination_failure.executor_pool_exhaustion.acquire_timeout`
+  - non-saturation    → `coordination_failure.asyncpg_connect_error.runtime` (2B)
+
+Carves the saturation case out of the `asyncpg_connect_error` namespace, which
+is reserved for substrate-unreachable semantics (architect FINDING 10).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+
+SATURATION_EVENT_TYPE = "coordination_failure.executor_pool_exhaustion.acquire_timeout"
+RUNTIME_EVENT_TYPE = "coordination_failure.asyncpg_connect_error.runtime"
+
+
+def _make_pool(*, size: int, max_size: int, idle: int):
+    pool = AsyncMock()
+    pool.acquire = AsyncMock(side_effect=asyncio.TimeoutError())
+    pool.release = AsyncMock()
+    pool.get_size = MagicMock(return_value=size)
+    pool.get_max_size = MagicMock(return_value=max_size)
+    pool.get_idle_size = MagicMock(return_value=idle)
+    return pool
+
+
+@pytest.mark.asyncio
+async def test_saturation_emits_executor_pool_exhaustion():
+    """When the pool is fully saturated (size==max AND idle==0) at TimeoutError,
+    the emit is `executor_pool_exhaustion.acquire_timeout` — NOT the substrate-
+    unreachable `asyncpg_connect_error.runtime` family."""
+    from src.db.postgres_backend import PostgresBackend
+
+    backend = PostgresBackend()
+    backend._pool = _make_pool(size=25, max_size=25, idle=0)
+
+    with patch(
+        "src.coordination_failure_emit.emit_coordination_failure_sync"
+    ) as mock_emit:
+        with pytest.raises(ConnectionError, match="pool exhausted"):
+            async with backend.acquire():
+                pytest.fail("body must not execute")
+
+    mock_emit.assert_called_once()
+    kwargs = mock_emit.call_args.kwargs
+    assert kwargs["event_type"] == SATURATION_EVENT_TYPE
+    payload = kwargs["payload"]
+    assert payload["error_class"] == "TimeoutError"
+    assert payload["pool_size"] == 25
+    assert payload["pool_max"] == 25
+    assert payload["pool_idle"] == 0
+    assert "incident_id" in payload
+    assert len(payload["incident_id"]) == 36
+
+
+@pytest.mark.asyncio
+async def test_non_saturation_keeps_asyncpg_connect_error_runtime():
+    """If the pool has idle capacity OR isn't at max, a TimeoutError reflects
+    substrate trouble (asyncpg internals couldn't deliver a connection that
+    SHOULD have been available). Preserve the 2B contract — emit
+    `asyncpg_connect_error.runtime`."""
+    from src.db.postgres_backend import PostgresBackend
+
+    backend = PostgresBackend()
+    # Idle > 0 means a connection should have been available immediately —
+    # if we still timed out, it's a substrate / asyncpg-internal issue, not saturation.
+    backend._pool = _make_pool(size=10, max_size=25, idle=3)
+
+    with patch(
+        "src.coordination_failure_emit.emit_coordination_failure_sync"
+    ) as mock_emit:
+        with pytest.raises(ConnectionError, match="pool exhausted"):
+            async with backend.acquire():
+                pytest.fail("body must not execute")
+
+    mock_emit.assert_called_once()
+    kwargs = mock_emit.call_args.kwargs
+    assert kwargs["event_type"] == RUNTIME_EVENT_TYPE
+
+
+@pytest.mark.asyncio
+async def test_size_at_max_but_some_idle_is_not_saturation():
+    """Boundary: size==max but idle>0 means connections exist but are returning
+    too slowly. NOT saturation — keep `asyncpg_connect_error.runtime`."""
+    from src.db.postgres_backend import PostgresBackend
+
+    backend = PostgresBackend()
+    backend._pool = _make_pool(size=25, max_size=25, idle=2)
+
+    with patch(
+        "src.coordination_failure_emit.emit_coordination_failure_sync"
+    ) as mock_emit:
+        with pytest.raises(ConnectionError):
+            async with backend.acquire():
+                pytest.fail("body must not execute")
+
+    assert mock_emit.call_args.kwargs["event_type"] == RUNTIME_EVENT_TYPE
+
+
+@pytest.mark.asyncio
+async def test_idle_zero_but_size_below_max_is_not_saturation():
+    """Boundary: idle==0 but size<max means asyncpg COULD have created a new
+    connection — the timeout is substrate-side, not saturation."""
+    from src.db.postgres_backend import PostgresBackend
+
+    backend = PostgresBackend()
+    backend._pool = _make_pool(size=15, max_size=25, idle=0)
+
+    with patch(
+        "src.coordination_failure_emit.emit_coordination_failure_sync"
+    ) as mock_emit:
+        with pytest.raises(ConnectionError):
+            async with backend.acquire():
+                pytest.fail("body must not execute")
+
+    assert mock_emit.call_args.kwargs["event_type"] == RUNTIME_EVENT_TYPE
+
+
+@pytest.mark.asyncio
+async def test_emit_failure_does_not_mask_connection_error():
+    """Failure-safety regression: even after the discriminator change, a raising
+    emit MUST NOT mask the user-facing ConnectionError."""
+    from src.db.postgres_backend import PostgresBackend
+
+    backend = PostgresBackend()
+    backend._pool = _make_pool(size=25, max_size=25, idle=0)
+
+    with patch(
+        "src.coordination_failure_emit.emit_coordination_failure_sync",
+        side_effect=RuntimeError("emit blew up"),
+    ):
+        with pytest.raises(ConnectionError, match="pool exhausted"):
+            async with backend.acquire():
+                pytest.fail("body must not execute")


### PR DESCRIPTION
## Summary

Wave 0 step 2C-2 — **completes the four event_type families** in the BEAM footprint roadmap (RFC §86). Council on §3 returned RESCOPE on the v0.2 polling-counter design; this PR ships the architect's reshape.

## Council findings (3-agent on §3 polling-counter design)

| Lane | Verdict | Key BLOCK |
|---|---|---|
| Architect | RESCOPE | Counter leak + threshold structurally unreachable + redundant with 2B + cross-cutting namespace conflict |
| Reviewer | RESCOPE | Counter leak on `__await__` path (production bypasses `__aexit__`); counter leak on CancelledError; pool-recreation orphans counter |
| Live-verifier | VERIFIED 7 / REFUTED 1 / PARTIAL 2 | `__await__` bypass confirmed at file:line; `_run_loop` is `run_forever()` with no coroutine; `DB_POSTGRES_MAX_CONN=25` makes pending>50 unreachable |

## What this PR ships

**§3 reshape (architect's proposal, ~30 LOC vs ~120):** drop the polling counter entirely. At the **existing** `_AcquireContext.__aenter__` TimeoutError site already wired in 2B (#366), pick the event_type by saturation discriminator:

- `pool_size == pool_max AND pool_idle == 0` → `coordination_failure.executor_pool_exhaustion.acquire_timeout`
- otherwise → `coordination_failure.asyncpg_connect_error.runtime` (current 2B behavior)

Carves saturation out of `asyncpg_connect_error` namespace, which is now reserved for substrate-unreachable semantics (architect FINDING 10).

**§2.executor_loop deferral confirmed.** All three lanes verified `ExecutorPool._run_loop` is `loop.run_forever()` with no main coroutine; anyio teardown cannot propagate cancel across `run_coroutine_threadsafe` (CPython #105836). If ever wired, family is **`executor_loop_died.*`**, NOT `anyio_cancellation.executor_loop` — different failure class.

**Doc upgraded to v0.3** with a pivot-inheritance table mapping each section's v0.2 design to what actually shipped. v0.2 body retained as historical context with explicit \"do not implement as written\" guidance.

## Wave 1 readiness — all four families now wired

| Family | Wired sub-types | PR |
|---|---|---|
| `mcp_handler_timeout` | `tool_decorator` | #345 |
| `asyncpg_connect_error` | `bootstrap` + `runtime` | #366 |
| `anyio_cancellation` | `background_task` | #368 |
| `executor_pool_exhaustion` | `acquire_timeout` | THIS PR |

The §129 14-day clock can now start.

## Test plan

- [x] `tests/test_wave_0_2c_2_executor_pool_exhaustion.py` (5 tests): saturation path / non-saturation preserves runtime / two boundary cases / emit-mask resilience
- [x] `tests/test_wave_0_2b_asyncpg_connect_error.py::TestRuntimeEmit` updated for the new contract (non-saturation pool setup)
- [x] Full suite: **8449 passed, 34 skipped, 0 failures** (test-cache.sh)

## Files

- `src/db/postgres_backend.py` — saturation discriminator in `_emit_runtime_coord_failure` (~12 LOC change)
- `tests/test_wave_0_2c_2_executor_pool_exhaustion.py` — new (5 tests)
- `tests/test_wave_0_2b_asyncpg_connect_error.py` — TestRuntimeEmit setup updated
- `docs/proposals/wave-0-step-2-call-site-scoping.md` — v0.3 addendum