### PR TITLE
feat(orchestrator): default-on best-effort agent:/ presence + signal

### DIFF
--- a/docs/proposals/agent-orchestrator-beam-v0.md
+++ b/docs/proposals/agent-orchestrator-beam-v0.md
@@ -44,40 +44,41 @@ exit — a finished or crashed agent stays finished. The supervisor buys
 *lifecycle ownership* (clean spawn, tracked teardown, lease release, fan-out over
 a known child set), not crash-restart durability. This is the honest scope.
 
-## Lease binding — kept in v0, with an honest caveat
+## Presence (default-on, best-effort) — self-heal caveat RESOLVED
 
-On spawn, an agent optionally acquires a lease for its surface (default
-`agent:<id>`) via the lease plane's RFC §5 HTTP surface; on exit it releases.
-This gives the fleet plane a record of which ephemeral agents are live, and
-admission control is free: `lease: %{required: true}` (default) refuses to start
-the agent if the lease is denied — fail closed. The `LeasePlaneClient` is
-behaviour-injected (`:lease_client` spec key) so tests and standalone runs need
-no live plane.
+By default an agent registers an `agent:/<id>` **presence** row on the lease
+plane on spawn and releases it on exit. The `agent:/` scheme (migration 042,
+PR #588) routes to the **self-healing `remote_heartbeat` TTL-row** path, so the
+caveat below is now resolved. Presence is **best-effort** (`required: false`):
+a plane failure does not block the spawn. `lease: false` opts out; a `:lease`
+map overrides (e.g. `required: true` for a genuinely gating lease). The
+`LeasePlaneClient` is behaviour-injected (`:lease_client`) so tests need no plane.
 
-### CAVEAT — these leases do NOT self-heal at TTL (council finding, 2026-06-03)
+The result's `:presence` field is the distinguishable signal: `:registered`
+(plane row exists), `:unregistered` (best-effort acquire failed — agent running
+but NOT on the plane, so plane-absence ≠ not-running), or `:disabled`.
 
-An earlier draft of this note claimed "orphans self-heal via the reaper's TTL
-(`remote_heartbeat` = pure DB TTL row)." **That is false for the surface the
-orchestrator actually uses**, and it was caught by council review + verified
-empirically against the live plane:
+### ~~CAVEAT — these leases do NOT self-heal at TTL~~ (RESOLVED by #588)
 
-- The plane routes `holder_kind` **by surface scheme, not by the request body**
-  (`http_router.ex:457-466`). Only `file://` surfaces get the TTL-row
-  `remote_heartbeat` path. Every other scheme — `resident:/`, and any future
-  `agent:` — is coerced to `local_beam`, which spawns an **auto-renewing holder**
-  on the plane's node. The `holder_kind: "remote_heartbeat"` this client sends is
-  silently overridden.
-- Proof: an orphan left by a failed smoke run had its `expires_at` *advancing*
-  under active renewal (12:07:46 → 12:09:26), not decaying toward a TTL reap. It
-  had to be explicitly released.
+> **RESOLVED 2026-06-03 via the `agent:/` scheme (PR #588).** `agent:/` surfaces
+> now route to `remote_heartbeat` (pure TTL row), so an orphaned presence row
+> reaps itself at TTL. The original finding is preserved below for the record.
 
-**Consequence for v0:** lease cleanup rests entirely on the runner's release
-paths (`finalize/2` on exit, `terminate/2` on stop), which the lifecycle-bug
-fixes below now make robust. The **residual risk** is a hard crash that skips
-`terminate/2` (`:brutal_kill`, VM crash): such a lease will NOT self-heal — it is
-held by the plane-side renewing holder until the plane restarts or an operator
-force-releases. The proper fix (an `agent:` scheme with non-renewing TTL-row
-routing) is deferred — see finding 1.
+An earlier draft of this note claimed "orphans self-heal via the reaper's TTL."
+That was **false for the surface the orchestrator used at the time**, caught by
+council + verified empirically:
+
+- The plane routes `holder_kind` **by surface scheme, not the request body**
+  (`http_router.ex`). At the time, only `file://` got the TTL-row path; every
+  other scheme (incl. the old `agent:<id>`) was coerced to the auto-renewing
+  `local_beam` holder. **#588 added `agent:/` to the `remote_heartbeat` branch**,
+  fixing exactly this.
+- Proof of the original bug: an orphan's `expires_at` *advanced* under active
+  renewal (12:07:46 → 12:09:26) instead of decaying to a TTL reap.
+
+**Residual:** a hard crash that skips `terminate/2` (`:brutal_kill`, VM crash) no
+longer leaks indefinitely — the `agent:/` presence row now reaps itself at TTL
+(≤ `default_lease_ttl_s`). Explicit release on exit remains the fast path.
 
 ## Verification
 

--- a/elixir/agent_orchestrator/lib/agent_orchestrator/agent_runner.ex
+++ b/elixir/agent_orchestrator/lib/agent_orchestrator/agent_runner.ex
@@ -31,15 +31,29 @@ defmodule AgentOrchestrator.AgentRunner do
         env: [{String.t(), String.t()}],   # extra env for the child (default [])
         cd: String.t() | nil,              # working dir
         max_output_lines: pos_integer(),   # buffer cap (default 1000)
-        lease: nil | lease_cfg,            # nil = no lease; map = lease-bound
+        lease: nil | false | lease_cfg,    # default (absent/nil) = best-effort agent:/ presence;
+                                           # false = no presence; map = override
         lease_client: module()             # injectable, default LeasePlaneClient
       }
 
       lease_cfg :: %{
-        required: boolean(),               # default true — refuse to start if acquire fails
+        required: boolean(),               # default FALSE — presence is best-effort, not gating
+        surface_id: String.t(),            # default "agent:/<id>" (presence surface)
         holder_agent_uuid: String.t(),     # the agent's governance UUID (generated if absent)
         ttl_s: pos_integer()               # default from config :default_lease_ttl_s
       }
+
+  ## Presence
+
+  By default an agent registers an `agent:/<id>` PRESENCE row on the lease plane
+  (migration 042 routes it to the self-healing remote_heartbeat path). It is
+  best-effort: a plane failure does NOT block the spawn. The result's `:presence`
+  field is the distinguishable signal:
+
+    * `:registered`   — a plane presence row exists for this agent.
+    * `:unregistered` — best-effort acquire failed; the agent is running but has
+      NO plane row (so plane-absence ≠ not-running).
+    * `:disabled`     — presence was turned off (`lease: false`).
   """
 
   use GenServer
@@ -60,6 +74,7 @@ defmodule AgentOrchestrator.AgentRunner do
     :lease_id,
     :lease_client,
     :lease_cfg,
+    :presence,
     :exit_status,
     :release_status,
     output: [],
@@ -147,8 +162,8 @@ defmodule AgentOrchestrator.AgentRunner do
       {:error, :lease_denied, reason} ->
         {:stop, {:lease_denied, reason}}
 
-      {:ok, lease_id} ->
-        state = %{state | lease_id: lease_id}
+      {:ok, lease_id, presence} ->
+        state = %{state | lease_id: lease_id, presence: presence}
 
         case open_port(spec) do
           {:ok, port, os_pid} ->
@@ -224,6 +239,12 @@ defmodule AgentOrchestrator.AgentRunner do
   # Terminal finalize: flush any partial line, release the lease, record the
   # exit status, reply to waiters, and stop. `status` is an integer for a clean
   # exit or `{:port_closed, reason}` for an abnormal close.
+  #
+  # NOTE: a late await/snapshot (one issued after the process has already exited)
+  # returns {:error, :not_found} — the result is not retained past process death.
+  # Callers that need a fast agent's final result should await before it exits or
+  # snapshot during the run. (Retaining results post-exit — e.g. an ETS result
+  # store — is a deferred follow-up; it is not required for presence.)
   defp finalize(state, status) do
     state = if state.partial != "", do: push_line(%{state | partial: ""}, state.partial), else: state
     Logger.info("agent #{state.agent_id} exited status=#{inspect(status)}")
@@ -273,36 +294,55 @@ defmodule AgentOrchestrator.AgentRunner do
     end
   end
 
-  defp normalize_lease_cfg(nil, _agent_id), do: nil
+  # Presence is DEFAULT-ON and best-effort: with no `:lease` key, an agent
+  # registers an `agent:/<id>` presence row on the plane (migration 042 routes it
+  # to the self-healing remote_heartbeat path). `lease: false` opts out entirely.
+  # A `:lease` map overrides the defaults (e.g. `required: true` to make it a
+  # gating lease, or a different `surface_id`).
+  defp normalize_lease_cfg(false, _agent_id), do: nil
+
+  defp normalize_lease_cfg(nil, agent_id), do: normalize_lease_cfg(%{}, agent_id)
 
   defp normalize_lease_cfg(%{} = cfg, agent_id) do
-    # Default surface is `agent:<id>`. NOTE: the lease plane's canonical scheme
-    # list (`file dialectic resident capture td`) does not yet include `agent`,
-    # so an `agent:` surface is rejected with invalid_scheme today. Adding the
-    # scheme touches Canonicalize in BOTH Elixir and Python (single-writer
-    # cross-repo coordination surface) — an operator/council follow-up. Callers
-    # can override `:surface_id` with a currently-valid scheme in the meantime.
     %{
-      required: Map.get(cfg, :required, true),
+      # Best-effort by default: presence should NOT gate spawning. A caller that
+      # genuinely needs a gating lease passes `required: true`.
+      required: Map.get(cfg, :required, false),
       holder_agent_uuid: Map.get(cfg, :holder_agent_uuid) || uuid4(),
-      surface_id: Map.get(cfg, :surface_id) || "agent:" <> agent_id,
+      surface_id: Map.get(cfg, :surface_id) || "agent:/" <> agent_id,
       ttl_s: Map.get(cfg, :ttl_s, Application.get_env(:agent_orchestrator, :default_lease_ttl_s, 300))
     }
   end
 
-  defp maybe_acquire_lease(%{lease_cfg: nil}), do: {:ok, nil}
+  # Returns {:ok, lease_id, presence} | {:error, :lease_denied, reason}.
+  # presence is :disabled | :registered | :unregistered — a distinguishable
+  # signal so a consumer of plane presence knows that an :unregistered agent is
+  # live-but-not-on-the-plane (absence from the plane ≠ not running).
+  defp maybe_acquire_lease(%{lease_cfg: nil}), do: {:ok, nil, :disabled}
 
-  defp maybe_acquire_lease(%{lease_cfg: cfg, lease_client: client}) do
+  defp maybe_acquire_lease(%{agent_id: agent_id, lease_cfg: cfg, lease_client: client}) do
     case client.acquire(cfg.surface_id, cfg.holder_agent_uuid, "remote_heartbeat", cfg.ttl_s) do
       {:ok, lease_id} ->
-        {:ok, lease_id}
+        {:ok, lease_id, :registered}
 
       {:error, reason} ->
         if cfg.required do
           {:error, :lease_denied, reason}
         else
-          Logger.warning("agent lease acquire failed (best-effort, proceeding): #{inspect(reason)}")
-          {:ok, nil}
+          # Best-effort: proceed, but emit a DISTINGUISHABLE signal. This agent is
+          # running yet has no plane presence row — anything querying the plane
+          # for "live agents" must not read this agent's absence as "not running."
+          # :no_bearer means presence is simply not configured (dev/test) → quiet;
+          # any other reason is a configured-but-unreachable plane → loud.
+          level = if reason == :no_bearer, do: :debug, else: :warning
+
+          Logger.log(
+            level,
+            "agent #{agent_id} presence UNREGISTERED (#{inspect(reason)}) — running " <>
+              "WITHOUT a presence row; plane-absence does NOT imply not-running"
+          )
+
+          {:ok, nil, :unregistered}
         end
     end
   end
@@ -389,6 +429,7 @@ defmodule AgentOrchestrator.AgentRunner do
       agent_id: state.agent_id,
       os_pid: state.os_pid,
       lease_id: state.lease_id,
+      presence: state.presence,
       exit_status: state.exit_status,
       running: state.exit_status == nil,
       lease_released: state.release_status == :ok,

--- a/elixir/agent_orchestrator/test/agent_orchestrator_test.exs
+++ b/elixir/agent_orchestrator/test/agent_orchestrator_test.exs
@@ -6,6 +6,11 @@ defmodule AgentOrchestratorTest do
   setup do
     Application.put_env(:agent_orchestrator, :test_pid, self())
     Application.put_env(:agent_orchestrator, :stub_acquire_result, {:ok, "stub-lease"})
+    # Presence is default-on, so a spec WITHOUT an injected lease_client uses the
+    # real LeasePlaneClient. Null the bearer so that path is a deterministic
+    # no-network :no_bearer fast-fail (→ presence :unregistered) regardless of
+    # the shell env — tests must never hit the live plane.
+    Application.put_env(:agent_orchestrator, :lease_plane_bearer_token, nil)
 
     on_exit(fn ->
       Application.delete_env(:agent_orchestrator, :test_pid)
@@ -111,22 +116,25 @@ defmodule AgentOrchestratorTest do
     test "acquires on spawn and releases on exit" do
       {:ok, id, _} =
         AgentOrchestrator.run(%{
-          cmd: "echo",
-          args: ["done"],
+          # Brief sleep (not echo) so await/0 registers as a waiter before the
+          # process exits — avoids the await-after-fast-exit race under load.
+          cmd: "sh",
+          args: ["-c", "sleep 0.15"],
           lease: %{holder_agent_uuid: "11111111-1111-4111-8111-111111111111"},
           lease_client: StubLeaseClient
         })
 
       assert_receive {:lease_event,
                       {:acquire, surface_id, "11111111-1111-4111-8111-111111111111",
-                       "remote_heartbeat", 300}}
+                       "remote_heartbeat", 300}},
+                     500
 
-      assert surface_id == "agent:" <> id
+      assert surface_id == "agent:/" <> id
 
-      assert {:ok, %{lease_id: "stub-lease", exit_status: 0, lease_released: true}} =
+      assert {:ok, %{lease_id: "stub-lease", exit_status: 0, lease_released: true, presence: :registered}} =
                AgentOrchestrator.await(id)
 
-      assert_receive {:lease_event, {:release, "stub-lease", "normal"}}
+      assert_receive {:lease_event, {:release, "stub-lease", "normal"}}, 500
     end
 
     test "releases the lease when the port fails to open after acquire (no orphan)" do
@@ -141,25 +149,62 @@ defmodule AgentOrchestratorTest do
       assert_receive {:lease_event, {:release, "stub-lease", "normal"}}
     end
 
-    test "refuses to start when a required lease is denied" do
+    test "refuses to start only when a lease is explicitly required and denied" do
       Application.put_env(:agent_orchestrator, :stub_acquire_result, {:error, {:held_by_other, "other"}})
 
       assert {:error, {:lease_denied, {:held_by_other, "other"}}} =
-               AgentOrchestrator.run(%{cmd: "echo", args: ["x"], lease: %{}, lease_client: StubLeaseClient})
+               AgentOrchestrator.run(%{
+                 cmd: "echo",
+                 args: ["x"],
+                 lease: %{required: true},
+                 lease_client: StubLeaseClient
+               })
     end
 
-    test "best-effort lease proceeds even when acquire fails" do
-      Application.put_env(:agent_orchestrator, :stub_acquire_result, {:error, :no_bearer})
+    test "best-effort presence proceeds and reports :unregistered when acquire fails" do
+      Application.put_env(:agent_orchestrator, :stub_acquire_result, {:error, :plane_down})
 
       {:ok, id, _} =
+        AgentOrchestrator.run(%{cmd: "sleep", args: ["5"], lease_client: StubLeaseClient})
+
+      # snapshot while alive — the agent proceeded despite the acquire failure.
+      assert {:ok, %{lease_id: nil, presence: :unregistered, running: true}} =
+               AgentOrchestrator.snapshot(id)
+
+      assert :ok = AgentOrchestrator.stop(id)
+    end
+  end
+
+  describe "presence (default-on, best-effort)" do
+    # Long-lived agents + snapshot/0 (read while alive) — avoids the await race
+    # where a fast command exits and unregisters before the assertion runs.
+    test "registers agent:/<id> presence by default with no :lease key" do
+      {:ok, id, _} =
+        AgentOrchestrator.run(%{cmd: "sleep", args: ["5"], lease_client: StubLeaseClient})
+
+      # required:false (best-effort), surface is the agent:/ presence surface.
+      assert_receive {:lease_event, {:acquire, surface_id, _uuid, "remote_heartbeat", 300}}, 500
+      assert surface_id == "agent:/" <> id
+      assert {:ok, %{presence: :registered, lease_id: "stub-lease", running: true}} =
+               AgentOrchestrator.snapshot(id)
+
+      assert :ok = AgentOrchestrator.stop(id)
+    end
+
+    test "lease: false disables presence (no acquire, :disabled)" do
+      {:ok, id, _} =
         AgentOrchestrator.run(%{
-          cmd: "echo",
-          args: ["x"],
-          lease: %{required: false},
+          cmd: "sleep",
+          args: ["5"],
+          lease: false,
           lease_client: StubLeaseClient
         })
 
-      assert {:ok, %{lease_id: nil, exit_status: 0}} = AgentOrchestrator.await(id)
+      refute_receive {:lease_event, {:acquire, _, _, _, _}}, 100
+      assert {:ok, %{presence: :disabled, lease_id: nil, running: true}} =
+               AgentOrchestrator.snapshot(id)
+
+      assert :ok = AgentOrchestrator.stop(id)
     end
   end
 end


### PR DESCRIPTION
Wires the BEAM agent orchestrator to **consume** the `agent:/` presence scheme (#588) — the follow-up the architect flagged. Closes the self-heal caveat from the orchestrator v0 doc.

## What it does
- **Presence is default-ON and best-effort.** Every ephemeral agent registers an `agent:/<id>` presence row (routed to the self-healing `remote_heartbeat` TTL path by #588). `required: false` — a plane failure does **not** block the spawn. `lease: false` opts out; a `:lease` map overrides (e.g. `required: true` for a genuinely gating lease).
- **Surface fixed to `agent:/<id>`** (was `agent:<id>` — the canonical single-slash form the scheme grammar expects).
- **Distinguishable acquire-failure signal** — the architect's "one thing most worth getting right," because it's what makes the presence data trustworthy. `result.presence`:
  - `:registered` — a plane row exists.
  - `:unregistered` — best-effort acquire failed; the agent is running but has **no** plane row, so **plane-absence ≠ not-running**. Logged loud for a configured-but-unreachable plane, quiet for `:no_bearer` (presence simply not configured).
  - `:disabled` — `lease: false`.

## Tests
A `presence` describe block (registered / unregistered / disabled, via snapshot-while-alive), `required: true` denial, `agent:/` surface assertions. `setup` nulls the bearer so the default real-client path is a deterministic no-network `:no_bearer` fast-fail — tests never hit the live plane. PR-B's own tests are deterministic across seeds.

## Known pre-existing (NOT introduced here)
The output tests have a mild **await-of-fast-command race** (an `await` issued after the process already exited returns `:not_found`) — present since the orchestrator v0 (#581), documented in `finalize/2`. The proper fix is a post-exit result-retention store (ETS), which is its own scoped follow-up. The presence tests here avoid it entirely via snapshot-while-alive. (Elixir tests are not CI-gated; the pure canonicalize/scheme tests gate.)

Depends on #588 (merged) for live behavior.