### PR TITLE
[codex] Fix doc health for ontology archive refs

### DIFF
--- a/docs/ontology/r2-honest-memory-integration.md
+++ b/docs/ontology/r2-honest-memory-integration.md
@@ -141,7 +141,7 @@ Same as v1, with explicit acknowledgement these are deferred *not* because they'
 
 | Channel | What it would measure | Prerequisite |
 |---|---|---|
-| **KG cite-and-extend** | Successor's KG writes within window cite or build on ≥ N of parent's entries | Selected as R5 v0.1's first shadow channel in `docs/ontology/r5-memory-deepening-reality.md`; runtime R2 gating still deferred until telemetry matures. |
+| **KG cite-and-extend** | Successor's KG writes within window cite or build on ≥ N of parent's entries | Selected as R5 v0.1's first shadow channel in private planning notes removed from public master; runtime R2 gating still deferred until telemetry matures. |
 | **Calibration-envelope match** | Successor's per-agent calibration curve falls within parent's confidence envelope | Per-agent calibration storage (R1 deferred C3). |
 | **Decision-distribution overlap** | Successor's decision distribution overlaps parent's | Persistent per-agent decision log (R1 deferred C4). |
 | **Forced re-derivation** (R5's domain) | Successor independently reproduces N of parent's KG conclusions from raw inputs | R5 — out of scope for R2; this is the integration-vs-replay discriminator. |
@@ -232,7 +232,7 @@ The forward-only trust-tier policy means clawback is bounded: only the *chain's*
 
 R2 uses the following columns on `core.identities` (canonical lineage table). R1 shipped the provisional/promotion subset; R2 Phase 1 shipped the lifecycle subset in migration 036:
 
-**Reconciliation (2026-05-05):** R1 PR #306 (migration 031) already shipped `provisional_lineage`, `provisional_score_id`, `provisional_recorded_at`, and `confirmed_at` on `core.identities`. R2 reuses these. `lineage_promoted_at` in the table below is satisfied by R1's existing `confirmed_at` — R2 does not introduce a duplicate column. R2's Phase 1 implementation (#357, migration 036) added the genuinely new columns: `lineage_declared_at`, `lineage_demoted_at`, `lineage_archived_at`, `lineage_last_eval_at`, `chain_obs_count`. See `docs/handoffs/2026-05-04-r2-implementation-plan.md`.
+**Reconciliation (2026-05-05):** R1 PR #306 (migration 031) already shipped `provisional_lineage`, `provisional_score_id`, `provisional_recorded_at`, and `confirmed_at` on `core.identities`. R2 reuses these. `lineage_promoted_at` in the table below is satisfied by R1's existing `confirmed_at` — R2 does not introduce a duplicate column. R2's Phase 1 implementation (#357, migration 036) added the genuinely new columns: `lineage_declared_at`, `lineage_demoted_at`, `lineage_archived_at`, `lineage_last_eval_at`, `chain_obs_count`. The implementation handoff was part of the private planning archive removed from public master after #357 landed.
 
 | Column | Type | Default | Purpose | Status |
 |---|---|---|---|---|

--- a/scripts/diagnostics/check_doc_health.py
+++ b/scripts/diagnostics/check_doc_health.py
@@ -38,6 +38,11 @@ _PATH_PATTERNS = [
     re.compile(r'\]\(((?:src|config|scripts|docs|db|dashboard)/[^\)#\s]+)\)'),
 ]
 
+# Individual files where dead refs are expected. Keep these narrow: most
+# ontology docs are current contract docs, but plan.md is an intentionally
+# preserved internal ledger after public master removed some private drafts.
+_DEAD_REF_SKIP_FILES = {"docs/ontology/plan.md"}
+
 # Directories where dead refs are expected: historical planning records, not
 # current documentation. Specs/handoffs/plans describe intent at a moment in
 # time; implementation often lands under different names, so refs drift by
@@ -82,6 +87,8 @@ def check_dead_refs(md_files: list[Path]) -> list[str]:
     seen = set()
     for fpath in md_files:
         rel = fpath.relative_to(REPO_ROOT)
+        if rel.as_posix() in _DEAD_REF_SKIP_FILES:
+            continue
         if any(d in rel.parts for d in _DEAD_REF_SKIP_DIRS):
             continue
         # Review artifacts (code-review, dialectic-review, adversary-review)
@@ -178,6 +185,7 @@ _TOOL_ALLOWLIST = {
     "postgres", "redis", "age", "docker",  # infra
     "smoke", "pytest",  # test
     "export",  # consolidated tool (registered as action, not standalone)
+    "get_db",  # internal DB helper, not an MCP tool
     "create_task",  # asyncio.create_task(), not an MCP tool
     "str", "float", "int", "bool", "dict", "list", "set", "tuple",  # Python casts
     "acquire", "release",  # asyncio.Lock / Semaphore methods

--- a/tests/test_doc_health_dead_refs.py
+++ b/tests/test_doc_health_dead_refs.py
@@ -196,6 +196,27 @@ def test_mixed_valid_and_dead_refs(stub_repo, doc_health):
     assert _FAKE_PATH in warnings[0]
 
 
+def test_dead_ref_check_skips_private_ontology_plan_ledger(tmp_path, monkeypatch, doc_health):
+    """The ontology plan ledger preserves private/internal refs removed from public master."""
+    plan = tmp_path / "docs" / "ontology" / "plan.md"
+    plan.parent.mkdir(parents=True)
+    plan.write_text("Historical handoff: `docs/handoffs/removed-private-note.md`\n")
+
+    monkeypatch.setattr(doc_health, "REPO_ROOT", tmp_path)
+
+    assert doc_health.check_dead_refs([plan]) == []
+
+
+def test_get_db_call_is_internal_helper_not_ghost_tool(tmp_path, monkeypatch, doc_health):
+    """AGENTS.md mentions get_db() as an internal helper, not an MCP tool claim."""
+    agents = tmp_path / "AGENTS.md"
+    agents.write_text("New handlers can use `get_db()` for DB access.\n")
+
+    monkeypatch.setattr(doc_health, "REPO_ROOT", tmp_path)
+
+    assert doc_health.check_ghost_tools([agents], {"onboard"}) == []
+
+
 def test_dedup_stripped_paths(stub_repo, doc_health):
     """Multiple refs to the same file with different line numbers dedupe to one warning."""
     content = (


### PR DESCRIPTION
## Summary

- Treat docs/ontology/plan.md as a narrow historical/private ledger for dead-ref validation.
- Replace stale private-path mentions in the R2 ontology doc with prose.
- Allowlist get_db() as an internal helper in the ghost-tool linter and add regressions for both cases.

## Why

After public master removed internal ontology/RFC/handoff drafts, doc-health still treated the ontology plan ledger and a couple of R2 historical refs as current public paths. Pre-push was reporting warnings even though the missing files were intentionally removed private planning artifacts.

## Impact

Documentation validation now reports a clean doc-health result without weakening current-doc checks broadly. The exemption is file-specific to docs/ontology/plan.md; other ontology docs remain audited for dead refs.

## Validation

- python3 scripts/diagnostics/check_doc_health.py --strict: all clear.
- pytest tests/test_doc_health_dead_refs.py: 13 passed.
- git diff --check.
- ./scripts/dev/test-cache.sh --staged: 8836 passed, 25 skipped, 2 warnings.
- Pre-push smoke: 138 passed, 8165 deselected; doc health all clear.
