### PR TITLE
feat(lease-plane): agent:/ ephemeral-agent presence scheme (self-healing)

### DIFF
--- a/db/postgres/migrations/042_lease_plane_agent_scheme.sql
+++ b/db/postgres/migrations/042_lease_plane_agent_scheme.sql
@@ -1,0 +1,38 @@
+-- 042_lease_plane_agent_scheme.sql
+--
+-- Add `agent:/` to the surface_id grammar so ephemeral-agent PRESENCE surfaces
+-- are legal. Ephemeral agents (spawned via the BEAM agent orchestrator,
+-- elixir/agent_orchestrator) register an `agent:/<id>` surface as a liveness
+-- record. The surface is unique per agent — it is presence, not a mutex — so it
+-- is routed in the plane's acquire_for_surface to the `remote_heartbeat` path
+-- (pure DB TTL row, NO auto-renewing LeaseHolder), exactly like `file://`. That
+-- means an orphaned presence row reaps itself at `expires_at` instead of being
+-- held open by a renewing holder for the BEAM process's lifetime.
+--
+-- Supersedes the migration-026 grammar regex. Idempotent: drops the existing
+-- CHECK (if present) and re-adds with `agent:/` appended. `surface_kind` is the
+-- migration-026 generated column (split_part(surface_id, ':', 1)), so an
+-- `agent:/...` surface_id derives surface_kind='agent' automatically; the
+-- migration-034 resident-only CHECK (substrate_state IS NULL OR
+-- surface_kind='resident') is unaffected because agent presence rows leave
+-- substrate_state NULL.
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'surface_id_grammar'
+          AND conrelid = 'lease_plane.surface_leases'::regclass
+    ) THEN
+        ALTER TABLE lease_plane.surface_leases DROP CONSTRAINT surface_id_grammar;
+    END IF;
+
+    ALTER TABLE lease_plane.surface_leases
+        ADD CONSTRAINT surface_id_grammar
+        CHECK (surface_id ~ '^(file://|dialectic:/|resident:/|capture:/|td:/|agent:/)');
+END $$;
+
+-- Register migration
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (42, 'lease_plane_agent_scheme', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/elixir/lease_plane/lib/unitares_lease_plane/canonicalize.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/canonicalize.ex
@@ -72,7 +72,7 @@ defmodule UnitaresLeasePlane.Canonicalize do
   require Logger
 
   # v0.8 canonical scheme list (RFC §7.2.1). Single source of truth in Elixir.
-  @canonical_schemes ~w(file dialectic resident capture td)
+  @canonical_schemes ~w(file dialectic resident capture td agent)
 
   @path_max 4096
 
@@ -137,6 +137,7 @@ defmodule UnitaresLeasePlane.Canonicalize do
   defp dispatch("resident:/" <> rest), do: canonicalize_resident(rest)
   defp dispatch("capture:/" <> rest), do: canonicalize_capture(rest)
   defp dispatch("td:/" <> rest), do: canonicalize_td(rest)
+  defp dispatch("agent:/" <> rest), do: canonicalize_agent(rest)
   defp dispatch(_), do: {:error, :invalid_scheme}
 
   @doc """
@@ -370,5 +371,17 @@ defmodule UnitaresLeasePlane.Canonicalize do
   # td:/ — reserved scheme; pass-through with no normalization (matches Python).
   defp canonicalize_td(path) do
     {:ok, "td:/" <> path}
+  end
+
+  # agent:/ — opaque ephemeral-agent id (url-safe base64-ish); case-sensitive,
+  # strip trailing /. Same reserved-char set as resident:/. This is a PRESENCE
+  # surface (unique per agent, routed to remote_heartbeat in the router), not a
+  # mutex — see migration 042 and http_router.acquire_for_surface.
+  defp canonicalize_agent(path) do
+    if String.match?(path, ~r/[ \t\n#&]/) do
+      {:error, :invalid_scheme}
+    else
+      {:ok, "agent:/" <> String.trim_trailing(path, "/")}
+    end
   end
 end

--- a/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
@@ -450,13 +450,21 @@ defmodule UnitaresLeasePlane.HTTPRouter do
   # that locked the file for the BEAM process's lifetime — memory files, with
   # their stable cross-session path, stayed locked for hours/days.
   #
+  # `agent:/` surfaces are ephemeral-agent PRESENCE rows from the BEAM agent
+  # orchestrator (elixir/agent_orchestrator). They are session-scoped like file
+  # edits and MUST self-heal if the agent dies without releasing — and the
+  # surface is unique per agent, so local_beam's mutex/auto-renew would only leak
+  # a renewing holder while coordinating nothing. They take the same
+  # remote_heartbeat (pure-TTL-row) path. See migration 042.
+  #
   # Every other surface (resident:/ presence, migration:/, etc.) keeps the
   # local_beam auto-renew path. Residents are intentionally long-lived and rely
   # on server-side auto-renew for continuity, so the routing is scoped to the
-  # file scheme precisely so it CANNOT regress resident coordination.
+  # file + agent schemes precisely so it CANNOT regress resident coordination.
   defp acquire_for_surface(%{surface_id: surface_id} = params)
        when is_binary(surface_id) do
-    if String.starts_with?(surface_id, "file://") do
+    if String.starts_with?(surface_id, "file://") or
+         String.starts_with?(surface_id, "agent:/") do
       UnitaresLeasePlane.acquire_remote_heartbeat(params)
     else
       UnitaresLeasePlane.acquire_local_beam(params)

--- a/elixir/lease_plane/test/canonicalize_test.exs
+++ b/elixir/lease_plane/test/canonicalize_test.exs
@@ -25,7 +25,7 @@ defmodule UnitaresLeasePlane.CanonicalizeTest do
     end
 
     test "canonical_schemes/0 returns the v0.8 list" do
-      assert Canonicalize.canonical_schemes() == ~w(file dialectic resident capture td)
+      assert Canonicalize.canonical_schemes() == ~w(file dialectic resident capture td agent)
     end
   end
 
@@ -194,6 +194,34 @@ defmodule UnitaresLeasePlane.CanonicalizeTest do
   end
 
   # ---------- file:// (full normalization, PR 7.5) ----------
+
+  describe "agent:/ (ephemeral-agent presence, migration 042)" do
+    test "preserves case and is a valid scheme" do
+      assert {:ok, "agent:/ag-7SDzA2Tm"} = Canonicalize.canonicalize("agent:/ag-7SDzA2Tm")
+    end
+
+    test "strips trailing slash" do
+      assert {:ok, "agent:/ag-abc"} = Canonicalize.canonicalize("agent:/ag-abc/")
+    end
+
+    test "accepts url-safe base64 ids (- and _)" do
+      assert {:ok, "agent:/FQSzK8iT_-x"} = Canonicalize.canonicalize("agent:/FQSzK8iT_-x")
+    end
+
+    test "rejects whitespace, # and & (parity with resident:/)" do
+      assert {:error, :invalid_scheme} = Canonicalize.canonicalize("agent:/with space")
+      assert {:error, :invalid_scheme} = Canonicalize.canonicalize("agent:/h#frag")
+      assert {:error, :invalid_scheme} = Canonicalize.canonicalize("agent:/a&b")
+    end
+
+    test "rejects ? at top level (parity)" do
+      assert {:error, :reserved_query_string} = Canonicalize.canonicalize("agent:/q?x=1")
+    end
+
+    test "is included in the canonical scheme list" do
+      assert "agent" in Canonicalize.canonical_schemes()
+    end
+  end
 
   describe "file:// (PR 7.5 full normalization)" do
     # Most file:// tests touch real filesystem state. async: false at the

--- a/elixir/lease_plane/test/http_router_test.exs
+++ b/elixir/lease_plane/test/http_router_test.exs
@@ -116,6 +116,22 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
       assert is_binary(lease["expires_at"])
     end
 
+    test "agent:/ surface routes to the remote_heartbeat self-healing path (migration 042)", _ctx do
+      agent_surface = "agent:/ag-" <> binary_part(random_uuid(), 0, 8)
+      on_exit(fn -> cleanup_surface(agent_surface) end)
+
+      # Body asks for local_beam (the acquire_body default); the plane routes by
+      # SCHEME, so an agent:/ surface is coerced to the remote_heartbeat path —
+      # a pure TTL row that self-heals, not a renewing local_beam holder.
+      resp = post_json("/v1/lease/acquire", acquire_body(agent_surface))
+
+      assert resp.status == 200
+      lease = parsed(resp)["lease"]
+      assert lease["surface_id"] == agent_surface
+      assert lease["holder_kind"] == "remote_heartbeat"
+      assert lease["heartbeat_required"] == true
+    end
+
     test "idempotent retry from same holder", ctx do
       body = acquire_body(ctx.surface)
 

--- a/src/lease_plane/canonicalize.py
+++ b/src/lease_plane/canonicalize.py
@@ -30,10 +30,11 @@ import os.path
 import tempfile
 
 # v0.8 canonical scheme list (RFC §7.2.1). Single source of truth in code.
-CANONICAL_SCHEMES: tuple[str, ...] = ("file", "dialectic", "resident", "capture", "td")
+# `agent` (ephemeral-agent presence surfaces) added by migration 042.
+CANONICAL_SCHEMES: tuple[str, ...] = ("file", "dialectic", "resident", "capture", "td", "agent")
 
-# Compiled scheme-grammar regex matches what migration 026 enforces at the DB layer.
-_SCHEME_GRAMMAR = "^(file://|dialectic:/|resident:/|capture:/|td:/)"
+# Compiled scheme-grammar regex matches what migrations 026 + 042 enforce at the DB layer.
+_SCHEME_GRAMMAR = "^(file://|dialectic:/|resident:/|capture:/|td:/|agent:/)"
 
 _PATH_MAX = 4096
 
@@ -104,6 +105,8 @@ def canonicalize(surface_id: str) -> str:
         # Reserved scheme; pass-through with no normalization beyond what the
         # caller supplied. Field_validator ensures the prefix matched the grammar.
         return f"td:/{surface_id[len('td:/') :]}"
+    if surface_id.startswith("agent:/"):
+        return _canonicalize_agent(surface_id[len("agent:/") :])
     raise CanonicalizeError(
         "invalid_scheme",
         f"surface_id does not match canonical scheme list ({CANONICAL_SCHEMES}): {surface_id!r}",
@@ -160,6 +163,20 @@ def _canonicalize_resident(path: str) -> str:
             f"resident:/ surface_id contains reserved character (?, #, &, whitespace): {path!r}",
         )
     return f"resident:/{path.rstrip('/')}"
+
+
+def _canonicalize_agent(path: str) -> str:
+    """agent:/ — opaque ephemeral-agent id; case-sensitive; strip trailing /.
+
+    A PRESENCE surface (unique per agent), routed to remote_heartbeat by the
+    plane — not a mutex. Same reserved-char rules as resident:/. (Migration 042.)
+    """
+    if any(ch in path for ch in (" ", "\t", "\n", "?", "#", "&")):
+        raise CanonicalizeError(
+            "invalid_scheme",
+            f"agent:/ surface_id contains reserved character (?, #, &, whitespace): {path!r}",
+        )
+    return f"agent:/{path.rstrip('/')}"
 
 
 def _canonicalize_capture(path: str) -> str:

--- a/src/lease_plane/canonicalize.py
+++ b/src/lease_plane/canonicalize.py
@@ -170,6 +170,11 @@ def _canonicalize_agent(path: str) -> str:
 
     A PRESENCE surface (unique per agent), routed to remote_heartbeat by the
     plane — not a mutex. Same reserved-char rules as resident:/. (Migration 042.)
+
+    Error-atom parity note (matches resident:/): a `?` in the path is rejected
+    here as ``invalid_scheme``, but the Elixir side catches `?` at the top level
+    and returns ``reserved_query_string``. The OK path is byte-identical across
+    languages; only the error label differs on `?`-bearing input.
     """
     if any(ch in path for ch in (" ", "\t", "\n", "?", "#", "&")):
         raise CanonicalizeError(

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -128,6 +128,9 @@ async def ensure_test_database_schema() -> None:
         # Migration 034: substrate_state columns for §7.13 resident heartbeat surface
         # (RFC v0.11). Adds 2 NULLABLE columns + 4 CHECK constraints + freshness index.
         await _execute_sql_file(conn, "db/postgres/migrations/034_lease_plane_substrate_state.sql")
+        # Migration 042: agent:/ ephemeral-agent presence scheme (extends the
+        # 026 grammar CHECK). Must run after 026; placed with the lease_plane group.
+        await _execute_sql_file(conn, "db/postgres/migrations/042_lease_plane_agent_scheme.sql")
         # Migration 035: Wave 0 coordination_events instrumentation table.
         await _execute_sql_file(conn, "db/postgres/migrations/035_coordination_events.sql")
         # Migration 036: R2 lineage lifecycle columns + sweeper-friendly partial index.

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -128,9 +128,6 @@ async def ensure_test_database_schema() -> None:
         # Migration 034: substrate_state columns for §7.13 resident heartbeat surface
         # (RFC v0.11). Adds 2 NULLABLE columns + 4 CHECK constraints + freshness index.
         await _execute_sql_file(conn, "db/postgres/migrations/034_lease_plane_substrate_state.sql")
-        # Migration 042: agent:/ ephemeral-agent presence scheme (extends the
-        # 026 grammar CHECK). Must run after 026; placed with the lease_plane group.
-        await _execute_sql_file(conn, "db/postgres/migrations/042_lease_plane_agent_scheme.sql")
         # Migration 035: Wave 0 coordination_events instrumentation table.
         await _execute_sql_file(conn, "db/postgres/migrations/035_coordination_events.sql")
         # Migration 036: R2 lineage lifecycle columns + sweeper-friendly partial index.
@@ -138,6 +135,10 @@ async def ensure_test_database_schema() -> None:
         # lineage_last_eval_at, chain_obs_count to core.identities. Required for
         # the R2 provisional → confirmed/demoted/archived FSM (PR 1).
         await _execute_sql_file(conn, "db/postgres/migrations/036_r2_lineage_lifecycle.sql")
+        # Migration 042: agent:/ ephemeral-agent presence scheme (extends the 026
+        # grammar CHECK). Applied last here so the bootstrap order matches the
+        # production numeric apply-order (042 > 036); it only depends on 026.
+        await _execute_sql_file(conn, "db/postgres/migrations/042_lease_plane_agent_scheme.sql")
 
         # Ensure partitioned audit tables can accept inserts for current month.
         await _execute_sql_file(conn, "db/postgres/partitions.sql")

--- a/tests/test_lease_plane_canonicalize.py
+++ b/tests/test_lease_plane_canonicalize.py
@@ -86,6 +86,24 @@ def test_capture_canonicalizes_member_ordering():
     )
 
 
+def test_agent_scheme_canonicalizes_as_presence_surface():
+    """agent:/ — ephemeral-agent presence surface (migration 042). Opaque,
+    case-sensitive, strip trailing /, same reserved chars as resident:/."""
+    from src.lease_plane import canonicalize as canon
+    from src.lease_plane.canonicalize import CANONICAL_SCHEMES, CanonicalizeError
+
+    assert "agent" in CANONICAL_SCHEMES
+
+    assert canon.canonicalize("agent:/ag-7SDzA2Tm") == "agent:/ag-7SDzA2Tm"
+    assert canon.canonicalize("agent:/ag-abc/") == "agent:/ag-abc"  # trailing / stripped
+    # url-safe base64 ids (the orchestrator's generate_agent_id output) are valid
+    assert canon.canonicalize("agent:/FQSzK8iT_-x") == "agent:/FQSzK8iT_-x"
+
+    for bad in ("agent:/with space", "agent:/h#frag", "agent:/a&b", "agent:/q?x=1"):
+        with pytest.raises(CanonicalizeError):
+            canon.canonicalize(bad)
+
+
 def test_canonicalize_error_semantics():
     """Helper raises CanonicalizeError with named reasons for bounded failure modes."""
     from src.lease_plane.canonicalize import CanonicalizeError, canonicalize

--- a/tests/test_migration_042_lease_plane_agent_scheme.py
+++ b/tests/test_migration_042_lease_plane_agent_scheme.py
@@ -1,0 +1,88 @@
+"""
+Schema test for migration 042 — the `agent:/` ephemeral-agent presence scheme.
+
+Migration 042 extends the migration-026 `surface_id_grammar` CHECK to allow
+`agent:/` surface_ids. These are ephemeral-agent presence rows (one per agent,
+routed to the remote_heartbeat pure-TTL-row path by the plane). This test pins
+the storage-layer acceptance: an `agent:/...` surface_id INSERTs cleanly and
+derives surface_kind='agent', while the prior canonical schemes still work and a
+non-canonical scheme is still rejected.
+"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+try:
+    import asyncpg
+except ImportError:
+    pytest.skip("asyncpg not installed", allow_module_level=True)
+
+from tests.test_db_utils import (
+    TEST_DB_URL,
+    can_connect_to_test_db,
+    ensure_test_database_schema,
+)
+
+if not can_connect_to_test_db():
+    pytest.skip("governance_test database not available", allow_module_level=True)
+
+
+async def _insert_lease(conn, *, surface_id: str, ttl_s: int = 60) -> uuid.UUID:
+    """Insert a remote_heartbeat lease row directly. Returns the lease_id."""
+    holder_uuid = uuid.uuid4()
+    now = datetime.now(UTC)
+    expires = now + timedelta(seconds=ttl_s)
+    lease_id = uuid.uuid4()
+    await conn.execute(
+        """
+        INSERT INTO lease_plane.surface_leases
+          (lease_id, surface_id, holder_agent_uuid, holder_kind,
+           holder_class, heartbeat_required, original_ttl_s,
+           acquired_at, expires_at)
+        VALUES ($1, $2, $3, 'remote_heartbeat', 'process_instance', true, $4, $5, $6)
+        """,
+        lease_id, surface_id, holder_uuid, ttl_s, now, expires,
+    )
+    return lease_id
+
+
+@pytest.mark.asyncio
+async def test_migration_042_accepts_agent_scheme_and_derives_kind():
+    """An agent:/ surface_id INSERTs cleanly and surface_kind derives to 'agent'."""
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await conn.execute("DELETE FROM lease_plane.surface_leases")
+        surface_id = "agent:/ag-7SDzA2Tm"
+        lease_id = await _insert_lease(conn, surface_id=surface_id)
+        kind = await conn.fetchval(
+            "SELECT surface_kind FROM lease_plane.surface_leases WHERE lease_id = $1",
+            lease_id,
+        )
+        assert kind == "agent", f"expected surface_kind='agent', got {kind!r}"
+    finally:
+        await conn.execute("DELETE FROM lease_plane.surface_leases")
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_042_still_rejects_non_canonical_scheme():
+    """042 only ADDS agent:/ — a bogus scheme is still rejected by the grammar."""
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        await conn.execute("DELETE FROM lease_plane.surface_leases")
+        with pytest.raises(asyncpg.CheckViolationError):
+            await _insert_lease(conn, surface_id="potato:/still_not_real")
+    finally:
+        await conn.execute("DELETE FROM lease_plane.surface_leases")
+        await conn.close()


### PR DESCRIPTION
Adds an `agent:/` surface scheme so the BEAM agent orchestrator can register ephemeral-agent **presence** on the lease plane — and closes the self-heal caveat documented in `agent-orchestrator-beam-v0`.

## The key idea
An `agent:<id>` surface is **unique per agent**, so a lease on it can never be contended — it's *presence, not a mutex*. Modeling it via `local_beam` (a mutex with an auto-renewing holder) would leak a renewing holder that coordinates nothing and never self-heals. So `agent:/` is routed — like `file://` — to the **`remote_heartbeat`** pure-TTL-row path: an orphaned presence row reaps itself at TTL instead of being held open by a renewing holder.

## Changes (one repo, both languages + DB, in lockstep)
- **migration 042** — extend the 026 `surface_id_grammar` CHECK to allow `agent:/`; registers version 42. `surface_kind='agent'` derives from the generated column.
- **Elixir** `Canonicalize` — `agent` scheme + dispatch + `canonicalize_agent` (mirrors `resident`); `http_router.acquire_for_surface` routes `agent:/` → `remote_heartbeat`.
- **Python** `src/lease_plane/canonicalize.py` — mirror (scheme list, grammar, dispatch, `_canonicalize_agent`).
- **tests** — Elixir canonicalize + http_router (pins `agent:/`→`remote_heartbeat`, overriding the body `holder_kind`); Python canonicalize + migration-042 grammar test; registered 042 in the test-db bootstrap.

## Verification
- Elixir **100 tests, 0 failures** + canonicalize **53/0** (against `governance_test` with 042 applied); Python migration-042 **2/2**; doctor `elixir_scheme_grammar_lint` **PASS** ("canonicalize.ex schemes match grammar incl agent").
- DB-backed tests skip in CI (no Postgres); the pure canonicalize tests are the CI gate.

## Council (3-agent)
- **live-verifier: 6/6 VERIFIED** against `governance_test` — grammar accepts `agent:/`, derives `surface_kind='agent'`, rejects `agent:test`/`agentX:/y`, no collision with migration-034's resident-only CHECK or the holder_kind CHECK, registry has version 42, routing → `remote_heartbeat` confirmed.
- **architect: KEEP AS-IS** — the presence-not-mutex reasoning holds; `agent` vs `resident:/` is a real lifecycle distinction (reap vs renew) so reuse isn't available.
- **reviewer: no correctness bugs** — applied its two doc/ordering nits (bootstrap apply-order, `?`-parity docstring).

## Follow-up (separate PR)
Wire the orchestrator to default-on **best-effort** `agent:/` presence (`required: false` — presence shouldn't gate spawning) with a distinguishable acquire-failure signal, and resolve the self-heal caveat in the design note. The live `governance` DB gets 042 via the normal deploy migration step.