### PR TITLE
feat(sentinel-summary): aggregate sentinel_alarm_finding events alongside fleet findings

### DIFF
--- a/src/http_api.py
+++ b/src/http_api.py
@@ -1501,14 +1501,18 @@ def _sentinel_summary_from_events(
     events, now=None, window_hours=_SENTINEL_DEFAULT_WINDOW_HOURS,
     recent_limit=_SENTINEL_DEFAULT_RECENT_LIMIT,
 ):
-    """Aggregate sentinel_finding events into dashboard-ready shape.
+    """Aggregate sentinel_finding and sentinel_alarm_finding events into
+    dashboard-ready shape.
 
     Pure function so tests can feed parsed-dict events and assert on the
     output without standing up Starlette or the event_detector singleton.
 
-    Unlike Watcher, sentinel findings have no open/closed lifecycle — they're
-    transient fleet-state signals. The aggregator surfaces severity + violation
-    class counts and a chronological stream, not an actionable queue.
+    Two event shapes are accepted: fleet-analysis findings (carry
+    `finding_type` + `violation_class`) and forced-release alarms (carry
+    `alarm_kind`, no violation class assigned in taxonomy yet). Stream
+    entries fall back `finding_type` to `alarm_kind` so the dashboard panel
+    has a non-null finding_type column for alarm rows. Sentinel findings
+    have no open/closed lifecycle — they're transient fleet-state signals.
     """
     from collections import Counter, defaultdict
     from datetime import datetime, timedelta, timezone
@@ -1569,7 +1573,9 @@ def _sentinel_summary_from_events(
             "timestamp": e.get("timestamp"),
             "severity": e.get("severity"),
             "violation_class": e.get("violation_class"),
-            "finding_type": e.get("finding_type"),
+            # Alarm events don't carry finding_type — fall back to alarm_kind
+            # so the dashboard panel doesn't show a blank cell.
+            "finding_type": e.get("finding_type") or e.get("alarm_kind"),
             "message": e.get("message"),
             "agent_id": e.get("agent_id"),
             "event_id": e.get("event_id"),
@@ -1588,13 +1594,15 @@ def _sentinel_summary_from_events(
 
 
 async def http_sentinel_summary(request):
-    """GET /v1/sentinel/summary — aggregate recent sentinel_finding events
-    for the dashboard panel.
+    """GET /v1/sentinel/summary — aggregate recent sentinel_finding and
+    sentinel_alarm_finding events for the dashboard panel.
 
     Reads from event_detector's in-memory ring buffer (same source that
     powers the live event stream). Transient across governance-mcp
     restarts by design — sentinel findings are fleet-state signals, not a
-    historical backlog."""
+    historical backlog. Both fleet-analysis findings and forced-release
+    alarms are surfaced together so the panel reflects the full Sentinel
+    output stream (Surface 2 + Surface 3 + Surface 4)."""
     http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
     if not _check_http_auth(request, http_api_token=http_api_token):
         return _http_unauthorized()
@@ -1612,9 +1620,16 @@ async def http_sentinel_summary(request):
     recent_limit = max(1, min(recent_limit, 500))
 
     from src.event_detector import event_detector
-    events = event_detector.get_recent_events(
+    # Fetch both Sentinel emit shapes. Pre-2026-05-06 the alarm path's
+    # `type` was `sentinel_forced_release_alarm` and got 400'd at the gate
+    # (#398); now that it lands as `sentinel_alarm_finding`, the panel
+    # also has to look it up here or alarms remain invisible.
+    events = list(event_detector.get_recent_events(
         event_type="sentinel_finding", limit=500,
-    )
+    ))
+    events.extend(event_detector.get_recent_events(
+        event_type="sentinel_alarm_finding", limit=500,
+    ))
 
     summary = _sentinel_summary_from_events(
         events, window_hours=window_hours, recent_limit=recent_limit,

--- a/tests/test_http_api_sentinel_summary.py
+++ b/tests/test_http_api_sentinel_summary.py
@@ -170,3 +170,83 @@ class TestRobustness:
     def test_missing_severity_falls_under_question_mark(self):
         out = _sentinel_summary_from_events([_event(severity=None)], now=NOW)
         assert out["by_severity"] == {"?": 1}
+
+
+class TestAlarmEventsSurface:
+    """Forced-release alarm follow-up to PR #398 (2026-05-06).
+
+    Pre-fix: alarms posted with `type="sentinel_forced_release_alarm"` were
+    400'd by the /api/findings suffix gate, so the dashboard never saw them.
+    PR #398 renamed the type to `sentinel_alarm_finding` so it satisfies the
+    `_finding` suffix. This test class pins the aggregator's contract so
+    alarms ride into the panel along with fleet-analysis findings — without
+    this, fixing the suffix gate alone leaves alarms invisible.
+    """
+
+    def _alarm(self, **kwargs):
+        base = {
+            "type": "sentinel_alarm_finding",
+            "severity": "high",
+            "message": "forced release: dialectic:/x (lease lease-1)",
+            "agent_id": "sentinel-uuid",
+            "agent_name": "Sentinel",
+            "fingerprint": "forced_release:ad_hoc:event-1",
+            "alarm_kind": "ad_hoc",
+            "timestamp": NOW.isoformat(),
+            "event_id": 100,
+        }
+        base.update(kwargs)
+        return base
+
+    def test_alarms_count_toward_total(self):
+        """Mixed stream: 2 fleet findings + 1 alarm → total 3."""
+        events = [
+            _event(event_id=1),
+            _event(event_id=2),
+            self._alarm(event_id=3),
+        ]
+        out = _sentinel_summary_from_events(events, now=NOW)
+        assert out["total"] == 3, (
+            "alarm events must count toward the panel's total — otherwise "
+            "the suffix-gate fix leaves them silently invisible"
+        )
+
+    def test_alarms_appear_in_recent_stream(self):
+        out = _sentinel_summary_from_events([self._alarm()], now=NOW)
+        assert len(out["recent"]) == 1
+        row = out["recent"][0]
+        assert row["message"] == "forced release: dialectic:/x (lease lease-1)"
+        assert row["severity"] == "high"
+
+    def test_alarm_finding_type_falls_back_to_alarm_kind(self):
+        """Alarms don't carry `finding_type` (only `alarm_kind`), so the
+        recent-stream `finding_type` must fall back to alarm_kind. Otherwise
+        the dashboard finding_type column shows null for every alarm row.
+        """
+        out = _sentinel_summary_from_events(
+            [self._alarm(alarm_kind="conflict_batch")],
+            now=NOW,
+        )
+        assert out["recent"][0]["finding_type"] == "conflict_batch"
+
+    def test_explicit_finding_type_wins_over_alarm_kind(self):
+        """If a future producer sets both fields, finding_type wins — we
+        only fall back when finding_type is absent. Pinning this stops a
+        later refactor from silently swapping precedence.
+        """
+        out = _sentinel_summary_from_events(
+            [self._alarm(finding_type="custom", alarm_kind="ad_hoc")],
+            now=NOW,
+        )
+        assert out["recent"][0]["finding_type"] == "custom"
+
+    def test_alarm_severity_aggregates_with_findings(self):
+        """One high alarm + one warning finding → by_severity {high:1, warning:1}.
+        Severities mix freely — no separate alarm bucket.
+        """
+        events = [
+            _event(event_id=1, severity="warning"),
+            self._alarm(event_id=2, severity="high"),
+        ]
+        out = _sentinel_summary_from_events(events, now=NOW)
+        assert out["by_severity"] == {"warning": 1, "high": 1}


### PR DESCRIPTION
Follow-up to #398 (sentinel `_finding`-suffixed type fix).

Without this change, fixing the suffix gate alone leaves forced-release alarms accepted by `/api/findings` but invisible on the dashboard panel — `/v1/sentinel/summary` was filtering events by `event_type="sentinel_finding"` only, so the new `sentinel_alarm_finding` type would never surface.

## Changes
- `http_sentinel_summary` now fetches both `sentinel_finding` and `sentinel_alarm_finding` events
- `_sentinel_summary_from_events` falls back `finding_type` → `alarm_kind` in the recent stream so alarm rows have a non-null finding_type column
- New `TestAlarmEventsSurface` test class pins the contract: total counts include alarms, recent stream includes alarms, alarm_kind fallback works, finding_type wins when both fields present, severities mix freely

## Out of scope (pre-existing, separate decisions)
- Vigil's `_SENTINEL_AUDIT_TRIGGERS` doesn't include alarm kinds — but Vigil reads from KG notes, not events, so this is independent
- Taxonomy YAML doesn't map alarm kinds (`ad_hoc` / `deprecation_batch` / `conflict_batch`) to violation classes — alarm bodies don't carry `finding_type` so the lookup wouldn't fire anyway. Punt to a future taxonomy pass

## Test plan
- 19/19 tests pass in `tests/test_http_api_sentinel_summary.py` (5 new in `TestAlarmEventsSurface`)
- 8486/8486 full Python suite passes
- 138/138 pre-push smoke