### PR TITLE
fix(identity): backfill thread_id/node_index on existing agent_metadata entries (closes the desync upstream of #424)

### DIFF
--- a/src/agent_metadata_persistence.py
+++ b/src/agent_metadata_persistence.py
@@ -484,6 +484,26 @@ def register_minted_agent_in_dict(
     enforced here.
     """
     if agent_uuid in agent_metadata:
+        # Existing entry — typically from an auto-mint path that ran with
+        # thread_id=None default. Backfill thread_id / node_index when this
+        # call has them and the existing entry doesn't, otherwise the
+        # in-memory cache stays desynced from PG and `process_agent_update`
+        # will mint a fresh thread_id (see #424). Strict fill-only — never
+        # overwrites a non-None value.
+        existing = agent_metadata[agent_uuid]
+        backfilled = False
+        if thread_id is not None and getattr(existing, "thread_id", None) is None:
+            existing.thread_id = thread_id
+            backfilled = True
+        if node_index is not None and not getattr(existing, "node_index", None):
+            existing.node_index = node_index
+            backfilled = True
+        if backfilled:
+            logger.debug(
+                f"Backfilled thread_id/node_index on existing dict entry for "
+                f"{agent_uuid[:8]}... (was registered by an earlier path "
+                f"without thread context)"
+            )
         return False
     now = datetime.now(timezone.utc).isoformat()
     agent_metadata[agent_uuid] = AgentMetadata(

--- a/tests/test_agent_metadata.py
+++ b/tests/test_agent_metadata.py
@@ -343,6 +343,53 @@ class TestRegisterMintedAgentInDict:
         assert agent_metadata[uid].label == "prior_label"
         assert agent_metadata[uid].status == "paused"
 
+    def test_backfills_thread_id_when_existing_entry_has_none(self):
+        # Regression for #424: if an auto-mint path (e.g. process_agent_update
+        # self-create) populated agent_metadata with thread_id=None before
+        # onboard ran, onboard's register call must backfill the missing
+        # thread_id rather than short-circuiting. Otherwise the in-memory
+        # cache stays desynced from PG and phases.py mints a fresh UUID-form
+        # thread_id at the next update, resetting node_index to 1.
+        from src.agent_metadata_persistence import register_minted_agent_in_dict
+        from src.agent_metadata_model import agent_metadata, AgentMetadata
+        uid = "11111111-1111-4111-8111-111111111111"
+        # Auto-mint path: entry exists, thread_id is None.
+        agent_metadata[uid] = AgentMetadata(
+            agent_id="auto_minted", status="active",
+            created_at="2026-05-08", last_update="2026-05-08",
+        )
+        assert agent_metadata[uid].thread_id is None
+
+        # Onboard runs, has the real thread_id.
+        added = register_minted_agent_in_dict(
+            uid, thread_id="t-d588dc931ace7a3b", node_index=1,
+        )
+        assert added is False  # didn't insert; entry was already there
+        # But thread_id and node_index were filled.
+        assert agent_metadata[uid].thread_id == "t-d588dc931ace7a3b"
+        assert agent_metadata[uid].node_index == 1
+
+    def test_backfill_does_not_overwrite_existing_thread_id(self):
+        # Strict fill-only: never overwrite a non-None value, even with a
+        # different one. Protects against the inverse failure mode where
+        # an auto-mint *did* manage to record a thread_id and a later call
+        # would otherwise replace it.
+        from src.agent_metadata_persistence import register_minted_agent_in_dict
+        from src.agent_metadata_model import agent_metadata, AgentMetadata
+        uid = "22222222-2222-4222-8222-222222222222"
+        agent_metadata[uid] = AgentMetadata(
+            agent_id="prior", status="active",
+            created_at="2026-05-08", last_update="2026-05-08",
+            thread_id="t-existing000000",
+            node_index=3,
+        )
+        added = register_minted_agent_in_dict(
+            uid, thread_id="t-different00000", node_index=99,
+        )
+        assert added is False
+        assert agent_metadata[uid].thread_id == "t-existing000000"
+        assert agent_metadata[uid].node_index == 3
+
 
 class TestMirrorStatusToDict:
     def setup_method(self):


### PR DESCRIPTION
## Summary

Closes the in-memory cache desync that causes #424 (thread_id reformat + position reset mid-session) by allowing `register_minted_agent_in_dict` to backfill `thread_id` and `node_index` on existing entries when the existing values are None.

## The poison sequence (from the #424 trace)

1. An auto-mint path (e.g. `process_agent_update`'s self-create at `phases.py:737`, or any read tool that escapes the S21-a allowlist) calls `get_or_create_metadata` and lands an `AgentMetadata` in `agent_metadata` with `thread_id=None` (the dataclass default; kwargs typically don't include `thread_id`).
2. `onboard()` runs. `resolution.py:1024` generates the canonical `t-<sha>` `thread_id`, persists it to PG identity metadata, then calls `register_minted_agent_in_dict(uid, thread_id="t-d588...", ...)`.
3. The "no overwrite" early-return at line 486 fires because the entry already exists. **PG has the thread_id; in-memory does not.**
4. The first `process_agent_update` reads `ctx.meta.thread_id=None`, hits `phases.py:826-829`, mints a fresh UUID-form `thread_id`, resets `node_index` to 1. Symptom complete.

## The patch

When an existing entry has `thread_id=None` and the call has a real `thread_id`, fill it. Same for `node_index`. **Strict fill-only — never overwrites a non-None value.** The original no-clobber contract for label/status/etc. is preserved untouched.

## Why this is a defensive patch, not the full fix

The upstream cause is the auto-mint paths themselves — that's #425. This PR doesn't touch them. It just stops them from leaving the cache permanently de-synced from PG when a legitimate later write should fill in the missing fields. Even after #425 is resolved, this defensive cache-fill is correct behavior: any path that registers identity should be able to fill in fields the prior path didn't have.

## Tests

- `test_backfills_thread_id_when_existing_entry_has_none` — exact poison sequence from #424. Asserts `thread_id` and `node_index` arrive in `agent_metadata` after onboard runs second.
- `test_backfill_does_not_overwrite_existing_thread_id` — guards the fill-only contract. An attempt to overwrite an existing non-None value is silently ignored.
- All 8082 tests pass, 34 skipped, 0 regressions.

## Refs

- #424 (thread_id reformat + position reset) — this PR closes the in-memory side of the symptom; the auto-mint avoidance is still tracked there.
- #425 (read tools auto-mint) — the upstream cause; out of scope for this PR.