### PR TITLE
[codex] Address KG grievance backlog

### DIFF
--- a/src/agent_lifecycle.py
+++ b/src/agent_lifecycle.py
@@ -211,6 +211,16 @@ async def auto_archive_orphan_agents(
             )
             if not ok:
                 continue
+            try:
+                from src.sequential_calibration import get_sequential_calibration_tracker
+                get_sequential_calibration_tracker().drop_agent_state(agent_id)
+            except Exception as exc:
+                logger.warning(
+                    "Archived orphan agent %s, but failed to prune sequential "
+                    "calibration state: %s",
+                    agent_id[:12],
+                    exc,
+                )
             logger.info(f"Auto-archived orphan agent: {agent_id[:12]}... ({reason})")
 
         results.append({

--- a/src/mcp_handlers/introspection/tool_introspection.py
+++ b/src/mcp_handlers/introspection/tool_introspection.py
@@ -98,6 +98,46 @@ def _resolve_json_schema_type(field_info: Dict[str, Any]) -> str:
     return "any"
 
 
+_LITE_PARAMETER_PRIORITIES: Dict[str, List[str]] = {
+    "process_agent_update": [
+        "client_session_id",
+        "response_text",
+        "complexity",
+        "confidence",
+        "task_type",
+        "response_mode",
+        "require_strong_identity",
+        "recent_tool_results",
+    ],
+    "outcome_event": [
+        "confidence",
+        "prediction_id",
+        "decision_action",
+        "session_id",
+        "verification_source",
+        "detail",
+    ],
+}
+
+_LITE_IDENTITY_FIELDS = {"continuity_token", "client_session_id", "agent_id"}
+
+
+def _format_lite_parameter(
+    field_name: str,
+    field_info: Dict[str, Any],
+    *,
+    required: bool = False,
+) -> str:
+    if required:
+        return f"{field_name} (required)"
+
+    field_type = _resolve_json_schema_type(field_info)
+    default = field_info.get("default")
+    if default is not None:
+        return f"{field_name}: {field_type} (default: {default})"
+    return f"{field_name}: {field_type}"
+
+
 def _getting_started_path() -> List[Dict[str, Any]]:
     """Canonical low-friction path for first-time governance callers."""
     return [
@@ -1234,24 +1274,48 @@ async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextConten
                     required_fields = schema.get("required", [])
 
                     params_simple = []
+                    shown_fields = set()
+
+                    def add_lite_field(
+                        field_name: str,
+                        *,
+                        required: bool = False,
+                        force: bool = False,
+                    ) -> bool:
+                        if field_name in shown_fields:
+                            return False
+                        if field_name in _LITE_IDENTITY_FIELDS and not force:
+                            return False
+                        field_info = properties.get(field_name, {})
+                        params_simple.append(
+                            _format_lite_parameter(
+                                field_name,
+                                field_info,
+                                required=required,
+                            )
+                        )
+                        shown_fields.add(field_name)
+                        return True
+
                     for field_name in required_fields:
-                        if field_name == "client_session_id":
-                            continue
-                        params_simple.append(f"{field_name} (required)")
+                        add_lite_field(field_name, required=True)
 
                     shown = 0
-                    for field_name, field_info in properties.items():
-                        if field_name in required_fields or field_name == "client_session_id":
+                    for field_name in _LITE_PARAMETER_PRIORITIES.get(tool_name, []):
+                        if add_lite_field(field_name, force=True):
+                            shown += 1
+
+                    for field_name in properties:
+                        if field_name in required_fields:
                             continue
-                        if shown >= 5:
+                        if field_name in shown_fields:
+                            continue
+                        if shown >= 5 and tool_name not in _LITE_PARAMETER_PRIORITIES:
                             break
-                        shown += 1
-                        field_type = _resolve_json_schema_type(field_info)
-                        default = field_info.get("default")
-                        if default is not None:
-                            params_simple.append(f"{field_name}: {field_type} (default: {default})")
-                        else:
-                            params_simple.append(f"{field_name}: {field_type}")
+                        if shown >= 8:
+                            break
+                        if add_lite_field(field_name):
+                            shown += 1
 
                     lite_schema = {"params_simple": params_simple, "required": required_fields}
             except Exception:

--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -2476,6 +2476,30 @@ async def handle_leave_note(arguments: Dict[str, Any]) -> Sequence[TextContent]:
 
         # Create note with minimal ceremony
         from src.knowledge_graph import tag_provenance_source as _tag_src
+        provenance = _tag_src(None, "explicit_leave_note")
+        try:
+            from src.provenance_context import (
+                attach_s22_context,
+                build_s22_write_context,
+                classify_fork_for_s22_context,
+            )
+
+            meta = mcp_server.agent_metadata.get(agent_id)
+            episode_fork_kind, identity_lineage_fork = classify_fork_for_s22_context(
+                meta, agent_id
+            )
+            s22_context = build_s22_write_context(
+                arguments,
+                meta=meta,
+                context_source="knowledge.note",
+                default_governance_mode="explicit",
+                episode_fork_kind=episode_fork_kind,
+                identity_lineage_fork=identity_lineage_fork,
+            )
+            provenance = attach_s22_context(provenance, s22_context)
+        except Exception as exc:
+            logger.debug("Could not capture note S22 provenance: %s", exc)
+
         note = DiscoveryNode(
             id=_utc_now_iso(),
             agent_id=agent_id,
@@ -2486,7 +2510,7 @@ async def handle_leave_note(arguments: Dict[str, Any]) -> Sequence[TextContent]:
             severity=note_severity,
             status="open",
             response_to=response_to,
-            provenance=_tag_src(None, "explicit_leave_note"),
+            provenance=provenance,
         )
         
         # Auto-link if tags provided (fast with indexes)

--- a/src/mcp_handlers/schemas/core.py
+++ b/src/mcp_handlers/schemas/core.py
@@ -150,6 +150,8 @@ class ToolResultEvidence(BaseModel):
     `verification_source="agent_reported_tool_result"`. A future server-verified
     primitive will provide `server_observation` outcomes for the subset of
     work the server can independently verify. See spec §1.
+
+    Example: {"tool": "pytest", "summary": "tests passed", "is_bad": false}
     """
     model_config = ConfigDict(extra="forbid")
 
@@ -160,12 +162,33 @@ class ToolResultEvidence(BaseModel):
             "tool/summary and falls back to command or tool_call."
         ),
     )
-    tool: str = Field(..., max_length=64)
+    tool: str = Field(..., max_length=64, description="Tool name, NOT 'name'.")
     summary: str = Field(..., max_length=512)
     exit_code: Optional[int] = None
-    is_bad: Optional[bool] = None
+    is_bad: Optional[bool] = Field(
+        default=None,
+        description=(
+            "Whether the tool outcome was bad (true=failure). Note: this is "
+            "the inverse of 'success'."
+        ),
+    )
     prediction_id: Optional[str] = None
     observed_at: Optional[datetime] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_success_alias_shape(cls, data):
+        if not isinstance(data, dict):
+            return data
+        if "name" in data and "success" in data:
+            raise ValueError(
+                "ToolResultEvidence does not accept {name, success}. "
+                "Use {tool, summary, is_bad}. "
+                "Example: {\"tool\": \"pytest\", \"summary\": \"tests passed\", "
+                "\"is_bad\": false}. "
+                "The 'kind' field is optional and inferred from tool when omitted."
+            )
+        return data
 
     @model_validator(mode="before")
     @classmethod

--- a/src/mcp_handlers/schemas/knowledge.py
+++ b/src/mcp_handlers/schemas/knowledge.py
@@ -283,6 +283,13 @@ class LeaveNoteParams(AgentIdentityMixin):
         default_factory=list,
         description="Tags"
     )
+    # S22 provenance - agent-knowable subset only. Keep parity with
+    # StoreKnowledgeGraphParams and KnowledgeParams so knowledge(action="note")
+    # can preserve dogfood diagnostic provenance instead of silently dropping it.
+    comparison_key: Optional[str] = Field(None, description="S22 H5 provenance: stable key for comparing the same bounded task across harnesses")
+    task_label: Optional[str] = Field(None, description="S22 H5 provenance: human-readable bounded task label")
+    task_outcome: Optional[str] = Field(None, description="S22 H5 provenance: outcome label for the bounded task")
+    memory_context: Optional[str] = Field(None, description="S22 provenance: memory/KG/transcript surfaces visible to the writer")
 
 
 class CleanupKnowledgeGraphParams(AgentIdentityMixin):
@@ -317,7 +324,7 @@ class KnowledgeParams(AgentIdentityMixin):
     limit: Optional[int] = Field(None, description="Max results")
     include_details: Optional[bool] = Field(None, description="Include full details inline (for action=search/get)")
     dry_run: Union[bool, str, None] = Field(None, description="Dry run mode (for action=cleanup)")
-    # S22 provenance — agent-knowable subset only. See StoreKnowledgeGraphParams
+    # S22 provenance - agent-knowable subset only. See StoreKnowledgeGraphParams
     # above for the dropped-field rationale.
     comparison_key: Optional[str] = Field(None, description="S22 H5 provenance: stable key for comparing the same bounded task across harnesses")
     task_label: Optional[str] = Field(None, description="S22 H5 provenance: human-readable bounded task label")

--- a/src/sequential_calibration.py
+++ b/src/sequential_calibration.py
@@ -54,11 +54,15 @@ Known limitations
 from __future__ import annotations
 
 from collections import defaultdict
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, Optional
+import fcntl
 import json
 import math
+import os
 import sys
+import tempfile
 from datetime import datetime, UTC
 
 from config.governance_config import GovernanceConfig
@@ -139,6 +143,18 @@ class SequentialCalibrationTracker:
         self.prior_failure = float(prior_failure)
         self.load_state()
 
+    @contextmanager
+    def _state_file_lock(self, *, exclusive: bool):
+        self.state_file.parent.mkdir(parents=True, exist_ok=True)
+        lock_path = self.state_file.with_name(f"{self.state_file.name}.lock")
+        with open(lock_path, "a+") as lock_file:
+            lock_mode = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+            fcntl.flock(lock_file.fileno(), lock_mode)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
     def reset(self) -> None:
         self.global_state = _empty_state()
         self.agent_states = defaultdict(_empty_state)
@@ -171,12 +187,32 @@ class SequentialCalibrationTracker:
             "epoch": GovernanceConfig.CURRENT_EPOCH,
         }
 
+    def _save_state_unlocked(self) -> None:
+        self.state_file.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(self.state_file.parent),
+            prefix=f".{self.state_file.name}.",
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(self._serialize(), f, indent=2)
+                f.write("\n")
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, self.state_file)
+            self._loaded_mtime = self._file_mtime()
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
     def save_state(self) -> None:
         try:
-            self.state_file.parent.mkdir(parents=True, exist_ok=True)
-            with open(self.state_file, "w") as f:
-                json.dump(self._serialize(), f, indent=2)
-            self._loaded_mtime = self._file_mtime()
+            with self._state_file_lock(exclusive=True):
+                self._save_state_unlocked()
         except Exception as e:
             print(f"Warning: Failed to save sequential calibration state: {e}", file=sys.stderr)
 
@@ -192,7 +228,12 @@ class SequentialCalibrationTracker:
         if current_mtime > getattr(self, "_loaded_mtime", 0.0):
             self.load_state()
 
-    def load_state(self) -> None:
+    def _reload_if_stale_unlocked(self) -> None:
+        current_mtime = self._file_mtime()
+        if current_mtime > getattr(self, "_loaded_mtime", 0.0):
+            self._load_state_unlocked()
+
+    def _load_state_unlocked(self) -> None:
         try:
             if not self.state_file.exists():
                 self.reset()
@@ -256,6 +297,15 @@ class SequentialCalibrationTracker:
             self.reset()
             self._loaded_mtime = 0.0
 
+    def load_state(self) -> None:
+        try:
+            with self._state_file_lock(exclusive=True):
+                self._load_state_unlocked()
+        except Exception as e:
+            print(f"Warning: Failed to load sequential calibration state: {e}, resetting", file=sys.stderr)
+            self.reset()
+            self._loaded_mtime = 0.0
+
     @staticmethod
     def _clamp_probability(value: float) -> float:
         return min(1.0 - 1e-6, max(1e-6, float(value)))
@@ -310,7 +360,7 @@ class SequentialCalibrationTracker:
             "log_e_value": state["log_e_value"],
         }
 
-    def record_exogenous_tactical_outcome(
+    def _record_exogenous_tactical_outcome_in_memory(
         self,
         *,
         confidence: float,
@@ -322,20 +372,7 @@ class SequentialCalibrationTracker:
         outcome_type: Optional[str] = None,
         timestamp: Optional[str] = None,
         prediction_id: Optional[str] = None,
-        persist: bool = True,
     ) -> Dict[str, Any]:
-        """Record one eligible hard exogenous tactical outcome.
-
-        prediction_id, if provided, is included in the return payload for
-        forensic audit. The tracker state itself remains aggregate and is
-        not indexed by prediction_id.
-
-        class_tag, when provided, drives the parallel class_states rollup
-        (S10). Callers should pass the agent's resolved class (per
-        src/grounding/class_indicator.py::classify_agent). Omitted writes
-        bucket into UNKNOWN_CLASS_BUCKET so the by-class view surfaces
-        calibration starvation in the unclassified band as a deficit signal.
-        """
         if not signal_source:
             raise ValueError("signal_source is required")
 
@@ -371,9 +408,6 @@ class SequentialCalibrationTracker:
             timestamp=ts,
         )
 
-        if persist:
-            self.save_state()
-
         return {
             "agent_id": agent_id,
             "class_tag": bucket,
@@ -385,6 +419,90 @@ class SequentialCalibrationTracker:
             "agent": agent_update,
             "class": class_update,
         }
+
+    def record_exogenous_tactical_outcome(
+        self,
+        *,
+        confidence: float,
+        outcome_correct: bool,
+        agent_id: Optional[str] = None,
+        class_tag: Optional[str] = None,
+        signal_source: str,
+        decision_action: Optional[str] = None,
+        outcome_type: Optional[str] = None,
+        timestamp: Optional[str] = None,
+        prediction_id: Optional[str] = None,
+        persist: bool = True,
+    ) -> Dict[str, Any]:
+        """Record one eligible hard exogenous tactical outcome.
+
+        prediction_id, if provided, is included in the return payload for
+        forensic audit. The tracker state itself remains aggregate and is
+        not indexed by prediction_id.
+
+        class_tag, when provided, drives the parallel class_states rollup
+        (S10). Callers should pass the agent's resolved class (per
+        src/grounding/class_indicator.py::classify_agent). Omitted writes
+        bucket into UNKNOWN_CLASS_BUCKET so the by-class view surfaces
+        calibration starvation in the unclassified band as a deficit signal.
+        """
+        if persist:
+            with self._state_file_lock(exclusive=True):
+                self._reload_if_stale_unlocked()
+                result = self._record_exogenous_tactical_outcome_in_memory(
+                    confidence=confidence,
+                    outcome_correct=outcome_correct,
+                    agent_id=agent_id,
+                    class_tag=class_tag,
+                    signal_source=signal_source,
+                    decision_action=decision_action,
+                    outcome_type=outcome_type,
+                    timestamp=timestamp,
+                    prediction_id=prediction_id,
+                )
+                self._save_state_unlocked()
+                return result
+
+        return self._record_exogenous_tactical_outcome_in_memory(
+            confidence=confidence,
+            outcome_correct=outcome_correct,
+            agent_id=agent_id,
+            class_tag=class_tag,
+            signal_source=signal_source,
+            decision_action=decision_action,
+            outcome_type=outcome_type,
+            timestamp=timestamp,
+            prediction_id=prediction_id,
+        )
+
+    def _drop_agent_state_in_memory(self, agent_id: str) -> bool:
+        if not agent_id or agent_id not in self.agent_states:
+            return False
+
+        del self.agent_states[agent_id]
+        # class_states is a derived read cache over agent_states. Once an agent
+        # slice is pruned, the old class rollup may still contain that slice, so
+        # clear it and force the existing rebucket sweeper to rebuild honestly.
+        self.class_states = defaultdict(_empty_state)
+        self.class_states_bootstrapped = False
+        return True
+
+    def drop_agent_state(self, agent_id: str, *, persist: bool = True) -> bool:
+        """Drop per-agent calibration state when lifecycle archival succeeds.
+
+        Global evidence remains intact. Per-agent slices are bounded by the
+        lifecycle archive path; class rollups are cleared because they are
+        derived from agent_states and must be rebuilt after a prune.
+        """
+        if persist:
+            with self._state_file_lock(exclusive=True):
+                self._load_state_unlocked()
+                changed = self._drop_agent_state_in_memory(agent_id)
+                if changed:
+                    self._save_state_unlocked()
+                return changed
+
+        return self._drop_agent_state_in_memory(agent_id)
 
     def compute_per_channel_health(self, min_samples_for_pin: int = 100) -> Dict[str, Dict[str, Any]]:
         """

--- a/src/tool_descriptions.py
+++ b/src/tool_descriptions.py
@@ -45,6 +45,11 @@ _DESCRIPTION_APPENDICES = {
         "staleness_threshold_seconds)"
     ),
     "process_agent_update": (
+        "\n\nCURRENT HIGH-VALUE PARAMETERS:\n"
+        "- response_mode: minimal | compact | standard | full | mirror | auto\n"
+        "- require_strong_identity: reject updates unless identity assurance is strong\n"
+        "- recent_tool_results: list of ToolResultEvidence items, shaped as "
+        "{tool, summary, is_bad}; kind is inferred when omitted\n"
         "\n\nS22 PROVENANCE FIELDS (optional, descriptive, not identity proof):\n"
         "- harness_type / harness: normalized harness family such as "
         "\"codex-cli\", \"claude-code\", or \"hermes\"\n"
@@ -64,6 +69,21 @@ _DESCRIPTION_APPENDICES = {
         "  \"task_label\": \"Run S22 H5 coverage diagnostic\",\n"
         "  \"task_outcome\": \"diagnostic-complete\"\n"
         "}"
+    ),
+    "outcome_event": (
+        "\n\nCURRENT OUTCOME TYPES:\n"
+        "- trajectory_validated: server-observed trajectory validation event\n"
+        "- dialectic_resolved: dialectic review reached a resolution\n"
+        "\n"
+        "CURRENT CALIBRATION / PROVENANCE FIELDS:\n"
+        "- confidence: agent confidence at outcome time; inferred from last "
+        "check-in if omitted\n"
+        "- prediction_id: tactical prediction id returned by process_agent_update; "
+        "binds this outcome to that prediction\n"
+        "- decision_action: decision taken, e.g. proceed or pause\n"
+        "- session_id: optional session id; falls back to client_session_id/context\n"
+        "- verification_source: agent_reported_tool_result | server_observation | "
+        "external_signal"
     ),
 }
 

--- a/tests/test_describe_tool_drift.py
+++ b/tests/test_describe_tool_drift.py
@@ -55,6 +55,69 @@ async def test_process_agent_update_describe_mentions_recent_tool_results():
 
 
 @pytest.mark.asyncio
+async def test_process_agent_update_lite_mentions_current_parameters():
+    import json
+    from src.mcp_handlers.introspection.tool_introspection import handle_describe_tool
+
+    result = await handle_describe_tool({"tool_name": "process_agent_update", "lite": True})
+    data = json.loads(result[0].text)
+    params = "\n".join(data["parameters"])
+
+    for field in (
+        "client_session_id",
+        "response_text",
+        "complexity",
+        "confidence",
+        "task_type",
+        "response_mode",
+        "require_strong_identity",
+        "recent_tool_results",
+    ):
+        assert field in params
+
+    assert "parameters:" not in params
+    assert "ethical_drift" not in params
+
+
+@pytest.mark.asyncio
+async def test_outcome_event_lite_mentions_calibration_parameters():
+    import json
+    from src.mcp_handlers.introspection.tool_introspection import handle_describe_tool
+
+    result = await handle_describe_tool({"tool_name": "outcome_event", "lite": True})
+    data = json.loads(result[0].text)
+    params = "\n".join(data["parameters"])
+
+    for field in (
+        "outcome_type",
+        "confidence",
+        "prediction_id",
+        "decision_action",
+        "session_id",
+        "verification_source",
+    ):
+        assert field in params
+
+
+@pytest.mark.asyncio
+async def test_outcome_event_describe_mentions_current_types_and_provenance():
+    import json
+    from src.mcp_handlers.introspection.tool_introspection import handle_describe_tool
+
+    result = await handle_describe_tool({"tool_name": "outcome_event", "lite": False})
+    description = json.loads(result[0].text)["tool"]["description"]
+
+    for text in (
+        "trajectory_validated",
+        "dialectic_resolved",
+        "prediction_id",
+        "decision_action",
+        "verification_source",
+    ):
+        assert text in description
+
+
+@pytest.mark.asyncio
 async def test_process_agent_update_describe_mentions_s22_h5_fields():
     from src.mcp_handlers.introspection.tool_introspection import handle_describe_tool
     result = await handle_describe_tool({"tool_name": "process_agent_update", "lite": False})

--- a/tests/test_kg_store.py
+++ b/tests/test_kg_store.py
@@ -1115,6 +1115,38 @@ class TestKnowledgeWriteBroadcast:
         data = parse_result(result)
         assert data["success"] is True
 
+    @pytest.mark.asyncio
+    async def test_knowledge_note_preserves_s22_context(
+        self, patch_common, registered_agent,
+    ):
+        """Unified knowledge(note) must not drop S22 provenance fields."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.consolidated import handle_knowledge
+
+        result = await handle_knowledge({
+            "action": "note",
+            "agent_id": registered_agent,
+            "content": "S22 note provenance test",
+            "comparison_key": "s22-note-2026-05-31",
+            "task_label": "Exercise knowledge note provenance",
+            "task_outcome": "note-recorded",
+            "memory_context": "repo+kg",
+        })
+
+        data = parse_result(result)
+        assert data["success"] is True
+        discovery = mock_graph.add_discovery.await_args.args[0]
+        provenance = discovery.provenance
+        assert provenance["source"] == "explicit_leave_note"
+        context = provenance["s22_context"]
+        assert context["schema"] == "s22.write_context.v1"
+        assert context["context_source"] == "knowledge.note"
+        assert context["comparison_key"] == "s22-note-2026-05-31"
+        assert context["task_label"] == "Exercise knowledge note provenance"
+        assert context["task_outcome"] == "note-recorded"
+        assert context["memory_context"] == "repo+kg"
+        assert context["governance_mode"] == "explicit"
+
 
 class TestKnowledgeReadBroadcast:
     """Read-side audit coverage. Without these emits the central usage

--- a/tests/test_mcp_server_std.py
+++ b/tests/test_mcp_server_std.py
@@ -1380,6 +1380,32 @@ class TestAutoArchiveOrphanAgents:
         finally:
             agent_metadata.pop(test_id, None)
 
+    @pytest.mark.asyncio
+    async def test_successful_archive_prunes_sequential_calibration_agent_state(self):
+        """Archive lifecycle is the retention boundary for per-agent calibration slices."""
+        from src.agent_state import auto_archive_orphan_agents, agent_metadata, AgentMetadata
+        old_time = (datetime.now() - timedelta(hours=5)).isoformat()
+        test_id = "calibration-prune-test-agent"
+        agent_metadata[test_id] = AgentMetadata(
+            agent_id=test_id, status="active", created_at=old_time, last_update=old_time,
+            total_updates=1,
+        )
+        tracker = MagicMock()
+        try:
+            with patch(
+                "src.mcp_handlers.lifecycle.helpers.agent_storage.archive_agent",
+                new_callable=AsyncMock,
+            ), patch(
+                "src.sequential_calibration.get_sequential_calibration_tracker",
+                return_value=tracker,
+            ):
+                results = await auto_archive_orphan_agents(low_update_hours=3.0)
+
+            assert [r["id"] for r in results] == [test_id]
+            tracker.drop_agent_state.assert_called_once_with(test_id)
+        finally:
+            agent_metadata.pop(test_id, None)
+
 
 # ============================================================================
 # Test: MCP list_tools handler

--- a/tests/test_pydantic_schemas.py
+++ b/tests/test_pydantic_schemas.py
@@ -171,6 +171,23 @@ class TestPydanticSchemas:
         missing = dispatcher_actions - schema_actions
         assert not missing, f"Schema missing dispatcher actions: {missing}"
 
+    def test_leave_note_accepts_s22_h5_agent_knowable_fields(self):
+        """Quick notes must preserve the same S22 diagnostic fields as store."""
+        from src.mcp_handlers.schemas.knowledge import LeaveNoteParams
+
+        params = LeaveNoteParams(
+            summary="dogfood diagnostic note",
+            comparison_key="s22-note-2026-05-31",
+            task_label="Exercise knowledge note provenance",
+            task_outcome="note-recorded",
+            memory_context="repo+kg",
+        )
+
+        assert params.comparison_key == "s22-note-2026-05-31"
+        assert params.task_label == "Exercise knowledge note provenance"
+        assert params.task_outcome == "note-recorded"
+        assert params.memory_context == "repo+kg"
+
     def test_dialectic_schema_accepts_quick_action(self):
         """Lightweight dialectic action must be accepted by public schema."""
         from src.mcp_handlers.schemas.dialectic import DialecticParams
@@ -245,6 +262,26 @@ class TestToolResultEvidence:
         from src.mcp_handlers.schemas.core import ToolResultEvidence
         ev = ToolResultEvidence(tool="curl", summary="health check passed", exit_code=0)
         assert ev.kind == "command"
+
+    def test_rejects_name_success_shape_with_recovery_hint(self):
+        from pydantic import ValidationError
+        from src.mcp_handlers.schemas.core import ToolResultEvidence
+
+        with pytest.raises(ValidationError) as exc_info:
+            ToolResultEvidence(name="pytest", summary="passed", success=True)
+
+        message = str(exc_info.value)
+        assert "does not accept {name, success}" in message
+        assert "Use {tool, summary, is_bad}" in message
+        assert "kind' field is optional" in message
+
+    def test_accepts_tool_summary_is_bad_shape_without_kind(self):
+        from src.mcp_handlers.schemas.core import ToolResultEvidence
+
+        ev = ToolResultEvidence(tool="pytest", summary="tests passed", is_bad=False)
+
+        assert ev.kind == "test"
+        assert ev.is_bad is False
 
     def test_rejects_extra_fields(self):
         from pydantic import ValidationError

--- a/tests/test_sequential_calibration.py
+++ b/tests/test_sequential_calibration.py
@@ -98,6 +98,96 @@ def test_agent_metrics_are_isolated(tmp_path):
     assert b_metrics["signal_sources"] == {"lint": 1}
 
 
+def test_persisted_record_reloads_before_write_to_avoid_stale_overwrite(tmp_path):
+    state_file = tmp_path / "seq_state.json"
+    first = SequentialCalibrationTracker(state_file=state_file)
+    stale_second = SequentialCalibrationTracker(state_file=state_file)
+
+    first.record_exogenous_tactical_outcome(
+        confidence=0.9,
+        outcome_correct=False,
+        agent_id="agent-a",
+        signal_source="tests",
+        decision_action="proceed",
+        outcome_type="test_failed",
+    )
+    stale_second.record_exogenous_tactical_outcome(
+        confidence=0.8,
+        outcome_correct=True,
+        agent_id="agent-b",
+        signal_source="lint",
+        decision_action="proceed",
+        outcome_type="task_completed",
+    )
+
+    reloaded = SequentialCalibrationTracker(state_file=state_file)
+
+    assert reloaded.compute_metrics()["eligible_samples"] == 2
+    assert reloaded.compute_metrics(agent_id="agent-a")["eligible_samples"] == 1
+    assert reloaded.compute_metrics(agent_id="agent-b")["eligible_samples"] == 1
+
+
+def test_persisted_record_preserves_local_unpersisted_samples_when_not_stale(tmp_path):
+    state_file = tmp_path / "seq_state.json"
+    tracker = SequentialCalibrationTracker(state_file=state_file)
+    tracker.record_exogenous_tactical_outcome(
+        confidence=0.9,
+        outcome_correct=False,
+        agent_id="agent-a",
+        signal_source="tests",
+        decision_action="proceed",
+        outcome_type="test_failed",
+        persist=False,
+    )
+
+    tracker.record_exogenous_tactical_outcome(
+        confidence=0.8,
+        outcome_correct=True,
+        agent_id="agent-b",
+        signal_source="lint",
+        decision_action="proceed",
+        outcome_type="task_completed",
+    )
+    reloaded = SequentialCalibrationTracker(state_file=state_file)
+
+    assert reloaded.compute_metrics()["eligible_samples"] == 2
+    assert reloaded.compute_metrics(agent_id="agent-a")["eligible_samples"] == 1
+    assert reloaded.compute_metrics(agent_id="agent-b")["eligible_samples"] == 1
+
+
+def test_drop_agent_state_prunes_agent_and_invalidates_class_rollup(tmp_path):
+    state_file = tmp_path / "seq_state.json"
+    tracker = SequentialCalibrationTracker(state_file=state_file)
+    tracker.record_exogenous_tactical_outcome(
+        confidence=0.9,
+        outcome_correct=False,
+        agent_id="agent-a",
+        class_tag="ephemeral",
+        signal_source="tests",
+        decision_action="proceed",
+        outcome_type="test_failed",
+    )
+    tracker.record_exogenous_tactical_outcome(
+        confidence=0.8,
+        outcome_correct=True,
+        agent_id="agent-b",
+        class_tag="session_like",
+        signal_source="lint",
+        decision_action="proceed",
+        outcome_type="task_completed",
+    )
+
+    assert tracker.drop_agent_state("agent-a") is True
+    reloaded = SequentialCalibrationTracker(state_file=state_file)
+
+    assert reloaded.compute_metrics()["eligible_samples"] == 2
+    assert reloaded.compute_metrics(agent_id="agent-a")["status"] == "no_data"
+    assert reloaded.compute_metrics(agent_id="agent-b")["eligible_samples"] == 1
+    by_class = reloaded.compute_metrics_by_class()
+    assert by_class["bootstrapped"] is False
+    assert by_class["by_class"] == {}
+
+
 def test_prediction_id_is_echoed_in_return_payload(tmp_path):
     """record_exogenous_tactical_outcome should pass prediction_id through for audit."""
     tracker = SequentialCalibrationTracker(state_file=tmp_path / "seq_state.json")


### PR DESCRIPTION
## Summary
- add targeted recovery text for invalid ToolResultEvidence `{name, success}` payloads
- make sequential calibration state saves/reloads safe under concurrent writers and prune archived agents from calibration state
- update describe_tool lite/full docs for current process_agent_update and outcome_event parameters
- preserve S22 provenance for `knowledge(action="note")` and add route/schema regression coverage

## Why
These changes implement the local fixes from the KG grievance pass: several KG rows were already verified as real defects or DX drift, but needed source changes and tests before they can be resolved after merge/deploy.

## Validation
- `./scripts/dev/test-cache.sh` -> 9058 passed, 37 skipped
- `./scripts/dev/test-cache.sh --staged` -> 9060 passed, 35 skipped
- `git diff --check`
- pre-push smoke -> 138 passed, 8396 deselected
