### PR TITLE
feat(sdk): thread connect_timeout/connect_retries through GovernanceAgent

### DIFF
--- a/agents/sdk/src/unitares_sdk/agent.py
+++ b/agents/sdk/src/unitares_sdk/agent.py
@@ -97,10 +97,20 @@ class GovernanceAgent:
         cycle_timeout_seconds: float | None = None,
         log_file: Path | None = None,
         max_log_lines: int = 10_000,
+        connect_timeout: float | None = None,
+        connect_retries: int | None = None,
     ):
         self.name = name
         self.mcp_url = mcp_url
         self.timeout = timeout
+        # Connect-handshake resilience, threaded to the per-cycle
+        # GovernanceClient. None lets the client resolve its own defaults
+        # (UNITARES_CONNECT_TIMEOUT / UNITARES_CONNECT_RETRIES env, else
+        # 10s / 1). Residents whose cycle budget differs from the default
+        # (e.g. a tighter cycle_timeout_seconds) can size these explicitly so
+        # worst-case connect time still fits the cycle.
+        self.connect_timeout = connect_timeout
+        self.connect_retries = connect_retries
         # Hard cap on a single cycle in both run_once() and run_forever()
         # (connect + run_cycle + checkin + heartbeat-check). Used by
         # residents whose cycles can stall on an MCP session that never
@@ -207,7 +217,12 @@ class GovernanceAgent:
         completion (success, failure, or timeout).
         """
         async def _cycle() -> None:
-            async with GovernanceClient(mcp_url=self.mcp_url, timeout=self.timeout) as client:
+            async with GovernanceClient(
+                mcp_url=self.mcp_url,
+                timeout=self.timeout,
+                connect_timeout=self.connect_timeout,
+                connect_retries=self.connect_retries,
+            ) as client:
                 await self._ensure_identity(client)
                 result = await self.run_cycle(client)
                 await self._handle_cycle_result(client, result)
@@ -233,7 +248,10 @@ class GovernanceAgent:
 
         async def _iteration() -> None:
             async with GovernanceClient(
-                mcp_url=self.mcp_url, timeout=self.timeout
+                mcp_url=self.mcp_url,
+                timeout=self.timeout,
+                connect_timeout=self.connect_timeout,
+                connect_retries=self.connect_retries,
             ) as client:
                 await self._ensure_identity(client)
                 result = await self.run_cycle(client)

--- a/agents/sdk/tests/test_agent.py
+++ b/agents/sdk/tests/test_agent.py
@@ -490,6 +490,55 @@ class TestCycleTimeout:
                 await agent.run_once()
 
     @pytest.mark.asyncio
+    async def test_connect_params_thread_to_client(self):
+        """connect_timeout/connect_retries reach the per-cycle GovernanceClient."""
+
+        class QuickAgent(GovernanceAgent):
+            async def run_cycle(self, client):
+                return None
+
+        agent = QuickAgent(
+            name="Tuned",
+            mcp_url="http://127.0.0.1:9999/mcp/",
+            connect_timeout=5.0,
+            connect_retries=2,
+        )
+        assert agent.connect_timeout == 5.0
+        assert agent.connect_retries == 2
+
+        with patch("unitares_sdk.agent.GovernanceClient") as mock_cm:
+            mock_client = AsyncMock()
+            mock_cm.return_value.__aenter__.return_value = mock_client
+            mock_cm.return_value.__aexit__.return_value = None
+            with patch.object(QuickAgent, "_ensure_identity", AsyncMock()):
+                await agent.run_once()
+            kwargs = mock_cm.call_args.kwargs
+            assert kwargs["connect_timeout"] == 5.0
+            assert kwargs["connect_retries"] == 2
+
+    @pytest.mark.asyncio
+    async def test_connect_params_default_none_passed_through(self):
+        """Defaults are None so the client resolves its own env/defaults."""
+
+        class QuickAgent(GovernanceAgent):
+            async def run_cycle(self, client):
+                return None
+
+        agent = QuickAgent(name="Default", mcp_url="http://127.0.0.1:9999/mcp/")
+        assert agent.connect_timeout is None
+        assert agent.connect_retries is None
+
+        with patch("unitares_sdk.agent.GovernanceClient") as mock_cm:
+            mock_client = AsyncMock()
+            mock_cm.return_value.__aenter__.return_value = mock_client
+            mock_cm.return_value.__aexit__.return_value = None
+            with patch.object(QuickAgent, "_ensure_identity", AsyncMock()):
+                await agent.run_once()
+            kwargs = mock_cm.call_args.kwargs
+            assert kwargs["connect_timeout"] is None
+            assert kwargs["connect_retries"] is None
+
+    @pytest.mark.asyncio
     async def test_run_forever_respects_cycle_timeout(self):
         """run_forever also bounds each iteration by cycle_timeout_seconds."""
 


### PR DESCRIPTION
Council follow-up to #559.

#559 gave `GovernanceClient` `connect_timeout`/`connect_retries` (bounding the MCP handshake), but `GovernanceAgent` didn't expose them — so residents could only tune the connect bound via `UNITARES_CONNECT_TIMEOUT` / `UNITARES_CONNECT_RETRIES` env vars. The architect flagged this as "a gap, not a blocker."

This surfaces both as `GovernanceAgent` constructor params (default `None` → the client resolves its own env/default), passed at **both** client-construction sites (`run_once` + `run_forever`). A resident whose `cycle_timeout_seconds` differs from the default can now size the connect bound explicitly so worst-case connect time still fits its cycle, without env-var gymnastics.

Tests: two new in `test_agent.py` (explicit values thread through to `GovernanceClient`; `None` defaults pass through cleanly). SDK suite: 186 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)