### PR TITLE
perf(wave-3-prereq): time the ODE call for A′.1 disconfirmer measurement

### DIFF
--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -13,6 +13,7 @@ import asyncio
 import os
 import re
 import secrets
+import time
 from datetime import datetime
 from typing import Any, Optional, Sequence
 
@@ -20,6 +21,7 @@ from mcp.types import TextContent
 
 from src.logging_utils import get_logger
 from src import agent_storage
+from src.perf_monitor import record_ms as _perf_record_ms
 
 from .context import UpdateContext
 from ..utils import error_response
@@ -975,9 +977,15 @@ async def execute_locked_update(ctx: UpdateContext) -> Optional[Sequence[TextCon
     except Exception as e:
         logger.debug(f"Anomaly detection skipped for {ctx.agent_id}: {e}")
 
-    # Execute ODE update
+    # Execute ODE update — timed for Wave 3 RFC §0 disconfirmer (A′.1).
+    # See docs/proposals/beam-wave-3-handler-dispatch.md §B1.2 — A′.1 measures
+    # whether >60% of process_agent_update p99 floor lives in this call.
+    # The surrounding [checkin_phases] log line in update_workflow_service.py
+    # already captures locked_update_total + total_ms; this wrap captures the
+    # ODE-only time so A′.1 = ode_call_ms / total_ms is computable.
     ctx.agent_state["task_type"] = ctx.task_type
 
+    _ode_start = time.perf_counter()
     try:
         ctx.result = await mcp_server.process_update_authenticated_async(
             agent_id=ctx.agent_id,
@@ -994,6 +1002,8 @@ async def execute_locked_update(ctx: UpdateContext) -> Optional[Sequence[TextCon
     except Exception as e:
         logger.error(f"Unexpected error in process_update_authenticated_async: {e}", exc_info=True)
         raise Exception(f"Error processing update: {str(e)}") from e
+    finally:
+        _perf_record_ms("phases.ode_call_ms", (time.perf_counter() - _ode_start) * 1000)
 
     # Cache monitor reference for Phase 5 and Phase 6 (guaranteed to exist post-ODE)
     ctx.monitor = mcp_server.monitors.get(ctx.agent_id)

--- a/src/perf_monitor.py
+++ b/src/perf_monitor.py
@@ -5,7 +5,7 @@ Design goals:
 - Zero external deps
 - Very low overhead
 - Safe for multi-threaded access
-- Snapshot returns compact summary (count/avg/p95/max)
+- Snapshot returns compact summary (count/avg/p50/p95/p99/max/last)
 """
 
 from __future__ import annotations
@@ -22,12 +22,13 @@ class PerfStats:
     avg_ms: float
     p50_ms: float
     p95_ms: float
+    p99_ms: float
     max_ms: float
     last_ms: float
 
 
 class PerfMonitor:
-    def __init__(self, max_samples_per_op: int = 200):
+    def __init__(self, max_samples_per_op: int = 1000):
         self._lock = threading.Lock()
         self._samples: Dict[str, Deque[float]] = defaultdict(lambda: deque(maxlen=max_samples_per_op))
 
@@ -73,6 +74,7 @@ class PerfMonitor:
                 avg_ms=avg,
                 p50_ms=pct(50),
                 p95_ms=pct(95),
+                p99_ms=pct(99),
                 max_ms=s_sorted[-1],
                 last_ms=s[-1],
             )
@@ -81,6 +83,7 @@ class PerfMonitor:
                 "avg_ms": round(stats.avg_ms, 3),
                 "p50_ms": round(stats.p50_ms, 3),
                 "p95_ms": round(stats.p95_ms, 3),
+                "p99_ms": round(stats.p99_ms, 3),
                 "max_ms": round(stats.max_ms, 3),
                 "last_ms": round(stats.last_ms, 3),
                 "sample_window": len(s_sorted),

--- a/tests/test_perf_monitor.py
+++ b/tests/test_perf_monitor.py
@@ -21,16 +21,17 @@ from src.perf_monitor import PerfStats, PerfMonitor, record_ms, snapshot
 class TestPerfStats:
 
     def test_creation(self):
-        s = PerfStats(count=10, avg_ms=5.0, p50_ms=4.5, p95_ms=9.0, max_ms=10.0, last_ms=6.0)
+        s = PerfStats(count=10, avg_ms=5.0, p50_ms=4.5, p95_ms=9.0, p99_ms=9.8, max_ms=10.0, last_ms=6.0)
         assert s.count == 10
         assert s.avg_ms == 5.0
         assert s.p50_ms == 4.5
         assert s.p95_ms == 9.0
+        assert s.p99_ms == 9.8
         assert s.max_ms == 10.0
         assert s.last_ms == 6.0
 
     def test_frozen(self):
-        s = PerfStats(count=1, avg_ms=1.0, p50_ms=1.0, p95_ms=1.0, max_ms=1.0, last_ms=1.0)
+        s = PerfStats(count=1, avg_ms=1.0, p50_ms=1.0, p95_ms=1.0, p99_ms=1.0, max_ms=1.0, last_ms=1.0)
         with pytest.raises(AttributeError):
             s.count = 2
 
@@ -101,6 +102,7 @@ class TestPerfMonitorSnapshot:
         assert "avg_ms" in entry
         assert "p50_ms" in entry
         assert "p95_ms" in entry
+        assert "p99_ms" in entry
         assert "max_ms" in entry
         assert "last_ms" in entry
         assert "sample_window" in entry
@@ -122,6 +124,7 @@ class TestPerfMonitorSnapshot:
         assert snap["op"]["avg_ms"] == 7.5
         assert snap["op"]["p50_ms"] == 7.5
         assert snap["op"]["p95_ms"] == 7.5
+        assert snap["op"]["p99_ms"] == 7.5
         assert snap["op"]["max_ms"] == 7.5
 
     def test_snapshot_multiple_ops(self):

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -758,6 +758,7 @@ class TestPerfMonitor:
             avg_ms=10.5,
             p50_ms=9.0,
             p95_ms=20.0,
+            p99_ms=24.0,
             max_ms=50.0,
             last_ms=12.0
         )
@@ -766,6 +767,7 @@ class TestPerfMonitor:
         assert stats.avg_ms == 10.5
         assert stats.p50_ms == 9.0
         assert stats.p95_ms == 20.0
+        assert stats.p99_ms == 24.0
         assert stats.max_ms == 50.0
         assert stats.last_ms == 12.0
 


### PR DESCRIPTION
## Summary
- Wraps `mcp_server.process_update_authenticated_async` (the ODE compute call at `phases.py:982`) with `perf_counter` timing; emits via existing `perf_monitor` under new key `phases.ode_call_ms`.
- Extends `perf_monitor.PerfStats` with `p99_ms` field; raises `max_samples_per_op` default 200 → 1000 (gives p99 reasonable granularity — 10th-highest of 1000 vs 2nd-highest of 200).
- Updates the two test files that asserted on the `PerfStats` signature.
- Behavior change: none for any handler caller. Pure observability patch.

## Why
Wave 3 RFC §0 disconfirmer (A′.1) — defined in `docs/proposals/beam-wave-3-handler-dispatch.md` §B1.2 v0.1.2 — measures whether >60% of `process_agent_update` p99 floor lives in the ODE compute call. If so, Wave 3's port-the-handler-layer-around-the-floor strategy can't shrink p99 because the floor is in `governance_core/` math (which Wave 3 explicitly leaves Python). A′.1 is the highest-leverage Go/No-Go gate in the Wave 3 RFC.

The orchestrator at `update_workflow_service.py:34-153` already emits `[checkin_phases]` log lines per call with `locked_update` + `total_ms`. Only the ODE-call-vs-locked-total split was missing.

## Operator collection workflow (post-merge)
1. Run governance-mcp under representative live traffic for ≥48h.
2. Query \`perf_monitor.snapshot()\` via admin handler.
3. Read \`phases.ode_call_ms\` p99; grep \`[checkin_phases]\` log lines for \`total_ms\` p99.
4. Compute A′.1 ratio = \`ode_call_p99 / total_p99\`.
5. Document result in \`docs/measurements/wave-3-ode-profile-2026-MM-DD.md\`.

## Wave 3 RFC dependency
Per Wave 3 RFC §B1.2 git-event anchor: this prereq commit must land on master before any commit on \`wave-3-rfc-draft\` (or successor branch) introduces a file under \`elixir/handler_dispatch/\` or any new \`elixir/\` tree.

## Test plan
- [x] \`tests/test_perf_monitor.py\` — 17 tests pass (extended for p99_ms field).
- [x] \`tests/test_utilities.py::TestPerfMonitor\` — passes (signature updated).
- [x] Full \`./scripts/dev/test-cache.sh\` — 8640 passed, 34 skipped, 0 failures.
- [ ] Operator-driven: ≥48h live-traffic observation window; document A′.1 ratio.