### PR TITLE
feat(wave-3): §14 prereq PR 1 — shadow DDL, divergence comparator, event types

### DIFF
--- a/db/postgres/migrations/043_identities_shadow.sql
+++ b/db/postgres/migrations/043_identities_shadow.sql
@@ -1,0 +1,42 @@
+-- 043_identities_shadow.sql
+--
+-- Wave 3 §8.1 (docs/proposals/beam-wave-3-handler-dispatch.md): shadow table
+-- for core.identities during the Wave 3 shadow window. The BEAM shadow writer
+-- (Wave 3 implementation — NOT this migration; nothing writes here yet)
+-- dual-writes PATH-3 fresh mints into this table. The comparator at
+-- scripts/ops/wave-3-shadow-divergence-check.sql full-outer-joins shadow
+-- against canonical and emits coordination_failure.beam_python_boundary.
+-- shadow_divergence per divergent row.
+--
+-- FK decision (§8.1, documented inline as required): LIKE ... INCLUDING ALL
+-- does NOT copy foreign-key constraints in PostgreSQL, and we deliberately
+-- leave FKs OFF the shadow table — it is a write-only audit replica, not a
+-- referential target. FKs would impose write-ordering constraints on the
+-- shadow writer that the comparator does not need.
+--
+-- Sequence note: INCLUDING ALL copies column DEFAULTs, so identity_id's
+-- default remains nextval('core.identities_identity_id_seq') — the SAME
+-- sequence as canonical. Accepted and documented rather than hidden: the
+-- shadow writer always supplies identity_id explicitly (copied from the
+-- canonical write), so the shared-sequence default is never exercised in
+-- normal operation, and a stray defaulted insert cannot collide with
+-- canonical values (one shared counter).
+--
+-- Schema drift on core.identities requires a paired shadow update;
+-- db/postgres/schema_drift_check.sh (this PR) fails when the column shapes
+-- diverge (modulo shadow_write_at).
+
+CREATE TABLE IF NOT EXISTS core.identities_shadow (
+    LIKE core.identities INCLUDING ALL,
+    shadow_write_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE core.identities_shadow IS
+    'Wave 3 §8 shadow replica of core.identities. Write-only audit target for '
+    'the BEAM shadow writer during the shadow window; no FKs by design; '
+    'compared hourly by scripts/ops/wave-3-shadow-divergence-check.sql.';
+
+-- Register migration
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (43, 'identities_shadow', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/db/postgres/migrations/044_agents_shadow.sql
+++ b/db/postgres/migrations/044_agents_shadow.sql
@@ -1,0 +1,25 @@
+-- 044_agents_shadow.sql
+--
+-- Wave 3 §8.1 (docs/proposals/beam-wave-3-handler-dispatch.md): shadow table
+-- for core.agents — the second of the two coupled tables written on PATH-3
+-- fresh mint (surface D in §3.1). Same design as 043_identities_shadow.sql;
+-- see that migration's header for the FK and sequence rationale.
+--
+-- FK decision (§8.1): no foreign keys on the shadow table, by design —
+-- write-only audit replica, not a referential target. (core.agents.id is
+-- TEXT with no default, so there is no sequence-sharing concern here.)
+
+CREATE TABLE IF NOT EXISTS core.agents_shadow (
+    LIKE core.agents INCLUDING ALL,
+    shadow_write_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE core.agents_shadow IS
+    'Wave 3 §8 shadow replica of core.agents. Write-only audit target for '
+    'the BEAM shadow writer during the shadow window; no FKs by design; '
+    'compared hourly by scripts/ops/wave-3-shadow-divergence-check.sql.';
+
+-- Register migration
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (44, 'agents_shadow', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/db/postgres/schema_drift_check.sh
+++ b/db/postgres/schema_drift_check.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# schema_drift_check.sh — Wave 3 §8.1 drift gate.
+#
+# core.identities_shadow / core.agents_shadow are created with
+# `LIKE <canonical> INCLUDING ALL` (migrations 043/044). If the canonical
+# table's shape later changes without a paired shadow migration, the §8.2
+# comparator silently compares against a stale shape. This script fails when
+# the column shape (name + data type, ordinal order) of a canonical table
+# diverges from its shadow (excluding the shadow-only `shadow_write_at`).
+#
+# Exit codes:
+#   0 — shapes match
+#   1 — DRIFT detected (fail the gate)
+#   2 — no database reachable (distinct from drift so CI wiring can decide;
+#       a silent pass without a DB would be a false gate)
+#
+# Usage: db/postgres/schema_drift_check.sh
+#   Honors GOVERNANCE_DATABASE_URL (default: local governance DB).
+
+set -euo pipefail
+
+DSN="${GOVERNANCE_DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/governance}"
+
+if ! psql "$DSN" -tAc "select 1" >/dev/null 2>&1; then
+  echo "[schema-drift] no database reachable at \$GOVERNANCE_DATABASE_URL — cannot verify (exit 2)" >&2
+  exit 2
+fi
+
+shape() { # shape <table_name> <exclude_column_or_empty>
+  local table="$1" exclude="${2:-}"
+  psql "$DSN" -tAc "
+    SELECT column_name || ':' || data_type
+    FROM information_schema.columns
+    WHERE table_schema = 'core'
+      AND table_name = '$table'
+      AND column_name <> COALESCE(NULLIF('$exclude', ''), '__none__')
+    ORDER BY ordinal_position"
+}
+
+drift=0
+for pair in identities agents; do
+  shadow="${pair}_shadow"
+  if [[ -z "$(psql "$DSN" -tAc "select to_regclass('core.$shadow')")" ]]; then
+    echo "[schema-drift] core.$shadow does not exist — apply migrations 043/044 first" >&2
+    drift=1
+    continue
+  fi
+  if ! diff <(shape "$pair") <(shape "$shadow" "shadow_write_at") >/tmp/schema_drift_$pair.diff 2>&1; then
+    echo "[schema-drift] DRIFT between core.$pair and core.$shadow:" >&2
+    cat /tmp/schema_drift_$pair.diff >&2
+    drift=1
+  else
+    echo "[schema-drift] core.$pair == core.$shadow (modulo shadow_write_at)"
+  fi
+done
+
+exit $drift

--- a/governance_core/coordination_events_helpers.py
+++ b/governance_core/coordination_events_helpers.py
@@ -73,3 +73,68 @@ def make_boundary_payload(
         "status_code": status_code,
         "elapsed_ms": elapsed_ms,
     }
+
+
+VALID_SHADOW_TABLES: Final[frozenset[str]] = frozenset({"identities", "agents"})
+
+VALID_DIVERGENCE_KINDS: Final[frozenset[str]] = frozenset({
+    "canonical_missing",
+    "shadow_missing",
+    "column_mismatch",
+})
+
+
+def make_shadow_divergence_payload(
+    *,
+    table_name: str,
+    agent_id: str,
+    kind: str,
+    divergent_columns: list[str],
+) -> dict:
+    """Build the Wave 3 §8.2 shadow-divergence payload.
+
+    Contract (pinned in `src/coordination_events.py` §8.4 comments):
+    `{table_name, agent_id, kind, divergent_columns}`. All
+    `coordination_failure.beam_python_boundary.shadow_divergence` emissions go
+    through this helper — same enforcement rationale as `make_boundary_payload`.
+
+    Raises:
+        ValueError: if `table_name` is not a shadowed table, `agent_id` is
+            empty, `kind` is outside the documented enum, or the
+            kind/column coherence rule is violated (`column_mismatch`
+            requires a non-empty column list; the missing-row kinds require
+            an empty one — the row diverged wholesale, not per-column).
+        TypeError: if `divergent_columns` is not a list of strings.
+    """
+    if table_name not in VALID_SHADOW_TABLES:
+        raise ValueError(
+            f"table_name={table_name!r} is not a shadowed table "
+            f"{sorted(VALID_SHADOW_TABLES)}"
+        )
+    if not agent_id or not agent_id.strip():
+        raise ValueError("agent_id must be the non-empty join-key of the divergent row")
+    if kind not in VALID_DIVERGENCE_KINDS:
+        raise ValueError(
+            f"kind={kind!r} is not in the documented enum "
+            f"{sorted(VALID_DIVERGENCE_KINDS)}"
+        )
+    if not isinstance(divergent_columns, list) or any(
+        not isinstance(c, str) for c in divergent_columns
+    ):
+        raise TypeError("divergent_columns must be a list of column-name strings")
+    if kind == "column_mismatch" and not divergent_columns:
+        raise ValueError(
+            "kind='column_mismatch' requires at least one divergent column"
+        )
+    if kind != "column_mismatch" and divergent_columns:
+        raise ValueError(
+            f"kind={kind!r} means the row is missing wholesale; "
+            "divergent_columns must be empty"
+        )
+
+    return {
+        "table_name": table_name,
+        "agent_id": agent_id,
+        "kind": kind,
+        "divergent_columns": list(divergent_columns),
+    }

--- a/scripts/dev/check-wave3-ode-prereq.sh
+++ b/scripts/dev/check-wave3-ode-prereq.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# check-wave3-ode-prereq.sh — Wave 3 §14 ordering gate.
+#
+# RFC (docs/proposals/beam-wave-3-handler-dispatch.md §14): all ten prereq
+# PRs land BEFORE any commit in elixir/handler_dispatch/. This lint engages
+# only when an elixir/handler_dispatch tree exists; until then it passes,
+# so it is safe to wire into CI from prereq PR #1 onward.
+#
+# When engaged, it requires:
+#   1. The prereq-PR #1 artifacts (shadow migrations, comparator, drift gate).
+#   2. The §5.2 boundary-cost audit artifact. The RFC names the audit output
+#      docs/handoffs/wave-3-section-5-2-boundary-audit-<date>.md, but
+#      docs/handoffs/ is gitignored — un-checkable in CI. ADAPTATION
+#      (documented for council review in prereq PR #1): a committed summary at
+#      docs/proposals/wave-3-section-5-2-boundary-audit-summary.md satisfies
+#      the gate in CI; the local gitignored handoff also satisfies it for
+#      local runs. Either is sufficient.
+#
+# Exit codes: 0 = gate passes (or not engaged); 1 = gate violated.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+if [[ ! -e "$ROOT/elixir/handler_dispatch" ]]; then
+  echo "[wave3-prereq] elixir/handler_dispatch absent — gate not engaged (pass)"
+  exit 0
+fi
+
+fail=0
+
+required=(
+  "db/postgres/migrations/043_identities_shadow.sql"
+  "db/postgres/migrations/044_agents_shadow.sql"
+  "db/postgres/schema_drift_check.sh"
+  "scripts/ops/wave-3-shadow-divergence-check.sql"
+  "scripts/ops/wave3_shadow_divergence_check.py"
+  "scripts/ops/wave3-shadow-replay.sh"
+)
+for f in "${required[@]}"; do
+  if [[ ! -e "$ROOT/$f" ]]; then
+    echo "[wave3-prereq] MISSING prereq artifact: $f" >&2
+    fail=1
+  fi
+done
+
+audit_ok=0
+if [[ -e "$ROOT/docs/proposals/wave-3-section-5-2-boundary-audit-summary.md" ]]; then
+  audit_ok=1
+fi
+if compgen -G "$ROOT/docs/handoffs/wave-3-section-5-2-boundary-audit-*.md" >/dev/null 2>&1; then
+  audit_ok=1
+fi
+if [[ "$audit_ok" -ne 1 ]]; then
+  echo "[wave3-prereq] MISSING §5.2 boundary-cost audit artifact (committed summary" >&2
+  echo "  docs/proposals/wave-3-section-5-2-boundary-audit-summary.md, or local" >&2
+  echo "  docs/handoffs/wave-3-section-5-2-boundary-audit-<date>.md)" >&2
+  fail=1
+fi
+
+if [[ "$fail" -eq 0 ]]; then
+  echo "[wave3-prereq] gate engaged and satisfied"
+fi
+exit $fail

--- a/scripts/ops/com.unitares.wave3-shadow-divergence-check.plist.template
+++ b/scripts/ops/com.unitares.wave3-shadow-divergence-check.plist.template
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Hourly Wave 3 §8.2 shadow-divergence comparator
+    (scripts/ops/wave3_shadow_divergence_check.py). Inert-by-construction
+    until the Wave 3 BEAM shadow writer populates core.identities_shadow /
+    core.agents_shadow — see the runner's docstring.
+
+    Before installing, substitute placeholders:
+      __UNITARES_ROOT__  → absolute path to the deploy worktree
+                           (the runner imports src/ + governance_core/)
+      __PYTHON3__        → absolute python3 with asyncpg installed
+                           (e.g. /Library/Frameworks/Python.framework/Versions/3.14/bin/python3)
+
+    Example:
+      sed -e "s|__UNITARES_ROOT__|$HOME/projects/unitares-deploy|g" \
+          -e "s|__PYTHON3__|/Library/Frameworks/Python.framework/Versions/3.14/bin/python3|g" \
+          scripts/ops/com.unitares.wave3-shadow-divergence-check.plist.template \
+          > ~/Library/LaunchAgents/com.unitares.wave3-shadow-divergence-check.plist
+      launchctl load ~/Library/LaunchAgents/com.unitares.wave3-shadow-divergence-check.plist
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.unitares.wave3-shadow-divergence-check</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__PYTHON3__</string>
+        <string>__UNITARES_ROOT__/scripts/ops/wave3_shadow_divergence_check.py</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__UNITARES_ROOT__</string>
+
+    <key>StartInterval</key>
+    <integer>3600</integer>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>__UNITARES_ROOT__/data/logs/wave3_shadow_divergence_launchd.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__UNITARES_ROOT__/data/logs/wave3_shadow_divergence_launchd.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>GOVERNANCE_DATABASE_URL</key>
+        <string>postgresql://postgres:postgres@localhost:5432/governance</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/ops/wave-3-shadow-divergence-check.sql
+++ b/scripts/ops/wave-3-shadow-divergence-check.sql
@@ -6,14 +6,24 @@
 -- (launchd: com.unitares.wave3-shadow-divergence-check), which emits one
 -- coordination_failure.beam_python_boundary.shadow_divergence event per row.
 --
+-- Alias contract (council fold, PR #597): every diff alias is EXACTLY
+-- '<canonical_column_name>_diff' — the runner derives the payload's
+-- divergent_columns by stripping the '_diff' suffix, so abbreviated aliases
+-- would emit names that match no real column. The RFC §8.2 sketch used
+-- shortened aliases (provisional_diff, allow_rebind_diff, ...); those were
+-- renamed here for payload fidelity. tests/test_wave3_shadow_divergence_runner.py
+-- pins alias-stem == canonical-column for every alias in this file.
+--
 -- Column-set rationale (live-schema verified 2026-06-10 against the
--- governance DB; §15 live-verifier lane should re-verify on review):
+-- governance DB; §15 live-verifier lane re-verified on review):
 --   * identities: compares every live column EXCEPT
 --       - identity_id   (serial PK; canonical and shadow draw the same
 --                        sequence but the shadow writer copies values —
 --                        compared implicitly via the agent_id join)
 --       - created_at / updated_at (writer-local timestamps; legitimate skew)
---       - metadata_tsv  (generated from metadata; equal iff metadata equal)
+--       - metadata_tsv  (GENERATED ALWAYS from agent_id + metadata fields;
+--                        agent_id is the join key — equal by construction on
+--                        matched rows — so the tsv is equal iff metadata is)
 --   * agents: compares every live column EXCEPT created_at / updated_at
 --     (same writer-local-timestamp rationale).
 -- The join keys are unique on the canonical side (identities_agent_id_key
@@ -36,32 +46,32 @@ WITH ident_compare AS (
         (c.metadata                 IS DISTINCT FROM s.metadata)                 AS metadata_diff,
         (c.disabled_at              IS DISTINCT FROM s.disabled_at)              AS disabled_at_diff,
         (c.last_activity_at         IS DISTINCT FROM s.last_activity_at)         AS last_activity_at_diff,
-        (c.provisional_lineage      IS DISTINCT FROM s.provisional_lineage)      AS provisional_diff,
+        (c.provisional_lineage      IS DISTINCT FROM s.provisional_lineage)      AS provisional_lineage_diff,
         (c.provisional_score_id     IS DISTINCT FROM s.provisional_score_id)     AS provisional_score_id_diff,
-        (c.provisional_recorded_at  IS DISTINCT FROM s.provisional_recorded_at)  AS provisional_recorded_diff,
-        (c.confirmed_at             IS DISTINCT FROM s.confirmed_at)             AS confirmed_diff,
-        (c.lineage_declared_at      IS DISTINCT FROM s.lineage_declared_at)      AS lineage_declared_diff,
-        (c.lineage_demoted_at       IS DISTINCT FROM s.lineage_demoted_at)       AS lineage_demoted_diff,
-        (c.lineage_last_eval_at     IS DISTINCT FROM s.lineage_last_eval_at)     AS lineage_last_eval_diff,
+        (c.provisional_recorded_at  IS DISTINCT FROM s.provisional_recorded_at)  AS provisional_recorded_at_diff,
+        (c.confirmed_at             IS DISTINCT FROM s.confirmed_at)             AS confirmed_at_diff,
+        (c.lineage_declared_at      IS DISTINCT FROM s.lineage_declared_at)      AS lineage_declared_at_diff,
+        (c.lineage_demoted_at       IS DISTINCT FROM s.lineage_demoted_at)       AS lineage_demoted_at_diff,
+        (c.lineage_last_eval_at     IS DISTINCT FROM s.lineage_last_eval_at)     AS lineage_last_eval_at_diff,
         (c.chain_obs_count          IS DISTINCT FROM s.chain_obs_count)          AS chain_obs_count_diff,
-        (c.lineage_archived_at      IS DISTINCT FROM s.lineage_archived_at)      AS lineage_archived_diff
+        (c.lineage_archived_at      IS DISTINCT FROM s.lineage_archived_at)      AS lineage_archived_at_diff
     FROM core.identities c
     FULL OUTER JOIN core.identities_shadow s USING (agent_id)
 )
 SELECT 'identities' AS table_name, agent_id, canonical_missing, shadow_missing,
        api_key_hash_diff, status_diff, parent_agent_id_diff, spawn_reason_diff,
        metadata_diff, disabled_at_diff, last_activity_at_diff,
-       provisional_diff, provisional_score_id_diff, provisional_recorded_diff, confirmed_diff,
-       lineage_declared_diff, lineage_demoted_diff, lineage_last_eval_diff, chain_obs_count_diff,
-       lineage_archived_diff
+       provisional_lineage_diff, provisional_score_id_diff, provisional_recorded_at_diff,
+       confirmed_at_diff, lineage_declared_at_diff, lineage_demoted_at_diff,
+       lineage_last_eval_at_diff, chain_obs_count_diff, lineage_archived_at_diff
 FROM ident_compare
 WHERE canonical_missing OR shadow_missing
    OR api_key_hash_diff OR status_diff OR parent_agent_id_diff
    OR spawn_reason_diff OR metadata_diff
    OR disabled_at_diff OR last_activity_at_diff
-   OR provisional_diff OR provisional_score_id_diff OR provisional_recorded_diff OR confirmed_diff
-   OR lineage_declared_diff OR lineage_demoted_diff OR lineage_last_eval_diff OR chain_obs_count_diff
-   OR lineage_archived_diff;
+   OR provisional_lineage_diff OR provisional_score_id_diff OR provisional_recorded_at_diff
+   OR confirmed_at_diff OR lineage_declared_at_diff OR lineage_demoted_at_diff
+   OR lineage_last_eval_at_diff OR chain_obs_count_diff OR lineage_archived_at_diff;
 
 -- core.agents divergence
 WITH agent_compare AS (
@@ -80,18 +90,18 @@ WITH agent_compare AS (
         (c.spawn_reason             IS DISTINCT FROM s.spawn_reason)             AS spawn_reason_diff,
         (c.thread_id                IS DISTINCT FROM s.thread_id)                AS thread_id_diff,
         (c.thread_position          IS DISTINCT FROM s.thread_position)          AS thread_position_diff,
-        (c.allow_rebind_after_exit  IS DISTINCT FROM s.allow_rebind_after_exit)  AS allow_rebind_diff,
-        (c.allow_concurrent_contexts IS DISTINCT FROM s.allow_concurrent_contexts) AS allow_concurrent_diff
+        (c.allow_rebind_after_exit  IS DISTINCT FROM s.allow_rebind_after_exit)  AS allow_rebind_after_exit_diff,
+        (c.allow_concurrent_contexts IS DISTINCT FROM s.allow_concurrent_contexts) AS allow_concurrent_contexts_diff
     FROM core.agents c
     FULL OUTER JOIN core.agents_shadow s USING (id)
 )
 SELECT 'agents' AS table_name, agent_id, canonical_missing, shadow_missing,
        api_key_diff, status_diff, parent_agent_id_diff, label_diff, purpose_diff,
-       notes_diff, tags_diff, archived_at_diff, spawn_reason_diff, thread_id_diff, thread_position_diff,
-       allow_rebind_diff, allow_concurrent_diff
+       notes_diff, tags_diff, archived_at_diff, spawn_reason_diff, thread_id_diff,
+       thread_position_diff, allow_rebind_after_exit_diff, allow_concurrent_contexts_diff
 FROM agent_compare
 WHERE canonical_missing OR shadow_missing
    OR api_key_diff OR status_diff OR parent_agent_id_diff OR label_diff
    OR purpose_diff OR notes_diff OR tags_diff OR archived_at_diff
    OR spawn_reason_diff OR thread_id_diff OR thread_position_diff
-   OR allow_rebind_diff OR allow_concurrent_diff;
+   OR allow_rebind_after_exit_diff OR allow_concurrent_contexts_diff;

--- a/scripts/ops/wave-3-shadow-divergence-check.sql
+++ b/scripts/ops/wave-3-shadow-divergence-check.sql
@@ -1,0 +1,97 @@
+-- wave-3-shadow-divergence-check.sql — Wave 3 §8.2 comparator.
+--
+-- Full outer join of canonical vs shadow for the two PATH-3 tables, all live
+-- columns, three divergence kinds (canonical_missing / shadow_missing /
+-- column mismatch). Run hourly by scripts/ops/wave3_shadow_divergence_check.py
+-- (launchd: com.unitares.wave3-shadow-divergence-check), which emits one
+-- coordination_failure.beam_python_boundary.shadow_divergence event per row.
+--
+-- Column-set rationale (live-schema verified 2026-06-10 against the
+-- governance DB; §15 live-verifier lane should re-verify on review):
+--   * identities: compares every live column EXCEPT
+--       - identity_id   (serial PK; canonical and shadow draw the same
+--                        sequence but the shadow writer copies values —
+--                        compared implicitly via the agent_id join)
+--       - created_at / updated_at (writer-local timestamps; legitimate skew)
+--       - metadata_tsv  (generated from metadata; equal iff metadata equal)
+--   * agents: compares every live column EXCEPT created_at / updated_at
+--     (same writer-local-timestamp rationale).
+-- The join keys are unique on the canonical side (identities_agent_id_key
+-- UNIQUE; agents_pkey) and copied to the shadows by LIKE ... INCLUDING ALL.
+--
+-- Statements are separated by top-level semicolons only (no procedural
+-- bodies, no semicolons inside string literals), so the runner strips
+-- comment lines and splits on semicolons.
+
+-- core.identities divergence
+WITH ident_compare AS (
+    SELECT
+        COALESCE(c.agent_id, s.agent_id)                              AS agent_id,
+        c.agent_id IS NULL                                             AS canonical_missing,
+        s.agent_id IS NULL                                             AS shadow_missing,
+        (c.api_key_hash             IS DISTINCT FROM s.api_key_hash)             AS api_key_hash_diff,
+        (c.status                   IS DISTINCT FROM s.status)                   AS status_diff,
+        (c.parent_agent_id          IS DISTINCT FROM s.parent_agent_id)          AS parent_agent_id_diff,
+        (c.spawn_reason             IS DISTINCT FROM s.spawn_reason)             AS spawn_reason_diff,
+        (c.metadata                 IS DISTINCT FROM s.metadata)                 AS metadata_diff,
+        (c.disabled_at              IS DISTINCT FROM s.disabled_at)              AS disabled_at_diff,
+        (c.last_activity_at         IS DISTINCT FROM s.last_activity_at)         AS last_activity_at_diff,
+        (c.provisional_lineage      IS DISTINCT FROM s.provisional_lineage)      AS provisional_diff,
+        (c.provisional_score_id     IS DISTINCT FROM s.provisional_score_id)     AS provisional_score_id_diff,
+        (c.provisional_recorded_at  IS DISTINCT FROM s.provisional_recorded_at)  AS provisional_recorded_diff,
+        (c.confirmed_at             IS DISTINCT FROM s.confirmed_at)             AS confirmed_diff,
+        (c.lineage_declared_at      IS DISTINCT FROM s.lineage_declared_at)      AS lineage_declared_diff,
+        (c.lineage_demoted_at       IS DISTINCT FROM s.lineage_demoted_at)       AS lineage_demoted_diff,
+        (c.lineage_last_eval_at     IS DISTINCT FROM s.lineage_last_eval_at)     AS lineage_last_eval_diff,
+        (c.chain_obs_count          IS DISTINCT FROM s.chain_obs_count)          AS chain_obs_count_diff,
+        (c.lineage_archived_at      IS DISTINCT FROM s.lineage_archived_at)      AS lineage_archived_diff
+    FROM core.identities c
+    FULL OUTER JOIN core.identities_shadow s USING (agent_id)
+)
+SELECT 'identities' AS table_name, agent_id, canonical_missing, shadow_missing,
+       api_key_hash_diff, status_diff, parent_agent_id_diff, spawn_reason_diff,
+       metadata_diff, disabled_at_diff, last_activity_at_diff,
+       provisional_diff, provisional_score_id_diff, provisional_recorded_diff, confirmed_diff,
+       lineage_declared_diff, lineage_demoted_diff, lineage_last_eval_diff, chain_obs_count_diff,
+       lineage_archived_diff
+FROM ident_compare
+WHERE canonical_missing OR shadow_missing
+   OR api_key_hash_diff OR status_diff OR parent_agent_id_diff
+   OR spawn_reason_diff OR metadata_diff
+   OR disabled_at_diff OR last_activity_at_diff
+   OR provisional_diff OR provisional_score_id_diff OR provisional_recorded_diff OR confirmed_diff
+   OR lineage_declared_diff OR lineage_demoted_diff OR lineage_last_eval_diff OR chain_obs_count_diff
+   OR lineage_archived_diff;
+
+-- core.agents divergence
+WITH agent_compare AS (
+    SELECT
+        COALESCE(c.id, s.id)                                          AS agent_id,
+        c.id IS NULL                                                   AS canonical_missing,
+        s.id IS NULL                                                   AS shadow_missing,
+        (c.api_key                  IS DISTINCT FROM s.api_key)                  AS api_key_diff,
+        (c.status                   IS DISTINCT FROM s.status)                   AS status_diff,
+        (c.parent_agent_id          IS DISTINCT FROM s.parent_agent_id)          AS parent_agent_id_diff,
+        (c.label                    IS DISTINCT FROM s.label)                    AS label_diff,
+        (c.purpose                  IS DISTINCT FROM s.purpose)                  AS purpose_diff,
+        (c.notes                    IS DISTINCT FROM s.notes)                    AS notes_diff,
+        (c.tags                     IS DISTINCT FROM s.tags)                     AS tags_diff,
+        (c.archived_at              IS DISTINCT FROM s.archived_at)              AS archived_at_diff,
+        (c.spawn_reason             IS DISTINCT FROM s.spawn_reason)             AS spawn_reason_diff,
+        (c.thread_id                IS DISTINCT FROM s.thread_id)                AS thread_id_diff,
+        (c.thread_position          IS DISTINCT FROM s.thread_position)          AS thread_position_diff,
+        (c.allow_rebind_after_exit  IS DISTINCT FROM s.allow_rebind_after_exit)  AS allow_rebind_diff,
+        (c.allow_concurrent_contexts IS DISTINCT FROM s.allow_concurrent_contexts) AS allow_concurrent_diff
+    FROM core.agents c
+    FULL OUTER JOIN core.agents_shadow s USING (id)
+)
+SELECT 'agents' AS table_name, agent_id, canonical_missing, shadow_missing,
+       api_key_diff, status_diff, parent_agent_id_diff, label_diff, purpose_diff,
+       notes_diff, tags_diff, archived_at_diff, spawn_reason_diff, thread_id_diff, thread_position_diff,
+       allow_rebind_diff, allow_concurrent_diff
+FROM agent_compare
+WHERE canonical_missing OR shadow_missing
+   OR api_key_diff OR status_diff OR parent_agent_id_diff OR label_diff
+   OR purpose_diff OR notes_diff OR tags_diff OR archived_at_diff
+   OR spawn_reason_diff OR thread_id_diff OR thread_position_diff
+   OR allow_rebind_diff OR allow_concurrent_diff;

--- a/scripts/ops/wave3-shadow-replay.sh
+++ b/scripts/ops/wave3-shadow-replay.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# wave3-shadow-replay.sh — Wave 3 §8.3 load-amplification harness (entrypoint).
+#
+# Replays captured production traffic at an amplified rate (default 2×)
+# against the Wave 3 shadow path. The 7-day zero-divergence clock starts
+# AFTER a replay completes with zero divergence events (§8.3).
+#
+# The shadow path itself ships with the Wave 3 implementation, NOT with this
+# prereq PR — until then this harness is runnable only against a test target.
+# It therefore REQUIRES an explicit --target; there is no default, so it can
+# never accidentally replay amplified traffic at the live MCP.
+#
+# Capture format (one JSON object per line):
+#   {"ts": "<ISO8601>", "method": "POST", "path": "/v1/...", "body": {...}}
+#
+# Usage:
+#   scripts/ops/wave3-shadow-replay.sh --capture <file.jsonl> --target <base-url> [--rate 2.0] [--dry-run]
+set -euo pipefail
+exec python3 "$(cd "$(dirname "$0")" && pwd)/wave3_shadow_replay.py" "$@"

--- a/scripts/ops/wave3_shadow_divergence_check.py
+++ b/scripts/ops/wave3_shadow_divergence_check.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Wave 3 §8.2 shadow-divergence checker (hourly via launchd).
+
+Runs scripts/ops/wave-3-shadow-divergence-check.sql against the governance DB
+and emits one `coordination_failure.beam_python_boundary.shadow_divergence`
+event per divergent row, payload built by
+`governance_core.coordination_events_helpers.make_shadow_divergence_payload`
+(contract: {table_name, agent_id, kind, divergent_columns}).
+
+Inert-by-construction until the Wave 3 BEAM shadow writer exists: with empty
+shadow tables, every canonical row reports `shadow_missing`, which would flood
+the failure channel with non-signal. So rows are only emitted once the shadow
+table is non-empty (the shadow window has actually started); until then the
+checker logs the would-be count and exits 0. This gate is documented here and
+in the PR body — remove it is NOT the right fix if you want earlier signal;
+start the shadow writer instead.
+
+Exit codes: 0 = ran (divergences, if any, were emitted — events are the
+signal); 1 = runner error (DB unreachable, SQL failure, emit failure).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+import asyncpg  # noqa: E402
+
+from governance_core.coordination_events_helpers import (  # noqa: E402
+    make_shadow_divergence_payload,
+)
+from src.coordination_events import (  # noqa: E402
+    COORDINATION_FAILURE_BEAM_PYTHON_BOUNDARY_SHADOW_DIVERGENCE,
+    emit_event,
+)
+
+SQL_FILE = Path(__file__).with_name("wave-3-shadow-divergence-check.sql")
+DSN = os.environ.get(
+    "GOVERNANCE_DATABASE_URL",
+    "postgresql://postgres:postgres@localhost:5432/governance",
+)
+
+# Maps the comparator's boolean *_diff columns to divergent-column names.
+_NON_DIFF_COLUMNS = {"table_name", "agent_id", "canonical_missing", "shadow_missing"}
+
+
+def _row_kind(row: asyncpg.Record) -> str:
+    if row["canonical_missing"]:
+        return "canonical_missing"
+    if row["shadow_missing"]:
+        return "shadow_missing"
+    return "column_mismatch"
+
+
+def _divergent_columns(row: asyncpg.Record) -> list[str]:
+    return sorted(
+        key.removesuffix("_diff")
+        for key, value in dict(row).items()
+        if key not in _NON_DIFF_COLUMNS and value is True
+    )
+
+
+async def main() -> int:
+    # Strip full-line comments FIRST (a comment may contain a quoted
+    # semicolon — it did, once), then split on top-level ';' (the comparator
+    # file guarantees no procedural bodies and no semicolons in string
+    # literals). Chunks without a SELECT (e.g. trailing whitespace) drop.
+    sql_text = "\n".join(
+        line
+        for line in SQL_FILE.read_text().splitlines()
+        if not line.lstrip().startswith("--")
+    )
+    statements = [s.strip() for s in sql_text.split(";") if s.strip()]
+    statements = [s for s in statements if "SELECT" in s.upper()]
+    if len(statements) != 2:
+        print(
+            f"[shadow-divergence] expected 2 comparator statements in "
+            f"{SQL_FILE.name}, found {len(statements)} — refusing to run",
+            file=sys.stderr,
+        )
+        return 1
+
+    pool = await asyncpg.create_pool(DSN, min_size=1, max_size=2)
+    try:
+        async with pool.acquire() as conn:
+            shadow_counts = {
+                "identities": await conn.fetchval(
+                    "SELECT count(*) FROM core.identities_shadow"
+                ),
+                "agents": await conn.fetchval(
+                    "SELECT count(*) FROM core.agents_shadow"
+                ),
+            }
+            rows: list[asyncpg.Record] = []
+            for stmt in statements:
+                rows.extend(await conn.fetch(stmt))
+
+        emitted = 0
+        skipped_inert = 0
+        for row in rows:
+            table_name = row["table_name"]
+            if shadow_counts.get(table_name, 0) == 0:
+                # Shadow window not started for this table — see module docstring.
+                skipped_inert += 1
+                continue
+            payload = make_shadow_divergence_payload(
+                table_name=table_name,
+                agent_id=str(row["agent_id"]),
+                kind=_row_kind(row),
+                divergent_columns=_divergent_columns(row),
+            )
+            await emit_event(
+                pool,
+                service="governance_mcp",
+                event_type=COORDINATION_FAILURE_BEAM_PYTHON_BOUNDARY_SHADOW_DIVERGENCE,
+                payload=payload,
+                agent_id=None,  # row agent_id may predate UUID discipline; carried in payload
+            )
+            emitted += 1
+
+        print(
+            f"[shadow-divergence] rows={len(rows)} emitted={emitted} "
+            f"inert_skipped={skipped_inert} shadow_counts={shadow_counts}"
+        )
+        return 0
+    finally:
+        await pool.close()
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/scripts/ops/wave3_shadow_divergence_check.py
+++ b/scripts/ops/wave3_shadow_divergence_check.py
@@ -108,19 +108,30 @@ async def main() -> int:
                 # Shadow window not started for this table — see module docstring.
                 skipped_inert += 1
                 continue
-            payload = make_shadow_divergence_payload(
-                table_name=table_name,
-                agent_id=str(row["agent_id"]),
-                kind=_row_kind(row),
-                divergent_columns=_divergent_columns(row),
-            )
-            await emit_event(
-                pool,
-                service="governance_mcp",
-                event_type=COORDINATION_FAILURE_BEAM_PYTHON_BOUNDARY_SHADOW_DIVERGENCE,
-                payload=payload,
-                agent_id=None,  # row agent_id may predate UUID discipline; carried in payload
-            )
+            try:
+                payload = make_shadow_divergence_payload(
+                    table_name=table_name,
+                    agent_id=str(row["agent_id"]),
+                    kind=_row_kind(row),
+                    divergent_columns=_divergent_columns(row),
+                )
+                await emit_event(
+                    pool,
+                    service="governance_mcp",
+                    event_type=COORDINATION_FAILURE_BEAM_PYTHON_BOUNDARY_SHADOW_DIVERGENCE,
+                    payload=payload,
+                    agent_id=None,  # row agent_id may predate UUID discipline; carried in payload
+                )
+            except Exception as exc:  # noqa: BLE001 — clean exit-1 contract
+                # Already-emitted events stay committed (each emit is its own
+                # INSERT); fail the run loudly but with the documented exit
+                # code rather than a traceback.
+                print(
+                    f"[shadow-divergence] emit failed after {emitted} events "
+                    f"({table_name}/{row['agent_id']}): {exc!r}",
+                    file=sys.stderr,
+                )
+                return 1
             emitted += 1
 
         print(

--- a/scripts/ops/wave3_shadow_replay.py
+++ b/scripts/ops/wave3_shadow_replay.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Wave 3 §8.3 shadow-replay harness. See wave3-shadow-replay.sh for context.
+
+Replays a JSONL capture of production requests against --target, compressing
+inter-arrival gaps by --rate (2.0 = twice the original rate). Stdlib-only so
+it runs anywhere the repo checks out.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+
+LIVE_MCP_MARKERS = (":8767",)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--capture", required=True, type=Path, help="JSONL capture file")
+    p.add_argument(
+        "--target",
+        required=True,
+        help="Base URL of the shadow path (no default, deliberately)",
+    )
+    p.add_argument("--rate", type=float, default=2.0, help="Rate multiplier (default 2.0)")
+    p.add_argument("--timeout", type=float, default=10.0, help="Per-request timeout seconds")
+    p.add_argument("--dry-run", action="store_true", help="Parse + schedule, send nothing")
+    p.add_argument(
+        "--allow-live-target",
+        action="store_true",
+        help="Required to point at a target that looks like the live MCP (:8767)",
+    )
+    return p.parse_args()
+
+
+def load_capture(path: Path) -> list[dict]:
+    entries = []
+    with path.open() as fh:
+        for lineno, line in enumerate(fh, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError as exc:
+                sys.exit(f"capture line {lineno}: invalid JSON ({exc})")
+            for key in ("ts", "method", "path"):
+                if key not in obj:
+                    sys.exit(f"capture line {lineno}: missing required key {key!r}")
+            entries.append(obj)
+    if not entries:
+        sys.exit("capture is empty — nothing to replay")
+    return entries
+
+
+def main() -> int:
+    args = parse_args()
+    if args.rate <= 0:
+        sys.exit("--rate must be > 0")
+    if any(m in args.target for m in LIVE_MCP_MARKERS) and not args.allow_live_target:
+        sys.exit(
+            f"target {args.target!r} looks like the live governance MCP; "
+            "refusing without --allow-live-target (§8.3 replay is for the "
+            "shadow path, which ships with the Wave 3 implementation)"
+        )
+
+    entries = load_capture(args.capture)
+    t0 = datetime.fromisoformat(entries[0]["ts"])
+    sent = errors = 0
+    start = time.monotonic()
+
+    for entry in entries:
+        offset_s = (datetime.fromisoformat(entry["ts"]) - t0).total_seconds() / args.rate
+        sleep_for = start + offset_s - time.monotonic()
+        if sleep_for > 0:
+            time.sleep(sleep_for)
+        if args.dry_run:
+            sent += 1
+            continue
+        url = args.target.rstrip("/") + entry["path"]
+        body = json.dumps(entry.get("body", {})).encode()
+        req = urllib.request.Request(
+            url,
+            data=body if entry["method"] not in ("GET", "HEAD") else None,
+            method=entry["method"],
+            headers={"Content-Type": "application/json", "X-Wave3-Replay": "1"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=args.timeout) as resp:
+                resp.read()
+            sent += 1
+        except (urllib.error.URLError, OSError) as exc:
+            errors += 1
+            print(f"[replay] {entry['method']} {entry['path']} failed: {exc}", file=sys.stderr)
+
+    elapsed = time.monotonic() - start
+    mode = "DRY-RUN " if args.dry_run else ""
+    print(
+        f"[replay] {mode}done: {sent} sent, {errors} errors, "
+        f"{len(entries)} captured, {elapsed:.1f}s at {args.rate}x"
+    )
+    # Non-zero on any error so the §8.3 "replay completes with zero events"
+    # precondition can be machine-checked from exit status.
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/coordination_events.py
+++ b/src/coordination_events.py
@@ -140,6 +140,57 @@ COORDINATION_FAILURE_WAVE_3A_ENVELOPE_INVALID = (
     "coordination_failure.wave_3a.envelope_invalid"
 )
 
+# Wave 3 §14 prereq PR #1 (RFC docs/proposals/beam-wave-3-handler-dispatch.md
+# §8.4): shadow-window divergence, ETS↔PG reconciliation divergence, and the
+# cutover 503 circuit-breaker breach. Constants land ahead of their emitters
+# per the Wave 3a precedent — the shadow comparator runner
+# (scripts/ops/wave3_shadow_divergence_check.py, this PR) is the first
+# shadow_divergence emitter; the ETS reconciliation (§10.3) and 503 aggregator
+# (§3.2) emitters land with the Wave 3 implementation.
+#
+# Payload shape (pinned at landing per the Stability discipline above):
+#
+#   shadow_divergence (§8.2; payloads built ONLY by
+#   governance_core.coordination_events_helpers.make_shadow_divergence_payload):
+#     payload = {
+#       "table_name": str,          # "identities" | "agents"
+#       "agent_id": str,            # join-key value of the divergent row
+#       "kind": str,                # "canonical_missing" | "shadow_missing" |
+#                                   # "column_mismatch"
+#       "divergent_columns": list,  # canonical column names; non-empty iff
+#                                   # kind == "column_mismatch"
+#     }
+#
+#   ets_pg_divergence (§10.3 pins {key, ets_value_hash, pg_value_hash};
+#   `store` is added here because TWO ETS tables share this event_type and
+#   §10.2's readiness-gated-:cold path is a second emitter — discriminators
+#   belong in the payload contract, not relitigated per call site):
+#     payload = {
+#       "store": str,               # "agent_baselines" | "feature_flags"
+#       "key": str,                 # agent_id or flag key
+#       "ets_value_hash": str | None,  # None when ETS side missing/cold
+#       "pg_value_hash": str | None,   # None when PG side missing
+#     }
+#
+#   cutover_503_rate_breach (§3.2; numerator/denominator are the
+#   MEASUREMENT_GOVERNANCE_MCP_* events below, same 60s window):
+#     payload = {
+#       "window_seconds": int,      # 60 per §3.2
+#       "rate": float,              # count_503 / count_request in the window
+#       "threshold": float,         # 0.01 per §3.2
+#       "count_503": int,
+#       "count_request": int,
+#     }
+COORDINATION_FAILURE_BEAM_PYTHON_BOUNDARY_SHADOW_DIVERGENCE = (
+    "coordination_failure.beam_python_boundary.shadow_divergence"
+)
+COORDINATION_FAILURE_BEAM_PYTHON_BOUNDARY_ETS_PG_DIVERGENCE = (
+    "coordination_failure.beam_python_boundary.ets_pg_divergence"
+)
+COORDINATION_FAILURE_GOVERNANCE_MCP_CUTOVER_503_RATE_BREACH = (
+    "coordination_failure.governance_mcp.cutover_503_rate_breach"
+)
+
 WAVE_0_EVENT_TYPES: frozenset[str] = frozenset({
     COORDINATION_FAILURE_ASYNCPG_CONNECT_ERROR,
     COORDINATION_FAILURE_ANYIO_CANCELLATION,
@@ -152,6 +203,40 @@ WAVE_0_EVENT_TYPES: frozenset[str] = frozenset({
     COORDINATION_FAILURE_WAVE_3A_FALLBACK,
     COORDINATION_FAILURE_WAVE_3A_TIMEOUT,
     COORDINATION_FAILURE_WAVE_3A_ENVELOPE_INVALID,
+    # Wave 3 §14 prereq PR #1 — see the §8.4 docstring above the constants.
+    # Migration 035/041's CHECK regex already accepts these — no DB follow-up.
+    COORDINATION_FAILURE_BEAM_PYTHON_BOUNDARY_SHADOW_DIVERGENCE,
+    COORDINATION_FAILURE_BEAM_PYTHON_BOUNDARY_ETS_PG_DIVERGENCE,
+    COORDINATION_FAILURE_GOVERNANCE_MCP_CUTOVER_503_RATE_BREACH,
+})
+
+# Wave 3 cutover measurement channel (RFC §3.2, §6.3): informational
+# numerator/denominator events for the 503 circuit-breaker. These target
+# `audit.coordination_measurements` (migration 041) — NOT
+# `audit.coordination_events` — so they are deliberately absent from
+# WAVE_0_EVENT_TYPES and rejected by `_validate_event_type` / `emit_event`,
+# which guard the failure channel only. Emitters land with prereq PR #6
+# (lease-plane measurement bridge) and PR #10 (transport 503 emission);
+# constants land first so those PRs emit without re-extending.
+#
+# Live-schema note (verified 2026-06-10): migration 041's CHECK is
+# `^measurement(\.[a-z0-9_]+)+$` — digits are legal (so `503_emission` is a
+# valid segment), and the `telemetry` family from the RFC §6.1 sketch was NOT
+# shipped; introducing telemetry.* later requires a migration.
+#
+#   measurement.governance_mcp.request  (denominator — emitted per request
+#     accepted for proxying during cutover):
+#     payload = {"request_path": str}
+#
+#   measurement.governance_mcp.503_emission  (numerator — emitted per 503
+#     returned during cutover):
+#     payload = {"request_path": str, "error_reason": str}
+MEASUREMENT_GOVERNANCE_MCP_REQUEST = "measurement.governance_mcp.request"
+MEASUREMENT_GOVERNANCE_MCP_503_EMISSION = "measurement.governance_mcp.503_emission"
+
+MEASUREMENT_EVENT_TYPES: frozenset[str] = frozenset({
+    MEASUREMENT_GOVERNANCE_MCP_REQUEST,
+    MEASUREMENT_GOVERNANCE_MCP_503_EMISSION,
 })
 
 # Cached emitter context — git_commit and host don't change at runtime.

--- a/tests/test_coordination_events.py
+++ b/tests/test_coordination_events.py
@@ -118,8 +118,52 @@ def test_event_type_constants_match_documented_set():
         "coordination_failure.wave_3a.fallback",
         "coordination_failure.wave_3a.timeout",
         "coordination_failure.wave_3a.envelope_invalid",
+        # Wave 3 §14 prereq PR #1 (§8.4) — shadow window, ETS reconciliation,
+        # cutover 503 breach. CHECK regex already accepts these.
+        "coordination_failure.beam_python_boundary.shadow_divergence",
+        "coordination_failure.beam_python_boundary.ets_pg_divergence",
+        "coordination_failure.governance_mcp.cutover_503_rate_breach",
     }
     assert WAVE_0_EVENT_TYPES == expected
+
+
+def test_wave3_prereq_constants_pass_validation_and_membership():
+    """The three §8.4 constants pass the client-side validator and are in the
+    failure-channel allowlist. Wire-up emitters: the shadow comparator runner
+    (this PR) for shadow_divergence; Wave 3 impl for the other two."""
+    from src.coordination_events import (
+        COORDINATION_FAILURE_BEAM_PYTHON_BOUNDARY_ETS_PG_DIVERGENCE,
+        COORDINATION_FAILURE_BEAM_PYTHON_BOUNDARY_SHADOW_DIVERGENCE,
+        COORDINATION_FAILURE_GOVERNANCE_MCP_CUTOVER_503_RATE_BREACH,
+    )
+
+    for et in (
+        COORDINATION_FAILURE_BEAM_PYTHON_BOUNDARY_SHADOW_DIVERGENCE,
+        COORDINATION_FAILURE_BEAM_PYTHON_BOUNDARY_ETS_PG_DIVERGENCE,
+        COORDINATION_FAILURE_GOVERNANCE_MCP_CUTOVER_503_RATE_BREACH,
+    ):
+        _validate_event_type(et)
+        assert et in WAVE_0_EVENT_TYPES
+
+
+def test_measurement_constants_are_a_separate_channel():
+    """Measurement constants (§3.2/§6.3) target audit.coordination_measurements,
+    NOT the failure channel: they match migration 041's CHECK regex
+    (`^measurement(\\.[a-z0-9_]+)+$`, digits legal), are absent from
+    WAVE_0_EVENT_TYPES, and are rejected by the failure-channel validator."""
+    import re
+
+    from src.coordination_events import MEASUREMENT_EVENT_TYPES
+
+    assert MEASUREMENT_EVENT_TYPES == {
+        "measurement.governance_mcp.request",
+        "measurement.governance_mcp.503_emission",
+    }
+    for et in MEASUREMENT_EVENT_TYPES:
+        assert re.fullmatch(r"measurement(\.[a-z0-9_]+)+", et), et
+        assert et not in WAVE_0_EVENT_TYPES
+        with pytest.raises(ValueError):
+            _validate_event_type(et)
 
 
 def test_beam_python_boundary_constants_pass_validation():

--- a/tests/test_coordination_events_helpers.py
+++ b/tests/test_coordination_events_helpers.py
@@ -146,3 +146,69 @@ class TestEnumIntegrity:
             "decode_error",
             "other",
         })
+
+
+class TestMakeShadowDivergencePayload:
+    """Wave 3 §8.2 shadow-divergence payload contract (prereq PR #1)."""
+
+    def _make(self, **overrides):
+        from governance_core.coordination_events_helpers import (
+            make_shadow_divergence_payload,
+        )
+
+        kwargs = dict(
+            table_name="identities",
+            agent_id="ag-123",
+            kind="column_mismatch",
+            divergent_columns=["status", "metadata"],
+        )
+        kwargs.update(overrides)
+        return make_shadow_divergence_payload(**kwargs)
+
+    def test_column_mismatch_happy_path_and_key_order(self):
+        payload = self._make()
+        assert payload == {
+            "table_name": "identities",
+            "agent_id": "ag-123",
+            "kind": "column_mismatch",
+            "divergent_columns": ["status", "metadata"],
+        }
+        assert list(payload.keys()) == [
+            "table_name", "agent_id", "kind", "divergent_columns",
+        ]
+
+    def test_missing_row_kinds_require_empty_columns(self):
+        payload = self._make(kind="shadow_missing", divergent_columns=[])
+        assert payload["divergent_columns"] == []
+        payload = self._make(kind="canonical_missing", divergent_columns=[])
+        assert payload["kind"] == "canonical_missing"
+
+    def test_column_mismatch_requires_columns(self):
+        with pytest.raises(ValueError, match="divergent column"):
+            self._make(divergent_columns=[])
+
+    def test_missing_kind_rejects_columns(self):
+        with pytest.raises(ValueError, match="wholesale"):
+            self._make(kind="shadow_missing", divergent_columns=["status"])
+
+    def test_unknown_table_rejected(self):
+        with pytest.raises(ValueError, match="table_name"):
+            self._make(table_name="dialectic_sessions")
+
+    def test_unknown_kind_rejected(self):
+        with pytest.raises(ValueError, match="kind"):
+            self._make(kind="drifted")
+
+    def test_empty_agent_id_rejected(self):
+        with pytest.raises(ValueError, match="agent_id"):
+            self._make(agent_id="  ")
+
+    def test_non_list_columns_rejected(self):
+        with pytest.raises(TypeError, match="divergent_columns"):
+            self._make(divergent_columns="status")
+
+    def test_returns_fresh_list(self):
+        cols = ["status"]
+        payload = self._make(divergent_columns=cols)
+        cols.append("mutated")
+        assert payload["divergent_columns"] == ["status"]

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -139,6 +139,10 @@ async def ensure_test_database_schema() -> None:
         # grammar CHECK). Applied last here so the bootstrap order matches the
         # production numeric apply-order (042 > 036); it only depends on 026.
         await _execute_sql_file(conn, "db/postgres/migrations/042_lease_plane_agent_scheme.sql")
+        # Migrations 043/044: Wave 3 §8.1 shadow tables (LIKE core.identities /
+        # core.agents INCLUDING ALL — depend only on schema.sql base tables).
+        await _execute_sql_file(conn, "db/postgres/migrations/043_identities_shadow.sql")
+        await _execute_sql_file(conn, "db/postgres/migrations/044_agents_shadow.sql")
 
         # Ensure partitioned audit tables can accept inserts for current month.
         await _execute_sql_file(conn, "db/postgres/partitions.sql")

--- a/tests/test_migration_043_044_shadow_tables.py
+++ b/tests/test_migration_043_044_shadow_tables.py
@@ -1,0 +1,177 @@
+"""
+Schema tests for migrations 043/044 — the Wave 3 §8.1 shadow tables.
+
+core.identities_shadow / core.agents_shadow are write-only audit replicas
+created with `LIKE <canonical> INCLUDING ALL` plus a `shadow_write_at`
+timestamp. These tests pin the §8.1 contract: column parity with canonical
+(modulo shadow_write_at), no foreign keys (deliberate — see migration
+headers), the comparator's unique join keys copied, and inserts accepted.
+"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+try:
+    import asyncpg
+except ImportError:
+    pytest.skip("asyncpg not installed", allow_module_level=True)
+
+from tests.test_db_utils import (
+    TEST_DB_URL,
+    can_connect_to_test_db,
+    ensure_test_database_schema,
+)
+
+if not can_connect_to_test_db():
+    pytest.skip("governance_test database not available", allow_module_level=True)
+
+PAIRS = (("identities", "identities_shadow"), ("agents", "agents_shadow"))
+
+_SHAPE_SQL = """
+    SELECT column_name, data_type
+    FROM information_schema.columns
+    WHERE table_schema = 'core' AND table_name = $1
+    ORDER BY ordinal_position
+"""
+
+
+@pytest.mark.asyncio
+async def test_shadow_tables_column_parity_with_canonical():
+    """Shadow shape == canonical shape + trailing shadow_write_at. This is the
+    same invariant db/postgres/schema_drift_check.sh gates operationally."""
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        for canonical, shadow in PAIRS:
+            canon_cols = [
+                (r["column_name"], r["data_type"])
+                for r in await conn.fetch(_SHAPE_SQL, canonical)
+            ]
+            shadow_cols = [
+                (r["column_name"], r["data_type"])
+                for r in await conn.fetch(_SHAPE_SQL, shadow)
+            ]
+            assert canon_cols, f"core.{canonical} missing from test schema"
+            assert shadow_cols, f"core.{shadow} missing — migrations 043/044 not applied"
+            assert shadow_cols[-1] == ("shadow_write_at", "timestamp with time zone"), (
+                f"core.{shadow} must end with shadow_write_at timestamptz, "
+                f"got {shadow_cols[-1]}"
+            )
+            assert shadow_cols[:-1] == canon_cols, (
+                f"core.{shadow} drifted from core.{canonical}: "
+                f"{set(shadow_cols[:-1]) ^ set(canon_cols)}"
+            )
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_shadow_write_at_not_null_with_default():
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        for _, shadow in PAIRS:
+            row = await conn.fetchrow(
+                """
+                SELECT is_nullable, column_default
+                FROM information_schema.columns
+                WHERE table_schema = 'core' AND table_name = $1
+                  AND column_name = 'shadow_write_at'
+                """,
+                shadow,
+            )
+            assert row is not None, f"core.{shadow}.shadow_write_at missing"
+            assert row["is_nullable"] == "NO"
+            assert row["column_default"] is not None, (
+                "shadow_write_at needs a now() default so the shadow writer "
+                "never has to supply it"
+            )
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_shadow_tables_have_no_foreign_keys():
+    """§8.1 FK decision: shadows are write-only audit replicas, no FKs.
+    LIKE ... INCLUDING ALL does not copy FKs; this pins that nobody adds one."""
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        for _, shadow in PAIRS:
+            fk_count = await conn.fetchval(
+                """
+                SELECT count(*) FROM pg_constraint
+                WHERE conrelid = ('core.' || $1)::regclass AND contype = 'f'
+                """,
+                shadow,
+            )
+            assert fk_count == 0, f"core.{shadow} must not carry FK constraints"
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_identities_shadow_copied_unique_agent_id_index():
+    """The §8.2 comparator full-outer-joins USING (agent_id); the canonical
+    unique index must be copied to the shadow by INCLUDING ALL."""
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    try:
+        defs = [
+            r["indexdef"]
+            for r in await conn.fetch(
+                """
+                SELECT indexdef FROM pg_indexes
+                WHERE schemaname = 'core' AND tablename = 'identities_shadow'
+                """
+            )
+        ]
+        assert any(
+            "UNIQUE" in d and "(agent_id)" in d for d in defs
+        ), f"no unique agent_id index on core.identities_shadow; have: {defs}"
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_shadow_tables_accept_writer_shaped_inserts():
+    """A row shaped like the shadow writer's output (explicit join key,
+    defaults for the rest) inserts cleanly into both shadows."""
+    await ensure_test_database_schema()
+    conn = await asyncpg.connect(TEST_DB_URL)
+    marker = f"shadow-test-{uuid.uuid4().hex[:12]}"
+    try:
+        await conn.execute(
+            """
+            INSERT INTO core.identities_shadow (identity_id, agent_id, api_key_hash)
+            VALUES (
+                (SELECT COALESCE(max(identity_id), 0) + 1000000 FROM core.identities_shadow),
+                $1,
+                'shadow-test-hash'
+            )
+            """,
+            marker,
+        )
+        await conn.execute(
+            "INSERT INTO core.agents_shadow (id, api_key) VALUES ($1, 'shadow-test-key')",
+            marker,
+        )
+        got = await conn.fetchval(
+            "SELECT shadow_write_at IS NOT NULL FROM core.identities_shadow WHERE agent_id = $1",
+            marker,
+        )
+        assert got is True
+    finally:
+        await conn.execute(
+            "DELETE FROM core.identities_shadow WHERE agent_id = $1", marker
+        )
+        await conn.execute("DELETE FROM core.agents_shadow WHERE id = $1", marker)
+        await conn.close()

--- a/tests/test_wave3_shadow_divergence_runner.py
+++ b/tests/test_wave3_shadow_divergence_runner.py
@@ -1,0 +1,123 @@
+"""Unit tests for scripts/ops/wave3_shadow_divergence_check.py (PR #597
+council fold) — the alias→column derivation and row-kind logic, plus a drift
+guard pinning the comparator's alias contract.
+
+The runner derives the payload's `divergent_columns` by stripping `_diff`
+from the comparator's SQL aliases. The original §8.2 sketch used abbreviated
+aliases (provisional_diff, allow_rebind_diff, ...) which produced names
+matching no real column — caught in council review. The contract is now:
+every diff alias is exactly `<canonical_column>_diff`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+_RUNNER_PATH = project_root / "scripts" / "ops" / "wave3_shadow_divergence_check.py"
+_SQL_PATH = project_root / "scripts" / "ops" / "wave-3-shadow-divergence-check.sql"
+
+spec = importlib.util.spec_from_file_location("wave3_shadow_divergence_check", _RUNNER_PATH)
+runner = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(runner)
+
+# Canonical column sets, pinned from the live schema 2026-06-10 (the
+# migration-parity tests in test_migration_043_044_shadow_tables.py keep the
+# shadow tables aligned with canonical; this pins the comparator's aliases
+# against the same shape).
+IDENTITIES_COLUMNS = {
+    "identity_id", "agent_id", "api_key_hash", "created_at", "updated_at",
+    "disabled_at", "parent_agent_id", "spawn_reason", "status", "metadata",
+    "metadata_tsv", "last_activity_at", "provisional_lineage",
+    "provisional_score_id", "provisional_recorded_at", "confirmed_at",
+    "lineage_declared_at", "lineage_demoted_at", "lineage_archived_at",
+    "lineage_last_eval_at", "chain_obs_count",
+}
+AGENTS_COLUMNS = {
+    "id", "api_key", "status", "purpose", "notes", "tags", "created_at",
+    "updated_at", "archived_at", "parent_agent_id", "spawn_reason", "label",
+    "thread_id", "thread_position", "allow_rebind_after_exit",
+    "allow_concurrent_contexts",
+}
+
+
+def _aliases_per_statement() -> list[set[str]]:
+    """Extract `AS <name>_diff` aliases per comparator statement."""
+    sql = _SQL_PATH.read_text()
+    blocks = sql.split("-- core.agents divergence")
+    assert len(blocks) == 2, "comparator file structure changed"
+    return [
+        set(re.findall(r"AS\s+([a-z0-9_]+)_diff\b", block)) for block in blocks
+    ]
+
+
+def test_every_sql_alias_stem_is_a_canonical_column():
+    """Drift guard for the alias contract: stripping `_diff` from every
+    comparator alias must yield a real canonical column name."""
+    ident_aliases, agent_aliases = _aliases_per_statement()
+    assert ident_aliases, "no identities aliases found — regex or file drift"
+    assert agent_aliases, "no agents aliases found — regex or file drift"
+    bad_ident = ident_aliases - IDENTITIES_COLUMNS
+    bad_agent = agent_aliases - AGENTS_COLUMNS
+    assert not bad_ident, f"identities aliases not matching canonical columns: {bad_ident}"
+    assert not bad_agent, f"agents aliases not matching canonical columns: {bad_agent}"
+
+
+def test_row_kind_three_kinds():
+    assert runner._row_kind({"canonical_missing": True, "shadow_missing": False}) == "canonical_missing"
+    assert runner._row_kind({"canonical_missing": False, "shadow_missing": True}) == "shadow_missing"
+    assert runner._row_kind({"canonical_missing": False, "shadow_missing": False}) == "column_mismatch"
+
+
+def test_divergent_columns_returns_exact_canonical_names():
+    row = {
+        "table_name": "identities",
+        "agent_id": "ag-1",
+        "canonical_missing": False,
+        "shadow_missing": False,
+        "provisional_lineage_diff": True,
+        "lineage_declared_at_diff": True,
+        "status_diff": False,
+        "metadata_diff": None,  # NULL boolean from SQL — must not count
+    }
+    cols = runner._divergent_columns(row)
+    assert cols == ["lineage_declared_at", "provisional_lineage"]
+    for c in cols:
+        assert c in IDENTITIES_COLUMNS
+
+
+def test_divergent_columns_excludes_non_diff_keys_and_handles_agents():
+    row = {
+        "table_name": "agents",
+        "agent_id": "ag-2",
+        "canonical_missing": False,
+        "shadow_missing": False,
+        "allow_rebind_after_exit_diff": True,
+        "allow_concurrent_contexts_diff": True,
+        "tags_diff": True,
+    }
+    cols = runner._divergent_columns(row)
+    assert cols == ["allow_concurrent_contexts", "allow_rebind_after_exit", "tags"]
+    for c in cols:
+        assert c in AGENTS_COLUMNS
+
+
+def test_missing_row_has_empty_divergent_columns():
+    """A shadow_missing row carries NULL diff booleans (full outer join) —
+    the derived column list must be empty, matching the payload helper's
+    kind/columns coherence rule."""
+    row = {
+        "table_name": "identities",
+        "agent_id": "ag-3",
+        "canonical_missing": False,
+        "shadow_missing": True,
+        "status_diff": None,
+        "metadata_diff": None,
+    }
+    assert runner._divergent_columns(row) == []
+    assert runner._row_kind(row) == "shadow_missing"


### PR DESCRIPTION
Implements row 1 of the Wave 3 §14 prereq sequence (`docs/proposals/beam-wave-3-handler-dispatch.md`, v0.3.2) — the designated first-lander. Operator move-forward decision 2026-06-03: stop gating on unwired experiments, ship the §14 prereq PRs.

## What ships

**Shadow DDL (§8.1)** — migrations 043/044 create `core.identities_shadow` / `core.agents_shadow` via `LIKE … INCLUDING ALL` + `shadow_write_at`. No FKs, by design (write-only audit replicas; decision documented inline per the RFC). The shared-sequence consequence of copying `identity_id`'s default is documented rather than hidden. `db/postgres/schema_drift_check.sh` gates canonical↔shadow shape parity (exit 2 = no DB ≠ exit 1 = drift, so CI wiring can't silently false-pass).

**Comparator + runner (§8.2)** — `scripts/ops/wave-3-shadow-divergence-check.sql` is the RFC's full-outer-join comparator, column set **live-schema-verified 2026-06-10** (all referenced columns exist; deliberate omissions — serial PK, writer-local `created_at`/`updated_at`, generated `metadata_tsv` — documented in the file header). `wave3_shadow_divergence_check.py` + hourly launchd template emit one `shadow_divergence` event per row, **inert-by-construction until the shadow window starts** (empty shadow tables would read as wall-to-wall `shadow_missing` noise; the runner skips emission for a table whose shadow is empty and says so in its log).

**Replay harness (§8.3)** — `wave3-shadow-replay.sh`/`.py`: JSONL capture replay at `--rate` (default 2×), stdlib-only, **requires explicit `--target`** and refuses live-MCP-looking targets without `--allow-live-target`. Non-zero exit on any error so the "replay completes clean" precondition is machine-checkable.

**Event types (§8.4)** — `shadow_divergence`, `ets_pg_divergence`, `cutover_503_rate_breach` constants + payload contracts into `WAVE_0_EVENT_TYPES`; `measurement.governance_mcp.{request,503_emission}` (§3.2 numerator/denominator) land as a separate `MEASUREMENT_EVENT_TYPES` channel — deliberately rejected by the failure-channel validator since they target `audit.coordination_measurements`.

**Ordering gate (§14)** — `scripts/dev/check-wave3-ode-prereq.sh` passes until an `elixir/handler_dispatch/` tree exists, then requires the prereq artifacts + the §5.2 audit artifact.

**Helper (§6.4)** — `make_shadow_divergence_payload` added to `governance_core/coordination_events_helpers.py`; runner emissions go through it.

## Spec adaptations for council attention

1. **§6.4 vs §8.2 payload tension**: §6.4 says all `beam_python_boundary.*` emissions go through `make_boundary_payload`, but §8.2's shadow payload has a different shape. Resolved by adding a sibling helper rather than exempting the emitter — keeps the construction-centralized enforcement story.
2. **Gitignored audit artifact**: §14 gates `elixir/handler_dispatch/` on a `docs/handoffs/…` artifact, but `docs/handoffs/` is gitignored — CI-unenforceable as written. The lint accepts EITHER the local handoff OR a committed summary at `docs/proposals/wave-3-section-5-2-boundary-audit-summary.md`.
3. **`ets_pg_divergence` payload**: §10.3 pins `{key, ets_value_hash, pg_value_hash}`; a `store` discriminator is added because two ETS tables share the event type and §10.2's readiness-gated-`:cold` path is a second emitter.
4. **Live-schema note**: migration 041's measurements CHECK is `^measurement(\.[a-z0-9_]+)+$` — digits legal (so `503_emission` works), and the RFC §6.1 sketch's `telemetry` family was never shipped; documented in the constants block.

## Explicitly NOT in this PR

- The §5.2 boundary-cost audit **document** (a local `docs/handoffs/` deliverable; being produced alongside, not committable).
- The BEAM shadow **writer** (Wave 3 implementation — nothing writes to the shadow tables yet; the comparator runner is inert until it does).
- The ODE profile commit component of §14 row 1 — already on master since PR #481; disconfirmer A.1 ran 2026-06-03 (p99 5181ms, math 0.8% → §11.4 passes).

## Verification

- 53 focused tests green (constants drift-guards, helper contract, 5 migration schema pins against `governance_test`).
- `schema_drift_check.sh` exit 0 against `governance_test` with 043/044 applied.
- Divergence runner smoke against `governance_test` (SQL split + inert gate exercised).
- Replay harness dry-run smoke.
- Post-merge operational step: apply 043/044 to the live governance DB (additive; tracked in `core.schema_migrations` — note the deploy scripts do NOT run migrations).
