### PR TITLE
feat(glossary): wrap verdict at response_formatter + unbound surfaces (#428 PR 3)

### DIFF
--- a/src/mcp_handlers/core.py
+++ b/src/mcp_handlers/core.py
@@ -125,9 +125,14 @@ async def handle_get_governance_metrics(arguments: ToolArgumentsDict) -> Sequenc
         except Exception:
             bound_agent_id = None
         if not bound_agent_id:
+            # #428: wrap the bare "unbound" string with meaning + next_action.
+            # The peer next_action below carries the same hint with a tool +
+            # example; the wrapped verdict carries the canonical glossary
+            # entry so the two surfaces can't drift.
+            from src.governance_glossary import explain_verdict
             return success_response({
                 "status": "⚪ unbound",
-                "verdict": "unbound",
+                "verdict": explain_verdict("unbound"),
                 "guidance": "Establish identity before reading agent metrics.",
                 "next_action": {
                     "tool": "identity",

--- a/src/mcp_handlers/response_formatter.py
+++ b/src/mcp_handlers/response_formatter.py
@@ -174,7 +174,12 @@ def _format_mirror(response_data: dict, saved_trust_tier: Optional[str], meta: A
     decision = response_data.get("decision", {}) if isinstance(response_data.get("decision"), dict) else {}
     metrics = response_data.get("metrics", {}) if isinstance(response_data.get("metrics"), dict) else {}
 
-    verdict = decision.get("action", "continue")
+    # #428: wrap the verdict with meaning + next_action at the response
+    # surface. Internal consumers read decision["action"] / metrics["verdict"]
+    # as bare strings; only the agent-facing payload key is wrapped.
+    from src.governance_glossary import explain_verdict
+    verdict_raw = decision.get("action", "continue")
+    verdict = explain_verdict(verdict_raw)
 
     # Collect mirror signals from enrichment-produced data
     mirror_signals = list(response_data.get("_mirror_signals", []))
@@ -352,6 +357,10 @@ def _format_compact(response_data: dict, using_default_mode: bool, saved_trust_t
     if canonical_risk is None:
         canonical_risk = metrics.get("risk_score")
 
+    # #428: wrap verdict with meaning + next_action at the response surface.
+    # The bare metrics["verdict"] is preserved for internal readers; this is
+    # a new dict consumed only by the agent-facing payload.
+    from src.governance_glossary import explain_verdict
     compact_metrics = {
         "E": metrics.get("E"),
         "I": metrics.get("I"),
@@ -360,7 +369,7 @@ def _format_compact(response_data: dict, using_default_mode: bool, saved_trust_t
         "coherence": metrics.get("coherence"),
         "risk_score": canonical_risk,
         "phi": metrics.get("phi"),
-        "verdict": metrics.get("verdict"),
+        "verdict": explain_verdict(metrics.get("verdict")),
         "lambda1": metrics.get("lambda1"),
         "health_status": metrics.get("health_status"),
         "health_message": metrics.get("health_message"),

--- a/tests/test_governance_glossary.py
+++ b/tests/test_governance_glossary.py
@@ -196,3 +196,51 @@ class TestGlossaryAppliedToMonitorResult:
             "explain_verdict() so the agent gets meaning + next_action with "
             "the verdict label."
         )
+
+
+class TestGlossaryAppliedToResponseFormatter:
+    """Source-level guards that the agent-facing response surface
+    (mirror, compact, unbound branch) wraps the verdict via the helper.
+    Most agent-noticeable surface for #428 — every check-in returns a
+    verdict; without wrapping the agent has to consult docs to act on it.
+    """
+
+    @staticmethod
+    def _read(rel_path: str) -> str:
+        from pathlib import Path
+        return (Path(__file__).parent.parent / rel_path).read_text()
+
+    def test_mirror_format_wraps_verdict(self):
+        source = self._read("src/mcp_handlers/response_formatter.py")
+        idx = source.find("def _format_mirror")
+        assert idx != -1
+        end = source.find("\ndef ", idx + 1)
+        window = source[idx:end if end != -1 else len(source)]
+        assert "explain_verdict" in window, (
+            "response_formatter._format_mirror must wrap verdict via "
+            "explain_verdict() at the response surface — mirror is the "
+            "highest-traffic agent-facing path."
+        )
+
+    def test_compact_metrics_wraps_verdict(self):
+        source = self._read("src/mcp_handlers/response_formatter.py")
+        idx = source.find("compact_metrics = {")
+        assert idx != -1
+        window = source[max(0, idx - 300):idx + 600]
+        assert "explain_verdict" in window, (
+            "compact_metrics must wrap verdict via explain_verdict() — "
+            "this is the response_mode='compact' agent surface."
+        )
+
+    def test_unbound_verdict_wrapped_in_core(self):
+        # The "unbound" verdict surfaces when get_governance_metrics is
+        # called against a session with no bound identity.
+        source = self._read("src/mcp_handlers/core.py")
+        idx = source.find('"verdict": ')
+        assert idx != -1
+        window = source[max(0, idx - 300):idx + 200]
+        assert "explain_verdict" in window, (
+            "core.py unbound branch must wrap the bare 'unbound' verdict "
+            "via explain_verdict() so an unbound agent gets the next-action "
+            "hint without consulting docs."
+        )

--- a/tests/test_handlers_core.py
+++ b/tests/test_handlers_core.py
@@ -297,7 +297,9 @@ class TestGetGovernanceMetrics:
             result = await handle_get_governance_metrics({"client_session_id": "agent-missing"})
 
             data = json.loads(result[0].text)
-            assert data["verdict"] == "unbound"
+            # #428: verdict is wrapped with meaning + next_action at the
+            # response surface. The bare value lives at .value.
+            assert data["verdict"]["value"] == "unbound"
             assert data["next_action"]["tool"] == "identity"
             mock_mcp_server.get_or_create_monitor.assert_not_called()
 

--- a/tests/test_response_formatter.py
+++ b/tests/test_response_formatter.py
@@ -485,7 +485,11 @@ class TestFormatMirror:
         data = _sample_response()
         data["decision"]["action"] = "pause"
         result = _format_mirror(data, saved_trust_tier=None)
-        assert result["verdict"] == "pause"
+        # #428: verdict is now wrapped with meaning + next_action at the
+        # response surface. The raw value lives at .value.
+        assert result["verdict"]["value"] == "pause"
+        assert "Needs attention" in result["verdict"]["meaning"]
+        assert "next_action" in result["verdict"]
 
     def test_calibration_insight_inverted(self):
         data = _sample_response()


### PR DESCRIPTION
## Summary

Builds on #441 + #442. Wraps the verdict at the most agent-facing surfaces — the mirror response, compact metrics, and the unbound branch in `get_governance_metrics`. Every check-in returns a verdict; without wrapping, the agent reads `"pause"` / `"guide"` / `"unbound"` and has to consult external docs to act.

## Wrapped surfaces

| File | Surface | Before | After |
|------|---------|--------|-------|
| `src/mcp_handlers/response_formatter.py` | `_format_mirror` `result["verdict"]` | `"pause"` | `{value: "pause", meaning: "Needs attention.", next_action: "Stop current work, ..."}` |
| `src/mcp_handlers/response_formatter.py` | `compact_metrics["verdict"]` | `"proceed"` | `{value: "proceed", meaning: "State is healthy.", next_action: "Continue working normally."}` |
| `src/mcp_handlers/core.py` | unbound branch `"verdict"` | `"unbound"` | `{value: "unbound", meaning: "No identity bound to this session.", next_action: "Call onboard() to mint an identity."}` |

## Internal vs response surface

Internal consumers that compare `metrics["verdict"]` or `decision["action"]` as bare strings are unaffected — those are different keys read upstream of `response_formatter`. Only the agent-facing payload key is wrapped.

## Test updates

The only test surfaces reading these specific keys:

- `tests/test_response_formatter.py::test_verdict_from_decision` — reads `result["verdict"]["value"]` and additionally asserts meaning + next_action are surfaced.
- `tests/test_handlers_core.py::test_get_metrics_unbound_does_not_create_monitor` — reads `data["verdict"]["value"]`.

## New source-level guards

In `tests/test_governance_glossary.py`:

- `TestGlossaryAppliedToResponseFormatter.test_mirror_format_wraps_verdict`
- `TestGlossaryAppliedToResponseFormatter.test_compact_metrics_wraps_verdict`
- `TestGlossaryAppliedToResponseFormatter.test_unbound_verdict_wrapped_in_core`

Each catches the regression "someone removed the wrapping" — substring assertion on `explain_verdict` import scope.

## Result

- 8127 tests pass, 34 skipped, 0 regressions.

## Out of scope (subsequent PRs)

- Apply `explain_basin` / `explain_mode` / `explain_trajectory` to non-lite payloads (full-verbosity `get_governance_metrics`, observability tools).
- Apply to `health_check` agent_signature surface (#431-related).

After this PR, the most agent-noticed verdict-bearing surfaces are wrapped end-to-end. Cold agents now learn what `pause` and `guide` and `unbound` mean from the response itself.

Refs #428.