### PR TITLE
fix(identity): reject free-text client_hint to stop descriptor-as-identifier leak

### DIFF
--- a/src/mcp_handlers/identity/resolution.py
+++ b/src/mcp_handlers/identity/resolution.py
@@ -74,6 +74,25 @@ def _audit_session_resolve_miss(
 # AGENT ID GENERATION (model+date format)
 # =============================================================================
 
+_CLIENT_HINT_SHAPE = re.compile(r"^[A-Za-z0-9_-]{1,40}$")
+
+
+def _is_valid_client_hint(client_hint: Optional[str]) -> bool:
+    """Validate client_hint is a short identifier, not free text.
+
+    `client_hint` is meant to identify the client *type* (cursor, vscode,
+    claude_desktop). Free-form descriptions ("Anthropic Claude, mobile app,
+    dogfooding UX review") must not become identifier fragments — descriptors
+    are not handles.
+    """
+    if not client_hint:
+        return False
+    stripped = client_hint.strip()
+    if stripped.lower() in ("unknown", "mcp", ""):
+        return False
+    return bool(_CLIENT_HINT_SHAPE.match(stripped))
+
+
 def _client_differs_from_model(client_hint: str, model_type: str) -> bool:
     """True if the client is a third-party wrapper, not native to the model vendor.
 
@@ -125,6 +144,11 @@ def _generate_agent_id(model_type: Optional[str] = None, client_hint: Optional[s
     """
     timestamp = datetime.now().strftime("%Y%m%d")
 
+    # Reject free-text client_hint before it can leak into the identifier.
+    # Descriptors are not handles. Invalid shapes fall through as if no hint
+    # was given.
+    valid_hint = _is_valid_client_hint(client_hint)
+
     if model_type:
         # Normalize and format model name
         model = model_type.strip()
@@ -133,15 +157,16 @@ def _generate_agent_id(model_type: Optional[str] = None, client_hint: Optional[s
         model = "_".join(word.capitalize() for word in model.split())
 
         # Third-party clients get prefixed to prevent identity confusion
-        if client_hint and _client_differs_from_model(client_hint, model_type):
+        if valid_hint and _client_differs_from_model(client_hint, model_type):
             client = client_hint.strip().replace("_", " ").replace("-", " ")
             client = "_".join(word.capitalize() for word in client.split())
             return f"{client}_{model}_{timestamp}"
 
         return f"{model}_{timestamp}"
-    elif client_hint and client_hint not in ("unknown", ""):
-        # Use client as fallback identifier
-        client = client_hint.strip().lower().replace(" ", "_")
+    elif valid_hint:
+        # Use client as fallback identifier (validator already restricts to
+        # [A-Za-z0-9_-], so .strip().lower() is sufficient).
+        client = client_hint.strip().lower()
         return f"{client}_{timestamp}"
     else:
         return f"mcp_{timestamp}"
@@ -162,9 +187,9 @@ def _generate_auto_label(model_type: Optional[str] = None, client_hint: Optional
     """
     parts = []
 
-    # Client type first (if meaningful)
-    if client_hint and client_hint not in ("unknown", "", "mcp"):
-        parts.append(client_hint.strip().lower().replace(" ", "-"))
+    # Client type first (if meaningful — same shape gate as _generate_agent_id)
+    if _is_valid_client_hint(client_hint):
+        parts.append(client_hint.strip().lower())
 
     # Model family (extract short name, drop version numbers)
     if model_type:

--- a/tests/test_identity_core.py
+++ b/tests/test_identity_core.py
@@ -151,9 +151,11 @@ class TestGenerateAgentId:
         result = self.generate(client_hint="cursor")
         assert result.startswith("cursor_")
 
-    def test_with_client_hint_spaces(self):
+    def test_client_hint_with_spaces_rejected(self):
+        # Spaces are not valid in a client_hint shape — descriptors must not
+        # become identifiers. Falls through to mcp_DATE.
         result = self.generate(client_hint="my editor")
-        assert result.startswith("my_editor_")
+        assert result.startswith("mcp_")
 
     def test_fallback_no_args(self):
         result = self.generate()

--- a/tests/test_identity_helpers.py
+++ b/tests/test_identity_helpers.py
@@ -137,6 +137,54 @@ class TestGenerateAgentId:
         assert len(result) > 0
 
 
+class TestClientHintLeakRegression:
+    """Regression tests for descriptor-as-identifier leak.
+
+    A free-text client_hint must never leak into agent_id. Identifiers are
+    structured handles; descriptors are display strings. The two layers must
+    not bleed.
+
+    Original bug: passing client_hint="Anthropic Claude, mobile app, dogfooding
+    UX review" produced agent_id "Anthropic Claude, mobile app, dogfooding UX
+    review_20260508" — a sentence, used as a primary key.
+    """
+
+    def test_dogfood_descriptor_does_not_become_identifier(self):
+        bug_input = "Anthropic Claude, mobile app, dogfooding UX review"
+        result = _generate_agent_id(client_hint=bug_input)
+        assert bug_input not in result
+        assert result.startswith("mcp_")
+
+    def test_long_hint_rejected(self):
+        result = _generate_agent_id(client_hint="x" * 41)
+        assert result.startswith("mcp_")
+
+    def test_hint_with_spaces_rejected(self):
+        result = _generate_agent_id(client_hint="cursor with extra context")
+        assert result.startswith("mcp_")
+
+    def test_hint_with_punctuation_rejected(self):
+        result = _generate_agent_id(client_hint="cursor, v1.2.3")
+        assert result.startswith("mcp_")
+
+    def test_valid_short_hints_still_work(self):
+        for hint in ("cursor", "vscode", "claude_desktop", "claude-code", "chatgpt"):
+            result = _generate_agent_id(client_hint=hint)
+            assert result.startswith(f"{hint.lower()}_"), \
+                f"Expected '{hint.lower()}_...' for hint {hint!r}, got {result!r}"
+
+    def test_valid_hint_with_model_still_prefixes(self):
+        result = _generate_agent_id(model_type="claude-opus-4-5", client_hint="cursor")
+        assert "Cursor_Claude_Opus_4_5" in result
+
+    def test_invalid_hint_with_model_uses_model_only(self):
+        bug_input = "Anthropic Claude, mobile app"
+        result = _generate_agent_id(model_type="claude-opus-4-5", client_hint=bug_input)
+        assert bug_input not in result
+        assert "Claude_Opus_4_5" in result
+        assert not result.startswith("Anthropic")
+
+
 # ============================================================================
 # derive_session_key (async, signals=None uses context/stdio fallback)
 # ============================================================================


### PR DESCRIPTION
## Summary

Free-text `client_hint` was leaking into `agent_id` because both `_generate_agent_id` and `_generate_auto_label` accepted any non-empty string and folded it into the identifier with only space substitution.

Surfaced in dogfood UX review: passing `client_hint="Anthropic Claude, mobile app, dogfooding UX review"` produced `agent_id` `"Anthropic Claude, mobile app, dogfooding UX review_20260508"` — a sentence used as a primary key.

## Why this matters (ontology)

The identity ontology says: UUID is truth, agent_id is a label, descriptors come from the agent, identifiers come from the system. Letting a descriptor become an identifier collapses that layer. Memory note: "load-bearing invariants belong in code" — this PR encodes the invariant.

## Changes

- `_is_valid_client_hint(s)`: shape gate (`^[A-Za-z0-9_-]{1,40}$`, excludes "unknown"/"mcp"/"" sentinels).
- `_generate_agent_id`: invalid hints fall through as if no hint were given (mcp_DATE for label-only path, model-only for model+hint path).
- `_generate_auto_label`: same gate applied — same contract.
- Tests: regression test using the exact dogfood input plus adversarial variants (long, spaces, punctuation). Inverted pre-existing `test_with_client_hint_spaces` which was documenting the bug.

## Test plan

- [x] `pytest tests/test_identity_helpers.py tests/test_identity_session.py tests/test_identity_core.py tests/test_identity_path1_fingerprint.py` — 222 passed
- [x] Full sweep `pytest tests/` — 8080 passed, 34 skipped, 0 regressions
- [x] Pre-commit / pre-push hooks pass

## Out of scope (filed separately)

This fixes one of seven findings from the dogfood review. The rest are filed as issues:
- thread_id reformat + position reset (two-path mint between onboard and `phases.py`)
- read tools auto-mint identity (`health_check` produces orphans before onboard)
- identity surface sprawl, S22 provenance fields agent-hostile, vocabulary glossary, tool aliasing