### PR TITLE
[codex] preserve identity middleware no-mint paths

### DIFF
--- a/src/mcp_handlers/middleware/identity_step.py
+++ b/src/mcp_handlers/middleware/identity_step.py
@@ -327,6 +327,11 @@ async def resolve_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
     client_session_id = arguments.get("client_session_id")
     force_new = arguments.get("force_new", False)
     continuity_token = arguments.get("continuity_token")
+    try:
+        from ..tool_stability import resolve_tool_alias
+        canonical_name, _alias_info = resolve_tool_alias(name)
+    except Exception:
+        canonical_name = name
 
     # --- Sticky transport binding: early return if cached ---
     transport_key = _transport_cache_key(signals)
@@ -442,8 +447,12 @@ async def resolve_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
         _partc_owned = _partc_token_aid == _direct_uuid
 
         if not _partc_owned:
-            from config.governance_config import identity_strict_mode
-            _partc_mode = identity_strict_mode()
+            _peer_pid = getattr(signals, "peer_pid", None) if signals else None
+            _transport = getattr(signals, "transport", None) if signals else None
+            _defer_to_substrate_handler = (
+                _transport == "uds" and isinstance(_peer_pid, int)
+            )
+            _partc_mode = None
 
             async def _emit_middleware_hijack(mode: str) -> None:
                 """Mirror the handlers.py event emission so middleware-path
@@ -474,7 +483,18 @@ async def resolve_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
                 except Exception as e:
                     logger.warning(f"[IDENTITY_HIJACK] middleware broadcast_event failed: {e}")
 
-            if _partc_mode == "strict":
+            if _defer_to_substrate_handler:
+                logger.debug(
+                    "[SUBSTRATE_GATE] Middleware PATH 0 saw UDS peer_pid=%d "
+                    "for %s...; deferring ownership decision to identity handler",
+                    _peer_pid,
+                    _direct_uuid[:8],
+                )
+            else:
+                from config.governance_config import identity_strict_mode
+                _partc_mode = identity_strict_mode()
+
+            if not _defer_to_substrate_handler and _partc_mode == "strict":
                 ctx.strict_reject = True
                 ctx.identity_result = {
                     "error": (
@@ -491,7 +511,7 @@ async def resolve_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
                 )
                 await _emit_middleware_hijack("strict")
                 return name, arguments, ctx
-            elif _partc_mode == "log":
+            elif not _defer_to_substrate_handler and _partc_mode == "log":
                 logger.warning(
                     "[IDENTITY_STRICT] Would reject middleware PATH 0 passthrough: "
                     "agent_uuid=%s... token_aid=%s",
@@ -585,7 +605,7 @@ async def resolve_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
             # identity, onboard, bind_session} now lives as decorator
             # arguments on those handlers.
             from src.mcp_handlers.decorators import get_tool_identity_requirement
-            if get_tool_identity_requirement(name) == "pre_onboard":
+            if get_tool_identity_requirement(canonical_name) == "pre_onboard":
                 logger.info(
                     "[DISPATCH] session_resolve_miss for %s under %s... "
                     "— leaving request unbound (no middleware auto-mint, "

--- a/tests/test_dispatch_ephemeral_identity.py
+++ b/tests/test_dispatch_ephemeral_identity.py
@@ -184,6 +184,37 @@ class TestEphemeralIdentityMarking:
         mock_db.update_session_activity.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_read_only_alias_session_miss_does_not_auto_mint(self, mock_db):
+        """Read-only aliases like status() must share the no-mint policy."""
+        identity_result = {
+            "resume_failed": True,
+            "error": "session_resolve_miss",
+            "session_key": "agent-missing",
+        }
+
+        resolve_mock = AsyncMock(return_value=identity_result)
+        patches = [
+            patch("src.mcp_handlers.context.get_session_signals", return_value=None),
+            patch("src.mcp_handlers.identity.handlers.derive_session_key", new_callable=AsyncMock, return_value="agent-missing"),
+            patch("src.mcp_handlers.identity.handlers.resolve_session_identity", resolve_mock),
+            patch("src.mcp_handlers.context.set_session_context", return_value=MagicMock()),
+            patch("src.db.get_db", return_value=mock_db),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            ctx = DispatchContext()
+            await resolve_identity("status", {"client_session_id": "agent-missing"}, ctx)
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        assert resolve_mock.await_count == 1
+        assert ctx.bound_agent_id is None
+        assert ctx.identity_result is identity_result
+        mock_db.update_session_activity.assert_not_called()
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("tool_name", ["identity", "onboard"])
     async def test_identity_lifecycle_session_miss_does_not_auto_mint_in_middleware(
         self, tool_name, mock_db,

--- a/tests/test_identity_honesty_partc.py
+++ b/tests/test_identity_honesty_partc.py
@@ -409,6 +409,64 @@ class TestMiddlewarePath0Gate:
         assert payload.get("source") == "middleware"
 
     @pytest.mark.asyncio
+    async def test_middleware_strict_defers_uds_peer_to_handler(self, monkeypatch):
+        """UDS peer_pid paths are substrate-checked by the identity handler.
+
+        Middleware must not pre-emit a hijack event for tokenless UUID-only
+        resident anchors, because the handler has the substrate-attestation
+        proof path that can legitimately accept them.
+        """
+        monkeypatch.setenv("UNITARES_IDENTITY_STRICT", "strict")
+
+        from src.mcp_handlers.middleware import identity_step as mw
+
+        broadcaster_stub = MagicMock()
+        broadcaster_stub.broadcast_event = AsyncMock()
+
+        signals = MagicMock(
+            transport="uds",
+            user_agent="resident-test",
+            ip_ua_fingerprint=None,
+            x_session_id=None,
+            x_agent_id=None,
+            mcp_session_id=None,
+            oauth_client_id=None,
+            x_client_id=None,
+            client_hint=None,
+            peer_pid=12345,
+        )
+        direct_uuid = "eeeeeeee-1111-2222-3333-444444444444"
+        with patch(
+            "src.mcp_handlers.context.get_session_signals",
+            return_value=signals,
+        ), patch(
+            "src.mcp_handlers.identity.handlers.derive_session_key",
+            new_callable=AsyncMock,
+            return_value="uds-session",
+        ), patch(
+            "src.mcp_handlers.context.set_session_context",
+            return_value=MagicMock(),
+        ), patch(
+            "src.mcp_handlers.identity.handlers._broadcaster",
+            return_value=broadcaster_stub,
+        ):
+            ctx = MagicMock()
+            ctx.strict_reject = False
+            ctx.identity_result = None
+            await mw.resolve_identity(
+                "identity",
+                {
+                    "agent_uuid": direct_uuid,
+                    "resume": True,
+                },
+                ctx,
+            )
+
+        assert ctx.strict_reject is False
+        assert ctx.bound_agent_id == direct_uuid
+        broadcaster_stub.broadcast_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_middleware_log_mode_emits_hijack_event(self, monkeypatch, caplog):
         """Log mode also emits — operators need to see attempts even when allowed."""
         import logging


### PR DESCRIPTION
## Summary
- resolve tool aliases before middleware identity-requirement checks so read-only aliases like status() inherit the pre_onboard no-mint policy
- let UDS peer_pid PATH 0 calls defer bare-UUID ownership decisions to the identity handler, which has substrate-attestation context
- add regression coverage for stale read-only alias sessions and strict-mode UDS resident passthrough

## Coordination
- checked open identity/onboarding PRs in CIRWEL/unitares and CIRWEL/unitares-governance-plugin before touching this single-writer surface; none were open

## Validation
- pytest tests/test_dispatch_ephemeral_identity.py::TestEphemeralIdentityMarking::test_read_only_alias_session_miss_does_not_auto_mint tests/test_identity_honesty_partc.py::TestMiddlewarePath0Gate::test_middleware_strict_defers_uds_peer_to_handler -q
- pytest tests/test_dispatch_ephemeral_identity.py tests/test_identity_honesty_partc.py tests/test_substrate_handler_gate.py tests/test_tool_stability.py -q (56 passed)
- git diff --cached --check
- ./scripts/dev/test-cache.sh --staged (8847 passed, 24 skipped)
- pre-push smoke/doc-health hook (138 passed, 8175 deselected; doc health all clear)