### PR TITLE
fix(lease-plane): outbox forwarder — failing rows no longer head-of-line block fresh work

### DIFF
--- a/db/postgres/migrations/046_outbox_unforwarded_attempts_index.sql
+++ b/db/postgres/migrations/046_outbox_unforwarded_attempts_index.sql
@@ -1,0 +1,21 @@
+-- 046_outbox_unforwarded_attempts_index.sql
+--
+-- Companion to the lease-plane outbox head-of-line-blocking fix: the
+-- forwarder's selection query now orders by (forward_attempts ASC, ts ASC)
+-- so rows that keep failing sink behind fresh work instead of monopolizing
+-- every batch (the 2026-06 partition-gap wedge: 2,199 permanently-failing
+-- rows blocked all forwarding for 11 days; see migration 045 for the
+-- partition repair itself).
+--
+-- The existing partial index lease_plane_events_unforwarded btree (ts)
+-- WHERE forwarded_at IS NULL stays — monitoring queries (min(ts), counts)
+-- use it. This one serves the new selection ordering.
+
+CREATE INDEX IF NOT EXISTS lease_plane_events_unforwarded_attempts
+    ON lease_plane.lease_plane_events (forward_attempts, ts)
+    WHERE forwarded_at IS NULL;
+
+-- Register migration
+INSERT INTO core.schema_migrations (version, name, applied_at)
+VALUES (46, 'outbox_unforwarded_attempts_index', NOW())
+ON CONFLICT (version) DO NOTHING;

--- a/elixir/lease_plane/lib/unitares_lease_plane/audit_outbox_forwarder.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/audit_outbox_forwarder.ex
@@ -32,27 +32,50 @@ defmodule UnitaresLeasePlane.AuditOutboxForwarder do
       end
 
     with {:ok, events} <- Repo.unforwarded_events(limit, opts) do
-      {forwarded, failed} =
-        Enum.reduce(events, {0, 0}, fn event, {ok_count, fail_count} ->
+      {forwarded, failed, failures_by_reason} =
+        Enum.reduce(events, {0, 0, %{}}, fn event, {ok_count, fail_count, by_reason} ->
           case Repo.forward_outbox_event(event.event_id) do
             :ok ->
-              {ok_count + 1, fail_count}
+              {ok_count + 1, fail_count, by_reason}
 
             {:error, :not_found} ->
-              {ok_count, fail_count}
+              {ok_count, fail_count, by_reason}
 
             {:error, reason} ->
-              Logger.warning(
-                "lease_plane audit forward failed for #{event.event_id}: #{inspect(reason)}"
-              )
+              key = failure_key(reason)
 
-              {ok_count, fail_count + 1}
+              by_reason =
+                Map.update(by_reason, key, {1, event.event_id}, fn {n, sample} ->
+                  {n + 1, sample}
+                end)
+
+              {ok_count, fail_count + 1, by_reason}
           end
         end)
+
+      # One warning per distinct failure shape per run, not one per row — a
+      # stuck batch of 100 rows sharing a single root cause (e.g. a missing
+      # audit partition) previously wrote 200 near-identical lines per
+      # minute, growing the log by hundreds of MB per week while saying
+      # nothing new.
+      Enum.each(failures_by_reason, fn {key, {count, sample_event_id}} ->
+        Logger.warning(
+          "lease_plane audit forward failed for #{count} event(s) " <>
+            "(sample #{sample_event_id}): #{key}"
+        )
+      end)
 
       {:ok, %{forwarded: forwarded, failed: failed}}
     end
   end
+
+  # Collapse failure terms into a stable grouping key: Postgrex errors keep
+  # code + message (connection_id and friends vary per row and would defeat
+  # the grouping); everything else falls back to inspect/1.
+  defp failure_key(%Postgrex.Error{postgres: %{code: code, message: message}}),
+    do: "postgres #{code}: #{message}"
+
+  defp failure_key(reason), do: inspect(reason)
 
   defp positive_arg(args, string_key, atom_key, default) do
     value = Map.get(args, string_key, Map.get(args, atom_key, default))

--- a/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
@@ -529,6 +529,13 @@ defmodule UnitaresLeasePlane.Repo do
         :error -> {"forwarded_at IS NULL", [limit]}
       end
 
+    # forward_attempts ASC before ts ASC: rows that keep failing sink behind
+    # fresh work instead of head-of-line blocking the batch, but are still
+    # retried once fresher rows drain — so a repaired downstream (e.g. the
+    # 2026-06 audit partition gap, migration 045) self-heals with no operator
+    # action and no parked/dead-letter state. The wedge this fixes: 2,199
+    # rows stuck on a partition hole monopolized every ORDER BY ts ASC batch
+    # for 11 days — zero forwards, 31k attempts per row.
     sql = """
     SELECT
       event_id::text AS event_id,
@@ -538,7 +545,7 @@ defmodule UnitaresLeasePlane.Repo do
       holder_class, advisory_mode, payload, earned_status
     FROM lease_plane.lease_plane_events
     WHERE #{where}
-    ORDER BY ts ASC
+    ORDER BY forward_attempts ASC, ts ASC
     LIMIT $1
     """
 

--- a/elixir/lease_plane/test/unitares_lease_plane_test.exs
+++ b/elixir/lease_plane/test/unitares_lease_plane_test.exs
@@ -391,6 +391,49 @@ defmodule UnitaresLeasePlaneTest do
     end
   end
 
+  describe "audit outbox selection ordering" do
+    # Regression: 2026-06 partition-gap wedge. 2,199 permanently-failing rows
+    # at the head of ORDER BY ts ASC monopolized every LIMIT-100 batch for 11
+    # days — zero forwards. Selection now orders by forward_attempts ASC
+    # first, so failing rows sink behind fresh work but are still retried
+    # once fresher rows drain (self-healing after the underlying repair, no
+    # parked/dead-letter state).
+    test "failing rows do not head-of-line block fresh rows", ctx do
+      insert_event = fn ts_offset_s, attempts ->
+        %{rows: [[event_id]]} =
+          Postgrex.query!(
+            UnitaresLeasePlane.DB,
+            """
+            INSERT INTO lease_plane.lease_plane_events
+              (ts, event_type, surface_id, surface_kind, advisory_mode,
+               payload, forward_attempts)
+            VALUES (now() - make_interval(secs => $1), 'acquire', $2,
+                    'dialectic', true, '{}'::jsonb, $3)
+            RETURNING event_id::text
+            """,
+            [ts_offset_s, ctx.surface, attempts]
+          )
+
+        event_id
+      end
+
+      poison_old = insert_event.(300, 7)
+      poison_older = insert_event.(600, 7)
+      fresh = insert_event.(30, 0)
+
+      # A batch smaller than the backlog must pick the fresh row first, even
+      # though both poison rows are older.
+      assert {:ok, [first]} = Repo.unforwarded_events(1, surface_id: ctx.surface)
+      assert first.event_id == fresh
+
+      # Failing rows are deprioritized, not dropped: a batch large enough for
+      # everything still includes them, oldest-first within the same attempt
+      # count.
+      assert {:ok, events} = Repo.unforwarded_events(10, surface_id: ctx.surface)
+      assert Enum.map(events, & &1.event_id) == [fresh, poison_older, poison_old]
+    end
+  end
+
   describe "status/1" do
     test "returns nil for unknown surface" do
       assert {:ok, nil} = UnitaresLeasePlane.status("test:elixir/never-acquired")


### PR DESCRIPTION
## What

Companion to #613 — closes the *class* of the incident, not just the instance.

The audit outbox forwarder selected `ORDER BY ts ASC LIMIT 100`, so permanently-failing rows monopolized every batch: during the partition-gap incident, 2,199 poison rows blocked **all** forwarding for 11 days (59k backlog, **31,029 attempts per row** — `forward_attempts` was bumped on every failure and never consulted by selection).

- `Repo.unforwarded_events/2`: `ORDER BY forward_attempts ASC, ts ASC` — fresh rows always forward first; failing rows sink but keep retrying once fresher rows drain. Self-healing after a downstream repair, no parked/dead-letter state, no time-based backoff to tune (clock-free by design).
- `AuditOutboxForwarder`: one warning per distinct failure shape per run (Postgrex `code: message` grouping key) instead of one per row — the wedge wrote ~250k near-identical lines into a 1.5GB log.
- Migration 046: supporting partial index `(forward_attempts, ts) WHERE forwarded_at IS NULL` (applied to live + test DBs).

## Trade-off noted

Under sustained arrivals exceeding forwarder capacity (>100 fresh rows/30s ≈ 288k/day), once-failed rows could starve. Current volume is ~5k/day against 288k/day capacity; if throughput ever approaches capacity the forwarder has bigger problems, and the failure mode is visible (attempts climbing in the aggregated warning).

## Verification

- New regression test: fresh row wins a LIMIT-1 batch over two older high-attempt rows; larger batch still includes failing rows oldest-first within attempt count.
- Full lease-plane suite: 163 tests + 11 properties, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)