### PR TITLE
fix(mirror): reflect, don't advise — de-prescribe mirror mode

### DIFF
--- a/src/dual_log/restorative.py
+++ b/src/dual_log/restorative.py
@@ -146,9 +146,12 @@ class RestorativeBalanceMonitor:
             )
         
         if cumulative_divergence > self.divergence_threshold:
+            # Descriptive, not interrogative — matches the neutralized mirror
+            # complexity-calibration line. The divergence is calibration data,
+            # not a demand to justify difficulty. (2026-06-03.)
             reasons.append(
-                f"complexity divergence pattern ({cumulative_divergence:.2f} cumulative) "
-                f"-- is your sense of difficulty calibrated?"
+                f"complexity divergence ({cumulative_divergence:.2f} cumulative, "
+                f"logged for calibration)"
             )
         
         if reasons:

--- a/src/mcp_handlers/response_formatter.py
+++ b/src/mcp_handlers/response_formatter.py
@@ -288,15 +288,17 @@ def _format_mirror(response_data: dict, saved_trust_tier: Any, meta: Any = None)
                         f"{derived:.2f} — logged for the calibration curve."
                     )
 
-    # 4. Restorative action — surface if system is cooling down
+    # 4. Pace — reflect cooldown-threshold state descriptively. NOT "Restorative
+    # action:" — that named an action (the verdict's voice). The mirror reflects
+    # the pace facts; the decision to cool down, if any, is the verdict's job.
     restorative = response_data.get("restorative", {})
     if isinstance(restorative, dict) and restorative.get("needs_restoration"):
         restorative_reason = restorative.get("reason")
         restorative_reasons = restorative.get("reasons", [])
         if isinstance(restorative_reason, str) and restorative_reason:
-            mirror_signals.append(f"Restorative action: {restorative_reason}")
+            mirror_signals.append(f"Pace: {restorative_reason}")
         elif restorative_reasons:
-            mirror_signals.append(f"Restorative action: {'; '.join(str(r) for r in restorative_reasons[:2])}")
+            mirror_signals.append(f"Pace: {'; '.join(str(r) for r in restorative_reasons[:2])}")
 
     # 5. Surface relevant KG discoveries — from mirror enrichment AND from existing enrichments
     relevant_prior = []
@@ -317,11 +319,12 @@ def _format_mirror(response_data: dict, saved_trust_tier: Any, meta: Any = None)
             entry["relevance"] = relevance
         relevant_prior.append(entry)
 
-    # 6. Surface the single most relevant question when state warrants it
-    question = response_data.get("_mirror_question")
-    if question is None:
-        # Backward compatibility for older enrichments/tests
-        question = response_data.get("_mirror_reflection", None)
+    # 6. Surface the single most relevant reflection when state warrants it — a
+    # descriptive lens, not a directive question (reflect, don't advise).
+    reflection = response_data.get("_mirror_reflection")
+    if reflection is None:
+        # Back-compat: older enrichments may still set _mirror_question.
+        reflection = response_data.get("_mirror_question", None)
 
     result = {
         "success": True,
@@ -333,8 +336,8 @@ def _format_mirror(response_data: dict, saved_trust_tier: Any, meta: Any = None)
     if relevant_prior:
         result["relevant_prior_work"] = relevant_prior
 
-    if question:
-        result["question"] = question
+    if reflection:
+        result["reflection"] = reflection
 
     # Include margin/edge warnings
     margin = decision.get("margin")

--- a/src/mcp_handlers/updates/enrichments.py
+++ b/src/mcp_handlers/updates/enrichments.py
@@ -1254,7 +1254,7 @@ async def enrich_mirror_signals(ctx: UpdateContext) -> None:
     Produces:
       - _mirror_signals: list of short insight strings
       - _mirror_kg_results: relevant KG discoveries by text search
-      - _mirror_question: targeted question when state warrants it
+      - _mirror_reflection: targeted descriptive reflection when state warrants it
       - _has_sensor_data: bool for auto-mode routing
     """
     try:
@@ -1274,13 +1274,13 @@ async def enrich_mirror_signals(ctx: UpdateContext) -> None:
         # 1. Gaming / autopilot detection (low variance in recent reports)
         signals.extend(_detect_gaming(ctx))
 
-        # 2. Targeted question — only when there is something worth reflecting on
-        question = _generate_mirror_question(ctx, signals)
-        if question:
-            ctx.response_data["_mirror_question"] = question
+        # 2. Targeted reflection — descriptive, only when state warrants it
+        reflection = _generate_mirror_reflection(ctx, signals)
+        if reflection:
+            ctx.response_data["_mirror_reflection"] = reflection
 
-        # 3. KG search is useful when there is a concrete signal/question, not on steady-state check-ins
-        if _should_search_kg_by_checkin_text(ctx, signals, question):
+        # 3. KG search is useful when there is a concrete signal/reflection, not on steady-state check-ins
+        if _should_search_kg_by_checkin_text(ctx, signals, reflection):
             kg_results = await _search_kg_by_checkin_text(ctx)
             if kg_results:
                 ctx.response_data["_mirror_kg_results"] = kg_results
@@ -1440,8 +1440,14 @@ def _get_complexity_disagreement(response_data: dict, meta: Any = None) -> dict 
     return None
 
 
-def _generate_mirror_question(ctx: UpdateContext, signals: list) -> str | None:
-    """Generate a targeted mirror-mode question only when the current state merits a nudge."""
+def _generate_mirror_reflection(ctx: UpdateContext, signals: list) -> str | None:
+    """Surface a single descriptive reflection when the current state merits one.
+
+    Reflect, don't advise: a mirror shows the agent its own state and lets the
+    agent draw the conclusion. Each branch returns the observation only — never a
+    directive ("what would you simplify / verify / change?"). Prescription, when
+    warranted, is the verdict channel's job, not the mirror's. A mirror that tells
+    the agent what to do is a verdict wearing a mirror's clothes. (2026-06-03.)"""
     try:
         response_data = ctx.response_data if isinstance(ctx.response_data, dict) else {}
         decision = response_data.get("decision", {})
@@ -1451,7 +1457,7 @@ def _generate_mirror_question(ctx: UpdateContext, signals: list) -> str | None:
         text_lower = (ctx.response_text or "").lower()
         verdict = ctx.metrics_dict.get("verdict", "proceed")
 
-        # Only nudge on a genuine first-person "I'm stuck" — not on any text that
+        # Only reflect on a genuine first-person "I'm stuck" — not on any text that
         # merely contains the substring "stuck"/"blocked" (e.g. reporting a lease
         # that "blocked my edits" or a fix that "unblocks" something). The bare
         # substring match fabricated "you said you're stuck" on check-ins that
@@ -1465,21 +1471,21 @@ def _generate_mirror_question(ctx: UpdateContext, signals: list) -> str | None:
             )
         )
         if first_person_stuck:
-            return "You flagged being stuck. What's the smallest concrete step that would unblock you right now?"
+            return "You flagged being stuck in this check-in."
 
         if verdict in ("guide", "pause", "reject"):
-            return f"Your state just triggered a {verdict} verdict. What changed immediately before that?"
+            return f"This check-in triggered a {verdict} verdict."
 
         if isinstance(restorative, dict) and restorative.get("needs_restoration"):
-            return "The system thinks you're pushing too hard. What can you simplify, defer, or slow down before the next step?"
+            return "Your recent pace is above the cooldown threshold."
 
         if _has_tight_margin(response_data) or (isinstance(state, dict) and state.get("borderline")):
             nearest_edge = decision.get("nearest_edge")
             if nearest_edge == "coherence":
-                return "You're close to a coherence edge. What's the smallest next step that would simplify the plan?"
+                return "You're close to a coherence edge."
             if nearest_edge in ("risk", "risk_threshold"):
-                return "You're close to a risk edge. What assumption would you verify before continuing?"
-            return "You're close to a governance edge. What's one simplification that would make the next step safer?"
+                return "You're close to a risk edge."
+            return "You're close to a governance edge."
 
         # Complexity divergence is surfaced as a neutral, recorded signal line
         # in the mirror (response_formatter._format_mirror), NOT as an
@@ -1493,16 +1499,16 @@ def _generate_mirror_question(ctx: UpdateContext, signals: list) -> str | None:
             derived_cap = conf_rel.get("derived_cap")
             try:
                 if external is not None and derived_cap is not None and float(external) - float(derived_cap) > 0.1:
-                    return "Your reported confidence is above what the system can justify so far. What evidence are you leaning on?"
+                    return "Your reported confidence is above what the system can justify so far."
             except (TypeError, ValueError):
                 pass
 
         for signal in signals:
             signal_lower = str(signal).lower()
             if "autopilot" in signal_lower:
-                return "Your recent check-ins look repetitive. What actually changed since the last one?"
+                return "Your recent check-ins look repetitive (low variance)."
             if "confidence" in signal_lower and "variance" in signal_lower:
-                return "Your confidence reports have been very flat. What evidence shifted this time?"
+                return "Your confidence reports have been very flat."
 
         return None
     except Exception:

--- a/tests/test_enrichments_mirror.py
+++ b/tests/test_enrichments_mirror.py
@@ -1,7 +1,7 @@
 """
 Tests for mirror signal enrichments in src/mcp_handlers/updates/enrichments.py.
 
-Tests _detect_gaming, _generate_mirror_question,
+Tests _detect_gaming, _generate_mirror_reflection,
 and mirror KG-search gating helpers.
 """
 
@@ -17,7 +17,7 @@ sys.path.insert(0, str(project_root))
 
 from src.mcp_handlers.updates.enrichments import (
     _detect_gaming,
-    _generate_mirror_question,
+    _generate_mirror_reflection,
     _should_search_kg_by_checkin_text,
 )
 
@@ -118,22 +118,24 @@ class TestDetectGaming:
 
 
 # ============================================================================
-# _generate_mirror_question
+# _generate_mirror_reflection
 # ============================================================================
 
-class TestGenerateMirrorQuestion:
+class TestGenerateMirrorReflection:
 
-    def test_stuck_keyword_in_text_returns_unblock_question(self):
+    def test_stuck_keyword_in_text_reflects_stuck(self):
         ctx = _make_ctx(task_type="mixed", response_text="I'm stuck on this problem")
-        question = _generate_mirror_question(ctx, signals=[])
-        assert question is not None
-        assert "unblock" in question.lower()
+        reflection = _generate_mirror_reflection(ctx, signals=[])
+        assert reflection is not None
+        # Descriptive reflection of their own words — NOT a directive ("what would unblock you?").
+        assert "stuck" in reflection.lower()
+        assert "?" not in reflection
 
     def test_tight_margin_returns_edge_question(self):
         ctx = _make_ctx(
             response_data={"decision": {"margin": 0.05, "nearest_edge": "coherence"}}
         )
-        question = _generate_mirror_question(ctx, signals=[])
+        question = _generate_mirror_reflection(ctx, signals=[])
         assert question is not None
         assert "coherence edge" in question.lower()
 
@@ -141,7 +143,7 @@ class TestGenerateMirrorQuestion:
         ctx = _make_ctx(
             response_data={"decision": {"margin": "settling", "nearest_edge": None}}
         )
-        question = _generate_mirror_question(ctx, signals=[])
+        question = _generate_mirror_reflection(ctx, signals=[])
         assert question is None
 
     def test_complexity_disagreement_no_longer_returns_question(self):
@@ -158,7 +160,7 @@ class TestGenerateMirrorQuestion:
                 }
             }
         )
-        question = _generate_mirror_question(ctx, signals=[])
+        question = _generate_mirror_reflection(ctx, signals=[])
         assert question is None
 
     def test_third_person_blocked_does_not_trigger_stuck_question(self):
@@ -171,17 +173,18 @@ class TestGenerateMirrorQuestion:
             "Investigated where the pipeline gets stuck for other agents.",
         ):
             ctx = _make_ctx(response_text=text)
-            assert _generate_mirror_question(ctx, signals=[]) is None, text
+            assert _generate_mirror_reflection(ctx, signals=[]) is None, text
 
-    def test_autopilot_signal_returns_question(self):
+    def test_autopilot_signal_reflects_repetition(self):
         ctx = _make_ctx()
-        question = _generate_mirror_question(ctx, signals=["Real work varies -- are you on autopilot?"])
-        assert question is not None
-        assert "actually changed" in question.lower()
+        reflection = _generate_mirror_reflection(ctx, signals=["Real work varies -- are you on autopilot?"])
+        assert reflection is not None
+        assert "repetitive" in reflection.lower()
+        assert "?" not in reflection
 
     def test_steady_state_returns_none(self):
         ctx = _make_ctx(task_type="feature", response_text="Finished tracing the mirror output path.")
-        question = _generate_mirror_question(ctx, signals=[])
+        question = _generate_mirror_reflection(ctx, signals=[])
         assert question is None
 
 

--- a/tests/test_response_formatter.py
+++ b/tests/test_response_formatter.py
@@ -654,11 +654,14 @@ class TestFormatMirror:
         assert "relevant_prior_work" in result
         assert result["relevant_prior_work"][0]["by"] == "AlvaNoto"
 
-    def test_question_prompt(self):
+    def test_legacy_mirror_question_surfaces_as_reflection(self):
+        # Back-compat: an older enrichment that still sets _mirror_question is
+        # surfaced under the descriptive `reflection` key (no `question` key).
         data = _sample_response()
-        data["_mirror_question"] = "What changed in your understanding?"
+        data["_mirror_question"] = "Something an old enrichment set"
         result = _format_mirror(data, saved_trust_tier=None)
-        assert result["question"] == "What changed in your understanding?"
+        assert result["reflection"] == "Something an old enrichment set"
+        assert "question" not in result
 
     def test_trust_tier_wrapped_with_meaning(self):
         # #428: mirror mode wraps trust_tier with meaning + criteria inline.
@@ -690,11 +693,12 @@ class TestFormatMirror:
         result = _format_mirror(data, saved_trust_tier=None)
         assert "trust_tier" not in result
 
-    def test_legacy_reflection_prompt_supported(self):
+    def test_reflection_surfaced_under_reflection_key(self):
         data = _sample_response()
-        data["_mirror_reflection"] = "What changed in your understanding?"
+        data["_mirror_reflection"] = "You're close to a coherence edge."
         result = _format_mirror(data, saved_trust_tier=None)
-        assert result["question"] == "What changed in your understanding?"
+        assert result["reflection"] == "You're close to a coherence edge."
+        assert "question" not in result
 
     def test_trust_tier_included(self):
         # #428: mirror now wraps with glossary; the bare name resolves
@@ -723,6 +727,7 @@ class TestFormatMirror:
         data.pop("_mirror_reflection", None)
         result = _format_mirror(data, saved_trust_tier=None)
         assert "steady state" in result["mirror"][0].lower()
+        assert "reflection" not in result
         assert "question" not in result
 
     def test_margin_included_when_tight(self):
@@ -776,14 +781,19 @@ class TestFormatMirror:
         # Should use continuity (0.7/0.22), not calibration_feedback (0.8/0.28)
         assert any("you reported 0.70" in s for s in result["mirror"])
 
-    def test_restorative_action_surfaced(self):
+    def test_pace_surfaced_descriptively(self):
         data = _sample_response()
         data["restorative"] = {
             "needs_restoration": True,
-            "reason": "complexity divergence pattern (0.48 cumulative)",
+            "reason": "complexity divergence (0.48 cumulative, logged for calibration)",
         }
         result = _format_mirror(data, saved_trust_tier=None)
-        assert any("restorative" in s.lower() for s in result["mirror"])
+        # Reflected as a descriptive "Pace:" line — NOT "Restorative action:"
+        # (which named an action = the verdict's voice, not the mirror's).
+        pace_lines = [s for s in result["mirror"] if s.startswith("Pace:")]
+        assert pace_lines, result["mirror"]
+        assert "0.48 cumulative" in pace_lines[0]
+        assert not any("restorative action" in s.lower() for s in result["mirror"])
 
     def test_existing_discoveries_merged_into_prior_work(self):
         data = _sample_response()


### PR DESCRIPTION
## The principle

A mirror is *descriptive* — it shows you yourself and lets you draw the conclusion. It doesn't advise. Mirror mode had drifted into a **prescriptive** voice ("you're running hot, reset" / "what can you simplify?"), which is a verdict wearing a mirror's clothes — and it risks the instrument measuring its own echo (the agent conforms to the injected directive, the next check-in confirms it).

The test, applied to every line the mirror can emit: **descriptive → mirror; prescriptive → belongs in the verdict.**

## What changed

- `_generate_mirror_question` → `_generate_mirror_reflection`. All **nine** hardcoded questions were `[observation] + [directive demand]`. Kept the observation, dropped the demand:
  | before | after |
  |---|---|
  | "You flagged being stuck. What's the smallest step that would unblock you?" | "You flagged being stuck in this check-in." |
  | "The system thinks you're pushing too hard. What can you simplify/defer/slow down?" | "Your recent pace is above the cooldown threshold." |
  | "You're close to a coherence edge. What's the smallest next step…?" | "You're close to a coherence edge." |
  | …(6 more, same shape) | … |
  Surfaced under a `reflection` key instead of `question` (back-compat reads the old `_mirror_question` into it).
- `response_formatter`: `"Restorative action: …"` → `"Pace: …"`. "Restorative action" named an action (the verdict's voice); the mirror reflects the pace facts.
- `restorative.py`: dropped `"-- is your sense of difficulty calibrated?"`, matching the already-neutralized complexity-calibration line.

## What did NOT change

The **verdict channel** (proceed/guide/pause/reject + `margin`/`nearest_edge`) is the legitimate prescriptive surface and is untouched. This PR only de-prescribes the *mirror*. The reflect/govern split is now clean: mirror reflects, verdict governs.

## Tests

195 green across `test_enrichments_mirror`, `test_response_formatter`, `test_core_update`. Repo-wide sweep confirms no remaining references to the old prescriptive strings.