### PR TITLE
fix(#424): close phases.py rogue thread_id mint path

### DIFF
--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -768,6 +768,108 @@ async def prepare_unlocked_inputs(ctx: UpdateContext) -> None:
             )
 
 
+async def _track_thread_identity(ctx: "UpdateContext") -> bool:
+    """Resolve `ctx.meta.thread_id` + `node_index` for a (possibly) new session.
+
+    Closes #424 (\"two independent thread_id mint paths\"). The previous
+    implementation called ``uuid.uuid4()`` mid-update whenever the in-memory
+    metadata cache had no thread_id — producing a UUID-format id that
+    conflicted with onboard's ``t-<sha16>`` format and resetting node_index
+    to 1 even when the durable PG record knew otherwise. The 2026-05-08
+    trace showed the path was reachable on a 30s session-resolve-miss
+    cadence in normal operation, not a rare race.
+
+    Resolution order (no random mints):
+
+    1. In-memory ``ctx.meta`` already has ``thread_id``. Use it; only bump
+       ``node_index`` and stamp ``active_session_key``.
+
+    2. ``ctx.meta`` lacks ``thread_id`` → read ``core.identities.metadata``
+       for the durable copy. The onboard-time persist may have committed
+       there even when the in-memory cache hadn't been rehydrated yet
+       (fresh process-instance, IP+UA fingerprint resolve, etc.).
+
+    3. PG also empty → derive deterministically from ``ctx.session_key``
+       via ``generate_thread_id`` — the exact function onboard uses, so
+       the format stays consistent. This is the final \"no random UUID\"
+       guarantee.
+
+    Returns True when the session-key actually changed and downstream
+    re-stamp/persist effects should fire; False on a no-op (already
+    tracking the same session).
+
+    **Known durable-state gap (not addressed here).** Live-verifier 2026-05-20:
+    ~35% of ``core.identities.metadata.thread_id`` rows already carry
+    UUID-format values from the broken mint path that pre-dated this fix
+    (886 of 2521 rows). Step 1 will read those back unchanged. Healing
+    them retroactively would silently change identity for 886 agents — a
+    bigger blast radius than this PR — so it is intentionally deferred to
+    a separate cleanup pass.
+    """
+    if not (ctx.meta and ctx.session_key):
+        return False
+    if getattr(ctx.meta, "active_session_key", None) == ctx.session_key:
+        return False
+
+    # Step 1: hydrate from durable PG metadata when the in-memory cache is
+    # empty. ExecutorPool means we can `await` asyncpg directly here without
+    # the locked-update concern (per CLAUDE.md post-PR-#218 note).
+    if not getattr(ctx.meta, "thread_id", None) and ctx.agent_uuid:
+        try:
+            from src.db import get_db
+            identity_record = await get_db().get_identity(ctx.agent_uuid)
+            if identity_record and identity_record.metadata:
+                persisted_thread_id = identity_record.metadata.get("thread_id")
+                persisted_node_index = identity_record.metadata.get("node_index")
+                persisted_session_key = identity_record.metadata.get(
+                    "active_session_key"
+                )
+                if persisted_thread_id:
+                    ctx.meta.thread_id = persisted_thread_id
+                if persisted_node_index is not None and not getattr(
+                    ctx.meta, "node_index", None
+                ):
+                    ctx.meta.node_index = persisted_node_index
+                if persisted_session_key is not None and getattr(
+                    ctx.meta, "active_session_key", None
+                ) is None:
+                    ctx.meta.active_session_key = persisted_session_key
+        except Exception as e:
+            logger.debug(
+                "thread_id PG hydration skipped for %s...: %s",
+                (ctx.agent_uuid or "?")[:8], e,
+            )
+
+    # Re-check after hydration: caller may have just adopted the session
+    # already (rare — only if PG had the exact same active_session_key).
+    if getattr(ctx.meta, "active_session_key", None) == ctx.session_key:
+        return False
+
+    # Step 2: deterministic fallback if still no thread_id. Matches onboard
+    # format; never invents a random UUID.
+    if not getattr(ctx.meta, "thread_id", None):
+        from src.thread_identity import generate_thread_id
+        ctx.meta.thread_id = generate_thread_id(ctx.session_key)
+        logger.info(
+            "[PROCESS_UPDATE] thread_id fallback-derived from session_key "
+            "(no in-memory cache or PG record): %s... agent=%s...",
+            ctx.meta.thread_id[:8],
+            (ctx.agent_uuid or "?")[:8],
+        )
+
+    # node_index bookkeeping. Re-entry into the same session leaves
+    # position alone (first branch); a session transition with a tracked
+    # prior session bumps (second branch). The PG hydration above already
+    # imported persisted_node_index when present, so process-restart no
+    # longer silently loses position continuity.
+    if getattr(ctx.meta, "active_session_key", None) is None:
+        ctx.meta.node_index = getattr(ctx.meta, "node_index", None) or 1
+    else:
+        ctx.meta.node_index = (getattr(ctx.meta, "node_index", None) or 1) + 1
+    ctx.meta.active_session_key = ctx.session_key
+    return True
+
+
 async def _persist_thread_identity_async(agent_uuid: str, metadata: dict) -> None:
     """Fire-and-forget thread-identity metadata persist. Eventual consistency
     is fine: in-memory ctx.meta is the source of truth within this process,
@@ -945,47 +1047,41 @@ async def execute_locked_update(ctx: UpdateContext) -> Optional[Sequence[TextCon
     except Exception as e:
         logger.debug(f"Baseline preload skipped: {e}")
 
-    # Track Thread Identity across sessions
-    if ctx.meta and ctx.session_key:
-        if getattr(ctx.meta, "active_session_key", None) != ctx.session_key:
-            import uuid
-            if not getattr(ctx.meta, "thread_id", None):
-                ctx.meta.thread_id = str(uuid.uuid4())
-            if getattr(ctx.meta, "active_session_key", None) is None:
-                ctx.meta.node_index = getattr(ctx.meta, "node_index", None) or 1
-            else:
-                ctx.meta.node_index = (getattr(ctx.meta, "node_index", None) or 1) + 1
-            ctx.meta.active_session_key = ctx.session_key
+    # Track Thread Identity across sessions. See `_track_thread_identity` for
+    # the #424 fix: no random-UUID mint mid-update; hydrate from PG, then fall
+    # back to deterministic derivation from session_key (matches onboard).
+    session_changed = await _track_thread_identity(ctx)
 
-            # Re-stamp R6 fork fields into the durable S22 envelope using the
-            # post-mutation node_index. The early stamp at prepare_unlocked_inputs
-            # ran before this block bumped node_index, so without the re-stamp
-            # a fresh-session transition would persist episode_fork_kind="none"
-            # while enrich_thread_identity (order=230) returns "sibling_locus"
-            # in the response. See _restamp_fork_after_thread_identity_update.
-            _restamp_fork_after_thread_identity_update(ctx)
+    if session_changed:
+        # Re-stamp R6 fork fields into the durable S22 envelope using the
+        # post-mutation node_index. The early stamp at prepare_unlocked_inputs
+        # ran before this block bumped node_index, so without the re-stamp
+        # a fresh-session transition would persist episode_fork_kind="none"
+        # while enrich_thread_identity (order=230) returns "sibling_locus"
+        # in the response. See _restamp_fork_after_thread_identity_update.
+        _restamp_fork_after_thread_identity_update(ctx)
 
-            # Fire-and-forget: PG metadata persist doesn't need to hold the
-            # agent lock. In-memory ctx.meta has already been mutated above
-            # and is the process-local source of truth; PG copy is for
-            # cross-process visibility. Same pattern as PR #360.
-            try:
-                _thread_metadata_snapshot = {
-                    "thread_id": ctx.meta.thread_id,
-                    "node_index": ctx.meta.node_index,
-                    "active_session_key": ctx.meta.active_session_key,
-                }
-                _spawn_persist_task(
-                    _persist_thread_identity_async(ctx.agent_uuid, _thread_metadata_snapshot),
-                    name="persist_thread_identity",
-                )
-            except RuntimeError:
-                # No running loop — extremely unusual for this code path
-                # since we're inside an async handler. Swallow per the
-                # PR #360 precedent.
-                pass
-            except Exception as e:
-                logger.debug(f"Could not schedule thread identity persist: {e}")
+        # Fire-and-forget: PG metadata persist doesn't need to hold the
+        # agent lock. In-memory ctx.meta has already been mutated above
+        # and is the process-local source of truth; PG copy is for
+        # cross-process visibility. Same pattern as PR #360.
+        try:
+            _thread_metadata_snapshot = {
+                "thread_id": ctx.meta.thread_id,
+                "node_index": ctx.meta.node_index,
+                "active_session_key": ctx.meta.active_session_key,
+            }
+            _spawn_persist_task(
+                _persist_thread_identity_async(ctx.agent_uuid, _thread_metadata_snapshot),
+                name="persist_thread_identity",
+            )
+        except RuntimeError:
+            # No running loop — extremely unusual for this code path
+            # since we're inside an async handler. Swallow per the
+            # PR #360 precedent.
+            pass
+        except Exception as e:
+            logger.debug(f"Could not schedule thread identity persist: {e}")
 
     # Per-agent anomaly detection: add entropy if current signals deviate from baseline
     try:

--- a/tests/test_phases_thread_identity_tracking.py
+++ b/tests/test_phases_thread_identity_tracking.py
@@ -1,0 +1,237 @@
+"""Tests for `_track_thread_identity` — issue #424 closure.
+
+The original mid-update mint path produced two bugs simultaneously:
+  - UUID-format thread_id (vs. onboard's ``t-<sha16>``) on the same session
+  - node_index reset to 1 even when the durable record knew otherwise
+
+These tests pin the post-fix invariants:
+  1. No random UUIDs ever appear in ctx.meta.thread_id from this code path.
+  2. Durable PG metadata is consulted before any fallback mint.
+  3. Fallback minting uses the deterministic `generate_thread_id` function
+     (matches onboard).
+  4. node_index continuity is preserved across process restarts when PG has
+     the persisted value (no silent reset to 1).
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# Lightweight stand-in for AgentMetadata — only the attrs the helper reads.
+@dataclass
+class _FakeMeta:
+    thread_id: Optional[str] = None
+    node_index: Optional[int] = None
+    active_session_key: Optional[str] = None
+
+
+def _make_ctx(
+    *,
+    meta: Optional[_FakeMeta],
+    session_key: Optional[str],
+    agent_uuid: str = "11111111-1111-1111-1111-111111111111",
+):
+    ctx = MagicMock()
+    ctx.meta = meta
+    ctx.session_key = session_key
+    ctx.agent_uuid = agent_uuid
+    return ctx
+
+
+def _identity_record(metadata: dict) -> Any:
+    rec = MagicMock()
+    rec.metadata = metadata
+    return rec
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Guards
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestTrackThreadIdentityGuards:
+    @pytest.mark.asyncio
+    async def test_no_meta_returns_false(self):
+        from src.mcp_handlers.updates.phases import _track_thread_identity
+        ctx = _make_ctx(meta=None, session_key="mcp:abc")
+        assert await _track_thread_identity(ctx) is False
+
+    @pytest.mark.asyncio
+    async def test_no_session_key_returns_false(self):
+        from src.mcp_handlers.updates.phases import _track_thread_identity
+        ctx = _make_ctx(meta=_FakeMeta(), session_key=None)
+        assert await _track_thread_identity(ctx) is False
+
+    @pytest.mark.asyncio
+    async def test_same_session_key_is_noop(self):
+        from src.mcp_handlers.updates.phases import _track_thread_identity
+        meta = _FakeMeta(
+            thread_id="t-abcdef0123456789",
+            node_index=7,
+            active_session_key="mcp:abc",
+        )
+        ctx = _make_ctx(meta=meta, session_key="mcp:abc")
+        assert await _track_thread_identity(ctx) is False
+        # Nothing mutated
+        assert meta.thread_id == "t-abcdef0123456789"
+        assert meta.node_index == 7
+        assert meta.active_session_key == "mcp:abc"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# #424 regression: no random UUIDs
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestNoRandomUuidMintRegression:
+    @pytest.mark.asyncio
+    async def test_empty_in_memory_and_pg_falls_back_to_session_key_derivation(self):
+        """The #424 worst case: no thread_id in memory, no PG record.
+
+        Old behavior: ``uuid.uuid4()`` produced a UUID-format id, position-1.
+        New behavior: deterministic derivation from session_key — same format
+        as onboard's ``generate_thread_id``.
+        """
+        from src.mcp_handlers.updates.phases import _track_thread_identity
+        from src.thread_identity import generate_thread_id
+
+        meta = _FakeMeta()  # all None
+        ctx = _make_ctx(meta=meta, session_key="mcp:fresh-session-xyz")
+        fake_db = MagicMock()
+        fake_db.get_identity = AsyncMock(return_value=None)
+
+        with patch("src.db.get_db", return_value=fake_db):
+            changed = await _track_thread_identity(ctx)
+
+        assert changed is True
+        # Format guarantee: matches onboard's t-<sha16> shape
+        assert meta.thread_id.startswith("t-")
+        assert len(meta.thread_id) == 18  # "t-" + 16 hex
+        # Format is deterministic — same call twice produces the same id
+        assert meta.thread_id == generate_thread_id("mcp:fresh-session-xyz")
+        # No UUID-format strings (UUID has hyphens at fixed positions)
+        assert meta.thread_id.count("-") == 1
+        # node_index = 1 because active_session_key was None pre-call
+        assert meta.node_index == 1
+        assert meta.active_session_key == "mcp:fresh-session-xyz"
+
+    @pytest.mark.asyncio
+    async def test_pg_hydration_wins_over_fallback(self):
+        """When PG has a thread_id, the fallback derivation must NOT fire."""
+        from src.mcp_handlers.updates.phases import _track_thread_identity
+
+        meta = _FakeMeta()
+        ctx = _make_ctx(meta=meta, session_key="mcp:new-session")
+        fake_db = MagicMock()
+        fake_db.get_identity = AsyncMock(
+            return_value=_identity_record({
+                "thread_id": "t-persistedfromonbo",
+                "node_index": 5,
+                "active_session_key": "mcp:prior-session",
+            })
+        )
+
+        with patch("src.db.get_db", return_value=fake_db):
+            changed = await _track_thread_identity(ctx)
+
+        assert changed is True
+        assert meta.thread_id == "t-persistedfromonbo"
+        # node_index bumped from 5 → 6 because active_session_key existed
+        assert meta.node_index == 6
+        assert meta.active_session_key == "mcp:new-session"
+
+    @pytest.mark.asyncio
+    async def test_pg_hydration_preserves_node_index_continuity(self):
+        """Process restart: in-memory empty, PG has node_index=4. The bump
+        must reflect prior continuity, not reset to 1."""
+        from src.mcp_handlers.updates.phases import _track_thread_identity
+
+        meta = _FakeMeta()
+        ctx = _make_ctx(meta=meta, session_key="mcp:after-restart-session")
+        fake_db = MagicMock()
+        fake_db.get_identity = AsyncMock(
+            return_value=_identity_record({
+                "thread_id": "t-restartcontinuity",
+                "node_index": 4,
+                "active_session_key": "mcp:pre-restart-session",
+            })
+        )
+
+        with patch("src.db.get_db", return_value=fake_db):
+            await _track_thread_identity(ctx)
+
+        # Continuity: 4 → 5, NOT 1 → 2
+        assert meta.node_index == 5
+
+    @pytest.mark.asyncio
+    async def test_pg_lookup_failure_falls_back_safely(self):
+        """A DB error during hydration must not crash the update — fall back
+        to deterministic derivation, log, and proceed."""
+        from src.mcp_handlers.updates.phases import _track_thread_identity
+
+        meta = _FakeMeta()
+        ctx = _make_ctx(meta=meta, session_key="mcp:fault-tolerant")
+        fake_db = MagicMock()
+        fake_db.get_identity = AsyncMock(side_effect=RuntimeError("pg unreachable"))
+
+        with patch("src.db.get_db", return_value=fake_db):
+            changed = await _track_thread_identity(ctx)
+
+        assert changed is True
+        assert meta.thread_id.startswith("t-")
+        assert len(meta.thread_id) == 18
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Happy path: in-memory cache already populated
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestInMemoryCachePopulated:
+    @pytest.mark.asyncio
+    async def test_no_pg_lookup_when_in_memory_thread_id_present(self):
+        """If ctx.meta.thread_id is already populated, do NOT round-trip to PG."""
+        from src.mcp_handlers.updates.phases import _track_thread_identity
+
+        meta = _FakeMeta(
+            thread_id="t-inmemory12345678",
+            node_index=2,
+            active_session_key="mcp:old-session",
+        )
+        ctx = _make_ctx(meta=meta, session_key="mcp:new-session")
+        fake_db = MagicMock()
+        fake_db.get_identity = AsyncMock()
+
+        with patch("src.db.get_db", return_value=fake_db):
+            changed = await _track_thread_identity(ctx)
+
+        # Did not call PG
+        fake_db.get_identity.assert_not_called()
+        assert changed is True
+        assert meta.thread_id == "t-inmemory12345678"
+        # 2 → 3 (active_session_key was non-None)
+        assert meta.node_index == 3
+        assert meta.active_session_key == "mcp:new-session"
+
+    @pytest.mark.asyncio
+    async def test_first_session_with_thread_id_sets_position_1(self):
+        """First-time session adoption: active_session_key was None → position 1."""
+        from src.mcp_handlers.updates.phases import _track_thread_identity
+
+        meta = _FakeMeta(
+            thread_id="t-firstcontactxxxx",
+            node_index=None,
+            active_session_key=None,
+        )
+        ctx = _make_ctx(meta=meta, session_key="mcp:first")
+
+        # No PG call needed (thread_id already present)
+        changed = await _track_thread_identity(ctx)
+
+        assert changed is True
+        assert meta.thread_id == "t-firstcontactxxxx"
+        assert meta.node_index == 1
+        assert meta.active_session_key == "mcp:first"


### PR DESCRIPTION
Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.