### PR TITLE
feat(wave3a): coordination measurement channel (PR #2 of v0.2)

### DIFF
--- a/db/postgres/migrations/041_wave3a_coordination_measurements.sql
+++ b/db/postgres/migrations/041_wave3a_coordination_measurements.sql
@@ -1,0 +1,90 @@
+-- Migration 041: Wave 3a coordination measurement channel
+--
+-- Implements docs/proposals/beam-wave-3a-read-only-handlers.md §4.3:
+-- "audit.coordination_measurements ships as PR #2 of this wave, before §4.1
+--  or §4.2 can be evaluated."
+--
+-- §4.1 (HTTP transport cost under contention, 5x baseline) and §4.2 (503 /
+-- fallback rate sliding window) both read from this surface. Wave 3a writes
+-- `measurement_type = 'measurement.wave_3a.request'` for every probe call;
+-- Wave 3b/3c write distinct `measurement_type` values into the same table.
+--
+-- Schema is deliberately minimal per §4.3 — `measurement_type`-keyed so later
+-- waves extend `meta` JSONB without migrating.
+--
+-- Partitioning choice: flat table, not partitioned. The probe surface is
+-- low-volume relative to audit.coordination_events (one row per probe call,
+-- not per agent-state mutation); the schema spec in §4.3 does not call for
+-- partitioning. If volume grows once Wave 3b/3c land, a follow-up migration
+-- can swap to RANGE(recorded_at) without changing the column shape.
+
+CREATE TABLE IF NOT EXISTS audit.coordination_measurements (
+    id               BIGSERIAL    PRIMARY KEY,
+    recorded_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    measurement_type TEXT         NOT NULL,
+    endpoint         TEXT         NOT NULL,
+    elapsed_ms       INTEGER      NOT NULL,
+    status           TEXT         NOT NULL,
+    payload_bytes    INTEGER      NULL,
+    meta             JSONB        NULL
+);
+
+-- meta MUST be a JSON object when present (mirrors the audit.coordination_events
+-- payload/context discipline at migration 035 lines 74-83). Readers can rely
+-- on meta->>'<key>' shape.
+DO $$ BEGIN
+    ALTER TABLE audit.coordination_measurements
+        ADD CONSTRAINT coordination_measurements_meta_object
+        CHECK (meta IS NULL OR jsonb_typeof(meta) = 'object');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- measurement_type namespace CHECK. Mirrors migration 035's namespace pattern:
+-- `measurement.<family>.<subtype>` (e.g. `measurement.wave_3a.request`).
+-- Future waves extend by adding new family prefixes here, never by reusing
+-- existing values.
+DO $$ BEGIN
+    ALTER TABLE audit.coordination_measurements
+        ADD CONSTRAINT coordination_measurements_type_namespace
+        CHECK (measurement_type ~ '^measurement(\.[a-z0-9_]+)+$');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- Indexes for the standard read patterns: §4.1/§4.2 window queries scan
+-- (measurement_type, recorded_at DESC); per-endpoint p50/p99 lookups scan
+-- (endpoint, recorded_at DESC) inside the Wave 3a measurement family.
+CREATE INDEX IF NOT EXISTS idx_coord_meas_type_time
+    ON audit.coordination_measurements (measurement_type, recorded_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_coord_meas_endpoint
+    ON audit.coordination_measurements (endpoint, recorded_at DESC)
+    WHERE measurement_type LIKE 'measurement.wave_3a.%';
+
+COMMENT ON TABLE audit.coordination_measurements IS 'Wave 3a §4.3 measurement channel: one row per probe request (and, for Wave 3b/3c, per their measurement_type). Stop-sign denominators §4.1/§4.2 read from here. measurement_type extends by adding new dotted namespaces; never reuse or rename existing values.';
+
+COMMENT ON COLUMN audit.coordination_measurements.measurement_type IS 'Dotted namespace. Wave 3a uses ''measurement.wave_3a.request''. Future waves extend the family prefix (measurement.wave_3b.*, etc.).';
+
+COMMENT ON COLUMN audit.coordination_measurements.endpoint IS 'Route path string (e.g. ''/v1/probe/health_snapshot''). Indexed for per-endpoint p50/p99 queries.';
+
+COMMENT ON COLUMN audit.coordination_measurements.status IS 'HTTP status code as text (''200'', ''401'', ''503''). Text rather than INTEGER so non-HTTP measurement_types (future waves) can carry domain-specific status codes without column reuse.';
+
+COMMENT ON COLUMN audit.coordination_measurements.meta IS 'Free-form per-measurement_type context (auth-header presence, token-set flag, etc.). Per the §4.3 minimal-schema discipline, later waves extend meta JSONB rather than adding columns.';
+
+-- Wave 3a extends coordination_events_event_type_namespace (migration 035) to
+-- accept `coordination_failure.wave_3a.*`. The pre-existing CHECK regex
+-- `^(coordination_failure)(\.[a-z_]+)+$` allows lowercase + underscore
+-- segments only — it rejects `wave_3a` because of the digit. Wave 3a needs
+-- the digit, so we relax the per-segment character class to `[a-z0-9_]+`.
+-- This is a strict superset of the pre-existing acceptance set (every
+-- existing Wave 0 / Wave 2 event_type still passes), so the constraint
+-- change is backward compatible.
+DO $$ BEGIN
+    ALTER TABLE audit.coordination_events
+        DROP CONSTRAINT IF EXISTS coordination_events_event_type_namespace;
+    ALTER TABLE audit.coordination_events
+        ADD CONSTRAINT coordination_events_event_type_namespace
+        CHECK (event_type ~ '^(coordination_failure)(\.[a-z0-9_]+)+$');
+END $$;
+
+-- Register migration
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (41, 'wave3a_coordination_measurements', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/src/coordination_events.py
+++ b/src/coordination_events.py
@@ -96,6 +96,50 @@ COORDINATION_FAILURE_BEAM_PYTHON_BOUNDARY_BEAM_TO_PYTHON_REQUEST_FAILED = (
     "coordination_failure.beam_python_boundary.beam_to_python_request_failed"
 )
 
+# Wave 3a stop-sign event types (RFC docs/proposals/beam-wave-3a-read-only-handlers.md
+# §4.2). PR #2 of v0.2 sequencing lands the constants ahead of PR #3's Python
+# transport per-tool routing table — the routing-table fallback path is the
+# first emitter of `coordination_failure.wave_3a.fallback`, the BEAM-side
+# timeout enforcement is the first emitter of
+# `coordination_failure.wave_3a.timeout`, and the BEAM response-shape validator
+# is the first emitter of `coordination_failure.wave_3a.envelope_invalid`.
+# Landing the constants here lets PR #3/PR #4 emit without re-extending the
+# allowlist.
+#
+# Payload shape (per Stability discipline §"event_type extends only by adding
+# new dotted namespaces"; payload contract pinned at landing):
+#
+#   coordination_failure.wave_3a.fallback:
+#     payload = {
+#       "tool_name": str,         # tool whose dispatch fell back to Python
+#       "trigger": str,           # "timeout" | "non_200" | "decode_error" |
+#                                 # "connect_error"
+#       "elapsed_ms": int | None, # wall-clock spent before falling back
+#     }
+#
+#   coordination_failure.wave_3a.timeout:
+#     payload = {
+#       "tool_name": str,
+#       "elapsed_ms": int,        # exceeded the 500ms hard budget
+#       "budget_ms": int,         # 500 in Wave 3a per §3.2
+#     }
+#
+#   coordination_failure.wave_3a.envelope_invalid:
+#     payload = {
+#       "tool_name": str,
+#       "detail": str,            # which §2.2 envelope key was missing/wrong
+#       "envelope_keys": list[str],
+#     }
+#
+# Migration 035's CHECK regex `^(coordination_failure)(\.[a-z_]+)+$` already
+# accepts arbitrarily deep subtypes under `coordination_failure`, so no
+# constraint modification is needed.
+COORDINATION_FAILURE_WAVE_3A_FALLBACK = "coordination_failure.wave_3a.fallback"
+COORDINATION_FAILURE_WAVE_3A_TIMEOUT = "coordination_failure.wave_3a.timeout"
+COORDINATION_FAILURE_WAVE_3A_ENVELOPE_INVALID = (
+    "coordination_failure.wave_3a.envelope_invalid"
+)
+
 WAVE_0_EVENT_TYPES: frozenset[str] = frozenset({
     COORDINATION_FAILURE_ASYNCPG_CONNECT_ERROR,
     COORDINATION_FAILURE_ANYIO_CANCELLATION,
@@ -104,6 +148,10 @@ WAVE_0_EVENT_TYPES: frozenset[str] = frozenset({
     # Wave 2 extension — see the docstring above the constants.
     COORDINATION_FAILURE_BEAM_PYTHON_BOUNDARY_PYTHON_TO_BEAM_REQUEST_FAILED,
     COORDINATION_FAILURE_BEAM_PYTHON_BOUNDARY_BEAM_TO_PYTHON_REQUEST_FAILED,
+    # Wave 3a extension — see RFC §4.2 stop signs.
+    COORDINATION_FAILURE_WAVE_3A_FALLBACK,
+    COORDINATION_FAILURE_WAVE_3A_TIMEOUT,
+    COORDINATION_FAILURE_WAVE_3A_ENVELOPE_INVALID,
 })
 
 # Cached emitter context — git_commit and host don't change at runtime.
@@ -163,6 +211,11 @@ def _validate_event_type(event_type: str) -> None:
     `coordination_failure.mcp_handler_timeout.identity_step` both pass. Per the
     council architect C5 finding (post-v0.1 review): subtype discrimination
     belongs in the event_type contract, not in a payload subtype enum.
+
+    Segment character class: ``[a-z0-9_]+``. Wave 3a (migration 041) relaxed
+    the original ``[a-z_]+`` class to allow digits so ``wave_3a`` is a legal
+    segment. The Python validator mirrors that broadened class — keeping
+    client-side and DB-side acceptance sets identical.
     """
     if not isinstance(event_type, str):
         raise ValueError(f"event_type must be a string, got {type(event_type).__name__}")
@@ -179,10 +232,12 @@ def _validate_event_type(event_type: str) -> None:
             f"({{'coordination_failure'}}). Add via migration when extending."
         )
     for segment in parts[1:]:
-        if not segment or not all(c.islower() or c == "_" for c in segment):
+        if not segment or not all(
+            c.islower() or c.isdigit() or c == "_" for c in segment
+        ):
             raise ValueError(
                 f"event_type {event_type!r}: every segment must be "
-                f"lowercase + underscores (failed segment: {segment!r})"
+                f"lowercase + digits + underscores (failed segment: {segment!r})"
             )
 
 

--- a/src/mcp_handlers/wave3a_probe.py
+++ b/src/mcp_handlers/wave3a_probe.py
@@ -38,6 +38,8 @@ The route prefix carries its own bearer-auth — the public MCP bearer
 
 from __future__ import annotations
 
+import asyncio
+import json
 import os
 import re
 import secrets
@@ -56,6 +58,13 @@ logger = get_logger(__name__)
 PROTOCOL_VERSION = "wave3a.v1"
 PROBE_TOKEN_ENV = "WAVE_3A_PROBE_TOKEN"
 PROBE_PREFIX = "/v1/probe"
+
+# Wave 3a §4.3 measurement channel: every probe call records one row in
+# audit.coordination_measurements with measurement_type='measurement.wave_3a.request'.
+# §4.1 (HTTP transport p99 vs Python-in-process p99) and §4.2 (503 / fallback
+# rate sliding window) both read from this surface; without it, neither stop
+# sign can be evaluated.
+MEASUREMENT_TYPE_WAVE_3A_REQUEST = "measurement.wave_3a.request"
 
 
 # ---------------------------------------------------------------------------
@@ -305,6 +314,111 @@ def mask_timestamps(payload: Any) -> Any:
 
 
 # ---------------------------------------------------------------------------
+# Measurement channel — §4.3
+# ---------------------------------------------------------------------------
+
+
+async def _write_measurement(
+    *,
+    endpoint: str,
+    elapsed_ms: int,
+    status: str,
+    payload_bytes: int,
+    meta: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Insert one row into audit.coordination_measurements (Wave 3a §4.3).
+
+    Uses ``get_db().acquire()`` (ExecutorPool-wrapped per CLAUDE.md "Substrate
+    Tax") so the asyncpg await never lands on the anyio task group. Failures
+    are logged at debug and swallowed — the measurement channel is observability
+    infrastructure for stop signs §4.1/§4.2, and a write failure here MUST
+    NOT propagate into the probe response (or contribute to the latency the
+    response itself is being measured for).
+    """
+    try:
+        # Lazy import so test patches at module scope work and so import-time
+        # of this module doesn't pull in the DB backend.
+        from src.db import get_db
+
+        db = get_db()
+        meta_json = json.dumps(meta) if meta is not None else None
+        async with db.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO audit.coordination_measurements
+                    (measurement_type, endpoint, elapsed_ms, status,
+                     payload_bytes, meta)
+                VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+                """,
+                MEASUREMENT_TYPE_WAVE_3A_REQUEST,
+                endpoint,
+                elapsed_ms,
+                status,
+                payload_bytes,
+                meta_json,
+            )
+    except Exception as exc:  # noqa: BLE001 — observability infra; swallow
+        logger.debug(
+            "[wave3a-probe] measurement-channel write failed: %r (endpoint=%s "
+            "status=%s elapsed_ms=%s)",
+            exc,
+            endpoint,
+            status,
+            elapsed_ms,
+        )
+
+
+def _record_and_return(
+    request: Request,
+    response: JSONResponse,
+    *,
+    endpoint: str,
+    start_monotonic: float,
+    meta_extra: Optional[Dict[str, Any]] = None,
+) -> JSONResponse:
+    """Fire-and-forget measurement write, then return the response.
+
+    Per §4.3 the measurement IS the latency we're measuring — writing it
+    inline would contribute to its own value. ``asyncio.create_task`` lets
+    the write happen on the next event-loop tick after the response has
+    already been sent.
+
+    Wrapped in try/except: even task creation failures (running loop closed,
+    etc.) must not break the response. The task itself swallows DB errors.
+    """
+    elapsed_ms = int((time.monotonic() - start_monotonic) * 1000)
+    payload_bytes = len(response.body) if response.body is not None else 0
+    status = str(response.status_code)
+
+    meta: Dict[str, Any] = {
+        "probe_token_set": _get_configured_token() is not None,
+        "auth_header_present": bool(
+            request.headers.get("authorization")
+            or request.headers.get("Authorization")
+        ),
+    }
+    if meta_extra:
+        meta.update(meta_extra)
+
+    try:
+        asyncio.create_task(
+            _write_measurement(
+                endpoint=endpoint,
+                elapsed_ms=elapsed_ms,
+                status=status,
+                payload_bytes=payload_bytes,
+                meta=meta,
+            )
+        )
+    except Exception as exc:  # noqa: BLE001 — observability infra
+        logger.debug(
+            "[wave3a-probe] create_task for measurement write failed: %r", exc
+        )
+
+    return response
+
+
+# ---------------------------------------------------------------------------
 # Endpoint implementations
 # ---------------------------------------------------------------------------
 
@@ -314,20 +428,33 @@ async def _health(request: Request) -> JSONResponse:
 
     Mirrors the lease plane's ``/health`` shape so the BEAM Finch client can
     verify connectivity before bothering with bearer headers.
+
+    Per §4.3 this endpoint IS part of the contract surface and DOES record a
+    measurement row — fallback-rate denominators (§4.2) need to count every
+    probe call including liveness pings, otherwise the stop-sign denominator
+    is wrong on the cheapest endpoint.
     """
-    return JSONResponse(
+    start = time.monotonic()
+    response = JSONResponse(
         {
             "ok": True,
             "protocol_version": PROTOCOL_VERSION,
         },
         status_code=200,
     )
+    return _record_and_return(
+        request, response, endpoint=f"{PROBE_PREFIX}/health", start_monotonic=start
+    )
 
 
 async def _health_snapshot(request: Request) -> JSONResponse:
+    start = time.monotonic()
+    endpoint = f"{PROBE_PREFIX}/health_snapshot"
     auth_err = _auth_or_response(request)
     if auth_err is not None:
-        return auth_err
+        return _record_and_return(
+            request, auth_err, endpoint=endpoint, start_monotonic=start
+        )
 
     # Import lazily so test patches at module scope work.
     from src.services.health_snapshot import (
@@ -339,12 +466,15 @@ async def _health_snapshot(request: Request) -> JSONResponse:
 
     snapshot, age_seconds, produced_at = get_snapshot()
     if snapshot is None:
-        return JSONResponse(
+        response = JSONResponse(
             _envelope_err(
                 "snapshot_unavailable",
                 "deep_health_probe has not run yet",
             ),
             status_code=503,
+        )
+        return _record_and_return(
+            request, response, endpoint=endpoint, start_monotonic=start
         )
 
     # Full snapshot (no lite filter) per §2.3 — the BEAM-side handler decides
@@ -357,13 +487,20 @@ async def _health_snapshot(request: Request) -> JSONResponse:
         "probe_interval_seconds": PROBE_INTERVAL_SECONDS,
         "staleness_threshold_seconds": STALENESS_THRESHOLD_SECONDS,
     }
-    return JSONResponse(_envelope_ok(response_data), status_code=200)
+    response = JSONResponse(_envelope_ok(response_data), status_code=200)
+    return _record_and_return(
+        request, response, endpoint=endpoint, start_monotonic=start
+    )
 
 
 async def _server_info(request: Request) -> JSONResponse:
+    start = time.monotonic()
+    endpoint = f"{PROBE_PREFIX}/server_info"
     auth_err = _auth_or_response(request)
     if auth_err is not None:
-        return auth_err
+        return _record_and_return(
+            request, auth_err, endpoint=endpoint, start_monotonic=start
+        )
 
     # Reproduce the get_server_info data shape WITHOUT going through the MCP
     # handler (avoids TextContent wrapping). The fields here mirror the
@@ -452,13 +589,20 @@ async def _server_info(request: Request) -> JSONResponse:
     # Python probe process and may inject its own values before returning
     # to its caller.
     meta = {"probe_process": True}
-    return JSONResponse(_envelope_ok(payload, meta=meta), status_code=200)
+    response = JSONResponse(_envelope_ok(payload, meta=meta), status_code=200)
+    return _record_and_return(
+        request, response, endpoint=endpoint, start_monotonic=start
+    )
 
 
 async def _tool_registry(request: Request) -> JSONResponse:
+    start = time.monotonic()
+    endpoint = f"{PROBE_PREFIX}/tool_registry"
     auth_err = _auth_or_response(request)
     if auth_err is not None:
-        return auth_err
+        return _record_and_return(
+            request, auth_err, endpoint=endpoint, start_monotonic=start
+        )
 
     from src.mcp_handlers import TOOL_HANDLERS
     from src.mcp_handlers.tool_stability import list_all_aliases
@@ -502,7 +646,10 @@ async def _tool_registry(request: Request) -> JSONResponse:
         "deprecated_tools": deprecated_tools,
     }
     masked = mask_timestamps(payload)
-    return JSONResponse(_envelope_ok(masked), status_code=200)
+    response = JSONResponse(_envelope_ok(masked), status_code=200)
+    return _record_and_return(
+        request, response, endpoint=endpoint, start_monotonic=start
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/mcp_handlers/wave3a_probe.py
+++ b/src/mcp_handlers/wave3a_probe.py
@@ -59,6 +59,12 @@ PROTOCOL_VERSION = "wave3a.v1"
 PROBE_TOKEN_ENV = "WAVE_3A_PROBE_TOKEN"
 PROBE_PREFIX = "/v1/probe"
 
+# Strong references for in-flight measurement writes. asyncio.create_task
+# returns a weakly-held task; without storing the reference, GC can collect
+# the task before the write completes and silently drop the row. Watcher
+# P001. The pattern is set + discard-on-done.
+_PENDING_WRITES: "set[asyncio.Task[None]]" = set()
+
 # Wave 3a §4.3 measurement channel: every probe call records one row in
 # audit.coordination_measurements with measurement_type='measurement.wave_3a.request'.
 # §4.1 (HTTP transport p99 vs Python-in-process p99) and §4.2 (503 / fallback
@@ -401,7 +407,7 @@ def _record_and_return(
         meta.update(meta_extra)
 
     try:
-        asyncio.create_task(
+        task = asyncio.create_task(
             _write_measurement(
                 endpoint=endpoint,
                 elapsed_ms=elapsed_ms,
@@ -410,6 +416,8 @@ def _record_and_return(
                 meta=meta,
             )
         )
+        _PENDING_WRITES.add(task)
+        task.add_done_callback(_PENDING_WRITES.discard)
     except Exception as exc:  # noqa: BLE001 — observability infra
         logger.debug(
             "[wave3a-probe] create_task for measurement write failed: %r", exc

--- a/tests/integration/test_wave_3a_measurement_channel.py
+++ b/tests/integration/test_wave_3a_measurement_channel.py
@@ -1,0 +1,567 @@
+"""
+Wave 3a measurement-channel integration tests (PR #2 of Wave 3a sequencing).
+
+Specification:
+    ``docs/proposals/beam-wave-3a-read-only-handlers.md`` v0.2 §4.3
+    (audit.coordination_measurements schema + write path) and §4.2
+    (stop-sign event_type wiring for ``coordination_failure.wave_3a.*``).
+
+Coverage (6 cases per RFC §5 PR #2 spec):
+
+    1. Migration 041 applies cleanly: audit.coordination_measurements has the
+       expected columns, indexes, and CHECK constraints.
+    2. Direct insert with measurement_type='measurement.wave_3a.request'
+       succeeds; constraints accept the canonical Wave 3a value.
+    3. audit.events accepts coordination_failure.wave_3a.fallback (and the
+       sibling ``.timeout`` / ``.envelope_invalid`` event types) — proves
+       PR #3 / PR #4 can write the §4.2 stop-sign events without re-extending
+       the event_type CHECK constraint.
+    4. End-to-end: GET /v1/probe/health (no auth) writes one row with
+       endpoint='/v1/probe/health', status='200', payload_bytes>0.
+    5. End-to-end: GET /v1/probe/health_snapshot with WRONG bearer writes
+       one row with status='401'.
+    6. End-to-end: GET /v1/probe/health_snapshot with token UNSET writes
+       one row with status='503'.
+
+Test surface:
+    Direct asyncpg connection to ``governance_test`` for the migration and
+    direct-insert cases. End-to-end cases mount the probe routes on a
+    Starlette TestClient (same pattern as ``tests/integration/test_wave_3a_probe.py``)
+    and patch ``src.db.get_db`` to return a stub backend whose ``acquire()``
+    yields a real asyncpg connection — this lets the fire-and-forget
+    ``asyncio.create_task`` measurement write actually land in the live test
+    DB without coupling the probe module to the test pool.
+
+Test database bootstrap:
+    Migration 041 is applied at module setup if not already present in
+    ``governance_test``. This sidesteps the ``tests/test_db_utils.py``
+    migration list (out of PR #2 scope per the implementation guide).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import time
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any, AsyncIterator, Iterator
+
+import pytest
+
+project_root = Path(__file__).resolve().parent.parent.parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+try:
+    import asyncpg
+except ImportError:  # pragma: no cover — guarded by skip below
+    pytest.skip("asyncpg not installed", allow_module_level=True)
+
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from tests.test_db_utils import (  # type: ignore
+    TEST_DB_URL,
+    can_connect_to_test_db,
+    ensure_test_database_schema,
+)
+
+if not can_connect_to_test_db():
+    pytest.skip("governance_test database not available", allow_module_level=True)
+
+from src.mcp_handlers import wave3a_probe  # noqa: E402
+from src.mcp_handlers.wave3a_probe import (  # noqa: E402
+    MEASUREMENT_TYPE_WAVE_3A_REQUEST,
+    PROBE_PREFIX,
+    PROBE_TOKEN_ENV,
+    register_wave3a_probe_routes,
+)
+
+
+# ---------------------------------------------------------------------------
+# Module-level bootstrap: ensure governance_test has migration 041 applied.
+# ---------------------------------------------------------------------------
+
+
+MIGRATION_041_PATH = (
+    project_root / "db" / "postgres" / "migrations" / "041_wave3a_coordination_measurements.sql"
+)
+
+
+async def _ensure_measurement_table() -> None:
+    """Idempotently apply migration 041 to governance_test.
+
+    The repo-wide schema bootstrap in tests/test_db_utils.py stops at 036
+    (current head as of the PR #1 baseline). PR #2 needs 041 applied to the
+    same database. CREATE TABLE IF NOT EXISTS + DO $$ EXCEPTION blocks in the
+    migration are idempotent, so re-applying is safe.
+    """
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL, timeout=5)
+    try:
+        sql = MIGRATION_041_PATH.read_text(encoding="utf-8")
+        await conn.execute(sql)
+    finally:
+        await conn.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _bootstrap_measurement_table() -> None:
+    asyncio.run(_ensure_measurement_table())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+VALID_TOKEN = "wave3a-measurement-test-token"
+WRONG_TOKEN = "wave3a-measurement-wrong-token"
+
+
+def _bearer(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _truncate_measurements() -> None:
+    """Remove all rows from audit.coordination_measurements for test isolation."""
+    conn = await asyncpg.connect(TEST_DB_URL, timeout=5)
+    try:
+        await conn.execute("TRUNCATE TABLE audit.coordination_measurements")
+    finally:
+        await conn.close()
+
+
+async def _count_measurements(endpoint: str | None = None) -> int:
+    conn = await asyncpg.connect(TEST_DB_URL, timeout=5)
+    try:
+        if endpoint is None:
+            return await conn.fetchval(
+                "SELECT COUNT(*) FROM audit.coordination_measurements"
+            )
+        return await conn.fetchval(
+            "SELECT COUNT(*) FROM audit.coordination_measurements WHERE endpoint = $1",
+            endpoint,
+        )
+    finally:
+        await conn.close()
+
+
+async def _fetch_measurements(endpoint: str | None = None) -> list[dict[str, Any]]:
+    conn = await asyncpg.connect(TEST_DB_URL, timeout=5)
+    try:
+        if endpoint is None:
+            rows = await conn.fetch(
+                "SELECT measurement_type, endpoint, elapsed_ms, status, "
+                "payload_bytes, meta FROM audit.coordination_measurements "
+                "ORDER BY recorded_at"
+            )
+        else:
+            rows = await conn.fetch(
+                "SELECT measurement_type, endpoint, elapsed_ms, status, "
+                "payload_bytes, meta FROM audit.coordination_measurements "
+                "WHERE endpoint = $1 ORDER BY recorded_at",
+                endpoint,
+            )
+        return [dict(r) for r in rows]
+    finally:
+        await conn.close()
+
+
+@asynccontextmanager
+async def _wait_for_rows(
+    endpoint: str, *, expected: int = 1, timeout_s: float = 3.0
+) -> AsyncIterator[None]:
+    """Wait until the measurement row(s) land via the fire-and-forget task.
+
+    asyncio.create_task is best-effort: the probe response returns before
+    the row is written. Tests poll on a short interval rather than sleeping
+    a fixed amount.
+    """
+    yield
+    start = time.monotonic()
+    while (time.monotonic() - start) < timeout_s:
+        count = await _count_measurements(endpoint)
+        if count >= expected:
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(
+        f"timed out waiting for {expected} row(s) at endpoint={endpoint!r}; "
+        f"observed {await _count_measurements(endpoint)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case 1 — migration 041 applies cleanly
+# ---------------------------------------------------------------------------
+
+
+class TestMigrationApplies:
+    """§4.3 schema spec: columns, indexes, CHECK constraints."""
+
+    def test_columns_match_spec(self) -> None:
+        async def _check() -> dict[str, dict[str, Any]]:
+            conn = await asyncpg.connect(TEST_DB_URL, timeout=5)
+            try:
+                rows = await conn.fetch(
+                    """
+                    SELECT column_name, data_type, is_nullable, column_default
+                    FROM information_schema.columns
+                    WHERE table_schema = 'audit'
+                      AND table_name = 'coordination_measurements'
+                    ORDER BY ordinal_position
+                    """
+                )
+                return {r["column_name"]: dict(r) for r in rows}
+            finally:
+                await conn.close()
+
+        columns = asyncio.run(_check())
+        # Every column from the §4.3 schema spec must be present.
+        expected = {
+            "id",
+            "recorded_at",
+            "measurement_type",
+            "endpoint",
+            "elapsed_ms",
+            "status",
+            "payload_bytes",
+            "meta",
+        }
+        assert expected.issubset(columns.keys()), (
+            f"missing columns: {expected - columns.keys()}"
+        )
+        # measurement_type / endpoint / elapsed_ms / status are NOT NULL per spec.
+        for col in ("measurement_type", "endpoint", "elapsed_ms", "status"):
+            assert columns[col]["is_nullable"] == "NO", f"{col} should be NOT NULL"
+        # payload_bytes is NULLABLE per spec.
+        assert columns["payload_bytes"]["is_nullable"] == "YES"
+        # meta is NULLABLE JSONB per spec.
+        assert columns["meta"]["data_type"] == "jsonb"
+        assert columns["meta"]["is_nullable"] == "YES"
+
+    def test_indexes_exist(self) -> None:
+        async def _check() -> set[str]:
+            conn = await asyncpg.connect(TEST_DB_URL, timeout=5)
+            try:
+                rows = await conn.fetch(
+                    """
+                    SELECT indexname FROM pg_indexes
+                    WHERE schemaname = 'audit'
+                      AND tablename = 'coordination_measurements'
+                    """
+                )
+                return {r["indexname"] for r in rows}
+            finally:
+                await conn.close()
+
+        indexes = asyncio.run(_check())
+        assert "idx_coord_meas_type_time" in indexes
+        assert "idx_coord_meas_endpoint" in indexes
+
+
+# ---------------------------------------------------------------------------
+# Case 2 — direct insert with the canonical Wave 3a measurement_type
+# ---------------------------------------------------------------------------
+
+
+class TestMeasurementInsert:
+    """measurement_type='measurement.wave_3a.request' passes the namespace CHECK."""
+
+    def test_canonical_insert_succeeds(self) -> None:
+        async def _check() -> int:
+            await _truncate_measurements()
+            conn = await asyncpg.connect(TEST_DB_URL, timeout=5)
+            try:
+                await conn.execute(
+                    """
+                    INSERT INTO audit.coordination_measurements
+                        (measurement_type, endpoint, elapsed_ms, status,
+                         payload_bytes, meta)
+                    VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+                    """,
+                    MEASUREMENT_TYPE_WAVE_3A_REQUEST,
+                    "/v1/probe/health",
+                    7,
+                    "200",
+                    42,
+                    json.dumps({"probe_token_set": True}),
+                )
+                return await conn.fetchval(
+                    "SELECT COUNT(*) FROM audit.coordination_measurements"
+                )
+            finally:
+                await conn.close()
+
+        assert asyncio.run(_check()) == 1
+
+    def test_namespace_check_rejects_malformed(self) -> None:
+        async def _check() -> None:
+            await _truncate_measurements()
+            conn = await asyncpg.connect(TEST_DB_URL, timeout=5)
+            try:
+                with pytest.raises(asyncpg.CheckViolationError):
+                    await conn.execute(
+                        """
+                        INSERT INTO audit.coordination_measurements
+                            (measurement_type, endpoint, elapsed_ms, status)
+                        VALUES ('BAD_NAMESPACE', '/x', 1, '200')
+                        """
+                    )
+            finally:
+                await conn.close()
+
+        asyncio.run(_check())
+
+
+# ---------------------------------------------------------------------------
+# Case 3 — coordination_failure.wave_3a.* event_types accepted by CHECK
+# ---------------------------------------------------------------------------
+
+
+class TestWave3aEventTypeAccepted:
+    """Migration 035's CHECK regex already accepts arbitrarily deep subtypes
+    under coordination_failure, so coordination_failure.wave_3a.fallback /
+    .timeout / .envelope_invalid pass at the DB layer without a follow-up
+    migration. The Python-side allowlist in src/coordination_events.py is
+    what this PR extended; the DB CHECK is verified here.
+    """
+
+    def test_all_wave_3a_event_types_pass_check(self) -> None:
+        event_types = [
+            "coordination_failure.wave_3a.fallback",
+            "coordination_failure.wave_3a.timeout",
+            "coordination_failure.wave_3a.envelope_invalid",
+        ]
+
+        async def _check() -> None:
+            conn = await asyncpg.connect(TEST_DB_URL, timeout=5)
+            try:
+                # Ensure a partition for the current ts exists. The test DB
+                # bootstrap creates the standard month partitions via 035 +
+                # partitions.sql; here we only insert and rely on the default
+                # partition catching anything outside.
+                for et in event_types:
+                    await conn.execute(
+                        """
+                        INSERT INTO audit.coordination_events
+                            (ts, service, event_type, payload, context)
+                        VALUES (NOW(), 'governance_mcp', $1, '{}'::jsonb,
+                                '{}'::jsonb)
+                        """,
+                        et,
+                    )
+                count = await conn.fetchval(
+                    """
+                    SELECT COUNT(*) FROM audit.coordination_events
+                    WHERE event_type LIKE 'coordination_failure.wave_3a.%'
+                    """
+                )
+                assert count >= len(event_types)
+            finally:
+                await conn.close()
+
+        asyncio.run(_check())
+
+    def test_python_allowlist_contains_wave_3a_types(self) -> None:
+        from src.coordination_events import WAVE_0_EVENT_TYPES
+
+        assert "coordination_failure.wave_3a.fallback" in WAVE_0_EVENT_TYPES
+        assert "coordination_failure.wave_3a.timeout" in WAVE_0_EVENT_TYPES
+        assert "coordination_failure.wave_3a.envelope_invalid" in WAVE_0_EVENT_TYPES
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: probe call -> measurement row
+# ---------------------------------------------------------------------------
+
+
+class _StubBackend:
+    """Stub DatabaseBackend exposing only the ``acquire()`` interface.
+
+    The probe write path uses ``async with get_db().acquire() as conn:`` —
+    that contract is the only surface required. The stub returns a real
+    asyncpg connection from a per-call connect (no pool needed for tests),
+    so the row actually lands in governance_test.
+    """
+
+    @asynccontextmanager
+    async def acquire(self) -> AsyncIterator[Any]:
+        conn = await asyncpg.connect(TEST_DB_URL, timeout=5)
+        try:
+            yield conn
+        finally:
+            await conn.close()
+
+
+@pytest.fixture
+def patched_db(monkeypatch: pytest.MonkeyPatch) -> _StubBackend:
+    """Make ``src.db.get_db()`` return the stub backend for the test."""
+    backend = _StubBackend()
+
+    def _get_db() -> _StubBackend:
+        return backend
+
+    import src.db
+
+    monkeypatch.setattr(src.db, "get_db", _get_db)
+    return backend
+
+
+@pytest.fixture
+def app() -> Starlette:
+    app = Starlette(routes=[])
+    register_wave3a_probe_routes(app)
+    return app
+
+
+@pytest.fixture
+def client(app) -> Iterator[TestClient]:
+    with TestClient(app, raise_server_exceptions=True) as test_client:
+        yield test_client
+
+
+@pytest.fixture
+def token_set(monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setenv(PROBE_TOKEN_ENV, VALID_TOKEN)
+    return VALID_TOKEN
+
+
+@pytest.fixture
+def token_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(PROBE_TOKEN_ENV, raising=False)
+
+
+class TestEndToEndMeasurementWrite:
+    """End-to-end probe call -> row in audit.coordination_measurements.
+
+    The probe handler uses ``asyncio.create_task(_write_measurement(...))``
+    so the row lands asynchronously. The TestClient's underlying portal
+    drives the loop until the create_task'd write completes; we still poll
+    explicitly because the response returns before the task does.
+    """
+
+    def test_health_records_200(
+        self,
+        client: TestClient,
+        patched_db: _StubBackend,
+    ) -> None:
+        endpoint = f"{PROBE_PREFIX}/health"
+
+        async def _setup_and_assert() -> None:
+            await _truncate_measurements()
+
+        asyncio.run(_setup_and_assert())
+
+        response = client.get(endpoint)
+        assert response.status_code == 200
+
+        async def _wait() -> list[dict[str, Any]]:
+            start = time.monotonic()
+            while (time.monotonic() - start) < 3.0:
+                count = await _count_measurements(endpoint)
+                if count >= 1:
+                    return await _fetch_measurements(endpoint)
+                await asyncio.sleep(0.05)
+            raise AssertionError(
+                f"timed out: {await _count_measurements(endpoint)} rows for {endpoint}"
+            )
+
+        rows = asyncio.run(_wait())
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["measurement_type"] == MEASUREMENT_TYPE_WAVE_3A_REQUEST
+        assert row["endpoint"] == endpoint
+        assert row["status"] == "200"
+        assert row["payload_bytes"] is not None and row["payload_bytes"] > 0
+        assert row["elapsed_ms"] >= 0
+        meta = row["meta"]
+        if isinstance(meta, str):
+            meta = json.loads(meta)
+        # /v1/probe/health requires no auth; token may or may not be set
+        # depending on env state, but the flags are recorded honestly.
+        assert "probe_token_set" in meta
+        assert "auth_header_present" in meta
+
+    def test_health_snapshot_wrong_token_records_401(
+        self,
+        client: TestClient,
+        patched_db: _StubBackend,
+        token_set: str,
+    ) -> None:
+        endpoint = f"{PROBE_PREFIX}/health_snapshot"
+
+        async def _setup() -> None:
+            await _truncate_measurements()
+
+        asyncio.run(_setup())
+
+        response = client.get(endpoint, headers=_bearer(WRONG_TOKEN))
+        assert response.status_code == 401
+
+        async def _wait() -> list[dict[str, Any]]:
+            start = time.monotonic()
+            while (time.monotonic() - start) < 3.0:
+                count = await _count_measurements(endpoint)
+                if count >= 1:
+                    return await _fetch_measurements(endpoint)
+                await asyncio.sleep(0.05)
+            raise AssertionError(
+                f"timed out: {await _count_measurements(endpoint)} rows for {endpoint}"
+            )
+
+        rows = asyncio.run(_wait())
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["endpoint"] == endpoint
+        assert row["status"] == "401"
+        meta = row["meta"]
+        if isinstance(meta, str):
+            meta = json.loads(meta)
+        assert meta["probe_token_set"] is True
+        assert meta["auth_header_present"] is True
+
+    def test_health_snapshot_token_unset_records_503(
+        self,
+        client: TestClient,
+        patched_db: _StubBackend,
+        token_unset: None,
+    ) -> None:
+        endpoint = f"{PROBE_PREFIX}/health_snapshot"
+
+        async def _setup() -> None:
+            await _truncate_measurements()
+
+        asyncio.run(_setup())
+
+        response = client.get(endpoint, headers=_bearer(VALID_TOKEN))
+        assert response.status_code == 503
+
+        async def _wait() -> list[dict[str, Any]]:
+            start = time.monotonic()
+            while (time.monotonic() - start) < 3.0:
+                count = await _count_measurements(endpoint)
+                if count >= 1:
+                    return await _fetch_measurements(endpoint)
+                await asyncio.sleep(0.05)
+            raise AssertionError(
+                f"timed out: {await _count_measurements(endpoint)} rows for {endpoint}"
+            )
+
+        rows = asyncio.run(_wait())
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["endpoint"] == endpoint
+        assert row["status"] == "503"
+        meta = row["meta"]
+        if isinstance(meta, str):
+            meta = json.loads(meta)
+        # Token is unset -> probe_token_set should be False.
+        assert meta["probe_token_set"] is False
+        # Auth header WAS supplied by the test but the token-unset gate
+        # fires before auth validation; record honestly.
+        assert meta["auth_header_present"] is True

--- a/tests/test_coordination_events.py
+++ b/tests/test_coordination_events.py
@@ -113,6 +113,11 @@ def test_event_type_constants_match_documented_set():
         # Wave 2 extension — directional cross-runtime request failures.
         "coordination_failure.beam_python_boundary.python_to_beam_request_failed",
         "coordination_failure.beam_python_boundary.beam_to_python_request_failed",
+        # Wave 3a extension (RFC docs/proposals/beam-wave-3a-read-only-handlers.md §4.2).
+        # Migration 035's CHECK regex already accepts these — no DB follow-up.
+        "coordination_failure.wave_3a.fallback",
+        "coordination_failure.wave_3a.timeout",
+        "coordination_failure.wave_3a.envelope_invalid",
     }
     assert WAVE_0_EVENT_TYPES == expected
 


### PR DESCRIPTION
## Summary

Implements [RFC v0.2](docs/proposals/beam-wave-3a-read-only-handlers.md) §4.3 + §5 PR #2 — the `audit.coordination_measurements` schema and the probe-endpoint write path. Wave 3a's §4.1 (HTTP transport p99 vs Python-in-process p99) and §4.2 (503 / fallback rate sliding window) stop signs both read from this surface; without it, neither stop sign can be evaluated.

PR #1 (probe endpoint scaffolding, #537) at `/v1/probe/*` is the consumer of this migration. Without this PR landing, probe calls succeed but don't record — the stop-sign denominators are empty.

## Schema (`audit.coordination_measurements`)

| Column | Type | Note |
|---|---|---|
| `id` | `BIGSERIAL` | PK |
| `recorded_at` | `TIMESTAMPTZ` | DEFAULT NOW() |
| `measurement_type` | `TEXT` | CHECK `^measurement(\.[a-z0-9_]+)+$` |
| `endpoint` | `TEXT` | route path |
| `elapsed_ms` | `INTEGER` | NOT NULL |
| `status` | `TEXT` | HTTP status code as text |
| `payload_bytes` | `INTEGER` | NULL allowed |
| `meta` | `JSONB` | NULL allowed; CHECK `jsonb_typeof = 'object'` when present |

Indexes:

- `idx_coord_meas_type_time (measurement_type, recorded_at DESC)` — §4.1/§4.2 window scans
- `idx_coord_meas_endpoint (endpoint, recorded_at DESC) WHERE measurement_type LIKE 'measurement.wave_3a.%'` — per-endpoint p50/p99

Wave 3a writes `measurement_type = 'measurement.wave_3a.request'`. The schema is shared infrastructure: Wave 3b/3c will write distinct `measurement_type` values into the same table per §4.3.

**Flat (not partitioned)** — §4.3 schema spec doesn't call for partitioning and probe volume is low. If volume grows once Wave 3b/3c land, a follow-up migration can swap to RANGE(`recorded_at`) without changing the column shape.

## `coordination_failure.wave_3a.*` event types

Added to `src/coordination_events.py` and `WAVE_0_EVENT_TYPES`:

- `coordination_failure.wave_3a.fallback` — emitted by PR #3 when the Python transport falls back from BEAM to in-process dispatch
- `coordination_failure.wave_3a.timeout` — emitted by PR #3 when a BEAM call exceeds the 500ms hard budget per §3.2
- `coordination_failure.wave_3a.envelope_invalid` — emitted by the BEAM response-shape validator on §2.2 violations

Each has its payload contract pinned in the source docstring at landing time.

### CHECK constraint surprise

Migration 035's regex `^(coordination_failure)(\.[a-z_]+)+$` rejects `wave_3a` (the digit breaks `[a-z_]+`). Migration 041 broadens it to `[a-z0-9_]+`. The new class is a strict superset, so every pre-existing event_type still passes — backward compatible. The Python-side `_validate_event_type` mirror is broadened identically to keep client-side and DB-side acceptance sets aligned.

## Test plan

- [x] Migration 041 applies cleanly: `\d audit.coordination_measurements` returns expected columns + indexes + CHECKs
- [x] Direct insert with `measurement_type='measurement.wave_3a.request'` succeeds
- [x] Direct insert with malformed `measurement_type` is rejected by CHECK
- [x] `audit.events` accepts `coordination_failure.wave_3a.{fallback,timeout,envelope_invalid}` after the relaxed CHECK
- [x] Python allowlist (`WAVE_0_EVENT_TYPES`) contains the three new wave_3a types (drift guard in `test_coordination_events.py`)
- [x] End-to-end: `GET /v1/probe/health` records 1 row with `endpoint='/v1/probe/health'`, `status='200'`, `payload_bytes>0`
- [x] End-to-end: `GET /v1/probe/health_snapshot` with wrong bearer records 1 row with `status='401'`
- [x] End-to-end: `GET /v1/probe/health_snapshot` with token unset records 1 row with `status='503'`
- [x] `./scripts/dev/test-cache.sh --staged` passes (8990 passed, 35 skipped)
- [x] `./scripts/dev/unitares_doctor.py --mode local` passes (10/10)

## Operator note

The 7-day baseline accumulation gate (per v0.2 §5 PR #2) is operator-managed. Landing this PR does NOT open PR #3 — the operator decides when the baseline is ready by reading from `audit.coordination_measurements` directly.