### PR TITLE
feat(kg): on-demand topic synthesis (close the loop, #44)

### DIFF
--- a/skills/knowledge-graph/SKILL.md
+++ b/skills/knowledge-graph/SKILL.md
@@ -108,3 +108,35 @@ The graph accumulates knowledge well but does not close loops automatically. Thi
 - **Periodically check for stale entries** in your domain using `knowledge(action="cleanup")`.
 
 Unresolved entries create noise. Closed loops create trust in the graph.
+
+## Synthesis: rolling up topics
+
+`knowledge(action="synthesize")` compounds the discrete discoveries under a topic
+(a tag) into a single rolled-up **summary row**, so a cross-referenced, compounded
+narrative exists *before* query time instead of only being assembled on read via
+`search(..., synthesize=true)`. It is the GraphRAG "community summary" pattern: a
+hierarchical summary layer maintained over the base discovery nodes.
+
+- `knowledge(action="synthesize")` — sweep the densest topics and (re)build their
+  rollups. `topic="..."` rolls up a single tag; `dry_run=true` previews without
+  writing; `min_members` (default 3) sets the threshold; `use_llm=false` forces the
+  deterministic narrative.
+- Rollups are stored as ordinary discoveries (`type="topic_rollup"`, deterministic
+  id `rollup::<topic>`, tagged `rollup`), so they upsert in place across runs and
+  are found by normal search — e.g. `knowledge(action="search", tags=["rollup"])`.
+
+Run it **on demand or on a periodic cadence (like cleanup/lint), not on every
+write** — a per-write LLM pass across a multi-agent fleet is exactly the
+high-frequency-noise anti-pattern this graph avoids.
+
+## Deferred: bi-temporal fact validity (documented idea, not built)
+
+A first-class notion of *when a fact became true/false* (valid-from / valid-to
+plus observation time, per the Graphiti/Zep bi-temporal model) was considered and
+**deliberately deferred**. It is a substrate-level change — migration, AGE query
+rewrites, and every read path having to reason about time — for a payoff
+(point-in-time reconstruction, automatic invalidation) that is speculative for
+current usage. The existing `superseded` status + `created_at` is an ~80%
+substitute. The signal to build it is a concrete failure: an agent acting on a
+stale fact in a way that actually bites. Until then this stays a documented idea,
+not a roadmap item.

--- a/src/db/mixins/knowledge_graph.py
+++ b/src/db/mixins/knowledge_graph.py
@@ -232,6 +232,48 @@ class KnowledgeGraphMixin:
 
             return [self._row_to_discovery_dict(row) for row in rows]
 
+    async def kg_topic_candidates(
+        self,
+        min_members: int = 3,
+        limit: int = 20,
+        exclude_types: Optional[List[str]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Topics (normalized tags) dense enough to be worth rolling up.
+
+        Powers the on-demand synthesis pass (Issue #1): returns each tag that
+        appears on at least ``min_members`` non-archived discoveries, most active
+        first. ``exclude_types`` drops rows whose ``type`` is in the list — the
+        synthesis pass passes its own rollup type so rollups never become members
+        of a future rollup (no feedback loop). Read-only aggregate; no writes.
+        """
+        excluded = exclude_types or []
+        async with self.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT tag AS topic,
+                       COUNT(*) AS member_count,
+                       COUNT(*) FILTER (WHERE status = 'open') AS open_count
+                FROM knowledge.discoveries d, unnest(d.tags) AS tag
+                WHERE d.status <> 'archived'
+                  AND ($3::text[] IS NULL OR d.type <> ALL($3::text[]))
+                GROUP BY tag
+                HAVING COUNT(*) >= $1
+                ORDER BY member_count DESC, tag ASC
+                LIMIT $2
+                """,
+                min_members,
+                limit,
+                excluded or None,
+            )
+            return [
+                {
+                    "topic": r["topic"],
+                    "member_count": r["member_count"],
+                    "open_count": r["open_count"],
+                }
+                for r in rows
+            ]
+
     async def kg_get_discovery(self, discovery_id: str) -> Optional[Dict[str, Any]]:
         """Get a single discovery by ID, including backlinks."""
         async with self.acquire() as conn:

--- a/src/mcp_handlers/__init__.py
+++ b/src/mcp_handlers/__init__.py
@@ -76,6 +76,7 @@ from .knowledge.handlers import (
     handle_get_discovery_details,
     handle_leave_note,
     handle_cleanup_knowledge_graph,
+    handle_synthesize_knowledge_graph,
     handle_get_lifecycle_stats,
 )
 # Dialectic - full protocol restored (Feb 2026)

--- a/src/mcp_handlers/consolidated.py
+++ b/src/mcp_handlers/consolidated.py
@@ -27,6 +27,7 @@ from .knowledge.handlers import (
     handle_get_discovery_details,
     handle_leave_note,
     handle_cleanup_knowledge_graph,
+    handle_synthesize_knowledge_graph,
     handle_get_lifecycle_stats,
     handle_supersede_discovery,
     handle_audit_knowledge_graph,
@@ -94,12 +95,13 @@ handle_knowledge = action_router(
         "details": handle_get_discovery_details,
         "note": handle_leave_note,
         "cleanup": handle_cleanup_knowledge_graph,
+        "synthesize": handle_synthesize_knowledge_graph,
         "stats": handle_get_lifecycle_stats,
         "supersede": handle_supersede_discovery,
         "audit": handle_audit_knowledge_graph,
     },
-    timeout=60.0,
-    description="Unified knowledge graph operations: store, search, get, list, update, details, note, cleanup, stats, supersede, audit",
+    timeout=120.0,
+    description="Unified knowledge graph operations: store, search, get, list, update, details, note, cleanup, synthesize, stats, supersede, audit",
     param_maps={
         "search": {"query": "search_query"},
         "store": {"content": "details"},  # Allow 'content' as alias for 'details'
@@ -110,6 +112,8 @@ handle_knowledge = action_router(
         "knowledge(action='store', summary='Found bug in auth', discovery_type='bug_found')",
         "knowledge(action='search', query='authentication issues')",
         "knowledge(action='note', content='Remember to check cache')",
+        "knowledge(action='synthesize')  # roll up the densest topics into summaries",
+        "knowledge(action='synthesize', topic='identity', dry_run=true)",
     ],
 )
 

--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -51,6 +51,10 @@ VALID_DISCOVERY_TYPES = {
     "architectural_decision", "learning", "pattern", "bug_fix",
     "refactoring", "documentation", "experiment", "question", "note", "rule",
     "insight", "bug_found", "improvement", "exploration", "observation",
+    # System-generated rollup rows (Issue #1 synthesis). Listed so search can
+    # filter discovery_type='topic_rollup'; written by the synthesis pass, not
+    # by agents directly.
+    "topic_rollup",
 }
 VALID_SEVERITIES = {"low", "medium", "high", "critical"}
 SEVERITY_ALIASES = {
@@ -2583,6 +2587,78 @@ async def handle_cleanup_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[
 
     except Exception as e:
         return [error_response(f"Failed to run lifecycle cleanup: {str(e)}")]
+
+@mcp_tool("synthesize_knowledge_graph", timeout=120.0, register=False)
+async def handle_synthesize_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[TextContent]:
+    """Compound discrete discoveries into rolled-up topic summaries (Issue #1).
+
+    Closes the loop the knowledge-graph skill admits is open ("does not close
+    loops automatically"): a periodic/on-demand pass that maintains a
+    cross-referenced, compounded narrative per topic *before* query time, the
+    way GraphRAG maintains hierarchical community summaries.
+
+    Deliberately NOT a per-write hook — running an LLM pass on every store/note
+    across a multi-agent fleet is the auto-checkin anti-pattern. This runs like
+    lint/cleanup: on demand, or wired to a periodic trigger. Rollups are stored
+    as ordinary discovery rows (type='topic_rollup', deterministic id
+    'rollup::<topic>'), so they upsert in place and need no schema change.
+
+    Args:
+        topic:       Synthesize just this one tag. Omit to sweep the densest topics.
+        limit:       Max topics processed this run (default 20). Bounds cost.
+        min_members: Minimum discoveries a topic needs to be rolled up (default 3).
+        use_llm:     Use the local LLM for the narrative (default true). When the
+                     LLM is unreachable, falls back to a deterministic rollup.
+        dry_run:     Preview the rollups without persisting them.
+
+    Returns a per-topic report (member counts, cross-references, summary source).
+    """
+    from .synthesis import synthesize_topics, MIN_TOPIC_MEMBERS, DEFAULT_TOPIC_LIMIT
+
+    topic = arguments.get("topic")
+
+    dry_run = arguments.get("dry_run", False)
+    if isinstance(dry_run, str):
+        dry_run = dry_run.lower() in ("true", "1", "yes")
+    elif dry_run is None:
+        dry_run = False
+
+    use_llm = arguments.get("use_llm", True)
+    if isinstance(use_llm, str):
+        use_llm = use_llm.lower() in ("true", "1", "yes")
+    elif use_llm is None:
+        use_llm = True
+
+    def _as_int(value, default):
+        try:
+            return max(1, int(value))
+        except (TypeError, ValueError):
+            return default
+
+    limit = _as_int(arguments.get("limit"), DEFAULT_TOPIC_LIMIT)
+    min_members = _as_int(arguments.get("min_members"), MIN_TOPIC_MEMBERS)
+
+    try:
+        graph = await get_knowledge_graph()
+        result = await synthesize_topics(
+            graph,
+            topic=topic,
+            limit=limit,
+            min_members=min_members,
+            use_llm=use_llm,
+            dry_run=dry_run,
+        )
+        prefix = "[DRY RUN] " if dry_run else ""
+        scope = f"topic '{topic}'" if topic else f"top {limit} topics"
+        return success_response({
+            "message": (
+                f"{prefix}Synthesis complete over {scope}: "
+                f"{result['rollups_written']} rollup(s) written"
+            ),
+            **result,
+        }, arguments=arguments)
+    except Exception as e:
+        return [error_response(f"Failed to synthesize knowledge graph: {str(e)}")]
 
 @mcp_tool("get_lifecycle_stats", timeout=30.0, rate_limit_exempt=True, register=False)
 async def handle_get_lifecycle_stats(arguments: Dict[str, Any]) -> Sequence[TextContent]:

--- a/src/mcp_handlers/knowledge/synthesis.py
+++ b/src/mcp_handlers/knowledge/synthesis.py
@@ -1,0 +1,294 @@
+"""On-demand knowledge-graph synthesis (Issue #1: closing the loop).
+
+The knowledge() store/note path persists discrete discovery rows + related_to
+edges, and synthesis only happens on read (``synthesize=true`` on search). The
+knowledge-graph skill itself notes the graph "does not close loops
+automatically" (surfaced by the LLM-wiki comparison, #44 / PR #45).
+
+This module compounds those discrete rows into rolled-up *topic summaries* so a
+cross-referenced, compounded narrative exists before query time — the way
+Microsoft GraphRAG maintains hierarchical community summaries over base nodes.
+
+Why on-demand, not on-write
+---------------------------
+The original proposal said "post-write synthesis pass". That framing is a trap
+for a multi-agent fleet: running an LLM synthesis pass on *every* store/note is
+the auto-checkin-on-every-trivial-write anti-pattern UNITARES explicitly lists
+as a non-goal — per-write latency, LLM cost, and a fresh noise source (stale
+auto-generated rollups racing live writes). So synthesis runs like lint or
+cleanup: periodically or on demand via ``knowledge(action='synthesize')``,
+reusing the existing store + LLM-delegation machinery. No per-write cost.
+
+Why no schema change
+--------------------
+Rollups are persisted as ordinary discovery rows: a deterministic id
+``rollup::<topic>`` and ``type='topic_rollup'``. That means they upsert in place
+(compounding across runs, never duplicating), are queryable through normal
+search/get, and are lifecycle-managed like any other discovery — with zero
+migration. Re-running refreshes ``summary``/``details`` via the existing
+``ON CONFLICT (id) DO UPDATE`` write path.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from src.knowledge_graph import DiscoveryNode, normalize_tags
+from src.logging_utils import get_logger
+from ..support.llm_delegation import call_local_llm
+
+logger = get_logger(__name__)
+
+# Rollup rows are first-class discoveries, distinguished by a reserved type and
+# a deterministic id so successive passes upsert the same row.
+ROLLUP_TYPE = "topic_rollup"
+ROLLUP_ID_PREFIX = "rollup::"
+# Stable synthetic writer for system-generated rollups (attribution, not auth).
+SYNTHESIS_WRITER_ID = "system:kg-synthesis"
+
+# Tuning. A topic needs a few members before a rollup carries more signal than
+# the raw rows. Per-run topic cap bounds cost the way cleanup bounds its batch.
+MIN_TOPIC_MEMBERS = 3
+DEFAULT_TOPIC_LIMIT = 20
+# Cap members fed to the narrative so the LLM prompt (and details blob) stays
+# small; GraphRAG likewise summarizes a bounded slice, not the whole community.
+MAX_MEMBERS_PER_ROLLUP = 12
+ROLLUP_SUMMARY_TOKENS = 256
+
+
+def rollup_id(topic: str) -> str:
+    """Deterministic discovery id for a topic's rollup row."""
+    return f"{ROLLUP_ID_PREFIX}{topic}"
+
+
+def is_rollup(discovery: Any) -> bool:
+    """True if a discovery dict / node is a synthesis rollup row."""
+    dtype = discovery.get("type") if isinstance(discovery, dict) else getattr(discovery, "type", None)
+    did = discovery.get("id") if isinstance(discovery, dict) else getattr(discovery, "id", "")
+    return dtype == ROLLUP_TYPE or (isinstance(did, str) and did.startswith(ROLLUP_ID_PREFIX))
+
+
+def extract_related_topics(members: List[Dict[str, Any]], topic: str, limit: int = 8) -> List[str]:
+    """Co-occurring tags across the members — the precomputed cross-reference set.
+
+    These let a reader hop topic -> topic without a query-time join. Ordered by
+    co-occurrence frequency so the densest neighbours come first.
+    """
+    counts: Dict[str, int] = {}
+    for m in members:
+        for tag in m.get("tags", []) or []:
+            if tag and tag != topic:
+                counts[tag] = counts.get(tag, 0) + 1
+    ranked = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
+    return [tag for tag, _ in ranked[:limit]]
+
+
+def _member_lines(members: List[Dict[str, Any]]) -> List[str]:
+    """One ``[type] summary (status)`` line per member, capped for prompt size."""
+    lines = []
+    for m in members[:MAX_MEMBERS_PER_ROLLUP]:
+        summary = (m.get("summary") or "").strip().replace("\n", " ")[:140]
+        dtype = m.get("type") or "note"
+        status = m.get("status") or "open"
+        lines.append(f"[{dtype}] {summary} ({status})")
+    return lines
+
+
+def build_deterministic_summary(
+    topic: str,
+    members: List[Dict[str, Any]],
+    related_topics: List[str],
+) -> str:
+    """Narrative used when no LLM is reachable.
+
+    Not a degraded placeholder — a faithful, query-time-free rollup assembled
+    from the member summaries. Deterministic so re-runs are stable.
+    """
+    open_count = sum(1 for m in members if (m.get("status") or "open") == "open")
+    header = (
+        f"Topic '{topic}': {len(members)} discoveries "
+        f"({open_count} open). "
+    )
+    if related_topics:
+        header += "Related topics: " + ", ".join(related_topics) + ". "
+    body = "\n".join(f"- {line}" for line in _member_lines(members))
+    return header + "\nKey discoveries:\n" + body
+
+
+async def _generate_narrative(
+    topic: str,
+    members: List[Dict[str, Any]],
+    related_topics: List[str],
+    *,
+    use_llm: bool,
+) -> tuple[str, str]:
+    """Return ``(narrative, source)`` where source is 'llm' or 'deterministic'.
+
+    Always returns a usable narrative — falls back to the deterministic rollup
+    if the LLM is disabled, unavailable, or times out (graceful, never raises).
+    """
+    deterministic = build_deterministic_summary(topic, members, related_topics)
+    if not use_llm:
+        return deterministic, "deterministic"
+
+    member_block = "\n".join(f"{i + 1}. {line}" for i, line in enumerate(_member_lines(members)))
+    related_hint = (
+        f"\nCross-references (co-occurring topics): {', '.join(related_topics)}"
+        if related_topics else ""
+    )
+    prompt = (
+        f"You are maintaining a rolled-up summary page for the topic '{topic}' "
+        f"in a shared knowledge graph. Compound these discoveries into a single "
+        f"coherent narrative: the current state, recurring patterns, and what is "
+        f"still open. 4-6 sentences, no preamble, no bullet list.\n\n"
+        f"Discoveries:\n{member_block}{related_hint}"
+    )
+    try:
+        result = await call_local_llm(
+            prompt=prompt, max_tokens=ROLLUP_SUMMARY_TOKENS, temperature=0.5, timeout=30.0
+        )
+    except Exception as exc:  # pragma: no cover - call_local_llm already guards
+        logger.warning("rollup narrative LLM call raised: %s", exc)
+        result = None
+
+    if result and result.strip():
+        return result.strip(), "llm"
+    return deterministic, "deterministic"
+
+
+def _make_rollup_node(
+    topic: str,
+    members: List[Dict[str, Any]],
+    narrative: str,
+    source: str,
+    related_topics: List[str],
+    *,
+    writer_id: str,
+) -> DiscoveryNode:
+    """Assemble the rollup discovery row for a topic."""
+    member_ids = [m["id"] for m in members[:MAX_MEMBERS_PER_ROLLUP] if m.get("id")]
+    open_count = sum(1 for m in members if (m.get("status") or "open") == "open")
+    headline = narrative.strip().split("\n", 1)[0][:200]
+    summary = f"[rollup] {topic}: {len(members)} discoveries ({open_count} open) — {headline}"
+
+    details_parts = [narrative.strip(), ""]
+    if related_topics:
+        details_parts.append("Related topics: " + ", ".join(related_topics))
+    details_parts.append(f"Members ({len(member_ids)} of {len(members)} shown):")
+    details_parts.extend(f"- {mid}" for mid in member_ids)
+    details = "\n".join(details_parts)
+
+    # Tag with the topic plus a marker so rollups are filterable in normal search
+    # (knowledge(action='search', tags=['rollup'])).
+    tags = normalize_tags([topic, "rollup"])
+
+    return DiscoveryNode(
+        id=rollup_id(topic),
+        agent_id=writer_id,
+        type=ROLLUP_TYPE,
+        summary=summary,
+        details=details,
+        tags=tags,
+        related_to=member_ids,
+        status="open",
+        provenance={
+            "synthesis": {
+                "topic": topic,
+                "member_count": len(members),
+                "open_count": open_count,
+                "summary_source": source,
+                "related_topics": related_topics,
+            },
+            "source": "kg_synthesis",
+        },
+    )
+
+
+async def synthesize_topic(
+    graph,
+    topic: str,
+    *,
+    use_llm: bool = True,
+    dry_run: bool = False,
+    writer_id: str = SYNTHESIS_WRITER_ID,
+    min_members: int = MIN_TOPIC_MEMBERS,
+) -> Optional[Dict[str, Any]]:
+    """Build (and unless ``dry_run``, persist) the rollup for one topic.
+
+    Returns a small report dict, or None if the topic has too few members to be
+    worth a rollup.
+    """
+    members = await graph.query(tags=[topic], limit=MAX_MEMBERS_PER_ROLLUP * 3, exclude_archived=True)
+    member_dicts = [m.to_dict(include_details=False) for m in members]
+    # Never let an existing rollup row become a member of itself.
+    member_dicts = [m for m in member_dicts if not is_rollup(m)]
+
+    if len(member_dicts) < min_members:
+        return {"topic": topic, "member_count": len(member_dicts), "action": "skipped", "reason": "below_min_members"}
+
+    related_topics = extract_related_topics(member_dicts, topic)
+    narrative, source = await _generate_narrative(topic, member_dicts, related_topics, use_llm=use_llm)
+    node = _make_rollup_node(topic, member_dicts, narrative, source, related_topics, writer_id=writer_id)
+
+    if not dry_run:
+        await graph.add_discovery(node)
+
+    return {
+        "topic": topic,
+        "rollup_id": node.id,
+        "member_count": len(member_dicts),
+        "related_topics": related_topics,
+        "summary_source": source,
+        "summary": node.summary,
+        "action": "previewed" if dry_run else "synthesized",
+    }
+
+
+async def synthesize_topics(
+    graph,
+    *,
+    topic: Optional[str] = None,
+    limit: int = DEFAULT_TOPIC_LIMIT,
+    min_members: int = MIN_TOPIC_MEMBERS,
+    use_llm: bool = True,
+    dry_run: bool = False,
+    writer_id: str = SYNTHESIS_WRITER_ID,
+) -> Dict[str, Any]:
+    """Run a synthesis pass over the densest topics (or one named topic).
+
+    Bounded by ``limit`` (topics per run) the way cleanup bounds its batch.
+    Each topic is synthesized independently and failures are isolated so one bad
+    topic never aborts the pass.
+    """
+    if topic:
+        candidates = [{"topic": normalize_tags([topic])[0] if normalize_tags([topic]) else topic}]
+    else:
+        from src.db import get_db
+        db = get_db()
+        candidates = await db.kg_topic_candidates(
+            min_members=min_members, limit=limit, exclude_types=[ROLLUP_TYPE]
+        )
+
+    rollups: List[Dict[str, Any]] = []
+    errors: List[Dict[str, str]] = []
+    for cand in candidates:
+        t = cand["topic"]
+        try:
+            report = await synthesize_topic(
+                graph, t, use_llm=use_llm, dry_run=dry_run,
+                writer_id=writer_id, min_members=min_members,
+            )
+            if report:
+                rollups.append(report)
+        except Exception as exc:
+            logger.warning("synthesis failed for topic %r: %s", t, exc)
+            errors.append({"topic": t, "error": str(exc)})
+
+    synthesized = [r for r in rollups if r.get("action") in ("synthesized", "previewed")]
+    return {
+        "topics_considered": len(candidates),
+        "rollups_written": 0 if dry_run else len(synthesized),
+        "dry_run": dry_run,
+        "rollups": rollups,
+        "errors": errors,
+    }

--- a/src/mcp_handlers/schemas/knowledge.py
+++ b/src/mcp_handlers/schemas/knowledge.py
@@ -310,7 +310,7 @@ class CleanupKnowledgeGraphParams(AgentIdentityMixin):
 
 class KnowledgeParams(AgentIdentityMixin):
     """Parameters for knowledge"""
-    action: Literal["store", "search", "get", "list", "update", "details", "note", "cleanup", "stats", "supersede", "audit"] = Field(..., description="Operation to perform")
+    action: Literal["store", "search", "get", "list", "update", "details", "note", "cleanup", "synthesize", "stats", "supersede", "audit"] = Field(..., description="Operation to perform")
     query: Optional[str] = Field(None, description="Search query (for action=search)")
     content: Optional[str] = Field(None, description="Extended content/details (for action=store or action=note)")
     details: Optional[str] = Field(None, description="Extended details for discovery (for action=store). Alias: content")
@@ -323,7 +323,11 @@ class KnowledgeParams(AgentIdentityMixin):
     agent_id: Optional[str] = Field(None, description="Filter by agent (for action=get, search)")
     limit: Optional[int] = Field(None, description="Max results")
     include_details: Optional[bool] = Field(None, description="Include full details inline (for action=search/get)")
-    dry_run: Union[bool, str, None] = Field(None, description="Dry run mode (for action=cleanup)")
+    dry_run: Union[bool, str, None] = Field(None, description="Dry run mode (for action=cleanup, synthesize)")
+    # Synthesis (action=synthesize): roll discoveries up into topic summaries.
+    topic: Optional[str] = Field(None, description="Synthesize just this one tag/topic (for action=synthesize). Omit to sweep the densest topics.")
+    min_members: Optional[int] = Field(None, description="Minimum discoveries a topic needs before it is rolled up (for action=synthesize, default 3)")
+    use_llm: Union[bool, str, None] = Field(None, description="Use the local LLM for the rollup narrative (for action=synthesize, default true; falls back to deterministic when unreachable)")
     # S22 provenance - agent-knowable subset only. See StoreKnowledgeGraphParams
     # above for the dropped-field rationale.
     comparison_key: Optional[str] = Field(None, description="S22 H5 provenance: stable key for comparing the same bounded task across harnesses")
@@ -335,4 +339,6 @@ class KnowledgeParams(AgentIdentityMixin):
     def coerce_booleans(self):
         if isinstance(self.dry_run, str):
             self.dry_run = self.dry_run.lower() in ('true', '1', 'yes')
+        if isinstance(self.use_llm, str):
+            self.use_llm = self.use_llm.lower() in ('true', '1', 'yes')
         return self

--- a/tests/test_consolidated_handlers.py
+++ b/tests/test_consolidated_handlers.py
@@ -435,7 +435,7 @@ class TestKnowledgeHandler:
         data = _parse_response(result)
         valid = sorted(data["recovery"]["valid_actions"])
         expected = sorted(["store", "search", "get", "list", "update",
-                           "details", "note", "cleanup", "stats", "supersede", "audit"])
+                           "details", "note", "cleanup", "synthesize", "stats", "supersede", "audit"])
         assert valid == expected
 
 

--- a/tests/test_kg_synthesis.py
+++ b/tests/test_kg_synthesis.py
@@ -1,0 +1,216 @@
+"""Tests for on-demand knowledge-graph synthesis (Issue #1).
+
+Covers the pure rollup-construction logic and the synthesis orchestration with a
+fake graph backend — no live DB or LLM required. The synthesis pass must:
+  * compound discrete discoveries into a topic rollup row (deterministic id),
+  * persist rollups as ordinary discoveries so there is no schema change,
+  * never let a rollup become a member of itself (no feedback loop),
+  * degrade to a deterministic narrative when the LLM is unreachable,
+  * skip topics below the member threshold, and isolate per-topic failures.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from src.knowledge_graph import DiscoveryNode
+from src.mcp_handlers.knowledge import synthesis as syn
+
+
+def _disc(did: str, summary: str, tags: List[str], *, dtype: str = "note", status: str = "open") -> DiscoveryNode:
+    return DiscoveryNode(id=did, agent_id="a1", type=dtype, summary=summary, tags=tags, status=status)
+
+
+class FakeGraph:
+    """Minimal backend stand-in: query-by-tag + record add_discovery calls."""
+
+    def __init__(self, members_by_tag: Dict[str, List[DiscoveryNode]]):
+        self._members = members_by_tag
+        self.added: List[DiscoveryNode] = []
+
+    async def query(self, tags=None, limit=50, exclude_archived=False, **kwargs) -> List[DiscoveryNode]:
+        tag = tags[0] if tags else None
+        return list(self._members.get(tag, []))
+
+    async def add_discovery(self, discovery: DiscoveryNode) -> None:
+        self.added.append(discovery)
+
+
+# --------------------------------------------------------------------------- #
+# Pure logic
+# --------------------------------------------------------------------------- #
+
+def test_rollup_id_is_deterministic_and_prefixed():
+    assert syn.rollup_id("identity") == "rollup::identity"
+    assert syn.rollup_id("identity") == syn.rollup_id("identity")
+
+
+def test_is_rollup_detects_type_and_id():
+    assert syn.is_rollup({"id": "rollup::x", "type": "topic_rollup"})
+    assert syn.is_rollup({"id": "rollup::x", "type": "note"})  # id prefix alone
+    assert syn.is_rollup({"id": "2026-01-01", "type": "topic_rollup"})  # type alone
+    assert not syn.is_rollup({"id": "2026-01-01", "type": "note"})
+    assert syn.is_rollup(_disc("rollup::y", "s", ["y"], dtype="topic_rollup"))
+
+
+def test_extract_related_topics_excludes_self_and_ranks_by_frequency():
+    members = [
+        {"tags": ["auth", "redis", "cache"]},
+        {"tags": ["auth", "redis"]},
+        {"tags": ["auth", "latency"]},
+    ]
+    related = syn.extract_related_topics(members, "auth")
+    assert "auth" not in related  # the topic itself is never its own cross-ref
+    assert related[0] == "redis"  # most frequent co-occurrence first
+    assert set(related) == {"redis", "cache", "latency"}
+
+
+def test_build_deterministic_summary_carries_counts_and_members():
+    members = [
+        {"summary": "leak in pool", "type": "bug_found", "status": "open"},
+        {"summary": "fixed pool", "type": "bug_fix", "status": "resolved"},
+    ]
+    text = syn.build_deterministic_summary("pool", members, ["redis"])
+    assert "pool" in text
+    assert "2 discoveries" in text
+    assert "1 open" in text
+    assert "redis" in text
+    assert "leak in pool" in text
+
+
+def test_make_rollup_node_shape():
+    members = [_disc(f"d{i}", f"summary {i}", ["topicx"]).to_dict(include_details=False) for i in range(3)]
+    node = syn._make_rollup_node("topicx", members, "A narrative.\nMore.", "llm", ["other"], writer_id="sys")
+    assert node.id == "rollup::topicx"
+    assert node.type == syn.ROLLUP_TYPE
+    assert node.agent_id == "sys"
+    assert "topicx" in node.tags and "rollup" in node.tags
+    assert node.related_to == ["d0", "d1", "d2"]
+    assert node.summary.startswith("[rollup] topicx:")
+    assert "other" in node.details  # related topics surfaced in details
+    assert node.provenance["synthesis"]["summary_source"] == "llm"
+    assert node.provenance["source"] == "kg_synthesis"
+
+
+def test_make_rollup_node_caps_related_to_at_max_members():
+    many = [_disc(f"d{i}", f"s{i}", ["t"]).to_dict(include_details=False) for i in range(syn.MAX_MEMBERS_PER_ROLLUP + 5)]
+    node = syn._make_rollup_node("t", many, "n", "deterministic", [], writer_id="sys")
+    assert len(node.related_to) == syn.MAX_MEMBERS_PER_ROLLUP
+
+
+# --------------------------------------------------------------------------- #
+# Narrative generation
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_generate_narrative_deterministic_when_llm_disabled():
+    members = [{"summary": "x", "type": "note", "status": "open"}]
+    text, source = await syn._generate_narrative("t", members, [], use_llm=False)
+    assert source == "deterministic"
+    assert "t" in text
+
+
+@pytest.mark.asyncio
+async def test_generate_narrative_uses_llm_when_available(monkeypatch):
+    async def fake_llm(*args, **kwargs):
+        return "  Compounded narrative.  "
+
+    monkeypatch.setattr(syn, "call_local_llm", fake_llm)
+    members = [{"summary": "x", "type": "note", "status": "open"}]
+    text, source = await syn._generate_narrative("t", members, ["u"], use_llm=True)
+    assert source == "llm"
+    assert text == "Compounded narrative."  # stripped
+
+
+@pytest.mark.asyncio
+async def test_generate_narrative_falls_back_when_llm_returns_none(monkeypatch):
+    async def fake_llm(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(syn, "call_local_llm", fake_llm)
+    members = [{"summary": "x", "type": "note", "status": "open"}]
+    text, source = await syn._generate_narrative("t", members, [], use_llm=True)
+    assert source == "deterministic"
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_synthesize_topic_skips_below_min_members():
+    graph = FakeGraph({"thin": [_disc("d0", "s", ["thin"])]})
+    report = await syn.synthesize_topic(graph, "thin", use_llm=False, min_members=3)
+    assert report["action"] == "skipped"
+    assert graph.added == []
+
+
+@pytest.mark.asyncio
+async def test_synthesize_topic_persists_and_excludes_existing_rollup():
+    members = [_disc(f"d{i}", f"s{i}", ["auth"]) for i in range(3)]
+    # An existing rollup row tagged 'auth' must not count as a member of itself.
+    members.append(_disc("rollup::auth", "old rollup", ["auth"], dtype="topic_rollup"))
+    graph = FakeGraph({"auth": members})
+
+    report = await syn.synthesize_topic(graph, "auth", use_llm=False)
+    assert report["action"] == "synthesized"
+    assert report["member_count"] == 3  # rollup excluded
+    assert len(graph.added) == 1
+    written = graph.added[0]
+    assert written.id == "rollup::auth"
+    assert "rollup::auth" not in written.related_to
+
+
+@pytest.mark.asyncio
+async def test_synthesize_topic_dry_run_does_not_persist():
+    members = [_disc(f"d{i}", f"s{i}", ["auth"]) for i in range(3)]
+    graph = FakeGraph({"auth": members})
+    report = await syn.synthesize_topic(graph, "auth", use_llm=False, dry_run=True)
+    assert report["action"] == "previewed"
+    assert graph.added == []
+
+
+@pytest.mark.asyncio
+async def test_synthesize_topics_single_topic_skips_db_candidates(monkeypatch):
+    members = [_disc(f"d{i}", f"s{i}", ["auth"]) for i in range(3)]
+    graph = FakeGraph({"auth": members})
+
+    # If a single topic is named, the densest-topics DB aggregate must not run.
+    def _boom():
+        raise AssertionError("kg_topic_candidates should not be called for single-topic synthesis")
+
+    monkeypatch.setattr("src.db.get_db", _boom)
+    result = await syn.synthesize_topics(graph, topic="auth", use_llm=False)
+    assert result["rollups_written"] == 1
+    assert result["dry_run"] is False
+
+
+@pytest.mark.asyncio
+async def test_synthesize_topics_sweeps_candidates_and_isolates_errors(monkeypatch):
+    good = [_disc(f"g{i}", f"s{i}", ["good"]) for i in range(3)]
+    graph = FakeGraph({"good": good})  # "bad" tag absent -> query returns []
+
+    class FakeDB:
+        async def kg_topic_candidates(self, min_members, limit, exclude_types):
+            assert syn.ROLLUP_TYPE in exclude_types
+            return [{"topic": "good"}, {"topic": "bad"}]
+
+    monkeypatch.setattr("src.db.get_db", lambda: FakeDB())
+
+    # Make "bad" blow up inside synthesize_topic to prove failure isolation.
+    real_topic = syn.synthesize_topic
+
+    async def flaky(graph, topic, **kwargs):
+        if topic == "bad":
+            raise RuntimeError("kaboom")
+        return await real_topic(graph, topic, **kwargs)
+
+    monkeypatch.setattr(syn, "synthesize_topic", flaky)
+
+    result = await syn.synthesize_topics(graph, use_llm=False)
+    assert result["topics_considered"] == 2
+    assert result["rollups_written"] == 1
+    assert len(result["errors"]) == 1
+    assert result["errors"][0]["topic"] == "bad"


### PR DESCRIPTION
## Summary

Addresses the two KG gaps surfaced by the LLM-wiki comparison (#44 / PR #45), but **scoped down after review** rather than building both as proposed:

- **Gap 1 — synthesis (built, reframed):** adds `knowledge(action="synthesize")`, a periodic/on-demand pass that compounds discrete discovery rows into rolled-up **topic summaries**, so a cross-referenced, compounded narrative exists *before* query time — not only on read via `search(..., synthesize=true)`. This closes the loop the knowledge-graph skill admits is open ("does not close loops automatically"), using the GraphRAG community-summary pattern.
- **Gap 2 — bi-temporal temporal edges (deferred, documented):** considered and **not built**. See rationale below.

### Why synthesis is on-demand, not on-write

The original issue framed this as a "post-write synthesis pass". For a multi-agent fleet that writes constantly, running an LLM pass on *every* `store`/`note` is the auto-checkin-on-every-trivial-write anti-pattern UNITARES lists as a non-goal — per-write latency, LLM cost, and a fresh noise source (stale auto-generated rollups racing live writes). So synthesis runs like `cleanup`/lint: on demand, or wired to a periodic trigger, reusing the existing store + LLM-delegation machinery. **No per-write cost.**

### Why no schema change

Rollups are persisted as **ordinary discovery rows** — `type="topic_rollup"`, deterministic id `rollup::<topic>`, tagged `rollup`. They upsert in place (compounding across runs, never duplicating) via the existing `ON CONFLICT (id) DO UPDATE` write path, are queryable through normal `search`, and are lifecycle-managed like any other discovery. **Zero migration.** Falls back to a deterministic narrative when no LLM is reachable, so it works headless.

## Usage

```text
knowledge(action="synthesize")                       # sweep densest topics, build rollups
knowledge(action="synthesize", topic="identity")     # one topic
knowledge(action="synthesize", dry_run=true)          # preview, no writes
knowledge(action="synthesize", use_llm=false)         # deterministic narrative only
knowledge(action="search", tags=["rollup"])           # read the rollups back
```

## Why Gap 2 (bi-temporal validity) was deferred

A first-class notion of when a fact became true/false (valid-from / valid-to + observation time, per the Graphiti/Zep model) is a **substrate-level change**: migration, AGE query rewrites, and every read path having to reason about time — for a payoff (point-in-time reconstruction, automatic invalidation) that is speculative for current usage. The existing `superseded` status + `created_at` is an ~80% substitute. The signal to build it is a concrete failure (an agent acting on a stale fact in a way that actually bites). It is recorded as a deliberately deferred idea in `skills/knowledge-graph/SKILL.md`, not a roadmap item.

## Changes

- `src/mcp_handlers/knowledge/synthesis.py` — rollup construction + the synthesis pass (pure helpers + orchestration)
- `src/mcp_handlers/knowledge/handlers.py` — `handle_synthesize_knowledge_graph`; register `topic_rollup` type
- `src/mcp_handlers/consolidated.py`, `schemas/knowledge.py`, `__init__.py` — wire the `synthesize` action + params (`topic`, `min_members`, `use_llm`)
- `src/db/mixins/knowledge_graph.py` — `kg_topic_candidates` read-only aggregate (densest tags)
- `skills/knowledge-graph/SKILL.md` — document `synthesize`; record the temporal-edges deferral
- `tests/test_kg_synthesis.py` — 14 tests (pure logic + orchestration, no live DB/LLM)

## Testing

- New suite: 14/14 pass.
- No regressions across knowledge/migration/handler/schema/router suites (`test_knowledge_graph_*`, `test_migration_registry_versions`, `test_kg_*`, `test_decorators`, `test_tool_stability`, `test_handler_registry`, `test_pydantic_schemas`, `test_extracted_handlers`, `test_admin_handlers`, `test_remaining_modules`, `test_tool_modes` — all green).
- Full DB-backed integration (live Postgres + AGE) wasn't runnable in this environment; CI is the final gate.

https://claude.ai/code/session_01Dz2VWo4AxPyE7eoNzHRo9U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dz2VWo4AxPyE7eoNzHRo9U)_