### PR TITLE
test(kg-search): bump neighbor-fetch concurrency assertion to 1000ms

### DIFF
--- a/tests/test_kg_search_neighbor_fetch.py
+++ b/tests/test_kg_search_neighbor_fetch.py
@@ -35,9 +35,13 @@ async def test_neighbor_fetch_runs_concurrently():
 
     With a 50ms simulated per-call latency, sequential execution takes
     ≥1500ms. Concurrent execution finishes in ~50ms (one wave). We
-    assert <500ms — generous enough to absorb event-loop noise but tight
-    enough to fail if the gather() were ever reverted to a sequential
-    `for await` loop.
+    assert <1000ms — well under sequential 1500ms even on a slow CI
+    runner, while still failing if the gather() were ever reverted to a
+    sequential `for await` loop. The original 500ms threshold flaked on
+    contended GitHub runners (observed 543ms and 655ms in PR #435 reruns)
+    even though the gather() shape was unchanged; the source-level
+    assertion below pins the actual concurrency contract regardless of
+    wall-clock noise.
     """
     from src.mcp_handlers.knowledge import handlers
 
@@ -78,7 +82,7 @@ async def test_neighbor_fetch_runs_concurrently():
     elapsed_ms = (time.perf_counter() - t0) * 1000
 
     assert len(pool) == 30
-    assert elapsed_ms < 500, \
+    assert elapsed_ms < 1000, \
         f"neighbor fetch took {elapsed_ms:.1f}ms — gather() not running concurrently?"
 
     # Source-level pin: the handler must use asyncio.gather, not a plain


### PR DESCRIPTION
## Summary

The `test_neighbor_fetch_runs_concurrently` 500ms wall-clock threshold flaked on contended GitHub runners during PR #435 reruns (observed 543ms and 655ms with the `gather()` shape unchanged). The threshold was too tight for noisy CI scheduler latency.

Bumps to **1000ms** — well under the sequential lower bound of 1500ms (so a regression to `for/await` still trips the test) while giving 2× headroom on the concurrent ideal of ~50ms.

The source-level `assert "asyncio.gather" in src` assertion at lines 88-96 is unchanged; that's the actual concurrency contract, with the wall-clock acting as a smoke check.

## Test plan

- [x] `pytest tests/test_kg_search_neighbor_fetch.py -q` → 2 passed in 0.78s
- [x] Pre-push smoke (138 tests) green
- [ ] CI gate