### PR TITLE
ode-profile: decompose process_update_authenticated_async + persist

### DIFF
--- a/docs/proposals/ode-profile-decomposition-2026-05-20.md
+++ b/docs/proposals/ode-profile-decomposition-2026-05-20.md
@@ -30,31 +30,44 @@ numpy compute, and PG persistence.
 Five sub-timers inside `process_update_authenticated_async`
 (`src/agent_loop_detection.py:353-560`):
 
-| Key | Surface measured | Expected character |
-|---|---|---|
-| `ode.auth_ms` | `verify_agent_ownership` in executor (sync PG/Redis-touching) | I/O-bound; sub-50ms typical |
-| `ode.loop_detect_ms` | `detect_loop_pattern` in executor | CPU-bound, in-process state inspection |
-| `ode.monitor_setup_ms` | `get_or_create_monitor` + `hydrate_from_db_if_fresh` | First-call I/O; cache-hit otherwise |
-| **`ode.compute_ms`** | `monitor.process_update` in executor — **the actual numpy ODE step** | CPU-bound numpy work; this is the "7s remainder" candidate |
-| `ode.persist_ms` | `increment_update_count` (PG atomic write) | I/O-bound; touches asyncpg via ExecutorPool |
+| Key | Surface measured | Persisted? | Expected character |
+|---|---|---|---|
+| `ode.auth_ms` | `verify_agent_ownership` in executor | volatile only | I/O-bound; sub-50ms typical |
+| `ode.loop_detect_ms` | `detect_loop_pattern` in executor | volatile only | CPU-bound, in-process state inspection |
+| `ode.monitor_setup_ms` | `get_or_create_monitor` + `hydrate_from_db_if_fresh` | volatile only | First-call I/O; cache-hit otherwise |
+| **`ode.numpy_step_ms`** | `monitor.process_update` in executor — numpy step (wall-clock includes executor queue-wait) | **yes (p50/p99)** | CPU-bound numpy work + executor queue-wait |
+| `ode.persist_ms` | `increment_update_count` (PG atomic write via ExecutorPool); covers `get_db()` acquisition cost | volatile only | I/O-bound |
+| `ode.persist_failed_ms` | sibling key when `increment_update_count` raises | volatile only | Failure rate signal; distinguishes "errored" from "never fired" |
 
 Sub-timers feed the existing in-process `perf_monitor` ring buffer
 (`src/perf_monitor.py`) — 1000 samples per key, p50/p95/p99/max exposed
 via the snapshot endpoint.
 
+**Honest gap:** only `ode.numpy_step_ms` reaches `metrics.series`. The
+other four sub-timers are volatile-only — visible via the snapshot
+endpoint for ad-hoc inspection, but they don't accumulate longitudinally.
+That means the "residual that doesn't sum is event-loop scheduling
+overhead" computation requires manual snapshot collection across a
+window, not a SQL query. A follow-up that promotes the other four to
+catalog entries can land when the first 7d of `numpy_step_ms` data has
+identified which decomposition slice is load-bearing.
+
 ## Persistence
 
 The catalog at `src/fleet_metrics/catalog.py` is intentionally a
 high-bar surface ("answers a question the operator will actually ask
-monthly"). Four new entries earned their rent:
+monthly"). Four entries earned their rent:
 
-- `ode.compute_ms.p50` / `.p99` — answers "is the numpy ODE step's
-  latency shrinking, stable, or growing?" The v0.3 RESOLUTION question.
+- `ode.numpy_step_ms.p50` / `.p99` — answers "is the numpy ODE step's
+  wall-clock shrinking, stable, or growing?" The v0.3 RESOLUTION
+  question. Renamed from the initial `ode.compute_ms` to make the
+  executor-queue-wait inclusion explicit (council architect-lane finding).
 - `lease_plane.client.v1.lease.acquire.p50` / `.p99` — answers "is the
   lease-boundary substrate-tax materializing?" The v0.3.2 amendment
-  question.
+  question. (Shared infra; persisted by this branch even though the
+  recorder lives in `lease-plane-phase-a-latency`.)
 
-`perf_monitor_persist_task` (`src/background_tasks.py:706+`, started at
+`perf_monitor_persist_task` (`src/background_tasks.py:715+`, started at
 server bootstrap alongside `coherence_monitoring_task`) samples
 `perf_monitor.snapshot()` every 5 minutes and writes these four series
 to `metrics.series` via `fleet_metrics.storage.record()`. The 5-minute
@@ -75,9 +88,10 @@ key somewhere in `src/`.
 - Does not split the ODE numpy compute itself into sub-steps. The Wave 3
   re-attempt may want that (governance_core changes); this branch stops
   at the boundary between `agent_loop_detection.py` and the numpy
-  module. Honest current-state: we will measure whether `ode.compute_ms`
-  is the load-bearing slice. If yes, a follow-up branch decomposes
-  governance_core's ODE solver.
+  module. Honest current-state: we will measure whether
+  `ode.numpy_step_ms` is the load-bearing slice. If yes, a follow-up
+  branch decomposes governance_core's ODE solver (and adds executor
+  queue-depth sampling to disambiguate numpy from queue-wait).
 - Does not redraft Wave 3 RFC. Per
   `feedback_redraft-cycle-bias-trap.md`, this is measure-first.
 - Does not change ODE behavior. Pure observation.
@@ -90,17 +104,25 @@ meaning if the bulk of `process_update_authenticated_async` is
 substrate question becomes about NumPy/SciPy not Python event loops.
 
 The four candidate readings, all directly checkable from the new
-series in 7+ days of steady traffic:
+series in 7+ days of steady traffic (caveats below):
 
 | Reading | Signature | Substrate-question consequence |
 |---|---|---|
-| ODE is numpy-bound | `ode.compute_ms.p99 > 6000` and other phases sub-100ms | Substrate-tax NOT at the asyncio boundary; consider numpy compile / vectorization, not BEAM port |
+| ODE is numpy-or-executor-bound | `ode.numpy_step_ms.p99 > 6000` and other phases sub-100ms | Either numpy is slow OR default executor pool is saturated under load — same wall-clock surface; disambiguate by sampling executor queue depth alongside |
 | ODE is asyncpg-bound | `ode.persist_ms.p99 > 5000` and rest fine | ExecutorPool isn't isolating; the bug class is still alive on this surface |
-| ODE is event-loop-bound | All sub-timers sum to << ode_call_ms | Substrate-tax IS the asyncio/anyio scheduling residual; supports v0.3 destination commitment |
+| ODE is event-loop-bound | All sub-timers sum to << `phases.ode_call_ms` (legacy outer-call timer in `phases.py:1062`) | Substrate-tax IS the asyncio/anyio scheduling residual; supports v0.3 destination commitment |
 | ODE is monitor-setup-bound | `ode.monitor_setup_ms.p99 > 1000` | Cache pathology, not substrate |
 
+**Readings are not mutually exclusive.** Numpy-bound and executor-bound
+can both be true simultaneously; the first row of the table captures
+their shared signature without resolving between them. Resolving
+requires executor queue-depth instrumentation that this branch does
+*not* add — that's a follow-up if/when the first row's signature fires.
+
 This makes the v0.3 RESOLUTION question structurally falsifiable for
-the first time.
+the first time. The legacy `phases.ode_call_ms` (whole-call timer in
+`phases.py:1062`) is preserved; together with `ode.numpy_step_ms` and
+the volatile sub-timers, the residual computation is well-defined.
 
 ## Cross-references
 
@@ -113,5 +135,5 @@ the first time.
 - `lease-plane-phase-a-latency-2026-05-20.md` — sibling lease-boundary
   measurement gate; shares the persistence infra introduced here
 - `CLAUDE.md §"Substrate Tax: anyio-asyncio Coupling"` — the
-  amplification phenomenon `ode.compute_ms` vs sum-of-other-phases is
+  amplification phenomenon `ode.numpy_step_ms` vs sum-of-other-phases is
   meant to detect or rule out

--- a/docs/proposals/ode-profile-decomposition-2026-05-20.md
+++ b/docs/proposals/ode-profile-decomposition-2026-05-20.md
@@ -1,0 +1,117 @@
+# ODE profile decomposition + persistence — 2026-05-20
+
+Anchors the load-bearing unknown from `beam-footprint-roadmap-v0.md`
+v0.3 RESOLUTION (2026-05-05): *"ODE profile
+(`process_update_authenticated_async`) is the load-bearing unknown —
+runs in parallel with Wave 1, lands in v0.3.1 amendment, doesn't gate
+Wave 1."* Eleven days passed; the v0.3.1 amendment never landed because
+the instrumentation it would cite didn't exist. This branch adds the
+instrumentation.
+
+## What was already in place
+
+`src/mcp_handlers/updates/phases.py:1044` wraps the ODE call with one
+timer:
+
+```python
+_perf_record_ms("phases.ode_call_ms", (time.perf_counter() - _ode_start) * 1000)
+```
+
+That records the **total** wall-clock of
+`mcp_server.process_update_authenticated_async`. The Wave 3 RFC §0
+disconfirmer A′.1 is computable from this alone (`ode_call_ms /
+total_ms`). But it does not answer the v0.3 RESOLUTION question — "what
+*within* the ODE call accounts for the 7s remainder?" — because the
+single bucket conflates auth, loop-detection, monitor setup, the actual
+numpy compute, and PG persistence.
+
+## What this branch adds
+
+Five sub-timers inside `process_update_authenticated_async`
+(`src/agent_loop_detection.py:353-560`):
+
+| Key | Surface measured | Expected character |
+|---|---|---|
+| `ode.auth_ms` | `verify_agent_ownership` in executor (sync PG/Redis-touching) | I/O-bound; sub-50ms typical |
+| `ode.loop_detect_ms` | `detect_loop_pattern` in executor | CPU-bound, in-process state inspection |
+| `ode.monitor_setup_ms` | `get_or_create_monitor` + `hydrate_from_db_if_fresh` | First-call I/O; cache-hit otherwise |
+| **`ode.compute_ms`** | `monitor.process_update` in executor — **the actual numpy ODE step** | CPU-bound numpy work; this is the "7s remainder" candidate |
+| `ode.persist_ms` | `increment_update_count` (PG atomic write) | I/O-bound; touches asyncpg via ExecutorPool |
+
+Sub-timers feed the existing in-process `perf_monitor` ring buffer
+(`src/perf_monitor.py`) — 1000 samples per key, p50/p95/p99/max exposed
+via the snapshot endpoint.
+
+## Persistence
+
+The catalog at `src/fleet_metrics/catalog.py` is intentionally a
+high-bar surface ("answers a question the operator will actually ask
+monthly"). Four new entries earned their rent:
+
+- `ode.compute_ms.p50` / `.p99` — answers "is the numpy ODE step's
+  latency shrinking, stable, or growing?" The v0.3 RESOLUTION question.
+- `lease_plane.client.v1.lease.acquire.p50` / `.p99` — answers "is the
+  lease-boundary substrate-tax materializing?" The v0.3.2 amendment
+  question.
+
+`perf_monitor_persist_task` (`src/background_tasks.py:706+`, started at
+server bootstrap alongside `coherence_monitoring_task`) samples
+`perf_monitor.snapshot()` every 5 minutes and writes these four series
+to `metrics.series` via `fleet_metrics.storage.record()`. The 5-minute
+cadence matches Steward EISV-sync cadence; the 1000-sample ring buffer
+absorbs ~85min of typical traffic before the p99 starts to drift to
+recent-only.
+
+Catalog-gated by design — perf_monitor may carry many keys; the
+persistence task only writes those whose name maps to a registered
+metric. New sub-timer? Add to both the catalog and
+`_PERF_PERSIST_TARGETS`. Test (`tests/test_perf_monitor_persist.py`)
+enforces both directions: every target's `metric_name` must be in the
+catalog, and every target's `op_key` must be a recorded perf_monitor
+key somewhere in `src/`.
+
+## What this branch deliberately does not do
+
+- Does not split the ODE numpy compute itself into sub-steps. The Wave 3
+  re-attempt may want that (governance_core changes); this branch stops
+  at the boundary between `agent_loop_detection.py` and the numpy
+  module. Honest current-state: we will measure whether `ode.compute_ms`
+  is the load-bearing slice. If yes, a follow-up branch decomposes
+  governance_core's ODE solver.
+- Does not redraft Wave 3 RFC. Per
+  `feedback_redraft-cycle-bias-trap.md`, this is measure-first.
+- Does not change ODE behavior. Pure observation.
+
+## Falsifier
+
+The v0.3 RESOLUTION's stop-sign was: *"ODE is 6+s of numpy compute"* —
+meaning if the bulk of `process_update_authenticated_async` is
+`monitor.process_update` itself, that's CPU-bound numpy work and the
+substrate question becomes about NumPy/SciPy not Python event loops.
+
+The four candidate readings, all directly checkable from the new
+series in 7+ days of steady traffic:
+
+| Reading | Signature | Substrate-question consequence |
+|---|---|---|
+| ODE is numpy-bound | `ode.compute_ms.p99 > 6000` and other phases sub-100ms | Substrate-tax NOT at the asyncio boundary; consider numpy compile / vectorization, not BEAM port |
+| ODE is asyncpg-bound | `ode.persist_ms.p99 > 5000` and rest fine | ExecutorPool isn't isolating; the bug class is still alive on this surface |
+| ODE is event-loop-bound | All sub-timers sum to << ode_call_ms | Substrate-tax IS the asyncio/anyio scheduling residual; supports v0.3 destination commitment |
+| ODE is monitor-setup-bound | `ode.monitor_setup_ms.p99 > 1000` | Cache pathology, not substrate |
+
+This makes the v0.3 RESOLUTION question structurally falsifiable for
+the first time.
+
+## Cross-references
+
+- `beam-footprint-roadmap-v0.md` v0.3 RESOLUTION (2026-05-05) — names
+  this gate
+- `beam-wave-3-handler-dispatch.md` §B1.2 — Wave 3 RFC A′.1 disconfirmer
+  (the single-timer ratio this branch refines)
+- `wave-1-window-evaluation-T0-2026-05-19.md` — sibling §129 measurement
+  gate
+- `lease-plane-phase-a-latency-2026-05-20.md` — sibling lease-boundary
+  measurement gate; shares the persistence infra introduced here
+- `CLAUDE.md §"Substrate Tax: anyio-asyncio Coupling"` — the
+  amplification phenomenon `ode.compute_ms` vs sum-of-other-phases is
+  meant to detect or rule out

--- a/src/agent_loop_detection.py
+++ b/src/agent_loop_detection.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os
 import re
 import json
+import time
 import asyncio
 from typing import Any, Dict, Optional
 from collections import Counter, deque
@@ -21,6 +22,7 @@ from src.agent_metadata_model import agent_metadata
 from src.agent_monitor_state import monitors, save_monitor_state, save_monitor_state_async
 from src.agent_identity_auth import verify_agent_ownership
 from src.agent_metadata_persistence import load_metadata_async
+from src.perf_monitor import record_ms as _perf_record_ms
 
 logger = get_logger(__name__)
 
@@ -371,9 +373,11 @@ async def process_update_authenticated_async(
     from src.agent_lifecycle import get_or_create_monitor
 
     loop = asyncio.get_running_loop()
+    _t0 = time.perf_counter()
     is_valid, error_msg = await loop.run_in_executor(
         None, verify_agent_ownership, agent_id, api_key, session_bound
     )
+    _perf_record_ms("ode.auth_ms", (time.perf_counter() - _t0) * 1000.0)
     if not is_valid:
         raise PermissionError(f"Authentication failed: {error_msg}")
 
@@ -392,7 +396,9 @@ async def process_update_authenticated_async(
         )
 
     # Check for loop pattern BEFORE processing
+    _t_loop = time.perf_counter()
     is_loop, loop_reason = await loop.run_in_executor(None, detect_loop_pattern, agent_id)
+    _perf_record_ms("ode.loop_detect_ms", (time.perf_counter() - _t_loop) * 1000.0)
     if is_loop:
         meta = agent_metadata[agent_id]
 
@@ -469,6 +475,7 @@ async def process_update_authenticated_async(
         )
 
     # Get or create monitor
+    _t_setup = time.perf_counter()
     monitor = await loop.run_in_executor(None, get_or_create_monitor, agent_id)
     # Heal the DB ↔ file persistence split: if the on-disk state file is
     # missing but core.agent_state has history, hydrate update_count +
@@ -476,13 +483,21 @@ async def process_update_authenticated_async(
     # rather than from a fresh zero.
     from src.agent_monitor_state import hydrate_from_db_if_fresh
     await hydrate_from_db_if_fresh(monitor, agent_id)
+    _perf_record_ms("ode.monitor_setup_ms", (time.perf_counter() - _t_setup) * 1000.0)
 
     task_type = agent_state.get("task_type", "mixed")
 
+    # The actual ODE compute — numpy work, no I/O. v0.3 RESOLUTION's
+    # "load-bearing unknown" was "what's in the 7s ODE remainder?"; this
+    # timer answers that. Combined with ode.auth_ms / ode.loop_detect_ms /
+    # ode.monitor_setup_ms / ode.persist_ms, the residual that doesn't sum
+    # is event-loop scheduling overhead — the substrate-tax candidate.
+    _t_compute = time.perf_counter()
     result = await loop.run_in_executor(
         None,
         partial(monitor.process_update, agent_state, confidence=confidence, task_type=task_type)
     )
+    _perf_record_ms("ode.compute_ms", (time.perf_counter() - _t_compute) * 1000.0)
 
     if auto_save:
         decision_action = result.get('decision', {}).get('action', 'unknown')
@@ -497,10 +512,12 @@ async def process_update_authenticated_async(
         try:
             from src import agent_storage
             db = agent_storage.get_db()
+            _t_persist = time.perf_counter()
             new_count = await db.increment_update_count(agent_id, extra_metadata={
                 "recent_update_timestamps": meta.recent_update_timestamps if meta else [now],
                 "recent_decisions": meta.recent_decisions if meta else [decision_action],
             })
+            _perf_record_ms("ode.persist_ms", (time.perf_counter() - _t_persist) * 1000.0)
             if meta is not None:
                 meta.total_updates = new_count
         except Exception as e:

--- a/src/agent_loop_detection.py
+++ b/src/agent_loop_detection.py
@@ -487,17 +487,21 @@ async def process_update_authenticated_async(
 
     task_type = agent_state.get("task_type", "mixed")
 
-    # The actual ODE compute — numpy work, no I/O. v0.3 RESOLUTION's
-    # "load-bearing unknown" was "what's in the 7s ODE remainder?"; this
-    # timer answers that. Combined with ode.auth_ms / ode.loop_detect_ms /
-    # ode.monitor_setup_ms / ode.persist_ms, the residual that doesn't sum
-    # is event-loop scheduling overhead — the substrate-tax candidate.
-    _t_compute = time.perf_counter()
+    # Numpy ODE step — `monitor.process_update` dispatched via the default
+    # executor pool. v0.3 RESOLUTION's "load-bearing unknown" was "what's
+    # in the 7s ODE remainder?"; this timer answers that. Named
+    # `ode.numpy_step_ms` (not `compute_ms`) because the wall-clock here
+    # includes executor queue-wait time as well as the numpy work — under
+    # concurrent load on a saturated default pool, queue-wait can dominate
+    # numpy compute. Disambiguating "numpy slow" from "executor saturated"
+    # requires looking at executor queue depth alongside, which is out of
+    # scope for this branch; called out in the eval doc's falsifier matrix.
+    _t_numpy = time.perf_counter()
     result = await loop.run_in_executor(
         None,
         partial(monitor.process_update, agent_state, confidence=confidence, task_type=task_type)
     )
-    _perf_record_ms("ode.compute_ms", (time.perf_counter() - _t_compute) * 1000.0)
+    _perf_record_ms("ode.numpy_step_ms", (time.perf_counter() - _t_numpy) * 1000.0)
 
     if auto_save:
         decision_action = result.get('decision', {}).get('action', 'unknown')
@@ -509,10 +513,10 @@ async def process_update_authenticated_async(
             meta.add_recent_update(now, decision_action)
 
         # Atomically increment total_updates in PostgreSQL
+        _t_persist = time.perf_counter()
         try:
             from src import agent_storage
             db = agent_storage.get_db()
-            _t_persist = time.perf_counter()
             new_count = await db.increment_update_count(agent_id, extra_metadata={
                 "recent_update_timestamps": meta.recent_update_timestamps if meta else [now],
                 "recent_decisions": meta.recent_decisions if meta else [decision_action],
@@ -521,6 +525,11 @@ async def process_update_authenticated_async(
             if meta is not None:
                 meta.total_updates = new_count
         except Exception as e:
+            # Record the failed-persist sample under a distinct key so the
+            # success-path series (`ode.persist_ms`) reflects only successful
+            # writes, while operators can still tell "failure" from "never
+            # fired" in perf_monitor snapshots.
+            _perf_record_ms("ode.persist_failed_ms", (time.perf_counter() - _t_persist) * 1000.0)
             logger.warning(f"Failed to increment update count for {agent_id[:8]}...: {e}")
             if meta is not None:
                 meta.total_updates += 1

--- a/src/background_tasks.py
+++ b/src/background_tasks.py
@@ -707,8 +707,8 @@ async def session_cleanup_task(interval_hours: float = 6.0):
 # perf_monitor.snapshot() may carry many more keys; the catalog gate keeps
 # metrics.series from filling with surface-area noise.
 _PERF_PERSIST_TARGETS: tuple[tuple[str, str, str], ...] = (
-    ("ode.compute_ms",                              "p50_ms", "ode.compute_ms.p50"),
-    ("ode.compute_ms",                              "p99_ms", "ode.compute_ms.p99"),
+    ("ode.numpy_step_ms",                           "p50_ms", "ode.numpy_step_ms.p50"),
+    ("ode.numpy_step_ms",                           "p99_ms", "ode.numpy_step_ms.p99"),
     ("lease_plane.client.v1.lease.acquire",         "p50_ms", "lease_plane.client.v1.lease.acquire.p50"),
     ("lease_plane.client.v1.lease.acquire",         "p99_ms", "lease_plane.client.v1.lease.acquire.p99"),
 )

--- a/src/background_tasks.py
+++ b/src/background_tasks.py
@@ -700,6 +700,72 @@ async def session_cleanup_task(interval_hours: float = 6.0):
 
 
 # ---------------------------------------------------------------------------
+# perf_monitor snapshot persistence
+# ---------------------------------------------------------------------------
+
+# Names registered in fleet_metrics.catalog.py — only these get persisted.
+# perf_monitor.snapshot() may carry many more keys; the catalog gate keeps
+# metrics.series from filling with surface-area noise.
+_PERF_PERSIST_TARGETS: tuple[tuple[str, str, str], ...] = (
+    ("ode.compute_ms",                              "p50_ms", "ode.compute_ms.p50"),
+    ("ode.compute_ms",                              "p99_ms", "ode.compute_ms.p99"),
+    ("lease_plane.client.v1.lease.acquire",         "p50_ms", "lease_plane.client.v1.lease.acquire.p50"),
+    ("lease_plane.client.v1.lease.acquire",         "p99_ms", "lease_plane.client.v1.lease.acquire.p99"),
+)
+
+
+async def perf_monitor_persist_task(interval_minutes: float = 5.0):
+    """Snapshot perf_monitor every N minutes; persist load-bearing percentiles
+    to ``metrics.series``.
+
+    The in-process perf_monitor singleton holds a 1000-sample ring per op key
+    (``src/perf_monitor.py``). That's volatile — process restart wipes it,
+    and snapshots are only visible via the snapshot HTTP endpoint. This task
+    samples the snapshot every 5min and writes the catalog-gated subset to
+    ``metrics.series`` so the substrate-question measurement gates
+    (``beam-footprint-roadmap-v0.md`` v0.3 RESOLUTION + v0.3.2 amendment) can
+    accumulate longitudinal data without each restart resetting the window.
+
+    Startup delay 90s to let monitor traffic accumulate at least one sample.
+    Errors are logged at WARNING so a silent gap is visible.
+    """
+    await asyncio.sleep(90.0)
+    logger.info(
+        f"[PERF_PERSIST] Started perf_monitor → metrics.series persistence "
+        f"(every {interval_minutes}m, {len(_PERF_PERSIST_TARGETS)} series)"
+    )
+    from src.perf_monitor import snapshot as _perf_snapshot
+    from src.fleet_metrics.storage import record as _record_metric
+
+    while True:
+        try:
+            await asyncio.sleep(interval_minutes * 60.0)
+            snap = _perf_snapshot()
+            written = 0
+            for op_key, pct_field, metric_name in _PERF_PERSIST_TARGETS:
+                op_stats = snap.get(op_key)
+                if not op_stats:
+                    continue
+                value = op_stats.get(pct_field)
+                if value is None:
+                    continue
+                try:
+                    await _record_metric(metric_name, float(value))
+                    written += 1
+                except Exception as e:
+                    logger.warning(
+                        f"[PERF_PERSIST] record {metric_name} failed: {e}"
+                    )
+            if written:
+                logger.debug(f"[PERF_PERSIST] wrote {written} series points")
+        except asyncio.CancelledError:
+            logger.info("[PERF_PERSIST] Task cancelled")
+            break
+        except Exception as e:
+            logger.warning(f"[PERF_PERSIST] Error: {e}", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
 # Coherence monitoring
 # ---------------------------------------------------------------------------
 
@@ -1526,6 +1592,9 @@ def start_all_background_tasks(connection_tracker, set_ready):
 
     _supervised_create_task(coherence_monitoring_task(interval_minutes=10.0), name="coherence_monitor")
     logger.info("[COHERENCE_MONITOR] Started proactive coherence monitoring (every 10m)")
+
+    _supervised_create_task(perf_monitor_persist_task(interval_minutes=5.0), name="perf_monitor_persist")
+    logger.info("[PERF_PERSIST] Started perf_monitor snapshot persistence (every 5m)")
 
     _supervised_create_task(periodic_telemetry_rotation(), name="telemetry_rotation")
     _supervised_create_task(periodic_audit_log_rotation(), name="audit_log_rotation")

--- a/src/fleet_metrics/catalog.py
+++ b/src/fleet_metrics/catalog.py
@@ -134,3 +134,33 @@ register(Metric(
     description="GitHub unique-cloner count summed across non-archived CIRWEL repos. GitHub traffic API rolling 14-day window; not daily delta.",
     unit="cloners",
 ))
+
+# ODE compute time — the load-bearing unknown from
+# beam-footprint-roadmap-v0.md v0.3 RESOLUTION ("what's in the 7s ODE
+# remainder?"). Sampled every 5 minutes from perf_monitor (in-process,
+# 1000-sample ring buffer). p50 + p99 only — finer percentiles do not
+# answer a question the operator will read.
+register(Metric(
+    name="ode.compute_ms.p50",
+    description="Median wall-clock of monitor.process_update (numpy ODE step) over the trailing in-process window. Snapshot every 5min.",
+    unit="ms",
+))
+register(Metric(
+    name="ode.compute_ms.p99",
+    description="p99 wall-clock of monitor.process_update over the trailing in-process window. Tracks the substrate-tax tail at the ODE compute boundary.",
+    unit="ms",
+))
+
+# Lease-plane client RPC latency — the v0.3.2 amendment's
+# "lease-plane Phase A latency instrumentation" gate. Sampled every
+# 5min from perf_monitor.
+register(Metric(
+    name="lease_plane.client.v1.lease.acquire.p50",
+    description="Median wall-clock for lease.acquire RPC (Python client to BEAM lease plane). Snapshot every 5min.",
+    unit="ms",
+))
+register(Metric(
+    name="lease_plane.client.v1.lease.acquire.p99",
+    description="p99 wall-clock for lease.acquire RPC. Tracks substrate-tax tail at the lease boundary (BEAM↔Python).",
+    unit="ms",
+))

--- a/src/fleet_metrics/catalog.py
+++ b/src/fleet_metrics/catalog.py
@@ -135,19 +135,24 @@ register(Metric(
     unit="cloners",
 ))
 
-# ODE compute time — the load-bearing unknown from
+# Numpy ODE step wall-clock — the load-bearing unknown from
 # beam-footprint-roadmap-v0.md v0.3 RESOLUTION ("what's in the 7s ODE
 # remainder?"). Sampled every 5 minutes from perf_monitor (in-process,
 # 1000-sample ring buffer). p50 + p99 only — finer percentiles do not
 # answer a question the operator will read.
+#
+# Naming note: this measures `monitor.process_update` dispatched via the
+# default executor — wall-clock includes executor queue-wait AND numpy
+# work. Renamed from `ode.compute_ms` to make this honest; see
+# ode-profile-decomposition-2026-05-20.md falsifier matrix.
 register(Metric(
-    name="ode.compute_ms.p50",
-    description="Median wall-clock of monitor.process_update (numpy ODE step) over the trailing in-process window. Snapshot every 5min.",
+    name="ode.numpy_step_ms.p50",
+    description="Median wall-clock of monitor.process_update (numpy ODE step) over the trailing in-process window. Snapshot every 5min. Includes executor queue-wait time as well as numpy compute.",
     unit="ms",
 ))
 register(Metric(
-    name="ode.compute_ms.p99",
-    description="p99 wall-clock of monitor.process_update over the trailing in-process window. Tracks the substrate-tax tail at the ODE compute boundary.",
+    name="ode.numpy_step_ms.p99",
+    description="p99 wall-clock of monitor.process_update over the trailing in-process window. Tracks the substrate-tax tail at the ODE numpy-step boundary; under saturated default executor, queue-wait can dominate numpy.",
     unit="ms",
 ))
 

--- a/tests/test_perf_monitor_persist.py
+++ b/tests/test_perf_monitor_persist.py
@@ -54,7 +54,7 @@ async def test_persist_iteration_writes_present_keys_only(monkeypatch):
     import src.background_tasks as bg
 
     fake_snapshot = {
-        "ode.compute_ms": {
+        "ode.numpy_step_ms": {
             "count": 12,
             "avg_ms": 100.0,
             "p50_ms": 80.0,
@@ -82,7 +82,7 @@ async def test_persist_iteration_writes_present_keys_only(monkeypatch):
             continue
         await fake_record(metric_name, float(value))
 
-    assert ("ode.compute_ms.p50", 80.0) in written
-    assert ("ode.compute_ms.p99", 200.0) in written
+    assert ("ode.numpy_step_ms.p50", 80.0) in written
+    assert ("ode.numpy_step_ms.p99", 200.0) in written
     # lease_plane absent from fake snapshot → not in written
     assert all("lease_plane" not in name for name, _ in written)

--- a/tests/test_perf_monitor_persist.py
+++ b/tests/test_perf_monitor_persist.py
@@ -1,0 +1,88 @@
+"""Tests for perf_monitor_persist_task — the bridge from in-process
+PerfMonitor samples to the longitudinal metrics.series table.
+
+These tests don't exercise the asyncio sleep loop. They verify the
+_PERF_PERSIST_TARGETS mapping and that the task writes only the keys
+present in its target list (catalog-gated by design).
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.background_tasks import _PERF_PERSIST_TARGETS, perf_monitor_persist_task
+
+
+def test_targets_reference_catalog_metric_names():
+    """Every (op_key, pct_field, metric_name) must have metric_name registered."""
+    from src.fleet_metrics.catalog import catalog
+
+    for _op_key, _pct, metric_name in _PERF_PERSIST_TARGETS:
+        assert metric_name in catalog, (
+            f"persist target {metric_name!r} is not in fleet_metrics.catalog — "
+            f"would fail catalog.require() at write time"
+        )
+
+
+def test_targets_reference_real_perf_monitor_keys():
+    """The op_key half must match keys actually populated by code under test.
+
+    perf_monitor keys are populated by `record_ms(<key>, elapsed_ms)` calls.
+    We grep the source rather than try to exercise the recording sites here.
+    """
+    import pathlib
+
+    src_root = pathlib.Path(__file__).parent.parent / "src"
+    haystack_files = list(src_root.rglob("*.py"))
+    haystack = "\n".join(p.read_text() for p in haystack_files)
+
+    for op_key, _pct, _metric_name in _PERF_PERSIST_TARGETS:
+        assert op_key in haystack, (
+            f"perf_monitor key {op_key!r} is in persist targets but not recorded "
+            f"anywhere in src/ — persistence task will silently never fire for it"
+        )
+
+
+def test_targets_use_only_supported_percentile_fields():
+    valid = {"count", "avg_ms", "p50_ms", "p95_ms", "p99_ms", "max_ms", "last_ms"}
+    for _op_key, pct_field, _metric_name in _PERF_PERSIST_TARGETS:
+        assert pct_field in valid, f"{pct_field!r} is not a PerfStats field"
+
+
+@pytest.mark.asyncio
+async def test_persist_iteration_writes_present_keys_only(monkeypatch):
+    """Given a partial snapshot, the task records what it can and skips the rest."""
+    import src.background_tasks as bg
+
+    fake_snapshot = {
+        "ode.compute_ms": {
+            "count": 12,
+            "avg_ms": 100.0,
+            "p50_ms": 80.0,
+            "p95_ms": 150.0,
+            "p99_ms": 200.0,
+            "max_ms": 250.0,
+            "last_ms": 90.0,
+        },
+        # Note: lease_plane key intentionally absent → those records skipped.
+    }
+    written: list[tuple[str, float]] = []
+
+    async def fake_record(name: str, value: float):
+        written.append((name, value))
+
+    monkeypatch.setattr(bg, "_PERF_PERSIST_TARGETS", _PERF_PERSIST_TARGETS)
+    # Manually run one iteration of the loop body. Cleaner than awaiting the
+    # while True loop — we are testing the dispatch, not the cadence.
+    for op_key, pct_field, metric_name in _PERF_PERSIST_TARGETS:
+        op_stats = fake_snapshot.get(op_key)
+        if not op_stats:
+            continue
+        value = op_stats.get(pct_field)
+        if value is None:
+            continue
+        await fake_record(metric_name, float(value))
+
+    assert ("ode.compute_ms.p50", 80.0) in written
+    assert ("ode.compute_ms.p99", 200.0) in written
+    # lease_plane absent from fake snapshot → not in written
+    assert all("lease_plane" not in name for name, _ in written)


### PR DESCRIPTION
## Summary

Anchors the load-bearing unknown from `beam-footprint-roadmap-v0.md` v0.3 RESOLUTION (2026-05-05): *"ODE profile is the load-bearing unknown."* The v0.3.1 amendment never landed in the 11 days since because the single `phases.ode_call_ms` timer couldn't distinguish numpy compute from event-loop overhead. This branch adds the decomposition.

- `src/agent_loop_detection.py` — 5 sub-timers inside `process_update_authenticated_async`:
  - `ode.auth_ms` (verify_agent_ownership)
  - `ode.loop_detect_ms` (detect_loop_pattern)
  - `ode.monitor_setup_ms` (get_or_create_monitor + hydrate_from_db_if_fresh)
  - **`ode.numpy_step_ms`** (monitor.process_update — numpy step; wall-clock includes executor queue-wait, named to make that explicit)
  - `ode.persist_ms` / `ode.persist_failed_ms` (increment_update_count + ExecutorPool acquisition; failure-path key for distinct signal)
- `src/background_tasks.py` — new `perf_monitor_persist_task` (5min cadence) + `_PERF_PERSIST_TARGETS` + bootstrap wiring
- `src/fleet_metrics/catalog.py` — 4 new catalog entries (`ode.numpy_step_ms.p50/p99`, `lease_plane.client.v1.lease.acquire.p50/p99`)
- `tests/test_perf_monitor_persist.py` — 4 new tests
- `docs/proposals/ode-profile-decomposition-2026-05-20.md` — 4-reading falsifier matrix

## Council pass

- **Architect**: SHIP with rename + 2 nits folded.
  - Renamed `ode.compute_ms` → `ode.numpy_step_ms` (was naming collision with `phases.ode_call_ms`; "compute" implied pure CPU but timer brackets `run_in_executor`)
  - Doc now names that the "numpy-bound" reading can't disambiguate numpy slowness from executor saturation
- **Reviewer**: BLOCK on `ode.persist_ms` timer starting AFTER `get_db()`. Fixed: moved before the try block; added `ode.persist_failed_ms` in the except branch.
- **Verifier**: 5 of 6 claims verified live; soft-refuted that "4 entries" implies "4 of 5 sub-timers persisted" — only `numpy_step_ms` is persisted, the other 4 are volatile-only (doc now flags this explicitly).

## Test plan

- [x] 56 tests pass (4 new + 52 existing across perf_monitor / fleet_metrics / loop_detection)
- [ ] Confirm `metrics.series` accumulates `ode.numpy_step_ms.p50/p99` rows after server restart (5min cadence)
- [ ] After 7d of steady traffic, evaluate the 4-reading falsifier matrix

## Substrate-question impact

Per `feedback_redraft-cycle-bias-trap.md`: measure-first. Does not redraft Wave 3 RFC. Makes v0.3 RESOLUTION's stop-sign structurally falsifiable for the first time. Shared infra (`perf_monitor_persist_task`) is the bridge from in-process samples to longitudinal `metrics.series` — also used by PR #480 (lease-plane Phase A latency).