### PR TITLE
fix(sentinel): bind BEAM check-ins to session anchor

### DIFF
--- a/elixir/sentinel/lib/unitares_sentinel/application.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/application.ex
@@ -17,6 +17,8 @@ defmodule UnitaresSentinel.Application do
 
   use Application
 
+  require Logger
+
   @impl true
   def start(_type, _args) do
     if Application.get_env(:unitares_sentinel, :start_application, true) do
@@ -84,19 +86,46 @@ defmodule UnitaresSentinel.Application do
 
   defp fleet_finding_emitter_children do
     if Application.get_env(:unitares_sentinel, :start_fleet_finding_emitter, false) do
-      [
-        {UnitaresSentinel.FleetFindingEmitter,
-         fleet_state:
-           Application.get_env(:unitares_sentinel, :fleet_state_name, UnitaresSentinel.FleetState),
-         interval_ms: Application.get_env(:unitares_sentinel, :analysis_interval_ms, 300_000),
-         initial_delay_ms:
-           Application.get_env(:unitares_sentinel, :analysis_initial_delay_ms, 5_000),
-         jitter_ms: Application.get_env(:unitares_sentinel, :analysis_jitter_ms, 5_000),
-         tick_timeout_ms:
-           Application.get_env(:unitares_sentinel, :analysis_tick_timeout_ms, 45_000)}
-      ]
+      [{UnitaresSentinel.FleetFindingEmitter, fleet_finding_emitter_opts()}]
     else
       []
+    end
+  end
+
+  @doc false
+  # Public for the runtime-boundary regression test.
+  def fleet_finding_emitter_opts do
+    [
+      fleet_state:
+        Application.get_env(:unitares_sentinel, :fleet_state_name, UnitaresSentinel.FleetState),
+      interval_ms: Application.get_env(:unitares_sentinel, :analysis_interval_ms, 300_000),
+      initial_delay_ms:
+        Application.get_env(:unitares_sentinel, :analysis_initial_delay_ms, 5_000),
+      jitter_ms: Application.get_env(:unitares_sentinel, :analysis_jitter_ms, 5_000),
+      tick_timeout_ms: Application.get_env(:unitares_sentinel, :analysis_tick_timeout_ms, 45_000)
+    ]
+    |> maybe_add_checkin_anchor()
+  end
+
+  defp maybe_add_checkin_anchor(opts) do
+    if Application.get_env(:unitares_sentinel, :emit_checkins, false) do
+      Keyword.put(opts, :checkin_opts, sentinel_checkin_opts())
+    else
+      opts
+    end
+  end
+
+  defp sentinel_checkin_opts do
+    case UnitaresSentinel.SessionAnchor.load() do
+      {:ok, anchor} ->
+        [anchor: anchor]
+
+      {:error, reason} ->
+        Logger.warning(
+          "Sentinel governance check-ins enabled but session anchor could not be loaded: #{inspect(reason)}"
+        )
+
+        []
     end
   end
 

--- a/elixir/sentinel/test/unitares_sentinel/application_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/application_test.exs
@@ -1,0 +1,51 @@
+defmodule UnitaresSentinel.ApplicationTest do
+  use ExUnit.Case, async: false
+
+  alias UnitaresSentinel.Application, as: SentinelApplication
+
+  @agent_uuid "11111111-1111-1111-1111-111111111111"
+  @continuity_token "v1.test-token"
+  @client_session_id "session-test"
+
+  setup do
+    keys = [:emit_checkins, :session_file_path, :legacy_session_file_path]
+    previous = Map.new(keys, &{&1, Application.get_env(:unitares_sentinel, &1)})
+
+    on_exit(fn ->
+      Enum.each(previous, fn
+        {key, nil} -> Application.delete_env(:unitares_sentinel, key)
+        {key, value} -> Application.put_env(:unitares_sentinel, key, value)
+      end)
+    end)
+
+    :ok
+  end
+
+  test "fleet finding emitter carries the Sentinel anchor when check-ins are enabled" do
+    path =
+      Path.join(System.tmp_dir!(), "sentinel-anchor-#{System.unique_integer([:positive])}.json")
+
+    File.write!(
+      path,
+      Jason.encode!(%{
+        "agent_uuid" => @agent_uuid,
+        "continuity_token" => @continuity_token,
+        "client_session_id" => @client_session_id
+      })
+    )
+
+    on_exit(fn -> File.rm(path) end)
+
+    Application.put_env(:unitares_sentinel, :emit_checkins, true)
+    Application.put_env(:unitares_sentinel, :session_file_path, path)
+    Application.delete_env(:unitares_sentinel, :legacy_session_file_path)
+
+    opts = SentinelApplication.fleet_finding_emitter_opts()
+
+    assert opts[:checkin_opts][:anchor] == %{
+             "agent_uuid" => @agent_uuid,
+             "continuity_token" => @continuity_token,
+             "client_session_id" => @client_session_id
+           }
+  end
+end


### PR DESCRIPTION
## Summary

- pass the loaded Sentinel session anchor into the supervised BEAM fleet-finding emitter when governance check-ins are enabled
- keep check-ins bound to the canonical Sentinel UUID instead of sending identity-less process_agent_update calls
- add a runtime-boundary regression for the emitter options

## Validation

- mix test test/unitares_sentinel/application_test.exs test/unitares_sentinel/governance_checkin_test.exs test/unitares_sentinel/fleet_finding_emitter_test.exs
- pre-push smoke: 138 passed, 7842 deselected
- pre-push doc health: all clear