### PR TITLE
feat(mirror): novelty-gate complexity line, disclose proxy basis, surface phi

### DIFF
--- a/src/governance_monitor.py
+++ b/src/governance_monitor.py
@@ -140,9 +140,12 @@ class UNITARESMonitor:
         self._last_drift_vector = None  # Concrete ethical drift (Δη)
         # Last signed complexity gap (self − derived) that was marked novel
         # for the mirror's calibration line. Monitor-lifetime only,
-        # deliberately not persisted: after a restart the line may fire once
-        # anew, which is acceptable session-scoped novelty. Written by
-        # monitor_result.build_monitor_result.
+        # deliberately not persisted: after a restart — or once per worker
+        # under multi-process serving (each worker caches its own monitor)
+        # — the line may fire anew, which is acceptable session-scoped
+        # novelty. Written by monitor_result._complexity_divergence_novel;
+        # simulate_update saves/restores it so simulations don't consume
+        # the agent's first real surfacing.
         self._last_surfaced_complexity_gap: Optional[float] = None
 
         # HCK v3.0: Track previous EISV for update coherence ρ(t) and state velocity
@@ -781,6 +784,10 @@ class UNITARESMonitor:
         saved_prev_verdict = self._prev_verdict_action
         saved_prev_norm = self._prev_drift_norm
         saved_prev_conf = self._prev_confidence
+        # The novelty gate for the mirror's complexity line mutates during
+        # result building (monitor_result._complexity_divergence_novel); a
+        # simulation must not consume the agent's first real surfacing.
+        saved_last_gap = self._last_surfaced_complexity_gap
         
         try:
             # OPTIMIZED: Shallow copy + selective deep copy
@@ -825,6 +832,7 @@ class UNITARESMonitor:
             self._prev_verdict_action = saved_prev_verdict
             self._prev_drift_norm = saved_prev_norm
             self._prev_confidence = saved_prev_conf
+            self._last_surfaced_complexity_gap = saved_last_gap
     
     def process_update(self, agent_state: Dict, confidence: Optional[float] = None, task_type: str = "mixed") -> Dict:
         """

--- a/src/governance_monitor.py
+++ b/src/governance_monitor.py
@@ -138,6 +138,12 @@ class UNITARESMonitor:
         self._last_continuity_metrics = None
         self._last_restorative_status = None
         self._last_drift_vector = None  # Concrete ethical drift (Δη)
+        # Last signed complexity gap (self − derived) that was marked novel
+        # for the mirror's calibration line. Monitor-lifetime only,
+        # deliberately not persisted: after a restart the line may fire once
+        # anew, which is acceptable session-scoped novelty. Written by
+        # monitor_result.build_monitor_result.
+        self._last_surfaced_complexity_gap: Optional[float] = None
 
         # HCK v3.0: Track previous EISV for update coherence ρ(t) and state velocity
         self._prev_E: Optional[float] = None

--- a/src/mcp_handlers/response_formatter.py
+++ b/src/mcp_handlers/response_formatter.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Optional
 
 from src.logging_utils import get_logger
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
+from src.monitor_result import DIVERGENCE_LINE_THRESHOLD
 logger = get_logger(__name__)
 
 
@@ -263,7 +264,10 @@ def _format_mirror(response_data: dict, saved_trust_tier: Any, meta: Any = None)
         pass  # Not enough history for meaningful complexity comparison
     else:
         continuity = response_data.get("continuity", {})
-        if isinstance(continuity, dict) and continuity.get("complexity_divergence", 0) > 0.15:
+        if (
+            isinstance(continuity, dict)
+            and continuity.get("complexity_divergence", 0) > DIVERGENCE_LINE_THRESHOLD
+        ):
             # Novelty gate (monitor_result computes it from the signed gap):
             # surface the line on the first crossing or when the gap
             # materially changes, not on every check-in of a stable
@@ -355,6 +359,9 @@ def _format_mirror(response_data: dict, saved_trust_tier: Any, meta: Any = None)
     # signal line — they sit top-level beside margin/nearest_edge, never
     # in the prose signals (dogfood 2026-06-10). NOT named "state": the
     # full payload has a deliberately-stripped duplicate key of that name.
+    # "Don't chase a number" still holds: these are governed-over values
+    # the agent cannot write, only influence through behavior — gaming
+    # coherence requires actually behaving more coherently.
     for state_key, state_val in (
         ("phi", metrics.get("phi")),
         ("coherence", metrics.get("coherence")),

--- a/src/mcp_handlers/response_formatter.py
+++ b/src/mcp_handlers/response_formatter.py
@@ -264,17 +264,31 @@ def _format_mirror(response_data: dict, saved_trust_tier: Any, meta: Any = None)
     else:
         continuity = response_data.get("continuity", {})
         if isinstance(continuity, dict) and continuity.get("complexity_divergence", 0) > 0.15:
-            reported = continuity.get("self_reported_complexity", 0)
-            derived = continuity.get("derived_complexity", 0)
-            divergence = continuity.get("complexity_divergence", 0)
-            # Neutral, recorded observation — not an interrogation. The derived
-            # value is a surface-feature proxy; the self-report is the richer
-            # signal, so a divergence is calibration data, not a demand to
-            # justify "difficulty" on an otherwise-healthy check-in.
-            mirror_signals.append(
-                f"Complexity calibration: you reported {reported:.2f}, surface estimate "
-                f"{derived:.2f} (Δ{divergence:.2f}) — logged for the calibration curve."
-            )
+            # Novelty gate (monitor_result computes it from the signed gap):
+            # surface the line on the first crossing or when the gap
+            # materially changes, not on every check-in of a stable
+            # session-long gap (dogfood 2026-06-10). Payloads without the
+            # key (older builders, hand-built dicts) keep the raw-threshold
+            # behavior.
+            divergence_novel = continuity.get("divergence_novel")
+            if divergence_novel is None:
+                divergence_novel = True
+            if divergence_novel:
+                reported = continuity.get("self_reported_complexity", 0)
+                derived = continuity.get("derived_complexity", 0)
+                divergence = continuity.get("complexity_divergence", 0)
+                # Neutral, recorded observation — not an interrogation. The
+                # derived value is a proxy, so name its basis inline: it
+                # measures output surface (response length/structure + tool
+                # mix), not task content. The self-report is the richer
+                # signal; a divergence is calibration data, not a demand to
+                # justify "difficulty" on an otherwise-healthy check-in.
+                mirror_signals.append(
+                    f"Complexity calibration: you reported {reported:.2f}; output-surface "
+                    f"estimate {derived:.2f} (Δ{divergence:.2f}) — estimate reads response "
+                    f"length/structure + tool mix, not task content; logged for the "
+                    f"calibration curve."
+                )
         else:
             # Fallback to calibration_feedback if continuity not present
             cal_feedback = response_data.get("calibration_feedback", {})
@@ -284,8 +298,9 @@ def _format_mirror(response_data: dict, saved_trust_tier: Any, meta: Any = None)
                     reported = complexity_info.get("reported", 0)
                     derived = complexity_info.get("derived", 0)
                     mirror_signals.append(
-                        f"Complexity calibration: you reported {reported:.2f}, surface estimate "
-                        f"{derived:.2f} — logged for the calibration curve."
+                        f"Complexity calibration: you reported {reported:.2f}; output-surface "
+                        f"estimate {derived:.2f} — estimate reads response length/structure "
+                        f"+ tool mix, not task content; logged for the calibration curve."
                     )
 
     # 4. Pace — reflect cooldown-threshold state descriptively. NOT "Restorative
@@ -333,6 +348,21 @@ def _format_mirror(response_data: dict, saved_trust_tier: Any, meta: Any = None)
         "mirror": mirror_signals if mirror_signals else ["No actionable signals — steady state"],
     }
 
+    # Proprioceptive numbers: phi is the primary basin discriminator
+    # (empirical, 2026-04-30) and coherence/risk are the pair the verdict
+    # reasons over. Without them a mirror-mode agent needs a second tool
+    # call (get_governance_metrics) to learn its own state. Data, not a
+    # signal line — they sit top-level beside margin/nearest_edge, never
+    # in the prose signals (dogfood 2026-06-10). NOT named "state": the
+    # full payload has a deliberately-stripped duplicate key of that name.
+    for state_key, state_val in (
+        ("phi", metrics.get("phi")),
+        ("coherence", metrics.get("coherence")),
+        ("risk_score", metrics.get("risk_score")),
+    ):
+        if state_val is not None:
+            result[state_key] = state_val
+
     if relevant_prior:
         result["relevant_prior_work"] = relevant_prior
 
@@ -377,6 +407,10 @@ def _format_minimal(response_data: dict, using_default_mode: bool, saved_trust_t
         "S": metrics.get("S"),
         "V": metrics.get("V"),
         "coherence": metrics.get("coherence"),
+        # phi is the primary basin discriminator (empirical, 2026-04-30);
+        # minimal carried every EISV channel except it. Compact already
+        # includes it — parity, not a new surface.
+        "phi": metrics.get("phi"),
         "risk_score": metrics.get("risk_score"),
         "risk_score_latest": metrics.get("latest_risk_score"),
     }

--- a/src/mcp_handlers/updates/enrichments.py
+++ b/src/mcp_handlers/updates/enrichments.py
@@ -13,6 +13,7 @@ from datetime import datetime, timezone
 from typing import Any, Optional
 
 from src.logging_utils import get_logger
+from src.monitor_result import DIVERGENCE_LINE_THRESHOLD
 from src.thread_identity import (
     LINEAGE_SPAWN_REASONS,
     classify_episode_fork,
@@ -1417,7 +1418,17 @@ def _get_complexity_disagreement(response_data: dict, meta: Any = None) -> dict 
             return None
 
         continuity = response_data.get("continuity", {})
-        if isinstance(continuity, dict) and continuity.get("complexity_divergence", 0) > 0.15:
+        if (
+            isinstance(continuity, dict)
+            and continuity.get("complexity_divergence", 0) > DIVERGENCE_LINE_THRESHOLD
+        ):
+            # Respect the novelty gate when the payload carries it: a stable
+            # session-long gap should not trigger a KG search on every
+            # check-in any more than it should repeat the mirror line
+            # (council fold, PR #603). A missing key (older builders) keeps
+            # the legacy always-fire behavior.
+            if continuity.get("divergence_novel") is False:
+                return None
             return {
                 "reported": continuity.get("self_reported_complexity"),
                 "derived": continuity.get("derived_complexity"),

--- a/src/monitor_result.py
+++ b/src/monitor_result.py
@@ -9,6 +9,41 @@ from src.logging_utils import get_logger
 
 logger = get_logger(__name__)
 
+# Mirror-line thresholds for the complexity-calibration signal: the line is
+# eligible above this divergence (matches response_formatter's gate) ...
+_DIVERGENCE_LINE_THRESHOLD = 0.15
+# ... and is NOVEL only on the first crossing or when the signed gap moves
+# by more than this since the last surfaced value.
+_DIVERGENCE_NOVELTY_DELTA = 0.10
+
+
+def _complexity_divergence_novel(monitor, cm) -> bool:
+    """True when the complexity divergence is worth surfacing again.
+
+    Novelty gate for the mirror's complexity-calibration line: only the
+    first threshold crossing, or a materially changed SIGNED gap
+    (magnitude shift > _DIVERGENCE_NOVELTY_DELTA, which includes
+    direction flips), counts as novel. A stable session-long gap
+    repeating the same line on every check-in is noise, not signal
+    (dogfood 2026-06-10). The signed gap (self − derived) is tracked
+    rather than |divergence| so an over→under-reporting flip of equal
+    magnitude still registers.
+
+    Mutates ``monitor._last_surfaced_complexity_gap`` when returning
+    True — deliberate, documented on the attribute
+    (governance_monitor.__init__). Not persisted: after a restart the
+    line may fire once anew (acceptable session-scoped novelty).
+    """
+    if cm.complexity_divergence <= _DIVERGENCE_LINE_THRESHOLD:
+        return False
+    self_cx = cm.self_complexity if cm.self_complexity is not None else 0.0
+    signed_gap = self_cx - cm.derived_complexity
+    last_gap = getattr(monitor, '_last_surfaced_complexity_gap', None)
+    if last_gap is None or abs(signed_gap - last_gap) > _DIVERGENCE_NOVELTY_DELTA:
+        monitor._last_surfaced_complexity_gap = signed_gap
+        return True
+    return False
+
 
 def build_result(
     monitor,
@@ -56,10 +91,12 @@ def build_result(
     # Dual-log continuity metrics
     if monitor._last_continuity_metrics:
         cm = monitor._last_continuity_metrics
+        divergence_novel = _complexity_divergence_novel(monitor, cm)
         result['continuity'] = {
             'derived_complexity': cm.derived_complexity,
             'self_reported_complexity': cm.self_complexity,
             'complexity_divergence': cm.complexity_divergence,
+            'divergence_novel': divergence_novel,
             'overconfidence_signal': cm.overconfidence_signal,
             'underconfidence_signal': cm.underconfidence_signal,
             'E_input': cm.E_input,

--- a/src/monitor_result.py
+++ b/src/monitor_result.py
@@ -9,11 +9,13 @@ from src.logging_utils import get_logger
 
 logger = get_logger(__name__)
 
-# Mirror-line thresholds for the complexity-calibration signal: the line is
-# eligible above this divergence (matches response_formatter's gate) ...
-_DIVERGENCE_LINE_THRESHOLD = 0.15
-# ... and is NOVEL only on the first crossing or when the signed gap moves
-# by more than this since the last surfaced value.
+# Eligibility threshold for the complexity-calibration signal. CANONICAL —
+# response_formatter (mirror line) and updates/enrichments
+# (_get_complexity_disagreement, KG-search gate) import this rather than
+# repeating the literal, so the three gates can't drift apart.
+DIVERGENCE_LINE_THRESHOLD = 0.15
+# The signal is NOVEL only on the first crossing or when the signed gap
+# moves by more than this since the last surfaced value.
 _DIVERGENCE_NOVELTY_DELTA = 0.10
 
 
@@ -31,10 +33,13 @@ def _complexity_divergence_novel(monitor, cm) -> bool:
 
     Mutates ``monitor._last_surfaced_complexity_gap`` when returning
     True — deliberate, documented on the attribute
-    (governance_monitor.__init__). Not persisted: after a restart the
-    line may fire once anew (acceptable session-scoped novelty).
+    (governance_monitor.__init__). Not persisted, and per-monitor-
+    instance: after a restart — or once per worker under multi-process
+    serving, where each worker holds its own monitor cache — the line
+    may fire anew (acceptable session-scoped novelty; degrades toward
+    the old always-fire behavior, never to wrong output).
     """
-    if cm.complexity_divergence <= _DIVERGENCE_LINE_THRESHOLD:
+    if cm.complexity_divergence <= DIVERGENCE_LINE_THRESHOLD:
         return False
     self_cx = cm.self_complexity if cm.self_complexity is not None else 0.0
     signed_gap = self_cx - cm.derived_complexity

--- a/tests/test_enrichments_mirror.py
+++ b/tests/test_enrichments_mirror.py
@@ -201,3 +201,47 @@ class TestShouldSearchKgByCheckinText:
     def test_signal_or_question_enables_kg_search(self):
         ctx = _make_ctx(response_text="I am stuck investigating a regression in auth.")
         assert _should_search_kg_by_checkin_text(ctx, signals=[], question="What unblocks you?") is True
+
+    def test_stale_complexity_gap_skips_kg_search(self):
+        """Council fold (PR #603): a stable session-long complexity gap is
+        novelty-gated out of the mirror line — the KG search it used to
+        trigger on every check-in must respect the same gate."""
+        ctx = _make_ctx(
+            response_text="Continuing the same long-running refactor as before.",
+            response_data={
+                "continuity": {
+                    "self_reported_complexity": 0.8,
+                    "derived_complexity": 0.22,
+                    "complexity_divergence": 0.58,
+                    "divergence_novel": False,
+                }
+            },
+        )
+        assert _should_search_kg_by_checkin_text(ctx, signals=[], question=None) is False
+
+    def test_novel_complexity_gap_still_enables_kg_search(self):
+        ctx = _make_ctx(
+            response_text="Continuing the same long-running refactor as before.",
+            response_data={
+                "continuity": {
+                    "self_reported_complexity": 0.8,
+                    "derived_complexity": 0.22,
+                    "complexity_divergence": 0.58,
+                    "divergence_novel": True,
+                }
+            },
+        )
+        assert _should_search_kg_by_checkin_text(ctx, signals=[], question=None) is True
+
+    def test_legacy_payload_without_novelty_key_still_enables_kg_search(self):
+        ctx = _make_ctx(
+            response_text="Continuing the same long-running refactor as before.",
+            response_data={
+                "continuity": {
+                    "self_reported_complexity": 0.8,
+                    "derived_complexity": 0.22,
+                    "complexity_divergence": 0.58,
+                }
+            },
+        )
+        assert _should_search_kg_by_checkin_text(ctx, signals=[], question=None) is True

--- a/tests/test_monitor_result_novelty.py
+++ b/tests/test_monitor_result_novelty.py
@@ -82,3 +82,28 @@ def test_monitor_without_attribute_uses_getattr_default():
     bare = SimpleNamespace()
     assert _complexity_divergence_novel(bare, _cm(0.7, 0.3)) is True
     assert bare._last_surfaced_complexity_gap == pytest.approx(0.4)
+
+
+def test_simulate_update_does_not_consume_novelty():
+    """Council fold (PR #603): simulate_update runs the full governance
+    cycle, including result building, which advances the novelty gate.
+    The simulation must save/restore the gap so a dry run doesn't
+    consume the agent's first REAL surfacing of the complexity line."""
+    from src.governance_monitor import UNITARESMonitor
+
+    monitor = UNITARESMonitor(agent_id="test-sim-novelty-gap")
+    assert monitor._last_surfaced_complexity_gap is None
+
+    # Large reported-vs-derived gap: short text + complexity 0.9 is the
+    # shape the live verifier reproduced (derived ≈ 0, Δ ≈ 0.9).
+    agent_state = {"response_text": "ok", "complexity": 0.9}
+
+    monitor.simulate_update(dict(agent_state))
+    assert monitor._last_surfaced_complexity_gap is None, (
+        "simulation burned the novelty gate — the first real check-in "
+        "would silently lose the complexity line"
+    )
+
+    # The real path still engages the gate.
+    monitor.process_update(dict(agent_state))
+    assert monitor._last_surfaced_complexity_gap is not None

--- a/tests/test_monitor_result_novelty.py
+++ b/tests/test_monitor_result_novelty.py
@@ -1,0 +1,84 @@
+"""Novelty gate for the mirror's complexity-calibration line.
+
+`_complexity_divergence_novel` (src/monitor_result.py) decides whether
+the divergence is worth surfacing AGAIN: first threshold crossing or a
+materially changed signed gap only. Dogfood 2026-06-10: a stable
+session-long gap repeated the same mirror line on every check-in.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.monitor_result import _complexity_divergence_novel
+
+
+def _monitor():
+    return SimpleNamespace(_last_surfaced_complexity_gap=None)
+
+
+def _cm(self_cx, derived_cx):
+    divergence = abs((self_cx if self_cx is not None else 0.0) - derived_cx)
+    return SimpleNamespace(
+        self_complexity=self_cx,
+        derived_complexity=derived_cx,
+        complexity_divergence=divergence,
+    )
+
+
+def test_first_crossing_is_novel():
+    m = _monitor()
+    assert _complexity_divergence_novel(m, _cm(0.7, 0.3)) is True
+    assert m._last_surfaced_complexity_gap == pytest.approx(0.4)
+
+
+def test_stable_gap_not_novel_on_repeat():
+    m = _monitor()
+    assert _complexity_divergence_novel(m, _cm(0.7, 0.3)) is True
+    assert _complexity_divergence_novel(m, _cm(0.7, 0.3)) is False
+    # Small wobble within the delta is still the same gap.
+    assert _complexity_divergence_novel(m, _cm(0.72, 0.35)) is False
+
+
+def test_materially_changed_gap_is_novel_again():
+    m = _monitor()
+    assert _complexity_divergence_novel(m, _cm(0.7, 0.3)) is True
+    assert _complexity_divergence_novel(m, _cm(0.9, 0.3)) is True
+    assert m._last_surfaced_complexity_gap == pytest.approx(0.6)
+
+
+def test_direction_flip_is_novel():
+    """Signed-gap tracking: over→under-reporting of equal magnitude must
+    register even though |divergence| is unchanged."""
+    m = _monitor()
+    assert _complexity_divergence_novel(m, _cm(0.5, 0.3)) is True   # gap +0.2
+    assert _complexity_divergence_novel(m, _cm(0.3, 0.5)) is True   # gap −0.2
+    assert m._last_surfaced_complexity_gap == pytest.approx(-0.2)
+
+
+def test_below_threshold_never_novel_and_keeps_state():
+    m = _monitor()
+    assert _complexity_divergence_novel(m, _cm(0.7, 0.3)) is True
+    # Dip below the line threshold: not novel, and the last surfaced gap
+    # is retained so returning to the SAME gap does not re-fire.
+    assert _complexity_divergence_novel(m, _cm(0.4, 0.3)) is False
+    assert m._last_surfaced_complexity_gap == pytest.approx(0.4)
+    assert _complexity_divergence_novel(m, _cm(0.7, 0.3)) is False
+
+
+def test_none_self_complexity_treated_as_zero():
+    m = _monitor()
+    cm = _cm(None, 0.5)
+    assert cm.complexity_divergence == pytest.approx(0.5)
+    assert _complexity_divergence_novel(m, cm) is True
+    assert m._last_surfaced_complexity_gap == pytest.approx(-0.5)
+
+
+def test_monitor_without_attribute_uses_getattr_default():
+    """Defensive: a monitor object predating the attribute (or a test
+    stub) starts from None."""
+    bare = SimpleNamespace()
+    assert _complexity_divergence_novel(bare, _cm(0.7, 0.3)) is True
+    assert bare._last_surfaced_complexity_gap == pytest.approx(0.4)

--- a/tests/test_response_formatter.py
+++ b/tests/test_response_formatter.py
@@ -111,6 +111,13 @@ class TestFormatMinimal:
         assert result["V"] == -0.02
         assert result["coherence"] == 0.92
 
+    def test_includes_phi(self):
+        """phi is the primary basin discriminator — minimal carried every
+        EISV channel except it (compact already includes it; parity)."""
+        data = _sample_response()
+        result = _format_minimal(data, using_default_mode=False, saved_trust_tier=None)
+        assert result["phi"] == 1.23
+
     def test_includes_margin(self):
         data = _sample_response()
         result = _format_minimal(data, using_default_mode=False, saved_trust_tier=None)
@@ -638,6 +645,70 @@ class TestFormatMirror:
             "what's driving" in s.lower() or "sense of difficulty" in s.lower()
             for s in result["mirror"]
         )
+        # The estimate's basis is disclosed inline — it reads output
+        # surface, not task content (dogfood 2026-06-10).
+        assert any("not task content" in s for s in result["mirror"])
+
+    def test_complexity_line_fires_when_divergence_novel(self):
+        data = _sample_response()
+        data["continuity"] = {
+            "self_reported_complexity": 0.7,
+            "derived_complexity": 0.3,
+            "complexity_divergence": 0.4,
+            "divergence_novel": True,
+        }
+        result = _format_mirror(data, saved_trust_tier=None)
+        line = next(s for s in result["mirror"] if "Complexity calibration" in s)
+        assert "you reported 0.70" in line
+        assert "0.30" in line
+        assert "not task content" in line
+
+    def test_complexity_line_suppressed_when_divergence_not_novel(self):
+        """A stable session-long gap must not repeat the same line on
+        every check-in — that's the noise this gate removes."""
+        data = _sample_response()
+        data["continuity"] = {
+            "self_reported_complexity": 0.7,
+            "derived_complexity": 0.3,
+            "complexity_divergence": 0.4,
+            "divergence_novel": False,
+        }
+        result = _format_mirror(data, saved_trust_tier=None)
+        assert not any("Complexity calibration" in s for s in result["mirror"])
+
+    def test_complexity_line_back_compat_without_novelty_key(self):
+        """Payloads built without divergence_novel (older builders,
+        hand-built dicts) keep the raw-threshold behavior."""
+        data = _sample_response()
+        data["continuity"] = {
+            "self_reported_complexity": 0.7,
+            "derived_complexity": 0.3,
+            "complexity_divergence": 0.4,
+        }
+        result = _format_mirror(data, saved_trust_tier=None)
+        assert any("Complexity calibration" in s for s in result["mirror"])
+
+    def test_proprioceptive_numbers_top_level(self):
+        """phi/coherence/risk_score surface as data beside margin —
+        without them a mirror-mode agent needs a second tool call to
+        learn its own state."""
+        data = _sample_response()
+        result = _format_mirror(data, saved_trust_tier=None)
+        assert result["phi"] == 1.23
+        assert result["coherence"] == 0.92
+        assert result["risk_score"] == 0.08
+        # Data keys, not prose — the signals list must not gain a
+        # numbers line out of this.
+        assert not any("phi" in s.lower() for s in result["mirror"])
+
+    def test_proprioceptive_numbers_omitted_when_absent(self):
+        data = _sample_response()
+        for key in ("phi", "coherence", "risk_score"):
+            data["metrics"].pop(key, None)
+        result = _format_mirror(data, saved_trust_tier=None)
+        assert "phi" not in result
+        assert "coherence" not in result
+        assert "risk_score" not in result
 
     def test_mirror_signals_from_enrichment(self):
         data = _sample_response()

--- a/tests/test_response_formatter.py
+++ b/tests/test_response_formatter.py
@@ -898,9 +898,12 @@ class TestFormatMirror:
         meta = MagicMock()
         meta.total_updates = 1
         result = _format_mirror(data, saved_trust_tier=None, meta=meta)
-        # No complexity divergence signals should appear
-        for s in result["mirror"]:
-            assert "complexity=" not in s, f"Unexpected complexity signal on early check-in: {s}"
+        # No complexity divergence signals should appear. (Council fold,
+        # PR #603: the old assertion checked for "complexity=", a string
+        # no signal ever contained — a no-op that passed regardless.)
+        assert not any("Complexity calibration" in s for s in result["mirror"]), (
+            f"Unexpected complexity signal on early check-in: {result['mirror']}"
+        )
 
     def test_complexity_divergence_shown_after_baseline(self):
         """With meta.total_updates > 3, complexity divergence appears normally."""


### PR DESCRIPTION
## Dogfood frictions (running as a long-lived mirror-mode agent, 2026-06-10)

**A1 — repetition.** The complexity-calibration line fires on every check-in once Δ>0.15. A stable session-long gap = the same line forever. Fix: `monitor_result` computes `divergence_novel` from the **signed** gap (self−derived) — first crossing or >0.10 shift (incl. direction flips) is novel; stable repeats suppress. Monitor-lifetime state, deliberately unpersisted. Formatter keeps raw-threshold behavior for payloads without the key (back-compat).

**A2 — undisclosed proxy.** 'surface estimate' never said what it measures. Verified the derivation (`dual_log/continuity.derive_complexity`): log-scaled response tokens, code blocks, list items, 0.70/0.30 tool-usage blend; its own docstring says 'OUTPUT complexity, not TASK complexity, heuristic and not empirically validated'. The line now disclo​ses inline: *estimate reads response length/structure + tool mix, not task content*.

**D — proprioception gap.** phi is the primary basin discriminator (empirical 2026-04-30), yet minimal carried every EISV channel *except* phi (compact has it), and mirror carried **no quantitative state at all** — an agent wanting its own numbers needs a second tool call. minimal gains `phi` (parity); mirror gains top-level `phi`/`coherence`/`risk_score` as **data beside margin/nearest_edge, never prose signals** (reflect-don't-advise preserved). Not nested under `state` — the full payload has a deliberately-stripped duplicate key of that name.

## Tests
7-case novelty unit suite; formatter gating/back-compat/disclosure pins; phi parity; numbers omitted-when-absent. Full suite 9281 green.

## Consumers checked
`continuity` dict gains one additive key (count-only/structural consumers unaffected); mirror/minimal payload keys are additive. Council (3-lane) reviewing — mirror precedents #572/#583.