### PR TITLE
phase-b evaluator: exclude synthetic/empty sessions from organic Type-A signal

### DIFF
--- a/scripts/lease_plane/evaluate_phase_b_promotion.py
+++ b/scripts/lease_plane/evaluate_phase_b_promotion.py
@@ -54,6 +54,43 @@ COLLISION_SYMPTOM_RE = (
 )
 DRILL_AUDIT_SESSION_PREFIX = "phase-b-drill:"
 
+# Session-label prefixes that mark *synthetic* conflict traffic — the HTTP race
+# harness and the live-probe smoke runner manufacture conflict_held_by_other
+# events against throwaway `.tmp` surfaces to exercise the plane. They must NOT
+# count as organic Type-A evidence (§6.1.3): they inflate the distinct-surface
+# count with conflicts that §6.1.4 can never corroborate (no real incident is
+# ever recorded, and their `codex-*` audit_session labels don't even share a
+# namespace with KG `provenance.writer_session_id_at_write`, which is `agent-*`).
+# 2026-05-30 forensic on surface_kind='file': all 6 "organic" surfaces were
+# harness/probe/bring-up artifacts; §6.1.4 was the only criterion preventing a
+# spurious promotion on test traffic. Tightening §6.1.3 removes that fragility.
+SYNTHETIC_SESSION_PREFIXES = ("codex-http-race", "codex-live-probe")
+
+
+def _organic_audit_session_sql() -> str:
+    """SQL predicate on ``payload->>'audit_session'`` selecting *organic*
+    conflict evidence for §6.1.3 / §6.1.4: a non-empty session that is neither a
+    controlled drill nor synthetic harness/probe traffic.
+
+    A conflict with an empty audit_session is excluded because it is
+    structurally unlinkable in §6.1.4 (no session to join to a KG incident), so
+    it cannot contribute corroborable Type-A evidence. All interpolated values
+    are trusted module constants (no quotes/wildcards), never user input — safe
+    to inline rather than parameterize. The LIKE wildcard is written ``%%``
+    because this fragment is embedded in a query that psycopg2 then runs through
+    %-style parameter substitution; a bare ``%`` would be misread as a
+    placeholder (IndexError: tuple index out of range).
+    """
+    clauses = [
+        "coalesce(payload->>'audit_session', '') <> ''",
+        f"payload->>'audit_session' NOT LIKE '{DRILL_AUDIT_SESSION_PREFIX}%%'",
+    ]
+    clauses.extend(
+        f"payload->>'audit_session' NOT LIKE '{prefix}%%'"
+        for prefix in SYNTHETIC_SESSION_PREFIXES
+    )
+    return " AND ".join(clauses)
+
 
 @dataclass
 class CriterionResult:
@@ -212,15 +249,16 @@ def _criterion_3_type_a_signal(
     cur, surface_kind: str, window_days: int, *, accept_drill_evidence: bool
 ) -> CriterionResult:
     """≥3 distinct surface_id with conflict_held_by_other in the window."""
+    organic_sql = _organic_audit_session_sql()
     cur.execute(
-        """
+        f"""
         SELECT count(DISTINCT surface_id) AS distinct_surfaces,
                count(*) AS total_conflicts,
                count(DISTINCT surface_id) FILTER (
-                 WHERE coalesce(payload->>'audit_session', '') NOT LIKE %s
+                 WHERE {organic_sql}
                ) AS organic_distinct_surfaces,
                count(*) FILTER (
-                 WHERE coalesce(payload->>'audit_session', '') NOT LIKE %s
+                 WHERE {organic_sql}
                ) AS organic_total_conflicts,
                count(DISTINCT surface_id) FILTER (
                  WHERE payload->>'audit_session' LIKE %s
@@ -235,8 +273,6 @@ def _criterion_3_type_a_signal(
           AND ts > now() - %s::interval
         """,
         (
-            f"{DRILL_AUDIT_SESSION_PREFIX}%",
-            f"{DRILL_AUDIT_SESSION_PREFIX}%",
             f"{DRILL_AUDIT_SESSION_PREFIX}%",
             f"{DRILL_AUDIT_SESSION_PREFIX}%",
             surface_kind,
@@ -341,8 +377,9 @@ def _criterion_4_incident_linkage(
             detail="knowledge.discoveries table not present; KG linkage cannot be evaluated",
         )
 
+    organic_sql = _organic_audit_session_sql()
     cur.execute(
-        """
+        f"""
         WITH conflicts AS (
           SELECT
             event_id,
@@ -354,7 +391,7 @@ def _criterion_4_incident_linkage(
             AND advisory_mode = true
             AND surface_kind = %s
             AND ts > now() - %s::interval
-            AND coalesce(payload->>'audit_session', '') NOT LIKE %s
+            AND {organic_sql}
         ), linked AS (
           SELECT DISTINCT
             c.event_id,
@@ -384,7 +421,6 @@ def _criterion_4_incident_linkage(
         (
             surface_kind,
             f"{window_days} days",
-            f"{DRILL_AUDIT_SESSION_PREFIX}%",
             COLLISION_SYMPTOM_RE,
         ),
     )

--- a/tests/test_lease_plane_phase_b_evaluator.py
+++ b/tests/test_lease_plane_phase_b_evaluator.py
@@ -371,6 +371,57 @@ def test_text_format_mentions_eligibility_date(evaluator, monkeypatch):
     assert "VERDICT: NOT PROMOTABLE" in text
 
 
+def test_organic_predicate_excludes_synthetic_and_empty(evaluator):
+    """§6.1.3/§6.1.4 organic predicate must exclude drill, synthetic harness/
+    probe sessions, and empty audit_session — and escape its LIKE wildcards as
+    ``%%`` so psycopg2 doesn't misread them as parameter placeholders.
+
+    Regression: the 2026-05-30 forensic found surface_kind='file' passing
+    §6.1.3 on 6 synthetic surfaces (race harness / live probe / empty-session
+    bring-up) because the filter only excluded the ``phase-b-drill:`` prefix.
+    """
+    sql = evaluator._organic_audit_session_sql()
+    # non-empty session required (empty is structurally unlinkable in §6.1.4)
+    assert "coalesce(payload->>'audit_session', '') <> ''" in sql
+    # drill + every synthetic prefix excluded
+    assert evaluator.DRILL_AUDIT_SESSION_PREFIX in sql
+    for prefix in evaluator.SYNTHETIC_SESSION_PREFIXES:
+        assert prefix in sql
+    assert evaluator.SYNTHETIC_SESSION_PREFIXES, "expected at least one synthetic prefix"
+    # every % must be part of %% — the fragment carries literal LIKE wildcards
+    # only, never a %s placeholder (those live in the outer query).
+    assert "%s" not in sql
+    assert sql.count("%") % 2 == 0
+    assert sql.replace("%%", "").count("%") == 0
+
+
+def test_criterion_3_query_is_percent_safe(evaluator):
+    """The criterion-3 query must mogrify cleanly: #placeholders == #params and
+    literal wildcards escaped. psycopg2 uses pyformat, so Python %-substitution
+    is a faithful proxy — a bare ``%`` in an inlined LIKE pattern would raise
+    here exactly as it raised IndexError in psycopg2 before the %% fix."""
+    cursor = FakeCursor(
+        [
+            {
+                "distinct_surfaces": 6,
+                "total_conflicts": 24,
+                "organic_distinct_surfaces": 0,
+                "organic_total_conflicts": 0,
+                "drill_distinct_surfaces": 0,
+                "drill_total_conflicts": 0,
+            }
+        ]
+    )
+    result = evaluator._criterion_3_type_a_signal(
+        cursor, "file", 14, accept_drill_evidence=False
+    )
+    assert result.status == "FAIL"  # 0 organic → correctly not promotable
+    sql, params = cursor.executed[0]
+    # Will raise ValueError/TypeError if a literal % is unescaped or the
+    # placeholder/param counts disagree — the precise regression we fixed.
+    sql % tuple("x" for _ in params)
+
+
 def test_main_exit_codes(evaluator, monkeypatch):
     """Exit code contract: 1 not-promotable, 3 unknown surface_kind."""
     # unknown surface_kind path — must not touch DB


### PR DESCRIPTION
## What

`evaluate_phase_b_promotion.py` §6.1.3 (Type-A conflict signal) only excluded the `phase-b-drill:` prefix from its "organic" count. Everything else — the HTTP race harness (`codex-http-race-*`), the live probe (`codex-live-probe-*`), and empty-`audit_session` bring-up conflicts — counted as organic distinct surfaces.

## Why it matters (2026-05-30 forensic, surface_kind=`file`)

All 6 surfaces that made `file` *pass* §6.1.3 were synthetic/test artifacts:

| surface | conflicts | audit_session | what |
|---|---|---|---|
| `.lease-race-9b4122bf1d8b.tmp` | 19 | `codex-http-race-*` | race harness |
| `.lease-probe-ae35f65c8e7c.tmp` | 1 | `codex-live-probe-*` | live probe |
| `…/unitares-lease-plane-smoke-runtime.txt` | 1 | (none) | smoke test |
| `elixir/wave3a_handlers` | 1 | (none) | bring-up |
| `scripts/dev/file_lease.py` | 1 | (none) | bring-up |
| `scripts/ops/com.unitares.wave3a-handlers.plist` | 1 | (none) | bring-up |

§6.1.4 (KG incident linkage) was the *only* criterion stopping a spurious `promotable` verdict on this traffic — and it only failed incidentally (synthetic conflicts produce no KG incident, and their `codex-*` session labels don't even share a namespace with KG `provenance.writer_session_id_at_write`, which is `agent-*`). That's an accidental backstop, not a designed gate.

## Change

- Factor a shared `_organic_audit_session_sql()` predicate, used by **both** §6.1.3 and §6.1.4: require non-empty `audit_session` (empty is structurally unlinkable in §6.1.4) and exclude drill + synthetic harness/probe prefixes (`SYNTHETIC_SESSION_PREFIXES`).
- Result: `file` §6.1.3 organic surfaces **6 → 0**, correctly FAIL.
- LIKE wildcards written `%%` — the fragment embeds in a query psycopg2 runs through %-substitution; a bare `%` is misread as a placeholder (`IndexError`).

## Tests

- `test_organic_predicate_excludes_synthetic_and_empty` — exclusion contract
- `test_criterion_3_query_is_percent_safe` — regression guard for the `%`/`%%` bug (pyformat proxy)

Focused file 13/13; adjacent lease-plane group 180 passed / 1 skipped. The unrelated `test_canonicalize_…macos` failure is a local `TMPDIR=/private/tmp` artifact (fails identically with this change stashed) — CI should not see it.

## Scope note

This makes the gate *correct*; it does not make any surface promotable. There is no organic collision corpus yet (consistent with the v7 corpus-maturity posture). Promotion still requires a real parallel-write collision recorded as a KG discovery — not synthetic drills.