### PR TITLE
feat(wave-1): add BEAM Sentinel cutover launchd

### DIFF
--- a/docs/install/cross-machine-surface.md
+++ b/docs/install/cross-machine-surface.md
@@ -59,6 +59,7 @@ Option 2 is cleanest for cross-machine portability. Not applied in this PR becau
 | `com.unitares.chronicler.plist.template` | Tracked template using `__UNITARES_ROOT__`, `__HOME__` | OK — reference pattern |
 | `com.unitares.ipv6-loopback-proxy.plist.template` | ✅ Resolved in this PR | `__UNITARES_ROOT__` + `__PYTHON3__` placeholders applied |
 | `com.unitares.sentinel.plist.template` | ✅ Added in this PR | Sanitized template created |
+| `com.unitares.sentinel-beam.plist.template` | ✅ Added in Wave 1 cutover PR | Sanitized BEAM Sentinel cutover target |
 | `com.unitares.vigil.plist.template` | ✅ Added in this PR | Sanitized template created |
 | `com.unitares.gateway-mcp.plist.template` | ✅ Added in this PR | Sanitized template created |
 | `com.unitares.governance-backup.plist.template` | ✅ Added in this PR | Sanitized template created |

--- a/docs/proposals/beam-wave-1-sentinel.md
+++ b/docs/proposals/beam-wave-1-sentinel.md
@@ -125,7 +125,7 @@ PR #376's `query_forced_rows` swallows DB errors and returns `[]` (logging at `:
 - Surface 2 (findings emit) cutover protocol unchanged.
 - Surface 3 (lease-advisory acquire) unchanged.
 - The 30s tick interval + ±5s jitter from PR #376's council fold is unchanged — adding two more queries per tick does not change the tick rate.
-- The `runtime: "beam_canonical"` cutover flag (v0.1.2 §B3) is read by `CycleState.load/1`'s short-circuit; the writer is still unowned (separate `mix sentinel.cutover` PR, not in scope here).
+- The `runtime: "beam_canonical"` cutover flag (v0.1.2 §B3) is read by `CycleState.load/1`'s short-circuit; the writer is owned by `mix sentinel.cutover` / `mix sentinel.rollback`.
 
 ### C1 (reviewer Important-5 + architect) — Test minimums
 
@@ -164,12 +164,12 @@ Rejected because:
 
 Recorded so future RFC passes (v0.2.x scope) can reconsider the hybrid against post-cutover failure-mode data, with explicit acknowledgment that the rejection was made in a pre-cutover context.
 
-### What's deferred to a follow-up RFC amendment (v0.1.4+)
+### Follow-up status
 
-- **Cutover flag writer.** `mix sentinel.cutover --to=beam` and `mix sentinel.rollback --to=python` operator scripts. Architect #4 from PR #376 council. Belongs in its own RFC pass because rollback semantics + dual-runtime safety windows need their own design.
-- **Surface 2 findings emit binding.** Once Surface 2 lands the alarm-emit path, the alarm shape may need `finding_type` / `violation_class` fields for downstream dedup. Architect #3 from PR #376 council flagged this as a forward-compat concern. Surface 2 ALSO MUST move cursor persistence into post-emit callback per §B4 above — that's the at-least-once recovery for the Surface-1-only at-most-once gap.
-- **First-boot lookback bound.** Three-class first-boot poll with `last_event_ts=nil` fetches everything in `lease_plane_events`. Python pays this once; BEAM's first cutover boot pays it again. Bind a first-boot LIMIT or a lookback window in v0.1.4 (architect concern).
-- **Phase-B promotion port.** Wave 2 scope per §C3.
+- **Cutover flag writer:** shipped as `mix sentinel.cutover --to=beam` and `mix sentinel.rollback --to=python`.
+- **Surface 2 findings emit binding:** shipped through the BEAM findings emitter and post-emit cursor advancement path.
+- **First-boot lookback bound:** shipped as `UNITARES_SENTINEL_FIRST_BOOT_LOOKBACK_SECONDS`, defaulting to seven days.
+- **Remaining deferred item:** Phase-B promotion port. Wave 2 scope per §C3.
 
 ---
 

--- a/elixir/sentinel/config/config.exs
+++ b/elixir/sentinel/config/config.exs
@@ -1,5 +1,28 @@
 import Config
 
+bool_env = fn name, default ->
+  case System.get_env(name) do
+    nil ->
+      default
+
+    "" ->
+      default
+
+    raw ->
+      case raw |> String.trim() |> String.downcase() do
+        "1" -> true
+        "true" -> true
+        "yes" -> true
+        "on" -> true
+        "0" -> false
+        "false" -> false
+        "no" -> false
+        "off" -> false
+        _ -> raise "#{name} must be a boolean-like value, got: #{inspect(raw)}"
+      end
+  end
+end
+
 first_boot_lookback_seconds =
   case System.get_env("UNITARES_SENTINEL_FIRST_BOOT_LOOKBACK_SECONDS") do
     nil -> 7 * 24 * 60 * 60
@@ -7,19 +30,23 @@ first_boot_lookback_seconds =
   end
 
 config :unitares_sentinel,
+  start_application: bool_env.("UNITARES_SENTINEL_START_APPLICATION", true),
   database_url:
     System.get_env("UNITARES_SENTINEL_DATABASE_URL") ||
       System.get_env("UNITARES_LEASE_PLANE_DATABASE_URL") ||
       "postgresql://postgres:postgres@localhost:5432/governance",
   pool_size: 2,
+  start_postgrex: bool_env.("UNITARES_SENTINEL_START_POSTGREX", true),
+  start_finch: bool_env.("UNITARES_SENTINEL_START_FINCH", true),
   session_file_path: System.get_env("UNITARES_SENTINEL_SESSION_FILE"),
   legacy_session_file_path: System.get_env("UNITARES_SENTINEL_LEGACY_SESSION_FILE"),
   poller_interval_ms: 30_000,
   poller_initial_delay_ms: 1_000,
   poller_tick_timeout_ms: 30_000,
-  start_fleet_state: true,
-  start_websocket: false,
-  start_fleet_finding_emitter: false,
+  start_fleet_state: bool_env.("UNITARES_SENTINEL_START_FLEET_STATE", true),
+  start_websocket: bool_env.("UNITARES_SENTINEL_START_WEBSOCKET", false),
+  start_fleet_finding_emitter: bool_env.("UNITARES_SENTINEL_START_FLEET_FINDING_EMITTER", false),
+  start_poller: bool_env.("UNITARES_SENTINEL_START_POLLER", false),
   analysis_interval_ms: 300_000,
   analysis_initial_delay_ms: 5_000,
   analysis_jitter_ms: 5_000,
@@ -34,8 +61,8 @@ config :unitares_sentinel,
   findings_timeout_ms: 3_000,
   findings_agent_id: System.get_env("UNITARES_SENTINEL_AGENT_ID") || "sentinel",
   findings_agent_name: "Sentinel",
-  emit_findings: true,
-  emit_checkins: false,
+  emit_findings: bool_env.("UNITARES_SENTINEL_EMIT_FINDINGS", true),
+  emit_checkins: bool_env.("UNITARES_SENTINEL_EMIT_CHECKINS", false),
   governance_tools_url:
     System.get_env("UNITARES_GOVERNANCE_TOOLS_URL") || "http://localhost:8767/v1/tools/call",
   governance_checkin_timeout_ms: 45_000

--- a/elixir/sentinel/scripts/start.sh
+++ b/elixir/sentinel/scripts/start.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Launchd entrypoint for BEAM Sentinel.
+#
+# Sources operator secrets, enables the Wave 1 runtime children, then execs
+# `mix run --no-halt` from the Sentinel app directory.
+#
+# Used by: scripts/ops/com.unitares.sentinel-beam.plist.template
+# Manual invocation: `./elixir/sentinel/scripts/start.sh`
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SENTINEL_DIR="$REPO_ROOT/elixir/sentinel"
+SECRETS_FILE="$HOME/.config/cirwel/secrets.env"
+
+if [[ -f "$SECRETS_FILE" ]]; then
+    # shellcheck disable=SC1090
+    source "$SECRETS_FILE"
+else
+    echo "[sentinel-beam] WARNING: $SECRETS_FILE missing - HTTP/lease auth may fail closed" >&2
+fi
+
+# Homebrew Elixir lives at /opt/homebrew/bin on Apple Silicon. PATH inherited
+# from launchd's user environment is sparse, so set it explicitly.
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+# Bind BEAM Sentinel to Python Sentinel's state/identity surfaces. These are
+# defaults only; launchd may pass explicit values for non-standard installs.
+export UNITARES_SENTINEL_STATE_FILE="${UNITARES_SENTINEL_STATE_FILE:-$REPO_ROOT/.sentinel_state}"
+export UNITARES_SENTINEL_SESSION_FILE="${UNITARES_SENTINEL_SESSION_FILE:-$HOME/.unitares/anchors/sentinel.json}"
+export UNITARES_SENTINEL_LEGACY_SESSION_FILE="${UNITARES_SENTINEL_LEGACY_SESSION_FILE:-$REPO_ROOT/.sentinel_session}"
+
+# Wave 1 production runtime: poll lease-plane events, ingest EISV over WS,
+# emit findings, and post governance check-ins. Config defaults remain safe
+# for tests and ad-hoc `mix run`; the launchd entrypoint opts in explicitly.
+export UNITARES_SENTINEL_START_APPLICATION="${UNITARES_SENTINEL_START_APPLICATION:-true}"
+export UNITARES_SENTINEL_START_POSTGREX="${UNITARES_SENTINEL_START_POSTGREX:-true}"
+export UNITARES_SENTINEL_START_FINCH="${UNITARES_SENTINEL_START_FINCH:-true}"
+export UNITARES_SENTINEL_START_FLEET_STATE="${UNITARES_SENTINEL_START_FLEET_STATE:-true}"
+export UNITARES_SENTINEL_START_WEBSOCKET="${UNITARES_SENTINEL_START_WEBSOCKET:-true}"
+export UNITARES_SENTINEL_START_FLEET_FINDING_EMITTER="${UNITARES_SENTINEL_START_FLEET_FINDING_EMITTER:-true}"
+export UNITARES_SENTINEL_START_POLLER="${UNITARES_SENTINEL_START_POLLER:-true}"
+export UNITARES_SENTINEL_EMIT_FINDINGS="${UNITARES_SENTINEL_EMIT_FINDINGS:-true}"
+export UNITARES_SENTINEL_EMIT_CHECKINS="${UNITARES_SENTINEL_EMIT_CHECKINS:-true}"
+
+cd "$SENTINEL_DIR"
+exec mix run --no-halt

--- a/scripts/ops/com.unitares.sentinel-beam.plist.template
+++ b/scripts/ops/com.unitares.sentinel-beam.plist.template
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  launchd manifest for BEAM Sentinel (Wave 1 cutover target).
+
+  Render, but do NOT load while Python Sentinel is still running:
+    sed -e "s|__UNITARES_ROOT__|$HOME/projects/unitares|g" \
+        -e "s|__HOME__|$HOME|g" \
+        scripts/ops/com.unitares.sentinel-beam.plist.template \
+        > ~/Library/LaunchAgents/com.unitares.sentinel-beam.plist
+
+  Direct cutover sequence:
+    launchctl unload ~/Library/LaunchAgents/com.unitares.sentinel.plist
+    cd __UNITARES_ROOT__/elixir/sentinel
+    mix sentinel.session_backup
+    mix sentinel.cutover --to=beam --state-file __UNITARES_ROOT__/.sentinel_state
+    launchctl load ~/Library/LaunchAgents/com.unitares.sentinel-beam.plist
+
+  Rollback:
+    launchctl unload ~/Library/LaunchAgents/com.unitares.sentinel-beam.plist
+    cd __UNITARES_ROOT__/elixir/sentinel
+    mix sentinel.rollback --to=python --state-file __UNITARES_ROOT__/.sentinel_state
+    launchctl load ~/Library/LaunchAgents/com.unitares.sentinel.plist
+
+  Verify:
+    launchctl list | grep com.unitares.sentinel-beam
+    tail -f __HOME__/Library/Logs/unitares-sentinel-beam.log
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.unitares.sentinel-beam</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__UNITARES_ROOT__/elixir/sentinel/scripts/start.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__UNITARES_ROOT__/elixir/sentinel</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/Library/Logs/unitares-sentinel-beam.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__HOME__/Library/Logs/unitares-sentinel-beam.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>LANG</key>
+        <string>en_US.UTF-8</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>UNITARES_SENTINEL_STATE_FILE</key>
+        <string>__UNITARES_ROOT__/.sentinel_state</string>
+        <key>UNITARES_SENTINEL_SESSION_FILE</key>
+        <string>__HOME__/.unitares/anchors/sentinel.json</string>
+        <key>UNITARES_SENTINEL_LEGACY_SESSION_FILE</key>
+        <string>__UNITARES_ROOT__/.sentinel_session</string>
+        <key>GOV_WS_URL</key>
+        <string>ws://localhost:8767/ws/eisv</string>
+        <key>UNITARES_FINDINGS_URL</key>
+        <string>http://localhost:8767/api/findings</string>
+        <key>UNITARES_GOVERNANCE_TOOLS_URL</key>
+        <string>http://localhost:8767/v1/tools/call</string>
+        <key>LEASE_PLANE_BASE_URL</key>
+        <string>http://127.0.0.1:8788</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/test_install_surface.py
+++ b/tests/test_install_surface.py
@@ -72,6 +72,7 @@ def test_no_operator_specific_defaults(relpath: str, pattern: str, rationale: st
 # Plist templates must use placeholder substitution, not live paths.
 PLIST_TEMPLATES = [
     "scripts/ops/com.unitares.sentinel.plist.template",
+    "scripts/ops/com.unitares.sentinel-beam.plist.template",
     "scripts/ops/com.unitares.vigil.plist.template",
     "scripts/ops/com.unitares.gateway-mcp.plist.template",
     "scripts/ops/com.unitares.governance-backup.plist.template",
@@ -96,3 +97,23 @@ def test_plist_template_uses_placeholders(relpath: str) -> None:
     assert "__UNITARES_ROOT__" in content or "__HOME__" in content, (
         f"plist template has no __UNITARES_ROOT__ or __HOME__ placeholder: {relpath}"
     )
+
+
+def test_beam_sentinel_launchd_entrypoint_is_cutover_ready() -> None:
+    relpath = "elixir/sentinel/scripts/start.sh"
+    content = _read(relpath)
+    required_env = [
+        "UNITARES_SENTINEL_START_APPLICATION",
+        "UNITARES_SENTINEL_START_POSTGREX",
+        "UNITARES_SENTINEL_START_FINCH",
+        "UNITARES_SENTINEL_START_FLEET_STATE",
+        "UNITARES_SENTINEL_START_WEBSOCKET",
+        "UNITARES_SENTINEL_START_FLEET_FINDING_EMITTER",
+        "UNITARES_SENTINEL_START_POLLER",
+        "UNITARES_SENTINEL_EMIT_FINDINGS",
+        "UNITARES_SENTINEL_EMIT_CHECKINS",
+    ]
+    for name in required_env:
+        assert name in content, f"{relpath} must set {name} for launchd cutover"
+    assert "/Users/" not in content, f"{relpath} must be operator-neutral"
+    assert (REPO / relpath).stat().st_mode & 0o111, f"{relpath} must be executable"


### PR DESCRIPTION
## Summary
- add BEAM Sentinel launchd plist template and executable start entrypoint
- make Sentinel supervisor/runtime gates env-driven for operator cutover
- extend install-surface guardrails and update Wave 1 RFC status

## Validation
- mix test (elixir/sentinel): 121 passed
- python3 -m pytest -q tests/test_install_surface.py: 13 passed
- make test-smoke: 8 passed
- pre-push smoke: 138 passed, 7834 deselected
- python3 scripts/diagnostics/check_doc_health.py
- plutil -lint rendered sentinel-beam plist
- bash -n elixir/sentinel/scripts/start.sh
- git diff --check