### PR TITLE
[codex] fix watcher unresolved stale paths

### DIFF
--- a/agents/watcher/findings.py
+++ b/agents/watcher/findings.py
@@ -289,6 +289,13 @@ _STATUS_TIMESTAMP_FIELD = {
 }
 
 
+def _finding_target_exists(finding: dict[str, Any]) -> bool:
+    path = finding.get("file", "")
+    if not path:
+        return False
+    return Path(path).exists()
+
+
 def update_finding_status(
     fingerprint_prefix: str,
     new_status: str,
@@ -399,8 +406,7 @@ def _sweep_stale_quiet() -> int:
     kept: list[dict[str, Any]] = []
     dropped = 0
     for f in findings:
-        path = f.get("file", "")
-        if path and Path(path).exists():
+        if _finding_target_exists(f):
             kept.append(f)
         else:
             dropped += 1
@@ -772,6 +778,7 @@ def print_unresolved(scope_root: Path | None = None) -> int:
         f
         for f in _iter_findings_raw()
         if f.get("status", "open") in ("open", "surfaced")
+        and _finding_target_exists(f)
     ]
     in_scope, out_groups = _partition_findings_by_scope(findings, scope_root)
 

--- a/agents/watcher/tests/test_agent.py
+++ b/agents/watcher/tests/test_agent.py
@@ -1430,6 +1430,47 @@ def test_print_unresolved_does_not_mutate_status(watcher_module):
     assert after[0]["status"] == "open"
 
 
+def test_print_unresolved_filters_missing_targets_without_mutating(
+    watcher_module, tmp_path, capsys
+):
+    existing = tmp_path / "alive.py"
+    existing.write_text("print('still here')\n")
+    missing = tmp_path / "deleted-worktree" / "ghost.py"
+    _seed_findings(
+        watcher_module,
+        [
+            _make_raw_entry("alive___00000000", file=str(existing), status="open"),
+            _make_raw_entry("ghost___00000000", file=str(missing), status="open"),
+        ],
+    )
+    before = watcher_module.FINDINGS_FILE.read_text()
+
+    rc = watcher_module.print_unresolved(scope_root=tmp_path)
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "alive.py" in out
+    assert "ghost.py" not in out
+    assert watcher_module.FINDINGS_FILE.read_text() == before
+
+
+def test_print_unresolved_silent_when_only_missing_targets(
+    watcher_module, tmp_path, capsys
+):
+    missing = tmp_path / "deleted-worktree" / "ghost.py"
+    _seed_findings(
+        watcher_module,
+        [_make_raw_entry("ghost___00000000", file=str(missing), status="surfaced")],
+    )
+    before = watcher_module.FINDINGS_FILE.read_text()
+
+    rc = watcher_module.print_unresolved(scope_root=tmp_path)
+
+    assert rc == 0
+    assert capsys.readouterr().out == ""
+    assert watcher_module.FINDINGS_FILE.read_text() == before
+
+
 def test_print_unresolved_silent_on_empty(watcher_module, capsys):
     rc = watcher_module.print_unresolved()
     assert rc == 0
@@ -1457,19 +1498,23 @@ def test_print_unresolved_silent_when_only_resolved(watcher_module, capsys):
 def test_print_unresolved_partitions_findings_by_scope(watcher_module, tmp_path, capsys):
     """In-scope findings render in the body; out-of-scope ones collapse to a
     single footer line keyed by their `.worktrees/<name>` segment."""
-    in_scope_file = str(tmp_path / "in_scope.py")
-    out_a = "/some/other/.worktrees/branch-a/src/foo.py"
-    out_b = "/some/other/.worktrees/branch-b/src/bar.py"
+    scope_root = tmp_path / "current"
+    in_scope_file = scope_root / "in_scope.py"
+    out_a = tmp_path / "other" / ".worktrees" / "branch-a" / "src" / "foo.py"
+    out_b = tmp_path / "other" / ".worktrees" / "branch-b" / "src" / "bar.py"
+    for path in (in_scope_file, out_a, out_b):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("print('fixture')\n")
     _seed_findings(
         watcher_module,
         [
-            _make_raw_entry("inside__00000000", status="open", file=in_scope_file),
-            _make_raw_entry("brancha_00000000", status="open", file=out_a),
-            _make_raw_entry("branchb_00000000", status="open", file=out_b),
-            _make_raw_entry("brancha2_0000000", status="surfaced", file=out_a),
+            _make_raw_entry("inside__00000000", status="open", file=str(in_scope_file)),
+            _make_raw_entry("brancha_00000000", status="open", file=str(out_a)),
+            _make_raw_entry("branchb_00000000", status="open", file=str(out_b)),
+            _make_raw_entry("brancha2_0000000", status="surfaced", file=str(out_a)),
         ],
     )
-    rc = watcher_module.print_unresolved(scope_root=tmp_path)
+    rc = watcher_module.print_unresolved(scope_root=scope_root)
     assert rc == 0
     out = capsys.readouterr().out
     assert "inside__" in out
@@ -1485,12 +1530,16 @@ def test_print_unresolved_emits_footer_only_when_in_scope_empty(
 ):
     """When every finding is out-of-scope, still emit a minimal block so the
     agent knows the backlog exists rather than appearing clean."""
-    out_path = "/some/other/.worktrees/branch-x/src/foo.py"
+    scope_root = tmp_path / "current"
+    scope_root.mkdir()
+    out_path = tmp_path / "other" / ".worktrees" / "branch-x" / "src" / "foo.py"
+    out_path.parent.mkdir(parents=True)
+    out_path.write_text("print('fixture')\n")
     _seed_findings(
         watcher_module,
-        [_make_raw_entry("x_______00000000", status="open", file=out_path)],
+        [_make_raw_entry("x_______00000000", status="open", file=str(out_path))],
     )
-    rc = watcher_module.print_unresolved(scope_root=tmp_path)
+    rc = watcher_module.print_unresolved(scope_root=scope_root)
     assert rc == 0
     out = capsys.readouterr().out
     assert "<unitares-watcher-findings>" in out


### PR DESCRIPTION
## Summary
- keep Watcher `--print-unresolved` read-only while filtering findings whose target file no longer exists
- share the target-exists predicate with stale sweep behavior
- add regressions for mixed live/missing findings, missing-only findings, and scoped out-of-worktree fixtures

## Validation
- `./scripts/dev/test-cache.sh` — 9308 passed, 34 skipped
- pre-push smoke — 138 passed
