### PR TITLE
feat(#428): wrap basin/mode/verdict in standard-verbosity path

### DIFF
--- a/src/services/runtime_queries.py
+++ b/src/services/runtime_queries.py
@@ -246,12 +246,17 @@ async def get_governance_metrics_data(agent_id: str, arguments: Dict[str, Any], 
         standardized_metrics["reflection"] = reflection
 
     if verbosity == "standard":
-        state = standardized_metrics.get("state", {})
         from src.governance_glossary import (
             explain_basin,
             explain_mode,
             explain_verdict,
         )
+        # Gate basin/mode on state presence — symmetric to lite path (lines
+        # 346-348). When interpret_state raises, standardized_metrics["state"]
+        # is absent; emitting explain_*(None) leaks {"value": null} without
+        # the meaning key, which is worse than just omitting the field.
+        state_present = "state" in standardized_metrics
+        state = standardized_metrics.get("state", {})
         standard_metrics = {
             "agent_id": display_name or public_agent_id,
             "display_name": display_name,
@@ -267,11 +272,12 @@ async def get_governance_metrics_data(agent_id: str, arguments: Dict[str, Any], 
             "verdict": explain_verdict(metrics.get("verdict", "uninitialized")),
             "risk_score": metrics.get("risk_score"),
             "primary_eisv_source": standardized_metrics.get("primary_eisv_source"),
-            "basin": explain_basin(state.get("basin")),
-            "mode": explain_mode(state.get("mode")),
             "summary": standardized_metrics.get("summary"),
             "guidance": state.get("guidance"),
         })
+        if state_present:
+            standard_metrics["basin"] = explain_basin(state.get("basin"))
+            standard_metrics["mode"] = explain_mode(state.get("mode"))
         if public_agent_id != agent_id:
             standard_metrics["agent_uuid"] = agent_id
         if reflection:

--- a/src/services/runtime_queries.py
+++ b/src/services/runtime_queries.py
@@ -247,6 +247,11 @@ async def get_governance_metrics_data(agent_id: str, arguments: Dict[str, Any], 
 
     if verbosity == "standard":
         state = standardized_metrics.get("state", {})
+        from src.governance_glossary import (
+            explain_basin,
+            explain_mode,
+            explain_verdict,
+        )
         standard_metrics = {
             "agent_id": display_name or public_agent_id,
             "display_name": display_name,
@@ -259,11 +264,11 @@ async def get_governance_metrics_data(agent_id: str, arguments: Dict[str, Any], 
             "S": metrics.get("S"),
             "V": metrics.get("V"),
             "coherence": metrics.get("coherence"),
-            "verdict": metrics.get("verdict", "uninitialized"),
+            "verdict": explain_verdict(metrics.get("verdict", "uninitialized")),
             "risk_score": metrics.get("risk_score"),
             "primary_eisv_source": standardized_metrics.get("primary_eisv_source"),
-            "basin": state.get("basin"),
-            "mode": state.get("mode"),
+            "basin": explain_basin(state.get("basin")),
+            "mode": explain_mode(state.get("mode")),
             "summary": standardized_metrics.get("summary"),
             "guidance": state.get("guidance"),
         })

--- a/tests/test_handlers_core.py
+++ b/tests/test_handlers_core.py
@@ -374,6 +374,53 @@ class TestGetGovernanceMetrics:
             assert "state_semantics" in data
 
     @pytest.mark.asyncio
+    async def test_get_metrics_standard_mode_wraps_basin_mode_verdict(self, mock_mcp_server):
+        """Standard verbosity wraps basin/mode/verdict with glossary entries (#428).
+
+        Lite mode already wrapped these via explain_*; standard mode used to
+        emit bare strings, leaving cold agents without point-of-use vocabulary.
+        Wraps now symmetric with lite path.
+        """
+        state = SimpleNamespace(
+            interpret_state=MagicMock(return_value={
+                "health": "healthy",
+                "mode": "building_alone",
+                "basin": "high",
+            }),
+            unitaires_state=None,
+        )
+        m = MagicMock()
+        m.state = state
+        m.get_metrics.return_value = {
+            "E": 0.7, "I": 0.6, "S": 0.2, "V": 0.0,
+            "coherence": 0.52, "risk_score": 0.3,
+            "initialized": True, "status": "ok",
+            "verdict": "proceed",
+        }
+        mock_mcp_server.agent_metadata = {"agent-1": MagicMock(purpose=None)}
+        mock_mcp_server.get_or_create_monitor.return_value = m
+
+        with patch("src.mcp_handlers.core.mcp_server", mock_mcp_server), \
+             patch("src.mcp_handlers.core.require_agent_id", return_value=("agent-1", None)), \
+             patch("src.governance_monitor.UNITARESMonitor") as MockMonitorClass:
+
+            MockMonitorClass.get_eisv_labels.return_value = {
+                "E": "Energy", "I": "Information", "S": "Entropy", "V": "Void"
+            }
+
+            from src.mcp_handlers.core import handle_get_governance_metrics
+            result = await handle_get_governance_metrics({"verbosity": "standard"})
+
+            data = json.loads(result[0].text)
+            assert data["verdict"]["value"] == "proceed"
+            assert "meaning" in data["verdict"]
+            assert "next_action" in data["verdict"]
+            assert data["basin"]["value"] == "high"
+            assert "meaning" in data["basin"]
+            assert data["mode"]["value"] == "building_alone"
+            assert "meaning" in data["mode"]
+
+    @pytest.mark.asyncio
     async def test_get_metrics_uninitialized_agent(self, mock_mcp_server):
         """Uninitialized agent should show pending status in lite mode."""
         state = SimpleNamespace(

--- a/tests/test_handlers_core.py
+++ b/tests/test_handlers_core.py
@@ -421,6 +421,43 @@ class TestGetGovernanceMetrics:
             assert "meaning" in data["mode"]
 
     @pytest.mark.asyncio
+    async def test_get_metrics_standard_mode_omits_basin_mode_when_state_missing(self, mock_mcp_server):
+        """When interpret_state raises, standard verbosity omits basin/mode rather
+        than emitting bare {"value": null}. Symmetric to lite path guard at
+        runtime_queries.py:346.
+        """
+        state = SimpleNamespace(
+            interpret_state=MagicMock(side_effect=RuntimeError("interpret failed")),
+            unitaires_state=None,
+        )
+        m = MagicMock()
+        m.state = state
+        m.get_metrics.return_value = {
+            "E": 0.5, "I": 0.5, "S": 0.5, "V": 0.0,
+            "coherence": None, "risk_score": None,
+            "initialized": True, "status": "ok",
+            "verdict": "proceed",
+        }
+        mock_mcp_server.agent_metadata = {"agent-1": MagicMock(purpose=None)}
+        mock_mcp_server.get_or_create_monitor.return_value = m
+
+        with patch("src.mcp_handlers.core.mcp_server", mock_mcp_server), \
+             patch("src.mcp_handlers.core.require_agent_id", return_value=("agent-1", None)), \
+             patch("src.governance_monitor.UNITARESMonitor") as MockMonitorClass:
+
+            MockMonitorClass.get_eisv_labels.return_value = {
+                "E": "Energy", "I": "Information", "S": "Entropy", "V": "Void"
+            }
+
+            from src.mcp_handlers.core import handle_get_governance_metrics
+            result = await handle_get_governance_metrics({"verbosity": "standard"})
+
+            data = json.loads(result[0].text)
+            assert "basin" not in data
+            assert "mode" not in data
+            assert data["verdict"]["value"] == "proceed"
+
+    @pytest.mark.asyncio
     async def test_get_metrics_uninitialized_agent(self, mock_mcp_server):
         """Uninitialized agent should show pending status in lite mode."""
         state = SimpleNamespace(


### PR DESCRIPTION
## Summary

The lite path of `get_governance_metrics` already wraps `basin` / `mode` / `verdict` with `explain_basin` / `explain_mode` / `explain_verdict` (`src/services/runtime_queries.py:341-348`). The standard path (`verbosity='standard'`) used to emit bare strings, leaving cold agents without point-of-use vocabulary.

Now symmetric: standard path uses the same helpers. No new helper code — just wiring an existing pattern into a second response surface.

Closes part of #428 (1 of 4 surfaces — see issue comment for full plan: basin/mode/verdict ✓, ethical_drift / trust_tier still pending).

## Test plan

- [x] New test `test_get_metrics_standard_mode_wraps_basin_mode_verdict` asserts each of basin/mode/verdict carries `{value, meaning, ...}`
- [x] Existing `TestGetGovernanceMetrics` suite (7 tests) still passes