### PR TITLE
DRAFT fix(enrichment): collapse post-lock amplification (sync I/O on event loop)

### DIFF
--- a/docs/proposals/beam-footprint-roadmap-v0.md
+++ b/docs/proposals/beam-footprint-roadmap-v0.md
@@ -1,10 +1,54 @@
 # BEAM Footprint Roadmap
 
 **Created:** May 3, 2026
-**Last Updated:** May 20, 2026 (v0.3.3 status fold — resident Phase B + lease/ODE measurement persistence; v0.3 destination unchanged)
-**Status:** v0.3 — destination is **A′ (committed, operator-decision-driven, 2026-05-05)**. Stateful coordination ports to BEAM in waves; stateless computation (numpy ODE, embeddings, LLM SDK calls) stays Python and is called from BEAM via Ports / HTTP. v0.2 had reopened the destination after PR #350's verdict; v0.3 closes it again on operator call after four Python-fixable PRs (#350 / #354 / #360 / #361) closed every measured floor without moving the user-visible ~11s p50 per-turn overhead. **Read the V0.3 RESOLUTION block first.** v0 / v0.1 / v0.2 bodies preserved as historical record.
+**Last Updated:** May 28, 2026 (v0.3.1 amendment — ODE profile landed; the "7s locked-phase floor" framing falsified; post-lock enrichment was the actual user-visible floor and is now Python-fixed in PR #533)
+**Status:** v0.3 — destination is **A′ (committed, operator-decision-driven, 2026-05-05)**. Stateful coordination ports to BEAM in waves; stateless computation (numpy ODE, embeddings, LLM SDK calls) stays Python and is called from BEAM via Ports / HTTP. v0.2 had reopened the destination after PR #350's verdict; v0.3 closes it again on operator call after four Python-fixable PRs (#350 / #354 / #360 / #361) closed every measured floor without moving the user-visible ~11s p50 per-turn overhead. **Read the V0.3 RESOLUTION block first**, then the V0.3.1 amendment for what changed on 2026-05-28. v0 / v0.1 / v0.2 bodies preserved as historical record.
 **Council pass v0.1 (2026-05-04):** dialectic-knowledge-architect (2B/4C/3D/4N), feature-dev:code-reviewer (2B/3C/2D/2N), live-verifier (7 VERIFIED, 6 DRIFT, 0 REFUTED, 1 SOURCE_ONLY) — all findings folded inline. Architect C3 + reviewer C3 both flagged "v0.1 destination committed pre-experiment"; the v0.1 conditionality block was the fold for that finding, and v0.2 was the realization of it.
 **Council pass v0.3:** none on the migration call itself — that's an operator decision after a multi-session debate, and adversarial review of the call after operator commitment is the relitigation pattern v0.3 is trying to end. Council passes ARE expected on technical scope (Wave 1 supervisor topology, BEAM↔Python boundary contracts, identity-state migration) once those land as RFCs.
+
+---
+
+## V0.3.1 AMENDMENT 2026-05-28 — ODE profile + post-lock enrichment Python-fix
+
+**Read this after V0.3 RESOLUTION.**
+
+The v0.3 RESOLUTION's load-bearing unknown was the ODE profile — the 7s remainder of what was framed as the "locked-phase floor." Both halves of that framing turned out to be wrong:
+
+- **The "7s" wasn't in the locked phase.** A side-by-side profile on 2026-05-28 (`/tmp/mcp_profile_analysis.txt`) measured the locked phase at ~100ms under 4-way concurrency, ~21ms serial — 2% of user-visible wall-clock, not 100%. The structured-log boundaries at `src/services/update_workflow_service.py:110-153` and `src/mcp_handlers/updates/pipeline.py:58-86` were already in place; the breakdown was always derivable, just not derived.
+
+- **The actual floor was post-lock enrichment**, specifically `enrich_learning_context` calling `audit_logger.query_audit_log` (`src/audit_log.py:54-84,729-778`), which scanned `.jsonl` files synchronously on the event loop. That blocking sync I/O was hogging the single shared ExecutorPool thread (introduced by PR #218); the other PG/KG-backed enrichers queued behind it.
+
+- **PR #533 collapsed it Python-side.** Side-by-side benchmark, same 4-way concurrent load, same DB:
+
+| Phase | Master `087404e7` | Branch `e83d2920` (PR #533) | Ratio |
+|---|---|---|---|
+| user-visible p50 | 5321 ms | **51 ms** | **104×** |
+| enrichment phase | 5070 ms | 22.7 ms | 224× |
+| checkin total | 5281 ms | 47 ms | 112× |
+| `enrich_learning_context` (directly fixed) | 3330 ms | 6.3 ms | 528× |
+| `enrich_knowledge_surfacing` (cascading) | 1784 ms | 5.3 ms | 337× |
+| `enrich_mirror_signals` (cascading) | 112 ms | 1.9 ms | 59× |
+
+The fix is a `loop.run_in_executor` wrap on the sync `query_audit_log` call plus an `asyncio.gather` refactor on the 5 independent reads in `build_temporal_context`. CLAUDE.md "Substrate Tax" pattern #2 (sync-client + executor) — already documented as the workaround for this exact bug class.
+
+**Bias accountability.** Memory `feedback_substrate-migration-status-quo-bias.md` flags that I reliably resist substrate migrations across sessions. This profile + fix lands in that pole. I'm flagging it explicitly: a Python-side fix collapsing 104× of the user-visible floor with one `run_in_executor` is exactly the shape v0.3 said it would no longer be moved by. The operator has two honest reads available:
+
+1. **The destination is still A′ on the architectural-ceiling argument.** The single-ExecutorPool-thread serialization is still real and is structural to anyio + asyncio + asyncpg on a shared event loop. Under N>>4 sustained concurrency this benchmark's 51ms p50 will degrade. The v0.3 framing was wrong about *which mechanism* dissolves under BEAM but right that *some* mechanism does. The fix doesn't change the destination; it changes the timeline pressure.
+
+2. **The destination is open to relitigation.** Every measured floor in the project's history has resolved as a Python-side fix. The CLAUDE.md "Substrate Tax" workarounds are workarounds-not-architecture, but they keep working. v0.3 already committed past this read once with eyes open; doing so a second time with the same data shape weakens the empirical posture. Stop sign #2 of v0.3 was conditional on "ODE profile lands and 6+ of the 7s is numpy/embedding compute" — the literal premise (locked-phase floor = 7s) didn't hold, so the conditional doesn't directly apply, but the spirit (Python-fixable floors keep collapsing) does.
+
+This amendment does not pick between (1) and (2). The v0.3 RESOLUTION explicitly named operator-decision as the criterion; same posture applies here. Wave 1 (Sentinel-on-BEAM, `com.unitares.sentinel-beam` PID 1782) is running and not affected by this finding. Wave 2 and Wave 3 sequencing are operator territory after this amendment is read.
+
+**What the amendment does NOT close:**
+- The single-ExecutorPool-thread serialization. PR #533 unhogged the executor thread for this specific bug; it did not eliminate the fact that all asyncpg goes through one thread. The deeper fix (multiple ExecutorPool instances, or `lite_safe`-skip-under-contention path in `pipeline.py:58-86`) is unaddressed.
+- Redis async clients are still not ExecutorPool-wrapped per CLAUDE.md; that's orthogonal to PR #533 but the same bug class.
+- The §129 14-day window (T+0 = 2026-05-19, closes 2026-06-02) is on its original auto-trigger via launchd one-shot `com.unitares.wave-1-section-129-reeval`. Condition 1 (incident_id wired) is still pending; this amendment does not satisfy it.
+
+**Artifacts:**
+- PR #533 — the fix + benchmark
+- Profile run: `/tmp/mcp_profile_analysis.txt`, `/tmp/mcp_phase_logs_tail100.txt`
+- Benchmark: `/tmp/loadgen_8770.py`, `/tmp/loadgen_baseline_out.txt`, `/tmp/loadgen_worktree_out.txt`, `/tmp/parse_phases.py`
+- Memory: `project_locked-phase-floor-is-the-ode.md` (the misattribution this amendment supersedes — needs a 2026-05-28 amendment of its own)
 
 ---
 

--- a/src/mcp_handlers/updates/enrichments.py
+++ b/src/mcp_handlers/updates/enrichments.py
@@ -6,6 +6,7 @@ Every function is fail-safe: wraps its logic in try/except so a single
 enrichment failure never crashes the update.
 """
 
+import asyncio
 import json
 import os
 from datetime import datetime, timezone
@@ -974,7 +975,16 @@ async def enrich_learning_context(ctx: UpdateContext) -> None:
         try:
             from src.audit_log import AuditLogger
             audit_logger = AuditLogger()
-            recent_events = audit_logger.query_audit_log(agent_id=ctx.agent_id, limit=10)
+            # query_audit_log does a reverse-scan over .jsonl files (sync
+            # blocking I/O on the event loop). Push to the default executor
+            # so other handlers can progress while the scan runs — the scan
+            # itself is the ~700ms floor on agents with deep audit history
+            # (post-lock enrichment profile, 2026-05-28).
+            loop = asyncio.get_event_loop()
+            recent_events = await loop.run_in_executor(
+                None,
+                lambda: audit_logger.query_audit_log(agent_id=ctx.agent_id, limit=10),
+            )
             if recent_events:
                 recent_decisions = []
                 for event in recent_events[:5]:

--- a/src/temporal.py
+++ b/src/temporal.py
@@ -6,6 +6,7 @@ Reads existing timestamped data and produces short, relative,
 human-readable temporal context when thresholds are crossed.
 """
 
+import asyncio
 from datetime import datetime, timezone, timedelta
 from typing import Optional
 
@@ -59,50 +60,67 @@ async def build_temporal_context(
         now = now or datetime.now(timezone.utc)
         signals = []
 
-        # Resolve identity
+        # Phase 1 (sequential): identity gates all per-identity queries.
         identity = await db.get_identity(agent_id)
         if not identity:
             return None
         identity_id = identity.identity_id
 
+        # Phase 2 (parallel): the 4-5 per-identity reads are mutually
+        # independent. Running them sequentially serialized through the
+        # shared executor thread under N-way concurrent enrichment and
+        # turned a ~5ms enricher into a ~500ms one (post-lock enrichment
+        # profile, 2026-05-28). Concurrent fan-out collapses that to one
+        # round-trip's worth of executor pressure.
+        coros = [
+            db.get_active_sessions_for_identity(identity_id),
+            db.get_last_inactive_session(identity_id),
+            db.get_latest_agent_state(identity_id),
+            db.get_agent_state_history(identity_id, limit=50),
+        ]
+        if include_cross_agent:
+            coros.append(db.get_recent_cross_agent_activity(identity_id))
+
+        results = await asyncio.gather(*coros, return_exceptions=True)
+
+        def _ok(idx, label):
+            r = results[idx]
+            if isinstance(r, BaseException):
+                logger.debug(f"Temporal: {label} query failed: {r}")
+                return None
+            return r
+
+        sessions = _ok(0, "session")
+        last_session = _ok(1, "gap")
+        latest_state = _ok(2, "idle")
+        history = _ok(3, "density")
+        cross_activity = _ok(4, "cross-agent") if include_cross_agent else None
+
         # Current session duration
-        try:
-            sessions = await db.get_active_sessions_for_identity(identity_id)
-            if sessions:
-                session_start = _ensure_utc(sessions[0].created_at)
-                session_duration = now - session_start
-                if session_duration > timedelta(hours=GovernanceConfig.TEMPORAL_LONG_SESSION_HOURS):
-                    signals.append(f"Session: {_format_duration(session_duration)}.")
-        except Exception as e:
-            logger.debug(f"Temporal: session query failed: {e}")
+        if sessions:
+            session_start = _ensure_utc(sessions[0].created_at)
+            session_duration = now - session_start
+            if session_duration > timedelta(hours=GovernanceConfig.TEMPORAL_LONG_SESSION_HOURS):
+                signals.append(f"Session: {_format_duration(session_duration)}.")
 
         # Gap since last session
         last_session_end = None
-        try:
-            last_session = await db.get_last_inactive_session(identity_id)
-            if last_session and last_session.last_active:
-                last_session_end = _ensure_utc(last_session.last_active)
-                gap = now - last_session_end
-                if gap > timedelta(hours=GovernanceConfig.TEMPORAL_GAP_HOURS):
-                    signals.append(f"Last session: {_format_duration(gap)} ago.")
-        except Exception as e:
-            logger.debug(f"Temporal: gap query failed: {e}")
+        if last_session and last_session.last_active:
+            last_session_end = _ensure_utc(last_session.last_active)
+            gap = now - last_session_end
+            if gap > timedelta(hours=GovernanceConfig.TEMPORAL_GAP_HOURS):
+                signals.append(f"Last session: {_format_duration(gap)} ago.")
 
         # Idle within session (time since last check-in)
-        try:
-            latest_state = await db.get_latest_agent_state(identity_id)
-            if latest_state and latest_state.recorded_at:
-                recorded = _ensure_utc(latest_state.recorded_at)
-                idle = now - recorded
-                if idle > timedelta(minutes=GovernanceConfig.TEMPORAL_IDLE_MINUTES):
-                    signals.append(f"Idle: {_format_duration(idle)} since last check-in.")
-        except Exception as e:
-            logger.debug(f"Temporal: idle query failed: {e}")
+        if latest_state and latest_state.recorded_at:
+            recorded = _ensure_utc(latest_state.recorded_at)
+            idle = now - recorded
+            if idle > timedelta(minutes=GovernanceConfig.TEMPORAL_IDLE_MINUTES):
+                signals.append(f"Idle: {_format_duration(idle)} since last check-in.")
 
         # High check-in density
-        try:
+        if history:
             window = timedelta(minutes=GovernanceConfig.TEMPORAL_HIGH_CHECKIN_WINDOW_MINUTES)
-            history = await db.get_agent_state_history(identity_id, limit=50)
             cutoff = now - window
             recent_count = sum(
                 1 for s in history
@@ -110,23 +128,17 @@ async def build_temporal_context(
             )
             if recent_count >= GovernanceConfig.TEMPORAL_HIGH_CHECKIN_COUNT:
                 signals.append(f"High activity: {recent_count} check-ins in {_format_duration(window)}.")
-        except Exception as e:
-            logger.debug(f"Temporal: density query failed: {e}")
 
         # Cross-agent activity
-        if include_cross_agent:
-            try:
-                cross_activity = await db.get_recent_cross_agent_activity(identity_id)
-                if cross_activity:
-                    entry = cross_activity[0]
-                    agent_time = _ensure_utc(entry.get("recorded_at", now))
-                    ago = _format_duration(now - agent_time)
-                    count = entry.get("count", 1)
-                    signals.append(f"Another agent active {ago} ago ({count} updates).")
-            except Exception as e:
-                logger.debug(f"Temporal: cross-agent query failed: {e}")
+        if include_cross_agent and cross_activity:
+            entry = cross_activity[0]
+            agent_time = _ensure_utc(entry.get("recorded_at", now))
+            ago = _format_duration(now - agent_time)
+            count = entry.get("count", 1)
+            signals.append(f"Another agent active {ago} ago ({count} updates).")
 
-        # New discoveries since last session
+        # Phase 3 (sequential): new discoveries since last session — depends
+        # on last_session_end from phase 2, so cannot join the gather batch.
         if last_session_end:
             try:
                 discoveries = await db.kg_query(

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -44,6 +44,9 @@ def test_kg_query_accepts_created_after():
 
 # ─── Duration formatter tests ─────────────────────────────────────
 
+import asyncio
+import time
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 from datetime import datetime, timezone, timedelta
@@ -371,3 +374,63 @@ async def test_temporal_enrichment_silence():
         await enrich_temporal_context(ctx)
 
         assert "temporal_context" not in ctx.response_data
+
+
+@pytest.mark.asyncio
+async def test_temporal_phase_2_reads_run_concurrently():
+    """The 4 per-identity reads (sessions/last_session/latest_state/history)
+    must run concurrently via asyncio.gather, not sequentially.
+
+    Under N-way concurrent enrichment, sequential awaits serialize through
+    the shared executor thread and turn a ~5ms enricher into a ~500ms one
+    (post-lock enrichment profile, 2026-05-28). This regression test
+    inserts a 50ms sleep on each mocked read; if they run sequentially the
+    total is ~200ms, if concurrently it's ~50ms. Allows ~120ms of headroom
+    for asyncio scheduling and slow CI.
+    """
+    now = datetime.now(timezone.utc)
+
+    db = AsyncMock()
+    db.get_identity.return_value = MagicMock(identity_id=1)
+
+    async def _slow(*args, **kwargs):
+        await asyncio.sleep(0.05)
+        return []
+
+    db.get_active_sessions_for_identity.side_effect = _slow
+    db.get_last_inactive_session.side_effect = _slow
+    db.get_latest_agent_state.side_effect = _slow
+    db.get_agent_state_history.side_effect = _slow
+    db.kg_query.return_value = []
+
+    start = time.perf_counter()
+    await build_temporal_context("test-uuid", db, now=now)
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 0.170, (
+        f"phase 2 reads serialized; elapsed {elapsed:.3f}s suggests "
+        f"sequential awaits instead of asyncio.gather"
+    )
+
+
+@pytest.mark.asyncio
+async def test_temporal_phase_2_tolerates_single_failure(mock_db):
+    """If one of the gathered reads raises, others still produce signals
+    (matches the pre-gather per-call try/except semantics).
+    """
+    now = datetime.now(timezone.utc)
+    mock_db.get_identity.return_value = MagicMock(identity_id=1)
+
+    mock_db.get_active_sessions_for_identity.return_value = [
+        MagicMock(created_at=now - timedelta(hours=3))
+    ]
+    mock_db.get_last_inactive_session.side_effect = RuntimeError("db go boom")
+    mock_db.get_latest_agent_state.return_value = MagicMock(
+        recorded_at=now - timedelta(minutes=2)
+    )
+    mock_db.get_agent_state_history.return_value = []
+    mock_db.kg_query.return_value = []
+
+    result = await build_temporal_context("test-uuid", mock_db, now=now)
+    assert result is not None
+    assert "Session: 3h" in result  # other reads still produced signal


### PR DESCRIPTION
## Summary

A 2026-05-28 profile found the user-visible `process_agent_update` p50 ~5.3s lives in **post-lock enrichment**, not the locked phase (which is ~2% of total). Two local fixes here collapse it to **p50 51ms** (104×) measured on a side-by-side benchmark between master and this branch.

The dominant fix is the `run_in_executor` wrap on `audit_logger.query_audit_log`, which was scanning `.jsonl` files synchronously on the event loop and hogging the single shared ExecutorPool thread. Unblocking it cascades into 3 other enrichers that were starving behind it.

Draft because the implications for the BEAM-migration roadmap (v0.3) need operator review — see "Implications" section.

## Benchmark

4 concurrent agents × 8 calls each, same shape both runs, side-by-side on production DB:

| Run | Build | Wall-clock | p50 | p99 |
|---|---|---|---|---|
| Baseline | master `087404e7` (port 8767) | 38.6s | 5321ms | 6734ms |
| Post-fix | this branch `e83d2920` (port 8770) | **0.5s** | **51ms** | **125ms** |

Per-enricher average (server-side structured-log boundaries; n=32):

| Phase | Baseline | Post-fix | Ratio |
|---|---|---|---|
| **enrichment phase total** | 5070ms | **22.7ms** | **224×** |
| `enrich_learning_context` (directly fixed) | 3330ms | 6.3ms | 528× |
| `enrich_knowledge_surfacing` (cascading benefit) | 1784ms | 5.3ms | 337× |
| `enrich_mirror_signals` (cascading benefit) | 112ms | 1.9ms | 59× |
| `enrich_temporal_context` (directly fixed) | 19.6ms | 5.6ms | 3.5× |
| checkin total | 5281ms | 47ms | 112× |

## The bug, and why one wrap fixes four enrichers

`enrich_learning_context` at `src/mcp_handlers/updates/enrichments.py:977` calls `audit_logger.query_audit_log(...)`, which does a synchronous reverse-scan over `.jsonl` files (`src/audit_log.py:54-84,729-778`). That scan is the ~700ms serial floor and it blocks the event loop while running.

PR #218 moved asyncpg behind a single ExecutorPool background thread (`src/db/executor_pool.py:223-230`). All asyncpg work — including the 4 hot KG/PG enrichers — funnels through that one thread via `run_coroutine_threadsafe`. When `enrich_learning_context` blocks the *event loop* with its sync scan, the entire pipeline queues:

1. The loop can't schedule the asyncpg callbacks coming back from the executor thread.
2. Concurrent requests pile up waiting for their own asyncpg `acquire`s to return.
3. Other enrichers' KG queries stall too.

Wrapping the sync scan in `loop.run_in_executor` releases the event loop, the executor-thread callbacks land, the queue drains, and the cascading enrichers (knowledge_surfacing, mirror_signals) un-starve.

## Fix #1 (dominant) — `enrichments.py`

`enrich_learning_context` `audit_logger.query_audit_log(...)` is now wrapped in `loop.run_in_executor(None, ...)`. CLAUDE.md "Substrate Tax" pattern #2 (the documented `run_in_executor` workaround for sync clients).

## Fix #2 (smaller, real) — `temporal.py`

`build_temporal_context` had 5-7 sequential `await db.X()` calls inside each invocation. They're independent given `identity_id`, so phase 2 now runs them as one `asyncio.gather`. Identity (phase 1) still gates the rest; the `kg_query` for new-discoveries-since-last-session (phase 3) stays sequential because it depends on `last_session_end` from phase 2. Per-call try/except semantics preserved via `gather(return_exceptions=True)`.

**Honest note**: The original profile claimed `enrich_temporal_context` was 498ms @ 4-way (80×). That didn't reproduce on current master — it was already ~20ms. The gather refactor is still real (3.5× under this benchmark) but the original 80× headline doesn't hold. The fix is defensible on invariant grounds (5 independent reads should be `gather`'d not awaited in series), but the dominant collapse on this branch is fix #1.

## Implications for v0.3 BEAM-migration roadmap

This is for operator review. The v0.3 doc said "every measured floor today resolved as sequential awaits in our own loops, not anyio scheduler interaction. The substrate-tax-as-anyio-coupling hypothesis is at its weakest in the project's history."

This benchmark adds another instance of that exact pattern. The dominant floor in current production was a `run_in_executor` away from disappearing, with cascading benefit to 3 other enrichers. The substrate-tax-as-anyio hypothesis weakens further.

What this does **not** close: the single-ExecutorPool-thread serialization is unfixed. Under N>>4 sustained concurrency it remains a structural bottleneck. The deeper fix (multiple ExecutorPool instances, or `lite_safe`-skip-under-contention path) is out of scope here.

Stop sign #2 from v0.3 ("ODE profile lands and 6+ of the 7s is numpy/embedding compute") was conditional on the locked phase being the floor. That premise didn't hold — the locked phase is ~2% of wall-clock. The honest reading is that the v0.3 architectural argument needs the operator's eyes again with the new data. **Memory feedback `substrate-migration-status-quo-bias.md` flagged that I reliably resist substrate migrations; I'm trying to present this honestly rather than steer the conclusion.**

## Test plan

- [x] `tests/test_temporal.py::test_temporal_phase_2_reads_run_concurrently` — 50ms sleep on each mocked read; total <170ms catches anyone undoing the gather.
- [x] `tests/test_temporal.py::test_temporal_phase_2_tolerates_single_failure` — confirms gather(return_exceptions=True) preserves the pre-existing per-call try/except semantics (one read failing doesn't suppress others).
- [x] Existing `tests/test_temporal.py` (27 tests) + `tests/test_enrichment_pipeline.py` (10 tests) pass unchanged.
- [x] `./scripts/dev/test-cache.sh --staged` clean: **8945 passed / 0 failed / 34 skipped** (3:02). Coverage 79.84%.
- [x] **Side-by-side benchmark**: master vs branch under identical 4-way concurrent load; 104× user-visible improvement (table above).
- [ ] **Not run**: sustained higher-concurrency benchmark (N_WORKERS=8-16) to validate the ceiling. Recommended pre-merge.
- [ ] **Not run**: full operator review of the v0.3 implications before merge.

## Discovery context

Discovered during operator-authorized ODE profiling (per `docs/proposals/beam-footprint-roadmap-v0.md` §V0.3 RESOLUTION). The "ODE profile" finding was that the user-visible 7s lives in post-lock enrichment, not the ODE; this PR collapses what it can. A v0.3.1 amendment doc will land separately.