### PR TITLE
fix(ops): report Ground Crew packet errors through argparse

### DIFF
--- a/scripts/ops/ground_crew.py
+++ b/scripts/ops/ground_crew.py
@@ -621,7 +621,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         claims = list(args.claim)
         evidence: list[str | EvidenceItem] = list(args.evidence)
         for packet_path in args.packet:
-            packet_claims, packet_evidence = load_evidence_packet(packet_path)
+            try:
+                packet_claims, packet_evidence = load_evidence_packet(packet_path)
+            except (OSError, ValueError) as exc:
+                parser.error(f"--packet {packet_path}: {exc}")
             claims.extend(packet_claims)
             evidence.extend(packet_evidence)
         audit = audit_claims(claims, evidence)

--- a/tests/test_ground_crew.py
+++ b/tests/test_ground_crew.py
@@ -345,3 +345,18 @@ def test_audit_json_uses_packet_evidence_ids(tmp_path, capsys) -> None:
     assert payload["audit"]["supported"][0]["claim"] == "Ground Crew pulse returned [SILENT]"
     assert payload["audit"]["supported"][0]["evidence_id"] == "cmd:pulse"
     assert payload["audit"]["supported"][0]["source"] == "terminal"
+
+
+def test_audit_packet_errors_use_argparse_reporting(tmp_path, capsys) -> None:
+    """Malformed packet input should fail like a CLI usage error, not a traceback."""
+    missing_packet = tmp_path / "missing-packet.json"
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(["audit", "--packet", str(missing_packet)])
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 2
+    assert "error:" in captured.err
+    assert "--packet" in captured.err
+    assert "missing-packet.json" in captured.err
+    assert "Traceback" not in captured.err


### PR DESCRIPTION
## Summary
- Convert Ground Crew `audit --packet` load failures into argparse-style CLI errors instead of Python tracebacks.
- Add regression coverage for missing packet paths.

## Verification
- `python3 -m pytest tests/test_ground_crew.py -q -o 'addopts='` → 16 passed
- `python3 -m py_compile scripts/ops/ground_crew.py tests/test_ground_crew.py` → passed
- `./scripts/dev/test-cache.sh --fresh` → 9192 passed, 24 skipped, 2 warnings
- Static added-line scans for hardcoded secrets, shell injection, eval/exec, pickle, and SQL formatting patterns → no matches
- Independent pre-commit review → approved; non-blocking suggestion to add a CLI malformed-schema case later

## Notes
- This keeps Ground Crew operator-facing: malformed packet input now exits through usage/error reporting rather than surfacing a traceback.
