### PR TITLE
fix(identity): anonymous auto-mint must not use the reserved 'mcp_' prefix

### DIFF
--- a/src/mcp_handlers/identity/resolution.py
+++ b/src/mcp_handlers/identity/resolution.py
@@ -133,7 +133,7 @@ def _generate_agent_id(model_type: Optional[str] = None, client_hint: Optional[s
     1. model_type with third-party client -> "Client_Model_20251227"
     2. model_type alone -> "Model_20251227"
     3. client_hint -> "client_20251227"
-    4. fallback -> "mcp_20251227"
+    4. fallback -> "anon_20251227"
 
     Args:
         model_type: Model identifier (e.g., "claude-opus-4-5", "gemini-pro")

--- a/src/mcp_handlers/identity/resolution.py
+++ b/src/mcp_handlers/identity/resolution.py
@@ -169,7 +169,16 @@ def _generate_agent_id(model_type: Optional[str] = None, client_hint: Optional[s
         client = client_hint.strip().lower()
         return f"{client}_{timestamp}"
     else:
-        return f"mcp_{timestamp}"
+        # Anonymous fallback. MUST NOT use a reserved prefix — the historical
+        # f"mcp_{timestamp}" mint collided with validators.
+        # validate_agent_id_reserved_names (RESERVED_PREFIXES includes 'mcp_'),
+        # so every anonymous session's tool calls were rejected with
+        # error_type=reserved_prefix. Invisible while tool_usage.success was
+        # hardcoded-true; surfaced 2026-06-10 after PR #543 made recording
+        # honest (~22-26k failure rows/day, all from auto-minted callers).
+        # The mint↔gate coupling is pinned by tests/test_identity_core.py::
+        # TestGenerateAgentId::test_auto_minted_names_pass_reserved_names_gate.
+        return f"anon_{timestamp}"
 
 
 def _generate_auto_label(model_type: Optional[str] = None, client_hint: Optional[str] = None) -> Optional[str]:

--- a/tests/test_identity_agent_id.py
+++ b/tests/test_identity_agent_id.py
@@ -157,7 +157,7 @@ class TestResolveSessionIdentityAgentId:
 
     @pytest.mark.asyncio
     async def test_new_agent_without_model_uses_anon_fallback(self):
-        """New agent without model_type should get mcp_ prefix."""
+        """New agent without model_type falls back to the anon_ prefix."""
         from src.mcp_handlers.identity.handlers import resolve_session_identity
 
         today = datetime.now().strftime("%Y%m%d")

--- a/tests/test_identity_agent_id.py
+++ b/tests/test_identity_agent_id.py
@@ -71,22 +71,24 @@ class TestGenerateAgentId:
         result = _generate_agent_id(model_type=None, client_hint="vscode")
         assert result == f"vscode_{today}"
 
-    def test_mcp_fallback(self):
-        """Without model_type or client_hint, should use 'mcp' prefix."""
+    def test_anon_fallback(self):
+        """Without model_type or client_hint, falls back to the 'anon' prefix
+        (non-reserved — 'mcp_' is in the validators' RESERVED_PREFIXES, and
+        minting it caused every anonymous caller to be rejected)."""
         from src.mcp_handlers.identity.handlers import _generate_agent_id
 
         today = datetime.now().strftime("%Y%m%d")
 
         # Neither model_type nor client_hint
         result = _generate_agent_id(model_type=None, client_hint=None)
-        assert result == f"mcp_{today}"
+        assert result == f"anon_{today}"
 
         # Empty strings should also fallback
         result = _generate_agent_id(model_type=None, client_hint="")
-        assert result == f"mcp_{today}"
+        assert result == f"anon_{today}"
 
         result = _generate_agent_id(model_type=None, client_hint="unknown")
-        assert result == f"mcp_{today}"
+        assert result == f"anon_{today}"
 
     def test_third_party_client_prefixed(self):
         """Third-party client using a model should be prefixed to prevent identity confusion."""
@@ -154,7 +156,7 @@ class TestResolveSessionIdentityAgentId:
             assert "agent_uuid" in result
 
     @pytest.mark.asyncio
-    async def test_new_agent_without_model_uses_mcp(self):
+    async def test_new_agent_without_model_uses_anon_fallback(self):
         """New agent without model_type should get mcp_ prefix."""
         from src.mcp_handlers.identity.handlers import resolve_session_identity
 
@@ -176,7 +178,7 @@ class TestResolveSessionIdentityAgentId:
             )
 
             assert result["created"] is True
-            assert result["agent_id"] == f"mcp_{today}"
+            assert result["agent_id"] == f"anon_{today}"
 
 
 class TestOnboardAgentIdResponse:
@@ -237,7 +239,7 @@ class TestEdgeCases:
         # Empty string - should not crash
         result = _generate_agent_id("")
         # Empty string is falsy, so should fallback to mcp_
-        assert result == f"mcp_{today}"
+        assert result == f"anon_{today}"
 
 
 if __name__ == "__main__":

--- a/tests/test_identity_core.py
+++ b/tests/test_identity_core.py
@@ -153,13 +153,13 @@ class TestGenerateAgentId:
 
     def test_client_hint_with_spaces_rejected(self):
         # Spaces are not valid in a client_hint shape — descriptors must not
-        # become identifiers. Falls through to mcp_DATE.
+        # become identifiers. Falls through to anon_DATE.
         result = self.generate(client_hint="my editor")
-        assert result.startswith("mcp_")
+        assert result.startswith("anon_")
 
     def test_fallback_no_args(self):
         result = self.generate()
-        assert result.startswith("mcp_")
+        assert result.startswith("anon_")
 
     def test_third_party_client_prefixed_with_model(self):
         result = self.generate(model_type="gemini-pro", client_hint="cursor")
@@ -172,11 +172,37 @@ class TestGenerateAgentId:
 
     def test_empty_client_hint_fallback(self):
         result = self.generate(client_hint="")
-        assert result.startswith("mcp_")
+        assert result.startswith("anon_")
 
     def test_unknown_client_hint_fallback(self):
         result = self.generate(client_hint="unknown")
-        assert result.startswith("mcp_")
+        assert result.startswith("anon_")
+
+    def test_auto_minted_names_pass_reserved_names_gate(self):
+        # The mint↔gate coupling test that was missing for months: the
+        # auto-mint MUST produce names the reserved-names security gate
+        # accepts. The historical default f"mcp_{timestamp}" was minted by
+        # the server and then rejected by the server ('mcp_' is in
+        # RESERVED_PREFIXES) — every anonymous poller failed every tool call
+        # with error_type=reserved_prefix, invisible until PR #543 made
+        # tool_usage.success honest (live incident, 2026-06-10).
+        from src.mcp_handlers.validators import validate_agent_id_reserved_names
+
+        for kwargs in (
+            {},                              # bare anonymous session
+            {"client_hint": "my editor"},    # invalid hint → fallback
+            {"client_hint": ""},             # empty hint → fallback
+            {"client_hint": "unknown"},      # filtered hint → fallback
+            {"model_type": "claude-opus-4-5", "client_hint": "claude_desktop"},
+            {"client_hint": "cursor"},
+        ):
+            minted = self.generate(**kwargs)
+            ok, err = validate_agent_id_reserved_names(minted)
+            assert err is None, (
+                f"auto-mint produced {minted!r} which the reserved-names "
+                f"gate rejects — server would refuse its own identity"
+            )
+            assert ok == minted
 
     def test_whitespace_model_type(self):
         result = self.generate(model_type="  claude-haiku  ")

--- a/tests/test_identity_core.py
+++ b/tests/test_identity_core.py
@@ -204,6 +204,22 @@ class TestGenerateAgentId:
             )
             assert ok == minted
 
+        # KNOWN GAP, pinned deliberately (council 2026-06-10): a model_type
+        # or client_hint that BEGINS with a reserved family word still mints
+        # a name the gate rejects — e.g. model_type="governance-core" →
+        # "Governance_Core_<date>" → reserved prefix 'governance_' (the gate
+        # lowercases before matching). Same incident class as the anonymous
+        # fallback, for NAMED callers; rare today (no real model/client name
+        # starts with a reserved word) and the mint-side remedy is an
+        # identity-surface design call — tracked as a follow-up. Pinned here
+        # so the gap stays visible instead of silent:
+        named_collision = self.generate(model_type="governance-core")
+        _, err = validate_agent_id_reserved_names(named_collision)
+        assert err is not None, (
+            "named reserved-word collision unexpectedly resolved — update "
+            "this pin, the coupling-test scope, and close the follow-up"
+        )
+
     def test_whitespace_model_type(self):
         result = self.generate(model_type="  claude-haiku  ")
         assert result.startswith("Claude_Haiku_")

--- a/tests/test_identity_helpers.py
+++ b/tests/test_identity_helpers.py
@@ -114,18 +114,18 @@ class TestGenerateAgentId:
         result = _generate_agent_id(model_type="claude-opus-4-5", client_hint="cursor")
         assert "Cursor_Claude_Opus_4_5" in result
 
-    def test_fallback_mcp(self):
+    def test_fallback_anon(self):
         result = _generate_agent_id()
-        assert result.startswith("mcp_")
+        assert result.startswith("anon_")
         assert datetime.now().strftime("%Y%m%d") in result
 
     def test_unknown_client_hint_falls_back(self):
         result = _generate_agent_id(client_hint="unknown")
-        assert result.startswith("mcp_")
+        assert result.startswith("anon_")
 
     def test_empty_client_hint_falls_back(self):
         result = _generate_agent_id(client_hint="")
-        assert result.startswith("mcp_")
+        assert result.startswith("anon_")
 
     def test_none_model_with_valid_client(self):
         result = _generate_agent_id(model_type=None, client_hint="vscode")
@@ -153,19 +153,19 @@ class TestClientHintLeakRegression:
         bug_input = "Anthropic Claude, mobile app, dogfooding UX review"
         result = _generate_agent_id(client_hint=bug_input)
         assert bug_input not in result
-        assert result.startswith("mcp_")
+        assert result.startswith("anon_")
 
     def test_long_hint_rejected(self):
         result = _generate_agent_id(client_hint="x" * 41)
-        assert result.startswith("mcp_")
+        assert result.startswith("anon_")
 
     def test_hint_with_spaces_rejected(self):
         result = _generate_agent_id(client_hint="cursor with extra context")
-        assert result.startswith("mcp_")
+        assert result.startswith("anon_")
 
     def test_hint_with_punctuation_rejected(self):
         result = _generate_agent_id(client_hint="cursor, v1.2.3")
-        assert result.startswith("mcp_")
+        assert result.startswith("anon_")
 
     def test_valid_short_hints_still_work(self):
         for hint in ("cursor", "vscode", "claude_desktop", "claude-code", "chatgpt"):

--- a/tests/test_identity_v2_redis.py
+++ b/tests/test_identity_v2_redis.py
@@ -111,7 +111,7 @@ class TestGenerateAgentId:
 
     def test_fallback(self):
         result = self.generate()
-        assert result.startswith("mcp_")
+        assert result.startswith("anon_")
 
     def test_third_party_client_prefixed(self):
         result = self.generate(model_type="gemini-pro", client_hint="cursor")
@@ -119,11 +119,11 @@ class TestGenerateAgentId:
 
     def test_empty_client_hint_uses_fallback(self):
         result = self.generate(client_hint="")
-        assert result.startswith("mcp_")
+        assert result.startswith("anon_")
 
     def test_unknown_client_hint_uses_fallback(self):
         result = self.generate(client_hint="unknown")
-        assert result.startswith("mcp_")
+        assert result.startswith("anon_")
 
 
 # ============================================================================


### PR DESCRIPTION
## The bug

The server rejects its own auto-minted identities. Anonymous MCP sessions get minted `mcp_<date>` (`resolution.py` fallback), and `validate_agent_id_reserved_names` blocks the `mcp_` prefix ('privilege confusion' gate). Result: **every anonymous caller fails every gated tool call** with `error_type=reserved_prefix`.

## Evidence (live, 2026-06-10)

- `audit.tool_usage`: 22-26k failures/day on `get_governance_metrics` since 2026-05-30; eight long-lived poller identities (`mcp_20260406` … `mcp_20260602`) each 2815 fails / 0 successes per 24h at ~30s cadence.
- Reproduced: `tools/call get_governance_metrics {agent_id: mcp_20260417}` → `SECURITY: agent_id 'mcp_20260417' uses reserved prefix`.
- The 2026-05-30 'onset' is **measurement onset**: `tool_usage.success` was hardcoded-true until PR #543 (same day). Pre-#543 'successes' from these callers were fake. The collision dates from the gate's landing (`c4fe4b58`, Security Priority 1).

## The fix (deliberately minimal)

Rename the mint fallback to `anon_<date>` — a non-reserved prefix. **The security gate is unchanged**: the alternative (provenance-exempting server-resolved names from the gate) weakens the gate's semantics and touches the middleware; renaming the mint keeps the threat model intact (callers still cannot claim `mcp_*`/`system_*`/etc).

New coupling test: every auto-mint shape must pass the reserved-names gate — the structurally missing test that allowed mint and gate to drift into collision.

## Post-merge

- Deploy (kickstart) → new anonymous resolutions mint `anon_*` and pass.
- Existing broken sticky bindings heal as they re-resolve; if residual `mcp_*` failures persist >30min post-deploy, targeted sweep of those bindings.
- Watch: `audit.tool_usage` failure rate on `get_governance_metrics` should collapse to ~0.

Suite: 9246 passed (staged full gate).