### PR TITLE
feat(#484): heal-on-read for pre-#483 UUID-format thread_ids

### DIFF
--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -798,13 +798,19 @@ async def _track_thread_identity(ctx: "UpdateContext") -> bool:
     re-stamp/persist effects should fire; False on a no-op (already
     tracking the same session).
 
-    **Known durable-state gap (not addressed here).** Live-verifier 2026-05-20:
-    ~35% of ``core.identities.metadata.thread_id`` rows already carry
-    UUID-format values from the broken mint path that pre-dated this fix
-    (886 of 2521 rows). Step 1 will read those back unchanged. Healing
-    them retroactively would silently change identity for 886 agents — a
-    bigger blast radius than this PR — so it is intentionally deferred to
-    a separate cleanup pass.
+    **Heal-on-read for pre-#483 UUID-format thread_ids (#484, 2026-05-20).**
+    886 of 2521 populated ``core.identities.metadata.thread_id`` rows still
+    carry UUID-format values from the broken mint path that pre-dated #483.
+    Step 1 detects them by the ``t-`` prefix check and treats them as malformed
+    — the value is skipped, and step 2 derives a fresh deterministic
+    ``t-<sha16>`` from ``session_key``. One update per affected agent migrates
+    the row via the regular persist path. The single downstream consumer that
+    keys on thread_id format is ``src/db/mixins/thread.py:71``; lookups on
+    the old UUID value will miss until that agent next updates, which is the
+    expected migration behavior. Spread cost, no concentrated burst.
+
+    ``node_index`` and ``active_session_key`` are still imported from the
+    persisted row — only ``thread_id`` is the corrupt field.
     """
     if not (ctx.meta and ctx.session_key):
         return False
@@ -824,6 +830,18 @@ async def _track_thread_identity(ctx: "UpdateContext") -> bool:
                 persisted_session_key = identity_record.metadata.get(
                     "active_session_key"
                 )
+                # #484 heal-on-read: pre-#483 mint path emitted UUID-format
+                # thread_ids. Treat them as malformed so step 2 re-derives
+                # the canonical t-<sha16> shape via generate_thread_id.
+                if persisted_thread_id and not persisted_thread_id.startswith("t-"):
+                    logger.info(
+                        "[PROCESS_UPDATE] heal-on-read: skipping legacy "
+                        "UUID-format thread_id %s... for agent=%s...; "
+                        "step 2 will re-derive canonical form",
+                        persisted_thread_id[:8],
+                        (ctx.agent_uuid or "?")[:8],
+                    )
+                    persisted_thread_id = None
                 if persisted_thread_id:
                     ctx.meta.thread_id = persisted_thread_id
                 if persisted_node_index is not None and not getattr(

--- a/tests/test_phases_thread_identity_tracking.py
+++ b/tests/test_phases_thread_identity_tracking.py
@@ -167,6 +167,63 @@ class TestNoRandomUuidMintRegression:
         assert meta.node_index == 5
 
     @pytest.mark.asyncio
+    async def test_pg_uuid_format_thread_id_heals_to_canonical(self):
+        """#484 heal-on-read: pre-#483 PG rows carry UUID-format thread_ids.
+        Step 1 must skip them so step 2 re-derives t-<sha16> from session_key.
+        node_index continuity is preserved (it's not the corrupt field).
+        """
+        from src.mcp_handlers.updates.phases import _track_thread_identity
+        from src.thread_identity import generate_thread_id
+
+        meta = _FakeMeta()
+        ctx = _make_ctx(meta=meta, session_key="mcp:heal-session-xyz")
+        fake_db = MagicMock()
+        # UUID-format thread_id from broken pre-#483 mint path
+        fake_db.get_identity = AsyncMock(
+            return_value=_identity_record({
+                "thread_id": "a3f2e1d0-1234-5678-9abc-def012345678",
+                "node_index": 7,
+                "active_session_key": "mcp:prior-session",
+            })
+        )
+
+        with patch("src.db.get_db", return_value=fake_db):
+            changed = await _track_thread_identity(ctx)
+
+        assert changed is True
+        # thread_id healed to canonical t-<sha16> derived from session_key
+        assert meta.thread_id.startswith("t-")
+        assert len(meta.thread_id) == 18
+        assert meta.thread_id == generate_thread_id("mcp:heal-session-xyz")
+        # node_index continuity preserved (7 → 8, NOT reset to 1)
+        assert meta.node_index == 8
+        assert meta.active_session_key == "mcp:heal-session-xyz"
+
+    @pytest.mark.asyncio
+    async def test_pg_canonical_thread_id_not_touched_by_heal_logic(self):
+        """Regression guard for #484: canonical t-<sha> values must pass
+        through step 1 unchanged. Heal-on-read must not break the happy path.
+        """
+        from src.mcp_handlers.updates.phases import _track_thread_identity
+
+        meta = _FakeMeta()
+        ctx = _make_ctx(meta=meta, session_key="mcp:happy-session")
+        fake_db = MagicMock()
+        fake_db.get_identity = AsyncMock(
+            return_value=_identity_record({
+                "thread_id": "t-canonicalvalue1",
+                "node_index": 3,
+                "active_session_key": "mcp:prior",
+            })
+        )
+
+        with patch("src.db.get_db", return_value=fake_db):
+            await _track_thread_identity(ctx)
+
+        # Canonical value preserved — NOT regenerated from session_key
+        assert meta.thread_id == "t-canonicalvalue1"
+
+    @pytest.mark.asyncio
     async def test_pg_lookup_failure_falls_back_safely(self):
         """A DB error during hydration must not crash the update — fall back
         to deterministic derivation, log, and proceed."""


### PR DESCRIPTION
## Summary

886 of 2521 populated \`core.identities.metadata.thread_id\` rows carry UUID-format values from the broken pre-#483 mint path. Live-verifier 2026-05-20 confirmed the rate.

This implements **issue #484 option 2 (heal-on-read)**: step 1 of \`_track_thread_identity\` detects UUID-format values via the \`t-\` prefix check, treats them as malformed (skips the in-memory assignment), and lets step 2 re-derive the canonical \`t-<sha16>\` from session_key via \`generate_thread_id\`. One update per affected agent migrates the row through the regular persist path.

\`node_index\` and \`active_session_key\` are still imported from the persisted row — only \`thread_id\` is the corrupt field, so continuity is preserved.

## Downstream impact

Per the issue audit: \`src/db/mixins/thread.py:71-93\` is the single SQL keyed query. A lookup on the old UUID value will miss for an affected agent until that agent next updates — that's the expected migration behavior. Lazy spread, no concentrated burst.

## Test plan

- [x] \`test_pg_uuid_format_thread_id_heals_to_canonical\` — UUID-format input → t-<sha16> derived from session_key; node_index continuity preserved (7 → 8)
- [x] \`test_pg_canonical_thread_id_not_touched_by_heal_logic\` — regression guard: canonical values pass through step 1 unchanged
- [x] All 11 tests in \`test_phases_thread_identity_tracking.py\` pass (includes #424/#483 coverage)

Closes #484.