### PR TITLE
docs: fold resident phase b status into BEAM plans

### DIFF
--- a/docs/proposals/beam-footprint-roadmap-v0.md
+++ b/docs/proposals/beam-footprint-roadmap-v0.md
@@ -1,7 +1,7 @@
 # BEAM Footprint Roadmap
 
 **Created:** May 3, 2026
-**Last Updated:** May 9, 2026 (v0.3.2 — Wave 3 substrate re-litigation; includes 2026-05-07 Wave 3 surface inventory addendum; v0.3 destination unchanged)
+**Last Updated:** May 20, 2026 (v0.3.3 status fold — resident Phase B + lease/ODE measurement persistence; v0.3 destination unchanged)
 **Status:** v0.3 — destination is **A′ (committed, operator-decision-driven, 2026-05-05)**. Stateful coordination ports to BEAM in waves; stateless computation (numpy ODE, embeddings, LLM SDK calls) stays Python and is called from BEAM via Ports / HTTP. v0.2 had reopened the destination after PR #350's verdict; v0.3 closes it again on operator call after four Python-fixable PRs (#350 / #354 / #360 / #361) closed every measured floor without moving the user-visible ~11s p50 per-turn overhead. **Read the V0.3 RESOLUTION block first.** v0 / v0.1 / v0.2 bodies preserved as historical record.
 **Council pass v0.1 (2026-05-04):** dialectic-knowledge-architect (2B/4C/3D/4N), feature-dev:code-reviewer (2B/3C/2D/2N), live-verifier (7 VERIFIED, 6 DRIFT, 0 REFUTED, 1 SOURCE_ONLY) — all findings folded inline. Architect C3 + reviewer C3 both flagged "v0.1 destination committed pre-experiment"; the v0.1 conditionality block was the fold for that finding, and v0.2 was the realization of it.
 **Council pass v0.3:** none on the migration call itself — that's an operator decision after a multi-session debate, and adversarial review of the call after operator commitment is the relitigation pattern v0.3 is trying to end. Council passes ARE expected on technical scope (Wave 1 supervisor topology, BEAM↔Python boundary contracts, identity-state migration) once those land as RFCs.
@@ -143,9 +143,9 @@ V0.3 lists dialectic resolution in the "stateful-coordinating, ports to BEAM" co
 
 ### C3 (reviewer) — Lease plane Phase A is advisory-only; Wave 3 needs Phase B
 
-V0.3 says "Lease plane already proves the boundary." Reviewer correction: Phase A contract is advisory mode — failed acquire MUST NOT block the caller's normal operation. Pattern generalizes for Sentinel (Wave 1) cleanly but NOT for Wave 3 handler dispatch, which requires Python MCP to stop accepting writes for an agent while its BEAM GenServer is mid-update. That's Phase B enforcement. Phase B eligibility for `dialectic:/` opens 2026-05-16 per lease plane RFC; **no Phase B window is named for `resident:/` surfaces.**
+V0.3 says "Lease plane already proves the boundary." Reviewer correction: Phase A contract is advisory mode — failed acquire MUST NOT block the caller's normal operation. Pattern generalizes for Sentinel (Wave 1) cleanly but NOT for Wave 3 handler dispatch, which requires Python MCP to stop accepting writes for an agent while its BEAM GenServer is mid-update. That's Phase B enforcement. Phase B eligibility for `dialectic:/` opens 2026-05-16 per lease plane RFC; at v0.3.1 time, **no Phase B window had yet been named for `resident:/` surfaces.**
 
-**Fold:** Wave 3 RFC MUST address opening a `resident:/` Phase B window OR specify a different enforcement-grade boundary mechanism. Wave 1 stays unaffected (Sentinel is fine on Phase A advisory).
+**Fold:** Wave 3 RFC MUST address opening a `resident:/` Phase B window OR specify a different enforcement-grade boundary mechanism. Superseded status note: resident Phase B opened later via PR #476 (merged 2026-05-20 UTC); Wave 3 still must specify its own enforcement-grade boundary for handler-dispatch cutover rather than treating resident evidence as proof for unrelated agent-state surfaces. Wave 1 stays unaffected (Sentinel is fine on Phase A advisory).
 
 ### C4 (reviewer) — Test strategy under migration
 
@@ -263,6 +263,29 @@ Each is referenceable for the architectural decisions tried at that iteration. N
 - The Wave 0 channel design (`audit.coordination_events`) or its CHECK constraint scope.
 
 What it changes: Wave 3 sequencing is on hold pending operator decision among (α)/(β)/(γ)/(δ). Until that decision lands, no v0.4 redraft, no implementation work on Wave-3-specific prereqs. The non-Wave-3-specific prereqs (lease-plane Phase A latency instrumentation, ODE profile, boundary-event helpers) can ship independently because they're useful regardless of Wave 3's eventual shape.
+
+---
+
+## V0.3.3 STATUS FOLD 2026-05-20 — resident Phase B + measurement persistence
+
+This is a bookkeeping fold over shipped work after v0.3.2. It does not change
+A' or resolve the Wave 3 re-litigation question.
+
+- **Resident Phase B is already open.** PR #476
+  (`feat(lease-plane): enforce resident phase b leases`) merged 2026-05-20 UTC
+  after the mechanical evaluator returned PROMOTABLE with controlled drill
+  evidence. Wave 3 no longer needs to open the `resident:/` Phase B window as
+  future work, but it still needs an enforcement-grade boundary decision for
+  handler-dispatch cutover.
+- **Lease-boundary RPC latency is now recorder + persistence.**
+  PR #480 added the Python client recorder in `src/lease_plane/client.py`;
+  PR #481 added `perf_monitor_persist_task`, catalog entries, and
+  `metrics.series` persistence for `lease_plane.client.v1.lease.acquire.p50`
+  and `.p99`.
+- **ODE profile persistence also landed.** PR #481 persists
+  `ode.numpy_step_ms.p50` / `.p99`; the remaining question is the 7+ day
+  reading, not whether the longitudinal storage path exists.
+
 ---
 
 ## V0.2 RESOLUTION 2026-05-05 — verdict landed; destination reopens *(SUPERSEDED by V0.3 RESOLUTION above; preserved as historical record)*

--- a/docs/proposals/beam-wave-1-sentinel.md
+++ b/docs/proposals/beam-wave-1-sentinel.md
@@ -525,7 +525,11 @@ v0.3 §Sequencing names Sentinel-on-BEAM as the smallest first ship under A′ (
 - Wave 3 work (handler dispatch, identity middleware, dialectic resolution). Lock-invariant inventory belongs in Wave 3 RFC, not here.
 - ODE profile work (`process_update_authenticated_async` profiling). Runs in parallel; lands in v0.3.1.1 amendment; gates Wave 1 *exit criteria authorship* (per v0.3.1 C1) but not implementation.
 - Vigil and Chronicler ports. Each gets its own RFC if/when sequenced.
-- Phase B `resident:/` enforcement window (v0.3.1 C3). Sentinel uses Phase A advisory; opening Phase B for resident surfaces is a Wave 3 prerequisite, not a Wave 1 prerequisite.
+- Resident Phase B promotion ownership (v0.3.1 C3). Wave 1 originally used
+  Phase A advisory; resident Phase B later opened via PR #476 (merged
+  2026-05-20 UTC). Sentinel-on-BEAM consumes that enforcement posture, but
+  Wave 1 does not define Phase-B promotion criteria or Wave 3 cutover
+  enforcement.
 - Migration of the `unitares_sdk` Python SDK to an Elixir SDK. Cross-runtime, BEAM Sentinel calls governance MCP via the same HTTP/REST contract Python Sentinel uses today.
 
 ## State migration (per v0.3.1 B1, B3, B4)

--- a/docs/proposals/beam-wave-3-handler-dispatch.md
+++ b/docs/proposals/beam-wave-3-handler-dispatch.md
@@ -1,11 +1,26 @@
 # Wave 3 RFC: handler dispatch + identity middleware + dialectic resolution → BEAM
 
-**Status:** v0.3, 2026-05-09. Full redraft superseding v0.2 (which superseded v0.1.x). Each prior version is preserved on its branch as a historical record. v0.3 closes the architectural irony the v0.2 council surfaced: cache coherence and feature-flag state move off PostgreSQL into BEAM-native ETS, so the RFC stops piling new PG-coordination load onto the substrate it exists to relieve.
-**Parent:** `docs/proposals/beam-footprint-roadmap-v0.md` v0.3.1.
+**Status:** v0.3.2 + 2026-05-20 status fold. Full redraft superseding v0.2 (which superseded v0.1.x). Each prior version is preserved on its branch as a historical record. v0.3 closes the architectural irony the v0.2 council surfaced: cache coherence and feature-flag state move off PostgreSQL into BEAM-native ETS, so the RFC stops piling new PG-coordination load onto the substrate it exists to relieve.
+**Parent:** `docs/proposals/beam-footprint-roadmap-v0.md` v0.3.3.
 **Sibling, completed:** `docs/proposals/beam-wave-1-sentinel.md` (Surface 1+2 shipped; Surface 3 in flight).
-**Sibling, completed:** `docs/proposals/surface-lease-plane-v0.md` Phase A + Wave 2 hardening (#412/#414/#417/#418/#419).
+**Sibling, completed:** `docs/proposals/surface-lease-plane-v0.md` Phase A + Wave 2 hardening + resident Phase B + lease RPC recorder/persistence (#412/#414/#417/#418/#419/#476/#480/#481).
 **Wave 0 channel:** `audit.coordination_events` exists with `event_type ~ '^(coordination_failure)(\.[a-z_]+)+$'` CHECK constraint; zero rows as of 2026-05-09. The constraint scopes the table to failure events only — informational latency lives in the parallel channel introduced in §6.
 **Single-writer surface:** Identity / onboarding (per `CLAUDE.md` "Before Starting Work on a Single-Writer Surface") spans this entire RFC plus its prereq PRs. Branch from this RFC's head before any parallel work.
+
+## Post-v0.3.2 status fold (2026-05-20)
+
+Two non-Wave-3-specific prerequisites moved after this RFC was drafted:
+
+- **Resident Phase B is already open.** PR #476 merged 2026-05-20 UTC after the
+  lease-plane evaluator returned PROMOTABLE with controlled drill evidence.
+  §4 option (α) is revised from "open resident Phase B" to "reuse existing
+  resident enforcement where it actually applies"; it is not evidence for
+  unrelated agent-state surfaces.
+- **Lease RPC instrumentation uses the existing client module.** PR #480 added
+  per-call recorder hooks in `src/lease_plane/client.py`; PR #481 persists
+  acquire p50/p99 snapshots to `metrics.series`. §6/§14 PR #6 should build on
+  that recorder if it still needs the `audit.coordination_measurements`
+  channel.
 
 ## What changed in v0.3.2 (vs v0.3.1)
 
@@ -145,10 +160,13 @@ Identity middleware decomposes into eight state surfaces.
 
 The cutover window has a dual-write phase where both BEAM and Python actively write to the same agent's state. After full cutover, BEAM is the sole writer for the migrated surfaces; this section's coordination is bounded to the cutover window.
 
-- **(α)** Open a `resident:/` Phase B window via amendment to `surface-lease-plane-v0.md`. Forces every Python resident (Sentinel, Vigil, Chronicler, in-process Steward) to learn fail-closed-on-deny semantics in the same window as cutover — couples two large changes.
+- **(α)** Reuse existing `resident` Phase B enforcement where the cutover touches resident-owned surfaces. PR #476 already opened resident enforcement, so this no longer couples Wave 3 to opening Phase B. It also does not generalize resident drill evidence to unrelated agent-state surfaces.
 - **(β) — recommended.** Per-agent PG advisory lock at the writer entry point (`pg_try_advisory_lock(hashtext(agent_uuid))`). BEAM acquires on enter, releases on exit; Python writers attempt with 50ms timeout and fail-fast (returning the same 503-equivalent surfaced as `governance_temporarily_unavailable`). Keeps lease plane unchanged. **Cost accounting:** the per-write advisory-lock round-trip is counted against disconfirmer (B)'s budget (§0). Bounded per write, not per observe.
 
-If (α) is chosen, B5.2 from v0.1.2 stands: operator evaluates `resident:/` against `surface-lease-plane-v0.md` §6.1 criteria and flips a flag rather than shipping a PR. If (β) is chosen, §4 is a binding implementation spec. Council confirms before implementation gate.
+If (α) is chosen, implementation must verify `LEASE_PLANE_ENFORCED_SURFACE_KINDS`
+includes `resident` in every process participating in the relevant cutover path
+and must name any non-resident surface_kind separately. If (β) is chosen, §4 is
+a binding implementation spec. Council confirms before implementation gate.
 
 ---
 
@@ -281,7 +299,12 @@ Wave 3 wires `coordination_failure.beam_python_boundary.*` emissions at:
 
 ### 6.3 Measurement call-sites (new channel, `audit.coordination_measurements`)
 
-- A new `src/lease_plane_client.py` (created by prereq PR #6 — does not currently exist) will emit `measurement.lease_plane.request` on every request to `127.0.0.1:8788`, payload `{endpoint, method, status_code, elapsed_ms}`. PR #6 primary deliverable; data accrues ≥14 days before disconfirmer (B) thresholds can be set.
+- Existing `src/lease_plane/client.py` emits per-call lease RPC latency into
+  `perf_monitor` (PR #480), and PR #481 persists acquire p50/p99 snapshots to
+  `metrics.series`. If prereq PR #6 still needs
+  `measurement.lease_plane.request` rows in `audit.coordination_measurements`,
+  it should bridge from this recorder rather than create a parallel one-off
+  client module.
 - Wave 3 BEAM handler-dispatch emits `measurement.beam_python_boundary.request` on every successful boundary call, payload `{endpoint, method, elapsed_ms, payload_bytes}`.
 - Python MCP transport during cutover emits `measurement.governance_mcp.503_emission` on every 503 it returns, payload `{request_path, error_reason}` — input to §3.2's halt aggregator.
 
@@ -732,7 +755,9 @@ Inheriting parent roadmap stop signs #1–#4, plus Wave-3-specific:
 - Does not port the LLM SDK call paths. Anthropic/OpenAI/Ollama call paths inside handlers stay Python, called from BEAM via Ports/HTTP.
 - Does not port Watcher. Single-shot LLM pattern matcher; no coordination shape.
 - Does not modify the `lease_plane` schema. Wave 3's new state lives in BEAM ETS (live) + new PG schemas/tables (durable): `coordination` schema (§9), `core.identities_shadow` + `core.agents_shadow` (§8), `audit.coordination_measurements` (§6), `core.feature_flags` (§10).
-- Does not extend `surface-lease-plane-v0.md` Phase B to `resident:/` unless §4 option (α) is chosen.
+- Does not open `surface-lease-plane-v0.md` Phase B for `resident:/`; PR #476
+  already did that. Does not extend Phase B to any new agent-state or cutover
+  surface_kind until §4 option (α) names it explicitly.
 - Does not version columns in `core.agent_behavioral_baselines` or `core.feature_flags`. v0.2's version-counter approach is retired in favor of single-writer ETS canonical + PG durable.
 
 ---
@@ -748,7 +773,7 @@ All ten prereq PRs land BEFORE any commit in `elixir/handler_dispatch/` or any n
 | 3 | `coordination_events_helpers.py` + Elixir helper + CI lint | `governance_core/coordination_events_helpers.py` (`make_boundary_payload`, `make_measurement_payload`), Elixir helper module, `scripts/dev/check-boundary-event-helpers.sh` (CI lint) | — |
 | 4 | IPUA pin integration test | `tests/integration/test_identity_path2_ipua_pin_pipeline.py` | — |
 | 5 | Golden-capture fixture + capture script + masking + parity test | `tests/fixtures/wave3_response_golden/` (50+), `scripts/dev/wave3-capture-goldens.sh`, `tests/integration/test_wave_3_response_parity.py` | — |
-| 6 | Lease-plane Phase A latency instrumentation + measurement table + retention | `db/postgres/migrations/0NN_audit_coordination_measurements.sql`, `src/lease_plane_client.py` (emit `measurement.lease_plane.request`), `scripts/ops/wave-0-channel-report.sh` (read both tables), `scripts/ops/wave-0-partition-roll.sh` + plist (90-day retention). Runs ≥14 days before disconfirmer (B) thresholds set | #3 (`make_measurement_payload`) |
+| 6 | Lease-plane Phase A latency instrumentation + measurement table + retention | `db/postgres/migrations/0NN_audit_coordination_measurements.sql`, `src/lease_plane/client.py` (existing recorder; bridge/emission to `measurement.lease_plane.request`), `scripts/ops/wave-0-channel-report.sh` (read both tables), `scripts/ops/wave-0-partition-roll.sh` + plist (90-day retention). Runs ≥14 days before disconfirmer (B) thresholds set | #3 (`make_measurement_payload`) |
 | 7 | Saga DDL + state machine | `db/postgres/migrations/0NN_coordination_session_resolution_sagas.sql` (CREATE SCHEMA + CREATE TABLE + partial unique index), Python interface stubs for tests | — |
 | 8a | BaselineWriter stub + Readiness GenServer + cold-ETS contract test | `elixir/handler_dispatch/lib/baseline_writer.ex` (skeleton: GenServer scaffolding, `:writer_warm` signal, no PG read yet), `elixir/handler_dispatch/lib/readiness.ex` (the readiness gate from §10.2), `elixir/handler_dispatch/test/cold_ets_contract_test.exs` (the `:cold` return contract; matches §10.2 belt-and-suspenders spec). No production wiring; allows the §10.2 invariants to ship and be tested before measurement data accrues. | #2 (FeatureFlagWriter pattern) |
 | 8b | BaselineWriter wiring + boundary endpoint + slow-reconciliation cron | Wires `BaselineWriter` to PG (bulk SELECT on init, write path per §10.1), boundary endpoint `POST /v1/baseline/get` for Python reads during transition, slow-reconciliation cron, ExUnit tests for ETS-PG single-writer invariant + reconciliation divergence detection. **Gated on PR #6 14-day window**: `scripts/dev/check-wave3-prereq-data-window.sh` (CI lint, added in this PR) verifies ≥14 days of `measurement.lease_plane.request` rows in `audit.coordination_measurements` before this PR can merge. Enforces criterion §11.5 mechanically rather than as a Go-decision document obligation. | #6 (14-day data), #8a |

--- a/docs/proposals/lease-plane-phase-a-latency-2026-05-20.md
+++ b/docs/proposals/lease-plane-phase-a-latency-2026-05-20.md
@@ -63,7 +63,7 @@ because the v0.3.2 gate predates the boundary:
 - 2026-05-06 → 2026-05-18 (13d): Phase A advisory mode (PR #305, merged
   2026-05-03)
 - 2026-05-19 → 2026-05-20 (1d at window close): Phase B resident
-  enforcement (PR #476, merged 2026-05-19)
+  enforcement drill began; PR #476 merged 2026-05-20 UTC
 
 The headline percentiles aggregate across both regimes. The conflict
 and TTL-reap counts are dominated by the 13-day advisory tail; Phase B
@@ -115,21 +115,20 @@ latency to the in-process `perf_monitor` under keys:
 - ... and corresponding outcome shards (`schema_invalid`,
   `transport_exception`, `permission_denied`, `service_unavailable`)
 
-`perf_monitor.snapshot()` exposes p50/p95/p99/max per key. For
-longitudinal capture, the next step is to persist these snapshots to
-`metrics.series` periodically — that work is tracked in the ODE-profile
-branch (`ode-profile-decompose`), which faces the same persistence gap
-and is the cleaner place to land the shared infrastructure.
+`perf_monitor.snapshot()` exposes p50/p95/p99/max per key. Longitudinal
+capture landed in PR #481: `perf_monitor_persist_task` samples the snapshot
+every 5 minutes and writes catalog-gated series to `metrics.series`,
+including `lease_plane.client.v1.lease.acquire.p50` and `.p99`.
 
 ## Falsifier — what this window cannot resolve
 
 The substrate-tax-at-lease-boundary question is **deferred** until:
 
-1. Client-side RPC instrumentation is persisted to `metrics.series`
-   (this branch adds the recorder; persistence pending).
-2. A subsequent 14-day window runs with the recorder live, under load
-   comparable to the §129 representative-load floor (≥ 500 agent_state
-   writes/day).
+1. A subsequent 14-day window runs with the recorder and persistence live,
+   under load comparable to the §129 representative-load floor (≥ 500
+   agent_state writes/day).
+2. The persisted client-side RPC series has enough samples to characterize
+   p50/p99 rather than only hold-time proxy data.
 3. RPC latency p95 for `lease.acquire.ok` is examined against the
    baseline that asyncpg-coupled handlers showed pre-`PR #218`
    ExecutorPool wrap. A 60× amplification signature at the lease

--- a/docs/proposals/surface-lease-plane-v0.md
+++ b/docs/proposals/surface-lease-plane-v0.md
@@ -1,7 +1,7 @@
 ---
-status: v0.11+ (Phase A SHIPPED 2026-05-03 via PR #305; post-Phase-A amendments: §7.5 v0.9 Pi remote_heartbeat TTL, §7.2.8/9 v0.10 payload-shape + scheme grammar, §7.13 v0.11 substrate-state separation; §7.13.3 v0.11.3 reviewer-judgment-at-review-time accepted; Phase B promotion eligibility window opens 2026-05-16 for `dialectic:/` per §6.2 ordering — earliest date any surface_kind satisfies §6.1.1's 14-day advisory-window minimum given Phase A close on 2026-05-02; mechanical evaluator at `scripts/lease_plane/evaluate_phase_b_promotion.py`)
+status: v0.11+ (Phase A SHIPPED 2026-05-03 via PR #305; post-Phase-A amendments: §7.5 v0.9 Pi remote_heartbeat TTL, §7.2.8/9 v0.10 payload-shape + scheme grammar, §7.13 v0.11 substrate-state separation; §7.13.3 v0.11.3 reviewer-judgment-at-review-time accepted; Phase B promotion eligibility window opened 2026-05-16; `resident` enforcement shipped 2026-05-20 UTC via PR #476 after the mechanical evaluator accepted controlled drill evidence; evaluator at `scripts/lease_plane/evaluate_phase_b_promotion.py`)
 authored: 2026-04-30
-amended: 2026-04-30 (v0.1–v0.8 same session); 2026-05-02 (v0.9 §7.5); 2026-05-02 (v0.10 §7.2.8/9); 2026-05-03 (v0.11 §7.13 substrate-state separation); 2026-05-04 (status: Phase B eligibility window + evaluator pointer)
+amended: 2026-04-30 (v0.1–v0.8 same session); 2026-05-02 (v0.9 §7.5); 2026-05-02 (v0.10 §7.2.8/9); 2026-05-03 (v0.11 §7.13 substrate-state separation); 2026-05-04 (status: Phase B eligibility window + evaluator pointer); 2026-05-20 (status: resident Phase B enforcement shipped via PR #476)
 council_pass_1: 2026-04-30
 ack_pass_1: 2026-04-30
 author_session: agent-68437d77-65c (claude_code-claude_68437d77)
@@ -465,8 +465,13 @@ runtime config (for example, `resident,file`); when their surface kind is listed
 they fail closed if lease acquisition returns `held_by_other` or the lease plane is
 unavailable. Omitting the surface kind keeps Phase A advisory behavior.
 
-- `dialectic:/...` likely first (lowest external blast radius, dialectic infra already has manual fallbacks).
-- `resident:/...` second (already has launchd-level protection, lease layer adds restart-window safety).
+**Current promotion state (2026-05-20 UTC):** `resident` is the first promoted
+surface_kind. PR #476 (`feat(lease-plane): enforce resident phase b leases`)
+merged after `evaluate_phase_b_promotion.py` returned PROMOTABLE with
+controlled drill evidence and zero active drill leases.
+
+- `resident:/...` first (PR #476; already has launchd-level protection, lease layer adds restart-window safety).
+- `dialectic:/...` next candidate (lowest external blast radius, dialectic infra already has manual fallbacks).
 - `file:/...` last (highest blast radius, every code-edit caller path must be integrated).
 
 Reverting a surface kind from enforcement back to advisory must be a single config flag, not a code change.


### PR DESCRIPTION
## Summary
- mark resident Phase B as shipped via PR #476 in the lease-plane RFC and BEAM roadmap docs
- update Wave 3 notes to reuse the existing `src/lease_plane/client.py` recorder instead of stale `src/lease_plane_client.py` language
- record that PR #481 now persists lease acquire and ODE p50/p99 series to `metrics.series`

## Validation
- `./scripts/dev/test-cache.sh` (cache hit: 8890 passed, 24 skipped)
- `python3 scripts/dev/unitares_doctor.py` (15 pass, 0 fail, 1 warn: `com.unitares.sentinel` not loaded)
- `git diff --check`
- stale-text `rg` for old resident Phase B / lease client / persistence-pending phrases
