### PR TITLE
chore(dialectic): remove appointed_mediator_id ghost field (NEW-3)

### DIFF
--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -1199,17 +1199,13 @@ async def handle_submit_synthesis(arguments: Dict[str, Any]) -> Sequence[TextCon
         # a compensating allow-list, any registered agent could drive a
         # synthesis to convergence and trigger resolution execution — a real
         # privilege escalation surface. The allow-list is: the paused agent,
-        # the assigned reviewer, any quorum reviewer (if escalated), and an
-        # appointed mediator if one has been set.
+        # the assigned reviewer, and any quorum reviewer (if escalated).
         eligible = set()
         if getattr(session, "paused_agent_id", None):
             eligible.add(session.paused_agent_id)
         if getattr(session, "reviewer_agent_id", None):
             eligible.add(session.reviewer_agent_id)
         eligible.update(getattr(session, "quorum_reviewer_ids", []) or [])
-        appointed_mediator = getattr(session, "appointed_mediator_id", None)
-        if appointed_mediator:
-            eligible.add(appointed_mediator)
         agent_uuid = resolve_agent_uuid(arguments, agent_id)
         if agent_id not in eligible and (not agent_uuid or agent_uuid not in eligible):
             return [error_response(

--- a/tests/test_dialectic_handlers.py
+++ b/tests/test_dialectic_handlers.py
@@ -905,16 +905,19 @@ class TestHandleSubmitSynthesis:
         assert data["success"] is False
 
     @pytest.mark.asyncio
-    async def test_synthesis_third_party_mediator(
+    async def test_synthesis_rejects_non_participant(
         self, mock_server, mock_pg_add_message, mock_pg_update_phase,
         mock_save_session, mock_context_agent,
     ):
-        """Third-party mediator can submit synthesis (resolves if agrees=True)."""
+        """Non-participants are rejected from submit_synthesis. The
+        appointed_mediator_id field was a ghost (never set anywhere); removing
+        it closes the privilege-escalation surface where any registered agent
+        could mutate a session in_memory and drive synthesis to convergence.
+        """
         from src.mcp_handlers.dialectic.handlers import handle_submit_synthesis
 
         session = _make_session(phase=DialecticPhase.SYNTHESIS)
         session.synthesis_round = 1
-        session.appointed_mediator_id = "agent-mediator"
 
         with patch(f"{DIALECTIC}.load_session", new_callable=AsyncMock,
                    return_value=session), \
@@ -922,13 +925,14 @@ class TestHandleSubmitSynthesis:
              mock_context_agent:
             result = await handle_submit_synthesis({
                 "session_id": session.session_id,
-                "agent_id": "agent-mediator",
+                "agent_id": "agent-not-a-participant",
                 "proposed_conditions": ["Test"],
                 "api_key": "key",
             })
 
         data = parse_result(result)
-        assert data["success"] is True
+        assert data["success"] is False
+        assert "not a participant" in data.get("error", "").lower()
 
     @pytest.mark.asyncio
     async def test_max_rounds_exceeded(


### PR DESCRIPTION
## Summary

The \`appointed_mediator_id\` field was referenced via \`getattr\` in \`handle_submit_synthesis\`'s eligibility gate (handlers.py:1210-1212) but never set anywhere — no \`DialecticSession.__init__\` default, no DB column, no MCP handler that sets it. The 2026-05-06 council code-review (NEW-3) flagged it as permanently inert dead code that nonetheless suggested mediator support existed.

This is the smallest piece of the path-A PR2 cleanup. The larger ESCALATED + quorum_voting retirement is queued separately because it crosses the >200-LOC test-deletion gate from CLAUDE.md and warrants explicit operator sign-off.

## What changes

- \`src/mcp_handlers/dialectic/handlers.py\`: drop the \`getattr(session, \"appointed_mediator_id\", None)\` block + \`if appointed_mediator: eligible.add(...)\` from the synthesis eligibility gate. Update the doc comment.
- \`tests/test_dialectic_handlers.py\`: \`test_synthesis_third_party_mediator\` (which mutated the ghost field manually to exercise dead behavior) → \`test_synthesis_rejects_non_participant\`, asserting the now-closed gate as a security regression test.

## Path-A context

PR2a of the dialectic stabilization sequence:

1. PR1 (#400) — wire \`outcome_event\` on resolution success path
2. **PR2a (this PR)** — remove \`appointed_mediator_id\` ghost field
3. PR2b/c — ESCALATED + quorum_voting retirement (pending operator call)
4. PR3 — TOCTOU lock on phase transition
5. PR4 — bilateral attestation fix

## Companion code path (no behavior change)

The third-party-mediator detection in \`DialecticSession.finalize_resolution\` (transcript scan for non-participant \`agrees=True\` synthesis) is now formally unreachable, since the eligibility gate filters non-participants before they can submit synthesis. This makes the closure explicit rather than effective. No code change required there.

## Test plan

- [x] \`tests/test_dialectic_*.py\`: 446 passed, 5 skipped (AGE)
- [x] New regression test asserts non-participant rejection with the \"not a participant\" error message