### PR TITLE
feat(with_checkin): detect test-cache workflow

### DIFF
--- a/scripts/dev/with_checkin.py
+++ b/scripts/dev/with_checkin.py
@@ -118,6 +118,8 @@ def infer_workflow(argv: list[str]) -> str:
             return "push"
     if first in {"pytest", "tox"}:
         return "test"
+    if first == "test-cache.sh":
+        return "test"
     if first in {"python", "python3"} and len(lowered) > 2:
         if lowered[1] == "-m" and lowered[2] in {"pytest", "unittest"}:
             return "test"

--- a/tests/test_postgres_backend_integration.py
+++ b/tests/test_postgres_backend_integration.py
@@ -1016,6 +1016,7 @@ class TestKnowledgeGraphOperations:
             "related_to": [],
             "response_to": None,
             "provenance": None,
+            "provenance_chain": None,
             "timestamp": _now().isoformat(),
         }
         defaults.update(kwargs)

--- a/tests/test_with_checkin.py
+++ b/tests/test_with_checkin.py
@@ -17,6 +17,8 @@ SPEC.loader.exec_module(with_checkin)
 def test_infer_workflow_for_common_commands():
     assert with_checkin.infer_workflow(["python3", "-m", "pytest", "tests"]) == "test"
     assert with_checkin.infer_workflow(["pytest", "tests"]) == "test"
+    assert with_checkin.infer_workflow(["./scripts/dev/test-cache.sh"]) == "test"
+    assert with_checkin.infer_workflow(["scripts/dev/test-cache.sh", "--staged"]) == "test"
     assert with_checkin.infer_workflow(["make", "smoke"]) == "test"
     assert with_checkin.infer_workflow(["mix", "test"]) == "test"
     assert with_checkin.infer_workflow(["git", "commit", "-m", "msg"]) == "commit"


### PR DESCRIPTION
Adds test-cache.sh detection to the opt-in check-in wrapper so the repo's cached pytest helper is classified as a test workflow.\n\nLocal verification:\n- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q -p no:cacheprovider tests/test_with_checkin.py