### PR TITLE
feat(vigil): wire watcher --scan-commits into 30min cycle

### DIFF
--- a/agents/vigil/agent.py
+++ b/agents/vigil/agent.py
@@ -511,6 +511,21 @@ class VigilAgent(GovernanceAgent):
                     pass
                 log(f"GROUNDSKEEPER: {note_text}")
 
+        # --- Watcher commit-scan: auto-resolve findings referenced in recent commits ---
+        try:
+            scan_proc = subprocess.run(
+                [sys.executable, str(project_root / "agents" / "watcher" / "agent.py"), "--scan-commits"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if scan_proc.returncode != 0:
+                log(f"GROUNDSKEEPER: watcher --scan-commits exited {scan_proc.returncode}: {scan_proc.stderr[:200]}")
+            else:
+                log(f"GROUNDSKEEPER: watcher --scan-commits: {scan_proc.stdout.strip()[:100]}")
+        except Exception as e:
+            log(f"GROUNDSKEEPER: watcher --scan-commits failed ({type(e).__name__}: {e})")
+
         return summary
 
     async def _run_aged_candidate_archive(

--- a/agents/vigil/tests/test_groundskeeper.py
+++ b/agents/vigil/tests/test_groundskeeper.py
@@ -463,6 +463,52 @@ class TestRunAgedCandidateArchive:
 
 
 # =============================================================================
+# Tests: watcher --scan-commits wiring
+# =============================================================================
+
+class TestGroundskeeperScanCommits:
+    """Watcher --scan-commits is called each cycle and exceptions don't propagate."""
+
+    @pytest.mark.asyncio
+    async def test_scan_commits_argv(self, monkeypatch):
+        """subprocess.run must be called with --scan-commits in argv."""
+        calls = []
+
+        class _FakeResult:
+            returncode = 0
+            stdout = "resolved 0"
+            stderr = ""
+
+        def _fake_run(args, **kwargs):
+            calls.append(list(args))
+            return _FakeResult()
+
+        monkeypatch.setattr(_hb_module.subprocess, "run", _fake_run)
+
+        agent = _make_agent()
+        client = _make_mock_client()
+        await agent._run_groundskeeper(client)
+
+        scan_calls = [c for c in calls if "--scan-commits" in c]
+        assert len(scan_calls) == 1
+        assert any("watcher" in str(a) and "agent.py" in str(a) for a in scan_calls[0])
+
+    @pytest.mark.asyncio
+    async def test_scan_commits_exception_does_not_propagate(self, monkeypatch):
+        """A crash in subprocess.run must not raise out of _run_groundskeeper."""
+
+        def _raise(*args, **kwargs):
+            raise RuntimeError("watcher exploded")
+
+        monkeypatch.setattr(_hb_module.subprocess, "run", _raise)
+
+        agent = _make_agent()
+        client = _make_mock_client()
+        result = await agent._run_groundskeeper(client)
+        assert isinstance(result, dict)
+
+
+# =============================================================================
 # Tests: with_audit flag
 # =============================================================================
 


### PR DESCRIPTION
Surfaced from stale-branch cleanup (branch tip 2026-05-07, never PR'd). Confirmed unique work not in master and merges cleanly.

## What's in the branch
- +15 lines on \`agents/vigil/agent.py\` — wires watcher \`--scan-commits\` into Vigil's 30min cycle
- +46 lines new test \`agents/vigil/tests/test_groundskeeper.py\`

## Posture
13 days old. Vigil cadence and Watcher --scan-commits behavior may have shifted; recommend verifying the wire-in matches current Watcher surface before landing.

Filed as draft so the work doesn't get lost if the branch was pruned.