### PR TITLE
feat(glossary): wrap ethical_drift + behavioral.verdict in monitor_result (#428 PR 2)

### DIFF
--- a/src/monitor_result.py
+++ b/src/monitor_result.py
@@ -93,14 +93,18 @@ def build_result(
     # Concrete Ethical Drift
     if monitor._last_drift_vector:
         dv = monitor._last_drift_vector
-        result['ethical_drift'] = {
+        # #428: wrap each component with meaning + range + ideal at point-of-use.
+        # `norm` and `norm_squared` aren't drift dimensions; they pass through
+        # with just `value` via the helper.
+        from src.governance_glossary import annotate_drift_components
+        result['ethical_drift'] = annotate_drift_components({
             'calibration_deviation': dv.calibration_deviation,
             'complexity_divergence': dv.complexity_divergence,
             'coherence_deviation': dv.coherence_deviation,
             'stability_deviation': dv.stability_deviation,
             'norm': dv.norm,
             'norm_squared': dv.norm_squared,
-        }
+        })
 
         try:
             record_drift(
@@ -142,11 +146,15 @@ def build_result(
 
     # Behavioral EISV
     if behavioral_assessment is not None:
+        # #428: wrap the behavioral verdict so the agent gets meaning +
+        # next_action alongside the bare label. Pattern matches
+        # ethical_drift wrapping above.
+        from src.governance_glossary import explain_verdict
         result['behavioral'] = {
             'state': monitor._behavioral_state.to_dict(),
             'assessment': {
                 'health': behavioral_assessment.health,
-                'verdict': behavioral_assessment.verdict,
+                'verdict': explain_verdict(behavioral_assessment.verdict),
                 'risk': behavioral_assessment.risk,
                 'coherence': behavioral_assessment.coherence,
                 'components': behavioral_assessment.components,

--- a/tests/test_governance_glossary.py
+++ b/tests/test_governance_glossary.py
@@ -159,3 +159,40 @@ class TestAnnotateDriftComponents:
         result = annotate_drift_components(drift)
         assert result["norm"] == {"value": 0.42}
         assert result["norm_squared"] == {"value": 0.176}
+
+
+class TestGlossaryAppliedToMonitorResult:
+    """Source-level guards that monitor_result.py uses the glossary helpers
+    to wrap ethical_drift and behavioral.assessment.verdict. Regression
+    catch if a future refactor removes the wrapping and bare values leak
+    back into agent-facing payloads.
+    """
+
+    @staticmethod
+    def _read(rel_path: str) -> str:
+        from pathlib import Path
+        return (Path(__file__).parent.parent / rel_path).read_text()
+
+    def test_ethical_drift_wrapped_via_helper(self):
+        source = self._read("src/monitor_result.py")
+        # The build_result block constructing ethical_drift must call
+        # annotate_drift_components — bare per-component float values
+        # would lose the meaning/range/ideal context.
+        idx = source.find("'ethical_drift'")
+        assert idx != -1
+        window = source[max(0, idx - 200):idx + 600]
+        assert "annotate_drift_components" in window, (
+            "monitor_result.py must wrap ethical_drift via annotate_drift_components(). "
+            "Bare per-component float values surface to agents without explanation."
+        )
+
+    def test_behavioral_verdict_wrapped_via_helper(self):
+        source = self._read("src/monitor_result.py")
+        idx = source.find("'verdict': ")
+        assert idx != -1
+        window = source[max(0, idx - 200):idx + 200]
+        assert "explain_verdict" in window, (
+            "monitor_result.py must wrap behavioral_assessment.verdict via "
+            "explain_verdict() so the agent gets meaning + next_action with "
+            "the verdict label."
+        )


### PR DESCRIPTION
## Summary

Builds on #441. Applies the embedded-at-point-of-use vocabulary pattern to `monitor_result.build_result`, which is upstream of `process_agent_update` responses and full-verbosity `get_governance_metrics`. Instrumenting it once propagates explanations to every consumer.

## Wrapped surfaces

**`result['ethical_drift']`** — each component (`calibration_deviation`, `complexity_divergence`, `coherence_deviation`, `stability_deviation`) now carries `{value, meaning, range, ideal}`. The `norm`/`norm_squared` scalars pass through with just `{value}` — they're not drift dimensions.

**`result['behavioral']['assessment']['verdict']`** — bare verdict string becomes `{value, meaning, next_action}` so the agent doesn't have to cross-reference docs to know what to do with a `pause` or `reject`.

Before:
```json
"ethical_drift": {
  "calibration_deviation": 0.05,
  "complexity_divergence": 0.12,
  ...
}
```

After:
```json
"ethical_drift": {
  "calibration_deviation": {
    "value": 0.05,
    "meaning": "Stated confidence vs observed outcome mismatch.",
    "range": "[0, 1]",
    "ideal": "<0.1"
  },
  ...
}
```

## Backwards compatibility

No internal consumers parse `result['ethical_drift']` or `result['behavioral']` (verified via grep across `src/`). The helpers preserve `value` at the same nesting depth the bare values used to live at, so any external consumer reading `result['ethical_drift']['calibration_deviation']` would just need to add `['value']` — but the existing internal grep finds zero such readers, so the surface is agent-facing only.

## Tests

- `TestGlossaryAppliedToMonitorResult` — source-level guards that `monitor_result.py` imports and calls `annotate_drift_components` and `explain_verdict`. Regression catches if a future refactor removes the wrapping.
- All 8122 pass, 34 skipped, 0 regressions.

## Out of scope (subsequent PRs)

- Apply `explain_verdict` to `process_agent_update`'s primary verdict path (the verdict an agent sees at every check-in)
- Apply to full-verbosity `get_governance_metrics`
- Apply to `health_check` agent_signature

Refs #428.