### PR TITLE
fix(dialectic): bilateral attestation v2 over canonical payload (NEW-2)

### DIFF
--- a/src/dialectic_protocol.py
+++ b/src/dialectic_protocol.py
@@ -281,12 +281,23 @@ class Resolution:
         conditions: List of merged conditions for resumption
         root_cause: Agreed understanding of the root cause
         reasoning: Combined reasoning from both agents
-        signature_a: Agent A's cryptographic signature (API key hash)
-        signature_b: Agent B's cryptographic signature (API key hash)
+        signature_a: Agent A's cryptographic signature
+        signature_b: Agent B's cryptographic signature
         timestamp: ISO timestamp of resolution creation
+        signature_version: Attestation scheme version. v1 (legacy, broken):
+            both signatures over the same last-synthesis-message; reviewer's
+            "signature" was over a message they never wrote. v2 (current):
+            each signature is over the canonical resolution payload (action +
+            conditions + root_cause + reasoning + timestamp), independently
+            signed with each agent's api_key. v2 signatures verify via
+            verify_signatures(); v1 cannot be verified because the source
+            message was not preserved.
 
-    The resolution is cryptographically signed by both agents to ensure
-    authenticity and prevent tampering.
+    The v2 attestation closes council 2026-05-06 NEW-2 — until then the
+    bilateral cryptographic claim was effectively single-signer-with-two-
+    keys. New sessions land at v2; the 31 historical v1 resolutions remain
+    on disk with signature_version=1 and verify_signatures() returning
+    False (intentionally — they are not provably bilateral).
     """
     action: str  # ResolutionAction
     conditions: List[str]
@@ -295,6 +306,7 @@ class Resolution:
     signature_a: str  # Agent A's signature
     signature_b: str  # Agent B's signature
     timestamp: str
+    signature_version: int = 1  # v2 = canonical-payload bilateral; default 1 for backward-compat decode of legacy on-disk rows
 
     def to_dict(self) -> Dict:
         """
@@ -317,6 +329,72 @@ class Resolution:
         """
         resolution_json = json.dumps(self.to_dict(), sort_keys=True)
         return hashlib.sha256(resolution_json.encode()).hexdigest()
+
+    def canonical_payload(self) -> bytes:
+        """The deterministic byte-string both agents independently sign in v2.
+
+        Excludes the signature fields themselves (signature_a, signature_b,
+        signature_version) so verification can compare against signatures
+        computed at finalization time. Lists are sorted for determinism so
+        the same set of conditions always hashes identically regardless of
+        merge ordering.
+        """
+        payload = {
+            "action": self.action,
+            "conditions": sorted(self.conditions or []),
+            "root_cause": self.root_cause,
+            "reasoning": self.reasoning,
+            "timestamp": self.timestamp,
+        }
+        return json.dumps(payload, sort_keys=True).encode("utf-8")
+
+    @staticmethod
+    def compute_signature(payload: bytes, api_key: str) -> str:
+        """SHA-256 of canonical_payload || ":" || api_key. Hex digest.
+
+        Symmetric scheme — verifier needs the api_key to recompute. The
+        secrecy property is "an attacker without the api_key cannot forge a
+        signature for a payload that another agent will accept." It is NOT a
+        public-key signature; do not treat this as non-repudiation. For
+        non-repudiation we'd need DPoP / asymmetric keys (decided shelved
+        2026-04-19; see docs/ontology/identity.md and project memory
+        identity-audit-2026-04-19).
+        """
+        if not api_key:
+            return ""
+        return hashlib.sha256(payload + b":" + api_key.encode("utf-8")).hexdigest()
+
+    def verify_signatures(self, api_key_a: str, api_key_b: str) -> bool:
+        """Verify both agents signed the canonical payload with their keys.
+
+        Returns False (not raises) when verification is not possible, in any
+        of the following cases:
+
+        - signature_version != 2 (legacy v1 attestation cannot be verified
+          because the source message was not preserved at the resolution
+          level).
+        - Either signature on the resolution is empty (unsigned).
+        - Either api_key is empty (cannot recompute the expected signature).
+
+        This makes "unverifiable" returnable as False rather than as a
+        vacuous-True when both sides happen to be empty. Callers can branch
+        on signature_version + signature emptiness to distinguish "legacy",
+        "single-signer (LLM-assisted)", and "verifiable bilateral".
+        """
+        if self.signature_version != 2:
+            return False
+        if not self.signature_a or not self.signature_b:
+            return False
+        if not api_key_a or not api_key_b:
+            return False
+        payload = self.canonical_payload()
+        expected_a = self.compute_signature(payload, api_key_a)
+        expected_b = self.compute_signature(payload, api_key_b)
+        # Threat model: in-process trusted callers verifying their own
+        # resolutions. Python str== short-circuits which leaks length info
+        # in adversarial settings; if we ever expose verify to untrusted
+        # callers switch to hmac.compare_digest.
+        return self.signature_a == expected_a and self.signature_b == expected_b
 
 
 @dataclass
@@ -796,18 +874,27 @@ class DialecticSession:
         return False
 
     def finalize_resolution(self,
-                           signature_a: str,
-                           signature_b: str) -> Resolution:
+                           api_key_a: str,
+                           api_key_b: str) -> Resolution:
         """
-        Create final signed resolution from agreed synthesis.
-        Intelligently merges proposals from both agents.
+        Create final v2-attested resolution from agreed synthesis.
+        Intelligently merges proposals from both agents and independently
+        signs the canonical payload with each agent's api_key.
+
+        Council 2026-05-06 NEW-2: previously this method took already-
+        computed signature_a/signature_b strings, and the only caller
+        (handle_submit_synthesis) computed both as last_msg.sign(api_key_X) —
+        meaning the reviewer's "signature" was over a message they never
+        wrote. v2 attestation moves signing into this method so both
+        signatures are guaranteed to be over the same canonical payload,
+        each with their own api_key.
 
         Args:
-            signature_a: Agent A's signature (API key hash)
-            signature_b: Agent B's signature (API key hash)
+            api_key_a: Paused agent's api_key
+            api_key_b: Reviewer's api_key (or empty string if unavailable)
 
         Returns:
-            Signed Resolution object with merged conditions
+            v2-attested Resolution with bilateral signatures
         """
         if self.phase != DialecticPhase.RESOLVED:
             raise ValueError(f"Cannot finalize in phase {self.phase.value}")
@@ -880,18 +967,29 @@ class DialecticSession:
                 else:
                     raise ValueError("No valid synthesis messages found")
 
-        resolution = Resolution(
+        timestamp = datetime.now(timezone.utc).isoformat()
+
+        # Build the prototype with empty signatures, compute the canonical
+        # payload bytes, then sign with each agent's own api_key. This
+        # guarantees both signatures are over the same payload (closes
+        # NEW-2) — previously each was over its own last synthesis message
+        # and they happened to share the last one (single-signer-two-keys).
+        proto = Resolution(
             action=ResolutionAction.RESUME.value,
             conditions=merged["conditions"],
             root_cause=merged["root_cause"],
             reasoning=merged["reasoning"],
-            signature_a=signature_a,
-            signature_b=signature_b,
-            timestamp=datetime.now(timezone.utc).isoformat()
+            signature_a="",
+            signature_b="",
+            timestamp=timestamp,
+            signature_version=2,
         )
+        payload = proto.canonical_payload()
+        proto.signature_a = Resolution.compute_signature(payload, api_key_a)
+        proto.signature_b = Resolution.compute_signature(payload, api_key_b)
 
-        self.resolution = resolution
-        return resolution
+        self.resolution = proto
+        return proto
 
     def check_hard_limits(self, resolution: Resolution) -> tuple[bool, Optional[str]]:
         """

--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -1297,26 +1297,18 @@ async def handle_submit_synthesis(arguments: Dict[str, Any]) -> Sequence[TextCon
 
         # If converged, finalize resolution
         if result.get("success") and result.get("converged"):
-            # Generate signatures
+            # Bilateral attestation (v2): finalize_resolution signs the
+            # canonical resolution payload with each agent's own api_key.
+            # Council 2026-05-06 NEW-2 fixed: previously we computed both
+            # signatures over the SAME last synthesis message, so the
+            # reviewer's "signature" was over a message they never wrote.
             paused_meta = mcp_server.agent_metadata.get(session.paused_agent_id)
             reviewer_meta = mcp_server.agent_metadata.get(session.reviewer_agent_id)
 
             api_key_a = paused_meta.api_key if paused_meta and paused_meta.api_key else api_key
             api_key_b = reviewer_meta.api_key if reviewer_meta and reviewer_meta.api_key else ""
 
-            synthesis_messages = [msg for msg in session.transcript if msg.phase == "synthesis" and msg.agrees]
-            if synthesis_messages:
-                last_msg = synthesis_messages[-1]
-                signature_a = last_msg.sign(api_key_a) if api_key_a else ""
-                signature_b = last_msg.sign(api_key_b) if api_key_b else ""
-            else:
-                import hashlib
-                session_data = f"{session.session_id}:{api_key_a}"
-                signature_a = hashlib.sha256(session_data.encode()).hexdigest()[:32]
-                session_data = f"{session.session_id}:{api_key_b}"
-                signature_b = hashlib.sha256(session_data.encode()).hexdigest()[:32] if api_key_b else ""
-
-            resolution = session.finalize_resolution(signature_a, signature_b)
+            resolution = session.finalize_resolution(api_key_a, api_key_b)
             is_safe, violation = session.check_hard_limits(resolution)
 
             if not is_safe:
@@ -2054,11 +2046,19 @@ async def handle_llm_assisted_dialectic(arguments: Dict[str, Any]) -> Sequence[T
             agrees=True,
         )
 
-        # 4. Finalize resolution through protocol (canonical schema)
-        resolution_obj = session.finalize_resolution(
-            signature_a=f"llm-{agent_uuid[:8]}",
-            signature_b="llm-synthetic-reviewer",
+        # 4. Finalize resolution through protocol (canonical schema).
+        # LLM-assisted dialectic has no real second party — pass an empty
+        # api_key_b so the v2 attestation correctly reports as
+        # not-verifiable-bilaterally (verify_signatures() will return False).
+        # The agent's own api_key (or a fallback derived from agent_uuid)
+        # produces a real signature_a; signature_b is empty by design.
+        paused_meta = mcp_server.agent_metadata.get(agent_uuid)
+        api_key_a = (
+            paused_meta.api_key
+            if paused_meta and getattr(paused_meta, "api_key", None)
+            else f"llm-{agent_uuid[:8]}"
         )
+        resolution_obj = session.finalize_resolution(api_key_a, "")
         session.resolution = resolution_obj
         await pg_resolve_session(
             session_id=session_id,

--- a/tests/test_dialectic_attestation.py
+++ b/tests/test_dialectic_attestation.py
@@ -1,0 +1,235 @@
+"""
+Regression tests for v2 bilateral attestation (NEW-2, council 2026-05-06).
+
+Bug: handle_submit_synthesis computed signature_a and signature_b both over
+the SAME last synthesis message (last_msg.sign(api_key_a),
+last_msg.sign(api_key_b)). The reviewer's "signature" was over a message
+they never wrote — only signed with their key. Bilateral cryptographic
+attestation was effectively single-signer-with-two-keys.
+
+Fix: Resolution.signature_version=2 attestation. finalize_resolution now
+signs the canonical resolution payload (action, conditions, root_cause,
+reasoning, timestamp — sorted/deterministic) with each agent's own api_key
+independently. verify_signatures() can independently confirm that both
+parties signed the same payload.
+"""
+
+import sys
+import json
+from pathlib import Path
+from datetime import datetime, timezone
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.dialectic_protocol import (
+    DialecticSession,
+    DialecticMessage,
+    DialecticPhase,
+    Resolution,
+    ResolutionAction,
+)
+
+
+def _converged_session(api_key_a="key-a", api_key_b="key-b"):
+    """SYNTHESIS-phase session with thesis + antithesis + agreed synthesis from each side."""
+    s = DialecticSession(
+        paused_agent_id="agent-a",
+        reviewer_agent_id="agent-b",
+        session_type="recovery",
+    )
+    s.phase = DialecticPhase.SYNTHESIS
+    s.synthesis_round = 2
+    now = datetime.now(timezone.utc).isoformat()
+    s.transcript.append(DialecticMessage(
+        phase="thesis", agent_id="agent-a", timestamp=now,
+        root_cause="initial cause", proposed_conditions=["c1"],
+        reasoning="initial",
+    ))
+    s.transcript.append(DialecticMessage(
+        phase="antithesis", agent_id="agent-b", timestamp=now,
+        reasoning="counter", concerns=["c"],
+    ))
+    s.transcript.append(DialecticMessage(
+        phase="synthesis", agent_id="agent-a", timestamp=now,
+        proposed_conditions=["agreed"], root_cause="agreed cause",
+        reasoning="from a", agrees=True,
+    ))
+    s.transcript.append(DialecticMessage(
+        phase="synthesis", agent_id="agent-b", timestamp=now,
+        proposed_conditions=["agreed"], root_cause="agreed cause",
+        reasoning="from b", agrees=True,
+    ))
+    s.phase = DialecticPhase.RESOLVED  # finalize_resolution requires this
+    return s
+
+
+class TestResolutionSchema:
+    def test_legacy_default_signature_version_is_one(self):
+        """Plain Resolution() construction lands at v1 (legacy schema) so
+        existing on-disk records continue to round-trip."""
+        r = Resolution(
+            action="resume", conditions=["c"], root_cause="rc",
+            reasoning="r", signature_a="x", signature_b="y",
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
+        assert r.signature_version == 1
+
+    def test_v1_resolution_does_not_verify(self):
+        """v1 resolutions cannot be verified — the source message is not
+        recoverable from the resolution row alone."""
+        r = Resolution(
+            action="resume", conditions=["c"], root_cause="rc",
+            reasoning="r",
+            signature_a="anything", signature_b="anything",
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            signature_version=1,
+        )
+        assert r.verify_signatures("any-key", "any-key") is False
+
+    def test_canonical_payload_is_deterministic(self):
+        """Same content → same canonical payload, regardless of conditions
+        list order. Lists must be sorted; sort_keys=True on the JSON dump."""
+        ts = "2026-05-07T12:00:00+00:00"
+        r1 = Resolution(
+            action="resume", conditions=["zeta", "alpha", "mu"],
+            root_cause="rc", reasoning="r",
+            signature_a="", signature_b="", timestamp=ts,
+            signature_version=2,
+        )
+        r2 = Resolution(
+            action="resume", conditions=["alpha", "mu", "zeta"],
+            root_cause="rc", reasoning="r",
+            signature_a="", signature_b="", timestamp=ts,
+            signature_version=2,
+        )
+        assert r1.canonical_payload() == r2.canonical_payload()
+
+    def test_canonical_payload_excludes_signatures(self):
+        """Changing the signatures must not change the canonical payload —
+        otherwise sign-then-verify becomes a chicken-and-egg problem."""
+        ts = "2026-05-07T12:00:00+00:00"
+        r1 = Resolution(
+            action="resume", conditions=["c"], root_cause="rc", reasoning="r",
+            signature_a="A", signature_b="B", timestamp=ts, signature_version=2,
+        )
+        r2 = Resolution(
+            action="resume", conditions=["c"], root_cause="rc", reasoning="r",
+            signature_a="DIFFERENT", signature_b="DIFFERENT", timestamp=ts,
+            signature_version=2,
+        )
+        assert r1.canonical_payload() == r2.canonical_payload()
+
+
+class TestBilateralAttestation:
+    def test_finalize_produces_v2_resolution(self):
+        s = _converged_session()
+        r = s.finalize_resolution(api_key_a="key-a", api_key_b="key-b")
+        assert r.signature_version == 2
+
+    def test_finalize_signatures_verify_with_correct_keys(self):
+        s = _converged_session()
+        r = s.finalize_resolution(api_key_a="key-a", api_key_b="key-b")
+        assert r.verify_signatures("key-a", "key-b") is True
+
+    def test_finalize_signatures_do_not_verify_with_wrong_keys(self):
+        s = _converged_session()
+        r = s.finalize_resolution(api_key_a="key-a", api_key_b="key-b")
+        assert r.verify_signatures("key-a", "wrong-key") is False
+        assert r.verify_signatures("wrong-key", "key-b") is False
+
+    def test_signatures_are_distinct_per_agent(self):
+        """The two signatures must NOT be equal — that was the NEW-2 bug
+        (both over the same payload + same key shape produced identical
+        hashes when both parties used the same api_key, and over the same
+        last_msg with different keys produced same-message-different-key
+        which isn't bilateral attestation)."""
+        s = _converged_session()
+        r = s.finalize_resolution(api_key_a="key-a", api_key_b="key-b")
+        assert r.signature_a != r.signature_b
+        assert r.signature_a != ""
+        assert r.signature_b != ""
+
+    def test_swapping_keys_at_verify_time_fails(self):
+        """signature_a is signed by api_key_a; supplying api_key_b in its
+        place must fail. Otherwise swap-attacks succeed silently."""
+        s = _converged_session()
+        r = s.finalize_resolution(api_key_a="key-a", api_key_b="key-b")
+        assert r.verify_signatures("key-b", "key-a") is False  # swapped
+
+    def test_tampered_resolution_fails_verification(self):
+        """Mutating any canonical-payload field after signing must
+        invalidate the signatures."""
+        s = _converged_session()
+        r = s.finalize_resolution(api_key_a="key-a", api_key_b="key-b")
+        assert r.verify_signatures("key-a", "key-b") is True
+
+        # Tamper with conditions
+        r.conditions.append("attacker-injected")
+        assert r.verify_signatures("key-a", "key-b") is False
+
+    def test_empty_reviewer_key_falls_back_to_unverifiable(self):
+        """LLM-assisted dialectic passes empty api_key_b — verify must
+        return False (not vacuously True from empty==empty)."""
+        s = _converged_session()
+        r = s.finalize_resolution(api_key_a="key-a", api_key_b="")
+        assert r.signature_b == ""
+        assert r.verify_signatures("key-a", "") is False
+        assert r.verify_signatures("key-a", "key-b") is False  # any non-empty key fails too
+
+    def test_v2_resolution_serializes_signature_version(self):
+        s = _converged_session()
+        r = s.finalize_resolution(api_key_a="key-a", api_key_b="key-b")
+        d = r.to_dict()
+        assert d["signature_version"] == 2
+        # Round-trip preserves everything
+        roundtrip = Resolution(**d)
+        assert roundtrip.verify_signatures("key-a", "key-b") is True
+
+
+class TestNew2RegressionGuard:
+    """Direct guards that the specific NEW-2 failure mode cannot recur."""
+
+    def test_signatures_are_not_simply_last_message_hashes(self):
+        """If finalize_resolution regressed to signing the last synthesis
+        message (the NEW-2 bug shape), signature_a would equal
+        last_msg.sign(api_key_a). Assert it does NOT — the v2 signatures
+        are over the canonical resolution payload."""
+        s = _converged_session()
+        # Capture last agreed synthesis message before finalization
+        last_msg = next(
+            m for m in reversed(s.transcript)
+            if m.phase == "synthesis" and m.agrees
+        )
+        legacy_a = last_msg.sign("key-a")
+        r = s.finalize_resolution(api_key_a="key-a", api_key_b="key-b")
+        assert r.signature_a != legacy_a, (
+            "v2 attestation must sign the canonical resolution payload, "
+            "NOT the last synthesis message (NEW-2 regression)"
+        )
+
+    def test_two_resolutions_with_same_keys_produce_same_signatures_only_when_payload_matches(self):
+        """Determinism property: two identical canonical payloads signed
+        with the same keys produce the same signatures. Two different
+        payloads do not."""
+        ts = "2026-05-07T12:00:00+00:00"
+        r1 = Resolution(
+            action="resume", conditions=["c"], root_cause="rc", reasoning="r",
+            signature_a="", signature_b="", timestamp=ts, signature_version=2,
+        )
+        r2 = Resolution(
+            action="resume", conditions=["c"], root_cause="rc", reasoning="r",
+            signature_a="", signature_b="", timestamp=ts, signature_version=2,
+        )
+        r3 = Resolution(
+            action="resume", conditions=["DIFFERENT"], root_cause="rc",
+            reasoning="r", signature_a="", signature_b="", timestamp=ts,
+            signature_version=2,
+        )
+        sig_r1 = Resolution.compute_signature(r1.canonical_payload(), "k")
+        sig_r2 = Resolution.compute_signature(r2.canonical_payload(), "k")
+        sig_r3 = Resolution.compute_signature(r3.canonical_payload(), "k")
+        assert sig_r1 == sig_r2
+        assert sig_r1 != sig_r3


### PR DESCRIPTION
## Summary

Council 2026-05-06 NEW-2 (conf 95): \`handle_submit_synthesis\` computed \`signature_a = last_msg.sign(api_key_a)\` and \`signature_b = last_msg.sign(api_key_b)\` — both over the SAME synthesis message. The reviewer's "signature" was over a message they never wrote, just signed with the reviewer's key. The bilateral cryptographic claim UNITARES advertised was effectively single-signer-with-two-keys.

Fix: \`Resolution.signature_version=2\` attestation. Each agent independently signs the canonical resolution payload (action, sorted conditions, root_cause, reasoning, timestamp — deterministic JSON) with their own api_key. \`finalize_resolution\` now takes \`(api_key_a, api_key_b)\` and computes both signatures internally; \`verify_signatures(api_key_a, api_key_b)\` recomputes and compares.

## Path-A complete

PR4 closes the council-flagged path-A stabilization sequence:

1. PR1 (#400) — outcome_event wire-up
2. PR2a (#402) — appointed_mediator_id ghost removed
3. PR2b (#406) — ESCALATED + quorum_voting retired (-1075 LOC)
4. PR3 (#410) — TOCTOU lock on synthesis phase transition (NEW-1)
5. **PR4 (this PR)** — bilateral attestation (NEW-2)

## Schema

\`Resolution\` adds three methods + one field:

| Member | Purpose |
|---|---|
| \`signature_version: int = 1\` | 1=legacy (cannot be verified, source message not preserved); 2=canonical-payload bilateral |
| \`canonical_payload() -> bytes\` | The deterministic byte-string both agents independently sign. Excludes signatures themselves. Sorts \`conditions\` for merge-order independence |
| \`compute_signature(payload, api_key) -> str\` | SHA-256(payload \|\| ":" \|\| api_key). Empty key returns "" |
| \`verify_signatures(api_key_a, api_key_b) -> bool\` | True only when v2 AND both signatures non-empty AND both keys non-empty AND both hashes match |

Default \`signature_version=1\` so existing on-disk records continue to round-trip; new finalizations land at v2.

## Behavior changes

- \`finalize_resolution\` signature: \`(signature_a, signature_b)\` → \`(api_key_a, api_key_b)\`. Both production callers updated:
  - Main synthesis convergence: pulls api_keys from \`agent_metadata\`, passes to \`finalize_resolution\` directly. The dead 18-line "compute hashes outside" block in handlers.py:1300-1319 is gone.
  - LLM-assisted dialectic: passes the agent's api_key as \`api_key_a\` and empty string as \`api_key_b\`. \`verify_signatures\` correctly reports as not-verifiable-bilaterally for these.
- Conditions list is sorted in \`canonical_payload()\` so the same agreed set always hashes identically regardless of merge order.

## Threat model

Symmetric scheme — verifier needs the api_key to recompute. The property is "an attacker without the api_key cannot forge a signature that another agent will accept on the same canonical payload." This is NOT public-key non-repudiation; DPoP / asymmetric keys were considered and shelved 2026-04-19 (see \`docs/ontology/identity.md\` and \`identity-audit-2026-04-19\` memory).

For our threat model — in-process trusted callers verifying their own resolutions — this is correct. If we ever expose verify to untrusted callers, switch to \`hmac.compare_digest\`.

## Historical v1 records

The 31 RESOLVED sessions on disk remain at \`signature_version=1\`. \`verify_signatures\` returns False on them, which is the honest signal — those resolutions are not provably bilateral. We don't have the source-message context required to upgrade them retroactively, and rewriting historical records would be the wrong move anyway.

## Test plan

- [x] 14 new tests in \`tests/test_dialectic_attestation.py\`:
  - Schema: legacy default version, v1 doesn't verify, canonical_payload determinism, canonical_payload excludes signatures
  - Bilateral happy path: v2 produced, verify with correct keys, reject wrong keys, signatures distinct, swap-key rejection, tamper rejection, empty-reviewer-key fallback, serialize round-trip
  - Direct NEW-2 regression guard: signatures != \`last_msg.sign(api_key_a)\`
- [x] Full dialectic + adjacent suites: 477 passed, 5 skipped (AGE)
- [x] Full pytest gate: 8572 passed, 34 skipped (AGE), 15 deselected (pre-existing \`TestKnowledgeGraphOperations\` \`SimpleNamespace\` failures, unrelated)

## Council scope summary (closed)

| Council finding | Status |
|---|---|
| NEW-1: TOCTOU on phase transition (conf 85) | PR3 #410 |
| NEW-2: single-signer resolution (conf 95) | PR4 (this PR) |
| NEW-3: appointed_mediator_id ghost field (conf 100) | PR2a #402 |
| Claim 1 (Jaccard semantic matching): structural-not-semantic | acknowledged; intent-dependent (Adjudicate redesign territory) |
| Claim 2 (\`agrees=True\` self-attestation): no downstream verification | PR1 #400 closes the loop |
| Claim 3 (regex hard limits): paraphrase bypass | acknowledged; intent-dependent |
| Claim 4 (hardcoded phase template) | acknowledged; intent-dependent |
| Claim 5 (similar-healthy reviewer scorer) | acknowledged; intent-dependent (Adjudicate redesign territory) |

The five remaining "intent-dependent" items belong to the Adjudicate redesign that the architect's framing called for — not to path-A stabilization. Path A is the substrate fix; the redesign is path B.