### PR TITLE
fix(r1): skip public KG emit when n_dims_used=0 (no data to score)

### DIFF
--- a/src/identity/trajectory_continuity.py
+++ b/src/identity/trajectory_continuity.py
@@ -172,8 +172,19 @@ async def _emit_public_kg_node(
     consumers needing forensic access read.
 
     Returns True on successful write, False otherwise (so tests can assert
-    the side-effect path without parsing logs).
+    the side-effect path without parsing logs). False covers both the
+    "no data to score" skip below and the fail-soft exception path.
     """
+    # When n_dims_used == 0 the verdict is forced to "inconclusive" by
+    # _classify_verdict's short-circuit (no channels had enough data to
+    # score). Emitting "I couldn't score this" to the public KG is noise:
+    # the audit row remains as the forensic anchor (canonical record per
+    # the v3.3-A docstring contract above), and downstream R2/sweep
+    # consumers operate on the audit table, not the KG node. Measured
+    # 2026-05-30: 24 of 26 new R1 KG discoveries were n_dims=0 from
+    # fresh-agent onboards that had no core.agent_state history yet.
+    if score.n_dims_used == 0:
+        return False
     try:
         from src.knowledge_graph import get_knowledge_graph
         from src.knowledge_graph import DiscoveryNode

--- a/tests/test_trajectory_continuity.py
+++ b/tests/test_trajectory_continuity.py
@@ -597,6 +597,36 @@ async def test_score_kg_node_id_is_deterministic_per_pair(mocked_db):
 
 
 @pytest.mark.asyncio
+async def test_score_skips_kg_emit_when_n_dims_used_is_zero(mocked_db):
+    """When the score had no EISV channels to compute on (n_dims_used=0,
+    typical for fresh-agent onboards with no core.agent_state history),
+    the verdict is forced inconclusive by _classify_verdict's short-circuit.
+    The audit row still writes (forensic anchor), but the public KG node
+    is skipped to avoid noise. 2026-05-30: 24 of 26 KG R1 discoveries were
+    n_dims=0 from this exact path."""
+    from src.identity.trajectory_continuity import score_trajectory_continuity
+
+    # Empty series → reconstruct returns no usable data for any channel
+    # → n_dims_used=0 → verdict forced to inconclusive.
+    empty_series = {"E": [], "I": [], "S": [], "V": []}
+    mocked_db.reconstruct_eisv_series = AsyncMock(
+        side_effect=_stub_reconstruct(empty_series, empty_series)
+    )
+
+    score = await score_trajectory_continuity(
+        claimed_parent_id="parent-uuid",
+        successor_id="successor-uuid",
+    )
+
+    assert score.n_dims_used == 0
+    assert score.verdict == "inconclusive"
+    # Audit row written (canonical forensic record).
+    mocked_db.record_r1_score_audit.assert_awaited_once()
+    # KG node skipped to avoid "I couldn't score this" noise.
+    mocked_db.public_kg_graph.add_discovery.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_score_kg_node_id_differs_across_pairs(mocked_db):
     """Different (parent, successor) pairs must produce different node ids
     so dedupe-by-pair is per-pair, not global."""


### PR DESCRIPTION
## Summary

24 of 26 R1 KG discoveries written today (2026-05-30, 08:37–13:32 UTC) carry `n_dims_used: 0`, `verdict: inconclusive` — the score had no EISV channels available because the freshly-onboarded agents had no `core.agent_state` history yet. The audit row is still valuable as a forensic anchor; the public KG node saying "I couldn't score this" is noise.

This adds a guard at the top of `_emit_public_kg_node` that returns `False` when `score.n_dims_used == 0`, skipping the KG write. The audit row still writes per the existing v3.3-A join-key contract.

## Why today

KG emission landed in PR #324 (`b42134b3`, 2026-05-03), but zero R1 KG discoveries existed between then and 2026-05-29 (27 days of audit rows that should have emitted). The governance MCP restarted at 06:52 UTC today; the first KG emit landed ~1h45m later. Whatever blocked emission in the pre-restart instance (stale-code or silent fail-soft) cleared on restart, and the per-onboard scoring path is now writing inconclusive-no-data rows at the rate of fresh onboards.

## Why this is the right gate, not the n_dims=0 case more generally

- `_classify_verdict` already short-circuits to `inconclusive` when `n_dims_used == 0` — no thresholds, no maturity gate, no per-channel reasoning runs.
- Downstream consumers (R2 FSM at `lineage_lifecycle.py:341`, `r1_maintenance` sweep, `handle_aggregate_metrics`, onboard background scoring) read the `audit.r1_score_audit` row, not the public KG node. The KG node is observability-only; the docstring at line 162–163 names the audit as canonical.
- Connection to `project_r1-audit-sparsity-and-stability-index-flat.md` Finding 1: 895 of 1163 historical audit rows are n_dims=0 — this is the canonical regime for fresh-agent onboards.

## Data anchors

- 26 KG discoveries from `governance_graph."Discovery"` where `properties->>'type' = 'trajectory_continuity_score'`, all timestamps within 2026-05-30 08:37–13:32 UTC.
- 24 with `n_dims_used: 0`, 2 with `n_dims_used: 4` (the 2 `plausible` verdicts in `audit.r1_score_audit` for the same day).
- Governance MCP PID 95761 started 2026-05-30 06:52 (per `ps -o etime` and log file mtime).

## Test plan

- [x] New test `test_score_skips_kg_emit_when_n_dims_used_is_zero` — stubs empty EISV series → `n_dims_used=0` → asserts audit row written but `add_discovery` not awaited.
- [x] Existing 22 trajectory_continuity tests still pass (verified locally).
- [x] R1-adjacent suites pass: `test_state_mixin_agent_state`, `test_lineage_continuity_helper`, `test_r1_maintenance` (37 tests total, all green).
- [x] `./scripts/dev/test-cache.sh` pre-push gate green (138 / 8346 deselected — the score-touching subset).