### PR TITLE
[codex] document health check wrapper fields

### DIFF
--- a/src/tool_descriptions.py
+++ b/src/tool_descriptions.py
@@ -35,6 +35,15 @@ _IDENTITY_DESCRIPTION_OVERRIDES = {
 }
 
 _DESCRIPTION_APPENDICES = {
+    "health_check": (
+        "\n\nRESPONSE WRAPPER FIELDS:\n"
+        "- server_time: ISO timestamp added by the shared MCP success wrapper\n"
+        "- agent_signature: caller identity signature object, e.g. "
+        "{\"uuid\": string|null}; may be {\"uuid\": null} before a caller is bound\n"
+        "- _cache: cached health snapshot metadata "
+        "(age_seconds, produced_at, stale, probe_interval_seconds, "
+        "staleness_threshold_seconds)"
+    ),
     "process_agent_update": (
         "\n\nS22 PROVENANCE FIELDS (optional, descriptive, not identity proof):\n"
         "- harness_type / harness: normalized harness family such as "

--- a/tests/test_describe_tool_drift.py
+++ b/tests/test_describe_tool_drift.py
@@ -7,6 +7,20 @@ contract drifting from actual behavior because nothing tests the description.
 import pytest
 
 
+def test_get_server_info_schema_tool_is_dispatch_registered():
+    """A tool advertised by MCP schemas must also resolve at dispatch time."""
+    from src.mcp_handlers import TOOL_HANDLERS
+    from src.tool_schemas import get_tool_definitions
+
+    schema_names = {tool.name for tool in get_tool_definitions(verbosity="full")}
+
+    assert "get_server_info" in schema_names
+    assert "get_server_info" in TOOL_HANDLERS, (
+        "get_server_info is advertised in tool schemas and health_check docs; "
+        "it must be dispatch-registered, not an unknown tool at call time"
+    )
+
+
 @pytest.mark.asyncio
 async def test_process_agent_update_describe_mentions_prediction_id():
     from src.mcp_handlers.introspection.tool_introspection import handle_describe_tool
@@ -66,10 +80,11 @@ async def test_health_check_describe_mentions_agent_signature():
     from src.mcp_handlers.introspection.tool_introspection import handle_describe_tool
     result = await handle_describe_tool({"tool_name": "health_check", "lite": False})
     description = _json.loads(result[0].text)["tool"]["description"]
-    assert "agent_signature" in description, (
-        "describe_tool(health_check) description text must document "
-        "agent_signature — response_base.py adds it to every non-lite response"
-    )
+    for field in ("agent_signature", "server_time", "_cache"):
+        assert field in description, (
+            "describe_tool(health_check) description text must document "
+            f"{field} from the shared response wrapper"
+        )
 
 
 def test_get_server_info_is_registered():


### PR DESCRIPTION
## Summary
- add a health_check describe_tool appendix for shared wrapper fields: server_time, agent_signature, and _cache
- keep registry drift coverage for get_server_info and expand health_check wrapper-field assertions

## Validation
- pytest tests/test_describe_tool_drift.py
- python3 scripts/diagnostics/check_doc_health.py --strict
- git diff --cached --check
- ./scripts/dev/test-cache.sh --staged (8845 passed, 24 skipped)
- pre-push smoke/doc-health hook (138 passed, 8173 deselected; doc health all clear)