### PR TITLE
feat(wave-2): deep-health probe of BEAM lease-plane boundary (Phase C.5)

### DIFF
--- a/src/services/runtime_queries.py
+++ b/src/services/runtime_queries.py
@@ -394,6 +394,74 @@ async def _bounded_scan_count(redis, pattern: str, *, cap: int = _HEALTH_KEYS_CA
     return n
 
 
+_LEASE_PLANE_PROBE_TIMEOUT_S = 2.0
+
+
+async def _probe_lease_plane_boundary(loop) -> Dict[str, Any]:
+    """Wave 2 Phase C.5: probe BEAM lease-plane /v1/health for the deep-health
+    snapshot. Returns a `checks["lease_plane"]`-shaped dict.
+
+    Failure-safe by composition: LeasePlaneClient.health_check() (Phase C,
+    PR #417) never raises — it returns a typed HealthOk | HealthUnavailable.
+    Wrapped here in a final try/except so even an import failure or config
+    misread surfaces as `status: "error"` rather than crashing the snapshot.
+
+    Uses `loop.run_in_executor` because the client is sync stdlib urllib —
+    keeps the probe off the anyio task group entirely. Tight 2s timeout
+    matches the snapshot's "fast liveness" purpose; full lease ops use the
+    config-default 5s.
+    """
+    import os
+
+    try:
+        from src.lease_plane import (
+            HealthOk,
+            LeasePlaneClient,
+            LeasePlaneClientConfig,
+        )
+
+        base_url = os.getenv("LEASE_PLANE_BASE_URL", "http://127.0.0.1:8788")
+        bearer = os.getenv("LEASE_PLANE_BEARER_TOKEN", "") or ""
+
+        # No bearer configured → this deploy doesn't have the lease-plane
+        # boundary in scope. Return "unavailable" (mirrors the redis_cache
+        # pattern when Redis isn't configured) so the snapshot's overall
+        # status logic can pop it via the line-705 special-case rather than
+        # degrading every test/CI run that doesn't have the bearer.
+        if not bearer:
+            return {
+                "status": "unavailable",
+                "ok": False,
+                "url": base_url,
+                "reason": "LEASE_PLANE_BEARER_TOKEN not configured",
+            }
+
+        config = LeasePlaneClientConfig(
+            base_url=base_url,
+            bearer_token=bearer,
+            timeout_s=_LEASE_PLANE_PROBE_TIMEOUT_S,
+        )
+        client = LeasePlaneClient(config)
+        health = await loop.run_in_executor(
+            None,
+            lambda: client.health_check(timeout_s=_LEASE_PLANE_PROBE_TIMEOUT_S),
+        )
+        if isinstance(health, HealthOk):
+            return {"status": "healthy", "ok": True, "url": base_url}
+        # HealthUnavailable: boundary did not confirm. Snapshot status is
+        # "warning" (not "error") because the deep-health probe shouldn't
+        # fail the whole snapshot just because a downstream is unhealthy —
+        # the operator wants the rest of the surface visible.
+        return {
+            "status": "warning",
+            "ok": False,
+            "url": base_url,
+            "reason": health.reason,
+        }
+    except Exception as e:  # noqa: BLE001 — probe must not poison snapshot
+        return {"status": "error", "error": str(e)}
+
+
 async def get_health_check_data(arguments: Dict[str, Any], server=None) -> Dict[str, Any]:
     """Build plain health-check data for operators and transports."""
     server = server or mcp_server
@@ -546,6 +614,14 @@ async def get_health_check_data(arguments: Dict[str, Any], server=None) -> Dict[
     except Exception as e:
         checks["redis_cache"] = {"status": "error", "present": False, "error": str(e)}
 
+    # Wave 2 §"Lease-integration boundary hardening" — Phase C.5 (#417 follow-on).
+    # Surface the Python↔BEAM lease-plane boundary in the deep-health snapshot.
+    # Uses the failure-safe LeasePlaneClient.health_check() (Phase C) so a
+    # transport/auth/server failure here can't propagate. The client is sync
+    # stdlib urllib, so it runs in the executor — keeps the probe off the
+    # anyio task group entirely (the original reason the BEAM port exists).
+    checks["lease_plane"] = await _probe_lease_plane_boundary(loop)
+
     continuity_status = get_identity_continuity_status(
         redis_present=checks.get("redis_cache", {}).get("present"),
         redis_operational=checks.get("redis_cache", {}).get("status") not in {"error", "unavailable"},
@@ -649,6 +725,20 @@ async def get_health_check_data(arguments: Dict[str, Any], server=None) -> Dict[
         and redis_check.get("status") == "unavailable"
     ):
         effective_checks.pop("redis_cache", None)
+
+    # Wave 2 Phase C.5: pop lease_plane from overall-status calculation when
+    # it's "unavailable" (no LEASE_PLANE_BEARER_TOKEN configured for this
+    # deploy). Mirrors the redis-cache treatment: an opt-in component that
+    # isn't configured shouldn't degrade the overall snapshot. A "warning"
+    # or "error" status here (i.e. bearer IS configured but the BEAM is
+    # unhealthy or unreachable) DOES still degrade — that's an actionable
+    # signal the operator needs to see in overall status.
+    lease_plane_check = effective_checks.get("lease_plane")
+    if (
+        isinstance(lease_plane_check, dict)
+        and lease_plane_check.get("status") == "unavailable"
+    ):
+        effective_checks.pop("lease_plane", None)
 
     statuses = [c.get("status") for c in effective_checks.values()]
     overall_status = "critical" if "error" in statuses else ("healthy" if all(s == "healthy" for s in statuses) else "moderate")

--- a/tests/test_deep_health_lease_plane_probe.py
+++ b/tests/test_deep_health_lease_plane_probe.py
@@ -1,0 +1,197 @@
+"""Wave 2 Phase C.5 (#417 follow-on) — deep-health probe of the BEAM lease-plane.
+
+Pins the helper that surfaces the Python↔BEAM boundary in
+governance-mcp's deep-health snapshot:
+- HealthOk → status="healthy"
+- HealthUnavailable → status="warning" with reason preserved
+- Exception (import failure, misconfig, runtime bug) → status="error",
+  isolated from the rest of the snapshot
+- The probe NEVER raises (fail-safe by composition with LeasePlaneClient
+  which itself never raises)
+
+Phase C ships the probe; the deep-health probe task in
+`src/background_tasks.py:deep_health_probe_task` calls
+`get_health_check_data` every PROBE_INTERVAL_SECONDS (30s) and the
+result lands at `/health/deep` for operators and the dashboard panel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from src.lease_plane import HealthOk, HealthUnavailable
+
+
+def _probe():
+    """Lazy import to avoid the circular-import chain that fires when
+    runtime_queries is imported top-level by a test (mcp_handlers/__init__
+    imports outcome_events which imports back into runtime_queries during
+    module init). Pre-importing mcp_handlers fully first lets the cycle
+    settle: the second-level imports inside outcome_events resolve once
+    runtime_queries is fully loaded."""
+    import src.mcp_handlers  # noqa: F401 — warm the module cycle first
+    from src.services.runtime_queries import _probe_lease_plane_boundary
+    return _probe_lease_plane_boundary
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_healthy_on_health_ok():
+    """Happy path: BEAM responds with HealthOk → snapshot entry is healthy."""
+    fake_client = type("FakeClient", (), {
+        "health_check": lambda self, *, timeout_s=None: HealthOk(ok=True, status="ok"),
+    })()
+
+    with patch.dict("os.environ", {"LEASE_PLANE_BEARER_TOKEN": "test-token"}, clear=False), \
+         patch("src.lease_plane.LeasePlaneClient", return_value=fake_client):
+        loop = asyncio.get_running_loop()
+        result = await _probe()(loop)
+
+    assert result["status"] == "healthy"
+    assert result["ok"] is True
+    assert "url" in result
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_unavailable_when_bearer_unset():
+    """No LEASE_PLANE_BEARER_TOKEN → return "unavailable" without making the
+    HTTP call. Mirrors the redis_cache pattern: an opt-in component not
+    configured for this deploy shouldn't degrade the overall snapshot.
+    The line-705 special-case in get_health_check_data pops "unavailable"
+    lease_plane entries from effective_checks so overall stays healthy."""
+    import os as _os
+    saved = _os.environ.pop("LEASE_PLANE_BEARER_TOKEN", None)
+    try:
+        loop = asyncio.get_running_loop()
+        result = await _probe()(loop)
+    finally:
+        if saved is not None:
+            _os.environ["LEASE_PLANE_BEARER_TOKEN"] = saved
+
+    assert result["status"] == "unavailable"
+    assert result["ok"] is False
+    assert "not configured" in result["reason"].lower()
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_warning_with_reason_on_health_unavailable():
+    """Bearer IS configured but boundary doesn't confirm → snapshot entry
+    is `warning`. The server's reason is preserved. Distinct from the
+    "no bearer configured" path which returns "unavailable" so the
+    overall-status logic can pop it (operator-actionable signal vs
+    config-not-set signal)."""
+    unhealthy = HealthUnavailable(
+        ok=False,
+        error="service_unavailable",
+        reason="transport failure: ConnectionRefusedError",
+    )
+    fake_client = type("FakeClient", (), {
+        "health_check": lambda self, *, timeout_s=None: unhealthy,
+    })()
+
+    with patch.dict("os.environ", {"LEASE_PLANE_BEARER_TOKEN": "test-token"}, clear=False), \
+         patch("src.lease_plane.LeasePlaneClient", return_value=fake_client):
+        loop = asyncio.get_running_loop()
+        result = await _probe()(loop)
+
+    assert result["status"] == "warning"
+    assert result["ok"] is False
+    assert result["reason"] == "transport failure: ConnectionRefusedError"
+    assert "url" in result
+
+
+@pytest.mark.asyncio
+async def test_probe_isolates_import_failure():
+    """If the lease_plane module is somehow unimportable (broken install,
+    test env, partial deploy), the probe must NOT crash get_health_check_data.
+    The deep-health snapshot's whole purpose is operator visibility — we
+    shouldn't lose it because of a bad-state probe."""
+    import sys
+    with patch.dict(sys.modules, {"src.lease_plane": None}):
+        loop = asyncio.get_running_loop()
+        result = await _probe()(loop)
+
+    assert result["status"] == "error"
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_probe_isolates_runtime_exception_in_client():
+    """A runtime bug in the client (e.g., a future refactor accidentally
+    raises before the failure-safe wrapper kicks in) must not propagate."""
+    fake_client = type("FakeClient", (), {
+        "health_check": lambda self, *, timeout_s=None: (_ for _ in ()).throw(
+            RuntimeError("client bug")
+        ),
+    })()
+
+    with patch.dict("os.environ", {"LEASE_PLANE_BEARER_TOKEN": "test-token"}, clear=False), \
+         patch("src.lease_plane.LeasePlaneClient", return_value=fake_client):
+        loop = asyncio.get_running_loop()
+        result = await _probe()(loop)
+
+    assert result["status"] == "error"
+    assert "client bug" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_probe_uses_env_for_base_url_and_token():
+    """The probe reads `LEASE_PLANE_BASE_URL` + `LEASE_PLANE_BEARER_TOKEN`
+    from env so operators can repoint without code changes — same env vars
+    the lease-plane plist sets."""
+    seen_configs = []
+
+    def capture_config(config):
+        seen_configs.append((config.base_url, config.bearer_token))
+        return type("FakeClient", (), {
+            "health_check": lambda self, *, timeout_s=None: HealthOk(
+                ok=True, status="ok"
+            ),
+        })()
+
+    env = {
+        "LEASE_PLANE_BASE_URL": "http://probe-test:8788",
+        "LEASE_PLANE_BEARER_TOKEN": "probe-token-xyz",
+    }
+    with patch.dict("os.environ", env, clear=False), \
+         patch("src.lease_plane.LeasePlaneClient", side_effect=capture_config):
+        loop = asyncio.get_running_loop()
+        result = await _probe()(loop)
+
+    assert result["status"] == "healthy"
+    assert result["url"] == "http://probe-test:8788"
+    assert seen_configs == [("http://probe-test:8788", "probe-token-xyz")]
+
+
+@pytest.mark.asyncio
+async def test_probe_falls_back_to_default_url_without_env():
+    """No LEASE_PLANE_BASE_URL → defaults to http://127.0.0.1:8788 (the
+    plist's default). Pin the literal so a future code change to the
+    default goes through review. Bearer must be set so the probe
+    actually instantiates the client (the no-bearer path short-circuits
+    before client creation, per `test_probe_returns_unavailable_when_bearer_unset`)."""
+    seen_urls = []
+
+    def capture(config):
+        seen_urls.append(config.base_url)
+        return type("FakeClient", (), {
+            "health_check": lambda self, *, timeout_s=None: HealthOk(
+                ok=True, status="ok"
+            ),
+        })()
+
+    import os as _os
+    saved_url = _os.environ.pop("LEASE_PLANE_BASE_URL", None)
+    try:
+        with patch.dict("os.environ", {"LEASE_PLANE_BEARER_TOKEN": "test-token"}, clear=False), \
+             patch("src.lease_plane.LeasePlaneClient", side_effect=capture):
+            loop = asyncio.get_running_loop()
+            await _probe()(loop)
+    finally:
+        if saved_url is not None:
+            _os.environ["LEASE_PLANE_BASE_URL"] = saved_url
+
+    assert seen_urls == ["http://127.0.0.1:8788"]


### PR DESCRIPTION
Wave 2 §\"Lease-integration boundary hardening\" — Phase C.5 follow-on to #417, finishing the boundary visibility loop.

## What this is
governance-mcp's deep-health snapshot now probes the BEAM lease-plane via the Phase C \`/v1/health\` endpoint and surfaces the result at \`checks[\"lease_plane\"]\`. The boundary is now part of the system-wide health surface (same place \`primary_db\`, \`audit_db\`, \`redis_cache\`, \`identity_continuity\` etc. live).

## Three-state mapping
- **HealthOk** → \`{status: \"healthy\", ok: true, url: ...}\`
- **HealthUnavailable** with bearer configured → \`{status: \"warning\", ok: false, reason: ...}\` (boundary tried, didn't confirm — operator-actionable)
- **No \`LEASE_PLANE_BEARER_TOKEN\` configured** → \`{status: \"unavailable\", ok: false, reason: \"not configured\"}\` (mirrors the redis_cache-not-configured pattern; popped from overall-status calculation via the line-705 effective_checks special-case)
- Any internal exception → \`{status: \"error\", error: ...}\` (probe wrapped in defensive try/except so it can't poison the snapshot)

## Why this scope
The Phase A/B/C trio (PR #412/#414/#417) put the contract surfaces in place; Phase C.5 closes the loop by routing the boundary signal to operators. Without this, the dashboard \`/health/deep\` panel doesn't know the BEAM boundary exists.

## Implementation
- \`src/services/runtime_queries.py\`: new \`_probe_lease_plane_boundary(loop)\` helper; called from \`get_health_check_data\` after \`redis_cache\`. Uses \`loop.run_in_executor\` because the client is sync stdlib urllib (keeps the probe off the anyio task group).
- Same \`src/services/runtime_queries.py\` line-705 effective_checks special-case extended: lease_plane gets popped when \`status == \"unavailable\"\` (matches redis_cache pattern — opt-in components not configured for this deploy don't count toward overall status).

## Failure-safe by composition
- Probe wraps everything in \`try/except Exception\` — never raises
- LeasePlaneClient.health_check() (Phase C, #417) is itself failure-safe — never raises
- 2-second timeout (vs the 5s default for full lease ops) keeps the probe in the snapshot's fast-liveness budget

## Tests
- 7 new tests in \`tests/test_deep_health_lease_plane_probe.py\`:
  - HealthOk → healthy (with bearer set)
  - HealthUnavailable → warning + reason preserved (with bearer set)
  - **No bearer → unavailable + \"not configured\" reason** (the test-context-friendly path)
  - Import failure → error + isolated
  - Runtime exception → error + isolated
  - Env vars (BASE_URL + BEARER_TOKEN) propagate to client config
  - Default URL fallback to \`http://127.0.0.1:8788\` when env unset
- Lazy-import workaround for the runtime_queries circular-import chain (mcp_handlers/__init__ → observability → outcome_events → back to runtime_queries) — pre-warm \`src.mcp_handlers\` before importing the probe; same pattern as \`tests/test_core_metrics.py\` lazy imports.

## Test plan
- 7/7 new tests pass
- 15/15 \`TestHealthCheck\` tests pass (the no-bearer special-case keeps existing tests stable — no test surface mods required)
- Full suite: 8615/8615 (and the previously-broken \`TestKnowledgeGraphOperations\` is now passing too post-#415)
- 138/138 pre-push smoke

## Wave 2 #2 closed (this PR finishes the trio + follow-on)
- ✅ Phase A — protocol_version field (#412, deployed)
- ✅ Phase B — error translation table (#414, deployed)
- ✅ Phase C — /v1/health endpoint + client method (#417, deployed)
- ✅ Phase C.5 — deep-health surface integration (this PR)