### PR TITLE
Fix AGE DB factory binding and quick dialectic risk scan

### DIFF
--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -284,10 +284,13 @@ async def handle_quick_dialectic(arguments: Dict[str, Any]) -> Sequence[TextCont
         observed_metrics = {}
 
     risk_flags: List[str] = []
-    issue_lower = issue.lower()
     high_risk_terms = ("paused", "reject", "unsafe", "security", "data loss", "delete", "drop", "credential")
+    issue_lower = issue.lower()
+    decision_context_lower = "\n".join([position, *concerns, *proposed_conditions]).lower()
     if any(term in issue_lower for term in high_risk_terms):
         risk_flags.append("issue_contains_high_risk_terms")
+    if any(term in decision_context_lower for term in high_risk_terms):
+        risk_flags.append("decision_context_contains_high_risk_terms")
 
     if len(concerns) >= 3:
         risk_flags.append("three_or_more_concerns")

--- a/src/storage/knowledge_graph_age.py
+++ b/src/storage/knowledge_graph_age.py
@@ -9,15 +9,13 @@ from __future__ import annotations
 
 import asyncio
 import json
-import uuid
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Set
-from pathlib import Path
 
 from src.logging_utils import get_logger
 from src.knowledge_graph import DiscoveryNode, ResponseTo
 from src.mcp_handlers.knowledge.limits import EMBED_DETAILS_WINDOW
-from src.db import get_db
+import src.db as db_module
 from src.db.age_queries import (
     create_discovery_node,
     create_agent_node,
@@ -26,9 +24,6 @@ from src.db.age_queries import (
     create_related_to_edge,
     create_tagged_edge,
     create_supersedes_edge,
-    query_agent_discoveries,
-    query_response_chain,
-    create_indexes,
 )
 
 logger = get_logger(__name__)
@@ -316,7 +311,7 @@ class KnowledgeGraphAGE:
     async def _get_db(self):
         """Get database backend (lazy initialization)."""
         if self._db is None:
-            self._db = get_db()
+            self._db = db_module.get_db()
             await self._db.init()
 
             # Best-effort: align our graph_name with backend config
@@ -1416,10 +1411,10 @@ class KnowledgeGraphAGE:
         # so we fetch all matches and rank by tag overlap in Python.
         db = await self._get_db()
 
-        cypher = f"""
+        cypher = """
             MATCH (d:Discovery)-[:TAGGED]->(t:Tag)
-            WHERE t.name IN ${{tags}}
-              AND d.id <> ${{exclude_id}}
+            WHERE t.name IN ${tags}
+              AND d.id <> ${exclude_id}
             WITH DISTINCT d
             RETURN d
         """

--- a/tests/test_consolidated_handlers.py
+++ b/tests/test_consolidated_handlers.py
@@ -691,6 +691,22 @@ class TestDialecticHandler:
         assert data["escalation_tool"] == "dialectic(action='request')"
         assert "issue_contains_high_risk_terms" in data["risk_flags"]
 
+    @pytest.mark.asyncio
+    async def test_quick_action_escalates_high_risk_in_position_or_concerns(self):
+        from src.mcp_handlers.consolidated import handle_dialectic
+
+        result = await handle_dialectic({
+            "action": "quick",
+            "issue_description": "Should I proceed?",
+            "position": "Delete credential state after the run",
+            "concerns": ["Possible data loss if the cache is wrong"],
+        })
+
+        data = _parse_response(result)
+        assert data["success"] is True
+        assert data["recommendation"] == "escalate_full_dialectic"
+        assert "decision_context_contains_high_risk_terms" in data["risk_flags"]
+
 
 # ===========================================================================
 # 4. Parameter mapping on real consolidated handlers

--- a/tests/test_knowledge_graph_age.py
+++ b/tests/test_knowledge_graph_age.py
@@ -148,7 +148,7 @@ class TestGetDb:
     async def test_lazy_init_calls_get_db_once(self):
         """_get_db should call get_db() and init() on first call only."""
         mock_db = make_mock_db()
-        with patch("src.storage.knowledge_graph_age.get_db", return_value=mock_db) as mock_get:
+        with patch("src.db.get_db", return_value=mock_db) as mock_get:
             kg = KnowledgeGraphAGE()
             # Prevent index creation from triggering recursive _get_db
             kg._indexes_created = True
@@ -162,7 +162,7 @@ class TestGetDb:
     async def test_subsequent_calls_return_cached_db(self):
         """_get_db should return cached instance on subsequent calls."""
         mock_db = make_mock_db()
-        with patch("src.storage.knowledge_graph_age.get_db", return_value=mock_db) as mock_get:
+        with patch("src.db.get_db", return_value=mock_db) as mock_get:
             kg = KnowledgeGraphAGE()
             kg._indexes_created = True
 
@@ -176,7 +176,7 @@ class TestGetDb:
         """_get_db should align graph_name from the backend if available."""
         mock_db = make_mock_db()
         mock_db._age_graph = "custom_graph"
-        with patch("src.storage.knowledge_graph_age.get_db", return_value=mock_db):
+        with patch("src.db.get_db", return_value=mock_db):
             kg = KnowledgeGraphAGE()
             kg._indexes_created = True
 
@@ -194,7 +194,7 @@ class TestGetDb:
         mock_pg._age_graph = "dual_graph"
         mock_db._postgres = mock_pg
 
-        with patch("src.storage.knowledge_graph_age.get_db", return_value=mock_db):
+        with patch("src.db.get_db", return_value=mock_db):
             kg = KnowledgeGraphAGE()
             kg._indexes_created = True
 
@@ -205,7 +205,7 @@ class TestGetDb:
     async def test_creates_indexes_on_first_use(self):
         """_get_db should trigger index creation on first call."""
         mock_db = make_mock_db(graph_available=False)
-        with patch("src.storage.knowledge_graph_age.get_db", return_value=mock_db):
+        with patch("src.db.get_db", return_value=mock_db):
             kg = KnowledgeGraphAGE()
             # _indexes_created is False by default
 

--- a/tests/test_knowledge_graph_backend_binding.py
+++ b/tests/test_knowledge_graph_backend_binding.py
@@ -1,0 +1,28 @@
+"""Regression tests for knowledge graph backend factory binding."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_age_backend_resolves_db_factory_at_call_time(monkeypatch):
+    """AGE backend must not keep a stale import-time get_db binding."""
+    import src.db as db_module
+    import src.storage.knowledge_graph_age as age_module
+
+    stale_db = MagicMock(name="stale_db")
+    stale_db.init = AsyncMock()
+    stale_db.graph_available = AsyncMock(return_value=False)
+
+    current_db = MagicMock(name="current_db")
+    current_db.init = AsyncMock()
+    current_db.graph_available = AsyncMock(return_value=False)
+
+    monkeypatch.setattr(age_module, "get_db", lambda: stale_db, raising=False)
+    monkeypatch.setattr(db_module, "get_db", lambda: current_db)
+
+    kg = age_module.KnowledgeGraphAGE()
+    db = await kg._get_db()
+
+    assert db is current_db


### PR DESCRIPTION
## Summary
- resolve the AGE knowledge graph DB factory through src.db at call time so patched/current factories are honored
- add a regression for AGE DB factory binding
- scan quick dialectic position, concerns, and proposed conditions for high-risk terms, not only the issue text
- update existing AGE backend tests to patch the current DB factory resolution point

## Validation
- focused pytest: tests/test_knowledge_graph_age.py::TestGetDb tests/test_knowledge_graph_backend_binding.py
- focused pytest: tests/test_knowledge_graph_backend_binding.py tests/test_consolidated_handlers.py::TestDialecticHandler::test_quick_action_escalates_high_risk_in_position_or_concerns
- ./scripts/dev/test-cache.sh: 9055 passed, 25 skipped, 2 warnings
- pre-push smoke: 138 passed, 8381 deselected
