### PR TITLE
chore(dialectic): retire ESCALATED phase + quorum_voting machinery

### DIFF
--- a/src/dialectic_protocol.py
+++ b/src/dialectic_protocol.py
@@ -172,16 +172,13 @@ class DialecticPhase(Enum):
     - **ANTITHESIS**: Reviewer responds with observations and concerns
     - **SYNTHESIS**: Negotiation phase where both agents propose merged resolutions
     - **RESOLVED**: Both agents have agreed and resolution is finalized
-    - **ESCALATED**: Max rounds exceeded or timeout, escalate to quorum
-    - **FAILED**: Session failed (timeout, error, etc.)
+    - **FAILED**: Session failed (timeout, max rounds exceeded, error, etc.)
     """
     THESIS = "thesis"
     ANTITHESIS = "antithesis"
     SYNTHESIS = "synthesis"
     RESOLVED = "resolved"
-    ESCALATED = "escalated"
     FAILED = "failed"
-    QUORUM_VOTING = "quorum_voting"
 
 
 class ResolutionAction(Enum):
@@ -319,112 +316,6 @@ class Resolution:
         return hashlib.sha256(resolution_json.encode()).hexdigest()
 
 
-@dataclass
-class QuorumVote:
-    """A single vote from a quorum reviewer."""
-    agent_id: str
-    vote: str  # "resume", "block", or "cooldown"
-    authority_weight: float
-    reasoning: str
-    conditions: Optional[List[str]] = None
-    timestamp: Optional[str] = None
-
-    def to_dict(self) -> Dict:
-        return asdict(self)
-
-
-@dataclass
-class QuorumResult:
-    """Tally result from quorum voting."""
-    action: str  # winning action or "no_supermajority"
-    achieved_supermajority: bool
-    margin: float  # winning weight fraction
-    total_weight: float
-    vote_counts: Dict[str, int]  # action -> count
-    votes: List[Dict[str, Any]]
-
-    def to_dict(self) -> Dict:
-        return asdict(self)
-
-
-def tally_quorum_votes(votes: List[QuorumVote]) -> QuorumResult:
-    """
-    Tally quorum votes using authority-weighted 2/3 supermajority.
-
-    Each vote's authority_weight counts toward its action. The action
-    with >= 2/3 of total weight wins. If none reaches 2/3, result
-    is "no_supermajority".
-
-    Args:
-        votes: List of QuorumVote objects
-
-    Returns:
-        QuorumResult with tally outcome
-    """
-    if not votes:
-        return QuorumResult(
-            action="no_supermajority",
-            achieved_supermajority=False,
-            margin=0.0,
-            total_weight=0.0,
-            vote_counts={},
-            votes=[],
-        )
-
-    # Accumulate weighted votes per action
-    weight_by_action: Dict[str, float] = {}
-    count_by_action: Dict[str, int] = {}
-    total_weight = 0.0
-
-    for v in votes:
-        w = max(0.0, v.authority_weight)
-        weight_by_action[v.vote] = weight_by_action.get(v.vote, 0.0) + w
-        count_by_action[v.vote] = count_by_action.get(v.vote, 0) + 1
-        total_weight += w
-
-    if total_weight <= 0:
-        return QuorumResult(
-            action="no_supermajority",
-            achieved_supermajority=False,
-            margin=0.0,
-            total_weight=0.0,
-            vote_counts=count_by_action,
-            votes=[v.to_dict() for v in votes],
-        )
-
-    # Check for 2/3 supermajority
-    threshold = 2.0 / 3.0
-    winner = None
-    winner_fraction = 0.0
-
-    for action, weight in weight_by_action.items():
-        fraction = weight / total_weight
-        if fraction >= threshold and fraction > winner_fraction:
-            winner = action
-            winner_fraction = fraction
-
-    if winner:
-        return QuorumResult(
-            action=winner,
-            achieved_supermajority=True,
-            margin=winner_fraction,
-            total_weight=total_weight,
-            vote_counts=count_by_action,
-            votes=[v.to_dict() for v in votes],
-        )
-
-    # No supermajority — return the leading action for info
-    leading = max(weight_by_action, key=weight_by_action.get)
-    return QuorumResult(
-        action="no_supermajority",
-        achieved_supermajority=False,
-        margin=weight_by_action[leading] / total_weight,
-        total_weight=total_weight,
-        vote_counts=count_by_action,
-        votes=[v.to_dict() for v in votes],
-    )
-
-
 class DialecticSession:
     """
     Manages a dialectic session between paused agent (A) and reviewer (B).
@@ -504,8 +395,6 @@ class DialecticSession:
         self.synthesis_round = 0
         self.resolution: Optional[Resolution] = None
         self.awaiting_facilitation = False  # True when reviewer is stuck and no auto-replacement found
-        self.quorum_reviewer_ids: List[str] = []  # Reviewer IDs selected for quorum voting
-        self.quorum_deadline: Optional[str] = None  # ISO deadline for quorum voting
 
         self.created_at = datetime.now(timezone.utc)
         self.session_id = self._generate_session_id()
@@ -620,11 +509,11 @@ class DialecticSession:
 
         # Check if we've exceeded max rounds
         if self.synthesis_round > self.max_synthesis_rounds:
-            self.phase = DialecticPhase.ESCALATED
+            self.phase = DialecticPhase.FAILED
             return {
                 "success": False,
                 "error": "Max synthesis rounds exceeded",
-                "action": "escalate_to_quorum",
+                "action": "failed_max_rounds",
                 "rounds": self.synthesis_round - 1
             }
 
@@ -1068,8 +957,6 @@ class DialecticSession:
             "awaiting_facilitation": getattr(self, 'awaiting_facilitation', False),
             "reason": getattr(self, 'reason', None),
             "trigger_source": getattr(self, 'trigger_source', None),
-            "quorum_reviewer_ids": getattr(self, 'quorum_reviewer_ids', []),
-            "quorum_deadline": getattr(self, 'quorum_deadline', None),
         }
 
 

--- a/src/mcp_handlers/__init__.py
+++ b/src/mcp_handlers/__init__.py
@@ -86,7 +86,6 @@ from .dialectic.handlers import (
     handle_submit_thesis,
     handle_submit_antithesis,
     handle_submit_synthesis,
-    handle_submit_quorum_vote,
     handle_llm_assisted_dialectic,
 )
 # Self-Recovery - Simplified recovery without external reviewers (Jan 2026)

--- a/src/mcp_handlers/consolidated.py
+++ b/src/mcp_handlers/consolidated.py
@@ -70,7 +70,6 @@ from .dialectic.handlers import (
     handle_submit_thesis,
     handle_submit_antithesis,
     handle_submit_synthesis,
-    handle_submit_quorum_vote,
     handle_reassign_reviewer,
 )
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
@@ -237,11 +236,10 @@ handle_dialectic = action_router(
         "thesis": handle_submit_thesis,
         "antithesis": handle_submit_antithesis,
         "synthesis": handle_submit_synthesis,
-        "vote": handle_submit_quorum_vote,
         "reassign": handle_reassign_reviewer,
     },
     timeout=60.0,
-    description="Dialectic operations: get, list, request, thesis, antithesis, synthesis, vote, reassign",
+    description="Dialectic operations: get, list, request, thesis, antithesis, synthesis, reassign",
     default_action="list",
     examples=[
         "dialectic(action='list')",

--- a/src/mcp_handlers/dialectic/__init__.py
+++ b/src/mcp_handlers/dialectic/__init__.py
@@ -7,12 +7,11 @@ from .handlers import (
     handle_submit_thesis,
     handle_submit_antithesis,
     handle_submit_synthesis,
-    handle_submit_quorum_vote,
     handle_llm_assisted_dialectic,
 )
 from .session import save_session, load_session
 from .resolution import execute_resolution
-from .reviewer import select_reviewer, select_quorum_reviewers
+from .reviewer import select_reviewer
 from .calibration import update_calibration_from_dialectic
 from .enforcement import enforce_complexity_limit, enforce_post_ode_conditions
 
@@ -23,13 +22,11 @@ __all__ = [
     "handle_submit_thesis",
     "handle_submit_antithesis",
     "handle_submit_synthesis",
-    "handle_submit_quorum_vote",
     "handle_llm_assisted_dialectic",
     "save_session",
     "load_session",
     "execute_resolution",
     "select_reviewer",
-    "select_quorum_reviewers",
     "update_calibration_from_dialectic",
     "enforce_complexity_limit",
     "enforce_post_ode_conditions",

--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -23,9 +23,6 @@ from src.dialectic_protocol import (
     DialecticMessage,
     DialecticPhase,
     Resolution,
-    QuorumVote,
-    QuorumResult,
-    tally_quorum_votes,
 )
 from ..utils import success_response, error_response, require_registered_agent
 from ..decorators import mcp_tool
@@ -34,7 +31,6 @@ from .auth import resolve_dialectic_agent_id
 from .responses import (
     default_cooldown_steps,
     default_escalate_steps,
-    default_quorum_steps,
     default_resume_steps,
     get_agent_not_found_recovery,
     get_reviewer_stuck_recovery,
@@ -50,7 +46,6 @@ from .responses import (
     next_step_execution_failed,
     next_step_negotiate_synthesis,
     next_step_no_consensus,
-    next_step_quorum_initiated,
     next_step_resume_not_applied,
     next_step_resumed,
     next_step_submit_antithesis,
@@ -106,7 +101,7 @@ from .calibration import (
     backfill_calibration_from_historical_sessions
 )
 from .resolution import execute_resolution
-from .reviewer import select_reviewer, select_quorum_reviewers, is_agent_in_active_session
+from .reviewer import select_reviewer, is_agent_in_active_session
 
 # Import PostgreSQL async functions for dialectic session storage
 from src.dialectic_db import (
@@ -1198,21 +1193,20 @@ async def handle_submit_synthesis(arguments: Dict[str, Any]) -> Sequence[TextCon
         # that check to support the "third-party synthesizer" pattern. Without
         # a compensating allow-list, any registered agent could drive a
         # synthesis to convergence and trigger resolution execution — a real
-        # privilege escalation surface. The allow-list is: the paused agent,
-        # the assigned reviewer, and any quorum reviewer (if escalated).
+        # privilege escalation surface. The allow-list is: the paused agent
+        # and the assigned reviewer.
         eligible = set()
         if getattr(session, "paused_agent_id", None):
             eligible.add(session.paused_agent_id)
         if getattr(session, "reviewer_agent_id", None):
             eligible.add(session.reviewer_agent_id)
-        eligible.update(getattr(session, "quorum_reviewer_ids", []) or [])
         agent_uuid = resolve_agent_uuid(arguments, agent_id)
         if agent_id not in eligible and (not agent_uuid or agent_uuid not in eligible):
             return [error_response(
                 f"Agent '{agent_id}' is not a participant in this dialectic session.",
                 recovery=(
-                    "Only the paused agent, the assigned reviewer, or assigned "
-                    "quorum members may submit synthesis."
+                    "Only the paused agent or the assigned reviewer "
+                    "may submit synthesis."
                 ),
             )]
 
@@ -1376,20 +1370,13 @@ async def handle_submit_synthesis(arguments: Dict[str, Any]) -> Sequence[TextCon
             await save_session(session)
 
         elif not result.get("success"):
-            # Max rounds exceeded — try quorum escalation before conservative default
-            quorum_info = await _initiate_quorum(session)
-            if quorum_info:
-                result["autonomous_resolution"] = False
-                result["resolution_type"] = "quorum_escalation"
-                result["quorum"] = quorum_info
-                result["next_step"] = next_step_quorum_initiated(len(quorum_info["reviewer_ids"]))
-                result["next_steps"] = default_quorum_steps()
-            else:
-                # Not enough agents for quorum — fall back to conservative default
-                result["autonomous_resolution"] = True
-                result["resolution_type"] = "conservative_default"
-                result["next_step"] = next_step_no_consensus()
-                result["cooldown_until"] = (datetime.now() + timedelta(hours=1)).isoformat()
+            # Max rounds exceeded — apply conservative default. The quorum-voting
+            # escalation path was retired (council 2026-05-06: 0 sessions ever
+            # escalated to quorum across 47 historical sessions / 6 months).
+            result["autonomous_resolution"] = True
+            result["resolution_type"] = "conservative_default"
+            result["next_step"] = next_step_no_consensus()
+            result["cooldown_until"] = (datetime.now() + timedelta(hours=1)).isoformat()
 
         return success_response(result)
 
@@ -1513,344 +1500,6 @@ async def handle_reassign_reviewer(arguments: Dict[str, Any]) -> Sequence[TextCo
             reason=reason,
         ),
     })
-
-
-async def _initiate_quorum(session: DialecticSession) -> Optional[Dict[str, Any]]:
-    """
-    Attempt to initiate quorum voting for an escalated dialectic session.
-
-    Selects 3-5 reviewers, sets session phase to QUORUM_VOTING,
-    and persists quorum data to PostgreSQL.
-
-    Returns:
-        Dict with reviewer_ids, scores, and deadline if quorum formed.
-        None if fewer than 3 eligible reviewers.
-    """
-    # Wave 2 audit: force=True dropped per PR #350 precedent. Quorum
-    # selection scans the in-memory fleet; cache is fresh enough.
-    await mcp_server.load_metadata_async()
-    metadata = mcp_server.agent_metadata or {}
-
-    reviewers = await select_quorum_reviewers(session, metadata)
-    if not reviewers:
-        return None
-
-    reviewer_ids = [r[0] for r in reviewers]
-    reviewer_scores = {r[0]: r[1] for r in reviewers}
-    deadline = (datetime.now(timezone.utc) + timedelta(hours=2)).isoformat()
-
-    session.phase = DialecticPhase.QUORUM_VOTING
-    session.quorum_reviewer_ids = reviewer_ids
-    session.quorum_deadline = deadline
-
-    # Persist to PostgreSQL. Wrapped with asyncio.wait_for because a direct
-    # ``await get_db()`` in an MCP handler path can deadlock under the
-    # anyio-asyncio conflict documented in CLAUDE.md. On timeout we fall
-    # through to the in-memory session state (already mutated above) and
-    # the subsequent ``save_session`` JSON write, matching the existing
-    # degrade-on-failure behavior.
-    try:
-        from src.db import get_db
-        db = await asyncio.wait_for(get_db(), timeout=0.5)
-        await asyncio.wait_for(
-            db.execute(
-                """UPDATE core.dialectic_sessions
-                   SET phase = 'quorum_voting',
-                       status = 'quorum_voting',
-                       quorum_reviewer_ids = $1::jsonb,
-                       quorum_deadline = $2::timestamptz,
-                       updated_at = NOW()
-                 WHERE session_id = $3""",
-                json.dumps(reviewer_ids),
-                deadline,
-                session.session_id,
-            ),
-            timeout=1.0,
-        )
-    except (asyncio.TimeoutError, Exception) as e:
-        logger.warning(f"Could not persist quorum to PostgreSQL: {e}")
-
-    try:
-        await save_session(session)
-    except Exception as e:
-        logger.warning(f"Could not save quorum session to JSON: {e}")
-
-    return {
-        "reviewer_ids": reviewer_ids,
-        "reviewer_scores": reviewer_scores,
-        "deadline": deadline,
-        "session_id": session.session_id,
-    }
-
-
-@mcp_tool("submit_quorum_vote", register=True)
-async def handle_submit_quorum_vote(arguments: Dict[str, Any]) -> Sequence[TextContent]:
-    """
-    Submit a vote in a quorum-escalated dialectic session.
-
-    Only agents assigned to the quorum may vote. Voting closes when all
-    assigned reviewers have voted or when 3+ votes are received.
-    A 2/3 authority-weighted supermajority decides the outcome.
-
-    Args:
-        session_id: Dialectic session ID
-        vote: "resume", "block", or "cooldown"
-        reasoning: Explanation for your vote
-        conditions: Optional conditions (for resume votes)
-    """
-    try:
-        # Require registered agent
-        agent_id, error = require_registered_agent(arguments)
-        if error:
-            return [error]
-
-        session_id = arguments.get("session_id")
-        if not session_id:
-            return [error_response(
-                "session_id is required",
-                recovery=missing_session_id_recovery(),
-            )]
-
-        vote_value = arguments.get("vote")
-        if vote_value not in ("resume", "block", "cooldown"):
-            return [error_response("vote must be 'resume', 'block', or 'cooldown'")]
-
-        reasoning = arguments.get("reasoning", "")
-        conditions = arguments.get("conditions")
-
-        # Load session
-        session = await load_session(session_id)
-        if not session:
-            return [error_response(
-                f"Session '{session_id}' not found",
-                recovery=session_not_found_recovery(),
-            )]
-
-        # Verify phase
-        if session.phase != DialecticPhase.QUORUM_VOTING:
-            return [error_response(
-                f"Session is in phase '{session.phase.value}', not 'quorum_voting'"
-            )]
-
-        # Read quorum reviewer IDs from session (set by _initiate_quorum)
-        quorum_reviewer_ids = getattr(session, 'quorum_reviewer_ids', []) or []
-
-        # PG fallback for sessions reconstructed before quorum_reviewer_ids was added.
-        # See _initiate_quorum above for why asyncio.wait_for is required here.
-        if not quorum_reviewer_ids:
-            try:
-                from src.db import get_db
-                db = await asyncio.wait_for(get_db(), timeout=0.5)
-                row = await asyncio.wait_for(
-                    db.fetchrow(
-                        "SELECT quorum_reviewer_ids FROM core.dialectic_sessions WHERE session_id = $1",
-                        session_id,
-                    ),
-                    timeout=1.0,
-                )
-                if row and row["quorum_reviewer_ids"]:
-                    qr = row["quorum_reviewer_ids"]
-                    quorum_reviewer_ids = json.loads(qr) if isinstance(qr, str) else qr
-                    session.quorum_reviewer_ids = quorum_reviewer_ids  # Cache on session
-            except (asyncio.TimeoutError, Exception) as e:
-                logger.warning(f"Could not load quorum_reviewer_ids from PG: {e}")
-
-        if not quorum_reviewer_ids:
-            return [error_response("No quorum reviewers assigned to this session")]
-
-        # Verify agent is in the quorum
-        agent_uuid = resolve_agent_uuid(arguments, agent_id)
-        if agent_uuid not in quorum_reviewer_ids and agent_id not in quorum_reviewer_ids:
-            return [error_response(
-                f"Agent '{agent_id}' is not in the quorum for this session"
-            )]
-
-        # Check for duplicate vote
-        existing_votes = [
-            msg for msg in session.transcript
-            if msg.phase == "quorum_vote" and msg.agent_id in (agent_id, agent_uuid)
-        ]
-        if existing_votes:
-            return [error_response(f"Agent '{agent_id}' has already voted in this session")]
-
-        # Get authority weight for this voter
-        # Wave 2 audit: force=True dropped per PR #350 precedent. Single-agent
-        # weight read; in-memory cache is fresh enough.
-        await mcp_server.load_metadata_async()
-        voter_meta = mcp_server.agent_metadata.get(agent_uuid) or mcp_server.agent_metadata.get(agent_id)
-        meta_dict = {}
-        if voter_meta and not isinstance(voter_meta, str):
-            for attr in ('tags', 'total_reviews', 'successful_reviews', 'last_update'):
-                val = getattr(voter_meta, attr, None) if not isinstance(voter_meta, dict) else voter_meta.get(attr)
-                if val is not None:
-                    meta_dict[attr] = val
-        try:
-            from src.dialectic_protocol import calculate_authority_score
-            authority_weight = calculate_authority_score(meta_dict)
-        except Exception:
-            authority_weight = 0.5
-
-        # Store vote as DialecticMessage
-        vote_msg = DialecticMessage(
-            phase="quorum_vote",
-            agent_id=agent_uuid or agent_id,
-            timestamp=datetime.now(timezone.utc).isoformat(),
-            reasoning=reasoning,
-            proposed_conditions=conditions,
-            observed_metrics={"authority_weight": authority_weight, "vote": vote_value},
-        )
-        session.transcript.append(vote_msg)
-
-        # Persist message to PostgreSQL
-        try:
-            await pg_add_message(
-                session_id=session_id,
-                agent_id=agent_uuid or agent_id,
-                message_type="quorum_vote",
-                reasoning=reasoning,
-                proposed_conditions=conditions or [],
-                observed_metrics={"authority_weight": authority_weight, "vote": vote_value},
-            )
-        except Exception as e:
-            logger.warning(f"Could not persist quorum vote to PG: {e}")
-
-        await save_session(session)
-
-        # Collect all quorum votes from transcript
-        all_vote_msgs = [
-            msg for msg in session.transcript
-            if msg.phase == "quorum_vote"
-        ]
-        vote_count = len(all_vote_msgs)
-
-        # Tally when: all reviewers voted OR 3+ votes received
-        should_tally = (vote_count >= len(quorum_reviewer_ids)) or (vote_count >= 3)
-
-        result: Dict[str, Any] = {
-            "success": True,
-            "session_id": session_id,
-            "vote_recorded": True,
-            "votes_received": vote_count,
-            "votes_needed": len(quorum_reviewer_ids),
-        }
-
-        if not should_tally:
-            result["status"] = "awaiting_more_votes"
-            result["next_step"] = f"Waiting for more votes ({vote_count}/{len(quorum_reviewer_ids)})"
-            return success_response(result)
-
-        # Build QuorumVote objects and tally
-        quorum_votes = []
-        for msg in all_vote_msgs:
-            metrics = msg.observed_metrics or {}
-            quorum_votes.append(QuorumVote(
-                agent_id=msg.agent_id,
-                vote=metrics.get("vote", "cooldown"),
-                authority_weight=metrics.get("authority_weight", 0.5),
-                reasoning=msg.reasoning or "",
-                conditions=msg.proposed_conditions,
-                timestamp=msg.timestamp,
-            ))
-
-        tally = tally_quorum_votes(quorum_votes)
-        result["quorum_result"] = tally.to_dict()
-
-        # Persist quorum result. See _initiate_quorum above for the rationale
-        # behind the asyncio.wait_for deadlock guard.
-        try:
-            from src.db import get_db
-            db = await asyncio.wait_for(get_db(), timeout=0.5)
-            await asyncio.wait_for(
-                db.execute(
-                    """UPDATE core.dialectic_sessions
-                       SET quorum_result = $1::jsonb, updated_at = NOW()
-                     WHERE session_id = $2""",
-                    json.dumps(tally.to_dict()),
-                    session_id,
-                ),
-                timeout=1.0,
-            )
-        except (asyncio.TimeoutError, Exception) as e:
-            logger.warning(f"Could not persist quorum_result to PG: {e}")
-
-        if tally.achieved_supermajority and tally.action == "resume":
-            # Merge conditions from resume voters
-            merged_conditions = []
-            for qv in quorum_votes:
-                if qv.vote == "resume" and qv.conditions:
-                    for c in qv.conditions:
-                        if c not in merged_conditions:
-                            merged_conditions.append(c)
-            if not merged_conditions:
-                merged_conditions = ["Monitor coherence for 24h"]
-
-            # Build resolution and execute
-            resolution = Resolution(
-                action="resume",
-                conditions=merged_conditions,
-                root_cause=f"Quorum vote: {tally.vote_counts}",
-                reasoning=f"Quorum supermajority ({tally.margin:.0%}) voted to resume",
-                signature_a="quorum",
-                signature_b="quorum",
-                timestamp=datetime.now(timezone.utc).isoformat(),
-            )
-            session.resolution = resolution
-            session.phase = DialecticPhase.RESOLVED
-
-            try:
-                execution_result = await execute_resolution(session, resolution)
-                result["execution"] = execution_result
-                result["next_step"] = next_step_resumed()
-                result["next_steps"] = default_resume_steps()
-            except Exception as e:
-                result["execution_error"] = str(e)
-                result["next_step"] = next_step_execution_failed(e)
-
-            try:
-                await pg_resolve_session(
-                    session_id=session_id,
-                    resolution=resolution.to_dict(),
-                    status="resolved",
-                )
-            except Exception as e:
-                logger.warning(f"Could not mark quorum-resolved session in PG: {e}")
-
-        elif tally.achieved_supermajority and tally.action == "block":
-            session.phase = DialecticPhase.FAILED
-            result["next_step"] = "Quorum voted to block. Agent remains paused."
-            try:
-                await pg_resolve_session(
-                    session_id=session_id,
-                    resolution={"action": "block", "quorum_result": tally.to_dict()},
-                    status="failed",
-                )
-            except Exception as e:
-                logger.warning(f"Could not mark quorum-blocked session in PG: {e}")
-
-        else:
-            # No supermajority (including cooldown majority) — conservative default
-            session.phase = DialecticPhase.ESCALATED
-            result["next_step"] = next_step_no_consensus()
-            result["cooldown_until"] = (datetime.now() + timedelta(hours=1)).isoformat()
-            try:
-                await pg_resolve_session(
-                    session_id=session_id,
-                    resolution={"action": "cooldown", "quorum_result": tally.to_dict()},
-                    status="escalated",
-                )
-            except Exception as e:
-                logger.warning(f"Could not mark quorum-cooldown session in PG: {e}")
-
-        # Invalidate cache
-        for aid in (session.paused_agent_id, session.reviewer_agent_id):
-            if aid and aid in _SESSION_METADATA_CACHE:
-                del _SESSION_METADATA_CACHE[aid]
-
-        await save_session(session)
-        return success_response(result)
-
-    except Exception as e:
-        return [error_response(f"Error submitting quorum vote: {str(e)}")]
 
 
 @mcp_tool("llm_assisted_dialectic", timeout=45.0, register=False)

--- a/src/mcp_handlers/dialectic/responses.py
+++ b/src/mcp_handlers/dialectic/responses.py
@@ -230,14 +230,3 @@ def default_escalate_steps() -> List[str]:
     ]
 
 
-def next_step_quorum_initiated(count: int) -> str:
-    """Next-step guidance after quorum voting is initiated."""
-    return f"Quorum of {count} reviewers assigned. Each should submit_quorum_vote."
-
-
-def default_quorum_steps() -> List[str]:
-    return [
-        "Quorum reviewers should call submit_quorum_vote with their vote",
-        "Voting closes when all reviewers vote or 3+ votes are in",
-        "A 2/3 authority-weighted supermajority decides the outcome",
-    ]

--- a/src/mcp_handlers/dialectic/reviewer.py
+++ b/src/mcp_handlers/dialectic/reviewer.py
@@ -175,7 +175,7 @@ async def is_agent_in_active_session(agent_id: str) -> bool:
     for session in ACTIVE_SESSIONS.values():
         if (session.paused_agent_id == agent_id or
             session.reviewer_agent_id == agent_id):
-            if session.phase not in [DialecticPhase.RESOLVED, DialecticPhase.FAILED, DialecticPhase.ESCALATED]:
+            if session.phase not in [DialecticPhase.RESOLVED, DialecticPhase.FAILED]:
                 _SESSION_METADATA_CACHE[agent_id] = {
                     'in_session': True,
                     'timestamp': time.time(),
@@ -367,86 +367,3 @@ async def select_reviewer(paused_agent_id: str,
     return top[0][0]
 
 
-async def select_quorum_reviewers(
-    session: DialecticSession,
-    metadata: Dict[str, Any],
-    min_reviewers: int = 3,
-    max_reviewers: int = 5,
-) -> List[tuple]:
-    """
-    Select a quorum of reviewers for an escalated dialectic session.
-
-    Same eligibility filters as select_reviewer but returns top N by
-    authority score (deterministic, no random). Uses a 6h recently-reviewed
-    window (shorter than the 24h for single reviewer).
-
-    Returns:
-        List of (agent_id, authority_score) tuples sorted by score descending,
-        or empty list if fewer than min_reviewers are eligible.
-    """
-    if not _autoselect_enabled():
-        logger.info(
-            "[DIALECTIC] Quorum auto-select disabled "
-            "(UNITARES_AUTOSELECT_REVIEWER unset). Returning empty list — "
-            "caller should escalate or assign quorum manually."
-        )
-        return []
-
-    if not metadata or not isinstance(metadata, dict):
-        return []
-
-    # Agents already involved in the session
-    exclude_ids = {session.paused_agent_id}
-    if session.reviewer_agent_id:
-        exclude_ids.add(session.reviewer_agent_id)
-
-    paused_agent_tags = []
-    if session.paused_agent_state:
-        paused_agent_tags = session.paused_agent_state.get("tags", [])
-
-    candidates = []
-
-    for agent_id, agent_meta in metadata.items():
-        if not isinstance(agent_id, str):
-            continue
-
-        if agent_id in exclude_ids:
-            continue
-
-        if await is_agent_in_active_session(agent_id):
-            continue
-
-        # Shorter cooldown for quorum (6h instead of 24h)
-        if await _has_recently_reviewed(agent_id, session.paused_agent_id, hours=6):
-            continue
-
-        if isinstance(agent_meta, str) or agent_meta is None:
-            continue
-
-        status = agent_meta.get('status') if isinstance(agent_meta, dict) else getattr(agent_meta, 'status', None)
-        if status and status != 'active':
-            continue
-
-        meta_dict = agent_meta if isinstance(agent_meta, dict) else {}
-        if not isinstance(agent_meta, dict):
-            meta_dict = {}
-            for attr in ('tags', 'total_reviews', 'successful_reviews', 'last_update'):
-                val = getattr(agent_meta, attr, None)
-                if val is not None:
-                    meta_dict[attr] = val
-        if paused_agent_tags:
-            meta_dict['paused_agent_tags'] = paused_agent_tags
-
-        try:
-            score = calculate_authority_score(meta_dict)
-        except Exception:
-            score = 0.5
-
-        candidates.append((agent_id, score))
-
-    if len(candidates) < min_reviewers:
-        return []
-
-    # Deterministic: sort by score descending, take top max_reviewers
-    candidates.sort(key=lambda x: x[1], reverse=True)
-    return candidates[:max_reviewers]

--- a/src/mcp_handlers/dialectic/session.py
+++ b/src/mcp_handlers/dialectic/session.py
@@ -124,10 +124,6 @@ def _reconstruct_session_from_dict(session_id: str, session_data: Dict) -> Optio
             session._max_synthesis_wait = session.MAX_SYNTHESIS_WAIT
             session._max_total_time = session.MAX_TOTAL_TIME
 
-        # Restore quorum fields
-        session.quorum_reviewer_ids = session_data.get("quorum_reviewer_ids", []) or []
-        session.quorum_deadline = session_data.get("quorum_deadline")
-
         return session
     except Exception as e:
         logger.error(f"Error reconstructing session {session_id}: {e}", exc_info=True)
@@ -144,7 +140,7 @@ async def save_session(session: DialecticSession) -> None:
     try:
         from src.dialectic_db import update_session_phase_async as pg_update_phase
         from src.dialectic_db import resolve_session_async as pg_resolve_session
-        if session.phase in (DialecticPhase.RESOLVED, DialecticPhase.FAILED, DialecticPhase.ESCALATED):
+        if session.phase in (DialecticPhase.RESOLVED, DialecticPhase.FAILED):
             resolution_dict = session.resolution.to_dict() if session.resolution else None
             status = session.phase.value if session.phase == DialecticPhase.RESOLVED else "failed"
             await pg_resolve_session(
@@ -202,7 +198,7 @@ async def load_all_sessions() -> int:
             if not full:
                 continue
             session = _reconstruct_session_from_dict(session_id, full)
-            if session and session.phase not in [DialecticPhase.RESOLVED, DialecticPhase.FAILED, DialecticPhase.ESCALATED]:
+            if session and session.phase not in [DialecticPhase.RESOLVED, DialecticPhase.FAILED]:
                 ACTIVE_SESSIONS[session_id] = session
                 loaded_count += 1
         if loaded_count > 0:

--- a/src/mcp_handlers/schemas/dialectic.py
+++ b/src/mcp_handlers/schemas/dialectic.py
@@ -108,20 +108,6 @@ class SubmitSynthesisParams(AgentIdentityMixin):
             self.agrees = self.agrees.lower() in ('true', '1', 'yes')
         return self
 
-class SubmitQuorumVoteParams(AgentIdentityMixin):
-    """
-    Submit a quorum vote on an escalated dialectic session
-    """
-    session_id: str = Field(..., description="Dialectic session ID")
-    vote: Literal["resume", "block", "cooldown"] = Field(
-        ..., description="Vote action: resume the agent, block permanently, or cooldown"
-    )
-    reasoning: str = Field(..., description="Explanation for your vote")
-    conditions: Optional[List[str]] = Field(
-        default=None, description="Conditions for resumption (relevant if vote is 'resume')"
-    )
-
-
 class LlmAssistedDialecticParams(AgentIdentityMixin):
     """
     Run LLM-assisted dialectic recovery
@@ -132,7 +118,7 @@ class LlmAssistedDialecticParams(AgentIdentityMixin):
 
 class DialecticParams(AgentIdentityMixin):
     """Parameters for dialectic"""
-    action: Literal["get", "list", "request", "thesis", "antithesis", "synthesis", "vote", "reassign"] = Field(..., description="Operation: get, list, request, thesis, antithesis, synthesis, vote, reassign")
+    action: Literal["get", "list", "request", "thesis", "antithesis", "synthesis", "reassign"] = Field(..., description="Operation: get, list, request, thesis, antithesis, synthesis, reassign")
     session_id: Optional[str] = Field(None, description="Dialectic session ID")
     agent_id: Optional[str] = Field(None, description="Filter by agent (for action=get or list)")
     status: Optional[str] = Field(None, description="Filter by phase (for action=list)")

--- a/src/mcp_handlers/tool_stability.py
+++ b/src/mcp_handlers/tool_stability.py
@@ -205,9 +205,6 @@ _TOOL_ALIASES: Dict[str, ToolAlias] = {
     "submit_synthesis": ToolAlias(
         old_name="submit_synthesis", new_name="dialectic", reason="consolidated",
         migration_note="Use dialectic(action='synthesis', session_id='...')", inject_action="synthesis"),
-    "submit_quorum_vote": ToolAlias(
-        old_name="submit_quorum_vote", new_name="dialectic", reason="consolidated",
-        migration_note="Use dialectic(action='vote', session_id='...', vote='resume')", inject_action="vote"),
     "reassign_reviewer": ToolAlias(
         old_name="reassign_reviewer", new_name="dialectic", reason="consolidated",
         migration_note="Use dialectic(action='reassign', session_id='...')", inject_action="reassign"),

--- a/src/tool_modes.py
+++ b/src/tool_modes.py
@@ -149,7 +149,6 @@ TOOL_TIERS: dict[str, Set[str]] = {
         "submit_thesis",
         "submit_antithesis",
         "submit_synthesis",
-        "submit_quorum_vote",
         "mark_response_complete",
         "compare_agents",
         "get_workspace_health",
@@ -255,7 +254,6 @@ TOOL_OPERATIONS: dict[str, str] = {
     "submit_thesis": "write",             # Submit thesis phase
     "submit_antithesis": "write",         # Submit antithesis phase
     "submit_synthesis": "write",          # Submit synthesis phase
-    "submit_quorum_vote": "write",        # Submit quorum vote
     "dialectic": "read",                  # Consolidated: get/list sessions
 
     # SSE-only
@@ -322,7 +320,6 @@ TOOL_CATEGORIES = {
         "submit_thesis",                 # Paused agent explains reasoning
         "submit_antithesis",             # Reviewer raises concerns
         "submit_synthesis",              # Negotiate resolution
-        "submit_quorum_vote",            # Vote in quorum-escalated session
         "dialectic",                     # Consolidated: get/list sessions
     },
 }

--- a/src/tool_schemas.py
+++ b/src/tool_schemas.py
@@ -105,7 +105,6 @@ TOOL_ORDER = [
     "submit_thesis",
     "submit_antithesis",
     "submit_synthesis",
-    "submit_quorum_vote",
     "archive_agent",
     "update_agent_metadata",
     "archive_old_test_agents",

--- a/tests/test_calibration_end_to_end.py
+++ b/tests/test_calibration_end_to_end.py
@@ -163,7 +163,7 @@ async def test_disagreement_calibration():
                 dispute_type="verification"
             )
             session.created_at = datetime.now()
-            session.phase = DialecticPhase.ESCALATED  # Max rounds exceeded
+            session.phase = DialecticPhase.FAILED  # Max rounds exceeded (ESCALATED retired)
             session.synthesis_round = 6  # Exceeded max rounds
             session.max_synthesis_rounds = 5
             
@@ -287,7 +287,7 @@ async def test_both_paths_together():
                 dispute_type="verification"
             )
             session2.created_at = datetime.now()
-            session2.phase = DialecticPhase.ESCALATED
+            session2.phase = DialecticPhase.FAILED  # ESCALATED retired
             session2.transcript.append(DialecticMessage(
                 phase="synthesis",
                 agent_id="test_agent_both_2",

--- a/tests/test_dialectic_handlers.py
+++ b/tests/test_dialectic_handlers.py
@@ -890,8 +890,6 @@ class TestHandleSubmitSynthesis:
 
         with patch(f"{DIALECTIC}.load_session", new_callable=AsyncMock,
                    return_value=session), \
-             patch(f"{DIALECTIC}._initiate_quorum", new_callable=AsyncMock,
-                   return_value=None), \
              mock_pg_add_message, mock_pg_update_phase, mock_save_session, \
              mock_context_agent:
             result = await handle_submit_synthesis({
@@ -948,8 +946,6 @@ class TestHandleSubmitSynthesis:
 
         with patch(f"{DIALECTIC}.load_session", new_callable=AsyncMock,
                    return_value=session), \
-             patch(f"{DIALECTIC}._initiate_quorum", new_callable=AsyncMock,
-                   return_value=None), \
              mock_pg_add_message, mock_pg_update_phase, mock_save_session, \
              mock_context_agent:
             result = await handle_submit_synthesis({
@@ -960,8 +956,11 @@ class TestHandleSubmitSynthesis:
             })
 
         data = parse_result(result)
-        # Session escalated or conservative default
-        assert data["success"] is False or data.get("autonomous_resolution") is True
+        # Quorum-escalation path retired; max-rounds always applies the
+        # conservative default (FAILED phase, autonomous_resolution=True).
+        assert data["success"] is False
+        assert data.get("autonomous_resolution") is True
+        assert data.get("resolution_type") == "conservative_default"
 
     @pytest.mark.asyncio
     async def test_convergence_with_resolution(
@@ -1088,40 +1087,6 @@ class TestHandleSubmitSynthesis:
         assert data["success"] is False
         assert "participant" in data["error"].lower(), (
             f"expected participant-set rejection, got: {data}"
-        )
-
-    @pytest.mark.asyncio
-    async def test_synthesis_accepts_quorum_reviewer(
-        self, mock_server, mock_pg_add_message, mock_pg_update_phase,
-        mock_save_session, mock_context_agent,
-    ):
-        """Quorum reviewers are legitimate participants once escalation has
-        assigned them; the gate must allow their synthesis submission."""
-        from src.mcp_handlers.dialectic.handlers import handle_submit_synthesis
-
-        session = _make_session(phase=DialecticPhase.SYNTHESIS)
-        session.synthesis_round = 1
-        # Simulate: session has been escalated to quorum voting, and an
-        # assigned quorum reviewer submits a synthesis proposal.
-        session.quorum_reviewer_ids = ["agent-active"]
-
-        with patch(f"{DIALECTIC}.load_session", new_callable=AsyncMock,
-                   return_value=session), \
-             mock_pg_add_message, mock_pg_update_phase, mock_save_session, \
-             mock_context_agent:
-            result = await handle_submit_synthesis({
-                "session_id": session.session_id,
-                "agent_id": "agent-active",
-                "proposed_conditions": ["Merged quorum condition"],
-                "root_cause": "test",
-                "reasoning": "on the quorum",
-                "agrees": False,
-                "api_key": "key123",
-            })
-
-        data = parse_result(result)
-        assert data["success"] is True, (
-            f"quorum reviewer must be accepted, got: {data}"
         )
 
     # ------------------------------------------------------------------
@@ -1313,56 +1278,6 @@ class TestHandleSubmitSynthesis:
             f"prior synthesis with conditions should bypass early-fail, got: {data}"
         )
 
-
-# ============================================================================
-# Deadlock guards: any direct ``await get_db()`` in a dialectic handler path
-# must not hang the anyio task group. CLAUDE.md rule: new MCP handlers that
-# need DB access must use ``run_in_executor`` or ``asyncio.wait_for`` with a
-# tight timeout and graceful degradation. The three sites covered:
-#   1448: ``_initiate_quorum`` phase persist
-#   1533: ``handle_submit_quorum_vote`` reviewer-id fallback read
-#   1646: ``handle_submit_quorum_vote`` post-vote result persist
-# ============================================================================
-
-
-class TestDeadlockGuards:
-    """Regression guards for the anyio/asyncpg deadlock pattern."""
-
-    @pytest.mark.asyncio
-    async def test_initiate_quorum_tolerates_get_db_deadlock(
-        self, mock_server, mock_save_session,
-    ):
-        """``_initiate_quorum`` must complete within a bounded time even if
-        ``get_db`` hangs. Before the guard, a stuck asyncpg pool would
-        deadlock the whole handler; after the guard, the except path logs a
-        warning and the function returns in-memory state."""
-        import asyncio as _asyncio
-        from src.mcp_handlers.dialectic.handlers import _initiate_quorum
-
-        # Seed some eligible reviewers so _initiate_quorum gets past the
-        # select_quorum_reviewers short-circuit.
-        mock_server.agent_metadata = {
-            f"reviewer-{i}": _make_agent_meta(status="active")
-            for i in range(5)
-        }
-
-        async def _never_returns():
-            await _asyncio.sleep(60)  # intentionally longer than any handler budget
-            return None  # pragma: no cover
-
-        session = _make_session(phase=DialecticPhase.ANTITHESIS)
-
-        with patch(f"{DIALECTIC}.select_quorum_reviewers", new_callable=AsyncMock,
-                   return_value=[(f"reviewer-{i}", 1.0) for i in range(3)]), \
-             patch("src.db.get_db", side_effect=_never_returns), \
-             mock_save_session:
-            # Bound the test's own patience to prove the handler has its own
-            # timeout. If the fix works the call returns quickly; if it doesn't,
-            # this wait_for fires and the test fails with a clear reason.
-            result = await _asyncio.wait_for(_initiate_quorum(session), timeout=5.0)
-
-        assert result is not None, "quorum must still form even if PG persist hangs"
-        assert len(result["reviewer_ids"]) == 3
 
 class TestHandleListDialecticSessions:
     """Tests for handle_list_dialectic_sessions handler."""
@@ -1841,275 +1756,3 @@ class TestGetDialecticNextSteps:
         assert any("human" in s.lower() for s in steps)
 
 
-# ============================================================================
-# select_quorum_reviewers
-# ============================================================================
-
-class TestSelectQuorumReviewers:
-    """Tests for select_quorum_reviewers from reviewer.py."""
-
-    @pytest.fixture(autouse=True)
-    def _enable_autoselect(self, monkeypatch):
-        # Quorum auto-select is gated off by default (ghost-reviewer fix);
-        # these tests exercise the filter logic and opt in via the env flag.
-        monkeypatch.setenv("UNITARES_AUTOSELECT_REVIEWER", "1")
-
-    @pytest.mark.asyncio
-    async def test_disabled_by_default(self, monkeypatch):
-        """When the env flag is unset, quorum selection returns [] immediately."""
-        from src.mcp_handlers.dialectic.reviewer import select_quorum_reviewers
-        monkeypatch.delenv("UNITARES_AUTOSELECT_REVIEWER", raising=False)
-        session = _make_session(phase=DialecticPhase.ESCALATED)
-        metadata = {f"agent-{i}": _make_agent_meta() for i in range(8)}
-        result = await select_quorum_reviewers(session, metadata)
-        assert result == []
-
-    @pytest.mark.asyncio
-    async def test_not_enough_agents(self):
-        """Returns empty list when fewer than 3 candidates exist."""
-        from src.mcp_handlers.dialectic.reviewer import select_quorum_reviewers
-        session = _make_session(phase=DialecticPhase.ESCALATED)
-        metadata = {
-            "agent-paused": _make_agent_meta(),
-            "agent-reviewer": _make_agent_meta(),
-            "agent-c": _make_agent_meta(),
-        }
-        with patch("src.mcp_handlers.dialectic.reviewer.is_agent_in_active_session",
-                    new_callable=AsyncMock, return_value=False), \
-             patch("src.mcp_handlers.dialectic.reviewer._has_recently_reviewed",
-                    new_callable=AsyncMock, return_value=False):
-            result = await select_quorum_reviewers(session, metadata)
-        # Only agent-c is eligible (paused and reviewer excluded)
-        assert result == []
-
-    @pytest.mark.asyncio
-    async def test_correct_filtering(self):
-        """Filters out paused agent, reviewer, and inactive agents."""
-        from src.mcp_handlers.dialectic.reviewer import select_quorum_reviewers
-        session = _make_session(phase=DialecticPhase.ESCALATED)
-        metadata = {
-            "agent-paused": _make_agent_meta(),
-            "agent-reviewer": _make_agent_meta(),
-            "agent-c": _make_agent_meta(),
-            "agent-d": _make_agent_meta(),
-            "agent-e": _make_agent_meta(),
-            "agent-f": _make_agent_meta(status="inactive"),
-        }
-        with patch("src.mcp_handlers.dialectic.reviewer.is_agent_in_active_session",
-                    new_callable=AsyncMock, return_value=False), \
-             patch("src.mcp_handlers.dialectic.reviewer._has_recently_reviewed",
-                    new_callable=AsyncMock, return_value=False):
-            result = await select_quorum_reviewers(session, metadata)
-        ids = [r[0] for r in result]
-        assert "agent-paused" not in ids
-        assert "agent-reviewer" not in ids
-        assert "agent-f" not in ids
-        assert len(result) == 3  # c, d, e
-
-    @pytest.mark.asyncio
-    async def test_deterministic_top_n(self):
-        """Returns top N by authority score, not random."""
-        from src.mcp_handlers.dialectic.reviewer import select_quorum_reviewers
-        session = _make_session(phase=DialecticPhase.ESCALATED)
-        metadata = {
-            "agent-paused": _make_agent_meta(),
-            "agent-reviewer": _make_agent_meta(),
-        }
-        # Add 5 candidates with distinct review records
-        for i, name in enumerate(["a", "b", "c", "d", "e"]):
-            meta = _make_agent_meta()
-            meta.total_reviews = 10
-            meta.successful_reviews = 10 - i  # a has best track record
-            meta.tags = []
-            metadata[f"agent-{name}"] = meta
-
-        with patch("src.mcp_handlers.dialectic.reviewer.is_agent_in_active_session",
-                    new_callable=AsyncMock, return_value=False), \
-             patch("src.mcp_handlers.dialectic.reviewer._has_recently_reviewed",
-                    new_callable=AsyncMock, return_value=False):
-            result1 = await select_quorum_reviewers(session, metadata)
-            result2 = await select_quorum_reviewers(session, metadata)
-        # Same order both times (deterministic)
-        assert [r[0] for r in result1] == [r[0] for r in result2]
-        # Scores descending
-        scores = [r[1] for r in result1]
-        assert scores == sorted(scores, reverse=True)
-
-    @pytest.mark.asyncio
-    async def test_empty_metadata(self):
-        from src.mcp_handlers.dialectic.reviewer import select_quorum_reviewers
-        session = _make_session(phase=DialecticPhase.ESCALATED)
-        result = await select_quorum_reviewers(session, {})
-        assert result == []
-
-    @pytest.mark.asyncio
-    async def test_none_metadata(self):
-        from src.mcp_handlers.dialectic.reviewer import select_quorum_reviewers
-        session = _make_session(phase=DialecticPhase.ESCALATED)
-        result = await select_quorum_reviewers(session, None)
-        assert result == []
-
-
-# ============================================================================
-# handle_submit_quorum_vote
-# ============================================================================
-
-class TestSubmitQuorumVote:
-    """Tests for the handle_submit_quorum_vote handler."""
-
-    HANDLER_MODULE = "src.mcp_handlers.dialectic.handlers"
-
-    def _mock_db(self, quorum_reviewer_ids=None):
-        """Create a mock DB that returns quorum_reviewer_ids."""
-        mock_db = AsyncMock()
-        row = {"quorum_reviewer_ids": quorum_reviewer_ids or []}
-        mock_db.fetchrow = AsyncMock(return_value=row)
-        mock_db.execute = AsyncMock()
-        return mock_db
-
-    @pytest.mark.asyncio
-    async def test_missing_session_id(self):
-        from src.mcp_handlers.dialectic.handlers import handle_submit_quorum_vote
-        mock_srv = _make_mock_server({"voter-1": _make_agent_meta()})
-        with patch(f"{self.HANDLER_MODULE}.mcp_server", mock_srv), \
-             patch(f"{self.HANDLER_MODULE}.require_registered_agent",
-                   return_value=("voter-1", None)):
-            result = parse_result(await handle_submit_quorum_vote({
-                "vote": "resume",
-                "reasoning": "ok",
-            }))
-        assert result["success"] is False
-        assert "session_id" in result["error"].lower()
-
-    @pytest.mark.asyncio
-    async def test_wrong_phase(self):
-        from src.mcp_handlers.dialectic.handlers import handle_submit_quorum_vote
-        session = _make_session(phase=DialecticPhase.SYNTHESIS)
-        mock_srv = _make_mock_server({"voter-1": _make_agent_meta()})
-        with patch(f"{self.HANDLER_MODULE}.mcp_server", mock_srv), \
-             patch(f"{self.HANDLER_MODULE}.require_registered_agent",
-                   return_value=("voter-1", None)), \
-             patch(f"{self.HANDLER_MODULE}.load_session",
-                   new_callable=AsyncMock, return_value=session):
-            result = parse_result(await handle_submit_quorum_vote({
-                "session_id": session.session_id,
-                "vote": "resume",
-                "reasoning": "ok",
-            }))
-        assert result["success"] is False
-        assert "quorum_voting" in result["error"]
-
-    @pytest.mark.asyncio
-    async def test_agent_not_in_quorum(self):
-        from src.mcp_handlers.dialectic.handlers import handle_submit_quorum_vote
-        session = _make_session(phase=DialecticPhase.QUORUM_VOTING)
-        mock_srv = _make_mock_server({"voter-1": _make_agent_meta()})
-        mock_db = self._mock_db(["other-agent-1", "other-agent-2", "other-agent-3"])
-        with patch(f"{self.HANDLER_MODULE}.mcp_server", mock_srv), \
-             patch(f"{self.HANDLER_MODULE}.require_registered_agent",
-                   return_value=("voter-1", None)), \
-             patch(f"{self.HANDLER_MODULE}.load_session",
-                   new_callable=AsyncMock, return_value=session), \
-             patch("src.db.get_db", new_callable=AsyncMock, return_value=mock_db):
-            result = parse_result(await handle_submit_quorum_vote({
-                "session_id": session.session_id,
-                "vote": "resume",
-                "reasoning": "ok",
-            }))
-        assert result["success"] is False
-        assert "not in the quorum" in result["error"]
-
-    @pytest.mark.asyncio
-    async def test_duplicate_vote(self):
-        from src.mcp_handlers.dialectic.handlers import handle_submit_quorum_vote
-        session = _make_session(phase=DialecticPhase.QUORUM_VOTING)
-        # Pre-add a vote from voter-1
-        session.transcript.append(DialecticMessage(
-            phase="quorum_vote",
-            agent_id="voter-1",
-            timestamp=datetime.now().isoformat(),
-            observed_metrics={"vote": "resume", "authority_weight": 0.8},
-        ))
-        mock_srv = _make_mock_server({"voter-1": _make_agent_meta()})
-        mock_db = self._mock_db(["voter-1", "voter-2", "voter-3"])
-        with patch(f"{self.HANDLER_MODULE}.mcp_server", mock_srv), \
-             patch(f"{self.HANDLER_MODULE}.require_registered_agent",
-                   return_value=("voter-1", None)), \
-             patch(f"{self.HANDLER_MODULE}.load_session",
-                   new_callable=AsyncMock, return_value=session), \
-             patch("src.db.get_db", new_callable=AsyncMock, return_value=mock_db):
-            result = parse_result(await handle_submit_quorum_vote({
-                "session_id": session.session_id,
-                "vote": "resume",
-                "reasoning": "ok",
-            }))
-        assert result["success"] is False
-        assert "already voted" in result["error"]
-
-    @pytest.mark.asyncio
-    async def test_vote_recorded_awaiting_more(self):
-        """First vote is recorded, status is awaiting_more_votes."""
-        from src.mcp_handlers.dialectic.handlers import handle_submit_quorum_vote
-        session = _make_session(phase=DialecticPhase.QUORUM_VOTING)
-        mock_srv = _make_mock_server({"voter-1": _make_agent_meta()})
-        mock_db = self._mock_db(["voter-1", "voter-2", "voter-3", "voter-4"])
-        with patch(f"{self.HANDLER_MODULE}.mcp_server", mock_srv), \
-             patch(f"{self.HANDLER_MODULE}.require_registered_agent",
-                   return_value=("voter-1", None)), \
-             patch(f"{self.HANDLER_MODULE}.load_session",
-                   new_callable=AsyncMock, return_value=session), \
-             patch(f"{self.HANDLER_MODULE}.save_session",
-                   new_callable=AsyncMock), \
-             patch(f"{self.HANDLER_MODULE}.pg_add_message",
-                   new_callable=AsyncMock), \
-             patch("src.db.get_db", new_callable=AsyncMock, return_value=mock_db):
-            result = parse_result(await handle_submit_quorum_vote({
-                "session_id": session.session_id,
-                "vote": "resume",
-                "reasoning": "looks good",
-            }))
-        assert result["success"] is True
-        assert result["vote_recorded"] is True
-        assert result["status"] == "awaiting_more_votes"
-
-    @pytest.mark.asyncio
-    async def test_tally_triggers_on_third_vote(self):
-        """Tally triggers when 3 votes are received."""
-        from src.mcp_handlers.dialectic.handlers import handle_submit_quorum_vote
-        session = _make_session(phase=DialecticPhase.QUORUM_VOTING)
-        # Pre-add 2 resume votes
-        for vid in ("voter-1", "voter-2"):
-            session.transcript.append(DialecticMessage(
-                phase="quorum_vote", agent_id=vid,
-                timestamp=datetime.now().isoformat(),
-                observed_metrics={"vote": "resume", "authority_weight": 0.8},
-                reasoning="ok",
-            ))
-        mock_srv = _make_mock_server({
-            "voter-3": _make_agent_meta(),
-            "agent-paused": _make_agent_meta(status="paused"),
-        })
-        mock_db = self._mock_db(["voter-1", "voter-2", "voter-3", "voter-4", "voter-5"])
-        with patch(f"{self.HANDLER_MODULE}.mcp_server", mock_srv), \
-             patch(f"{self.HANDLER_MODULE}.require_registered_agent",
-                   return_value=("voter-3", None)), \
-             patch(f"{self.HANDLER_MODULE}.load_session",
-                   new_callable=AsyncMock, return_value=session), \
-             patch(f"{self.HANDLER_MODULE}.save_session",
-                   new_callable=AsyncMock), \
-             patch(f"{self.HANDLER_MODULE}.pg_add_message",
-                   new_callable=AsyncMock), \
-             patch(f"{self.HANDLER_MODULE}.pg_resolve_session",
-                   new_callable=AsyncMock), \
-             patch(f"{self.HANDLER_MODULE}.execute_resolution",
-                   new_callable=AsyncMock, return_value={"success": True}), \
-             patch("src.db.get_db", new_callable=AsyncMock, return_value=mock_db):
-            result = parse_result(await handle_submit_quorum_vote({
-                "session_id": session.session_id,
-                "vote": "resume",
-                "reasoning": "ok",
-            }))
-        assert result["success"] is True
-        assert "quorum_result" in result
-        assert result["quorum_result"]["achieved_supermajority"] is True
-        assert result["quorum_result"]["action"] == "resume"

--- a/tests/test_dialectic_session_handlers.py
+++ b/tests/test_dialectic_session_handlers.py
@@ -321,7 +321,7 @@ class TestReconstructSessionFromDict:
     def test_reconstruction_with_all_phases(self):
         from src.mcp_handlers.dialectic.session import _reconstruct_session_from_dict
 
-        for phase_value in ["thesis", "antithesis", "synthesis", "resolved", "escalated", "failed"]:
+        for phase_value in ["thesis", "antithesis", "synthesis", "resolved", "failed"]:
             data = _make_session_dict(phase=phase_value)
             session = _reconstruct_session_from_dict(f"sess_{phase_value}", data)
             assert session is not None

--- a/tests/test_dialectic_session_pure.py
+++ b/tests/test_dialectic_session_pure.py
@@ -19,9 +19,6 @@ from src.dialectic_protocol import (
     Resolution,
     DialecticPhase,
     ResolutionAction,
-    QuorumVote,
-    QuorumResult,
-    tally_quorum_votes,
 )
 from src.mcp_handlers.dialectic.session import _reconstruct_session_from_dict
 
@@ -41,18 +38,16 @@ class TestDialecticPhase:
     def test_resolved_value(self):
         assert DialecticPhase.RESOLVED.value == "resolved"
 
-    def test_quorum_voting_value(self):
-        assert DialecticPhase.QUORUM_VOTING.value == "quorum_voting"
-
     def test_all_phases(self):
         phases = [p.value for p in DialecticPhase]
         assert "thesis" in phases
         assert "antithesis" in phases
         assert "synthesis" in phases
         assert "resolved" in phases
-        assert "escalated" in phases
         assert "failed" in phases
-        assert "quorum_voting" in phases
+        # ESCALATED + QUORUM_VOTING retired; 0/47 historical uses (council 2026-05-06)
+        assert "escalated" not in phases
+        assert "quorum_voting" not in phases
 
 
 # ============================================================================
@@ -602,7 +597,9 @@ class TestDialecticProtocolFlow:
         result = session.submit_synthesis(self._synthesis_msg("agent-a"), "key-a")
         assert result["success"] is False
         assert "Max synthesis rounds exceeded" in result["error"]
-        assert session.phase == DialecticPhase.ESCALATED
+        # ESCALATED retired; max-rounds now routes to FAILED with action="failed_max_rounds"
+        assert session.phase == DialecticPhase.FAILED
+        assert result.get("action") == "failed_max_rounds"
 
     def test_convergence_single_agrees(self):
         """Single synthesis with agrees=True resolves. No fourth phase."""
@@ -632,128 +629,3 @@ class TestDialecticProtocolFlow:
         assert d["session_id"] is not None
 
 
-# ============================================================================
-# QuorumVote and tally_quorum_votes
-# ============================================================================
-
-class TestQuorumVote:
-
-    def test_create(self):
-        v = QuorumVote(
-            agent_id="a1", vote="resume", authority_weight=0.8,
-            reasoning="looks good",
-        )
-        assert v.vote == "resume"
-        assert v.authority_weight == 0.8
-
-    def test_to_dict(self):
-        v = QuorumVote(
-            agent_id="a1", vote="block", authority_weight=0.5,
-            reasoning="unsafe", conditions=["halt"],
-        )
-        d = v.to_dict()
-        assert d["agent_id"] == "a1"
-        assert d["vote"] == "block"
-        assert d["conditions"] == ["halt"]
-
-
-class TestTallyQuorumVotes:
-
-    def _vote(self, agent_id, vote, weight):
-        return QuorumVote(
-            agent_id=agent_id, vote=vote, authority_weight=weight,
-            reasoning="test",
-        )
-
-    def test_empty_votes(self):
-        result = tally_quorum_votes([])
-        assert result.action == "no_supermajority"
-        assert result.achieved_supermajority is False
-        assert result.total_weight == 0.0
-
-    def test_unanimous_resume(self):
-        votes = [
-            self._vote("a1", "resume", 0.8),
-            self._vote("a2", "resume", 0.7),
-            self._vote("a3", "resume", 0.6),
-        ]
-        result = tally_quorum_votes(votes)
-        assert result.action == "resume"
-        assert result.achieved_supermajority is True
-        assert result.margin == 1.0
-        assert result.vote_counts == {"resume": 3}
-
-    def test_unanimous_block(self):
-        votes = [
-            self._vote("a1", "block", 0.9),
-            self._vote("a2", "block", 0.8),
-            self._vote("a3", "block", 0.7),
-        ]
-        result = tally_quorum_votes(votes)
-        assert result.action == "block"
-        assert result.achieved_supermajority is True
-
-    def test_two_thirds_supermajority(self):
-        """2 out of 3 equal-weight votes = 2/3 exactly."""
-        votes = [
-            self._vote("a1", "resume", 1.0),
-            self._vote("a2", "resume", 1.0),
-            self._vote("a3", "block", 1.0),
-        ]
-        result = tally_quorum_votes(votes)
-        assert result.action == "resume"
-        assert result.achieved_supermajority is True
-        assert abs(result.margin - 2/3) < 0.01
-
-    def test_split_no_supermajority(self):
-        """Even split = no supermajority."""
-        votes = [
-            self._vote("a1", "resume", 1.0),
-            self._vote("a2", "block", 1.0),
-            self._vote("a3", "cooldown", 1.0),
-        ]
-        result = tally_quorum_votes(votes)
-        assert result.action == "no_supermajority"
-        assert result.achieved_supermajority is False
-
-    def test_authority_weighted_edge(self):
-        """High-authority resume voter outweighs two low-authority block voters."""
-        votes = [
-            self._vote("a1", "resume", 0.9),
-            self._vote("a2", "resume", 0.8),
-            self._vote("a3", "block", 0.1),
-            self._vote("a4", "block", 0.1),
-        ]
-        result = tally_quorum_votes(votes)
-        # resume weight: 1.7, total: 1.9, fraction = ~89%
-        assert result.action == "resume"
-        assert result.achieved_supermajority is True
-
-    def test_authority_weighted_no_supermajority(self):
-        """One high-authority block voter prevents resume supermajority."""
-        votes = [
-            self._vote("a1", "resume", 0.4),
-            self._vote("a2", "resume", 0.4),
-            self._vote("a3", "block", 0.9),
-        ]
-        result = tally_quorum_votes(votes)
-        # resume weight: 0.8, total: 1.7, fraction = ~47% < 67%
-        assert result.achieved_supermajority is False
-
-    def test_zero_weight_votes(self):
-        """All zero-weight votes = no supermajority."""
-        votes = [
-            self._vote("a1", "resume", 0.0),
-            self._vote("a2", "resume", 0.0),
-        ]
-        result = tally_quorum_votes(votes)
-        assert result.action == "no_supermajority"
-        assert result.achieved_supermajority is False
-
-    def test_result_to_dict(self):
-        votes = [self._vote("a1", "resume", 0.8)]
-        result = tally_quorum_votes(votes)
-        d = result.to_dict()
-        assert "action" in d
-        assert "votes" in d
-        assert "total_weight" in d


### PR DESCRIPTION
## Summary

Hard-retire of the dialectic ESCALATED phase + quorum_voting machinery. Council 2026-05-06 live-verifier confirmed both paths are entirely vestigial across 6 months of production:

- \`DialecticPhase.ESCALATED\`: 0 sessions in 47
- \`DialecticPhase.QUORUM_VOTING\`: 0 sessions in 47
- \`quorum_reviewer_ids\` / \`quorum_deadline\`: NULL across all rows
- \`vote\` MCP action: never invoked

Architect's synthesis was that current quorum is recovery-escalation-shaped, not claim-adjudication-shaped — design Adjudicate from scratch when ready rather than retrofit. Operator chose hard-retire (option A) over repurpose (option B) or soft-retire (option C).

## Path-A context

PR2b of the dialectic stabilization sequence:

1. PR1 (#400) — wire \`outcome_event\` on resolution success path
2. PR2a (#402) — remove \`appointed_mediator_id\` ghost field
3. **PR2b (this PR)** — retire ESCALATED + quorum_voting
4. PR3 (next) — TOCTOU lock on phase transition (NEW-1)
5. PR4 (next) — bilateral attestation fix (NEW-2)

## What's removed

| Surface | What | Rationale |
|---|---|---|
| Protocol enum | \`DialecticPhase.ESCALATED\`, \`DialecticPhase.QUORUM_VOTING\` | Never set by any code path that exercises in production |
| Protocol classes | \`QuorumVote\`, \`QuorumResult\`, \`tally_quorum_votes\` | Tally function never called (0 votes ever) |
| Session fields | \`quorum_reviewer_ids\`, \`quorum_deadline\` | NULL across all 47 rows |
| Handlers | \`_initiate_quorum\` (~80 LOC), \`handle_submit_quorum_vote\` (~270 LOC) | Never reached at runtime |
| Reviewer | \`select_quorum_reviewers\` (~85 LOC) | Caller deleted |
| Responses | \`next_step_quorum_initiated\`, \`default_quorum_steps\` | Caller deleted |
| Schema | \`SubmitQuorumVoteParams\`, \`"vote"\` from \`DialecticParams.action\` Literal | No tool dispatches it |
| Tool registries | \`submit_quorum_vote\` from \`tool_schemas\`, \`tool_modes\`, \`tool_stability\`, \`consolidated\` dispatcher | Tool retired |

## Behavior changes

- \`submit_synthesis\` max-rounds path: sets \`phase=FAILED\` with \`action="failed_max_rounds"\` (previously \`phase=ESCALATED\`, \`action="escalate_to_quorum"\`).
- Handler-side max-rounds branch in \`handle_submit_synthesis\` always applies \`conservative_default\` (previously attempted quorum formation first; quorum was never reachable).
- Session terminal-phase checks now check \`{RESOLVED, FAILED}\` only (previously included \`ESCALATED\`).

## Schema NOT changed

Columns \`quorum_reviewer_ids\`, \`quorum_deadline\`, \`quorum_result\` remain on \`core.dialectic_sessions\`. Status check-constraint still permits \`'escalated'\` and \`'quorum_voting'\`. Soft-retire keeps the existing 47 rows readable. Column drop is a separate migration PR if/when desired — there's no functional benefit to the migration since nothing writes those columns anymore.

## Diff stats

\`16 files changed, 33 insertions(+), 1108 deletions(-)\` — net **-1075 LOC**.

## Test plan

- [x] Full pytest gate: 8455 passed, 34 skipped (AGE), 0 regressions
- [x] Net -29 tests vs PR1 baseline, all from deleted: \`TestQuorumVote\`, \`TestTallyQuorumVotes\`, \`TestSelectQuorumReviewers\`, \`TestSubmitQuorumVote\`, \`TestDeadlockGuards\`, \`test_synthesis_accepts_quorum_reviewer\`
- [x] Updated tests: \`test_synthesis_wrong_phase\`, \`test_max_rounds_exceeded\` (drop \`_initiate_quorum\` patch + tighten conservative-default assertion), \`test_max_synthesis_rounds_exceeded\` (FAILED instead of ESCALATED), \`test_reconstruction_with_all_phases\` (drop escalated from phase iteration), \`test_calibration_end_to_end\` (FAILED instead of ESCALATED)
- [x] All quorum/escalation imports removed from handlers, exports clean

## Conflicts with PR2a (#402)

PR2a deletes \`test_synthesis_third_party_mediator\` from \`test_dialectic_handlers.py\`. PR2b leaves that test alone (still passes against PR2b base since the \`appointed_mediator_id\` field still works in master). Whichever lands second will need a small rebase on \`test_dialectic_handlers.py\`. Trivial.