### PR TITLE
[codex] update lease-plane health probe docs

### DIFF
--- a/docs/operations/lease-plane-operator-runbook.md
+++ b/docs/operations/lease-plane-operator-runbook.md
@@ -41,7 +41,7 @@ tail -f ~/Library/Logs/unitares-lease-plane.log
 
 # Health probe (sources LEASE_PLANE_BEARER_TOKEN from ~/.config/cirwel/secrets.env)
 curl -s -H "Authorization: Bearer $LEASE_PLANE_BEARER_TOKEN" \
-     "http://127.0.0.1:8788/v1/lease/status?surface_id=file:///tmp/probe"
+     "http://127.0.0.1:8788/v1/health"
 ```
 
 ## Stop
@@ -55,14 +55,14 @@ launchctl unload ~/Library/LaunchAgents/com.unitares.lease-plane.plist
 
 ## Health check
 
-Sentinel monitors the lease plane via `GET /v1/lease/status?surface_id=__healthcheck__` (RFC §7.7).
+Sentinel monitors the lease plane via `GET /v1/health` (RFC §7.7).
 
 **What the probe is**
 
-`__healthcheck__` is a sentinel surface_id reserved for liveness — the lease plane never holds a real lease against it. A successful probe returns `{"ok": true, "lease": null}` with HTTP 200, proving:
+A successful `/v1/health` probe returns `{"ok": true, "status": "ok", "protocol_version": "v1.0"}` with HTTP 200, proving:
 1. Bandit/Plug router is up
 2. `HTTPAuth` plug accepts the configured `LEASE_PLANE_BEARER_TOKEN`
-3. The Postgres `governance` connection is alive (status query touches `lease_plane.surface_leases`)
+3. The Postgres `governance` connection is alive
 
 **Sentinel alarm rules**
 
@@ -267,7 +267,7 @@ launchctl kickstart -k system/com.unitares.lease-plane
 
 # 5. Confirm the lease plane is back up
 curl -fsS -H "Authorization: Bearer $LEASE_PLANE_BEARER_TOKEN" \
-  http://127.0.0.1:8788/v1/lease/status?surface_id=__healthcheck__
+  http://127.0.0.1:8788/v1/health
 ```
 
 **Rotation cadence**

--- a/docs/proposals/surface-lease-plane-v0.md
+++ b/docs/proposals/surface-lease-plane-v0.md
@@ -424,7 +424,7 @@ Mirror the precedent set by `path1-sync-fingerprint-check.md` and the IDENTITY_S
 **Promotion gate to Phase B per surface_kind requires ALL of:**
 
 1. ≥14 days of advisory-mode telemetry for that surface_kind.
-2. 0 service-availability incidents on the lease plane itself during the window (Sentinel `/v1/lease/status?surface_id=__healthcheck__` uptime ≥ 99.5%).
+2. 0 service-availability incidents on the lease plane itself during the window (Sentinel `/v1/health` uptime ≥ 99.5%).
 3. **Type A signal**: at least one observable conflict event:
    ```sql
    SELECT count(DISTINCT surface_id) FROM lease_plane.lease_plane_events
@@ -733,7 +733,7 @@ The **§6.1 promotion-gate denominator is the outbox**, never PromEx.
 
 Already covered in §4.5: callers receive `{ok: false, error: "service_unavailable"}` and proceed advisory-style. v0 enforcement does not block on lease-plane availability. Phase B selective-enforcement does — a `file:/` surface that's been promoted to enforce *will* block writes if the lease plane is unreachable. That's an operational hazard worth naming.
 
-**Mitigation:** the lease plane itself is supervised by launchd (or homebrew services); restart on crash; alarm on prolonged downtime. A specific Sentinel check should monitor `/v1/lease/status?surface_id=__healthcheck__` and alert if unreachable for >5min. Document in operational runbook before any surface kind reaches enforcement.
+**Mitigation:** the lease plane itself is supervised by launchd (or homebrew services); restart on crash; alarm on prolonged downtime. A specific Sentinel check should monitor `/v1/health` and alert if unreachable for >5min. Document in operational runbook before any surface kind reaches enforcement.
 
 ### 7.8 Lease plane's own identity in UNITARES (council finding 4.1)
 
@@ -1274,7 +1274,7 @@ Required before any `.ex` file is written:
 - [x] §7 open questions all answered (RFC tentative -> RFC committed) — §7.1/7.4/7.6/7.8 resolved v0.2; §7.7 resolved v0.2 with operator-action carve-out; §7.9/7.10 resolved v0.6; §7.2/7.3 resolved v0.7; §7.11/7.12 resolved v0.8; **§7.5 Pi path resolved v0.9 (measured 2026-05-03; Mac path remains provisional pending Mac-resident measurement)** (v0.8 §7.12.4 leaves v1 forward-compat option (a) vs (b) Open, by design)
 - [x] Shelf-Python sketch checked in alongside the Elixir spec — same schema, same API, same return shapes (v0.4)
 - [x] Operational runbook draft: `docs/operations/lease-plane-operator-runbook.md`. **v0.6 commitment:** runbook MUST cover (a) §7.9 rename-orphan manual-release procedure ✓, and (b) §7.10 `LEASE_FORCE_RELEASE_TOKEN` provisioning + rotation steps ✓. **v0.7 addition:** (c) §7.11 scheme-deprecation 30-day drain procedure ✓ (extensive coverage including SIGKILL recovery + idempotent-rerun guidance). Concrete bash commands and SQL audit queries shipped; "Common operations" section retains TBD entries for post-Phase-A operational lore.
-- [x] Sentinel monitoring spec for `/v1/lease/status?surface_id=__healthcheck__` — committed in `docs/operations/lease-plane-operator-runbook.md` "Health check" section. Probe cadence 30s, 5-min sliding-window alarm thresholds, four typed alarm rules (`lease_plane.unreachable`, `lease_plane.auth_drift`, `lease_plane.db_degraded`, `lease_plane.slow`), explicit non-coverage list (reaper liveness + audit-outbox + per-kind acquire rate are separate signals).
+- [x] Sentinel monitoring spec for `/v1/health` — committed in `docs/operations/lease-plane-operator-runbook.md` "Health check" section. Probe cadence 30s, 5-min sliding-window alarm thresholds, four typed alarm rules (`lease_plane.unreachable`, `lease_plane.auth_drift`, `lease_plane.db_degraded`, `lease_plane.slow`), explicit non-coverage list (reaper liveness + audit-outbox + per-kind acquire rate are separate signals).
 - [x] Decision: which exact surface_kind goes first into advisory — **`dialectic:/`**. Rationale: (a) lowest blast-radius surface (dialectic sessions are short-lived, single-writer by nature, and the existing dialectic flow can fall through to advisory-skip on lease unavailability without losing work); (b) the dialectic-knowledge-architect / feature-dev:code-reviewer / live-verifier council pattern naturally exercises lease handoff and held_by_other paths during normal use, surfacing real conflict telemetry quickly; (c) operator (the operator) interacts with dialectic surfaces directly and can recognize anomalies without instrumentation overhead. Contrast: `file://` would be higher-risk (every code edit hits it; one bug locks the workspace) and `capture://` is broader but lower-frequency. Promotion to enforcement gated on §6.1 conflict-log evidence (still open as a separate operator decision — see remaining unchecked rows).
 - [ ] Decision on §6.1 promotion-gate criteria — what specifically counts as "the conflict log says 'we would have prevented a real bug here'". **Deferred until conflict-log data exists.** Phase A ships with `dialectic:/` in advisory; promotion-to-enforcement is the next gate, and locking a threshold on zero advisory-mode evidence would be arbitrary. Reopen when the conflict log has accumulated entries against `dialectic:/` traffic.
 

--- a/scripts/ops/com.unitares.lease-plane.plist.template
+++ b/scripts/ops/com.unitares.lease-plane.plist.template
@@ -4,8 +4,8 @@
 
   Phase A advisory service for shared-surface coordination across the fleet
   (Watcher, Vigil, Sentinel, Chronicler, Steward, ship.sh, dispatch). Bind
-  defaults to 127.0.0.1:8788; bearer-auth is fail-closed (HTTPAuth → 503
- if LEASE_PLANE_BEARER_TOKEN is unset). .
+	  defaults to 127.0.0.1:8788; bearer-auth is fail-closed (HTTPAuth → 503
+	 if LEASE_PLANE_BEARER_TOKEN is unset).
 
   Install (render __VARS__ then load):
     sed -e "s|__UNITARES_ROOT__|$HOME/projects/unitares|g" \
@@ -18,7 +18,7 @@
     launchctl list | grep com.unitares.lease-plane
     tail -f ~/Library/Logs/unitares-lease-plane.log
     curl -s -H "Authorization: Bearer $LEASE_PLANE_BEARER_TOKEN" \
-         "http://127.0.0.1:8788/v1/lease/status?surface_id=file:///tmp/probe"
+         "http://127.0.0.1:8788/v1/health"
 -->
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">


### PR DESCRIPTION
## Summary
- replace stale lease-plane status/`__healthcheck__` probe references with the live `/v1/health` route
- update the operator runbook, lease-plane RFC, and launchd plist verification comment
- fix an adjacent punctuation typo in the launchd template comment

## Why
The service now exposes a dedicated `/v1/health` endpoint. The old pseudo-surface probe fails canonicalization, so operator docs should point at the route the live BEAM service and tests pin.

## Validation
- `./scripts/dev/test-cache.sh` (cache hit for this tree; prior full run: 8890 passed, 24 skipped)
- pre-push smoke tests: 138 passed, doc health clear
- live `/v1/health` curl returned `{"ok":true,"status":"ok","protocol_version":"v1.0"}`
- `rg` found no remaining `__healthcheck__` references
