### PR TITLE
fix(decorators): wire incident_id in mcp_handler_timeout emit (Wave 0 dedup contract)

### DIFF
--- a/src/mcp_handlers/decorators.py
+++ b/src/mcp_handlers/decorators.py
@@ -152,10 +152,17 @@ def mcp_tool(
                 effective_agent_id = args_agent_id or get_context_agent_id()
                 session_id = get_context_session_key()
 
+                from uuid import uuid4
+
                 emit_payload: Dict[str, Any] = {
                     "tool_name": tool_name,
                     "timeout_s": timeout,
                     "elapsed_s": round(time.time() - start_time, 3),
+                    # Wave 0 step 2 dedup contract (wave-0-step-2-call-site-scoping.md §"Dedup contract"):
+                    # §129 evaluates `COUNT(DISTINCT payload->>'incident_id')`. The other four wired
+                    # emit sites carry this field; this site was the gap (see
+                    # docs/proposals/wave-1-window-evaluation-2026-05-18.md Caveat 1).
+                    "incident_id": str(uuid4()),
                 }
                 if isinstance(arguments, dict) and arguments.get("action"):
                     emit_payload["action"] = arguments["action"]

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -229,6 +229,13 @@ class TestDecoratorExecution:
         assert call_kwargs["payload"]["timeout_s"] == 0.05
         assert "elapsed_s" in call_kwargs["payload"]
         assert call_kwargs["agent_id"] == "test-uuid-1234"
+        # Wave 0 step 2 dedup contract: every coordination_failure event carries
+        # an incident_id UUID for §129 dedup. The decorator emit site was the
+        # one gap (see docs/proposals/wave-1-window-evaluation-2026-05-18.md).
+        import uuid as _uuid
+        incident_id = call_kwargs["payload"]["incident_id"]
+        assert isinstance(incident_id, str)
+        _uuid.UUID(incident_id)  # raises if not a valid UUID
 
     @pytest.mark.asyncio
     async def test_timeout_emit_handles_arguments_without_agent_id(self):


### PR DESCRIPTION
Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.