### PR TITLE
[codex] add cached quick test gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Makefile for governance-mcp-v1
-.PHONY: help test test-quick test-smoke version version-check version-bump restart logs serve docs clean
+.PHONY: help test test-cache-quick test-quick test-smoke version version-check version-bump restart logs serve docs clean
 
 help: ## Show this help message
 	@echo "Available commands:"
@@ -24,6 +24,9 @@ test: ## Run full test suite with coverage
 	@python3 -m pytest \
 		--cov=src --cov=agents/sdk/src/unitares_sdk --cov=agents \
 		--cov-report=term-missing --cov-fail-under=25
+
+test-cache-quick: ## Run cached full test suite without coverage
+	@./scripts/dev/test-cache.sh --quick
 
 test-quick: ## Run tests without coverage
 	@python3 -m pytest -o addopts= -q

--- a/scripts/dev/test-cache.sh
+++ b/scripts/dev/test-cache.sh
@@ -7,6 +7,7 @@
 #
 # Usage:
 #   ./scripts/dev/test-cache.sh              # default: pytest tests/ agents/ -q --tb=short -x
+#   ./scripts/dev/test-cache.sh --quick      # same gate without coverage instrumentation
 #   ./scripts/dev/test-cache.sh --staged     # hash staged commit candidate
 #   ./scripts/dev/test-cache.sh --fresh      # ignore cache, force run
 #   ./scripts/dev/test-cache.sh -- -k "test_foo"  # extra pytest args after --
@@ -26,11 +27,13 @@ cd "$PROJECT_ROOT"
 # --- parse args ---
 FRESH=false
 STAGED=false
+QUICK=false
 PYTEST_EXTRA=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --fresh) FRESH=true; shift ;;
         --staged) STAGED=true; shift ;;
+        --quick) QUICK=true; shift ;;
         --)      shift; PYTEST_EXTRA=("$@"); break ;;
         *)       PYTEST_EXTRA+=("$1"); shift ;;
     esac
@@ -227,10 +230,15 @@ else
     TREE_HASH=$(_hash_worktree_inputs)
 fi
 
+TEST_PROFILE="coverage"
+if [[ "$QUICK" == true ]]; then
+    TEST_PROFILE="quick"
+fi
+
 PYTEST_ARGS_HASH=$(_hash_pytest_args ${PYTEST_EXTRA[@]+"${PYTEST_EXTRA[@]}"})
-CACHE_KEY=$(printf '%s\0%s\0%s\0%s\0%s\0' "$CACHE_VERSION" "$HASH_MODE" "$TREE_HASH" "$PYTEST_ARGS_HASH" "$RUNTIME_HASH" | shasum -a 256 | cut -d' ' -f1)
+CACHE_KEY=$(printf '%s\0%s\0%s\0%s\0%s\0%s\0' "$CACHE_VERSION" "$HASH_MODE" "$TEST_PROFILE" "$TREE_HASH" "$PYTEST_ARGS_HASH" "$RUNTIME_HASH" | shasum -a 256 | cut -d' ' -f1)
 CACHE_FILE="$CACHE_DIR/$CACHE_KEY"
-CACHE_LABEL="$HASH_MODE inputs $TREE_HASH runtime $RUNTIME_HASH"
+CACHE_LABEL="$HASH_MODE inputs $TREE_HASH profile $TEST_PROFILE runtime $RUNTIME_HASH"
 if [[ ${#PYTEST_EXTRA[@]} -gt 0 ]]; then
     CACHE_LABEL="$CACHE_LABEL args $PYTEST_ARGS_HASH"
 fi
@@ -292,10 +300,15 @@ fi
 mkdir -p "$CACHE_DIR"
 echo "[test-cache] MISS — $CACHE_LABEL, running pytest..."
 
-PYTEST_CMD=("$PYTHON" -m pytest tests/ agents/ -q --tb=short -x \
-	--cov=src --cov=agents/sdk/src/unitares_sdk --cov=agents \
-	--cov-report=term-missing --cov-fail-under=25 \
-	${PYTEST_EXTRA[@]+"${PYTEST_EXTRA[@]}"})
+if [[ "$QUICK" == true ]]; then
+    PYTEST_CMD=("$PYTHON" -m pytest tests/ agents/ -q --tb=short -x \
+        ${PYTEST_EXTRA[@]+"${PYTEST_EXTRA[@]}"})
+else
+    PYTEST_CMD=("$PYTHON" -m pytest tests/ agents/ -q --tb=short -x \
+        --cov=src --cov=agents/sdk/src/unitares_sdk --cov=agents \
+        --cov-report=term-missing --cov-fail-under=25 \
+        ${PYTEST_EXTRA[@]+"${PYTEST_EXTRA[@]}"})
+fi
 TMPOUT=$(mktemp)
 set +e
 "${PYTEST_CMD[@]}" 2>&1 | tee "$TMPOUT"

--- a/tests/test_test_cache_script.py
+++ b/tests/test_test_cache_script.py
@@ -60,6 +60,7 @@ fi
 
 if [[ "${1:-}" == "-m" && "${2:-}" == "pytest" ]]; then
     count_file="${FAKE_PYTEST_COUNT:?}"
+    printf "%s\\n" "$*" > "${FAKE_PYTEST_ARGS:?}"
     count=0
     if [[ -f "$count_file" ]]; then
         count="$(cat "$count_file")"
@@ -81,6 +82,7 @@ exit 99
     env["UNITARES_PYTHON"] = str(fake_python)
     env["UNITARES_TEST_CACHE_LOCK_DIR"] = str(repo / "test-cache.lock")
     env["FAKE_PYTEST_COUNT"] = str(repo / "pytest-count.txt")
+    env["FAKE_PYTEST_ARGS"] = str(repo / "pytest-args.txt")
     return repo, env
 
 
@@ -100,6 +102,10 @@ def _pytest_count(repo: Path) -> int:
     if not path.exists():
         return 0
     return int(path.read_text(encoding="utf-8").strip())
+
+
+def _pytest_args(repo: Path) -> str:
+    return (repo / "pytest-args.txt").read_text(encoding="utf-8")
 
 
 def test_tracked_sql_change_invalidates_worktree_cache(cache_repo):
@@ -144,6 +150,29 @@ def test_untracked_test_file_invalidates_worktree_cache(cache_repo):
     third = _run_cache(repo, env)
     assert third.returncode == 0, third.stdout + third.stderr
     assert "[test-cache] MISS" in third.stdout
+    assert _pytest_count(repo) == 2
+
+
+def test_quick_mode_omits_coverage_and_uses_separate_cache(cache_repo):
+    repo, env = cache_repo
+
+    quick_first = _run_cache(repo, env, "--quick")
+    assert quick_first.returncode == 0, quick_first.stdout + quick_first.stderr
+    assert "[test-cache] MISS" in quick_first.stdout
+    assert "profile quick" in quick_first.stdout
+    assert "--cov=src" not in _pytest_args(repo)
+    assert _pytest_count(repo) == 1
+
+    full = _run_cache(repo, env)
+    assert full.returncode == 0, full.stdout + full.stderr
+    assert "[test-cache] MISS" in full.stdout
+    assert "profile coverage" in full.stdout
+    assert "--cov=src" in _pytest_args(repo)
+    assert _pytest_count(repo) == 2
+
+    quick_second = _run_cache(repo, env, "--quick")
+    assert quick_second.returncode == 0, quick_second.stdout + quick_second.stderr
+    assert "[test-cache] HIT" in quick_second.stdout
     assert _pytest_count(repo) == 2
 
 


### PR DESCRIPTION
Adds a --quick profile to scripts/dev/test-cache.sh so developers can run the full tests/ agents/ selection without coverage instrumentation while keeping the tree-hash cache and lock semantics. Adds make test-cache-quick and a fake-pytest regression proving quick/full cache keys stay separate and quick mode omits coverage args. Validation: python3 -m pytest -q tests/test_test_cache_script.py; ./scripts/dev/test-cache.sh --quick -- -k test_quick_mode_omits_coverage_and_uses_separate_cache; ./scripts/dev/test-cache.sh; pre-push smoke hook.