### PR TITLE
fix(wave3a): honor handler port env

### DIFF
--- a/elixir/wave3a_handlers/config/config.exs
+++ b/elixir/wave3a_handlers/config/config.exs
@@ -1,5 +1,24 @@
 import Config
 
+port_env = fn name, default ->
+  case System.get_env(name) do
+    nil ->
+      default
+
+    "" ->
+      default
+
+    raw ->
+      case Integer.parse(raw) do
+        {port, ""} when port in 1..65_535 ->
+          port
+
+        _ ->
+          raise "#{name} must be an integer TCP port in 1..65535, got: #{inspect(raw)}"
+      end
+  end
+end
+
 # Defaults for the Wave 3a BEAM handler app.
 #
 # Listening port discipline (RFC §5 PR #4): pick a Wave-3a-specific port
@@ -15,9 +34,9 @@ import Config
 # 8770 leaves the heterogeneity rule from MEMORY.md "Ports & Endpoints —
 # DO NOT NORMALIZE" intact while keeping numeric adjacency to the rest of
 # the MCP family. Verified free of conflicting listeners on 2026-05-30 via
-# `lsof -i :8770`.
+# `lsof -i :8770`. Override with WAVE_3A_HANDLERS_PORT for local drills.
 config :wave3a_handlers,
-  http_port: 8770,
+  http_port: port_env.("WAVE_3A_HANDLERS_PORT", 8770),
   http_ip: {127, 0, 0, 1},
   start_application: true,
   start_http: true,

--- a/elixir/wave3a_handlers/lib/wave3a_handlers/application.ex
+++ b/elixir/wave3a_handlers/lib/wave3a_handlers/application.ex
@@ -71,9 +71,7 @@ defmodule Wave3aHandlers.Application do
       port = Application.get_env(:wave3a_handlers, :http_port, 8770)
       ip = Application.get_env(:wave3a_handlers, :http_ip, {127, 0, 0, 1})
 
-      Logger.info(
-        "[wave3a_handlers] starting Bandit listener at #{inspect(ip)}:#{port}"
-      )
+      Logger.info("[wave3a_handlers] starting Bandit listener at #{inspect(ip)}:#{port}")
 
       [
         Supervisor.child_spec(

--- a/elixir/wave3a_handlers/scripts/start.sh
+++ b/elixir/wave3a_handlers/scripts/start.sh
@@ -4,7 +4,7 @@
 # Sources WAVE_3A_BEAM_TOKEN + WAVE_3A_PROBE_TOKEN from
 # ~/.config/cirwel/secrets.env (mode 600 — not keychain), then execs
 # `mix run --no-halt`. Bind defaults to 127.0.0.1:8770; override via
-# the :wave3a_handlers runtime config or env (see application.ex).
+# the :wave3a_handlers runtime config or env (see config/config.exs).
 #
 # Used by: scripts/ops/com.unitares.wave3a-handlers.plist (NOT loaded by
 # default — operator must `launchctl load` when ready for cutover).

--- a/elixir/wave3a_handlers/test/envelope_shape_test.exs
+++ b/elixir/wave3a_handlers/test/envelope_shape_test.exs
@@ -82,6 +82,7 @@ defmodule Wave3aHandlers.EnvelopeShapeTest do
       # Top-level keys present, no nesting under 'data'.
       assert body["ok"] == true
       assert body["protocol_version"] == "wave3a.v1"
+
       refute Map.has_key?(body, "data"),
              "§2.2: envelope MUST be top-level keys, never nested under 'data'"
     end

--- a/elixir/wave3a_handlers/test/supervisor_test.exs
+++ b/elixir/wave3a_handlers/test/supervisor_test.exs
@@ -9,24 +9,17 @@ defmodule Wave3aHandlers.SupervisorTest do
     the §3.2 Python-side proxy has a 500ms hard timeout; a slow restart
     would cascade into the fallback rate on the §4.2 stop sign.
 
-  This test starts a private supervisor tree on an ephemeral port so it
-  doesn't collide with anything else listening on 8770. The shape of the
-  child spec is the same one `Wave3aHandlers.Application.http_children/0`
-  builds at boot.
+  This test starts a private supervisor tree on port 0 so Bandit chooses
+  an available ephemeral port. The shape of the child spec is the same one
+  `Wave3aHandlers.Application.http_children/0` builds at boot, with
+  startup logging disabled only to keep test output quiet.
   """
 
   use ExUnit.Case, async: false
 
-  alias Wave3aHandlers.HTTPRouter
+  import ExUnit.CaptureLog
 
-  # Returns a port we expect to be free. Bandit will actually bind it; on
-  # collision the test fails fast and a re-run picks a different one.
-  defp ephemeral_port do
-    # 1024-65535, biased toward the high range to avoid common-service
-    # collisions. We don't try to bind+release first because Bandit's
-    # binding error gives a clean failure already.
-    49152 + :rand.uniform(16383)
-  end
+  alias Wave3aHandlers.HTTPRouter
 
   defp wait_for_pid(supervisor, child_id, deadline_ms \\ 2_000, step_ms \\ 25)
 
@@ -35,7 +28,9 @@ defmodule Wave3aHandlers.SupervisorTest do
   defp wait_for_pid(supervisor, child_id, deadline_ms, step_ms) do
     case Supervisor.which_children(supervisor)
          |> Enum.find(fn {id, _pid, _, _} -> id == child_id end) do
-      {^child_id, pid, _type, _modules} when is_pid(pid) -> pid
+      {^child_id, pid, _type, _modules} when is_pid(pid) ->
+        pid
+
       _ ->
         Process.sleep(step_ms)
         wait_for_pid(supervisor, child_id, deadline_ms - step_ms, step_ms)
@@ -43,11 +38,9 @@ defmodule Wave3aHandlers.SupervisorTest do
   end
 
   test "supervisor boots with one_for_one strategy and the HTTP listener as a child" do
-    port = ephemeral_port()
-
     children = [
       Supervisor.child_spec(
-        {Bandit, plug: HTTPRouter, ip: {127, 0, 0, 1}, port: port},
+        {Bandit, plug: HTTPRouter, ip: {127, 0, 0, 1}, port: 0, startup_log: false},
         id: Wave3aHandlers.HTTPListener
       )
     ]
@@ -74,11 +67,9 @@ defmodule Wave3aHandlers.SupervisorTest do
   end
 
   test "one_for_one: killing the listener triggers a fresh restart" do
-    port = ephemeral_port()
-
     children = [
       Supervisor.child_spec(
-        {Bandit, plug: HTTPRouter, ip: {127, 0, 0, 1}, port: port},
+        {Bandit, plug: HTTPRouter, ip: {127, 0, 0, 1}, port: 0, startup_log: false},
         id: Wave3aHandlers.HTTPListener
       )
     ]
@@ -91,41 +82,46 @@ defmodule Wave3aHandlers.SupervisorTest do
     listener_before = wait_for_pid(sup, Wave3aHandlers.HTTPListener)
     assert is_pid(listener_before)
 
-    # Kill the listener uncleanly. Supervisor must respawn it under the
-    # same child_id with a NEW pid; if it didn't, one_for_one wasn't in
-    # effect or the child_spec rejected restarts.
-    ref = Process.monitor(listener_before)
-    Process.exit(listener_before, :kill)
-    assert_receive {:DOWN, ^ref, :process, ^listener_before, _reason}, 1_000
+    capture_log(fn ->
+      # Kill the listener uncleanly. Supervisor must respawn it under the
+      # same child_id with a NEW pid; if it didn't, one_for_one wasn't in
+      # effect or the child_spec rejected restarts.
+      ref = Process.monitor(listener_before)
+      Process.exit(listener_before, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^listener_before, _reason}, 1_000
 
-    # Wait for the supervisor to bring up a new pid for the same child_id.
-    # The pid should be different (proves a restart happened, not a stale
-    # entry).
-    deadline_ms = 1_500
-    step_ms = 25
+      # Wait for the supervisor to bring up a new pid for the same child_id.
+      # The pid should be different (proves a restart happened, not a stale
+      # entry).
+      deadline_ms = 1_500
+      step_ms = 25
 
-    listener_after =
-      Stream.unfold(deadline_ms, fn
-        ms when ms <= 0 ->
-          nil
+      listener_after =
+        Stream.unfold(deadline_ms, fn
+          ms when ms <= 0 ->
+            nil
 
-        ms ->
-          case Supervisor.which_children(sup)
-               |> Enum.find(fn {id, _pid, _, _} -> id == Wave3aHandlers.HTTPListener end) do
-            {_id, pid, _, _} when is_pid(pid) and pid != listener_before -> {pid, 0}
-            _ ->
-              Process.sleep(step_ms)
-              {nil, ms - step_ms}
-          end
-      end)
-      |> Enum.find(&is_pid/1)
+          ms ->
+            case Supervisor.which_children(sup)
+                 |> Enum.find(fn {id, _pid, _, _} -> id == Wave3aHandlers.HTTPListener end) do
+              {_id, pid, _, _} when is_pid(pid) and pid != listener_before ->
+                {pid, 0}
 
-    assert is_pid(listener_after),
-           "supervisor did not restart the HTTP listener under one_for_one within #{deadline_ms}ms"
+              _ ->
+                Process.sleep(step_ms)
+                {nil, ms - step_ms}
+            end
+        end)
+        |> Enum.find(&is_pid/1)
 
-    assert listener_after != listener_before,
-           "supervisor returned the dead pid — restart did not actually occur"
+      assert is_pid(listener_after),
+             "supervisor did not restart the HTTP listener under one_for_one within #{deadline_ms}ms"
 
-    assert Process.alive?(listener_after)
+      assert listener_after != listener_before,
+             "supervisor returned the dead pid — restart did not actually occur"
+
+      assert Process.alive?(listener_after)
+      Process.sleep(100)
+    end)
   end
 end


### PR DESCRIPTION
## Summary
- make the Wave 3a BEAM listener config honor WAVE_3A_HANDLERS_PORT with range validation
- update the start-script comment to point at config/config.exs
- quiet the Bandit supervisor restart test by using port 0 and capturing expected crash logs

## Validation
- mix test (elixir/wave3a_handlers): 27 passed
- WAVE_3A_HANDLERS_PORT=8799 mix run --no-start: reports 8799
- WAVE_3A_HANDLERS_PORT=bad mix run --no-start: fails config load as expected
- ./scripts/dev/test-cache.sh: HIT from full pytest run, 9009 passed / 24 skipped
- ./scripts/dev/test-cache.sh --staged: full staged run, 9009 passed / 24 skipped
- pre-push smoke: 138 passed, doc health clear