### PR TITLE
[codex] canonicalize grounding class fold

### DIFF
--- a/scripts/calibrate_class_conditional.py
+++ b/scripts/calibrate_class_conditional.py
@@ -34,6 +34,7 @@ import math
 import statistics
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 try:
@@ -43,26 +44,18 @@ except ImportError:
     print("ERROR: psycopg2 not installed. Run: pip install psycopg2-binary", file=sys.stderr)
     sys.exit(1)
 
+# Ensure repo root is importable so we can use the canonical class fold from
+# src/. The module is pure-stdlib (no governance-server runtime dependency).
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
-KNOWN_RESIDENT_LABELS = {"Lumen", "Vigil", "Sentinel", "Watcher", "Steward", "Chronicler"}
+from src.grounding.class_indicator import (  # noqa: E402
+    KNOWN_RESIDENT_LABELS,
+    classify_by_label_and_tags as classify_from_db_row,
+)
+
 HEALTHY_REGIMES = ("nominal", "STABLE", "CONVERGENCE", "EXPLORATION")
-
-
-def classify_from_db_row(label: Optional[str], tags: Optional[list]) -> str:
-    """Mirror src/grounding/class_indicator.classify_agent for DB-row inputs.
-
-    Kept inline so this script has no governance-server runtime dependency.
-    """
-    if label and label in KNOWN_RESIDENT_LABELS:
-        return label
-    tags_set = set(tags or [])
-    if "embodied" in tags_set:
-        return "embodied"
-    if "ephemeral" in tags_set:
-        return "ephemeral"
-    if "persistent" in tags_set and "autonomous" in tags_set:
-        return "resident_persistent"
-    return "default"
 
 
 @dataclass

--- a/scripts/verdict_counterfactual.py
+++ b/scripts/verdict_counterfactual.py
@@ -24,6 +24,7 @@ import json
 import math
 import sys
 from collections import Counter, defaultdict
+from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 try:
@@ -33,22 +34,15 @@ except ImportError:
     print("ERROR: psycopg2 not installed. Run: pip install psycopg2-binary", file=sys.stderr)
     sys.exit(1)
 
+# Ensure repo root is importable so we can use the canonical class fold from
+# src/. The module is pure-stdlib (no governance-server runtime dependency).
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
-# ── Mirror of src/grounding/class_indicator.classify_agent ────────────
-KNOWN_RESIDENT_LABELS = {"Lumen", "Vigil", "Sentinel", "Watcher", "Steward", "Chronicler"}
-
-
-def classify_from_db_row(label: Optional[str], tags: Optional[list]) -> str:
-    if label and label in KNOWN_RESIDENT_LABELS:
-        return label
-    tags_set = set(tags or [])
-    if "embodied" in tags_set:
-        return "embodied"
-    if "ephemeral" in tags_set:
-        return "ephemeral"
-    if "persistent" in tags_set and "autonomous" in tags_set:
-        return "resident_persistent"
-    return "default"
+from src.grounding.class_indicator import (  # noqa: E402
+    classify_by_label_and_tags as classify_from_db_row,
+)
 
 
 # ── Mirror of config.governance_config.classify_basin ─────────────────

--- a/src/grounding/class_indicator.py
+++ b/src/grounding/class_indicator.py
@@ -10,7 +10,7 @@ class, where fleet-wide constants apply.
 Returns a class name string used to key into the class-conditional scale
 maps in config/governance_config.py (S_SCALE_BY_CLASS, etc.).
 """
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
 
 # Specific labels that identify a unique resident agent. Each is its own
 # calibration class because population N=1 means class==agent in practice.
@@ -26,14 +26,23 @@ CLASS_ENGAGED_EPHEMERAL = "engaged_ephemeral"
 CLASS_DEFAULT = "default"
 
 
-def classify_agent(meta: Optional[Any]) -> str:
-    """Return the calibration class name for an agent given its metadata.
+def classify_by_label_and_tags(
+    label: Optional[str], tags: Optional[Iterable[str]]
+) -> str:
+    """Canonical fold: return the calibration class name from raw label + tags.
+
+    Single source of truth for class assignment k(a). Both the runtime path
+    (`classify_agent` below, given a meta object) and batch scripts that read
+    directly from DB rows delegate here — do not duplicate the resolution
+    logic. Drift between runtime and batch folds silently mis-classifies
+    agents at fit time vs at gating time.
 
     Resolution order:
-      1. Known resident label (Lumen / Vigil / Sentinel / Watcher / Steward).
+      1. Known resident label (Lumen / Vigil / Sentinel / Watcher / Steward /
+         Chronicler) — each is its own class because N=1 means class==agent.
       2. Tag-derived: embodied → embodied; engaged_ephemeral → engaged_ephemeral;
          ephemeral → ephemeral; persistent + autonomous → resident_persistent.
-      3. Default — used for session-bounded agents and anything unrecognized.
+      3. Default — session-bounded agents and anything unrecognized.
 
     Axis note (technical debt — see KG follow-up): ``embodied`` and
     ``ephemeral`` are *identity-class* claims; ``engaged_ephemeral`` is a
@@ -47,26 +56,35 @@ def classify_agent(meta: Optional[Any]) -> str:
     any transient state where both tags coexist (the promotion UPDATE
     strips ephemeral atomically, but the in-memory cache sync is best
     effort), the post-promotion class wins.
+    """
+    if label and label in KNOWN_RESIDENT_LABELS:
+        return label
+
+    tags_set = set(tags) if tags else set()
+
+    if "embodied" in tags_set:
+        return CLASS_EMBODIED
+    if "engaged_ephemeral" in tags_set:
+        return CLASS_ENGAGED_EPHEMERAL
+    if "ephemeral" in tags_set:
+        return CLASS_EPHEMERAL
+    if "persistent" in tags_set and "autonomous" in tags_set:
+        return CLASS_RESIDENT_PERSISTENT
+
+    return CLASS_DEFAULT
+
+
+def classify_agent(meta: Optional[Any]) -> str:
+    """Return the calibration class name for an agent given its metadata.
+
+    Thin adapter over `classify_by_label_and_tags`; accepts any object with
+    ``label`` and ``tags`` attributes (the runtime metadata shape).
 
     Returns 'default' if meta is None or carries no class-relevant tags.
     """
     if meta is None:
         return CLASS_DEFAULT
-
-    label = getattr(meta, "label", None)
-    if label and label in KNOWN_RESIDENT_LABELS:
-        return label
-
-    tags_raw = getattr(meta, "tags", None) or []
-    tags = set(tags_raw)
-
-    if "embodied" in tags:
-        return CLASS_EMBODIED
-    if "engaged_ephemeral" in tags:
-        return CLASS_ENGAGED_EPHEMERAL
-    if "ephemeral" in tags:
-        return CLASS_EPHEMERAL
-    if "persistent" in tags and "autonomous" in tags:
-        return CLASS_RESIDENT_PERSISTENT
-
-    return CLASS_DEFAULT
+    return classify_by_label_and_tags(
+        getattr(meta, "label", None),
+        getattr(meta, "tags", None),
+    )

--- a/tests/test_grounding_class_indicator.py
+++ b/tests/test_grounding_class_indicator.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 from src.grounding.class_indicator import (
     classify_agent,
+    classify_by_label_and_tags,
     KNOWN_RESIDENT_LABELS,
     CLASS_EMBODIED,
     CLASS_RESIDENT_PERSISTENT,
@@ -104,3 +105,93 @@ def test_engaged_ephemeral_does_not_collide_with_resident_persistent():
         classify_agent(_meta(tags=["engaged_ephemeral", "persistent", "autonomous"]))
         == CLASS_ENGAGED_EPHEMERAL
     )
+
+
+# Canonical label-and-tags fold: batch scripts and the runtime path must
+# agree byte-for-byte. The runtime adapter (classify_agent) goes through
+# this function; these tests pin the raw entry point that calibrate and
+# verdict_counterfactual now import directly, so regressions in either
+# direction show up here.
+
+
+class TestClassifyByLabelAndTags:
+    def test_none_label_none_tags_returns_default(self):
+        assert classify_by_label_and_tags(None, None) == CLASS_DEFAULT
+
+    def test_none_label_empty_tags_returns_default(self):
+        assert classify_by_label_and_tags(None, []) == CLASS_DEFAULT
+
+    def test_known_resident_labels_return_themselves(self):
+        for label in KNOWN_RESIDENT_LABELS:
+            assert classify_by_label_and_tags(label, []) == label
+
+    def test_known_label_overrides_tags(self):
+        assert classify_by_label_and_tags("Vigil", ["embodied"]) == "Vigil"
+
+    def test_unknown_label_falls_through_to_tags(self):
+        assert (
+            classify_by_label_and_tags("random_session_agent", ["ephemeral"])
+            == CLASS_EPHEMERAL
+        )
+
+    def test_embodied_tag(self):
+        assert classify_by_label_and_tags(None, ["embodied"]) == CLASS_EMBODIED
+
+    def test_engaged_ephemeral_tag(self):
+        assert (
+            classify_by_label_and_tags(None, ["engaged_ephemeral"])
+            == CLASS_ENGAGED_EPHEMERAL
+        )
+
+    def test_ephemeral_tag(self):
+        assert classify_by_label_and_tags(None, ["ephemeral"]) == CLASS_EPHEMERAL
+
+    def test_resident_persistent_requires_both_tags(self):
+        assert (
+            classify_by_label_and_tags(None, ["autonomous", "persistent"])
+            == CLASS_RESIDENT_PERSISTENT
+        )
+        assert classify_by_label_and_tags(None, ["persistent"]) == CLASS_DEFAULT
+        assert classify_by_label_and_tags(None, ["autonomous"]) == CLASS_DEFAULT
+
+    def test_engaged_ephemeral_beats_ephemeral_in_race(self):
+        """Eliminating the historical drift: the legacy script fold returned
+        'ephemeral' here. Canonical fold returns engaged_ephemeral."""
+        assert (
+            classify_by_label_and_tags(None, ["ephemeral", "engaged_ephemeral"])
+            == CLASS_ENGAGED_EPHEMERAL
+        )
+
+    def test_embodied_beats_engaged_ephemeral(self):
+        assert (
+            classify_by_label_and_tags(None, ["embodied", "engaged_ephemeral"])
+            == CLASS_EMBODIED
+        )
+
+    def test_empty_string_label_is_treated_as_no_label(self):
+        assert classify_by_label_and_tags("", ["ephemeral"]) == CLASS_EPHEMERAL
+
+    def test_accepts_iterable_tags(self):
+        """DB rows can deliver tags as list, tuple, or set — all must work."""
+        assert (
+            classify_by_label_and_tags(None, ("ephemeral",)) == CLASS_EPHEMERAL
+        )
+        assert (
+            classify_by_label_and_tags(None, {"ephemeral"}) == CLASS_EPHEMERAL
+        )
+
+    def test_classify_agent_delegates_to_canonical(self):
+        """The adapter must produce the same answer as the canonical fold
+        for any input that can be expressed via a meta object."""
+        cases = [
+            (None, None),
+            ("Vigil", []),
+            ("random", ["ephemeral"]),
+            (None, ["embodied", "persistent"]),
+            (None, ["engaged_ephemeral", "ephemeral"]),
+            (None, ["persistent", "autonomous"]),
+        ]
+        for label, tags in cases:
+            adapter_result = classify_agent(SimpleNamespace(label=label, tags=tags or []))
+            canonical_result = classify_by_label_and_tags(label, tags)
+            assert adapter_result == canonical_result, (label, tags)


### PR DESCRIPTION
## Summary

- Adds `classify_by_label_and_tags` as the canonical raw label/tag class fold.
- Makes the calibration and verdict counterfactual scripts import the runtime fold instead of duplicating it.
- Pins precedence and adapter parity with grounding class indicator tests.

## Validation

- `pytest tests/test_grounding_class_indicator.py -q`
- `pytest tests/test_calibrate_class_conditional.py -q`
- `python3 -m py_compile src/grounding/class_indicator.py scripts/calibrate_class_conditional.py scripts/verdict_counterfactual.py`
- `git diff --cached --check`
- `./scripts/dev/test-cache.sh --staged` -> 8877 passed, 24 skipped
- pre-push smoke -> 138 passed, 8205 deselected; doc health clear