### PR TITLE
Guard branch hygiene salvage paths

### DIFF
--- a/agents/vigil_hygiene/agent.py
+++ b/agents/vigil_hygiene/agent.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python3
 """vigil-hygiene — weekly branch hygiene sweep.
 
-Runs once per week via launchd. Prunes [gone] local branches, removes
-their worktrees (when clean), and deletes origin branches whose commits
-are all squash-merged. Reports HOLD branches for human review.
+Runs once per week via launchd. Prunes [gone] local branches only after
+checking that their commits are merged or patch-equivalent, removes their
+worktrees (when clean), and deletes origin branches whose commits are all
+squash-merged. Reports HOLD branches with unique commits for human salvage
+review.
 
 Usage:
     python3 agents/vigil_hygiene/agent.py [--repo PATH] [--live]
 
 Defaults to dry-run. --live enables actual deletions.
+See docs/operations/branch-hygiene-runbook.md for the salvage contract.
 
 """
 from __future__ import annotations
@@ -30,7 +33,7 @@ project_root = Path(__file__).resolve().parent.parent.parent
 if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
 
-from agents.vigil_hygiene.cherry import CherryVerdict, parse_cherry
+from agents.vigil_hygiene.cherry import CherryResult, CherryVerdict, parse_cherry
 from agents.vigil_hygiene.clean_check import check_worktree_clean
 
 KEEPALIVE_BRANCH_NAMES = frozenset({"master", "main", "feat/branch-hygiene-automation"})
@@ -87,7 +90,7 @@ def list_gone_branches(repo: Path) -> list[str]:
     result = run_git("branch", "-vv", repo=repo)
     gone = []
     for line in result.stdout.splitlines():
-        m = re.match(r"^[*+ ]\s*(\S+)\s+\S+\s+\[.*: gone\]", line)
+        m = re.match(r"^[*+ ]\s*(\S+)\s+\S+(?:\s+\([^)]*\))?\s+\[.*: gone\]", line)
         if m:
             gone.append(m.group(1))
     return gone
@@ -141,6 +144,32 @@ def cherry(repo: Path, branch: str, base: str = "master") -> str:
         return ""
 
 
+def cherry_local(repo: Path, branch: str, base: str = "master") -> Optional[str]:
+    try:
+        result = run_git("cherry", base, branch, repo=repo)
+        return result.stdout
+    except subprocess.CalledProcessError as e:
+        log(f"SKIP gone-branch '{branch}': git cherry failed ({e.stderr.strip()})")
+        return None
+
+
+def classify_local_gone_cherry(output: str, base: str = "master") -> CherryResult:
+    result = parse_cherry(output)
+    if (
+        result.verdict == CherryVerdict.SKIP
+        and result.plus_count == 0
+        and result.minus_count == 0
+        and result.reason.startswith("empty output")
+    ):
+        return CherryResult(
+            CherryVerdict.DELETE,
+            0,
+            0,
+            f"no commits ahead of {base}",
+        )
+    return result
+
+
 def is_keepalive(
     branch: str,
     open_pr_branches: set[str],
@@ -188,6 +217,22 @@ def sweep(repo: Path, dry_run: bool = True) -> SweepReport:
 
     # 2. Local [gone] cleanup
     for branch in list_gone_branches(repo):
+        cherry_out = cherry_local(repo, branch)
+        if cherry_out is None:
+            continue
+        cherry_result = classify_local_gone_cherry(cherry_out)
+        if cherry_result.verdict == CherryVerdict.HOLD:
+            report.holds.append(branch)
+            report.holds_count += 1
+            log(
+                f"HOLD gone-branch '{branch}': {cherry_result.reason}; "
+                "inspect/salvage before deleting"
+            )
+            continue
+        if cherry_result.verdict == CherryVerdict.SKIP:
+            log(f"SKIP gone-branch '{branch}': {cherry_result.reason}")
+            continue
+
         wt = branch_to_wt.get(branch)
         if wt is not None:
             status = _safe_status(wt)
@@ -211,11 +256,11 @@ def sweep(repo: Path, dry_run: bool = True) -> SweepReport:
                     continue
 
         if dry_run:
-            log(f"DRY-RUN would branch -D '{branch}'")
+            log(f"DRY-RUN would branch -D '{branch}': {cherry_result.reason}")
         else:
             try:
                 run_git("branch", "-D", branch, repo=repo)
-                log(f"deleted local branch: {branch}")
+                log(f"deleted local branch: {branch}: {cherry_result.reason}")
                 report.branches_pruned += 1
             except subprocess.CalledProcessError as e:
                 log(f"ERROR branch -D {branch}: {e.stderr}")

--- a/docs/operations/branch-hygiene-runbook.md
+++ b/docs/operations/branch-hygiene-runbook.md
@@ -1,0 +1,42 @@
+# Branch Hygiene Runbook
+
+`agents/vigil_hygiene/agent.py` is the resident branch-hygiene sweep. It is
+designed to remove branch clutter without deleting salvageable work.
+
+## Safety Contract
+
+For local branches whose upstream is gone:
+
+- `git cherry master <branch>` with one or more `+` commits means **HOLD**.
+  The branch contains unique local work. Inspect, salvage into a fresh PR, or
+  explicitly delete after review.
+- all `-` commits means the work is patch-equivalent to `master`, usually from
+  a squash merge. The branch is safe to prune if the worktree is clean.
+- empty output means the branch has no commits ahead of `master`. The branch is
+  safe to prune if the worktree is clean.
+- unparseable or failed `git cherry` output means **SKIP**. Do not delete.
+- dirty worktrees, paused rebases, paused cherry-picks, merges, or bisects are
+  never removed by the sweep.
+
+For remote `origin/*` branches:
+
+- branches with open PRs are keepalive.
+- branches newer than 24 hours are keepalive.
+- branches with all `-` commits are squash-merged and may be deleted.
+- branches with any `+` commits are **HOLD** for human review.
+
+## Manual Review Loop
+
+When a branch is held:
+
+1. Inspect `git cherry master <branch>` and `git show --stat <sha>`.
+2. Check whether the touched surface is single-writer locked in `AGENTS.md`.
+3. If useful work remains, create a fresh `codex/*` branch from `master` and
+   cherry-pick or manually port only the live hunks.
+4. Run focused tests, then `./scripts/dev/test-cache.sh --staged`.
+5. Open a PR and let CI finish before merging.
+6. Delete the stale branch only after the salvage PR is merged or after review
+   proves the branch is fully superseded.
+
+This is the expected self-improvement loop: classify, preserve evidence, carry
+forward bounded useful work, verify, merge, and remove stale references.

--- a/tests/test_vigil_hygiene_sweep.py
+++ b/tests/test_vigil_hygiene_sweep.py
@@ -11,6 +11,7 @@ import pytest
 
 from agents.vigil_hygiene import agent as agent_mod
 from agents.vigil_hygiene.agent import is_keepalive, sweep
+from agents.vigil_hygiene.cherry import CherryVerdict
 
 
 def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
@@ -95,6 +96,68 @@ class TestSweepDryRun:
 
         assert report.errors == []
         assert report.duration_s > 0
+
+
+class TestSweepGoneBranchSalvageGuard:
+    def test_empty_local_cherry_is_delete_candidate(self):
+        result = agent_mod.classify_local_gone_cherry("")
+        assert result.verdict == CherryVerdict.DELETE
+        assert "no commits ahead" in result.reason
+
+    def test_live_holds_gone_branch_with_unique_commits(self, fake_repo: Path, monkeypatch):
+        _git(fake_repo, "switch", "-c", "codex/unique-local")
+        (fake_repo / "unique.txt").write_text("unique work\n")
+        _git(fake_repo, "add", "unique.txt")
+        _git(fake_repo, "commit", "-m", "unique local work")
+        _git(fake_repo, "push", "-u", "origin", "codex/unique-local")
+        _git(fake_repo, "switch", "master")
+        _git(fake_repo, "push", "origin", "--delete", "codex/unique-local")
+        monkeypatch.setattr(agent_mod, "list_open_pr_branches", lambda repo: set())
+
+        report = sweep(fake_repo, dry_run=False)
+
+        branches = _git(fake_repo, "branch", "--list", "codex/unique-local").stdout
+        assert "codex/unique-local" in branches
+        assert "codex/unique-local" in report.holds
+        assert report.branches_pruned == 0
+
+    def test_live_holds_gone_worktree_branch_with_unique_commits(self, fake_repo: Path, monkeypatch):
+        wt_dir = fake_repo / ".worktrees" / "wt-unique"
+        _git(fake_repo, "worktree", "add", "-b", "codex/wt-unique", str(wt_dir))
+        (wt_dir / "wt-unique.txt").write_text("unique worktree work\n")
+        _git(wt_dir, "add", "wt-unique.txt")
+        _git(wt_dir, "commit", "-m", "unique worktree work")
+        _git(wt_dir, "push", "-u", "origin", "codex/wt-unique")
+        _git(fake_repo, "push", "origin", "--delete", "codex/wt-unique")
+        monkeypatch.setattr(agent_mod, "list_open_pr_branches", lambda repo: set())
+
+        report = sweep(fake_repo, dry_run=False)
+
+        branches = _git(fake_repo, "branch", "--list", "codex/wt-unique").stdout
+        assert "codex/wt-unique" in branches
+        assert wt_dir.exists()
+        assert "codex/wt-unique" in report.holds
+        assert report.worktrees_removed == 0
+
+    def test_live_deletes_gone_branch_when_patch_equivalent(self, fake_repo: Path, monkeypatch):
+        _git(fake_repo, "switch", "-c", "codex/squash-merged")
+        (fake_repo / "squash.txt").write_text("squash-equivalent work\n")
+        _git(fake_repo, "add", "squash.txt")
+        _git(fake_repo, "commit", "-m", "squash-equivalent work")
+        feature_sha = _git(fake_repo, "rev-parse", "HEAD").stdout.strip()
+        _git(fake_repo, "push", "-u", "origin", "codex/squash-merged")
+        _git(fake_repo, "switch", "master")
+        _git(fake_repo, "cherry-pick", feature_sha)
+        _git(fake_repo, "push", "origin", "master")
+        _git(fake_repo, "push", "origin", "--delete", "codex/squash-merged")
+        monkeypatch.setattr(agent_mod, "list_open_pr_branches", lambda repo: set())
+
+        report = sweep(fake_repo, dry_run=False)
+
+        branches = _git(fake_repo, "branch", "--list", "codex/squash-merged").stdout
+        assert "codex/squash-merged" not in branches
+        assert report.holds == []
+        assert report.branches_pruned == 1
 
 
 class TestSweepHelpers:


### PR DESCRIPTION
## Summary
- hold local `[gone]` branches with unique commits instead of deleting them in live branch-hygiene sweeps
- detect `[gone]` branches checked out in worktrees before deciding whether to remove clean worktrees
- document the branch hygiene salvage contract for operators

## Root cause
The branch hygiene sweep treated local `[gone]` branches as disposable once their upstream ref disappeared. That was fine for branches already merged into `master`, but unsafe for abandoned remote branches that still had unique local commits, especially when those branches were checked out in worktrees.

## Validation
- `pytest tests/test_vigil_hygiene_cherry.py tests/test_vigil_hygiene_sweep.py tests/test_vigil_hygiene_clean_check.py -q`
- `python3 -m py_compile agents/vigil_hygiene/agent.py agents/vigil_hygiene/cherry.py agents/vigil_hygiene/clean_check.py`
- `python3 scripts/diagnostics/check_doc_health.py --strict`
- `python3 agents/vigil_hygiene/agent.py --repo /Users/cirwel/projects/unitares`
- `./scripts/dev/test-cache.sh --staged`
- pre-push smoke tests