### PR TITLE
feat(wave-1): Surface 1 — CycleState shadow file with max-on-boot semantics

### DIFF
--- a/elixir/sentinel/lib/mix/tasks/sentinel.cursor_diff.ex
+++ b/elixir/sentinel/lib/mix/tasks/sentinel.cursor_diff.ex
@@ -1,0 +1,90 @@
+defmodule Mix.Tasks.Sentinel.CursorDiff do
+  @moduledoc """
+  Print the canonical (Python) and shadow (BEAM) Sentinel cursor cursors
+  side-by-side, with delta. Operator-facing observability shim for the
+  Surface 1 shadow window — see RFC v0.1.2 §C2.
+
+  ## Usage
+
+      mix sentinel.cursor_diff
+      UNITARES_SENTINEL_STATE_FILE=/path/to/.sentinel_state mix sentinel.cursor_diff
+
+  Resolves the same path as `UnitaresSentinel.CycleState`: config
+  `:unitares_sentinel, :state_file_path` first, then env var.
+
+  Exit code is always 0 — this is a diagnostic, not a gate.
+  """
+
+  use Mix.Task
+
+  alias UnitaresSentinel.CycleState
+
+  @shortdoc "Show Python vs BEAM Sentinel cursor positions and delta"
+
+  @impl Mix.Task
+  def run(_args) do
+    Application.ensure_all_started(:unitares_sentinel)
+
+    canonical = resolve_canonical()
+    shadow = canonical <> ".beam"
+
+    canonical_state = read_state(canonical)
+    shadow_state = read_state(shadow)
+
+    canonical_cursor = CycleState.get_last_event_ts(canonical_state || %{})
+    shadow_cursor = CycleState.get_last_event_ts(shadow_state || %{})
+
+    Mix.shell().info("canonical: #{canonical}")
+    Mix.shell().info("  exists:  #{canonical_state != nil}")
+    Mix.shell().info("  cursor:  #{format_cursor(canonical_cursor)}")
+    Mix.shell().info("")
+    Mix.shell().info("shadow:    #{shadow}")
+    Mix.shell().info("  exists:  #{shadow_state != nil}")
+    Mix.shell().info("  cursor:  #{format_cursor(shadow_cursor)}")
+    Mix.shell().info("")
+    Mix.shell().info("delta:     #{format_delta(canonical_cursor, shadow_cursor)}")
+  end
+
+  defp resolve_canonical do
+    Application.get_env(:unitares_sentinel, :state_file_path) ||
+      System.get_env("UNITARES_SENTINEL_STATE_FILE") ||
+      Mix.raise("""
+      sentinel.cursor_diff: STATE_FILE path not configured.
+      Set :unitares_sentinel, :state_file_path or UNITARES_SENTINEL_STATE_FILE.
+      """)
+  end
+
+  defp read_state(path) do
+    with {:ok, contents} <- File.read(path),
+         {:ok, decoded} when is_map(decoded) <- Jason.decode(contents) do
+      decoded
+    else
+      _ -> nil
+    end
+  end
+
+  defp format_cursor(nil), do: "<none>"
+  defp format_cursor(cursor), do: cursor
+
+  defp format_delta(nil, nil), do: "both empty"
+  defp format_delta(c, nil), do: "canonical only (shadow has no cursor): #{c}"
+  defp format_delta(nil, s), do: "shadow only (canonical has no cursor): #{s}"
+
+  defp format_delta(c, s) when c == s, do: "in sync"
+
+  defp format_delta(c, s) do
+    with {:ok, c_dt, _} <- DateTime.from_iso8601(c),
+         {:ok, s_dt, _} <- DateTime.from_iso8601(s) do
+      diff_seconds = DateTime.diff(c_dt, s_dt)
+      direction = if diff_seconds > 0, do: "canonical leads", else: "shadow leads"
+      "#{direction} by #{format_seconds(abs(diff_seconds))}"
+    else
+      _ -> "lex compare: canonical=#{c} shadow=#{s}"
+    end
+  end
+
+  defp format_seconds(s) when s < 60, do: "#{s}s"
+  defp format_seconds(s) when s < 3600, do: "#{div(s, 60)}m#{rem(s, 60)}s"
+  defp format_seconds(s) when s < 86_400, do: "#{div(s, 3600)}h#{div(rem(s, 3600), 60)}m"
+  defp format_seconds(s), do: "#{div(s, 86_400)}d#{div(rem(s, 86_400), 3600)}h"
+end

--- a/elixir/sentinel/lib/mix/tasks/sentinel.cursor_diff.ex
+++ b/elixir/sentinel/lib/mix/tasks/sentinel.cursor_diff.ex
@@ -25,7 +25,16 @@ defmodule Mix.Tasks.Sentinel.CursorDiff do
   def run(_args) do
     Application.ensure_all_started(:unitares_sentinel)
 
-    canonical = resolve_canonical()
+    # Single source of truth for path resolution lives in CycleState.
+    # Catch the raise to convert to Mix.raise/1 for tooling-friendly exit.
+    canonical =
+      try do
+        CycleState.resolve_canonical_path()
+      rescue
+        e in RuntimeError ->
+          Mix.raise("sentinel.cursor_diff: " <> Exception.message(e))
+      end
+
     shadow = canonical <> ".beam"
 
     canonical_state = read_state(canonical)
@@ -43,15 +52,6 @@ defmodule Mix.Tasks.Sentinel.CursorDiff do
     Mix.shell().info("  cursor:  #{format_cursor(shadow_cursor)}")
     Mix.shell().info("")
     Mix.shell().info("delta:     #{format_delta(canonical_cursor, shadow_cursor)}")
-  end
-
-  defp resolve_canonical do
-    Application.get_env(:unitares_sentinel, :state_file_path) ||
-      System.get_env("UNITARES_SENTINEL_STATE_FILE") ||
-      Mix.raise("""
-      sentinel.cursor_diff: STATE_FILE path not configured.
-      Set :unitares_sentinel, :state_file_path or UNITARES_SENTINEL_STATE_FILE.
-      """)
   end
 
   defp read_state(path) do

--- a/elixir/sentinel/lib/unitares_sentinel/cycle_state.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/cycle_state.ex
@@ -1,0 +1,164 @@
+defmodule UnitaresSentinel.CycleState do
+  @moduledoc """
+  Cross-cycle state file (the de-dup fence) for Sentinel-on-BEAM.
+
+  Surface 1 of the Wave 1 RFC. See `docs/proposals/beam-wave-1-sentinel.md`
+  v0.1.2 amendment block — that is the binding spec; v0.1.1 §Surface 1
+  prose is superseded on every point of conflict.
+
+  ## Path resolution (v0.1.2 §B1)
+
+  Canonical path resolves from `:unitares_sentinel, :state_file_path`
+  (Application env), falling back to `UNITARES_SENTINEL_STATE_FILE`
+  (system env). Production launchd plist is the source of the env var.
+  Shadow path is the canonical path with `.beam` suffix appended,
+  written to the same directory.
+
+  ## Boot semantics (v0.1.2 §B2 — max-on-boot)
+
+  `load/1` reads both files when both exist and returns the state with
+  the larger `forced_release_alarm.last_event_ts` (ISO-8601 lex compare,
+  valid because Python writes UTC-offset isoformat). Empty cursors are
+  treated as older than any timestamp.
+
+  ## Cutover (v0.1.2 §B3 — max wins)
+
+  Composes with the boot rule: at cutover, BEAM re-reads both files
+  one last time, persists the max to the shadow path, and from then on
+  the canonical reader stops touching the Python file. Cutover signal
+  is a `runtime` flag in the shadow file itself for forensic clarity.
+
+  ## Save semantics (v0.1.2 §C3, §N1)
+
+  - String-key normalization via `Jason.encode! |> Jason.decode!` —
+    atom-keyed input round-trips back as string-keyed regardless of
+    the caller's shape.
+  - Log-and-continue: `AtomicWrite.write/2` failures are caught,
+    logged at `:warning`, and `:ok` is returned. Mirrors Python's
+    `save_state` swallow at `agents/sentinel/agent.py:506-508` so
+    BEAM does not become more brittle than Python on ENOSPC / RO-fs.
+  """
+
+  alias UnitaresSentinel.AtomicWrite
+
+  require Logger
+
+  @forced_release_key "forced_release_alarm"
+  @cursor_key "last_event_ts"
+
+  @type t :: %{String.t() => term()}
+
+  @doc """
+  Load the cross-cycle state with max-on-boot semantics.
+
+  Options:
+    * `:canonical` — explicit canonical (Python) path, overrides config
+    * `:shadow` — explicit shadow (BEAM) path, overrides default
+                  (canonical + ".beam")
+  """
+  @spec load(keyword()) :: t()
+  def load(opts \\ []) do
+    {canonical, shadow} = resolve_paths(opts)
+
+    canonical_state = read_decode(canonical)
+    shadow_state = read_decode(shadow)
+
+    pick_max(canonical_state, shadow_state)
+  end
+
+  @doc """
+  Persist `state` to the shadow file, swallowing write errors.
+
+  Always returns `:ok`. Atom-keyed maps are normalized to string keys
+  via Jason round-trip before writing.
+
+  Options:
+    * `:path` — explicit write target, overrides default shadow path
+  """
+  @spec save(map(), keyword()) :: :ok
+  def save(state, opts \\ []) when is_map(state) do
+    path = Keyword.get(opts, :path) || default_shadow_path()
+    normalized = state |> Jason.encode!() |> Jason.decode!()
+
+    try do
+      :ok = AtomicWrite.write(path, Jason.encode!(normalized))
+    rescue
+      e ->
+        Logger.warning(
+          "UnitaresSentinel.CycleState.save: write failed at #{inspect(path)} — #{inspect(e)}"
+        )
+
+        :ok
+    end
+  end
+
+  @doc """
+  Single read accessor for the cursor (mirrors Python's one-site discipline
+  at agents/sentinel/agent.py:663).
+  """
+  @spec get_last_event_ts(t()) :: String.t() | nil
+  def get_last_event_ts(state) when is_map(state) do
+    state
+    |> Map.get(@forced_release_key, %{})
+    |> Map.get(@cursor_key)
+  end
+
+  @doc """
+  Single write accessor for the cursor. Preserves sibling keys under
+  `forced_release_alarm`.
+  """
+  @spec update_last_event_ts(t(), String.t()) :: t()
+  def update_last_event_ts(state, cursor) when is_map(state) and is_binary(cursor) do
+    inner =
+      state
+      |> Map.get(@forced_release_key, %{})
+      |> Map.put(@cursor_key, cursor)
+
+    Map.put(state, @forced_release_key, inner)
+  end
+
+  # ---- internals ---------------------------------------------------------
+
+  defp resolve_paths(opts) do
+    canonical = Keyword.get(opts, :canonical) || resolve_canonical_from_config()
+    shadow = Keyword.get(opts, :shadow) || canonical <> ".beam"
+    {canonical, shadow}
+  end
+
+  defp resolve_canonical_from_config do
+    Application.get_env(:unitares_sentinel, :state_file_path) ||
+      System.get_env("UNITARES_SENTINEL_STATE_FILE") ||
+      raise """
+      UnitaresSentinel.CycleState: STATE_FILE path not configured.
+      Set :unitares_sentinel, :state_file_path in config or
+      UNITARES_SENTINEL_STATE_FILE in the environment. The launchd
+      plist is the source of truth in production.
+      """
+  end
+
+  defp default_shadow_path, do: resolve_canonical_from_config() <> ".beam"
+
+  # Mirrors Python's load_state guard at agents/sentinel/agent.py:494-501:
+  # missing file → %{}, decode failure → %{}, non-map decode → %{}.
+  defp read_decode(path) do
+    with {:ok, contents} <- File.read(path),
+         {:ok, decoded} when is_map(decoded) <- Jason.decode(contents) do
+      decoded
+    else
+      _ -> %{}
+    end
+  end
+
+  # Max-on-boot: empty cursors lose to any non-empty cursor; ISO-8601 with
+  # zero-padded fields and consistent timezone offset is lex-comparable.
+  defp pick_max(canonical_state, shadow_state) do
+    canonical_cursor = get_last_event_ts(canonical_state) || ""
+    shadow_cursor = get_last_event_ts(shadow_state) || ""
+
+    cond do
+      canonical_state == %{} and shadow_state == %{} -> %{}
+      canonical_cursor >= shadow_cursor -> canonical_state
+      true -> shadow_state
+    end
+  end
+end

--- a/elixir/sentinel/lib/unitares_sentinel/cycle_state.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/cycle_state.ex
@@ -45,6 +45,8 @@ defmodule UnitaresSentinel.CycleState do
 
   @forced_release_key "forced_release_alarm"
   @cursor_key "last_event_ts"
+  @runtime_key "runtime"
+  @runtime_beam_canonical "beam_canonical"
 
   @type t :: %{String.t() => term()}
 
@@ -60,10 +62,19 @@ defmodule UnitaresSentinel.CycleState do
   def load(opts \\ []) do
     {canonical, shadow} = resolve_paths(opts)
 
-    canonical_state = read_decode(canonical)
     shadow_state = read_decode(shadow)
 
-    pick_max(canonical_state, shadow_state)
+    # Cutover short-circuit (v0.1.2 §B3): once the shadow declares
+    # `runtime: "beam_canonical"`, BEAM stops reading the Python file.
+    # This honors §B3's "from then on the canonical reader stops touching
+    # the Python file" — without it, max-on-boot would let a stale Python
+    # cursor silently win after cutover.
+    if Map.get(shadow_state, @runtime_key) == @runtime_beam_canonical do
+      shadow_state
+    else
+      canonical_state = read_decode(canonical)
+      pick_max(canonical_state, shadow_state)
+    end
   end
 
   @doc """
@@ -78,10 +89,16 @@ defmodule UnitaresSentinel.CycleState do
   @spec save(map(), keyword()) :: :ok
   def save(state, opts \\ []) when is_map(state) do
     path = Keyword.get(opts, :path) || default_shadow_path()
-    normalized = state |> Jason.encode!() |> Jason.decode!()
+
+    # Normalize OUTSIDE the try block: caller-side encoding bugs (e.g.,
+    # a map containing a PID or a tuple) raise `Protocol.UndefinedError`
+    # and MUST propagate. Python's `save_state` only swallows around
+    # `atomic_write` — `json.dumps` happens on the same line and a
+    # TypeError there would also propagate. Mirror that scope.
+    encoded = state |> Jason.encode!() |> Jason.decode!() |> Jason.encode!()
 
     try do
-      :ok = AtomicWrite.write(path, Jason.encode!(normalized))
+      :ok = AtomicWrite.write(path, encoded)
     rescue
       e ->
         Logger.warning(
@@ -117,15 +134,27 @@ defmodule UnitaresSentinel.CycleState do
     Map.put(state, @forced_release_key, inner)
   end
 
-  # ---- internals ---------------------------------------------------------
+  @doc """
+  Read the cutover runtime flag from a state map (`"beam_canonical"`,
+  `"python_canonical"`, or `nil` when shadow mode is in effect).
+  Per v0.1.2 §B3 cutover protocol.
+  """
+  @spec get_runtime(t()) :: String.t() | nil
+  def get_runtime(state) when is_map(state), do: Map.get(state, @runtime_key)
 
-  defp resolve_paths(opts) do
-    canonical = Keyword.get(opts, :canonical) || resolve_canonical_from_config()
-    shadow = Keyword.get(opts, :shadow) || canonical <> ".beam"
-    {canonical, shadow}
-  end
+  @doc """
+  Resolve the canonical (Python) STATE_FILE path from config / env var.
 
-  defp resolve_canonical_from_config do
+  Public so the `mix sentinel.cursor_diff` task and any future Sentinel
+  diagnostic can share the resolution discipline — eliminates the drift
+  class flagged in the Surface 1 council fold (reviewer concern: two
+  copies of the resolution order).
+
+  Raises if neither `:unitares_sentinel, :state_file_path` (Application env)
+  nor `UNITARES_SENTINEL_STATE_FILE` (system env) is set.
+  """
+  @spec resolve_canonical_path() :: String.t()
+  def resolve_canonical_path do
     Application.get_env(:unitares_sentinel, :state_file_path) ||
       System.get_env("UNITARES_SENTINEL_STATE_FILE") ||
       raise """
@@ -136,7 +165,15 @@ defmodule UnitaresSentinel.CycleState do
       """
   end
 
-  defp default_shadow_path, do: resolve_canonical_from_config() <> ".beam"
+  # ---- internals ---------------------------------------------------------
+
+  defp resolve_paths(opts) do
+    canonical = Keyword.get(opts, :canonical) || resolve_canonical_path()
+    shadow = Keyword.get(opts, :shadow) || canonical <> ".beam"
+    {canonical, shadow}
+  end
+
+  defp default_shadow_path, do: resolve_canonical_path() <> ".beam"
 
   # Mirrors Python's load_state guard at agents/sentinel/agent.py:494-501:
   # missing file → %{}, decode failure → %{}, non-map decode → %{}.
@@ -149,16 +186,25 @@ defmodule UnitaresSentinel.CycleState do
     end
   end
 
-  # Max-on-boot: empty cursors lose to any non-empty cursor; ISO-8601 with
-  # zero-padded fields and consistent timezone offset is lex-comparable.
+  # Max-on-boot per v0.1.2 §B2.
+  #
+  # Single-empty short-circuit FIRST: when only one file decodes to a
+  # non-empty map, return that one unconditionally — never run the lex
+  # compare against an empty placeholder. The earlier shape (cursor
+  # compare with `||""` defaults) silently dropped sibling keys when
+  # one side was `%{"forced_release_alarm" => %{}}` and the other was
+  # truly absent. Surface 1 council fold catch.
+  defp pick_max(%{} = canonical, shadow) when map_size(canonical) == 0, do: shadow
+  defp pick_max(canonical, %{} = shadow) when map_size(shadow) == 0, do: canonical
+
   defp pick_max(canonical_state, shadow_state) do
     canonical_cursor = get_last_event_ts(canonical_state) || ""
     shadow_cursor = get_last_event_ts(shadow_state) || ""
 
-    cond do
-      canonical_state == %{} and shadow_state == %{} -> %{}
-      canonical_cursor >= shadow_cursor -> canonical_state
-      true -> shadow_state
+    if canonical_cursor >= shadow_cursor do
+      canonical_state
+    else
+      shadow_state
     end
   end
 end

--- a/elixir/sentinel/test/fixtures/sentinel_state_beam_v1.json
+++ b/elixir/sentinel/test/fixtures/sentinel_state_beam_v1.json
@@ -1,0 +1,1 @@
+{"forced_release_alarm":{"last_event_ts":"2026-05-04T12:00:00.000000+00:00"}}

--- a/elixir/sentinel/test/fixtures/sentinel_state_python_v1.json
+++ b/elixir/sentinel/test/fixtures/sentinel_state_python_v1.json
@@ -1,0 +1,1 @@
+{"forced_release_alarm": {"last_event_ts": "2026-05-03T13:56:34.479878+00:00"}}

--- a/elixir/sentinel/test/unitares_sentinel/cycle_state_config_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/cycle_state_config_test.exs
@@ -1,0 +1,69 @@
+defmodule UnitaresSentinel.CycleStateConfigTest do
+  @moduledoc """
+  Path-resolution-from-config tests live in a non-async module because they
+  mutate `Application.env`, which is global. If these ran with `async: true`
+  alongside the main `cycle_state_test.exs`, any concurrent test that called
+  `CycleState.save/1` or `CycleState.load/0` with no `:path` opt could pick
+  up the polluted config key and resolve to this test's tmp path.
+
+  Surface 1 council fold (reviewer Critical-2): the prior shape had this
+  test in the async module; the race was latent because the only no-opts
+  callers in the test file were here. But the contract surface is global —
+  any future test that defaults the path would join the race. Isolating
+  here removes the class.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias UnitaresSentinel.CycleState
+
+  setup do
+    tmpdir =
+      System.tmp_dir!()
+      |> Path.join("unitares_sentinel_cycle_state_config_test_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmpdir)
+    on_exit(fn -> File.rm_rf!(tmpdir) end)
+
+    canonical = Path.join(tmpdir, ".sentinel_state")
+
+    on_exit(fn -> Application.delete_env(:unitares_sentinel, :state_file_path) end)
+
+    {:ok, tmpdir: tmpdir, canonical: canonical}
+  end
+
+  test "default path resolves from :unitares_sentinel, :state_file_path config", ctx do
+    Application.put_env(:unitares_sentinel, :state_file_path, ctx.canonical)
+
+    state = %{"forced_release_alarm" => %{"last_event_ts" => "2026-05-05T03:14:15+00:00"}}
+
+    # save with no opts uses config; load with no opts uses config.
+    :ok = CycleState.save(state)
+    assert CycleState.load() == state
+  end
+
+  test "resolve_canonical_path/0 prefers Application env over system env", ctx do
+    Application.put_env(:unitares_sentinel, :state_file_path, ctx.canonical)
+    System.put_env("UNITARES_SENTINEL_STATE_FILE", "/should/not/be/used")
+    on_exit(fn -> System.delete_env("UNITARES_SENTINEL_STATE_FILE") end)
+
+    assert CycleState.resolve_canonical_path() == ctx.canonical
+  end
+
+  test "resolve_canonical_path/0 falls back to env var when config absent", ctx do
+    Application.delete_env(:unitares_sentinel, :state_file_path)
+    System.put_env("UNITARES_SENTINEL_STATE_FILE", ctx.canonical)
+    on_exit(fn -> System.delete_env("UNITARES_SENTINEL_STATE_FILE") end)
+
+    assert CycleState.resolve_canonical_path() == ctx.canonical
+  end
+
+  test "resolve_canonical_path/0 raises when neither config nor env set", _ctx do
+    Application.delete_env(:unitares_sentinel, :state_file_path)
+    System.delete_env("UNITARES_SENTINEL_STATE_FILE")
+
+    assert_raise RuntimeError, ~r/STATE_FILE path not configured/, fn ->
+      CycleState.resolve_canonical_path()
+    end
+  end
+end

--- a/elixir/sentinel/test/unitares_sentinel/cycle_state_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/cycle_state_test.exs
@@ -114,6 +114,84 @@ defmodule UnitaresSentinel.CycleStateTest do
              "2026-05-04T00:00:00.000000+00:00"
   end
 
+  # Council fold: reviewer Critical-1. Without the single-empty short-circuit,
+  # `pick_max("" >= "")` was true and returned canonical (`%{}`), silently
+  # dropping shadow's sibling keys when canonical was absent.
+  test "max-on-boot: only shadow exists with empty cursor — sibling keys preserved", ctx do
+    # canonical absent; shadow has forced_release_alarm with no cursor but
+    # other tracked sibling keys (real cycle-worker shape pre-first-emit).
+    File.write!(
+      ctx.shadow,
+      ~s({"forced_release_alarm": {"first_seen_at": "2026-05-04T00:00:00+00:00"}, "runtime": "shadow"})
+    )
+
+    state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+    # Must NOT be %{} — the sibling data has to survive boot.
+    assert get_in(state, ["forced_release_alarm", "first_seen_at"]) ==
+             "2026-05-04T00:00:00+00:00"
+    assert Map.get(state, "runtime") == "shadow"
+  end
+
+  test "max-on-boot: only canonical exists with empty cursor — sibling keys preserved", ctx do
+    File.write!(
+      ctx.canonical,
+      ~s({"forced_release_alarm": {"some_python_metadata": "preserve_me"}})
+    )
+
+    state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+    assert get_in(state, ["forced_release_alarm", "some_python_metadata"]) == "preserve_me"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Cutover flag awareness (v0.1.2 §B3) — runtime: beam_canonical short-circuit.
+  # ---------------------------------------------------------------------------
+
+  test "cutover: shadow with runtime=beam_canonical — canonical is NOT read", ctx do
+    # Canonical has a NEWER cursor but the operator has cut over to BEAM.
+    # Per §B3, BEAM "stops reading STATE_FILE" once canonical → reading
+    # both and picking max would silently regress to Python's diagnostic
+    # write if the operator runs Python for any reason post-cutover.
+    File.write!(
+      ctx.canonical,
+      ~s({"forced_release_alarm": {"last_event_ts": "2026-05-10T00:00:00.000000+00:00"}})
+    )
+
+    File.write!(
+      ctx.shadow,
+      ~s({"runtime": "beam_canonical", "forced_release_alarm": {"last_event_ts": "2026-05-04T00:00:00.000000+00:00"}})
+    )
+
+    state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+    # Shadow wins despite older cursor — the runtime flag is load-bearing.
+    assert get_in(state, ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-04T00:00:00.000000+00:00"
+    assert CycleState.get_runtime(state) == "beam_canonical"
+  end
+
+  test "cutover: shadow with runtime=python_canonical — falls back to max-on-boot", ctx do
+    # Rollback case: operator set runtime back to python_canonical to revert.
+    # Shadow's runtime flag is no longer "beam_canonical" so the short-circuit
+    # is OFF; max-on-boot resumes and picks the newer cursor (likely python's).
+    File.write!(
+      ctx.canonical,
+      ~s({"forced_release_alarm": {"last_event_ts": "2026-05-10T00:00:00.000000+00:00"}})
+    )
+
+    File.write!(
+      ctx.shadow,
+      ~s({"runtime": "python_canonical", "forced_release_alarm": {"last_event_ts": "2026-05-04T00:00:00.000000+00:00"}})
+    )
+
+    state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+    assert get_in(state, ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-10T00:00:00.000000+00:00"
+  end
+
+  test "get_runtime/1 returns nil when no flag set (shadow mode default)", _ctx do
+    assert CycleState.get_runtime(%{"forced_release_alarm" => %{}}) == nil
+    assert CycleState.get_runtime(%{}) == nil
+  end
+
   # ---------------------------------------------------------------------------
   # Schema binding (v0.1.1 §Surface 1, retained in v0.1.2).
   # ---------------------------------------------------------------------------
@@ -177,6 +255,20 @@ defmodule UnitaresSentinel.CycleStateTest do
     assert CycleState.save(%{"forced_release_alarm" => %{"last_event_ts" => "2026-05-05T00:00:00+00:00"}}, path: ctx.shadow) == :ok
   end
 
+  # Council fold: reviewer Important-3. Encoding errors are caller-side bugs,
+  # NOT I/O errors — they MUST propagate. Python's save_state swallows only
+  # around atomic_write; json.dumps would raise TypeError for non-serializable
+  # values and that propagates. BEAM must match scope, not be broader.
+  test "save propagates Jason encoding errors (programming bugs are not I/O failures)", ctx do
+    # PIDs are not JSON-encodable — Jason.encode! raises Protocol.UndefinedError.
+    # If save catches this, the missing write is invisible to the caller.
+    state_with_pid = %{"forced_release_alarm" => %{"some_pid" => self()}}
+
+    assert_raise Protocol.UndefinedError, fn ->
+      CycleState.save(state_with_pid, path: ctx.shadow)
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # Single-site accessors (v0.1.2 verifier REFUTED — Python has one read site).
   # ---------------------------------------------------------------------------
@@ -225,18 +317,8 @@ defmodule UnitaresSentinel.CycleStateTest do
            "Python fixture cursor must be ISO-8601 (got: #{inspect(cursor)})"
   end
 
-  # ---------------------------------------------------------------------------
-  # Path resolution from config (v0.1.2 §B1).
-  # ---------------------------------------------------------------------------
-
-  test "default path resolves from :unitares_sentinel, :state_file_path config", ctx do
-    Application.put_env(:unitares_sentinel, :state_file_path, ctx.canonical)
-    on_exit(fn -> Application.delete_env(:unitares_sentinel, :state_file_path) end)
-
-    state = %{"forced_release_alarm" => %{"last_event_ts" => "2026-05-05T03:14:15+00:00"}}
-
-    # save with no opts uses config; load with no opts uses config.
-    :ok = CycleState.save(state)
-    assert CycleState.load() == state
-  end
+  # NOTE: The Application.put_env-based path-resolution test lives in a
+  # SEPARATE non-async module (`cycle_state_config_test.exs`) — Application
+  # env is global and races against other async tests in this module that
+  # call `save/1` / `load/0` with no opts. Council fold: reviewer Critical-2.
 end

--- a/elixir/sentinel/test/unitares_sentinel/cycle_state_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/cycle_state_test.exs
@@ -1,0 +1,242 @@
+defmodule UnitaresSentinel.CycleStateTest do
+  @moduledoc """
+  Surface 1 binding spec — see `docs/proposals/beam-wave-1-sentinel.md`
+  v0.1.2 amendment block. Path resolution, max-on-boot semantics,
+  string-key normalization, isinstance guard, and log-and-continue
+  exception contract are all council-folded BLOCKs/CONCERNs. These
+  tests are the regression bar.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias UnitaresSentinel.CycleState
+
+  setup do
+    tmpdir =
+      System.tmp_dir!()
+      |> Path.join("unitares_sentinel_cycle_state_test_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmpdir)
+    on_exit(fn -> File.rm_rf!(tmpdir) end)
+
+    # Surface 1 path discipline: shadow file lives next to canonical
+    # with `.beam` suffix appended (v0.1.2 §B1).
+    canonical = Path.join(tmpdir, ".sentinel_state")
+    shadow = canonical <> ".beam"
+
+    {:ok, tmpdir: tmpdir, canonical: canonical, shadow: shadow}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Round-trip: save then load recovers the cursor (canonical happy path).
+  # ---------------------------------------------------------------------------
+
+  test "save then load round-trips the cursor", ctx do
+    state = %{"forced_release_alarm" => %{"last_event_ts" => "2026-05-03T13:56:34.479878+00:00"}}
+
+    :ok = CycleState.save(state, path: ctx.shadow)
+    assert CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow) == state
+  end
+
+  # ---------------------------------------------------------------------------
+  # Max-on-boot (v0.1.2 §B2). The four cases the amendment enumerates.
+  # ---------------------------------------------------------------------------
+
+  test "max-on-boot: both files exist, beam newer — beam wins", ctx do
+    File.write!(
+      ctx.canonical,
+      ~s({"forced_release_alarm": {"last_event_ts": "2026-05-03T00:00:00.000000+00:00"}})
+    )
+
+    File.write!(
+      ctx.shadow,
+      ~s({"forced_release_alarm": {"last_event_ts": "2026-05-04T00:00:00.000000+00:00"}})
+    )
+
+    state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+    assert get_in(state, ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-04T00:00:00.000000+00:00"
+  end
+
+  test "max-on-boot: both files exist, python newer — python wins", ctx do
+    File.write!(
+      ctx.canonical,
+      ~s({"forced_release_alarm": {"last_event_ts": "2026-05-05T12:00:00.000000+00:00"}})
+    )
+
+    File.write!(
+      ctx.shadow,
+      ~s({"forced_release_alarm": {"last_event_ts": "2026-05-04T00:00:00.000000+00:00"}})
+    )
+
+    state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+    assert get_in(state, ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-05T12:00:00.000000+00:00"
+  end
+
+  test "max-on-boot: only python file exists — python wins", ctx do
+    File.write!(
+      ctx.canonical,
+      ~s({"forced_release_alarm": {"last_event_ts": "2026-05-03T13:56:34.479878+00:00"}})
+    )
+
+    state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+    assert get_in(state, ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-03T13:56:34.479878+00:00"
+  end
+
+  test "max-on-boot: only beam file exists — beam wins", ctx do
+    File.write!(
+      ctx.shadow,
+      ~s({"forced_release_alarm": {"last_event_ts": "2026-05-04T01:02:03.456789+00:00"}})
+    )
+
+    state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+    assert get_in(state, ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-04T01:02:03.456789+00:00"
+  end
+
+  test "max-on-boot: neither file exists — empty map", ctx do
+    assert CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow) == %{}
+  end
+
+  test "max-on-boot: empty cursor counts as oldest (any non-empty wins)", ctx do
+    # Canonical has the key but empty; shadow has a real timestamp.
+    File.write!(ctx.canonical, ~s({"forced_release_alarm": {}}))
+
+    File.write!(
+      ctx.shadow,
+      ~s({"forced_release_alarm": {"last_event_ts": "2026-05-04T00:00:00.000000+00:00"}})
+    )
+
+    state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+    assert get_in(state, ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-04T00:00:00.000000+00:00"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Schema binding (v0.1.1 §Surface 1, retained in v0.1.2).
+  # ---------------------------------------------------------------------------
+
+  test "schema binding: forced_release_alarm.last_event_ts stays top-level ISO-8601 string", ctx do
+    state = %{"forced_release_alarm" => %{"last_event_ts" => "2026-05-05T12:34:56.789012+00:00"}}
+    :ok = CycleState.save(state, path: ctx.shadow)
+
+    raw = File.read!(ctx.shadow)
+    decoded = Jason.decode!(raw)
+
+    # Top-level key, not nested under "state" or "cursor" — Python's
+    # rollback reader at agents/sentinel/agent.py:663 reads exactly this path.
+    assert get_in(decoded, ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-05T12:34:56.789012+00:00"
+  end
+
+  # ---------------------------------------------------------------------------
+  # String-key normalization (v0.1.2 §C3) — atom keys round-trip as strings.
+  # ---------------------------------------------------------------------------
+
+  test "string-key normalization: atom-keyed input round-trips as string-keyed", ctx do
+    atom_keyed = %{forced_release_alarm: %{last_event_ts: "2026-05-05T12:00:00.000000+00:00"}}
+
+    :ok = CycleState.save(atom_keyed, path: ctx.shadow)
+    loaded = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+
+    # Caller MUST see string keys back regardless of input shape.
+    assert loaded == %{
+             "forced_release_alarm" => %{"last_event_ts" => "2026-05-05T12:00:00.000000+00:00"}
+           }
+  end
+
+  # ---------------------------------------------------------------------------
+  # isinstance guard (v0.1.2 verifier REFUTED) — non-map JSON falls through.
+  # ---------------------------------------------------------------------------
+
+  test "isinstance guard: non-map JSON (array) falls through to %{}", ctx do
+    File.write!(ctx.shadow, ~s([1, 2, 3]))
+
+    assert CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow) == %{}
+  end
+
+  test "isinstance guard: malformed JSON falls through to %{}", ctx do
+    File.write!(ctx.shadow, "not json at all {{{")
+
+    assert CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow) == %{}
+  end
+
+  # ---------------------------------------------------------------------------
+  # save/1 log-and-continue (v0.1.2 §N1).
+  # ---------------------------------------------------------------------------
+
+  test "save log-and-continue: returns :ok even when AtomicWrite fails", ctx do
+    # Force AtomicWrite to raise by making the destination a non-empty directory
+    # (matches the AtomicWrite test's failure-injection strategy).
+    File.mkdir_p!(ctx.shadow)
+    File.touch!(Path.join(ctx.shadow, "hold"))
+
+    # Must NOT raise — Python's save_state swallows; BEAM matches.
+    assert CycleState.save(%{"forced_release_alarm" => %{"last_event_ts" => "2026-05-05T00:00:00+00:00"}}, path: ctx.shadow) == :ok
+  end
+
+  # ---------------------------------------------------------------------------
+  # Single-site accessors (v0.1.2 verifier REFUTED — Python has one read site).
+  # ---------------------------------------------------------------------------
+
+  test "get_last_event_ts/1 returns the cursor string", _ctx do
+    state = %{"forced_release_alarm" => %{"last_event_ts" => "2026-05-05T01:23:45.678901+00:00"}}
+    assert CycleState.get_last_event_ts(state) == "2026-05-05T01:23:45.678901+00:00"
+  end
+
+  test "get_last_event_ts/1 returns nil on empty/missing", _ctx do
+    assert CycleState.get_last_event_ts(%{}) == nil
+    assert CycleState.get_last_event_ts(%{"forced_release_alarm" => %{}}) == nil
+  end
+
+  test "update_last_event_ts/2 sets the cursor under the canonical key path", _ctx do
+    updated = CycleState.update_last_event_ts(%{}, "2026-05-05T01:23:45.678901+00:00")
+    assert get_in(updated, ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-05T01:23:45.678901+00:00"
+  end
+
+  test "update_last_event_ts/2 preserves sibling keys under forced_release_alarm", _ctx do
+    state = %{"forced_release_alarm" => %{"sibling_key" => "preserve_me"}}
+    updated = CycleState.update_last_event_ts(state, "2026-05-05T01:23:45+00:00")
+    assert get_in(updated, ["forced_release_alarm", "sibling_key"]) == "preserve_me"
+    assert get_in(updated, ["forced_release_alarm", "last_event_ts"]) == "2026-05-05T01:23:45+00:00"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Tier 2 cross-runtime fixture (v0.1.2 §C4).
+  # ---------------------------------------------------------------------------
+
+  test "Tier 2: BEAM CycleState.load round-trips a Python-written fixture", ctx do
+    # The committed fixture is byte-equivalent to what `agents/sentinel/agent.py`
+    # writes via `save_state`. Drift between Python's writer and this fixture
+    # is a Tier 2 contract violation and a CI failure.
+    fixture_path = Path.join([__DIR__, "..", "fixtures", "sentinel_state_python_v1.json"])
+    fixture = File.read!(fixture_path)
+
+    File.write!(ctx.canonical, fixture)
+    state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+
+    # Cursor MUST be recoverable from the Python fixture without loss.
+    cursor = CycleState.get_last_event_ts(state)
+    assert is_binary(cursor), "Python fixture cursor must be a binary string"
+    assert String.match?(cursor, ~r/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/),
+           "Python fixture cursor must be ISO-8601 (got: #{inspect(cursor)})"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Path resolution from config (v0.1.2 §B1).
+  # ---------------------------------------------------------------------------
+
+  test "default path resolves from :unitares_sentinel, :state_file_path config", ctx do
+    Application.put_env(:unitares_sentinel, :state_file_path, ctx.canonical)
+    on_exit(fn -> Application.delete_env(:unitares_sentinel, :state_file_path) end)
+
+    state = %{"forced_release_alarm" => %{"last_event_ts" => "2026-05-05T03:14:15+00:00"}}
+
+    # save with no opts uses config; load with no opts uses config.
+    :ok = CycleState.save(state)
+    assert CycleState.load() == state
+  end
+end

--- a/scripts/ops/com.unitares.sentinel.plist.template
+++ b/scripts/ops/com.unitares.sentinel.plist.template
@@ -55,6 +55,14 @@
         <string>__UNITARES_ROOT__</string>
         <key>PATH</key>
         <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <!-- HOME required for Path.home() resolution (SESSION_FILE at
+             agents/sentinel/agent.py:59). Lease-plane plist sets HOME;
+             sentinel was missing it, leaving Python on a passwd-database
+             fallback that BEAM's Path.expand("~") does NOT share. Surface 1
+             council fold (RFC v0.1.2 §B4) — preventive against any code
+             path that drifts toward tilde-expansion. -->
+        <key>HOME</key>
+        <string>__HOME__</string>
     </dict>
 </dict>
 </plist>

--- a/tests/test_sentinel_cross_runtime_state.py
+++ b/tests/test_sentinel_cross_runtime_state.py
@@ -1,0 +1,87 @@
+"""
+Tier 2 cross-runtime contract test — Wave 1 Surface 1 (RFC v0.1.2 §C4).
+
+The BEAM Sentinel writes `.sentinel_state.beam` via
+`UnitaresSentinel.CycleState.save/2` (elixir/sentinel/lib/unitares_sentinel/cycle_state.ex).
+On rollback or operator intervention, the Python Sentinel may need to
+read whatever BEAM last wrote. If Python's `load_state` ever fails to
+recover the cursor from a BEAM-written file, the de-dup fence regresses
+and the alarm replay storm condition (RFC v0.1.1 §Surface 1 rollback
+procedure step 4) fires.
+
+The fixture at `elixir/sentinel/test/fixtures/sentinel_state_beam_v1.json`
+is byte-equivalent to what `CycleState.save/2` produces today. Drift
+between this fixture and BEAM's writer is a CI failure on the BEAM side
+(see `cycle_state_test.exs` "Tier 2: BEAM CycleState.load round-trips
+a Python-written fixture" for the symmetric direction).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+BEAM_FIXTURE = (
+    project_root
+    / "elixir"
+    / "sentinel"
+    / "test"
+    / "fixtures"
+    / "sentinel_state_beam_v1.json"
+)
+
+
+def test_beam_fixture_exists_and_decodes():
+    """The BEAM-written fixture committed to the tree must parse as JSON."""
+    assert BEAM_FIXTURE.exists(), (
+        f"Tier 2 contract: missing BEAM fixture at {BEAM_FIXTURE}. "
+        "Regenerate via `mix run -e 'UnitaresSentinel.CycleState.save(%{...}, "
+        "path: \"test/fixtures/sentinel_state_beam_v1.json\")'`."
+    )
+    decoded = json.loads(BEAM_FIXTURE.read_text())
+    assert isinstance(decoded, dict), (
+        f"BEAM fixture must decode to a dict; got {type(decoded).__name__}"
+    )
+
+
+def test_python_load_state_recovers_cursor_from_beam_fixture(tmp_path, monkeypatch):
+    """
+    Python's load_state at agents/sentinel/agent.py:492 MUST recover
+    the cursor from a BEAM-written file. This is the symmetric Tier 2
+    contract from RFC v0.1.2 §C4. If this fails, BEAM-on-rollback breaks
+    Python's de-dup fence and triggers alarm replay.
+    """
+    # Stage the BEAM fixture as the canonical state file (rollback scenario:
+    # BEAM was the canonical writer mid-shadow, then operator unloads BEAM
+    # and reloads Python — Python must read whatever's there).
+    state_file = tmp_path / ".sentinel_state"
+    state_file.write_bytes(BEAM_FIXTURE.read_bytes())
+
+    from agents.sentinel import agent as sentinel_agent
+
+    monkeypatch.setattr(sentinel_agent, "STATE_FILE", state_file)
+
+    # load_state references the module-level STATE_FILE, not `self`, so we
+    # can invoke it directly off the class without instantiating the agent
+    # (which would pull in WS, SDK, identity, etc.).
+    state = sentinel_agent.SentinelAgent.load_state(None)
+
+    cursor = state.get("forced_release_alarm", {}).get("last_event_ts")
+    assert cursor is not None, (
+        f"Python load_state failed to recover cursor from BEAM fixture: state={state!r}"
+    )
+    assert isinstance(cursor, str), (
+        f"cursor must be a string (ISO-8601), got {type(cursor).__name__}"
+    )
+    # Loose ISO-8601 shape check; the BEAM writer's exact format is the
+    # contract, but we don't pin a specific timestamp here so the fixture
+    # can be regenerated without breaking this test.
+    assert "T" in cursor and ("+" in cursor or "Z" in cursor), (
+        f"cursor must be ISO-8601 with timezone offset, got: {cursor!r}"
+    )


### PR DESCRIPTION
## Summary

Wave 1 Surface 1 implementation against RFC v0.1.2 binding spec (`docs/proposals/beam-wave-1-sentinel.md` v0.1.2 amendment block, merged in #374).

`UnitaresSentinel.CycleState` — the BEAM-side cross-cycle state surface (de-dup fence for forced-release alarms). Max-on-boot semantics, log-and-continue save, single-site read/write accessors mirroring Python's discipline at `agents/sentinel/agent.py:663`.

**Out of scope (later PRs):**
- Findings emit (Surface 2) — direct flip, no shadow mode
- Lease-advisory acquire (Surface 3) — same lease-plane API, no migration
- Cycle worker / Postgrex consumer — binds to this state surface but is a separate writer-locked region
- BEAM Sentinel launchd plist — sequenced after cutover decision

## Council fold compliance (v0.1.2)

| Block / Concern | Where it lives in this PR |
| --- | --- |
| §B1 path resolution | `cycle_state.ex` `resolve_canonical_from_config/0`; tests cover config + env-var precedence |
| §B2 max-on-boot | `cycle_state.ex` `pick_max/2`; 6 ExUnit cases (both/either/neither/empty) |
| §B3 cutover protocol | Composes with B2; cutover signal (`runtime` flag) lands in the cycle-worker PR |
| §B4 HOME env var | `scripts/ops/com.unitares.sentinel.plist.template` |
| §C1 fsync trade-off | Accepted; AtomicWrite parity with Python (no fsync) retained |
| §C2 cursor-diff observability | `mix sentinel.cursor_diff` |
| §C3 string-key contract | `save/2` Jason round-trip; ExUnit pin: atom-keyed input → string-keyed output |
| §C4 Tier 2 contract | Both directions: `cycle_state_test.exs` (Python→BEAM) + `tests/test_sentinel_cross_runtime_state.py` (BEAM→Python); fixtures committed |
| §N1 log-and-continue | `save/2` try/rescue + `Logger.warning`; ExUnit pin |

Verifier REFUTEDs from v0.1.2 honored:
- Single cursor read site (vs three) — `get_last_event_ts/1` exposes one accessor
- `isinstance` guard mirrored — non-map JSON falls through to `%{}`
- `load_state` line-range pinned at 494-501 in module doc references

## Test plan

- [x] `mix test` (elixir/sentinel): 23 tests, 0 failures
- [x] `pytest tests/test_sentinel_cross_runtime_state.py -v`: 2 tests, both pass
- [x] Smoke test of `mix sentinel.cursor_diff` against the live `.sentinel_state` (cursor recovered, shadow absent reported correctly)
- [ ] Council review (architect + reviewer + live-verifier in parallel) — leaving as **draft** until council passes
- [ ] Operator acceptance: install updated plist (re-render template + `launchctl unload && load`); verify Python Sentinel cycle still green

## Stack

- #373 — Wave 1 bootstrap (skeleton + AtomicWrite) — merged
- #374 — RFC v0.1.2 Surface 1 council fold — merged
- **THIS PR** — Surface 1 implementation against v0.1.2 binding spec
- Next — Surface 1 cycle worker (Postgrex consumer that drives `CycleState` via the cursor accessors), Surface 2 findings emit cutover