### PR TITLE
fix(api): canonical metrics.risk_score across all response modes

### DIFF
--- a/scripts/demo/quick_demo.py
+++ b/scripts/demo/quick_demo.py
@@ -79,9 +79,13 @@ def banner(title: str) -> None:
 
 
 def fmt_metrics(m: dict) -> str:
+    # risk_score: smoothed mean-of-10, the value make_decision gated on
+    # risk_score_latest: raw last observation (spike), shown alongside
+    latest = m.get("risk_score_latest")
+    latest_str = f" latest={latest:.2f}" if latest is not None else ""
     return (
         f"E={m['E']:+.2f} I={m['I']:+.2f} S={m['S']:+.2f} V={m['V']:+.2f}  "
-        f"coh={m['coherence']:.2f} risk={m['risk_score']:.2f}"
+        f"coh={m['coherence']:.2f} risk={m['risk_score']:.2f}{latest_str}"
     )
 
 
@@ -122,17 +126,25 @@ def main() -> int:
         print(f"     reason: {d['reason']}")
 
     banner("3. what just happened")
-    print("  Risk trajectory across the seven steps:")
-    print("    step 1–3 (clean work):              risk ≈ 0.27")
-    print("    step 4   (calibration drift):       risk ≈ 0.29")
-    print("    step 5–6 (confidence collapse):     risk → 0.95")
-    print("    step 7   (overconfident on garble): risk > 1.00")
+    print("  Two risk signals to watch in each step above:")
     print()
-    print("  Verdicts stayed `proceed` because this is a brand-new agent —")
-    print("  self-relative scoring needs ~30 check-ins to build a Welford baseline.")
-    print("  On a warm agent the same drift would flip to `guide` then `pause`.")
-    print("  The drift is *legible in the metrics from check-in #1*; the verdict is")
-    print("  what the system would gate on once it has enough self-history to trust.")
+    print("  • risk         = smoothed mean of the last 10 observations.")
+    print("                   This is the value `make_decision` gates on, and")
+    print("                   the percentage you see in `decision.reason`.")
+    print("  • latest       = raw last observation. A single bad check-in can")
+    print("                   spike this without moving the gating signal.")
+    print()
+    print("  On this 7-step cold-agent trajectory, latest climbs sharply (raw")
+    print("  signal sees the drift) while risk stays low (smoothing damps a")
+    print("  short history). Verdicts therefore stay `proceed`.")
+    print()
+    print("  This is the system being conservative on a fresh agent —")
+    print("  self-relative scoring needs ~30 check-ins to build a Welford")
+    print("  baseline. On a warm agent the same drift would shift the smoothed")
+    print("  risk faster and flip to `guide` or `pause`. The honest read of")
+    print("  this demo: latest tells you what just happened, risk tells you")
+    print("  what the gate believes — and the gap between them is the cold-")
+    print("  start cost.")
 
     banner("done")
     print("  • Every number above came from check-in responses — no DB queries.")

--- a/src/mcp_handlers/response_formatter.py
+++ b/src/mcp_handlers/response_formatter.py
@@ -137,7 +137,7 @@ def _format_standard(response_data: dict, task_type: str) -> dict:
     S = float(metrics.get("S", 0.1))
     V = float(metrics.get("V", 0.0))
     coherence = float(metrics.get("coherence", 0.5))
-    risk_score = metrics.get("latest_risk_score") or metrics.get("risk_score")
+    risk_score = metrics.get("risk_score")
 
     temp_state = GovernanceState()
     temp_state.unitaires_state = State(E=E, I=I, S=S, V=V)
@@ -337,7 +337,8 @@ def _format_minimal(response_data: dict, using_default_mode: bool, saved_trust_t
         "S": metrics.get("S"),
         "V": metrics.get("V"),
         "coherence": metrics.get("coherence"),
-        "risk_score": metrics.get("latest_risk_score") or metrics.get("risk_score"),
+        "risk_score": metrics.get("risk_score"),
+        "risk_score_latest": metrics.get("latest_risk_score"),
     }
 
     margin = decision.get("margin")
@@ -366,9 +367,12 @@ def _format_compact(response_data: dict, using_default_mode: bool, saved_trust_t
     metrics = response_data.get("metrics", {}) if isinstance(response_data.get("metrics"), dict) else {}
     decision = response_data.get("decision", {}) if isinstance(response_data.get("decision"), dict) else {}
 
-    canonical_risk = metrics.get("latest_risk_score")
-    if canonical_risk is None:
-        canonical_risk = metrics.get("risk_score")
+    # `metrics.risk_score` is the smoothed gating value (mean of last 10
+    # observations) — the same number `make_decision` reasoned over.
+    # `latest_risk_score` is the raw most-recent observation; surface it
+    # alongside so readers can see both the gating signal and the spike.
+    canonical_risk = metrics.get("risk_score")
+    latest_risk = metrics.get("latest_risk_score")
 
     # #428: wrap verdict with meaning + next_action at the response surface.
     # The bare metrics["verdict"] is preserved for internal readers; this is
@@ -381,6 +385,7 @@ def _format_compact(response_data: dict, using_default_mode: bool, saved_trust_t
         "V": metrics.get("V"),
         "coherence": metrics.get("coherence"),
         "risk_score": canonical_risk,
+        "risk_score_latest": latest_risk,
         "phi": metrics.get("phi"),
         "verdict": explain_verdict(metrics.get("verdict")),
         "lambda1": metrics.get("lambda1"),

--- a/tests/test_response_formatter.py
+++ b/tests/test_response_formatter.py
@@ -46,8 +46,8 @@ def _sample_response():
             "S": 0.1,
             "V": -0.02,
             "coherence": 0.92,
-            "risk_score": 0.08,
-            "latest_risk_score": 0.08,
+            "risk_score": 0.08,           # smoothed (gating)
+            "latest_risk_score": 0.42,    # raw last observation (spike)
             "phi": 1.23,
             "verdict": "approve",
             "lambda1": 0.9,
@@ -147,16 +147,23 @@ class TestFormatMinimal:
         result = _format_minimal(data, using_default_mode=False, saved_trust_tier=None)
         assert "trust_tier" not in result
 
-    def test_risk_score_from_latest(self):
+    def test_risk_score_is_canonical_gating_value(self):
+        """metrics.risk_score in the response must be the smoothed gating
+        value (the one make_decision reasoned over), not the raw spike."""
         data = _sample_response()
+        # Sample has risk_score=0.08 (smoothed), latest_risk_score=0.42 (spike).
         result = _format_minimal(data, using_default_mode=False, saved_trust_tier=None)
         assert result["risk_score"] == 0.08
+        assert result["risk_score_latest"] == 0.42
 
-    def test_risk_score_fallback(self):
+    def test_risk_score_latest_missing(self):
+        """If latest_risk_score is absent, risk_score still surfaces the
+        canonical gating value; latest is None."""
         data = _sample_response()
         data["metrics"].pop("latest_risk_score")
         result = _format_minimal(data, using_default_mode=False, saved_trust_tier=None)
-        assert result["risk_score"] == 0.08  # falls back to risk_score
+        assert result["risk_score"] == 0.08
+        assert result["risk_score_latest"] is None
 
     def test_empty_decision(self):
         data = _sample_response()
@@ -230,11 +237,24 @@ class TestFormatCompact:
         result = _format_compact(data, using_default_mode=False, saved_trust_tier=None)
         assert "_tip" not in result
 
-    def test_risk_score_fallback(self):
+    def test_risk_score_is_canonical_gating_value(self):
+        """Compact response's metrics.risk_score must be the smoothed gating
+        value (matches decision.reason). Raw last observation lives in
+        risk_score_latest."""
+        data = _sample_response()
+        # Sample has risk_score=0.08 (smoothed), latest_risk_score=0.42 (spike).
+        result = _format_compact(data, using_default_mode=False, saved_trust_tier=None)
+        assert result["metrics"]["risk_score"] == 0.08
+        assert result["metrics"]["risk_score_latest"] == 0.42
+
+    def test_risk_score_latest_missing(self):
+        """If latest_risk_score is absent, risk_score still surfaces canonical
+        gating value; risk_score_latest is None."""
         data = _sample_response()
         data["metrics"]["latest_risk_score"] = None
         result = _format_compact(data, using_default_mode=False, saved_trust_tier=None)
         assert result["metrics"]["risk_score"] == 0.08
+        assert result["metrics"]["risk_score_latest"] is None
 
     def test_empty_metrics(self):
         data = _sample_response()


### PR DESCRIPTION
## Summary

The compact, minimal, and interpreted response formatters silently overrode `metrics.risk_score` with `metrics.latest_risk_score`, surfacing the raw last observation under the canonical name. The smoothed mean-of-10 (the value `make_decision` actually gates on, and the percentage shown in `decision.reason`) was hidden from compact/minimal consumers entirely.

## Why this matters

Surfaced by the `make demo` script (PR #493 sibling). On a 7-step cold-agent trajectory:

| field | value | what it is |
|---|---|---|
| `decision.reason` "Low risk (17%)" | 0.17 | smoothed mean-of-10 — what gating used |
| `metrics.risk_score` (compact, BEFORE fix) | 1.03 | raw last observation — silently relabeled |
| `metrics.latest_risk_score` (full mode only) | 1.03 | raw last observation — honestly named |

Same field name, two unrelated quantities, no way to tell from the compact response alone. Anyone using the SDK's `sync_client.checkin()` was seeing the spike value as `metrics.risk_score` while `decision.reason` cited a different number.

## Changes

- **`src/mcp_handlers/response_formatter.py`** — drop the `latest_risk_score or risk_score` override at three formatter sites (L140 interpreted, L340 minimal, L369-371 compact). Compact and minimal now surface both values explicitly:
  ```
  metrics.risk_score         = smoothed mean-of-10 (the gating value)
  metrics.risk_score_latest  = raw last observation (the spike)
  ```
- **`tests/test_response_formatter.py`** — sample data now has `risk_score=0.08` and `latest_risk_score=0.42` (divergent, so the contract is testable). Old `test_risk_score_from_latest` renamed/rewritten to `test_risk_score_is_canonical_gating_value`; old fallback test rewritten to assert `risk_score_latest is None` when source field is missing.
- **`scripts/demo/quick_demo.py`** — prints both fields per step. Rewrites the "what just happened" panel: cold-agent damping is now the story (latest climbs, smoothed gate damps, verdicts stay `proceed` because the gate honestly doesn't see drift yet on a 7-step history). The previous narrative was implicitly reading the misleading override.

## What did NOT change

- Gating logic (`make_decision`), ODE, behavioral assessment, audit log, dashboard.
- `full` response mode already exposed both fields under their honest names; unchanged.
- `metrics.risk_score` in the underlying monitor metrics (line 1189 of `governance_monitor.py`) was always the smoothed value; the lie was purely in the response formatters.

## Test plan

- [x] Full local suite: `8820 passed, 34 skipped, 79.64% coverage` (`./scripts/dev/test-cache.sh --staged`)
- [x] Targeted: `tests/test_response_formatter.py` 98 passed
- [ ] After merge: restart `com.unitares.governance-mcp`; rerun `make demo`; confirm `risk` and `latest` print separately and the smoothed value matches the `reason` percentage.

## Coordination with PR #493

PR #493 fixed the **labels** in `decision.reason` (called the value "complexity" when it was risk). This PR fixes the **field name collision** in the response surface (called the spike "risk_score" when the gate used the smoothed value). Together, they make the reason text and `metrics.risk_score` tell the same story end-to-end. The two PRs touch disjoint files and can land in either order; merging #493 first is fine.

## Open question, not addressed here

Whether the mean-of-10 smoothing is the right window for a fresh agent is a separate design question. The demo's new narrative is honest about the cold-start cost but doesn't take a position on whether the smoothing is calibrated correctly. If audits suggest the gate is too slow on short histories, that's a follow-up.