### PR TITLE
fix(wave-1): keep BEAM Sentinel scheduler alive

### DIFF
--- a/elixir/sentinel/lib/unitares_sentinel/forced_release_poller.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/forced_release_poller.ex
@@ -389,7 +389,7 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
       running?: false
     }
 
-    Process.send_after(self(), :tick, initial_delay_ms + sample_jitter(jitter_ms))
+    Process.send_after(self(), :tick, schedule_delay(initial_delay_ms, jitter_ms))
     {:ok, state}
   end
 
@@ -413,6 +413,7 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
     try do
       case await_runtime_tick(state) do
         {:ok, next_state} ->
+          schedule_next_tick(next_state)
           {:noreply, next_state}
 
         :timeout ->
@@ -463,15 +464,16 @@ defmodule UnitaresSentinel.ForcedReleasePoller do
       persist_cursor(new_cursor, [])
     end
 
-    # Jitter the next tick to avoid Python/BEAM lockstep races after
-    # simultaneous boots (architect #5).
-    schedule_next_tick(state)
-
     %{state | running?: false, cursor: new_cursor}
   end
 
   defp schedule_next_tick(state) do
-    Process.send_after(self(), :tick, state.interval_ms + sample_jitter(state.jitter_ms))
+    Process.send_after(self(), :tick, schedule_delay(state.interval_ms, state.jitter_ms))
+  end
+
+  @doc false
+  def schedule_delay(base_ms, jitter_ms) when is_integer(base_ms) do
+    max(0, base_ms + sample_jitter(jitter_ms))
   end
 
   defp acquire_runtime_lease(%{lease_advisory?: false}),

--- a/elixir/sentinel/test/unitares_sentinel/forced_release_poller_structure_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/forced_release_poller_structure_test.exs
@@ -155,6 +155,62 @@ defmodule UnitaresSentinel.ForcedReleasePollerStructureTest do
   # §C2 — running? guard skips :tick when previous still in flight.
   # ---------------------------------------------------------------------------
 
+  test "scheduler clamps jittered delay to non-negative timer values" do
+    assert ForcedReleasePoller.schedule_delay(1_000, 0) == 1_000
+    assert ForcedReleasePoller.schedule_delay(-1, 0) == 0
+
+    for _ <- 1..1_000 do
+      assert ForcedReleasePoller.schedule_delay(1_000, 5_000) >= 0
+    end
+  end
+
+  test "GenServer self-schedules the next tick after runtime task returns" do
+    parent = self()
+    lease_id = "77777777-7777-7777-7777-777777777777"
+
+    lease_http_post = fn url, body, _headers, _timeout_ms ->
+      cond do
+        String.ends_with?(url, "/v1/lease/acquire") ->
+          send(parent, {:lease_acquire, body})
+
+          {:ok, 200,
+           Jason.encode!(%{
+             ok: true,
+             idempotent: false,
+             lease: %{lease_id: lease_id},
+             drift_warning: []
+           })}
+
+        String.ends_with?(url, "/v1/lease/release") ->
+          {:ok, 200, ~s({"ok":true})}
+      end
+    end
+
+    {:ok, pid} =
+      GenServer.start(
+        ForcedReleasePoller,
+        [
+          db: UnitaresSentinel.DB,
+          interval_ms: 20,
+          initial_delay_ms: 1,
+          jitter_ms: 0,
+          tick_timeout_ms: 1_000,
+          lease_advisory: true,
+          lease_opts: [
+            base_url: "http://lease.test",
+            bearer_token: "test-token",
+            http_post: lease_http_post
+          ]
+        ],
+        name: :"test_self_schedule_#{System.unique_integer([:positive])}"
+      )
+
+    assert_receive {:lease_acquire, _first}, 1_000
+    assert_receive {:lease_acquire, _second}, 1_000
+
+    GenServer.stop(pid)
+  end
+
   test "GenServer skips :tick when running? is true (mailbox guard)" do
     # Verifier-confirmed (PR #378 council): deleting the
     # `handle_info(:tick, %{running?: true})` head causes this test to fail


### PR DESCRIPTION
## Summary
- clamp jittered Sentinel poller timer delays to non-negative values
- schedule follow-up ticks from the GenServer process after the runtime task returns
- add structure tests for both launch-time jitter clamp and repeated self-scheduled ticks

## Production note
- discovered during live BEAM Sentinel canary after PR #392
- Python Sentinel was rolled back, patch applied, and BEAM canary retried successfully

## Validation
- mix test test/unitares_sentinel/forced_release_poller_structure_test.exs: 8 passed
- mix test (elixir/sentinel): 123 passed
- pre-push smoke: 138 passed, 7834 deselected
- doc health: all clear
- live BEAM canary: WebSocket connected and repeated lease acquire/release ticks observed