### PR TITLE
fix(audit): migration 045 — repair tz-induced partition gap + self-healing partition maintenance

### DIFF
--- a/db/postgres/migrations/045_audit_partition_tz_gap_repair.sql
+++ b/db/postgres/migrations/045_audit_partition_tz_gap_repair.sql
@@ -109,11 +109,15 @@ CREATE OR REPLACE FUNCTION audit.ensure_partition_indexes(
     p_partition TEXT
 ) RETURNS VOID AS $$
 BEGIN
-    EXECUTE format(
-        'CREATE INDEX IF NOT EXISTS idx_%s_agent_ts ON audit.%I (agent_id, ts DESC)',
-        p_partition, p_partition
-    );
+    -- The three original audit parents predate partitioned indexes and carry
+    -- per-partition index DDL. Parents whose indexes are declared ON the
+    -- partitioned table (e.g. r1_score_audit, relkind 'I' indexes) cascade
+    -- automatically and need nothing here.
     IF p_parent = 'events' THEN
+        EXECUTE format(
+            'CREATE INDEX IF NOT EXISTS idx_%s_agent_ts ON audit.%I (agent_id, ts DESC)',
+            p_partition, p_partition
+        );
         EXECUTE format(
             'CREATE INDEX IF NOT EXISTS idx_%s_type_ts ON audit.%I (event_type, ts DESC)',
             p_partition, p_partition
@@ -124,10 +128,18 @@ BEGIN
         );
     ELSIF p_parent = 'tool_usage' THEN
         EXECUTE format(
+            'CREATE INDEX IF NOT EXISTS idx_%s_agent_ts ON audit.%I (agent_id, ts DESC)',
+            p_partition, p_partition
+        );
+        EXECUTE format(
             'CREATE INDEX IF NOT EXISTS idx_%s_tool_ts ON audit.%I (tool_name, ts DESC)',
             p_partition, p_partition
         );
     ELSIF p_parent = 'outcome_events' THEN
+        EXECUTE format(
+            'CREATE INDEX IF NOT EXISTS idx_%s_agent_ts ON audit.%I (agent_id, ts DESC)',
+            p_partition, p_partition
+        );
         EXECUTE format(
             'CREATE INDEX IF NOT EXISTS idx_%s_type_ts ON audit.%I (outcome_type, ts DESC)',
             p_partition, p_partition
@@ -251,6 +263,48 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+-- audit.r1_score_audit (migration 031) copied the same DATE-cast pattern and
+-- — worse — had NO scheduled creation path at all: partitions existed only
+-- through 2026-07, so R1 score persistence (record_r1_score_audit, a plain
+-- INSERT that fails soft to False) would have silently stopped on 2026-08-01.
+-- Rebuild it on the deterministic bounds and wire it into maintenance below.
+-- No per-partition index DDL: r1's indexes are declared on the partitioned
+-- parent (relkind 'I') and cascade to new partitions automatically.
+CREATE OR REPLACE FUNCTION audit.create_r1_score_audit_partition(
+    p_year  INTEGER,
+    p_month INTEGER
+)
+RETURNS TEXT AS $$
+DECLARE
+    v_partition_name TEXT;
+    v_bounds RECORD;
+BEGIN
+    v_partition_name := format('r1_score_audit_%s_%s', p_year, lpad(p_month::text, 2, '0'));
+
+    IF EXISTS (
+        SELECT 1 FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid
+        WHERE n.nspname = 'audit' AND c.relname = v_partition_name
+    ) THEN
+        RETURN format('Partition %s already exists', v_partition_name);
+    END IF;
+
+    SELECT * INTO v_bounds
+      FROM audit.month_partition_bounds('audit.r1_score_audit'::regclass, p_year, p_month);
+    IF v_bounds.v_start >= v_bounds.v_end THEN
+        RETURN format('Month %s-%s already covered by existing partitions',
+                      p_year, lpad(p_month::text, 2, '0'));
+    END IF;
+
+    EXECUTE format(
+        'CREATE TABLE IF NOT EXISTS audit.%I PARTITION OF audit.r1_score_audit
+         FOR VALUES FROM (%L) TO (%L)',
+        v_partition_name, v_bounds.v_start, v_bounds.v_end
+    );
+
+    RETURN format('Created partition %s', v_partition_name);
+END;
+$$ LANGUAGE plpgsql;
+
 -- ---------------------------------------------------------------------------
 -- 4. Gap diagnostic
 -- ---------------------------------------------------------------------------
@@ -268,7 +322,8 @@ RETURNS TABLE(parent TEXT, gap_start TIMESTAMPTZ, gap_end TIMESTAMPTZ) AS $$
         JOIN pg_class parent ON parent.oid = i.inhparent
         JOIN pg_namespace n ON n.oid = parent.relnamespace
         WHERE n.nspname = 'audit'
-          AND parent.relname IN ('events', 'tool_usage', 'outcome_events')
+          AND parent.relname IN ('events', 'tool_usage', 'outcome_events',
+                                 'r1_score_audit')
           AND c.relkind = 'r'
     ), ordered AS (
         SELECT parent, lo, hi,
@@ -381,6 +436,20 @@ BEGIN
 
     v_msg := audit.create_outcome_partition(v_next_year, v_next_month);
     v_result := v_result || jsonb_build_object('outcome_events_next', v_msg);
+
+    -- r1_score_audit (migration 031) — guarded because the fresh-install
+    -- bootstrap (partitions.sql) defines this maintenance function before
+    -- migration 031 creates the r1 table. No retention drop by design: the
+    -- audit table keeps full score history (public KG nodes are the
+    -- 30-day-archived projection, see r1_maintenance.py).
+    IF to_regclass('audit.r1_score_audit') IS NOT NULL
+       AND to_regprocedure('audit.create_r1_score_audit_partition(integer, integer)') IS NOT NULL THEN
+        v_msg := audit.create_r1_score_audit_partition(v_current_year, v_current_month);
+        v_result := v_result || jsonb_build_object('r1_score_audit_current', v_msg);
+
+        v_msg := audit.create_r1_score_audit_partition(v_next_year, v_next_month);
+        v_result := v_result || jsonb_build_object('r1_score_audit_next', v_msg);
+    END IF;
 
     -- Clean up old partitions
     v_result := v_result || jsonb_build_object(

--- a/db/postgres/migrations/045_audit_partition_tz_gap_repair.sql
+++ b/db/postgres/migrations/045_audit_partition_tz_gap_repair.sql
@@ -1,17 +1,38 @@
--- Partition Management for audit.events and audit.tool_usage
--- Run after schema.sql
+-- 045_audit_partition_tz_gap_repair.sql
 --
--- Partition strategy: Monthly, with 180-day retention for events, 90-day for tool_usage
+-- Incident (found 2026-06-11): audit partitions through 2026-05 carry
+-- UTC-midnight bounds while 2026-06/07 carry America/Denver-midnight bounds,
+-- leaving a six-hour hole [2026-05-31 18:00-06, 2026-06-01 00:00-06) in
+-- audit.events, audit.tool_usage, and audit.outcome_events. Root cause: the
+-- create-partition helpers computed bounds from DATE values, which cast to
+-- timestamptz using the *session* TimeZone — the weekly maintenance task's
+-- session default flipped from UTC to America/Denver between runs. Inserts
+-- in the hole fail with "no partition of relation found for row"; the
+-- lease-plane audit outbox forwarder (ORDER BY ts ASC LIMIT 100) head-of-line
+-- blocked on 2,199 such rows and forwarded nothing after 2026-06-01.
 --
--- Usage:
---   1. Run this file to create initial partitions
---   2. Schedule partition_maintenance() weekly via pg_cron or external cron
+-- This migration makes partition management timezone-deterministic and
+-- self-healing:
+--   1. audit.month_partition_bounds() — deterministic month edges pinned to
+--      America/Denver (matching the live 2026-06/07 bounds so the chain
+--      continues without overlap), snapped to neighboring partitions' bounds
+--      so creation is gapless and overlap-free by construction.
+--   2. audit.ensure_partition_indexes() — shared per-parent index DDL.
+--   3. The three create_*_partition helpers rebuilt on (1)+(2).
+--   4. audit.partition_gaps() — diagnostic: holes between consecutive bounds.
+--   5. audit.partition_maintenance() — now fills any detected gap with a
+--      bounds-exact filler partition (raising a WARNING for observability)
+--      before the usual create/drop cycle.
+--   6. Runs partition_maintenance() once, which repairs the live hole and
+--      unblocks the forwarder backlog.
+--
+-- db/postgres/partitions.sql (the fresh-install bootstrap) is updated in the
+-- same commit; keep the two in sync.
 
--- =============================================================================
--- PARTITION CREATION FUNCTIONS
--- =============================================================================
+-- ---------------------------------------------------------------------------
+-- 1. Deterministic, neighbor-snapped month bounds
+-- ---------------------------------------------------------------------------
 
--- Timezone-deterministic month bounds, snapped to neighbors (migration 045)
 CREATE OR REPLACE FUNCTION audit.month_partition_bounds(
     p_parent REGCLASS,
     p_year INTEGER,
@@ -71,7 +92,10 @@ COMMENT ON FUNCTION audit.month_partition_bounds(REGCLASS, INTEGER, INTEGER) IS
     'snapped to neighboring partition bounds so creation is gapless and '
     'overlap-free regardless of what convention older partitions used.';
 
--- Shared per-parent index DDL (migration 045)
+-- ---------------------------------------------------------------------------
+-- 2. Shared per-parent index DDL
+-- ---------------------------------------------------------------------------
+
 CREATE OR REPLACE FUNCTION audit.ensure_partition_indexes(
     p_parent TEXT,
     p_partition TEXT
@@ -104,7 +128,10 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- Create a monthly partition for audit.events
+-- ---------------------------------------------------------------------------
+-- 3. Rebuild the three create helpers on (1) + (2)
+-- ---------------------------------------------------------------------------
+
 CREATE OR REPLACE FUNCTION audit.create_events_partition(
     p_year INTEGER,
     p_month INTEGER
@@ -142,7 +169,6 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- Create a monthly partition for audit.tool_usage
 CREATE OR REPLACE FUNCTION audit.create_tool_usage_partition(
     p_year INTEGER,
     p_month INTEGER
@@ -180,7 +206,6 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- Create a monthly partition for audit.outcome_events
 CREATE OR REPLACE FUNCTION audit.create_outcome_partition(
     p_year INTEGER,
     p_month INTEGER
@@ -218,132 +243,9 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- =============================================================================
--- RETENTION / CLEANUP FUNCTIONS
--- =============================================================================
-
--- Drop old event partitions (older than retention_days)
-CREATE OR REPLACE FUNCTION audit.drop_old_events_partitions(
-    p_retention_days INTEGER DEFAULT 180
-)
-RETURNS TABLE(partition_name TEXT, action TEXT) AS $$
-DECLARE
-    v_cutoff DATE;
-    v_rec RECORD;
-BEGIN
-    v_cutoff := current_date - (p_retention_days || ' days')::INTERVAL;
-
-    FOR v_rec IN
-        SELECT c.relname as partition_name,
-               pg_get_expr(c.relpartbound, c.oid) as partition_bound
-        FROM pg_class c
-        JOIN pg_namespace n ON n.oid = c.relnamespace
-        JOIN pg_inherits i ON i.inhrelid = c.oid
-        JOIN pg_class parent ON parent.oid = i.inhparent
-        WHERE n.nspname = 'audit'
-          AND parent.relname = 'events'
-          AND c.relkind = 'r'
-    LOOP
-        -- Extract end date from partition bound (e.g., "FOR VALUES FROM ('2025-01-01') TO ('2025-02-01')")
-        -- If end date < cutoff, drop it
-        IF v_rec.partition_bound ~ 'TO \(''(\d{4}-\d{2}-\d{2})' THEN
-            DECLARE
-                v_end_date DATE;
-            BEGIN
-                v_end_date := (regexp_match(v_rec.partition_bound, 'TO \(''(\d{4}-\d{2}-\d{2})'))[1]::DATE;
-                IF v_end_date < v_cutoff THEN
-                    EXECUTE format('DROP TABLE IF EXISTS audit.%I', v_rec.partition_name);
-                    partition_name := v_rec.partition_name;
-                    action := 'dropped';
-                    RETURN NEXT;
-                END IF;
-            END;
-        END IF;
-    END LOOP;
-END;
-$$ LANGUAGE plpgsql;
-
--- Drop old tool_usage partitions (older than retention_days)
-CREATE OR REPLACE FUNCTION audit.drop_old_tool_usage_partitions(
-    p_retention_days INTEGER DEFAULT 90
-)
-RETURNS TABLE(partition_name TEXT, action TEXT) AS $$
-DECLARE
-    v_cutoff DATE;
-    v_rec RECORD;
-BEGIN
-    v_cutoff := current_date - (p_retention_days || ' days')::INTERVAL;
-
-    FOR v_rec IN
-        SELECT c.relname as partition_name,
-               pg_get_expr(c.relpartbound, c.oid) as partition_bound
-        FROM pg_class c
-        JOIN pg_namespace n ON n.oid = c.relnamespace
-        JOIN pg_inherits i ON i.inhrelid = c.oid
-        JOIN pg_class parent ON parent.oid = i.inhparent
-        WHERE n.nspname = 'audit'
-          AND parent.relname = 'tool_usage'
-          AND c.relkind = 'r'
-    LOOP
-        IF v_rec.partition_bound ~ 'TO \(''(\d{4}-\d{2}-\d{2})' THEN
-            DECLARE
-                v_end_date DATE;
-            BEGIN
-                v_end_date := (regexp_match(v_rec.partition_bound, 'TO \(''(\d{4}-\d{2}-\d{2})'))[1]::DATE;
-                IF v_end_date < v_cutoff THEN
-                    EXECUTE format('DROP TABLE IF EXISTS audit.%I', v_rec.partition_name);
-                    partition_name := v_rec.partition_name;
-                    action := 'dropped';
-                    RETURN NEXT;
-                END IF;
-            END;
-        END IF;
-    END LOOP;
-END;
-$$ LANGUAGE plpgsql;
-
--- Drop old outcome_events partitions (older than retention_days)
-CREATE OR REPLACE FUNCTION audit.drop_old_outcome_partitions(
-    p_retention_days INTEGER DEFAULT 365
-)
-RETURNS TABLE(partition_name TEXT, action TEXT) AS $$
-DECLARE
-    v_cutoff DATE;
-    v_rec RECORD;
-BEGIN
-    v_cutoff := current_date - (p_retention_days || ' days')::INTERVAL;
-
-    FOR v_rec IN
-        SELECT c.relname as partition_name,
-               pg_get_expr(c.relpartbound, c.oid) as partition_bound
-        FROM pg_class c
-        JOIN pg_namespace n ON n.oid = c.relnamespace
-        JOIN pg_inherits i ON i.inhrelid = c.oid
-        JOIN pg_class parent ON parent.oid = i.inhparent
-        WHERE n.nspname = 'audit'
-          AND parent.relname = 'outcome_events'
-          AND c.relkind = 'r'
-    LOOP
-        IF v_rec.partition_bound ~ 'TO \(''(\d{4}-\d{2}-\d{2})' THEN
-            DECLARE
-                v_end_date DATE;
-            BEGIN
-                v_end_date := (regexp_match(v_rec.partition_bound, 'TO \(''(\d{4}-\d{2}-\d{2})'))[1]::DATE;
-                IF v_end_date < v_cutoff THEN
-                    EXECUTE format('DROP TABLE IF EXISTS audit.%I', v_rec.partition_name);
-                    partition_name := v_rec.partition_name;
-                    action := 'dropped';
-                    RETURN NEXT;
-                END IF;
-            END;
-        END IF;
-    END LOOP;
-END;
-$$ LANGUAGE plpgsql;
-
--- =============================================================================
--- MAINTENANCE FUNCTION (call weekly)
--- =============================================================================
+-- ---------------------------------------------------------------------------
+-- 4. Gap diagnostic
+-- ---------------------------------------------------------------------------
 
 CREATE OR REPLACE FUNCTION audit.partition_gaps()
 RETURNS TABLE(parent TEXT, gap_start TIMESTAMPTZ, gap_end TIMESTAMPTZ) AS $$
@@ -375,6 +277,10 @@ COMMENT ON FUNCTION audit.partition_gaps() IS
     'Holes between consecutive partition bounds of the monthly-partitioned '
     'audit parents. Non-empty output means inserts in the hole fail with '
     '"no partition of relation found for row".';
+
+-- ---------------------------------------------------------------------------
+-- 5. Maintenance now self-heals gaps
+-- ---------------------------------------------------------------------------
 
 CREATE OR REPLACE FUNCTION audit.partition_maintenance()
 RETURNS JSONB AS $$
@@ -476,57 +382,21 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- =============================================================================
--- INITIAL PARTITION CREATION
--- Create partitions for current month and next 2 months
--- =============================================================================
+-- ---------------------------------------------------------------------------
+-- 6. Repair the live hole now (guarded for fresh installs where the audit
+--    tables may not exist yet when this file is applied out of order)
+-- ---------------------------------------------------------------------------
 
 DO $$
-DECLARE
-    v_year INTEGER;
-    v_month INTEGER;
-    v_i INTEGER;
 BEGIN
-    FOR v_i IN 0..2 LOOP
-        v_year := EXTRACT(YEAR FROM current_date + (v_i || ' month')::INTERVAL)::INTEGER;
-        v_month := EXTRACT(MONTH FROM current_date + (v_i || ' month')::INTERVAL)::INTEGER;
-
-        PERFORM audit.create_events_partition(v_year, v_month);
-        PERFORM audit.create_tool_usage_partition(v_year, v_month);
-        PERFORM audit.create_outcome_partition(v_year, v_month);
-    END LOOP;
+    IF to_regclass('audit.events') IS NOT NULL
+       AND to_regclass('audit.tool_usage') IS NOT NULL
+       AND to_regclass('audit.outcome_events') IS NOT NULL THEN
+        PERFORM audit.partition_maintenance();
+    END IF;
 END $$;
 
--- =============================================================================
--- OPTIONAL: pg_cron SCHEDULING
--- Uncomment if pg_cron is installed
--- =============================================================================
-
--- SELECT cron.schedule(
---     'partition-maintenance',
---     '0 3 * * 0',  -- Every Sunday at 3 AM
---     'SELECT audit.partition_maintenance()'
--- );
-
--- =============================================================================
--- UTILITY VIEWS
--- =============================================================================
-
--- List all partitions with row counts and sizes
-CREATE OR REPLACE VIEW audit.v_partition_stats AS
-SELECT
-    n.nspname as schema_name,
-    parent.relname as parent_table,
-    c.relname as partition_name,
-    pg_get_expr(c.relpartbound, c.oid) as partition_bounds,
-    pg_size_pretty(pg_relation_size(c.oid)) as size,
-    (SELECT count(*) FROM pg_class WHERE oid = c.oid) as approx_rows
-FROM pg_class c
-JOIN pg_namespace n ON n.oid = c.relnamespace
-JOIN pg_inherits i ON i.inhrelid = c.oid
-JOIN pg_class parent ON parent.oid = i.inhparent
-WHERE n.nspname = 'audit'
-  AND c.relkind = 'r'
-ORDER BY parent.relname, c.relname;
-
-COMMENT ON VIEW audit.v_partition_stats IS 'Shows all audit partitions with sizes and bounds';
+-- Register migration
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (45, 'audit_partition_tz_gap_repair', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/db/postgres/migrations/045_audit_partition_tz_gap_repair.sql
+++ b/db/postgres/migrations/045_audit_partition_tz_gap_repair.sql
@@ -49,6 +49,14 @@ BEGIN
     -- already use Denver-midnight bounds — pinning UTC would overlap them
     -- at the next month boundary. make_timestamptz() with an explicit zone
     -- is immune to the session-TimeZone drift that caused the 2026-06 hole.
+    -- NOTE: on a FRESH install the pin is the sole bound-determinant (no
+    -- neighbor to snap to), so a future UTC-tz host bootstraps
+    -- Denver-offset bounds by design — internally consistent and gapless,
+    -- but offset from UTC month edges. Intended end-state is an
+    -- operator-gated detach/reattach normalization to uniform UTC bounds;
+    -- until then this pin and partitions.sql must stay in agreement.
+    -- (Denver DST transitions fire at 02:00 local on Sundays; month-firsts
+    -- at 00:00 are never skipped or ambiguous, verified 2000-2040.)
     v_start := make_timestamptz(p_year, p_month, 1, 0, 0, 0, 'America/Denver');
     IF p_month = 12 THEN
         v_end := make_timestamptz(p_year + 1, 1, 1, 0, 0, 0, 'America/Denver');
@@ -276,7 +284,11 @@ $$ LANGUAGE sql STABLE;
 COMMENT ON FUNCTION audit.partition_gaps() IS
     'Holes between consecutive partition bounds of the monthly-partitioned '
     'audit parents. Non-empty output means inserts in the hole fail with '
-    '"no partition of relation found for row".';
+    '"no partition of relation found for row". Blind spot: DEFAULT and '
+    'MINVALUE/MAXVALUE partitions do not match the bound regex and are '
+    'excluded — if a DEFAULT partition is ever added to these parents, '
+    'gaps adjacent to it become invisible here (rows route to the DEFAULT '
+    'instead of failing).';
 
 -- ---------------------------------------------------------------------------
 -- 5. Maintenance now self-heals gaps
@@ -302,6 +314,24 @@ BEGIN
         v_fill_name := format('%s_fill_%s', v_gap.parent,
                               to_char(v_gap.gap_start AT TIME ZONE 'UTC',
                                       'YYYYMMDD_HH24MI'));
+        -- An orphaned table squatting on the filler name would make
+        -- CREATE TABLE IF NOT EXISTS silently skip while the gap stays
+        -- open — surface that instead of warning identically every week.
+        IF EXISTS (
+            SELECT 1 FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = 'audit' AND c.relname = v_fill_name
+              AND NOT EXISTS (
+                  SELECT 1 FROM pg_inherits i
+                  JOIN pg_class p ON p.oid = i.inhparent
+                  WHERE i.inhrelid = c.oid AND p.relname = v_gap.parent
+              )
+        ) THEN
+            RAISE WARNING 'audit.% exists but is not attached to audit.%; '
+                'gap [% - %) cannot be auto-filled — manual intervention required',
+                v_fill_name, v_gap.parent, v_gap.gap_start, v_gap.gap_end;
+            CONTINUE;
+        END IF;
         EXECUTE format(
             'CREATE TABLE IF NOT EXISTS audit.%I PARTITION OF audit.%I
              FOR VALUES FROM (%L) TO (%L)',

--- a/db/postgres/partitions.sql
+++ b/db/postgres/partitions.sql
@@ -85,11 +85,15 @@ CREATE OR REPLACE FUNCTION audit.ensure_partition_indexes(
     p_partition TEXT
 ) RETURNS VOID AS $$
 BEGIN
-    EXECUTE format(
-        'CREATE INDEX IF NOT EXISTS idx_%s_agent_ts ON audit.%I (agent_id, ts DESC)',
-        p_partition, p_partition
-    );
+    -- The three original audit parents predate partitioned indexes and carry
+    -- per-partition index DDL. Parents whose indexes are declared ON the
+    -- partitioned table (e.g. r1_score_audit, relkind 'I' indexes) cascade
+    -- automatically and need nothing here.
     IF p_parent = 'events' THEN
+        EXECUTE format(
+            'CREATE INDEX IF NOT EXISTS idx_%s_agent_ts ON audit.%I (agent_id, ts DESC)',
+            p_partition, p_partition
+        );
         EXECUTE format(
             'CREATE INDEX IF NOT EXISTS idx_%s_type_ts ON audit.%I (event_type, ts DESC)',
             p_partition, p_partition
@@ -100,10 +104,18 @@ BEGIN
         );
     ELSIF p_parent = 'tool_usage' THEN
         EXECUTE format(
+            'CREATE INDEX IF NOT EXISTS idx_%s_agent_ts ON audit.%I (agent_id, ts DESC)',
+            p_partition, p_partition
+        );
+        EXECUTE format(
             'CREATE INDEX IF NOT EXISTS idx_%s_tool_ts ON audit.%I (tool_name, ts DESC)',
             p_partition, p_partition
         );
     ELSIF p_parent = 'outcome_events' THEN
+        EXECUTE format(
+            'CREATE INDEX IF NOT EXISTS idx_%s_agent_ts ON audit.%I (agent_id, ts DESC)',
+            p_partition, p_partition
+        );
         EXECUTE format(
             'CREATE INDEX IF NOT EXISTS idx_%s_type_ts ON audit.%I (outcome_type, ts DESC)',
             p_partition, p_partition
@@ -366,7 +378,8 @@ RETURNS TABLE(parent TEXT, gap_start TIMESTAMPTZ, gap_end TIMESTAMPTZ) AS $$
         JOIN pg_class parent ON parent.oid = i.inhparent
         JOIN pg_namespace n ON n.oid = parent.relnamespace
         WHERE n.nspname = 'audit'
-          AND parent.relname IN ('events', 'tool_usage', 'outcome_events')
+          AND parent.relname IN ('events', 'tool_usage', 'outcome_events',
+                                 'r1_score_audit')
           AND c.relkind = 'r'
     ), ordered AS (
         SELECT parent, lo, hi,
@@ -476,6 +489,20 @@ BEGIN
 
     v_msg := audit.create_outcome_partition(v_next_year, v_next_month);
     v_result := v_result || jsonb_build_object('outcome_events_next', v_msg);
+
+    -- r1_score_audit (migration 031) — guarded because the fresh-install
+    -- bootstrap (partitions.sql) defines this maintenance function before
+    -- migration 031 creates the r1 table. No retention drop by design: the
+    -- audit table keeps full score history (public KG nodes are the
+    -- 30-day-archived projection, see r1_maintenance.py).
+    IF to_regclass('audit.r1_score_audit') IS NOT NULL
+       AND to_regprocedure('audit.create_r1_score_audit_partition(integer, integer)') IS NOT NULL THEN
+        v_msg := audit.create_r1_score_audit_partition(v_current_year, v_current_month);
+        v_result := v_result || jsonb_build_object('r1_score_audit_current', v_msg);
+
+        v_msg := audit.create_r1_score_audit_partition(v_next_year, v_next_month);
+        v_result := v_result || jsonb_build_object('r1_score_audit_next', v_msg);
+    END IF;
 
     -- Clean up old partitions
     v_result := v_result || jsonb_build_object(

--- a/db/postgres/partitions.sql
+++ b/db/postgres/partitions.sql
@@ -28,6 +28,14 @@ BEGIN
     -- already use Denver-midnight bounds — pinning UTC would overlap them
     -- at the next month boundary. make_timestamptz() with an explicit zone
     -- is immune to the session-TimeZone drift that caused the 2026-06 hole.
+    -- NOTE: on a FRESH install the pin is the sole bound-determinant (no
+    -- neighbor to snap to), so a future UTC-tz host bootstraps
+    -- Denver-offset bounds by design — internally consistent and gapless,
+    -- but offset from UTC month edges. Intended end-state is an
+    -- operator-gated detach/reattach normalization to uniform UTC bounds;
+    -- until then this pin and partitions.sql must stay in agreement.
+    -- (Denver DST transitions fire at 02:00 local on Sundays; month-firsts
+    -- at 00:00 are never skipped or ambiguous, verified 2000-2040.)
     v_start := make_timestamptz(p_year, p_month, 1, 0, 0, 0, 'America/Denver');
     IF p_month = 12 THEN
         v_end := make_timestamptz(p_year + 1, 1, 1, 0, 0, 0, 'America/Denver');
@@ -374,7 +382,12 @@ $$ LANGUAGE sql STABLE;
 COMMENT ON FUNCTION audit.partition_gaps() IS
     'Holes between consecutive partition bounds of the monthly-partitioned '
     'audit parents. Non-empty output means inserts in the hole fail with '
-    '"no partition of relation found for row".';
+    '"no partition of relation found for row". Blind spot: DEFAULT and '
+    'MINVALUE/MAXVALUE partitions do not match the bound regex and are '
+    'excluded — if a DEFAULT partition is ever added to these parents, '
+    'gaps adjacent to it become invisible here (rows route to the DEFAULT '
+    'instead of failing).';
+
 
 CREATE OR REPLACE FUNCTION audit.partition_maintenance()
 RETURNS JSONB AS $$
@@ -396,6 +409,24 @@ BEGIN
         v_fill_name := format('%s_fill_%s', v_gap.parent,
                               to_char(v_gap.gap_start AT TIME ZONE 'UTC',
                                       'YYYYMMDD_HH24MI'));
+        -- An orphaned table squatting on the filler name would make
+        -- CREATE TABLE IF NOT EXISTS silently skip while the gap stays
+        -- open — surface that instead of warning identically every week.
+        IF EXISTS (
+            SELECT 1 FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = 'audit' AND c.relname = v_fill_name
+              AND NOT EXISTS (
+                  SELECT 1 FROM pg_inherits i
+                  JOIN pg_class p ON p.oid = i.inhparent
+                  WHERE i.inhrelid = c.oid AND p.relname = v_gap.parent
+              )
+        ) THEN
+            RAISE WARNING 'audit.% exists but is not attached to audit.%; '
+                'gap [% - %) cannot be auto-filled — manual intervention required',
+                v_fill_name, v_gap.parent, v_gap.gap_start, v_gap.gap_end;
+            CONTINUE;
+        END IF;
         EXECUTE format(
             'CREATE TABLE IF NOT EXISTS audit.%I PARTITION OF audit.%I
              FOR VALUES FROM (%L) TO (%L)',
@@ -475,6 +506,7 @@ BEGIN
     RETURN v_result;
 END;
 $$ LANGUAGE plpgsql;
+
 
 -- =============================================================================
 -- INITIAL PARTITION CREATION


### PR DESCRIPTION
## Incident

Audit partitions through 2026-05 carry **UTC-midnight bounds**; 2026-06/07 carry **America/Denver-midnight bounds**. The create-partition helpers computed bounds from `DATE` values, which cast to `timestamptz` using the *session* TimeZone — and the weekly maintenance session's default flipped between runs. That left a six-hour hole `[2026-05-31 18:00 -06, 2026-06-01 00:00 -06)` in **all three** monthly-partitioned audit parents (`events`, `tool_usage`, `outcome_events`).

Consequences (live-verified):
- Inserts in the hole fail: `no partition of relation "tool_usage" found for row`.
- The lease-plane audit outbox forwarder (`ORDER BY ts ASC LIMIT 100`) head-of-line blocked on 2,199 poison rows — **zero rows forwarded to audit.tool_usage since 2026-06-01** (59,397-row backlog), 250k+ warnings, 1.5GB log.
- `audit.events` / `outcome_events` writes in the window were fire-and-forget → silently lost (no outbox to replay).

## Fix

- `audit.month_partition_bounds()` — deterministic month edges via `make_timestamptz(..., 'America/Denver')` (immune to session-TZ drift), **snapped to neighboring partitions' bounds** so creation is gapless and overlap-free by construction. Denver (not UTC) because the live 2026-06/07 partitions already use Denver midnight; pinning UTC would overlap them at the next boundary.
- `audit.ensure_partition_indexes()` — shared per-parent index DDL.
- `audit.partition_gaps()` — diagnostic returning holes between consecutive bounds.
- `audit.partition_maintenance()` — now **fills detected gaps** with bounds-exact filler partitions (raising a WARNING) before the usual create/drop cycle. A recurrence self-heals within one weekly run; `record_outcome_event` already retries via `partition_maintenance()` on missing-partition errors, making that path insert-time self-healing.
- `partitions.sql` (fresh-install bootstrap) updated to match — keep in sync with the migration.

## Verification

- **governance_test incident replay**: artificial 12h gap → `partition_gaps()` detects it → `partition_maintenance()` fills it → insert lands in the filler partition → `create_tool_usage_partition(2026, 9)` snaps gaplessly onto mismatched bounds. Test DB restored after.
- **Applied to live governance DB 2026-06-11** (manual-migration deploy model): three `*_fill_20260601_0000` partitions created, `audit.partition_gaps()` empty, forwarder backlog draining (59,422 → 59,324 within minutes; full drain ~5h at 100/30s).

Follow-up (separate PR): forwarder poison-row hardening in the Elixir lease plane — attempt tracking so a permanently-failing row can never head-of-line-block the outbox again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)