### PR TITLE
[codex] Add agent fragmentation diagnostic

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,6 @@
 # Scripts Directory
 
-**Last Updated:** 2026-05-06
+**Last Updated:** 2026-05-24
 
 > **Note:** Most functionality is available via MCP tools. Scripts are for CLI-only interfaces, operations, and maintenance.
 >
@@ -96,7 +96,12 @@ Analysis and reporting scripts, including outcome / calibration reporting, tool 
 Client-side utilities including the Ollama MCP bridge and session/freshness helpers.
 
 ### `diagnostics/`
-Diagnostic scripts for debugging server and agent issues.
+Diagnostic scripts for debugging server and agent issues. Notable operator
+checks:
+
+| Script | Description |
+|--------|-------------|
+| `agent_fragmentation.py` | Read-only report for identities with zero or sparse real check-ins, grouped by model/session/thread so fresh-UUID fragmentation is visible. |
 
 ### `migration/`
 Database maintenance scripts (embeddings backfill, ghost agent cleanup, knowledge graph maintenance).

--- a/scripts/diagnostics/agent_fragmentation.py
+++ b/scripts/diagnostics/agent_fragmentation.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Report identities with no or sparse measured check-ins.
+
+Read-only. This diagnostic is for the operational gap where fresh process UUIDs
+are minted correctly, but clients do not send ``initial_state`` or real
+``process_agent_update`` calls often enough to establish measured trajectories.
+
+Usage:
+    python3 scripts/diagnostics/agent_fragmentation.py
+    python3 scripts/diagnostics/agent_fragmentation.py --json
+    python3 scripts/diagnostics/agent_fragmentation.py --since 2026-05-20T00:00:00Z
+    python3 scripts/diagnostics/agent_fragmentation.py --stale-hours 24
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+
+sys.path.insert(
+    0,
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+)
+
+from src.db import close_db
+from src.identity.agent_fragmentation import collect_agent_fragmentation
+
+
+def _parse_timestamp(value: str) -> datetime:
+    text = value.strip()
+    if not text:
+        raise argparse.ArgumentTypeError("timestamp must not be empty")
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "timestamp must be ISO-8601, e.g. 2026-05-20T00:00:00Z"
+        ) from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--since",
+        type=_parse_timestamp,
+        help="Restrict identities to created_at >= this timestamp.",
+    )
+    parser.add_argument(
+        "--stale-hours",
+        type=float,
+        default=24.0,
+        help="Age threshold for active zero/low-check-in identities.",
+    )
+    parser.add_argument(
+        "--low-checkin-max",
+        type=int,
+        default=3,
+        help="Maximum real check-ins counted as sparse trajectory.",
+    )
+    parser.add_argument(
+        "--sample-limit",
+        type=int,
+        default=30,
+        help="Maximum sample identities to include per sample section.",
+    )
+    parser.add_argument("--json", action="store_true", help="Print JSON output.")
+    args = parser.parse_args()
+
+    try:
+        report = await collect_agent_fragmentation(
+            since=args.since,
+            stale_hours=args.stale_hours,
+            low_checkin_max=args.low_checkin_max,
+            sample_limit=args.sample_limit,
+        )
+    finally:
+        await close_db()
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 0
+
+    _print_text_report(report)
+    return 0
+
+
+def _print_text_report(report: dict) -> None:
+    totals = report["totals"]
+    state_rows = report["state_rows"]
+    print(f"decision: {report['decision']}")
+    print(f"reason: {report['reason']}")
+    print(f"observed at: {report['observed_at']}")
+    print(f"since: {report.get('since') or '<all>'}")
+    print(
+        "totals: "
+        f"identities={totals['identities']} "
+        f"active={totals['active']} "
+        f"zero_real={totals['zero_real_checkins']} "
+        f"one_real={totals['one_real_checkin']} "
+        f"one_to_low={totals['one_to_low_real_checkins']} "
+        f"active_zero={totals['active_zero_real_checkins']} "
+        f"active_zero_stale={totals['active_zero_real_stale']} "
+        f"active_one_to_low_stale={totals['active_one_to_low_real_stale']}"
+    )
+    print(
+        "state rows: "
+        f"measured={state_rows['measured_rows']} "
+        f"measured_identities={state_rows['measured_identities']} "
+        f"synthetic={state_rows['synthetic_rows']} "
+        f"synthetic_identities={state_rows['synthetic_identities']}"
+    )
+    for window, block in report["recent"].items():
+        print(
+            f"{window}: identities={block['identities']} "
+            f"zero_real={block['zero_real_checkins']} "
+            f"one_to_low={block['one_to_low_real_checkins']} "
+            f"gt_low={block['more_than_low_real_checkins']}"
+        )
+
+    print("\nactive zero-real by model:")
+    for row in report["active_zero_by_model"][:10]:
+        label = "labeled" if row["has_label"] else "unlabeled"
+        print(f"  {row['model_type']:<24} {label:<9} {row['identities']}")
+
+    print("\nrecent 7d by session source:")
+    for row in report["recent_7d_by_session_source"][:10]:
+        print(
+            f"  {row['session_resolution_source']:<28} "
+            f"{row['transport']:<14} "
+            f"identities={row['identities']} "
+            f"zero_real={row['zero_real_checkins']} "
+            f"one_to_low={row['one_to_low_real_checkins']}"
+        )
+
+    print("\nthread clusters (active <= low-checkin-max):")
+    clusters = report["thread_clusters"][:10]
+    if not clusters:
+        print("  none")
+    for row in clusters:
+        labels = ", ".join(row["sample_labels"])
+        print(
+            f"  {row['thread_id']}: "
+            f"active_low={row['active_low_identities']} "
+            f"zero_real={row['zero_real_checkins']} "
+            f"one_to_low={row['one_to_low_real_checkins']} "
+            f"labels={labels}"
+        )
+
+    print("\nrecommendations:")
+    for item in report["recommendations"]:
+        print(f"  - {item}")
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/src/identity/agent_fragmentation.py
+++ b/src/identity/agent_fragmentation.py
@@ -1,0 +1,517 @@
+"""Read-only diagnostics for low-check-in identity fragmentation.
+
+Fresh UUIDs are the intended process-instance identity boundary. This module
+measures the failure mode around that boundary: identities that exist but have
+no measured trajectory, or only a very small number of real check-ins.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+from src.db import get_db
+
+
+IDENTITY_FRAGMENTATION_SQL = """
+WITH per_identity AS (
+    SELECT
+        i.identity_id,
+        i.agent_id,
+        i.status,
+        i.created_at,
+        i.updated_at,
+        i.last_activity_at,
+        i.parent_agent_id,
+        i.spawn_reason,
+        i.provisional_lineage,
+        i.chain_obs_count,
+        COALESCE(
+            NULLIF(i.metadata->>'label', ''),
+            NULLIF(i.metadata->>'display_name', ''),
+            NULLIF(a.label, ''),
+            ''
+        ) AS label,
+        COALESCE(NULLIF(i.metadata->>'model_type', ''), '') AS model_type,
+        COALESCE(NULLIF(i.metadata->>'purpose', ''), '') AS purpose,
+        COALESCE(NULLIF(i.metadata->>'thread_id', ''), NULLIF(a.thread_id, ''), '') AS thread_id,
+        NULLIF(i.metadata->>'active_session_key', '') AS active_session_key,
+        CASE
+            WHEN (i.metadata->>'total_updates') ~ '^[0-9]+$'
+            THEN (i.metadata->>'total_updates')::INT
+            ELSE NULL
+        END AS metadata_total_updates,
+        COUNT(s.*) FILTER (WHERE s.synthetic = false) AS real_checkins,
+        COUNT(s.*) FILTER (WHERE s.synthetic = true) AS bootstrap_rows,
+        MIN(s.recorded_at) FILTER (WHERE s.synthetic = false) AS first_real_checkin_at,
+        MAX(s.recorded_at) FILTER (WHERE s.synthetic = false) AS last_real_checkin_at,
+        MAX(s.recorded_at) AS last_any_state_at,
+        latest.session_resolution_source,
+        latest.transport,
+        latest.context_source
+    FROM core.identities i
+    LEFT JOIN core.agents a ON a.id = i.agent_id
+    LEFT JOIN core.agent_state s ON s.identity_id = i.identity_id
+    LEFT JOIN LATERAL (
+        SELECT
+            s2.state_json#>>'{provenance_context,session_resolution_source}'
+                AS session_resolution_source,
+            s2.state_json#>>'{provenance_context,transport}' AS transport,
+            s2.state_json#>>'{provenance_context,context_source}' AS context_source
+        FROM core.agent_state s2
+        WHERE s2.identity_id = i.identity_id
+        ORDER BY s2.recorded_at DESC
+        LIMIT 1
+    ) latest ON TRUE
+    GROUP BY
+        i.identity_id,
+        i.agent_id,
+        i.status,
+        i.created_at,
+        i.updated_at,
+        i.last_activity_at,
+        i.parent_agent_id,
+        i.spawn_reason,
+        i.provisional_lineage,
+        i.chain_obs_count,
+        label,
+        model_type,
+        purpose,
+        thread_id,
+        active_session_key,
+        metadata_total_updates,
+        latest.session_resolution_source,
+        latest.transport,
+        latest.context_source
+)
+SELECT *
+FROM per_identity
+WHERE ($1::TIMESTAMPTZ IS NULL OR created_at >= $1::TIMESTAMPTZ)
+ORDER BY created_at DESC
+"""
+
+
+SYNTHETIC_STATE_SQL = """
+SELECT
+    synthetic,
+    COUNT(*) AS rows,
+    COUNT(DISTINCT identity_id) AS identities,
+    MIN(recorded_at) AS first_seen,
+    MAX(recorded_at) AS last_seen
+FROM core.agent_state
+GROUP BY synthetic
+ORDER BY synthetic
+"""
+
+
+async def collect_agent_fragmentation(
+    *,
+    db: Optional[Any] = None,
+    since: Optional[datetime] = None,
+    stale_hours: float = 24.0,
+    low_checkin_max: int = 3,
+    sample_limit: int = 30,
+    observed_at: Optional[datetime] = None,
+) -> dict[str, Any]:
+    """Collect and assess identity/check-in fragmentation from PostgreSQL."""
+    backend = db or get_db()
+    async with backend.acquire() as conn:
+        rows = await conn.fetch(IDENTITY_FRAGMENTATION_SQL, since)
+        synthetic_rows = await conn.fetch(SYNTHETIC_STATE_SQL)
+
+    return build_agent_fragmentation_snapshot(
+        rows,
+        synthetic_rows,
+        stale_hours=stale_hours,
+        low_checkin_max=low_checkin_max,
+        sample_limit=sample_limit,
+        observed_at=observed_at,
+        since=since,
+    )
+
+
+def build_agent_fragmentation_snapshot(
+    identity_rows: Sequence[Mapping[str, Any]],
+    synthetic_rows: Sequence[Mapping[str, Any]] = (),
+    *,
+    stale_hours: float = 24.0,
+    low_checkin_max: int = 3,
+    sample_limit: int = 30,
+    observed_at: Optional[datetime] = None,
+    since: Optional[datetime] = None,
+) -> dict[str, Any]:
+    """Build the report payload from already-fetched rows."""
+    observed = _aware(observed_at or datetime.now(timezone.utc))
+    stale_cutoff = observed - timedelta(hours=stale_hours)
+    recent_24h_cutoff = observed - timedelta(hours=24)
+    recent_7d_cutoff = observed - timedelta(days=7)
+    low_checkin_max = max(int(low_checkin_max), 1)
+    sample_limit = max(int(sample_limit), 0)
+
+    rows = [_normalize_identity_row(row) for row in identity_rows]
+    synthetic = _normalize_synthetic_rows(synthetic_rows)
+
+    total = len(rows)
+    active = [row for row in rows if row["status"] == "active"]
+    zero_real = [row for row in rows if row["real_checkins"] == 0]
+    one_real = [row for row in rows if row["real_checkins"] == 1]
+    low_real = [
+        row for row in rows if 1 <= row["real_checkins"] <= low_checkin_max
+    ]
+    more_than_low = [row for row in rows if row["real_checkins"] > low_checkin_max]
+    active_zero = [row for row in active if row["real_checkins"] == 0]
+    active_low = [
+        row for row in active if 1 <= row["real_checkins"] <= low_checkin_max
+    ]
+    active_zero_stale = [
+        row for row in active_zero if _older_than(row["created_at"], stale_cutoff)
+    ]
+    active_low_stale = [
+        row for row in active_low if _older_than(row["created_at"], stale_cutoff)
+    ]
+    recent_24h = [row for row in rows if _at_or_after(row["created_at"], recent_24h_cutoff)]
+    recent_7d = [row for row in rows if _at_or_after(row["created_at"], recent_7d_cutoff)]
+    no_state = [
+        row for row in rows
+        if row["real_checkins"] == 0 and row["bootstrap_rows"] == 0
+    ]
+    bootstrap_only = [
+        row for row in rows
+        if row["real_checkins"] == 0 and row["bootstrap_rows"] > 0
+    ]
+
+    payload = {
+        "decision": _decision(active_zero_stale, active_low_stale, synthetic),
+        "reason": _reason(active_zero_stale, active_low_stale, synthetic),
+        "observed_at": observed.isoformat(),
+        "since": since.isoformat() if since else None,
+        "thresholds": {
+            "stale_hours": stale_hours,
+            "low_checkin_max": low_checkin_max,
+        },
+        "totals": {
+            "identities": total,
+            "active": len(active),
+            "zero_real_checkins": len(zero_real),
+            "one_real_checkin": len(one_real),
+            "one_to_low_real_checkins": len(low_real),
+            "more_than_low_real_checkins": len(more_than_low),
+            "active_zero_real_checkins": len(active_zero),
+            "active_one_to_low_real_checkins": len(active_low),
+            "active_zero_real_stale": len(active_zero_stale),
+            "active_one_to_low_real_stale": len(active_low_stale),
+            "no_state_at_all": len(no_state),
+            "bootstrap_only": len(bootstrap_only),
+        },
+        "recent": {
+            "created_24h": _count_block(recent_24h, low_checkin_max),
+            "created_7d": _count_block(recent_7d, low_checkin_max),
+        },
+        "state_rows": synthetic,
+        "status_breakdown": _status_breakdown(rows, low_checkin_max),
+        "active_zero_by_model": _group_active_zero_by_model(active_zero),
+        "recent_7d_by_session_source": _group_recent_by_session(recent_7d, low_checkin_max),
+        "thread_clusters": _thread_clusters(active, low_checkin_max),
+        "samples": {
+            "active_zero_real": _sample(active_zero, sample_limit),
+            "active_zero_real_stale": _sample(active_zero_stale, sample_limit),
+        },
+        "recommendations": _recommendations(
+            active_zero_stale,
+            active_low_stale,
+            synthetic,
+        ),
+    }
+    return payload
+
+
+def _decision(
+    active_zero_stale: Sequence[Mapping[str, Any]],
+    active_low_stale: Sequence[Mapping[str, Any]],
+    synthetic: Mapping[str, Any],
+) -> str:
+    if active_zero_stale:
+        return "attention"
+    if active_low_stale:
+        return "watch"
+    if synthetic["synthetic_rows"] <= 1:
+        return "watch"
+    return "ok"
+
+
+def _reason(
+    active_zero_stale: Sequence[Mapping[str, Any]],
+    active_low_stale: Sequence[Mapping[str, Any]],
+    synthetic: Mapping[str, Any],
+) -> str:
+    if active_zero_stale:
+        return "active_identities_without_measured_trajectory"
+    if active_low_stale:
+        return "active_identities_with_sparse_measured_trajectory"
+    if synthetic["synthetic_rows"] <= 1:
+        return "bootstrap_rows_absent_or_nearly_absent"
+    return "measured_trajectory_coverage_acceptable"
+
+
+def _recommendations(
+    active_zero_stale: Sequence[Mapping[str, Any]],
+    active_low_stale: Sequence[Mapping[str, Any]],
+    synthetic: Mapping[str, Any],
+) -> list[str]:
+    items: list[str] = []
+    if active_zero_stale:
+        items.append(
+            "Fix managed startup paths that mint identities without initial_state "
+            "or an immediate first process_agent_update."
+        )
+        items.append(
+            "Group operator views by thread_id/role in addition to UUID so fresh "
+            "process identity does not look like task fragmentation."
+        )
+    if active_low_stale:
+        items.append(
+            "Add adapter-side check-in prompts or automatic bounded-task check-ins "
+            "for long sessions with only 1-3 measured updates."
+        )
+    if synthetic["synthetic_rows"] <= 1:
+        items.append(
+            "Verify hook/client adapters are actually sending onboard.initial_state; "
+            "the bootstrap path is present but not materially populated."
+        )
+    if not items:
+        items.append("No immediate fragmentation action required.")
+    return items
+
+
+def _count_block(rows: Sequence[Mapping[str, Any]], low_checkin_max: int) -> dict[str, Any]:
+    return {
+        "identities": len(rows),
+        "zero_real_checkins": sum(row["real_checkins"] == 0 for row in rows),
+        "one_real_checkin": sum(row["real_checkins"] == 1 for row in rows),
+        "one_to_low_real_checkins": sum(
+            1 <= row["real_checkins"] <= low_checkin_max for row in rows
+        ),
+        "more_than_low_real_checkins": sum(
+            row["real_checkins"] > low_checkin_max for row in rows
+        ),
+    }
+
+
+def _status_breakdown(
+    rows: Sequence[Mapping[str, Any]],
+    low_checkin_max: int,
+) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, bool], list[Mapping[str, Any]]] = {}
+    for row in rows:
+        grouped.setdefault((row["status"], bool(row["label"])), []).append(row)
+
+    out: list[dict[str, Any]] = []
+    for (status, has_label), items in sorted(grouped.items()):
+        block = _count_block(items, low_checkin_max)
+        out.append({"status": status, "has_label": has_label, **block})
+    return out
+
+
+def _group_active_zero_by_model(
+    rows: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, bool], int] = {}
+    for row in rows:
+        key = (_display(row["model_type"]), bool(row["label"]))
+        grouped[key] = grouped.get(key, 0) + 1
+    return [
+        {"model_type": model_type, "has_label": has_label, "identities": count}
+        for (model_type, has_label), count in sorted(
+            grouped.items(),
+            key=lambda item: (-item[1], item[0][0], item[0][1]),
+        )
+    ]
+
+
+def _group_recent_by_session(
+    rows: Sequence[Mapping[str, Any]],
+    low_checkin_max: int,
+) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, str], list[Mapping[str, Any]]] = {}
+    for row in rows:
+        key = (_display(row["session_resolution_source"]), _display(row["transport"]))
+        grouped.setdefault(key, []).append(row)
+
+    out: list[dict[str, Any]] = []
+    for (session_source, transport), items in grouped.items():
+        block = _count_block(items, low_checkin_max)
+        out.append({
+            "session_resolution_source": session_source,
+            "transport": transport,
+            **block,
+        })
+    return sorted(out, key=lambda item: (-item["identities"], item["session_resolution_source"]))
+
+
+def _thread_clusters(
+    rows: Sequence[Mapping[str, Any]],
+    low_checkin_max: int,
+) -> list[dict[str, Any]]:
+    grouped: dict[str, list[Mapping[str, Any]]] = {}
+    for row in rows:
+        if not row["thread_id"] or row["real_checkins"] > low_checkin_max:
+            continue
+        grouped.setdefault(row["thread_id"], []).append(row)
+
+    out: list[dict[str, Any]] = []
+    for thread_id, items in grouped.items():
+        if len(items) <= 1:
+            continue
+        created = [item["created_at"] for item in items if item["created_at"]]
+        out.append({
+            "thread_id": thread_id,
+            "active_low_identities": len(items),
+            "zero_real_checkins": sum(item["real_checkins"] == 0 for item in items),
+            "one_to_low_real_checkins": sum(
+                1 <= item["real_checkins"] <= low_checkin_max for item in items
+            ),
+            "first_created_at": min(created).isoformat() if created else None,
+            "last_created_at": max(created).isoformat() if created else None,
+            "sample_labels": [
+                item["label"] or item["agent_id"] for item in sorted(
+                    items,
+                    key=lambda item: item["created_at"] or datetime.min.replace(tzinfo=timezone.utc),
+                    reverse=True,
+                )[:5]
+            ],
+        })
+    return sorted(
+        out,
+        key=lambda item: (
+            -item["active_low_identities"],
+            -item["zero_real_checkins"],
+            item["thread_id"],
+        ),
+    )
+
+
+def _sample(
+    rows: Sequence[Mapping[str, Any]],
+    sample_limit: int,
+) -> list[dict[str, Any]]:
+    if sample_limit <= 0:
+        return []
+    sorted_rows = sorted(
+        rows,
+        key=lambda row: row["created_at"] or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=True,
+    )
+    return [
+        {
+            "created_at": row["created_at"].isoformat() if row["created_at"] else None,
+            "agent_id": row["agent_id"],
+            "label": row["label"] or None,
+            "model_type": row["model_type"] or None,
+            "purpose": row["purpose"] or None,
+            "spawn_reason": row["spawn_reason"] or None,
+            "thread_id": row["thread_id"] or None,
+            "parent_agent_id": row["parent_agent_id"] or None,
+        }
+        for row in sorted_rows[:sample_limit]
+    ]
+
+
+def _normalize_identity_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "identity_id": row.get("identity_id"),
+        "agent_id": str(row.get("agent_id") or ""),
+        "status": str(row.get("status") or "unknown"),
+        "created_at": _aware_or_none(row.get("created_at")),
+        "updated_at": _aware_or_none(row.get("updated_at")),
+        "last_activity_at": _aware_or_none(row.get("last_activity_at")),
+        "parent_agent_id": _text(row.get("parent_agent_id")),
+        "spawn_reason": _text(row.get("spawn_reason")),
+        "provisional_lineage": bool(row.get("provisional_lineage") or False),
+        "chain_obs_count": _int(row.get("chain_obs_count")),
+        "label": _text(row.get("label")),
+        "model_type": _text(row.get("model_type")),
+        "purpose": _text(row.get("purpose")),
+        "thread_id": _text(row.get("thread_id")),
+        "active_session_key": _text(row.get("active_session_key")),
+        "metadata_total_updates": _int(row.get("metadata_total_updates")),
+        "real_checkins": _int(row.get("real_checkins")),
+        "bootstrap_rows": _int(row.get("bootstrap_rows")),
+        "first_real_checkin_at": _aware_or_none(row.get("first_real_checkin_at")),
+        "last_real_checkin_at": _aware_or_none(row.get("last_real_checkin_at")),
+        "last_any_state_at": _aware_or_none(row.get("last_any_state_at")),
+        "session_resolution_source": _text(row.get("session_resolution_source")),
+        "transport": _text(row.get("transport")),
+        "context_source": _text(row.get("context_source")),
+    }
+
+
+def _normalize_synthetic_rows(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    by_flag = {bool(row.get("synthetic")): row for row in rows}
+    measured = by_flag.get(False, {})
+    synthetic = by_flag.get(True, {})
+    return {
+        "measured_rows": _int(measured.get("rows")),
+        "measured_identities": _int(measured.get("identities")),
+        "synthetic_rows": _int(synthetic.get("rows")),
+        "synthetic_identities": _int(synthetic.get("identities")),
+        "synthetic_first_seen": (
+            _aware_or_none(synthetic.get("first_seen")).isoformat()
+            if _aware_or_none(synthetic.get("first_seen")) else None
+        ),
+        "synthetic_last_seen": (
+            _aware_or_none(synthetic.get("last_seen")).isoformat()
+            if _aware_or_none(synthetic.get("last_seen")) else None
+        ),
+    }
+
+
+def _aware(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _aware_or_none(value: Any) -> Optional[datetime]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return _aware(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        if text.endswith("Z"):
+            text = f"{text[:-1]}+00:00"
+        try:
+            return _aware(datetime.fromisoformat(text))
+        except ValueError:
+            return None
+    return None
+
+
+def _at_or_after(value: Optional[datetime], cutoff: datetime) -> bool:
+    return bool(value and value >= cutoff)
+
+
+def _older_than(value: Optional[datetime], cutoff: datetime) -> bool:
+    return bool(value and value < cutoff)
+
+
+def _int(value: Any) -> int:
+    if value is None:
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _text(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _display(value: str) -> str:
+    return value or "<none>"

--- a/src/mcp_handlers/support/wrapper_generator.py
+++ b/src/mcp_handlers/support/wrapper_generator.py
@@ -118,8 +118,15 @@ def _resolve_param_type(param_def: dict) -> Any:
             vtype = variant.get("type")
             if vtype == "null":
                 has_null = True
+            elif "$ref" in variant:
+                # Pydantic emits nested BaseModel fields as $ref entries. FastMCP
+                # only needs the Python wrapper to accept a JSON object here; the
+                # handler's Pydantic schema performs the nested validation later.
+                types.append(dict)
             elif vtype:
                 types.append(_json_type_to_python(vtype))
+            elif variant.get("properties") is not None:
+                types.append(dict)
             elif "anyOf" in variant:
                 # Nested anyOf (Pydantic wraps constrained unions this way)
                 inner = _resolve_param_type(variant)
@@ -156,6 +163,11 @@ def _resolve_param_type(param_def: dict) -> Any:
         if has_null:
             return Optional[base]  # type: ignore
         return base
+
+    if "$ref" in param_def:
+        return dict
+    if param_def.get("properties") is not None:
+        return dict
 
     return _json_type_to_python(param_def.get("type", "string"))
 

--- a/tests/test_agent_fragmentation.py
+++ b/tests/test_agent_fragmentation.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from src.identity.agent_fragmentation import build_agent_fragmentation_snapshot
+
+
+NOW = datetime(2026, 5, 24, tzinfo=timezone.utc)
+
+
+def _row(**overrides):
+    row = {
+        "identity_id": 1,
+        "agent_id": "agent-a",
+        "status": "active",
+        "created_at": datetime(2026, 5, 20, tzinfo=timezone.utc),
+        "updated_at": datetime(2026, 5, 20, tzinfo=timezone.utc),
+        "last_activity_at": None,
+        "parent_agent_id": None,
+        "spawn_reason": "new_session",
+        "provisional_lineage": False,
+        "chain_obs_count": 0,
+        "label": "",
+        "model_type": "claude",
+        "purpose": "",
+        "thread_id": "thread-a",
+        "active_session_key": None,
+        "metadata_total_updates": 0,
+        "real_checkins": 0,
+        "bootstrap_rows": 0,
+        "first_real_checkin_at": None,
+        "last_real_checkin_at": None,
+        "last_any_state_at": None,
+        "session_resolution_source": None,
+        "transport": None,
+        "context_source": None,
+    }
+    row.update(overrides)
+    return row
+
+
+def _synthetic_rows(*, measured=10, synthetic=0):
+    return [
+        {"synthetic": False, "rows": measured, "identities": 3},
+        {"synthetic": True, "rows": synthetic, "identities": synthetic},
+    ]
+
+
+def test_snapshot_flags_stale_active_zero_real_identities():
+    report = build_agent_fragmentation_snapshot(
+        [_row()],
+        _synthetic_rows(measured=10, synthetic=1),
+        observed_at=NOW,
+        stale_hours=24,
+    )
+
+    assert report["decision"] == "attention"
+    assert report["reason"] == "active_identities_without_measured_trajectory"
+    assert report["totals"]["active_zero_real_checkins"] == 1
+    assert report["totals"]["active_zero_real_stale"] == 1
+    assert report["totals"]["no_state_at_all"] == 1
+    assert report["totals"]["bootstrap_only"] == 0
+    assert "initial_state" in report["recommendations"][0]
+
+
+def test_snapshot_distinguishes_bootstrap_only_from_no_state():
+    report = build_agent_fragmentation_snapshot(
+        [_row(bootstrap_rows=1)],
+        _synthetic_rows(measured=10, synthetic=1),
+        observed_at=NOW,
+    )
+
+    assert report["totals"]["no_state_at_all"] == 0
+    assert report["totals"]["bootstrap_only"] == 1
+
+
+def test_snapshot_reports_bootstrap_absence_even_without_stale_active_agents():
+    report = build_agent_fragmentation_snapshot(
+        [
+            _row(
+                status="archived",
+                created_at=datetime(2026, 5, 20, tzinfo=timezone.utc),
+            )
+        ],
+        _synthetic_rows(measured=10, synthetic=0),
+        observed_at=NOW,
+    )
+
+    assert report["decision"] == "watch"
+    assert report["reason"] == "bootstrap_rows_absent_or_nearly_absent"
+    assert report["state_rows"]["synthetic_rows"] == 0
+
+
+def test_thread_clusters_group_active_low_checkin_agents():
+    report = build_agent_fragmentation_snapshot(
+        [
+            _row(agent_id="agent-a", label="Agent A", real_checkins=0),
+            _row(agent_id="agent-b", label="Agent B", real_checkins=2),
+            _row(agent_id="agent-c", label="Agent C", real_checkins=9),
+            _row(agent_id="agent-d", thread_id="solo", real_checkins=1),
+        ],
+        _synthetic_rows(measured=20, synthetic=5),
+        observed_at=NOW,
+        low_checkin_max=3,
+    )
+
+    assert report["thread_clusters"] == [
+        {
+            "thread_id": "thread-a",
+            "active_low_identities": 2,
+            "zero_real_checkins": 1,
+            "one_to_low_real_checkins": 1,
+            "first_created_at": "2026-05-20T00:00:00+00:00",
+            "last_created_at": "2026-05-20T00:00:00+00:00",
+            "sample_labels": ["Agent A", "Agent B"],
+        }
+    ]
+
+
+def test_recent_session_source_grouping_counts_zero_and_sparse():
+    report = build_agent_fragmentation_snapshot(
+        [
+            _row(
+                created_at=datetime(2026, 5, 23, 12, tzinfo=timezone.utc),
+                session_resolution_source="explicit_client_session_id",
+                transport="mcp",
+                real_checkins=0,
+            ),
+            _row(
+                created_at=datetime(2026, 5, 23, 11, tzinfo=timezone.utc),
+                session_resolution_source="explicit_client_session_id",
+                transport="mcp",
+                real_checkins=3,
+            ),
+            _row(
+                created_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
+                session_resolution_source="old",
+                transport="rest",
+                real_checkins=0,
+            ),
+        ],
+        _synthetic_rows(measured=20, synthetic=5),
+        observed_at=NOW,
+    )
+
+    assert report["recent"]["created_7d"]["identities"] == 2
+    assert report["recent_7d_by_session_source"] == [
+        {
+            "session_resolution_source": "explicit_client_session_id",
+            "transport": "mcp",
+            "identities": 2,
+            "zero_real_checkins": 1,
+            "one_real_checkin": 0,
+            "one_to_low_real_checkins": 1,
+            "more_than_low_real_checkins": 0,
+        }
+    ]

--- a/tests/test_wrapper_generator.py
+++ b/tests/test_wrapper_generator.py
@@ -272,6 +272,49 @@ class TestCreateTypedWrapper:
         sig = inspect.signature(wrapper)
         assert len(sig.parameters) == 6
 
+    def test_nullable_ref_param_resolves_to_object(self):
+        """Nested Pydantic models arrive as $ref | null, not string.
+
+        Regression guard for onboard.initial_state: if this degrades to str,
+        MCP clients cannot send the bootstrap object that the server validator
+        expects, so managed sessions mint UUIDs without a synthetic t=0 anchor.
+        """
+        call_log = []
+
+        def get_handler(name):
+            async def handler(**kwargs):
+                call_log.append(kwargs)
+                return kwargs
+            return handler
+
+        schema = {
+            "$defs": {
+                "BootstrapStateParams": {
+                    "type": "object",
+                    "properties": {"task_type": {"type": "string"}},
+                }
+            },
+            "properties": {
+                "initial_state": {
+                    "anyOf": [
+                        {"$ref": "#/$defs/BootstrapStateParams"},
+                        {"type": "null"},
+                    ]
+                }
+            },
+            "required": [],
+        }
+
+        wrapper = create_typed_wrapper("onboard", schema, get_handler)
+        sig = inspect.signature(wrapper)
+
+        assert sig.parameters["initial_state"].annotation == Optional[dict]
+
+        tool = Tool.from_function(wrapper, structured_output=False)
+        asyncio.run(tool.run({"initial_state": {"task_type": "introspection"}}))
+
+        assert call_log == [{"initial_state": {"task_type": "introspection"}}]
+
 
 # ============================================================================
 # FastMCP Context parameter detection


### PR DESCRIPTION
## Summary
- Add a read-only agent fragmentation diagnostic and CLI report for zero/sparse real check-ins.
- Fix MCP wrapper schema resolution for nested Pydantic `$ref` objects so `onboard.initial_state` can be submitted as a JSON object.
- Add regression coverage and script documentation.

## Root Cause
Optional nested Pydantic models are emitted as `anyOf: [$ref, null]`. The FastMCP wrapper generator did not recognize `$ref` object variants and degraded them to strings, which blocked clients from sending the bootstrap state object that anchors a fresh UUID at t=0.

## Validation
- `./scripts/dev/test-cache.sh` — 8912 passed, 25 skipped.
- Pre-push smoke gate — 138 passed, 8240 deselected.
- Live MCP smoke verified one synthetic bootstrap row plus one real `process_agent_update` row, then archived the smoke identity.

## Notes
- `check_health.sh` still reports the pre-existing KG durable/AGE drift; this PR does not address that drift.
