### PR TITLE
[codex] Stop auto-injecting continuity tokens

### DIFF
--- a/agents/sdk/src/unitares_sdk/agent.py
+++ b/agents/sdk/src/unitares_sdk/agent.py
@@ -283,8 +283,8 @@ class GovernanceAgent:
         # Fast path: we know who we are — just tell the server
         if self.agent_uuid:
             # Identity Honesty Part C: server's PATH 0 now requires
-            # continuity_token alongside agent_uuid. Copy the saved token to
-            # the client so call_tool auto-injects it on this first request.
+            # continuity_token alongside agent_uuid. Pass it explicitly here;
+            # generic client auto-injection is intentionally token-free.
             if self.continuity_token and not client.continuity_token:
                 client.continuity_token = self.continuity_token
             try:
@@ -293,9 +293,15 @@ class GovernanceAgent:
                 # resident_name to build surface_id = "resident:/<name>").
                 # Without this, residents that resume via UUID never set
                 # resident_name and substrate emission skips.
-                await client.identity(
-                    name=self.name, agent_uuid=self.agent_uuid, resume=True
-                )
+                identity_kwargs: dict[str, Any] = {
+                    "name": self.name,
+                    "agent_uuid": self.agent_uuid,
+                    "resume": True,
+                }
+                token = self.continuity_token or getattr(client, "continuity_token", None)
+                if token:
+                    identity_kwargs["continuity_token"] = token
+                await client.identity(**identity_kwargs)
                 self._sync_from_client(client)
                 self._save_session()
                 logger.info("%s: resumed via UUID %s", self.name, self.agent_uuid[:12])

--- a/agents/sdk/src/unitares_sdk/client.py
+++ b/agents/sdk/src/unitares_sdk/client.py
@@ -481,14 +481,12 @@ class GovernanceClient:
     # --- Internal helpers ---
 
     def _inject_session(self, tool_name: str, arguments: dict) -> dict:
-        """Auto-append session/continuity IDs. Skip for identity tools."""
+        """Auto-append in-process session ID. Skip for identity tools."""
         if tool_name in _IDENTITY_TOOLS:
             return arguments
         args = dict(arguments)
         if self.client_session_id and "client_session_id" not in args:
             args["client_session_id"] = self.client_session_id
-        if self.continuity_token and "continuity_token" not in args:
-            args["continuity_token"] = self.continuity_token
         return args
 
     def _capture_identity(self, raw: dict) -> None:

--- a/agents/sdk/src/unitares_sdk/sync_client.py
+++ b/agents/sdk/src/unitares_sdk/sync_client.py
@@ -427,8 +427,6 @@ class SyncGovernanceClient:
         args = dict(arguments)
         if self.client_session_id and "client_session_id" not in args:
             args["client_session_id"] = self.client_session_id
-        if self.continuity_token and "continuity_token" not in args:
-            args["continuity_token"] = self.continuity_token
         return args
 
     def _capture_identity(self, raw: dict) -> None:

--- a/agents/sdk/tests/test_agent.py
+++ b/agents/sdk/tests/test_agent.py
@@ -106,6 +106,7 @@ class TestIdentityResolution:
         client.identity.assert_called_once()
         args = client.identity.call_args
         assert args.kwargs.get("agent_uuid") == "uuid-test"
+        assert args.kwargs.get("continuity_token") == _make_token("uuid-test")
         assert args.kwargs.get("resume") is True
         client.onboard.assert_not_called()
 

--- a/agents/sdk/tests/test_client.py
+++ b/agents/sdk/tests/test_client.py
@@ -56,7 +56,7 @@ class TestSessionInjection:
 
         result = client._inject_session("process_agent_update", {"response_text": "hi"})
         assert result["client_session_id"] == "sid-123"
-        assert result["continuity_token"] == "tok-456"
+        assert "continuity_token" not in result
         assert result["response_text"] == "hi"
 
     def test_skips_injection_for_onboard(self):

--- a/agents/sdk/tests/test_sync_client.py
+++ b/agents/sdk/tests/test_sync_client.py
@@ -130,8 +130,10 @@ class TestSyncSessionInjection:
     def test_injects_session_id(self):
         client = SyncGovernanceClient(transport="rest")
         client.client_session_id = "sid-123"
+        client.continuity_token = "tok-456"
         result = client._inject_session("process_agent_update", {"response_text": "hi"})
         assert result["client_session_id"] == "sid-123"
+        assert "continuity_token" not in result
 
     def test_skips_for_identity_tools(self):
         client = SyncGovernanceClient(transport="rest")

--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -192,7 +192,7 @@ def _save_session(client_session_id: str, continuity_token: str, agent_uuid: str
 
 
 def resolve_identity(client) -> None:
-    """Resolve Watcher identity via UUID-direct → token → fresh onboard.
+    """Resolve Watcher identity via proof-owned UUID-direct → fresh onboard.
 
     Name-resume (previous Step 2) was removed 2026-04-17 when the server-side
     name-claim path was deleted. Without it, every `identity(name="Watcher")`
@@ -213,41 +213,35 @@ def resolve_identity(client) -> None:
     global _watcher_identity
     saved = _load_session()
 
-    # Step 0: UUID-direct (PATH 0) — strongest resume signal.
-    # Works whenever we have a stored UUID, even if the token is stale.
-    # Identity Honesty Part C: server requires continuity_token alongside
-    # agent_uuid for PATH 0 resume — load the saved token into the client so
-    # SyncGovernanceClient.call_tool auto-injects it.
+    # Step 0: UUID-direct (PATH 0) — strongest resume signal when proof-owned.
+    # Identity Honesty Part C + S1-c: server requires continuity_token alongside
+    # agent_uuid for PATH 0 resume, and token-only resume is retired. Pass the
+    # token explicitly; generic client auto-injection is intentionally token-free.
     if saved.get("agent_uuid"):
-        if saved.get("continuity_token") and not getattr(client, "continuity_token", None):
-            client.continuity_token = saved["continuity_token"]
-        try:
-            client.identity(agent_uuid=saved["agent_uuid"], resume=True)
-            _sync_identity(client)
-            return
-        except GovernanceTimeoutError as e:
-            # Transient server slowness — don't fork a new agent. Skip this
-            # cycle; the stored UUID remains the ground truth.
-            log(f"uuid-direct resume timed out ({e}) — skipping, will retry next cycle", "warning")
-            _watcher_identity = None
-            return
-        except Exception as e:
-            log(f"uuid-direct resume failed: {e}", "warning")
+        token = saved.get("continuity_token") or getattr(client, "continuity_token", None)
+        if token:
+            if not getattr(client, "continuity_token", None):
+                client.continuity_token = token
+            try:
+                client.identity(
+                    agent_uuid=saved["agent_uuid"],
+                    continuity_token=token,
+                    resume=True,
+                )
+                _sync_identity(client)
+                return
+            except GovernanceTimeoutError as e:
+                # Transient server slowness — don't fork a new agent. Skip this
+                # cycle; the stored UUID remains the ground truth.
+                log(f"uuid-direct resume timed out ({e}) — skipping, will retry next cycle", "warning")
+                _watcher_identity = None
+                return
+            except Exception as e:
+                log(f"uuid-direct resume failed: {e}", "warning")
+        else:
+            log("uuid-direct resume skipped: missing continuity_token ownership proof", "warning")
 
-    # Step 1: Token resume (PATH 2.8) — fallback when UUID is missing.
-    if saved.get("continuity_token"):
-        try:
-            client.identity(continuity_token=saved["continuity_token"], resume=True)
-            _sync_identity(client)
-            return
-        except GovernanceTimeoutError as e:
-            log(f"token resume timed out ({e}) — skipping, will retry next cycle", "warning")
-            _watcher_identity = None
-            return
-        except Exception as e:
-            log(f"token resume failed: {e}", "warning")
-
-    # Step 2: Fresh onboard — only when nothing else works.
+    # Step 1: Fresh onboard — only when no proof-owned UUID rebind works.
     # Silent-fork guard (added 2026-04-19 anchor-resilience series): Watcher
     # is a resident; missing anchor + no UNITARES_FIRST_RUN means the
     # operator did not authorize a fresh identity. Refuse loudly rather

--- a/agents/watcher/tests/test_agent.py
+++ b/agents/watcher/tests/test_agent.py
@@ -2656,7 +2656,7 @@ SESSION_FILE_NAME = ".watcher_session"
 
 
 class TestWatcherIdentity:
-    """Watcher identity resolution: uuid-direct → token → fresh onboard.
+    """Watcher identity resolution: proof-owned uuid-direct → fresh onboard.
 
     Name-resume was removed 2026-04-17 alongside the server-side name-claim
     deletion. Without name-claim, identity(name="Watcher") forked a fresh
@@ -2695,7 +2695,7 @@ class TestWatcherIdentity:
         assert session_file.exists()
 
     def test_uuid_direct_resume_when_agent_uuid_saved(self, watcher_module, tmp_path, monkeypatch):
-        """Session file with agent_uuid → PATH 0 UUID-direct. Token/name untouched."""
+        """Session file with agent_uuid + token → proof-owned PATH 0 UUID-direct."""
         session_file = tmp_path / SESSION_FILE_NAME
         session_file.write_text(json.dumps({
             "client_session_id": "old-sess",
@@ -2719,14 +2719,23 @@ class TestWatcherIdentity:
                 calls.append(("onboard", name))
 
         watcher_module.resolve_identity(FakeClient())
-        assert calls == [("identity", {"agent_uuid": "uuid-watcher-001", "resume": True})]
-        # No onboard, no token fallback — PATH 0 succeeded on first try.
+        assert calls == [
+            (
+                "identity",
+                {
+                    "agent_uuid": "uuid-watcher-001",
+                    "continuity_token": "old-tok",
+                    "resume": True,
+                },
+            )
+        ]
+        # No onboard, no token-only fallback — PATH 0 succeeded on first try.
 
-    def test_token_resume_when_uuid_missing(self, watcher_module, tmp_path, monkeypatch):
-        """Session file with continuity_token but no agent_uuid → token resume.
+    def test_token_only_resume_retired_when_uuid_missing(self, watcher_module, tmp_path, monkeypatch):
+        """Session file with continuity_token but no agent_uuid does not resume.
 
-        Covers the transition window where an older session file was written
-        before Step 0 existed.
+        S1-c retired token-only identity resume; without a UUID ownership
+        target, Watcher cannot prove PATH 0 ownership.
         """
         session_file = tmp_path / SESSION_FILE_NAME
         session_file.write_text(json.dumps({
@@ -2735,7 +2744,6 @@ class TestWatcherIdentity:
         }))
         monkeypatch.setattr(watcher_module, "SESSION_FILE", session_file)
 
-        identity_called = {}
         onboard_called = {}
 
         class FakeClient:
@@ -2744,19 +2752,16 @@ class TestWatcherIdentity:
             agent_uuid = "uuid-watcher-001"
 
             def identity(self, **kwargs):
-                identity_called.update(kwargs)
-                return type("R", (), {"success": True})()
+                raise AssertionError("token-only identity resume must not be attempted")
 
             def onboard(self, name, **kwargs):
                 onboard_called["name"] = name
 
         watcher_module.resolve_identity(FakeClient())
-        assert identity_called.get("continuity_token") == "old-tok"
-        assert identity_called.get("resume") is True
         assert not onboard_called
 
-    def test_token_fallback_when_uuid_direct_fails(self, watcher_module, tmp_path, monkeypatch):
-        """UUID-direct raises (e.g. agent archived) → fall back to token resume."""
+    def test_no_token_only_fallback_when_uuid_direct_fails(self, watcher_module, tmp_path, monkeypatch):
+        """UUID-direct raises; token-only fallback is retired by S1-c."""
         session_file = tmp_path / SESSION_FILE_NAME
         session_file.write_text(json.dumps({
             "continuity_token": "stale-tok",
@@ -2773,17 +2778,22 @@ class TestWatcherIdentity:
 
             def identity(self, **kwargs):
                 calls.append(("identity", kwargs))
-                if kwargs.get("agent_uuid"):
-                    raise RuntimeError("uuid not found")
-                return type("R", (), {"success": True})()
+                raise RuntimeError("uuid not found")
 
             def onboard(self, name, **kwargs):
                 calls.append(("onboard", name))
 
         watcher_module.resolve_identity(FakeClient())
-        assert calls[0] == ("identity", {"agent_uuid": "uuid-old", "resume": True})
-        assert calls[1] == ("identity", {"continuity_token": "stale-tok", "resume": True})
-        assert len(calls) == 2  # no onboard needed
+        assert calls == [
+            (
+                "identity",
+                {
+                    "agent_uuid": "uuid-old",
+                    "continuity_token": "stale-tok",
+                    "resume": True,
+                },
+            )
+        ]
 
     def test_fresh_onboard_when_both_uuid_direct_and_token_fail(self, watcher_module, tmp_path, monkeypatch):
         """Both UUID-direct AND token fail → fresh onboard (Step 2).
@@ -2816,8 +2826,8 @@ class TestWatcherIdentity:
 
         watcher_module.resolve_identity(FakeClient())
         assert calls[0][0] == "identity" and calls[0][1].get("agent_uuid") == "uuid-archived"
-        assert calls[1][0] == "identity" and calls[1][1].get("continuity_token") == "stale-tok"
-        assert calls[2] == ("onboard", "Watcher")
+        assert calls[0][1].get("continuity_token") == "stale-tok"
+        assert calls[1] == ("onboard", "Watcher")
 
     def test_governance_down_leaves_identity_none(self, watcher_module, tmp_path, monkeypatch):
         """If governance is unreachable, identity is None — scanning still works.

--- a/commands/checkin.md
+++ b/commands/checkin.md
@@ -25,7 +25,7 @@ Inputs:
 - `response_text`: concise summary of what was actually accomplished
 - `complexity`: estimate `0.0-1.0`
 - `confidence`: honest estimate `0.0-1.0`
-- include `continuity_token` only when it is current in-process ownership proof, otherwise rely on the active session binding or `client_session_id` when the client needs explicit continuity data
+- use the active session binding or `client_session_id`; do not auto-inject `continuity_token` into `process_agent_update`
 - use `response_mode="mirror"` by default for Codex
 
 Guidelines:

--- a/commands/governance-start.md
+++ b/commands/governance-start.md
@@ -10,7 +10,7 @@ Use the shared helper in this repo:
 
 - `scripts/client/session_cache.py list`
 
-If the newest entry contains `parent_agent_id`, treat it as a lineage candidate, not ownership proof. Ignore any legacy `continuity_token` field for startup; tokens are only for same-live-owner proof paths and in-process calls.
+If the newest entry contains `parent_agent_id`, treat it as a lineage candidate, not ownership proof. Ignore any legacy `continuity_token` field for startup; tokens are only for explicit same-live-owner PATH 0 proof rebinds.
 
 Call `onboard()` against UNITARES using the strongest honest mode:
 
@@ -21,7 +21,7 @@ Call `onboard()` against UNITARES using the strongest honest mode:
 
 Do not use bare `identity(agent_uuid=<uuid>, resume=true)`. UUID alone is an unsigned claim and is hijack-shaped under strict identity mode.
 
-Do not use `onboard(continuity_token=...)` as cross-process resume except when deliberately testing the S1-a deprecation path.
+Do not use `onboard(continuity_token=...)` as cross-process resume; after S1-c it returns `status=continuity_token_resume_rejected`.
 
 After a successful `identity()` or `onboard()` response:
 

--- a/scripts/dev/with_checkin.py
+++ b/scripts/dev/with_checkin.py
@@ -44,7 +44,6 @@ class CheckinContext:
     session: str | None = None
     agent_id: str | None = None
     client_session_id: str | None = None
-    continuity_token: str | None = None
     task_type: str | None = None
     complexity: float | None = None
     confidence: float | None = None
@@ -233,7 +232,6 @@ def build_checkin_payload(result: CommandResult, context: CheckinContext) -> dic
 
     put_if_present(payload, "agent_id", context.agent_id)
     put_if_present(payload, "client_session_id", context.client_session_id)
-    put_if_present(payload, "continuity_token", context.continuity_token)
     put_if_present(payload, "harness_type", context.harness_type)
     put_if_present(payload, "harness_id", context.harness_id)
     put_if_present(payload, "model_provider", context.model_provider)
@@ -354,6 +352,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--continuity-token",
         default=env_default("UNITARES_CONTINUITY_TOKEN"),
+        help=(
+            "Deprecated compatibility flag; ignored for process_agent_update. "
+            "Use continuity_token only with explicit identity(agent_uuid, "
+            "continuity_token, resume=true) PATH 0 rebinds."
+        ),
     )
     parser.add_argument("--workflow", choices=WORKFLOWS, default="auto")
     parser.add_argument("--task-type")
@@ -415,7 +418,6 @@ def build_context(args: argparse.Namespace, command: list[str]) -> CheckinContex
         session=args.session,
         agent_id=args.agent_id,
         client_session_id=args.client_session_id,
-        continuity_token=args.continuity_token,
         task_type=args.task_type,
         complexity=args.complexity,
         confidence=args.confidence,

--- a/scripts/unitares
+++ b/scripts/unitares
@@ -135,15 +135,15 @@ _curl_get() {
 
 _curl_post_tool() {
     local tool="$1" args="${2:-{\}}"
-    # Inject known continuity material for ordinary in-process calls, but
-    # never onto force_new startup onboards.
+    # Inject known in-session transport continuity for ordinary calls, but
+    # never onto force_new startup onboards. continuity_token is deliberately
+    # not auto-injected; it is only for explicit PATH 0 ownership rebinds.
     local payload include_session
-    payload=$(TOOL="$tool" RAW_ARGS="$args" CSID="${SESSION_ID:-}" CTOKEN="${CONT_TOKEN:-}" python3 -c '
+    payload=$(TOOL="$tool" RAW_ARGS="$args" CSID="${SESSION_ID:-}" python3 -c '
 import json, os, sys
 tool = os.environ["TOOL"]
 raw_args = os.environ.get("RAW_ARGS") or "{}"
 sid = os.environ.get("CSID") or ""
-token = os.environ.get("CTOKEN") or ""
 try:
     args = json.loads(raw_args) if raw_args else {}
 except json.JSONDecodeError as exc:
@@ -155,8 +155,6 @@ if not isinstance(args, dict):
 inject = not bool(args.get("force_new"))
 if inject and sid:
     args.setdefault("client_session_id", sid)
-if inject and token:
-    args.setdefault("continuity_token", token)
 print(json.dumps({"name": tool, "arguments": args}))
 ') || return $?
     include_session=$(RAW_ARGS="$args" python3 -c '

--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -225,10 +225,13 @@ async def resolve_identity_and_guards(ctx: UpdateContext) -> Optional[Sequence[T
                 "process_agent_update requires strong identity assurance for this call",
                 details={
                     "identity_assurance": ctx.identity_assurance,
-                    "hint": "Use bind_session(..., strict=true) or continuity_token for strong identity continuity.",
+                    "hint": (
+                        "Use explicit client_session_id for the active process, "
+                        "or proof-owned identity(agent_uuid=..., continuity_token=..., resume=true)."
+                    ),
                 },
                 recovery={
-                    "action": "Re-bind with strict identity or pass continuity_token, then retry.",
+                    "action": "Re-bind with strong identity proof, then retry.",
                     "related_tools": ["bind_session", "identity", "onboard"],
                 }
             )]

--- a/tests/test_unitares_cli_script.py
+++ b/tests/test_unitares_cli_script.py
@@ -446,6 +446,30 @@ def test_curl_post_tool_does_not_inject_continuity_when_force_new(tmp_path):
     assert include_session_file.read_text() == "0"
 
 
+def test_curl_post_tool_does_not_auto_inject_continuity_token(tmp_path):
+    """S2/S3: ordinary calls use client_session_id, not token auto-injection."""
+    session_file = tmp_path / "session.json"
+    session_file.write_text(json.dumps({
+        "uuid": "parent-uuid",
+        "client_session_id": "cached-session",
+        "continuity_token": "cached-token",
+    }))
+    env = os.environ.copy()
+    env["UNITARES_SESSION_FILE"] = str(session_file)
+    env["UNITARES_AGENT"] = "cli-unit"
+
+    script = (
+        "_curl_fetch() { printf '%s' \"$3\"; }; "
+        "_curl_post_tool process_agent_update '{\"response_text\": \"hi\"}'"
+    )
+    result = _source_cli_and_run(script, env)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    args = payload["arguments"]
+    assert args["client_session_id"] == "cached-session"
+    assert "continuity_token" not in args
+
+
 def test_cmd_onboard_declares_cached_uuid_as_parent(tmp_path):
     """The CLI onboard command should use cached uuid as lineage, not resume."""
     session_file = tmp_path / "session.json"

--- a/tests/test_with_checkin.py
+++ b/tests/test_with_checkin.py
@@ -41,6 +41,7 @@ def test_build_checkin_payload_records_successful_s22_evidence():
     )
     context = with_checkin.CheckinContext(
         workflow="test",
+        client_session_id="sid-123",
         comparison_key="pair-key",
         task_label="Run unit tests",
         invocation_id="inv-1",
@@ -53,6 +54,8 @@ def test_build_checkin_payload_records_successful_s22_evidence():
 
     ProcessAgentUpdateParams.model_validate(payload)
     assert payload["response_mode"] == "minimal"
+    assert payload["client_session_id"] == "sid-123"
+    assert "continuity_token" not in payload
     assert payload["task_type"] == "testing"
     assert payload["confidence"] == 0.82
     assert payload["harness_type"] == "codex-cli"


### PR DESCRIPTION
## Summary
- stop SDK, CLI, and with_checkin generic tool calls from auto-injecting `continuity_token`
- keep resident and Watcher PATH 0 ownership proof explicit via `identity(agent_uuid, continuity_token, resume=true)`
- update check-in/governance-start guidance and strong-identity recovery text for S1-c

## Validation
- focused SDK/Watcher/CLI/check-in tests: 150 passed
- `python3 -m py_compile agents/sdk/src/unitares_sdk/client.py agents/sdk/src/unitares_sdk/sync_client.py agents/sdk/src/unitares_sdk/agent.py agents/watcher/agent.py scripts/dev/with_checkin.py`
- `git diff --check`
- `python3 agents/watcher/agent.py --print-unresolved`
- `./scripts/dev/test-cache.sh`: 8881 passed, 24 skipped, 2 warnings
- `./scripts/dev/test-cache.sh --staged`: 8881 passed, 24 skipped, 2 warnings
