### PR TITLE
Track metadata hydration tasks

### DIFF
--- a/src/agent_metadata_persistence.py
+++ b/src/agent_metadata_persistence.py
@@ -40,6 +40,15 @@ UNITARES_METADATA_WRITE_JSON_SNAPSHOT = os.getenv("UNITARES_METADATA_WRITE_JSON_
 
 _metadata_backend_resolved: str | None = None
 
+# Prevent fire-and-forget tasks from being GC'd (P001). See
+# src/agent_loop_detection.py:40 for the canonical pattern.
+_background_tasks: set[asyncio.Task] = set()
+
+
+def _track_background_task(task: asyncio.Task) -> None:
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
 
 def _resolve_metadata_backend() -> str:
     """
@@ -328,7 +337,9 @@ async def load_metadata_async(force: bool = False) -> None:
         # start observe calls don't block on it. Snapshot the dict so
         # later mutations don't race the hydration loop.
         try:
-            asyncio.create_task(_hydrate_metadata_cache_async(dict(result)))
+            _track_background_task(
+                asyncio.create_task(_hydrate_metadata_cache_async(dict(result)))
+            )
         except RuntimeError:
             pass
     except Exception as e:


### PR DESCRIPTION
## Summary
- keep strong references to fire-and-forget metadata cache hydration tasks
- resolve the stale P001 branch against current `phases.py`, which already had the stronger `_spawn_persist_task` pattern

## Why
The stale P001 branch still had one useful missing fix: `load_metadata_async()` scheduled Redis metadata-cache hydration with a bare `asyncio.create_task(...)`. Keeping a module-level strong reference matches the existing P001 pattern and avoids task GC while hydration is in flight.

## Validation
- `pytest tests/test_metadata_cold_start.py tests/test_agent_metadata.py tests/test_p001_task_refs.py -q`
- `python3 -m py_compile src/agent_metadata_persistence.py src/mcp_handlers/updates/phases.py`
- `./scripts/dev/test-cache.sh --staged`
- pre-push smoke tests