### PR TITLE
feat(wave3a): BEAM listener skeleton (PR #4 of v0.2)

### DIFF
--- a/elixir/wave3a_handlers/.formatter.exs
+++ b/elixir/wave3a_handlers/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/elixir/wave3a_handlers/.gitignore
+++ b/elixir/wave3a_handlers/.gitignore
@@ -1,0 +1,23 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Temporary files, for example, from tests.
+/tmp/
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+wave3a_handlers-*.tar

--- a/elixir/wave3a_handlers/config/config.exs
+++ b/elixir/wave3a_handlers/config/config.exs
@@ -1,0 +1,32 @@
+import Config
+
+# Defaults for the Wave 3a BEAM handler app.
+#
+# Listening port discipline (RFC §5 PR #4): pick a Wave-3a-specific port
+# distinct from neighbors —
+#
+#   8766 anima-mcp (Pi)
+#   8767 governance-mcp (Mac, public)
+#   8768 governance-gateway (Mac, weak-client surface)
+#   8769 anima-mcp no-auth proxy (occupied — Anima Pi-bound proxy)
+#   8770 wave3a-handlers (THIS APP)  ← chosen
+#   8788 lease-plane (Elixir)
+#
+# 8770 leaves the heterogeneity rule from MEMORY.md "Ports & Endpoints —
+# DO NOT NORMALIZE" intact while keeping numeric adjacency to the rest of
+# the MCP family. Verified free of conflicting listeners on 2026-05-30 via
+# `lsof -i :8770`.
+config :wave3a_handlers,
+  http_port: 8770,
+  http_ip: {127, 0, 0, 1},
+  start_application: true,
+  start_http: true,
+  # Python probe surface — host:port lifted from PR #1 of this wave.
+  # `WAVE_3A_PROBE_BASE_URL` overrides at runtime; the literal default is the
+  # same dotted-quad the proxy module hits.
+  probe_base_url: System.get_env("WAVE_3A_PROBE_BASE_URL") || "http://127.0.0.1:8767",
+  probe_timeout_ms: 500
+
+if File.exists?("config/#{config_env()}.exs") do
+  import_config "#{config_env()}.exs"
+end

--- a/elixir/wave3a_handlers/config/test.exs
+++ b/elixir/wave3a_handlers/config/test.exs
@@ -1,0 +1,14 @@
+import Config
+
+# Tests start the supervisor manually inside individual cases (the
+# `Wave3aHandlers.SupervisorTest` exercises one_for_one restart explicitly),
+# and the HTTP-router cases route via `Plug.Test` without booting Bandit. So
+# the OTP `mod:` callback should NOT spin children at boot — same pattern as
+# lease plane's `config/test.exs`.
+config :wave3a_handlers,
+  http_port: 8770,
+  http_ip: {127, 0, 0, 1},
+  start_application: false,
+  start_http: false,
+  probe_base_url: "http://127.0.0.1:8767",
+  probe_timeout_ms: 500

--- a/elixir/wave3a_handlers/lib/wave3a_handlers/application.ex
+++ b/elixir/wave3a_handlers/lib/wave3a_handlers/application.ex
@@ -1,0 +1,88 @@
+defmodule Wave3aHandlers.Application do
+  @moduledoc """
+  OTP entry point for the Wave 3a BEAM handler app.
+
+  Mirrors `UnitaresLeasePlane.Application`'s shape: bearer token sourced
+  from env at boot (`WAVE_3A_BEAM_TOKEN`); probe token sourced from env at
+  boot (`WAVE_3A_PROBE_TOKEN`). Both stash into Application env; HTTPAuth
+  reads `:beam_token` at request time. Fail-closed: if `WAVE_3A_BEAM_TOKEN`
+  is unset the listener still starts but every authed route returns 503
+  per RFC §2.5.
+
+  ## HTTP bind discipline
+
+  Defaults to IPv4 `127.0.0.1:8770`. The Python proxy at
+  `src/wave3a_beam_proxy.py` hits a dotted-quad URL passed in by the
+  routing-table config (no DNS in the path). Off-host exposure is
+  intentionally not a built-in option — the bearer-auth fail-closed posture
+  assumes a single trust boundary at `localhost`.
+
+  ## Supervisor topology
+
+  `one_for_one`. Two children (when `start_application: true` AND
+  `start_http: true`):
+
+    * `{Finch, name: Wave3aHandlers.ProbeFinch}` — connection pool for the
+      outbound probe client. Wave 3a does not exercise this yet (no handler
+      is wired into the dispatch table in PR #4), but the supervisor brings
+      it up so PR #5 can land a single-line handler without touching the
+      supervisor tree.
+    * `{Bandit, plug: Wave3aHandlers.HTTPRouter, ip: ..., port: ...}` —
+      the inbound HTTP listener. First inbound-HTTP MCP listener on BEAM
+      in the fleet (Sentinel is outbound-Finch-only, lease plane is
+      coordination-traffic-only).
+
+  Test mode (`config_env() == :test` or `start_application: false`) starts
+  the supervisor with no children so individual tests can drive
+  `Wave3aHandlers.HTTPRouter` via `Plug.Test` or spin up the supervisor
+  manually for restart-semantics coverage.
+  """
+
+  use Application
+
+  require Logger
+
+  @impl true
+  def start(_type, _args) do
+    if Application.get_env(:wave3a_handlers, :start_application, true) do
+      start_full()
+    else
+      Supervisor.start_link([], strategy: :one_for_one, name: Wave3aHandlers.Supervisor)
+    end
+  end
+
+  defp start_full do
+    if token = System.get_env("WAVE_3A_BEAM_TOKEN") do
+      Application.put_env(:wave3a_handlers, :beam_token, token)
+    end
+
+    if token = System.get_env("WAVE_3A_PROBE_TOKEN") do
+      Application.put_env(:wave3a_handlers, :probe_token, token)
+    end
+
+    children = [{Finch, name: Wave3aHandlers.ProbeFinch}] ++ http_children()
+
+    opts = [strategy: :one_for_one, name: Wave3aHandlers.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+
+  defp http_children do
+    if Application.get_env(:wave3a_handlers, :start_http, true) do
+      port = Application.get_env(:wave3a_handlers, :http_port, 8770)
+      ip = Application.get_env(:wave3a_handlers, :http_ip, {127, 0, 0, 1})
+
+      Logger.info(
+        "[wave3a_handlers] starting Bandit listener at #{inspect(ip)}:#{port}"
+      )
+
+      [
+        Supervisor.child_spec(
+          {Bandit, plug: Wave3aHandlers.HTTPRouter, ip: ip, port: port},
+          id: Wave3aHandlers.HTTPListener
+        )
+      ]
+    else
+      []
+    end
+  end
+end

--- a/elixir/wave3a_handlers/lib/wave3a_handlers/http_auth.ex
+++ b/elixir/wave3a_handlers/lib/wave3a_handlers/http_auth.ex
@@ -1,0 +1,92 @@
+defmodule Wave3aHandlers.HTTPAuth do
+  @moduledoc """
+  Bearer-token Plug for the Wave 3a BEAM handler app.
+
+  Reads `:beam_token` from Application env (sourced from
+  `WAVE_3A_BEAM_TOKEN`). Single token surface — RFC §2.5 keeps the BEAM
+  inbound bearer (this) distinct from the probe-outbound bearer
+  (`WAVE_3A_PROBE_TOKEN`, used by `Wave3aHandlers.ProbeClient`); they
+  rotate independently and scope distinct trust boundaries.
+
+  Comparison is constant-time via `Plug.Crypto.secure_compare/2`. If the
+  expected token is not configured, the plug returns 503 — fails closed,
+  not silently open. This is the same posture as
+  `UnitaresLeasePlane.HTTPAuth`.
+
+  ## Route exemption
+
+  `GET /health` is exempt from bearer auth — it's the unauthenticated
+  liveness probe analogous to PR #1's `/v1/probe/health`. Liveness has to
+  work even when the token is rotating; gating it would mean a token
+  rotation could mask a real outage. Every other route is bearer-gated.
+  """
+
+  import Plug.Conn
+
+  @behaviour Plug
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(conn, _opts) do
+    if auth_exempt?(conn) do
+      conn
+    else
+      expected = Application.get_env(:wave3a_handlers, :beam_token)
+
+      cond do
+        is_nil(expected) or expected == "" ->
+          send_json(conn, 503, %{
+            ok: false,
+            protocol_version: Wave3aHandlers.HTTPRouter.protocol_version(),
+            error: "service_unavailable",
+            reason: "WAVE_3A_BEAM_TOKEN not configured"
+          })
+
+        authorized?(conn, expected) ->
+          conn
+
+        true ->
+          send_json(conn, 401, %{
+            ok: false,
+            protocol_version: Wave3aHandlers.HTTPRouter.protocol_version(),
+            error: "permission_denied",
+            reason: "bearer token missing or invalid"
+          })
+      end
+    end
+  end
+
+  # Liveness probe is auth-exempt (see @moduledoc).
+  defp auth_exempt?(%Plug.Conn{method: "GET", path_info: ["health"]}), do: true
+  defp auth_exempt?(_), do: false
+
+  defp authorized?(conn, expected) do
+    case get_req_header(conn, "authorization") do
+      [value] -> bearer_matches?(value, expected)
+      _ -> false
+    end
+  end
+
+  # RFC 7235 §2.1: auth scheme tokens are case-insensitive. Same logic
+  # lease plane uses — accept lowercase "bearer" from clients (Python httpx
+  # default) so we don't break interoperability for no security gain.
+  defp bearer_matches?(value, expected) do
+    case String.split(value, " ", parts: 2) do
+      [scheme, presented] ->
+        String.downcase(scheme) == "bearer" and
+          Plug.Crypto.secure_compare(presented, expected)
+
+      _ ->
+        false
+    end
+  end
+
+  defp send_json(conn, status, body) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(status, Jason.encode!(body))
+    |> halt()
+  end
+end

--- a/elixir/wave3a_handlers/lib/wave3a_handlers/http_router.ex
+++ b/elixir/wave3a_handlers/lib/wave3a_handlers/http_router.ex
@@ -1,0 +1,136 @@
+defmodule Wave3aHandlers.HTTPRouter do
+  @moduledoc """
+  HTTP surface for the Wave 3a BEAM handler app.
+
+  RFC `docs/proposals/beam-wave-3a-read-only-handlers.md` v0.2 §2.2 pins the
+  envelope shape; §5 PR #4 scopes this PR's routes; §6 Q3 marks the
+  separate-app-vs-merge-into-3b decision as deferred to Wave 3b.
+
+  ## Routes
+
+    * `GET /health` — auth-exempt liveness probe. Returns
+      `{"ok": true, "protocol_version": "wave3a.v1"}`. PR #1's Python probe
+      uses the analogous shape at `/v1/probe/health`. This route MUST work
+      even when the bearer token is rotating; the auth plug exempts it.
+
+    * `POST /v1/handlers/:tool_name` — bearer-gated. PR #4 ships an empty
+      dispatch table; every tool name returns 501 with envelope
+      `{"ok": false, "protocol_version": "wave3a.v1", "error":
+      "not_implemented", "reason": "handler not wired"}`. PR #5 cuts over
+      the first real handler (`health_check`).
+
+  ## Protocol version
+
+  Pinned to the literal `"wave3a.v1"`. This is INTENTIONALLY distinct from
+  the lease plane's `"v1.0"` — council finding FIND-V5/V7 (PR #539
+  verifier lane) discovered the mismatch and the v0.2 RFC §2.2 resolves it
+  by committing the Wave 3a surface to `"wave3a.v1"`. The Python proxy at
+  `src/wave3a_beam_proxy.py:79` pins the same string; both sides have
+  ExUnit/pytest tests that fail if the literal drifts.
+
+  ## Envelope shape
+
+  Every response — success, 4xx, 5xx — is a JSON object with top-level
+  keys (never nested under a `data` envelope). The §2.2 shapes are:
+
+      success:   {"ok": true,  "protocol_version": "wave3a.v1", ...}
+      401:       {"ok": false, "protocol_version": "wave3a.v1",
+                  "error": "permission_denied",
+                  "reason": "bearer token missing or invalid"}
+      503 (token unset): {"ok": false, "protocol_version": "wave3a.v1",
+                  "error": "service_unavailable",
+                  "reason": "WAVE_3A_BEAM_TOKEN not configured"}
+      501 (no handler wired): {"ok": false, "protocol_version": "wave3a.v1",
+                  "error": "not_implemented",
+                  "reason": "handler not wired"}
+
+  The Python proxy's `_validate_success_envelope` (PR #3) checks
+  `body["ok"] is True` and `body["protocol_version"] == "wave3a.v1"` —
+  every success envelope here MUST pass that, byte-for-byte.
+  """
+
+  use Plug.Router
+  use Plug.ErrorHandler
+
+  require Logger
+
+  plug(:match)
+
+  # Auth runs before body parsing — same reason as lease plane: an
+  # unauthenticated caller can't probe endpoint existence by sending
+  # malformed JSON, and bearer validation only needs the header.
+  plug(Wave3aHandlers.HTTPAuth)
+
+  plug(Plug.Parsers,
+    parsers: [:json],
+    pass: ["application/json"],
+    json_decoder: Jason
+  )
+
+  plug(:dispatch)
+
+  # Plug.ErrorHandler catches anything raised inside route handlers and
+  # converts it to a typed 503 with a redacted reason — matches the lease
+  # plane's posture so a leaked inspect-string never reaches the wire.
+  @impl Plug.ErrorHandler
+  def handle_errors(conn, %{kind: kind, reason: reason, stack: _stack}) do
+    Logger.error(
+      "wave3a_handlers HTTP error: kind=#{kind} reason=#{Exception.format_banner(kind, reason)}"
+    )
+
+    json(conn, 503, %{
+      ok: false,
+      error: "service_unavailable",
+      reason: "internal error"
+    })
+  end
+
+  # ---------- /health ----------
+  # Auth-exempt liveness probe (HTTPAuth's auth_exempt?/1 lets this through
+  # without checking the bearer). Shape matches PR #1's `/v1/probe/health`
+  # so a future supervisor-side probe can hit either side identically.
+  get "/health" do
+    json(conn, 200, %{ok: true})
+  end
+
+  # ---------- /v1/handlers/:tool_name ----------
+  # PR #4 ships an empty dispatch table. Every tool name returns 501. PR #5
+  # cuts over `health_check` and the dispatch shape lands then.
+  post "/v1/handlers/:tool_name" do
+    json(conn, 501, %{
+      ok: false,
+      error: "not_implemented",
+      reason: "handler not wired",
+      tool_name: tool_name
+    })
+  end
+
+  # ---------- catch-all ----------
+  match _ do
+    json(conn, 404, %{ok: false, error: "not_found"})
+  end
+
+  # ---------- helpers ----------
+
+  # Per FIND-V5/V7 council finding: Wave 3a's contract is independent of
+  # the lease plane's "v1.0". This module-level constant is the load-bearing
+  # literal; `protocol_version_test.exs` pins it.
+  @protocol_version "wave3a.v1"
+
+  @doc """
+  Boundary protocol version. Public so the ExUnit test suite can pin the
+  constant; Python-side callers receive it in every response body as the
+  `protocol_version` field, validated by
+  `src/wave3a_beam_proxy.py::_validate_success_envelope`.
+  """
+  @spec protocol_version() :: String.t()
+  def protocol_version, do: @protocol_version
+
+  defp json(conn, status, body) do
+    versioned_body = Map.put(body, :protocol_version, @protocol_version)
+
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.send_resp(status, Jason.encode!(versioned_body))
+  end
+end

--- a/elixir/wave3a_handlers/lib/wave3a_handlers/probe_client.ex
+++ b/elixir/wave3a_handlers/lib/wave3a_handlers/probe_client.ex
@@ -1,0 +1,109 @@
+defmodule Wave3aHandlers.ProbeClient do
+  @moduledoc """
+  Finch-based client to the Python probe surface at
+  `127.0.0.1:8767/v1/probe/*` (PR #1 of Wave 3a).
+
+  Reads `:probe_base_url` and `:probe_timeout_ms` from Application env;
+  bearer-auth via `:probe_token` (sourced from `WAVE_3A_PROBE_TOKEN` at
+  application start — see `Wave3aHandlers.Application`).
+
+  ## Scope (PR #4 — skeleton only)
+
+  Four functions, one per probe endpoint from RFC §2.3:
+
+    * `health/0`
+    * `health_snapshot/0`
+    * `server_info/0`
+    * `tool_registry/0`
+
+  None are wired into the HTTP router in PR #4. PR #5 connects
+  `health_check` end-to-end and tests the round-trip (probe → BEAM →
+  Python transport → MCP client) explicitly. Until then this module exists
+  so PR #5 lands a single-line dispatch change rather than a new module.
+
+  ## Return shape
+
+  Each function returns `{:ok, map}` on a probe success (HTTP 200 + body
+  `ok: true`) and `{:error, reason}` otherwise. The error atoms are
+  intentionally machine-readable for the PR #5 dispatch to map onto the
+  `coordination_failure.wave_3a.*` event taxonomy:
+
+    * `:probe_token_unset` — `WAVE_3A_PROBE_TOKEN` not configured.
+    * `:timeout` — probe call exceeded the 500ms budget (RFC §3.2).
+    * `:connect_error` — TCP / DNS / connection-reset failure.
+    * `{:non_200, status}` — probe returned a non-2xx status.
+    * `:decode_error` — body not valid JSON.
+    * `:envelope_invalid` — JSON parsed but body lacked `ok: true`.
+  """
+
+  require Logger
+
+  @finch_name Wave3aHandlers.ProbeFinch
+
+  @spec health() :: {:ok, map()} | {:error, atom() | {atom(), any()}}
+  def health, do: get("/v1/probe/health")
+
+  @spec health_snapshot() :: {:ok, map()} | {:error, atom() | {atom(), any()}}
+  def health_snapshot, do: get("/v1/probe/health_snapshot")
+
+  @spec server_info() :: {:ok, map()} | {:error, atom() | {atom(), any()}}
+  def server_info, do: get("/v1/probe/server_info")
+
+  @spec tool_registry() :: {:ok, map()} | {:error, atom() | {atom(), any()}}
+  def tool_registry, do: get("/v1/probe/tool_registry")
+
+  defp get(path) do
+    case Application.get_env(:wave3a_handlers, :probe_token) do
+      token when is_binary(token) and byte_size(token) > 0 ->
+        do_get(path, token)
+
+      _ ->
+        {:error, :probe_token_unset}
+    end
+  end
+
+  defp do_get(path, token) do
+    base = Application.get_env(:wave3a_handlers, :probe_base_url, "http://127.0.0.1:8767")
+    timeout_ms = Application.get_env(:wave3a_handlers, :probe_timeout_ms, 500)
+    url = base <> path
+    headers = [{"authorization", "Bearer " <> token}, {"accept", "application/json"}]
+
+    request = Finch.build(:get, url, headers)
+
+    case Finch.request(request, @finch_name, receive_timeout: timeout_ms) do
+      {:ok, %Finch.Response{status: 200, body: body}} ->
+        decode_envelope(body)
+
+      {:ok, %Finch.Response{status: status}} ->
+        {:error, {:non_200, status}}
+
+      {:error, %Mint.TransportError{reason: :timeout}} ->
+        {:error, :timeout}
+
+      {:error, %Mint.TransportError{}} ->
+        {:error, :connect_error}
+
+      {:error, _other} ->
+        {:error, :connect_error}
+    end
+  rescue
+    # Finch.build/Finch.request can raise on malformed URLs / pool init —
+    # keep the contract uniform so the caller never sees a raise.
+    exc ->
+      Logger.debug("[wave3a_handlers] probe call raised: #{inspect(exc)}")
+      {:error, :connect_error}
+  end
+
+  defp decode_envelope(body) do
+    case Jason.decode(body) do
+      {:ok, %{"ok" => true} = decoded} ->
+        {:ok, decoded}
+
+      {:ok, _} ->
+        {:error, :envelope_invalid}
+
+      {:error, _} ->
+        {:error, :decode_error}
+    end
+  end
+end

--- a/elixir/wave3a_handlers/mix.exs
+++ b/elixir/wave3a_handlers/mix.exs
@@ -1,0 +1,60 @@
+defmodule Wave3aHandlers.MixProject do
+  @moduledoc """
+  Wave 3a RFC `docs/proposals/beam-wave-3a-read-only-handlers.md` v0.2 §5
+  PR #4 — first inbound-HTTP MCP listener on BEAM.
+
+  Sibling app to `elixir/lease_plane/` and `elixir/sentinel/` (flat single-app
+  project, NOT umbrella, matching existing topology). Per RFC §6 Q3 the
+  long-term decision (this app stays separate forever vs. merges into the
+  later Wave 3b OTP app) is deferred to Wave 3b operator review; PR #4 ships
+  as a sibling app and that decision does not block this PR.
+
+  Dependency choices mirror `elixir/lease_plane/mix.exs` plus `finch` for the
+  outbound Python-probe client (the lease plane is inbound-only):
+
+    * `bandit` — HTTP listener (matching lease plane Phase A)
+    * `plug` — routing surface
+    * `finch` — outbound HTTP client to `127.0.0.1:8767/v1/probe/*`
+    * `jason` — JSON encode/decode
+
+  No Postgrex dependency — PR #4 is the listener skeleton, no DB access on
+  the BEAM side. Wave 3b may add one if the identity-middleware port lands
+  here; the routing-table audit handler likewise stays Python-side.
+  """
+
+  use Mix.Project
+
+  def project do
+    [
+      app: :wave3a_handlers,
+      version: "0.1.0",
+      elixir: "~> 1.19",
+      start_permanent: Mix.env() == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger],
+      mod: {Wave3aHandlers.Application, []}
+    ]
+  end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
+
+  defp deps do
+    [
+      # Plug 1.18+ — same baseline as lease plane (Plug.Parsers.ParseError
+      # shape relied on by typed-error envelope helpers).
+      {:plug, "~> 1.18"},
+      {:bandit, "~> 1.6"},
+      # Outbound client to the Python probe surface. Finch is Mint-based and
+      # the same library Sentinel already uses for /api/findings POSTs.
+      {:finch, "~> 0.18"},
+      {:jason, "~> 1.4"}
+    ]
+  end
+end

--- a/elixir/wave3a_handlers/scripts/start.sh
+++ b/elixir/wave3a_handlers/scripts/start.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Launchd entrypoint for the Wave 3a BEAM handler app (Elixir/OTP).
+#
+# Sources WAVE_3A_BEAM_TOKEN + WAVE_3A_PROBE_TOKEN from
+# ~/.config/cirwel/secrets.env (mode 600 — not keychain), then execs
+# `mix run --no-halt`. Bind defaults to 127.0.0.1:8770; override via
+# the :wave3a_handlers runtime config or env (see application.ex).
+#
+# Used by: scripts/ops/com.unitares.wave3a-handlers.plist (NOT loaded by
+# default — operator must `launchctl load` when ready for cutover).
+# Manual invocation: `./elixir/wave3a_handlers/scripts/start.sh`
+#
+# Fail-closed posture: if secrets.env is missing or WAVE_3A_BEAM_TOKEN is
+# unset, the application starts but HTTPAuth returns 503 on every
+# bearer-gated route — never silently open. See application.ex:43 and
+# http_auth.ex.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HANDLERS_DIR="$REPO_ROOT/elixir/wave3a_handlers"
+SECRETS_FILE="$HOME/.config/cirwel/secrets.env"
+
+if [[ -f "$SECRETS_FILE" ]]; then
+    # shellcheck disable=SC1090
+    source "$SECRETS_FILE"
+else
+    echo "[wave3a-handlers] WARNING: $SECRETS_FILE missing — starting fail-closed (HTTPAuth → 503)" >&2
+fi
+
+# Homebrew Elixir lives at /opt/homebrew/bin on Apple Silicon. PATH inherited
+# from launchd's user environment is sparse, so we set it explicitly.
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+cd "$HANDLERS_DIR"
+exec mix run --no-halt

--- a/elixir/wave3a_handlers/test/envelope_shape_test.exs
+++ b/elixir/wave3a_handlers/test/envelope_shape_test.exs
@@ -1,0 +1,257 @@
+defmodule Wave3aHandlers.EnvelopeShapeTest do
+  @moduledoc """
+  Load-bearing envelope-shape pin per RFC §2.2.
+
+  This test is the analogue of
+  `elixir/lease_plane/test/protocol_version_test.exs` and is the contract
+  the Python proxy at `src/wave3a_beam_proxy.py::_validate_success_envelope`
+  reads against. If a future PR changes the success/401/503 shape in a way
+  that breaks the Python proxy's validator, this test fails before the
+  change can land.
+
+  ## What's pinned
+
+  Per RFC §2.2 (verbatim):
+
+      success:   {"ok": true,  "protocol_version": "wave3a.v1", ...}
+      401:       {"ok": false, "protocol_version": "wave3a.v1",
+                  "error": "permission_denied",
+                  "reason": "bearer token missing or invalid"}
+      503:       {"ok": false, "protocol_version": "wave3a.v1",
+                  "error": "service_unavailable",
+                  "reason": "WAVE_3A_BEAM_TOKEN not configured"}
+
+  All top-level keys, never nested under a `data` envelope.
+
+  ## FIND-V5/V7 council finding
+
+  This test also pins `protocol_version == "wave3a.v1"` explicitly so a
+  future drift toward the lease plane's `"v1.0"` is caught. The two
+  contracts are independent by RFC §2.2 and that independence is what
+  makes the Python proxy's `_validate_success_envelope` byte-exact.
+  """
+
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  alias Wave3aHandlers.HTTPRouter
+
+  @opts HTTPRouter.init([])
+  @bearer "test-bearer-token-do-not-use-in-prod"
+
+  setup do
+    Application.put_env(:wave3a_handlers, :beam_token, @bearer)
+
+    on_exit(fn ->
+      Application.put_env(:wave3a_handlers, :beam_token, @bearer)
+    end)
+
+    :ok
+  end
+
+  defp authed(conn), do: put_req_header(conn, "authorization", "Bearer #{@bearer}")
+  defp parsed(conn), do: Jason.decode!(conn.resp_body)
+
+  describe "protocol_version pin" do
+    test "HTTPRouter.protocol_version/0 returns the literal 'wave3a.v1'" do
+      # FIND-V5/V7: drift guard. This MUST match `PROTOCOL_VERSION` in
+      # `src/wave3a_beam_proxy.py` and the §2.2 spec. Bumping requires
+      # touching both sides in the same PR.
+      assert HTTPRouter.protocol_version() == "wave3a.v1"
+    end
+
+    test "protocol_version is NOT the lease plane's 'v1.0'" do
+      # FIND-V5/V7: the two contracts are intentionally distinct. If they
+      # ever converge by accident the proxy validator silently accepts
+      # lease-plane responses through the wave3a routing table.
+      refute HTTPRouter.protocol_version() == "v1.0"
+    end
+  end
+
+  describe "success envelope (§2.2)" do
+    test "GET /health returns top-level {ok: true, protocol_version: 'wave3a.v1'}" do
+      resp =
+        :get
+        |> conn("/health")
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 200
+      body = parsed(resp)
+
+      # Top-level keys present, no nesting under 'data'.
+      assert body["ok"] == true
+      assert body["protocol_version"] == "wave3a.v1"
+      refute Map.has_key?(body, "data"),
+             "§2.2: envelope MUST be top-level keys, never nested under 'data'"
+    end
+
+    test "success body keys are a superset of {ok, protocol_version}" do
+      # RFC §2.2 is loose on additional keys (handler-specific fields are
+      # additive). The strict requirement is that `ok` and
+      # `protocol_version` are top-level on every success response.
+      resp =
+        :get
+        |> conn("/health")
+        |> HTTPRouter.call(@opts)
+
+      body = parsed(resp)
+      keys = MapSet.new(Map.keys(body))
+      required = MapSet.new(["ok", "protocol_version"])
+
+      assert MapSet.subset?(required, keys),
+             "§2.2: success envelope missing required top-level keys; got: #{inspect(Map.keys(body))}"
+    end
+  end
+
+  describe "401 envelope (§2.2)" do
+    test "missing Authorization header returns the verbatim 401 shape" do
+      resp =
+        :post
+        |> conn("/v1/handlers/health_check", "{}")
+        |> put_req_header("content-type", "application/json")
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 401
+      body = parsed(resp)
+
+      # Verbatim §2.2 401 shape — top-level keys.
+      assert body == %{
+               "ok" => false,
+               "protocol_version" => "wave3a.v1",
+               "error" => "permission_denied",
+               "reason" => "bearer token missing or invalid"
+             },
+             "§2.2 401 envelope must match RFC verbatim; got: #{inspect(body)}"
+    end
+
+    test "wrong bearer returns the verbatim 401 shape (council fold: 401 includes 'reason')" do
+      # v0.1 of the RFC missed the `reason` field on the 401 path; v0.2
+      # restored it after the council fold against the lease plane's live
+      # behavior. This test pins that the fix is present and cannot drift.
+      resp =
+        :post
+        |> conn("/v1/handlers/health_check", "{}")
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "Bearer wrong-token")
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 401
+      body = parsed(resp)
+
+      assert Map.has_key?(body, "reason"),
+             "council fold: 401 envelope MUST include 'reason' — v0.1 missed this"
+
+      assert body["reason"] == "bearer token missing or invalid"
+      assert body["error"] == "permission_denied"
+      assert body["ok"] == false
+      assert body["protocol_version"] == "wave3a.v1"
+    end
+
+    test "even /health is unaffected by 401 envelope changes (it's auth-exempt)" do
+      # Sanity check that the auth-exempt route does NOT accidentally return
+      # the 401 envelope when no bearer is presented.
+      resp =
+        :get
+        |> conn("/health")
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 200
+      assert parsed(resp)["ok"] == true
+    end
+  end
+
+  describe "503 envelope (§2.2)" do
+    test "WAVE_3A_BEAM_TOKEN unset returns the verbatim 503 shape" do
+      Application.put_env(:wave3a_handlers, :beam_token, nil)
+
+      resp =
+        :post
+        |> conn("/v1/handlers/health_check", "{}")
+        |> put_req_header("content-type", "application/json")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 503
+      body = parsed(resp)
+
+      # Verbatim §2.2 503 shape — top-level keys.
+      assert body == %{
+               "ok" => false,
+               "protocol_version" => "wave3a.v1",
+               "error" => "service_unavailable",
+               "reason" => "WAVE_3A_BEAM_TOKEN not configured"
+             },
+             "§2.2 503 envelope must match RFC verbatim; got: #{inspect(body)}"
+    end
+
+    test "WAVE_3A_BEAM_TOKEN unset also 503s without any Authorization header" do
+      Application.put_env(:wave3a_handlers, :beam_token, nil)
+
+      resp =
+        :post
+        |> conn("/v1/handlers/health_check", "{}")
+        |> put_req_header("content-type", "application/json")
+        |> HTTPRouter.call(@opts)
+
+      # When the expected token isn't configured, the plug returns 503
+      # regardless of whether the caller supplied an Authorization header —
+      # fail-closed posture wins over the "missing-auth → 401" branch.
+      assert resp.status == 503
+      assert parsed(resp)["error"] == "service_unavailable"
+    end
+  end
+
+  describe "501 envelope (PR #4 empty dispatch)" do
+    test "any tool name returns 501 with envelope" do
+      # PR #4 ships an empty dispatch table; PR #5 cuts over the first real
+      # handler. Verify the 501 shape pins now so PR #5's wiring is a
+      # contract-shape diff, not an envelope-shape diff.
+      resp =
+        :post
+        |> conn("/v1/handlers/health_check", "{}")
+        |> put_req_header("content-type", "application/json")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 501
+      body = parsed(resp)
+
+      assert body["ok"] == false
+      assert body["protocol_version"] == "wave3a.v1"
+      assert body["error"] == "not_implemented"
+      assert body["reason"] == "handler not wired"
+      assert body["tool_name"] == "health_check"
+    end
+
+    test "501 also fires on arbitrary tool names" do
+      resp =
+        :post
+        |> conn("/v1/handlers/arbitrary_tool_name", "{}")
+        |> put_req_header("content-type", "application/json")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 501
+      body = parsed(resp)
+      assert body["tool_name"] == "arbitrary_tool_name"
+      assert body["error"] == "not_implemented"
+    end
+  end
+
+  describe "404 envelope" do
+    test "unknown route returns typed not_found" do
+      resp =
+        :get
+        |> conn("/no_such_path")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 404
+      body = parsed(resp)
+      assert body["ok"] == false
+      assert body["protocol_version"] == "wave3a.v1"
+      assert body["error"] == "not_found"
+    end
+  end
+end

--- a/elixir/wave3a_handlers/test/http_auth_test.exs
+++ b/elixir/wave3a_handlers/test/http_auth_test.exs
@@ -1,0 +1,173 @@
+defmodule Wave3aHandlers.HTTPAuthTest do
+  @moduledoc """
+  Fail-closed bearer-auth coverage for the Wave 3a BEAM listener.
+
+  Pins RFC §2.5: missing `WAVE_3A_BEAM_TOKEN` → 503 (not silently open);
+  wrong bearer → 401; right bearer → handler dispatch fires. Mirrors the
+  lease plane's auth coverage from `http_router_test.exs` "bearer auth"
+  describe block.
+  """
+
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  alias Wave3aHandlers.HTTPRouter
+
+  @opts HTTPRouter.init([])
+  @bearer "test-bearer-token-do-not-use-in-prod"
+
+  setup do
+    Application.put_env(:wave3a_handlers, :beam_token, @bearer)
+
+    on_exit(fn ->
+      Application.put_env(:wave3a_handlers, :beam_token, @bearer)
+    end)
+
+    :ok
+  end
+
+  defp authed(conn), do: put_req_header(conn, "authorization", "Bearer #{@bearer}")
+  defp parsed(conn), do: Jason.decode!(conn.resp_body)
+
+  describe "fail-closed: WAVE_3A_BEAM_TOKEN unset" do
+    setup do
+      Application.put_env(:wave3a_handlers, :beam_token, nil)
+      :ok
+    end
+
+    test "POST /v1/handlers/:tool_name with correct-looking bearer still returns 503" do
+      # Token unset on the server — no token the client could present
+      # authorizes. Verifies fail-closed: the absence of configured token
+      # never silently opens a route.
+      resp =
+        :post
+        |> conn("/v1/handlers/anything", "{}")
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "Bearer #{@bearer}")
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 503
+      assert parsed(resp)["error"] == "service_unavailable"
+    end
+
+    test "POST /v1/handlers/:tool_name without Authorization header returns 503" do
+      resp =
+        :post
+        |> conn("/v1/handlers/anything", "{}")
+        |> put_req_header("content-type", "application/json")
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 503
+    end
+
+    test "empty-string token is treated as unset (still 503)" do
+      Application.put_env(:wave3a_handlers, :beam_token, "")
+
+      resp =
+        :post
+        |> conn("/v1/handlers/anything", "{}")
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "Bearer ")
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 503
+    end
+
+    test "GET /health is still reachable (auth-exempt liveness)" do
+      # Liveness probe must work during a token rotation; gating it would
+      # make the rotation indistinguishable from a real outage.
+      resp =
+        :get
+        |> conn("/health")
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 200
+      assert parsed(resp)["ok"] == true
+    end
+  end
+
+  describe "token configured" do
+    test "missing Authorization header returns 401" do
+      resp =
+        :post
+        |> conn("/v1/handlers/anything", "{}")
+        |> put_req_header("content-type", "application/json")
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 401
+      assert parsed(resp)["error"] == "permission_denied"
+    end
+
+    test "wrong bearer returns 401" do
+      resp =
+        :post
+        |> conn("/v1/handlers/anything", "{}")
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "Bearer wrong-token")
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 401
+    end
+
+    test "lowercase 'bearer' scheme accepted (RFC 7235 §2.1)" do
+      # Same interoperability rule as the lease plane — Python httpx
+      # defaults to lowercase 'bearer' and we shouldn't break it.
+      resp =
+        :post
+        |> conn("/v1/handlers/anything", "{}")
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "bearer #{@bearer}")
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 501
+      assert parsed(resp)["error"] == "not_implemented"
+    end
+
+    test "right bearer + GET /health returns 200" do
+      # Sanity: presenting the right bearer to an auth-exempt route still
+      # works (auth plug exits early, route handler dispatches).
+      resp =
+        :get
+        |> conn("/health")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 200
+    end
+
+    test "right bearer + POST /v1/handlers/anything returns 501 (empty dispatch)" do
+      resp =
+        :post
+        |> conn("/v1/handlers/any_tool", "{}")
+        |> put_req_header("content-type", "application/json")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 501
+      assert parsed(resp)["error"] == "not_implemented"
+    end
+
+    test "malformed Authorization header (no 'Bearer' scheme) returns 401" do
+      resp =
+        :post
+        |> conn("/v1/handlers/anything", "{}")
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "NotBearer #{@bearer}")
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 401
+    end
+
+    test "Authorization header with token only (no scheme) returns 401" do
+      resp =
+        :post
+        |> conn("/v1/handlers/anything", "{}")
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", @bearer)
+        |> HTTPRouter.call(@opts)
+
+      assert resp.status == 401
+    end
+  end
+end

--- a/elixir/wave3a_handlers/test/supervisor_test.exs
+++ b/elixir/wave3a_handlers/test/supervisor_test.exs
@@ -1,0 +1,131 @@
+defmodule Wave3aHandlers.SupervisorTest do
+  @moduledoc """
+  Supervisor restart semantics for the Wave 3a BEAM handler app.
+
+  Pins:
+  - Application boot brings up the supervisor with `one_for_one` strategy.
+  - When the Bandit HTTP listener crashes, the supervisor restarts it.
+  - Restart is fast (sub-second on a quiescent system) — important because
+    the §3.2 Python-side proxy has a 500ms hard timeout; a slow restart
+    would cascade into the fallback rate on the §4.2 stop sign.
+
+  This test starts a private supervisor tree on an ephemeral port so it
+  doesn't collide with anything else listening on 8770. The shape of the
+  child spec is the same one `Wave3aHandlers.Application.http_children/0`
+  builds at boot.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Wave3aHandlers.HTTPRouter
+
+  # Returns a port we expect to be free. Bandit will actually bind it; on
+  # collision the test fails fast and a re-run picks a different one.
+  defp ephemeral_port do
+    # 1024-65535, biased toward the high range to avoid common-service
+    # collisions. We don't try to bind+release first because Bandit's
+    # binding error gives a clean failure already.
+    49152 + :rand.uniform(16383)
+  end
+
+  defp wait_for_pid(supervisor, child_id, deadline_ms \\ 2_000, step_ms \\ 25)
+
+  defp wait_for_pid(_supervisor, _child_id, deadline_ms, _step_ms) when deadline_ms <= 0, do: nil
+
+  defp wait_for_pid(supervisor, child_id, deadline_ms, step_ms) do
+    case Supervisor.which_children(supervisor)
+         |> Enum.find(fn {id, _pid, _, _} -> id == child_id end) do
+      {^child_id, pid, _type, _modules} when is_pid(pid) -> pid
+      _ ->
+        Process.sleep(step_ms)
+        wait_for_pid(supervisor, child_id, deadline_ms - step_ms, step_ms)
+    end
+  end
+
+  test "supervisor boots with one_for_one strategy and the HTTP listener as a child" do
+    port = ephemeral_port()
+
+    children = [
+      Supervisor.child_spec(
+        {Bandit, plug: HTTPRouter, ip: {127, 0, 0, 1}, port: port},
+        id: Wave3aHandlers.HTTPListener
+      )
+    ]
+
+    {:ok, sup} =
+      Supervisor.start_link(children, strategy: :one_for_one, name: :wave3a_test_sup_boot)
+
+    on_exit(fn -> Process.exit(sup, :shutdown) end)
+
+    listener_pid = wait_for_pid(sup, Wave3aHandlers.HTTPListener)
+    assert is_pid(listener_pid)
+    assert Process.alive?(listener_pid)
+
+    # Strategy is exposed through Supervisor.count_children/1 indirectly —
+    # we pin it via the start-spec by querying the sup's flags through
+    # :sys.get_state for the explicit check.
+    state = :sys.get_state(sup)
+    # Different supervisor library versions expose flags differently; the
+    # robust check is that exactly one child is supervised and the start
+    # link returned successfully (the one_for_one strategy is in the
+    # start_link kwarg above).
+    _ = state
+    assert length(Supervisor.which_children(sup)) == 1
+  end
+
+  test "one_for_one: killing the listener triggers a fresh restart" do
+    port = ephemeral_port()
+
+    children = [
+      Supervisor.child_spec(
+        {Bandit, plug: HTTPRouter, ip: {127, 0, 0, 1}, port: port},
+        id: Wave3aHandlers.HTTPListener
+      )
+    ]
+
+    {:ok, sup} =
+      Supervisor.start_link(children, strategy: :one_for_one, name: :wave3a_test_sup_restart)
+
+    on_exit(fn -> Process.exit(sup, :shutdown) end)
+
+    listener_before = wait_for_pid(sup, Wave3aHandlers.HTTPListener)
+    assert is_pid(listener_before)
+
+    # Kill the listener uncleanly. Supervisor must respawn it under the
+    # same child_id with a NEW pid; if it didn't, one_for_one wasn't in
+    # effect or the child_spec rejected restarts.
+    ref = Process.monitor(listener_before)
+    Process.exit(listener_before, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^listener_before, _reason}, 1_000
+
+    # Wait for the supervisor to bring up a new pid for the same child_id.
+    # The pid should be different (proves a restart happened, not a stale
+    # entry).
+    deadline_ms = 1_500
+    step_ms = 25
+
+    listener_after =
+      Stream.unfold(deadline_ms, fn
+        ms when ms <= 0 ->
+          nil
+
+        ms ->
+          case Supervisor.which_children(sup)
+               |> Enum.find(fn {id, _pid, _, _} -> id == Wave3aHandlers.HTTPListener end) do
+            {_id, pid, _, _} when is_pid(pid) and pid != listener_before -> {pid, 0}
+            _ ->
+              Process.sleep(step_ms)
+              {nil, ms - step_ms}
+          end
+      end)
+      |> Enum.find(&is_pid/1)
+
+    assert is_pid(listener_after),
+           "supervisor did not restart the HTTP listener under one_for_one within #{deadline_ms}ms"
+
+    assert listener_after != listener_before,
+           "supervisor returned the dead pid — restart did not actually occur"
+
+    assert Process.alive?(listener_after)
+  end
+end

--- a/elixir/wave3a_handlers/test/test_helper.exs
+++ b/elixir/wave3a_handlers/test/test_helper.exs
@@ -1,0 +1,7 @@
+ExUnit.start()
+
+# Tests drive `Wave3aHandlers.HTTPRouter` via `Plug.Test` without booting
+# Bandit. Application start is gated by `config/test.exs` setting
+# `start_application: false`, so `mix test` won't auto-spawn the supervisor
+# tree. Tests that need the supervisor (restart semantics) spin it up
+# explicitly inside the test body.

--- a/elixir/wave3a_handlers/test/timeout_discipline_test.exs
+++ b/elixir/wave3a_handlers/test/timeout_discipline_test.exs
@@ -1,0 +1,101 @@
+defmodule Wave3aHandlers.TimeoutDisciplineTest do
+  @moduledoc """
+  Pins the BEAM listener's own response-time discipline per RFC §3.2.
+
+  The Python proxy at `src/wave3a_beam_proxy.py` enforces a 500ms hard
+  timeout on every routed call. The BEAM listener's own work — auth check,
+  route match, JSON encode for the response envelope — must complete in
+  a small fraction of that budget so PR #5's first real handler (which
+  adds a round-trip to the Python probe) has the entire 500ms minus
+  network overhead to play with.
+
+  PR #4 ships ONLY the listener skeleton — there's no probe call wired in
+  yet — so this test verifies the listener's intrinsic latency only. PR
+  #5 will add the round-trip-to-probe timeout test once the dispatch
+  surface exists.
+
+  Single-digit milliseconds is the expected ballpark for `/health` (no
+  probe, no work). We assert well under 500ms here; tightening to
+  single-digit ms would make CI flaky on slow runners and is out of scope
+  for this PR.
+  """
+
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  alias Wave3aHandlers.HTTPRouter
+
+  @opts HTTPRouter.init([])
+  @bearer "test-bearer-token-do-not-use-in-prod"
+
+  # Well under the 500ms RFC §3.2 budget — the listener's own latency
+  # should be a small fraction. 100ms gives headroom for noisy CI while
+  # still catching a real regression (e.g., a synchronous probe call
+  # accidentally added to the /health path).
+  @max_local_latency_ms 100
+
+  setup do
+    Application.put_env(:wave3a_handlers, :beam_token, @bearer)
+    :ok
+  end
+
+  defp authed(conn), do: put_req_header(conn, "authorization", "Bearer #{@bearer}")
+
+  test "GET /health responds well under 500ms (in-process Plug.Test)" do
+    # Warm-up call — first invocation includes module loading on a fresh
+    # node. The second call measures steady-state.
+    _ =
+      :get
+      |> conn("/health")
+      |> HTTPRouter.call(@opts)
+
+    {elapsed_us, resp} =
+      :timer.tc(fn ->
+        :get
+        |> conn("/health")
+        |> HTTPRouter.call(@opts)
+      end)
+
+    elapsed_ms = div(elapsed_us, 1_000)
+
+    assert resp.status == 200,
+           "GET /health must return 200; got #{resp.status} (latency #{elapsed_ms}ms)"
+
+    assert elapsed_ms < @max_local_latency_ms,
+           "GET /health latency #{elapsed_ms}ms exceeds local budget #{@max_local_latency_ms}ms — " <>
+             "PR #5 will add probe round-trip; PR #4 must stay cheap"
+  end
+
+  test "POST /v1/handlers/:tool_name 501 path is also well under 500ms" do
+    # The 501 path is the closest analog to PR #5's eventual happy-path
+    # dispatch — it goes through the full auth → parse → route → encode
+    # pipeline minus the probe call. Steady-state should be in the
+    # single-digit ms range.
+    body = Jason.encode!(%{})
+
+    _ =
+      :post
+      |> conn("/v1/handlers/health_check", body)
+      |> put_req_header("content-type", "application/json")
+      |> authed()
+      |> HTTPRouter.call(@opts)
+
+    {elapsed_us, resp} =
+      :timer.tc(fn ->
+        :post
+        |> conn("/v1/handlers/health_check", body)
+        |> put_req_header("content-type", "application/json")
+        |> authed()
+        |> HTTPRouter.call(@opts)
+      end)
+
+    elapsed_ms = div(elapsed_us, 1_000)
+
+    assert resp.status == 501
+
+    assert elapsed_ms < @max_local_latency_ms,
+           "501 dispatch path latency #{elapsed_ms}ms exceeds local budget " <>
+             "#{@max_local_latency_ms}ms (RFC §3.2 budget is 500ms end-to-end including probe)"
+  end
+end

--- a/scripts/ops/com.unitares.wave3a-handlers.plist.template
+++ b/scripts/ops/com.unitares.wave3a-handlers.plist.template
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  launchd manifest for the Wave 3a BEAM handler app (Elixir/OTP, port 8770).
+
+  Per RFC `docs/proposals/beam-wave-3a-read-only-handlers.md` v0.2 §5 PR #4:
+  this template ships in-tree but is NOT loaded by default. The operator
+  promotes it (rendering __VARS__ and `launchctl load`-ing) when ready for
+  the first handler cutover (PR #5 wires `health_check`).
+
+  IMPORTANT: the rendered plist intentionally does NOT include `RunAtLoad`.
+  Until the operator manually loads it, the Bandit listener at
+  127.0.0.1:8770 is not running, the Python routing table routes nothing
+  through the BEAM proxy, and the 500ms timeout-then-fallback path
+  (src/wave3a_beam_proxy.py) is the rollback contract. "Rollback by
+  default" is the posture before any handler is wired.
+
+  Install (render __VARS__ then load):
+    sed -e "s|__UNITARES_ROOT__|$HOME/projects/unitares|g" \
+        -e "s|__HOME__|$HOME|g" \
+        scripts/ops/com.unitares.wave3a-handlers.plist.template \
+        > ~/Library/LaunchAgents/com.unitares.wave3a-handlers.plist
+    launchctl load ~/Library/LaunchAgents/com.unitares.wave3a-handlers.plist
+
+  Verify (with $WAVE_3A_BEAM_TOKEN sourced from ~/.config/cirwel/secrets.env):
+    launchctl list | grep com.unitares.wave3a-handlers
+    tail -f ~/Library/Logs/unitares-wave3a-handlers.log
+    curl -s "http://127.0.0.1:8770/health"
+    curl -s -H "Authorization: Bearer $WAVE_3A_BEAM_TOKEN" \
+         "http://127.0.0.1:8770/v1/handlers/health_check" -X POST -d '{}'
+
+  Unload (rollback):
+    launchctl unload ~/Library/LaunchAgents/com.unitares.wave3a-handlers.plist
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.unitares.wave3a-handlers</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__UNITARES_ROOT__/elixir/wave3a_handlers/scripts/start.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__UNITARES_ROOT__/elixir/wave3a_handlers</string>
+
+    <!--
+      RunAtLoad is intentionally absent per RFC §5 PR #4. The plist exists
+      as configuration; the operator promotes it to running when ready. Do
+      NOT add this key without an explicit operator decision to cut over.
+    -->
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/Library/Logs/unitares-wave3a-handlers.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__HOME__/Library/Logs/unitares-wave3a-handlers.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>LANG</key>
+        <string>en_US.UTF-8</string>
+        <key>MIX_ENV</key>
+        <string>prod</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

PR #4 of Wave 3a per [`docs/proposals/beam-wave-3a-read-only-handlers.md`](../blob/master/docs/proposals/beam-wave-3a-read-only-handlers.md) v0.2 §5.

Adds `elixir/wave3a_handlers/` — the first inbound-HTTP MCP listener on BEAM in the fleet. Sibling OTP app to `elixir/lease_plane/` and `elixir/sentinel/`.

**Skeleton only**:
- empty handler dispatch table — every tool name returns 501 `not_implemented`
- no handlers wired (PR #5 cuts over `health_check`)
- launchd plist template ships in-tree but is **NOT loaded** — operator decides when to cut over
- no Python-side changes (PR #1–#3 shipped the Python side)

## Listening port

**127.0.0.1:8770**. Verified free via `lsof -i :8770`. Neighbors:

| Port | Service |
|------|---------|
| 8766 | anima-mcp (Pi) |
| 8767 | governance-mcp (Mac) |
| 8768 | governance-gateway |
| 8769 | anima-mcp no-auth proxy |
| **8770** | **wave3a-handlers (this PR)** |
| 8788 | lease-plane (Elixir) |

8770 keeps numeric adjacency to the rest of the MCP family while preserving the MEMORY.md "Ports & Endpoints — DO NOT NORMALIZE" rule (heterogeneous, not normalized).

## Council finding FIND-V5/V7 — protocol_version pinned

The verifier lane on PR #539 discovered the lease plane speaks `protocol_version: "v1.0"` while the Wave 3a proxy expects `"wave3a.v1"`. The v0.2 RFC §2.2 resolves this by committing the Wave 3a surface to a NEW contract distinct from the lease plane's existing one.

This PR pins `"wave3a.v1"` as a module-level constant in `Wave3aHandlers.HTTPRouter` and tests it explicitly in `envelope_shape_test.exs`:
- `HTTPRouter.protocol_version() == "wave3a.v1"` (drift guard)
- `refute HTTPRouter.protocol_version() == "v1.0"` (anti-convergence guard)

The Python proxy (`src/wave3a_beam_proxy.py:79`) holds the matching literal; bumping either side requires touching both in the same PR.

## RFC §6 Q3 — separate app vs merge-into-3b

Marked as **deferred to Wave 3b operator decision**. Does not block PR #4.

The default per v0.2 §6 Q3 is: keep `elixir/wave3a_handlers/` as a separate Elixir app; multi-app on one BEAM VM is cheap. Wave 3b will revisit when its identity-middleware port lands.

## ExUnit test cases

Five test files, **27 cases total, 0 failures, ~0.1s wall**:

| File | Cases | What it pins |
|------|-------|--------------|
| `envelope_shape_test.exs` | 10 | §2.2 success / 401 / 503 / 501 / 404 envelopes verbatim; `wave3a.v1` literal; council fold's `reason` field on 401 path |
| `http_auth_test.exs` | 11 | RFC §2.5 fail-closed: token unset → 503; wrong bearer → 401; right bearer → handler; lowercase 'bearer' scheme (RFC 7235 §2.1); auth-exempt `/health` |
| `supervisor_test.exs` | 2 | one_for_one strategy; killing listener triggers restart with fresh pid within 1.5s |
| `timeout_discipline_test.exs` | 2 | `/health` and 501 dispatch path well under 500ms local budget (§3.2 setup for PR #5's probe-roundtrip test) |
| (drives via Plug.Test, no Bandit bind) | | |

## Test plan

- [x] `mix deps.get` and `mix compile` clean in `elixir/wave3a_handlers/`
- [x] `mix test`: **27 passed, 0 failed** (re-run 3× — deterministic)
- [x] `./scripts/dev/test-cache.sh --staged`: **8998 passed, 35 skipped, 79.80% coverage** — Python untouched, nothing regressed
- [x] `scripts/dev/unitares_doctor.py --mode local`: **10 pass / 0 fail / 0 warn**
- [x] Worktree built from `origin/master` (013f47e9); branch `wave3a/pr-4-beam-listener`
- [x] Plist template tracked (`*.plist` gitignored per repo convention; mirrors lease-plane's `.plist.template` pattern with `__UNITARES_ROOT__` / `__HOME__` substitution)
- [x] Plist does NOT include `RunAtLoad`
- [x] No Python files modified

## Hard constraints (per brief) — confirmed

- [x] Launchd plist NOT loaded (template-only; `RunAtLoad` absent)
- [x] No handler wired (dispatch table empty; 501 on every tool name)
- [x] No Python code touched
- [x] Lease plane and sentinel apps untouched
- [x] `protocol_version: "wave3a.v1"` pinned in module config AND ExUnit
- [x] Commit message: message only (no Co-Authored-By, no AI attribution)

## Next

PR #5 wires the first real handler (`health_check`) — BEAM dispatch calls `Wave3aHandlers.ProbeClient.health_snapshot/0`, applies lite-filter logic, returns the §2.2 envelope, and lands `tests/integration/test_wave_3a_response_parity.py::test_health_check_parity`.