### PR TITLE
feat(pause-ttl): auto-expire stale pauses at all gate-traversal sites

### DIFF
--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -697,7 +697,40 @@ class GovernanceConfig:
     # cycle's verdict will catch genuine high-risk states). Evidence in
     # knowledge graph discovery 2026-05-15T14:27:26.894282+00:00.
     GAP_RECOVERY_CYCLES = 2
-    
+
+    # Pause TTL: an agent paused for longer than this is considered stale
+    # and the next gate-traversal is allowed through, letting the
+    # categorizer re-evaluate (its own gap-suppression handles the
+    # first-after-gap state; a real problem re-pauses immediately on the
+    # next cycle via the normal circuit-breaker path).
+    #
+    # Motivation: GAP_RECOVERY_CYCLES above only protects the *categorizer
+    # path* — the case where a long gap would falsely paint a pause on a
+    # first-after-gap check-in. It does not help once an agent is
+    # *already* paused, because the pause-status check at every gate
+    # (src/mcp_handlers/support/agent_auth.py, src/mcp_handlers/updates/
+    # phases.py, etc.) rejects the call before the categorizer runs. The
+    # 2026-05-09 → 2026-05-18 Watcher/Sentinel/Lumen silence (recovered
+    # 2026-05-18 via operator self_recovery) was this class: pauses set
+    # during the earlier 2026-05-08 sleep-wake incident persisted across
+    # nine days because there was no aging mechanism.
+    #
+    # Default 72h (3 days): long enough to cover a long-weekend operator-
+    # AFK window without the dashboard going noisy; shorter than the
+    # observed 9-day silence so the operator's first sign would be one
+    # auto-expire event in the audit log instead of weeks of fleet
+    # blindness. All pause sources are categorizer-driven (only
+    # agent_loop_detection.py:513 sets status=paused in the codebase, and
+    # only on `decision_action == 'pause'` from monitor_decision.py's
+    # four pause paths); loop-detection uses a separate cooldown
+    # mechanism (loop_detected_at + loop_cooldown_until) and is not
+    # affected by this TTL.
+    #
+    # Override via env `UNITARES_PAUSE_AUTO_EXPIRE_SECONDS` (seconds).
+    PAUSE_AUTO_EXPIRE_SECONDS = int(
+        os.getenv("UNITARES_PAUSE_AUTO_EXPIRE_SECONDS", str(72 * 3600))
+    )
+
     # History window for metrics
     HISTORY_WINDOW = 1000  # Keep last 1000 updates for statistics
     

--- a/src/audit_log.py
+++ b/src/audit_log.py
@@ -110,6 +110,31 @@ class AuditLogger:
         )
         self._write_entry(entry)
     
+    def log_pause_auto_expired(self, agent_id: str,
+                                original_paused_at: Optional[str],
+                                elapsed_seconds: float):
+        """Log a stale-pause auto-expiration.
+
+        Emitted when a paused agent's status is auto-cleared at a gate
+        because the pause is older than `PAUSE_AUTO_EXPIRE_SECONDS`.
+        The categorizer is allowed to re-evaluate on the same call;
+        if the agent is genuinely degraded, the normal circuit-breaker
+        path re-pauses on the next cycle. See
+        `src/mcp_handlers/support/pause_ttl.py` and
+        `docs/proposals/wave-1-window-evaluation-2026-05-18.md`.
+        """
+        entry = AuditEntry(
+            timestamp=datetime.now().isoformat(),
+            agent_id=agent_id,
+            event_type="pause_auto_expired",
+            confidence=0.0,
+            details={
+                "original_paused_at": original_paused_at,
+                "elapsed_seconds": round(elapsed_seconds, 1),
+            }
+        )
+        self._write_entry(entry)
+
     def log_attest_gap_suppressed(self, agent_id: str, elapsed_seconds: float,
                                    risk_score: float, original_reason: str,
                                    cycles_remaining: int,

--- a/src/mcp_handlers/support/agent_auth.py
+++ b/src/mcp_handlers/support/agent_auth.py
@@ -149,6 +149,17 @@ def check_agent_can_operate(agent_uuid: str) -> Optional[TextContent]:
     meta = mcp_server.agent_metadata[agent_uuid]
 
     if meta.status == "paused":
+        # Pause TTL: stale pauses auto-expire (in-memory flip is
+        # synchronous; persistence is fire-and-forget). Sleep-wake
+        # artifacts that produced the 2026-05-09 → 2026-05-18 Watcher/
+        # Sentinel/Lumen silence are categorizer-driven pauses; once
+        # the TTL elapses, the next gate-traversal here clears the
+        # in-memory status, and the agent's next check-in flows through
+        # the categorizer which re-pauses if state is genuinely
+        # degraded. See src/mcp_handlers/support/pause_ttl.py.
+        from .pause_ttl import maybe_auto_expire_pause_sync
+        if maybe_auto_expire_pause_sync(agent_uuid, meta):
+            return None  # status now active; let caller proceed
         return error_response(
             "Agent is paused - circuit breaker active",
             error_code="AGENT_PAUSED",

--- a/src/mcp_handlers/support/pause_ttl.py
+++ b/src/mcp_handlers/support/pause_ttl.py
@@ -1,0 +1,254 @@
+"""Pause TTL — auto-expire stale paused states across all gate-traversal sites.
+
+A paused agent's status persists in `mcp_server.agent_metadata` until an
+explicit `self_recovery` call. Sleep-wake artifacts (Mac clamshell, host
+suspend, Pi power blip) can trigger a categorizer-driven pause whose
+underlying "stale state input" cause has long since resolved, but the
+pause itself persists indefinitely because every subsequent
+gate-traversal is rejected before the categorizer can re-evaluate.
+
+This module provides a TTL: pauses older than
+`GovernanceConfig.PAUSE_AUTO_EXPIRE_SECONDS` auto-clear on the next
+gate-traversal, letting the categorizer re-evaluate. A genuinely
+degraded agent re-pauses on the next cycle via the normal
+circuit-breaker path. A sleep-wake artifact resumes clean.
+
+All callers share `_pause_is_stale` for the decision and
+`_apply_in_memory_expire` for the mutation, so behavior is identical
+across all the pause gates in the system. Audit visibility via
+`audit_logger.log_pause_auto_expired` happens in both sync and async
+entry points.
+
+The async entry point awaits persistence; the sync entry point
+fire-and-forget schedules it on the running loop (or AuditLogger's
+captured main loop) using the same pattern as
+`src/coordination_failure_emit.py:_schedule_coordination_events_dual_write`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from src.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+# ─── Stale-pause detection ─────────────────────────────────────────────
+
+
+def _pause_is_stale(paused_at: Optional[str]) -> bool:
+    """Return True if the recorded pause is older than the TTL.
+
+    `paused_at` is an ISO 8601 string per `AgentMetadata`. Unparseable
+    or absent values are treated as not-stale (fail-closed: keep the
+    pause rather than auto-clear on bad data).
+
+    Naive timestamps are interpreted as UTC. Both the canonical write
+    path (`src/agent_loop_detection.py:514` via
+    `datetime.now(timezone.utc).isoformat()`) and legacy persisted
+    naive forms compare correctly under this convention.
+    """
+    if not paused_at:
+        return False
+    try:
+        from config.governance_config import GovernanceConfig
+        threshold_s = int(GovernanceConfig.PAUSE_AUTO_EXPIRE_SECONDS)
+        paused_dt = datetime.fromisoformat(paused_at.replace("Z", "+00:00"))
+        if paused_dt.tzinfo is None:
+            # Legacy naive form — interpret as UTC, matching the
+            # convention used elsewhere when serializing timestamps.
+            paused_dt = paused_dt.replace(tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
+        return (now - paused_dt).total_seconds() > threshold_s
+    except (ValueError, TypeError, AttributeError, ImportError):
+        return False
+
+
+def _apply_in_memory_expire(meta: Any) -> Optional[str]:
+    """Flip status and clear paused_at in-memory; record a lifecycle event.
+
+    Returns the original paused_at string for use by callers that need
+    to log it. Preserves the system invariant that
+    `status == "paused" ⟺ paused_at is truthy` (asserted at
+    `src/agent_metadata_model.py:260` and read at
+    `src/auto_ground_truth.py:285`).
+    """
+    original_paused_at = meta.paused_at
+    meta.status = "active"
+    meta.paused_at = None
+    meta.add_lifecycle_event(
+        "pause_auto_expired",
+        f"pause from {original_paused_at} aged out beyond "
+        f"PAUSE_AUTO_EXPIRE_SECONDS; categorizer re-evaluation triggered "
+        f"on this gate-traversal",
+    )
+    return original_paused_at
+
+
+def _emit_audit(agent_uuid: str, original_paused_at: Optional[str]) -> None:
+    """Fire-and-forget audit emit. Never raises."""
+    try:
+        from src.audit_log import audit_logger
+        elapsed_s: float = 0.0
+        if original_paused_at:
+            try:
+                paused_dt = datetime.fromisoformat(
+                    original_paused_at.replace("Z", "+00:00")
+                )
+                if paused_dt.tzinfo is None:
+                    paused_dt = paused_dt.replace(tzinfo=timezone.utc)
+                elapsed_s = (
+                    datetime.now(timezone.utc) - paused_dt
+                ).total_seconds()
+            except (ValueError, TypeError):
+                pass
+        audit_logger.log_pause_auto_expired(
+            agent_id=agent_uuid,
+            original_paused_at=original_paused_at,
+            elapsed_seconds=elapsed_s,
+        )
+    except Exception as exc:  # noqa: BLE001 — observability MUST NOT mask
+        logger.debug(
+            "[pause-ttl] audit emit failed for %s: %r", agent_uuid[:12], exc
+        )
+
+
+# ─── Async entry point (process_agent_update path) ─────────────────────
+
+
+async def maybe_auto_expire_pause_async(agent_uuid: str, meta: Any) -> bool:
+    """Auto-expire a stale pause; await persistence. Returns True if expired.
+
+    Callers should invoke this BEFORE returning the AGENT_PAUSED error
+    response. If it returns True, the gate should fall through to
+    normal processing (the agent is no longer paused). If False, the
+    pause is not stale and the gate should reject as before.
+    """
+    if not _pause_is_stale(meta.paused_at):
+        return False
+
+    original_paused_at = _apply_in_memory_expire(meta)
+    logger.warning(
+        "[pause-ttl] auto-expired stale pause for %s (paused_at=%s); "
+        "categorizer will re-evaluate",
+        agent_uuid[:12],
+        original_paused_at,
+    )
+    _emit_audit(agent_uuid, original_paused_at)
+
+    try:
+        from src import agent_storage
+        await agent_storage.persist_runtime_state(
+            agent_uuid,
+            paused_at=None,
+            append_lifecycle_event={
+                "event": "pause_auto_expired",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "reason": f"pause from {original_paused_at} aged out",
+            },
+        )
+    except Exception as exc:  # noqa: BLE001 — persistence is non-fatal
+        # In-memory flip already lets this gate through. If persistence
+        # fails, the next load_metadata_async(force=True) may re-hydrate
+        # paused_at; this code path will fire again on the next stale
+        # check-in, producing one extra audit row per check-in until
+        # persistence succeeds.
+        logger.warning(
+            "[pause-ttl] persist_runtime_state(pause_auto_expired) failed "
+            "for %s: %r",
+            agent_uuid[:12],
+            exc,
+        )
+    return True
+
+
+# ─── Sync entry point (check_agent_can_operate path) ───────────────────
+
+
+# Module-local strong-ref set for in-flight fire-and-forget persistence
+# tasks. Mirrors the pattern in `src/coordination_failure_emit.py`: we
+# can't rely on the background-tasks supervisor because callers of this
+# helper are themselves invoked from a wide variety of contexts (sync
+# tools, REST endpoints, MCP handlers).
+_inflight_persistence_tasks: "set[asyncio.Task]" = set()
+
+
+def _spawn_persistence_task(loop: asyncio.AbstractEventLoop, coro: Any) -> None:
+    """Spawn coro on `loop` and pin a strong ref until it completes."""
+    task = loop.create_task(coro, name="pause_ttl_fire_and_forget_persist")
+    _inflight_persistence_tasks.add(task)
+    task.add_done_callback(_inflight_persistence_tasks.discard)
+
+
+def _schedule_persistence_fire_and_forget(
+    agent_uuid: str, original_paused_at: Optional[str]
+) -> None:
+    """Schedule the persistence coroutine on the best-available loop.
+
+    Mirrors `src/coordination_failure_emit.py:_schedule_coordination_events_dual_write`.
+    """
+    try:
+        from src import agent_storage
+
+        def _coro_factory():
+            return agent_storage.persist_runtime_state(
+                agent_uuid,
+                paused_at=None,
+                append_lifecycle_event={
+                    "event": "pause_auto_expired",
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "reason": f"pause from {original_paused_at} aged out "
+                              f"(sync path)",
+                },
+            )
+
+        try:
+            loop = asyncio.get_running_loop()
+            _spawn_persistence_task(loop, _coro_factory())
+            return
+        except RuntimeError:
+            pass
+
+        captured_loop = None
+        try:
+            from src.audit_log import AuditLogger
+            captured_loop = getattr(AuditLogger, "_event_loop", None)
+        except Exception:  # noqa: BLE001
+            captured_loop = None
+
+        if captured_loop is not None and captured_loop.is_running():
+            def _spawn_on_main():
+                _spawn_persistence_task(captured_loop, _coro_factory())
+            captured_loop.call_soon_threadsafe(_spawn_on_main)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "[pause-ttl] persistence schedule failed for %s: %r",
+            agent_uuid[:12],
+            exc,
+        )
+
+
+def maybe_auto_expire_pause_sync(agent_uuid: str, meta: Any) -> bool:
+    """Sync variant: in-memory flip is synchronous, persistence is scheduled.
+
+    Returns True if the pause was expired; False if it should still
+    block. Callers should check the return value before returning the
+    AGENT_PAUSED error.
+    """
+    if not _pause_is_stale(meta.paused_at):
+        return False
+
+    original_paused_at = _apply_in_memory_expire(meta)
+    logger.warning(
+        "[pause-ttl] auto-expired stale pause for %s (paused_at=%s); "
+        "categorizer will re-evaluate (sync path)",
+        agent_uuid[:12],
+        original_paused_at,
+    )
+    _emit_audit(agent_uuid, original_paused_at)
+    _schedule_persistence_fire_and_forget(agent_uuid, original_paused_at)
+    return True

--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -168,24 +168,33 @@ async def resolve_identity_and_guards(ctx: UpdateContext) -> Optional[Sequence[T
                 }
             )]
 
-    # Circuit breaker: paused / archived agents cannot update
+    # Circuit breaker: paused / archived agents cannot update.
+    # Pause TTL: stale pauses auto-expire via the shared helper, letting
+    # the categorizer re-evaluate downstream. Implementation in
+    # src/mcp_handlers/support/pause_ttl.py — same module serves
+    # check_agent_can_operate to keep all gates in sync.
     if ctx.agent_uuid in mcp_server.agent_metadata:
         meta = mcp_server.agent_metadata[ctx.agent_uuid]
         if meta.status == "paused":
-            return [error_response(
-                "Agent is paused and cannot process updates",
-                error_code="AGENT_PAUSED",
-                details={
-                    "agent_id": ctx.agent_uuid[:12],
-                    "paused_at": meta.paused_at,
-                    "status": "paused",
-                },
-                recovery={
-                    "action": "Use self_recovery(action='quick') for safe states, or self_recovery(action='review', reflection='...') for full recovery",
-                    "note": "Circuit breaker triggered due to governance threshold violation",
-                    "auto_recovery": "Dialectic recovery may already be in progress",
-                }
-            )]
+            from ..support.pause_ttl import maybe_auto_expire_pause_async
+            expired = await maybe_auto_expire_pause_async(ctx.agent_uuid, meta)
+            if not expired:
+                return [error_response(
+                    "Agent is paused and cannot process updates",
+                    error_code="AGENT_PAUSED",
+                    details={
+                        "agent_id": ctx.agent_uuid[:12],
+                        "paused_at": meta.paused_at,
+                        "status": "paused",
+                    },
+                    recovery={
+                        "action": "Use self_recovery(action='quick') for safe states, or self_recovery(action='review', reflection='...') for full recovery",
+                        "note": "Circuit breaker triggered due to governance threshold violation",
+                        "auto_recovery": "Dialectic recovery may already be in progress",
+                    }
+                )]
+            # Expired — fall through to normal processing; categorizer
+            # will re-pause if state is genuinely degraded.
         # NOTE: Do NOT block archived here. Phase 2 (handle_onboarding_and_resume)
         # auto-resumes archived agents on engagement. Blocking here prevented
         # onboard() reactivation from taking effect (Phase 1 ran before metadata

--- a/tests/test_circuit_breaker_enforcement.py
+++ b/tests/test_circuit_breaker_enforcement.py
@@ -41,7 +41,7 @@ class TestCircuitBreakerEnforcement:
         """Paused agent is blocked."""
         mock_meta = MagicMock()
         mock_meta.status = "paused"
-        mock_meta.paused_at = "2026-02-05T10:00:00"
+        mock_meta.paused_at = datetime.now().isoformat()  # fresh — pause TTL would expire stale ones
         mock_mcp_server.agent_metadata["paused-agent"] = mock_meta
 
         with patch('src.mcp_handlers.shared.get_mcp_server', return_value=mock_mcp_server):
@@ -67,7 +67,7 @@ class TestCircuitBreakerEnforcement:
         """Paused agent error includes recovery guidance."""
         mock_meta = MagicMock()
         mock_meta.status = "paused"
-        mock_meta.paused_at = "2026-02-05T10:00:00"
+        mock_meta.paused_at = datetime.now().isoformat()  # fresh — pause TTL would expire stale ones
         mock_mcp_server.agent_metadata["paused-agent"] = mock_meta
 
         with patch('src.mcp_handlers.shared.get_mcp_server', return_value=mock_mcp_server):
@@ -141,7 +141,7 @@ class TestCircuitBreakerStates:
         for status, expected in statuses_and_expected:
             mock_meta = MagicMock()
             mock_meta.status = status
-            mock_meta.paused_at = "2026-02-05T10:00:00" if status == "paused" else None
+            mock_meta.paused_at = datetime.now().isoformat() if status == "paused" else None  # fresh — pause TTL would expire stale ones
             mock_mcp_server.agent_metadata["test-agent"] = mock_meta
 
             with patch('src.mcp_handlers.shared.get_mcp_server', return_value=mock_mcp_server):

--- a/tests/test_core_update.py
+++ b/tests/test_core_update.py
@@ -309,7 +309,9 @@ class TestProcessAgentUpdate:
     async def test_paused_agent_rejected(self, mock_server):
         """Paused agent cannot process updates."""
         agent_uuid = "test-uuid-paused"
-        meta = _make_metadata(status="paused", paused_at="2026-01-20T12:00:00")
+        # Fresh paused_at — pause TTL auto-expires stale ones (>72h default)
+        from datetime import datetime as _dt
+        meta = _make_metadata(status="paused", paused_at=_dt.now().isoformat())
         mock_server.agent_metadata = {agent_uuid: meta}
 
         with patch("src.mcp_handlers.core.mcp_server", mock_server), \

--- a/tests/test_kg_lifecycle.py
+++ b/tests/test_kg_lifecycle.py
@@ -546,7 +546,9 @@ class TestLeaveNote:
     async def test_leave_note_paused_agent(self, patch_common, registered_agent, mock_mcp_server):
         """Paused agents cannot leave notes (circuit breaker)."""
         mock_mcp_server.agent_metadata[registered_agent].status = "paused"
-        mock_mcp_server.agent_metadata[registered_agent].paused_at = "2026-01-01T00:00:00"
+        # Fresh paused_at — pause TTL auto-expires stale ones (>72h default)
+        from datetime import datetime as _dt
+        mock_mcp_server.agent_metadata[registered_agent].paused_at = _dt.now().isoformat()
 
         from src.mcp_handlers.knowledge.handlers import handle_leave_note
 

--- a/tests/test_kg_store.py
+++ b/tests/test_kg_store.py
@@ -472,7 +472,9 @@ class TestStoreKnowledgeGraph:
     async def test_store_paused_agent_blocked(self, patch_common, registered_agent, mock_mcp_server):
         """Paused agents cannot store knowledge (circuit breaker)."""
         mock_mcp_server.agent_metadata[registered_agent].status = "paused"
-        mock_mcp_server.agent_metadata[registered_agent].paused_at = "2026-01-01T00:00:00"
+        # Fresh paused_at — pause TTL auto-expires stale ones (>72h default)
+        from datetime import datetime as _dt
+        mock_mcp_server.agent_metadata[registered_agent].paused_at = _dt.now().isoformat()
 
         from src.mcp_handlers.knowledge.handlers import handle_store_knowledge_graph
 

--- a/tests/test_mcp_utils.py
+++ b/tests/test_mcp_utils.py
@@ -262,7 +262,9 @@ class TestCheckAgentCanOperate:
     @patch("src.mcp_handlers.support.agent_auth.compute_agent_signature", return_value={"uuid": None})
     @patch("src.mcp_handlers.shared.get_mcp_server")
     def test_paused_blocked(self, mock_srv, mock_sig):
-        mock_srv.return_value = _mock_server({"p": _meta(status="paused", paused_at="2026-01-01")})
+        from datetime import datetime as _dt
+        # Fresh paused_at — pause TTL auto-expires stale ones (>72h default)
+        mock_srv.return_value = _mock_server({"p": _meta(status="paused", paused_at=_dt.now().isoformat())})
         r = check_agent_can_operate("p")
         assert r is not None
         d = _parse_tc(r)

--- a/tests/test_phases_pause_ttl.py
+++ b/tests/test_phases_pause_ttl.py
@@ -1,0 +1,216 @@
+"""Tests for the shared pause-TTL helpers in support/pause_ttl.py.
+
+A stale pause (older than `PAUSE_AUTO_EXPIRE_SECONDS`) should not block
+gate-traversal. The categorizer re-evaluates downstream and will
+re-pause if a real problem persists. A fresh pause should still block.
+
+Background: a pause set during a sleep-wake artifact persisted in the
+in-memory agent_metadata until self_recovery was called. The 2026-05-09
+→ 2026-05-18 Watcher/Sentinel/Lumen silence was caused by this; the
+categorizer's gap-suppression doesn't help because the pause-status
+gates run before the categorizer.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.mcp_handlers.support.pause_ttl import (
+    _apply_in_memory_expire,
+    _pause_is_stale,
+    maybe_auto_expire_pause_async,
+    maybe_auto_expire_pause_sync,
+)
+
+
+# ─── _pause_is_stale ───────────────────────────────────────────────────
+
+
+def test_pause_is_stale_returns_false_for_none():
+    assert _pause_is_stale(None) is False
+
+
+def test_pause_is_stale_returns_false_for_empty_string():
+    assert _pause_is_stale("") is False
+
+
+def test_pause_is_stale_returns_false_for_unparseable():
+    assert _pause_is_stale("not-a-timestamp") is False
+
+
+def test_pause_is_stale_returns_false_for_fresh_aware_pause():
+    """A pause set 1 minute ago is not stale (aware UTC form)."""
+    fresh = (datetime.now(timezone.utc) - timedelta(minutes=1)).isoformat()
+    assert _pause_is_stale(fresh) is False
+
+
+def test_pause_is_stale_returns_true_for_aged_aware_pause():
+    """A pause set 73 hours ago (> default 72h TTL) is stale."""
+    aged = (datetime.now(timezone.utc) - timedelta(hours=73)).isoformat()
+    assert _pause_is_stale(aged) is True
+
+
+def test_pause_is_stale_handles_z_suffix():
+    """ISO timestamps with Z suffix parse correctly."""
+    aged = (
+        datetime.now(timezone.utc) - timedelta(hours=73)
+    ).isoformat().replace("+00:00", "Z")
+    assert _pause_is_stale(aged) is True
+
+
+def test_pause_is_stale_treats_naive_as_utc():
+    """Legacy naive ISO strings are interpreted as UTC, not local.
+
+    This is the regression guard for reviewer finding #1: an earlier
+    draft compared naive paused_at to naive datetime.now(), which on a
+    non-UTC host produced staleness errors up to the host's UTC offset.
+    """
+    aged_naive = (datetime.now(timezone.utc) - timedelta(hours=73)).replace(tzinfo=None).isoformat()
+    assert _pause_is_stale(aged_naive) is True
+
+    fresh_naive = (datetime.now(timezone.utc) - timedelta(minutes=1)).replace(tzinfo=None).isoformat()
+    assert _pause_is_stale(fresh_naive) is False
+
+
+def test_pause_is_stale_respects_env_var_override(monkeypatch):
+    """UNITARES_PAUSE_AUTO_EXPIRE_SECONDS env var is honored.
+
+    Regression guard for reviewer finding #4: an earlier draft
+    documented the env override but did not wire it.
+    """
+    monkeypatch.setenv("UNITARES_PAUSE_AUTO_EXPIRE_SECONDS", "60")
+    # Re-import config so the class-attribute picks up the env value
+    import importlib
+    from config import governance_config
+    importlib.reload(governance_config)
+    # ALSO reload the pause_ttl module so its lazy import sees the new value
+    from src.mcp_handlers.support import pause_ttl
+    importlib.reload(pause_ttl)
+    try:
+        # 5 minutes ago, threshold is 60 seconds → stale
+        aged = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+        assert pause_ttl._pause_is_stale(aged) is True
+    finally:
+        # Clean up: restore default
+        monkeypatch.delenv("UNITARES_PAUSE_AUTO_EXPIRE_SECONDS", raising=False)
+        importlib.reload(governance_config)
+        importlib.reload(pause_ttl)
+
+
+# ─── _apply_in_memory_expire ───────────────────────────────────────────
+
+
+def test_apply_in_memory_expire_flips_status_and_clears_paused_at():
+    """Clears paused_at to preserve the system invariant
+    (status==paused ⟺ paused_at truthy). Original is returned for audit."""
+    meta = MagicMock()
+    meta.status = "paused"
+    meta.paused_at = "2026-05-09T04:38:00+00:00"
+    meta.add_lifecycle_event = MagicMock()
+
+    original = _apply_in_memory_expire(meta)
+
+    assert meta.status == "active"
+    assert meta.paused_at is None
+    assert original == "2026-05-09T04:38:00+00:00"
+    meta.add_lifecycle_event.assert_called_once()
+    event_args = meta.add_lifecycle_event.call_args[0]
+    assert event_args[0] == "pause_auto_expired"
+    assert "aged out" in event_args[1]
+
+
+# ─── maybe_auto_expire_pause_async (process_agent_update path) ─────────
+
+
+@pytest.mark.asyncio
+async def test_async_entry_point_no_op_on_fresh_pause():
+    meta = MagicMock()
+    meta.status = "paused"
+    meta.paused_at = (datetime.now(timezone.utc) - timedelta(minutes=1)).isoformat()
+
+    expired = await maybe_auto_expire_pause_async("uuid-fresh-12", meta)
+
+    assert expired is False
+    assert meta.status == "paused"
+    assert meta.paused_at is not None
+
+
+@pytest.mark.asyncio
+async def test_async_entry_point_expires_stale_pause():
+    meta = MagicMock()
+    meta.status = "paused"
+    meta.paused_at = (datetime.now(timezone.utc) - timedelta(hours=73)).isoformat()
+    meta.add_lifecycle_event = MagicMock()
+
+    with patch(
+        "src.agent_storage.persist_runtime_state",
+        new_callable=AsyncMock,
+    ) as mock_persist:
+        expired = await maybe_auto_expire_pause_async("uuid-stale-12", meta)
+
+    assert expired is True
+    assert meta.status == "active"
+    assert meta.paused_at is None
+    mock_persist.assert_awaited_once()
+    persist_kwargs = mock_persist.call_args.kwargs
+    assert persist_kwargs["paused_at"] is None
+    assert persist_kwargs["append_lifecycle_event"]["event"] == "pause_auto_expired"
+
+
+@pytest.mark.asyncio
+async def test_async_entry_point_swallows_persist_failure():
+    """In-memory flip is preserved even if DB write fails."""
+    meta = MagicMock()
+    meta.status = "paused"
+    meta.paused_at = (datetime.now(timezone.utc) - timedelta(hours=73)).isoformat()
+    meta.add_lifecycle_event = MagicMock()
+
+    with patch(
+        "src.agent_storage.persist_runtime_state",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("DB down"),
+    ):
+        expired = await maybe_auto_expire_pause_async("uuid-12", meta)
+
+    assert expired is True
+    assert meta.status == "active"
+
+
+# ─── maybe_auto_expire_pause_sync (check_agent_can_operate path) ───────
+
+
+def test_sync_entry_point_no_op_on_fresh_pause():
+    meta = MagicMock()
+    meta.status = "paused"
+    meta.paused_at = (datetime.now(timezone.utc) - timedelta(minutes=1)).isoformat()
+
+    expired = maybe_auto_expire_pause_sync("uuid-fresh-12", meta)
+
+    assert expired is False
+    assert meta.status == "paused"
+
+
+@pytest.mark.asyncio
+async def test_sync_entry_point_expires_stale_pause_under_running_loop():
+    """When called from inside a running event loop, persistence is
+    scheduled as a fire-and-forget task; the in-memory flip is sync."""
+    meta = MagicMock()
+    meta.status = "paused"
+    meta.paused_at = (datetime.now(timezone.utc) - timedelta(hours=73)).isoformat()
+    meta.add_lifecycle_event = MagicMock()
+
+    with patch(
+        "src.agent_storage.persist_runtime_state",
+        new_callable=AsyncMock,
+    ) as mock_persist:
+        expired = maybe_auto_expire_pause_sync("uuid-stale-12", meta)
+        # Yield once so the scheduled task runs
+        import asyncio
+        await asyncio.sleep(0)
+
+    assert expired is True
+    assert meta.status == "active"
+    assert meta.paused_at is None
+    # Persistence was scheduled — the AsyncMock was awaited via the task
+    mock_persist.assert_awaited_once()


### PR DESCRIPTION
Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.