### PR TITLE
docs: Phase A pre-flight audit — 2026-05-15

### DIFF
--- a/docs/proposals/anima-broker-beam-port-phase-a-audit-2026-05-15.md
+++ b/docs/proposals/anima-broker-beam-port-phase-a-audit-2026-05-15.md
@@ -1,0 +1,40 @@
+# Phase A Pre-flight Audit — 2026-05-15
+
+RFC: `docs/proposals/anima-broker-beam-port-v0.md` (v0.2, merged 2026-05-01, PR #265)
+Audit triggered: 14 days post-merge.
+
+**MATERIAL FINDING: RFC retired 2026-05-01T12:23:47Z by operator decision — Phase A pre-flight is moot.**
+
+---
+
+## §9.3 Checklist Status
+
+| # | Item | Status | Evidence |
+|---|------|--------|----------|
+| 1 | JSON schema `docs/schemas/anima_state_envelope.v0.json` + corpus test | NO | Both files absent |
+| 2 | `anima-mcp/systemd/unitares-bridge.service` | NO | File absent; `systemd/` directory does not exist |
+| 3 | `SERVER_GOVERNANCE_FALLBACK_SECONDS` deleted; `SHM_BROKER_STALE_SECONDS` introduced | NO | Old constant live at `server_state.py:36`, imported+used `server.py:49,923,924`; new constant not found |
+| 4 | KG entries tagged `lumen-broker-port` | YES | 8 entries; most recent `2026-05-01T12:23:47Z` = **v0 RETIRED** |
+| 5 | Git commits referencing BEAM port keywords (since 2026-05-01) | PARTIAL | unitares: 0 matches; anima-mcp: `b874830`, `9e6afa0` (Python ops tuning, not BEAM port) |
+
+---
+
+## Which checklist items have shipped
+
+None.
+
+## What's still open
+
+All §9.3 Phase A pre-flight items are open — but see DRIFT.
+
+---
+
+## BLOCKs / DRIFTs
+
+**DRIFT (critical):** KG entry `2026-05-01T12:23:47Z` (tags: `v0-retired`, `operator-decision`) records retirement on the same day the RFC merged:
+
+> "Anima broker BEAM port v0 RETIRED 2026-05-01 by operator decision. S6 ambiguous-band (50–75%) judged not-met-decisively; v0.3's 'ambiguous defaults to falsified' rule kept; no v0.5; no new load-bearing leg invoked; surviving work re-scoped to Python discipline track."
+
+The merge of PR #265 and the retirement are same-day artefacts of the same session. Phase A pre-flight is moot. No action required on §9.3 items unless operator re-opens the BEAM leg.
+
+**anima-mcp `b874830` / `9e6afa0`**: operational tuning of the existing Python `unitares-bridge` (`response_mode=minimal`, timeout 5s→30s). Consistent with Python-discipline reframing; not BEAM port progress.


### PR DESCRIPTION
Automated audit of §9.3 Phase A pre-flight checklist, 14 days post-merge of RFC v0.2 (PR #265).

**Bottom line:** 0 of 5 pre-flight deliverables shipped — and the RFC was retired on 2026-05-01 (same day as merge) by operator decision. Phase A is moot unless the BEAM leg is re-opened.

Single new file: `docs/proposals/anima-broker-beam-port-phase-a-audit-2026-05-15.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_0179w55qvzsuMLJfPm9wkhwA)_