### PR TITLE
feat(doctor): detect code-vs-DB column drift via INSERT scan

### DIFF
--- a/scripts/dev/unitares_doctor.py
+++ b/scripts/dev/unitares_doctor.py
@@ -235,6 +235,100 @@ def check_schema_migrations(db_url: str, repo_root: Path | None = None) -> Check
                        f"schema at version {version}; registry matches source manifest")
 
 
+_SQL_INSERT_COLUMNS_RE = re.compile(
+    r"INSERT\s+INTO\s+(\w+)\.(\w+)\s*\(([^)]+)\)",
+    re.IGNORECASE | re.DOTALL,
+)
+_SQL_IDENT_RE = re.compile(r"^([a-z_][a-z0-9_]*)", re.IGNORECASE)
+
+
+def _scan_insert_column_refs(src_dirs: list[Path]) -> dict[tuple[str, str], set[str]]:
+    """Scan Python source for ``INSERT INTO schema.table (...)`` SQL fragments.
+
+    Returns ``{(schema, table): {col1, col2, ...}}`` for each table whose
+    INSERT column list could be parsed. Only handles bare-identifier column
+    lists (no function calls in the column position) — that covers every
+    INSERT in the current codebase, where function calls live in VALUES.
+    """
+    refs: dict[tuple[str, str], set[str]] = {}
+    for src_dir in src_dirs:
+        if not src_dir.is_dir():
+            continue
+        for path in src_dir.rglob("*.py"):
+            try:
+                text = path.read_text()
+            except Exception:
+                continue
+            for match in _SQL_INSERT_COLUMNS_RE.finditer(text):
+                schema, table, col_list = match.group(1), match.group(2), match.group(3)
+                cleaned = re.sub(r"--[^\n]*", "", col_list)
+                cols: set[str] = set()
+                for tok in cleaned.split(","):
+                    tok = tok.strip()
+                    if not tok:
+                        continue
+                    m = _SQL_IDENT_RE.match(tok)
+                    if m:
+                        cols.add(m.group(1).lower())
+                if cols:
+                    refs.setdefault((schema.lower(), table.lower()), set()).update(cols)
+    return refs
+
+
+def _fetch_table_columns(db_url: str, schema: str, table: str) -> set[str] | None:
+    """Return the set of column names for a table, or None on lookup failure."""
+    proc = subprocess.run(
+        ["psql", db_url, "-Atqc",
+         f"SELECT column_name FROM information_schema.columns "
+         f"WHERE table_schema='{schema}' AND table_name='{table}'"],
+        capture_output=True, text=True, timeout=5,
+    )
+    if proc.returncode != 0:
+        return None
+    cols = {line.strip().lower() for line in proc.stdout.splitlines() if line.strip()}
+    return cols or None
+
+
+def check_column_drift(db_url: str, repo_root: Path) -> CheckResult:
+    """Verify columns in INSERT INTO statements exist in the running DB.
+
+    Catches code-vs-DB drift the schema_migrations check misses: code
+    references a column the migration never added, INSERT fails at runtime
+    with "column ... does not exist". Same blind-spot class as the
+    2026-04-17 last_activity_at incident, the 2026-04-19 trigger_source
+    outage, and the 2026-05-07 discoveries.provenance_chain bug.
+    """
+    name, mode = "column_drift", "local"
+    if shutil.which("psql") is None:
+        return CheckResult(name, mode, Status.SKIP, "psql not on PATH")
+    src_dirs = [repo_root / "src", repo_root / "governance_core"]
+    refs = _scan_insert_column_refs(src_dirs)
+    if not refs:
+        return CheckResult(name, mode, Status.SKIP, "no INSERT statements found")
+
+    missing: list[str] = []
+    total_refs = 0
+    for (schema, table), cols in sorted(refs.items()):
+        existing = _fetch_table_columns(db_url, schema, table)
+        if existing is None:
+            continue  # table absent or lookup error; other checks own that
+        total_refs += len(cols)
+        for col in sorted(cols):
+            if col not in existing:
+                missing.append(f"{schema}.{table}.{col}")
+
+    if missing:
+        return CheckResult(
+            name, mode, Status.FAIL,
+            f"code references {len(missing)} column(s) missing from DB",
+            detail="\n".join(missing),
+        )
+    return CheckResult(
+        name, mode, Status.PASS,
+        f"all {total_refs} INSERT-referenced columns exist across {len(refs)} table(s)",
+    )
+
+
 def check_elixir_deprecated_scheme_lint(db_url: str, repo_root: Path) -> CheckResult:
     """Phase B prep (RFC §7.11.8): WARN if any Elixir source mentions a
     surface_kind currently in lease_plane.deprecated_schemes.
@@ -568,6 +662,7 @@ def build_checks(repo_root: Path, db_url: str) -> list[Check]:
         Check("governance_database", "local", lambda: check_governance_database(db_url)),
         Check("pg_extensions", "local", lambda: check_pg_extensions(db_url)),
         Check("schema_migrations", "local", lambda: check_schema_migrations(db_url, repo_root)),
+        Check("column_drift", "local", lambda: check_column_drift(db_url, repo_root)),
         Check("elixir_deprecated_scheme_lint", "local",
               lambda: check_elixir_deprecated_scheme_lint(db_url, repo_root)),
         Check("elixir_scheme_grammar_lint", "local",

--- a/tests/test_unitares_doctor_script.py
+++ b/tests/test_unitares_doctor_script.py
@@ -150,6 +150,94 @@ def test_check_schema_migrations_detects_unexpected_out_of_band_row(doctor, monk
     assert "unexpected 24:manual hotfix" in result.detail
 
 
+def _src_root_with_insert(tmp_path: Path, sql: str) -> Path:
+    """Create a tmp_path/repo with src/fake.py containing the given SQL string."""
+    root = tmp_path / "repo"
+    src_dir = root / "src"
+    src_dir.mkdir(parents=True)
+    (src_dir / "fake.py").write_text(
+        'async def insert():\n'
+        f'    await conn.execute("""\n{sql}\n""")\n'
+    )
+    return root
+
+
+def test_check_column_drift_skips_when_no_inserts(doctor, monkeypatch, tmp_path):
+    root = tmp_path / "repo"
+    (root / "src").mkdir(parents=True)
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: "/usr/bin/psql")
+    result = doctor.check_column_drift("postgresql://example", root)
+    assert result.status == doctor.Status.SKIP
+    assert "no INSERT" in result.message
+
+
+def test_check_column_drift_passes_when_all_columns_exist(doctor, monkeypatch, tmp_path):
+    sql = "INSERT INTO core.identities (id, name, status) VALUES ($1, $2, $3)"
+    root = _src_root_with_insert(tmp_path, sql)
+
+    class Proc:
+        returncode = 0
+        stdout = "id\nname\nstatus\n"
+        stderr = ""
+
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: "/usr/bin/psql")
+    monkeypatch.setattr(doctor.subprocess, "run", lambda *args, **kwargs: Proc())
+
+    result = doctor.check_column_drift("postgresql://example", root)
+    assert result.status == doctor.Status.PASS
+    assert "3 INSERT-referenced columns" in result.message
+
+
+def test_check_column_drift_fails_when_column_missing(doctor, monkeypatch, tmp_path):
+    """Reproduces the 2026-05-07 discoveries.provenance_chain class of bug:
+    code references a column the running DB doesn't have."""
+    sql = (
+        "INSERT INTO knowledge.discoveries (\n"
+        "    id, summary, provenance_chain\n"
+        ") VALUES ($1, $2, $3)"
+    )
+    root = _src_root_with_insert(tmp_path, sql)
+
+    class Proc:
+        returncode = 0
+        stdout = "id\nsummary\n"  # provenance_chain column missing from DB
+        stderr = ""
+
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: "/usr/bin/psql")
+    monkeypatch.setattr(doctor.subprocess, "run", lambda *args, **kwargs: Proc())
+
+    result = doctor.check_column_drift("postgresql://example", root)
+    assert result.status == doctor.Status.FAIL
+    assert "missing from DB" in result.message
+    assert "knowledge.discoveries.provenance_chain" in result.detail
+
+
+def test_check_column_drift_skips_table_lookup_failure(doctor, monkeypatch, tmp_path):
+    """If a referenced table doesn't exist (psql lookup returns empty),
+    that's another check's concern — column_drift just skips."""
+    sql = "INSERT INTO some.notable_table (a, b) VALUES ($1, $2)"
+    root = _src_root_with_insert(tmp_path, sql)
+
+    class Proc:
+        returncode = 0
+        stdout = ""  # table absent
+        stderr = ""
+
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: "/usr/bin/psql")
+    monkeypatch.setattr(doctor.subprocess, "run", lambda *args, **kwargs: Proc())
+
+    result = doctor.check_column_drift("postgresql://example", root)
+    # Pass with 0 refs counted (table skipped)
+    assert result.status == doctor.Status.PASS
+    assert "0 INSERT-referenced columns" in result.message
+
+
+def test_check_column_drift_skips_when_psql_missing(doctor, monkeypatch, tmp_path):
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: None)
+    result = doctor.check_column_drift("postgresql://example", tmp_path)
+    assert result.status == doctor.Status.SKIP
+
+
 def test_main_json_output(doctor, monkeypatch, capsys, tmp_path):
     # Replace build_checks so we don't probe the live system.
     fake_checks = [_fake(doctor, "always_pass", "local", doctor.Status.PASS)]


### PR DESCRIPTION
## Summary
- New `check_column_drift` in `scripts/dev/unitares_doctor.py`: scans `src/` and `governance_core/` for `INSERT INTO schema.table (...)` SQL fragments, validates each referenced column against `information_schema.columns` of the running DB.
- Closes a recurring blind-spot class — the existing `schema_migrations` check validates manifest parity but has no visibility into whether columns the *code* expects actually exist. A migration can be missing entirely and `schema_migrations` still passes.
- Same class as: 2026-04-17 last_activity_at incident · 2026-04-19 trigger_source outage · 2026-05-07 discoveries.provenance_chain (companion PR #415).

## Scope
Intentionally narrow: INSERT column lists only. INSERT lists are unambiguous and parseable; arbitrary SELECT/WHERE identifier references would require real SQL parsing. Every drift incident in our history was caught at INSERT time, so this captures the high-value cases without false-positive risk.

## Live verification
Against the post-037 governance DB: **171 INSERT-referenced columns across 20 tables, all present.** The check would have caught the `provenance_chain` bug if run before that PR landed (verified by the synthetic-drift unit test below).

## Test plan
- [x] 5 new unit tests (mocked psql), all passing:
  - skips when psql missing
  - skips when src/ has no INSERT statements
  - passes when all columns exist (3-column happy path)
  - **fails when column missing — directly reproduces the `knowledge.discoveries.provenance_chain` failure shape**
  - skips silently when referenced table doesn't exist
- [x] All 31 doctor tests pass
- [x] Full test suite via `test-cache.sh`: 8580 passed, 34 skipped, 0 failed
- [x] Live doctor run: `column_drift: all 171 INSERT-referenced columns exist across 20 table(s)`