### PR TITLE
fix(observe): observe.aggregate reads Postgres, not in-memory monitors

### DIFF
--- a/db/postgres/migrations/038_agent_state_risk_score.sql
+++ b/db/postgres/migrations/038_agent_state_risk_score.sql
@@ -1,0 +1,53 @@
+-- 038_agent_state_risk_score.sql
+--
+-- Promote `risk_score` from state_json (already written by agent_storage.record_agent_state)
+-- to a typed column on core.agent_state, so fleet aggregation can compute mean_risk
+-- in SQL without reading every monitor's in-memory state.
+--
+-- Context: observe.aggregate currently iterates mcp_server.monitors and means
+-- monitor.state.risk_score. The in-memory monitors are load-once-per-process and
+-- drift from Postgres truth on every cross-process write. The fix is to query
+-- core.mv_latest_agent_states directly; that matview needs risk_score to do the job.
+--
+-- Backfill source: state_json->>'risk_score' is populated by record_agent_state
+-- at src/agent_storage.py:572. Backfill is best-effort (NULL where state_json
+-- never carried the field — pre-grounding rows, bootstrap rows).
+--
+-- Rollback shape: ALTER TABLE DROP COLUMN risk_score; recreate matview without
+-- the column.
+
+ALTER TABLE core.agent_state
+    ADD COLUMN IF NOT EXISTS risk_score real;
+
+-- Backfill from existing state_json. Best-effort cast — invalid values stay NULL.
+UPDATE core.agent_state
+SET risk_score = (state_json ->> 'risk_score')::real
+WHERE risk_score IS NULL
+  AND state_json ? 'risk_score'
+  AND (state_json ->> 'risk_score') ~ '^-?[0-9]+(\.[0-9]+)?$';
+
+-- Drop+recreate matview to include risk_score. Same shape as migration 023,
+-- plus the new column. Cascade not needed — no dependent views.
+DROP MATERIALIZED VIEW IF EXISTS core.mv_latest_agent_states;
+
+CREATE MATERIALIZED VIEW core.mv_latest_agent_states AS
+SELECT DISTINCT ON (s.identity_id)
+       s.state_id, s.identity_id, i.agent_id, s.recorded_at,
+       s.entropy, s.integrity, s.stability_index, s.volatility,
+       s.regime, s.coherence, s.risk_score, s.state_json, s.synthetic
+FROM core.agent_state s
+JOIN core.identities i ON i.identity_id = s.identity_id
+WHERE s.synthetic = false
+ORDER BY s.identity_id, s.recorded_at DESC;
+
+-- Unique index required for REFRESH CONCURRENTLY (mirrors 008/023).
+CREATE UNIQUE INDEX idx_mv_latest_states_identity
+    ON core.mv_latest_agent_states (identity_id);
+
+-- Lookups by agent_id (mirrors 008/023).
+CREATE INDEX idx_mv_latest_states_agent
+    ON core.mv_latest_agent_states (agent_id);
+
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (38, 'agent_state_risk_score', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/src/agent_storage.py
+++ b/src/agent_storage.py
@@ -589,6 +589,7 @@ async def record_agent_state(
         regime=db_regime,
         coherence=coherence,
         state_json=state_json,
+        risk_score=risk_score,
     )
 
     return state_id

--- a/src/db/mixins/state.py
+++ b/src/db/mixins/state.py
@@ -25,19 +25,21 @@ class StateMixin:
         regime: str,
         coherence: float,
         state_json: Optional[Dict[str, Any]] = None,
+        risk_score: Optional[float] = None,
     ) -> int:
         from config.governance_config import GovernanceConfig
         async with self.acquire() as conn:
             state_id = await conn.fetchval(
                 """
                 INSERT INTO core.agent_state
-                    (identity_id, entropy, integrity, stability_index, volatility, regime, coherence, state_json, epoch)
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                    (identity_id, entropy, integrity, stability_index, volatility, regime, coherence, state_json, epoch, risk_score)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
                 RETURNING state_id
                 """,
                 identity_id, entropy, integrity, stability_index, void,  # void maps to volatility column
                 regime, coherence, json.dumps(state_json or {}),
                 GovernanceConfig.CURRENT_EPOCH,
+                risk_score,
             )
             # Matview refresh moved to periodic_matview_refresh() in background_tasks.py
             return state_id

--- a/src/mcp_handlers/observability/handlers.py
+++ b/src/mcp_handlers/observability/handlers.py
@@ -725,109 +725,180 @@ async def handle_detect_anomalies(arguments: Dict[str, Any]) -> Sequence[TextCon
 
 @mcp_tool("aggregate_metrics", timeout=15.0, register=False)
 async def handle_aggregate_metrics(arguments: Dict[str, Any]) -> Sequence[TextContent]:
-    """Get fleet-level health overview"""
-    from src.governance_monitor import UNITARESMonitor
-    import numpy as np
+    """Get fleet-level health overview.
 
-    # Wave 0 follow-up: was force=True, comment claimed "non-blocking" but
-    # the implementation blocks ~16s per call (3221 sequential awaits on
-    # metadata_cache.set in the loader). Same anti-pattern as the prior
-    # list_agents incident (lifecycle/query.py:41). Drop force; in-memory
-    # cache is kept current by process_agent_update / onboard / background
-    # paths and is fresh enough for fleet-aggregate use.
-    await mcp_server.load_metadata_async()
-    
+    Postgres-canonical. Reads core.mv_latest_agent_states for per-agent state
+    rollups, core.agents for active membership + currently-paused, audit.events
+    for current-epoch pause counts, and audit.r1_score_audit for verdict
+    distribution. No in-memory monitor iteration — the prior implementation
+    summed monitor.state across in-process monitors, which is load-once-per-
+    process and drifts from PG truth on cross-process writes, producing
+    persistent "0 pauses" reports while audit.events has hundreds.
+    """
+    from datetime import datetime, timezone
+    from src.db import get_db
+
     agent_ids = arguments.get("agent_ids")
     include_health_breakdown = arguments.get("include_health_breakdown", True)
-    
-    # Get agent list
-    if not agent_ids:
-        agent_ids = [aid for aid, meta in mcp_server.agent_metadata.items() if meta.status == "active"]
-    
-    # Aggregate metrics
-    total_agents = len(agent_ids)
-    agents_with_data = 0
-    total_updates = 0
-    risk_scores = []  # Governance/operational risk scores
-    coherence_scores = []
-    health_statuses = {"healthy": 0, "moderate": 0, "critical": 0, "unknown": 0}
-    decision_counts = {"proceed": 0, "pause": 0}  # Two-tier system (backward compat: approve/reflect/reject mapped)
-    verdict_counts = {"safe": 0, "caution": 0, "high-risk": 0}  # Behavioral verdict distribution
-    
-    for agent_id in agent_ids:
-        monitor = mcp_server.monitors.get(agent_id)
-        if monitor is None:
-            # Load monitor state (non-blocking)
-            loop = asyncio.get_running_loop()
-            persisted_state = await loop.run_in_executor(None, mcp_server.load_monitor_state, agent_id)
-            if persisted_state:
-                monitor = UNITARESMonitor(agent_id, load_state=False)
-                monitor.state = persisted_state
-        
-        if monitor:
-            agents_with_data += 1
-            metrics = monitor.get_metrics()
-            
-            # Aggregate risk_score and coherence
-            risk_score = metrics.get("risk_score") or metrics.get("current_risk")
-            if risk_score is not None:
-                risk_scores.append(float(risk_score))
-            elif monitor.state.risk_history:
-                # Fallback to risk_history if risk_score not available
-                history_values = [float(r) for r in monitor.state.risk_history[-10:]]  # Last 10 updates
-                risk_scores.extend(history_values)
-            coherence_scores.append(float(monitor.state.coherence))
-            
-            # Aggregate health status
-            status = metrics.get("status", "unknown")
-            health_statuses[status] = health_statuses.get(status, 0) + 1
-            
-            # Aggregate decisions
-            decision_stats = metrics.get("decision_statistics", {})
-            # Map old decisions to new system
-            proceed_count = decision_stats.get("proceed", 0) + decision_stats.get("approve", 0) + decision_stats.get("reflect", 0) + decision_stats.get("revise", 0)
-            pause_count = decision_stats.get("pause", 0) + decision_stats.get("reject", 0)
-            decision_counts["proceed"] += proceed_count
-            decision_counts["pause"] += pause_count
-            # Backward compatibility (keep old keys for compatibility)
-            decision_counts["approve"] = decision_stats.get("approve", 0)
-            decision_counts["reflect"] = decision_stats.get("reflect", 0) + decision_stats.get("revise", 0)
-            decision_counts["reject"] = decision_stats.get("reject", 0)
-            
-            # Aggregate verdict distribution from metrics
-            verdict = metrics.get("verdict")
-            if verdict and verdict in verdict_counts:
-                verdict_counts[verdict] += 1
 
-            # Count total updates — prefer meta.total_updates (Postgres-backed)
-            meta = mcp_server.agent_metadata.get(agent_id)
-            total_updates += meta.total_updates if meta else monitor.state.update_count
-    
-    # Compute aggregate statistics
-    aggregate_data = {
-        "total_agents": total_agents,
-        "agents_with_data": agents_with_data,
-        "total_updates": total_updates,
-        "mean_risk_score": float(np.mean(risk_scores)) if risk_scores else 0.0,  # Governance/operational risk (mean)
-        "mean_risk": float(np.mean(risk_scores)) if risk_scores else 0.0,  # DEPRECATED: Use mean_risk_score instead
-        "mean_coherence": float(np.mean(coherence_scores)) if coherence_scores else 0.0,
-        "decision_distribution": {
-            **decision_counts,
-            "total": sum(decision_counts.values())
-        },
-        "verdict_distribution": {
-            **verdict_counts,
-            "total": sum(verdict_counts.values())
-        }
+    db = get_db()
+    async with db.acquire() as conn:
+        # Current epoch: max(epoch) in core.epochs is the authoritative
+        # boundary for "this epoch" rollups; outcome_events.epoch and
+        # agent_state.epoch are written against the same value via
+        # GovernanceConfig.CURRENT_EPOCH.
+        epoch_row = await conn.fetchrow(
+            "SELECT epoch, started_at FROM core.epochs ORDER BY epoch DESC LIMIT 1"
+        )
+        current_epoch = epoch_row["epoch"] if epoch_row else 1
+        epoch_started_at = epoch_row["started_at"] if epoch_row else None
+
+        # Build agent scope. agent_ids=None → all active agents. agent_ids=list
+        # → that explicit set (no active-status filter; matches prior behavior
+        # of trusting the caller).
+        if agent_ids:
+            scope_clause = "WHERE a.id = ANY($1::text[])"
+            scope_args: tuple = (list(agent_ids),)
+        else:
+            scope_clause = "WHERE a.status = 'active'"
+            scope_args = ()
+
+        # State rollups via matview. The matview excludes synthetic bootstrap
+        # rows at definition time (migration 023), so no extra filter needed.
+        # LEFT JOIN preserves agents that never wrote a measured state row.
+        state_sql = f"""
+            WITH scope AS (
+                SELECT a.id AS agent_id, a.status
+                FROM core.agents a
+                {scope_clause}
+            )
+            SELECT
+              count(*)::int AS total_agents,
+              count(ls.identity_id)::int AS agents_with_data,
+              avg(ls.risk_score)::real AS mean_risk_score,
+              avg(ls.coherence)::real AS mean_coherence,
+              count(*) FILTER (
+                  WHERE ls.regime IN ('nominal','STABLE','CONVERGENCE')
+              )::int AS healthy,
+              count(*) FILTER (
+                  WHERE ls.regime IN ('warning','EXPLORATION','recovery')
+              )::int AS moderate,
+              count(*) FILTER (
+                  WHERE ls.regime IN ('critical','DIVERGENCE')
+              )::int AS critical,
+              count(*) FILTER (WHERE ls.identity_id IS NULL)::int AS unknown_health,
+              count(*) FILTER (WHERE scope.status = 'paused')::int AS paused_now,
+              EXTRACT(EPOCH FROM (now() - min(ls.recorded_at)))::bigint
+                  AS staleness_oldest_seconds,
+              EXTRACT(EPOCH FROM (now() - max(ls.recorded_at)))::bigint
+                  AS staleness_newest_seconds
+            FROM scope
+            LEFT JOIN core.mv_latest_agent_states ls ON ls.agent_id = scope.agent_id
+        """
+        state_row = await conn.fetchrow(state_sql, *scope_args)
+
+        # total_updates: persisted as core.identities.metadata->>'total_updates'
+        # (atomically incremented by db.increment_update_count on every
+        # process_agent_update). chain_obs_count is an R2-specific lineage
+        # counter — only ~27 across all active agents — so don't confuse it.
+        updates_sql = f"""
+            SELECT COALESCE(
+                SUM(COALESCE((i.metadata->>'total_updates')::int, 0)), 0
+            )::bigint AS total_updates
+            FROM core.agents a
+            JOIN core.identities i ON i.agent_id = a.id
+            {scope_clause}
+        """
+        total_updates = await conn.fetchval(updates_sql, *scope_args)
+
+        # Pauses this epoch: governance pauses persist to audit.events as
+        # event_type='lifecycle_paused' (fired from agent_loop_detection.py
+        # when a circuit-breaker pause decision lands). circuit_breaker_trip
+        # fires 1:1 alongside; counting both would double-count.
+        if epoch_started_at is not None:
+            pause_sql = """
+                SELECT count(*)::int FROM audit.events
+                WHERE ts >= $1 AND event_type = 'lifecycle_paused'
+            """
+            pauses_this_epoch = await conn.fetchval(pause_sql, epoch_started_at)
+
+            # Proceed proxy: trajectory_validated outcomes in audit.outcome_events
+            # for this epoch. Not a perfect 1:1 with "governance said proceed"
+            # — there is no lifecycle_proceeded event today — but it's the
+            # measured "agent kept moving" signal scoped to the same window.
+            proceed_sql = """
+                SELECT count(*)::int FROM audit.outcome_events
+                WHERE epoch = $1 AND outcome_type = 'trajectory_validated'
+            """
+            proceed_this_epoch = await conn.fetchval(proceed_sql, current_epoch)
+
+            # Verdict distribution from r1 score audit, current-epoch window.
+            verdict_sql = """
+                SELECT verdict, count(*)::int AS n
+                FROM audit.r1_score_audit
+                WHERE recorded_at >= $1 AND verdict IS NOT NULL
+                GROUP BY verdict
+            """
+            verdict_rows = await conn.fetch(verdict_sql, epoch_started_at)
+        else:
+            pauses_this_epoch = 0
+            proceed_this_epoch = 0
+            verdict_rows = []
+
+    # Map r1 verdicts (plausible/inconclusive/unsupported) into the
+    # legacy verdict_distribution surface (safe/caution/high-risk) so
+    # external readers don't break. R1 vocabulary is the persisted truth;
+    # the legacy keys are presentation.
+    R1_TO_LEGACY = {
+        "plausible": "safe",
+        "inconclusive": "caution",
+        "unsupported": "high-risk",
     }
-    
+    verdict_distribution = {"safe": 0, "caution": 0, "high-risk": 0}
+    for row in verdict_rows:
+        legacy_key = R1_TO_LEGACY.get(row["verdict"], row["verdict"])
+        verdict_distribution[legacy_key] = (
+            verdict_distribution.get(legacy_key, 0) + int(row["n"])
+        )
+    verdict_distribution["total"] = sum(
+        v for k, v in verdict_distribution.items() if k != "total"
+    )
+
+    decision_distribution = {
+        "proceed": int(proceed_this_epoch or 0),
+        "pause": int(pauses_this_epoch or 0),
+        "total": int((proceed_this_epoch or 0) + (pauses_this_epoch or 0)),
+    }
+
+    aggregate_data = {
+        "total_agents": int(state_row["total_agents"]),
+        "agents_with_data": int(state_row["agents_with_data"]),
+        "total_updates": int(total_updates or 0),
+        "mean_risk_score": float(state_row["mean_risk_score"] or 0.0),
+        "mean_risk": float(state_row["mean_risk_score"] or 0.0),  # DEPRECATED alias
+        "mean_coherence": float(state_row["mean_coherence"] or 0.0),
+        "paused_now": int(state_row["paused_now"] or 0),
+        "pauses_this_epoch": int(pauses_this_epoch or 0),
+        "epoch": int(current_epoch),
+        "as_of": datetime.now(timezone.utc).isoformat(),
+        "staleness": {
+            "oldest_state_seconds": int(state_row["staleness_oldest_seconds"] or 0),
+            "newest_state_seconds": int(state_row["staleness_newest_seconds"] or 0),
+        },
+        "decision_distribution": decision_distribution,
+        "verdict_distribution": verdict_distribution,
+    }
+
     if include_health_breakdown:
-        aggregate_data["health_breakdown"] = health_statuses
-    
-    # Add EISV labels for API documentation
+        aggregate_data["health_breakdown"] = {
+            "healthy": int(state_row["healthy"]),
+            "moderate": int(state_row["moderate"]),
+            "critical": int(state_row["critical"]),
+            "unknown": int(state_row["unknown_health"]),
+        }
+
     return success_response({
         "aggregate": aggregate_data,
-        # eisv_labels omitted by default — use get_governance_metrics(lite=false) for labels
     })
 
 # REMOVED: handle_get_status - redundant with status alias → get_governance_metrics

--- a/tests/test_observability_handlers.py
+++ b/tests/test_observability_handlers.py
@@ -1116,18 +1116,138 @@ class TestHandleDetectAnomalies:
 # handle_aggregate_metrics
 # ---------------------------------------------------------------------------
 
+class _FakeAggregateConn:
+    """Routes the four queries handle_aggregate_metrics issues to canned rows.
+
+    The handler issues:
+      1. epoch lookup (fetchrow)
+      2. state rollup (fetchrow)        — fields: total_agents, agents_with_data, ...
+      3. total_updates (fetchval)
+      4. pauses_this_epoch (fetchval)   — lifecycle_paused count
+      5. proceed_this_epoch (fetchval)  — trajectory_validated count
+      6. verdict distribution (fetch)
+    """
+
+    def __init__(
+        self,
+        *,
+        epoch: int = 3,
+        epoch_started_at=None,
+        state_row=None,
+        total_updates: int = 0,
+        pauses_this_epoch: int = 0,
+        proceed_this_epoch: int = 0,
+        verdict_rows=None,
+    ):
+        from datetime import datetime, timezone
+        self._epoch = epoch
+        self._epoch_started_at = epoch_started_at or datetime(
+            2026, 4, 27, tzinfo=timezone.utc
+        )
+        self._state_row = state_row or {
+            "total_agents": 0,
+            "agents_with_data": 0,
+            "mean_risk_score": 0.0,
+            "mean_coherence": 0.0,
+            "healthy": 0,
+            "moderate": 0,
+            "critical": 0,
+            "unknown_health": 0,
+            "paused_now": 0,
+            "staleness_oldest_seconds": 0,
+            "staleness_newest_seconds": 0,
+        }
+        self._total_updates = total_updates
+        self._pauses_this_epoch = pauses_this_epoch
+        self._proceed_this_epoch = proceed_this_epoch
+        self._verdict_rows = verdict_rows or []
+        # captured args so tests can assert scoping
+        self.fetchrow_calls = []
+        self.fetchval_calls = []
+        self.fetch_calls = []
+
+    async def fetchrow(self, sql, *args):
+        self.fetchrow_calls.append((sql, args))
+        if "core.epochs" in sql:
+            return {
+                "epoch": self._epoch,
+                "started_at": self._epoch_started_at,
+            }
+        # state rollup
+        return self._state_row
+
+    async def fetchval(self, sql, *args):
+        self.fetchval_calls.append((sql, args))
+        if "metadata->>'total_updates'" in sql or "total_updates" in sql:
+            return self._total_updates
+        if "lifecycle_paused" in sql:
+            return self._pauses_this_epoch
+        if "trajectory_validated" in sql:
+            return self._proceed_this_epoch
+        return 0
+
+    async def fetch(self, sql, *args):
+        self.fetch_calls.append((sql, args))
+        return self._verdict_rows
+
+
+class _FakeAcquire:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeDB:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def acquire(self):
+        return _FakeAcquire(self._conn)
+
+
+def _patch_db(conn):
+    """Patch get_db at its source so the in-function import resolves to fake."""
+    fake_db = _FakeDB(conn)
+    return patch("src.db.get_db", return_value=fake_db)
+
+
 class TestHandleAggregateMetrics:
-    """Tests for handle_aggregate_metrics."""
+    """Tests for handle_aggregate_metrics — Postgres-canonical path.
+
+    The handler queries core.mv_latest_agent_states, core.agents,
+    core.identities.metadata, audit.events (lifecycle_paused),
+    audit.outcome_events (trajectory_validated), and audit.r1_score_audit.
+    These tests mock the DB connection — the prior in-memory monitor
+    iteration was replaced because it produced "0 pauses" reports while
+    audit.events had hundreds.
+    """
 
     @pytest.mark.asyncio
     async def test_happy_path(self):
-        """Aggregate metrics across active agents."""
-        id1 = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
-        id2 = "aaaaaaaa-bbbb-cccc-dddd-222222222222"
-        server = _build_mock_server(agent_ids=[id1, id2])
-
-        with patch(_PATCH_SERVER, server), \
-             patch(_PATCH_CTX, return_value=None):
+        conn = _FakeAggregateConn(
+            state_row={
+                "total_agents": 2,
+                "agents_with_data": 2,
+                "mean_risk_score": 0.25,
+                "mean_coherence": 0.5,
+                "healthy": 1,
+                "moderate": 1,
+                "critical": 0,
+                "unknown_health": 0,
+                "paused_now": 0,
+                "staleness_oldest_seconds": 100,
+                "staleness_newest_seconds": 10,
+            },
+            total_updates=137000,
+            pauses_this_epoch=81,
+            proceed_this_epoch=13000,
+        )
+        with _patch_db(conn):
             from src.mcp_handlers.observability.handlers import handle_aggregate_metrics
             result = await handle_aggregate_metrics({})
 
@@ -1136,190 +1256,128 @@ class TestHandleAggregateMetrics:
         agg = data["aggregate"]
         assert agg["total_agents"] == 2
         assert agg["agents_with_data"] == 2
-        assert "mean_risk_score" in agg
-        assert "mean_coherence" in agg
-        assert "decision_distribution" in agg
+        assert agg["mean_risk_score"] == pytest.approx(0.25)
+        assert agg["mean_coherence"] == pytest.approx(0.5)
+        assert agg["total_updates"] == 137000
+        assert agg["pauses_this_epoch"] == 81
+        assert agg["paused_now"] == 0
+        assert agg["epoch"] == 3
+        assert "as_of" in agg
+        assert "staleness" in agg
+        assert agg["decision_distribution"]["pause"] == 81
+        assert agg["decision_distribution"]["proceed"] == 13000
 
     @pytest.mark.asyncio
     async def test_no_active_agents(self):
-        """No agents -> zero aggregates."""
-        server = _build_mock_server()
-
-        with patch(_PATCH_SERVER, server), \
-             patch(_PATCH_CTX, return_value=None):
+        conn = _FakeAggregateConn()  # all zeros by default
+        with _patch_db(conn):
             from src.mcp_handlers.observability.handlers import handle_aggregate_metrics
             result = await handle_aggregate_metrics({})
-
         data = parse_result(result)
-        assert data["success"] is True
         agg = data["aggregate"]
         assert agg["total_agents"] == 0
         assert agg["agents_with_data"] == 0
         assert agg["mean_risk_score"] == 0.0
         assert agg["mean_coherence"] == 0.0
+        assert agg["pauses_this_epoch"] == 0
 
     @pytest.mark.asyncio
-    async def test_specific_agent_ids(self):
-        """Aggregate only specified agents."""
-        id1 = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
-        id2 = "aaaaaaaa-bbbb-cccc-dddd-222222222222"
-        server = _build_mock_server(agent_ids=[id1, id2])
-
-        with patch(_PATCH_SERVER, server), \
-             patch(_PATCH_CTX, return_value=None):
+    async def test_specific_agent_ids_scopes_query(self):
+        """When agent_ids passed, the SQL uses WHERE a.id = ANY($1::text[])."""
+        conn = _FakeAggregateConn(
+            state_row={**_FakeAggregateConn().__dict__["_state_row"], "total_agents": 1, "agents_with_data": 1},
+        )
+        ids = ["aaaaaaaa-bbbb-cccc-dddd-111111111111"]
+        with _patch_db(conn):
             from src.mcp_handlers.observability.handlers import handle_aggregate_metrics
-            result = await handle_aggregate_metrics({"agent_ids": [id1]})
+            await handle_aggregate_metrics({"agent_ids": ids})
 
-        data = parse_result(result)
-        assert data["success"] is True
-        agg = data["aggregate"]
-        assert agg["total_agents"] == 1
-
-    @pytest.mark.asyncio
-    async def test_health_breakdown_included(self):
-        """include_health_breakdown=True (default) -> health_breakdown key present."""
-        id1 = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
-        server = _build_mock_server(agent_ids=[id1])
-
-        with patch(_PATCH_SERVER, server), \
-             patch(_PATCH_CTX, return_value=None):
-            from src.mcp_handlers.observability.handlers import handle_aggregate_metrics
-            result = await handle_aggregate_metrics({})
-
-        data = parse_result(result)
-        assert data["success"] is True
-        assert "health_breakdown" in data["aggregate"]
+        # First fetchrow after epoch lookup is the state rollup with the scope
+        state_call = [c for c in conn.fetchrow_calls if "scope" in c[0]][0]
+        assert "ANY($1::text[])" in state_call[0]
+        assert state_call[1] == (ids,)
 
     @pytest.mark.asyncio
     async def test_health_breakdown_excluded(self):
-        """include_health_breakdown=False -> no health_breakdown key."""
-        id1 = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
-        server = _build_mock_server(agent_ids=[id1])
-
-        with patch(_PATCH_SERVER, server), \
-             patch(_PATCH_CTX, return_value=None):
+        conn = _FakeAggregateConn()
+        with _patch_db(conn):
             from src.mcp_handlers.observability.handlers import handle_aggregate_metrics
-            result = await handle_aggregate_metrics({
-                "include_health_breakdown": False,
-            })
-
+            result = await handle_aggregate_metrics({"include_health_breakdown": False})
         data = parse_result(result)
-        assert data["success"] is True
         assert "health_breakdown" not in data["aggregate"]
 
     @pytest.mark.asyncio
-    async def test_decision_distribution_totals(self):
-        """Decision distribution total matches sum of counts."""
-        id1 = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
-        server = _build_mock_server(agent_ids=[id1])
-
-        with patch(_PATCH_SERVER, server), \
-             patch(_PATCH_CTX, return_value=None):
+    async def test_pauses_persist_even_when_agents_freshly_loaded(self):
+        """Regression: this is the load-bearing fix. The prior in-memory path
+        reported pauses=0 when no agent in this process had been written-through
+        since startup, despite audit.events showing real pauses. The new path
+        always reads audit.events directly, so pauses surface regardless of
+        process state."""
+        conn = _FakeAggregateConn(
+            state_row={
+                "total_agents": 100,
+                "agents_with_data": 0,  # nothing in matview for this scope
+                "mean_risk_score": 0.0,
+                "mean_coherence": 0.0,
+                "healthy": 0, "moderate": 0, "critical": 0, "unknown_health": 100,
+                "paused_now": 5,
+                "staleness_oldest_seconds": 0,
+                "staleness_newest_seconds": 0,
+            },
+            pauses_this_epoch=83,  # the real audit.events count from the bug report
+        )
+        with _patch_db(conn):
             from src.mcp_handlers.observability.handlers import handle_aggregate_metrics
             result = await handle_aggregate_metrics({})
-
         data = parse_result(result)
-        dist = data["aggregate"]["decision_distribution"]
-        # Total should be sum of proceed + pause (and backward compat keys)
-        assert "total" in dist
+        agg = data["aggregate"]
+        assert agg["pauses_this_epoch"] == 83
+        assert agg["paused_now"] == 5
+        assert agg["decision_distribution"]["pause"] == 83
 
     @pytest.mark.asyncio
-    async def test_monitor_loaded_from_persisted_state(self):
-        """When monitor not in memory, load from persisted state."""
-        id1 = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
-        metadata = {id1: _make_metadata(id1)}
-        server = _build_mock_server(metadata_dict=metadata)
-        server.load_monitor_state = MagicMock(return_value=_make_state())
-
-        with patch(_PATCH_SERVER, server), \
-             patch(_PATCH_CTX, return_value=None), \
-             patch("src.governance_monitor.UNITARESMonitor") as MockMonitor:
-            mock_instance = _make_monitor(id1)
-            MockMonitor.return_value = mock_instance
-            from src.mcp_handlers.observability.handlers import handle_aggregate_metrics
-            result = await handle_aggregate_metrics({"agent_ids": [id1]})
-
-        data = parse_result(result)
-        assert data["success"] is True
-        assert data["aggregate"]["agents_with_data"] == 1
-
-    @pytest.mark.asyncio
-    async def test_risk_history_fallback(self):
-        """When risk_score and current_risk are None, fall back to risk_history."""
-        id1 = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
-        monitor = _make_monitor(id1, metrics={
-            "risk_score": None,
-            "current_risk": None,
-        })
-        monitor.state = _make_state(risk_history=[0.3, 0.4, 0.5])
-
-        server = _build_mock_server(
-            monitors_dict={id1: monitor},
-            metadata_dict={id1: _make_metadata(id1)},
+    async def test_verdict_mapping_r1_to_legacy(self):
+        """r1_score_audit verdicts (plausible/inconclusive/unsupported) map to
+        legacy verdict_distribution keys (safe/caution/high-risk)."""
+        conn = _FakeAggregateConn(
+            verdict_rows=[
+                {"verdict": "plausible", "n": 10},
+                {"verdict": "inconclusive", "n": 4},
+                {"verdict": "unsupported", "n": 1},
+            ],
         )
-
-        with patch(_PATCH_SERVER, server), \
-             patch(_PATCH_CTX, return_value=None):
-            from src.mcp_handlers.observability.handlers import handle_aggregate_metrics
-            result = await handle_aggregate_metrics({"agent_ids": [id1]})
-
-        data = parse_result(result)
-        assert data["success"] is True
-        # mean_risk_score should be computed from risk_history
-        assert data["aggregate"]["mean_risk_score"] > 0
-
-    @pytest.mark.asyncio
-    async def test_total_updates_aggregated(self):
-        """total_updates across agents are summed (from meta.total_updates)."""
-        id1 = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
-        id2 = "aaaaaaaa-bbbb-cccc-dddd-222222222222"
-
-        m1 = _make_monitor(id1)
-        m1.state = _make_state(update_count=10)
-        m2 = _make_monitor(id2)
-        m2.state = _make_state(update_count=20)
-
-        server = _build_mock_server(
-            monitors_dict={id1: m1, id2: m2},
-            metadata_dict={id1: _make_metadata(id1, total_updates=10), id2: _make_metadata(id2, total_updates=20)},
-        )
-
-        with patch(_PATCH_SERVER, server), \
-             patch(_PATCH_CTX, return_value=None):
+        with _patch_db(conn):
             from src.mcp_handlers.observability.handlers import handle_aggregate_metrics
             result = await handle_aggregate_metrics({})
-
-        data = parse_result(result)
-        assert data["aggregate"]["total_updates"] == 30
+        v = parse_result(result)["aggregate"]["verdict_distribution"]
+        assert v["safe"] == 10
+        assert v["caution"] == 4
+        assert v["high-risk"] == 1
+        assert v["total"] == 15
 
     @pytest.mark.asyncio
-    async def test_does_not_force_full_metadata_reload(self):
-        """Regression: handle_aggregate_metrics MUST NOT call load_metadata_async
-        with force=True. The force-reload triggers 3221 sequential per-agent
-        cache.set awaits (~16s blocking), causing decorator timeouts and
-        bystander timeouts on concurrent handlers via shared event loop. See
-        Wave 0 follow-up to PR #348 — substrate-tax framing in CLAUDE.md.
-        Pin the regression so the slow path can't reappear silently."""
-        id1 = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
-        server = _build_mock_server(agent_ids=[id1])
-
-        with patch(_PATCH_SERVER, server), \
-             patch(_PATCH_CTX, return_value=None):
+    async def test_response_includes_freshness_metadata(self):
+        """as_of, epoch, and staleness must be present so callers know the
+        freshness window. The prior handler reported in-memory state as fleet
+        truth with no freshness signal — that's the ontology bug being fixed."""
+        conn = _FakeAggregateConn(
+            state_row={
+                "total_agents": 1, "agents_with_data": 1,
+                "mean_risk_score": 0.3, "mean_coherence": 0.5,
+                "healthy": 1, "moderate": 0, "critical": 0, "unknown_health": 0,
+                "paused_now": 0,
+                "staleness_oldest_seconds": 42,
+                "staleness_newest_seconds": 5,
+            },
+        )
+        with _patch_db(conn):
             from src.mcp_handlers.observability.handlers import handle_aggregate_metrics
-            await handle_aggregate_metrics({})
-
-        # The handler MUST call load_metadata_async (cache hint), but with NO
-        # force=True. Inspect every call's kwargs and any positional bool.
-        for call in server.load_metadata_async.await_args_list:
-            assert call.kwargs.get("force", False) is False, (
-                f"handle_aggregate_metrics called load_metadata_async with "
-                f"force=True (kwargs={call.kwargs}); this is the slow path"
-            )
-            for arg in call.args:
-                assert arg is not True, (
-                    f"handle_aggregate_metrics called load_metadata_async "
-                    f"with positional True (args={call.args}); equivalent to force=True"
-                )
+            result = await handle_aggregate_metrics({})
+        agg = parse_result(result)["aggregate"]
+        assert agg["epoch"] == 3
+        assert "as_of" in agg and agg["as_of"]
+        assert agg["staleness"]["oldest_state_seconds"] == 42
+        assert agg["staleness"]["newest_state_seconds"] == 5
 
 
 # ---------------------------------------------------------------------------
@@ -1378,9 +1436,11 @@ class TestHandleObserveRouter:
         """action='aggregate' routes to handle_aggregate_metrics."""
         id1 = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
         server = _build_mock_server(agent_ids=[id1])
+        conn = _FakeAggregateConn()
 
         with patch(_PATCH_SERVER, server), \
-             patch(_PATCH_CTX, return_value=None):
+             patch(_PATCH_CTX, return_value=None), \
+             _patch_db(conn):
             from src.mcp_handlers.consolidated import handle_observe
             result = await handle_observe({"action": "aggregate"})
 


### PR DESCRIPTION
## Summary

`observe.aggregate` iterated `mcp_server.monitors` and meaned `monitor.state.*` across in-process objects. The cache is load-once-per-process and drifts from PG truth on every cross-process write, so the aggregate reported \`pauses=0\` even when \`audit.events\` held 81 \`lifecycle_paused\` rows in the current epoch (kenny dogfood, 2026-05-19).

Replaces the in-memory loop with three Postgres queries:
- \`core.mv_latest_agent_states\` — state rollups (mean_risk, mean_coherence, regime → health, staleness window)
- \`audit.events\` (\`lifecycle_paused\`) — current-epoch pause count
- \`audit.outcome_events\` (\`trajectory_validated\`) — proceed proxy
- \`audit.r1_score_audit\` — verdict distribution

Migration **038** promotes \`risk_score\` from \`state_json\` to a typed column on \`core.agent_state\` and into \`core.mv_latest_agent_states\` so mean_risk computes in SQL. Backfilled 158,036 rows from existing state_json (87.9% non-null on the matview; rest are pre-grounding rows).

Response gains \`paused_now\`, \`pauses_this_epoch\`, \`epoch\`, \`as_of\`, and \`staleness\` so callers can see the freshness window instead of trusting an opaque rollup.

## Live verification (before → after)

| Field | Before (in-memory fossil) | After (PG canonical) |
|---|---|---|
| \`pauses_this_epoch\` | 0 | **81** |
| \`total_updates\` | 136,835 | 137,859 |
| \`mean_risk\` | 0.30 | 0.25 |
| \`mean_coherence\` | 0.49 | 0.49 |
| \`paused_now\` | absent | 0 |
| \`epoch\`, \`as_of\`, \`staleness\` | absent | populated |

## Test plan

- [x] \`scripts/dev/test-cache.sh\` — 8,734 passed, 0 failed, 34 skipped
- [x] \`scripts/dev/unitares_doctor.py\` — 15 pass, 0 fail, 1 warn (unrelated PID file)
- [x] New \`TestHandleAggregateMetrics\` class — 7 tests mock the DB via \`get_db\` patch; old in-memory-monitor mocks deleted
- [x] Migration 038 applied to live \`governance\` + \`governance_test\`
- [x] Live SQL preview against \`governance\` confirms expected numbers above