### PR TITLE
feat(wave-2): lease-plane error translation table (Phase B)

### DIFF
--- a/src/lease_plane/client.py
+++ b/src/lease_plane/client.py
@@ -339,18 +339,104 @@ def _check_protocol_version(payload: Mapping[str, Any], path: str) -> None:
     )
 
 
+# Wave 2 §"Lease-integration boundary hardening" — Phase B (error translation
+# table). One declarative dict per endpoint family that maps the BEAM-emitted
+# `error` discriminant to the typed Pydantic result model. Adding a new error
+# variant means: add the typed model in models.py, add the discriminant here,
+# done. The previous if-else chain meant an undocumented variant silently
+# degraded to `service_unavailable` — the new design surfaces unknowns
+# explicitly via `_unknown_error_fallback` so a Python ↔ BEAM mapping drift
+# becomes a visible reason string instead of a swallowed misclassification.
+#
+# `BEAM_EMITTED_ACQUIRE_ERRORS` etc. enumerate the discriminants the Elixir
+# router actually emits today (per `elixir/lease_plane/lib/unitares_lease_plane/
+# {http_router,http_auth}.ex`). The contract tests in
+# `tests/test_lease_plane_error_translation.py` assert that every BEAM-side
+# discriminant has a Python mapping; drift catches at test time before it
+# silently degrades errors in production.
+_ACQUIRE_ERROR_PARSERS: dict[str, type] = {
+    "held_by_other": AcquireHeldByOther,
+    "permission_denied": AcquirePermissionDenied,
+    "schema_invalid": AcquireSchemaInvalid,
+    "service_unavailable": AcquireServiceUnavailable,
+}
+
+_STATUS_ERROR_PARSERS: dict[str, type] = {
+    "schema_invalid": StatusSchemaInvalid,
+    "service_unavailable": StatusServiceUnavailable,
+}
+
+# `_parse_simple` covers renew/heartbeat/release/handoff_offer/handoff_accept/
+# force_release. The BEAM router emits the first six; `not_holder` and
+# `already_released` are reserved for future server-side semantics (see
+# surface_registry.ex `:not_holder` return — currently caught by the generic
+# `{:error, reason}` arm and surfaces as `service_unavailable`, but the
+# typed model accepts them so a future router map-through doesn't require a
+# coordinated client deploy).
+_SIMPLE_ACCEPTED_ERRORS: frozenset[str] = frozenset({
+    "not_found",
+    "expired",
+    "not_holder",
+    "already_released",
+    "permission_denied",
+    "schema_invalid",
+    "service_unavailable",
+})
+
+# Authoritative BEAM-emitted error sets per endpoint family. Mirrors the
+# `elixir/lease_plane/lib/unitares_lease_plane/http_router.ex` discriminants
+# and the `http_auth.ex` 401 paths. Synced by the contract tests.
+BEAM_EMITTED_ACQUIRE_ERRORS: frozenset[str] = frozenset({
+    "held_by_other",
+    "permission_denied",
+    "schema_invalid",
+    "service_unavailable",
+})
+
+BEAM_EMITTED_STATUS_ERRORS: frozenset[str] = frozenset({
+    # /v1/lease/status emits service_unavailable on internal error and
+    # schema_invalid on missing/invalid surface_id. 404 returns ok:true with
+    # lease=null (typed-absence shape), not an error envelope.
+    "schema_invalid",
+    "service_unavailable",
+})
+
+BEAM_EMITTED_SIMPLE_ERRORS: frozenset[str] = frozenset({
+    # renew / heartbeat / release / handoff_offer / handoff_accept /
+    # force_release. `expired` is renew-specific (409); `not_found` is the
+    # 404 across all simple-shaped endpoints; `permission_denied` covers
+    # both auth-layer 401 and force-release token mismatch.
+    "not_found",
+    "expired",
+    "permission_denied",
+    "schema_invalid",
+    "service_unavailable",
+})
+
+
+def _unknown_error_fallback(payload: Mapping[str, Any]) -> str:
+    """Build a `reason` string that names the unknown discriminant. Pre-Phase-B
+    these were silently coerced to `service_unavailable` with no signal —
+    the operator had to dig through Elixir router logs to find the actual
+    discriminant. Naming it in the Python-side reason makes drift visible."""
+    raw = payload.get("error")
+    if raw is None:
+        return "missing error discriminant in BEAM response"
+    return f"unrecognized error discriminant: {raw!r} (BEAM/Python registry drift?)"
+
+
 def _parse_acquire(payload: Mapping[str, Any]) -> AcquireResult:
     try:
         if payload.get("ok") is True:
             return AcquireOk.model_validate(payload)
-        error = payload.get("error")
-        if error == "held_by_other":
-            return AcquireHeldByOther.model_validate(payload)
-        if error == "permission_denied":
-            return AcquirePermissionDenied.model_validate(payload)
-        if error == "schema_invalid":
-            return AcquireSchemaInvalid.model_validate(payload)
-        return AcquireServiceUnavailable.model_validate({"ok": False, "error": "service_unavailable"})
+        model_cls = _ACQUIRE_ERROR_PARSERS.get(payload.get("error"))
+        if model_cls is None:
+            return AcquireServiceUnavailable.model_validate({
+                "ok": False,
+                "error": "service_unavailable",
+                "reason": _unknown_error_fallback(payload),
+            })
+        return model_cls.model_validate(payload)
     except ValidationError as exc:
         return AcquireSchemaInvalid(ok=False, error="schema_invalid", detail=exc.errors())
 
@@ -359,9 +445,14 @@ def _parse_status(payload: Mapping[str, Any]) -> StatusResult:
     try:
         if payload.get("ok") is True:
             return StatusOk.model_validate(payload)
-        if payload.get("error") == "schema_invalid":
-            return StatusSchemaInvalid.model_validate(payload)
-        return StatusServiceUnavailable.model_validate({"ok": False, "error": "service_unavailable"})
+        model_cls = _STATUS_ERROR_PARSERS.get(payload.get("error"))
+        if model_cls is None:
+            return StatusServiceUnavailable.model_validate({
+                "ok": False,
+                "error": "service_unavailable",
+                "reason": _unknown_error_fallback(payload),
+            })
+        return model_cls.model_validate(payload)
     except ValidationError as exc:
         return StatusSchemaInvalid(ok=False, error="schema_invalid", detail=exc.errors())
 
@@ -371,20 +462,12 @@ def _parse_simple(payload: Mapping[str, Any]) -> SimpleResult:
         if payload.get("ok") is True:
             return SimpleOk.model_validate(payload)
         error = payload.get("error")
-        if error in {
-            "not_found",
-            "expired",
-            "not_holder",
-            "already_released",
-            "permission_denied",
-            "schema_invalid",
-            "service_unavailable",
-        }:
+        if error in _SIMPLE_ACCEPTED_ERRORS:
             return SimpleError.model_validate(payload)
         return SimpleError(
             ok=False,
             error="service_unavailable",
-            reason=f"unrecognized error: {error!r}" if error is not None else "missing error discriminant",
+            reason=_unknown_error_fallback(payload),
         )
     except ValidationError as exc:
         return SimpleError(ok=False, error="schema_invalid", detail=exc.errors())

--- a/src/lease_plane/models.py
+++ b/src/lease_plane/models.py
@@ -262,6 +262,13 @@ class AcquireSchemaInvalid(BaseModel):
 class AcquireServiceUnavailable(BaseModel):
     ok: Literal[False]
     error: Literal["service_unavailable"]
+    # Phase B (Wave 2 boundary hardening): the client may surface a reason
+    # here when an unknown error discriminant from the BEAM gets coerced
+    # to service_unavailable — the human-readable string names the actual
+    # discriminant so registry-drift becomes visible instead of swallowed.
+    # None on the legitimate service-unavailable path (advisory escape
+    # valve, transport failure, server 503 with no reason).
+    reason: str | None = None
 
 
 AcquireResult: TypeAlias = (
@@ -287,6 +294,10 @@ class StatusSchemaInvalid(BaseModel):
 class StatusServiceUnavailable(BaseModel):
     ok: Literal[False]
     error: Literal["service_unavailable"]
+    # Phase B (Wave 2 boundary hardening): same semantics as
+    # AcquireServiceUnavailable.reason — surfaces the unknown discriminant
+    # name when registry drift coerces a BEAM error to service_unavailable.
+    reason: str | None = None
 
 
 StatusResult: TypeAlias = StatusOk | StatusSchemaInvalid | StatusServiceUnavailable

--- a/tests/test_lease_plane_error_translation.py
+++ b/tests/test_lease_plane_error_translation.py
@@ -1,0 +1,269 @@
+"""Wave 2 §"Lease-integration boundary hardening" — Phase B (error translation).
+
+Pins the contract that every error discriminant the BEAM lease-plane router
+emits has a Python-side parser entry. Pre-Phase-B the parsers were nested
+if-else chains and an unknown discriminant silently degraded to
+`service_unavailable` — operators had to dig through Elixir router logs to
+find the actual discriminant. Post-Phase-B the parsers are declarative tables
+keyed on `error`, with a fallback that names the unknown discriminant in the
+result's `reason` field so drift is visible.
+
+These tests assert:
+1. The Python translation tables (`_ACQUIRE_ERROR_PARSERS`, etc.) are
+   supersets of the documented BEAM-emitted error sets — drift surfaces here
+   before it surfaces in production.
+2. An unknown discriminant produces a `service_unavailable` result whose
+   `reason` field names the unknown value (registry-drift visibility).
+3. Each known discriminant still parses to the correct typed model
+   (no regression from the refactor).
+
+The BEAM-side authoritative emit set lives in
+`elixir/lease_plane/lib/unitares_lease_plane/{http_router,http_auth}.ex`
+and is mirrored as `BEAM_EMITTED_*_ERRORS` in `src/lease_plane/client.py`.
+Any new BEAM error variant must update both sides in the same PR (Stability
+discipline).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.lease_plane import (
+    AcquireHeldByOther,
+    AcquireOk,
+    AcquirePermissionDenied,
+    AcquireSchemaInvalid,
+    AcquireServiceUnavailable,
+    SimpleError,
+    SimpleOk,
+    StatusOk,
+    StatusSchemaInvalid,
+    StatusServiceUnavailable,
+)
+from src.lease_plane.client import (
+    BEAM_EMITTED_ACQUIRE_ERRORS,
+    BEAM_EMITTED_SIMPLE_ERRORS,
+    BEAM_EMITTED_STATUS_ERRORS,
+    _ACQUIRE_ERROR_PARSERS,
+    _SIMPLE_ACCEPTED_ERRORS,
+    _STATUS_ERROR_PARSERS,
+    _parse_acquire,
+    _parse_simple,
+    _parse_status,
+)
+
+
+# ============================================================================
+# Coverage: every BEAM-emitted discriminant has a Python parser
+# ============================================================================
+
+
+def test_acquire_parser_covers_every_beam_emitted_acquire_error():
+    """Drift guard: if the BEAM router adds a new acquire-error discriminant
+    (e.g., `rate_limited`, `quota_exceeded`), the Python parser table MUST be
+    extended in the same PR. Without this assertion, the new discriminant
+    would silently fall through to `service_unavailable` and the typed
+    result loses fidelity."""
+    missing = BEAM_EMITTED_ACQUIRE_ERRORS - set(_ACQUIRE_ERROR_PARSERS.keys())
+    assert not missing, (
+        f"BEAM emits acquire errors {sorted(missing)} that the Python "
+        f"_ACQUIRE_ERROR_PARSERS table doesn't map. Add them or update "
+        f"BEAM_EMITTED_ACQUIRE_ERRORS if those discriminants were retired."
+    )
+
+
+def test_status_parser_covers_every_beam_emitted_status_error():
+    missing = BEAM_EMITTED_STATUS_ERRORS - set(_STATUS_ERROR_PARSERS.keys())
+    assert not missing, (
+        f"BEAM emits status errors {sorted(missing)} that the Python "
+        f"_STATUS_ERROR_PARSERS table doesn't map."
+    )
+
+
+def test_simple_parser_covers_every_beam_emitted_simple_error():
+    missing = BEAM_EMITTED_SIMPLE_ERRORS - _SIMPLE_ACCEPTED_ERRORS
+    assert not missing, (
+        f"BEAM emits simple-shape errors {sorted(missing)} that the Python "
+        f"_SIMPLE_ACCEPTED_ERRORS set doesn't map."
+    )
+
+
+# ============================================================================
+# Unknown-discriminant fallback (registry-drift visibility)
+# ============================================================================
+
+
+def test_acquire_unknown_discriminant_surfaces_in_reason():
+    """An unknown discriminant from the BEAM (e.g., a future error variant
+    that landed on the server before the client deploy) must NOT silently
+    coerce to a flat service_unavailable. The result's `reason` field must
+    name the unknown discriminant so the operator can grep for it."""
+    result = _parse_acquire({"ok": False, "error": "some_future_variant"})
+    assert isinstance(result, AcquireServiceUnavailable)
+    assert result.reason is not None
+    assert "some_future_variant" in result.reason
+    assert "registry drift" in result.reason.lower() or "unrecognized" in result.reason.lower()
+
+
+def test_status_unknown_discriminant_surfaces_in_reason():
+    result = _parse_status({"ok": False, "error": "some_future_variant"})
+    assert isinstance(result, StatusServiceUnavailable)
+    assert result.reason is not None
+    assert "some_future_variant" in result.reason
+
+
+def test_simple_unknown_discriminant_surfaces_in_reason():
+    result = _parse_simple({"ok": False, "error": "some_future_variant"})
+    assert isinstance(result, SimpleError)
+    assert result.error == "service_unavailable"
+    assert result.reason is not None
+    assert "some_future_variant" in result.reason
+
+
+def test_missing_error_discriminant_surfaces_named_reason():
+    """A response with `ok: false` but no `error` field at all (malformed
+    BEAM output, schema bug) gets a named reason rather than silently
+    swallowed."""
+    result = _parse_acquire({"ok": False})
+    assert isinstance(result, AcquireServiceUnavailable)
+    assert result.reason is not None
+    assert "missing" in result.reason.lower()
+
+
+# ============================================================================
+# Known-discriminant regression: each Phase-A behavior preserved post-refactor
+# ============================================================================
+
+
+def test_acquire_known_discriminants_still_parse_to_correct_models():
+    """Spot-check each acquire-error variant routes to the right typed
+    model post-refactor. The if-else → table swap must not silently
+    change classifications."""
+    samples = [
+        (
+            {
+                "ok": False,
+                "error": "held_by_other",
+                "surface_id": "dialectic:/x",
+                "blocking_lease_id": "11111111-1111-1111-1111-111111111111",
+                "held_by_uuid": "22222222-2222-2222-2222-222222222222",
+                "expires_at": "2026-05-08T00:00:00+00:00",
+                "retry_after_hint_ms": 250,
+            },
+            AcquireHeldByOther,
+        ),
+        (
+            {"ok": False, "error": "permission_denied", "reason": "role_holders_unsupported"},
+            AcquirePermissionDenied,
+        ),
+        (
+            {"ok": False, "error": "schema_invalid", "detail": "surface_id required"},
+            AcquireSchemaInvalid,
+        ),
+        (
+            {"ok": False, "error": "service_unavailable"},
+            AcquireServiceUnavailable,
+        ),
+    ]
+    for payload, expected_cls in samples:
+        result = _parse_acquire(payload)
+        assert isinstance(result, expected_cls), (
+            f"discriminant {payload['error']!r} should parse to "
+            f"{expected_cls.__name__}, got {type(result).__name__}"
+        )
+
+
+def test_acquire_ok_path_unchanged_by_refactor():
+    """The success path stays an AcquireOk — refactor only touched the
+    error branches."""
+    payload = {
+        "ok": True,
+        "lease": {
+            "lease_id": "00000000-0000-0000-0000-000000000001",
+            "surface_id": "dialectic:/x",
+            "surface_kind": "dialectic",
+            "holder_agent_uuid": "11111111-1111-1111-1111-111111111111",
+            "holder_class": "process_instance",
+            "holder_kind": "local_beam",
+            "heartbeat_required": False,
+            "expires_at": "2026-05-08T00:00:00+00:00",
+            "original_ttl_s": 60,
+        },
+        "idempotent": False,
+        "drift_warning": [],
+    }
+    result = _parse_acquire(payload)
+    assert isinstance(result, AcquireOk)
+
+
+def test_status_ok_with_null_lease_unchanged_by_refactor():
+    """The 404-as-typed-absence shape (200 + ok:true + lease:null) — must
+    NOT be misclassified as an error post-refactor."""
+    result = _parse_status({"ok": True, "lease": None})
+    assert isinstance(result, StatusOk)
+    assert result.lease is None
+
+
+def test_simple_known_discriminants_still_parse():
+    """Each currently-accepted simple-shape error parses to SimpleError
+    with the right `error` discriminant preserved."""
+    for discriminant in _SIMPLE_ACCEPTED_ERRORS:
+        result = _parse_simple({"ok": False, "error": discriminant, "reason": "test"})
+        assert isinstance(result, SimpleError)
+        assert result.error == discriminant
+        assert result.reason == "test"
+
+
+def test_simple_ok_path_unchanged_by_refactor():
+    result = _parse_simple({"ok": True})
+    assert isinstance(result, SimpleOk)
+
+
+# ============================================================================
+# Validation-error fallback unchanged
+# ============================================================================
+
+
+def test_acquire_validation_error_falls_back_to_schema_invalid():
+    """When a known discriminant is present but the rest of the payload
+    fails the typed model's validation (e.g., held_by_other missing
+    required fields), the parser falls back to AcquireSchemaInvalid with
+    the Pydantic error detail. Pre-refactor behavior, pinned here."""
+    # held_by_other missing all the required fields below the discriminant
+    result = _parse_acquire({"ok": False, "error": "held_by_other"})
+    assert isinstance(result, AcquireSchemaInvalid)
+    assert result.detail is not None  # Pydantic error list
+
+
+# ============================================================================
+# Drift smoke check between docstrings and constants
+# ============================================================================
+
+
+def test_beam_emitted_acquire_errors_constant_is_nonempty_and_ascii():
+    """Pin the literal contents so a future find/replace can't silently
+    rename a discriminant. The Elixir router test pins the same strings
+    on the other side."""
+    assert BEAM_EMITTED_ACQUIRE_ERRORS == frozenset({
+        "held_by_other",
+        "permission_denied",
+        "schema_invalid",
+        "service_unavailable",
+    })
+
+
+def test_beam_emitted_status_errors_constant_is_documented_set():
+    assert BEAM_EMITTED_STATUS_ERRORS == frozenset({
+        "schema_invalid",
+        "service_unavailable",
+    })
+
+
+def test_beam_emitted_simple_errors_constant_is_documented_set():
+    assert BEAM_EMITTED_SIMPLE_ERRORS == frozenset({
+        "not_found",
+        "expired",
+        "permission_denied",
+        "schema_invalid",
+        "service_unavailable",
+    })


### PR DESCRIPTION
Wave 2 §\"Lease-integration boundary hardening\" — Phase B (continues from #412 Phase A protocol_version).

## What this is
Refactor the Python lease-plane client's error parsers from nested if-else chains to declarative discriminant tables, with an unknown-discriminant fallback that names the unrecognized value in the result's \`reason\` field.

Pre-Phase-B: \`_parse_acquire\`/\`_parse_status\`/\`_parse_simple\` had if-else chains; an unknown discriminant (e.g., a future BEAM error variant landed before the client deploy) silently coerced to \`service_unavailable\` with no signal. Operators had to dig through Elixir router logs to find the actual error.

Post-Phase-B: parsers consult \`_ACQUIRE_ERROR_PARSERS\` / \`_STATUS_ERROR_PARSERS\` / \`_SIMPLE_ACCEPTED_ERRORS\` declarative tables; unknown discriminants flow through \`_unknown_error_fallback\` which names the discriminant in the result's \`reason\` field (\"unrecognized error discriminant: 'rate_limited' (BEAM/Python registry drift?)\"). The drift is now visible at the call site.

## Authoritative BEAM-emitted error sets
Three frozensets in \`client.py\` mirror the discriminants the Elixir router actually emits:
- \`BEAM_EMITTED_ACQUIRE_ERRORS\` = {held_by_other, permission_denied, schema_invalid, service_unavailable}
- \`BEAM_EMITTED_STATUS_ERRORS\` = {schema_invalid, service_unavailable}
- \`BEAM_EMITTED_SIMPLE_ERRORS\` = {not_found, expired, permission_denied, schema_invalid, service_unavailable}

Sourced from a grep of \`elixir/lease_plane/lib/unitares_lease_plane/{http_router,http_auth}.ex\`. Future BEAM error variants extend both the BEAM router AND these sets in the same PR (Stability discipline). The contract tests catch drift before it surfaces in production.

## Why this scope
- Discoverability: a single source of truth per endpoint family beats scattered if-else.
- Drift visibility: registry drift used to silently degrade; now it lands as a typed result with the unknown discriminant named.
- Coverage: contract tests assert each Python parser table is a superset of the BEAM emit set. Adding a new BEAM variant without updating the Python side fails CI.

## Models
\`AcquireServiceUnavailable\` and \`StatusServiceUnavailable\` gained an optional \`reason: str | None = None\` field so the unknown-discriminant fallback can surface a structured signal. \`SimpleError\` already had \`reason\`.

## Tests
14 new tests in \`tests/test_lease_plane_error_translation.py\`:
- 3 coverage tests (Python tables ⊇ BEAM emit sets)
- 4 unknown-discriminant tests (\`reason\` names the unknown value across all three parsers + missing-error case)
- 4 known-discriminant regression tests (each variant still routes to the right typed model post-refactor)
- 3 BEAM-set literal pin tests (drift guard against accidental rename/typo)

## Test plan
- 14/14 new tests pass
- 26/26 existing \`tests/test_lease_plane_client.py\` tests pass (no regression from the if-else → table refactor)
- Full suite: 8576/8576 (with the same pre-existing-broken \`TestKnowledgeGraphOperations\` deselected as on prior PRs)
- 138/138 pre-push smoke

## Phase C remaining
- \`/v1/health\` BEAM endpoint returning \`{ok, protocol_version}\`
- Python \`health_check()\` method with timeout
- Optional governance-mcp deep-health probe boundary check