### PR TITLE
feat(dashboard): system-health panel surfacing /health/deep snapshot (incl. lease_plane)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -34,6 +34,7 @@
     <script src="/dashboard/watcher.js"></script>
     <script src="/dashboard/sentinel.js"></script>
     <script src="/dashboard/vigil.js"></script>
+    <script src="/dashboard/system-health.js"></script>
 </head>
 
 <body>
@@ -84,6 +85,7 @@
         <a href="#watcher-section" class="section-nav-item" data-section="watcher-section">Watcher</a>
         <a href="#sentinel-section" class="section-nav-item" data-section="sentinel-section">Sentinel</a>
         <a href="#vigil-section" class="section-nav-item" data-section="vigil-section">Vigil</a>
+        <a href="#system-health-section" class="section-nav-item" data-section="system-health-section">Health</a>
         <a href="/phase" style="margin-left:auto; opacity:0.6; padding:6px 14px; border-radius:20px; font-size:0.8rem; font-weight:500; color:var(--text-secondary); text-decoration:none; white-space:nowrap;">Phase Space &rarr;</a>
     </nav>
 
@@ -633,6 +635,46 @@
             <div class="vigil-stream" id="vigil-writes"></div>
             <div class="fleet-metrics-meta">
                 <span id="vigil-meta" class="fleet-metrics-scrape-status"></span>
+            </div>
+        </div>
+
+        <!-- System Health — surfaces the deep-health snapshot built by
+             deep_health_probe_task (every 30s) and read from a cached
+             in-memory snapshot at /health/deep. Each row is one check
+             from src/services/runtime_queries.get_health_check_data:
+             primary_db / audit_db / redis_cache / knowledge_graph /
+             calibration / lease_plane / etc. The lease_plane row is
+             Wave 2 Phase C.5 (#418), routing the BEAM↔Python boundary
+             into the operator-visible surface. -->
+        <div class="panel" id="system-health-section">
+            <div class="panel-header">
+                <h2>System Health</h2>
+                <div class="panel-controls">
+                    <span id="system-health-overall" class="system-health-overall system-health-status-unknown">—</span>
+                    <button id="system-health-refresh" class="panel-button" type="button">Refresh</button>
+                </div>
+            </div>
+            <div class="system-health-counts">
+                <div class="system-health-stat system-health-status-healthy">
+                    <span class="system-health-stat-label">healthy</span>
+                    <span class="system-health-stat-value" id="system-health-count-healthy">—</span>
+                </div>
+                <div class="system-health-stat system-health-status-warning">
+                    <span class="system-health-stat-label">warning</span>
+                    <span class="system-health-stat-value" id="system-health-count-warning">—</span>
+                </div>
+                <div class="system-health-stat system-health-status-unavailable">
+                    <span class="system-health-stat-label">unavailable</span>
+                    <span class="system-health-stat-value" id="system-health-count-unavailable">—</span>
+                </div>
+                <div class="system-health-stat system-health-status-error">
+                    <span class="system-health-stat-label">error</span>
+                    <span class="system-health-stat-value" id="system-health-count-error">—</span>
+                </div>
+            </div>
+            <div class="system-health-grid" id="system-health-grid"></div>
+            <div class="fleet-metrics-meta">
+                <span id="system-health-meta" class="fleet-metrics-scrape-status"></span>
             </div>
         </div>
 

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -5671,3 +5671,143 @@ main {
 .rp-status-error    { background: rgba(220,80,80,0.20);  color: #f08080; }
 .rp-status-unresolved { background: rgba(120,120,140,0.15); color: #909098; }
 .rp-status-init     { background: rgba(120,120,140,0.10); color: #909098; }
+
+/* ---------------------------------------------------------------------- */
+/* System Health panel — Wave 2 Phase C.5 (#418) deep-health surface.     */
+/* Reuses the .panel container; provides its own counts + grid layout.    */
+/* ---------------------------------------------------------------------- */
+
+.system-health-counts {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 12px;
+    margin-bottom: 16px;
+}
+.system-health-stat {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    padding: 10px 14px;
+    border-radius: 8px;
+    background: rgba(255,255,255,0.03);
+    border: 1px solid rgba(255,255,255,0.06);
+}
+.system-health-stat-label {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-secondary);
+}
+.system-health-stat-value {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1.4rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.system-health-overall {
+    display: inline-block;
+    padding: 4px 12px;
+    border-radius: 14px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-right: 12px;
+}
+
+.system-health-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 8px;
+}
+.system-health-row {
+    display: grid;
+    grid-template-columns: 200px 100px 1fr;
+    gap: 12px;
+    align-items: center;
+    padding: 8px 12px;
+    border-radius: 6px;
+    background: rgba(255,255,255,0.02);
+    border-left: 3px solid transparent;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.85rem;
+}
+.system-health-row-name {
+    color: var(--text-primary);
+    font-weight: 500;
+}
+.system-health-row-status {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-secondary);
+}
+.system-health-row-detail {
+    color: var(--text-secondary);
+    font-size: 0.78rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* Status colors — match the runtime_queries vocabulary. Distinct from the
+   severity scale (.sentinel-stat-sev-*) so operators don't conflate
+   "service unreachable" with "high-severity finding". */
+.system-health-status-healthy {
+    border-left-color: #7fdc8f;
+}
+.system-health-status-healthy .system-health-row-status,
+.system-health-status-healthy.system-health-overall,
+.system-health-status-healthy .system-health-stat-value {
+    color: #7fdc8f;
+}
+
+.system-health-status-warning {
+    border-left-color: #f1c860;
+}
+.system-health-status-warning .system-health-row-status,
+.system-health-status-warning.system-health-overall,
+.system-health-status-warning .system-health-stat-value {
+    color: #f1c860;
+}
+
+.system-health-status-unavailable {
+    border-left-color: #909098;
+}
+.system-health-status-unavailable .system-health-row-status,
+.system-health-status-unavailable.system-health-overall,
+.system-health-status-unavailable .system-health-stat-value {
+    color: #a8a8b4;
+}
+
+.system-health-status-error {
+    border-left-color: #f08080;
+}
+.system-health-status-error .system-health-row-status,
+.system-health-status-error.system-health-overall,
+.system-health-status-error .system-health-stat-value {
+    color: #f08080;
+}
+
+.system-health-status-unknown {
+    border-left-color: rgba(255,255,255,0.1);
+}
+.system-health-status-unknown .system-health-row-status,
+.system-health-status-unknown.system-health-overall {
+    color: var(--text-secondary);
+}
+
+.system-health-empty {
+    padding: 20px;
+    text-align: center;
+    color: var(--text-secondary);
+    font-style: italic;
+}
+
+.system-health-meta-stale {
+    color: #f08080;
+    font-weight: 500;
+}

--- a/dashboard/system-health.js
+++ b/dashboard/system-health.js
@@ -1,0 +1,218 @@
+// system-health.js — System Health panel.
+//
+// Consumes:
+//   GET /health/deep — cached snapshot from deep_health_probe_task
+//                      (src/services/runtime_queries.py::get_health_check_data)
+//
+// Surfaces the per-component check matrix that operators previously had to
+// curl by hand: primary_db / audit_db / redis_cache / knowledge_graph /
+// calibration / agent_metadata / data_directory / pi_connectivity /
+// telemetry / identity_continuity / lease_plane (added 2026-05-08, Wave 2
+// Phase C.5 #418). Each row shows status badge + a short detail line.
+//
+// No charts in this panel — Chart.js setup is intentionally NOT applied.
+// Just authFetch + DOM rendering.
+//
+// Auth + fetch go through `authFetch` from utils.js.
+
+(function () {
+    'use strict';
+
+    async function fetchDeepHealth() {
+        try {
+            var resp = await authFetch('/health/deep');
+            if (resp.status === 503) {
+                // Probe task hasn't populated the cache yet — surface that
+                // explicitly rather than treating as a fetch error.
+                return { _not_yet_populated: true };
+            }
+            if (!resp.ok) throw new Error('HTTP ' + resp.status);
+            return await resp.json();
+        } catch (e) {
+            console.warn('[SystemHealth] deep fetch failed:', e);
+            return null;
+        }
+    }
+
+    function setMetric(id, value) {
+        var el = document.getElementById(id);
+        if (el) el.textContent = value;
+    }
+
+    function statusBadgeClass(status) {
+        // Maps the runtime_queries status vocabulary to themed classes.
+        // Matches the four status colors used in sentinel-stat-sev-* (kept
+        // visually distinct from the severity scale).
+        switch (status) {
+            case 'healthy':     return 'system-health-status-healthy';
+            case 'warning':     return 'system-health-status-warning';
+            case 'unavailable': return 'system-health-status-unavailable';
+            case 'deprecated':  return 'system-health-status-warning';
+            case 'error':       return 'system-health-status-error';
+            default:            return 'system-health-status-unknown';
+        }
+    }
+
+    function shortDetailFor(name, check) {
+        // Per-check detail line: human-readable, max ~80 chars. Pulls the
+        // most informative single field per check rather than dumping JSON.
+        if (!check || typeof check !== 'object') return '';
+        if (check.error) return String(check.error);
+        if (check.reason) return String(check.reason);
+        switch (name) {
+            case 'primary_db':
+                if (check.info && check.info.pool_size != null) {
+                    return 'pool=' + check.info.pool_size + ' ' +
+                           (check.configured_backend || '');
+                }
+                return check.configured_backend || '';
+            case 'redis_cache':
+                if (check.present === false) return 'not configured';
+                if (check.stats && check.stats.keyspace_hit_rate_percent != null) {
+                    return 'hit ' + check.stats.keyspace_hit_rate_percent + '%';
+                }
+                return '';
+            case 'lease_plane':
+                return check.url || '';
+            case 'calibration':
+                if (check.pending_updates != null) {
+                    return 'pending=' + check.pending_updates;
+                }
+                return '';
+            case 'identity_continuity':
+                return check.mode || '';
+            case 'pi_connectivity':
+                if (check.reachable === false) return 'unreachable';
+                return '';
+            case 'knowledge_graph':
+                if (check.warning) return String(check.warning);
+                return '';
+            case 'telemetry':
+                if (check.audit_log_exists === false) return 'audit log missing';
+                return '';
+            case 'data_directory':
+                if (check.exists === false) return 'data dir missing';
+                return '';
+            default:
+                return '';
+        }
+    }
+
+    function renderOverall(snapshot) {
+        var status = snapshot.status || 'unknown';
+        var breakdown = snapshot.status_breakdown || {};
+        var overallEl = document.getElementById('system-health-overall');
+        if (overallEl) {
+            overallEl.textContent = status;
+            // Reset class list to avoid pile-up on repeated refreshes.
+            overallEl.className = 'system-health-overall ' + statusBadgeClass(status);
+        }
+        setMetric('system-health-count-healthy', breakdown.healthy || 0);
+        setMetric('system-health-count-warning', breakdown.warning || 0);
+        setMetric('system-health-count-unavailable', breakdown.unavailable || 0);
+        setMetric('system-health-count-error', breakdown.error || 0);
+    }
+
+    function renderChecks(snapshot) {
+        var grid = document.getElementById('system-health-grid');
+        if (!grid) return;
+        grid.innerHTML = '';
+        var checks = snapshot.checks || {};
+        var names = Object.keys(checks).sort();
+        if (names.length === 0) {
+            var empty = document.createElement('div');
+            empty.className = 'system-health-empty';
+            empty.textContent = 'No checks present in snapshot.';
+            grid.appendChild(empty);
+            return;
+        }
+        names.forEach(function (name) {
+            var check = checks[name];
+            var status = (check && check.status) || 'unknown';
+            var row = document.createElement('div');
+            row.className = 'system-health-row ' + statusBadgeClass(status);
+            row.innerHTML =
+                '<span class="system-health-row-name"></span>' +
+                '<span class="system-health-row-status"></span>' +
+                '<span class="system-health-row-detail"></span>';
+            row.children[0].textContent = name;
+            row.children[1].textContent = status;
+            row.children[2].textContent = shortDetailFor(name, check);
+            grid.appendChild(row);
+        });
+    }
+
+    function renderMeta(snapshot) {
+        var meta = document.getElementById('system-health-meta');
+        if (!meta) return;
+        var cache = snapshot._cache || {};
+        var ageSec = cache.age_seconds;
+        var stale = cache.stale;
+        if (ageSec == null) {
+            meta.textContent = 'snapshot age unknown';
+            return;
+        }
+        var label = 'snapshot ' + ageSec.toFixed(0) + 's old';
+        if (stale) label += ' · STALE';
+        meta.textContent = label;
+        meta.classList.toggle('system-health-meta-stale', !!stale);
+    }
+
+    function renderUnavailableState() {
+        var grid = document.getElementById('system-health-grid');
+        if (grid) {
+            grid.innerHTML = '';
+            var msg = document.createElement('div');
+            msg.className = 'system-health-empty';
+            msg.textContent = 'Deep-health probe has not run yet — retry in a few seconds.';
+            grid.appendChild(msg);
+        }
+        var overall = document.getElementById('system-health-overall');
+        if (overall) {
+            overall.textContent = 'pending';
+            overall.className = 'system-health-overall system-health-status-unknown';
+        }
+    }
+
+    function renderErrorState() {
+        var grid = document.getElementById('system-health-grid');
+        if (grid) {
+            grid.innerHTML = '';
+            var msg = document.createElement('div');
+            msg.className = 'system-health-empty';
+            msg.textContent = 'Failed to fetch /health/deep — see browser console.';
+            grid.appendChild(msg);
+        }
+    }
+
+    async function refresh() {
+        var snapshot = await fetchDeepHealth();
+        if (!snapshot) {
+            renderErrorState();
+            return;
+        }
+        if (snapshot._not_yet_populated) {
+            renderUnavailableState();
+            return;
+        }
+        renderOverall(snapshot);
+        renderChecks(snapshot);
+        renderMeta(snapshot);
+    }
+
+    function wire() {
+        var btn = document.getElementById('system-health-refresh');
+        if (btn) btn.addEventListener('click', refresh);
+        refresh();
+        // Light auto-refresh — match the deep-health probe cadence (30s).
+        setInterval(refresh, 30000);
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', wire);
+    } else {
+        wire();
+    }
+
+    window.SystemHealthPanel = { refresh: refresh };
+})();

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -858,6 +858,7 @@ async def http_dashboard_static(request):
         "dialectic.js", "eisv-charts.js", "timeline.js",
         "residents.js", "fleet-metrics.js", "watcher.js", "sentinel.js",
         "vigil.js", "resident-progress.js",
+        "system-health.js",
         "styles.css", "dashboard.js",
         "phase.js",
     ]


### PR DESCRIPTION
Surfaces the deep-health snapshot built by \`deep_health_probe_task\` (every 30s, cached at \`src/services/health_snapshot.py\`) on the operator dashboard. Each row of the new panel is one check from \`get_health_check_data\` — \`primary_db\`, \`audit_db\`, \`redis_cache\`, \`knowledge_graph\`, \`calibration\`, \`telemetry\`, \`identity_continuity\`, \`agent_metadata\`, \`data_directory\`, \`pi_connectivity\`, and the new \`lease_plane\` row added in PR #418 (Wave 2 Phase C.5).

Pre-this-PR, operators had to \`curl /health/deep\` to see the boundary status. Post-this-PR it's a dashboard panel with status badges, breakdown counts, and an auto-refresh tied to the probe cadence.

## Files
- **\`dashboard/system-health.js\`** (new): authFetch \`/health/deep\`, render counts + per-check rows. No Chart.js (pure status grid). 30s auto-refresh matches probe cadence. Handles the 503 \"snapshot not yet populated\" path explicitly. \`window.SystemHealthPanel.refresh\` exported for manual triggering.
- **\`dashboard/index.html\`**:
  - Script tag \`<script src=\"/dashboard/system-health.js\"></script>\` (non-deferred per dashboard-skill convention)
  - Top-nav link \`Health\` → \`#system-health-section\`
  - New panel container after \`#vigil-section\`
- **\`dashboard/styles.css\`** (+~140 lines): \`.system-health-*\` classes for counts grid, status overall badge, per-check row layout (200px name / 100px status / flex detail), and four status colors mapping the runtime_queries vocabulary (\`healthy\` / \`warning\` / \`unavailable\` / \`error\`). Status colors are deliberately distinct from \`.sentinel-stat-sev-*\` so operators don't conflate \"service unavailable\" with \"high-severity finding\".
- **\`src/http_api.py\`**: \`system-health.js\` added to \`http_dashboard_static\`'s allowlist (an unlisted file returns JSON \`{\"error\":\"File not allowed\"}\` instead of 404, which the browser silently fails on).

## Dashboard-skill checklist (per the \`unitares-dashboard\` skill)
- ✅ Allowlist updated
- ✅ Script tag added without \`defer\`
- ✅ \`authFetch\` from utils.js (no private token helper)
- ❌ N/A: Chart.js defaults — no chart in this panel
- ❌ N/A: option structure copy — no chart
- ❌ N/A: MetricColors.HEX — no chart series
- ✅ Panel container \`<div class=\"panel\" id=\"system-health-section\">\` with \`.panel-header\`
- ❌ N/A: chart wrapper height/contain — no chart
- ❌ N/A: canvas sizing — no canvas
- ✅ Nav link with matching \`data-section\`

## Tests
- \`tests/test_dashboard_static_allowlist.py::test_every_index_html_reference_is_allowed\` passes — catches missing allowlist entry
- Full Python suite: 8615/8615
- 138/138 pre-push smoke

## Browser verification
After merge + governance-mcp restart, the verification flow per the dashboard skill:
1. \`curl http://127.0.0.1:8767/dashboard/system-health.js | head -1\` — must be JS, not \`{\"error\":...}\`
2. Hard-refresh dashboard, scroll to \"System Health\" panel
3. DevTools → Network tab — confirm \`system-health.js\` 200, no 4xx
4. Confirm 12 rows visible, each with name + status + detail
5. Click \"Refresh\" — counts + rows update; the \`lease_plane\` row should show \`healthy\` with \`http://127.0.0.1:8788\` in the detail

## Related
- Wave 2 #2 (boundary hardening) closed by #412/#414/#417/#418/#419; this PR makes the new boundary signal operator-visible.