### PR TITLE
fix(sentinel): give fleet finding emitter its own lease surface

### DIFF
--- a/elixir/sentinel/lib/unitares_sentinel/application.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/application.ex
@@ -102,7 +102,11 @@ defmodule UnitaresSentinel.Application do
       initial_delay_ms:
         Application.get_env(:unitares_sentinel, :analysis_initial_delay_ms, 5_000),
       jitter_ms: Application.get_env(:unitares_sentinel, :analysis_jitter_ms, 5_000),
-      tick_timeout_ms: Application.get_env(:unitares_sentinel, :analysis_tick_timeout_ms, 45_000)
+      tick_timeout_ms: Application.get_env(:unitares_sentinel, :analysis_tick_timeout_ms, 45_000),
+      # Distinct surface from ForcedReleasePoller's resident:/sentinel_cycle so
+      # the two GenServers don't collide as held_by_other when their tick
+      # windows overlap (KG 2026-05-08T02:14:43.822544+00:00).
+      lease_opts: [surface_id: "resident:/sentinel_fleet_emit"]
     ]
     |> maybe_add_checkin_anchor()
   end

--- a/elixir/sentinel/test/unitares_sentinel/application_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/application_test.exs
@@ -21,6 +21,12 @@ defmodule UnitaresSentinel.ApplicationTest do
     :ok
   end
 
+  test "fleet finding emitter uses its own lease surface, distinct from sentinel_cycle" do
+    opts = SentinelApplication.fleet_finding_emitter_opts()
+
+    assert opts[:lease_opts][:surface_id] == "resident:/sentinel_fleet_emit"
+  end
+
   test "fleet finding emitter carries the Sentinel anchor when check-ins are enabled" do
     path =
       Path.join(System.tmp_dir!(), "sentinel-anchor-#{System.unique_integer([:positive])}.json")


### PR DESCRIPTION
## Summary

Two GenServers in the BEAM Sentinel runtime were sharing the lease surface `resident:/sentinel_cycle`: the periodic Sentinel-cycle ticker and the FleetFindingEmitter. When their tick windows overlapped, the second to acquire saw `held_by_other` and silently no-op'd — losing fleet findings on overlap.

Fix: give the fleet finding emitter its own surface — `resident:/sentinel_fleet_emit` — wired through `lease_opts` in `application.ex`.

KG note: `2026-05-08T02:14:43.822544+00:00` — the diagnosis was already in the graph; the code fix had stalled in a detached worktree for two days.

## Test plan
- [x] `mix test test/unitares_sentinel/application_test.exs` (2 passed) — new regression test pins the surface_id
- [ ] CI Tests gate (Python smoke + full)
- [ ] CodeQL