### PR TITLE
[codex] clarify Unitares public branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ This `unitares` repo is the governance server/runtime. Plugin-side `.codex-plugi
 
 ## Citation
 
-Kenny Wang ([ORCID 0009-0006-7544-2374](https://orcid.org/0009-0006-7544-2374)), cirwel Systems. If you build on this work, please cite — see [`CITATION.cff`](CITATION.cff).
+Kenny Wang ([ORCID 0009-0006-7544-2374](https://orcid.org/0009-0006-7544-2374)), CIRWEL Systems. If you build on this work, please cite — see [`CITATION.cff`](CITATION.cff).
 
 ```bibtex
 @misc{wang2026unitares,

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,89 +1,137 @@
 # Unitares Governance Dashboard
 
 **Created:** December 30, 2025
-**Last Updated:** April 2026
-**Status:** Active
-
----
+**Last updated:** May 2026
+**Status:** Active static dashboard. Phoenix/LiveView migration is deferred, not currently the implementation path.
 
 ## Overview
 
-Web-based dashboard for visualizing multi-agent coordination in real-time. Shows active agents, EISV metrics, knowledge graph discoveries, and system health.
+The dashboard is the operator web UI for Unitares. It serves from the Python governance server and shows fleet health, agent state, EISV history, knowledge graph activity, dialectic sessions, resident status, and resident-specific panels for Watcher, Sentinel, Vigil, and Chronicler.
+
+It is intentionally buildless today: plain HTML, CSS, and JavaScript served from `dashboard/`.
 
 ## Access
 
-Once the MCP server is running, access the dashboard at:
+Start the governance server, then open:
 
-- **Local:** http://127.0.0.1:8767/dashboard
-- **Root:** http://127.0.0.1:8767/ (also serves dashboard)
-- **Via tunnel:** `https://<your-domain>/dashboard` (if configured)
+- `http://127.0.0.1:8767/dashboard`
+- `http://127.0.0.1:8767/` (same dashboard)
+- `http://127.0.0.1:8767/phase` (phase-space view)
+- `https://<your-domain>/dashboard` if the server is exposed through a tunnel
 
-## Features
+If `UNITARES_HTTP_API_TOKEN` is configured, provide the token either as:
 
-### Real-Time Metrics
-- **Total Agents:** Count of all registered agents
-- **Active Agents:** Currently active agents (not paused/archived)
-- **Knowledge Discoveries:** Recent entries in the knowledge graph
-- **Dialectic Sessions:** Active peer review sessions
+- `?token=<token>` in the dashboard URL
+- `localStorage.unitares_api_token`
 
-### Agent List
-- Loads up to 200 recent agents by default, then renders 20 at a time with "Show more"
-- Displays EISV metrics (Energy, Integrity, Coherence)
-- Color-coded status indicators (active/paused/archived)
-- Real-time updates every 30 seconds
-- Local browser state can hide agents via search, status, metrics-only, production-only, trust-tier, and pagination filters
+`authFetch()` and `DashboardAPI` attach the bearer token for dashboard REST and tool calls.
 
-### Recent Discoveries
-- Latest knowledge graph entries
-- Shows summary, content, agent, and timestamp
-- Filtered by discovery type
+## Current Surfaces
 
-## Technical Details
+- **Stats:** fleet coherence, active/total agents, stuck agents, discoveries, dialectic sessions, system health, calibration, anomalies, and trust-tier distribution.
+- **Pulse:** latest governance decision, risk/confidence/complexity vitals, event sparkline, and pinned-agent support.
+- **EISV:** fleet and per-agent time-series charts backed by Chart.js.
+- **Agents:** searchable/filterable agent table with pagination, status, metrics, trust tiers, lineage badges, and operator actions.
+- **Discoveries:** recent knowledge graph entries with filters and status actions.
+- **Dialectic:** peer-review/recovery sessions, phase/status counts, and transcript views.
+- **Activity:** timeline of check-ins, verdicts, discoveries, dialectic events, lifecycle events, and resident events.
+- **Residents:** always-on fleet strip with silence detection and recent writes.
+- **Chronicler:** fleet metrics panel.
+- **Watcher:** findings pipeline and pattern status panel.
+- **Sentinel:** findings stream and severity/class breakdown.
+- **Vigil:** janitor resident cycles and write stream.
+- **Phase Space:** separate `/phase` view with E/I particles, basin contours, flow field, and live updates.
 
-### Architecture
-- **Frontend:** Pure HTML/CSS/JavaScript (no build step required)
-- **Backend:** Uses existing `/v1/tools/call` HTTP API
-- **Auto-refresh:** Polls every 30 seconds (with 25s client-side cache)
-- **Responsive:** Works on desktop and mobile
+## Architecture
 
-### API Calls
-The dashboard makes the following tool calls:
-- `agent(action='list')` — Get agent list with metrics
-- `search_knowledge_graph` — Get recent discoveries
-- `get_dialectic_session` / `list_dialectic_sessions` — Dialectic sessions and transcripts
+- **Frontend:** static `index.html`, `styles.css`, and JS modules in `dashboard/`.
+- **Charts:** Chart.js for dashboard charts; the `/phase` page uses D3.
+- **Tool calls:** `DashboardAPI.callTool()` posts to `/v1/tools/call`.
+- **REST calls:** direct dashboard endpoints use `authFetch()`.
+- **Live updates:** `/ws/eisv` streams EISV and broadcaster events. The UI falls back to polling where needed.
+- **Refresh cadence:** full dashboard refresh every 30 seconds; API client cache defaults to 25 seconds.
+- **Static-file guard:** `tests/test_dashboard_static_allowlist.py` ensures every `/dashboard/*.js` reference in `index.html` is allowlisted by `src/http_api.py`.
 
-### File Structure
-- `index.html` — Main dashboard page
-- `styles.css` — Extracted CSS (dark/light theme support)
-- `utils.js` — API client, data processing, theme manager
-- `components.js` — Reusable UI components
+## Important Files
 
-### Customization
-Edit the dashboard files to:
-- Change refresh interval (default: 30000ms)
-- Modify displayed metrics
-- Adjust styling/colors
-- Add new panels/sections
+- `index.html` - main dashboard shell and section layout.
+- `dashboard.js` - application orchestration, refresh loop, stats, modals, operator actions.
+- `utils.js` - API client, authenticated fetch, cache/retry logic, formatting helpers, WebSocket client.
+- `state.js` - shared dashboard state container.
+- `agents.js` - agent table, filters, lineage display, live agent updates.
+- `discoveries.js` - knowledge graph discovery panel.
+- `dialectic.js` - dialectic session panel and transcript rendering.
+- `eisv-charts.js` - EISV charts and WebSocket integration.
+- `timeline.js` - activity timeline and event classification.
+- `residents.js` - resident fleet strip.
+- `fleet-metrics.js` - Chronicler/fleet metrics panel.
+- `watcher.js` - Watcher findings panel.
+- `sentinel.js` - Sentinel findings panel.
+- `vigil.js` - Vigil panel.
+- `phase.html` / `phase.js` - phase-space visualization.
+
+## Backend Endpoints Used
+
+Tool calls through `/v1/tools/call` include unified tools plus a few legacy dashboard/operator entry points:
+
+- `agent(action="list" | "resume")`
+- `knowledge(action="stats")`
+- `search_knowledge_graph`
+- `dialectic(action="list")`
+- `archive_agent`
+- `operator_resume_agent`
+- `request_dialectic_review`
+- `update_discovery_status_graph`
+- `compare_agents`
+- `detect_stuck_agents`
+- `detect_anomalies`
+- `check_calibration`
+- `config(action="get" | "set")`
+
+Dedicated HTTP endpoints include:
+
+- `/health`
+- `/api/events`
+- `/api/activity`
+- `/api/incidents`
+- `/v1/residents`
+- `/v1/residents/tag_audit`
+- `/v1/watcher/summary`
+- `/v1/sentinel/summary`
+- `/v1/vigil/summary`
+- `/ws/eisv`
 
 ## Development
 
-### Local Testing
-1. Start the MCP server: `python src/mcp_server.py --port 8767`
-2. Open browser: http://127.0.0.1:8767/dashboard
-3. Edit `dashboard/index.html` and refresh
+1. Start the server:
 
-### Agent Visibility Checks
+   ```bash
+   python src/mcp_server.py --port 8767
+   ```
 
-If an agent has checked in but is not visible in the browser:
+2. Open `http://127.0.0.1:8767/dashboard`.
+3. Edit files in `dashboard/` and refresh the browser.
+4. If you add a JS or CSS file referenced by `index.html`, update the static allowlist in `src/http_api.py` and run the allowlist test.
+
+Useful checks:
+
+```bash
+pytest tests/test_dashboard_static_allowlist.py
+pytest tests/test_dashboard.py
+```
+
+## Agent Visibility Checks
+
+If an agent checked in but does not appear in the browser:
 
 1. Clear the agent search box.
 2. Set status to `All`.
 3. Disable metrics-only and production-only filters.
-4. Clear any trust-tier filter by reloading the page.
-5. Search by the UUID prefix or exact label.
+4. Clear trust-tier filters by reloading the page.
+5. Search by UUID prefix or exact label.
 6. Hard refresh the browser if the API result is correct but the view is stale.
 
-The dashboard API call is the source of truth for the browser list:
+The dashboard API call is the browser list source of truth:
 
 ```bash
 curl -s -X POST http://127.0.0.1:8767/v1/tools/call \
@@ -92,30 +140,15 @@ curl -s -X POST http://127.0.0.1:8767/v1/tools/call \
   --data '{"name":"agent","arguments":{"action":"list","include_metrics":true,"recent_days":30,"limit":200,"min_updates":0,"status_filter":"all"}}'
 ```
 
-If the agent appears in that response, ingestion and persistence are working; the remaining issue is client-side filter, pagination, cache, or stale browser state.
+If the agent appears in that response, ingestion and persistence are working. The remaining issue is usually a client-side filter, pagination state, cache, WebSocket lag, or stale browser state.
 
-### Adding New Features
-1. Add new API calls using `DashboardAPI` in `utils.js`
-2. Update HTML in `index.html` to display new data
-3. Style with CSS in `styles.css`
+## Phoenix / LiveView Status
 
-## Completed Enhancements
+The repo has active Elixir/OTP work under `elixir/lease_plane/`, but that is the BEAM coordination kernel/lease plane, not a Phoenix dashboard rewrite.
 
-- [x] Filter/search agents
-- [x] Export data (CSV/JSON) — via `utils.js` DataProcessor
-- [x] Dark/light theme toggle — via ThemeManager
-- [x] Dialectic session viewer with filters and transcript display
-- [x] Modular component architecture (`components.js`)
-- [x] Extracted CSS with theme variables (`styles.css`)
-- [x] Loading performance optimization — scoped CSS transitions, reduced API calls, fast DB paths for dialectic
+`docs/proposals/surface-lease-plane-v0.md` explicitly lists these as deferred follow-up scope:
 
-## Future Enhancements
+- Phoenix LiveView migration of the existing dashboard.
+- Phoenix PubSub migration of the existing broadcaster, Discord bridge, and dashboard WebSocket plumbing.
 
-- [ ] EISV metrics charts over time
-- [ ] Agent activity timeline
-- [ ] Knowledge graph visualization
-- [ ] Real-time WebSocket updates (instead of polling)
-
----
-
-**Status:** Active — Serving at `/dashboard`
+So the dashboard README should stay current for the static dashboard. A Phoenix migration may still be a good direction later, especially for LiveView + PubSub, but there is no checked-in Phoenix app and no active dashboard migration branch in this repo.


### PR DESCRIPTION
## Summary
- keep `Unitares` as the public product/UI/prose name
- leave formal `UNITARES` contexts intact, including the hero asset text, citation title, and environment variable names
- fix `cirwel Systems` to `CIRWEL Systems` in the root README citation line
- refresh the dashboard README to match the current static dashboard and deferred Phoenix/LiveView status

## Branding rule
- `Unitares`: human-facing product name and dashboard/UI prose
- `UNITARES`: formal research/acronym contexts and env vars
- `unitares`: repo, package, command, URL, and local-storage slugs

## Validation
- `pytest tests/test_dashboard_static_allowlist.py tests/test_dashboard.py`
- pre-push smoke hook: 138 passed
- `git diff --check`

Note: pre-push doc health reports `authFetch` in `dashboard/README.md` as a possible ghost tool; this is a dashboard JS helper reference, not an MCP tool reference.