### PR TITLE
docs: stop linking local-only policy refs

### DIFF
--- a/docs/dev/MARKDOWN_PROLIFERATION_POLICY.md
+++ b/docs/dev/MARKDOWN_PROLIFERATION_POLICY.md
@@ -101,11 +101,11 @@ If a document is mainly a completed plan, one-time incident writeup, migration n
 
 The repository's `.gitignore` already encodes the operator's split between public docs and local-only working notes:
 
-- `docs/archive/` — retired/superseded proposals kept locally for the operator's records, not surfaced publicly. The frontmatter banner on the retired doc is sufficient public signal; the body of a rejected proposal serves no public purpose and noises the active proposals/ directory.
+- local-only archive directory under `docs/` — retired/superseded proposals kept locally for the operator's records, not surfaced publicly. The frontmatter banner on the retired doc is sufficient public signal; the body of a rejected proposal serves no public purpose and noises the active proposals/ directory.
 - `docs/handoffs/` — date-stamped session-to-session handoffs. Pinned to their moment by definition; aged-out handoffs only confuse external readers. Specific handoffs may be force-added to the public tree when they crystallize into permanent contracts (e.g., `2026-05-03-r1-implementation-handoff.md`).
-- `docs/INTERNAL_CONFIG.md` — operator-specific configuration not meant for forks.
+- local-only internal configuration file under `docs/` — operator-specific configuration not meant for forks.
 
-Retiring a proposal: move the file to `docs/archive/` (which is gitignored), and `git rm` the public copy. The file stays on the operator's disk; the public repo loses a 400-line RFC that proposes work nobody should implement.
+Retiring a proposal: move the file to the gitignored local archive under `docs/`, and `git rm` the public copy. The file stays on the operator's disk; the public repo loses a 400-line RFC that proposes work nobody should implement.
 
 ## Relationship To Knowledge Storage
 


### PR DESCRIPTION
Fixes the doc-health warnings from the Wave 1 pre-push checks.

What changed:
- Reworded the markdown proliferation policy so gitignored local-only paths are described as local-only working areas instead of backtick-linked public repo refs.
- Kept the policy behavior unchanged: retired proposals and operator config still live outside the public docs tree.

Validation:
- python3 scripts/diagnostics/check_doc_health.py: all clear.
- Pre-push smoke: 138 passed, 7832 deselected; doc health all clear.