### PR TITLE
feat(identity): STRICT_IDENTITY_REQUIRED env flag for typed-refusal contract (#425 staged rollout)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,19 @@ When you write a new MCP handler that needs DB access, pick one of the three pat
 
 - Knowledge graph AGE tests require a live AGE connection (errors, not failures, when unavailable)
 
+## STRICT_IDENTITY_REQUIRED (#425 staged rollout)
+
+`STRICT_IDENTITY_REQUIRED=true` flips the dispatch middleware from auto-minting an ephemeral identity for non-`pre_onboard` tools to returning a typed-refusal response (`status: identity_required`). Default is `false` so existing callers (residents, dispatch workers, plugins doing bare `onboard()`) keep working. Per-tool identity requirements are declared via `requires_identity=` on the `@mcp_tool` decorator (see `src/mcp_handlers/decorators.py`).
+
+Rollout sequence:
+
+1. Local dev (your shell) → set the flag, run a session through, watch for typed refusals where you expected work.
+2. Lumen (Pi) → flag the Pi env, observe resident agents (vigil/sentinel/watcher/chronicler) for refusals at scheduled boundaries; fix offenders by adding `parent_agent_id` to their bootstrap.
+3. Dispatch (the Discord bridge / dispatch worker) → flag, observe per-thread agent spawns.
+4. Flip the default in code only after all three burn-ins are clean for ≥1 week.
+
+When investigating a typed-refusal, the response carries `tool`, `hint`, `ontology_ref`, and `rollout_flag` so the cause is structurally identifiable.
+
 ## Minimal Agent Workflow
 
 Per identity.md v2 ontology, fresh process-instances mint fresh identity. Lineage is declared, not resumed via token.

--- a/src/mcp_handlers/middleware/identity_step.py
+++ b/src/mcp_handlers/middleware/identity_step.py
@@ -1,6 +1,7 @@
 """Step 1: Resolve Session Identity."""
 
 import asyncio
+import os
 import time as _time
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
@@ -526,6 +527,34 @@ async def resolve_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
                     name, session_key[:20],
                 )
             else:
+                # #425 contract: when STRICT_IDENTITY_REQUIRED is on, return
+                # a typed-refusal response instead of auto-minting an
+                # ephemeral identity. Default off for staged rollout —
+                # local → Lumen → dispatch → flip default. The refusal is
+                # a structured success-shape, not an MCP error: error
+                # responses invite retry-with-mint catch paths and would
+                # reintroduce the leak.
+                strict_mode = os.getenv("STRICT_IDENTITY_REQUIRED", "false").lower() in ("1", "true", "yes")
+                if strict_mode:
+                    logger.info(
+                        "[DISPATCH] session_resolve_miss for %s... "
+                        "— STRICT_IDENTITY_REQUIRED=true; returning typed "
+                        "refusal (no auto-mint).",
+                        session_key[:20],
+                    )
+                    from src.mcp_handlers.response_base import success_response
+                    return success_response({
+                        "status": "identity_required",
+                        "tool": name,
+                        "tool_class": "required",
+                        "hint": (
+                            "Call onboard() first to mint a governance identity. "
+                            "If continuing prior work, pass parent_agent_id to "
+                            "declare lineage; otherwise pass force_new=true."
+                        ),
+                        "ontology_ref": "docs/ontology/identity.md",
+                        "rollout_flag": "STRICT_IDENTITY_REQUIRED",
+                    })
                 logger.info(
                     "[DISPATCH] session_resolve_miss for %s... — minting "
                     "ephemeral dispatch identity (S21-a, spawn_reason="

--- a/tests/test_identity_s21a.py
+++ b/tests/test_identity_s21a.py
@@ -460,3 +460,59 @@ class TestS21BSpawnReasonPlumbing:
         assert db.upsert_agent.call_args.kwargs["spawn_reason"] == "dispatch_auto_mint"
         assert db.upsert_identity.call_args.kwargs["spawn_reason"] == "dispatch_auto_mint"
         assert in_memory["agent-s21b-force-new"]["spawn_reason"] == "dispatch_auto_mint"
+
+
+# ---------------------------------------------------------------------------
+# #425 — STRICT_IDENTITY_REQUIRED env flag for staged rollout of typed-refusal
+# ---------------------------------------------------------------------------
+
+class TestStrictIdentityRequiredFlag:
+    """When STRICT_IDENTITY_REQUIRED=true, the dispatch retry replaces the
+    auto-mint else branch with a typed-refusal response. Default is off so
+    rollout is staged: local → Lumen → dispatch → flip default. The refusal
+    is a structured success-shape (not an MCP error) so callers can't catch
+    it and retry into the auto-mint path."""
+
+    def test_strict_branch_present_in_source(self):
+        """Source-level guard: the typed-refusal block must coexist with
+        the auto-mint block, gated by os.getenv. If a future refactor drops
+        either branch, this test fails before the production behavior
+        regresses."""
+        from pathlib import Path
+        src_path = (Path(__file__).parent.parent
+                    / "src" / "mcp_handlers" / "middleware" / "identity_step.py")
+        source = src_path.read_text()
+
+        retry_idx = source.find("session_resolve_miss")
+        assert retry_idx != -1
+        retry_window = source[retry_idx:retry_idx + 3500]
+
+        assert 'os.getenv("STRICT_IDENTITY_REQUIRED"' in retry_window, (
+            "Strict-mode branch must be gated on STRICT_IDENTITY_REQUIRED env var "
+            "for staged rollout."
+        )
+        assert '"status": "identity_required"' in retry_window, (
+            "Typed-refusal must carry status='identity_required' so callers "
+            "can structurally distinguish it from a success or error."
+        )
+        assert '"hint":' in retry_window and 'onboard()' in retry_window, (
+            "Typed-refusal must hint at the next action (onboard call)."
+        )
+        # Auto-mint branch must still exist for non-strict mode (default).
+        assert 'spawn_reason="dispatch_auto_mint"' in retry_window, (
+            "Default-off path must still fall through to auto-mint; "
+            "removing this would break existing callers before rollout."
+        )
+
+    def test_default_is_false(self):
+        import os
+        # No env var set means default-off. Belt-and-suspenders against a
+        # future commit that flips the default before residents are migrated.
+        from pathlib import Path
+        src_path = (Path(__file__).parent.parent
+                    / "src" / "mcp_handlers" / "middleware" / "identity_step.py")
+        source = src_path.read_text()
+        assert 'os.getenv("STRICT_IDENTITY_REQUIRED", "false")' in source, (
+            "Default value of STRICT_IDENTITY_REQUIRED must be 'false' in os.getenv. "
+            "Default-on would break callers across the fleet without staged rollout."
+        )


### PR DESCRIPTION
## Summary

Builds on PR #433. Implements the (a)+(c) synthesis from #425's council pass: typed-refusal contract via the per-tool `requires_identity` attribute, gated behind a staged-rollout env flag so existing callers don't break at deploy.

## Behavior

When `STRICT_IDENTITY_REQUIRED=true`, the dispatch middleware (`src/mcp_handlers/middleware/identity_step.py`, the auto-mint else branch) returns a typed-refusal response instead of minting an ephemeral identity:

```json
{
  "status": "identity_required",
  "tool": "<tool_name>",
  "tool_class": "required",
  "hint": "Call onboard() first to mint a governance identity. If continuing prior work, pass parent_agent_id to declare lineage; otherwise pass force_new=true.",
  "ontology_ref": "docs/ontology/identity.md",
  "rollout_flag": "STRICT_IDENTITY_REQUIRED"
}
```

The response uses `success_response` shape, **not** `error_response`. Per the architect's review in #425: error responses invite retry-with-mint catch paths and would reintroduce the leak. Typed success-response makes the contract structurally visible and impossible to swallow.

## Default off

`STRICT_IDENTITY_REQUIRED` defaults to `false`. The auto-mint else branch is unchanged in default-off mode — every existing caller that relies on auto-mint to "just work" keeps working until the operator opts in.

## Rollout sequence

Documented in CLAUDE.md:

1. **Local dev shell** — set the flag, walk through a session, watch for typed refusals.
2. **Lumen (Pi residents)** — flag the Pi env, observe vigil/sentinel/watcher/chronicler at scheduled boundaries; fix offenders by adding `parent_agent_id` to their bootstrap.
3. **Dispatch / Discord bridge** — flag, observe per-thread agent spawns.
4. **Flip default in code** only after all three burn in clean for ≥1 week.

## Tests

- `TestStrictIdentityRequiredFlag.test_strict_branch_present_in_source` — source-level guard that the typed-refusal block exists with `status`, `hint`, and `os.getenv` gating.
- `TestStrictIdentityRequiredFlag.test_default_is_false` — guard that the env-var default stays `"false"` until rollout completes.
- 8099 pass, 34 skipped, 0 regressions.

Source-level rather than runtime tests for the same reason `test_dispatch_retry_declares_dispatch_auto_mint` (in the same file) is source-level: mocking the full dispatch chain end-to-end is heavy and brittle, and the regression risk we want to catch is "someone removes or weakens the gate" — which a source-level assertion catches cleanly.

## Out of scope (for now)

- Closing the five non-allowlisted mint paths (B/C/D/E/F per #425's reviewer scan). This PR closes Path A (the dispatch-middleware retry) only. Subsequent PRs will close the others.
- Audit-log nullable agent_id is already present in `audit.events.agent_id` schema; no migration needed.
- The "deprecate `archive_orphan_agents`" decision waits until all paths are closed and the orphan rate falls to zero.

Refs #425.