### PR TITLE
watcher: P016 structural verifiers for inner-layer assertion shapes

### DIFF
--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -1347,6 +1347,36 @@ _P016_GETATTR_SUCCESS = re.compile(
     r"""\bgetattr\s*\([^,]+,\s*['"]success['"]"""
 )
 
+# Regex: an inner-layer assertion cue appearing AFTER the flagged outer
+# `.get("success")` check. The two-layer envelope-parsing shape is:
+#
+#     if not data.get("success", False):   # ← outer (flagged)
+#         raise ...
+#     result = data.get("result")
+#     if isinstance(result, dict) and result.get("isError"):   # ← inner cue
+#         raise ...
+#     # or: _raise_for_tool_failure(name, result)
+#     # or: <Typed>Result.model_validate(result)  (raises on inner failure)
+#     # or: _parse_mcp_result(result)
+#
+# When any of these cues appear in the lines following a flagged success check,
+# the operator has already wired the inner-layer assertion; P016 is satisfied.
+_P016_INNER_LAYER_FOLLOWUP = re.compile(
+    r"""\.get\(\s*['"]isError['"]\s*\)"""
+    r"""|\b_raise_for_tool_failure\s*\("""
+    r"""|\b_parse_mcp_result\s*\("""
+    r"""|\b\w*Result\.model_validate\s*\("""
+)
+
+# Regex: helper-function definitions whose body operates on already-unwrapped
+# inner results (the caller did the outer-envelope check before invoking them).
+# `_raise_for_tool_failure(tool_name, raw)` is the canonical SDK shape — single
+# `raw.get("success") is False` check + raise. By convention these helpers do
+# not double-check an envelope they were never handed.
+_P016_INNER_ASSERTION_HELPER_DEF = re.compile(
+    r"""^\s*(?:async\s+)?def\s+_raise_for_\w+\s*\("""
+)
+
 # Regex: P005 resource-leak false positive when the acquire/cursor/connect/lock
 # call sits inside an `async with` (or plain `with`) header — the context
 # manager guarantees release on `__aexit__`, so by construction it is not a
@@ -1581,6 +1611,60 @@ def _has_preceding_persist_call(
     return False
 
 
+def _is_p016_followed_by_inner_layer_check(
+    flagged_line: int,
+    snippet_lines_by_num: dict[int, str],
+    lookahead: int = 20,
+) -> bool:
+    """Detect the canonical two-layer envelope-parsing shape where the
+    flagged outer `.get("success")` is followed within `lookahead` lines
+    by an inner-layer assertion — `result.get("isError")`, a typed
+    `XxxResult.model_validate(...)`, `_raise_for_tool_failure(...)`, or
+    `_parse_mcp_result(...)`. The operator has already wired the inner
+    leg; P016 is satisfied. Caught when qwen3 reflagged the SDK's
+    `_rest_call` (sync_client.py:342, client.py equivalent) on 2026-05-20.
+    """
+    for line_no in range(flagged_line + 1, flagged_line + lookahead + 1):
+        line = snippet_lines_by_num.get(line_no, "")
+        if not line.strip():
+            continue
+        # A new `def`/`class` at the same-or-lower indent ends the function.
+        if _P003_OTHER_DEF.match(line):
+            return False
+        if _P016_INNER_LAYER_FOLLOWUP.search(line):
+            return True
+    return False
+
+
+def _is_p016_inside_inner_assertion_helper(
+    flagged_line: int,
+    snippet_lines_by_num: dict[int, str],
+    lookback: int = 6,
+) -> bool:
+    """Detect that the flagged success check sits inside a helper named
+    `_raise_for_*`. By project convention these helpers operate on
+    already-unwrapped inner results — the caller did the outer-envelope
+    check before invoking them. Shape:
+
+        def _raise_for_tool_failure(tool_name: str, raw: dict) -> None:
+            if raw.get("success") is False:          # ← flagged
+                raise GovernanceConnectionError(...)
+
+    Caught when qwen3 reflagged sync_client.py:458 (and client.py's
+    equivalent at :545) on 2026-05-20.
+    """
+    for line_no in range(flagged_line - 1, flagged_line - lookback - 1, -1):
+        line = snippet_lines_by_num.get(line_no, "")
+        if not line.strip():
+            continue
+        if _P016_INNER_ASSERTION_HELPER_DEF.match(line):
+            return True
+        # A different def header above means we walked past our enclosing fn.
+        if _P003_OTHER_DEF.match(line):
+            return False
+    return False
+
+
 def _verify_finding_against_source(
     finding: Finding, raw_evidence: str, snippet_lines_by_num: dict[int, str]
 ) -> bool:
@@ -1727,6 +1811,36 @@ def _verify_finding_against_source(
         log(
             f"drop P016 {finding.file}:{finding.line} — getattr-style typed "
             f"attribute access (no nested envelope): {src_line.strip()[:80]}",
+            "warning",
+        )
+        return False
+    # P016 specifically: the flagged outer success check is followed within
+    # ~20 lines by an inner-layer assertion (`isError`, `_raise_for_tool_failure`,
+    # `_parse_mcp_result`, or `<Result>.model_validate`). This is the canonical
+    # SDK envelope-parsing shape: outer envelope failure raises on transport
+    # error, then inner-layer assertion raises on tool failure. Caught when
+    # qwen3 reflagged sync_client.py:342 on 2026-05-20.
+    if finding.pattern == "P016" and _is_p016_followed_by_inner_layer_check(
+        finding.line, snippet_lines_by_num
+    ):
+        log(
+            f"drop P016 {finding.file}:{finding.line} — outer success check "
+            f"followed by inner-layer assertion (isError / _raise_for_tool_failure "
+            f"/ model_validate): {src_line.strip()[:80]}",
+            "warning",
+        )
+        return False
+    # P016 specifically: the flagged success check sits inside a `_raise_for_*`
+    # helper that operates on an already-unwrapped inner result. By project
+    # convention the caller validated the outer envelope before invoking it.
+    # Caught when qwen3 reflagged sync_client.py:458 (and client.py:545) on
+    # 2026-05-20.
+    if finding.pattern == "P016" and _is_p016_inside_inner_assertion_helper(
+        finding.line, snippet_lines_by_num
+    ):
+        log(
+            f"drop P016 {finding.file}:{finding.line} — inside _raise_for_* "
+            f"inner-layer assertion helper: {src_line.strip()[:80]}",
             "warning",
         )
         return False

--- a/agents/watcher/patterns.md
+++ b/agents/watcher/patterns.md
@@ -353,6 +353,28 @@ this gap and harden the entire detector pipeline, not just P016. Two
 sweeps in three weeks is enough evidence that the rule's own escape hatch
 (move to experimental) is on the table if the storage fix doesn't ship.
 
+False-positive sweep 2026-05-20: third sweep, two findings (fingerprints
+`651b3427` at `sync_client.py:342`, `2b12fa39` at `sync_client.py:458`).
+Different shape from the 2026-05-04 batch — both flagged lines DO contain
+the quoted `"success"` literal, so the required-token filter could not have
+caught them. Instead they are the **already-unwrapped-result check** shape:
+the operator wired the inner-layer assertion (`result.get("isError")` at
+sync_client.py:352, or the `_raise_for_tool_failure` helper itself), but the
+model sees a single `.get("success")` and flags. Closed by adding two
+structural verifiers parallel to `_P016_GETATTR_SUCCESS`:
+
+- `_is_p016_followed_by_inner_layer_check` walks forward ~20 lines for
+  `isError`, `_raise_for_tool_failure(`, `_parse_mcp_result(`, or
+  `<Result>.model_validate(` as the inner-leg cue.
+- `_is_p016_inside_inner_assertion_helper` walks backward up to 6 lines for
+  a `def _raise_for_*(` enclosing header — by convention these helpers
+  operate on already-unwrapped inner results.
+
+The `src_line` storage fix from the 2026-05-04 note remains separately
+useful for line-drift FPs and is tracked outside this rule. Move-to-
+experimental stays off the table as long as the structural-verifier path
+keeps closing new shapes.
+
 **Why this is in the active library and not experimental:** the shape is
 reasonably lexical — the model can spot a conditional on one success flag
 that ignores a nested success flag in the same response object. If Qwen3

--- a/agents/watcher/tests/test_agent.py
+++ b/agents/watcher/tests/test_agent.py
@@ -2370,6 +2370,159 @@ def test_p016_kept_for_dict_envelope_parse(watcher_module):
         ), f"P016 should fire on dict-envelope parse: {src_line!r}"
 
 
+def test_p016_dropped_when_followed_by_inner_layer_check(watcher_module):
+    """The canonical SDK two-layer shape: outer `data.get("success")` raises
+    on transport failure, then inner `result.get("isError")` raises on tool
+    failure. Caught when qwen3 reflagged
+    agents/sdk/src/unitares_sdk/sync_client.py:342 on 2026-05-20 (fingerprint
+    651b3427) — the operator had already wired both legs."""
+    f = watcher_module.Finding(
+        pattern="P016",
+        file="/repo/agents/sdk/src/unitares_sdk/sync_client.py",
+        line=342,
+        hint="t",
+        severity="high",
+        detected_at="2026-05-20T00:00:00Z",
+        model_used="t",
+    )
+    snippet = {
+        342: 'if not data.get("success", False):',
+        343: '    error = data.get("error", "Unknown error")',
+        344: '    raise GovernanceConnectionError(f"Tool {tool_name} failed: {error}")',
+        345: "",
+        346: 'result = data.get("result")',
+        347: "if result is None:",
+        348: '    raise GovernanceConnectionError(f"No result from {tool_name}")',
+        349: "",
+        350: "# Check MCP-level isError flag (outer envelope success doesn't",
+        351: "# guarantee the tool itself succeeded).",
+        352: 'if isinstance(result, dict) and result.get("isError"):',
+    }
+    assert not watcher_module._verify_finding_against_source(f, "", snippet), (
+        "P016 should be dropped when outer success check is followed by an "
+        "inner result.get('isError') assertion"
+    )
+
+
+def test_p016_dropped_when_followed_by_raise_for_tool_failure_call(watcher_module):
+    """A caller that does `result = self._rest_call(...)` then
+    `self._raise_for_tool_failure(tool_name, result)` has wired the inner-layer
+    assertion via a helper. The outer `.get("success")` in `_rest_call` (or a
+    parallel one in `call_tool`) should not be flagged."""
+    f = watcher_module.Finding(
+        pattern="P016",
+        file="/repo/agents/sdk/src/unitares_sdk/sync_client.py",
+        line=100,
+        hint="t",
+        severity="high",
+        detected_at="2026-05-20T00:00:00Z",
+        model_used="t",
+    )
+    snippet = {
+        100: 'if not data.get("success", False):',
+        101: "    raise GovernanceConnectionError('transport failed')",
+        102: "result = data.get('result')",
+        103: "self._raise_for_tool_failure(tool_name, result)",
+    }
+    assert not watcher_module._verify_finding_against_source(f, "", snippet)
+
+
+def test_p016_dropped_when_followed_by_model_validate(watcher_module):
+    """Typed-result validation through pydantic's `model_validate(...)` raises
+    on schema mismatch / explicit failure markers, so it serves as the inner
+    leg of the two-layer check."""
+    f = watcher_module.Finding(
+        pattern="P016",
+        file="/repo/agents/sdk/src/unitares_sdk/sync_client.py",
+        line=200,
+        hint="t",
+        severity="high",
+        detected_at="2026-05-20T00:00:00Z",
+        model_used="t",
+    )
+    snippet = {
+        200: 'if not data.get("success", False):',
+        201: "    raise GovernanceConnectionError('transport failed')",
+        202: "return OnboardResult.model_validate(data)",
+    }
+    assert not watcher_module._verify_finding_against_source(f, "", snippet)
+
+
+def test_p016_dropped_inside_raise_for_tool_failure_helper(watcher_module):
+    """The `_raise_for_*` helper-fn shape operates on an already-unwrapped
+    inner result; the caller has done the outer-envelope check before
+    invoking it. Caught when qwen3 reflagged sync_client.py:458 on
+    2026-05-20 (fingerprint 2b12fa39)."""
+    f = watcher_module.Finding(
+        pattern="P016",
+        file="/repo/agents/sdk/src/unitares_sdk/sync_client.py",
+        line=458,
+        hint="t",
+        severity="high",
+        detected_at="2026-05-20T00:00:00Z",
+        model_used="t",
+    )
+    snippet = {
+        456: "    @staticmethod",
+        457: "    def _raise_for_tool_failure(tool_name: str, raw: dict) -> None:",
+        458: '        if raw.get("success") is False:',
+        459: '            error = raw.get("error", "Unknown error")',
+        460: '            raise GovernanceConnectionError(f"Tool {tool_name} failed: {error}")',
+    }
+    assert not watcher_module._verify_finding_against_source(f, "", snippet), (
+        "P016 should be dropped inside _raise_for_* helper — the helper "
+        "operates on an already-unwrapped inner result"
+    )
+
+
+def test_p016_kept_when_no_inner_layer_followup(watcher_module):
+    """Negative case: a bare `data.get("success")` check in a function that
+    writes state without an inner-leg assertion is the original bug shape.
+    This is the parse_onboard pattern (scripts/unitares, commit 718ccd3)."""
+    f = watcher_module.Finding(
+        pattern="P016",
+        file="/repo/scripts/unitares",
+        line=100,
+        hint="t",
+        severity="high",
+        detected_at="2026-05-20T00:00:00Z",
+        model_used="t",
+    )
+    snippet = {
+        100: 'if data.get("success"):',
+        101: "    write_session_file(data.get('result', {}))",
+        102: "    log.info('session written')",
+        103: "    return True",
+    }
+    assert watcher_module._verify_finding_against_source(f, "", snippet), (
+        "P016 should fire when outer check is not followed by an inner-layer "
+        "assertion — this is the real bug shape"
+    )
+
+
+def test_p016_kept_when_helper_def_has_different_name(watcher_module):
+    """Negative case: a helper whose name is NOT `_raise_for_*` doesn't
+    get the inner-assertion-helper benefit of the doubt. Without the inner
+    leg, the bare success check is still the bug shape."""
+    f = watcher_module.Finding(
+        pattern="P016",
+        file="/repo/src/something.py",
+        line=458,
+        hint="t",
+        severity="high",
+        detected_at="2026-05-20T00:00:00Z",
+        model_used="t",
+    )
+    snippet = {
+        456: "    @staticmethod",
+        457: "    def process_response(tool_name: str, raw: dict) -> None:",
+        458: '        if raw.get("success") is False:',
+        459: '            log.warning("failed silently")',
+        460: "            return None",
+    }
+    assert watcher_module._verify_finding_against_source(f, "", snippet)
+
+
 # ---------------------------------------------------------------------------
 # violation_class loading
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the 2026-05-20 P016 false-positive sweep on `agents/sdk/src/unitares_sdk/sync_client.py` (fingerprints `651b3427` at line 342, `2b12fa39` at line 458). Different shape from the 2026-05-04 batch — both lines literally contain `"success"`, so the existing required-token filter couldn't drop them. Adds two structural verifiers parallel to `_P016_GETATTR_SUCCESS`.

- `_is_p016_followed_by_inner_layer_check` — forward walker (~20 lines) for `result.get("isError")`, `_raise_for_tool_failure(`, `_parse_mcp_result(`, or `<Result>.model_validate(`. Catches `sync_client.py:342` (the SDK's `_rest_call` two-layer check).
- `_is_p016_inside_inner_assertion_helper` — backward walker (~6 lines) for an enclosing `def _raise_for_*(`. By convention these helpers operate on already-unwrapped inner results. Catches `sync_client.py:458` and `client.py:545`.

`patterns.md` records the third-sweep distinction. The separate `src_line`-storage fix from the 2026-05-04 note remains useful for line-drift FPs and stays as follow-up.

## Test plan

- [x] 6 new P016 tests pinning both shapes plus negatives (bare success check without followup; helper named differently than `_raise_for_*`)
- [x] `pytest agents/watcher/tests/` — 246 passed locally
- [x] `./scripts/dev/test-cache.sh --staged` — 8825 passed, 34 skipped (exit 0)
- [ ] CI green