### PR TITLE
[codex] surface SDK MCP tool failures

### DIFF
--- a/agents/sdk/src/unitares_sdk/client.py
+++ b/agents/sdk/src/unitares_sdk/client.py
@@ -180,7 +180,14 @@ class GovernanceClient:
             try:
                 with anyio.fail_after(effective_timeout):
                     result = await self._session.call_tool(tool_name, injected_args)
-                return self._parse_mcp_result(result)
+                raw = self._parse_mcp_result(result)
+                # Centralized failure check. The MCP transport can succeed at
+                # the HTTP layer but carry a structured tool failure inside
+                # the JSON payload. Without this check, callers like onboard()
+                # and identity() would silently extract empty identity fields
+                # from a failure response (dogfood pulse 2026-05-03 regression).
+                self._raise_for_tool_failure(tool_name, raw)
+                return raw
 
             except TimeoutError:
                 last_error = GovernanceTimeoutError(
@@ -482,7 +489,16 @@ class GovernanceClient:
         return args
 
     def _capture_identity(self, raw: dict) -> None:
-        """Extract and store session ID, continuity token, and UUID from a response."""
+        """Extract and store session ID, continuity token, and UUID from a response.
+
+        Skips extraction when the response declares failure — extracted
+        fields would be None and would silently overwrite nothing while
+        hiding the upstream error. call_tool() already raises in that case;
+        this is a defensive guard for callers that pass arbitrary dicts.
+        """
+        if raw.get("success") is False:
+            return
+
         sid = self._extract_session_id(raw)
         token = self._extract_continuity_token(raw)
         uuid = self._extract_uuid(raw)
@@ -530,7 +546,23 @@ class GovernanceClient:
 
     @staticmethod
     def _parse_mcp_result(result: Any) -> dict:
-        """Parse MCP tool result content blocks into a merged dict."""
+        """Parse MCP tool result content blocks into a merged dict.
+
+        Raises GovernanceConnectionError when the MCP layer marked the
+        call as an error (result.isError). HTTP-level success does not
+        imply tool-level success: the streamable_http transport can wrap
+        a structured failure in an otherwise-200 response.
+        """
+        if getattr(result, "isError", False):
+            error_text = ""
+            for content in getattr(result, "content", []) or []:
+                if hasattr(content, "text"):
+                    error_text = content.text
+                    break
+            raise GovernanceConnectionError(
+                f"MCP tool returned isError=true: {error_text or 'no detail'}"
+            )
+
         final: dict = {}
         raw_texts: list[str] = []
         json_parsed = False

--- a/agents/sdk/src/unitares_sdk/sync_client.py
+++ b/agents/sdk/src/unitares_sdk/sync_client.py
@@ -428,6 +428,12 @@ class SyncGovernanceClient:
         return args
 
     def _capture_identity(self, raw: dict) -> None:
+        # See GovernanceClient._capture_identity for why this short-circuits
+        # on declared failure. call_tool() raises in that case, but external
+        # callers may pass arbitrary dicts.
+        if raw.get("success") is False:
+            return
+
         from unitares_sdk.client import GovernanceClient
 
         sid = GovernanceClient._extract_session_id(raw)

--- a/agents/sdk/tests/test_client.py
+++ b/agents/sdk/tests/test_client.py
@@ -172,6 +172,56 @@ class TestMCPParsing:
         )
         assert result["success"] is False
 
+    def test_isError_true_raises(self):
+        # Dogfood pulse 2026-05-03 regression: after a governance restart
+        # the MCP layer returned isError=true with a textual error, but the
+        # SDK silently parsed empty content and proceeded.
+        @dataclass
+        class FakeErrorResult:
+            content: list
+            isError: bool
+
+        with pytest.raises(GovernanceConnectionError, match="boom"):
+            GovernanceClient._parse_mcp_result(
+                FakeErrorResult(
+                    content=[FakeTextContent(text="boom")],
+                    isError=True,
+                )
+            )
+
+
+class TestCaptureIdentitySkipsFailures:
+    def test_skips_extraction_on_inner_failure(self):
+        # Even if a failure response contains a stale uuid field, we must
+        # not silently overwrite identity state from it.
+        client = GovernanceClient()
+        client._capture_identity({
+            "success": False,
+            "error": "governance restarted",
+            "uuid": "u-stale",
+            "continuity_token": "tok-stale",
+        })
+        assert client.agent_uuid is None
+        assert client.continuity_token is None
+
+
+class TestOnboardFailureSurfaces:
+    @pytest.mark.asyncio
+    async def test_onboard_inner_failure_raises(self):
+        # Before the fix, onboard() never called _raise_for_tool_failure,
+        # so a {success: False} response left the client with a None uuid
+        # and proceeded as if onboarding succeeded.
+        session = AsyncMock()
+        session.call_tool = AsyncMock(return_value=make_mcp_result({
+            "success": False,
+            "error": "governance restarted",
+        }))
+        client = make_client_with_session(session)
+
+        with pytest.raises(GovernanceConnectionError, match="governance restarted"):
+            await client.onboard("TestAgent")
+        assert client.agent_uuid is None
+
 
 # --- Tool name mapping ---
 


### PR DESCRIPTION
## Summary

- raises async SDK `call_tool()` responses when the parsed payload has `success: false`
- raises when MCP returns an `isError=true` result envelope
- avoids capturing identity/session fields from declared failure payloads
- adds regression tests for MCP error envelopes, failure payload identity capture, and onboard failure surfacing

## Why

A governance restart can return a transport-successful MCP response that still carries tool-level failure. The SDK previously parsed that as ordinary data in some paths, letting callers proceed with empty or stale identity state.

## Validation

- `python3 -m pytest agents/sdk/tests/test_client.py agents/sdk/tests/test_sync_client.py -q --tb=short`
- pre-push smoke: `138 passed, 7834 deselected`
- pre-push doc health: all clear
