### PR TITLE
watcher: narrow P004 to Redis-only (asyncpg safe post-ExecutorPool)

### DIFF
--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -1280,13 +1280,18 @@ _PERSIST_VERB_PATTERN = re.compile(
 _PATTERN_REQUIRED_TOKENS: dict[str, tuple[str, ...]] = {
     "P001": ("create_task(",),
     "P003": ("UNITARESMonitor(",),
-    # P004 needs a literal asyncpg/Redis call marker on the flagged line.
-    # Without this, qwen3-coder-next associates the pattern with a nearby
-    # `async def http_dashboard(...)` or unrelated arithmetic. Caught when
-    # it flagged http_api.py:736 and :907 on 2026-04-14.
-    "P004": ("asyncpg", "pool.acquire", "conn.fetch", "conn.execute",
-             "db.fetch", "db.execute", "await redis", "redis.get(",
-             "redis.set(", "load_metadata_async(", "archive_agent("),
+    # P004 needs a literal Redis call marker on the flagged line.
+    # Narrowed to Redis-only on 2026-05-23: asyncpg ops in MCP handlers are
+    # safe post-PR #218 (2026-04-27), which wraps the asyncpg pool in
+    # ExecutorPool so direct `await conn.fetchval(...)` no longer collides
+    # with the MCP SDK's anyio task group. Redis is NOT wrapped — those
+    # awaits still need `asyncio.wait_for` guards per CLAUDE.md
+    # "Substrate Tax" section, so the rule still fires on raw Redis ops.
+    # The literal-token guard (vs. just "any await") protects against
+    # qwen3-coder-next associating the pattern with nearby unrelated lines;
+    # caught when it flagged http_api.py:736 and :907 on 2026-04-14.
+    "P004": ("await redis", "redis.get(", "redis.set(", "redis.delete(",
+             "redis.hget(", "redis.hset(", "redis.expire(", "redis.exists("),
     # P005 needs a literal acquire/cursor call on the flagged line.
     # Without this, the model sometimes associates a P005 "resource leak"
     # finding with the method DEFINITION (async def __aexit__, etc.)
@@ -1306,7 +1311,7 @@ _PATTERN_REQUIRED_TOKENS: dict[str, tuple[str, ...]] = {
 }
 
 # File-path substrings that MUST be present in finding.file for the pattern
-# to apply. P004 (asyncpg-in-MCP-handler) is only relevant to code under
+# to apply. P004 (Redis-in-MCP-handler) is only relevant to code under
 # src/mcp_handlers/ — the pattern library explicitly excludes Starlette REST
 # routes in src/http_api.py, which run outside the MCP anyio task group.
 _PATTERN_FILE_PATH_CONSTRAINTS: dict[str, tuple[str, ...]] = {
@@ -1532,7 +1537,7 @@ def _is_wait_for_guarded_onboard_pin_helper(
 
     `lookup_onboard_pin()` and `set_onboard_pin()` bound their inner Redis
     work with `asyncio.wait_for(..., timeout=_PIN_REDIS_TIMEOUT)`. P004's
-    actionable condition is unbounded async Redis/asyncpg in an MCP handler;
+    actionable condition is unbounded async Redis in an MCP handler;
     this shape has the timeout mitigation and regression tests already.
     """
     helper_name = None

--- a/agents/watcher/patterns.md
+++ b/agents/watcher/patterns.md
@@ -83,48 +83,73 @@ that the cache uses to populate itself). See
 
 **Hint template:** `transient monitor — use get_or_create_monitor`
 
-### P004 — DB-touching code inside MCP tool handler (severity: high, project-specific, violation_class: REC)
+### P004 — Unguarded Redis call inside MCP tool handler (severity: high, project-specific, violation_class: REC)
 
-Any `await` on asyncpg or Redis inside an `@mcp_tool`-decorated handler
+Any `await` on a raw Redis async client inside an `@mcp_tool`-decorated handler
 (functions in `src/mcp_handlers/`). The anyio task group in the MCP SDK's
-StreamableHTTP transport deadlocks with asyncpg/Redis async calls. Symptom:
+StreamableHTTP transport deadlocks with unbounded Redis async calls. Symptom:
 `/v1/tools/call` hangs indefinitely for that tool.
+
+**Scope narrowed 2026-05-23: Redis only.** asyncpg ops in MCP handlers are
+*safe* post-PR #218 (2026-04-27), which wraps the asyncpg pool in
+`src/db/executor_pool.py`. Direct `await conn.fetchval(...)`,
+`await db.acquire()`, and `await mcp_server.load_metadata_async()` no longer
+collide with the anyio task group — the asyncpg work happens on a dedicated
+background thread. Historic dismiss rate on asyncpg-firing P004s was 89.5%
+(17 dismissed / 19 fired) post-#218; the two `confirmed`s were correct
+*before* #218 and are stale. Per CLAUDE.md "Substrate Tax" section:
+*"New handlers can use `async with db.acquire() as conn: await
+conn.fetchval(...)` directly — no wrapper needed for asyncpg DB work."*
+
+Redis is **NOT** ExecutorPool-wrapped. Existing Redis `asyncio.wait_for`
+timeouts in `identity_step.py`, `persistence.py`, `session.py` remain
+load-bearing; do not remove them, and do not add new unguarded `await redis.*`
+in MCP handlers.
 
 **SAFE — DO NOT FLAG:**
 ```python
 # Starlette REST route handlers in src/http_api.py (http_health, http_metrics,
 # http_incidents, etc.) run in normal asyncio context, NOT inside the MCP
-# SDK's anyio task group. asyncpg calls in REST endpoints do not deadlock.
+# SDK's anyio task group. asyncpg and Redis are both safe in REST endpoints.
 async def http_incidents(request):
     events = await query_audit_events_async(...)  # safe — REST handler
 
 # MCP helper whose public entrypoint bounds the async Redis work.
 async def lookup_onboard_pin(fp):
     return await asyncio.wait_for(_lookup_onboard_pin_inner(fp), timeout=0.5)
+
+# asyncpg in MCP handlers — safe via ExecutorPool (post-PR #218):
+@mcp_tool("my_tool")
+async def handle_my_tool(arguments):
+    async with db.acquire() as conn:
+        row = await conn.fetchval("SELECT ...")  # safe — ExecutorPool-wrapped
 ```
 
-Only flag `await` on asyncpg/Redis in files under `src/mcp_handlers/` or in
-functions decorated with `@mcp_tool` / `@mcp.tool()`. Do NOT flag plain
-Starlette route handlers in `src/http_api.py`.
+**FLAG:**
+```python
+@mcp_tool("my_tool")
+async def handle_my_tool(arguments):
+    val = await redis.get(key)  # P004 — unguarded Redis in MCP handler
+```
 
-The structural verifier now enforces both constraints post-hoc: P004 findings
+Only flag `await` on raw Redis calls in files under `src/mcp_handlers/` or in
+functions decorated with `@mcp_tool` / `@mcp.tool()`. Do NOT flag plain
+Starlette route handlers in `src/http_api.py`, and do NOT flag asyncpg ops
+(those go through ExecutorPool).
+
+The structural verifier enforces both constraints post-hoc: P004 findings
 outside `src/mcp_handlers/` are dropped, and the flagged line must contain a
-literal asyncpg/Redis call marker (`asyncpg`, `pool.acquire`, `conn.fetch`,
-`await redis`, etc.). See `_PATTERN_FILE_PATH_CONSTRAINTS` and
-`_PATTERN_REQUIRED_TOKENS["P004"]` in `agent.py`.
+literal Redis call marker (`await redis`, `redis.get(`, `redis.set(`, etc.).
+See `_PATTERN_FILE_PATH_CONSTRAINTS` and `_PATTERN_REQUIRED_TOKENS["P004"]`
+in `agent.py`.
 
 **Seen in:** `health_check` MCP tool (fixed via Option F), KG lifecycle, eisv_sync.
 False-positive sweep 2026-04-14 (flagged `async def http_dashboard` and
 unrelated arithmetic in `src/http_api.py`) motivated the verifier constraints.
+Scope-narrowing sweep 2026-05-23 dismissed 9 stale asyncpg findings and
+removed asyncpg tokens from `_PATTERN_REQUIRED_TOKENS["P004"]`.
 
-**Hint template:** `asyncpg/Redis in MCP handler — will deadlock, wrap in executor`
-
-> NOTE for resolvers: the hint historically said only "asyncpg", which led
-> agents to dismiss real `await raw_redis.get(...)` deadlock sites. Both
-> drivers share the same anyio task-group conflict — see CLAUDE.md
-> "Known Issue: anyio-asyncio Conflict" and the existing
-> `_load_binding_from_redis` `wait_for` mitigation. Do not dismiss a
-> P004 just because the call is Redis rather than asyncpg.
+**Hint template:** `unguarded Redis in MCP handler — wrap with asyncio.wait_for(..., timeout=N)`
 
 ### P005 — Acquire without paired release (severity: high, violation_class: REC)
 

--- a/agents/watcher/tests/test_agent.py
+++ b/agents/watcher/tests/test_agent.py
@@ -2098,9 +2098,9 @@ def _verify_finding(watcher_module, pattern, line, src_line, file="/repo/src/mcp
 
 
 def test_p004_dropped_outside_mcp_handlers_directory(watcher_module):
-    """P004 is the asyncpg-in-MCP-handler deadlock pattern. It MUST NOT fire
-    on files outside src/mcp_handlers/ (e.g. Starlette REST handlers in
-    src/http_api.py), which is exactly what happened on 2026-04-14."""
+    """P004 is the unguarded-Redis-in-MCP-handler deadlock pattern. It MUST
+    NOT fire on files outside src/mcp_handlers/ (e.g. Starlette REST handlers
+    in src/http_api.py), which is exactly what happened on 2026-04-14."""
     assert not _verify_finding(
         watcher_module,
         pattern="P004",
@@ -2110,10 +2110,10 @@ def test_p004_dropped_outside_mcp_handlers_directory(watcher_module):
     )
 
 
-def test_p004_dropped_when_flagged_line_has_no_asyncpg_marker(watcher_module):
-    """Even inside src/mcp_handlers/, P004 requires a literal asyncpg/Redis
-    call on the flagged line. `bucket = max(1, min(bucket, 30))` cannot be
-    an asyncpg deadlock source and must be dropped."""
+def test_p004_dropped_when_flagged_line_has_no_redis_marker(watcher_module):
+    """Even inside src/mcp_handlers/, P004 requires a literal Redis call on
+    the flagged line. `bucket = max(1, min(bucket, 30))` cannot be a Redis
+    deadlock source and must be dropped."""
     assert not _verify_finding(
         watcher_module,
         pattern="P004",
@@ -2122,14 +2122,44 @@ def test_p004_dropped_when_flagged_line_has_no_asyncpg_marker(watcher_module):
     )
 
 
-def test_p004_kept_for_real_asyncpg_call_inside_mcp_handler(watcher_module):
-    """Positive case: a real `await conn.fetch(...)` inside src/mcp_handlers/
-    MUST survive verification — that's the whole point of P004."""
-    assert _verify_finding(
+def test_p004_dropped_for_asyncpg_in_mcp_handler(watcher_module):
+    """Scope narrowed 2026-05-23: asyncpg in MCP handlers is SAFE post-PR #218
+    (ExecutorPool wraps the pool, so direct `await conn.fetchval(...)` no
+    longer collides with the anyio task group). The rule must NOT flag
+    asyncpg call sites anymore — historic dismiss rate on these was 89.5%
+    after #218 deployed. Per CLAUDE.md "Substrate Tax" section: 'New handlers
+    can use `async with db.acquire() as conn: await conn.fetchval(...)`
+    directly — no wrapper needed for asyncpg DB work.'"""
+    assert not _verify_finding(
         watcher_module,
         pattern="P004",
         line=42,
         src_line="rows = await conn.fetchrow(query)",
+        file="/repo/src/mcp_handlers/identity/handlers.py",
+    )
+
+
+def test_p004_kept_for_unguarded_redis_in_mcp_handler(watcher_module):
+    """Positive case: a raw `await redis.get(...)` inside src/mcp_handlers/
+    MUST survive verification. Redis is NOT ExecutorPool-wrapped — those
+    awaits still need `asyncio.wait_for` guards. This is the remaining
+    actionable surface for P004 post-scope-narrowing."""
+    assert _verify_finding(
+        watcher_module,
+        pattern="P004",
+        line=42,
+        src_line="val = await redis.get(cache_key)",
+        file="/repo/src/mcp_handlers/identity/handlers.py",
+    )
+
+
+def test_p004_kept_for_redis_set_in_mcp_handler(watcher_module):
+    """Multiple Redis call shapes are flagged — get/set/delete/hget/hset/etc."""
+    assert _verify_finding(
+        watcher_module,
+        pattern="P004",
+        line=42,
+        src_line="await redis.set(key, value, ex=60)",
         file="/repo/src/mcp_handlers/identity/handlers.py",
     )
 


### PR DESCRIPTION
Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.