### PR TITLE
feat(wave-1): add Sentinel cutover scripts

### DIFF
--- a/elixir/sentinel/lib/mix/tasks/sentinel.cutover.ex
+++ b/elixir/sentinel/lib/mix/tasks/sentinel.cutover.ex
@@ -1,0 +1,54 @@
+defmodule Mix.Tasks.Sentinel.Cutover do
+  @moduledoc """
+  Mark BEAM Sentinel as canonical for the cycle-state file.
+
+  ## Usage
+
+      mix sentinel.cutover --to=beam
+      mix sentinel.cutover --to=beam --state-file /path/to/.sentinel_state
+
+  The task re-reads `STATE_FILE` and `STATE_FILE.beam`, picks the max
+  `forced_release_alarm.last_event_ts`, writes it to `STATE_FILE.beam`, and
+  adds `runtime: "beam_canonical"`.
+
+  Stop Python Sentinel before running this task; start BEAM Sentinel after it.
+  Launchctl orchestration is intentionally outside this Mix task.
+  """
+
+  use Mix.Task
+
+  alias UnitaresSentinel.Cutover
+
+  @shortdoc "Set Sentinel cycle-state runtime to beam_canonical"
+
+  @impl Mix.Task
+  def run(args) do
+    opts = parse!(args, "beam")
+    {:ok, result} = Cutover.cutover_to_beam(opts)
+
+    Mix.shell().info("sentinel.cutover: runtime=#{result.runtime}")
+    Mix.shell().info("canonical: #{result.canonical}")
+    Mix.shell().info("shadow:    #{result.shadow}")
+    Mix.shell().info("cursor:    #{format_cursor(result.cursor)}")
+  end
+
+  defp parse!(args, expected) do
+    {opts, rest, invalid} = OptionParser.parse(args, strict: [to: :string, state_file: :string])
+
+    if rest != [] or invalid != [] do
+      Mix.raise("sentinel.cutover: invalid arguments; use --to=#{expected}")
+    end
+
+    if opts[:to] != expected do
+      Mix.raise("sentinel.cutover: expected --to=#{expected}")
+    end
+
+    case opts[:state_file] do
+      nil -> []
+      path -> [canonical: path]
+    end
+  end
+
+  defp format_cursor(nil), do: "<none>"
+  defp format_cursor(cursor), do: cursor
+end

--- a/elixir/sentinel/lib/mix/tasks/sentinel.rollback.ex
+++ b/elixir/sentinel/lib/mix/tasks/sentinel.rollback.ex
@@ -1,0 +1,54 @@
+defmodule Mix.Tasks.Sentinel.Rollback do
+  @moduledoc """
+  Mark Python Sentinel as canonical for the cycle-state file.
+
+  ## Usage
+
+      mix sentinel.rollback --to=python
+      mix sentinel.rollback --to=python --state-file /path/to/.sentinel_state
+
+  The task re-reads `STATE_FILE` and `STATE_FILE.beam`, picks the max
+  `forced_release_alarm.last_event_ts`, writes that Python-compatible state
+  back to `STATE_FILE`, and marks `STATE_FILE.beam` as
+  `runtime: "python_canonical"` for rollback forensics.
+
+  Stop BEAM Sentinel before running this task; start Python Sentinel after it.
+  """
+
+  use Mix.Task
+
+  alias UnitaresSentinel.Cutover
+
+  @shortdoc "Set Sentinel cycle-state runtime to python_canonical"
+
+  @impl Mix.Task
+  def run(args) do
+    opts = parse!(args, "python")
+    {:ok, result} = Cutover.rollback_to_python(opts)
+
+    Mix.shell().info("sentinel.rollback: runtime=#{result.runtime}")
+    Mix.shell().info("canonical: #{result.canonical}")
+    Mix.shell().info("shadow:    #{result.shadow}")
+    Mix.shell().info("cursor:    #{format_cursor(result.cursor)}")
+  end
+
+  defp parse!(args, expected) do
+    {opts, rest, invalid} = OptionParser.parse(args, strict: [to: :string, state_file: :string])
+
+    if rest != [] or invalid != [] do
+      Mix.raise("sentinel.rollback: invalid arguments; use --to=#{expected}")
+    end
+
+    if opts[:to] != expected do
+      Mix.raise("sentinel.rollback: expected --to=#{expected}")
+    end
+
+    case opts[:state_file] do
+      nil -> []
+      path -> [canonical: path]
+    end
+  end
+
+  defp format_cursor(nil), do: "<none>"
+  defp format_cursor(cursor), do: cursor
+end

--- a/elixir/sentinel/lib/unitares_sentinel/cutover.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/cutover.ex
@@ -1,0 +1,117 @@
+defmodule UnitaresSentinel.Cutover do
+  @moduledoc """
+  File-level cutover helpers for Sentinel-on-BEAM.
+
+  These helpers implement the v0.1.2 §B3 max-wins protocol:
+
+    * cutover to BEAM writes the max cursor to `STATE_FILE.beam` with
+      `runtime: "beam_canonical"`;
+    * rollback to Python writes the max cursor back to `STATE_FILE` and marks
+      the shadow as `runtime: "python_canonical"` for forensics.
+
+  Launchctl stop/start ordering remains an operator/script concern outside
+  these pure file operations.
+  """
+
+  alias UnitaresSentinel.{AtomicWrite, CycleState}
+
+  @runtime_key "runtime"
+  @beam_canonical "beam_canonical"
+  @python_canonical "python_canonical"
+
+  @type result :: %{
+          canonical: Path.t(),
+          shadow: Path.t(),
+          cursor: String.t() | nil,
+          runtime: String.t()
+        }
+
+  @doc """
+  Mark the BEAM shadow file canonical after applying max-cursor merge.
+  """
+  @spec cutover_to_beam(keyword()) :: {:ok, result()}
+  def cutover_to_beam(opts \\ []) do
+    {canonical, shadow} = resolve_paths(opts)
+
+    state =
+      canonical
+      |> load_max_state(shadow)
+      |> Map.put(@runtime_key, @beam_canonical)
+
+    :ok = write_state(shadow, state)
+
+    {:ok,
+     %{
+       canonical: canonical,
+       shadow: shadow,
+       cursor: CycleState.get_last_event_ts(state),
+       runtime: @beam_canonical
+     }}
+  end
+
+  @doc """
+  Copy the max cursor back to the Python canonical file and mark shadow rollback.
+  """
+  @spec rollback_to_python(keyword()) :: {:ok, result()}
+  def rollback_to_python(opts \\ []) do
+    {canonical, shadow} = resolve_paths(opts)
+
+    state =
+      canonical
+      |> load_max_state(shadow)
+      |> Map.delete(@runtime_key)
+
+    :ok = write_state(canonical, state)
+    :ok = write_state(shadow, Map.put(state, @runtime_key, @python_canonical))
+
+    {:ok,
+     %{
+       canonical: canonical,
+       shadow: shadow,
+       cursor: CycleState.get_last_event_ts(state),
+       runtime: @python_canonical
+     }}
+  end
+
+  @doc false
+  @spec resolve_paths(keyword()) :: {Path.t(), Path.t()}
+  def resolve_paths(opts \\ []) do
+    canonical = Keyword.get(opts, :canonical) || CycleState.resolve_canonical_path()
+    shadow = Keyword.get(opts, :shadow) || canonical <> ".beam"
+    {canonical, shadow}
+  end
+
+  defp load_max_state(canonical, shadow) do
+    canonical
+    |> read_state()
+    |> pick_max(read_state(shadow))
+  end
+
+  defp read_state(path) do
+    with {:ok, contents} <- File.read(path),
+         {:ok, decoded} when is_map(decoded) <- Jason.decode(contents) do
+      decoded
+    else
+      _ -> %{}
+    end
+  end
+
+  defp write_state(path, state) do
+    encoded = state |> Jason.encode!() |> Jason.decode!() |> Jason.encode!()
+    AtomicWrite.write(path, encoded)
+  end
+
+  defp pick_max(%{} = canonical, shadow) when map_size(canonical) == 0, do: shadow
+  defp pick_max(canonical, %{} = shadow) when map_size(shadow) == 0, do: canonical
+
+  defp pick_max(canonical, shadow) do
+    canonical_cursor = CycleState.get_last_event_ts(canonical) || ""
+    shadow_cursor = CycleState.get_last_event_ts(shadow) || ""
+
+    if canonical_cursor >= shadow_cursor do
+      canonical
+    else
+      shadow
+    end
+  end
+end

--- a/elixir/sentinel/test/unitares_sentinel/cutover_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/cutover_test.exs
@@ -1,0 +1,84 @@
+defmodule UnitaresSentinel.CutoverTest do
+  use ExUnit.Case, async: true
+
+  alias UnitaresSentinel.Cutover
+
+  setup do
+    tmpdir =
+      System.tmp_dir!()
+      |> Path.join("unitares_sentinel_cutover_test_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmpdir)
+    canonical = Path.join(tmpdir, ".sentinel_state")
+    shadow = canonical <> ".beam"
+
+    on_exit(fn -> File.rm_rf!(tmpdir) end)
+
+    {:ok, canonical: canonical, shadow: shadow}
+  end
+
+  test "cutover_to_beam writes max cursor to shadow with beam runtime", ctx do
+    write_state(ctx.canonical, "2026-05-05T01:00:00Z")
+    write_state(ctx.shadow, "2026-05-05T02:00:00Z", %{"runtime" => "shadow"})
+
+    {:ok, result} = Cutover.cutover_to_beam(canonical: ctx.canonical, shadow: ctx.shadow)
+
+    assert result.runtime == "beam_canonical"
+    assert result.cursor == "2026-05-05T02:00:00Z"
+
+    decoded = decode!(ctx.shadow)
+    assert decoded["runtime"] == "beam_canonical"
+
+    assert get_in(decoded, ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-05T02:00:00Z"
+
+    canonical = decode!(ctx.canonical)
+    refute Map.has_key?(canonical, "runtime")
+  end
+
+  test "cutover_to_beam lets canonical win when canonical cursor is newer", ctx do
+    write_state(ctx.canonical, "2026-05-05T03:00:00Z")
+    write_state(ctx.shadow, "2026-05-05T02:00:00Z")
+
+    {:ok, result} = Cutover.cutover_to_beam(canonical: ctx.canonical, shadow: ctx.shadow)
+
+    assert result.cursor == "2026-05-05T03:00:00Z"
+
+    assert get_in(decode!(ctx.shadow), ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-05T03:00:00Z"
+  end
+
+  test "rollback_to_python copies max cursor back to canonical and marks shadow", ctx do
+    write_state(ctx.canonical, "2026-05-05T01:00:00Z")
+    write_state(ctx.shadow, "2026-05-05T04:00:00Z", %{"runtime" => "beam_canonical"})
+
+    {:ok, result} = Cutover.rollback_to_python(canonical: ctx.canonical, shadow: ctx.shadow)
+
+    assert result.runtime == "python_canonical"
+    assert result.cursor == "2026-05-05T04:00:00Z"
+
+    canonical = decode!(ctx.canonical)
+
+    assert get_in(canonical, ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-05T04:00:00Z"
+
+    refute Map.has_key?(canonical, "runtime")
+
+    shadow = decode!(ctx.shadow)
+    assert shadow["runtime"] == "python_canonical"
+
+    assert get_in(shadow, ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-05T04:00:00Z"
+  end
+
+  defp write_state(path, cursor, extra \\ %{}) do
+    state =
+      Map.merge(extra, %{
+        "forced_release_alarm" => %{"last_event_ts" => cursor}
+      })
+
+    File.write!(path, Jason.encode!(state))
+  end
+
+  defp decode!(path), do: path |> File.read!() |> Jason.decode!()
+end


### PR DESCRIPTION
Implements the Wave 1 Sentinel cutover and rollback file operations.

What changed:
- Adds UnitaresSentinel.Cutover with max-cursor merge helpers for STATE_FILE and STATE_FILE.beam.
- Adds mix sentinel.cutover --to=beam to write the max cursor into the BEAM shadow file with runtime beam_canonical.
- Adds mix sentinel.rollback --to=python to copy the max cursor back into the Python canonical file and mark the shadow python_canonical for rollback forensics.
- Adds ExUnit coverage for shadow-wins, canonical-wins, and rollback copy-back behavior.

Why:
The RFC already made CycleState aware of runtime flags, but the operator-owned writer for those flags was still missing. These tasks own only file state. Launchctl stop/start order remains outside this PR.

Validation:
- mix test in elixir/sentinel: 79 tests, 0 failures.
- Pre-push smoke: 138 passed, 7832 deselected. Doc health reported existing warnings for dead refs in docs/dev/MARKDOWN_PROLIFERATION_POLICY.md.