### PR TITLE
docs(identity): surface prior-UUID discovery for server-only sessions + #434 parity backfill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,19 @@ When you write a new MCP handler that needs DB access, pick one of the three pat
 
 - Knowledge graph AGE tests require a live AGE connection (errors, not failures, when unavailable)
 
+## STRICT_IDENTITY_REQUIRED (#425 staged rollout)
+
+`STRICT_IDENTITY_REQUIRED=true` flips the dispatch middleware from auto-minting an ephemeral identity for non-`pre_onboard` tools to returning a typed-refusal response (`status: identity_required`). Default is `false` so existing callers (residents, dispatch workers, plugins doing bare `onboard()`) keep working. Per-tool identity requirements are declared via `requires_identity=` on the `@mcp_tool` decorator (see `src/mcp_handlers/decorators.py`).
+
+Rollout sequence:
+
+1. Local dev (your shell) → set the flag, run a session through, watch for typed refusals where you expected work.
+2. Lumen (Pi) → flag the Pi env, observe resident agents (vigil/sentinel/watcher/chronicler) for refusals at scheduled boundaries; fix offenders by adding `parent_agent_id` to their bootstrap.
+3. Dispatch (the Discord bridge / dispatch worker) → flag, observe per-thread agent spawns.
+4. Flip the default in code only after all three burn-ins are clean for ≥1 week.
+
+When investigating a typed-refusal, the response carries `tool`, `hint`, `ontology_ref`, and `rollout_flag` so the cause is structurally identifiable.
+
 ## Minimal Agent Workflow
 
 Per identity.md v2 ontology, fresh process-instances mint fresh identity. Lineage is declared, not resumed via token.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,11 @@ Default happy path:
 2. `process_agent_update(response_text=..., complexity=..., client_session_id=...)` for in-process check-ins
 3. On a future process-instance, repeat step 1 with the new prior UUID — do not auto-resume
 
+Discovering the prior UUID for step 1:
+
+- **Plugin-loaded sessions** are the canonical path. The `unitares-governance-plugin` SessionStart banner surfaces the cached workspace UUID as a lineage candidate (S11, plugin PR #17); Codex sessions get the same hint via `commands/governance-start.md` (S11-a).
+- **Server-only sessions** (working directly inside this repo without the plugin's hook chain) have no pre-onboard discovery surface. Onboarding without `parent_agent_id` mints honestly as `lineage_state: no_lineage_declared`. The onboard response still returns `thread_context.predecessor.uuid` when a session-resolved predecessor exists — record it and declare it on the **next** fresh process-instance, not retroactively against the just-minted UUID.
+
 Identity rules:
 
 - A fresh process-instance is a fresh agent. Process-instance boundaries are honored.
@@ -160,5 +165,6 @@ Identity rules:
 - `continuity_token` is being narrowed (S1 in `docs/ontology/plan.md`) — present-day external clients can still resume with it, but plugin-internal flows declare lineage instead.
 - Substrate-anchored agents (Lumen, the long-lived residents) earn cross-process continuity via the substrate-earned identity pattern in `docs/ontology/identity.md` — they may use a hardcoded UUID across restarts.
 - Arg-less `onboard()` with no proof signal triggers the v2 fresh-instance gate — the server flips `force_new=true` and emits a `[FRESH_INSTANCE]` log line (S13).
+- Lineage is declared at onboard time and is one-shot. A UUID minted without `parent_agent_id` stays unlineaged for its lifetime — record any observed predecessor UUID for the next fresh process-instance instead.
 
 <!-- END SHARED CONTRACT -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,11 @@ Default happy path:
 2. `process_agent_update(response_text=..., complexity=..., client_session_id=...)` for in-process check-ins
 3. On a future process-instance, repeat step 1 with the new prior UUID — do not auto-resume
 
+Discovering the prior UUID for step 1:
+
+- **Plugin-loaded sessions** are the canonical path. The `unitares-governance-plugin` SessionStart banner surfaces the cached workspace UUID as a lineage candidate (S11, plugin PR #17); Codex sessions get the same hint via `commands/governance-start.md` (S11-a).
+- **Server-only sessions** (working directly inside this repo without the plugin's hook chain) have no pre-onboard discovery surface. Onboarding without `parent_agent_id` mints honestly as `lineage_state: no_lineage_declared`. The onboard response still returns `thread_context.predecessor.uuid` when a session-resolved predecessor exists — record it and declare it on the **next** fresh process-instance, not retroactively against the just-minted UUID.
+
 Identity rules:
 
 - A fresh process-instance is a fresh agent. Process-instance boundaries are honored.
@@ -152,5 +157,6 @@ Identity rules:
 - `continuity_token` is being narrowed (S1 in `docs/ontology/plan.md`) — present-day external clients can still resume with it, but plugin-internal flows declare lineage instead.
 - Substrate-anchored agents (Lumen, the long-lived residents) earn cross-process continuity via the substrate-earned identity pattern in `docs/ontology/identity.md` — they may use a hardcoded UUID across restarts.
 - Arg-less `onboard()` with no proof signal triggers the v2 fresh-instance gate — the server flips `force_new=true` and emits a `[FRESH_INSTANCE]` log line (S13).
+- Lineage is declared at onboard time and is one-shot. A UUID minted without `parent_agent_id` stays unlineaged for its lifetime — record any observed predecessor UUID for the next fresh process-instance instead.
 
 <!-- END SHARED CONTRACT -->


### PR DESCRIPTION
## Summary

Doc-only. Two commits:

1. **`762b683` — `docs(shared-contract): backfill STRICT_IDENTITY_REQUIRED block in AGENTS.md`**
   - PR #434 added the section to `CLAUDE.md` only. `scripts/dev/check-shared-contract.sh` was already failing on this drift before this branch existed; surfaced when I ran the check after editing the workflow section.
   - Mirrored byte-identically per the SHARED CONTRACT contract.

2. **`ee9c2b1` — `docs(identity): surface prior-UUID discovery for server-only sessions`**
   - The "Minimal Agent Workflow" recommends declaring `parent_agent_id="<prior UUID>"` at onboard, but didn't tell operators where to find that UUID when the `unitares-governance-plugin` hook chain isn't loaded — i.e., when working directly inside this server repo, the configuration this CLAUDE.md / AGENTS.md governs by design.
   - Hit during a dogfood session on this branch: onboarded with no `parent_agent_id` despite a real predecessor (`Claude-dogfood-test`, position 7 in the resolved thread); server honestly labelled the result `lineage_state: no_lineage_declared`.
   - Adds a **"Discovering the prior UUID for step 1"** subsection:
     - Points plugin-loaded sessions to the SessionStart banner / `governance-start` command (S11 / S11-a — already shipped).
     - Tells server-only operators no pre-onboard discovery surface exists, but `thread_context.predecessor.uuid` is in the onboard response — record it for the *next* fresh process-instance.
   - Adds one Identity rule clarifying lineage declaration is one-shot at onboard and not retro-declarable.
   - No code change.

## Why split

Commit 1 is a mechanical pre-existing-drift fix, unrelated to commit 2's content but required for the parity check (and CI) to pass. Reviewers can assess them independently.

## Test plan

- [x] `./scripts/dev/check-shared-contract.sh` → `SHARED CONTRACT: in sync (124 lines)`
- [ ] CI gate
- _Note:_ `./scripts/dev/test-cache.sh` couldn't run in the dogfood environment (no pytest available); change is pure-doc with no Python touched.

## Out of scope (potential follow-ups)

- Whether the server should grow a `pre_onboard` lineage-candidate tool so server-only sessions could discover the predecessor UUID *before* minting. This crosses the Identity / onboarding single-writer surface and is bigger than a doc fix; not included here.
- Updating `docs/ontology/plan.md` to record this finding under S11 / a new row. Plan is single-writer-locked; left for operator decision.

https://claude.ai/code/session_014y8zKYSJaWykVNwNKuXrki

---
_Generated by [Claude Code](https://claude.ai/code/session_014y8zKYSJaWykVNwNKuXrki)_