### PR TITLE
feat(identity): UA fingerprint preimage capture + newsyslog rotation config

### DIFF
--- a/scripts/ops/newsyslog-unitares.conf
+++ b/scripts/ops/newsyslog-unitares.conf
@@ -1,0 +1,20 @@
+# newsyslog rotation for UNITARES launchd service logs.
+#
+# launchd does NOT rotate StandardOut/ErrorPath files — the lease-plane log
+# reached 1.5GB (6.2M lines) during the 2026-06 partition-gap incident before
+# anyone looked. Install (one-time, needs sudo):
+#
+#   sudo cp scripts/ops/newsyslog-unitares.conf /etc/newsyslog.d/unitares.conf
+#
+# newsyslog runs from system launchd every 30 minutes; `J` compresses rotated
+# files with bzip2. Sizes are in KB: rotate at ~100MB, keep 5 generations.
+# `B` marks the files as binary-ish (no "logfile turned over" banner written
+# into them, which would confuse line-oriented log consumers).
+#
+# logfilename                                            [owner:group]  mode  count  size      when  flags
+/Users/cirwel/Library/Logs/unitares-lease-plane.log      cirwel:staff   644   5      102400    *     JB
+/Users/cirwel/Library/Logs/unitares-sentinel-beam.log    cirwel:staff   644   5      102400    *     JB
+/Users/cirwel/Library/Logs/unitares-wave3a-handlers.log  cirwel:staff   644   5      102400    *     JB
+/Users/cirwel/Library/Logs/unitares-vigil.log            cirwel:staff   644   3      51200     *     JB
+/Users/cirwel/Library/Logs/unitares-watcher.log          cirwel:staff   644   3      51200     *     JB
+/Users/cirwel/Library/Logs/unitares-discord-bridge.log   cirwel:staff   644   3      51200     *     JB

--- a/src/connection_tracker.py
+++ b/src/connection_tracker.py
@@ -480,6 +480,8 @@ class ConnectionTrackingMiddleware:
                 client = scope.get("client")
                 client_ip = client[0] if (client and len(client) >= 1) else "unknown"
                 ua_fingerprint = hashlib.md5(ua.encode()).hexdigest()[:6]
+                from src.mcp_handlers.context import note_ua_fingerprint
+                note_ua_fingerprint(ua_fingerprint, ua)
                 base_id = f"{client_ip}:{ua_fingerprint}"
 
             # Build SessionSignals for legacy paths (if not already set)

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -59,6 +59,8 @@ def _build_http_session_signals(request):
         host = request.client.host if request.client else "unknown"
         import hashlib
         ua_fp = hashlib.md5(ua.encode()).hexdigest()[:6] if ua else "000000"
+        from src.mcp_handlers.context import note_ua_fingerprint
+        note_ua_fingerprint(ua_fp, ua)
         ip_ua_fp = f"{host}:{ua_fp}"
     except Exception:
         pass

--- a/src/mcp_handlers/context.py
+++ b/src/mcp_handlers/context.py
@@ -279,6 +279,33 @@ def get_trajectory_confidence() -> Optional[float]:
     """Get trajectory confidence from context, or None if not set."""
     return _trajectory_confidence.get()
 
+_logged_ua_fingerprints: set = set()
+_MAX_LOGGED_UA_FINGERPRINTS = 512
+
+
+def note_ua_fingerprint(ua_fingerprint: Optional[str], user_agent: Optional[str]) -> None:
+    """Record the fingerprint -> raw User-Agent preimage, once per distinct
+    hash per process lifetime.
+
+    Session keys carry only md5(UA)[:6], which is one-way: when an unbound
+    caller shows up in the logs as e.g. ``127.0.0.1:f304dd:*`` there is
+    nothing in the system that says what client that actually is (the
+    stage-1 strict-identity burn-in spent a candidate hunt on exactly that
+    and gave up with "revisit with a header capture" — this is that
+    capture). One INFO line per distinct fingerprint; the set is capped so
+    a UA-randomizing caller cannot grow it unbounded.
+    """
+    if not ua_fingerprint or ua_fingerprint in _logged_ua_fingerprints:
+        return
+    if len(_logged_ua_fingerprints) >= _MAX_LOGGED_UA_FINGERPRINTS:
+        return
+    _logged_ua_fingerprints.add(ua_fingerprint)
+    import logging
+    logging.getLogger(__name__).info(
+        "[UA_FINGERPRINT] %s -> %r", ua_fingerprint, user_agent
+    )
+
+
 def detect_client_from_user_agent(user_agent: str) -> Optional[str]:
     """
     Detect client type from User-Agent string.

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -938,7 +938,7 @@ async def main():
                     from src.mcp_handlers.context import (
                         SessionSignals, set_session_signals, reset_session_signals,
                         detect_client_from_user_agent, set_transport_client_hint, reset_transport_client_hint,
-                        set_mcp_session_id, reset_mcp_session_id
+                        set_mcp_session_id, reset_mcp_session_id, note_ua_fingerprint
                     )
                     headers = Headers(scope=scope)
 
@@ -949,6 +949,7 @@ async def main():
                     ua = headers.get("user-agent", "unknown")
                     import hashlib
                     ua_fingerprint = hashlib.md5(ua.encode()).hexdigest()[:6]
+                    note_ua_fingerprint(ua_fingerprint, ua)
                     x_session_id = headers.get("x-session-id")
                     x_client_id = headers.get("x-client-id") or headers.get("x-mcp-client-id")
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -304,3 +304,62 @@ class TestSessionSignalsPeerPid:
         from src.mcp_handlers.context import SessionSignals
         src = inspect.getsource(SessionSignals)
         assert '"uds"' in src
+
+
+class TestNoteUaFingerprint:
+    """note_ua_fingerprint logs the fingerprint -> raw-UA preimage once per
+    distinct hash (session keys carry only md5(UA)[:6], which is one-way —
+    the f304dd hunt in the stage-1 strict-identity burn-in had no way to
+    recover the client behind a fingerprint)."""
+
+    def setup_method(self):
+        from src.mcp_handlers import context
+        context._logged_ua_fingerprints.clear()
+
+    def test_logs_once_per_fingerprint(self, caplog):
+        import logging
+        from src.mcp_handlers.context import note_ua_fingerprint
+
+        with caplog.at_level(logging.INFO, logger="src.mcp_handlers.context"):
+            note_ua_fingerprint("f304dd", "Some-Client/1.2.3")
+            note_ua_fingerprint("f304dd", "Some-Client/1.2.3")
+            note_ua_fingerprint("f304dd", "Some-Client/1.2.3")
+
+        hits = [r for r in caplog.records if "[UA_FINGERPRINT]" in r.getMessage()]
+        assert len(hits) == 1
+        assert "f304dd" in hits[0].getMessage()
+        assert "Some-Client/1.2.3" in hits[0].getMessage()
+
+    def test_distinct_fingerprints_each_logged(self, caplog):
+        import logging
+        from src.mcp_handlers.context import note_ua_fingerprint
+
+        with caplog.at_level(logging.INFO, logger="src.mcp_handlers.context"):
+            note_ua_fingerprint("aaaaaa", "Client-A/1.0")
+            note_ua_fingerprint("bbbbbb", "Client-B/2.0")
+
+        hits = [r for r in caplog.records if "[UA_FINGERPRINT]" in r.getMessage()]
+        assert len(hits) == 2
+
+    def test_none_and_empty_fingerprint_ignored(self, caplog):
+        import logging
+        from src.mcp_handlers.context import note_ua_fingerprint
+
+        with caplog.at_level(logging.INFO, logger="src.mcp_handlers.context"):
+            note_ua_fingerprint(None, "Client/1.0")
+            note_ua_fingerprint("", "Client/1.0")
+
+        hits = [r for r in caplog.records if "[UA_FINGERPRINT]" in r.getMessage()]
+        assert hits == []
+
+    def test_set_is_capped(self, caplog):
+        import logging
+        from src.mcp_handlers import context
+        from src.mcp_handlers.context import note_ua_fingerprint
+
+        with caplog.at_level(logging.INFO, logger="src.mcp_handlers.context"):
+            for i in range(context._MAX_LOGGED_UA_FINGERPRINTS + 50):
+                note_ua_fingerprint(f"{i:06x}", f"Client/{i}")
+
+        hits = [r for r in caplog.records if "[UA_FINGERPRINT]" in r.getMessage()]
+        assert len(hits) == context._MAX_LOGGED_UA_FINGERPRINTS


### PR DESCRIPTION
## What

Two small operational hardening pieces from today's incident work:

**1. UA fingerprint preimage capture.** Session keys carry only `md5(User-Agent)[:6]` — one-way. When an unbound caller shows up as `127.0.0.1:f304dd:*` (4.5k calls, still firing), nothing in the system can say what client it is; the stage-1 strict-identity burn-in parked it with *"revisit with a header capture."* This is that capture: `note_ua_fingerprint()` logs `[UA_FINGERPRINT] <hash> -> <raw UA>` **once per distinct fingerprint per process** (capped set, so a UA-randomizing caller can't grow it unbounded), wired at all three fingerprint-computation sites (MCP ASGI wrapper, REST signal builder, connection-tracker legacy path).

f304dd's strong candidate (this session's investigation): **Cursor's extension-host MCP client** — `~/.cursor/mcp.json` declares `unitares-governance` as `type: http → localhost:8767/mcp/` with Basic auth, and the extension host has held connections to :8767 continuously since 2026-05-31, polling without onboarding. A ~10M-candidate offline md5-preimage brute force found no legitimate match (one 6-hex collision rejected against the installed Cursor version), so the live capture is the proof path: after deploy, `grep "UA_FINGERPRINT] f304dd" data/logs/mcp_server.log`.

**2. newsyslog rotation config** (`scripts/ops/newsyslog-unitares.conf`) — launchd doesn't rotate `StandardOut/ErrorPath` files; the lease-plane log hit 1.5GB during the partition-gap incident before anyone looked. One-time operator install: `sudo cp scripts/ops/newsyslog-unitares.conf /etc/newsyslog.d/unitares.conf`.

## Verification

- 4 new tests (once-per-fingerprint, distinct fingerprints, None/empty ignored, cap respected); full local gate green: 9,357 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)