### PR TITLE
chore: dead-code assessment — remove unused imports, add ruff F401 CI gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,11 @@ jobs:
       run: |
         python scripts/diagnostics/check_doc_drift.py
 
+    - name: Dead-code gate (unused imports)
+      run: |
+        pip install "ruff>=0.15"
+        ruff check .
+
     - name: Run smoke tests
       run: |
         make test-smoke

--- a/agents/sdk/src/unitares_sdk/agent.py
+++ b/agents/sdk/src/unitares_sdk/agent.py
@@ -14,7 +14,7 @@ import logging
 import os
 import signal
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 

--- a/agents/sdk/src/unitares_sdk/client.py
+++ b/agents/sdk/src/unitares_sdk/client.py
@@ -18,7 +18,6 @@ from unitares_sdk.errors import (
     GovernanceConnectionError,
     GovernanceTimeoutError,
     IdentityDriftError,
-    VerdictError,
 )
 from unitares_sdk.models import (
     ArchiveResult,

--- a/agents/sentinel/agent.py
+++ b/agents/sentinel/agent.py
@@ -34,7 +34,7 @@ import time
 from collections import deque
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List
 
 # Add project root to path
 project_root = Path(__file__).parent.parent.parent
@@ -44,7 +44,6 @@ from agents.common.config import GOV_MCP_URL, GOV_WS_URL
 from unitares_sdk.agent import CycleResult, GovernanceAgent
 from unitares_sdk.client import GovernanceClient
 from unitares_sdk.models import CheckinResult
-from unitares_sdk.errors import GovernanceError, VerdictError
 from unitares_sdk.utils import notify
 from agents.common.findings import post_finding, compute_fingerprint
 from agents.sentinel.phase_b_promotion import (

--- a/agents/sentinel/forced_release_alarm.py
+++ b/agents/sentinel/forced_release_alarm.py
@@ -28,7 +28,6 @@ and `lease_plane.deprecated_schemes`. It does NOT write to either table.
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any

--- a/agents/vigil/agent.py
+++ b/agents/vigil/agent.py
@@ -37,7 +37,6 @@ from typing import Any, Dict, List, Optional, Tuple
 project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
 
-import httpx
 
 from agents.common.config import GOV_MCP_URL
 from unitares_sdk.agent import CycleResult, GovernanceAgent

--- a/agents/watcher/findings.py
+++ b/agents/watcher/findings.py
@@ -19,7 +19,6 @@ from typing import Any
 
 from agents.common.findings import post_finding
 from agents.watcher._util import (
-    hash_line_content,
     log,
     repo_relative_path,
     watcher_state_dir,

--- a/agents/watcher/tests/test_hook_input.py
+++ b/agents/watcher/tests/test_hook_input.py
@@ -171,6 +171,8 @@ def test_extract_regions_works_against_real_repo(hook_input_module, tmp_path):
         subprocess.run(["git", "init", "-q"], check=True)
         subprocess.run(["git", "config", "user.email", "t@t"], check=True)
         subprocess.run(["git", "config", "user.name", "t"], check=True)
+        # Hermetic: host config may force commit signing (e.g. remote containers)
+        subprocess.run(["git", "config", "commit.gpgsign", "false"], check=True)
         target = repo / "foo.py"
         target.write_text("\n".join(f"line{i}" for i in range(1, 51)) + "\n")
         subprocess.run(["git", "add", "foo.py"], check=True)

--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -11,7 +11,6 @@ class _LazyNumpy:
         return getattr(numpy, name)
 np = _LazyNumpy()
 
-import re
 import os
 
 

--- a/data/v7-fhat/fit/em.py
+++ b/data/v7-fhat/fit/em.py
@@ -21,7 +21,6 @@ L2 λ=0.01, seed=42.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-import json
 import pathlib
 from typing import Iterable
 

--- a/data/v7-fhat/fit/run_fit.py
+++ b/data/v7-fhat/fit/run_fit.py
@@ -32,7 +32,6 @@ from .em import (
     SIGMA_TRANS_MAX,
     SIGMA_TRANS_MIN,
 )
-from .ode import fx as ode_fx
 from .ukf_smoother import run_ukf_smoother
 
 REPO = pathlib.Path(__file__).resolve().parents[3]

--- a/data/v7-fhat/fit/ukf_smoother.py
+++ b/data/v7-fhat/fit/ukf_smoother.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import numpy as np
-from filterpy.kalman import UnscentedKalmanFilter, MerweScaledSigmaPoints, rts_smoother
+from filterpy.kalman import UnscentedKalmanFilter, MerweScaledSigmaPoints
 
 from .ode import fx as _fx
 

--- a/governance_core/parameters.py
+++ b/governance_core/parameters.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 import json
 import os
-from typing import ClassVar
 
 
 @dataclass

--- a/governance_core/phase_aware.py
+++ b/governance_core/phase_aware.py
@@ -26,7 +26,6 @@ Authors: Well_Tempered_Claude_CLI, claude_opus_governance_explorer_20251127
 Date: 2025-11-27
 """
 
-import math
 import numpy as np
 from typing import List, Dict, Tuple
 from dataclasses import dataclass

--- a/governance_core/research.py
+++ b/governance_core/research.py
@@ -8,7 +8,6 @@ Migrated from src/unitaires-server/unitaires_core.py during cleanup.
 """
 
 from __future__ import annotations
-import random
 from dataclasses import asdict
 from typing import Dict
 

--- a/governance_core/stability.py
+++ b/governance_core/stability.py
@@ -17,7 +17,7 @@ Public API:
 from __future__ import annotations
 
 import math
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 import numpy as np
 
@@ -28,7 +28,7 @@ from .parameters import (
     get_active_params,
     get_i_dynamics_mode,
 )
-from .coherence import coherence, lambda1 as _lambda1, lambda2 as _lambda2
+from .coherence import lambda2 as _lambda2
 
 
 # ---------------------------------------------------------------------------
@@ -51,7 +51,6 @@ def _compute_rhs(
     complexity: float = 0.5,
 ) -> np.ndarray:
     """Evaluate the ODE right-hand side F(x) at zero drift."""
-    from .utils import drift_norm
     derivs = _derivatives(state, 0.0, theta, params, 0.0, complexity, None)
     return np.array(derivs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,3 +93,34 @@ exclude_lines = [
     "if TYPE_CHECKING:",
     "@abstractmethod",
 ]
+
+[tool.ruff]
+target-version = "py312"
+
+[tool.ruff.lint]
+# Dead-code gate: unused imports only, kept at zero by CI.
+# F841/F811/ERA cleanups are tracked separately — widen this list as they reach zero.
+select = ["F401"]
+
+[tool.ruff.lint.per-file-ignores]
+# Package __init__ re-export surfaces
+"**/__init__.py" = ["F401"]
+# Pytest imports fixtures/plugins that ruff cannot see as used
+"tests/**" = ["F401"]
+"agents/*/tests/**" = ["F401"]
+"agents/sdk/tests/**" = ["F401"]
+# Declared re-export facades (docstring-marked); consumers import moved names through them
+"src/agent_state.py" = ["F401"]
+"src/mcp_handlers/utils.py" = ["F401"]
+"src/mcp_handlers/cirs/protocol.py" = ["F401"]
+"src/mcp_handlers/lifecycle/handlers.py" = ["F401"]
+"src/mcp_handlers/identity/core.py" = ["F401"]
+"src/mcp_handlers/identity/handlers.py" = ["F401"]
+# Re-export hub for watcher tests/hooks (tests monkeypatch.setattr these names on the agent module)
+"agents/watcher/agent.py" = ["F401"]
+# Surfaces owned by in-flight PRs #619/#622 — clean up after those land
+"src/http_api.py" = ["F401"]
+"src/mcp_handlers/middleware/identity_step.py" = ["F401"]
+"src/mcp_handlers/identity/session.py" = ["F401"]
+"src/mcp_handlers/tool_stability.py" = ["F401"]
+"src/mcp_handlers/consolidated.py" = ["F401"]

--- a/scripts/analysis/compositionality_metrics.py
+++ b/scripts/analysis/compositionality_metrics.py
@@ -15,7 +15,7 @@ import math
 import sqlite3
 import sys
 from pathlib import Path
-from typing import Dict, Any, List, Optional, Tuple
+from typing import Dict, Any, List, Tuple
 
 import numpy as np
 

--- a/scripts/analysis/contraction_analysis.py
+++ b/scripts/analysis/contraction_analysis.py
@@ -23,13 +23,13 @@ project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
 
 from governance_core.dynamics import (
-    compute_dynamics, compute_equilibrium, State, _derivatives,
+    compute_equilibrium, State, _derivatives,
 )
 from governance_core.parameters import (
     DynamicsParams, Theta, get_active_params, DEFAULT_THETA,
     get_i_dynamics_mode,
 )
-from governance_core.coherence import coherence, lambda1, lambda2
+from governance_core.coherence import lambda2
 from governance_core.utils import drift_norm
 
 

--- a/scripts/analysis/outcome_validation.py
+++ b/scripts/analysis/outcome_validation.py
@@ -33,11 +33,10 @@ import argparse
 import asyncio
 import csv
 import json
-import math
 import sys
 from collections import Counter, defaultdict
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 import asyncpg
 

--- a/scripts/analysis/plot_eisv_trajectories.py
+++ b/scripts/analysis/plot_eisv_trajectories.py
@@ -23,7 +23,7 @@ import numpy as np
 
 from governance_core.dynamics import State, compute_dynamics
 from governance_core.parameters import DEFAULT_THETA, get_active_params
-from governance_core.scoring import phi_objective, verdict_from_phi
+from governance_core.scoring import phi_objective
 
 
 def run_scenario(state, delta_eta, steps, complexity=0.5, dt=0.1):

--- a/scripts/analysis/validate_theoretical_foundations.py
+++ b/scripts/analysis/validate_theoretical_foundations.py
@@ -10,10 +10,7 @@ Usage:
 """
 
 import sys
-import re
-import ast
 from pathlib import Path
-from typing import Dict, List, Tuple
 
 # Add project root to path
 project_root = Path(__file__).parent.parent.parent
@@ -24,10 +21,8 @@ sys.path.insert(0, str(project_root))
 GOVERNANCE_CORE_SOURCE = project_root / "governance_core"
 HAS_SOURCE = GOVERNANCE_CORE_SOURCE.is_dir() and (GOVERNANCE_CORE_SOURCE / "dynamics.py").exists()
 
-from governance_core.dynamics import compute_dynamics, State
-from governance_core.coherence import coherence, lambda1, lambda2
-from governance_core.parameters import DEFAULT_PARAMS, DEFAULT_THETA, Theta, DynamicsParams
-from config.governance_config import config
+from governance_core.coherence import coherence, lambda1
+from governance_core.parameters import DEFAULT_PARAMS, DEFAULT_THETA, Theta
 
 
 class ValidationResult:

--- a/scripts/client/ollama_bridge.py
+++ b/scripts/client/ollama_bridge.py
@@ -15,7 +15,6 @@ Usage:
 
 import argparse
 import sys
-import readline  # enables arrow keys / history in input()
 
 from smolagents import tool, ToolCollection, OpenAIServerModel, CodeAgent
 

--- a/scripts/client/onboard_helper.py
+++ b/scripts/client/onboard_helper.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import sys
 import tempfile
 import urllib.error
 import urllib.request

--- a/scripts/dev/backfill_tactical_calibration.py
+++ b/scripts/dev/backfill_tactical_calibration.py
@@ -22,7 +22,6 @@ from typing import Dict, List
 from src.sequential_calibration import sequential_calibration_tracker
 from src.calibration import calibration_checker
 from src.mcp_handlers.observability.outcome_events import (
-    HARD_EXOGENOUS_TYPES,
     _HARD_EXOGENOUS_TYPE_TO_CHANNEL,
 )
 
@@ -144,7 +143,6 @@ async def backfill(days: int, dry_run: bool) -> Dict[str, int]:
         # flush by awaiting the postgres write directly.
         try:
             from src.db import get_db
-            from collections import defaultdict
             db = get_db()
             state_data = {
                 'bins': {k: dict(v) for k, v in calibration_checker.bin_stats.items()},

--- a/scripts/dev/section_129_reeval.py
+++ b/scripts/dev/section_129_reeval.py
@@ -32,7 +32,6 @@ import os
 import sys
 from dataclasses import dataclass, asdict
 from datetime import date, datetime, timedelta, timezone
-from typing import Optional
 
 import psycopg2  # type: ignore
 import psycopg2.extras  # type: ignore

--- a/scripts/dev/unitares_doctor.py
+++ b/scripts/dev/unitares_doctor.py
@@ -31,7 +31,7 @@ import stat
 import subprocess
 import sys
 import urllib.request
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Callable

--- a/scripts/diagnostics/audit_markdown_proliferation.py
+++ b/scripts/diagnostics/audit_markdown_proliferation.py
@@ -11,11 +11,10 @@ Usage:
 """
 
 import sys
-import re
 from pathlib import Path
 from collections import defaultdict
 from datetime import datetime
-from typing import Dict, List, Tuple, Set
+from typing import Dict, List
 
 # Add project root to path
 project_root = Path(__file__).parent.parent.parent

--- a/scripts/diagnostics/check_doc_drift.py
+++ b/scripts/diagnostics/check_doc_drift.py
@@ -7,7 +7,6 @@ that have already caused agents to surface outdated architecture claims.
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
 

--- a/scripts/diagnostics/check_test_coverage.py
+++ b/scripts/diagnostics/check_test_coverage.py
@@ -20,7 +20,7 @@ def run_coverage_check():
     
     # Check if pytest-cov is available
     try:
-        import pytest_cov
+        import pytest_cov  # noqa: F401 — availability probe
     except ImportError:
         print("⚠️  pytest-cov not installed. Install with: pip install pytest-cov")
         print("Running basic test discovery instead...")

--- a/scripts/diagnostics/count_tools.py
+++ b/scripts/diagnostics/count_tools.py
@@ -11,12 +11,10 @@ Usage:
     python3 scripts/diagnostics/count_tools.py --by-module  # Breakdown by module
 """
 
-import os
 import re
-import sys
 import json
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict
 
 PROJECT_ROOT = Path(__file__).parent.parent.parent
 

--- a/scripts/diagnostics/diagnose_date_context_connection.py
+++ b/scripts/diagnostics/diagnose_date_context_connection.py
@@ -10,7 +10,6 @@ import sys
 import json
 from pathlib import Path
 from datetime import datetime
-from typing import Optional
 
 # Add project root to path
 project_root = Path(__file__).parent.parent.parent

--- a/scripts/diagnostics/doc_tools.py
+++ b/scripts/diagnostics/doc_tools.py
@@ -11,7 +11,6 @@ Usage:
 
 import sys
 from pathlib import Path
-from datetime import datetime
 
 # Add project root to path
 project_root = Path(__file__).parent.parent.parent
@@ -23,7 +22,7 @@ def check_small_markdowns():
     archive_path = project_root / "scripts" / "archive"
     if str(archive_path) not in sys.path:
         sys.path.insert(0, str(archive_path))
-    from check_small_markdowns import find_small_markdowns, ESSENTIAL_DOCS, SKIP_DIRS
+    from check_small_markdowns import find_small_markdowns
     
     docs_dir = project_root / "docs"
     small_files = find_small_markdowns(docs_dir)

--- a/scripts/diagnostics/generate_tool_docs.py
+++ b/scripts/diagnostics/generate_tool_docs.py
@@ -12,7 +12,6 @@ Generates tools/README.md with comprehensive tool documentation.
 """
 
 import ast
-import inspect
 from pathlib import Path
 from typing import Dict, List, Any, Optional
 from dataclasses import dataclass

--- a/scripts/diagnostics/sync_bridge_with_mcp.py
+++ b/scripts/diagnostics/sync_bridge_with_mcp.py
@@ -15,7 +15,6 @@ Usage:
 import re
 import sys
 from pathlib import Path
-from typing import List, Tuple
 
 # Add project root to path
 project_root = Path(__file__).parent.parent.parent

--- a/scripts/diagnostics/update_readme_metadata.py
+++ b/scripts/diagnostics/update_readme_metadata.py
@@ -17,7 +17,6 @@ import re
 import sys
 from pathlib import Path
 from datetime import datetime
-from typing import Tuple, List
 
 
 class ReadmeMetadataUpdater:

--- a/scripts/diagnostics/validate_all.py
+++ b/scripts/diagnostics/validate_all.py
@@ -10,9 +10,8 @@ Usage:
 """
 
 import sys
-import re
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import List, Tuple
 
 # Add project root to path
 project_root = Path(__file__).parent.parent.parent

--- a/scripts/diagnostics/validate_markdown_formatting.py
+++ b/scripts/diagnostics/validate_markdown_formatting.py
@@ -18,7 +18,7 @@ Usage:
 import sys
 import re
 from pathlib import Path
-from typing import List, Dict, Tuple
+from typing import List, Dict
 from datetime import datetime
 
 # Add project root to path

--- a/scripts/migration/cleanup_data_directory.py
+++ b/scripts/migration/cleanup_data_directory.py
@@ -13,12 +13,10 @@ Usage:
     python scripts/cleanup_data_directory.py --clean     # Actually clean files
 """
 
-import os
 import sys
 from pathlib import Path
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import List, Dict, Tuple
-import json
 
 # Add project root to path
 project_root = Path(__file__).parent.parent.parent

--- a/scripts/migration/cleanup_ghost_agents.py
+++ b/scripts/migration/cleanup_ghost_agents.py
@@ -15,7 +15,6 @@ Usage:
 """
 import asyncio
 import sys
-import uuid as uuid_mod
 
 BATCH_SIZE = 100
 

--- a/scripts/migration/cleanup_knowledge_graph.py
+++ b/scripts/migration/cleanup_knowledge_graph.py
@@ -16,7 +16,6 @@ Usage:
 """
 
 import sys
-import os
 import asyncio
 import argparse
 import json

--- a/scripts/migration/reembed_corpus.py
+++ b/scripts/migration/reembed_corpus.py
@@ -20,7 +20,6 @@ import asyncio
 import os
 import sys
 import time
-from pathlib import Path
 
 # Add project root to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
@@ -30,7 +29,6 @@ from src.embeddings import (
     KNOWN_MODELS,
     DEFAULT_MODEL_KEY,
     EmbeddingsService,
-    get_active_table_name,
 )
 
 

--- a/scripts/ops/mcp_agent.py
+++ b/scripts/ops/mcp_agent.py
@@ -32,7 +32,6 @@ import sys
 import json
 import asyncio
 import argparse
-import os
 import httpx
 from pathlib import Path
 from typing import Dict, Any, Optional

--- a/scripts/ops/update_changelog.py
+++ b/scripts/ops/update_changelog.py
@@ -32,7 +32,7 @@ import re
 import subprocess
 from pathlib import Path
 from datetime import datetime
-from typing import List, Dict, Tuple, Optional
+from typing import List, Dict, Optional
 from dataclasses import dataclass, field
 from collections import defaultdict
 

--- a/scripts/verdict_counterfactual.py
+++ b/scripts/verdict_counterfactual.py
@@ -25,7 +25,7 @@ import math
 import sys
 from collections import Counter, defaultdict
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List
 
 try:
     import psycopg2

--- a/src/agent_metadata_model.py
+++ b/src/agent_metadata_model.py
@@ -8,7 +8,6 @@ and project-level constants shared across agent_state sub-modules.
 from __future__ import annotations
 
 import sys
-import os
 import threading
 from pathlib import Path
 from dataclasses import dataclass, asdict

--- a/src/agent_metadata_persistence.py
+++ b/src/agent_metadata_persistence.py
@@ -11,7 +11,6 @@ import json
 import time
 import fcntl
 import asyncio
-import threading
 from pathlib import Path
 from datetime import datetime, timezone
 

--- a/src/agent_process_mgmt.py
+++ b/src/agent_process_mgmt.py
@@ -13,13 +13,13 @@ import time
 from pathlib import Path
 
 from src.logging_utils import get_logger
-from src.agent_metadata_model import project_root, logger as _model_logger
+from src.agent_metadata_model import project_root
 
 logger = get_logger(__name__)
 
 # Optional dependency flags
 try:
-    import aiofiles
+    import aiofiles  # noqa: F401 — availability probe
     AIOFILES_AVAILABLE = True
 except ImportError:
     AIOFILES_AVAILABLE = False

--- a/src/agent_storage.py
+++ b/src/agent_storage.py
@@ -41,7 +41,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Mapping, Optional
 
 from src.db import get_db
-from src.db.base import IdentityRecord, AgentStateRecord
+from src.db.base import AgentStateRecord
 from src.logging_utils import get_logger
 
 logger = get_logger(__name__)

--- a/src/audit_log.py
+++ b/src/audit_log.py
@@ -6,7 +6,6 @@ JSONL is the raw truth log. PostgreSQL provides queryable indexing.
 """
 
 import json
-import sys
 from pathlib import Path
 from datetime import datetime
 from typing import Dict, Iterator, List, Optional

--- a/src/auto_ground_truth.py
+++ b/src/auto_ground_truth.py
@@ -28,7 +28,7 @@ import json
 import asyncio
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import List, Dict, Optional
+from typing import Dict, Optional
 import logging
 
 logger = logging.getLogger(__name__)

--- a/src/background_tasks.py
+++ b/src/background_tasks.py
@@ -7,7 +7,6 @@ Each task runs as an asyncio coroutine, started during server initialization.
 
 import asyncio
 import gzip
-import os
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path

--- a/src/behavioral_state.py
+++ b/src/behavioral_state.py
@@ -10,7 +10,6 @@ from the agent's own characteristic operating point instead of fixed thresholds.
 
 from __future__ import annotations
 
-import math
 import time
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional

--- a/src/cache/redis_client.py
+++ b/src/cache/redis_client.py
@@ -30,7 +30,6 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Optional, Any, Dict, Callable, TypeVar
 from functools import wraps
-from contextlib import asynccontextmanager
 import json as _json
 import threading
 import inspect

--- a/src/calibration.py
+++ b/src/calibration.py
@@ -10,9 +10,7 @@ from pathlib import Path
 import json
 import sys
 import time
-import numpy as np
 import os
-from datetime import datetime
 
 
 @dataclass

--- a/src/concept_extraction.py
+++ b/src/concept_extraction.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import hashlib
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Set
 
 import numpy as np
 

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -11,13 +11,12 @@ Configuration Sources:
 4. Server constants: src/mcp_server_std.py (MAX_KEEP_PROCESSES, etc.)
 """
 
-import os
 from typing import Dict, Any, Optional
 from dataclasses import dataclass
 
 # Import static configs
 from config import governance_config as static_config_module
-from governance_core.parameters import DynamicsParams, Theta
+from governance_core.parameters import DynamicsParams
 from src.runtime_config import get_thresholds, get_effective_threshold, set_thresholds as _set_thresholds
 
 

--- a/src/coordination_events.py
+++ b/src/coordination_events.py
@@ -27,7 +27,6 @@ import logging
 import os
 import socket
 import subprocess
-import time
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal

--- a/src/db/base.py
+++ b/src/db/base.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional
 
 
 @dataclass

--- a/src/db/postgres_backend.py
+++ b/src/db/postgres_backend.py
@@ -8,7 +8,6 @@ Methods are organized into mixin modules under src/db/mixins/.
 from __future__ import annotations
 
 import asyncio
-import json
 import os
 import time
 from typing import Any, Dict, Optional

--- a/src/dialectic_protocol.py
+++ b/src/dialectic_protocol.py
@@ -159,7 +159,6 @@ from enum import Enum
 import json
 import hashlib
 import hmac
-import secrets
 import numpy as np
 
 

--- a/src/drift_telemetry.py
+++ b/src/drift_telemetry.py
@@ -21,12 +21,11 @@ DATA COLLECTED:
 
 import gzip
 import json
-import os
 import shutil
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Any, Optional, List, Tuple
-from dataclasses import dataclass, field
+from typing import Dict, Any, Optional, List
+from dataclasses import dataclass
 import threading
 
 from src.logging_utils import get_logger

--- a/src/eisv_format.py
+++ b/src/eisv_format.py
@@ -13,7 +13,7 @@ The ODE's E, I, S, V values in EISVMetrics may differ from the behavioral
 state's E, I, S, V (which are EMA-smoothed observations).
 """
 
-from typing import Dict, Optional, Tuple, NamedTuple
+from typing import Dict, NamedTuple
 from dataclasses import dataclass
 
 

--- a/src/gateway_server.py
+++ b/src/gateway_server.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import argparse
 import logging
-import os
 import sys
 from pathlib import Path
 from typing import Optional

--- a/src/governance_monitor.py
+++ b/src/governance_monitor.py
@@ -12,7 +12,6 @@ Version History:
 
 import os
 import numpy as np
-from dataclasses import field
 from typing import Dict, Optional, Any
 from datetime import datetime
 from pathlib import Path
@@ -51,9 +50,8 @@ from governance_core import (
     State, Theta,
     DEFAULT_STATE, DEFAULT_THETA, DEFAULT_PARAMS,
     step_state, coherence,
-    phi_objective, verdict_from_phi,
-    compute_ethical_drift,
-)
+    phi_objective, verdict_from_phi,  # noqa: F401 — re-exported; consumers import them from this module
+    )
 
 # UNITARES params profile selection (optional v4.1 alignment)
 from governance_core.parameters import get_active_params

--- a/src/governance_state.py
+++ b/src/governance_state.py
@@ -11,8 +11,7 @@ from typing import Dict, List, Optional, Tuple
 from governance_core import (
     State, Theta,
     DEFAULT_STATE, DEFAULT_THETA,
-    lambda1 as lambda1_from_theta,
-    DynamicsParams, DEFAULT_PARAMS
+    lambda1 as lambda1_from_theta
 )
 from governance_core.parameters import get_active_params
 

--- a/src/identity/trajectory_continuity.py
+++ b/src/identity/trajectory_continuity.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 
 import json
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Literal, Optional
 

--- a/src/lock_cleanup.py
+++ b/src/lock_cleanup.py
@@ -9,8 +9,7 @@ import os
 import json
 import time
 from pathlib import Path
-from typing import List, Dict, Tuple
-import sys
+from typing import Dict, Tuple
 
 # Import structured logging
 from src.logging_utils import get_logger

--- a/src/mcp_handlers/admin/calibration.py
+++ b/src/mcp_handlers/admin/calibration.py
@@ -6,15 +6,9 @@ Extracted from admin.py for maintainability.
 
 from typing import Dict, Any, List, Sequence, Optional
 from mcp.types import TextContent
-import json
-import sys
-import os
-from datetime import datetime
-from pathlib import Path
-from ..utils import success_response, error_response, require_agent_id, require_registered_agent
+from ..utils import success_response, error_response
 from ..decorators import mcp_tool
 from src.logging_utils import get_logger
-from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 logger = get_logger(__name__)
 
 

--- a/src/mcp_handlers/admin/config.py
+++ b/src/mcp_handlers/admin/config.py
@@ -4,11 +4,9 @@ Configuration tool handlers.
 
 from typing import Dict, Any, Sequence
 from mcp.types import TextContent
-import json
-import sys
 from ..utils import success_response, error_response
 from ..decorators import mcp_tool
-from ..error_helpers import agent_not_found_error, authentication_error
+from ..error_helpers import agent_not_found_error
 from src.logging_utils import get_logger
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 logger = get_logger(__name__)

--- a/src/mcp_handlers/admin/handlers.py
+++ b/src/mcp_handlers/admin/handlers.py
@@ -2,14 +2,12 @@
 Admin tool handlers.
 """
 
-from typing import Dict, Any, List, Sequence, Optional
+from typing import Dict, Any, Sequence, Optional
 from mcp.types import TextContent
-import json
 import sys
-import os
 from datetime import datetime
 from pathlib import Path
-from ..utils import success_response, error_response, require_agent_id, require_registered_agent
+from ..utils import success_response, error_response, require_registered_agent
 from ..decorators import mcp_tool
 from ..validators import validate_file_path_policy
 from src.logging_utils import get_logger
@@ -465,8 +463,6 @@ async def handle_get_workspace_health(arguments: Dict[str, Any]) -> Sequence[Tex
         health_data = get_workspace_health()
         return success_response(health_data)
     except Exception as e:
-        import traceback
-        import sys
         # SECURITY: Log full traceback internally but sanitize for client
         logger.error(f"Error checking workspace health: {e}", exc_info=True)
         return [error_response(

--- a/src/mcp_handlers/cirs/governance_action.py
+++ b/src/mcp_handlers/cirs/governance_action.py
@@ -2,7 +2,7 @@
 CIRS governance_action handler — initiate, respond, query, status.
 """
 
-from typing import Dict, Any, Sequence, Optional
+from typing import Dict, Any, Sequence
 from datetime import datetime
 import uuid
 

--- a/src/mcp_handlers/context.py
+++ b/src/mcp_handlers/context.py
@@ -14,8 +14,6 @@ With contextvars, session context is set once at dispatch entry and accessible e
 from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
-import os
-from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 # =============================================================================
 # SESSION SIGNALS (unified transport signal capture)
 # =============================================================================

--- a/src/mcp_handlers/core.py
+++ b/src/mcp_handlers/core.py
@@ -8,21 +8,14 @@ See docs/guides/EISV_COMPLETENESS.md for usage.
 
 from typing import Dict, Any, Optional, Sequence
 from mcp.types import TextContent
-import json
 from .types import ToolArgumentsDict
 from .utils import success_response, error_response, require_agent_id
 from .decorators import mcp_tool
-from config.governance_config import GovernanceConfig
 from src.logging_utils import get_logger
-from src.services.update_response_service import (
-    build_process_update_response_data,
-    serialize_process_update_response,
-)
 from src.services.update_workflow_service import run_process_update_workflow
 
 logger = get_logger(__name__)
 
-from pathlib import Path
 
 # Get mcp_server_std module (using shared utility)
 

--- a/src/mcp_handlers/decorators.py
+++ b/src/mcp_handlers/decorators.py
@@ -4,7 +4,7 @@ MCP Tool Decorators - Auto-registration and utilities
 Reduces boilerplate and enables auto-discovery of tools.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, Any, Callable, Optional, Sequence
 from functools import wraps
 import asyncio

--- a/src/mcp_handlers/dialectic/auto_resolve.py
+++ b/src/mcp_handlers/dialectic/auto_resolve.py
@@ -12,7 +12,6 @@ from typing import Dict, Any
 from src.logging_utils import get_logger
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 from src.dialectic_db import (
-    get_dialectic_db,
     get_active_sessions_async,
     update_session_status_async,
     update_session_reviewer_async,

--- a/src/mcp_handlers/dialectic/calibration.py
+++ b/src/mcp_handlers/dialectic/calibration.py
@@ -6,17 +6,15 @@ Uses peer agreement and disagreement signals to improve confidence calibration.
 """
 
 from typing import Dict, Any, Optional
-from pathlib import Path
-import json
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from src.dialectic_protocol import DialecticSession, Resolution
 from src.calibration import calibration_checker
 from src.audit_log import audit_logger
 from src.logging_utils import get_logger
 from .session import SESSION_STORAGE_DIR, load_session
-from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
+from src.mcp_handlers.shared import lazy_mcp_server as mcp_server  # noqa: F401 — tests patch {MODULE}.mcp_server
 logger = get_logger(__name__)
 
 async def update_calibration_from_dialectic(session: DialecticSession, resolution: Optional[Resolution] = None) -> bool:

--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -6,23 +6,15 @@ Implements MCP tools for peer-review dialectic resolution of circuit breaker sta
 
 from typing import Dict, Any, Sequence, Optional, List
 from mcp.types import TextContent
-import asyncio
 import json
 from datetime import datetime, timedelta, timezone
-import random
 
 # Import type definitions
-from ..types import (
-    ToolArgumentsDict,
-    DialecticSessionDict,
-    ResolutionDict
-)
 
 from src.dialectic_protocol import (
     DialecticSession,
     DialecticMessage,
     DialecticPhase,
-    Resolution,
 )
 from ..utils import success_response, error_response, require_registered_agent
 from ..decorators import mcp_tool
@@ -33,7 +25,6 @@ from .responses import (
     default_escalate_steps,
     default_resume_steps,
     get_agent_not_found_recovery,
-    get_reviewer_stuck_recovery,
     get_session_exception_recovery,
     get_session_timeout_recovery,
     llm_failed_recovery,
@@ -62,8 +53,6 @@ async def _resolve_dialectic_agent_id(
         arguments, enforce_session_ownership=enforce_session_ownership
     )
 from src.logging_utils import get_logger
-import sys
-import os
 
 logger = get_logger(__name__)
 
@@ -74,12 +63,11 @@ from .session import (
     save_session,
     load_session,
     load_session_as_dict,
-    load_all_sessions,
+    load_all_sessions,  # noqa: F401 — re-exported for existing consumers
     list_all_sessions,
     ACTIVE_SESSIONS,
-    SESSION_STORAGE_DIR,
+    SESSION_STORAGE_DIR,  # noqa: F401 — re-exported for existing consumers
     _SESSION_METADATA_CACHE,
-    _CACHE_TTL,
     get_session_lock,
 )
 
@@ -88,7 +76,7 @@ from .session import (
 
 # Check if aiofiles is available for async I/O
 try:
-    import aiofiles
+    import aiofiles  # noqa: F401 — availability probe
     AIOFILES_AVAILABLE = True
 except ImportError:
     AIOFILES_AVAILABLE = False
@@ -99,7 +87,7 @@ except ImportError:
 from .calibration import (
     update_calibration_from_dialectic,
     update_calibration_from_dialectic_disagreement,
-    backfill_calibration_from_historical_sessions
+    backfill_calibration_from_historical_sessions,  # noqa: F401 — re-exported; tests patch via this module
 )
 from .resolution import execute_resolution
 from .reviewer import select_reviewer, is_agent_in_active_session
@@ -111,13 +99,10 @@ from src.dialectic_db import (
     update_session_reviewer_async as pg_update_reviewer,
     add_message_async as pg_add_message,
     resolve_session_async as pg_resolve_session,
-    get_session_async as pg_get_session,
-    get_session_by_agent_async as pg_get_session_by_agent,
     get_all_sessions_by_agent_async as pg_get_all_sessions_by_agent,
 )
 
 # Import database abstraction for dual-write (Phase 4 migration)
-from src.db import get_db
 
 # ==============================================================================
 # NOTE: Dialectic handlers (Feb 2026)
@@ -956,7 +941,6 @@ async def handle_get_dialectic_session(arguments: Dict[str, Any]) -> Sequence[Te
         )]
 
     except Exception as e:
-        import traceback
         # SECURITY: Log full traceback internally but sanitize for client
         logger.error(f"Error getting dialectic session: {e}", exc_info=True)
         return [error_response(
@@ -1755,7 +1739,7 @@ async def handle_llm_assisted_dialectic(arguments: Dict[str, Any]) -> Sequence[T
     # Persist as a proper dialectic session via the DialecticSession protocol
     session_id = None
     try:
-        from src.dialectic_protocol import DialecticSession, DialecticMessage as DMsg, Resolution
+        from src.dialectic_protocol import DialecticSession, DialecticMessage as DMsg
         session = DialecticSession(
             paused_agent_id=agent_uuid,
             reviewer_agent_id="llm-synthetic-reviewer",

--- a/src/mcp_handlers/dialectic/reviewer.py
+++ b/src/mcp_handlers/dialectic/reviewer.py
@@ -17,7 +17,7 @@ import json
 import asyncio
 import contextvars
 
-from src.dialectic_protocol import calculate_authority_score, DialecticPhase, DialecticSession
+from src.dialectic_protocol import calculate_authority_score, DialecticPhase
 from src.logging_utils import get_logger
 
 # Reentrancy guard for the auto-resolve pre-check inside is_agent_in_active_session.
@@ -35,7 +35,6 @@ from .session import (
     _SESSION_METADATA_CACHE,
     _CACHE_TTL
 )
-from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 # Import PostgreSQL async functions for cross-process visibility
 from src.dialectic_db import (
     is_agent_in_active_session_async as pg_is_agent_in_active_session,

--- a/src/mcp_handlers/dialectic/session.py
+++ b/src/mcp_handlers/dialectic/session.py
@@ -10,14 +10,13 @@ from pathlib import Path
 import json
 import os
 import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 from src.dialectic_protocol import DialecticSession, DialecticPhase
 from src.db.acquire_compat import compatible_acquire
 from src.logging_utils import get_logger
 
 logger = get_logger(__name__)
-from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 # PostgreSQL backend (cross-process shared state)
 from src.dialectic_db import (
     get_session_async as pg_get_session,

--- a/src/mcp_handlers/identity/bootstrap_checkin.py
+++ b/src/mcp_handlers/identity/bootstrap_checkin.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional
 
 from src.mcp_handlers.schemas.core import BootstrapStateParams
 

--- a/src/mcp_handlers/identity/resolution.py
+++ b/src/mcp_handlers/identity/resolution.py
@@ -22,7 +22,6 @@ from .persistence import (
     _get_agent_label,
     _get_agent_status,
     _get_agent_id_from_metadata,
-    _find_agent_by_label,
 )
 
 from config.governance_config import GovernanceConfig

--- a/src/mcp_handlers/introspection/export.py
+++ b/src/mcp_handlers/introspection/export.py
@@ -4,11 +4,10 @@ Export tool handlers.
 
 from typing import Dict, Any, Sequence
 from mcp.types import TextContent
-import sys
 import os
 import json
 from datetime import datetime
-from ..utils import success_response, error_response, require_agent_id, require_registered_agent
+from ..utils import success_response, error_response, require_registered_agent
 from ..decorators import mcp_tool
 from src.logging_utils import get_logger
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server

--- a/src/mcp_handlers/introspection/tool_introspection.py
+++ b/src/mcp_handlers/introspection/tool_introspection.py
@@ -6,12 +6,7 @@ Extracted from admin.py for maintainability.
 
 from typing import Dict, Any, List, Sequence, Optional
 from mcp.types import TextContent
-import json
-import sys
-import os
-from datetime import datetime
-from pathlib import Path
-from ..utils import success_response, error_response, require_agent_id, require_registered_agent
+from ..utils import success_response, error_response
 from ..decorators import mcp_tool
 from ..support.coerce import coerce_bool
 from src.logging_utils import get_logger

--- a/src/mcp_handlers/lifecycle/operations.py
+++ b/src/mcp_handlers/lifecycle/operations.py
@@ -26,7 +26,6 @@ from src.logging_utils import get_logger
 from config.governance_config import GovernanceConfig
 
 from .helpers import (
-    _invalidate_agent_cache,
     _archive_one_agent,
     _is_test_agent,
     _resume_with_persistence,

--- a/src/mcp_handlers/lifecycle/query.py
+++ b/src/mcp_handlers/lifecycle/query.py
@@ -6,7 +6,7 @@ Extracted from handlers.py for maintainability.
 
 import hashlib
 import uuid
-from typing import Dict, Any, Optional, Sequence
+from typing import Any, Optional, Sequence
 from mcp.types import TextContent
 from datetime import datetime, timedelta, timezone
 
@@ -18,13 +18,11 @@ from ..utils import (
     error_response,
 )
 from ..error_helpers import (
-    agent_not_found_error,
     system_error as system_error_helper,
 )
 from ..decorators import mcp_tool
-from ..support.coerce import safe_float, resolve_agent_uuid
+from ..support.coerce import safe_float
 from src.logging_utils import get_logger
-from src.cache import get_metadata_cache
 from src.agent_monitor_state import ensure_hydrated
 
 from .helpers import _is_test_agent

--- a/src/mcp_handlers/lifecycle/self_recovery.py
+++ b/src/mcp_handlers/lifecycle/self_recovery.py
@@ -43,7 +43,7 @@ from ..decorators import mcp_tool
 from ..support.coerce import safe_float, resolve_agent_uuid
 from .helpers import (
     _resume_with_persistence,
-    clear_loop_detector_state,  # re-exported for legacy imports from this module
+    clear_loop_detector_state,  # noqa: F401 — re-exported for legacy imports from this module
 )
 from src import agent_storage
 from src.logging_utils import get_logger

--- a/src/mcp_handlers/observability/handlers.py
+++ b/src/mcp_handlers/observability/handlers.py
@@ -6,8 +6,7 @@ import asyncio
 import math
 from typing import Dict, Any, Sequence
 from mcp.types import TextContent
-import sys
-from ..utils import success_response, error_response, require_argument, require_registered_agent
+from ..utils import success_response, error_response, require_registered_agent
 from ..decorators import mcp_tool
 from src.logging_utils import get_logger
 from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
@@ -388,7 +387,6 @@ async def handle_compare_me_to_similar(arguments: Dict[str, Any]) -> Sequence[Te
     
     IMPROVEMENT #5: Agent comparison templates
     """
-    from src.governance_monitor import UNITARESMonitor
     # SECURITY FIX: Require registered agent (prevents phantom agent_ids)
     agent_id, error = require_registered_agent(arguments)
     if error:
@@ -718,7 +716,6 @@ async def handle_detect_anomalies(arguments: Dict[str, Any]) -> Sequence[TextCon
                     all_anomalies.extend(result)
                 elif isinstance(result, Exception):
                     # Log but continue
-                    import sys
                     logger.warning(f"Error processing agent in detect_anomalies: {result}", exc_info=True)
     except Exception as e:
         logger.error(f"Error in detect_anomalies: {e}", exc_info=True)

--- a/src/mcp_handlers/response_base.py
+++ b/src/mcp_handlers/response_base.py
@@ -1,5 +1,5 @@
 """Response formatting utilities for MCP handlers."""
-from typing import Dict, Any, Sequence, Optional
+from typing import Dict, Any, Sequence
 from mcp.types import TextContent
 import json
 from datetime import datetime

--- a/src/mcp_handlers/response_formatter.py
+++ b/src/mcp_handlers/response_formatter.py
@@ -5,10 +5,9 @@ Extracted from core.py to reduce its size and make response modes independently 
 """
 
 import os
-from typing import Any, Dict, Optional
+from typing import Any
 
 from src.logging_utils import get_logger
-from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 from src.monitor_result import DIVERGENCE_LINE_THRESHOLD
 logger = get_logger(__name__)
 

--- a/src/mcp_handlers/schemas/admin.py
+++ b/src/mcp_handlers/schemas/admin.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Literal, Dict, Any, List, Sequence
+from typing import Optional, Union, Literal, Dict, Any
 from pydantic import Field, model_validator
 from .mixins import AgentIdentityMixin
 

--- a/src/mcp_handlers/schemas/calibration.py
+++ b/src/mcp_handlers/schemas/calibration.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Literal, Dict, Any, List, Sequence
+from typing import Optional, Union, Literal
 from pydantic import Field, model_validator
 from .mixins import AgentIdentityMixin
 

--- a/src/mcp_handlers/schemas/core.py
+++ b/src/mcp_handlers/schemas/core.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional, Union, Literal, Dict, Any, List, Sequence
+from typing import Optional, Union, Literal, Dict, Any, List
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from .mixins import AgentIdentityMixin
 

--- a/src/mcp_handlers/schemas/dialectic.py
+++ b/src/mcp_handlers/schemas/dialectic.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Literal, Dict, Any, List, Sequence
+from typing import Optional, Union, Literal, List
 from pydantic import Field, model_validator
 from .mixins import AgentIdentityMixin
 

--- a/src/mcp_handlers/schemas/export.py
+++ b/src/mcp_handlers/schemas/export.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Literal, Dict, Any, List, Sequence
+from typing import Optional, Literal
 from pydantic import Field
 from .mixins import AgentIdentityMixin
 

--- a/src/mcp_handlers/schemas/identity.py
+++ b/src/mcp_handlers/schemas/identity.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Literal, Dict, Any, List, Sequence
+from typing import Optional, Union
 from pydantic import Field, model_validator
 from .mixins import AgentIdentityMixin
 from .core import BootstrapStateParams

--- a/src/mcp_handlers/schemas/knowledge.py
+++ b/src/mcp_handlers/schemas/knowledge.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Literal, Dict, Any, List, Sequence
+from typing import Optional, Union, Literal, List
 from pydantic import Field, model_validator
 from .mixins import AgentIdentityMixin
 

--- a/src/mcp_handlers/schemas/lifecycle.py
+++ b/src/mcp_handlers/schemas/lifecycle.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Literal, Dict, Any, List, Sequence
+from typing import Optional, Union, Literal, Any, List
 from pydantic import Field, model_validator
 from .mixins import AgentIdentityMixin
 

--- a/src/mcp_handlers/schemas/mixins.py
+++ b/src/mcp_handlers/schemas/mixins.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Literal, Dict, Any, List, Sequence
+from typing import Optional
 from pydantic import BaseModel, Field
 
 class AgentIdentityMixin(BaseModel):

--- a/src/mcp_handlers/schemas/observability.py
+++ b/src/mcp_handlers/schemas/observability.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Literal, Dict, Any, List, Sequence
+from typing import Optional, Union, Literal, Any, List
 from pydantic import Field, model_validator
 from .mixins import AgentIdentityMixin
 

--- a/src/mcp_handlers/support/agent_auth.py
+++ b/src/mcp_handlers/support/agent_auth.py
@@ -1,7 +1,6 @@
 """Agent authentication and identity verification for MCP handlers."""
 from typing import Dict, Any, Tuple, Optional
 from mcp.types import TextContent
-import json
 from datetime import datetime
 
 from src.logging_utils import get_logger

--- a/src/mcp_handlers/support/condition_parser.py
+++ b/src/mcp_handlers/support/condition_parser.py
@@ -5,10 +5,9 @@ Parses natural language conditions into structured format and applies them.
 """
 
 import re
-from typing import Dict, Any, List, Optional, Tuple
+from typing import Dict, Any, Optional
 from datetime import datetime
 from src.logging_utils import get_logger
-from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 logger = get_logger(__name__)
 
 class ParsedCondition:

--- a/src/mcp_handlers/support/llm_delegation.py
+++ b/src/mcp_handlers/support/llm_delegation.py
@@ -25,7 +25,6 @@ import os
 import json
 
 from src.logging_utils import get_logger
-from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 logger = get_logger(__name__)
 
 # Check if OpenAI SDK available

--- a/src/mcp_handlers/support/model_inference.py
+++ b/src/mcp_handlers/support/model_inference.py
@@ -10,7 +10,7 @@ Agents call models for reasoning, generation, or analysis.
 Usage tracked in EISV (Energy consumption) for self-regulation.
 """
 
-from typing import Dict, Any, Sequence, Optional
+from typing import Dict, Any, Sequence
 from mcp.types import TextContent
 import os
 

--- a/src/mcp_handlers/support/naming_helpers.py
+++ b/src/mcp_handlers/support/naming_helpers.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from typing import Optional, List, Dict, Any
 import os
 import re
-from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 def detect_interface_context() -> Dict[str, str]:
     """
     Detect interface and context information for name generation.

--- a/src/mcp_handlers/support/pattern_helpers.py
+++ b/src/mcp_handlers/support/pattern_helpers.py
@@ -4,10 +4,9 @@ Pattern detection helpers for tool handlers.
 Detects code changes and prompts for testing.
 """
 
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, Optional
 from src.pattern_tracker import get_pattern_tracker
 from src.logging_utils import get_logger
-from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 logger = get_logger(__name__)
 
 def detect_code_changes(tool_name: str, arguments: Dict[str, Any]) -> Optional[Dict[str, Any]]:

--- a/src/mcp_handlers/support/pause_ttl.py
+++ b/src/mcp_handlers/support/pause_ttl.py
@@ -28,7 +28,6 @@ captured main loop) using the same pattern as
 from __future__ import annotations
 
 import asyncio
-import os
 from datetime import datetime, timezone
 from typing import Any, Optional
 

--- a/src/mcp_handlers/support/wrapper_generator.py
+++ b/src/mcp_handlers/support/wrapper_generator.py
@@ -16,7 +16,6 @@ import logging
 from typing import Annotated, Any, Callable, Optional, Union
 
 from pydantic import ConfigDict, Field
-from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 logger = logging.getLogger(__name__)
 
 def create_typed_wrapper(

--- a/src/mcp_handlers/types.py
+++ b/src/mcp_handlers/types.py
@@ -4,8 +4,7 @@ Type definitions for MCP tool handlers.
 Provides TypedDict definitions for better type safety and IDE support.
 """
 
-from typing import TypedDict, Optional, List, Dict, Any, Sequence
-from datetime import datetime
+from typing import TypedDict, Optional, List, Dict, Any
 
 
 class AgentMetadataDict(TypedDict, total=False):

--- a/src/mcp_handlers/updates/context.py
+++ b/src/mcp_handlers/updates/context.py
@@ -7,7 +7,6 @@ Each phase reads/writes fields on this dataclass instead of relying on closure s
 
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
-from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 @dataclass
 class UpdateContext:
     """Carries state between extracted update phases and enrichments."""

--- a/src/mcp_handlers/updates/enrichments.py
+++ b/src/mcp_handlers/updates/enrichments.py
@@ -22,7 +22,6 @@ from src.thread_identity import (
 
 from .context import UpdateContext
 from .pipeline import enrichment
-from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 logger = get_logger(__name__)
 
 # ─── Identity Reminder ─────────────────────────────────────────────────

--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -14,7 +14,6 @@ import os
 import re
 import secrets
 import time
-from datetime import datetime
 from typing import Optional, Sequence
 
 from mcp.types import TextContent
@@ -29,7 +28,6 @@ from ..support.tool_hints import (
     KNOWLEDGE_SEARCH_SUGGESTION,
     KNOWLEDGE_OPEN_QUESTIONS_WORKFLOW,
 )
-from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 logger = get_logger(__name__)
 
 _ALLOWED_EPISTEMIC_CLASSES = {
@@ -362,8 +360,7 @@ async def handle_onboarding_and_resume(ctx: UpdateContext) -> Optional[Sequence[
                 try:
                     from ..support.naming_helpers import (
                         detect_interface_context,
-                        generate_name_suggestions,
-                        format_naming_guidance
+                        generate_name_suggestions
                     )
                     existing_names = [
                         getattr(m, 'label', None)

--- a/src/mcp_handlers/validators.py
+++ b/src/mcp_handlers/validators.py
@@ -11,7 +11,6 @@ LITE MODEL SUPPORT:
 from typing import Dict, Any, Optional, Tuple, List
 from mcp.types import TextContent
 from .utils import error_response
-from src.mcp_handlers.shared import lazy_mcp_server as mcp_server
 from src.logging_utils import get_logger
 
 logger = get_logger(__name__)
@@ -74,7 +73,6 @@ def validate_file_path_policy(file_path: str) -> Tuple[Optional[str], Optional[T
         Returns warning, not error, to inform but not block.
     """
     import os
-    from pathlib import Path
     if file_path is None:
         return (None, None)
     file_path = os.path.normpath(file_path)

--- a/src/mcp_handlers/wave3a_admin.py
+++ b/src/mcp_handlers/wave3a_admin.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Dict, Optional, Set
+from typing import Any, Dict, Set
 
 from starlette.requests import Request
 from starlette.responses import JSONResponse

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -36,12 +36,9 @@ import asyncio
 import argparse
 import time
 from pathlib import Path
-from typing import Any, Dict, Set, Optional
+from typing import Dict, Optional
 from datetime import datetime, timedelta, timezone
-from contextlib import asynccontextmanager
 import json
-import traceback
-import uuid
 
 # Load environment variables from ~/.env.mcp
 try:
@@ -62,7 +59,6 @@ project_root = ensure_project_root()
 from src.logging_utils import get_logger
 from src.services.identity_continuity import (
     format_identity_continuity_startup_message,
-    get_identity_continuity_status,
     probe_identity_continuity_status,
 )
 from src.versioning import load_version_from_file
@@ -88,7 +84,7 @@ from src.connection_tracker import (
 try:
     from mcp.server import FastMCP
     from mcp.server.fastmcp import Context
-    from mcp.types import TextContent
+    from mcp.types import TextContent  # noqa: F401 — availability probe
     MCP_SDK_AVAILABLE = True
 except ImportError as e:
     MCP_SDK_AVAILABLE = False
@@ -97,7 +93,7 @@ except ImportError as e:
     sys.exit(1)
 
 # Import dispatch_tool from handlers (reuse all existing tool logic)
-from src.mcp_handlers import dispatch_tool, TOOL_HANDLERS
+from src.mcp_handlers import dispatch_tool
 # Wave 3a per-tool routing table imports — hoisted to module load time so
 # (a) the per-call ~200-500ns import cost vanishes from the dispatch hot
 # path, and (b) ``patch("src.wave3a_routing.get_route")`` style mocks
@@ -644,7 +640,7 @@ from src.process_management import (
     write_server_pid_file, remove_server_pid_file,
     acquire_server_lock, release_server_lock,
     ensure_server_pid_file, ensure_server_lock,
-    SERVER_PID_FILE, SERVER_LOCK_FILE, CURRENT_PID,
+    SERVER_PID_FILE, SERVER_LOCK_FILE,
 )
 
 
@@ -813,7 +809,7 @@ async def main():
     # Run the governance MCP server
     try:
         import uvicorn
-        from starlette.applications import Starlette
+        from starlette.applications import Starlette  # noqa: F401 — availability probe
         from starlette.responses import JSONResponse
         from starlette.middleware.cors import CORSMiddleware
         from mcp.server.streamable_http_manager import StreamableHTTPSessionManager

--- a/src/mcp_server_std.py
+++ b/src/mcp_server_std.py
@@ -46,7 +46,6 @@ except ImportError:
 from src.logging_utils import get_logger
 from src.services.identity_continuity import (
     format_identity_continuity_startup_message,
-    get_identity_continuity_status,
     probe_identity_continuity_status,
 )
 logger = get_logger(__name__)
@@ -77,7 +76,7 @@ from src.agent_state import (
 from src.tool_schemas import get_tool_definitions
 from src.lock_cleanup import cleanup_stale_state_locks
 from src.services.tool_usage_recorder import classify_tool_result, record_tool_usage
-from src.background_tasks import create_tracked_task
+from src.background_tasks import create_tracked_task  # noqa: F401 — re-exported for consumers of this module
 
 # ============================================================================
 # MCP Server Instance

--- a/src/monitor_calibration.py
+++ b/src/monitor_calibration.py
@@ -5,7 +5,6 @@ Retrospective trajectory validation + strategic/tactical calibration.
 
 import math
 import time as _time
-from datetime import datetime
 from typing import Dict, Optional
 
 from src.calibration import calibration_checker

--- a/src/monitor_drift.py
+++ b/src/monitor_drift.py
@@ -1,6 +1,6 @@
 """Ethical drift vector computation for governance monitor."""
 
-from typing import Dict, Optional, Tuple
+from typing import Dict, Tuple
 
 from governance_core import (
     coherence, compute_ethical_drift, get_agent_baseline,

--- a/src/monitor_metrics.py
+++ b/src/monitor_metrics.py
@@ -20,7 +20,7 @@ import time as _time
 import numpy as np
 
 from config.governance_config import config
-from governance_core.parameters import get_active_params, get_params_profile_name, DEFAULT_WEIGHTS
+from governance_core.parameters import get_params_profile_name, DEFAULT_WEIGHTS
 from governance_core.scoring import phi_objective, verdict_from_phi
 from governance_core import approximate_stability_check
 from src.health_thresholds import HealthThresholds

--- a/src/monitor_result.py
+++ b/src/monitor_result.py
@@ -1,7 +1,7 @@
 """Result assembly for governance monitor process_update."""
 
 from datetime import datetime
-from typing import Dict, Optional
+from typing import Dict
 
 from governance_core import get_agent_baseline
 from src.drift_telemetry import record_drift

--- a/src/pattern_tracker.py
+++ b/src/pattern_tracker.py
@@ -9,8 +9,8 @@ Tracks:
 
 from collections import deque
 from datetime import datetime, timezone, timedelta
-from typing import Dict, List, Optional, Tuple, Any
-from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Any
+from dataclasses import dataclass
 import hashlib
 import json
 import logging

--- a/src/perf_monitor.py
+++ b/src/perf_monitor.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from collections import defaultdict, deque
 from dataclasses import dataclass
 import threading
-from typing import Any, Deque, Dict, Optional
+from typing import Any, Deque, Dict
 
 
 @dataclass(frozen=True)

--- a/src/process_cleanup.py
+++ b/src/process_cleanup.py
@@ -8,7 +8,7 @@ Ensures only active processes remain running.
 import os
 import time
 from pathlib import Path
-from typing import List, Dict, Optional
+from typing import List, Dict
 
 try:
     import psutil

--- a/src/resident_progress/probe_task.py
+++ b/src/resident_progress/probe_task.py
@@ -6,7 +6,6 @@ import logging
 import uuid
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
-from typing import Protocol
 
 from src.resident_progress.heartbeat import HeartbeatStatus
 from src.resident_progress.registry import (

--- a/src/sequential_calibration.py
+++ b/src/sequential_calibration.py
@@ -56,7 +56,7 @@ from __future__ import annotations
 from collections import defaultdict
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, Optional
+from typing import Any, Callable, Dict, Optional
 import fcntl
 import json
 import math

--- a/src/state_locking.py
+++ b/src/state_locking.py
@@ -15,10 +15,9 @@ import fcntl
 import os
 import time
 import json
-import asyncio
 from pathlib import Path
 from contextlib import contextmanager, asynccontextmanager
-from typing import Optional, Dict, Any
+from typing import Optional
 
 
 def is_process_alive(pid: int) -> bool:

--- a/src/telemetry_cache.py
+++ b/src/telemetry_cache.py
@@ -7,8 +7,6 @@ Helps future agents by reducing blocking file operations.
 
 from typing import Dict, Optional, Any
 from datetime import datetime, timedelta
-from collections import defaultdict
-import asyncio
 import hashlib
 import json
 import threading

--- a/src/tool_usage_tracker.py
+++ b/src/tool_usage_tracker.py
@@ -14,7 +14,6 @@ from typing import Dict, List, Optional
 import json
 import fcntl
 import os
-import sys
 
 # Import structured logging
 from src.logging_utils import get_logger

--- a/src/trajectory_identity.py
+++ b/src/trajectory_identity.py
@@ -15,7 +15,6 @@ Agents can operate without providing trajectory signatures; this is additive.
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
-import json
 import math
 
 from src.logging_utils import get_logger

--- a/src/workspace_health.py
+++ b/src/workspace_health.py
@@ -8,7 +8,7 @@ Consolidates validation logic from various scripts into a single MCP tool.
 import json
 import os
 from pathlib import Path
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any
 from datetime import datetime, timezone
 
 
@@ -223,8 +223,8 @@ def check_workspace_status() -> Dict[str, Any]:
     # Check if dependencies are installed (basic check)
     dependencies_installed = True
     try:
-        import mcp
-        import numpy
+        import mcp  # noqa: F401 — availability probe
+        import numpy  # noqa: F401 — availability probe
     except ImportError:
         dependencies_installed = False
     
@@ -234,7 +234,6 @@ def check_workspace_status() -> Dict[str, Any]:
         # Try to import the server module
         from src._imports import ensure_project_root
         ensure_project_root()
-        import src.agent_state
     except Exception:
         mcp_servers_responding = False
     

--- a/tests/test_core_metrics.py
+++ b/tests/test_core_metrics.py
@@ -939,11 +939,15 @@ class TestExportToFile:
             assert "error" in data or "not supported" in json.dumps(data).lower()
 
     @pytest.mark.asyncio
-    async def test_write_failure_returns_error(self, mock_server, mock_monitor):
+    async def test_write_failure_returns_error(self, mock_server, mock_monitor, tmp_path):
         """File write failure returns informative error."""
         mock_server.get_or_create_monitor.return_value = mock_monitor
-        # Set project_root to a non-writable path
-        mock_server.project_root = "/nonexistent/path/that/does/not/exist"
+        # Set project_root to a path whose parent is a regular file — mkdir/write
+        # under it fails with ENOTDIR even when running as root (a bare
+        # "/nonexistent/..." path is creatable by root, so it doesn't inject a failure)
+        blocker = tmp_path / "blocker"
+        blocker.write_text("")
+        mock_server.project_root = str(blocker / "not-a-dir")
 
         with patch("src.mcp_handlers.introspection.export.mcp_server", mock_server), \
              patch("src.mcp_handlers.introspection.export.require_registered_agent", return_value=("agent-1", None)):

--- a/tests/test_session_end_stash.py
+++ b/tests/test_session_end_stash.py
@@ -47,6 +47,8 @@ def git_repo(tmp_path):
         subprocess.run(["git", "init", "-q", "-b", "main"], check=True)
         subprocess.run(["git", "config", "user.email", "t@t"], check=True)
         subprocess.run(["git", "config", "user.name", "t"], check=True)
+        # Hermetic: host config may force commit signing (e.g. remote containers)
+        subprocess.run(["git", "config", "commit.gpgsign", "false"], check=True)
         (repo / "seed.py").write_text("seed\n")
         subprocess.run(["git", "add", "seed.py"], check=True)
         subprocess.run(["git", "commit", "-q", "-m", "seed"], check=True)

--- a/tests/test_test_cache_script.py
+++ b/tests/test_test_cache_script.py
@@ -46,6 +46,8 @@ def cache_repo(tmp_path: Path) -> tuple[Path, dict[str, str]]:
     subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
     subprocess.run(["git", "config", "user.email", "t@t"], cwd=repo, check=True)
     subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+    # Hermetic: host config may force commit signing (e.g. remote containers)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=repo, check=True)
     subprocess.run(["git", "add", "."], cwd=repo, check=True)
     subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=repo, check=True)
 

--- a/tests/test_watcher_fingerprint.py
+++ b/tests/test_watcher_fingerprint.py
@@ -59,6 +59,8 @@ def two_worktrees(tmp_path):
     _git(main, "init", "-q", "-b", "main")
     _git(main, "config", "user.email", "t@t.t")
     _git(main, "config", "user.name", "t")
+    # Hermetic: host config may force commit signing (e.g. remote containers)
+    _git(main, "config", "commit.gpgsign", "false")
     src = main / "src"
     src.mkdir()
     file_main = src / "x.py"

--- a/tests/test_workspace_closeout.py
+++ b/tests/test_workspace_closeout.py
@@ -33,6 +33,8 @@ def git_repo(tmp_path):
         subprocess.run(["git", "init", "-q", "-b", "main"], check=True)
         subprocess.run(["git", "config", "user.email", "t@t"], check=True)
         subprocess.run(["git", "config", "user.name", "t"], check=True)
+        # Hermetic: host config may force commit signing (e.g. remote containers)
+        subprocess.run(["git", "config", "commit.gpgsign", "false"], check=True)
         (repo / "seed.py").write_text("seed\n")
         subprocess.run(["git", "add", "seed.py"], check=True)
         subprocess.run(["git", "commit", "-q", "-m", "seed"], check=True)


### PR DESCRIPTION
## What

Follow-up to a dead-code assessment of all 935 Python files (ruff + vulture + manual verification). Headline finding: **no orphaned modules** — the import graph is tight; the only module-level candidate (`src/gateway_server.py`) is a live plist-launched entrypoint. The real debt was **527 unused imports and no lint gate** to stop reaccumulation.

Commit 1 removes the 260 verifiably-dead imports (−237 lines across ~130 files), annotates the deliberately-kept ones, and adds a CI gate so the count stays at zero. Commit 2 fixes 28 environment-dependent tests the validation run surfaced (details below).

## How removals were verified

Every flagged import was checked three ways before deletion:

1. **Dotted-path references** — `mock.patch("module.name")`-style targets anywhere in the repo.
2. **Facade consumers** — `from <module> import name` (single-line and parenthesized multiline) anywhere in the repo, since several modules are declared re-export facades.
3. **Object-style test patches** — `monkeypatch.setattr(mod, "name", ...)` / `patch.object(mod, "name")` sweeps, which dotted-path scans can't see. This is what caught the watcher agent's re-exported `STATE_DIR`/`FINDINGS_FILE`/`DEDUP_FILE` names.
4. Imports bound with `as` aliases were re-checked under their **local binding name** — that check kept `dialectic/calibration.py`'s `mcp_server`, which `tests/test_remaining_modules.py` patches.

Notable removal class: 13 handler modules imported `lazy_mcp_server as mcp_server` with no in-module use **and** no test patching it (verified per-module). The CLAUDE.md convention exists so tests can patch `{MODULE}.mcp_server` — modules that need it still have it; re-add per module if a test starts patching one.

## Kept (with per-file-ignores or inline noqa)

- Declared re-export facades: `agent_state.py`, `cirs/protocol.py`, `lifecycle/handlers.py`, `identity/{core,handlers}.py`, `mcp_handlers/utils.py`, `agents/watcher/agent.py`
- `**/__init__.py` re-export surfaces, `tests/**` (pytest fixture imports look unused to ruff)
- **Surfaces owned by in-flight PRs #619/#622** (`http_api.py`, `identity_step.py`, `identity/session.py`, `tool_stability.py`, `consolidated.py`) — left byte-identical to avoid merge collisions; their 11 stragglers carry a per-file-ignore with a comment to clean after those land
- Individually re-exported names (`governance_monitor.phi_objective`, dialectic handler re-exports, etc.) get inline `# noqa: F401` with the reason
- `try: import X` availability probes

## CI gate

New "Dead-code gate" step in the smoke job: `ruff check .` with `[tool.ruff]` config in pyproject.toml, `select = ["F401"]` only. F841 (42), F811 (14), ERA001 (83 commented-out blocks) are left for follow-ups — widen the select list as each reaches zero.

## Test fixes (commit 2)

The full validation run surfaced 31 environment-dependent breakages, all reproducible on clean master:

- **27 errors**: throwaway git-repo fixtures inherited the host's global `commit.gpgsign=true` (remote containers sign through a proxy that rejects fixture commits). Fixtures already pinned `user.email`/`user.name` locally; they now pin `commit.gpgsign=false` too — hermetic for any contributor with forced signing.
- **1 failure**: `test_core_metrics` write-failure case injected failure via an unwritable absolute path, which root happily creates. The injection now points `project_root` under a regular file (`ENOTDIR` regardless of privilege).
- **3 failures, no repo change**: shadow-pin-lookup tests fail only under Python 3.11, where `asyncio.wait_for` copies the context into a task and drops the `ContextVar.set`. Repo requires 3.12+, where they pass.

## Out of scope (flagged for a decision, not touched)

The assessment also found a layer of **functions whose only callers are their own tests** — candidates for deletion or promotion to documented API: `audit_log.py` (7 `log_*` methods), `activity_tracker.py` (`track_conversation_turn`, `get_activity_summary`), `governance_core/dynamics.py` (`estimate_convergence`, `check_basin`), `agent_storage.agent_exists`, `audit_db.search_audit_events_async`. Removing them would also remove >200 lines of tests, so per AGENTS.md that gets its own intent-first PR if wanted.

## Verification

- `ruff check .` clean repo-wide; `py_compile` on all touched files
- **Full suite under Python 3.12: 8,943 passed, 186 skipped, 0 failed, 0 errors** (local remote-container run, no Postgres/AGE — AGE-dependent tests skip)
- **GitHub CI green on both commits** (Tests + Documentation Validation), including the first run of the new dead-code gate

https://claude.ai/code/session_01DqmVuCNPd2WZB8U84fALQk