### PR TITLE
feat(kg): audit knowledge_read events

### DIFF
--- a/src/broadcaster.py
+++ b/src/broadcaster.py
@@ -96,7 +96,7 @@ class EISVBroadcaster:
             lifecycle_paused, lifecycle_resumed, lifecycle_archived,
             lifecycle_created, lifecycle_loop_detected, lifecycle_stuck_detected,
             identity_drift, identity_assurance_change,
-            knowledge_write, knowledge_confidence_clamped,
+            knowledge_write, knowledge_read, knowledge_confidence_clamped,
             circuit_breaker_trip, circuit_breaker_reset
         """
         event = {

--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -124,6 +124,44 @@ async def _broadcast_knowledge_write(discovery, agent_id: str) -> None:
         logger.debug("knowledge_write broadcast skipped: %s", exc)
 
 
+async def _broadcast_knowledge_read(
+    action: str,
+    reader_agent_id: Optional[str],
+    payload: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Emit a ``knowledge_read`` event so read traffic is observable.
+
+    Writes have been audited since the broadcaster shipped; reads were not,
+    which made the central usage question for the KG ("is anyone actually
+    pulling from this?") unanswerable from audit.events. This helper closes
+    that gap. ``action`` is one of ``search``/``get``/``list``/``details``;
+    when knowable (``details``, search-result enumeration), the payload
+    carries the writer agent_id so cross-agent reads can be distinguished
+    from self-reads in SQL.
+    """
+    try:
+        body: Dict[str, Any] = {"action": action}
+        if payload:
+            body.update(payload)
+        await broadcaster_instance.broadcast_event(
+            "knowledge_read",
+            agent_id=reader_agent_id,
+            payload=body,
+        )
+    except Exception as exc:
+        logger.debug("knowledge_read broadcast skipped: %s", exc)
+
+
+def _resolve_reader_agent_id(arguments: Dict[str, Any]) -> Optional[str]:
+    """Best-effort reader-identity extraction for read-side audit events."""
+    from ..context import get_context_agent_id
+    return (
+        arguments.get("_agent_uuid")
+        or get_context_agent_id()
+        or arguments.get("agent_id")
+    )
+
+
 def _compute_staleness_warning(discovery, current_server_version: str) -> Optional[str]:
     """Flag open entries that are likely stale (>60 days old or 2+ minor versions behind)."""
     warning_parts = []
@@ -1587,6 +1625,19 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
 
             asyncio.create_task(_touch_referenced([d.id for d in results]))
 
+        writer_sample = list({d.agent_id for d in results if d.agent_id})[:10]
+        await _broadcast_knowledge_read(
+            "search",
+            _resolve_reader_agent_id(arguments),
+            payload={
+                "result_count": len(results),
+                "query_present": bool(query_text),
+                "query_term_count": query_term_count,
+                "search_mode": locals().get("search_mode") or search_mode_param,
+                "writer_agent_ids": writer_sample,
+                "filter_agent_id": arguments.get("agent_id"),
+            },
+        )
         return success_response(response_data, arguments=arguments)
 
     except Exception as e:
@@ -1652,8 +1703,17 @@ async def handle_get_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[Text
         if limit and len(discoveries) == limit:
             response_data["_more_available"] = f"Results limited to {limit}. Use limit=N to get more."
 
+        await _broadcast_knowledge_read(
+            "get",
+            _resolve_reader_agent_id(arguments),
+            payload={
+                "target_agent_id": agent_id,
+                "result_count": len(discoveries),
+                "include_details": bool(include_details),
+            },
+        )
         return success_response(response_data, arguments=arguments)
-        
+
     except Exception as e:
         return [error_response(f"Failed to retrieve knowledge: {str(e)}")]
 
@@ -1695,6 +1755,14 @@ async def handle_list_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[Tex
         scope_summary = (
             f"epoch_scope={stats.get('scope', {}).get('epoch_scope', '?')}, "
             f"including_cold={stats.get('scope', {}).get('including_cold', '?')}"
+        )
+        await _broadcast_knowledge_read(
+            "list",
+            _resolve_reader_agent_id(arguments),
+            payload={
+                "epoch_scope": stats.get("scope", {}).get("epoch_scope") if isinstance(stats, dict) else None,
+                "including_cold": including_cold,
+            },
         )
         return success_response({
             "stats": stats,
@@ -1955,6 +2023,15 @@ async def handle_get_discovery_details(arguments: Dict[str, Any]) -> Sequence[Te
 
         asyncio.create_task(_touch(discovery_id))
 
+        await _broadcast_knowledge_read(
+            "details",
+            _resolve_reader_agent_id(arguments),
+            payload={
+                "discovery_id": discovery_id,
+                "writer_agent_id": getattr(discovery, "agent_id", None),
+                "include_response_chain": bool(arguments.get("include_response_chain", False)),
+            },
+        )
         return success_response(response, arguments=arguments)
 
     except Exception as e:

--- a/tests/test_kg_store.py
+++ b/tests/test_kg_store.py
@@ -1116,6 +1116,104 @@ class TestKnowledgeWriteBroadcast:
         assert data["success"] is True
 
 
+class TestKnowledgeReadBroadcast:
+    """Read-side audit coverage. Without these emits the central usage
+    question for the KG ("is anyone pulling from this?") is unanswerable
+    from audit.events — only writes show up. Pin the four read paths."""
+
+    @pytest.mark.asyncio
+    async def test_get_emits_knowledge_read(self, patch_common, registered_agent):
+        mock_mcp_server, mock_graph = patch_common
+        mock_graph.get_agent_discoveries.return_value = [
+            make_discovery(id="d1", agent_id=registered_agent),
+            make_discovery(id="d2", agent_id=registered_agent),
+        ]
+        from src.mcp_handlers.knowledge.handlers import handle_get_knowledge_graph
+
+        with patch(
+            "src.mcp_handlers.knowledge.handlers.broadcaster_instance.broadcast_event",
+            new_callable=AsyncMock,
+        ) as bc:
+            await handle_get_knowledge_graph({"agent_id": registered_agent})
+
+        read_calls = [c for c in bc.await_args_list if c.args and c.args[0] == "knowledge_read"]
+        assert read_calls, "expected knowledge_read to be emitted on get"
+        payload = read_calls[0].kwargs["payload"]
+        assert payload["action"] == "get"
+        assert payload["target_agent_id"] == registered_agent
+        assert payload["result_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_list_emits_knowledge_read(self, patch_common):
+        mock_mcp_server, mock_graph = patch_common
+        mock_graph.get_stats.return_value = {
+            "total_discoveries": 7,
+            "total_agents": 3,
+            "scope": {"epoch_scope": "current", "including_cold": False},
+        }
+        from src.mcp_handlers.knowledge.handlers import handle_list_knowledge_graph
+
+        with patch(
+            "src.mcp_handlers.knowledge.handlers.broadcaster_instance.broadcast_event",
+            new_callable=AsyncMock,
+        ) as bc:
+            await handle_list_knowledge_graph({})
+
+        read_calls = [c for c in bc.await_args_list if c.args and c.args[0] == "knowledge_read"]
+        assert read_calls, "expected knowledge_read to be emitted on list"
+        payload = read_calls[0].kwargs["payload"]
+        assert payload["action"] == "list"
+
+    @pytest.mark.asyncio
+    async def test_details_emits_knowledge_read_with_writer_agent(
+        self, patch_common, registered_agent,
+    ):
+        mock_mcp_server, mock_graph = patch_common
+        writer_uuid = "11111111-1111-4111-8111-111111111111"
+        mock_graph.get_discovery.return_value = make_discovery(
+            id="disc-xyz", agent_id=writer_uuid, summary="something",
+        )
+        from src.mcp_handlers.knowledge.handlers import handle_get_discovery_details
+
+        with patch(
+            "src.mcp_handlers.knowledge.handlers.broadcaster_instance.broadcast_event",
+            new_callable=AsyncMock,
+        ) as bc, patch(
+            "src.mcp_handlers.context.get_context_agent_id",
+            return_value=registered_agent,
+        ):
+            await handle_get_discovery_details({"discovery_id": "disc-xyz"})
+
+        read_calls = [c for c in bc.await_args_list if c.args and c.args[0] == "knowledge_read"]
+        assert read_calls, "expected knowledge_read to be emitted on details"
+        call = read_calls[0]
+        payload = call.kwargs["payload"]
+        assert payload["action"] == "details"
+        assert payload["discovery_id"] == "disc-xyz"
+        assert payload["writer_agent_id"] == writer_uuid
+
+    @pytest.mark.asyncio
+    async def test_broadcast_failure_does_not_break_read(
+        self, patch_common, registered_agent,
+    ):
+        """A dead broadcaster on the read path must not fail the read."""
+        mock_mcp_server, mock_graph = patch_common
+        mock_graph.get_agent_discoveries.return_value = [
+            make_discovery(id="d1", agent_id=registered_agent),
+        ]
+        from src.mcp_handlers.knowledge.handlers import handle_get_knowledge_graph
+
+        with patch(
+            "src.mcp_handlers.knowledge.handlers.broadcaster_instance.broadcast_event",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("broadcaster dead"),
+        ):
+            result = await handle_get_knowledge_graph({"agent_id": registered_agent})
+
+        data = parse_result(result)
+        assert data["success"] is True
+
+
 class TestLeaveNoteTagPassthrough:
     """leave_note must not auto-inject `ephemeral` into caller-supplied tags.
 


### PR DESCRIPTION
Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.