### PR TITLE
fix(test-cache): guard PYTEST_EXTRA[@] expansion for bash 3.2 compat

### DIFF
--- a/scripts/dev/test-cache.sh
+++ b/scripts/dev/test-cache.sh
@@ -118,7 +118,7 @@ else
     TREE_HASH=$(_hash_worktree_python)
 fi
 
-PYTEST_ARGS_HASH=$(_hash_pytest_args "${PYTEST_EXTRA[@]}")
+PYTEST_ARGS_HASH=$(_hash_pytest_args ${PYTEST_EXTRA[@]+"${PYTEST_EXTRA[@]}"})
 CACHE_KEY=$(printf '%s\0%s\0%s\0%s\0' "$CACHE_VERSION" "$HASH_MODE" "$TREE_HASH" "$PYTEST_ARGS_HASH" | shasum -a 256 | cut -d' ' -f1)
 CACHE_FILE="$CACHE_DIR/$CACHE_KEY"
 CACHE_LABEL="$HASH_MODE tree $TREE_HASH"


### PR DESCRIPTION
## Summary

macOS ships bash 3.2 by default. Under \`set -u\` the bare \`\${PYTEST_EXTRA[@]}\` expansion at line 121 errors when the array is empty (no trailing pytest args passed):

\`\`\`
./scripts/dev/test-cache.sh: line 121: PYTEST_EXTRA[@]: unbound variable
\`\`\`

Apply the same \`\${arr[@]+\"\${arr[@]}\"}\` guard pattern already used at line 191 of this same script — consistent with existing convention, one-line change, no behavior change when PYTEST_EXTRA is non-empty.

## Reproduce

\`\`\`bash
bash --version  # 3.2.x on macOS default
./scripts/dev/test-cache.sh   # errors at line 121
\`\`\`

## Test plan

- [x] Synthetic bash 3.2 verification: empty array hashes to e3b0c44... (sha256 of empty input), non-empty array hashes distinctly
- [x] Pattern matches the existing guarded expansion at line 191 of the same script
- [ ] Post-merge: confirm \`./scripts/dev/test-cache.sh\` runs end-to-end on a fresh macOS shell