### PR TITLE
fix(dialectic): TOCTOU lock on synthesis phase transition (NEW-1)

### DIFF
--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -79,7 +79,8 @@ from .session import (
     ACTIVE_SESSIONS,
     SESSION_STORAGE_DIR,
     _SESSION_METADATA_CACHE,
-    _CACHE_TTL
+    _CACHE_TTL,
+    get_session_lock,
 )
 
 # Session metadata cache for fast lookups (re-exported for backward compatibility)
@@ -1175,202 +1176,210 @@ async def handle_submit_synthesis(arguments: Dict[str, Any]) -> Sequence[TextCon
         if agent_error:
             return agent_error
 
-        # Always reload from disk to get latest state
-        session = await load_session(session_id)
-        if session:
-            ACTIVE_SESSIONS[session_id] = session
-        else:
-            session = ACTIVE_SESSIONS.get(session_id)
-            if not session:
-                return [error_response(
-                    f"Session '{session_id}' not found",
-                    recovery=session_not_found_recovery(),
-                )]
+        # NEW-1 (council 2026-05-06): serialize phase transitions per-session.
+        # Without this, two concurrent submit_synthesis calls with agrees=True
+        # both pass the SYNTHESIS-phase check on their own in-memory copies,
+        # both call finalize_resolution, and the second pg_resolve_session
+        # overwrites the first.
+        session_lock = await get_session_lock(session_id)
+        async with session_lock:
 
-        # Participant-set eligibility gate. The sibling handlers
-        # (submit_thesis / submit_antithesis) pass enforce_session_ownership=True
-        # to _resolve_dialectic_agent_id; submit_synthesis intentionally relaxes
-        # that check to support the "third-party synthesizer" pattern. Without
-        # a compensating allow-list, any registered agent could drive a
-        # synthesis to convergence and trigger resolution execution — a real
-        # privilege escalation surface. The allow-list is: the paused agent
-        # and the assigned reviewer.
-        eligible = set()
-        if getattr(session, "paused_agent_id", None):
-            eligible.add(session.paused_agent_id)
-        if getattr(session, "reviewer_agent_id", None):
-            eligible.add(session.reviewer_agent_id)
-        agent_uuid = resolve_agent_uuid(arguments, agent_id)
-        if agent_id not in eligible and (not agent_uuid or agent_uuid not in eligible):
-            return [error_response(
-                f"Agent '{agent_id}' is not a participant in this dialectic session.",
-                recovery=(
-                    "Only the paused agent or the assigned reviewer "
-                    "may submit synthesis."
-                ),
-            )]
-
-        # Coerce agrees to bool (MCP tools may send "true"/"false" strings)
-        raw_agrees = arguments.get('agrees', False)
-        if isinstance(raw_agrees, str):
-            agrees = raw_agrees.lower() in ('true', '1', 'yes')
-        else:
-            agrees = bool(raw_agrees)
-
-        # Resolve proposed_conditions, accepting `conditions` as an alias
-        # to prevent silent data loss from parameter-name confusion.
-        proposed_conditions = _read_proposed_conditions(arguments)
-
-        # Early-fail: synthesis with agrees=True must contribute conditions, OR
-        # there must already be a prior synthesis in transcript that did.
-        # Without this gate, the empty-conditions path slips through to
-        # check_hard_limits at finalize time and leaves the session in a
-        # phase=failed / resolution.action=resume inconsistent terminal state.
-        if agrees and not proposed_conditions:
-            prior_has_conditions = any(
-                getattr(msg, "phase", None) == "synthesis"
-                and getattr(msg, "proposed_conditions", None)
-                for msg in (session.transcript or [])
-            )
-            if not prior_has_conditions:
-                return [error_response(
-                    "Cannot agree (agrees=True) with empty proposed_conditions when no "
-                    "prior synthesis has supplied any. Either pass proposed_conditions=[...] "
-                    "(or its alias `conditions=[...]`) populated with the agreed terms, "
-                    "or set agrees=False to register disagreement instead.",
-                    error_code="EMPTY_AGREEMENT",
-                    error_category="validation_error",
-                    recovery={
-                        "action": (
-                            "Re-submit synthesis with proposed_conditions populated. "
-                            "If you intended to disagree, set agrees=false."
-                        ),
-                        "related_tools": ["dialectic"],
-                    },
-                    arguments=arguments,
-                )]
-
-        # Create synthesis message
-        message = DialecticMessage(
-            phase="synthesis",
-            agent_id=agent_id,
-            timestamp=datetime.now(timezone.utc).isoformat(),
-            proposed_conditions=proposed_conditions,
-            root_cause=arguments.get('root_cause'),
-            reasoning=arguments.get('reasoning'),
-            agrees=agrees
-        )
-
-        # Submit to session
-        result = session.submit_synthesis(message, api_key)
-
-        if result.get("success"):
-            # Persist synthesis message to PostgreSQL
-            # NOTE: Defer phase update for converged sessions until after finalize_resolution
-            # succeeds, to avoid "resolved" phase in PG without a resolution if finalize fails.
-            try:
-                await pg_add_message(
-                    session_id=session_id,
-                    agent_id=agent_id,
-                    message_type="synthesis",
-                    root_cause=arguments.get('root_cause'),
-                    proposed_conditions=proposed_conditions,
-                    reasoning=arguments.get('reasoning'),
-                    agrees=agrees,
-                )
-                if not result.get("converged"):
-                    await pg_update_phase(session_id, session.phase.value)
-            except Exception as e:
-                logger.warning(f"Could not update PostgreSQL after synthesis: {e}")
-
-            # Persist to JSON
-            try:
-                await save_session(session)
-            except Exception as e:
-                logger.warning(f"Could not save session after synthesis: {e}")
-
-        # If converged, finalize resolution
-        if result.get("success") and result.get("converged"):
-            # Bilateral attestation (v2): finalize_resolution signs the
-            # canonical resolution payload with each agent's own api_key.
-            # Council 2026-05-06 NEW-2 fixed: previously we computed both
-            # signatures over the SAME last synthesis message, so the
-            # reviewer's "signature" was over a message they never wrote.
-            paused_meta = mcp_server.agent_metadata.get(session.paused_agent_id)
-            reviewer_meta = mcp_server.agent_metadata.get(session.reviewer_agent_id)
-
-            api_key_a = paused_meta.api_key if paused_meta and paused_meta.api_key else api_key
-            api_key_b = reviewer_meta.api_key if reviewer_meta and reviewer_meta.api_key else ""
-
-            resolution = session.finalize_resolution(api_key_a, api_key_b)
-            is_safe, violation = session.check_hard_limits(resolution)
-
-            if not is_safe:
-                # Safety violation: mark session as FAILED (not RESOLVED)
-                session.phase = DialecticPhase.FAILED
-                result["action"] = "block"
-                result["success"] = False
-                result["reason"] = f"Safety violation: {violation}"
-                try:
-                    await pg_resolve_session(session_id=session_id, resolution={"action": "block", "reason": violation}, status="failed")
-                except Exception as e:
-                    logger.warning(f"Could not resolve session in PostgreSQL: {e}")
+            # Always reload from disk to get latest state
+            session = await load_session(session_id)
+            if session:
+                ACTIVE_SESSIONS[session_id] = session
             else:
-                result["action"] = "resume"
-                result["resolution"] = resolution.to_dict()
-
+                session = ACTIVE_SESSIONS.get(session_id)
+                if not session:
+                    return [error_response(
+                        f"Session '{session_id}' not found",
+                        recovery=session_not_found_recovery(),
+                    )]
+    
+            # Participant-set eligibility gate. The sibling handlers
+            # (submit_thesis / submit_antithesis) pass enforce_session_ownership=True
+            # to _resolve_dialectic_agent_id; submit_synthesis intentionally relaxes
+            # that check to support the "third-party synthesizer" pattern. Without
+            # a compensating allow-list, any registered agent could drive a
+            # synthesis to convergence and trigger resolution execution — a real
+            # privilege escalation surface. The allow-list is: the paused agent
+            # and the assigned reviewer.
+            eligible = set()
+            if getattr(session, "paused_agent_id", None):
+                eligible.add(session.paused_agent_id)
+            if getattr(session, "reviewer_agent_id", None):
+                eligible.add(session.reviewer_agent_id)
+            agent_uuid = resolve_agent_uuid(arguments, agent_id)
+            if agent_id not in eligible and (not agent_uuid or agent_uuid not in eligible):
+                return [error_response(
+                    f"Agent '{agent_id}' is not a participant in this dialectic session.",
+                    recovery=(
+                        "Only the paused agent or the assigned reviewer "
+                        "may submit synthesis."
+                    ),
+                )]
+    
+            # Coerce agrees to bool (MCP tools may send "true"/"false" strings)
+            raw_agrees = arguments.get('agrees', False)
+            if isinstance(raw_agrees, str):
+                agrees = raw_agrees.lower() in ('true', '1', 'yes')
+            else:
+                agrees = bool(raw_agrees)
+    
+            # Resolve proposed_conditions, accepting `conditions` as an alias
+            # to prevent silent data loss from parameter-name confusion.
+            proposed_conditions = _read_proposed_conditions(arguments)
+    
+            # Early-fail: synthesis with agrees=True must contribute conditions, OR
+            # there must already be a prior synthesis in transcript that did.
+            # Without this gate, the empty-conditions path slips through to
+            # check_hard_limits at finalize time and leaves the session in a
+            # phase=failed / resolution.action=resume inconsistent terminal state.
+            if agrees and not proposed_conditions:
+                prior_has_conditions = any(
+                    getattr(msg, "phase", None) == "synthesis"
+                    and getattr(msg, "proposed_conditions", None)
+                    for msg in (session.transcript or [])
+                )
+                if not prior_has_conditions:
+                    return [error_response(
+                        "Cannot agree (agrees=True) with empty proposed_conditions when no "
+                        "prior synthesis has supplied any. Either pass proposed_conditions=[...] "
+                        "(or its alias `conditions=[...]`) populated with the agreed terms, "
+                        "or set agrees=False to register disagreement instead.",
+                        error_code="EMPTY_AGREEMENT",
+                        error_category="validation_error",
+                        recovery={
+                            "action": (
+                                "Re-submit synthesis with proposed_conditions populated. "
+                                "If you intended to disagree, set agrees=false."
+                            ),
+                            "related_tools": ["dialectic"],
+                        },
+                        arguments=arguments,
+                    )]
+    
+            # Create synthesis message
+            message = DialecticMessage(
+                phase="synthesis",
+                agent_id=agent_id,
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                proposed_conditions=proposed_conditions,
+                root_cause=arguments.get('root_cause'),
+                reasoning=arguments.get('reasoning'),
+                agrees=agrees
+            )
+    
+            # Submit to session
+            result = session.submit_synthesis(message, api_key)
+    
+            if result.get("success"):
+                # Persist synthesis message to PostgreSQL
+                # NOTE: Defer phase update for converged sessions until after finalize_resolution
+                # succeeds, to avoid "resolved" phase in PG without a resolution if finalize fails.
                 try:
-                    execution_result = await execute_resolution(session, resolution)
-                    result["execution"] = execution_result
-                    if execution_result.get("success"):
-                        result["next_step"] = next_step_resumed()
-                    else:
-                        result["next_step"] = next_step_resume_not_applied(
-                            execution_result.get("warning")
-                        )
-
-                    # Execution succeeded - mark resolved in PG
+                    await pg_add_message(
+                        session_id=session_id,
+                        agent_id=agent_id,
+                        message_type="synthesis",
+                        root_cause=arguments.get('root_cause'),
+                        proposed_conditions=proposed_conditions,
+                        reasoning=arguments.get('reasoning'),
+                        agrees=agrees,
+                    )
+                    if not result.get("converged"):
+                        await pg_update_phase(session_id, session.phase.value)
+                except Exception as e:
+                    logger.warning(f"Could not update PostgreSQL after synthesis: {e}")
+    
+                # Persist to JSON
+                try:
+                    await save_session(session)
+                except Exception as e:
+                    logger.warning(f"Could not save session after synthesis: {e}")
+    
+            # If converged, finalize resolution
+            if result.get("success") and result.get("converged"):
+                # Bilateral attestation (v2): finalize_resolution signs the
+                # canonical resolution payload with each agent's own api_key.
+                # Council 2026-05-06 NEW-2 fixed: previously we computed both
+                # signatures over the SAME last synthesis message, so the
+                # reviewer's "signature" was over a message they never wrote.
+                paused_meta = mcp_server.agent_metadata.get(session.paused_agent_id)
+                reviewer_meta = mcp_server.agent_metadata.get(session.reviewer_agent_id)
+    
+                api_key_a = paused_meta.api_key if paused_meta and paused_meta.api_key else api_key
+                api_key_b = reviewer_meta.api_key if reviewer_meta and reviewer_meta.api_key else ""
+    
+                resolution = session.finalize_resolution(api_key_a, api_key_b)
+                is_safe, violation = session.check_hard_limits(resolution)
+    
+                if not is_safe:
+                    # Safety violation: mark session as FAILED (not RESOLVED)
+                    session.phase = DialecticPhase.FAILED
+                    result["action"] = "block"
+                    result["success"] = False
+                    result["reason"] = f"Safety violation: {violation}"
                     try:
-                        await pg_resolve_session(session_id=session_id, resolution=resolution.to_dict(), status="resolved")
+                        await pg_resolve_session(session_id=session_id, resolution={"action": "block", "reason": violation}, status="failed")
                     except Exception as e:
                         logger.warning(f"Could not resolve session in PostgreSQL: {e}")
-                except Exception as e:
-                    # Execution failed - mark FAILED, not resolved
-                    session.phase = DialecticPhase.FAILED
-                    result["success"] = False
-                    result["execution_error"] = str(e)
-                    result["next_step"] = next_step_execution_failed(e)
+                else:
+                    result["action"] = "resume"
+                    result["resolution"] = resolution.to_dict()
+    
                     try:
-                        await pg_resolve_session(session_id=session_id, resolution=resolution.to_dict(), status="failed")
-                    except Exception as pg_e:
-                        logger.warning(f"Could not mark failed session in PostgreSQL: {pg_e}")
-
-            # Update calibration from dialectic outcome
-            try:
-                if result.get("action") == "resume":
-                    await update_calibration_from_dialectic(session)
-                elif not is_safe:
-                    await update_calibration_from_dialectic_disagreement(session)
-            except Exception as cal_e:
-                logger.debug(f"Calibration update after dialectic: {cal_e}")
-
-            # Always invalidate cache after convergence (success or failure)
-            for aid in (session.paused_agent_id, session.reviewer_agent_id):
-                if aid and aid in _SESSION_METADATA_CACHE:
-                    del _SESSION_METADATA_CACHE[aid]
-
-            await save_session(session)
-
-        elif not result.get("success"):
-            # Max rounds exceeded — apply conservative default. The quorum-voting
-            # escalation path was retired (council 2026-05-06: 0 sessions ever
-            # escalated to quorum across 47 historical sessions / 6 months).
-            result["autonomous_resolution"] = True
-            result["resolution_type"] = "conservative_default"
-            result["next_step"] = next_step_no_consensus()
-            result["cooldown_until"] = (datetime.now() + timedelta(hours=1)).isoformat()
-
-        return success_response(result)
+                        execution_result = await execute_resolution(session, resolution)
+                        result["execution"] = execution_result
+                        if execution_result.get("success"):
+                            result["next_step"] = next_step_resumed()
+                        else:
+                            result["next_step"] = next_step_resume_not_applied(
+                                execution_result.get("warning")
+                            )
+    
+                        # Execution succeeded - mark resolved in PG
+                        try:
+                            await pg_resolve_session(session_id=session_id, resolution=resolution.to_dict(), status="resolved")
+                        except Exception as e:
+                            logger.warning(f"Could not resolve session in PostgreSQL: {e}")
+                    except Exception as e:
+                        # Execution failed - mark FAILED, not resolved
+                        session.phase = DialecticPhase.FAILED
+                        result["success"] = False
+                        result["execution_error"] = str(e)
+                        result["next_step"] = next_step_execution_failed(e)
+                        try:
+                            await pg_resolve_session(session_id=session_id, resolution=resolution.to_dict(), status="failed")
+                        except Exception as pg_e:
+                            logger.warning(f"Could not mark failed session in PostgreSQL: {pg_e}")
+    
+                # Update calibration from dialectic outcome
+                try:
+                    if result.get("action") == "resume":
+                        await update_calibration_from_dialectic(session)
+                    elif not is_safe:
+                        await update_calibration_from_dialectic_disagreement(session)
+                except Exception as cal_e:
+                    logger.debug(f"Calibration update after dialectic: {cal_e}")
+    
+                # Always invalidate cache after convergence (success or failure)
+                for aid in (session.paused_agent_id, session.reviewer_agent_id):
+                    if aid and aid in _SESSION_METADATA_CACHE:
+                        del _SESSION_METADATA_CACHE[aid]
+    
+                await save_session(session)
+    
+            elif not result.get("success"):
+                # Max rounds exceeded — apply conservative default. The quorum-voting
+                # escalation path was retired (council 2026-05-06: 0 sessions ever
+                # escalated to quorum across 47 historical sessions / 6 months).
+                result["autonomous_resolution"] = True
+                result["resolution_type"] = "conservative_default"
+                result["next_step"] = next_step_no_consensus()
+                result["cooldown_until"] = (datetime.now() + timedelta(hours=1)).isoformat()
+    
+            return success_response(result)
 
     except Exception as e:
         return [error_response(f"Error submitting synthesis: {str(e)}")]

--- a/src/mcp_handlers/dialectic/session.py
+++ b/src/mcp_handlers/dialectic/session.py
@@ -35,6 +35,39 @@ ACTIVE_SESSIONS: Dict[str, DialecticSession] = {}
 _SESSION_METADATA_CACHE: Dict[str, Dict] = {}
 _CACHE_TTL = 60.0  # Cache TTL in seconds (1 minute)
 
+# Per-session asyncio locks for serializing phase transitions. Council 2026-05-06
+# NEW-1: handle_submit_synthesis loads → mutates → writes without a row-level
+# lock; concurrent synthesis calls with agrees=True from both participants can
+# both pass the SYNTHESIS-phase check on their own in-memory copies and both
+# call finalize_resolution, with the second pg_resolve_session overwriting the
+# first. In-process asyncio.Lock per session_id serializes the critical region
+# without adding a new asyncpg await (per CLAUDE.md "Substrate Tax" guidance,
+# new DB awaits in MCP handlers are accreted workarounds, not progress).
+#
+# Single-process MCP deployment makes this sufficient. If/when multi-process
+# lands, this gets replaced by a postgres advisory lock or SELECT FOR UPDATE
+# pattern. Track that decision via the open-question doc, not by accreting
+# more in-process state.
+_SESSION_LOCKS: Dict[str, asyncio.Lock] = {}
+_SESSION_LOCKS_DICT_LOCK = asyncio.Lock()
+
+
+async def get_session_lock(session_id: str) -> asyncio.Lock:
+    """Return the lock for `session_id`, creating it if absent.
+
+    The dict-of-locks itself is guarded by `_SESSION_LOCKS_DICT_LOCK` to make
+    lazy creation safe under concurrent first-acquires. Locks are not actively
+    pruned — sessions terminate, traffic doesn't grow indefinitely. If memory
+    becomes a concern, prune RESOLVED/FAILED entries on save_session.
+    """
+    async with _SESSION_LOCKS_DICT_LOCK:
+        lock = _SESSION_LOCKS.get(session_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            _SESSION_LOCKS[session_id] = lock
+        return lock
+
+
 UNITARES_DIALECTIC_WRITE_JSON_SNAPSHOT = os.getenv("UNITARES_DIALECTIC_WRITE_JSON_SNAPSHOT", "1").strip().lower() not in (
     "0",
     "false",

--- a/tests/test_dialectic_toctou.py
+++ b/tests/test_dialectic_toctou.py
@@ -1,0 +1,230 @@
+"""
+Regression tests for the dialectic synthesis TOCTOU lock (NEW-1, council 2026-05-06).
+
+Bug: handle_submit_synthesis loaded → mutated → wrote without a row-level
+lock. Two concurrent submit_synthesis calls with agrees=True from the two
+participants could both pass the SYNTHESIS-phase check on their own in-memory
+copies, both call finalize_resolution, and the second pg_resolve_session
+overwrite the first.
+
+Fix: per-session asyncio.Lock acquired around the load-mutate-persist
+critical region in handle_submit_synthesis.
+"""
+
+import pytest
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import patch, AsyncMock, MagicMock
+from types import SimpleNamespace
+from datetime import datetime, timezone
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.dialectic_protocol import DialecticSession, DialecticPhase, DialecticMessage
+from src.mcp_handlers.dialectic.session import (
+    get_session_lock,
+    _SESSION_LOCKS,
+    ACTIVE_SESSIONS,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_module_state():
+    _SESSION_LOCKS.clear()
+    ACTIVE_SESSIONS.clear()
+    yield
+    _SESSION_LOCKS.clear()
+    ACTIVE_SESSIONS.clear()
+
+
+class TestSessionLockIdentity:
+    @pytest.mark.asyncio
+    async def test_same_session_id_returns_same_lock(self):
+        a = await get_session_lock("sess-x")
+        b = await get_session_lock("sess-x")
+        assert a is b, "lock dict must reuse a single Lock per session_id"
+
+    @pytest.mark.asyncio
+    async def test_different_session_ids_return_different_locks(self):
+        a = await get_session_lock("sess-x")
+        b = await get_session_lock("sess-y")
+        assert a is not b, "different session_ids must get distinct locks"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_first_acquire_is_safe(self):
+        """Two concurrent first-acquires for the same session must converge to one Lock."""
+        results = await asyncio.gather(
+            *(get_session_lock("sess-race") for _ in range(20))
+        )
+        first = results[0]
+        assert all(r is first for r in results), "dict-of-locks lazy create must be atomic"
+
+
+class TestSynthesisHandlerSerializesPhaseTransition:
+    """Verifies the lock actually blocks the synthesis handler under contention."""
+
+    DIALECTIC = "src.mcp_handlers.dialectic.handlers"
+
+    def _make_synthesis_session(self):
+        """SYNTHESIS-phase session with thesis + antithesis already in transcript."""
+        session = DialecticSession(
+            paused_agent_id="agent-paused",
+            reviewer_agent_id="agent-reviewer",
+            session_type="recovery",
+        )
+        session.phase = DialecticPhase.SYNTHESIS
+        session.synthesis_round = 1
+        session.transcript.append(DialecticMessage(
+            phase="thesis",
+            agent_id="agent-paused",
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            root_cause="initial cause",
+            proposed_conditions=["c1"],
+            reasoning="initial",
+        ))
+        session.transcript.append(DialecticMessage(
+            phase="antithesis",
+            agent_id="agent-reviewer",
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            reasoning="counter",
+            concerns=["concern-1"],
+        ))
+        return session
+
+    def _mock_server(self):
+        server = MagicMock()
+        server.agent_metadata = {
+            "agent-paused": SimpleNamespace(
+                status="paused", api_key="key-a", label="A",
+                last_update=datetime.now().isoformat(), paused_at=None, structured_id=None,
+            ),
+            "agent-reviewer": SimpleNamespace(
+                status="active", api_key="key-b", label="B",
+                last_update=datetime.now().isoformat(), paused_at=None, structured_id=None,
+            ),
+        }
+        server.load_metadata_async = AsyncMock(return_value=None)
+        server.monitors = {}
+        return server
+
+    @pytest.mark.asyncio
+    async def test_handler_blocks_when_session_lock_held_externally(self):
+        """If something else holds the per-session lock, handle_submit_synthesis
+        must not proceed past the lock acquire. This proves the wiring is
+        actually around the critical region, not a no-op."""
+        from src.mcp_handlers.dialectic.handlers import handle_submit_synthesis
+
+        session = self._make_synthesis_session()
+        sid = session.session_id
+
+        lock = await get_session_lock(sid)
+        await lock.acquire()
+        try:
+            with patch(f"{self.DIALECTIC}.mcp_server", self._mock_server()), \
+                 patch("src.mcp_handlers.shared.get_mcp_server", return_value=self._mock_server()), \
+                 patch(f"{self.DIALECTIC}.load_session", new_callable=AsyncMock,
+                       return_value=session), \
+                 patch(f"{self.DIALECTIC}.pg_add_message", new_callable=AsyncMock), \
+                 patch(f"{self.DIALECTIC}.pg_update_phase", new_callable=AsyncMock), \
+                 patch(f"{self.DIALECTIC}.save_session", new_callable=AsyncMock), \
+                 patch("src.mcp_handlers.context.get_context_agent_id", return_value=None):
+                handler_task = asyncio.create_task(handle_submit_synthesis({
+                    "session_id": sid,
+                    "agent_id": "agent-paused",
+                    "proposed_conditions": ["c1"],
+                    "reasoning": "ok",
+                    "agrees": False,
+                    "api_key": "key-a",
+                }))
+                # Give the handler time to reach the lock acquire and block.
+                # If the lock weren't held around the critical region, the
+                # handler would race to completion before this sleep returns.
+                await asyncio.sleep(0.2)
+                assert not handler_task.done(), (
+                    "handler must block on session_lock; if it completed, "
+                    "the lock is not actually around the critical region"
+                )
+        finally:
+            lock.release()
+
+        # Now the handler should be able to proceed and return.
+        result = await asyncio.wait_for(handler_task, timeout=5.0)
+        # We don't assert success/failure shape — only that it ran to completion
+        # once the contended lock was released.
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_concurrent_synthesis_does_not_double_resolve(self):
+        """Two concurrent submit_synthesis calls with agrees=True against the
+        same SYNTHESIS-phase session: only one converges. The other arrives
+        with the in-memory phase already RESOLVED and is rejected by
+        DialecticSession.submit_synthesis's phase check.
+        """
+        from src.mcp_handlers.dialectic.handlers import handle_submit_synthesis
+
+        session = self._make_synthesis_session()
+        sid = session.session_id
+
+        # Both handlers see the SAME in-memory session (this is the actual
+        # production behavior under ACTIVE_SESSIONS reuse). Without the lock,
+        # both load it concurrently in SYNTHESIS phase, both submit_synthesis
+        # paths would race on phase mutation. With the lock, the second
+        # handler enters serially and observes phase=RESOLVED.
+        with patch(f"{self.DIALECTIC}.mcp_server", self._mock_server()), \
+             patch("src.mcp_handlers.shared.get_mcp_server", return_value=self._mock_server()), \
+             patch(f"{self.DIALECTIC}.load_session", new_callable=AsyncMock,
+                   return_value=session), \
+             patch(f"{self.DIALECTIC}.pg_add_message", new_callable=AsyncMock), \
+             patch(f"{self.DIALECTIC}.pg_update_phase", new_callable=AsyncMock), \
+             patch(f"{self.DIALECTIC}.pg_resolve_session", new_callable=AsyncMock), \
+             patch(f"{self.DIALECTIC}.save_session", new_callable=AsyncMock), \
+             patch(f"{self.DIALECTIC}.execute_resolution", new_callable=AsyncMock,
+                   return_value={"success": True, "agent_id": "agent-paused", "new_status": "active"}), \
+             patch("src.mcp_handlers.context.get_context_agent_id", return_value=None):
+            results = await asyncio.gather(
+                handle_submit_synthesis({
+                    "session_id": sid,
+                    "agent_id": "agent-paused",
+                    "proposed_conditions": ["agreed condition"],
+                    "root_cause": "agreed cause",
+                    "reasoning": "agree",
+                    "agrees": True,
+                    "api_key": "key-a",
+                }),
+                handle_submit_synthesis({
+                    "session_id": sid,
+                    "agent_id": "agent-reviewer",
+                    "proposed_conditions": ["agreed condition"],
+                    "root_cause": "agreed cause",
+                    "reasoning": "agree",
+                    "agrees": True,
+                    "api_key": "key-b",
+                }),
+                return_exceptions=True,
+            )
+
+        assert session.phase == DialecticPhase.RESOLVED, (
+            "exactly one synthesis path must transition session to RESOLVED"
+        )
+        # The RESOLVED-rejecting branch returns success=False with a phase
+        # error. The converging branch returns success=True with converged=True.
+        # Parse both result envelopes and assert exactly one converged.
+        import json
+        successes = []
+        for r in results:
+            if isinstance(r, Exception):
+                continue
+            payload = r[0].text if hasattr(r[0], "text") else str(r[0])
+            try:
+                parsed = json.loads(payload)
+            except (ValueError, TypeError):
+                continue
+            if parsed.get("converged") is True:
+                successes.append(parsed)
+
+        assert len(successes) == 1, (
+            f"exactly one synthesis must converge under contention, got "
+            f"{len(successes)} successes; results={results}"
+        )


### PR DESCRIPTION
## Summary

Council 2026-05-06 NEW-1: \`handle_submit_synthesis\` loaded → mutated → wrote without a row-level lock. Two concurrent \`submit_synthesis\` calls with \`agrees=True\` from the two participants could both pass the SYNTHESIS-phase check on their own in-memory copies, both call \`finalize_resolution\`, and the second \`pg_resolve_session\` overwrite the first.

Fix: per-session \`asyncio.Lock\` acquired around the load-mutate-persist critical region in \`handle_submit_synthesis\`. The lock dict is itself guarded by an \`asyncio.Lock\` so lazy creation is atomic under concurrent first-acquires.

## Why in-process Lock instead of postgres-level

CLAUDE.md "Substrate Tax: anyio-asyncio Coupling" documents that new \`asyncpg\` awaits in MCP handler hot paths are accreted workarounds, not progress (60× amplification on KG calls in some configurations). Adding a \`pg_advisory_lock\` or \`SELECT FOR UPDATE\` would add an asyncpg await on every synthesis call.

In-process \`asyncio.Lock\` is sufficient given single-process MCP deployment. If/when multi-process lands, this gets replaced by a postgres-level lock — track that decision via \`beam-footprint-roadmap-v0.md\`, not by accreting more in-process state.

## Path-A context

PR3 of the dialectic stabilization sequence:

1. PR1 (#400) — wire \`outcome_event\` on resolution
2. PR2a (#402) — remove \`appointed_mediator_id\` ghost
3. PR2b (#406) — retire ESCALATED + quorum_voting (-1075 LOC)
4. **PR3 (this PR)** — TOCTOU lock
5. PR4 (next) — bilateral attestation fix (NEW-2)

## What changes

\`session.py\`:
- New \`_SESSION_LOCKS: Dict[str, asyncio.Lock]\` keyed by session_id
- New \`_SESSION_LOCKS_DICT_LOCK: asyncio.Lock\` guarding the dict for atomic lazy create
- New \`get_session_lock(session_id) -> asyncio.Lock\` helper

\`handlers.py\`:
- Imports \`get_session_lock\`
- Wraps the synthesis handler's load-mutate-persist critical region in \`async with session_lock:\` (the indentation diff is mechanical — review with \`git diff -w\` for clarity)

\`tests/test_dialectic_toctou.py\` (new):
- \`TestSessionLockIdentity\`: same session_id → same Lock instance; different session_ids → distinct Locks; concurrent first-acquire is atomic
- \`TestSynthesisHandlerSerializesPhaseTransition::test_handler_blocks_when_session_lock_held_externally\` — proves the lock is actually around the critical region (handler blocks when lock is externally held)
- \`TestSynthesisHandlerSerializesPhaseTransition::test_concurrent_synthesis_does_not_double_resolve\` — the actual race scenario: \`asyncio.gather\` of two synthesis calls with \`agrees=True\` against the same session converges exactly once

## Test plan

- [x] New file: 5 tests, all passing
- [x] Full dialectic + calibration suite: 457 passed, 5 skipped (AGE)
- [x] Full pytest gate: 8563 passed, 34 skipped (AGE), 15 deselected
- [ ] **Pre-existing failure unrelated to this PR**: \`tests/test_postgres_backend_integration.py::TestKnowledgeGraphOperations\` (15 tests) fails on master with \`AttributeError: 'types.SimpleNamespace' object has no attribute 'provenance_chain'\`. The mock SimpleNamespace in the test file is missing that attribute. None of my changes touch \`src/db/mixins/knowledge_graph.py\` or \`tests/test_postgres_backend_integration.py\`. Deselected for this gate.

## Future-work hooks

- Same lock pattern could apply to \`handle_submit_thesis\`, \`handle_submit_antithesis\`, \`handle_reassign_reviewer\` — same TOCTOU shape but lower blast radius (those don't trigger \`finalize_resolution\`). Deferred unless evidence of actual races there.
- Lock pruning: locks accumulate one entry per session_id ever seen. Sessions terminate, traffic doesn't grow indefinitely; if memory becomes a concern, prune RESOLVED/FAILED entries on \`save_session\`. Comment in code documents this.