### PR TITLE
feat(wave-1): Surface 2 forced-release findings emit

### DIFF
--- a/elixir/sentinel/config/config.exs
+++ b/elixir/sentinel/config/config.exs
@@ -7,7 +7,12 @@ config :unitares_sentinel,
       "postgresql://postgres:postgres@localhost:5432/governance",
   pool_size: 2,
   poller_interval_ms: 30_000,
-  poller_initial_delay_ms: 1_000
+  poller_initial_delay_ms: 1_000,
+  findings_url: System.get_env("UNITARES_FINDINGS_URL") || "http://localhost:8767/api/findings",
+  findings_timeout_ms: 3_000,
+  findings_agent_id: System.get_env("UNITARES_SENTINEL_AGENT_ID") || "sentinel",
+  findings_agent_name: "Sentinel",
+  emit_findings: true
 
 if File.exists?("config/#{config_env()}.exs") do
   import_config "#{config_env()}.exs"

--- a/elixir/sentinel/config/test.exs
+++ b/elixir/sentinel/config/test.exs
@@ -8,6 +8,7 @@ config :unitares_sentinel,
   start_application: false,
   start_postgrex: false,
   start_poller: false,
+  start_finch: false,
   database_url:
     System.get_env("UNITARES_SENTINEL_DATABASE_URL") ||
       System.get_env("UNITARES_LEASE_PLANE_DATABASE_URL") ||

--- a/elixir/sentinel/lib/unitares_sentinel.ex
+++ b/elixir/sentinel/lib/unitares_sentinel.ex
@@ -23,7 +23,8 @@ defmodule UnitaresSentinel do
   ## Bootstrap status
 
   This module + its `Application` supervisor are the minimum scaffold per
-  the §Bootstrap spec (B5 reviewer fold). The cycle worker, lease consumer,
-  WebSocket ingester, and `post_finding/2` client land in follow-up PRs.
+  the §Bootstrap spec (B5 reviewer fold). The cycle worker and Surface 2
+  forced-release alarm findings client are wired; lease consumer, WebSocket
+  ingester, and full fleet `sentinel_finding` parity land in follow-up PRs.
   """
 end

--- a/elixir/sentinel/lib/unitares_sentinel/application.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/application.ex
@@ -2,11 +2,9 @@ defmodule UnitaresSentinel.Application do
   @moduledoc """
   OTP entry point for the Sentinel app.
 
-  Skeleton-only at this stage: the supervisor starts with no children
-  in :test mode (`config/test.exs`) and a placeholder set in :prod / :dev.
-  Cycle worker, lease consumer, WebSocket ingester, and Finch HTTP client
-  pool will be added by follow-up PRs as their respective surfaces (1–5)
-  are wired per the v0.1.1 RFC.
+  The supervisor starts with no children in :test mode (`config/test.exs`).
+  Runtime mode starts Postgrex, the Finch HTTP client pool used by Surface 2
+  findings emission, and the poller when `:start_poller` is enabled.
 
   Mirrors the `:start_application` gate that `UnitaresLeasePlane.Application`
   uses (`elixir/lease_plane/lib/unitares_lease_plane/application.ex`) so
@@ -25,7 +23,7 @@ defmodule UnitaresSentinel.Application do
   end
 
   defp start_full do
-    children = postgrex_children() ++ poller_children()
+    children = postgrex_children() ++ finch_children() ++ poller_children()
     Supervisor.start_link(children, strategy: :one_for_one, name: UnitaresSentinel.Supervisor)
   end
 
@@ -40,6 +38,14 @@ defmodule UnitaresSentinel.Application do
   defp poller_children do
     if Application.get_env(:unitares_sentinel, :start_poller, false) do
       [UnitaresSentinel.ForcedReleasePoller]
+    else
+      []
+    end
+  end
+
+  defp finch_children do
+    if Application.get_env(:unitares_sentinel, :start_finch, true) do
+      [{Finch, name: UnitaresSentinel.Finch}]
     else
       []
     end

--- a/elixir/sentinel/lib/unitares_sentinel/findings.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/findings.ex
@@ -1,0 +1,138 @@
+defmodule UnitaresSentinel.Findings do
+  @moduledoc """
+  Best-effort `/api/findings` client for BEAM Sentinel.
+
+  Mirrors `agents.common.findings.post_finding`: callers get a boolean,
+  network/API failures return `false`, and exceptions never leave the hot
+  cycle path. `ForcedReleasePoller` uses this for Surface 2 forced-release
+  alarm emission.
+  """
+
+  require Logger
+
+  @default_url "http://localhost:8767/api/findings"
+  @default_timeout_ms 3_000
+  @default_agent_id "sentinel"
+  @default_agent_name "Sentinel"
+
+  @type http_post ::
+          (String.t(), map(), [{String.t(), String.t()}], pos_integer() ->
+             {:ok, non_neg_integer(), String.t()} | {:error, term()})
+
+  @doc """
+  POST one forced-release alarm as a `sentinel_forced_release_alarm` finding.
+  """
+  @spec post_alarm(UnitaresSentinel.ForcedReleasePoller.Logic.alarm(), keyword()) :: boolean()
+  def post_alarm(alarm, opts \\ []) when is_map(alarm) do
+    alarm
+    |> alarm_body(opts)
+    |> post_json(opts)
+  end
+
+  @doc false
+  @spec alarm_body(UnitaresSentinel.ForcedReleasePoller.Logic.alarm(), keyword()) :: map()
+  def alarm_body(alarm, opts \\ []) when is_map(alarm) do
+    base = %{
+      "type" => Keyword.get(opts, :event_type, "sentinel_forced_release_alarm"),
+      "severity" => Map.fetch!(alarm, :severity),
+      "message" => Map.fetch!(alarm, :summary),
+      "agent_id" => agent_id(opts),
+      "agent_name" => agent_name(opts),
+      "fingerprint" => Map.fetch!(alarm, :fingerprint),
+      "alarm_kind" => Map.fetch!(alarm, :kind)
+    }
+
+    alarm
+    |> Map.get(:extra, %{})
+    |> stringify_keys()
+    |> Map.merge(base, fn _key, _extra_value, base_value -> base_value end)
+  end
+
+  @doc false
+  @spec post_json(map(), keyword()) :: boolean()
+  def post_json(body, opts \\ []) when is_map(body) do
+    http_post = Keyword.get(opts, :http_post, &finch_post/4)
+    url = Keyword.get(opts, :url, findings_url())
+    timeout_ms = Keyword.get(opts, :timeout_ms, findings_timeout_ms())
+
+    case http_post.(url, body, headers(), timeout_ms) do
+      {:ok, 200, response_body} ->
+        accepted?(response_body)
+
+      {:ok, status, _response_body} ->
+        Logger.debug("UnitaresSentinel.Findings.post_json non-200: #{inspect(status)}")
+        false
+
+      {:error, reason} ->
+        Logger.debug("UnitaresSentinel.Findings.post_json failed: #{inspect(reason)}")
+        false
+    end
+  rescue
+    e ->
+      Logger.debug("UnitaresSentinel.Findings.post_json raised: #{inspect(e)}")
+      false
+  catch
+    :exit, reason ->
+      Logger.debug("UnitaresSentinel.Findings.post_json exited: #{inspect(reason)}")
+      false
+  end
+
+  defp finch_post(url, body, headers, timeout_ms) do
+    json = Jason.encode!(body)
+    request = Finch.build(:post, url, headers, json)
+
+    case Finch.request(request, UnitaresSentinel.Finch, receive_timeout: timeout_ms) do
+      {:ok, %Finch.Response{status: status, body: response_body}} ->
+        {:ok, status, response_body}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp accepted?(response_body) when is_binary(response_body) do
+    case Jason.decode(response_body) do
+      {:ok, %{"success" => true} = decoded} -> not Map.get(decoded, "deduped", false)
+      _ -> false
+    end
+  end
+
+  defp headers do
+    base = [{"Content-Type", "application/json"}]
+
+    case System.get_env("UNITARES_HTTP_API_TOKEN") do
+      nil -> base
+      "" -> base
+      token -> [{"Authorization", "Bearer #{token}"} | base]
+    end
+  end
+
+  defp findings_url do
+    Application.get_env(:unitares_sentinel, :findings_url) ||
+      System.get_env("UNITARES_FINDINGS_URL") ||
+      @default_url
+  end
+
+  defp findings_timeout_ms do
+    Application.get_env(:unitares_sentinel, :findings_timeout_ms, @default_timeout_ms)
+  end
+
+  defp agent_id(opts) do
+    Keyword.get(opts, :agent_id) ||
+      Application.get_env(:unitares_sentinel, :findings_agent_id) ||
+      System.get_env("UNITARES_SENTINEL_AGENT_ID") ||
+      @default_agent_id
+  end
+
+  defp agent_name(opts) do
+    Keyword.get(opts, :agent_name) ||
+      Application.get_env(:unitares_sentinel, :findings_agent_name, @default_agent_name)
+  end
+
+  defp stringify_keys(map) when is_map(map) do
+    Map.new(map, fn
+      {key, value} when is_atom(key) -> {Atom.to_string(key), value}
+      {key, value} when is_binary(key) -> {key, value}
+    end)
+  end
+end

--- a/elixir/sentinel/lib/unitares_sentinel/forced_release_poller.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/forced_release_poller.ex
@@ -1,27 +1,24 @@
 defmodule UnitaresSentinel.ForcedReleasePoller do
   @moduledoc """
-  Surface 1 cycle worker — periodic poller that drives `CycleState`.
+  Surface 1 cycle worker plus Surface 2 forced-release findings emission.
 
   Reads the cursor from `CycleState`, queries `lease_plane.lease_plane_events`
-  for `event_type='forced'` rows past the cursor, builds alarms via
-  `ForcedReleasePoller.Logic.build_alarms/2`, advances the cursor to
-  max(rows.ts), and persists via `CycleState.save/2`.
+  for all three forced-release alarm classes, builds alarms via
+  `ForcedReleasePoller.Logic.build_all_alarms/4`, emits each alarm to
+  `/api/findings`, then persists the candidate cursor via `CycleState.save/2`.
 
-  ## Scope (this PR)
+  Cursor persistence happens after the emit loop in the GenServer path.
+  This restores the Python ordering at `agents/sentinel/agent.py:681-699`
+  and closes the Surface-1-only pre-emit-persist gap called out by v0.1.3
+  §B4. The public `tick/1` API remains an alarm builder/poller for tests and
+  explicit callers; the GenServer is the runtime writer that emits and then
+  persists.
 
-  Ad_hoc forced events (`event_type='forced'`) only — the lowest-volume
-  class. Deferred to follow-up PRs:
+  ## Phase-B promotion scope
 
-    * `event_type='lease.deprecation_swept'` deprecation-batch class
-    * `event_type='conflict_held_by_other'` conflict-batch class
-
-  ## Findings emit
-
-  This module RETURNS alarms but does NOT POST them. Surface 2 (findings
-  emit) is a separate writer-locked surface and lands in its own PR.
-  Returning alarms keeps the API forward-compatible: when Surface 2 wires
-  up, it calls `tick/1` and routes the alarms to the dashboard / Discord
-  bridge.
+  Python feeds `conflict_batch` alarms into `_emit_phase_b_transitions/2`.
+  Wave 1 BEAM does not port that evaluator; conflict_batch findings emit,
+  but phase-B promotion remains Python/Wave-2 scope.
 
   ## Tick API
 
@@ -62,13 +59,15 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
 
   require Logger
 
-  alias UnitaresSentinel.{CycleState, ForcedReleasePoller.Logic}
+  alias UnitaresSentinel.{CycleState, Findings, ForcedReleasePoller.Logic}
 
   @type opts :: [
           prior_cursor: DateTime.t() | nil,
           db: GenServer.server(),
           persist: boolean(),
-          state_path: Path.t() | nil
+          state_path: Path.t() | nil,
+          emit_findings: boolean(),
+          findings_opts: keyword()
         ]
 
   # ---- Public tick API --------------------------------------------------
@@ -306,9 +305,27 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
   @impl true
   def init(opts) do
     db = Keyword.get(opts, :db, UnitaresSentinel.DB)
-    interval_ms = Keyword.get(opts, :interval_ms, Application.get_env(:unitares_sentinel, :poller_interval_ms, 30_000))
-    initial_delay_ms = Keyword.get(opts, :initial_delay_ms, Application.get_env(:unitares_sentinel, :poller_initial_delay_ms, 1_000))
-    jitter_ms = Keyword.get(opts, :jitter_ms, Application.get_env(:unitares_sentinel, :poller_jitter_ms, 5_000))
+
+    interval_ms =
+      Keyword.get(
+        opts,
+        :interval_ms,
+        Application.get_env(:unitares_sentinel, :poller_interval_ms, 30_000)
+      )
+
+    initial_delay_ms =
+      Keyword.get(
+        opts,
+        :initial_delay_ms,
+        Application.get_env(:unitares_sentinel, :poller_initial_delay_ms, 1_000)
+      )
+
+    jitter_ms =
+      Keyword.get(
+        opts,
+        :jitter_ms,
+        Application.get_env(:unitares_sentinel, :poller_jitter_ms, 5_000)
+      )
 
     cursor = load_cursor_from_state()
 
@@ -317,6 +334,13 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
       cursor: cursor,
       interval_ms: interval_ms,
       jitter_ms: jitter_ms,
+      emit_findings?:
+        Keyword.get(
+          opts,
+          :emit_findings,
+          Application.get_env(:unitares_sentinel, :emit_findings, true)
+        ),
+      findings_opts: Keyword.get(opts, :findings_opts, []),
       # v0.1.3 §C2 tick-skip guard. Under self-scheduling (next :tick is
       # only enqueued AFTER the current tick returns), this flag will never
       # actually be true at message-arrival time — BEAM serializes handle_*
@@ -353,8 +377,14 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
     file_cursor = load_cursor_from_state()
     effective_prior = max_cursor(state.cursor, file_cursor)
 
-    {_alarms, new_cursor} =
-      tick(prior_cursor: effective_prior, db: state.db, persist: true)
+    {alarms, new_cursor} =
+      tick(prior_cursor: effective_prior, db: state.db, persist: false)
+
+    emit_findings(alarms, state)
+
+    if new_cursor != nil and not same_cursor?(new_cursor, effective_prior) do
+      persist_cursor(new_cursor, [])
+    end
 
     # Jitter the next tick to avoid Python/BEAM lockstep races after
     # simultaneous boots (architect #5).
@@ -377,6 +407,12 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
 
   defp max_cursor(%DateTime{} = a, %DateTime{} = b) do
     if DateTime.compare(a, b) == :gt, do: a, else: b
+  end
+
+  defp emit_findings(_alarms, %{emit_findings?: false}), do: :ok
+
+  defp emit_findings(alarms, %{findings_opts: findings_opts}) when is_list(alarms) do
+    Enum.each(alarms, &Findings.post_alarm(&1, findings_opts))
   end
 
   defp load_cursor_from_state do

--- a/elixir/sentinel/test/unitares_sentinel/findings_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/findings_test.exs
@@ -1,0 +1,68 @@
+defmodule UnitaresSentinel.FindingsTest do
+  use ExUnit.Case, async: true
+
+  alias UnitaresSentinel.Findings
+
+  defp alarm do
+    %{
+      kind: "ad_hoc",
+      severity: "high",
+      summary: "forced release: dialectic:/x (lease lease-1)",
+      fingerprint: "forced_release:ad_hoc:event-1",
+      extra: %{
+        event_id: "event-1",
+        ts: "2026-05-06T00:00:00Z",
+        lease_id: "lease-1",
+        surface_id: "dialectic:/x",
+        surface_kind: "dialectic",
+        fingerprint: "spoofed"
+      }
+    }
+  end
+
+  test "alarm_body mirrors Python forced-release post_finding shape" do
+    body = Findings.alarm_body(alarm(), agent_id: "sentinel-test", agent_name: "Sentinel")
+
+    assert body["type"] == "sentinel_forced_release_alarm"
+    assert body["severity"] == "high"
+    assert body["message"] == "forced release: dialectic:/x (lease lease-1)"
+    assert body["agent_id"] == "sentinel-test"
+    assert body["agent_name"] == "Sentinel"
+    assert body["fingerprint"] == "forced_release:ad_hoc:event-1"
+    assert body["alarm_kind"] == "ad_hoc"
+    assert body["event_id"] == "event-1"
+    assert body["surface_kind"] == "dialectic"
+  end
+
+  test "post_alarm returns true only for accepted non-deduped response" do
+    http_post = fn url, body, headers, timeout_ms ->
+      assert url == "http://example.test/api/findings"
+      assert body["type"] == "sentinel_forced_release_alarm"
+      assert {"Content-Type", "application/json"} in headers
+      assert timeout_ms == 123
+
+      {:ok, 200, ~s({"success":true,"deduped":false})}
+    end
+
+    assert Findings.post_alarm(
+             alarm(),
+             url: "http://example.test/api/findings",
+             timeout_ms: 123,
+             http_post: http_post
+           )
+  end
+
+  test "post_alarm swallows transport failures" do
+    http_post = fn _url, _body, _headers, _timeout_ms -> raise "connection refused" end
+
+    refute Findings.post_alarm(alarm(), http_post: http_post)
+  end
+
+  test "post_alarm returns false for deduped responses" do
+    http_post = fn _url, _body, _headers, _timeout_ms ->
+      {:ok, 200, ~s({"success":true,"deduped":true})}
+    end
+
+    refute Findings.post_alarm(alarm(), http_post: http_post)
+  end
+end

--- a/elixir/sentinel/test/unitares_sentinel/forced_release_poller_findings_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/forced_release_poller_findings_test.exs
@@ -1,0 +1,96 @@
+defmodule UnitaresSentinel.ForcedReleasePollerFindingsTest do
+  @moduledoc """
+  Surface 2 bindings for forced-release findings emission.
+
+  The GenServer runtime path must POST alarms before persisting the candidate
+  cursor. If the process crashes between poll and emit, the cursor remains
+  behind and the next boot can replay the alarms, matching Python ordering.
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :db
+
+  alias SentinelTestHelpers, as: H
+  alias UnitaresSentinel.ForcedReleasePoller
+
+  setup do
+    label = H.random_label()
+    surface_prefix = "dialectic:/test_sentinel_findings_#{label}"
+
+    tmpdir =
+      System.tmp_dir!()
+      |> Path.join("unitares_sentinel_findings_test_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmpdir)
+    state_file = Path.join(tmpdir, ".sentinel_state")
+    Application.put_env(:unitares_sentinel, :state_file_path, state_file)
+
+    on_exit(fn ->
+      H.cleanup_surface_prefix(surface_prefix)
+      Application.delete_env(:unitares_sentinel, :state_file_path)
+      File.rm_rf!(tmpdir)
+    end)
+
+    {:ok, surface_prefix: surface_prefix, state_file: state_file}
+  end
+
+  test "GenServer emits findings before persisting candidate cursor", ctx do
+    parent = self()
+    shadow_path = ctx.state_file <> ".beam"
+    prior = ~U[2030-01-01 00:00:00.000000Z]
+    event_ts = DateTime.add(prior, 1, :second)
+    surface_id = ctx.surface_prefix <> "/emit_order"
+
+    File.write!(
+      ctx.state_file,
+      ~s({"forced_release_alarm":{"last_event_ts":"#{DateTime.to_iso8601(prior)}"}})
+    )
+
+    {event_id, _returned_ts} = H.insert_forced_event(surface_id, event_ts)
+
+    http_post = fn _url, body, _headers, _timeout_ms ->
+      if body["event_id"] == event_id do
+        send(parent, {:posted_target_alarm, body, File.exists?(shadow_path)})
+      end
+
+      {:ok, 200, ~s({"success":true,"deduped":false})}
+    end
+
+    {:ok, pid} =
+      ForcedReleasePoller.start_link(
+        name: :"test_findings_emit_#{System.unique_integer([:positive])}",
+        db: UnitaresSentinel.DB,
+        interval_ms: 60_000,
+        initial_delay_ms: 60_000,
+        jitter_ms: 0,
+        emit_findings: true,
+        findings_opts: [
+          agent_id: "sentinel-test",
+          agent_name: "Sentinel",
+          http_post: http_post
+        ]
+      )
+
+    send(pid, :tick)
+
+    assert_receive {:posted_target_alarm, body, persisted_before_post?}, 2_000
+
+    refute persisted_before_post?,
+           "cursor must not be written until after the Surface 2 emit loop completes"
+
+    assert body["type"] == "sentinel_forced_release_alarm"
+    assert body["alarm_kind"] == "ad_hoc"
+    assert body["fingerprint"] == "forced_release:ad_hoc:#{event_id}"
+
+    Process.sleep(50)
+    assert File.exists?(shadow_path), "cursor should persist after emit loop"
+
+    decoded = shadow_path |> File.read!() |> Jason.decode!()
+
+    assert get_in(decoded, ["forced_release_alarm", "last_event_ts"]) ==
+             DateTime.to_iso8601(event_ts)
+
+    GenServer.stop(pid)
+  end
+end


### PR DESCRIPTION
Implements the Wave 1 Surface 2 forced-release findings emit path for BEAM Sentinel.

What changed:
- Adds UnitaresSentinel.Findings, a best-effort Finch client for POST /api/findings that mirrors Python post_finding semantics: boolean result, dedup awareness, auth token header, and no exceptions escaping the cycle path.
- Wires ForcedReleasePoller runtime ticks to poll without pre-persisting, emit every forced-release alarm, then persist the candidate cursor after the emit loop completes.
- Starts a named Finch pool in the Sentinel supervisor and adds config for findings URL, timeout, agent id/name, and test gating.
- Documents that BEAM Wave 1 emits conflict_batch findings but still does not port Python phase-B promotion.

Why:
Surface 1 intentionally returned alarms before an emitter existed, which left a known pre-emit cursor persistence gap. Surface 2 closes that by restoring Python post-before-save ordering for the GenServer runtime path.

Validation:
- mix test in elixir/sentinel: 81 tests, 0 failures.
- Pre-push smoke: 138 passed, 7832 deselected. Doc health reported existing warnings for dead refs in docs/dev/MARKDOWN_PROLIFERATION_POLICY.md.