### PR TITLE
fix(watcher): checkout-independent state dir + proof-rebind on check-in

### DIFF
--- a/agents/watcher/_util.py
+++ b/agents/watcher/_util.py
@@ -19,6 +19,90 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
 LOG_FILE = Path.home() / "Library" / "Logs" / "unitares-watcher.log"
 
+# Legacy state location — relative to whichever checkout this module loads from.
+# Kept only as a migration source; nothing should write here anymore.
+_LEGACY_STATE_DIR = PROJECT_ROOT / "data" / "watcher"
+
+# Files that make up Watcher's local state, migrated together.
+_STATE_FILES = ("findings.jsonl", "dedup.json", "pattern_floor.json")
+
+_state_dir_cache: Path | None = None
+_legacy_migration_done = False
+
+
+def watcher_state_dir() -> Path:
+    """Checkout-independent home for Watcher's local state.
+
+    The Watcher agent (writer) is pinned to the dev checkout by the PostToolUse
+    hook, while http_api (reader) runs from whichever checkout serves the live
+    MCP — after the deploy-worktree cutover those are different trees. Because
+    ``data/watcher`` is gitignored local state, the deploy tree had no such dir
+    and the dashboard panel silently read zeroes. Anchoring state under
+    ``~/.unitares`` (same place as the identity anchor) makes writer and reader
+    agree regardless of which checkout each runs from.
+
+    Override with ``UNITARES_WATCHER_DATA_DIR``. Pure path resolution with no
+    filesystem side effects — call :func:`migrate_legacy_watcher_state` once at
+    process start to carry forward any pre-existing legacy state.
+    """
+    global _state_dir_cache
+    if _state_dir_cache is not None:
+        return _state_dir_cache
+
+    override = os.environ.get("UNITARES_WATCHER_DATA_DIR")
+    _state_dir_cache = (
+        Path(override).expanduser()
+        if override
+        else Path.home() / ".unitares" / "watcher"
+    )
+    return _state_dir_cache
+
+
+def migrate_legacy_watcher_state() -> None:
+    """Copy legacy checkout-relative state into the shared dir if absent there.
+
+    Idempotent and best-effort: runs its filesystem work once per process, and
+    a file is only copied when it exists in the legacy dir and not yet in the
+    target. The legacy copy is left untouched so an older-code Watcher still
+    running mid-rollout is never disrupted. Kept out of :func:`watcher_state_dir`
+    so importing the path constants never touches the filesystem.
+
+    Mid-rollout note: because this copies a one-time snapshot and never re-copies,
+    a still-running old-code Watcher that keeps appending to the legacy dir will
+    not have those appends reflected in the shared dir until it restarts onto the
+    new code. The reader (``http_api._watcher_findings_path``) compensates by
+    falling back to the legacy file while the shared one is empty, so the panel
+    shows live data rather than a frozen snapshot during the window.
+    """
+    global _legacy_migration_done
+    if _legacy_migration_done:
+        return
+    _legacy_migration_done = True
+
+    target = watcher_state_dir()
+    legacy = _LEGACY_STATE_DIR
+    try:
+        if legacy.resolve() == target.resolve() or not legacy.is_dir():
+            return
+    except OSError:
+        return
+    try:
+        target.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return
+
+    import shutil
+
+    for name in _STATE_FILES:
+        src = legacy / name
+        dst = target / name
+        if src.is_file() and not dst.exists():
+            try:
+                shutil.copy2(src, dst)
+                log(f"migrated watcher state {name} from {legacy} to {target}")
+            except OSError as e:
+                log(f"watcher state migration failed for {name}: {e}", "warning")
+
 # Cap for ~/Library/Logs/unitares-watcher.log rotation. Watcher logs a few
 # lines per scan; 5000 lines ≈ 500 scans of operational history, which is
 # plenty for debugging. Without this, the log file was a direct P002 match

--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -77,6 +77,7 @@ from agents.watcher._util import (
     PROJECT_ROOT,
     hash_line_content,
     log,
+    migrate_legacy_watcher_state,
     repo_relative_path,
 )
 from agents.common.log import trim_log as _common_trim_log
@@ -562,11 +563,32 @@ def _do_checkin() -> None:
         client.continuity_token = identity["continuity_token"]
         client.agent_uuid = identity["agent_uuid"]
 
+        # Pass the continuity token as an explicit arg so process_agent_update
+        # resolves identity by cryptographic ownership proof (REST PATH 2.8
+        # rebind) instead of relying solely on the client_session_id cache.
+        # Observed mechanism (2026-06-05, verified against the live MCP/Redis):
+        # the Watcher's csid->uuid binding lives in Redis with a ~24h TTL and no
+        # durable row stands in for it (the agent_sessions table held it for no
+        # Watcher row). A csid-only check-in carries no proof, so once that cache
+        # entry lapses the resolver has nothing to rebind from and dispatch
+        # returns "Identity not resolved" — failures began exactly 24h after the
+        # last good check-in and stayed dark for ~11h. The token-bearing call
+        # rebinds via proof and re-warms the cache (TTL reset confirmed live), so
+        # check-ins self-heal across the TTL boundary. resolve_identity() runs
+        # before this in main() and refreshes the token; the empty-token guard
+        # below degrades gracefully to the old csid-only behavior if it is stale.
+        # The SDK still injects client_session_id alongside the token.
+        checkin_kwargs = {}
+        token = identity.get("continuity_token")
+        if token:
+            checkin_kwargs["continuity_token"] = token
+
         client.checkin(
             response_text=summary,
             complexity=complexity,
             confidence=confidence,
             response_mode="compact",
+            **checkin_kwargs,
         )
         log(f"check-in: {summary}")
     except Exception as e:
@@ -584,7 +606,8 @@ SKIP_PATH_FRAGMENTS = (
     "/build/",
     "/.pytest_cache/",
     "/data/logs/",
-    "/data/watcher/",  # never scan our own findings
+    "/data/watcher/",  # never scan our own findings (legacy checkout-relative state)
+    "/.unitares/watcher/",  # never scan our own findings (shared home-anchored state)
 )
 
 SKIP_EXTENSIONS = (
@@ -2125,6 +2148,10 @@ def list_findings(only_open: bool = False) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
+    # Carry forward any legacy checkout-relative state to the shared dir once
+    # per process, before anything reads/writes findings.
+    migrate_legacy_watcher_state()
+
     parser = argparse.ArgumentParser(description="UNITARES Watcher bug-pattern agent")
     parser.add_argument("--file", help="file to scan")
     parser.add_argument("--region", help="line range within file, e.g. L10-L40")

--- a/agents/watcher/findings.py
+++ b/agents/watcher/findings.py
@@ -19,10 +19,10 @@ from typing import Any
 
 from agents.common.findings import post_finding
 from agents.watcher._util import (
-    PROJECT_ROOT,
     hash_line_content,
     log,
     repo_relative_path,
+    watcher_state_dir,
 )
 from agents.watcher.calibration import (
     classify_file,
@@ -35,7 +35,7 @@ from agents.watcher.floor_state import FloorState, load_floor
 # Paths & Config
 # ---------------------------------------------------------------------------
 
-STATE_DIR = PROJECT_ROOT / "data" / "watcher"
+STATE_DIR = watcher_state_dir()
 FINDINGS_FILE = STATE_DIR / "findings.jsonl"
 DEDUP_FILE = STATE_DIR / "dedup.json"
 

--- a/agents/watcher/floor_state.py
+++ b/agents/watcher/floor_state.py
@@ -35,12 +35,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Mapping
 
-from agents.watcher._util import PROJECT_ROOT
+from agents.watcher._util import watcher_state_dir
 from agents.watcher.calibration import BucketStats
 
 
 FLOOR_FILE_NAME = "pattern_floor.json"
-DEFAULT_STATE_DIR = PROJECT_ROOT / "data" / "watcher"
+DEFAULT_STATE_DIR = watcher_state_dir()
 _KEY_SEP = "|"
 
 

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -1307,9 +1307,42 @@ async def http_get_progress_flat_recent(request):
     return JSONResponse({"success": True, "rows": out})
 
 
-_WATCHER_FINDINGS_PATH = (
-    Path(__file__).resolve().parent.parent / "data" / "watcher" / "findings.jsonl"
-)
+def _watcher_findings_path() -> Path:
+    """Resolve Watcher's findings.jsonl via the shared, checkout-independent
+    state dir.
+
+    Must match where the Watcher agent writes. A checkout-relative path here
+    (``__file__``-derived) silently zeroed the dashboard once the MCP began
+    serving from the deploy worktree while the agent kept writing to the dev
+    checkout — see ``agents.watcher._util.watcher_state_dir``. Resolved lazily
+    (not at import) so ``agents`` need not be importable at module load.
+
+    Mid-rollout safety: if the shared findings file is still empty/absent but a
+    legacy checkout-relative file has data, read the legacy file. This collapses
+    the cutover window where the new reader is live but an old-code Watcher is
+    still appending to the legacy dir (which would otherwise leave the panel
+    frozen on the migration snapshot). The fallback can be dropped once the
+    writer is confirmed on the shared dir.
+    """
+    from agents.watcher._util import (
+        _LEGACY_STATE_DIR,
+        migrate_legacy_watcher_state,
+        watcher_state_dir,
+    )
+
+    migrate_legacy_watcher_state()  # one-time, idempotent
+    shared = watcher_state_dir() / "findings.jsonl"
+    try:
+        if shared.exists() and shared.stat().st_size > 0:
+            return shared
+        legacy = _LEGACY_STATE_DIR / "findings.jsonl"
+        if legacy.exists() and legacy.stat().st_size > 0:
+            return legacy
+    except OSError:
+        pass
+    return shared
+
+
 _WATCHER_DAILY_WINDOW_DAYS = 30
 
 
@@ -1491,7 +1524,7 @@ async def http_watcher_summary(request):
         return _http_unauthorized()
 
     rows = []
-    path = _WATCHER_FINDINGS_PATH
+    path = _watcher_findings_path()
     try:
         if path.exists():
             with path.open("r", encoding="utf-8") as f:

--- a/tests/test_http_api_watcher_summary.py
+++ b/tests/test_http_api_watcher_summary.py
@@ -9,7 +9,57 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from src.http_api import _watcher_summary_from_rows
+from src.http_api import _watcher_findings_path, _watcher_summary_from_rows
+
+
+class TestFindingsPathMatchesWriter:
+    """The reader (http_api) and the writer (Watcher agent) must resolve the
+    same findings.jsonl. They previously diverged across the dev/deploy
+    checkout split and the dashboard read zeroes."""
+
+    def test_reader_path_is_under_shared_state_dir(self, monkeypatch, tmp_path):
+        import agents.watcher._util as util
+
+        monkeypatch.setattr(util, "_state_dir_cache", None)
+        monkeypatch.setattr(util, "_legacy_migration_done", True)  # skip fs work
+        monkeypatch.setenv("UNITARES_WATCHER_DATA_DIR", str(tmp_path / "shared"))
+
+        # Reader resolves through the same shared resolver the writer uses.
+        assert _watcher_findings_path() == util.watcher_state_dir() / "findings.jsonl"
+        assert _watcher_findings_path() == tmp_path / "shared" / "findings.jsonl"
+
+    def test_falls_back_to_legacy_while_shared_empty(self, monkeypatch, tmp_path):
+        import agents.watcher._util as util
+
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        (legacy / "findings.jsonl").write_text('{"pattern":"P001"}\n')
+        shared = tmp_path / "shared"
+
+        monkeypatch.setattr(util, "_state_dir_cache", None)
+        monkeypatch.setattr(util, "_legacy_migration_done", True)  # skip migration copy
+        monkeypatch.setattr(util, "_LEGACY_STATE_DIR", legacy)
+        monkeypatch.setenv("UNITARES_WATCHER_DATA_DIR", str(shared))
+
+        # Shared dir has no data yet → read the live legacy file, not a frozen blank.
+        assert _watcher_findings_path() == legacy / "findings.jsonl"
+
+    def test_prefers_shared_once_populated(self, monkeypatch, tmp_path):
+        import agents.watcher._util as util
+
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        (legacy / "findings.jsonl").write_text("legacy\n")
+        shared = tmp_path / "shared"
+        shared.mkdir()
+        (shared / "findings.jsonl").write_text("shared\n")
+
+        monkeypatch.setattr(util, "_state_dir_cache", None)
+        monkeypatch.setattr(util, "_legacy_migration_done", True)
+        monkeypatch.setattr(util, "_LEGACY_STATE_DIR", legacy)
+        monkeypatch.setenv("UNITARES_WATCHER_DATA_DIR", str(shared))
+
+        assert _watcher_findings_path() == shared / "findings.jsonl"
 
 
 NOW = datetime(2026, 4, 23, 12, 0, tzinfo=timezone.utc)

--- a/tests/test_watcher_checkin_proof_rebind.py
+++ b/tests/test_watcher_checkin_proof_rebind.py
@@ -1,0 +1,76 @@
+"""Watcher check-in must carry the continuity token for proof-based rebind.
+
+Regression coverage for the "Identity not resolved" outage: the Watcher's
+session->uuid binding lives only in Redis with a ~24h TTL and is never
+DB-persisted (REST resolution uses persist=False). A check-in that sends only
+client_session_id has nothing to rebind from once that cache entry lapses, so
+process_agent_update returns "Identity not resolved" (observed 2026-06-05:
+failures began exactly 24h after the last good check-in). Passing the
+continuity token routes process_agent_update through the REST PATH 2.8
+cryptographic-ownership rebind, which re-warms the cache and self-heals.
+"""
+
+from __future__ import annotations
+
+import agents.watcher.agent as agent
+
+
+class _FakeClient:
+    def __init__(self):
+        self.client_session_id = None
+        self.continuity_token = None
+        self.agent_uuid = None
+        self.checkin_kwargs = None
+
+    def checkin(self, **kwargs):
+        self.checkin_kwargs = kwargs
+        return {"verdict": "proceed"}
+
+
+def _wire(monkeypatch, identity):
+    fake = _FakeClient()
+    monkeypatch.setattr(agent, "_make_identity_client", lambda: fake)
+    monkeypatch.setattr(agent, "get_watcher_identity", lambda: identity)
+    monkeypatch.setattr(agent, "_build_checkin_summary", lambda: ("summary", 0.2, 0.7))
+    return fake
+
+
+def test_checkin_forwards_continuity_token(monkeypatch):
+    identity = {
+        "client_session_id": "agent-907e3195-c64",
+        "continuity_token": "v1.sometoken",
+        "agent_uuid": "907e3195-c649-49db-b753-1edc1a105f33",
+    }
+    fake = _wire(monkeypatch, identity)
+
+    agent._do_checkin()
+
+    assert fake.checkin_kwargs is not None
+    assert fake.checkin_kwargs.get("continuity_token") == "v1.sometoken"
+    # session fields are still restored onto the client for SDK injection
+    assert fake.client_session_id == "agent-907e3195-c64"
+    assert fake.agent_uuid == "907e3195-c649-49db-b753-1edc1a105f33"
+
+
+def test_checkin_omits_token_when_absent(monkeypatch):
+    identity = {
+        "client_session_id": "agent-907e3195-c64",
+        "continuity_token": "",
+        "agent_uuid": "907e3195-c649-49db-b753-1edc1a105f33",
+    }
+    fake = _wire(monkeypatch, identity)
+
+    agent._do_checkin()
+
+    # An empty token must not be forwarded — sending "" would be a no-op at best
+    # and a malformed-proof signal at worst.
+    assert fake.checkin_kwargs is not None
+    assert "continuity_token" not in fake.checkin_kwargs
+
+
+def test_checkin_skipped_without_identity(monkeypatch):
+    fake = _wire(monkeypatch, None)
+
+    agent._do_checkin()
+
+    assert fake.checkin_kwargs is None

--- a/tests/test_watcher_state_dir.py
+++ b/tests/test_watcher_state_dir.py
@@ -1,0 +1,119 @@
+"""Tests for the checkout-independent Watcher state dir + legacy migration.
+
+Regression coverage for the dashboard-zeroes bug: the Watcher agent (writer)
+ran from the dev checkout while http_api (reader) ran from the deploy worktree,
+so each resolved a different ``data/watcher`` and the panel read zeroes. The
+fix anchors state under ``~/.unitares`` (or ``UNITARES_WATCHER_DATA_DIR``) so
+writer and reader always agree.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import agents.watcher._util as util
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    """Each test starts with the module path cache and migration flag clear."""
+    monkeypatch.setattr(util, "_state_dir_cache", None)
+    monkeypatch.setattr(util, "_legacy_migration_done", False)
+    monkeypatch.delenv("UNITARES_WATCHER_DATA_DIR", raising=False)
+    yield
+
+
+class TestResolution:
+    def test_default_is_home_anchored(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        assert util.watcher_state_dir() == tmp_path / ".unitares" / "watcher"
+
+    def test_env_override_wins(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("UNITARES_WATCHER_DATA_DIR", str(tmp_path / "custom"))
+        assert util.watcher_state_dir() == tmp_path / "custom"
+
+    def test_env_override_expands_user(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("UNITARES_WATCHER_DATA_DIR", "~/elsewhere")
+        assert util.watcher_state_dir() == tmp_path / "elsewhere"
+
+    def test_result_is_cached(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("UNITARES_WATCHER_DATA_DIR", str(tmp_path / "a"))
+        first = util.watcher_state_dir()
+        # Changing the env after first resolution must not move the dir.
+        monkeypatch.setenv("UNITARES_WATCHER_DATA_DIR", str(tmp_path / "b"))
+        assert util.watcher_state_dir() == first
+
+    def test_resolution_has_no_filesystem_side_effects(self, monkeypatch, tmp_path):
+        target = tmp_path / "never_created"
+        monkeypatch.setenv("UNITARES_WATCHER_DATA_DIR", str(target))
+        util.watcher_state_dir()
+        assert not target.exists()
+
+
+class TestMigration:
+    def _point_legacy(self, monkeypatch, legacy: Path, target: Path):
+        monkeypatch.setattr(util, "_LEGACY_STATE_DIR", legacy)
+        monkeypatch.setenv("UNITARES_WATCHER_DATA_DIR", str(target))
+
+    def test_copies_existing_state_files(self, monkeypatch, tmp_path):
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        (legacy / "findings.jsonl").write_text('{"pattern":"P001"}\n')
+        (legacy / "dedup.json").write_text("{}")
+        target = tmp_path / "home" / "watcher"
+        self._point_legacy(monkeypatch, legacy, target)
+
+        util.migrate_legacy_watcher_state()
+
+        assert (target / "findings.jsonl").read_text() == '{"pattern":"P001"}\n'
+        assert (target / "dedup.json").read_text() == "{}"
+
+    def test_does_not_delete_source(self, monkeypatch, tmp_path):
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        (legacy / "findings.jsonl").write_text("x\n")
+        target = tmp_path / "home" / "watcher"
+        self._point_legacy(monkeypatch, legacy, target)
+
+        util.migrate_legacy_watcher_state()
+
+        assert (legacy / "findings.jsonl").exists()
+
+    def test_does_not_clobber_existing_target(self, monkeypatch, tmp_path):
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        (legacy / "findings.jsonl").write_text("OLD\n")
+        target = tmp_path / "home" / "watcher"
+        target.mkdir(parents=True)
+        (target / "findings.jsonl").write_text("NEW\n")
+        self._point_legacy(monkeypatch, legacy, target)
+
+        util.migrate_legacy_watcher_state()
+
+        assert (target / "findings.jsonl").read_text() == "NEW\n"
+
+    def test_noop_when_legacy_absent(self, monkeypatch, tmp_path):
+        legacy = tmp_path / "does_not_exist"
+        target = tmp_path / "home" / "watcher"
+        self._point_legacy(monkeypatch, legacy, target)
+
+        util.migrate_legacy_watcher_state()
+
+        assert not target.exists()
+
+    def test_runs_filesystem_work_once_per_process(self, monkeypatch, tmp_path):
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        (legacy / "findings.jsonl").write_text("v1\n")
+        target = tmp_path / "home" / "watcher"
+        self._point_legacy(monkeypatch, legacy, target)
+
+        util.migrate_legacy_watcher_state()
+        # A later legacy change is ignored — migration already ran this process.
+        (legacy / "dedup.json").write_text("{}")
+        util.migrate_legacy_watcher_state()
+
+        assert not (target / "dedup.json").exists()


### PR DESCRIPTION
## Why
Started from "is Watcher even working — dashboard shows zeroes." It surfaced **two independent Watcher reliability bugs**. Watcher's scan engine was fine the whole time.

## Bug 1 — dashboard read zeroes (checkout split)
The Watcher agent (writer) is pinned to the **dev** checkout `~/projects/unitares` by the PostToolUse hook, while `http_api` (reader) serves from the **deploy** worktree `~/projects/unitares-deploy` after the 2026-06-03 cutover. Each resolved a *different* checkout-relative `data/watcher/findings.jsonl` — and since that dir is gitignored local state, the deploy tree had none, so the panel read an empty/absent file → zeroes.

**Fix:** `agents/watcher/_util.py:watcher_state_dir()` — checkout-independent, home-anchored at `~/.unitares/watcher` (co-located with the identity anchor `~/.unitares/anchors/`), overridable via `UNITARES_WATCHER_DATA_DIR`. Used by **both** writer (`findings.py` `STATE_DIR`, `floor_state.py` `DEFAULT_STATE_DIR`) and reader (`http_api._watcher_findings_path()`). Idempotent one-time `migrate_legacy_watcher_state()` carries forward existing state; the reader falls back to the legacy file while the shared one is empty so rollout order can't re-zero the panel.

## Bug 2 — check-ins failed "Identity not resolved" for ~11h
The Watcher's `client_session_id → uuid` binding lives **only in Redis with a ~24h TTL**; no durable row stands in for it. `_do_checkin()` sent only `client_session_id`, so once that cache entry lapsed the resolver had no proof to rebind from → "Identity not resolved."

Verified live (council live-verifier):
- Failures began at **2026-06-05T15:07:07Z — exactly 24h** after the last good check-in (2026-06-04T15:07:07Z).
- Redis itself had **15+ days uptime** — the session store never restarted (the MCP `-9` exit was a red herring).
- A token-bearing `process_agent_update` resolves to the correct uuid and **re-sets the TTL to ~24h**.

**Fix:** `_do_checkin()` now also passes `continuity_token`, so `process_agent_update` resolves via cryptographic ownership proof (REST PATH 2.8 rebind), re-warming the cache and self-healing across the TTL boundary. Empty-token guard degrades gracefully to the old behavior.

## Council review (3 agents, adversarial)
- **code-reviewer**, **dialectic-knowledge-architect**, **live-verifier** ran in parallel.
- Acted on: corrected the root-cause comment to the empirically-grounded version; added `/.unitares/watcher/` to `SKIP_PATH_FRAGMENTS`; added the reader's legacy read-fallback for the rollout window.
- Declined (with reasoning): import-time `STATE_DIR` capture (non-issue — env is process-static at launch); the deeper "class fix" in `resolve_identity`/SDK (defer — expanding into the fork-incident-sensitive resume path without its own verification). See follow-up below.

## Tests
- `test_watcher_state_dir.py` — resolution/env-override/expanduser/caching/no-side-effects + migration (copy-if-absent, never-delete-source, no-clobber, noop-when-absent, once-per-process).
- `test_http_api_watcher_summary.py` — reader/writer path agreement + legacy fallback + prefers-shared-once-populated.
- `test_watcher_checkin_proof_rebind.py` — token forwarded / omitted-when-empty / skipped-without-identity.
- Full local gate: 5019 passed before halting on one **pre-existing, environmental** failure (`test_lease_plane_canonicalize` — sandbox `TMPDIR=/private/tmp` vs `/var/folders`; fails identically on master, untouched by this diff). Pre-push smoke: 138 passed.

## Follow-ups (not in this PR)
- Class-fix candidate: set `client.client_session_id` in `resolve_identity()` before its `identity()` resume, or have the SDK auto-inject `continuity_token` like it does `client_session_id`, so any future `process_agent_update` call site is covered without threading the token.
- Ops after merge: update the dev-checkout Watcher to this code, migrate `~/projects/unitares/data/watcher/*` → `~/.unitares/watcher/`, and remove the diagnostic symlink at `~/projects/unitares-deploy/data/watcher`.

## Note
Not set to auto-merge — identity-adjacent surface, left for your review.