### PR TITLE
fix(vigil): groundskeeper note dedup — compare stale_found only, ignore archived

### DIFF
--- a/agents/vigil/agent.py
+++ b/agents/vigil/agent.py
@@ -441,8 +441,14 @@ class VigilAgent(GovernanceAgent):
         Operators can still invoke ``archive_orphan_agents`` manually.
 
         ``prev_state`` is the previous cycle's state dict; when supplied, the
-        summary KG note is suppressed if (stale_found, archived) is unchanged
-        from the prior cycle. Local log + findings still surface every cycle.
+        summary KG note is suppressed if ``stale_found`` (the persistent
+        backlog count) is unchanged from the prior cycle. We deliberately
+        ignore ``archived`` here — that's per-cycle progress that flips
+        between 0 and 1 as new entries arrive and Vigil archives them, and
+        comparing both keys defeated dedup whenever the backlog stayed flat
+        but archived oscillated (observed pattern: 4/0 → 4/1 → 4/0 → 4/1
+        producing a fresh KG row every 30 min). Local log + findings still
+        surface every cycle.
         """
         summary: Dict[str, Any] = {
             "audit_run": False,
@@ -487,9 +493,10 @@ class VigilAgent(GovernanceAgent):
                 f"{summary['archived']} archived"
             )
             prev = prev_state or {}
+            # Compare only the persistent backlog count. The archived count
+            # is per-cycle progress, not state, and oscillates (see docstring).
             unchanged = (
                 prev.get("groundskeeper_stale") == summary["stale_found"]
-                and prev.get("groundskeeper_archived") == summary["archived"]
             )
             if unchanged and prev:
                 summary["note_suppressed"] = True

--- a/agents/vigil/tests/test_groundskeeper.py
+++ b/agents/vigil/tests/test_groundskeeper.py
@@ -173,6 +173,31 @@ class TestRunGroundskeeper:
         assert result["note_suppressed"] is True
 
     @pytest.mark.asyncio
+    async def test_groundskeeper_suppresses_when_only_archived_differs(self):
+        """Backlog flat, archived oscillating between 0 and 1 — must suppress.
+
+        Regression: the two-key (stale, archived) dedup let oscillation
+        through. Observed pattern in production was 4 stale / 0 archived
+        flip-flopping with 4 stale / 1 archived every 30 minutes, producing
+        a fresh KG row each tick. The persistent backlog is 4 in both
+        states; archived is per-cycle progress, not state. Now we compare
+        stale_found only.
+        """
+        agent = _make_agent()
+        client = _make_mock_client(
+            audit_result=AuditResult(
+                success=True,
+                audit={"buckets": {"healthy": 2, "stale": 1, "candidate_for_archive": 3}},
+            ),
+            cleanup_result=CleanupResult(success=True, cleaned=0),
+        )
+        prev = {"groundskeeper_stale": 4, "groundskeeper_archived": 1}
+        result = await agent._run_groundskeeper(client, prev_state=prev)
+
+        client.leave_note.assert_not_called()
+        assert result["note_suppressed"] is True
+
+    @pytest.mark.asyncio
     async def test_groundskeeper_posts_note_on_change(self):
         """When numbers differ from prev_state, leave_note must fire."""
         agent = _make_agent()


### PR DESCRIPTION
## Problem

KG search on \`tags=[vigil, groundskeeper]\` shows Vigil emitting a note every 30 minutes despite the existing dedup at \`agents/vigil/agent.py:489-496\`. The pattern is steady — backlog flat at 4, archived oscillating 0 ↔ 1:

```
2026-05-09T19:30  Groundskeeper: 4 stale, 0 archived
2026-05-09T18:30  Groundskeeper: 4 stale, 1 archived
2026-05-08T14:59  Groundskeeper: 4 stale, 0 archived
2026-05-08T14:29  Groundskeeper: 4 stale, 1 archived
2026-05-08T12:59  Groundskeeper: 4 stale, 0 archived
2026-05-08T12:29  Groundskeeper: 4 stale, 1 archived
...
```

Two-key check (\`stale_found\` AND \`archived\`) sees the archived count differ each tick and lets the note through. Result: a steady 1-row-per-30-min KG pollution stream against a flat backlog.

This is the production shape of the issue first flagged on 2026-04-27 (KG entry \`2026-04-27T08:59:03.950547+00:00\`, watcher-triage hygiene write-path note, sub-issue (a)).

## Fix

\`archived\` is per-cycle progress, not persistent state. \`stale_found\` IS the persistent backlog. The dedup should compare only the latter. Local log + findings still surface every cycle so cleanup activity isn't lost — only the KG row stops landing.

## Tests

\`test_groundskeeper_suppresses_when_only_archived_differs\` pins the regression directly: prev=(stale=4, archived=1), current=(stale=4, archived=0), expect \`leave_note\` not called and \`note_suppressed\` true. Existing groundskeeper tests still pass.

## Out of scope

Pre-existing \`tests/test_doc_drift.py::test_ground_truth_from_objective_signals\` failure on \`origin/master\` is unrelated.