### PR TITLE
[codex] Harden outcome_event DB writes

### DIFF
--- a/src/db/mixins/tool_usage.py
+++ b/src/db/mixins/tool_usage.py
@@ -11,6 +11,20 @@ from src.logging_utils import get_logger
 logger = get_logger(__name__)
 
 
+def _is_missing_outcome_partition(exc: Exception) -> bool:
+    msg = str(exc).lower()
+    return "no partition of relation" in msg and "outcome_events" in msg
+
+
+def _is_missing_verification_source_column(exc: Exception) -> bool:
+    msg = str(exc).lower()
+    class_name = exc.__class__.__name__.lower()
+    return (
+        "verification_source" in msg
+        and ("does not exist" in msg or "undefinedcolumn" in class_name)
+    )
+
+
 class ToolUsageMixin:
     """Tool usage recording, outcome events, and EISV queries."""
 
@@ -68,25 +82,82 @@ class ToolUsageMixin:
         """
         from config.governance_config import GovernanceConfig
         async with self.acquire() as conn:
-            try:
-                outcome_id = await conn.fetchval(
+            def _detail_json(*, legacy_verification_source: bool = False) -> str:
+                payload = dict(detail or {})
+                if legacy_verification_source and verification_source is not None:
+                    payload.setdefault("verification_source", verification_source)
+                return json.dumps(payload)
+
+            async def _insert(*, include_verification_source: bool = True):
+                if include_verification_source:
+                    return await conn.fetchval(
+                        """
+                        INSERT INTO audit.outcome_events
+                            (ts, agent_id, session_id, outcome_type, outcome_score, is_bad,
+                             eisv_e, eisv_i, eisv_s, eisv_v, eisv_phi, eisv_verdict, eisv_coherence, eisv_regime,
+                             detail, epoch, verification_source)
+                        VALUES (now(), $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+                        RETURNING outcome_id
+                        """,
+                        agent_id, session_id, outcome_type, outcome_score, is_bad,
+                        eisv_e, eisv_i, eisv_s, eisv_v, eisv_phi, eisv_verdict, eisv_coherence, eisv_regime,
+                        _detail_json(),
+                        GovernanceConfig.CURRENT_EPOCH,
+                        verification_source,
+                    )
+
+                return await conn.fetchval(
                     """
                     INSERT INTO audit.outcome_events
                         (ts, agent_id, session_id, outcome_type, outcome_score, is_bad,
                          eisv_e, eisv_i, eisv_s, eisv_v, eisv_phi, eisv_verdict, eisv_coherence, eisv_regime,
-                         detail, epoch, verification_source)
-                    VALUES (now(), $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+                         detail, epoch)
+                    VALUES (now(), $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
                     RETURNING outcome_id
                     """,
                     agent_id, session_id, outcome_type, outcome_score, is_bad,
                     eisv_e, eisv_i, eisv_s, eisv_v, eisv_phi, eisv_verdict, eisv_coherence, eisv_regime,
-                    json.dumps(detail or {}),
+                    _detail_json(legacy_verification_source=True),
                     GovernanceConfig.CURRENT_EPOCH,
-                    verification_source,
                 )
-                return str(outcome_id)
-            except Exception:
-                return None
+
+            try:
+                outcome_id = await _insert()
+                return str(outcome_id) if outcome_id else None
+            except Exception as exc:
+                last_exc = exc
+
+            if _is_missing_outcome_partition(last_exc):
+                logger.warning(
+                    "record_outcome_event encountered missing outcome_events partition; "
+                    "running audit.partition_maintenance() before one retry"
+                )
+                try:
+                    await conn.fetchval("SELECT audit.partition_maintenance()")
+                    outcome_id = await _insert()
+                    return str(outcome_id) if outcome_id else None
+                except Exception as retry_exc:
+                    last_exc = retry_exc
+
+            if _is_missing_verification_source_column(last_exc):
+                logger.warning(
+                    "record_outcome_event found audit.outcome_events without "
+                    "verification_source column; retrying legacy insert without "
+                    "optional provenance column"
+                )
+                try:
+                    outcome_id = await _insert(include_verification_source=False)
+                    return str(outcome_id) if outcome_id else None
+                except Exception as retry_exc:
+                    last_exc = retry_exc
+
+            logger.error(
+                "record_outcome_event failed for agent=%s outcome_type=%s: %s",
+                agent_id,
+                outcome_type,
+                last_exc,
+            )
+            return None
 
     async def get_recent_outcomes(
         self,

--- a/tests/test_outcome_events_verification_source.py
+++ b/tests/test_outcome_events_verification_source.py
@@ -15,6 +15,7 @@ source / claimant / strength axes; v2 redesign is tracked separately in
 project_outcome-verification-taxonomy-redesign. These tests pin the v1
 classifications so the v2 work can be a deliberate motion, not silent drift.
 """
+import json
 import sys
 from pathlib import Path
 from contextlib import ExitStack
@@ -27,6 +28,7 @@ project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
 from tests.helpers import make_agent_meta, make_mock_server, make_monitor
+from src.db.mixins.tool_usage import ToolUsageMixin
 from src.mcp_handlers.updates.context import UpdateContext
 
 
@@ -217,3 +219,81 @@ def test_mixin_record_outcome_event_accepts_verification_source():
     assert "verification_source" in insert_block, (
         "verification_source must appear in the INSERT column list, not just the docstring"
     )
+
+
+class _FakeAcquire:
+    def __init__(self, conn):
+        self.conn = conn
+
+    async def __aenter__(self):
+        return self.conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeOutcomeConn:
+    def __init__(self, effects):
+        self.effects = list(effects)
+        self.calls = []
+
+    async def fetchval(self, sql, *args):
+        self.calls.append((sql, args))
+        effect = self.effects.pop(0)
+        if isinstance(effect, Exception):
+            raise effect
+        return effect
+
+
+class _OutcomeMixinHarness(ToolUsageMixin):
+    def __init__(self, conn):
+        self.conn = conn
+
+    def acquire(self):
+        return _FakeAcquire(self.conn)
+
+
+@pytest.mark.asyncio
+async def test_mixin_retries_legacy_insert_when_verification_source_column_missing():
+    conn = _FakeOutcomeConn([
+        Exception('column "verification_source" of relation "outcome_events" does not exist'),
+        "legacy-outcome-id",
+    ])
+    db = _OutcomeMixinHarness(conn)
+
+    result = await db.record_outcome_event(
+        agent_id="agent-1",
+        outcome_type="task_completed",
+        is_bad=False,
+        verification_source="agent_reported_tool_result",
+    )
+
+    assert result == "legacy-outcome-id"
+    assert len(conn.calls) == 2
+    assert "verification_source" in conn.calls[0][0]
+    assert "verification_source" not in conn.calls[1][0]
+    legacy_detail = json.loads(conn.calls[1][1][13])
+    assert legacy_detail["verification_source"] == "agent_reported_tool_result"
+
+
+@pytest.mark.asyncio
+async def test_mixin_runs_partition_maintenance_once_for_missing_outcome_partition():
+    conn = _FakeOutcomeConn([
+        Exception('no partition of relation "outcome_events" found for row'),
+        '{"outcome_events_current": "Created partition outcome_events_2026_06"}',
+        "partition-retry-outcome-id",
+    ])
+    db = _OutcomeMixinHarness(conn)
+
+    result = await db.record_outcome_event(
+        agent_id="agent-1",
+        outcome_type="task_completed",
+        is_bad=False,
+        verification_source="agent_reported_tool_result",
+    )
+
+    assert result == "partition-retry-outcome-id"
+    assert len(conn.calls) == 3
+    assert "verification_source" in conn.calls[0][0]
+    assert "SELECT audit.partition_maintenance()" == conn.calls[1][0]
+    assert "verification_source" in conn.calls[2][0]


### PR DESCRIPTION
## Summary
- Harden `record_outcome_event` so outcome writes no longer collapse to an opaque `DB_ERROR` on known operational drift.
- Retry once after `audit.partition_maintenance()` when PostgreSQL reports a missing `audit.outcome_events` partition.
- Fall back to a legacy insert when the optional `verification_source` column is absent, preserving that value in `detail` JSONB for older schemas.
- Log the underlying DB exception for remaining failures instead of silently returning `None`.

## KG
- Addresses KG discovery `2026-06-01T03:51:09.274831+00:00` (`outcome_event(task_completed)` returned `DB_ERROR` twice during KG grievance closure).

## Validation
- `pytest tests/test_outcome_events_verification_source.py tests/test_outcome_calibration.py tests/test_outcome_events_classification.py tests/test_phases_phase5_evidence.py tests/integration/test_outcome_event_calibration_wiring.py -q` -> 60 passed
- `./scripts/dev/test-cache.sh` -> 9121 passed, 35 skipped, 2 warnings
- `./scripts/dev/test-cache.sh --staged` -> 9121 passed, 35 skipped, 2 warnings
- pre-push smoke -> 138 passed, 8437 deselected; doc health clear
