### PR TITLE
Improve governance DX affordances

### DIFF
--- a/src/mcp_handlers/admin/calibration.py
+++ b/src/mcp_handlers/admin/calibration.py
@@ -17,6 +17,55 @@ from src.logging_utils import get_logger
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 logger = get_logger(__name__)
 
+
+def _build_calibration_guidance(
+    *,
+    calibration_status: str,
+    truth_channel: str,
+    total_samples: int,
+    issues: List[str],
+    correction_factors: Dict[str, float],
+    failure_modes: Dict[str, Any],
+    tactical_staleness_days: Optional[float],
+) -> Dict[str, Any]:
+    """Operator guidance derived from calibration, without changing decisions."""
+    actions: List[str] = []
+    confidence_policy = "use_reported_confidence"
+
+    if total_samples == 0:
+        confidence_policy = "no_auto_correction"
+        actions.append("Collect hard outcome evidence via recent_tool_results or outcome_event before interpreting calibration.")
+    elif calibration_status == "signal_stale":
+        confidence_policy = "do_not_use_stale_bins_for_correction"
+        actions.append("Refresh tactical evidence before applying calibration corrections.")
+    elif calibration_status == "miscalibrated":
+        confidence_policy = "require_evidence_for_high_confidence_actions"
+        actions.append("Treat high-confidence actions in miscalibrated bins as requiring external evidence.")
+        if correction_factors:
+            actions.append("Use correction_factors as advisory scaling when presenting calibrated confidence.")
+    else:
+        actions.append("Calibration is currently acceptable; continue recording objective outcomes.")
+
+    warning = None
+    if isinstance(failure_modes, dict):
+        warning = failure_modes.get("verdict_quality_warning")
+        if warning:
+            actions.append("Review failure_modes before trusting confidence-heavy verdicts.")
+
+    return {
+        "mode": "advisory_only",
+        "confidence_policy": confidence_policy,
+        "truth_channel": truth_channel,
+        "tactical_staleness_days": tactical_staleness_days,
+        "correction_factors": correction_factors,
+        "failure_modes": failure_modes,
+        "verdict_quality_warning": warning,
+        "actions": actions,
+        "issues": issues,
+        "note": "Guidance does not silently alter verdicts or reported confidence.",
+    }
+
+
 @mcp_tool("check_calibration", timeout=10.0, rate_limit_exempt=True, register=False)
 async def handle_check_calibration(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """
@@ -179,6 +228,39 @@ async def handle_check_calibration(arguments: Dict[str, Any]) -> Sequence[TextCo
         response['per_channel_calibration'] = metrics['per_channel_calibration']
     if 'per_channel_health' in metrics:
         response['per_channel_health'] = metrics['per_channel_health']
+
+    correction_factors: Dict[str, float] = {}
+    try:
+        compute_corrections = getattr(calibration_checker, "compute_correction_factors", None)
+        if callable(compute_corrections):
+            maybe_corrections = compute_corrections()
+            if isinstance(maybe_corrections, dict):
+                correction_factors = {
+                    str(bin_key): float(factor)
+                    for bin_key, factor in maybe_corrections.items()
+                }
+    except Exception as e_corr:
+        logger.debug(f"Calibration correction factors skipped: {e_corr}")
+
+    failure_modes: Dict[str, Any] = {}
+    try:
+        characterize = getattr(calibration_checker, "characterize_failure_modes", None)
+        if callable(characterize):
+            maybe_failure_modes = characterize()
+            if isinstance(maybe_failure_modes, dict):
+                failure_modes = maybe_failure_modes
+    except Exception as e_modes:
+        logger.debug(f"Calibration failure-mode characterization skipped: {e_modes}")
+
+    response["calibration_guidance"] = _build_calibration_guidance(
+        calibration_status=calibration_status,
+        truth_channel=truth_channel,
+        total_samples=total_samples,
+        issues=response["issues"],
+        correction_factors=correction_factors,
+        failure_modes=failure_modes,
+        tactical_staleness_days=tactical_staleness_days,
+    )
 
     # Add complexity calibration metrics if available
     if 'complexity_calibration' in metrics:

--- a/src/mcp_handlers/consolidated.py
+++ b/src/mcp_handlers/consolidated.py
@@ -67,6 +67,7 @@ from .observability.handlers import (
 from .dialectic.handlers import (
     handle_get_dialectic_session,
     handle_list_dialectic_sessions,
+    handle_quick_dialectic,
     handle_request_dialectic_review,
     handle_submit_thesis,
     handle_submit_antithesis,
@@ -235,6 +236,7 @@ handle_dialectic = action_router(
     actions={
         "get": handle_get_dialectic_session,
         "list": handle_list_dialectic_sessions,
+        "quick": handle_quick_dialectic,
         "request": handle_request_dialectic_review,
         "thesis": handle_submit_thesis,
         "antithesis": handle_submit_antithesis,
@@ -247,6 +249,7 @@ handle_dialectic = action_router(
     examples=[
         "dialectic(action='list')",
         "dialectic(action='get', session_id='abc123')",
+        "dialectic(action='quick', issue_description='Should I proceed?', position='Proceed after tests pass')",
         "dialectic(action='request', issue_description='Agent stuck in loop')",
         "dialectic(action='thesis', session_id='abc123', root_cause='...', proposed_conditions=[...])",
         "dialectic(action='vote', session_id='abc123', vote='resume', reasoning='...')",

--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -238,6 +238,105 @@ def _agent_display(agent_id: Optional[str]) -> str:
     return _agent_label(agent_id) or agent_id
 
 
+def _as_string_list(value: Any) -> List[str]:
+    """Normalize string/list-ish caller input into a clean list of strings."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value.strip()] if value.strip() else []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return [str(value).strip()] if str(value).strip() else []
+
+
+@mcp_tool("quick_dialectic", timeout=10.0, register=False)
+async def handle_quick_dialectic(arguments: Dict[str, Any]) -> Sequence[TextContent]:
+    """Lightweight decision triage without opening a full dialectic session.
+
+    Use this when an agent wants structured second-thoughts for a small
+    decision. It does not mutate dialectic session state. If risk markers are
+    present, it tells the caller to escalate to dialectic(action='request').
+    """
+    issue = str(arguments.get("issue_description") or arguments.get("reason") or "").strip()
+    if not issue:
+        return [error_response(
+            "issue_description is required for quick dialectic triage",
+            error_code="MISSING_PARAMETER",
+            error_category="validation_error",
+            recovery={
+                "action": "Pass issue_description='the decision or concern to triage'",
+                "related_tools": ["dialectic"],
+            },
+            arguments=arguments,
+        )]
+
+    position = str(
+        arguments.get("position")
+        or arguments.get("decision")
+        or arguments.get("root_cause")
+        or arguments.get("reasoning")
+        or ""
+    ).strip()
+    concerns = _as_string_list(arguments.get("concerns"))
+    proposed_conditions = _as_string_list(_read_proposed_conditions(arguments))
+    observed_metrics = arguments.get("observed_metrics") or {}
+    if not isinstance(observed_metrics, dict):
+        observed_metrics = {}
+
+    risk_flags: List[str] = []
+    issue_lower = issue.lower()
+    high_risk_terms = ("paused", "reject", "unsafe", "security", "data loss", "delete", "drop", "credential")
+    if any(term in issue_lower for term in high_risk_terms):
+        risk_flags.append("issue_contains_high_risk_terms")
+
+    if len(concerns) >= 3:
+        risk_flags.append("three_or_more_concerns")
+
+    try:
+        risk_score = float(observed_metrics.get("risk_score"))
+        if risk_score >= 0.7:
+            risk_flags.append("risk_score_at_or_above_0.70")
+    except (TypeError, ValueError):
+        pass
+
+    try:
+        coherence = float(observed_metrics.get("coherence"))
+        if coherence <= 0.4:
+            risk_flags.append("coherence_at_or_below_0.40")
+    except (TypeError, ValueError):
+        pass
+
+    if not position:
+        risk_flags.append("no_position_supplied")
+
+    if risk_flags:
+        recommendation = "escalate_full_dialectic"
+        next_steps = [
+            "Call dialectic(action='request', issue_description=...) to open a full review session.",
+            "Prepare root_cause and proposed_conditions before submitting thesis.",
+        ]
+    else:
+        recommendation = "record_decision"
+        next_steps = [
+            "Proceed with the stated position if it still matches current evidence.",
+            "Leave a knowledge note if this decision should be discoverable later.",
+        ]
+
+    return success_response({
+        "mode": "quick_dialectic",
+        "lightweight": True,
+        "full_session_created": False,
+        "issue_description": issue,
+        "position": position or None,
+        "concerns": concerns,
+        "proposed_conditions": proposed_conditions,
+        "risk_flags": risk_flags,
+        "recommendation": recommendation,
+        "next_steps": next_steps,
+        "escalation_tool": "dialectic(action='request')" if risk_flags else None,
+    }, arguments=arguments)
+
+
 def _build_dialectic_actionability(session_data: Dict[str, Any]) -> Dict[str, Any]:
     """Annotate a session payload with concrete next-action metadata."""
     paused_agent_id = session_data.get("paused_agent_id")

--- a/src/mcp_handlers/introspection/export.py
+++ b/src/mcp_handlers/introspection/export.py
@@ -42,14 +42,14 @@ async def handle_get_system_history(arguments: Dict[str, Any]) -> Sequence[TextC
 
     # Check if monitor has any history
     if not monitor.state.E_history and not monitor.state.timestamp_history:
-        return [error_response(
-            "No history available for this agent",
-            details={"agent_id": agent_id[:12] if agent_id else "unknown"},
-            recovery={
-                "action": "Agent needs to call process_agent_update() first to generate history",
-                "related_tools": ["process_agent_update", "get_governance_metrics"]
-            }
-        )]
+        return success_response({
+            "format": format_type,
+            "history": [],
+            "agent_id": agent_id,
+            "empty": True,
+            "message": "No history available yet for this agent",
+            "next_step": "Call process_agent_update() to generate history",
+        })
     
     history_data = monitor.export_history(format=format_type)
     

--- a/src/mcp_handlers/introspection/tool_introspection.py
+++ b/src/mcp_handlers/introspection/tool_introspection.py
@@ -97,6 +97,56 @@ def _resolve_json_schema_type(field_info: Dict[str, Any]) -> str:
             return "|".join(non_null)
     return "any"
 
+
+def _getting_started_path() -> List[Dict[str, Any]]:
+    """Canonical low-friction path for first-time governance callers."""
+    return [
+        {
+            "step": 1,
+            "tool": "onboard",
+            "call": "onboard(force_new=true)",
+            "why": "Mint a fresh process identity. If continuing prior work, include parent_agent_id and spawn_reason='new_session'.",
+        },
+        {
+            "step": 2,
+            "tool": "process_agent_update",
+            "call": "process_agent_update(response_text='what changed', complexity=0.5, confidence=0.7)",
+            "why": "Record meaningful work and receive a governance verdict.",
+        },
+        {
+            "step": 3,
+            "tool": "get_governance_metrics",
+            "call": "get_governance_metrics()",
+            "why": "Inspect current EISV state without mutating history.",
+        },
+        {
+            "step": 4,
+            "tool": "knowledge",
+            "call": "knowledge(action='search', query='topic') or knowledge(action='note', content='short note')",
+            "why": "Reuse shared memory before writing; leave lightweight notes when useful.",
+        },
+        {
+            "step": 5,
+            "tool": "list_tools",
+            "call": "list_tools(essential_only=true)",
+            "why": "Stay in the small core tool set until the workflow needs more surface area.",
+        },
+    ]
+
+
+def _essential_toolkit() -> Dict[str, Any]:
+    """Short orientation block for agents trying not to drown in the tool list."""
+    return {
+        "default_path": [item["tool"] for item in _getting_started_path()],
+        "small_surface": "Use list_tools(essential_only=true) or list_tools(lite=true) before exploring the full registry.",
+        "preferred_consolidated_tools": {
+            "knowledge": "Use action='search'|'note'|'store' instead of older KG-specific tools.",
+            "dialectic": "Use action='quick' for simple decision triage; use request/thesis/antithesis/synthesis for paused-state recovery.",
+            "calibration": "Use action='check' first; add ground truth with action='update' only when you have trusted external evidence.",
+            "export": "Use action='history' for in-memory export; action='file' writes a server-side file.",
+        },
+    }
+
 @mcp_tool("list_tools", timeout=10.0, rate_limit_exempt=True, requires_identity="pre_onboard")
 async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """List all available governance tools with descriptions and categories
@@ -786,7 +836,9 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
             },
             "more": "list_tools(lite=false) for all tools with full category details",
             "tip": "describe_tool(tool_name=...) for parameter details and examples",
-            "quick_start": "Start fresh with onboard(force_new=true); use parent_agent_id for lineage, not bare UUID resume"
+            "quick_start": "Start fresh with onboard(force_new=true); use parent_agent_id for lineage, not bare UUID resume",
+            "getting_started_path": _getting_started_path(),
+            "essential_toolkit": _essential_toolkit(),
         }
         
         # Add first-time hint for new agents
@@ -958,6 +1010,8 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
             "dialectic": "💭 View archived dialectic sessions"
         },
         "getting_started": {
+            "path": _getting_started_path(),
+            "essential_toolkit": _essential_toolkit(),
             "for_new_agents": [
                 {
                     "category": "identity",
@@ -1124,6 +1178,25 @@ async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextConten
                         "by_tag": "knowledge(action=\"search\", tags=[\"bug\"], limit=10)",
                         "by_type": "knowledge(action=\"search\", discovery_type=\"insight\", limit=5)",
                         "full_text": "knowledge(action=\"search\", query=\"authentication\", limit=10)"
+                    },
+                    "knowledge": {
+                        "quick_note": "knowledge(action=\"note\", content=\"Short shared note\", tags=[\"topic\"])",
+                        "store_discovery": "knowledge(action=\"store\", summary=\"Found issue\", discovery_type=\"bug_found\", severity=\"medium\")",
+                        "search": "knowledge(action=\"search\", query=\"authentication\", limit=10)"
+                    },
+                    "dialectic": {
+                        "quick_decision": "dialectic(action=\"quick\", issue_description=\"...\", position=\"...\", concerns=[...])",
+                        "request_recovery": "dialectic(action=\"request\", issue_description=\"Agent is paused because ...\")",
+                        "submit_thesis": "dialectic(action=\"thesis\", session_id=\"...\", root_cause=\"...\", proposed_conditions=[...])"
+                    },
+                    "calibration": {
+                        "check": "calibration(action=\"check\")",
+                        "update_truth": "calibration(action=\"update\", confidence=0.8, actual_correct=true)",
+                        "rebuild_preview": "calibration(action=\"rebuild\", dry_run=true)"
+                    },
+                    "export": {
+                        "history": "export(action=\"history\", format=\"json\")",
+                        "file": "export(action=\"file\", format=\"json\", filename=\"agent_history\")"
                     },
                     "get_governance_metrics": {
                         "check_state": "get_governance_metrics()  # uses bound identity",

--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -47,6 +47,67 @@ logger = get_logger(__name__)
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 from src.broadcaster import broadcaster_instance
 
+VALID_DISCOVERY_TYPES = {
+    "architectural_decision", "learning", "pattern", "bug_fix",
+    "refactoring", "documentation", "experiment", "question", "note", "rule",
+    "insight", "bug_found", "improvement", "exploration", "observation",
+}
+VALID_SEVERITIES = {"low", "medium", "high", "critical"}
+SEVERITY_ALIASES = {
+    "info": "low",
+    "informational": "low",
+    "warn": "medium",
+    "warning": "medium",
+    "error": "high",
+    "fatal": "critical",
+    "urgent": "critical",
+}
+
+
+def _normalize_discovery_type(discovery_type: Any) -> Any:
+    if isinstance(discovery_type, str):
+        normalized = discovery_type.strip().lower()
+        if normalized == "bug":
+            return "bug_found"
+        return normalized
+    return discovery_type
+
+
+def _invalid_enum_response(field: str, value: Any, valid_values: set[str], *, tip: str | None = None):
+    normalized = str(value).strip().lower()
+    suggestion = None
+    if field == "severity":
+        suggestion = SEVERITY_ALIASES.get(normalized)
+    elif field == "discovery_type" and normalized == "bug":
+        suggestion = "bug_found"
+
+    valid = sorted(valid_values)
+    message = f"Invalid {field} '{normalized}'. Valid: {valid}."
+    if suggestion in valid_values:
+        message += f" Did you mean '{suggestion}'?"
+    elif tip:
+        message += f" {tip}"
+
+    return error_response(
+        message,
+        error_code="PARAMETER_ERROR",
+        error_category="validation_error",
+        details={
+            "error_type": "invalid_enum_value",
+            "parameter": field,
+            "provided_value": normalized,
+            "valid_values": valid,
+            "suggested_value": suggestion if suggestion in valid_values else None,
+        },
+        recovery={
+            "action": (
+                f"Use {field}='{suggestion}'"
+                if suggestion in valid_values
+                else f"Use one of: {', '.join(valid)}"
+            )
+        },
+    )
+
 
 async def _clamp_confidence_to_coherence(discovery, agent_id: str) -> bool:
     """Cross-check discovery confidence against agent's EISV coherence.
@@ -490,18 +551,15 @@ async def handle_store_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[Te
     # Single discovery mode (original behavior)
     # LITE-FIRST: discovery_type defaults to "note" (simplest form)
     discovery_type = arguments.get("discovery_type", "note")
-    if isinstance(discovery_type, str):
-        discovery_type = discovery_type.strip().lower()
-        # UX alias: many callers naturally use "bug"
-        if discovery_type == "bug":
-            discovery_type = "bug_found"
+    discovery_type = _normalize_discovery_type(discovery_type)
     
     # Validate discovery_type enum
-    VALID_DISCOVERY_TYPES = {"architectural_decision", "learning", "pattern", "bug_fix", "refactoring", "documentation", "experiment", "question", "note", "rule", "insight", "bug_found", "improvement", "exploration", "observation"}
     if discovery_type not in VALID_DISCOVERY_TYPES:
-        return error_response(
-            f"Invalid discovery_type '{discovery_type}'. Valid types: {sorted(VALID_DISCOVERY_TYPES)}. "
-            "Tip: use 'bug_found' (or shorthand 'bug')."
+        return _invalid_enum_response(
+            "discovery_type",
+            discovery_type,
+            VALID_DISCOVERY_TYPES,
+            tip="Tip: use 'bug_found' (or shorthand 'bug').",
         )
 
     summary, error = require_argument(arguments, "summary",
@@ -583,10 +641,9 @@ async def handle_store_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[Te
         # Validate severity if provided
         severity = arguments.get("severity")
         if severity is not None:
-            VALID_SEVERITIES = {"low", "medium", "high", "critical"}
             severity = str(severity).lower()
             if severity not in VALID_SEVERITIES:
-                return error_response(f"Invalid severity '{severity}'. Valid: {sorted(VALID_SEVERITIES)}")
+                return _invalid_enum_response("severity", severity, VALID_SEVERITIES)
 
         # Auto-populate system_version at write time (Task 1: KG version coupling)
         system_version = getattr(mcp_server, "SERVER_VERSION", "unknown")
@@ -1886,21 +1943,15 @@ async def handle_update_discovery_status_graph(arguments: Dict[str, Any]) -> Seq
             updates["details"] = str(raw_details)
 
         if severity is not None:
-            VALID_SEVERITIES = {"low", "medium", "high", "critical"}
             severity = str(severity).lower()
             if severity not in VALID_SEVERITIES:
-                return [error_response(f"Invalid severity '{severity}'. Valid: {sorted(VALID_SEVERITIES)}")]
+                return [_invalid_enum_response("severity", severity, VALID_SEVERITIES)]
             updates["severity"] = severity
 
         if discovery_type is not None:
-            VALID_DISCOVERY_TYPES = {"architectural_decision", "learning", "pattern", "bug_fix", "refactoring", "documentation", "experiment", "question", "note", "rule", "insight", "bug_found", "improvement", "exploration", "observation"}
-            discovery_type = str(discovery_type).strip().lower()
-            if discovery_type == "bug":
-                discovery_type = "bug_found"
+            discovery_type = _normalize_discovery_type(discovery_type)
             if discovery_type not in VALID_DISCOVERY_TYPES:
-                return [error_response(
-                    f"Invalid discovery_type '{discovery_type}'. Valid types: {sorted(VALID_DISCOVERY_TYPES)}."
-                )]
+                return [_invalid_enum_response("discovery_type", discovery_type, VALID_DISCOVERY_TYPES)]
             updates["type"] = discovery_type
 
         if tags is not None:
@@ -2070,17 +2121,12 @@ async def _handle_store_knowledge_graph_batch(arguments: Dict[str, Any], agent_i
                     errors.append(f"Discovery {idx}: must be a dict")
                     continue
                 
-                discovery_type = disc_data.get("discovery_type")
-                if isinstance(discovery_type, str):
-                    discovery_type = discovery_type.strip().lower()
-                    if discovery_type == "bug":
-                        discovery_type = "bug_found"
+                discovery_type = _normalize_discovery_type(disc_data.get("discovery_type"))
                 if not discovery_type:
                     errors.append(f"Discovery {idx}: discovery_type is required")
                     continue
                 
-                VALID_TYPES = {"architectural_decision", "learning", "pattern", "bug_fix", "refactoring", "documentation", "experiment", "question", "note", "rule", "insight", "bug_found", "improvement", "exploration", "observation"}
-                if discovery_type not in VALID_TYPES:
+                if discovery_type not in VALID_DISCOVERY_TYPES:
                     errors.append(f"Discovery {idx}: invalid discovery_type '{discovery_type}'")
                     continue
                 
@@ -2136,7 +2182,6 @@ async def _handle_store_knowledge_graph_batch(arguments: Dict[str, Any], agent_i
                 # Validate severity
                 severity = disc_data.get("severity")
                 if severity is not None:
-                    VALID_SEVERITIES = {"low", "medium", "high", "critical"}
                     if severity not in VALID_SEVERITIES:
                         severity = "medium"  # Use default if invalid
                 

--- a/src/mcp_handlers/middleware/params_step.py
+++ b/src/mcp_handlers/middleware/params_step.py
@@ -1,6 +1,8 @@
 """Steps 3-6: Parameter handling (unwrap kwargs, resolve alias, inject identity, validate)."""
 
 import json
+import re
+from difflib import get_close_matches
 from typing import Any, Dict
 
 from src.logging_utils import get_logger
@@ -216,7 +218,64 @@ def _format_pydantic_error(error, tool_name: str):
 
     # Map common Pydantic error types to our error taxonomy
     if err_type == "missing":
+        missing_fields = [
+            ".".join(str(part) for part in err.get("loc", []))
+            for err in errors
+            if err.get("type") == "missing"
+        ]
+        if len(missing_fields) > 1:
+            return error_response(
+                f"Missing required parameters for '{tool_name}': {', '.join(missing_fields)}",
+                error_code="MISSING_PARAMETER",
+                error_category="validation_error",
+                details={
+                    "error_type": "missing_parameter",
+                    "tool_name": tool_name,
+                    "missing_parameters": missing_fields,
+                },
+                recovery={
+                    "action": f"Add all missing parameters: {', '.join(missing_fields)}",
+                    "related_tools": ["describe_tool"],
+                    "workflow": [
+                        f"1. Use describe_tool(tool_name='{tool_name}') for the full schema",
+                        "2. Add the missing parameters listed above",
+                        "3. Retry the tool call",
+                    ],
+                },
+            )
         return missing_parameter_error(loc, tool_name=tool_name)[0]
+
+    if err_type == "literal_error":
+        valid_values = _literal_expected_values(first)
+        provided = first.get("input")
+        suggestion = _suggest_enum_value(loc, provided, valid_values)
+        message = f"Invalid value for '{loc}': {provided!r}. Valid values: {', '.join(valid_values)}"
+        recovery_action = f"Use one of: {', '.join(valid_values)}"
+        if suggestion:
+            message += f". Did you mean '{suggestion}'?"
+            recovery_action = f"Use {loc}='{suggestion}' or another valid value"
+        return error_response(
+            message,
+            error_code="PARAMETER_ERROR",
+            error_category="validation_error",
+            details={
+                "error_type": "invalid_enum_value",
+                "tool_name": tool_name,
+                "parameter": loc,
+                "provided_value": provided,
+                "valid_values": valid_values,
+                "suggested_value": suggestion,
+            },
+            recovery={
+                "action": recovery_action,
+                "related_tools": ["describe_tool"],
+                "workflow": [
+                    f"1. Use describe_tool(tool_name='{tool_name}') for allowed values",
+                    f"2. Set {loc} to a valid value",
+                    "3. Retry the tool call",
+                ],
+            },
+        )
 
     if err_type in ("int_parsing", "float_parsing", "bool_parsing"):
         expected = err_type.replace("_parsing", "")
@@ -248,3 +307,43 @@ def _format_pydantic_error(error, tool_name: str):
             ]
         }
     )
+
+
+def _literal_expected_values(error: Dict[str, Any]) -> list[str]:
+    """Extract Literal choices from Pydantic's human-readable ctx."""
+    expected = (error.get("ctx") or {}).get("expected", "")
+    values = re.findall(r"'([^']+)'", expected)
+    return values or [expected] if expected else []
+
+
+def _suggest_enum_value(parameter: str, provided: Any, valid_values: list[str]) -> str | None:
+    """Suggest a likely enum value for common caller vocabulary."""
+    if provided is None or not valid_values:
+        return None
+
+    raw = str(provided).strip()
+    lowered = raw.lower()
+    aliases = {
+        "severity": {
+            "info": "low",
+            "informational": "low",
+            "warn": "medium",
+            "warning": "medium",
+            "error": "high",
+            "fatal": "critical",
+            "urgent": "critical",
+        },
+        "discovery_type": {
+            "bug": "bug_found",
+            "issue": "bug_found",
+            "finding": "insight",
+            "idea": "insight",
+            "obs": "observation",
+        },
+    }
+    alias = aliases.get(parameter, {}).get(lowered)
+    if alias in valid_values:
+        return alias
+
+    matches = get_close_matches(lowered, valid_values, n=1, cutoff=0.58)
+    return matches[0] if matches else None

--- a/src/mcp_handlers/schemas/dialectic.py
+++ b/src/mcp_handlers/schemas/dialectic.py
@@ -118,7 +118,7 @@ class LlmAssistedDialecticParams(AgentIdentityMixin):
 
 class DialecticParams(AgentIdentityMixin):
     """Parameters for dialectic"""
-    action: Literal["get", "list", "request", "thesis", "antithesis", "synthesis", "reassign"] = Field(..., description="Operation: get, list, request, thesis, antithesis, synthesis, reassign")
+    action: Literal["get", "list", "quick", "request", "thesis", "antithesis", "synthesis", "reassign"] = Field(..., description="Operation: get, list, quick, request, thesis, antithesis, synthesis, reassign")
     session_id: Optional[str] = Field(None, description="Dialectic session ID")
     agent_id: Optional[str] = Field(None, description="Filter by agent (for action=get or list)")
     status: Optional[str] = Field(None, description="Filter by phase (for action=list)")
@@ -127,6 +127,8 @@ class DialecticParams(AgentIdentityMixin):
     check_timeout: Optional[bool] = Field(None, description="Check reviewer/session timeouts for action=get")
     # Write action fields
     issue_description: Optional[str] = Field(None, description="Issue description (for action=request)")
+    position: Optional[str] = Field(None, description="Current position or proposed decision (for action=quick)")
+    decision: Optional[Literal["proceed", "defer", "escalate", "block", "unknown"]] = Field(None, description="Decision label (for action=quick)")
     root_cause: Optional[str] = Field(None, description="Root cause analysis (for action=thesis/synthesis)")
     proposed_conditions: Optional[List[str]] = Field(None, description="Conditions for resumption (for action=thesis/synthesis)")
     reasoning: Optional[str] = Field(None, description="Explanation/reasoning")

--- a/src/mcp_handlers/schemas/knowledge.py
+++ b/src/mcp_handlers/schemas/knowledge.py
@@ -2,14 +2,19 @@ from typing import Optional, Union, Literal, Dict, Any, List, Sequence
 from pydantic import Field, model_validator
 from .mixins import AgentIdentityMixin
 
+DiscoveryType = Literal[
+    "architectural_decision", "learning", "pattern", "bug_fix",
+    "refactoring", "documentation", "experiment", "question", "note", "rule",
+    "insight", "bug_found", "bug", "improvement", "exploration", "observation"
+]
+
+Severity = Literal["low", "medium", "high", "critical"]
+
 class StoreKnowledgeGraphParams(AgentIdentityMixin):
     """
     Store knowledge discovery/discoveries in graph
     """
-    discovery_type: Optional[Literal[
-        "architectural_decision", "learning", "pattern", "bug_fix", 
-        "refactoring", "documentation", "experiment", "question", "note", "rule"
-    ]] = Field(
+    discovery_type: Optional[DiscoveryType] = Field(
         default=None,
         description="Type of discovery"
     )
@@ -29,7 +34,7 @@ class StoreKnowledgeGraphParams(AgentIdentityMixin):
         default_factory=list,
         description="IDs of related discoveries"
     )
-    severity: Optional[Literal["low", "medium", "high", "critical"]] = Field(
+    severity: Optional[Severity] = Field(
         default="medium",
         description="Importance/impact"
     )

--- a/src/mcp_handlers/support/model_inference.py
+++ b/src/mcp_handlers/support/model_inference.py
@@ -291,12 +291,22 @@ async def handle_call_model(arguments: Dict[str, Any]) -> Sequence[TextContent]:
         elif "rate limit" in error_msg.lower():
             error_code = "RATE_LIMIT_EXCEEDED"
             recovery_hint = "Wait a moment and retry, or use a different model"
+        elif (
+            ("localhost" in base_url or "127.0.0.1" in base_url)
+            and any(marker in error_msg.lower() for marker in ("connection refused", "connection error", "failed to establish", "connect"))
+        ):
+            error_code = "MODEL_PROVIDER_UNAVAILABLE"
+            recovery_hint = (
+                "Ollama is not reachable. Start Ollama, or explicitly opt into fallback "
+                "routing with privacy='auto' or privacy='cloud' and provider='hf'."
+            )
         elif "not found" in error_msg.lower() or "invalid" in error_msg.lower():
             error_code = "MODEL_NOT_AVAILABLE"
             if "localhost" in base_url or "127.0.0.1" in base_url:
                 recovery_hint = (
                     f"Model '{model}' is not pulled on this host. "
-                    "Run `ollama list` to see available models, or `ollama pull {model}` to fetch it."
+                    f"Run `ollama list` to see available models, `ollama pull {model}` to fetch it, "
+                    "or call with privacy='auto' to allow configured cloud fallback."
                 )
             else:
                 recovery_hint = (
@@ -322,10 +332,10 @@ async def handle_call_model(arguments: Dict[str, Any]) -> Sequence[TextContent]:
                 "workflow": [
                     "1. Check provider configuration",
                     "2. Verify model is available (`ollama list` for local)",
-                    "3. Try a different model",
-                    "4. Check server logs for details"
+                    "3. For local failures, start Ollama or pull the requested model",
+                    "4. To allow fallback, retry with privacy='auto' or privacy='cloud' and provider='hf'",
+                    "5. Check server logs for details"
                 ]
             }
         )]
-
 

--- a/tests/test_admin_handlers.py
+++ b/tests/test_admin_handlers.py
@@ -1151,6 +1151,11 @@ class TestCheckCalibration:
             }
         )
         mock_checker.get_pending_updates.return_value = 2
+        mock_checker.compute_correction_factors.return_value = {"0.8-0.9": 0.75}
+        mock_checker.characterize_failure_modes.return_value = {
+            "verdict_quality_warning": "High confidence bin is overconfident",
+            "tactical": {"status": "analyzed"},
+        }
         mock_seq_tracker = MagicMock()
         mock_seq_tracker.compute_metrics.return_value = {
             "status": "no_data",
@@ -1170,6 +1175,12 @@ class TestCheckCalibration:
             assert data["tactical_evidence"]["status"] == "no_data"
             assert "log_evidence" not in data["tactical_evidence"]
             assert "capped_alarm" not in data["tactical_evidence"]
+            guidance = data["calibration_guidance"]
+            assert guidance["mode"] == "advisory_only"
+            assert guidance["confidence_policy"] == "require_evidence_for_high_confidence_actions"
+            assert guidance["correction_factors"] == {"0.8-0.9": 0.75}
+            assert guidance["verdict_quality_warning"] == "High confidence bin is overconfident"
+            assert "silently alter" in guidance["note"]
 
     @pytest.mark.asyncio
     async def test_check_calibration_empty_bins(self, patch_context_agent_id):
@@ -1794,6 +1805,8 @@ class TestListTools:
             assert data["success"] is True
             assert "tools" in data
             assert data["shown"] > 0
+            assert data["getting_started_path"][0]["tool"] == "onboard"
+            assert data["essential_toolkit"]["preferred_consolidated_tools"]["dialectic"].startswith("Use action='quick'")
 
     @pytest.mark.asyncio
     async def test_list_tools_full_mode(self, mock_mcp_server, patch_context_agent_id):
@@ -1837,6 +1850,8 @@ class TestListTools:
             assert "categories" in data
             assert "workflows" in data
             assert "tool_map" in data
+            assert data["getting_started"]["path"][0]["tool"] == "onboard"
+            assert "knowledge" in data["getting_started"]["essential_toolkit"]["preferred_consolidated_tools"]
             assert data["total_tools"] >= 0
 
     @pytest.mark.asyncio

--- a/tests/test_consolidated_handlers.py
+++ b/tests/test_consolidated_handlers.py
@@ -656,6 +656,41 @@ class TestDialecticHandler:
             assert data["session"]["id"] == "abc123"
             mock_get.assert_awaited_once()
 
+    @pytest.mark.asyncio
+    async def test_quick_action_triages_without_session(self):
+        from src.mcp_handlers.consolidated import handle_dialectic
+
+        result = await handle_dialectic({
+            "action": "quick",
+            "issue_description": "Should I merge this small refactor?",
+            "position": "Proceed after focused tests pass",
+            "concerns": ["limited blast radius"],
+            "proposed_conditions": ["focused tests pass"],
+        })
+
+        data = _parse_response(result)
+        assert data["success"] is True
+        assert data["mode"] == "quick_dialectic"
+        assert data["full_session_created"] is False
+        assert data["recommendation"] == "record_decision"
+
+    @pytest.mark.asyncio
+    async def test_quick_action_escalates_high_risk(self):
+        from src.mcp_handlers.consolidated import handle_dialectic
+
+        result = await handle_dialectic({
+            "action": "quick",
+            "issue_description": "Paused agent wants to delete credential state",
+            "position": "Proceed",
+            "observed_metrics": {"risk_score": 0.8},
+        })
+
+        data = _parse_response(result)
+        assert data["success"] is True
+        assert data["recommendation"] == "escalate_full_dialectic"
+        assert data["escalation_tool"] == "dialectic(action='request')"
+        assert "issue_contains_high_risk_terms" in data["risk_flags"]
+
 
 # ===========================================================================
 # 4. Parameter mapping on real consolidated handlers

--- a/tests/test_core_metrics.py
+++ b/tests/test_core_metrics.py
@@ -731,8 +731,8 @@ class TestGetSystemHistory:
             assert data["agent_id"] == "agent-1"
 
     @pytest.mark.asyncio
-    async def test_no_history_returns_error(self, mock_server):
-        """Agent with no history returns informative error."""
+    async def test_no_history_returns_empty_success(self, mock_server):
+        """Agent with no history returns an empty export instead of an error."""
         empty_monitor = _make_monitor(E_history=[], timestamp_history=[])
         mock_server.get_or_create_monitor.return_value = empty_monitor
 
@@ -744,7 +744,10 @@ class TestGetSystemHistory:
             result = await handle_get_system_history({})
 
             data = _parse(result)
-            assert "error" in data or "No history" in json.dumps(data)
+            assert data["success"] is True
+            assert data["empty"] is True
+            assert data["history"] == []
+            assert data["agent_id"] == "agent-1"
 
     @pytest.mark.asyncio
     async def test_requires_agent_registration(self, mock_server):
@@ -1523,4 +1526,3 @@ class TestVerbosityTiers:
 # ============================================================================
 # EXTENDED COVERAGE: process_agent_update deeper paths
 # ============================================================================
-

--- a/tests/test_pydantic_schemas.py
+++ b/tests/test_pydantic_schemas.py
@@ -171,6 +171,38 @@ class TestPydanticSchemas:
         missing = dispatcher_actions - schema_actions
         assert not missing, f"Schema missing dispatcher actions: {missing}"
 
+    def test_dialectic_schema_accepts_quick_action(self):
+        """Lightweight dialectic action must be accepted by public schema."""
+        from src.mcp_handlers.schemas.dialectic import DialecticParams
+
+        model = DialecticParams(
+            action="quick",
+            issue_description="Should I proceed?",
+            position="Proceed after tests pass",
+            decision="proceed",
+            concerns=["low blast radius"],
+        )
+
+        assert model.action == "quick"
+        assert model.position == "Proceed after tests pass"
+
+    def test_store_knowledge_schema_matches_handler_discovery_types(self):
+        """Public schema must not reject discovery types the handler accepts."""
+        import typing
+        from src.mcp_handlers.schemas.knowledge import StoreKnowledgeGraphParams
+
+        schema_types = set(typing.get_args(StoreKnowledgeGraphParams.model_fields["discovery_type"].annotation.__args__[0]))
+        handler_types = {
+            "architectural_decision", "learning", "pattern", "bug_fix",
+            "refactoring", "documentation", "experiment", "question", "note", "rule",
+            "insight", "bug_found", "bug", "improvement", "exploration", "observation",
+        }
+
+        missing = handler_types - schema_types
+        assert not missing, f"Store schema missing handler discovery types: {missing}"
+        assert StoreKnowledgeGraphParams(summary="found auth issue", discovery_type="bug_found").discovery_type == "bug_found"
+        assert StoreKnowledgeGraphParams(summary="shorthand", discovery_type="bug").discovery_type == "bug"
+
 
 class TestVerificationSource:
     def test_default_is_agent_reported_tool_result(self):

--- a/tests/test_remaining_modules.py
+++ b/tests/test_remaining_modules.py
@@ -1480,6 +1480,46 @@ class TestValidateParams:
             assert isinstance(result, list)  # Error response
 
     @pytest.mark.asyncio
+    async def test_enum_validation_error_suggests_common_alias(self):
+        """Literal enum failures include valid values and an actionable suggestion."""
+        from pydantic import BaseModel
+        from typing import Literal
+
+        class SeverityModel(BaseModel):
+            severity: Literal["low", "medium", "high", "critical"]
+
+        ctx = DispatchContext()
+        with patch("src.tool_schemas.get_pydantic_schemas", return_value={"severity_tool": SeverityModel}):
+            result = await validate_params("severity_tool", {"severity": "info"}, ctx)
+
+        assert isinstance(result, list)
+        data = json.loads(result[0].text)
+        assert data["success"] is False
+        assert data["parameter"] == "severity"
+        assert data["suggested_value"] == "low"
+        assert data["valid_values"] == ["low", "medium", "high", "critical"]
+        assert "Did you mean 'low'" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_multiple_missing_params_returned_together(self):
+        """Agents get all missing required fields in one validation response."""
+        from pydantic import BaseModel
+
+        class ThesisModel(BaseModel):
+            root_cause: str
+            proposed_conditions: list[str]
+
+        ctx = DispatchContext()
+        with patch("src.tool_schemas.get_pydantic_schemas", return_value={"thesis_tool": ThesisModel}):
+            result = await validate_params("thesis_tool", {}, ctx)
+
+        assert isinstance(result, list)
+        data = json.loads(result[0].text)
+        assert data["success"] is False
+        assert data["missing_parameters"] == ["root_cause", "proposed_conditions"]
+        assert "root_cause, proposed_conditions" in data["error"]
+
+    @pytest.mark.asyncio
     async def test_passthrough_with_no_schema(self):
         """Without schema, params pass through with aliases applied."""
         ctx = DispatchContext()


### PR DESCRIPTION
## Summary
- improve Pydantic and handler validation messages for required fields and enum-like inputs
- add getting-started/tool-introspection guidance plus a lightweight dialectic quick action
- make empty history export successful and surface advisory calibration/model fallback guidance

## Validation
- ./scripts/dev/test-cache.sh: 9051 passed, 25 skipped, 2 warnings
- pre-push smoke: 138 passed, 8377 deselected
