### PR TITLE
[codex] refresh stale README references

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,20 +80,20 @@ The agent reads its own metrics and adjusts *before* external controls have to f
 
 ## Production snapshot
 
-As of April 2026 (single-operator deployment — self-traffic, not external adoption). Headline: **94K+ governance events processed · ≈51K in the last 7 days**.
+As of May 6, 2026 (single-operator deployment — self-traffic, not external adoption). Headline: **351K+ governance events processed · ≈94K in the last 7 days**.
 
 <details>
 <summary><strong>Full metrics table</strong></summary>
 
 | Metric | Value |
 |--------|-------|
-| Agents onboarded | 2,574 total process-instances — overwhelmingly ephemeral CLI sessions from one operator's workstation plus a handful of long-running resident agents (launchd crons, Pi-side Lumen) |
-| Distinct external (non-resident) agents | ~56 over a 3-week post-grounding window |
-| Unique agents active (last 7 days) | 2,226 |
-| Governance events processed | 94,000+ (≈51K in the last 7 days) |
-| Knowledge graph discoveries | 578 |
+| Agents onboarded | 3,660 total process-instances — overwhelmingly ephemeral CLI sessions from one operator's workstation plus a handful of long-running resident agents (launchd crons, Pi-side Lumen) |
+| Distinct event-emitting identities (last 21 days) | 1,144 total; mostly ephemeral local CLI sessions, not external adoption |
+| Unique agents active (last 7 days) | 135 distinct event emitters |
+| Governance events processed | 351,000+ (≈94K in the last 7 days) |
+| Knowledge graph discoveries | 860 |
 | V operating range | Active agents often within [-0.1, 0.1] |
-| Tests | 6,200+ passing · ~76% line coverage (25% min gate) |
+| Tests | 8,500+ collected · smoke/pre-push subset plus 25% min coverage gate |
 
 </details>
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,6 +1,6 @@
 # agents/
 
-Reference implementations of UNITARES governance agents. These are **not** part of the public contract — the public contract is [`unitares-sdk`](sdk/) (published as its own package). Treat the code under `vigil/`, `sentinel/`, and `watcher/` as examples of how to build a resident agent, not as load-bearing governance internals.
+Reference implementations of Unitares governance agents. These are **not** part of the public contract — the public contract is [`unitares-sdk`](sdk/) (published as its own package). Treat the code under `vigil/`, `sentinel/`, and `watcher/` as examples of how to build a resident agent, not as load-bearing governance internals.
 
 ## Layout
 

--- a/agents/sdk/README.md
+++ b/agents/sdk/README.md
@@ -1,6 +1,6 @@
 # unitares-sdk
 
-Build your own UNITARES resident agent. A resident is a long-running (or
+Build your own Unitares resident agent. A resident is a long-running (or
 scheduled) process that checks in to governance, carries an EISV state
 vector, and participates in the shared knowledge graph. Vigil, Sentinel,
 and Chronicler are reference implementations.

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -24,7 +24,7 @@ If `UNITARES_HTTP_API_TOKEN` is configured, provide the token either as:
 - `?token=<token>` in the dashboard URL
 - `localStorage.unitares_api_token`
 
-`authFetch()` and `DashboardAPI` attach the bearer token for dashboard REST and tool calls.
+The `authFetch` helper and `DashboardAPI` attach the bearer token for dashboard REST and tool calls.
 
 ## Current Surfaces
 
@@ -47,7 +47,7 @@ If `UNITARES_HTTP_API_TOKEN` is configured, provide the token either as:
 - **Frontend:** static `index.html`, `styles.css`, and JS modules in `dashboard/`.
 - **Charts:** Chart.js for dashboard charts; the `/phase` page uses D3.
 - **Tool calls:** `DashboardAPI.callTool()` posts to `/v1/tools/call`.
-- **REST calls:** direct dashboard endpoints use `authFetch()`.
+- **REST calls:** direct dashboard endpoints use the `authFetch` helper.
 - **Live updates:** `/ws/eisv` streams EISV and broadcaster events. The UI falls back to polling where needed.
 - **Refresh cadence:** full dashboard refresh every 30 seconds; API client cache defaults to 25 seconds.
 - **Static-file guard:** `tests/test_dashboard_static_allowlist.py` ensures every `/dashboard/*.js` reference in `index.html` is allowlisted by `src/http_api.py`.

--- a/data/README.md
+++ b/data/README.md
@@ -1,6 +1,6 @@
 # Data Directory
 
-Runtime data for UNITARES Governance. Everything here is generated at runtime and **not tracked in git** (except this README, `.gitkeep`, and `agent_metadata.example.json`).
+Runtime data for Unitares governance. Everything here is generated at runtime and **not tracked in git** (except this README, `.gitkeep`, and `agent_metadata.example.json`).
 
 ## Structure
 
@@ -20,7 +20,7 @@ data/
 
 ## Primary Storage
 
-As of v2.6.0, PostgreSQL is the primary backend for agents, dialectic sessions, and the knowledge graph. The KG uses PostgreSQL FTS by default; AGE remains available for explicit graph traversal work. SQLite (`governance.db`) remains for some legacy state but is not the source of truth.
+Since v2.6.0, PostgreSQL is the primary backend for agents, dialectic sessions, and the knowledge graph. The KG uses PostgreSQL FTS by default; AGE remains available for explicit graph traversal work. SQLite (`governance.db`) remains for some legacy state but is not the source of truth.
 
 ## Tracked in Git
 

--- a/db/postgres/README.md
+++ b/db/postgres/README.md
@@ -1,6 +1,6 @@
 # PostgreSQL + Apache AGE Setup
 
-This directory contains the schema and setup files for migrating to PostgreSQL with Apache AGE extension.
+This directory contains the schema, migrations, and setup files for the PostgreSQL backend with Apache AGE available for graph-specific traversal work.
 
 ## Files
 
@@ -164,12 +164,18 @@ Schema versions are tracked in `core.schema_migrations`:
 SELECT version, name, applied_at FROM core.schema_migrations ORDER BY version;
 ```
 
+The table below is a milestone summary, not the full migration ledger. See `db/postgres/migrations/` for every numbered migration; the current checked-in series runs through `036_r2_lineage_lifecycle.sql`.
+
 | Version | Migration | Description |
 |---------|-----------|-------------|
 | 1 | `initial_schema` | Core tables (agents, sessions, dialectic) |
 | 2 | `knowledge_schema` | Knowledge graph tables for PostgreSQL FTS |
 | 3 | `dialectic_messages` | Dialectic messages table (migrated from SQLite) |
 | 15 | `agent_process_bindings` | Concurrent identity binding invariant (#123): `core.agent_process_bindings` + `allow_rebind_after_exit` / `allow_concurrent_contexts` flags on `core.agents` |
+| 24 | `lease_plane` | Surface lease-plane contract anchor |
+| 31 | `r1_provisional_lineage` | R1 provisional-lineage columns and audit table |
+| 35 | `coordination_events` | Wave 0 coordination-event instrumentation |
+| 36 | `r2_lineage_lifecycle` | R2 lineage lifecycle columns |
 
 The health check returns `schema_version` from this table.
 
@@ -185,14 +191,12 @@ The `/health_check` tool returns a three-tier aggregate status:
 
 The response includes a `status_breakdown` field showing counts per status type.
 
-## Migration Phases
+## Current Storage Posture
 
-1. **Phase 1**: PostgreSQL tables for agents and sessions
-2. **Phase 2**: Install AGE, create graph, dual-write discoveries
-3. **Phase 3**: Backfill historical discoveries to graph
-4. **Phase 4**: Cut over reads to AGE
-5. **Phase 5**: Remove JSON/SQLite knowledge graph paths
-6. **Phase 6**: Migrate dialectic sessions/messages to PostgreSQL (current state)
+1. PostgreSQL is the canonical runtime store for agents, identities, sessions, dialectic, audit events, outcome events, and resident/coordination telemetry.
+2. Knowledge graph reads/writes default to PostgreSQL FTS (`UNITARES_KNOWLEDGE_BACKEND=postgres` or `auto` with `DB_BACKEND=postgres`).
+3. Apache AGE remains available for explicit graph traversal experiments; it is not the default KG read path.
+4. SQLite/JSON files under `data/` are legacy or local runtime artifacts, not the source of truth for current production state.
 
 ## Troubleshooting
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,6 @@
 # Scripts Directory
 
-**Last Updated:** 2026-04-11
+**Last Updated:** 2026-05-06
 
 > **Note:** Most functionality is available via MCP tools. Scripts are for CLI-only interfaces, operations, and maintenance.
 >
@@ -14,7 +14,7 @@
 |--------|-------------|
 | `bump_epoch.py` | Bump governance epoch |
 | `check_ci_python_version_sync.py` | Verify CI Python version matches project |
-| `doc_audit.sh` | Check all three UNITARES repos for stale docs |
+| `doc_audit.sh` | Check all three Unitares repos for stale docs |
 | `test-cache.sh` | Tree-hash pytest cache (skips if tests already passed against this exact working tree) |
 | `update_docs_tool_count.py` | Update tool counts in documentation |
 | `version_manager.py` | Version management utilities |
@@ -29,16 +29,15 @@ The bulk of operational scripts live in `scripts/ops/`.
 
 | Script | Description |
 |--------|-------------|
-| `heartbeat_agent.py` | Periodic heartbeat agent for health monitoring |
 | `mcp_agent.py` | Autonomous MCP agent |
 | `operator_agent.py` | Operator-level agent with elevated permissions |
-| `governance_cli.sh` | Governance CLI wrapper |
+| `enroll_resident.py` | Enroll resident identity anchors |
 
 ### Server Lifecycle
 
 | Script / file | Description |
 |----------------|-------------|
-| `ops/com.unitares.governance-backup.plist` | LaunchAgent template: daily DB backup at 03:00 (copy to `~/Library/LaunchAgents/`, adjust paths) |
+| `ops/com.unitares.governance-backup.plist.template` | LaunchAgent template: daily DB backup at 03:00 (copy to `~/Library/LaunchAgents/`, adjust paths) |
 | `start_unitares.sh` | Start the governance MCP server |
 | `stop_unitares.sh` | Stop the governance MCP server |
 | `start_server.sh` | Alternative server start |
@@ -63,9 +62,8 @@ The bulk of operational scripts live in `scripts/ops/`.
 | Script | Description |
 |--------|-------------|
 | `emergency_fix_postgres.sh` | Emergency PostgreSQL fixes |
-| `fix_database_connections.sh` | Fix connection pool issues |
-| `cleanup_stale_connections.sh` | Clean stale database connections |
 | `cleanup_stale.sh` | General stale data cleanup |
+| `backfill_calibration.py` | Calibration maintenance/backfill helper |
 
 ### Git & CI
 


### PR DESCRIPTION
## Summary

- refreshes root README production snapshot with current local Postgres counters and pytest collection count
- removes a dashboard README `authFetch()` ghost-tool false positive while keeping the implementation reference
- aligns active README prose with the Unitares branding pattern
- removes missing scripts from `scripts/README.md` and updates the backup plist template path
- updates `db/postgres/README.md` away from old AGE-primary migration-phase language and records current migration milestones through 036

## Validation

- `python3 scripts/diagnostics/check_doc_health.py --strict`
- `python3 scripts/dev/update_docs_tool_count.py --check`
- `python3 scripts/ops/version_manager.py --check`
- README link audit for active README files
- `python3 -m pytest --collect-only -q` (`8515 tests collected`)
- pre-push smoke: `138 passed, 7835 deselected`
- pre-push doc health: all clear
