### PR TITLE
[codex] Clarify retired stability index field

### DIFF
--- a/src/db/base.py
+++ b/src/db/base.py
@@ -48,12 +48,13 @@ class AgentStateRecord:
     """Agent state snapshot (EISV metrics).
 
     Column → EISV mapping:
-        DB column       Python field    EISV dimension
-        ─────────────   ────────────    ──────────────
-        (state_json.E)  energy          E  (Energy)
-        integrity       integrity       I  (Information Integrity)
-        entropy         entropy         S  (Entropy)
-        volatility      void            V  (Void)
+        DB column        Python field    EISV dimension
+        ─────────────    ────────────    ──────────────
+        (state_json.E)   energy          E  (Energy)
+        integrity        integrity       I  (Information Integrity)
+        entropy          entropy         S  (Entropy)
+        volatility       void            V  (Void)
+        stability_index  stability_index DEAD — was 1.0 − S, retired in 20684dd1
     """
     state_id: int
     identity_id: int


### PR DESCRIPTION
## Summary

- Clarify the AgentStateRecord docstring so stability_index is explicitly marked as a retained dead field.
- Preserve the EISV mapping for live dimensions while documenting that stability_index was retired as 1.0 - S.

## Why

A stale remote branch contained this useful documentation-only fix but was based on pre-merge history and would have reverted the recently merged calibration/BEAM/doc-health work if used directly. This PR salvages only the intended docstring change onto current master.

## Validation

- python3 -m py_compile src/db/base.py
- git diff --check
- ./scripts/dev/test-cache.sh --staged: 8843 passed, 25 skipped, 2 warnings.
- Pre-push smoke: 138 passed, 8172 deselected; doc health all clear.
