### PR TITLE
feat(elixir): BEAM-native ephemeral-agent orchestrator (Layer A, v0)

### DIFF
--- a/docs/proposals/agent-orchestrator-beam-v0.md
+++ b/docs/proposals/agent-orchestrator-beam-v0.md
@@ -1,0 +1,148 @@
+# Agent Orchestrator on BEAM — v0 (thin slice)
+
+**Created:** June 3, 2026
+**Status:** v0 — thin vertical slice, council-reviewed, lifecycle bugs fixed,
+12 tests + live-verified. NOT merged to any running surface; it is a library +
+smoke, not a service. Scope decision (which layer) made with the operator this
+session: **Layer A — BEAM as orchestrator/supervisor of ephemeral agents**, pulled
+by *fleet capability we lack* + *architectural coherence* (explicitly NOT a fix
+for a measured failure). Lease-binding kept for v0 with a documented self-heal
+caveat (operator call); the `agent:`-scheme fix and a possible
+governance-lineage-injection pivot are deferred follow-ups (see findings).
+
+## What this is — and what it is NOT
+
+This is a **new axis** of the BEAM footprint, distinct from the two existing tracks:
+
+- It is **NOT** the governance-server migration (Wave 1–3 handler dispatch,
+  `beam-footprint-roadmap-v0.md`). That track is about where the governance MCP's
+  handlers run. This is about the *agents that call governance*, not governance.
+- It is **NOT** the lease plane itself (`surface-lease-plane-v0.md`). It is a
+  *client* of the lease plane.
+
+It is BEAM owning the **lifecycle of ephemeral agents** — short-lived external
+runtimes (a Claude SDK process, `claude -p`, a tool worker) — as OTP-supervised
+children, one process per agent, each wrapping a `Port`.
+
+### The trap we did not walk into
+
+Reimplementing the agent loop (call-model → parse-tools → dispatch → loop) in
+Elixir was the rejected option. The harness/SDK is Anthropic-maintained and
+moving fast; rebuilding it to own less is a losing trade. BEAM owns
+**lifecycle**, not the loop. The Port is the boundary: the loop stays in the
+runtime Anthropic maintains.
+
+## Topology
+
+    AgentOrchestrator.Supervisor            (one_for_one)
+    ├── Registry  (AgentOrchestrator.Registry)   agent_id -> runner pid
+    └── AgentSupervisor  (DynamicSupervisor)
+        └── AgentRunner  (GenServer + Port)       restart: :temporary
+
+`restart: :temporary` is deliberate. Ephemeral agents are not resurrected on
+exit — a finished or crashed agent stays finished. The supervisor buys
+*lifecycle ownership* (clean spawn, tracked teardown, lease release, fan-out over
+a known child set), not crash-restart durability. This is the honest scope.
+
+## Lease binding — kept in v0, with an honest caveat
+
+On spawn, an agent optionally acquires a lease for its surface (default
+`agent:<id>`) via the lease plane's RFC §5 HTTP surface; on exit it releases.
+This gives the fleet plane a record of which ephemeral agents are live, and
+admission control is free: `lease: %{required: true}` (default) refuses to start
+the agent if the lease is denied — fail closed. The `LeasePlaneClient` is
+behaviour-injected (`:lease_client` spec key) so tests and standalone runs need
+no live plane.
+
+### CAVEAT — these leases do NOT self-heal at TTL (council finding, 2026-06-03)
+
+An earlier draft of this note claimed "orphans self-heal via the reaper's TTL
+(`remote_heartbeat` = pure DB TTL row)." **That is false for the surface the
+orchestrator actually uses**, and it was caught by council review + verified
+empirically against the live plane:
+
+- The plane routes `holder_kind` **by surface scheme, not by the request body**
+  (`http_router.ex:457-466`). Only `file://` surfaces get the TTL-row
+  `remote_heartbeat` path. Every other scheme — `resident:/`, and any future
+  `agent:` — is coerced to `local_beam`, which spawns an **auto-renewing holder**
+  on the plane's node. The `holder_kind: "remote_heartbeat"` this client sends is
+  silently overridden.
+- Proof: an orphan left by a failed smoke run had its `expires_at` *advancing*
+  under active renewal (12:07:46 → 12:09:26), not decaying toward a TTL reap. It
+  had to be explicitly released.
+
+**Consequence for v0:** lease cleanup rests entirely on the runner's release
+paths (`finalize/2` on exit, `terminate/2` on stop), which the lifecycle-bug
+fixes below now make robust. The **residual risk** is a hard crash that skips
+`terminate/2` (`:brutal_kill`, VM crash): such a lease will NOT self-heal — it is
+held by the plane-side renewing holder until the plane restarts or an operator
+force-releases. The proper fix (an `agent:` scheme with non-renewing TTL-row
+routing) is deferred — see finding 1.
+
+## Verification
+
+- **Unit:** 12 tests, 0 failures (`mix test`, stable across seeds) — supervised
+  spawn/capture/exit, multi-line + merged-stderr + non-zero-exit + env
+  passthrough, executable-not-found refusal, over-long-line bounding, registry
+  list/count/stop, `run_fleet`, lease acquire-on-spawn / release-on-exit /
+  release-on-port-open-failure / required-lease-denial / best-effort (via stub).
+- **Live:** `scripts/live_smoke.exs` against the running plane (127.0.0.1:8788)
+  proves a real acquire→run→release round-trip — `lease_released: true` is
+  asserted, not assumed. (First run reported a false success; the success check
+  now requires the release to actually land. See findings.)
+
+## Lifecycle bug fixes (council review, 2026-06-03)
+
+The slice went through a 3-agent council (code-reviewer + architect +
+live-verifier). Operator chose "fix the bugs, keep lease-binding with the caveat,
+defer the architecture call." Fixed:
+
+1. **Orphan on port-open failure.** `init/1` used a `with/else` where the acquired
+   `lease_id` was out of scope on the port-open-failure branch, so a failed Port
+   open after a successful acquire leaked the lease. Restructured to a `case` so
+   the release path sees the lease.
+2. **Skipped release retry after a transient error.** `terminate/2` skipped its
+   release whenever `release_status` was non-nil — including a prior `{:error,_}`
+   (plane briefly unreachable). Now retries unless the prior release was `:ok` or
+   `:no_lease`. Matters precisely because these leases do not self-heal.
+3. **Exit-status / port-EXIT ordering race.** The `{:exit_status}` handler
+   required `state.port` to still match the reference; if the linked-port
+   `{:EXIT}` cleared it first, the status was dropped, waiters hung forever, and
+   the lease was never released. Both messages now route through a shared
+   `finalize/2` that is order-independent.
+4. **`await/2` caller crash.** A race between `whereis/0` and the call landing
+   could exit the caller `:noproc`; now caught → `{:error, :not_found}`.
+5. **Unbounded partial-line buffer.** A child emitting a line longer than
+   `@line_max_bytes` with no newline grew `partial` without limit; now flushed at
+   the cap.
+
+## Findings surfaced by building the slice (operator/council decisions)
+
+1. **No `agent:` surface scheme — and the missing scheme is *why* leases don't
+   self-heal.** The canonical scheme list is `file dialectic resident capture td`;
+   `agent:` is rejected `invalid_scheme`. Adding it is not "append a string to two
+   allowlists" — it requires a lifecycle-routing decision in `acquire_for_surface`
+   (`http_router.ex:457-466`): ephemeral agents want the **non-renewing TTL-row**
+   path (like `file://`), NOT the auto-renewing `local_beam` holder every non-file
+   scheme currently gets. That touches `Canonicalize` + acquire routing in **both**
+   Elixir and Python (single-writer cross-repo coordination surface per CLAUDE.md)
+   — an operator/council follow-up. Until then, the self-heal caveat above stands.
+   The runner's `:surface_id` is overridable so a valid scheme works today.
+2. **`release_reason` is allowlisted.** Valid: `normal | down_local | reaped_* |
+   handoff` (live-verifier confirmed a 7th, `forced`, in the DB CHECK). The runner
+   releases with `normal`. (The first smoke run used an invalid reason and the
+   release 422'd — caught only because the live success-check was later made
+   honest. The orphan it left is the same one that proved the no-self-heal finding.)
+3. **`holder_kind` is coerced by the plane** (live-verifier). For non-`file://`
+   surfaces the plane stores `local_beam` regardless of the requested
+   `remote_heartbeat`, enforced by a DB CHECK. Callers must not infer accepted
+   `remote_heartbeat` semantics from a 200.
+
+## Deferred (not in v0)
+
+- A control surface (HTTP/MCP) to spawn/list/stop agents from outside BEAM.
+- Distributed Erlang multi-node fan-out.
+- The `agent:` surface scheme (finding 1) and any governance-onboarding env
+  injection contract for spawned agents (so a spawned agent declares lineage to
+  its orchestrator).
+- A launchd plist + deploy story (this is a library + smoke today, not a service).

--- a/elixir/agent_orchestrator/.gitignore
+++ b/elixir/agent_orchestrator/.gitignore
@@ -1,0 +1,23 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Temporary files, for example, from tests.
+/tmp/
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+agent_orchestrator-*.tar

--- a/elixir/agent_orchestrator/config/config.exs
+++ b/elixir/agent_orchestrator/config/config.exs
@@ -1,0 +1,14 @@
+import Config
+
+# Lease plane HTTP boundary. The lease plane binds IPv4 127.0.0.1:8788 only
+# (Bandit does not bind ::1), so the dotted-quad literal is intentional — a
+# `localhost` URL would resolve to ::1 first on macOS Sonoma+ and fail.
+config :agent_orchestrator,
+  lease_plane_base_url: System.get_env("LEASE_PLANE_BASE_URL", "http://127.0.0.1:8788"),
+  # Bearer is read from env at boot. Absent → LeasePlaneClient returns
+  # {:error, :no_bearer} and lease-required agents refuse to start (fail closed).
+  lease_plane_bearer_token: System.get_env("LEASE_PLANE_BEARER_TOKEN"),
+  # Default TTL for an ephemeral agent's remote_heartbeat lease. The lease is a
+  # pure DB TTL row reaped by the lease plane's reaper, so a crashed orchestrator
+  # self-heals within one TTL rather than leaking the surface forever.
+  default_lease_ttl_s: 300

--- a/elixir/agent_orchestrator/lib/agent_orchestrator.ex
+++ b/elixir/agent_orchestrator/lib/agent_orchestrator.ex
@@ -1,0 +1,36 @@
+defmodule AgentOrchestrator do
+  @moduledoc """
+  Public facade for the BEAM-native ephemeral-agent orchestrator.
+
+  Spawn an ephemeral agent as an OTP-supervised external process, optionally
+  bound to a lease on the plane; await it, snapshot it, or fan out a fleet.
+
+      {:ok, id, _pid} = AgentOrchestrator.run(%{cmd: "echo", args: ["hello"]})
+      {:ok, %{exit_status: 0, output: ["hello"]}} = AgentOrchestrator.await(id)
+
+  Lease-bound (requires the lease plane up + `LEASE_PLANE_BEARER_TOKEN`):
+
+      {:ok, id, _} = AgentOrchestrator.run(%{cmd: "claude", args: ["-p", task], lease: %{}})
+
+  See `AgentOrchestrator.AgentRunner` for the full spec.
+  """
+
+  alias AgentOrchestrator.{AgentRunner, AgentSupervisor}
+
+  @doc "Spawn a supervised ephemeral agent. Returns `{:ok, agent_id, pid}`."
+  @spec run(map()) :: {:ok, String.t(), pid()} | {:error, term()}
+  defdelegate run(spec), to: AgentSupervisor, as: :start_agent
+
+  @doc "Spawn a fleet; returns the list of `{:ok, agent_id, pid}` / `{:error, _}` results in order."
+  @spec run_fleet([map()]) :: [{:ok, String.t(), pid()} | {:error, term()}]
+  def run_fleet(specs) when is_list(specs), do: Enum.map(specs, &run/1)
+
+  defdelegate await(agent_id, timeout \\ 30_000), to: AgentRunner
+  defdelegate snapshot(agent_id), to: AgentRunner
+  defdelegate stop(agent_id, reason \\ :operator_stop), to: AgentRunner
+  defdelegate list(), to: AgentRunner
+
+  @doc "Count of live supervised agents."
+  @spec count() :: non_neg_integer()
+  defdelegate count(), to: AgentSupervisor
+end

--- a/elixir/agent_orchestrator/lib/agent_orchestrator/agent_runner.ex
+++ b/elixir/agent_orchestrator/lib/agent_orchestrator/agent_runner.ex
@@ -1,0 +1,415 @@
+defmodule AgentOrchestrator.AgentRunner do
+  @moduledoc """
+  One GenServer per ephemeral agent, wrapping a `Port` to an external runtime.
+
+  The Port is the BEAM↔runtime boundary: the agent's actual model-calling work
+  runs in a separate OS process (a Claude SDK script, `claude -p`, a tool
+  worker), and BEAM owns only its lifecycle. We deliberately do NOT reimplement
+  the agent loop in Elixir — the harness/SDK is Anthropic-maintained; rebuilding
+  it here would be owning a moving target to gain less.
+
+  ## Lifecycle
+
+    1. `init/1` optionally acquires a `remote_heartbeat` lease for the agent's
+       `agent:<id>` surface. If a lease is configured (`:required`) and the
+       acquire fails, the agent refuses to start (admission control, fail closed).
+    2. The Port is opened with `:exit_status` and line framing; stdout+stderr are
+       captured into a bounded buffer.
+    3. On `{:exit_status, status}` the lease is released and the runner stops
+       `:normal` (status 0) or `{:shutdown, {:exit_status, n}}` (non-zero). Being
+       `restart: :temporary`, the supervisor does not resurrect it.
+    4. `terminate/2` releases the lease on any shutdown path (kill, app stop), so
+       the lease is freed promptly rather than waiting out its TTL — the TTL is
+       the backstop for a crash that skips `terminate/2`, not the normal path.
+
+  ## Spec
+
+      %{
+        agent_id: String.t() | nil,        # generated if absent
+        cmd: String.t(),                   # executable name or absolute path (required)
+        args: [String.t()],                # argv (default [])
+        env: [{String.t(), String.t()}],   # extra env for the child (default [])
+        cd: String.t() | nil,              # working dir
+        max_output_lines: pos_integer(),   # buffer cap (default 1000)
+        lease: nil | lease_cfg,            # nil = no lease; map = lease-bound
+        lease_client: module()             # injectable, default LeasePlaneClient
+      }
+
+      lease_cfg :: %{
+        required: boolean(),               # default true — refuse to start if acquire fails
+        holder_agent_uuid: String.t(),     # the agent's governance UUID (generated if absent)
+        ttl_s: pos_integer()               # default from config :default_lease_ttl_s
+      }
+  """
+
+  use GenServer
+
+  import Bitwise
+
+  require Logger
+
+  alias AgentOrchestrator.LeasePlaneClient
+
+  @default_max_lines 1000
+  @line_max_bytes 65_536
+
+  defstruct [
+    :agent_id,
+    :port,
+    :os_pid,
+    :lease_id,
+    :lease_client,
+    :lease_cfg,
+    :exit_status,
+    :release_status,
+    output: [],
+    output_count: 0,
+    max_output_lines: @default_max_lines,
+    partial: "",
+    waiters: []
+  ]
+
+  # Orchestrator-initiated lease release reason. The plane validates
+  # release_reason against an allowlist (normal | down_local | reaped_* |
+  # handoff); "normal" is the orderly-release member.
+  @release_reason "normal"
+
+  # ---------- public API ----------
+
+  def start_link(%{} = spec) do
+    agent_id = Map.fetch!(spec, :agent_id)
+    GenServer.start_link(__MODULE__, spec, name: via(agent_id))
+  end
+
+  @doc "Block until the agent exits (or `timeout` ms). Returns `{:ok, result}` or `{:error, :timeout}`."
+  @spec await(String.t(), timeout()) :: {:ok, map()} | {:error, :timeout | :not_found}
+  def await(agent_id, timeout \\ 30_000) do
+    call(agent_id, :await, timeout)
+  catch
+    :exit, {:timeout, _} ->
+      {:error, :timeout}
+
+    # The agent can exit between whereis/0 and the call landing in its mailbox
+    # (it stops itself on exit). GenServer.call then exits :noproc/:normal —
+    # catch it instead of crashing the caller. The final result is lost on this
+    # narrow race; snapshot/1 during the run or await earlier to avoid it.
+    :exit, _ ->
+      {:error, :not_found}
+  end
+
+  @doc "Current captured output and status without blocking."
+  @spec snapshot(String.t()) :: {:ok, map()} | {:error, :not_found}
+  def snapshot(agent_id), do: call(agent_id, :snapshot)
+
+  @doc "Stop the agent: close the Port (terminating the child) and release its lease."
+  @spec stop(String.t(), term()) :: :ok | {:error, :not_found}
+  def stop(agent_id, reason \\ :operator_stop) do
+    case whereis(agent_id) do
+      nil -> {:error, :not_found}
+      pid -> GenServer.stop(pid, {:shutdown, reason})
+    end
+  end
+
+  @doc "List live agent ids."
+  @spec list() :: [String.t()]
+  def list do
+    Registry.select(AgentOrchestrator.Registry, [{{:"$1", :_, :_}, [], [:"$1"]}])
+  end
+
+  @doc "Generate a short, collision-resistant ephemeral agent id."
+  @spec generate_agent_id() :: String.t()
+  def generate_agent_id do
+    "ag-" <> (:crypto.strong_rand_bytes(6) |> Base.url_encode64(padding: false))
+  end
+
+  # ---------- GenServer ----------
+
+  @impl true
+  def init(spec) do
+    Process.flag(:trap_exit, true)
+    agent_id = Map.fetch!(spec, :agent_id)
+    lease_client = Map.get(spec, :lease_client, LeasePlaneClient)
+    lease_cfg = normalize_lease_cfg(Map.get(spec, :lease), agent_id)
+
+    state = %__MODULE__{
+      agent_id: agent_id,
+      lease_client: lease_client,
+      lease_cfg: lease_cfg,
+      max_output_lines: Map.get(spec, :max_output_lines, @default_max_lines)
+    }
+
+    # Not a `with`: the acquired lease_id must be in scope on the port-open
+    # failure path so we can release it. A `with/else` only sees the failing
+    # clause's value, so the acquired lease_id would be invisible there and the
+    # lease would orphan (and a non-file lease does NOT self-heal — see release
+    # discipline in terminate/2).
+    case maybe_acquire_lease(state) do
+      {:error, :lease_denied, reason} ->
+        {:stop, {:lease_denied, reason}}
+
+      {:ok, lease_id} ->
+        state = %{state | lease_id: lease_id}
+
+        case open_port(spec) do
+          {:ok, port, os_pid} ->
+            Logger.info(
+              "agent #{agent_id} started os_pid=#{os_pid} lease=#{lease_id || "none"} cmd=#{Map.get(spec, :cmd)}"
+            )
+
+            {:ok, %{state | port: port, os_pid: os_pid}}
+
+          {:error, reason} ->
+            # Port failed to open after a lease was taken — release so we don't
+            # leak the surface (state now carries lease_id).
+            _ = maybe_release_lease(state, @release_reason)
+            {:stop, reason}
+        end
+    end
+  end
+
+  @impl true
+  def handle_call(:snapshot, _from, state), do: {:reply, {:ok, result(state)}, state}
+
+  def handle_call(:await, from, %{exit_status: nil} = state) do
+    {:noreply, %{state | waiters: [from | state.waiters]}}
+  end
+
+  def handle_call(:await, _from, state), do: {:reply, {:ok, result(state)}, state}
+
+  @impl true
+  # Line-framed stdout/stderr from the child.
+  def handle_info({port, {:data, {:eol, line}}}, %{port: port} = state) do
+    {:noreply, push_line(state, state.partial <> line)}
+  end
+
+  def handle_info({port, {:data, {:noeol, chunk}}}, %{port: port} = state) do
+    partial = state.partial <> chunk
+
+    # Bound the partial buffer: a child that emits a line longer than
+    # @line_max_bytes with no newline would otherwise grow `partial` without
+    # limit. Flush the oversized fragment as a synthetic line instead.
+    if byte_size(partial) >= @line_max_bytes do
+      {:noreply, push_line(%{state | partial: ""}, partial)}
+    else
+      {:noreply, %{state | partial: partial}}
+    end
+  end
+
+  # exit_status is the authoritative terminal signal. Match on any port and
+  # not-yet-finalized rather than requiring state.port to still equal the
+  # reference — the linked-port {:EXIT} and {:exit_status} can arrive in either
+  # order, and if {:EXIT} cleared state.port first, requiring a match here would
+  # drop the status, hang waiters, and never release the lease.
+  def handle_info({port, {:exit_status, status}}, %{exit_status: nil} = state)
+      when is_port(port) do
+    finalize(state, status)
+  end
+
+  def handle_info({_port, {:exit_status, _status}}, state), do: {:noreply, state}
+
+  # Linked Port EXIT. If exit_status already finalized us, this is just cleanup.
+  # If it has NOT (EXIT won the race, or the port died without a status),
+  # finalize anyway so waiters get a reply and the lease is released — using the
+  # exit reason as the terminal status since no numeric code is available.
+  def handle_info({:EXIT, port, reason}, state) when is_port(port) do
+    if is_nil(state.exit_status) do
+      finalize(%{state | port: nil}, {:port_closed, reason})
+    else
+      {:noreply, %{state | port: nil}}
+    end
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # Terminal finalize: flush any partial line, release the lease, record the
+  # exit status, reply to waiters, and stop. `status` is an integer for a clean
+  # exit or `{:port_closed, reason}` for an abnormal close.
+  defp finalize(state, status) do
+    state = if state.partial != "", do: push_line(%{state | partial: ""}, state.partial), else: state
+    Logger.info("agent #{state.agent_id} exited status=#{inspect(status)}")
+    release_status = maybe_release_lease(state, @release_reason)
+    state = %{state | exit_status: status, port: nil, release_status: release_status}
+    state = reply_waiters(state)
+
+    if status == 0 do
+      {:stop, :normal, state}
+    else
+      {:stop, {:shutdown, {:exit_status, status}}, state}
+    end
+  end
+
+  @impl true
+  def terminate(_reason, state) do
+    # Idempotent with the exit-status path: release returns :not_found harmlessly
+    # if already released. Closing the port here kills the child on operator stop.
+    if state.port, do: safe_close(state.port)
+    # Retry the release UNLESS the finalize path already released cleanly
+    # (:ok) or there was no lease (:no_lease). A previous {:error, _} (e.g. the
+    # plane was briefly unreachable) must NOT be treated as done — a non-file
+    # lease is held by an auto-renewing plane-side holder and will NOT self-heal
+    # at TTL, so the release is the only thing that frees it.
+    unless state.release_status in [:ok, :no_lease] do
+      maybe_release_lease(state, @release_reason)
+    end
+
+    :ok
+  end
+
+  # ---------- internals ----------
+
+  defp via(agent_id), do: {:via, Registry, {AgentOrchestrator.Registry, agent_id}}
+
+  defp whereis(agent_id) do
+    case Registry.lookup(AgentOrchestrator.Registry, agent_id) do
+      [{pid, _}] -> pid
+      [] -> nil
+    end
+  end
+
+  defp call(agent_id, msg, timeout \\ 5_000) do
+    case whereis(agent_id) do
+      nil -> {:error, :not_found}
+      pid -> GenServer.call(pid, msg, timeout)
+    end
+  end
+
+  defp normalize_lease_cfg(nil, _agent_id), do: nil
+
+  defp normalize_lease_cfg(%{} = cfg, agent_id) do
+    # Default surface is `agent:<id>`. NOTE: the lease plane's canonical scheme
+    # list (`file dialectic resident capture td`) does not yet include `agent`,
+    # so an `agent:` surface is rejected with invalid_scheme today. Adding the
+    # scheme touches Canonicalize in BOTH Elixir and Python (single-writer
+    # cross-repo coordination surface) — an operator/council follow-up. Callers
+    # can override `:surface_id` with a currently-valid scheme in the meantime.
+    %{
+      required: Map.get(cfg, :required, true),
+      holder_agent_uuid: Map.get(cfg, :holder_agent_uuid) || uuid4(),
+      surface_id: Map.get(cfg, :surface_id) || "agent:" <> agent_id,
+      ttl_s: Map.get(cfg, :ttl_s, Application.get_env(:agent_orchestrator, :default_lease_ttl_s, 300))
+    }
+  end
+
+  defp maybe_acquire_lease(%{lease_cfg: nil}), do: {:ok, nil}
+
+  defp maybe_acquire_lease(%{lease_cfg: cfg, lease_client: client}) do
+    case client.acquire(cfg.surface_id, cfg.holder_agent_uuid, "remote_heartbeat", cfg.ttl_s) do
+      {:ok, lease_id} ->
+        {:ok, lease_id}
+
+      {:error, reason} ->
+        if cfg.required do
+          {:error, :lease_denied, reason}
+        else
+          Logger.warning("agent lease acquire failed (best-effort, proceeding): #{inspect(reason)}")
+          {:ok, nil}
+        end
+    end
+  end
+
+  defp maybe_release_lease(%{lease_id: nil}, _reason), do: :no_lease
+
+  defp maybe_release_lease(%{lease_id: lease_id, lease_client: client}, reason) do
+    case client.release(lease_id, reason) do
+      :ok ->
+        :ok
+
+      {:error, r} = err ->
+        Logger.warning("agent lease release failed lease=#{lease_id}: #{inspect(r)}")
+        err
+    end
+  end
+
+  defp open_port(spec) do
+    cmd = Map.fetch!(spec, :cmd)
+
+    case resolve_executable(cmd) do
+      nil ->
+        {:error, {:executable_not_found, cmd}}
+
+      path ->
+        opts =
+          [
+            :binary,
+            :exit_status,
+            :stderr_to_stdout,
+            {:line, @line_max_bytes},
+            {:args, Map.get(spec, :args, [])}
+          ]
+          |> maybe_opt(:env, encode_env(Map.get(spec, :env, [])))
+          |> maybe_opt(:cd, Map.get(spec, :cd))
+
+        try do
+          port = Port.open({:spawn_executable, path}, opts)
+          os_pid = port |> Port.info(:os_pid) |> elem(1)
+          {:ok, port, os_pid}
+        rescue
+          e -> {:error, {:port_open_error, Exception.message(e)}}
+        end
+    end
+  end
+
+  defp resolve_executable(cmd) do
+    if String.contains?(cmd, "/"), do: cmd, else: System.find_executable(cmd)
+  end
+
+  defp maybe_opt(opts, _key, nil), do: opts
+  defp maybe_opt(opts, _key, []), do: opts
+  defp maybe_opt(opts, key, val), do: [{key, val} | opts]
+
+  defp encode_env([]), do: []
+
+  defp encode_env(env) do
+    Enum.map(env, fn {k, v} -> {String.to_charlist(k), String.to_charlist(v)} end)
+  end
+
+  defp push_line(state, line) do
+    # Bounded ring: keep newest max_output_lines. Stored newest-first for O(1)
+    # prepend; reversed on read in result/1.
+    output = [line | state.output]
+
+    {output, count} =
+      if state.output_count + 1 > state.max_output_lines do
+        {Enum.take(output, state.max_output_lines), state.max_output_lines}
+      else
+        {output, state.output_count + 1}
+      end
+
+    %{state | output: output, output_count: count, partial: ""}
+  end
+
+  defp reply_waiters(state) do
+    result = result(state)
+    Enum.each(state.waiters, fn from -> GenServer.reply(from, {:ok, result}) end)
+    %{state | waiters: []}
+  end
+
+  defp result(state) do
+    %{
+      agent_id: state.agent_id,
+      os_pid: state.os_pid,
+      lease_id: state.lease_id,
+      exit_status: state.exit_status,
+      running: state.exit_status == nil,
+      lease_released: state.release_status == :ok,
+      output: Enum.reverse(state.output)
+    }
+  end
+
+  defp safe_close(port) do
+    if Port.info(port) != nil, do: Port.close(port)
+  catch
+    :error, _ -> :ok
+  end
+
+  # RFC-4122 v4 UUID without a third-party dep. Version nibble forced to 4 and
+  # the variant high bits to 10xx per §4.4.
+  defp uuid4 do
+    <<a::32, b::16, c::16, d::16, e::48>> = :crypto.strong_rand_bytes(16)
+    c = c &&& 0x0FFF ||| 0x4000
+    d = d &&& 0x3FFF ||| 0x8000
+
+    :io_lib.format("~8.16.0b-~4.16.0b-~4.16.0b-~4.16.0b-~12.16.0b", [a, b, c, d, e])
+    |> IO.iodata_to_binary()
+  end
+end

--- a/elixir/agent_orchestrator/lib/agent_orchestrator/agent_supervisor.ex
+++ b/elixir/agent_orchestrator/lib/agent_orchestrator/agent_supervisor.ex
@@ -1,0 +1,47 @@
+defmodule AgentOrchestrator.AgentSupervisor do
+  @moduledoc """
+  DynamicSupervisor over `AgentRunner` processes — one per live ephemeral agent.
+
+  Children are `restart: :temporary` on purpose. Ephemeral agents are, by
+  definition, not restarted on exit: a finished or crashed agent stays finished.
+  The supervisor exists for *lifecycle ownership* (clean spawn, tracked teardown,
+  lease release on shutdown, fan-out/collect over a known child set), not for
+  crash-restart durability. That is the honest scope: this buys orchestration,
+  not resurrection.
+  """
+
+  use DynamicSupervisor
+
+  alias AgentOrchestrator.AgentRunner
+
+  def start_link(_args), do: DynamicSupervisor.start_link(__MODULE__, [], name: __MODULE__)
+
+  @impl true
+  def init(_), do: DynamicSupervisor.init(strategy: :one_for_one)
+
+  @doc """
+  Spawn a supervised ephemeral agent. `spec` is passed through to
+  `AgentRunner` (see its `t:spec/0`). Returns `{:ok, agent_id, pid}`.
+  """
+  @spec start_agent(map()) :: {:ok, String.t(), pid()} | {:error, term()}
+  def start_agent(%{} = spec) do
+    agent_id = Map.get(spec, :agent_id) || AgentRunner.generate_agent_id()
+    spec = Map.put(spec, :agent_id, agent_id)
+
+    child = %{
+      id: {AgentRunner, agent_id},
+      start: {AgentRunner, :start_link, [spec]},
+      restart: :temporary
+    }
+
+    case DynamicSupervisor.start_child(__MODULE__, child) do
+      {:ok, pid} -> {:ok, agent_id, pid}
+      {:error, {:already_started, _pid}} -> {:error, {:already_running, agent_id}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc "Number of live agents under supervision."
+  @spec count() :: non_neg_integer()
+  def count, do: DynamicSupervisor.count_children(__MODULE__).active
+end

--- a/elixir/agent_orchestrator/lib/agent_orchestrator/application.ex
+++ b/elixir/agent_orchestrator/lib/agent_orchestrator/application.ex
@@ -1,0 +1,36 @@
+defmodule AgentOrchestrator.Application do
+  @moduledoc """
+  OTP entry point for the ephemeral-agent orchestrator.
+
+  This is the BEAM-native fleet runtime axis of the BEAM footprint: it is NOT
+  the governance-server migration (Wave 1-3, `beam-footprint-roadmap-v0.md`) and
+  it is NOT the lease plane itself. It supervises *ephemeral agents* — short-lived
+  external runtimes (a Claude SDK process, `claude -p`, a tool worker) — as
+  OTP children, one `AgentRunner` GenServer per agent, each wrapping a `Port`.
+
+  Topology:
+
+      AgentOrchestrator.Supervisor            (one_for_one)
+      ├── Registry  (AgentOrchestrator.Registry)   agent_id -> runner pid
+      └── AgentSupervisor  (DynamicSupervisor)
+          └── AgentRunner  (GenServer + Port)       restart: :temporary
+
+  Lease-binding to the plane is the architectural-coherence payoff: an agent
+  acquires a `remote_heartbeat` lease on its `agent:<id>` surface when it spawns
+  and releases it on exit, so the fleet plane has a single source of truth for
+  "which ephemeral agents are live" and orphans self-heal via the reaper's TTL.
+  """
+
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    children = [
+      {Registry, keys: :unique, name: AgentOrchestrator.Registry},
+      AgentOrchestrator.AgentSupervisor
+    ]
+
+    opts = [strategy: :one_for_one, name: AgentOrchestrator.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/elixir/agent_orchestrator/lib/agent_orchestrator/lease_plane_client.ex
+++ b/elixir/agent_orchestrator/lib/agent_orchestrator/lease_plane_client.ex
@@ -1,0 +1,95 @@
+defmodule AgentOrchestrator.LeasePlaneClient do
+  @moduledoc """
+  Thin HTTP client for the lease plane's RFC §5 surface, used by `AgentRunner`
+  to bind an ephemeral agent to a lease.
+
+  Uses OTP's built-in `:httpc` so the orchestrator carries no third-party HTTP
+  dependency. The plane is localhost-only (IPv4 127.0.0.1:8788) and bearer-auth'd;
+  this client fails closed when the bearer is absent rather than calling unauth'd.
+
+  The three functions form a behaviour so tests (and standalone runs without a
+  live plane) can inject a stub via the `:lease_client` spec key.
+  """
+
+  @behaviour AgentOrchestrator.LeasePlaneClient.Behaviour
+
+  require Logger
+
+  @impl true
+  def acquire(surface_id, holder_agent_uuid, holder_kind, ttl_s) do
+    body = %{
+      surface_id: surface_id,
+      holder_agent_uuid: holder_agent_uuid,
+      holder_kind: holder_kind,
+      ttl_s: ttl_s
+    }
+
+    case post("/v1/lease/acquire", body) do
+      {:ok, 200, %{"ok" => true, "lease" => %{"lease_id" => lease_id}}} ->
+        {:ok, lease_id}
+
+      {:ok, 409, %{"error" => "held_by_other"} = info} ->
+        {:error, {:held_by_other, Map.get(info, "held_by_uuid")}}
+
+      {:ok, status, %{"error" => err} = info} ->
+        {:error, {:lease_plane_error, status, err, Map.get(info, "reason") || Map.get(info, "detail")}}
+
+      {:ok, status, _body} ->
+        {:error, {:lease_plane_unexpected, status}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @impl true
+  def release(lease_id, reason) do
+    case post("/v1/lease/release", %{lease_id: lease_id, release_reason: reason}) do
+      {:ok, 200, %{"ok" => true}} -> :ok
+      {:ok, 404, _} -> :ok
+      {:ok, status, body} -> {:error, {:release_failed, status, body}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # ---------- internals ----------
+
+  defp post(path, body) do
+    with {:ok, token} <- bearer() do
+      url = base_url() <> path
+      headers = [{~c"authorization", String.to_charlist("Bearer " <> token)}]
+      payload = Jason.encode!(body)
+
+      request = {String.to_charlist(url), headers, ~c"application/json", payload}
+
+      case :httpc.request(:post, request, [{:timeout, 5_000}, {:connect_timeout, 2_000}], []) do
+        {:ok, {{_http, status, _reason}, _resp_headers, resp_body}} ->
+          {:ok, status, decode(resp_body)}
+
+        {:error, reason} ->
+          {:error, {:http, reason}}
+      end
+    end
+  end
+
+  defp bearer do
+    case Application.get_env(:agent_orchestrator, :lease_plane_bearer_token) do
+      nil -> {:error, :no_bearer}
+      "" -> {:error, :no_bearer}
+      token -> {:ok, token}
+    end
+  end
+
+  defp base_url do
+    Application.get_env(:agent_orchestrator, :lease_plane_base_url, "http://127.0.0.1:8788")
+  end
+
+  defp decode(body) when is_list(body), do: decode(IO.iodata_to_binary(body))
+
+  defp decode(body) when is_binary(body) do
+    case Jason.decode(body) do
+      {:ok, map} -> map
+      {:error, _} -> %{"raw" => body}
+    end
+  end
+end

--- a/elixir/agent_orchestrator/lib/agent_orchestrator/lease_plane_client/behaviour.ex
+++ b/elixir/agent_orchestrator/lib/agent_orchestrator/lease_plane_client/behaviour.ex
@@ -1,0 +1,16 @@
+defmodule AgentOrchestrator.LeasePlaneClient.Behaviour do
+  @moduledoc """
+  The lease-binding contract `AgentRunner` depends on. The default
+  implementation is `AgentOrchestrator.LeasePlaneClient` (real HTTP); tests and
+  standalone runs inject a stub via the `:lease_client` spec key.
+  """
+
+  @callback acquire(
+              surface_id :: String.t(),
+              holder_agent_uuid :: String.t(),
+              holder_kind :: String.t(),
+              ttl_s :: pos_integer()
+            ) :: {:ok, String.t()} | {:error, term()}
+
+  @callback release(lease_id :: String.t(), reason :: String.t()) :: :ok | {:error, term()}
+end

--- a/elixir/agent_orchestrator/mix.exs
+++ b/elixir/agent_orchestrator/mix.exs
@@ -1,0 +1,34 @@
+defmodule AgentOrchestrator.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :agent_orchestrator,
+      version: "0.1.0",
+      elixir: "~> 1.19",
+      start_permanent: Mix.env() == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
+      deps: deps()
+    ]
+  end
+
+  def application do
+    # :inets/:ssl provide the built-in :httpc client used by LeasePlaneClient,
+    # so the orchestrator carries no third-party HTTP dependency. The lease
+    # plane is localhost-only; :ssl is listed for httpc's startup contract,
+    # not because the boundary is TLS.
+    [
+      extra_applications: [:logger, :inets, :ssl],
+      mod: {AgentOrchestrator.Application, []}
+    ]
+  end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
+
+  defp deps do
+    [
+      {:jason, "~> 1.4"}
+    ]
+  end
+end

--- a/elixir/agent_orchestrator/scripts/live_smoke.exs
+++ b/elixir/agent_orchestrator/scripts/live_smoke.exs
@@ -1,0 +1,61 @@
+# Live smoke: spawn a lease-bound ephemeral agent against the running lease
+# plane (127.0.0.1:8788) using the REAL LeasePlaneClient, prove acquire-on-spawn
+# and release-on-exit end to end.
+#
+#   source ~/.config/cirwel/secrets.env
+#   LEASE_PLANE_BEARER_TOKEN=$LEASE_PLANE_BEARER_TOKEN mix run scripts/live_smoke.exs
+#
+# Acquires a remote_heartbeat lease on a novel `agent:<id>` surface (pure DB TTL
+# row, reaper-reaped — self-heals even if this script is killed mid-run).
+
+require Logger
+
+bearer = Application.get_env(:agent_orchestrator, :lease_plane_bearer_token)
+
+if is_nil(bearer) or bearer == "" do
+  IO.puts("\n  SKIP: LEASE_PLANE_BEARER_TOKEN not set — cannot hit the live plane.\n")
+  System.halt(0)
+end
+
+# `resident:/` is a STAND-IN scheme: the plane has no `agent:` scheme yet (the
+# real follow-up this slice surfaced). Using a valid scheme here proves the live
+# acquire→release HTTP/auth/lifecycle path end to end.
+surface = "resident:/ephemeral-agent-smoke-#{System.system_time(:second)}"
+
+{:ok, id, _pid} =
+  AgentOrchestrator.run(%{
+    cmd: "sh",
+    args: ["-c", "echo 'ephemeral agent reporting in'; sleep 1; echo done"],
+    lease: %{required: true, surface_id: surface}
+  })
+
+IO.puts("\n  spawned lease-bound ephemeral agent: #{id}")
+
+case AgentOrchestrator.await(id, 10_000) do
+  {:ok, result} ->
+    IO.puts("  exit_status   : #{result.exit_status}")
+    IO.puts("  lease_id      : #{result.lease_id}")
+    IO.puts("  lease_released: #{result.lease_released}")
+    IO.puts("  output        : #{inspect(result.output)}")
+
+    cond do
+      is_nil(result.lease_id) ->
+        IO.puts("\n  ✗ FAIL: no lease_id — plane did not grant a lease\n")
+        System.halt(1)
+
+      result.exit_status != 0 ->
+        IO.puts("\n  ✗ FAIL: non-zero exit\n")
+        System.halt(1)
+
+      not result.lease_released ->
+        IO.puts("\n  ✗ FAIL: lease #{result.lease_id} was NOT released (orphan until TTL)\n")
+        System.halt(1)
+
+      true ->
+        IO.puts("\n  ✓ live acquire→run→release round-trip OK (lease #{result.lease_id} released)\n")
+    end
+
+  {:error, reason} ->
+    IO.puts("\n  ✗ FAIL: await returned #{inspect(reason)}\n")
+    System.halt(1)
+end

--- a/elixir/agent_orchestrator/test/agent_orchestrator_test.exs
+++ b/elixir/agent_orchestrator/test/agent_orchestrator_test.exs
@@ -1,0 +1,165 @@
+defmodule AgentOrchestratorTest do
+  use ExUnit.Case, async: false
+
+  alias AgentOrchestrator.StubLeaseClient
+
+  setup do
+    Application.put_env(:agent_orchestrator, :test_pid, self())
+    Application.put_env(:agent_orchestrator, :stub_acquire_result, {:ok, "stub-lease"})
+
+    on_exit(fn ->
+      Application.delete_env(:agent_orchestrator, :test_pid)
+      Application.delete_env(:agent_orchestrator, :stub_acquire_result)
+      # Tear down any agents a test left running.
+      Enum.each(AgentOrchestrator.list(), &AgentOrchestrator.stop(&1, :test_cleanup))
+    end)
+
+    :ok
+  end
+
+  # Poll a condition for up to ~250ms (async Registry/process teardown).
+  defp eventually(fun, retries \\ 50) do
+    cond do
+      fun.() -> true
+      retries <= 0 -> false
+      true -> Process.sleep(5) && eventually(fun, retries - 1)
+    end
+  end
+
+  describe "supervised lifecycle (no lease)" do
+    test "runs an ephemeral agent and captures its output" do
+      {:ok, id, pid} = AgentOrchestrator.run(%{cmd: "echo", args: ["hello world"]})
+      assert is_pid(pid)
+      assert {:ok, result} = AgentOrchestrator.await(id, 5_000)
+      assert result.exit_status == 0
+      assert result.output == ["hello world"]
+      assert result.running == false
+      refute Process.alive?(pid)
+    end
+
+    test "captures multi-line stdout in order" do
+      {:ok, id, _} = AgentOrchestrator.run(%{cmd: "sh", args: ["-c", "printf 'a\\nb\\nc\\n'"]})
+      assert {:ok, %{output: ["a", "b", "c"], exit_status: 0}} = AgentOrchestrator.await(id)
+    end
+
+    test "captures stderr (merged) and a non-zero exit status" do
+      {:ok, id, _} = AgentOrchestrator.run(%{cmd: "sh", args: ["-c", "echo oops 1>&2; exit 7"]})
+      assert {:ok, result} = AgentOrchestrator.await(id)
+      assert result.exit_status == 7
+      assert "oops" in result.output
+    end
+
+    test "passes env through to the child" do
+      {:ok, id, _} =
+        AgentOrchestrator.run(%{
+          cmd: "sh",
+          args: ["-c", "echo $FLEET_TASK"],
+          env: [{"FLEET_TASK", "build-widget"}]
+        })
+
+      assert {:ok, %{output: ["build-widget"]}} = AgentOrchestrator.await(id)
+    end
+
+    test "refuses to start when the executable does not exist" do
+      assert {:error, {:executable_not_found, "definitely-not-a-real-binary-xyz"}} =
+               AgentOrchestrator.run(%{cmd: "definitely-not-a-real-binary-xyz"})
+    end
+
+    test "bounds an over-long unterminated line but still captures all of it" do
+      big = String.duplicate("x", 70_000)
+
+      {:ok, id, _} =
+        AgentOrchestrator.run(%{
+          cmd: "sh",
+          args: ["-c", ~s(printf '%s\\n' "$BIG")],
+          env: [{"BIG", big}]
+        })
+
+      assert {:ok, result} = AgentOrchestrator.await(id)
+      assert result.exit_status == 0
+      # Flushed across one or more bounded fragments; no byte lost.
+      assert result.output |> Enum.join() |> byte_size() == 70_000
+    end
+  end
+
+  describe "fleet + registry" do
+    test "list/count track live agents and stop tears one down" do
+      {:ok, id, pid} = AgentOrchestrator.run(%{cmd: "sleep", args: ["30"]})
+      assert id in AgentOrchestrator.list()
+      assert AgentOrchestrator.count() >= 1
+
+      assert :ok = AgentOrchestrator.stop(id)
+      refute Process.alive?(pid)
+      # Registry unregisters a dead process via its own async :DOWN handler, so
+      # the id can linger in list/0 for a beat after the process is gone.
+      assert eventually(fn -> id not in AgentOrchestrator.list() end)
+    end
+
+    test "run_fleet spawns each spec" do
+      results =
+        AgentOrchestrator.run_fleet([
+          %{cmd: "echo", args: ["one"]},
+          %{cmd: "echo", args: ["two"]}
+        ])
+
+      assert [{:ok, _, _}, {:ok, _, _}] = results
+      for {:ok, id, _} <- results, do: assert({:ok, %{exit_status: 0}} = AgentOrchestrator.await(id))
+    end
+  end
+
+  describe "lease binding" do
+    test "acquires on spawn and releases on exit" do
+      {:ok, id, _} =
+        AgentOrchestrator.run(%{
+          cmd: "echo",
+          args: ["done"],
+          lease: %{holder_agent_uuid: "11111111-1111-4111-8111-111111111111"},
+          lease_client: StubLeaseClient
+        })
+
+      assert_receive {:lease_event,
+                      {:acquire, surface_id, "11111111-1111-4111-8111-111111111111",
+                       "remote_heartbeat", 300}}
+
+      assert surface_id == "agent:" <> id
+
+      assert {:ok, %{lease_id: "stub-lease", exit_status: 0, lease_released: true}} =
+               AgentOrchestrator.await(id)
+
+      assert_receive {:lease_event, {:release, "stub-lease", "normal"}}
+    end
+
+    test "releases the lease when the port fails to open after acquire (no orphan)" do
+      assert {:error, {:executable_not_found, _}} =
+               AgentOrchestrator.run(%{
+                 cmd: "definitely-not-a-real-binary-xyz",
+                 lease: %{holder_agent_uuid: "22222222-2222-4222-8222-222222222222"},
+                 lease_client: StubLeaseClient
+               })
+
+      assert_receive {:lease_event, {:acquire, _surface, _uuid, "remote_heartbeat", 300}}
+      assert_receive {:lease_event, {:release, "stub-lease", "normal"}}
+    end
+
+    test "refuses to start when a required lease is denied" do
+      Application.put_env(:agent_orchestrator, :stub_acquire_result, {:error, {:held_by_other, "other"}})
+
+      assert {:error, {:lease_denied, {:held_by_other, "other"}}} =
+               AgentOrchestrator.run(%{cmd: "echo", args: ["x"], lease: %{}, lease_client: StubLeaseClient})
+    end
+
+    test "best-effort lease proceeds even when acquire fails" do
+      Application.put_env(:agent_orchestrator, :stub_acquire_result, {:error, :no_bearer})
+
+      {:ok, id, _} =
+        AgentOrchestrator.run(%{
+          cmd: "echo",
+          args: ["x"],
+          lease: %{required: false},
+          lease_client: StubLeaseClient
+        })
+
+      assert {:ok, %{lease_id: nil, exit_status: 0}} = AgentOrchestrator.await(id)
+    end
+  end
+end

--- a/elixir/agent_orchestrator/test/support/stub_lease_client.ex
+++ b/elixir/agent_orchestrator/test/support/stub_lease_client.ex
@@ -1,0 +1,31 @@
+defmodule AgentOrchestrator.StubLeaseClient do
+  @moduledoc """
+  Test double for `AgentOrchestrator.LeasePlaneClient.Behaviour`.
+
+  Reports every acquire/release to the pid in `:agent_orchestrator, :test_pid`
+  and returns the canned result in `:agent_orchestrator, :stub_acquire_result`
+  (default `{:ok, "stub-lease"}`), so tests can assert lease lifecycle without a
+  live plane.
+  """
+
+  @behaviour AgentOrchestrator.LeasePlaneClient.Behaviour
+
+  @impl true
+  def acquire(surface_id, holder_agent_uuid, holder_kind, ttl_s) do
+    notify({:acquire, surface_id, holder_agent_uuid, holder_kind, ttl_s})
+    Application.get_env(:agent_orchestrator, :stub_acquire_result, {:ok, "stub-lease"})
+  end
+
+  @impl true
+  def release(lease_id, reason) do
+    notify({:release, lease_id, reason})
+    :ok
+  end
+
+  defp notify(event) do
+    case Application.get_env(:agent_orchestrator, :test_pid) do
+      pid when is_pid(pid) -> send(pid, {:lease_event, event})
+      _ -> :ok
+    end
+  end
+end

--- a/elixir/agent_orchestrator/test/test_helper.exs
+++ b/elixir/agent_orchestrator/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
## What this is

A **new axis** of the BEAM footprint, distinct from the governance-server migration (Wave 1–3) and the lease plane: BEAM owns the **lifecycle** of ephemeral agents (Claude SDK process, `claude -p`, tool workers) as OTP-supervised children — one `AgentRunner` GenServer per agent, each wrapping a `Port`. **BEAM owns lifecycle; the SDK owns the loop** — we deliberately do NOT reimplement the agent loop in Elixir.

Lives at `elixir/agent_orchestrator/`. Library + smoke today, **not wired to any running surface**.

## Topology

```
AgentOrchestrator.Supervisor            (one_for_one)
├── Registry  (agent_id -> runner pid)
└── AgentSupervisor  (DynamicSupervisor)
    └── AgentRunner  (GenServer + Port)   restart: :temporary
```

`restart: :temporary` is deliberate: ephemerals are not resurrected. The supervisor buys lifecycle ownership (clean spawn, tracked teardown, lease release, fan-out), not crash-restart durability.

Facade: `run/1`, `run_fleet/1`, `await/2`, `snapshot/1`, `stop/2`, `list/0`, `count/0`.

## Lease binding — kept, with an honest caveat

Acquire-on-spawn / release-on-exit via the lease plane's RFC §5 HTTP surface (`LeasePlaneClient`, behaviour-injected for tests). Fail-closed admission control on required leases.

**CAVEAT (verified against the live plane):** the plane routes `holder_kind` by **surface scheme, not the request body** (`http_router.ex:457-466`). Only `file://` gets the TTL-row `remote_heartbeat` path; every other scheme (`resident:/`, future `agent:`) is coerced to an **auto-renewing `local_beam` holder → does NOT self-heal at TTL**. Proven empirically: an orphan's `expires_at` was *advancing* under renewal. So cleanup rests on the runner's release paths (now robust); residual risk is a `:brutal_kill`/VM-crash skipping `terminate/2`.

## Council review (code-reviewer + architect + live-verifier)

Operator call: keep lease-binding with the caveat, **fix the lifecycle bugs**, defer the architecture pivot. Fixed:

1. Orphan on port-open failure (`lease_id` out of scope in `with/else`)
2. Skipped release-retry after a transient `{:error,_}`
3. `exit_status`/port-`EXIT` ordering race (dropped status + hung waiters) → shared order-independent `finalize/2`
4. `await/2` caller crash on `:noproc` race
5. Unbounded partial-line buffer

## Deferred follow-ups (operator decisions)

- **`agent:` surface scheme with non-renewing TTL-row routing** — the real self-heal fix; touches `Canonicalize` in **both** Elixir and Python (single-writer cross-repo surface).
- **Governance-lineage-injection pivot** (architect's recommendation) — BEAM injects `parent_agent_id`/`spawn_reason` into spawned agents so lineage is correct by construction; arguably the more coherent BEAM-native capability than lease-binding.

## Verification

- 12 tests, 0 failures (`cd elixir/agent_orchestrator && mix test`), stable across seeds.
- Live `scripts/live_smoke.exs` against the running plane proves acquire→run→release with `lease_released: true` asserted (not assumed).

Design note: `docs/proposals/agent-orchestrator-beam-v0.md`.