### PR TITLE
feat(lease-plane): enable BEAM hot-code-reload (named node + hot-reload.sh)

### DIFF
--- a/docs/operations/lease-plane-operator-runbook.md
+++ b/docs/operations/lease-plane-operator-runbook.md
@@ -52,10 +52,16 @@ curl -s -H "Authorization: Bearer $LEASE_PLANE_BEARER_TOKEN" \
 
 ## Updating the running code (deploy)
 
-Deploys are full-restart in v0 (BEAM hot-code-reload is the floor we're building toward — see "Hot code reload" below). To deploy merged `master` changes:
+Two paths now exist: full-restart (always correct) and hot-code-reload (no restart, no dropped leases — for stateless modules; see "Hot code reload" below). To deploy merged `master` changes with a restart:
 
 ```bash
 scripts/ops/deploy-lease-plane.sh
+```
+
+To deploy a stateless-module change (router, plugs, pure logic) *without* a restart, `git pull` in the deploy worktree then:
+
+```bash
+scripts/ops/hot-reload.sh --changed     # or name modules explicitly
 ```
 
 It fast-forwards `$HOME/projects/unitares-deploy` to `origin/master`, recompiles, restarts the LaunchAgent (`launchctl kickstart -k gui/$(id -u)/com.unitares.lease-plane`), and verifies `/v1/health`. Idempotent; creates the deploy worktree if missing. Because the service runs from this dedicated worktree, "is the merged fix actually live?" has a clean answer: `git -C "$HOME/projects/unitares-deploy" rev-parse HEAD`.
@@ -103,11 +109,15 @@ The healthcheck probe is a binary "is the front door open" signal. Functional he
 
 ## Live introspection (the BEAM superpower)
 
-This is the part most worth learning. From your laptop:
+This is the part most worth learning. Requires the node started named +
+cookied (set `LEASE_PLANE_NODE_COOKIE` in `secrets.env` — see `start.sh`).
+The node is `unitares-lease-plane@<short-hostname>` and distribution is pinned
+to loopback, so attach from the same host:
 
 ```bash
-# Connect to the running BEAM node interactively
-iex --sname operator --remsh unitares-lease-plane@localhost
+# Connect to the running BEAM node interactively (same cookie as the node)
+iex --sname operator --cookie "$LEASE_PLANE_NODE_COOKIE" \
+    --remsh "unitares-lease-plane@$(hostname -s)"
 ```
 
 Once attached, useful commands:
@@ -410,7 +420,38 @@ When a new version of a module is deployed, the BEAM node can swap it in place w
 - Old: `ps -o etime` + `git log --since=` to figure out if the resident has the fix you think it has
 - New: deploy = module swap = the running node *has the fix*. The "is this code running?" question becomes "what version is loaded?", which `:application.loaded_applications/0` answers directly.
 
-v0 does not *automate* hot-reload deploys. Initial deploys are full-restart. But the capability is the floor, not a feature add.
+### How it works now
+
+Enable once (a single restart pays for itself): set a strong random
+`LEASE_PLANE_NODE_COOKIE` in `~/.config/cirwel/secrets.env`, then restart the
+plane (`launchctl kickstart -k gui/$(id -u)/com.unitares.lease-plane`). From
+then on the node runs named + cookied, distribution pinned to loopback.
+
+Reload after pulling new code into the deploy worktree:
+
+```bash
+cd "$HOME/projects/unitares-deploy" && git pull --ff-only
+elixir/lease_plane/scripts/ops/hot-reload.sh --changed
+# or name modules: scripts/ops/hot-reload.sh UnitaresLeasePlane.HTTPRouter
+```
+
+The helper recompiles in the worktree and `:code.purge` + `:code.load_file`s
+each module into the running node via a short-lived `:rpc` peer — no restart,
+no dropped leases. Verify with `/v1/health` or `:application.loaded_applications/0`.
+
+### Scope — what reloads cleanly, and the frontier
+
+- **Stateless modules reload cleanly**: `HTTPRouter`, plugs, `Canonicalize`,
+  pure logic. Requests run in transient processes that pick up new code on the
+  next call. Proven end-to-end 2026-06-03 (isolated node, `/v1/health` swapped
+  with no restart).
+- **Long-lived stateful GenServers are the relup / `code_change` frontier**:
+  `LeaseHolder` (per-lease, auto-renew state), `HandoffServer`, the periodic
+  workers. `:code.purge` *kills* any process still executing the old module,
+  and a changed state shape needs `code_change/3`. Reload these in place only
+  when the state shape is unchanged; otherwise full-restart that change. Full
+  `appup`/`relup` release upgrades remain deliberately out of scope until a
+  stateful change actually demands them.
 
 ## When things go wrong
 

--- a/elixir/lease_plane/scripts/ops/hot-reload.sh
+++ b/elixir/lease_plane/scripts/ops/hot-reload.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Hot-code-reload helper for the Surface Lease Plane (BEAM).
+#
+# Recompiles the lease_plane app in THIS working tree and swaps the named
+# modules into the *running* node in place — no restart, no dropped leases.
+# This is the operational realization of the running-process-vs-master-commit
+# fix: after `git pull` in the deploy worktree, run this to make the live node
+# actually run the new code.
+#
+#   scripts/ops/hot-reload.sh UnitaresLeasePlane.HTTPRouter [More.Modules ...]
+#   scripts/ops/hot-reload.sh --changed     # reload every module recompiled just now
+#
+# Requires:
+#   - LEASE_PLANE_NODE_COOKIE in ~/.config/cirwel/secrets.env
+#   - the node started named (start.sh with the cookie present)
+#
+# SCOPE — what reloads cleanly vs. what does not:
+#   Stateless modules (HTTPRouter, plugs, Canonicalize, pure logic) reload
+#   cleanly: requests are served by transient processes that pick up new code
+#   on the next call. Long-lived *stateful* GenServers (LeaseHolder,
+#   HandoffServer, the periodic workers) are the relup / code_change frontier:
+#   `:code.purge` KILLS any process still executing the old module, and a
+#   changed state shape needs `code_change/3`. Reload those only when you know
+#   the state shape is unchanged — otherwise do a full restart for that change.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# scripts/ops/hot-reload.sh -> lease_plane root is two levels up
+LEASE_PLANE_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SECRETS_FILE="$HOME/.config/cirwel/secrets.env"
+EBIN="$LEASE_PLANE_DIR/_build/dev/lib/lease_plane/ebin"
+
+if [[ -f "$SECRETS_FILE" ]]; then
+    # shellcheck disable=SC1090
+    set -a; source "$SECRETS_FILE"; set +a
+fi
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+if [[ -z "${LEASE_PLANE_NODE_COOKIE:-}" ]]; then
+    echo "[hot-reload] LEASE_PLANE_NODE_COOKIE unset — the node is not named; cannot reload. Set it in $SECRETS_FILE and restart the plane once." >&2
+    exit 1
+fi
+
+NODE_SNAME="${LEASE_PLANE_NODE_SNAME:-unitares-lease-plane}"
+TARGET_NODE="${NODE_SNAME}@$(hostname -s)"
+export ERL_EPMD_ADDRESS="127.0.0.1"
+
+cd "$LEASE_PLANE_DIR"
+
+declare -a MODS=()
+if [[ "${1:-}" == "--changed" ]]; then
+    # Reference instant: anything mix rewrites *during* the compile below is
+    # strictly newer than this marker; an unchanged tree rewrites nothing.
+    MARK="$(mktemp)"
+    touch "$MARK"
+    mix compile >/dev/null
+    while IFS= read -r beam; do
+        MODS+=("$(basename "$beam" .beam)")   # e.g. Elixir.UnitaresLeasePlane.HTTPRouter
+    done < <(find "$EBIN" -name '*.beam' -newer "$MARK")
+    rm -f "$MARK"
+    if [[ ${#MODS[@]} -eq 0 ]]; then
+        echo "[hot-reload] nothing recompiled — node already runs current code."
+        exit 0
+    fi
+else
+    if [[ $# -lt 1 ]]; then
+        echo "usage: hot-reload.sh <Module> [Module ...] | --changed" >&2
+        exit 2
+    fi
+    mix compile >/dev/null
+    for m in "$@"; do MODS+=("Elixir.$m"); done
+fi
+
+CTRL='
+node = System.get_env("HR_NODE") |> String.to_atom()
+case Node.ping(node) do
+  :pong -> :ok
+  :pang ->
+    IO.puts(:stderr, "[hot-reload] cannot reach #{inspect(node)} — node named + cookie correct?")
+    System.halt(1)
+end
+mods = Enum.map(System.argv(), &String.to_atom/1)
+Enum.each(mods, fn m ->
+  :rpc.call(node, :code, :purge, [m])
+  case :rpc.call(node, :code, :load_file, [m]) do
+    {:module, ^m} -> IO.puts("[hot-reload] ok   #{inspect(m)}")
+    other ->
+      IO.puts(:stderr, "[hot-reload] FAIL #{inspect(m)} -> #{inspect(other)}")
+      System.halt(1)
+  end
+end)
+IO.puts("[hot-reload] reloaded #{length(mods)} module(s) on #{inspect(node)} — no restart")
+'
+
+HR_NODE="$TARGET_NODE" exec elixir \
+    --sname "hotreload$$" \
+    --cookie "$LEASE_PLANE_NODE_COOKIE" \
+    -e "$CTRL" -- "${MODS[@]}"

--- a/elixir/lease_plane/scripts/start.sh
+++ b/elixir/lease_plane/scripts/start.sh
@@ -31,4 +31,28 @@ fi
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
 
 cd "$LEASE_PLANE_DIR"
-exec mix run --no-halt
+
+# --- Distributed node for BEAM hot-code-reload ---
+# When LEASE_PLANE_NODE_COOKIE is set (in secrets.env) we start the node
+# *named* + *cookied* so an operator can attach a remote shell or drive an
+# in-place module swap (scripts/ops/hot-reload.sh) WITHOUT a restart — the
+# substrate answer to the running-process-vs-master-commit drift class.
+#
+# Security: the Erlang distribution port is authenticated ONLY by the cookie
+# (node access == arbitrary code execution), so we (a) refuse to name the
+# node without a cookie — falling back to the pre-hot-reload UNNAMED launch,
+# preserving exact current behavior — and (b) pin epmd + the distribution
+# listener to 127.0.0.1, matching the lease plane's localhost trust boundary.
+NODE_SNAME="${LEASE_PLANE_NODE_SNAME:-unitares-lease-plane}"
+
+if [[ -n "${LEASE_PLANE_NODE_COOKIE:-}" ]]; then
+    export ERL_EPMD_ADDRESS="127.0.0.1"
+    exec elixir \
+        --sname "$NODE_SNAME" \
+        --cookie "$LEASE_PLANE_NODE_COOKIE" \
+        --erl "-kernel inet_dist_use_interface {127,0,0,1}" \
+        -S mix run --no-halt
+else
+    echo "[lease-plane] LEASE_PLANE_NODE_COOKIE unset — starting UNNAMED (hot-reload disabled; set the cookie in secrets.env and restart to enable)" >&2
+    exec mix run --no-halt
+fi


### PR DESCRIPTION
## Why

Deploying the lease plane today = full restart = resident BEAM processes die and re-acquire their leases. This adds in-place module reload so a deploy can stop dropping leases — the substrate-level answer to the running-process-vs-master-commit drift class.

The seed motivation is **continuity**, not ops convenience: residents get the restart-as-death problem solved at the substrate level for code changes.

## What

- **`start.sh`** — when `LEASE_PLANE_NODE_COOKIE` is set (secrets.env), launch the node **named + cookied** with Erlang distribution + epmd pinned to `127.0.0.1`. Absent the cookie it falls back to the current **UNNAMED** launch, so **this PR is a no-op at runtime until the secret is added and the plane is restarted once.** (Naming the node without a secret cookie would expose an RCE surface — hence the gate.)
- **`scripts/ops/hot-reload.sh`** — recompiles in the worktree and `:code.purge` + `:code.load_file`s modules into the live node via a short-lived `:rpc` peer. Takes explicit module names or `--changed`. No restart, no dropped leases.
- **runbook** — enable-once flow, fixes the stale `--remsh` example (node is `unitares-lease-plane@<short-host>`, cookie required), records the scope boundary.

## Verified

Proven end-to-end on an **isolated** named test node (port 8799, workers off — never touched the production plane or live lease data):
- explicit form: `hot-reload.sh UnitaresLeasePlane.HTTPRouter` → `/v1/health` swapped `ok` → `ok-via-helper` on the **same live process, no restart**
- `--changed` form: edit → detect → reload → `/v1/health` = `ok-FINAL`; second run correctly no-ops

## Scope (honest boundary)

Stateless modules (HTTPRouter, plugs, `Canonicalize`, pure logic) reload cleanly. Long-lived **stateful GenServers** (`LeaseHolder`, `HandoffServer`, periodic workers) are the relup / `code_change` frontier: `:code.purge` kills processes still running old code, and a state-shape change needs `code_change/3`. Reload those in place only when the state shape is unchanged; otherwise full-restart that change. `appup`/`relup` release upgrades stay deliberately out of scope until a stateful change demands them.

## Operator step (not in this PR)

To enable: add a strong random `LEASE_PLANE_NODE_COOKIE` to `~/.config/cirwel/secrets.env`, then one restart (`launchctl kickstart -k gui/$(id -u)/com.unitares.lease-plane`). That single restart is the last forced one for stateless changes.