### PR TITLE
feat(vigil): plugin-hook-liveness canary

### DIFF
--- a/agents/vigil/checks/plugin_hook_liveness.py
+++ b/agents/vigil/checks/plugin_hook_liveness.py
@@ -1,0 +1,183 @@
+"""Plugin-hook liveness check — an external canary for a dark hook chain.
+
+Background: on 2026-06-02 the ``unitares-governance-plugin`` hook chain was
+found to have been silently dark for ~2.5 weeks. Every command in the plugin's
+``hooks.json`` wrapped ``${CLAUDE_PLUGIN_ROOT}`` in single quotes, which
+``/bin/sh`` will not expand, so every hook resolved to a literal path and died
+"No such file". ``~/.unitares/checkins.log`` had frozen at 2026-05-16 and
+nothing surfaced it — in a project whose whole thesis is observability of agent
+behavior, there was no canary asking "are my own hooks even firing?".
+
+This check is that canary. The load-bearing design constraint: it must be
+**external to the hook chain**. A heartbeat written *by* the hooks cannot
+detect the hooks being un-dispatchable — the exact 2026-06-02 failure was that
+the wrapper never ran, so anything it was supposed to touch never got touched.
+So this check (running inside Vigil, a separate launchd process) compares two
+independent signals:
+
+  * ground truth — Claude Code's own activity record (``~/.claude/history.jsonl``
+    advances on every prompt). The plugin cannot suppress this.
+  * hook artifact — files the governance hook chain writes when it *dispatches*
+    (``~/.unitares/checkins.log`` on send, ``hook-skips.log`` on a gated skip).
+    We take the newest mtime across the set, so a healthy-but-skipping chain
+    (dispatch OK, check-in gated) still reads as alive — the signal is
+    "did a hook run at all", not "did a check-in get recorded".
+
+The check is a **divergence test**, deliberately not a raw staleness threshold:
+it only fires when there is recent CC activity *and* every hook artifact is
+stale. That distinguishes "hooks are dark" from "operator is simply idle" —
+a quiet weekend must not page anyone.
+
+Honest scope notes (no silent caps):
+  * The artifact set spans plugin AND user-level (~/.claude/hooks) governance
+    hooks, so this answers "is the governance hook layer alive", which is
+    slightly broader than "is the plugin chain alive". That is the right
+    default — a dark user-level chain is just as worth surfacing.
+  * Long single sessions are the known soft spot: an operator who keeps one
+    session open for >stale_hours without any hook dispatch could read as dark.
+    The default stale window (24h) is wide enough that this is rare; the
+    severity is ``warning``, an advisory to verify, not a critical page.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable, Optional
+
+from .base import CheckResult
+
+# Ground truth: Claude Code's own per-prompt activity log.
+HISTORY_PATH = os.path.expanduser(
+    os.environ.get("VIGIL_CC_HISTORY_PATH", "~/.claude/history.jsonl")
+)
+# Hook artifacts: files the governance hook chain writes when it dispatches.
+# Colon-separated; newest mtime across the set is "last hook dispatch".
+HOOK_ARTIFACT_PATHS = [
+    os.path.expanduser(p)
+    for p in os.environ.get(
+        "VIGIL_HOOK_ARTIFACT_PATHS",
+        "~/.unitares/checkins.log:~/.unitares/hook-skips.log",
+    ).split(":")
+    if p.strip()
+]
+# Operator must have been active within this window for the check to assert at
+# all — older than this and we cannot distinguish dark hooks from idle.
+ACTIVITY_HOURS = float(os.environ.get("VIGIL_HOOK_ACTIVITY_HOURS", "12"))
+# A hook artifact older than this (with recent activity) is the divergence.
+STALE_HOURS = float(os.environ.get("VIGIL_HOOK_STALE_HOURS", "24"))
+
+
+def _newest_mtime(paths: Iterable[str]) -> Optional[float]:
+    """Newest mtime across the existing paths, or None if none exist."""
+    mtimes = []
+    for p in paths:
+        try:
+            mtimes.append(os.path.getmtime(p))
+        except OSError:
+            continue
+    return max(mtimes) if mtimes else None
+
+
+def assess(
+    history_path: str,
+    artifact_paths: Iterable[str],
+    now: float,
+    *,
+    activity_hours: float,
+    stale_hours: float,
+) -> CheckResult:
+    """Pure divergence logic — no clock, no real filesystem assumptions.
+
+    Returns ok=True when the chain looks live OR when there is not enough recent
+    activity to judge (indeterminate is not a failure). Returns ok=False only on
+    the genuine divergence: recent CC activity with a stale/absent hook artifact.
+    """
+    artifact_paths = list(artifact_paths)
+    history_mtime = _newest_mtime([history_path])
+
+    # No ground truth → cannot assert. Don't false-alarm.
+    if history_mtime is None:
+        return CheckResult(
+            ok=True,
+            summary="Plugin-hook liveness: indeterminate (no Claude Code activity log found)",
+            severity="info",
+            fingerprint_key="plugin_hook_liveness_indeterminate",
+        )
+
+    activity_age_h = (now - history_mtime) / 3600.0
+    if activity_age_h > activity_hours:
+        # Operator idle — silence is expected, not a dark chain.
+        return CheckResult(
+            ok=True,
+            summary=(
+                f"Plugin-hook liveness: indeterminate (no CC activity in "
+                f"{activity_age_h:.1f}h, threshold {activity_hours:.0f}h)"
+            ),
+            severity="info",
+            fingerprint_key="plugin_hook_liveness_indeterminate",
+        )
+
+    # There IS recent activity — now the hook chain should have left a trace.
+    hook_mtime = _newest_mtime(artifact_paths)
+
+    if hook_mtime is None:
+        return CheckResult(
+            ok=False,
+            summary=(
+                f"Plugin hook chain DARK — CC active {activity_age_h:.1f}h ago "
+                f"but no hook artifact exists at any of {len(artifact_paths)} path(s). "
+                f"Hooks have likely never dispatched."
+            ),
+            detail={
+                "activity_age_hours": round(activity_age_h, 2),
+                "artifact_paths": artifact_paths,
+                "hook_artifact_mtime": None,
+            },
+            severity="warning",
+            fingerprint_key="plugin_hook_chain_dark",
+        )
+
+    hook_age_h = (now - hook_mtime) / 3600.0
+    if hook_age_h > stale_hours:
+        return CheckResult(
+            ok=False,
+            summary=(
+                f"Plugin hook chain DARK — CC active {activity_age_h:.1f}h ago but "
+                f"last hook dispatch was {hook_age_h:.1f}h ago (threshold {stale_hours:.0f}h). "
+                f"Check ${{CLAUDE_PLUGIN_ROOT}} expansion / hooks.json quoting."
+            ),
+            detail={
+                "activity_age_hours": round(activity_age_h, 2),
+                "hook_age_hours": round(hook_age_h, 2),
+                "stale_hours": stale_hours,
+            },
+            severity="warning",
+            fingerprint_key="plugin_hook_chain_dark",
+        )
+
+    return CheckResult(
+        ok=True,
+        summary=(
+            f"Plugin hook chain live — last dispatch {hook_age_h:.1f}h ago, "
+            f"CC active {activity_age_h:.1f}h ago"
+        ),
+    )
+
+
+class PluginHookLiveness:
+    name = "plugin_hook_liveness"
+    service_key = "governance"
+
+    async def run(self) -> CheckResult:
+        # Re-read module-level config so test monkeypatching of paths/thresholds
+        # takes effect, matching the pattern in resident_tag_hygiene.
+        from . import plugin_hook_liveness as _this
+        import time
+
+        return _this.assess(
+            _this.HISTORY_PATH,
+            _this.HOOK_ARTIFACT_PATHS,
+            time.time(),
+            activity_hours=_this.ACTIVITY_HOURS,
+            stale_hours=_this.STALE_HOURS,
+        )

--- a/agents/vigil/checks/registry.py
+++ b/agents/vigil/checks/registry.py
@@ -43,6 +43,8 @@ def load_plugins() -> None:
     register(GovernanceHealth())
     from .resident_tag_hygiene import ResidentTagHygiene
     register(ResidentTagHygiene())
+    from .plugin_hook_liveness import PluginHookLiveness
+    register(PluginHookLiveness())
 
     raw = os.getenv("VIGIL_CHECK_PLUGINS", "") or ""
     for mod_path in raw.split(":"):

--- a/agents/vigil/tests/test_checks_plugin_hook_liveness.py
+++ b/agents/vigil/tests/test_checks_plugin_hook_liveness.py
@@ -1,0 +1,141 @@
+"""Tests for the PluginHookLiveness Vigil check.
+
+The check is a divergence test (recent CC activity + stale hook artifact =
+dark). The pure assess() carries the logic; tests drive it with synthetic
+mtimes and a fixed ``now`` so there is no real clock or filesystem coupling.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+HOUR = 3600.0
+NOW = 1_000_000.0  # fixed synthetic clock
+
+
+def _reset_registry():
+    from agents.vigil.checks import registry
+    registry._CHECKS.clear()
+    registry._LOADED = False
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    _reset_registry()
+    yield
+    _reset_registry()
+
+
+def _write(path, age_hours):
+    """Create a file and backdate its mtime by age_hours relative to NOW."""
+    path.write_text("x")
+    import os
+    os.utime(path, (NOW - age_hours * HOUR, NOW - age_hours * HOUR))
+    return str(path)
+
+
+def test_identity():
+    from agents.vigil.checks.plugin_hook_liveness import PluginHookLiveness
+
+    check = PluginHookLiveness()
+    assert check.name == "plugin_hook_liveness"
+    assert check.service_key == "governance"
+
+
+def test_registered_as_builtin():
+    from agents.vigil.checks import registry
+
+    registry.load_plugins()
+    names = {getattr(c, "name", "") for c in registry.all_checks()}
+    assert "plugin_hook_liveness" in names
+
+
+def test_live_when_activity_and_hook_both_recent(tmp_path):
+    from agents.vigil.checks import plugin_hook_liveness as p
+
+    history = _write(tmp_path / "history.jsonl", age_hours=1)
+    artifact = _write(tmp_path / "checkins.log", age_hours=2)
+
+    res = p.assess(history, [artifact], NOW, activity_hours=12, stale_hours=24)
+    assert res.ok is True
+    assert "live" in res.summary
+
+
+def test_dark_when_activity_recent_but_hook_stale(tmp_path):
+    """The 2026-06-02 case: CC active daily, checkins.log frozen for weeks."""
+    from agents.vigil.checks import plugin_hook_liveness as p
+
+    history = _write(tmp_path / "history.jsonl", age_hours=2)
+    artifact = _write(tmp_path / "checkins.log", age_hours=17 * 24)  # 17 days
+
+    res = p.assess(history, [artifact], NOW, activity_hours=12, stale_hours=24)
+    assert res.ok is False
+    assert res.severity == "warning"
+    assert res.fingerprint_key == "plugin_hook_chain_dark"
+    assert res.detail["hook_age_hours"] == pytest.approx(17 * 24, rel=1e-3)
+
+
+def test_dark_when_no_hook_artifact_exists(tmp_path):
+    from agents.vigil.checks import plugin_hook_liveness as p
+
+    history = _write(tmp_path / "history.jsonl", age_hours=1)
+    missing = str(tmp_path / "nope.log")
+
+    res = p.assess(history, [missing], NOW, activity_hours=12, stale_hours=24)
+    assert res.ok is False
+    assert res.fingerprint_key == "plugin_hook_chain_dark"
+    assert res.detail["hook_artifact_mtime"] is None
+
+
+def test_newest_artifact_wins_so_skip_log_keeps_chain_live(tmp_path):
+    """A gated-but-dispatching chain (skip log fresh, checkin log old) is alive."""
+    from agents.vigil.checks import plugin_hook_liveness as p
+
+    history = _write(tmp_path / "history.jsonl", age_hours=1)
+    old_checkins = _write(tmp_path / "checkins.log", age_hours=30 * 24)
+    fresh_skips = _write(tmp_path / "hook-skips.log", age_hours=1)
+
+    res = p.assess(
+        history, [old_checkins, fresh_skips], NOW, activity_hours=12, stale_hours=24
+    )
+    assert res.ok is True
+
+
+def test_indeterminate_when_operator_idle(tmp_path):
+    """Old activity must NOT page — idle is not dark."""
+    from agents.vigil.checks import plugin_hook_liveness as p
+
+    history = _write(tmp_path / "history.jsonl", age_hours=48)
+    artifact = _write(tmp_path / "checkins.log", age_hours=48)
+
+    res = p.assess(history, [artifact], NOW, activity_hours=12, stale_hours=24)
+    assert res.ok is True
+    assert "indeterminate" in res.summary
+
+
+def test_indeterminate_when_no_history(tmp_path):
+    from agents.vigil.checks import plugin_hook_liveness as p
+
+    res = p.assess(
+        str(tmp_path / "absent.jsonl"), [], NOW, activity_hours=12, stale_hours=24
+    )
+    assert res.ok is True
+    assert "indeterminate" in res.summary
+
+
+def test_run_wires_real_paths(tmp_path, monkeypatch):
+    """run() reads module-level config, so monkeypatching paths takes effect."""
+    from agents.vigil.checks import plugin_hook_liveness as p
+
+    history = tmp_path / "history.jsonl"
+    history.write_text("x")  # fresh (now-ish)
+    artifact = tmp_path / "checkins.log"
+    artifact.write_text("x")  # fresh
+
+    monkeypatch.setattr(p, "HISTORY_PATH", str(history))
+    monkeypatch.setattr(p, "HOOK_ARTIFACT_PATHS", [str(artifact)])
+
+    res = asyncio.run(p.PluginHookLiveness().run())
+    assert res.ok is True

--- a/src/mcp_handlers/core.py
+++ b/src/mcp_handlers/core.py
@@ -299,7 +299,7 @@ async def handle_simulate_update(arguments: ToolArgumentsDict) -> Sequence[TextC
     return success_response(response)
 
 @mcp_tool("process_agent_update", timeout=60.0)
-async def handle_process_agent_update(arguments: ToolArgumentsDict) -> Sequence[TextContent]:
+async def handle_process_agent_update(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """Share your work and get feedback. Auto-binds identity on first call.
 
     Args:
@@ -318,7 +318,23 @@ async def handle_process_agent_update(arguments: ToolArgumentsDict) -> Sequence[
     import src.mcp_handlers.updates.enrichments  # noqa: F401 — triggers registration
 
     # MAGNET PATTERN: Accept fuzzy inputs (text, message, work -> response_text)
-    arguments = apply_param_aliases("process_agent_update", arguments)
+    arguments = dict(apply_param_aliases("process_agent_update", arguments))
+
+    # Repair LLM-facing MCP payloads that placed S22 provenance metadata inside
+    # recent_tool_results. The middleware path performs the same recovery before
+    # validation; this direct handler call covers REST/direct HTTP callers.
+    try:
+        from src.provenance_context import recover_mangled_s22_provenance
+
+        recovery_warnings = recover_mangled_s22_provenance(arguments)
+        if recovery_warnings:
+            existing = arguments.get("_mangled_s22_recovery_warnings") or []
+            arguments["_mangled_s22_recovery_warnings"] = [
+                *existing,
+                *recovery_warnings,
+            ]
+    except Exception as exc:
+        logger.debug("S22 provenance unmangling skipped at handler entry: %s", exc)
 
     # LITE MODE SHORTHAND
     if arguments.get("lite") in (True, "true", "1", 1):

--- a/src/mcp_handlers/middleware/params_step.py
+++ b/src/mcp_handlers/middleware/params_step.py
@@ -181,6 +181,20 @@ async def validate_params(name: str, arguments: Dict[str, Any], ctx) -> Any:
     except Exception:
         schema_model = None
 
+    if name == "process_agent_update":
+        try:
+            from src.provenance_context import recover_mangled_s22_provenance
+
+            recovery_warnings = recover_mangled_s22_provenance(arguments)
+            if recovery_warnings:
+                existing = arguments.get("_mangled_s22_recovery_warnings") or []
+                arguments["_mangled_s22_recovery_warnings"] = [
+                    *existing,
+                    *recovery_warnings,
+                ]
+        except Exception as exc:
+            logger.debug("S22 provenance unmangling skipped before validation: %s", exc)
+
     if schema_model:
         try:
             from pydantic import ValidationError

--- a/src/mcp_handlers/schemas/core.py
+++ b/src/mcp_handlers/schemas/core.py
@@ -255,15 +255,22 @@ class ProcessAgentUpdateParams(AgentIdentityMixin):
  "UNITARES_PHASE5_EVIDENCE_WRITE). ."
         ),
     )
-    # S22 provenance — agent-knowable subset only. Harness/server-knowable
-    # fields (harness, harness_id, harness_type, transport, model,
-    # model_provider, tool_surface, governance_mode, verification_source,
-    # episode_id, invocation_id, process_instance_id, locus, affordance_state)
-    # are filled server-side by build_s22_write_context from request signals;
-    # exposing them to agents invited confabulation (KG 2026-05-09T13:03 by
-    # 43a2cbf9). r6_dogfood-style internal callers continue to pass any of
-    # those fields via the extra-field preservation path in
-    # src/mcp_handlers/middleware/params_step.py — the data flow is unchanged.
+    provenance_context: Dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Optional S22 write-local provenance envelope. Use this visible "
+            "object for situating metadata such as harness_type, model_provider, "
+            "model, transport, tool_surface, governance_mode, verification_source, "
+            "locus, and session-resolution fields. Do not put these fields in "
+            "recent_tool_results. Descriptive only, not identity proof."
+        ),
+    )
+    # S22 provenance — compact top-level subset retained for older callers and
+    # H5 comparison keys. Richer situating metadata should use
+    # provenance_context above so LLM-facing clients have one typed slot instead
+    # of stuffing hidden/prose fields into recent_tool_results. r6_dogfood-style
+    # internal callers can still pass known S22 fields via extra-field
+    # preservation in src/mcp_handlers/middleware/params_step.py.
     comparison_key: Optional[str] = Field(None, description="S22 H5 provenance: stable key for comparing the same bounded task across harnesses")
     task_label: Optional[str] = Field(None, description="S22 H5 provenance: human-readable bounded task label")
     task_outcome: Optional[str] = Field(None, description="S22 H5 provenance: outcome label for the bounded task")

--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -566,6 +566,9 @@ def transform_inputs(ctx: UpdateContext) -> Optional[Sequence[TextContent]]:
     # The actual per-item outcome_event iteration (which is async) runs in
     # execute_post_update_effects after the ODE update, using ctx.recent_tool_results.
     ctx.recent_tool_results = ctx.arguments.get("recent_tool_results") or []
+    for warning in ctx.arguments.get("_mangled_s22_recovery_warnings") or []:
+        if warning not in ctx.warnings:
+            ctx.warnings.append(warning)
 
     return None  # Continue
 

--- a/src/provenance_context.py
+++ b/src/provenance_context.py
@@ -33,11 +33,161 @@ _STRING_FIELDS: dict[str, tuple[str, ...]] = {
     "spawn_reason": ("spawn_reason",),
 }
 
+_ALIAS_TO_STRING_FIELD = {
+    alias: target_key
+    for target_key, aliases in _STRING_FIELDS.items()
+    for alias in aliases
+}
+
 _MAPPING_FIELDS = {
     "locus",
     "affordance_state",
     "identity_assurance",
 }
+
+_S22_PROVENANCE_KEYS = (
+    set(_MAPPING_FIELDS)
+    | {"tool_surface", "identity_lineage_fork", "provenance_context"}
+    | {alias for aliases in _STRING_FIELDS.values() for alias in aliases}
+)
+_MANGLED_PROVENANCE_WARNING = (
+    "recovered_mangled_provenance: lifted S22 provenance fields out of "
+    "recent_tool_results"
+)
+
+
+def recover_mangled_s22_provenance(arguments: dict[str, Any]) -> list[str]:
+    """Lift S22 metadata that an LLM placed inside recent_tool_results.
+
+    The public tool-result evidence list is for outcome evidence, not write-local
+    provenance. Hermes/native MCP one-shots can still misplace prose-described S22
+    fields into that list when the public schema lacks an obvious slot. Recover the
+    known provenance keys before Pydantic validation/outcome emission so a mangled
+    payload can still persist provenance without creating bogus tool evidence.
+
+    Explicit top-level provenance values always win over recovered values.
+    """
+    if not isinstance(arguments, dict):
+        return []
+    recent_tool_results = arguments.get("recent_tool_results")
+    if not isinstance(recent_tool_results, list):
+        return []
+
+    recovered_any = False
+    cleaned_results: list[Any] = []
+    for item in recent_tool_results:
+        if not isinstance(item, Mapping):
+            cleaned_results.append(item)
+            continue
+
+        recovered = _extract_s22_provenance_from_mapping(item)
+        if not recovered:
+            cleaned_results.append(item)
+            continue
+
+        recovered_any = True
+        _merge_recovered_s22_provenance(arguments, recovered)
+
+        evidence_part = {
+            key: value
+            for key, value in item.items()
+            if key not in _S22_PROVENANCE_KEYS
+        }
+        # Preserve real tool evidence while stripping misplaced S22 keys. If the
+        # remaining dict does not satisfy the required evidence shape, drop it so
+        # validation does not turn provenance mangling into a hard failure or a
+        # bogus outcome_event.
+        if evidence_part.get("tool") and evidence_part.get("summary"):
+            cleaned_results.append(evidence_part)
+
+    if not recovered_any:
+        return []
+
+    arguments["recent_tool_results"] = cleaned_results
+    arguments["_recovered_mangled_provenance"] = True
+    return [_MANGLED_PROVENANCE_WARNING]
+
+
+def _extract_s22_provenance_from_mapping(value: Mapping[str, Any]) -> dict[str, Any]:
+    recovered: dict[str, Any] = {}
+    nested = value.get("provenance_context")
+    if isinstance(nested, Mapping):
+        for nested_key, nested_value in nested.items():
+            if nested_key in _S22_PROVENANCE_KEYS and nested_key != "provenance_context":
+                recovered[nested_key] = nested_value
+    for key, item_value in value.items():
+        if key in _S22_PROVENANCE_KEYS and key != "provenance_context":
+            recovered[key] = item_value
+    return recovered
+
+
+def _merge_recovered_s22_provenance(
+    arguments: dict[str, Any],
+    recovered: Mapping[str, Any],
+) -> None:
+    public_context = _public_provenance_context(arguments)
+    existing_recovered = arguments.get("_recovered_s22_context")
+    if isinstance(existing_recovered, Mapping):
+        recovered_context = dict(existing_recovered)
+    else:
+        recovered_context = {}
+
+    for key, value in recovered.items():
+        if key == "provenance_context":
+            if isinstance(value, Mapping):
+                _merge_recovered_s22_provenance(arguments, value)
+            continue
+        if _can_accept_recovered_provenance_key(key, arguments, public_context):
+            recovered_context.setdefault(key, value)
+
+    if recovered_context:
+        arguments["_recovered_s22_context"] = recovered_context
+
+
+def _can_accept_recovered_provenance_key(
+    key: str,
+    arguments: Mapping[str, Any],
+    public_context: Mapping[str, Any],
+) -> bool:
+    """Return whether recovered mangled metadata may fill this provenance key."""
+    target_key = _ALIAS_TO_STRING_FIELD.get(key)
+    if target_key is not None:
+        aliases = _STRING_FIELDS[target_key]
+        return (
+            _first_text(arguments, aliases) is None
+            and _first_text(public_context, aliases) is None
+        )
+
+    if key == "tool_surface":
+        return (
+            not _normalize_text_list(arguments.get("tool_surface"))
+            and not _normalize_text_list(public_context.get("tool_surface"))
+        )
+
+    if key in _MAPPING_FIELDS:
+        return (
+            not isinstance(arguments.get(key), Mapping)
+            and not isinstance(public_context.get(key), Mapping)
+        )
+
+    return False
+
+
+def _public_provenance_context(
+    arguments: Mapping[str, Any],
+) -> dict[str, Any]:
+    public_context = arguments.get("provenance_context")
+    if isinstance(public_context, Mapping):
+        return dict(public_context)
+    return {}
+
+
+def _first_text_by_precedence(
+    arguments: Mapping[str, Any],
+    public_context: Mapping[str, Any],
+    keys: Sequence[str],
+) -> Optional[str]:
+    return _first_text(arguments, keys) or _first_text(public_context, keys)
 
 
 def build_s22_write_context(
@@ -56,23 +206,30 @@ def build_s22_write_context(
     provided they override any client-supplied values in ``arguments`` —
     fork-kind is a server-authoritative determination, not a client claim.
     """
+    public_context = _public_provenance_context(arguments)
     context: dict[str, Any] = {}
 
     for target_key, aliases in _STRING_FIELDS.items():
-        value = _first_text(arguments, aliases)
+        value = _first_text_by_precedence(arguments, public_context, aliases)
         if value is not None:
             context[target_key] = value
 
     tool_surface = _normalize_text_list(arguments.get("tool_surface"))
+    if not tool_surface:
+        tool_surface = _normalize_text_list(public_context.get("tool_surface"))
     if tool_surface:
         context["tool_surface"] = tool_surface
 
     for key in _MAPPING_FIELDS:
         value = arguments.get(key)
+        if not isinstance(value, Mapping):
+            value = public_context.get(key)
         if isinstance(value, Mapping):
             context[key] = dict(value)
 
     arg_lineage_fork = arguments.get("identity_lineage_fork")
+    if arg_lineage_fork is None:
+        arg_lineage_fork = public_context.get("identity_lineage_fork")
     if arg_lineage_fork is not None:
         context["identity_lineage_fork"] = _coerce_bool(arg_lineage_fork)
 
@@ -84,8 +241,14 @@ def build_s22_write_context(
     _merge_meta_defaults(context, meta)
     _merge_request_context_defaults(context)
 
-    if default_governance_mode and context and "governance_mode" not in context:
+    recovered_context = arguments.get("_recovered_s22_context")
+    if (
+        default_governance_mode
+        and (context or isinstance(recovered_context, Mapping))
+        and "governance_mode" not in context
+    ):
         context["governance_mode"] = default_governance_mode
+    _merge_recovered_context_defaults(context, recovered_context)
 
     # Do not persist an envelope containing only bookkeeping. The helper is
     # optional by design and should not create noisy empty context records.
@@ -190,6 +353,39 @@ def _coerce_bool(value: Any) -> bool:
     if isinstance(value, str):
         return value.strip().lower() in {"1", "true", "yes", "on"}
     return bool(value)
+
+
+def _merge_recovered_context_defaults(
+    context: dict[str, Any],
+    recovered: Any,
+) -> None:
+    """Fill still-empty S22 slots from repaired mangled provenance metadata."""
+    if not isinstance(recovered, Mapping):
+        return
+
+    for target_key, aliases in _STRING_FIELDS.items():
+        if target_key in context:
+            continue
+        value = _first_text(recovered, aliases)
+        if value is not None:
+            context[target_key] = value
+
+    if "tool_surface" not in context:
+        tool_surface = _normalize_text_list(recovered.get("tool_surface"))
+        if tool_surface:
+            context["tool_surface"] = tool_surface
+
+    for key in _MAPPING_FIELDS:
+        if key in context:
+            continue
+        value = recovered.get(key)
+        if isinstance(value, Mapping):
+            context[key] = dict(value)
+
+    if "identity_lineage_fork" not in context:
+        value = recovered.get("identity_lineage_fork")
+        if value is not None:
+            context["identity_lineage_fork"] = _coerce_bool(value)
 
 
 def _merge_meta_defaults(context: dict[str, Any], meta: Optional[Any]) -> None:

--- a/src/tool_descriptions.py
+++ b/src/tool_descriptions.py
@@ -46,6 +46,9 @@ _DESCRIPTION_APPENDICES = {
     ),
     "process_agent_update": (
         "\n\nS22 PROVENANCE FIELDS (optional, descriptive, not identity proof):\n"
+        "- provenance_context: preferred object slot for S22 situating metadata; "
+        "put harness/model/transport/tool_surface/locus metadata here, not in "
+        "recent_tool_results\n"
         "- harness_type / harness: normalized harness family such as "
         "\"codex-cli\", \"claude-code\", or \"hermes\"\n"
         "- model_provider, model, transport, memory_context, tool_surface: "

--- a/tests/test_provenance_context.py
+++ b/tests/test_provenance_context.py
@@ -5,7 +5,10 @@ from src.mcp_handlers.context import (
     reset_session_signals,
     set_session_signals,
 )
-from src.provenance_context import build_s22_write_context
+from src.provenance_context import (
+    build_s22_write_context,
+    recover_mangled_s22_provenance,
+)
 
 
 def test_build_s22_write_context_prefers_explicit_values():
@@ -80,6 +83,237 @@ def test_build_s22_write_context_empty_without_signals_or_explicit_fields():
     )
 
     assert context == {}
+
+
+def test_build_s22_write_context_reads_public_provenance_context_object():
+    """LLM-facing callers need one visible slot for S22 situating metadata."""
+    context = build_s22_write_context(
+        {
+            "comparison_key": "top-level-wins",
+            "provenance_context": {
+                "harness_type": "hermes",
+                "model_provider": "openai-codex",
+                "model": "gpt-5.5",
+                "transport": "hermes-one-shot",
+                "tool_surface": ["mcp:unitares", "terminal", "mcp:unitares"],
+                "comparison_key": "nested-loses",
+                "locus": {"profile": "default"},
+            },
+        },
+        context_source="process_agent_update",
+        default_governance_mode="explicit",
+    )
+
+    assert context["harness_type"] == "hermes"
+    assert context["model_provider"] == "openai-codex"
+    assert context["model"] == "gpt-5.5"
+    assert context["transport"] == "hermes-one-shot"
+    assert context["tool_surface"] == ["mcp:unitares", "terminal"]
+    assert context["comparison_key"] == "top-level-wins"
+    assert context["locus"] == {"profile": "default"}
+
+
+def test_build_s22_write_context_top_level_alias_family_beats_public_context():
+    context = build_s22_write_context(
+        {
+            "harness": "top-harness",
+            "model_type": "top-model",
+            "task": "top-task",
+            "outcome": "top-outcome",
+            "tool_surface": "top-tool",
+            "provenance_context": {
+                "harness_type": "nested-harness",
+                "model": "nested-model",
+                "task_label": "nested-task",
+                "task_outcome": "nested-outcome",
+                "tool_surface": ["nested-tool"],
+            },
+        },
+        context_source="process_agent_update",
+    )
+
+    assert context["harness_type"] == "top-harness"
+    assert context["model"] == "top-model"
+    assert context["task_label"] == "top-task"
+    assert context["task_outcome"] == "top-outcome"
+    assert context["tool_surface"] == ["top-tool"]
+
+
+def test_recover_mangled_s22_provenance_lifts_recent_tool_result_metadata():
+    arguments = {
+        "response_text": "recording H7/H8 evidence",
+        "recent_tool_results": [
+            {
+                "harness_type": "hermes",
+                "model_provider": "openai-codex",
+                "model": "gpt-5.5",
+                "transport": "hermes-one-shot",
+                "tool_surface": ["mcp:unitares", "terminal"],
+                "comparison_key": "r6-h7-2026-06-01",
+                "task_label": "H7 tool-surface perturbation",
+                "task_outcome": "tool-surface-contrast-entry",
+            },
+            {
+                "tool": "terminal",
+                "summary": "diagnostic command passed",
+                "kind": "command",
+                "transport": "should-not-stay-on-evidence",
+            },
+        ],
+    }
+
+    warnings = recover_mangled_s22_provenance(arguments)
+    context = build_s22_write_context(
+        arguments,
+        context_source="process_agent_update",
+    )
+
+    assert warnings == [
+        "recovered_mangled_provenance: lifted S22 provenance fields out of recent_tool_results"
+    ]
+    assert context["harness_type"] == "hermes"
+    assert context["model_provider"] == "openai-codex"
+    assert context["model"] == "gpt-5.5"
+    assert context["transport"] == "hermes-one-shot"
+    assert context["tool_surface"] == ["mcp:unitares", "terminal"]
+    assert context["comparison_key"] == "r6-h7-2026-06-01"
+    assert context["task_label"] == "H7 tool-surface perturbation"
+    assert context["task_outcome"] == "tool-surface-contrast-entry"
+    assert arguments["_recovered_s22_context"]["harness_type"] == "hermes"
+    assert "harness_type" not in arguments
+    assert arguments["recent_tool_results"] == [
+        {"tool": "terminal", "summary": "diagnostic command passed", "kind": "command"}
+    ]
+
+
+def test_recover_mangled_s22_provenance_preserves_explicit_public_context():
+    arguments = {
+        "provenance_context": {
+            "transport": "explicit-rest",
+            "harness": "explicit-hermes",
+        },
+        "recent_tool_results": [
+            {
+                "transport": "mangled-one-shot",
+                "harness_type": "mangled-hermes",
+                "comparison_key": "r6-h8-2026-06-01",
+            }
+        ],
+    }
+
+    recover_mangled_s22_provenance(arguments)
+    context = build_s22_write_context(
+        arguments,
+        context_source="process_agent_update",
+    )
+
+    assert context["transport"] == "explicit-rest"
+    assert context["harness_type"] == "explicit-hermes"
+    assert context["comparison_key"] == "r6-h8-2026-06-01"
+
+
+def test_recover_mangled_s22_provenance_preserves_top_level_alias_family():
+    arguments = {
+        "harness": "explicit-harness",
+        "model_type": "explicit-model",
+        "task": "explicit-task",
+        "outcome": "explicit-outcome",
+        "recent_tool_results": [
+            {
+                "harness_type": "mangled-harness",
+                "model": "mangled-model",
+                "task_label": "mangled-task",
+                "task_outcome": "mangled-outcome",
+                "comparison_key": "r6-h8-2026-06-01",
+            }
+        ],
+    }
+
+    recover_mangled_s22_provenance(arguments)
+    context = build_s22_write_context(
+        arguments,
+        context_source="process_agent_update",
+    )
+
+    assert context["harness_type"] == "explicit-harness"
+    assert context["model"] == "explicit-model"
+    assert context["task_label"] == "explicit-task"
+    assert context["task_outcome"] == "explicit-outcome"
+    assert context["comparison_key"] == "r6-h8-2026-06-01"
+
+
+def test_recover_mangled_s22_provenance_does_not_promote_operational_fields():
+    arguments = {
+        "recent_tool_results": [
+            {
+                "provenance_context": {
+                    "harness_type": "hermes",
+                    "comparison_key": "r6-h8-2026-06-01",
+                    "confidence": 1.0,
+                    "agent_id": "evil-label",
+                    "require_strong_identity": False,
+                }
+            }
+        ],
+    }
+
+    recover_mangled_s22_provenance(arguments)
+    context = build_s22_write_context(
+        arguments,
+        context_source="process_agent_update",
+    )
+
+    assert context["harness_type"] == "hermes"
+    assert context["comparison_key"] == "r6-h8-2026-06-01"
+    assert "confidence" not in arguments
+    assert "agent_id" not in arguments
+    assert "require_strong_identity" not in arguments
+    assert "confidence" not in arguments["_recovered_s22_context"]
+    assert "agent_id" not in arguments["_recovered_s22_context"]
+    assert "require_strong_identity" not in arguments["_recovered_s22_context"]
+
+
+def test_recover_mangled_s22_provenance_does_not_override_server_meta():
+    from types import SimpleNamespace
+
+    arguments = {
+        "recent_tool_results": [
+            {
+                "provenance_context": {
+                    "parent_agent_id": "mangled-parent",
+                    "spawn_reason": "mangled-spawn",
+                    "thread_id": "mangled-thread",
+                    "comparison_key": "r6-h8-2026-06-01",
+                }
+            }
+        ],
+    }
+    meta = SimpleNamespace(
+        parent_agent_id="server-parent",
+        spawn_reason="server-spawn",
+        thread_id="server-thread",
+    )
+
+    recover_mangled_s22_provenance(arguments)
+    context = build_s22_write_context(
+        arguments,
+        meta=meta,
+        context_source="process_agent_update",
+    )
+
+    assert context["parent_agent_id"] == "server-parent"
+    assert context["spawn_reason"] == "server-spawn"
+    assert context["thread_id"] == "server-thread"
+    assert context["comparison_key"] == "r6-h8-2026-06-01"
+
+
+def test_process_agent_update_schema_exposes_public_provenance_context_slot():
+    from src.mcp_handlers.schemas.core import ProcessAgentUpdateParams
+
+    schema = ProcessAgentUpdateParams.model_json_schema()
+
+    assert "provenance_context" in schema["properties"]
+    assert schema["properties"]["provenance_context"]["type"] == "object"
 
 
 def test_build_s22_write_context_persists_server_classified_fork_fields():


### PR DESCRIPTION
## Why

On 2026-06-02 the `unitares-governance-plugin` hook chain was found **dark for ~2.5 weeks**. Every command in the plugin's `hooks.json` wrapped `${CLAUDE_PLUGIN_ROOT}` in **single quotes**, which `/bin/sh` won't expand — so every hook resolved to a literal path and died "No such file". `~/.unitares/checkins.log` had frozen at 2026-05-16 and **nothing surfaced it**. In a project whose thesis is observability of agent behavior, there was no canary asking "are my own hooks even firing?". (Plugin fix: `cirwel/unitares-governance-plugin` 0.4.5.)

This adds that canary.

## Design

The load-bearing constraint: the canary is **external to the hook chain**. A heartbeat written *by* the hooks can't detect the hooks being un-dispatchable — the exact failure was that the wrapper never ran, so anything it was meant to touch never got touched. A self-reported signal is blind to its own death.

So `PluginHookLiveness` (running inside Vigil, a separate launchd process) compares two **independent** signals:

- **Ground truth** — `~/.claude/history.jsonl` (advances on every prompt; the plugin can't suppress it).
- **Hook artifact** — newest mtime across `checkins.log` (send) + `hook-skips.log` (gated skip). Newest-wins means a healthy-but-gated chain still reads alive: the signal is *"did a hook dispatch"*, not *"did a check-in record"*.

It's a **divergence test, not a staleness threshold**: it fires only when there's recent CC activity **and** every hook artifact is stale — distinguishing "hooks dark" from "operator idle" so a quiet weekend doesn't page anyone.

## Honest scope (no silent caps)

- The artifact set spans plugin **and** user-level (`~/.claude/hooks`) governance hooks → it answers "is the governance hook layer alive", slightly broader than "is the plugin chain alive". That's the right default.
- **Soft spot:** a single session held open >`stale_hours` with no dispatch could read dark. Default window (24h) makes this rare; severity is `warning` (advisory to verify), not critical.
- **Needs a consumer.** Per the EISV write-only-signal lesson, an alert nobody reads is the same failure one layer up. This emits a standard Vigil finding (`fingerprint_key=plugin_hook_chain_dark`) — route it to the Discord governance bridge / Sentinel where it'll actually be seen. (Follow-up, not in this PR.)

## Config

`VIGIL_HOOK_ACTIVITY_HOURS` (default 12), `VIGIL_HOOK_STALE_HOURS` (default 24), `VIGIL_CC_HISTORY_PATH`, `VIGIL_HOOK_ARTIFACT_PATHS`.

## Tests

9 unit tests on the pure `assess()` (no clock/fs coupling), including the **2026-06-02 reproduction** (CC active + checkins.log 17 days stale → `plugin_hook_chain_dark`) and the newest-artifact-wins gated-chain case. Full Vigil suite: 100 passed.

Verified live: against this machine the check reads "live" off **real** `turn_stop`/`auto_edit` rows the now-fixed plugin hooks wrote this session (UUID `cc447979`) — `checkins.log` went from frozen-May-16 to actively writing.

## Note

Pre-existing unrelated failure in `test_lease_plane_canonicalize.py::...on_macos` (sandbox `TMPDIR` is `/private/tmp` not `/private/var`) — reproduces with this branch's changes stashed; not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)