### PR TITLE
fix(governance): restore behavioral baseline on DB hydrate (fleet-wide is_baselined=false starvation)

### DIFF
--- a/src/agent_monitor_state.py
+++ b/src/agent_monitor_state.py
@@ -345,6 +345,21 @@ async def hydrate_from_db_if_fresh(monitor: UNITARESMonitor, agent_id: str) -> b
         # it as "how much history have we seen" which is exactly len(chrono).
         monitor.state.update_count = len(chrono)
 
+        # Restore the behavioral baseline from the latest row's state_json.
+        # hydrate previously healed only the ODE state, leaving _behavioral_state
+        # fresh (update_count=0) on every JSON-snapshot-loss restart — which kept
+        # the entire fleet permanently is_baselined=false (2026-06-03 starvation).
+        # record_agent_state now persists behavioral_eisv into state_json, so the
+        # DB path is symmetric with the JSON path (PR #545). Fail-open.
+        try:
+            latest_sj = getattr(latest, "state_json", None) or {}
+            beh_blob = latest_sj.get("behavioral_eisv") if isinstance(latest_sj, dict) else None
+            if isinstance(beh_blob, dict) and beh_blob:
+                from src.behavioral_state import BehavioralEISV
+                monitor._behavioral_state = BehavioralEISV.from_dict(beh_blob)
+        except Exception:
+            logger.debug("Behavioral baseline restore during hydrate skipped", exc_info=True)
+
         logger.info(
             "Hydrated monitor from core.agent_state: "
             "%s records, coherence=%.3f, regime=%s",

--- a/src/agent_storage.py
+++ b/src/agent_storage.py
@@ -537,6 +537,7 @@ async def record_agent_state(
     action: Optional[str] = None,
     provenance_context: Optional[Mapping[str, Any]] = None,
     epistemic_class: Optional[str] = "agent_report",
+    behavioral_eisv: Optional[Mapping[str, Any]] = None,
 ) -> int:
     """
     Record agent EISV state to PostgreSQL.
@@ -582,6 +583,12 @@ async def record_agent_state(
         state_json["provenance_context"] = dict(provenance_context)
     if epistemic_class is not None:
         state_json["epistemic_class"] = epistemic_class
+    # Persist the behavioral baseline alongside the ODE state so a JSON-snapshot
+    # loss + DB-hydrate restart restores baseline maturity instead of resetting
+    # it to update_count=0. Symmetric with the JSON path (PR #545); closes the
+    # hydrate gap that left the fleet permanently is_baselined=false (2026-06-03).
+    if behavioral_eisv:
+        state_json["behavioral_eisv"] = dict(behavioral_eisv)
 
     state_id = await db.record_agent_state(
         identity_id=identity.identity_id,

--- a/src/behavioral_state.py
+++ b/src/behavioral_state.py
@@ -255,6 +255,27 @@ class BehavioralEISV:
             d["baseline_confidence"] = round(self.baseline_confidence, 2)
         return d
 
+    def to_dict_for_persistence(self) -> Dict:
+        """Lean snapshot for the append-only DB path (core.agent_state.state_json).
+
+        Carries everything needed to restore baseline maturity across a restart —
+        EMA scalars, alphas, update_count, and the Welford baseline_stats — but
+        OMITS the up-to-100-entry E/I/S/V/obs history arrays. The full
+        ``to_dict_with_history`` (~5KB) is fine for the JSON file (one overwritten
+        file per agent) but would bloat the DB, which appends a row per check-in.
+        Histories rebuild within a few updates after restore; baseline_stats and
+        update_count are what gate ``is_baselined`` and drive z-scoring.
+        """
+        d = self.to_dict()
+        d["alphas"] = dict(self.alphas)
+        d["baseline_stats"] = {
+            "E": self._baseline_E.to_dict(),
+            "I": self._baseline_I.to_dict(),
+            "S": self._baseline_S.to_dict(),
+            "V": self._baseline_V.to_dict(),
+        }
+        return d
+
     def to_dict_with_history(self) -> Dict:
         """Export state with history for persistence."""
         d = self.to_dict()

--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -1512,6 +1512,17 @@ async def execute_post_update_effects(ctx: UpdateContext) -> None:
     except Exception as e:
         logger.debug(f"Drift dialectic trigger skipped: {e}")
 
+    # Snapshot the behavioral baseline so the DB row carries it (survives a
+    # JSON-snapshot loss + DB-hydrate restart). Fail-open: a serialization
+    # error must never break the state record. (Fleet starvation fix 2026-06-03.)
+    try:
+        behavioral_snapshot = (
+            monitor._behavioral_state.to_dict_for_persistence()
+            if monitor is not None else None
+        )
+    except Exception:
+        behavioral_snapshot = None
+
     # PostgreSQL: Record EISV state
     try:
         await agent_storage.record_agent_state(
@@ -1530,6 +1541,7 @@ async def execute_post_update_effects(ctx: UpdateContext) -> None:
                 or (ctx.result.get('decision') or {}).get('action'),
             provenance_context=ctx.agent_state.get("provenance_context"),
             epistemic_class=ctx.epistemic_class,
+            behavioral_eisv=behavioral_snapshot,
         )
         logger.debug(f"PostgreSQL: Recorded state for {agent_id}")
     except ValueError:
@@ -1611,6 +1623,7 @@ async def execute_post_update_effects(ctx: UpdateContext) -> None:
                     or (ctx.result.get('decision') or {}).get('action'),
                 provenance_context=ctx.agent_state.get("provenance_context"),
                 epistemic_class=ctx.epistemic_class,
+                behavioral_eisv=behavioral_snapshot,
             )
             logger.debug(f"PostgreSQL: Created agent and recorded state for {agent_id}")
         except Exception as create_error:

--- a/tests/test_agent_storage.py
+++ b/tests/test_agent_storage.py
@@ -772,6 +772,26 @@ class TestRecordAgentState:
         assert call_kwargs["state_json"]["health_status"] == "healthy"
         assert call_kwargs["state_json"]["E"] == 0.7
         assert call_kwargs["state_json"]["epistemic_class"] == "agent_report"
+        # No behavioral_eisv passed → key absent (backward compatible)
+        assert "behavioral_eisv" not in call_kwargs["state_json"]
+
+    @pytest.mark.asyncio
+    async def test_persists_behavioral_eisv_into_state_json(self):
+        """behavioral_eisv, when supplied, lands in state_json so a DB-hydrate
+        restart can restore baseline maturity (2026-06-03 fleet starvation fix)."""
+        identity = _make_identity(identity_id=42)
+        db = _mock_db(get_identity=identity, record_agent_state=1)
+        beh = {"updates": 30, "warmup": {"is_baselined": True}, "E": 0.31}
+        with patch("src.agent_storage.get_db", return_value=db):
+            from src.agent_storage import record_agent_state
+            await record_agent_state(
+                "agent-1",
+                E=0.31, I=0.81, S=0.24, V=-0.45,
+                regime="CONVERGENCE", coherence=0.29,
+                behavioral_eisv=beh,
+            )
+        call_kwargs = db.record_agent_state.call_args.kwargs
+        assert call_kwargs["state_json"]["behavioral_eisv"] == beh
 
     @pytest.mark.asyncio
     async def test_raises_when_agent_not_found(self):

--- a/tests/test_behavioral_state.py
+++ b/tests/test_behavioral_state.py
@@ -241,3 +241,28 @@ class TestSerialization:
         assert "updates" in d
         # Basic dict should NOT have history
         assert "E_history" not in d
+
+
+def test_to_dict_for_persistence_round_trips_baseline_without_histories():
+    """Lean DB-persistence snapshot: restores baseline maturity (Welford stats +
+    update_count) but omits the bulky history arrays. (Fleet starvation fix.)"""
+    from src.behavioral_state import BehavioralEISV
+
+    src = BehavioralEISV()
+    for _ in range(30):
+        src.update(0.31, 0.81, 0.24)
+    assert src.is_baselined is True
+
+    blob = src.to_dict_for_persistence()
+    # History arrays omitted (the whole point — avoid per-row DB bloat)
+    assert "E_history" not in blob
+    assert "obs_history" not in blob
+    # But baseline_stats + counts present
+    assert "baseline_stats" in blob
+    assert blob["updates"] == 30
+
+    restored = BehavioralEISV.from_dict(blob)
+    assert restored.update_count == 30
+    assert restored.is_baselined is True
+    # Welford baseline survived → z-scoring works post-restore
+    assert restored._baseline_E.count == src._baseline_E.count

--- a/tests/test_monitor_hydration.py
+++ b/tests/test_monitor_hydration.py
@@ -607,3 +607,67 @@ async def test_process_update_authenticated_async_tolerates_missing_meta(monkeyp
     # Handler returned, save was reached (previously skipped via exception)
     assert result is not None
     assert save_called.is_set(), "save_monitor_state_async was not reached"
+
+
+# ─── Behavioral baseline restore during hydrate (2026-06-03 fleet starvation) ──
+# Regression: hydrate healed only the ODE state, leaving _behavioral_state fresh
+# (update_count=0) on every JSON-snapshot-loss restart. Combined with frequent
+# restarts, no agent ever reached the 25-update baseline → fleet-wide
+# is_baselined=false → atypical agents (e.g. Lumen) false-paused on universal
+# thresholds. record_agent_state now persists behavioral_eisv into state_json and
+# hydrate restores it.
+
+@pytest.mark.asyncio
+async def test_hydrate_restores_behavioral_baseline_from_state_json():
+    from src.behavioral_state import BehavioralEISV
+
+    # Build a mature, baselined behavioral state and serialize it as the latest
+    # DB row would carry it.
+    mature = BehavioralEISV()
+    for _ in range(30):
+        mature.update(0.31, 0.81, 0.24)  # Lumen-like low-energy operating point
+    assert mature.is_baselined is True
+    beh_blob = mature.to_dict_with_history()
+
+    monitor = _make_fresh_monitor("hydrate-behavioral")
+    assert monitor._behavioral_state.update_count == 0  # precondition: starved
+
+    fake_identity = MagicMock(identity_id=7)
+    fake_rows_desc = [
+        _FakeStateRow(E=0.31, I=0.81, S=0.24, V=-0.45, coherence=0.29,
+                      regime="CONVERGENCE", state_json={"behavioral_eisv": beh_blob}),
+        _FakeStateRow(E=0.32, I=0.80, S=0.23, V=-0.44, coherence=0.30,
+                      regime="CONVERGENCE"),
+    ]
+    fake_db = MagicMock()
+    fake_db.get_identity = AsyncMock(return_value=fake_identity)
+    fake_db.get_agent_state_history = AsyncMock(return_value=fake_rows_desc)
+
+    with patch("src.db.get_db", return_value=fake_db):
+        applied = await hydrate_from_db_if_fresh(monitor, "hydrate-behavioral")
+
+    assert applied is True
+    # The behavioral baseline survived the restart instead of resetting to 0.
+    assert monitor._behavioral_state.update_count == 30
+    assert monitor._behavioral_state.is_baselined is True
+
+
+@pytest.mark.asyncio
+async def test_hydrate_without_behavioral_blob_leaves_fresh_state():
+    """Backward-compat: rows predating the behavioral_eisv persistence carry no
+    blob — hydrate must not crash and leaves the behavioral state fresh."""
+    monitor = _make_fresh_monitor("hydrate-no-behavioral")
+
+    fake_identity = MagicMock(identity_id=8)
+    fake_rows_desc = [
+        _FakeStateRow(E=0.7, I=0.8, S=0.1, V=0.0, coherence=0.5, regime="EXPLORATION"),
+    ]
+    fake_db = MagicMock()
+    fake_db.get_identity = AsyncMock(return_value=fake_identity)
+    fake_db.get_agent_state_history = AsyncMock(return_value=fake_rows_desc)
+
+    with patch("src.db.get_db", return_value=fake_db):
+        applied = await hydrate_from_db_if_fresh(monitor, "hydrate-no-behavioral")
+
+    assert applied is True
+    assert monitor._behavioral_state.update_count == 0  # unchanged, no crash


### PR DESCRIPTION
## What

Restores the behavioral baseline (`_behavioral_state`) on the DB-hydrate restart path. Fixes the fleet-wide starvation where **no agent ever reaches `is_baselined`**, which caused atypical agents (Lumen) to be false-paused.

## Root cause (verified)

`core.agent_state` (DB) and the per-agent JSON state file are independent persistence paths. JSON saves are sometimes dropped (anyio executor stall — tolerated by design). On restart with a missing JSON file, the monitor DB-hydrates via `hydrate_from_db_if_fresh`, which restored the ODE EISV state + `update_count=len(history)` **but not the behavioral baseline** — it reset to `update_count=0` every dropped-save restart.

Behavioral baseline needs 25 updates to become `is_baselined`; restarts are frequent → no agent ever baselines (observed: all 8 residents `is_baselined=false`). Pre-baseline, `deviation()` returns 0, so behavioral assessment scores against **universal thresholds** rather than the agent's own profile. Lumen's atypical-but-normal operating point (E~0.31, V~-0.45) reads as "high-risk" → `risk 1.15 > beta_high 0.7` → CIRS hard-block pause on the first post-restart check-in (2026-06-03 incident).

Fingerprint: Lumen's top-level `update_count` (58) − behavioral `updates` (8) = **50, exactly the hydrate `limit`**.

## Fix (symmetric with #545, which fixed the JSON path)

- `record_agent_state()` accepts `behavioral_eisv` and persists it into `state_json` via a new **lean** `to_dict_for_persistence()` (baseline_stats + counts + EMA scalars, **no** history arrays — the DB appends a row per check-in, so the full ~5KB `to_dict_with_history` would bloat the table).
- The process_update effects path snapshots the behavioral state (fail-open, `None`-guarded) and passes it at both `record_agent_state` call sites.
- `hydrate_from_db_if_fresh` restores `_behavioral_state` from the latest row's `state_json.behavioral_eisv` when present (fail-open; absent blob → fresh state, backward compatible).

This is **store-and-restore of the agent's own accumulated baseline — not reconstruction from telemetry** (the council-rejected approach per the EISV-validation-gap history).

## Not included (deliberately)

The restart-transient **ODE coherence dip** (coherence 0.288 < tau_low 0.3 for ~1 cycle, self-heals) is a separate, secondary trigger. A narrow per-process ODE-warmup pause-guard for it is a planned follow-up; once agents actually baseline (this PR), the dominant risk-ceiling false-positive class disappears.

## Tests

- `test_hydrate_restores_behavioral_baseline_from_state_json` / `test_hydrate_without_behavioral_blob_leaves_fresh_state`
- `test_persists_behavioral_eisv_into_state_json` (+ absent-case assertion)
- `test_to_dict_for_persistence_round_trips_baseline_without_histories`
- Regression sweep: 412 + 307 across monitor/behavioral/eisv/storage/hydration suites, all green.

## Review

Council-reviewed (architect + adversarial reviewer + live-verifier). Reviewer verdict ship-with-changes; both findings addressed in-PR (the `None` guard and the write-amplification lean variant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)