### PR TITLE
docs: fix dangling links from the archive cut; add proposals index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,8 @@ This is the documentation tree for the [UNITARES governance MCP server](../READM
 ### Canonical reference
 
 - **[`UNIFIED_ARCHITECTURE.md`](UNIFIED_ARCHITECTURE.md)** — the canonical architecture doc. End-to-end picture of the server, state model, transports, and storage.
+- **[`REVIEWER_GUIDE.md`](REVIEWER_GUIDE.md)** — guided tour for reviewers evaluating the project.
+- **[`trust-contract.md`](trust-contract.md)** — what the system guarantees, what it does not, and what honest failure looks like.
 - **[`CHANGELOG.md`](CHANGELOG.md)** — release history.
 
 ### `guides/` — getting started
@@ -24,6 +26,7 @@ User- and integrator-facing how-tos. Thin by design — most architecture lives 
 
 - [`START_HERE.md`](guides/START_HERE.md) — workflow + canonical-sources pointer
 - [`TROUBLESHOOTING.md`](guides/TROUBLESHOOTING.md) — common failures
+- [`CIRS_PROTOCOL.md`](guides/CIRS_PROTOCOL.md) — multi-agent coordination protocol (specialized; not a general architecture overview)
 
 ### `install/` — installation
 
@@ -48,6 +51,9 @@ How to run this in production. Most readers can skip these.
 - [`DEFINITIVE_PORTS.md`](operations/DEFINITIVE_PORTS.md) — port assignments across services
 - [`database_architecture.md`](operations/database_architecture.md) — single-Postgres / schema-isolation model
 - [`lease-plane-operator-runbook.md`](operations/lease-plane-operator-runbook.md) — Elixir lease-plane operations
+- [`branch-hygiene-runbook.md`](operations/branch-hygiene-runbook.md) — resident branch-hygiene sweep (`agents/vigil_hygiene`)
+- [`DATA_NOTES.md`](operations/DATA_NOTES.md) — operational data dictionary for the production governance database
+- [`DEPLOYMENT_DATA_CAVEAT.md`](operations/DEPLOYMENT_DATA_CAVEAT.md) — what the cited deployment numbers do and don't mean
 
 ### `dev/` — developer-internal
 
@@ -60,6 +66,8 @@ For people working on UNITARES itself, not using it.
 ### `proposals/` — RFCs
 
 Active and resolved RFCs that don't (yet) belong in `ontology/`. The Plexus / lease-plane / BEAM-coordination thread lives here. Each doc carries its own resolution status in the body.
+
+→ Status-grouped index at **[`proposals/README.md`](proposals/README.md)**.
 
 ### `assets/`
 

--- a/docs/ontology/README.md
+++ b/docs/ontology/README.md
@@ -36,21 +36,22 @@ So `r1-verify-lineage-claim.md` resolves row R1 in `plan.md`; `s1-continuity-tok
 **Research RFCs** (R-rows, *inventive* primitives):
 - [`r1-verify-lineage-claim.md`](r1-verify-lineage-claim.md) — behavioral-continuity verification (shipped)
 - [`r2-honest-memory-integration.md`](r2-honest-memory-integration.md) — honest memory integration (Phase 1 shipped)
-- [`r5-memory-deepening-reality.md`](r5-memory-deepening-reality.md) — memory-deepening-reality tooling
 - [`r6-episode-fork-response-shape.md`](r6-episode-fork-response-shape.md) — R6 sub-item, episode-fork API shape
-- [`r6-candidate-envelope-evaluation-2026-05-19.md`](r6-candidate-envelope-evaluation-2026-05-19.md) — R6 dogfood envelope evaluation
-- [`r6-h1-h5-dogfood-20260429.md`](r6-h1-h5-dogfood-20260429.md) — R6 dogfood run
 
 **System RFCs** (S-rows, *descriptive* cleanups):
 - [`s1-continuity-token-retirement.md`](s1-continuity-token-retirement.md) — token deprecation plan
-- [`s7-kg-provenance-lineage-schema.md`](s7-kg-provenance-lineage-schema.md) — KG provenance schema
 - [`s8a-tag-discipline-audit.md`](s8a-tag-discipline-audit.md) · [`s8a-phase2-prep.md`](s8a-phase2-prep.md) — tag discipline + phase 2
 - [`s10-fleet-aggregation-plan.md`](s10-fleet-aggregation-plan.md) — fleet aggregation
-- [`s11a-skill-text-drift.md`](s11a-skill-text-drift.md) — skill text drift detection
 - [`s15-server-side-skills.md`](s15-server-side-skills.md) — server-side skills surface
-- [`s20-cache-scope-narrowing.md`](s20-cache-scope-narrowing.md) — cache-scope narrowing
-- [`s21-session-resolution-bypass-incident.md`](s21-session-resolution-bypass-incident.md) · [`s21-fix-council-review.md`](s21-fix-council-review.md) · [`s21b-auth-consistency.md`](s21b-auth-consistency.md) · [`s21b-items-5-6-council-review-2026-04-30.md`](s21b-items-5-6-council-review-2026-04-30.md) — S21 series
+- [`s21-session-resolution-bypass-incident.md`](s21-session-resolution-bypass-incident.md) — S21 incident record
 - [`v7-fhat-spec-v5-amendment.md`](v7-fhat-spec-v5-amendment.md) — v5 amendment to v7 spec
+
+**Dated records**:
+- [`ledger-triage-2026-06-11.md`](ledger-triage-2026-06-11.md) — read-only triage of the deferred/blocked `plan.md` rows against their unblock triggers
+
+## Operator-archived docs
+
+Not every doc cited by a `plan.md` row is in this folder. On 2026-05-21 the internal-dialogue artifacts — council review notes, dated dogfood reports, implementation handoffs — were moved to the operator's private archive (commits `27642d1` / `4ad624a`); the load-bearing specs above were restored, the rest stayed archived. Archived from this folder: the R5 memory-deepening spec, the R6 dogfood/envelope evaluations, the S7 KG-provenance schema, S11-a skill-text drift, S20 cache-scope narrowing, and the S21 council-review series (`s21-fix-council-review`, `s21b-*`). `plan.md` still cites them by filename — that's intentional; the ledger is the historical record. `docs/handoffs/` is gitignored for the same reason (operator-local handoffs, cited from public docs as provenance).
 
 ## How rows resolve
 

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -1,0 +1,56 @@
+# Proposals — RFC Index
+
+Active and resolved RFCs that don't (yet) belong in [`docs/ontology/`](../ontology/README.md). **Each doc's body carries its own resolution status and is canonical — this index is a map.** Dated docs are point-in-time records and deliberately preserve references as they were at writing (the doc-health dead-ref check exempts this folder for that reason).
+
+Several of these are **single-writer surfaces** (see the shared contract in `AGENTS.md` / `CLAUDE.md`): the hot Plexus / lease-plane / BEAM thread gets restructured in flight. If another session has an open PR touching one, branch from its head rather than starting a parallel edit.
+
+## Active threads
+
+### Plexus / surface lease plane
+
+| Doc | Status (as of 2026-06-11) |
+|---|---|
+| [`plexus-scope.md`](plexus-scope.md) | Active boundary name over the live Surface Lease Plane; Plexus Zero retained as manual fallback |
+| [`surface-lease-plane-v0.md`](surface-lease-plane-v0.md) | The lease-plane RFC, v0.11+. Phase A shipped 2026-05-03 (PR #305); Phase B promotion window opened 2026-05-16; `resident` enforcement shipped (PR #476) |
+| [`surface-lease-plane-phase-a-plan.md`](surface-lease-plane-phase-a-plan.md) | COMPLETE — Phase A execution plan, shipped with PR #305 |
+| [`worktree-isolation-vs-lease-default.md`](worktree-isolation-vs-lease-default.md) | v0.2 counter-note / companion to the lease-plane RFC (not a replacement) |
+| [`lease-plane-phase-a-latency-2026-05-20.md`](lease-plane-phase-a-latency-2026-05-20.md) | First latency measurement anchoring the substrate-tax gate from the BEAM roadmap |
+
+### BEAM footprint (substrate migration waves)
+
+| Doc | Status (as of 2026-06-11) |
+|---|---|
+| [`beam-footprint-roadmap-v0.md`](beam-footprint-roadmap-v0.md) | v0.3 — destination A′ committed (operator decision 2026-05-05). Read the V0.3 RESOLUTION block first |
+| [`beam-wave-1-sentinel.md`](beam-wave-1-sentinel.md) | v0.1.3 — Wave 1 Surface 1 cycle worker shipped (PR #376). Read the v0.1.3 amendment first |
+| [`beam-wave-3-handler-dispatch.md`](beam-wave-3-handler-dispatch.md) | v0.3.2 — active redraft; supersedes v0.2/v0.1.x |
+| [`beam-wave-3a-read-only-handlers.md`](beam-wave-3a-read-only-handlers.md) | v0.2 — council-fold complete; operator review pending |
+| [`agent-orchestrator-beam-v0.md`](agent-orchestrator-beam-v0.md) | v0 thin slice — council-reviewed library + smoke, not merged to any running surface |
+| [`wave-3-section-5-2-boundary-audit-summary.md`](wave-3-section-5-2-boundary-audit-summary.md) | CI-checkable §5.2 boundary-cost audit summary (2026-06-10), required before `elixir/handler_dispatch/` commits |
+
+### Other active
+
+| Doc | Status (as of 2026-06-11) |
+|---|---|
+| [`behavioral-running-hot-detector-v0.md`](behavioral-running-hot-detector-v0.md) | v0.1 plan, pending council |
+
+## Shipped / resolved
+
+| Doc | Resolution |
+|---|---|
+| [`onboard-bootstrap-checkin.md`](onboard-bootstrap-checkin.md) | SHIPPED — Phase 5 landed via PR #188 |
+| [`onboard-bootstrap-checkin.filter-audit.md`](onboard-bootstrap-checkin.filter-audit.md) | SHIPPED — retained as historical control surface for the parent doc |
+| [`refined-phase-5-evidence-contract.md`](refined-phase-5-evidence-contract.md) | SHIPPED — paired with `onboard-bootstrap-checkin.md` (PR #188) |
+| [`path1-sync-fingerprint-check.md`](path1-sync-fingerprint-check.md) | SHIPPED — `sync_fingerprint` lives in `src/mcp_handlers/identity/shared.py` |
+| [`s19-attestation-mechanism.md`](s19-attestation-mechanism.md) | Mechanism selection council-passed 2026-04-25; implementation correctness gated separately |
+| [`section-129-measurement-fix-2026-06-03.md`](section-129-measurement-fix-2026-06-03.md) | Council-passed fix restoring the Wave 1 condition-1 measurement gate |
+
+## Dated evaluation / measurement records
+
+Point-in-time records; superseded analysis is preserved in place by design.
+
+| Doc | What it captured |
+|---|---|
+| [`wave-0-step-2-call-site-scoping.md`](wave-0-step-2-call-site-scoping.md) | Coordination-failure call-site scoping (v0.3, post-2A-pivot; earlier prescriptions superseded by PR #345) |
+| [`wave-1-window-evaluation-2026-05-18.md`](wave-1-window-evaluation-2026-05-18.md) | Wave 1 exit-condition evaluation of the T+0=2026-05-05 → T+13 window |
+| [`wave-1-window-evaluation-T0-2026-05-19.md`](wave-1-window-evaluation-T0-2026-05-19.md) | Sibling re-anchor: next evaluation window under the prior doc's falsifier |
+| [`ode-profile-decomposition-2026-05-20.md`](ode-profile-decomposition-2026-05-20.md) | ODE profile decomposition + persistence — the BEAM roadmap's load-bearing unknown |

--- a/scripts/client/check-skill-freshness.sh
+++ b/scripts/client/check-skill-freshness.sh
@@ -4,7 +4,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-PROJECTS_ROOT="${UNITARES_PROJECTS_ROOT:-$(cd "${PLUGIN_ROOT}/.." && pwd)}"
+# In this repo skills/ lives at the repo root (scripts/client/../..), not at
+# scripts/client/.. — that layout belongs to the plugin repo this script was
+# adapted from. _check_freshness.py reads "<root>/skills".
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+PROJECTS_ROOT="${UNITARES_PROJECTS_ROOT:-$(cd "${REPO_ROOT}/.." && pwd)}"
 
-exec python3 "${SCRIPT_DIR}/_check_freshness.py" "${PLUGIN_ROOT}" "${PROJECTS_ROOT}"
+exec python3 "${SCRIPT_DIR}/_check_freshness.py" "${REPO_ROOT}" "${PROJECTS_ROOT}"

--- a/scripts/diagnostics/check_doc_health.py
+++ b/scripts/diagnostics/check_doc_health.py
@@ -106,6 +106,14 @@ def check_dead_refs(md_files: list[Path]) -> list[str]:
                     if ref_path in seen:
                         continue
                     seen.add(ref_path)
+                    # Refs INTO docs/handoffs/ are operator-local by
+                    # convention: the directory is gitignored and holds
+                    # private handoffs; public docs cite them by filename
+                    # as provenance (see e.g. AGENTS.md strict-identity
+                    # stage-1 burn-in, wave-3 §5.2 audit summary). They
+                    # are expected to be unresolvable in the public tree.
+                    if ref_path.startswith("docs/handoffs/"):
+                        continue
                     # Skip wildcards, placeholders, and example paths
                     if any(c in ref_path for c in "*<>{}"):
                         continue

--- a/skills/dialectic-reasoning/SKILL.md
+++ b/skills/dialectic-reasoning/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Use when an agent is participating in a UNITARES dialectic session — paused and needs to
   submit a thesis, reviewing another agent's thesis, or synthesizing conditions for resolution.
   Covers structured argumentation and convergence.
-last_verified: "2026-04-25"
+last_verified: "2026-06-11"
 freshness_days: 14
 source_files:
   - unitares/src/mcp_handlers/dialectic/handlers.py
@@ -27,7 +27,7 @@ Dialectics are not punishment. They are a structured way to resolve disagreement
 
 ## Phase 1: Thesis
 
-The paused or requesting agent submits their position:
+The paused agent submits their position (the protocol rejects a thesis from anyone else):
 
 ```
 submit_thesis(
@@ -84,6 +84,7 @@ Convergence happens when both sides agree on conditions. The synthesis should re
 | **resume** | Agent continues with agreed conditions |
 | **block** | Agent stays paused — conditions not met or agreement not reached |
 | **escalate** | Needs human/operator intervention |
+| **cooldown** | Temporary pause — retry after a delay |
 
 ## How to Participate Well
 

--- a/skills/governance-fundamentals/SKILL.md
+++ b/skills/governance-fundamentals/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Use when an agent needs to understand UNITARES governance concepts — EISV state vectors,
   basins, verdicts, coherence, calibration. Reference material for interpreting governance
   metrics and understanding the thermodynamic model.
-last_verified: "2026-04-25"
+last_verified: "2026-06-11"
 freshness_days: 14
 source_files:
   - unitares/config/governance_config.py
@@ -51,14 +51,16 @@ Use `get_governance_metrics()` as the source of truth for the current basin/mode
 
 ## Verdicts
 
-Governance issues a verdict after each check-in:
+Governance issues a decision after each check-in. The response's `verdict` field wraps the decision **action**, which is binary — `proceed` or `pause` — qualified by a `sub_action`:
 
-| Verdict | Meaning | Action |
-|---------|---------|--------|
-| **proceed** | State is healthy | Continue working normally |
-| **guide** | Something is slightly off | Read the guidance text, adjust approach |
-| **pause** | Needs attention | Stop current work, reflect, consider dialectic review |
-| **reject** | Significant concern | Requires dialectic review or human input |
+| Action | Sub-action | Meaning | What to do |
+|--------|-----------|---------|------------|
+| **proceed** | `approve` | State is healthy | Continue working normally |
+| **proceed** | `guide` | Something is slightly off | Read the guidance text, adjust approach |
+| **pause** | `reject` | Risk threshold reached | Stop current work, reflect; dialectic review or human input |
+| **pause** | `void_pause`, `coherence_pause`, `basin_pause`, `risk_pause`, `cirs_block` | A specific subsystem tripped | Read the `reason`/`guidance` fields; consider dialectic review |
+
+Separately, `metrics.verdict` carries the internal UNITARES verdict from phi scoring — `safe` / `caution` / `high-risk`. It drives the decision above; read it as context, not as the action itself.
 
 A `margin: tight` flag means you are near a basin edge. Be more careful with next steps.
 

--- a/skills/knowledge-graph/SKILL.md
+++ b/skills/knowledge-graph/SKILL.md
@@ -3,7 +3,7 @@ name: knowledge-graph
 description: >
   Use when an agent needs to search the shared knowledge graph, contribute a discovery,
   or update existing entries. Covers search, tagging, discovery types, and status lifecycle.
-last_verified: "2026-04-25"
+last_verified: "2026-06-11"
 freshness_days: 14
 source_files:
   - unitares/src/mcp_handlers/knowledge/handlers.py
@@ -15,7 +15,7 @@ source_files:
 
 ## What It Is
 
-The knowledge graph is shared institutional memory across all agents. It is backed by PostgreSQL with Apache AGE for graph queries. Every agent can search, contribute, and update entries. Discoveries persist across sessions and are available to all agents in the system.
+The knowledge graph is shared institutional memory across all agents. It is backed by PostgreSQL — full-text search is the canonical default backend, with Apache AGE as an optional graph backend (`UNITARES_KNOWLEDGE_BACKEND=age`). Every agent can search, contribute, and update entries. Discoveries persist across sessions and are available to all agents in the system.
 
 ## Search Before Creating
 
@@ -59,7 +59,10 @@ For more control, use the `knowledge()` tool with an action parameter:
 | `details` | Get full details including graph relationships |
 | `note` | Same as `leave_note()` but through the unified interface |
 | `cleanup` | Run lifecycle cleanup for stale entries |
+| `synthesize` | Roll up a topic's discoveries into a summary row (see below) |
 | `stats` | Get knowledge graph statistics |
+| `supersede` | Mark a discovery as superseding another (creates a SUPERSEDES edge) |
+| `audit` | Read-only staleness/health scoring of open entries |
 
 ## Discovery Types
 
@@ -86,7 +89,9 @@ open  -->  resolved    (problem solved, finding addressed)
 
 - **open**: Active, still relevant, may need attention
 - **resolved**: The issue or finding has been addressed
-- **archived**: No longer relevant (outdated, superseded, or duplicate)
+- **archived**: No longer relevant (outdated or duplicate)
+
+The runtime accepts more terminal states than the two above: `disputed` (contested finding), `closed` (terminal, generic), `wont_fix` (acknowledged, deliberately not addressed), and `superseded` (replaced by a newer entry — pair with `knowledge(action="supersede")`). Check the live tool schema for the authoritative set.
 
 ## Tagging Best Practices
 

--- a/skills/unitares-dashboard/SKILL.md
+++ b/skills/unitares-dashboard/SKILL.md
@@ -7,7 +7,7 @@ description: >
   they were visible: file allowlist, Chart.js dark-theme defaults, the
   authFetch helper, the script-load chain, and the .panel layout
   contract. A repo-specific reference — not general dashboard advice.
-last_verified: "2026-04-25"
+last_verified: "2026-06-11"
 freshness_days: 30
 source_files:
   - unitares/dashboard/index.html
@@ -32,7 +32,7 @@ When adding a new panel, every item below must be done:
 
 | # | Do | File | Why |
 |---|----|----|-----|
-| 1 | Add filename to `allowed_files` list | `src/http_api.py::http_dashboard_static()` | Static handler 404s anything not on the allowlist — the browser silently fails to load |
+| 1 | Add filename to `allowed_files` list | `src/http_api.py::http_dashboard_static()` | Static handler rejects (403) anything not on the allowlist — the browser silently fails to load |
 | 2 | Add `<script src="/dashboard/NAME.js"></script>` **without** `defer` | `dashboard/index.html` (Layer 2 block) | All peer modules load non-deferred and the IIFE has its own `DOMContentLoaded` guard |
 | 3 | Use `authFetch(url)` from `utils.js` | module JS | Shared helper reads the canonical `unitares_api_token` localStorage key; don't re-invent |
 | 4 | Set `Chart.defaults.color`, `.font.family`, `.borderColor` from body CSS vars | before `new Chart()` | Chart.js defaults to dark-grey ticks on your dark-grey background — invisible axis labels |
@@ -106,7 +106,7 @@ The reference implementation is `dashboard/eisv-charts.js::makeChartOptions`. Co
 
 ## The Allowlist Trap (Item 1)
 
-`src/http_api.py::http_dashboard_static()` has a hardcoded `allowed_files` list. A file not on it returns JSON `{"error": "File not allowed"}` — NOT a 404, but a 200 with an error body. The browser still fails to load the script and `Console` shows a SyntaxError deep in the JSON. Easy to miss.
+`src/http_api.py::http_dashboard_static()` has a hardcoded `allowed_files` list. A file not on it returns a **403** with JSON body `{"error": "File not allowed"}` — not a 404. The browser still fails to load the script and `Console` shows the failed request. Easy to miss.
 
 Verify by `curl`:
 ```bash

--- a/skills/unitares-governance/SKILL.md
+++ b/skills/unitares-governance/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Compatibility umbrella skill for the UNITARES governance framework. Use this
   as the entrypoint when you need the overall model and route into the split
   governance skills.
-last_verified: "2026-04-25"
+last_verified: "2026-06-11"
 freshness_days: 14
 source_files:
   - unitares/src/mcp_handlers/core.py

--- a/tests/test_doc_health_dead_refs.py
+++ b/tests/test_doc_health_dead_refs.py
@@ -207,6 +207,24 @@ def test_dead_ref_check_skips_private_ontology_plan_ledger(tmp_path, monkeypatch
     assert doc_health.check_dead_refs([plan]) == []
 
 
+def test_dead_ref_check_skips_operator_local_handoffs_refs(tmp_path, monkeypatch, doc_health):
+    """Refs into docs/handoffs/ are operator-local (the dir is gitignored).
+
+    Public docs cite private handoffs by filename as provenance — e.g. the
+    AGENTS.md strict-identity stage-1 burn-in note. Those paths are expected
+    to be unresolvable in the public tree, from any doc, not just the
+    skip-listed ledger files.
+    """
+    agents = tmp_path / "AGENTS.md"
+    agents.write_text(
+        "Stage 1 run (`docs/handoffs/strict-identity-stage1-burnin-2026-06-11.md`)\n"
+    )
+
+    monkeypatch.setattr(doc_health, "REPO_ROOT", tmp_path)
+
+    assert doc_health.check_dead_refs([agents]) == []
+
+
 def test_get_db_call_is_internal_helper_not_ghost_tool(tmp_path, monkeypatch, doc_health):
     """AGENTS.md mentions get_db() as an internal helper, not an MCP tool claim."""
     agents = tmp_path / "AGENTS.md"


### PR DESCRIPTION
## What

Workspace organizing pass, three layers. No file moves — the hot Plexus / lease-plane / BEAM docs are single-writer surfaces, so this indexes and repairs instead of restructuring.

### 1. docs/ tree — dangling links from the archive cut (`e16329a`)

The 2026-05-21 archive cut (`27642d1`) moved internal RFC/review docs to the operator's private archive; the restore (`4ad624a`) brought the load-bearing specs back but restored the **old** ontology README, leaving nine links to docs that intentionally stayed archived. The links were relative (`[x](s20-….md)`), which `check_doc_health`'s repo-rooted path patterns never see.

- **`docs/ontology/README.md`** — drop the nine archived-doc links; add an "Operator-archived docs" section so `plan.md`'s surviving citations read as intentional; index the new `ledger-triage-2026-06-11.md`.
- **`docs/README.md`** — index the six docs missing from the layout map (`REVIEWER_GUIDE`, `trust-contract`, `guides/CIRS_PROTOCOL`, `operations/{DATA_NOTES, DEPLOYMENT_DATA_CAVEAT, branch-hygiene-runbook}`); link the new proposals index.
- **`docs/proposals/README.md`** (new) — status-grouped map of the 24 RFCs; each doc's body stays canonical for status.
- **`check_doc_health.py`** — refs into `docs/handoffs/` are operator-local by convention (the dir is gitignored at `.gitignore:165`); skip them in the dead-ref check instead of flagging AGENTS.md. Clears the doctor's only warning without touching the shared-contract files (in flight on #619). Regression test added.

### 2. Skill-freshness tooling repair (`7146f17`)

`scripts/client/check-skill-freshness.sh` was adapted from the plugin repo, where `scripts/client/..` is the root containing `skills/`; here `skills/` is at the repo root, so it crashed on the nonexistent `scripts/skills`. Two-line root fix. The working checker then reported 6 of 7 skills STALE.

### 3. Skill verification pass (`1701c15`, `d10e2e2`)

Every claim checked against live handlers/schemas before bumping `last_verified` to 2026-06-11:

- **dialectic-reasoning** — add missing `cooldown` resolution outcome (`ResolutionAction.COOLDOWN`); clarify only the paused agent can submit the thesis.
- **knowledge-graph** — document `synthesize`/`supersede`/`audit` actions (router is 12 actions now); list the four runtime-accepted terminal statuses beyond open/resolved/archived; correct the backend claim (PostgreSQL FTS canonical since `2abbac7`, AGE optional).
- **unitares-dashboard** — disallowed static files return **403** with the JSON error body (`src/http_api.py:892`), not the documented 200-with-error-body (and a "404s" claim in the checklist).
- **unitares-governance** — all routing/tool/identity claims verified correct; date bump only.
- **governance-fundamentals** — the Verdicts table presented proceed/guide/pause/reject as four flat verdicts; rewrote to the real two-level structure (binary `action` proceed|pause × `sub_action`, with `metrics.verdict` = safe/caution/high-risk as the separate internal phi signal).

Deliberately not bumped: **governance-lifecycle** (being refreshed in PR #619), **discord-bridge** (source lives in the bridge repo).

### Found but not fixed (code, not docs)

`src/knowledge_graph.py:75` — `response_type` Literal allows 4 values, but `VALID_RESPONSE_TYPES` in `knowledge/handlers.py:635` accepts 9. The type and the validation have drifted apart; behavior-relevant, left for a dedicated change.

## Verification

- `check_doc_health.py` → all clear (was 1 warning)
- `check-skill-freshness.sh` → 6 of 7 skills FRESH (lifecycle deferred to #619, discord-bridge AGING/unverifiable)
- `tests/test_doc_health_dead_refs.py` + `tests/test_skills_introspection.py` → 26 passed
- Every relative `.md` link in the touched/created READMEs verified to resolve

https://claude.ai/code/session_0175AVycpcUwuEiizCU1T1iY