### PR TITLE
feat(#428): wire trust_tier through governance_glossary

### DIFF
--- a/src/governance_glossary.py
+++ b/src/governance_glossary.py
@@ -119,6 +119,36 @@ TRAJECTORIES: Dict[str, Dict[str, str]] = {
 
 
 # -----------------------------------------------------------------------------
+# TRUST_TIERS — trajectory-identity tiers from compute_trust_tier
+# -----------------------------------------------------------------------------
+# Source: src/trajectory_identity.py:25-30 (_TRUST_TIER_NAMES) and the
+# compute_trust_tier docstring (lines 737-741).
+
+TRUST_TIERS: Dict[int, Dict[str, str]] = {
+    0: {
+        "name": "unknown",
+        "meaning": "No trajectory data yet — identity has nothing to compare against.",
+        "criteria": "Pre-genesis or trajectory metadata missing.",
+    },
+    1: {
+        "name": "emerging",
+        "meaning": "Identity is forming. Genesis is recorded but behavioral consistency is not yet established.",
+        "criteria": "< 50 observations OR identity_confidence < 0.5.",
+    },
+    2: {
+        "name": "established",
+        "meaning": "Identity has consistent behavior across enough observations to be trustworthy.",
+        "criteria": ">= 50 observations, identity_confidence >= 0.5, lineage_similarity > 0.7.",
+    },
+    3: {
+        "name": "verified",
+        "meaning": "Identity is robustly grounded — long-running and consistent.",
+        "criteria": ">= 200 observations, identity_confidence >= 0.7, lineage_similarity > 0.8.",
+    },
+}
+
+
+# -----------------------------------------------------------------------------
 # DRIFT_COMPONENTS — concrete ethical-drift dimensions
 # -----------------------------------------------------------------------------
 # Source: src/monitor_result.py reads dv.calibration_deviation etc.
@@ -179,6 +209,41 @@ def explain_mode(mode: Optional[str]) -> Dict[str, Any]:
 def explain_trajectory(trajectory: Optional[str]) -> Dict[str, Any]:
     """Wrap a trajectory value with meaning."""
     return _wrap(trajectory, TRAJECTORIES)
+
+
+def explain_trust_tier(tier: Optional[Any]) -> Dict[str, Any]:
+    """Wrap a trust-tier integer with name + meaning + criteria.
+
+    Accepts int 0-3, the existing {tier, name, reason} dict shape produced by
+    `compute_trust_tier`, or None. Returns a merged dict that preserves all
+    existing keys and adds `meaning` + `criteria` from the glossary.
+
+    Callers can drop this in place of the previous hardcoded
+    {tier, name, reason} block without breaking consumers.
+    """
+    if tier is None:
+        return {"value": None}
+    # Already a dict — preserve all fields, add glossary annotation
+    if isinstance(tier, dict):
+        tier_value = tier.get("tier")
+        info = TRUST_TIERS.get(tier_value)
+        if info is None:
+            return {**tier, "meaning": "unknown (not in glossary)"}
+        return {**tier, "meaning": info["meaning"], "criteria": info["criteria"]}
+    # Raw int
+    try:
+        tier_int = int(tier)
+    except (TypeError, ValueError):
+        return {"value": tier, "meaning": "unknown (not in glossary)"}
+    info = TRUST_TIERS.get(tier_int)
+    if info is None:
+        return {"tier": tier_int, "meaning": "unknown (not in glossary)"}
+    return {
+        "tier": tier_int,
+        "name": info["name"],
+        "meaning": info["meaning"],
+        "criteria": info["criteria"],
+    }
 
 
 def annotate_drift_components(drift: Dict[str, float]) -> Dict[str, Dict[str, Any]]:

--- a/src/services/identity_payloads.py
+++ b/src/services/identity_payloads.py
@@ -376,12 +376,15 @@ def build_onboard_response_data(
         result["previous_status"] = "archived"
 
     if trajectory_result:
+        from src.governance_glossary import explain_trust_tier
         result["trajectory"] = dict(trajectory_result)
-        result["trajectory"]["trust_tier"] = {
+        # #428: glossary-sourced trust_tier with meaning + criteria.
+        # Preserves prior {tier, name, reason} shape and adds the explanation.
+        result["trajectory"]["trust_tier"] = explain_trust_tier({
             "tier": 1,
             "name": "emerging",
             "reason": "Genesis stored at onboard. Identity will mature with behavioral consistency.",
-        }
+        })
 
     return result
 

--- a/tests/test_governance_glossary.py
+++ b/tests/test_governance_glossary.py
@@ -125,6 +125,51 @@ class TestExplainTrajectory:
         assert "dialectic" in result["meaning"].lower()
 
 
+class TestExplainTrustTier:
+
+    def test_int_tier_returns_full_glossary_entry(self):
+        from src.governance_glossary import explain_trust_tier
+        result = explain_trust_tier(1)
+        assert result["tier"] == 1
+        assert result["name"] == "emerging"
+        assert "forming" in result["meaning"].lower() or "consistency" in result["meaning"].lower()
+        assert "50" in result["criteria"]  # observation threshold
+
+    def test_existing_dict_preserved_and_annotated(self):
+        """compute_trust_tier emits {tier, name, reason, ...}.
+        explain_trust_tier must preserve all existing keys and ADD meaning + criteria."""
+        from src.governance_glossary import explain_trust_tier
+        existing = {
+            "tier": 2,
+            "name": "established",
+            "reason": "60 observations, confidence 0.6, lineage 0.8",
+            "observation_count": 60,
+        }
+        result = explain_trust_tier(existing)
+        assert result["tier"] == 2
+        assert result["name"] == "established"
+        assert result["reason"] == existing["reason"]
+        assert result["observation_count"] == 60  # extra fields survive
+        assert "meaning" in result
+        assert "criteria" in result
+
+    def test_unknown_tier_marked(self):
+        from src.governance_glossary import explain_trust_tier
+        result = explain_trust_tier(99)
+        assert result["tier"] == 99
+        assert "unknown" in result["meaning"].lower()
+
+    def test_none_returns_value_none(self):
+        from src.governance_glossary import explain_trust_tier
+        assert explain_trust_tier(None) == {"value": None}
+
+    def test_verified_tier_mentions_long_running(self):
+        from src.governance_glossary import explain_trust_tier
+        result = explain_trust_tier(3)
+        assert result["name"] == "verified"
+        assert "200" in result["criteria"]  # higher observation threshold
+
+
 class TestAnnotateDriftComponents:
 
     def test_annotates_known_components(self):


### PR DESCRIPTION
## Summary

The hardcoded inline \`trust_tier\` dict at \`identity_payloads.py:380-384\` emitted \`{tier, name, reason}\` as a one-off; agents had no point-of-use way to learn what \`tier=1\` means or what the tier scale even is.

Adds \`TRUST_TIERS\` table to \`governance_glossary.py\` mirroring \`_TRUST_TIER_NAMES\` + \`compute_trust_tier\` criteria from \`src/trajectory_identity.py\`:

| tier | name        | criteria |
|---|---|---|
| 0 | unknown     | no trajectory data |
| 1 | emerging    | < 50 obs OR confidence < 0.5 |
| 2 | established | 50+ obs, confidence >= 0.5, lineage > 0.7 |
| 3 | verified    | 200+ obs, confidence >= 0.7, lineage > 0.8 |

Adds \`explain_trust_tier(tier)\` helper accepting int OR dict OR None. When a dict is passed (the \`compute_trust_tier\` output shape) all existing keys are preserved and \`meaning\` + \`criteria\` are added — pure addition, existing readers of \`.tier\` / \`.name\` / \`.reason\` keep working.

Wires the helper at \`identity_payloads.py:380\` so onboard responses now carry \`{tier, name, reason, meaning, criteria}\`.

Closes 4 of 5 surfaces from #428 (verdict ✓ via prior work, basin/mode ✓ via #488, trust_tier ✓ here). Remaining \`ethical_drift\` positional-list shape is a separate ontology design question.

## Test plan

- [x] \`TestExplainTrustTier\` (5 tests) covers int / dict-preservation / unknown / None / verified-tier paths
- [x] All 27 tests in \`test_governance_glossary.py\` pass
- [x] All 5 tests in \`test_identity_payloads.py\` pass