### PR TITLE
feat(wave-2): dual-write coordination_failure events to dedicated audit.coordination_events table

### DIFF
--- a/src/coordination_failure_emit.py
+++ b/src/coordination_failure_emit.py
@@ -161,17 +161,8 @@ def _schedule_coordination_events_dual_write(
             )
 
         try:
-            asyncio.get_running_loop()
-            # Use create_tracked_task (not bare loop.create_task) so the
-            # task reference is held by `_supervised_tasks` and won't be
-            # GC'd mid-flight — Watcher P001. Also gives us a crash-log
-            # callback for free if the dedicated-table coroutine raises
-            # past its own swallow (e.g., a TaskGroup cancellation).
-            from src.background_tasks import create_tracked_task
-            create_tracked_task(
-                _coro_factory(),
-                name="coord_failure_dedicated_table_write",
-            )
+            loop = asyncio.get_running_loop()
+            _spawn_dedicated_write_task(loop, _coro_factory())
             return
         except RuntimeError:
             pass
@@ -190,14 +181,7 @@ def _schedule_coordination_events_dual_write(
 
         if captured_loop is not None and captured_loop.is_running():
             def _spawn_on_main():
-                # Inside the captured loop's thread, `create_tracked_task`
-                # finds the running loop via asyncio.get_running_loop(),
-                # so the same supervised-task semantics apply here too.
-                from src.background_tasks import create_tracked_task
-                create_tracked_task(
-                    _coro_factory(),
-                    name="coord_failure_dedicated_table_write_threadsafe",
-                )
+                _spawn_dedicated_write_task(captured_loop, _coro_factory())
 
             captured_loop.call_soon_threadsafe(_spawn_on_main)
     except Exception as exc:  # noqa: BLE001 — observability MUST NOT mask the real bug
@@ -206,6 +190,31 @@ def _schedule_coordination_events_dual_write(
             "audit.events row remains durable",
             exc,
         )
+
+
+# Module-local strong-ref set for in-flight dedicated-table coroutines.
+# Watcher P001: bare `loop.create_task(coro)` returns a Task that the GC
+# can collect mid-flight if no one holds a reference. We can't use
+# `background_tasks.create_tracked_task` because the supervisor's
+# cancellation done-callback recursively calls back into
+# `emit_coordination_failure_sync` (Wave 0 step 2C-1 cancellation emit),
+# which would re-register a fresh task on the *same* `_supervised_tasks`
+# list and break `test_stop_all_background_tasks_cancels_supervised_tasks`'s
+# emptiness invariant. A private ref set isolated to this module gives the
+# same GC protection without sharing fate with the supervisor.
+_inflight_dedicated_writes: "set[asyncio.Task]" = set()
+
+
+def _spawn_dedicated_write_task(loop, coro):
+    """Spawn coro on `loop` and pin a strong ref until it completes.
+
+    Mirrors the canonical asyncio "save the task to a set; remove on done"
+    pattern. The `name=` kwarg is preserved so a stray crash log still
+    identifies the call site as `coord_failure_dedicated_table_write`.
+    """
+    task = loop.create_task(coro, name="coord_failure_dedicated_table_write")
+    _inflight_dedicated_writes.add(task)
+    task.add_done_callback(_inflight_dedicated_writes.discard)
 
 
 async def _emit_to_coordination_events_async(

--- a/src/coordination_failure_emit.py
+++ b/src/coordination_failure_emit.py
@@ -14,11 +14,15 @@ production for the entire `audit.events` infrastructure, sidesteps the
 anyio task group entirely, and provides the durability guarantees we
 already trust (JSONL append + fire-and-forget Postgres).
 
-PR #342's `audit.coordination_events` table + async emitter remain on a
-separate open PR for FUTURE Wave 0 step 3 work if a separate replay surface
-becomes necessary. For Wave 0 step 2A — wire the smallest meaningful
-chokepoint (the @mcp_tool decorator's TimeoutError handler) — `audit.events`
-with a namespaced `event_type` is enough.
+PR #342's `audit.coordination_events` table + async emitter remain the
+dedicated replay surface. As of Wave 2 §"audit.coordination_events
+routing fix" (RFC roadmap), this module dual-writes: the existing
+audit.events path stays as the failure-safe truth (Wave 1 exit criterion
+queries depend on it), and the dedicated table is populated in parallel
+via a fire-and-forget `loop.create_task` after the sync write — same
+anyio-deadlock-avoiding pattern as audit_log._write_entry's Postgres tail.
+A failure on the dedicated-table side is logged at WARNING and dropped;
+audit.events remains durable.
 
 `event_type` namespace:
   coordination_failure.<class>.<subtype>   (e.g. mcp_handler_timeout.tool_decorator)
@@ -111,5 +115,143 @@ def emit_coordination_failure_sync(
             "[coord-failure-emit] write failed for %s/%s: %r — original exception preserved",
             effective_service,
             event_type,
+            exc,
+        )
+
+    # Wave 2 §"audit.coordination_events routing fix" (RFC roadmap):
+    # Dual-write to the dedicated replay surface in addition to audit.events.
+    # The audit.events row above remains the failure-safe truth (Wave 1 exit
+    # criterion queries depend on it); this populates the dedicated table
+    # the v0 envelope specified, so a future Chronicler/dashboard projection
+    # has a single-purpose surface to read instead of LIKE-filtering
+    # audit.events. Fire-and-forget by design — same anyio-deadlock-avoiding
+    # pattern as audit_log._write_entry's Postgres tail.
+    _schedule_coordination_events_dual_write(
+        service=effective_service,
+        event_type=event_type,
+        payload=payload or {},
+        agent_id=agent_id,
+    )
+
+
+def _schedule_coordination_events_dual_write(
+    *,
+    service: str,
+    event_type: str,
+    payload: dict[str, Any],
+    agent_id: str | None,
+) -> None:
+    """Fire-and-forget schedule of an audit.coordination_events insert.
+
+    Failure-safe by contract: never raises, never blocks. If no event loop
+    is reachable, the dedicated-table write is dropped silently — the
+    audit.events row is still durable. Mirrors audit_log._write_entry's
+    fire-and-forget Postgres pattern so this stays sync-safe under the
+    council BLOCK on direct-asyncpg-await from decorator except clauses.
+    """
+    try:
+        import asyncio
+
+        def _coro_factory():
+            return _emit_to_coordination_events_async(
+                service=service,
+                event_type=event_type,
+                payload=payload,
+                agent_id=agent_id,
+            )
+
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(_coro_factory())
+            return
+        except RuntimeError:
+            pass
+
+        # No running loop in this thread — try the audit-logger's captured
+        # main loop, which is set up at server boot for executor-thread
+        # writes. If that's also unavailable (CLI / pure unit tests), drop
+        # the dedicated-table write rather than block the caller.
+        captured_loop = None
+        try:
+            from src.audit_log import AuditLogger
+
+            captured_loop = getattr(AuditLogger, "_event_loop", None)
+        except Exception:  # noqa: BLE001 — defensive on import failure
+            captured_loop = None
+
+        if captured_loop is not None and captured_loop.is_running():
+            def _spawn_on_main():
+                captured_loop.create_task(_coro_factory())
+
+            captured_loop.call_soon_threadsafe(_spawn_on_main)
+    except Exception as exc:  # noqa: BLE001 — observability MUST NOT mask the real bug
+        logger.debug(
+            "[coord-failure-emit] dedicated-table schedule failed: %r — "
+            "audit.events row remains durable",
+            exc,
+        )
+
+
+async def _emit_to_coordination_events_async(
+    *,
+    service: str,
+    event_type: str,
+    payload: dict[str, Any],
+    agent_id: str | None,
+) -> None:
+    """Write a coordination event into audit.coordination_events.
+
+    Failure-safe: WARNING-level log on failure, never raises. The audit.events
+    row was already committed via the sync path before this coroutine ran;
+    losing the dedicated-table write costs only the replay surface, not
+    durability.
+    """
+    try:
+        import asyncpg
+
+        from src.coordination_events import emit_event
+        from src.db import get_db
+
+        db = get_db()
+        # Match audit_db.append_audit_event_async's lazy-init dance. Without
+        # this, the very first emit after process boot races the pool warmup.
+        if not hasattr(db, "_pool") or getattr(db, "_pool", None) is None:
+            try:
+                await db.init()
+            except Exception:  # noqa: BLE001
+                # init() failures land on the outer handler below; the
+                # explicit catch here just prevents partial init from
+                # masking the original error class.
+                raise
+        pool = getattr(db, "_pool", None)
+        # `isinstance(pool, asyncpg.Pool)` is the right gate. Without it,
+        # the autouse `_isolate_db_backend` fixture leaves `_pool` as an
+        # AsyncMock auto-attribute, and `async with pool.acquire()` inside
+        # emit_event falls through into AsyncMock's coroutine-returning
+        # call protocol, leaving an unawaited AsyncMockMixin coroutine that
+        # the pytest_warning_recorded hook (per memory
+        # feedback_pytest-unawaited-coroutine) flags as a leak in any test
+        # that incidentally triggers an emit. The leak fires SILENTLY in
+        # production absent this check too — async with would raise
+        # TypeError on a non-real pool — so the isinstance gate is correct
+        # production posture, not just test ergonomics.
+        if not isinstance(pool, asyncpg.Pool):
+            logger.debug(
+                "[coord-failure-emit] dedicated-table write skipped: "
+                "pool is not asyncpg.Pool (got %s)",
+                type(pool).__name__,
+            )
+            return
+
+        await emit_event(
+            pool,
+            service=service,  # type: ignore[arg-type]  # validated against SERVICES upstream
+            event_type=event_type,
+            payload=payload,
+            agent_id=agent_id,
+        )
+    except Exception as exc:  # noqa: BLE001 — observability MUST NOT mask the real bug
+        logger.warning(
+            "[coord-failure-emit] dedicated-table write failed (non-fatal): %r",
             exc,
         )

--- a/src/coordination_failure_emit.py
+++ b/src/coordination_failure_emit.py
@@ -161,8 +161,17 @@ def _schedule_coordination_events_dual_write(
             )
 
         try:
-            loop = asyncio.get_running_loop()
-            loop.create_task(_coro_factory())
+            asyncio.get_running_loop()
+            # Use create_tracked_task (not bare loop.create_task) so the
+            # task reference is held by `_supervised_tasks` and won't be
+            # GC'd mid-flight — Watcher P001. Also gives us a crash-log
+            # callback for free if the dedicated-table coroutine raises
+            # past its own swallow (e.g., a TaskGroup cancellation).
+            from src.background_tasks import create_tracked_task
+            create_tracked_task(
+                _coro_factory(),
+                name="coord_failure_dedicated_table_write",
+            )
             return
         except RuntimeError:
             pass
@@ -181,7 +190,14 @@ def _schedule_coordination_events_dual_write(
 
         if captured_loop is not None and captured_loop.is_running():
             def _spawn_on_main():
-                captured_loop.create_task(_coro_factory())
+                # Inside the captured loop's thread, `create_tracked_task`
+                # finds the running loop via asyncio.get_running_loop(),
+                # so the same supervised-task semantics apply here too.
+                from src.background_tasks import create_tracked_task
+                create_tracked_task(
+                    _coro_factory(),
+                    name="coord_failure_dedicated_table_write_threadsafe",
+                )
 
             captured_loop.call_soon_threadsafe(_spawn_on_main)
     except Exception as exc:  # noqa: BLE001 — observability MUST NOT mask the real bug

--- a/tests/test_coordination_failure_emit.py
+++ b/tests/test_coordination_failure_emit.py
@@ -182,3 +182,169 @@ def test_emit_session_id_defaults_to_none():
             payload={"tool_name": "x"},
         )
     assert fake_entry_cls.call_args.kwargs["session_id"] is None
+
+
+# ============================================================================
+# Wave 2 §"audit.coordination_events routing fix" — dedicated-table dual-write
+# ============================================================================
+#
+# Pre-Wave-2: events landed only in audit.events (a generic table) under a
+# `coordination_failure.*` event_type namespace. The dedicated
+# audit.coordination_events table existed (PR #342, migration 035) but was
+# empty because production deliberately didn't write to it — direct
+# asyncpg-await from the @mcp_tool decorator's except clause was BLOCKED by
+# council on anyio task-group deadlock grounds. Wave 2's routing fix is
+# fire-and-forget dual-write: the sync audit.events path stays intact, and
+# the dedicated table is populated in parallel via loop.create_task. These
+# tests pin (1) the dual-write fires when an event loop is reachable,
+# (2) it's silent when no loop is reachable (CLI / executor thread without
+# captured loop), and (3) failure on the dedicated-table side never raises.
+
+
+@pytest.mark.asyncio
+async def test_emit_schedules_dual_write_when_loop_running():
+    """Happy path: in async context, emit_coordination_failure_sync schedules
+    a coroutine that calls coordination_events.emit_event with the same
+    service/event_type/payload/agent_id. The audit.events sync write happens
+    first (failure-safe truth), then the dedicated-table coroutine is
+    scheduled on the running loop."""
+    import asyncio
+
+    import asyncpg
+
+    fake_logger = MagicMock()
+    seen_calls = []
+
+    async def fake_emit_event(pool, **kwargs):
+        seen_calls.append(kwargs)
+        return "fake-uuid"
+
+    # spec=asyncpg.Pool so the isinstance gate in
+    # _emit_to_coordination_events_async accepts the test pool. Without
+    # spec=, the gate would correctly reject a bare MagicMock.
+    fake_db = MagicMock()
+    fake_db._pool = MagicMock(spec=asyncpg.Pool)
+    fake_db.init = MagicMock()  # not awaited because _pool is set
+
+    with patch("src.audit_log.audit_logger", fake_logger), \
+         patch("src.audit_log.AuditEntry"), \
+         patch("src.coordination_events.emit_event", side_effect=fake_emit_event), \
+         patch("src.db.get_db", return_value=fake_db):
+        emit_coordination_failure_sync(
+            service="governance_mcp",
+            event_type="coordination_failure.mcp_handler_timeout.tool_decorator",
+            payload={"tool_name": "process_agent_update"},
+            agent_id="some-uuid",
+        )
+        # Dedicated-table write is scheduled, not awaited. Yield to let the
+        # scheduled task run before the patches unwind.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    # audit.events path still primary.
+    fake_logger._write_entry.assert_called_once()
+    # Dedicated-table path also fired with the same envelope.
+    assert len(seen_calls) == 1, (
+        f"Wave 2 dual-write must fire once on the running loop; got {len(seen_calls)} calls"
+    )
+    call = seen_calls[0]
+    assert call["service"] == "governance_mcp"
+    assert call["event_type"] == "coordination_failure.mcp_handler_timeout.tool_decorator"
+    assert call["payload"] == {"tool_name": "process_agent_update"}
+    assert call["agent_id"] == "some-uuid"
+
+
+def test_emit_dual_write_silent_when_no_loop_reachable():
+    """No running loop AND no captured main loop → dedicated-table write is
+    dropped silently. emit_coordination_failure_sync must still complete
+    successfully (audit.events write is the durable path)."""
+    fake_logger = MagicMock()
+
+    # Force the captured-loop fallback path to also be unavailable.
+    class _StubAuditLogger:
+        _event_loop = None
+
+    with patch("src.audit_log.audit_logger", fake_logger), \
+         patch("src.audit_log.AuditEntry"), \
+         patch("src.audit_log.AuditLogger", _StubAuditLogger), \
+         patch("src.coordination_events.emit_event") as fake_emit:
+        # MUST NOT raise.
+        emit_coordination_failure_sync(
+            service="governance_mcp",
+            event_type="coordination_failure.mcp_handler_timeout.tool_decorator",
+            payload={},
+        )
+
+    # Sync truth path landed.
+    fake_logger._write_entry.assert_called_once()
+    # Dedicated-table path was never invoked.
+    fake_emit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_emit_dual_write_swallows_pool_acquisition_failure():
+    """If get_db()/pool acquisition fails (DB down at the moment of emit),
+    the dedicated-table coroutine logs WARNING and returns. The audit.events
+    row is already durable; dropping the dedicated-table write is acceptable
+    by the failure-safe contract."""
+    import asyncio
+
+    fake_logger = MagicMock()
+    fake_db = MagicMock()
+    fake_db._pool = None
+
+    async def fake_init():
+        # Simulate db.init() also failing — pool stays None.
+        raise RuntimeError("db down")
+
+    fake_db.init = fake_init
+
+    with patch("src.audit_log.audit_logger", fake_logger), \
+         patch("src.audit_log.AuditEntry"), \
+         patch("src.coordination_events.emit_event") as fake_emit, \
+         patch("src.db.get_db", return_value=fake_db):
+        emit_coordination_failure_sync(  # MUST NOT raise
+            service="governance_mcp",
+            event_type="coordination_failure.mcp_handler_timeout.tool_decorator",
+            payload={},
+        )
+        # Let the scheduled task run + hit the swallowed exception.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    # audit.events still landed.
+    fake_logger._write_entry.assert_called_once()
+    # emit_event itself never reached (pool unavailable).
+    fake_emit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_emit_dual_write_swallows_emit_event_exception():
+    """If coordination_events.emit_event itself raises (e.g., schema drift,
+    transient PG error), the failure is logged at WARNING and swallowed.
+    Pins the contract that a dedicated-table failure never propagates."""
+    import asyncio
+
+    import asyncpg
+
+    fake_logger = MagicMock()
+    fake_db = MagicMock()
+    fake_db._pool = MagicMock(spec=asyncpg.Pool)
+
+    async def raising_emit(pool, **kwargs):
+        raise RuntimeError("connection lost mid-write")
+
+    with patch("src.audit_log.audit_logger", fake_logger), \
+         patch("src.audit_log.AuditEntry"), \
+         patch("src.coordination_events.emit_event", side_effect=raising_emit), \
+         patch("src.db.get_db", return_value=fake_db):
+        emit_coordination_failure_sync(  # MUST NOT raise
+            service="governance_mcp",
+            event_type="coordination_failure.mcp_handler_timeout.tool_decorator",
+            payload={},
+        )
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    # audit.events still landed.
+    fake_logger._write_entry.assert_called_once()


### PR DESCRIPTION
Wave 2 §\"audit.coordination_events routing fix\" from \`docs/proposals/beam-footprint-roadmap-v0.md\`.

## What changed
- \`src/coordination_failure_emit.py\` now schedules a fire-and-forget write to \`audit.coordination_events\` after the existing \`audit.events\` sync write. Pattern mirrors \`audit_log._write_entry\`'s Postgres tail (\`asyncio.get_running_loop().create_task\`, with a captured-main-loop fallback for executor-thread callers).
- Failure-safe by contract: dual-write coroutine catches all exceptions at WARNING level, the audit.events row remains the durable truth, and Wave 1 exit-criterion queries (which read \`audit.events\`) keep working unchanged.
- \`isinstance(pool, asyncpg.Pool)\` gate in the dedicated-table coroutine so it skips cleanly under the autouse \`_isolate_db_backend\` test fixture (whose AsyncMock-auto-attribute \`_pool\` would otherwise trigger \`async with pool.acquire()\` on a coroutine and leak unawaited \`AsyncMockMixin._execute_mock_call\` per memory \`feedback_pytest-unawaited-coroutine\`).

## Why this scope
Pre-Wave-2: PR #342 created the \`audit.coordination_events\` table + async \`emit_event\` helper, but production deliberately wrote to \`audit.events\` instead — direct asyncpg-await from the @mcp_tool decorator's except clause was BLOCKED by council on anyio task-group deadlock grounds. The dedicated table sat empty.

The dual-write fixes that without breaking the deadlock-avoidance: sync emit hits \`audit.events\` first (failure-safe truth), then schedules a fire-and-forget coroutine to populate the dedicated table. Future Chronicler/dashboard projections can now read a single-purpose surface instead of LIKE-filtering \`audit.events\`.

## Tests
- 4 new tests in \`TestCoordinationEventsDualWrite\`-equivalent class:
  - \`test_emit_schedules_dual_write_when_loop_running\` — happy path: same envelope reaches both tables
  - \`test_emit_dual_write_silent_when_no_loop_reachable\` — CLI/no-loop case drops dedicated write silently
  - \`test_emit_dual_write_swallows_pool_acquisition_failure\` — DB down at emit time → audit.events still durable
  - \`test_emit_dual_write_swallows_emit_event_exception\` — schema drift / transient PG error never propagates

## Test plan
- 16/16 tests in \`tests/test_coordination_failure_emit.py\` pass
- 8492/8492 full Python suite passes (vs 8486 before — 4 new tests + 2 kept coverage)
- 138/138 pre-push smoke
- No new \`AsyncMock\` coroutine leaks (verified via the \`pytest_warning_recorded\` hook gate)