### PR TITLE
feat(s10): per-class fleet calibration aggregation

### DIFF
--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -1193,6 +1193,23 @@ async function loadSystemHealth() {
     }
 }
 
+// S10.3: format the by_class breakdown as a chip strip for the card detail
+// line. The envelope shape comes from sequential_calibration.compute_metrics_by_class:
+//   { bootstrapped: bool, by_class: { class_tag: { eligible_samples, calibration_gap, ... } } }
+// Returns a string like "substrate: 12 · ephemeral: 8" with the top
+// buckets by sample count, or null when the envelope has no useful content.
+function formatByClassChips(byClassEnvelope) {
+    if (!byClassEnvelope || !byClassEnvelope.by_class) return null;
+    var buckets = byClassEnvelope.by_class;
+    var entries = Object.keys(buckets)
+        .map(function (k) { return { name: k, samples: buckets[k].eligible_samples || 0 }; })
+        .filter(function (e) { return e.samples > 0; })
+        .sort(function (a, b) { return b.samples - a.samples; })
+        .slice(0, 3);
+    if (entries.length === 0) return null;
+    return entries.map(function (e) { return e.name + ': ' + e.samples; }).join(' · ');
+}
+
 async function loadCalibration() {
     try {
         const result = await callTool('check_calibration', {});
@@ -1202,6 +1219,8 @@ async function loadCalibration() {
         if (result && result.success) {
             const samples = result.total_samples ?? 0;
             const th = result.trajectory_health ?? result.accuracy ?? 0;
+            const byClass = result.by_class;
+            const byClassBootstrapping = byClass && byClass.bootstrapped === false;
             if (samples === 0) {
                 valueEl.textContent = '—';
                 valueEl.style.color = '';
@@ -1222,21 +1241,29 @@ async function loadCalibration() {
                     : 'var(--color-danger, #ef4444)';
                 var trajectoryPct = (th * 100).toFixed(0);
 
-                // Per-channel chips render when the broadened truth channel
-                // has populated state. Falls back to the legacy detail line
-                // when per_channel_calibration is absent.
+                // S10.3: per-class breakdown leads the detail line when
+                // available; per-channel chips (S22) follow. The bootstrap
+                // window (pre-S10 state file pre-first-rebucket) renders
+                // explicitly as "bootstrapping\u2026" so operators see the
+                // gap honestly rather than reading partial buckets as
+                // fleet-representative.
+                var classChips = byClassBootstrapping
+                    ? 'bootstrapping\u2026'
+                    : formatByClassChips(byClass);
                 var perChannel = result.per_channel_calibration;
+                var channelChips = null;
                 if (perChannel && Object.keys(perChannel).length > 0) {
-                    var chips = Object.keys(perChannel).map(function (name) {
+                    channelChips = Object.keys(perChannel).map(function (name) {
                         var c = perChannel[name];
                         var icon = c.calibrated ? '\u2713' : '\u2715';
                         return name + ': ' + icon;
                     }).join(' \u00b7 ');
-                    detailEl.textContent = samples + ' samples \u00b7 ' + chips
-                        + ' \u00b7 ' + trajectoryPct + '% trajectory';
-                } else {
-                    detailEl.textContent = samples + ' samples \u00b7 ' + trajectoryPct + '% trajectory';
                 }
+                var detailParts = [samples + ' samples'];
+                if (classChips) detailParts.push(classChips);
+                if (channelChips) detailParts.push(channelChips);
+                detailParts.push(trajectoryPct + '% trajectory');
+                detailEl.textContent = detailParts.join(' \u00b7 ');
             }
         } else {
             valueEl.textContent = '-';
@@ -2225,6 +2252,43 @@ if (calibrationCard) {
                 '<div><strong>Trajectory health:</strong> ' + (th * 100).toFixed(1) + '%</div>' +
                 '<div><strong>Samples:</strong> ' + samples + '</div>' +
                 (dist.mean != null ? '<div><strong>Confidence mean:</strong> ' + (dist.mean * 100).toFixed(1) + '%</div>' : '');
+
+            // S10.3: per-class breakdown panel. Renders bootstrap banner when
+            // the tracker has agent history that hasn't been rebucketed yet
+            // (first 30min after a pre-S10 state file load). Class envelopes
+            // carry only descriptive statistics — log_evidence / capped_alarm
+            // are intentionally absent (see plan.md §3.4 anytime-validity scope).
+            var byClassData = r?.by_class;
+            if (byClassData) {
+                calHtml += '<div style="margin-top:12px;border-top:1px solid rgba(255,255,255,0.06);padding-top:8px"><strong>By class:</strong>';
+                if (byClassData.bootstrapped === false) {
+                    calHtml += ' <span style="opacity:0.6;font-style:italic">(bootstrapping — class data sparse until next 30-min sweeper tick)</span>';
+                }
+                var buckets = byClassData.by_class || {};
+                var bucketNames = Object.keys(buckets).filter(function (n) {
+                    return (buckets[n].eligible_samples || 0) > 0;
+                });
+                if (bucketNames.length === 0) {
+                    calHtml += '<div style="opacity:0.5;padding:4px 0;font-size:12px">No per-class samples yet</div>';
+                } else {
+                    bucketNames.sort(function (a, b) {
+                        return (buckets[b].eligible_samples || 0) - (buckets[a].eligible_samples || 0);
+                    });
+                    calHtml += '<ul style="margin:4px 0;padding-left:18px">';
+                    bucketNames.forEach(function (name) {
+                        var b = buckets[name];
+                        var accPct = (b.empirical_accuracy != null) ? (b.empirical_accuracy * 100).toFixed(1) + '%' : '—';
+                        var gap = (b.calibration_gap != null) ? b.calibration_gap.toFixed(3) : '—';
+                        calHtml += '<li>' + escapeHtml(name) + ': '
+                            + b.eligible_samples + ' samples · '
+                            + accPct + ' accuracy · '
+                            + 'gap ' + gap + '</li>';
+                    });
+                    calHtml += '</ul>';
+                }
+                calHtml += '</div>';
+            }
+
             if (issues.length > 0) {
                 calHtml += '<div style="margin-top:8px"><strong>Issues:</strong><ul style="margin:4px 0;padding-left:18px">';
                 issues.forEach(function (iss) { calHtml += '<li>' + escapeHtml(iss) + '</li>'; });

--- a/docs/ontology/s10-fleet-aggregation-plan.md
+++ b/docs/ontology/s10-fleet-aggregation-plan.md
@@ -1,0 +1,140 @@
+# S10 — Fleet calibration aggregation paths (plan)
+
+**Status:** drafting, 2026-05-19. Unblocked 2026-05-06 when S7 closed.
+**Plan row:** `docs/ontology/plan.md` row S10. "Default aggregation unit shifts from UUID to role. Dashboards + external-consumer contracts updated."
+**Branch / worktree:** `s10-fleet-aggregation` at `.worktrees/s10-fleet-aggregation/`.
+
+---
+
+## 1. Audit baseline (the mechanical sweep)
+
+Mechanical pass for every site in `src/` that aggregates calibration data by `agent_id` / `agent_uuid`. Ranked.
+
+| # | Site | Shape | Role |
+|---|---|---|---|
+| 1 | `src/sequential_calibration.py:99` | `agent_states: defaultdict[agent_id → state_dict]` | **Only UUID-keyed aggregation in the calibration domain.** |
+| 2 | `src/sequential_calibration.py:260-268` | `record_exogenous_tactical_outcome(agent_id=…)` writes through to `agent_states[agent_id]` and `global_state` | Writer. Hot path from `outcome_events.py:332`. |
+| 3 | `src/sequential_calibration.py:311-362` | `compute_metrics(agent_id=Optional[str])` reads agent slice or global | Reader. Per-UUID branch is **dormant** — no live caller passes `agent_id`. |
+| 4 | `src/sequential_calibration.py:104, 164-167` | Persist / restore `agents: {agent_id: state}` to disk | Lifecycle. |
+
+**No other UUID-keyed calibration aggregator exists in `src/`.** `src/calibration.py` bins (`CalibrationBin`, `ComplexityCalibrationBin`) are confidence-bucket-keyed, not agent-keyed. `src/drift_telemetry.py` is event-keyed. The S10 surface is bounded to `sequential_calibration.py` and its readers.
+
+### Readers (all pass `agent_id=None` today)
+
+| Caller | Method | Field consumed | Class-relevant? |
+|---|---|---|---|
+| `src/calibration.py:1155` `_tactical_signal_age_days` | `compute_metrics()` | `last_updated` only | No |
+| `src/calibration.py:683` | `compute_per_channel_health()` | `signal_source_outcomes` (not agent_states) | No |
+| `src/mcp_handlers/admin/calibration.py:78` `handle_check_calibration` | `compute_metrics()` | `status`, `empirical_accuracy`, `last_updated` from global | **Yes — primary external surface** |
+
+### Dashboard consumer
+
+- `dashboard/dashboard.js:1198` → MCP `check_calibration` → renders calibration card.
+- Reads: `calibration_status`, `tactical_staleness_days`, `per_channel_calibration`. No per-class field today.
+
+### Class taxonomy
+
+- `src/grounding/class_indicator.py::classify_agent(meta)` — canonical resolver.
+- `src/grounding/onboard_classifier.py::stamp_default_class_tags` — write at onboard.
+- `src/grounding/class_promotion.py::class_promotion_sweeper_task` — 30min cadence promotion sweep (S8a Phase 2, #252).
+- Live class tags: `substrate`, `session_like`, `engaged_ephemeral`, `ephemeral`. S8b backfill complete 2026-05-05.
+
+---
+
+## 2. Honest re-framing of the plan row
+
+The row reads "shift default aggregation unit from UUID to role." But the current default in every live reader is **global, not UUID** — `compute_metrics(agent_id=None)`. The per-UUID partition is structurally wired (write path populates it) but no reader consumes it.
+
+So S10 is not "stop aggregating by UUID and start aggregating by role." It is:
+
+> **Add per-class as the primary fleet view, with global preserved as the all-bucket sum and UUID retained as drill-down.**
+
+This is the load-bearing read of the row. The dashboard pivots to per-class as its primary calibration card; the `check_calibration` MCP response leads with `by_class` breakdown; global stays available as a summary line; per-UUID stays available as drill-down on demand.
+
+---
+
+## 3. Design decisions (operator-confirmed)
+
+### 3.1 Where per-class becomes default — Dashboard + MCP both pivot
+`check_calibration` response leads with `by_class` breakdown; global drops to summary line. Dashboard renders the class strip as the primary calibration card. **External MCP consumers see a contract change** — this is the contract reshape the plan row promises.
+
+### 3.2 Storage shape — Parallel `class_states`
+Tracker maintains both `agent_states[uuid]` (authoritative per-UUID counters) and `class_states[class_tag]` (denormalized per-class rollup). Writes update both. Reads from `class_states` are O(1) per class.
+
+**Reclassification drift** is the known cost of this choice (an agent promoted ephemeral → session_like silently strands old counters in the ephemeral bucket). Mitigation: a periodic rebucket pass that rebuilds `class_states` from `agent_states` joined to current `core.identities.class_tag`. Coupled to the existing `class_promotion_sweeper_task` (30min cadence) so rebucket fires whenever promotion fires.
+
+### 3.3 Class source at write time
+Three options on the table:
+
+1. **(a) Caller fetches meta + classifies at `outcome_events.py:332`.** The site has `agent_id` only — no `meta` is in scope (live-verified 2026-05-19). S10.2 will add `meta = await load_agent_metadata(agent_id); class_tag = classify_agent(meta)` immediately before the tracker call. ExecutorPool makes the asyncpg read cheap, and outcome events are not a hot path like `process_agent_update`. On fetch failure or timeout, fall through to `UNKNOWN_CLASS_BUCKET` — calibration write stays durable, lookup failures surface as a deficit signal.
+2. **(b) Tracker looks up `core.identities` per write.** Same DB hit but inside the tracker — couples a pure observational module to identity storage. Reject.
+3. **(c) Tracker caches class-per-UUID, refreshes on sweep tick.** Adds a second source of truth with its own staleness story. Rebucket already covers bulk drift; layering a TTL cache on top reinvents that.
+
+**Chosen: (a).** S10.1 ships the tracker plumbing with the `class_tag` parameter ready to receive. S10.2 wires the fetch at the outcome_events call site.
+
+**Verification corrections (2026-05-19 council pass):**
+- Class is stored in `metadata.tags` JSONB array, not as a column. `classify_agent(meta)` reads `meta.tags` to resolve one of: `embodied` / `engaged_ephemeral` / `ephemeral` / `persistent`+`autonomous`. Live distribution: ephemeral=218, engaged_ephemeral=202, persistent variants ~10, embodied=1, untagged=8 (~2% over 437 active agents).
+- `session_like` is a derived class (not a literal tag) — `classify_agent` returns it as a fallback when no other tag fires. S10.2's `classify_agent(meta)` call returns the right string regardless.
+
+### 3.4 Response shape (new `by_class` field on `check_calibration`)
+
+```json
+{
+  "calibration_status": "tracking",
+  "by_class": {
+    "bootstrapped": true,
+    "buckets": {
+      "substrate":         {"eligible_samples": ..., "mean_confidence": ..., "empirical_accuracy": ..., "calibration_gap": ..., "signal_sources": {...}, "last_updated": ...},
+      "session_like":      {...},
+      "engaged_ephemeral": {...},
+      "ephemeral":         {...},
+      "unknown":           {...}
+    }
+  },
+  "global": {"eligible_samples": ..., "empirical_accuracy": ..., "log_evidence": ..., "capped_alarm": ..., ...},
+  "tactical_staleness_days": ...,
+  "per_channel_calibration": ...
+}
+```
+
+`global` retained for backward compatibility and as the all-bucket sum. Removing it is S10-deferred follow-up.
+
+**Anytime-validity scope (S10 council finding).** Class-scope envelopes deliberately omit `log_evidence`, `capped_alarm`, `last_alt_probability`, `last_e_value`. A class bucket under live writes is its own e-process — valid in isolation, not multipliable against `global`/`agent` (same rule the module docstring at `src/sequential_calibration.py:42-45` already states for the global × per-agent product). After `rebucket_from_agent_states` runs, `class_states` is a sum of per-agent `log_e_values` across different `q`-trajectories, which has no martingale interpretation. Rather than expose a field that is sometimes anytime-valid and sometimes not, the class envelope is restricted to descriptive statistics that survive aggregation. Operators reading e-process alarms should read the `global` (or per-agent) envelope, not class.
+
+**Bootstrap labeling.** `by_class.bootstrapped` is `false` until the first `rebucket_from_agent_states` run; this surfaces honestly to consumers during the gap between S10.1 deploy and S10.2 sweeper wire-up. Pre-S10 state files restored at server start retain prior `global` and `agent_states` history but have an empty `class_states` until rebucket runs. Dashboards should render a "by-class data sparse: bootstrap in progress" banner when `bootstrapped=false`.
+
+---
+
+## 4. Sequencing
+
+Three PRs, smallest-first:
+
+| PR | Scope | Touches |
+|---|---|---|
+| **S10.1** | Tracker plumbing | `src/sequential_calibration.py` — add `class_states`, accept `class_tag` on `record_exogenous_tactical_outcome`, add `compute_metrics_by_class()`. Add rebucket primitive. Persistence schema bump (additive). Tests. |
+| **S10.2** | MCP response reshape | `src/mcp_handlers/admin/calibration.py` — surface `by_class`. Wire `class_tag` at call site in `src/mcp_handlers/observability/outcome_events.py:332`. Hook rebucket into `class_promotion_sweeper_task`. Tests + contract test that `by_class` appears. |
+| **S10.3** | Dashboard pivot | `dashboard/dashboard.js` calibration card — render class strip as primary, global as summary. |
+
+Each PR independently shippable. S10.1 leaves the by-class data available but unused; S10.2 surfaces it; S10.3 makes it the operator's primary view.
+
+---
+
+## 5. Open questions before code
+
+1. **Persistence schema bump for `class_states`** — additive fields (`classes`, `class_states_bootstrapped`) on the existing JSON state file. Pre-S10 files load cleanly with `bootstrapped=false`. No migration row needed (file is gitignored runtime state).
+2. **"unknown" bucket policy** — first-class row, so calibration starvation in the un-classified band reads as a deficit signal.
+3. **Drop `global` after a release cycle?** Not in S10 scope; leave as a deferred row in `plan.md` if/when the dashboard read settles.
+
+---
+
+## 6. Council review (fired 2026-05-19, S10.1 revised)
+
+Three-agent parallel adversarial pass per memory ("Council also for load-bearing implementation" + "Council prompts must invite adversarial bug-hunting"). Three findings, all addressed in the revised S10.1.
+
+| Lane | Finding | Resolution |
+|---|---|---|
+| `dialectic-knowledge-architect` | Summing `log_e_value` across agents via `_merge_state` is **not** a valid e-process — same forbidden product the module docstring already warns against for `global × per-agent`. Class-scope `capped_alarm` would look anytime-valid but isn't. | Class envelope omits `log_evidence`, `capped_alarm`, `last_alt_probability`, `last_e_value` unconditionally (not just post-rebucket). `_state_to_metrics(scope="class", ...)` enforces. Tests pin the contract. |
+| `feature-dev:code-reviewer` | (a) `except Exception` in rebucket silently swallows classifier bugs. (b) Pre-S10 files leave class_states sparse vs global with no honest labeling. (c) `last_alt_probability` on class envelope is single-agent provenance. | (a) Classifier exceptions log to stderr with type + agent_id + message, and increment a `classifier_errors` field in telemetry. (b) `class_states_bootstrapped: bool` added to serialized state + envelope; defaults `False` for pre-S10 files with non-empty `agents`; flipped to `True` on first rebucket. (c) Covered by architect's finding. |
+| `live-verifier` | Verifier REFUTED two plan assumptions: no `class_tag` column on `core.identities`, and `outcome_events.py:332` has no `meta` in scope. | Cross-checked: class actually lives in `metadata.tags` JSONB array, classifier reads `meta.tags`. 99% of active agents have a recognized tag. Verifier read the wrong state file (worktree's `data/` was contaminated by test runs). Master's production tracker has 95 agents, 5525 global samples, no `classes` key — confirmed pre-S10 state. §3.3 updated: S10.2 fetches meta at the call site (verifier was right about no meta in scope there). |
+
+**Memo lesson** (added to memory candidates): Pre-flagging a concern in the architect's prompt got it confirmed *and* extended (architect went beyond the rebucket case to the live-write case, which I hadn't fully thought through). Worth doing again when I sense a math/ontology issue at the boundary of the change.

--- a/src/background_tasks.py
+++ b/src/background_tasks.py
@@ -11,6 +11,7 @@ import os
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Optional
 
 from src.logging_utils import get_logger
 from src.connection_tracker import CONNECTIONS_ACTIVE
@@ -195,6 +196,15 @@ async def class_promotion_sweeper_task(interval_minutes: float = 30.0):
 
     Startup delay 60s to let metadata cache warm. Errors are logged at
     WARNING (not debug) so a 30-min silent gap is visible to operators.
+
+    S10.2: at the tail of each cycle, also call
+    ``SequentialCalibrationTracker.rebucket_from_agent_states`` so the
+    by-class calibration rollup tracks any promotions just executed.
+    Rebucket is decoupled from promotion success — even cycles with zero
+    promotions still rebucket so that out-of-band tag edits (manual
+    re-tagging, label changes) eventually converge in the by-class view.
+    Errors in the rebucket pass are isolated from the promotion pass so a
+    rebucket failure cannot starve future promotions.
     """
     await asyncio.sleep(60.0)
     while True:
@@ -214,6 +224,38 @@ async def class_promotion_sweeper_task(interval_minutes: float = 30.0):
             break
         except Exception as e:
             logger.warning(f"[CLASS_PROMOTION] Sweep failed (will retry): {e}")
+
+        # S10.2: rebucket calibration class_states from current metadata.
+        # Isolated try-block so a rebucket failure does not abort the sweeper
+        # loop or starve future promotion cycles. Telemetry is logged at INFO
+        # when meaningful (non-zero tracked or any errors) and at DEBUG on
+        # the idle path so the cycle stays quiet under steady state.
+        try:
+            from src.agent_metadata_model import agent_metadata
+            from src.grounding.class_indicator import classify_agent
+            from src.sequential_calibration import get_sequential_calibration_tracker
+
+            def _s10_classifier(aid: str) -> Optional[str]:
+                meta = agent_metadata.get(aid)
+                return classify_agent(meta) if meta is not None else None
+
+            rebucket = get_sequential_calibration_tracker().rebucket_from_agent_states(
+                classifier=_s10_classifier,
+            )
+            if rebucket["tracked_agents"] > 0 or rebucket["classifier_errors"] > 0:
+                logger.info(
+                    f"[S10_REBUCKET] tracked={rebucket['tracked_agents']} "
+                    f"unresolved={rebucket['unresolved_agents']} "
+                    f"errors={rebucket['classifier_errors']} "
+                    f"buckets={rebucket['buckets']}"
+                )
+            else:
+                logger.debug("[S10_REBUCKET] no tracked agents this cycle")
+        except asyncio.CancelledError:
+            break
+        except Exception as e:
+            logger.warning(f"[S10_REBUCKET] Sweep failed (will retry): {e}")
+
         try:
             await asyncio.sleep(interval_minutes * 60)
         except asyncio.CancelledError:

--- a/src/mcp_handlers/admin/calibration.py
+++ b/src/mcp_handlers/admin/calibration.py
@@ -160,6 +160,18 @@ async def handle_check_calibration(arguments: Dict[str, Any]) -> Sequence[TextCo
             ),
         }
 
+    # S10.2: per-class fleet calibration breakdown. The envelope carries
+    # `bootstrapped` (False during the pre-rebucket bootstrap window after a
+    # pre-S10 state-file load) and `by_class` (descriptive stats only — see
+    # SequentialCalibrationTracker._state_to_metrics for the anytime-validity
+    # rationale: log_evidence/capped_alarm are intentionally omitted at class
+    # scope and only appear on the tactical_evidence (global) envelope above).
+    try:
+        from src.sequential_calibration import get_sequential_calibration_tracker
+        response["by_class"] = get_sequential_calibration_tracker().compute_metrics_by_class()
+    except Exception as e_bc:
+        logger.debug(f"S10 by_class breakdown skipped: {e_bc}")
+
     # Forward per-channel breakdown + hygiene from CalibrationChecker.check_calibration.
     # The handler composes its own response dict, so additions to the underlying
     # metrics dict do not propagate automatically — they have to be forwarded here.

--- a/src/mcp_handlers/observability/outcome_events.py
+++ b/src/mcp_handlers/observability/outcome_events.py
@@ -328,6 +328,21 @@ async def _record_outcome_event_inline(arguments: Dict[str, Any]) -> Dict[str, A
             logger.debug(f"Calibration from outcome_event skipped: {e_cal}")
 
         if eprocess_eligible:
+            # S10.2: resolve class_tag from the in-memory agent_metadata cache so
+            # the tracker's by-class rollup gets the agent's current class at
+            # write time. classify_agent(None) returns "default" — a benign
+            # bucket — when the cache lookup misses (uncached agent or transient
+            # eviction). On any unexpected error, fall through to None so the
+            # tracker writes into UNKNOWN_CLASS_BUCKET; the calibration write
+            # itself must not fail because class resolution failed.
+            class_tag: Optional[str] = None
+            try:
+                from src.agent_metadata_model import agent_metadata
+                from src.grounding.class_indicator import classify_agent
+                class_tag = classify_agent(agent_metadata.get(agent_id))
+            except Exception as e_cls:
+                logger.debug(f"S10 class lookup failed (defaulting to unknown bucket): {e_cls}")
+
             try:
                 from src.sequential_calibration import sequential_calibration_tracker
 
@@ -335,6 +350,7 @@ async def _record_outcome_event_inline(arguments: Dict[str, Any]) -> Dict[str, A
                     confidence=_confidence,
                     outcome_correct=not is_bad,
                     agent_id=agent_id,
+                    class_tag=class_tag,
                     signal_source=hard_exogenous_signal,
                     decision_action=decision_action,
                     outcome_type=outcome_type,

--- a/src/sequential_calibration.py
+++ b/src/sequential_calibration.py
@@ -52,13 +52,55 @@ from __future__ import annotations
 
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Iterable, Optional
 import json
 import math
 import sys
 from datetime import datetime, UTC
 
 from config.governance_config import GovernanceConfig
+
+# S10: the bucket name used when a write arrives without a class_tag, or when
+# the classifier cannot resolve a class for an agent_id during a rebucket pass.
+# Surfaced as a first-class row in compute_metrics_by_class so calibration
+# starvation in the unclassified band reads as a deficit signal, not a silent
+# fold into "global."
+UNKNOWN_CLASS_BUCKET = "unknown"
+
+
+def _merge_state(dst: Dict[str, Any], src: Dict[str, Any]) -> None:
+    """Fold src counters into dst in place. Used by rebucket_from_agent_states
+    to recompose class_states from per-agent slices.
+
+    Sums extensive quantities (samples, successes, confidence_sum, log_e_value);
+    forwards the most-recent last_* fields by timestamp; merges signal_sources
+    and signal_source_outcomes additively. Last-value semantics for last_e_value
+    and last_alt_probability are best-effort under aggregation — the e-process
+    martingale property holds per-state, not across folded states.
+    """
+    dst["eligible_samples"] = int(dst.get("eligible_samples", 0)) + int(src.get("eligible_samples", 0))
+    dst["successes"] = int(dst.get("successes", 0)) + int(src.get("successes", 0))
+    dst["confidence_sum"] = float(dst.get("confidence_sum", 0.0)) + float(src.get("confidence_sum", 0.0))
+    dst["log_e_value"] = float(dst.get("log_e_value", 0.0)) + float(src.get("log_e_value", 0.0))
+
+    src_ts = src.get("last_updated")
+    dst_ts = dst.get("last_updated")
+    if src_ts and (dst_ts is None or src_ts > dst_ts):
+        dst["last_updated"] = src_ts
+        dst["last_e_value"] = float(src.get("last_e_value", dst.get("last_e_value", 1.0)))
+        dst["last_alt_probability"] = float(
+            src.get("last_alt_probability", dst.get("last_alt_probability", 0.5))
+        )
+
+    dst_sources = dst.setdefault("signal_sources", {})
+    for k, v in (src.get("signal_sources") or {}).items():
+        dst_sources[k] = int(dst_sources.get(k, 0)) + int(v)
+
+    dst_outcomes = dst.setdefault("signal_source_outcomes", {})
+    for channel, counts in (src.get("signal_source_outcomes") or {}).items():
+        merged = dst_outcomes.setdefault(channel, {"samples": 0, "successes": 0})
+        merged["samples"] = int(merged.get("samples", 0)) + int(counts.get("samples", 0))
+        merged["successes"] = int(merged.get("successes", 0)) + int(counts.get("successes", 0))
 
 
 def _empty_state() -> Dict[str, Any]:
@@ -97,11 +139,30 @@ class SequentialCalibrationTracker:
     def reset(self) -> None:
         self.global_state = _empty_state()
         self.agent_states = defaultdict(_empty_state)
+        # S10: denormalized per-class rollup. Writes update class_states alongside
+        # global_state and agent_states; reads via compute_metrics_by_class are O(1)
+        # per class. Authoritative counters remain in agent_states — class_states is
+        # a read cache that must be rebuilt via rebucket_from_agent_states when
+        # class membership shifts (S8a promotion sweeps, manual re-tagging).
+        self.class_states = defaultdict(_empty_state)
+        # S10 bootstrap flag: True once class_states is known to represent the
+        # full agent_states corpus (either because it was populated by live
+        # writes only — a fresh epoch — or because rebucket_from_agent_states
+        # has been run at least once). False indicates pre-S10 file load where
+        # class_states is sparse relative to agent_states/global_state. Surfaced
+        # in compute_metrics_by_class so dashboards/MCP consumers can label the
+        # window honestly instead of showing a misleading-by-class breakdown.
+        self.class_states_bootstrapped = True
 
     def _serialize(self) -> Dict[str, Any]:
         return {
             "global": dict(self.global_state),
             "agents": {agent_id: dict(state) for agent_id, state in self.agent_states.items()},
+            # S10: additive field. Tracker state files predating S10 will load
+            # cleanly (load_state defaults to empty class_states); the first
+            # rebucket pass repopulates from agent_states.
+            "classes": {class_tag: dict(state) for class_tag, state in self.class_states.items()},
+            "class_states_bootstrapped": self.class_states_bootstrapped,
             "prior_success": self.prior_success,
             "prior_failure": self.prior_failure,
             "epoch": GovernanceConfig.CURRENT_EPOCH,
@@ -165,6 +226,27 @@ class SequentialCalibrationTracker:
                 restored = _empty_state()
                 restored.update(state or {})
                 self.agent_states[agent_id] = restored
+
+            # S10: load class_states if present; absent for pre-S10 state files,
+            # in which case the next rebucket pass will repopulate from agent_states.
+            self.class_states = defaultdict(_empty_state)
+            classes_data = data.get("classes")
+            for class_tag, state in (classes_data or {}).items():
+                restored = _empty_state()
+                restored.update(state or {})
+                self.class_states[class_tag] = restored
+
+            # S10 bootstrap flag. Honest gap labeling for the window between
+            # pre-S10 file load and the first rebucket run. If the file lacks
+            # the flag AND has no `classes` key AND has non-empty `agents`,
+            # this is a pre-S10 file with history that class_states does not
+            # represent — bootstrap is required.
+            if "class_states_bootstrapped" in data:
+                self.class_states_bootstrapped = bool(data["class_states_bootstrapped"])
+            elif classes_data is None and data.get("agents"):
+                self.class_states_bootstrapped = False
+            else:
+                self.class_states_bootstrapped = True
             self._loaded_mtime = self._file_mtime()
         except Exception as e:
             print(f"Warning: Failed to load sequential calibration state: {e}, resetting", file=sys.stderr)
@@ -231,6 +313,7 @@ class SequentialCalibrationTracker:
         confidence: float,
         outcome_correct: bool,
         agent_id: Optional[str] = None,
+        class_tag: Optional[str] = None,
         signal_source: str,
         decision_action: Optional[str] = None,
         outcome_type: Optional[str] = None,
@@ -243,6 +326,12 @@ class SequentialCalibrationTracker:
         prediction_id, if provided, is included in the return payload for
         forensic audit. The tracker state itself remains aggregate and is
         not indexed by prediction_id.
+
+        class_tag, when provided, drives the parallel class_states rollup
+        (S10). Callers should pass the agent's resolved class (per
+        src/grounding/class_indicator.py::classify_agent). Omitted writes
+        bucket into UNKNOWN_CLASS_BUCKET so the by-class view surfaces
+        calibration starvation in the unclassified band as a deficit signal.
         """
         if not signal_source:
             raise ValueError("signal_source is required")
@@ -267,17 +356,31 @@ class SequentialCalibrationTracker:
                 timestamp=ts,
             )
 
+        # S10: write-through to the class bucket. UNKNOWN_CLASS_BUCKET when the
+        # caller did not pass a class_tag (rather than skipping entirely) keeps
+        # the class breakdown lossless against the global rollup.
+        bucket = class_tag or UNKNOWN_CLASS_BUCKET
+        class_update = self._update_state(
+            self.class_states[bucket],
+            confidence=confidence,
+            outcome_correct=outcome_correct,
+            signal_source=signal_source,
+            timestamp=ts,
+        )
+
         if persist:
             self.save_state()
 
         return {
             "agent_id": agent_id,
+            "class_tag": bucket,
             "prediction_id": prediction_id,
             "decision_action": decision_action,
             "outcome_type": outcome_type,
             "signal_source": signal_source,
             "global": global_update,
             "agent": agent_update,
+            "class": class_update,
         }
 
     def compute_per_channel_health(self, min_samples_for_pin: int = 100) -> Dict[str, Dict[str, Any]]:
@@ -308,57 +411,185 @@ class SequentialCalibrationTracker:
             }
         return out
 
-    def compute_metrics(self, agent_id: Optional[str] = None) -> Dict[str, Any]:
-        """Return bounded, operator-friendly metrics for the tracked e-process."""
-        self._reload_if_stale()
-        if agent_id:
-            state = self.agent_states.get(agent_id)
-            if not state:
-                return {
-                    "status": "no_data",
-                    "eligible_samples": 0,
-                    "scope": "agent",
-                    "agent_id": agent_id,
-                    "signal_sources": {},
-                    "log_evidence": 0.0,
-                    "capped_alarm": 0.0,
-                }
-            scope = "agent"
-        else:
-            state = self.global_state
-            scope = "global"
+    def _state_to_metrics(
+        self,
+        state: Optional[Dict[str, Any]],
+        *,
+        scope: str,
+        agent_id: Optional[str] = None,
+        class_tag: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Render one state dict (global / agent_states[id] / class_states[tag])
+        into the operator-facing metrics payload.
+
+        ANYTIME-VALIDITY SCOPE (S10 council finding):
+        - scope="global" / scope="agent" expose the full e-process envelope
+          including `log_evidence`, `capped_alarm`, `last_alt_probability` —
+          each is a single coherent filtration with valid martingale guarantees.
+        - scope="class" deliberately omits those fields. A class bucket is
+          either (a) a parallel e-process under live writes — valid in
+          isolation but not multipliable against global/agent (same warning
+          the module docstring at the top of this file gives) — or (b) a
+          rebucketed sum of agent log_e_values with different q-trajectories,
+          which has no martingale interpretation. Rather than expose a field
+          that is sometimes anytime-valid and sometimes not, the class
+          envelope is restricted to descriptive statistics that survive
+          aggregation: eligible_samples, mean_confidence, empirical_accuracy,
+          calibration_gap, signal_sources, last_updated.
+        """
+        is_class_scope = scope == "class"
+
+        empty_envelope: Dict[str, Any] = {
+            "status": "no_data",
+            "eligible_samples": 0,
+            "scope": scope,
+            "signal_sources": {},
+        }
+        if not is_class_scope:
+            empty_envelope["log_evidence"] = 0.0
+            empty_envelope["capped_alarm"] = 0.0
+        if agent_id is not None:
+            empty_envelope["agent_id"] = agent_id
+        if class_tag is not None:
+            empty_envelope["class_tag"] = class_tag
+
+        if not state:
+            return empty_envelope
 
         total = int(state["eligible_samples"])
-        positive_log = max(0.0, float(state["log_e_value"]))
 
         if total == 0:
-            return {
-                "status": "no_data",
-                "eligible_samples": 0,
-                "scope": scope,
-                "agent_id": agent_id,
-                "signal_sources": dict(state.get("signal_sources", {})),
-                "log_evidence": 0.0,
-                "capped_alarm": 0.0,
-            }
+            empty_envelope["signal_sources"] = dict(state.get("signal_sources", {}))
+            return empty_envelope
 
         mean_confidence = float(state["confidence_sum"]) / total
         empirical_accuracy = float(state["successes"]) / total
         calibration_gap = empirical_accuracy - mean_confidence
 
-        return {
+        payload: Dict[str, Any] = {
             "status": "tracking",
             "scope": scope,
-            "agent_id": agent_id,
             "eligible_samples": total,
             "mean_confidence": round(mean_confidence, 4),
             "empirical_accuracy": round(empirical_accuracy, 4),
             "calibration_gap": round(calibration_gap, 4),
-            "log_evidence": round(positive_log, 4),
-            "capped_alarm": round(1.0 - math.exp(-positive_log), 4),
-            "last_alt_probability": round(float(state["last_alt_probability"]), 4),
             "signal_sources": dict(state.get("signal_sources", {})),
             "last_updated": state.get("last_updated"),
+        }
+        if not is_class_scope:
+            positive_log = max(0.0, float(state["log_e_value"]))
+            payload["log_evidence"] = round(positive_log, 4)
+            payload["capped_alarm"] = round(1.0 - math.exp(-positive_log), 4)
+            payload["last_alt_probability"] = round(float(state["last_alt_probability"]), 4)
+        if agent_id is not None:
+            payload["agent_id"] = agent_id
+        if class_tag is not None:
+            payload["class_tag"] = class_tag
+        return payload
+
+    def compute_metrics(self, agent_id: Optional[str] = None) -> Dict[str, Any]:
+        """Return bounded, operator-friendly metrics for the tracked e-process."""
+        self._reload_if_stale()
+        if agent_id:
+            return self._state_to_metrics(
+                self.agent_states.get(agent_id),
+                scope="agent",
+                agent_id=agent_id,
+            )
+        return self._state_to_metrics(self.global_state, scope="global")
+
+    def compute_metrics_by_class(self) -> Dict[str, Any]:
+        """S10: per-class rollup keyed by class_tag (substrate / session_like /
+        engaged_ephemeral / ephemeral / UNKNOWN_CLASS_BUCKET).
+
+        Returns an envelope:
+            {
+                "bootstrapped": bool,
+                "by_class": {class_tag: descriptive_metrics, ...},
+            }
+
+        `bootstrapped=False` signals that class_states was loaded from a pre-S10
+        state file and has not been reconciled against agent_states yet —
+        consumers (dashboard, MCP responses) should label the by-class breakdown
+        as a sparse bootstrap view rather than a fleet-representative summary.
+        First successful rebucket_from_agent_states call flips this to True.
+
+        Each by_class value carries only descriptive statistics
+        (eligible_samples, mean_confidence, empirical_accuracy, calibration_gap,
+        signal_sources, last_updated). The e-process fields (log_evidence,
+        capped_alarm, last_alt_probability) are deliberately omitted at class
+        scope — see _state_to_metrics docstring for the anytime-validity
+        rationale.
+        """
+        self._reload_if_stale()
+        return {
+            "bootstrapped": bool(getattr(self, "class_states_bootstrapped", True)),
+            "by_class": {
+                class_tag: self._state_to_metrics(state, scope="class", class_tag=class_tag)
+                for class_tag, state in self.class_states.items()
+            },
+        }
+
+    def rebucket_from_agent_states(
+        self,
+        classifier: Callable[[str], Optional[str]],
+        *,
+        persist: bool = True,
+    ) -> Dict[str, Any]:
+        """S10: rebuild class_states from agent_states by re-asking the classifier
+        for each tracked agent_id.
+
+        classifier(agent_id) returns the current class_tag (or None to bucket the
+        agent's counters into UNKNOWN_CLASS_BUCKET). The walk is full-replacement —
+        old class_states are discarded so a promotion (ephemeral → session_like)
+        moves the counters cleanly rather than leaving the donor bucket inflated.
+
+        IMPORTANT: the merged class_states is a descriptive-stats rollup, not an
+        e-process. `_merge_state` sums per-agent log_e_values across different
+        q-trajectories, which has no martingale interpretation. By design,
+        `_state_to_metrics(scope="class", ...)` omits log_evidence/capped_alarm
+        from the output so this sum never appears in the operator-facing payload.
+
+        Classifier exceptions are caught per-agent (a periodic sweep must not
+        be fragile against transient DB lookup failures), routed to
+        UNKNOWN_CLASS_BUCKET, and logged to stderr with the exception type +
+        agent_id prefix so the operator surface can distinguish "agent not
+        classified" from "classifier raised."
+
+        Returns a telemetry dict (tracked_agents, unresolved_agents, buckets,
+        classifier_errors) and flips class_states_bootstrapped to True.
+        """
+        new_class_states: Dict[str, Dict[str, Any]] = defaultdict(_empty_state)
+        movement: Dict[str, int] = defaultdict(int)
+        unresolved = 0
+        classifier_errors = 0
+
+        for agent_id, agent_state in self.agent_states.items():
+            try:
+                resolved = classifier(agent_id)
+            except Exception as exc:
+                resolved = None
+                classifier_errors += 1
+                print(
+                    f"[S10 rebucket] classifier raised on agent_id={agent_id!r}: "
+                    f"{type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                )
+            bucket = resolved or UNKNOWN_CLASS_BUCKET
+            if resolved is None:
+                unresolved += 1
+            _merge_state(new_class_states[bucket], agent_state)
+            movement[bucket] += 1
+
+        self.class_states = new_class_states
+        self.class_states_bootstrapped = True
+        if persist:
+            self.save_state()
+        return {
+            "tracked_agents": sum(movement.values()),
+            "unresolved_agents": unresolved,
+            "classifier_errors": classifier_errors,
+            "buckets": {k: v for k, v in movement.items()},
         }
 
 

--- a/tests/test_outcome_calibration.py
+++ b/tests/test_outcome_calibration.py
@@ -354,6 +354,7 @@ class TestExplicitOutcomeEventCalibration:
             confidence=0.85,
             outcome_correct=True,
             agent_id='agent-test',
+            class_tag='default',  # S10.2: classify_agent(None)="default" when agent_metadata cache miss
             signal_source='tests',
             decision_action='proceed',
             outcome_type='test_passed',
@@ -409,6 +410,7 @@ class TestExplicitOutcomeEventCalibration:
             confidence=0.7,
             outcome_correct=True,
             agent_id='agent-mon',
+            class_tag='default',
             signal_source='tasks',
             decision_action=None,
             outcome_type='task_completed',
@@ -544,6 +546,7 @@ class TestExplicitOutcomeEventCalibration:
             confidence=0.9,
             outcome_correct=False,
             agent_id='agent-tf',
+            class_tag='default',
             signal_source='tests',
             decision_action='proceed',
             outcome_type='test_failed',

--- a/tests/test_s10_wire_up.py
+++ b/tests/test_s10_wire_up.py
@@ -1,0 +1,307 @@
+"""S10.2 wire-up tests: class_tag flows from agent_metadata cache through
+outcome_events.py into the sequential calibration tracker; check_calibration
+MCP response carries the by_class envelope; class_promotion_sweeper_task
+rebuckets the tracker.
+"""
+
+import sys
+import pytest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock, AsyncMock
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from tests.helpers import parse_result
+
+
+# ============================================================================
+# outcome_events.py:332 — class_tag is fetched and passed through
+# ============================================================================
+
+class TestOutcomeEventsClassTagWireUp:
+    """outcome_events resolves class_tag via classify_agent(agent_metadata[agent_id])
+    and passes it to record_exogenous_tactical_outcome. Cache miss falls through
+    to classify_agent(None) == "default". Exceptions in the lookup degrade
+    gracefully to class_tag=None (UNKNOWN_CLASS_BUCKET in the tracker)."""
+
+    @pytest.mark.asyncio
+    async def test_class_tag_resolved_from_cached_meta(self):
+        """When agent_metadata has the agent with tags, classify_agent's
+        result is forwarded to the tracker."""
+        mock_db = MagicMock()
+        mock_db.record_outcome_event = AsyncMock(return_value='oe-class')
+        mock_db.get_latest_eisv_by_agent_id = AsyncMock(return_value={
+            'E': 0.7, 'I': 0.75, 'S': 0.15, 'V': -0.03,
+            'phi': 0.1, 'verdict': 'safe', 'coherence': 0.48, 'regime': 'CONVERGENCE',
+        })
+        mock_checker = MagicMock()
+        mock_seq_tracker = MagicMock()
+
+        # AgentMetadata-shape stub: classify_agent reads .tags via getattr.
+        cached_meta = SimpleNamespace(tags=['engaged_ephemeral'], label='alice')
+
+        with patch('src.db.get_db', return_value=mock_db), \
+             patch('src.mcp_handlers.observability.outcome_events.mcp_server') as mock_server, \
+             patch('src.mcp_handlers.context.get_context_agent_id', return_value='agent-engaged'), \
+             patch('src.calibration.calibration_checker', mock_checker), \
+             patch('src.sequential_calibration.sequential_calibration_tracker', mock_seq_tracker), \
+             patch.dict('src.agent_metadata_model.agent_metadata', {'agent-engaged': cached_meta}, clear=False):
+
+            mock_server.monitors = {}
+
+            from src.mcp_handlers.observability.outcome_events import handle_outcome_event
+            await handle_outcome_event({
+                'outcome_type': 'test_passed',
+                'confidence': 0.9,
+            })
+
+        mock_seq_tracker.record_exogenous_tactical_outcome.assert_called_once()
+        kwargs = mock_seq_tracker.record_exogenous_tactical_outcome.call_args[1]
+        assert kwargs['class_tag'] == 'engaged_ephemeral'
+        assert kwargs['agent_id'] == 'agent-engaged'
+
+    @pytest.mark.asyncio
+    async def test_class_tag_defaults_on_cache_miss(self):
+        """When agent_metadata has no entry for agent_id, classify_agent(None)
+        returns "default" — that string is forwarded to the tracker. The
+        write must not skip just because class lookup misses."""
+        mock_db = MagicMock()
+        mock_db.record_outcome_event = AsyncMock(return_value='oe-miss')
+        mock_db.get_latest_eisv_by_agent_id = AsyncMock(return_value={
+            'E': 0.7, 'I': 0.75, 'S': 0.15, 'V': -0.03,
+            'phi': 0.1, 'verdict': 'safe', 'coherence': 0.48, 'regime': 'CONVERGENCE',
+        })
+        mock_checker = MagicMock()
+        mock_seq_tracker = MagicMock()
+
+        with patch('src.db.get_db', return_value=mock_db), \
+             patch('src.mcp_handlers.observability.outcome_events.mcp_server') as mock_server, \
+             patch('src.mcp_handlers.context.get_context_agent_id', return_value='agent-missing'), \
+             patch('src.calibration.calibration_checker', mock_checker), \
+             patch('src.sequential_calibration.sequential_calibration_tracker', mock_seq_tracker), \
+             patch.dict('src.agent_metadata_model.agent_metadata', {}, clear=True):
+
+            mock_server.monitors = {}
+
+            from src.mcp_handlers.observability.outcome_events import handle_outcome_event
+            await handle_outcome_event({
+                'outcome_type': 'test_passed',
+                'confidence': 0.9,
+            })
+
+        mock_seq_tracker.record_exogenous_tactical_outcome.assert_called_once()
+        kwargs = mock_seq_tracker.record_exogenous_tactical_outcome.call_args[1]
+        assert kwargs['class_tag'] == 'default'
+
+    @pytest.mark.asyncio
+    async def test_class_lookup_exception_degrades_to_none(self):
+        """If the class lookup itself raises, class_tag falls through to None
+        and the tracker write still fires. The calibration data must not be
+        lost because the class resolver had a transient failure."""
+        mock_db = MagicMock()
+        mock_db.record_outcome_event = AsyncMock(return_value='oe-err')
+        mock_db.get_latest_eisv_by_agent_id = AsyncMock(return_value={
+            'E': 0.7, 'I': 0.75, 'S': 0.15, 'V': -0.03,
+            'phi': 0.1, 'verdict': 'safe', 'coherence': 0.48, 'regime': 'CONVERGENCE',
+        })
+        mock_checker = MagicMock()
+        mock_seq_tracker = MagicMock()
+
+        with patch('src.db.get_db', return_value=mock_db), \
+             patch('src.mcp_handlers.observability.outcome_events.mcp_server') as mock_server, \
+             patch('src.mcp_handlers.context.get_context_agent_id', return_value='agent-raise'), \
+             patch('src.calibration.calibration_checker', mock_checker), \
+             patch('src.sequential_calibration.sequential_calibration_tracker', mock_seq_tracker), \
+             patch('src.grounding.class_indicator.classify_agent',
+                   side_effect=RuntimeError("boom")):
+
+            mock_server.monitors = {}
+
+            from src.mcp_handlers.observability.outcome_events import handle_outcome_event
+            await handle_outcome_event({
+                'outcome_type': 'test_passed',
+                'confidence': 0.9,
+            })
+
+        mock_seq_tracker.record_exogenous_tactical_outcome.assert_called_once()
+        kwargs = mock_seq_tracker.record_exogenous_tactical_outcome.call_args[1]
+        assert kwargs['class_tag'] is None
+
+
+# ============================================================================
+# admin/calibration.py — by_class envelope on check_calibration response
+# ============================================================================
+
+class TestCheckCalibrationByClassEnvelope:
+    """The check_calibration MCP response should carry a by_class envelope
+    with bootstrapped + buckets keys, derived from the tracker."""
+
+    @pytest.mark.asyncio
+    async def test_by_class_envelope_present_in_response(self, tmp_path):
+        """End-to-end: write a few outcomes with different class_tags, call
+        handle_check_calibration, assert by_class envelope is in the
+        response and reflects the writes."""
+        from src.sequential_calibration import SequentialCalibrationTracker
+
+        # Drive a fresh tracker so we can control state precisely.
+        tracker = SequentialCalibrationTracker(state_file=tmp_path / "seq.json")
+        for _ in range(2):
+            tracker.record_exogenous_tactical_outcome(
+                confidence=0.9, outcome_correct=True,
+                agent_id="a", class_tag="substrate",
+                signal_source="tests",
+            )
+        for _ in range(3):
+            tracker.record_exogenous_tactical_outcome(
+                confidence=0.7, outcome_correct=False,
+                agent_id="b", class_tag="ephemeral",
+                signal_source="tests",
+            )
+
+        mock_checker = MagicMock()
+        # Minimal check_calibration return shape.
+        mock_checker.check_calibration.return_value = (
+            True,
+            {"bins": {}, "issues": [], "per_channel_calibration": {}},
+        )
+        mock_checker.get_pending_updates.return_value = []
+
+        with patch('src.calibration.calibration_checker', mock_checker), \
+             patch('src.sequential_calibration.get_sequential_calibration_tracker',
+                   return_value=tracker):
+
+            from src.mcp_handlers.admin.calibration import handle_check_calibration
+            result = await handle_check_calibration({})
+
+        parsed = parse_result(result)
+        assert "by_class" in parsed
+        envelope = parsed["by_class"]
+        assert envelope["bootstrapped"] is True
+        assert "substrate" in envelope["by_class"]
+        assert "ephemeral" in envelope["by_class"]
+        assert envelope["by_class"]["substrate"]["eligible_samples"] == 2
+        assert envelope["by_class"]["ephemeral"]["eligible_samples"] == 3
+        # E-process fields stay off the class envelope (S10 council finding).
+        assert "log_evidence" not in envelope["by_class"]["substrate"]
+        assert "capped_alarm" not in envelope["by_class"]["substrate"]
+
+    @pytest.mark.asyncio
+    async def test_response_survives_tracker_error(self):
+        """If the tracker raises during compute_metrics_by_class, the response
+        still succeeds — by_class is best-effort, not load-bearing."""
+        mock_checker = MagicMock()
+        mock_checker.check_calibration.return_value = (
+            True, {"bins": {}, "issues": [], "per_channel_calibration": {}},
+        )
+        mock_checker.get_pending_updates.return_value = []
+
+        broken_tracker = MagicMock()
+        broken_tracker.compute_metrics_by_class.side_effect = RuntimeError("nope")
+        # The handler also reads compute_metrics() for the tactical_evidence
+        # block earlier in the response build; let that be quiet.
+        broken_tracker.compute_metrics.return_value = {}
+
+        with patch('src.calibration.calibration_checker', mock_checker), \
+             patch('src.sequential_calibration.get_sequential_calibration_tracker',
+                   return_value=broken_tracker):
+
+            from src.mcp_handlers.admin.calibration import handle_check_calibration
+            result = await handle_check_calibration({})
+
+        parsed = parse_result(result)
+        # Response must still be successful; by_class simply absent.
+        assert parsed.get("calibration_status") in {"no_data", "calibrated", "miscalibrated", "signal_stale"}
+        assert "by_class" not in parsed
+
+
+# ============================================================================
+# background_tasks.class_promotion_sweeper_task — rebucket hook
+# ============================================================================
+
+class TestSweeperRebucketHook:
+    """The class_promotion_sweeper_task should call
+    tracker.rebucket_from_agent_states each cycle, with a classifier closure
+    that reads agent_metadata and routes through classify_agent."""
+
+    @pytest.mark.asyncio
+    async def test_sweeper_calls_rebucket_with_metadata_classifier(self):
+        """Drive one cycle of the sweeper by patching asyncio.sleep to break
+        the loop on the second sleep; assert tracker.rebucket_from_agent_states
+        was invoked and the classifier resolves a known agent through the
+        agent_metadata cache. Classifier must be exercised INSIDE the patched
+        scope so agent_metadata.get sees the test entry."""
+        from types import SimpleNamespace
+
+        captured = {}
+
+        def fake_rebucket(*, classifier, persist=True):
+            # Exercise the classifier while agent_metadata is still patched
+            # so the closure sees the test entry, not real empty cache.
+            captured['known'] = classifier('agent-x')
+            captured['unknown'] = classifier('agent-unknown')
+            return {
+                "tracked_agents": 1,
+                "unresolved_agents": 0,
+                "classifier_errors": 0,
+                "buckets": {"engaged_ephemeral": 1},
+            }
+
+        tracker_stub = SimpleNamespace(rebucket_from_agent_states=fake_rebucket)
+
+        call_count = {"n": 0}
+        original_sleep = __import__("asyncio").sleep
+
+        async def staged_sleep(delay):
+            call_count["n"] += 1
+            if call_count["n"] >= 2:
+                raise __import__("asyncio").CancelledError
+            return await original_sleep(0)
+
+        cached_meta = SimpleNamespace(tags=['engaged_ephemeral'])
+
+        with patch('asyncio.sleep', side_effect=staged_sleep), \
+             patch('src.grounding.class_promotion.promote_engaged_ephemeral',
+                   new=AsyncMock(return_value={"promoted": 0, "threshold": 3})), \
+             patch('src.sequential_calibration.get_sequential_calibration_tracker',
+                   return_value=tracker_stub), \
+             patch.dict('src.agent_metadata_model.agent_metadata',
+                        {'agent-x': cached_meta}, clear=False):
+
+            from src.background_tasks import class_promotion_sweeper_task
+            await class_promotion_sweeper_task(interval_minutes=0.0)
+
+        assert captured.get('known') == 'engaged_ephemeral', captured
+        # Missing agents return None so the tracker buckets to UNKNOWN.
+        assert captured.get('unknown') is None
+
+    @pytest.mark.asyncio
+    async def test_sweeper_rebucket_failure_does_not_abort(self):
+        """A rebucket exception must not break the sweeper loop — log + retry."""
+        from types import SimpleNamespace
+
+        broken_tracker = SimpleNamespace(
+            rebucket_from_agent_states=MagicMock(side_effect=RuntimeError("rebucket boom"))
+        )
+
+        call_count = {"n": 0}
+        original_sleep = __import__("asyncio").sleep
+
+        async def staged_sleep(delay):
+            call_count["n"] += 1
+            if call_count["n"] >= 2:
+                raise __import__("asyncio").CancelledError
+            return await original_sleep(0)
+
+        with patch('asyncio.sleep', side_effect=staged_sleep), \
+             patch('src.grounding.class_promotion.promote_engaged_ephemeral',
+                   new=AsyncMock(return_value={"promoted": 0, "threshold": 3})), \
+             patch('src.sequential_calibration.get_sequential_calibration_tracker',
+                   return_value=broken_tracker):
+
+            from src.background_tasks import class_promotion_sweeper_task
+            # Must not raise — the sweeper swallows rebucket exceptions.
+            await class_promotion_sweeper_task(interval_minutes=0.0)
+
+        broken_tracker.rebucket_from_agent_states.assert_called_once()

--- a/tests/test_sequential_calibration_by_class.py
+++ b/tests/test_sequential_calibration_by_class.py
@@ -1,0 +1,307 @@
+"""S10 tests — class_states plumbing on SequentialCalibrationTracker.
+
+Covers:
+- record_exogenous_tactical_outcome accepts and writes through to class_states
+- omitted class_tag buckets into UNKNOWN_CLASS_BUCKET (lossless against global)
+- compute_metrics_by_class envelope shape (bootstrapped flag + by_class dict)
+- class-scope envelope omits log_evidence/capped_alarm/last_alt_probability
+  (S10 council finding: not anytime-valid at class granularity)
+- rebucket_from_agent_states moves counters when class membership shifts,
+  flips bootstrapped, logs to stderr on classifier exceptions
+- persistence round-trips class_states; pre-S10 files load with bootstrapped=False
+"""
+
+import json
+
+from src.sequential_calibration import (
+    SequentialCalibrationTracker,
+    UNKNOWN_CLASS_BUCKET,
+)
+
+
+def _record(tracker, *, confidence, outcome_correct, agent_id, class_tag, signal_source="tests"):
+    return tracker.record_exogenous_tactical_outcome(
+        confidence=confidence,
+        outcome_correct=outcome_correct,
+        agent_id=agent_id,
+        class_tag=class_tag,
+        signal_source=signal_source,
+        decision_action="proceed",
+        outcome_type="test_passed" if outcome_correct else "test_failed",
+    )
+
+
+def test_class_tag_writes_through_to_class_states(tmp_path):
+    tracker = SequentialCalibrationTracker(state_file=tmp_path / "seq.json")
+
+    _record(tracker, confidence=0.9, outcome_correct=False, agent_id="a", class_tag="substrate")
+    _record(tracker, confidence=0.9, outcome_correct=True, agent_id="b", class_tag="session_like")
+    _record(tracker, confidence=0.9, outcome_correct=False, agent_id="c", class_tag="session_like")
+
+    envelope = tracker.compute_metrics_by_class()
+    by_class = envelope["by_class"]
+    assert envelope["bootstrapped"] is True
+    assert set(by_class.keys()) == {"substrate", "session_like"}
+    assert by_class["substrate"]["eligible_samples"] == 1
+    assert by_class["session_like"]["eligible_samples"] == 2
+    assert by_class["session_like"]["scope"] == "class"
+    assert by_class["session_like"]["class_tag"] == "session_like"
+
+
+def test_class_envelope_omits_e_process_fields(tmp_path):
+    """S10 council finding: class-scope metrics cannot include log_evidence /
+    capped_alarm / last_alt_probability because rebucket sums log_e_values
+    across agents with different q-trajectories — no martingale interpretation.
+    Drop those fields unconditionally at class scope (even on live-write data,
+    so consumers can't accidentally read them as anytime-valid)."""
+    tracker = SequentialCalibrationTracker(state_file=tmp_path / "seq.json")
+
+    _record(tracker, confidence=0.9, outcome_correct=False, agent_id="a", class_tag="substrate")
+    _record(tracker, confidence=0.9, outcome_correct=False, agent_id="a", class_tag="substrate")
+
+    by_class = tracker.compute_metrics_by_class()["by_class"]
+    metrics = by_class["substrate"]
+    assert metrics["status"] == "tracking"
+    # Descriptive stats present:
+    for field in ("eligible_samples", "mean_confidence", "empirical_accuracy",
+                  "calibration_gap", "signal_sources", "last_updated"):
+        assert field in metrics, f"class envelope missing {field}"
+    # E-process fields explicitly absent:
+    for field in ("log_evidence", "capped_alarm", "last_alt_probability", "last_e_value"):
+        assert field not in metrics, f"class envelope must not carry {field}"
+
+    # Global view still carries the e-process fields.
+    global_metrics = tracker.compute_metrics()
+    assert "log_evidence" in global_metrics
+    assert "capped_alarm" in global_metrics
+
+
+def test_class_envelope_no_data_also_omits_e_process_fields(tmp_path):
+    """No-data and zero-sample empty envelopes must also keep the contract."""
+    tracker = SequentialCalibrationTracker(state_file=tmp_path / "seq.json")
+    # Force a zero-sample class_states entry by direct dict access:
+    tracker.class_states["ephemeral"]  # touch defaultdict to materialize
+    envelope = tracker.compute_metrics_by_class()
+    metrics = envelope["by_class"]["ephemeral"]
+    assert metrics["status"] == "no_data"
+    assert "log_evidence" not in metrics
+    assert "capped_alarm" not in metrics
+
+
+def test_omitted_class_tag_buckets_into_unknown(tmp_path):
+    tracker = SequentialCalibrationTracker(state_file=tmp_path / "seq.json")
+
+    result = tracker.record_exogenous_tactical_outcome(
+        confidence=0.5,
+        outcome_correct=True,
+        agent_id="a",
+        signal_source="tests",
+    )
+    assert result["class_tag"] == UNKNOWN_CLASS_BUCKET
+
+    by_class = tracker.compute_metrics_by_class()["by_class"]
+    assert UNKNOWN_CLASS_BUCKET in by_class
+    assert by_class[UNKNOWN_CLASS_BUCKET]["eligible_samples"] == 1
+
+
+def test_class_sum_equals_global(tmp_path):
+    """The class breakdown must be lossless against the global rollup."""
+    tracker = SequentialCalibrationTracker(state_file=tmp_path / "seq.json")
+
+    _record(tracker, confidence=0.8, outcome_correct=True, agent_id="a", class_tag="substrate")
+    _record(tracker, confidence=0.8, outcome_correct=False, agent_id="b", class_tag="session_like")
+    _record(tracker, confidence=0.8, outcome_correct=True, agent_id="c", class_tag=None)
+
+    by_class = tracker.compute_metrics_by_class()["by_class"]
+    class_samples = sum(m["eligible_samples"] for m in by_class.values())
+    global_metrics = tracker.compute_metrics()
+
+    assert class_samples == global_metrics["eligible_samples"] == 3
+
+
+def test_compute_metrics_by_class_no_data(tmp_path):
+    tracker = SequentialCalibrationTracker(state_file=tmp_path / "seq.json")
+    envelope = tracker.compute_metrics_by_class()
+    assert envelope == {"bootstrapped": True, "by_class": {}}
+
+
+def test_rebucket_moves_counters_under_promotion(tmp_path):
+    """An agent promoted ephemeral → session_like should move counters cleanly
+    when rebucket runs; the donor bucket should not retain inflated counts."""
+    tracker = SequentialCalibrationTracker(state_file=tmp_path / "seq.json")
+
+    _record(tracker, confidence=0.7, outcome_correct=True, agent_id="promoted", class_tag="ephemeral")
+    _record(tracker, confidence=0.7, outcome_correct=True, agent_id="promoted", class_tag="ephemeral")
+    _record(tracker, confidence=0.7, outcome_correct=True, agent_id="stable", class_tag="substrate")
+
+    # Pre-rebucket: ephemeral has both samples from "promoted".
+    pre = tracker.compute_metrics_by_class()["by_class"]
+    assert pre["ephemeral"]["eligible_samples"] == 2
+    assert pre["substrate"]["eligible_samples"] == 1
+
+    # Promote "promoted" to session_like via the classifier callback.
+    current_class = {"promoted": "session_like", "stable": "substrate"}
+    telemetry = tracker.rebucket_from_agent_states(classifier=lambda aid: current_class.get(aid))
+
+    post = tracker.compute_metrics_by_class()["by_class"]
+    assert post["session_like"]["eligible_samples"] == 2
+    assert post["substrate"]["eligible_samples"] == 1
+    assert "ephemeral" not in post  # donor bucket cleared, not inflated
+    assert telemetry["tracked_agents"] == 2
+    assert telemetry["unresolved_agents"] == 0
+    assert telemetry["classifier_errors"] == 0
+    assert telemetry["buckets"] == {"session_like": 1, "substrate": 1}
+
+
+def test_rebucket_unresolved_classifier_falls_to_unknown(tmp_path):
+    tracker = SequentialCalibrationTracker(state_file=tmp_path / "seq.json")
+    _record(tracker, confidence=0.9, outcome_correct=True, agent_id="mystery", class_tag="ephemeral")
+
+    telemetry = tracker.rebucket_from_agent_states(classifier=lambda aid: None)
+    by_class = tracker.compute_metrics_by_class()["by_class"]
+
+    assert UNKNOWN_CLASS_BUCKET in by_class
+    assert by_class[UNKNOWN_CLASS_BUCKET]["eligible_samples"] == 1
+    assert telemetry["unresolved_agents"] == 1
+    assert telemetry["classifier_errors"] == 0  # None is not an error, it's "unresolved"
+
+
+def test_rebucket_classifier_exception_logs_to_stderr(tmp_path, capsys):
+    """A classifier raising should (a) bucket the agent into unknown so the
+    sweep doesn't crash, (b) increment classifier_errors in telemetry, and
+    (c) emit a stderr line so operators can distinguish classifier bugs from
+    legitimate mass-UNKNOWN scenarios. Council finding: bare except without
+    logging masks programming errors."""
+    tracker = SequentialCalibrationTracker(state_file=tmp_path / "seq.json")
+    _record(tracker, confidence=0.9, outcome_correct=True, agent_id="brittle", class_tag="ephemeral")
+
+    def raising_classifier(_aid):
+        raise RuntimeError("db unavailable")
+
+    telemetry = tracker.rebucket_from_agent_states(classifier=raising_classifier)
+    by_class = tracker.compute_metrics_by_class()["by_class"]
+
+    assert by_class[UNKNOWN_CLASS_BUCKET]["eligible_samples"] == 1
+    assert telemetry["unresolved_agents"] == 1
+    assert telemetry["classifier_errors"] == 1
+
+    captured = capsys.readouterr()
+    assert "[S10 rebucket]" in captured.err
+    assert "brittle" in captured.err
+    assert "RuntimeError" in captured.err
+    assert "db unavailable" in captured.err
+
+
+def test_class_states_persists_round_trip(tmp_path):
+    state_file = tmp_path / "seq.json"
+    t1 = SequentialCalibrationTracker(state_file=state_file)
+    _record(t1, confidence=0.6, outcome_correct=True, agent_id="a", class_tag="substrate")
+    _record(t1, confidence=0.6, outcome_correct=False, agent_id="b", class_tag="session_like")
+
+    t2 = SequentialCalibrationTracker(state_file=state_file)
+    envelope = t2.compute_metrics_by_class()
+    assert envelope["bootstrapped"] is True
+    by_class = envelope["by_class"]
+    assert by_class["substrate"]["eligible_samples"] == 1
+    assert by_class["session_like"]["eligible_samples"] == 1
+
+
+def test_pre_s10_state_file_loads_with_bootstrap_false(tmp_path):
+    """A state file written before S10 (no `classes` key) must load without
+    error AND signal bootstrapped=False so dashboards can label the by-class
+    view as a sparse bootstrap window rather than fleet-representative."""
+    state_file = tmp_path / "seq.json"
+    pre_s10 = {
+        "global": {
+            "eligible_samples": 100,
+            "successes": 80,
+            "confidence_sum": 75.0,
+            "log_e_value": 0.0,
+            "last_e_value": 1.0,
+            "last_alt_probability": 0.5,
+            "signal_sources": {"tests": 100},
+            "signal_source_outcomes": {"tests": {"samples": 100, "successes": 80}},
+            "last_updated": "2026-05-01T00:00:00+00:00",
+        },
+        "agents": {
+            "legacy-agent": {
+                "eligible_samples": 50,
+                "successes": 40,
+                "confidence_sum": 37.5,
+                "log_e_value": 0.0,
+                "last_e_value": 1.0,
+                "last_alt_probability": 0.5,
+                "signal_sources": {"tests": 50},
+                "signal_source_outcomes": {"tests": {"samples": 50, "successes": 40}},
+                "last_updated": "2026-05-01T00:00:00+00:00",
+            },
+        },
+        "prior_success": 1.0,
+        "prior_failure": 1.0,
+    }
+    from config.governance_config import GovernanceConfig
+    pre_s10["epoch"] = GovernanceConfig.CURRENT_EPOCH
+    state_file.write_text(json.dumps(pre_s10))
+
+    tracker = SequentialCalibrationTracker(state_file=state_file)
+    envelope = tracker.compute_metrics_by_class()
+    # Honest gap labeling: no class_states populated yet AND we know there's
+    # agent history that isn't represented.
+    assert envelope["bootstrapped"] is False
+    assert envelope["by_class"] == {}
+
+    # Rebucket flips bootstrapped to True.
+    tracker.rebucket_from_agent_states(classifier=lambda aid: "substrate")
+    envelope_post = tracker.compute_metrics_by_class()
+    assert envelope_post["bootstrapped"] is True
+    assert envelope_post["by_class"]["substrate"]["eligible_samples"] == 50
+
+
+def test_fresh_tracker_is_bootstrapped(tmp_path):
+    """A brand-new tracker (no prior state file) starts bootstrapped=True —
+    there is no agent history hiding behind an empty class_states."""
+    tracker = SequentialCalibrationTracker(state_file=tmp_path / "seq.json")
+    envelope = tracker.compute_metrics_by_class()
+    assert envelope["bootstrapped"] is True
+
+
+def test_bootstrap_flag_persists_after_rebucket(tmp_path):
+    state_file = tmp_path / "seq.json"
+    from config.governance_config import GovernanceConfig
+
+    pre_s10 = {
+        "global": {"eligible_samples": 1, "successes": 1, "confidence_sum": 0.5,
+                   "log_e_value": 0.0, "last_e_value": 1.0, "last_alt_probability": 0.5,
+                   "signal_sources": {"tests": 1},
+                   "signal_source_outcomes": {"tests": {"samples": 1, "successes": 1}},
+                   "last_updated": "2026-05-01T00:00:00+00:00"},
+        "agents": {"a": {"eligible_samples": 1, "successes": 1, "confidence_sum": 0.5,
+                         "log_e_value": 0.0, "last_e_value": 1.0, "last_alt_probability": 0.5,
+                         "signal_sources": {"tests": 1},
+                         "signal_source_outcomes": {"tests": {"samples": 1, "successes": 1}},
+                         "last_updated": "2026-05-01T00:00:00+00:00"}},
+        "prior_success": 1.0, "prior_failure": 1.0,
+        "epoch": GovernanceConfig.CURRENT_EPOCH,
+    }
+    state_file.write_text(json.dumps(pre_s10))
+
+    t1 = SequentialCalibrationTracker(state_file=state_file)
+    assert t1.compute_metrics_by_class()["bootstrapped"] is False
+    t1.rebucket_from_agent_states(classifier=lambda aid: "substrate")
+
+    t2 = SequentialCalibrationTracker(state_file=state_file)
+    assert t2.compute_metrics_by_class()["bootstrapped"] is True
+
+
+def test_rebucket_preserves_last_updated_max(tmp_path):
+    tracker = SequentialCalibrationTracker(state_file=tmp_path / "seq.json")
+    _record(tracker, confidence=0.6, outcome_correct=True, agent_id="a", class_tag="ephemeral")
+    _record(tracker, confidence=0.6, outcome_correct=True, agent_id="b", class_tag="ephemeral")
+
+    # Force last_updated divergence between the two agents.
+    tracker.agent_states["a"]["last_updated"] = "2026-05-01T00:00:00+00:00"
+    tracker.agent_states["b"]["last_updated"] = "2026-05-10T00:00:00+00:00"
+
+    tracker.rebucket_from_agent_states(classifier=lambda _aid: "session_like")
+    by_class = tracker.compute_metrics_by_class()["by_class"]
+    assert by_class["session_like"]["last_updated"] == "2026-05-10T00:00:00+00:00"


### PR DESCRIPTION
Closes S10 row in `docs/ontology/plan.md` — unblocked 2026-05-06 when S7 closed.

## What ships

Default fleet calibration view shifts from global-only to per-class, with global preserved as the all-bucket sum. UUID retained as drill-down.

Three commits, logically separable:

| Commit | Scope |
|---|---|
| 3dd79894 | **S10.1** — `SequentialCalibrationTracker` plumbing: `class_states` denormalized rollup, `compute_metrics_by_class()`, `rebucket_from_agent_states()`, `class_states_bootstrapped` flag, `UNKNOWN_CLASS_BUCKET`. Persistence is additive — pre-S10 state files load cleanly with `bootstrapped=false`. |
| 8f8b4681 | **S10.2** — wire `class_tag = classify_agent(agent_metadata.get(agent_id))` at `outcome_events.py:332`; `check_calibration` MCP response carries `by_class` envelope; `class_promotion_sweeper_task` tails each cycle with a rebucket pass. |
| 83f34651 | **S10.3** — dashboard calibration card detail line leads with per-class chips; modal expands to per-class table; `bootstrapping…` banner during the gap until first sweeper tick. |

## Council pass on S10.1

Three-agent adversarial pass (`dialectic-knowledge-architect` + `feature-dev:code-reviewer` + `live-verifier`) before this branch existed; revisions folded into the S10.1 commit:

- **Architect math finding (confirmed my pre-flag).** Summing `log_e_value` across agents in `_merge_state` is not a valid e-process — each agent's log uses a different `q`-trajectory. Class scope envelopes drop `log_evidence` / `capped_alarm` / `last_alt_probability` / `last_e_value` unconditionally. Test `test_class_envelope_omits_e_process_fields` pins the contract.
- **Reviewer.** `except Exception` in rebucket now logs to stderr + increments `classifier_errors`. Bootstrap window labeled via `class_states_bootstrapped`. `last_alt_probability` at class scope dropped.
- **Live-verifier.** Refuted my "caller has meta in scope" assumption at outcome_events.py:334 — S10.2 wires the `agent_metadata.get(agent_id)` lookup at the write site as a result. Also corrected the verifier's "100% unknown" claim: class lives in `metadata.tags` JSONB array (218 ephemeral, 202 engaged_ephemeral, ~10 persistent variants, 1 embodied, 8 untagged out of 437 active).

## Test plan

- [x] 187 green across the touched neighborhood:
  - tests/test_sequential_calibration_by_class.py — 14 new tests
  - tests/test_s10_wire_up.py — 7 new tests
  - tests/test_sequential_calibration.py — 4 regression
  - tests/test_sequential_calibration_epoch.py — 3 regression
  - tests/test_sequential_calibration_hygiene.py — 3 regression
  - tests/test_outcome_calibration.py — 28 regression (3 updated to expect new `class_tag='default'` kwarg)
  - tests/test_admin_handlers.py — 111 regression
  - tests/test_class_promotion.py — 17 regression
- [x] `node --check dashboard/dashboard.js` passes
- [x] Plan memo at `docs/ontology/s10-fleet-aggregation-plan.md` documents the audit baseline, design decisions, council findings, sequencing

## Honest re-framing of the plan row

The S10 row says "shift default aggregation unit from UUID to role." But the live default before this PR was *global*, not UUID — `compute_metrics(agent_id=None)` returned `global_state`. Per-UUID partition was structurally wired (the write path populates `agent_states`) but no reader consumed it. So S10 is *adding* per-class as the primary fleet view, with global preserved as the all-bucket sum and UUID retained as drill-down. Documented in `docs/ontology/s10-fleet-aggregation-plan.md` §2.

## Files

- `src/sequential_calibration.py` (+266 / -35)
- `src/mcp_handlers/observability/outcome_events.py` (+19 / -1)
- `src/mcp_handlers/admin/calibration.py` (+12)
- `src/background_tasks.py` (+39 / -2)
- `tests/test_outcome_calibration.py` (3 kwargs updated)
- `tests/test_sequential_calibration_by_class.py` (new, 16 tests)
- `tests/test_s10_wire_up.py` (new, 7 tests)
- `dashboard/dashboard.js` (+72 / -8)
- `docs/ontology/s10-fleet-aggregation-plan.md` (new)