### PR TITLE
fix(governance): label decision reason as 'risk' not 'complexity'

### DIFF
--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -627,7 +627,7 @@ class GovernanceConfig:
             return {
                 'action': 'proceed',
                 'sub_action': 'approve',
-                'reason': f'Low complexity ({risk_score:.1%}) - healthy operating range',
+                'reason': f'Low risk ({risk_score:.1%}) - healthy operating range',
                 'guidance': f'{margin_to_pause:.0%} margin to PAUSE threshold ({effective_revise_threshold:.0%})',
                 'margin': margin_info['margin'],
                 'nearest_edge': margin_info['nearest_edge']
@@ -647,7 +647,7 @@ class GovernanceConfig:
             return {
                 'action': 'proceed',
                 'sub_action': 'guide',
-                'reason': f'Moderate complexity ({risk_score:.1%}) - PAUSE threshold: {effective_revise_threshold:.0%}',
+                'reason': f'Moderate risk ({risk_score:.1%}) - PAUSE threshold: {effective_revise_threshold:.0%}',
                 'guidance': guidance,
                 'margin': margin_info['margin'],
                 'nearest_edge': margin_info['nearest_edge']
@@ -657,7 +657,7 @@ class GovernanceConfig:
         return {
             'action': 'pause',
             'sub_action': 'reject',
-            'reason': f'Complexity threshold reached ({risk_score:.1%} ≥ {effective_revise_threshold:.0%})',
+            'reason': f'Risk threshold reached ({risk_score:.1%} ≥ {effective_revise_threshold:.0%})',
             'guidance': f'Pause suggested: simplify approach, break into smaller steps, or take a break. Coherence: {coherence:.2f} (critical: {effective_coherence_threshold:.2f})',
             'margin': margin_info['margin'],
             'nearest_edge': margin_info['nearest_edge']


### PR DESCRIPTION
## Summary

`make_decision()` in `config/governance_config.py` formats `risk_score` into the reason string but labels it "complexity" in three places. The variable is **risk_score** (governance/operational risk likelihood), not the agent-reported `complexity` input — see the function's own docstring at L570.

## Why this matters

Surfaced while writing the new `make demo` trajectory script (#scripts/demo/quick_demo.py). The check-in response shows `metrics.risk_score=1.03` while the reason reads `"Low complexity (17.4%) - healthy operating range"`. Same word, two different numbers, reads as a bug to anyone watching the output — and the demo's intended audience is exactly first-time evaluators who will be watching.

## Changes

Three label-only renames in `config/governance_config.py`:

| Before                                  | After                              |
|-----------------------------------------|------------------------------------|
| `Low complexity (X%)`                   | `Low risk (X%)`                    |
| `Moderate complexity (X%)`              | `Moderate risk (X%)`               |
| `Complexity threshold reached (X% ≥ Y%)`| `Risk threshold reached (X% ≥ Y%)` |

No semantic change. No test asserted on the prior strings (grep `"'Low complexity\|'Moderate complexity\|'Complexity threshold"` returns only this file).

## Test plan

- [x] Full local suite green (`test-cache.sh --staged`: 8819 passed, 34 skipped, 79.65% coverage)
- [x] Direct branch verification — each of `make_decision`'s three return paths now reads coherently against the value it actually gates on:
  ```
  low:  Low risk (27.0%) - healthy operating range
  mid:  Moderate risk (55.0%) - PAUSE threshold: 70%
  high: Risk threshold reached (85.0% ≥ 70%)
  ```
- [ ] After merge: restart `com.unitares.governance-mcp` and confirm `make demo` reads new labels.

## Notes

- This is the same shape as PR #467's "reason-string change shipped without rollback artifact" issue, hence the PR rather than direct push.
- Deeper question (deferred): there appear to be two `risk_score` quantities in the system — the one fed to `make_decision` (in the "(X%)" reason text) and the one surfaced in `metrics.risk_score` of the check-in response. They diverged on the demo (`metrics`=1.03, `reason`=17.4%). This PR only fixes the label drift; the dual-source question lives separately.