### PR TITLE
[codex] preserve resident and wrapper passthrough state

### DIFF
--- a/src/http_api.py
+++ b/src/http_api.py
@@ -2070,6 +2070,43 @@ def _parse_resident_timestamp(value: object) -> Optional[datetime]:
     return parsed
 
 
+def _safe_resident_total_updates(meta: object) -> int:
+    try:
+        return int(getattr(meta, "total_updates", 0) or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _resident_meta_preference_key(meta: object) -> tuple[int, int, float, int]:
+    """Sort key for duplicate resident labels.
+
+    Governance restarts can leave active 0-update resident forks beside the
+    canonical row. Prefer an active row, then one that has real updates, then
+    the freshest timestamp, then total update count as a final tiebreaker.
+    """
+    status = getattr(meta, "status", None)
+    total_updates = _safe_resident_total_updates(meta)
+    last_dt = _parse_resident_timestamp(getattr(meta, "last_update", None))
+    return (
+        1 if status == "active" else 0,
+        1 if total_updates > 0 else 0,
+        last_dt.timestamp() if last_dt else 0.0,
+        total_updates,
+    )
+
+
+def _latest_eisv_for_label(label: str) -> Optional[dict]:
+    """Find the most recent eisv_update event for a resident label."""
+    for event in reversed(broadcaster_instance.event_history):
+        if not isinstance(event, dict):
+            continue
+        if event.get("type") != "eisv_update":
+            continue
+        if event.get("agent_name") == label:
+            return event
+    return None
+
+
 def _coherence_history_for_agent(agent_id: str, window_minutes: int = 60) -> list[dict]:
     """Collect coherence (plus risk, verdict) data points for a sparkline.
 
@@ -2186,19 +2223,7 @@ async def http_residents(request):
                 label_to_meta[label] = (agent_id, meta)
                 continue
             existing_meta = existing[1]
-            # Prefer active over archived/paused.
-            existing_status = getattr(existing_meta, "status", None)
-            new_status = getattr(meta, "status", None)
-            existing_active = existing_status == "active"
-            new_active = new_status == "active"
-            if new_active and not existing_active:
-                label_to_meta[label] = (agent_id, meta)
-                continue
-            if existing_active and not new_active:
-                continue
-            # Both same activity tier — prefer the one with more updates.
-            if (getattr(meta, "total_updates", 0) or 0) > \
-               (getattr(existing_meta, "total_updates", 0) or 0):
+            if _resident_meta_preference_key(meta) > _resident_meta_preference_key(existing_meta):
                 label_to_meta[label] = (agent_id, meta)
 
         residents: list[dict] = []
@@ -2209,6 +2234,29 @@ async def http_residents(request):
             meta = entry[1] if entry else None
 
             latest = _latest_eisv_for_agent(agent_id) if agent_id else None
+
+            # If metadata points at a stale duplicate UUID but the broadcaster
+            # has a newer EISV event for the same resident label, follow the
+            # live event. This catches resident identity skew without waiting
+            # for metadata hydration to converge.
+            latest_by_label = _latest_eisv_for_label(label)
+            if latest_by_label:
+                label_dt = _parse_resident_timestamp(latest_by_label.get("timestamp"))
+                current_event_dt = _parse_resident_timestamp(latest.get("timestamp")) if latest else None
+                metadata_dt_for_selection = _parse_resident_timestamp(
+                    getattr(meta, "last_update", None) if meta else None
+                )
+                if (
+                    label_dt
+                    and (current_event_dt is None or label_dt > current_event_dt)
+                    and (metadata_dt_for_selection is None or label_dt >= metadata_dt_for_selection)
+                ):
+                    latest = latest_by_label
+                    event_agent_id = latest_by_label.get("agent_id")
+                    if event_agent_id and event_agent_id != agent_id:
+                        agent_id = event_agent_id
+                        meta = getattr(mcp_server_obj, "agent_metadata", {}).get(event_agent_id)
+
             history = _coherence_history_for_agent(agent_id) if agent_id else []
             recent_writes = await _recent_writes_for_agent(agent_id) if agent_id else []
 
@@ -2257,13 +2305,12 @@ async def http_residents(request):
 
             # Status: paused > silent > healthy > unknown.
             status = "unknown"
-            if meta:
-                if getattr(meta, "status", None) in ("paused", "archived"):
-                    status = getattr(meta, "status")
-                elif silence_seconds is not None and silence_seconds > silence_threshold:
-                    status = "silent"
-                elif latest is not None or silence_seconds is not None:
-                    status = "healthy"
+            if meta and getattr(meta, "status", None) in ("paused", "archived"):
+                status = getattr(meta, "status")
+            elif silence_seconds is not None and silence_seconds > silence_threshold:
+                status = "silent"
+            elif latest is not None or silence_seconds is not None:
+                status = "healthy"
 
             flat = _extract_eisv_fields(latest) if latest else None
             from src.resident_progress.registry import is_event_driven_label

--- a/src/mcp_handlers/support/wrapper_generator.py
+++ b/src/mcp_handlers/support/wrapper_generator.py
@@ -15,7 +15,7 @@ import inspect
 import logging
 from typing import Annotated, Any, Callable, Optional, Union
 
-from pydantic import Field
+from pydantic import ConfigDict, Field
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 logger = logging.getLogger(__name__)
 
@@ -62,6 +62,46 @@ def create_typed_wrapper(
     wrapper.__qualname__ = tool_name
     
     return wrapper
+
+def enable_extra_argument_passthrough(tool: Any) -> bool:
+    """Preserve unknown top-level MCP arguments through FastMCP validation.
+
+    FastMCP builds an internal Pydantic argument model from a wrapper's
+    signature and, by default, Pydantic ignores keys that are not named in that
+    signature. UNITARES' dispatch middleware already preserves extra fields
+    after its own Pydantic validation, but internal S22/R6 callers need those
+    fields to survive FastMCP's earlier validation boundary first.
+
+    This helper intentionally leaves the public/listed tool schema unchanged;
+    it only swaps the registered FastMCP tool's internal argument model for a
+    subclass with ``extra='allow'`` whose ``model_dump_one_level`` includes the
+    retained extras.
+    """
+    fn_metadata = getattr(tool, "fn_metadata", None)
+    arg_model = getattr(fn_metadata, "arg_model", None)
+    if fn_metadata is None or arg_model is None:
+        return False
+    if getattr(arg_model, "__unitaires_extra_passthrough_enabled__", False):
+        return False
+
+    base_config = dict(getattr(arg_model, "model_config", {}) or {})
+
+    class ExtraPassthroughArgModel(arg_model):  # type: ignore[misc, valid-type]
+        __unitaires_extra_passthrough_enabled__ = True
+        model_config = ConfigDict(**{**base_config, "extra": "allow"})
+
+        def model_dump_one_level(self) -> dict[str, Any]:
+            values = super().model_dump_one_level()
+            extras = getattr(self, "__pydantic_extra__", None) or {}
+            values.update(extras)
+            return values
+
+    ExtraPassthroughArgModel.__name__ = f"{arg_model.__name__}ExtraPassthrough"
+    ExtraPassthroughArgModel.__qualname__ = ExtraPassthroughArgModel.__name__
+    ExtraPassthroughArgModel.model_rebuild(force=True)
+    fn_metadata.arg_model = ExtraPassthroughArgModel
+    return True
+
 
 def _resolve_param_type(param_def: dict) -> Any:
     """Resolve a JSON Schema parameter definition to a Python type.

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -347,6 +347,14 @@ TOOLS_NEEDING_SESSION_INJECTION = {
     "compare_me_to_similar",
 }
 
+# FastMCP validates tool arguments before dispatch_tool sees them. For these
+# internal/provenance-heavy tools, UNITARES dispatch middleware is the source of
+# truth and must receive caller-supplied extra fields unchanged.
+EXTRA_ARGUMENT_PASSTHROUGH_TOOLS = {
+    "process_agent_update",
+}
+
+
 def auto_register_all_tools():
     """
     Auto-register tools from tool_schemas.py with typed signatures.
@@ -371,7 +379,10 @@ def auto_register_all_tools():
     The SSE server will automatically pick it up.
     """
     from src.tool_schemas import get_tool_definitions
-    from src.mcp_handlers.support.wrapper_generator import create_typed_wrapper
+    from src.mcp_handlers.support.wrapper_generator import (
+        create_typed_wrapper,
+        enable_extra_argument_passthrough,
+    )
     from src.mcp_handlers.decorators import get_tool_registry
     from src.tool_modes import TOOL_MODE, get_tools_for_mode
 
@@ -415,6 +426,26 @@ def auto_register_all_tools():
 
             # Register with FastMCP - it will infer schema from signature
             mcp.tool(description=description, structured_output=False)(wrapper)
+            if tool_name in EXTRA_ARGUMENT_PASSTHROUGH_TOOLS:
+                tool_manager = getattr(mcp, "_tool_manager", None)
+                registered_tool = (
+                    tool_manager.get_tool(tool_name)
+                    if tool_manager and hasattr(tool_manager, "get_tool")
+                    else None
+                )
+                if registered_tool is None:
+                    logger.warning(
+                        "Failed to enable extra argument passthrough for %s: "
+                        "registered FastMCP tool not found",
+                        tool_name,
+                    )
+                else:
+                    enabled = enable_extra_argument_passthrough(registered_tool)
+                    if enabled:
+                        logger.info(
+                            "Enabled extra argument passthrough for %s",
+                            tool_name,
+                        )
             registered_count += 1
 
         except Exception as e:

--- a/tests/test_http_residents_resolve.py
+++ b/tests/test_http_residents_resolve.py
@@ -15,6 +15,7 @@ residents that aren't running.
 """
 import os
 import json
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -207,6 +208,96 @@ async def test_residents_use_broadcaster_event_when_it_is_newer(monkeypatch):
     assert lumen["last_checkin_at"] == "2026-04-28T10:06:04+00:00"
     assert lumen["last_checkin_source"] == "broadcaster_eisv"
     assert lumen["metadata_last_update"] == "2026-04-28T10:01:56+00:00"
+
+
+@pytest.mark.asyncio
+async def test_residents_duplicate_label_prefers_fresh_real_metadata(monkeypatch):
+    """A stale 0-update resident fork must not shadow the active resident."""
+    from src import http_api
+
+    request = SimpleNamespace(
+        headers={},
+        query_params={},
+        url=SimpleNamespace(path="/v1/residents"),
+        client=SimpleNamespace(host="127.0.0.1"),
+    )
+    server = SimpleNamespace(agent_metadata={
+        "sentinel-stale": _resident_meta(
+            label="Sentinel",
+            last_update="2026-05-01T01:58:39+00:00",
+            total_updates=0,
+        ),
+        "sentinel-active": _resident_meta(
+            label="Sentinel",
+            last_update="2026-05-18T21:32:04+00:00",
+            total_updates=1,
+        ),
+    })
+
+    http_api.broadcaster_instance.event_history.clear()
+    http_api.broadcaster_instance.event_history.append({
+        "type": "eisv_update",
+        "agent_id": "sentinel-active",
+        "agent_name": "Sentinel",
+        "timestamp": "2026-05-18T21:32:04+00:00",
+        "eisv": {"E": 0.7, "I": 0.6, "S": 0.2, "V": 0.1},
+        "metrics": {"coherence": 0.5, "risk_score": 0.2, "verdict": "safe"},
+    })
+
+    with patch("src.mcp_handlers.shared.lazy_mcp_server", server), \
+            patch("src.http_api._recent_writes_for_agent", AsyncMock(return_value=[])):
+        resp = await http_api.http_residents(request)
+
+    data = json.loads(resp.body.decode())
+    sentinel = data["residents"][0]
+    assert sentinel["agent_id"] == "sentinel-active"
+    assert sentinel["last_checkin_at"] == "2026-05-18T21:32:04+00:00"
+
+
+@pytest.mark.asyncio
+async def test_residents_rebinds_stale_metadata_to_newer_label_event(monkeypatch):
+    """A live EISV event can recover a resident whose metadata label points at a stale UUID."""
+    from src import http_api
+
+    request = SimpleNamespace(
+        headers={},
+        query_params={},
+        url=SimpleNamespace(path="/v1/residents"),
+        client=SimpleNamespace(host="127.0.0.1"),
+    )
+    server = SimpleNamespace(agent_metadata={
+        "sentinel-stale": _resident_meta(
+            label="Sentinel",
+            last_update="2026-05-01T01:58:39+00:00",
+            total_updates=0,
+        ),
+    })
+
+    http_api.broadcaster_instance.event_history.clear()
+    http_api.broadcaster_instance.event_history.append({
+        "type": "eisv_update",
+        "agent_id": "sentinel-real",
+        "agent_name": "Sentinel",
+        "timestamp": "2026-05-18T21:32:04+00:00",
+        "eisv": {"E": 0.74, "I": 0.68, "S": 0.24, "V": 0.08},
+        "metrics": {"coherence": 0.496, "risk_score": 0.6535, "verdict": "high-risk"},
+    })
+    monkeypatch.setattr(
+        http_api.time,
+        "time",
+        lambda: datetime(2026, 5, 18, 21, 33, 0, tzinfo=timezone.utc).timestamp(),
+    )
+
+    with patch("src.mcp_handlers.shared.lazy_mcp_server", server), \
+            patch("src.http_api._recent_writes_for_agent", AsyncMock(return_value=[])):
+        resp = await http_api.http_residents(request)
+
+    data = json.loads(resp.body.decode())
+    sentinel = data["residents"][0]
+    assert sentinel["agent_id"] == "sentinel-real"
+    assert sentinel["status"] == "healthy"
+    assert sentinel["last_checkin_source"] == "broadcaster_eisv"
+    assert sentinel["latest_eisv_at"] == "2026-05-18T21:32:04+00:00"
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_extra_passthrough.py
+++ b/tests/test_mcp_extra_passthrough.py
@@ -1,0 +1,22 @@
+"""Regression tests for FastMCP extra-argument passthrough wiring."""
+
+from __future__ import annotations
+
+
+def test_process_agent_update_registered_for_extra_argument_passthrough():
+    """The registered FastMCP tool must preserve internal S22 envelope fields."""
+    from src import mcp_server
+
+    tool = mcp_server.mcp._tool_manager.get_tool("process_agent_update")
+    assert tool is not None
+
+    arg_model = tool.fn_metadata.arg_model
+    assert arg_model.model_config.get("extra") == "allow"
+    assert getattr(arg_model, "__unitaires_extra_passthrough_enabled__", False)
+
+    # Keep the public/LLM-facing schema unchanged: internal harness fields may be
+    # forwarded by wrappers, but should not become advertised agent-fillable args.
+    properties = tool.parameters.get("properties", {})
+    assert "comparison_key" in properties
+    assert "harness_type" not in properties
+    assert "verification_source" not in properties

--- a/tests/test_wrapper_generator.py
+++ b/tests/test_wrapper_generator.py
@@ -18,7 +18,9 @@ from src.mcp_handlers.support.wrapper_generator import (
     _json_type_to_python,
     create_typed_wrapper,
     _create_simple_wrapper,
+    enable_extra_argument_passthrough,
 )
+from mcp.server.fastmcp.tools.base import Tool
 
 
 # ============================================================================
@@ -364,3 +366,62 @@ class TestSessionWrapperContextDetection:
         wrapper = create_typed_wrapper("plain", schema, get_handler, inject_session=False)
         assert "ctx" not in inspect.signature(wrapper).parameters
         assert "ctx" not in wrapper.__annotations__
+
+
+class TestExtraArgumentPassthrough:
+
+    def test_fastmcp_validation_preserves_process_agent_update_s22_envelope(self):
+        """FastMCP must not drop internal S22 fields before dispatch middleware."""
+        call_log = []
+
+        def get_handler(name):
+            async def handler(**kwargs):
+                call_log.append(kwargs)
+                return {"ok": True}
+            return handler
+
+        def session_extractor(ctx):
+            return "session-id"
+
+        # Mirrors the public process_agent_update shape: only the agent-knowable
+        # provenance fields are named schema properties. Harness/server-known
+        # fields arrive as extra top-level MCP arguments from internal callers.
+        schema = {
+            "properties": {
+                "response_text": {"type": "string"},
+                "comparison_key": {"type": "string"},
+                "task_label": {"type": "string"},
+                "task_outcome": {"type": "string"},
+                "memory_context": {"type": "string"},
+            },
+            "required": [],
+        }
+        wrapper = create_typed_wrapper(
+            "process_agent_update",
+            schema,
+            get_handler,
+            inject_session=True,
+            session_extractor=session_extractor,
+        )
+        tool = Tool.from_function(wrapper, structured_output=False)
+        enable_extra_argument_passthrough(tool)
+
+        sent = {
+            "response_text": "round-trip check",
+            "harness_type": "r6_dogfood",
+            "model": "test-model",
+            "tool_surface": "hermes-wrapper",
+            "memory_context": "memory+kg+transcript",
+            "comparison_key": "hermes-wrapper-rt-test",
+            "task_label": "Hermes MCP wrapper round-trip",
+            "task_outcome": "test_passed",
+            "verification_source": "agent_reported_tool_result",
+            "governance_mode": "governed",
+            "locus": "in_process_mcp_wrapper",
+        }
+
+        asyncio.run(tool.run(sent))
+
+        assert call_log
+        for key, value in sent.items():
+            assert call_log[0][key] == value


### PR DESCRIPTION
## Summary
- prefer the active/fresh resident metadata row when duplicate resident labels exist
- recover resident dashboard state from a newer broadcaster EISV event for the same resident label when metadata points at a stale UUID
- preserve internal S22/R6 top-level MCP arguments through FastMCP validation for process_agent_update without advertising those internal fields in the public schema

## Validation
- pytest tests/test_http_residents_resolve.py tests/test_mcp_extra_passthrough.py tests/test_wrapper_generator.py -q (46 passed)
- git diff --cached --check
- ./scripts/dev/test-cache.sh --staged (8851 passed, 24 skipped)
- pre-push smoke/doc-health hook (138 passed, 8179 deselected; doc health all clear)