### PR TITLE
feat(wave-2): add protocol_version field to lease-plane responses (Phase A)

### DIFF
--- a/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
@@ -51,16 +51,11 @@ defmodule UnitaresLeasePlane.HTTPRouter do
       "lease plane HTTP error: kind=#{kind} reason=#{Exception.format_banner(kind, reason)}"
     )
 
-    body =
-      Jason.encode!(%{
-        ok: false,
-        error: "service_unavailable",
-        reason: "internal error"
-      })
-
-    conn
-    |> Plug.Conn.put_resp_content_type("application/json")
-    |> Plug.Conn.send_resp(503, body)
+    json(conn, 503, %{
+      ok: false,
+      error: "service_unavailable",
+      reason: "internal error"
+    })
   end
 
   # ---------- /v1/lease/acquire ----------
@@ -533,9 +528,30 @@ defmodule UnitaresLeasePlane.HTTPRouter do
   defp iso(nil), do: nil
   defp iso(%DateTime{} = dt), do: DateTime.to_iso8601(dt)
 
+  # Wave 2 §"Lease-integration boundary hardening" — versioned contracts.
+  # Every response from this router carries a `protocol_version` field so
+  # clients can detect server/client shape skew without having to enumerate
+  # every endpoint. Bump when response shapes change in a way that requires
+  # a coordinated client/server deploy. The Python client
+  # (src/lease_plane/client.py) keeps its own constant and logs a WARNING
+  # on mismatch (does NOT fail) during the rollout grace window — see
+  # `tests/test_lease_plane_protocol_version.py`. URL versioning (/v1/lease/*)
+  # remains the major-version axis; `protocol_version` is the finer-grained
+  # shape-version axis within /v1.
+  @protocol_version "v1.0"
+
+  @doc """
+  Boundary protocol version. Public so tests on the Elixir side can pin
+  the constant; Python-side callers don't reach this directly — they
+  receive it in every response body as the `protocol_version` field.
+  """
+  @spec protocol_version() :: String.t()
+  def protocol_version, do: @protocol_version
+
   defp json(conn, status, body) do
+    versioned_body = Map.put(body, :protocol_version, @protocol_version)
     conn
     |> Plug.Conn.put_resp_content_type("application/json")
-    |> Plug.Conn.send_resp(status, Jason.encode!(body))
+    |> Plug.Conn.send_resp(status, Jason.encode!(versioned_body))
   end
 end

--- a/elixir/lease_plane/test/http_router_test.exs
+++ b/elixir/lease_plane/test/http_router_test.exs
@@ -368,7 +368,7 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
       Process.sleep(1100)
       renew = post_json("/v1/lease/renew", %{lease_id: lease_id})
       assert renew.status == 200
-      assert parsed(renew) == %{"ok" => true}
+      assert Map.delete(parsed(renew), "protocol_version") == %{"ok" => true}
 
       status =
         :get
@@ -401,7 +401,7 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
 
       resp = post_json("/v1/lease/release", %{lease_id: lease_id, release_reason: "normal"})
       assert resp.status == 200
-      assert parsed(resp) == %{"ok" => true}
+      assert Map.delete(parsed(resp), "protocol_version") == %{"ok" => true}
 
       # Subsequent status returns nil — released
       status =
@@ -452,7 +452,7 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
       handoff_id = parsed(offer)["handoff_id"]
       accept = post_json("/v1/lease/handoff/accept", %{handoff_id: handoff_id})
       assert accept.status == 200
-      assert parsed(accept) == %{"ok" => true}
+      assert Map.delete(parsed(accept), "protocol_version") == %{"ok" => true}
 
       status =
         :get
@@ -545,11 +545,12 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
       assert result.status == 503
       body = Jason.decode!(result.resp_body)
 
-      assert body == %{
+      assert Map.delete(body, "protocol_version") == %{
                "ok" => false,
                "error" => "service_unavailable",
                "reason" => "internal error"
              }
+      assert body["protocol_version"] == "v1.0"
 
       # Verify the leaky inspect string never made it to the wire.
       refute result.resp_body =~ "hunter2"

--- a/elixir/lease_plane/test/protocol_version_test.exs
+++ b/elixir/lease_plane/test/protocol_version_test.exs
@@ -1,0 +1,150 @@
+defmodule UnitaresLeasePlane.HTTPRouter.ProtocolVersionTest do
+  @moduledoc """
+  Wave 2 §"Lease-integration boundary hardening" — protocol_version contract.
+
+  Pins the server side of the protocol_version handshake added in this PR:
+  - `UnitaresLeasePlane.HTTPRouter.protocol_version/0` returns the literal
+    `"v1.0"` (the Python `tests/test_lease_plane_protocol_version.py` does
+    the same pin from the other side; bumping requires touching both).
+  - Every JSON response body — happy paths, typed-error paths, and the
+    Plug.ErrorHandler 503 fallback — carries a top-level `protocol_version`
+    field. Without that, a Python client running the v1.0 contract has no
+    way to detect that a server upgrade silently shifted shapes.
+
+  The /v1/lease/* major-version stays the URL versioning axis. The new
+  `protocol_version` is the finer-grained shape-version axis WITHIN /v1.
+  """
+
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  import LeaseTestHelpers
+
+  alias UnitaresLeasePlane.HTTPRouter
+
+  @opts HTTPRouter.init([])
+  @bearer "test-bearer-token-do-not-use-in-prod"
+
+  setup do
+    Application.put_env(:lease_plane, :bearer_token, @bearer)
+    surface = unique_surface_id("protover")
+    on_exit(fn -> cleanup_surface(surface) end)
+    {:ok, surface: surface}
+  end
+
+  defp authed(conn), do: put_req_header(conn, "authorization", "Bearer #{@bearer}")
+
+  defp post_json(path, body) do
+    :post
+    |> conn(path, Jason.encode!(body))
+    |> put_req_header("content-type", "application/json")
+    |> authed()
+    |> HTTPRouter.call(@opts)
+  end
+
+  defp parsed(conn), do: Jason.decode!(conn.resp_body)
+
+  test "protocol_version/0 returns the literal v1.0" do
+    # Drift guard: this string MUST match `PROTOCOL_VERSION` in
+    # src/lease_plane/__init__.py. Bumping requires touching both sides
+    # in the same PR. See the module @moduledoc.
+    assert HTTPRouter.protocol_version() == "v1.0"
+  end
+
+  test "200-class success response carries protocol_version", ctx do
+    body = %{
+      surface_id: ctx.surface,
+      surface_kind: "test",
+      holder_agent_uuid: random_uuid(),
+      holder_kind: "local_beam",
+      holder_class: "process_instance",
+      ttl_s: 30,
+      intent: "http test"
+    }
+
+    resp = post_json("/v1/lease/acquire", body)
+
+    assert resp.status == 200
+    assert parsed(resp)["protocol_version"] == HTTPRouter.protocol_version()
+  end
+
+  test "422 schema_invalid response carries protocol_version" do
+    # Missing surface_id → schema_invalid via the typed-error arm. The
+    # version field must ride along even on rejected requests so a Python
+    # client doing schema-shape validation doesn't see a shape change
+    # silently.
+    body = %{
+      surface_kind: "test",
+      holder_agent_uuid: random_uuid(),
+      holder_kind: "local_beam",
+      holder_class: "process_instance",
+      ttl_s: 30
+    }
+
+    resp = post_json("/v1/lease/acquire", body)
+
+    assert resp.status == 422
+    decoded = parsed(resp)
+    assert decoded["error"] == "schema_invalid"
+    assert decoded["protocol_version"] == HTTPRouter.protocol_version()
+  end
+
+  test "401 permission_denied response carries protocol_version", ctx do
+    # Auth-layer 401 is emitted by http_auth.ex, not the typed-error router
+    # arm. Pre-Wave-2 the auth response did not go through the json/3 helper
+    # — it built its body inline. If a future refactor adds protocol_version
+    # to the auth layer too, update this test to assert it. Today the auth
+    # 401 path SKIPS the router's json/3 helper (Plug.Conn.send_resp is
+    # called directly with a JSON-encoded literal body), so we only assert
+    # the JSON envelope shape — NOT protocol_version. The gap is documented
+    # for a follow-up; the contract Wave 2 §A wedge ships covers the typed
+    # response shapes.
+    resp =
+      :post
+      |> conn("/v1/lease/acquire", Jason.encode!(%{
+           surface_id: ctx.surface,
+           holder_agent_uuid: random_uuid(),
+           holder_kind: "local_beam",
+           holder_class: "process_instance",
+           ttl_s: 30
+         }))
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer wrong-token")
+      |> HTTPRouter.call(@opts)
+
+    assert resp.status == 401
+    # Documented gap: protocol_version is NOT yet emitted on auth-layer 401.
+    # Phase A of the boundary-hardening series ships the typed-error contract
+    # surfaces only.
+    decoded = parsed(resp)
+    refute Map.has_key?(decoded, "protocol_version")
+  end
+
+  test "happy path response shape is unchanged apart from the new field", ctx do
+    # Pin that the new field is additive — every previously-asserted field
+    # is still present in its pre-Wave-2 form. If this test fails, the
+    # protocol_version PR accidentally renamed/dropped a field that
+    # downstream Pydantic models on the Python side would silently lose.
+    body = %{
+      surface_id: ctx.surface,
+      surface_kind: "test",
+      holder_agent_uuid: random_uuid(),
+      holder_kind: "local_beam",
+      holder_class: "process_instance",
+      ttl_s: 30,
+      intent: "http test"
+    }
+
+    resp = post_json("/v1/lease/acquire", body)
+    decoded = parsed(resp)
+
+    # Pre-existing fields all still here.
+    assert decoded["ok"] == true
+    assert is_map(decoded["lease"])
+    assert is_boolean(decoded["idempotent"])
+    assert is_list(decoded["drift_warning"])
+    # New field is the literal Wave 2 contract.
+    assert decoded["protocol_version"] == "v1.0"
+  end
+end

--- a/src/lease_plane/__init__.py
+++ b/src/lease_plane/__init__.py
@@ -4,6 +4,18 @@ The Elixir/OTP node owns live coordination, but Python callers use this
 package as the stable boundary. Raw HTTP calls should stay behind this module.
 """
 
+# Wave 2 §"Lease-integration boundary hardening" — versioned contracts.
+# Bumped when the lease-plane response shapes change in a way that requires
+# a coordinated client/server deploy. Mirrored on the Elixir side at
+# `elixir/lease_plane/lib/unitares_lease_plane/http_router.ex` —
+# `@protocol_version`. Kept in sync by:
+#   - `tests/test_lease_plane_protocol_version.py` on the Python side
+#   - `test/unitares_lease_plane/http_router_protocol_version_test.exs` on the
+#     Elixir side (each pinning the literal "v1.0")
+# Mismatch behavior: Python client logs WARNING, does NOT fail (rollout
+# grace). See `LeasePlaneClient._request_json`.
+PROTOCOL_VERSION = "v1.0"
+
 from .client import LeasePlaneClient, LeasePlaneClientConfig, LeasePlaneDisabledClient
 from .models import (
     AcquireHeldByOther,
@@ -32,6 +44,7 @@ from .models import (
 )
 
 __all__ = [
+    "PROTOCOL_VERSION",
     "AcquireHeldByOther",
     "AcquireOk",
     "AcquirePermissionDenied",

--- a/src/lease_plane/client.py
+++ b/src/lease_plane/client.py
@@ -8,6 +8,7 @@ handler paths that would block the anyio task group.
 from __future__ import annotations
 
 import json
+import logging
 import random
 import time
 import urllib.error
@@ -18,6 +19,8 @@ from dataclasses import dataclass
 from typing import Any
 
 from pydantic import ValidationError
+
+logger = logging.getLogger(__name__)
 
 from .models import (
     AcquireHeldByOther,
@@ -274,6 +277,7 @@ class LeasePlaneClient:
             return {"ok": False, "error": "service_unavailable"}
         if not isinstance(payload, Mapping):
             return {"ok": False, "error": "schema_invalid", "detail": "response was not an object"}
+        _check_protocol_version(payload, path)
         return payload
 
 
@@ -282,6 +286,57 @@ class LeasePlaneDisabledClient(LeasePlaneClient):
 
     def __init__(self) -> None:
         super().__init__(transport=lambda _: {"ok": False, "error": "service_unavailable"})
+
+
+# Wave 2 §"Lease-integration boundary hardening" — versioned contracts.
+# Module-level dedup state so a steady mismatch (post-deploy of one side
+# only) doesn't spam the log every call. The (path, server_version) key is
+# small enough to bound — `path` is a closed set of route templates and
+# `server_version` is whatever the BEAM is reporting today.
+_logged_protocol_mismatches: set[tuple[str, str]] = set()
+_logged_protocol_absences: bool = False
+
+
+def _check_protocol_version(payload: Mapping[str, Any], path: str) -> None:
+    """Compare the server's reported protocol_version to PROTOCOL_VERSION.
+
+    Failure-safe: never raises, never alters the payload. On mismatch logs
+    a single WARNING per (path, server_version) pair so a stuck mismatch
+    is loud once but quiet thereafter. On absence (older BEAM that hasn't
+    deployed the field yet) logs ONE info-level breadcrumb per process —
+    the rollout grace window where some routes are versioned and others
+    aren't is expected and shouldn't generate noise.
+    """
+    # Local import keeps tests free to monkeypatch the module-level constant.
+    from src.lease_plane import PROTOCOL_VERSION
+
+    server_version = payload.get("protocol_version")
+    if server_version is None:
+        global _logged_protocol_absences
+        if not _logged_protocol_absences:
+            logger.debug(
+                "[lease-plane] response %s has no protocol_version field — "
+                "Wave 2 rollout grace; client expecting %r once both sides "
+                "have deployed the boundary version",
+                path,
+                PROTOCOL_VERSION,
+            )
+            _logged_protocol_absences = True
+        return
+    if server_version == PROTOCOL_VERSION:
+        return
+    key = (path, str(server_version))
+    if key in _logged_protocol_mismatches:
+        return
+    _logged_protocol_mismatches.add(key)
+    logger.warning(
+        "[lease-plane] protocol_version mismatch on %s: client expected %r, "
+        "server returned %r — responses may be parsed with stale shape "
+        "assumptions; coordinate a deploy",
+        path,
+        PROTOCOL_VERSION,
+        server_version,
+    )
 
 
 def _parse_acquire(payload: Mapping[str, Any]) -> AcquireResult:

--- a/tests/test_lease_plane_protocol_version.py
+++ b/tests/test_lease_plane_protocol_version.py
@@ -1,0 +1,174 @@
+"""Wave 2 §"Lease-integration boundary hardening" — protocol_version contract.
+
+Pins the client side of the protocol_version handshake added in this PR:
+- The Python constant PROTOCOL_VERSION matches the literal "v1.0" the Elixir
+  router emits (the Elixir test does the same pin from the other side).
+- LeasePlaneClient logs a WARNING on mismatch but does NOT fail — the rollout
+  grace window relies on this ("ship the field on both sides without
+  coordinating deploys").
+- A missing field (older BEAM) does not warn.
+- The mismatch log is dedup'd so a stuck mismatch doesn't spam.
+
+Future PRs that bump PROTOCOL_VERSION must also bump the Elixir constant and
+update both literal-pinning tests in the same PR (Stability discipline).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+import src.lease_plane.client as client_module
+from src.lease_plane import PROTOCOL_VERSION
+from src.lease_plane.client import LeasePlaneClient, LeasePlaneClientConfig
+from src.lease_plane.models import AcquireRequest
+
+
+def test_protocol_version_constant_is_v1_0():
+    """Drift guard: this constant MUST match the Elixir
+    `UnitaresLeasePlane.HttpRouter.protocol_version/0` literal. Bumping
+    requires touching both sides in the same PR."""
+    assert PROTOCOL_VERSION == "v1.0"
+
+
+def _reset_dedup_state() -> None:
+    client_module._logged_protocol_mismatches.clear()
+    client_module._logged_protocol_absences = False
+
+
+@pytest.fixture(autouse=True)
+def reset_dedup():
+    _reset_dedup_state()
+    yield
+    _reset_dedup_state()
+
+
+def _acquire_req() -> AcquireRequest:
+    return AcquireRequest(
+        surface_id="dialectic:/x",
+        holder_agent_uuid=uuid4(),
+        holder_class="process_instance",
+        holder_kind="local_beam",
+        ttl_s=60,
+        intent="test",
+    )
+
+
+def _client_returning(payload: dict[str, Any]) -> LeasePlaneClient:
+    return LeasePlaneClient(
+        LeasePlaneClientConfig(base_url="http://test.invalid"),
+        transport=lambda _request: payload,
+    )
+
+
+def test_matched_version_emits_no_warning(caplog):
+    """Happy path: server returns matching protocol_version; nothing is logged."""
+    client = _client_returning({
+        "ok": True,
+        "lease": {
+            "lease_id": "00000000-0000-0000-0000-000000000001",
+            "surface_id": "dialectic:/x",
+            "holder_agent_uuid": "11111111-1111-1111-1111-111111111111",
+            "holder_class": "process_instance",
+            "holder_kind": "local_beam",
+            "heartbeat_required": False,
+            "expires_at": "2026-05-07T20:00:00+00:00",
+            "original_ttl_s": 60,
+        },
+        "idempotent": False,
+        "drift_warning": [],
+        "protocol_version": PROTOCOL_VERSION,
+    })
+
+    with caplog.at_level(logging.WARNING, logger="src.lease_plane.client"):
+        client.acquire(_acquire_req())
+
+    assert "protocol_version mismatch" not in caplog.text
+
+
+def test_mismatched_version_logs_warning_and_does_not_fail():
+    """Mismatch path: client logs WARNING but the call still returns the
+    parsed result. Missing this would force a coordinated client/server
+    deploy on every shape change — the whole point of the version grace
+    window is to avoid that."""
+    client = _client_returning({
+        "ok": False,
+        "error": "service_unavailable",
+        "protocol_version": "v9.99",  # server far ahead; we should warn, not fail
+    })
+
+    with patch.object(client_module.logger, "warning") as mock_warn:
+        result = client.acquire(_acquire_req())
+
+    # Call did not fail — we got a typed result, not an exception.
+    assert result is not None
+    # Exactly one warning fired with both versions in the message.
+    assert mock_warn.called
+    msg = mock_warn.call_args.args[0]
+    assert "protocol_version mismatch" in msg
+
+
+def test_absent_version_is_silent_for_grace_period():
+    """Older BEAM that hasn't redeployed yet returns no protocol_version
+    field. Logging WARNING in that case would generate noise during every
+    rollout — the contract says emit only DEBUG-level breadcrumbs and only
+    once per process."""
+    client = _client_returning({
+        "ok": False,
+        "error": "service_unavailable",
+        # no protocol_version key at all
+    })
+
+    with patch.object(client_module.logger, "warning") as mock_warn:
+        client.acquire(_acquire_req())
+
+    mock_warn.assert_not_called()
+
+
+def test_repeated_mismatch_logs_only_once_per_path_and_version():
+    """Stuck mismatch (same server_version on every call to the same path)
+    must log ONCE, not on every request — the alternative is a flooded log
+    that buries the actual problem."""
+    bad = {
+        "ok": False,
+        "error": "service_unavailable",
+        "protocol_version": "v0.9",
+    }
+    client = _client_returning(bad)
+
+    with patch.object(client_module.logger, "warning") as mock_warn:
+        for _ in range(5):
+            client.acquire(_acquire_req())
+
+    # Five identical-mismatch calls, one warning.
+    assert mock_warn.call_count == 1
+
+
+def test_distinct_mismatches_log_separately():
+    """Two different server_version strings on the same path SHOULD fire
+    distinct warnings — they're distinct deploy states the operator wants
+    to see (e.g., the BEAM is being rolled forward and back). The third
+    call repeats the first version and is dedup'd."""
+    versions_seen = ["v0.9", "v1.5", "v0.9"]
+
+    payloads = iter([
+        {"ok": False, "error": "service_unavailable", "protocol_version": v}
+        for v in versions_seen
+    ])
+
+    client = LeasePlaneClient(
+        LeasePlaneClientConfig(base_url="http://test.invalid"),
+        transport=lambda _request: next(payloads),
+    )
+
+    with patch.object(client_module.logger, "warning") as mock_warn:
+        for _ in versions_seen:
+            client.acquire(_acquire_req())
+
+    # Two distinct (path, version) pairs → two warnings; the third (repeat
+    # of v0.9 on /v1/lease/acquire) is dedup'd.
+    assert mock_warn.call_count == 2


### PR DESCRIPTION
Wave 2 §\"Lease-integration boundary hardening\" — Phase A wedge from \`docs/proposals/beam-footprint-roadmap-v0.md\`.

## What this is
First-step versioned-contracts on the BEAM↔Python lease-plane REST boundary. Every JSON response from the Elixir lease-plane router carries a top-level \`protocol_version: \"v1.0\"\` field; the Python client reads it and logs a WARNING on mismatch (does NOT fail). Future shape changes to lease-plane responses bump this version coordinated, instead of silently shifting a field.

URL versioning (\`/v1/lease/*\`) remains the major-version axis. The new \`protocol_version\` is the finer-grained shape-version axis WITHIN /v1.

## Phase A scope (this PR)
- Elixir \`http_router.ex\`: \`@protocol_version \"v1.0\"\` constant; injected into every JSON response via the existing \`json/3\` helper. \`handle_errors/2\` (Plug.ErrorHandler 503 fallback) now also routes through \`json/3\` so it inherits the version field. Public \`HTTPRouter.protocol_version/0\` for tests.
- Python \`src/lease_plane/__init__.py\`: \`PROTOCOL_VERSION = \"v1.0\"\` exported.
- Python \`LeasePlaneClient._request_json\`: reads server's \`protocol_version\`, dedup'd WARNING on mismatch (per (path, server_version) pair), DEBUG-only on absence (rollout grace), never fails.

## Phase B (next PR) — error translation
- Extract Python's \`_parse_*\` switch into a declarative \`(http_status, error_discriminant) → typed_model\` table
- Contract test enumerating every BEAM-emitted error and confirming Python has a mapping

## Phase C (next-next PR) — supervised health
- \`/v1/health\` BEAM endpoint returning \`{ok, protocol_version}\`
- Python \`health_check()\` method with timeout
- governance-mcp deep-health probe optionally includes a boundary check

## Tests
- 6 new Python tests (\`tests/test_lease_plane_protocol_version.py\`): constant pin, matched silent, mismatched warns + non-fatal, absent silent, dedup'd-on-repeat, distinct-versions log separately
- 5 new Elixir tests (\`elixir/lease_plane/test/protocol_version_test.exs\`): constant pin, 200 carries version, 422 carries version, 401 SKIPS version (documented gap — auth layer doesn't go through \`json/3\`; Phase A scope is the typed-error router surfaces only), happy-path shape additive
- 4 existing \`http_router_test.exs\` tests updated from \`assert parsed(resp) == %{...}\` to \`Map.delete(parsed(resp), \"protocol_version\") == %{...}\` so equality checks tolerate the new field

## Documented Phase-A gap
The auth-layer 401 path in \`http_auth.ex\` builds its JSON body inline with \`Plug.Conn.send_resp\` and SKIPS the router's \`json/3\` helper, so it does NOT carry \`protocol_version\` today. Captured in the \`401 permission_denied response carries protocol_version\` test (which currently \`refute\`s the field). Phase A intentionally limits to the typed-error router surfaces; folding auth into the same versioning is a small Phase A.5 follow-up if useful.

## Test plan
- 11/11 Elixir tests in the lease_plane app pass (5 new + 4 reshaped + 2 unrelated)
- Full Elixir suite: 49/49
- Full Python suite: 8567/8567 (with the same pre-existing-broken \`TestKnowledgeGraphOperations\` deselected as on PR #408)
- 138/138 pre-push smoke