### PR TITLE
fix(r1): correct EISV column-to-channel mapping (E and S were swapped/dead since 2026-03-26)

### DIFF
--- a/src/db/mixins/state.py
+++ b/src/db/mixins/state.py
@@ -367,7 +367,7 @@ class StateMixin:
         async with self.acquire() as conn:
             rows = await conn.fetch(
                 """
-                SELECT s.entropy, s.integrity, s.stability_index, s.volatility,
+                SELECT s.entropy, s.integrity, s.volatility, s.state_json,
                        s.recorded_at
                 FROM core.agent_state s
                 JOIN core.identities i ON i.identity_id = s.identity_id
@@ -380,11 +380,17 @@ class StateMixin:
                 agent_id, epoch, window,
             )
 
+        # Column → EISV mapping per db/base.py:50-57: state_json.E → E,
+        # integrity → I, entropy → S, volatility → V. The stability_index
+        # column was retired in commit 20684dd1 (2026-03-26) and is no
+        # longer read; the writer hardcodes 0.0.
         series: Dict[str, List[float]] = {"E": [], "I": [], "S": [], "V": []}
         for row in rows:
-            series["E"].append(float(row["entropy"]))
+            sj_raw = row["state_json"]
+            sj = json.loads(sj_raw) if isinstance(sj_raw, str) else (sj_raw or {})
+            series["E"].append(float(sj.get("E", 0.5)))
             series["I"].append(float(row["integrity"]))
-            series["S"].append(float(row["stability_index"]))
+            series["S"].append(float(row["entropy"]))
             series["V"].append(float(row["volatility"]))
         return series
 

--- a/tests/test_lineage_continuity_helper.py
+++ b/tests/test_lineage_continuity_helper.py
@@ -32,9 +32,13 @@ async def test_reconstruct_eisv_series_maps_rows_to_per_dim_lists():
     """Behavior: rows in window get bucketed into {E, I, S, V} → list[float]
     in recorded_at-ascending order.
 
-    Mocks self.acquire() context manager returning a connection whose fetch()
-    returns three synthetic rows. Verifies dimension-key mapping
-    (entropy→E, integrity→I, stability_index→S, volatility→V) and order.
+    Verifies dimension-key mapping per db/base.py:50-57:
+      state_json.E → E, integrity → I, entropy → S, volatility → V.
+    The stability_index column was retired in commit 20684dd1 (2026-03-26)
+    and is no longer read. The earlier version of this test had E and S
+    swapped — entropy was mapped to E and the dead stability_index column
+    was mapped to S — which silently produced wrong R1 components for ~2
+    months until the reader was corrected.
     """
     from src.db.mixins.state import StateMixin
 
@@ -46,11 +50,15 @@ async def test_reconstruct_eisv_series_maps_rows_to_per_dim_lists():
         async def __aenter__(self):
             conn = AsyncMock()
             # Three rows ordered ascending by recorded_at; columns match the
-            # SQL projection in the helper.
+            # SQL projection in the helper. Distinct values per channel let
+            # any mismapping surface in the assertions below.
             conn.fetch = AsyncMock(return_value=[
-                _row(entropy=0.5, integrity=0.6, stability_index=0.4, volatility=0.1),
-                _row(entropy=0.6, integrity=0.7, stability_index=0.4, volatility=0.2),
-                _row(entropy=0.7, integrity=0.8, stability_index=0.5, volatility=0.3),
+                _row(entropy=0.5, integrity=0.6, volatility=0.1,
+                     state_json={"E": 0.9}),
+                _row(entropy=0.6, integrity=0.7, volatility=0.2,
+                     state_json={"E": 0.85}),
+                _row(entropy=0.7, integrity=0.8, volatility=0.3,
+                     state_json={"E": 0.8}),
             ])
             return conn
 
@@ -65,9 +73,9 @@ async def test_reconstruct_eisv_series_maps_rows_to_per_dim_lists():
     )
 
     assert set(result.keys()) == {"E", "I", "S", "V"}
-    assert result["E"] == [0.5, 0.6, 0.7]
+    assert result["E"] == [0.9, 0.85, 0.8]
     assert result["I"] == [0.6, 0.7, 0.8]
-    assert result["S"] == [0.4, 0.4, 0.5]
+    assert result["S"] == [0.5, 0.6, 0.7]
     assert result["V"] == [0.1, 0.2, 0.3]
 
 

--- a/tests/test_state_mixin_agent_state.py
+++ b/tests/test_state_mixin_agent_state.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock
 
 import pytest
@@ -66,3 +66,109 @@ async def test_all_latest_falls_back_when_matview_lacks_epistemic_class():
     assert rows[0].state_json["epistemic_class"] == "substrate_interpretation"
     assert any("core.mv_latest_agent_states" in sql for sql in calls)
     assert any("FROM core.agent_state s" in sql for sql in calls)
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_eisv_series_column_to_dimension_mapping():
+    """Per db/base.py:50-57 the column↔EISV mapping is:
+    state_json.E → E, integrity → I, entropy → S, volatility → V.
+
+    Pre-fix the reader read entropy as E and the dead stability_index column
+    as S; this test would have failed under that mapping for E (got 0.2,
+    expected 0.6) and for S (got 0.0, expected 0.2).
+    """
+    from src.db.mixins.state import StateMixin
+
+    class _Stub(StateMixin):
+        def acquire(self):
+            return _Acquire()
+
+    class _Acquire:
+        async def __aenter__(self):
+            conn = AsyncMock()
+
+            async def _fetch(sql, *args):
+                return [
+                    _state_row(
+                        entropy=0.2, integrity=0.8, volatility=0.1,
+                        state_json={"E": 0.6}, stability_index=0.0,
+                    ),
+                ]
+
+            conn.fetch = _fetch
+            return conn
+
+        async def __aexit__(self, *args):
+            return None
+
+    series = await _Stub().reconstruct_eisv_series(
+        agent_id="agent-state-mixin", window=timedelta(hours=1), epoch=1,
+    )
+
+    assert series["E"] == [0.6]
+    assert series["I"] == [0.8]
+    assert series["S"] == [0.2]
+    assert series["V"] == [0.1]
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_eisv_series_handles_state_json_as_string():
+    """asyncpg can return state_json as either a dict or a JSON string
+    depending on codec registration. The reader must tolerate both
+    (mirrors _row_to_agent_state at db/mixins/state.py:425-444).
+    """
+    from src.db.mixins.state import StateMixin
+
+    class _Stub(StateMixin):
+        def acquire(self):
+            return _Acquire()
+
+    class _Acquire:
+        async def __aenter__(self):
+            conn = AsyncMock()
+
+            async def _fetch(sql, *args):
+                return [_state_row(state_json='{"E": 0.42}')]
+
+            conn.fetch = _fetch
+            return conn
+
+        async def __aexit__(self, *args):
+            return None
+
+    series = await _Stub().reconstruct_eisv_series(
+        agent_id="agent-state-mixin", window=timedelta(hours=1), epoch=1,
+    )
+
+    assert series["E"] == [0.42]
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_eisv_series_defaults_missing_e_to_neutral():
+    """When state_json lacks an 'E' key, default to 0.5 (matches
+    _row_to_agent_state.energy default in db/base.py:63).
+    """
+    from src.db.mixins.state import StateMixin
+
+    class _Stub(StateMixin):
+        def acquire(self):
+            return _Acquire()
+
+    class _Acquire:
+        async def __aenter__(self):
+            conn = AsyncMock()
+
+            async def _fetch(sql, *args):
+                return [_state_row(state_json={})]
+
+            conn.fetch = _fetch
+            return conn
+
+        async def __aexit__(self, *args):
+            return None
+
+    series = await _Stub().reconstruct_eisv_series(
+        agent_id="agent-state-mixin", window=timedelta(hours=1), epoch=1,
+    )
+
+    assert series["E"] == [0.5]


### PR DESCRIPTION
## Summary

`reconstruct_eisv_series` at `src/db/mixins/state.py:370-389` has been silently mis-reading two of four R1 channels since commit `20684dd1` (2026-03-26). This PR fixes the reader and updates the one test that pinned the buggy mapping. The empirical pre/post-fix replay below confirms **zero of the currently-plausible 268 rows flip** under the corrected reader — the fix is safe to merge as-is, no threshold retuning needed.

## The bug

Per the documented EISV ↔ column mapping in `src/db/base.py:50-57` (and confirmed at the writer site `src/agent_storage.py:586-590`):

| Channel | Source |
|---|---|
| E | `state_json.E` |
| I | `integrity` column |
| S | `entropy` column |
| V | `volatility` column |
| _(dead)_ | `stability_index` — retired in `20684dd1`, hardcoded to `0.0` |

The reader's mapping had two errors:

```python
series["E"].append(float(row["entropy"]))         # wrong: entropy is S
series["I"].append(float(row["integrity"]))       # ok
series["S"].append(float(row["stability_index"])) # wrong: dead column
series["V"].append(float(row["volatility"]))      # ok
```

The query never pulled `state_json`, so the real E value could not be reconstructed at all.

## Effect on production data

For every `audit.r1_score_audit` row written since 2026-04-01 (DB-side cutover of the writer change):

- `components.E` actually carries S-similarity (computed off the `entropy` column, which is the real S signal).
- `components.S` is structurally **1.0** — `DTW(zeros, zeros) = 0`, `exp(0) = 1.0`.
- `components.I` and `components.V` are correct.

Live check on `audit.r1_score_audit` (n=1163): all 268 `plausible` rows have `components.S = 1.0` exactly.

## Fix

`src/db/mixins/state.py` — SELECT pulls `state_json` instead of `stability_index`; loop maps `state_json.E → series["E"]` and `entropy → series["S"]`. Mirrors the convention used by `_row_to_agent_state` in the same file.

## Empirical pre/post-fix replay

Ran the corrected reader against the last-30-day production audit population (n=268 plausible rows over 3 unique parent→successor pairs) and recomputed plausibility under the fixed mapping.

| Transition | Count |
|---|---|
| plausible → plausible | **268** |
| plausible → inconclusive | 0 |
| plausible → unsupported | 0 |

**Distribution shift** (new − stored plausibility):

| Quantile | Δ |
|---|---|
| min | −0.0315 |
| P10 | −0.0182 |
| median | −0.0112 |
| P90 | −0.0063 |
| max | −0.0063 |
| mean | −0.0120 |

Lowest post-fix plausibility is **0.8686** — clears the 0.70 threshold by 0.169.

**Why the shift is smaller than expected:** the +0.25 deterministic boost from the always-1.0 S channel doesn't fully disappear; it's partially refunded. Under the fix, "E" gets its true source (`state_json.E`, ~0.87–0.93), which is *higher* than the entropy-column proxy (~0.80–0.86) the buggy reader was treating as E. The two errors partially cancel.

**Sanity check:** I and V channels (which the fix doesn't touch) recomputed to within 1e-3 of stored values for all 268 rows. DTW reproduction matches production.

**Caveat worth knowing, not blocking:** safety margin is empirical for the current fleet's 3 active pairs. Re-running this replay after the next 30-day window confirms whether the margin persists as the fleet shifts.

## Downstream impact (audited)

**No per-channel consumers in production.** Verified across `src/`, `agents/`, `dashboard/`, and `~/projects/unitares-discord-bridge/`:
- Dashboard renders only EISV-state verdicts (proceed/guide/pause), not R1 lineage verdicts. No R1 panel exists.
- Discord bridge has zero references to `plausibility` / `r1_score` / `trajectory_continuity`.
- Residents (Vigil, Sentinel, Watcher, Chronicler) have zero references.
- The public KG payload redacts `components` (`_build_public_payload` in `src/identity/trajectory_continuity.py:116-130`; pinned by `tests/test_trajectory_continuity.py:299-303`).

The `components` jsonb is forensic-only.

**Thresholds are seeded, not fit.** `_THRESHOLD_PLAUSIBLE = 0.70` / `_THRESHOLD_UNSUPPORTED = 0.55` at `src/identity/trajectory_continuity.py:50-51` are documented as hand-set synthetic-seeded (`docs/ontology/r1-verify-lineage-claim.md:118-136`). Live `core.r1_calibration_state.calibration_status='seeded'` since 2026-05-03; never advanced to `earned`. The fix does not invalidate a fit.

**Aggregate consumers** read only `verdict` / `plausibility` and will see the (small) shifted distribution without mislabeling:
- `src/identity/lineage_lifecycle.py:341-440` — R2 FSM
- `src/identity/r1_maintenance.py:64-100` — sweep
- `src/mcp_handlers/observability/handlers.py:843-854` — `handle_aggregate_metrics`
- `src/mcp_handlers/identity/handlers.py:2819-2841` — fire-and-forget background scoring at onboard

**R2 Phase 1 telemetry gate** (`src/identity/r2_phase1_telemetry.py:19-21`) counts confirmed/demoted pairs against fixed minima (50 confirmed / 10 demoted); currently confirmed=3, provisional=13. Gate nowhere near tripping.

## Discovery context

Discovered during a single-channel ablation study on R1 verdicts (2026-05-28). Saved as memory at `~/.claude/projects/-Users-cirwel/memory/project_r1-audit-sparsity-and-stability-index-flat.md`.

## Test plan

- [x] Unit test added: `tests/test_state_mixin_agent_state.py::test_reconstruct_eisv_series_column_to_dimension_mapping` — exercises the corrected E/I/S/V mapping with distinct values per channel.
- [x] Unit test added: handles `state_json` returned as a JSON string (asyncpg codec variance).
- [x] Unit test added: defaults missing `E` key to 0.5 (matches `_row_to_agent_state.energy` default in `db/base.py:63`).
- [x] Existing `tests/test_lineage_continuity_helper.py::test_reconstruct_eisv_series_maps_rows_to_per_dim_lists` updated — it was authored against the buggy mapping and would have continued locking the bug in place.
- [x] `tests/test_trajectory_continuity.py` (22 tests) — feeds pre-built series via `_stub_reconstruct`, bypasses the reader, remains valid.
- [x] Local: `./scripts/dev/test-cache.sh --staged` passes (8943 passed / 0 failed / 34 skipped; coverage 79.82%).
- [x] **Empirical replay**: 0 of 268 plausible verdicts flip under the corrected reader; min post-fix plausibility 0.8686 (0.169 above threshold). Replay script at `/tmp/r1_flip_analysis.py`.