### PR TITLE
build(ship): classify elixir/ as runtime so BEAM changes get a PR

### DIFF
--- a/scripts/dev/ship.sh
+++ b/scripts/dev/ship.sh
@@ -41,6 +41,11 @@ RUNTIME_PATTERNS=(
     '^src/mcp_server'
     '^src/core\.py$'
     '^src/background_tasks\.py$'
+    # BEAM substrate (Sentinel, lease plane, future apps under elixir/) is
+    # runtime: every change wants a CI-gated PR, not direct push. Without
+    # this, a fix to elixir/sentinel/ falls through to "other" and ships
+    # without a rollback artifact (see PR #446 — opened manually).
+    '^elixir/'
 )
 
 classify() {


### PR DESCRIPTION
## Summary

`scripts/dev/ship.sh`'s `RUNTIME_PATTERNS` only covered Python runtime surfaces (`agents/`, `src/mcp_handlers/`, `src/mcp_server`, `src/core.py`, `src/background_tasks.py`). BEAM substrate code under `elixir/` (Sentinel runtime, lease plane) fell through to "other" and shipped via direct push — no PR, no rollback artifact. PR #446 is the immediate symptom: a one-line lease-surface fix to `elixir/sentinel/` that ship.sh would have shipped without review until I opened the PR manually.

This adds `^elixir/` to the runtime pattern list. Verified with `--classify`:
- `elixir/sentinel/lib/x.ex` staged → `runtime`
- `scripts/dev/ship.sh` staged alone → `other` (unchanged)

## Test plan
- [x] Local `--classify` smoke against both an `elixir/` file and a non-runtime file
- [x] Existing pre-push smoke (138 passed)