### PR TITLE
glossary: extend trust_tier + behavioral verdicts to mirror/compact + observe_agent

### DIFF
--- a/src/governance_glossary.py
+++ b/src/governance_glossary.py
@@ -65,6 +65,21 @@ VERDICTS: Dict[str, Dict[str, str]] = {
         "meaning": "Synonym of proceed; legacy label still used in some payloads.",
         "next_action": "Continue working normally.",
     },
+    # Behavioral-assessment verdicts (src/behavioral_assessment.py, monitor_decision.py).
+    # Different vocabulary than the decision verdicts above but flows through the
+    # same `metrics["verdict"]` field, so agents see both schemes.
+    "safe": {
+        "meaning": "Behavioral assessment: low risk.",
+        "next_action": "Continue working normally.",
+    },
+    "caution": {
+        "meaning": "Behavioral assessment: elevated risk — proceed deliberately.",
+        "next_action": "Continue but watch coherence and risk_score; consider a check-in.",
+    },
+    "high-risk": {
+        "meaning": "Behavioral assessment: significant risk.",
+        "next_action": "Pause, reflect, or request dialectic review.",
+    },
 }
 
 
@@ -211,12 +226,18 @@ def explain_trajectory(trajectory: Optional[str]) -> Dict[str, Any]:
     return _wrap(trajectory, TRAJECTORIES)
 
 
-def explain_trust_tier(tier: Optional[Any]) -> Dict[str, Any]:
-    """Wrap a trust-tier integer with name + meaning + criteria.
+_TIER_BY_NAME: Dict[str, int] = {info["name"]: tier_int for tier_int, info in TRUST_TIERS.items()}
 
-    Accepts int 0-3, the existing {tier, name, reason} dict shape produced by
-    `compute_trust_tier`, or None. Returns a merged dict that preserves all
-    existing keys and adds `meaning` + `criteria` from the glossary.
+
+def explain_trust_tier(tier: Optional[Any]) -> Dict[str, Any]:
+    """Wrap a trust-tier value with name + meaning + criteria.
+
+    Accepts:
+      - None → {"value": None}
+      - int 0-3 → full {tier, name, meaning, criteria} dict
+      - name string ("emerging", "established", ...) → same as int via reverse lookup
+      - {tier, name, reason} dict from compute_trust_tier → preserves all fields, adds meaning + criteria
+      - any other value → {"value": <as-is>, "meaning": "unknown (not in glossary)"}
 
     Callers can drop this in place of the previous hardcoded
     {tier, name, reason} block without breaking consumers.
@@ -226,10 +247,27 @@ def explain_trust_tier(tier: Optional[Any]) -> Dict[str, Any]:
     # Already a dict — preserve all fields, add glossary annotation
     if isinstance(tier, dict):
         tier_value = tier.get("tier")
-        info = TRUST_TIERS.get(tier_value)
+        if tier_value is None and "name" in tier:
+            tier_value = _TIER_BY_NAME.get(tier["name"])
+        info = TRUST_TIERS.get(tier_value) if tier_value is not None else None
         if info is None:
             return {**tier, "meaning": "unknown (not in glossary)"}
-        return {**tier, "meaning": info["meaning"], "criteria": info["criteria"]}
+        merged = {**tier, "meaning": info["meaning"], "criteria": info["criteria"]}
+        merged.setdefault("tier", tier_value)
+        merged.setdefault("name", info["name"])
+        return merged
+    # Name string — reverse-lookup to int
+    if isinstance(tier, str):
+        tier_int = _TIER_BY_NAME.get(tier)
+        if tier_int is None:
+            return {"value": tier, "meaning": "unknown (not in glossary)"}
+        info = TRUST_TIERS[tier_int]
+        return {
+            "tier": tier_int,
+            "name": info["name"],
+            "meaning": info["meaning"],
+            "criteria": info["criteria"],
+        }
     # Raw int
     try:
         tier_int = int(tier)

--- a/src/mcp_handlers/observability/handlers.py
+++ b/src/mcp_handlers/observability/handlers.py
@@ -126,6 +126,10 @@ async def handle_observe_agent(arguments: Dict[str, Any]) -> Sequence[TextConten
             pE, pI, pS, pV = monitor.get_primary_eisv()
         except (AttributeError, TypeError, ValueError):
             pE, pI, pS, pV = float(monitor.state.E), float(monitor.state.I), float(monitor.state.S), float(monitor.state.V)
+        # #428: vocabulary at point-of-use — wrap the verdict with
+        # meaning + next_action inline so cold-onboarded agents observing
+        # themselves don't have to look up what "pause"/"guide" mean.
+        from src.governance_glossary import explain_verdict
         observation = {
             "current_state": {
                 "E": pE,
@@ -135,7 +139,7 @@ async def handle_observe_agent(arguments: Dict[str, Any]) -> Sequence[TextConten
                 "coherence": float(monitor.state.coherence),
                 "risk_score": float(metrics.get("risk_score") or metrics.get("current_risk") or 0.0),  # Governance/operational risk
                 "phi": metrics.get("phi"),  # Primary physics signal
-                "verdict": metrics.get("verdict"),  # Primary governance signal
+                "verdict": explain_verdict(metrics.get("verdict")),  # Primary governance signal
                 "lambda1": float(monitor.state.lambda1),
                 "update_count": monitor.state.update_count
             }

--- a/src/mcp_handlers/response_formatter.py
+++ b/src/mcp_handlers/response_formatter.py
@@ -62,10 +62,16 @@ def format_response(
     if meta and hasattr(meta, 'preferences') and meta.preferences:
         agent_verbosity_pref = meta.preferences.get("verbosity")
 
-    # Preserve trust_tier across filtering
+    # Preserve trust_tier across filtering. Save the full upstream dict (not
+    # just the name) so terse modes can re-emit it through explain_trust_tier
+    # at the agent-facing surface. #428: vocabulary at point-of-use.
     saved_trust_tier = None
     try:
-        saved_trust_tier = response_data.get("trajectory_identity", {}).get("trust_tier", {}).get("name")
+        tier_obj = response_data.get("trajectory_identity", {}).get("trust_tier")
+        if isinstance(tier_obj, dict):
+            saved_trust_tier = tier_obj
+        elif tier_obj is not None:
+            saved_trust_tier = {"name": str(tier_obj)}
     except Exception:
         pass
 
@@ -169,7 +175,7 @@ def _format_standard(response_data: dict, task_type: str) -> dict:
     _copy_passthrough_fields(response_data, result, ("prediction_id", "warnings"))
     return result
 
-def _format_mirror(response_data: dict, saved_trust_tier: Optional[str], meta: Any = None) -> dict:
+def _format_mirror(response_data: dict, saved_trust_tier: Any, meta: Any = None) -> dict:
     """Build mirror response: a lens on the full data, not a filter that hides it."""
     decision = response_data.get("decision", {}) if isinstance(response_data.get("decision"), dict) else {}
     metrics = response_data.get("metrics", {}) if isinstance(response_data.get("metrics"), dict) else {}
@@ -309,7 +315,9 @@ def _format_mirror(response_data: dict, saved_trust_tier: Optional[str], meta: A
             result["nearest_edge"] = decision.get("nearest_edge")
 
     if saved_trust_tier:
-        result["trust_tier"] = saved_trust_tier
+        # #428: wrap with glossary so agent sees tier scale + meaning inline.
+        from src.governance_glossary import explain_trust_tier
+        result["trust_tier"] = explain_trust_tier(saved_trust_tier)
     if "thread_context" in response_data:
         result["thread_context"] = response_data["thread_context"]
     if "identity_assurance" in response_data:
@@ -324,7 +332,7 @@ def _format_mirror(response_data: dict, saved_trust_tier: Optional[str], meta: A
     return result
 
 
-def _format_minimal(response_data: dict, using_default_mode: bool, saved_trust_tier: Optional[str]) -> dict:
+def _format_minimal(response_data: dict, using_default_mode: bool, saved_trust_tier: Any) -> dict:
     """Build minimal response: action + EISV + margin."""
     decision = response_data.get("decision", {}) if isinstance(response_data.get("decision"), dict) else {}
     metrics = response_data.get("metrics", {}) if isinstance(response_data.get("metrics"), dict) else {}
@@ -350,7 +358,11 @@ def _format_minimal(response_data: dict, using_default_mode: bool, saved_trust_t
     if using_default_mode:
         result["_tip"] = "Set verbosity: update_agent_metadata(preferences={'verbosity':'minimal'})"
     if saved_trust_tier:
-        result["trust_tier"] = saved_trust_tier
+        # Minimal mode is intentionally terse — emit the name string only.
+        # Agents wanting tier-scale + meaning should use mirror/compact.
+        result["trust_tier"] = (
+            saved_trust_tier.get("name") if isinstance(saved_trust_tier, dict) else saved_trust_tier
+        )
     if "thread_context" in response_data:
         result["thread_context"] = response_data["thread_context"]
     if "identity_assurance" in response_data:
@@ -362,7 +374,7 @@ def _format_minimal(response_data: dict, using_default_mode: bool, saved_trust_t
 
     return result
 
-def _format_compact(response_data: dict, using_default_mode: bool, saved_trust_tier: Optional[str]) -> dict:
+def _format_compact(response_data: dict, using_default_mode: bool, saved_trust_tier: Any) -> dict:
     """Build compact response: brief metrics + decision summary."""
     metrics = response_data.get("metrics", {}) if isinstance(response_data.get("metrics"), dict) else {}
     decision = response_data.get("decision", {}) if isinstance(response_data.get("decision"), dict) else {}
@@ -420,7 +432,9 @@ def _format_compact(response_data: dict, using_default_mode: bool, saved_trust_t
     }
 
     if saved_trust_tier:
-        result["trust_tier"] = saved_trust_tier
+        # #428: glossary at point-of-use — tier scale + meaning inline.
+        from src.governance_glossary import explain_trust_tier
+        result["trust_tier"] = explain_trust_tier(saved_trust_tier)
     if using_default_mode:
         result["_tip"] = "Verbosity options: response_mode='minimal'|'compact'|'full', or set permanently via update_agent_metadata(preferences={'verbosity':'minimal'})"
     if "thread_context" in response_data:

--- a/tests/test_governance_glossary.py
+++ b/tests/test_governance_glossary.py
@@ -42,6 +42,18 @@ class TestGlossaryIntegrity:
                 f"agent can act on it without consulting external docs."
             )
 
+    def test_behavioral_verdicts_covered(self):
+        # behavioral_assessment.py and monitor_decision.py emit a parallel
+        # vocabulary {safe, caution, high-risk} through the same `verdict`
+        # field. Agents should not see these without an inline gloss.
+        for verdict in ("safe", "caution", "high-risk"):
+            assert verdict in VERDICTS, (
+                f"Behavioral verdict {verdict!r} must be in the glossary — "
+                f"it flows through metrics['verdict'] alongside the decision "
+                f"verdicts and would otherwise fall to the unknown branch."
+            )
+            assert "next_action" in VERDICTS[verdict]
+
     def test_all_basins_have_meaning(self):
         for basin, info in BASINS.items():
             assert "meaning" in info and info["meaning"]
@@ -169,6 +181,32 @@ class TestExplainTrustTier:
         assert result["name"] == "verified"
         assert "200" in result["criteria"]  # higher observation threshold
 
+    def test_name_string_resolves_via_reverse_lookup(self):
+        # The response formatter previously stored trust_tier as the bare
+        # name string. The helper must accept that shape so existing
+        # callers compose naturally.
+        from src.governance_glossary import explain_trust_tier
+        result = explain_trust_tier("established")
+        assert result["tier"] == 2
+        assert result["name"] == "established"
+        assert "meaning" in result
+        assert "criteria" in result
+
+    def test_unknown_name_string_marked(self):
+        from src.governance_glossary import explain_trust_tier
+        result = explain_trust_tier("not_a_tier_name")
+        assert result["value"] == "not_a_tier_name"
+        assert "unknown" in result["meaning"].lower()
+
+    def test_dict_with_only_name_resolves(self):
+        # Some upstream paths build {"name": "established"} without "tier".
+        # Helper should resolve tier via reverse lookup.
+        from src.governance_glossary import explain_trust_tier
+        result = explain_trust_tier({"name": "verified"})
+        assert result["name"] == "verified"
+        assert result["tier"] == 3
+        assert "meaning" in result
+
 
 class TestAnnotateDriftComponents:
 
@@ -288,4 +326,49 @@ class TestGlossaryAppliedToResponseFormatter:
             "core.py unbound branch must wrap the bare 'unbound' verdict "
             "via explain_verdict() so an unbound agent gets the next-action "
             "hint without consulting docs."
+        )
+
+    def test_mirror_format_wraps_trust_tier(self):
+        # #428: trust_tier was a bare name string ("established"); mirror
+        # now emits it through explain_trust_tier so meaning + criteria
+        # appear inline.
+        source = self._read("src/mcp_handlers/response_formatter.py")
+        idx = source.find("def _format_mirror")
+        end = source.find("\ndef ", idx + 1)
+        window = source[idx:end if end != -1 else len(source)]
+        assert "explain_trust_tier" in window, (
+            "response_formatter._format_mirror must wrap trust_tier via "
+            "explain_trust_tier() so the agent sees the tier scale inline."
+        )
+
+    def test_compact_format_wraps_trust_tier(self):
+        source = self._read("src/mcp_handlers/response_formatter.py")
+        idx = source.find("def _format_compact")
+        end = source.find("\ndef ", idx + 1)
+        window = source[idx:end if end != -1 else len(source)]
+        assert "explain_trust_tier" in window, (
+            "response_formatter._format_compact must wrap trust_tier via "
+            "explain_trust_tier()."
+        )
+
+
+class TestGlossaryAppliedToObservabilityHandlers:
+    """Regression guard: observe_agent's current_state must wrap verdict via
+    the glossary helper. observe_agent is the primary tool an agent uses to
+    inspect itself or peers; a bare verdict here forces a docs lookup.
+    """
+
+    @staticmethod
+    def _read(rel_path: str) -> str:
+        from pathlib import Path
+        return (Path(__file__).parent.parent / rel_path).read_text()
+
+    def test_observe_agent_wraps_verdict(self):
+        source = self._read("src/mcp_handlers/observability/handlers.py")
+        idx = source.find('"verdict": ')
+        assert idx != -1
+        window = source[max(0, idx - 300):idx + 300]
+        assert "explain_verdict" in window, (
+            "observe_agent's current_state must wrap verdict via "
+            "explain_verdict() — it's the primary self-observation surface."
         )

--- a/tests/test_observability_handlers.py
+++ b/tests/test_observability_handlers.py
@@ -233,6 +233,27 @@ class TestHandleObserveAgent:
         assert "coherence" in state
 
     @pytest.mark.asyncio
+    async def test_verdict_wrapped_with_meaning(self):
+        """#428: observe_agent's current_state.verdict carries meaning + next_action inline."""
+        uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        server = _build_mock_server(agent_ids=[uuid])
+
+        with patch(_PATCH_SERVER, server), \
+             patch(_PATCH_CTX, return_value="other-caller-uuid"):
+            from src.mcp_handlers.observability.handlers import handle_observe_agent
+            result = await handle_observe_agent({
+                "target_agent_id": uuid,
+                "analyze_patterns": False,  # raw-state branch is the one we wrap
+            })
+
+        data = parse_result(result)
+        verdict = data["observation"]["current_state"]["verdict"]
+        assert isinstance(verdict, dict), "verdict must be glossary-wrapped, not bare"
+        assert verdict["value"] == "caution"
+        assert "meaning" in verdict
+        assert "next_action" in verdict
+
+    @pytest.mark.asyncio
     async def test_missing_target_agent_id(self):
         """No target_agent_id and no fallback -> error."""
         server = _build_mock_server()

--- a/tests/test_response_formatter.py
+++ b/tests/test_response_formatter.py
@@ -223,9 +223,30 @@ class TestFormatCompact:
         assert "0.92" in result["summary"]
 
     def test_trust_tier_included(self):
+        # #428: compact mode wraps trust_tier with meaning + criteria inline.
         data = _sample_response()
         result = _format_compact(data, using_default_mode=False, saved_trust_tier="established")
-        assert result["trust_tier"] == "established"
+        tt = result["trust_tier"]
+        assert isinstance(tt, dict)
+        assert tt["name"] == "established"
+        assert tt["tier"] == 2
+        assert "meaning" in tt
+        assert "criteria" in tt
+
+    def test_trust_tier_from_dict(self):
+        # #428: also accepts the upstream {tier, name, reason} dict shape.
+        data = _sample_response()
+        result = _format_compact(
+            data,
+            using_default_mode=False,
+            saved_trust_tier={"tier": 2, "name": "established", "reason": "test"},
+        )
+        tt = result["trust_tier"]
+        assert tt["tier"] == 2
+        assert tt["name"] == "established"
+        assert tt["reason"] == "test"
+        assert "meaning" in tt
+        assert "criteria" in tt
 
     def test_tip_when_default_mode(self):
         data = _sample_response()
@@ -430,6 +451,31 @@ class TestFormatResponse:
             result = format_response(data, {})  # No per-call mode
             assert result["_mode"] == "compact"
 
+    def test_trust_tier_propagates_through_format_response_compact(self):
+        # #428: end-to-end — trajectory_identity.trust_tier dict at the top
+        # carries through to the compact-mode trust_tier dict.
+        data = _sample_response()
+        data["trajectory_identity"]["trust_tier"] = {"tier": 2, "name": "established"}
+        result = format_response(data, {"response_mode": "compact"})
+        tt = result["trust_tier"]
+        assert isinstance(tt, dict)
+        assert tt["name"] == "established"
+        assert "meaning" in tt
+        assert "criteria" in tt
+
+    def test_trust_tier_propagates_through_format_response_mirror(self):
+        # Same end-to-end check for mirror mode.
+        data = _sample_response()
+        data["trajectory_identity"]["trust_tier"] = {"tier": 3, "name": "verified"}
+        # Force mirror via no sensor_data + healthy.
+        data["health_status"] = "healthy"
+        result = format_response(data, {"response_mode": "auto"})
+        assert result["_mode"] == "mirror"
+        tt = result["trust_tier"]
+        assert tt["name"] == "verified"
+        assert tt["tier"] == 3
+        assert "meaning" in tt
+
     def test_per_call_overrides_env_var(self):
         data = _sample_response()
         with patch.dict(os.environ, {"UNITARES_PROCESS_UPDATE_RESPONSE_MODE": "compact"}):
@@ -593,6 +639,36 @@ class TestFormatMirror:
         result = _format_mirror(data, saved_trust_tier=None)
         assert result["question"] == "What changed in your understanding?"
 
+    def test_trust_tier_wrapped_with_meaning(self):
+        # #428: mirror mode wraps trust_tier with meaning + criteria inline.
+        data = _sample_response()
+        result = _format_mirror(data, saved_trust_tier="established")
+        tt = result["trust_tier"]
+        assert isinstance(tt, dict)
+        assert tt["name"] == "established"
+        assert tt["tier"] == 2
+        assert "meaning" in tt
+        assert "criteria" in tt
+
+    def test_trust_tier_from_dict_preserves_upstream_fields(self):
+        # When upstream passes the full {tier, name, reason} dict, mirror
+        # preserves all fields and layers meaning + criteria on top.
+        data = _sample_response()
+        result = _format_mirror(
+            data,
+            saved_trust_tier={"tier": 1, "name": "emerging", "reason": "test reason"},
+        )
+        tt = result["trust_tier"]
+        assert tt["name"] == "emerging"
+        assert tt["tier"] == 1
+        assert tt["reason"] == "test reason"
+        assert "meaning" in tt
+
+    def test_no_trust_tier_when_none(self):
+        data = _sample_response()
+        result = _format_mirror(data, saved_trust_tier=None)
+        assert "trust_tier" not in result
+
     def test_legacy_reflection_prompt_supported(self):
         data = _sample_response()
         data["_mirror_reflection"] = "What changed in your understanding?"
@@ -600,9 +676,12 @@ class TestFormatMirror:
         assert result["question"] == "What changed in your understanding?"
 
     def test_trust_tier_included(self):
+        # #428: mirror now wraps with glossary; the bare name resolves
+        # through reverse-lookup so existing string callers compose.
         data = _sample_response()
         result = _format_mirror(data, saved_trust_tier="established")
-        assert result["trust_tier"] == "established"
+        assert isinstance(result["trust_tier"], dict)
+        assert result["trust_tier"]["name"] == "established"
 
     def test_thread_context_preserved(self):
         data = _sample_response()


### PR DESCRIPTION
Closes #428.

Wires the existing `governance_glossary` helpers into the agent-facing surfaces that were still emitting bare values:

- **`response_formatter._format_mirror` / `_format_compact`** now wrap `trust_tier` via `explain_trust_tier` — was a bare name string ("established"), now a `{tier, name, meaning, criteria}` dict. `format_response` preserves the full upstream dict instead of flattening to `.name`. Minimal mode stays bare (terse-mode contract).
- **`observability.handlers.observe_agent`** wraps `current_state.verdict` via `explain_verdict` — primary self-observation tool.
- **`governance_glossary.VERDICTS`** gains the behavioral assessment vocabulary (`safe` / `caution` / `high-risk`) emitted by `behavioral_assessment.py` and `monitor_decision.py`. These flow through `metrics["verdict"]` alongside the decision verdicts; previously fell to the unknown branch.
- **`explain_trust_tier`** accepts name strings and `{name}`-only dicts via reverse lookup so existing string-passing call sites compose naturally.

Issue-#428 category coverage after this PR:

| Category | Status |
|---|---|
| Verdicts (`proceed`/`pause`/etc.) | ✅ wrapped in mirror, compact, observe_agent, unbound branch |
| Basins (`high`/`low`/`boundary`) | ✅ `services/runtime_queries.py` |
| Ethical drift components | ✅ `monitor_result.py` |
| Trajectory signatures | ✅ `services/runtime_queries.py` |
| Trust tier | ✅ this PR (mirror + compact) |

Tests: 8894 → 8899 passed, 0 failed. Source-level guards in `test_governance_glossary.py` ensure future refactors can't silently strip the helpers back out.