### PR TITLE
feat(wave-1): add Sentinel fleet analysis findings

### DIFF
--- a/elixir/sentinel/lib/unitares_sentinel.ex
+++ b/elixir/sentinel/lib/unitares_sentinel.ex
@@ -27,7 +27,7 @@ defmodule UnitaresSentinel do
   cycle worker, Surface 2
   forced-release alarm findings client, Surface 3 lease-advisory wrapper,
   Surface 4 runtime timeout, and Surface 5 session anchor reader/backup
-  boundary are wired; full fleet `sentinel_finding` parity lands in follow-up
-  PRs.
+  boundary and fleet-analysis finding reducer are wired; full runtime
+  `sentinel_finding` emission parity lands in follow-up PRs.
   """
 end

--- a/elixir/sentinel/lib/unitares_sentinel/findings.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/findings.ex
@@ -29,6 +29,16 @@ defmodule UnitaresSentinel.Findings do
     |> post_json(opts)
   end
 
+  @doc """
+  POST one fleet analysis finding as a `sentinel_finding` event.
+  """
+  @spec post_finding(map(), keyword()) :: boolean()
+  def post_finding(finding, opts \\ []) when is_map(finding) do
+    finding
+    |> finding_body(opts)
+    |> post_json(opts)
+  end
+
   @doc false
   @spec alarm_body(UnitaresSentinel.ForcedReleasePoller.Logic.alarm(), keyword()) :: map()
   def alarm_body(alarm, opts \\ []) when is_map(alarm) do
@@ -46,6 +56,36 @@ defmodule UnitaresSentinel.Findings do
     |> Map.get(:extra, %{})
     |> stringify_keys()
     |> Map.merge(base, fn _key, _extra_value, base_value -> base_value end)
+  end
+
+  @doc false
+  @spec finding_body(map(), keyword()) :: map()
+  def finding_body(finding, opts \\ []) when is_map(finding) do
+    finding_type = map_fetch!(finding, :type)
+    violation_class = map_get(finding, :violation_class, "")
+    agent_id = agent_id(opts)
+
+    %{
+      "type" => Keyword.get(opts, :event_type, "sentinel_finding"),
+      "severity" => map_fetch!(finding, :severity),
+      "message" => map_fetch!(finding, :summary),
+      "agent_id" => agent_id,
+      "agent_name" => agent_name(opts),
+      "fingerprint" => compute_fingerprint(["sentinel", finding_type, violation_class, agent_id]),
+      "violation_class" => violation_class,
+      "finding_type" => finding_type
+    }
+  end
+
+  @doc false
+  @spec compute_fingerprint(Enumerable.t()) :: String.t()
+  def compute_fingerprint(parts) do
+    parts
+    |> Enum.map(&to_string/1)
+    |> Enum.join("|")
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.encode16(case: :lower)
+    |> binary_part(0, 16)
   end
 
   @doc false
@@ -134,5 +174,15 @@ defmodule UnitaresSentinel.Findings do
       {key, value} when is_atom(key) -> {Atom.to_string(key), value}
       {key, value} when is_binary(key) -> {key, value}
     end)
+  end
+
+  defp map_fetch!(map, key) when is_atom(key) do
+    Map.fetch!(map, key)
+  rescue
+    KeyError -> Map.fetch!(map, Atom.to_string(key))
+  end
+
+  defp map_get(map, key, default) when is_atom(key) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key), default)
   end
 end

--- a/elixir/sentinel/lib/unitares_sentinel/fleet_analysis.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/fleet_analysis.ex
@@ -1,0 +1,262 @@
+defmodule UnitaresSentinel.FleetAnalysis do
+  @moduledoc """
+  Pure fleet finding reducer for BEAM Sentinel.
+
+  Ports the Python Sentinel's `FleetState.analyze/1` rules onto the BEAM
+  `FleetState` snapshot without performing notifications, check-ins, or HTTP
+  emission.
+  """
+
+  alias UnitaresSentinel.FleetState
+  alias UnitaresSentinel.FleetState.AgentSnapshot
+
+  @coherence_drop_threshold 0.15
+  @coordinated_window_ms 10 * 60 * 1_000
+  @coordinated_min_agents 2
+  @entropy_sigma 2.0
+  @entropy_window_ms 60 * 60 * 1_000
+  @verdict_shift_min_observations 5
+  @verdict_shift_pause_rate 0.20
+  @typed_event_prefixes ["lifecycle_", "circuit_breaker_", "identity_", "knowledge_"]
+
+  @doc """
+  Analyze a FleetState reducer or snapshot and return Sentinel finding maps.
+  """
+  def analyze(state_or_snapshot, opts \\ [])
+
+  def analyze(%FleetState{} = state, opts) do
+    state
+    |> FleetState.snapshot_state()
+    |> analyze(opts)
+  end
+
+  def analyze(%{agents: agents, events: events}, opts) when is_map(agents) and is_list(events) do
+    now_ms = Keyword.get(opts, :now_ms, System.system_time(:millisecond))
+    self_agent_id = Keyword.get(opts, :self_agent_id, "")
+
+    []
+    |> Kernel.++(coordinated_degradation(agents, now_ms))
+    |> Kernel.++(entropy_outliers(agents, now_ms, self_agent_id))
+    |> Kernel.++(verdict_shift(agents, now_ms))
+    |> Kernel.++(correlated_events(events, now_ms))
+  end
+
+  defp coordinated_degradation(agents, now_ms) do
+    degraded =
+      agents
+      |> Enum.reject(fn {_agent_id, snapshot} ->
+        now_ms - snapshot.last_seen_ms > @coordinated_window_ms * 2
+      end)
+      |> Enum.map(fn {agent_id, snapshot} ->
+        {agent_id, snapshot.name, coherence_drop(snapshot, now_ms, @coordinated_window_ms)}
+      end)
+      |> Enum.filter(fn {_agent_id, _name, drop} -> drop >= @coherence_drop_threshold end)
+
+    if length(degraded) >= @coordinated_min_agents do
+      agents_str =
+        Enum.map_join(degraded, ", ", fn {agent_id, name, drop} ->
+          "#{display_name(agent_id, name)}(-#{format_float(drop, 2)})"
+        end)
+
+      [
+        %{
+          type: "coordinated_degradation",
+          violation_class: "CON",
+          severity: "high",
+          summary: "Coordinated coherence drop: #{agents_str}",
+          agents: Enum.map(degraded, fn {agent_id, _name, _drop} -> agent_id end),
+          details:
+            Map.new(degraded, fn {agent_id, _name, drop} ->
+              {agent_id, Float.round(drop * 1.0, 3)}
+            end)
+        }
+      ]
+    else
+      []
+    end
+  end
+
+  defp entropy_outliers(agents, now_ms, self_agent_id) do
+    entropies =
+      agents
+      |> Enum.reject(fn {_agent_id, snapshot} ->
+        now_ms - snapshot.last_seen_ms > @entropy_window_ms
+      end)
+      |> Enum.map(fn {agent_id, snapshot} ->
+        {agent_id, snapshot.name, mean_entropy(snapshot, now_ms, @entropy_window_ms)}
+      end)
+      |> Enum.filter(fn {_agent_id, _name, entropy} -> entropy > 0 end)
+
+    if length(entropies) >= 3 do
+      values = Enum.map(entropies, fn {_agent_id, _name, entropy} -> entropy end)
+      mean = Enum.sum(values) / length(values)
+      std = sample_std(values, mean)
+
+      if std > 0 do
+        entropies
+        |> Enum.map(fn {agent_id, name, entropy} ->
+          {agent_id, name, entropy, (entropy - mean) / std}
+        end)
+        |> Enum.filter(fn {_agent_id, _name, _entropy, z} -> z >= @entropy_sigma end)
+        |> Enum.map(fn {agent_id, name, entropy, z} ->
+          self_observation? = agent_id == self_agent_id
+
+          %{
+            type: "entropy_outlier",
+            violation_class: "ENT",
+            severity: if(self_observation?, do: "info", else: "medium"),
+            summary:
+              "#{display_name(agent_id, name)} entropy outlier (z=#{format_float(z, 1)}, S=#{format_float(entropy, 3)})",
+            agents: [agent_id],
+            self_observation: self_observation?
+          }
+        end)
+      else
+        []
+      end
+    else
+      []
+    end
+  end
+
+  defp verdict_shift(agents, now_ms) do
+    recent_verdicts =
+      agents
+      |> Enum.reject(fn {_agent_id, snapshot} ->
+        now_ms - snapshot.last_seen_ms > @coordinated_window_ms
+      end)
+      |> Enum.flat_map(fn {_agent_id, snapshot} ->
+        snapshot.eisv_history
+        |> Enum.filter(fn history -> history.ts_ms >= now_ms - @coordinated_window_ms end)
+        |> Enum.map(& &1.verdict)
+      end)
+
+    if length(recent_verdicts) >= @verdict_shift_min_observations do
+      pause_count = Enum.count(recent_verdicts, &(&1 in ["pause", "reject"]))
+      pause_rate = pause_count / length(recent_verdicts)
+
+      if pause_rate >= @verdict_shift_pause_rate do
+        [
+          %{
+            type: "verdict_shift",
+            violation_class: "ENT",
+            severity: "high",
+            summary:
+              "Pause rate #{round(pause_rate * 100)}% in last #{div(@coordinated_window_ms, 60_000)}min (#{pause_count}/#{length(recent_verdicts)})",
+            details: %{pause_rate: Float.round(pause_rate * 1.0, 3), pause_count: pause_count}
+          }
+        ]
+      else
+        []
+      end
+    else
+      []
+    end
+  end
+
+  defp correlated_events(events, now_ms) do
+    recent_typed =
+      events
+      |> Enum.filter(&typed_event?/1)
+      |> Enum.filter(&(event_age_ms(&1, now_ms) < @coordinated_window_ms))
+
+    if length(recent_typed) >= 3 do
+      event_types =
+        recent_typed
+        |> Enum.map(&string_value(&1, "type"))
+        |> Enum.uniq()
+        |> Enum.sort()
+
+      if length(event_types) >= 2 do
+        [
+          %{
+            type: "correlated_events",
+            violation_class: "BEH",
+            severity: "medium",
+            summary:
+              "#{length(recent_typed)} governance events in #{div(@coordinated_window_ms, 60_000)}min: #{Enum.join(event_types, ", ")}",
+            details: %{event_types: event_types, count: length(recent_typed)}
+          }
+        ]
+      else
+        []
+      end
+    else
+      []
+    end
+  end
+
+  defp coherence_drop(%AgentSnapshot{} = snapshot, now_ms, window_ms) do
+    recent =
+      Enum.filter(snapshot.eisv_history, fn history ->
+        history.ts_ms >= now_ms - window_ms
+      end)
+
+    if length(recent) >= 2 do
+      List.first(recent).coherence - List.last(recent).coherence
+    else
+      0.0
+    end
+  end
+
+  defp mean_entropy(%AgentSnapshot{} = snapshot, now_ms, window_ms) do
+    values =
+      snapshot.eisv_history
+      |> Enum.filter(fn history -> history.ts_ms >= now_ms - window_ms end)
+      |> Enum.map(&Map.fetch!(&1, :S))
+
+    if values == [] do
+      0.0
+    else
+      Enum.sum(values) / length(values)
+    end
+  end
+
+  defp sample_std([_value], _mean), do: 0.0
+
+  defp sample_std(values, mean) do
+    variance =
+      values
+      |> Enum.map(fn value -> :math.pow(value - mean, 2) end)
+      |> Enum.sum()
+      |> Kernel./(length(values) - 1)
+
+    :math.sqrt(variance)
+  end
+
+  defp typed_event?(event) do
+    event_type = string_value(event, "type")
+    Enum.any?(@typed_event_prefixes, &String.starts_with?(event_type, &1))
+  end
+
+  defp event_age_ms(event, now_ms) do
+    with timestamp when timestamp != "" <- string_value(event, "timestamp"),
+         {:ok, datetime, _offset} <- DateTime.from_iso8601(timestamp) do
+      now_ms - DateTime.to_unix(datetime, :millisecond)
+    else
+      _ -> :infinity
+    end
+  end
+
+  defp display_name(_agent_id, name) when is_binary(name) and name != "", do: name
+  defp display_name(agent_id, _name), do: String.slice(agent_id, 0, 8)
+
+  defp format_float(value, decimals) do
+    :erlang.float_to_binary(value * 1.0, decimals: decimals)
+  end
+
+  defp string_value(map, key, default \\ "")
+
+  defp string_value(map, key, default) do
+    case value(map, key) do
+      nil -> default
+      "" -> default
+      value when is_binary(value) -> value
+      value -> to_string(value)
+    end
+  end
+
+  defp value(map, key) when is_map(map) do
+    Map.get(map, key) || Map.get(map, String.to_atom(key))
+  end
+end

--- a/elixir/sentinel/test/unitares_sentinel/findings_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/findings_test.exs
@@ -34,6 +34,54 @@ defmodule UnitaresSentinel.FindingsTest do
     assert body["surface_kind"] == "dialectic"
   end
 
+  test "finding_body mirrors Python sentinel_finding shape and fingerprint" do
+    body =
+      Findings.finding_body(
+        %{
+          type: "coordinated_degradation",
+          violation_class: "BEH",
+          severity: "high",
+          summary: "3 agents drifting in lockstep"
+        },
+        agent_id: "sentinel-test-uuid",
+        agent_name: "Sentinel"
+      )
+
+    assert body["type"] == "sentinel_finding"
+    assert body["severity"] == "high"
+    assert body["message"] == "3 agents drifting in lockstep"
+    assert body["agent_id"] == "sentinel-test-uuid"
+    assert body["agent_name"] == "Sentinel"
+    assert body["violation_class"] == "BEH"
+    assert body["finding_type"] == "coordinated_degradation"
+    assert body["fingerprint"] == "da9b8e957ab6971e"
+  end
+
+  test "post_finding returns true only for accepted non-deduped response" do
+    http_post = fn url, body, headers, timeout_ms ->
+      assert url == "http://example.test/api/findings"
+      assert body["type"] == "sentinel_finding"
+      assert body["finding_type"] == "verdict_shift"
+      assert {"Content-Type", "application/json"} in headers
+      assert timeout_ms == 123
+
+      {:ok, 200, ~s({"success":true,"deduped":false})}
+    end
+
+    assert Findings.post_finding(
+             %{
+               type: "verdict_shift",
+               violation_class: "ENT",
+               severity: "high",
+               summary: "Pause rate 40% in last 10min (2/5)"
+             },
+             url: "http://example.test/api/findings",
+             timeout_ms: 123,
+             agent_id: "sentinel-test-uuid",
+             http_post: http_post
+           )
+  end
+
   test "post_alarm returns true only for accepted non-deduped response" do
     http_post = fn url, body, headers, timeout_ms ->
       assert url == "http://example.test/api/findings"

--- a/elixir/sentinel/test/unitares_sentinel/fleet_analysis_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/fleet_analysis_test.exs
@@ -1,0 +1,123 @@
+defmodule UnitaresSentinel.FleetAnalysisTest do
+  use ExUnit.Case, async: true
+
+  alias UnitaresSentinel.FleetAnalysis
+  alias UnitaresSentinel.FleetState
+
+  @now_ms 1_776_512_400_000
+
+  test "detects coordinated coherence drops across active agents" do
+    state =
+      FleetState.new()
+      |> ingest_eisv(@now_ms - 300_000, "agent-a", "Agent A", 0.9, 0.2, "proceed")
+      |> ingest_eisv(@now_ms, "agent-a", "Agent A", 0.7, 0.2, "guide")
+      |> ingest_eisv(@now_ms - 300_000, "agent-b", "Agent B", 0.8, 0.3, "proceed")
+      |> ingest_eisv(@now_ms, "agent-b", "Agent B", 0.6, 0.3, "guide")
+
+    assert [
+             %{
+               type: "coordinated_degradation",
+               violation_class: "CON",
+               severity: "high",
+               agents: ["agent-a", "agent-b"],
+               details: %{"agent-a" => 0.2, "agent-b" => 0.2}
+             } = finding
+           ] = FleetAnalysis.analyze(state, now_ms: @now_ms)
+
+    assert finding.summary == "Coordinated coherence drop: Agent A(-0.20), Agent B(-0.20)"
+  end
+
+  test "detects entropy outliers and tags self observations" do
+    state =
+      Enum.reduce(1..9, FleetState.new(), fn index, state ->
+        ingest_eisv(state, @now_ms, "agent-#{index}", "Agent #{index}", 0.9, 0.1, "proceed")
+      end)
+      |> ingest_eisv(@now_ms, "self-agent", "Sentinel", 0.9, 1.0, "proceed")
+
+    findings = FleetAnalysis.analyze(state, now_ms: @now_ms, self_agent_id: "self-agent")
+
+    assert [
+             %{
+               type: "entropy_outlier",
+               violation_class: "ENT",
+               severity: "info",
+               agents: ["self-agent"],
+               self_observation: true
+             } = finding
+           ] = findings
+
+    assert finding.summary == "Sentinel entropy outlier (z=2.8, S=1.000)"
+  end
+
+  test "detects verdict distribution shifts from recent pause and reject verdicts" do
+    state =
+      FleetState.new()
+      |> ingest_eisv(@now_ms - 240_000, "agent-a", "Agent A", 0.9, 0.2, "proceed")
+      |> ingest_eisv(@now_ms - 180_000, "agent-a", "Agent A", 0.9, 0.2, "proceed")
+      |> ingest_eisv(@now_ms - 120_000, "agent-a", "Agent A", 0.9, 0.2, "guide")
+      |> ingest_eisv(@now_ms - 60_000, "agent-a", "Agent A", 0.9, 0.2, "pause")
+      |> ingest_eisv(@now_ms, "agent-a", "Agent A", 0.9, 0.2, "reject")
+
+    assert [
+             %{
+               type: "verdict_shift",
+               violation_class: "ENT",
+               severity: "high",
+               details: %{pause_count: 2, pause_rate: 0.4},
+               summary: "Pause rate 40% in last 10min (2/5)"
+             }
+           ] = FleetAnalysis.analyze(state, now_ms: @now_ms)
+  end
+
+  test "detects correlated typed governance events" do
+    now = DateTime.from_unix!(@now_ms, :millisecond)
+
+    state =
+      FleetState.new(event_window_size: 5)
+      |> ingest_event(%{
+        "type" => "lifecycle_paused",
+        "agent_id" => "agent-a",
+        "timestamp" => DateTime.to_iso8601(DateTime.add(now, -120, :second))
+      })
+      |> ingest_event(%{
+        "type" => "identity_drift",
+        "agent_id" => "agent-b",
+        "timestamp" => DateTime.to_iso8601(DateTime.add(now, -60, :second))
+      })
+      |> ingest_event(%{
+        "type" => "lifecycle_resumed",
+        "agent_id" => "agent-a",
+        "timestamp" => DateTime.to_iso8601(now)
+      })
+
+    assert [
+             %{
+               type: "correlated_events",
+               violation_class: "BEH",
+               severity: "medium",
+               details: %{
+                 event_types: ["identity_drift", "lifecycle_paused", "lifecycle_resumed"],
+                 count: 3
+               }
+             } = finding
+           ] = FleetAnalysis.analyze(state, now_ms: @now_ms)
+
+    assert finding.summary ==
+             "3 governance events in 10min: identity_drift, lifecycle_paused, lifecycle_resumed"
+  end
+
+  defp ingest_eisv(state, now_ms, agent_id, agent_name, coherence, entropy, verdict) do
+    state
+    |> Map.put(:clock, fn :millisecond -> now_ms end)
+    |> FleetState.ingest_event(%{
+      "type" => "eisv_update",
+      "agent_id" => agent_id,
+      "agent_name" => agent_name,
+      "eisv" => %{"E" => 0.2, "I" => 0.3, "S" => entropy, "V" => 0.4},
+      "coherence" => coherence,
+      "decision" => %{"action" => verdict}
+    })
+  end
+
+  defp ingest_event(state, event), do: FleetState.ingest_event(state, event)
+end


### PR DESCRIPTION
## Summary

- add pure BEAM `FleetAnalysis.analyze/2` for Python Sentinel parity finding classes:
  - `coordinated_degradation`
  - `entropy_outlier`
  - `verdict_shift`
  - `correlated_events`
- add `Findings.finding_body/2` and `post_finding/2` for `sentinel_finding` event bodies
- add SHA-256 16-hex fingerprint parity for `["sentinel", finding_type, violation_class, agent_id]`
- keep runtime cycle emission out of this slice; this PR only adds the reducer and body contract

## Validation

- `mix test`
- `python3 scripts/diagnostics/check_doc_health.py`
- `git diff --check`
- push hook smoke slice: `138 passed, 7832 deselected`
