### PR TITLE
feat(wave-1): cycle worker — deprecation_batch + conflict_batch (combined poller)

### DIFF
--- a/elixir/sentinel/lib/unitares_sentinel/forced_release_poller.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/forced_release_poller.ex
@@ -93,9 +93,10 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
     prior_cursor = Keyword.get(opts, :prior_cursor)
     persist? = Keyword.get(opts, :persist, false)
 
-    case query_ad_hoc_rows_in_transaction(db, prior_cursor) do
-      {:ok, rows} ->
-        {alarms, new_cursor} = Logic.build_alarms(rows, prior_cursor)
+    case query_all_rows_in_transaction(db, prior_cursor) do
+      {:ok, %{ad_hoc: ad_hoc, deprecation: dep, conflict: conf}} ->
+        {alarms, new_cursor} =
+          Logic.build_all_alarms(ad_hoc, dep, conf, prior_cursor)
 
         # Persist only on actual advance (not every nil-cursor tick), to avoid
         # needless file writes that would also bump the file's mtime and
@@ -152,16 +153,17 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
   # DB connection across file I/O is the BEAM-side analogue of the
   # anyio-asyncio coupling pattern documented in CLAUDE.md.
   #
-  # NAMING — `_ad_hoc_` in the function name is deliberate: this function
-  # only runs the ad_hoc class query. The next PR REPLACES it with
-  # `query_all_rows_in_transaction/2` returning a tagged map (per-class
-  # row lists). Naming this scope-explicit signals to the next-PR diff
-  # reviewer that the rename is intentional, not a refactor accident.
-  # Architect lead finding in the PR #378 council fold.
-  defp query_ad_hoc_rows_in_transaction(db, prior_cursor) do
+  # v0.1.3 §B5 single-Postgrex-connection-per-tick: all three queries
+  # share one snapshot. If ANY query returns {:error, _}, Postgrex.rollback
+  # is called → outer transaction returns {:error, _} → §B6 all-or-nothing
+  # cursor advance kicks in (no partial advance possible).
+  defp query_all_rows_in_transaction(db, prior_cursor) do
     Postgrex.transaction(db, fn conn ->
-      case query_forced_rows(conn, prior_cursor) do
-        {:ok, rows} -> rows
+      with {:ok, ad_hoc} <- query_forced_rows(conn, prior_cursor),
+           {:ok, dep} <- query_deprecation_batch_rows(conn, prior_cursor),
+           {:ok, conf} <- query_conflict_batch_rows(conn, prior_cursor) do
+        %{ad_hoc: ad_hoc, deprecation: dep, conflict: conf}
+      else
         {:error, e} -> Postgrex.rollback(conn, e)
       end
     end)
@@ -185,6 +187,69 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
       {:error, _} = err -> err
     end
   end
+
+  # v0.1.3 §B2 asymmetry: filter on `ds.sweep_completed_at`, NOT `e.ts`.
+  # Cursor still advances on max(e.last_ts) via Logic.build_deprecation_batch_alarms.
+  # Mirrors agents/sentinel/forced_release_alarm.py:113-134.
+  defp query_deprecation_batch_rows(conn, prior_cursor) do
+    sql = """
+    SELECT
+      ds.deprecation_id::text AS deprecation_id,
+      ds.surface_kind,
+      ds.sweep_completed_at,
+      count(e.event_id) AS event_count,
+      min(e.ts) AS first_ts,
+      max(e.ts) AS last_ts
+    FROM lease_plane.lease_plane_events e
+    JOIN lease_plane.deprecated_schemes ds
+      ON ds.deprecation_id::text = e.payload->>'deprecation_id'
+    WHERE e.event_type = 'lease.deprecation_swept'
+      AND ds.sweep_completed_at IS NOT NULL
+      AND ($1::timestamptz IS NULL OR ds.sweep_completed_at > $1)
+    GROUP BY ds.deprecation_id, ds.surface_kind, ds.sweep_completed_at
+    """
+
+    case Postgrex.query(conn, sql, [prior_cursor]) do
+      {:ok, %{rows: rows, columns: cols}} ->
+        {:ok, Enum.map(rows, &row_to_map(cols, &1)) |> Enum.map(&coerce_event_count/1)}
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  # GROUP BY surface_id within this poll cycle. Mirrors
+  # agents/sentinel/forced_release_alarm.py:148-167.
+  defp query_conflict_batch_rows(conn, prior_cursor) do
+    sql = """
+    SELECT
+      surface_id,
+      surface_kind,
+      count(event_id) AS event_count,
+      min(ts) AS first_ts,
+      max(ts) AS last_ts
+    FROM lease_plane.lease_plane_events
+    WHERE event_type = 'conflict_held_by_other'
+      AND ($1::timestamptz IS NULL OR ts > $1)
+    GROUP BY surface_id, surface_kind
+    """
+
+    case Postgrex.query(conn, sql, [prior_cursor]) do
+      {:ok, %{rows: rows, columns: cols}} ->
+        {:ok, Enum.map(rows, &row_to_map(cols, &1)) |> Enum.map(&coerce_event_count/1)}
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  # Postgrex returns count() as Decimal — coerce to integer for shape parity
+  # with Python's asyncpg int return.
+  defp coerce_event_count(%{event_count: %Decimal{} = d} = row) do
+    %{row | event_count: Decimal.to_integer(d)}
+  end
+
+  defp coerce_event_count(row), do: row
 
   defp row_to_map(columns, row) do
     columns

--- a/elixir/sentinel/lib/unitares_sentinel/forced_release_poller/logic.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/forced_release_poller/logic.ex
@@ -3,22 +3,24 @@ defmodule UnitaresSentinel.ForcedReleasePoller.Logic do
   Pure logic for transforming `lease_plane.lease_plane_events` rows into
   Sentinel alarms + advancing the cursor.
 
-  Surface 1 cycle worker scope (this PR): `event_type='forced'` only —
-  the per-event ad_hoc class. Mirrors `_ad_hoc_alarm` in
-  `agents/sentinel/forced_release_alarm.py` for parity.
+  Three event classes (v0.1.3 §B1 combined poller binding):
+    * ad_hoc — `event_type='forced'`, one alarm per event
+    * deprecation_batch — `event_type='lease.deprecation_swept'`, one
+      alarm per completed batch (joined with `deprecated_schemes`)
+    * conflict_batch — `event_type='conflict_held_by_other'`, one alarm
+      per surface per cycle
 
-  Deferred (follow-up PRs):
-    * `event_type='lease.deprecation_swept'` deprecation-batch class
-    * `event_type='conflict_held_by_other'` conflict-batch class
+  Cursor advances on `max(event.ts)` across ALL classes. Filter columns
+  differ per class — see `ForcedReleasePoller.query_*` for the SQL side.
+  v0.1.3 §B2 asymmetry: deprecation_batch FILTERS on `sweep_completed_at`,
+  but cursor ADVANCES on `last_ts` (event-stream parity).
 
-  Caller contract (the GenServer): rows arrive as `[%{event_id: binary,
-  ts: DateTime.t, lease_id: binary | nil, surface_id: binary,
-  surface_kind: binary}]` — atom keys, UUIDs already cast to text by the
-  SQL layer. The `prior_cursor` is `DateTime.t | nil`; `nil` means first
-  poll, advance to max(rows.ts) or stay nil if rows are empty.
+  Mirrors `_ad_hoc_alarm`, `_batch_alarm`, `_conflict_alarm` in
+  `agents/sentinel/forced_release_alarm.py` for cross-runtime parity.
+  Cursor never regresses (defensive against a buggy SQL filter).
   """
 
-  @type row :: %{
+  @type ad_hoc_row :: %{
           required(:event_id) => binary(),
           required(:ts) => DateTime.t(),
           required(:lease_id) => binary() | nil,
@@ -26,36 +28,50 @@ defmodule UnitaresSentinel.ForcedReleasePoller.Logic do
           required(:surface_kind) => binary()
         }
 
+  @type deprecation_batch_row :: %{
+          required(:deprecation_id) => binary(),
+          required(:surface_kind) => binary(),
+          required(:sweep_completed_at) => DateTime.t(),
+          required(:event_count) => non_neg_integer(),
+          required(:first_ts) => DateTime.t(),
+          required(:last_ts) => DateTime.t()
+        }
+
+  @type conflict_batch_row :: %{
+          required(:surface_id) => binary(),
+          required(:surface_kind) => binary(),
+          required(:event_count) => non_neg_integer(),
+          required(:first_ts) => DateTime.t(),
+          required(:last_ts) => DateTime.t()
+        }
+
+  # Backwards-compat alias — earlier tests reference `Logic.row` as a type.
+  @type row :: ad_hoc_row()
+
   @type alarm :: %{
           kind: String.t(),
           severity: String.t(),
           summary: String.t(),
           fingerprint: String.t(),
-          extra: %{
-            event_id: binary(),
-            ts: String.t(),
-            lease_id: binary() | nil,
-            surface_id: binary(),
-            surface_kind: binary()
-          }
+          extra: map()
         }
 
+  # ---- ad_hoc ----------------------------------------------------------
+
   @doc """
-  Build alarms from `rows` and advance the cursor.
+  Build ad_hoc alarms from `rows` and advance the cursor.
 
   Cursor never regresses: if every row's ts is older than `prior_cursor`,
-  the prior is preserved. This is defensive — the SQL filter should
-  already exclude older rows, but a buggy filter must not corrupt the
-  de-dup fence.
+  the prior is preserved.
   """
-  @spec build_alarms([row()], DateTime.t() | nil) :: {[alarm()], DateTime.t() | nil}
+  @spec build_alarms([ad_hoc_row()], DateTime.t() | nil) :: {[alarm()], DateTime.t() | nil}
   def build_alarms(rows, prior_cursor) when is_list(rows) do
-    alarms = Enum.map(rows, &row_to_alarm/1)
-    new_cursor = advance_cursor(rows, prior_cursor)
+    alarms = Enum.map(rows, &row_to_ad_hoc_alarm/1)
+    new_cursor = advance_cursor_from(rows, :ts, prior_cursor)
     {alarms, new_cursor}
   end
 
-  defp row_to_alarm(%{event_id: event_id, surface_id: surface_id} = row) do
+  defp row_to_ad_hoc_alarm(%{event_id: event_id, surface_id: surface_id} = row) do
     lease_label = lease_label(row.lease_id)
 
     %{
@@ -76,10 +92,115 @@ defmodule UnitaresSentinel.ForcedReleasePoller.Logic do
   defp lease_label(nil), do: "<unknown>"
   defp lease_label(lease_id) when is_binary(lease_id), do: lease_id
 
-  defp advance_cursor([], prior), do: prior
+  # ---- deprecation_batch -----------------------------------------------
 
-  defp advance_cursor(rows, prior) do
-    max_ts = rows |> Enum.map(& &1.ts) |> Enum.max(DateTime)
+  @doc """
+  Build deprecation_batch alarms — one per completed sweep batch.
+
+  v0.1.3 §B2 asymmetry: rows are FILTERED by `sweep_completed_at > $1`
+  (SQL side), but the cursor ADVANCES on `max(last_ts)` (event-stream
+  parity). Never mix event-stream and table-metadata timestamps in the
+  cursor (Python PR 5 council fix at agents/sentinel/forced_release_alarm.py:137-142).
+  """
+  @spec build_deprecation_batch_alarms([deprecation_batch_row()], DateTime.t() | nil) ::
+          {[alarm()], DateTime.t() | nil}
+  def build_deprecation_batch_alarms(rows, prior_cursor) when is_list(rows) do
+    alarms = Enum.map(rows, &row_to_deprecation_alarm/1)
+    new_cursor = advance_cursor_from(rows, :last_ts, prior_cursor)
+    {alarms, new_cursor}
+  end
+
+  defp row_to_deprecation_alarm(%{deprecation_id: depr_id, surface_kind: kind, event_count: count} = row) do
+    %{
+      kind: "deprecation_batch",
+      severity: "medium",
+      summary: "deprecation sweep complete: kind=#{kind} count=#{count}",
+      fingerprint: "forced_release:deprecation_batch:#{depr_id}",
+      extra: %{
+        deprecation_id: depr_id,
+        kind: kind,
+        count: count,
+        first_ts: DateTime.to_iso8601(row.first_ts),
+        last_ts: DateTime.to_iso8601(row.last_ts),
+        sweep_completed_at: DateTime.to_iso8601(row.sweep_completed_at)
+      }
+    }
+  end
+
+  # ---- conflict_batch --------------------------------------------------
+
+  @doc """
+  Build conflict_batch alarms — one per surface per cycle. Fingerprint
+  includes `last_ts` so a later cycle producing more conflicts on the
+  same surface yields a distinct alarm (Python parity:
+  `agents/sentinel/forced_release_alarm.py:204`).
+  """
+  @spec build_conflict_batch_alarms([conflict_batch_row()], DateTime.t() | nil) ::
+          {[alarm()], DateTime.t() | nil}
+  def build_conflict_batch_alarms(rows, prior_cursor) when is_list(rows) do
+    alarms = Enum.map(rows, &row_to_conflict_alarm/1)
+    new_cursor = advance_cursor_from(rows, :last_ts, prior_cursor)
+    {alarms, new_cursor}
+  end
+
+  defp row_to_conflict_alarm(%{surface_id: surface_id, event_count: count, last_ts: last_ts} = row) do
+    %{
+      kind: "conflict_batch",
+      severity: "medium",
+      summary: "held-by-other conflicts: #{surface_id} (count=#{count})",
+      fingerprint: "forced_release:conflict_batch:#{surface_id}:#{DateTime.to_iso8601(last_ts)}",
+      extra: %{
+        surface_id: surface_id,
+        surface_kind: row.surface_kind,
+        count: count,
+        first_ts: DateTime.to_iso8601(row.first_ts),
+        last_ts: DateTime.to_iso8601(last_ts)
+      }
+    }
+  end
+
+  # ---- combined --------------------------------------------------------
+
+  @doc """
+  Build alarms from all three classes, advance cursor to max across all.
+
+  Composes the three per-class builders. The combined cursor is
+  `max(ad_hoc_cursor, deprecation_cursor, conflict_cursor, prior_cursor)`
+  — defensive against a buggy SQL filter that lets older rows through
+  in any one class.
+  """
+  @spec build_all_alarms(
+          [ad_hoc_row()],
+          [deprecation_batch_row()],
+          [conflict_batch_row()],
+          DateTime.t() | nil
+        ) :: {[alarm()], DateTime.t() | nil}
+  def build_all_alarms(ad_hoc_rows, deprecation_rows, conflict_rows, prior_cursor) do
+    {ad_hoc_alarms, c1} = build_alarms(ad_hoc_rows, prior_cursor)
+    {deprecation_alarms, c2} = build_deprecation_batch_alarms(deprecation_rows, prior_cursor)
+    {conflict_alarms, c3} = build_conflict_batch_alarms(conflict_rows, prior_cursor)
+
+    combined = ad_hoc_alarms ++ deprecation_alarms ++ conflict_alarms
+    new_cursor = max_of([c1, c2, c3, prior_cursor])
+
+    {combined, new_cursor}
+  end
+
+  defp max_of(cursors) do
+    cursors
+    |> Enum.reject(&is_nil/1)
+    |> case do
+      [] -> nil
+      list -> Enum.max(list, DateTime)
+    end
+  end
+
+  # ---- internals -------------------------------------------------------
+
+  defp advance_cursor_from([], _key, prior), do: prior
+
+  defp advance_cursor_from(rows, key, prior) do
+    max_ts = rows |> Enum.map(&Map.fetch!(&1, key)) |> Enum.max(DateTime)
 
     cond do
       is_nil(prior) -> max_ts

--- a/elixir/sentinel/test/support/sentinel_test_helpers.ex
+++ b/elixir/sentinel/test/support/sentinel_test_helpers.ex
@@ -50,6 +50,49 @@ defmodule SentinelTestHelpers do
     {event_id, returned_ts}
   end
 
+  @doc """
+  Insert one `event_type='conflict_held_by_other'` row.
+  """
+  def insert_conflict_event(surface_id, ts \\ nil) do
+    sql = """
+    INSERT INTO lease_plane.lease_plane_events
+      (ts, event_type, lease_id, surface_id, surface_kind, advisory_mode, payload)
+    VALUES (COALESCE($1::timestamptz, now()), 'conflict_held_by_other', gen_random_uuid(), $2, $3, true, '{}'::jsonb)
+    RETURNING event_id::text, ts
+    """
+
+    {:ok, %{rows: [[event_id, returned_ts]]}} =
+      Postgrex.query(DB, sql, [ts, surface_id, surface_kind_of(surface_id)])
+
+    {event_id, returned_ts}
+  end
+
+  @doc """
+  Insert one `event_type='lease.deprecation_swept'` row with payload
+  carrying `deprecation_id` (text). Caller is responsible for ensuring
+  the corresponding `deprecated_schemes` row exists with a
+  non-NULL `sweep_completed_at`.
+  """
+  def insert_deprecation_swept_event(surface_id, deprecation_id, ts \\ nil) do
+    sql = """
+    INSERT INTO lease_plane.lease_plane_events
+      (ts, event_type, lease_id, surface_id, surface_kind, advisory_mode, payload)
+    VALUES (
+      COALESCE($1::timestamptz, now()),
+      'lease.deprecation_swept',
+      gen_random_uuid(),
+      $2, $3, true,
+      jsonb_build_object('deprecation_id', $4::text)
+    )
+    RETURNING event_id::text, ts
+    """
+
+    {:ok, %{rows: [[event_id, returned_ts]]}} =
+      Postgrex.query(DB, sql, [ts, surface_id, surface_kind_of(surface_id), deprecation_id])
+
+    {event_id, returned_ts}
+  end
+
   @doc "DELETE all lease_plane_events rows for surface_ids beginning with the prefix."
   def cleanup_surface_prefix(prefix) when is_binary(prefix) do
     Postgrex.query!(

--- a/elixir/sentinel/test/unitares_sentinel/forced_release_poller_3class_integration_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/forced_release_poller_3class_integration_test.exs
@@ -1,0 +1,131 @@
+defmodule UnitaresSentinel.ForcedReleasePoller3ClassIntegrationTest do
+  @moduledoc """
+  Integration tests for the v0.1.3 combined-poller refactor — three event
+  classes against live `governance_test`. Per v0.1.3 §C1 minimum coverage:
+  per-class detection + cross-class tick + §B6 partial-failure pin.
+
+  Skipped automatically when DB unreachable (test_helper.exs).
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :db
+
+  alias UnitaresSentinel.{ForcedReleasePoller}
+  alias SentinelTestHelpers, as: H
+
+  setup do
+    label = H.random_label()
+    surface_prefix = "dialectic:/test_sentinel_3c_#{label}"
+
+    tmpdir =
+      System.tmp_dir!()
+      |> Path.join("unitares_sentinel_3c_test_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmpdir)
+    state_file = Path.join(tmpdir, ".sentinel_state")
+    Application.put_env(:unitares_sentinel, :state_file_path, state_file)
+
+    on_exit(fn ->
+      H.cleanup_surface_prefix(surface_prefix)
+      Application.delete_env(:unitares_sentinel, :state_file_path)
+      File.rm_rf!(tmpdir)
+    end)
+
+    {:ok, surface_prefix: surface_prefix, state_file: state_file, tmpdir: tmpdir}
+  end
+
+  test "tick picks up a conflict_held_by_other event past prior cursor", ctx do
+    surface_id = ctx.surface_prefix <> "/conflict"
+    {_event_id, event_ts} = H.insert_conflict_event(surface_id)
+
+    prior = DateTime.add(event_ts, -1, :second)
+
+    {alarms, new_cursor} = ForcedReleasePoller.tick(prior_cursor: prior, db: UnitaresSentinel.DB)
+
+    our = Enum.find(alarms, &(&1.kind == "conflict_batch" and &1.extra.surface_id == surface_id))
+    assert our != nil, "conflict_batch alarm must be emitted for inserted event"
+    assert our.extra.count == 1
+    assert DateTime.compare(new_cursor, event_ts) in [:gt, :eq]
+  end
+
+  test "tick GROUPs multiple conflicts on same surface into one alarm", ctx do
+    surface_id = ctx.surface_prefix <> "/group"
+
+    {_, _} = H.insert_conflict_event(surface_id)
+    {_, _} = H.insert_conflict_event(surface_id)
+    {_, last_ts} = H.insert_conflict_event(surface_id)
+
+    prior = DateTime.add(last_ts, -10, :second)
+
+    {alarms, _new_cursor} =
+      ForcedReleasePoller.tick(prior_cursor: prior, db: UnitaresSentinel.DB)
+
+    ours = Enum.filter(alarms, &(&1.kind == "conflict_batch" and &1.extra.surface_id == surface_id))
+    assert length(ours) == 1, "GROUP BY surface_id must collapse 3 events into 1 alarm"
+    assert hd(ours).extra.count == 3
+  end
+
+  test "tick combines all three classes when each has events past cursor", ctx do
+    # ad_hoc
+    ad_hoc_surface = ctx.surface_prefix <> "/ad_hoc"
+    {_, ah_ts} = H.insert_forced_event(ad_hoc_surface)
+
+    # conflict
+    conf_surface = ctx.surface_prefix <> "/conf"
+    {_, conf_ts} = H.insert_conflict_event(conf_surface)
+
+    # Use the earlier of the two as the prior cursor so both are picked up.
+    earliest = if DateTime.compare(ah_ts, conf_ts) == :lt, do: ah_ts, else: conf_ts
+    prior = DateTime.add(earliest, -1, :second)
+
+    {alarms, _new_cursor} =
+      ForcedReleasePoller.tick(prior_cursor: prior, db: UnitaresSentinel.DB)
+
+    kinds_ours =
+      alarms
+      |> Enum.filter(fn a ->
+        case a.kind do
+          "ad_hoc" -> a.extra.surface_id == ad_hoc_surface
+          "conflict_batch" -> a.extra.surface_id == conf_surface
+          _ -> false
+        end
+      end)
+      |> Enum.map(& &1.kind)
+      |> Enum.sort()
+
+    assert "ad_hoc" in kinds_ours, "combined tick MUST include ad_hoc"
+    assert "conflict_batch" in kinds_ours, "combined tick MUST include conflict_batch"
+  end
+
+  test "§B6 partial-failure: tick rolls back transaction if any one query errors", _ctx do
+    # We can't easily inject a per-query SQL error into tick/1 without a test
+    # seam. Pin the underlying contract instead: Postgrex.transaction with
+    # an inner `with` chain that rolls back on the second clause must return
+    # {:error, _} and never reach the success branch. Mirrors the structure
+    # of `query_all_rows_in_transaction/2`.
+    result =
+      Postgrex.transaction(UnitaresSentinel.DB, fn conn ->
+        with {:ok, _} <- Postgrex.query(conn, "SELECT 1", []),
+             {:ok, _} <- {:error, :simulated_class2_failure},
+             {:ok, _} <- Postgrex.query(conn, "SELECT 2", []) do
+          %{ad_hoc: [], deprecation: [], conflict: []}
+        else
+          {:error, e} -> Postgrex.rollback(conn, e)
+        end
+      end)
+
+    assert result == {:error, :simulated_class2_failure},
+           "all-or-nothing: a single rolled-back step short-circuits the entire transaction"
+  end
+
+  test "tick on no-events tick returns no alarms and preserves cursor", _ctx do
+    far_future = DateTime.utc_now() |> DateTime.add(86_400 * 365, :second)
+
+    {alarms, new_cursor} =
+      ForcedReleasePoller.tick(prior_cursor: far_future, db: UnitaresSentinel.DB)
+
+    assert alarms == []
+    assert new_cursor == far_future
+  end
+end

--- a/elixir/sentinel/test/unitares_sentinel/forced_release_poller_logic_3class_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/forced_release_poller_logic_3class_test.exs
@@ -1,0 +1,287 @@
+defmodule UnitaresSentinel.ForcedReleasePoller.Logic3ClassTest do
+  @moduledoc """
+  Pure-logic tests for the deprecation_batch + conflict_batch + combined
+  builders (v0.1.3 §B1 combined poller binding).
+
+  Per v0.1.3 §C1 floor (21+ pure across three classes); ad_hoc class is
+  already covered by `forced_release_poller_logic_test.exs` (7 tests).
+  This file adds 7+ for deprecation_batch, 7+ for conflict_batch, and
+  cross-class coverage via build_all_alarms/4.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias UnitaresSentinel.ForcedReleasePoller.Logic
+
+  defp dt(iso) do
+    {:ok, dt, _} = DateTime.from_iso8601(iso)
+    dt
+  end
+
+  defp dep_row(opts) do
+    %{
+      deprecation_id: Keyword.fetch!(opts, :deprecation_id),
+      surface_kind: Keyword.get(opts, :surface_kind, "dialectic"),
+      sweep_completed_at: Keyword.fetch!(opts, :sweep_completed_at),
+      event_count: Keyword.get(opts, :event_count, 5),
+      first_ts: Keyword.fetch!(opts, :first_ts),
+      last_ts: Keyword.fetch!(opts, :last_ts)
+    }
+  end
+
+  defp conf_row(opts) do
+    %{
+      surface_id: Keyword.fetch!(opts, :surface_id),
+      surface_kind: Keyword.get(opts, :surface_kind, "dialectic"),
+      event_count: Keyword.get(opts, :event_count, 3),
+      first_ts: Keyword.fetch!(opts, :first_ts),
+      last_ts: Keyword.fetch!(opts, :last_ts)
+    }
+  end
+
+  defp ad_hoc_row(opts) do
+    %{
+      event_id: Keyword.fetch!(opts, :event_id),
+      ts: Keyword.fetch!(opts, :ts),
+      lease_id: Keyword.get(opts, :lease_id, "lease-stub"),
+      surface_id: Keyword.fetch!(opts, :surface_id),
+      surface_kind: Keyword.get(opts, :surface_kind, "dialectic")
+    }
+  end
+
+  # =========================================================================
+  # deprecation_batch (7 tests)
+  # =========================================================================
+
+  test "deprecation_batch: empty rows + nil cursor → empty alarms, cursor unchanged" do
+    assert {[], nil} = Logic.build_deprecation_batch_alarms([], nil)
+  end
+
+  test "deprecation_batch: single row produces one alarm with parity-shaped fields" do
+    row =
+      dep_row(
+        deprecation_id: "depr-uuid-1",
+        surface_kind: "dialectic",
+        sweep_completed_at: dt("2026-05-05T10:00:00Z"),
+        event_count: 12,
+        first_ts: dt("2026-05-05T09:00:00Z"),
+        last_ts: dt("2026-05-05T09:30:00Z")
+      )
+
+    {[alarm], cursor} = Logic.build_deprecation_batch_alarms([row], nil)
+
+    assert alarm.kind == "deprecation_batch"
+    assert alarm.severity == "medium"
+    assert alarm.summary == "deprecation sweep complete: kind=dialectic count=12"
+    assert alarm.fingerprint == "forced_release:deprecation_batch:depr-uuid-1"
+    assert alarm.extra.deprecation_id == "depr-uuid-1"
+    assert alarm.extra.kind == "dialectic"
+    assert alarm.extra.count == 12
+    assert alarm.extra.last_ts == DateTime.to_iso8601(row.last_ts)
+    assert alarm.extra.sweep_completed_at == DateTime.to_iso8601(row.sweep_completed_at)
+    # v0.1.3 §B2 asymmetry: cursor advances on last_ts, NOT sweep_completed_at
+    assert cursor == row.last_ts
+  end
+
+  test "deprecation_batch: §B2 asymmetry — cursor advances on last_ts even when sweep_completed_at is later" do
+    # sweep_completed_at > last_ts is the typical case (sweep finishes after
+    # last event), but the cursor MUST advance on last_ts not sweep_completed_at.
+    row =
+      dep_row(
+        deprecation_id: "depr-2",
+        sweep_completed_at: dt("2026-05-05T15:00:00Z"),
+        first_ts: dt("2026-05-05T08:00:00Z"),
+        last_ts: dt("2026-05-05T09:00:00Z")
+      )
+
+    {[_alarm], cursor} = Logic.build_deprecation_batch_alarms([row], nil)
+    assert cursor == row.last_ts, "cursor MUST advance on last_ts, not sweep_completed_at"
+    refute cursor == row.sweep_completed_at,
+           "Python PR 5 council fix: never mix event-stream and table-metadata timestamps"
+  end
+
+  test "deprecation_batch: multi-row cursor advances to max(last_ts)" do
+    older = dt("2026-05-04T00:00:00Z")
+    newer = dt("2026-05-05T00:00:00Z")
+
+    rows = [
+      dep_row(deprecation_id: "d1", sweep_completed_at: dt("2026-05-04T01:00:00Z"), first_ts: older, last_ts: older),
+      dep_row(deprecation_id: "d2", sweep_completed_at: dt("2026-05-05T01:00:00Z"), first_ts: older, last_ts: newer)
+    ]
+
+    {alarms, cursor} = Logic.build_deprecation_batch_alarms(rows, nil)
+    assert length(alarms) == 2
+    assert cursor == newer
+  end
+
+  test "deprecation_batch: cursor never regresses below prior" do
+    prior = dt("2026-05-10T00:00:00Z")
+    row = dep_row(deprecation_id: "old", sweep_completed_at: dt("2026-05-09T00:00:00Z"), first_ts: dt("2026-05-08T00:00:00Z"), last_ts: dt("2026-05-08T00:00:00Z"))
+
+    {_alarms, cursor} = Logic.build_deprecation_batch_alarms([row], prior)
+    assert cursor == prior, "cursor must NOT regress"
+  end
+
+  test "deprecation_batch: fingerprint is unique per deprecation_id" do
+    rows = [
+      dep_row(deprecation_id: "A", sweep_completed_at: dt("2026-05-05T01:00:00Z"), first_ts: dt("2026-05-05T00:00:00Z"), last_ts: dt("2026-05-05T00:00:00Z")),
+      dep_row(deprecation_id: "B", sweep_completed_at: dt("2026-05-05T01:00:00Z"), first_ts: dt("2026-05-05T00:00:00Z"), last_ts: dt("2026-05-05T00:00:00Z"))
+    ]
+
+    {alarms, _} = Logic.build_deprecation_batch_alarms(rows, nil)
+    fps = Enum.map(alarms, & &1.fingerprint)
+    assert Enum.uniq(fps) == fps
+  end
+
+  test "deprecation_batch: nil cursor + rows → cursor becomes max last_ts" do
+    row = dep_row(deprecation_id: "x", sweep_completed_at: dt("2026-05-05T01:00:00Z"), first_ts: dt("2026-05-04T00:00:00Z"), last_ts: dt("2026-05-04T12:00:00Z"))
+    {_, cursor} = Logic.build_deprecation_batch_alarms([row], nil)
+    assert cursor == row.last_ts
+  end
+
+  # =========================================================================
+  # conflict_batch (7 tests)
+  # =========================================================================
+
+  test "conflict_batch: empty rows + nil cursor → empty alarms, cursor unchanged" do
+    assert {[], nil} = Logic.build_conflict_batch_alarms([], nil)
+  end
+
+  test "conflict_batch: single row produces one alarm with parity-shaped fields" do
+    row =
+      conf_row(
+        surface_id: "dialectic:/conflict_test",
+        surface_kind: "dialectic",
+        event_count: 7,
+        first_ts: dt("2026-05-05T08:00:00Z"),
+        last_ts: dt("2026-05-05T09:00:00Z")
+      )
+
+    {[alarm], cursor} = Logic.build_conflict_batch_alarms([row], nil)
+
+    assert alarm.kind == "conflict_batch"
+    assert alarm.severity == "medium"
+    assert alarm.summary == "held-by-other conflicts: dialectic:/conflict_test (count=7)"
+    # Fingerprint includes last_ts so a later cycle yields a distinct alarm
+    assert alarm.fingerprint == "forced_release:conflict_batch:dialectic:/conflict_test:#{DateTime.to_iso8601(row.last_ts)}"
+    assert alarm.extra.surface_id == "dialectic:/conflict_test"
+    assert alarm.extra.count == 7
+    assert cursor == row.last_ts
+  end
+
+  test "conflict_batch: fingerprint includes last_ts (later cycle = distinct alarm)" do
+    early =
+      conf_row(
+        surface_id: "dialectic:/x",
+        first_ts: dt("2026-05-05T00:00:00Z"),
+        last_ts: dt("2026-05-05T01:00:00Z")
+      )
+
+    late =
+      conf_row(
+        surface_id: "dialectic:/x",
+        first_ts: dt("2026-05-05T02:00:00Z"),
+        last_ts: dt("2026-05-05T03:00:00Z")
+      )
+
+    {[a1], _} = Logic.build_conflict_batch_alarms([early], nil)
+    {[a2], _} = Logic.build_conflict_batch_alarms([late], nil)
+    refute a1.fingerprint == a2.fingerprint,
+           "same surface, different cycle = different fingerprint (downstream dedup contract)"
+  end
+
+  test "conflict_batch: multiple surfaces produce distinct alarms" do
+    rows = [
+      conf_row(surface_id: "dialectic:/a", first_ts: dt("2026-05-05T00:00:00Z"), last_ts: dt("2026-05-05T01:00:00Z")),
+      conf_row(surface_id: "dialectic:/b", first_ts: dt("2026-05-05T00:00:00Z"), last_ts: dt("2026-05-05T01:00:00Z"))
+    ]
+
+    {alarms, _} = Logic.build_conflict_batch_alarms(rows, nil)
+    assert length(alarms) == 2
+    fps = Enum.map(alarms, & &1.fingerprint)
+    assert Enum.uniq(fps) == fps
+  end
+
+  test "conflict_batch: cursor advances to max(last_ts)" do
+    earlier = dt("2026-05-04T01:00:00Z")
+    later = dt("2026-05-05T01:00:00Z")
+
+    rows = [
+      conf_row(surface_id: "dialectic:/a", first_ts: dt("2026-05-04T00:00:00Z"), last_ts: earlier),
+      conf_row(surface_id: "dialectic:/b", first_ts: dt("2026-05-05T00:00:00Z"), last_ts: later)
+    ]
+
+    {_, cursor} = Logic.build_conflict_batch_alarms(rows, nil)
+    assert cursor == later
+  end
+
+  test "conflict_batch: cursor never regresses below prior" do
+    prior = dt("2026-06-01T00:00:00Z")
+    row = conf_row(surface_id: "dialectic:/old", first_ts: dt("2026-05-01T00:00:00Z"), last_ts: dt("2026-05-01T01:00:00Z"))
+    {_, cursor} = Logic.build_conflict_batch_alarms([row], prior)
+    assert cursor == prior
+  end
+
+  test "conflict_batch: empty list with prior preserves prior" do
+    prior = dt("2026-05-05T12:00:00Z")
+    assert {[], ^prior} = Logic.build_conflict_batch_alarms([], prior)
+  end
+
+  # =========================================================================
+  # build_all_alarms — combined cross-class (7 tests)
+  # =========================================================================
+
+  test "build_all_alarms: all empty + nil cursor → empty alarms, nil cursor" do
+    assert {[], nil} = Logic.build_all_alarms([], [], [], nil)
+  end
+
+  test "build_all_alarms: cursor is max across all three class-cursors and prior" do
+    ad_hoc = [ad_hoc_row(event_id: "e1", ts: dt("2026-05-05T01:00:00Z"), surface_id: "dialectic:/a")]
+    dep = [dep_row(deprecation_id: "d1", sweep_completed_at: dt("2026-05-05T05:00:00Z"), first_ts: dt("2026-05-05T02:00:00Z"), last_ts: dt("2026-05-05T03:00:00Z"))]
+    conf = [conf_row(surface_id: "dialectic:/c", first_ts: dt("2026-05-05T04:00:00Z"), last_ts: dt("2026-05-05T04:30:00Z"))]
+
+    {alarms, cursor} = Logic.build_all_alarms(ad_hoc, dep, conf, nil)
+    assert length(alarms) == 3
+    # Max of 01:00 (ad_hoc), 03:00 (dep last_ts), 04:30 (conf) → 04:30
+    assert cursor == dt("2026-05-05T04:30:00Z")
+  end
+
+  test "build_all_alarms: prior cursor wins if it's the max" do
+    prior = dt("2026-06-01T00:00:00Z")
+    ad_hoc = [ad_hoc_row(event_id: "e", ts: dt("2026-05-05T01:00:00Z"), surface_id: "dialectic:/x")]
+    {_alarms, cursor} = Logic.build_all_alarms(ad_hoc, [], [], prior)
+    assert cursor == prior
+  end
+
+  test "build_all_alarms: combined alarm list contains all three kinds" do
+    ad_hoc = [ad_hoc_row(event_id: "e1", ts: dt("2026-05-05T01:00:00Z"), surface_id: "dialectic:/a")]
+    dep = [dep_row(deprecation_id: "d1", sweep_completed_at: dt("2026-05-05T05:00:00Z"), first_ts: dt("2026-05-05T02:00:00Z"), last_ts: dt("2026-05-05T03:00:00Z"))]
+    conf = [conf_row(surface_id: "dialectic:/c", first_ts: dt("2026-05-05T04:00:00Z"), last_ts: dt("2026-05-05T04:30:00Z"))]
+
+    {alarms, _} = Logic.build_all_alarms(ad_hoc, dep, conf, nil)
+    kinds = alarms |> Enum.map(& &1.kind) |> Enum.sort()
+    assert kinds == ["ad_hoc", "conflict_batch", "deprecation_batch"]
+  end
+
+  test "build_all_alarms: only ad_hoc populated → only ad_hoc alarms" do
+    ad_hoc = [ad_hoc_row(event_id: "e", ts: dt("2026-05-05T01:00:00Z"), surface_id: "dialectic:/a")]
+    {alarms, cursor} = Logic.build_all_alarms(ad_hoc, [], [], nil)
+    assert length(alarms) == 1
+    assert hd(alarms).kind == "ad_hoc"
+    assert cursor == dt("2026-05-05T01:00:00Z")
+  end
+
+  test "build_all_alarms: only deprecation populated → only deprecation alarms" do
+    dep = [dep_row(deprecation_id: "d1", sweep_completed_at: dt("2026-05-05T05:00:00Z"), first_ts: dt("2026-05-05T02:00:00Z"), last_ts: dt("2026-05-05T03:00:00Z"))]
+    {alarms, _cursor} = Logic.build_all_alarms([], dep, [], nil)
+    assert length(alarms) == 1
+    assert hd(alarms).kind == "deprecation_batch"
+  end
+
+  test "build_all_alarms: only conflict populated → only conflict alarms" do
+    conf = [conf_row(surface_id: "dialectic:/c", first_ts: dt("2026-05-05T04:00:00Z"), last_ts: dt("2026-05-05T04:30:00Z"))]
+    {alarms, _cursor} = Logic.build_all_alarms([], [], conf, nil)
+    assert length(alarms) == 1
+    assert hd(alarms).kind == "conflict_batch"
+  end
+end


### PR DESCRIPTION
Final Wave 1 Surface 1 PR. Implements v0.1.3 §B1 combined poller against the structural prep landed in #378. tick/1 now runs all 3 queries inside one Postgrex.transaction, advances one cursor, all-or-nothing rollback on any single-query failure.

Tests: 50 → 76 (+26). 21 pure-logic + 5 integration. §B2 asymmetry, §B5 single-tx, §B6 all-or-nothing, §B3 row shapes — all pinned.

Stack: #373/374/375/376/377/378 → THIS.