### PR TITLE
Salvage trim monitor backlog fixes

### DIFF
--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -880,6 +880,14 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
         rerank_scores_dict = {}
         rrf_scores_dict = {}
         search_degraded_warning = None
+        hybrid_skipped_reason = None
+        fts_fallback_skipped_reason = None
+        query_terms = str(query_text).split() if query_text else []
+        query_term_count = len(query_terms)
+        # Broad agent-generated queries can spend the whole tool budget in
+        # hybrid fan-out or automatic OR recall fallback. Keep explicit caller
+        # intent available, but make auto mode cheap by default.
+        complex_query_term_limit = 4
 
         # Phase 3: cross-encoder reranker. When enabled, first-stage retrieval
         # fetches a wider pool (up to rerank_pool_size) so the reranker has
@@ -975,6 +983,17 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
             else:
                 hybrid_path = (
                     search_mode_param == "auto" and hybrid_on and use_semantic and has_fts
+                )
+            if (
+                hybrid_path
+                and search_mode_param == "auto"
+                and query_term_count > complex_query_term_limit
+            ):
+                hybrid_path = False
+                hybrid_skipped_reason = (
+                    f"auto hybrid skipped for {query_term_count}-term query "
+                    f"(limit {complex_query_term_limit}); use search_mode='hybrid' "
+                    "to force RRF fusion"
                 )
             if hybrid_path:
                 import asyncio as _asyncio
@@ -1106,14 +1125,21 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
                     not candidates
                     and operator_forced is None
                     and primary_op == "AND"
-                    and len(str(query_text).split()) > 1
+                    and query_term_count > 1
                 ):
-                    candidates = await graph.full_text_search(
-                        str(query_text), limit=candidate_limit, operator="OR",
-                    )
-                    if candidates:
-                        fts_operator_used = "OR"
-                        fts_fallback_used = True
+                    if query_term_count <= complex_query_term_limit:
+                        candidates = await graph.full_text_search(
+                            str(query_text), limit=candidate_limit, operator="OR",
+                        )
+                        if candidates:
+                            fts_operator_used = "OR"
+                            fts_fallback_used = True
+                    else:
+                        fts_fallback_skipped_reason = (
+                            f"automatic OR fallback skipped for {query_term_count}-term "
+                            f"query (limit {complex_query_term_limit}); pass operator='OR' "
+                            "to request broad recall"
+                        )
                 search_mode = "fts"
             elif not hybrid_path and not use_semantic:
                 # JSON backend fallback: bounded scan of most recent entries.
@@ -1187,7 +1213,6 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
             # operator_used reports what the FTS layer actually ran. For
             # non-FTS modes (semantic, hybrid, substring) this stays "N/A" —
             # boolean operators only apply to the FTS query string. (#165)
-            query_terms = str(query_text).split() if query_text else []
             if fts_operator_used and len(query_terms) > 1:
                 operator_used = fts_operator_used
             elif len(query_terms) > 1:
@@ -1243,14 +1268,21 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
                         not fts_candidates
                         and operator_forced is None
                         and primary_op == "AND"
-                        and len(str(query_text).split()) > 1
+                        and query_term_count > 1
                     ):
-                        fts_candidates = await graph.full_text_search(
-                            str(query_text), limit=limit * 2, operator="OR",
-                        )
-                        if fts_candidates:
-                            semantic_fallback_op = "OR"
-                            semantic_fallback_or_retry = True
+                        if query_term_count <= complex_query_term_limit:
+                            fts_candidates = await graph.full_text_search(
+                                str(query_text), limit=limit * 2, operator="OR",
+                            )
+                            if fts_candidates:
+                                semantic_fallback_op = "OR"
+                                semantic_fallback_or_retry = True
+                        else:
+                            fts_fallback_skipped_reason = (
+                                f"automatic OR fallback skipped for {query_term_count}-term "
+                                f"query (limit {complex_query_term_limit}); pass operator='OR' "
+                                "to request broad recall"
+                            )
                     # Apply same filters
                     for d in fts_candidates:
                         if agent_id and d.agent_id != agent_id:
@@ -1401,6 +1433,10 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
         if search_degraded_warning:
             response_data["search_degraded"] = True
             response_data["search_degraded_message"] = search_degraded_warning
+        if hybrid_skipped_reason:
+            response_data["hybrid_skipped_reason"] = hybrid_skipped_reason
+        if fts_fallback_skipped_reason:
+            response_data["fts_fallback_skipped_reason"] = fts_fallback_skipped_reason
 
         # UX FIX: Make fallback behavior explicit and transparent
         if fallback_used:
@@ -1458,7 +1494,10 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
         # UX FIX: Document operator behavior upfront for multi-term queries
         if query_text and len(str(query_text).split()) > 1:
             if search_mode == "fts" and not fallback_used:
-                response_data["operator_note"] = "Multi-term queries use OR operator by default (finds discoveries matching any term). If you need AND behavior, use tags or multiple filters."
+                response_data["operator_note"] = (
+                    f"Multi-term FTS ran with operator={fts_operator_used or operator_used}. "
+                    "Use operator='OR' for broader recall, or tags/filters for tighter scope."
+                )
             elif search_mode == "semantic":
                 response_data["operator_note"] = "Semantic search considers all terms together (conceptual similarity, not keyword matching)."
 

--- a/src/mcp_handlers/lifecycle/query.py
+++ b/src/mcp_handlers/lifecycle/query.py
@@ -4,7 +4,9 @@ Lifecycle query handlers — read-only agent listing and metadata retrieval.
 Extracted from handlers.py for maintainability.
 """
 
-from typing import Dict, Any, Sequence
+import hashlib
+import uuid
+from typing import Dict, Any, Optional, Sequence
 from mcp.types import TextContent
 from datetime import datetime, timedelta, timezone
 
@@ -28,6 +30,102 @@ from src.agent_monitor_state import ensure_hydrated
 from .helpers import _is_test_agent
 
 logger = get_logger(__name__)
+
+
+def _is_uuid_like_agent_id(value: Any) -> bool:
+    """Return True for identifiers that could be used as UUID credentials."""
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        uuid.UUID(value)
+        return True
+    except (TypeError, ValueError, AttributeError):
+        pass
+
+    if value.startswith("agent-"):
+        suffix = value[6:]
+        return (
+            len(suffix) >= 12
+            and all(ch in "0123456789abcdefABCDEF" for ch in suffix[:12])
+        )
+    return False
+
+
+def _public_agent_identifier(agent_id: str, meta: Any) -> str:
+    for attr in ("public_agent_id", "structured_id", "label", "display_name"):
+        value = getattr(meta, attr, None)
+        if value:
+            return str(value)
+    digest = hashlib.sha256(str(agent_id).encode("utf-8")).hexdigest()[:12]
+    return f"agent-redacted-{digest}"
+
+
+def _can_disclose_agent_uuid(
+    agent_id: Optional[str],
+    *,
+    caller_uuid: Optional[str],
+    operator_caller: bool,
+) -> bool:
+    if not agent_id:
+        return True
+    if operator_caller or agent_id == caller_uuid:
+        return True
+    return not _is_uuid_like_agent_id(agent_id)
+
+
+def _visible_agent_identifier(
+    agent_id: str,
+    meta: Any,
+    *,
+    caller_uuid: Optional[str],
+    operator_caller: bool,
+) -> tuple[str, bool]:
+    if _can_disclose_agent_uuid(
+        agent_id,
+        caller_uuid=caller_uuid,
+        operator_caller=operator_caller,
+    ):
+        return agent_id, False
+    return _public_agent_identifier(agent_id, meta), True
+
+
+def _visible_related_agent_identifier(
+    agent_id: Optional[str],
+    *,
+    caller_uuid: Optional[str],
+    operator_caller: bool,
+) -> tuple[Optional[str], bool]:
+    if not agent_id:
+        return None, False
+    if _can_disclose_agent_uuid(
+        agent_id,
+        caller_uuid=caller_uuid,
+        operator_caller=operator_caller,
+    ):
+        return agent_id, False
+
+    related_meta = mcp_server.agent_metadata.get(agent_id)
+    if related_meta:
+        return _public_agent_identifier(agent_id, related_meta), True
+
+    digest = hashlib.sha256(str(agent_id).encode("utf-8")).hexdigest()[:12]
+    return f"agent-redacted-{digest}", True
+
+
+def _context_agent_id() -> Optional[str]:
+    try:
+        from ..context import get_context_agent_id
+        return get_context_agent_id()
+    except Exception:
+        return None
+
+
+def _is_operator_request() -> bool:
+    try:
+        from src.mcp_handlers.identity.operator import is_operator_caller
+        return is_operator_caller()
+    except Exception:
+        return False
 
 
 @mcp_tool("list_agents", timeout=15.0, rate_limit_exempt=True, register=False)
@@ -57,6 +155,8 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                 lite_mode = False
             elif arguments.get("summary_only") is True or arguments.get("grouped") is False:
                 lite_mode = False
+        caller_uuid = _context_agent_id()
+        operator_caller = _is_operator_request()
         if lite_mode:
             # Ultra-compact response - only real agents
             limit = arguments.get("limit", 20)
@@ -122,8 +222,19 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                 label = getattr(meta, 'label', None)
                 public_id = getattr(meta, 'public_agent_id', None) or getattr(meta, 'structured_id', None)
                 from src.resident_progress.registry import is_event_driven_label
-                agents.append({
-                    "id": agent_id,
+                visible_id, uuid_redacted = _visible_agent_identifier(
+                    agent_id,
+                    meta,
+                    caller_uuid=caller_uuid,
+                    operator_caller=operator_caller,
+                )
+                parent_id, parent_redacted = _visible_related_agent_identifier(
+                    getattr(meta, 'parent_agent_id', None),
+                    caller_uuid=caller_uuid,
+                    operator_caller=operator_caller,
+                )
+                agent_entry = {
+                    "id": visible_id,
                     # display_name (user-chosen) takes precedence; agent_id is fallback
                     "label": label or public_id,
                     "status": meta.status,
@@ -132,26 +243,30 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                     "last": meta.last_update[:10] if meta.last_update else None,
                     "last_update": meta.last_update,
                     "trust_tier": getattr(meta, 'trust_tier', None),
-                    "parent_agent_id": getattr(meta, 'parent_agent_id', None),
+                    "parent_agent_id": parent_id,
                     "spawn_reason": getattr(meta, 'spawn_reason', None),
                     "event_driven": is_event_driven_label(label),
-                })
+                }
+                if uuid_redacted:
+                    agent_entry["uuid_redacted"] = True
+                if parent_redacted:
+                    agent_entry["parent_agent_id_redacted"] = True
+                agents.append(agent_entry)
             # Sort: labeled first, then by most recent activity
             agents.sort(key=lambda x: (0 if x.get("label") else 1, -(x.get("updates") or 0), x.get("last_update", "") or ""), reverse=False)
 
             # Always include the requesting agent even if filtered out
-            caller_uuid = None
-            try:
-                from ..context import get_context_agent_id
-                caller_uuid = get_context_agent_id()
-            except Exception:
-                pass
             caller_in_list = caller_uuid and any(a["id"] == caller_uuid for a in agents)
             if caller_uuid and not caller_in_list:
                 caller_meta = mcp_server.agent_metadata.get(caller_uuid)
                 if caller_meta:
                     caller_label = getattr(caller_meta, 'label', None)
                     caller_public = getattr(caller_meta, 'public_agent_id', None) or getattr(caller_meta, 'structured_id', None)
+                    parent_id, parent_redacted = _visible_related_agent_identifier(
+                        getattr(caller_meta, 'parent_agent_id', None),
+                        caller_uuid=caller_uuid,
+                        operator_caller=operator_caller,
+                    )
                     agents.append({
                         "id": caller_uuid,
                         "label": caller_label or caller_public,
@@ -161,10 +276,12 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                         "last": caller_meta.last_update[:10] if caller_meta.last_update else None,
                         "last_update": caller_meta.last_update,
                         "trust_tier": getattr(caller_meta, 'trust_tier', None),
-                        "parent_agent_id": getattr(caller_meta, 'parent_agent_id', None),
+                        "parent_agent_id": parent_id,
                         "spawn_reason": getattr(caller_meta, 'spawn_reason', None),
                         "you": True,
                     })
+                    if parent_redacted:
+                        agents[-1]["parent_agent_id_redacted"] = True
 
             for a in agents:
                 # Mark the requesting agent
@@ -278,8 +395,19 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                     inferred_status = "archived"  # Old activity = archived
 
             from src.resident_progress.registry import is_event_driven_label
+            visible_agent_id, uuid_redacted = _visible_agent_identifier(
+                agent_id,
+                meta,
+                caller_uuid=caller_uuid,
+                operator_caller=operator_caller,
+            )
+            parent_id, parent_redacted = _visible_related_agent_identifier(
+                getattr(meta, 'parent_agent_id', None),
+                caller_uuid=caller_uuid,
+                operator_caller=operator_caller,
+            )
             agent_info = {
-                "agent_id": agent_id,
+                "agent_id": visible_agent_id,
                 "label": getattr(meta, 'label', None),
                 "purpose": getattr(meta, 'purpose', None),
                 "lifecycle_status": inferred_status,
@@ -288,10 +416,14 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                 "total_updates": meta.total_updates,
                 "tags": meta.tags.copy() if meta.tags else [],
                 "notes": meta.notes if meta.notes else "",
-                "parent_agent_id": getattr(meta, 'parent_agent_id', None),
+                "parent_agent_id": parent_id,
                 "spawn_reason": getattr(meta, 'spawn_reason', None),
                 "event_driven": is_event_driven_label(getattr(meta, 'label', None)),
             }
+            if uuid_redacted:
+                agent_info["agent_id_redacted"] = True
+            if parent_redacted:
+                agent_info["parent_agent_id_redacted"] = True
 
             # Lazy load metrics only if requested (optimization)
             if include_metrics:
@@ -419,6 +551,7 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
             # Trust tier from cached trajectory data (DB fallback done in batch below)
             cached_tier = getattr(meta, 'trust_tier', None)
             agent_info["trust_tier"] = cached_tier
+            agent_info["_agent_uuid"] = agent_id
 
             agents_list.append(agent_info)
 
@@ -430,10 +563,10 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                 from src.identity.trust_tier_routing import resolve_trust_tier
                 from src.db import get_db as _get_db
                 db = _get_db()
-                ids_to_fetch = [a["agent_id"] for a in agents_needing_tiers]
+                ids_to_fetch = [a["_agent_uuid"] for a in agents_needing_tiers]
                 identities = await db.get_identities_batch(ids_to_fetch)
                 for agent_info in agents_needing_tiers:
-                    aid = agent_info["agent_id"]
+                    aid = agent_info["_agent_uuid"]
                     identity = identities.get(aid)
                     if identity and identity.metadata:
                         meta_obj = mcp_server.agent_metadata.get(aid)
@@ -470,6 +603,8 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
             agents_list = agents_list[offset:offset + limit]
         elif offset > 0:
             agents_list = agents_list[offset:]
+        for agent_info in agents_list:
+            agent_info.pop("_agent_uuid", None)
 
         # Group by status if requested (for returned agents only)
         if grouped and not summary_only:

--- a/src/mcp_handlers/observability/handlers.py
+++ b/src/mcp_handlers/observability/handlers.py
@@ -3,6 +3,7 @@ Observability tool handlers.
 """
 
 import asyncio
+import math
 from typing import Dict, Any, Sequence
 from mcp.types import TextContent
 import sys
@@ -14,6 +15,33 @@ from src.agent_monitor_state import ensure_hydrated
 logger = get_logger(__name__)
 
 # Import from mcp_server_std module (using shared utility)
+
+
+def _coerce_float_metric(value: Any, default: float) -> float:
+    """Return a finite float, falling back when sparse state returns None."""
+    try:
+        coerced = float(value)
+    except (TypeError, ValueError):
+        return default
+    return coerced if math.isfinite(coerced) else default
+
+
+def _resolve_agent_from_memory(target: str) -> str | None:
+    if target in mcp_server.agent_metadata:
+        return target
+    for uuid_key, meta in mcp_server.agent_metadata.items():
+        if target in (
+            getattr(meta, "label", None),
+            getattr(meta, "display_name", None),
+            getattr(meta, "structured_id", None),
+            getattr(meta, "public_agent_id", None),
+        ):
+            return uuid_key
+    return None
+
+
+def _get_observable_monitor(agent_id: str):
+    return mcp_server.monitors.get(agent_id)
 
 
 def _agent_display_name(agent_id: str) -> str | None:
@@ -31,7 +59,6 @@ def _agent_display_name(agent_id: str) -> str | None:
 @mcp_tool("observe_agent", timeout=15.0, register=False)
 async def handle_observe_agent(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """Observe another agent's governance state with pattern analysis"""
-    from src.governance_monitor import UNITARESMonitor
     # Resolve the TARGET agent to observe.
     # Accept "target_agent_id" (preferred) or "agent_id" (legacy, only if it
     # doesn't match the caller's session-bound UUID — avoids self-observe).
@@ -64,44 +91,11 @@ async def handle_observe_agent(arguments: Dict[str, Any]) -> Sequence[TextConten
                 "example": "observe(action='agent', target_agent_id='<agent-label>')"
             }
         )]
-    # Resolve label to UUID if needed
-    agent_id = target
-    if not (len(target) == 36 and target.count('-') == 4):
-        # Looks like a label, resolve to UUID
-        resolved = None
-        try:
-            from src.mcp_handlers.identity.handlers import _find_agent_by_label
-            resolved = await _find_agent_by_label(target)
-        except Exception as e:
-            logger.debug(f"Label DB lookup failed for '{target}': {e}")
-
-        if not resolved:
-            # Fallback: search in-memory metadata by label.
-            # Was force=True; dropped because the in-memory dict is kept current
-            # by the regular write paths (process_agent_update / onboard /
-            # background load), and a full PG reload here would block all
-            # other handlers ~16s per call. If the agent isn't in memory,
-            # the DB lookup above already missed it.
-            await mcp_server.load_metadata_async()
-            for uuid, meta in mcp_server.agent_metadata.items():
-                if getattr(meta, 'label', None) == target:
-                    resolved = uuid
-                    break
-
-        if resolved:
-            agent_id = resolved
-        else:
-            return [error_response(
-                f"Agent '{target}' not found. Use list_agents to see available agents.",
-                recovery={"related_tools": ["list_agents"]}
-            )]
-    # Verify agent exists. Was force=True full reload; dropped — the
-    # in-memory dict is kept current by the write paths, so reloading all
-    # 3221 agents to look up one is overkill. If the agent is genuinely
-    # missing from in-memory, force-reloading will not surface it (the
-    # DB row was already there or wasn't).
-    await mcp_server.load_metadata_async()
-    if agent_id not in mcp_server.agent_metadata:
+    # Resolve label/UUID from the in-memory metadata snapshot only. Avoid
+    # async DB lookups here: MCP/anyio request handlers can deadlock when they
+    # await asyncpg/Redis work. Background loaders keep this snapshot fresh.
+    agent_id = _resolve_agent_from_memory(target)
+    if not agent_id:
         return [error_response(
             f"Agent '{target}' not found in active metadata. They may need to check in first.",
             recovery={"related_tools": ["list_agents"]}
@@ -110,9 +104,17 @@ async def handle_observe_agent(arguments: Dict[str, Any]) -> Sequence[TextConten
     include_history = arguments.get("include_history", True)
     analyze_patterns_flag = arguments.get("analyze_patterns", True)
     
-    # Load monitor state from disk if not in memory (consistent with get_governance_metrics)
-    monitor = mcp_server.get_or_create_monitor(agent_id)
-    await ensure_hydrated(monitor, agent_id)
+    # Read a monitor snapshot without request-time DB hydration. If no
+    # in-memory/sync-loaded snapshot exists yet, return a clear cache miss.
+    monitor = _get_observable_monitor(agent_id)
+    if monitor is None:
+        return [error_response(
+            f"Observation snapshot for agent '{target}' is not available yet.",
+            recovery={
+                "related_tools": ["get_governance_metrics", "list_agents"],
+                "hint": "Have the agent check in, or retry after background metadata/state loading catches up.",
+            },
+        )]
 
     # Perform pattern analysis
     if analyze_patterns_flag:
@@ -334,11 +336,11 @@ async def handle_compare_me_to_similar(arguments: Dict[str, Any]) -> Sequence[Te
     my_metrics = monitor.get_metrics()
     my_meta = mcp_server.agent_metadata.get(agent_id)
     
-    my_E = float(my_metrics.get('E', 0.7))
-    my_I = float(my_metrics.get('I', 0.8))
-    my_S = float(my_metrics.get('S', 0.2))
-    my_coherence = float(my_metrics.get('coherence', 0.5))
-    my_phi = my_metrics.get('phi', 0.0)
+    my_E = _coerce_float_metric(my_metrics.get('E'), 0.7)
+    my_I = _coerce_float_metric(my_metrics.get('I'), 0.8)
+    my_S = _coerce_float_metric(my_metrics.get('S'), 0.2)
+    my_coherence = _coerce_float_metric(my_metrics.get('coherence'), 0.5)
+    my_phi = _coerce_float_metric(my_metrics.get('phi'), 0.0)
     my_verdict = my_metrics.get('verdict', 'caution')
     my_regime = my_metrics.get('regime', 'nominal')
     my_total_updates = my_meta.total_updates if my_meta else 0
@@ -356,10 +358,12 @@ async def handle_compare_me_to_similar(arguments: Dict[str, Any]) -> Sequence[Te
             await ensure_hydrated(other_monitor, other_id)
             other_metrics = other_monitor.get_metrics()
 
-            other_E = float(other_metrics.get('E', 0.7))
-            other_I = float(other_metrics.get('I', 0.8))
-            other_S = float(other_metrics.get('S', 0.2))
-            other_coherence = float(other_metrics.get('coherence', 0.5))
+            other_E = _coerce_float_metric(other_metrics.get('E'), 0.7)
+            other_I = _coerce_float_metric(other_metrics.get('I'), 0.8)
+            other_S = _coerce_float_metric(other_metrics.get('S'), 0.2)
+            other_coherence = _coerce_float_metric(other_metrics.get('coherence'), 0.5)
+            other_phi = _coerce_float_metric(other_metrics.get('phi'), 0.0)
+            other_risk = _coerce_float_metric(other_metrics.get('risk_score'), 0.4)
             
             # Calculate similarity (Euclidean distance in EISV space)
             E_diff = abs(my_E - other_E)
@@ -381,9 +385,9 @@ async def handle_compare_me_to_similar(arguments: Dict[str, Any]) -> Sequence[Te
                         "I": other_I,
                         "S": other_S,
                         "coherence": other_coherence,
-                        "phi": other_metrics.get('phi', 0.0),
+                        "phi": other_phi,
                         "verdict": other_metrics.get('verdict', 'caution'),
-                        "risk_score": other_metrics.get('risk_score', 0.4)
+                        "risk_score": other_risk
                     },
                     "differences": {
                         "E": other_E - my_E,
@@ -429,7 +433,7 @@ async def handle_compare_me_to_similar(arguments: Dict[str, Any]) -> Sequence[Te
             "coherence": my_coherence,
             "phi": my_phi,
             "verdict": my_verdict,
-            "risk_score": my_metrics.get('risk_score', 0.4)
+            "risk_score": _coerce_float_metric(my_metrics.get('risk_score'), 0.4)
         },
         "similar_agents": top_similar,
         "message": f"Found {len(top_similar)} similar agent(s). Here's how you compare:",

--- a/tests/test_kg_search.py
+++ b/tests/test_kg_search.py
@@ -1757,6 +1757,52 @@ class TestIssue165FtsOperator:
         assert "Invalid operator" in data["error"]
 
 
+class TestKgSearchComplexityCeiling:
+    """Broad auto queries stay inside the MCP tool budget."""
+
+    @pytest.mark.asyncio
+    async def test_auto_hybrid_skips_long_query_unless_forced(self, patch_common, monkeypatch):
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        monkeypatch.setenv("UNITARES_ENABLE_HYBRID", "1")
+        disc = make_discovery(id="sem-1", summary="Semantic match")
+        mock_graph.semantic_search = AsyncMock(return_value=[(disc, 0.82)])
+        mock_graph.full_text_search = AsyncMock(return_value=[disc])
+
+        result = await handle_search_knowledge_graph({
+            "query": "one two three four five six",
+        })
+        data = parse_result(result)
+
+        assert data["success"] is True
+        assert data["search_mode_used"] == "semantic"
+        assert "hybrid_skipped_reason" in data
+        mock_graph.semantic_search.assert_awaited_once()
+        mock_graph.full_text_search.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_long_fts_query_skips_automatic_or_fallback(self, patch_common):
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        del mock_graph.semantic_search
+        mock_graph.full_text_search = AsyncMock(return_value=[])
+
+        result = await handle_search_knowledge_graph({
+            "query": "one two three four five six",
+        })
+        data = parse_result(result)
+
+        assert data["success"] is True
+        assert data["search_mode_used"] == "fts"
+        assert data["fts_operator_used"] == "AND"
+        assert data["fts_fallback_used"] is False
+        assert "fts_fallback_skipped_reason" in data
+        assert mock_graph.full_text_search.await_count == 1
+        assert mock_graph.full_text_search.await_args.kwargs["operator"] == "AND"
+
+
 class TestIssue165ListScope:
     """list response declares its scope and accepts epoch_scope/including_cold."""
 
@@ -1864,6 +1910,5 @@ class TestIssue165Provenance:
         mock_graph.add_discovery.assert_awaited()
         node = mock_graph.add_discovery.await_args.args[0]
         assert node.provenance["source"] == "self_recovery_quick_resume"
-
 
 

--- a/tests/test_lifecycle_agents.py
+++ b/tests/test_lifecycle_agents.py
@@ -197,6 +197,88 @@ class TestListAgentsLite:
             assert by_id["parent-agent"]["spawn_reason"] is None
             assert by_id["orphan-agent"]["parent_agent_id"] is None
 
+    @pytest.mark.asyncio
+    async def test_lite_redacts_uuid_ids_for_non_operator(self, server):
+        parent_uuid = "11111111-2222-3333-4444-555555555555"
+        child_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        server.agent_metadata = {
+            parent_uuid: make_agent_meta(label="Parent", total_updates=20),
+            child_uuid: make_agent_meta(
+                label="Child",
+                total_updates=3,
+                parent_agent_id=parent_uuid,
+                spawn_reason="new_session",
+            ),
+        }
+        with patch_lifecycle_server(server):
+            from src.mcp_handlers.lifecycle.handlers import handle_list_agents
+            result = await handle_list_agents({"lite": True})
+            data = _parse(result)
+
+        by_label = {a["label"]: a for a in data["agents"]}
+        assert by_label["Child"]["id"] == "Child"
+        assert by_label["Child"]["uuid_redacted"] is True
+        assert by_label["Child"]["parent_agent_id"] == "Parent"
+        assert by_label["Child"]["parent_agent_id_redacted"] is True
+        assert by_label["Parent"]["id"] == "Parent"
+
+    @pytest.mark.asyncio
+    async def test_lite_operator_can_see_uuid_ids(self, server, monkeypatch):
+        parent_uuid = "11111111-2222-3333-4444-555555555555"
+        child_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        server.agent_metadata = {
+            parent_uuid: make_agent_meta(label="Parent", total_updates=20),
+            child_uuid: make_agent_meta(
+                label="Child",
+                total_updates=3,
+                parent_agent_id=parent_uuid,
+            ),
+        }
+        monkeypatch.setenv("UNITARES_OPERATOR_TOKENS", "test-operator-token")
+
+        from src.mcp_handlers.context import (
+            SessionSignals,
+            reset_session_signals,
+            set_session_signals,
+        )
+
+        token = set_session_signals(
+            SessionSignals(unitares_operator_token="test-operator-token")
+        )
+        try:
+            with patch_lifecycle_server(server):
+                from src.mcp_handlers.lifecycle.handlers import handle_list_agents
+                result = await handle_list_agents({"lite": True})
+                data = _parse(result)
+        finally:
+            reset_session_signals(token)
+
+        by_label = {a["label"]: a for a in data["agents"]}
+        assert by_label["Child"]["id"] == child_uuid
+        assert by_label["Child"]["parent_agent_id"] == parent_uuid
+        assert "uuid_redacted" not in by_label["Child"]
+        assert by_label["Parent"]["id"] == parent_uuid
+
+    @pytest.mark.asyncio
+    async def test_lite_non_operator_still_sees_own_uuid(self, server):
+        self_uuid = "11111111-2222-3333-4444-555555555555"
+        other_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        server.agent_metadata = {
+            self_uuid: make_agent_meta(label="Self", total_updates=20),
+            other_uuid: make_agent_meta(label="Other", total_updates=3),
+        }
+        with patch_lifecycle_server(server), \
+             patch("src.mcp_handlers.context.get_context_agent_id", return_value=self_uuid):
+            from src.mcp_handlers.lifecycle.handlers import handle_list_agents
+            result = await handle_list_agents({"lite": True})
+            data = _parse(result)
+
+        by_label = {a["label"]: a for a in data["agents"]}
+        assert by_label["Self"]["id"] == self_uuid
+        assert by_label["Self"]["you"] is True
+        assert by_label["Other"]["id"] == "Other"
+        assert by_label["Other"]["uuid_redacted"] is True
+
 
 # ============================================================================
 # handle_list_agents - Non-Lite (Full) Mode
@@ -337,6 +419,44 @@ class TestListAgentsFull:
             assert by_id["child-agent"]["parent_agent_id"] == "parent-agent"
             assert by_id["child-agent"]["spawn_reason"] == "new_session"
             assert by_id["parent-agent"]["parent_agent_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_full_mode_redacts_uuid_ids_for_non_operator(self, server):
+        parent_uuid = "11111111-2222-3333-4444-555555555555"
+        child_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        server.agent_metadata = {
+            parent_uuid: make_agent_meta(
+                status="active", label="Parent", total_updates=20, notes="", trust_tier="known"
+            ),
+            child_uuid: make_agent_meta(
+                status="active",
+                label="Child",
+                total_updates=3,
+                notes="",
+                parent_agent_id=parent_uuid,
+                spawn_reason="new_session",
+                trust_tier="known",
+            ),
+        }
+        health_status = MagicMock()
+        health_status.value = "healthy"
+        server.health_checker = MagicMock()
+        server.health_checker.get_health_status.return_value = (health_status, {})
+        server.monitors = {}
+
+        with patch_lifecycle_server(server):
+            from src.mcp_handlers.lifecycle.handlers import handle_list_agents
+            result = await handle_list_agents({
+                "lite": False, "grouped": False, "include_metrics": False,
+            })
+            data = _parse(result)
+
+        by_label = {a["label"]: a for a in data["agents"]}
+        assert by_label["Child"]["agent_id"] == "Child"
+        assert by_label["Child"]["agent_id_redacted"] is True
+        assert by_label["Child"]["parent_agent_id"] == "Parent"
+        assert by_label["Child"]["parent_agent_id_redacted"] is True
+        assert by_label["Parent"]["agent_id"] == "Parent"
 
     @pytest.mark.asyncio
     async def test_full_mode_status_filter_all(self, server):
@@ -2389,4 +2509,3 @@ class TestMarkResponseCompleteEdgeCases:
 # ============================================================================
 # handle_direct_resume_if_safe - edge cases (lines 1317, 1355-1356, 1391-1392)
 # ============================================================================
-

--- a/tests/test_observability_handlers.py
+++ b/tests/test_observability_handlers.py
@@ -208,6 +208,7 @@ class TestHandleObserveAgent:
         assert data["success"] is True
         assert data["agent_id"] == uuid
         assert "observation" in data
+        server.load_metadata_async.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_happy_path_without_pattern_analysis(self):
@@ -292,27 +293,27 @@ class TestHandleObserveAgent:
 
     @pytest.mark.asyncio
     async def test_label_resolution(self):
-        """When target is a label (not UUID format), resolve via _find_agent_by_label."""
+        """When target is a label, resolve from in-memory metadata."""
         uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-        server = _build_mock_server(agent_ids=[uuid])
+        meta = _make_metadata(uuid, label="Lumen")
+        server = _build_mock_server(
+            monitors_dict={uuid: _make_monitor(uuid)},
+            metadata_dict={uuid: meta},
+        )
 
         with patch(_PATCH_SERVER, server), \
-             patch(_PATCH_CTX, return_value="caller-uuid"), \
-             patch(
-                 "src.mcp_handlers.identity.handlers._find_agent_by_label",
-                 new_callable=AsyncMock,
-                 return_value=uuid,
-             ):
+             patch(_PATCH_CTX, return_value="caller-uuid"):
             from src.mcp_handlers.observability.handlers import handle_observe_agent
             result = await handle_observe_agent({"target_agent_id": "Lumen"})
 
         data = parse_result(result)
         assert data["success"] is True
         assert data["agent_id"] == uuid
+        server.load_metadata_async.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_label_resolution_metadata_fallback(self):
-        """When _find_agent_by_label returns None, fall back to metadata label search."""
+        """Observe does not call async label lookup; metadata label search is enough."""
         uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
         meta = _make_metadata(uuid, label="Lumen")
         server = _build_mock_server(
@@ -326,13 +327,15 @@ class TestHandleObserveAgent:
                  "src.mcp_handlers.identity.handlers._find_agent_by_label",
                  new_callable=AsyncMock,
                  return_value=None,
-             ):
+             ) as mock_find:
             from src.mcp_handlers.observability.handlers import handle_observe_agent
             result = await handle_observe_agent({"target_agent_id": "Lumen"})
 
         data = parse_result(result)
         assert data["success"] is True
         assert data["agent_id"] == uuid
+        mock_find.assert_not_awaited()
+        server.load_metadata_async.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_label_not_found(self):
@@ -722,6 +725,63 @@ class TestHandleCompareMeToSimilar:
 
         data = parse_result(result)
         assert data["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_none_metrics_use_defaults_instead_of_crashing(self):
+        """Sparse hydrated state can return explicit None values for metrics."""
+        my_uuid = "aaaaaaaa-bbbb-cccc-dddd-000000000000"
+        other_uuid = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
+        none_metrics = {
+            "E": None,
+            "I": None,
+            "S": None,
+            "coherence": None,
+            "phi": None,
+            "risk_score": None,
+        }
+        monitors = {
+            my_uuid: _make_monitor(my_uuid, metrics=none_metrics),
+            other_uuid: _make_monitor(other_uuid, metrics=none_metrics),
+        }
+        metadata = {
+            my_uuid: _make_metadata(my_uuid, status="active", total_updates=1),
+            other_uuid: _make_metadata(other_uuid, status="active", total_updates=1),
+        }
+        server = _build_mock_server(monitors_dict=monitors, metadata_dict=metadata)
+
+        with self._patches(server, my_uuid):
+            from src.mcp_handlers.observability.handlers import handle_compare_me_to_similar
+            result = await handle_compare_me_to_similar({"agent_id": my_uuid})
+
+        data = parse_result(result)
+        assert data["success"] is True
+        assert data["my_metrics"]["E"] == 0.7
+        assert data["my_metrics"]["I"] == 0.8
+        assert data["my_metrics"]["S"] == 0.2
+        assert data["my_metrics"]["coherence"] == 0.5
+        assert data["my_metrics"]["phi"] == 0.0
+        assert data["my_metrics"]["risk_score"] == 0.4
+        assert data["similar_agents"][0]["metrics"]["risk_score"] == 0.4
+
+    @pytest.mark.asyncio
+    async def test_consolidated_similar_uses_session_bound_identity(self):
+        """observe(action='similar') works without explicit agent_id when context is bound."""
+        my_uuid = "aaaaaaaa-bbbb-cccc-dddd-000000000000"
+        others = {
+            "aaaaaaaa-bbbb-cccc-dddd-111111111111": {
+                "E": 0.76, "I": 0.84, "S": 0.16, "coherence": 0.64,
+                "total_updates": 8,
+            },
+        }
+        server = self._setup_server_with_similar(my_uuid, others)
+
+        with self._patches(server, my_uuid):
+            from src.mcp_handlers.consolidated import handle_observe
+            result = await handle_observe({"action": "similar"})
+
+        data = parse_result(result)
+        assert data["success"] is True
+        assert data["agent_id"] == my_uuid
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- bound KG auto-search fan-out for long generated queries while preserving explicit hybrid/OR requests
- redact UUID-like agent IDs from list_agents for non-operator callers, while preserving operator and self visibility
- make observe_agent use in-memory snapshots only and guard compare-similar against None metrics

## Validation
- pytest tests/test_kg_search.py::TestKgSearchComplexityCeiling -q
- pytest tests/test_lifecycle_agents.py::TestListAgentsLite tests/test_lifecycle_agents.py::TestListAgentsFull -q
- pytest tests/test_observability_handlers.py::TestHandleObserveAgent tests/test_observability_handlers.py::TestHandleCompareMeToSimilar -q
- pytest tests/test_kg_search.py tests/test_lifecycle_agents.py tests/test_observability_handlers.py -q
- ./scripts/dev/test-cache.sh --staged
- pre-push hook