### PR TITLE
fix(telemetry): record real tool failures in audit.tool_usage.success

### DIFF
--- a/src/mcp_server_std.py
+++ b/src/mcp_server_std.py
@@ -76,7 +76,7 @@ from src.agent_state import (
 
 from src.tool_schemas import get_tool_definitions
 from src.lock_cleanup import cleanup_stale_state_locks
-from src.services.tool_usage_recorder import record_tool_usage
+from src.services.tool_usage_recorder import classify_tool_result, record_tool_usage
 from src.background_tasks import create_tracked_task
 
 # ============================================================================
@@ -459,7 +459,9 @@ async def call_tool(name: str, arguments: dict[str, Any] | None) -> Sequence[Tex
         result = await dispatch_tool(name, arguments)
         latency_ms = int((time.monotonic() - t0) * 1000)
         if result is not None:
-            record_tool_usage(tool_name=name, agent_id=agent_id, success=True, latency_ms=latency_ms)
+            success, error_type = classify_tool_result(result)
+            record_tool_usage(tool_name=name, agent_id=agent_id, success=success,
+                              error_type=error_type, latency_ms=latency_ms)
             return result
         record_tool_usage(tool_name=name, agent_id=agent_id, success=False,
                           error_type="unknown_tool", latency_ms=latency_ms)

--- a/src/services/http_tool_service.py
+++ b/src/services/http_tool_service.py
@@ -18,7 +18,7 @@ from src.mcp_handlers.core import handle_process_agent_update
 from src.mcp_handlers.utils import require_agent_id
 from src.services.http_dispatch_fallback import execute_http_dispatch_fallback
 from src.services.runtime_queries import get_governance_metrics_data, get_health_check_data
-from src.services.tool_usage_recorder import record_tool_usage
+from src.services.tool_usage_recorder import classify_tool_result, record_tool_usage
 
 ToolHandler = Callable[[Dict[str, Any]], Awaitable[Any]]
 
@@ -73,13 +73,15 @@ async def execute_http_tool(tool_name: str, arguments: Dict[str, Any]) -> Any:
         if handler is not None:
             result = await handler(arguments)
             latency_ms = int((time.monotonic() - t0) * 1000)
+            success, error_type = classify_tool_result(result)
             record_tool_usage(tool_name=tool_name, agent_id=agent_id,
-                              success=True, latency_ms=latency_ms)
+                              success=success, error_type=error_type, latency_ms=latency_ms)
             return _normalize_direct_http_result(result)
         result = await execute_http_dispatch_fallback(tool_name, arguments)
         latency_ms = int((time.monotonic() - t0) * 1000)
+        success, error_type = classify_tool_result(result)
         record_tool_usage(tool_name=tool_name, agent_id=agent_id,
-                          success=True, latency_ms=latency_ms)
+                          success=success, error_type=error_type, latency_ms=latency_ms)
         return result
     except Exception as e:
         latency_ms = int((time.monotonic() - t0) * 1000)

--- a/src/services/tool_usage_recorder.py
+++ b/src/services/tool_usage_recorder.py
@@ -8,11 +8,61 @@ asyncpg (anyio-asyncio deadlock rule).
 
 from __future__ import annotations
 
-from typing import Optional
+import json
+from typing import Any, Optional, Tuple
 
 from src.logging_utils import get_logger
 
 logger = get_logger(__name__)
+
+
+def _payload_from_result(result: Any) -> Optional[dict]:
+    """Best-effort extraction of the JSON payload dict from a dispatched tool result.
+
+    Handlers return either a single-element list of MCP TextContent (whose .text is
+    a JSON string) or already-decoded data. Returns the decoded dict, or None when
+    the result is not a recognizable JSON object (treated as success — no signal).
+    """
+    if isinstance(result, dict):
+        return result
+    # All known error-bearing responses put the payload in element 0; inspect it
+    # regardless of list length so a multi-element response can't hide a failure.
+    if isinstance(result, (list, tuple)) and result and hasattr(result[0], "text"):
+        try:
+            decoded = json.loads(result[0].text)
+        except (json.JSONDecodeError, TypeError, AttributeError):
+            return None
+        return decoded if isinstance(decoded, dict) else None
+    return None
+
+
+# error_category values that are caused by governance (EISV) rather than by the
+# caller or the substrate. AGENT_PAUSED / AGENT_ARCHIVED gate-refusals carry
+# error_category="state_error"; counting them as tool failures would re-import the
+# circularity this label exists to avoid (a paused agent's later calls fail ONLY
+# because EISV paused it). Treat as no-signal to keep tool_usage.success EISV-blind.
+_EISV_CAUSED_ERROR_CATEGORIES = frozenset({"state_error"})
+
+
+def classify_tool_result(result: Any) -> Tuple[bool, Optional[str]]:
+    """Distinguish a genuine, EISV-blind tool failure from a successful call (possibly
+    carrying a governance verdict) by inspecting the result payload.
+
+    Only ``error_response()`` sets ``success: False`` (validation/auth/state/system
+    errors). ``success_response()`` always sets ``success: True`` and spreads any
+    governance ``verdict`` (pause/reject) into the payload — those are SUCCESSFUL
+    tool calls and must NOT be flagged as failures. ``state_error`` refusals are
+    excluded too: they are governance-caused (see ``_EISV_CAUSED_ERROR_CATEGORIES``),
+    so counting them would make the label circular. Returns ``(success, error_type)``.
+    """
+    payload = _payload_from_result(result)
+    if isinstance(payload, dict) and payload.get("success") is False:
+        category = payload.get("error_category")
+        if category in _EISV_CAUSED_ERROR_CATEGORIES:
+            return True, None  # governance-caused refusal — not an EISV-blind failure
+        error_type = category or payload.get("error_code") or "tool_error"
+        return False, str(error_type)
+    return True, None
 
 
 def record_tool_usage(

--- a/tests/test_tool_usage_classification.py
+++ b/tests/test_tool_usage_classification.py
@@ -1,0 +1,151 @@
+"""Tests for classify_tool_result — the discriminator that makes tool_usage.success
+an EISV-blind external signal.
+
+The hinge: only error_response() sets success=False (genuine validation/auth/state/
+system errors). success_response() always sets success=True and spreads governance
+verdicts (pause/reject) into the payload. A paused agent is a SUCCESSFUL tool call,
+not a failure, and must never be logged as one — otherwise the external label becomes
+circular (EISV drives the pause it would then be "validated" against).
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.services.tool_usage_recorder import classify_tool_result
+
+
+def _text_result(payload: dict):
+    """Mimic a single-element list of MCP TextContent (what dispatch_tool returns)."""
+    return [SimpleNamespace(text=json.dumps(payload))]
+
+
+# --- unit: classify_tool_result -------------------------------------------------
+
+def test_error_payload_dict_is_failure():
+    ok, etype = classify_tool_result(
+        {"success": False, "error": "bad", "error_category": "validation_error"}
+    )
+    assert ok is False
+    assert etype == "validation_error"
+
+
+def test_error_payload_textcontent_is_failure():
+    ok, etype = classify_tool_result(
+        _text_result({"success": False, "error": "boom", "error_code": "STATE_001"})
+    )
+    assert ok is False
+    assert etype == "STATE_001"
+
+
+def test_error_payload_without_category_falls_back():
+    ok, etype = classify_tool_result({"success": False, "error": "x"})
+    assert ok is False
+    assert etype == "tool_error"
+
+
+def test_governance_pause_verdict_is_success():
+    """CRITICAL: a pause verdict is success=True — must NOT be flagged as a failure."""
+    ok, etype = classify_tool_result(
+        _text_result({"success": True, "verdict": "pause", "phi": 0.05})
+    )
+    assert ok is True
+    assert etype is None
+
+
+def test_governance_reject_verdict_is_success():
+    ok, etype = classify_tool_result(
+        _text_result({"success": True, "verdict": "reject", "regime": "divergence"})
+    )
+    assert ok is True
+    assert etype is None
+
+
+def test_state_error_pause_gate_is_excluded():
+    """CRITICAL (council): AGENT_PAUSED/ARCHIVED gate refusals carry error_category=
+    state_error and are EISV-CAUSED — must be treated as no-signal, not a failure,
+    or the label becomes circular (a paused agent's later calls fail only because
+    EISV paused it)."""
+    ok, etype = classify_tool_result(
+        _text_result({"success": False, "error": "Agent is paused",
+                      "error_code": "AGENT_PAUSED", "error_category": "state_error"})
+    )
+    assert ok is True
+    assert etype is None
+
+
+def test_multi_element_list_failure_in_element_zero_is_caught():
+    """A failure payload in element 0 of a multi-element list must not slip through."""
+    result = [SimpleNamespace(text=json.dumps(
+        {"success": False, "error": "boom", "error_category": "system_error"})),
+        SimpleNamespace(text="trailing chunk")]
+    ok, etype = classify_tool_result(result)
+    assert ok is False
+    assert etype == "system_error"
+
+
+def test_plain_success_payload():
+    ok, etype = classify_tool_result({"success": True, "data": 1})
+    assert ok == (True) and etype is None
+
+
+def test_payload_without_success_key_is_success():
+    # health_check-style data with no explicit success flag -> no failure signal
+    ok, etype = classify_tool_result({"status": "healthy"})
+    assert ok is True and etype is None
+
+
+def test_unparseable_result_is_success():
+    ok, etype = classify_tool_result([MagicMock()])  # .text is not JSON
+    assert ok is True and etype is None
+    assert classify_tool_result(None) == (True, None)
+    assert classify_tool_result("not a payload") == (True, None)
+
+
+# --- integration: the recorder actually receives the classified verdict ---------
+
+def _consume_coro(coro, name=None):
+    if hasattr(coro, "close"):
+        coro.close()
+    return MagicMock()
+
+
+@pytest.mark.asyncio
+async def test_http_direct_handler_error_payload_records_failure():
+    from src.services.http_tool_service import execute_http_tool
+
+    mock_tracker = MagicMock()
+    err = _text_result({"success": False, "error": "nope", "error_category": "auth_error"})
+    direct_handler = AsyncMock(return_value=err)
+
+    with patch("src.services.http_tool_service.get_direct_http_tool_handler",
+               return_value=direct_handler), \
+         patch("src.tool_usage_tracker.get_tool_usage_tracker", return_value=mock_tracker), \
+         patch("src.background_tasks.create_tracked_task", side_effect=_consume_coro):
+        await execute_http_tool("identity", {"agent_id": "a1"})
+
+    kwargs = mock_tracker.log_tool_call.call_args.kwargs
+    assert kwargs["success"] is False
+    assert kwargs["error_type"] == "auth_error"
+
+
+@pytest.mark.asyncio
+async def test_http_pause_verdict_records_success():
+    """A governance pause flowing through the HTTP path is logged success=True."""
+    from src.services.http_tool_service import execute_http_tool
+
+    mock_tracker = MagicMock()
+    paused = _text_result({"success": True, "verdict": "pause", "phi": 0.04})
+    direct_handler = AsyncMock(return_value=paused)
+
+    with patch("src.services.http_tool_service.get_direct_http_tool_handler",
+               return_value=direct_handler), \
+         patch("src.tool_usage_tracker.get_tool_usage_tracker", return_value=mock_tracker), \
+         patch("src.background_tasks.create_tracked_task", side_effect=_consume_coro):
+        await execute_http_tool("process_agent_update", {"agent_id": "a1"})
+
+    kwargs = mock_tracker.log_tool_call.call_args.kwargs
+    assert kwargs["success"] is True
+    assert kwargs["error_type"] is None


### PR DESCRIPTION
## Why

While auditing whether governance EISV actually tracks real outcomes, I found `audit.tool_usage.success` is **hardcoded-true across 3.24M rows** (`SELECT count(*) FILTER (WHERE NOT success)` = 0). Root cause: the recorder logged `success=True` whenever `dispatch_tool` returned non-None — but handlers catch their own errors and **return** `{"success": false, ...}` as a normal payload rather than raising. So the failure signal was never read; it sat one layer down inside `result[0].text`.

This matters because `tool_usage.success` is the one **EISV-blind** external ground-truth label the schema is designed to hold. With it empty, every discrimination test against EISV is circular: of the existing `outcome_events` "bad" labels, **93% are EISV-derived** (trajectory self-validation + CIRS), and the only clean external label (`task_failed`) is n=29. Empirically the deployed governance verdict has **~12% recall** (88% of bad outcomes occurred under `verdict=safe`) — but we can't tell whether that's the metric or the missing label until the external signal exists.

## What

Add `classify_tool_result()` (+ `_payload_from_result()`) in `tool_usage_recorder.py` and wire it into **both** dispatch boundaries — STDIO `call_tool` and HTTP `execute_http_tool`. It inspects the returned payload:

- `success: False` → tool failure; `error_type` from `error_category`/`error_code`
- `success: True` → success. **Governance pause/reject verdicts ride here** (`success_response()` hard-codes `success: True` and spreads the verdict in) and must NOT count as failures, or the label becomes circular.

## Council review (architect + reviewer + live-verifier), applied

- **[architect, critical]** Exclude `error_category="state_error"`. A paused agent's *next* call hits the `AGENT_PAUSED` gate → `error_response(error_category="state_error")` → `success:False`. That failure exists **only because EISV paused the agent** — counting it re-imports the exact circularity this label exists to escape. Now treated as no-signal.
- **[reviewer]** Inspect element 0 of multi-element content lists so a failure can't slip through as success.
- **[live-verifier]** Confirmed against the running MCP (8767) + psql: `success_response()` returns `success:True` for pause and `status: identity_required` typed refusals (so those are correctly **not** counted as failures); `tool_usage` currently 0/3.24M false.

## Known edge (deferred, documented not fixed)

`success_response()`'s double-serialization-failure fallback emits `success:False`. Extremely low probability (requires a non-serializable object in a verdict payload *and* primary serialization to fail). Documented in the commit; not worth expanding scope into the shared `response_base.py`.

## Follow-ups (NOT in this PR — flagged by council)

1. **No live consumer yet.** `tool_usage.success` currently feeds only `get_tool_usage_stats` (operator UI). The new failure signal is write-only until something routes it into the validation/calibration path. This PR makes the signal *exist*; wiring a consumer is the next step.
2. **Selection bias remains.** Even a clean label is measured on an EISV-censored population (paused agents stop emitting). Non-circular validation needs either a non-enforced **shadow arm** (compute the pause, don't enforce, observe realized failure rate) or restricting correlation to the `proceed`-only stratum. Don't claim "EISV tracks outcomes" from this label alone.
3. **Weight by category downstream.** `validation_error` is the strongest agent-attributable signal; `system_error` is substrate noise; `state_error` is excluded. The validation effort should stratify, not collapse to a boolean.

## Tests

`tests/test_tool_usage_classification.py` (12 cases): error payloads → failure; pause/reject/`identity_required` verdicts → success; `state_error` excluded; multi-element list failure caught; unparseable/non-dict → success. Existing `test_http_tool_service_tool_usage.py` unchanged and green. Full suite: 4,935 passed (1 pre-existing env-only failure in `test_lease_plane_canonicalize`, reproduces on unmodified master — `TMPDIR` under `/private/tmp`).