### PR TITLE
feat(governance_core): add make_boundary_payload helper

### DIFF
--- a/governance_core/coordination_events_helpers.py
+++ b/governance_core/coordination_events_helpers.py
@@ -1,0 +1,75 @@
+"""Helpers that build canonical payloads for `coordination_failure.beam_python_boundary.*`
+events. Direct dict construction at emission sites is prohibited — every emission
+goes through this module so the documented payload contract (in
+`src/coordination_events.py` Wave 2 schema extension comments) is enforced once,
+not relitigated per call site.
+
+The helper exists ahead of the wire-up call sites that come with Wave 3 (or
+earlier if lease-integration boundary hardening produces them) so that when
+emissions land, the payload shape is already pinned and lint-checkable.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+
+VALID_ERROR_CLASSES: Final[frozenset[str]] = frozenset({
+    "timeout",
+    "connect_error",
+    "non_200",
+    "decode_error",
+    "other",
+})
+
+
+def make_boundary_payload(
+    *,
+    endpoint: str,
+    method: str,
+    error_class: str,
+    status_code: int | None,
+    elapsed_ms: int | None,
+) -> dict:
+    """Build a canonical boundary-event payload.
+
+    Mandatory keyword-only arguments. Returns a fresh dict in the order the
+    payload contract documents — callers that re-order keys violate the
+    contract; using this helper is the cheapest way to stay compliant.
+
+    Raises:
+        ValueError: if `endpoint` or `method` is empty/whitespace-only, if
+            `error_class` is missing from the documented enum, or if
+            `status_code` is None when `error_class == "non_200"` (the doc
+            comment pins `status_code` as populated for that case).
+        TypeError: if `status_code` or `elapsed_ms` is the wrong type when
+            non-None — caught here rather than at INSERT time so emission-
+            site bugs surface in tests, not in production audit gaps.
+    """
+    if not endpoint or not endpoint.strip():
+        raise ValueError("endpoint must be a non-empty stable identifier")
+    if not method or not method.strip():
+        raise ValueError("method must be a non-empty HTTP method")
+    if error_class not in VALID_ERROR_CLASSES:
+        raise ValueError(
+            f"error_class={error_class!r} is not in the documented enum "
+            f"{sorted(VALID_ERROR_CLASSES)}; emission sites must declare a "
+            f"specific class, not None or a free-form string"
+        )
+    if error_class == "non_200" and status_code is None:
+        raise ValueError(
+            "status_code is required when error_class == 'non_200'; the "
+            "payload contract pins it for that case"
+        )
+    if status_code is not None and not isinstance(status_code, int):
+        raise TypeError(f"status_code must be int or None, got {type(status_code).__name__}")
+    if elapsed_ms is not None and not isinstance(elapsed_ms, int):
+        raise TypeError(f"elapsed_ms must be int or None, got {type(elapsed_ms).__name__}")
+
+    return {
+        "endpoint": endpoint,
+        "method": method,
+        "error_class": error_class,
+        "status_code": status_code,
+        "elapsed_ms": elapsed_ms,
+    }

--- a/tests/test_coordination_events_helpers.py
+++ b/tests/test_coordination_events_helpers.py
@@ -1,0 +1,148 @@
+"""Contract tests for `governance_core/coordination_events_helpers.py`.
+
+Pinning the payload-shape rules so emission-site bugs surface here, not
+in production audit gaps.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from governance_core.coordination_events_helpers import (
+    VALID_ERROR_CLASSES,
+    make_boundary_payload,
+)
+
+
+class TestValidPayloads:
+    def test_timeout_with_no_status_code(self):
+        payload = make_boundary_payload(
+            endpoint="https://beam.local/v1/dispatch",
+            method="POST",
+            error_class="timeout",
+            status_code=None,
+            elapsed_ms=2050,
+        )
+        assert payload == {
+            "endpoint": "https://beam.local/v1/dispatch",
+            "method": "POST",
+            "error_class": "timeout",
+            "status_code": None,
+            "elapsed_ms": 2050,
+        }
+
+    def test_non_200_requires_status_code(self):
+        payload = make_boundary_payload(
+            endpoint="governance_mcp/process_agent_update",
+            method="POST",
+            error_class="non_200",
+            status_code=502,
+            elapsed_ms=140,
+        )
+        assert payload["status_code"] == 502
+        assert payload["error_class"] == "non_200"
+
+    def test_connect_error_with_unmeasured_elapsed(self):
+        payload = make_boundary_payload(
+            endpoint="https://beam.local/v1/identity/resolve",
+            method="GET",
+            error_class="connect_error",
+            status_code=None,
+            elapsed_ms=None,
+        )
+        assert payload["elapsed_ms"] is None
+        assert payload["status_code"] is None
+
+    def test_payload_is_a_fresh_dict(self):
+        # Ensure callers can't shoot themselves by mutating a shared default.
+        a = make_boundary_payload(
+            endpoint="x", method="POST", error_class="other",
+            status_code=None, elapsed_ms=None,
+        )
+        b = make_boundary_payload(
+            endpoint="x", method="POST", error_class="other",
+            status_code=None, elapsed_ms=None,
+        )
+        a["endpoint"] = "mutated"
+        assert b["endpoint"] == "x"
+
+    def test_key_order_matches_contract(self):
+        payload = make_boundary_payload(
+            endpoint="x", method="GET", error_class="decode_error",
+            status_code=None, elapsed_ms=42,
+        )
+        assert list(payload.keys()) == ["endpoint", "method", "error_class", "status_code", "elapsed_ms"]
+
+
+class TestRejectsInvalidInput:
+    def test_empty_endpoint_rejected(self):
+        with pytest.raises(ValueError, match="endpoint"):
+            make_boundary_payload(
+                endpoint="", method="POST", error_class="other",
+                status_code=None, elapsed_ms=None,
+            )
+
+    def test_whitespace_endpoint_rejected(self):
+        with pytest.raises(ValueError, match="endpoint"):
+            make_boundary_payload(
+                endpoint="   ", method="POST", error_class="other",
+                status_code=None, elapsed_ms=None,
+            )
+
+    def test_empty_method_rejected(self):
+        with pytest.raises(ValueError, match="method"):
+            make_boundary_payload(
+                endpoint="x", method="", error_class="other",
+                status_code=None, elapsed_ms=None,
+            )
+
+    def test_unknown_error_class_rejected(self):
+        with pytest.raises(ValueError, match="error_class"):
+            make_boundary_payload(
+                endpoint="x", method="POST", error_class="weird",
+                status_code=None, elapsed_ms=None,
+            )
+
+    def test_none_error_class_rejected(self):
+        with pytest.raises(ValueError, match="error_class"):
+            make_boundary_payload(
+                endpoint="x", method="POST", error_class=None,  # type: ignore[arg-type]
+                status_code=None, elapsed_ms=None,
+            )
+
+    def test_non_200_without_status_code_rejected(self):
+        with pytest.raises(ValueError, match="status_code"):
+            make_boundary_payload(
+                endpoint="x", method="POST", error_class="non_200",
+                status_code=None, elapsed_ms=None,
+            )
+
+    def test_status_code_wrong_type(self):
+        with pytest.raises(TypeError, match="status_code"):
+            make_boundary_payload(
+                endpoint="x", method="POST", error_class="non_200",
+                status_code="500",  # type: ignore[arg-type]
+                elapsed_ms=None,
+            )
+
+    def test_elapsed_ms_wrong_type(self):
+        with pytest.raises(TypeError, match="elapsed_ms"):
+            make_boundary_payload(
+                endpoint="x", method="POST", error_class="other",
+                status_code=None,
+                elapsed_ms="50",  # type: ignore[arg-type]
+            )
+
+
+class TestEnumIntegrity:
+    def test_valid_error_classes_match_documented_set(self):
+        # Pinned against `src/coordination_events.py`'s payload-shape comment.
+        # Adding a new error_class requires updating BOTH this set AND the
+        # documentation comment in coordination_events.py.
+        assert VALID_ERROR_CLASSES == frozenset({
+            "timeout",
+            "connect_error",
+            "non_200",
+            "decode_error",
+            "other",
+        })


### PR DESCRIPTION
## Summary

- New `governance_core/coordination_events_helpers.py::make_boundary_payload` enforces the documented payload contract for `coordination_failure.beam_python_boundary.*` events (per `src/coordination_events.py` Wave 2 schema-extension comments).
- Mandatory keyword args, validated `error_class` enum, type-checked `status_code`/`elapsed_ms`, key-order pinned to contract. Raises `ValueError`/`TypeError` so emission-site bugs surface in tests rather than as audit gaps in production.
- Lands ahead of Wave 3 wire-up call sites so the contract is pinned + lint-checkable before emissions arrive. Useful regardless of which (α/β/γ/δ) Wave 3 ultimately takes — the boundary payload shape is stable across all of them.

Context: this is the v0.3 RFC §14 PR #3 (Python side, scope-reduced — Elixir helper + CI lint deferred until Wave 3 RFC re-attempts post-measurement). The Wave 3 RFC itself is paused per `wave-3-substrate-relitigation` branch's amendment to the parent roadmap.

## Test plan

- [x] 14 contract tests in `tests/test_coordination_events_helpers.py` (valid payloads, invalid input rejection, enum integrity) — all passing locally
- [x] Pre-push smoke: 138 passed
- [ ] CI green on push