### PR TITLE
fix(watcher): auto-sweep stale findings before chime

### DIFF
--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -93,6 +93,7 @@ from agents.watcher.findings import (
     _label_for_other_worktree,
     _partition_findings_by_scope,
     _resolve_session_scope_root,
+    _sweep_stale_quiet,
     _write_findings_atomic,
     compact_findings,
     escalate,
@@ -1044,7 +1045,14 @@ def surface_pending() -> int:
     high-severity queue drains. This prevents the silent-drop bug where
     medium findings were previously marked surfaced without the user ever
     seeing them.
+
+    Auto-sweep on entry: drops findings whose target file no longer
+    exists before computing the chime. Closes the failure mode observed
+    on 2026-05-07 dogfood — 36% of open findings (48/132) were dangling
+    against deleted worktree paths, inflating chime severity rankings.
+    Quiet so it doesn't pollute the chime block stdout.
     """
+    _sweep_stale_quiet()
     all_findings = _iter_findings_raw()
     open_findings = [f for f in all_findings if f.get("status", "open") == "open"]
 

--- a/agents/watcher/findings.py
+++ b/agents/watcher/findings.py
@@ -380,17 +380,20 @@ def update_finding_status(
     return 0
 
 
-def sweep_stale_findings() -> int:
-    """Drop findings whose target file no longer exists on disk.
+def _sweep_stale_quiet() -> int:
+    """Drop findings whose target file no longer exists. Quiet variant.
 
-    This is the "the file got deleted or renamed" cleanup — we don't want
-    the surface hook to keep nagging you about a file that isn't there
-    anymore. Open/surfaced findings get aged_out via this path too because
-    there's no code to evaluate.
+    Returns the count dropped. Logs to the watcher log when non-zero but
+    never prints — safe to call from chime/SessionStart paths where
+    stdout becomes part of the agent context. Called by ``surface_pending``
+    (chime) so the chime never shows findings against deleted paths
+    without the operator having to remember to run --sweep-stale.
+
+    Same logic as ``sweep_stale_findings``, factored so the CLI variant
+    can stay print-y while the auto-call-site stays silent.
     """
     findings = _iter_findings_raw()
     if not findings:
-        print("(no findings to sweep)")
         return 0
 
     kept: list[dict[str, Any]] = []
@@ -403,12 +406,35 @@ def sweep_stale_findings() -> int:
             dropped += 1
 
     if dropped == 0:
-        print(f"(nothing to sweep: {len(findings)} findings, all target files present)")
         return 0
 
     _write_findings_atomic(kept)
-    log(f"sweep_stale_findings: dropped {dropped} findings for missing files")
-    print(f"ok: dropped {dropped} finding(s) with missing target files, kept {len(kept)}")
+    log(f"sweep_stale_findings (auto): dropped {dropped} findings for missing files")
+    return dropped
+
+
+def sweep_stale_findings() -> int:
+    """Drop findings whose target file no longer exists on disk.
+
+    CLI variant: prints a human-readable summary. The chime/auto-call
+    path uses ``_sweep_stale_quiet`` instead — same drop logic, no stdout.
+
+    This is the "the file got deleted or renamed" cleanup — we don't want
+    the surface hook to keep nagging you about a file that isn't there
+    anymore. Open/surfaced findings get aged_out via this path too because
+    there's no code to evaluate.
+    """
+    findings = _iter_findings_raw()
+    if not findings:
+        print("(no findings to sweep)")
+        return 0
+
+    total = len(findings)
+    dropped = _sweep_stale_quiet()
+    if dropped == 0:
+        print(f"(nothing to sweep: {total} findings, all target files present)")
+        return 0
+    print(f"ok: dropped {dropped} finding(s) with missing target files, kept {total - dropped}")
     return 0
 
 

--- a/agents/watcher/tests/test_agent.py
+++ b/agents/watcher/tests/test_agent.py
@@ -722,7 +722,7 @@ def _make_raw_entry(
     fingerprint: str,
     *,
     pattern: str = "P001",
-    file: str = "/tmp/seeded.py",
+    file: str = str(Path(__file__).resolve()),
     line: int = 10,
     status: str = "open",
     detected_at: str = "2026-04-11T00:00:00Z",
@@ -1364,6 +1364,41 @@ def test_surface_pending_transitions_open_to_surfaced(watcher_module):
     assert after["open____00000000"] == "surfaced"
     # Already-surfaced findings stay surfaced (no-op on them)
     assert after["surfac__00000000"] == "surfaced"
+
+
+def test_surface_pending_auto_sweeps_stale_before_chime(watcher_module, tmp_path, capsys):
+    """surface_pending must drop findings whose target file has vanished
+    *before* computing the chime — closes the 2026-05-07 dogfood failure
+    mode where 36% of open findings were dangling against deleted worktree
+    paths and inflating chime severity rankings.
+    """
+    real = tmp_path / "real.py"
+    real.write_text("print('hi')\n")
+    missing = tmp_path / "deleted-worktree" / "ghost.py"  # never created
+
+    _seed_findings(
+        watcher_module,
+        [
+            _make_raw_entry("real____00000000", file=str(real), status="open"),
+            _make_raw_entry("ghost___00000000", file=str(missing), status="open"),
+        ],
+    )
+
+    rc = watcher_module.surface_pending()
+    assert rc == 0
+
+    after = {f["fingerprint"]: f["status"] for f in watcher_module._iter_findings_raw()}
+    # Real-file finding survives and gets surfaced
+    assert after["real____00000000"] == "surfaced"
+    # Stale finding is gone — auto-sweep dropped it before the chime ran
+    assert "ghost___00000000" not in after
+
+    # Sweep must be silent: chime stdout contains the real finding only,
+    # not "dropped N findings" CLI text.
+    captured = capsys.readouterr()
+    assert "ghost.py" not in captured.out
+    assert "dropped" not in captured.out
+    assert str(real) in captured.out
 
 
 def test_surface_pending_only_prints_when_there_are_new_open_findings(
@@ -2651,10 +2686,18 @@ class TestWatcherCheckin:
     """Check-in appended to surface_pending()."""
 
     def _write_findings(self, watcher_module, findings: list[dict]):
-        """Helper: write findings to the isolated findings.jsonl."""
+        """Helper: write findings to the isolated findings.jsonl.
+
+        Rewrites the ``file`` field on each entry to point at this test
+        file so the auto-sweep on ``surface_pending`` doesn't drop them.
+        Tests that exercise the sweep itself use ``_seed_findings`` +
+        ``_make_raw_entry(file=...)`` instead.
+        """
+        real_path = str(Path(__file__).resolve())
         watcher_module.FINDINGS_FILE.parent.mkdir(parents=True, exist_ok=True)
         with watcher_module.FINDINGS_FILE.open("w") as f:
             for finding in findings:
+                finding = {**finding, "file": real_path}
                 f.write(json.dumps(finding) + "\n")
 
     def test_checkin_posts_summary_after_surface(self, watcher_module, monkeypatch):
@@ -2967,14 +3010,17 @@ class TestWatcherLifecycleIntegration:
         from agents.watcher import agent as real_watcher
         monkeypatch.setattr(real_watcher, "_watcher_identity", watcher_module.get_watcher_identity())
 
-        # 2. Simulate a finding being persisted
+        # 2. Simulate a finding being persisted. File must actually exist
+        # on disk so the auto-sweep on surface_pending doesn't drop it.
+        test_code_path = tmp_path / "test_code.py"
+        test_code_path.write_text("# placeholder\n")
         watcher_module.FINDINGS_FILE.parent.mkdir(parents=True, exist_ok=True)
         finding = {
             "fingerprint": "integ00000000000",
             "status": "open",
             "severity": "high",
             "pattern": "P004",
-            "file": str(tmp_path / "test_code.py"),
+            "file": str(test_code_path),
             "line": 42,
             "hint": "asyncpg in handler",
             "violation_class": "REC",


### PR DESCRIPTION
## Summary
Closes one of the three structural failure modes from the 2026-05-07 deep-dogfood thread: **the chime accumulating findings against deleted worktree paths**.

`surface_pending` (UserPromptSubmit hook) read findings.jsonl with no GC. When a worktree was deleted via \`git worktree remove\`, any open/surfaced finding against that path stayed in the chime forever. On 2026-05-07 a single \`--sweep-stale\` dropped **48 of 132 open findings (36% of the backlog)** — all dangling against removed paths. Severity rankings were lying: a HIGH against a deleted worktree is not a HIGH against the running fleet.

## Fix
- New private helper \`_sweep_stale_quiet()\` in \`agents/watcher/findings.py\` — same drop logic as the existing \`sweep_stale_findings\`, but no stdout. \`surface_pending\` calls it before computing the chime block.
- The CLI \`sweep_stale_findings\` remains print-y (delegates to the quiet helper, prints a one-line summary).
- Auto-sweep is silent — chime stdout never carries \"dropped N findings\" text into the agent's context window.

## Why surface_pending and not print_unresolved
\`print_unresolved\` (SessionStart) is documented as **read-only by design** (\"so session starts never accidentally reshape the findings state\"). Auto-sweep belongs in the chime path, which already mutates state (open → surfaced transitions). Within minutes of any session, the chime fires and cleanup happens.

## Test plan
- [x] New: \`test_surface_pending_auto_sweeps_stale_before_chime\` — finding whose file was deleted is dropped before chime; sweep stays silent (no \"dropped\" text in chime stdout); finding with real file survives and gets surfaced.
- [x] Defensive: \`_make_raw_entry\` default \`file\` moved from \`/tmp/seeded.py\` (which doesn't exist) to the test file path, so existing surface_pending tests don't get accidentally swept.
- [x] \`TestWatcherCheckin\` / \`TestWatcherResolution\` \`_write_findings\` helpers rewrite each entry's file field to the test file path (their inline \`/tmp/x.py\` paths would otherwise be swept and break the lifecycle/check-in summary assertions).
- [x] \`TestWatcherLifecycleIntegration.test_full_lifecycle\` now creates \`test_code.py\` on disk so its finding survives the sweep.
- [x] All 135 watcher tests pass
- [x] Full test-cache: 8616 passed, 34 skipped, 0 failed

## Companion to
- #415 — migration 037 (knowledge.discoveries.provenance_chain column missing) [merged]
- #416 — doctor column-drift check (closes the recurring schema-drift blind spot) [merged]

This PR closes the third recurring failure mode identified that session: watcher chime crying wolf at 36% noise floor. **The integration-test gap for \`kg_add_discovery\` (which let the provenance_chain bug ship) is still open** — separate PR.