### PR TITLE
feat(wave-1): add Sentinel governance checkin client

### DIFF
--- a/elixir/sentinel/config/config.exs
+++ b/elixir/sentinel/config/config.exs
@@ -34,7 +34,11 @@ config :unitares_sentinel,
   findings_timeout_ms: 3_000,
   findings_agent_id: System.get_env("UNITARES_SENTINEL_AGENT_ID") || "sentinel",
   findings_agent_name: "Sentinel",
-  emit_findings: true
+  emit_findings: true,
+  emit_checkins: false,
+  governance_tools_url:
+    System.get_env("UNITARES_GOVERNANCE_TOOLS_URL") || "http://localhost:8767/v1/tools/call",
+  governance_checkin_timeout_ms: 45_000
 
 if File.exists?("config/#{config_env()}.exs") do
   import_config "#{config_env()}.exs"

--- a/elixir/sentinel/config/test.exs
+++ b/elixir/sentinel/config/test.exs
@@ -12,6 +12,7 @@ config :unitares_sentinel,
   start_fleet_state: false,
   start_websocket: false,
   start_fleet_finding_emitter: false,
+  emit_checkins: false,
   lease_advisory_enabled: false,
   database_url:
     System.get_env("UNITARES_SENTINEL_DATABASE_URL") ||

--- a/elixir/sentinel/lib/unitares_sentinel.ex
+++ b/elixir/sentinel/lib/unitares_sentinel.ex
@@ -27,8 +27,8 @@ defmodule UnitaresSentinel do
   cycle worker, Surface 2
   forced-release alarm findings client, Surface 3 lease-advisory wrapper,
   Surface 4 runtime timeout, and Surface 5 session anchor reader/backup
-  boundary, fleet-analysis finding reducer, and opt-in runtime
-  `sentinel_finding` emitter are wired; governance `process_agent_update`
-  check-in parity lands in follow-up PRs.
+  boundary, fleet-analysis finding reducer, opt-in runtime
+  `sentinel_finding` emitter, and opt-in `process_agent_update` REST
+  check-in boundary are wired.
   """
 end

--- a/elixir/sentinel/lib/unitares_sentinel/application.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/application.ex
@@ -4,10 +4,11 @@ defmodule UnitaresSentinel.Application do
 
   The supervisor starts with no children in :test mode (`config/test.exs`).
   Runtime mode starts Postgrex, the Finch HTTP client pool used by Surface 2
-  findings emission, the in-memory fleet state process, the `/ws/eisv`
-  consumer when `:start_websocket` is enabled, the fleet finding emitter when
-  `:start_fleet_finding_emitter` is enabled, and the poller when
-  `:start_poller` is enabled.
+  findings/check-in emission, the in-memory fleet state process, the
+  `/ws/eisv` consumer when `:start_websocket` is enabled, the fleet finding
+  emitter when `:start_fleet_finding_emitter` is enabled, and the poller when
+  `:start_poller` is enabled. Governance check-ins remain gated by
+  `:emit_checkins` inside the emitter.
 
   Mirrors the `:start_application` gate that `UnitaresLeasePlane.Application`
   uses (`elixir/lease_plane/lib/unitares_lease_plane/application.ex`) so

--- a/elixir/sentinel/lib/unitares_sentinel/cycle_summary.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/cycle_summary.ex
@@ -1,0 +1,66 @@
+defmodule UnitaresSentinel.CycleSummary do
+  @moduledoc """
+  Python-compatible Sentinel cycle check-in summary builder.
+
+  This is a pure boundary for the `CycleResult` values Python Sentinel returns
+  before the SDK calls `process_agent_update`. It does not perform HTTP writes.
+  """
+
+  @default_response_mode "compact"
+
+  @doc """
+  Build the `process_agent_update` argument subset for one Sentinel cycle.
+  """
+  @spec build(keyword()) :: map()
+  def build(opts \\ []) do
+    fleet_findings = Keyword.get(opts, :fleet_findings, [])
+    self_findings = Keyword.get(opts, :self_findings, [])
+    ws_connected? = Keyword.get(opts, :ws_connected?, Keyword.get(opts, :ws_connected, false))
+    active_agents = active_agents(Keyword.get(opts, :snapshot, %{}))
+    cycle_count = Keyword.get(opts, :cycle_count, 1)
+
+    parts =
+      [
+        "Cycle #{cycle_count}",
+        "Fleet: #{active_agents} agents",
+        "WS: #{if(ws_connected?, do: "connected", else: "DISCONNECTED")}"
+      ] ++ Enum.map(fleet_findings, &fleet_line/1) ++ Enum.map(self_findings, &self_line/1)
+
+    high_issues = Enum.count(fleet_findings, &(map_get(&1, :severity, "") == "high"))
+
+    %{
+      response_text: "Sentinel analysis: #{Enum.join(parts, " | ")}",
+      complexity:
+        min(1.0, 0.2 + length(fleet_findings) * 0.15 + if(ws_connected?, do: 0, else: 0.1)),
+      confidence: max(0.4, 0.85 - high_issues * 0.1 - if(ws_connected?, do: 0, else: 0.15)),
+      response_mode: Keyword.get(opts, :response_mode, @default_response_mode)
+    }
+  end
+
+  defp fleet_line(finding) do
+    severity = finding |> map_get(:severity, "") |> String.upcase()
+    violation_class = map_get(finding, :violation_class, "")
+    cls_tag = if violation_class == "", do: "", else: "[#{violation_class}] "
+
+    "[#{severity}] #{cls_tag}#{map_get(finding, :summary, "")}"
+  end
+
+  defp self_line(finding), do: "[SELF] #{map_get(finding, :summary, "")}"
+
+  defp active_agents(%{active_agents: count}) when is_integer(count), do: count
+  defp active_agents(%{"active_agents" => count}) when is_integer(count), do: count
+  defp active_agents(%{summary: summary}) when is_map(summary), do: map_size(summary)
+  defp active_agents(%{"summary" => summary}) when is_map(summary), do: map_size(summary)
+  defp active_agents(%{agents: agents}) when is_map(agents), do: map_size(agents)
+  defp active_agents(%{"agents" => agents}) when is_map(agents), do: map_size(agents)
+  defp active_agents(_snapshot), do: 0
+
+  defp map_get(map, key, default) when is_map(map) and is_atom(key) do
+    value = Map.get(map, key) || Map.get(map, Atom.to_string(key), default)
+
+    case value do
+      nil -> default
+      value -> to_string(value)
+    end
+  end
+end

--- a/elixir/sentinel/lib/unitares_sentinel/fleet_finding_emitter.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/fleet_finding_emitter.ex
@@ -6,17 +6,24 @@ defmodule UnitaresSentinel.FleetFindingEmitter do
   duplicate `sentinel_finding` emission, so production cutover must stop the
   Python Sentinel before enabling this GenServer.
 
-  It is not the full governance check-in loop yet. It analyzes the BEAM
-  `FleetState`, skips self-observations, and emits fleet findings to
-  `/api/findings` using the Python-compatible `Findings.post_finding/2`
-  contract.
+  The governance check-in path is present but opt-in. It analyzes the BEAM
+  `FleetState`, skips self-observations for finding emission, emits fleet
+  findings to `/api/findings`, and can build/post the Python-compatible
+  `process_agent_update` summary only when `:emit_checkins` is enabled.
   """
 
   use GenServer
 
   require Logger
 
-  alias UnitaresSentinel.{Findings, FleetAnalysis, FleetState, LeaseAdvisory}
+  alias UnitaresSentinel.{
+    CycleSummary,
+    Findings,
+    FleetAnalysis,
+    FleetState,
+    GovernanceCheckin,
+    LeaseAdvisory
+  }
 
   @default_interval_ms 300_000
   @default_initial_delay_ms 5_000
@@ -28,7 +35,9 @@ defmodule UnitaresSentinel.FleetFindingEmitter do
   @type tick_result :: %{
           fleet_findings: [map()],
           self_findings: [map()],
-          posted_count: non_neg_integer()
+          posted_count: non_neg_integer(),
+          checkin: map(),
+          checkin_result: {:ok, map()} | {:error, term()} | nil
         }
 
   @doc false
@@ -72,7 +81,35 @@ defmodule UnitaresSentinel.FleetFindingEmitter do
         0
       end
 
-    %{fleet_findings: fleet_findings, self_findings: self_findings, posted_count: posted_count}
+    checkin =
+      CycleSummary.build(
+        cycle_count: Keyword.get(opts, :cycle_count, 1),
+        snapshot: snapshot,
+        ws_connected?: Keyword.get(opts, :ws_connected?, Keyword.get(opts, :ws_connected, false)),
+        fleet_findings: fleet_findings,
+        self_findings: self_findings
+      )
+
+    checkin_result =
+      if Keyword.get(
+           opts,
+           :emit_checkins,
+           Keyword.get(
+             opts,
+             :emit_checkin,
+             Application.get_env(:unitares_sentinel, :emit_checkins, false)
+           )
+         ) do
+        GovernanceCheckin.checkin(checkin, Keyword.get(opts, :checkin_opts, []))
+      end
+
+    %{
+      fleet_findings: fleet_findings,
+      self_findings: self_findings,
+      posted_count: posted_count,
+      checkin: checkin,
+      checkin_result: checkin_result
+    }
   end
 
   @impl true
@@ -129,6 +166,7 @@ defmodule UnitaresSentinel.FleetFindingEmitter do
           Application.get_env(:unitares_sentinel, :lease_advisory_enabled, true)
         ),
       lease_opts: Keyword.get(opts, :lease_opts, []),
+      cycle_count: Keyword.get(opts, :cycle_count, 0),
       running?: false,
       last_result: nil
     }
@@ -152,7 +190,9 @@ defmodule UnitaresSentinel.FleetFindingEmitter do
       case await_runtime_tick(state) do
         {:ok, result} ->
           schedule_next_tick(state)
-          {:noreply, %{state | running?: false, last_result: result}}
+
+          {:noreply,
+           %{state | running?: false, last_result: result, cycle_count: state.cycle_count + 1}}
 
         :timeout ->
           Logger.warning(
@@ -167,8 +207,8 @@ defmodule UnitaresSentinel.FleetFindingEmitter do
     end
   end
 
-  defp await_runtime_tick(%{tick_timeout_ms: timeout_ms, opts: opts}) do
-    task = Task.async(fn -> tick(opts) end)
+  defp await_runtime_tick(%{tick_timeout_ms: timeout_ms, opts: opts, cycle_count: cycle_count}) do
+    task = Task.async(fn -> tick(Keyword.put(opts, :cycle_count, cycle_count + 1)) end)
     Process.unlink(task.pid)
 
     case Task.yield(task, timeout_ms) || Task.shutdown(task, :brutal_kill) do

--- a/elixir/sentinel/lib/unitares_sentinel/governance_checkin.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/governance_checkin.ex
@@ -1,0 +1,155 @@
+defmodule UnitaresSentinel.GovernanceCheckin do
+  @moduledoc """
+  Best-effort REST client for Sentinel `process_agent_update` check-ins.
+
+  Wave 1 binds BEAM Sentinel to the existing HTTP tool-call surface:
+  `POST /v1/tools/call` with `name=process_agent_update`. This module keeps
+  that boundary explicit and fail-soft; transport errors return `{:error, ...}`
+  rather than escaping the runtime analysis cycle.
+  """
+
+  require Logger
+
+  @default_url "http://localhost:8767/v1/tools/call"
+  @default_timeout_ms 45_000
+
+  @type http_post ::
+          (String.t(), map(), [{String.t(), String.t()}], pos_integer() ->
+             {:ok, non_neg_integer(), String.t()} | {:error, term()})
+
+  @doc """
+  POST one cycle summary to `process_agent_update`.
+  """
+  @spec checkin(map(), keyword()) :: {:ok, map()} | {:error, term()}
+  def checkin(summary, opts \\ []) when is_map(summary) do
+    summary
+    |> body(opts)
+    |> post_json(opts)
+  end
+
+  @doc false
+  @spec body(map(), keyword()) :: map()
+  def body(summary, opts \\ []) when is_map(summary) do
+    anchor = Keyword.get(opts, :anchor, %{})
+
+    arguments =
+      %{
+        "response_text" => map_fetch!(summary, :response_text),
+        "complexity" => map_fetch!(summary, :complexity),
+        "confidence" => map_fetch!(summary, :confidence),
+        "response_mode" => map_get(summary, :response_mode, "compact")
+      }
+      |> put_optional("agent_id", Keyword.get(opts, :agent_id) || Map.get(anchor, "agent_uuid"))
+      |> put_optional(
+        "client_session_id",
+        Keyword.get(opts, :client_session_id) || Map.get(anchor, "client_session_id")
+      )
+      |> put_optional(
+        "continuity_token",
+        Keyword.get(opts, :continuity_token) || Map.get(anchor, "continuity_token")
+      )
+
+    %{"name" => "process_agent_update", "arguments" => arguments}
+  end
+
+  @doc false
+  @spec post_json(map(), keyword()) :: {:ok, map()} | {:error, term()}
+  def post_json(body, opts \\ []) when is_map(body) do
+    http_post = Keyword.get(opts, :http_post, &finch_post/4)
+    url = Keyword.get(opts, :url, governance_tools_url())
+    timeout_ms = Keyword.get(opts, :timeout_ms, governance_timeout_ms())
+
+    case http_post.(url, body, headers(), timeout_ms) do
+      {:ok, 200, response_body} ->
+        decode_response(response_body)
+
+      {:ok, status, response_body} ->
+        Logger.debug("UnitaresSentinel.GovernanceCheckin.post_json non-200: #{inspect(status)}")
+
+        {:error, {:http_status, status, response_body}}
+
+      {:error, reason} ->
+        Logger.debug("UnitaresSentinel.GovernanceCheckin.post_json failed: #{inspect(reason)}")
+        {:error, reason}
+    end
+  rescue
+    e ->
+      Logger.debug("UnitaresSentinel.GovernanceCheckin.post_json raised: #{inspect(e)}")
+      {:error, e}
+  catch
+    :exit, reason ->
+      Logger.debug("UnitaresSentinel.GovernanceCheckin.post_json exited: #{inspect(reason)}")
+      {:error, {:exit, reason}}
+  end
+
+  defp finch_post(url, body, headers, timeout_ms) do
+    json = Jason.encode!(body)
+    request = Finch.build(:post, url, headers, json)
+
+    case Finch.request(request, UnitaresSentinel.Finch, receive_timeout: timeout_ms) do
+      {:ok, %Finch.Response{status: status, body: response_body}} ->
+        {:ok, status, response_body}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp decode_response(response_body) when is_binary(response_body) do
+    case Jason.decode(response_body) do
+      {:ok, %{"success" => true, "result" => %{} = result}} ->
+        case ensure_tool_success(result) do
+          :ok -> {:ok, result}
+          {:error, _reason} = error -> error
+        end
+
+      {:ok, %{"success" => false} = decoded} ->
+        {:error, {:tool_error, Map.get(decoded, "error", "unknown")}}
+
+      {:ok, decoded} ->
+        {:error, {:invalid_response, decoded}}
+
+      {:error, reason} ->
+        {:error, {:invalid_json, reason}}
+    end
+  end
+
+  defp ensure_tool_success(%{"success" => false} = result),
+    do: {:error, {:tool_error, Map.get(result, "error", "unknown")}}
+
+  defp ensure_tool_success(_result), do: :ok
+
+  defp headers do
+    base = [{"Content-Type", "application/json"}]
+
+    case System.get_env("UNITARES_HTTP_API_TOKEN") do
+      nil -> base
+      "" -> base
+      token -> [{"Authorization", "Bearer #{token}"} | base]
+    end
+  end
+
+  defp governance_tools_url do
+    Application.get_env(:unitares_sentinel, :governance_tools_url) ||
+      System.get_env("UNITARES_GOVERNANCE_TOOLS_URL") ||
+      @default_url
+  end
+
+  defp governance_timeout_ms do
+    Application.get_env(:unitares_sentinel, :governance_checkin_timeout_ms, @default_timeout_ms)
+  end
+
+  defp put_optional(payload, _key, nil), do: payload
+  defp put_optional(payload, _key, ""), do: payload
+  defp put_optional(payload, key, value) when is_binary(value), do: Map.put(payload, key, value)
+
+  defp map_fetch!(map, key) when is_atom(key) do
+    Map.fetch!(map, key)
+  rescue
+    KeyError -> Map.fetch!(map, Atom.to_string(key))
+  end
+
+  defp map_get(map, key, default) when is_atom(key) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key), default)
+  end
+end

--- a/elixir/sentinel/test/unitares_sentinel/cycle_summary_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/cycle_summary_test.exs
@@ -1,0 +1,60 @@
+defmodule UnitaresSentinel.CycleSummaryTest do
+  use ExUnit.Case, async: true
+
+  alias UnitaresSentinel.CycleSummary
+
+  test "build mirrors Python Sentinel cycle check-in fields" do
+    summary =
+      CycleSummary.build(
+        cycle_count: 7,
+        snapshot: %{active_agents: 3},
+        ws_connected?: false,
+        fleet_findings: [
+          %{
+            severity: "high",
+            violation_class: "CON",
+            summary: "Coordinated coherence drop: Agent A(-0.20), Agent B(-0.20)"
+          },
+          %{
+            severity: "medium",
+            violation_class: "",
+            summary: "4 governance events in 10min: lifecycle_pause, identity_resume"
+          }
+        ],
+        self_findings: [
+          %{
+            severity: "info",
+            violation_class: "ENT",
+            summary: "Sentinel entropy outlier (z=2.8, S=1.000)"
+          }
+        ]
+      )
+
+    assert summary.response_text ==
+             "Sentinel analysis: Cycle 7 | Fleet: 3 agents | WS: DISCONNECTED | " <>
+               "[HIGH] [CON] Coordinated coherence drop: Agent A(-0.20), Agent B(-0.20) | " <>
+               "[MEDIUM] 4 governance events in 10min: lifecycle_pause, identity_resume | " <>
+               "[SELF] Sentinel entropy outlier (z=2.8, S=1.000)"
+
+    assert summary.complexity == 0.6
+    assert summary.confidence == 0.6
+    assert summary.response_mode == "compact"
+  end
+
+  test "build derives active agent count from FleetState snapshots" do
+    summary =
+      CycleSummary.build(
+        cycle_count: 1,
+        snapshot: %{summary: %{"a" => %{}, "b" => %{}}},
+        ws_connected?: true,
+        fleet_findings: [],
+        self_findings: []
+      )
+
+    assert summary.response_text ==
+             "Sentinel analysis: Cycle 1 | Fleet: 2 agents | WS: connected"
+
+    assert summary.complexity == 0.2
+    assert summary.confidence == 0.85
+  end
+end

--- a/elixir/sentinel/test/unitares_sentinel/fleet_finding_emitter_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/fleet_finding_emitter_test.exs
@@ -58,6 +58,58 @@ defmodule UnitaresSentinel.FleetFindingEmitterTest do
     assert body["violation_class"] == "CON"
   end
 
+  test "tick can opt in to governance check-in emission" do
+    parent = self()
+
+    analysis_fun = fn _snapshot, _analysis_opts -> [fleet_finding(), self_finding()] end
+
+    checkin_http_post = fn url, body, _headers, timeout_ms ->
+      send(parent, {:checkin_posted, url, body, timeout_ms})
+
+      {:ok, 200,
+       Jason.encode!(%{
+         "success" => true,
+         "result" => %{"decision" => %{"action" => "proceed"}}
+       })}
+    end
+
+    result =
+      FleetFindingEmitter.tick(
+        snapshot: %{active_agents: 2, agents: %{}, events: []},
+        analysis_fun: analysis_fun,
+        emit_findings: false,
+        emit_checkins: true,
+        cycle_count: 4,
+        ws_connected?: false,
+        checkin_opts: [
+          url: "http://example.test/v1/tools/call",
+          timeout_ms: 123,
+          http_post: checkin_http_post,
+          agent_id: "sentinel-test"
+        ]
+      )
+
+    assert result.posted_count == 0
+    assert result.checkin.response_mode == "compact"
+    assert {:ok, %{"decision" => %{"action" => "proceed"}}} = result.checkin_result
+
+    assert_receive {:checkin_posted, url, body, timeout_ms}
+    assert url == "http://example.test/v1/tools/call"
+    assert timeout_ms == 123
+    assert body["name"] == "process_agent_update"
+
+    args = body["arguments"]
+    assert args["agent_id"] == "sentinel-test"
+    assert args["response_mode"] == "compact"
+    assert_in_delta args["complexity"], 0.45, 0.000_001
+    assert_in_delta args["confidence"], 0.6, 0.000_001
+
+    assert args["response_text"] ==
+             "Sentinel analysis: Cycle 4 | Fleet: 2 agents | WS: DISCONNECTED | " <>
+               "[HIGH] [CON] Coordinated coherence drop: Agent A(-0.20), Agent B(-0.20) | " <>
+               "[SELF] Sentinel entropy outlier (z=2.8, S=1.000)"
+  end
+
   test "GenServer wraps runtime tick in advisory lease acquire and release" do
     parent = self()
     lease_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"

--- a/elixir/sentinel/test/unitares_sentinel/governance_checkin_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/governance_checkin_test.exs
@@ -1,0 +1,89 @@
+defmodule UnitaresSentinel.GovernanceCheckinTest do
+  use ExUnit.Case, async: true
+
+  alias UnitaresSentinel.GovernanceCheckin
+
+  @agent_uuid "11111111-1111-1111-1111-111111111111"
+  @continuity_token "v1.test-token"
+  @client_session_id "session-test"
+
+  defp summary do
+    %{
+      response_text: "Sentinel analysis: Cycle 1 | Fleet: 2 agents | WS: connected",
+      complexity: 0.35,
+      confidence: 0.85,
+      response_mode: "compact"
+    }
+  end
+
+  test "body targets process_agent_update and carries session anchor identity" do
+    body =
+      GovernanceCheckin.body(summary(),
+        anchor: %{
+          "agent_uuid" => @agent_uuid,
+          "continuity_token" => @continuity_token,
+          "client_session_id" => @client_session_id
+        }
+      )
+
+    assert body["name"] == "process_agent_update"
+    args = body["arguments"]
+    assert args["response_text"] == summary().response_text
+    assert args["complexity"] == 0.35
+    assert args["confidence"] == 0.85
+    assert args["response_mode"] == "compact"
+    assert args["agent_id"] == @agent_uuid
+    assert args["continuity_token"] == @continuity_token
+    assert args["client_session_id"] == @client_session_id
+  end
+
+  test "checkin posts to the HTTP tool-call endpoint and returns result" do
+    parent = self()
+
+    http_post = fn url, body, headers, timeout_ms ->
+      send(parent, {:posted, url, body, headers, timeout_ms})
+
+      {:ok, 200,
+       Jason.encode!(%{
+         "success" => true,
+         "result" => %{
+           "decision" => %{"action" => "proceed"},
+           "metrics" => %{"coherence" => 0.9}
+         }
+       })}
+    end
+
+    assert {:ok, result} =
+             GovernanceCheckin.checkin(summary(),
+               url: "http://example.test/v1/tools/call",
+               timeout_ms: 123,
+               http_post: http_post
+             )
+
+    assert result["decision"]["action"] == "proceed"
+    assert result["metrics"]["coherence"] == 0.9
+
+    assert_receive {:posted, url, body, headers, timeout_ms}
+    assert url == "http://example.test/v1/tools/call"
+    assert body["name"] == "process_agent_update"
+    assert body["arguments"]["response_text"] == summary().response_text
+    assert {"Content-Type", "application/json"} in headers
+    assert timeout_ms == 123
+  end
+
+  test "checkin returns error for tool-level failure envelopes" do
+    http_post = fn _url, _body, _headers, _timeout_ms ->
+      {:ok, 200, ~s({"success":true,"result":{"success":false,"error":"paused"}})}
+    end
+
+    assert {:error, {:tool_error, "paused"}} =
+             GovernanceCheckin.checkin(summary(), http_post: http_post)
+  end
+
+  test "checkin swallows transport exceptions" do
+    http_post = fn _url, _body, _headers, _timeout_ms -> raise "connection refused" end
+
+    assert {:error, %RuntimeError{message: "connection refused"}} =
+             GovernanceCheckin.checkin(summary(), http_post: http_post)
+  end
+end


### PR DESCRIPTION
Summary:
- add Python-compatible CycleSummary for Sentinel process_agent_update payloads
- add fail-soft GovernanceCheckin REST client for /v1/tools/call
- add opt-in FleetFindingEmitter check-in emission behind emit_checkins=false

Tests:
- mix test
- make test-smoke
- git diff --check
- python3 scripts/diagnostics/check_doc_health.py
- pre-push smoke/doc-health