### PR TITLE
feat(wave-1): Surface 1 cycle worker — ForcedReleasePoller (ad_hoc class)

### DIFF
--- a/elixir/sentinel/config/config.exs
+++ b/elixir/sentinel/config/config.exs
@@ -5,7 +5,9 @@ config :unitares_sentinel,
     System.get_env("UNITARES_SENTINEL_DATABASE_URL") ||
       System.get_env("UNITARES_LEASE_PLANE_DATABASE_URL") ||
       "postgresql://postgres:postgres@localhost:5432/governance",
-  pool_size: 2
+  pool_size: 2,
+  poller_interval_ms: 30_000,
+  poller_initial_delay_ms: 1_000
 
 if File.exists?("config/#{config_env()}.exs") do
   import_config "#{config_env()}.exs"

--- a/elixir/sentinel/config/test.exs
+++ b/elixir/sentinel/config/test.exs
@@ -1,7 +1,14 @@
 import Config
 
-# Skeleton-stage: skip starting the application supervisor in tests.
-# Test files exercise pure modules (e.g. AtomicWrite) without needing
-# the supervisor tree. Postgrex sandbox + supervisor children land in
-# follow-up PRs as the Surface 1–5 wires arrive.
-config :unitares_sentinel, start_application: false
+# Test mode: skip the application supervisor tree. Postgrex is started
+# manually by `test/test_helper.exs` (skip-if-unavailable pattern) so
+# integration tests run when governance_test is reachable and pure-logic
+# tests run regardless.
+config :unitares_sentinel,
+  start_application: false,
+  start_postgrex: false,
+  start_poller: false,
+  database_url:
+    System.get_env("UNITARES_SENTINEL_DATABASE_URL") ||
+      System.get_env("UNITARES_LEASE_PLANE_DATABASE_URL") ||
+      "postgresql://postgres:postgres@localhost:5432/governance_test"

--- a/elixir/sentinel/lib/mix/tasks/sentinel.cursor_diff.ex
+++ b/elixir/sentinel/lib/mix/tasks/sentinel.cursor_diff.ex
@@ -1,0 +1,90 @@
+defmodule Mix.Tasks.Sentinel.CursorDiff do
+  @moduledoc """
+  Print the canonical (Python) and shadow (BEAM) Sentinel cursor cursors
+  side-by-side, with delta. Operator-facing observability shim for the
+  Surface 1 shadow window — see RFC v0.1.2 §C2.
+
+  ## Usage
+
+      mix sentinel.cursor_diff
+      UNITARES_SENTINEL_STATE_FILE=/path/to/.sentinel_state mix sentinel.cursor_diff
+
+  Resolves the same path as `UnitaresSentinel.CycleState`: config
+  `:unitares_sentinel, :state_file_path` first, then env var.
+
+  Exit code is always 0 — this is a diagnostic, not a gate.
+  """
+
+  use Mix.Task
+
+  alias UnitaresSentinel.CycleState
+
+  @shortdoc "Show Python vs BEAM Sentinel cursor positions and delta"
+
+  @impl Mix.Task
+  def run(_args) do
+    Application.ensure_all_started(:unitares_sentinel)
+
+    canonical = resolve_canonical()
+    shadow = canonical <> ".beam"
+
+    canonical_state = read_state(canonical)
+    shadow_state = read_state(shadow)
+
+    canonical_cursor = CycleState.get_last_event_ts(canonical_state || %{})
+    shadow_cursor = CycleState.get_last_event_ts(shadow_state || %{})
+
+    Mix.shell().info("canonical: #{canonical}")
+    Mix.shell().info("  exists:  #{canonical_state != nil}")
+    Mix.shell().info("  cursor:  #{format_cursor(canonical_cursor)}")
+    Mix.shell().info("")
+    Mix.shell().info("shadow:    #{shadow}")
+    Mix.shell().info("  exists:  #{shadow_state != nil}")
+    Mix.shell().info("  cursor:  #{format_cursor(shadow_cursor)}")
+    Mix.shell().info("")
+    Mix.shell().info("delta:     #{format_delta(canonical_cursor, shadow_cursor)}")
+  end
+
+  defp resolve_canonical do
+    Application.get_env(:unitares_sentinel, :state_file_path) ||
+      System.get_env("UNITARES_SENTINEL_STATE_FILE") ||
+      Mix.raise("""
+      sentinel.cursor_diff: STATE_FILE path not configured.
+      Set :unitares_sentinel, :state_file_path or UNITARES_SENTINEL_STATE_FILE.
+      """)
+  end
+
+  defp read_state(path) do
+    with {:ok, contents} <- File.read(path),
+         {:ok, decoded} when is_map(decoded) <- Jason.decode(contents) do
+      decoded
+    else
+      _ -> nil
+    end
+  end
+
+  defp format_cursor(nil), do: "<none>"
+  defp format_cursor(cursor), do: cursor
+
+  defp format_delta(nil, nil), do: "both empty"
+  defp format_delta(c, nil), do: "canonical only (shadow has no cursor): #{c}"
+  defp format_delta(nil, s), do: "shadow only (canonical has no cursor): #{s}"
+
+  defp format_delta(c, s) when c == s, do: "in sync"
+
+  defp format_delta(c, s) do
+    with {:ok, c_dt, _} <- DateTime.from_iso8601(c),
+         {:ok, s_dt, _} <- DateTime.from_iso8601(s) do
+      diff_seconds = DateTime.diff(c_dt, s_dt)
+      direction = if diff_seconds > 0, do: "canonical leads", else: "shadow leads"
+      "#{direction} by #{format_seconds(abs(diff_seconds))}"
+    else
+      _ -> "lex compare: canonical=#{c} shadow=#{s}"
+    end
+  end
+
+  defp format_seconds(s) when s < 60, do: "#{s}s"
+  defp format_seconds(s) when s < 3600, do: "#{div(s, 60)}m#{rem(s, 60)}s"
+  defp format_seconds(s) when s < 86_400, do: "#{div(s, 3600)}h#{div(rem(s, 3600), 60)}m"
+  defp format_seconds(s), do: "#{div(s, 86_400)}d#{div(rem(s, 86_400), 3600)}h"
+end

--- a/elixir/sentinel/lib/mix/tasks/sentinel.cursor_diff.ex
+++ b/elixir/sentinel/lib/mix/tasks/sentinel.cursor_diff.ex
@@ -25,7 +25,16 @@ defmodule Mix.Tasks.Sentinel.CursorDiff do
   def run(_args) do
     Application.ensure_all_started(:unitares_sentinel)
 
-    canonical = resolve_canonical()
+    # Single source of truth for path resolution lives in CycleState.
+    # Catch the raise to convert to Mix.raise/1 for tooling-friendly exit.
+    canonical =
+      try do
+        CycleState.resolve_canonical_path()
+      rescue
+        e in RuntimeError ->
+          Mix.raise("sentinel.cursor_diff: " <> Exception.message(e))
+      end
+
     shadow = canonical <> ".beam"
 
     canonical_state = read_state(canonical)
@@ -43,15 +52,6 @@ defmodule Mix.Tasks.Sentinel.CursorDiff do
     Mix.shell().info("  cursor:  #{format_cursor(shadow_cursor)}")
     Mix.shell().info("")
     Mix.shell().info("delta:     #{format_delta(canonical_cursor, shadow_cursor)}")
-  end
-
-  defp resolve_canonical do
-    Application.get_env(:unitares_sentinel, :state_file_path) ||
-      System.get_env("UNITARES_SENTINEL_STATE_FILE") ||
-      Mix.raise("""
-      sentinel.cursor_diff: STATE_FILE path not configured.
-      Set :unitares_sentinel, :state_file_path or UNITARES_SENTINEL_STATE_FILE.
-      """)
   end
 
   defp read_state(path) do

--- a/elixir/sentinel/lib/unitares_sentinel/application.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/application.ex
@@ -25,7 +25,77 @@ defmodule UnitaresSentinel.Application do
   end
 
   defp start_full do
-    children = []
+    children = postgrex_children() ++ poller_children()
     Supervisor.start_link(children, strategy: :one_for_one, name: UnitaresSentinel.Supervisor)
+  end
+
+  defp postgrex_children do
+    if Application.get_env(:unitares_sentinel, :start_postgrex, true) do
+      [{Postgrex, postgrex_opts()}]
+    else
+      []
+    end
+  end
+
+  defp poller_children do
+    if Application.get_env(:unitares_sentinel, :start_poller, false) do
+      [UnitaresSentinel.ForcedReleasePoller]
+    else
+      []
+    end
+  end
+
+  @doc false
+  # Public for test_helper bootstrap; not part of the runtime API.
+  def postgrex_opts do
+    url =
+      Application.get_env(:unitares_sentinel, :database_url) ||
+        raise "UNITARES_SENTINEL_DATABASE_URL or :unitares_sentinel database_url config required"
+
+    pool_size = Application.get_env(:unitares_sentinel, :pool_size, 2)
+    parsed = parse_database_url(url)
+
+    [
+      hostname: parsed.host,
+      port: parsed.port,
+      username: parsed.username,
+      password: parsed.password,
+      database: parsed.database,
+      pool_size: pool_size,
+      name: UnitaresSentinel.DB
+    ]
+  end
+
+  @doc false
+  # URI-parse a libpq-style URL into a Postgrex opts map. Mirrors the
+  # `UnitaresLeasePlane.Application.parse_database_url/1` helper —
+  # duplicated rather than shared because the two apps are independent
+  # deployables. A third caller would warrant a shared lib.
+  def parse_database_url("postgresql://" <> _ = url), do: parse_database_url(URI.parse(url))
+  def parse_database_url("postgres://" <> _ = url), do: parse_database_url(URI.parse(url))
+
+  def parse_database_url(%URI{scheme: scheme} = uri) when scheme in ["postgresql", "postgres"] do
+    {user, pass} =
+      case uri.userinfo do
+        nil ->
+          raise ArgumentError, "database_url must include user:password@host"
+
+        userinfo ->
+          case String.split(userinfo, ":", parts: 2) do
+            [u, p] -> {URI.decode(u), URI.decode(p)}
+            [u] -> {URI.decode(u), ""}
+          end
+      end
+
+    host = uri.host || raise(ArgumentError, "database_url missing host")
+    port = uri.port || 5432
+
+    database =
+      case uri.path do
+        "/" <> db when db != "" -> db
+        _ -> raise ArgumentError, "database_url missing database name"
+      end
+
+    %{username: user, password: pass, host: host, port: port, database: database}
   end
 end

--- a/elixir/sentinel/lib/unitares_sentinel/cycle_state.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/cycle_state.ex
@@ -1,0 +1,164 @@
+defmodule UnitaresSentinel.CycleState do
+  @moduledoc """
+  Cross-cycle state file (the de-dup fence) for Sentinel-on-BEAM.
+
+  Surface 1 of the Wave 1 RFC. See `docs/proposals/beam-wave-1-sentinel.md`
+  v0.1.2 amendment block — that is the binding spec; v0.1.1 §Surface 1
+  prose is superseded on every point of conflict.
+
+  ## Path resolution (v0.1.2 §B1)
+
+  Canonical path resolves from `:unitares_sentinel, :state_file_path`
+  (Application env), falling back to `UNITARES_SENTINEL_STATE_FILE`
+  (system env). Production launchd plist is the source of the env var.
+  Shadow path is the canonical path with `.beam` suffix appended,
+  written to the same directory.
+
+  ## Boot semantics (v0.1.2 §B2 — max-on-boot)
+
+  `load/1` reads both files when both exist and returns the state with
+  the larger `forced_release_alarm.last_event_ts` (ISO-8601 lex compare,
+  valid because Python writes UTC-offset isoformat). Empty cursors are
+  treated as older than any timestamp.
+
+  ## Cutover (v0.1.2 §B3 — max wins)
+
+  Composes with the boot rule: at cutover, BEAM re-reads both files
+  one last time, persists the max to the shadow path, and from then on
+  the canonical reader stops touching the Python file. Cutover signal
+  is a `runtime` flag in the shadow file itself for forensic clarity.
+
+  ## Save semantics (v0.1.2 §C3, §N1)
+
+  - String-key normalization via `Jason.encode! |> Jason.decode!` —
+    atom-keyed input round-trips back as string-keyed regardless of
+    the caller's shape.
+  - Log-and-continue: `AtomicWrite.write/2` failures are caught,
+    logged at `:warning`, and `:ok` is returned. Mirrors Python's
+    `save_state` swallow at `agents/sentinel/agent.py:506-508` so
+    BEAM does not become more brittle than Python on ENOSPC / RO-fs.
+  """
+
+  alias UnitaresSentinel.AtomicWrite
+
+  require Logger
+
+  @forced_release_key "forced_release_alarm"
+  @cursor_key "last_event_ts"
+
+  @type t :: %{String.t() => term()}
+
+  @doc """
+  Load the cross-cycle state with max-on-boot semantics.
+
+  Options:
+    * `:canonical` — explicit canonical (Python) path, overrides config
+    * `:shadow` — explicit shadow (BEAM) path, overrides default
+                  (canonical + ".beam")
+  """
+  @spec load(keyword()) :: t()
+  def load(opts \\ []) do
+    {canonical, shadow} = resolve_paths(opts)
+
+    canonical_state = read_decode(canonical)
+    shadow_state = read_decode(shadow)
+
+    pick_max(canonical_state, shadow_state)
+  end
+
+  @doc """
+  Persist `state` to the shadow file, swallowing write errors.
+
+  Always returns `:ok`. Atom-keyed maps are normalized to string keys
+  via Jason round-trip before writing.
+
+  Options:
+    * `:path` — explicit write target, overrides default shadow path
+  """
+  @spec save(map(), keyword()) :: :ok
+  def save(state, opts \\ []) when is_map(state) do
+    path = Keyword.get(opts, :path) || default_shadow_path()
+    normalized = state |> Jason.encode!() |> Jason.decode!()
+
+    try do
+      :ok = AtomicWrite.write(path, Jason.encode!(normalized))
+    rescue
+      e ->
+        Logger.warning(
+          "UnitaresSentinel.CycleState.save: write failed at #{inspect(path)} — #{inspect(e)}"
+        )
+
+        :ok
+    end
+  end
+
+  @doc """
+  Single read accessor for the cursor (mirrors Python's one-site discipline
+  at agents/sentinel/agent.py:663).
+  """
+  @spec get_last_event_ts(t()) :: String.t() | nil
+  def get_last_event_ts(state) when is_map(state) do
+    state
+    |> Map.get(@forced_release_key, %{})
+    |> Map.get(@cursor_key)
+  end
+
+  @doc """
+  Single write accessor for the cursor. Preserves sibling keys under
+  `forced_release_alarm`.
+  """
+  @spec update_last_event_ts(t(), String.t()) :: t()
+  def update_last_event_ts(state, cursor) when is_map(state) and is_binary(cursor) do
+    inner =
+      state
+      |> Map.get(@forced_release_key, %{})
+      |> Map.put(@cursor_key, cursor)
+
+    Map.put(state, @forced_release_key, inner)
+  end
+
+  # ---- internals ---------------------------------------------------------
+
+  defp resolve_paths(opts) do
+    canonical = Keyword.get(opts, :canonical) || resolve_canonical_from_config()
+    shadow = Keyword.get(opts, :shadow) || canonical <> ".beam"
+    {canonical, shadow}
+  end
+
+  defp resolve_canonical_from_config do
+    Application.get_env(:unitares_sentinel, :state_file_path) ||
+      System.get_env("UNITARES_SENTINEL_STATE_FILE") ||
+      raise """
+      UnitaresSentinel.CycleState: STATE_FILE path not configured.
+      Set :unitares_sentinel, :state_file_path in config or
+      UNITARES_SENTINEL_STATE_FILE in the environment. The launchd
+      plist is the source of truth in production.
+      """
+  end
+
+  defp default_shadow_path, do: resolve_canonical_from_config() <> ".beam"
+
+  # Mirrors Python's load_state guard at agents/sentinel/agent.py:494-501:
+  # missing file → %{}, decode failure → %{}, non-map decode → %{}.
+  defp read_decode(path) do
+    with {:ok, contents} <- File.read(path),
+         {:ok, decoded} when is_map(decoded) <- Jason.decode(contents) do
+      decoded
+    else
+      _ -> %{}
+    end
+  end
+
+  # Max-on-boot: empty cursors lose to any non-empty cursor; ISO-8601 with
+  # zero-padded fields and consistent timezone offset is lex-comparable.
+  defp pick_max(canonical_state, shadow_state) do
+    canonical_cursor = get_last_event_ts(canonical_state) || ""
+    shadow_cursor = get_last_event_ts(shadow_state) || ""
+
+    cond do
+      canonical_state == %{} and shadow_state == %{} -> %{}
+      canonical_cursor >= shadow_cursor -> canonical_state
+      true -> shadow_state
+    end
+  end
+end

--- a/elixir/sentinel/lib/unitares_sentinel/cycle_state.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/cycle_state.ex
@@ -45,6 +45,8 @@ defmodule UnitaresSentinel.CycleState do
 
   @forced_release_key "forced_release_alarm"
   @cursor_key "last_event_ts"
+  @runtime_key "runtime"
+  @runtime_beam_canonical "beam_canonical"
 
   @type t :: %{String.t() => term()}
 
@@ -60,10 +62,19 @@ defmodule UnitaresSentinel.CycleState do
   def load(opts \\ []) do
     {canonical, shadow} = resolve_paths(opts)
 
-    canonical_state = read_decode(canonical)
     shadow_state = read_decode(shadow)
 
-    pick_max(canonical_state, shadow_state)
+    # Cutover short-circuit (v0.1.2 §B3): once the shadow declares
+    # `runtime: "beam_canonical"`, BEAM stops reading the Python file.
+    # This honors §B3's "from then on the canonical reader stops touching
+    # the Python file" — without it, max-on-boot would let a stale Python
+    # cursor silently win after cutover.
+    if Map.get(shadow_state, @runtime_key) == @runtime_beam_canonical do
+      shadow_state
+    else
+      canonical_state = read_decode(canonical)
+      pick_max(canonical_state, shadow_state)
+    end
   end
 
   @doc """
@@ -78,10 +89,16 @@ defmodule UnitaresSentinel.CycleState do
   @spec save(map(), keyword()) :: :ok
   def save(state, opts \\ []) when is_map(state) do
     path = Keyword.get(opts, :path) || default_shadow_path()
-    normalized = state |> Jason.encode!() |> Jason.decode!()
+
+    # Normalize OUTSIDE the try block: caller-side encoding bugs (e.g.,
+    # a map containing a PID or a tuple) raise `Protocol.UndefinedError`
+    # and MUST propagate. Python's `save_state` only swallows around
+    # `atomic_write` — `json.dumps` happens on the same line and a
+    # TypeError there would also propagate. Mirror that scope.
+    encoded = state |> Jason.encode!() |> Jason.decode!() |> Jason.encode!()
 
     try do
-      :ok = AtomicWrite.write(path, Jason.encode!(normalized))
+      :ok = AtomicWrite.write(path, encoded)
     rescue
       e ->
         Logger.warning(
@@ -117,15 +134,27 @@ defmodule UnitaresSentinel.CycleState do
     Map.put(state, @forced_release_key, inner)
   end
 
-  # ---- internals ---------------------------------------------------------
+  @doc """
+  Read the cutover runtime flag from a state map (`"beam_canonical"`,
+  `"python_canonical"`, or `nil` when shadow mode is in effect).
+  Per v0.1.2 §B3 cutover protocol.
+  """
+  @spec get_runtime(t()) :: String.t() | nil
+  def get_runtime(state) when is_map(state), do: Map.get(state, @runtime_key)
 
-  defp resolve_paths(opts) do
-    canonical = Keyword.get(opts, :canonical) || resolve_canonical_from_config()
-    shadow = Keyword.get(opts, :shadow) || canonical <> ".beam"
-    {canonical, shadow}
-  end
+  @doc """
+  Resolve the canonical (Python) STATE_FILE path from config / env var.
 
-  defp resolve_canonical_from_config do
+  Public so the `mix sentinel.cursor_diff` task and any future Sentinel
+  diagnostic can share the resolution discipline — eliminates the drift
+  class flagged in the Surface 1 council fold (reviewer concern: two
+  copies of the resolution order).
+
+  Raises if neither `:unitares_sentinel, :state_file_path` (Application env)
+  nor `UNITARES_SENTINEL_STATE_FILE` (system env) is set.
+  """
+  @spec resolve_canonical_path() :: String.t()
+  def resolve_canonical_path do
     Application.get_env(:unitares_sentinel, :state_file_path) ||
       System.get_env("UNITARES_SENTINEL_STATE_FILE") ||
       raise """
@@ -136,7 +165,15 @@ defmodule UnitaresSentinel.CycleState do
       """
   end
 
-  defp default_shadow_path, do: resolve_canonical_from_config() <> ".beam"
+  # ---- internals ---------------------------------------------------------
+
+  defp resolve_paths(opts) do
+    canonical = Keyword.get(opts, :canonical) || resolve_canonical_path()
+    shadow = Keyword.get(opts, :shadow) || canonical <> ".beam"
+    {canonical, shadow}
+  end
+
+  defp default_shadow_path, do: resolve_canonical_path() <> ".beam"
 
   # Mirrors Python's load_state guard at agents/sentinel/agent.py:494-501:
   # missing file → %{}, decode failure → %{}, non-map decode → %{}.
@@ -149,16 +186,25 @@ defmodule UnitaresSentinel.CycleState do
     end
   end
 
-  # Max-on-boot: empty cursors lose to any non-empty cursor; ISO-8601 with
-  # zero-padded fields and consistent timezone offset is lex-comparable.
+  # Max-on-boot per v0.1.2 §B2.
+  #
+  # Single-empty short-circuit FIRST: when only one file decodes to a
+  # non-empty map, return that one unconditionally — never run the lex
+  # compare against an empty placeholder. The earlier shape (cursor
+  # compare with `||""` defaults) silently dropped sibling keys when
+  # one side was `%{"forced_release_alarm" => %{}}` and the other was
+  # truly absent. Surface 1 council fold catch.
+  defp pick_max(%{} = canonical, shadow) when map_size(canonical) == 0, do: shadow
+  defp pick_max(canonical, %{} = shadow) when map_size(shadow) == 0, do: canonical
+
   defp pick_max(canonical_state, shadow_state) do
     canonical_cursor = get_last_event_ts(canonical_state) || ""
     shadow_cursor = get_last_event_ts(shadow_state) || ""
 
-    cond do
-      canonical_state == %{} and shadow_state == %{} -> %{}
-      canonical_cursor >= shadow_cursor -> canonical_state
-      true -> shadow_state
+    if canonical_cursor >= shadow_cursor do
+      canonical_state
+    else
+      shadow_state
     end
   end
 end

--- a/elixir/sentinel/lib/unitares_sentinel/forced_release_poller.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/forced_release_poller.ex
@@ -28,6 +28,34 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
   `tick/1` is the unit of work — call it from the GenServer's tick loop
   OR from tests with explicit options. The GenServer itself is a thin
   scheduler; the testable behavior lives in `tick/1`.
+
+  ## Cursor topology (binding for follow-up PRs)
+
+  This module is **the sole writer** of `forced_release_alarm.last_event_ts`
+  during the ad_hoc-only scope. The follow-up PRs that add the
+  `lease.deprecation_swept` (deprecation-batch) and `conflict_held_by_other`
+  (conflict-batch) query classes **MUST NOT** ship as sibling GenServers
+  that independently write the same cursor key.
+
+  The Python reference at `agents/sentinel/forced_release_alarm.py:87`
+  (`_poll_inner`) advances **one cursor** across all three classes in a
+  single pass — the cursor is `max(ts)` across every row seen. Three
+  independent pollers writing one cursor file would mean: poller A
+  advances past T, then poller B's next query filters `ts > T`,
+  silently skipping any rows older than T that B hadn't yet read.
+
+  Pick one topology before the next PR ships:
+    1. **Combined poller** — one GenServer with three SQL passes per
+       tick (matches Python parity, simplest).
+    2. **Per-class cursor keys** — `forced_release_alarm.last_event_ts`
+       becomes `forced_release_alarm.last_event_ts.ad_hoc` etc. Requires
+       a Python-compat read shim (Python's `agent.py:663` reads the
+       single key — would need to migrate or read the union of keys).
+    3. **Coordinator + workers** — fan-out to three workers, fan-in
+       on a single cursor advance. Most code; cleanest topology.
+
+  Architect council fold for #376 made this binding. Whichever path the
+  next PR picks, it must be explicit in the RFC before any code lands.
   """
 
   use GenServer
@@ -108,13 +136,25 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
   end
 
   defp persist_cursor(new_cursor, opts) do
-    state = CycleState.update_last_event_ts(%{}, DateTime.to_iso8601(new_cursor))
-
+    # Council fold: reviewer Critical-1 (PR #376). Building from %{} would
+    # silently erase any sibling keys in the shadow file — most importantly
+    # the v0.1.2 §B3 `runtime: "beam_canonical"` cutover flag. Load the
+    # existing state first, then update only the cursor, preserving every
+    # other key.
     save_opts =
       case Keyword.get(opts, :state_path) do
         nil -> []
         path -> [path: path]
       end
+
+    load_opts =
+      case Keyword.get(opts, :state_path) do
+        nil -> []
+        path -> [shadow: path]
+      end
+
+    existing = CycleState.load(load_opts)
+    state = CycleState.update_last_event_ts(existing, DateTime.to_iso8601(new_cursor))
 
     CycleState.save(state, save_opts)
   end
@@ -137,26 +177,54 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
     db = Keyword.get(opts, :db, UnitaresSentinel.DB)
     interval_ms = Keyword.get(opts, :interval_ms, Application.get_env(:unitares_sentinel, :poller_interval_ms, 30_000))
     initial_delay_ms = Keyword.get(opts, :initial_delay_ms, Application.get_env(:unitares_sentinel, :poller_initial_delay_ms, 1_000))
+    jitter_ms = Keyword.get(opts, :jitter_ms, Application.get_env(:unitares_sentinel, :poller_jitter_ms, 5_000))
 
     cursor = load_cursor_from_state()
 
     state = %{
       db: db,
       cursor: cursor,
-      interval_ms: interval_ms
+      interval_ms: interval_ms,
+      jitter_ms: jitter_ms
     }
 
-    Process.send_after(self(), :tick, initial_delay_ms)
+    Process.send_after(self(), :tick, initial_delay_ms + sample_jitter(jitter_ms))
     {:ok, state}
   end
 
   @impl true
   def handle_info(:tick, state) do
-    {_alarms, new_cursor} =
-      tick(prior_cursor: state.cursor, db: state.db, persist: true)
+    # Council fold: architect #2 (PR #376). Re-read the file cursor each tick
+    # and use max(in-memory, file). Defends against an operator (or a future
+    # cursor_repair task) writing the shadow file between ticks; without this,
+    # the GenServer would clobber the operator's edit on the next tick.
+    file_cursor = load_cursor_from_state()
+    effective_prior = max_cursor(state.cursor, file_cursor)
 
-    Process.send_after(self(), :tick, state.interval_ms)
+    {_alarms, new_cursor} =
+      tick(prior_cursor: effective_prior, db: state.db, persist: true)
+
+    # Jitter the next tick to avoid Python/BEAM lockstep races after
+    # simultaneous boots (architect #5).
+    Process.send_after(self(), :tick, state.interval_ms + sample_jitter(state.jitter_ms))
+
     {:noreply, %{state | cursor: new_cursor}}
+  end
+
+  # Symmetric ±jitter_ms uniform sample. Non-negative result clamp avoids
+  # ever scheduling a tick into the past if jitter_ms ever exceeds interval_ms
+  # (which would be a config error, but cheap to guard against).
+  defp sample_jitter(0), do: 0
+
+  defp sample_jitter(jitter_ms) when is_integer(jitter_ms) and jitter_ms > 0 do
+    :rand.uniform(2 * jitter_ms + 1) - jitter_ms - 1
+  end
+
+  defp max_cursor(nil, b), do: b
+  defp max_cursor(a, nil), do: a
+
+  defp max_cursor(%DateTime{} = a, %DateTime{} = b) do
+    if DateTime.compare(a, b) == :gt, do: a, else: b
   end
 
   defp load_cursor_from_state do

--- a/elixir/sentinel/lib/unitares_sentinel/forced_release_poller.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/forced_release_poller.ex
@@ -1,0 +1,176 @@
+defmodule UnitaresSentinel.ForcedReleasePoller do
+  @moduledoc """
+  Surface 1 cycle worker — periodic poller that drives `CycleState`.
+
+  Reads the cursor from `CycleState`, queries `lease_plane.lease_plane_events`
+  for `event_type='forced'` rows past the cursor, builds alarms via
+  `ForcedReleasePoller.Logic.build_alarms/2`, advances the cursor to
+  max(rows.ts), and persists via `CycleState.save/2`.
+
+  ## Scope (this PR)
+
+  Ad_hoc forced events (`event_type='forced'`) only — the lowest-volume
+  class. Deferred to follow-up PRs:
+
+    * `event_type='lease.deprecation_swept'` deprecation-batch class
+    * `event_type='conflict_held_by_other'` conflict-batch class
+
+  ## Findings emit
+
+  This module RETURNS alarms but does NOT POST them. Surface 2 (findings
+  emit) is a separate writer-locked surface and lands in its own PR.
+  Returning alarms keeps the API forward-compatible: when Surface 2 wires
+  up, it calls `tick/1` and routes the alarms to the dashboard / Discord
+  bridge.
+
+  ## Tick API
+
+  `tick/1` is the unit of work — call it from the GenServer's tick loop
+  OR from tests with explicit options. The GenServer itself is a thin
+  scheduler; the testable behavior lives in `tick/1`.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias UnitaresSentinel.{CycleState, ForcedReleasePoller.Logic}
+
+  @type opts :: [
+          prior_cursor: DateTime.t() | nil,
+          db: GenServer.server(),
+          persist: boolean(),
+          state_path: Path.t() | nil
+        ]
+
+  # ---- Public tick API --------------------------------------------------
+
+  @doc """
+  Run one poll cycle.
+
+  Options:
+    * `:prior_cursor` — cursor to filter against (`nil` = no filter, fetch all)
+    * `:db` — Postgrex registered name (default: `UnitaresSentinel.DB`)
+    * `:persist` — when true, write the new cursor via `CycleState.save/2`
+       (default: false; the GenServer flips this to true at runtime, tests
+       opt in selectively)
+    * `:state_path` — explicit shadow path to persist into; only used when
+       `:persist` is true and overrides the default config-resolved path
+
+  Returns `{alarms, new_cursor}` where `new_cursor` is `DateTime.t() | nil`.
+  """
+  @spec tick(opts()) :: {[Logic.alarm()], DateTime.t() | nil}
+  def tick(opts \\ []) do
+    db = Keyword.get(opts, :db, UnitaresSentinel.DB)
+    prior_cursor = Keyword.get(opts, :prior_cursor)
+    persist? = Keyword.get(opts, :persist, false)
+
+    rows = query_forced_rows(db, prior_cursor)
+    {alarms, new_cursor} = Logic.build_alarms(rows, prior_cursor)
+
+    if persist? and new_cursor != nil do
+      persist_cursor(new_cursor, opts)
+    end
+
+    {alarms, new_cursor}
+  end
+
+  defp query_forced_rows(db, prior_cursor) do
+    sql = """
+    SELECT event_id::text AS event_id,
+           ts,
+           lease_id::text AS lease_id,
+           surface_id,
+           surface_kind
+    FROM lease_plane.lease_plane_events
+    WHERE event_type = 'forced'
+      AND ($1::timestamptz IS NULL OR ts > $1)
+    ORDER BY ts
+    """
+
+    case Postgrex.query(db, sql, [prior_cursor]) do
+      {:ok, %{rows: rows, columns: cols}} ->
+        Enum.map(rows, &row_to_map(cols, &1))
+
+      {:error, e} ->
+        Logger.warning(
+          "ForcedReleasePoller.query_forced_rows: #{inspect(e)} — returning empty rows"
+        )
+
+        []
+    end
+  end
+
+  defp row_to_map(columns, row) do
+    columns
+    |> Enum.zip(row)
+    |> Enum.into(%{}, fn {col, val} -> {String.to_atom(col), val} end)
+  end
+
+  defp persist_cursor(new_cursor, opts) do
+    state = CycleState.update_last_event_ts(%{}, DateTime.to_iso8601(new_cursor))
+
+    save_opts =
+      case Keyword.get(opts, :state_path) do
+        nil -> []
+        path -> [path: path]
+      end
+
+    CycleState.save(state, save_opts)
+  end
+
+  # ---- GenServer scheduler ----------------------------------------------
+
+  @doc """
+  Start the poller GenServer. Reads cursor from CycleState on init,
+  schedules first tick after `:poller_initial_delay_ms`, then ticks
+  every `:poller_interval_ms`.
+
+  Both intervals are config-driven so tests can inject short values.
+  """
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  @impl true
+  def init(opts) do
+    db = Keyword.get(opts, :db, UnitaresSentinel.DB)
+    interval_ms = Keyword.get(opts, :interval_ms, Application.get_env(:unitares_sentinel, :poller_interval_ms, 30_000))
+    initial_delay_ms = Keyword.get(opts, :initial_delay_ms, Application.get_env(:unitares_sentinel, :poller_initial_delay_ms, 1_000))
+
+    cursor = load_cursor_from_state()
+
+    state = %{
+      db: db,
+      cursor: cursor,
+      interval_ms: interval_ms
+    }
+
+    Process.send_after(self(), :tick, initial_delay_ms)
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info(:tick, state) do
+    {_alarms, new_cursor} =
+      tick(prior_cursor: state.cursor, db: state.db, persist: true)
+
+    Process.send_after(self(), :tick, state.interval_ms)
+    {:noreply, %{state | cursor: new_cursor}}
+  end
+
+  defp load_cursor_from_state do
+    case CycleState.get_last_event_ts(CycleState.load()) do
+      nil ->
+        nil
+
+      ts when is_binary(ts) ->
+        case DateTime.from_iso8601(ts) do
+          {:ok, dt, _} -> dt
+          _ -> nil
+        end
+    end
+  rescue
+    _ -> nil
+  end
+end

--- a/elixir/sentinel/lib/unitares_sentinel/forced_release_poller/logic.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/forced_release_poller/logic.ex
@@ -1,0 +1,90 @@
+defmodule UnitaresSentinel.ForcedReleasePoller.Logic do
+  @moduledoc """
+  Pure logic for transforming `lease_plane.lease_plane_events` rows into
+  Sentinel alarms + advancing the cursor.
+
+  Surface 1 cycle worker scope (this PR): `event_type='forced'` only —
+  the per-event ad_hoc class. Mirrors `_ad_hoc_alarm` in
+  `agents/sentinel/forced_release_alarm.py` for parity.
+
+  Deferred (follow-up PRs):
+    * `event_type='lease.deprecation_swept'` deprecation-batch class
+    * `event_type='conflict_held_by_other'` conflict-batch class
+
+  Caller contract (the GenServer): rows arrive as `[%{event_id: binary,
+  ts: DateTime.t, lease_id: binary | nil, surface_id: binary,
+  surface_kind: binary}]` — atom keys, UUIDs already cast to text by the
+  SQL layer. The `prior_cursor` is `DateTime.t | nil`; `nil` means first
+  poll, advance to max(rows.ts) or stay nil if rows are empty.
+  """
+
+  @type row :: %{
+          required(:event_id) => binary(),
+          required(:ts) => DateTime.t(),
+          required(:lease_id) => binary() | nil,
+          required(:surface_id) => binary(),
+          required(:surface_kind) => binary()
+        }
+
+  @type alarm :: %{
+          kind: String.t(),
+          severity: String.t(),
+          summary: String.t(),
+          fingerprint: String.t(),
+          extra: %{
+            event_id: binary(),
+            ts: String.t(),
+            lease_id: binary() | nil,
+            surface_id: binary(),
+            surface_kind: binary()
+          }
+        }
+
+  @doc """
+  Build alarms from `rows` and advance the cursor.
+
+  Cursor never regresses: if every row's ts is older than `prior_cursor`,
+  the prior is preserved. This is defensive — the SQL filter should
+  already exclude older rows, but a buggy filter must not corrupt the
+  de-dup fence.
+  """
+  @spec build_alarms([row()], DateTime.t() | nil) :: {[alarm()], DateTime.t() | nil}
+  def build_alarms(rows, prior_cursor) when is_list(rows) do
+    alarms = Enum.map(rows, &row_to_alarm/1)
+    new_cursor = advance_cursor(rows, prior_cursor)
+    {alarms, new_cursor}
+  end
+
+  defp row_to_alarm(%{event_id: event_id, surface_id: surface_id} = row) do
+    lease_label = lease_label(row.lease_id)
+
+    %{
+      kind: "ad_hoc",
+      severity: "high",
+      summary: "forced release: #{surface_id} (lease #{lease_label})",
+      fingerprint: "forced_release:ad_hoc:#{event_id}",
+      extra: %{
+        event_id: event_id,
+        ts: DateTime.to_iso8601(row.ts),
+        lease_id: row.lease_id,
+        surface_id: surface_id,
+        surface_kind: row.surface_kind
+      }
+    }
+  end
+
+  defp lease_label(nil), do: "<unknown>"
+  defp lease_label(lease_id) when is_binary(lease_id), do: lease_id
+
+  defp advance_cursor([], prior), do: prior
+
+  defp advance_cursor(rows, prior) do
+    max_ts = rows |> Enum.map(& &1.ts) |> Enum.max(DateTime)
+
+    cond do
+      is_nil(prior) -> max_ts
+      DateTime.compare(max_ts, prior) == :gt -> max_ts
+      true -> prior
+    end
+  end
+end

--- a/elixir/sentinel/test/fixtures/sentinel_state_beam_v1.json
+++ b/elixir/sentinel/test/fixtures/sentinel_state_beam_v1.json
@@ -1,0 +1,1 @@
+{"forced_release_alarm":{"last_event_ts":"2026-05-04T12:00:00.000000+00:00"}}

--- a/elixir/sentinel/test/fixtures/sentinel_state_python_v1.json
+++ b/elixir/sentinel/test/fixtures/sentinel_state_python_v1.json
@@ -1,0 +1,1 @@
+{"forced_release_alarm": {"last_event_ts": "2026-05-03T13:56:34.479878+00:00"}}

--- a/elixir/sentinel/test/support/sentinel_test_helpers.ex
+++ b/elixir/sentinel/test/support/sentinel_test_helpers.ex
@@ -1,0 +1,66 @@
+defmodule SentinelTestHelpers do
+  @moduledoc """
+  Test fixtures + cleanup for `:db`-tagged integration tests.
+
+  All fixtures use a unique `surface_id` prefix derived from a per-test
+  random label so they cannot collide with concurrent tests or production
+  rows. Cleanup deletes by exactly that prefix.
+
+  Mirrors `LeaseTestHelpers` in `elixir/lease_plane/test/support/`.
+  """
+
+  alias UnitaresSentinel.DB
+
+  @doc "Random hex label suitable as a fixture-isolation suffix."
+  def random_label do
+    :crypto.strong_rand_bytes(6) |> Base.encode16(case: :lower)
+  end
+
+  @doc """
+  Generate a unique surface_id for a single test using the
+  `dialectic:/test_sentinel_<label>_<rand>` canonical scheme so the
+  surface_id passes migration 026's `surface_id_grammar` CHECK.
+  """
+  def unique_surface_id(label) when is_binary(label) do
+    "dialectic:/test_sentinel_#{label}_#{random_label()}"
+  end
+
+  @doc "Stable random UUID-as-string for holder_agent_uuid in fixtures."
+  def random_uuid do
+    <<a::32, b::16, c::16, d::16, e::48>> = :crypto.strong_rand_bytes(16)
+    parts = [<<a::32>>, <<b::16>>, <<c::16>>, <<d::16>>, <<e::48>>]
+    parts |> Enum.map_join("-", &Base.encode16(&1, case: :lower))
+  end
+
+  @doc """
+  Insert one `event_type='forced'` row into `lease_plane.lease_plane_events`
+  with the given surface_id and ts. Returns the inserted event_id (uuid string).
+  """
+  def insert_forced_event(surface_id, ts \\ nil) do
+    sql = """
+    INSERT INTO lease_plane.lease_plane_events
+      (ts, event_type, lease_id, surface_id, surface_kind, advisory_mode, payload)
+    VALUES (COALESCE($1::timestamptz, now()), 'forced', gen_random_uuid(), $2, $3, true, '{}'::jsonb)
+    RETURNING event_id::text, ts
+    """
+
+    {:ok, %{rows: [[event_id, returned_ts]]}} =
+      Postgrex.query(DB, sql, [ts, surface_id, surface_kind_of(surface_id)])
+
+    {event_id, returned_ts}
+  end
+
+  @doc "DELETE all lease_plane_events rows for surface_ids beginning with the prefix."
+  def cleanup_surface_prefix(prefix) when is_binary(prefix) do
+    Postgrex.query!(
+      DB,
+      "DELETE FROM lease_plane.lease_plane_events WHERE surface_id LIKE $1",
+      [prefix <> "%"]
+    )
+
+    :ok
+  end
+
+  defp surface_kind_of("dialectic:/" <> _), do: "dialectic"
+  defp surface_kind_of(other), do: other |> String.split(":", parts: 2) |> hd()
+end

--- a/elixir/sentinel/test/test_helper.exs
+++ b/elixir/sentinel/test/test_helper.exs
@@ -1,1 +1,32 @@
-ExUnit.start()
+# Try to start Postgrex against the test DB. If the DB is unreachable,
+# integration tests tagged `:db` are excluded so the suite stays green
+# for environments without local Postgres. Pure-logic tests run regardless.
+
+db_available? =
+  try do
+    opts = UnitaresSentinel.Application.postgrex_opts()
+
+    case Postgrex.start_link(Keyword.put(opts, :pool_size, 2)) do
+      {:ok, _pid} ->
+        case Postgrex.query(UnitaresSentinel.DB, "SELECT 1", []) do
+          {:ok, _} -> true
+          _ -> false
+        end
+
+      _ ->
+        false
+    end
+  rescue
+    _ -> false
+  end
+
+if db_available? do
+  ExUnit.start()
+else
+  IO.puts(
+    :stderr,
+    "[test_helper] governance_test DB unreachable — excluding :db-tagged tests"
+  )
+
+  ExUnit.start(exclude: [:db])
+end

--- a/elixir/sentinel/test/unitares_sentinel/cycle_state_config_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/cycle_state_config_test.exs
@@ -1,0 +1,69 @@
+defmodule UnitaresSentinel.CycleStateConfigTest do
+  @moduledoc """
+  Path-resolution-from-config tests live in a non-async module because they
+  mutate `Application.env`, which is global. If these ran with `async: true`
+  alongside the main `cycle_state_test.exs`, any concurrent test that called
+  `CycleState.save/1` or `CycleState.load/0` with no `:path` opt could pick
+  up the polluted config key and resolve to this test's tmp path.
+
+  Surface 1 council fold (reviewer Critical-2): the prior shape had this
+  test in the async module; the race was latent because the only no-opts
+  callers in the test file were here. But the contract surface is global —
+  any future test that defaults the path would join the race. Isolating
+  here removes the class.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias UnitaresSentinel.CycleState
+
+  setup do
+    tmpdir =
+      System.tmp_dir!()
+      |> Path.join("unitares_sentinel_cycle_state_config_test_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmpdir)
+    on_exit(fn -> File.rm_rf!(tmpdir) end)
+
+    canonical = Path.join(tmpdir, ".sentinel_state")
+
+    on_exit(fn -> Application.delete_env(:unitares_sentinel, :state_file_path) end)
+
+    {:ok, tmpdir: tmpdir, canonical: canonical}
+  end
+
+  test "default path resolves from :unitares_sentinel, :state_file_path config", ctx do
+    Application.put_env(:unitares_sentinel, :state_file_path, ctx.canonical)
+
+    state = %{"forced_release_alarm" => %{"last_event_ts" => "2026-05-05T03:14:15+00:00"}}
+
+    # save with no opts uses config; load with no opts uses config.
+    :ok = CycleState.save(state)
+    assert CycleState.load() == state
+  end
+
+  test "resolve_canonical_path/0 prefers Application env over system env", ctx do
+    Application.put_env(:unitares_sentinel, :state_file_path, ctx.canonical)
+    System.put_env("UNITARES_SENTINEL_STATE_FILE", "/should/not/be/used")
+    on_exit(fn -> System.delete_env("UNITARES_SENTINEL_STATE_FILE") end)
+
+    assert CycleState.resolve_canonical_path() == ctx.canonical
+  end
+
+  test "resolve_canonical_path/0 falls back to env var when config absent", ctx do
+    Application.delete_env(:unitares_sentinel, :state_file_path)
+    System.put_env("UNITARES_SENTINEL_STATE_FILE", ctx.canonical)
+    on_exit(fn -> System.delete_env("UNITARES_SENTINEL_STATE_FILE") end)
+
+    assert CycleState.resolve_canonical_path() == ctx.canonical
+  end
+
+  test "resolve_canonical_path/0 raises when neither config nor env set", _ctx do
+    Application.delete_env(:unitares_sentinel, :state_file_path)
+    System.delete_env("UNITARES_SENTINEL_STATE_FILE")
+
+    assert_raise RuntimeError, ~r/STATE_FILE path not configured/, fn ->
+      CycleState.resolve_canonical_path()
+    end
+  end
+end

--- a/elixir/sentinel/test/unitares_sentinel/cycle_state_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/cycle_state_test.exs
@@ -114,6 +114,84 @@ defmodule UnitaresSentinel.CycleStateTest do
              "2026-05-04T00:00:00.000000+00:00"
   end
 
+  # Council fold: reviewer Critical-1. Without the single-empty short-circuit,
+  # `pick_max("" >= "")` was true and returned canonical (`%{}`), silently
+  # dropping shadow's sibling keys when canonical was absent.
+  test "max-on-boot: only shadow exists with empty cursor — sibling keys preserved", ctx do
+    # canonical absent; shadow has forced_release_alarm with no cursor but
+    # other tracked sibling keys (real cycle-worker shape pre-first-emit).
+    File.write!(
+      ctx.shadow,
+      ~s({"forced_release_alarm": {"first_seen_at": "2026-05-04T00:00:00+00:00"}, "runtime": "shadow"})
+    )
+
+    state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+    # Must NOT be %{} — the sibling data has to survive boot.
+    assert get_in(state, ["forced_release_alarm", "first_seen_at"]) ==
+             "2026-05-04T00:00:00+00:00"
+    assert Map.get(state, "runtime") == "shadow"
+  end
+
+  test "max-on-boot: only canonical exists with empty cursor — sibling keys preserved", ctx do
+    File.write!(
+      ctx.canonical,
+      ~s({"forced_release_alarm": {"some_python_metadata": "preserve_me"}})
+    )
+
+    state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+    assert get_in(state, ["forced_release_alarm", "some_python_metadata"]) == "preserve_me"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Cutover flag awareness (v0.1.2 §B3) — runtime: beam_canonical short-circuit.
+  # ---------------------------------------------------------------------------
+
+  test "cutover: shadow with runtime=beam_canonical — canonical is NOT read", ctx do
+    # Canonical has a NEWER cursor but the operator has cut over to BEAM.
+    # Per §B3, BEAM "stops reading STATE_FILE" once canonical → reading
+    # both and picking max would silently regress to Python's diagnostic
+    # write if the operator runs Python for any reason post-cutover.
+    File.write!(
+      ctx.canonical,
+      ~s({"forced_release_alarm": {"last_event_ts": "2026-05-10T00:00:00.000000+00:00"}})
+    )
+
+    File.write!(
+      ctx.shadow,
+      ~s({"runtime": "beam_canonical", "forced_release_alarm": {"last_event_ts": "2026-05-04T00:00:00.000000+00:00"}})
+    )
+
+    state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+    # Shadow wins despite older cursor — the runtime flag is load-bearing.
+    assert get_in(state, ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-04T00:00:00.000000+00:00"
+    assert CycleState.get_runtime(state) == "beam_canonical"
+  end
+
+  test "cutover: shadow with runtime=python_canonical — falls back to max-on-boot", ctx do
+    # Rollback case: operator set runtime back to python_canonical to revert.
+    # Shadow's runtime flag is no longer "beam_canonical" so the short-circuit
+    # is OFF; max-on-boot resumes and picks the newer cursor (likely python's).
+    File.write!(
+      ctx.canonical,
+      ~s({"forced_release_alarm": {"last_event_ts": "2026-05-10T00:00:00.000000+00:00"}})
+    )
+
+    File.write!(
+      ctx.shadow,
+      ~s({"runtime": "python_canonical", "forced_release_alarm": {"last_event_ts": "2026-05-04T00:00:00.000000+00:00"}})
+    )
+
+    state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+    assert get_in(state, ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-10T00:00:00.000000+00:00"
+  end
+
+  test "get_runtime/1 returns nil when no flag set (shadow mode default)", _ctx do
+    assert CycleState.get_runtime(%{"forced_release_alarm" => %{}}) == nil
+    assert CycleState.get_runtime(%{}) == nil
+  end
+
   # ---------------------------------------------------------------------------
   # Schema binding (v0.1.1 §Surface 1, retained in v0.1.2).
   # ---------------------------------------------------------------------------
@@ -177,6 +255,20 @@ defmodule UnitaresSentinel.CycleStateTest do
     assert CycleState.save(%{"forced_release_alarm" => %{"last_event_ts" => "2026-05-05T00:00:00+00:00"}}, path: ctx.shadow) == :ok
   end
 
+  # Council fold: reviewer Important-3. Encoding errors are caller-side bugs,
+  # NOT I/O errors — they MUST propagate. Python's save_state swallows only
+  # around atomic_write; json.dumps would raise TypeError for non-serializable
+  # values and that propagates. BEAM must match scope, not be broader.
+  test "save propagates Jason encoding errors (programming bugs are not I/O failures)", ctx do
+    # PIDs are not JSON-encodable — Jason.encode! raises Protocol.UndefinedError.
+    # If save catches this, the missing write is invisible to the caller.
+    state_with_pid = %{"forced_release_alarm" => %{"some_pid" => self()}}
+
+    assert_raise Protocol.UndefinedError, fn ->
+      CycleState.save(state_with_pid, path: ctx.shadow)
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # Single-site accessors (v0.1.2 verifier REFUTED — Python has one read site).
   # ---------------------------------------------------------------------------
@@ -225,18 +317,8 @@ defmodule UnitaresSentinel.CycleStateTest do
            "Python fixture cursor must be ISO-8601 (got: #{inspect(cursor)})"
   end
 
-  # ---------------------------------------------------------------------------
-  # Path resolution from config (v0.1.2 §B1).
-  # ---------------------------------------------------------------------------
-
-  test "default path resolves from :unitares_sentinel, :state_file_path config", ctx do
-    Application.put_env(:unitares_sentinel, :state_file_path, ctx.canonical)
-    on_exit(fn -> Application.delete_env(:unitares_sentinel, :state_file_path) end)
-
-    state = %{"forced_release_alarm" => %{"last_event_ts" => "2026-05-05T03:14:15+00:00"}}
-
-    # save with no opts uses config; load with no opts uses config.
-    :ok = CycleState.save(state)
-    assert CycleState.load() == state
-  end
+  # NOTE: The Application.put_env-based path-resolution test lives in a
+  # SEPARATE non-async module (`cycle_state_config_test.exs`) — Application
+  # env is global and races against other async tests in this module that
+  # call `save/1` / `load/0` with no opts. Council fold: reviewer Critical-2.
 end

--- a/elixir/sentinel/test/unitares_sentinel/cycle_state_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/cycle_state_test.exs
@@ -1,0 +1,242 @@
+defmodule UnitaresSentinel.CycleStateTest do
+  @moduledoc """
+  Surface 1 binding spec — see `docs/proposals/beam-wave-1-sentinel.md`
+  v0.1.2 amendment block. Path resolution, max-on-boot semantics,
+  string-key normalization, isinstance guard, and log-and-continue
+  exception contract are all council-folded BLOCKs/CONCERNs. These
+  tests are the regression bar.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias UnitaresSentinel.CycleState
+
+  setup do
+    tmpdir =
+      System.tmp_dir!()
+      |> Path.join("unitares_sentinel_cycle_state_test_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmpdir)
+    on_exit(fn -> File.rm_rf!(tmpdir) end)
+
+    # Surface 1 path discipline: shadow file lives next to canonical
+    # with `.beam` suffix appended (v0.1.2 §B1).
+    canonical = Path.join(tmpdir, ".sentinel_state")
+    shadow = canonical <> ".beam"
+
+    {:ok, tmpdir: tmpdir, canonical: canonical, shadow: shadow}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Round-trip: save then load recovers the cursor (canonical happy path).
+  # ---------------------------------------------------------------------------
+
+  test "save then load round-trips the cursor", ctx do
+    state = %{"forced_release_alarm" => %{"last_event_ts" => "2026-05-03T13:56:34.479878+00:00"}}
+
+    :ok = CycleState.save(state, path: ctx.shadow)
+    assert CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow) == state
+  end
+
+  # ---------------------------------------------------------------------------
+  # Max-on-boot (v0.1.2 §B2). The four cases the amendment enumerates.
+  # ---------------------------------------------------------------------------
+
+  test "max-on-boot: both files exist, beam newer — beam wins", ctx do
+    File.write!(
+      ctx.canonical,
+      ~s({"forced_release_alarm": {"last_event_ts": "2026-05-03T00:00:00.000000+00:00"}})
+    )
+
+    File.write!(
+      ctx.shadow,
+      ~s({"forced_release_alarm": {"last_event_ts": "2026-05-04T00:00:00.000000+00:00"}})
+    )
+
+    state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+    assert get_in(state, ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-04T00:00:00.000000+00:00"
+  end
+
+  test "max-on-boot: both files exist, python newer — python wins", ctx do
+    File.write!(
+      ctx.canonical,
+      ~s({"forced_release_alarm": {"last_event_ts": "2026-05-05T12:00:00.000000+00:00"}})
+    )
+
+    File.write!(
+      ctx.shadow,
+      ~s({"forced_release_alarm": {"last_event_ts": "2026-05-04T00:00:00.000000+00:00"}})
+    )
+
+    state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+    assert get_in(state, ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-05T12:00:00.000000+00:00"
+  end
+
+  test "max-on-boot: only python file exists — python wins", ctx do
+    File.write!(
+      ctx.canonical,
+      ~s({"forced_release_alarm": {"last_event_ts": "2026-05-03T13:56:34.479878+00:00"}})
+    )
+
+    state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+    assert get_in(state, ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-03T13:56:34.479878+00:00"
+  end
+
+  test "max-on-boot: only beam file exists — beam wins", ctx do
+    File.write!(
+      ctx.shadow,
+      ~s({"forced_release_alarm": {"last_event_ts": "2026-05-04T01:02:03.456789+00:00"}})
+    )
+
+    state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+    assert get_in(state, ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-04T01:02:03.456789+00:00"
+  end
+
+  test "max-on-boot: neither file exists — empty map", ctx do
+    assert CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow) == %{}
+  end
+
+  test "max-on-boot: empty cursor counts as oldest (any non-empty wins)", ctx do
+    # Canonical has the key but empty; shadow has a real timestamp.
+    File.write!(ctx.canonical, ~s({"forced_release_alarm": {}}))
+
+    File.write!(
+      ctx.shadow,
+      ~s({"forced_release_alarm": {"last_event_ts": "2026-05-04T00:00:00.000000+00:00"}})
+    )
+
+    state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+    assert get_in(state, ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-04T00:00:00.000000+00:00"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Schema binding (v0.1.1 §Surface 1, retained in v0.1.2).
+  # ---------------------------------------------------------------------------
+
+  test "schema binding: forced_release_alarm.last_event_ts stays top-level ISO-8601 string", ctx do
+    state = %{"forced_release_alarm" => %{"last_event_ts" => "2026-05-05T12:34:56.789012+00:00"}}
+    :ok = CycleState.save(state, path: ctx.shadow)
+
+    raw = File.read!(ctx.shadow)
+    decoded = Jason.decode!(raw)
+
+    # Top-level key, not nested under "state" or "cursor" — Python's
+    # rollback reader at agents/sentinel/agent.py:663 reads exactly this path.
+    assert get_in(decoded, ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-05T12:34:56.789012+00:00"
+  end
+
+  # ---------------------------------------------------------------------------
+  # String-key normalization (v0.1.2 §C3) — atom keys round-trip as strings.
+  # ---------------------------------------------------------------------------
+
+  test "string-key normalization: atom-keyed input round-trips as string-keyed", ctx do
+    atom_keyed = %{forced_release_alarm: %{last_event_ts: "2026-05-05T12:00:00.000000+00:00"}}
+
+    :ok = CycleState.save(atom_keyed, path: ctx.shadow)
+    loaded = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+
+    # Caller MUST see string keys back regardless of input shape.
+    assert loaded == %{
+             "forced_release_alarm" => %{"last_event_ts" => "2026-05-05T12:00:00.000000+00:00"}
+           }
+  end
+
+  # ---------------------------------------------------------------------------
+  # isinstance guard (v0.1.2 verifier REFUTED) — non-map JSON falls through.
+  # ---------------------------------------------------------------------------
+
+  test "isinstance guard: non-map JSON (array) falls through to %{}", ctx do
+    File.write!(ctx.shadow, ~s([1, 2, 3]))
+
+    assert CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow) == %{}
+  end
+
+  test "isinstance guard: malformed JSON falls through to %{}", ctx do
+    File.write!(ctx.shadow, "not json at all {{{")
+
+    assert CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow) == %{}
+  end
+
+  # ---------------------------------------------------------------------------
+  # save/1 log-and-continue (v0.1.2 §N1).
+  # ---------------------------------------------------------------------------
+
+  test "save log-and-continue: returns :ok even when AtomicWrite fails", ctx do
+    # Force AtomicWrite to raise by making the destination a non-empty directory
+    # (matches the AtomicWrite test's failure-injection strategy).
+    File.mkdir_p!(ctx.shadow)
+    File.touch!(Path.join(ctx.shadow, "hold"))
+
+    # Must NOT raise — Python's save_state swallows; BEAM matches.
+    assert CycleState.save(%{"forced_release_alarm" => %{"last_event_ts" => "2026-05-05T00:00:00+00:00"}}, path: ctx.shadow) == :ok
+  end
+
+  # ---------------------------------------------------------------------------
+  # Single-site accessors (v0.1.2 verifier REFUTED — Python has one read site).
+  # ---------------------------------------------------------------------------
+
+  test "get_last_event_ts/1 returns the cursor string", _ctx do
+    state = %{"forced_release_alarm" => %{"last_event_ts" => "2026-05-05T01:23:45.678901+00:00"}}
+    assert CycleState.get_last_event_ts(state) == "2026-05-05T01:23:45.678901+00:00"
+  end
+
+  test "get_last_event_ts/1 returns nil on empty/missing", _ctx do
+    assert CycleState.get_last_event_ts(%{}) == nil
+    assert CycleState.get_last_event_ts(%{"forced_release_alarm" => %{}}) == nil
+  end
+
+  test "update_last_event_ts/2 sets the cursor under the canonical key path", _ctx do
+    updated = CycleState.update_last_event_ts(%{}, "2026-05-05T01:23:45.678901+00:00")
+    assert get_in(updated, ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-05T01:23:45.678901+00:00"
+  end
+
+  test "update_last_event_ts/2 preserves sibling keys under forced_release_alarm", _ctx do
+    state = %{"forced_release_alarm" => %{"sibling_key" => "preserve_me"}}
+    updated = CycleState.update_last_event_ts(state, "2026-05-05T01:23:45+00:00")
+    assert get_in(updated, ["forced_release_alarm", "sibling_key"]) == "preserve_me"
+    assert get_in(updated, ["forced_release_alarm", "last_event_ts"]) == "2026-05-05T01:23:45+00:00"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Tier 2 cross-runtime fixture (v0.1.2 §C4).
+  # ---------------------------------------------------------------------------
+
+  test "Tier 2: BEAM CycleState.load round-trips a Python-written fixture", ctx do
+    # The committed fixture is byte-equivalent to what `agents/sentinel/agent.py`
+    # writes via `save_state`. Drift between Python's writer and this fixture
+    # is a Tier 2 contract violation and a CI failure.
+    fixture_path = Path.join([__DIR__, "..", "fixtures", "sentinel_state_python_v1.json"])
+    fixture = File.read!(fixture_path)
+
+    File.write!(ctx.canonical, fixture)
+    state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+
+    # Cursor MUST be recoverable from the Python fixture without loss.
+    cursor = CycleState.get_last_event_ts(state)
+    assert is_binary(cursor), "Python fixture cursor must be a binary string"
+    assert String.match?(cursor, ~r/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/),
+           "Python fixture cursor must be ISO-8601 (got: #{inspect(cursor)})"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Path resolution from config (v0.1.2 §B1).
+  # ---------------------------------------------------------------------------
+
+  test "default path resolves from :unitares_sentinel, :state_file_path config", ctx do
+    Application.put_env(:unitares_sentinel, :state_file_path, ctx.canonical)
+    on_exit(fn -> Application.delete_env(:unitares_sentinel, :state_file_path) end)
+
+    state = %{"forced_release_alarm" => %{"last_event_ts" => "2026-05-05T03:14:15+00:00"}}
+
+    # save with no opts uses config; load with no opts uses config.
+    :ok = CycleState.save(state)
+    assert CycleState.load() == state
+  end
+end

--- a/elixir/sentinel/test/unitares_sentinel/forced_release_poller_integration_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/forced_release_poller_integration_test.exs
@@ -123,4 +123,45 @@ defmodule UnitaresSentinel.ForcedReleasePollerIntegrationTest do
     refute File.exists?(ctx.state_file <> ".beam"),
            "persist: false must not create the shadow file"
   end
+
+  # Council fold: reviewer Critical-1 (PR #376). persist_cursor was building
+  # from %{} on every tick, silently erasing the v0.1.2 §B3 runtime flag and
+  # any other sibling keys. This test pins the contract: an existing
+  # `runtime: "beam_canonical"` flag in the shadow file MUST survive a tick
+  # that persists a new cursor.
+  test "tick preserves existing runtime flag in shadow file", ctx do
+    shadow_path = ctx.state_file <> ".beam"
+
+    # Pre-stage the shadow file with the cutover flag and an old cursor.
+    File.write!(
+      shadow_path,
+      ~s({"runtime": "beam_canonical", "forced_release_alarm": {"last_event_ts": "2026-05-01T00:00:00.000000+00:00"}})
+    )
+
+    # Insert a new event so the tick has something to advance to.
+    surface_id = ctx.surface_prefix <> "/runtime_preserve"
+    {_event_id, event_ts} = H.insert_forced_event(surface_id)
+
+    prior = DateTime.add(event_ts, -1, :second)
+
+    _ =
+      ForcedReleasePoller.tick(
+        prior_cursor: prior,
+        db: UnitaresSentinel.DB,
+        persist: true,
+        state_path: shadow_path
+      )
+
+    # Re-read the shadow file directly (bypass max-on-boot canonical merge
+    # by using a non-existent canonical path).
+    raw = File.read!(shadow_path)
+    decoded = Jason.decode!(raw)
+
+    assert decoded["runtime"] == "beam_canonical",
+           "runtime flag must survive cycle-worker tick (was: #{inspect(decoded)})"
+
+    # Cursor still advanced.
+    assert get_in(decoded, ["forced_release_alarm", "last_event_ts"]) ==
+             DateTime.to_iso8601(event_ts)
+  end
 end

--- a/elixir/sentinel/test/unitares_sentinel/forced_release_poller_integration_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/forced_release_poller_integration_test.exs
@@ -1,0 +1,126 @@
+defmodule UnitaresSentinel.ForcedReleasePollerIntegrationTest do
+  @moduledoc """
+  Integration tests for the cycle worker against a real `governance_test`
+  Postgres. Skipped automatically when the DB is unreachable (see
+  `test/test_helper.exs`).
+
+  Surface 1 cycle worker contract: a single tick reads the cursor from
+  `CycleState`, queries `lease_plane.lease_plane_events` for `event_type='forced'`
+  rows newer than the cursor, builds alarms via `Logic.build_alarms/2`,
+  advances the cursor to max(rows.ts), persists via `CycleState.save/2`.
+
+  Findings emit (POSTing alarms) is Surface 2 — out of scope for this PR.
+  The tick returns `{alarms, new_cursor}` so callers can wire emit later
+  without changing this surface.
+
+  Async: false because we mutate global Application env (state_file_path)
+  and rely on Postgrex.start_link in test_helper having registered the DB.
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :db
+
+  alias UnitaresSentinel.{CycleState, ForcedReleasePoller}
+  alias SentinelTestHelpers, as: H
+
+  setup do
+    label = H.random_label()
+    surface_prefix = "dialectic:/test_sentinel_surface1_#{label}"
+
+    tmpdir =
+      System.tmp_dir!()
+      |> Path.join("unitares_sentinel_poller_test_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmpdir)
+    state_file = Path.join(tmpdir, ".sentinel_state")
+
+    Application.put_env(:unitares_sentinel, :state_file_path, state_file)
+
+    on_exit(fn ->
+      H.cleanup_surface_prefix(surface_prefix)
+      Application.delete_env(:unitares_sentinel, :state_file_path)
+      File.rm_rf!(tmpdir)
+    end)
+
+    {:ok, surface_prefix: surface_prefix, state_file: state_file, tmpdir: tmpdir}
+  end
+
+  test "tick on empty cursor + zero matching rows → no alarms, cursor unchanged", _ctx do
+    {alarms, new_cursor} = ForcedReleasePoller.tick(prior_cursor: nil, db: UnitaresSentinel.DB)
+
+    assert alarms == []
+    assert new_cursor == nil
+  end
+
+  test "tick picks up a newly-inserted forced event past the prior cursor", ctx do
+    surface_id = ctx.surface_prefix <> "/inserted"
+    {event_id, event_ts} = H.insert_forced_event(surface_id)
+
+    # Use a prior cursor 1 second before the inserted event so the SQL
+    # filter must include this row.
+    prior = DateTime.add(event_ts, -1, :second)
+
+    {alarms, new_cursor} = ForcedReleasePoller.tick(prior_cursor: prior, db: UnitaresSentinel.DB)
+
+    # Filter to alarms for OUR surface — concurrent tests may have
+    # inserted other forced events with their own prefixes.
+    our_alarms = Enum.filter(alarms, &(&1.extra.surface_id == surface_id))
+
+    assert length(our_alarms) == 1
+    assert hd(our_alarms).extra.event_id == event_id
+    assert hd(our_alarms).fingerprint == "forced_release:ad_hoc:#{event_id}"
+
+    # Cursor must advance at least to our event_ts (or further if other tests
+    # inserted later events). Truncated comparison to avoid microsecond churn.
+    assert DateTime.compare(new_cursor, event_ts) in [:gt, :eq]
+  end
+
+  test "tick with cursor PAST the event ts excludes already-seen events", ctx do
+    surface_id = ctx.surface_prefix <> "/already_seen"
+    {_event_id, event_ts} = H.insert_forced_event(surface_id)
+
+    # Cursor is 1 second AFTER the event — SQL filter `ts > $1` excludes it.
+    future = DateTime.add(event_ts, 1, :second)
+
+    {alarms, _new_cursor} =
+      ForcedReleasePoller.tick(prior_cursor: future, db: UnitaresSentinel.DB)
+
+    refute Enum.any?(alarms, &(&1.extra.surface_id == surface_id)),
+           "events past the cursor must not re-fire"
+  end
+
+  test "tick persists the new cursor through CycleState.save", ctx do
+    surface_id = ctx.surface_prefix <> "/persistence"
+    {_event_id, event_ts} = H.insert_forced_event(surface_id)
+
+    prior = DateTime.add(event_ts, -1, :second)
+
+    {_alarms, new_cursor} =
+      ForcedReleasePoller.tick(
+        prior_cursor: prior,
+        db: UnitaresSentinel.DB,
+        persist: true,
+        state_path: ctx.state_file <> ".beam"
+      )
+
+    # Reading back via CycleState must show the same cursor.
+    persisted = CycleState.load(canonical: ctx.state_file, shadow: ctx.state_file <> ".beam")
+    persisted_ts = CycleState.get_last_event_ts(persisted)
+
+    assert is_binary(persisted_ts)
+    assert persisted_ts == DateTime.to_iso8601(new_cursor)
+  end
+
+  test "tick with persist: false does NOT write CycleState", ctx do
+    surface_id = ctx.surface_prefix <> "/no_persist"
+    {_event_id, event_ts} = H.insert_forced_event(surface_id)
+
+    prior = DateTime.add(event_ts, -1, :second)
+
+    _ = ForcedReleasePoller.tick(prior_cursor: prior, db: UnitaresSentinel.DB, persist: false)
+
+    refute File.exists?(ctx.state_file <> ".beam"),
+           "persist: false must not create the shadow file"
+  end
+end

--- a/elixir/sentinel/test/unitares_sentinel/forced_release_poller_logic_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/forced_release_poller_logic_test.exs
@@ -1,0 +1,138 @@
+defmodule UnitaresSentinel.ForcedReleasePoller.LogicTest do
+  @moduledoc """
+  Pure-logic tests for the ad_hoc forced-release alarm builder.
+
+  Mirrors the parity contract with `agents/sentinel/forced_release_alarm.py`
+  for `event_type='forced'` rows: one alarm per event, max(ts) is the new
+  cursor. Deprecation-batch and conflict-batch query classes are deferred
+  to follow-up PRs.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias UnitaresSentinel.ForcedReleasePoller.Logic
+
+  # Helper — Postgrex returns DateTime for timestamptz; we compose the same
+  # shape here so the pure logic can be exercised without a real DB.
+  defp dt(iso) do
+    {:ok, dt, _} = DateTime.from_iso8601(iso)
+    dt
+  end
+
+  defp ad_hoc_row(opts) do
+    %{
+      event_id: Keyword.fetch!(opts, :event_id),
+      ts: Keyword.fetch!(opts, :ts),
+      lease_id: Keyword.get(opts, :lease_id, "lease-uuid-stub"),
+      surface_id: Keyword.fetch!(opts, :surface_id),
+      surface_kind: Keyword.get(opts, :surface_kind, "dialectic")
+    }
+  end
+
+  test "no rows + nil cursor → empty alarms, cursor unchanged" do
+    assert {[], nil} = Logic.build_alarms([], nil)
+  end
+
+  test "no rows + existing cursor → empty alarms, cursor unchanged" do
+    cursor = dt("2026-05-04T12:00:00Z")
+    assert {[], ^cursor} = Logic.build_alarms([], cursor)
+  end
+
+  test "single ad_hoc row → one alarm with parity-shaped fields" do
+    ts = dt("2026-05-05T01:23:45.000000Z")
+
+    rows = [
+      ad_hoc_row(
+        event_id: "evt-001",
+        ts: ts,
+        lease_id: "lease-abc",
+        surface_id: "dialectic:/test_surface_1",
+        surface_kind: "dialectic"
+      )
+    ]
+
+    {alarms, new_cursor} = Logic.build_alarms(rows, nil)
+
+    assert [alarm] = alarms
+    assert alarm.kind == "ad_hoc"
+    assert alarm.severity == "high"
+    assert alarm.summary == "forced release: dialectic:/test_surface_1 (lease lease-abc)"
+    assert alarm.fingerprint == "forced_release:ad_hoc:evt-001"
+    assert alarm.extra.event_id == "evt-001"
+    assert alarm.extra.lease_id == "lease-abc"
+    assert alarm.extra.surface_id == "dialectic:/test_surface_1"
+    assert alarm.extra.surface_kind == "dialectic"
+    assert alarm.extra.ts == DateTime.to_iso8601(ts)
+
+    assert new_cursor == ts
+  end
+
+  test "multiple rows → cursor advances to max(ts) regardless of input order" do
+    earlier = dt("2026-05-04T00:00:00Z")
+    middle = dt("2026-05-04T12:00:00Z")
+    latest = dt("2026-05-04T23:59:59Z")
+
+    rows = [
+      ad_hoc_row(event_id: "e2", ts: middle, surface_id: "dialectic:/s/2"),
+      ad_hoc_row(event_id: "e3", ts: latest, surface_id: "dialectic:/s/3"),
+      ad_hoc_row(event_id: "e1", ts: earlier, surface_id: "dialectic:/s/1")
+    ]
+
+    {alarms, new_cursor} = Logic.build_alarms(rows, nil)
+
+    assert length(alarms) == 3
+    assert new_cursor == latest
+  end
+
+  test "prior cursor is preserved when all new rows are older (caller filters before passing)" do
+    # Defensive contract: if a buggy SQL filter ever lets older rows through,
+    # the new cursor must NOT regress below the prior cursor.
+    prior = dt("2026-05-04T12:00:00Z")
+    older = dt("2026-05-03T00:00:00Z")
+
+    rows = [ad_hoc_row(event_id: "stale", ts: older, surface_id: "dialectic:/old")]
+
+    {_alarms, new_cursor} = Logic.build_alarms(rows, prior)
+
+    assert new_cursor == prior, "cursor must never regress"
+  end
+
+  test "lease_id is nil-tolerant (fixture rows can have NULL lease_id)" do
+    # In the live schema lease_id is nullable on lease_plane_events. Don't
+    # explode the summary string when it's missing; mirror Python's `str()`
+    # fallback which yields "None" — we use "<unknown>" to signal absence
+    # without leaking Elixir nil rendering.
+    ts = dt("2026-05-05T01:23:45Z")
+
+    rows = [
+      ad_hoc_row(
+        event_id: "evt-no-lease",
+        ts: ts,
+        lease_id: nil,
+        surface_id: "dialectic:/test_no_lease"
+      )
+    ]
+
+    {[alarm], _} = Logic.build_alarms(rows, nil)
+
+    assert alarm.summary =~ "forced release: dialectic:/test_no_lease"
+    refute alarm.summary =~ "lease )" or alarm.summary =~ "lease nil)"
+    assert alarm.extra.lease_id == nil
+  end
+
+  test "fingerprint is unique per event_id (downstream dedup contract)" do
+    ts = dt("2026-05-05T01:23:45Z")
+
+    rows = [
+      ad_hoc_row(event_id: "evt-A", ts: ts, surface_id: "dialectic:/x"),
+      ad_hoc_row(event_id: "evt-B", ts: ts, surface_id: "dialectic:/x"),
+      ad_hoc_row(event_id: "evt-C", ts: ts, surface_id: "dialectic:/x")
+    ]
+
+    {alarms, _} = Logic.build_alarms(rows, nil)
+
+    fingerprints = Enum.map(alarms, & &1.fingerprint)
+    assert Enum.uniq(fingerprints) == fingerprints,
+           "every event_id must yield a distinct fingerprint"
+  end
+end

--- a/scripts/ops/com.unitares.sentinel.plist.template
+++ b/scripts/ops/com.unitares.sentinel.plist.template
@@ -55,6 +55,14 @@
         <string>__UNITARES_ROOT__</string>
         <key>PATH</key>
         <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <!-- HOME required for Path.home() resolution (SESSION_FILE at
+             agents/sentinel/agent.py:59). Lease-plane plist sets HOME;
+             sentinel was missing it, leaving Python on a passwd-database
+             fallback that BEAM's Path.expand("~") does NOT share. Surface 1
+             council fold (RFC v0.1.2 §B4) — preventive against any code
+             path that drifts toward tilde-expansion. -->
+        <key>HOME</key>
+        <string>__HOME__</string>
     </dict>
 </dict>
 </plist>

--- a/tests/test_sentinel_cross_runtime_state.py
+++ b/tests/test_sentinel_cross_runtime_state.py
@@ -1,0 +1,87 @@
+"""
+Tier 2 cross-runtime contract test — Wave 1 Surface 1 (RFC v0.1.2 §C4).
+
+The BEAM Sentinel writes `.sentinel_state.beam` via
+`UnitaresSentinel.CycleState.save/2` (elixir/sentinel/lib/unitares_sentinel/cycle_state.ex).
+On rollback or operator intervention, the Python Sentinel may need to
+read whatever BEAM last wrote. If Python's `load_state` ever fails to
+recover the cursor from a BEAM-written file, the de-dup fence regresses
+and the alarm replay storm condition (RFC v0.1.1 §Surface 1 rollback
+procedure step 4) fires.
+
+The fixture at `elixir/sentinel/test/fixtures/sentinel_state_beam_v1.json`
+is byte-equivalent to what `CycleState.save/2` produces today. Drift
+between this fixture and BEAM's writer is a CI failure on the BEAM side
+(see `cycle_state_test.exs` "Tier 2: BEAM CycleState.load round-trips
+a Python-written fixture" for the symmetric direction).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+BEAM_FIXTURE = (
+    project_root
+    / "elixir"
+    / "sentinel"
+    / "test"
+    / "fixtures"
+    / "sentinel_state_beam_v1.json"
+)
+
+
+def test_beam_fixture_exists_and_decodes():
+    """The BEAM-written fixture committed to the tree must parse as JSON."""
+    assert BEAM_FIXTURE.exists(), (
+        f"Tier 2 contract: missing BEAM fixture at {BEAM_FIXTURE}. "
+        "Regenerate via `mix run -e 'UnitaresSentinel.CycleState.save(%{...}, "
+        "path: \"test/fixtures/sentinel_state_beam_v1.json\")'`."
+    )
+    decoded = json.loads(BEAM_FIXTURE.read_text())
+    assert isinstance(decoded, dict), (
+        f"BEAM fixture must decode to a dict; got {type(decoded).__name__}"
+    )
+
+
+def test_python_load_state_recovers_cursor_from_beam_fixture(tmp_path, monkeypatch):
+    """
+    Python's load_state at agents/sentinel/agent.py:492 MUST recover
+    the cursor from a BEAM-written file. This is the symmetric Tier 2
+    contract from RFC v0.1.2 §C4. If this fails, BEAM-on-rollback breaks
+    Python's de-dup fence and triggers alarm replay.
+    """
+    # Stage the BEAM fixture as the canonical state file (rollback scenario:
+    # BEAM was the canonical writer mid-shadow, then operator unloads BEAM
+    # and reloads Python — Python must read whatever's there).
+    state_file = tmp_path / ".sentinel_state"
+    state_file.write_bytes(BEAM_FIXTURE.read_bytes())
+
+    from agents.sentinel import agent as sentinel_agent
+
+    monkeypatch.setattr(sentinel_agent, "STATE_FILE", state_file)
+
+    # load_state references the module-level STATE_FILE, not `self`, so we
+    # can invoke it directly off the class without instantiating the agent
+    # (which would pull in WS, SDK, identity, etc.).
+    state = sentinel_agent.SentinelAgent.load_state(None)
+
+    cursor = state.get("forced_release_alarm", {}).get("last_event_ts")
+    assert cursor is not None, (
+        f"Python load_state failed to recover cursor from BEAM fixture: state={state!r}"
+    )
+    assert isinstance(cursor, str), (
+        f"cursor must be a string (ISO-8601), got {type(cursor).__name__}"
+    )
+    # Loose ISO-8601 shape check; the BEAM writer's exact format is the
+    # contract, but we don't pin a specific timestamp here so the fixture
+    # can be regenerated without breaking this test.
+    assert "T" in cursor and ("+" in cursor or "Z" in cursor), (
+        f"cursor must be ISO-8601 with timezone offset, got: {cursor!r}"
+    )


### PR DESCRIPTION
**Stacked on #375** — depends on `CycleState` and merges only after #375 lands. Targets `feat/wave-1-surface-1-state-shadow` so the diff view shows just the cycle-worker layer.

## Summary

Surface 1 cycle worker — the periodic poller that drives `CycleState.update_last_event_ts/2` from `lease_plane.lease_plane_events`. Without this, `CycleState`'s shadow file never advances during shadow mode and there's nothing to compare to Python's cursor.

`UnitaresSentinel.ForcedReleasePoller` is split into:

- **`Logic`** — pure, fully unit-testable. `build_alarms(rows, prior_cursor)` → `{alarms, new_cursor}`. Cursor never regresses (defensive against a buggy SQL filter).
- **GenServer + `tick/1`** — `tick/1` is the testable unit of work; the GenServer is a thin scheduler. Tests exercise `tick/1` directly with explicit `:db` + `:prior_cursor` opts; the GenServer integration is light because the work-bearing surface is the function.

## Scope

✅ **In scope** — `event_type='forced'` ad_hoc class only (lowest volume, simplest)
❌ **Deferred to follow-up PRs:**
- Surface 2: findings emit (POST /api/findings)
- Surface 3: lease-advisory acquire on `resident:/sentinel_cycle`
- `lease.deprecation_swept` deprecation-batch class
- `conflict_held_by_other` conflict-batch class
- BEAM Sentinel launchd plist
- `mix sentinel.cutover` / `mix sentinel.rollback` operator scripts

The smaller-PR discipline is the lesson from PR #375's council fold: v0.1.2 caught three BLOCKs against a too-broad spec; smaller chunks let council see issues earlier.

## Postgrex wiring

- Mirrors `UnitaresLeasePlane.Application.parse_database_url/1` (URI-based, percent-decode credentials)
- `:start_postgrex` config gates child-spec inclusion; test config sets it false and `test_helper.exs` bootstraps Postgrex manually
- `:start_poller` defaults false in dev so sessions don't auto-poll
- Skip-if-unavailable: tests tagged `:db` are excluded by `test_helper.exs` when `governance_test` is unreachable. Pure-logic tests run regardless. Stderr warning printed.

## Test plan

- [x] `mix test` (elixir/sentinel): **44 tests / 0 failures** (32 from #375 + 7 pure logic + 5 integration)
- [x] Pure-logic coverage: empty/empty, multi-row max-ts, no-regress, nil lease_id, fingerprint uniqueness
- [x] Integration coverage (live PG): no-op on empty, new-event detection, past-cursor exclusion, CycleState round-trip, persist:false suppression
- [x] Smoke `mix sentinel.cursor_diff` against live `.sentinel_state` (no regression)
- [ ] Council review (architect + reviewer + live-verifier) — keeping draft until council passes
- [ ] Operator: enable `:start_poller` + run shadow window; observe via `mix sentinel.cursor_diff` that BEAM cursor tracks Python's

## Stack

| PR | Status | Description |
| --- | --- | --- |
| #373 | merged | Wave 1 bootstrap (skeleton + AtomicWrite) |
| #374 | merged | RFC v0.1.2 Surface 1 council fold |
| #375 | open | Surface 1 CycleState (council-folded) |
| **THIS** | draft | Surface 1 cycle worker (ad_hoc class) — base = #375 |
| Next | TBD | Surface 2 findings emit; deprecation/conflict batch classes |