### PR TITLE
fix(resident-progress): measure sentinel via substrate-agnostic check-ins

### DIFF
--- a/src/background_tasks.py
+++ b/src/background_tasks.py
@@ -632,6 +632,7 @@ async def progress_flat_probe_task(interval_seconds: float | None = None):
     from src.resident_progress.sentinel_source import SentinelPulseSource
     from src.resident_progress.snapshot_writer import SnapshotWriter
     from src.resident_progress.sources import (
+        CheckinSource,
         EISVSyncSource,
         KnowledgeDiscoverySource,
         MetricsSeriesSource,
@@ -688,6 +689,7 @@ async def progress_flat_probe_task(interval_seconds: float | None = None):
         "eisv_sync_rows":   EISVSyncSource(db),
         "metrics_series":   MetricsSeriesSource(db),
         "sentinel_pulse":   SentinelPulseSource(db),
+        "agent_checkins":   CheckinSource(db),
     }
     probe = ProgressFlatProbe(
         sources_by_name=sources,

--- a/src/resident_progress/registry.py
+++ b/src/resident_progress/registry.py
@@ -45,13 +45,13 @@ RESIDENT_PROGRESS_REGISTRY: dict[str, ResidentConfig] = {
     "watcher":    ResidentConfig("watcher_findings", "rows_any",     timedelta(hours=6),     1, expected_cadence_s=None),
     "steward":    ResidentConfig("eisv_sync_rows",   "rows_written", timedelta(minutes=30),  1, expected_cadence_s=300),
     "chronicler": ResidentConfig("metrics_series",   "rows_written", timedelta(hours=26),    1, expected_cadence_s=86400),
-    # Sentinel migrated to the Elixir/BEAM runtime (com.unitares.sentinel-beam),
-    # which does not post record_progress_pulse — so the sentinel_pulse source
-    # read a permanent 0 and the probe false-flagged sentinel as "flat-candidate"
-    # against a 60s expected cadence. Retired from the progress probe: BEAM
-    # sentinel liveness shows via the resident strip + its launchd KeepAlive, and
-    # its findings still feed Vigil. To re-cover it here, re-add an entry and have
-    # the BEAM sentinel emit record_progress_pulse (the source is still wired).
+    # Sentinel runs on the Elixir/BEAM runtime (com.unitares.sentinel-beam). It
+    # does NOT post record_progress_pulse (Python-only) but it DOES check in via
+    # process_agent_update like every other resident — so it's measured on the
+    # substrate-agnostic `agent_checkins` source (core.agent_state), not the
+    # Python pulse. PR #566 retired it as a stopgap; this is the real re-key.
+    # Cadence is the BEAM fleet-cycle (~5min), not the old Python 60s loop.
+    "sentinel":   ResidentConfig("agent_checkins",   "checkin_count", timedelta(minutes=30),  1, expected_cadence_s=300),
 }
 
 

--- a/src/resident_progress/sources.py
+++ b/src/resident_progress/sources.py
@@ -144,3 +144,49 @@ class MetricsSeriesSource:
             )
         n = int(row["n"]) if row else 0
         return {u: n for u in resident_uuids}
+
+
+class CheckinSource:
+    """Counts genuine governance check-ins (``core.agent_state`` rows) per
+    resident in the window — a *substrate-agnostic* productivity signal.
+
+    Unlike the role-specific sources (kg_writes, eisv_sync_rows, …), this reads
+    the universal channel EVERY resident uses to report a cycle of work:
+    ``process_agent_update`` → ``core.agent_state``. That makes it correct
+    regardless of runtime — the BEAM Sentinel checks in over REST exactly like
+    the Python residents did. Used for residents whose "work" IS the check-in
+    (Sentinel, after its BEAM migration); the old ``record_progress_pulse``
+    pulse was a Python-sentinel-only channel the BEAM runtime never wrote.
+
+    Mapping gotcha (load-bearing — cost a misdiagnosis 2026-06-03):
+    ``core.agent_state`` has NO ``agent_id`` column; it keys on ``identity_id``
+    (the ``core.identities`` PK). The resolved ``resident_uuids`` are agent_id
+    HANDLES (the anchor's ``agent_uuid``), so we join through ``identities`` and
+    match ``i.agent_id``, NOT ``s.identity_id``. The join also folds re-onboards
+    / UUID rotation under one handle. Synthetic (bootstrap) rows are excluded so
+    the count reflects real cycles, not genesis seeding.
+    """
+    name = "agent_checkins"
+
+    def __init__(self, db) -> None:
+        self._db = db
+
+    async def fetch(self, resident_uuids: list[str], window: timedelta) -> dict[str, int]:
+        if not resident_uuids:
+            return {}
+        async with self._db.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT i.agent_id::text AS uuid, count(*) AS n
+                FROM core.agent_state s
+                JOIN core.identities i ON i.identity_id = s.identity_id
+                WHERE i.agent_id = ANY($1::text[])
+                  AND s.recorded_at > now() - $2::interval
+                  AND s.synthetic IS NOT TRUE
+                GROUP BY i.agent_id
+                """,
+                resident_uuids,
+                window,
+            )
+        counts = {r["uuid"]: int(r["n"]) for r in rows}
+        return {u: counts.get(u, 0) for u in resident_uuids}

--- a/tests/resident_progress/test_registry.py
+++ b/tests/resident_progress/test_registry.py
@@ -14,11 +14,12 @@ from src.resident_progress.registry import (
 )
 
 
-def test_registry_has_four_residents():
-    # Sentinel was retired when it moved to the BEAM runtime (it no longer
-    # posts record_progress_pulse). See registry.py for the rationale.
+def test_registry_has_five_residents():
+    # Sentinel is back on a substrate-agnostic source (agent_checkins) after
+    # its BEAM migration — it checks in via process_agent_update like the rest.
+    # (PR #566 retired it as a stopgap; this re-keys it correctly.)
     assert set(RESIDENT_PROGRESS_REGISTRY) == {
-        "vigil", "watcher", "steward", "chronicler"
+        "vigil", "watcher", "steward", "chronicler", "sentinel"
     }
 
 
@@ -27,7 +28,7 @@ def test_registry_entries_have_required_fields():
         assert isinstance(cfg, ResidentConfig)
         assert cfg.source in {
             "kg_writes", "watcher_findings", "eisv_sync_rows",
-            "metrics_series", "sentinel_pulse",
+            "metrics_series", "sentinel_pulse", "agent_checkins",
         }
         assert cfg.window.total_seconds() > 0
         assert cfg.threshold >= 1
@@ -47,6 +48,7 @@ def test_registry_cadences_match_resident_natural_periods():
         label: cfg.expected_cadence_s
         for label, cfg in RESIDENT_PROGRESS_REGISTRY.items()
     }
+    assert cadences["sentinel"] == 300      # BEAM fleet-cycle (~5min)
     assert cadences["steward"] == 300       # 5-min EISV sync
     assert cadences["vigil"] == 1800        # 30-min launchd cron
     assert cadences["watcher"] is None      # event-driven
@@ -103,7 +105,7 @@ def test_is_event_driven_label_only_true_for_watcher():
     # (residents.js, agents.js) — they consume this flag to suppress
     # "Inactive" badges and pick the right pill style.
     assert is_event_driven_label("watcher") is True
-    for label in ("vigil", "steward", "chronicler"):
+    for label in ("vigil", "steward", "chronicler", "sentinel"):
         assert is_event_driven_label(label) is False, label
 
 

--- a/tests/resident_progress/test_sources.py
+++ b/tests/resident_progress/test_sources.py
@@ -9,6 +9,7 @@ from src.resident_progress.sources import (
     KnowledgeDiscoverySource,
     EISVSyncSource,
     MetricsSeriesSource,
+    CheckinSource,
     CHRONICLER_SERIES_NAMES,
 )
 
@@ -106,4 +107,66 @@ async def test_metrics_series_source_returns_uniform_count(test_db):
 async def test_kg_source_empty_uuid_list_no_query(test_db):
     src = KnowledgeDiscoverySource(test_db)
     out = await src.fetch([], timedelta(hours=1))
+    assert out == {}
+
+
+# --- CheckinSource: substrate-agnostic productivity via core.agent_state ---
+
+
+async def _seed_identity_with_state(conn, handle, *, synthetic):
+    """Insert (or reset) the agents->identities->agent_state chain for a handle
+    + one agent_state row. Idempotent across re-runs via delete-first.
+    (identities.agent_id is a FK to core.agents.id, so the agent must exist.)"""
+    await conn.execute(
+        "DELETE FROM core.agent_state WHERE identity_id IN "
+        "(SELECT identity_id FROM core.identities WHERE agent_id=$1)", handle
+    )
+    await conn.execute("DELETE FROM core.identities WHERE agent_id=$1", handle)
+    await conn.execute("DELETE FROM core.agents WHERE id=$1", handle)
+    await conn.execute(
+        "INSERT INTO core.agents (id, api_key) VALUES ($1, 'test')", handle
+    )
+    iid = await conn.fetchval(
+        "INSERT INTO core.identities (agent_id, api_key_hash) VALUES ($1, 'test') "
+        "RETURNING identity_id", handle
+    )
+    await conn.execute(
+        "INSERT INTO core.agent_state (identity_id, synthetic) VALUES ($1, $2)",
+        iid, synthetic,
+    )
+
+
+@pytest.mark.asyncio
+async def test_checkin_source_returns_zero_for_unknown_handle(test_db):
+    src = CheckinSource(test_db)
+    out = await src.fetch(["no-such-handle-000"], timedelta(minutes=30))
+    assert out == {"no-such-handle-000": 0}
+
+
+@pytest.mark.asyncio
+async def test_checkin_source_counts_real_checkins_via_agent_id_join(test_db):
+    # Exercises the agent_id(handle) -> identity_id(PK) join. A naive
+    # `WHERE identity_id = handle` would return 0 here (the 2026-06-03 bug).
+    handle = "test-checkin-handle-real"
+    async with test_db.acquire() as conn:
+        await _seed_identity_with_state(conn, handle, synthetic=False)
+    src = CheckinSource(test_db)
+    out = await src.fetch([handle], timedelta(minutes=30))
+    assert out[handle] == 1
+
+
+@pytest.mark.asyncio
+async def test_checkin_source_excludes_synthetic_bootstrap_rows(test_db):
+    handle = "test-checkin-handle-synthetic"
+    async with test_db.acquire() as conn:
+        await _seed_identity_with_state(conn, handle, synthetic=True)
+    src = CheckinSource(test_db)
+    out = await src.fetch([handle], timedelta(minutes=30))
+    assert out[handle] == 0  # genesis/bootstrap seeding is not "work done"
+
+
+@pytest.mark.asyncio
+async def test_checkin_source_empty_uuid_list_no_query(test_db):
+    src = CheckinSource(test_db)
+    out = await src.fetch([], timedelta(minutes=30))
     assert out == {}


### PR DESCRIPTION
## What & why
Re-keys **sentinel** onto a runtime-neutral productivity source, **superseding #566's stopgap retire**. The full trace (this session): sentinel-beam is a *healthy, checking-in resident* — it posts `process_agent_update` (~6 check-ins / 30min, verified live), holds leases, emits findings. Its permanent `flat-candidate` was **never** a substrate or wiring failure — the probe's `sentinel_pulse` source watched `record_progress_pulse`, a **Python-sentinel-only** channel the BEAM runtime never writes. The probe was looking in the wrong drawer.

This is the "all residents, any substrate" fix we scoped: productivity measured off the **universal channel every resident uses** — the governance check-in.

## Changes
- **`CheckinSource`** (`sources.py`): counts genuine `core.agent_state` rows per resident in the window. Substrate-agnostic — Python or BEAM, a check-in is a unit of work reported.
- **Registry**: re-add sentinel → `source=agent_checkins`, `cadence=300s` (BEAM fleet-cycle ~5min, not the old Python 60s loop).
- **Registered** the source in the probe (`background_tasks.py`). `SentinelPulseSource` stays registered (unused, harmless — re-lightable).

## The gotcha this bakes in (so nobody re-trips it)
`core.agent_state` keys on `identity_id` (a **bigint** serial PK); the resolved resident UUIDs are `agent_id` **text handles** (the anchor's `agent_uuid`, e.g. `f92dcea8…`). So the query **joins through `core.identities` and matches `agent_id`, not `identity_id`.** A naive `WHERE identity_id = handle` returns 0 — that exact mistake cost a misdiagnosis earlier today. Documented in the source docstring and asserted by a join-exercising test. Synthetic/bootstrap rows excluded.

## Relationship to #566
#566 (merged) retired sentinel to silence the false amber — a stopgap. This restores it as a first-class resident measured correctly. The canary is visible again, which is the whole point of proving a BEAM resident integrates.

## Follow-up (separate)
Option 2 — a **lease-presence** source feeding the *liveness* axis off the Plexus lease plane (`:8788`) — is the complementary substrate-neutral signal. Scoped separately; the read API (`GET /v1/lease/status?surface_id=`) exists.

## Tests
Re-add sentinel registry assertions; 4 `CheckinSource` tests (join, synthetic-exclusion, zero, empty). `tests/resident_progress/` = **75 passed**. Source query live-verified against the running DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)