### PR TITLE
feat(wave-0): wire coordination_failure.executor_loop_died.{uncaught,premature_return}

### DIFF
--- a/src/db/executor_pool.py
+++ b/src/db/executor_pool.py
@@ -30,6 +30,44 @@ CLOSE_TIMEOUT_SECONDS = 10.0
 THREAD_JOIN_TIMEOUT_SECONDS = 2.0
 
 
+def _emit_executor_loop_died(sub_type: str, *, error_class: str | None) -> None:
+    """Failure-safe emit for `coordination_failure.executor_loop_died.<sub_type>`.
+
+    Wave 0 follow-up to PR #369's reshape: the original §2.executor_loop
+    scoping under `anyio_cancellation` was structurally wrong (no main
+    coroutine to receive cancel; CPython #105836 prevents anyio teardown
+    from propagating cancel across `run_coroutine_threadsafe`). The honest
+    failure class for this loop is "the loop died" — premature `run_forever()`
+    return or uncaught exception in `_run_loop` — a different family.
+
+    `sub_type` is one of: "uncaught", "premature_return".
+
+    Same failure-safety contract as the postgres_backend coord-failure
+    helpers — wraps the inner emit in try/except so neither an ImportError
+    nor an emit-side bug can mask the original exception (`raise` follows
+    in `_run_loop` for the uncaught path)."""
+    try:
+        from uuid import uuid4
+
+        from src.coordination_failure_emit import emit_coordination_failure_sync
+
+        emit_coordination_failure_sync(
+            service="governance_mcp",
+            event_type=f"coordination_failure.executor_loop_died.{sub_type}",
+            payload={
+                "error_class": error_class,
+                "incident_id": str(uuid4()),
+            },
+            agent_id=None,
+        )
+    except Exception as exc:  # noqa: BLE001 — observability MUST NOT mask the real bug
+        logger.warning(
+            "[coord-events] executor_loop_died emit raised — original "
+            "exception (if any) will still propagate: %r",
+            exc,
+        )
+
+
 async def _await_on_loop(target: Any, loop: asyncio.AbstractEventLoop) -> Any:
     """Schedule on `loop` (a different thread's loop) and await the result.
 
@@ -222,7 +260,22 @@ class ExecutorPool:
     def _run_loop(self) -> None:
         asyncio.set_event_loop(self._loop)
         self._loop_ready.set()
-        self._loop.run_forever()
+        try:
+            self._loop.run_forever()
+        except BaseException as exc:
+            # Uncaught exception in the executor loop thread. Daemon threads
+            # die silently when the parent process exits, so without this
+            # emit a structural failure here would only surface as missing
+            # behavior elsewhere. Re-raise so the thread dies visibly.
+            _emit_executor_loop_died("uncaught", error_class=type(exc).__name__)
+            raise
+        else:
+            # `run_forever()` returned normally. If the operator initiated
+            # shutdown via `close()`, `_closed_flag` is True and this is
+            # expected teardown. Otherwise the loop exited unexpectedly —
+            # that's a structural bug worth flagging.
+            if not self._closed_flag:
+                _emit_executor_loop_died("premature_return", error_class=None)
 
     def acquire(self, timeout: Any = None) -> _AcquireContext:
         return _AcquireContext(self._raw_pool, self._loop, timeout=timeout)

--- a/tests/test_executor_loop_died.py
+++ b/tests/test_executor_loop_died.py
@@ -1,0 +1,122 @@
+"""executor_loop_died.{premature_return,uncaught} — Wave 0 follow-up.
+
+Council on the original §2.executor_loop scoping (in PR #369's reshape) reframed
+the failure class: `ExecutorPool._run_loop` is a thread runner calling
+`loop.run_forever()` — there is no main coroutine to receive cancellation.
+The honest surface is a try/except/finally around `run_forever()` itself.
+
+Two sub-types:
+  - `coordination_failure.executor_loop_died.uncaught`         — run_forever() raised
+  - `coordination_failure.executor_loop_died.premature_return` — run_forever() returned
+                                                                 without operator-initiated close
+
+The supervisor ought never see this fire under normal operation; if it does,
+the pool is structurally broken and the operator needs to know.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+
+UNCAUGHT_EVENT_TYPE = "coordination_failure.executor_loop_died.uncaught"
+PREMATURE_RETURN_EVENT_TYPE = "coordination_failure.executor_loop_died.premature_return"
+
+
+def _make_bare_pool(*, closed_flag: bool):
+    """Construct an ExecutorPool-shaped instance bypassing the thread-spawning
+    constructor so we can drive `_run_loop` directly in the test thread."""
+    from src.db.executor_pool import ExecutorPool
+
+    pool = ExecutorPool.__new__(ExecutorPool)
+    pool._loop = MagicMock(spec=asyncio.AbstractEventLoop)
+    pool._loop_ready = threading.Event()
+    pool._closed_flag = closed_flag
+    return pool
+
+
+def test_run_forever_raises_emits_uncaught():
+    """An uncaught exception inside `loop.run_forever()` MUST emit
+    `executor_loop_died.uncaught` and re-raise so the daemon thread dies
+    visibly rather than silently."""
+    pool = _make_bare_pool(closed_flag=False)
+    pool._loop.run_forever = MagicMock(side_effect=RuntimeError("loop crashed"))
+
+    with patch(
+        "src.coordination_failure_emit.emit_coordination_failure_sync"
+    ) as mock_emit:
+        with pytest.raises(RuntimeError, match="loop crashed"):
+            pool._run_loop()
+
+    mock_emit.assert_called_once()
+    kwargs = mock_emit.call_args.kwargs
+    assert kwargs["service"] == "governance_mcp"
+    assert kwargs["event_type"] == UNCAUGHT_EVENT_TYPE
+    assert kwargs["payload"]["error_class"] == "RuntimeError"
+    assert "incident_id" in kwargs["payload"]
+    assert len(kwargs["payload"]["incident_id"]) == 36
+    # _loop_ready was set before run_forever() was called — caller can still
+    # inspect this if it's ever useful, but the assert here just pins that
+    # the emit didn't happen *before* loop_ready (which would mean we wrapped
+    # too aggressively).
+    assert pool._loop_ready.is_set()
+
+
+def test_run_forever_returns_without_close_emits_premature_return():
+    """`loop.run_forever()` returning while `_closed_flag` is still False means
+    the loop exited without operator-initiated shutdown — structural bug
+    worth flagging."""
+    pool = _make_bare_pool(closed_flag=False)
+    pool._loop.run_forever = MagicMock(return_value=None)  # returns immediately
+
+    with patch(
+        "src.coordination_failure_emit.emit_coordination_failure_sync"
+    ) as mock_emit:
+        pool._run_loop()  # should NOT raise
+
+    mock_emit.assert_called_once()
+    kwargs = mock_emit.call_args.kwargs
+    assert kwargs["event_type"] == PREMATURE_RETURN_EVENT_TYPE
+    # No specific exception class — the loop just returned
+    assert kwargs["payload"].get("error_class") is None
+    assert "incident_id" in kwargs["payload"]
+
+
+def test_normal_close_does_not_emit():
+    """When the operator calls `close()` (which sets `_closed_flag = True`
+    before stopping the loop), `run_forever()` returning is the EXPECTED
+    teardown — no emit."""
+    pool = _make_bare_pool(closed_flag=True)
+    pool._loop.run_forever = MagicMock(return_value=None)
+
+    with patch(
+        "src.coordination_failure_emit.emit_coordination_failure_sync"
+    ) as mock_emit:
+        pool._run_loop()
+
+    mock_emit.assert_not_called()
+
+
+def test_emit_failure_does_not_swallow_uncaught_exception():
+    """Defense-in-depth: if the emit itself raises, the original RuntimeError
+    from `run_forever()` MUST still propagate. Observability must not mask
+    the real bug."""
+    pool = _make_bare_pool(closed_flag=False)
+    pool._loop.run_forever = MagicMock(side_effect=RuntimeError("loop crashed"))
+
+    with patch(
+        "src.coordination_failure_emit.emit_coordination_failure_sync",
+        side_effect=ValueError("emit blew up"),
+    ):
+        # Original RuntimeError propagates, NOT ValueError from emit
+        with pytest.raises(RuntimeError, match="loop crashed"):
+            pool._run_loop()


### PR DESCRIPTION
## Summary

Wave 0 follow-up to #369's council reshape. Wires the **`executor_loop_died.*`** family — the architect's renamed framing for what the v0.2 doc miscalled \"§2.executor_loop\" under `anyio_cancellation`. The actual failure class is the executor loop dying, not getting cancelled (CPython #105836 prevents cross-loop cancel propagation; the loop has no main coroutine).

## Two sub-types

| Sub-type | Trigger |
|---|---|
| `executor_loop_died.uncaught` | `loop.run_forever()` raised an unexpected exception (re-raised after emit so the daemon thread dies visibly) |
| `executor_loop_died.premature_return` | `run_forever()` returned without `_closed_flag` set — operator never initiated shutdown |

## Why this matters

The executor loop runs in a daemon thread. Daemon threads die silently when the parent exits. Without these emits, a structural failure on the loop surfaces only as cascading symptoms elsewhere. With them, the failure leaves an `audit.events` row.

## Test plan

- [x] `tests/test_executor_loop_died.py` (4 tests): uncaught emits + re-raises / premature_return emits / normal close does NOT emit / emit failure does not mask original
- [x] Full suite: **8453 passed, 34 skipped, 0 failures**

## Stack

- #345/#366/#368/#369 — Wave 0 step 2, all 4 `coordination_failure.*` families wired
- THIS PR — `executor_loop_died` (different family, not blocking Wave 1)