### PR TITLE
fix(lease-plane): route file:// edit-leases to remote_heartbeat so they self-heal

### DIFF
--- a/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
@@ -62,7 +62,7 @@ defmodule UnitaresLeasePlane.HTTPRouter do
   post "/v1/lease/acquire" do
     case extract_acquire_params(conn.body_params) do
       {:ok, params} ->
-        case UnitaresLeasePlane.acquire_local_beam(params) do
+        case acquire_for_surface(params) do
           {:ok, lease, kind} ->
             json(conn, 200, %{
               ok: true,
@@ -438,6 +438,32 @@ defmodule UnitaresLeasePlane.HTTPRouter do
   end
 
   defp extract_acquire_params(_), do: {:error, "body must be a JSON object"}
+
+  # Route the acquire to the correct lease lifecycle based on the surface scheme.
+  #
+  # `file://` surfaces are file-edit leases from the plugin's per-edit hook —
+  # one-shot / session-scoped and MUST self-heal if the editing session dies
+  # without releasing. They take the `remote_heartbeat` path: a pure DB row with
+  # NO auto-renewing LeaseHolder, reaped by the Reaper at `expires_at` (the
+  # editor's post-edit heartbeat extends it while the session is alive). Before
+  # this, every file edit spawned an immortally-auto-renewing local_beam holder
+  # that locked the file for the BEAM process's lifetime — memory files, with
+  # their stable cross-session path, stayed locked for hours/days.
+  #
+  # Every other surface (resident:/ presence, migration:/, etc.) keeps the
+  # local_beam auto-renew path. Residents are intentionally long-lived and rely
+  # on server-side auto-renew for continuity, so the routing is scoped to the
+  # file scheme precisely so it CANNOT regress resident coordination.
+  defp acquire_for_surface(%{surface_id: surface_id} = params)
+       when is_binary(surface_id) do
+    if String.starts_with?(surface_id, "file://") do
+      UnitaresLeasePlane.acquire_remote_heartbeat(params)
+    else
+      UnitaresLeasePlane.acquire_local_beam(params)
+    end
+  end
+
+  defp acquire_for_surface(params), do: UnitaresLeasePlane.acquire_local_beam(params)
 
   defp extract_release_params(%{"lease_id" => lease_id} = body)
        when is_binary(lease_id) and byte_size(lease_id) > 0 do

--- a/elixir/lease_plane/test/http_router_test.exs
+++ b/elixir/lease_plane/test/http_router_test.exs
@@ -270,6 +270,47 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
       assert payload["detail"] =~ "invalid_scheme"
     end
 
+    # --- file-lease self-heal routing (acquire_for_surface) ---
+    # file:// edit-leases must NOT spawn an auto-renewing local_beam holder
+    # (that made them immortal and locked memory files for hours). They route
+    # to the remote_heartbeat path — a pure DB row reaped at TTL — so a dead
+    # editing session self-heals. resident:/ and other coordination surfaces
+    # MUST stay local_beam (long-lived auto-renew presence), even when the
+    # caller sends holder_kind="remote_heartbeat" (as the resident advisory
+    # path does), so the routing is scoped strictly to the file scheme.
+
+    @tag :tmp_dir
+    test "file:// surface routes to remote_heartbeat (self-healing, no holder)", ctx do
+      path = Path.join(ctx.tmp_dir, "edit-target.txt")
+      File.write!(path, "x")
+      resp =
+        post_json(
+          "/v1/lease/acquire",
+          acquire_body("file://" <> path, holder_kind: "remote_heartbeat")
+        )
+
+      assert resp.status == 200
+      lease = parsed(resp)["lease"]
+      on_exit(fn -> cleanup_surface(lease["surface_id"]) end)
+      assert lease["surface_kind"] == "file"
+      assert lease["holder_kind"] == "remote_heartbeat"
+    end
+
+    test "resident:/ surface stays local_beam even when remote_heartbeat requested", _ctx do
+      surface = "resident:/lease-routing-test-#{random_uuid()}"
+      resp =
+        post_json(
+          "/v1/lease/acquire",
+          acquire_body(surface, holder_kind: "remote_heartbeat")
+        )
+
+      assert resp.status == 200
+      lease = parsed(resp)["lease"]
+      on_exit(fn -> cleanup_surface(lease["surface_id"]) end)
+      # Routing is scoped to file://; residents keep auto-renew presence.
+      assert lease["holder_kind"] == "local_beam"
+    end
+
     test "PR 7 — capture:/ unsorted members → server stores canonical (sorted)" do
       # Per PR 7 council BLOCK 2 (reviewer): construct surface_canonical via
       # the Canonicalize helper itself, not by hand. This eliminates the


### PR DESCRIPTION
## Why

File-edit leases became **immortal** and locked files for hours/days. `memory.md` was held ~12h from a single morning edit; every MCP memory write was blocked all session, and Sentinel flagged the held-by-other conflict.

Root cause: the plugin's per-edit hook acquires a lease on every Edit/Write, and `/v1/lease/acquire` routed **everything** through `acquire_local_beam`, which spawns a `LeaseHolder` GenServer that auto-renews `expires_at` every `ttl/3` **forever**, with no tie to whether the editing session is alive. The reaper only reaps `expires_at < now()`, which auto-renew guarantees never happens. So a session ending without release (crash / `kill -9` / no `SessionEnd`) left an immortal lease. Memory files are worst-hit because they're a **stable shared path** across sessions.

## What

Route `/v1/lease/acquire` by **surface scheme**:
- `file://` → `acquire_remote_heartbeat` — a pure DB row, **no holder process**, reaped by the Reaper at `expires_at`. The editor's post-edit heartbeat extends it while the session lives; a dead session self-heals at TTL.
- everything else (`resident:/` presence, `migration:/`, …) → `acquire_local_beam`, **unchanged**.

This is scoped strictly to the file scheme **on purpose**: residents are intentionally long-lived and rely on server-side auto-renew for continuity. The resident advisory path (`advisory.py`) *also* sends `holder_kind="remote_heartbeat"`, so a blanket "honor holder_kind" would have moved residents onto the reaper path and risked their coordination — confirmed and avoided. (Operator confirmed residents are long-lived by design.)

The design went through a 3-lane council: my initial `no_renew` design was **rejected** in favor of activating the existing, model-validated, previously **test-only** `acquire_remote_heartbeat` path — which dodges the GenServer-leak / self-timer / per-edit-release-race bugs the reviewer found in the `no_renew` approach. A gating verification then **refuted** the council's assumption that residents send `local_beam`, which is why this is scheme-scoped rather than holder_kind-routed.

## Notes

- **No schema migration, no plugin change** — the plugin already sends `holder_kind=remote_heartbeat` for `file://` surfaces; this just stops the server from forcing `local_beam`.
- **Takes effect on lease-plane restart** (`launchctl reload com.unitares.lease-plane`).
- 4 pre-existing stale memory leases were already cleared manually via `/v1/lease/release`.

## Tests

`http_router_test.exs`: `file://` → `remote_heartbeat`; `resident:/` stays `local_beam` even when the caller requests `remote_heartbeat`. Full Elixir suite green locally: **144 tests, 11 properties, 0 failures**.

## Follow-ups (not this PR)

- `LEASE_FORCE_RELEASE_TOKEN` is unset → `/v1/lease/force-release` returns 503; consider configuring it for operator cleanup.
- Plugin TTL is 900s (crash self-heal window = ~15min); could lower.
- Scope-narrowing: the hook leases *every* file edit incl. per-worktree-unique paths with zero contention — could scope to shared/stable surfaces only (architect's deeper point).