### PR TITLE
fix(resident-progress): retire sentinel entry (moved to BEAM)

### DIFF
--- a/src/resident_progress/registry.py
+++ b/src/resident_progress/registry.py
@@ -45,7 +45,13 @@ RESIDENT_PROGRESS_REGISTRY: dict[str, ResidentConfig] = {
     "watcher":    ResidentConfig("watcher_findings", "rows_any",     timedelta(hours=6),     1, expected_cadence_s=None),
     "steward":    ResidentConfig("eisv_sync_rows",   "rows_written", timedelta(minutes=30),  1, expected_cadence_s=300),
     "chronicler": ResidentConfig("metrics_series",   "rows_written", timedelta(hours=26),    1, expected_cadence_s=86400),
-    "sentinel":   ResidentConfig("sentinel_pulse",   "latest_count", timedelta(minutes=30),  1, expected_cadence_s=60),
+    # Sentinel migrated to the Elixir/BEAM runtime (com.unitares.sentinel-beam),
+    # which does not post record_progress_pulse — so the sentinel_pulse source
+    # read a permanent 0 and the probe false-flagged sentinel as "flat-candidate"
+    # against a 60s expected cadence. Retired from the progress probe: BEAM
+    # sentinel liveness shows via the resident strip + its launchd KeepAlive, and
+    # its findings still feed Vigil. To re-cover it here, re-add an entry and have
+    # the BEAM sentinel emit record_progress_pulse (the source is still wired).
 }
 
 

--- a/tests/resident_progress/test_registry.py
+++ b/tests/resident_progress/test_registry.py
@@ -14,9 +14,11 @@ from src.resident_progress.registry import (
 )
 
 
-def test_registry_has_five_residents():
+def test_registry_has_four_residents():
+    # Sentinel was retired when it moved to the BEAM runtime (it no longer
+    # posts record_progress_pulse). See registry.py for the rationale.
     assert set(RESIDENT_PROGRESS_REGISTRY) == {
-        "vigil", "watcher", "steward", "chronicler", "sentinel"
+        "vigil", "watcher", "steward", "chronicler"
     }
 
 
@@ -45,7 +47,6 @@ def test_registry_cadences_match_resident_natural_periods():
         label: cfg.expected_cadence_s
         for label, cfg in RESIDENT_PROGRESS_REGISTRY.items()
     }
-    assert cadences["sentinel"] == 60       # continuous loop
     assert cadences["steward"] == 300       # 5-min EISV sync
     assert cadences["vigil"] == 1800        # 30-min launchd cron
     assert cadences["watcher"] is None      # event-driven
@@ -102,7 +103,7 @@ def test_is_event_driven_label_only_true_for_watcher():
     # (residents.js, agents.js) — they consume this flag to suppress
     # "Inactive" badges and pick the right pill style.
     assert is_event_driven_label("watcher") is True
-    for label in ("vigil", "steward", "chronicler", "sentinel"):
+    for label in ("vigil", "steward", "chronicler"):
         assert is_event_driven_label(label) is False, label
 
 


### PR DESCRIPTION
## Why
The Resident Progress panel showed **sentinel** as a permanent amber `flat-candidate (0/1)`. Root cause (traced live): the `sentinel_pulse` source reads rows from `record_progress_pulse`, which **only the Python Sentinel posted** — and Sentinel was **intentionally migrated to the Elixir/BEAM runtime** (`com.unitares.sentinel-beam`). The BEAM sentinel doesn't emit `record_progress_pulse`, so the source reads a perpetual 0 and the probe flags a healthy resident as flat against its 60s cadence. A false alarm for a deliberate substrate move.

## Fix
Retire the `sentinel` entry from `RESIDENT_PROGRESS_REGISTRY`. This is the scoped "fix the panel":
- BEAM sentinel liveness still surfaces via the **resident strip** (green chip) + its **launchd KeepAlive**, and its **KG findings still feed Vigil** — so we're not blind to it.
- `SentinelPulseSource` stays registered (harmless) so the panel can be **re-lit later** by re-adding the entry once the BEAM sentinel emits `record_progress_pulse`.
- Not done here (deliberately out of scope): wiring a BEAM-output source. That's a feature, not a panel fix.

## Tests
Updated `tests/resident_progress/test_registry.py` (resident set 5→4, dropped the sentinel cadence/event-driven assertions). Full `tests/resident_progress/`: **71 passed**. `test_sentinel_source.py` still green — the source class is intact.

## Deploy note
The probe runs inside the governance-MCP server, so the panel keeps showing the stale amber until the server restarts on this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)