### PR TITLE
[codex] Fix calibration no-data and add state epistemic class

### DIFF
--- a/db/postgres/migrations/040_agent_state_epistemic_class.sql
+++ b/db/postgres/migrations/040_agent_state_epistemic_class.sql
@@ -1,0 +1,58 @@
+-- 040_agent_state_epistemic_class.sql
+--
+-- Forward-only warrant label for core.agent_state rows. This intentionally
+-- does NOT backfill historical rows: pre-040 process_agent_update inputs
+-- (response_text / complexity / confidence) were not persisted in a
+-- recoverable form, so old rows must remain epistemically opaque rather than
+-- be relabeled by regex or transport heuristics.
+--
+-- `epistemic_class` avoids the existing sequential_calibration.signal_source
+-- vocabulary, which routes hard-outcome channels such as "tests" and "tasks".
+--
+-- Values:
+--   agent_report              agent-authored process_agent_update report
+--   substrate_observation     raw substrate fact / measurement
+--   substrate_interpretation  hook/tool-derived interpretation or heuristic
+--   prediction                explicit forward claim intended for scoring
+--   synthetic                 server-authored bootstrap/synthetic row
+--
+-- This migration does not drop/recreate core.mv_latest_agent_states. Existing
+-- deployments keep the old materialized-view projection; the Python read path
+-- falls back to the base table when the matview lacks epistemic_class. Fresh
+-- installs from schema.sql expose the column in the matview immediately.
+--
+-- Rollback shape: remove column epistemic_class and its index/constraint in a
+-- separately approved rollback migration.
+
+ALTER TABLE core.agent_state
+    ADD COLUMN IF NOT EXISTS epistemic_class text;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'ck_agent_state_epistemic_class'
+          AND conrelid = 'core.agent_state'::regclass
+    ) THEN
+        ALTER TABLE core.agent_state
+            ADD CONSTRAINT ck_agent_state_epistemic_class
+            CHECK (
+                epistemic_class IS NULL OR epistemic_class IN (
+                    'agent_report',
+                    'substrate_observation',
+                    'substrate_interpretation',
+                    'prediction',
+                    'synthetic'
+                )
+            );
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_agent_state_epistemic_class
+    ON core.agent_state (epistemic_class, recorded_at DESC)
+    WHERE epistemic_class IS NOT NULL;
+
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (40, 'agent_state_epistemic_class', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/db/postgres/schema.sql
+++ b/db/postgres/schema.sql
@@ -162,6 +162,17 @@ CREATE TABLE IF NOT EXISTS core.agent_state (
     -- Full state snapshot (for complex queries)
     state_json          JSONB NOT NULL DEFAULT '{}'::jsonb,
 
+    -- Forward-only warrant label. Historical rows may be NULL because
+    -- pre-040 process_agent_update inputs were not recoverably persisted.
+    epistemic_class     TEXT
+                        CHECK (epistemic_class IS NULL OR epistemic_class IN (
+                            'agent_report',
+                            'substrate_observation',
+                            'substrate_interpretation',
+                            'prediction',
+                            'synthetic'
+                        )),
+
     -- Epoch (added by migration 007; backported here so base DDL is honest
     -- under R1 v3.3-F. Bumped when EISV coupling constants, coherence formulas,
     -- or calibration logic change in a way that invalidates existing rows.)
@@ -174,6 +185,9 @@ CREATE TABLE IF NOT EXISTS core.agent_state (
 CREATE INDEX IF NOT EXISTS idx_agent_state_identity_time ON core.agent_state(identity_id, recorded_at DESC);
 CREATE INDEX IF NOT EXISTS idx_agent_state_regime ON core.agent_state(regime) WHERE regime != 'nominal';
 CREATE INDEX IF NOT EXISTS idx_agent_state_epoch ON core.agent_state(epoch);
+CREATE INDEX IF NOT EXISTS idx_agent_state_epistemic_class
+    ON core.agent_state(epistemic_class, recorded_at DESC)
+    WHERE epistemic_class IS NOT NULL;
 
 -- -----------------------------------------------------------------------------
 -- Schema Migrations (track applied migrations)
@@ -491,7 +505,7 @@ CREATE MATERIALIZED VIEW core.mv_latest_agent_states AS
 SELECT DISTINCT ON (s.identity_id)
        s.state_id, s.identity_id, i.agent_id, s.recorded_at,
        s.entropy, s.integrity, s.stability_index, s.volatility,
-       s.regime, s.coherence, s.state_json
+       s.regime, s.coherence, s.epistemic_class, s.state_json
 FROM core.agent_state s
 JOIN core.identities i ON i.identity_id = s.identity_id
 ORDER BY s.identity_id, s.recorded_at DESC;

--- a/scripts/ops/backfill_calibration.py
+++ b/scripts/ops/backfill_calibration.py
@@ -177,10 +177,12 @@ async def backfill(apply: bool = False, verbose: bool = False) -> dict:
     if apply:
         metrics = tracker.compute_metrics()
         result["tracker_state"] = {
+            "status": metrics.get("status", "no_data"),
             "eligible_samples": metrics.get("eligible_samples", 0),
-            "log_evidence": metrics.get("log_evidence", 0),
-            "capped_alarm": metrics.get("capped_alarm", 0),
         }
+        for field in ("log_evidence", "capped_alarm"):
+            if field in metrics:
+                result["tracker_state"][field] = metrics[field]
 
     return result
 
@@ -207,9 +209,12 @@ def main():
     if "tracker_state" in result:
         ts = result["tracker_state"]
         print(f"\n  Tracker state after backfill:")
+        print(f"    status:           {ts['status']}")
         print(f"    eligible_samples: {ts['eligible_samples']}")
-        print(f"    log_evidence:     {ts['log_evidence']:.4f}")
-        print(f"    capped_alarm:     {ts['capped_alarm']:.4f}")
+        if "log_evidence" in ts:
+            print(f"    log_evidence:     {ts['log_evidence']:.4f}")
+        if "capped_alarm" in ts:
+            print(f"    capped_alarm:     {ts['capped_alarm']:.4f}")
 
     return 0
 

--- a/src/agent_storage.py
+++ b/src/agent_storage.py
@@ -536,6 +536,7 @@ async def record_agent_state(
     verdict: Optional[str] = None,
     action: Optional[str] = None,
     provenance_context: Optional[Mapping[str, Any]] = None,
+    epistemic_class: Optional[str] = "agent_report",
 ) -> int:
     """
     Record agent EISV state to PostgreSQL.
@@ -579,6 +580,8 @@ async def record_agent_state(
         state_json["action"] = action
     if provenance_context:
         state_json["provenance_context"] = dict(provenance_context)
+    if epistemic_class is not None:
+        state_json["epistemic_class"] = epistemic_class
 
     state_id = await db.record_agent_state(
         identity_id=identity.identity_id,
@@ -590,6 +593,7 @@ async def record_agent_state(
         coherence=coherence,
         state_json=state_json,
         risk_score=risk_score,
+        epistemic_class=epistemic_class,
     )
 
     return state_id

--- a/src/db/base.py
+++ b/src/db/base.py
@@ -66,6 +66,7 @@ class AgentStateRecord:
     void: float = 0.1
     regime: str = "nominal"
     coherence: float = 1.0
+    epistemic_class: Optional[str] = None
     state_json: Dict[str, Any] = field(default_factory=dict)
 
 
@@ -304,6 +305,8 @@ class DatabaseBackend(ABC):
         regime: str,
         coherence: float,
         state_json: Optional[Dict[str, Any]] = None,
+        risk_score: Optional[float] = None,
+        epistemic_class: Optional[str] = None,
     ) -> int:
         """Record a new state snapshot. Returns state_id."""
         pass
@@ -427,4 +430,3 @@ class DatabaseBackend(ABC):
     ) -> List[Dict[str, Any]]:
         """Query tool usage records."""
         pass
-

--- a/src/db/mixins/state.py
+++ b/src/db/mixins/state.py
@@ -26,20 +26,26 @@ class StateMixin:
         coherence: float,
         state_json: Optional[Dict[str, Any]] = None,
         risk_score: Optional[float] = None,
+        epistemic_class: Optional[str] = None,
     ) -> int:
         from config.governance_config import GovernanceConfig
+        payload = dict(state_json or {})
+        if epistemic_class is not None:
+            payload.setdefault("epistemic_class", epistemic_class)
         async with self.acquire() as conn:
             state_id = await conn.fetchval(
                 """
                 INSERT INTO core.agent_state
-                    (identity_id, entropy, integrity, stability_index, volatility, regime, coherence, state_json, epoch, risk_score)
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+                    (identity_id, entropy, integrity, stability_index, volatility, regime,
+                     coherence, state_json, epoch, risk_score, epistemic_class)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
                 RETURNING state_id
                 """,
                 identity_id, entropy, integrity, stability_index, void,  # void maps to volatility column
-                regime, coherence, json.dumps(state_json or {}),
+                regime, coherence, json.dumps(payload),
                 GovernanceConfig.CURRENT_EPOCH,
                 risk_score,
+                epistemic_class,
             )
             # Matview refresh moved to periodic_matview_refresh() in background_tasks.py
             return state_id
@@ -64,18 +70,20 @@ class StateMixin:
         """
         import asyncpg
         from config.governance_config import GovernanceConfig
+        payload = dict(state_json)
+        payload.setdefault("epistemic_class", "synthetic")
         async with self.acquire() as conn:
             try:
                 state_id = await conn.fetchval(
                     """
                     INSERT INTO core.agent_state
                         (identity_id, entropy, integrity, stability_index, volatility,
-                         regime, coherence, state_json, epoch, synthetic)
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, true)
+                         regime, coherence, state_json, epoch, synthetic, epistemic_class)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, true, 'synthetic')
                     RETURNING state_id
                     """,
                     identity_id, entropy, integrity, stability_index, void,
-                    regime, coherence, json.dumps(state_json),
+                    regime, coherence, json.dumps(payload),
                     GovernanceConfig.CURRENT_EPOCH,
                 )
                 return state_id, True
@@ -219,7 +227,7 @@ class StateMixin:
                 """
                 SELECT s.state_id, s.identity_id, i.agent_id, s.recorded_at,
                        s.entropy, s.integrity, s.stability_index, s.volatility,
-                       s.regime, s.coherence, s.state_json
+                       s.regime, s.coherence, s.state_json, s.epistemic_class
                 FROM core.agent_state s
                 JOIN core.identities i ON i.identity_id = s.identity_id
                 WHERE s.identity_id = $1 AND s.epoch = $2
@@ -261,7 +269,7 @@ class StateMixin:
             base_sql = """
                 SELECT s.state_id, s.identity_id, i.agent_id, s.recorded_at,
                        s.entropy, s.integrity, s.stability_index, s.volatility,
-                       s.regime, s.coherence, s.state_json
+                       s.regime, s.coherence, s.state_json, s.epistemic_class
                 FROM core.agent_state s
                 JOIN core.identities i ON i.identity_id = s.identity_id
                 WHERE s.identity_id = $1 AND s.epoch = $2
@@ -291,12 +299,14 @@ class StateMixin:
                     """
                     SELECT state_id, identity_id, agent_id, recorded_at,
                            entropy, integrity, stability_index, volatility,
-                           regime, coherence, state_json
+                           regime, coherence, state_json, epistemic_class
                     FROM core.mv_latest_agent_states
                     """,
                 )
             except Exception:
-                # Matview may not exist yet — fall back to base table.
+                # Matview may not exist yet, or may still be on the pre-040
+                # projection that lacks epistemic_class. Fall back to the base
+                # table rather than requiring a DROP/CREATE matview migration.
                 # Filter `synthetic = false` here because the base table
                 # contains both measured and synthetic rows.
                 from config.governance_config import GovernanceConfig
@@ -306,7 +316,7 @@ class StateMixin:
                     SELECT DISTINCT ON (s.identity_id)
                            s.state_id, s.identity_id, i.agent_id, s.recorded_at,
                            s.entropy, s.integrity, s.stability_index, s.volatility,
-                           s.regime, s.coherence, s.state_json
+                           s.regime, s.coherence, s.state_json, s.epistemic_class
                     FROM core.agent_state s
                     JOIN core.identities i ON i.identity_id = s.identity_id
                     WHERE s.epoch = $1
@@ -414,6 +424,12 @@ class StateMixin:
 
     def _row_to_agent_state(self, row) -> AgentStateRecord:
         sj = json.loads(row["state_json"]) if isinstance(row["state_json"], str) else (row["state_json"] or {})
+        try:
+            epistemic_class = row["epistemic_class"]
+        except (KeyError, IndexError):
+            epistemic_class = None
+        if epistemic_class is not None:
+            sj.setdefault("epistemic_class", epistemic_class)
         return AgentStateRecord(
             state_id=row["state_id"],
             identity_id=row["identity_id"],
@@ -426,5 +442,6 @@ class StateMixin:
             void=row["volatility"],  # Map database column 'volatility' to 'void' field
             regime=row["regime"],
             coherence=row["coherence"],
+            epistemic_class=epistemic_class,
             state_json=sj,
         )

--- a/src/mcp_handlers/identity/bootstrap_checkin.py
+++ b/src/mcp_handlers/identity/bootstrap_checkin.py
@@ -103,6 +103,7 @@ def build_state_json(filled: Dict[str, Any]) -> Dict[str, Any]:
         "confidence": filled["confidence"],
         "task_type": filled["task_type"],
         "ethical_drift": filled["ethical_drift"],
+        "epistemic_class": "synthetic",
     }
 
 

--- a/src/mcp_handlers/schemas/core.py
+++ b/src/mcp_handlers/schemas/core.py
@@ -15,6 +15,20 @@ TaskType = Literal[
 
 ToolResultKind = Literal["command", "test", "lint", "build", "file_op", "tool_call"]
 
+StateEpistemicClass = Literal[
+    "agent_report",
+    "substrate_observation",
+    "substrate_interpretation",
+    "prediction",
+    "synthetic",
+]
+ProcessUpdateEpistemicClass = Literal[
+    "agent_report",
+    "substrate_observation",
+    "substrate_interpretation",
+    "prediction",
+]
+
 
 def _infer_tool_result_kind(tool: Any, summary: Any = "") -> str:
     text = f"{tool or ''} {summary or ''}".strip().lower()
@@ -194,6 +208,16 @@ class ProcessAgentUpdateParams(AgentIdentityMixin):
         ge=0.0, 
         le=1.0,
         description="Confidence level for this update (0-1, optional)."
+    )
+    epistemic_class: ProcessUpdateEpistemicClass = Field(
+        default="agent_report",
+        description=(
+            "Forward-only storage label for this state row. Defaults to "
+            "agent_report. Use substrate_observation for raw measured facts, "
+            "substrate_interpretation for hook/tool-derived heuristics, "
+            "and prediction for explicit forward claims. Server-authored "
+            "bootstrap rows are labeled synthetic internally."
+        ),
     )
     response_mode: Literal["minimal", "compact", "standard", "full", "mirror", "auto"] = Field(
         default="auto",

--- a/src/mcp_handlers/updates/context.py
+++ b/src/mcp_handlers/updates/context.py
@@ -31,6 +31,7 @@ class UpdateContext:
     response_text: str = ""
     complexity: float = 0.5
     confidence: Optional[float] = None
+    epistemic_class: str = "agent_report"
     ethical_drift: List[float] = field(default_factory=lambda: [0.0, 0.0, 0.0])
     task_type: str = "mixed"
     calibration_correction_info: Optional[str] = None

--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -32,6 +32,13 @@ from ..support.tool_hints import (
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 logger = get_logger(__name__)
 
+_ALLOWED_EPISTEMIC_CLASSES = {
+    "agent_report",
+    "substrate_observation",
+    "substrate_interpretation",
+    "prediction",
+}
+
 _STRONG_IDENTITY_SOURCES = {
     "continuity_token",
     "explicit_client_session_id",
@@ -520,6 +527,18 @@ def transform_inputs(ctx: UpdateContext) -> Optional[Sequence[TextContent]]:
         except Exception as e:
             logger.debug(f"Calibration correction skipped: {e}")
 
+    # Epistemic class: forward-only storage label for the state row. Pydantic
+    # validates the public schema; this fallback keeps non-schema internal
+    # callers on the honest default.
+    raw_epistemic_class = ctx.arguments.get("epistemic_class") or "agent_report"
+    if raw_epistemic_class not in _ALLOWED_EPISTEMIC_CLASSES:
+        logger.warning(
+            "Unknown epistemic_class %r on process_agent_update; defaulting to agent_report",
+            raw_epistemic_class,
+        )
+        raw_epistemic_class = "agent_report"
+    ctx.epistemic_class = raw_epistemic_class
+
     # Low-assurance identity should not drive high-confidence updates.
     if ctx.identity_assurance.get("tier") == "weak" and ctx.confidence is not None:
         original_confidence = ctx.confidence
@@ -594,7 +613,8 @@ async def prepare_unlocked_inputs(ctx: UpdateContext) -> None:
         "parameters": np.array(ctx.arguments.get("parameters", [])),
         "ethical_drift": np.array(ctx.ethical_drift),
         "response_text": ctx.response_text,
-        "complexity": ctx.complexity
+        "complexity": ctx.complexity,
+        "epistemic_class": ctx.epistemic_class,
     }
     try:
         from src.provenance_context import (
@@ -1500,6 +1520,7 @@ async def execute_post_update_effects(ctx: UpdateContext) -> None:
             action=(ctx.result.get('decision') or {}).get('sub_action')
                 or (ctx.result.get('decision') or {}).get('action'),
             provenance_context=ctx.agent_state.get("provenance_context"),
+            epistemic_class=ctx.epistemic_class,
         )
         logger.debug(f"PostgreSQL: Recorded state for {agent_id}")
     except ValueError:
@@ -1580,6 +1601,7 @@ async def execute_post_update_effects(ctx: UpdateContext) -> None:
                 action=(ctx.result.get('decision') or {}).get('sub_action')
                     or (ctx.result.get('decision') or {}).get('action'),
                 provenance_context=ctx.agent_state.get("provenance_context"),
+                epistemic_class=ctx.epistemic_class,
             )
             logger.debug(f"PostgreSQL: Created agent and recorded state for {agent_id}")
         except Exception as create_error:

--- a/src/sequential_calibration.py
+++ b/src/sequential_calibration.py
@@ -27,10 +27,13 @@ Null and construction
   making the bet F_{n-1}-measurable. Under H0, E[e_n | F_{n-1}] = 1, so the
   running product is a nonnegative martingale with mean 1 and the cumulative
   log is a valid e-process for anytime-valid testing.
-- The exposed alarm metric is capped_alarm = 1 - exp(-max(0, log_e_value)),
-  which lives in [0, 1). log_evidence is similarly clamped at 0 from below
-  so favorable trajectories do not produce negative alarms. Raw e-values
-  remain internal to the tracker and are not exposed as governance state.
+- When at least one eligible sample exists, the exposed alarm metric is
+  capped_alarm = 1 - exp(-max(0, log_e_value)), which lives in [0, 1).
+  log_evidence is similarly clamped at 0 from below so favorable trajectories
+  do not produce negative alarms. No-data envelopes deliberately omit those
+  e-process fields so consumers cannot read calibration starvation as a
+  healthy zero alarm. Raw e-values remain internal to the tracker and are not
+  exposed as governance state.
 
 Known limitations
 -----------------
@@ -424,8 +427,11 @@ class SequentialCalibrationTracker:
 
         ANYTIME-VALIDITY SCOPE (S10 council finding):
         - scope="global" / scope="agent" expose the full e-process envelope
-          including `log_evidence`, `capped_alarm`, `last_alt_probability` —
-          each is a single coherent filtration with valid martingale guarantees.
+          once at least one eligible sample exists, including `log_evidence`,
+          `capped_alarm`, `last_alt_probability` — each is a single coherent
+          filtration with valid martingale guarantees. No-data envelopes omit
+          these fields so a missing signal cannot be mistaken for a healthy
+          zero alarm.
         - scope="class" deliberately omits those fields. A class bucket is
           either (a) a parallel e-process under live writes — valid in
           isolation but not multipliable against global/agent (same warning
@@ -445,9 +451,6 @@ class SequentialCalibrationTracker:
             "scope": scope,
             "signal_sources": {},
         }
-        if not is_class_scope:
-            empty_envelope["log_evidence"] = 0.0
-            empty_envelope["capped_alarm"] = 0.0
         if agent_id is not None:
             empty_envelope["agent_id"] = agent_id
         if class_tag is not None:

--- a/tests/test_admin_handlers.py
+++ b/tests/test_admin_handlers.py
@@ -1155,8 +1155,6 @@ class TestCheckCalibration:
         mock_seq_tracker.compute_metrics.return_value = {
             "status": "no_data",
             "eligible_samples": 0,
-            "log_evidence": 0.0,
-            "capped_alarm": 0.0,
             "signal_sources": {},
         }
 
@@ -1170,6 +1168,8 @@ class TestCheckCalibration:
             assert data["pending_updates"] == 2
             assert "complexity_calibration" in data
             assert data["tactical_evidence"]["status"] == "no_data"
+            assert "log_evidence" not in data["tactical_evidence"]
+            assert "capped_alarm" not in data["tactical_evidence"]
 
     @pytest.mark.asyncio
     async def test_check_calibration_empty_bins(self, patch_context_agent_id):
@@ -1180,8 +1180,6 @@ class TestCheckCalibration:
         mock_seq_tracker.compute_metrics.return_value = {
             "status": "no_data",
             "eligible_samples": 0,
-            "log_evidence": 0.0,
-            "capped_alarm": 0.0,
             "signal_sources": {},
         }
 
@@ -1194,6 +1192,8 @@ class TestCheckCalibration:
             assert data["total_samples"] == 0
             assert data["trajectory_health"] == 0.0
             assert data["confidence_distribution"]["mean"] == 0.0
+            assert "log_evidence" not in data["tactical_evidence"]
+            assert "capped_alarm" not in data["tactical_evidence"]
 
     @pytest.mark.asyncio
     async def test_check_calibration_accuracy_uses_real_outcome_evidence(self, patch_context_agent_id):
@@ -1258,8 +1258,6 @@ class TestCheckCalibration:
         mock_seq_tracker.compute_metrics.return_value = {
             "status": "no_data",
             "eligible_samples": 0,
-            "log_evidence": 0.0,
-            "capped_alarm": 0.0,
             "signal_sources": {},
         }
 
@@ -1272,6 +1270,8 @@ class TestCheckCalibration:
             assert data["accuracy"] is None
             assert data["trajectory_health"] == 0.97
             assert data["truth_channel"] == "trajectory_proxy"
+            assert "log_evidence" not in data["tactical_evidence"]
+            assert "capped_alarm" not in data["tactical_evidence"]
 
 
 # ============================================================================

--- a/tests/test_agent_storage.py
+++ b/tests/test_agent_storage.py
@@ -768,8 +768,10 @@ class TestRecordAgentState:
         assert call_kwargs["void"] == -0.01
         assert call_kwargs["regime"] == "EXPLORATION"
         assert call_kwargs["coherence"] == 0.5
+        assert call_kwargs["epistemic_class"] == "agent_report"
         assert call_kwargs["state_json"]["health_status"] == "healthy"
         assert call_kwargs["state_json"]["E"] == 0.7
+        assert call_kwargs["state_json"]["epistemic_class"] == "agent_report"
 
     @pytest.mark.asyncio
     async def test_raises_when_agent_not_found(self):
@@ -836,6 +838,23 @@ class TestRecordAgentState:
         assert state_json["risk_score"] == 0.3
         assert state_json["phi"] == 0.42
         assert state_json["verdict"] == "safe"
+
+    @pytest.mark.asyncio
+    async def test_epistemic_class_persisted_to_column_and_state_json(self):
+        identity = _make_identity()
+        db = _mock_db(get_identity=identity, record_agent_state=1)
+        with patch("src.agent_storage.get_db", return_value=db):
+            from src.agent_storage import record_agent_state
+            await record_agent_state(
+                "agent-1",
+                E=0.5, I=0.5, S=0.5, V=0.0,
+                regime="nominal", coherence=1.0,
+                epistemic_class="substrate_interpretation",
+            )
+
+        call_kwargs = db.record_agent_state.call_args.kwargs
+        assert call_kwargs["epistemic_class"] == "substrate_interpretation"
+        assert call_kwargs["state_json"]["epistemic_class"] == "substrate_interpretation"
 
     @pytest.mark.asyncio
     async def test_provenance_context_in_state_json(self):

--- a/tests/test_backfill_calibration_script.py
+++ b/tests/test_backfill_calibration_script.py
@@ -165,4 +165,7 @@ async def test_backfill_skips_unmatched_missing_confidence(
     assert result["rebuilt_samples"] == 0
     assert result["paired_missing_confidence"] == 0
     assert result["skipped_no_match"] == 1
+    assert result["tracker_state"]["status"] == "no_data"
+    assert "log_evidence" not in result["tracker_state"]
+    assert "capped_alarm" not in result["tracker_state"]
     assert metrics["status"] == "no_data"

--- a/tests/test_bootstrap_checkin_helper.py
+++ b/tests/test_bootstrap_checkin_helper.py
@@ -95,6 +95,7 @@ def test_state_json_marks_source_and_carries_digest():
     assert sj["source"] == "bootstrap"
     assert sj["bootstrap_digest"] == filled["bootstrap_digest"]
     assert sj["complexity"] == 0.7
+    assert sj["epistemic_class"] == "synthetic"
 
 
 def test_pydantic_rejects_extra_fields():

--- a/tests/test_phases_transform_inputs.py
+++ b/tests/test_phases_transform_inputs.py
@@ -34,3 +34,35 @@ def test_transform_inputs_missing_key_defaults_to_empty_string():
     ctx = UpdateContext(arguments={"complexity": 0.5})
     transform_inputs(ctx)
     assert ctx.response_text == ""
+
+
+def test_transform_inputs_defaults_epistemic_class_to_agent_report():
+    ctx = UpdateContext(arguments={"response_text": "done", "complexity": 0.5})
+    transform_inputs(ctx)
+    assert ctx.epistemic_class == "agent_report"
+
+
+def test_transform_inputs_preserves_valid_epistemic_class():
+    ctx = UpdateContext(
+        arguments={
+            "response_text": "edited foo.py; 3 command(s)",
+            "complexity": 0.65,
+            "epistemic_class": "substrate_interpretation",
+        }
+    )
+    transform_inputs(ctx)
+    assert ctx.epistemic_class == "substrate_interpretation"
+
+
+def test_transform_inputs_invalid_epistemic_class_degrades_to_agent_report():
+    """Non-schema internal callers should not be able to trip the DB CHECK."""
+    for bad_class in ("vitals", "synthetic"):
+        ctx = UpdateContext(
+            arguments={
+                "response_text": "done",
+                "complexity": 0.5,
+                "epistemic_class": bad_class,
+            }
+        )
+        transform_inputs(ctx)
+        assert ctx.epistemic_class == "agent_report"

--- a/tests/test_pydantic_schemas.py
+++ b/tests/test_pydantic_schemas.py
@@ -65,6 +65,30 @@ class TestPydanticSchemas:
         with pytest.raises(ValidationError):
             ProcessAgentUpdateParams(response_text="T", response_mode="invalid_mode")
 
+    def test_process_update_epistemic_class_validation(self):
+        """process_agent_update accepts the forward-only warrant labels."""
+        from src.mcp_handlers.schemas.core import ProcessAgentUpdateParams
+
+        valid = ProcessAgentUpdateParams(
+            response_text="hook-derived summary",
+            epistemic_class="substrate_interpretation",
+        )
+        assert valid.epistemic_class == "substrate_interpretation"
+
+        default = ProcessAgentUpdateParams(response_text="agent-authored")
+        assert default.epistemic_class == "agent_report"
+
+        with pytest.raises(ValidationError):
+            ProcessAgentUpdateParams(
+                response_text="old draft vocabulary",
+                epistemic_class="vitals",
+            )
+        with pytest.raises(ValidationError):
+            ProcessAgentUpdateParams(
+                response_text="caller cannot self-label measured rows synthetic",
+                epistemic_class="synthetic",
+            )
+
     def test_schema_registry_complete(self):
         """Ensure all 79 tools mapped in PYDANTIC_SCHEMAS exist and are valid subclasses of BaseModel."""
         schemas = get_pydantic_schemas()

--- a/tests/test_sequential_calibration.py
+++ b/tests/test_sequential_calibration.py
@@ -3,6 +3,20 @@
 from src.sequential_calibration import SequentialCalibrationTracker
 
 
+def test_no_data_omits_e_process_fields(tmp_path):
+    tracker = SequentialCalibrationTracker(state_file=tmp_path / "seq_state.json")
+
+    global_metrics = tracker.compute_metrics()
+    agent_metrics = tracker.compute_metrics(agent_id="missing-agent")
+
+    for metrics in (global_metrics, agent_metrics):
+        assert metrics["status"] == "no_data"
+        assert metrics["eligible_samples"] == 0
+        assert "log_evidence" not in metrics
+        assert "capped_alarm" not in metrics
+        assert "last_alt_probability" not in metrics
+
+
 def test_overconfident_failures_accumulate_positive_evidence(tmp_path):
     tracker = SequentialCalibrationTracker(state_file=tmp_path / "seq_state.json")
 

--- a/tests/test_state_mixin_agent_state.py
+++ b/tests/test_state_mixin_agent_state.py
@@ -1,0 +1,68 @@
+"""Unit coverage for StateMixin agent-state read contracts."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def _state_row(**overrides):
+    row = {
+        "state_id": 11,
+        "identity_id": 22,
+        "agent_id": "agent-state-mixin",
+        "recorded_at": datetime.now(timezone.utc),
+        "entropy": 0.2,
+        "integrity": 0.8,
+        "stability_index": 0.0,
+        "volatility": 0.1,
+        "regime": "nominal",
+        "coherence": 0.7,
+        "state_json": {"E": 0.6},
+        "epistemic_class": "agent_report",
+    }
+    row.update(overrides)
+    return row
+
+
+@pytest.mark.asyncio
+async def test_all_latest_falls_back_when_matview_lacks_epistemic_class():
+    """Migration 040 avoids DROP/CREATE on the matview.
+
+    Existing deployments may still have a materialized view without
+    epistemic_class. The read path should catch that failure and use the base
+    table projection, preserving the forward-only label from the base row.
+    """
+    from src.db.mixins.state import StateMixin
+
+    calls = []
+
+    class _Stub(StateMixin):
+        def acquire(self):
+            return _Acquire()
+
+    class _Acquire:
+        async def __aenter__(self):
+            conn = AsyncMock()
+
+            async def _fetch(sql, *args):
+                calls.append(sql)
+                if "FROM core.mv_latest_agent_states" in sql:
+                    raise Exception('column "epistemic_class" does not exist')
+                return [_state_row(epistemic_class="substrate_interpretation")]
+
+            conn.fetch = _fetch
+            return conn
+
+        async def __aexit__(self, *args):
+            return None
+
+    rows = await _Stub().get_all_latest_agent_states()
+
+    assert len(rows) == 1
+    assert rows[0].epistemic_class == "substrate_interpretation"
+    assert rows[0].state_json["epistemic_class"] == "substrate_interpretation"
+    assert any("core.mv_latest_agent_states" in sql for sql in calls)
+    assert any("FROM core.agent_state s" in sql for sql in calls)


### PR DESCRIPTION
## Summary

- Fix sequential calibration no-data envelopes so missing evidence is not reported as zero evidence.
- Add forward-only agent_state epistemic_class storage and schema support, including migration 040.
- Preserve internal synthetic labeling for bootstrap rows while rejecting synthetic as a public process_agent_update label.

## Why

The archived vitals/narrative split notes pointed at two related issues: no-data calibration looked like measured zero evidence, and state rows lacked a first-class epistemic label to distinguish agent report, substrate observation, interpretation, prediction, and synthetic bootstrap data.

## Impact

Existing rows remain untouched. New state rows can carry epistemic_class, fresh installs get the schema projection, and existing deployments fall back to base-table reads if the materialized latest-state projection has not yet been refreshed.

## Validation

- Applied migration 040 locally to governance and governance_test.
- ./scripts/dev/unitares_doctor.py --mode local
- Focused pytest batches for calibration, schemas, update phases, storage, bootstrap, and evidence wiring.
- ./scripts/dev/test-cache.sh: 8842 passed, 24 skipped, 2 warnings.
- Pre-push smoke: 138 passed, 8163 deselected.

## Notes

Pre-push doc health reported pre-existing dead references in docs/ontology/plan.md and a possible AGENTS.md ghost-tool warning; this PR does not touch those surfaces.
