### PR TITLE
fix(wave-1): parse Sentinel cursors before max compare

### DIFF
--- a/elixir/sentinel/lib/unitares_sentinel/cutover.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/cutover.ex
@@ -105,10 +105,10 @@ defmodule UnitaresSentinel.Cutover do
   defp pick_max(canonical, %{} = shadow) when map_size(shadow) == 0, do: canonical
 
   defp pick_max(canonical, shadow) do
-    canonical_cursor = CycleState.get_last_event_ts(canonical) || ""
-    shadow_cursor = CycleState.get_last_event_ts(shadow) || ""
+    canonical_cursor = CycleState.get_last_event_ts(canonical)
+    shadow_cursor = CycleState.get_last_event_ts(shadow)
 
-    if canonical_cursor >= shadow_cursor do
+    if CycleState.compare_cursor(canonical_cursor, shadow_cursor) in [:gt, :eq] do
       canonical
     else
       shadow

--- a/elixir/sentinel/lib/unitares_sentinel/cycle_state.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/cycle_state.ex
@@ -17,9 +17,8 @@ defmodule UnitaresSentinel.CycleState do
   ## Boot semantics (v0.1.2 §B2 — max-on-boot)
 
   `load/1` reads both files when both exist and returns the state with
-  the larger `forced_release_alarm.last_event_ts` (ISO-8601 lex compare,
-  valid because Python writes UTC-offset isoformat). Empty cursors are
-  treated as older than any timestamp.
+  the larger `forced_release_alarm.last_event_ts` after ISO-8601 parsing.
+  Empty cursors are treated as older than any timestamp.
 
   ## Cutover (v0.1.2 §B3 — max wins)
 
@@ -142,6 +141,21 @@ defmodule UnitaresSentinel.CycleState do
   @spec get_runtime(t()) :: String.t() | nil
   def get_runtime(state) when is_map(state), do: Map.get(state, @runtime_key)
 
+  @doc false
+  @spec compare_cursor(String.t() | nil, String.t() | nil) :: :lt | :eq | :gt
+  def compare_cursor(nil, nil), do: :eq
+  def compare_cursor(nil, cursor) when is_binary(cursor), do: :lt
+  def compare_cursor(cursor, nil) when is_binary(cursor), do: :gt
+
+  def compare_cursor(a, b) when is_binary(a) and is_binary(b) do
+    with {:ok, a_dt, _} <- DateTime.from_iso8601(a),
+         {:ok, b_dt, _} <- DateTime.from_iso8601(b) do
+      DateTime.compare(a_dt, b_dt)
+    else
+      _ -> lex_compare(a, b)
+    end
+  end
+
   @doc """
   Resolve the canonical (Python) STATE_FILE path from config / env var.
 
@@ -198,13 +212,21 @@ defmodule UnitaresSentinel.CycleState do
   defp pick_max(canonical, %{} = shadow) when map_size(shadow) == 0, do: canonical
 
   defp pick_max(canonical_state, shadow_state) do
-    canonical_cursor = get_last_event_ts(canonical_state) || ""
-    shadow_cursor = get_last_event_ts(shadow_state) || ""
+    canonical_cursor = get_last_event_ts(canonical_state)
+    shadow_cursor = get_last_event_ts(shadow_state)
 
-    if canonical_cursor >= shadow_cursor do
+    if compare_cursor(canonical_cursor, shadow_cursor) in [:gt, :eq] do
       canonical_state
     else
       shadow_state
+    end
+  end
+
+  defp lex_compare(a, b) do
+    cond do
+      a > b -> :gt
+      a < b -> :lt
+      true -> :eq
     end
   end
 end

--- a/elixir/sentinel/test/unitares_sentinel/cutover_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/cutover_test.exs
@@ -48,6 +48,20 @@ defmodule UnitaresSentinel.CutoverTest do
              "2026-05-05T03:00:00Z"
   end
 
+  test "cutover_to_beam parses mixed ISO precision before max-cursor merge", ctx do
+    # Raw string comparison would pick the older "Z" cursor because "Z" sorts
+    # above "." after the whole-second prefix.
+    write_state(ctx.canonical, "2026-05-05T02:00:00Z")
+    write_state(ctx.shadow, "2026-05-05T02:00:00.000001+00:00")
+
+    {:ok, result} = Cutover.cutover_to_beam(canonical: ctx.canonical, shadow: ctx.shadow)
+
+    assert result.cursor == "2026-05-05T02:00:00.000001+00:00"
+
+    assert get_in(decode!(ctx.shadow), ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-05T02:00:00.000001+00:00"
+  end
+
   test "rollback_to_python copies max cursor back to canonical and marks shadow", ctx do
     write_state(ctx.canonical, "2026-05-05T01:00:00Z")
     write_state(ctx.shadow, "2026-05-05T04:00:00Z", %{"runtime" => "beam_canonical"})

--- a/elixir/sentinel/test/unitares_sentinel/cycle_state_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/cycle_state_test.exs
@@ -54,6 +54,7 @@ defmodule UnitaresSentinel.CycleStateTest do
     )
 
     state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+
     assert get_in(state, ["forced_release_alarm", "last_event_ts"]) ==
              "2026-05-04T00:00:00.000000+00:00"
   end
@@ -70,8 +71,28 @@ defmodule UnitaresSentinel.CycleStateTest do
     )
 
     state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+
     assert get_in(state, ["forced_release_alarm", "last_event_ts"]) ==
              "2026-05-05T12:00:00.000000+00:00"
+  end
+
+  test "max-on-boot parses mixed ISO precision before comparing", ctx do
+    # Regression: raw string comparison ranks trailing "Z" above fractional
+    # ".000001+00:00", choosing the older whole-second cursor.
+    File.write!(
+      ctx.canonical,
+      ~s({"forced_release_alarm": {"last_event_ts": "2026-05-05T02:00:00Z"}})
+    )
+
+    File.write!(
+      ctx.shadow,
+      ~s({"forced_release_alarm": {"last_event_ts": "2026-05-05T02:00:00.000001+00:00"}})
+    )
+
+    state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+
+    assert get_in(state, ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-05T02:00:00.000001+00:00"
   end
 
   test "max-on-boot: only python file exists — python wins", ctx do
@@ -81,6 +102,7 @@ defmodule UnitaresSentinel.CycleStateTest do
     )
 
     state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+
     assert get_in(state, ["forced_release_alarm", "last_event_ts"]) ==
              "2026-05-03T13:56:34.479878+00:00"
   end
@@ -92,6 +114,7 @@ defmodule UnitaresSentinel.CycleStateTest do
     )
 
     state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+
     assert get_in(state, ["forced_release_alarm", "last_event_ts"]) ==
              "2026-05-04T01:02:03.456789+00:00"
   end
@@ -110,6 +133,7 @@ defmodule UnitaresSentinel.CycleStateTest do
     )
 
     state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+
     assert get_in(state, ["forced_release_alarm", "last_event_ts"]) ==
              "2026-05-04T00:00:00.000000+00:00"
   end
@@ -129,6 +153,7 @@ defmodule UnitaresSentinel.CycleStateTest do
     # Must NOT be %{} — the sibling data has to survive boot.
     assert get_in(state, ["forced_release_alarm", "first_seen_at"]) ==
              "2026-05-04T00:00:00+00:00"
+
     assert Map.get(state, "runtime") == "shadow"
   end
 
@@ -165,6 +190,7 @@ defmodule UnitaresSentinel.CycleStateTest do
     # Shadow wins despite older cursor — the runtime flag is load-bearing.
     assert get_in(state, ["forced_release_alarm", "last_event_ts"]) ==
              "2026-05-04T00:00:00.000000+00:00"
+
     assert CycleState.get_runtime(state) == "beam_canonical"
   end
 
@@ -183,6 +209,7 @@ defmodule UnitaresSentinel.CycleStateTest do
     )
 
     state = CycleState.load(canonical: ctx.canonical, shadow: ctx.shadow)
+
     assert get_in(state, ["forced_release_alarm", "last_event_ts"]) ==
              "2026-05-10T00:00:00.000000+00:00"
   end
@@ -196,7 +223,8 @@ defmodule UnitaresSentinel.CycleStateTest do
   # Schema binding (v0.1.1 §Surface 1, retained in v0.1.2).
   # ---------------------------------------------------------------------------
 
-  test "schema binding: forced_release_alarm.last_event_ts stays top-level ISO-8601 string", ctx do
+  test "schema binding: forced_release_alarm.last_event_ts stays top-level ISO-8601 string",
+       ctx do
     state = %{"forced_release_alarm" => %{"last_event_ts" => "2026-05-05T12:34:56.789012+00:00"}}
     :ok = CycleState.save(state, path: ctx.shadow)
 
@@ -252,7 +280,10 @@ defmodule UnitaresSentinel.CycleStateTest do
     File.touch!(Path.join(ctx.shadow, "hold"))
 
     # Must NOT raise — Python's save_state swallows; BEAM matches.
-    assert CycleState.save(%{"forced_release_alarm" => %{"last_event_ts" => "2026-05-05T00:00:00+00:00"}}, path: ctx.shadow) == :ok
+    assert CycleState.save(
+             %{"forced_release_alarm" => %{"last_event_ts" => "2026-05-05T00:00:00+00:00"}},
+             path: ctx.shadow
+           ) == :ok
   end
 
   # Council fold: reviewer Important-3. Encoding errors are caller-side bugs,
@@ -285,6 +316,7 @@ defmodule UnitaresSentinel.CycleStateTest do
 
   test "update_last_event_ts/2 sets the cursor under the canonical key path", _ctx do
     updated = CycleState.update_last_event_ts(%{}, "2026-05-05T01:23:45.678901+00:00")
+
     assert get_in(updated, ["forced_release_alarm", "last_event_ts"]) ==
              "2026-05-05T01:23:45.678901+00:00"
   end
@@ -293,7 +325,9 @@ defmodule UnitaresSentinel.CycleStateTest do
     state = %{"forced_release_alarm" => %{"sibling_key" => "preserve_me"}}
     updated = CycleState.update_last_event_ts(state, "2026-05-05T01:23:45+00:00")
     assert get_in(updated, ["forced_release_alarm", "sibling_key"]) == "preserve_me"
-    assert get_in(updated, ["forced_release_alarm", "last_event_ts"]) == "2026-05-05T01:23:45+00:00"
+
+    assert get_in(updated, ["forced_release_alarm", "last_event_ts"]) ==
+             "2026-05-05T01:23:45+00:00"
   end
 
   # ---------------------------------------------------------------------------
@@ -313,6 +347,7 @@ defmodule UnitaresSentinel.CycleStateTest do
     # Cursor MUST be recoverable from the Python fixture without loss.
     cursor = CycleState.get_last_event_ts(state)
     assert is_binary(cursor), "Python fixture cursor must be a binary string"
+
     assert String.match?(cursor, ~r/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/),
            "Python fixture cursor must be ISO-8601 (got: #{inspect(cursor)})"
   end


### PR DESCRIPTION
Summary:
- replace raw string cursor max comparisons with parsed ISO-8601 DateTime comparison
- reuse the parsed comparator in cutover max-cursor merge
- add regressions for Z vs fractional +00:00 cursor ordering

Tests:
- mix test
- make test-smoke
- git diff --check
- python3 scripts/diagnostics/check_doc_health.py
- pre-push smoke/doc-health