### PR TITLE
fix(dialectic): stop auto self-review from occupying the reviewer slot

### DIFF
--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -638,7 +638,7 @@ async def handle_request_dialectic_review(arguments: Dict[str, Any]) -> Sequence
         paused_agent_state = {}
 
     # Reviewer selection
-    auto_self_review = False
+    auto_awaiting_reviewer = False
     if reviewer_mode == "self":
         reviewer_agent_id = agent_uuid
     elif reviewer_mode == "auto":
@@ -654,13 +654,20 @@ async def handle_request_dialectic_review(arguments: Dict[str, Any]) -> Sequence
         except Exception as e:
             logger.warning(f"Auto reviewer selection failed: {e}")
             reviewer_agent_id = None
-        # Fall back to self-review if no eligible reviewer found
+        # No eligible independent reviewer found. Leave the reviewer slot OPEN
+        # (reviewer_agent_id=None) so a summoned agent or operator-assigned
+        # first-responder can claim it via submit_antithesis. Previously this
+        # self-assigned the paused agent as its own reviewer, which occupied the
+        # slot and blocked every later reviewer's first-responder path (the
+        # first-responder guard requires reviewer_agent_id is None) — and
+        # self-review is not a genuine antithesis. reviewer_mode="self" remains
+        # the explicit opt-in for deliberate solo self-review.
         if reviewer_agent_id is None:
             logger.info(
-                "[DIALECTIC] No eligible reviewer found; falling back to self-review"
+                "[DIALECTIC] No eligible reviewer found; leaving reviewer slot "
+                "open for first-responder/summon, flagging awaiting_facilitation"
             )
-            reviewer_agent_id = agent_uuid
-            auto_self_review = True
+            auto_awaiting_reviewer = True
     else:
         # Manual mode or unknown - no reviewer assigned
         # First responder can claim via submit_antithesis
@@ -710,9 +717,19 @@ async def handle_request_dialectic_review(arguments: Dict[str, Any]) -> Sequence
     # Cache in-memory for quick access
     ACTIVE_SESSIONS[session.session_id] = session
 
+    if auto_awaiting_reviewer:
+        # No independent reviewer yet; the antithesis is owed by a summoned or
+        # operator-assigned reviewer, not by the paused agent itself.
+        session.awaiting_facilitation = True
+
     # Build response based on reviewer assignment
-    if auto_self_review:
-        note = "No eligible reviewer available — configured for self-review. Use submit_thesis, then submit_antithesis for your counter-perspective."
+    if auto_awaiting_reviewer:
+        note = (
+            "No independent reviewer is currently available. The reviewer slot is "
+            "left open: submit your thesis now, and an independent reviewer "
+            "(summoned or operator-assigned) can claim it via submit_antithesis. "
+            "To proceed solo, recreate the session with reviewer_mode='self'."
+        )
     elif session.reviewer_agent_id and session.reviewer_agent_id != agent_uuid:
         note = f"Reviewer assigned: {session.reviewer_agent_id[:12]}... Use submit_thesis to add your thesis."
     elif session.reviewer_agent_id:

--- a/src/mcp_handlers/dialectic/reviewer.py
+++ b/src/mcp_handlers/dialectic/reviewer.py
@@ -15,9 +15,20 @@ import os
 import random
 import json
 import asyncio
+import contextvars
 
 from src.dialectic_protocol import calculate_authority_score, DialecticPhase, DialecticSession
 from src.logging_utils import get_logger
+
+# Reentrancy guard for the auto-resolve pre-check inside is_agent_in_active_session.
+# select_reviewer() calls is_agent_in_active_session() once per candidate, and
+# auto_resolve_stuck_sessions() calls select_reviewer() — so without this guard a
+# single submit_antithesis first-responder check fans out to O(fleet_size) stuck-
+# session PG scans once UNITARES_AUTOSELECT_REVIEWER is enabled. ContextVar scopes
+# the guard per asyncio task-tree, so concurrent requests don't suppress each other.
+_AUTO_RESOLVE_IN_PROGRESS = contextvars.ContextVar(
+    "_dialectic_auto_resolve_in_progress", default=False
+)
 from .session import (
     SESSION_STORAGE_DIR,
     ACTIVE_SESSIONS,
@@ -139,15 +150,22 @@ async def is_agent_in_active_session(agent_id: str) -> bool:
     import time
     
     # QUICK WIN A: Auto-resolve stuck sessions before checking
-    # This prevents "session conflict" errors when sessions are actually stuck
-    try:
-        from src.mcp_handlers.dialectic.auto_resolve import check_and_resolve_stuck_sessions
-        resolution_result = await check_and_resolve_stuck_sessions()
-        if resolution_result.get("resolved_count", 0) > 0:
-            logger.info(f"Auto-resolved {resolution_result['resolved_count']} stuck session(s) before checking active sessions")
-    except Exception as e:
-        # Best-effort: don't block reviewer selection if auto-resolve fails
-        logger.warning(f"Auto-resolve pre-check failed in is_agent_in_active_session: {e}")
+    # This prevents "session conflict" errors when sessions are actually stuck.
+    # Reentrancy-guarded: auto_resolve -> select_reviewer -> is_agent_in_active_session
+    # would otherwise recurse back here once per candidate. Run the pre-check at
+    # most once per asyncio task-tree.
+    if not _AUTO_RESOLVE_IN_PROGRESS.get():
+        token = _AUTO_RESOLVE_IN_PROGRESS.set(True)
+        try:
+            from src.mcp_handlers.dialectic.auto_resolve import check_and_resolve_stuck_sessions
+            resolution_result = await check_and_resolve_stuck_sessions()
+            if resolution_result.get("resolved_count", 0) > 0:
+                logger.info(f"Auto-resolved {resolution_result['resolved_count']} stuck session(s) before checking active sessions")
+        except Exception as e:
+            # Best-effort: don't block reviewer selection if auto-resolve fails
+            logger.warning(f"Auto-resolve pre-check failed in is_agent_in_active_session: {e}")
+        finally:
+            _AUTO_RESOLVE_IN_PROGRESS.reset(token)
 
     # PRIMARY: Use PostgreSQL for cross-process visibility
     # This is the key fix - CLI and SSE processes now share session state

--- a/tests/test_dialectic_handlers.py
+++ b/tests/test_dialectic_handlers.py
@@ -239,15 +239,24 @@ class TestHandleRequestDialecticReview:
         pg_create.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_happy_path_auto_mode_no_reviewer_falls_back_to_self(
+    async def test_auto_mode_no_reviewer_leaves_slot_open(
         self, mock_server, mock_require_registered, mock_verify_ownership,
         mock_pg_create, mock_is_in_session, mock_context_agent, mock_select_reviewer,
     ):
-        """Auto mode falls back to self-review when no eligible reviewer found."""
+        """Auto mode with no eligible reviewer leaves the slot OPEN (not self-review).
+
+        Regression guard: previously this self-assigned the paused agent as its own
+        reviewer, which occupied the slot and blocked any later summoned/first-
+        responder reviewer (the first-responder guard requires reviewer_agent_id
+        is None). The slot must stay claimable and the session flag
+        awaiting_facilitation.
+        """
         from src.mcp_handlers.dialectic.handlers import handle_request_dialectic_review
+        from src.mcp_handlers.dialectic.session import ACTIVE_SESSIONS
 
         with mock_require_registered("agent-paused"), mock_verify_ownership, \
-             mock_pg_create, mock_is_in_session, mock_context_agent, mock_select_reviewer:
+             mock_pg_create as pg_create, mock_is_in_session, mock_context_agent, \
+             mock_select_reviewer:
             result = await handle_request_dialectic_review({
                 "agent_id": "agent-paused",
                 "_agent_uuid": "agent-paused",
@@ -257,10 +266,42 @@ class TestHandleRequestDialecticReview:
 
         data = parse_result(result)
         assert data["success"] is True
-        # Falls back to self-review instead of leaving session orphaned
+        # Slot left open so a summoned/first-responder reviewer can claim it.
+        assert data["reviewer_agent_id"] is None
+        assert data["awaiting_reviewer"] is True
+        assert "self-review" not in data["note"].lower()
+        assert "submit_antithesis" in data["note"]
+        # Persisted with a NULL reviewer (not the paused agent).
+        assert pg_create.await_args.kwargs["reviewer_agent_id"] is None
+        # Session flagged as awaiting an independent reviewer.
+        session = ACTIVE_SESSIONS[data["session_id"]]
+        assert session.awaiting_facilitation is True
+
+    @pytest.mark.asyncio
+    async def test_explicit_self_review_still_self_assigns(
+        self, mock_server, mock_require_registered, mock_verify_ownership,
+        mock_pg_create, mock_is_in_session, mock_context_agent, mock_select_reviewer,
+    ):
+        """reviewer_mode='self' remains the deliberate solo escape hatch.
+
+        Even with no eligible auto reviewer, an explicit self request must still
+        bind the paused agent as reviewer (the auto path no longer does this
+        silently, but the explicit opt-in is preserved)."""
+        from src.mcp_handlers.dialectic.handlers import handle_request_dialectic_review
+
+        with mock_require_registered("agent-paused"), mock_verify_ownership, \
+             mock_pg_create, mock_is_in_session, mock_context_agent, mock_select_reviewer:
+            result = await handle_request_dialectic_review({
+                "agent_id": "agent-paused",
+                "_agent_uuid": "agent-paused",
+                "reason": "Solo recovery",
+                "reviewer_mode": "self",
+            })
+
+        data = parse_result(result)
+        assert data["success"] is True
         assert data["reviewer_agent_id"] == "agent-paused"
         assert data["awaiting_reviewer"] is False
-        assert "self-review" in data["note"]
 
     @pytest.mark.asyncio
     async def test_agent_not_registered(self, mock_server, mock_context_agent):

--- a/tests/test_dialectic_reviewer_reentrancy.py
+++ b/tests/test_dialectic_reviewer_reentrancy.py
@@ -1,0 +1,71 @@
+"""Reentrancy guard for the auto-resolve pre-check in is_agent_in_active_session.
+
+select_reviewer() calls is_agent_in_active_session() once per candidate, and
+auto_resolve_stuck_sessions() calls select_reviewer(). Without a guard, one
+top-level is_agent_in_active_session() call fans the stuck-session sweep out to
+O(fleet_size) PG scans once UNITARES_AUTOSELECT_REVIEWER is enabled. The guard
+runs the sweep at most once per asyncio task-tree.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+REVIEWER = "src.mcp_handlers.dialectic.reviewer"
+AUTO_RESOLVE = "src.mcp_handlers.dialectic.auto_resolve"
+
+
+@pytest.mark.asyncio
+async def test_auto_resolve_runs_once_at_top_level():
+    """A plain call runs the stuck-session sweep exactly once."""
+    from src.mcp_handlers.dialectic.reviewer import is_agent_in_active_session
+
+    sweep = AsyncMock(return_value={"resolved_count": 0})
+    with patch(f"{AUTO_RESOLVE}.check_and_resolve_stuck_sessions", sweep), \
+         patch(f"{REVIEWER}.pg_is_agent_in_active_session",
+               new_callable=AsyncMock, return_value=False):
+        result = await is_agent_in_active_session("agent-x")
+
+    assert result is False
+    sweep.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_auto_resolve_skipped_when_already_in_progress():
+    """When the guard is already set (i.e. we are nested inside an auto-resolve
+    -> select_reviewer chain), the inner call must NOT re-trigger the sweep."""
+    from src.mcp_handlers.dialectic.reviewer import (
+        is_agent_in_active_session,
+        _AUTO_RESOLVE_IN_PROGRESS,
+    )
+
+    sweep = AsyncMock(return_value={"resolved_count": 0})
+    token = _AUTO_RESOLVE_IN_PROGRESS.set(True)
+    try:
+        with patch(f"{AUTO_RESOLVE}.check_and_resolve_stuck_sessions", sweep), \
+             patch(f"{REVIEWER}.pg_is_agent_in_active_session",
+                   new_callable=AsyncMock, return_value=False):
+            result = await is_agent_in_active_session("agent-x")
+    finally:
+        _AUTO_RESOLVE_IN_PROGRESS.reset(token)
+
+    assert result is False
+    sweep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_guard_resets_after_call():
+    """The guard must not leak across sequential top-level calls."""
+    from src.mcp_handlers.dialectic.reviewer import (
+        is_agent_in_active_session,
+        _AUTO_RESOLVE_IN_PROGRESS,
+    )
+
+    sweep = AsyncMock(return_value={"resolved_count": 0})
+    with patch(f"{AUTO_RESOLVE}.check_and_resolve_stuck_sessions", sweep), \
+         patch(f"{REVIEWER}.pg_is_agent_in_active_session",
+               new_callable=AsyncMock, return_value=False):
+        await is_agent_in_active_session("agent-x")
+        await is_agent_in_active_session("agent-y")
+
+    assert _AUTO_RESOLVE_IN_PROGRESS.get() is False
+    assert sweep.await_count == 2


### PR DESCRIPTION
## Why

Investigating why the dialectic system hangs and never reaches synthesis without manual facilitation, the verified root cause is **no independent second reasoner**: `select_reviewer()` is disabled by default (its candidate pool is ephemeral dead sessions + deterministic resident scripts), so auto mode fell through to a **silent self-review** — it assigned the paused agent as its own reviewer.

That self-assignment occupied the reviewer slot, which **blocks every later reviewer**: the first-responder path in `submit_antithesis` only fires when `reviewer_agent_id is None`. Live evidence: 34/48 historical sessions ran `paused_agent == reviewer`, and one session (`e8417ad0`) has been stuck in `antithesis` as a self-review for 3 days.

This is the no-regrets first step toward summoning a real (heterogeneous) reviewer — it unblocks the slot without yet building any summon/dispatch infrastructure.

## What

- **Auto mode no longer silently self-reviews.** When no eligible independent reviewer is found, the slot is left **open** (`reviewer_agent_id=None`) and the session is flagged `awaiting_facilitation`, so a summoned or operator-assigned reviewer can claim it via `submit_antithesis`. The response note explains this.
- **`reviewer_mode="self"` is preserved** as the explicit, deliberate solo-recovery opt-in (so a genuinely solo agent isn't stranded — it just has to ask).
- **Reentrancy guard** on the auto-resolve pre-check in `is_agent_in_active_session` (`is_agent_in_active_session → auto_resolve → select_reviewer → is_agent_in_active_session`), which would otherwise fan out to O(fleet_size) stuck-session PG scans once `UNITARES_AUTOSELECT_REVIEWER` is enabled. ContextVar-scoped per asyncio task-tree.

## Tests

- Updated the auto-mode regression test: asserts the slot stays open + `awaiting_facilitation`, persisted reviewer is NULL, note omits "self-review".
- Added an explicit-`self`-review escape-hatch test.
- Added reentrancy-guard coverage (runs once at top level; skipped when nested; resets between calls).
- Local: 107 dialectic-suite tests pass; full `test-cache` 4979 pass (1 unrelated pre-existing env failure: `test_lease_plane_canonicalize` asserts `/private/var/` but the sandbox `TMPDIR` is `/private/tmp` — fails identically on clean master, passes under normal CI `TMPDIR`).

## Scope / context

Vehicle (BEAM session-model) and the heterogeneous-reviewer engine design are separate follow-ups; this PR is the slot-unblock only. Does not touch identity, migrations, or the lease-plane.