### PR TITLE
refactor(identity): single-source the sticky-cache consult across MCP + REST transports

### DIFF
--- a/src/http_api.py
+++ b/src/http_api.py
@@ -270,42 +270,38 @@ async def _resolve_http_bound_agent(tool_name: str, arguments: dict, signals) ->
         update_context_agent_id(explicit_agent_id)
         return explicit_agent_id
 
-    # Sticky transport cache: the MCP middleware path (identity_step.py) consults
-    # this cache before calling resolve_session_identity, which prevents identity
-    # fragmentation for repeat callers from the same IP:UA fingerprint. The REST
-    # path previously bypassed this cache entirely — every call went through
-    # PATH 3 creation, producing mcp_YYYYMMDD ghost identities at a rate of
-    # hundreds per day (see identity-ghost-proliferation investigation 2026-04-15).
-    # Mirror the same check here so REST gets the same ghost protection.
-    force_new = bool(arguments.get("force_new"))
-    client_session_id = arguments.get("client_session_id")
-    continuity_token = arguments.get("continuity_token")
-    transport_key = None
-    if not force_new and not client_session_id and not continuity_token:
-        try:
-            import time as _time
-            from src.mcp_handlers.middleware.identity_step import (
-                _TRANSPORT_CACHE_TTL,
-                _transport_cache_key,
-                _transport_identity_cache,
-            )
-            transport_key = _transport_cache_key(signals)
-            if transport_key:
-                cached = _transport_identity_cache.get(transport_key)
-                if cached and (_time.monotonic() - cached.bound_at) < _TRANSPORT_CACHE_TTL:
-                    update_context_agent_id(cached.agent_uuid)
-                    arguments["agent_id"] = cached.agent_uuid
-                    # S3: emit the cache-hit envelope `sticky_cache:<original>`
-                    # so `_compute_identity_assurance` can apply decay-by-one
-                    # against the original proof tier. Pre-S3 Redis entries
-                    # (and bindings created before this field was threaded)
-                    # carry original="unknown" and continue to map to weak.
-                    set_session_resolution_source(
-                        f"sticky_cache:{cached.original_session_source}"
-                    )
-                    return cached.agent_uuid
-        except Exception as e:
-            logger.debug("[STICKY-REST] cache check failed: %s", e)
+    # Sticky transport cache: single-sourced consult shared with the MCP
+    # middleware (identity_step.consult_sticky_binding), which prevents
+    # identity fragmentation for repeat callers from the same IP:UA
+    # fingerprint. The REST path previously bypassed this cache entirely —
+    # every call went through PATH 3 creation, producing mcp_YYYYMMDD ghost
+    # identities at a rate of hundreds per day (see identity-ghost-
+    # proliferation investigation 2026-04-15). redis_recovery=False
+    # preserves this surface's historical in-memory-only consult: REST
+    # never recovered bindings from Redis after a restart.
+    from src.mcp_handlers.identity.session import extract_token_agent_uuid_safe
+    from src.mcp_handlers.middleware.identity_step import (
+        consult_sticky_binding,
+        sticky_resolution_source,
+        update_transport_binding,
+    )
+
+    consult = None
+    try:
+        consult = await consult_sticky_binding(signals, arguments, redis_recovery=False)
+        if consult.binding is not None:
+            cached = consult.binding
+            update_context_agent_id(cached.agent_uuid)
+            arguments["agent_id"] = cached.agent_uuid
+            # S3: emit the cache-hit envelope `sticky_cache:<original>`
+            # so `_compute_identity_assurance` can apply decay-by-one
+            # against the original proof tier. Pre-S3 Redis entries
+            # (and bindings created before this field was threaded)
+            # carry original="unknown" and continue to map to weak.
+            set_session_resolution_source(sticky_resolution_source(cached))
+            return cached.agent_uuid
+    except Exception as e:
+        logger.debug("[STICKY-REST] cache check failed: %s", e)
 
     session_key = await derive_session_key(signals, arguments)
 
@@ -314,13 +310,7 @@ async def _resolve_http_bound_agent(tool_name: str, arguments: dict, signals) ->
     # distinguish \"Watcher owns agent-907e3195-c64\" from \"some prior REST
     # caller claimed that session_key and got cached\", and PATH 1 happily
     # returns whichever agent the cache holds (issue #110).
-    _token_agent_uuid = None
-    if continuity_token:
-        try:
-            from src.mcp_handlers.identity.session import extract_token_agent_uuid
-            _token_agent_uuid = extract_token_agent_uuid(str(continuity_token))
-        except Exception:
-            pass
+    _token_agent_uuid = extract_token_agent_uuid_safe(arguments.get("continuity_token"))
 
     resolved = await resolve_session_identity(
         session_key,
@@ -337,18 +327,22 @@ async def _resolve_http_bound_agent(tool_name: str, arguments: dict, signals) ->
             arguments["agent_id"] = agent_uuid
             # Populate sticky cache so subsequent REST calls from the same
             # fingerprint hit the cache path above and skip resolution entirely.
-            if transport_key:
+            # Write back only when the consult guard passed (`cacheable`):
+            # proof-carrying requests (client_session_id / continuity_token /
+            # force_new) are never cached under the bare fingerprint on this
+            # surface.
+            writeback_key = (
+                consult.transport_key if (consult and consult.cacheable) else None
+            )
+            if writeback_key:
                 try:
-                    from src.mcp_handlers.middleware.identity_step import (
-                        update_transport_binding,
-                    )
                     # `resolved.source` is the proof source from
                     # resolve_session_identity — exactly what the tier mapper
                     # consumes. Mirror it as the binding's original_session_source
                     # so future cache hits decay against it.
                     _original = resolved.get("source") or "rest_resolution"
                     update_transport_binding(
-                        transport_key,
+                        writeback_key,
                         agent_uuid,
                         session_key,
                         source="rest",

--- a/src/mcp_handlers/identity/session.py
+++ b/src/mcp_handlers/identity/session.py
@@ -311,6 +311,23 @@ def extract_token_agent_uuid(token: str) -> Optional[str]:
         return None
 
 
+def extract_token_agent_uuid_safe(token: object) -> Optional[str]:
+    """Best-effort `extract_token_agent_uuid`: None for falsy or invalid input.
+
+    The MCP dispatch middleware (identity_step) and the REST prebind path
+    (http_api._resolve_http_bound_agent) both need "token → agent UUID, or
+    None" without exception handling at the call site. Single-sourced here
+    so the str() coercion and swallow-everything posture cannot drift
+    between transports.
+    """
+    if not token:
+        return None
+    try:
+        return extract_token_agent_uuid(str(token))
+    except Exception:
+        return None
+
+
 def resolve_continuity_token(
     token: str,
     *,

--- a/src/mcp_handlers/middleware/identity_step.py
+++ b/src/mcp_handlers/middleware/identity_step.py
@@ -300,6 +300,73 @@ async def _invalidate_binding_redis_async(key: str) -> None:
         pass
 
 
+@dataclass
+class StickyConsult:
+    """Result of `consult_sticky_binding` — the single-sourced sticky-cache
+    consult shared by the MCP dispatch middleware (`resolve_identity`) and
+    the REST prebind path (`http_api._resolve_http_bound_agent`).
+
+    `transport_key` is the raw cache key for the signals (None when the
+    transport is uncacheable). `cacheable` is True only when the consult
+    guard passed — no force_new / client_session_id / continuity_token /
+    explicit UUID on the request — i.e. when a caller that resolves
+    identity afterwards may write the result back under `transport_key`.
+    The REST path writes back only when `cacheable`; the middleware
+    deliberately writes back on the raw key even for proof-carrying
+    requests (e.g. PATH 0 agent_uuid passthrough).
+    """
+    transport_key: Optional[str]
+    binding: Optional[TransportBinding]
+    cacheable: bool
+
+
+async def consult_sticky_binding(
+    signals,
+    arguments: Optional[Dict[str, Any]],
+    *,
+    has_explicit_uuid: bool = False,
+    redis_recovery: bool = True,
+) -> StickyConsult:
+    """Consult the sticky transport-binding cache (MCP middleware + REST).
+
+    Single-sources the consult guard, the TTL check, and (optionally) the
+    Redis restart-recovery fallback so the two transports cannot drift —
+    the REST copy of this logic had already diverged silently (no Redis
+    recovery, no explicit-UUID guard) before consolidation.
+    `redis_recovery=False` preserves the REST path's historical behavior:
+    it only ever consulted the in-memory cache, never Redis after a
+    restart. The divergence is now an explicit parameter instead of a
+    drifting copy.
+    """
+    transport_key = _transport_cache_key(signals)
+    args = arguments if isinstance(arguments, dict) else {}
+    cacheable = bool(
+        transport_key
+        and not args.get("force_new")
+        and not args.get("client_session_id")
+        and not args.get("continuity_token")
+        and not has_explicit_uuid
+    )
+    if not cacheable:
+        return StickyConsult(transport_key, None, False)
+    cached = _transport_identity_cache.get(transport_key)
+    if not cached and redis_recovery:
+        cached = await _load_binding_from_redis(transport_key)
+    if cached and (_time.monotonic() - cached.bound_at) < _TRANSPORT_CACHE_TTL:
+        return StickyConsult(transport_key, cached, True)
+    return StickyConsult(transport_key, None, True)
+
+
+def sticky_resolution_source(binding: TransportBinding) -> str:
+    """The S3 cache-hit envelope ``sticky_cache:<original>``, single-sourced.
+
+    Both transports must emit the identical envelope so
+    `_compute_identity_assurance` applies the same decay-by-one against the
+    original proof tier regardless of which surface served the hit.
+    """
+    return f"sticky_cache:{binding.original_session_source}"
+
+
 def _evict_stale_entries() -> None:
     """Lazy TTL eviction + max size enforcement."""
     now = _time.monotonic()
@@ -334,64 +401,58 @@ async def resolve_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
         canonical_name = name
 
     # --- Sticky transport binding: early return if cached ---
-    transport_key = _transport_cache_key(signals)
+    consult = await consult_sticky_binding(
+        signals,
+        arguments,
+        has_explicit_uuid=bool(arguments and arguments.get("agent_uuid")),
+    )
+    transport_key = consult.transport_key
     ctx._transport_key = transport_key
 
-    _has_agent_uuid = bool(arguments and arguments.get("agent_uuid"))
-    if (transport_key
-        and not force_new
-        and not client_session_id
-        and not continuity_token
-        and not _has_agent_uuid):
-        cached = _transport_identity_cache.get(transport_key)
-        # On miss, try Redis (survives restarts)
-        if not cached:
-            cached = await _load_binding_from_redis(transport_key)
-        if cached and (_time.monotonic() - cached.bound_at) < _TRANSPORT_CACHE_TTL:
-            logger.debug(
-                f"[STICKY] Cache hit for {transport_key}: agent={cached.agent_uuid[:8]}... "
-                f"session_key={cached.session_key[:30]}..."
-            )
-            core_status = await _lookup_core_agent_row_status(
-                cached.agent_uuid,
-                "STICKY",
-            )
-            # Reuse cached binding — set context and return early.
-            # S3: mark session_resolution_source with the cache-hit envelope
-            # `sticky_cache:<original>` so the tier mapper can apply
-            # decay-by-one (strong→medium, medium→weak, weak→weak) against
-            # the original proof, instead of treating every cache hit as
-            # uniformly weak. See `_compute_identity_assurance`.
-            from ..context import set_session_context, set_session_resolution_source
-            set_session_resolution_source(
-                f"sticky_cache:{cached.original_session_source}"
-            )
-            client_hint = arguments.get("client_hint") if arguments else None
-            identity_result = {
-                "agent_uuid": cached.agent_uuid,
-                "source": "sticky_cache",
-                "original_session_source": cached.original_session_source,
-                "core_agent_row_status": core_status,
-            }
-            context_token = set_session_context(
-                session_key=cached.session_key,
-                client_session_id=client_session_id,
-                agent_id=cached.agent_uuid,
-                client_hint=client_hint,
-                identity_result=identity_result,
-            )
-            ctx.session_key = cached.session_key
-            ctx.client_session_id = client_session_id
-            ctx.bound_agent_id = cached.agent_uuid
-            ctx.context_token = context_token
-            ctx.client_hint = client_hint
-            ctx.identity_result = identity_result
-            _attach_middleware_identity(
-                arguments,
-                session_key=cached.session_key,
-                identity_result=identity_result,
-            )
-            return name, arguments, ctx
+    if consult.binding is not None:
+        cached = consult.binding
+        logger.debug(
+            f"[STICKY] Cache hit for {transport_key}: agent={cached.agent_uuid[:8]}... "
+            f"session_key={cached.session_key[:30]}..."
+        )
+        core_status = await _lookup_core_agent_row_status(
+            cached.agent_uuid,
+            "STICKY",
+        )
+        # Reuse cached binding — set context and return early.
+        # S3: mark session_resolution_source with the cache-hit envelope
+        # `sticky_cache:<original>` so the tier mapper can apply
+        # decay-by-one (strong→medium, medium→weak, weak→weak) against
+        # the original proof, instead of treating every cache hit as
+        # uniformly weak. See `_compute_identity_assurance`.
+        from ..context import set_session_context, set_session_resolution_source
+        set_session_resolution_source(sticky_resolution_source(cached))
+        client_hint = arguments.get("client_hint") if arguments else None
+        identity_result = {
+            "agent_uuid": cached.agent_uuid,
+            "source": "sticky_cache",
+            "original_session_source": cached.original_session_source,
+            "core_agent_row_status": core_status,
+        }
+        context_token = set_session_context(
+            session_key=cached.session_key,
+            client_session_id=client_session_id,
+            agent_id=cached.agent_uuid,
+            client_hint=client_hint,
+            identity_result=identity_result,
+        )
+        ctx.session_key = cached.session_key
+        ctx.client_session_id = client_session_id
+        ctx.bound_agent_id = cached.agent_uuid
+        ctx.context_token = context_token
+        ctx.client_hint = client_hint
+        ctx.identity_result = identity_result
+        _attach_middleware_identity(
+            arguments,
+            session_key=cached.session_key,
+            identity_result=identity_result,
+        )
+        return name, arguments, ctx
 
     # Invalidate cache on force_new
     if force_new and transport_key:
@@ -436,14 +497,10 @@ async def resolve_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
     if _direct_uuid and name in ("identity", "onboard"):
         # Identity Honesty Part C: require matching continuity_token.
         # Matches the handler-layer gate in identity/handlers.py PATH 0.
-        _partc_token_aid = None
-        _partc_token = arguments.get("continuity_token") if arguments else None
-        if _partc_token:
-            try:
-                from ..identity.session import extract_token_agent_uuid
-                _partc_token_aid = extract_token_agent_uuid(str(_partc_token))
-            except Exception:
-                _partc_token_aid = None
+        from ..identity.session import extract_token_agent_uuid_safe
+        _partc_token_aid = extract_token_agent_uuid_safe(
+            arguments.get("continuity_token") if arguments else None
+        )
         _partc_owned = _partc_token_aid == _direct_uuid
 
         if not _partc_owned:
@@ -561,13 +618,10 @@ async def resolve_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
         return name, arguments, ctx
 
     # Extract agent UUID from continuity token for PATH 2.8 direct lookup
-    _token_agent_uuid = None
-    if arguments and arguments.get("continuity_token"):
-        try:
-            from ..identity.session import extract_token_agent_uuid
-            _token_agent_uuid = extract_token_agent_uuid(str(arguments["continuity_token"]))
-        except Exception:
-            pass
+    from ..identity.session import extract_token_agent_uuid_safe
+    _token_agent_uuid = extract_token_agent_uuid_safe(
+        arguments.get("continuity_token") if arguments else None
+    )
 
     bound_agent_id = None
     identity_result = None

--- a/tests/test_transport_resolution_parity.py
+++ b/tests/test_transport_resolution_parity.py
@@ -1,0 +1,221 @@
+"""Golden-parity tests for the single-sourced sticky-cache consult.
+
+PR #245 consolidated the middleware↔handler identity-resolution paths
+(S21-b items 5+6); the REST prebind path (`_resolve_http_bound_agent`)
+remained a third, hand-mirrored copy that had already drifted (no Redis
+restart-recovery, no explicit-UUID guard). These tests pin the shared
+consult (`consult_sticky_binding`) and the shared S3 decay envelope
+(`sticky_resolution_source`) so the two transports cannot drift again,
+and make the one deliberate divergence — REST consults in-memory only —
+an explicit, tested parameter instead of a silent difference.
+"""
+
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+project_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.mcp_handlers.middleware.identity_step import (
+    _transport_identity_cache,
+    consult_sticky_binding,
+    sticky_resolution_source,
+    update_transport_binding,
+)
+
+
+@dataclass
+class FakeSignals:
+    """Minimal SessionSignals stand-in (mirrors test_sticky_identity.py)."""
+    mcp_session_id: Optional[str] = None
+    x_session_id: Optional[str] = None
+    x_client_id: Optional[str] = None
+    oauth_client_id: Optional[str] = None
+    ip_ua_fingerprint: Optional[str] = None
+    user_agent: Optional[str] = None
+    client_hint: Optional[str] = None
+    x_agent_name: Optional[str] = None
+    x_agent_id: Optional[str] = None
+    transport: str = "rest"
+
+
+@pytest.fixture(autouse=True)
+def clean_cache():
+    _transport_identity_cache.clear()
+    yield
+    _transport_identity_cache.clear()
+
+
+def _signals(fp: str = "10.0.0.1:uaP") -> FakeSignals:
+    return FakeSignals(ip_ua_fingerprint=fp)
+
+
+class TestConsultParity:
+    """Same signals through the middleware shape and the REST shape must
+    reach the same binding decision."""
+
+    @pytest.mark.asyncio
+    async def test_hit_parity_between_transport_shapes(self):
+        update_transport_binding("sticky:10.0.0.1:uaP", "uuid-parity", "sk-p", "redis")
+
+        mw = await consult_sticky_binding(_signals(), {})  # middleware shape
+        rest = await consult_sticky_binding(_signals(), {}, redis_recovery=False)
+
+        assert mw.transport_key == rest.transport_key == "sticky:10.0.0.1:uaP"
+        assert mw.binding is not None and rest.binding is not None
+        assert mw.binding.agent_uuid == rest.binding.agent_uuid == "uuid-parity"
+        assert mw.cacheable and rest.cacheable
+
+    @pytest.mark.asyncio
+    async def test_envelope_parity(self):
+        """Both surfaces must emit the identical S3 decay envelope."""
+        update_transport_binding(
+            "sticky:10.0.0.1:uaP", "uuid-parity", "sk-p", "redis",
+            original_session_source="x_session_id",
+        )
+        mw = await consult_sticky_binding(_signals(), {})
+        rest = await consult_sticky_binding(_signals(), {}, redis_recovery=False)
+        assert (
+            sticky_resolution_source(mw.binding)
+            == sticky_resolution_source(rest.binding)
+            == "sticky_cache:x_session_id"
+        )
+
+    @pytest.mark.asyncio
+    async def test_envelope_default_unknown(self):
+        update_transport_binding("sticky:10.0.0.1:uaP", "uuid-parity", "sk-p", "redis")
+        consult = await consult_sticky_binding(_signals(), {})
+        assert sticky_resolution_source(consult.binding) == "sticky_cache:unknown"
+
+
+class TestConsultGuard:
+    """Proof-carrying requests suppress the cache hit on both shapes; the
+    transport key is still computed for callers that need it."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("blocker", [
+        {"force_new": True},
+        {"client_session_id": "csi-1"},
+        {"continuity_token": "v1.x.y"},
+    ])
+    async def test_argument_blockers(self, blocker):
+        update_transport_binding("sticky:10.0.0.1:uaP", "uuid-cached", "sk", "redis")
+        for redis_recovery in (True, False):
+            consult = await consult_sticky_binding(
+                _signals(), dict(blocker), redis_recovery=redis_recovery
+            )
+            assert consult.binding is None
+            assert consult.cacheable is False
+            assert consult.transport_key == "sticky:10.0.0.1:uaP"
+
+    @pytest.mark.asyncio
+    async def test_explicit_uuid_blocks(self):
+        update_transport_binding("sticky:10.0.0.1:uaP", "uuid-cached", "sk", "redis")
+        consult = await consult_sticky_binding(_signals(), {}, has_explicit_uuid=True)
+        assert consult.binding is None
+        assert consult.cacheable is False
+
+    @pytest.mark.asyncio
+    async def test_uncacheable_transport_yields_no_key(self):
+        consult = await consult_sticky_binding(
+            FakeSignals(x_session_id="stable-id"), {}
+        )
+        assert consult.transport_key is None
+        assert consult.binding is None
+        assert consult.cacheable is False
+
+    @pytest.mark.asyncio
+    async def test_ttl_expired_binding_misses(self):
+        update_transport_binding("sticky:10.0.0.1:uaP", "uuid-stale", "sk", "redis")
+        _transport_identity_cache["sticky:10.0.0.1:uaP"].bound_at = (
+            time.monotonic() - 7201
+        )
+        consult = await consult_sticky_binding(_signals(), {}, redis_recovery=False)
+        assert consult.binding is None
+        assert consult.cacheable is True  # guard passed; entry just expired
+
+
+class TestRedisRecoveryDivergence:
+    """The one deliberate transport divergence: middleware recovers from
+    Redis on in-memory miss, REST does not."""
+
+    @pytest.mark.asyncio
+    async def test_rest_shape_never_touches_redis(self):
+        with patch(
+            "src.mcp_handlers.middleware.identity_step._load_binding_from_redis",
+            new_callable=AsyncMock,
+        ) as mock_load:
+            consult = await consult_sticky_binding(
+                _signals(), {}, redis_recovery=False
+            )
+        mock_load.assert_not_awaited()
+        assert consult.binding is None
+
+    @pytest.mark.asyncio
+    async def test_middleware_shape_recovers_from_redis(self):
+        from src.mcp_handlers.middleware.identity_step import TransportBinding
+        recovered = TransportBinding(
+            agent_uuid="uuid-from-redis",
+            session_key="sk-r",
+            bound_at=time.monotonic(),
+            source="redis_recovery",
+        )
+        with patch(
+            "src.mcp_handlers.middleware.identity_step._load_binding_from_redis",
+            new_callable=AsyncMock,
+            return_value=recovered,
+        ) as mock_load:
+            consult = await consult_sticky_binding(_signals(), {})
+        mock_load.assert_awaited_once_with("sticky:10.0.0.1:uaP")
+        assert consult.binding is recovered
+
+
+class TestRestSurfaceParity:
+    """End-to-end: the REST prebind emits the same envelope and uuid the
+    middleware would for the same cached binding."""
+
+    @pytest.mark.asyncio
+    async def test_rest_cache_hit_uses_shared_envelope(self):
+        from src.http_api import _resolve_http_bound_agent
+        from src.mcp_handlers.context import get_session_resolution_source
+
+        update_transport_binding(
+            "sticky:10.0.0.2:uaQ", "uuid-rest-q", "sk-q", "rest",
+            original_session_source="x_session_id",
+        )
+        signals = FakeSignals(ip_ua_fingerprint="10.0.0.2:uaQ")
+
+        result = await _resolve_http_bound_agent("call_model", {}, signals)
+
+        assert result == "uuid-rest-q"
+        assert get_session_resolution_source() == "sticky_cache:x_session_id"
+
+    @pytest.mark.asyncio
+    async def test_rest_writeback_skipped_for_proof_carrying_request(self):
+        """client_session_id requests resolve but never cache under the
+        bare fingerprint (pre-consolidation REST behavior, preserved)."""
+        from src.http_api import _resolve_http_bound_agent
+
+        signals = FakeSignals(ip_ua_fingerprint="10.0.0.3:uaR")
+        mock_identity = {"agent_uuid": "uuid-proof", "created": False, "source": "redis"}
+        with patch(
+            "src.mcp_handlers.identity.handlers.derive_session_key",
+            new_callable=AsyncMock,
+            return_value="sk-proof",
+        ), patch(
+            "src.mcp_handlers.identity.handlers.resolve_session_identity",
+            new_callable=AsyncMock,
+            return_value=mock_identity,
+        ):
+            result = await _resolve_http_bound_agent(
+                "call_model", {"client_session_id": "csi-x"}, signals
+            )
+
+        assert result == "uuid-proof"
+        assert "sticky:10.0.0.3:uaR" not in _transport_identity_cache


### PR DESCRIPTION
## What

Closes out the last residue of S21-b item 5: the REST prebind path (`http_api._resolve_http_bound_agent`) was a third, hand-mirrored copy of the middleware's sticky-cache consult — the "third architectural location at `http_api.py:312`" flagged in the plan.md S21 audit pass (2026-04-29), and the same surface the strict-identity stage-1 burn-in (2026-06-11) caught drifting from the middleware.

PR #245 consolidated middleware ↔ handler; this PR consolidates middleware ↔ REST. The copy had already diverged silently:

- no Redis restart-recovery on REST (in-memory consult only)
- no explicit-UUID guard in the REST consult
- writeback suppressed for proof-carrying requests on REST, but not on the middleware

## Changes

**`src/mcp_handlers/middleware/identity_step.py`**
- `consult_sticky_binding(signals, arguments, *, has_explicit_uuid, redis_recovery)` — the single-sourced consult guard + TTL check + optional Redis recovery, returning `StickyConsult(transport_key, binding, cacheable)`. Both transports call it; the REST divergence is now an explicit `redis_recovery=False` parameter instead of a drifting copy (same single-source discipline as `strict_identity_refusal_payload`, stage-1 burn-in fold).
- `sticky_resolution_source(binding)` — the S3 decay envelope `sticky_cache:<original>` single-sourced so both surfaces feed `_compute_identity_assurance` identically.
- `resolve_identity` refactored onto the shared consult; PATH 0 Part C and PATH 2.8 token extraction now use the shared safe extractor.

**`src/mcp_handlers/identity/session.py`**
- `extract_token_agent_uuid_safe` — the token → UUID-or-None shape, replacing three duplicated try/except blocks (middleware ×2, REST ×1).

**`src/http_api.py`**
- `_resolve_http_bound_agent` consumes the shared helpers and no longer reaches into `identity_step` private internals (`_transport_identity_cache` / `_TRANSPORT_CACHE_TTL` / `_transport_cache_key`).
- REST behaviors preserved exactly: in-memory-only consult (no restart recovery), writeback only when the consult guard passed (proof-carrying requests are never cached under the bare fingerprint).

## Why now

Wave 3a is about to put a per-tool BEAM-vs-Python routing table on the Python transport. Single-sourcing the consult first means routing lands on one call site instead of two, without prejudging the Wave 3b identity-middleware question — this PR changes no behavior.

## Verification

- New golden-parity suite `tests/test_transport_resolution_parity.py` (13 tests): hit/envelope parity between transport shapes, guard blockers (force_new / client_session_id / continuity_token / explicit UUID), TTL expiry, the deliberate Redis-recovery divergence, and end-to-end REST envelope + writeback-eligibility pins.
- Touched-surface suites green (693 passed): test_sticky_identity, test_sticky_archive, test_rest_strict_identity_gate, test_http_endpoints, test_identity_honesty_partc, test_s1_continuity_token_narrow, test_dispatch_ephemeral_identity, test_identity_session, test_identity_s21a, test_http_dispatch_fallback, test_identity_handlers, test_dispatch_integration.
- Full gate deferred to CI per AGENTS.md (remote container has no Postgres/AGE).

## Review posture

Identity resolution is council-required pre-merge territory per the S21 ledger row ("Council also for load-bearing implementation"). Draft until that pass happens. Cross-repo check: no in-flight identity PRs on `cirwel/unitares` (#619/#620 don't touch identity code); `unitares-governance-plugin` was not visible from this session and should be checked before merge.

https://claude.ai/code/session_013RpDJkeAsEQnbkFLxWAGEn

---
_Generated by [Claude Code](https://claude.ai/code/session_013RpDJkeAsEQnbkFLxWAGEn)_