### PR TITLE
feat(wave3a): Python probe endpoint scaffolding (PR #1 of v0.2)

### DIFF
--- a/src/mcp_handlers/wave3a_probe.py
+++ b/src/mcp_handlers/wave3a_probe.py
@@ -1,0 +1,531 @@
+"""
+Wave 3a Python probe endpoint surface.
+
+Internal HTTP surface at ``/v1/probe/*`` consumed only by the BEAM-side
+Wave 3a handler listener (see ``docs/proposals/beam-wave-3a-read-only-handlers.md``
+§2.3). This module is PR #1 of the v0.2 sequencing — scaffolding only; no
+production traffic flows through it until PR #4/PR #5 land.
+
+Contract surfaces:
+
+- §2.2 envelope shape: top-level keys (``ok``, ``protocol_version``, ...).
+  Matches the lease plane top-level-keys contract (no nested ``data`` wrapper).
+- §2.5 bearer-auth via ``WAVE_3A_PROBE_TOKEN``; missing -> 503 (fail-closed);
+  present-but-wrong -> 401.
+- §2.6 timestamp masking applied to ``tool_registry`` so the response is
+  byte-deterministic across calls (catches ``list_tools``-style
+  "non-determinism added later" regressions at probe scope, not just at
+  handler scope).
+
+Council folds addressed in this module:
+
+- FIND-R2 (``list_all_aliases`` lazy state). ``tool_stability.list_all_aliases``
+  returns a copy of a module-level dict that is populated at import time;
+  there is no first-call build. The byte-equality test on the masked
+  ``tool_registry`` response is the structural guard against a future
+  regression that introduces lazy state.
+- FIND-R3 (``get_server_info`` PID semantics). The probe response describes
+  the Python probe process. ``meta.probe_process: true`` makes the response
+  self-identifying so the BEAM caller can override or annotate before
+  returning to its own client.
+
+This module mounts its routes on the existing MCP HTTP listener (the
+Starlette ``app`` created in ``src/mcp_server.py``) via
+``register_wave3a_probe_routes(app)``. It does NOT spawn a new HTTP server.
+The route prefix carries its own bearer-auth — the public MCP bearer
+(``UNITARES_HTTP_API_TOKEN``) is not consulted on this prefix.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import secrets
+import time
+from typing import Any, Dict, Optional
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+from src.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+PROTOCOL_VERSION = "wave3a.v1"
+PROBE_TOKEN_ENV = "WAVE_3A_PROBE_TOKEN"
+PROBE_PREFIX = "/v1/probe"
+
+
+# ---------------------------------------------------------------------------
+# Envelope helpers
+# ---------------------------------------------------------------------------
+
+
+def _envelope_ok(payload: Dict[str, Any], *, meta: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Build a top-level-keys success envelope per §2.2.
+
+    The handler-specific payload is flattened under ``data`` (NOT nested
+    under ``data.data``); ``meta`` is optional and reserved for
+    response-shape annotations like ``probe_process`` (FIND-R3 fold).
+    """
+    body: Dict[str, Any] = {
+        "ok": True,
+        "protocol_version": PROTOCOL_VERSION,
+        "data": payload,
+    }
+    if meta is not None:
+        body["meta"] = meta
+    return body
+
+
+def _envelope_err(error: str, reason: str, *, detail: Optional[Any] = None) -> Dict[str, Any]:
+    """Build a top-level-keys error envelope per §2.2.
+
+    ``error`` is machine-readable; ``reason`` is short human prose;
+    ``detail`` is optional structured context.
+    """
+    body: Dict[str, Any] = {
+        "ok": False,
+        "protocol_version": PROTOCOL_VERSION,
+        "error": error,
+        "reason": reason,
+    }
+    if detail is not None:
+        body["detail"] = detail
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Auth — §2.5 fail-closed
+# ---------------------------------------------------------------------------
+
+
+def _get_configured_token() -> Optional[str]:
+    """Read the probe token from env each request — supports rotation."""
+    tok = os.environ.get(PROBE_TOKEN_ENV)
+    if tok is None or tok == "":
+        return None
+    return tok
+
+
+def _service_unavailable_response() -> JSONResponse:
+    """Fail-closed response when the probe token is not configured."""
+    return JSONResponse(
+        _envelope_err(
+            "service_unavailable",
+            f"{PROBE_TOKEN_ENV} not configured",
+        ),
+        status_code=503,
+    )
+
+
+def _unauthorized_response() -> JSONResponse:
+    return JSONResponse(
+        _envelope_err(
+            "permission_denied",
+            "bearer token missing or invalid",
+        ),
+        status_code=401,
+    )
+
+
+def _check_bearer(request: Request, configured_token: str) -> bool:
+    """Constant-time bearer-token check."""
+    auth = request.headers.get("authorization") or request.headers.get("Authorization")
+    if not auth or not isinstance(auth, str):
+        return False
+    if not auth.lower().startswith("bearer "):
+        return False
+    token = auth.split(" ", 1)[1].strip()
+    return secrets.compare_digest(token, configured_token)
+
+
+def _auth_or_response(request: Request) -> Optional[JSONResponse]:
+    """Returns an error JSONResponse if auth fails, else None.
+
+    Order:
+        1. Token unset in env -> 503 (fail-closed).
+        2. Token set, request missing/wrong bearer -> 401.
+        3. Token set, request authorized -> None.
+
+    /v1/probe/health is exempted by the caller — see ``_health`` handler.
+    """
+    configured = _get_configured_token()
+    if configured is None:
+        return _service_unavailable_response()
+    if not _check_bearer(request, configured):
+        return _unauthorized_response()
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Timestamp masking — §2.6
+# ---------------------------------------------------------------------------
+
+
+# ISO-8601 datetime: YYYY-MM-DD[T ]HH:MM:SS[.ffffff][Z|+HH:MM]
+_ISO8601_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})?$"
+)
+
+# UUID (8-4-4-4-12 hex)
+_UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+
+# Fields whose values are always non-deterministic and should be masked
+# regardless of value shape. Keep this conservative — false-positive masking
+# is cheaper than letting jitter slip through and break golden parity.
+_VOLATILE_FIELD_NAMES = frozenset(
+    {
+        # timestamps / time deltas
+        "created_at",
+        "updated_at",
+        "started_at",
+        "completed_at",
+        "timestamp",
+        "ts",
+        "produced_at",
+        "server_time",
+        "build_date",
+        # latency / cumulative counters
+        "uptime",
+        "uptime_seconds",
+        "uptime_minutes",
+        "uptime_hours",
+        "uptime_formatted",
+        "current_uptime_seconds",
+        "current_uptime_formatted",
+        "elapsed_ms",
+        "processing_time_ms",
+        "duration_ms",
+        "age_seconds",
+        "monotonic_ns",
+        "create_time",
+        # PIDs and process-identifying ints
+        "pid",
+        "current_pid",
+        "ppid",
+        # request/correlation ids
+        "request_id",
+        "correlation_id",
+        "trace_id",
+        "span_id",
+    }
+)
+
+# Suffix matchers — anything ending with these is masked.
+_VOLATILE_SUFFIXES = (
+    "_at",
+    "_ms",
+    "_ns",
+    "_uuid",
+    "_pid",
+    "_id_uuid",
+)
+
+
+def _is_volatile_key(key: str) -> bool:
+    if key in _VOLATILE_FIELD_NAMES:
+        return True
+    for suffix in _VOLATILE_SUFFIXES:
+        if key.endswith(suffix):
+            # _id is too broad (tool_id, agent_id are legitimately stable in
+            # tests); _id_uuid catches the explicitly volatile variant.
+            if suffix == "_uuid" or suffix == "_pid":
+                return True
+            # _at, _ms, _ns, _id_uuid are unambiguous; safe to mask
+            return True
+    return False
+
+
+def _mask_value(key: str, value: Any) -> Any:
+    """Mask a single value by key and shape.
+
+    Strategy:
+      - Key-based: if key matches a volatile name/suffix, replace.
+      - Shape-based: if the value LOOKS like an ISO-8601 timestamp or UUID,
+        replace even if the key wasn't on the volatile list (catches
+        timestamps stashed in generic ``meta`` blobs).
+    """
+    if _is_volatile_key(key):
+        if isinstance(value, str):
+            if _ISO8601_RE.match(value):
+                return "<MASKED_TIMESTAMP>"
+            if _UUID_RE.match(value):
+                return "<MASKED_UUID>"
+            # uptime_formatted ("Xh Ym"), build_date strings, etc.
+            return "<MASKED_TIMESTAMP>"
+        if isinstance(value, bool):
+            # bools subclass int — preserve them
+            return value
+        if isinstance(value, int):
+            # PIDs and counters
+            if key.endswith("_pid") or key == "pid" or key == "current_pid" or key == "ppid":
+                return "<MASKED_PID>"
+            return "<MASKED_COUNTER>"
+        if isinstance(value, float):
+            return "<MASKED_COUNTER>"
+        if value is None:
+            return None
+        return mask_timestamps(value) if isinstance(value, (dict, list)) else value
+
+    # Shape-based fallback for strings under non-volatile keys
+    if isinstance(value, str):
+        if _ISO8601_RE.match(value):
+            return "<MASKED_TIMESTAMP>"
+        if _UUID_RE.match(value):
+            return "<MASKED_UUID>"
+        return value
+
+    if isinstance(value, (dict, list)):
+        return mask_timestamps(value)
+    return value
+
+
+def mask_timestamps(payload: Any) -> Any:
+    """Recursively replace non-deterministic fields with stable placeholders.
+
+    Applied to the ``tool_registry`` response to guarantee byte-deterministic
+    output. The byte-equality test in
+    ``tests/integration/test_wave_3a_probe.py`` calls this endpoint twice
+    and diffs the masked bodies; any new non-deterministic field that this
+    helper misses will break that test.
+
+    Returns a new structure; does not mutate the input.
+    """
+    if isinstance(payload, dict):
+        return {key: _mask_value(key, value) for key, value in payload.items()}
+    if isinstance(payload, list):
+        return [mask_timestamps(item) for item in payload]
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Endpoint implementations
+# ---------------------------------------------------------------------------
+
+
+async def _health(request: Request) -> JSONResponse:
+    """Bare liveness probe. No auth, no data payload.
+
+    Mirrors the lease plane's ``/health`` shape so the BEAM Finch client can
+    verify connectivity before bothering with bearer headers.
+    """
+    return JSONResponse(
+        {
+            "ok": True,
+            "protocol_version": PROTOCOL_VERSION,
+        },
+        status_code=200,
+    )
+
+
+async def _health_snapshot(request: Request) -> JSONResponse:
+    auth_err = _auth_or_response(request)
+    if auth_err is not None:
+        return auth_err
+
+    # Import lazily so test patches at module scope work.
+    from src.services.health_snapshot import (
+        PROBE_INTERVAL_SECONDS,
+        STALENESS_THRESHOLD_SECONDS,
+        get_snapshot,
+        is_stale,
+    )
+
+    snapshot, age_seconds, produced_at = get_snapshot()
+    if snapshot is None:
+        return JSONResponse(
+            _envelope_err(
+                "snapshot_unavailable",
+                "deep_health_probe has not run yet",
+            ),
+            status_code=503,
+        )
+
+    # Full snapshot (no lite filter) per §2.3 — the BEAM-side handler decides
+    # whether to apply the lite filter on its end.
+    response_data = dict(snapshot)
+    response_data["_cache"] = {
+        "age_seconds": round(age_seconds, 1) if age_seconds is not None else None,
+        "produced_at": produced_at,
+        "stale": is_stale(age_seconds),
+        "probe_interval_seconds": PROBE_INTERVAL_SECONDS,
+        "staleness_threshold_seconds": STALENESS_THRESHOLD_SECONDS,
+    }
+    return JSONResponse(_envelope_ok(response_data), status_code=200)
+
+
+async def _server_info(request: Request) -> JSONResponse:
+    auth_err = _auth_or_response(request)
+    if auth_err is not None:
+        return auth_err
+
+    # Reproduce the get_server_info data shape WITHOUT going through the MCP
+    # handler (avoids TextContent wrapping). The fields here mirror the
+    # success_response payload returned by handle_get_server_info — golden
+    # parity is enforced in PR #6, not here.
+    import sys
+
+    from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
+
+    argv = [str(a) for a in getattr(sys, "argv", [])]
+    is_http = any("mcp_server.py" in a for a in argv)
+    is_stdio = any("mcp_server_std.py" in a for a in argv)
+    transport = "HTTP" if is_http else ("STDIO" if is_stdio else "unknown")
+
+    current_pid = os.getpid()
+    server_version = getattr(mcp_server, "SERVER_VERSION", None) or "unknown"
+    server_build_date = getattr(mcp_server, "SERVER_BUILD_DATE", None) or "unknown"
+
+    server_processes = []
+    current_uptime = 0.0
+    if mcp_server.PSUTIL_AVAILABLE:
+        import psutil
+
+        target_script = (
+            "mcp_server.py" if is_http else ("mcp_server_std.py" if is_stdio else None)
+        )
+        try:
+            for proc in psutil.process_iter(["pid", "name", "cmdline", "create_time", "status"]):
+                try:
+                    cmdline = proc.info.get("cmdline", [])
+                    if not cmdline:
+                        continue
+                    if target_script:
+                        if not any(target_script in str(arg) for arg in cmdline):
+                            continue
+                    else:
+                        if not any(
+                            ("mcp_server_std.py" in str(arg) or "mcp_server.py" in str(arg))
+                            for arg in cmdline
+                        ):
+                            continue
+                    pid = proc.info["pid"]
+                    create_time = proc.info.get("create_time", 0)
+                    uptime_seconds = time.time() - create_time
+                    server_processes.append(
+                        {
+                            "pid": pid,
+                            "is_current": pid == current_pid,
+                            "uptime_seconds": int(uptime_seconds),
+                            "status": proc.info.get("status", "unknown"),
+                        }
+                    )
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    continue
+        except Exception as exc:
+            server_processes = [{"error": f"Could not enumerate processes: {exc}"}]
+
+        try:
+            current_proc = psutil.Process(current_pid)
+            current_uptime = time.time() - current_proc.create_time()
+            if not server_processes:
+                server_processes.append(
+                    {
+                        "pid": current_pid,
+                        "is_current": True,
+                        "uptime_seconds": int(current_uptime),
+                        "status": getattr(current_proc, "status", lambda: "unknown")(),
+                    }
+                )
+        except Exception:
+            current_uptime = 0.0
+
+    from src.mcp_handlers import TOOL_HANDLERS
+
+    payload = {
+        "transport": transport,
+        "server_version": server_version,
+        "build_date": server_build_date,
+        "tool_count": len(TOOL_HANDLERS),
+        "current_pid": current_pid,
+        "current_uptime_seconds": int(current_uptime),
+        "server_processes": server_processes,
+        "health": "healthy",
+    }
+    # FIND-R3 fold: BEAM caller knows this PID/transport describes the
+    # Python probe process and may inject its own values before returning
+    # to its caller.
+    meta = {"probe_process": True}
+    return JSONResponse(_envelope_ok(payload, meta=meta), status_code=200)
+
+
+async def _tool_registry(request: Request) -> JSONResponse:
+    auth_err = _auth_or_response(request)
+    if auth_err is not None:
+        return auth_err
+
+    from src.mcp_handlers import TOOL_HANDLERS
+    from src.mcp_handlers.tool_stability import list_all_aliases
+    from src.tool_modes import TOOL_TIERS
+
+    # Tools: names + (optional) tier classification.
+    tool_names = sorted(TOOL_HANDLERS.keys())
+    tools = [{"name": name} for name in tool_names]
+
+    # Aliases: old_name -> {new_name, ...}. Datetime fields are coerced to
+    # ISO-8601 strings so JSON serialization succeeds; they're then masked
+    # by ``mask_timestamps`` below (deterministic byte-equality contract).
+    from datetime import date, datetime
+
+    aliases_raw = list_all_aliases()
+    aliases: Dict[str, Dict[str, Any]] = {}
+    for old_name, alias in aliases_raw.items():
+        entry: Dict[str, Any] = {}
+        for attr in ("new_name", "deprecated_since", "removal_target", "migration"):
+            value = getattr(alias, attr, None)
+            if value is None:
+                continue
+            if isinstance(value, (datetime, date)):
+                value = value.isoformat()
+            entry[attr] = value
+        aliases[old_name] = entry
+
+    # Tiers: tier_name -> [tools].
+    tiers: Dict[str, list] = {}
+    if isinstance(TOOL_TIERS, dict):
+        for tier_name, tier_tools in TOOL_TIERS.items():
+            if isinstance(tier_tools, (list, tuple, set)):
+                tiers[str(tier_name)] = sorted(str(t) for t in tier_tools)
+
+    deprecated_tools = sorted(aliases.keys())
+
+    payload = {
+        "tools": tools,
+        "aliases": aliases,
+        "tiers": tiers,
+        "deprecated_tools": deprecated_tools,
+    }
+    masked = mask_timestamps(payload)
+    return JSONResponse(_envelope_ok(masked), status_code=200)
+
+
+# ---------------------------------------------------------------------------
+# Route registration
+# ---------------------------------------------------------------------------
+
+
+def register_wave3a_probe_routes(app) -> None:
+    """Mount the Wave 3a probe routes on an existing Starlette app.
+
+    Idempotent: re-registering does nothing.
+    """
+    existing_paths = {
+        getattr(route, "path", None) for route in getattr(app, "routes", [])
+    }
+    routes = [
+        Route(f"{PROBE_PREFIX}/health", _health, methods=["GET"]),
+        Route(f"{PROBE_PREFIX}/health_snapshot", _health_snapshot, methods=["GET"]),
+        Route(f"{PROBE_PREFIX}/server_info", _server_info, methods=["GET"]),
+        Route(f"{PROBE_PREFIX}/tool_registry", _tool_registry, methods=["GET"]),
+    ]
+    for route in routes:
+        if route.path in existing_paths:
+            continue
+        app.routes.append(route)
+        logger.debug("wave3a probe route registered: %s", route.path)

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -842,6 +842,13 @@ async def main():
             mcp_server_name=mcp.name,
         )
 
+        # === Wave 3a probe endpoint (PR #1 scaffolding, see docs/proposals/
+        # beam-wave-3a-read-only-handlers.md §2.3). Internal-only surface
+        # consumed by the BEAM listener once PR #4 lands. Fail-closed:
+        # missing WAVE_3A_PROBE_TOKEN -> 503 on every /v1/probe/* call.
+        from src.mcp_handlers.wave3a_probe import register_wave3a_probe_routes
+        register_wave3a_probe_routes(app)
+
         # === Streamable HTTP endpoint (/mcp) ===
         if HAS_STREAMABLE_HTTP:
             # Create a pure ASGI app for /mcp that wraps the session manager

--- a/tests/integration/test_wave_3a_probe.py
+++ b/tests/integration/test_wave_3a_probe.py
@@ -1,0 +1,359 @@
+"""
+Wave 3a probe-endpoint integration tests (PR #1 of Wave 3a sequencing).
+
+Specification:
+    ``docs/proposals/beam-wave-3a-read-only-handlers.md`` v0.2 §2.2 (envelope),
+    §2.3 (endpoint list), §2.5 (bearer auth), §2.6 (timestamp masking).
+
+Test surface:
+    A minimal Starlette ASGI app with the Wave 3a probe routes mounted via
+    ``register_wave3a_probe_routes``. The MCP server is NOT started — these
+    tests exercise the route handlers directly through Starlette's
+    ``TestClient``, the same pattern used by
+    ``tests/test_http_endpoints.py``.
+
+Coverage (8 cases):
+    1. Token unset -> 503 on every /v1/probe/* endpoint (fail-closed §2.5).
+    2. Wrong token -> 401 on every endpoint.
+    3. Missing Authorization header -> 401 on every endpoint.
+    4. Correct token -> 200 with top-level-keys envelope (§2.2) on every
+       endpoint.
+    5. ``protocol_version`` is exactly ``wave3a.v1`` on every response.
+    6. Timestamp masking: ``tool_registry`` byte-equality across two calls
+       (FIND-R2 fold — guards against future ``list_all_aliases``-style
+       non-determinism).
+    7. ``/v1/probe/health`` has no ``data`` key (bare liveness).
+    8. ``/v1/probe/server_info`` has ``meta.probe_process: true``
+       (FIND-R3 fold — BEAM caller knows the PID/transport identifies the
+       Python probe).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+project_root = Path(__file__).resolve().parent.parent.parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+from src.mcp_handlers import wave3a_probe
+from src.mcp_handlers.wave3a_probe import (
+    PROBE_PREFIX,
+    PROBE_TOKEN_ENV,
+    PROTOCOL_VERSION,
+    register_wave3a_probe_routes,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+VALID_TOKEN = "wave3a-test-token-correct"
+WRONG_TOKEN = "wave3a-test-token-wrong"
+
+
+@pytest.fixture
+def app() -> Starlette:
+    """Bare Starlette app with only the probe routes mounted."""
+    app = Starlette(routes=[])
+    register_wave3a_probe_routes(app)
+    return app
+
+
+@pytest.fixture
+def client(app) -> Iterator[TestClient]:
+    with TestClient(app, raise_server_exceptions=True) as test_client:
+        yield test_client
+
+
+@pytest.fixture
+def token_set(monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setenv(PROBE_TOKEN_ENV, VALID_TOKEN)
+    return VALID_TOKEN
+
+
+@pytest.fixture
+def token_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(PROBE_TOKEN_ENV, raising=False)
+
+
+# Endpoints subject to bearer-auth (all of §2.3 except /health).
+AUTHED_ENDPOINTS = [
+    f"{PROBE_PREFIX}/health_snapshot",
+    f"{PROBE_PREFIX}/server_info",
+    f"{PROBE_PREFIX}/tool_registry",
+]
+
+LIVENESS_ENDPOINT = f"{PROBE_PREFIX}/health"
+
+
+def _bearer(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Case 1 — fail-closed when token unset
+# ---------------------------------------------------------------------------
+
+
+class TestTokenUnset:
+    """§2.5: missing WAVE_3A_PROBE_TOKEN -> 503 on every authed endpoint."""
+
+    def test_authed_endpoints_return_503_when_token_unset(
+        self, client: TestClient, token_unset: None
+    ) -> None:
+        for path in AUTHED_ENDPOINTS:
+            response = client.get(path, headers=_bearer(VALID_TOKEN))
+            assert response.status_code == 503, f"{path} did not 503"
+            body = response.json()
+            assert body["ok"] is False
+            assert body["protocol_version"] == PROTOCOL_VERSION
+            assert body["error"] == "service_unavailable"
+            assert "WAVE_3A_PROBE_TOKEN" in body["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Case 2 — wrong bearer token
+# ---------------------------------------------------------------------------
+
+
+class TestWrongToken:
+    """§2.5: bearer token does not match -> 401."""
+
+    def test_authed_endpoints_return_401_when_token_wrong(
+        self, client: TestClient, token_set: str
+    ) -> None:
+        for path in AUTHED_ENDPOINTS:
+            response = client.get(path, headers=_bearer(WRONG_TOKEN))
+            assert response.status_code == 401, f"{path} did not 401"
+            body = response.json()
+            assert body["ok"] is False
+            assert body["protocol_version"] == PROTOCOL_VERSION
+            assert body["error"] == "permission_denied"
+            assert body["reason"] == "bearer token missing or invalid"
+
+
+# ---------------------------------------------------------------------------
+# Case 3 — missing Authorization header
+# ---------------------------------------------------------------------------
+
+
+class TestMissingAuthHeader:
+    """§2.5: Authorization header absent -> 401 (when token is set)."""
+
+    def test_authed_endpoints_return_401_when_header_missing(
+        self, client: TestClient, token_set: str
+    ) -> None:
+        for path in AUTHED_ENDPOINTS:
+            response = client.get(path)  # no headers
+            assert response.status_code == 401, f"{path} did not 401"
+            body = response.json()
+            assert body["ok"] is False
+            assert body["protocol_version"] == PROTOCOL_VERSION
+            assert body["error"] == "permission_denied"
+
+
+# ---------------------------------------------------------------------------
+# Case 4 — correct token returns 200 + top-level envelope
+# ---------------------------------------------------------------------------
+
+
+class TestAuthedEnvelope:
+    """§2.2: top-level keys ok / protocol_version / data; no nested wrapper."""
+
+    def test_health_snapshot_envelope(
+        self, client: TestClient, token_set: str, snapshot_stub: None
+    ) -> None:
+        response = client.get(
+            f"{PROBE_PREFIX}/health_snapshot", headers=_bearer(VALID_TOKEN)
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["ok"] is True
+        assert body["protocol_version"] == PROTOCOL_VERSION
+        assert "data" in body
+        assert isinstance(body["data"], dict)
+        # Forbid nested envelope: data["ok"] would mean a double-wrap.
+        assert "ok" not in body["data"]
+        assert "protocol_version" not in body["data"]
+
+    def test_server_info_envelope(
+        self, client: TestClient, token_set: str
+    ) -> None:
+        response = client.get(
+            f"{PROBE_PREFIX}/server_info", headers=_bearer(VALID_TOKEN)
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["ok"] is True
+        assert body["protocol_version"] == PROTOCOL_VERSION
+        assert "data" in body
+        assert isinstance(body["data"], dict)
+        assert "current_pid" in body["data"]
+
+    def test_tool_registry_envelope(
+        self, client: TestClient, token_set: str
+    ) -> None:
+        response = client.get(
+            f"{PROBE_PREFIX}/tool_registry", headers=_bearer(VALID_TOKEN)
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["ok"] is True
+        assert body["protocol_version"] == PROTOCOL_VERSION
+        assert "data" in body
+        data = body["data"]
+        for key in ("tools", "aliases", "tiers", "deprecated_tools"):
+            assert key in data, f"missing top-level key {key}"
+
+
+# ---------------------------------------------------------------------------
+# Case 5 — protocol_version is exactly wave3a.v1
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolVersion:
+
+    def test_protocol_version_pinned_on_success(
+        self, client: TestClient, token_set: str, snapshot_stub: None
+    ) -> None:
+        for path in [LIVENESS_ENDPOINT, *AUTHED_ENDPOINTS]:
+            response = client.get(path, headers=_bearer(VALID_TOKEN))
+            assert response.status_code == 200
+            assert response.json()["protocol_version"] == "wave3a.v1"
+
+    def test_protocol_version_pinned_on_auth_failure(
+        self, client: TestClient, token_set: str
+    ) -> None:
+        for path in AUTHED_ENDPOINTS:
+            response = client.get(path, headers=_bearer(WRONG_TOKEN))
+            assert response.status_code == 401
+            assert response.json()["protocol_version"] == "wave3a.v1"
+
+    def test_protocol_version_pinned_on_fail_closed(
+        self, client: TestClient, token_unset: None
+    ) -> None:
+        for path in AUTHED_ENDPOINTS:
+            response = client.get(path, headers=_bearer(VALID_TOKEN))
+            assert response.status_code == 503
+            assert response.json()["protocol_version"] == "wave3a.v1"
+
+
+# ---------------------------------------------------------------------------
+# Case 6 — timestamp masking yields byte-deterministic tool_registry
+# ---------------------------------------------------------------------------
+
+
+class TestToolRegistryMaskingDeterminism:
+    """§2.6 + FIND-R2 fold: tool_registry must be byte-equal across calls.
+
+    If a future change introduces a non-deterministic field (timestamp,
+    UUID, monotonic counter, PID) into the tool_registry payload that the
+    ``mask_timestamps`` regex set misses, this test fails. That is the
+    intended signal: extend the regex set in ``wave3a_probe.py`` to cover
+    the new field.
+    """
+
+    def test_two_calls_produce_byte_equal_body(
+        self, client: TestClient, token_set: str
+    ) -> None:
+        first = client.get(
+            f"{PROBE_PREFIX}/tool_registry", headers=_bearer(VALID_TOKEN)
+        )
+        second = client.get(
+            f"{PROBE_PREFIX}/tool_registry", headers=_bearer(VALID_TOKEN)
+        )
+        assert first.status_code == 200
+        assert second.status_code == 200
+        # Compare canonicalized JSON to ignore key ordering differences
+        # produced by Starlette's JSONResponse.
+        import json
+
+        first_norm = json.dumps(first.json(), sort_keys=True)
+        second_norm = json.dumps(second.json(), sort_keys=True)
+        assert first_norm == second_norm, (
+            "tool_registry response differed across calls — masking regex "
+            "missed a non-deterministic field; extend _VOLATILE_FIELD_NAMES "
+            "or _VOLATILE_SUFFIXES in src/mcp_handlers/wave3a_probe.py"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case 7 — /v1/probe/health is bare liveness
+# ---------------------------------------------------------------------------
+
+
+class TestLivenessShape:
+
+    def test_health_has_no_data_key(self, client: TestClient) -> None:
+        response = client.get(LIVENESS_ENDPOINT)
+        assert response.status_code == 200
+        body = response.json()
+        assert body == {"ok": True, "protocol_version": "wave3a.v1"}
+        assert "data" not in body
+
+    def test_health_does_not_require_auth(
+        self, client: TestClient, token_unset: None
+    ) -> None:
+        """Liveness probes must work even before the operator configures the
+        probe token — that's the point of having a bare liveness endpoint."""
+        response = client.get(LIVENESS_ENDPOINT)
+        assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Case 8 — server_info carries meta.probe_process: true
+# ---------------------------------------------------------------------------
+
+
+class TestServerInfoProbeProcessFlag:
+    """FIND-R3 fold: meta.probe_process: true tells the BEAM caller that the
+    PID/transport fields describe the Python probe, not the BEAM listener."""
+
+    def test_meta_probe_process_true(
+        self, client: TestClient, token_set: str
+    ) -> None:
+        response = client.get(
+            f"{PROBE_PREFIX}/server_info", headers=_bearer(VALID_TOKEN)
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert "meta" in body
+        assert body["meta"].get("probe_process") is True
+
+
+# ---------------------------------------------------------------------------
+# Supporting helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def snapshot_stub(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Inject a deterministic health snapshot so /health_snapshot returns 200.
+
+    The real snapshot is populated by ``deep_health_probe_task`` running in
+    the background; tests don't have that task wired, so we stub the
+    accessor used by the probe handler.
+    """
+    from src.services import health_snapshot as hs
+
+    fake_snapshot = {
+        "status": "ok",
+        "version": "test",
+        "checks": {"db": {"status": "ok"}},
+    }
+
+    def fake_get_snapshot():
+        return fake_snapshot, 1.0, 1234567890.0
+
+    monkeypatch.setattr(hs, "get_snapshot", fake_get_snapshot)
+    # is_stale stays as-is (cheap pure function); PROBE_INTERVAL_SECONDS and
+    # STALENESS_THRESHOLD_SECONDS are module constants the handler reads.


### PR DESCRIPTION
## Spec

Implements PR #1 of the BEAM Wave 3a sequencing per `docs/proposals/beam-wave-3a-read-only-handlers.md` v0.2 (still in review on #535). Section anchors: §2.2 envelope, §2.3 endpoint list, §2.5 token discipline, §2.6 timestamp masking.

**This is scaffolding only.** No production traffic flows through `/v1/probe/*` until PR #4 (BEAM listener) and PR #5 (first ported handler) land. No existing handlers are modified.

## Endpoints (all under `/v1/probe/`)

| Path | Auth | Returns |
|---|---|---|
| `GET /health` | none | bare liveness `{ok: true, protocol_version: "wave3a.v1"}` |
| `GET /health_snapshot` | bearer | full `get_snapshot()` body + `_cache` block |
| `GET /server_info` | bearer | psutil enumeration + `TOOL_HANDLERS` count + `meta.probe_process: true` |
| `GET /tool_registry` | bearer | tools/aliases/tiers/deprecated; timestamp-masked for byte-equality |

## Envelope shape (§2.2)

Top-level keys only, matching the lease plane's typed REST contract:

```json
{"ok": true, "protocol_version": "wave3a.v1", "data": {...}, "meta": {...}}
{"ok": false, "protocol_version": "wave3a.v1", "error": "...", "reason": "...", "detail": "..."}
```

No nested `data` wrapper — the lease plane's existing analogue test (`test/unitares_lease_plane_test.exs:221`) rejects that shape.

## Auth behavior (§2.5)

- `WAVE_3A_PROBE_TOKEN` unset → 503 with `error: service_unavailable` on every authed endpoint. Fail-closed by default.
- Wrong/missing bearer → 401 with `error: permission_denied`, `reason: bearer token missing or invalid`.
- Constant-time comparison via `secrets.compare_digest`.
- `/v1/probe/health` is exempt from auth so the BEAM Finch client can verify connectivity before bothering with bearer headers.

**Note on HTTP status:** the lease plane returns 200 + `ok: false` for `permission_denied`; this PR follows the explicit 401/503 codes from the PR #1 instructions. If the operator wants strict parity with the lease plane's status convention, a one-line change flips it; flagging here.

## Council folds addressed

- **FIND-R2** (`list_all_aliases` lazy state): `tool_stability.list_all_aliases` returns a copy of a module-level dict populated at import time — no first-call build today. The byte-equality test on the masked `tool_registry` response is the structural guard against a future regression that introduces lazy state. If a non-deterministic field slips in, the test fails and points at the regex set to extend.
- **FIND-R3** (`get_server_info` PID semantics): `meta.probe_process: true` makes the response self-identifying. BEAM caller knows the `current_pid` / `transport` fields describe the Python probe process and may override them on its side before returning to its caller (default per v0.2 PR #6 is option 1 — accept Python-PID semantics with the meta annotation).

## Test plan

`tests/integration/test_wave_3a_probe.py` — 13 cases covering the 8 scenarios in the PR #1 spec:

- [x] Case 1: token unset → 503 on every `/v1/probe/*` authed endpoint
- [x] Case 2: wrong token → 401 on every endpoint
- [x] Case 3: missing Authorization header → 401 on every endpoint
- [x] Case 4: correct token → 200 + top-level envelope on each endpoint
- [x] Case 5: `protocol_version == "wave3a.v1"` on success, auth-failure, and fail-closed responses
- [x] Case 6: `tool_registry` byte-equal across two consecutive calls (catches `list_tools`-style non-determinism regressions)
- [x] Case 7: `/v1/probe/health` has no `data` key and works without auth
- [x] Case 8: `/v1/probe/server_info` carries `meta.probe_process: true`

Full local gate: `./scripts/dev/test-cache.sh --staged` → 8982 passed, 34 skipped (cached at staged tree `b0d8f3047daa...`).

## Files

- `src/mcp_handlers/wave3a_probe.py` — new module, +474 lines
- `tests/integration/test_wave_3a_probe.py` — new module, +334 lines
- `src/mcp_server.py` — 7-line addition mounting `register_wave3a_probe_routes(app)` after the existing `register_http_routes` call

## Not in scope here

- BEAM-side listener — PR #4
- Per-tool routing table on the Python transport — PR #3
- `audit.coordination_measurements` migration + write path — PR #2
- Identity-middleware verification gate per §2.4 — PR #5
- Golden parity fixtures — PR #5+

## Spec link

Sibling PR (RFC v0.2 itself): #535.