### PR TITLE
feat(dialectic): emit dialectic_resolved outcome_event on resume

### DIFF
--- a/src/mcp_handlers/dialectic/resolution.py
+++ b/src/mcp_handlers/dialectic/resolution.py
@@ -12,6 +12,7 @@ from src.dialectic_protocol import DialecticSession, Resolution
 from src.logging_utils import get_logger
 from ..support.condition_parser import parse_condition, apply_condition
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
+from src.mcp_handlers.observability.outcome_events import _record_outcome_event_inline
 logger = get_logger(__name__)
 
 async def execute_resolution(session: DialecticSession, resolution: Resolution) -> Dict[str, Any]:
@@ -151,13 +152,47 @@ async def execute_resolution(session: DialecticSession, resolution: Resolution) 
         "applied_conditions": applied_conditions,
         "resolution_hash": resolution.hash()
     }
-    
+
     # Add discovery update info if present
     if session.discovery_id:
         result["discovery_id"] = session.discovery_id
         result["discovery_updated"] = discovery_updated
         if discovery_updated:
             result["discovery_status"] = "resolved" if resolution.action == "resume" else "open"
-    
+
+    # Emit outcome_event so downstream calibration / back-tests can correlate
+    # resumption with subsequent agent state. dialectic_resolved is neutral
+    # (process succeeded); whether conditions hold up is a separate later test.
+    # Failure isolation: emit failure must not break resolution execution.
+    try:
+        applied_count = sum(
+            1 for c in applied_conditions
+            if isinstance(c, dict) and c.get("status") != "failed"
+        )
+        await _record_outcome_event_inline({
+            "agent_id": agent_id,
+            "outcome_type": "dialectic_resolved",
+            "is_bad": False,
+            "outcome_score": 1.0,
+            "decision_action": "proceed",
+            "detail": {
+                "dialectic_session_id": session.session_id,
+                "session_type": getattr(session, "session_type", None),
+                "root_cause": resolution.root_cause,
+                "conditions": resolution.conditions,
+                "conditions_applied": applied_count,
+                "conditions_total": len(applied_conditions),
+                "synthesis_round": session.synthesis_round,
+                "resolution_hash": resolution.hash(),
+                "discovery_id": session.discovery_id,
+                "status_changed": status_changed,
+            },
+        })
+    except Exception as e:
+        logger.warning(
+            f"outcome_event emit on dialectic_resolved failed for "
+            f"session {session.session_id}: {e}"
+        )
+
     return result
 

--- a/src/mcp_handlers/observability/outcome_events.py
+++ b/src/mcp_handlers/observability/outcome_events.py
@@ -20,7 +20,11 @@ logger = get_logger(__name__)
 # Outcome types that are considered "bad" by default
 BAD_OUTCOME_TYPES = {"test_failed", "tool_rejected", "drawing_abandoned", "task_failed"}
 GOOD_OUTCOME_TYPES = {"test_passed", "drawing_completed", "task_completed"}
-NEUTRAL_OUTCOME_TYPES = {"trajectory_validated"}  # is_bad determined by score
+# dialectic_resolved is neutral: agreement was reached, but whether the
+# resolution holds up under the agreed conditions is a separate later test.
+# Recording it closes the dialectic→outcome_events tracking gap so downstream
+# back-tests can correlate resumption with subsequent agent state.
+NEUTRAL_OUTCOME_TYPES = {"trajectory_validated", "dialectic_resolved"}  # is_bad determined by score
 VALID_OUTCOME_TYPES = BAD_OUTCOME_TYPES | GOOD_OUTCOME_TYPES | NEUTRAL_OUTCOME_TYPES
 
 _HARD_EXOGENOUS_DETAIL_KEYS = (

--- a/src/mcp_handlers/schemas/core.py
+++ b/src/mcp_handlers/schemas/core.py
@@ -255,7 +255,7 @@ class ProcessAgentUpdateParams(AgentIdentityMixin):
 
 class OutcomeEventParams(AgentIdentityMixin):
     """Parameters for outcome_event"""
-    outcome_type: Literal["drawing_completed", "drawing_abandoned", "test_passed", "test_failed", "tool_rejected", "task_completed", "task_failed", "trajectory_validated"] = Field(..., description="Type of outcome event")
+    outcome_type: Literal["drawing_completed", "drawing_abandoned", "test_passed", "test_failed", "tool_rejected", "task_completed", "task_failed", "trajectory_validated", "dialectic_resolved"] = Field(..., description="Type of outcome event")
     outcome_score: Optional[float] = Field(None, description="Quality score 0.0 (worst) to 1.0 (best). Inferred from type if omitted.")
     is_bad: Optional[bool] = Field(None, description="Whether this is a negative outcome. Inferred from type if omitted.")
     detail: Optional[Dict[str, Any]] = Field(None, description="Type-specific metadata (e.g., mark_count, test_name, error_message)")

--- a/tests/test_dialectic_outcome_events.py
+++ b/tests/test_dialectic_outcome_events.py
@@ -1,0 +1,129 @@
+"""
+Closes the dialectic→outcome_events tracking gap surfaced by the
+2026-05-06 council review: 0 outcome_events referenced any dialectic
+session_id across 47 historical sessions, leaving 98.5% agrees=True
+resolutions with no downstream coupling. execute_resolution now emits
+a neutral `dialectic_resolved` outcome_event so back-tests can correlate
+resumption with subsequent agent state.
+"""
+
+import pytest
+import sys
+from pathlib import Path
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch, MagicMock
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from tests.helpers import make_agent_meta, make_mock_server
+
+
+AGENT_ID = "paused-agent-under-test"
+
+
+def _resolution(conditions=None, root_cause="agreed root cause"):
+    from src.dialectic_protocol import Resolution
+    return Resolution(
+        action="resume",
+        conditions=conditions or [],
+        root_cause=root_cause,
+        reasoning="merged reasoning",
+        signature_a="sig_a",
+        signature_b="sig_b",
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+def _session(session_type="recovery", discovery_id=None, synthesis_round=1):
+    session = MagicMock()
+    session.paused_agent_id = AGENT_ID
+    session.discovery_id = discovery_id
+    session.session_id = "dialectic-sess-abc123"
+    session.dispute_type = None
+    session.session_type = session_type
+    session.synthesis_round = synthesis_round
+    return session
+
+
+def _patch_targets(emit_mock):
+    meta = make_agent_meta(status="paused", paused_at="2026-04-16T10:00:00+00:00")
+    server = make_mock_server()
+    server.agent_metadata = {AGENT_ID: meta}
+    server.load_metadata_async = AsyncMock(return_value=None)
+    storage = MagicMock()
+    storage.update_agent = AsyncMock(return_value=True)
+    storage.persist_runtime_state = AsyncMock(return_value=True)
+    return server, storage, patch.multiple(
+        "src.mcp_handlers.dialectic.resolution",
+        mcp_server=server,
+        _record_outcome_event_inline=emit_mock,
+    ), patch("src.agent_storage", storage)
+
+
+class TestExecuteResolutionEmitsOutcomeEvent:
+    @pytest.mark.asyncio
+    async def test_emits_dialectic_resolved_with_session_id_in_detail(self):
+        emit = AsyncMock(return_value={"outcome_id": "evt-1"})
+        session = _session(synthesis_round=2)
+        resolution = _resolution(conditions=["monitor for 24h", "reduce complexity to 0.3"])
+
+        _, _, p_module, p_storage = _patch_targets(emit)
+        with p_module, p_storage:
+            from src.mcp_handlers.dialectic.resolution import execute_resolution
+            result = await execute_resolution(session, resolution)
+
+        assert result["success"] is True
+        emit.assert_awaited_once()
+        args = emit.await_args.args[0]
+        assert args["outcome_type"] == "dialectic_resolved"
+        assert args["agent_id"] == AGENT_ID
+        assert args["is_bad"] is False
+        assert args["outcome_score"] == 1.0
+        assert args["decision_action"] == "proceed"
+        detail = args["detail"]
+        assert detail["dialectic_session_id"] == "dialectic-sess-abc123"
+        assert detail["session_type"] == "recovery"
+        assert detail["root_cause"] == "agreed root cause"
+        assert detail["conditions"] == ["monitor for 24h", "reduce complexity to 0.3"]
+        assert detail["synthesis_round"] == 2
+        assert detail["status_changed"] is True
+        assert "resolution_hash" in detail
+
+    @pytest.mark.asyncio
+    async def test_emit_failure_does_not_break_resolution(self):
+        emit = AsyncMock(side_effect=RuntimeError("simulated db outage"))
+        session = _session()
+        resolution = _resolution()
+
+        _, storage, p_module, p_storage = _patch_targets(emit)
+        with p_module, p_storage:
+            from src.mcp_handlers.dialectic.resolution import execute_resolution
+            result = await execute_resolution(session, resolution)
+
+        assert result["success"] is True
+        assert result["new_status"] == "active"
+        emit.assert_awaited_once()
+        storage.persist_runtime_state.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_conditions_applied_count_excludes_failed(self):
+        emit = AsyncMock(return_value={"outcome_id": "evt-2"})
+        session = _session()
+        resolution = _resolution(conditions=["c1", "c2", "c3"])
+
+        _, _, p_module, p_storage = _patch_targets(emit)
+        from src.mcp_handlers.dialectic import resolution as resolution_mod
+
+        async def fake_apply(parsed, agent_id, server):
+            cond = parsed.get("raw") if isinstance(parsed, dict) else None
+            return {"condition": cond, "status": "failed" if cond == "c2" else "applied"}
+
+        with p_module, p_storage, \
+             patch.object(resolution_mod, "parse_condition", side_effect=lambda c: {"raw": c}), \
+             patch.object(resolution_mod, "apply_condition", side_effect=fake_apply):
+            await resolution_mod.execute_resolution(session, resolution)
+
+        detail = emit.await_args.args[0]["detail"]
+        assert detail["conditions_total"] == 3
+        assert detail["conditions_applied"] == 2  # c2 failed


### PR DESCRIPTION
## Summary

Closes the dialectic→outcome_events tracking gap surfaced by the 2026-05-06 council review:

- 47 historical sessions, 0 outcome_events referenced any dialectic session_id
- 98.5% of synthesis messages carry `agrees=True`, but resolution had no downstream coupling
- The Mercor failure mode (verdict dressed as note) was structurally possible because nothing ever back-tested whether resolved conditions held up

`execute_resolution` now emits a neutral `dialectic_resolved` outcome_event after a successful resume, carrying `dialectic_session_id`, `session_type`, `root_cause`, `conditions`, applied count, `synthesis_round`, and `resolution_hash` in the detail dict. Read-only addition: protocol behavior is unchanged; this just opens the data channel so back-tests and calibration can correlate resumption with subsequent agent state.

## Path-A context

This is PR1 of a four-PR Path-A stabilization sequence on the dialectic surface:

1. **PR1 (this PR)** — wire outcome_event on success path
2. PR2 — cleanup: retire `appointed_mediator_id` ghost field, `DialecticPhase.ESCALATED` (0/47 uses), quorum_voting (NULL across all rows)
3. PR3 — TOCTOU lock on phase transition (concurrent synthesis can both pass phase check)
4. PR4 — bilateral attestation fix (`signature_a` + `signature_b` currently sign the same message with different keys)

Failure-path emission (timeout / safety-violation / execution-error) deferred to a follow-up; this PR covers the success path that all 31 historical RESOLVED sessions flow through.

## Test plan

- [x] New test file `tests/test_dialectic_outcome_events.py` (3 tests):
  - emits `dialectic_resolved` with session_id in detail
  - emit failure does not break resolution execution
  - applied-count excludes failed conditions
- [x] Full test suite: 8484 passed, 34 skipped (AGE), 0 regressions
- [ ] Post-merge: query `audit.outcome_events WHERE outcome_type='dialectic_resolved'` after a real dialectic resolution to confirm wire-up fires in production

## Watcher findings

3 P011 findings flagged on lines 74-76 of resolution.py (`meta.status`, `meta.paused_at`, `add_lifecycle_event`) — all false positives. Those mutations are followed immediately by `persist_runtime_state(...)` at lines 80-90, which is the PR #359 P011 fix the watcher's line-local heuristic doesn't trace.

Fingerprints: #ef6b1dac, #9f37ae65, #13ab2cf8