### PR TITLE
S8a Phase-2 30-day check: engaged_ephemeral corpus growth

### DIFF
--- a/docs/ontology/s8a-30day-check-2026-05-30.md
+++ b/docs/ontology/s8a-30day-check-2026-05-30.md
@@ -1,0 +1,70 @@
+# S8a Phase-2 30-day check — engaged_ephemeral corpus growth
+
+**Scheduled by 2026-04-30 ship; fires 2026-05-30 per REVIEW BY cookie on `config/governance_config.py:DELTA_NORM_MAX_BY_CLASS["engaged_ephemeral"]`.**
+
+## Baseline (2026-04-30 post-backfill)
+
+- 168 engaged_ephemeral total
+- 163 active, 5 archived
+- Ship PR: https://github.com/CIRWEL/unitares/pull/252 (commit `741b088a`)
+- Day-7 audit: `docs/ontology/s8a-phase2-prep.md`
+- KG axis-debt: `2026-05-01T01:51:00.839345+00:00`
+
+## Query #1 — overall corpus
+
+```bash
+psql -h localhost -U postgres -d governance -A -F'|' -c "
+SELECT status, COUNT(*) FROM core.identities
+WHERE metadata->'tags' @> '[\"engaged_ephemeral\"]'::jsonb
+GROUP BY status ORDER BY 2 DESC;
+"
+```
+
+## Query #2 — active cohort by label
+
+```bash
+psql -h localhost -U postgres -d governance -A -F'|' -c "
+SELECT
+  CASE
+    WHEN metadata->>'label' LIKE 'claude_desktop%' THEN 'claude_desktop'
+    WHEN metadata->>'label' LIKE 'claude_code%' THEN 'claude_code'
+    WHEN metadata->>'label' IS NULL THEN 'anonymous'
+    ELSE 'other_named'
+  END AS label_cohort,
+  COUNT(*) AS n,
+  AVG((metadata->>'total_updates')::int)::int AS avg_updates,
+  MAX((metadata->>'total_updates')::int) AS max_updates
+FROM core.identities
+WHERE status = 'active'
+  AND metadata->'tags' @> '[\"engaged_ephemeral\"]'::jsonb
+GROUP BY 1 ORDER BY 2 DESC;
+"
+```
+
+## Sweeper-running check
+
+Independent of count — confirm the in-server background task is alive:
+
+```bash
+grep -E '\[CLASS_PROMOTION\]' /Users/cirwel/projects/unitares/data/logs/mcp_server.log | tail -10
+```
+
+Expected: at least one `Started ephemeral → engaged_ephemeral sweep` line at last startup, plus periodic `no promotions` debug or `N ephemeral → engaged_ephemeral` info lines.
+
+## Interpretation
+
+| Active count vs baseline (163) | Meaning | Action |
+|---|---|---|
+| Still 163 (zero growth) | Sweeper not running OR no new agents crossed `total_updates >= 3` | Check `[CLASS_PROMOTION]` log lines; verify governance-mcp was restarted to pick up the 2026-04-30 task wiring (the ship left restart pending) |
+| Below 163 | Schema regression or accidental DELETE | Investigate `core.identities` directly and recent migrations |
+| 163 → 163+N (N < 30) | Sweeper running, corpus growing slowly | Probably fine; revisit in another 30 days |
+| 163 + N (N ≥ 30) | Corpus meaningful enough to re-measure | Run `scripts/calibrate_class_conditional.py` against engaged_ephemeral; update alias entries in `config/governance_config.py` |
+| N ≥ 100 | Strong engagement signal | Same as above; also consider whether threshold = 3 is still calibrated correctly given the new shape |
+
+## Operator checklist
+
+- [ ] Run query #1; paste result as a comment below.
+- [ ] Run query #2; paste result as a comment below.
+- [ ] Run sweeper-running check; paste result as a comment below.
+- [ ] Decide: close as healthy / file recalibration follow-up / file investigation issue.
+- [ ] If recalibration: open a new PR re-running `scripts/calibrate_class_conditional.py` and updating ScaleConstant entries.


### PR DESCRIPTION
## Purpose

Scheduled 30-day follow-up for S8a Phase-2 (`engaged_ephemeral` cohort tag), triggered by the `REVIEW BY: 2026-05-30` cookie on `config/governance_config.py:DELTA_NORM_MAX_BY_CLASS["engaged_ephemeral"]`.

Ship PR: https://github.com/CIRWEL/unitares/pull/252 (commit `741b088a`, 2026-04-30)

## What this PR adds

`docs/ontology/s8a-30day-check-2026-05-30.md` — a verification guide containing:

- **Query #1**: overall `engaged_ephemeral` corpus count by status
- **Query #2**: active cohort breakdown by label (`claude_desktop` / `claude_code` / anonymous / other)
- **Sweeper-running check**: `grep` against the mcp_server log for `[CLASS_PROMOTION]` lines
- **Interpretation table**: what each count range means and what action to take
- **Operator checklist**: paste query results here as comments, then decide

## How to use this PR

1. Run the three queries/checks from the doc locally (no code change needed).
2. Paste each result as a comment on this PR.
3. Use the interpretation table to decide: close as healthy, open a recalibration follow-up, or file an investigation issue.

No code is changed. This PR exists solely as the coordination surface for the scheduled check.

## Pre-check (automated)

`engaged_ephemeral` confirmed present in `src/grounding/class_indicator.py` (line 25, 67) and `src/grounding/class_promotion.py` (line 53–55, 58) — no reorg has removed the tag.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4o5tXCirTGzRAi8nu4Btk)_