### PR TITLE
fix(metrics): zero-observation responses stop asserting seed-derived assessments

### DIFF
--- a/src/mcp_handlers/introspection/feedback.py
+++ b/src/mcp_handlers/introspection/feedback.py
@@ -55,6 +55,14 @@ def get_calibration_feedback(include_complexity: bool = True) -> Dict[str, Any]:
                         show_message = True
 
                     calibration_feedback['confidence'] = {
+                        # Fleet-wide singleton data (calibration_checker
+                        # aggregates across ALL agents). The scope label is
+                        # unconditional — the explanatory message below is
+                        # cache-gated and absent most of the time, which left
+                        # bare fleet numbers in agent-scoped responses
+                        # looking like personal calibration (dogfood
+                        # 2026-06-10; same class as the #572 mirror fix).
+                        'scope': 'fleet',
                         'system_accuracy': overall_accuracy,
                         'mean_confidence': mean_confidence,
                         'calibration_error': calibration_error

--- a/src/services/runtime_queries.py
+++ b/src/services/runtime_queries.py
@@ -158,6 +158,20 @@ async def get_governance_metrics_data(agent_id: str, arguments: Dict[str, Any], 
     include_state = arguments.get("include_state", False)
     metrics = monitor.get_metrics(include_state=include_state)
 
+    # Zero-observation honesty (dogfood 2026-06-10, cold-caller probe):
+    # everything below that ASSESSES the agent (summary, health/mode/
+    # basin/trajectory/guidance, stability, regime, phi, fleet
+    # calibration) is gated on this flag. On zero observations those
+    # values are functions of the default seed vector — identical for
+    # every fresh agent, zero information about THIS one — and
+    # presenting them unlabeled beside the honest "uninitialized"
+    # status fabricates a measurement that never happened. Same flag
+    # the lite status/coherence/risk treatment already uses.
+    is_uninitialized = (
+        metrics.get("initialized") is False
+        or metrics.get("status") == "uninitialized"
+    )
+
     from src.governance_monitor import UNITARESMonitor
     from src.mcp_handlers.utils import format_metrics_report, get_calibration_feedback
 
@@ -192,33 +206,67 @@ async def get_governance_metrics_data(agent_id: str, arguments: Dict[str, Any], 
         standardized_metrics["purpose"] = meta.purpose
 
     calibration_feedback = {}
-    try:
-        if meta:
-            derived_complexity = metrics.get("complexity", None)
-            if derived_complexity is not None:
-                calibration_feedback["complexity"] = {
-                    "derived": derived_complexity,
-                    "message": f"System-derived complexity: {derived_complexity:.2f} (based on current state)",
-                }
-    except Exception as e:
-        logger.debug(f"Could not add complexity calibration feedback: {e}")
+    if not is_uninitialized:
+        try:
+            if meta:
+                derived_complexity = metrics.get("complexity", None)
+                if derived_complexity is not None:
+                    calibration_feedback["complexity"] = {
+                        "derived": derived_complexity,
+                        "message": f"System-derived complexity: {derived_complexity:.2f} (based on current state)",
+                    }
+        except Exception as e:
+            logger.debug(f"Could not add complexity calibration feedback: {e}")
 
-    confidence_feedback = get_calibration_feedback(include_complexity=False)
-    if confidence_feedback:
-        calibration_feedback.update(confidence_feedback)
+        confidence_feedback = get_calibration_feedback(include_complexity=False)
+        if confidence_feedback:
+            calibration_feedback.update(confidence_feedback)
     if calibration_feedback:
         standardized_metrics["calibration_feedback"] = calibration_feedback
 
-    try:
-        risk_score = metrics.get("risk_score") or metrics.get("latest_risk_score")
-        interpreted_state = monitor.state.interpret_state(risk_score=risk_score)
-        standardized_metrics["state"] = interpreted_state
-        health = interpreted_state.get("health", "unknown")
-        mode = interpreted_state.get("mode", "unknown")
-        basin = interpreted_state.get("basin", "unknown")
-        standardized_metrics["summary"] = f"{health} | {mode} | {basin} basin"
-    except Exception as e:
-        logger.debug(f"Could not generate state interpretation: {e}")
+    if is_uninitialized:
+        # No interpret_state call: health/mode/basin/trajectory/guidance
+        # would describe the seed vector, and its borderline branch emits
+        # "Pattern may be shifting" on an agent with no pattern.
+        standardized_metrics["summary"] = "uninitialized | no observations yet"
+        standardized_metrics["state"] = {
+            "status": "pending (first check-in required)",
+            "note": (
+                "health/mode/basin/trajectory are withheld until the first "
+                "check-in — on zero observations they would describe the "
+                "default seed vector, identically for every fresh agent."
+            ),
+        }
+        # Same treatment for the analysis blocks get_metrics() derives
+        # from the seed state: real math, no agent-specific signal.
+        if "stability" in standardized_metrics:
+            standardized_metrics["stability"] = {
+                "status": "pending (first check-in required)",
+                "note": (
+                    "Lyapunov analysis runs on the default seed vector until "
+                    "observations accumulate; reporting it would imply a "
+                    "measurement of this agent."
+                ),
+            }
+        if "regime" in standardized_metrics:
+            standardized_metrics["regime"] = None
+        if "phi" in standardized_metrics:
+            standardized_metrics["phi"] = None
+        v41 = standardized_metrics.get("unitares_v41")
+        if isinstance(v41, dict) and "basin" in v41:
+            v41["basin"] = None
+            v41["basin_note"] = "pending (first check-in required)"
+    else:
+        try:
+            risk_score = metrics.get("risk_score") or metrics.get("latest_risk_score")
+            interpreted_state = monitor.state.interpret_state(risk_score=risk_score)
+            standardized_metrics["state"] = interpreted_state
+            health = interpreted_state.get("health", "unknown")
+            mode = interpreted_state.get("mode", "unknown")
+            basin = interpreted_state.get("basin", "unknown")
+            standardized_metrics["summary"] = f"{health} | {mode} | {basin} basin"
+        except Exception as e:
+            logger.debug(f"Could not generate state interpretation: {e}")
 
     try:
         from governance_core import compute_saturation_diagnostics
@@ -281,9 +329,16 @@ async def get_governance_metrics_data(agent_id: str, arguments: Dict[str, Any], 
                 standardized_metrics.get("primary_eisv_source")
             ),
             "summary": standardized_metrics.get("summary"),
-            "guidance": state.get("guidance"),
+            "guidance": (
+                "Submit one check-in to activate governance."
+                if is_uninitialized
+                else state.get("guidance")
+            ),
         })
-        if state_present:
+        # basin/mode are assessments — withheld for uninitialized agents
+        # (the pending state dict has no basin/mode keys; explain_*(None)
+        # would leak {"value": null} without a meaning).
+        if state_present and not is_uninitialized:
             standard_metrics["basin"] = explain_basin(state.get("basin"))
             standard_metrics["mode"] = explain_mode(state.get("mode"))
         if public_agent_id != agent_id:
@@ -305,7 +360,8 @@ async def get_governance_metrics_data(agent_id: str, arguments: Dict[str, Any], 
             "critical": "🔴",
             "unknown": "⚪",
         }.get(health, "⚪")
-        is_uninitialized = metrics.get("initialized") is False or metrics.get("status") == "uninitialized"
+        # is_uninitialized computed once, function-scope, right after
+        # get_metrics() — the same flag gates summary/state/stability up top.
 
         if is_uninitialized:
             status_display = "⚪ uninitialized"
@@ -366,7 +422,9 @@ async def get_governance_metrics_data(agent_id: str, arguments: Dict[str, Any], 
         lite_metrics["primary_eisv_source_meta"] = explain_eisv_source(
             standardized_metrics.get("primary_eisv_source")
         )
-        if "state" in standardized_metrics:
+        # mode/basin are assessments — withheld for uninitialized agents
+        # (the pending state dict carries no mode/basin keys).
+        if "state" in standardized_metrics and not is_uninitialized:
             lite_metrics["mode"] = explain_mode(standardized_metrics["state"].get("mode"))
             lite_metrics["basin"] = explain_basin(standardized_metrics["state"].get("basin"))
         if is_uninitialized:

--- a/src/services/runtime_queries.py
+++ b/src/services/runtime_queries.py
@@ -252,6 +252,15 @@ async def get_governance_metrics_data(agent_id: str, arguments: Dict[str, Any], 
             standardized_metrics["regime"] = None
         if "phi" in standardized_metrics:
             standardized_metrics["phi"] = None
+        # _build_eisv_semantics merged seed phi/regime into the nested
+        # ode_diagnostics block before this branch ran — null them there
+        # too, or the full response contradicts its own top-level nulls
+        # (review fold, PR #605).
+        ode_diag = standardized_metrics.get("ode_diagnostics")
+        if isinstance(ode_diag, dict):
+            for seed_key in ("phi", "regime"):
+                if seed_key in ode_diag:
+                    ode_diag[seed_key] = None
         v41 = standardized_metrics.get("unitares_v41")
         if isinstance(v41, dict) and "basin" in v41:
             v41["basin"] = None

--- a/tests/test_zero_observation_honesty.py
+++ b/tests/test_zero_observation_honesty.py
@@ -67,11 +67,20 @@ async def test_uninitialized_full_shape_withholds_assessments():
     for key in ("health", "mode", "basin", "trajectory", "guidance"):
         assert key not in data["state"]
     # Seed-derived analysis blocks are withheld, not reported as measurement.
-    if "stability" in data:
-        assert data["stability"]["status"] == "pending (first check-in required)"
-        assert "stable" not in data["stability"]
+    # stability is ALWAYS present in the full shape (get_monitor_metrics
+    # emits it unconditionally) — assert presence so a regression that
+    # drops the block entirely cannot silently skip these checks.
+    assert "stability" in data
+    assert data["stability"]["status"] == "pending (first check-in required)"
+    assert "stable" not in data["stability"]
     assert data.get("regime") is None
     assert data.get("phi") is None
+    # The nested ode_diagnostics block must not contradict the top-level
+    # nulls with seed values (review fold).
+    ode_diag = data.get("ode_diagnostics")
+    if isinstance(ode_diag, dict):
+        assert ode_diag.get("phi") is None
+        assert ode_diag.get("regime") is None
     v41 = data.get("unitares_v41")
     if isinstance(v41, dict):
         assert v41.get("basin") is None

--- a/tests/test_zero_observation_honesty.py
+++ b/tests/test_zero_observation_honesty.py
@@ -1,0 +1,162 @@
+"""Zero-observation honesty for the read-only metrics surface.
+
+Dogfood 2026-06-10 (cold-caller probe, trust-contract review): a
+zero-observation agent's get_governance_metrics response asserted
+`summary: "moderate | building_alone | high basin"`, a mode block
+reading the seed vector as "focused independent work", a
+`stability.stable=True` Lyapunov analysis, `regime: divergence`, a
+seed phi, and unlabeled fleet-wide calibration numbers — all beside an
+honest `status: uninitialized` and pending coherence/risk. These values
+are functions of the default seed vector: identical for every fresh
+agent, zero information about THIS one.
+
+`get_governance_metrics_data` now gates every assessment on the same
+`is_uninitialized` flag the status/coherence/risk treatment already
+used.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# Settle the handler import chain BEFORE anything pulls
+# src.services.runtime_queries: importing it while governance_monitor's
+# own import is mid-flight trips the runtime_queries ↔ observability/
+# outcome_events cycle (`_build_eisv_semantics` from a partially
+# initialized module).
+import src.mcp_handlers.core  # noqa: F401  (import-order anchor)
+
+
+def _server_for(monitor):
+    return SimpleNamespace(
+        get_or_create_monitor=lambda aid: monitor,
+        agent_metadata={},
+    )
+
+
+def _fresh_monitor(agent_id="test-zeroobs-fresh"):
+    # Deferred import — runtime_queries participates in an import cycle
+    # (its own consumers import it inside functions for the same reason).
+    from src.governance_monitor import UNITARESMonitor
+    return UNITARESMonitor(agent_id, load_state=False)
+
+
+@pytest.fixture(autouse=True)
+def _no_db_hydration():
+    with patch(
+        "src.agent_monitor_state.hydrate_from_db_if_fresh",
+        new=AsyncMock(return_value=False),
+    ):
+        yield
+
+
+@pytest.mark.asyncio
+async def test_uninitialized_full_shape_withholds_assessments():
+    monitor = _fresh_monitor()
+    from src.services.runtime_queries import get_governance_metrics_data
+    data = await get_governance_metrics_data(
+        "test-zeroobs-fresh", {"lite": False}, server=_server_for(monitor)
+    )
+
+    assert data["summary"] == "uninitialized | no observations yet"
+    assert data["state"]["status"] == "pending (first check-in required)"
+    # No fabricated interpretation keys on the pending state block.
+    for key in ("health", "mode", "basin", "trajectory", "guidance"):
+        assert key not in data["state"]
+    # Seed-derived analysis blocks are withheld, not reported as measurement.
+    if "stability" in data:
+        assert data["stability"]["status"] == "pending (first check-in required)"
+        assert "stable" not in data["stability"]
+    assert data.get("regime") is None
+    assert data.get("phi") is None
+    v41 = data.get("unitares_v41")
+    if isinstance(v41, dict):
+        assert v41.get("basin") is None
+    # Fleet-scoped calibration has no place in a zero-history response.
+    assert "calibration_feedback" not in data
+
+
+@pytest.mark.asyncio
+async def test_uninitialized_lite_shape_withholds_mode_and_basin():
+    monitor = _fresh_monitor()
+    from src.services.runtime_queries import get_governance_metrics_data
+    data = await get_governance_metrics_data(
+        "test-zeroobs-fresh", {"lite": True}, server=_server_for(monitor)
+    )
+
+    assert data["status"] == "⚪ uninitialized"
+    assert data["summary"] == "uninitialized | no observations yet"
+    assert "mode" not in data
+    assert "basin" not in data
+    # The existing honest fields stay honest.
+    assert data["verdict"]["value"] == "uninitialized"
+    assert data["guidance"] == "Submit one check-in to activate governance."
+    assert data["coherence"]["value"] is None
+    assert data["risk_score"]["value"] is None
+
+
+@pytest.mark.asyncio
+async def test_uninitialized_standard_shape_withholds_mode_and_basin():
+    monitor = _fresh_monitor()
+    from src.services.runtime_queries import get_governance_metrics_data
+    data = await get_governance_metrics_data(
+        "test-zeroobs-fresh", {"verbosity": "standard"}, server=_server_for(monitor)
+    )
+
+    assert data["summary"] == "uninitialized | no observations yet"
+    assert data["guidance"] == "Submit one check-in to activate governance."
+    assert "basin" not in data
+    assert "mode" not in data
+
+
+@pytest.mark.asyncio
+async def test_initialized_agent_keeps_interpretation():
+    """Regression guard: one real check-in restores the full
+    interpretation surface — the gate must not over-suppress."""
+    monitor = _fresh_monitor("test-zeroobs-active")
+    monitor.process_update({
+        "response_text": "Working through the zero-observation honesty fix.",
+        "complexity": 0.5,
+    })
+
+    from src.services.runtime_queries import get_governance_metrics_data
+    data = await get_governance_metrics_data(
+        "test-zeroobs-active", {"lite": False}, server=_server_for(monitor)
+    )
+
+    assert " | " in data["summary"]
+    assert data["summary"].endswith("basin")
+    for key in ("health", "mode", "basin", "trajectory"):
+        assert key in data["state"]
+    assert data.get("phi") is not None
+    if "stability" in data:
+        assert "stable" in data["stability"]
+
+    lite = await get_governance_metrics_data(
+        "test-zeroobs-active", {"lite": True}, server=_server_for(monitor)
+    )
+    assert "mode" in lite
+    assert "basin" in lite
+
+
+def test_fleet_calibration_feedback_carries_scope_label():
+    """The fleet-wide calibration numbers must self-identify as fleet
+    data even when the cache-gated explanatory message is absent."""
+    from src.mcp_handlers.introspection.feedback import get_calibration_feedback
+
+    fake_metrics = {
+        "bins": {
+            "0.8-1.0": {"count": 10, "accuracy": 0.9, "expected_accuracy": 0.95},
+        }
+    }
+    with patch(
+        "src.calibration.calibration_checker.check_calibration",
+        return_value=(False, fake_metrics),
+    ):
+        feedback = get_calibration_feedback(include_complexity=False)
+
+    assert feedback["confidence"]["scope"] == "fleet"
+    assert "system_accuracy" in feedback["confidence"]


### PR DESCRIPTION
## Source

External trust-contract review (claude.ai session probing the live MCP, relayed by operator) + my own cold-caller reproduction (fresh UA via REST, three probes).

## Confirmed (and now fixed)

| Claim | Status |
|---|---|
| `summary: 'moderate \| building_alone \| high basin'` on zero observations | CONFIRMED — `interpret_state` runs on the seed vector unconditionally |
| `stability.stable=True` + 15-decimal Lyapunov alpha as measurement | CONFIRMED — real eigenvalue math on the seed point, no agent signal |
| `guidance: 'Pattern may be shifting'` with no pattern | CONFIRMED — `_generate_guidance` borderline branch on seed values |
| Fleet `system_accuracy` unlabeled in agent-scoped response | CONFIRMED — the 'System-wide' disclaimer is cache-gated; bare numbers leak the rest of the time |
| Read call auto-mints identity | PARTIAL — real, but **in-memory only** (3 probes → 3 fresh `auto_*` identities, **zero** `core.identities` rows; 3,934 count is historical). The ghost-ROW factory claim is refuted; the per-call in-memory monitor growth is real and is the follow-up PR (middleware no-mint flag for read-only tools, identity surface + council) |

## Fix

One `is_uninitialized` flag (the same one already gating lite status/coherence/risk), now gating *every* assessment: summary, state interpretation, stability, regime, phi, `unitares_v41.basin`, mode/basin glossary blocks, calibration_feedback. Initialized agents are untouched (regression-guarded). `calibration_feedback.confidence` gains an unconditional `scope: 'fleet'` label.

Pattern precedent: #572 (fleet line out of the mirror), #603 (proxy-basis disclosure). The principle is the trust-contract's: on zero observations, an assessment is a property of the seed constants, not the agent — withhold it or it reads as measurement.

Full suite 9306 green.