### PR TITLE
calibrate engaged_ephemeral constants

### DIFF
--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -930,15 +930,11 @@ DELTA_NORM_MAX_BY_CLASS: Dict[str, ScaleConstant] = {
               "one check-in per day means a corpus takes weeks to build. "
               "Re-run scripts/calibrate_class_conditional.py once corpus exists."),
     "engaged_ephemeral": ScaleConstant(
-        name="DELTA_NORM_MAX[engaged_ephemeral]", value=0.2018, measured_on="2026-04-30",
-        corpus_size=0, percentile=None, provenance="alias",
-        notes="Alias to default. engaged_ephemeral cohort added by S8a Phase 2 "
- ": ephemeral agents with "
-              "total_updates >= 3 promote to engaged_ephemeral; the corpus does "
-              "not exist until promotion runs. "
-              "REVIEW BY: 2026-05-30 — if corpus_size is still 0 after a month, "
-              "either the sweeper isn't running or the threshold is wrong. "
-              "If corpus crosses N>=30, re-run scripts/calibrate_class_conditional.py."),
+        name="DELTA_NORM_MAX[engaged_ephemeral]", value=0.4246, measured_on="2026-05-30",
+        corpus_size=1289, percentile=95, provenance="measured",
+        notes="S8a 30-day REVIEW BY recalibration. engaged_ephemeral active "
+              "identity count grew from 163 to 261; healthy production slice "
+              "is now large enough to replace the default alias."),
 }
 
 # Healthy operating points per class — median (E, I, S) on healthy-regime
@@ -952,7 +948,7 @@ HEALTHY_OPERATING_POINT_BY_CLASS: Dict[str, Tuple[float, float, float]] = {
     "Watcher":  (0.7482, 0.7686, 0.2477),   # N=283
     "Steward":  (0.7264, 0.7934, 0.2364),   # alias=default (N=0; see DELTA_NORM_MAX[Steward])
     "Chronicler": (0.7264, 0.7934, 0.2364), # alias=default (N=0; see DELTA_NORM_MAX[Chronicler])
-    "engaged_ephemeral": (0.7264, 0.7934, 0.2364), # alias=default (S8a Phase 2; see DELTA_NORM_MAX[engaged_ephemeral])
+    "engaged_ephemeral": (0.7556, 0.6853, 0.3068), # measured 2026-05-30; N=1289
 }
 
 # Default healthy operating point (fleet fallback for unclassified agents).

--- a/tests/test_grounding_scale_constants.py
+++ b/tests/test_grounding_scale_constants.py
@@ -145,6 +145,24 @@ def test_healthy_operating_point_class_conditional():
     assert unknown_hop == HEALTHY_OPERATING_POINT_DEFAULT
 
 
+def test_engaged_ephemeral_review_cookie_recalibrated():
+    """S8a 30-day review replaced the default alias with measured values."""
+    from config.governance_config import (
+        DELTA_NORM_MAX_BY_CLASS,
+        HEALTHY_OPERATING_POINT_BY_CLASS,
+    )
+
+    sc = DELTA_NORM_MAX_BY_CLASS["engaged_ephemeral"]
+    assert sc.provenance == "measured"
+    assert sc.measured_on == "2026-05-30"
+    assert sc.corpus_size == 1289
+    assert sc.percentile == 95
+    assert sc.value == pytest.approx(0.4246)
+    assert HEALTHY_OPERATING_POINT_BY_CLASS["engaged_ephemeral"] == pytest.approx(
+        (0.7556, 0.6853, 0.3068)
+    )
+
+
 def test_delta_norm_max_default_covers_full_state_space_diagonal():
     """Fleet-wide default must allow full diagonal so unclassified agents can hit C=0."""
     assert DELTA_NORM_MAX.value >= math.sqrt(3) - 0.01


### PR DESCRIPTION
## Summary

Follows the S8a 30-day review in #547. The active engaged_ephemeral identity count is now 261, up from the 2026-04-30 baseline of 163, so the #547 interpretation table puts this in the recalibration path.

This PR keeps the scope to engaged_ephemeral rather than replacing every class emitted by the calibration script. It updates:

- `DELTA_NORM_MAX_BY_CLASS["engaged_ephemeral"]` from the default alias to a measured 95th-percentile radius of `0.4246`
- `HEALTHY_OPERATING_POINT_BY_CLASS["engaged_ephemeral"]` to `(0.7556, 0.6853, 0.3068)`
- a regression test that verifies the review-cookie recalibration remains measured

## Measurement

Commands/results from local production DB on 2026-05-30:

- Query #1: active `261`, archived `9`
- Query #2 active cohort: other_named `167` avg `34` max `898`; claude_code `41` avg `17` max `197`; anonymous `38` avg `34` max `250`; claude_desktop `15` avg `44` max `441`
- `scripts/calibrate_class_conditional.py --window-days 30` found `engaged_ephemeral N=1289` healthy observations
- Sweeper logs are present in `data/logs/mcp_server_error.log` rather than the PR guide's `mcp_server.log`; recent lines include `[CLASS_PROMOTION] Started ephemeral → engaged_ephemeral sweep (every 30m)` and `1 ephemeral → engaged_ephemeral (threshold=3)`

## Validation

- `python3 -m py_compile config/governance_config.py tests/test_grounding_scale_constants.py`
- `python3 -m pytest tests/test_grounding_scale_constants.py tests/test_grounding_class_indicator.py tests/test_class_promotion.py tests/test_s10_wire_up.py` (`64 passed`)
- `./scripts/dev/test-cache.sh` (`9034 passed, 36 skipped`)
- `./scripts/dev/test-cache.sh --staged` (`9035 passed, 35 skipped`)
- pre-push smoke (`138 passed`)
