### PR TITLE
fix(kg-age): filter orphan dst_ids before edge INSERT to survive backend drift

### DIFF
--- a/src/storage/knowledge_graph_age.py
+++ b/src/storage/knowledge_graph_age.py
@@ -220,21 +220,52 @@ class KnowledgeGraphAGE:
             )
 
         if edge_rows:
-            await conn.executemany(
+            # Filter out dst_ids that have no row in knowledge.discoveries.
+            # AGE and the PG table can drift (AGE→PG canonical flip on
+            # 2026-05-04 left 4 AGE-only Discovery nodes; find_similar
+            # returned those IDs into related_to, and the unguarded INSERT
+            # below tripped the discovery_edges_dst_id_fkey FK constraint,
+            # rolling back the entire tagged write. Tags landed empty even
+            # on the underlying discovery row that did get inserted earlier
+            # in the transaction (KG 2026-05-10T00:58:42 by d0832eaf). The
+            # orphans on the live DB were cleaned up out-of-band; this
+            # guard makes future drift survivable instead of write-fatal.
+            dst_ids = {row[1] for row in edge_rows}
+            existing = await conn.fetch(
                 """
-                INSERT INTO knowledge.discovery_edges (
-                    src_id, dst_id, edge_type, response_type, weight,
-                    created_at, created_by, metadata
-                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-                ON CONFLICT (src_id, dst_id, edge_type) DO UPDATE SET
-                    response_type = EXCLUDED.response_type,
-                    weight = EXCLUDED.weight,
-                    created_at = EXCLUDED.created_at,
-                    created_by = EXCLUDED.created_by,
-                    metadata = EXCLUDED.metadata
+                SELECT id FROM knowledge.discoveries
+                WHERE id = ANY($1::text[])
                 """,
-                edge_rows,
+                list(dst_ids),
             )
+            existing_set = {r["id"] for r in existing}
+            missing = dst_ids - existing_set
+            if missing:
+                logger.warning(
+                    "_sync_discovery_edges: dropping %d edge(s) to missing "
+                    "dst_id(s) for src_id=%r — drift between graph backend and "
+                    "knowledge.discoveries. Missing: %s",
+                    len(missing),
+                    discovery.id,
+                    sorted(missing),
+                )
+                edge_rows = [row for row in edge_rows if row[1] in existing_set]
+            if edge_rows:
+                await conn.executemany(
+                    """
+                    INSERT INTO knowledge.discovery_edges (
+                        src_id, dst_id, edge_type, response_type, weight,
+                        created_at, created_by, metadata
+                    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                    ON CONFLICT (src_id, dst_id, edge_type) DO UPDATE SET
+                        response_type = EXCLUDED.response_type,
+                        weight = EXCLUDED.weight,
+                        created_at = EXCLUDED.created_at,
+                        created_by = EXCLUDED.created_by,
+                        metadata = EXCLUDED.metadata
+                    """,
+                    edge_rows,
+                )
 
     async def _sync_updated_discovery_row(
         self,

--- a/tests/test_knowledge_graph_age.py
+++ b/tests/test_knowledge_graph_age.py
@@ -357,6 +357,73 @@ class TestAddDiscovery:
         assert mock_db.graph_query.await_count >= 5
 
     @pytest.mark.asyncio
+    async def test_sync_discovery_edges_drops_missing_dst_ids(self, caplog):
+        """Regression: dst_ids absent from knowledge.discoveries must be
+        filtered before INSERT, not allowed to trip the FK constraint.
+
+        Reproduces KG 2026-05-10T00:58:42 (d0832eaf): AGE→PG canonical flip
+        left orphan Discovery nodes in AGE. find_similar returned the
+        orphan IDs into related_to, and the unguarded INSERT into
+        knowledge.discovery_edges hit discovery_edges_dst_id_fkey,
+        rolling back the entire tagged write so tags landed empty even on
+        the underlying discovery row.
+        """
+        kg, _ = make_kg_with_mock_db()
+
+        conn = AsyncMock()
+        conn.execute = AsyncMock()
+        # Only "live-parent" exists in knowledge.discoveries.
+        # "dead-parent" is an AGE orphan — must be filtered.
+        conn.fetch = AsyncMock(return_value=[{"id": "live-parent"}])
+        conn.executemany = AsyncMock()
+
+        discovery = make_discovery(
+            related_to=["live-parent", "dead-parent"],
+        )
+
+        import logging
+        with caplog.at_level(logging.WARNING):
+            await kg._sync_discovery_edges(
+                conn,
+                discovery,
+                datetime(2026, 5, 13, 12, 0, 0),
+            )
+
+        # The INSERT must have fired with only the live edge.
+        assert conn.executemany.await_count == 1
+        inserted_rows = conn.executemany.await_args.args[1]
+        inserted_dst_ids = [row[1] for row in inserted_rows]
+        assert inserted_dst_ids == ["live-parent"]
+
+        # Drift must surface as a warning the operator can act on.
+        assert any(
+            "dropping" in rec.getMessage() and "dead-parent" in rec.getMessage()
+            for rec in caplog.records
+        ), f"expected dead-parent drop warning, got: {[r.getMessage() for r in caplog.records]}"
+
+    @pytest.mark.asyncio
+    async def test_sync_discovery_edges_all_dst_missing_skips_insert(self):
+        """When every dst_id is an orphan, INSERT must not run at all."""
+        kg, _ = make_kg_with_mock_db()
+
+        conn = AsyncMock()
+        conn.execute = AsyncMock()
+        conn.fetch = AsyncMock(return_value=[])  # all dst_ids are orphans
+        conn.executemany = AsyncMock()
+
+        discovery = make_discovery(
+            related_to=["orphan-a", "orphan-b"],
+        )
+        await kg._sync_discovery_edges(
+            conn,
+            discovery,
+            datetime(2026, 5, 13, 12, 0, 0),
+        )
+
+        # The DELETE always runs; the INSERT must not.
+        assert conn.executemany.await_count == 0
+
+    @pytest.mark.asyncio
     async def test_add_discovery_with_tags(self):
         """Should create TAGGED edges for each tag."""
         kg, mock_db = make_kg_with_mock_db()


### PR DESCRIPTION
## Problem

KG 2026-05-10T00:58:42 (filed by `d0832eaf`, reproduced repeatedly across sessions): every tagged write through `leave_note` / `knowledge(action="store")` / `knowledge(action="note")` fails with

```
insert or update on table "discovery_edges" violates foreign key constraint
"discovery_edges_dst_id_fkey"
DETAIL: dst_id=2026-04-03T03:30:30.759122
```

Reproduced again during this session — `knowledge(action="store")` calls landed with `tags: []` on the response even though tags were passed.

## Root cause (verified on live DB)

The AGE Discovery graph and `knowledge.discoveries` SQL table can drift. Quantified today against the live `governance` DB:

```
age_count: 904   pg_count: 913   age_orphans_no_pg: 4   pg_only_no_age: 13
```

The four AGE-only orphans were all from 2026-04-03 — likely artifacts of the 2026-05-04 AGE→PG canonical flip. The reported `dst_id=2026-04-03T03:30:30.759122` was one of them.

Flow:
1. `find_similar` (AGE backend, `src/storage/knowledge_graph_age.py:1273`) runs against AGE and returns the orphan IDs.
2. `leave_note` handler (`src/mcp_handlers/knowledge/handlers.py:2332`) assigns them to `note.related_to`.
3. `_sync_discovery_edges` builds INSERT rows pointing at the orphan dst_id.
4. PostgreSQL's `discovery_edges_dst_id_fkey` FK to `knowledge.discoveries(id)` rejects → entire transaction rolls back → tags drop, edges drop, the discovery row that was inserted earlier in the same transaction silently loses its tag/edge attachment.

## Fix

In `_sync_discovery_edges` (`src/storage/knowledge_graph_age.py:178`), validate every dst_id against `knowledge.discoveries` before INSERT. Drop missing ones with a warn log naming the src_id and the missing dst_ids. INSERT only the valid remainder.

Defense-in-depth — catches drift from any source (`find_similar`, manual `related_to`, `response_to`), not just AGE orphans. One extra `fetch()` on the existing connection, no new pool round-trip.

## Operator action (already done)

The four specific AGE orphans on the live DB were cleaned up out-of-band before this PR via AGE Cypher DELETE on the Discovery nodes whose IDs were absent from `knowledge.discoveries`. Verified BEFORE=4, AFTER=0.

## Tests

`tests/test_knowledge_graph_age.py`:
- `test_sync_discovery_edges_drops_missing_dst_ids` — mixed live/orphan dst_ids → INSERT runs with only the live one, warn log fires naming the dead-parent.
- `test_sync_discovery_edges_all_dst_missing_skips_insert` — all orphans → INSERT does not run at all.

## Out of scope

Pre-existing `tests/test_doc_drift.py::test_ground_truth_from_objective_signals` failure on `origin/master` is unrelated.