### PR TITLE
chore(gitignore): ignore .sentinel_state.<suffix> variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,6 +183,7 @@ scripts/archive/
 .vigil_state
 .sentinel_session
 .sentinel_state
+.sentinel_state.*
 .watcher_session
 .watcher_session.*
 


### PR DESCRIPTION
## Summary
- `.sentinel_state` matches only the literal name; sentinel writes `.sentinel_state.beam` into the repo root.
- Add `.sentinel_state.*` mirror of the `.watcher_session.*` pattern.

## Test plan
- [x] `git check-ignore -v .sentinel_state.beam` → matches `.gitignore:186:.sentinel_state.*`