### PR TITLE
[codex] add Sentinel session anchor boundary

### DIFF
--- a/elixir/sentinel/config/config.exs
+++ b/elixir/sentinel/config/config.exs
@@ -12,6 +12,8 @@ config :unitares_sentinel,
       System.get_env("UNITARES_LEASE_PLANE_DATABASE_URL") ||
       "postgresql://postgres:postgres@localhost:5432/governance",
   pool_size: 2,
+  session_file_path: System.get_env("UNITARES_SENTINEL_SESSION_FILE"),
+  legacy_session_file_path: System.get_env("UNITARES_SENTINEL_LEGACY_SESSION_FILE"),
   poller_interval_ms: 30_000,
   poller_initial_delay_ms: 1_000,
   poller_tick_timeout_ms: 30_000,

--- a/elixir/sentinel/lib/mix/tasks/sentinel.session_backup.ex
+++ b/elixir/sentinel/lib/mix/tasks/sentinel.session_backup.ex
@@ -1,0 +1,68 @@
+defmodule Mix.Tasks.Sentinel.SessionBackup do
+  @moduledoc """
+  Back up the Sentinel governance identity anchor before BEAM cutover.
+
+  ## Usage
+
+      mix sentinel.session_backup
+      mix sentinel.session_backup --session-file /path/to/sentinel.json
+      mix sentinel.session_backup --backup-file /path/to/sentinel.json.pre-beam
+      mix sentinel.session_backup --legacy-session-file /repo/.sentinel_session
+      mix sentinel.session_backup --force
+
+  The backup is the binding Surface 5 cutover step:
+  `sentinel.json` → `sentinel.json.pre-beam`.
+  """
+
+  use Mix.Task
+
+  alias UnitaresSentinel.SessionAnchor
+
+  @shortdoc "Back up Sentinel session anchor before BEAM cutover"
+
+  @impl Mix.Task
+  def run(args) do
+    opts = parse!(args)
+
+    case SessionAnchor.backup_for_cutover(opts) do
+      {:ok, result} ->
+        Mix.shell().info("sentinel.session_backup: ok")
+        Mix.shell().info("source:     #{result.source}")
+        Mix.shell().info("backup:     #{result.backup}")
+        Mix.shell().info("agent_uuid: #{result.agent_uuid}")
+
+      {:error, {:backup_exists, path}} ->
+        Mix.raise(
+          "sentinel.session_backup: backup already exists at #{path}; pass --force to overwrite"
+        )
+
+      {:error, reason} ->
+        Mix.raise("sentinel.session_backup: #{inspect(reason)}")
+    end
+  end
+
+  defp parse!(args) do
+    {opts, rest, invalid} =
+      OptionParser.parse(args,
+        strict: [
+          session_file: :string,
+          backup_file: :string,
+          legacy_session_file: :string,
+          force: :boolean
+        ]
+      )
+
+    if rest != [] or invalid != [] do
+      Mix.raise("sentinel.session_backup: invalid arguments")
+    end
+
+    []
+    |> maybe_put(:path, opts[:session_file])
+    |> maybe_put(:backup_path, opts[:backup_file])
+    |> maybe_put(:legacy_path, opts[:legacy_session_file])
+    |> Keyword.put(:force, opts[:force] == true)
+  end
+
+  defp maybe_put(opts, _key, nil), do: opts
+  defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
+end

--- a/elixir/sentinel/lib/unitares_sentinel.ex
+++ b/elixir/sentinel/lib/unitares_sentinel.ex
@@ -24,8 +24,9 @@ defmodule UnitaresSentinel do
 
   This module + its `Application` supervisor are the minimum scaffold per
   the §Bootstrap spec (B5 reviewer fold). The cycle worker, Surface 2
-  forced-release alarm findings client, and Surface 3 lease-advisory wrapper
-  are wired; WebSocket ingester and full fleet `sentinel_finding` parity land
-  in follow-up PRs.
+  forced-release alarm findings client, Surface 3 lease-advisory wrapper,
+  Surface 4 runtime timeout, and Surface 5 session anchor reader/backup
+  boundary are wired; WebSocket ingester and full fleet `sentinel_finding`
+  parity land in follow-up PRs.
   """
 end

--- a/elixir/sentinel/lib/unitares_sentinel/session_anchor.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/session_anchor.ex
@@ -1,0 +1,220 @@
+defmodule UnitaresSentinel.SessionAnchor do
+  @moduledoc """
+  Python-compatible Sentinel governance identity anchor.
+
+  Surface 5 of Wave 1. Python `SentinelAgent` passes
+  `~/.unitares/anchors/sentinel.json` to `GovernanceAgent`, whose live
+  contract is:
+
+    * migrate from legacy `.sentinel_session` if the host anchor is missing;
+    * read `agent_uuid`, optional `continuity_token`, and optional
+      `client_session_id`;
+    * preserve the JSON object shape so rollback to Python can resume.
+
+  This module is intentionally conservative: it can read, migrate, validate,
+  derive future REST resume payloads, and create the required `.pre-beam`
+  cutover backup. It does not mint identities.
+  """
+
+  alias UnitaresSentinel.AtomicWrite
+
+  @agent_uuid_key "agent_uuid"
+  @continuity_token_key "continuity_token"
+  @client_session_id_key "client_session_id"
+  @default_agent_name "Sentinel"
+
+  @type t :: %{String.t() => term()}
+  @type load_error ::
+          :missing_anchor
+          | :empty_anchor
+          | {:invalid_json, term()}
+          | :anchor_not_object
+          | :missing_agent_uuid
+          | {:invalid_field, String.t()}
+
+  @doc """
+  Load the Sentinel session anchor, migrating the legacy project-local anchor
+  first when needed.
+
+  Options:
+    * `:path` — explicit `sentinel.json` path
+    * `:legacy_path` — explicit legacy `.sentinel_session` path
+  """
+  @spec load(keyword()) :: {:ok, t()} | {:error, load_error()}
+  def load(opts \\ []) do
+    path = Keyword.get(opts, :path) || resolve_path()
+    legacy_path = Keyword.get(opts, :legacy_path) || resolve_legacy_path()
+
+    maybe_migrate_legacy(path, legacy_path)
+
+    path
+    |> read_json_object()
+    |> validate()
+  end
+
+  @doc """
+  Same as `load/1`, but raises on invalid or missing anchors.
+  """
+  @spec load!(keyword()) :: t()
+  def load!(opts \\ []) do
+    case load(opts) do
+      {:ok, anchor} ->
+        anchor
+
+      {:error, reason} ->
+        raise ArgumentError, "invalid Sentinel session anchor: #{inspect(reason)}"
+    end
+  end
+
+  @doc """
+  Build the future REST identity resume payload from a loaded anchor.
+
+  Optional fields are included only when present, matching Python
+  `_ensure_identity/1` and `GovernanceClient` injection behavior.
+  """
+  @spec resume_payload(t(), keyword()) :: map()
+  def resume_payload(anchor, opts \\ []) when is_map(anchor) do
+    %{
+      "name" => Keyword.get(opts, :name, @default_agent_name),
+      "agent_uuid" => Map.fetch!(anchor, @agent_uuid_key),
+      "resume" => true
+    }
+    |> put_optional(@continuity_token_key, Map.get(anchor, @continuity_token_key))
+    |> put_optional(@client_session_id_key, Map.get(anchor, @client_session_id_key))
+  end
+
+  @doc """
+  Create the binding pre-BEAM backup for direct identity cutover.
+
+  Defaults to `<sentinel.json>.pre-beam`. The source anchor is validated
+  before copy, and the destination is written atomically with mode 0600.
+  """
+  @spec backup_for_cutover(keyword()) ::
+          {:ok, %{source: Path.t(), backup: Path.t(), agent_uuid: String.t()}}
+          | {:error, term()}
+  def backup_for_cutover(opts \\ []) do
+    path = Keyword.get(opts, :path) || resolve_path()
+    backup_path = Keyword.get(opts, :backup_path) || path <> ".pre-beam"
+    force? = Keyword.get(opts, :force, false)
+
+    with {:ok, anchor} <- load(opts),
+         :ok <- ensure_backup_target(backup_path, force?),
+         {:ok, bytes} <- File.read(path),
+         :ok <- AtomicWrite.write(backup_path, bytes) do
+      {:ok, %{source: path, backup: backup_path, agent_uuid: Map.fetch!(anchor, @agent_uuid_key)}}
+    else
+      {:error, _} = err -> err
+      other -> {:error, other}
+    end
+  end
+
+  @doc """
+  Resolve the host-scoped Sentinel session anchor.
+
+  Config/env order:
+    1. `:unitares_sentinel, :session_file_path`
+    2. `UNITARES_SENTINEL_SESSION_FILE`
+    3. `<home>/.unitares/anchors/sentinel.json`
+
+  Uses `System.user_home/0` instead of `Path.expand("~")` so launchd
+  environments without `HOME` still resolve through Erlang's user-home
+  lookup when available.
+  """
+  @spec resolve_path() :: Path.t()
+  def resolve_path do
+    Application.get_env(:unitares_sentinel, :session_file_path) ||
+      System.get_env("UNITARES_SENTINEL_SESSION_FILE") ||
+      Path.join([user_home!(), ".unitares", "anchors", "sentinel.json"])
+  end
+
+  @doc """
+  Resolve Python Sentinel's legacy project-local `.sentinel_session` path.
+  """
+  @spec resolve_legacy_path() :: Path.t()
+  def resolve_legacy_path do
+    Application.get_env(:unitares_sentinel, :legacy_session_file_path) ||
+      System.get_env("UNITARES_SENTINEL_LEGACY_SESSION_FILE") ||
+      Path.expand(Path.join([__DIR__, "..", "..", "..", "..", ".sentinel_session"]))
+  end
+
+  defp maybe_migrate_legacy(path, legacy_path) do
+    if not File.exists?(path) and File.exists?(legacy_path) do
+      case read_json_object(legacy_path) do
+        {:ok, legacy} when map_size(legacy) > 0 ->
+          File.mkdir_p!(Path.dirname(path))
+          AtomicWrite.write(path, Jason.encode!(legacy))
+
+        _ ->
+          :ok
+      end
+    end
+
+    :ok
+  rescue
+    _ -> :ok
+  end
+
+  defp read_json_object(path) do
+    case File.read(path) do
+      {:ok, ""} ->
+        {:error, :empty_anchor}
+
+      {:ok, contents} ->
+        case Jason.decode(contents) do
+          {:ok, %{} = decoded} -> {:ok, decoded}
+          {:ok, _} -> {:error, :anchor_not_object}
+          {:error, reason} -> {:error, {:invalid_json, reason}}
+        end
+
+      {:error, :enoent} ->
+        {:error, :missing_anchor}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp validate({:error, reason}), do: {:error, reason}
+
+  defp validate({:ok, anchor}) do
+    cond do
+      not non_empty_binary?(Map.get(anchor, @agent_uuid_key)) ->
+        {:error, :missing_agent_uuid}
+
+      invalid_optional?(anchor, @continuity_token_key) ->
+        {:error, {:invalid_field, @continuity_token_key}}
+
+      invalid_optional?(anchor, @client_session_id_key) ->
+        {:error, {:invalid_field, @client_session_id_key}}
+
+      true ->
+        {:ok, anchor}
+    end
+  end
+
+  defp ensure_backup_target(path, false) do
+    if File.exists?(path), do: {:error, {:backup_exists, path}}, else: :ok
+  end
+
+  defp ensure_backup_target(_path, true), do: :ok
+
+  defp put_optional(payload, _key, nil), do: payload
+  defp put_optional(payload, _key, ""), do: payload
+  defp put_optional(payload, key, value) when is_binary(value), do: Map.put(payload, key, value)
+
+  defp invalid_optional?(anchor, key) do
+    case Map.get(anchor, key) do
+      nil -> false
+      value -> not non_empty_binary?(value)
+    end
+  end
+
+  defp non_empty_binary?(value), do: is_binary(value) and String.trim(value) != ""
+
+  defp user_home! do
+    case System.user_home() do
+      home when is_binary(home) and home != "" -> home
+      _ -> raise "could not resolve user home for Sentinel session anchor"
+    end
+  end
+end

--- a/elixir/sentinel/test/unitares_sentinel/session_anchor_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/session_anchor_test.exs
@@ -1,0 +1,154 @@
+defmodule UnitaresSentinel.SessionAnchorTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  alias UnitaresSentinel.SessionAnchor
+
+  @agent_uuid "11111111-1111-1111-1111-111111111111"
+  @continuity_token "v1.test-token"
+  @client_session_id "session-test"
+
+  setup do
+    tmpdir =
+      System.tmp_dir!()
+      |> Path.join("unitares_sentinel_session_anchor_test_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmpdir)
+
+    on_exit(fn ->
+      Mix.Task.clear()
+      File.rm_rf!(tmpdir)
+    end)
+
+    {:ok,
+     tmpdir: tmpdir,
+     session: Path.join(tmpdir, "sentinel.json"),
+     legacy: Path.join(tmpdir, ".sentinel_session")}
+  end
+
+  test "load reads Python anchor fields and preserves unknown metadata", ctx do
+    write_json!(ctx.session, %{
+      "agent_uuid" => @agent_uuid,
+      "continuity_token" => @continuity_token,
+      "client_session_id" => @client_session_id,
+      "runtime" => "python",
+      "extra" => %{"preserve" => true}
+    })
+
+    assert {:ok, anchor} = SessionAnchor.load(path: ctx.session, legacy_path: ctx.legacy)
+
+    assert anchor["agent_uuid"] == @agent_uuid
+    assert anchor["continuity_token"] == @continuity_token
+    assert anchor["client_session_id"] == @client_session_id
+    assert anchor["runtime"] == "python"
+    assert anchor["extra"] == %{"preserve" => true}
+
+    assert SessionAnchor.resume_payload(anchor) == %{
+             "name" => "Sentinel",
+             "agent_uuid" => @agent_uuid,
+             "continuity_token" => @continuity_token,
+             "client_session_id" => @client_session_id,
+             "resume" => true
+           }
+  end
+
+  test "continuity token is optional for Python-compatible UDS anchors", ctx do
+    write_json!(ctx.session, %{"agent_uuid" => @agent_uuid})
+
+    assert {:ok, anchor} = SessionAnchor.load(path: ctx.session, legacy_path: ctx.legacy)
+
+    assert SessionAnchor.resume_payload(anchor) == %{
+             "name" => "Sentinel",
+             "agent_uuid" => @agent_uuid,
+             "resume" => true
+           }
+  end
+
+  test "load rejects anchors without agent_uuid", ctx do
+    write_json!(ctx.session, %{"continuity_token" => @continuity_token})
+
+    assert {:error, :missing_agent_uuid} =
+             SessionAnchor.load(path: ctx.session, legacy_path: ctx.legacy)
+  end
+
+  test "load migrates legacy project-local session when host anchor is missing", ctx do
+    write_json!(ctx.legacy, %{
+      "agent_uuid" => @agent_uuid,
+      "continuity_token" => @continuity_token,
+      "legacy_only" => true
+    })
+
+    assert {:ok, anchor} = SessionAnchor.load(path: ctx.session, legacy_path: ctx.legacy)
+    assert anchor["legacy_only"] == true
+
+    assert ctx.session |> File.read!() |> Jason.decode!() == %{
+             "agent_uuid" => @agent_uuid,
+             "continuity_token" => @continuity_token,
+             "legacy_only" => true
+           }
+  end
+
+  test "backup_for_cutover validates and writes pre-beam backup with 0600 mode", ctx do
+    write_json!(ctx.session, %{
+      "agent_uuid" => @agent_uuid,
+      "continuity_token" => @continuity_token
+    })
+
+    assert {:ok, result} =
+             SessionAnchor.backup_for_cutover(path: ctx.session, legacy_path: ctx.legacy)
+
+    assert result.source == ctx.session
+    assert result.backup == ctx.session <> ".pre-beam"
+    assert result.agent_uuid == @agent_uuid
+    assert File.read!(result.backup) == File.read!(ctx.session)
+
+    stat = File.stat!(result.backup)
+    assert Bitwise.band(stat.mode, 0o777) == 0o600
+  end
+
+  test "backup_for_cutover refuses to overwrite unless forced", ctx do
+    write_json!(ctx.session, %{"agent_uuid" => @agent_uuid})
+    File.write!(ctx.session <> ".pre-beam", "old")
+
+    assert {:error, {:backup_exists, _path}} =
+             SessionAnchor.backup_for_cutover(path: ctx.session, legacy_path: ctx.legacy)
+
+    assert {:ok, _result} =
+             SessionAnchor.backup_for_cutover(
+               path: ctx.session,
+               legacy_path: ctx.legacy,
+               force: true
+             )
+
+    assert File.read!(ctx.session <> ".pre-beam") == File.read!(ctx.session)
+  end
+
+  test "mix sentinel.session_backup reports identity summary without token", ctx do
+    write_json!(ctx.session, %{
+      "agent_uuid" => @agent_uuid,
+      "continuity_token" => @continuity_token
+    })
+
+    output =
+      capture_io(fn ->
+        Mix.Task.run("sentinel.session_backup", [
+          "--session-file",
+          ctx.session,
+          "--legacy-session-file",
+          ctx.legacy
+        ])
+      end)
+
+    assert output =~ "sentinel.session_backup: ok"
+    assert output =~ "source:     #{ctx.session}"
+    assert output =~ "backup:     #{ctx.session}.pre-beam"
+    assert output =~ "agent_uuid: #{@agent_uuid}"
+    refute output =~ @continuity_token
+  end
+
+  defp write_json!(path, map) do
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, Jason.encode!(map))
+  end
+end


### PR DESCRIPTION
## Summary

Adds the Wave 1 Surface 5 Sentinel session-anchor boundary.

The new `UnitaresSentinel.SessionAnchor` module mirrors the live Python `GovernanceAgent` session contract for `~/.unitares/anchors/sentinel.json`: it migrates from legacy `.sentinel_session` when needed, reads `agent_uuid`, optional `continuity_token`, and optional `client_session_id`, preserves unknown JSON fields, and can derive the future REST identity resume payload without minting a new identity.

The PR also adds `mix sentinel.session_backup`, which performs the binding direct-cutover backup step by validating `sentinel.json` and writing `sentinel.json.pre-beam` atomically with mode `0600`.

## Validation

- `mix test` in `elixir/sentinel` — 100 tests, 0 failures
- pre-push smoke — 138 passed, 7832 deselected
- `python3 scripts/diagnostics/check_doc_health.py` — all clear
