### PR TITLE
feat(wave-1): bootstrap elixir/sentinel/ skeleton + AtomicWrite helper

### DIFF
--- a/elixir/sentinel/.gitignore
+++ b/elixir/sentinel/.gitignore
@@ -1,0 +1,23 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Temporary files, for example, from tests.
+/tmp/
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+unitares_sentinel-*.tar

--- a/elixir/sentinel/config/config.exs
+++ b/elixir/sentinel/config/config.exs
@@ -1,0 +1,12 @@
+import Config
+
+config :unitares_sentinel,
+  database_url:
+    System.get_env("UNITARES_SENTINEL_DATABASE_URL") ||
+      System.get_env("UNITARES_LEASE_PLANE_DATABASE_URL") ||
+      "postgresql://postgres:postgres@localhost:5432/governance",
+  pool_size: 2
+
+if File.exists?("config/#{config_env()}.exs") do
+  import_config "#{config_env()}.exs"
+end

--- a/elixir/sentinel/config/test.exs
+++ b/elixir/sentinel/config/test.exs
@@ -1,0 +1,7 @@
+import Config
+
+# Skeleton-stage: skip starting the application supervisor in tests.
+# Test files exercise pure modules (e.g. AtomicWrite) without needing
+# the supervisor tree. Postgrex sandbox + supervisor children land in
+# follow-up PRs as the Surface 1–5 wires arrive.
+config :unitares_sentinel, start_application: false

--- a/elixir/sentinel/lib/unitares_sentinel.ex
+++ b/elixir/sentinel/lib/unitares_sentinel.ex
@@ -1,0 +1,29 @@
+defmodule UnitaresSentinel do
+  @moduledoc """
+  Wave 1 — Sentinel-on-BEAM. Per `docs/proposals/beam-wave-1-sentinel.md`
+  v0.1.1 (council-folded).
+
+  Top-level invariant inherited from the lease plane: **BEAM owns live
+  coordination, Python owns governance truth, Postgres owns durable truth.**
+  Nothing in this app may silently become source of truth for identity,
+  EISV, KG, or calibration. Sentinel reads from Postgres + WebSocket
+  feeds and emits findings + EISV check-ins via REST to the Python
+  governance MCP.
+
+  ## State surfaces (5 total per v0.1.1)
+
+    1. `STATE_FILE` cycle state at `~/.unitares/anchors/.sentinel_state`
+    2. Findings emit channel via `post_finding(...)` → `POST /api/findings`
+    3. Lease-advisory scope `resident:/sentinel_cycle`
+    4. Python-runtime-specific anyio mitigations (BEAM-side: not inherited)
+    5. `SESSION_FILE` at `~/.unitares/anchors/sentinel.json` — governance
+       identity continuity (binding: schema MUST stay forwards-compatible
+       with Python's `GovernanceAgent._ensure_identity`)
+
+  ## Bootstrap status
+
+  This module + its `Application` supervisor are the minimum scaffold per
+  the §Bootstrap spec (B5 reviewer fold). The cycle worker, lease consumer,
+  WebSocket ingester, and `post_finding/2` client land in follow-up PRs.
+  """
+end

--- a/elixir/sentinel/lib/unitares_sentinel/application.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/application.ex
@@ -1,0 +1,31 @@
+defmodule UnitaresSentinel.Application do
+  @moduledoc """
+  OTP entry point for the Sentinel app.
+
+  Skeleton-only at this stage: the supervisor starts with no children
+  in :test mode (`config/test.exs`) and a placeholder set in :prod / :dev.
+  Cycle worker, lease consumer, WebSocket ingester, and Finch HTTP client
+  pool will be added by follow-up PRs as their respective surfaces (1–5)
+  are wired per the v0.1.1 RFC.
+
+  Mirrors the `:start_application` gate that `UnitaresLeasePlane.Application`
+  uses (`elixir/lease_plane/lib/unitares_lease_plane/application.ex`) so
+  ExUnit can boot the OTP app without a full child tree.
+  """
+
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    if Application.get_env(:unitares_sentinel, :start_application, true) do
+      start_full()
+    else
+      Supervisor.start_link([], strategy: :one_for_one, name: UnitaresSentinel.Supervisor)
+    end
+  end
+
+  defp start_full do
+    children = []
+    Supervisor.start_link(children, strategy: :one_for_one, name: UnitaresSentinel.Supervisor)
+  end
+end

--- a/elixir/sentinel/lib/unitares_sentinel/atomic_write.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/atomic_write.ex
@@ -1,0 +1,41 @@
+defmodule UnitaresSentinel.AtomicWrite do
+  @moduledoc """
+  Atomic file write with mode-0600 permissions and orphan-tmp cleanup.
+
+  Binding contract per the v0.1.1 council fold (B1 reviewer): the Python
+  helper at `agents/sdk/src/unitares_sdk/utils.py:atomic_write` (used for
+  `~/.unitares/anchors/sentinel.json`) creates with 0o600 via
+  `tempfile.mkstemp` + `os.fchmod` + `os.replace`. Naive `File.write/2`
+  + `File.rename/2` would inherit the launchd umask (typically 022 →
+  0o644), regressing security on a credential-bearing cursor file. This
+  helper preserves the 0o600 invariant on the BEAM side.
+
+  Cleanup discipline: the `.tmp` file is removed in the `rescue` clause
+  if any step (write/chmod/rename) fails. Without this, partial writes
+  leave orphan `<path>.tmp` files that pile up across crash-loop restarts.
+
+  fsync is not called on either side (Python or here) — NIT-level on
+  macOS APFS and called out only so a future BLOCK doesn't surprise.
+  """
+
+  @doc """
+  Write `content` to `path` atomically with mode 0o600.
+
+  Implementation: write to `path <> ".tmp"`, chmod 0o600, then atomic
+  rename. On any failure, remove the orphan tmp and re-raise.
+  """
+  @spec write(Path.t(), iodata()) :: :ok
+  def write(path, content) do
+    tmp = path <> ".tmp"
+
+    try do
+      :ok = File.write!(tmp, content)
+      :ok = File.chmod!(tmp, 0o600)
+      :ok = File.rename!(tmp, path)
+    rescue
+      e ->
+        _ = File.rm(tmp)
+        reraise e, __STACKTRACE__
+    end
+  end
+end

--- a/elixir/sentinel/mix.exs
+++ b/elixir/sentinel/mix.exs
@@ -1,0 +1,46 @@
+defmodule UnitaresSentinel.MixProject do
+  @moduledoc """
+  Wave 1 RFC `docs/proposals/beam-wave-1-sentinel.md` v0.1.1 §Bootstrap spec
+  (B5 reviewer council fold). Sibling app to `elixir/lease_plane/` —
+  flat single-app project, NOT umbrella, matching existing topology
+  (architect N4: umbrella promotion deferred to Wave 3+).
+  """
+
+  use Mix.Project
+
+  def project do
+    [
+      app: :unitares_sentinel,
+      version: "0.1.0",
+      elixir: "~> 1.19",
+      start_permanent: Mix.env() == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger],
+      mod: {UnitaresSentinel.Application, []}
+    ]
+  end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
+
+  defp deps do
+    [
+      # Postgrex for `lease_plane_events` polling (Surface 3).
+      {:postgrex, "~> 0.20"},
+      # JSON for findings emission (Surface 2 → POST /api/findings).
+      {:jason, "~> 1.4"},
+      # WebSocket consumer for `/ws/eisv` ingestion (B2 reviewer fold).
+      {:mint_web_socket, "~> 1.0"},
+      # HTTP client for `/api/findings` POSTs — Mint-based, hex.pm grade.
+      {:finch, "~> 0.18"},
+      # Property tests for fingerprint equivalence (Tier 2 contract).
+      {:stream_data, "~> 0.6", only: :test}
+    ]
+  end
+end

--- a/elixir/sentinel/test/test_helper.exs
+++ b/elixir/sentinel/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/elixir/sentinel/test/unitares_sentinel/atomic_write_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/atomic_write_test.exs
@@ -1,0 +1,66 @@
+defmodule UnitaresSentinel.AtomicWriteTest do
+  use ExUnit.Case, async: true
+
+  alias UnitaresSentinel.AtomicWrite
+
+  setup do
+    tmpdir = System.tmp_dir!() |> Path.join("unitares_sentinel_atomic_write_test_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmpdir)
+    on_exit(fn -> File.rm_rf!(tmpdir) end)
+    {:ok, tmpdir: tmpdir}
+  end
+
+  test "writes content atomically and the file holds exactly that content", %{tmpdir: tmpdir} do
+    path = Path.join(tmpdir, "anchor.json")
+    content = ~s({"agent_uuid": "abc", "continuity_token": "v1.eyJ..."})
+
+    :ok = AtomicWrite.write(path, content)
+
+    assert File.read!(path) == content
+  end
+
+  test "the written file has mode 0o600 (binding per RFC v0.1.1 §B1 reviewer)", %{tmpdir: tmpdir} do
+    path = Path.join(tmpdir, "anchor.json")
+    :ok = AtomicWrite.write(path, "secret-credential-payload")
+
+    %File.Stat{mode: mode} = File.stat!(path)
+    # mode is the full 32-bit st_mode; mask off file-type bits to compare permissions only.
+    permission_bits = Bitwise.band(mode, 0o777)
+    assert permission_bits == 0o600,
+           "atomic write must produce mode 0o600 — got #{inspect(Integer.to_string(permission_bits, 8))}"
+  end
+
+  test "tmp file is cleaned up on success (no orphan)", %{tmpdir: tmpdir} do
+    path = Path.join(tmpdir, "anchor.json")
+    :ok = AtomicWrite.write(path, "hello")
+
+    refute File.exists?(path <> ".tmp"),
+           "atomic write must leave no orphan .tmp file after a successful rename"
+  end
+
+  test "tmp file is cleaned up on rename failure (orphan-cleanup invariant)", %{tmpdir: tmpdir} do
+    # Force a rename failure by making the destination a directory (POSIX rename
+    # of a regular file onto a non-empty directory is an error). The helper
+    # MUST still remove the .tmp afterwards before re-raising.
+    path = Path.join(tmpdir, "anchor.json")
+    File.mkdir_p!(path)
+    File.touch!(Path.join(path, "hold"))  # make the directory non-empty
+
+    assert_raise File.RenameError, fn ->
+      AtomicWrite.write(path, "anything")
+    end
+
+    refute File.exists?(path <> ".tmp"),
+           "atomic write must remove the orphan .tmp on failure (B1 reviewer fold)"
+  end
+
+  test "subsequent writes overwrite cleanly without orphan accumulation", %{tmpdir: tmpdir} do
+    path = Path.join(tmpdir, "anchor.json")
+    :ok = AtomicWrite.write(path, "v1")
+    :ok = AtomicWrite.write(path, "v2")
+    :ok = AtomicWrite.write(path, "v3")
+
+    assert File.read!(path) == "v3"
+    refute File.exists?(path <> ".tmp")
+  end
+end


### PR DESCRIPTION
## Summary

Wave 1 first slice per `docs/proposals/beam-wave-1-sentinel.md` v0.1.1 §Bootstrap spec (B5 reviewer council fold). Lands the OTP app skeleton at `elixir/sentinel/` and the binding **`AtomicWrite`** helper from §B1 reviewer fold.

**No Sentinel logic yet** — that ships in follow-up PRs, one per surface (1–5).

## Why this first

The council fold flagged that Python's `atomic_write` (used for `~/.unitares/anchors/sentinel.json`) creates mode-0o600 files via `tempfile.mkstemp` + `os.fchmod`. Naive Elixir `File.write/2` + `File.rename/2` would inherit launchd's umask (typically 022 → 0o644) — a security regression on a credential-bearing cursor. Locking the helper down NOW means subsequent surface-PRs use a tested helper instead of re-deriving the chmod-and-rename dance.

## Layout

Matches `elixir/lease_plane/` (architect N4: flat single-app, **NOT** umbrella; promotion deferred to Wave 3+).

| File | Purpose |
|---|---|
| `mix.exs` | `:unitares_sentinel` with the binding deps: `postgrex 0.20` / `jason 1.4` / `mint_web_socket 1.0` / `finch 0.18` / `stream_data 0.6` (test-only) |
| `lib/unitares_sentinel.ex` | Top-level module with the BEAM-owns-coordination invariant restated |
| `lib/unitares_sentinel/application.ex` | Minimal supervisor with the `:start_application` gate (mirrors lease_plane's pattern) so ExUnit can boot without a full child tree |
| `lib/unitares_sentinel/atomic_write.ex` | The B1-reviewer binding helper; chmod 0o600 + orphan-tmp cleanup in `rescue` |
| `config/config.exs` | `UNITARES_SENTINEL_DATABASE_URL` env var with fallback to `LEASE_PLANE_*` (binding: separate role for read-only Sentinel deploys) |
| `config/test.exs` | `:start_application: false` so tests exercise pure modules without supervisor (Postgrex sandbox lands with Surface 3) |
| `test/unitares_sentinel/atomic_write_test.exs` | 5 tests pinning write-content / mode-0o600 / no-orphan-on-success / orphan-cleanup-on-rename-failure / multi-write idempotence |
| `.gitignore` | Same shape as lease_plane |

## Test plan

- [x] `mix test` in `elixir/sentinel/`: **5 tests, 0 failures**
- [x] Python suite via `scripts/dev/test-cache.sh`: **8456 passed, 34 skipped, 0 failures** (Python paths untouched, no regression possible by structure but run anyway)

## NOT included (intentional, keeps slice small)

- CI integration for `mix test` in `elixir/sentinel/` — RFC §B5 reviewer says \"added by the Wave 1 implementation PR\"; deferred since no cycle worker exists yet to need it
- Postgrex sandbox in `test_helper.exs` — lands when Surface 3 is wired
- Cycle worker / lease consumer / WS ingester / `post_finding/2` — one PR per surface in subsequent slices

## Stack

- #364 — Wave 1 RFC v0.1.1 (council-folded, binding spec)
- **THIS PR** — skeleton + AtomicWrite (B5 + B1 reviewer fold)
- Next — Surface 1: cycle state file + STATE_FILE migration