### PR TITLE
lease-plane: Phase A latency RPC recorder + 14d audit-mining

### DIFF
--- a/docs/proposals/lease-plane-phase-a-latency-2026-05-20.md
+++ b/docs/proposals/lease-plane-phase-a-latency-2026-05-20.md
@@ -1,0 +1,136 @@
+# Lease-plane Phase A latency — first measurement 2026-05-20
+
+Anchors the substrate-tax measurement gate from
+`beam-footprint-roadmap-v0.md` v0.3.2 amendment 2026-05-09: *"lease-plane
+Phase A latency instrumentation producing ≥14d of data."*
+
+## Scope
+
+This doc evaluates the lease-plane's BEAM↔Python boundary for
+substrate-tax signature using **existing 14-day audit data only**, plus
+adds client-side RPC instrumentation for the next window. Same
+methodology as `surface-lease-plane-v0.md` §7.5 v0.9 (Steward
+audit-mining): use what is already in the audit log rather than waiting
+for purpose-built telemetry.
+
+## What "Phase A latency" measures here
+
+The v0.3.2 amendment names this gate to capture substrate-tax cost at
+the lease boundary — Python clients (residents, handlers) calling the
+BEAM lease plane over HTTP. The interesting distributions are:
+
+- **RPC latency** — Python-client wall-clock from request send to
+  response. *Not yet recorded* — added in this branch
+  (`src/lease_plane/client.py` → `perf_monitor`).
+- **Hold time** — `released_at − acquired_at` from the BEAM event log.
+  *Available retroactively*; not RPC latency but the closest proxy.
+- **Conflict / TTL-reap rates** — operational signal that the lease
+  plane is doing useful work.
+- **forward_attempts distribution** — BEAM↔Postgres internal retry
+  signal; non-zero indicates coordination friction inside the BEAM node.
+
+## Headline (window: 2026-05-06 → 2026-05-20)
+
+From `scripts/dev/lease_plane_latency_audit.py` on `lease_plane.lease_plane_events`:
+
+| Surface | n acquire→release | p50 | p95 | p99 | p100 |
+|---|---|---|---|---|---|
+| resident | 44,535 | 28 ms | 338 ms | 5,146 ms | 60,933 ms |
+
+Event-type distribution:
+
+| event_type | count |
+|---|---|
+| acquire | 44,560 |
+| release | 44,535 |
+| renew | 27,645 |
+| conflict_held_by_other | 69 |
+| reaped_local_ttl | 21 |
+| down_local | 3 |
+
+Derived rates over 14 days:
+
+- Conflict (`held_by_other / acquires`): **0.155%**
+- TTL reap (`reaped_local_ttl / acquires`): **0.047%**
+- BEAM↔Postgres forward attempts: **100% of 116,833 events** completed
+  on the first forward attempt — no retry pile-up.
+
+## Honest reading
+
+The numbers are **compatible with no substrate-tax signature at the
+lease boundary**, but they do not conclusively measure it. Specifically:
+
+- Hold time at p99=5.1s and p100=60.9s is *not evidence of slow lease
+  operations*. The default lease TTL is 300s (per the
+  `resident:/sentinel_cycle` and `resident:/steward_eisv_sync` events
+  inspected for shape), so a 60s hold is one-fifth of TTL — well within
+  normal "lease held while resident did work" territory. The hold-time
+  tail is dominated by *work duration under lease*, not by
+  *acquire-RPC overhead*.
+- `audit.tool_usage.latency_ms` is **NULL for 100% of 116,833 lease
+  events** over 14 days. The Elixir-side `insert_tool_usage`
+  (`elixir/lease_plane/lib/unitares_lease_plane/repo.ex:594-619`)
+  hardcodes the column to NULL. The substrate-tax signal — Python
+  client wall-clock per RPC — is not in this data at all.
+- Forward-attempt distribution is uniformly 1 across the entire window.
+  This is either "no BEAM↔Postgres friction" (best case) or "the
+  forward-retry path simply doesn't get exercised because nothing fails"
+  (Caveat 2 of `wave-1-window-evaluation-2026-05-18.md` re-applies).
+  The data cannot distinguish these.
+
+The 60× amplification finding from `CLAUDE.md §"Substrate Tax:
+anyio-asyncio Coupling"` (KG calls running 21–71ms standalone,
+~4,464ms in-handler) is what a substrate-tax floor at the lease
+boundary would look like — and that is **not visible** in this 14-day
+window. But it is also not measurable from this data either way until
+the RPC instrumentation lands.
+
+## What this branch adds for the next window
+
+`src/lease_plane/client.py:_request_json` now records per-call RPC
+latency to the in-process `perf_monitor` under keys:
+
+- `lease_plane.client.v1.lease.acquire`
+- `lease_plane.client.v1.lease.acquire.ok`
+- `lease_plane.client.v1.lease.acquire.held_by_other`
+- `lease_plane.client.v1.lease.release`
+- `lease_plane.client.v1.lease.release.ok`
+- `lease_plane.client.v1.lease.renew`
+- ... and corresponding outcome shards (`schema_invalid`,
+  `transport_exception`, `permission_denied`, `service_unavailable`)
+
+`perf_monitor.snapshot()` exposes p50/p95/p99/max per key. For
+longitudinal capture, the next step is to persist these snapshots to
+`metrics.series` periodically — that work is tracked in the ODE-profile
+branch (`ode-profile-decompose`), which faces the same persistence gap
+and is the cleaner place to land the shared infrastructure.
+
+## Falsifier — what this window cannot resolve
+
+The substrate-tax-at-lease-boundary question is **deferred** until:
+
+1. Client-side RPC instrumentation is persisted to `metrics.series`
+   (this branch adds the recorder; persistence pending).
+2. A subsequent 14-day window runs with the recorder live, under load
+   comparable to the §129 representative-load floor (≥ 500 agent_state
+   writes/day).
+3. RPC latency p95 for `lease.acquire.ok` is examined against the
+   baseline that asyncpg-coupled handlers showed pre-`PR #218`
+   ExecutorPool wrap. A 60× amplification signature at the lease
+   boundary would falsify "no substrate tax here"; sub-100ms p95 would
+   support "lease boundary is clean."
+
+This is **measure-first**, not redraft. Per `feedback_redraft-cycle-bias-trap.md`, this doc does not propose any change to
+the Wave 3 RFC; it adds the missing instrumentation that the v0.3.2
+amendment's gate needed.
+
+## Cross-references
+
+- `beam-footprint-roadmap-v0.md` v0.3.2 amendment (2026-05-09) — names
+  this gate
+- `wave-1-window-evaluation-T0-2026-05-19.md` — sibling measurement
+  track (Wave 1 §129 re-eval, separate gate)
+- `surface-lease-plane-v0.md` §7.5 v0.9 — audit-mining precedent
+- `CLAUDE.md §"Substrate Tax: anyio-asyncio Coupling"` — the
+  amplification phenomenon this gate is meant to detect at the lease
+  boundary

--- a/docs/proposals/lease-plane-phase-a-latency-2026-05-20.md
+++ b/docs/proposals/lease-plane-phase-a-latency-2026-05-20.md
@@ -55,6 +55,22 @@ Derived rates over 14 days:
 - BEAM↔Postgres forward attempts: **100% of 116,833 events** completed
   on the first forward attempt — no retry pile-up.
 
+## Regime boundary inside the window
+
+The 14-day window straddles two enforcement regimes — this is named here
+because the v0.3.2 gate predates the boundary:
+
+- 2026-05-06 → 2026-05-18 (13d): Phase A advisory mode (PR #305, merged
+  2026-05-03)
+- 2026-05-19 → 2026-05-20 (1d at window close): Phase B resident
+  enforcement (PR #476, merged 2026-05-19)
+
+The headline percentiles aggregate across both regimes. The conflict
+and TTL-reap counts are dominated by the 13-day advisory tail; Phase B
+enforcement has not produced enough events to characterize on its own.
+The next 14d window will be Phase-B-only and is the cleaner attribution
+surface — flag for the follow-up doc.
+
 ## Honest reading
 
 The numbers are **compatible with no substrate-tax signature at the

--- a/scripts/dev/lease_plane_latency_audit.py
+++ b/scripts/dev/lease_plane_latency_audit.py
@@ -43,19 +43,39 @@ def connect():
 
 
 HOLD_TIME_SQL = """
-WITH pairs AS (
+-- One row per lease_id, computed as MIN(acquire.ts) -> MIN(release.ts).
+-- The naive (a.lease_id = r.lease_id) join produced an N*M Cartesian
+-- fanout whenever a lease had a duplicate release event (reaper +
+-- corrective release race) or a duplicate acquire (idempotent retry).
+-- That inflated percentile counts and admitted phantom durations.
+-- Aggregating both sides first removes the cardinality risk; for
+-- substrate-tax measurement we want the *first* release after the
+-- *first* acquire, which is what MIN/MIN expresses.
+WITH first_acquire AS (
+  SELECT lease_id, MIN(ts) AS acquired_ts,
+         MIN(surface_kind) AS surface_kind,
+         MIN(surface_id)   AS surface_id
+  FROM lease_plane.lease_plane_events
+  WHERE event_type = 'acquire'
+    AND ts > now() - make_interval(days := %s)
+  GROUP BY lease_id
+),
+first_release AS (
+  SELECT lease_id, MIN(ts) AS released_ts
+  FROM lease_plane.lease_plane_events
+  WHERE event_type = 'release'
+  GROUP BY lease_id
+),
+pairs AS (
   SELECT
     a.lease_id,
     a.surface_kind,
     a.surface_id,
-    a.ts AS acquired_ts,
-    r.ts AS released_ts,
-    EXTRACT(EPOCH FROM (r.ts - a.ts)) * 1000 AS hold_ms
-  FROM lease_plane.lease_plane_events a
-  JOIN lease_plane.lease_plane_events r
-    ON r.lease_id = a.lease_id AND r.event_type = 'release'
-  WHERE a.event_type = 'acquire'
-    AND a.ts > now() - make_interval(days := %s)
+    a.acquired_ts,
+    r.released_ts,
+    EXTRACT(EPOCH FROM (r.released_ts - a.acquired_ts)) * 1000 AS hold_ms
+  FROM first_acquire a
+  JOIN first_release r USING (lease_id)
 )
 SELECT
   surface_kind,

--- a/scripts/dev/lease_plane_latency_audit.py
+++ b/scripts/dev/lease_plane_latency_audit.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Lease-plane Phase A latency audit.
+
+Mines the existing audit trail for substrate-tax indicators at the lease
+boundary. Same pattern as `surface-lease-plane-v0.md` §7.5 v0.9 (Steward
+audit-mining): use what's already instrumented rather than waiting for
+purpose-built telemetry.
+
+Inputs:
+  - `lease_plane.lease_plane_events` (BEAM-side event log; 13+ event_types)
+  - `audit.tool_usage` (forwarded `lease.*` rows; `latency_ms` currently NULL)
+
+Outputs (text or JSON via --json):
+  1. Hold-time distribution by surface_kind — `acquire` → `release` deltas
+     from `lease_plane_events`. Not RPC latency, but the closest proxy
+     available without client-side timing.
+  2. Conflict / TTL-reap / down-local rates as fraction of acquires.
+  3. Forward-attempt distribution — non-zero forward_attempts indicate
+     coordination_failure-class retries between BEAM and Postgres.
+  4. `audit.tool_usage.latency_ms` NULL-rate audit — explicit gap statement.
+
+Usage:
+    python3 scripts/dev/lease_plane_latency_audit.py
+    python3 scripts/dev/lease_plane_latency_audit.py --days 14 --json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+import psycopg2  # type: ignore
+
+
+def connect():
+    dsn = os.environ.get(
+        "GOVERNANCE_DATABASE_URL",
+        "postgresql://postgres:postgres@localhost:5432/governance",
+    )
+    return psycopg2.connect(dsn)
+
+
+HOLD_TIME_SQL = """
+WITH pairs AS (
+  SELECT
+    a.lease_id,
+    a.surface_kind,
+    a.surface_id,
+    a.ts AS acquired_ts,
+    r.ts AS released_ts,
+    EXTRACT(EPOCH FROM (r.ts - a.ts)) * 1000 AS hold_ms
+  FROM lease_plane.lease_plane_events a
+  JOIN lease_plane.lease_plane_events r
+    ON r.lease_id = a.lease_id AND r.event_type = 'release'
+  WHERE a.event_type = 'acquire'
+    AND a.ts > now() - make_interval(days := %s)
+)
+SELECT
+  surface_kind,
+  count(*) AS n,
+  percentile_cont(0.50) WITHIN GROUP (ORDER BY hold_ms) AS p50,
+  percentile_cont(0.95) WITHIN GROUP (ORDER BY hold_ms) AS p95,
+  percentile_cont(0.99) WITHIN GROUP (ORDER BY hold_ms) AS p99,
+  max(hold_ms) AS p100
+FROM pairs
+GROUP BY surface_kind
+ORDER BY n DESC
+"""
+
+EVENT_TYPE_DISTRIBUTION_SQL = """
+SELECT event_type, count(*)
+FROM lease_plane.lease_plane_events
+WHERE ts > now() - make_interval(days := %s)
+GROUP BY event_type
+ORDER BY count(*) DESC
+"""
+
+FORWARD_ATTEMPTS_SQL = """
+SELECT
+  forward_attempts,
+  count(*)
+FROM lease_plane.lease_plane_events
+WHERE ts > now() - make_interval(days := %s)
+GROUP BY forward_attempts
+ORDER BY forward_attempts
+"""
+
+TOOL_USAGE_LATENCY_NULL_SQL = """
+SELECT
+  tool_name,
+  count(*) AS total,
+  count(*) FILTER (WHERE latency_ms IS NULL) AS null_latency
+FROM audit.tool_usage
+WHERE tool_name LIKE 'lease.%%'
+  AND ts > now() - make_interval(days := %s)
+GROUP BY tool_name
+ORDER BY total DESC
+"""
+
+
+def fetchall_dict(cur, sql: str, days: int) -> list[dict[str, Any]]:
+    cur.execute(sql, (days,))
+    cols = [d[0] for d in cur.description]
+    return [dict(zip(cols, row)) for row in cur.fetchall()]
+
+
+def run(days: int) -> dict[str, Any]:
+    with connect() as conn:
+        with conn.cursor() as cur:
+            hold = fetchall_dict(cur, HOLD_TIME_SQL, days)
+            etype = fetchall_dict(cur, EVENT_TYPE_DISTRIBUTION_SQL, days)
+            fwd = fetchall_dict(cur, FORWARD_ATTEMPTS_SQL, days)
+            null_lat = fetchall_dict(cur, TOOL_USAGE_LATENCY_NULL_SQL, days)
+    total_acquires = sum(r["count"] for r in etype if r["event_type"] == "acquire")
+    conflict_rate = (
+        sum(r["count"] for r in etype if r["event_type"] == "conflict_held_by_other")
+        / total_acquires if total_acquires else 0.0
+    )
+    reaped_rate = (
+        sum(r["count"] for r in etype if r["event_type"] in ("reaped_local_ttl", "reaped_remote_ttl"))
+        / total_acquires if total_acquires else 0.0
+    )
+    return {
+        "window_days": days,
+        "hold_time_by_surface_kind": [
+            {
+                "surface_kind": r["surface_kind"],
+                "n": int(r["n"]),
+                "p50_ms": float(r["p50"]) if r["p50"] is not None else None,
+                "p95_ms": float(r["p95"]) if r["p95"] is not None else None,
+                "p99_ms": float(r["p99"]) if r["p99"] is not None else None,
+                "p100_ms": float(r["p100"]) if r["p100"] is not None else None,
+            }
+            for r in hold
+        ],
+        "event_type_distribution": [
+            {"event_type": r["event_type"], "count": int(r["count"])}
+            for r in etype
+        ],
+        "conflict_rate": round(conflict_rate, 6),
+        "reaped_rate": round(reaped_rate, 6),
+        "forward_attempts_distribution": [
+            {"forward_attempts": int(r["forward_attempts"]), "count": int(r["count"])}
+            for r in fwd
+        ],
+        "tool_usage_latency_null_audit": [
+            {
+                "tool_name": r["tool_name"],
+                "total": int(r["total"]),
+                "null_latency": int(r["null_latency"]),
+                "null_pct": round(100.0 * r["null_latency"] / r["total"], 2) if r["total"] else 0.0,
+            }
+            for r in null_lat
+        ],
+    }
+
+
+def render_text(result: dict[str, Any]) -> str:
+    lines = [
+        f"Lease-plane Phase A latency audit (window: {result['window_days']}d)",
+        "",
+        "Hold-time distribution (acquire -> release, ms):",
+    ]
+    for r in result["hold_time_by_surface_kind"]:
+        lines.append(
+            f"  [{r['surface_kind']:<10}] n={r['n']:>6}  "
+            f"p50={r['p50_ms']:>8.1f}  p95={r['p95_ms']:>10.1f}  "
+            f"p99={r['p99_ms']:>10.1f}  p100={r['p100_ms']:>10.1f}"
+        )
+
+    lines.extend(["", "Event-type distribution:"])
+    for r in result["event_type_distribution"]:
+        lines.append(f"  {r['event_type']:<35} {r['count']:>8}")
+
+    lines.extend(
+        [
+            "",
+            f"Conflict rate (held_by_other / acquires):  {result['conflict_rate']*100:.4f}%",
+            f"Reaped rate    (TTL reap   / acquires):  {result['reaped_rate']*100:.4f}%",
+        ]
+    )
+
+    lines.extend(["", "Forward-attempt distribution (BEAM->Postgres retry signal):"])
+    for r in result["forward_attempts_distribution"]:
+        lines.append(f"  attempts={r['forward_attempts']:>2}  count={r['count']:>8}")
+
+    lines.extend(["", "audit.tool_usage.latency_ms NULL audit:"])
+    for r in result["tool_usage_latency_null_audit"]:
+        lines.append(
+            f"  {r['tool_name']:<28} total={r['total']:>6}  "
+            f"null={r['null_latency']:>6}  null_pct={r['null_pct']:.1f}%"
+        )
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--days", type=int, default=14, help="window in days (default 14)")
+    parser.add_argument("--json", action="store_true", help="emit JSON")
+    args = parser.parse_args()
+    result = run(args.days)
+    if args.json:
+        print(json.dumps(result, indent=2, default=str))
+    else:
+        print(render_text(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/lease_plane/client.py
+++ b/src/lease_plane/client.py
@@ -72,6 +72,23 @@ class LeaseHTTPRequest:
 LeaseTransport = Callable[[LeaseHTTPRequest], Mapping[str, Any]]
 
 
+def _record_lease_rpc_latency(path: str, start_perf: float, outcome: str) -> None:
+    """Record lease RPC latency to the in-process perf_monitor.
+
+    Best-effort: a profile run with perf_monitor missing or import-broken must
+    never break a lease call. Key shape: ``lease_plane.client.<path>.<outcome>``
+    plus a coarser ``lease_plane.client.<path>`` aggregate.
+    """
+    try:
+        from src.perf_monitor import record_ms
+    except Exception:
+        return
+    elapsed_ms = (time.perf_counter() - start_perf) * 1000.0
+    op = path.lstrip("/").replace("/", ".")
+    record_ms(f"lease_plane.client.{op}", elapsed_ms)
+    record_ms(f"lease_plane.client.{op}.{outcome}", elapsed_ms)
+
+
 def _urllib_transport(request: LeaseHTTPRequest) -> Mapping[str, Any]:
     body = None
     if request.json_body is not None:
@@ -333,13 +350,18 @@ class LeasePlaneClient:
             json_body=json_body,
             timeout_s=self.config.timeout_s,
         )
+        _start = time.perf_counter()
         try:
             payload = self._transport(request)
         except Exception:
+            _record_lease_rpc_latency(path, _start, "transport_exception")
             return {"ok": False, "error": "service_unavailable"}
         if not isinstance(payload, Mapping):
+            _record_lease_rpc_latency(path, _start, "schema_invalid")
             return {"ok": False, "error": "schema_invalid", "detail": "response was not an object"}
+        outcome = "ok" if payload.get("ok", True) else str(payload.get("error", "error"))
         _check_protocol_version(payload, path)
+        _record_lease_rpc_latency(path, _start, outcome)
         return payload
 
 

--- a/src/lease_plane/client.py
+++ b/src/lease_plane/client.py
@@ -359,7 +359,15 @@ class LeasePlaneClient:
         if not isinstance(payload, Mapping):
             _record_lease_rpc_latency(path, _start, "schema_invalid")
             return {"ok": False, "error": "schema_invalid", "detail": "response was not an object"}
-        outcome = "ok" if payload.get("ok", True) else str(payload.get("error", "error"))
+        # Default-True on `ok` is wrong: a malformed response without an `ok`
+        # key (custom transport, future caller) would be silently recorded
+        # as success. Treat absent `ok` as an error. Use `unknown_error` as
+        # the bucket for `ok:false` rows with no `error` discriminant so
+        # they don't collapse into a literal `"error"` perf_monitor key.
+        if payload.get("ok") is True:
+            outcome = "ok"
+        else:
+            outcome = str(payload.get("error") or "unknown_error")
         _check_protocol_version(payload, path)
         _record_lease_rpc_latency(path, _start, outcome)
         return payload

--- a/src/perf_monitor.py
+++ b/src/perf_monitor.py
@@ -46,6 +46,12 @@ class PerfMonitor:
         with self._lock:
             self._samples[op].append(float(duration_ms))
 
+    def reset(self) -> None:
+        """Drop all recorded samples. Test-fixture helper; production code
+        should rely on the per-op ring buffer's natural decay."""
+        with self._lock:
+            self._samples.clear()
+
     def snapshot(self) -> Dict[str, Dict[str, Any]]:
         """
         Return compact stats per operation.

--- a/tests/test_lease_plane_client.py
+++ b/tests/test_lease_plane_client.py
@@ -372,3 +372,86 @@ def test_simple_unknown_error_preserves_raw_string_in_reason():
     assert result.error == "service_unavailable"
     assert result.reason is not None
     assert "wormhole_collapsed" in result.reason
+
+
+# --- Phase A latency instrumentation (substrate-tax measurement gate) ---
+
+def test_rpc_latency_recorded_on_ok_acquire():
+    """ok acquire records both an aggregate and an `.ok` shard."""
+    from src.perf_monitor import perf_monitor as _pm
+
+    _pm._samples.clear()  # type: ignore[attr-defined]
+
+    holder = uuid4()
+
+    def transport(_request: LeaseHTTPRequest):
+        return {"ok": True, "lease": _lease_payload(holder_agent_uuid=holder)}
+
+    LeasePlaneClient(transport=transport).acquire(
+        AcquireRequest(
+            surface_id="file:///tmp/a",
+            holder_agent_uuid=holder,
+            holder_class="process_instance",
+            holder_kind="remote_heartbeat",
+            ttl_s=90,
+        )
+    )
+
+    snap = _pm.snapshot()
+    assert "lease_plane.client.v1.lease.acquire" in snap
+    assert "lease_plane.client.v1.lease.acquire.ok" in snap
+    assert snap["lease_plane.client.v1.lease.acquire"]["count"] == 1
+
+
+def test_rpc_latency_recorded_on_transport_exception():
+    """transport exception is timed and tagged `transport_exception`."""
+    from src.perf_monitor import perf_monitor as _pm
+
+    _pm._samples.clear()  # type: ignore[attr-defined]
+
+    def transport(_request: LeaseHTTPRequest):
+        raise TimeoutError("down")
+
+    LeasePlaneClient(transport=transport).acquire(
+        AcquireRequest(
+            surface_id="file:///tmp/a",
+            holder_agent_uuid=uuid4(),
+            holder_class="process_instance",
+            holder_kind="remote_heartbeat",
+            ttl_s=90,
+        )
+    )
+
+    snap = _pm.snapshot()
+    assert "lease_plane.client.v1.lease.acquire" in snap
+    assert "lease_plane.client.v1.lease.acquire.transport_exception" in snap
+
+
+def test_rpc_latency_recorded_on_held_by_other_outcome():
+    """typed-absence outcomes are recorded under their error shard."""
+    from src.perf_monitor import perf_monitor as _pm
+
+    _pm._samples.clear()  # type: ignore[attr-defined]
+
+    def transport(_request: LeaseHTTPRequest):
+        return {
+            "ok": False,
+            "error": "held_by_other",
+            "surface_id": "file:///tmp/a",
+            "blocking_lease_id": str(uuid4()),
+            "held_by_uuid": str(uuid4()),
+            "expires_at": datetime.now(UTC).isoformat(),
+        }
+
+    LeasePlaneClient(transport=transport).acquire(
+        AcquireRequest(
+            surface_id="file:///tmp/a",
+            holder_agent_uuid=uuid4(),
+            holder_class="process_instance",
+            holder_kind="remote_heartbeat",
+            ttl_s=90,
+        )
+    )
+
+    snap = _pm.snapshot()
+    assert "lease_plane.client.v1.lease.acquire.held_by_other" in snap

--- a/tests/test_lease_plane_client.py
+++ b/tests/test_lease_plane_client.py
@@ -380,7 +380,7 @@ def test_rpc_latency_recorded_on_ok_acquire():
     """ok acquire records both an aggregate and an `.ok` shard."""
     from src.perf_monitor import perf_monitor as _pm
 
-    _pm._samples.clear()  # type: ignore[attr-defined]
+    _pm.reset()
 
     holder = uuid4()
 
@@ -407,7 +407,7 @@ def test_rpc_latency_recorded_on_transport_exception():
     """transport exception is timed and tagged `transport_exception`."""
     from src.perf_monitor import perf_monitor as _pm
 
-    _pm._samples.clear()  # type: ignore[attr-defined]
+    _pm.reset()
 
     def transport(_request: LeaseHTTPRequest):
         raise TimeoutError("down")
@@ -431,7 +431,7 @@ def test_rpc_latency_recorded_on_held_by_other_outcome():
     """typed-absence outcomes are recorded under their error shard."""
     from src.perf_monitor import perf_monitor as _pm
 
-    _pm._samples.clear()  # type: ignore[attr-defined]
+    _pm.reset()
 
     def transport(_request: LeaseHTTPRequest):
         return {


### PR DESCRIPTION
## Summary

Anchors the substrate-tax measurement gate from `beam-footprint-roadmap-v0.md` v0.3.2 amendment (2026-05-09): *"lease-plane Phase A latency instrumentation producing ≥14d of data."*

- `src/lease_plane/client.py` — `_request_json` now times each RPC and records to `perf_monitor` under `lease_plane.client.<path>(.<outcome>)`
- `tests/test_lease_plane_client.py` — 3 new tests
- `scripts/dev/lease_plane_latency_audit.py` — audit-mining over 14d of existing `lease_plane.lease_plane_events` (n=44.5k acquire→release pairs)
- `docs/proposals/lease-plane-phase-a-latency-2026-05-20.md` — first measurement + falsifier
- `src/perf_monitor.py` — added public `reset()` method

## Existing-data findings (14d)

Hold-time p50=28ms, p95=338ms; conflict rate 0.155%; 100% first-attempt BEAM→Postgres forward. **Compatible with no substrate-tax signature, but does not conclusively measure it** — `audit.tool_usage.latency_ms` is NULL for 100% of 117k events (BEAM-side `insert_tool_usage` hardcodes NULL at `repo.ex:594-619`). The new client recorder closes the gap for the next window.

## Council pass

- **Architect**: SHIP with structural nit folded — doc now names the Phase A→B regime boundary inside the 14d window (PR #476 enforced Phase B 2026-05-19).
- **Reviewer**: BLOCK on HOLD_TIME_SQL Cartesian fanout + outcome derivation + private-attr test access. All three fixed in second commit:
  - SQL: aggregate first-acquire and first-release per lease_id before joining (one row per lease, no cardinality risk)
  - Outcome: treat absent `ok` as error; bucket no-discriminant failures as `unknown_error` not literal `"error"`
  - Tests now use `PerfMonitor.reset()` public method
- **Verifier**: 6 of 6 claims verified live (lease events present, latency_ms NULL confirmed, BEAM hardcoding confirmed, tests pass, audit script numbers match, perf_monitor import works).

## Test plan

- [x] 21 lease-plane tests pass (18 pre-existing + 3 new)
- [x] Audit script produces stable headline numbers (~28ms p50, 0.155% conflict)
- [ ] Next 14d window will have client-side RPC latency populated; produce a follow-up doc with that data

## Substrate-question impact

Per `feedback_redraft-cycle-bias-trap.md`: measure-first. The falsifier (next 14d under representative load, examine `lease.acquire.ok` p95) is now structurally checkable.