### PR TITLE
chore(ship): add governance decision pipeline to runtime allowlist

### DIFF
--- a/scripts/dev/ship.sh
+++ b/scripts/dev/ship.sh
@@ -41,6 +41,16 @@ RUNTIME_PATTERNS=(
     '^src/mcp_server'
     '^src/core\.py$'
     '^src/background_tasks\.py$'
+    # Governance decision pipeline — drives every auto_attest verdict.
+    # Fell into "other" for PR #467 (CIRS reason-string + behavioral
+    # components instrumentation) and shipped without a PR until manually
+    # opened. Same rollback-artifact rationale as elixir/ below.
+    '^src/governance_monitor\.py$'
+    '^src/governance_state\.py$'
+    '^src/monitor_[^/]+\.py$'
+    '^src/cirs\.py$'
+    '^src/behavioral_[^/]+\.py$'
+    '^governance_core/'
     # BEAM substrate (Sentinel, lease plane, future apps under elixir/) is
     # runtime: every change wants a CI-gated PR, not direct push. Without
     # this, a fix to elixir/sentinel/ falls through to "other" and ships


### PR DESCRIPTION
PR #467 (CIRS reason-string fix + behavioral components instrumentation) touched `src/governance_monitor.py` and `src/monitor_decision.py` — both clearly runtime — but `ship.sh` classified the change as 'other' and direct-pushed without opening a PR. PR had to be created manually, which loses the CI-gated rollback-artifact intent of the runtime path.

Adds patterns for:
- `^src/governance_monitor\.py$`
- `^src/governance_state\.py$`
- `^src/monitor_[^/]+\.py$` (decision, cirs, phi, risk, regime, result, metrics)
- `^src/cirs\.py$`
- `^src/behavioral_[^/]+\.py$` (sensor, assessment, state)
- `^governance_core/`

Verified locally against PR #467 files (all match runtime) and an unrelated control path (still 'other'). Smoke gate green via ship.sh.