### PR TITLE
[codex] housekeeping inventory and continuity cleanup

### DIFF
--- a/CODEX_START.md
+++ b/CODEX_START.md
@@ -94,7 +94,9 @@ python3 scripts/dev/housekeeping_inventory.py
 
 It reports dirty or detached worktrees, gone-upstream branches, old stashes,
 open GitHub PRs, and unresolved Watcher output. For automation, add
-`--fail-on-attention` to exit nonzero when any reported attention item exists.
+`--fail-on-attention` to exit nonzero when any reported attention item exists,
+or narrow it with comma-separated categories such as
+`--fail-on-attention worktrees,watcher`.
 
 ## Commands
 

--- a/CODEX_START.md
+++ b/CODEX_START.md
@@ -84,6 +84,18 @@ Do not treat every file edit as a governance event. High-signal check-ins are mo
 - `continuity_token_supported`
 - `identity_assurance` when an update response includes it
 
+## Housekeeping
+
+Use the read-only inventory before starting or resuming messy local work:
+
+```bash
+python3 scripts/dev/housekeeping_inventory.py
+```
+
+It reports dirty or detached worktrees, gone-upstream branches, old stashes,
+open GitHub PRs, and unresolved Watcher output. For automation, add
+`--fail-on-attention` to exit nonzero when any reported attention item exists.
+
 ## Commands
 
 - `/governance-start` to create or declare lineage and refresh local continuity state

--- a/scripts/client/onboard_helper.py
+++ b/scripts/client/onboard_helper.py
@@ -28,6 +28,7 @@ import sys
 import tempfile
 import urllib.error
 import urllib.request
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
@@ -74,27 +75,81 @@ def _post_json(url: str, payload: dict, timeout: float, token: str | None) -> di
         return {}
 
 
-def _read_cache(workspace: Path, slot: str | None = None) -> dict:
-    """Read the cache for this slot, falling back to the legacy unslotted file.
+def _read_cache_file(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) and data else {}
 
-    Fallback exists so existing single-process flows (no slot supplied) keep
-    working unchanged, and so a slotted hook can still pick up continuity
-    state written by an earlier unslotted run.
-    """
-    primary = workspace / CACHE_DIR / _slot_filename(slot)
-    candidates = [primary]
-    if slot:
-        candidates.append(workspace / CACHE_DIR / CACHE_FILE)
-    for path in candidates:
-        if not path.exists():
-            continue
+
+def _parse_cache_timestamp(payload: dict, path: Path) -> float:
+    raw = payload.get("updated_at")
+    if isinstance(raw, str) and raw:
         try:
-            data = json.loads(path.read_text(encoding="utf-8"))
+            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed.timestamp()
         except Exception:
+            pass
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def _cache_lineage_uuid(payload: dict) -> str:
+    for key in ("uuid", "agent_uuid"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _session_cache_paths(cache_dir: Path) -> list[Path]:
+    if not cache_dir.is_dir():
+        return []
+    paths: list[Path] = []
+    for path in cache_dir.iterdir():
+        if not path.is_file():
             continue
-        if isinstance(data, dict) and data:
-            return data
-    return {}
+        if path.name == CACHE_FILE:
+            paths.append(path)
+        elif path.name.startswith("session-") and path.name.endswith(".json"):
+            paths.append(path)
+    return paths
+
+
+def _read_cache(workspace: Path, slot: str | None = None) -> dict:
+    """Read the best local lineage candidate for this process.
+
+    The exact slot wins first. If a fresh process has a new slot, fall back to
+    the newest valid session cache in the workspace, including legacy
+    ``session.json``. This mirrors ``session_cache.py list`` and avoids the
+    common Codex/adapter failure mode where prior lineage exists only in a
+    different slotted file.
+    """
+    cache_dir = workspace / CACHE_DIR
+    primary = cache_dir / _slot_filename(slot)
+    primary_payload = _read_cache_file(primary)
+    if _cache_lineage_uuid(primary_payload):
+        return primary_payload
+
+    candidates: list[tuple[float, dict]] = []
+    for path in _session_cache_paths(cache_dir):
+        if path == primary:
+            continue
+        payload = _read_cache_file(path)
+        if _cache_lineage_uuid(payload):
+            candidates.append((_parse_cache_timestamp(payload, path), payload))
+
+    if not candidates:
+        return primary_payload
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    return candidates[0][1]
 
 
 def _write_cache(workspace: Path, payload: dict, slot: str | None = None) -> None:
@@ -267,6 +322,7 @@ def run_onboard(
     # caller can use them transiently within the same process if needed.
     # S20.3 — mirrors the plugin helper's v2 cache schema (session_cache.py).
     new_cache = {
+        "schema_version": 2,
         "server_url": server_url,
         "agent_name": agent_name,
         "slot": slot or "",
@@ -275,6 +331,7 @@ def run_onboard(
         "client_session_id": parsed.get("client_session_id", ""),
         "session_resolution_source": parsed.get("session_resolution_source", ""),
         "display_name": parsed.get("display_name", ""),
+        "updated_at": datetime.now(timezone.utc).isoformat(),
     }
     if parent_agent_id:
         new_cache["parent_agent_id"] = parent_agent_id

--- a/scripts/dev/housekeeping_inventory.py
+++ b/scripts/dev/housekeeping_inventory.py
@@ -120,6 +120,33 @@ class AttentionSummary:
         )
 
 
+ATTENTION_KEYS = (
+    "dirty_worktrees",
+    "detached_worktrees",
+    "worktree_status_errors",
+    "gone_upstream_branches",
+    "merged_branch_candidates",
+    "old_stashes",
+    "open_github_prs",
+    "watcher_unresolved_lines",
+    "probe_errors",
+)
+
+ATTENTION_GROUPS = {
+    "all": ATTENTION_KEYS,
+    "worktrees": (
+        "dirty_worktrees",
+        "detached_worktrees",
+        "worktree_status_errors",
+    ),
+    "branches": ("gone_upstream_branches", "merged_branch_candidates"),
+    "stashes": ("old_stashes",),
+    "github": ("open_github_prs",),
+    "watcher": ("watcher_unresolved_lines",),
+    "probes": ("probe_errors",),
+}
+
+
 def run_cmd(
     args: list[str],
     cwd: Path | str,
@@ -604,6 +631,36 @@ def attention_summary(inventory: Inventory) -> AttentionSummary:
     )
 
 
+def parse_attention_keys(raw: str | None) -> tuple[str, ...]:
+    if not raw:
+        return ()
+
+    selected: list[str] = []
+    unknown: list[str] = []
+    for part in raw.split(","):
+        key = part.strip().replace("-", "_")
+        if not key:
+            continue
+        if key in ATTENTION_GROUPS:
+            selected.extend(ATTENTION_GROUPS[key])
+        elif key in ATTENTION_KEYS:
+            selected.append(key)
+        else:
+            unknown.append(part.strip())
+
+    if unknown:
+        choices = ", ".join(sorted((*ATTENTION_GROUPS.keys(), *ATTENTION_KEYS)))
+        raise ValueError(
+            f"unknown attention key(s): {', '.join(unknown)}; choices: {choices}"
+        )
+
+    return tuple(dict.fromkeys(selected))
+
+
+def selected_attention_total(summary: AttentionSummary, keys: tuple[str, ...]) -> int:
+    return sum(getattr(summary, key) for key in keys)
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--cwd", default=".", help="repo directory to inspect")
@@ -621,8 +678,15 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--json", action="store_true", help="emit JSON")
     parser.add_argument(
         "--fail-on-attention",
-        action="store_true",
-        help="exit 1 when any attention item is present; default is report-only",
+        nargs="?",
+        const="all",
+        default="",
+        metavar="KEYS",
+        help=(
+            "exit 1 when selected attention items are present; optional KEYS is "
+            "comma-separated and may include all, worktrees, branches, stashes, "
+            "github, watcher, probes, or exact attention keys"
+        ),
     )
     parser.add_argument("--limit", type=int, default=20, help="max rows per text section")
     parser.add_argument("--no-github", action="store_true", help="skip gh PR probe")
@@ -646,12 +710,17 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    try:
+        fail_keys = parse_attention_keys(args.fail_on_attention)
+    except ValueError as exc:
+        parser.error(str(exc))
+
     inventory = build_inventory(args)
     if args.json:
         print(json.dumps(to_jsonable(inventory), indent=2, sort_keys=True))
     else:
         print_text_report(inventory, limit=args.limit)
-    if args.fail_on_attention and attention_summary(inventory).total:
+    if fail_keys and selected_attention_total(attention_summary(inventory), fail_keys):
         return 1
     return 0
 

--- a/scripts/dev/housekeeping_inventory.py
+++ b/scripts/dev/housekeeping_inventory.py
@@ -1,0 +1,596 @@
+#!/usr/bin/env python3
+"""Read-only UNITARES worktree housekeeping inventory.
+
+Reports the local residue that tends to make agent sessions drift:
+
+- dirty or detached worktrees
+- local branches whose upstream was pruned
+- fully merged local branch deletion candidates
+- old stashes
+- open GitHub PRs, when ``gh`` is available
+- unresolved watcher output, when the watcher script is available
+
+The command never mutates git state. It is intentionally safe to run from
+hooks, shell aliases, and a half-configured fresh checkout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_TIMEOUT_SEC = 10
+DEFAULT_STASH_DAYS = 14
+
+
+@dataclass
+class CommandResult:
+    args: list[str]
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+    timed_out: bool = False
+
+
+@dataclass
+class WorktreeInfo:
+    path: str
+    head: str = ""
+    branch: str = ""
+    detached: bool = False
+    dirty_paths: list[str] = field(default_factory=list)
+    status_error: str = ""
+
+
+@dataclass
+class BranchInfo:
+    name: str
+    upstream: str
+    track: str
+    head: str
+    date: str
+    subject: str
+
+
+@dataclass
+class StashInfo:
+    ref: str
+    hash: str
+    date: str
+    subject: str
+    age_days: int | None = None
+
+
+@dataclass
+class ProbeResult:
+    status: str
+    message: str = ""
+    items: list[dict[str, Any]] = field(default_factory=list)
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass
+class Inventory:
+    repo_root: str
+    generated_at: str
+    worktrees: list[WorktreeInfo]
+    gone_upstream_branches: list[BranchInfo]
+    merged_branch_candidates: list[BranchInfo]
+    unmerged_branches: list[BranchInfo]
+    stashes: list[StashInfo]
+    old_stashes: list[StashInfo]
+    github_prs: ProbeResult
+    watcher: ProbeResult
+
+
+def run_cmd(
+    args: list[str],
+    cwd: Path | str,
+    *,
+    timeout: int = DEFAULT_TIMEOUT_SEC,
+) -> CommandResult:
+    try:
+        proc = subprocess.run(
+            args,
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return CommandResult(
+            args=args,
+            returncode=proc.returncode,
+            stdout=proc.stdout,
+            stderr=proc.stderr,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return CommandResult(
+            args=args,
+            returncode=124,
+            stdout=exc.stdout or "",
+            stderr=exc.stderr or "",
+            timed_out=True,
+        )
+    except OSError as exc:
+        return CommandResult(args=args, returncode=127, stderr=str(exc))
+
+
+def git_root(cwd: Path) -> Path:
+    result = run_cmd(["git", "rev-parse", "--show-toplevel"], cwd)
+    if result.returncode != 0:
+        raise SystemExit("not inside a git repository")
+    return Path(result.stdout.strip()).resolve()
+
+
+def parse_worktree_porcelain(stdout: str) -> list[WorktreeInfo]:
+    worktrees: list[WorktreeInfo] = []
+    current: dict[str, str | bool] = {}
+
+    def flush() -> None:
+        if not current:
+            return
+        branch = str(current.get("branch", ""))
+        detached = bool(current.get("detached", False)) or not branch
+        worktrees.append(
+            WorktreeInfo(
+                path=str(current.get("worktree", "")),
+                head=str(current.get("head", "")),
+                branch=branch,
+                detached=detached,
+            )
+        )
+        current.clear()
+
+    for raw in stdout.splitlines():
+        line = raw.strip()
+        if not line:
+            flush()
+            continue
+        key, _, value = line.partition(" ")
+        if key == "worktree":
+            flush()
+            current["worktree"] = value
+        elif key == "HEAD":
+            current["head"] = value[:12]
+        elif key == "branch":
+            current["branch"] = value.removeprefix("refs/heads/")
+        elif key == "detached":
+            current["detached"] = True
+    flush()
+    return worktrees
+
+
+def parse_status_short(stdout: str) -> list[str]:
+    paths: list[str] = []
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        # Porcelain v1 has a two-column status plus a space before the path.
+        paths.append(line[3:] if len(line) > 3 else line.strip())
+    return paths
+
+
+def collect_worktrees(repo_root: Path) -> list[WorktreeInfo]:
+    result = run_cmd(["git", "worktree", "list", "--porcelain"], repo_root)
+    if result.returncode != 0:
+        return [
+            WorktreeInfo(
+                path=str(repo_root),
+                status_error=result.stderr.strip() or "git worktree list failed",
+            )
+        ]
+
+    worktrees = parse_worktree_porcelain(result.stdout)
+    for wt in worktrees:
+        status = run_cmd(
+            ["git", "status", "--short", "--untracked-files=all"],
+            wt.path,
+            timeout=DEFAULT_TIMEOUT_SEC,
+        )
+        if status.returncode == 0:
+            wt.dirty_paths = parse_status_short(status.stdout)
+        else:
+            wt.status_error = status.stderr.strip() or "git status failed"
+
+        if not wt.branch:
+            branch = run_cmd(["git", "branch", "--show-current"], wt.path)
+            wt.branch = branch.stdout.strip() if branch.returncode == 0 else ""
+            wt.detached = not wt.branch
+    return worktrees
+
+
+def parse_branch_rows(stdout: str) -> list[BranchInfo]:
+    rows: list[BranchInfo] = []
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t", 5)
+        while len(parts) < 6:
+            parts.append("")
+        name, upstream, track, head, date, subject = parts
+        rows.append(
+            BranchInfo(
+                name=name,
+                upstream=upstream,
+                track=track,
+                head=head,
+                date=date,
+                subject=subject,
+            )
+        )
+    return rows
+
+
+def branch_rows(repo_root: Path, *extra_args: str) -> list[BranchInfo]:
+    fmt = (
+        "%(refname:short)%09%(upstream:short)%09%(upstream:track)%09"
+        "%(objectname:short)%09%(committerdate:iso8601)%09%(subject)"
+    )
+    result = run_cmd(
+        ["git", "for-each-ref", *extra_args, f"--format={fmt}", "refs/heads"],
+        repo_root,
+    )
+    if result.returncode != 0:
+        return []
+    return parse_branch_rows(result.stdout)
+
+
+def protected_branch(name: str) -> bool:
+    return name in {"main", "master"} or name.startswith(("backup/", "archive/"))
+
+
+def collect_branches(
+    repo_root: Path,
+    checked_out_branches: set[str],
+    base: str,
+) -> tuple[list[BranchInfo], list[BranchInfo], list[BranchInfo]]:
+    all_branches = branch_rows(repo_root)
+    gone = [row for row in all_branches if "[gone]" in row.track]
+
+    merged = branch_rows(repo_root, "--merged", base)
+    merged_candidates = [
+        row
+        for row in merged
+        if not protected_branch(row.name) and row.name not in checked_out_branches
+    ]
+
+    unmerged = branch_rows(repo_root, "--no-merged", base)
+    unmerged = [row for row in unmerged if not protected_branch(row.name)]
+    return gone, merged_candidates, unmerged
+
+
+def parse_stash_rows(stdout: str, now: datetime) -> list[StashInfo]:
+    stashes: list[StashInfo] = []
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t", 3)
+        while len(parts) < 4:
+            parts.append("")
+        ref, stash_hash, date_raw, subject = parts
+        age_days: int | None = None
+        try:
+            parsed = datetime.fromisoformat(date_raw)
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            age_days = max(0, (now - parsed.astimezone(timezone.utc)).days)
+        except ValueError:
+            age_days = None
+        stashes.append(
+            StashInfo(
+                ref=ref,
+                hash=stash_hash,
+                date=date_raw,
+                subject=subject,
+                age_days=age_days,
+            )
+        )
+    return stashes
+
+
+def collect_stashes(repo_root: Path, now: datetime) -> list[StashInfo]:
+    result = run_cmd(
+        [
+            "git",
+            "stash",
+            "list",
+            "--date=iso-strict",
+            "--format=%gd%x09%H%x09%cd%x09%gs",
+        ],
+        repo_root,
+    )
+    if result.returncode != 0:
+        return []
+    return parse_stash_rows(result.stdout, now)
+
+
+def github_repo_from_remote(remote: str) -> str:
+    remote = remote.strip()
+    if not remote:
+        return ""
+    patterns = (
+        r"github\.com[:/]([^/]+/[^/.]+)(?:\.git)?$",
+        r"github\.com[:/]([^/]+/[^/]+?)(?:\.git)?(?:/)?$",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, remote)
+        if match:
+            return match.group(1)
+    return ""
+
+
+def collect_github_prs(
+    repo_root: Path,
+    *,
+    repo: str = "",
+    skip: bool = False,
+    timeout: int = DEFAULT_TIMEOUT_SEC,
+) -> ProbeResult:
+    if skip:
+        return ProbeResult(status="skipped", message="disabled by flag")
+    if shutil.which("gh") is None:
+        return ProbeResult(status="skipped", message="gh not found on PATH")
+    if not repo:
+        remote = run_cmd(["git", "remote", "get-url", "origin"], repo_root)
+        if remote.returncode == 0:
+            repo = github_repo_from_remote(remote.stdout)
+    if not repo:
+        return ProbeResult(status="skipped", message="could not infer GitHub repo")
+
+    result = run_cmd(
+        [
+            "gh",
+            "pr",
+            "list",
+            "-R",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            "100",
+            "--json",
+            "number,title,isDraft,headRefName,updatedAt,url",
+        ],
+        repo_root,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        status = "timeout" if result.timed_out else "error"
+        return ProbeResult(
+            status=status,
+            message=result.stderr.strip() or f"gh exited {result.returncode}",
+            stderr=result.stderr,
+        )
+    try:
+        items = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        return ProbeResult(status="error", message=f"could not parse gh JSON: {exc}")
+    return ProbeResult(status="ok", items=items)
+
+
+def collect_watcher(
+    repo_root: Path,
+    *,
+    skip: bool = False,
+    timeout: int = DEFAULT_TIMEOUT_SEC,
+) -> ProbeResult:
+    if skip:
+        return ProbeResult(status="skipped", message="disabled by flag")
+    watcher = repo_root / "agents" / "watcher" / "agent.py"
+    if not watcher.exists():
+        return ProbeResult(status="skipped", message="agents/watcher/agent.py not found")
+
+    result = run_cmd(
+        [sys.executable, str(watcher), "--print-unresolved"],
+        repo_root,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        status = "timeout" if result.timed_out else "error"
+        return ProbeResult(
+            status=status,
+            message=result.stderr.strip() or f"watcher exited {result.returncode}",
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+    return ProbeResult(status="ok", stdout=result.stdout)
+
+
+def build_inventory(args: argparse.Namespace) -> Inventory:
+    repo_root = git_root(Path(args.cwd).resolve())
+    now = datetime.now(timezone.utc)
+    worktrees = collect_worktrees(repo_root)
+    checked_out = {wt.branch for wt in worktrees if wt.branch}
+    gone, merged_candidates, unmerged = collect_branches(
+        repo_root,
+        checked_out,
+        args.base,
+    )
+    stashes = collect_stashes(repo_root, now)
+    old_stashes = [
+        stash
+        for stash in stashes
+        if stash.age_days is not None and stash.age_days >= args.stash_days
+    ]
+
+    github_prs = collect_github_prs(
+        repo_root,
+        repo=args.github_repo,
+        skip=args.no_github,
+        timeout=args.github_timeout,
+    )
+    watcher = collect_watcher(
+        repo_root,
+        skip=args.no_watcher,
+        timeout=args.watcher_timeout,
+    )
+
+    return Inventory(
+        repo_root=str(repo_root),
+        generated_at=now.isoformat(),
+        worktrees=worktrees,
+        gone_upstream_branches=gone,
+        merged_branch_candidates=merged_candidates,
+        unmerged_branches=unmerged,
+        stashes=stashes,
+        old_stashes=old_stashes,
+        github_prs=github_prs,
+        watcher=watcher,
+    )
+
+
+def _short_path(path: str, root: str) -> str:
+    try:
+        return os.path.relpath(path, root)
+    except ValueError:
+        return path
+
+
+def _print_branch_list(title: str, branches: list[BranchInfo], limit: int) -> None:
+    print(f"{title}: {len(branches)}")
+    for row in branches[:limit]:
+        upstream = f" upstream={row.upstream}" if row.upstream else ""
+        track = f" {row.track}" if row.track else ""
+        print(f"  - {row.name} {row.head}{upstream}{track} :: {row.subject}")
+    if len(branches) > limit:
+        print(f"  ... {len(branches) - limit} more")
+
+
+def print_text_report(inventory: Inventory, *, limit: int) -> None:
+    root = inventory.repo_root
+    dirty = [wt for wt in inventory.worktrees if wt.dirty_paths]
+    detached = [wt for wt in inventory.worktrees if wt.detached]
+    status_errors = [wt for wt in inventory.worktrees if wt.status_error]
+
+    print("UNITARES housekeeping inventory")
+    print(f"repo: {root}")
+    print(f"generated_at: {inventory.generated_at}")
+    print()
+
+    print(
+        "worktrees: "
+        f"{len(inventory.worktrees)} total, {len(dirty)} dirty, "
+        f"{len(detached)} detached, {len(status_errors)} status errors"
+    )
+    for wt in dirty[:limit]:
+        label = wt.branch or "(detached)"
+        rel = _short_path(wt.path, root)
+        print(f"  - {rel} [{label} {wt.head[:8]}] {len(wt.dirty_paths)} changed")
+        for path in wt.dirty_paths[:8]:
+            print(f"      {path}")
+        if len(wt.dirty_paths) > 8:
+            print(f"      ... {len(wt.dirty_paths) - 8} more")
+    if len(dirty) > limit:
+        print(f"  ... {len(dirty) - limit} more dirty worktrees")
+    for wt in detached[:limit]:
+        if wt in dirty:
+            continue
+        rel = _short_path(wt.path, root)
+        print(f"  - detached clean: {rel} [{wt.head[:8]}]")
+    print()
+
+    _print_branch_list("gone-upstream branches", inventory.gone_upstream_branches, limit)
+    _print_branch_list(
+        "merged local delete candidates",
+        inventory.merged_branch_candidates,
+        limit,
+    )
+    _print_branch_list("unmerged local branches", inventory.unmerged_branches, limit)
+    print()
+
+    print(f"stashes: {len(inventory.stashes)} total, {len(inventory.old_stashes)} old")
+    for stash in inventory.old_stashes[:limit]:
+        age = "unknown age" if stash.age_days is None else f"{stash.age_days}d"
+        print(f"  - {stash.ref} {stash.hash[:8]} {age} :: {stash.subject}")
+    if len(inventory.old_stashes) > limit:
+        print(f"  ... {len(inventory.old_stashes) - limit} more old stashes")
+    print()
+
+    prs = inventory.github_prs
+    if prs.status == "ok":
+        print(f"github open PRs: {len(prs.items)}")
+        for item in prs.items[:limit]:
+            draft = "draft " if item.get("isDraft") else ""
+            print(
+                f"  - #{item.get('number')} {draft}{item.get('headRefName')}: "
+                f"{item.get('title')} ({item.get('url')})"
+            )
+        if len(prs.items) > limit:
+            print(f"  ... {len(prs.items) - limit} more")
+    else:
+        print(f"github open PRs: {prs.status} - {prs.message}")
+    print()
+
+    watcher = inventory.watcher
+    if watcher.status == "ok":
+        lines = [line for line in watcher.stdout.splitlines() if line.strip()]
+        print(f"watcher unresolved output: {len(lines)} non-empty line(s)")
+        for line in lines[:limit]:
+            print(f"  {line}")
+        if len(lines) > limit:
+            print(f"  ... {len(lines) - limit} more")
+    else:
+        print(f"watcher unresolved output: {watcher.status} - {watcher.message}")
+
+
+def to_jsonable(inventory: Inventory) -> dict[str, Any]:
+    return asdict(inventory)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cwd", default=".", help="repo directory to inspect")
+    parser.add_argument(
+        "--base",
+        default="master",
+        help="base branch for merged/unmerged branch classification",
+    )
+    parser.add_argument(
+        "--stash-days",
+        type=int,
+        default=DEFAULT_STASH_DAYS,
+        help=f"age threshold for old stashes (default: {DEFAULT_STASH_DAYS})",
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON")
+    parser.add_argument("--limit", type=int, default=20, help="max rows per text section")
+    parser.add_argument("--no-github", action="store_true", help="skip gh PR probe")
+    parser.add_argument("--github-repo", default="", help="GitHub owner/repo override")
+    parser.add_argument(
+        "--github-timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT_SEC,
+        help="seconds before gh PR probe times out",
+    )
+    parser.add_argument("--no-watcher", action="store_true", help="skip watcher probe")
+    parser.add_argument(
+        "--watcher-timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT_SEC,
+        help="seconds before watcher probe times out",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    inventory = build_inventory(args)
+    if args.json:
+        print(json.dumps(to_jsonable(inventory), indent=2, sort_keys=True))
+    else:
+        print_text_report(inventory, limit=args.limit)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/housekeeping_inventory.py
+++ b/scripts/dev/housekeeping_inventory.py
@@ -93,6 +93,33 @@ class Inventory:
     watcher: ProbeResult
 
 
+@dataclass
+class AttentionSummary:
+    dirty_worktrees: int = 0
+    detached_worktrees: int = 0
+    worktree_status_errors: int = 0
+    gone_upstream_branches: int = 0
+    merged_branch_candidates: int = 0
+    old_stashes: int = 0
+    open_github_prs: int = 0
+    watcher_unresolved_lines: int = 0
+    probe_errors: int = 0
+
+    @property
+    def total(self) -> int:
+        return (
+            self.dirty_worktrees
+            + self.detached_worktrees
+            + self.worktree_status_errors
+            + self.gone_upstream_branches
+            + self.merged_branch_candidates
+            + self.old_stashes
+            + self.open_github_prs
+            + self.watcher_unresolved_lines
+            + self.probe_errors
+        )
+
+
 def run_cmd(
     args: list[str],
     cwd: Path | str,
@@ -475,6 +502,7 @@ def print_text_report(inventory: Inventory, *, limit: int) -> None:
     print("UNITARES housekeeping inventory")
     print(f"repo: {root}")
     print(f"generated_at: {inventory.generated_at}")
+    print(f"attention_total: {attention_summary(inventory).total}")
     print()
 
     print(
@@ -544,7 +572,36 @@ def print_text_report(inventory: Inventory, *, limit: int) -> None:
 
 
 def to_jsonable(inventory: Inventory) -> dict[str, Any]:
-    return asdict(inventory)
+    payload = asdict(inventory)
+    payload["attention"] = asdict(attention_summary(inventory))
+    payload["attention"]["total"] = attention_summary(inventory).total
+    return payload
+
+
+def attention_summary(inventory: Inventory) -> AttentionSummary:
+    dirty = [wt for wt in inventory.worktrees if wt.dirty_paths]
+    detached = [wt for wt in inventory.worktrees if wt.detached]
+    status_errors = [wt for wt in inventory.worktrees if wt.status_error]
+    watcher_lines = [
+        line for line in inventory.watcher.stdout.splitlines() if line.strip()
+    ] if inventory.watcher.status == "ok" else []
+    probe_errors = sum(
+        1
+        for probe in (inventory.github_prs, inventory.watcher)
+        if probe.status in {"error", "timeout"}
+    )
+    open_prs = len(inventory.github_prs.items) if inventory.github_prs.status == "ok" else 0
+    return AttentionSummary(
+        dirty_worktrees=len(dirty),
+        detached_worktrees=len(detached),
+        worktree_status_errors=len(status_errors),
+        gone_upstream_branches=len(inventory.gone_upstream_branches),
+        merged_branch_candidates=len(inventory.merged_branch_candidates),
+        old_stashes=len(inventory.old_stashes),
+        open_github_prs=open_prs,
+        watcher_unresolved_lines=len(watcher_lines),
+        probe_errors=probe_errors,
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -562,6 +619,11 @@ def build_parser() -> argparse.ArgumentParser:
         help=f"age threshold for old stashes (default: {DEFAULT_STASH_DAYS})",
     )
     parser.add_argument("--json", action="store_true", help="emit JSON")
+    parser.add_argument(
+        "--fail-on-attention",
+        action="store_true",
+        help="exit 1 when any attention item is present; default is report-only",
+    )
     parser.add_argument("--limit", type=int, default=20, help="max rows per text section")
     parser.add_argument("--no-github", action="store_true", help="skip gh PR probe")
     parser.add_argument("--github-repo", default="", help="GitHub owner/repo override")
@@ -589,6 +651,8 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(to_jsonable(inventory), indent=2, sort_keys=True))
     else:
         print_text_report(inventory, limit=args.limit)
+    if args.fail_on_attention and attention_summary(inventory).total:
+        return 1
     return 0
 
 

--- a/tests/test_housekeeping_inventory.py
+++ b/tests/test_housekeeping_inventory.py
@@ -218,6 +218,24 @@ def test_attention_summary_counts_only_actionable_probe_states(inventory_module)
     assert summary.total == 4
 
 
+def test_parse_attention_keys_accepts_groups_fields_and_dash_aliases(inventory_module):
+    assert inventory_module.parse_attention_keys("") == ()
+    assert inventory_module.parse_attention_keys("worktrees") == (
+        "dirty_worktrees",
+        "detached_worktrees",
+        "worktree_status_errors",
+    )
+    assert inventory_module.parse_attention_keys(
+        "old-stashes,watcher_unresolved_lines"
+    ) == (
+        "old_stashes",
+        "watcher_unresolved_lines",
+    )
+
+    with pytest.raises(ValueError, match="unknown attention key"):
+        inventory_module.parse_attention_keys("nope")
+
+
 def test_main_fail_on_attention_is_opt_in(inventory_module, monkeypatch, capsys):
     inventory = inventory_module.Inventory(
         repo_root="/repo",
@@ -242,4 +260,16 @@ def test_main_fail_on_attention_is_opt_in(inventory_module, monkeypatch, capsys)
 
     assert inventory_module.main(["--no-github", "--no-watcher"]) == 0
     assert inventory_module.main(["--no-github", "--no-watcher", "--fail-on-attention"]) == 1
+    assert (
+        inventory_module.main(
+            ["--no-github", "--no-watcher", "--fail-on-attention", "old-stashes"]
+        )
+        == 0
+    )
+    assert (
+        inventory_module.main(
+            ["--no-github", "--no-watcher", "--fail-on-attention", "worktrees"]
+        )
+        == 1
+    )
     capsys.readouterr()

--- a/tests/test_housekeeping_inventory.py
+++ b/tests/test_housekeeping_inventory.py
@@ -176,6 +176,70 @@ def test_text_report_includes_core_counts(inventory_module, capsys):
 
     out = capsys.readouterr().out
     assert "worktrees: 2 total, 1 dirty, 1 detached" in out
+    assert "attention_total: 4" in out
     assert "README.md" in out
     assert "stashes: 1 total, 1 old" in out
     assert "watcher unresolved output: 1 non-empty line(s)" in out
+
+
+def test_attention_summary_counts_only_actionable_probe_states(inventory_module):
+    inventory = inventory_module.Inventory(
+        repo_root="/repo",
+        generated_at="2026-06-02T12:00:00+00:00",
+        worktrees=[
+            inventory_module.WorktreeInfo(
+                path="/repo",
+                branch="master",
+                dirty_paths=["README.md"],
+            ),
+            inventory_module.WorktreeInfo(path="/detached", detached=True),
+        ],
+        gone_upstream_branches=[
+            inventory_module.BranchInfo("codex/gone", "origin/codex/gone", "[gone]", "abc", "", "")
+        ],
+        merged_branch_candidates=[],
+        unmerged_branches=[],
+        stashes=[],
+        old_stashes=[],
+        github_prs=inventory_module.ProbeResult(
+            status="ok",
+            items=[{"number": 1, "title": "open"}],
+        ),
+        watcher=inventory_module.ProbeResult(status="skipped", message="disabled"),
+    )
+
+    summary = inventory_module.attention_summary(inventory)
+
+    assert summary.dirty_worktrees == 1
+    assert summary.detached_worktrees == 1
+    assert summary.gone_upstream_branches == 1
+    assert summary.open_github_prs == 1
+    assert summary.probe_errors == 0
+    assert summary.total == 4
+
+
+def test_main_fail_on_attention_is_opt_in(inventory_module, monkeypatch, capsys):
+    inventory = inventory_module.Inventory(
+        repo_root="/repo",
+        generated_at="2026-06-02T12:00:00+00:00",
+        worktrees=[
+            inventory_module.WorktreeInfo(
+                path="/repo",
+                branch="master",
+                dirty_paths=["README.md"],
+            )
+        ],
+        gone_upstream_branches=[],
+        merged_branch_candidates=[],
+        unmerged_branches=[],
+        stashes=[],
+        old_stashes=[],
+        github_prs=inventory_module.ProbeResult(status="skipped"),
+        watcher=inventory_module.ProbeResult(status="skipped"),
+    )
+
+    monkeypatch.setattr(inventory_module, "build_inventory", lambda args: inventory)
+
+    assert inventory_module.main(["--no-github", "--no-watcher"]) == 0
+    assert inventory_module.main(["--no-github", "--no-watcher", "--fail-on-attention"]) == 1
+    capsys.readouterr()

--- a/tests/test_housekeeping_inventory.py
+++ b/tests/test_housekeeping_inventory.py
@@ -1,0 +1,181 @@
+"""Tests for scripts/dev/housekeeping_inventory.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def inventory_module():
+    project_root = Path(__file__).resolve().parent.parent
+    module_path = project_root / "scripts" / "dev" / "housekeeping_inventory.py"
+    spec = importlib.util.spec_from_file_location("housekeeping_inventory", module_path)
+    assert spec and spec.loader, f"could not load {module_path}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["housekeeping_inventory"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_worktree_porcelain_marks_detached_without_branch(inventory_module):
+    stdout = """worktree /repo
+HEAD abcdef1234567890
+branch refs/heads/master
+
+worktree /repo-wt
+HEAD 9999999999999999
+detached
+
+"""
+
+    worktrees = inventory_module.parse_worktree_porcelain(stdout)
+
+    assert len(worktrees) == 2
+    assert worktrees[0].path == "/repo"
+    assert worktrees[0].branch == "master"
+    assert worktrees[0].detached is False
+    assert worktrees[1].path == "/repo-wt"
+    assert worktrees[1].branch == ""
+    assert worktrees[1].detached is True
+    assert worktrees[1].head == "999999999999"
+
+
+def test_parse_status_short_returns_paths(inventory_module):
+    stdout = " M README.md\n?? tests/new_test.py\nA  scripts/dev/new.py\n"
+
+    paths = inventory_module.parse_status_short(stdout)
+
+    assert paths == ["README.md", "tests/new_test.py", "scripts/dev/new.py"]
+
+
+def test_parse_branch_rows_handles_subject_tabs(inventory_module):
+    stdout = (
+        "codex/foo\torigin/codex/foo\t[gone]\tabc123\t"
+        "2026-06-02 10:00:00 -0600\tfix: keep\ttabbed subject\n"
+    )
+
+    rows = inventory_module.parse_branch_rows(stdout)
+
+    assert len(rows) == 1
+    assert rows[0].name == "codex/foo"
+    assert rows[0].upstream == "origin/codex/foo"
+    assert rows[0].track == "[gone]"
+    assert rows[0].subject == "fix: keep\ttabbed subject"
+
+
+def test_protected_branch_keeps_primary_and_archive_refs(inventory_module):
+    assert inventory_module.protected_branch("master") is True
+    assert inventory_module.protected_branch("main") is True
+    assert inventory_module.protected_branch("archive/stash-20260420") is True
+    assert inventory_module.protected_branch("backup/foo") is True
+    assert inventory_module.protected_branch("codex/foo") is False
+
+
+def test_parse_stash_rows_computes_age_days(inventory_module):
+    now = datetime(2026, 6, 2, 12, 0, tzinfo=timezone.utc)
+    stdout = (
+        "stash@{0}\tabcdef\t2026-05-20T12:00:00+00:00\tOn master: old\n"
+        "stash@{1}\t999999\t2026-06-01T12:00:00+00:00\tOn master: new\n"
+    )
+
+    stashes = inventory_module.parse_stash_rows(stdout, now)
+
+    assert [stash.age_days for stash in stashes] == [13, 1]
+    assert stashes[0].subject == "On master: old"
+
+
+def test_collect_stashes_uses_git_pretty_tab_escape(inventory_module, monkeypatch):
+    seen_args: list[str] = []
+
+    def fake_run_cmd(args, cwd):
+        nonlocal seen_args
+        seen_args = args
+        return inventory_module.CommandResult(
+            args=args,
+            returncode=0,
+            stdout=(
+                "stash@{0}\tabcdef\t2026-05-20T12:00:00+00:00\t"
+                "On master: old\n"
+            ),
+        )
+
+    monkeypatch.setattr(inventory_module, "run_cmd", fake_run_cmd)
+
+    stashes = inventory_module.collect_stashes(
+        Path("/repo"),
+        datetime(2026, 6, 2, 12, 0, tzinfo=timezone.utc),
+    )
+
+    assert any("%gd%x09%H%x09%cd%x09%gs" in arg for arg in seen_args)
+    assert stashes[0].hash == "abcdef"
+    assert stashes[0].age_days == 13
+
+
+def test_github_repo_from_remote_accepts_https_and_ssh(inventory_module):
+    assert (
+        inventory_module.github_repo_from_remote(
+            "https://github.com/CIRWEL/unitares.git"
+        )
+        == "CIRWEL/unitares"
+    )
+    assert (
+        inventory_module.github_repo_from_remote("git@github.com:CIRWEL/unitares.git")
+        == "CIRWEL/unitares"
+    )
+    assert inventory_module.github_repo_from_remote("file:///tmp/origin.git") == ""
+
+
+def test_text_report_includes_core_counts(inventory_module, capsys):
+    inventory = inventory_module.Inventory(
+        repo_root="/repo",
+        generated_at="2026-06-02T12:00:00+00:00",
+        worktrees=[
+            inventory_module.WorktreeInfo(
+                path="/repo",
+                head="abcdef123456",
+                branch="master",
+                dirty_paths=["README.md"],
+            ),
+            inventory_module.WorktreeInfo(
+                path="/repo-wt",
+                head="999999999999",
+                detached=True,
+            ),
+        ],
+        gone_upstream_branches=[],
+        merged_branch_candidates=[],
+        unmerged_branches=[],
+        stashes=[
+            inventory_module.StashInfo(
+                ref="stash@{0}",
+                hash="abc",
+                date="2026-05-01T00:00:00+00:00",
+                subject="On master: old",
+                age_days=32,
+            )
+        ],
+        old_stashes=[
+            inventory_module.StashInfo(
+                ref="stash@{0}",
+                hash="abc",
+                date="2026-05-01T00:00:00+00:00",
+                subject="On master: old",
+                age_days=32,
+            )
+        ],
+        github_prs=inventory_module.ProbeResult(status="skipped", message="test"),
+        watcher=inventory_module.ProbeResult(status="ok", stdout="P001 unresolved\n"),
+    )
+
+    inventory_module.print_text_report(inventory, limit=10)
+
+    out = capsys.readouterr().out
+    assert "worktrees: 2 total, 1 dirty, 1 detached" in out
+    assert "README.md" in out
+    assert "stashes: 1 total, 1 old" in out
+    assert "watcher unresolved output: 1 non-empty line(s)" in out

--- a/tests/test_onboard_helper.py
+++ b/tests/test_onboard_helper.py
@@ -157,8 +157,10 @@ class TestRunOnboard:
         assert "parent_agent_id" not in sent_args
 
         written = json.loads(cache_path.read_text())
+        assert written["schema_version"] == 2
         assert written["uuid"] == "uuid-ok"
         assert written["client_session_id"] == "agent-ok"
+        assert "updated_at" in written
         # S20.3: continuity_token must NOT be persisted to the cache file.
         # The field stays in the in-process return value (transient) so a
         # caller can use it within the same process, but is never written
@@ -410,6 +412,78 @@ class TestSlotIsolation:
         legacy_path = tmp_path / ".unitares" / "session.json"
         assert legacy_path.exists()
         assert json.loads(legacy_path.read_text()) == legacy
+
+    def test_new_slot_uses_newest_existing_slotted_cache_for_lineage(self, tmp_path: Path) -> None:
+        """A fresh process usually has a fresh slot. It should still see
+        workspace lineage from the newest existing session cache, not only
+        from legacy session.json."""
+        older = {
+            "uuid": "older-parent",
+            "updated_at": "2026-05-01T00:00:00+00:00",
+        }
+        newer = {
+            "uuid": "newer-parent",
+            "updated_at": "2026-05-02T00:00:00+00:00",
+        }
+        result, poster, cache_path = self._call(
+            tmp_path,
+            [_success_response(uuid="child-uuid", session_id="agent-child")],
+            slot="fresh-process",
+            initial_files={
+                "session-older.json": older,
+                "session-newer.json": newer,
+            },
+        )
+
+        assert result["status"] == "ok"
+        sent_args = poster.calls[0][1]["arguments"]
+        assert sent_args["parent_agent_id"] == "newer-parent"
+        assert sent_args["spawn_reason"] == "new_session"
+        assert cache_path.name == "session-fresh-process.json"
+
+    def test_exact_slot_cache_wins_over_newer_other_slot(self, tmp_path: Path) -> None:
+        exact = {
+            "uuid": "exact-parent",
+            "updated_at": "2026-05-01T00:00:00+00:00",
+        }
+        newer_other = {
+            "uuid": "other-parent",
+            "updated_at": "2026-05-02T00:00:00+00:00",
+        }
+        _, poster, _ = self._call(
+            tmp_path,
+            [_success_response(uuid="child-uuid", session_id="agent-child")],
+            slot="same-process",
+            initial_files={
+                "session-same-process.json": exact,
+                "session-other-process.json": newer_other,
+            },
+        )
+
+        sent_args = poster.calls[0][1]["arguments"]
+        assert sent_args["parent_agent_id"] == "exact-parent"
+
+    def test_newest_cache_without_uuid_does_not_hide_older_lineage(self, tmp_path: Path) -> None:
+        uuid_less = {
+            "client_session_id": "agent-no-uuid",
+            "updated_at": "2026-05-03T00:00:00+00:00",
+        }
+        older_with_uuid = {
+            "uuid": "usable-parent",
+            "updated_at": "2026-05-02T00:00:00+00:00",
+        }
+        _, poster, _ = self._call(
+            tmp_path,
+            [_success_response(uuid="child-uuid", session_id="agent-child")],
+            slot="fresh-process",
+            initial_files={
+                "session-no-uuid.json": uuid_less,
+                "session-usable.json": older_with_uuid,
+            },
+        )
+
+        sent_args = poster.calls[0][1]["arguments"]
+        assert sent_args["parent_agent_id"] == "usable-parent"
 
     def test_unsanitized_slot_filename_chars_are_replaced(self, tmp_path: Path) -> None:
         # Slot keys come from external input (Claude Code session_id) — must


### PR DESCRIPTION
## Summary

- add a read-only housekeeping inventory for dirty/detached worktrees, stale local refs, old stashes, open PRs, and Watcher output
- add opt-in attention totals plus scoped `--fail-on-attention` categories for future agent/session gates
- fix Codex onboard helper lineage discovery so slotted session caches can still find the newest valid predecessor
- document the Codex housekeeping flow in `CODEX_START.md`

## Validation

- `python3 -m pytest tests/test_housekeeping_inventory.py`
- `python3 -m pytest tests/test_onboard_helper.py tests/test_client_session_cache_contract.py`
- `./scripts/dev/test-cache.sh --staged` -> 9121 passed, 35 skipped
- pre-push smoke gate -> 138 passed, 8437 deselected
