### PR TITLE
perf(tests): isolate tool_usage_tracker + collapse 5s waits

### DIFF
--- a/scripts/dev/test-cache.sh
+++ b/scripts/dev/test-cache.sh
@@ -41,7 +41,7 @@ _hash_worktree_python() {
 import hashlib
 import subprocess
 
-patterns = ["src/*.py", "tests/*.py", "agents/*.py"]
+patterns = ["src/*.py", "tests/*.py", "agents/*.py", "governance_core/*.py", "pyproject.toml"]
 proc = subprocess.run(
     ["git", "ls-files", "-z", "--", *patterns],
     check=True,
@@ -68,7 +68,7 @@ _hash_staged_python() {
 import hashlib
 import subprocess
 
-patterns = ["src/*.py", "tests/*.py", "agents/*.py"]
+patterns = ["src/*.py", "tests/*.py", "agents/*.py", "governance_core/*.py", "pyproject.toml"]
 proc = subprocess.run(
     ["git", "ls-files", "-s", "-z", "--", *patterns],
     check=True,
@@ -98,8 +98,8 @@ PY
 }
 
 _print_staged_dirty_python() {
-    git diff --name-only -- 'src/*.py' 'tests/*.py' 'agents/*.py'
-    git ls-files --others --exclude-standard -- 'src/*.py' 'tests/*.py' 'agents/*.py'
+    git diff --name-only -- 'src/*.py' 'tests/*.py' 'agents/*.py' 'governance_core/*.py' 'pyproject.toml'
+    git ls-files --others --exclude-standard -- 'src/*.py' 'tests/*.py' 'agents/*.py' 'governance_core/*.py' 'pyproject.toml'
 }
 
 # --- compute tree hash ---

--- a/src/tool_usage_tracker.py
+++ b/src/tool_usage_tracker.py
@@ -49,9 +49,19 @@ class ToolUsageTracker:
     
     def __init__(self, log_file: Optional[Path] = None):
         if log_file is None:
-            project_root = Path(__file__).parent.parent
-            log_file = project_root / "data" / "tool_usage.jsonl"
-        
+            # UNITARES_TOOL_USAGE_LOG lets test/integration harnesses redirect
+            # the singleton to a tmp file. Without it, subprocess-spawned
+            # mcp_server.py instances (e.g. CLI integration tests) read the
+            # developer-machine data/tool_usage.jsonl on every process_update
+            # call — observed at 1.09M lines / 177MB on dev box, dominating
+            # any test that triggers a single update.
+            env_path = os.environ.get("UNITARES_TOOL_USAGE_LOG")
+            if env_path:
+                log_file = Path(env_path)
+            else:
+                project_root = Path(__file__).parent.parent
+                log_file = project_root / "data" / "tool_usage.jsonl"
+
         self.log_file = log_file
         self.log_file.parent.mkdir(parents=True, exist_ok=True)
     

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -299,6 +299,38 @@ def _isolate_db_backend(monkeypatch):
     storage_module._db_ready_cache.clear()
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _isolate_tool_usage_tracker(tmp_path_factory):
+    """
+    Redirect the tool_usage_tracker singleton to a session-scoped tmp file.
+
+    governance_monitor.process_update() calls get_tool_usage_tracker().get_usage_stats()
+    every cycle as part of dual-log complexity grounding. The default singleton
+    points at <repo>/data/tool_usage.jsonl, which on developer machines accumulates
+    to hundreds of MB / millions of entries — get_usage_stats() reads and json.loads()
+    every line on each call.
+
+    Measured cost (2026-05-06 dev box, 176MB / 1.09M-line tool_usage.jsonl):
+      - Default tracker: 2779 ms / process_update
+      - Tmp tracker:        0.3 ms / process_update  (~9000x speedup)
+
+    Tests that legitimately exercise the tracker construct ToolUsageTracker
+    directly with their own log_file (test_tool_usage_tracker.py), or patch
+    get_tool_usage_tracker via unittest.mock.patch — both override this default.
+
+    Session scope is safe because the tracker has no cross-test state we read;
+    the file is only ever appended to and we never assert on its contents here.
+    """
+    import src.tool_usage_tracker as tut
+    tmp_log = tmp_path_factory.mktemp("tool_usage") / "tool_usage.jsonl"
+    original = tut._tool_usage_tracker
+    tut._tool_usage_tracker = tut.ToolUsageTracker(log_file=tmp_log)
+    try:
+        yield tut._tool_usage_tracker
+    finally:
+        tut._tool_usage_tracker = original
+
+
 @pytest.fixture(autouse=True)
 def _neutralize_metadata_loading(monkeypatch):
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -336,13 +336,35 @@ def _neutralize_metadata_loading(monkeypatch):
     """
     Prevent ensure_metadata_loaded() from trying to connect to PostgreSQL.
 
-    Sets _metadata_loaded = True in agent_state so the fast-path returns
-    immediately. Tests that need to exercise metadata loading should
-    explicitly set _metadata_loaded = False and mock load_metadata_async.
+    The canonical state lives on ``src.agent_metadata_model`` (the
+    ``_model`` reference inside ``agent_metadata_persistence``). Patching
+    ``agent_state._metadata_loaded`` alone is a no-op because that name is
+    only an import-time copy of the bool — assigning to it does not
+    propagate back to ``agent_metadata_model``. Pre-2026-05-06 the fixture
+    only patched ``agent_state``, so every code path that hit
+    ``require_registered_agent`` (e.g. all dialectic submit handlers) blocked
+    for the full 5.0s ``_metadata_loaded_event.wait(timeout=5.0)`` ceiling
+    inside ``ensure_metadata_loaded()``. Three suite tests sat at exactly
+    5.01s for that reason.
+
+    Patch the canonical module *and* pre-set the threading event so any
+    handler that reaches ``ensure_metadata_loaded`` returns on the fast
+    path. Tests that need to exercise the loader explicitly clear these
+    in-place (see ``_isolate_identity_state`` teardown).
     """
     try:
-        import src.agent_state as agent_state
-        monkeypatch.setattr(agent_state, '_metadata_loaded', True)
+        import src.agent_metadata_model as amm
+        monkeypatch.setattr(amm, '_metadata_loaded', True, raising=False)
+        monkeypatch.setattr(amm, '_metadata_loading', False, raising=False)
+        amm._metadata_loaded_event.set()
+
+        # Keep the legacy patch on agent_state for any code that introspects
+        # via that re-exported name (defensive — not currently the hot path).
+        try:
+            import src.agent_state as agent_state
+            monkeypatch.setattr(agent_state, '_metadata_loaded', True, raising=False)
+        except Exception:
+            pass
     except Exception as exc:
         import warnings
         warnings.warn(f"test cleanup failed: {exc}", stacklevel=2)

--- a/tests/test_remaining_modules.py
+++ b/tests/test_remaining_modules.py
@@ -608,12 +608,23 @@ class TestCallLocalLLM:
 
     @pytest.mark.asyncio
     async def test_timeout_returns_none(self):
+        """When the LLM call times out, call_local_llm returns None.
+
+        The implementation wraps the executor call in
+        ``asyncio.wait_for(..., timeout=timeout + 5)`` and catches
+        ``asyncio.TimeoutError``. Pre-2026-05-06 this test used
+        ``time.sleep(5)`` inside the mock to make ``wait_for`` actually fire
+        — but with the +5 buffer that meant the test ran for the full 5
+        seconds on every invocation. We exercise the same except-clause by
+        raising ``asyncio.TimeoutError`` directly from the mocked OpenAI
+        call, which propagates out of ``run_in_executor`` and ``wait_for``
+        unchanged. Same exception class, same handler branch — without the
+        artificial 5s wait.
+        """
+        import asyncio as _asyncio
+
         mock_client = MagicMock()
-
-        def slow_call(**kwargs):
-            time.sleep(5)
-
-        mock_client.chat.completions.create.side_effect = slow_call
+        mock_client.chat.completions.create.side_effect = _asyncio.TimeoutError("simulated timeout")
 
         with patch("src.mcp_handlers.support.llm_delegation.OPENAI_AVAILABLE", True), \
              patch("src.mcp_handlers.support.llm_delegation._get_ollama_client", return_value=mock_client):

--- a/tests/test_unitares_cli_script.py
+++ b/tests/test_unitares_cli_script.py
@@ -99,6 +99,11 @@ def mcp_test_server(tmp_path_factory):
     # secret is configured. Provide a deterministic test secret so the
     # CLI tests can assert on the token field.
     env.setdefault("UNITARES_CONTINUITY_TOKEN_SECRET", "pytest-fixture-secret")
+    # Redirect the tool-usage tracker to a fresh tmp file so the subprocess
+    # server doesn't read the developer-machine data/tool_usage.jsonl
+    # (~1M lines / 177MB) on every process_update — that file is parsed
+    # line-by-line by get_usage_stats and dominates CLI test wall-clock.
+    env["UNITARES_TOOL_USAGE_LOG"] = str(state_dir / "tool_usage.jsonl")
 
     proc = subprocess.Popen(
         [sys.executable, str(REPO_ROOT / "src" / "mcp_server.py"),


### PR DESCRIPTION
Surfaced from stale-branch cleanup (branch tip 2026-05-06). Rebased on master 2026-05-20 and slimmed from 5 commits to 2 load-bearing perf commits.

## What's in the branch

**Kept (2 commits, load-bearing):**
- \`perf(tests): isolate tool_usage_tracker; widen test-cache.sh hash\` — singleton tracker pointed at \`<repo>/data/tool_usage.jsonl\` (1.09M lines / 177MB on dev box); each \`process_update\` re-reads the file. Measured 2779ms → 0.3ms per update (~9000×). Plus widens test-cache.sh hash patterns to include \`governance_core/*.py\` and \`pyproject.toml\` (rebased onto master's HASH_MODE/staged-hash structure).
- \`perf(tests): collapse 5s waits — metadata-load, llm-buffer, subprocess tool-usage\` — three 5.01s waits identified: \`_neutralize_metadata_loading\` patched the wrong \`_metadata_loaded\` (the re-export, not the canonical \`_model\` reference); LLM buffer; subprocess tool-usage. Full suite ~4:48 → ~4:23.

**Dropped during rebase (3 commits):**
- \`docs: normalize project casing to UNITARES; refresh dashboard README\` — cosmetic casing sweep, stale conflicts across 9 dashboard files
- \`fix(tests): add provenance_chain to KG integration test factory\`
- \`fix(kg-age): close provenance_chain round-trip gap on AGE backend\` — master already wires \`provenance_chain\` through \`knowledge_graph_age.py\` (lines 81, 82, 826, 1253-4); these two commits look superseded. If the round-trip gap is still real, surface it as its own focused PR.

## Verification
- \`tests/test_remaining_modules.py tests/test_unitares_cli_script.py\`: 217/217 pass
- \`tests/ -k tool_usage\`: 31/31 pass

Ready for review.