### PR TITLE
fix(cirs): attribute hard_block reason to actual trigger and log behavioral components

### DIFF
--- a/src/governance_monitor.py
+++ b/src/governance_monitor.py
@@ -1129,6 +1129,13 @@ class UNITARESMonitor:
                     'overconf': continuity_metrics.overconfidence_signal,
                     'underconf': continuity_metrics.underconfidence_signal,
                 },
+                'behavioral': {
+                    'verdict': behavioral_assessment.verdict,
+                    'health': behavioral_assessment.health,
+                    'risk': behavioral_assessment.risk,
+                    'components': behavioral_assessment.components,
+                    'baselined': self._behavioral_state.is_baselined,
+                },
             }
         )
 

--- a/src/monitor_decision.py
+++ b/src/monitor_decision.py
@@ -76,18 +76,48 @@ def make_decision(
     )
 
     # --- Priority 1: CIRS hard_block override ---
+    # classify_response() can fire hard_block from three independent conditions:
+    # coherence < tau_low, risk > beta_high, or resonant + bad state. Attribute
+    # the reason to the actual trigger instead of blanket-labeling as resonance.
     if response_tier == 'hard_block':
-        oi = oscillation_state.oi if oscillation_state else 0.0
-        flips = oscillation_state.flips if oscillation_state else 0
+        from src.cirs import CIRS_DEFAULTS
+        resonant = bool(oscillation_state and oscillation_state.resonant)
+        if resonant:
+            oi = oscillation_state.oi
+            flips = oscillation_state.flips
+            reason = (
+                f'CIRS resonance detected (OI={oi:.2f}, flips={flips}) — decision oscillating'
+            )
+            guidance = 'Governance is flip-flopping. Reduce complexity or wait for state to settle.'
+            nearest_edge = 'oscillation'
+        elif risk_score > CIRS_DEFAULTS['beta_high']:
+            reason = f'CIRS risk ceiling breached (risk={risk_score:.2f} > {CIRS_DEFAULTS["beta_high"]})'
+            guidance = 'Risk score exceeded the hard-block ceiling. Pause to investigate the input driving the spike.'
+            nearest_edge = 'risk'
+        elif state.coherence < CIRS_DEFAULTS['tau_low']:
+            reason = f'CIRS coherence floor breached (coherence={state.coherence:.2f} < {CIRS_DEFAULTS["tau_low"]})'
+            guidance = 'Coherence fell below the hard-block floor. Pause to let state stabilize.'
+            nearest_edge = 'coherence'
+        else:
+            # hard_block reached us but none of the documented conditions hold —
+            # surface that fact rather than mislabeling as resonance.
+            oi = oscillation_state.oi if oscillation_state else 0.0
+            flips = oscillation_state.flips if oscillation_state else 0
+            reason = (
+                f'CIRS hard_block (cause unclassified; OI={oi:.2f}, flips={flips}, '
+                f'risk={risk_score:.2f}, coherence={state.coherence:.2f})'
+            )
+            guidance = 'CIRS forced a hard block but the trigger condition is ambiguous; inspect monitor inputs.'
+            nearest_edge = 'oscillation'
         return {
             'action': 'pause',
             'sub_action': 'cirs_block',
-            'reason': f'CIRS resonance detected (OI={oi:.2f}, flips={flips}) — decision oscillating',
-            'guidance': 'Governance is flip-flopping. Reduce complexity or wait for state to settle.',
+            'reason': reason,
+            'guidance': guidance,
             'critical': False,
             'basin': basin,
             'margin': 'critical',
-            'nearest_edge': 'oscillation',
+            'nearest_edge': nearest_edge,
         }
 
     # --- Priority 2: void_active → pause (runtime adaptive threshold) ---

--- a/tests/test_eval_fixes.py
+++ b/tests/test_eval_fixes.py
@@ -251,7 +251,7 @@ class TestDecisionSubAction:
         assert decision['action'] == 'pause'
         assert decision['sub_action'] == 'coherence_pause'
 
-    def test_monitor_decision_cirs_block(self):
+    def test_monitor_decision_cirs_block_resonance(self):
         state = MagicMock()
         state.E = 0.8
         state.I = 0.8
@@ -262,14 +262,67 @@ class TestDecisionSubAction:
         state.coherence_history = []
 
         oi_state = MagicMock()
-        oi_state.oi = 0.9
+        oi_state.oi = 3.5
         oi_state.flips = 5
+        oi_state.resonant = True
 
         decision = monitor_make_decision(
             state=state, risk_score=0.1,
             response_tier='hard_block', oscillation_state=oi_state
         )
         assert decision['sub_action'] == 'cirs_block'
+        assert 'resonance' in decision['reason'].lower()
+        assert decision['nearest_edge'] == 'oscillation'
+
+    def test_monitor_decision_cirs_block_risk_ceiling(self):
+        """hard_block fired by risk > beta_high should label the reason as risk, not resonance."""
+        state = MagicMock()
+        state.E = 0.3
+        state.I = 0.9
+        state.S = 0.25
+        state.V = 0.0
+        state.coherence = 0.49
+        state.void_active = False
+        state.coherence_history = []
+
+        oi_state = MagicMock()
+        oi_state.oi = 0.30
+        oi_state.flips = 2
+        oi_state.resonant = False
+
+        decision = monitor_make_decision(
+            state=state, risk_score=0.85,
+            response_tier='hard_block', oscillation_state=oi_state
+        )
+        assert decision['sub_action'] == 'cirs_block'
+        assert 'risk ceiling' in decision['reason'].lower()
+        assert 'resonance' not in decision['reason'].lower()
+        assert decision['nearest_edge'] == 'risk'
+
+    def test_monitor_decision_cirs_block_coherence_floor(self):
+        """hard_block fired by coherence < tau_low should label the reason as coherence."""
+        state = MagicMock()
+        state.E = 0.5
+        state.I = 0.5
+        state.S = 0.5
+        state.V = 0.0
+        state.coherence = 0.25
+        state.void_active = False
+        state.coherence_history = []
+
+        oi_state = MagicMock()
+        oi_state.oi = 0.10
+        oi_state.flips = 1
+        oi_state.resonant = False
+
+        decision = monitor_make_decision(
+            state=state, risk_score=0.4,
+            response_tier='hard_block', oscillation_state=oi_state
+        )
+        assert decision['sub_action'] == 'cirs_block'
+        assert 'coherence floor' in decision['reason'].lower()
+        assert 'resonance' not in decision['reason'].lower()
+        assert decision['nearest_edge'] == 'coherence'
 
     def test_monitor_decision_risk_pause(self):
         state = MagicMock()


### PR DESCRIPTION
Lumen's recent pauses surfaced two issues in the CIRS hard_block path.

## Finding 1 — labeling bug

`monitor_decision.py` unconditionally attributed every CIRS `hard_block` to 'resonance detected', even when `classify_response()` actually fired from the risk ceiling or coherence floor. Audit log for Lumen showed three recent pauses with OI=0.30 and flips=2 (well below thresholds 3.0/3) — the actual trigger was `risk_score` reaching 0.79–0.85 against `beta_high=0.7`.

Fix: branch the reason string on the actual trigger (resonance / risk ceiling / coherence floor / unclassified). `sub_action='cirs_block'` preserved for downstream contracts.

## Finding 2 — missing diagnostics

`auto_attest` payload logged `beh_obs` but not the `behavioral_assessment.components` dict that drives `risk_score`. Without it, you can see the spike but not which weighted component (low_E / low_I / high_S / high_V / adversarial_rho / high_CE) fired.

Add a `behavioral` block to the payload with `verdict`, `health`, `risk`, `components`, `baselined`. Purely additive.

## Tests

3 new tests in `test_eval_fixes.py` cover the three real hard_block branches (resonance / risk ceiling / coherence floor). All 247 CIRS/governance_monitor tests pass; smoke gate (138 tests) green via ship.sh.

## Why this didn't auto-PR

`ship.sh` classifier only treats `src/mcp_handlers/`, `src/mcp_server`, `src/core.py`, `src/background_tasks.py`, and `elixir/` as runtime. `src/governance_monitor.py` and `src/monitor_decision.py` fell into 'other' and direct-pushed without opening a PR. Allowlist likely deserves an update, but that's a separate change.