### PR TITLE
fix(validators): make apply_param_aliases non-destructive on collision

### DIFF
--- a/src/mcp_handlers/validators.py
+++ b/src/mcp_handlers/validators.py
@@ -12,16 +12,43 @@ from typing import Dict, Any, Optional, Tuple, List
 from mcp.types import TextContent
 from .utils import error_response
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
+from src.logging_utils import get_logger
+
+logger = get_logger(__name__)
 PARAM_ALIASES: Dict[str, Dict[str, str]] = {'store_knowledge_graph': {'discovery': 'summary', 'insight': 'summary', 'finding': 'summary', 'content': 'details', 'text': 'summary', 'message': 'summary', 'note': 'summary', 'learning': 'summary', 'observation': 'summary', 'type': 'discovery_type', 'kind': 'discovery_type', 'category': 'discovery_type'}, 'leave_note': {'discovery': 'summary', 'insight': 'summary', 'finding': 'summary', 'text': 'summary', 'note': 'summary', 'content': 'summary', 'message': 'summary', 'learning': 'summary'}, 'search_knowledge_graph': {'search': 'query', 'term': 'query', 'text': 'query', 'find': 'query'}, 'process_agent_update': {'text': 'response_text', 'message': 'response_text', 'update': 'response_text', 'content': 'response_text', 'work': 'response_text', 'summary': 'response_text'}, 'identity': {'label': 'name', 'display_name': 'name', 'nickname': 'name'}, 'agent': {'op': 'action'}}
 
 def apply_param_aliases(tool_name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
-    """Apply parameter aliases - convert intuitive names to canonical ones."""
+    """Apply parameter aliases - convert intuitive names to canonical ones.
+
+    Collision policy: when both an alias and its canonical key are present,
+    the canonical value wins and the alias is dropped (warning logged if the
+    values differ). The previous one-pass implementation let dict-iteration
+    order decide, which silently clobbered an explicit canonical value —
+    e.g. leave_note(summary=..., content=...) overwrote summary with content
+    because content aliases to summary.
+    """
     aliases = PARAM_ALIASES.get(tool_name)
     if not aliases:
         return arguments
-    result = {}
+    result: Dict[str, Any] = {}
+    # Pass 1: copy non-aliased keys verbatim. Canonical values supplied
+    # directly land here untouched regardless of dict iteration order.
     for key, value in arguments.items():
-        canonical = aliases.get(key, key)
+        if key not in aliases:
+            result[key] = value
+    # Pass 2: apply aliases only where the canonical slot is unfilled.
+    for key, value in arguments.items():
+        if key not in aliases:
+            continue
+        canonical = aliases[key]
+        if canonical in result:
+            if result[canonical] != value:
+                logger.warning(
+                    "apply_param_aliases(%r): alias %r collides with canonical %r; "
+                    "keeping canonical, dropping alias value",
+                    tool_name, key, canonical,
+                )
+            continue
         result[canonical] = value
     return result
 # Legacy generic validators removed (Pydantic schemas now handle types, enums, and bounds)

--- a/src/mcp_handlers/validators.py
+++ b/src/mcp_handlers/validators.py
@@ -43,10 +43,15 @@ def apply_param_aliases(tool_name: str, arguments: Dict[str, Any]) -> Dict[str, 
         canonical = aliases[key]
         if canonical in result:
             if result[canonical] != value:
+                # canonical is sourced from the static PARAM_ALIASES values
+                # (no taint from arguments). The aliased key itself is not
+                # logged — caller-supplied keys could in principle contain
+                # sensitive identifiers, and CodeQL's clear-text-logging
+                # rule (correctly) treats arguments.items() as tainted.
                 logger.warning(
-                    "apply_param_aliases(%r): alias %r collides with canonical %r; "
+                    "apply_param_aliases(%r): an alias collided with canonical %r; "
                     "keeping canonical, dropping alias value",
-                    tool_name, key, canonical,
+                    tool_name, canonical,
                 )
             continue
         result[canonical] = value

--- a/tests/test_param_aliases.py
+++ b/tests/test_param_aliases.py
@@ -1,0 +1,111 @@
+"""Regression tests for apply_param_aliases collision handling.
+
+The original one-pass implementation rewrote canonical keys with aliased
+values when both were present, depending on dict iteration order. A
+2026-05-09 leave_note call with summary=... and content=... saw content
+overwrite summary, dropping the actual summary text and corrupting the
+KG record. These tests pin the non-destructive collision policy.
+"""
+
+import logging
+
+from src.mcp_handlers.validators import apply_param_aliases
+
+
+def test_unknown_tool_returns_arguments_unchanged():
+    args = {"foo": 1, "bar": 2}
+    out = apply_param_aliases("not_a_tool", args)
+    assert out is args  # passthrough preserves identity
+
+
+def test_alias_only_is_renamed_to_canonical():
+    out = apply_param_aliases("leave_note", {"text": "hello"})
+    assert out == {"summary": "hello"}
+
+
+def test_canonical_only_passes_through():
+    out = apply_param_aliases("leave_note", {"summary": "hello"})
+    assert out == {"summary": "hello"}
+
+
+def test_alias_and_canonical_both_present_canonical_wins():
+    out = apply_param_aliases(
+        "leave_note", {"summary": "real-summary", "content": "extended-body"}
+    )
+    assert out == {"summary": "real-summary"}
+
+
+def test_collision_order_independent_canonical_first():
+    # Insertion order: canonical first
+    out = apply_param_aliases(
+        "leave_note", {"summary": "real", "content": "should-drop"}
+    )
+    assert out["summary"] == "real"
+
+
+def test_collision_order_independent_alias_first():
+    # Insertion order: alias first
+    out = apply_param_aliases(
+        "leave_note", {"content": "should-drop", "summary": "real"}
+    )
+    assert out["summary"] == "real"
+
+
+def test_collision_emits_warning(caplog):
+    with caplog.at_level(logging.WARNING, logger="src.mcp_handlers.validators"):
+        apply_param_aliases(
+            "leave_note", {"summary": "kept", "content": "dropped"}
+        )
+    assert any(
+        "alias 'content' collides with canonical 'summary'" in rec.getMessage()
+        for rec in caplog.records
+    )
+
+
+def test_equal_values_no_warning(caplog):
+    with caplog.at_level(logging.WARNING, logger="src.mcp_handlers.validators"):
+        apply_param_aliases(
+            "leave_note", {"summary": "same", "content": "same"}
+        )
+    assert not [
+        r for r in caplog.records if "collides" in r.getMessage()
+    ]
+
+
+def test_store_knowledge_content_alias_for_details_does_not_clobber():
+    # store_knowledge_graph aliases content -> details; both present means
+    # details (canonical) must win.
+    out = apply_param_aliases(
+        "store_knowledge_graph",
+        {"summary": "s", "details": "real-details", "content": "extra"},
+    )
+    assert out["details"] == "real-details"
+    assert out["summary"] == "s"
+
+
+def test_process_agent_update_summary_alias_for_response_text():
+    # process_agent_update aliases summary -> response_text. Both present:
+    # response_text wins.
+    out = apply_param_aliases(
+        "process_agent_update",
+        {"response_text": "real", "summary": "should-drop"},
+    )
+    assert out == {"response_text": "real"}
+
+
+def test_unrelated_keys_pass_through():
+    out = apply_param_aliases(
+        "leave_note",
+        {"summary": "s", "tags": ["a", "b"], "agent_id": "x"},
+    )
+    assert out == {"summary": "s", "tags": ["a", "b"], "agent_id": "x"}
+
+
+def test_multiple_aliases_to_same_canonical_first_wins():
+    # leave_note has many aliases all mapping to summary. If two are
+    # supplied without canonical, first encountered wins; later ones
+    # are dropped (whichever path: collision against earlier-set canonical).
+    out = apply_param_aliases(
+        "leave_note", {"text": "first", "note": "second"}
+    )
+    assert out == {"summary": "first"}

--- a/tests/test_param_aliases.py
+++ b/tests/test_param_aliases.py
@@ -57,7 +57,7 @@ def test_collision_emits_warning(caplog):
             "leave_note", {"summary": "kept", "content": "dropped"}
         )
     assert any(
-        "alias 'content' collides with canonical 'summary'" in rec.getMessage()
+        "alias collided with canonical 'summary'" in rec.getMessage()
         for rec in caplog.records
     )
 


### PR DESCRIPTION
## Problem

`apply_param_aliases` (`src/mcp_handlers/validators.py`) ran a single pass that let dict-iteration order pick which value survived when both an alias and its canonical key were passed. Real failure mode caught today (2026-05-09):

```python
knowledge(action="note", summary="real summary", content="extended body")
```

The `leave_note` aliases include `content -> summary`. Iteration saw `summary` first, then `content`, so the alias overwrote the canonical with the extended body. The note was saved with the wrong text in the summary field and tags that depended on the canonical never got attached cleanly. Same shape exists in:

- `store_knowledge_graph`: `content -> details`
- `process_agent_update`: `summary -> response_text`

## Fix

Two-pass implementation in `apply_param_aliases`:

1. Copy every non-aliased key verbatim. Canonical values supplied directly always land regardless of iteration order.
2. Apply aliases only when the canonical slot is unfilled. If the canonical is already present, drop the alias value (warning logged when the dropped value differs).

## Tests

`tests/test_param_aliases.py` — 12 cases covering:

- alias-only rename
- canonical-only passthrough
- collision with canonical first / alias first (order-independent)
- warning emitted on real collision, silent on equal-value collision
- collision policy across `store_knowledge_graph` and `process_agent_update`
- multiple-aliases-to-same-canonical first-wins

## Out of scope

`tests/test_doc_drift.py::TestGovernanceFundamentalsClaims::test_ground_truth_from_objective_signals` fails on `origin/master` independent of this change — verified by stashing the diff and running the same test on the base commit.