### PR TITLE
fix(P004): bound Redis awaits in enrich_identity_notifications

### DIFF
--- a/src/mcp_handlers/updates/enrichments.py
+++ b/src/mcp_handlers/updates/enrichments.py
@@ -1552,6 +1552,15 @@ def _should_search_kg_by_checkin_text(ctx: UpdateContext, signals: list, questio
 
 # ─── Identity Notifications ──────────────────────────────────────────
 
+# P004: bound every Redis await in this MCP-handler path. The anyio<->asyncpg/
+# Redis seam can stall an await indefinitely (see CLAUDE.md "Known Issue"); an
+# unguarded await here would hang the whole update-enrichment pipeline. This is a
+# best-effort surfacing of pending notifications, so on timeout we degrade to
+# "no notifications this turn" rather than block. Mirrors the
+# _REDIS_RECOVERY_TIMEOUT idiom in mcp_handlers/middleware/identity_step.py.
+_REDIS_NOTIF_TIMEOUT = 0.5
+
+
 @enrichment(order=250)
 async def enrich_identity_notifications(ctx: UpdateContext) -> None:
     """Surface pending identity notifications (e.g., session accessed from elsewhere)."""
@@ -1563,7 +1572,9 @@ async def enrich_identity_notifications(ctx: UpdateContext) -> None:
             return
 
         key = f"identity_notifications:{ctx.agent_uuid}"
-        notifications = await redis.lrange(key, 0, -1)
+        notifications = await asyncio.wait_for(
+            redis.lrange(key, 0, -1), timeout=_REDIS_NOTIF_TIMEOUT
+        )
         if not notifications:
             return
 
@@ -1577,8 +1588,13 @@ async def enrich_identity_notifications(ctx: UpdateContext) -> None:
         if parsed:
             ctx.response_data["_identity_notifications"] = parsed
             # Clear after delivery
-            await redis.delete(key)
+            await asyncio.wait_for(redis.delete(key), timeout=_REDIS_NOTIF_TIMEOUT)
 
+    except asyncio.TimeoutError:
+        logger.debug(
+            "identity notifications check timed out after %.3fs (degrading to none)",
+            _REDIS_NOTIF_TIMEOUT,
+        )
     except Exception as e:
         logger.debug(f"Could not check identity notifications: {e}")
 

--- a/tests/test_identity_notifications_timeout.py
+++ b/tests/test_identity_notifications_timeout.py
@@ -1,0 +1,64 @@
+"""P004 regression: enrich_identity_notifications must bound its Redis awaits.
+
+A hung Redis (anyio<->asyncpg/Redis deadlock class) must not stall the update
+enrichment pipeline — the enrichment degrades to "no notifications this turn".
+"""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.mcp_handlers.updates import enrichments
+from src.mcp_handlers.updates.enrichments import enrich_identity_notifications
+
+
+def _ctx():
+    return SimpleNamespace(agent_uuid="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", response_data={})
+
+
+@pytest.mark.asyncio
+async def test_hung_redis_lrange_does_not_stall(monkeypatch):
+    """If redis.lrange hangs, the enrichment times out and returns cleanly."""
+    monkeypatch.setattr(enrichments, "_REDIS_NOTIF_TIMEOUT", 0.01)
+
+    async def _hang(*_a, **_k):
+        await asyncio.sleep(5)  # never completes within the timeout
+        return []
+
+    fake_redis = SimpleNamespace(lrange=_hang, delete=AsyncMock())
+    ctx = _ctx()
+
+    with patch("src.cache.redis_client.get_redis", new=AsyncMock(return_value=fake_redis)):
+        # Must finish well under the hang; generous outer bound guards against regressions.
+        await asyncio.wait_for(enrich_identity_notifications(ctx), timeout=1.0)
+
+    assert "_identity_notifications" not in ctx.response_data
+    fake_redis.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_happy_path_surfaces_and_clears(monkeypatch):
+    """Normal path: notifications are surfaced and the key is cleared."""
+    fake_redis = SimpleNamespace(
+        lrange=AsyncMock(return_value=[json.dumps({"message": "session accessed elsewhere"})]),
+        delete=AsyncMock(),
+    )
+    ctx = _ctx()
+
+    with patch("src.cache.redis_client.get_redis", new=AsyncMock(return_value=fake_redis)):
+        await enrich_identity_notifications(ctx)
+
+    assert ctx.response_data["_identity_notifications"] == [{"message": "session accessed elsewhere"}]
+    fake_redis.delete.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_no_redis_is_noop():
+    """When Redis is unavailable, the enrichment is a clean no-op."""
+    ctx = _ctx()
+    with patch("src.cache.redis_client.get_redis", new=AsyncMock(return_value=None)):
+        await enrich_identity_notifications(ctx)
+    assert "_identity_notifications" not in ctx.response_data


### PR DESCRIPTION
## What
Wraps the two unguarded Redis awaits in `enrich_identity_notifications` (`redis.lrange`, `redis.delete`) with `asyncio.wait_for(timeout=_REDIS_NOTIF_TIMEOUT=0.5)`.

## Why
Watcher P004 (`#4a8550fc`, `#4e50ce93`): unguarded Redis in an MCP-handler path. The anyio↔asyncpg/Redis seam can stall an await indefinitely → hangs the entire update-enrichment pipeline. This is a best-effort surfacing of pending notifications, so on timeout it degrades to "no notifications this turn" rather than blocking. Matches the established `_REDIS_RECOVERY_TIMEOUT` idiom in `mcp_handlers/middleware/identity_step.py`.

## Tests
`tests/test_identity_notifications_timeout.py` — hung-Redis (must not stall), happy-path (surfaces + clears key), no-Redis no-op. 13 passed incl. existing `test_enrichment_pipeline.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)