### PR TITLE
fix(identity): mark REST sticky-cache hit, tier=weak per 04-17 honesty

### DIFF
--- a/src/http_api.py
+++ b/src/http_api.py
@@ -293,11 +293,14 @@ async def _resolve_http_bound_agent(tool_name: str, arguments: dict, signals) ->
                 if cached and (_time.monotonic() - cached.bound_at) < _TRANSPORT_CACHE_TTL:
                     update_context_agent_id(cached.agent_uuid)
                     arguments["agent_id"] = cached.agent_uuid
-                    # Mark resolution source so _compute_identity_assurance
-                    # doesn't read None and downgrade to "weak / unknown".
-                    # Cache-hit means the caller supplied no auth this call
-                    # but matches a recently-proven binding by transport
-                    # fingerprint. See _MEDIUM_IDENTITY_SOURCES rationale.
+                    # Mark resolution source for diagnostic clarity.
+                    # The tier stays weak (intentionally — see
+                    # phases.py _MEDIUM_IDENTITY_SOURCES note: a cache hit
+                    # carries no per-call proof). The mark replaces
+                    # "unknown" with "sticky_transport_cache" so callers
+                    # can see where their identity came from. R6 H1
+                    # dogfood 2026-05-19 surfaced the prior "unknown"
+                    # behavior as identity-honesty noise.
                     set_session_resolution_source("sticky_transport_cache")
                     return cached.agent_uuid
         except Exception as e:

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -256,7 +256,10 @@ async def _resolve_http_bound_agent(tool_name: str, arguments: dict, signals) ->
     if tool_name in skip_tools:
         return None
 
-    from src.mcp_handlers.context import update_context_agent_id
+    from src.mcp_handlers.context import (
+        set_session_resolution_source,
+        update_context_agent_id,
+    )
     from src.mcp_handlers.identity.handlers import derive_session_key, resolve_session_identity
 
     # Respect an already explicit UUID.
@@ -290,6 +293,12 @@ async def _resolve_http_bound_agent(tool_name: str, arguments: dict, signals) ->
                 if cached and (_time.monotonic() - cached.bound_at) < _TRANSPORT_CACHE_TTL:
                     update_context_agent_id(cached.agent_uuid)
                     arguments["agent_id"] = cached.agent_uuid
+                    # Mark resolution source so _compute_identity_assurance
+                    # doesn't read None and downgrade to "weak / unknown".
+                    # Cache-hit means the caller supplied no auth this call
+                    # but matches a recently-proven binding by transport
+                    # fingerprint. See _MEDIUM_IDENTITY_SOURCES rationale.
+                    set_session_resolution_source("sticky_transport_cache")
                     return cached.agent_uuid
         except Exception as e:
             logger.debug("[STICKY-REST] cache check failed: %s", e)

--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -46,6 +46,12 @@ _MEDIUM_IDENTITY_SOURCES = {
     "pinned_onboard_session",
     "context_mcp_session_id",
     "context_session_key",
+    # Sticky transport cache hit: caller supplied no auth signal this call,
+    # but the IP:UA fingerprint matched a recently-resolved binding (TTL'd).
+    # Honest tier: the chain-of-trust is fingerprint-stability since the
+    # original strongly-proven resolution. Not weak ("no signal at all"),
+    # not strong ("this call carried explicit proof").
+    "sticky_transport_cache",
 }
 
 

--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -46,13 +46,18 @@ _MEDIUM_IDENTITY_SOURCES = {
     "pinned_onboard_session",
     "context_mcp_session_id",
     "context_session_key",
-    # Sticky transport cache hit: caller supplied no auth signal this call,
-    # but the IP:UA fingerprint matched a recently-resolved binding (TTL'd).
-    # Honest tier: the chain-of-trust is fingerprint-stability since the
-    # original strongly-proven resolution. Not weak ("no signal at all"),
-    # not strong ("this call carried explicit proof").
-    "sticky_transport_cache",
 }
+
+# NOTE: "sticky_transport_cache" is intentionally NOT in either set above.
+# A sticky-cache hit means the caller supplied no per-call proof. The 04-17
+# identity-honesty rollout treats per-call proof absence as weak, even when
+# the server's own cache trusts the binding. Marking the source (in
+# http_api.py:_resolve_http_bound_agent) gives diagnostic clarity
+# (session_source="sticky_transport_cache" instead of "unknown") without
+# upgrading the tier away from honest weak. A durable per-binding tier would
+# require TransportBinding to capture the original session_resolution_source
+# at mint time (currently it only captures load-provenance: redis/postgres/
+# rest). See r6-h1 dogfood 2026-05-19 finding.
 
 
 def _compute_identity_assurance(

--- a/tests/test_sticky_identity.py
+++ b/tests/test_sticky_identity.py
@@ -660,17 +660,23 @@ class TestStickyRESTPath:
         result = await _resolve_http_bound_agent("call_model", {}, signals)
 
         assert result == "uuid-cached"
-        # The mark is the load-bearing assertion — without it,
-        # _compute_identity_assurance reads None → weak / unknown.
+        # The mark is the load-bearing assertion. Pre-fix, the cache-hit
+        # branch returned without ever calling set_session_resolution_source,
+        # leaving the contextvar at None — _compute_identity_assurance then
+        # reported session_source="unknown".
         source = get_session_resolution_source()
         assert source == "sticky_transport_cache"
 
-        # And the assurance computation must map it to medium, not weak —
-        # cache hit implies fingerprint-stability since the original
-        # (strongly-proven) resolution, not a no-signal-at-all call.
+        # Tier intentionally stays weak: a cache hit means the caller
+        # supplied no per-call proof. The 04-17 identity-honesty stance
+        # is that per-call proof absence is weak even when the server's
+        # own cache trusts the binding. The mark gives diagnostic
+        # clarity (source identified) without claiming a stronger tier
+        # than the caller proved. See the _MEDIUM_IDENTITY_SOURCES note
+        # in phases.py for rationale.
         from src.mcp_handlers.updates.phases import _compute_identity_assurance
         assurance = _compute_identity_assurance(source, None)
-        assert assurance["tier"] == "medium"
+        assert assurance["tier"] == "weak"
         assert assurance["session_source"] == "sticky_transport_cache"
 
     @pytest.mark.asyncio

--- a/tests/test_sticky_identity.py
+++ b/tests/test_sticky_identity.py
@@ -638,6 +638,42 @@ class TestStickyRESTPath:
         mock_resolve.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_rest_cache_hit_marks_session_resolution_source(self):
+        """Cache-hit short-circuit must mark session_resolution_source.
+
+        Regression for the REST process_agent_update identity-assurance
+        mismatch surfaced during R6 H1 dogfood 2026-05-19: the cache-hit
+        branch bound the right agent_uuid but never called
+        ``set_session_resolution_source``. Downstream
+        ``_compute_identity_assurance`` then read None and reported
+        ``tier: weak / session_source: unknown`` even though the row
+        landed under the correctly bound UUID. Response body and durable
+        state disagreed about assurance tier — the kind of identity-
+        honesty regression the 2026-04-17 rollout was meant to close.
+        """
+        from src.http_api import _resolve_http_bound_agent
+        from src.mcp_handlers.context import get_session_resolution_source
+
+        update_transport_binding("sticky:7.7.7.7:ua-hit", "uuid-cached", "sk", "rest")
+        signals = FakeSignals(ip_ua_fingerprint="7.7.7.7:ua-hit")
+
+        result = await _resolve_http_bound_agent("call_model", {}, signals)
+
+        assert result == "uuid-cached"
+        # The mark is the load-bearing assertion — without it,
+        # _compute_identity_assurance reads None → weak / unknown.
+        source = get_session_resolution_source()
+        assert source == "sticky_transport_cache"
+
+        # And the assurance computation must map it to medium, not weak —
+        # cache hit implies fingerprint-stability since the original
+        # (strongly-proven) resolution, not a no-signal-at-all call.
+        from src.mcp_handlers.updates.phases import _compute_identity_assurance
+        assurance = _compute_identity_assurance(source, None)
+        assert assurance["tier"] == "medium"
+        assert assurance["session_source"] == "sticky_transport_cache"
+
+    @pytest.mark.asyncio
     async def test_rest_cache_populated_on_miss(self):
         """First REST call for a fingerprint populates the cache so next call hits it."""
         from src.http_api import _resolve_http_bound_agent


### PR DESCRIPTION
## Summary

REST `/v1/tools/call`'s sticky-cache hit branch returned the bound `agent_uuid` without calling `set_session_resolution_source`. Downstream `_compute_identity_assurance` then read `None` → `session_source="unknown"` → `tier="weak"`, while the row landed under the correctly resolved UUID. Response body and durable state disagreed about assurance tier.

Surfaced 2026-05-19 during R6 H1 dogfood: Hermes's MCP session populated the cache via `identity_step.py:651`; a subsequent REST replay (no auth in arguments) hit the cache short-circuit and produced the disagreement.

## What this fixes

- **Diagnostic clarity**: `session_source` now reads `"sticky_transport_cache"` instead of `"unknown"` — callers can see where the binding came from.
- **Honest tier**: stays `weak`. A cache hit means the caller supplied no per-call proof; the 2026-04-17 identity-honesty stance treats per-call absence as weak even when the server's own cache trusts the binding.

## Council pivot (commits)

1. `2daf75fd` — initial fix, mapped cache hit to `tier="medium"` reasoning that fingerprint-stability since strong-proof is medium-ish.
2. `70ee15c8` — pivot after 3-agent council review. The dialectic-knowledge-architect flagged the medium mapping as the inverse pole of the categorical fabrication the 04-17 rollout was built to prevent (similar shape, lower amplitude). Live-verifier confirmed `TransportBinding.source` stores load-provenance, not original-proof-source. The principled answer is `weak` + diagnostic mark.

Kept the two-commit history (vs squashing) so the reasoning trail is recoverable.

## Out of scope (follow-ups)

- **S3 — TransportBinding remembers original source**: schema-change so cache hits could report per-binding tier-decay honestly. Would let strongly-minted bindings inherit medium on cache hit and weakly-minted ones stay weak. Bigger refactor.
- **Hermes wrapper field-drop**: separate Hermes-side bug that forced the REST replay in the first place (drops S22 envelope fields from `process_agent_update` arguments). Tracked in memory.

## Test plan

- [x] `tests/test_sticky_identity.py::test_rest_cache_hit_marks_session_resolution_source` — pins both the mark and `tier="weak"` mapping.
- [x] Full local suite green (8736 passed, 34 skipped, same as pre-change baseline).
- [x] Council review (architect + code-reviewer + live-verifier) integrated; pivot reasoning in commit body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)