### PR TITLE
fix(governance): warmup structural grace — close the residual cold-ODE restart false-pause

### DIFF
--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -698,6 +698,25 @@ class GovernanceConfig:
     # knowledge graph discovery 2026-05-15T14:27:26.894282+00:00.
     GAP_RECOVERY_CYCLES = 2
 
+    # Warmup structural grace: on the first WARMUP_STRUCTURAL_GRACE_CYCLES
+    # process-LOCAL updates after a process (re)start, the ODE state
+    # (coherence/V) is a cold-start transient — the integrators reset and
+    # state.coherence/V can briefly cross the void/coherence/basin floors even
+    # for a healthy agent. In that window we suppress STRUCTURAL pauses
+    # (void_pause / coherence_pause / basin_pause / cirs coherence-floor) ONLY
+    # when the behavioral baseline is established AND says 'safe' — i.e. the
+    # trustworthy self-relative signal contradicts the cold structural metric.
+    # Risk-ceiling, CIRS resonance, and a non-safe behavioral verdict are NEVER
+    # suppressed (a genuinely-degraded agent has high behavioral risk / a
+    # non-safe verdict). Per-process counter — NOT persisted, NOT restored on
+    # hydrate. Composes with the #575 baseline-restore: that restores the
+    # baseline this guard trusts. (2026-06-03 Lumen restart false-pause; the
+    # behavioral fix alone left a residual void_pause on the cold restart state.)
+    WARMUP_STRUCTURAL_GRACE_CYCLES = 3
+    WARMUP_STRUCTURAL_GRACE_ENABLED = (
+        os.environ.get('GOVERNANCE_WARMUP_STRUCTURAL_GRACE', 'true').lower() == 'true'
+    )
+
     # Pause TTL: an agent paused for longer than this is considered stale
     # and the next gate-traversal is allowed through, letting the
     # categorizer re-evaluate (its own gap-suppression handles the

--- a/src/audit_log.py
+++ b/src/audit_log.py
@@ -177,6 +177,33 @@ class AuditLogger:
         )
         self._write_entry(entry)
 
+    def log_warmup_structural_suppressed(self, agent_id: str, sub_action: str,
+                                         original_reason: str, process_cycle: int,
+                                         coherence: float = None, void: float = None):
+        """Log a STRUCTURAL pause suppressed by the warmup grace window.
+
+        Emitted when a void/coherence/basin (cold-ODE-transient) pause fires in
+        the first few process-LOCAL cycles after a restart, but the restored
+        behavioral baseline is established and judges the agent 'safe'. The pause
+        is downgraded to 'proceed' on the assumption the structural metric is a
+        cold-start artifact, not real degradation. Every suppression is recorded
+        so an operator can audit that no genuine safety signal was masked.
+        """
+        entry = AuditEntry(
+            timestamp=datetime.now().isoformat(),
+            agent_id=agent_id,
+            event_type="warmup_structural_suppressed",
+            confidence=0.0,
+            details={
+                "sub_action": sub_action,
+                "original_reason": original_reason,
+                "process_cycle": process_cycle,
+                "coherence": round(coherence, 4) if coherence is not None else None,
+                "void": round(void, 4) if void is not None else None,
+            }
+        )
+        self._write_entry(entry)
+
     def log_auto_attest(self, agent_id: str, confidence: float, ci_passed: bool,
                        risk_score: float, decision: str, details: Dict = None):
         """Log an auto-attestation event"""

--- a/src/governance_monitor.py
+++ b/src/governance_monitor.py
@@ -163,6 +163,13 @@ class UNITARESMonitor:
         # via audit_logger.log_attest_gap_suppressed. Decrements each cycle.
         self._gap_recovery_cycles_remaining: int = 0
 
+        # Per-process update counter for the warmup STRUCTURAL grace. Counts
+        # process_update calls in THIS process only — NOT persisted, NOT restored
+        # by load/hydrate, so every (re)start begins at 0. Distinct from
+        # state.update_count (lifetime, restored) and from behavioral update_count.
+        # While this is small, the ODE state is a cold-start transient.
+        self._process_local_updates: int = 0
+
         # Tactical prediction registry: open (confidence, id) pairs awaiting an
         # outcome. Minted at check-in time, consumed when an outcome references
         # the id. Enables exact filtration for the sequential calibration lane
@@ -841,6 +848,10 @@ class UNITARESMonitor:
             'metrics': {...},
         }
         """
+        # Per-process cycle count for the warmup STRUCTURAL grace (see
+        # _maybe_warmup_structural_suppress). Reset to 0 on every process start.
+        self._process_local_updates += 1
+
         # Compute elapsed time for gap-aware decay scaling
         now = datetime.now()
         # Guard against NTP step-back / clock skew: dt must never be negative.
@@ -1160,7 +1171,15 @@ class UNITARESMonitor:
         decision = self._maybe_gap_suppress(
             decision, elapsed_seconds, risk_score, confidence
         )
-        
+
+        # Warmup structural grace: on the first few process-LOCAL cycles after a
+        # restart, the cold ODE state can trip the void/coherence/basin floors
+        # even for a healthy agent. Suppress those STRUCTURAL pauses only when the
+        # restored behavioral baseline is established and says 'safe'. Applied
+        # after gap-suppress and after the recording paths above (which saw the
+        # original decision). See _maybe_warmup_structural_suppress.
+        decision = self._maybe_warmup_structural_suppress(decision)
+
         # Determine overall status using health thresholds (aligned with health_checker)
         # Use same thresholds as health_checker for consistency: risk_healthy_max=0.35, risk_moderate_max=0.60
         from src.health_thresholds import HealthThresholds
@@ -1258,6 +1277,82 @@ class UNITARESMonitor:
                 cycles_remaining=self._gap_recovery_cycles_remaining - 1,
             )
         self._gap_recovery_cycles_remaining -= 1
+        return decision
+
+    # Structural pauses that are cold-ODE transients on restart and may be
+    # suppressed during warmup. NOT included: 'risk_pause' (high-risk verdict)
+    # and any oscillation-edged block — those reflect real signal.
+    _WARMUP_SUPPRESSIBLE_SUBACTIONS = frozenset(
+        {'void_pause', 'coherence_pause', 'basin_pause', 'cirs_block'}
+    )
+
+    def _maybe_warmup_structural_suppress(self, decision: Dict) -> Dict:
+        """Suppress a STRUCTURAL pause during the post-restart warmup window.
+
+        Rationale: on the first WARMUP_STRUCTURAL_GRACE_CYCLES process-LOCAL
+        cycles, the ODE integrators are cold and state.coherence/V can briefly
+        cross the void/coherence/basin floors even for a healthy agent (verified
+        2026-06-03: a restored-but-healthy Lumen still tripped void_pause on the
+        first post-restart check-in, with behavioral risk 0.00). We trust the
+        restored behavioral baseline over the cold structural metric — but ONLY
+        when that baseline is established AND says 'safe'. A genuinely-degraded
+        agent has high behavioral risk or a non-safe verdict and is never
+        suppressed; CIRS resonance (oscillation) and the high-risk verdict path
+        are never suppressed. Fail-safe: any uncertainty leaves the pause intact.
+
+        Composes with the DB behavioral-restore (#575), which is what makes the
+        baseline available to trust here. Counter is per-process (not persisted).
+
+        Operator-transparency note (same semantics as _maybe_gap_suppress): this
+        runs AFTER the recording paths (calibration, log_auto_attest,
+        decision_history.append), so those record the ORIGINAL structural pause —
+        the `observe` decision_distribution will show e.g. a `void_pause` for a
+        cycle the agent actually proceeded through. That's intentional (audit sees
+        the true pre-suppress decision); the dedicated warmup_structural_suppressed
+        audit event is the reconciling record.
+        """
+        if not config.WARMUP_STRUCTURAL_GRACE_ENABLED:
+            return decision
+        if self._process_local_updates > config.WARMUP_STRUCTURAL_GRACE_CYCLES:
+            return decision
+        if decision.get('action') != 'pause':
+            return decision
+        if decision.get('sub_action') not in self._WARMUP_SUPPRESSIBLE_SUBACTIONS:
+            return decision
+        # CIRS resonance is accumulated real signal, never a cold-start artifact.
+        if decision.get('nearest_edge') == 'oscillation':
+            return decision
+        # Only trust the behavioral signal when its baseline is established AND
+        # it independently judges the agent safe. Fresh/unbaselined behavioral
+        # (the universal-threshold regime) is exactly what NOT to trust here.
+        bs = self._behavioral_state
+        if not bs.is_baselined:
+            return decision
+        if self._last_behavioral_verdict != 'safe':
+            return decision
+
+        original_reason = decision.get('reason', 'pause')
+        original_sub = decision.get('sub_action')
+        decision['original_action'] = 'pause'
+        decision['warmup_structural_suppressed'] = True
+        decision['action'] = 'proceed'
+        decision['reason'] = (
+            f"warmup-structural-suppressed (was: {original_reason}); "
+            f"behavioral baselined+safe overrides cold structural metric; "
+            f"process_cycle={self._process_local_updates}/"
+            f"{config.WARMUP_STRUCTURAL_GRACE_CYCLES}"
+        )
+        try:
+            audit_logger.log_warmup_structural_suppressed(
+                agent_id=self.agent_id,
+                sub_action=original_sub,
+                original_reason=original_reason,
+                process_cycle=self._process_local_updates,
+                coherence=self.state.coherence,
+                void=self.state.V,
+            )
+        except Exception:
+            logger.debug("warmup_structural_suppressed audit log skipped", exc_info=True)
         return decision
 
     def _compute_phi_and_risk(self, grounded_agent_state, agent_state, task_type):

--- a/tests/test_warmup_structural_grace.py
+++ b/tests/test_warmup_structural_grace.py
@@ -1,0 +1,112 @@
+"""Warmup structural grace: suppress cold-ODE structural pauses on the first few
+process-local cycles after a restart, but ONLY when the restored behavioral
+baseline is established and says 'safe'.
+
+Regression for the 2026-06-03 Lumen restart false-pause: the DB behavioral
+restore (#575) fixed the risk-ceiling trigger but a residual void_pause remained
+on the cold post-restart state (verified: behavioral risk 0.00, yet void_pause).
+This guard closes that, gated on the trustworthy baselined+safe behavioral signal
+so a genuinely-degraded agent (high risk / non-safe verdict) is never suppressed.
+"""
+from unittest.mock import patch
+import pytest
+
+from config.governance_config import GovernanceConfig
+from src.governance_monitor import UNITARESMonitor
+
+
+def _mon(label="wsg"):
+    return UNITARESMonitor(label, load_state=False)
+
+
+def _baseline_safe(m):
+    """Drive the behavioral state to baselined, and stamp the last verdict safe."""
+    for _ in range(30):
+        m._behavioral_state.update(0.34, 0.74, 0.20)
+    assert m._behavioral_state.is_baselined
+    m._last_behavioral_verdict = "safe"
+
+
+def _struct_pause(sub="void_pause", edge="void"):
+    return {"action": "pause", "sub_action": sub, "reason": f"{sub} fired", "nearest_edge": edge}
+
+
+class TestSuppressesWhenBaselinedSafeInWindow:
+    @pytest.mark.parametrize("sub", ["void_pause", "coherence_pause", "basin_pause", "cirs_block"])
+    def test_structural_pause_suppressed(self, sub):
+        m = _mon(); _baseline_safe(m); m._process_local_updates = 1
+        with patch("src.governance_monitor.audit_logger.log_warmup_structural_suppressed"):
+            out = m._maybe_warmup_structural_suppress(_struct_pause(sub, "coherence" if sub == "cirs_block" else "void"))
+        assert out["action"] == "proceed"
+        assert out["warmup_structural_suppressed"] is True
+        assert out["original_action"] == "pause"
+
+
+class TestNeverSuppresses:
+    def test_when_not_baselined(self):
+        m = _mon(); m._last_behavioral_verdict = "safe"; m._process_local_updates = 1
+        assert not m._behavioral_state.is_baselined
+        out = m._maybe_warmup_structural_suppress(_struct_pause())
+        assert out["action"] == "pause"
+
+    def test_when_behavioral_not_safe(self):
+        m = _mon(); _baseline_safe(m); m._last_behavioral_verdict = "caution"; m._process_local_updates = 1
+        out = m._maybe_warmup_structural_suppress(_struct_pause())
+        assert out["action"] == "pause"
+
+    def test_oscillation_edge(self):
+        m = _mon(); _baseline_safe(m); m._process_local_updates = 1
+        out = m._maybe_warmup_structural_suppress(_struct_pause("cirs_block", "oscillation"))
+        assert out["action"] == "pause"
+
+    def test_risk_pause_not_in_suppressible_set(self):
+        m = _mon(); _baseline_safe(m); m._process_local_updates = 1
+        out = m._maybe_warmup_structural_suppress(_struct_pause("risk_pause", "risk"))
+        assert out["action"] == "pause"
+
+    def test_after_window_closes(self):
+        m = _mon(); _baseline_safe(m)
+        m._process_local_updates = GovernanceConfig.WARMUP_STRUCTURAL_GRACE_CYCLES + 1
+        out = m._maybe_warmup_structural_suppress(_struct_pause())
+        assert out["action"] == "pause"
+
+    def test_boundary_last_in_window_still_suppressed(self):
+        """cycle == GRACE_CYCLES is the last IN-window cycle (gate is `> CYCLES`).
+        Pins the boundary so a future `>=` regression is caught."""
+        m = _mon(); _baseline_safe(m)
+        m._process_local_updates = GovernanceConfig.WARMUP_STRUCTURAL_GRACE_CYCLES
+        with patch("src.governance_monitor.audit_logger.log_warmup_structural_suppressed"):
+            out = m._maybe_warmup_structural_suppress(_struct_pause())
+        assert out["action"] == "proceed"
+
+    def test_non_pause_untouched(self):
+        m = _mon(); _baseline_safe(m); m._process_local_updates = 1
+        out = m._maybe_warmup_structural_suppress({"action": "proceed", "sub_action": "approve"})
+        assert out["action"] == "proceed"
+        assert "warmup_structural_suppressed" not in out
+
+    def test_flag_disabled(self):
+        m = _mon(); _baseline_safe(m); m._process_local_updates = 1
+        orig = GovernanceConfig.WARMUP_STRUCTURAL_GRACE_ENABLED
+        try:
+            GovernanceConfig.WARMUP_STRUCTURAL_GRACE_ENABLED = False
+            out = m._maybe_warmup_structural_suppress(_struct_pause())
+            assert out["action"] == "pause"
+        finally:
+            GovernanceConfig.WARMUP_STRUCTURAL_GRACE_ENABLED = orig
+
+
+class TestPerProcessCounter:
+    def test_counter_starts_zero_and_increments_per_update(self):
+        m = _mon()
+        assert m._process_local_updates == 0
+        m.process_update({"response_text": "x", "complexity": 0.2})
+        assert m._process_local_updates == 1
+
+    def test_counter_not_persisted_in_state(self):
+        """The counter lives on the monitor, not GovernanceState — a restored
+        state (high lifetime update_count) must not inflate it."""
+        m = _mon()
+        d = m.state.to_dict()
+        assert "_process_local_updates" not in d
+        assert "process_local_updates" not in d


### PR DESCRIPTION
## What

Second half of the 2026-06-03 Lumen restart false-pause fix. **#575** (merged) restored the behavioral baseline on DB-hydrate, fixing the risk-ceiling trigger. This PR closes the **residual** structural false-pause.

## Why #575 wasn't enough (verified by reproduction probe)

Even with the baseline restored (behavioral risk **0.00**), a healthy agent **still false-pauses on the first post-restart check-in via `void_active`**:

| case | behavioral risk | decision |
|---|---|---|
| pre-#575 (fresh behavioral) | 1.00 | pause (`cirs_block`) |
| **post-#575 (baseline restored)** | **0.00** | **pause (`void_pause`)** ← residual |
| **+ this PR** | **0.00** | **proceed** |

Cause: the ODE integrators are **cold on (re)start**, so `state.coherence`/`V` are transients that briefly cross the void/coherence/basin floors even for a healthy agent.

## Fix

A per-process counter `_process_local_updates` (init 0 in `__init__`, incremented per `process_update`, **not persisted/restored on hydrate**) and `_maybe_warmup_structural_suppress`, wired after `_maybe_gap_suppress`. On the first `WARMUP_STRUCTURAL_GRACE_CYCLES` (3) process-local cycles it downgrades a **structural** pause (`void_pause` / `coherence_pause` / `basin_pause` / `cirs_block` coherence-edge; never `oscillation`) to proceed — **only when** `is_baselined` AND `_last_behavioral_verdict == 'safe'`.

The trustworthy self-relative signal overrides the cold structural metric; a genuinely-degraded agent (high behavioral risk → non-safe verdict, or unbaselined) is **never** suppressed — closing the prior council's "bad agent runs free" concern. Flag-gated `WARMUP_STRUCTURAL_GRACE_ENABLED`; every suppression emits a `warmup_structural_suppressed` audit event. Recording paths run before suppress (same semantics as gap-suppress) so audit/`observe` see the original pause.

**Composes with #575**: that restores the baseline this guard trusts. Neither alone fully prevents the false-pause; together they do.

## Review

Council-reviewed (adversarial). Verdict ship-with-changes; both asks addressed in-PR: boundary test at `cycle == GRACE_CYCLES`, and a documented note on the `decision_history` asymmetry. The reviewer confirmed the `baselined+safe` gate prevents the bad-agent hole, `_last_behavioral_verdict` is non-stale at the call site, and the counter is genuinely per-process (crash-loop mitigated by the gate).

## Tests

14 unit tests (suppress matrix, never-suppress cases incl. unbaselined / non-safe / oscillation / risk_pause / post-window / boundary / flag-off, per-process counter). Regression: 391 green across monitor/behavioral/eisv/cirs/hydration/audit suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)