### PR TITLE
fix(monitor): persist created_at across restarts

### DIFF
--- a/src/governance_monitor.py
+++ b/src/governance_monitor.py
@@ -263,6 +263,17 @@ class UNITARESMonitor:
                 beh_data = data.pop('behavioral_eisv', None)
                 if beh_data:
                     self._behavioral_state = BehavioralEISV.from_dict(beh_data)
+                # Restore created_at if persisted; otherwise __init__ will fall
+                # back to now() for older state files that predate this field.
+                created_at_iso = data.pop('created_at_iso', None)
+                if created_at_iso:
+                    try:
+                        self.created_at = datetime.fromisoformat(created_at_iso)
+                    except (TypeError, ValueError) as e:
+                        logger.warning(
+                            f"Could not parse created_at_iso for {self.agent_id} "
+                            f"({created_at_iso!r}): {e}; falling back to now()",
+                        )
                 # Restore last_update if persisted; otherwise leave the in-memory
                 # value (set in __init__) intact. last_update lives on the monitor,
                 # not on GovernanceState, so it's handled here as a side effect —
@@ -294,6 +305,10 @@ class UNITARESMonitor:
             state_data = self.state.to_dict_with_history()
             # Include behavioral EISV state for persistence
             state_data['behavioral_eisv'] = self._behavioral_state.to_dict_with_history()
+            # Persist created_at so agent age/maturity survives process restarts.
+            created_at = getattr(self, 'created_at', None)
+            if created_at is not None:
+                state_data['created_at_iso'] = created_at.isoformat()
             # Persist last_update so cross-restart gaps integrate against the real
             # prior check-in time, not the lazy-init wall-clock.
             state_data['last_update_iso'] = self.last_update.isoformat()

--- a/tests/test_governance_monitor.py
+++ b/tests/test_governance_monitor.py
@@ -9,6 +9,7 @@ import pytest
 import numpy as np
 import json
 import sys
+from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
 from unittest.mock import patch, MagicMock
@@ -1621,6 +1622,24 @@ class TestStatePersistence:
         with open(state_file, 'r') as f:
             loaded = json.load(f)
         assert loaded is not None
+
+    def test_save_and_load_roundtrip_preserves_created_at(self, tmp_path, monkeypatch):
+        """Persisted monitor state should preserve original creation time."""
+        import src._imports as imports_module
+
+        monkeypatch.setattr(imports_module, "_project_root", tmp_path)
+        original_created_at = datetime(2024, 1, 2, 3, 4, 5, 678901)
+
+        mon = UNITARESMonitor("test-created-at", load_state=False)
+        mon.created_at = original_created_at
+        mon.save_persisted_state()
+
+        state_file = tmp_path / "data" / "agents" / "test-created-at_state.json"
+        saved = json.loads(state_file.read_text())
+        assert saved["created_at_iso"] == original_created_at.isoformat()
+
+        reloaded = UNITARESMonitor("test-created-at", load_state=True)
+        assert reloaded.created_at == original_created_at
 
     def test_load_nonexistent_state(self):
         """Loading nonexistent state should return None."""


### PR DESCRIPTION
## Summary
- Persist `UNITARESMonitor.created_at` as `created_at_iso` alongside `last_update_iso`.
- Restore `created_at` during state load before the legacy fallback-to-now path.
- Add a regression test that proves save/load preserves the original creation timestamp.

## Test Plan
- [x] RED: `pytest tests/test_governance_monitor.py::TestStatePersistence::test_save_and_load_roundtrip_preserves_created_at -q` failed before implementation with `KeyError: 'created_at_iso'`.
- [x] `pytest tests/test_governance_monitor.py::TestStatePersistence -q`
- [x] `pytest tests/test_governance_monitor.py -q`
- [x] `make test-smoke`
- [x] `python3 -m py_compile src/governance_monitor.py tests/test_governance_monitor.py`
- [x] `python3 scripts/dev/check_ci_python_version_sync.py`
- [x] `python3 scripts/diagnostics/check_ci_python_matrix_sync.py`
- [x] `python3 scripts/diagnostics/check_doc_drift.py`
- [x] `python3 scripts/dev/update_docs_tool_count.py --check`
- [x] `python3 scripts/ops/version_manager.py --check`
- [x] `git diff --check -- src/governance_monitor.py tests/test_governance_monitor.py`

## Local full-suite note
- `pytest tests/ -q` on this Mac/Python 3.14 ran 8198 tests: 8171 passed, 26 skipped, 1 failed in `tests/test_doc_drift.py::TestGovernanceFundamentalsClaims::test_ground_truth_from_objective_signals`.
- That failure reads the sibling local repo `../unitares-governance-plugin/skills/governance-fundamentals/SKILL.md`; no files in this PR touch that plugin/doc-drift surface.

Follow-up to PR #451 / PR #224 task #8.
