### PR TITLE
fix(P001): pin fire-and-forget task refs in audit_log + phases to prevent GC drop

### DIFF
--- a/src/audit_log.py
+++ b/src/audit_log.py
@@ -19,6 +19,22 @@ from src.logging_utils import get_logger
 logger = get_logger(__name__)
 
 
+# Module-local strong-ref set for in-flight fire-and-forget PG audit-write
+# tasks. Without this, `loop.create_task(coro)` returns a Task that CPython
+# GC can collect mid-await — `_write_to_postgres` awaits asyncpg, so a
+# collection between yields drops the write. Mirrors the canonical pattern
+# at `src/coordination_failure_emit.py:_inflight_dedicated_writes` and
+# `src/mcp_handlers/support/pause_ttl.py:_inflight_persistence_tasks`.
+_inflight_pg_audit_tasks: "set" = set()
+
+
+def _spawn_pg_audit_task(loop, coro) -> None:
+    """Spawn coro on `loop` and pin a strong ref until it completes."""
+    task = loop.create_task(coro, name="pg_audit_write")
+    _inflight_pg_audit_tasks.add(task)
+    task.add_done_callback(_inflight_pg_audit_tasks.discard)
+
+
 def _parse_ts_naive(ts: str) -> datetime:
     """Parse an ISO timestamp and strip tzinfo for naive-naive comparison.
 
@@ -613,18 +629,21 @@ class AuditLogger:
             logger.warning(f"Could not write audit log: {e}", exc_info=True)
 
         # Fire-and-forget Postgres write; see docstring for the loss/latency
-        # tradeoff.
+        # tradeoff. The task is pinned in `_inflight_pg_audit_tasks` until
+        # done so CPython GC can't collect it mid-await — bare create_task
+        # is a documented P001 hazard (Watcher #69f2ccbc, 2026-05-18).
         try:
             import asyncio
             try:
                 loop = asyncio.get_running_loop()
                 # In event loop thread — schedule directly
-                loop.create_task(self._write_to_postgres(entry_dict))
+                _spawn_pg_audit_task(loop, self._write_to_postgres(entry_dict))
             except RuntimeError:
                 # In executor thread — schedule back to main loop
                 loop = self.__class__._event_loop
                 if loop is not None and loop.is_running():
-                    loop.call_soon_threadsafe(loop.create_task, self._write_to_postgres(entry_dict))
+                    coro = self._write_to_postgres(entry_dict)
+                    loop.call_soon_threadsafe(_spawn_pg_audit_task, loop, coro)
         except Exception:
             pass  # No event loop at all (tests, CLI)
 

--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -126,6 +126,29 @@ def _derive_outcome(evidence: dict) -> tuple:
     return ("task_failed" if is_bad else "task_completed", is_bad)
 
 
+# Module-local strong-ref set for in-flight fire-and-forget persist tasks
+# (thread-identity, inferred-purpose). Without this, `asyncio.create_task(coro)`
+# returns a Task that CPython GC can collect mid-await — these persisters
+# await asyncpg, so a collection between yields silently drops the write.
+# Mirrors the canonical pattern at
+# `src/coordination_failure_emit.py:_inflight_dedicated_writes` and
+# `src/mcp_handlers/support/pause_ttl.py:_inflight_persistence_tasks`.
+# P001 fix per Watcher findings #0a0616c2 and #acfc7012 (2026-05-18).
+_inflight_persist_tasks: "set" = set()
+
+
+def _spawn_persist_task(coro, *, name: str) -> None:
+    """Spawn coro on the running loop and pin a strong ref until done.
+
+    Callers should be inside an async handler (running loop required);
+    `RuntimeError` from `get_running_loop` is left to the caller's
+    existing try/except to swallow.
+    """
+    task = asyncio.get_running_loop().create_task(coro, name=name)
+    _inflight_persist_tasks.add(task)
+    task.add_done_callback(_inflight_persist_tasks.discard)
+
+
 # ─── Phase 1: Identity Resolution & Guards ─────────────────────────────
 
 async def resolve_identity_and_guards(ctx: UpdateContext) -> Optional[Sequence[TextContent]]:
@@ -908,8 +931,9 @@ async def execute_locked_update(ctx: UpdateContext) -> Optional[Sequence[TextCon
                     "node_index": ctx.meta.node_index,
                     "active_session_key": ctx.meta.active_session_key,
                 }
-                asyncio.create_task(
-                    _persist_thread_identity_async(ctx.agent_uuid, _thread_metadata_snapshot)
+                _spawn_persist_task(
+                    _persist_thread_identity_async(ctx.agent_uuid, _thread_metadata_snapshot),
+                    name="persist_thread_identity",
                 )
             except RuntimeError:
                 # No running loop — extremely unusual for this code path
@@ -1007,8 +1031,9 @@ async def execute_locked_update(ctx: UpdateContext) -> Optional[Sequence[TextCon
             if inferred:
                 meta.purpose = inferred
                 try:
-                    asyncio.create_task(
-                        _persist_inferred_purpose_async(ctx.agent_id, inferred)
+                    _spawn_persist_task(
+                        _persist_inferred_purpose_async(ctx.agent_id, inferred),
+                        name="persist_inferred_purpose",
                     )
                 except RuntimeError:
                     pass

--- a/tests/test_p001_task_refs.py
+++ b/tests/test_p001_task_refs.py
@@ -1,0 +1,92 @@
+"""Regression guards for P001 fire-and-forget task references.
+
+Bare `loop.create_task(coro)` returns a Task that CPython GC can collect
+mid-await if no caller holds a reference. For tasks that await asyncpg
+(audit-log PG tail, thread-identity persist, inferred-purpose persist),
+collection between yields silently drops the write.
+
+These tests pin the "store ref in module-local set, clear on done"
+pattern at each of the three fixed sites (Watcher P001 fingerprints
+#69f2ccbc, #0a0616c2, #acfc7012 — 2026-05-18).
+"""
+
+import asyncio
+
+import pytest
+
+
+# ─── audit_log._spawn_pg_audit_task ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_audit_log_spawn_pins_task_until_done():
+    """`_spawn_pg_audit_task` adds the Task to the inflight set on create
+    and removes it via done callback when the coro finishes."""
+    from src.audit_log import _inflight_pg_audit_tasks, _spawn_pg_audit_task
+
+    completed = asyncio.Event()
+
+    async def _stub():
+        await asyncio.sleep(0)
+        completed.set()
+
+    loop = asyncio.get_running_loop()
+    before = len(_inflight_pg_audit_tasks)
+    _spawn_pg_audit_task(loop, _stub())
+    # Pinned immediately on spawn
+    assert len(_inflight_pg_audit_tasks) == before + 1
+
+    # Let the coroutine run + done callback fire
+    await asyncio.wait_for(completed.wait(), timeout=1.0)
+    # done callback runs on the same loop; one more yield gives it the slot
+    await asyncio.sleep(0)
+    assert len(_inflight_pg_audit_tasks) == before
+
+
+# ─── phases._spawn_persist_task ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_phases_spawn_pins_task_until_done():
+    """`_spawn_persist_task` does the same for thread-identity and
+    inferred-purpose persisters."""
+    from src.mcp_handlers.updates.phases import (
+        _inflight_persist_tasks,
+        _spawn_persist_task,
+    )
+
+    completed = asyncio.Event()
+
+    async def _stub():
+        await asyncio.sleep(0)
+        completed.set()
+
+    before = len(_inflight_persist_tasks)
+    _spawn_persist_task(_stub(), name="test_persist")
+    assert len(_inflight_persist_tasks) == before + 1
+
+    await asyncio.wait_for(completed.wait(), timeout=1.0)
+    await asyncio.sleep(0)
+    assert len(_inflight_persist_tasks) == before
+
+
+@pytest.mark.asyncio
+async def test_phases_spawn_task_carries_name():
+    """The Task name is preserved so a stray crash log identifies the
+    call site. Mirrors the same property tested for
+    coordination_failure_emit._spawn_dedicated_write_task."""
+    from src.mcp_handlers.updates.phases import (
+        _inflight_persist_tasks,
+        _spawn_persist_task,
+    )
+
+    async def _stub():
+        await asyncio.sleep(0)
+
+    _spawn_persist_task(_stub(), name="my_distinctive_name")
+    pinned = [t for t in _inflight_persist_tasks if t.get_name() == "my_distinctive_name"]
+    assert len(pinned) == 1
+
+    # Let the task complete to keep the set clean for sibling tests
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)


### PR DESCRIPTION
Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.