### PR TITLE
fix(identity): subagent onboards must not displace the driver's fingerprint pin

### DIFF
--- a/docs/ontology/identity.md
+++ b/docs/ontology/identity.md
@@ -144,6 +144,50 @@ compares EISV dynamics assuming comparable operating conditions. A
 within-role lifecycle stage does not violate that assumption; a role
 change does.
 
+### Transport-level continuity (a performative layer, named as such)
+
+For clients that do not echo `client_session_id`, the server bridges
+argument-less calls back to an onboarded identity via a short-TTL Redis
+pin keyed on the transport fingerprint (`recent_onboard:<ip:ua>`, with
+client/model-scoped variants — `set_onboard_pin` /
+`lookup_onboard_pin`, `src/mcp_handlers/identity/session.py`). By this
+document's own taxonomy that mechanism is **performative**: it treats
+"same fingerprint" as "same subject" without verification. It is kept
+because it makes the common case (one interactive driver per host)
+work; its assumptions and decay conditions are stated here so they are
+properties, not surprises:
+
+- **One driver per fingerprint.** Co-resident process-instances —
+  Task/Agent-tool subagents, concurrent terminal sessions — share the
+  fingerprint and violate the assumption. The fingerprint cannot
+  distinguish them, by construction.
+- **Subagent onboards do not displace the pin.** An onboard that
+  *explicitly declares* `spawn_reason="subagent"` writes the pin
+  only-if-absent (SET NX). This is matched against the declared
+  argument only, never `infer_spawn_reason()`'s guess: inference can
+  label a fresh driver's succession onboard "subagent," and NX-gating
+  on that would lock the new driver behind its dead predecessor's
+  still-live pin (incident class: 2026-06-10, where the inverse —
+  unconditional writes — let each council subagent capture the
+  driver's resolution; ~50 driver check-ins scattered across seven
+  subagent identities).
+- **Honor-system boundary.** A subagent that omits `spawn_reason`
+  keeps the displacing write; a non-echoing subagent resolves to the
+  driver's pin and its stray argument-less writes land on the driver
+  (contamination of one surviving stream — recoverable — rather than
+  fragmentation of the driver across ephemeral identities, which is
+  not). Both residuals vanish for conforming subagents.
+- **Staleness edge.** A dead driver's pin survives until TTL expiry
+  (lookups refresh TTL while anyone keeps resolving through it), and a
+  subagent's NX write will not clear it.
+- **The authoritative path is not the pin.** Echoing
+  `client_session_id` (resolution step 2) yields `tier: strong`;
+  pin-resolved calls are honestly labeled
+  (`session_source: pinned_onboard_session` /
+  `continuity_claim: resumed_by_recent_onboard_pin`, tier weak-medium).
+  Long-running drivers should record the `client_session_id` their
+  onboard returns and pass it on every call.
+
 ## Open questions
 
 - **Trajectory portability.** When a prior process-instance's trajectory informs a successor's priors, is the successor inheriting identity or inheriting data? Answer probably depends on whether the successor *integrates* the prior's trajectory (identity-adjacent, per axiom #12) or merely *reads* it (data-only).

--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -2191,9 +2191,16 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     # When Claude.ai doesn't pass client_session_id, dispatch_tool() can
     # use this pin to inject the correct session ID based on transport fingerprint.
     # This prevents knowledge graph attribution from scattering across random UUIDs.
+    #
+    # Subagent onboards write the pin only-if-absent: a spawned helper
+    # shares the driver's exact fingerprint, and an unconditional write
+    # here CAPTURES the driver's argument-less resolution for the rest of
+    # the session (incident 2026-06-10 — see SUBAGENT_PIN_NX_SPAWN_REASONS
+    # in identity/session.py for the full mechanism).
     try:
         logger.debug(f"[ONBOARD_PIN] base_session_key={base_session_key!r}")
         base_fp = _extract_base_fingerprint(base_session_key)
+        from .session import SUBAGENT_PIN_NX_SPAWN_REASONS
         await set_onboard_pin(
             base_fp,
             agent_uuid,
@@ -2201,6 +2208,7 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
             client_hint=client_hint,
             model_type=model_type,
             user_agent=signals.user_agent if signals else None,
+            if_absent=_spawn_reason in SUBAGENT_PIN_NX_SPAWN_REASONS,
         )
     except Exception as e:
         logger.warning(f"[ONBOARD_PIN] Could not set pin: {e}")

--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -2197,6 +2197,17 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     # here CAPTURES the driver's argument-less resolution for the rest of
     # the session (incident 2026-06-10 — see SUBAGENT_PIN_NX_SPAWN_REASONS
     # in identity/session.py for the full mechanism).
+    #
+    # EXPLICITLY-DECLARED spawn_reason only — never the inferred
+    # `_spawn_reason`. infer_spawn_reason() classifies a succession
+    # onboard (parent_agent_id declared, spawn_reason omitted, thread
+    # has prior nodes) as "subagent" whenever client_hint isn't in the
+    # arguments, which would NX-block a legitimate fresh DRIVER behind
+    # its dead predecessor's still-live pin — the same wrong-resolution
+    # bug in the opposite direction (council block, PR #604). The cost:
+    # a subagent that omits spawn_reason keeps today's displacing write;
+    # that boundary is documented on the constant and in
+    # docs/ontology/identity.md.
     try:
         logger.debug(f"[ONBOARD_PIN] base_session_key={base_session_key!r}")
         base_fp = _extract_base_fingerprint(base_session_key)
@@ -2208,7 +2219,7 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
             client_hint=client_hint,
             model_type=model_type,
             user_agent=signals.user_agent if signals else None,
-            if_absent=_spawn_reason in SUBAGENT_PIN_NX_SPAWN_REASONS,
+            if_absent=arguments.get("spawn_reason") in SUBAGENT_PIN_NX_SPAWN_REASONS,
         )
     except Exception as e:
         logger.warning(f"[ONBOARD_PIN] Could not set pin: {e}")

--- a/src/mcp_handlers/identity/session.py
+++ b/src/mcp_handlers/identity/session.py
@@ -814,6 +814,22 @@ async def _lookup_onboard_pin_inner(base_fingerprint: str, *, refresh_ttl: bool)
     return pinned_session_id
 
 
+# Spawn reasons whose onboards must NOT displace an existing pin. The pin
+# bridges argument-less calls from ONE long-lived client per fingerprint
+# (the driver) back to its onboarded identity; in-process-spawned helpers
+# (Task/Agent-tool subagents) share the driver's exact fingerprint (same
+# host, same binary → same IP:UA, same client_hint, usually same model
+# scope), so an unconditional pin write at their onboard CAPTURES the
+# driver's fallback resolution. Incident 2026-06-10: across one operator
+# session, each council dispatch's last-onboarded subagent took the pin —
+# ~50 of the driver's check-ins scattered over seven subagent identities
+# while the driver's own trajectory froze at its first hour. Subagents
+# keep identity continuity the documented way (echoing the
+# client_session_id their onboard returned); the NX write below only
+# matters for the argument-less fallback they should not win.
+SUBAGENT_PIN_NX_SPAWN_REASONS = frozenset({"subagent"})
+
+
 async def set_onboard_pin(
     base_fingerprint: str,
     agent_uuid: str,
@@ -822,6 +838,7 @@ async def set_onboard_pin(
     client_hint: Optional[str] = None,
     model_type: Optional[str] = None,
     user_agent: Optional[str] = None,
+    if_absent: bool = False,
 ) -> bool:
     """Set a pin mapping a transport fingerprint to an onboarded agent.
 
@@ -831,8 +848,14 @@ async def set_onboard_pin(
         base_fingerprint: Output of _extract_base_fingerprint(), e.g. "ua:d20c2f"
         agent_uuid: The newly onboarded agent's UUID
         client_session_id: The stable session ID to inject on subsequent calls
+        if_absent: Write each candidate pin only when no pin exists for it
+            (Redis SET NX). Used for subagent onboards
+            (SUBAGENT_PIN_NX_SPAWN_REASONS) so a spawned helper never
+            displaces the live driver's pin; on a fingerprint with no
+            standing pin the subagent may still claim it.
 
-    Returns: True if the pin was set successfully.
+    Returns: True if the pin was set successfully (with ``if_absent``,
+    True when at least one candidate slot was claimed).
     """
     if not base_fingerprint:
         logger.debug("[ONBOARD_PIN] No fingerprint — skip pin-set")
@@ -846,6 +869,7 @@ async def set_onboard_pin(
                 client_hint=client_hint,
                 model_type=model_type,
                 user_agent=user_agent,
+                if_absent=if_absent,
             ),
             timeout=_PIN_REDIS_TIMEOUT,
         )
@@ -868,6 +892,7 @@ async def _set_onboard_pin_inner(
     client_hint: Optional[str] = None,
     model_type: Optional[str] = None,
     user_agent: Optional[str] = None,
+    if_absent: bool = False,
 ) -> bool:
     from src.cache.redis_client import get_redis
     import json as _json
@@ -889,8 +914,27 @@ async def _set_onboard_pin_inner(
         "agent_uuid": agent_uuid,
         "client_session_id": client_session_id,
     })
+    wrote_any = False
     for fp in candidates:
         pin_key = f"recent_onboard:{fp}"
+        if if_absent:
+            # SET NX + EX: claim the slot only when empty. A standing pin
+            # (the driver's) is left untouched — including its TTL, which
+            # the driver's own lookups refresh.
+            claimed = await raw_redis.set(pin_key, pin_data, ex=_PIN_TTL, nx=True)
+            if claimed:
+                wrote_any = True
+                logger.info(
+                    f"[ONBOARD_PIN] Claimed empty pin slot for agent "
+                    f"{agent_uuid[:8]}... (nx)"
+                )
+            else:
+                logger.info(
+                    f"[ONBOARD_PIN] Pin slot already held — subagent "
+                    f"{agent_uuid[:8]}... does not displace it (nx)"
+                )
+            continue
         await raw_redis.setex(pin_key, _PIN_TTL, pin_data)
+        wrote_any = True
         logger.info(f"[ONBOARD_PIN] Set pin for agent {agent_uuid[:8]}...")
-    return True
+    return wrote_any

--- a/src/mcp_handlers/identity/session.py
+++ b/src/mcp_handlers/identity/session.py
@@ -827,6 +827,16 @@ async def _lookup_onboard_pin_inner(base_fingerprint: str, *, refresh_ttl: bool)
 # keep identity continuity the documented way (echoing the
 # client_session_id their onboard returned); the NX write below only
 # matters for the argument-less fallback they should not win.
+#
+# Matched against the EXPLICITLY-DECLARED spawn_reason argument only,
+# never infer_spawn_reason()'s output: inference can label a fresh
+# driver's succession onboard "subagent" (parent declared, reason
+# omitted, client_hint not in arguments), and NX-gating on that would
+# lock the new driver behind its dead predecessor's still-live pin.
+# Honor-system boundary, accepted deliberately: a subagent that omits
+# spawn_reason keeps the displacing write (today's behavior). The
+# authoritative continuity path was never the pin — it is echoing
+# client_session_id (resolution step 2, tier strong).
 SUBAGENT_PIN_NX_SPAWN_REASONS = frozenset({"subagent"})
 
 

--- a/tests/test_identity_handlers.py
+++ b/tests/test_identity_handlers.py
@@ -459,6 +459,121 @@ class TestOnboardPin:
             assert result is False
 
 
+def _nx_fake_redis(stored_data):
+    """Dict-backed raw-Redis fake supporting setex, get, expire, and
+    SET NX (the if_absent path)."""
+    mock_raw = AsyncMock()
+
+    async def mock_setex(key, ttl, value):
+        stored_data[key] = value
+
+    async def mock_set(key, value, ex=None, nx=False):
+        if nx and key in stored_data:
+            return None  # redis-py returns None when NX blocks the write
+        stored_data[key] = value
+        return True
+
+    async def mock_get(key):
+        return stored_data.get(key)
+
+    async def mock_expire(key, ttl):
+        pass
+
+    mock_raw.setex = mock_setex
+    mock_raw.set = mock_set
+    mock_raw.get = mock_get
+    mock_raw.expire = mock_expire
+    return mock_raw
+
+
+class TestSubagentPinCapture:
+    """Incident 2026-06-10: every subagent onboard displaced the driver's
+    fingerprint pin (unconditional SETEX, last-writer-wins on a
+    host-shared key), so the driver's argument-less calls resolved to
+    the most recently onboarded subagent — ~50 driver check-ins
+    scattered across seven subagent identities in one session. Subagent
+    onboards now write the pin only-if-absent."""
+
+    @pytest.mark.asyncio
+    async def test_subagent_if_absent_does_not_displace_driver_pin(self):
+        """THE incident shape: driver pins, subagent onboards, driver's
+        fingerprint must still resolve to the driver."""
+        from src.mcp_handlers.identity.handlers import (
+            lookup_onboard_pin,
+            set_onboard_pin,
+        )
+
+        stored = {}
+
+        async def _get_raw():
+            return _nx_fake_redis(stored)
+
+        with patch("src.cache.redis_client.get_redis", new=_get_raw):
+            assert await set_onboard_pin(
+                "ua:d20c2f", "driver-uuid", "agent-driver-123456"
+            ) is True
+            claimed = await set_onboard_pin(
+                "ua:d20c2f", "subagent-uuid", "agent-subagent-9999",
+                if_absent=True,
+            )
+            assert claimed is False
+            assert await lookup_onboard_pin("ua:d20c2f") == "agent-driver-123456"
+
+    @pytest.mark.asyncio
+    async def test_subagent_if_absent_claims_empty_slot(self):
+        """No standing pin (subagent on a fresh fingerprint) → the
+        subagent may claim it, preserving its own continuity."""
+        from src.mcp_handlers.identity.handlers import (
+            lookup_onboard_pin,
+            set_onboard_pin,
+        )
+
+        stored = {}
+
+        async def _get_raw():
+            return _nx_fake_redis(stored)
+
+        with patch("src.cache.redis_client.get_redis", new=_get_raw):
+            claimed = await set_onboard_pin(
+                "ua:fresh1", "subagent-uuid", "agent-subagent-9999",
+                if_absent=True,
+            )
+            assert claimed is True
+            assert await lookup_onboard_pin("ua:fresh1") == "agent-subagent-9999"
+
+    @pytest.mark.asyncio
+    async def test_driver_onboard_still_displaces(self):
+        """Driver succession is preserved: a later non-subagent onboard
+        (fresh driver session on the same host) takes the pin."""
+        from src.mcp_handlers.identity.handlers import (
+            lookup_onboard_pin,
+            set_onboard_pin,
+        )
+
+        stored = {}
+
+        async def _get_raw():
+            return _nx_fake_redis(stored)
+
+        with patch("src.cache.redis_client.get_redis", new=_get_raw):
+            await set_onboard_pin("ua:d20c2f", "old-driver", "agent-old-111111")
+            await set_onboard_pin("ua:d20c2f", "new-driver", "agent-new-222222")
+            assert await lookup_onboard_pin("ua:d20c2f") == "agent-new-222222"
+
+    def test_spawn_reason_set_membership(self):
+        """The NX set covers the Agent-tool dispatch convention."""
+        from src.mcp_handlers.identity.session import (
+            SUBAGENT_PIN_NX_SPAWN_REASONS,
+        )
+
+        assert "subagent" in SUBAGENT_PIN_NX_SPAWN_REASONS
+        # Driver-shaped spawn reasons must NOT be in the set — a fresh
+        # driver session declaring lineage uses new_session and must be
+        # able to take over the host fingerprint.
+        assert "new_session" not in SUBAGENT_PIN_NX_SPAWN_REASONS
+        assert None not in SUBAGENT_PIN_NX_SPAWN_REASONS
+
+
 # ============================================================================
 # handle_identity_v2 (tool handler, not the decorator adapter)
 # ============================================================================
@@ -1767,6 +1882,56 @@ class TestHandleOnboardV2:
         assert "session_continuity" not in data
         assert "workflow" not in data
         assert "what_this_does" not in data
+
+    @pytest.mark.asyncio
+    async def test_subagent_onboard_passes_if_absent_to_pin(self, patch_onboard_deps, mock_db, mock_redis):
+        """spawn_reason='subagent' must reach set_onboard_pin as
+        if_absent=True (the NX write) — the wiring half of the
+        2026-06-10 pin-capture fix."""
+        from src.mcp_handlers.identity import handlers as h
+
+        mock_redis.get.return_value = None
+        mock_db.get_session.return_value = None
+        mock_db.find_agent_by_label.return_value = None
+        mock_db.get_identity.side_effect = [
+            None, None, SimpleNamespace(identity_id="ni", metadata={}),
+        ]
+
+        pin_mock = AsyncMock(return_value=True)
+        with patch.object(h, "set_onboard_pin", pin_mock):
+            result = await h.handle_onboard_v2({
+                "client_session_id": "onboard-subagent-wiring",
+                "force_new": True,
+                "spawn_reason": "subagent",
+            })
+        data = parse_result(result)
+        assert data["success"] is True
+        pin_mock.assert_awaited_once()
+        assert pin_mock.await_args.kwargs.get("if_absent") is True
+
+    @pytest.mark.asyncio
+    async def test_driver_onboard_passes_if_absent_false(self, patch_onboard_deps, mock_db, mock_redis):
+        """new_session (and absent) spawn reasons keep last-writer-wins."""
+        from src.mcp_handlers.identity import handlers as h
+
+        mock_redis.get.return_value = None
+        mock_db.get_session.return_value = None
+        mock_db.find_agent_by_label.return_value = None
+        mock_db.get_identity.side_effect = [
+            None, None, SimpleNamespace(identity_id="ni", metadata={}),
+        ]
+
+        pin_mock = AsyncMock(return_value=True)
+        with patch.object(h, "set_onboard_pin", pin_mock):
+            result = await h.handle_onboard_v2({
+                "client_session_id": "onboard-driver-wiring",
+                "force_new": True,
+                "spawn_reason": "new_session",
+            })
+        data = parse_result(result)
+        assert data["success"] is True
+        pin_mock.assert_awaited_once()
+        assert pin_mock.await_args.kwargs.get("if_absent") is False
 
     @pytest.mark.asyncio
     async def test_arg_less_onboard_gates_to_fresh_per_v2_ontology(self, patch_onboard_deps, mock_db, mock_redis, caplog):

--- a/tests/test_identity_handlers.py
+++ b/tests/test_identity_handlers.py
@@ -459,15 +459,19 @@ class TestOnboardPin:
             assert result is False
 
 
-def _nx_fake_redis(stored_data):
+def _nx_fake_redis(stored_data, set_calls=None):
     """Dict-backed raw-Redis fake supporting setex, get, expire, and
-    SET NX (the if_absent path)."""
+    SET NX (the if_absent path). ``set_calls`` (optional list) records
+    (key, ex, nx) per set() call so tests can assert TTL is carried on
+    the NX path too."""
     mock_raw = AsyncMock()
 
     async def mock_setex(key, ttl, value):
         stored_data[key] = value
 
     async def mock_set(key, value, ex=None, nx=False):
+        if set_calls is not None:
+            set_calls.append((key, ex, nx))
         if nx and key in stored_data:
             return None  # redis-py returns None when NX blocks the write
         stored_data[key] = value
@@ -522,16 +526,19 @@ class TestSubagentPinCapture:
     @pytest.mark.asyncio
     async def test_subagent_if_absent_claims_empty_slot(self):
         """No standing pin (subagent on a fresh fingerprint) → the
-        subagent may claim it, preserving its own continuity."""
+        subagent may claim it, preserving its own continuity. The NX
+        write must carry the same TTL as the SETEX path."""
         from src.mcp_handlers.identity.handlers import (
             lookup_onboard_pin,
             set_onboard_pin,
         )
+        from src.mcp_handlers.identity.session import _PIN_TTL
 
         stored = {}
+        set_calls = []
 
         async def _get_raw():
-            return _nx_fake_redis(stored)
+            return _nx_fake_redis(stored, set_calls)
 
         with patch("src.cache.redis_client.get_redis", new=_get_raw):
             claimed = await set_onboard_pin(
@@ -540,6 +547,10 @@ class TestSubagentPinCapture:
             )
             assert claimed is True
             assert await lookup_onboard_pin("ua:fresh1") == "agent-subagent-9999"
+        assert set_calls, "NX path must go through set(), not setex()"
+        for _key, ex, nx in set_calls:
+            assert nx is True
+            assert ex == _PIN_TTL
 
     @pytest.mark.asyncio
     async def test_driver_onboard_still_displaces(self):
@@ -1927,6 +1938,43 @@ class TestHandleOnboardV2:
                 "client_session_id": "onboard-driver-wiring",
                 "force_new": True,
                 "spawn_reason": "new_session",
+            })
+        data = parse_result(result)
+        assert data["success"] is True
+        pin_mock.assert_awaited_once()
+        assert pin_mock.await_args.kwargs.get("if_absent") is False
+
+    @pytest.mark.asyncio
+    async def test_driver_succession_inference_never_triggers_nx(self, patch_onboard_deps, mock_db, mock_redis):
+        """Council block (PR #604): the textbook succession onboard —
+        parent_agent_id declared, spawn_reason OMITTED, thread already
+        has nodes — lets infer_spawn_reason label the fork 'subagent'
+        (client_hint absent from arguments). The NX gate must key on the
+        EXPLICIT argument only, so this driver still takes the pin
+        (if_absent=False) instead of being locked behind its dead
+        predecessor's still-live pin."""
+        from src.mcp_handlers.identity import handlers as h
+
+        mock_redis.get.return_value = None
+        mock_db.get_session.return_value = None
+        mock_db.find_agent_by_label.return_value = None
+        mock_db.get_identity.side_effect = [
+            None, None, SimpleNamespace(identity_id="ni", metadata={}),
+        ]
+        # Charitable lineage path: parent has no class tag.
+        mock_db.read_class_tag = AsyncMock(return_value=None)
+        # Existing thread nodes make the inference branch reachable.
+        mock_db.get_thread_nodes.return_value = [
+            {"agent_uuid": "dead-predecessor", "position": 1},
+        ]
+
+        pin_mock = AsyncMock(return_value=True)
+        with patch.object(h, "set_onboard_pin", pin_mock):
+            result = await h.handle_onboard_v2({
+                "client_session_id": "onboard-succession-wiring",
+                "force_new": True,
+                "parent_agent_id": "11111111-2222-3333-4444-555555555555",
+                # spawn_reason deliberately omitted — inference territory
             })
         data = parse_result(result)
         assert data["success"] is True


### PR DESCRIPTION
## Incident (dogfood, 2026-06-10)

The driver session's governance attribution silently broke ALL DAY. Reconstructed from `audit.tool_usage` + `core.identities`:

| pin stolen by | onboarded | driver's check-ins captured |
|---|---|---|
| branch-rescue batch (last of 5) | 00:33 | 14 (00:41–12:58 window) |
| council-verifier-pr597 | 01:54 | 5 |
| rescue-housekeeping | 05:57 | 5 |
| council-verifier-pr598 | 06:33 | 11 |
| council-verifier-pr599 | 07:23 | 11 |
| council-verifier-pr600 | 11:12 | 7 |
| council-architect-pr601 | 11:53 | 3 + leave_note + the #603 validation probes |

The driver's own identity (`be70db89`) froze at 00:06. **MCP restarts were red herrings** — the steal is immediate at subagent onboard, because the streamable transport runs stateless for this client (no `Mcp-Session-Id`), so *every* argument-less call re-derives its session key through `recent_onboard:<fingerprint>` — and `set_onboard_pin` is an unconditional `SETEX` on a key all same-host Claude Code processes share.

## Fix

Spawn-aware pin write: `spawn_reason='subagent'` onboards write each pin candidate with **SET NX + EX** — a standing (driver's) pin is never displaced; an empty slot may still be claimed. Driver-shaped onboards keep last-writer-wins (succession: a fresh driver session on the same host must take the fingerprint; it declares `spawn_reason='new_session'`). Subagents keep continuity the documented way — echoing their onboard's `client_session_id`.

Considered and rejected: first-writer-wins for everyone (breaks driver succession — resurrects stale identity by fingerprint); parent-aware NX (a fresh driver declaring lineage would also be blocked); candidate-list disambiguation at lookup (no discriminator exists in the argument-less fallback by definition).

## Residual (documented, not fixed here)

A subagent that does NOT echo its `client_session_id` now falls through to the driver's pin — its check-ins would land on the driver. That is the pre-existing error direction for any non-echoing client sharing a fingerprint, bounded to lazy subagents, vs. today's inversion where one onboard corrupts the long-lived trajectory-bearing identity for the rest of the session. Dispatch prompts now instruct echoing.

## Recovery note

The strong rebind lever works: `identity(agent_uuid=…, continuity_token=…, resume=true)` → tier strong via `agent_uuid_direct_fastpath` (the `resume=true` flag is required or the S1-c token-retirement gate rejects the shape).

Tests: incident shape, empty-slot claim, driver succession, set membership, handler wiring both ways. Full suite 9299 green. Identity = single-writer surface: `gh pr list` checked clean on both repos at investigation start; council review incoming.