### PR TITLE
Add EISV outcome inventory analysis tools

### DIFF
--- a/scripts/analysis/eisv_ablation_matrix.py
+++ b/scripts/analysis/eisv_ablation_matrix.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Run a compact EISV ablation matrix across scopes, windows, and lead times.
+
+This wraps ``eisv_skeptic_report`` so skeptical checks are reproducible instead
+of depending on ad-hoc shell loops. It still makes the same limited claim: do
+EISV/prior-state candidates beat the boring previous-outcome baseline on both
+ranking and calibration in each slice?
+
+Usage:
+    python3 scripts/analysis/eisv_ablation_matrix.py --windows 30,90 --leads 0,30
+    python3 scripts/analysis/eisv_ablation_matrix.py --scopes strict,task --output data/analysis/eisv_ablation_matrix.md
+
+Env:
+    GOVERNANCE_DATABASE_URL  (default inherited from eisv_skeptic_report; redact in reports)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+if __package__ is None or __package__ == "":
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.analysis.eisv_skeptic_report import (
+    DEFAULT_DB_URL,
+    STRICT_OUTCOMES,
+    TASK_OUTCOMES,
+    ModelScore,
+    OutcomeRow,
+    build_model_scores,
+    fetch_rows,
+    score_deltas_vs_baseline,
+    summarize_conclusion,
+)
+
+
+@dataclass(frozen=True)
+class AblationMatrixRow:
+    scope: str
+    window_days: int
+    lead_minutes: float
+    trusted: int
+    bad: int
+    prior_state: int
+    prior_risk: int
+    baseline_auc: float | None
+    baseline_brier: float | None
+    best_candidate: str | None
+    best_auc_delta: float | None
+    best_brier_improvement: float | None
+    beats_both: bool
+    conclusion: str
+
+
+def _fmt_float(value: float | None, digits: int = 3) -> str:
+    if value is None:
+        return "-"
+    return f"{value:.{digits}f}"
+
+
+def _fmt_lead(value: float) -> str:
+    return f"{value:g}"
+
+
+def _baseline(scores: Sequence[ModelScore]) -> ModelScore | None:
+    return next((score for score in scores if score.name == "previous_outcome_bad"), None)
+
+
+def build_matrix_row(
+    rows: Sequence[OutcomeRow],
+    *,
+    scope: str,
+    window_days: int,
+    lead_minutes: float,
+    train_fraction: float = 0.7,
+    min_feature_rows: int = 30,
+) -> AblationMatrixRow:
+    """Summarize one scope/window/lead ablation slice."""
+    scores = build_model_scores(
+        rows,
+        train_fraction=train_fraction,
+        min_feature_rows=min_feature_rows,
+    )
+    baseline = _baseline(scores)
+    deltas = score_deltas_vs_baseline(scores)
+    best_delta = max(
+        deltas,
+        key=lambda delta: (
+            delta.beats_baseline,
+            delta.auc_delta,
+            delta.brier_improvement,
+        ),
+        default=None,
+    )
+    return AblationMatrixRow(
+        scope=scope,
+        window_days=window_days,
+        lead_minutes=lead_minutes,
+        trusted=len(rows),
+        bad=sum(int(row.is_bad) for row in rows),
+        prior_state=sum(1 for row in rows if row.prior_state_age_seconds is not None),
+        prior_risk=sum(1 for row in rows if row.prior_risk is not None),
+        baseline_auc=baseline.auc if baseline else None,
+        baseline_brier=baseline.brier if baseline else None,
+        best_candidate=best_delta.name if best_delta else None,
+        best_auc_delta=best_delta.auc_delta if best_delta else None,
+        best_brier_improvement=(best_delta.brier_improvement if best_delta else None),
+        beats_both=bool(best_delta and best_delta.beats_baseline),
+        conclusion=summarize_conclusion(rows, scores),
+    )
+
+
+def format_matrix_report(
+    rows: Sequence[AblationMatrixRow],
+    *,
+    generated_at: datetime | None = None,
+) -> str:
+    """Render a compact markdown table for skeptical multi-slice reporting."""
+    generated_at = generated_at or datetime.now(timezone.utc)
+    lines = [
+        "# EISV Ablation Matrix",
+        "",
+        f"Generated: {generated_at.strftime('%Y-%m-%d %H:%M:%S %Z')}",
+        "",
+        "Positive AUC delta means better ranking than `previous_outcome_bad`; positive Brier improvement means lower probability error. `Beats both?` is the conservative quick read.",
+        "",
+        "| Scope | Window days | Lead min | Trusted | Bad | Prior state | Prior risk | Baseline AUC | Baseline Brier | Best EISV/prior model | AUC delta | Brier improvement | Beats both? | Conclusion |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---|",
+    ]
+    if rows:
+        for row in rows:
+            lines.append(
+                "| "
+                f"{row.scope} | {row.window_days} | {_fmt_lead(row.lead_minutes)} "
+                f"| {row.trusted} | {row.bad} | {row.prior_state} | {row.prior_risk} "
+                f"| {_fmt_float(row.baseline_auc, 3)} | {_fmt_float(row.baseline_brier, 4)} "
+                f"| {row.best_candidate or '-'} | {_fmt_float(row.best_auc_delta, 3)} "
+                f"| {_fmt_float(row.best_brier_improvement, 4)} "
+                f"| {'yes' if row.beats_both else 'no'} | {row.conclusion} |"
+            )
+    else:
+        lines.append("| - | - | - | 0 | 0 | 0 | 0 | - | - | - | - | - | no | no rows |")
+    lines.extend(
+        [
+            "",
+            "Interpretation rule: this matrix does not validate EISV as ontology. It only checks whether EISV/prior-state fields add measurable predictive signal over a simple previous-outcome baseline across slices.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _parse_int_list(raw: str) -> list[int]:
+    return [int(part.strip()) for part in raw.split(",") if part.strip()]
+
+
+def _parse_float_list(raw: str) -> list[float]:
+    return [float(part.strip()) for part in raw.split(",") if part.strip()]
+
+
+def _parse_scope_list(raw: str) -> list[str]:
+    scopes = [part.strip() for part in raw.split(",") if part.strip()]
+    invalid = [scope for scope in scopes if scope not in {"strict", "task"}]
+    if invalid:
+        raise argparse.ArgumentTypeError(f"invalid scope(s): {', '.join(invalid)}")
+    return scopes
+
+
+async def build_matrix_from_db(
+    db_url: str,
+    *,
+    scopes: Sequence[str],
+    windows: Sequence[int],
+    leads: Sequence[float],
+    train_fraction: float = 0.7,
+    min_feature_rows: int = 30,
+) -> list[AblationMatrixRow]:
+    matrix_rows: list[AblationMatrixRow] = []
+    for scope in scopes:
+        outcome_types = STRICT_OUTCOMES if scope == "strict" else TASK_OUTCOMES
+        for window_days in windows:
+            for lead_minutes in leads:
+                outcome_rows = await fetch_rows(
+                    db_url,
+                    window_days=window_days,
+                    lead_minutes=lead_minutes,
+                    outcome_types=outcome_types,
+                )
+                matrix_rows.append(
+                    build_matrix_row(
+                        outcome_rows,
+                        scope=scope,
+                        window_days=window_days,
+                        lead_minutes=lead_minutes,
+                        train_fraction=train_fraction,
+                        min_feature_rows=min_feature_rows,
+                    )
+                )
+    return matrix_rows
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db-url", default=DEFAULT_DB_URL)
+    parser.add_argument("--scopes", type=_parse_scope_list, default="strict,task")
+    parser.add_argument("--windows", type=_parse_int_list, default="30,90,365")
+    parser.add_argument("--leads", type=_parse_float_list, default="0,5,30")
+    parser.add_argument("--train-fraction", type=float, default=0.7)
+    parser.add_argument("--min-feature-rows", type=int, default=30)
+    parser.add_argument("--output", help="Optional markdown output path")
+    return parser.parse_args(argv)
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    if not (0.1 <= args.train_fraction <= 0.9):
+        print("error: --train-fraction must be between 0.1 and 0.9")
+        return 2
+    rows = await build_matrix_from_db(
+        args.db_url,
+        scopes=args.scopes,
+        windows=args.windows,
+        leads=args.leads,
+        train_fraction=args.train_fraction,
+        min_feature_rows=args.min_feature_rows,
+    )
+    report = format_matrix_report(rows)
+    if args.output:
+        path = Path(args.output)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(report + "\n", encoding="utf-8")
+        print(f"Wrote {path}")
+    else:
+        print(report)
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    return asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/analysis/eisv_skeptic_report.py
+++ b/scripts/analysis/eisv_skeptic_report.py
@@ -47,6 +47,14 @@ TASK_OUTCOMES = (
 
 SMOOTHING_ALPHA = 1.0
 
+EISV_PRIOR_STATE_MODELS = (
+    "previous_bad_plus_prior_risk",
+    "prior_risk_binned",
+    "prior_phi_binned",
+    "prior_s_binned",
+    "prior_verdict",
+)
+
 
 @dataclass(frozen=True)
 class OutcomeRow:
@@ -87,6 +95,54 @@ class ModelScore:
     auc: float | None
     brier: float | None
     note: str = ""
+
+
+@dataclass(frozen=True)
+class ScoreDelta:
+    """A paired scoreboard delta against a named boring baseline."""
+
+    name: str
+    baseline_name: str
+    auc_delta: float
+    brier_improvement: float
+    beats_baseline: bool
+
+
+def score_deltas_vs_baseline(
+    scores: Sequence[ModelScore],
+    *,
+    baseline_name: str = "previous_outcome_bad",
+    candidate_names: Sequence[str] = EISV_PRIOR_STATE_MODELS,
+) -> list[ScoreDelta]:
+    """Return AUC/Brier deltas for EISV/prior-state candidates vs baseline.
+
+    Positive AUC delta means better ranking than the baseline. Positive Brier
+    improvement means lower probability error than the baseline. Candidates with
+    missing AUC or Brier are skipped so single-class/sparse slices do not pretend
+    to have measurable lift.
+    """
+    baseline = next((score for score in scores if score.name == baseline_name), None)
+    if baseline is None or baseline.auc is None or baseline.brier is None:
+        return []
+
+    deltas: list[ScoreDelta] = []
+    for score in scores:
+        if score.name not in candidate_names:
+            continue
+        if score.auc is None or score.brier is None:
+            continue
+        auc_delta = round(score.auc - baseline.auc, 12)
+        brier_improvement = round(baseline.brier - score.brier, 12)
+        deltas.append(
+            ScoreDelta(
+                name=score.name,
+                baseline_name=baseline_name,
+                auc_delta=auc_delta,
+                brier_improvement=brier_improvement,
+                beats_baseline=auc_delta > 0.0 and brier_improvement > 0.0,
+            )
+        )
+    return deltas
 
 
 def _to_float(value: Any) -> float | None:
@@ -767,6 +823,25 @@ def build_report(
             f"| {_fmt_float(score.auc, 3)} | {_fmt_float(score.brier, 4)} | {score.note} |"
         )
     a("")
+
+    a("## Ablation vs Previous-Outcome Baseline")
+    a("")
+    a("Positive AUC delta means better ranking; positive Brier improvement means lower probability error.")
+    a("")
+    a("| EISV/prior-state model | AUC delta | Brier improvement | Beats both? |")
+    a("|---|---:|---:|---|")
+    deltas = score_deltas_vs_baseline(scores)
+    if deltas:
+        for delta in deltas:
+            a(
+                f"| `{delta.name}` | {_fmt_float(delta.auc_delta, 3)} "
+                f"| {_fmt_float(delta.brier_improvement, 4)} "
+                f"| {'yes' if delta.beats_baseline else 'no'} |"
+            )
+    else:
+        a("| (insufficient paired baseline/candidate metrics) | - | - | no |")
+    a("")
+
     a("## Conclusion")
     a("")
     a(conclusion)

--- a/scripts/analysis/eisv_skeptic_report.py
+++ b/scripts/analysis/eisv_skeptic_report.py
@@ -83,6 +83,7 @@ class OutcomeRow:
     snapshot_v: float | None
     snapshot_phi: float | None
     snapshot_coherence: float | None
+    row_key: str | None = None
     previous_bad: bool | None = None
 
 
@@ -95,6 +96,10 @@ class ModelScore:
     auc: float | None
     brier: float | None
     note: str = ""
+    scored_row_keys: tuple[Any, ...] = ()
+    y_true: tuple[int, ...] = ()
+    y_prob: tuple[float, ...] = ()
+    y_auc_score: tuple[float, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -105,7 +110,69 @@ class ScoreDelta:
     baseline_name: str
     auc_delta: float
     brier_improvement: float
+    paired_n: int
     beats_baseline: bool
+
+
+def _score_row_key(row: OutcomeRow) -> Any:
+    return row.row_key if row.row_key is not None else id(row)
+
+
+def _paired_model_metrics(
+    baseline: ModelScore,
+    candidate: ModelScore,
+) -> tuple[float | None, float | None, float | None, float | None, int]:
+    """Return candidate and baseline metrics over the candidate-covered rows."""
+    baseline_n = len(baseline.scored_row_keys)
+    candidate_n = len(candidate.scored_row_keys)
+    if not (
+        baseline_n
+        and len(baseline.y_true) == baseline_n
+        and len(baseline.y_prob) == baseline_n
+        and len(baseline.y_auc_score) == baseline_n
+        and candidate_n
+        and len(candidate.y_true) == candidate_n
+        and len(candidate.y_prob) == candidate_n
+        and len(candidate.y_auc_score) == candidate_n
+    ):
+        return (
+            candidate.auc,
+            candidate.brier,
+            baseline.auc,
+            baseline.brier,
+            min(baseline.n_test_scored, candidate.n_test_scored),
+        )
+
+    baseline_by_key = {
+        key: idx for idx, key in enumerate(baseline.scored_row_keys)
+    }
+    paired_true: list[int] = []
+    paired_candidate_prob: list[float] = []
+    paired_candidate_auc_score: list[float] = []
+    paired_baseline_prob: list[float] = []
+    paired_baseline_auc_score: list[float] = []
+    for candidate_idx, key in enumerate(candidate.scored_row_keys):
+        baseline_idx = baseline_by_key.get(key)
+        if baseline_idx is None:
+            continue
+        if baseline.y_true[baseline_idx] != candidate.y_true[candidate_idx]:
+            continue
+        paired_true.append(candidate.y_true[candidate_idx])
+        paired_candidate_prob.append(candidate.y_prob[candidate_idx])
+        paired_candidate_auc_score.append(candidate.y_auc_score[candidate_idx])
+        paired_baseline_prob.append(baseline.y_prob[baseline_idx])
+        paired_baseline_auc_score.append(baseline.y_auc_score[baseline_idx])
+
+    if not paired_true:
+        return None, None, None, None, 0
+
+    return (
+        auc_score(paired_true, paired_candidate_auc_score),
+        brier_score(paired_true, paired_candidate_prob),
+        auc_score(paired_true, paired_baseline_auc_score),
+        brier_score(paired_true, paired_baseline_prob),
+        len(paired_true),
+    )
 
 
 def score_deltas_vs_baseline(
@@ -122,23 +189,32 @@ def score_deltas_vs_baseline(
     to have measurable lift.
     """
     baseline = next((score for score in scores if score.name == baseline_name), None)
-    if baseline is None or baseline.auc is None or baseline.brier is None:
+    if baseline is None:
         return []
 
     deltas: list[ScoreDelta] = []
     for score in scores:
         if score.name not in candidate_names:
             continue
-        if score.auc is None or score.brier is None:
+        candidate_auc, candidate_brier, baseline_auc, baseline_brier, paired_n = (
+            _paired_model_metrics(baseline, score)
+        )
+        if (
+            candidate_auc is None
+            or candidate_brier is None
+            or baseline_auc is None
+            or baseline_brier is None
+        ):
             continue
-        auc_delta = round(score.auc - baseline.auc, 12)
-        brier_improvement = round(baseline.brier - score.brier, 12)
+        auc_delta = round(candidate_auc - baseline_auc, 12)
+        brier_improvement = round(baseline_brier - candidate_brier, 12)
         deltas.append(
             ScoreDelta(
                 name=score.name,
                 baseline_name=baseline_name,
                 auc_delta=auc_delta,
                 brier_improvement=brier_improvement,
+                paired_n=paired_n,
                 beats_baseline=auc_delta > 0.0 and brier_improvement > 0.0,
             )
         )
@@ -282,11 +358,13 @@ def _score_predictions(
     y_true: list[int] = []
     y_prob: list[float] = []
     y_auc_score: list[float] = []
+    scored_row_keys: list[Any] = []
     for row in test_rows:
         prediction = predict_fn(row)
         if prediction is None:
             continue
         probability = _clamp_probability(float(prediction))
+        scored_row_keys.append(_score_row_key(row))
         y_true.append(int(row.is_bad))
         y_prob.append(probability)
         if raw_score_fn is None:
@@ -302,6 +380,10 @@ def _score_predictions(
         auc=auc_score(y_true, y_auc_score),
         brier=brier_score(y_true, y_prob),
         note=note,
+        scored_row_keys=tuple(scored_row_keys),
+        y_true=tuple(y_true),
+        y_prob=tuple(y_prob),
+        y_auc_score=tuple(y_auc_score),
     )
 
 
@@ -614,41 +696,34 @@ def summarize_conclusion(rows: Sequence[OutcomeRow], scores: Sequence[ModelScore
     if bad < 10:
         return "INCONCLUSIVE: fewer than 10 bad outcomes; predictive lift is too fragile."
 
-    baseline = next((s for s in scores if s.name == "previous_outcome_bad"), None)
-    combined = next((s for s in scores if s.name == "previous_bad_plus_prior_risk"), None)
-    risk = next((s for s in scores if s.name == "prior_risk_binned"), None)
-    phi = next((s for s in scores if s.name == "prior_phi_binned"), None)
-    entropy = next((s for s in scores if s.name == "prior_s_binned"), None)
-    verdict = next((s for s in scores if s.name == "prior_verdict"), None)
-
-    candidates = [
-        s
-        for s in (combined, risk, phi, entropy, verdict)
-        if s and s.auc is not None and s.brier is not None
-    ]
-    if not candidates:
+    deltas = score_deltas_vs_baseline(scores)
+    if not deltas:
         return "INCONCLUSIVE: EISV/prior-state coverage is too low for model comparison."
 
-    best = max(candidates, key=lambda s: (s.auc or 0.0, -(s.brier or 1.0)))
-    if baseline and baseline.auc is not None and baseline.brier is not None:
-        auc_lift = (best.auc or 0.0) - baseline.auc
-        brier_lift = baseline.brier - (best.brier or baseline.brier)
-        if auc_lift >= 0.03 and brier_lift >= 0.001:
-            return (
-                "KEEP TESTING: EISV/prior-state features show modest lift over the "
-                f"previous-outcome baseline (best={best.name}, AUC lift={auc_lift:.3f}, "
-                f"Brier improvement={brier_lift:.4f})."
-            )
-        if auc_lift <= 0.0 or brier_lift <= 0.0:
-            return (
-                "SKEPTICAL: EISV/prior-state features do not beat the boring "
-                "previous-outcome baseline across both ranking and calibration "
-                f"in this split (best={best.name}, AUC lift={auc_lift:.3f}, "
-                f"Brier improvement={brier_lift:.4f})."
-            )
-    if best.auc is not None and best.auc < 0.55:
+    best_delta = max(
+        deltas,
+        key=lambda d: (d.beats_baseline, d.auc_delta, d.brier_improvement),
+    )
+    best = next((s for s in scores if s.name == best_delta.name), None)
+    if best_delta.auc_delta >= 0.03 and best_delta.brier_improvement >= 0.001:
+        return (
+            "KEEP TESTING: EISV/prior-state features show modest lift over the "
+            f"previous-outcome baseline (best={best_delta.name}, "
+            f"paired N={best_delta.paired_n}, AUC lift={best_delta.auc_delta:.3f}, "
+            f"Brier improvement={best_delta.brier_improvement:.4f})."
+        )
+    if best_delta.auc_delta <= 0.0 or best_delta.brier_improvement <= 0.0:
+        return (
+            "SKEPTICAL: EISV/prior-state features do not beat the boring "
+            "previous-outcome baseline across both ranking and calibration "
+            f"in this split (best={best_delta.name}, paired N={best_delta.paired_n}, "
+            f"AUC lift={best_delta.auc_delta:.3f}, "
+            f"Brier improvement={best_delta.brier_improvement:.4f})."
+        )
+    if best is not None and best.auc is not None and best.auc < 0.55:
         return f"SKEPTICAL: best EISV/prior-state AUC is weak ({best.name} AUC={best.auc:.3f})."
-    return f"WEAK SIGNAL: {best.name} has some predictive signal, but compare across more windows."
+    best_name = best.name if best is not None else best_delta.name
+    return f"WEAK SIGNAL: {best_name} has some predictive signal, but compare across more windows."
 
 
 def build_report(
@@ -826,20 +901,25 @@ def build_report(
 
     a("## Ablation vs Previous-Outcome Baseline")
     a("")
+    a(
+        "Deltas compare each candidate against the previous-outcome baseline over "
+        "the candidate-scored rows."
+    )
     a("Positive AUC delta means better ranking; positive Brier improvement means lower probability error.")
     a("")
-    a("| EISV/prior-state model | AUC delta | Brier improvement | Beats both? |")
-    a("|---|---:|---:|---|")
+    a("| EISV/prior-state model | Paired N | AUC delta | Brier improvement | Beats both? |")
+    a("|---|---:|---:|---:|---|")
     deltas = score_deltas_vs_baseline(scores)
     if deltas:
         for delta in deltas:
             a(
-                f"| `{delta.name}` | {_fmt_float(delta.auc_delta, 3)} "
+                f"| `{delta.name}` | {delta.paired_n} "
+                f"| {_fmt_float(delta.auc_delta, 3)} "
                 f"| {_fmt_float(delta.brier_improvement, 4)} "
                 f"| {'yes' if delta.beats_baseline else 'no'} |"
             )
     else:
-        a("| (insufficient paired baseline/candidate metrics) | - | - | no |")
+        a("| (insufficient paired baseline/candidate metrics) | 0 | - | - | no |")
     a("")
 
     a("## Conclusion")
@@ -868,6 +948,7 @@ def _row_from_record(record: Any) -> OutcomeRow:
     detail = _parse_detail(record.get("detail"))
     return OutcomeRow(
         ts=record["ts"],
+        row_key=str(record["outcome_id"]) if record.get("outcome_id") is not None else None,
         agent_id=record["agent_id"],
         outcome_type=record["outcome_type"],
         is_bad=bool(record["is_bad"]),
@@ -914,6 +995,7 @@ async def fetch_rows(
             """
             SELECT
                 o.ts,
+                o.outcome_id,
                 o.agent_id,
                 o.outcome_type,
                 o.outcome_score,

--- a/scripts/analysis/outcome_inventory.py
+++ b/scripts/analysis/outcome_inventory.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Inventory outcome-event provenance and prior-state coverage.
+
+This is a read-only diagnostic for UNITARES/EISV validation work. It does not
+claim predictive lift; it answers the prerequisite question: what outcome data
+exists, how objective is it, how many failures are present, and whether prior
+agent state is available at prospective lead times.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+DEFAULT_DB_URL = os.environ.get(
+    "GOVERNANCE_DATABASE_URL",
+    "postgresql://postgres:***@localhost:5432/governance",
+)
+
+STRICT_OUTCOMES = frozenset({"test_passed", "test_failed", "tool_rejected"})
+TASK_OUTCOMES = frozenset(
+    {
+        "test_passed",
+        "test_failed",
+        "tool_rejected",
+        "task_completed",
+        "task_failed",
+    }
+)
+
+
+@dataclass(frozen=True)
+class OutcomeInventoryRow:
+    """One outcome row with enough metadata for inventory aggregation."""
+
+    outcome_type: str
+    is_bad: bool
+    verification_source: str | None
+    detail: Mapping[str, Any] = field(default_factory=dict)
+    prior_state_by_lead: Mapping[float, bool] = field(default_factory=dict)
+
+
+@dataclass
+class InventoryBucket:
+    """Aggregated outcome bucket for one evidence/provenance lane."""
+
+    scope: str
+    outcome_type: str
+    verification_source: str
+    hard_exogenous: bool
+    eprocess_eligible: bool
+    prediction_binding: str
+    n_total: int = 0
+    n_bad: int = 0
+    prediction_id_count: int = 0
+    prior_state_counts: dict[float, int] = field(default_factory=dict)
+
+    @property
+    def bad_rate(self) -> float | None:
+        """Return bad-outcome rate for this bucket, or None if empty."""
+        if self.n_total == 0:
+            return None
+        return self.n_bad / self.n_total
+
+
+@dataclass(frozen=True)
+class OutcomeInventory:
+    """Complete outcome inventory plus totals used in the printed report."""
+
+    buckets: tuple[InventoryBucket, ...]
+    lead_minutes: tuple[float, ...]
+    total_outcomes: int
+    total_bad: int
+    strict_outcomes: int
+    strict_bad: int
+    hard_exogenous_count: int
+    eprocess_eligible_count: int
+    total_prediction_id_count: int
+
+    @property
+    def total_bad_rate(self) -> float | None:
+        """Return global bad-outcome rate, or None if there are no outcomes."""
+        if self.total_outcomes == 0:
+            return None
+        return self.total_bad / self.total_outcomes
+
+
+def _truthy(value: Any) -> bool:
+    """Interpret JSON-ish booleans without treating arbitrary strings as true."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "t", "yes", "y"}
+    return False
+
+
+def _normalized_detail(detail: Mapping[str, Any] | str | None) -> Mapping[str, Any]:
+    """Return a dict-like detail mapping from asyncpg JSONB or test fixtures."""
+    if detail is None:
+        return {}
+    if isinstance(detail, str):
+        try:
+            parsed = json.loads(detail)
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, Mapping) else {}
+    return detail if isinstance(detail, Mapping) else {}
+
+
+def _verification_source(row: OutcomeInventoryRow) -> str:
+    """Prefer promoted verification_source column; fall back to detail JSON."""
+    if row.verification_source:
+        return row.verification_source
+    detail = _normalized_detail(row.detail)
+    source = detail.get("verification_source")
+    return str(source) if source else "unknown"
+
+
+def _scope_for_outcome(outcome_type: str) -> str:
+    """Classify rows into strict, broader task, or other outcome scopes."""
+    if outcome_type in STRICT_OUTCOMES:
+        return "strict"
+    if outcome_type in TASK_OUTCOMES:
+        return "task"
+    return "other"
+
+
+def _grouped_outcome_type(outcome_type: str) -> str:
+    """Group pass/fail pairs where the inventory question is failure coverage."""
+    if outcome_type in {"test_passed", "test_failed"}:
+        return "test_passed/test_failed"
+    return outcome_type
+
+
+def _prediction_binding(detail: Mapping[str, Any]) -> str:
+    """Return prediction-binding label, using a stable 'none' value when absent."""
+    binding = detail.get("prediction_binding")
+    return str(binding) if binding else "none"
+
+
+def _has_prediction_id(detail: Mapping[str, Any]) -> bool:
+    """Return whether an outcome references an explicit prediction id."""
+    prediction_id = detail.get("prediction_id")
+    return prediction_id not in (None, "")
+
+
+def build_inventory(
+    rows: Sequence[OutcomeInventoryRow],
+    *,
+    lead_minutes: Sequence[float],
+) -> OutcomeInventory:
+    """Aggregate outcome rows by provenance, objectivity, and lead coverage."""
+    leads = tuple(float(lead) for lead in lead_minutes)
+    buckets: dict[tuple[str, str, str, bool, bool, str], InventoryBucket] = {}
+
+    total_outcomes = 0
+    total_bad = 0
+    strict_outcomes = 0
+    strict_bad = 0
+    hard_exogenous_count = 0
+    eprocess_eligible_count = 0
+    total_prediction_id_count = 0
+
+    for row in rows:
+        detail = _normalized_detail(row.detail)
+        scope = _scope_for_outcome(row.outcome_type)
+        hard_exogenous = _truthy(detail.get("hard_exogenous"))
+        eprocess_eligible = _truthy(detail.get("eprocess_eligible"))
+        prediction_binding = _prediction_binding(detail)
+        key = (
+            scope,
+            _grouped_outcome_type(row.outcome_type),
+            _verification_source(row),
+            hard_exogenous,
+            eprocess_eligible,
+            prediction_binding,
+        )
+        bucket = buckets.get(key)
+        if bucket is None:
+            bucket = InventoryBucket(
+                scope=key[0],
+                outcome_type=key[1],
+                verification_source=key[2],
+                hard_exogenous=key[3],
+                eprocess_eligible=key[4],
+                prediction_binding=key[5],
+                prior_state_counts={lead: 0 for lead in leads},
+            )
+            buckets[key] = bucket
+
+        bucket.n_total += 1
+        total_outcomes += 1
+        if row.is_bad:
+            bucket.n_bad += 1
+            total_bad += 1
+            if scope == "strict":
+                strict_bad += 1
+        if scope == "strict":
+            strict_outcomes += 1
+        if hard_exogenous:
+            hard_exogenous_count += 1
+        if eprocess_eligible:
+            eprocess_eligible_count += 1
+        if _has_prediction_id(detail):
+            bucket.prediction_id_count += 1
+            total_prediction_id_count += 1
+        for lead in leads:
+            if bool(row.prior_state_by_lead.get(lead, False)):
+                bucket.prior_state_counts[lead] += 1
+
+    sorted_buckets = tuple(
+        sorted(
+            buckets.values(),
+            key=lambda bucket: (
+                bucket.scope,
+                bucket.outcome_type,
+                bucket.verification_source,
+                bucket.hard_exogenous,
+                bucket.eprocess_eligible,
+                bucket.prediction_binding,
+            ),
+        )
+    )
+    return OutcomeInventory(
+        buckets=sorted_buckets,
+        lead_minutes=leads,
+        total_outcomes=total_outcomes,
+        total_bad=total_bad,
+        strict_outcomes=strict_outcomes,
+        strict_bad=strict_bad,
+        hard_exogenous_count=hard_exogenous_count,
+        eprocess_eligible_count=eprocess_eligible_count,
+        total_prediction_id_count=total_prediction_id_count,
+    )
+
+
+def _format_rate(rate: float | None) -> str:
+    """Format a bad-rate value for CLI output."""
+    if rate is None:
+        return "n/a"
+    return f"{rate:.3f}"
+
+
+def _format_lead(lead: float) -> str:
+    """Format a lead-minute value for stable column names."""
+    return str(int(lead)) if float(lead).is_integer() else str(lead).replace(".", "p")
+
+
+def format_inventory_report(
+    inventory: OutcomeInventory,
+    *,
+    window_days: int,
+    lead_minutes: Sequence[float],
+) -> str:
+    """Render a compact terminal-friendly markdown report."""
+    leads = tuple(float(lead) for lead in lead_minutes)
+    lines = [
+        "# Outcome Inventory",
+        "",
+        f"window_days: {window_days}",
+        f"lead_minutes: {', '.join(_format_lead(lead) for lead in leads)}",
+        f"total_outcomes: {inventory.total_outcomes}",
+        f"total_bad: {inventory.total_bad}",
+        f"total_bad_rate: {_format_rate(inventory.total_bad_rate)}",
+        f"strict_outcomes: {inventory.strict_outcomes}",
+        f"strict_bad: {inventory.strict_bad}",
+        f"hard_exogenous: {inventory.hard_exogenous_count}",
+        f"eprocess_eligible: {inventory.eprocess_eligible_count}",
+        f"prediction_id_present: {inventory.total_prediction_id_count}",
+        "",
+    ]
+
+    lead_headers = [f"prior_state_{_format_lead(lead)}m" for lead in leads]
+    headers = [
+        "scope",
+        "outcome_type",
+        "verification_source",
+        "hard_exogenous",
+        "eprocess_eligible",
+        "prediction_binding",
+        "n_total",
+        "n_bad",
+        "bad_rate",
+        "prediction_id",
+        *lead_headers,
+    ]
+    lines.append("\t".join(headers))
+    for bucket in inventory.buckets:
+        prior_columns = [
+            f"{bucket.prior_state_counts.get(lead, 0)}/{bucket.n_total}"
+            for lead in leads
+        ]
+        lines.append(
+            "\t".join(
+                [
+                    bucket.scope,
+                    bucket.outcome_type,
+                    bucket.verification_source,
+                    str(bucket.hard_exogenous).lower(),
+                    str(bucket.eprocess_eligible).lower(),
+                    bucket.prediction_binding,
+                    str(bucket.n_total),
+                    str(bucket.n_bad),
+                    _format_rate(bucket.bad_rate),
+                    str(bucket.prediction_id_count),
+                    *prior_columns,
+                ]
+            )
+        )
+    return "\n".join(lines)
+
+
+def parse_leads(value: str) -> tuple[float, ...]:
+    """Parse comma-separated lead-minute values."""
+    leads = tuple(float(part.strip()) for part in value.split(",") if part.strip())
+    if not leads:
+        raise argparse.ArgumentTypeError("at least one lead minute is required")
+    return leads
+
+
+def _lead_alias(index: int) -> str:
+    """Return the SQL alias used for a lead index."""
+    return f"prior_state_lead_{index}"
+
+
+def _build_fetch_query(lead_minutes: Sequence[float]) -> str:
+    """Build the read-only outcome inventory query for the requested leads."""
+    lead_selects = []
+    for index, _lead in enumerate(lead_minutes):
+        placeholder = index + 2
+        lead_selects.append(
+            f"""
+                EXISTS (
+                    SELECT 1
+                    FROM core.identities ident
+                    JOIN core.agent_state state
+                      ON state.identity_id = ident.identity_id
+                    WHERE ident.agent_id = o.agent_id
+                      AND state.synthetic IS NOT TRUE
+                      AND state.recorded_at <= o.ts - (${placeholder}::double precision * INTERVAL '1 minute')
+                    LIMIT 1
+                ) AS {_lead_alias(index)}
+            """
+        )
+    return f"""
+        SELECT
+            o.outcome_type,
+            o.is_bad,
+            COALESCE(o.verification_source, o.detail->>'verification_source') AS verification_source,
+            o.detail,
+            {", ".join(lead_selects)}
+        FROM audit.outcome_events o
+        WHERE o.ts >= now() - ($1::int * INTERVAL '1 day')
+        ORDER BY o.ts ASC
+    """
+
+
+def _row_from_record(record: Mapping[str, Any], lead_minutes: Sequence[float]) -> OutcomeInventoryRow:
+    """Convert an asyncpg record to an inventory row."""
+    data = dict(record)
+    prior_state_by_lead = {
+        float(lead): bool(data[_lead_alias(index)])
+        for index, lead in enumerate(lead_minutes)
+    }
+    return OutcomeInventoryRow(
+        outcome_type=str(data["outcome_type"]),
+        is_bad=bool(data["is_bad"]),
+        verification_source=data.get("verification_source"),
+        detail=_normalized_detail(data.get("detail")),
+        prior_state_by_lead=prior_state_by_lead,
+    )
+
+
+async def fetch_rows(
+    db_url: str,
+    *,
+    window_days: int,
+    lead_minutes: Sequence[float],
+) -> list[OutcomeInventoryRow]:
+    """Fetch outcome inventory rows from PostgreSQL without mutating state."""
+    try:
+        asyncpg = importlib.import_module("asyncpg")
+    except ImportError:
+        print("error: asyncpg not installed. Install with `pip install asyncpg`.", file=sys.stderr)
+        raise SystemExit(1) from None
+
+    leads = tuple(float(lead) for lead in lead_minutes)
+    conn = await asyncpg.connect(db_url)
+    try:
+        records = await conn.fetch(_build_fetch_query(leads), window_days, *leads)
+    finally:
+        await conn.close()
+    return [_row_from_record(record, leads) for record in records]
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--window-days", type=int, default=365)
+    parser.add_argument("--leads", type=parse_leads, default=(0.0, 5.0, 30.0))
+    parser.add_argument("--db-url", default=DEFAULT_DB_URL)
+    parser.add_argument("--output", help="Optional report output path")
+    return parser.parse_args(argv)
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    """Run the inventory query and print or write the report."""
+    rows = await fetch_rows(
+        args.db_url,
+        window_days=args.window_days,
+        lead_minutes=args.leads,
+    )
+    inventory = build_inventory(rows, lead_minutes=args.leads)
+    report = format_inventory_report(
+        inventory,
+        window_days=args.window_days,
+        lead_minutes=args.leads,
+    )
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(report + "\n", encoding="utf-8")
+        print(f"Wrote {output_path}")
+    else:
+        print(report)
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point."""
+    args = parse_args(argv)
+    return asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/mcp_handlers/observability/outcome_events.py
+++ b/src/mcp_handlers/observability/outcome_events.py
@@ -273,6 +273,7 @@ async def _record_outcome_event_inline(arguments: Dict[str, Any]) -> Dict[str, A
     detail["eprocess_eligible"] = eprocess_eligible
     detail["prediction_id"] = prediction_id
     detail["prediction_source"] = prediction_source
+    detail["prediction_binding"] = prediction_binding
     # Pydantic validation (params_step.py) fills defaults before the MCP
     # entry point runs, so the schema default ("agent_reported_tool_result")
     # is already present in `arguments` for that path. In-process callers

--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -163,8 +163,11 @@ def _derive_outcome(evidence: dict) -> tuple:
     if is_bad is None:
         exit_code = evidence.get("exit_code")
         is_bad = (exit_code is not None and exit_code != 0)
-    if evidence.get("kind") == "test":
+    kind = evidence.get("kind")
+    if kind == "test":
         return ("test_failed" if is_bad else "test_passed", is_bad)
+    if kind == "tool_call" and is_bad:
+        return ("tool_rejected", is_bad)
     return ("task_failed" if is_bad else "task_completed", is_bad)
 
 

--- a/tests/test_eisv_ablation_matrix.py
+++ b/tests/test_eisv_ablation_matrix.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import subprocess
+import sys
+
+from scripts.analysis.eisv_ablation_matrix import (
+    AblationMatrixRow,
+    build_matrix_row,
+    format_matrix_report,
+)
+from scripts.analysis.eisv_skeptic_report import OutcomeRow
+
+
+def _row(idx: int, *, bad: bool, risk: float | None, agent: str = "agent-a") -> OutcomeRow:
+    ts = datetime.now(timezone.utc).replace(microsecond=0) + timedelta(minutes=idx)
+    return OutcomeRow(
+        ts=ts,
+        agent_id=agent,
+        outcome_type="task_failed" if bad else "task_completed",
+        is_bad=bad,
+        outcome_score=0.0 if bad else 1.0,
+        verification_source="server_observation",
+        reported_confidence=None,
+        reported_complexity=None,
+        detail={},
+        prior_state_age_seconds=30.0 if risk is not None else None,
+        prior_risk=risk,
+        prior_phi=1.0 - risk if risk is not None else None,
+        prior_verdict="high-risk" if risk is not None and risk > 0.7 else "safe",
+        prior_coherence=0.5,
+        prior_e=0.7,
+        prior_i=0.7,
+        prior_s=risk if risk is not None else None,
+        prior_v=0.0,
+        snapshot_verdict=None,
+        snapshot_e=None,
+        snapshot_i=None,
+        snapshot_s=None,
+        snapshot_v=None,
+        snapshot_phi=None,
+        snapshot_coherence=None,
+    )
+
+
+def test_build_matrix_row_summarizes_baseline_and_best_candidate():
+    rows = []
+    for idx in range(120):
+        bad = idx % 10 in (8, 9)
+        risk = 0.9 if bad else 0.1
+        rows.append(_row(idx, bad=bad, risk=risk, agent=f"agent-{idx % 6}"))
+
+    row = build_matrix_row(
+        rows,
+        scope="task",
+        window_days=90,
+        lead_minutes=30,
+        train_fraction=0.7,
+        min_feature_rows=10,
+    )
+
+    assert row.scope == "task"
+    assert row.window_days == 90
+    assert row.lead_minutes == 30
+    assert row.trusted == 120
+    assert row.bad == 24
+    assert row.prior_state == 120
+    assert row.baseline_auc is not None
+    assert row.baseline_brier is not None
+    assert row.best_candidate in {
+        "previous_bad_plus_prior_risk",
+        "prior_risk_binned",
+        "prior_phi_binned",
+        "prior_s_binned",
+        "prior_verdict",
+    }
+    assert row.best_auc_delta is not None
+    assert row.best_brier_improvement is not None
+    assert isinstance(row.beats_both, bool)
+
+
+def test_format_matrix_report_contains_skeptical_ablation_table():
+    rows = [
+        AblationMatrixRow(
+            scope="task",
+            window_days=90,
+            lead_minutes=30,
+            trusted=120,
+            bad=24,
+            prior_state=120,
+            prior_risk=120,
+            baseline_auc=0.70,
+            baseline_brier=0.12,
+            best_candidate="prior_risk_binned",
+            best_auc_delta=0.03,
+            best_brier_improvement=0.01,
+            beats_both=True,
+            conclusion="KEEP TESTING: synthetic row",
+        )
+    ]
+
+    report = format_matrix_report(rows)
+
+    assert report.startswith("# EISV Ablation Matrix")
+    assert "| Scope | Window days | Lead min | Trusted | Bad | Prior state | Prior risk |" in report
+    assert "| task | 90 | 30 | 120 | 24 | 120 | 120 |" in report
+    assert "prior_risk_binned" in report
+    assert "KEEP TESTING" in report
+
+
+def test_cli_help_runs_when_invoked_as_a_file():
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, "scripts/analysis/eisv_ablation_matrix.py", "--help"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Run a compact EISV ablation matrix" in result.stdout

--- a/tests/test_eisv_skeptic_report.py
+++ b/tests/test_eisv_skeptic_report.py
@@ -11,6 +11,7 @@ from scripts.analysis.eisv_skeptic_report import (
     risk_bucket_rates,
     score_deltas_vs_baseline,
     smoothed_rate,
+    summarize_conclusion,
 )
 
 
@@ -106,6 +107,55 @@ def test_score_deltas_vs_baseline_reports_auc_and_brier_lift():
     assert deltas[1].auc_delta == 0.04
     assert deltas[1].brier_improvement == -0.01
     assert deltas[1].beats_baseline is False
+
+
+def test_score_deltas_use_candidate_covered_rows_for_baseline():
+    deltas = score_deltas_vs_baseline([
+        ModelScore(
+            "previous_outcome_bad",
+            70,
+            30,
+            30,
+            auc=0.0,
+            brier=0.80,
+            scored_row_keys=("a", "b", "c", "d"),
+            y_true=(0, 0, 1, 1),
+            y_prob=(0.9, 0.1, 0.1, 0.9),
+            y_auc_score=(0.9, 0.1, 0.1, 0.9),
+        ),
+        ModelScore(
+            "prior_risk_binned",
+            70,
+            30,
+            2,
+            auc=0.9,
+            brier=0.10,
+            scored_row_keys=("b", "d"),
+            y_true=(0, 1),
+            y_prob=(0.4, 0.6),
+            y_auc_score=(0.4, 0.6),
+        ),
+    ])
+
+    assert len(deltas) == 1
+    assert deltas[0].auc_delta == 0.0
+    assert deltas[0].brier_improvement == -0.15
+    assert deltas[0].paired_n == 2
+    assert deltas[0].beats_baseline is False
+
+
+def test_summarize_conclusion_prefers_candidates_that_beat_both_metrics():
+    rows = [_row(idx, bad=idx % 5 == 0, risk=0.5) for idx in range(120)]
+    scores = [
+        ModelScore("previous_outcome_bad", 84, 36, 36, auc=0.50, brier=0.020),
+        ModelScore("prior_phi_binned", 84, 36, 36, auc=0.95, brier=0.030),
+        ModelScore("prior_risk_binned", 84, 36, 36, auc=0.80, brier=0.0195),
+    ]
+
+    conclusion = summarize_conclusion(rows, scores)
+
+    assert "prior_risk_binned" in conclusion
+    assert "do not beat" not in conclusion
 
 
 def test_build_report_includes_ablation_delta_section():

--- a/tests/test_eisv_skeptic_report.py
+++ b/tests/test_eisv_skeptic_report.py
@@ -1,12 +1,15 @@
 from datetime import datetime, timedelta, timezone
 
 from scripts.analysis.eisv_skeptic_report import (
+    ModelScore,
     OutcomeRow,
     auc_score,
     brier_score,
     build_model_scores,
+    build_report,
     quantile_cuts,
     risk_bucket_rates,
+    score_deltas_vs_baseline,
     smoothed_rate,
 )
 
@@ -86,3 +89,42 @@ def test_build_model_scores_includes_prior_risk_when_covered():
     names = {score.name for score in scores}
     assert "global_bad_rate" in names
     assert "prior_risk_binned" in names
+
+
+def test_score_deltas_vs_baseline_reports_auc_and_brier_lift():
+    deltas = score_deltas_vs_baseline([
+        ModelScore("previous_outcome_bad", 70, 30, 30, auc=0.70, brier=0.120),
+        ModelScore("prior_risk_binned", 70, 30, 30, auc=0.73, brier=0.110),
+        ModelScore("prior_phi_binned", 70, 30, 30, auc=0.74, brier=0.130),
+        ModelScore("prior_verdict", 70, 30, 30, auc=None, brier=0.115),
+    ])
+
+    assert [delta.name for delta in deltas] == ["prior_risk_binned", "prior_phi_binned"]
+    assert deltas[0].auc_delta == 0.03
+    assert deltas[0].brier_improvement == 0.01
+    assert deltas[0].beats_baseline is True
+    assert deltas[1].auc_delta == 0.04
+    assert deltas[1].brier_improvement == -0.01
+    assert deltas[1].beats_baseline is False
+
+
+def test_build_report_includes_ablation_delta_section():
+    rows = []
+    for idx in range(120):
+        bad = idx >= 96
+        risk = 0.9 if bad else 0.1
+        rows.append(_row(idx, bad=bad, risk=risk, agent=f"agent-{idx % 6}"))
+
+    report = build_report(
+        rows,
+        scope="task",
+        window_days=90,
+        lead_minutes=30,
+        train_fraction=0.7,
+        generated_at=rows[0].ts + timedelta(days=1),
+    )
+
+    assert "## Ablation vs Previous-Outcome Baseline" in report
+    assert "| `prior_risk_binned` |" in report
+    assert "AUC delta" in report
+    assert "Brier improvement" in report

--- a/tests/test_outcome_calibration.py
+++ b/tests/test_outcome_calibration.py
@@ -808,6 +808,8 @@ class TestPredictionBindingEcho:
 
         parsed = parse_result(result)
         assert parsed.get('prediction_binding') == 'registry'
+        _, db_kwargs = mock_db.record_outcome_event.call_args
+        assert db_kwargs['detail']['prediction_binding'] == 'registry'
         # Record is consumed
         assert open_predictions[pid].get('consumed') is True
 
@@ -840,6 +842,8 @@ class TestPredictionBindingEcho:
 
         parsed = parse_result(result)
         assert parsed.get('prediction_binding') == 'missing_prediction'
+        _, db_kwargs = mock_db.record_outcome_event.call_args
+        assert db_kwargs['detail']['prediction_binding'] == 'missing_prediction'
 
     @pytest.mark.asyncio
     async def test_binding_ttl_expired_when_record_present_but_old(self):
@@ -875,6 +879,8 @@ class TestPredictionBindingEcho:
 
         parsed = parse_result(result)
         assert parsed.get('prediction_binding') == 'ttl_expired_fallback'
+        _, db_kwargs = mock_db.record_outcome_event.call_args
+        assert db_kwargs['detail']['prediction_binding'] == 'ttl_expired_fallback'
         # Record must NOT have been consumed
         assert open_predictions[pid].get('consumed') is not True
 
@@ -905,6 +911,8 @@ class TestPredictionBindingEcho:
 
         parsed = parse_result(result)
         assert parsed.get('prediction_binding') == 'argument_fallback'
+        _, db_kwargs = mock_db.record_outcome_event.call_args
+        assert db_kwargs['detail']['prediction_binding'] == 'argument_fallback'
 
     @pytest.mark.asyncio
     async def test_binding_no_binding_when_all_fallbacks_fail(self):
@@ -927,6 +935,8 @@ class TestPredictionBindingEcho:
 
         parsed = parse_result(result)
         assert parsed.get('prediction_binding') == 'no_binding'
+        _, db_kwargs = mock_db.record_outcome_event.call_args
+        assert db_kwargs['detail']['prediction_binding'] == 'no_binding'
 
 
 # ============================================================================

--- a/tests/test_outcome_inventory.py
+++ b/tests/test_outcome_inventory.py
@@ -1,0 +1,127 @@
+from scripts.analysis.outcome_inventory import (
+    OutcomeInventoryRow,
+    build_inventory,
+    format_inventory_report,
+)
+
+
+def test_build_inventory_groups_by_scope_type_source_and_evidence_flags():
+    rows = [
+        OutcomeInventoryRow(
+            outcome_type="test_passed",
+            is_bad=False,
+            verification_source="server_observation",
+            detail={
+                "hard_exogenous": True,
+                "eprocess_eligible": True,
+                "prediction_binding": "registry",
+                "prediction_id": "pred-1",
+            },
+            prior_state_by_lead={0.0: True, 5.0: True, 30.0: False},
+        ),
+        OutcomeInventoryRow(
+            outcome_type="test_failed",
+            is_bad=True,
+            verification_source="server_observation",
+            detail={
+                "hard_exogenous": True,
+                "eprocess_eligible": True,
+                "prediction_binding": "registry",
+                "prediction_id": "pred-2",
+            },
+            prior_state_by_lead={0.0: True, 5.0: False, 30.0: False},
+        ),
+        OutcomeInventoryRow(
+            outcome_type="task_failed",
+            is_bad=True,
+            verification_source="agent_reported_tool_result",
+            detail={
+                "hard_exogenous": False,
+                "eprocess_eligible": False,
+                "prediction_binding": "prev_confidence_fallback",
+            },
+            prior_state_by_lead={0.0: True, 5.0: True, 30.0: True},
+        ),
+        OutcomeInventoryRow(
+            outcome_type="drawing_completed",
+            is_bad=False,
+            verification_source=None,
+            detail={"verification_source": "external_signal"},
+            prior_state_by_lead={0.0: False, 5.0: False, 30.0: False},
+        ),
+    ]
+
+    inventory = build_inventory(rows, lead_minutes=(0.0, 5.0, 30.0))
+    by_key = {
+        (
+            bucket.scope,
+            bucket.outcome_type,
+            bucket.verification_source,
+            bucket.hard_exogenous,
+            bucket.eprocess_eligible,
+            bucket.prediction_binding,
+        ): bucket
+        for bucket in inventory.buckets
+    }
+
+    strict_tests = by_key[(
+        "strict",
+        "test_passed/test_failed",
+        "server_observation",
+        True,
+        True,
+        "registry",
+    )]
+    assert strict_tests.n_total == 2
+    assert strict_tests.n_bad == 1
+    assert strict_tests.bad_rate == 0.5
+    assert strict_tests.prior_state_counts == {0.0: 2, 5.0: 1, 30.0: 0}
+    assert strict_tests.prediction_id_count == 2
+
+    task_failed = by_key[(
+        "task",
+        "task_failed",
+        "agent_reported_tool_result",
+        False,
+        False,
+        "prev_confidence_fallback",
+    )]
+    assert task_failed.n_total == 1
+    assert task_failed.n_bad == 1
+    assert task_failed.prior_state_counts == {0.0: 1, 5.0: 1, 30.0: 1}
+
+    other = by_key[("other", "drawing_completed", "external_signal", False, False, "none")]
+    assert other.n_total == 1
+    assert inventory.total_outcomes == 4
+    assert inventory.total_bad == 2
+    assert inventory.total_prediction_id_count == 2
+
+
+def test_format_inventory_report_exposes_zero_bad_strict_and_prior_coverage():
+    rows = [
+        OutcomeInventoryRow(
+            outcome_type="test_passed",
+            is_bad=False,
+            verification_source="server_observation",
+            detail={"hard_exogenous": True, "eprocess_eligible": True},
+            prior_state_by_lead={0.0: True, 5.0: False},
+        ),
+        OutcomeInventoryRow(
+            outcome_type="task_failed",
+            is_bad=True,
+            verification_source="agent_reported_tool_result",
+            detail={"hard_exogenous": False, "eprocess_eligible": False},
+            prior_state_by_lead={0.0: True, 5.0: True},
+        ),
+    ]
+
+    inventory = build_inventory(rows, lead_minutes=(0.0, 5.0))
+    report = format_inventory_report(inventory, window_days=30, lead_minutes=(0.0, 5.0))
+
+    assert "Outcome Inventory" in report
+    assert "total_outcomes: 2" in report
+    assert "strict_outcomes: 1" in report
+    assert "strict_bad: 0" in report
+    assert "task_failed" in report
+    assert "prior_state_5m" in report
+    assert "agent_reported_tool_result" in report

--- a/tests/test_phases_phase5_evidence.py
+++ b/tests/test_phases_phase5_evidence.py
@@ -165,6 +165,12 @@ class TestDeriveOutcome:
         assert outcome_type == "task_failed"
         assert is_bad is True
 
+    def test_tool_call_exit1_is_tool_rejected(self):
+        ev = {"kind": "tool_call", "exit_code": 1, "is_bad": None}
+        outcome_type, is_bad = _derive_outcome(ev)
+        assert outcome_type == "tool_rejected"
+        assert is_bad is True
+
     def test_is_bad_true_overrides_exit_code(self):
         # is_bad=True takes priority even if exit_code=0
         ev = {"kind": "command", "exit_code": 0, "is_bad": True}
@@ -184,8 +190,8 @@ class TestDeriveOutcome:
         assert outcome_type == "task_completed"
         assert is_bad is False
 
-    def test_all_non_test_kinds_map_to_task(self):
-        for kind in ("command", "lint", "build", "file_op", "tool_call"):
+    def test_non_test_non_tool_call_kinds_map_to_task(self):
+        for kind in ("command", "lint", "build", "file_op"):
             ev = {"kind": kind, "exit_code": 0, "is_bad": None}
             outcome_type, is_bad = _derive_outcome(ev)
             assert outcome_type == "task_completed", (
@@ -311,7 +317,7 @@ async def test_per_item_isolation_one_bad_does_not_abort_siblings(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_kind_to_outcome_type_mapping(monkeypatch):
-    """Spec §1: test→test_passed/test_failed; all others→task_completed/task_failed."""
+    """Spec §1: tests stay strict and failed tool calls become tool_rejected."""
     monkeypatch.setenv("UNITARES_PHASE5_EVIDENCE_WRITE", "1")
 
     outcome_event_mock = AsyncMock(return_value=[MagicMock(text='{"outcome_id":"eid"}')])
@@ -337,10 +343,10 @@ async def test_kind_to_outcome_type_mapping(monkeypatch):
 
     outcome_types = sorted(args["outcome_type"] for args in phase5_calls)
     # test(exit=0)→test_passed, lint(exit=0)→task_completed, command(exit=1)→task_failed,
-    # build(exit=0)→task_completed, file_op(exit=0)→task_completed, tool_call(exit=1)→task_failed
+    # build(exit=0)→task_completed, file_op(exit=0)→task_completed, tool_call(exit=1)→tool_rejected
     expected = sorted([
         "test_passed", "task_completed", "task_failed",
-        "task_completed", "task_completed", "task_failed",
+        "task_completed", "task_completed", "tool_rejected",
     ])
     assert outcome_types == expected, (
         f"Mapping mismatch.\nExpected: {expected}\nGot:      {outcome_types}"

--- a/tests/test_redis_resilience.py
+++ b/tests/test_redis_resilience.py
@@ -6,7 +6,6 @@ Tests circuit breaker, retry logic, metrics, and fallback behavior.
 
 import pytest
 import asyncio
-import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from src.cache.redis_client import (
@@ -64,47 +63,52 @@ class TestCircuitBreaker:
 
     def test_half_open_after_timeout(self):
         """Circuit transitions to half-open after timeout."""
-        cb = CircuitBreaker(threshold=3, timeout=0.1)  # 100ms timeout
+        with patch("src.cache.redis_client.time.time") as mock_time:
+            mock_time.return_value = 1000.0
+            cb = CircuitBreaker(threshold=3, timeout=0.1)  # 100ms timeout
 
-        # Open the circuit
-        for _ in range(3):
-            cb.record_failure()
-        assert cb.state == CircuitBreaker.OPEN
+            # Open the circuit
+            for _ in range(3):
+                cb.record_failure()
+            assert cb.state == CircuitBreaker.OPEN
 
-        # Wait for timeout
-        time.sleep(0.15)
+            mock_time.return_value = 1000.15
 
-        # Should transition to half-open
-        assert cb.state == CircuitBreaker.HALF_OPEN
-        assert cb.is_available() is True
+            # Should transition to half-open
+            assert cb.state == CircuitBreaker.HALF_OPEN
+            assert cb.is_available() is True
 
     def test_half_open_closes_on_success(self):
         """Circuit closes from half-open on success."""
-        cb = CircuitBreaker(threshold=3, timeout=0.1)
+        with patch("src.cache.redis_client.time.time") as mock_time:
+            mock_time.return_value = 1000.0
+            cb = CircuitBreaker(threshold=3, timeout=0.1)
 
-        # Open -> half-open
-        for _ in range(3):
-            cb.record_failure()
-        time.sleep(0.15)
-        assert cb.state == CircuitBreaker.HALF_OPEN
+            # Open -> half-open
+            for _ in range(3):
+                cb.record_failure()
+            mock_time.return_value = 1000.15
+            assert cb.state == CircuitBreaker.HALF_OPEN
 
-        # Success closes it
-        cb.record_success()
-        assert cb.state == CircuitBreaker.CLOSED
+            # Success closes it
+            cb.record_success()
+            assert cb.state == CircuitBreaker.CLOSED
 
     def test_half_open_reopens_on_failure(self):
         """Circuit reopens from half-open on failure."""
-        cb = CircuitBreaker(threshold=3, timeout=0.1)
+        with patch("src.cache.redis_client.time.time") as mock_time:
+            mock_time.return_value = 1000.0
+            cb = CircuitBreaker(threshold=3, timeout=0.1)
 
-        # Open -> half-open
-        for _ in range(3):
+            # Open -> half-open
+            for _ in range(3):
+                cb.record_failure()
+            mock_time.return_value = 1000.15
+            assert cb.state == CircuitBreaker.HALF_OPEN
+
+            # Failure reopens it
             cb.record_failure()
-        time.sleep(0.15)
-        assert cb.state == CircuitBreaker.HALF_OPEN
-
-        # Failure reopens it
-        cb.record_failure()
-        assert cb.state == CircuitBreaker.OPEN
+            assert cb.state == CircuitBreaker.OPEN
 
     def test_reset(self):
         """Reset returns circuit to initial state."""


### PR DESCRIPTION
## Summary
- add outcome inventory tooling for provenance/objectivity/prior-state coverage
- add EISV ablation matrix tooling over scope/window/lead slices
- persist `prediction_binding` in outcome event detail and map failed `tool_call` evidence to strict `tool_rejected`
- extend skeptic report with paired prior-state model deltas against the `previous_outcome_bad` baseline
- stabilize Redis circuit-breaker timing tests by mocking time instead of sleeping, so CI test runs are less flaky
- keep the conclusion skeptical: this reports predictive lift/signal only, not EISV ontology validation

## Validation
- `python3 -m pytest tests/test_phases_phase5_evidence.py tests/test_outcome_calibration.py tests/test_outcome_inventory.py tests/test_eisv_skeptic_report.py tests/test_eisv_ablation_matrix.py tests/test_analysis_tools.py tests/test_grounding_class_indicator.py tests/test_calibrate_class_conditional.py -q` → 127 passed
- `python3 -m pytest tests/test_redis_resilience.py -q` → 27 passed
- `python3 -m py_compile scripts/analysis/eisv_ablation_matrix.py tests/test_eisv_ablation_matrix.py scripts/analysis/eisv_skeptic_report.py tests/test_eisv_skeptic_report.py scripts/analysis/outcome_inventory.py tests/test_outcome_inventory.py src/mcp_handlers/updates/phases.py src/mcp_handlers/observability/outcome_events.py tests/test_phases_phase5_evidence.py tests/test_outcome_calibration.py`
- staged security grep scans for hardcoded secrets, shell injection, eval/exec, pickle, and SQL string formatting → no findings
- independent pre-commit reviewer passed after the paired-ablation fix
- `python3 scripts/analysis/eisv_ablation_matrix.py --scopes strict,task --windows 30,90 --leads 0,5,30`
- pre-push hook: smoke/doc-health passed (`138 passed, 8288 deselected`)

## Current smoke read
- strict scope is still inconclusive: 90d strict has 2451 trusted outcomes and 0 bad outcomes
- task 30d/0m shows one weak paired positive slice, but this is not robust validation
- task 90d slices remain skeptical against the previous-outcome baseline
