### PR TITLE
feat(wave-2): inject protocol_version into auth-layer 401/503 responses (Phase A.5)

### DIFF
--- a/elixir/lease_plane/lib/unitares_lease_plane/http_auth.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/http_auth.ex
@@ -84,9 +84,19 @@ defmodule UnitaresLeasePlane.HTTPAuth do
   end
 
   defp send_json(conn, status, body) do
+    # Wave 2 §"Lease-integration boundary hardening" — Phase A.5 follow-on
+    # to #412. The router's `json/3` helper injects `protocol_version` on
+    # every response; this auth-layer helper has to do the same so a Python
+    # client probing /v1/health (or any auth-gated endpoint) doesn't see an
+    # envelope-shape mismatch on 401/503 vs 200. Pre-Phase-A.5 the auth 401
+    # body was missing `protocol_version` and the Phase A test pinned that
+    # gap (`refute Map.has_key?(decoded, "protocol_version")` on the 401
+    # path). Phase A.5 closes the gap; that test inverts.
+    versioned = Map.put(body, :protocol_version, UnitaresLeasePlane.HTTPRouter.protocol_version())
+
     conn
     |> put_resp_content_type("application/json")
-    |> send_resp(status, Jason.encode!(body))
+    |> send_resp(status, Jason.encode!(versioned))
     |> halt()
   end
 end

--- a/elixir/lease_plane/test/health_test.exs
+++ b/elixir/lease_plane/test/health_test.exs
@@ -6,9 +6,8 @@ defmodule UnitaresLeasePlane.HTTPRouter.HealthTest do
   - 200 with `{ok: true, status: "ok"}` envelope
   - `protocol_version` injected by the shared `json/3` helper
   - Bearer auth applies (consistent with other /v1/* routes)
-  - Missing/wrong bearer → 401 (auth-layer 401 still does NOT carry
-    protocol_version per the documented Phase A gap; pinned in
-    `protocol_version_test.exs`)
+  - Missing/wrong bearer → 401 (auth-layer 401 carries protocol_version
+    too as of Phase A.5; pinned in `protocol_version_test.exs`)
   - GET-only — POST returns 404 (Plug.Router won't match a different verb)
 
   The Python test (`tests/test_lease_plane_health_check.py`) pins the

--- a/elixir/lease_plane/test/protocol_version_test.exs
+++ b/elixir/lease_plane/test/protocol_version_test.exs
@@ -90,16 +90,11 @@ defmodule UnitaresLeasePlane.HTTPRouter.ProtocolVersionTest do
     assert decoded["protocol_version"] == HTTPRouter.protocol_version()
   end
 
-  test "401 permission_denied response carries protocol_version", ctx do
-    # Auth-layer 401 is emitted by http_auth.ex, not the typed-error router
-    # arm. Pre-Wave-2 the auth response did not go through the json/3 helper
-    # — it built its body inline. If a future refactor adds protocol_version
-    # to the auth layer too, update this test to assert it. Today the auth
-    # 401 path SKIPS the router's json/3 helper (Plug.Conn.send_resp is
-    # called directly with a JSON-encoded literal body), so we only assert
-    # the JSON envelope shape — NOT protocol_version. The gap is documented
-    # for a follow-up; the contract Wave 2 §A wedge ships covers the typed
-    # response shapes.
+  test "401 permission_denied response carries protocol_version (Phase A.5)", ctx do
+    # Phase A.5 (this PR's predecessor for the auth-layer follow-on) routes
+    # the auth-layer 401/503 bodies through a versioned wrapper so the
+    # envelope shape matches every other response. Pre-Phase-A.5 this test
+    # `refute`d the field's presence and documented the gap.
     resp =
       :post
       |> conn("/v1/lease/acquire", Jason.encode!(%{
@@ -114,11 +109,57 @@ defmodule UnitaresLeasePlane.HTTPRouter.ProtocolVersionTest do
       |> HTTPRouter.call(@opts)
 
     assert resp.status == 401
-    # Documented gap: protocol_version is NOT yet emitted on auth-layer 401.
-    # Phase A of the boundary-hardening series ships the typed-error contract
-    # surfaces only.
     decoded = parsed(resp)
-    refute Map.has_key?(decoded, "protocol_version")
+    assert decoded["error"] == "permission_denied"
+    assert decoded["protocol_version"] == HTTPRouter.protocol_version()
+  end
+
+  test "401 missing-Authorization-header response carries protocol_version (Phase A.5)", ctx do
+    # The other auth-failure path: no Authorization header at all (vs wrong
+    # token above). Both go through the same send_json helper, so both must
+    # carry protocol_version post-Phase-A.5.
+    resp =
+      :post
+      |> conn("/v1/lease/acquire", Jason.encode!(%{
+           surface_id: ctx.surface,
+           holder_agent_uuid: random_uuid(),
+           holder_kind: "local_beam",
+           holder_class: "process_instance",
+           ttl_s: 30
+         }))
+      |> put_req_header("content-type", "application/json")
+      |> HTTPRouter.call(@opts)
+
+    assert resp.status == 401
+    decoded = parsed(resp)
+    assert decoded["protocol_version"] == HTTPRouter.protocol_version()
+  end
+
+  test "503 token-not-configured response carries protocol_version (Phase A.5)", ctx do
+    # The fail-closed path when no bearer token is configured at all.
+    # Auth plug returns 503 service_unavailable — must also be versioned.
+    Application.put_env(:lease_plane, :bearer_token, nil)
+
+    resp =
+      :post
+      |> conn("/v1/lease/acquire", Jason.encode!(%{
+           surface_id: ctx.surface,
+           holder_agent_uuid: random_uuid(),
+           holder_kind: "local_beam",
+           holder_class: "process_instance",
+           ttl_s: 30
+         }))
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer anything")
+      |> HTTPRouter.call(@opts)
+
+    # Restore for sibling tests.
+    Application.put_env(:lease_plane, :bearer_token, @bearer)
+
+    assert resp.status == 503
+    decoded = parsed(resp)
+    assert decoded["error"] == "service_unavailable"
+    assert decoded["protocol_version"] == HTTPRouter.protocol_version()
   end
 
   test "happy path response shape is unchanged apart from the new field", ctx do


### PR DESCRIPTION
Wave 2 §\"Lease-integration boundary hardening\" — Phase A.5 follow-on to #412/#414/#417/#418.

## What this is
Closes the documented Phase A gap: \`http_auth.ex\`'s \`send_json\` helper builds the JSON body inline via \`Plug.Conn.send_resp\`, skipping the router's \`json/3\` helper that injects \`protocol_version\`. Pre-Phase-A.5 the auth-layer 401 (wrong/missing bearer) and 503 (no bearer configured) responses were the only paths from /v1/* that didn't carry the version field.

The Phase A test (\`protocol_version_test.exs\`) explicitly pinned the gap with \`refute Map.has_key?(decoded, \"protocol_version\")\` on the 401 path. This PR inverts that to \`assert decoded[\"protocol_version\"] == HTTPRouter.protocol_version()\` and adds two siblings.

## Why this scope
A Python client probing \`/v1/health\` (or any auth-gated endpoint) sees protocol_version on the 200 path but NOT on the 401/503 paths. That's an envelope-shape inconsistency — minor for the rollout grace window where mismatches just log WARNING, but eliminating it makes the contract uniform: every JSON response from this service carries protocol_version. Future phase that tightens the mismatch to a hard fail (\`A′\` in the original boundary-hardening plan) needs the contract to already be uniform.

## Implementation
\`elixir/lease_plane/lib/unitares_lease_plane/http_auth.ex\`: \`send_json\` now wraps the body via \`Map.put(body, :protocol_version, UnitaresLeasePlane.HTTPRouter.protocol_version())\` before encoding. Single point of change — auth plug already routes both 401 and 503 paths through this helper.

## Tests
Three updates / additions in \`protocol_version_test.exs\`:
- **Inverted**: \"401 permission_denied response carries protocol_version (Phase A.5)\" — was \`refute\`, now \`assert\`
- **New**: \"401 missing-Authorization-header response carries protocol_version (Phase A.5)\" — covers the no-header path
- **New**: \"503 token-not-configured response carries protocol_version (Phase A.5)\" — covers the fail-closed path when \`:bearer_token\` is unset

\`health_test.exs\` docstring updated to remove the reference to the now-closed gap.

## Test plan
- 56/56 Elixir lease_plane tests (3 added, 1 inverted, all passing)
- Full Python suite: 8614/8614
- 138/138 pre-push smoke

## Wave 2 #2 ledger (uniform-envelope contract closed)
- ✅ Phase A — protocol_version on router responses (#412)
- ✅ Phase B — error translation table (#414)
- ✅ Phase C — /v1/health endpoint + client method (#417)
- ✅ Phase C.5 — deep-health snapshot integration (#418)
- ✅ **Phase A.5 — auth-layer 401/503 also carries protocol_version (this PR)**

## Next-up if you want to keep going
Dashboard \`lease_plane\` panel — surface the new health check on \`dashboard/index.html\` alongside \`primary_db\`/\`audit_db\`/\`redis_cache\`. Single-file panel addition; turns the new probe into operator-visible signal. Or pivot off Wave 2 entirely.