### PR TITLE
[codex] Restore Docker quickstart database bootstrap

### DIFF
--- a/db/postgres/docker-initdb.sh
+++ b/db/postgres/docker-initdb.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="/docker-entrypoint-initdb.d/unitares"
+PSQL=(psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB")
+
+run_sql() {
+    local rel_path="$1"
+    echo "UNITARES init: applying ${rel_path}"
+    "${PSQL[@]}" -f "${ROOT}/${rel_path}"
+}
+
+run_migration() {
+    local path="$1"
+    echo "UNITARES init: applying migrations/$(basename "$path")"
+    "${PSQL[@]}" -f "$path"
+}
+
+run_sql "schema.sql"
+run_sql "knowledge_schema.sql"
+"${PSQL[@]}" -c "INSERT INTO core.schema_migrations (version, name, applied_at) VALUES (2, 'knowledge_schema', NOW()) ON CONFLICT (version) DO NOTHING;"
+
+run_sql "embeddings_schema.sql"
+run_sql "embeddings_bge_m3_schema.sql"
+
+for migration in "${ROOT}"/migrations/*.sql; do
+    base="$(basename "$migration")"
+    version="${base%%_*}"
+    case "$version" in
+        ""|*[!0-9]*) continue ;;
+    esac
+
+    # 001 and 002 are markers for schema.sql and knowledge_schema.sql.
+    # 031 extends partition maintenance, so partitions.sql must run first.
+    if (( 10#$version >= 3 && 10#$version <= 30 )); then
+        run_migration "$migration"
+    fi
+done
+
+run_sql "partitions.sql"
+run_sql "graph_schema.sql"
+
+for migration in "${ROOT}"/migrations/*.sql; do
+    base="$(basename "$migration")"
+    version="${base%%_*}"
+    case "$version" in
+        ""|*[!0-9]*) continue ;;
+    esac
+
+    if (( 10#$version >= 31 )); then
+        run_migration "$migration"
+    fi
+done
+
+echo "UNITARES init: complete"

--- a/db/postgres/graph_schema.sql
+++ b/db/postgres/graph_schema.sql
@@ -70,21 +70,21 @@ BEGIN
     -- Check if agent vertex exists
     EXECUTE format(
         $q$SELECT EXISTS(
-            SELECT 1 FROM cypher('governance_graph', $$
-                MATCH (a:Agent {agent_id: '%s'}) RETURN a
-            $$) as (a agtype)
+            SELECT 1 FROM cypher('governance_graph', $cypher$
+                MATCH (a:Agent {agent_id: %L}) RETURN a
+            $cypher$) as (a agtype)
         )$q$, p_agent_id
     ) INTO v_exists;
 
     IF NOT v_exists THEN
         -- Create agent vertex
         EXECUTE format(
-            $q$SELECT * FROM cypher('governance_graph', $$
+            $q$SELECT * FROM cypher('governance_graph', $cypher$
                 CREATE (a:Agent {
-                    agent_id: '%s',
+                    agent_id: %L,
                     created_at: datetime()
                 })
-            $$) as (a agtype)$q$, p_agent_id
+            $cypher$) as (a agtype)$q$, p_agent_id
         );
     END IF;
 END;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,16 +32,11 @@ services:
       - "127.0.0.1:${POSTGRES_HOST_PORT:-5432}:5432"
     volumes:
       - postgres-age-data:/var/lib/postgresql/data
-      # Schema bootstrap: docker-entrypoint-initdb.d runs *.sql in lexical
-      # order on first startup (empty data volume). Numbering matches the
-      # order documented in db/postgres/README.md. 00-init-extensions.sql
-      # is baked into the image.
-      - ./db/postgres/schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
-      - ./db/postgres/partitions.sql:/docker-entrypoint-initdb.d/02-partitions.sql:ro
-      - ./db/postgres/knowledge_schema.sql:/docker-entrypoint-initdb.d/03-knowledge_schema.sql:ro
-      - ./db/postgres/embeddings_schema.sql:/docker-entrypoint-initdb.d/04-embeddings_schema.sql:ro
-      - ./db/postgres/embeddings_bge_m3_schema.sql:/docker-entrypoint-initdb.d/05-embeddings_bge_m3_schema.sql:ro
-      - ./db/postgres/graph_schema.sql:/docker-entrypoint-initdb.d/06-graph_schema.sql:ro
+      # Schema bootstrap: the official Postgres entrypoint runs this script
+      # once for an empty data volume. The script owns ordering across base
+      # schema files, migrations, partition setup, and AGE graph setup.
+      - ./db/postgres/docker-initdb.sh:/docker-entrypoint-initdb.d/01-unitares-init.sh:ro
+      - ./db/postgres:/docker-entrypoint-initdb.d/unitares:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-governance}"]
       interval: 5s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.12"
 dependencies = [
     "mcp>=1.26.0,<2.0.0",
     "numpy>=1.24.0,<3.0.0",
+    "PyYAML>=6.0.0",
     # governance_core (EISV ODE engine) lives in this repo at top-level
     # governance_core/ — pure Python, no separate install needed. The package
     # was previously a separate private compiled wheel (CIRWEL/unitares-core);

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -13,9 +13,11 @@ mcp>=1.26.0,<2.0.0
 # Governance system core math
 numpy>=1.24.0,<3.0.0
 
+# Skill and taxonomy metadata parsing
+PyYAML>=6.0.0
+
 # governance_core (EISV ODE engine) lives at top-level governance_core/
 # in this repo — no separate install. Was previously a private compiled wheel
 # (CIRWEL/unitares-core); folded back 2026-04-24.
 # To skip the ODE entirely (behavioral-only mode):
 #   export UNITARES_DISABLE_ODE=1
-

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -13,6 +13,9 @@ mcp>=1.26.0,<2.0.0
 # Governance system core math (governance_core/ is in-repo, pure Python)
 numpy>=1.24.0,<3.0.0
 
+# Skill and taxonomy metadata parsing
+PyYAML>=6.0.0
+
 # HTTP server support (multi-client mode)
 uvicorn>=0.30.0
 starlette>=0.37.0


### PR DESCRIPTION
## Summary

Restores the one-command Docker quickstart from a clean checkout.

- Adds `PyYAML` to the core and Docker dependency surfaces so startup imports for server-side skills and taxonomy metadata succeed.
- Replaces the Compose file's hand-picked schema mounts with an executable init script that applies base schema files, migrations, partition setup, and AGE graph setup in order on a fresh Postgres volume.
- Fixes nested dollar-quoting in `graph_schema.sql` and uses SQL literal quoting for agent IDs inside the generated Cypher.

## Root Cause

The Docker path had drifted behind the runtime schema and package surface. A fresh Compose volume skipped current migrations, so tables like `audit.outcome_events` were missing before partition creation. The MCP image also lacked `PyYAML`, causing the server container to restart on import, and AGE graph setup failed on nested `$$` quoting.

## Validation

- `./scripts/dev/test-cache.sh` -> `8727 passed, 25 skipped`
- Pre-push smoke -> `138 passed, 8070 deselected`; doc-health warnings were pre-existing ghost-tool warnings
- Fresh Docker smoke with clean volumes and port overrides:
  - `POSTGRES_HOST_PORT=55432 REDIS_HOST_PORT=56379 GOVERNANCE_HOST_PORT=58767 docker compose up -d --build`
  - Postgres, Redis, and MCP containers healthy
  - `/v1/tools` returned 20 tools
  - `core.schema_migrations` max version `37`, count `35`
  - AGE graph `governance_graph` exists
  - `audit.outcome_events` exists
  - `onboard` and `process_agent_update` succeeded against `http://127.0.0.1:58767`
