### PR TITLE
feat(wave-1): bound Sentinel first-boot backfill

### DIFF
--- a/elixir/sentinel/config/config.exs
+++ b/elixir/sentinel/config/config.exs
@@ -1,5 +1,11 @@
 import Config
 
+first_boot_lookback_seconds =
+  case System.get_env("UNITARES_SENTINEL_FIRST_BOOT_LOOKBACK_SECONDS") do
+    nil -> 7 * 24 * 60 * 60
+    raw -> String.to_integer(raw)
+  end
+
 config :unitares_sentinel,
   database_url:
     System.get_env("UNITARES_SENTINEL_DATABASE_URL") ||
@@ -8,6 +14,7 @@ config :unitares_sentinel,
   pool_size: 2,
   poller_interval_ms: 30_000,
   poller_initial_delay_ms: 1_000,
+  first_boot_lookback_seconds: first_boot_lookback_seconds,
   findings_url: System.get_env("UNITARES_FINDINGS_URL") || "http://localhost:8767/api/findings",
   findings_timeout_ms: 3_000,
   findings_agent_id: System.get_env("UNITARES_SENTINEL_AGENT_ID") || "sentinel",

--- a/elixir/sentinel/lib/unitares_sentinel/forced_release_poller.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/forced_release_poller.ex
@@ -14,6 +14,11 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
   explicit callers; the GenServer is the runtime writer that emits and then
   persists.
 
+  First runtime boot is bounded: if both the in-memory cursor and file cursor
+  are absent, the GenServer polls from `:first_boot_lookback_seconds` ago
+  instead of scanning the full historical `lease_plane_events` table. Explicit
+  `tick(prior_cursor: nil)` calls keep their manual "fetch all" semantics.
+
   ## Phase-B promotion scope
 
   Python feeds `conflict_batch` alarms into `_emit_phase_b_transitions/2`.
@@ -67,7 +72,8 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
           persist: boolean(),
           state_path: Path.t() | nil,
           emit_findings: boolean(),
-          findings_opts: keyword()
+          findings_opts: keyword(),
+          first_boot_lookback_seconds: non_neg_integer()
         ]
 
   # ---- Public tick API --------------------------------------------------
@@ -327,6 +333,13 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
         Application.get_env(:unitares_sentinel, :poller_jitter_ms, 5_000)
       )
 
+    first_boot_lookback_seconds =
+      Keyword.get(
+        opts,
+        :first_boot_lookback_seconds,
+        Application.get_env(:unitares_sentinel, :first_boot_lookback_seconds, 7 * 24 * 60 * 60)
+      )
+
     cursor = load_cursor_from_state()
 
     state = %{
@@ -334,6 +347,7 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
       cursor: cursor,
       interval_ms: interval_ms,
       jitter_ms: jitter_ms,
+      first_boot_lookback_seconds: first_boot_lookback_seconds,
       emit_findings?:
         Keyword.get(
           opts,
@@ -375,7 +389,11 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
     # cursor_repair task) writing the shadow file between ticks; without this,
     # the GenServer would clobber the operator's edit on the next tick.
     file_cursor = load_cursor_from_state()
-    effective_prior = max_cursor(state.cursor, file_cursor)
+
+    effective_prior =
+      state.cursor
+      |> max_cursor(file_cursor)
+      |> apply_first_boot_lookback(state)
 
     {alarms, new_cursor} =
       tick(prior_cursor: effective_prior, db: state.db, persist: false)
@@ -408,6 +426,13 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
   defp max_cursor(%DateTime{} = a, %DateTime{} = b) do
     if DateTime.compare(a, b) == :gt, do: a, else: b
   end
+
+  defp apply_first_boot_lookback(nil, %{first_boot_lookback_seconds: seconds})
+       when is_integer(seconds) and seconds > 0 do
+    DateTime.utc_now() |> DateTime.add(-seconds, :second)
+  end
+
+  defp apply_first_boot_lookback(cursor, _state), do: cursor
 
   defp emit_findings(_alarms, %{emit_findings?: false}), do: :ok
 

--- a/elixir/sentinel/test/unitares_sentinel/forced_release_poller_findings_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/forced_release_poller_findings_test.exs
@@ -93,4 +93,49 @@ defmodule UnitaresSentinel.ForcedReleasePollerFindingsTest do
 
     GenServer.stop(pid)
   end
+
+  test "GenServer first boot bounds nil cursor by lookback window", ctx do
+    parent = self()
+    now = DateTime.utc_now()
+    old_surface = ctx.surface_prefix <> "/old_backfill"
+    new_surface = ctx.surface_prefix <> "/within_lookback"
+
+    {old_event_id, _old_ts} = H.insert_forced_event(old_surface, DateTime.add(now, -120, :second))
+    {new_event_id, _new_ts} = H.insert_forced_event(new_surface, DateTime.add(now, -10, :second))
+
+    http_post = fn _url, body, _headers, _timeout_ms ->
+      cond do
+        body["event_id"] == old_event_id ->
+          send(parent, {:posted_old_backfill, body})
+
+        body["event_id"] == new_event_id ->
+          send(parent, {:posted_within_lookback, body})
+
+        true ->
+          :ok
+      end
+
+      {:ok, 200, ~s({"success":true,"deduped":false})}
+    end
+
+    {:ok, pid} =
+      ForcedReleasePoller.start_link(
+        name: :"test_first_boot_lookback_#{System.unique_integer([:positive])}",
+        db: UnitaresSentinel.DB,
+        interval_ms: 60_000,
+        initial_delay_ms: 60_000,
+        jitter_ms: 0,
+        first_boot_lookback_seconds: 60,
+        emit_findings: true,
+        findings_opts: [http_post: http_post]
+      )
+
+    send(pid, :tick)
+
+    assert_receive {:posted_within_lookback, body}, 2_000
+    assert body["event_id"] == new_event_id
+    refute_receive {:posted_old_backfill, _body}, 200
+
+    GenServer.stop(pid)
+  end
 end


### PR DESCRIPTION
Implements the Wave 1 first-boot lookback bound called out in the RFC.

What changed:
- Adds UNITARES_SENTINEL_FIRST_BOOT_LOOKBACK_SECONDS / :first_boot_lookback_seconds config, defaulting to 7 days.
- Bounds only the GenServer runtime first tick when both memory and file cursors are absent.
- Leaves explicit tick(prior_cursor: nil) calls unchanged, preserving manual/test fetch-all semantics.
- Adds integration coverage proving an old forced-release event outside the lookback is not emitted while a recent event is emitted.

Why:
After the three-class combined poller landed, a nil runtime cursor could scan the entire lease_plane_events history on BEAM first boot. This avoids replay/backfill storms during cutover while keeping an explicit escape hatch through direct tick calls.

Validation:
- mix test in elixir/sentinel: 85 tests, 0 failures.
- python3 scripts/diagnostics/check_doc_health.py: all clear.
- Pre-push smoke: 138 passed, 7832 deselected; doc health all clear.