### PR TITLE
feat(identity): close Paths B/C/D/E under STRICT_IDENTITY_REQUIRED (#425)

### DIFF
--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -1666,6 +1666,40 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
                 # core.agents). Caller-provided values are preserved.
                 if not _spawn_reason:
                     _spawn_reason = "auto_onboard_no_session"
+
+                # #425 Path B: when STRICT_IDENTITY_REQUIRED is on, refuse
+                # bare onboard() (no parent_agent_id and no force_new=True)
+                # because the caller hasn't declared lineage intent. Either
+                # path is fine — declared lineage or explicit force_new —
+                # but the implicit auto_onboard_no_session mint violates
+                # the ontology's "lineage declared, not auto-minted" rule.
+                # Default off; gated by env flag for staged rollout.
+                from src.mcp_handlers.identity_bootstrap import is_strict_identity_required
+                if (is_strict_identity_required()
+                        and not _parent_agent_id
+                        and not force_new):
+                    logger.info(
+                        "[ONBOARD] STRICT_IDENTITY_REQUIRED=true and bare "
+                        "onboard() (no parent_agent_id, no force_new=true) "
+                        "— refusing rather than auto-minting "
+                        "auto_onboard_no_session (#425 Path B)"
+                    )
+                    # success_response is imported at module level (line 22).
+                    # Do NOT re-import here — it shadows the module binding
+                    # for the entire function scope and breaks every other
+                    # success_response call in handle_onboard_v2.
+                    return success_response({
+                        "status": "lineage_declaration_required",
+                        "tool": "onboard",
+                        "hint": (
+                            "Bare onboard() is ambiguous — pass "
+                            "parent_agent_id=<prior UUID> to continue prior "
+                            "work, OR force_new=true to confirm a fresh "
+                            "process-instance with no lineage."
+                        ),
+                        "ontology_ref": "docs/ontology/identity.md",
+                        "rollout_flag": "STRICT_IDENTITY_REQUIRED",
+                    })
                 logger.info(
                     "[ONBOARD] No existing session for session_key=%s... "
                     "minting fresh in-memory identity (spawn_reason=%s)",

--- a/src/mcp_handlers/identity_bootstrap.py
+++ b/src/mcp_handlers/identity_bootstrap.py
@@ -1,0 +1,29 @@
+"""Identity-bootstrap policy helpers for #425.
+
+Centralizes the STRICT_IDENTITY_REQUIRED env-flag check so every auto-mint
+path checks the same gate the same way. Without this, the gate drifts
+(one path checks "true", another "1", another normalizes case differently)
+and the rollout becomes a per-path negotiation instead of a single switch.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def is_strict_identity_required() -> bool:
+    """True iff STRICT_IDENTITY_REQUIRED env var is set to a truthy value.
+
+    Truthy values: "1", "true", "yes", "on" (case-insensitive). Anything
+    else, including unset, is False.
+
+    When True, all auto-mint paths MUST refuse-or-skip rather than create
+    an ephemeral identity. See docs/ontology/identity.md and #425 for the
+    contract; CLAUDE.md "STRICT_IDENTITY_REQUIRED" section for the rollout
+    sequence.
+    """
+    raw = os.getenv("STRICT_IDENTITY_REQUIRED", "").strip().lower()
+    return raw in _TRUTHY

--- a/src/mcp_handlers/middleware/identity_step.py
+++ b/src/mcp_handlers/middleware/identity_step.py
@@ -534,8 +534,8 @@ async def resolve_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
                 # a structured success-shape, not an MCP error: error
                 # responses invite retry-with-mint catch paths and would
                 # reintroduce the leak.
-                strict_mode = os.getenv("STRICT_IDENTITY_REQUIRED", "false").lower() in ("1", "true", "yes")
-                if strict_mode:
+                from src.mcp_handlers.identity_bootstrap import is_strict_identity_required
+                if is_strict_identity_required():
                     logger.info(
                         "[DISPATCH] session_resolve_miss for %s... "
                         "— STRICT_IDENTITY_REQUIRED=true; returning typed "

--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -787,6 +787,31 @@ async def execute_locked_update(ctx: UpdateContext) -> Optional[Sequence[TextCon
 
     # Ensure agent exists
     if ctx.is_new_agent:
+        # #425 Path C: when STRICT_IDENTITY_REQUIRED is on, refuse to
+        # auto-create the agent here — process_agent_update should not
+        # mint identity. Caller must onboard() first. Default off; gated
+        # by env flag for staged rollout.
+        from src.mcp_handlers.identity_bootstrap import is_strict_identity_required
+        if is_strict_identity_required():
+            logger.info(
+                "[PROCESS_UPDATE] STRICT_IDENTITY_REQUIRED=true and "
+                "agent %s... not in PG — refusing to auto-create "
+                "(#425 Path C)",
+                (ctx.agent_id or "")[:12],
+            )
+            from src.mcp_handlers.response_base import success_response
+            return success_response({
+                "status": "identity_required",
+                "tool": "process_agent_update",
+                "tool_class": "required",
+                "hint": (
+                    "Agent is not registered. Call onboard() first to "
+                    "mint identity, then retry the update."
+                ),
+                "ontology_ref": "docs/ontology/identity.md",
+                "rollout_flag": "STRICT_IDENTITY_REQUIRED",
+            })
+
         purpose = ctx.arguments.get("purpose")
         purpose_str = purpose.strip() if purpose and isinstance(purpose, str) else None
         ctx.api_key = secrets.token_urlsafe(32)
@@ -1319,6 +1344,22 @@ async def execute_post_update_effects(ctx: UpdateContext) -> None:
         )
         logger.debug(f"PostgreSQL: Recorded state for {agent_id}")
     except ValueError:
+        # #425 Path D: when STRICT_IDENTITY_REQUIRED is on, do NOT auto-
+        # create on the recovery path. The agent should have onboarded
+        # explicitly; missing-row at this layer means something went
+        # wrong upstream (orphan agent, race, or upstream auto-mint that
+        # was correctly refused). Fail loud rather than silently mint.
+        # Default off; gated by env flag for staged rollout.
+        from src.mcp_handlers.identity_bootstrap import is_strict_identity_required
+        if is_strict_identity_required():
+            logger.warning(
+                "[PROCESS_UPDATE] STRICT_IDENTITY_REQUIRED=true and "
+                "agent %s... missing from PG at record_agent_state — "
+                "skipping self-create (#425 Path D); state for this "
+                "update will not be recorded.",
+                (agent_id or "")[:12],
+            )
+            return
         logger.debug(f"Agent {agent_id} not found, creating...")
         try:
             await agent_storage.create_agent(

--- a/src/mcp_server_std.py
+++ b/src/mcp_server_std.py
@@ -322,6 +322,21 @@ async def inject_lightweight_heartbeat(
         load_metadata()
 
         if agent_id not in agent_metadata:
+            # #425 Path E: when STRICT_IDENTITY_REQUIRED is on, do NOT
+            # auto-create metadata for an unknown agent. Heartbeat for
+            # an unbound agent_id is itself a side-effect of an upstream
+            # auto-mint that the contract refuses; minting metadata here
+            # would re-introduce the leak outside the middleware. Default
+            # off; gated by env flag for staged rollout.
+            from src.mcp_handlers.identity_bootstrap import is_strict_identity_required
+            if is_strict_identity_required():
+                logger.debug(
+                    "[HEARTBEAT] STRICT_IDENTITY_REQUIRED=true and "
+                    "agent_id %s... not in metadata cache — skipping "
+                    "heartbeat (#425 Path E)",
+                    (agent_id or "")[:12],
+                )
+                return
             get_or_create_metadata(agent_id)
 
         meta = agent_metadata.get(agent_id)

--- a/tests/test_identity_s21a.py
+++ b/tests/test_identity_s21a.py
@@ -487,9 +487,9 @@ class TestStrictIdentityRequiredFlag:
         assert retry_idx != -1
         retry_window = source[retry_idx:retry_idx + 3500]
 
-        assert 'os.getenv("STRICT_IDENTITY_REQUIRED"' in retry_window, (
-            "Strict-mode branch must be gated on STRICT_IDENTITY_REQUIRED env var "
-            "for staged rollout."
+        assert 'is_strict_identity_required' in retry_window, (
+            "Strict-mode branch must call the shared is_strict_identity_required() "
+            "helper so all auto-mint paths use one gate (#425)."
         )
         assert '"status": "identity_required"' in retry_window, (
             "Typed-refusal must carry status='identity_required' so callers "
@@ -504,15 +504,127 @@ class TestStrictIdentityRequiredFlag:
             "removing this would break existing callers before rollout."
         )
 
-    def test_default_is_false(self):
+    def test_helper_default_is_false(self):
+        # Verify the shared helper itself defaults to False when env unset —
+        # belt-and-suspenders against a future commit that flips the default
+        # before residents are migrated.
         import os
-        # No env var set means default-off. Belt-and-suspenders against a
-        # future commit that flips the default before residents are migrated.
+        from src.mcp_handlers.identity_bootstrap import is_strict_identity_required
+
+        prior = os.environ.pop("STRICT_IDENTITY_REQUIRED", None)
+        try:
+            assert is_strict_identity_required() is False
+        finally:
+            if prior is not None:
+                os.environ["STRICT_IDENTITY_REQUIRED"] = prior
+
+    def test_helper_truthy_values(self):
+        import os
+        from src.mcp_handlers.identity_bootstrap import is_strict_identity_required
+
+        prior = os.environ.get("STRICT_IDENTITY_REQUIRED")
+        try:
+            for val in ("1", "true", "TRUE", "yes", "Yes", "on"):
+                os.environ["STRICT_IDENTITY_REQUIRED"] = val
+                assert is_strict_identity_required() is True, f"value {val!r} should be truthy"
+            for val in ("0", "false", "no", "off", "", "garbage"):
+                os.environ["STRICT_IDENTITY_REQUIRED"] = val
+                assert is_strict_identity_required() is False, f"value {val!r} should be falsy"
+        finally:
+            if prior is None:
+                os.environ.pop("STRICT_IDENTITY_REQUIRED", None)
+            else:
+                os.environ["STRICT_IDENTITY_REQUIRED"] = prior
+
+
+class TestStrictModeMintPathClosure:
+    """#425 Paths B/C/D/E: source-level guards that each auto-mint path
+    checks the shared is_strict_identity_required() helper before minting.
+
+    Source-level rather than runtime because the runtime test surface (mocking
+    the full dispatch + PG + Redis stack for each path) is heavy and brittle,
+    and the regression risk we want to catch is "someone removes the gate" —
+    a substring assertion on the file catches that cleanly.
+
+    Each test names the path letter from the #425 council scan so the
+    failure message points at the source-of-truth issue.
+    """
+
+    @staticmethod
+    def _read(rel_path: str) -> str:
         from pathlib import Path
-        src_path = (Path(__file__).parent.parent
-                    / "src" / "mcp_handlers" / "middleware" / "identity_step.py")
-        source = src_path.read_text()
-        assert 'os.getenv("STRICT_IDENTITY_REQUIRED", "false")' in source, (
-            "Default value of STRICT_IDENTITY_REQUIRED must be 'false' in os.getenv. "
-            "Default-on would break callers across the fleet without staged rollout."
+        return (Path(__file__).parent.parent / rel_path).read_text()
+
+    def test_path_b_onboard_auto_onboard_no_session_gated(self):
+        # Path B: onboard()'s auto_onboard_no_session branch should refuse
+        # in strict mode if neither parent_agent_id nor force_new=True is
+        # passed. Caller must declare lineage intent.
+        source = self._read("src/mcp_handlers/identity/handlers.py")
+        idx = source.find("auto_onboard_no_session")
+        assert idx != -1
+        window = source[idx:idx + 3000]
+        assert "is_strict_identity_required" in window, (
+            "Path B (#425): the auto_onboard_no_session branch must check "
+            "is_strict_identity_required() before minting. Without this gate, "
+            "bare onboard() continues to violate the lineage-declaration ontology."
         )
+        assert "lineage_declaration_required" in window, (
+            "Path B's strict-mode refusal must use status='lineage_declaration_required' "
+            "to distinguish from the generic identity_required (the caller HAS an identity "
+            "intent, just hasn't declared lineage)."
+        )
+        assert "parent_agent_id" in window and "force_new" in window, (
+            "Path B's hint must mention both parent_agent_id and force_new so the caller "
+            "can pick the right resolution."
+        )
+
+    def test_path_c_process_agent_update_self_create_gated(self):
+        # Path C: process_agent_update self-create at the get_or_create_agent
+        # call should refuse in strict mode. There are multiple `if
+        # ctx.is_new_agent:` blocks in phases.py; we want the one in
+        # `prepare_unlocked_inputs` that calls get_or_create_agent (the
+        # self-create branch), not the onboarding-guidance branch in
+        # resolve_identity_and_guards.
+        source = self._read("src/mcp_handlers/updates/phases.py")
+        idx = source.find("get_or_create_agent")
+        assert idx != -1
+        # Pre-window: the gate must precede the get_or_create_agent call.
+        pre_window = source[max(0, idx - 2500):idx]
+        assert "is_strict_identity_required" in pre_window, (
+            "Path C (#425): process_agent_update's self-create branch must check "
+            "is_strict_identity_required() before calling get_or_create_agent."
+        )
+        assert "Path C" in pre_window, (
+            "Path C's strict block must reference '#425 Path C' in a comment so future "
+            "audits can map symptom back to issue."
+        )
+
+    def test_path_d_record_agent_state_recovery_gated(self):
+        # Path D: record_agent_state recovery should refuse in strict mode
+        # if the agent isn't in PG. Missing-row at this layer indicates an
+        # upstream orphan; fail loud.
+        source = self._read("src/mcp_handlers/updates/phases.py")
+        idx = source.find("Agent {agent_id} not found, creating")
+        assert idx != -1
+        # Pre-window: gate must come BEFORE the create_agent call.
+        pre_window = source[max(0, idx - 1500):idx + 500]
+        assert "is_strict_identity_required" in pre_window, (
+            "Path D (#425): record_agent_state's recovery branch must check "
+            "is_strict_identity_required() before calling create_agent."
+        )
+        assert "Path D" in pre_window, "Path D strict block must reference '#425 Path D'."
+
+    def test_path_e_stdio_heartbeat_gated(self):
+        # Path E: stdio heartbeat should skip metadata creation for unknown
+        # agent_id in strict mode (don't create metadata for unregistered).
+        source = self._read("src/mcp_server_std.py")
+        idx = source.find("def inject_lightweight_heartbeat")
+        assert idx != -1
+        window = source[idx:idx + 2500]
+        assert "is_strict_identity_required" in window, (
+            "Path E (#425): inject_lightweight_heartbeat must check "
+            "is_strict_identity_required() before calling get_or_create_metadata "
+            "for an unknown agent_id. This path runs OUTSIDE the middleware so "
+            "the dispatch allowlist doesn't reach it."
+        )
+        assert "Path E" in window, "Path E strict block must reference '#425 Path E'."


### PR DESCRIPTION
## Summary

Completes the auto-mint path closure for #425's typed-refusal contract. Builds on PR #434 (env flag + Path A in dispatch middleware). Each remaining path now checks the shared `is_strict_identity_required()` helper before auto-creating identity. **Default off; gated by env flag for staged rollout. Default behavior preserved.**

## New helper

`src/mcp_handlers/identity_bootstrap.py` — `is_strict_identity_required()` is the single source of truth for the env-flag check across all auto-mint paths. Centralizing prevents drift (one path checking `"true"`, another `"1"`, another normalizing case differently). Truthy: `1 / true / yes / on` (case-insensitive). Anything else, including unset, is False.

The middleware (`identity_step.py`) is also refactored to use the helper. The pre-existing source-level test was updated to assert the helper call.

## Paths closed

| Path | File | Strict-mode behavior | Default behavior |
|------|------|----------------------|------------------|
| **B** — onboard `auto_onboard_no_session` | `identity/handlers.py` ~L1668 | Refuses bare `onboard()` (no `parent_agent_id`, no `force_new=true`) with `status="lineage_declaration_required"`. Caller must declare lineage. | Mints with `auto_onboard_no_session` (current). |
| **C** — `process_agent_update` self-create | `updates/phases.py` `prepare_unlocked_inputs` | Refuses with `status="identity_required"` when `ctx.is_new_agent`. | Auto-creates via `get_or_create_agent` (current). |
| **D** — `record_agent_state` recovery | `updates/phases.py` `execute_post_update_effects` | Skips `create_agent` on missing-row `ValueError`. State for that update is not recorded; logs WARNING surfacing the upstream orphan. | Auto-creates (current). |
| **E** — stdio heartbeat | `mcp_server_std.py` `inject_lightweight_heartbeat` | Skips `get_or_create_metadata` for unknown `agent_id`. | Creates metadata (current). |

## Path F intentionally NOT gated

`persistence.py:555` `lazy_creation` is the legitimate two-phase commit path for onboard's captured-fresh-mint flow:

1. `resolve_session_identity(persist=False, force_new=True)` mints the in-memory identity
2. Caller proceeds with work
3. `ensure_agent_persisted(agent_uuid)` writes the PG row with `source="lazy_creation"`

This is correct lazy-persist, not a leak. With B/C/D/E closed in strict mode, no orphan `agent_uuid` reaches F — onboard is the only producer of agent_uuids that need lazy-persist, and it's gated upstream. Gating F too would break onboard's own commit path.

If a future audit shows F minting for non-onboard sources, the fix is to find the upstream leak (which path generated the agent_uuid?), not to gate F.

## Path E note: outside middleware

E is the most insidious of the five — `inject_lightweight_heartbeat` runs outside the dispatch middleware, so the S21-a allowlist doesn't reach it. Resident agents (vigil, sentinel, watcher, chronicler) call `health_check` and other tools with an `agent_id` arg; once the heartbeat threshold trips, this path mints metadata for any agent_id it sees. Closing E here is the only way to prevent residents from minting on scheduled reads in strict mode.

## Tests

- `TestStrictIdentityRequiredFlag.test_helper_default_is_false` — env-unset is False.
- `TestStrictIdentityRequiredFlag.test_helper_truthy_values` — case-insensitive `{1, true, yes, on}` truthy; everything else falsy.
- `TestStrictModeMintPathClosure` — source-level guards for Paths B/C/D/E. Each test names the path letter so failures map directly back to the #425 council scan.
- All 8104 pass, 34 skipped, 0 regressions.

Source-level rather than runtime tests for the same reason `test_dispatch_retry_declares_dispatch_auto_mint` (in the same file) is source-level: mocking each path's full stack is heavy and brittle, and the regression risk we want to catch is "someone removes the gate" — substring assertions on the file catch that cleanly.

## Rollout

Per `CLAUDE.md` "STRICT_IDENTITY_REQUIRED" section (added in #434):

1. Local dev shell — set the flag, walk through a session.
2. Lumen Pi — flag the Pi env, observe vigil/sentinel/watcher/chronicler at scheduled boundaries; fix offenders by adding `parent_agent_id` to their bootstrap.
3. Dispatch / Discord bridge — flag, observe per-thread agent spawns.
4. Flip default in code only after all three burn in clean for ≥1 week.

Refs #425.