### PR TITLE
deprecation: per-call telemetry for soft-deprecated tools (#429)

### DIFF
--- a/src/mcp_handlers/decorators.py
+++ b/src/mcp_handlers/decorators.py
@@ -108,6 +108,18 @@ def mcp_tool(
 
         @wraps(func)
         async def wrapper(arguments: Dict[str, Any]):
+            # #429: log every call to a deprecated tool so the operator can
+            # tell when usage drops to ~0 and removal is safe. structured
+            # prefix `deprecated_tool_called:` makes the log line greppable.
+            # Once-per-call (not once-per-process) — duplicate volume is the
+            # signal, not noise. No DB write here to keep the hot path off
+            # asyncpg per CLAUDE.md's anyio coupling notes.
+            if deprecated:
+                _superseded = superseded_by or "(no replacement registered)"
+                logger.warning(
+                    f"deprecated_tool_called: tool={tool_name} "
+                    f"superseded_by={_superseded}"
+                )
             start_time = time.time()
             try:
                 result = await asyncio.wait_for(func(arguments), timeout=timeout)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -123,6 +123,49 @@ class TestMcpToolDecorator:
         meta = get_tool_metadata("leave_note")
         assert meta["superseded_by"] == "knowledge"
 
+    def test_deprecated_tool_call_emits_log_line(self, caplog):
+        """Every call to a deprecated tool must emit a structured log line
+        (`deprecated_tool_called: tool=... superseded_by=...`) so the
+        operator can grep `mcp_server.log` to measure usage before removing
+        the tool per #429's "remove after N weeks" process. Without this,
+        the removal decision is blind."""
+        import asyncio
+        import logging
+
+        @mcp_tool("test_legacy_tool", deprecated=True, superseded_by="test_new_tool")
+        async def handle_test_legacy_tool(arguments):
+            return []
+
+        with caplog.at_level(logging.WARNING, logger="src.mcp_handlers.decorators"):
+            asyncio.run(handle_test_legacy_tool({}))
+
+        deprecation_lines = [
+            r.message for r in caplog.records
+            if "deprecated_tool_called" in r.message
+        ]
+        assert len(deprecation_lines) == 1
+        assert "tool=test_legacy_tool" in deprecation_lines[0]
+        assert "superseded_by=test_new_tool" in deprecation_lines[0]
+
+    def test_non_deprecated_tool_emits_no_deprecation_log(self, caplog):
+        """Non-deprecated tools must NOT emit the deprecation log line —
+        otherwise the grep signal is meaningless."""
+        import asyncio
+        import logging
+
+        @mcp_tool("test_modern_tool")
+        async def handle_test_modern_tool(arguments):
+            return []
+
+        with caplog.at_level(logging.WARNING, logger="src.mcp_handlers.decorators"):
+            asyncio.run(handle_test_modern_tool({}))
+
+        deprecation_lines = [
+            r.message for r in caplog.records
+            if "deprecated_tool_called" in r.message
+        ]
+        assert deprecation_lines == []
+
     def test_describe_tool_surfaces_deprecation(self):
         """describe_tool must inject deprecation block for deprecated tools (#429 council fix).
 


### PR DESCRIPTION
Refs #429 (does not close — only one piece of the broader alias-collapse work).

Adds per-call telemetry for tools decorated with `deprecated=True`. Every call now emits a greppable warning to `mcp_server.log`:

    deprecated_tool_called: tool=<name> superseded_by=<replacement>

### Why

#429 specifies the deprecation process as *"describe_tool returns a deprecation notice; remove after N weeks."* The describe_tool surface is wired (registry entry + `@mcp_tool(deprecated=True)` flag + `_describe_tool_deprecation_block`). What was missing: a way to **measure actual usage** so the "remove after N weeks" decision isn't blind.

After this lands, the operator can run:

    grep deprecated_tool_called data/logs/mcp_server.log | awk '{print \$3}' | sort | uniq -c

to track usage decline by tool before removing.

### Scope

- Log-only — no DB write in the hot path per CLAUDE.md's anyio-asyncio coupling rules.
- Once-per-call (not once-per-process), so volume IS the signal.
- Generalizes to every current and future `@mcp_tool(deprecated=True)` caller (today: `leave_note`, `direct_resume_if_safe`; future: any new deprecation).

### Still open in #429

- `leave_note` actual removal (currently soft-deprecated since 2026-05-20; telemetry from this PR informs the timing)
- `onboard` / `identity` / `bind_session` consolidation (identity-architecture-sensitive)
- `action` ↔ `op` canonical direction (current code accepts both; the issue proposes inverting which is canonical — needs rationale)
- `lite=true` flag deprecation in favor of `response_mode='minimal'`

Each of those is a separate slice with operator-judgment dependencies; this PR only wires the telemetry that makes the *removal* step on any of them data-informed.

Tests: 38 → 40 `test_decorators.py`; full suite 8899 passed.