### PR TITLE
fix(metrics): provenance label on saturation_diagnostics (trust-contract §2)

### DIFF
--- a/src/services/runtime_queries.py
+++ b/src/services/runtime_queries.py
@@ -287,6 +287,17 @@ async def get_governance_metrics_data(agent_id: str, arguments: Dict[str, Any], 
         if unitares_state:
             sat_diag = compute_saturation_diagnostics(unitares_state, theta)
             standardized_metrics["saturation_diagnostics"] = {
+                # Provenance (trust-contract §2): these are properties of
+                # the ODE CONFIGURATION evaluated at the current state
+                # vector — legitimate model diagnostics even pre-check-in,
+                # but at zero observations the state input is the seed, so
+                # the values describe the config, not this agent. Labeled,
+                # not suppressed (external re-probe finding, 2026-06-11).
+                "source": (
+                    "config_derived (parameters + seed state — no observations yet)"
+                    if is_uninitialized
+                    else "derived (parameters + current state)"
+                ),
                 "sat_margin": sat_diag["sat_margin"],
                 "dynamics_mode": sat_diag["dynamics_mode"],
                 "will_saturate": sat_diag["will_saturate"],

--- a/tests/test_zero_observation_honesty.py
+++ b/tests/test_zero_observation_honesty.py
@@ -84,6 +84,11 @@ async def test_uninitialized_full_shape_withholds_assessments():
     v41 = data.get("unitares_v41")
     if isinstance(v41, dict):
         assert v41.get("basin") is None
+    # saturation_diagnostics is legitimate config-derived math — labeled,
+    # not suppressed (external re-probe finding, 2026-06-11). Present on
+    # every fresh monitor (unitaires_state initializes at construction).
+    assert "saturation_diagnostics" in data
+    assert data["saturation_diagnostics"]["source"].startswith("config_derived")
     # Fleet-scoped calibration has no place in a zero-history response.
     assert "calibration_feedback" not in data
 
@@ -143,6 +148,8 @@ async def test_initialized_agent_keeps_interpretation():
     assert data.get("phi") is not None
     if "stability" in data:
         assert "stable" in data["stability"]
+    if "saturation_diagnostics" in data:
+        assert data["saturation_diagnostics"]["source"].startswith("derived")
 
     lite = await get_governance_metrics_data(
         "test-zeroobs-active", {"lite": True}, server=_server_for(monitor)


### PR DESCRIPTION
External re-probe of the deployed #605 found the one remaining row-1-adjacent residual: `saturation_diagnostics` emits `sat_margin`/`I_equilibrium` at zero observations unlabeled. These are legitimate **config-derived** diagnostics (ODE parameters evaluated at the state vector), so per trust-contract §2 the fix is a provenance label, not suppression: `config_derived (parameters + seed state — no observations yet)` when uninitialized, `derived (parameters + current state)` after. Reviewer's exact suggested shape. Tests pin both label forms. Closes the §6 row-1 family completely.