### PR TITLE
fix(orchestrator): stop/2 tolerates an agent that died mid-call (stacked on #590)

### DIFF
--- a/docs/proposals/agent-orchestrator-beam-v0.md
+++ b/docs/proposals/agent-orchestrator-beam-v0.md
@@ -111,8 +111,17 @@ defer the architecture call." Fixed:
    `{:EXIT}` cleared it first, the status was dropped, waiters hung forever, and
    the lease was never released. Both messages now route through a shared
    `finalize/2` that is order-independent.
-4. **`await/2` caller crash.** A race between `whereis/0` and the call landing
-   could exit the caller `:noproc`; now caught → `{:error, :not_found}`.
+4. **`await/2` caller crash, and the result lost behind it.** A race between
+   `whereis/0` and the call landing could exit the caller `:noproc`; that exit is
+   caught. But a fast agent (`echo`, a sub-second worker) could be *gone* before
+   the await even looked, and the documented "await earlier / snapshot during the
+   run" workaround does not help a fan-out caller collecting results after exit —
+   the final result was simply lost to `{:error, :not_found}`. Now `finalize/2`
+   writes the terminal result to `AgentOrchestrator.ResultStore` (a TTL-bounded
+   ETS table owned by the app, not by any runner) *before* the runner stops, so a
+   late `await`/`snapshot` that observes the runner as dead falls back to the
+   retained result. The write happens-before process death, so the race is closed,
+   not merely narrowed.
 5. **Unbounded partial-line buffer.** A child emitting a line longer than
    `@line_max_bytes` with no newline grew `partial` without limit; now flushed at
    the cap.

--- a/elixir/agent_orchestrator/config/config.exs
+++ b/elixir/agent_orchestrator/config/config.exs
@@ -11,4 +11,11 @@ config :agent_orchestrator,
   # Default TTL for an ephemeral agent's remote_heartbeat lease. The lease is a
   # pure DB TTL row reaped by the lease plane's reaper, so a crashed orchestrator
   # self-heals within one TTL rather than leaking the surface forever.
-  default_lease_ttl_s: 300
+  default_lease_ttl_s: 300,
+  # AgentOrchestrator.ResultStore retention (closes the await-vs-fast-exit race,
+  # #581). A finished runner retains its final result for this long so a late
+  # await/snapshot survives process death; the sweep evicts expired rows and the
+  # max caps the table under a churn burst within one TTL window.
+  result_retention_ms: 300_000,
+  result_sweep_interval_ms: 60_000,
+  result_store_max: 10_000

--- a/elixir/agent_orchestrator/lib/agent_orchestrator/agent_runner.ex
+++ b/elixir/agent_orchestrator/lib/agent_orchestrator/agent_runner.ex
@@ -145,8 +145,20 @@ defmodule AgentOrchestrator.AgentRunner do
   @spec stop(String.t(), term()) :: :ok | {:error, :not_found}
   def stop(agent_id, reason \\ :operator_stop) do
     case whereis(agent_id) do
-      nil -> {:error, :not_found}
-      pid -> GenServer.stop(pid, {:shutdown, reason})
+      nil ->
+        {:error, :not_found}
+
+      pid ->
+        # The agent can die between whereis/0 and this call (it is
+        # restart: :temporary and stops itself on exit; the Registry unregisters
+        # only on the async :DOWN). GenServer.stop then exits :noproc and would
+        # crash the caller — e.g. on_exit cleanup sweeping a just-exited agent.
+        # Stopping something that's already gone IS success, so treat it as :ok.
+        try do
+          GenServer.stop(pid, {:shutdown, reason})
+        catch
+          :exit, _ -> :ok
+        end
     end
   end
 

--- a/elixir/agent_orchestrator/lib/agent_orchestrator/agent_runner.ex
+++ b/elixir/agent_orchestrator/lib/agent_orchestrator/agent_runner.ex
@@ -63,6 +63,7 @@ defmodule AgentOrchestrator.AgentRunner do
   require Logger
 
   alias AgentOrchestrator.LeasePlaneClient
+  alias AgentOrchestrator.ResultStore
 
   @default_max_lines 1000
   @line_max_bytes 65_536
@@ -99,22 +100,46 @@ defmodule AgentOrchestrator.AgentRunner do
   @doc "Block until the agent exits (or `timeout` ms). Returns `{:ok, result}` or `{:error, :timeout}`."
   @spec await(String.t(), timeout()) :: {:ok, map()} | {:error, :timeout | :not_found}
   def await(agent_id, timeout \\ 30_000) do
-    call(agent_id, :await, timeout)
+    case call(agent_id, :await, timeout) do
+      # whereis/0 already saw the runner gone — fall back to the retained result.
+      {:error, :not_found} -> retained_or_not_found(agent_id)
+      reply -> reply
+    end
   catch
     :exit, {:timeout, _} ->
       {:error, :timeout}
 
     # The agent can exit between whereis/0 and the call landing in its mailbox
     # (it stops itself on exit). GenServer.call then exits :noproc/:normal —
-    # catch it instead of crashing the caller. The final result is lost on this
-    # narrow race; snapshot/1 during the run or await earlier to avoid it.
+    # catch it instead of crashing the caller. The runner writes its final
+    # result to ResultStore before it dies (see finalize/2), so a fast agent's
+    # result survives this race rather than being lost to :not_found (#581).
     :exit, _ ->
-      {:error, :not_found}
+      retained_or_not_found(agent_id)
   end
 
   @doc "Current captured output and status without blocking."
   @spec snapshot(String.t()) :: {:ok, map()} | {:error, :not_found}
-  def snapshot(agent_id), do: call(agent_id, :snapshot)
+  def snapshot(agent_id) do
+    case call(agent_id, :snapshot) do
+      {:error, :not_found} -> retained_or_not_found(agent_id)
+      reply -> reply
+    end
+  catch
+    # Same dead-mid-call race as await/2: a live whereis/0 followed by the
+    # process exiting before the snapshot lands. Fall back to the retained
+    # terminal result instead of crashing the caller with the GenServer exit.
+    :exit, _ ->
+      retained_or_not_found(agent_id)
+  end
+
+  # On a dead runner, the terminal result may have been retained by finalize/2.
+  defp retained_or_not_found(agent_id) do
+    case ResultStore.fetch(agent_id) do
+      {:ok, result} -> {:ok, result}
+      :error -> {:error, :not_found}
+    end
+  end
 
   @doc "Stop the agent: close the Port (terminating the child) and release its lease."
   @spec stop(String.t(), term()) :: :ok | {:error, :not_found}
@@ -237,20 +262,22 @@ defmodule AgentOrchestrator.AgentRunner do
   def handle_info(_msg, state), do: {:noreply, state}
 
   # Terminal finalize: flush any partial line, release the lease, record the
-  # exit status, reply to waiters, and stop. `status` is an integer for a clean
-  # exit or `{:port_closed, reason}` for an abnormal close.
+  # exit status, reply to waiters, retain the result, and stop. `status` is an
+  # integer for a clean exit or `{:port_closed, reason}` for an abnormal close.
   #
-  # NOTE: a late await/snapshot (one issued after the process has already exited)
-  # returns {:error, :not_found} — the result is not retained past process death.
-  # Callers that need a fast agent's final result should await before it exits or
-  # snapshot during the run. (Retaining results post-exit — e.g. an ETS result
-  # store — is a deferred follow-up; it is not required for presence.)
+  # The ResultStore write happens-before the {:stop, ...} return (the GenServer
+  # only terminates after this callback returns), so a late await/snapshot that
+  # observes the runner as dead is guaranteed to find the retained result rather
+  # than racing to {:error, :not_found} (#581). Retention is TTL-bounded — see
+  # ResultStore — so a fan-out caller that collects results after exit still
+  # works, without retaining forever.
   defp finalize(state, status) do
     state = if state.partial != "", do: push_line(%{state | partial: ""}, state.partial), else: state
     Logger.info("agent #{state.agent_id} exited status=#{inspect(status)}")
     release_status = maybe_release_lease(state, @release_reason)
     state = %{state | exit_status: status, port: nil, release_status: release_status}
     state = reply_waiters(state)
+    ResultStore.put(state.agent_id, result(state))
 
     if status == 0 do
       {:stop, :normal, state}

--- a/elixir/agent_orchestrator/lib/agent_orchestrator/application.ex
+++ b/elixir/agent_orchestrator/lib/agent_orchestrator/application.ex
@@ -12,8 +12,13 @@ defmodule AgentOrchestrator.Application do
 
       AgentOrchestrator.Supervisor            (one_for_one)
       ├── Registry  (AgentOrchestrator.Registry)   agent_id -> runner pid
+      ├── ResultStore  (GenServer + ETS)            retained final results
       └── AgentSupervisor  (DynamicSupervisor)
           └── AgentRunner  (GenServer + Port)       restart: :temporary
+
+  `ResultStore` starts before `AgentSupervisor` so its ETS table exists before
+  any runner can finalize and write its result — closing the await-vs-fast-exit
+  race (#581) where a finished agent's result was lost to `:not_found`.
 
   Lease-binding to the plane is the architectural-coherence payoff: an agent
   acquires a `remote_heartbeat` lease on its `agent:<id>` surface when it spawns
@@ -27,6 +32,7 @@ defmodule AgentOrchestrator.Application do
   def start(_type, _args) do
     children = [
       {Registry, keys: :unique, name: AgentOrchestrator.Registry},
+      AgentOrchestrator.ResultStore,
       AgentOrchestrator.AgentSupervisor
     ]
 

--- a/elixir/agent_orchestrator/lib/agent_orchestrator/result_store.ex
+++ b/elixir/agent_orchestrator/lib/agent_orchestrator/result_store.ex
@@ -1,0 +1,174 @@
+defmodule AgentOrchestrator.ResultStore do
+  @moduledoc """
+  Short-lived retention of an ephemeral agent's FINAL result, keyed by agent_id,
+  so a late `await`/`snapshot` survives the agent's process death instead of
+  racing to `{:error, :not_found}`.
+
+  ## Why this exists
+
+  `AgentRunner` stops itself the instant its Port reports exit (it is
+  `restart: :temporary`). A fast agent — `echo`, a sub-second tool worker — can
+  therefore be gone before the orchestrator's `await` even reaches its mailbox:
+  `whereis/0` returns `nil`, or the `GenServer.call` exits `:noproc` mid-flight.
+  Pre-existing since #581, the final result was simply lost on that race; the
+  documented workaround was "await before it exits or snapshot during the run,"
+  which a fan-out orchestrator collecting results sequentially cannot always do.
+
+  This store closes the race. `AgentRunner.finalize/2` writes the terminal
+  `result/1` here BEFORE returning `{:stop, ...}`, so the write strictly
+  happens-before the process dies (the GenServer only terminates after the
+  callback returns). Any `await`/`snapshot` that observes the runner as dead is
+  guaranteed to find the retained result already present.
+
+  ## Ownership and concurrency
+
+  The ETS table is `:public` and `:named_table`, owned by this GenServer purely
+  for *lifetime* (the table dies with the orchestrator app, not with any one
+  runner). Runners write directly with `:ets.insert/2` and readers with
+  `:ets.lookup/2` — no message passing on the hot path, so the happens-before
+  guarantee holds without a synchronous round-trip through this process.
+
+  ## Eviction
+
+  Retention is bounded so a high-churn fleet cannot grow the table without limit:
+
+    * TTL — entries older than `:result_retention_ms` (default 300_000) are
+      dropped. Expiry is enforced both lazily on `fetch/1` and by a periodic
+      sweep every `:result_sweep_interval_ms` (default 60_000).
+    * Soft cap — if a sweep finds more than `:result_store_max` (default 10_000)
+      live entries, the oldest are evicted down to the cap. This is a safety
+      backstop for a churn burst within one TTL window, not the primary path.
+  """
+
+  use GenServer
+
+  @table __MODULE__
+
+  @default_retention_ms 300_000
+  @default_sweep_interval_ms 60_000
+  @default_max_entries 10_000
+
+  # ---------- public API ----------
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Retain `result` for `agent_id`. Called from `AgentRunner.finalize/2` before the
+  runner stops. Overwrites any prior entry for the same id (random ids make
+  collisions negligible; a re-used id keeps the newest result).
+  """
+  @spec put(String.t(), map()) :: :ok
+  def put(agent_id, result) when is_binary(agent_id) and is_map(result) do
+    # Direct write from the caller process — synchronous and ordered with the
+    # finalize that issues it, so the retained result is visible the moment the
+    # runner dies. Guard against a not-yet-started / torn-down table (e.g. in a
+    # unit test that exercises a runner without the full app) rather than letting
+    # a missing table crash the exiting runner.
+    if table_ready?() do
+      :ets.insert(@table, {agent_id, result, now_ms()})
+    end
+
+    :ok
+  end
+
+  @doc """
+  Fetch a retained result, honoring the TTL. Returns `{:ok, result}` if a live
+  (non-expired) entry exists, else `:error`.
+  """
+  @spec fetch(String.t()) :: {:ok, map()} | :error
+  def fetch(agent_id) when is_binary(agent_id) do
+    if table_ready?() do
+      case :ets.lookup(@table, agent_id) do
+        [{^agent_id, result, stored_at}] ->
+          if expired?(stored_at) do
+            # Lazy expiry: drop the stale row so a later sweep need not.
+            :ets.delete(@table, agent_id)
+            :error
+          else
+            {:ok, result}
+          end
+
+        [] ->
+          :error
+      end
+    else
+      :error
+    end
+  end
+
+  # ---------- GenServer ----------
+
+  @impl true
+  def init(opts) do
+    retention_ms = opt(opts, :result_retention_ms, @default_retention_ms)
+    sweep_ms = opt(opts, :result_sweep_interval_ms, @default_sweep_interval_ms)
+    max_entries = opt(opts, :result_store_max, @default_max_entries)
+
+    # :public so runners write without routing through this process; this
+    # GenServer is the table's owner only so the table outlives any one runner.
+    :ets.new(@table, [:set, :public, :named_table, read_concurrency: true])
+
+    schedule_sweep(sweep_ms)
+
+    {:ok, %{retention_ms: retention_ms, sweep_ms: sweep_ms, max_entries: max_entries}}
+  end
+
+  @impl true
+  def handle_info(:sweep, state) do
+    sweep(state)
+    schedule_sweep(state.sweep_ms)
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # ---------- internals ----------
+
+  defp opt(opts, key, default) do
+    Keyword.get(opts, key, Application.get_env(:agent_orchestrator, key, default))
+  end
+
+  defp schedule_sweep(sweep_ms), do: Process.send_after(self(), :sweep, sweep_ms)
+
+  defp now_ms, do: System.monotonic_time(:millisecond)
+
+  defp expired?(stored_at), do: now_ms() - stored_at > retention_ms()
+
+  # Read retention from app env on each check so a config change (and the
+  # lazy-expiry path, which has no GenServer state in scope) stays consistent
+  # with the sweep's view.
+  defp retention_ms,
+    do: Application.get_env(:agent_orchestrator, :result_retention_ms, @default_retention_ms)
+
+  defp table_ready?, do: :ets.whereis(@table) != :undefined
+
+  # Drop expired rows, then enforce the soft cap by evicting the oldest survivors.
+  defp sweep(%{retention_ms: retention_ms, max_entries: max_entries}) do
+    cutoff = now_ms() - retention_ms
+
+    # match_delete every row whose stored_at is at/under the cutoff. `:"$1"` binds
+    # stored_at; the guard keeps the deletion to expired rows only.
+    expired_spec = [{{:_, :_, :"$1"}, [{:"=<", :"$1", cutoff}], [true]}]
+    :ets.select_delete(@table, expired_spec)
+
+    enforce_cap(max_entries)
+  end
+
+  defp enforce_cap(max_entries) do
+    case :ets.info(@table, :size) do
+      size when is_integer(size) and size > max_entries ->
+        # Over the cap within one TTL window: evict oldest-first down to the cap.
+        # Rare backstop path, so the full-scan sort is acceptable.
+        @table
+        |> :ets.tab2list()
+        |> Enum.sort_by(fn {_id, _result, stored_at} -> stored_at end)
+        |> Enum.take(size - max_entries)
+        |> Enum.each(fn {id, _result, _stored_at} -> :ets.delete(@table, id) end)
+
+      _ ->
+        :ok
+    end
+  end
+end

--- a/elixir/agent_orchestrator/test/agent_orchestrator_test.exs
+++ b/elixir/agent_orchestrator/test/agent_orchestrator_test.exs
@@ -141,6 +141,17 @@ defmodule AgentOrchestratorTest do
       assert eventually(fn -> id not in AgentOrchestrator.list() end)
     end
 
+    test "stop/2 does not crash when the agent died between lookup and the call" do
+      {:ok, id, pid} = AgentOrchestrator.run(%{cmd: "sleep", args: ["30"], lease: false})
+      # Brutal kill: terminate/2 does NOT run and the Registry :DOWN is still in
+      # flight, so stop/2's whereis/0 may still return this now-dead pid and reach
+      # GenServer.stop on a dead process. It must NOT exit/crash the caller —
+      # :ok (stop of an already-gone agent) or :not_found (whereis lost the race),
+      # never an uncaught :noproc exit. (Regression for the on_exit cleanup flake.)
+      Process.exit(pid, :kill)
+      assert AgentOrchestrator.stop(id) in [:ok, {:error, :not_found}]
+    end
+
     test "run_fleet spawns each spec" do
       results =
         AgentOrchestrator.run_fleet([

--- a/elixir/agent_orchestrator/test/agent_orchestrator_test.exs
+++ b/elixir/agent_orchestrator/test/agent_orchestrator_test.exs
@@ -87,6 +87,47 @@ defmodule AgentOrchestratorTest do
     end
   end
 
+  describe "await/snapshot after exit (retained result, #581 race)" do
+    test "await after a fast agent has already exited returns the retained result" do
+      {:ok, id, pid} = AgentOrchestrator.run(%{cmd: "echo", args: ["fast"]})
+
+      # Drive the race deterministically: wait until the runner is fully gone
+      # before awaiting, so whereis/0 is nil (or the call exits :noproc). Before
+      # the ResultStore this returned {:error, :not_found} and lost the result.
+      assert eventually(fn -> id not in AgentOrchestrator.list() end)
+      refute Process.alive?(pid)
+
+      assert {:ok, result} = AgentOrchestrator.await(id)
+      assert result.exit_status == 0
+      assert result.output == ["fast"]
+      assert result.running == false
+    end
+
+    test "snapshot after exit returns the retained result instead of :not_found" do
+      {:ok, id, _} = AgentOrchestrator.run(%{cmd: "echo", args: ["snap"]})
+
+      assert eventually(fn -> id not in AgentOrchestrator.list() end)
+
+      assert {:ok, %{exit_status: 0, output: ["snap"], running: false}} =
+               AgentOrchestrator.snapshot(id)
+    end
+
+    test "a non-zero fast exit is still retained for a late await" do
+      {:ok, id, _} = AgentOrchestrator.run(%{cmd: "sh", args: ["-c", "echo boom 1>&2; exit 3"]})
+
+      assert eventually(fn -> id not in AgentOrchestrator.list() end)
+
+      assert {:ok, result} = AgentOrchestrator.await(id)
+      assert result.exit_status == 3
+      assert "boom" in result.output
+    end
+
+    test "await/snapshot for an agent id that never ran returns :not_found" do
+      assert {:error, :not_found} = AgentOrchestrator.await("ag-never-existed")
+      assert {:error, :not_found} = AgentOrchestrator.snapshot("ag-never-existed")
+    end
+  end
+
   describe "fleet + registry" do
     test "list/count track live agents and stop tears one down" do
       {:ok, id, pid} = AgentOrchestrator.run(%{cmd: "sleep", args: ["30"]})

--- a/elixir/agent_orchestrator/test/result_store_test.exs
+++ b/elixir/agent_orchestrator/test/result_store_test.exs
@@ -1,0 +1,65 @@
+defmodule AgentOrchestrator.ResultStoreTest do
+  # async: false — exercises the singleton ResultStore + its shared ETS table,
+  # and mutates :result_retention_ms app env for the expiry case.
+  use ExUnit.Case, async: false
+
+  alias AgentOrchestrator.ResultStore
+
+  # The orchestrator app (and thus the ResultStore GenServer + its named table)
+  # is already started for the test run; these exercise the public API directly.
+
+  defp unique_id, do: "ag-test-" <> Integer.to_string(System.unique_integer([:positive]))
+
+  defp result_for(id) do
+    %{
+      agent_id: id,
+      os_pid: 1234,
+      lease_id: nil,
+      presence: :disabled,
+      exit_status: 0,
+      running: false,
+      lease_released: false,
+      output: ["done"]
+    }
+  end
+
+  test "fetch returns :error for an id that was never stored" do
+    assert :error = ResultStore.fetch(unique_id())
+  end
+
+  test "put then fetch returns the retained result" do
+    id = unique_id()
+    result = result_for(id)
+
+    assert :ok = ResultStore.put(id, result)
+    assert {:ok, ^result} = ResultStore.fetch(id)
+  end
+
+  test "put overwrites a prior entry for the same id (newest wins)" do
+    id = unique_id()
+    assert :ok = ResultStore.put(id, %{result_for(id) | exit_status: 1})
+    assert :ok = ResultStore.put(id, %{result_for(id) | exit_status: 0})
+
+    assert {:ok, %{exit_status: 0}} = ResultStore.fetch(id)
+  end
+
+  test "fetch lazily expires an entry past its TTL" do
+    prior = Application.get_env(:agent_orchestrator, :result_retention_ms)
+    on_exit(fn -> restore_env(:result_retention_ms, prior) end)
+
+    # Tighten the TTL so the entry ages out within the test window. Lazy expiry
+    # reads retention from app env on each fetch, so no GenServer restart needed.
+    Application.put_env(:agent_orchestrator, :result_retention_ms, 1)
+
+    id = unique_id()
+    assert :ok = ResultStore.put(id, result_for(id))
+    Process.sleep(10)
+
+    assert :error = ResultStore.fetch(id)
+    # And the stale row is dropped, not just hidden.
+    assert :error = ResultStore.fetch(id)
+  end
+
+  defp restore_env(_key, nil), do: Application.delete_env(:agent_orchestrator, :result_retention_ms)
+  defp restore_env(key, val), do: Application.put_env(:agent_orchestrator, key, val)
+end


### PR DESCRIPTION
**Stacked on #590** (base is its branch, not master — the diff here is just my one fix). You asked me to fix the residual flake my verify pass on #590 found.

## What #590 fixed vs. what was left
#590 correctly closes the **await/snapshot `:not_found`** race (result-retention store — clean work). But stress-testing #590's branch still showed **~7% flake (2/30)**, on a *different, pre-existing* race:

```
** (exit) exited in: GenServer.stop(#PID, {:shutdown, :test_cleanup}, :infinity)
```

`stop/2` does `whereis/0` then `GenServer.stop(pid, …)`. The agent is `restart: :temporary` and stops itself on exit; the Registry unregisters only on the async `:DOWN`. So `whereis` can hand back a pid that's already dead by the time `GenServer.stop` runs → it exits `:noproc` and crashes the caller (the `on_exit` cleanup sweeping a just-exited agent triggered it).

## Fix
Stopping an already-gone agent **is** success → catch the `:exit`, return `:ok`. Plus a non-flaky regression test that brutally kills the runner so the stale-pid path is actually exercised, asserting `:ok | {:error, :not_found}`, never an uncaught exit.

## Verification
- master: ~15% flake · #590 alone: 2/30 · **#590 + this: 0/35 seeds.** Both races closed.

Merge target: fold into #590's branch, then #590 → master. (Or merge #590 first and rebase this onto master — same result.)