### PR TITLE
fix(kg): harden topic-rollup synthesis (auto-link exclusion + staleness watermark)

### DIFF
--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -802,7 +802,15 @@ async def handle_store_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[Te
         # Find similar discoveries (fast with tag index) - DEFAULT: true for better linking
         similar_discoveries = []
         if arguments.get("auto_link_related", True):  # Default to true - new graph uses indexes (fast)
-            similar = await graph.find_similar(discovery, limit=5)
+            # Drop system-generated rollup rows from auto-linking. A topic_rollup
+            # is a summary OF discoveries, not a peer discovery; linking a fresh
+            # write to one would pollute related_to edges and let rollups accrete
+            # inbound peer edges, then feed back into other rollups' member sets
+            # (#44 synthesis follow-up). The storage find_similar layer has no
+            # rollup awareness, so filter here. Fetch a wider pool first so the
+            # exclusion does not shrink the suggestion set below the cap.
+            from .synthesis import is_rollup
+            similar = [s for s in await graph.find_similar(discovery, limit=8) if not is_rollup(s)][:5]
             discovery.related_to = [s.id for s in similar]
             similar_discoveries = [s.to_dict(include_details=False) for s in similar]
         

--- a/src/mcp_handlers/knowledge/synthesis.py
+++ b/src/mcp_handlers/knowledge/synthesis.py
@@ -31,6 +31,7 @@ migration. Re-running refreshes ``summary``/``details`` via the existing
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from src.knowledge_graph import DiscoveryNode, normalize_tags
@@ -168,6 +169,17 @@ def _make_rollup_node(
     """Assemble the rollup discovery row for a topic."""
     member_ids = [m["id"] for m in members[:MAX_MEMBERS_PER_ROLLUP] if m.get("id")]
     open_count = sum(1 for m in members if (m.get("status") or "open") == "open")
+
+    # Staleness watermark. A rollup's id is deterministic (rollup::<topic>), so
+    # re-runs upsert in place and there is otherwise NO record of how current the
+    # row is. `newest_member_id` is the lexicographically-max member id across
+    # ALL considered members (discovery ids are UTC-ISO timestamps, so max == the
+    # newest discovery rolled up); a reader or a periodic pass can compare it
+    # against the topic's current newest discovery to know whether the rollup is
+    # behind. `synthesized_at` is wall-clock recency for the same purpose.
+    member_id_pool = [m.get("id") for m in members if m.get("id")]
+    newest_member_id = max(member_id_pool) if member_id_pool else None
+    synthesized_at = datetime.now(timezone.utc).isoformat()
     headline = narrative.strip().split("\n", 1)[0][:200]
     summary = f"[rollup] {topic}: {len(members)} discoveries ({open_count} open) — {headline}"
 
@@ -198,6 +210,8 @@ def _make_rollup_node(
                 "open_count": open_count,
                 "summary_source": source,
                 "related_topics": related_topics,
+                "synthesized_at": synthesized_at,
+                "newest_member_id": newest_member_id,
             },
             "source": "kg_synthesis",
         },

--- a/tests/test_kg_store.py
+++ b/tests/test_kg_store.py
@@ -269,6 +269,45 @@ class TestStoreKnowledgeGraph:
         assert len(data["related_discoveries"]) == 1
 
     @pytest.mark.asyncio
+    async def test_store_auto_link_excludes_rollup_rows(self, patch_common, registered_agent):
+        """Auto-linking drops system-generated topic_rollup rows (#44 follow-up).
+
+        A rollup is a summary OF discoveries, not a peer; linking a fresh write to
+        one would pollute related_to edges and let rollups accrete inbound peer
+        edges. find_similar has no rollup awareness, so the store handler filters.
+        """
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_store_knowledge_graph
+
+        real = make_discovery(id="2026-06-04T00:00:00", summary="Real peer")
+        rollup = make_discovery(id="rollup::auth", type="topic_rollup", summary="[rollup] auth")
+        mock_graph.find_similar = AsyncMock(return_value=[real, rollup])
+
+        captured = {}
+        orig_add = mock_graph.add_discovery
+
+        async def _capture(node):
+            captured["related_to"] = list(node.related_to or [])
+            return await orig_add(node) if orig_add else None
+
+        mock_graph.add_discovery = AsyncMock(side_effect=_capture)
+
+        result = await handle_store_knowledge_graph({
+            "agent_id": registered_agent,
+            "summary": "Something related",
+            "auto_link_related": True,
+        })
+
+        data = parse_result(result)
+        assert data["success"] is True
+        # The rollup is excluded from both the stored edges and the surfaced set.
+        assert "rollup::auth" not in captured.get("related_to", [])
+        assert "2026-06-04T00:00:00" in captured.get("related_to", [])
+        related_ids = {d.get("id") for d in data.get("related_discoveries", [])}
+        assert "rollup::auth" not in related_ids
+        assert "2026-06-04T00:00:00" in related_ids
+
+    @pytest.mark.asyncio
     async def test_store_graph_exception(self, patch_common, registered_agent):
         """Exception from graph backend returns error response."""
         mock_mcp_server, mock_graph = patch_common

--- a/tests/test_kg_synthesis.py
+++ b/tests/test_kg_synthesis.py
@@ -94,6 +94,37 @@ def test_make_rollup_node_shape():
     assert node.provenance["source"] == "kg_synthesis"
 
 
+def test_make_rollup_node_carries_staleness_watermark():
+    # Member ids are UTC-ISO timestamps; the watermark must be the newest one
+    # across ALL members (not just the capped/shown slice), so a reader can tell
+    # whether the rollup is behind the topic's current newest discovery.
+    members = [
+        _disc("2026-01-01T00:00:00", "old", ["t"]).to_dict(include_details=False),
+        _disc("2026-06-04T12:00:00", "newest", ["t"]).to_dict(include_details=False),
+        _disc("2026-03-15T00:00:00", "mid", ["t"]).to_dict(include_details=False),
+    ]
+    node = syn._make_rollup_node("t", members, "n", "deterministic", [], writer_id="sys")
+    synth = node.provenance["synthesis"]
+    assert synth["newest_member_id"] == "2026-06-04T12:00:00"
+    # synthesized_at is a parseable UTC-aware ISO timestamp.
+    from datetime import datetime
+    parsed = datetime.fromisoformat(synth["synthesized_at"])
+    assert parsed.tzinfo is not None
+
+
+def test_make_rollup_node_watermark_spans_beyond_member_cap():
+    # The newest member can sit past MAX_MEMBERS_PER_ROLLUP in the input list;
+    # the watermark must still find it even though related_to is capped.
+    members = [
+        _disc(f"2026-01-{i + 1:02d}T00:00:00", f"s{i}", ["t"]).to_dict(include_details=False)
+        for i in range(syn.MAX_MEMBERS_PER_ROLLUP + 3)
+    ]
+    node = syn._make_rollup_node("t", members, "n", "deterministic", [], writer_id="sys")
+    newest = max(m["id"] for m in members)
+    assert node.provenance["synthesis"]["newest_member_id"] == newest
+    assert len(node.related_to) == syn.MAX_MEMBERS_PER_ROLLUP  # edges still capped
+
+
 def test_make_rollup_node_caps_related_to_at_max_members():
     many = [_disc(f"d{i}", f"s{i}", ["t"]).to_dict(include_details=False) for i in range(syn.MAX_MEMBERS_PER_ROLLUP + 5)]
     node = syn._make_rollup_node("t", many, "n", "deterministic", [], writer_id="sys")


### PR DESCRIPTION
## Context

Investigating gov-plugin issue [#44](https://github.com/cirwel/unitares-governance-plugin/issues/44) ("KG gaps from the LLM-wiki comparison"), I found its one actionable item — **Gap #1, periodic synthesis** — is **already implemented** in this repo: `src/mcp_handlers/knowledge/synthesis.py` + `knowledge(action='synthesize')`. It matches the proposal closely (on-demand not per-write, GraphRAG-style topic rollups, no schema change). So #44's runtime work largely landed; this PR hardens two gaps it left, both of which the issue itself anticipated as risks.

(Gap #2, bi-temporal edges, remains correctly YAGNI-deferred — confirmed nothing bi-temporal was built. The issue's "periodic" trigger is still not wired — synthesis is on-demand only — but that's a larger background-task change left out of this PR.)

## Changes

**1. Exclude rollups from auto-linking** (`handlers.py`)
`store_knowledge_graph` writes `find_similar` suggestions into `related_to` and surfaces them as `related_discoveries`. The storage `find_similar` layer has **zero rollup awareness** (`topic_rollup` appears in no read path), so a fresh write could be auto-linked to a system-generated `rollup::<topic>` row — treating a summary as a peer, polluting edges, and letting rollups accrete inbound peer edges that then feed back into other rollups' member sets. Now filtered with `is_rollup()` in the handler (fetching a wider pool first so the suggestion cap still holds). This is the concrete, non-judgment-call version of the "stale auto-generated rows" risk #44 flagged.

**2. Staleness watermark on rollups** (`synthesis.py`)
A rollup's id is deterministic (`rollup::<topic>`), so re-runs upsert in place leaving no record of how current the row is. `provenance.synthesis` now carries:
- `synthesized_at` — wall-clock UTC recency.
- `newest_member_id` — lexicographically-max member id across **all** considered members (discovery ids are UTC-ISO timestamps, so max == the newest rolled-up discovery), found even when it sits past the `MAX_MEMBERS_PER_ROLLUP` edge cap.

A reader (or a future periodic pass) can compare `newest_member_id` against the topic's current newest discovery to know whether the rollup is behind.

## Why low-risk

Both are additive: no schema change, no behavior change to `search`/`list`. The auto-link change only removes synthetic rows from a suggestion set.

## Tests

- `test_kg_store.py::test_store_auto_link_excludes_rollup_rows` — a rollup returned by `find_similar` is dropped from both the stored `related_to` edges and the surfaced `related_discoveries`, while a real peer is kept.
- `test_kg_synthesis.py` — watermark is the newest member id (and spans beyond the member cap); `synthesized_at` is a parseable UTC-aware timestamp.

Compile-checked locally; the container is network-restricted so pytest/deps couldn't be installed — CI's Python 3.12 job is the gate.

https://claude.ai/code/session_01BDxQm53VqocqYcHcyHUZ7B

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDxQm53VqocqYcHcyHUZ7B)_