### PR TITLE
feat(watcher): findings lease gate

### DIFF
--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -36,6 +36,9 @@ Design notes:
       30s server-side ceiling and drops token counts; direct Ollama is the
       natural path for a local-LLM pattern scanner.
     - Env-configurable: WATCHER_MODEL, WATCHER_TIMEOUT, WATCHER_OLLAMA_URL.
+    - Findings-state mutations acquire the lease-plane surface for
+      data/watcher. Default is advisory; set WATCHER_FINDINGS_LEASE_MODE=enforce
+      to block on held_by_other / unavailable lease outcomes.
     - Findings are append-only; lifecycle (resolved/dismissed/aged-out) happens
       via the surface hook and explicit user action.
 """
@@ -50,6 +53,7 @@ import subprocess
 import sys
 import time
 import urllib.request
+from collections.abc import Callable
 from dataclasses import asdict, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -115,6 +119,12 @@ OLLAMA_URL = os.environ.get(
 )
 DEFAULT_MODEL = os.environ.get("WATCHER_MODEL", "qwen3-coder-next:latest")
 DEFAULT_TIMEOUT = int(os.environ.get("WATCHER_TIMEOUT", "90"))
+
+WATCHER_FINDINGS_LEASE_MODE_ENV = "WATCHER_FINDINGS_LEASE_MODE"
+WATCHER_FINDINGS_LEASE_TTL_ENV = "WATCHER_FINDINGS_LEASE_TTL_S"
+WATCHER_FINDINGS_LEASE_DEFAULT_TTL_S = 120
+WATCHER_FINDINGS_LEASE_BLOCK_RC = 3
+_LEASE_ACQUIRED_OUTCOMES = {"acquired_new", "acquired_idempotent"}
 
 # How many lines of context to include when no explicit region is given.
 # Qwen3-Coder-Next (the current default detector) has a 256K context window,
@@ -312,6 +322,174 @@ def _make_identity_client():
     """Create a SyncGovernanceClient for identity resolution."""
     from unitares_sdk import SyncGovernanceClient
     return SyncGovernanceClient(rest_url=GOV_REST_URL, transport="rest", timeout=30)
+
+
+# ---------------------------------------------------------------------------
+# Lease-plane guard for Watcher findings mutations
+# ---------------------------------------------------------------------------
+
+
+def _watcher_findings_surface_id() -> str:
+    """Canonical lease surface for the local Watcher state directory."""
+    return f"file://{STATE_DIR}"
+
+
+def _watcher_findings_lease_mode() -> str:
+    raw = os.environ.get(
+        WATCHER_FINDINGS_LEASE_MODE_ENV,
+        os.environ.get("WATCHER_LEASE_MODE", "advisory"),
+    )
+    mode = raw.strip().lower()
+    if mode in ("", "advisory", "advise", "phase_a", "phase-a"):
+        return "advisory"
+    if mode in ("enforce", "enforced", "required", "phase_b", "phase-b"):
+        return "enforce"
+    if mode in ("off", "disable", "disabled", "none"):
+        return "off"
+    log(
+        f"{WATCHER_FINDINGS_LEASE_MODE_ENV}: unknown mode {raw!r}; "
+        "falling back to advisory",
+        "warning",
+    )
+    return "advisory"
+
+
+def _watcher_findings_lease_ttl_s() -> int:
+    raw = os.environ.get(
+        WATCHER_FINDINGS_LEASE_TTL_ENV,
+        str(WATCHER_FINDINGS_LEASE_DEFAULT_TTL_S),
+    )
+    try:
+        ttl_s = int(raw)
+    except ValueError:
+        log(
+            f"{WATCHER_FINDINGS_LEASE_TTL_ENV}: invalid value {raw!r}; "
+            f"using {WATCHER_FINDINGS_LEASE_DEFAULT_TTL_S}s",
+            "warning",
+        )
+        return WATCHER_FINDINGS_LEASE_DEFAULT_TTL_S
+    if ttl_s <= 0 or ttl_s > 3600:
+        log(
+            f"{WATCHER_FINDINGS_LEASE_TTL_ENV}: out of range {ttl_s}; "
+            f"using {WATCHER_FINDINGS_LEASE_DEFAULT_TTL_S}s",
+            "warning",
+        )
+        return WATCHER_FINDINGS_LEASE_DEFAULT_TTL_S
+    return ttl_s
+
+
+def _watcher_findings_holder_uuid(agent_id: str | None):
+    """Use the operator/Watcher UUID when valid; otherwise mint a process UUID."""
+    from uuid import UUID
+
+    from src.lease_plane.advisory import new_holder_uuid
+
+    identity = get_watcher_identity() or {}
+    for candidate in (agent_id, identity.get("agent_uuid")):
+        if not candidate:
+            continue
+        try:
+            return UUID(candidate)
+        except ValueError:
+            log(f"watcher lease: invalid holder UUID {candidate!r}; ignoring", "warning")
+    return new_holder_uuid()
+
+
+def _run_with_watcher_findings_lease(
+    intent: str,
+    mutation: Callable[[], int],
+    *,
+    holder_agent_id: str | None = None,
+) -> int:
+    """Run a Watcher state mutation under the lease plane.
+
+    Default mode is Phase A advisory: the mutation still runs when the lease
+    plane is unavailable or contended. Setting WATCHER_FINDINGS_LEASE_MODE to
+    `enforce` promotes this one surface to Phase B-style caller enforcement.
+    """
+    mode = _watcher_findings_lease_mode()
+    if mode == "off":
+        return mutation()
+
+    from src.lease_plane import (
+        AcquireHeldByOther,
+        AcquireOk,
+        AcquirePermissionDenied,
+        AcquireRequest,
+        AcquireSchemaInvalid,
+        AcquireServiceUnavailable,
+    )
+    from src.lease_plane.advisory import make_advisory_client, release_advisory
+
+    client = make_advisory_client()
+    lease_id = None
+    surface_id = _watcher_findings_surface_id()
+    audit_session = (get_watcher_identity() or {}).get("client_session_id") or None
+
+    try:
+        result = client.acquire(
+            AcquireRequest(
+                surface_id=surface_id,
+                holder_agent_uuid=_watcher_findings_holder_uuid(holder_agent_id),
+                holder_class="process_instance",
+                holder_kind="remote_heartbeat",
+                ttl_s=_watcher_findings_lease_ttl_s(),
+                intent=intent,
+                audit_session=audit_session,
+            )
+        )
+    except Exception as exc:  # defensive; LeasePlaneClient should be no-raise
+        outcome = "client_error"
+        detail = f"client_error err={exc!r}"
+    else:
+        if isinstance(result, AcquireOk):
+            outcome = "acquired_idempotent" if result.idempotent else "acquired_new"
+            detail = f"{outcome} lease_id={result.lease.lease_id}"
+            lease_id = result.lease.lease_id
+        elif isinstance(result, AcquireHeldByOther):
+            outcome = "held_by_other"
+            detail = (
+                f"held_by_other held_by={result.held_by_uuid} "
+                f"blocking_lease={result.blocking_lease_id} "
+                f"expires_at={result.expires_at.isoformat()} "
+                f"retry_after_hint_ms={result.retry_after_hint_ms}"
+            )
+        elif isinstance(result, AcquirePermissionDenied):
+            outcome = "permission_denied"
+            detail = f"permission_denied reason={result.reason}"
+        elif isinstance(result, AcquireSchemaInvalid):
+            outcome = "schema_invalid"
+            detail = f"schema_invalid detail={result.detail}"
+        elif isinstance(result, AcquireServiceUnavailable):
+            outcome = "service_unavailable"
+            detail = "service_unavailable"
+        else:
+            outcome = "client_error"
+            detail = f"unrecognized_result result={result!r}"
+
+    if outcome == "held_by_other":
+        print(
+            f"warning: watcher findings lease {detail} for {surface_id}",
+            file=sys.stderr,
+        )
+    if mode == "enforce" and outcome not in _LEASE_ACQUIRED_OUTCOMES:
+        print(
+            f"error: watcher findings mutation blocked: {detail} "
+            f"surface={surface_id} intent={intent!r}",
+            file=sys.stderr,
+        )
+        log(
+            f"watcher findings mutation blocked by lease: {detail} "
+            f"surface={surface_id} intent={intent!r}",
+            "warning",
+        )
+        return WATCHER_FINDINGS_LEASE_BLOCK_RC
+
+    try:
+        return mutation()
+    finally:
+        if lease_id is not None:
+            release_advisory(client, lease_id)
 
 
 # ---------------------------------------------------------------------------
@@ -1833,7 +2011,7 @@ def list_findings(only_open: bool = False) -> int:
     return 0
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="UNITARES Watcher bug-pattern agent")
     parser.add_argument("--file", help="file to scan")
     parser.add_argument("--region", help="line range within file, e.g. L10-L40")
@@ -1923,7 +2101,7 @@ def main() -> int:
         default="30 days ago",
         help='git --since=<value> for --scan-commits (default: "30 days ago")',
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     # --- Identity resolution (best-effort) ---
     try:
@@ -1937,21 +2115,47 @@ def main() -> int:
     if args.list_findings:
         return list_findings(only_open=args.only_open)
     if args.resolve:
-        return update_finding_status(
-            args.resolve, "confirmed", resolver_agent_id=args.agent_id, reason=args.reason
+        return _run_with_watcher_findings_lease(
+            f"resolve {args.resolve}",
+            lambda: update_finding_status(
+                args.resolve,
+                "confirmed",
+                resolver_agent_id=args.agent_id,
+                reason=args.reason,
+            ),
+            holder_agent_id=args.agent_id,
         )
     if args.dismiss:
-        return update_finding_status(
-            args.dismiss, "dismissed", resolver_agent_id=args.agent_id, reason=args.reason
+        return _run_with_watcher_findings_lease(
+            f"dismiss {args.dismiss}",
+            lambda: update_finding_status(
+                args.dismiss,
+                "dismissed",
+                resolver_agent_id=args.agent_id,
+                reason=args.reason,
+            ),
+            holder_agent_id=args.agent_id,
         )
     if args.sweep_stale:
-        return sweep_stale_findings()
+        return _run_with_watcher_findings_lease(
+            "sweep stale findings",
+            sweep_stale_findings,
+            holder_agent_id=args.agent_id,
+        )
     if args.compact:
-        return compact_findings(max_age_days=args.compact_days)
+        return _run_with_watcher_findings_lease(
+            f"compact findings older than {args.compact_days}d",
+            lambda: compact_findings(max_age_days=args.compact_days),
+            holder_agent_id=args.agent_id,
+        )
     if args.print_unresolved:
         return print_unresolved()
     if args.surface_pending:
-        return surface_pending()
+        return _run_with_watcher_findings_lease(
+            "surface pending findings",
+            surface_pending,
+            holder_agent_id=args.agent_id,
+        )
     if args.scan_commits:
         return 0 if scan_commits(since=args.scan_since) >= 0 else 1
     if args.recompute_floor:

--- a/agents/watcher/tests/test_agent.py
+++ b/agents/watcher/tests/test_agent.py
@@ -25,6 +25,7 @@ import json
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from uuid import uuid4
 
 import pytest
 
@@ -937,6 +938,189 @@ def test_update_finding_status_omits_reason_when_not_provided(watcher_module):
     row = watcher_module._iter_findings_raw()[0]
     assert "resolution_reason" not in row
     assert "resolved_by" not in row
+
+
+# --- Watcher findings lease gate -------------------------------------------
+
+
+class _FakeLeaseClient:
+    def __init__(self, result):
+        self.result = result
+        self.acquire_requests = []
+        self.release_requests = []
+
+    def acquire(self, request):
+        self.acquire_requests.append(request)
+        return self.result
+
+    def release(self, request):
+        from src.lease_plane import SimpleOk
+
+        self.release_requests.append(request)
+        return SimpleOk(ok=True)
+
+
+def _held_by_other_result():
+    from src.lease_plane import AcquireHeldByOther
+
+    return AcquireHeldByOther(
+        ok=False,
+        error="held_by_other",
+        surface_id="file:///tmp/watcher-state",
+        blocking_lease_id=uuid4(),
+        held_by_uuid=uuid4(),
+        expires_at=datetime.now(timezone.utc) + timedelta(seconds=30),
+        retry_after_hint_ms=250,
+    )
+
+
+def _acquire_ok_result():
+    from src.lease_plane import AcquireOk, LeaseRecord
+
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    return AcquireOk(
+        ok=True,
+        idempotent=False,
+        drift_warning=[],
+        lease=LeaseRecord(
+            lease_id=uuid4(),
+            surface_id="file:///tmp/watcher-state",
+            surface_kind="file",
+            holder_agent_uuid=uuid4(),
+            holder_class="process_instance",
+            holder_kind="remote_heartbeat",
+            holder_pid=None,
+            heartbeat_required=True,
+            intent="unit-test mutation",
+            acquired_at=now,
+            expires_at=now + timedelta(seconds=120),
+            last_heartbeat_at=now,
+            released_at=None,
+            release_reason=None,
+            audit_session=None,
+            original_ttl_s=120,
+            earned_status="provisional",
+        ),
+    )
+
+
+def test_watcher_findings_lease_advisory_runs_when_held_by_other(
+    watcher_module, monkeypatch, capsys
+):
+    from src.lease_plane import advisory as advisory_module
+
+    result = _held_by_other_result()
+    client = _FakeLeaseClient(result)
+    monkeypatch.setattr(advisory_module, "make_advisory_client", lambda: client)
+    monkeypatch.delenv(watcher_module.WATCHER_FINDINGS_LEASE_MODE_ENV, raising=False)
+
+    calls = []
+    rc = watcher_module._run_with_watcher_findings_lease(
+        "unit-test mutation",
+        lambda: calls.append("ran") or 0,
+        holder_agent_id=str(uuid4()),
+    )
+
+    assert rc == 0
+    assert calls == ["ran"]
+    assert len(client.acquire_requests) == 1
+    assert client.release_requests == []
+    captured = capsys.readouterr()
+    assert "held_by_other" in captured.err
+    assert str(result.held_by_uuid) in captured.err
+    assert str(result.blocking_lease_id) in captured.err
+
+
+def test_watcher_findings_lease_enforcement_blocks_when_held_by_other(
+    watcher_module, monkeypatch, capsys
+):
+    from src.lease_plane import advisory as advisory_module
+
+    result = _held_by_other_result()
+    client = _FakeLeaseClient(result)
+    monkeypatch.setattr(advisory_module, "make_advisory_client", lambda: client)
+    monkeypatch.setenv(watcher_module.WATCHER_FINDINGS_LEASE_MODE_ENV, "enforce")
+
+    calls = []
+    rc = watcher_module._run_with_watcher_findings_lease(
+        "unit-test mutation",
+        lambda: calls.append("ran") or 0,
+        holder_agent_id=str(uuid4()),
+    )
+
+    assert rc == watcher_module.WATCHER_FINDINGS_LEASE_BLOCK_RC
+    assert calls == []
+    assert len(client.acquire_requests) == 1
+    assert client.release_requests == []
+    captured = capsys.readouterr()
+    assert "mutation blocked" in captured.err
+    assert str(result.held_by_uuid) in captured.err
+
+
+def test_watcher_findings_lease_enforcement_runs_and_releases_when_acquired(
+    watcher_module, monkeypatch
+):
+    from src.lease_plane import advisory as advisory_module
+
+    result = _acquire_ok_result()
+    client = _FakeLeaseClient(result)
+    monkeypatch.setattr(advisory_module, "make_advisory_client", lambda: client)
+    monkeypatch.setenv(watcher_module.WATCHER_FINDINGS_LEASE_MODE_ENV, "enforce")
+
+    calls = []
+    rc = watcher_module._run_with_watcher_findings_lease(
+        "unit-test mutation",
+        lambda: calls.append("ran") or 0,
+        holder_agent_id=str(uuid4()),
+    )
+
+    assert rc == 0
+    assert calls == ["ran"]
+    assert len(client.acquire_requests) == 1
+    assert len(client.release_requests) == 1
+    assert client.release_requests[0].lease_id == result.lease.lease_id
+
+
+def test_main_resolve_routes_through_findings_lease_wrapper(
+    watcher_module, monkeypatch
+):
+    resolver = str(uuid4())
+    _seed_findings(watcher_module, [_make_raw_entry("aaaaaaaaaaaaaaaa")])
+    monkeypatch.setattr(watcher_module, "_make_identity_client", lambda: object())
+    monkeypatch.setattr(watcher_module, "resolve_identity", lambda _client: None)
+
+    seen = {}
+
+    def fake_lease_wrapper(intent, mutation, *, holder_agent_id=None):
+        seen["intent"] = intent
+        seen["holder_agent_id"] = holder_agent_id
+        return mutation()
+
+    monkeypatch.setattr(
+        watcher_module,
+        "_run_with_watcher_findings_lease",
+        fake_lease_wrapper,
+    )
+
+    rc = watcher_module.main(
+        ["--resolve", "aaaaaaaa", "--agent-id", resolver, "--reason", "fixed"]
+    )
+
+    assert rc == 0
+    assert seen == {"intent": "resolve aaaaaaaa", "holder_agent_id": resolver}
+
+
+def test_main_print_unresolved_is_read_only_and_unleased(watcher_module, monkeypatch):
+    _seed_findings(watcher_module, [_make_raw_entry("aaaaaaaaaaaaaaaa")])
+    monkeypatch.setattr(watcher_module, "_make_identity_client", lambda: object())
+    monkeypatch.setattr(watcher_module, "resolve_identity", lambda _client: None)
+    monkeypatch.setattr(
+        watcher_module,
+        "_run_with_watcher_findings_lease",
+        lambda *a, **kw: (_ for _ in ()).throw(AssertionError("unexpected lease")),
+    )
+
+    assert watcher_module.main(["--print-unresolved"]) == 0
 
 
 # --- sweep_stale_findings ---------------------------------------------------


### PR DESCRIPTION
Surfaced from stale-branch cleanup (branch tip 2026-05-05, never PR'd). Confirmed unique work not in master and merges cleanly.

## What's in the branch
- +222 lines on `agents/watcher/agent.py` — findings lease gate
- +184 lines new test file `agents/watcher/tests/test_agent.py`
- Vigil log redirection during tests (`agents/vigil/agent.py`, `tests/conftest.py`)

## Posture
14 days old; predates several Watcher/Vigil changes. Recommend rebasing and verifying behavior still matches the lease-plane surface as it stands today (#412/#414/#417/#418/#419 hardening) before landing.

Filed as draft so the work doesn't get lost if the branch was pruned.