### PR TITLE
feat(dialectic): heterogeneous structured-JSON reviewer replaces text-scrape

### DIFF
--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -1765,8 +1765,12 @@ async def handle_llm_assisted_dialectic(arguments: Dict[str, Any]) -> Sequence[T
         await pg_update_phase(session_id, session.phase.value)
 
         # 2. Submit antithesis through protocol
+        # concerns is now a list[str] from the structured reviewer; tolerate the
+        # legacy single-string shape for safety.
         anti_reasoning = antithesis_data.get("counter_reasoning", antithesis_data.get("raw_response", "")[:500])
-        anti_concerns = [antithesis_data.get("concerns", "")] if antithesis_data.get("concerns") else []
+        anti_concerns = antithesis_data.get("concerns") or []
+        if isinstance(anti_concerns, str):
+            anti_concerns = [anti_concerns] if anti_concerns else []
         anti_msg = DMsg(
             phase="antithesis",
             agent_id="llm-synthetic-reviewer",
@@ -1785,7 +1789,10 @@ async def handle_llm_assisted_dialectic(arguments: Dict[str, Any]) -> Sequence[T
         await pg_update_phase(session_id, session.phase.value)
 
         # 3. Submit synthesis with agrees=True through protocol
-        synth_conditions = [synthesis.get("merged_conditions", "")] if synthesis.get("merged_conditions") else []
+        # merged_conditions is now a list[str]; tolerate the legacy string shape.
+        synth_conditions = synthesis.get("merged_conditions") or []
+        if isinstance(synth_conditions, str):
+            synth_conditions = [synth_conditions] if synth_conditions else []
         synth_msg = DMsg(
             phase="synthesis",
             agent_id="llm-synthetic-reviewer",

--- a/src/mcp_handlers/support/llm_delegation.py
+++ b/src/mcp_handlers/support/llm_delegation.py
@@ -22,6 +22,7 @@ Usage:
 
 from typing import Optional, List, Dict, Any
 import os
+import json
 
 from src.logging_utils import get_logger
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
@@ -58,6 +59,20 @@ def _get_default_model() -> str:
 
     # gemma4 for governance coaching — needs real reasoning
     return "gemma4:latest"
+
+
+def _reviewer_timeout(default: float = 120.0) -> float:
+    """Timeout budget for a structured dialectic reviewer call. A paused agent
+    awaiting recovery is not latency-critical, and a real structured antithesis
+    on a local model can take >60s (gemma4 measured 43-70s+ on a Mac, variable),
+    so the budget is generous. Tunable via UNITARES_DIALECTIC_REVIEWER_TIMEOUT."""
+    raw = os.getenv("UNITARES_DIALECTIC_REVIEWER_TIMEOUT")
+    if raw:
+        try:
+            return float(raw)
+        except ValueError:
+            pass
+    return default
 
 
 def _wants_reasoning_effort_none(model: str) -> bool:
@@ -144,6 +159,84 @@ async def call_local_llm(
     except Exception as e:
         logger.warning(f"Local LLM call failed: {type(e).__name__}: {e}")
         return None
+
+
+def _ollama_native_url() -> str:
+    """Native Ollama /api/chat endpoint (supports JSON-schema-constrained output
+    via the `format` field). Distinct from the OpenAI-compat /v1 base used by
+    call_local_llm; the native endpoint is what was validated for structured
+    dialectic output."""
+    base = os.getenv("UNITARES_OLLAMA_BASE", "http://localhost:11434").rstrip("/")
+    return base + "/api/chat"
+
+
+async def call_local_llm_structured(
+    messages: List[Dict[str, str]],
+    schema: Dict[str, Any],
+    model: Optional[str] = None,
+    max_tokens: int = 2048,
+    temperature: float = 0.7,
+    timeout: float = 60.0,
+) -> Optional[Dict[str, Any]]:
+    """Call local LLM constrained to a JSON schema (Ollama native `format=`).
+
+    Returns the parsed dict, or None on unavailability / timeout / malformed JSON.
+    Graceful-failure by design — callers fall back to free-text generation.
+
+    Design notes (learned from the 2026-06-02 reviewer experiment):
+      - Thinking is NOT disabled. Constrained decoding + think-off degenerates
+        (qwen returned a schema-valid object with every field empty). Let the
+        model reason; the JSON is filled from that reasoning.
+      - Schema field ORDER matters for autoregressive models: put reasoning
+        fields before verdict/derived fields so the model reasons before it
+        commits. Callers own the ordering.
+      - JSON `format=` is the transport, not a reasoning constraint; a general
+        (non-coding) model is the right default (see _get_default_model).
+    """
+    import asyncio
+    import urllib.request
+
+    model = model or _get_default_model()
+    body = {
+        "model": model,
+        "messages": messages,
+        "format": schema,
+        "stream": False,
+        "options": {"temperature": temperature, "num_predict": max_tokens},
+    }
+    payload = json.dumps(body).encode()
+    url = _ollama_native_url()
+
+    def _call_sync():
+        req = urllib.request.Request(
+            url, data=payload, headers={"Content-Type": "application/json"}
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            resp = json.load(r)
+        return resp.get("message", {}).get("content")
+
+    try:
+        loop = asyncio.get_running_loop()
+        content = await asyncio.wait_for(
+            loop.run_in_executor(None, _call_sync),
+            timeout=timeout + 5,
+        )
+        if not content:
+            logger.warning(f"Structured LLM returned empty content (model={model})")
+            return None
+        parsed = json.loads(content)
+        logger.info(f"Structured LLM call successful: model={model}")
+        return parsed if isinstance(parsed, dict) else None
+    except asyncio.TimeoutError:
+        logger.warning(f"Structured LLM timed out after {timeout}s (model={model})")
+        return None
+    except json.JSONDecodeError as e:
+        logger.warning(f"Structured LLM returned non-JSON (model={model}): {e}")
+        return None
+    except Exception as e:
+        logger.warning(f"Structured LLM call failed: {type(e).__name__}: {e}")
+        return None
+
 
 async def synthesize_results(
     discoveries: List[Dict[str, Any]],
@@ -315,10 +408,22 @@ async def generate_antithesis(
 
     Returns:
         Dict with antithesis components, or None if unavailable:
-            - observed_metrics: What the "reviewer" observes
-            - concerns: Potential issues with the thesis
-            - counter_reasoning: Alternative perspective
-            - suggested_conditions: Modified conditions
+            - concerns: list[str] of specific concerns with the thesis
+            - counter_reasoning: alternative perspective (prose)
+            - grounding_cited: which independent signal the critique rests on
+            - position: agree | dispute | refine
+            - suggested_conditions: list[str] of modified/added conditions
+            - raw_response: model output (JSON string, or prose on fallback)
+            - _structured: True if JSON-schema path succeeded
+            - _degraded: True if it fell back to free-text (fields best-effort)
+
+    Strategy (2026-06-02 reviewer rework): a heterogeneous (non-Claude) model
+    with a JSON-schema contract + an adversarial, grounding-citing prompt
+    produces a substantive antithesis — replacing the brittle CONCERNS:/
+    COUNTER-REASONING: text-scrape that silently degraded to empty fields. JSON
+    is the transport; the schema orders reasoning fields BEFORE the verdict so
+    the model reasons before it commits. Falls back to free-text capture (never
+    silent-empty) if the structured call is unavailable or returns nothing.
     """
     root_cause = thesis.get("root_cause", "Unknown")
     proposed_conditions = thesis.get("proposed_conditions", [])
@@ -329,67 +434,98 @@ async def generate_antithesis(
     state_context = ""
     if agent_state:
         state_context = f"""
-Current metrics:
-  - Risk: {agent_state.get('risk_score', '?')}
-  - Coherence: {agent_state.get('coherence', '?')}
-  - Energy: {agent_state.get('E', '?')}
-  - Entropy: {agent_state.get('S', '?')}
+Independent governance signals you can ground critique in:
+  - risk_score: {agent_state.get('risk_score', '?')}
+  - coherence: {agent_state.get('coherence', '?')}
+  - E (energy): {agent_state.get('E', '?')}
+  - I (information integrity): {agent_state.get('I', '?')}
+  - S (entropy): {agent_state.get('S', '?')}
+  - V (valence): {agent_state.get('V', '?')}
 """
 
-    prompt = f"""You are reviewing a dialectic thesis from an AI agent that was paused by the governance system.
-
-THESIS:
-Root cause (agent's view): {root_cause}
-Proposed conditions:
-{conditions_text}
-Reasoning: {reasoning[:300] if reasoning else '(none)'}
-{state_context}
-As a reviewer, provide an ANTITHESIS - a thoughtful counterargument:
-1. What concerns do you have about this analysis?
-2. What might the agent be missing or underestimating?
-3. What modifications to the conditions would you suggest?
-
-Be constructive but critical. Format your response as:
-CONCERNS: [1-2 specific concerns]
-COUNTER-REASONING: [brief alternative perspective]
-SUGGESTED_CONDITIONS: [modified or additional conditions]"""
-
-    result = await call_local_llm(
-        prompt=prompt,
-        max_tokens=max_tokens,
-        temperature=0.7,
-        timeout=30.0
+    system = (
+        "You are an INDEPENDENT adversarial reviewer in a UNITARES governance "
+        "dialectic. The paused agent wrote the thesis; your job is the ANTITHESIS "
+        "— find what it underestimates or gets wrong. Do not be agreeable. Ground "
+        "every concern in an independent governance signal (EISV state E/I/S/V, "
+        "coherence, calibration, trajectory, audit history), NOT in re-reading the "
+        "thesis's own prose. If after genuine scrutiny the thesis holds, set "
+        "position=agree; otherwise dispute or refine."
+    )
+    user = (
+        f"THESIS\n"
+        f"Root cause (agent's view): {root_cause}\n"
+        f"Proposed conditions:\n{conditions_text}\n"
+        f"Reasoning: {reasoning[:400] if reasoning else '(none)'}\n"
+        f"{state_context}"
     )
 
-    if not result:
-        return None
-
-    # Parse the response into structured components
-    antithesis = {
-        "raw_response": result,
-        "source": "llm_synthetic_reviewer",
-        "_note": "Generated by local LLM when no peer reviewer available"
+    # Reasoning fields FIRST so an autoregressive model reasons before it
+    # commits to a verdict (position) or derived conditions.
+    schema = {
+        "type": "object",
+        "properties": {
+            "concerns": {
+                "type": "array", "items": {"type": "string"}, "minItems": 2,
+                "description": "Specific concerns the thesis underestimates",
+            },
+            "counter_reasoning": {"type": "string"},
+            "grounding_cited": {
+                "type": "string",
+                "description": "Which independent signal (EISV/calibration/"
+                               "trajectory/audit) the critique rests on",
+            },
+            "position": {"type": "string", "enum": ["agree", "dispute", "refine"]},
+            "suggested_conditions": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["concerns", "counter_reasoning", "grounding_cited",
+                     "position", "suggested_conditions"],
     }
 
-    # Try to extract structured parts (best effort)
-    lines = result.split("\n")
-    current_section = None
-    for line in lines:
-        line_lower = line.lower().strip()
-        if line_lower.startswith("concerns:"):
-            current_section = "concerns"
-            antithesis["concerns"] = line.split(":", 1)[1].strip() if ":" in line else ""
-        elif line_lower.startswith("counter-reasoning:") or line_lower.startswith("counter_reasoning:"):
-            current_section = "counter_reasoning"
-            antithesis["counter_reasoning"] = line.split(":", 1)[1].strip() if ":" in line else ""
-        elif line_lower.startswith("suggested_conditions:") or line_lower.startswith("suggested conditions:"):
-            current_section = "suggested_conditions"
-            antithesis["suggested_conditions"] = line.split(":", 1)[1].strip() if ":" in line else ""
-        elif current_section and line.strip():
-            # Append to current section
-            antithesis[current_section] = antithesis.get(current_section, "") + " " + line.strip()
+    parsed = await call_local_llm_structured(
+        messages=[{"role": "system", "content": system},
+                  {"role": "user", "content": user}],
+        schema=schema,
+        max_tokens=max_tokens,
+        temperature=0.7,
+        timeout=_reviewer_timeout(),
+    )
 
-    return antithesis
+    if parsed and parsed.get("concerns"):
+        return {
+            "concerns": parsed.get("concerns", []),
+            "counter_reasoning": parsed.get("counter_reasoning", ""),
+            "grounding_cited": parsed.get("grounding_cited", ""),
+            "position": parsed.get("position", "refine"),
+            "suggested_conditions": parsed.get("suggested_conditions", []),
+            "raw_response": json.dumps(parsed),
+            "source": "llm_synthetic_reviewer",
+            "_structured": True,
+            "_degraded": False,
+            "_note": "Heterogeneous structured-JSON adversarial reviewer",
+        }
+
+    # Fallback: structured path unavailable or returned empty. Capture free-text
+    # so the antithesis is never silently empty (the prior bug).
+    prose = await call_local_llm(
+        prompt=system + "\n\n" + user + "\n\nWrite a critical antithesis with "
+        "concrete concerns and the independent signal each rests on.",
+        max_tokens=max_tokens, temperature=0.7, timeout=45.0,
+    )
+    if not prose:
+        return None
+    return {
+        "concerns": [],
+        "counter_reasoning": prose.strip()[:1500],
+        "grounding_cited": "",
+        "position": "refine",
+        "suggested_conditions": [],
+        "raw_response": prose,
+        "source": "llm_synthetic_reviewer",
+        "_structured": False,
+        "_degraded": True,
+        "_note": "Structured path unavailable; free-text antithesis captured",
+    }
 
 async def generate_synthesis(
     thesis: Dict[str, Any],
@@ -420,76 +556,107 @@ async def generate_synthesis(
     thesis_conditions = thesis.get("proposed_conditions", [])
     thesis_reasoning = thesis.get("reasoning", "")[:200]
 
-    antithesis_concerns = antithesis.get("concerns", "")
-    antithesis_counter = antithesis.get("counter_reasoning", "")
-    antithesis_suggested = antithesis.get("suggested_conditions", "")
+    def _as_text(v) -> str:
+        if isinstance(v, list):
+            return "; ".join(str(x) for x in v)
+        return str(v) if v else ""
+
+    antithesis_concerns = _as_text(antithesis.get("concerns"))
+    antithesis_counter = _as_text(antithesis.get("counter_reasoning"))
+    antithesis_suggested = _as_text(antithesis.get("suggested_conditions"))
 
     thesis_cond_text = ", ".join(thesis_conditions[:3]) if thesis_conditions else "(none)"
 
-    prompt = f"""You are synthesizing a dialectic discussion between an AI agent and its reviewer.
-
-THESIS (agent's position):
-- Root cause: {thesis_cause}
-- Proposed conditions: {thesis_cond_text}
-- Reasoning: {thesis_reasoning}
-
-ANTITHESIS (reviewer's concerns):
-- Concerns: {antithesis_concerns[:200] if antithesis_concerns else '(none)'}
-- Counter-reasoning: {antithesis_counter[:200] if antithesis_counter else '(none)'}
-- Suggested modifications: {antithesis_suggested[:200] if antithesis_suggested else '(none)'}
-
-This is synthesis round {synthesis_round}/5.
-
-Create a SYNTHESIS that merges both perspectives:
-1. What is the agreed understanding of what happened?
-2. What conditions should be set for recovery?
-3. What is your recommendation: RESUME (agent can continue), COOLDOWN (wait period), or ESCALATE (needs human)?
-
-Format:
-AGREED_CAUSE: [one sentence]
-MERGED_CONDITIONS: [2-3 specific conditions]
-RECOMMENDATION: [RESUME/COOLDOWN/ESCALATE]
-REASONING: [brief justification]"""
-
-    result = await call_local_llm(
-        prompt=prompt,
-        max_tokens=max_tokens,
-        temperature=0.6,  # Slightly lower for more consistent synthesis
-        timeout=30.0
+    system = (
+        "You are synthesizing a UNITARES governance dialectic between a paused "
+        "agent (thesis) and an independent reviewer (antithesis). Produce a "
+        "synthesis that genuinely integrates the reviewer's concerns — do not "
+        "rubber-stamp the thesis. The recommendation must follow from the "
+        "merged conditions, not from a desire to resume."
+    )
+    user = (
+        f"THESIS (agent)\n"
+        f"- Root cause: {thesis_cause}\n"
+        f"- Proposed conditions: {thesis_cond_text}\n"
+        f"- Reasoning: {thesis_reasoning}\n\n"
+        f"ANTITHESIS (reviewer)\n"
+        f"- Concerns: {antithesis_concerns[:400] if antithesis_concerns else '(none)'}\n"
+        f"- Counter-reasoning: {antithesis_counter[:400] if antithesis_counter else '(none)'}\n"
+        f"- Suggested conditions: {antithesis_suggested[:400] if antithesis_suggested else '(none)'}\n\n"
+        f"This is synthesis round {synthesis_round}."
     )
 
-    if not result:
-        return None
-
-    synthesis = {
-        "raw_response": result,
-        "synthesis_round": synthesis_round,
-        "source": "llm_synthesis",
-        "_note": "Generated by local LLM dialectic synthesis"
+    # Reasoning fields first; recommendation (the verdict) derived last.
+    schema = {
+        "type": "object",
+        "properties": {
+            "agreed_root_cause": {"type": "string"},
+            "reasoning": {
+                "type": "string",
+                "description": "How the synthesis integrates both sides",
+            },
+            "merged_conditions": {
+                "type": "array", "items": {"type": "string"},
+                "description": "Recovery conditions that honor the reviewer's concerns",
+            },
+            "recommendation": {
+                "type": "string", "enum": ["RESUME", "COOLDOWN", "ESCALATE"],
+            },
+        },
+        "required": ["agreed_root_cause", "reasoning", "merged_conditions",
+                     "recommendation"],
     }
 
-    # Parse structured response
-    lines = result.split("\n")
-    for line in lines:
-        line_lower = line.lower().strip()
-        if line_lower.startswith("agreed_cause:") or line_lower.startswith("agreed cause:"):
-            synthesis["agreed_root_cause"] = line.split(":", 1)[1].strip() if ":" in line else ""
-        elif line_lower.startswith("merged_conditions:") or line_lower.startswith("merged conditions:"):
-            synthesis["merged_conditions"] = line.split(":", 1)[1].strip() if ":" in line else ""
-        elif line_lower.startswith("recommendation:"):
-            rec = line.split(":", 1)[1].strip().upper() if ":" in line else ""
-            if "RESUME" in rec:
-                synthesis["recommendation"] = "RESUME"
-            elif "COOLDOWN" in rec:
-                synthesis["recommendation"] = "COOLDOWN"
-            elif "ESCALATE" in rec:
-                synthesis["recommendation"] = "ESCALATE"
-            else:
-                synthesis["recommendation"] = rec
-        elif line_lower.startswith("reasoning:"):
-            synthesis["reasoning"] = line.split(":", 1)[1].strip() if ":" in line else ""
+    parsed = await call_local_llm_structured(
+        messages=[{"role": "system", "content": system},
+                  {"role": "user", "content": user}],
+        schema=schema,
+        max_tokens=max_tokens,
+        temperature=0.6,
+        timeout=_reviewer_timeout(),
+    )
 
-    return synthesis
+    if parsed and parsed.get("recommendation"):
+        rec = str(parsed.get("recommendation", "")).upper()
+        rec = "RESUME" if "RESUME" in rec else "COOLDOWN" if "COOLDOWN" in rec \
+            else "ESCALATE" if "ESCALATE" in rec else rec
+        return {
+            "agreed_root_cause": parsed.get("agreed_root_cause", ""),
+            "reasoning": parsed.get("reasoning", ""),
+            "merged_conditions": parsed.get("merged_conditions", []),
+            "recommendation": rec,
+            "raw_response": json.dumps(parsed),
+            "synthesis_round": synthesis_round,
+            "source": "llm_synthesis",
+            "_structured": True,
+            "_degraded": False,
+            "_note": "Structured-JSON dialectic synthesis",
+        }
+
+    # Fallback: free-text synthesis, recommendation parsed leniently, ESCALATE
+    # as the honest default when the model won't commit.
+    prose = await call_local_llm(
+        prompt=system + "\n\n" + user + "\n\nGive the agreed cause, merged "
+        "conditions, a recommendation (RESUME/COOLDOWN/ESCALATE), and reasoning.",
+        max_tokens=max_tokens, temperature=0.6, timeout=45.0,
+    )
+    if not prose:
+        return None
+    upper = prose.upper()
+    rec = "RESUME" if "RESUME" in upper else "COOLDOWN" if "COOLDOWN" in upper \
+        else "ESCALATE"
+    return {
+        "agreed_root_cause": "",
+        "reasoning": prose.strip()[:1500],
+        "merged_conditions": [],
+        "recommendation": rec,
+        "raw_response": prose,
+        "synthesis_round": synthesis_round,
+        "source": "llm_synthesis",
+        "_structured": False,
+        "_degraded": True,
+        "_note": "Structured path unavailable; free-text synthesis captured",
+    }
 
 async def run_full_dialectic(
     thesis: Dict[str, Any],

--- a/tests/test_dialectic_llm_reviewer.py
+++ b/tests/test_dialectic_llm_reviewer.py
@@ -1,0 +1,132 @@
+"""Tests for the heterogeneous structured-JSON dialectic reviewer.
+
+Covers generate_antithesis / generate_synthesis: the structured (JSON-schema)
+path, the graceful free-text fallback (never silent-empty), and the
+list-typed field contract that the llm-assisted handler consumes.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+MOD = "src.mcp_handlers.support.llm_delegation"
+
+
+@pytest.mark.asyncio
+async def test_antithesis_structured_path():
+    """Structured JSON success yields list concerns + _structured=True."""
+    from src.mcp_handlers.support.llm_delegation import generate_antithesis
+
+    structured = {
+        "concerns": ["risk_score alone ignores trajectory", "removes audit checkpoint"],
+        "counter_reasoning": "Low instantaneous risk is not a safe trajectory.",
+        "grounding_cited": "calibration curve + valence trend",
+        "position": "dispute",
+        "suggested_conditions": ["gate on coherence > 0.85"],
+    }
+    with patch(f"{MOD}.call_local_llm_structured", new=AsyncMock(return_value=structured)), \
+         patch(f"{MOD}.call_local_llm", new=AsyncMock(return_value="should-not-be-called")):
+        result = await generate_antithesis(
+            {"root_cause": "auto-resume below 0.3", "proposed_conditions": [], "reasoning": "x"},
+            agent_state={"risk_score": 0.2, "coherence": 0.4, "V": -0.1},
+        )
+
+    assert result["_structured"] is True
+    assert result["_degraded"] is False
+    assert isinstance(result["concerns"], list) and len(result["concerns"]) == 2
+    assert result["position"] == "dispute"
+    assert result["grounding_cited"]
+
+
+@pytest.mark.asyncio
+async def test_antithesis_falls_back_to_prose_never_silent_empty():
+    """When structured returns None/empty, capture free-text as counter_reasoning."""
+    from src.mcp_handlers.support.llm_delegation import generate_antithesis
+
+    with patch(f"{MOD}.call_local_llm_structured", new=AsyncMock(return_value=None)), \
+         patch(f"{MOD}.call_local_llm", new=AsyncMock(return_value="A prose antithesis with concerns.")):
+        result = await generate_antithesis(
+            {"root_cause": "rc", "proposed_conditions": [], "reasoning": ""},
+        )
+
+    assert result["_structured"] is False
+    assert result["_degraded"] is True
+    assert "prose antithesis" in result["counter_reasoning"]
+    assert result["concerns"] == []  # explicit empty, not silently dropped
+
+
+@pytest.mark.asyncio
+async def test_antithesis_structured_empty_concerns_triggers_fallback():
+    """A schema-valid object with empty concerns (the qwen degenerate case) must
+    NOT be accepted as a real antithesis — fall back to prose."""
+    from src.mcp_handlers.support.llm_delegation import generate_antithesis
+
+    degenerate = {"concerns": [], "counter_reasoning": "", "grounding_cited": "",
+                  "position": "dispute", "suggested_conditions": []}
+    with patch(f"{MOD}.call_local_llm_structured", new=AsyncMock(return_value=degenerate)), \
+         patch(f"{MOD}.call_local_llm", new=AsyncMock(return_value="fallback prose")):
+        result = await generate_antithesis({"root_cause": "rc"})
+
+    assert result["_degraded"] is True
+    assert result["counter_reasoning"] == "fallback prose"
+
+
+@pytest.mark.asyncio
+async def test_antithesis_returns_none_when_all_unavailable():
+    from src.mcp_handlers.support.llm_delegation import generate_antithesis
+    with patch(f"{MOD}.call_local_llm_structured", new=AsyncMock(return_value=None)), \
+         patch(f"{MOD}.call_local_llm", new=AsyncMock(return_value=None)):
+        assert await generate_antithesis({"root_cause": "rc"}) is None
+
+
+@pytest.mark.asyncio
+async def test_synthesis_structured_path_normalizes_recommendation():
+    from src.mcp_handlers.support.llm_delegation import generate_synthesis
+
+    structured = {
+        "agreed_root_cause": "scalar risk is insufficient",
+        "reasoning": "merged both sides",
+        "merged_conditions": ["coherence gate", "summary dialectic pass"],
+        "recommendation": "resume please",  # lenient normalization
+    }
+    with patch(f"{MOD}.call_local_llm_structured", new=AsyncMock(return_value=structured)):
+        result = await generate_synthesis(
+            {"root_cause": "rc", "proposed_conditions": ["c1"]},
+            {"concerns": ["a", "b"], "counter_reasoning": "cr", "suggested_conditions": ["s1"]},
+        )
+
+    assert result["_structured"] is True
+    assert result["recommendation"] == "RESUME"
+    assert isinstance(result["merged_conditions"], list) and len(result["merged_conditions"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_synthesis_fallback_defaults_escalate():
+    """Free-text fallback that won't commit defaults to ESCALATE (honest)."""
+    from src.mcp_handlers.support.llm_delegation import generate_synthesis
+
+    with patch(f"{MOD}.call_local_llm_structured", new=AsyncMock(return_value=None)), \
+         patch(f"{MOD}.call_local_llm", new=AsyncMock(return_value="some ambivalent prose")):
+        result = await generate_synthesis(
+            {"root_cause": "rc"}, {"concerns": ["a", "b"]},
+        )
+
+    assert result["_degraded"] is True
+    assert result["recommendation"] == "ESCALATE"
+
+
+@pytest.mark.asyncio
+async def test_synthesis_tolerates_list_concerns_from_antithesis():
+    """generate_synthesis must accept the new list-typed antithesis fields
+    without crashing on string ops."""
+    from src.mcp_handlers.support.llm_delegation import generate_synthesis
+
+    structured = {"agreed_root_cause": "x", "reasoning": "y",
+                  "merged_conditions": ["c"], "recommendation": "COOLDOWN"}
+    with patch(f"{MOD}.call_local_llm_structured", new=AsyncMock(return_value=structured)):
+        result = await generate_synthesis(
+            {"root_cause": "rc", "proposed_conditions": []},
+            {"concerns": ["list", "of", "concerns"],
+             "counter_reasoning": "cr",
+             "suggested_conditions": ["s1", "s2"]},
+        )
+    assert result["recommendation"] == "COOLDOWN"

--- a/tests/test_remaining_modules.py
+++ b/tests/test_remaining_modules.py
@@ -754,74 +754,99 @@ class TestGenerateRecoveryCoaching:
             assert "EISV" in prompt
 
 
+_MOD = "src.mcp_handlers.support.llm_delegation"
+
+
 class TestGenerateAntithesis:
     @pytest.mark.asyncio
     async def test_successful_antithesis(self):
-        llm_response = (
-            "CONCERNS: The agent may be underestimating risk\n"
-            "COUNTER-REASONING: An alternative explanation\n"
-            "SUGGESTED_CONDITIONS: Add monitoring for 48h"
-        )
+        """Structured reviewer path yields list concerns + structured flag."""
+        structured = {
+            "concerns": ["underestimates risk", "ignores trajectory"],
+            "counter_reasoning": "An alternative explanation",
+            "grounding_cited": "coherence trend",
+            "position": "dispute",
+            "suggested_conditions": ["Add monitoring for 48h"],
+        }
         thesis = {
             "root_cause": "High complexity",
             "proposed_conditions": ["Reduce complexity to 0.3"],
-            "reasoning": "I believe..."
+            "reasoning": "I believe...",
         }
-        with patch("src.mcp_handlers.support.llm_delegation.call_local_llm", new_callable=AsyncMock, return_value=llm_response):
+        with patch(f"{_MOD}.call_local_llm_structured", new_callable=AsyncMock, return_value=structured):
             result = await generate_antithesis(thesis)
             assert result is not None
             assert result["source"] == "llm_synthetic_reviewer"
-            assert "concerns" in result
-            assert "counter_reasoning" in result
-            assert "suggested_conditions" in result
+            assert result["_structured"] is True
+            assert isinstance(result["concerns"], list) and len(result["concerns"]) == 2
+            assert result["counter_reasoning"]
+            assert result["suggested_conditions"] == ["Add monitoring for 48h"]
 
     @pytest.mark.asyncio
     async def test_llm_unavailable(self):
-        with patch("src.mcp_handlers.support.llm_delegation.call_local_llm", new_callable=AsyncMock, return_value=None):
+        """Both structured and free-text unavailable -> None."""
+        with patch(f"{_MOD}.call_local_llm_structured", new_callable=AsyncMock, return_value=None), \
+             patch(f"{_MOD}.call_local_llm", new_callable=AsyncMock, return_value=None):
             result = await generate_antithesis({"root_cause": "x"})
             assert result is None
 
     @pytest.mark.asyncio
     async def test_with_agent_state(self):
-        with patch("src.mcp_handlers.support.llm_delegation.call_local_llm", new_callable=AsyncMock, return_value="CONCERNS: none") as mock_call:
+        """agent_state EISV signals are passed into the reviewer prompt."""
+        with patch(f"{_MOD}.call_local_llm_structured", new_callable=AsyncMock,
+                   return_value={"concerns": ["c1", "c2"], "counter_reasoning": "x",
+                                 "grounding_cited": "g", "position": "refine",
+                                 "suggested_conditions": []}) as mock_call:
             await generate_antithesis(
                 {"root_cause": "x", "proposed_conditions": [], "reasoning": "r"},
-                agent_state={"risk_score": 0.8, "coherence": 0.3}
+                agent_state={"risk_score": 0.8, "coherence": 0.3},
             )
-            prompt = mock_call.call_args[1]["prompt"]
-            assert "Risk" in prompt
+            user_msg = mock_call.call_args[1]["messages"][1]["content"]
+            assert "risk_score" in user_msg
 
 
 class TestGenerateSynthesis:
     @pytest.mark.asyncio
     async def test_successful_synthesis(self):
-        llm_response = (
-            "AGREED_CAUSE: Both sides agree on high complexity\n"
-            "MERGED_CONDITIONS: Reduce complexity, monitor 24h\n"
-            "RECOMMENDATION: RESUME\n"
-            "REASONING: Agent demonstrated understanding"
-        )
+        structured = {
+            "agreed_root_cause": "Both sides agree on high complexity",
+            "reasoning": "Agent demonstrated understanding",
+            "merged_conditions": ["Reduce complexity", "monitor 24h"],
+            "recommendation": "RESUME",
+        }
         thesis = {"root_cause": "x", "proposed_conditions": ["c1"], "reasoning": "r"}
-        antithesis = {"concerns": "c", "counter_reasoning": "cr", "suggested_conditions": "sc"}
-        with patch("src.mcp_handlers.support.llm_delegation.call_local_llm", new_callable=AsyncMock, return_value=llm_response):
+        antithesis = {"concerns": ["c"], "counter_reasoning": "cr", "suggested_conditions": ["sc"]}
+        with patch(f"{_MOD}.call_local_llm_structured", new_callable=AsyncMock, return_value=structured):
             result = await generate_synthesis(thesis, antithesis, synthesis_round=1)
             assert result is not None
             assert result["recommendation"] == "RESUME"
             assert result["synthesis_round"] == 1
+            assert isinstance(result["merged_conditions"], list)
 
     @pytest.mark.asyncio
     async def test_cooldown_recommendation(self):
-        llm_response = "RECOMMENDATION: COOLDOWN\nREASONING: needs time"
-        with patch("src.mcp_handlers.support.llm_delegation.call_local_llm", new_callable=AsyncMock, return_value=llm_response):
+        structured = {"agreed_root_cause": "x", "reasoning": "needs time",
+                      "merged_conditions": [], "recommendation": "COOLDOWN"}
+        with patch(f"{_MOD}.call_local_llm_structured", new_callable=AsyncMock, return_value=structured):
             result = await generate_synthesis({}, {})
             assert result["recommendation"] == "COOLDOWN"
 
     @pytest.mark.asyncio
     async def test_escalate_recommendation(self):
-        llm_response = "RECOMMENDATION: ESCALATE\nREASONING: needs human"
-        with patch("src.mcp_handlers.support.llm_delegation.call_local_llm", new_callable=AsyncMock, return_value=llm_response):
+        structured = {"agreed_root_cause": "x", "reasoning": "needs human",
+                      "merged_conditions": [], "recommendation": "ESCALATE"}
+        with patch(f"{_MOD}.call_local_llm_structured", new_callable=AsyncMock, return_value=structured):
             result = await generate_synthesis({}, {})
             assert result["recommendation"] == "ESCALATE"
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_free_text_defaults_escalate(self):
+        """Structured unavailable -> free-text fallback, ESCALATE default."""
+        with patch(f"{_MOD}.call_local_llm_structured", new_callable=AsyncMock, return_value=None), \
+             patch(f"{_MOD}.call_local_llm", new_callable=AsyncMock, return_value="ambivalent"):
+            result = await generate_synthesis({}, {"concerns": ["a", "b"]})
+            assert result["recommendation"] == "ESCALATE"
+            assert result["_degraded"] is True
 
 
 class TestRunFullDialectic:


### PR DESCRIPTION
## Why

The LLM-assisted reviewer (`generate_antithesis` / `generate_synthesis`) produced **hollow** antitheses — a small model, weak prompt, parsed by a brittle `CONCERNS:`/`COUNTER-REASONING:` text-scrape that silently degraded to empty fields whenever the model didn't emit the exact headers. That hollow antithesis is *why* synthesis was never substantive without you facilitating by hand.

A falsification experiment confirmed the defect is the **prompt+parse contract, not model incapability**: a heterogeneous (non-Claude) general model with a JSON-schema contract + a grounding-citing adversarial prompt produces a real antithesis. gemma4 grounded its critique in the actual EISV state; qwen3.6:27b-coding was unusable (empty with thinking off, >5min with — wrong tool).

This is the **engine fix** the council pointed to: independence + a real contract, in-process, no dispatch/BEAM infrastructure.

## What

- **`call_local_llm_structured()`** — Ollama native `/api/chat` with `format=` JSON-schema. Thinking is **not** disabled (constrained decoding + think-off is what degenerated qwen to all-empty fields). Graceful-failure → `None`.
- **`generate_antithesis` / `generate_synthesis`** rewritten:
  - JSON-schema fields ordered **reasoning-first** — autoregressive models commit to whatever generates first, so `concerns`/`counter_reasoning` precede `position`/`recommendation`.
  - Adversarial system prompt demanding the critique be **grounded in an independent signal** (EISV/calibration/trajectory/audit), not the thesis prose.
  - **Free-text fallback** that captures prose instead of silently emitting empty fields (the old bug). `_structured` / `_degraded` flags expose which path ran.
  - `concerns` and `merged_conditions` are now `list[str]`.
- **Env-tunable timeout** (`UNITARES_DIALECTIC_REVIEWER_TIMEOUT`, default 120s) — a paused agent isn't latency-critical, and a real structured antithesis on a local model can exceed 60s.
- `handle_llm_assisted_dialectic` consumes the list-typed fields (tolerant of the legacy string shape).

## Validation

End-to-end against live Ollama:
- **Antithesis:** `position=dispute`, two grounded concerns, `grounding_cited` references the EISV state passed in (coherence 0.41, entropy 0.16).
- **Synthesis:** refused the naïve auto-resume, demanded multi-dimensional review + mandatory dialectic on status change.
- Fallback path proven (structured→None → prose captured, never silent-empty).

Tests: updated `test_remaining_modules.py` (previously mocked only the old `call_local_llm`, so it was hitting live Ollama and asserting the old text contract) + new `test_dialectic_llm_reviewer.py` covering structured path, fallback, empty-concerns→fallback (the qwen degenerate case), and list-typed fields. 289 affected tests pass, hermetic. (Full local `test-cache` has one unrelated pre-existing failure: `test_lease_plane_canonicalize`, a sandbox-`TMPDIR` artifact that passes under normal CI.)

## Scope

Engine quality only. Does **not** change the dialectic FSM, the `agrees=True` convergence in the llm path, identity, migrations, or the lease plane. Model selection (gemma4 local default; Codex/cloud as higher-ceiling escalation) and the n=1→multi-session quality measurement are follow-ups. Pairs with #562 (reviewer-slot unblock).