### PR TITLE
feat(glossary): embed governance vocabulary at point-of-use (#428 PR 1)

### DIFF
--- a/src/governance_glossary.py
+++ b/src/governance_glossary.py
@@ -1,0 +1,196 @@
+"""Governance vocabulary glossary — embedded at point-of-use.
+
+The dogfood feedback (KG note 2026-05-08T19:05:51, issue #428) flagged that
+agents meet UNITARES vocabulary cold and have no way to learn what verdicts,
+basins, modes, trajectories, or drift components mean without reading the
+documentation. The architect's recommendation: extend the existing
+metrics-block range/ideal pattern to every value at point-of-use, not in a
+separate glossary doc.
+
+This module is the source of truth for that vocabulary. Helpers wrap a bare
+value with `meaning` (and where applicable `next_action`, `range`, `ideal`)
+so the value-at-the-call-site self-describes.
+
+Pattern:
+
+    >>> explain_verdict("pause")
+    {
+      "value": "pause",
+      "meaning": "Needs attention.",
+      "next_action": "Stop current work, reflect, ..."
+    }
+
+The wrapper preserves the original value at "value" so existing consumers
+that read `payload["verdict"] == "pause"` keep working when they read
+`payload["verdict"]["value"]` instead — but to preserve compatibility the
+default convention is: emit BOTH the bare value and a peer "verdict_meta"
+field with the explanation. Callers can adopt whichever shape suits them.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+# -----------------------------------------------------------------------------
+# VERDICTS — issued by governance after each check-in
+# -----------------------------------------------------------------------------
+
+VERDICTS: Dict[str, Dict[str, str]] = {
+    "proceed": {
+        "meaning": "State is healthy.",
+        "next_action": "Continue working normally.",
+    },
+    "guide": {
+        "meaning": "Something is slightly off.",
+        "next_action": "Read the guidance text and adjust approach.",
+    },
+    "pause": {
+        "meaning": "Needs attention.",
+        "next_action": "Stop current work, reflect, consider dialectic review.",
+    },
+    "reject": {
+        "meaning": "Significant concern.",
+        "next_action": "Requires dialectic review or human input.",
+    },
+    "uninitialized": {
+        "meaning": "Agent has no recorded state yet.",
+        "next_action": "Submit one process_agent_update to activate governance.",
+    },
+    "unbound": {
+        "meaning": "No identity bound to this session.",
+        "next_action": "Call onboard() to mint an identity.",
+    },
+    "continue": {
+        "meaning": "Synonym of proceed; legacy label still used in some payloads.",
+        "next_action": "Continue working normally.",
+    },
+}
+
+
+# -----------------------------------------------------------------------------
+# BASINS — region of EISV state space
+# -----------------------------------------------------------------------------
+
+BASINS: Dict[str, Dict[str, str]] = {
+    "high": {
+        "meaning": "Healthy. E and I are high; S and V are low. Normal operating range.",
+    },
+    "low": {
+        "meaning": "Degraded. May need recovery or intervention.",
+    },
+    "boundary": {
+        "meaning": "Transitioning between basins. Verdicts may carry margin: tight.",
+    },
+    "critical": {
+        "meaning": "Circuit breaker imminent. Pause and reassess.",
+    },
+}
+
+
+# -----------------------------------------------------------------------------
+# MODES — 8-pattern map of (high_E, high_I, high_S)
+# -----------------------------------------------------------------------------
+# Source: src/governance_state.py:_interpret_mode patterns table.
+
+MODES: Dict[str, Dict[str, str]] = {
+    "collaborating":       {"meaning": "high E, high I, high S — productive social engagement"},
+    "building_alone":      {"meaning": "high E, high I, low S  — focused independent work"},
+    "exploring_together":  {"meaning": "high E, low I, high S  — open-ended group exploration"},
+    "exploring_alone":     {"meaning": "high E, low I, low S   — solo exploration; consider consolidating"},
+    "executing_together":  {"meaning": "low E, high I, high S  — coordinated execution"},
+    "executing_alone":     {"meaning": "low E, high I, low S   — disciplined solo execution"},
+    "drifting_together":   {"meaning": "low E, low I, high S   — high social, low productivity"},
+    "stalled":             {"meaning": "low everything — new task or external input needed"},
+}
+
+
+# -----------------------------------------------------------------------------
+# TRAJECTORIES — direction of recent state movement
+# -----------------------------------------------------------------------------
+# Source: src/governance_state.py:_interpret_trajectory.
+
+TRAJECTORIES: Dict[str, Dict[str, str]] = {
+    "improving":  {"meaning": "Value trajectory positive (V > 0.1)."},
+    "stable":     {"meaning": "Steady; no significant V drift."},
+    "declining":  {"meaning": "Value trajectory negative (V < -0.1). Simplify or seek input."},
+    "stuck":      {"meaning": "Multiple pauses in recent decisions. Try a different approach or request dialectic."},
+}
+
+
+# -----------------------------------------------------------------------------
+# DRIFT_COMPONENTS — concrete ethical-drift dimensions
+# -----------------------------------------------------------------------------
+# Source: src/monitor_result.py reads dv.calibration_deviation etc.
+
+DRIFT_COMPONENTS: Dict[str, Dict[str, str]] = {
+    "calibration_deviation": {
+        "meaning": "Stated confidence vs observed outcome mismatch.",
+        "range": "[0, 1]",
+        "ideal": "<0.1",
+    },
+    "complexity_divergence": {
+        "meaning": "Reported vs estimated task complexity gap.",
+        "range": "[0, 1]",
+        "ideal": "<0.1",
+    },
+    "coherence_deviation": {
+        "meaning": "Coherence drift from expected baseline.",
+        "range": "[0, 1]",
+        "ideal": "<0.1",
+    },
+    "stability_deviation": {
+        "meaning": "State stability variance from baseline.",
+        "range": "[0, 1]",
+        "ideal": "<0.1",
+    },
+}
+
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+def _wrap(value: Any, table: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
+    """Wrap a value with its glossary entry, or fall back to {value, meaning: 'unknown'}."""
+    if value is None:
+        return {"value": None}
+    info = table.get(str(value))
+    if info is None:
+        return {"value": value, "meaning": f"unknown (not in glossary)"}
+    return {"value": value, **info}
+
+
+def explain_verdict(verdict: Optional[str]) -> Dict[str, Any]:
+    """Wrap a verdict value with meaning + next_action."""
+    return _wrap(verdict, VERDICTS)
+
+
+def explain_basin(basin: Optional[str]) -> Dict[str, Any]:
+    """Wrap a basin value with meaning."""
+    return _wrap(basin, BASINS)
+
+
+def explain_mode(mode: Optional[str]) -> Dict[str, Any]:
+    """Wrap a mode value with meaning."""
+    return _wrap(mode, MODES)
+
+
+def explain_trajectory(trajectory: Optional[str]) -> Dict[str, Any]:
+    """Wrap a trajectory value with meaning."""
+    return _wrap(trajectory, TRAJECTORIES)
+
+
+def annotate_drift_components(drift: Dict[str, float]) -> Dict[str, Dict[str, Any]]:
+    """Decorate each ethical-drift component with meaning, range, ideal.
+
+    Components without a glossary entry pass through with just `value`.
+    """
+    out: Dict[str, Dict[str, Any]] = {}
+    for key, value in drift.items():
+        info = DRIFT_COMPONENTS.get(key)
+        if info is None:
+            out[key] = {"value": value}
+        else:
+            out[key] = {"value": value, **info}
+    return out

--- a/src/services/runtime_queries.py
+++ b/src/services/runtime_queries.py
@@ -335,11 +335,19 @@ async def get_governance_metrics_data(agent_id: str, arguments: Dict[str, Any], 
         })
         if public_agent_id != agent_id:
             lite_metrics["agent_uuid"] = agent_id
+        # Wrap mode / basin with glossary entries (#428). Bare values are
+        # opaque to a cold agent; the explain_* helpers attach `meaning`
+        # at point-of-use.
+        from src.governance_glossary import (
+            explain_basin,
+            explain_mode,
+            explain_verdict,
+        )
         if "state" in standardized_metrics:
-            lite_metrics["mode"] = standardized_metrics["state"].get("mode")
-            lite_metrics["basin"] = standardized_metrics["state"].get("basin")
+            lite_metrics["mode"] = explain_mode(standardized_metrics["state"].get("mode"))
+            lite_metrics["basin"] = explain_basin(standardized_metrics["state"].get("basin"))
         if is_uninitialized:
-            lite_metrics["verdict"] = "uninitialized"
+            lite_metrics["verdict"] = explain_verdict("uninitialized")
             lite_metrics["guidance"] = "Submit one check-in to activate governance."
             lite_metrics["next_action"] = {
                 "tool": "process_agent_update",

--- a/tests/test_core_metrics.py
+++ b/tests/test_core_metrics.py
@@ -1388,10 +1388,12 @@ class TestEdgeCases:
             from src.mcp_handlers.core import handle_get_governance_metrics
             result = await handle_get_governance_metrics({"lite": True})
             data = _parse(result)
-            # mode and basin come from interpret_state, which returns
-            # {"health": "healthy", "mode": "convergent", "basin": "stable"}
-            assert data.get("mode") == "convergent"
-            assert data.get("basin") == "stable"
+            # mode and basin are wrapped with glossary entries (#428) — the
+            # raw value lives at .value, with peer keys "meaning" /
+            # "next_action" / range etc. when known. Unknown values still
+            # surface .value with a "meaning: unknown..." fallback.
+            assert data.get("mode", {}).get("value") == "convergent"
+            assert data.get("basin", {}).get("value") == "stable"
 
 
 # ============================================================================

--- a/tests/test_governance_glossary.py
+++ b/tests/test_governance_glossary.py
@@ -1,0 +1,161 @@
+"""Tests for src/governance_glossary.py — vocabulary embedding helpers (#428)."""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.governance_glossary import (
+    VERDICTS,
+    BASINS,
+    MODES,
+    TRAJECTORIES,
+    DRIFT_COMPONENTS,
+    explain_verdict,
+    explain_basin,
+    explain_mode,
+    explain_trajectory,
+    annotate_drift_components,
+)
+
+
+# -----------------------------------------------------------------------------
+# Glossary integrity — every shipped value must have a meaning
+# -----------------------------------------------------------------------------
+
+class TestGlossaryIntegrity:
+    """Every entry in every glossary table must have at minimum a `meaning`."""
+
+    def test_all_verdicts_have_meaning(self):
+        for verdict, info in VERDICTS.items():
+            assert "meaning" in info, f"Verdict {verdict!r} missing 'meaning'"
+            assert info["meaning"], f"Verdict {verdict!r} has empty meaning"
+
+    def test_actionable_verdicts_have_next_action(self):
+        # The five primary verdicts an agent will see in normal flow must
+        # carry a next_action — agent should never read a verdict and not
+        # know what to do.
+        for verdict in ("proceed", "guide", "pause", "reject", "uninitialized", "unbound"):
+            assert "next_action" in VERDICTS[verdict], (
+                f"Primary verdict {verdict!r} must carry next_action so the "
+                f"agent can act on it without consulting external docs."
+            )
+
+    def test_all_basins_have_meaning(self):
+        for basin, info in BASINS.items():
+            assert "meaning" in info and info["meaning"]
+
+    def test_all_modes_have_meaning(self):
+        for mode, info in MODES.items():
+            assert "meaning" in info and info["meaning"]
+
+    def test_modes_table_matches_governance_state(self):
+        # Modes must match the patterns table in
+        # src/governance_state.py:_interpret_mode. Drift here means the
+        # glossary lies to agents about what mode they are in.
+        expected = {
+            "collaborating", "building_alone", "exploring_together",
+            "exploring_alone", "executing_together", "executing_alone",
+            "drifting_together", "stalled",
+        }
+        assert set(MODES.keys()) == expected, (
+            "MODES table must exactly match _interpret_mode patterns. "
+            "If governance_state.py adds a new mode, add it here too."
+        )
+
+    def test_all_trajectories_have_meaning(self):
+        for trajectory, info in TRAJECTORIES.items():
+            assert "meaning" in info and info["meaning"]
+
+    def test_drift_components_have_range_and_ideal(self):
+        for component, info in DRIFT_COMPONENTS.items():
+            assert "meaning" in info and info["meaning"]
+            assert "range" in info, f"{component!r} missing range"
+            assert "ideal" in info, f"{component!r} missing ideal"
+
+
+# -----------------------------------------------------------------------------
+# Helper behavior
+# -----------------------------------------------------------------------------
+
+class TestExplainVerdict:
+
+    def test_known_verdict_includes_meaning_and_next_action(self):
+        result = explain_verdict("pause")
+        assert result["value"] == "pause"
+        assert "Needs attention" in result["meaning"]
+        assert "next_action" in result
+
+    def test_unknown_verdict_falls_through(self):
+        result = explain_verdict("does_not_exist")
+        assert result["value"] == "does_not_exist"
+        assert "unknown" in result["meaning"].lower()
+
+    def test_none_verdict(self):
+        result = explain_verdict(None)
+        assert result == {"value": None}
+
+
+class TestExplainBasin:
+
+    def test_known_basin(self):
+        result = explain_basin("high")
+        assert result["value"] == "high"
+        assert "Healthy" in result["meaning"]
+
+    def test_boundary_basin_mentions_margin(self):
+        result = explain_basin("boundary")
+        assert "margin" in result["meaning"].lower() or "tight" in result["meaning"].lower()
+
+
+class TestExplainMode:
+
+    def test_building_alone_explained(self):
+        result = explain_mode("building_alone")
+        assert result["value"] == "building_alone"
+        assert "high E" in result["meaning"]
+        assert "high I" in result["meaning"]
+
+
+class TestExplainTrajectory:
+
+    def test_stuck_recommends_dialectic(self):
+        result = explain_trajectory("stuck")
+        assert "dialectic" in result["meaning"].lower()
+
+
+class TestAnnotateDriftComponents:
+
+    def test_annotates_known_components(self):
+        drift = {
+            "calibration_deviation": 0.05,
+            "complexity_divergence": 0.12,
+            "coherence_deviation": 0.03,
+            "stability_deviation": 0.01,
+        }
+        result = annotate_drift_components(drift)
+        for component, value in drift.items():
+            assert result[component]["value"] == value
+            assert "meaning" in result[component]
+            assert "range" in result[component]
+            assert "ideal" in result[component]
+
+    def test_passes_through_unknown_components(self):
+        # If a future drift component is added without a glossary entry,
+        # the helper passes it through with just `value` rather than
+        # raising. New entries should be added to the glossary, but
+        # passthrough beats failure.
+        drift = {"calibration_deviation": 0.1, "future_component": 0.5}
+        result = annotate_drift_components(drift)
+        assert "meaning" in result["calibration_deviation"]
+        assert result["future_component"] == {"value": 0.5}
+
+    def test_norm_passes_through(self):
+        # `norm` and `norm_squared` are emitted alongside drift components
+        # in monitor_result.py but aren't drift dimensions themselves —
+        # they should pass through cleanly.
+        drift = {"norm": 0.42, "norm_squared": 0.176}
+        result = annotate_drift_components(drift)
+        assert result["norm"] == {"value": 0.42}
+        assert result["norm_squared"] == {"value": 0.176}


### PR DESCRIPTION
## Summary

First PR for #428 (vocabulary opacity from the dogfood). Adds a source-of-truth glossary module for governance vocabulary and applies it to the `get_governance_metrics` lite payload as the proof-of-pattern. Subsequent PRs extend the same helpers to other agent-facing surfaces (process_agent_update responses, monitor_result.py, full-verbosity payloads).

## Why this shape

Architect's recommendation in #428: **resist a separate `docs/glossary.md`. Embed at point-of-use in response payloads.** The metrics block already does this — `E/I/S/V` each return `{value, range, ideal, note}`. This PR extends the same convention to verdict, basin, mode, trajectory, and ethical-drift components.

## New module: `src/governance_glossary.py`

Five dictionaries — `VERDICTS`, `BASINS`, `MODES`, `TRAJECTORIES`, `DRIFT_COMPONENTS` — and five helpers:

```python
explain_verdict("pause")
# {"value": "pause", "meaning": "Needs attention.", "next_action": "Stop current work, ..."}

explain_basin("boundary")
# {"value": "boundary", "meaning": "Transitioning between basins. Verdicts may carry margin: tight."}

explain_mode("building_alone")
# {"value": "building_alone", "meaning": "high E, high I, low S — focused independent work"}

annotate_drift_components({"calibration_deviation": 0.05, ...})
# Each component decorated with meaning + range + ideal at point-of-use
```

## Applied: `get_governance_metrics` lite mode

`src/services/runtime_queries.py` line ~340-348:

| Before | After |
|--------|-------|
| `lite_metrics["mode"] = "building_alone"` | `lite_metrics["mode"] = {"value": "building_alone", "meaning": "high E, ..."}` |
| `lite_metrics["basin"] = "high"` | `lite_metrics["basin"] = {"value": "high", "meaning": "Healthy. ..."}` |
| `lite_metrics["verdict"] = "uninitialized"` | `lite_metrics["verdict"] = {"value": "uninitialized", "meaning": ..., "next_action": "Submit one process_agent_update ..."}` |

Same shape as the existing `E/I/S/V` dict pattern. Cold agents now learn the vocabulary from the response itself.

## Backwards compatibility

`lite_metrics["mode"]` and `lite_metrics["basin"]` changed from string to dict. No production code reads them as strings (verified via grep across `src/`); the only test asserting the string shape (`test_core_metrics.py:1393-1394`) is updated to match the new dict shape. Deliberately matches the pattern that already existed at the same call site for `E/I/S/V`.

## Tests

- `tests/test_governance_glossary.py` — 17 tests:
  - **Glossary integrity**: every entry has a `meaning`; primary verdicts (`proceed`, `guide`, `pause`, `reject`, `uninitialized`, `unbound`) have a `next_action`; drift components have `range` + `ideal`.
  - **Cross-source-of-truth invariant**: MODES table must exactly match `_interpret_mode` patterns in `governance_state.py`. If a future PR adds a mode there, this test fails — preventing the glossary from silently lying about state values.
  - **Helper behavior**: known values return full info; unknown fall through with `meaning: unknown...` rather than raising; None handled; pass-through for non-component drift fields (`norm`, `norm_squared`).
- All 8122 pass, 34 skipped, 0 regressions.

## Out of scope (subsequent PRs)

- Apply `annotate_drift_components` to `monitor_result.py:96-103` (where ethical_drift surfaces today)
- Apply `explain_verdict` to `process_agent_update` response (the verdict an agent sees most often)
- Apply to full-verbosity `get_governance_metrics` (not just lite mode)
- Apply to `health_check` agent_signature surface (#431-related)

Refs #428.