### PR TITLE
fix(identity): role-family comparison in cross-role lineage envelope

### DIFF
--- a/docs/ontology/identity.md
+++ b/docs/ontology/identity.md
@@ -115,6 +115,35 @@ The taxonomy + axioms provide a gate for each existing mechanism:
 
 A sequenced plan for these belongs in a separate document. The taxonomy + axioms let planning proceed without re-opening ontology.
 
+### Cross-role lineage envelope (role families)
+
+Lineage declaration is gated at onboard by a cross-role pre-check
+(`pre_check_cross_role`, `src/identity/lineage_lifecycle.py`): a successor
+may only declare a parent whose **role family** matches its own. The unit
+of enforcement is the family, not the atomic class tag, because tags
+encode two different things — *role* (ephemeral process vs. resident vs.
+embodied) and *lifecycle stage within a role* (S8a promotion renames
+`ephemeral → engaged_ephemeral` on engagement). Promotion is a lifecycle
+stage, not a role change: a promoted parent remains the same kind of
+thing its successor is, and severing lineage on promotion would punish
+exactly the agents that earned engagement (audited 2026-06-10: every
+`lineage_cross_role_rejected` event on record was this false positive).
+
+The families (`ROLE_FAMILIES`, `src/identity/trajectory_continuity.py`):
+the ephemeral cohort (`ephemeral`, `engaged_ephemeral`, reserved
+`session_like`) is one family; `embodied` and `persistent` are each their
+own family — substrate-to-substrate lineage (a Lumen declaring a resident,
+or vice versa) remains cross-role. Unknown tags are strict by default:
+they match only their own kind until explicitly placed in a family, and
+any tag-rename promotion path must keep source and target in one family
+(pinned by `test_role_family_map_covers_promotion_path`).
+
+What the envelope protects is R1's shared-operating-envelope assumption
+(per `r2-honest-memory-integration.md`): trajectory-continuity scoring
+compares EISV dynamics assuming comparable operating conditions. A
+within-role lifecycle stage does not violate that assumption; a role
+change does.
+
 ## Open questions
 
 - **Trajectory portability.** When a prior process-instance's trajectory informs a successor's priors, is the successor inheriting identity or inheriting data? Answer probably depends on whether the successor *integrates* the prior's trajectory (identity-adjacent, per axiom #12) or merely *reads* it (data-only).

--- a/docs/ontology/r2-honest-memory-integration.md
+++ b/docs/ontology/r2-honest-memory-integration.md
@@ -99,10 +99,22 @@ If R2 silently allows cross-role declarations through to the demotion path, the 
 **Pre-check rule.** At onboard, when `parent_agent_id` is provided:
 1. Look up parent's class tags (`core.identities.metadata.class_tags` per S8a).
 2. Compare to successor's class tags (which are stamped at onboard per S8a Phase 2).
-3. If the primary class tag differs, **reject the lineage declaration** with audit event `lineage_cross_role_rejected`, payload `{successor_class, parent_class, reason: "role_envelope_mismatch"}`.
+3. If the **role family** differs (`role_family()` in
+   `src/identity/trajectory_continuity.py`), **reject the lineage
+   declaration** with audit event `lineage_cross_role_rejected`, payload
+   `{successor_class, parent_class, successor_family, parent_family, reason:
+   "role_envelope_mismatch"}`. Raw-tag equality was the original rule; it
+   broke on S8a promotion (`ephemeral → engaged_ephemeral` renamed the
+   parent's tag, severing every promoted-parent lineage — 45 false
+   positives, zero true catches, audited 2026-06-10). Promotion is a
+   lifecycle stage within one role, so the ephemeral cohort
+   (`ephemeral`, `engaged_ephemeral`, reserved `session_like`) is one
+   family; this matches the rationale above — what the envelope protects
+   is R1's shared-operating-envelope assumption, which a within-role
+   lifecycle stage does not violate.
 4. Successor proceeds with no `parent_agent_id` recorded. The `parent_agent_id` value the agent supplied is logged in the audit event but not written to `core.identities`.
 
-**Caveat.** S8a's class-tag taxonomy is itself evolving. The pre-check defers to S8a's taxonomy of-the-day — if S8a adds or splits classes, R2 inherits the change without code modification. If the successor or parent has no class tag (orphan-record path before S8a backfill completes), the pre-check is skipped and the declaration proceeds as same-role (charitable default).
+**Caveat.** S8a's class-tag taxonomy is itself evolving. The pre-check defers to S8a's taxonomy of-the-day — if S8a adds or splits classes, R2 inherits the change without code modification **except** that a new atomic tag must be placed in `ROLE_FAMILIES` (unknown tags are strict-by-default: they match lineage only against their own kind). A tag-rename promotion path must keep source and target in one family — `test_role_family_map_covers_promotion_path` pins this against `class_promotion.py`'s constants. If the successor or parent has no class tag (orphan-record path before S8a backfill completes), the pre-check is skipped and the declaration proceeds as same-role (charitable default).
 
 **Open question #1 (was Q5 in v1):** should cross-role lineage be *flagged-but-allowed* rather than *rejected*? Allow-with-flag preserves operator visibility into "X tried to claim Y's lineage despite role mismatch," which can surface attempted fork-reclassifications. Reject-at-declaration is cleaner but loses that signal. v2 picks reject as default for clean audit semantics; revisit if operator wants the flagged-allow visibility.
 

--- a/src/grounding/onboard_classifier.py
+++ b/src/grounding/onboard_classifier.py
@@ -16,9 +16,10 @@ born outside the explicit onboard handler aren't left untagged. See
 the gap (72 of 200 in-window identities untagged, including a 441-update
 ``claude_desktop-claude`` row).
 
-The ``ephemeral → session_like`` promotion rule lives in the Vigil sweep
-that runs against the corpus this stamp produces; this module deliberately
-stamps only the floor-level class.
+The ``ephemeral → engaged_ephemeral`` promotion rule (S8a Phase-2;
+``session_like`` was the pre-ship name) lives in the Vigil sweep that runs
+against the corpus this stamp produces; this module deliberately stamps
+only the floor-level class.
 """
 from __future__ import annotations
 

--- a/src/identity/lineage_lifecycle.py
+++ b/src/identity/lineage_lifecycle.py
@@ -50,7 +50,10 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Dict, Literal, Optional
 
 from src.db import get_db
-from src.identity.trajectory_continuity import score_trajectory_continuity
+from src.identity.trajectory_continuity import (
+    role_family,
+    score_trajectory_continuity,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -190,9 +193,18 @@ async def pre_check_cross_role(
 ) -> Optional[Dict[str, Any]]:
     """R2 PR 3: cross-role envelope check.
 
-    Returns ``None`` if same-role (declaration may proceed); returns a
-    rejection dict ``{parent_class, successor_class, reason}`` if
-    cross-role.
+    Returns ``None`` if same role-family (declaration may proceed);
+    returns a rejection dict ``{parent_class, successor_class,
+    parent_family, successor_family, reason}`` if cross-family.
+
+    The comparison unit is the role FAMILY (``role_family``), not the
+    raw class tag: S8a Phase-2 promotion renames ``ephemeral`` →
+    ``engaged_ephemeral`` on engagement — a lifecycle stage within one
+    role, not a role change. Raw tag equality (the pre-2026-06-10
+    behavior) rejected every lineage declared against a promoted
+    parent: all 45 ``lineage_cross_role_rejected`` events on record
+    were engaged_ephemeral-parent/ephemeral-successor false positives,
+    and the check had never caught a true cross-role declaration.
 
     Charitable default: if either side has no class tag (orphan path
     before S8a backfill completes, or a parent that was created
@@ -216,11 +228,15 @@ async def pre_check_cross_role(
     parent_class = await backend.read_class_tag(parent_id)
     if parent_class is None or successor_class is None:
         return None
-    if parent_class == successor_class:
+    parent_family = role_family(parent_class)
+    successor_family = role_family(successor_class)
+    if parent_family == successor_family:
         return None
     return {
         "parent_class": parent_class,
         "successor_class": successor_class,
+        "parent_family": parent_family,
+        "successor_family": successor_family,
         "reason": "role_envelope_mismatch",
     }
 

--- a/src/identity/lineage_lifecycle.py
+++ b/src/identity/lineage_lifecycle.py
@@ -202,8 +202,9 @@ async def pre_check_cross_role(
     ``engaged_ephemeral`` on engagement — a lifecycle stage within one
     role, not a role change. Raw tag equality (the pre-2026-06-10
     behavior) rejected every lineage declared against a promoted
-    parent: all 45 ``lineage_cross_role_rejected`` events on record
-    were engaged_ephemeral-parent/ephemeral-successor false positives,
+    parent: every ``lineage_cross_role_rejected`` event on record (45
+    at the 2026-06-10 audit, still accruing until this fix deployed)
+    was an engaged_ephemeral-parent/ephemeral-successor false positive,
     and the check had never caught a true cross-role declaration.
 
     Charitable default: if either side has no class tag (orphan path

--- a/src/identity/trajectory_continuity.py
+++ b/src/identity/trajectory_continuity.py
@@ -90,9 +90,10 @@ _CLASS_TAG_PRIORITY = (
 # enforcement is the FAMILY, not the atomic tag: S8a Phase-2 promotion
 # renames `ephemeral` → `engaged_ephemeral` on engagement, which is a
 # lifecycle stage within one role, not a role change — raw tag equality
-# therefore rejects every promoted-parent lineage (audited 2026-06-10:
-# 45/45 `lineage_cross_role_rejected` events were
-# engaged_ephemeral-parent/ephemeral-successor false positives; zero
+# therefore rejected every promoted-parent lineage (audited 2026-06-10:
+# every `lineage_cross_role_rejected` event on record — 45 at audit, 47
+# by council live-verification the same day — was an
+# engaged_ephemeral-parent/ephemeral-successor false positive; zero
 # true cross-role catches since the check shipped). Substrate tags stay
 # their own families — embodied↔persistent lineage remains rejected, as
 # the existing envelope tests pin.
@@ -101,7 +102,11 @@ ROLE_FAMILIES = {
     "persistent": "persistent",
     "ephemeral": "ephemeral",
     "engaged_ephemeral": "ephemeral",
-    "session_like": "ephemeral",  # reserved tag — same family when it ships
+    # Reserved: `session_like` was the ratified pre-ship name of the
+    # Phase-2 promotion target, renamed to `engaged_ephemeral` at ship
+    # (#252) — if it ever gets a stamp path it ships as this cohort, so
+    # ephemeral-family placement is rename-lineage, not a guess.
+    "session_like": "ephemeral",
 }
 
 

--- a/src/identity/trajectory_continuity.py
+++ b/src/identity/trajectory_continuity.py
@@ -85,6 +85,35 @@ _CLASS_TAG_PRIORITY = (
     "ephemeral",
 )
 
+# Role families for the cross-role lineage envelope
+# (lineage_lifecycle.pre_check_cross_role). The envelope's unit of
+# enforcement is the FAMILY, not the atomic tag: S8a Phase-2 promotion
+# renames `ephemeral` → `engaged_ephemeral` on engagement, which is a
+# lifecycle stage within one role, not a role change — raw tag equality
+# therefore rejects every promoted-parent lineage (audited 2026-06-10:
+# 45/45 `lineage_cross_role_rejected` events were
+# engaged_ephemeral-parent/ephemeral-successor false positives; zero
+# true cross-role catches since the check shipped). Substrate tags stay
+# their own families — embodied↔persistent lineage remains rejected, as
+# the existing envelope tests pin.
+ROLE_FAMILIES = {
+    "embodied": "embodied",
+    "persistent": "persistent",
+    "ephemeral": "ephemeral",
+    "engaged_ephemeral": "ephemeral",
+    "session_like": "ephemeral",  # reserved tag — same family when it ships
+}
+
+
+def role_family(class_tag: str) -> str:
+    """Map an atomic class tag to its lineage-envelope role family.
+
+    Unknown tags map to themselves, so a future tag is strict by
+    default — it only matches lineage against its own kind until
+    explicitly placed in a family here.
+    """
+    return ROLE_FAMILIES.get(class_tag, class_tag)
+
 
 # ---------------------------------------------------------------------------
 # Dataclass — full record returned to internal callers (v3.1 §"Input signature")

--- a/src/sequential_calibration.py
+++ b/src/sequential_calibration.py
@@ -662,7 +662,7 @@ class SequentialCalibrationTracker:
 
         classifier(agent_id) returns the current class_tag (or None to bucket the
         agent's counters into UNKNOWN_CLASS_BUCKET). The walk is full-replacement —
-        old class_states are discarded so a promotion (ephemeral → session_like)
+        old class_states are discarded so a promotion (ephemeral → engaged_ephemeral)
         moves the counters cleanly rather than leaving the donor bucket inflated.
 
         IMPORTANT: the merged class_states is a descriptive-stats rollup, not an

--- a/tests/test_lineage_cross_role.py
+++ b/tests/test_lineage_cross_role.py
@@ -144,6 +144,133 @@ async def test_pre_check_embodied_parent_rejects_ephemeral():
 
 
 # ---------------------------------------------------------------------------
+# 6a. Role families — promotion is a lifecycle stage, not a role change
+#     (2026-06-10: all 45 rejections on record were
+#     engaged_ephemeral-parent false positives from raw tag equality)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pre_check_promoted_parent_accepts_ephemeral_successor():
+    """parent=engaged_ephemeral (S8a-promoted), successor=ephemeral → accept.
+
+    THE production false-positive case: S8a Phase-2 promotes an engaged
+    parent's tag from `ephemeral` to `engaged_ephemeral`, after which
+    every fresh spawn declaring it as parent was rejected under raw tag
+    equality. Same role family → None.
+    """
+    from src.db import get_db
+    backend = get_db()
+    backend.read_class_tag = AsyncMock(return_value="engaged_ephemeral")
+
+    result = await pre_check_cross_role("promoted-parent-uuid", "ephemeral")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_pre_check_ephemeral_parent_accepts_promoted_successor():
+    """Inverse direction: parent=ephemeral, successor=engaged_ephemeral → accept."""
+    from src.db import get_db
+    backend = get_db()
+    backend.read_class_tag = AsyncMock(return_value="ephemeral")
+
+    result = await pre_check_cross_role("plain-parent-uuid", "engaged_ephemeral")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_pre_check_session_like_in_ephemeral_family():
+    """Reserved `session_like` tag sits in the ephemeral family already."""
+    from src.db import get_db
+    backend = get_db()
+    backend.read_class_tag = AsyncMock(return_value="engaged_ephemeral")
+
+    result = await pre_check_cross_role("promoted-parent-uuid", "session_like")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_pre_check_promoted_parent_still_rejects_substrate_successor():
+    """Family fix does not loosen the substrate envelope.
+
+    parent=persistent, successor=engaged_ephemeral → still cross-family.
+    The rejection dict now carries both raw classes and their families
+    so the audit event distinguishes tag-level from family-level data.
+    """
+    from src.db import get_db
+    backend = get_db()
+    backend.read_class_tag = AsyncMock(return_value="persistent")
+
+    result = await pre_check_cross_role("resident-uuid", "engaged_ephemeral")
+
+    assert result is not None
+    assert result["parent_class"] == "persistent"
+    assert result["successor_class"] == "engaged_ephemeral"
+    assert result["parent_family"] == "persistent"
+    assert result["successor_family"] == "ephemeral"
+    assert result["reason"] == "role_envelope_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_pre_check_substrate_tags_stay_distinct_families():
+    """embodied vs persistent are different roles, not one substrate family.
+
+    The family map merges only lifecycle stages of the SAME role
+    (ephemeral cohort). Lumen declaring lineage to a resident — or vice
+    versa — remains cross-role.
+    """
+    from src.db import get_db
+    backend = get_db()
+    backend.read_class_tag = AsyncMock(return_value="embodied")
+
+    result = await pre_check_cross_role("lumen-uuid", "persistent")
+
+    assert result is not None
+    assert result["parent_family"] == "embodied"
+    assert result["successor_family"] == "persistent"
+
+
+@pytest.mark.asyncio
+async def test_pre_check_unknown_tag_stays_strict():
+    """A tag outside ROLE_FAMILIES maps to itself — strict by default.
+
+    An unknown future tag never silently joins an existing family;
+    against any known class it stays cross-family until explicitly
+    placed in `ROLE_FAMILIES`.
+    """
+    from src.db import get_db
+    backend = get_db()
+    backend.read_class_tag = AsyncMock(return_value="quarantined")
+
+    result = await pre_check_cross_role("odd-parent-uuid", "ephemeral")
+
+    assert result is not None
+    assert result["parent_class"] == "quarantined"
+    assert result["parent_family"] == "quarantined"
+    assert result["successor_family"] == "ephemeral"
+
+
+def test_role_family_map_covers_class_tag_priority():
+    """Every tag in `_CLASS_TAG_PRIORITY` has an explicit family.
+
+    Drift guard: a new atomic class tag added to the priority tuple
+    without a family placement would silently fall into
+    strict-by-default and reproduce the promotion false-positive
+    pattern this fix removed.
+    """
+    from src.identity.trajectory_continuity import (
+        _CLASS_TAG_PRIORITY,
+        ROLE_FAMILIES,
+    )
+
+    missing = [t for t in _CLASS_TAG_PRIORITY if t not in ROLE_FAMILIES]
+    assert missing == []
+
+
+# ---------------------------------------------------------------------------
 # 7. read_class_tag — live DB shape (mirrors test_class_promotion.py
 #    pattern; the mocked backend can't validate JSONB operators)
 # ---------------------------------------------------------------------------

--- a/tests/test_lineage_cross_role.py
+++ b/tests/test_lineage_cross_role.py
@@ -270,6 +270,28 @@ def test_role_family_map_covers_class_tag_priority():
     assert missing == []
 
 
+def test_role_family_map_covers_promotion_path():
+    """The S8a promotion source AND target tags share one family.
+
+    Council fold (PR #601): the original bug was a tag RENAME
+    (ephemeral → engaged_ephemeral) splitting parent from successor.
+    `_CLASS_TAG_PRIORITY` is the scoring tuple, not the mutation path —
+    a future promotion target added to `class_promotion.py` without a
+    priority entry would dodge the guard above. Anchor the guard to the
+    actual tag-mutation constants so any rename keeps both endpoints in
+    the same family (a promotion must never sever lineage).
+    """
+    from src.grounding.class_promotion import (
+        PROMOTION_SOURCE_TAG,
+        PROMOTION_TARGET_TAG,
+    )
+    from src.identity.trajectory_continuity import ROLE_FAMILIES, role_family
+
+    assert PROMOTION_SOURCE_TAG in ROLE_FAMILIES
+    assert PROMOTION_TARGET_TAG in ROLE_FAMILIES
+    assert role_family(PROMOTION_SOURCE_TAG) == role_family(PROMOTION_TARGET_TAG)
+
+
 # ---------------------------------------------------------------------------
 # 7. read_class_tag — live DB shape (mirrors test_class_promotion.py
 #    pattern; the mocked backend can't validate JSONB operators)


### PR DESCRIPTION
## What

`pre_check_cross_role` compared raw class tags. S8a Phase-2 promotion renames `ephemeral` → `engaged_ephemeral`, so every lineage declared against a promoted parent was rejected as cross-role.

**Evidence (audit, 2026-06-10):** 45/45 `lineage_cross_role_rejected` events on record are `engaged_ephemeral`-parent / `ephemeral`-successor false positives. The check has never caught a true cross-role declaration. Found by dogfooding: my own onboard (declaring my prior session UUID as parent) and ~10 of this week's council subagents (declaring the meta-session as parent) all had their lineage silently broken by this.

## Fix

- `ROLE_FAMILIES` + `role_family()` in `trajectory_continuity.py`, co-located with `_CLASS_TAG_PRIORITY` (the existing atomic-tag taxonomy home; `lineage_lifecycle` already imports from there).
- Envelope compares **families**: the ephemeral cohort (`ephemeral`, `engaged_ephemeral`, reserved `session_like`) is one family — promotion is a lifecycle stage within one role, not a role change.
- **Deliberately narrow:** `embodied` and `persistent` stay distinct families (embodied↔persistent lineage still rejects — no new ontology decision smuggled in). Unknown tags map to themselves: strict by default. Charitable `None` defaults unchanged.
- Rejection dict (→ audit payload via the handler's `{**rejection}` spread) now carries `parent_family`/`successor_family`.

## Placement candidates considered

1. Extend `EPHEMERAL_CLASS_TAGS` in `substrate.py` — rejected: that tuple gates substrate-earned class-continuity (`_has_ephemeral_tag`, substrate.py:167); engaged_ephemeral's exclusion there may be intentional S8a design (the engaged cohort is exactly the one being studied for earned continuity). Different axis, different PR if ever.
2. Local map in `lineage_lifecycle.py` — rejected: fourth scattered taxonomy site.
3. **Co-locate with `_CLASS_TAG_PRIORITY`** — chosen; one taxonomy home, drift guard test pins coverage.

## Tests

7 new: the 45-case both directions, session_like membership, substrate envelope unchanged (persistent vs engaged_ephemeral; embodied vs persistent), unknown-tag strictness, drift guard (`_CLASS_TAG_PRIORITY` ⊆ `ROLE_FAMILIES`). Full suite: 9267 passed.

## Operator follow-up (separate decision)

The 45 broken edges in prod are one-shot-ontology casualties — repairing them retroactively is Kenny's call (noted in audit thread).

## Validation plan

After deploy: fresh onboard declaring `be70db89-…` (engaged_ephemeral) as parent must return `lineage_state: provisional`, not `rejected_cross_role`.