### PR TITLE
[codex] report delivery state at closeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Codex has no hook system analogous to Claude's. **Nothing is automatic.** You de
 - `/checkin` — governance update after meaningful work
 - `/diagnose` — identity, state, and operator diagnostics
 - `/dialectic` — structured review
-- `/closeout` — final workspace hygiene check; reports dirty files and repo-rooted processes, and can stash/stop them when cleanup is requested
+- `/closeout` — final workspace hygiene check; reports dirty files, Git delivery state (local vs pushed/merged), and repo-rooted processes; can stash/stop when cleanup is requested
 
 Raw tool flow when slash commands are unavailable: `onboard(force_new=true, parent_agent_id=<prior uuid if continuing>, spawn_reason="new_session")` → save `uuid` + `client_session_id` → `process_agent_update(response_text, complexity, client_session_id=...)` → `get_governance_metrics()` for read-only checks → `health_check()` only if system health is suspect.
 
@@ -44,6 +44,22 @@ Use `--agent-id` when resolving or dismissing so the audit trail stays attribute
 
 - `.claude/CLAUDE.md` — Claude-only machine-local overlay.
 - `~/.claude/projects/.../memory/MEMORY.md` — Claude's memory system; Codex uses `.unitares/session.json` instead.
+
+### Delivery state is part of closeout
+
+Codex must not leave the operator to infer GitHub state from "tests passed".
+Before a final response after edits, run `/closeout` or
+`python3 scripts/dev/workspace_closeout.py` and report the delivery line:
+
+- `local_changes` means not committed, not pushed, not merged.
+- `unpushed_commits` means committed locally but not pushed.
+- `pushed_branch` means pushed, but PR/merge state is not proven by local git.
+- `synced_default` means the current checkout is clean and synced with the
+  default upstream.
+
+If the operator asks whether something is merged, answer from this delivery
+state plus any explicit GitHub check you performed. Do not imply local edits
+are merged.
 
 <!-- BEGIN SHARED CONTRACT — keep byte-identical across AGENTS.md and CLAUDE.md; scripts/dev/check-shared-contract.sh enforces parity -->
 

--- a/CODEX_START.md
+++ b/CODEX_START.md
@@ -18,6 +18,7 @@ Connect to a running UNITARES governance server, preserve continuity cleanly, an
 4. Run `/checkin` after a meaningful milestone
 5. Run `/diagnose` when continuity or governance state looks wrong
 6. Use `/dialectic` when you need structured review
+7. Run `/closeout` before saying edited work is done
 
 If you are not using commands directly, the equivalent raw tool flow is:
 
@@ -98,12 +99,34 @@ open GitHub PRs, and unresolved Watcher output. For automation, add
 or narrow it with comma-separated categories such as
 `--fail-on-attention worktrees,watcher`.
 
+Use closeout before the final response after edits:
+
+```bash
+python3 scripts/dev/workspace_closeout.py
+```
+
+The `delivery:` line is mandatory context. In particular:
+
+- `local_changes` means not committed, not pushed, not merged.
+- `unpushed_commits` means committed locally but not pushed.
+- `pushed_branch` means pushed, but PR/merge state is not proven by local git.
+- `synced_default` means clean and synced with the default upstream.
+
+If you want Codex to ship the current staged change, use:
+
+```bash
+./scripts/dev/ship.sh "type(scope): concise message"
+```
+
+That helper chooses direct push versus PR+auto-merge based on the staged files.
+
 ## Commands
 
 - `/governance-start` to create or declare lineage and refresh local continuity state
 - `/checkin` for a governance update after meaningful work
 - `/diagnose` for identity, state, and operator diagnostics
 - `/dialectic` for structured review
+- `/closeout` for workspace hygiene and explicit GitHub delivery state
 
 ## Watcher
 

--- a/commands/closeout.md
+++ b/commands/closeout.md
@@ -18,6 +18,8 @@ started repo-rooted processes.
 Report:
 
 - whether git is clean
+- the `delivery:` line, including whether work is local-only, unpushed,
+  pushed-but-not-proven-merged, or synced with default upstream
 - any staged, unstaged, or untracked files
 - any repo-rooted processes still running
 - whether a remaining process is managed by a LaunchAgent label
@@ -34,6 +36,14 @@ Rules:
   committed/stashed.
 - If there are staged changes, decide whether to commit, unstage, or stash
   before final response; do not leave them ambiguous.
+- If `delivery` is `local_changes`, say plainly: not committed, not pushed,
+  not merged.
+- If `delivery` is `unpushed_commits`, say plainly: committed locally but not
+  pushed or merged.
+- If `delivery` is `pushed_branch`, do not claim merge completion unless you
+  also checked GitHub PR state explicitly.
+- If the operator asks "merged?", answer directly from delivery state and any
+  GitHub check performed.
 - If there are unrelated dirty files, preserve them in a labeled stash rather
   than reverting them.
 - Stop only processes rooted inside the current workspace. Do not stop services

--- a/scripts/dev/workspace_closeout.py
+++ b/scripts/dev/workspace_closeout.py
@@ -6,7 +6,8 @@ they have modified the repo or started local services. It answers two
 questions the user should not have to audit manually:
 
 1. Is the git worktree still dirty?
-2. Are any long-running processes still rooted inside this workspace?
+2. Has local git state actually been delivered upstream?
+3. Are any long-running processes still rooted inside this workspace?
 
 By default the script reports only. With explicit flags it can stash dirty
 work and terminate or boot out repo-rooted processes.
@@ -39,6 +40,13 @@ class GitState:
     staged: list[str]
     unstaged: list[str]
     untracked: list[str]
+    detached: bool = False
+    head: str = ""
+    upstream: str | None = None
+    ahead: int | None = None
+    behind: int | None = None
+    delivery_status: str = "unknown"
+    delivery_detail: str = "delivery state not computed"
 
 
 @dataclass
@@ -205,7 +213,98 @@ def git_state(root: Path) -> GitState:
     state = parse_git_porcelain(status_stdout)
     rc_branch, branch_stdout, _ = _run(["git", "branch", "--show-current"], root)
     state.branch = branch_stdout.strip() if rc_branch == 0 else ""
+    state.detached = not bool(state.branch)
+    state.head = _git_stdout(["git", "rev-parse", "--short", "HEAD"], root)
+    upstream = _git_stdout(
+        ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+        root,
+    )
+    state.upstream = upstream or None
+    if state.upstream:
+        state.ahead, state.behind = ahead_behind(root, state.upstream)
+    state.delivery_status, state.delivery_detail = compute_delivery_state(
+        state,
+        default_upstream=default_upstream(root),
+    )
     return state
+
+
+def _git_stdout(args: list[str], root: Path) -> str:
+    rc, stdout, _ = _run(args, root)
+    return stdout.strip() if rc == 0 else ""
+
+
+def ahead_behind(root: Path, upstream: str) -> tuple[int | None, int | None]:
+    rc, stdout, _ = _run(
+        ["git", "rev-list", "--left-right", "--count", f"HEAD...{upstream}"],
+        root,
+    )
+    if rc != 0:
+        return None, None
+    parts = stdout.strip().split()
+    if len(parts) != 2:
+        return None, None
+    try:
+        return int(parts[0]), int(parts[1])
+    except ValueError:
+        return None, None
+
+
+def default_upstream(root: Path) -> str | None:
+    """Return the best local name for origin's default branch."""
+    symbolic = _git_stdout(
+        ["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+        root,
+    )
+    if symbolic:
+        return symbolic
+    for candidate in ("origin/master", "origin/main"):
+        if _git_stdout(["git", "rev-parse", "--verify", "--quiet", candidate], root):
+            return candidate
+    return None
+
+
+def compute_delivery_state(
+    state: GitState,
+    *,
+    default_upstream: str | None = None,
+) -> tuple[str, str]:
+    """Summarize whether local work is committed, pushed, and plausibly merged.
+
+    This is intentionally local-git based. It does not claim a feature branch is
+    merged unless the current checkout is clean and synced with the default
+    upstream; for feature branches it reports that PR/merge state is not proven.
+    """
+    if state.dirty:
+        return "local_changes", "not committed, not pushed, not merged"
+    if state.detached:
+        return "detached", "clean detached HEAD; switch/create a branch before delivery"
+    if not state.branch:
+        return "unknown", "could not identify the current branch"
+    if not state.upstream:
+        return "no_upstream", "clean branch has no upstream; push it before asking GitHub to merge"
+    if state.ahead is None or state.behind is None:
+        return "unknown", f"could not compare HEAD with {state.upstream}"
+    if state.ahead > 0 and state.behind > 0:
+        return (
+            "diverged",
+            f"{state.ahead} local commit(s) ahead and {state.behind} behind {state.upstream}",
+        )
+    if state.ahead > 0:
+        return "unpushed_commits", f"{state.ahead} local commit(s) not pushed to {state.upstream}"
+    if state.behind > 0:
+        return "behind_upstream", f"clean but {state.behind} commit(s) behind {state.upstream}"
+    if default_upstream and state.upstream == default_upstream:
+        return "synced_default", f"clean and synced with {state.upstream}"
+    return (
+        "pushed_branch",
+        f"clean and pushed to {state.upstream}; PR/merge state not proven by local git",
+    )
+
+
+def delivery_needs_attention(state: GitState) -> bool:
+    """Return true for delivery states that mean local work is definitely stuck."""
+    return state.delivery_status in {"local_changes", "unpushed_commits", "diverged"}
 
 
 def build_stash_message(branch: str, file_count: int, timestamp: str) -> str:
@@ -562,7 +661,11 @@ def start_check(
 
 
 def result_has_issues(result: CloseoutResult) -> bool:
-    return result.git.dirty or bool(result.repo_processes) or bool(result.errors)
+    return (
+        delivery_needs_attention(result.git)
+        or bool(result.repo_processes)
+        or bool(result.errors)
+    )
 
 
 def isolation_is_issue(result: StartCheckResult) -> bool:
@@ -597,6 +700,18 @@ def render_text(result: CloseoutResult) -> str:
             lines.append(f"  {entry}")
     else:
         lines.append("git: clean")
+
+    branch = result.git.branch or "(detached)"
+    upstream = result.git.upstream or "(none)"
+    ahead = "?" if result.git.ahead is None else str(result.git.ahead)
+    behind = "?" if result.git.behind is None else str(result.git.behind)
+    lines.append(
+        f"delivery: {result.git.delivery_status} - {result.git.delivery_detail}"
+    )
+    lines.append(
+        f"  branch={branch} head={result.git.head or '?'} "
+        f"upstream={upstream} ahead={ahead} behind={behind}"
+    )
 
     if result.stashed:
         lines.append(f"stash: created - {result.stash_message}")

--- a/tests/test_http_api_watcher_summary.py
+++ b/tests/test_http_api_watcher_summary.py
@@ -22,6 +22,7 @@ class TestFindingsPathMatchesWriter:
 
         monkeypatch.setattr(util, "_state_dir_cache", None)
         monkeypatch.setattr(util, "_legacy_migration_done", True)  # skip fs work
+        monkeypatch.setattr(util, "_LEGACY_STATE_DIR", tmp_path / "missing-legacy")
         monkeypatch.setenv("UNITARES_WATCHER_DATA_DIR", str(tmp_path / "shared"))
 
         # Reader resolves through the same shared resolver the writer uses.

--- a/tests/test_workspace_closeout.py
+++ b/tests/test_workspace_closeout.py
@@ -165,6 +165,53 @@ def test_closeout_stashes_dirty_repo_when_requested(closeout_module, git_repo, m
     assert "workspace-closeout auto-stash" in stash_list.stdout
 
 
+def test_git_state_marks_dirty_work_as_not_delivered(closeout_module, git_repo):
+    (git_repo / "seed.py").write_text("dirty\n")
+
+    state = closeout_module.git_state(git_repo)
+
+    assert state.dirty is True
+    assert state.delivery_status == "local_changes"
+    assert closeout_module.delivery_needs_attention(state) is True
+
+
+def test_git_state_marks_unpushed_commits_as_not_delivered(
+    closeout_module, git_repo, tmp_path
+):
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(origin)], check=True)
+    subprocess.run(["git", "remote", "add", "origin", str(origin)], cwd=git_repo, check=True)
+    subprocess.run(["git", "push", "-u", "origin", "main"], cwd=git_repo, check=True)
+
+    (git_repo / "seed.py").write_text("second\n")
+    subprocess.run(["git", "add", "seed.py"], cwd=git_repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "second"], cwd=git_repo, check=True)
+
+    state = closeout_module.git_state(git_repo)
+
+    assert state.dirty is False
+    assert state.upstream == "origin/main"
+    assert state.ahead == 1
+    assert state.behind == 0
+    assert state.delivery_status == "unpushed_commits"
+    assert closeout_module.delivery_needs_attention(state) is True
+
+
+def test_git_state_marks_synced_default_as_delivered(
+    closeout_module, git_repo, tmp_path
+):
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(origin)], check=True)
+    subprocess.run(["git", "remote", "add", "origin", str(origin)], cwd=git_repo, check=True)
+    subprocess.run(["git", "push", "-u", "origin", "main"], cwd=git_repo, check=True)
+
+    state = closeout_module.git_state(git_repo)
+
+    assert state.dirty is False
+    assert state.delivery_status == "synced_default"
+    assert closeout_module.delivery_needs_attention(state) is False
+
+
 def _add_worktree(repo: Path, path: Path, branch: str) -> Path:
     subprocess.run(
         ["git", "worktree", "add", str(path), "-b", branch],


### PR DESCRIPTION
## Summary
- add explicit closeout delivery states for local-only, unpushed, pushed-branch, and synced-default git states
- update Codex closeout docs to require reporting delivery state before saying edited work is done
- make watcher summary path test hermetic against local ignored legacy watcher state

## Validation
- ./scripts/dev/test-cache.sh
- python3 -m pytest -q tests/test_http_api_watcher_summary.py tests/test_workspace_closeout.py
- ./scripts/dev/check-shared-contract.sh
- git diff --check
- pre-push smoke hook: 138 passed