### PR TITLE
wave-1: launchd one-shot for 2026-06-02 §129 re-evaluation

### DIFF
--- a/scripts/dev/run_section_129_reeval_one_shot.sh
+++ b/scripts/dev/run_section_129_reeval_one_shot.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# One-shot wrapper for the Wave 1 §129 re-evaluation. Fires at 09:00 MDT on
+# 2026-06-02 (T+14 of the 2026-05-19 anchor) via
+# `com.unitares.wave-1-section-129-reeval` launchd plist.
+#
+# Self-unloads after firing so it doesn't run again on 2027-06-02. The
+# script itself is idempotent against the 2026-05-19 anchor, so a stray
+# re-fire would only re-confirm the same window — but the cleaner UX is to
+# tear down after one shot.
+
+set -u
+
+LABEL="com.unitares.wave-1-section-129-reeval"
+PLIST="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+PROJECT_ROOT="/Users/cirwel/projects/unitares"
+LOG_DIR="${PROJECT_ROOT}/data/logs"
+LOG_FILE="${LOG_DIR}/section_129_reeval_2026-06-02.log"
+
+mkdir -p "$LOG_DIR"
+
+{
+    printf '=== Wave 1 §129 re-evaluation — fired %s ===\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    cd "$PROJECT_ROOT" || exit 2
+    /usr/bin/env python3 scripts/dev/section_129_reeval.py
+    RC=$?
+    printf '\n=== exit code: %d ===\n' "$RC"
+    case "$RC" in
+        0) printf 'verdict: SUBSTANTIVE PASS (all three conditions met)\n' ;;
+        1) printf 'verdict: FAIL — at least one condition not met. Substrate-question evidence; see docs/proposals/beam-footprint-roadmap-v0.md AMENDMENT 2026-05-04.\n' ;;
+        2) printf 'verdict: PENDING (window incomplete — this should not happen on T+14)\n' ;;
+        *) printf 'verdict: ERROR (unexpected exit code)\n' ;;
+    esac
+} >> "$LOG_FILE" 2>&1
+
+# Self-unload via the same launchctl handle that fired this wrapper. The
+# `bootout` form works on macOS 13+; falls back to legacy `unload` if not.
+launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null \
+    || launchctl unload "$PLIST" 2>/dev/null \
+    || true
+
+# Note: deliberately leaving the .plist file on disk for audit trail.
+# Re-arming for a future re-eval is a `launchctl bootstrap gui/$(id -u) <plist>`
+# away with an updated StartCalendarInterval.

--- a/scripts/ops/com.unitares.wave-1-section-129-reeval.plist.template
+++ b/scripts/ops/com.unitares.wave-1-section-129-reeval.plist.template
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    One-shot Wave 1 §129 re-evaluation. Fires at 09:00 local time on
+    June 2 (= 09:00 MDT = 15:00 UTC during Denver summer). Anchored to
+    the 2026-05-19 decorator-fix merge (PR #463); T+14 = 2026-06-02.
+
+    The wrapper at scripts/dev/run_section_129_reeval_one_shot.sh
+    self-unloads after firing so this is effectively one-shot for
+    2026-06-02. The plist file stays on disk as an audit trail; rearm
+    by editing the calendar interval and `launchctl bootstrap` again.
+
+    Before installing, substitute placeholders:
+      __UNITARES_ROOT__  → absolute path to your unitares checkout
+      __HOME__           → your $HOME (expanded absolute path)
+
+    Example:
+      sed -e "s|__UNITARES_ROOT__|$HOME/projects/unitares|g" \
+          -e "s|__HOME__|$HOME|g" \
+          scripts/ops/com.unitares.wave-1-section-129-reeval.plist.template \
+          > ~/Library/LaunchAgents/com.unitares.wave-1-section-129-reeval.plist
+      launchctl bootstrap gui/$(id -u) \
+          ~/Library/LaunchAgents/com.unitares.wave-1-section-129-reeval.plist
+
+    Cross-references:
+      - docs/proposals/wave-1-window-evaluation-T0-2026-05-19.md
+      - docs/proposals/wave-1-window-evaluation-2026-05-18.md
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.unitares.wave-1-section-129-reeval</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__UNITARES_ROOT__/scripts/dev/run_section_129_reeval_one_shot.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__UNITARES_ROOT__</string>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Month</key>
+        <integer>6</integer>
+        <key>Day</key>
+        <integer>2</integer>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>__UNITARES_ROOT__/data/logs/section_129_reeval_launchd.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__UNITARES_ROOT__/data/logs/section_129_reeval_launchd.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>GOVERNANCE_DATABASE_URL</key>
+        <string>postgresql://postgres:postgres@localhost:5432/governance</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Companion to #479. Schedules `section_129_reeval.py` to fire at 09:00 MDT on 2026-06-02 (T+14 of the 2026-05-19 anchor) via launchd, then self-unload after firing.

- `scripts/dev/run_section_129_reeval_one_shot.sh` — wrapper. Runs the script, tags result by exit code (0=PASS, 1=FAIL, 2=PENDING), `launchctl bootout`s itself.
- `scripts/ops/com.unitares.wave-1-section-129-reeval.plist.template` — follows the `chronicler.plist.template` idiom. Operator deploys with `sed` substitution + `launchctl bootstrap`.

The plist is already loaded on the operator's machine and verified registered with launchd (`state = not running`, calendar interval armed). This PR just lands the artifacts in-repo so they're not orphaned.

## Test plan

- [x] Wrapper runs cleanly when invoked directly (tested via `bash run_section_129_reeval_one_shot.sh`)
- [x] Plist loads via `launchctl bootstrap` without error
- [ ] Fires at 09:00 MDT on 2026-06-02 — write-once log appears at `data/logs/section_129_reeval_2026-06-02.log`