### PR TITLE
[codex] Embed governance vocabulary in response payloads

### DIFF
--- a/src/governance_glossary.py
+++ b/src/governance_glossary.py
@@ -87,18 +87,42 @@ VERDICTS: Dict[str, Dict[str, str]] = {
 # BASINS — region of EISV state space
 # -----------------------------------------------------------------------------
 
-BASINS: Dict[str, Dict[str, str]] = {
+BASINS: Dict[str, Dict[str, Any]] = {
     "high": {
         "meaning": "Healthy. E and I are high; S and V are low. Normal operating range.",
+        "thresholds": {
+            "type": "all",
+            "E_min": 0.6,
+            "I_min": 0.7,
+            "S_max": 0.25,
+            "V_abs_max": 0.15,
+            "coherence_min": 0.45,
+            "risk_max": 0.45,
+        },
     },
     "low": {
         "meaning": "Degraded. May need recovery or intervention.",
+        "thresholds": {
+            "type": "any",
+            "I_below": 0.5,
+            "coherence_below": 0.40,
+            "V_abs_above": 0.30,
+            "risk_at_or_above": 0.70,
+        },
     },
     "boundary": {
         "meaning": "Transitioning between basins. Verdicts may carry margin: tight.",
+        "thresholds": {
+            "type": "complement",
+            "rule": "Neither high nor low; transitional remainder of state space.",
+        },
     },
     "critical": {
         "meaning": "Circuit breaker imminent. Pause and reassess.",
+        "thresholds": {
+            "type": "operator_alert",
+            "rule": "Used by higher-level diagnostics when risk/coherence guards are near breaker thresholds.",
+        },
     },
 }
 
@@ -130,6 +154,24 @@ TRAJECTORIES: Dict[str, Dict[str, str]] = {
     "stable":     {"meaning": "Steady; no significant V drift."},
     "declining":  {"meaning": "Value trajectory negative (V < -0.1). Simplify or seek input."},
     "stuck":      {"meaning": "Multiple pauses in recent decisions. Try a different approach or request dialectic."},
+}
+
+
+# -----------------------------------------------------------------------------
+# EISV_SOURCES — which state estimate is primary in read APIs
+# -----------------------------------------------------------------------------
+
+EISV_SOURCES: Dict[str, Dict[str, Any]] = {
+    "behavioral": {
+        "meaning": "Primary EISV comes from observed behavioral state.",
+        "thresholds": {"behavioral_confidence_min": 0.3},
+        "next_action": "Read behavioral_eisv first; use ode_eisv only as diagnostics.",
+    },
+    "ode_fallback": {
+        "meaning": "Behavioral confidence is too low, so primary EISV falls back to ODE dynamics.",
+        "thresholds": {"behavioral_confidence_below": 0.3},
+        "next_action": "Treat flat EISV as a fallback estimate until behavioral observations accumulate.",
+    },
 }
 
 
@@ -192,6 +234,58 @@ DRIFT_COMPONENTS: Dict[str, Dict[str, str]] = {
 }
 
 
+# Public process_agent_update accepts a positional ethical_drift vector. Keep
+# this separate from concrete drift-vector telemetry above: these are the three
+# caller-facing input slots from src/mcp_handlers/schemas/core.py.
+ETHICAL_DRIFT_VECTOR_COMPONENTS: Dict[str, Dict[str, str]] = {
+    "primary_drift": {
+        "meaning": "Caller-reported primary ethical-drift pressure for this update.",
+        "range": "[0, 1]",
+        "ideal": "0",
+    },
+    "coherence_loss": {
+        "meaning": "Caller-reported contribution from lost coherence or destabilized reasoning.",
+        "range": "[0, 1]",
+        "ideal": "0",
+    },
+    "complexity_contribution": {
+        "meaning": "Caller-reported contribution from task complexity or overload.",
+        "range": "[0, 1]",
+        "ideal": "0",
+    },
+}
+
+
+# -----------------------------------------------------------------------------
+# TRAJECTORY_SIGNATURE_TERMS — opaque labels that appear inside trajectory data
+# -----------------------------------------------------------------------------
+
+TRAJECTORY_SIGNATURE_TERMS: Dict[str, Dict[str, Any]] = {
+    "settling": {
+        "meaning": "Projected state is moving toward an attractor or stable set point.",
+        "next_action": "Usually safe to continue; watch for rising risk or entropy.",
+    },
+    "ode_fallback": EISV_SOURCES["ode_fallback"],
+    "behavioral": EISV_SOURCES["behavioral"],
+    "divergence": {
+        "meaning": "Open exploration regime; higher entropy can be normal.",
+        "next_action": "Keep scope visible and consolidate before switching to execution.",
+    },
+    "transition": {
+        "meaning": "Between exploration and convergence; state may shift quickly.",
+        "next_action": "Avoid raising complexity until coherence stabilizes.",
+    },
+    "convergence": {
+        "meaning": "Focused regime; integrity and low entropy matter more than novelty.",
+        "next_action": "Prefer verification and completion over new branches of work.",
+    },
+    "stable": {
+        "meaning": "State is near equilibrium or recently steady.",
+        "next_action": "Continue, while watching for hidden stasis if no progress is being made.",
+    },
+}
+
+
 # -----------------------------------------------------------------------------
 # Helpers
 # -----------------------------------------------------------------------------
@@ -224,6 +318,32 @@ def explain_mode(mode: Optional[str]) -> Dict[str, Any]:
 def explain_trajectory(trajectory: Optional[str]) -> Dict[str, Any]:
     """Wrap a trajectory value with meaning."""
     return _wrap(trajectory, TRAJECTORIES)
+
+
+def explain_eisv_source(source: Optional[str]) -> Dict[str, Any]:
+    """Wrap a primary EISV source label with meaning + activation threshold."""
+    return _wrap(source, EISV_SOURCES)
+
+
+def explain_trajectory_signature_term(term: Optional[str]) -> Dict[str, Any]:
+    """Wrap a string found in trajectory-signature payloads.
+
+    The terms can come from several local vocabularies: state modes,
+    trajectories, basins, primary EISV source labels, and CIRS regimes.
+    """
+    if term is None:
+        return {"value": None}
+    key = str(term)
+    for table in (
+        MODES,
+        TRAJECTORIES,
+        BASINS,
+        EISV_SOURCES,
+        TRAJECTORY_SIGNATURE_TERMS,
+    ):
+        if key in table:
+            return {"value": term, **table[key]}
+    return {"value": term, "meaning": "unknown (not in glossary)"}
 
 
 _TIER_BY_NAME: Dict[str, int] = {info["name"]: tier_int for tier_int, info in TRUST_TIERS.items()}
@@ -297,3 +417,69 @@ def annotate_drift_components(drift: Dict[str, float]) -> Dict[str, Dict[str, An
         else:
             out[key] = {"value": value, **info}
     return out
+
+
+def explain_ethical_drift_vector(drift: Optional[Any]) -> Dict[str, Any]:
+    """Name the three positional ethical_drift input components.
+
+    Public schemas accept ethical_drift as
+    [primary_drift, coherence_loss, complexity_contribution]. Returning both
+    the original vector and named components preserves the wire shape while
+    making the input self-describing at the response surface.
+    """
+    if drift is None:
+        return {"value": None}
+    try:
+        values = list(drift)
+    except TypeError:
+        return {"value": drift, "meaning": "unknown (expected three-component vector)"}
+
+    component_names = list(ETHICAL_DRIFT_VECTOR_COMPONENTS.keys())
+    components: Dict[str, Dict[str, Any]] = {}
+    for idx, name in enumerate(component_names):
+        value = values[idx] if idx < len(values) else None
+        components[name] = {
+            "value": value,
+            **ETHICAL_DRIFT_VECTOR_COMPONENTS[name],
+        }
+    extras = values[len(component_names):]
+    result: Dict[str, Any] = {
+        "value": values,
+        "order": component_names,
+        "components": components,
+    }
+    if extras:
+        result["extra_components"] = [
+            {"index": len(component_names) + i, "value": v}
+            for i, v in enumerate(extras)
+        ]
+    return result
+
+
+def annotate_trajectory_signature_terms(signature: Optional[Any]) -> Dict[str, Dict[str, Any]]:
+    """Return glossary entries for known string values inside a signature.
+
+    The original trajectory_signature can be large and structurally owned by
+    upstream agents. This helper leaves it untouched and returns path-keyed
+    annotations only for known terms.
+    """
+    if not isinstance(signature, dict):
+        return {}
+
+    annotations: Dict[str, Dict[str, Any]] = {}
+
+    def walk(value: Any, path: str) -> None:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                child_path = f"{path}.{key}" if path else str(key)
+                walk(child, child_path)
+        elif isinstance(value, list):
+            for idx, child in enumerate(value):
+                walk(child, f"{path}[{idx}]")
+        elif isinstance(value, str):
+            explained = explain_trajectory_signature_term(value)
+            if "meaning" in explained and not str(explained["meaning"]).startswith("unknown"):
+                annotations[path] = explained
+
+    walk(signature, "")
+    return annotations

--- a/src/mcp_handlers/cirs/types.py
+++ b/src/mcp_handlers/cirs/types.py
@@ -92,10 +92,16 @@ class StateAnnounce:
         }
         if self.trajectory_signature:
             result["trajectory_signature"] = self.trajectory_signature
+            from src.governance_glossary import annotate_trajectory_signature_terms
+            signature_glossary = annotate_trajectory_signature_terms(self.trajectory_signature)
+            if signature_glossary:
+                result["trajectory_signature_glossary"] = signature_glossary
         if self.purpose:
             result["purpose"] = self.purpose
         if self.trust_tier:
             result["trust_tier"] = self.trust_tier
+            from src.governance_glossary import explain_trust_tier
+            result["trust_tier_meta"] = explain_trust_tier(self.trust_tier)
         return result
 
 

--- a/src/mcp_handlers/core.py
+++ b/src/mcp_handlers/core.py
@@ -291,6 +291,11 @@ async def handle_simulate_update(arguments: ToolArgumentsDict) -> Sequence[TextC
     if dialectic_warnings:
         response["dialectic_condition_warnings"] = dialectic_warnings
 
+    from src.governance_glossary import explain_ethical_drift_vector
+    response["input_glossary"] = {
+        "ethical_drift": explain_ethical_drift_vector(ethical_drift),
+    }
+
     return success_response(response)
 
 @mcp_tool("process_agent_update", timeout=60.0)

--- a/src/mcp_handlers/response_formatter.py
+++ b/src/mcp_handlers/response_formatter.py
@@ -114,7 +114,7 @@ def format_response(
 
     # STANDARD MODE: Human-readable interpretation
     elif response_mode in ("standard", "interpreted"):
-        response_data = _format_standard(response_data, task_type)
+        response_data = _format_standard(response_data, task_type, saved_trust_tier)
 
     # MINIMAL MODE: Bare essentials
     elif response_mode == "minimal":
@@ -130,7 +130,7 @@ def format_response(
 
     return response_data
 
-def _format_standard(response_data: dict, task_type: str) -> dict:
+def _format_standard(response_data: dict, task_type: str, saved_trust_tier: Any = None) -> dict:
     """Build standard (interpreted) response."""
     from governance_state import GovernanceState
     from governance_core import State, Theta, DEFAULT_THETA
@@ -152,6 +152,11 @@ def _format_standard(response_data: dict, task_type: str) -> dict:
     temp_state.decision_history = response_data.get("history", {}).get("decision_history", [])
 
     interpreted = temp_state.interpret_state(risk_score=risk_score, task_type=task_type)
+    from src.governance_glossary import (
+        explain_basin,
+        explain_mode,
+        explain_trajectory,
+    )
 
     result = {
         "success": True,
@@ -165,6 +170,20 @@ def _format_standard(response_data: dict, task_type: str) -> dict:
         "_mode": "standard",
         "_raw_available": "Use response_mode='full' to see complete metrics",
     }
+    state_glossary = {}
+    if interpreted.get("mode") is not None:
+        state_glossary["mode"] = explain_mode(interpreted.get("mode"))
+    if interpreted.get("basin") is not None:
+        state_glossary["basin"] = explain_basin(interpreted.get("basin"))
+    if interpreted.get("trajectory") is not None:
+        state_glossary["trajectory"] = explain_trajectory(interpreted.get("trajectory"))
+    if state_glossary:
+        result["state_glossary"] = state_glossary
+    if saved_trust_tier:
+        from src.governance_glossary import explain_trust_tier
+        result["trust_tier"] = explain_trust_tier(saved_trust_tier)
+    if "input_glossary" in response_data:
+        result["input_glossary"] = response_data["input_glossary"]
     if "thread_context" in response_data:
         result["thread_context"] = response_data["thread_context"]
     if "identity_assurance" in response_data:

--- a/src/mcp_handlers/updates/enrichments.py
+++ b/src/mcp_handlers/updates/enrichments.py
@@ -67,6 +67,20 @@ async def enrich_state_interpretation(ctx: UpdateContext) -> None:
             task_type=task_type
         )
         ctx.response_data['state'] = interpreted_state
+        from src.governance_glossary import (
+            explain_basin,
+            explain_mode,
+            explain_trajectory,
+        )
+        state_glossary = {}
+        if interpreted_state.get("mode") is not None:
+            state_glossary["mode"] = explain_mode(interpreted_state.get("mode"))
+        if interpreted_state.get("basin") is not None:
+            state_glossary["basin"] = explain_basin(interpreted_state.get("basin"))
+        if interpreted_state.get("trajectory") is not None:
+            state_glossary["trajectory"] = explain_trajectory(interpreted_state.get("trajectory"))
+        if state_glossary:
+            ctx.response_data['state_glossary'] = state_glossary
 
         health = interpreted_state.get('health', 'unknown')
         mode = interpreted_state.get('mode', 'unknown')
@@ -310,6 +324,19 @@ def enrich_health_status_toplevel(ctx: UpdateContext) -> None:
                     pass
     except Exception as e:
         logger.debug(f"Could not enrich health status: {e}")
+
+
+@enrichment(order=85, lite_safe=True)
+def enrich_input_glossary(ctx: UpdateContext) -> None:
+    """Attach point-of-use glossary for positional input vectors."""
+    try:
+        from src.governance_glossary import explain_ethical_drift_vector
+
+        ctx.response_data["input_glossary"] = {
+            "ethical_drift": explain_ethical_drift_vector(ctx.ethical_drift),
+        }
+    except Exception as e:
+        logger.debug(f"Could not enrich input glossary: {e}")
 
 # ─── CIRS Response Fields ──────────────────────────────────────────────
 
@@ -714,6 +741,10 @@ async def enrich_trajectory_identity(ctx: UpdateContext) -> None:
                 "observation_count": trajectory_result.get("observation_count"),
                 "identity_confidence": trajectory_result.get("identity_confidence"),
             }
+            from src.governance_glossary import annotate_trajectory_signature_terms
+            signature_glossary = annotate_trajectory_signature_terms(trajectory_signature)
+            if signature_glossary:
+                ctx.response_data["trajectory_identity"]["signature_glossary"] = signature_glossary
 
             if "lineage_similarity" in trajectory_result:
                 ctx.response_data["trajectory_identity"]["lineage"] = {
@@ -747,15 +778,17 @@ async def enrich_trajectory_identity(ctx: UpdateContext) -> None:
                         )
 
                 if trust_tier:
-                    ctx.response_data["trajectory_identity"]["trust_tier"] = trust_tier
+                    from src.governance_glossary import explain_trust_tier
+                    explained_trust_tier = explain_trust_tier(trust_tier)
+                    ctx.response_data["trajectory_identity"]["trust_tier"] = explained_trust_tier
 
                     mcp_server = ctx.mcp_server
                     meta = ctx.meta or mcp_server.agent_metadata.get(ctx.agent_id)
                     if meta:
-                        meta.trust_tier = trust_tier.get("name", "unknown")
-                        meta.trust_tier_num = trust_tier.get("tier", 0)
+                        meta.trust_tier = explained_trust_tier.get("name", "unknown")
+                        meta.trust_tier_num = explained_trust_tier.get("tier", 0)
 
-                    tier_num = trust_tier.get("tier", 0)
+                    tier_num = explained_trust_tier.get("tier", 0)
                     is_anomaly = trajectory_result.get("is_anomaly", False)
 
                     risk_adj = 0.0
@@ -766,7 +799,7 @@ async def enrich_trajectory_identity(ctx: UpdateContext) -> None:
                         risk_reason = "Behavioral deviation detected (lineage < 0.6)"
                     elif tier_num <= 1:
                         risk_adj = 0.05
-                        risk_reason = f"Trust tier {tier_num} ({trust_tier['name']}): identity not yet established"
+                        risk_reason = f"Trust tier {tier_num} ({explained_trust_tier['name']}): identity not yet established"
                     elif tier_num == 3:
                         risk_adj = -0.05
                         risk_reason = f"Trust tier 3 (verified): earned trust reduces friction"

--- a/src/services/runtime_queries.py
+++ b/src/services/runtime_queries.py
@@ -73,6 +73,8 @@ def _build_eisv_semantics(metrics: Dict[str, Any], monitor: Any) -> Dict[str, An
         behavioral_confidence = 0.0
 
     primary_source = "behavioral" if behavioral_confidence >= 0.3 else "ode_fallback"
+    from src.governance_glossary import explain_eisv_source
+    primary_source_meta = explain_eisv_source(primary_source)
     ode_diagnostics = {
         "phi": metrics.get("phi"),
         "verdict": metrics.get("verdict"),
@@ -86,6 +88,7 @@ def _build_eisv_semantics(metrics: Dict[str, Any], monitor: Any) -> Dict[str, An
         "eisv": primary_eisv,
         "primary_eisv": primary_eisv,
         "primary_eisv_source": primary_source,
+        "primary_eisv_source_meta": primary_source_meta,
         "behavioral_eisv": behavioral_eisv,
         "ode_eisv": ode_eisv,
         "ode_diagnostics": ode_diagnostics,
@@ -105,6 +108,7 @@ def _build_eisv_semantics(metrics: Dict[str, Any], monitor: Any) -> Dict[str, An
             ),
             "ode_diagnostics_role": "Thermostat dynamics diagnostics (phi, regime, lambda1)",
             "verdict_source": primary_source,
+            "verdict_source_meta": primary_source_meta,
             "hierarchy": [
                 "1. behavioral_eisv (primary when confidence >= 0.3)",
                 "2. ode_eisv (fallback when behavioral data insufficient)",
@@ -248,6 +252,7 @@ async def get_governance_metrics_data(agent_id: str, arguments: Dict[str, Any], 
     if verbosity == "standard":
         from src.governance_glossary import (
             explain_basin,
+            explain_eisv_source,
             explain_mode,
             explain_verdict,
         )
@@ -272,6 +277,9 @@ async def get_governance_metrics_data(agent_id: str, arguments: Dict[str, Any], 
             "verdict": explain_verdict(metrics.get("verdict", "uninitialized")),
             "risk_score": metrics.get("risk_score"),
             "primary_eisv_source": standardized_metrics.get("primary_eisv_source"),
+            "primary_eisv_source_meta": explain_eisv_source(
+                standardized_metrics.get("primary_eisv_source")
+            ),
             "summary": standardized_metrics.get("summary"),
             "guidance": state.get("guidance"),
         })
@@ -351,8 +359,12 @@ async def get_governance_metrics_data(agent_id: str, arguments: Dict[str, Any], 
         # at point-of-use.
         from src.governance_glossary import (
             explain_basin,
+            explain_eisv_source,
             explain_mode,
             explain_verdict,
+        )
+        lite_metrics["primary_eisv_source_meta"] = explain_eisv_source(
+            standardized_metrics.get("primary_eisv_source")
         )
         if "state" in standardized_metrics:
             lite_metrics["mode"] = explain_mode(standardized_metrics["state"].get("mode"))

--- a/tests/test_enrichment_pipeline.py
+++ b/tests/test_enrichment_pipeline.py
@@ -18,7 +18,7 @@ from src.mcp_handlers.updates.pipeline import (
 
 class TestEnrichmentRegistration:
     def test_all_enrichments_registered(self):
-        assert get_enrichment_count() == 29
+        assert get_enrichment_count() == 30
 
     def test_enrichment_order_is_unique(self):
         orders = [e.order for e in _ENRICHMENTS]
@@ -30,6 +30,8 @@ class TestEnrichmentRegistration:
         # state_interpretation before actionable_feedback before llm_coaching
         assert idx["enrich_state_interpretation"] < idx["enrich_actionable_feedback"]
         assert idx["enrich_actionable_feedback"] < idx["enrich_llm_coaching"]
+        assert idx["enrich_health_status_toplevel"] < idx["enrich_input_glossary"]
+        assert idx["enrich_input_glossary"] < idx["enrich_cirs_response_fields"]
         # mirror_signals runs late
         assert idx["enrich_mirror_signals"] > idx["enrich_websocket_broadcast"]
 
@@ -219,6 +221,7 @@ class TestLiteModeSkipping:
         assert names_to_lite_safe.get("enrich_learning_context") is True
         assert names_to_lite_safe.get("enrich_knowledge_surfacing") is True
         assert names_to_lite_safe.get("enrich_mirror_signals") is True
+        assert names_to_lite_safe.get("enrich_input_glossary") is True
         # Side-effect enrichments must NOT be lite_safe — confirms intent.
         assert names_to_lite_safe.get("enrich_websocket_broadcast") is False
         assert names_to_lite_safe.get("enrich_basin_tracking") is False

--- a/tests/test_governance_glossary.py
+++ b/tests/test_governance_glossary.py
@@ -12,10 +12,16 @@ from src.governance_glossary import (
     MODES,
     TRAJECTORIES,
     DRIFT_COMPONENTS,
+    EISV_SOURCES,
+    ETHICAL_DRIFT_VECTOR_COMPONENTS,
+    TRAJECTORY_SIGNATURE_TERMS,
     explain_verdict,
     explain_basin,
+    explain_eisv_source,
     explain_mode,
     explain_trajectory,
+    explain_ethical_drift_vector,
+    annotate_trajectory_signature_terms,
     annotate_drift_components,
 )
 
@@ -57,6 +63,7 @@ class TestGlossaryIntegrity:
     def test_all_basins_have_meaning(self):
         for basin, info in BASINS.items():
             assert "meaning" in info and info["meaning"]
+            assert "thresholds" in info and info["thresholds"]
 
     def test_all_modes_have_meaning(self):
         for mode, info in MODES.items():
@@ -78,6 +85,21 @@ class TestGlossaryIntegrity:
 
     def test_all_trajectories_have_meaning(self):
         for trajectory, info in TRAJECTORIES.items():
+            assert "meaning" in info and info["meaning"]
+
+    def test_all_eisv_sources_have_thresholds(self):
+        for source, info in EISV_SOURCES.items():
+            assert "meaning" in info and info["meaning"]
+            assert "thresholds" in info and info["thresholds"]
+
+    def test_positional_ethical_drift_components_have_range_and_ideal(self):
+        for component, info in ETHICAL_DRIFT_VECTOR_COMPONENTS.items():
+            assert "meaning" in info and info["meaning"]
+            assert "range" in info
+            assert "ideal" in info
+
+    def test_trajectory_signature_terms_have_meaning(self):
+        for term, info in TRAJECTORY_SIGNATURE_TERMS.items():
             assert "meaning" in info and info["meaning"]
 
     def test_drift_components_have_range_and_ideal(self):
@@ -135,6 +157,16 @@ class TestExplainTrajectory:
     def test_stuck_recommends_dialectic(self):
         result = explain_trajectory("stuck")
         assert "dialectic" in result["meaning"].lower()
+
+
+class TestExplainEisvSource:
+
+    def test_ode_fallback_includes_threshold_and_action(self):
+        result = explain_eisv_source("ode_fallback")
+        assert result["value"] == "ode_fallback"
+        assert "Behavioral confidence" in result["meaning"]
+        assert result["thresholds"]["behavioral_confidence_below"] == 0.3
+        assert "next_action" in result
 
 
 class TestExplainTrustTier:
@@ -244,6 +276,37 @@ class TestAnnotateDriftComponents:
         assert result["norm_squared"] == {"value": 0.176}
 
 
+class TestExplainEthicalDriftVector:
+
+    def test_names_three_positional_components(self):
+        result = explain_ethical_drift_vector([0.1, 0.2, 0.3])
+        assert result["value"] == [0.1, 0.2, 0.3]
+        assert result["order"] == [
+            "primary_drift",
+            "coherence_loss",
+            "complexity_contribution",
+        ]
+        assert result["components"]["primary_drift"]["value"] == 0.1
+        assert "meaning" in result["components"]["coherence_loss"]
+        assert "range" in result["components"]["complexity_contribution"]
+        assert "ideal" in result["components"]["complexity_contribution"]
+
+
+class TestAnnotateTrajectorySignatureTerms:
+
+    def test_returns_path_keyed_known_terms_without_mutating_signature(self):
+        signature = {
+            "state": {"mode": "building_alone"},
+            "source": "ode_fallback",
+            "projection": {"phase": "settling"},
+        }
+        result = annotate_trajectory_signature_terms(signature)
+        assert result["state.mode"]["value"] == "building_alone"
+        assert result["source"]["value"] == "ode_fallback"
+        assert result["projection.phase"]["value"] == "settling"
+        assert signature["source"] == "ode_fallback"
+
+
 class TestGlossaryAppliedToMonitorResult:
     """Source-level guards that monitor_result.py uses the glossary helpers
     to wrap ethical_drift and behavioral.assessment.verdict. Regression
@@ -351,6 +414,23 @@ class TestGlossaryAppliedToResponseFormatter:
             "explain_trust_tier()."
         )
 
+    def test_standard_format_wraps_state_glossary(self):
+        source = self._read("src/mcp_handlers/response_formatter.py")
+        idx = source.find("def _format_standard")
+        end = source.find("\ndef ", idx + 1)
+        window = source[idx:end if end != -1 else len(source)]
+        assert "state_glossary" in window
+        assert "explain_basin" in window
+        assert "explain_mode" in window
+        assert "explain_trajectory" in window
+
+    def test_simulate_update_wraps_input_ethical_drift(self):
+        source = self._read("src/mcp_handlers/core.py")
+        idx = source.find("def handle_simulate_update")
+        end = source.find("\n@mcp_tool(\"process_agent_update\"", idx + 1)
+        window = source[idx:end if end != -1 else len(source)]
+        assert "explain_ethical_drift_vector" in window
+
 
 class TestGlossaryAppliedToObservabilityHandlers:
     """Regression guard: observe_agent's current_state must wrap verdict via
@@ -372,3 +452,45 @@ class TestGlossaryAppliedToObservabilityHandlers:
             "observe_agent's current_state must wrap verdict via "
             "explain_verdict() — it's the primary self-observation surface."
         )
+
+
+class TestGlossaryAppliedToRuntimeQueries:
+    """Read APIs should keep raw values and add peer glossary metadata."""
+
+    @staticmethod
+    def _read(rel_path: str) -> str:
+        from pathlib import Path
+        return (Path(__file__).parent.parent / rel_path).read_text()
+
+    def test_primary_eisv_source_has_meta(self):
+        source = self._read("src/services/runtime_queries.py")
+        assert "primary_eisv_source_meta" in source
+        assert "explain_eisv_source" in source
+
+
+class TestGlossaryAppliedToUpdateEnrichments:
+    """process_agent_update full payload should annotate raw state/signature fields."""
+
+    @staticmethod
+    def _read(rel_path: str) -> str:
+        from pathlib import Path
+        return (Path(__file__).parent.parent / rel_path).read_text()
+
+    def test_state_interpretation_adds_state_glossary(self):
+        source = self._read("src/mcp_handlers/updates/enrichments.py")
+        idx = source.find("def enrich_state_interpretation")
+        end = source.find("\n@enrichment", idx + 1)
+        window = source[idx:end if end != -1 else len(source)]
+        assert "state_glossary" in window
+        assert "explain_basin" in window
+        assert "explain_mode" in window
+        assert "explain_trajectory" in window
+
+    def test_trajectory_identity_adds_signature_glossary_and_wrapped_trust_tier(self):
+        source = self._read("src/mcp_handlers/updates/enrichments.py")
+        idx = source.find("def enrich_trajectory_identity")
+        end = source.find("\n@enrichment", idx + 1)
+        window = source[idx:end if end != -1 else len(source)]
+        assert "annotate_trajectory_signature_terms" in window
+        assert "signature_glossary" in window
+        assert "explain_trust_tier" in window


### PR DESCRIPTION
## Summary
- extend the governance glossary with basin thresholds, primary EISV source labels, positional ethical_drift names, and trajectory-signature term annotations
- wire point-of-use glossary metadata into governance metrics, process update payloads, standard response mode, simulation, and CIRS state announcements
- add regression coverage for the new glossary helpers and enrichment registry contract

## Validation
- git diff --check
- python3 -m pytest tests/test_governance_glossary.py tests/test_response_formatter.py tests/test_handlers_core.py::TestGetGovernanceMetrics::test_get_metrics_lite_mode tests/test_handlers_core.py::TestGetGovernanceMetrics::test_get_metrics_standard_mode_wraps_basin_mode_verdict tests/test_core_metrics.py::TestEdgeCases::test_get_metrics_includes_mode_and_basin_in_lite tests/test_core_update.py::TestProcessAgentUpdateExtended::test_trajectory_identity_updated tests/test_core_update.py::TestProcessAgentUpdateExtended::test_trajectory_identity_anomaly_detected tests/test_core_update.py::TestProcessAgentUpdateExtended::test_trajectory_identity_genesis_created tests/test_cirs_protocol_handlers.py::TestStateAnnounce -q
- ./scripts/dev/test-cache.sh: 8937 passed, 25 skipped
- pre-push smoke: 138 passed, 8263 deselected

Fixes #428