### PR TITLE
fix(governance): persist behavioral EISV across restarts (save was dropping it)

### DIFF
--- a/src/agent_monitor_state.py
+++ b/src/agent_monitor_state.py
@@ -91,6 +91,26 @@ def _snapshot_governor_state(monitor: UNITARESMonitor) -> None:
         monitor.state._governor_state_dict = None
 
 
+def _attach_behavioral_state(monitor: UNITARESMonitor, state_data: dict) -> None:
+    """Merge the behavioral EISV EMA into the persisted snapshot.
+
+    The load path (``GovernanceMonitor.load_persisted_state``) already restores a
+    ``behavioral_eisv`` block via ``BehavioralEISV.from_dict``, but the live save
+    path historically serialized only the ODE state — so behavioral confidence reset
+    to ODE-fallback on every process restart (0/702 state files carried it). This
+    makes save symmetric with load. ``to_dict_with_history``/``from_dict`` round-trip
+    update_count, EMA values, histories, and the Welford baseline faithfully.
+    Telemetry serialization must never break a state save, so it is fail-open.
+    """
+    beh = getattr(monitor, "_behavioral_state", None)
+    if beh is None:
+        return
+    try:
+        state_data["behavioral_eisv"] = beh.to_dict_with_history()
+    except Exception:  # noqa: BLE001 — never let a snapshot serialization break the save
+        logger.debug("Behavioral state serialization skipped during save", exc_info=True)
+
+
 async def save_monitor_state_async(agent_id: str, monitor: UNITARESMonitor) -> None:
     """
     Async version of save_monitor_state - uses file-based storage.
@@ -99,6 +119,7 @@ async def save_monitor_state_async(agent_id: str, monitor: UNITARESMonitor) -> N
     """
     _snapshot_governor_state(monitor)
     state_data = monitor.state.to_dict_with_history()
+    _attach_behavioral_state(monitor, state_data)
 
     state_file = get_state_file(agent_id)
     state_file.parent.mkdir(parents=True, exist_ok=True)
@@ -168,6 +189,7 @@ def save_monitor_state(agent_id: str, monitor: UNITARESMonitor) -> None:
     """Save monitor state to file with locking to prevent race conditions."""
     _snapshot_governor_state(monitor)
     state_data = monitor.state.to_dict_with_history()
+    _attach_behavioral_state(monitor, state_data)
 
     state_file = get_state_file(agent_id)
     state_file.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_monitor_hydration.py
+++ b/tests/test_monitor_hydration.py
@@ -467,6 +467,79 @@ async def test_save_monitor_state_async_writes_normally_under_budget(tmp_path, m
     assert "update_count" in data or "E" in data
 
 
+# ─── Behavioral EISV survives restart (save was dropping it) ─────────────
+
+def _advance_behavioral(monitor, n=4):
+    """Advance the monitor's behavioral EMA so update_count > fallback threshold."""
+    for _ in range(n):
+        monitor._behavioral_state.update(0.6, 0.7, 0.25)
+    return monitor._behavioral_state.update_count
+
+
+def test_attach_behavioral_state_includes_ema():
+    from types import SimpleNamespace
+    from src.agent_monitor_state import _attach_behavioral_state
+    from src.behavioral_state import BehavioralEISV
+
+    beh = BehavioralEISV()
+    for _ in range(3):
+        beh.update(0.6, 0.7, 0.25)
+    monitor = SimpleNamespace(_behavioral_state=beh)
+    state_data = {}
+    _attach_behavioral_state(monitor, state_data)
+
+    assert "behavioral_eisv" in state_data
+    assert state_data["behavioral_eisv"]["updates"] == 3
+
+
+def test_attach_behavioral_state_failopen_when_absent():
+    from types import SimpleNamespace
+    from src.agent_monitor_state import _attach_behavioral_state
+
+    # No _behavioral_state attribute → no key, no raise
+    state_data = {}
+    _attach_behavioral_state(SimpleNamespace(), state_data)
+    assert "behavioral_eisv" not in state_data
+
+    # _behavioral_state present but serialization raises → fail-open, no key
+    class _Boom:
+        def to_dict_with_history(self):
+            raise RuntimeError("boom")
+
+    state_data = {}
+    _attach_behavioral_state(SimpleNamespace(_behavioral_state=_Boom()), state_data)
+    assert "behavioral_eisv" not in state_data
+
+
+@pytest.mark.asyncio
+async def test_save_persists_behavioral_eisv_and_round_trips(tmp_path, monkeypatch):
+    """Regression: the live save path dropped behavioral_eisv, so behavioral
+    confidence reset to ODE-fallback on every restart. Save must now persist it,
+    and the saved block must restore faithfully via from_dict (the load side)."""
+    from src import agent_monitor_state
+    from src.behavioral_state import BehavioralEISV
+
+    monkeypatch.setattr(
+        agent_monitor_state, "get_state_file",
+        lambda agent_id: tmp_path / f"{agent_id}_state.json",
+    )
+
+    monitor = _make_fresh_monitor("beh-persist")
+    count = _advance_behavioral(monitor, n=4)
+    assert count == 4  # precondition: would clear fallback (>=3)
+
+    await save_monitor_state_async("beh-persist", monitor)
+
+    data = json.loads((tmp_path / "beh-persist_state.json").read_text())
+    assert "behavioral_eisv" in data, "save path still dropping behavioral state"
+    assert data["behavioral_eisv"]["updates"] == 4
+
+    # Load side (from_dict) restores the persisted block faithfully.
+    restored = BehavioralEISV.from_dict(data["behavioral_eisv"])
+    assert restored.update_count == 4
+    assert restored.confidence >= 0.3  # no longer stuck in fallback after restart
+
+
 # ─── Fix #4: meta-None guards in process_update_authenticated_async ───────
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

Investigating why ~99% of agents run on the ODE prior, a council live-verifier found that **behavioral EISV is never persisted to disk** (`save_persisted_state()` carries the right serialization but is dead in production; the live save path strips the field). **0 of 702 state files contain a `behavioral_eisv` block.** So on every governance-MCP restart, behavioral confidence resets to ODE-fallback — and the agents that lose state are exactly the residents / substrate-anchored agents (Vigil/Sentinel/Lumen) for whom behavioral EISV actually accrues. After each restart they need 3 fresh check-ins to climb back out of fallback.

The load path is already correct (`governance_monitor.load_persisted_state` restores `behavioral_eisv` via `BehavioralEISV.from_dict`, wired at `governance_monitor.py:202`). The bug is purely that **save drops what load expects.**

## What

`save_monitor_state_async` and `save_monitor_state` both did `state_data = monitor.state.to_dict_with_history()` — ODE state only. Add `_attach_behavioral_state()` and call it in both, making save symmetric with load.

- `to_dict_with_history` ⇄ `from_dict` round-trips `update_count`, EMA values, E/I/S/V + obs histories, alphas, and the Welford `baseline_stats` faithfully (verified by test).
- **Fail-open**: a serialization error logs at debug and never breaks a state save.
- **No new concurrency surface**: the behavioral block rides the *existing* `fcntl`-locked atomic `_write_state_file` (`os.replace`) — no new writer, unlike the auto-fold sweep the council rejected.
- **No migration**: stays on the current file store. (The "move to Postgres" option was scoped out — its main benefit was cross-process access for the auto-fold sweep, which is not being built; reaching for it here would be a migration without a justifying consumer.)

## Identity-consistency

Keyed by `agent_id`. Fresh process-instances mint fresh UUIDs → fresh (empty) behavioral state, preserving the "fresh process = fresh agent" invariant. Only substrate-anchored UUIDs (residents/Lumen, hardcoded across restarts) gain the intended cross-restart continuity — which is correct for them.

## Tests

`tests/test_monitor_hydration.py` (+3): `_attach_behavioral_state` includes the EMA; fail-open when absent or serialization raises; and a save→read→`from_dict` round-trip proving `update_count=4` survives and `confidence >= 0.3` (no longer stuck in fallback after restart). Focused persistence/behavioral families: **346 passed**. (Full `test-cache` halts only on a pre-existing env-only failure in `test_lease_plane_canonicalize`, which reproduces on unmodified master — `TMPDIR` under `/private/tmp`.)

## Context

Minimal response to this session's design-council finding (architect's `core.behavioral_state` Option B intent + live-verifier's "behavioral_eisv never persisted"). The broader auto-fold-from-tool-telemetry idea was deliberately **not** built — tool telemetry feeds only ~15% of the behavioral sensor, so folding it would clear fallback on near-bootstrap state. See companion PR #543 (record real tool failures).