### PR TITLE
feat(wave-1): cycle worker structural prep — Postgrex.transaction + all-or-nothing + tick guard

### DIFF
--- a/elixir/sentinel/lib/unitares_sentinel/forced_release_poller.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/forced_release_poller.ex
@@ -93,28 +93,38 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
     prior_cursor = Keyword.get(opts, :prior_cursor)
     persist? = Keyword.get(opts, :persist, false)
 
-    case query_rows_in_transaction(db, prior_cursor) do
+    case query_ad_hoc_rows_in_transaction(db, prior_cursor) do
       {:ok, rows} ->
         {alarms, new_cursor} = Logic.build_alarms(rows, prior_cursor)
 
         # Persist only on actual advance (not every nil-cursor tick), to avoid
         # needless file writes that would also bump the file's mtime and
         # confuse `mix sentinel.cursor_diff` operators tracking activity.
-        if persist? and new_cursor != nil and new_cursor != prior_cursor do
+        # Use DateTime.compare/2 (not `!=`) because two DateTime structs with
+        # the same instant but different `:microsecond` precision tuples
+        # would compare unequal by struct identity. Architect #3 in PR #378
+        # council fold.
+        if persist? and new_cursor != nil and not same_cursor?(new_cursor, prior_cursor) do
           persist_cursor(new_cursor, opts)
         end
 
         {alarms, new_cursor}
 
       {:error, reason} ->
-        # v0.1.3 §B6 all-or-nothing cursor advance: on transaction failure,
-        # the cursor MUST NOT advance and the persist MUST NOT happen.
-        # Returning `{[], prior_cursor}` preserves both invariants — the
-        # caller (GenServer) updates its in-memory cursor to the same prior
-        # value (no-op) and the next tick re-attempts from the same fence.
-        # Mirrors Python's behavior at agent.py:695-699 where an exception
-        # propagating out of poll_forced_release_alarms means save_state is
-        # never reached.
+        # v0.1.3 §B6 all-or-nothing cursor advance — covers the `{:error, _}`
+        # return class (real DB errors: connection drop mid-transaction,
+        # constraint violation, server-side rollback, query-level error).
+        # The cursor MUST NOT advance and the persist MUST NOT happen.
+        # Returning `{[], prior_cursor}` preserves both invariants.
+        #
+        # The other failure class is process exit (e.g. `:noproc` if the
+        # registered Postgrex name doesn't exist). That bypasses this match
+        # arm entirely — the GenServer dies, the supervisor restarts it,
+        # `init/1` re-reads the cursor from disk, and the on-disk cursor
+        # was never advanced (because no successful tick wrote it). Both
+        # paths preserve the §B6 invariant; only this path returns cleanly.
+        # Mirrors Python's caught-exception early return at agent.py:671-673
+        # where save_state is never reached on poll failure.
         Logger.warning(
           "ForcedReleasePoller.tick: transaction failed — #{inspect(reason)} — cursor unchanged"
         )
@@ -122,6 +132,13 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
         {[], prior_cursor}
     end
   end
+
+  defp same_cursor?(nil, nil), do: true
+  defp same_cursor?(nil, _), do: false
+  defp same_cursor?(_, nil), do: false
+
+  defp same_cursor?(%DateTime{} = a, %DateTime{} = b),
+    do: DateTime.compare(a, b) == :eq
 
   # v0.1.3 §B5 single-Postgrex-connection-per-tick binding. The transaction
   # wrapper checks out one connection from the pool and runs all queries
@@ -134,7 +151,14 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
   # connection is returned to the pool before the file write. Holding a
   # DB connection across file I/O is the BEAM-side analogue of the
   # anyio-asyncio coupling pattern documented in CLAUDE.md.
-  defp query_rows_in_transaction(db, prior_cursor) do
+  #
+  # NAMING — `_ad_hoc_` in the function name is deliberate: this function
+  # only runs the ad_hoc class query. The next PR REPLACES it with
+  # `query_all_rows_in_transaction/2` returning a tagged map (per-class
+  # row lists). Naming this scope-explicit signals to the next-PR diff
+  # reviewer that the rename is intentional, not a refactor accident.
+  # Architect lead finding in the PR #378 council fold.
+  defp query_ad_hoc_rows_in_transaction(db, prior_cursor) do
     Postgrex.transaction(db, fn conn ->
       case query_forced_rows(conn, prior_cursor) do
         {:ok, rows} -> rows
@@ -174,6 +198,15 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
     # the v0.1.2 §B3 `runtime: "beam_canonical"` cutover flag. Load the
     # existing state first, then update only the cursor, preserving every
     # other key.
+    #
+    # OPT-KEY ASYMMETRY (load=:shadow, save=:path) is intentional:
+    # `CycleState.load/1` reads BOTH the canonical (Python) file and the
+    # shadow (BEAM) file for max-on-boot semantics — `:shadow` overrides
+    # the BEAM-side path while canonical resolves from config.
+    # `CycleState.save/2` writes ONE file — `:path` is that target. The
+    # asymmetry follows the "load is two-file, save is one-file" semantic
+    # split in CycleState; harmonizing the keys would force one side or
+    # the other to lie about its file-count semantics.
     save_opts =
       case Keyword.get(opts, :state_path) do
         nil -> []

--- a/elixir/sentinel/lib/unitares_sentinel/forced_release_poller.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/forced_release_poller.ex
@@ -93,17 +93,57 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
     prior_cursor = Keyword.get(opts, :prior_cursor)
     persist? = Keyword.get(opts, :persist, false)
 
-    rows = query_forced_rows(db, prior_cursor)
-    {alarms, new_cursor} = Logic.build_alarms(rows, prior_cursor)
+    case query_rows_in_transaction(db, prior_cursor) do
+      {:ok, rows} ->
+        {alarms, new_cursor} = Logic.build_alarms(rows, prior_cursor)
 
-    if persist? and new_cursor != nil do
-      persist_cursor(new_cursor, opts)
+        # Persist only on actual advance (not every nil-cursor tick), to avoid
+        # needless file writes that would also bump the file's mtime and
+        # confuse `mix sentinel.cursor_diff` operators tracking activity.
+        if persist? and new_cursor != nil and new_cursor != prior_cursor do
+          persist_cursor(new_cursor, opts)
+        end
+
+        {alarms, new_cursor}
+
+      {:error, reason} ->
+        # v0.1.3 §B6 all-or-nothing cursor advance: on transaction failure,
+        # the cursor MUST NOT advance and the persist MUST NOT happen.
+        # Returning `{[], prior_cursor}` preserves both invariants — the
+        # caller (GenServer) updates its in-memory cursor to the same prior
+        # value (no-op) and the next tick re-attempts from the same fence.
+        # Mirrors Python's behavior at agent.py:695-699 where an exception
+        # propagating out of poll_forced_release_alarms means save_state is
+        # never reached.
+        Logger.warning(
+          "ForcedReleasePoller.tick: transaction failed — #{inspect(reason)} — cursor unchanged"
+        )
+
+        {[], prior_cursor}
     end
-
-    {alarms, new_cursor}
   end
 
-  defp query_forced_rows(db, prior_cursor) do
+  # v0.1.3 §B5 single-Postgrex-connection-per-tick binding. The transaction
+  # wrapper checks out one connection from the pool and runs all queries
+  # against it. With one query (this PR), the snapshot consistency is
+  # trivial; it matters when the next PR adds the deprecation_batch and
+  # conflict_batch queries — they MUST share one snapshot to avoid the
+  # multi-connection lost-event class (architect #2 in the v0.1.3 council).
+  #
+  # File I/O (CycleState.save) MUST happen OUTSIDE this function so the
+  # connection is returned to the pool before the file write. Holding a
+  # DB connection across file I/O is the BEAM-side analogue of the
+  # anyio-asyncio coupling pattern documented in CLAUDE.md.
+  defp query_rows_in_transaction(db, prior_cursor) do
+    Postgrex.transaction(db, fn conn ->
+      case query_forced_rows(conn, prior_cursor) do
+        {:ok, rows} -> rows
+        {:error, e} -> Postgrex.rollback(conn, e)
+      end
+    end)
+  end
+
+  defp query_forced_rows(conn, prior_cursor) do
     sql = """
     SELECT event_id::text AS event_id,
            ts,
@@ -116,16 +156,9 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
     ORDER BY ts
     """
 
-    case Postgrex.query(db, sql, [prior_cursor]) do
-      {:ok, %{rows: rows, columns: cols}} ->
-        Enum.map(rows, &row_to_map(cols, &1))
-
-      {:error, e} ->
-        Logger.warning(
-          "ForcedReleasePoller.query_forced_rows: #{inspect(e)} — returning empty rows"
-        )
-
-        []
+    case Postgrex.query(conn, sql, [prior_cursor]) do
+      {:ok, %{rows: rows, columns: cols}} -> {:ok, Enum.map(rows, &row_to_map(cols, &1))}
+      {:error, _} = err -> err
     end
   end
 
@@ -185,7 +218,14 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
       db: db,
       cursor: cursor,
       interval_ms: interval_ms,
-      jitter_ms: jitter_ms
+      jitter_ms: jitter_ms,
+      # v0.1.3 §C2 tick-skip guard. Under self-scheduling (next :tick is
+      # only enqueued AFTER the current tick returns), this flag will never
+      # actually be true at message-arrival time — BEAM serializes handle_*
+      # callbacks per process. The guard exists to defend against external
+      # `send(pid, :tick)` from tests or operator scripts that bypass the
+      # scheduler discipline. Option 1 of the v0.1.3 §C2 binding.
+      running?: false
     }
 
     Process.send_after(self(), :tick, initial_delay_ms + sample_jitter(jitter_ms))
@@ -193,7 +233,21 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
   end
 
   @impl true
+  def handle_info(:tick, %{running?: true} = state) do
+    # v0.1.3 §C2 guard fires: a :tick message arrived while the previous
+    # tick body was still executing. Under serialized handle_info this is
+    # only reachable when an external sender bypasses the scheduler.
+    Logger.warning(
+      "ForcedReleasePoller: skipping :tick — previous tick still in flight (mailbox guard)"
+    )
+
+    {:noreply, state}
+  end
+
+  @impl true
   def handle_info(:tick, state) do
+    state = %{state | running?: true}
+
     # Council fold: architect #2 (PR #376). Re-read the file cursor each tick
     # and use max(in-memory, file). Defends against an operator (or a future
     # cursor_repair task) writing the shadow file between ticks; without this,
@@ -208,7 +262,7 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
     # simultaneous boots (architect #5).
     Process.send_after(self(), :tick, state.interval_ms + sample_jitter(state.jitter_ms))
 
-    {:noreply, %{state | cursor: new_cursor}}
+    {:noreply, %{state | running?: false, cursor: new_cursor}}
   end
 
   # Symmetric ±jitter_ms uniform sample. Non-negative result clamp avoids

--- a/elixir/sentinel/test/unitares_sentinel/forced_release_poller_structure_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/forced_release_poller_structure_test.exs
@@ -46,21 +46,25 @@ defmodule UnitaresSentinel.ForcedReleasePollerStructureTest do
   # ---------------------------------------------------------------------------
 
   @moduletag :db
-  test "tick on dead DB module preserves prior cursor and does NOT persist", ctx do
-    # Pass a registered name that doesn't exist. Postgrex.transaction against
-    # a non-existent process raises an exit signal in the calling process,
-    # which our caller catches via `try/rescue` to convert into the
-    # all-or-nothing error path.
+  test "tick on dead DB exits — supervisor restart preserves cursor (the OTHER §B6 path)", ctx do
+    # v0.1.3 §B6 covers two failure classes:
+    #   (a) `{:error, _}` returned from transaction → tick returns
+    #       `{[], prior_cursor}`, no persist. (Pinned by the rollback
+    #       test below.)
+    #   (b) Process exit (e.g. :noproc on dead registered name) →
+    #       caller dies, supervisor restarts, init/1 re-reads on-disk
+    #       cursor. The cursor was never advanced because the dying
+    #       tick never reached `persist_cursor/2`.
+    #
+    # This test pins (b): the dead-DB call exits AND no shadow file is
+    # written. Verifier-confirmed in PR #378 council that `Postgrex.transaction`
+    # against a non-registered name raises `:noproc` rather than returning
+    # `{:error, _}`. Pre-council, this test had a dual-acceptance branch
+    # that was dead code; honest version below.
     fake_db = :"nonexistent_db_#{System.unique_integer([:positive])}"
-
     prior = ~U[2026-05-04 12:00:00.000000Z]
 
-    # Wrapping in try/rescue/catch since calling Postgrex.transaction on a
-    # non-registered name exits the calling process. The poller code is
-    # expected to surface this as an error path; if it doesn't, this test
-    # captures the exit so the suite stays green and we get a meaningful
-    # assertion below.
-    result =
+    exit_caught? =
       try do
         ForcedReleasePoller.tick(
           prior_cursor: prior,
@@ -68,27 +72,37 @@ defmodule UnitaresSentinel.ForcedReleasePollerStructureTest do
           persist: true,
           state_path: ctx.state_file <> ".beam"
         )
+
+        false
       catch
-        :exit, _reason -> :exited
+        :exit, _reason -> true
       end
 
-    case result do
-      {[], ^prior} ->
-        # The poller surfaced the error as the documented {[], prior_cursor}
-        # path. Confirm no shadow file was written.
-        refute File.exists?(ctx.state_file <> ".beam"),
-               "transaction failure must NOT persist cursor (v0.1.3 §B6)"
+    assert exit_caught?,
+           "dead DB module must exit (supervisor-restart path), not return — §B6 path (b)"
 
-      :exited ->
-        # The poller did not catch the exit. Document the gap explicitly:
-        # for §B6 to be load-bearing, the next PR (when it adds three
-        # queries that can fail in more ways) must surface failures as
-        # {:error, _} from the transaction body, not exits from a missing
-        # registered name. For now, this single-query case relies on
-        # Postgrex.transaction returning {:error, _} on real DB errors —
-        # which the integration test below pins.
-        :ok
-    end
+    refute File.exists?(ctx.state_file <> ".beam"),
+           "exit before persist_cursor MUST NOT have written shadow file — §B6 (b)"
+  end
+
+  test "tick on Postgrex.rollback returns {[], prior_cursor} (§B6 path (a))", _ctx do
+    # Pin §B6 path (a) by exercising Postgrex.transaction's rollback-returns-
+    # {:error, _} contract directly. Verifier-confirmed:
+    #   Postgrex.transaction(DB, fn conn -> Postgrex.rollback(conn, :x) end)
+    # returns `{:error, :x}`. tick/1 matches this and returns
+    # `{[], prior_cursor}` without persisting.
+    #
+    # We can't easily inject a rollback into tick/1's hardcoded SELECT, but
+    # we can pin the contract on the underlying Postgrex behavior the
+    # error-path branch relies on. If this test starts failing, tick/1's
+    # `{:error, reason} ->` branch is unreachable and §B6 (a) is broken.
+    result =
+      Postgrex.transaction(UnitaresSentinel.DB, fn conn ->
+        Postgrex.rollback(conn, :test_rollback_for_b6_pin)
+      end)
+
+    assert result == {:error, :test_rollback_for_b6_pin},
+           "Postgrex.rollback contract underpins §B6 path (a) — if this fails, tick/1's error branch is unreachable"
   end
 
   test "tick on real DB with prior cursor that returns empty rows preserves cursor", _ctx do
@@ -140,9 +154,19 @@ defmodule UnitaresSentinel.ForcedReleasePollerStructureTest do
   # ---------------------------------------------------------------------------
 
   test "GenServer skips :tick when running? is true (mailbox guard)" do
-    # Start the GenServer with a long initial_delay so it doesn't tick during
-    # the test, then manipulate state to set running?=true, then send :tick
-    # manually and verify it returns without error (the guard logs + skips).
+    # Verifier-confirmed (PR #378 council): deleting the
+    # `handle_info(:tick, %{running?: true})` head causes this test to fail
+    # because the real tick body would set running? back to false. The
+    # assertion `state.running? == true` after `send(pid, :tick)` is
+    # structurally load-bearing — it pins that the guard short-circuited
+    # without entering the body.
+    #
+    # The guard itself is unreachable under self-scheduling (next :tick is
+    # only enqueued AFTER the current tick returns) — this test exercises
+    # the EXTERNAL `send(pid, :tick)` path that justifies the guard's
+    # existence (operator iex sends, future cron-style schedulers, etc.).
+    # Without this test the guard would be flagged as dead code by future
+    # cleanup-PRs.
     {:ok, pid} =
       ForcedReleasePoller.start_link(
         name: :"test_guard_#{System.unique_integer([:positive])}",

--- a/elixir/sentinel/test/unitares_sentinel/forced_release_poller_structure_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/forced_release_poller_structure_test.exs
@@ -1,0 +1,179 @@
+defmodule UnitaresSentinel.ForcedReleasePollerStructureTest do
+  @moduledoc """
+  Structural binding tests for the cycle worker (RFC v0.1.3 §B5/§B6/§C2).
+
+  These pin behaviors that prepare the ground for the deprecation_batch +
+  conflict_batch refactor in the next PR:
+
+    * §B5 — tick uses a single Postgrex.transaction so all queries (one
+      now, three later) share one snapshot.
+    * §B6 — on transaction failure, the cursor MUST NOT advance and the
+      persist MUST NOT happen. Returning `{[], prior_cursor}` enforces
+      both invariants.
+    * §C2 — the GenServer's `running?` guard skips :tick messages that
+      arrive while a previous tick is in flight (defends against external
+      send(pid, :tick) bypassing the scheduler).
+  """
+
+  use ExUnit.Case, async: false
+
+  alias UnitaresSentinel.ForcedReleasePoller
+  alias SentinelTestHelpers, as: H
+
+  setup do
+    label = H.random_label()
+    surface_prefix = "dialectic:/test_sentinel_struct_#{label}"
+
+    tmpdir =
+      System.tmp_dir!()
+      |> Path.join("unitares_sentinel_struct_test_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmpdir)
+    state_file = Path.join(tmpdir, ".sentinel_state")
+    Application.put_env(:unitares_sentinel, :state_file_path, state_file)
+
+    on_exit(fn ->
+      H.cleanup_surface_prefix(surface_prefix)
+      Application.delete_env(:unitares_sentinel, :state_file_path)
+      File.rm_rf!(tmpdir)
+    end)
+
+    {:ok, surface_prefix: surface_prefix, state_file: state_file, tmpdir: tmpdir}
+  end
+
+  # ---------------------------------------------------------------------------
+  # §B6 — transaction failure preserves cursor + does NOT persist.
+  # ---------------------------------------------------------------------------
+
+  @moduletag :db
+  test "tick on dead DB module preserves prior cursor and does NOT persist", ctx do
+    # Pass a registered name that doesn't exist. Postgrex.transaction against
+    # a non-existent process raises an exit signal in the calling process,
+    # which our caller catches via `try/rescue` to convert into the
+    # all-or-nothing error path.
+    fake_db = :"nonexistent_db_#{System.unique_integer([:positive])}"
+
+    prior = ~U[2026-05-04 12:00:00.000000Z]
+
+    # Wrapping in try/rescue/catch since calling Postgrex.transaction on a
+    # non-registered name exits the calling process. The poller code is
+    # expected to surface this as an error path; if it doesn't, this test
+    # captures the exit so the suite stays green and we get a meaningful
+    # assertion below.
+    result =
+      try do
+        ForcedReleasePoller.tick(
+          prior_cursor: prior,
+          db: fake_db,
+          persist: true,
+          state_path: ctx.state_file <> ".beam"
+        )
+      catch
+        :exit, _reason -> :exited
+      end
+
+    case result do
+      {[], ^prior} ->
+        # The poller surfaced the error as the documented {[], prior_cursor}
+        # path. Confirm no shadow file was written.
+        refute File.exists?(ctx.state_file <> ".beam"),
+               "transaction failure must NOT persist cursor (v0.1.3 §B6)"
+
+      :exited ->
+        # The poller did not catch the exit. Document the gap explicitly:
+        # for §B6 to be load-bearing, the next PR (when it adds three
+        # queries that can fail in more ways) must surface failures as
+        # {:error, _} from the transaction body, not exits from a missing
+        # registered name. For now, this single-query case relies on
+        # Postgrex.transaction returning {:error, _} on real DB errors —
+        # which the integration test below pins.
+        :ok
+    end
+  end
+
+  test "tick on real DB with prior cursor that returns empty rows preserves cursor", _ctx do
+    # No fixture inserted; cursor is far in the future so any real rows are
+    # filtered out. `Logic.build_alarms([], prior)` returns `{[], prior}`,
+    # and the persist gate `new_cursor != prior_cursor` skips the file write.
+    far_future = DateTime.utc_now() |> DateTime.add(86_400 * 365, :second)
+
+    {alarms, new_cursor} =
+      ForcedReleasePoller.tick(
+        prior_cursor: far_future,
+        db: UnitaresSentinel.DB,
+        persist: true
+      )
+
+    assert alarms == []
+    assert new_cursor == far_future, "cursor MUST be preserved when no new rows"
+  end
+
+  # ---------------------------------------------------------------------------
+  # §B5 — transaction wrapping (proxy: works against real DB; multi-query
+  # snapshot consistency is the point but only testable with the next PR's
+  # extra query classes). Pin via "tick still works post-refactor" + a
+  # smoke that a transaction is in flight by checking pg_stat_activity.
+  # ---------------------------------------------------------------------------
+
+  test "tick works against real DB after Postgrex.transaction refactor", ctx do
+    surface_id = ctx.surface_prefix <> "/tx_smoke"
+    {event_id, event_ts} = H.insert_forced_event(surface_id)
+
+    prior = DateTime.add(event_ts, -1, :second)
+
+    {alarms, new_cursor} =
+      ForcedReleasePoller.tick(
+        prior_cursor: prior,
+        db: UnitaresSentinel.DB,
+        persist: true,
+        state_path: ctx.state_file <> ".beam"
+      )
+
+    our = Enum.find(alarms, &(&1.extra.surface_id == surface_id))
+    assert our != nil, "transaction-wrapped tick must still find the inserted event"
+    assert our.extra.event_id == event_id
+    assert DateTime.compare(new_cursor, event_ts) in [:gt, :eq]
+  end
+
+  # ---------------------------------------------------------------------------
+  # §C2 — running? guard skips :tick when previous still in flight.
+  # ---------------------------------------------------------------------------
+
+  test "GenServer skips :tick when running? is true (mailbox guard)" do
+    # Start the GenServer with a long initial_delay so it doesn't tick during
+    # the test, then manipulate state to set running?=true, then send :tick
+    # manually and verify it returns without error (the guard logs + skips).
+    {:ok, pid} =
+      ForcedReleasePoller.start_link(
+        name: :"test_guard_#{System.unique_integer([:positive])}",
+        db: UnitaresSentinel.DB,
+        # Long enough that no :tick will fire on its own during the test.
+        interval_ms: 60_000,
+        initial_delay_ms: 60_000,
+        jitter_ms: 0
+      )
+
+    # Force running? = true via :sys.replace_state. This is a test-only
+    # introspection seam — production code never sets running? from outside.
+    :sys.replace_state(pid, fn state -> %{state | running?: true} end)
+
+    # Send a synthetic :tick. The guard MUST handle it without crashing
+    # the GenServer.
+    send(pid, :tick)
+
+    # Give the GenServer a beat to process the message.
+    state = :sys.get_state(pid)
+
+    assert Process.alive?(pid), "guard must not crash the GenServer"
+    assert state.running? == true, "guard must NOT clear running? (only the real tick body does)"
+
+    # Now flip running? off and verify the next :tick CAN run.
+    :sys.replace_state(pid, fn state -> %{state | running?: false} end)
+    send(pid, :tick)
+    Process.sleep(50)
+
+    assert Process.alive?(pid), "tick after guard clear must not crash the GenServer"
+
+    GenServer.stop(pid)
+  end
+end


### PR DESCRIPTION
## Summary

Splits the v0.1.3 implementation across two PRs (per "proceed best" operator scope decision). This PR ships the structural §B5/§B6/§C2 bindings against the existing single-query (ad_hoc) path. The next PR adds the deprecation_batch + conflict_batch query classes against the now-existing transaction structure.

Tighter council loops: a transaction-wrapping bug or guard-semantics issue gets caught before three query classes' worth of code rides on it.

## v0.1.3 binding compliance (this PR's scope)

| Section | What this PR ships |
| --- | --- |
| §B5 single Postgrex connection per tick | `tick/1` wraps the SELECT in `Postgrex.transaction/2` via `query_rows_in_transaction/2`. File I/O stays outside the transaction (BEAM-side anyio analogue avoidance). |
| §B6 all-or-nothing cursor advance | On `{:error, _}` from the transaction, `tick/1` returns `{[], prior_cursor}` and does NOT persist. Mirrors Python at `agent.py:695-699`. |
| §C2 tick-skip-if-still-running guard | `:running?` field on GenServer state; `handle_info(:tick, %{running?: true})` head logs warning + skips. Defends against external `send(pid, :tick)`. |

## Out of scope (next PR — query classes)

| Section | Deferred to |
| --- | --- |
| §B2 per-class filter columns + asymmetry | next PR (deprecation_batch + conflict_batch) |
| §B3 row shape definitions | next PR |
| §C1 test minimums (21 pure + 15 integration) | next PR |
| §C3 phase-B promotion stays Python-side | next PR (moduledoc note) |

## Test plan

- [x] `mix test` (elixir/sentinel): **49 tests / 0 failures** (45 from prior + 4 new structural)
- [x] Tick on real DB preserves cursor when no new rows match
- [x] Tick post-refactor still finds inserted events
- [x] §C2 guard logs warning + skips when running?=true (pinned)
- [x] Smoke `mix sentinel.cursor_diff` against live `.sentinel_state`
- [ ] Council review (architect + reviewer + live-verifier in parallel) — keeping draft until council passes
- [ ] Operator: confirm structural binding satisfies v0.1.3 before next PR opens

## Stack

| PR | Status | Description |
| --- | --- | --- |
| #373/374/375/376 | merged | Wave 1 bootstrap → Surface 1 → cycle worker (ad_hoc) |
| #377 | merged | RFC v0.1.3 combined-poller topology binding |
| **THIS** | draft | Structural prep (§B5/§B6/§C2) for 3-query refactor |
| Next | TBD | Deprecation_batch + conflict_batch query classes against this structure |