### PR TITLE
fix(mirror): stop non-sequitur fleet stat + false "you're stuck" nudges

### DIFF
--- a/src/mcp_handlers/response_formatter.py
+++ b/src/mcp_handlers/response_formatter.py
@@ -244,12 +244,18 @@ def _format_mirror(response_data: dict, saved_trust_tier: Any, meta: Any = None)
                     "low_confidence_trajectory_health",
                     cal.get("low_confidence_accuracy", "?"),
                 )
-                mirror_signals.append(
-                    f"Fleet calibration: {trajectory_health:.0%} trajectory health over "
-                    f"{cal['total_decisions']} fleet-wide decisions "
-                    f"(high-conf health: {high_conf_health}, "
-                    f"low-conf health: {low_conf_health})"
-                )
+                # Only surface the fleet number when it is actually informative —
+                # i.e. when fleet trajectory health is degrading. At steady-high
+                # (~0.99 on every check-in) it is a constant dashboard stat with
+                # zero per-turn signal that reads as a non-sequitur in a per-agent
+                # mirror. The INVERTED case above still fires regardless.
+                if isinstance(trajectory_health, (int, float)) and trajectory_health < 0.95:
+                    mirror_signals.append(
+                        f"Fleet calibration degrading: {trajectory_health:.0%} trajectory health over "
+                        f"{cal['total_decisions']} fleet-wide decisions "
+                        f"(high-conf health: {high_conf_health}, "
+                        f"low-conf health: {low_conf_health})"
+                    )
 
     # 3. Complexity divergence — suppress on first few check-ins (no baseline)
     update_count = getattr(meta, 'total_updates', 999) if meta else 999
@@ -261,9 +267,13 @@ def _format_mirror(response_data: dict, saved_trust_tier: Any, meta: Any = None)
             reported = continuity.get("self_reported_complexity", 0)
             derived = continuity.get("derived_complexity", 0)
             divergence = continuity.get("complexity_divergence", 0)
+            # Neutral, recorded observation — not an interrogation. The derived
+            # value is a surface-feature proxy; the self-report is the richer
+            # signal, so a divergence is calibration data, not a demand to
+            # justify "difficulty" on an otherwise-healthy check-in.
             mirror_signals.append(
-                f"You reported complexity={reported:.2f} but system derives {derived:.2f} "
-                f"(divergence={divergence:.2f}) — what's driving your sense of difficulty?"
+                f"Complexity calibration: you reported {reported:.2f}, surface estimate "
+                f"{derived:.2f} (Δ{divergence:.2f}) — logged for the calibration curve."
             )
         else:
             # Fallback to calibration_feedback if continuity not present
@@ -274,8 +284,8 @@ def _format_mirror(response_data: dict, saved_trust_tier: Any, meta: Any = None)
                     reported = complexity_info.get("reported", 0)
                     derived = complexity_info.get("derived", 0)
                     mirror_signals.append(
-                        f"You reported complexity={reported:.2f} but system estimates {derived:.2f} "
-                        f"— what's driving your sense of difficulty?"
+                        f"Complexity calibration: you reported {reported:.2f}, surface estimate "
+                        f"{derived:.2f} — logged for the calibration curve."
                     )
 
     # 4. Restorative action — surface if system is cooling down

--- a/src/mcp_handlers/updates/enrichments.py
+++ b/src/mcp_handlers/updates/enrichments.py
@@ -1451,8 +1451,21 @@ def _generate_mirror_question(ctx: UpdateContext, signals: list) -> str | None:
         text_lower = (ctx.response_text or "").lower()
         verdict = ctx.metrics_dict.get("verdict", "proceed")
 
-        if "stuck" in text_lower or "blocked" in text_lower:
-            return "You said you're stuck. What's the smallest concrete step that would unblock you right now?"
+        # Only nudge on a genuine first-person "I'm stuck" — not on any text that
+        # merely contains the substring "stuck"/"blocked" (e.g. reporting a lease
+        # that "blocked my edits" or a fix that "unblocks" something). The bare
+        # substring match fabricated "you said you're stuck" on check-ins that
+        # described a *resolved* or external block. (2026-06-03 dogfood.)
+        first_person_stuck = any(
+            p in text_lower
+            for p in (
+                "i'm stuck", "im stuck", "i am stuck", "i feel stuck",
+                "feeling stuck", "i'm blocked", "im blocked", "i am blocked",
+                "still stuck",
+            )
+        )
+        if first_person_stuck:
+            return "You flagged being stuck. What's the smallest concrete step that would unblock you right now?"
 
         if verdict in ("guide", "pause", "reject"):
             return f"Your state just triggered a {verdict} verdict. What changed immediately before that?"
@@ -1468,12 +1481,12 @@ def _generate_mirror_question(ctx: UpdateContext, signals: list) -> str | None:
                 return "You're close to a risk edge. What assumption would you verify before continuing?"
             return "You're close to a governance edge. What's one simplification that would make the next step safer?"
 
-        disagreement = _get_complexity_disagreement(response_data, ctx.meta)
-        if disagreement:
-            return (
-                "You and the system disagree on difficulty. "
-                "Is that coming from scope, uncertainty, or hidden dependencies?"
-            )
+        # Complexity divergence is surfaced as a neutral, recorded signal line
+        # in the mirror (response_formatter._format_mirror), NOT as an
+        # in-the-moment question demanding the agent justify itself on an
+        # otherwise-healthy check-in. The derived complexity is a surface-feature
+        # proxy; the self-report is the richer signal, so a divergence is data
+        # for the calibration curve, not an interrogation. (2026-06-03.)
 
         if isinstance(conf_rel, dict):
             external = conf_rel.get("external_provided")

--- a/tests/test_enrichments_mirror.py
+++ b/tests/test_enrichments_mirror.py
@@ -144,7 +144,11 @@ class TestGenerateMirrorQuestion:
         question = _generate_mirror_question(ctx, signals=[])
         assert question is None
 
-    def test_complexity_disagreement_returns_question(self):
+    def test_complexity_disagreement_no_longer_returns_question(self):
+        # Complexity divergence is now surfaced as a neutral, recorded mirror
+        # *signal* line (response_formatter._format_mirror), not as an
+        # in-the-moment question demanding the agent justify itself on an
+        # otherwise-healthy check-in. (2026-06-03)
         ctx = _make_ctx(
             response_data={
                 "continuity": {
@@ -155,8 +159,19 @@ class TestGenerateMirrorQuestion:
             }
         )
         question = _generate_mirror_question(ctx, signals=[])
-        assert question is not None
-        assert "disagree on difficulty" in question.lower()
+        assert question is None
+
+    def test_third_person_blocked_does_not_trigger_stuck_question(self):
+        # Regression: a check-in that merely contains "blocked"/"stuck" while
+        # describing a *resolved* or external event must not fabricate a
+        # "you're stuck" nudge. Only genuine first-person stuckness should.
+        for text in (
+            "Cleared stale leases that blocked my edits; all green now.",
+            "The fix unblocks future sessions.",
+            "Investigated where the pipeline gets stuck for other agents.",
+        ):
+            ctx = _make_ctx(response_text=text)
+            assert _generate_mirror_question(ctx, signals=[]) is None, text
 
     def test_autopilot_signal_returns_question(self):
         ctx = _make_ctx()

--- a/tests/test_response_formatter.py
+++ b/tests/test_response_formatter.py
@@ -605,7 +605,24 @@ class TestFormatMirror:
         assert "fleet" in signal.lower(), \
             "Calibration trajectory-health signal must be labeled fleet-wide"
 
-    def test_complexity_divergence_question(self):
+    def test_fleet_calibration_suppressed_when_healthy(self):
+        # At steady-high fleet health the line is a constant dashboard stat with
+        # no per-turn signal — it must NOT appear in a per-agent mirror.
+        data = _sample_response()
+        data["learning_context"] = {
+            "calibration": {
+                "insight": "Well calibrated",
+                "total_decisions": 41705,
+                "trajectory_health": 0.99,
+                "high_confidence_trajectory_health": 0.99,
+                "low_confidence_trajectory_health": 0.99,
+            }
+        }
+        result = _format_mirror(data, saved_trust_tier=None)
+        assert not any("fleet calibration" in s.lower() for s in result["mirror"]), \
+            "Healthy fleet calibration must be suppressed (no non-sequitur dashboard stat)"
+
+    def test_complexity_divergence_signal_is_neutral_not_interrogation(self):
         data = _sample_response()
         data["calibration_feedback"] = {
             "complexity": {
@@ -615,8 +632,12 @@ class TestFormatMirror:
             }
         }
         result = _format_mirror(data, saved_trust_tier=None)
-        assert any("complexity=0.80" in s for s in result["mirror"])
-        assert any("what's driving" in s.lower() for s in result["mirror"])
+        # Recorded observation, not a demand to justify "difficulty".
+        assert any("you reported 0.80" in s and "surface estimate" in s for s in result["mirror"])
+        assert not any(
+            "what's driving" in s.lower() or "sense of difficulty" in s.lower()
+            for s in result["mirror"]
+        )
 
     def test_mirror_signals_from_enrichment(self):
         data = _sample_response()
@@ -738,7 +759,7 @@ class TestFormatMirror:
             "complexity_divergence": 0.48,
         }
         result = _format_mirror(data, saved_trust_tier=None)
-        assert any("complexity=0.70" in s for s in result["mirror"])
+        assert any("you reported 0.70" in s for s in result["mirror"])
         assert any("0.22" in s for s in result["mirror"])
 
     def test_continuity_takes_precedence_over_calibration_feedback(self):
@@ -753,7 +774,7 @@ class TestFormatMirror:
         }
         result = _format_mirror(data, saved_trust_tier=None)
         # Should use continuity (0.7/0.22), not calibration_feedback (0.8/0.28)
-        assert any("complexity=0.70" in s for s in result["mirror"])
+        assert any("you reported 0.70" in s for s in result["mirror"])
 
     def test_restorative_action_surfaced(self):
         data = _sample_response()
@@ -780,7 +801,7 @@ class TestFormatMirror:
             "complexity": {"reported": 0.8, "derived": 0.28, "discrepancy": 0.52}
         }
         result = _format_mirror(data, saved_trust_tier=None)
-        assert any("complexity=0.80" in s for s in result["mirror"])
+        assert any("you reported 0.80" in s for s in result["mirror"])
 
     def test_complexity_divergence_suppressed_early(self):
         """With meta.total_updates <= 3, complexity divergence is suppressed."""
@@ -811,7 +832,7 @@ class TestFormatMirror:
         meta = MagicMock()
         meta.total_updates = 10
         result = _format_mirror(data, saved_trust_tier=None, meta=meta)
-        assert any("complexity=0.70" in s for s in result["mirror"])
+        assert any("you reported 0.70" in s for s in result["mirror"])
 
 
 class TestFormatResponseMirror:


### PR DESCRIPTION
## Why

Operator feedback (dogfood, 2026-06-03): mirror-mode `process_agent_update` responses surface text that reads as non-topical to the agent receiving it — a global dashboard stat, a fabricated "you're stuck" nudge, and an interrogating complexity prompt on healthy check-ins. A proprioceptive mirror should reflect *this agent's* state, quietly; it was reflecting the fleet and demanding self-justification.

## What (all server-side → reaches every agent, not just one harness)

1. **Fleet calibration line** — was emitted on every check-in (constant ~99%, zero per-turn signal). Now gated to appear only when fleet trajectory health is actually degrading (`<0.95`). The INVERTED-confidence case still fires.
2. **"You said you're stuck" nudge** — fired on a naive substring match of `stuck`/`blocked` anywhere in the check-in text, so a check-in describing a *resolved* block ("cleared leases that blocked my edits") fabricated a stuck nudge. Now requires genuine first-person phrasing.
3. **Complexity divergence** — the "…what's driving your sense of difficulty?" prompt interrogated the agent on healthy check-ins and treated the surface-feature proxy as the reference. Reframed as a neutral recorded observation ("Complexity calibration: you reported X, surface estimate Y — logged for the calibration curve"); the redundant disagreement *question* is removed.

## Test

`tests/test_response_formatter.py` + `tests/test_enrichments_mirror.py`: fleet line suppressed when healthy / shown when degrading; divergence signal neutral (no interrogation); third-person "blocked" no longer triggers a stuck nudge; complexity-disagreement question removed. Full local gate: 5006 passed (1 unrelated pre-existing failure — `test_canonicalize_resolves_var_to_private_var_on_macos`, an OS-tempdir assertion that can't hold under this sandbox's `TMPDIR=/private/tmp/...`; different subsystem, not touched here).