### PR TITLE
[codex] ignore watcher symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ data/.last_active_agent
 data/.metadata.lock
 data/locks/
 data/processes/
+data/watcher
 data/watcher/
 
 # Claude Code / Cursor local state (machine-specific, never commit)


### PR DESCRIPTION
## Summary
- ignore `data/watcher` symlinks as well as watcher directories
- keeps deploy worktrees clean when `data/watcher` points at shared runtime watcher state

## Validation
- ./scripts/dev/test-cache.sh --staged
- pre-push smoke tests

## Notes
- Pre-push doc health reported the existing dead reference `AGENTS.md:142` -> `docs/handoffs/strict-identity-stage1-burnin-2026-06-11.md`; this PR does not touch that doc surface.
