### PR TITLE
feat(governance): cadence-silence — soft detection of active-then-silent agents

### DIFF
--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -1085,7 +1085,12 @@ async function loadStuckAgents() {
         if (!countEl || !detailEl || !cardEl) return;
 
         if (result && result.success) {
-            const stuck = result.stuck_agents || [];
+            // Soft signals (e.g. cadence_silence) are surfaced via the audit
+            // trail, NOT as alarming "Stuck" badges/counts — they deliberately
+            // include benign finished-and-idle agents the rule can't distinguish
+            // from a genuine hang, so folding them into the stuck count/health
+            // metric would mislead. Hard (actionable) stuck only here.
+            const stuck = (result.stuck_agents || []).filter(s => !s.soft);
             cachedStuckAgents = stuck;
             const count = stuck.length;
             animateValue(countEl, count);

--- a/src/mcp_handlers/lifecycle/stuck.py
+++ b/src/mcp_handlers/lifecycle/stuck.py
@@ -114,6 +114,31 @@ async def _trigger_dialectic_for_stuck_agent(
         "note": note,
     }
 
+# Cadence-silence (soft) detection tunables. An agent that was checking in at a
+# regular ACTIVE cadence and then went silent for far longer than that cadence is
+# possibly hung/abandoned mid-work. Gated on prior-active-cadence so it does NOT
+# fire on orphans or naturally-slow/idle agents — which is exactly why the old
+# blunt "no updates > 30 min" rule was removed. Soft signal: surfaced (audit
+# trail), never auto-recovered. Origin: dogfood 2026-06-04 (agent finished a
+# task, was told "proceed on your own accord", wandered off-task + hung ~3h, and
+# nothing flagged it).
+CADENCE_MIN_UPDATES = 5                  # had a real session (>= this many check-ins)
+CADENCE_ACTIVE_MAX_GAP_MINUTES = 30.0   # avg gap <= this => an active cadence, not a slow cron
+CADENCE_SILENCE_FLOOR_MINUTES = 30.0    # never flag before this much silence
+CADENCE_SILENCE_MULTIPLIER = 6.0        # silent for >= this many times its own cadence
+# Upper bound: only flag agents that went quiet RECENTLY. Beyond this, an idle
+# agent is abandoned / archive-pending, not a fresh hang worth a live signal —
+# this is what keeps the audit trail from filling with finished-but-unarchived
+# ephemeral agents (which cadence cannot distinguish from a genuine hang).
+CADENCE_SILENCE_STALE_CAP_MINUTES = 1440.0   # 24h
+# NOTE on the cadence proxy: avg_gap is computed over the agent's WHOLE life
+# (created_at -> last_update), which is a coarse proxy for "recent rhythm." A
+# recent-window cadence (last N gaps) would be more precise but needs the
+# per-check-in timestamp series, which this path doesn't have. Coarse-but-safe:
+# it errs toward flagging, and the signal is soft. Also note the MULTIPLIER is
+# floor-dominated for fast agents (avg_gap < 5min => 6*gap < 30 => floor wins).
+
+
 def _detect_stuck_agents(
     max_age_minutes: float = 30.0,  # Unused, kept for API compatibility
     critical_margin_timeout_minutes: float = 5.0,
@@ -132,9 +157,16 @@ def _detect_stuck_agents(
     2. Tight margin + no updates > 15 min → potentially stuck (struggling)
     3. Cognitive loop pattern → stuck (repeating unproductive behavior)
     4. Time box exceeded → stuck (taking too long on a task)
+    5. Cadence-silence (SOFT) → reason "cadence_silence". An agent that HAD an
+       active check-in cadence and then went silent for >> that cadence. The one
+       inactivity-based signal — deliberately gated on prior-active-cadence
+       (>= CADENCE_MIN_UPDATES at avg gap <= CADENCE_ACTIVE_MAX_GAP_MINUTES) so it
+       does NOT regress to flagging idle agents. soft=True → surfaced via the
+       audit trail, never auto-recovered.
 
     NOT stuck:
-    - Simply being idle/inactive (that's normal, not stuck)
+    - Idle/inactive with NO prior active cadence (orphans, slow cron agents) —
+      raw inactivity alone is still not stuck.
     - Low update count (that's orphan/test agent, not stuck)
 
     Args:
@@ -186,6 +218,55 @@ def _detect_stuck_agents(
         except (ValueError, TypeError, AttributeError) as e:
             logger.debug(f"Could not parse last_update for {agent_id}: {e}")
             continue
+
+        # Detection rule 5 (SOFT): cadence-silence. An agent that HAD an active
+        # check-in cadence and then went silent for >> that cadence. Independent
+        # of margin/monitor (a silent agent's last margin reads healthy, which is
+        # exactly the blind spot). Gated on prior-active-cadence so orphans and
+        # slow/idle agents don't trip it. Surfaced via the audit trail; soft=True
+        # routes it past auto-recovery (the agent is gone, not in a recoverable
+        # in-process state, and it may simply have finished and idled).
+        try:
+            created_dt = last_update_dt
+            cstr = meta.created_at
+            if isinstance(cstr, str):
+                created_dt = datetime.fromisoformat(
+                    cstr.replace('Z', '+00:00') if 'Z' in cstr else cstr
+                )
+                if created_dt.tzinfo is None:
+                    created_dt = created_dt.replace(tzinfo=timezone.utc)
+            elif cstr is not None:
+                created_dt = cstr
+
+            span_minutes = (last_update_dt - created_dt).total_seconds() / 60
+            if total_updates >= CADENCE_MIN_UPDATES and span_minutes > 0:
+                avg_gap_minutes = span_minutes / (total_updates - 1)
+                if 0 < avg_gap_minutes <= CADENCE_ACTIVE_MAX_GAP_MINUTES:
+                    silence_threshold = max(
+                        CADENCE_SILENCE_FLOOR_MINUTES,
+                        CADENCE_SILENCE_MULTIPLIER * avg_gap_minutes,
+                    )
+                    # Window: recently went quiet, but not so long ago it's just
+                    # abandoned/archive-pending (which would be noise).
+                    if silence_threshold < age_minutes <= CADENCE_SILENCE_STALE_CAP_MINUTES:
+                        stuck_agents.append({
+                            "agent_id": agent_id,
+                            "reason": "cadence_silence",
+                            "age_minutes": round(age_minutes, 1),
+                            "soft": True,
+                            "details": (
+                                f"Active cadence ~{avg_gap_minutes:.1f} min over {total_updates} "
+                                f"updates, then silent {age_minutes:.0f} min "
+                                f"(> {silence_threshold:.0f} min threshold). Possibly hung/abandoned "
+                                f"mid-work — verify. Soft signal; not auto-recovered."
+                            ),
+                        })
+                        # A confirmed-silent agent: surface the soft signal and move
+                        # on — don't also margin-evaluate its STALE state below (which
+                        # would double-list it and is meaningless for a gone agent).
+                        continue
+        except (ValueError, TypeError, AttributeError) as e:
+            logger.debug(f"cadence-silence check failed for {agent_id}: {e}")
 
         # Get current metrics to compute margin
         try:
@@ -499,6 +580,12 @@ async def handle_detect_stuck_agents(arguments: Dict[str, Any]) -> Sequence:
         recovered = []
         if auto_recover and stuck_agents:
             for stuck in stuck_agents:
+                # Soft signals (e.g. cadence_silence) are surfaced via the audit
+                # trail only — never auto-recovered. The agent is silent/gone, not
+                # in a recoverable in-process state, and it may simply have
+                # finished and idled; recovering it would be a phantom action.
+                if stuck.get("soft"):
+                    continue
                 result = await _try_recover_agent(stuck, note_cooldown_minutes)
                 if result:
                     recovered.extend(result if isinstance(result, list) else [result])
@@ -528,7 +615,7 @@ async def handle_detect_stuck_agents(arguments: Dict[str, Any]) -> Sequence:
                 "total_recovered": len(recovered) if auto_recover else 0,
                 "by_reason": {
                     reason: sum(1 for s in stuck_agents if s["reason"] == reason)
-                    for reason in ["critical_margin_timeout", "tight_margin_timeout", "cognitive_loop", "time_box_exceeded"]
+                    for reason in ["critical_margin_timeout", "tight_margin_timeout", "cognitive_loop", "time_box_exceeded", "cadence_silence"]
                 }
             }
         })

--- a/tests/test_lifecycle_detect_stuck.py
+++ b/tests/test_lifecycle_detect_stuck.py
@@ -596,3 +596,102 @@ class TestBaselineRelativeMargin:
         assert result["margin"] == "warning"
         assert result["nearest_edge"] == "coherence"
         assert result["distance_to_edge"] < 0
+
+
+class TestDetectStuckAgentsCadenceSilence:
+    """Rule 5 (soft): an agent that HAD an active cadence then went silent."""
+
+    def _silent_meta(self, now, *, created_min_ago, last_update_min_ago, total_updates):
+        return _make_agent_meta(
+            created_at=now - timedelta(minutes=created_min_ago),
+            last_update=now - timedelta(minutes=last_update_min_ago),
+            total_updates=total_updates,
+        )
+
+    @patch(_PATCHES["mcp_server"])
+    def test_active_cadence_then_silent_flags_soft(self, mock_server):
+        # 13 updates over ~10 min (avg gap ~0.8 min => active), then silent 50 min.
+        now = datetime.now(timezone.utc)
+        mock_server.agent_metadata = {
+            "a1": self._silent_meta(now, created_min_ago=60, last_update_min_ago=50, total_updates=13),
+        }
+        mock_server.monitors = {}
+        mock_server.load_monitor_state.return_value = None
+        from src.mcp_handlers.lifecycle.stuck import _detect_stuck_agents
+        result = _detect_stuck_agents()
+        cadence = [r for r in result if r["reason"] == "cadence_silence"]
+        assert len(cadence) == 1
+        assert cadence[0]["soft"] is True
+        assert cadence[0]["agent_id"] == "a1"
+
+    @patch(_PATCHES["mcp_server"])
+    def test_orphan_below_min_updates_not_flagged(self, mock_server):
+        # Only 3 updates => below CADENCE_MIN_UPDATES (5) => no active cadence.
+        now = datetime.now(timezone.utc)
+        mock_server.agent_metadata = {
+            "a1": self._silent_meta(now, created_min_ago=60, last_update_min_ago=50, total_updates=3),
+        }
+        mock_server.monitors = {}
+        mock_server.load_monitor_state.return_value = None
+        from src.mcp_handlers.lifecycle.stuck import _detect_stuck_agents
+        result = _detect_stuck_agents()
+        assert [r for r in result if r["reason"] == "cadence_silence"] == []
+
+    @patch(_PATCHES["mcp_server"])
+    def test_slow_cron_cadence_not_flagged(self, mock_server):
+        # 6 updates over ~24h => avg gap ~270 min >> 30 => not an active cadence.
+        now = datetime.now(timezone.utc)
+        mock_server.agent_metadata = {
+            "a1": self._silent_meta(now, created_min_ago=24 * 60, last_update_min_ago=90, total_updates=6),
+        }
+        mock_server.monitors = {}
+        mock_server.load_monitor_state.return_value = None
+        from src.mcp_handlers.lifecycle.stuck import _detect_stuck_agents
+        result = _detect_stuck_agents()
+        assert [r for r in result if r["reason"] == "cadence_silence"] == []
+
+    @patch(_PATCHES["mcp_server"])
+    def test_active_cadence_recent_silence_not_flagged(self, mock_server):
+        # Active cadence but only silent 10 min (< 30 min floor) => not yet flagged.
+        now = datetime.now(timezone.utc)
+        mock_server.agent_metadata = {
+            "a1": self._silent_meta(now, created_min_ago=60, last_update_min_ago=10, total_updates=13),
+        }
+        mock_server.monitors = {}
+        mock_server.load_monitor_state.return_value = None
+        from src.mcp_handlers.lifecycle.stuck import _detect_stuck_agents
+        result = _detect_stuck_agents()
+        assert [r for r in result if r["reason"] == "cadence_silence"] == []
+
+    @patch(_PATCHES["mcp_server"])
+    def test_stale_silence_beyond_cap_not_flagged(self, mock_server):
+        # Active cadence but silent ~25h (> 24h stale cap) => abandoned, not a
+        # fresh hang => suppressed (the false-positive-noise guard).
+        now = datetime.now(timezone.utc)
+        mock_server.agent_metadata = {
+            "a1": self._silent_meta(now, created_min_ago=26 * 60, last_update_min_ago=25 * 60, total_updates=13),
+        }
+        mock_server.monitors = {}
+        mock_server.load_monitor_state.return_value = None
+        from src.mcp_handlers.lifecycle.stuck import _detect_stuck_agents
+        result = _detect_stuck_agents()
+        assert [r for r in result if r["reason"] == "cadence_silence"] == []
+
+    @patch(_PATCHES["gov_config"])
+    @patch(_PATCHES["mcp_server"])
+    def test_silent_agent_not_double_listed_with_margin(self, mock_server, mock_config):
+        # Fires cadence_silence AND has a (stale) critical-margin monitor: must
+        # appear ONCE (cadence_silence), not also as a margin entry — the
+        # `continue` after the cadence append is what guarantees this.
+        now = datetime.now(timezone.utc)
+        mock_server.agent_metadata = {
+            "a1": self._silent_meta(now, created_min_ago=60, last_update_min_ago=50, total_updates=13),
+        }
+        mock_server.monitors = {"a1": _make_monitor(risk=0.8, coherence=0.42)}
+        mock_config.compute_proprioceptive_margin.return_value = _margin_info(
+            "critical", nearest_edge="risk", distance=0.02
+        )
+        from src.mcp_handlers.lifecycle.stuck import _detect_stuck_agents
+        result = [r for r in _detect_stuck_agents(critical_margin_timeout_minutes=5) if r["agent_id"] == "a1"]
+        assert len(result) == 1
+        assert result[0]["reason"] == "cadence_silence"


### PR DESCRIPTION
Closes the dogfood blind spot: a healthy agent told *"proceed on your own accord"* wandered off-task and **hung ~3h, and nothing flagged it** — because every stuck rule requires a problematic margin or an active loop, and a *healthy-then-silent* agent fires none. (The pure-inactivity rule had been removed for false-positiving on idle agents; #593 fixed the doc, this restores the *capability* — done right.)

## The rule (rule 5, `cadence_silence`)
An agent that **had an active check-in cadence** (≥5 updates at avg gap ≤30 min) and then went **silent for ≫ that cadence** (>6× its gap, floor 30 min) **and recently** (≤24 h). The *prior-active-cadence* gate is what the old blunt rule lacked — it does **not** fire on orphans or slow/idle agents. **`soft=True`: surfaced via the audit trail, never auto-recovered.**

## Council-hardened (architect SHIP / reviewer / live-verifier, all ran)
- **reviewer (critical bug):** the cadence block didn't `continue`, so an agent that *also* tripped a margin rule got double-listed → added `continue` + a regression test.
- **live-verifier:** **VERIFIED it fires on the real dogfood agent** (avg_gap 5.3 m, silence 35.8 h, threshold 31.9 m). Also found that *without a cap* it flags ~30% of eligible agents — finished-but-unarchived ephemerals it can't distinguish from a hang → added a **24 h stale cap** so it's a *fresh*-quiescence signal (catches a hang in its actionable first hours, suppresses days-old abandoned clutter).
- **architect merge-gate (consumer audit):** the **dashboard** rendered `stuck_agents` as a color-coded "Stuck" count + badge *without checking `soft`* → `dashboard.js` now filters soft out of the alarming stuck UI. Sweeper is log-only; Sentinel doesn't consume it.
- comments mark avg-gap-over-life as the known-coarse proxy and the floor-dominated multiplier.

## Honest limit (why soft, not a verdict)
The signal **cannot** distinguish "finished cleanly" from "hung" — there's no terminal-state on clean exit, so the two have an identical signature. Hence soft / audit-only / never-recover. The high-fidelity version — a **declared-continuation deadline** the agent sets — is the deferred durable follow-up; cadence-silence is the backstop for the agent that *never declares one* (exactly the dogfood case).

## Tests
99 lifecycle tests pass — 6 new cadence cases (active→silent flags soft; orphan / slow-cron / recent-silence / stale-cap all correctly *not* flagged; no double-list with margin) + zero regressions.

Stacks on the dogfood thread: doc-drift fix #593; KG insight `2026-06-05T16:22:19` (will resolve when this lands).