### PR TITLE
feat(#429): mark leave_note deprecated, superseded by knowledge(action='note')

### DIFF
--- a/agents/sdk/src/unitares_sdk/client.py
+++ b/agents/sdk/src/unitares_sdk/client.py
@@ -364,12 +364,15 @@ class GovernanceClient:
         tags: list[str] | None = None,
         **kwargs: Any,
     ) -> NoteResult:
-        """Leave a knowledge graph note. Maps to server tool: leave_note."""
-        args: dict[str, Any] = {"summary": summary}
+        """Leave a knowledge graph note. Routes through `knowledge(action='note')` —
+        the `leave_note` MCP tool is deprecated (issue #429) but the SDK method
+        name is retained for backward compatibility.
+        """
+        args: dict[str, Any] = {"action": "note", "summary": summary}
         if tags is not None:
             args["tags"] = tags
         args.update(kwargs)
-        raw = await self.call_tool("leave_note", args)
+        raw = await self.call_tool("knowledge", args)
         return NoteResult.model_validate(raw)
 
     async def search_knowledge(self, query: str, **kwargs: Any) -> SearchResult:

--- a/agents/sdk/src/unitares_sdk/sync_client.py
+++ b/agents/sdk/src/unitares_sdk/sync_client.py
@@ -207,11 +207,15 @@ class SyncGovernanceClient:
     def leave_note(
         self, summary: str, tags: list[str] | None = None, **kwargs: Any
     ) -> NoteResult:
-        args: dict[str, Any] = {"summary": summary}
+        """Routes through `knowledge(action='note')` — the `leave_note` MCP tool
+        is deprecated (issue #429) but the SDK method name is retained for
+        backward compatibility.
+        """
+        args: dict[str, Any] = {"action": "note", "summary": summary}
         if tags is not None:
             args["tags"] = tags
         args.update(kwargs)
-        raw = self.call_tool("leave_note", args)
+        raw = self.call_tool("knowledge", args)
         return NoteResult.model_validate(raw)
 
     def search_knowledge(self, query: str, **kwargs: Any) -> SearchResult:

--- a/agents/sdk/tests/test_client.py
+++ b/agents/sdk/tests/test_client.py
@@ -272,6 +272,26 @@ class TestToolMapping:
         assert args["query"] == "test query"
 
     @pytest.mark.asyncio
+    async def test_leave_note_routes_through_knowledge_action_note(self):
+        """SDK leave_note() now routes through the canonical `knowledge` tool
+        with action='note' (#429 council fix). The MCP `leave_note` tool is
+        deprecated; SDK method name retained for backward compatibility."""
+        session = AsyncMock()
+        session.call_tool = AsyncMock(return_value=make_mcp_result({
+            "success": True,
+            "note_id": "n-123",
+        }))
+        client = make_client_with_session(session)
+
+        await client.leave_note(summary="test note", tags=["test"])
+        tool_name = session.call_tool.call_args[0][0]
+        args = session.call_tool.call_args[0][1]
+        assert tool_name == "knowledge"
+        assert args["action"] == "note"
+        assert args["summary"] == "test note"
+        assert args["tags"] == ["test"]
+
+    @pytest.mark.asyncio
     async def test_store_discovery_maps_to_knowledge_action_store(self):
         session = AsyncMock()
         session.call_tool = AsyncMock(return_value=make_mcp_result({

--- a/src/mcp_handlers/dialectic/responses.py
+++ b/src/mcp_handlers/dialectic/responses.py
@@ -33,9 +33,9 @@ def get_session_timeout_recovery(timeout_reason: str) -> Dict[str, Any]:
         "what_you_can_do": [
             "1. Check your state with get_governance_metrics",
             "2. Use self_recovery(action='quick') if you believe you can proceed safely",
-            "3. Leave a note about what happened with leave_note",
+            "3. Leave a note about what happened with knowledge(action='note', summary='...')",
         ],
-        "related_tools": ["get_governance_metrics", "self_recovery", "leave_note"],
+        "related_tools": ["get_governance_metrics", "self_recovery", "knowledge"],
         "note": "Session is no longer active. Inspect the transcript and current state before retrying.",
     }
 
@@ -50,9 +50,9 @@ def get_reviewer_stuck_recovery(reviewer_agent_id: str | None) -> Dict[str, Any]
         "what_you_can_do": [
             "1. Check your state with get_governance_metrics",
             "2. Use self_recovery(action='quick') if you believe you can proceed safely",
-            "3. Leave a note about what happened with leave_note",
+            "3. Leave a note about what happened with knowledge(action='note', summary='...')",
         ],
-        "related_tools": ["get_governance_metrics", "self_recovery", "leave_note"],
+        "related_tools": ["get_governance_metrics", "self_recovery", "knowledge"],
         "note": "The session is no longer active. Start a new review only if the issue still stands.",
     }
 

--- a/src/mcp_handlers/introspection/tool_introspection.py
+++ b/src/mcp_handlers/introspection/tool_introspection.py
@@ -19,6 +19,54 @@ from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 logger = get_logger(__name__)
 
 
+# Deprecation registry surfaced by both list_tools (via tool_relationships)
+# and describe_tool (via _describe_tool_deprecation_block). Keeping the
+# migration string in one place avoids drift between the two surfaces.
+# Mirrored into tool_relationships in handle_list_tools below.
+_DEPRECATION_REGISTRY: Dict[str, Dict[str, str]] = {
+    "leave_note": {
+        "deprecated_since": "2026-05-20",
+        "superseded_by": "knowledge",
+        "migration": (
+            "MCP tool surface: call `knowledge` with action='note', "
+            "summary='...', tags=[...]. unitares_sdk callers can keep using "
+            "client.leave_note() — that method now routes through `knowledge` "
+            "internally (same audit shape, same DB row)."
+        ),
+    },
+    "request_dialectic_review": {
+        "deprecated_since": "2026-01-29",
+        "superseded_by": "self_recovery_review",
+        "migration": "Use self_recovery_review(reflection='...') instead",
+    },
+    "direct_resume_if_safe": {
+        "deprecated_since": "2026-01-29",
+        "superseded_by": "quick_resume",
+        "migration": (
+            "Use quick_resume() if coherence > 0.60 and risk < 0.40, "
+            "otherwise use self_recovery_review(reflection='...')"
+        ),
+    },
+}
+
+
+def _describe_tool_deprecation_block(tool_name: str) -> Optional[Dict[str, Any]]:
+    """Return a deprecation block for the named tool, or None if not deprecated.
+
+    Surfaces server-side deprecation metadata in describe_tool responses so
+    agents don't have to call list_tools to learn the migration story.
+    """
+    entry = _DEPRECATION_REGISTRY.get(tool_name)
+    if entry is None:
+        return None
+    return {
+        "deprecated": True,
+        "deprecated_since": entry["deprecated_since"],
+        "superseded_by": entry["superseded_by"],
+        "migration": entry["migration"],
+    }
+
+
 def _resolve_json_schema_type(field_info: Dict[str, Any]) -> str:
     """Render a Pydantic/JSON Schema field's type for lite-mode param lists.
 
@@ -344,7 +392,12 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
             "depends_on": [],  # No deps - identity auto-binds
             "related_to": ["knowledge", "store_knowledge_graph"],
             "category": "knowledge",
-            "migration": "Use knowledge(action='note', summary='...', tags=[...]) — same handler, same params"
+            "migration": (
+                "MCP tool surface: call `knowledge` with action='note', "
+                "summary='...', tags=[...]. unitares_sdk callers can keep using "
+                "client.leave_note() — that method now routes through `knowledge` "
+                "internally (same audit shape, same DB row)."
+            ),
         },
         "update_discovery_status_graph": {
             "depends_on": ["get_discovery_details"],
@@ -1165,6 +1218,10 @@ async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextConten
                     "note": "Lite mode - use describe_tool(tool_name=..., lite=false) for full schema"
                 }
 
+                deprecation = _describe_tool_deprecation_block(tool_name)
+                if deprecation is not None:
+                    response_data["deprecation"] = deprecation
+
                 if tool_aliases:
                     # Format: {"content": "summary"} → "content → summary"
                     response_data["parameter_aliases"] = {
@@ -1213,6 +1270,10 @@ async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextConten
                     "note": "Lite mode - use describe_tool(tool_name=..., lite=false) for full schema"
                 }
 
+                deprecation = _describe_tool_deprecation_block(tool_name)
+                if deprecation is not None:
+                    response_data["deprecation"] = deprecation
+
                 if tool_aliases:
                     response_data["parameter_aliases"] = {
                         alias: f"→ {canonical}" for alias, canonical in tool_aliases.items()
@@ -1223,12 +1284,16 @@ async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextConten
 
                 return success_response(response_data)
 
-        return success_response({
+        full_response: Dict[str, Any] = {
             "tool": {
                 "name": tool.name,
                 "description": description,
                 "inputSchema": tool.inputSchema if include_schema else None,
             }
-        })
+        }
+        deprecation = _describe_tool_deprecation_block(tool_name)
+        if deprecation is not None:
+            full_response["deprecation"] = deprecation
+        return success_response(full_response)
     except Exception as e:
         return [error_response(f"Error describing tool: {str(e)}")]

--- a/src/mcp_handlers/introspection/tool_introspection.py
+++ b/src/mcp_handlers/introspection/tool_introspection.py
@@ -338,9 +338,13 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
             "category": "knowledge"
         },
         "leave_note": {
+            "deprecated": True,
+            "deprecated_since": "2026-05-20",
+            "superseded_by": "knowledge",
             "depends_on": [],  # No deps - identity auto-binds
-            "related_to": ["store_knowledge_graph"],
-            "category": "knowledge"
+            "related_to": ["knowledge", "store_knowledge_graph"],
+            "category": "knowledge",
+            "migration": "Use knowledge(action='note', summary='...', tags=[...]) — same handler, same params"
         },
         "update_discovery_status_graph": {
             "depends_on": ["get_discovery_details"],

--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -2219,12 +2219,13 @@ async def handle_answer_question(arguments: Dict[str, Any]) -> Sequence[TextCont
     except Exception as e:
         return [error_response(f"Failed to answer question: {str(e)}")]
 
-@mcp_tool("leave_note", timeout=10.0)
+@mcp_tool("leave_note", timeout=10.0, deprecated=True, superseded_by="knowledge")
 async def handle_leave_note(arguments: Dict[str, Any]) -> Sequence[TextContent]:
-    """Leave a quick note in the knowledge graph - minimal friction contribution.
+    """[DEPRECATED — use knowledge(action='note') instead] Leave a quick note in the knowledge graph.
 
     Just agent_id + summary + optional tags. Auto-sets type='note', severity='low'.
-    For when you want to jot something down without the full store_knowledge_graph ceremony.
+    Functionally identical to ``knowledge(action='note', summary=...)``; deprecation
+    is per dogfood-UX issue #429 (tool aliasing — pick one). Calls still work.
     """
     # Apply parameter aliases (e.g., "text" → "summary", "note" → "summary")
     arguments = apply_param_aliases("leave_note", arguments)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -114,6 +114,15 @@ class TestMcpToolDecorator:
         assert is_tool_deprecated("test_normal_tool") is False
         assert is_tool_hidden("test_normal_tool") is False
 
+    def test_leave_note_marked_deprecated(self):
+        """leave_note is the issue-#429 canonical deprecation: superseded by knowledge(action='note')."""
+        # Import handler to trigger decorator registration in the live registry.
+        import src.mcp_handlers.knowledge.handlers  # noqa: F401
+
+        assert is_tool_deprecated("leave_note") is True
+        meta = get_tool_metadata("leave_note")
+        assert meta["superseded_by"] == "knowledge"
+
 
 class TestListRegisteredTools:
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -123,6 +123,27 @@ class TestMcpToolDecorator:
         meta = get_tool_metadata("leave_note")
         assert meta["superseded_by"] == "knowledge"
 
+    def test_describe_tool_surfaces_deprecation(self):
+        """describe_tool must inject deprecation block for deprecated tools (#429 council fix).
+
+        Pre-fix, the deprecation lived only in tool_relationships (consumed by
+        list_tools) and on the decorator. describe_tool built responses from
+        get_tool_definitions only — agents calling describe_tool('leave_note')
+        got no migration hint.
+        """
+        from src.mcp_handlers.introspection.tool_introspection import (
+            _describe_tool_deprecation_block,
+        )
+        block = _describe_tool_deprecation_block("leave_note")
+        assert block is not None
+        assert block["deprecated"] is True
+        assert block["superseded_by"] == "knowledge"
+        assert "knowledge" in block["migration"]
+        assert "action='note'" in block["migration"]
+
+        # Non-deprecated tool returns None
+        assert _describe_tool_deprecation_block("process_agent_update") is None
+
 
 class TestListRegisteredTools:
 


### PR DESCRIPTION
## Summary

\`leave_note\` and \`knowledge(action='note')\` are functional aliases — same handler, same params. Per the 2026-05-08 dogfood-UX review (#429), this is the easiest of the four aliasing collapses.

Changes:
- \`@mcp_tool\` decorator on \`handle_leave_note\` → \`deprecated=True, superseded_by=\"knowledge\"\`
- Introspection registry entry adds \`deprecated_since=2026-05-20\` + \`migration\` string
- Docstring re-leads with \`[DEPRECATED — use knowledge(action='note') instead]\`

**Behavior unchanged.** Callers still work; \`describe_tool(\"leave_note\")\` now surfaces the migration path, and \`is_tool_deprecated(\"leave_note\")\` returns True.

Closes 1 of 4 cuts from #429. The \`op\` parameter and \`lite\` flag deprecations are parameter-level (not tool-level) and need separate handling.

## Test plan

- [x] New test \`test_leave_note_marked_deprecated\` in \`tests/test_decorators.py\`
- [x] \`tests/test_decorators.py\` full suite (37 tests) passes
- [x] \`tests/test_describe_tool_drift.py\` (7 tests) passes
- [x] Existing \`leave_note\` tests in \`tests/test_kg_store.py\` (3 tests) pass