### PR TITLE
[codex] Fix R1 knowledge graph AGE drift

### DIFF
--- a/src/identity/trajectory_continuity.py
+++ b/src/identity/trajectory_continuity.py
@@ -175,9 +175,8 @@ async def _emit_public_kg_node(
     the side-effect path without parsing logs).
     """
     try:
-        from src.db import get_db
+        from src.knowledge_graph import get_knowledge_graph
         from src.knowledge_graph import DiscoveryNode
-        backend = get_db()
 
         public = _build_public_payload(score)
         node = DiscoveryNode(
@@ -199,7 +198,8 @@ async def _emit_public_kg_node(
             severity="low",
             status="open",
         )
-        await backend.kg_add_discovery(node)
+        graph = await get_knowledge_graph()
+        await graph.add_discovery(node)
         return True
     except Exception as exc:
         import logging

--- a/src/storage/knowledge_graph_age.py
+++ b/src/storage/knowledge_graph_age.py
@@ -1168,16 +1168,35 @@ class KnowledgeGraphAGE:
                 return
 
             graph_count = await self._count_age_discoveries()
-            if graph_count > 0:
+            if graph_count == pg_count:
+                return
+
+            if graph_count == 0:
+                logger.warning(
+                    f"AGE graph '{self.graph_name}' is empty while PostgreSQL has {pg_count} discoveries; rehydrating"
+                )
+                restored = await self._rehydrate_from_postgres()
+                logger.warning(
+                    f"Rehydrated AGE graph '{self.graph_name}' from PostgreSQL: "
+                    f"{restored['discoveries']} discoveries, {restored['related_edges']} related edges"
+                )
+                return
+
+            if graph_count < pg_count:
+                logger.warning(
+                    f"AGE graph '{self.graph_name}' has {graph_count}/{pg_count} "
+                    "PostgreSQL discoveries; rehydrating missing rows"
+                )
+                restored = await self._rehydrate_missing_from_postgres()
+                logger.warning(
+                    f"Rehydrated missing AGE rows for graph '{self.graph_name}': "
+                    f"{restored['discoveries']} discoveries, {restored['related_edges']} related edges"
+                )
                 return
 
             logger.warning(
-                f"AGE graph '{self.graph_name}' is empty while PostgreSQL has {pg_count} discoveries; rehydrating"
-            )
-            restored = await self._rehydrate_from_postgres()
-            logger.warning(
-                f"Rehydrated AGE graph '{self.graph_name}' from PostgreSQL: "
-                f"{restored['discoveries']} discoveries, {restored['related_edges']} related edges"
+                f"AGE graph '{self.graph_name}' has {graph_count} discoveries but "
+                f"PostgreSQL has {pg_count}; AGE-only rows require operator review"
             )
         except Exception as e:
             logger.error(f"AGE graph rehydration check failed: {e}")
@@ -1196,6 +1215,80 @@ class KnowledgeGraphAGE:
         if result and isinstance(result[0], (int, float)):
             return int(result[0])
         return 0
+
+    async def _list_age_discovery_ids(self) -> Set[str]:
+        """Return discovery IDs currently present in AGE."""
+        db = await self._get_db()
+        result = await db.graph_query("MATCH (d:Discovery) RETURN d.id", {})
+        return {str(item) for item in result if item is not None}
+
+    async def _fetch_missing_postgres_discovery_rows(self, limit: Optional[int] = None) -> List[Any]:
+        """Fetch durable discovery rows that have no AGE Discovery vertex."""
+        db = await self._get_db()
+        age_ids = list(await self._list_age_discovery_ids())
+        limit_clause = ""
+        if limit is not None:
+            limit_clause = f"LIMIT {max(0, int(limit))}"
+
+        async with db.acquire() as conn:
+            if age_ids:
+                rows = await conn.fetch(
+                    f"""
+                    SELECT *
+                    FROM knowledge.discoveries
+                    WHERE NOT (id = ANY($1::text[]))
+                    ORDER BY created_at ASC, id ASC
+                    {limit_clause}
+                    """,
+                    age_ids,
+                )
+            else:
+                rows = await conn.fetch(
+                    f"""
+                    SELECT *
+                    FROM knowledge.discoveries
+                    ORDER BY created_at ASC, id ASC
+                    {limit_clause}
+                    """
+                )
+        return list(rows)
+
+    async def _rehydrate_missing_from_postgres(self, limit: Optional[int] = None) -> Dict[str, int]:
+        """Restore durable PostgreSQL discoveries that are missing from AGE."""
+        db = await self._get_db()
+        discovery_rows = await self._fetch_missing_postgres_discovery_rows(limit=limit)
+        if not discovery_rows:
+            return {"discoveries": 0, "related_edges": 0}
+
+        discovery_ids = [row["id"] for row in discovery_rows]
+        async with db.acquire() as conn:
+            related_rows = await conn.fetch(
+                """
+                SELECT src_id, dst_id, weight, metadata
+                FROM knowledge.discovery_edges
+                WHERE edge_type = 'related'
+                  AND (src_id = ANY($1::text[]) OR dst_id = ANY($1::text[]))
+                ORDER BY created_at ASC, src_id ASC, dst_id ASC
+                """,
+                discovery_ids,
+            )
+
+        async with db.transaction() as conn:
+            for row in discovery_rows:
+                await self._import_discovery_row(conn, row)
+            for row in related_rows:
+                cypher, params = create_related_to_edge(
+                    from_discovery_id=row["src_id"],
+                    to_discovery_id=row["dst_id"],
+                    strength=row["weight"],
+                    reason=(row["metadata"] or {}).get("reason") if isinstance(row["metadata"], dict) else None,
+                )
+                await db.graph_query(cypher, params, conn=conn)
+
+        return {
+            "discoveries": len(discovery_rows),
+            "related_edges": len(related_rows),
+        }
 
     async def _rehydrate_from_postgres(self) -> Dict[str, int]:
         """Restore AGE vertices and edges from durable PostgreSQL knowledge tables."""

--- a/tests/test_knowledge_graph_age_load.py
+++ b/tests/test_knowledge_graph_age_load.py
@@ -1,4 +1,5 @@
-from unittest.mock import AsyncMock
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -23,7 +24,7 @@ async def test_load_rehydrates_when_age_empty_and_postgres_has_data():
 
 
 @pytest.mark.asyncio
-async def test_load_skips_rehydrate_when_age_already_has_data():
+async def test_load_rehydrates_missing_when_age_has_partial_data():
     kg = KnowledgeGraphAGE()
     db = AsyncMock()
     db.graph_available.return_value = True
@@ -31,7 +32,91 @@ async def test_load_skips_rehydrate_when_age_already_has_data():
     kg._count_postgres_discoveries = AsyncMock(return_value=5)
     kg._count_age_discoveries = AsyncMock(return_value=3)
     kg._rehydrate_from_postgres = AsyncMock()
+    kg._rehydrate_missing_from_postgres = AsyncMock(
+        return_value={"discoveries": 2, "related_edges": 1}
+    )
 
     await kg.load()
 
     kg._rehydrate_from_postgres.assert_not_called()
+    kg._rehydrate_missing_from_postgres.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_load_skips_rehydrate_when_counts_match():
+    kg = KnowledgeGraphAGE()
+    db = AsyncMock()
+    db.graph_available.return_value = True
+    kg._get_db = AsyncMock(return_value=db)
+    kg._count_postgres_discoveries = AsyncMock(return_value=5)
+    kg._count_age_discoveries = AsyncMock(return_value=5)
+    kg._rehydrate_from_postgres = AsyncMock()
+    kg._rehydrate_missing_from_postgres = AsyncMock()
+
+    await kg.load()
+
+    kg._rehydrate_from_postgres.assert_not_called()
+    kg._rehydrate_missing_from_postgres.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fetch_missing_postgres_discovery_rows_excludes_age_ids():
+    kg = KnowledgeGraphAGE()
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[{"id": "pg-only"}])
+    db = MagicMock()
+    db.graph_query = AsyncMock(return_value=["age-1", "age-2"])
+
+    @asynccontextmanager
+    async def acquire():
+        yield conn
+
+    db.acquire = acquire
+    kg._get_db = AsyncMock(return_value=db)
+
+    rows = await kg._fetch_missing_postgres_discovery_rows()
+
+    assert rows == [{"id": "pg-only"}]
+    conn.fetch.assert_awaited_once()
+    query, age_ids = conn.fetch.await_args.args
+    assert "WHERE NOT (id = ANY($1::text[]))" in query
+    assert set(age_ids) == {"age-1", "age-2"}
+
+
+@pytest.mark.asyncio
+async def test_rehydrate_missing_from_postgres_imports_only_missing_rows():
+    kg = KnowledgeGraphAGE()
+    rows = [{"id": "pg-only"}]
+    kg._fetch_missing_postgres_discovery_rows = AsyncMock(return_value=rows)
+    kg._import_discovery_row = AsyncMock()
+
+    acquire_conn = MagicMock()
+    acquire_conn.fetch = AsyncMock(return_value=[
+        {
+            "src_id": "pg-only",
+            "dst_id": "age-1",
+            "weight": 0.8,
+            "metadata": {"reason": "test"},
+        }
+    ])
+    tx_conn = MagicMock()
+    db = MagicMock()
+    db.graph_query = AsyncMock()
+
+    @asynccontextmanager
+    async def acquire():
+        yield acquire_conn
+
+    @asynccontextmanager
+    async def transaction():
+        yield tx_conn
+
+    db.acquire = acquire
+    db.transaction = transaction
+    kg._get_db = AsyncMock(return_value=db)
+
+    result = await kg._rehydrate_missing_from_postgres()
+
+    assert result == {"discoveries": 1, "related_edges": 1}
+    kg._import_discovery_row.assert_awaited_once_with(tx_conn, rows[0])
+    db.graph_query.assert_awaited_once()

--- a/tests/test_trajectory_continuity.py
+++ b/tests/test_trajectory_continuity.py
@@ -59,13 +59,20 @@ def mocked_db(monkeypatch):
     # Per-test overrides set get_identity to return a record with metadata.tags
     # containing a recognized class tag.
     backend.get_identity = AsyncMock(return_value=None)
+    graph = AsyncMock()
+    graph.add_discovery = AsyncMock(return_value=None)
+    backend.public_kg_graph = graph
 
     def _get_db():
         return backend
 
+    async def _get_knowledge_graph():
+        return graph
+
     # The score primitive imports get_db inside the function (per CLAUDE.md
     # anyio pattern lazy imports); patch the source module.
     monkeypatch.setattr("src.db.get_db", _get_db)
+    monkeypatch.setattr("src.knowledge_graph.get_knowledge_graph", _get_knowledge_graph)
     return backend
 
 
@@ -526,12 +533,11 @@ async def test_score_dataclass_internal_caller_surface_unchanged(mocked_db):
 @pytest.mark.asyncio
 async def test_score_emits_public_kg_node_after_audit(mocked_db):
     """Per v3.3-A: score_trajectory_continuity publishes a redacted node to
-    the public KG via `kg_add_discovery`, joined to the audit row by
+    the configured public KG backend, joined to the audit row by
     score_id."""
     import json
     from src.identity.trajectory_continuity import score_trajectory_continuity
 
-    mocked_db.kg_add_discovery = AsyncMock(return_value=None)
     parent, successor = synthetic_trajectory_pair(seed=60, kind="genuine")
     mocked_db.reconstruct_eisv_series = AsyncMock(
         side_effect=_stub_reconstruct(parent, successor)
@@ -542,9 +548,9 @@ async def test_score_emits_public_kg_node_after_audit(mocked_db):
         successor_id="successor-uuid",
     )
 
-    mocked_db.kg_add_discovery.assert_awaited_once()
+    mocked_db.public_kg_graph.add_discovery.assert_awaited_once()
     # Inspect the DiscoveryNode that was passed
-    (node,), _kw = mocked_db.kg_add_discovery.call_args
+    (node,), _kw = mocked_db.public_kg_graph.add_discovery.call_args
     assert node.type == "trajectory_continuity_score"
     assert node.agent_id == "successor-uuid"
     assert node.id.startswith("r1_score:")
@@ -563,11 +569,10 @@ async def test_score_emits_public_kg_node_after_audit(mocked_db):
 async def test_score_kg_node_id_is_deterministic_per_pair(mocked_db):
     """Per v3.2-D dedupe-by-pair: the node id MUST be deterministic from
     (parent_id, successor_id). Re-scoring the same pair produces the same
-    id, so ON CONFLICT (id) DO UPDATE in `kg_add_discovery` overwrites
+    id, so ON CONFLICT (id) DO UPDATE in the active KG backend overwrites
     rather than appends."""
     from src.identity.trajectory_continuity import score_trajectory_continuity
 
-    mocked_db.kg_add_discovery = AsyncMock(return_value=None)
     parent, successor = synthetic_trajectory_pair(seed=61, kind="genuine")
     mocked_db.reconstruct_eisv_series = AsyncMock(
         side_effect=_stub_reconstruct(parent, successor)
@@ -580,14 +585,14 @@ async def test_score_kg_node_id_is_deterministic_per_pair(mocked_db):
         claimed_parent_id="parent-uuid", successor_id="successor-uuid",
     )
 
-    assert mocked_db.kg_add_discovery.await_count == 2
-    first_id = mocked_db.kg_add_discovery.call_args_list[0][0][0].id
-    second_id = mocked_db.kg_add_discovery.call_args_list[1][0][0].id
+    assert mocked_db.public_kg_graph.add_discovery.await_count == 2
+    first_id = mocked_db.public_kg_graph.add_discovery.call_args_list[0][0][0].id
+    second_id = mocked_db.public_kg_graph.add_discovery.call_args_list[1][0][0].id
     assert first_id == second_id
     # Each score has a fresh score_id (audit retains all); the node id is
     # the dedupe key, NOT the score_id.
-    first_payload = mocked_db.kg_add_discovery.call_args_list[0][0][0].details
-    second_payload = mocked_db.kg_add_discovery.call_args_list[1][0][0].details
+    first_payload = mocked_db.public_kg_graph.add_discovery.call_args_list[0][0][0].details
+    second_payload = mocked_db.public_kg_graph.add_discovery.call_args_list[1][0][0].details
     assert first_payload != second_payload  # score_id differs across calls
 
 
@@ -597,7 +602,6 @@ async def test_score_kg_node_id_differs_across_pairs(mocked_db):
     so dedupe-by-pair is per-pair, not global."""
     from src.identity.trajectory_continuity import score_trajectory_continuity
 
-    mocked_db.kg_add_discovery = AsyncMock(return_value=None)
     parent, successor = synthetic_trajectory_pair(seed=62, kind="genuine")
     mocked_db.reconstruct_eisv_series = AsyncMock(
         side_effect=_stub_reconstruct(parent, successor)
@@ -614,7 +618,7 @@ async def test_score_kg_node_id_differs_across_pairs(mocked_db):
     )
 
     ids = [
-        mocked_db.kg_add_discovery.call_args_list[i][0][0].id
+        mocked_db.public_kg_graph.add_discovery.call_args_list[i][0][0].id
         for i in range(3)
     ]
     assert len(set(ids)) == 3, "expected 3 distinct node ids for 3 distinct pairs"
@@ -627,7 +631,7 @@ async def test_score_kg_emission_failure_is_non_fatal(mocked_db):
     audit row is durably written."""
     from src.identity.trajectory_continuity import score_trajectory_continuity
 
-    mocked_db.kg_add_discovery = AsyncMock(side_effect=RuntimeError("kg pool down"))
+    mocked_db.public_kg_graph.add_discovery = AsyncMock(side_effect=RuntimeError("kg pool down"))
     parent, successor = synthetic_trajectory_pair(seed=63, kind="genuine")
     mocked_db.reconstruct_eisv_series = AsyncMock(
         side_effect=_stub_reconstruct(parent, successor)
@@ -651,7 +655,6 @@ async def test_score_kg_emission_skipped_when_audit_fails(mocked_db):
     from src.identity.trajectory_continuity import score_trajectory_continuity
 
     mocked_db.record_r1_score_audit = AsyncMock(return_value=False)
-    mocked_db.kg_add_discovery = AsyncMock(return_value=None)
     parent, successor = synthetic_trajectory_pair(seed=64, kind="genuine")
     mocked_db.reconstruct_eisv_series = AsyncMock(
         side_effect=_stub_reconstruct(parent, successor)
@@ -662,4 +665,4 @@ async def test_score_kg_emission_skipped_when_audit_fails(mocked_db):
             claimed_parent_id="parent-uuid", successor_id="successor-uuid",
         )
 
-    mocked_db.kg_add_discovery.assert_not_awaited()
+    mocked_db.public_kg_graph.add_discovery.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Route R1 public KG emission through the configured knowledge graph backend instead of the SQL-only database helper.
- Add partial AGE rehydration from durable PostgreSQL rows when the AGE graph is missing discoveries.
- Update trajectory-continuity and AGE-load regression tests.

## Root Cause
R1 trajectory continuity scores called `backend.kg_add_discovery()`, which writes only to `knowledge.discoveries`. On an AGE-backed deployment this created durable-only `r1_score:*` rows and caused health drift between PostgreSQL and AGE.

## Live Repair
- Compared durable IDs with AGE `Discovery` IDs: 15 durable-only rows, 0 AGE-only rows.
- Rehydrated the 15 missing `r1_score:*` discoveries into AGE with non-destructive `MERGE` operations.
- `scripts/diagnostics/check_health.sh` now reports durable and AGE counts match at 938.
- Restarted the local service; launchd brought it back on PID 73723 and health remained green.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q -p no:cacheprovider tests/test_knowledge_graph_age.py tests/test_knowledge_graph_age_load.py tests/test_trajectory_continuity.py` — 188 passed.
- `./scripts/dev/test-cache.sh` — 8923 passed, 26 skipped.
- Pre-push smoke gate — 138 passed, 8252 deselected.
