### PR TITLE
follow-up: PR #224 DT_MAX semantics + __init__-now audit

### DIFF
--- a/docs/proposals/dt-max-saturation-semantics.md
+++ b/docs/proposals/dt-max-saturation-semantics.md
@@ -1,0 +1,89 @@
+# DT_MAX Saturation Semantics — Design Note
+
+**Status**: Proposed  
+**Date**: 2026-05-11  
+**Context**: PR #224 deferred task #7  
+**Scope**: `src/governance_monitor.py` · `governance_core` ODE · `unitares-paper-v6/unitares-v6.tex`
+
+## The Problem
+
+PR #224 fixed `last_update` persistence so cross-restart gaps now integrate correctly. A side effect is that the DT_MAX saturation band is very narrow. From `config/governance_config.py`:
+
+```
+DT = 0.1                     # base timestep
+DT_EXPECTED_INTERVAL = 15.0  # expected check-in cadence (seconds)
+DT_MAX = 1.0                 # Euler stability cap
+```
+
+The linear scale formula (`process_update`, post-PR #224):
+
+```python
+scaled_dt = elapsed_seconds * (DT / DT_EXPECTED_INTERVAL)
+effective_dt = max(DT, min(scaled_dt, DT_MAX))
+```
+
+`scaled_dt > DT_MAX` when `elapsed > DT_MAX * DT_EXPECTED_INTERVAL / DT = 150 seconds`.
+
+Any gap longer than **2.5 minutes** hits the cap. A 17-hour gap and a 30-hour gap both integrate as `effective_dt = 1.0`. Gap information above 150 s is silently discarded from the ODE. The info-level log added by PR #224 makes this operator-visible, but does not resolve it.
+
+## What the Cap Protects
+
+`DT_MAX` is an Euler stability constraint, not a physical timescale. The forward-Euler step in `governance_core.step_state()` is conditionally stable only for small dt. With the current dynamics (μ = 0.8 decay on S, δ = 0.4 on V), `dt > 1/μ ≈ 1.25` risks instability. `DT_MAX = 1.0` gives a safety margin. This constraint is unrelated to the physical meaning of a long gap.
+
+## Architecture Note: ODE Is Now Diagnostic
+
+Since `BEHAVIORAL_VERDICT_ENABLED = True` (default), the ODE no longer drives verdicts. Behavioral assessment (EMA + z-score) is primary; ODE provides the phi objective, regime detection, and historical continuity. The practical urgency of option (a) is therefore lower than at PR #224 ship time — but the information loss remains real for operators reading EISV traces.
+
+## Three Candidate Resolutions
+
+### Option (a) — Variable-Step Integrator
+
+Replace the Euler step in `governance_core.step_state()` with `scipy.solve_ivp` (RK45 or similar). The integrator handles arbitrarily large gaps without stability concerns.
+
+**Pros**: Physically correct gap integration; no information loss.  
+**Cons**: Changes ODE numerics (all existing EISV histories become non-comparable across the cutover); requires paper revalidation of new discretization scheme; scipy in the hot path; not a small change. Requires full council review.
+
+### Option (b) — Explicit Stale-Gap Flag Bypassing ODE Information Loss
+
+Above a gap threshold τ (e.g., 4 hours), continue running the ODE with `effective_dt = DT_MAX` (no numeric change), but emit a `stale_gap: true` flag and `gap_seconds` field in the `process_update` result dict. Callers and operators can surface this signal instead of silently treating a 17h gap as identical to a 150s gap.
+
+**Pros**: No ODE change; no paper-numeric impact; operator-visible; honest about what the model cannot represent; τ is tunable without touching numerics.  
+**Cons**: Introduces a new result field that downstream consumers must handle; requires a paper note clarifying stale-gap semantics; τ threshold is a new parameter to maintain.
+
+### Option (c) — Document as Known Approximation
+
+Add a paragraph to `unitares-v6.tex` §sec:equations noting that the discretization uses forward Euler with stability cap `DT_MAX`, and that gaps longer than `DT_MAX * DT_EXPECTED_INTERVAL / DT` seconds are represented as `DT_MAX` in the decay integral. No code change.
+
+**Pros**: Minimal; honest; zero operational risk.  
+**Cons**: Leaves the silent information loss in place; a 17h vs 30h gap remains indistinguishable in EISV traces. Only viable if the ODE's diagnostic role is considered permanently secondary.
+
+## Recommendation: Option (b)
+
+Option (b) is recommended for the following reasons:
+
+1. **Saturation is not an edge case.** The cap fires at 150s — any agent offline for > 2.5 minutes hits it. Gap saturation is the normal case for overnight or weekend gaps, not an exception.
+
+2. **The ODE is in a diagnostic role but still read.** Operators inspecting EISV traces or phi plots after a long gap cannot currently tell whether a decay curve reflects a real 30-hour physics event or a clipped 150s step. The stale flag restores that interpretability without changing the physics.
+
+3. **Option (a) changes published numerics.** Any paper-published result or operator dashboard that records EISV histories becomes non-comparable across the cutover. This deserves a separate, deliberate decision with full council review.
+
+4. **Option (c) is honest but incomplete.** Documenting the approximation without exposing it programmatically means operators must manually cross-reference logs against the paper to interpret any saturated trace.
+
+## Implementation Sketch (for operator review — do not implement without approval)
+
+`config/governance_config.py` gains:
+```python
+DT_STALE_THRESHOLD_SECONDS = 4 * 3600  # 4 hours; tunable
+```
+
+`process_update` emits `stale_gap: bool` and `gap_seconds: float` in the result dict, set when `elapsed_seconds > DT_STALE_THRESHOLD_SECONDS`. No change to `effective_dt`. The existing DT_MAX saturation log line stays.
+
+The paper gains a sentence in §sec:equations describing the Euler stability cap and citing `DT_MAX`. This note is owed regardless of which option is chosen — the paper currently has no mention of discretization.
+
+## Paper Scope
+
+The paper repo (`unitares-paper-v6`) is NOT modified in this run per the operator instruction. A §sec:equations discretization note is the minimum required for any of the three options and should be added in the same PR that implements the chosen resolution.
+
+---
+
+*Filed 2026-05-11 as follow-up to PR #224, task #7. No runtime changes made.*

--- a/docs/proposals/init-now-audit.md
+++ b/docs/proposals/init-now-audit.md
@@ -1,0 +1,111 @@
+# `__init__`-sets-now Audit — Follow-up to PR #224
+
+**Status**: Audit complete, no changes implemented  
+**Date**: 2026-05-11  
+**Context**: PR #224 deferred task #8  
+**Operator action required**: Review findings; approve fixes before implementation
+
+## Audit Scope
+
+Broadest grep across the two files named in the PR:
+
+```
+grep -nE 'self\.\w+ = (datetime\.now\(\)|time\.monotonic\(\))' \
+    src/governance_monitor.py src/dual_log/*.py
+```
+
+Plus manual trace of `_prev_checkin_time` (written in the delegated `src/monitor_calibration.py`, not in `__init__`).
+
+---
+
+## Findings
+
+### MEDIUM — `created_at` not persisted across restart
+
+**File**: `src/governance_monitor.py`  
+**Lines**: `_initialize_fresh_state()` — `self.created_at = datetime.now()`;  
+`load_persisted_state()` fallback — `if not hasattr(self, 'created_at'): self.created_at = datetime.now()`
+
+**Mechanism**: `__init__` calls `load_persisted_state()` *before* `created_at` is assigned anywhere (it is only set inside `_initialize_fresh_state()`, which is *not* called when state loads successfully). When state IS found on disk, `hasattr(self, 'created_at')` is `False` and the fallback fires, setting `created_at = datetime.now()` — the restart wall clock, not the original creation time. `save_persisted_state()` does not write `created_at` to the JSON file.
+
+**Cross-restart**: Yes. Every server restart resets `created_at` to the current time for every agent whose state file exists.
+
+**User-visible effect**: Agent "age" (time since first check-in) resets on every restart. Any metric derived from `created_at` — agent maturity for calibration gating, age-in-dashboard displays — understates agent age after restart. For long-lived resident agents (Lumen, Vigil, Sentinel) this means perceived maturity never accumulates past one server uptime period.
+
+**Test coverage**: `tests/test_created_at_fix.py` does **not exist** (zero search results across the repo). No test pins this behavior.
+
+**Fix sketch** (do not implement without approval): Add `created_at_iso` to the `save_persisted_state` JSON payload, symmetric with `last_update_iso` from PR #224. In `load_persisted_state`, restore it explicitly before the `hasattr` fallback — the fallback then fires only for state files that predate the fix (backward compat preserved).
+
+---
+
+### N/A — `_prev_checkin_time` init value is already correct
+
+**File**: `src/governance_monitor.py` `__init__`  
+**Current value**: `self._prev_checkin_time: Optional[float] = None`  
+**Actual writer**: `src/monitor_calibration.py` — `monitor._prev_checkin_time = _time.monotonic()`
+
+**Status**: The PR description mentioned "line 158 — `_prev_checkin_time = time.monotonic()`" but the current code initializes to `None`. The `None` sentinel is correct: it causes `elapsed_since_prev = float('inf')`, satisfying the 10-second guard in `run_calibration_recording`, but the outer check `monitor._prev_verdict_action is not None` is also `False` on restart, so no spurious calibration signal fires. `time.monotonic()` is only used for within-process elapsed time (the 10s rapid-fire guard); its value is process-local by design.
+
+**Cross-restart**: Behaves correctly. No action needed.
+
+---
+
+### LOW — `ContinuityLayer` previous-session state not persisted without Redis
+
+**File**: `src/dual_log/continuity.py` — `ContinuityLayer.__init__`  
+**Fields**: `_prev_session_id`, `_prev_timestamp`, `_prev_derived_complexity`, `_prev_topic_hash`  
+**Call site**: `UNITARESMonitor.__init__` — `ContinuityLayer(agent_id=agent_id, redis_client=None)`
+
+**Mechanism**: `_load_state()` and `_save_state()` are no-ops when `redis_client=None`. All four tracking fields stay at `None` / `0.0` through restart.
+
+**Cross-restart**: `_prev_timestamp = None` → `is_session_continuation = False` for the first check-in after every restart → `S_input += 0.1` (the "new session" uncertainty penalty in `compute_continuity_metrics`). Rate-of-change complexity divergence starts at `0.0` and self-corrects after one cycle.
+
+**User-visible effect**: First check-in after restart gets a modest false uncertainty signal (+0.1 S_input). For agents with infrequent restarts the effect is invisible. For agents with frequent restarts (e.g., during development cycles) it could slightly bias S upward systematically.
+
+**Fix sketch** (do not implement without approval): Option (a) wire a Redis client from environment into `ContinuityLayer`; option (b) add a JSON sidecar persistence path for `_prev_session_id` and `_prev_timestamp`, mirroring the `last_update_iso` pattern. Option (a) should be evaluated together with the broader Redis-or-not architectural question for the dual-log layer.
+
+---
+
+### LOW — `RestorativeBalanceMonitor` activity window not persisted without Redis
+
+**File**: `src/dual_log/restorative.py` — `RestorativeBalanceMonitor.__init__`  
+**Fields**: `_timestamps: List[datetime]`, `_divergences: List[float]`  
+**Call site**: `UNITARESMonitor.__init__` — `RestorativeBalanceMonitor(agent_id=agent_id, redis_client=None)`
+
+**Mechanism**: Same Redis-or-nothing pattern. The 5-minute rolling window and divergence accumulator reset to empty on restart.
+
+**Cross-restart**: Activity rate and cumulative divergence start at zero after every restart. An agent that was in a high-activity or high-divergence state before restart does not trigger the restorative balance check on the first few post-restart check-ins.
+
+**User-visible effect**: Overloaded agents that restart get a brief false-clean window from the restorative balance check. Since this is an advisory signal (no hard governance gate), operational impact is low.
+
+**Fix sketch** (do not implement without approval): Wire Redis (same path as `ContinuityLayer`), or accept this behavior as acceptable for the advisory-only use case. The 5-minute window resets are self-healing regardless.
+
+---
+
+## Broader Grep Results — `governance_monitor.py`
+
+| Assignment | Clock | Status |
+|---|---|---|
+| `self.last_update = datetime.now()` in `__init__` (~line 130) | wall | **FIXED by PR #224** (persisted via `last_update_iso`) |
+| `self.last_update = datetime.now()` in `_initialize_fresh_state()` | wall | Correct — fresh-state path only |
+| `self.created_at = datetime.now()` in `_initialize_fresh_state()` | wall | **Not persisted — MEDIUM finding above** |
+| `self._prev_checkin_time = None` in `__init__` | — | Correct (`None` sentinel) |
+
+`src/dual_log/*.py`: No `datetime.now()` or `time.monotonic()` assignments in any `__init__`. Fields are initialized to `None`/`[]` and populated from Redis (no-op without client).
+
+---
+
+## Summary
+
+| Finding | File | Severity | Cross-restart bug? | Needs approval? |
+|---|---|---|---|---|
+| `created_at` not persisted | `src/governance_monitor.py` | **MEDIUM** | Yes | Yes — fix is small and well-scoped |
+| `_prev_checkin_time` init value | `src/governance_monitor.py` | N/A | Already correct | No action needed |
+| `ContinuityLayer` state (no Redis) | `src/dual_log/continuity.py` | LOW | Yes (soft S bias) | Needs Redis wiring decision |
+| `RestorativeBalanceMonitor` window | `src/dual_log/restorative.py` | LOW | Yes (advisory reset) | Low urgency; tied to Redis decision |
+
+The one item ready for a small follow-up PR is `created_at` persistence — the pattern is established by PR #224 and the fix is 3–4 lines symmetric with `last_update_iso`.
+
+---
+
+*Filed 2026-05-11 as follow-up to PR #224, task #8. No runtime changes made.*


### PR DESCRIPTION
Two-week soak follow-up on #224. No runtime changes — docs only.

## What's here

- `docs/proposals/dt-max-saturation-semantics.md` — design note for task #7 (DT_MAX semantics). Recommends **option (b): stale-gap flag**. See note for full reasoning; no ODE changes until Kenny approves.
- `docs/proposals/init-now-audit.md` — audit for task #8 (`__init__`-sets-now bugs). Four findings, no fixes implemented.

## Soak observations (STEP 1)

- PR #224 merged 2026-04-27T23:06:16Z.
- 20+ commits since merge — none touch `last_update`, `DT_MAX`, or saturation. Both deferred tasks remain open.
- Log saturation count requires live server access; not checkable from GitHub.

## DT_MAX design note (task #7)

The saturation threshold is lower than the PR description implied: `DT_MAX * DT_EXPECTED_INTERVAL / DT = 1.0 * 15.0 / 0.1 = 150 seconds`. Any gap > 2.5 minutes saturates. With `last_update` persistence now shipping, this fires on every overnight and weekend gap.

Recommendation is **option (b)** — emit `stale_gap: bool` + `gap_seconds` in the result dict when `elapsed > τ` (proposed τ = 4h), without touching `effective_dt` or ODE numerics. Option (a) (variable-step integrator) changes published numerics and needs a separate council decision. Option (c) (doc only) is honest but leaves the 17h-vs-30h indistinguishability in place for operators reading EISV traces.

Note also: the paper (`unitares-paper-v6`) has no mention of the forward-Euler discretization at all. That note is owed regardless of which option is chosen and should land in the same PR that implements the resolution.

## `__init__`-now audit (task #8)

| Finding | File | Severity |
|---|---|---|
| `created_at` not persisted | `src/governance_monitor.py` | **MEDIUM** |
| `_prev_checkin_time` init | `src/governance_monitor.py` | N/A (already correct — `None` sentinel) |
| `ContinuityLayer` state (no Redis) | `src/dual_log/continuity.py` | LOW |
| `RestorativeBalanceMonitor` window | `src/dual_log/restorative.py` | LOW |

The `created_at` fix is the most actionable: same 3-4 line pattern as `last_update_iso` from PR #224, no architectural decision needed. `tests/test_created_at_fix.py` does not exist — a test should accompany the fix.

The LOW items (dual-log state without Redis) are tied to the broader question of whether to wire Redis into `ContinuityLayer` / `RestorativeBalanceMonitor` at all. Suggest deferring to that architectural decision.

## Next steps (operator approval needed before any implementation)

- [ ] Kenny approves DT_MAX option (b) vs (c) vs defer
- [ ] Kenny approves `created_at` persistence fix (small, well-scoped)
- [ ] Redis-or-sidecar decision for dual-log state (LOW severity; lower priority)
- [ ] Paper discretization note (owed regardless of DT_MAX option; paper repo not touched here)

Documents the follow-up for PR #224 task #7 and task #8. This PR does not implement either runtime fix; implementation remains deferred pending operator approval.

---
_Generated by [Claude Code](https://claude.ai/code/session_0165sdE7epLwokDcFT77M9Ky)_
