### PR TITLE
fix(watcher): P002 required-token + bound-cue drops (82% lifetime FP rate)

### DIFF
--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -1302,6 +1302,17 @@ _PERSIST_VERB_PATTERN = re.compile(
 # finding is dropped as a false positive.
 _PATTERN_REQUIRED_TOKENS: dict[str, tuple[str, ...]] = {
     "P001": ("create_task(",),
+    # P002 needs the actual growth operation on the flagged line — an
+    # append/extend call or a subscript assignment (`x[key] = ...`,
+    # spaced or not). The model otherwise associates the finding with a
+    # nearby def line, docstring, dict literal, or loop header.
+    # False-positive sweep 2026-06-10: 7 of 9 dismissed lifetime P002
+    # findings had no growth op on the flagged line
+    # (agent_metadata_model.py:212-213 def+docstring of a bounded
+    # mutator, event_detector.py:261/:344 loop header + dict-literal
+    # value lines, identity_step.py:64/:106 drifted lines,
+    # agent_metadata_model.py:194 a bare asdict return).
+    "P002": (".append(", ".extend(", "] =", "]="),
     "P003": ("UNITARESMonitor(",),
     # P004 needs a literal Redis call marker on the flagged line.
     # Narrowed to Redis-only on 2026-05-23: asyncpg ops in MCP handlers are
@@ -1351,6 +1362,25 @@ _P001_TASK_ASSIGNMENT = re.compile(r"\b[a-zA-Z_]\w*\s*=\s*[^=].*create_task\(")
 # `create_tracked_task` contains the substring `create_task(`. Caught when
 # qwen3-coder-next flagged 2 sites in mcp_server_std.py on 2026-04-17.
 _P001_TRACKED_HELPER = re.compile(r"\bcreate_tracked_task\s*\(")
+
+# Regex: bounded-growth cues near a flagged P002 growth op — a len-cap
+# trim check (`if len(x) > CAP:`), an explicit eviction (`.pop(0)`,
+# `.popleft()`), or a deque bounded at construction (`maxlen=`). The
+# P002 library text requires growth "without a cap, LRU eviction, or
+# periodic sweep"; the model judges the append line in isolation and
+# misses the trim that sits right next to it. False-positive sweep
+# 2026-06-10: event_detector.py:291/:414 both have the len-cap trim on
+# the very next line; agent_metadata_model.py's bounded mutators trim
+# within three lines of the append.
+_P002_BOUND_CUE = re.compile(
+    r"\bif\s+len\s*\(|\bmaxlen\s*=|\.popleft\s*\(|\.pop\s*\(\s*0\s*\)"
+)
+# Window: multi-line `.append({...})` literals push the trim a few lines
+# past the flagged call (add_lifecycle_event's 5-line append → trim at
+# +5), so the after-window is wider than the before-window (pop-before-
+# append idioms sit within a line or two above).
+_P002_CUE_LINES_BEFORE = 3
+_P002_CUE_LINES_AFTER = 6
 
 # Regex: header line of `def get_or_create_monitor(` — when a P003 flag
 # lands inside the body of this function (which IS the cache), the
@@ -1764,6 +1794,24 @@ def _verify_finding_against_source(
             "warning",
         )
         return False
+    # P002 specifically: the library text requires growth "without a
+    # cap, LRU eviction, or periodic sweep". If a bound cue (len-cap
+    # trim, pop/popleft eviction, deque maxlen) sits within a few lines
+    # of the flagged growth op, the cap the rule asks for is present —
+    # the model just can't see past the single line.
+    if finding.pattern == "P002":
+        for cue_line_no in range(
+            finding.line - _P002_CUE_LINES_BEFORE,
+            finding.line + _P002_CUE_LINES_AFTER + 1,
+        ):
+            nearby = snippet_lines_by_num.get(cue_line_no, "")
+            if nearby and _P002_BOUND_CUE.search(nearby):
+                log(
+                    f"drop P002 {finding.file}:{finding.line} — bound cue at "
+                    f"line {cue_line_no}: {nearby.strip()[:80]}",
+                    "warning",
+                )
+                return False
     # P003 specifically: if the flagged line is inside the body of
     # get_or_create_monitor itself (the cache function), the
     # "instantiated outside the cache" rule does not apply.

--- a/agents/watcher/patterns.md
+++ b/agents/watcher/patterns.md
@@ -60,6 +60,26 @@ calls). See `_P001_TRACKED_HELPER` in `agent.py`.
 `dict[key] = value` or `list.append(x)` inside a loop or per-event handler
 without a cap, LRU eviction, or periodic sweep.
 
+**NOT a match** (the cap the rule asks for is already present):
+
+- `collections.deque(maxlen=N)` containers — bounded by construction; appends
+  to them need no sweep.
+- A growth op with its trim adjacent — `x.append(...)` immediately followed by
+  `if len(x) > CAP:` + slice/del, or preceded by `.pop(0)` / `.popleft()`.
+  The append and its cap are one unit; read the surrounding lines before
+  flagging.
+- Bounded-mutator methods whose body enforces a declared cap (e.g.
+  `add_recent_update` → `MAX_RECENT_UPDATES`). Do not flag the `def` line or
+  docstring of such a method.
+- Flag the line holding the growth op itself — never a loop header, dict
+  literal value line, or function signature near it.
+
+False-positive sweep 2026-06-10: 9 of 11 lifetime P002 findings were dismissed
+— all were cap-adjacent appends or def/docstring lines of bounded mutators
+(`event_detector.py`, `agent_metadata_model.py`, `identity_step.py`). Verifier
+backstops: required growth-token on the flagged line + `_P002_BOUND_CUE`
+window drop in `agent.py`.
+
 **Seen in:** `adaptive_prediction.py`, `serialization.py` (Ogler finds, 2026-04),
 `lifecycle_events` cap fix (2026-04-07)
 

--- a/tests/test_watcher_fingerprint.py
+++ b/tests/test_watcher_fingerprint.py
@@ -214,3 +214,134 @@ def test_p003_async_def_get_or_create_monitor_also_protected():
         11: "    monitor = UNITARESMonitor(agent_id)",
     }
     assert _is_inside_get_or_create_monitor(11, snippet) is True
+
+
+# ---------------------------------------------------------------------------
+# P002 structural verifier refinements (false-positive sweep 2026-06-10:
+# 9 of 11 lifetime findings dismissed — cap-adjacent appends and
+# def/docstring/loop-header flags on bounded mutators)
+# ---------------------------------------------------------------------------
+
+
+def _p002_finding(line: int) -> Finding:
+    return Finding(
+        pattern="P002",
+        file="/repo/src/x.py",
+        line=line,
+        hint="unbounded growth",
+        severity="medium",
+        detected_at="2026-06-10T00:00:00Z",
+        model_used="test-stub",
+    )
+
+
+def test_p002_drops_def_line_flag():
+    """Flag on a bounded-mutator's def line has no growth op — required
+    token drop (agent_metadata_model.py:212 shape)."""
+    src_line = "def add_recent_update(self, timestamp: str, decision: str) -> None:"
+    snippet = {1: src_line}
+    f = _p002_finding(1)
+    assert _verify_finding_against_source(f, src_line, snippet) is False
+
+
+def test_p002_drops_loop_header_flag():
+    """Flag on a loop header has no growth op — required token drop
+    (event_detector.py:261 shape)."""
+    src_line = "for threshold in RISK_THRESHOLDS:"
+    snippet = {1: src_line}
+    f = _p002_finding(1)
+    assert _verify_finding_against_source(f, src_line, snippet) is False
+
+
+def test_p002_drops_append_with_len_cap_next_line():
+    """Append with the len-cap trim on the very next line is bounded —
+    the exact event_detector.py:414 dismissal."""
+    snippet = {
+        414: "self._recent_events.append(event)",
+        415: "if len(self._recent_events) > self._max_stored_events:",
+        416: "    self._recent_events = self._recent_events[-self._max_stored_events:]",
+    }
+    f = _p002_finding(414)
+    assert _verify_finding_against_source(f, snippet[414], snippet) is False
+
+
+def test_p002_drops_append_with_trim_a_few_lines_down():
+    """Multi-line append literal with the trim after the closing brace
+    (agent_metadata_model.add_lifecycle_event shape: trim at +5)."""
+    snippet = {
+        201: "self.lifecycle_events.append({",
+        202: '    "event": event,',
+        203: '    "timestamp": ts,',
+        204: '    "reason": reason',
+        205: "})",
+        206: "if len(self.lifecycle_events) > self.MAX_LIFECYCLE_EVENTS:",
+    }
+    f = _p002_finding(201)
+    assert _verify_finding_against_source(f, snippet[201], snippet) is False
+
+
+def test_p002_drops_append_to_deque_with_maxlen_nearby():
+    """A deque constructed with maxlen= in the window is bounded by
+    construction."""
+    snippet = {
+        10: "self._samples = deque(maxlen=10_000)",
+        11: "for item in batch:",
+        12: "    self._samples.append(item)",
+    }
+    f = _p002_finding(12)
+    assert _verify_finding_against_source(f, snippet[12], snippet) is False
+
+
+def test_p002_drops_pop_before_append():
+    """Evict-then-append idiom: `.pop(0)` just above the append is the
+    cap."""
+    snippet = {
+        30: "if len(self.history) >= self.cap:",
+        31: "    self.history.pop(0)",
+        32: "self.history.append(entry)",
+    }
+    f = _p002_finding(32)
+    assert _verify_finding_against_source(f, snippet[32], snippet) is False
+
+
+def test_p002_keeps_bare_unbounded_append():
+    """True-positive guard: an append with no bound cue anywhere in the
+    window must still surface — that's the real bug shape."""
+    snippet = {
+        100: "def on_event(self, event):",
+        101: "    self.events.append(event)",
+        102: "    self.notify(event)",
+    }
+    f = _p002_finding(101)
+    assert _verify_finding_against_source(f, snippet[101], snippet) is True
+
+
+def test_p002_keeps_unbounded_dict_assignment():
+    """True-positive guard: per-event dict growth with no eviction
+    survives, both spaced and unspaced assignment forms."""
+    snippet_spaced = {
+        200: "def register(self, key, value):",
+        201: "    self.registry[key] = value",
+    }
+    f = _p002_finding(201)
+    assert (
+        _verify_finding_against_source(f, snippet_spaced[201], snippet_spaced)
+        is True
+    )
+    snippet_unspaced = {201: "    self.registry[key]=value"}
+    f2 = _p002_finding(201)
+    assert (
+        _verify_finding_against_source(f2, snippet_unspaced[201], snippet_unspaced)
+        is True
+    )
+
+
+def test_p002_cue_outside_window_does_not_drop():
+    """Pins the window width: a len-cap check 8 lines below the append
+    (beyond _P002_CUE_LINES_AFTER=6) does not rescue the finding."""
+    snippet = {
+        50: "self.buffer.append(item)",
+        58: "if len(self.unrelated) > CAP:",
+    }
+    f = _p002_finding(50)
+    assert _verify_finding_against_source(f, snippet[50], snippet) is True


### PR DESCRIPTION
## Evidence (dogfood sweep, 2026-06-10)

9 of 11 lifetime P002 findings in `data/watcher/findings.jsonl` are dismissed false positives. Two shapes:

| Shape | Count | Example |
|---|---|---|
| No growth op on flagged line (def/docstring/loop-header/dict-literal) | 7 | `agent_metadata_model.py:212` flags the `def add_recent_update` line of a mutator whose body enforces `MAX_RECENT_UPDATES` |
| Cap-adjacent append (trim on next line, invisible to single-line judgment) | 2 | `event_detector.py:414` — `.append(event)` followed by `if len(...) > self._max_stored_events:` |

## Fix (both backstops conservative — drop-only, never widen matching)

1. **Required token** for P002 (`.append(` / `.extend(` / `] =` / `]=`) — same mechanism P001/P003/P004/P005/P008/P012/P016 already use.
2. **`_P002_BOUND_CUE` window drop** — `if len(` / `maxlen=` / `.pop(0)` / `.popleft()` within −3/+6 lines of the flagged growth op means the cap the rule text requires is present.
3. **patterns.md NOT-a-match block** (prompt-side, prevents generation): deque(maxlen=), trim-adjacent appends, bounded mutators, flag-the-op-not-the-neighborhood.

## Tests

9 new: all five evidenced dismissal shapes, **two true-positive guards** (bare unbounded append and dict growth with no cue must still surface), window-width pin (cue at +8 does not rescue). Full suite 9277 green.

## Risk note

False-negative window: a genuinely unbounded append sitting within 6 lines of an *unrelated* len-check would be masked. Accepted for a medium-severity advisory pattern running at 82% FP — the dismissal cost (operator attention) currently exceeds the miss cost, and the true-positive guards pin that bare growth still fires.