### PR TITLE
fix(§129): un-blind the substrate-tax gate (nesting) + stop counting shutdown noise

### DIFF
--- a/docs/proposals/section-129-measurement-fix-2026-06-03.md
+++ b/docs/proposals/section-129-measurement-fix-2026-06-03.md
@@ -1,0 +1,40 @@
+# §129 measurement-gate fix — 2026-06-03
+
+Status: fix of the Wave 1 condition-1 / substrate-question measurement gate, after the T+14 checkpoint (2026-06-02) came due and the gate read inconclusive. Council-passed (architect + reviewer + live-verifier, parallel). Does **not** make a Wave 3 / substrate-migration recommendation — it restores the gate so that decision rests on a working measurement.
+
+## Why
+
+The 2026-05-20 measurement gates (#479/#480/#481) anchored a re-evaluation at T+14 = 2026-06-02. Running `scripts/dev/section_129_reeval.py` on 2026-06-03 returned **FAIL with `incident_id` 0/70** — but "FAIL" here meant "the gate cannot trust itself," not "incidents were found." Investigation found the gate was **doubly broken**, in a direction that would have manufactured pro-migration evidence if half-fixed.
+
+## Two bugs (council-confirmed, live-verified)
+
+### Bug 1 — nesting blindness
+
+`emit_coordination_failure_sync` (`src/coordination_failure_emit.py`) stores the caller payload under `AuditEntry.details["payload"]`, and `audit_db.py` maps `details` → the `audit.events.payload` column. So the stored shape is `{"service": …, "payload": {…, "incident_id": …}}` and `incident_id` lives at `payload->'payload'->>'incident_id'`. §129 queried `payload->>'incident_id'` (top level) → **blind to a field present on every row** (verified: 69/69 in-window `anyio_cancellation.background_task` rows carry it nested; 0 at top level).
+
+Fix: query the nested path in **both** the `DISTINCT` count **and** the `?` existence filter, in **both** `check_zero_incidents` and `check_incident_id_wired`. Storage was **not** normalized — `audit.events.payload` is a heterogeneous column shared by dozens of event types; the spec's flat-path language (`wave-0-step-2-call-site-scoping.md:83`) was the error, not the storage shape.
+
+**Divergence to remember:** the dual-write to `audit.coordination_events` stores the caller payload **flat**, so a query *there* uses `payload->>'incident_id'`. The nested path is `audit.events`-only. (Verifier: `audit.coordination_events` currently carries no `incident_id` rows at all.)
+
+### Bug 2 — graceful-shutdown cancellations counted as substrate incidents
+
+`_on_background_task_done` emitted `coordination_failure.anyio_cancellation.background_task` on **every** supervised-task cancellation, including graceful shutdown, where all ~N tasks are cancelled at once. The 14-day window's 70 rows were **69 such cancellations** which the live-verifier collapsed to **8 sub-5ms fanout bursts** (= 8 server restarts; task names all housekeeping: `matview_refresh`, `audit_log_rotation`, `auto_ground_truth_collector`, …). Several were caused by this session's own MCP cutover restarts.
+
+Had only Bug 1 been fixed, §129 would count **69 distinct "incidents"** → condition-3 FAIL → a spurious read of *"anyio substrate-coupling is firing"* → false **pro-BEAM** evidence.
+
+Fix: a one-way `_background_tasks_shutting_down` latch set at the top of `stop_all_background_tasks()` (before the cancel loop, so the done-callbacks fired during the gather-await see it); the cancellation emitter suppresses when set. **Runtime-anomalous** cancellations (server up — e.g. `cancel_and_respawn_task`) still emit, preserving the genuine substrate signal. Tests cover both: shutdown suppresses, runtime cancel still emits.
+
+## What the corrected gate reads
+
+- Nesting fix verified live: `rows_with_incident_id` 0 → 69; `distinct_incidents` 0 → 69.
+- The 69 are historical shutdown noise (already written; the emit-latch only prevents *future* ones), so the **historical** window still shows them. The verifier's fanout analysis establishes the **true substrate-tax incident count for the window is 0**.
+- `coordination_failure.mcp_handler_timeout.tool_decorator` (the substrate-tax signature) fired **0 times in 14 days** (223 all-time, last burst 2026-05-04, gone after the locked-update perf fix). Combined with `ode.numpy_step_ms` p50 22ms / p99 44ms and sub-second p50 at 16 concurrent agents (v0.3.1b), **the latency/substrate-tax justification for Wave 3 remains dissolved.**
+
+## The honest caveat (architect lane) — carry this into any Wave 3 call
+
+A corrected `distinct_incidents = 0` is the **expected** reading for a healthy Python substrate, but the measurement has **low coverage**: 5 of 6 wired `coordination_failure` sub-types have **zero production fires ever**, and the one that historically fired stopped after a perf fix. A zero therefore means *"no instrumented failure mode fired,"* **not** strong *"stay Python"* evidence. The fix makes the gate **non-spurious**, not **complete**. Wave 3, if pursued, rests on the **coordination/ownership / lock-dissolution** architectural argument (A′, operator-committed), not on this latency-class signal.
+
+## Residual follow-ups (out of scope here)
+
+1. `coordination_failure.wave_3a.fallback` (a third emitter, `src/wave3a_beam_proxy.py`) carries **no** `incident_id`, so §129's `rows_with_id < raw_rows` caveat will fire whenever a fallback occurs even in a clean window. The dedup contract says every coordination_failure emit should carry it; extend the proxy emitter. Distinct emitter, not in this council's scope.
+2. The real §129 read needs a **fresh forward window** under representative load (≥500 `core.agent_state` writes/day) now that the gate is trustworthy — the original spec's path-1.

--- a/scripts/dev/section_129_reeval.py
+++ b/scripts/dev/section_129_reeval.py
@@ -71,8 +71,8 @@ def check_incident_id_wired(cur, start: datetime, end: datetime) -> ConditionRes
     cur.execute(
         """
         SELECT
-            count(*) FILTER (WHERE payload ? 'incident_id') AS with_id,
-            count(*)                                        AS total,
+            count(*) FILTER (WHERE payload->'payload' ? 'incident_id') AS with_id,
+            count(*)                                                   AS total,
             min(ts), max(ts)
         FROM audit.events
         WHERE event_type = 'coordination_failure.mcp_handler_timeout.tool_decorator'
@@ -139,12 +139,23 @@ def check_representative_load(cur, start: datetime, end: datetime) -> ConditionR
 
 
 def check_zero_incidents(cur, start: datetime, end: datetime) -> ConditionResult:
+    # NESTING (2026-06-03 fix): emit_coordination_failure_sync stores the
+    # caller payload under AuditEntry.details["payload"], which becomes the
+    # audit.events.payload column, so incident_id lives at
+    # payload->'payload'->>'incident_id' — NOT top-level. The original flat
+    # `payload->>'incident_id'` was blind to it (read 0/70 while the field was
+    # present on every row). NOTE the sibling table differs: the dual-write to
+    # audit.coordination_events stores the caller payload FLAT, so a query there
+    # uses payload->>'incident_id'. Do not copy this nested path to that table.
+    # Graceful-shutdown background_task cancellations no longer emit (they were
+    # benign restart noise inflating the count); see background_tasks.py
+    # _background_tasks_shutting_down.
     cur.execute(
         """
         SELECT
-            count(*)                                  AS raw_rows,
-            count(DISTINCT payload->>'incident_id')   AS distinct_incidents,
-            count(*) FILTER (WHERE payload ? 'incident_id') AS rows_with_id
+            count(*)                                            AS raw_rows,
+            count(DISTINCT payload->'payload'->>'incident_id')  AS distinct_incidents,
+            count(*) FILTER (WHERE payload->'payload' ? 'incident_id') AS rows_with_id
         FROM audit.events
         WHERE event_type LIKE 'coordination_failure.%%'
           AND ts >= %s AND ts < %s

--- a/src/background_tasks.py
+++ b/src/background_tasks.py
@@ -995,6 +995,15 @@ def _prune_log_archives(archive_dir: Path, stem: str, keep_months: int = 6):
 
 _supervised_tasks: list = []
 
+# Set True at the top of stop_all_background_tasks() before the cancel loop.
+# Graceful shutdown cancels every supervised task at once (a sub-5ms fanout
+# burst); those are benign lifecycle, NOT substrate-coupling incidents, so the
+# cancellation emitter suppresses them when this is set. Runtime-anomalous
+# cancellations (server up — e.g. cancel_and_respawn_task) still emit, which is
+# the genuine §129 substrate-tax signal. One-way latch: never reset (once the
+# graceful-shutdown sequence starts, the process is going down).
+_background_tasks_shutting_down: bool = False
+
 
 def _on_background_task_done(task: asyncio.Task) -> None:
     """Callback for background task completion — logs crashes, emits a
@@ -1028,6 +1037,17 @@ def _emit_background_task_cancellation(task_name: str) -> None:
     is defense-in-depth so an ImportError at the wire-up site cannot break
     the supervisor's bookkeeping (the `_supervised_tasks.remove(...)` that
     follows in `_on_background_task_done`)."""
+    if _background_tasks_shutting_down:
+        # Graceful-shutdown teardown cancels all supervised tasks at once; these
+        # are expected lifecycle, not coordination failures. Emitting them
+        # pollutes the §129 substrate-tax incident count with restart noise (a
+        # nesting+noise audit on 2026-06-03 found 69 such rows = 8 restart
+        # bursts). Suppress; runtime-anomalous cancellations (flag still False)
+        # still emit and remain the real signal.
+        logger.debug(
+            "[coord-events] suppressing graceful-shutdown cancellation for task %r", task_name
+        )
+        return
     try:
         from uuid import uuid4
 
@@ -1588,6 +1608,12 @@ def list_restartable_tasks() -> list[str]:
 
 async def stop_all_background_tasks() -> None:
     """Cancel and await all supervised background tasks before teardown."""
+    # Latch the shutdown flag BEFORE the cancel loop so the done-callbacks (which
+    # fire during the gather await below) see it and suppress their cancellation
+    # emits — otherwise every graceful restart writes ~N benign coordination-
+    # failure rows that poison the §129 substrate-tax measurement.
+    global _background_tasks_shutting_down
+    _background_tasks_shutting_down = True
     tasks = [task for task in list(_supervised_tasks) if not task.done()]
     if not tasks:
         return

--- a/tests/test_wave_0_2c_anyio_cancellation.py
+++ b/tests/test_wave_0_2c_anyio_cancellation.py
@@ -29,6 +29,20 @@ sys.path.insert(0, str(project_root))
 EVENT_TYPE = "coordination_failure.anyio_cancellation.background_task"
 
 
+@pytest.fixture(autouse=True)
+def _reset_shutdown_latch():
+    """The shutdown latch (`_background_tasks_shutting_down`) is a one-way
+    module global; other test files call stop_all_background_tasks() which
+    latches it True for the whole pytest process, which would suppress the
+    emits these tests assert on. Reset to the runtime default around each test
+    so ordering can't contaminate the result."""
+    import src.background_tasks as bt
+
+    bt._background_tasks_shutting_down = False
+    yield
+    bt._background_tasks_shutting_down = False
+
+
 @pytest.mark.asyncio
 async def test_cancelled_task_emits_event():
     """A supervised task ending via cancellation MUST trigger an emit
@@ -133,3 +147,63 @@ async def test_emit_failure_does_not_break_supervised_list_bookkeeping():
         await asyncio.sleep(0)
 
     assert task not in _supervised_tasks
+
+
+@pytest.mark.asyncio
+async def test_graceful_shutdown_cancellation_does_not_emit(monkeypatch):
+    """When the graceful-shutdown latch is set, supervised-task cancellations
+    are benign restart teardown and MUST NOT emit a coordination_failure event
+    — they were inflating the §129 substrate-tax incident count with restart
+    noise (2026-06-03 fix). monkeypatch restores the one-way flag after the
+    test so it cannot contaminate the runtime-cancel tests."""
+    import src.background_tasks as bt
+    from src.background_tasks import _supervised_create_task
+
+    async def long_runner():
+        await asyncio.sleep(60)
+
+    monkeypatch.setattr(bt, "_background_tasks_shutting_down", True)
+
+    with patch(
+        "src.coordination_failure_emit.emit_coordination_failure_sync"
+    ) as mock_emit:
+        task = _supervised_create_task(long_runner(), name="test_shutdown_suppressed")
+        await asyncio.sleep(0)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        await asyncio.sleep(0)
+
+    # Suppressed during shutdown — no substrate-tax incident emitted.
+    mock_emit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_runtime_cancellation_still_emits_when_not_shutting_down():
+    """Defense for reviewer Finding 3: a runtime cancellation (flag still
+    False — e.g. cancel_and_respawn_task while the server is up) MUST still
+    emit; the shutdown latch must not over-suppress the genuine signal."""
+    import src.background_tasks as bt
+    from src.background_tasks import _supervised_create_task
+
+    assert bt._background_tasks_shutting_down is False  # default runtime state
+
+    async def long_runner():
+        await asyncio.sleep(60)
+
+    with patch(
+        "src.coordination_failure_emit.emit_coordination_failure_sync"
+    ) as mock_emit:
+        task = _supervised_create_task(long_runner(), name="test_runtime_cancel_emits")
+        await asyncio.sleep(0)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        await asyncio.sleep(0)
+
+    mock_emit.assert_called_once()
+    assert mock_emit.call_args.kwargs["event_type"] == EVENT_TYPE


### PR DESCRIPTION
## Why

The Wave-1 / substrate-question measurement gate (`scripts/dev/section_129_reeval.py`) came due at T+14 (2026-06-02) and read **FAIL, incident_id 0/70** — but that was the gate unable to *trust itself*, not incidents found. Council-passed (architect + reviewer + live-verifier) fix of two bugs that, half-fixed, would have **manufactured pro-migration evidence**.

## Bugs

**1. Nesting blindness.** `emit_coordination_failure_sync` stores the caller payload under `AuditEntry.details["payload"]` → the `audit.events.payload` column → `incident_id` lives at `payload->'payload'->>'incident_id'`, not top level. §129 queried top level → blind to a field present on every row (verified 69/69 in-window). Fixed the path in **both** the `DISTINCT` count **and** the `?` existence filter, in **both** checks. Storage **not** normalized (heterogeneous column; the spec's flat-path language was the bug). The `audit.coordination_events` dual-write stores payload **flat** — divergence documented inline.

**2. Shutdown noise counted as substrate incidents.** `_on_background_task_done` emitted on every cancellation incl. graceful shutdown; the 69 in-window rows = **8 sub-5ms restart bursts** (housekeeping tasks, several from this session's own cutover). Nesting-only fix → §129 counts 69 "incidents" → false FAIL → spurious **pro-BEAM** signal. Fixed with a one-way `_background_tasks_shutting_down` latch set before the cancel loop; runtime-anomalous cancellations still emit (the real signal).

## Verified

- Nesting fix live: `rows_with_incident_id` 0→69, `distinct_incidents` 0→69.
- Tests: shutdown-suppresses + runtime-still-emits, with an autouse fixture resetting the one-way latch so test ordering can't contaminate (caught a real cross-file contamination). `tests/test_wave_0_2c_anyio_cancellation.py` + neighbors: 46 passed together.

## The caveat that rides with any Wave 3 call

A corrected `distinct=0` is the **expected** healthy reading, but **5 of 6** `coordination_failure` sub-types have **never fired** in production — so zero is *"no instrumented failure fired,"* **not** strong *"stay Python"* evidence. The gate is now non-spurious, not complete. Combined with `mcp_handler_timeout.tool_decorator` = 0 in 14d and `ode.numpy_step_ms` p50 22ms, the **latency** case for Wave 3 stays dissolved; Wave 3 rests on the coordination/ownership argument (A′, operator-committed). Full writeup: `docs/proposals/section-129-measurement-fix-2026-06-03.md`.

## Residual (out of scope)

`coordination_failure.wave_3a.fallback` (a third emitter) still lacks `incident_id`; and the real §129 read needs a fresh forward window under representative load now that the gate is trustworthy.