### PR TITLE
fix(schemas): trim S22 provenance to agent-knowable subset on knowledge + process_agent_update

### DIFF
--- a/src/mcp_handlers/schemas/core.py
+++ b/src/mcp_handlers/schemas/core.py
@@ -231,24 +231,19 @@ class ProcessAgentUpdateParams(AgentIdentityMixin):
             "UNITARES_PHASE5_EVIDENCE_WRITE). See docs/proposals/refined-phase-5-evidence-contract.md."
         ),
     )
-    harness: Optional[str] = Field(None, description="S22 provenance: harness type/body mediating the write")
-    harness_id: Optional[str] = Field(None, description="S22 provenance: concrete harness/runtime instance")
-    harness_type: Optional[str] = Field(None, description="S22 provenance: normalized harness family")
-    transport: Optional[str] = Field(None, description="S22 provenance: channel/protocol used for the write")
-    model_provider: Optional[str] = Field(None, description="S22 provenance: model provider")
-    model: Optional[str] = Field(None, description="S22 provenance: model identifier")
-    memory_context: Optional[str] = Field(None, description="S22 provenance: memory/KG/transcript surfaces visible to the writer")
-    tool_surface: Optional[Union[List[str], str]] = Field(None, description="S22 provenance: available tool families")
-    governance_mode: Optional[str] = Field(None, description="S22 provenance: explicit/ambient/gated/lifecycle/posthoc mode")
-    verification_source: Optional[str] = Field(None, description="S22 provenance: evidence source vocabulary")
+    # S22 provenance — agent-knowable subset only. Harness/server-knowable
+    # fields (harness, harness_id, harness_type, transport, model,
+    # model_provider, tool_surface, governance_mode, verification_source,
+    # episode_id, invocation_id, process_instance_id, locus, affordance_state)
+    # are filled server-side by build_s22_write_context from request signals;
+    # exposing them to agents invited confabulation (KG 2026-05-09T13:03 by
+    # 43a2cbf9). r6_dogfood-style internal callers continue to pass any of
+    # those fields via the extra-field preservation path in
+    # src/mcp_handlers/middleware/params_step.py — the data flow is unchanged.
     comparison_key: Optional[str] = Field(None, description="S22 H5 provenance: stable key for comparing the same bounded task across harnesses")
     task_label: Optional[str] = Field(None, description="S22 H5 provenance: human-readable bounded task label")
     task_outcome: Optional[str] = Field(None, description="S22 H5 provenance: outcome label for the bounded task")
-    episode_id: Optional[str] = Field(None, description="S22 provenance: local interaction span")
-    invocation_id: Optional[str] = Field(None, description="S22 provenance: concrete command/run invocation")
-    process_instance_id: Optional[str] = Field(None, description="S22 provenance: opaque process-instance fingerprint")
-    locus: Optional[Dict[str, Any]] = Field(None, description="S22 provenance: situated transport context")
-    affordance_state: Optional[Dict[str, Any]] = Field(None, description="S22 provenance: available reach/capability snapshot")
+    memory_context: Optional[str] = Field(None, description="S22 provenance: memory/KG/transcript surfaces visible to the writer")
 
     @model_validator(mode='after')
     def coerce_types(self):

--- a/src/mcp_handlers/schemas/knowledge.py
+++ b/src/mcp_handlers/schemas/knowledge.py
@@ -37,24 +37,18 @@ class StoreKnowledgeGraphParams(AgentIdentityMixin):
         default=None,
         description="Array of discovery objects for batch storage"
     )
-    harness: Optional[str] = Field(None, description="S22 provenance: harness type/body mediating the write")
-    harness_id: Optional[str] = Field(None, description="S22 provenance: concrete harness/runtime instance")
-    harness_type: Optional[str] = Field(None, description="S22 provenance: normalized harness family")
-    transport: Optional[str] = Field(None, description="S22 provenance: channel/protocol used for the write")
-    model_provider: Optional[str] = Field(None, description="S22 provenance: model provider")
-    model: Optional[str] = Field(None, description="S22 provenance: model identifier")
-    memory_context: Optional[str] = Field(None, description="S22 provenance: memory/KG/transcript surfaces visible to the writer")
-    tool_surface: Optional[Union[List[str], str]] = Field(None, description="S22 provenance: available tool families")
-    governance_mode: Optional[str] = Field(None, description="S22 provenance: explicit/ambient/gated/lifecycle/posthoc mode")
-    verification_source: Optional[str] = Field(None, description="S22 provenance: evidence source vocabulary")
+    # S22 provenance — agent-knowable subset only. Harness/server-knowable
+    # fields (harness, harness_id, harness_type, transport, model,
+    # model_provider, tool_surface, governance_mode, verification_source,
+    # episode_id, invocation_id, process_instance_id, locus, affordance_state)
+    # are filled server-side by build_s22_write_context from request signals;
+    # exposing them to agents invited confabulation (KG 2026-05-09T13:03 by
+    # 43a2cbf9). The four kept here are author-of-intent facts that only the
+    # agent can honestly supply for H5 cross-harness comparison.
     comparison_key: Optional[str] = Field(None, description="S22 H5 provenance: stable key for comparing the same bounded task across harnesses")
     task_label: Optional[str] = Field(None, description="S22 H5 provenance: human-readable bounded task label")
     task_outcome: Optional[str] = Field(None, description="S22 H5 provenance: outcome label for the bounded task")
-    episode_id: Optional[str] = Field(None, description="S22 provenance: local interaction span")
-    invocation_id: Optional[str] = Field(None, description="S22 provenance: concrete command/run invocation")
-    process_instance_id: Optional[str] = Field(None, description="S22 provenance: opaque process-instance fingerprint")
-    locus: Optional[Dict[str, Any]] = Field(None, description="S22 provenance: situated transport context")
-    affordance_state: Optional[Dict[str, Any]] = Field(None, description="S22 provenance: available reach/capability snapshot")
+    memory_context: Optional[str] = Field(None, description="S22 provenance: memory/KG/transcript surfaces visible to the writer")
 
 
 class SearchKnowledgeGraphParams(AgentIdentityMixin):
@@ -318,24 +312,12 @@ class KnowledgeParams(AgentIdentityMixin):
     limit: Optional[int] = Field(None, description="Max results")
     include_details: Optional[bool] = Field(None, description="Include full details inline (for action=search/get)")
     dry_run: Union[bool, str, None] = Field(None, description="Dry run mode (for action=cleanup)")
-    harness: Optional[str] = Field(None, description="S22 provenance: harness type/body mediating the write")
-    harness_id: Optional[str] = Field(None, description="S22 provenance: concrete harness/runtime instance")
-    harness_type: Optional[str] = Field(None, description="S22 provenance: normalized harness family")
-    transport: Optional[str] = Field(None, description="S22 provenance: channel/protocol used for the write")
-    model_provider: Optional[str] = Field(None, description="S22 provenance: model provider")
-    model: Optional[str] = Field(None, description="S22 provenance: model identifier")
-    memory_context: Optional[str] = Field(None, description="S22 provenance: memory/KG/transcript surfaces visible to the writer")
-    tool_surface: Optional[Union[List[str], str]] = Field(None, description="S22 provenance: available tool families")
-    governance_mode: Optional[str] = Field(None, description="S22 provenance: explicit/ambient/gated/lifecycle/posthoc mode")
-    verification_source: Optional[str] = Field(None, description="S22 provenance: evidence source vocabulary")
+    # S22 provenance — agent-knowable subset only. See StoreKnowledgeGraphParams
+    # above for the dropped-field rationale.
     comparison_key: Optional[str] = Field(None, description="S22 H5 provenance: stable key for comparing the same bounded task across harnesses")
     task_label: Optional[str] = Field(None, description="S22 H5 provenance: human-readable bounded task label")
     task_outcome: Optional[str] = Field(None, description="S22 H5 provenance: outcome label for the bounded task")
-    episode_id: Optional[str] = Field(None, description="S22 provenance: local interaction span")
-    invocation_id: Optional[str] = Field(None, description="S22 provenance: concrete command/run invocation")
-    process_instance_id: Optional[str] = Field(None, description="S22 provenance: opaque process-instance fingerprint")
-    locus: Optional[Dict[str, Any]] = Field(None, description="S22 provenance: situated transport context")
-    affordance_state: Optional[Dict[str, Any]] = Field(None, description="S22 provenance: available reach/capability snapshot")
+    memory_context: Optional[str] = Field(None, description="S22 provenance: memory/KG/transcript surfaces visible to the writer")
 
     @model_validator(mode='after')
     def coerce_booleans(self):

--- a/tests/test_pydantic_schemas.py
+++ b/tests/test_pydantic_schemas.py
@@ -226,23 +226,48 @@ class TestProcessAgentUpdateAcceptsRecentToolResults:
         assert len(params.recent_tool_results) == 1
         assert params.recent_tool_results[0].kind == "test"
 
-    def test_accepts_s22_h5_provenance_fields(self):
+    def test_accepts_s22_h5_agent_knowable_fields(self):
+        """ProcessAgentUpdateParams keeps only the 4 agent-knowable S22 fields.
+
+        Per KG 2026-05-09T13:03 (43a2cbf9): the 14 harness/server-knowable
+        S22 fields (harness, harness_id, harness_type, transport, model,
+        model_provider, tool_surface, governance_mode, verification_source,
+        episode_id, invocation_id, process_instance_id, locus,
+        affordance_state) are filled server-side by build_s22_write_context
+        and were removed from the agent-callable schema. The 4 kept fields
+        are author-of-intent facts only the agent can supply.
+        """
         from src.mcp_handlers.schemas.core import ProcessAgentUpdateParams
         params = ProcessAgentUpdateParams(
             response_text="ran H5 diagnostic",
-            harness_type="codex-cli",
-            model_provider="openai",
-            model="gpt-5",
-            transport="codex-cli",
-            tool_surface=["terminal", "mcp:unitares"],
             comparison_key="s22-h5-2026-05-06",
             task_label="Run S22 H5 coverage diagnostic",
             task_outcome="diagnostic-complete",
+            memory_context="MEMORY.md + KG search results",
         )
-        assert params.harness_type == "codex-cli"
         assert params.comparison_key == "s22-h5-2026-05-06"
         assert params.task_label == "Run S22 H5 coverage diagnostic"
         assert params.task_outcome == "diagnostic-complete"
+        assert params.memory_context == "MEMORY.md + KG search results"
+
+    def test_dropped_s22_fields_no_longer_on_model(self):
+        """The 14 dropped S22 fields must not be declared on the schema.
+
+        Regression for KG 2026-05-09T13:03: keep the agent-facing schema
+        from re-accreting fields that only the harness can honestly know.
+        """
+        from src.mcp_handlers.schemas.core import ProcessAgentUpdateParams
+        dropped = {
+            "harness", "harness_id", "harness_type", "transport",
+            "model", "model_provider", "tool_surface", "governance_mode",
+            "verification_source", "episode_id", "invocation_id",
+            "process_instance_id", "locus", "affordance_state",
+        }
+        declared = set(ProcessAgentUpdateParams.model_fields.keys())
+        assert dropped.isdisjoint(declared), (
+            f"S22 fields that should be harness-filled are still declared: "
+            f"{sorted(dropped & declared)}"
+        )
 
     def test_accepts_evidence_without_kind(self):
         from src.mcp_handlers.schemas.core import ProcessAgentUpdateParams


### PR DESCRIPTION
## Problem

KG 2026-05-09T13:03 (agent `43a2cbf9`): `knowledge` and `process_agent_update` Pydantic schemas exposed 18 "S22 provenance" fields agent-callable. 14 of them describe harness/server-knowable facts the agent cannot honestly answer (`harness`, `harness_id`, `harness_type`, `transport`, `model`, `model_provider`, `tool_surface`, `governance_mode`, `verification_source`, `episode_id`, `invocation_id`, `process_instance_id`, `locus`, `affordance_state`). Schema sprawl invited confabulation.

## Council pass

Ran the 3-agent council (architect + reviewer + live-verifier). All three converged on Option C: split-schema, keep the agent-knowable, drop the harness-knowable.

- **Architect** (principle): "fields whose ground truth lives outside the agent's epistemic horizon do not appear in its schema." Schema IS the contract.
- **Reviewer** (lowest blast): zero impact on plugin, discord-dispatch, hermes-agent. `r6_dogfood` continues to flow via `params_step.py:187-191` extra-field preservation (verified). 1 test file to update. Option B (collapse to `_provenance` dict) blocked by Pydantic v2 underscore-private-attr rule; not viable.
- **Live-verifier** (ground-truth):
  - Confirmed all fields advertised in inputSchema via `describe_tool` against the running MCP.
  - Confirmed `leave_note`, `observe`, `dialectic` have zero S22 fields; `outcome_event` has its own separate constrained-enum `verification_source` (unaffected).
  - `r6_dogfood` is dead deployment-wise (manual-only, not launchd/cron); still keeps working unchanged.
  - Flagged a separate footgun: `knowledge(action="note")` routes through `LeaveNoteParams` which has zero S22 slots — silently drops any S22 fields agents pass on the note path. Distinct bug, follow-up.

Tightened beyond the architect's "5 fields" baseline by dropping `verification_source` — the agent can't honestly distinguish between the `agent_reported_tool_result` / `harness_observed_tool_result` enum values that the constrained-enum surface on `outcome_event` enforces. Open-string evidence narratives belong in `details` text.

## Change

**Dropped (14)** from agent-callable schemas in `schemas/knowledge.py` (both `StoreKnowledgeGraphParams` and `KnowledgeParams`) and `schemas/core.py` (`ProcessAgentUpdateParams`):

`harness`, `harness_id`, `harness_type`, `transport`, `model`, `model_provider`, `tool_surface`, `governance_mode`, `verification_source`, `episode_id`, `invocation_id`, `process_instance_id`, `locus`, `affordance_state`

Server-side `build_s22_write_context` (`src/provenance_context.py:43`) already derives these from request signals (`signals.transport`, `client_hint→harness_type`, `meta.parent_agent_id/spawn_reason/thread_id`, `session_resolution_source`). No functional regression.

**Kept (4)** — author-of-intent fields the agent must supply for H5 cross-harness comparison:

`comparison_key`, `task_label`, `task_outcome`, `memory_context`

**Internal callers** (`r6_dogfood.py`): unchanged. They continue to pass any of the dropped fields via the extra-field preservation path in `src/mcp_handlers/middleware/params_step.py:187-191` — verified that this path keeps the data flowing to `build_s22_write_context` for legitimate internal diagnostics.

## Tests

- `test_accepts_s22_h5_agent_knowable_fields`: pins the 4-field surface.
- `test_dropped_s22_fields_no_longer_on_model`: pins absence of the 14 dropped — keeps the schema from re-accreting.

All 92 focused schema/provenance/r6_dogfood/kg_store tests pass.

## Out of scope

- `knowledge(action="note")` silent-drop on `LeaveNoteParams` — separate bug, follow-up.
- Pre-existing `tests/test_doc_drift.py::test_ground_truth_from_objective_signals` failure on `origin/master` is unrelated to this change.