### PR TITLE
fix(knowledge): remove write-only last_referenced touches + retry AGE concurrent updates

### DIFF
--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -1679,21 +1679,6 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
         elif synthesize and len(discovery_list) < SYNTHESIS_THRESHOLD:
             response_data["_synthesis_note"] = f"Synthesis skipped: fewer than {SYNTHESIS_THRESHOLD} results"
 
-        # Touch last_referenced on results that had details included (fire-and-forget)
-        if include_details and results:
-            import asyncio
-
-            async def _touch_referenced(ids):
-                try:
-                    g = await get_knowledge_graph()
-                    now_iso = _utc_now_iso()
-                    for did in ids:
-                        await g.update_discovery(did, {"last_referenced": now_iso})
-                except Exception:
-                    pass  # Best-effort, don't fail the search
-
-            asyncio.create_task(_touch_referenced([d.id for d in results]))
-
         writer_sample = list({d.agent_id for d in results if d.agent_id})[:10]
         await _broadcast_knowledge_read(
             "search",
@@ -2091,17 +2076,6 @@ async def handle_get_discovery_details(arguments: Dict[str, Any]) -> Sequence[Te
                     "error": "Response chain traversal not supported by current backend",
                     "note": "Use AGE backend (UNITARES_KNOWLEDGE_BACKEND=age) for full graph features"
                 }
-
-        # Touch last_referenced (fire-and-forget keep-alive signal)
-        import asyncio
-
-        async def _touch(did):
-            try:
-                await graph.update_discovery(did, {"last_referenced": _utc_now_iso()})
-            except Exception:
-                pass
-
-        asyncio.create_task(_touch(discovery_id))
 
         await _broadcast_knowledge_read(
             "details",

--- a/src/storage/knowledge_graph_age.py
+++ b/src/storage/knowledge_graph_age.py
@@ -829,7 +829,7 @@ class KnowledgeGraphAGE:
         set_parts: List[str] = []
         params: List[Any] = []
 
-        for key in ("status", "severity", "type", "summary", "details", "last_referenced"):
+        for key in ("status", "severity", "type", "summary", "details"):
             if key in updates:
                 params.append(updates[key])
                 set_parts.append(f"{key} = ${len(params)}")
@@ -861,8 +861,11 @@ class KnowledgeGraphAGE:
         """Update discovery fields in AGE graph.
 
         Supports updating: status, resolved_at, updated_at, tags, severity, type,
-        summary, details, and last_referenced.
+        summary, and details.
         Falls back to direct SQL UPDATE when the discovery has no AGE node.
+        Retries once on AGE concurrent-update conflicts ("Entity failed to be
+        updated"), which AGE raises instead of re-evaluating the tuple the way
+        plain PostgreSQL UPDATE does under READ COMMITTED.
         """
         db = await self._get_db()
 
@@ -880,7 +883,7 @@ class KnowledgeGraphAGE:
             updates["tags"] = normalize_tags(updates["tags"])
 
         for key, value in updates.items():
-            if key in ("status", "resolved_at", "updated_at", "severity", "type", "last_referenced", "summary", "details"):
+            if key in ("status", "resolved_at", "updated_at", "severity", "type", "summary", "details"):
                 param_name = f"val_{key}"
                 set_parts.append(f"d.{key} = ${{{param_name}}}")
                 params[param_name] = value
@@ -899,19 +902,32 @@ class KnowledgeGraphAGE:
             RETURN d.id
         """
 
-        try:
-            async with db.transaction() as conn:
-                result = await db.graph_query(cypher, params, conn=conn)
-                if not result or (isinstance(result[0], dict) and "error" in result[0]):
-                    # No AGE node — fall back to SQL for SQL-only orphans.
-                    return await self._sql_update_discovery(discovery_id, updates)
-                await self._sync_updated_discovery_row(conn, discovery_id, updates)
-            if "summary" in updates or "details" in updates:
-                await self._refresh_embedding(discovery_id)
-            return True
-        except Exception as e:
-            logger.error(f"Failed to update discovery {discovery_id}: {e}")
-            return False
+        max_attempts = 2
+        for attempt in range(1, max_attempts + 1):
+            try:
+                async with db.transaction() as conn:
+                    result = await db.graph_query(cypher, params, conn=conn)
+                    if not result or (isinstance(result[0], dict) and "error" in result[0]):
+                        # No AGE node — fall back to SQL for SQL-only orphans.
+                        return await self._sql_update_discovery(discovery_id, updates)
+                    await self._sync_updated_discovery_row(conn, discovery_id, updates)
+                if "summary" in updates or "details" in updates:
+                    await self._refresh_embedding(discovery_id)
+                return True
+            except Exception as e:
+                # AGE raises TM_Updated ("Entity failed to be updated: 3") on a
+                # write-write race; the conflict is transient once the other
+                # transaction commits, so one retry resolves it.
+                if "Entity failed to be updated" in str(e) and attempt < max_attempts:
+                    logger.warning(
+                        f"Concurrent update conflict on discovery {discovery_id}; "
+                        f"retrying (attempt {attempt + 1} of {max_attempts})"
+                    )
+                    await asyncio.sleep(0.05 * attempt)
+                    continue
+                logger.error(f"Failed to update discovery {discovery_id}: {e}")
+                return False
+        return False
 
     async def get_stats(
         self,
@@ -2230,6 +2246,12 @@ class KnowledgeGraphAGE:
 
         Stale discoveries are old, unresolved items that might need
         archiving or resolution.
+
+        Staleness is creation-time based (d.timestamp). Read-recency, if a
+        future predicate wants it, is durably recorded in audit.events as
+        knowledge_read events (via _broadcast_knowledge_read) — do not
+        reintroduce a per-read vertex property for it; that caused AGE
+        TM_Updated write-write races (removed 2026-06-11).
 
         Args:
             older_than_days: Find discoveries older than this

--- a/tests/test_age_sql_fallback.py
+++ b/tests/test_age_sql_fallback.py
@@ -458,3 +458,105 @@ class TestUpdateDiscoverySQLFallback:
         assert ok is True
         db.graph_query.assert_not_awaited()
         db._pool.fetchval.assert_not_awaited()
+
+
+# ===========================================================================
+# update_discovery concurrent-update retry (AGE TM_Updated)
+# ===========================================================================
+
+@pytest.mark.asyncio
+class TestUpdateDiscoveryConcurrentRetry:
+    """AGE raises "Entity failed to be updated: <TM_Result>" on a write-write
+    race instead of re-evaluating the tuple like plain PostgreSQL UPDATE.
+    The conflict is transient, so update_discovery retries once."""
+
+    def _kg_with_age_node(self, db):
+        db._pool.fetchval = AsyncMock(return_value=None)
+        return db
+
+    async def test_retries_once_on_concurrent_update_conflict(self):
+        db = _make_db(graph_available=True)
+        db.graph_query = AsyncMock(
+            side_effect=[
+                Exception("Entity failed to be updated: 3"),
+                [{"d.id": "disc-age-001"}],
+            ]
+        )
+        kg = await _make_kg(db)
+        kg._sync_updated_discovery_row = AsyncMock()  # type: ignore[assignment]
+        kg._refresh_embedding = AsyncMock()  # type: ignore[assignment]
+
+        ok = await kg.update_discovery("disc-age-001", {"status": "resolved"})
+
+        assert ok is True
+        assert db.graph_query.await_count == 2
+        kg._sync_updated_discovery_row.assert_awaited_once()
+
+    async def test_returns_false_when_conflict_persists(self):
+        db = _make_db(graph_available=True)
+        db.graph_query = AsyncMock(
+            side_effect=Exception("Entity failed to be updated: 3")
+        )
+        kg = await _make_kg(db)
+
+        ok = await kg.update_discovery("disc-age-001", {"status": "resolved"})
+
+        assert ok is False
+        assert db.graph_query.await_count == 2  # initial attempt + one retry
+
+    async def test_no_retry_on_unrelated_errors(self):
+        db = _make_db(graph_available=True)
+        db.graph_query = AsyncMock(side_effect=ValueError("boom"))
+        kg = await _make_kg(db)
+
+        ok = await kg.update_discovery("disc-age-001", {"status": "resolved"})
+
+        assert ok is False
+        assert db.graph_query.await_count == 1
+
+
+# ===========================================================================
+# last_referenced removed from the update surface
+# ===========================================================================
+
+@pytest.mark.asyncio
+class TestLastReferencedRemoved:
+    """last_referenced was a write-only AGE vertex property: no reader
+    anywhere, no SQL column, and its fire-and-forget touches raced between
+    concurrent sessions producing TM_Updated error storms. It is no longer
+    an updatable field on either path."""
+
+    async def test_age_path_treats_last_referenced_as_noop(self):
+        db = _make_db(graph_available=True)
+        kg = await _make_kg(db)
+
+        ok = await kg.update_discovery(
+            "disc-age-001", {"last_referenced": "2026-06-11T00:00:00+00:00"}
+        )
+
+        assert ok is True
+        db.graph_query.assert_not_awaited()
+        db._pool.fetchval.assert_not_awaited()
+
+    async def test_sql_fallback_treats_last_referenced_as_noop(self):
+        db = _make_db(graph_available=False)
+        kg = await _make_kg(db)
+
+        ok = await kg._sql_update_discovery(
+            "disc-sql-001", {"last_referenced": "2026-06-11T00:00:00+00:00"}
+        )
+
+        assert ok is True
+        db._pool.fetchval.assert_not_awaited()
+
+    async def test_update_discovery_last_referenced_noop_when_graph_unavailable(self):
+        db = _make_db(graph_available=False)
+        kg = await _make_kg(db)
+
+        ok = await kg.update_discovery(
+            "disc-sql-001", {"last_referenced": "2026-06-11T00:00:00+00:00"}
+        )
+
+        assert ok is True
+        db.graph_query.assert_not_awaited()
+        db._pool.fetchval.assert_not_awaited()


### PR DESCRIPTION
## What

Kills an ongoing AGE error storm: **1,180 ERROR lines** of `Entity failed to be updated: 3` since 2026-05-30, still firing daily (40 today, last at 15:15 UTC).

- **Remove both `last_referenced` touch sites** in `knowledge/handlers.py` — the fire-and-forget per-result vertex writes on `search` (`include_details` / `auto_details` ≤3 results) and the unconditional touch on `details`.
- **Remove `last_referenced` from the `update_discovery` surface** (AGE allowed keys + SQL fallback column tuple — the SQL path would have generated `SET last_referenced = $n` against a column that does not exist in `knowledge.discoveries`).
- **Add a bounded retry (1 retry)** in `update_discovery` on AGE concurrent-update conflicts, hardening the remaining legitimate updates (status/tags/summary) against the same race class. AGE raises `TM_Updated` instead of re-evaluating the tuple the way plain PostgreSQL `UPDATE` does under READ COMMITTED.

## Why removal, not "make it real"

`last_referenced` is write-only:
- No reader in this repo, the plugin, the dashboards, or the resident agents (live-verified; 582 live AGE vertices carry the property, zero consumers).
- Staleness sweeps (`get_stale_discoveries`) use `d.timestamp` (creation time).
- No SQL column; `_sync_updated_discovery_row` skips it.

Removal is information-safe: both call sites keep `_broadcast_knowledge_read`, which durably persists `knowledge_read` events to `audit.events` — read-recency is reconstructable from there. A breadcrumb in `get_stale_discoveries` points future lifecycle work at that sink instead of back to a per-read vertex property. If read-popularity should ever extend KG lifecycle (operator call), the right shape is a migration-backed column + batched single UPDATE or a periodic rollup from `audit.events` — not a resurrected per-result touch.

## Verification

- Full local suite green (`test-cache.sh`), `tests/test_age_sql_fallback.py` 32 passed (6 new: retry success/exhaustion/non-retriable, last_referenced no-op on all three paths).
- 3-agent council: adversarial reviewer (no critical findings; coverage-gap test + log-message fixes applied), live-verifier (storm/backend/no-reader claims verified against live log, plist, and live AGE graph), dialectic (removal information-safe given the durable audit.events sink).

🤖 Generated with [Claude Code](https://claude.com/claude-code)