### PR TITLE
docs(beam): add sustained process update benchmark

### DIFF
--- a/docs/proposals/beam-footprint-roadmap-v0.md
+++ b/docs/proposals/beam-footprint-roadmap-v0.md
@@ -1,7 +1,7 @@
 # BEAM Footprint Roadmap
 
 **Created:** May 3, 2026
-**Last Updated:** May 28, 2026 (v0.3.1 amendment — ODE profile landed; the "7s locked-phase floor" framing falsified; post-lock enrichment was the actual user-visible floor and is now Python-fixed in PR #533)
+**Last Updated:** May 28, 2026 (v0.3.1b amendment — ODE profile landed; the "7s locked-phase floor" framing falsified; post-lock enrichment was the actual user-visible floor, Python-fixed in PR #533, and re-benchmarked at 8/16 concurrent workers)
 **Status:** v0.3 — destination is **A′ (committed, operator-decision-driven, 2026-05-05)**. Stateful coordination ports to BEAM in waves; stateless computation (numpy ODE, embeddings, LLM SDK calls) stays Python and is called from BEAM via Ports / HTTP. v0.2 had reopened the destination after PR #350's verdict; v0.3 closes it again on operator call after four Python-fixable PRs (#350 / #354 / #360 / #361) closed every measured floor without moving the user-visible ~11s p50 per-turn overhead. **Read the V0.3 RESOLUTION block first**, then the V0.3.1 amendment for what changed on 2026-05-28. v0 / v0.1 / v0.2 bodies preserved as historical record.
 **Council pass v0.1 (2026-05-04):** dialectic-knowledge-architect (2B/4C/3D/4N), feature-dev:code-reviewer (2B/3C/2D/2N), live-verifier (7 VERIFIED, 6 DRIFT, 0 REFUTED, 1 SOURCE_ONLY) — all findings folded inline. Architect C3 + reviewer C3 both flagged "v0.1 destination committed pre-experiment"; the v0.1 conditionality block was the fold for that finding, and v0.2 was the realization of it.
 **Council pass v0.3:** none on the migration call itself — that's an operator decision after a multi-session debate, and adversarial review of the call after operator commitment is the relitigation pattern v0.3 is trying to end. Council passes ARE expected on technical scope (Wave 1 supervisor topology, BEAM↔Python boundary contracts, identity-state migration) once those land as RFCs.
@@ -31,6 +31,20 @@ The v0.3 RESOLUTION's load-bearing unknown was the ODE profile — the 7s remain
 
 The fix is a `loop.run_in_executor` wrap on the sync `query_audit_log` call plus an `asyncio.gather` refactor on the 5 independent reads in `build_temporal_context`. CLAUDE.md "Substrate Tax" pattern #2 (sync-client + executor) — already documented as the workaround for this exact bug class.
 
+### V0.3.1b sustained-concurrency follow-up — 2026-05-28
+
+PR #533 merged before the recommended 8-16 worker benchmark ran. A follow-up run on current master (`13517b42`, governance MCP on `127.0.0.1:8767`) used the repo-captured load generator in `scripts/dev/process_update_loadgen.py`. Each worker minted a fresh identity and ran 16 `process_agent_update` calls with `response_mode=minimal`; this tests multi-agent concurrency, not same-agent mailbox serialization.
+
+| Run | Calls | Wall-clock | p50 | p95 | p99 | max | Errors |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| PR #533 4 workers | 32 | 0.5s | 51ms | n/a | 125ms | 125ms | 0 |
+| Master 8 workers | 128 | 4.5s | 281ms | 338ms | 360ms | 378ms | 0 |
+| Master 16 workers | 256 | 8.9s | 554ms | 622ms | 641ms | 647ms | 0 |
+
+**Interpretation.** The single-ExecutorPool-thread ceiling is still visible: p50 grows roughly with worker count. But the ceiling under this synthetic fresh-agent load is sub-second at 16 concurrent agents, not multi-second. That materially weakens "Wave 3 as urgent latency rescue" and strengthens "Wave 3 only if the coordination/ownership argument survives its own gates."
+
+This is not the Wave 3 RFC §0(A.2) production-telemetry measurement by itself. The run uses fresh synthetic identities, short audit histories, no resident traffic mix, and one local server window. It is still enough to require a production telemetry read before citing old 5-11s `process_agent_update` p99 as current evidence for handler-dispatch migration pressure.
+
 **Bias accountability.** Memory `feedback_substrate-migration-status-quo-bias.md` flags that I reliably resist substrate migrations across sessions. This profile + fix lands in that pole. I'm flagging it explicitly: a Python-side fix collapsing 104× of the user-visible floor with one `run_in_executor` is exactly the shape v0.3 said it would no longer be moved by. The operator has two honest reads available:
 
 1. **The destination is still A′ on the architectural-ceiling argument.** The single-ExecutorPool-thread serialization is still real and is structural to anyio + asyncio + asyncpg on a shared event loop. Under N>>4 sustained concurrency this benchmark's 51ms p50 will degrade. The v0.3 framing was wrong about *which mechanism* dissolves under BEAM but right that *some* mechanism does. The fix doesn't change the destination; it changes the timeline pressure.
@@ -48,6 +62,8 @@ This amendment does not pick between (1) and (2). The v0.3 RESOLUTION explicitly
 - PR #533 — the fix + benchmark
 - Profile run: `/tmp/mcp_profile_analysis.txt`, `/tmp/mcp_phase_logs_tail100.txt`
 - Benchmark: `/tmp/loadgen_8770.py`, `/tmp/loadgen_baseline_out.txt`, `/tmp/loadgen_worktree_out.txt`, `/tmp/parse_phases.py`
+- Reproducible benchmark tooling: `scripts/dev/process_update_loadgen.py`, `scripts/dev/parse_update_phase_logs.py`
+- Sustained local benchmark outputs: `/tmp/process_update_loadgen_8x16.json`, `/tmp/process_update_loadgen_16x16.json`
 - Memory: `project_locked-phase-floor-is-the-ode.md` (the misattribution this amendment supersedes — needs a 2026-05-28 amendment of its own)
 
 ---

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,6 +16,8 @@
 | `check_ci_python_version_sync.py` | Verify CI Python version matches project |
 | `doc_audit.sh` | Check all three Unitares repos for stale docs |
 | `file_lease.py` | Claim BEAM lease-plane `file://` surfaces before code edits; `guard --changed` wraps commands, `hold --changed` refreshes and heartbeats during agent work |
+| `parse_update_phase_logs.py` | Parse `[checkin_phases]` and `[enrichment_phases]` timing lines from MCP logs |
+| `process_update_loadgen.py` | Drive concurrent `process_agent_update` load against the local governance MCP server |
 | `test-cache.sh` | Tree-hash pytest cache (skips if tests already passed against this exact working tree) |
 | `update_docs_tool_count.py` | Update tool counts in documentation |
 | `version_manager.py` | Version management utilities |

--- a/scripts/dev/parse_update_phase_logs.py
+++ b/scripts/dev/parse_update_phase_logs.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Parse process_agent_update phase timing lines from a log slice."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import statistics
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+
+ENRICHERS = (
+    "enrich_knowledge_surfacing",
+    "enrich_temporal_context",
+    "enrich_learning_context",
+    "enrich_mirror_signals",
+)
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = round((len(ordered) - 1) * pct)
+    return ordered[index]
+
+
+def _stats(values: list[float]) -> str:
+    if not values:
+        return "n=0"
+    return (
+        f"n={len(values)} avg={statistics.mean(values):.1f}ms "
+        f"p50={_percentile(values, 0.50):.0f}ms "
+        f"p90={_percentile(values, 0.90):.0f}ms "
+        f"p99={_percentile(values, 0.99):.0f}ms "
+        f"max={max(values):.0f}ms"
+    )
+
+
+def _read_selected_lines(path: Path, start_line: int, end_line: int | None) -> Iterable[str]:
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, 1):
+            if line_number < start_line:
+                continue
+            if end_line is not None and line_number > end_line:
+                break
+            yield line
+
+
+def _extract_ms(line: str, key: str) -> float | None:
+    match = re.search(rf"{re.escape(key)}=(\d+(?:\.\d+)?)ms", line)
+    if match:
+        return float(match.group(1))
+    return None
+
+
+def parse_log(
+    path: Path,
+    start_line: int,
+    end_line: int | None,
+) -> tuple[list[float], list[float], dict[str, list[float]], int]:
+    checkin_totals: list[float] = []
+    enrichment_totals: list[float] = []
+    per_enricher: dict[str, list[float]] = {name: [] for name in ENRICHERS}
+    enrichment_line_count = 0
+
+    for line in _read_selected_lines(path, start_line, end_line):
+        if "[checkin_phases]" in line:
+            total = _extract_ms(line, "total")
+            enrichment = _extract_ms(line, "enrichment")
+            if total is not None:
+                checkin_totals.append(total)
+            if enrichment is not None:
+                enrichment_totals.append(enrichment)
+        elif "[enrichment_phases]" in line:
+            enrichment_line_count += 1
+            for enricher in ENRICHERS:
+                duration = _extract_ms(line, enricher)
+                if duration is not None:
+                    per_enricher[enricher].append(duration)
+
+    return checkin_totals, enrichment_totals, per_enricher, enrichment_line_count
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path)
+    parser.add_argument("--start-line", type=int, default=1)
+    parser.add_argument("--end-line", type=int)
+    parser.add_argument("--label", default="phase log")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    checkin_totals, enrichment_totals, per_enricher, enrichment_line_count = parse_log(
+        args.path,
+        args.start_line,
+        args.end_line,
+    )
+
+    line_range = f"{args.start_line}..{args.end_line}" if args.end_line else f"{args.start_line}..EOF"
+    print(f"=== {args.label} ({line_range}, enrichment_lines={enrichment_line_count}) ===")
+    print(f"checkin total: {_stats(checkin_totals)}")
+    print(f"enrichment phase: {_stats(enrichment_totals)}")
+    for enricher in ENRICHERS:
+        print(f"  {enricher}: {_stats(per_enricher[enricher])}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/process_update_loadgen.py
+++ b/scripts/dev/process_update_loadgen.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Drive concurrent process_agent_update calls against a governance MCP server.
+
+This is intentionally a local development/load diagnostic. It mints fresh
+short-lived identities, then runs one worker thread per identity so benchmark
+traffic exercises multiple agent locks and the post-lock enrichment fan-out.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+
+DEFAULT_URL = "http://127.0.0.1:8767/v1/tools/call"
+
+
+@dataclass
+class ToolCallResult:
+    payload: dict[str, Any] | None
+    duration_ms: float
+    error: str | None
+
+
+@dataclass
+class WorkerResult:
+    durations_ms: list[float]
+    errors: list[str]
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = round((len(ordered) - 1) * pct)
+    return ordered[index]
+
+
+def _stats(values: list[float]) -> dict[str, float | int]:
+    if not values:
+        return {
+            "n": 0,
+            "min_ms": 0.0,
+            "p50_ms": 0.0,
+            "p95_ms": 0.0,
+            "p99_ms": 0.0,
+            "max_ms": 0.0,
+            "mean_ms": 0.0,
+        }
+    return {
+        "n": len(values),
+        "min_ms": min(values),
+        "p50_ms": _percentile(values, 0.50),
+        "p95_ms": _percentile(values, 0.95),
+        "p99_ms": _percentile(values, 0.99),
+        "max_ms": max(values),
+        "mean_ms": statistics.mean(values),
+    }
+
+
+def _call_tool(
+    *,
+    url: str,
+    name: str,
+    arguments: dict[str, Any],
+    agent_header: str,
+    session_id: str | None,
+    timeout_s: float,
+) -> ToolCallResult:
+    headers = {
+        "Content-Type": "application/json",
+        "X-Agent-Id": agent_header,
+    }
+    if session_id:
+        headers["X-Session-ID"] = session_id
+
+    body = json.dumps({"name": name, "arguments": arguments}).encode()
+    request = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    started = time.perf_counter()
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_s) as response:
+            payload = json.loads(response.read())
+        return ToolCallResult(payload, (time.perf_counter() - started) * 1000, None)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")
+        return ToolCallResult(None, (time.perf_counter() - started) * 1000, f"HTTP {exc.code}: {detail}")
+    except Exception as exc:  # noqa: BLE001 - load diagnostic should collect all failures.
+        return ToolCallResult(None, (time.perf_counter() - started) * 1000, f"{type(exc).__name__}: {exc}")
+
+
+def _onboard_worker(args: argparse.Namespace, index: int) -> tuple[str, str] | None:
+    result = _call_tool(
+        url=args.url,
+        name="onboard",
+        arguments={
+            "force_new": True,
+            "spawn_reason": args.spawn_reason,
+            "name": f"{args.worker_name_prefix}_w{index}",
+            "initial_state": {
+                "purpose": "process_agent_update_loadgen",
+                "worker_index": index,
+                "created_by": "scripts/dev/process_update_loadgen.py",
+            },
+        },
+        agent_header=args.agent_header,
+        session_id=None,
+        timeout_s=args.timeout_s,
+    )
+    if result.error or result.payload is None:
+        print(f"  onboard w{index} ERR: {result.error}", flush=True)
+        return None
+
+    body = result.payload.get("result", result.payload)
+    agent_uuid = body.get("uuid") or body.get("agent_uuid")
+    client_session_id = body.get("client_session_id")
+    if not agent_uuid or not client_session_id:
+        print(f"  onboard w{index} ERR: missing uuid/client_session_id in {body}", flush=True)
+        return None
+    return str(agent_uuid), str(client_session_id)
+
+
+def _update_loop(
+    *,
+    args: argparse.Namespace,
+    label: str,
+    client_session_id: str,
+    results: dict[str, WorkerResult],
+) -> None:
+    durations: list[float] = []
+    errors: list[str] = []
+    for index in range(args.calls_per_worker):
+        result = _call_tool(
+            url=args.url,
+            name="process_agent_update",
+            arguments={
+                "response_text": (
+                    f"{args.payload_label} {label} iter {index}; "
+                    "sustained concurrency benchmark for BEAM migration analysis"
+                ),
+                "complexity": 0.5 + (index % 5) * 0.1,
+                "confidence": 0.6 + (index % 4) * 0.08,
+                "client_session_id": client_session_id,
+                "task_type": "mixed",
+                "response_mode": "minimal",
+            },
+            agent_header=args.agent_header,
+            session_id=client_session_id,
+            timeout_s=args.timeout_s,
+        )
+        durations.append(result.duration_ms)
+        if result.error:
+            errors.append(f"iter {index}: {result.error}")
+        elif result.payload is not None:
+            body = result.payload.get("result", result.payload)
+            if body.get("success") is False:
+                errors.append(f"iter {index}: tool returned success=false: {body}")
+    results[label] = WorkerResult(durations, errors)
+
+
+def _print_worker_summary(label: str, result: WorkerResult) -> None:
+    stats = _stats(result.durations_ms)
+    print(
+        f"  [{label}] n={stats['n']} errs={len(result.errors)} "
+        f"p50={stats['p50_ms']:.0f}ms p95={stats['p95_ms']:.0f}ms "
+        f"p99={stats['p99_ms']:.0f}ms max={stats['max_ms']:.0f}ms",
+        flush=True,
+    )
+    for error in result.errors[:3]:
+        print(f"    error: {error}", flush=True)
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    workers: list[tuple[str, str, str]] = []
+    for index in range(args.workers):
+        onboarded = _onboard_worker(args, index)
+        if onboarded is not None:
+            agent_uuid, client_session_id = onboarded
+            workers.append((f"w{index}", agent_uuid, client_session_id))
+
+    print(f"onboarded {len(workers)} workers", flush=True)
+
+    results: dict[str, WorkerResult] = {}
+    threads: list[threading.Thread] = []
+    started = time.perf_counter()
+    for label, _agent_uuid, client_session_id in workers:
+        thread = threading.Thread(
+            target=_update_loop,
+            kwargs={
+                "args": args,
+                "label": label,
+                "client_session_id": client_session_id,
+                "results": results,
+            },
+            name=f"loadgen-{label}",
+        )
+        thread.start()
+        threads.append(thread)
+
+    for thread in threads:
+        thread.join()
+    wall_clock_s = time.perf_counter() - started
+
+    all_durations: list[float] = []
+    total_errors = 0
+    for label in sorted(results):
+        result = results[label]
+        _print_worker_summary(label, result)
+        all_durations.extend(result.durations_ms)
+        total_errors += len(result.errors)
+
+    total_stats = _stats(all_durations)
+    print(
+        f"TOTAL: {total_stats['n']} calls in {wall_clock_s:.1f}s "
+        f"(p50={total_stats['p50_ms']:.0f}ms p95={total_stats['p95_ms']:.0f}ms "
+        f"p99={total_stats['p99_ms']:.0f}ms max={total_stats['max_ms']:.0f}ms "
+        f"errors={total_errors})",
+        flush=True,
+    )
+    return {
+        "url": args.url,
+        "workers_requested": args.workers,
+        "workers_onboarded": len(workers),
+        "calls_per_worker": args.calls_per_worker,
+        "wall_clock_s": wall_clock_s,
+        "total_errors": total_errors,
+        "total": total_stats,
+        "workers": {
+            label: {
+                "errors": result.errors,
+                "stats": _stats(result.durations_ms),
+            }
+            for label, result in sorted(results.items())
+        },
+    }
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", default=os.environ.get("GOVERNANCE_TOOL_URL", DEFAULT_URL))
+    parser.add_argument("--workers", type=int, default=int(os.environ.get("N_WORKERS", "4")))
+    parser.add_argument(
+        "--calls-per-worker",
+        type=int,
+        default=int(os.environ.get("N_PER_WORKER", "8")),
+    )
+    parser.add_argument("--timeout-s", type=float, default=60.0)
+    parser.add_argument("--agent-header", default=os.environ.get("LOADGEN_AGENT_HEADER", "process-update-loadgen"))
+    parser.add_argument("--worker-name-prefix", default="process_update_loadgen")
+    parser.add_argument("--spawn-reason", default="perf_profile_load")
+    parser.add_argument("--payload-label", default="process_update_loadgen")
+    parser.add_argument("--json-output", help="Optional path for machine-readable benchmark output.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    summary = run(args)
+    if args.json_output:
+        with open(args.json_output, "w", encoding="utf-8") as handle:
+            json.dump(summary, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+    return 1 if summary["total_errors"] or summary["workers_onboarded"] != args.workers else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- adds a reusable concurrent `process_agent_update` load generator and phase-log parser under `scripts/dev/`
- records the missing 8/16-worker follow-up from PR #533 in the BEAM footprint roadmap
- documents that the synthetic 16-agent run is sub-second p99, so old 5-11s p99 numbers should not be cited as current Wave 3 latency pressure without production telemetry

## Benchmark

Current master `13517b42`, governance MCP on `127.0.0.1:8767`:

| Run | Calls | Wall-clock | p50 | p95 | p99 | max | Errors |
|---|---:|---:|---:|---:|---:|---:|---:|
| 8 workers x 16 calls | 128 | 4.5s | 281ms | 338ms | 360ms | 378ms | 0 |
| 16 workers x 16 calls | 256 | 8.9s | 554ms | 622ms | 641ms | 647ms | 0 |

## Test plan

- `python3 -m py_compile scripts/dev/process_update_loadgen.py scripts/dev/parse_update_phase_logs.py`
- `python3 scripts/dev/parse_update_phase_logs.py /tmp/mcp_phase_logs_tail100.txt --label tmp-profile`
- `python3 scripts/dev/process_update_loadgen.py --workers 1 --calls-per-worker 1 --timeout-s 60 --json-output /tmp/process_update_loadgen_smoke.json`
- `python3 scripts/dev/process_update_loadgen.py --workers 8 --calls-per-worker 16 --timeout-s 120 --json-output /tmp/process_update_loadgen_8x16.json`
- `python3 scripts/dev/process_update_loadgen.py --workers 16 --calls-per-worker 16 --timeout-s 120 --json-output /tmp/process_update_loadgen_16x16.json`
- `./scripts/dev/test-cache.sh` -> 8968 passed, 25 skipped, 2 warnings
- pre-push smoke -> 138 passed, 8294 deselected; doc health clear

Note: `./scripts/dev/test-cache.sh --staged` was not completed because it waited behind another worktree's active pytest lock after the full test-cache run had already passed.