### PR TITLE
feat(wave3): §14 prereq #10 — transport 503 emission + consumer retry-on-503

### DIFF
--- a/agents/common/findings.py
+++ b/agents/common/findings.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import time
 from typing import Any, Iterable, Optional
 
 import httpx
@@ -20,6 +21,12 @@ DEFAULT_URL = os.environ.get(
     "UNITARES_FINDINGS_URL", "http://localhost:8767/api/findings"
 )
 DEFAULT_TIMEOUT_SECONDS = 3.0
+
+# Wave 3 §3.2 (prereq PR #10): one bounded retry on HTTP 503, honoring the
+# server's Retry-After header / retry_after_seconds body field. Capped low —
+# post_finding sits on agent-cycle hot paths and must stay near-instant even
+# when the server is mid-cutover.
+MAX_503_RETRY_SLEEP_SECONDS = 5.0
 
 
 def compute_fingerprint(parts: Iterable[Any]) -> str:
@@ -36,6 +43,21 @@ def compute_fingerprint(parts: Iterable[Any]) -> str:
 def _httpx_post(url: str, json: dict, headers: dict, timeout: float):
     """Thin wrapper so tests can monkeypatch this single call."""
     return httpx.post(url, json=json, headers=headers, timeout=timeout)
+
+
+def _retry_after_from_503(resp: Any) -> float:
+    """Bounded server-suggested delay from a 503 response: Retry-After
+    header first, then the §3.2 body's retry_after_seconds, else the cap."""
+    try:
+        raw = resp.headers.get("Retry-After")
+        if raw is None:
+            raw = resp.json().get("retry_after_seconds")
+        seconds = float(raw)
+        if seconds < 0:
+            return MAX_503_RETRY_SLEEP_SECONDS
+        return min(seconds, MAX_503_RETRY_SLEEP_SECONDS)
+    except Exception:  # noqa: BLE001 — malformed header/body
+        return MAX_503_RETRY_SLEEP_SECONDS
 
 
 def post_finding(
@@ -77,6 +99,12 @@ def post_finding(
 
     try:
         resp = _httpx_post(url, json=body, headers=headers, timeout=timeout)
+        if getattr(resp, "status_code", 0) == 503:
+            # §3.2 typed-unavailable from a mid-cutover transport: honor the
+            # server's delay (bounded) and retry exactly once. Still never
+            # raises; a second 503 falls through to the non-200 return below.
+            time.sleep(_retry_after_from_503(resp))
+            resp = _httpx_post(url, json=body, headers=headers, timeout=timeout)
     except Exception as exc:
         log.debug("post_finding failed: %s", exc)
         return False

--- a/agents/common/tests/test_findings.py
+++ b/agents/common/tests/test_findings.py
@@ -173,3 +173,78 @@ def test_compute_fingerprint_format_is_locked():
     assert actual == actual.lower()
     assert len(actual) == 16
     assert all(c in "0123456789abcdef" for c in actual)
+
+
+# --- Wave 3 §3.2 retry-on-503 (§14 prereq PR #10) ---
+
+
+def _resp(status_code: int, body: dict | None = None, headers: dict | None = None):
+    class FakeResp:
+        pass
+
+    resp = FakeResp()
+    resp.status_code = status_code
+    resp.headers = headers or {}
+    resp.json = lambda: body if body is not None else {}
+    return resp
+
+
+def test_post_finding_retries_once_on_503(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr("agents.common.findings.time.sleep", sleeps.append)
+    responses = [
+        _resp(503, headers={"Retry-After": "2"}),
+        _resp(200, {"success": True, "deduped": False}),
+    ]
+    calls = []
+
+    def fake_post(url, json, headers, timeout):  # noqa: A002
+        calls.append(url)
+        return responses.pop(0)
+
+    monkeypatch.setattr("agents.common.findings._httpx_post", fake_post)
+    ok = post_finding(
+        event_type="sentinel_finding", severity="high", message="m",
+        agent_id="sentinel-01", agent_name="Sentinel", fingerprint="fp",
+    )
+    assert ok is True
+    assert len(calls) == 2
+    assert sleeps == [2.0]
+
+
+def test_post_finding_503_twice_returns_false(monkeypatch):
+    monkeypatch.setattr("agents.common.findings.time.sleep", lambda s: None)
+    body = {
+        "ok": False,
+        "error": "governance_temporarily_unavailable",
+        "retry_after_seconds": 5,
+    }
+
+    def fake_post(url, json, headers, timeout):  # noqa: A002
+        return _resp(503, body)
+
+    monkeypatch.setattr("agents.common.findings._httpx_post", fake_post)
+    # Still never raises — best-effort contract holds through cutover.
+    assert post_finding(
+        event_type="vigil_finding", severity="critical", message="m",
+        agent_id="vigil", agent_name="Vigil", fingerprint="fp",
+    ) is False
+
+
+def test_post_finding_503_sleep_is_capped(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr("agents.common.findings.time.sleep", sleeps.append)
+    responses = [
+        _resp(503, {"retry_after_seconds": 600}),
+        _resp(200, {"success": True, "deduped": False}),
+    ]
+    monkeypatch.setattr(
+        "agents.common.findings._httpx_post",
+        lambda url, json, headers, timeout: responses.pop(0),
+    )
+    post_finding(
+        event_type="sentinel_finding", severity="low", message="m",
+        agent_id="s", agent_name="S", fingerprint="fp",
+    )
+    # Hot-path cap: never parks an agent cycle longer than 5s.
+    assert sleeps == [5.0]

--- a/agents/sdk/src/unitares_sdk/client.py
+++ b/agents/sdk/src/unitares_sdk/client.py
@@ -17,8 +17,11 @@ from mcp.client.streamable_http import streamable_http_client
 from unitares_sdk.errors import (
     GovernanceConnectionError,
     GovernanceTimeoutError,
+    GovernanceUnavailableError,
     IdentityDriftError,
     VerdictError,
+    extract_retry_after_seconds,
+    parse_retry_after_header,
 )
 from unitares_sdk.models import (
     ArchiveResult,
@@ -274,6 +277,25 @@ class GovernanceClient:
                 with anyio.fail_after(effective_timeout):
                     result = await self._session.call_tool(tool_name, injected_args)
                 raw = self._parse_mcp_result(result)
+                # Wave 3 §3.2: the cutover proxy / fail-fast writer surfaces a
+                # typed-unavailable payload. Honor retry_after_seconds with one
+                # retry (prereq PR #10 consumer contract), then raise typed so
+                # resident cycle loops can back off with the server's delay.
+                retry_after = extract_retry_after_seconds(raw)
+                if retry_after is not None:
+                    last_error = GovernanceUnavailableError(
+                        f"{tool_name}: governance temporarily unavailable "
+                        f"(retry_after_seconds={retry_after})",
+                        retry_after_seconds=retry_after,
+                    )
+                    if attempt == 0:
+                        logger.warning(
+                            "%s unavailable (503-equivalent), retrying in %.1fs",
+                            tool_name, retry_after,
+                        )
+                        await asyncio.sleep(retry_after)
+                        continue
+                    raise last_error
                 # Centralized failure check. The MCP transport can succeed at
                 # the HTTP layer but carry a structured tool failure inside
                 # the JSON payload. Without this check, callers like onboard()
@@ -290,6 +312,35 @@ class GovernanceClient:
                     logger.warning("Timeout on %s, retrying in %.1fs", tool_name, self.retry_delay)
                     await asyncio.sleep(self.retry_delay)
                     continue
+            except httpx.HTTPStatusError as e:
+                # §3.2 cutover 503 surfacing at the HTTP layer instead of as a
+                # parsed tool payload. Honor Retry-After; other statuses keep
+                # the pre-existing connection-error treatment.
+                status = e.response.status_code if e.response is not None else None
+                if status == 503:
+                    retry_after = (
+                        parse_retry_after_header(
+                            e.response.headers.get("Retry-After")
+                        )
+                        if e.response is not None
+                        else None
+                    ) or 5.0
+                    last_error = GovernanceUnavailableError(
+                        f"{tool_name}: HTTP 503 from governance transport "
+                        f"(retry_after_seconds={retry_after})",
+                        retry_after_seconds=retry_after,
+                    )
+                    if attempt == 0:
+                        logger.warning(
+                            "HTTP 503 on %s, retrying in %.1fs", tool_name, retry_after
+                        )
+                        await asyncio.sleep(retry_after)
+                        continue
+                else:
+                    last_error = GovernanceConnectionError(str(e))
+                    if attempt == 0:
+                        await asyncio.sleep(self.retry_delay)
+                        continue
             except (httpx.ConnectError, httpx.TimeoutException, ConnectionError, OSError) as e:
                 last_error = GovernanceConnectionError(str(e))
                 if attempt == 0:

--- a/agents/sdk/src/unitares_sdk/errors.py
+++ b/agents/sdk/src/unitares_sdk/errors.py
@@ -1,5 +1,7 @@
 """SDK exception hierarchy."""
 
+from __future__ import annotations
+
 
 class GovernanceError(Exception):
     """Base exception for all SDK errors."""
@@ -11,6 +13,69 @@ class GovernanceConnectionError(GovernanceError):
 
 class GovernanceTimeoutError(GovernanceError):
     """MCP call exceeded timeout (likely anyio deadlock)."""
+
+
+class GovernanceUnavailableError(GovernanceError):
+    """Server returned the Wave 3 §3.2 typed-unavailable response (HTTP 503
+    body ``{"ok": false, "error": "governance_temporarily_unavailable",
+    "retry_after_seconds": N}`` with a matching ``Retry-After`` header).
+
+    Raised after the client's retry budget is exhausted. Carries the
+    server-suggested delay so calling layers with their own scheduling
+    (resident cycle loops) can back off honestly instead of guessing.
+    """
+
+    def __init__(self, message: str, retry_after_seconds: float = 5.0):
+        self.retry_after_seconds = retry_after_seconds
+        super().__init__(message)
+
+
+# Pinned by docs/proposals/beam-wave-3-handler-dispatch.md §3.2 step 3; the
+# server-side single source is src/mcp_transport.py::make_unavailable_body.
+UNAVAILABLE_ERROR = "governance_temporarily_unavailable"
+
+# Server-suggested delays are honored but bounded — a misconfigured or
+# malicious Retry-After must not park a resident cycle indefinitely.
+MAX_RETRY_AFTER_SECONDS = 30.0
+DEFAULT_RETRY_AFTER_SECONDS = 5.0
+
+
+def extract_retry_after_seconds(payload: object) -> float | None:
+    """Return the bounded retry delay when ``payload`` is the §3.2
+    typed-unavailable body, else ``None``.
+
+    Detection keys on ``error == "governance_temporarily_unavailable"`` —
+    NOT on the bare presence of ``retry_after_seconds``, which the deep
+    health endpoint also uses for an unrelated warming-up shape.
+    """
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("error") != UNAVAILABLE_ERROR:
+        return None
+    return _bound_retry_after(payload.get("retry_after_seconds"))
+
+
+def parse_retry_after_header(value: object) -> float | None:
+    """Parse an HTTP ``Retry-After`` header (delta-seconds form only — the
+    HTTP-date form is not used by the §3.2 contract). Returns the bounded
+    delay, or ``None`` when absent/unparseable."""
+    if value is None:
+        return None
+    try:
+        seconds = float(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+    return _bound_retry_after(seconds)
+
+
+def _bound_retry_after(value: object) -> float:
+    try:
+        seconds = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return DEFAULT_RETRY_AFTER_SECONDS
+    if seconds < 0:
+        return DEFAULT_RETRY_AFTER_SECONDS
+    return min(seconds, MAX_RETRY_AFTER_SECONDS)
 
 
 class IdentityDriftError(GovernanceError):

--- a/agents/sdk/src/unitares_sdk/sync_client.py
+++ b/agents/sdk/src/unitares_sdk/sync_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 import urllib.error
 import urllib.request
 from typing import Any
@@ -12,7 +13,10 @@ from typing import Any
 from unitares_sdk.errors import (
     GovernanceConnectionError,
     GovernanceTimeoutError,
+    GovernanceUnavailableError,
     IdentityDriftError,
+    extract_retry_after_seconds,
+    parse_retry_after_header,
 )
 from unitares_sdk.models import (
     ArchiveResult,
@@ -316,28 +320,59 @@ class SyncGovernanceClient:
     def _rest_call(
         self, tool_name: str, arguments: dict, *, timeout: float | None = None
     ) -> dict:
-        """POST to /v1/tools/call and parse the response envelope."""
+        """POST to /v1/tools/call and parse the response envelope.
+
+        Wave 3 §3.2 (prereq PR #10 consumer contract): an HTTP 503 carrying
+        the typed-unavailable body is retried once after the server-suggested
+        delay (``Retry-After`` header, falling back to the body's
+        ``retry_after_seconds``), then surfaced as
+        ``GovernanceUnavailableError`` so resident cycle loops can back off
+        with the server's delay instead of guessing.
+        """
         effective_timeout = timeout or self.timeout
         payload = json.dumps({"name": tool_name, "arguments": arguments}).encode()
-        req = urllib.request.Request(
-            self.rest_url,
-            data=payload,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        try:
-            with urllib.request.urlopen(req, timeout=effective_timeout) as resp:
-                data = json.loads(resp.read().decode())
-        except TimeoutError as e:
-            raise GovernanceTimeoutError(
-                f"{tool_name} timed out after {effective_timeout}s"
-            ) from e
-        except urllib.error.URLError as e:
-            if isinstance(getattr(e, "reason", None), TimeoutError):
+
+        data: dict | None = None
+        for attempt in range(2):
+            req = urllib.request.Request(
+                self.rest_url,
+                data=payload,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=effective_timeout) as resp:
+                    data = json.loads(resp.read().decode())
+                break
+            except TimeoutError as e:
                 raise GovernanceTimeoutError(
                     f"{tool_name} timed out after {effective_timeout}s"
                 ) from e
-            raise GovernanceConnectionError(f"REST call to {self.rest_url} failed: {e}") from e
+            except urllib.error.HTTPError as e:
+                if e.code == 503:
+                    retry_after = self._extract_503_retry_after(e)
+                    if attempt == 0:
+                        logger.warning(
+                            "%s unavailable (HTTP 503), retrying in %.1fs",
+                            tool_name, retry_after,
+                        )
+                        time.sleep(retry_after)
+                        continue
+                    raise GovernanceUnavailableError(
+                        f"{tool_name}: governance temporarily unavailable "
+                        f"(retry_after_seconds={retry_after})",
+                        retry_after_seconds=retry_after,
+                    ) from e
+                raise GovernanceConnectionError(
+                    f"REST call to {self.rest_url} failed: {e}"
+                ) from e
+            except urllib.error.URLError as e:
+                if isinstance(getattr(e, "reason", None), TimeoutError):
+                    raise GovernanceTimeoutError(
+                        f"{tool_name} timed out after {effective_timeout}s"
+                    ) from e
+                raise GovernanceConnectionError(f"REST call to {self.rest_url} failed: {e}") from e
+        assert data is not None  # loop either broke with data or raised
 
         if not data.get("success", False):
             error = data.get("error", "Unknown error")
@@ -456,3 +491,18 @@ class SyncGovernanceClient:
         if raw.get("success") is False:
             error = raw.get("error", "Unknown error")
             raise GovernanceConnectionError(f"Tool {tool_name} failed: {error}")
+
+    @staticmethod
+    def _extract_503_retry_after(e: urllib.error.HTTPError) -> float:
+        """Server-suggested delay from a 503: ``Retry-After`` header first,
+        then the §3.2 body's ``retry_after_seconds``, else 5.0 (bounded by
+        the errors-module cap either way)."""
+        retry_after = parse_retry_after_header(e.headers.get("Retry-After"))
+        if retry_after is not None:
+            return retry_after
+        try:
+            body = json.loads(e.read().decode())
+        except Exception:  # noqa: BLE001 — non-JSON 503 body
+            body = None
+        retry_after = extract_retry_after_seconds(body)
+        return retry_after if retry_after is not None else 5.0

--- a/agents/sdk/tests/test_retry_503.py
+++ b/agents/sdk/tests/test_retry_503.py
@@ -1,0 +1,214 @@
+"""Wave 3 §3.2 consumer retry-on-503 — §14 prereq PR #10.
+
+The SDK is the consumer-side surface for the resident agents (Sentinel via
+the async client, Watcher via the sync REST client). Contract: honor the
+``Retry-After`` header OR the typed body's ``retry_after_seconds``, retry
+once, then raise ``GovernanceUnavailableError`` carrying the server delay.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from unitares_sdk.client import GovernanceClient
+from unitares_sdk.errors import (
+    DEFAULT_RETRY_AFTER_SECONDS,
+    MAX_RETRY_AFTER_SECONDS,
+    GovernanceUnavailableError,
+    extract_retry_after_seconds,
+    parse_retry_after_header,
+)
+from unitares_sdk.sync_client import SyncGovernanceClient
+
+
+UNAVAILABLE_BODY = {
+    "ok": False,
+    "error": "governance_temporarily_unavailable",
+    "reason": "handler_dispatch_unavailable",
+    "retry_after_seconds": 5,
+}
+
+
+# --- Detection helpers ---
+
+
+class TestExtractRetryAfterSeconds:
+    def test_typed_body(self):
+        assert extract_retry_after_seconds(UNAVAILABLE_BODY) == 5.0
+
+    def test_requires_the_pinned_error_literal(self):
+        # retry_after_seconds alone is NOT the §3.2 shape — the deep-health
+        # warming-up body also carries it and must not trigger tool retry.
+        assert extract_retry_after_seconds(
+            {"error": "Health snapshot not yet populated", "retry_after_seconds": 5}
+        ) is None
+        assert extract_retry_after_seconds({"retry_after_seconds": 5}) is None
+
+    def test_non_dict(self):
+        assert extract_retry_after_seconds(None) is None
+        assert extract_retry_after_seconds("503") is None
+
+    def test_missing_delay_defaults(self):
+        body = {"ok": False, "error": "governance_temporarily_unavailable"}
+        assert extract_retry_after_seconds(body) == DEFAULT_RETRY_AFTER_SECONDS
+
+    def test_delay_is_capped(self):
+        body = dict(UNAVAILABLE_BODY, retry_after_seconds=86400)
+        assert extract_retry_after_seconds(body) == MAX_RETRY_AFTER_SECONDS
+
+    def test_negative_delay_defaults(self):
+        body = dict(UNAVAILABLE_BODY, retry_after_seconds=-1)
+        assert extract_retry_after_seconds(body) == DEFAULT_RETRY_AFTER_SECONDS
+
+
+class TestParseRetryAfterHeader:
+    def test_delta_seconds(self):
+        assert parse_retry_after_header("5") == 5.0
+        assert parse_retry_after_header(" 2 ") == 2.0
+
+    def test_absent_or_unparseable(self):
+        assert parse_retry_after_header(None) is None
+        assert parse_retry_after_header("Wed, 21 Oct 2026 07:28:00 GMT") is None
+
+    def test_capped(self):
+        assert parse_retry_after_header("3600") == MAX_RETRY_AFTER_SECONDS
+
+
+# --- Async client (Sentinel path) ---
+
+
+def _make_mcp_result(data: dict):
+    content = MagicMock()
+    content.text = json.dumps(data)
+    result = MagicMock()
+    result.isError = False
+    result.content = [content]
+    return result
+
+
+def _make_async_client(session: AsyncMock) -> GovernanceClient:
+    client = GovernanceClient(timeout=5.0, retry_delay=0.01)
+    client._session = session
+    return client
+
+
+class TestAsyncClientRetry503:
+    @pytest.mark.asyncio
+    async def test_retries_once_then_succeeds(self):
+        session = AsyncMock()
+        session.call_tool.side_effect = [
+            _make_mcp_result(UNAVAILABLE_BODY),
+            _make_mcp_result({"success": True, "data": "ok"}),
+        ]
+        client = _make_async_client(session)
+        with patch("unitares_sdk.client.asyncio.sleep", new=AsyncMock()) as sleep:
+            raw = await client.call_tool("knowledge", {"action": "search"})
+        assert raw["data"] == "ok"
+        assert session.call_tool.await_count == 2
+        # Slept the server-suggested delay, not the generic retry_delay.
+        sleep.assert_awaited_once_with(5.0)
+
+    @pytest.mark.asyncio
+    async def test_raises_typed_after_budget(self):
+        session = AsyncMock()
+        session.call_tool.return_value = _make_mcp_result(UNAVAILABLE_BODY)
+        client = _make_async_client(session)
+        with patch("unitares_sdk.client.asyncio.sleep", new=AsyncMock()):
+            with pytest.raises(GovernanceUnavailableError) as exc_info:
+                await client.call_tool("process_agent_update", {"response_text": "x"})
+        assert exc_info.value.retry_after_seconds == 5.0
+        assert session.call_tool.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_plain_failure_payload_untouched(self):
+        # Ordinary tool failures keep the pre-existing single-attempt raise.
+        session = AsyncMock()
+        session.call_tool.return_value = _make_mcp_result(
+            {"success": False, "error": "Tool not found"}
+        )
+        client = _make_async_client(session)
+        from unitares_sdk.errors import GovernanceConnectionError
+
+        with pytest.raises(GovernanceConnectionError, match="Tool not found"):
+            await client.call_tool("bad_tool", {})
+        assert session.call_tool.await_count == 1
+
+
+# --- Sync REST client (Watcher path) ---
+
+
+def _http_503(
+    body: dict | None = None, retry_after_header: str | None = None
+) -> urllib.error.HTTPError:
+    headers = {}
+    if retry_after_header is not None:
+        headers["Retry-After"] = retry_after_header
+    raw = json.dumps(body if body is not None else UNAVAILABLE_BODY).encode()
+    return urllib.error.HTTPError(
+        url="http://127.0.0.1:8767/v1/tools/call",
+        code=503,
+        msg="Service Unavailable",
+        hdrs=headers,  # HTTPError exposes .headers with a dict-like .get
+        fp=io.BytesIO(raw),
+    )
+
+
+def _ok_response(data: dict):
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = json.dumps(data).encode()
+    mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+class TestSyncClientRetry503:
+    @patch("unitares_sdk.sync_client.time.sleep")
+    @patch("unitares_sdk.sync_client.urllib.request.urlopen")
+    def test_retries_once_then_succeeds(self, mock_open, mock_sleep):
+        mock_open.side_effect = [
+            _http_503(retry_after_header="2"),
+            _ok_response({"success": True, "result": {"success": True, "data": "ok"}}),
+        ]
+        client = SyncGovernanceClient(transport="rest")
+        raw = client.call_tool("knowledge", {"action": "search"})
+        assert raw["data"] == "ok"
+        assert mock_open.call_count == 2
+        mock_sleep.assert_called_once_with(2.0)
+
+    @patch("unitares_sdk.sync_client.time.sleep")
+    @patch("unitares_sdk.sync_client.urllib.request.urlopen")
+    def test_raises_typed_after_budget(self, mock_open, mock_sleep):
+        mock_open.side_effect = [_http_503(), _http_503()]
+        client = SyncGovernanceClient(transport="rest")
+        with pytest.raises(GovernanceUnavailableError) as exc_info:
+            client.call_tool("knowledge", {"action": "search"})
+        assert exc_info.value.retry_after_seconds == 5.0
+        assert mock_open.call_count == 2
+
+    @patch("unitares_sdk.sync_client.time.sleep")
+    @patch("unitares_sdk.sync_client.urllib.request.urlopen")
+    def test_body_delay_used_when_header_absent(self, mock_open, mock_sleep):
+        mock_open.side_effect = [
+            _http_503(body=dict(UNAVAILABLE_BODY, retry_after_seconds=3)),
+            _ok_response({"success": True, "result": {"success": True}}),
+        ]
+        client = SyncGovernanceClient(transport="rest")
+        client.call_tool("knowledge", {"action": "search"})
+        mock_sleep.assert_called_once_with(3.0)
+
+    @patch("unitares_sdk.sync_client.urllib.request.urlopen")
+    def test_non_503_http_error_unchanged(self, mock_open):
+        mock_open.side_effect = urllib.error.HTTPError(
+            url="http://x", code=500, msg="boom", hdrs={}, fp=io.BytesIO(b"")
+        )
+        from unitares_sdk.errors import GovernanceConnectionError
+
+        client = SyncGovernanceClient(transport="rest")
+        with pytest.raises(GovernanceConnectionError):
+            client.call_tool("knowledge", {"action": "search"})
+        assert mock_open.call_count == 1

--- a/src/background_tasks.py
+++ b/src/background_tasks.py
@@ -1751,6 +1751,12 @@ def start_all_background_tasks(connection_tracker, set_ready):
     _supervised_create_task(perf_monitor_persist_task(interval_minutes=5.0), name="perf_monitor_persist")
     logger.info("[PERF_PERSIST] Started perf_monitor snapshot persistence (every 5m)")
 
+    # Wave 3 §3.2 cutover 503-rate halt aggregator (§14 prereq PR #10).
+    # Inert unless WAVE3_CUTOVER_503_AGGREGATOR is set; the task logs and
+    # returns immediately when the flag is off.
+    from src.mcp_transport import cutover_503_aggregator_task
+    _supervised_create_task(cutover_503_aggregator_task(), name="cutover_503_aggregator")
+
     _supervised_create_task(periodic_telemetry_rotation(), name="telemetry_rotation")
     _supervised_create_task(periodic_audit_log_rotation(), name="audit_log_rotation")
     _supervised_create_task(periodic_tool_usage_rotation(), name="tool_usage_rotation")

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -859,6 +859,13 @@ async def main():
             server_ready_fn=lambda: SERVER_READY,
             server_version=SERVER_VERSION,
         )
+
+        # === Wave 3 §3.2 numerator capture (§14 prereq PR #10) ===
+        # One measurement.governance_mcp.503_emission row per 503 the
+        # transport returns. Single emission point — the Wave 3 cutover proxy
+        # must NOT emit its own numerator row (see src/mcp_transport.py).
+        from src.mcp_transport import Transport503EmissionMiddleware
+        app.add_middleware(Transport503EmissionMiddleware)
         
         # === Start all background tasks ===
         from src.background_tasks import start_all_background_tasks, stop_all_background_tasks

--- a/src/mcp_transport.py
+++ b/src/mcp_transport.py
@@ -1,0 +1,395 @@
+"""Wave 3 §3.2 transport-side 503 machinery — §14 prereq PR #10.
+
+Spec: ``docs/proposals/beam-wave-3-handler-dispatch.md`` §3.2 step 3 (503
+circuit-breaker for the cutover gap) and §14 row 10. This module is the
+RFC-named single source for:
+
+1. **The typed-unavailable response contract.** ``make_unavailable_body()``
+   builds the pinned §3.2 body ``{"ok": false, "error":
+   "governance_temporarily_unavailable", "reason": ..., "retry_after_seconds":
+   5}``. The Wave 3 cutover proxy and the §4(β) Python-writer fail-fast path
+   both build their 503 responses from here; SDK consumers
+   (``agents/sdk/src/unitares_sdk/errors.py::extract_retry_after_seconds``)
+   detect the same shape. Field names are pinned — clients key on them.
+
+2. **The numerator emission point.** ``Transport503EmissionMiddleware`` writes
+   one ``measurement.governance_mcp.503_emission`` row per 503 the transport
+   returns, payload ``{request_path, error_reason}``. The middleware is the
+   ONLY numerator emitter — the cutover proxy must NOT emit its own row for a
+   503 it returns, or the §3.2 rate double-counts.
+
+3. **The denominator emission helper.** ``spawn_request_accepted_measurement``
+   writes one ``measurement.governance_mcp.request`` row per request accepted
+   for proxying. No caller exists pre-cutover (nothing proxies handler
+   dispatch yet); the Wave 3 implementation wires it at the proxy entry.
+
+4. **The §3.2 sliding-window aggregator.** ``cutover_503_aggregator_task``
+   reads both event counts over the last 60s once per 15s and emits
+   ``coordination_failure.governance_mcp.cutover_503_rate_breach`` when the
+   rate exceeds 1%. Inert by default — gated on the
+   ``WAVE3_CUTOVER_503_AGGREGATOR`` env flag (same shipped-inert posture as
+   the REST strict-identity gate); the cutover runbook flips it.
+
+Numerator and denominator share one source (``audit.coordination_measurements``,
+migration 041), so the rate is restart-recoverable from PG history within the
+60s window — no process-memory counter (§0 item 11).
+
+Constants for both measurement event types live in
+``src/coordination_events.py`` (landed with §14 prereq PR #1); this module
+emits without re-extending them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from typing import Any, Dict, Optional
+
+from src.coordination_events import (
+    COORDINATION_FAILURE_GOVERNANCE_MCP_CUTOVER_503_RATE_BREACH,
+    MEASUREMENT_GOVERNANCE_MCP_503_EMISSION,
+    MEASUREMENT_GOVERNANCE_MCP_REQUEST,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# §3.2 typed-unavailable contract
+# ---------------------------------------------------------------------------
+
+# Pinned by §3.2 step 3 and consumed by SDK retry logic. Do not rename.
+UNAVAILABLE_ERROR = "governance_temporarily_unavailable"
+UNAVAILABLE_REASON_HANDLER_DISPATCH = "handler_dispatch_unavailable"
+UNAVAILABLE_RETRY_AFTER_SECONDS = 5
+
+# §3.2 aggregator parameters (also pinned in the breach-event payload contract
+# in src/coordination_events.py — keep in sync).
+AGGREGATOR_WINDOW_SECONDS = 60
+AGGREGATOR_THRESHOLD = 0.01
+AGGREGATOR_POLL_SECONDS = 15
+
+# Default-off: the aggregator only runs during the Wave 3 cutover/rollback
+# window. The runbook sets this in the server environment and restarts.
+AGGREGATOR_ENV_FLAG = "WAVE3_CUTOVER_503_AGGREGATOR"
+
+
+def make_unavailable_body(
+    reason: str = UNAVAILABLE_REASON_HANDLER_DISPATCH,
+    retry_after_seconds: int = UNAVAILABLE_RETRY_AFTER_SECONDS,
+) -> Dict[str, Any]:
+    """Build the pinned §3.2 503 response body.
+
+    Callers must also set the HTTP ``Retry-After`` header to the same value —
+    §3.2 names both, and clients are allowed to honor either.
+    """
+    return {
+        "ok": False,
+        "error": UNAVAILABLE_ERROR,
+        "reason": reason,
+        "retry_after_seconds": retry_after_seconds,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Measurement-row writes (fire-and-forget, strong task refs)
+# ---------------------------------------------------------------------------
+
+# Same set+discard pattern as ``src/wave3a_beam_proxy.py::_PENDING_WRITES`` —
+# asyncio.create_task returns a weakly-held task and GC can collect it before
+# the write completes (Watcher P001).
+_PENDING_WRITES: "set[asyncio.Task[None]]" = set()
+
+
+async def _write_measurement_row(
+    *,
+    measurement_type: str,
+    request_path: str,
+    status: str,
+    meta: Dict[str, Any],
+) -> None:
+    """Insert one numerator/denominator row into
+    ``audit.coordination_measurements``. Failures swallowed — this channel is
+    observability infrastructure for the §3.2 halt aggregator and a write
+    failure MUST NOT propagate into the response path (mirrors
+    ``wave3a_beam_proxy.py::_write_success_measurement``).
+
+    ``elapsed_ms`` is 0 by contract: these are counter events, not latency
+    samples; the §0(B) latency series lives in ``measurement.lease_plane.*``.
+    """
+    try:
+        from src.db import get_db
+
+        db = get_db()
+        async with db.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO audit.coordination_measurements
+                    (measurement_type, endpoint, elapsed_ms, status, meta)
+                VALUES ($1, $2, $3, $4, $5::jsonb)
+                """,
+                measurement_type,
+                request_path,
+                0,
+                status,
+                json.dumps(meta),
+            )
+    except Exception as exc:  # noqa: BLE001 — observability infra; swallow
+        logger.debug(
+            "[mcp-transport] measurement write failed: %r (type=%s path=%s)",
+            exc,
+            measurement_type,
+            request_path,
+        )
+
+
+def _spawn_write(coro) -> None:
+    """Fire-and-forget a measurement write, keeping a strong task ref."""
+    try:
+        task = asyncio.create_task(coro)
+        _PENDING_WRITES.add(task)
+        task.add_done_callback(_PENDING_WRITES.discard)
+    except Exception as exc:  # noqa: BLE001 — no running loop, etc.
+        coro.close()
+        logger.debug("[mcp-transport] create_task for write failed: %r", exc)
+
+
+def spawn_503_measurement(request_path: str, error_reason: str) -> None:
+    """Emit the §3.2 numerator: one ``measurement.governance_mcp.503_emission``
+    row, payload ``{request_path, error_reason}`` (pinned in
+    src/coordination_events.py)."""
+    _spawn_write(
+        _write_measurement_row(
+            measurement_type=MEASUREMENT_GOVERNANCE_MCP_503_EMISSION,
+            request_path=request_path,
+            status="503",
+            meta={"request_path": request_path, "error_reason": error_reason},
+        )
+    )
+
+
+def spawn_request_accepted_measurement(request_path: str) -> None:
+    """Emit the §3.2 denominator: one ``measurement.governance_mcp.request``
+    row per request accepted for proxying, payload ``{request_path}``.
+
+    Pre-cutover this has no caller — the Wave 3 cutover proxy wires it at its
+    entry point. It ships here so the proxy lands against a tested emitter.
+    """
+    _spawn_write(
+        _write_measurement_row(
+            measurement_type=MEASUREMENT_GOVERNANCE_MCP_REQUEST,
+            request_path=request_path,
+            status="accepted",
+            meta={"request_path": request_path},
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Numerator capture — ASGI middleware
+# ---------------------------------------------------------------------------
+
+
+class Transport503EmissionMiddleware:
+    """Pure-ASGI middleware: emit one numerator row per HTTP 503 returned.
+
+    Watches ``http.response.start`` for status 503, then sniffs the FIRST
+    ``http.response.body`` chunk for a JSON object carrying ``reason`` /
+    ``error`` / ``status`` to attribute the 503 (e.g.
+    ``handler_dispatch_unavailable`` during cutover, ``warming_up`` from the
+    readiness probe). Non-JSON or streaming bodies fall back to
+    ``error_reason="unknown"``. The sniff only runs on 503s, so the hot path
+    is two dict lookups per send event.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request_path = scope.get("path", "")
+        state = {"is_503": False, "emitted": False}
+
+        async def send_wrapper(message):
+            if message.get("type") == "http.response.start":
+                state["is_503"] = message.get("status") == 503
+            elif (
+                message.get("type") == "http.response.body"
+                and state["is_503"]
+                and not state["emitted"]
+            ):
+                state["emitted"] = True
+                spawn_503_measurement(
+                    request_path, _sniff_error_reason(message.get("body"))
+                )
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)
+
+
+def _sniff_error_reason(body: Optional[bytes]) -> str:
+    """Best-effort error_reason from the first 503 body chunk."""
+    if not body:
+        return "unknown"
+    try:
+        parsed = json.loads(body)
+    except Exception:  # noqa: BLE001 — non-JSON body
+        return "unknown"
+    if not isinstance(parsed, dict):
+        return "unknown"
+    for key in ("reason", "error", "status"):
+        value = parsed.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# §3.2 sliding-window aggregator
+# ---------------------------------------------------------------------------
+
+
+async def read_503_window_counts(db) -> tuple[int, int]:
+    """Return ``(count_503, count_request)`` over the trailing
+    ``AGGREGATOR_WINDOW_SECONDS`` from ``audit.coordination_measurements``."""
+    async with db.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT
+                COUNT(*) FILTER (WHERE measurement_type = $1) AS count_503,
+                COUNT(*) FILTER (WHERE measurement_type = $2) AS count_request
+            FROM audit.coordination_measurements
+            WHERE measurement_type IN ($1, $2)
+              AND recorded_at > NOW() - make_interval(secs => $3)
+            """,
+            MEASUREMENT_GOVERNANCE_MCP_503_EMISSION,
+            MEASUREMENT_GOVERNANCE_MCP_REQUEST,
+            float(AGGREGATOR_WINDOW_SECONDS),
+        )
+    return int(row["count_503"]), int(row["count_request"])
+
+
+async def check_503_breach_once(db) -> Optional[Dict[str, Any]]:
+    """One aggregator tick. Returns the breach payload when the §3.2 rate
+    exceeds the threshold (after emitting the breach event), else ``None``.
+
+    A zero denominator means nothing is being proxied in the window — no rate
+    exists, never a breach (§3.2's rate is specifically
+    ``count(503_emission) / count(request)``).
+    """
+    count_503, count_request = await read_503_window_counts(db)
+    if count_request <= 0:
+        return None
+    rate = count_503 / count_request
+    if rate <= AGGREGATOR_THRESHOLD:
+        return None
+
+    # Payload pinned in src/coordination_events.py (§8.4 docstring).
+    payload = {
+        "window_seconds": AGGREGATOR_WINDOW_SECONDS,
+        "rate": rate,
+        "threshold": AGGREGATOR_THRESHOLD,
+        "count_503": count_503,
+        "count_request": count_request,
+    }
+    try:
+        from src.coordination_events import emit_event
+
+        pool = getattr(db, "_pool", None)
+        if pool is None:
+            logger.warning(
+                "[mcp-transport] 503 breach detected but no pool for emit: %s",
+                payload,
+            )
+            return payload
+        await emit_event(
+            pool,
+            service="governance_mcp",
+            event_type=COORDINATION_FAILURE_GOVERNANCE_MCP_CUTOVER_503_RATE_BREACH,
+            payload=payload,
+        )
+    except Exception as exc:  # noqa: BLE001 — breach detection must outlive emit
+        logger.warning(
+            "[mcp-transport] 503 breach emit failed: %r (payload=%s)", exc, payload
+        )
+    logger.error(
+        "[mcp-transport] §3.2 cutover 503-rate breach: %.4f > %.2f "
+        "(%d/%d in %ds window) — halt direction: restore Python writers "
+        "before stopping (stop sign #7)",
+        rate,
+        AGGREGATOR_THRESHOLD,
+        count_503,
+        count_request,
+        AGGREGATOR_WINDOW_SECONDS,
+    )
+    return payload
+
+
+def aggregator_enabled() -> bool:
+    """True when the cutover runbook has armed the aggregator."""
+    return os.environ.get(AGGREGATOR_ENV_FLAG, "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+async def cutover_503_aggregator_task(
+    interval_seconds: float = AGGREGATOR_POLL_SECONDS,
+) -> None:
+    """§3.2 halt aggregator loop. Inert unless ``WAVE3_CUTOVER_503_AGGREGATOR``
+    is set — registered unconditionally at server start so the cutover runbook
+    only has to set the flag and restart, with no code change at cutover time.
+    """
+    if not aggregator_enabled():
+        logger.info(
+            "[mcp-transport] cutover 503 aggregator inert (%s not set)",
+            AGGREGATOR_ENV_FLAG,
+        )
+        return
+
+    logger.info(
+        "[mcp-transport] cutover 503 aggregator armed: window=%ds poll=%.0fs "
+        "threshold=%.2f",
+        AGGREGATOR_WINDOW_SECONDS,
+        interval_seconds,
+        AGGREGATOR_THRESHOLD,
+    )
+    while True:
+        started = time.monotonic()
+        try:
+            from src.db import get_db
+
+            await check_503_breach_once(get_db())
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — keep the watchdog alive
+            logger.warning("[mcp-transport] aggregator tick failed: %r", exc)
+        elapsed = time.monotonic() - started
+        await asyncio.sleep(max(0.0, interval_seconds - elapsed))
+
+
+__all__ = [
+    "AGGREGATOR_ENV_FLAG",
+    "AGGREGATOR_POLL_SECONDS",
+    "AGGREGATOR_THRESHOLD",
+    "AGGREGATOR_WINDOW_SECONDS",
+    "Transport503EmissionMiddleware",
+    "UNAVAILABLE_ERROR",
+    "UNAVAILABLE_REASON_HANDLER_DISPATCH",
+    "UNAVAILABLE_RETRY_AFTER_SECONDS",
+    "check_503_breach_once",
+    "cutover_503_aggregator_task",
+    "aggregator_enabled",
+    "make_unavailable_body",
+    "read_503_window_counts",
+    "spawn_503_measurement",
+    "spawn_request_accepted_measurement",
+]

--- a/tests/test_mcp_transport_503.py
+++ b/tests/test_mcp_transport_503.py
@@ -1,0 +1,263 @@
+"""Wave 3 §3.2 transport-side 503 machinery — §14 prereq PR #10.
+
+Covers src/mcp_transport.py: the pinned typed-unavailable body, the
+numerator-emission middleware, the sliding-window aggregator math, and the
+default-inert flag gating. Spec: docs/proposals/beam-wave-3-handler-dispatch.md
+§3.2 step 3.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.coordination_events import (
+    COORDINATION_FAILURE_GOVERNANCE_MCP_CUTOVER_503_RATE_BREACH,
+    MEASUREMENT_GOVERNANCE_MCP_503_EMISSION,
+    MEASUREMENT_GOVERNANCE_MCP_REQUEST,
+)
+from src.mcp_transport import (
+    AGGREGATOR_THRESHOLD,
+    AGGREGATOR_WINDOW_SECONDS,
+    Transport503EmissionMiddleware,
+    UNAVAILABLE_ERROR,
+    UNAVAILABLE_REASON_HANDLER_DISPATCH,
+    UNAVAILABLE_RETRY_AFTER_SECONDS,
+    _sniff_error_reason,
+    aggregator_enabled,
+    check_503_breach_once,
+    cutover_503_aggregator_task,
+    make_unavailable_body,
+)
+
+
+# --- §3.2 typed-unavailable body contract ---
+
+
+class TestUnavailableBody:
+    def test_pinned_shape(self):
+        body = make_unavailable_body()
+        assert body == {
+            "ok": False,
+            "error": "governance_temporarily_unavailable",
+            "reason": "handler_dispatch_unavailable",
+            "retry_after_seconds": 5,
+        }
+
+    def test_pinned_constants(self):
+        # Clients key on these literals — renaming is a breaking contract change.
+        assert UNAVAILABLE_ERROR == "governance_temporarily_unavailable"
+        assert UNAVAILABLE_REASON_HANDLER_DISPATCH == "handler_dispatch_unavailable"
+        assert UNAVAILABLE_RETRY_AFTER_SECONDS == 5
+
+    def test_custom_reason(self):
+        body = make_unavailable_body(reason="writer_lock_timeout", retry_after_seconds=2)
+        assert body["reason"] == "writer_lock_timeout"
+        assert body["retry_after_seconds"] == 2
+        assert body["error"] == UNAVAILABLE_ERROR
+
+
+# --- error_reason sniffing ---
+
+
+class TestSniffErrorReason:
+    def test_typed_unavailable_body(self):
+        raw = json.dumps(make_unavailable_body()).encode()
+        assert _sniff_error_reason(raw) == "handler_dispatch_unavailable"
+
+    def test_warming_up_body(self):
+        # The readiness probe's pre-existing 503 shape.
+        assert _sniff_error_reason(b'{"status": "warming_up"}') == "warming_up"
+
+    def test_error_key_fallback(self):
+        assert _sniff_error_reason(b'{"error": "tracemalloc not enabled"}') == (
+            "tracemalloc not enabled"
+        )
+
+    @pytest.mark.parametrize("body", [None, b"", b"not json", b"[1,2]", b'{"x": 1}'])
+    def test_unknown_fallbacks(self, body):
+        assert _sniff_error_reason(body) == "unknown"
+
+
+# --- Numerator middleware ---
+
+
+def _make_asgi_app(status: int, body: bytes):
+    async def app(scope, receive, send):
+        await send({"type": "http.response.start", "status": status, "headers": []})
+        await send({"type": "http.response.body", "body": body})
+
+    return app
+
+
+def _http_scope(path: str = "/v1/tools/call") -> dict:
+    return {"type": "http", "path": path, "method": "POST", "headers": []}
+
+
+async def _drive(middleware, scope) -> list[dict]:
+    sent: list[dict] = []
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    await middleware(scope, receive, send)
+    return sent
+
+
+class TestTransport503EmissionMiddleware:
+    @pytest.mark.asyncio
+    async def test_emits_on_503(self):
+        app = _make_asgi_app(503, json.dumps(make_unavailable_body()).encode())
+        middleware = Transport503EmissionMiddleware(app)
+        with patch("src.mcp_transport.spawn_503_measurement") as spawn:
+            sent = await _drive(middleware, _http_scope())
+        spawn.assert_called_once_with(
+            "/v1/tools/call", "handler_dispatch_unavailable"
+        )
+        # Response passes through untouched.
+        assert sent[0]["status"] == 503
+
+    @pytest.mark.asyncio
+    async def test_no_emit_on_200(self):
+        app = _make_asgi_app(200, b'{"ok": true}')
+        middleware = Transport503EmissionMiddleware(app)
+        with patch("src.mcp_transport.spawn_503_measurement") as spawn:
+            await _drive(middleware, _http_scope())
+        spawn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_emits_once_for_multi_chunk_body(self):
+        async def app(scope, receive, send):
+            await send({"type": "http.response.start", "status": 503, "headers": []})
+            await send(
+                {"type": "http.response.body", "body": b'{"reason": "x"}', "more_body": True}
+            )
+            await send({"type": "http.response.body", "body": b"tail"})
+
+        middleware = Transport503EmissionMiddleware(app)
+        with patch("src.mcp_transport.spawn_503_measurement") as spawn:
+            await _drive(middleware, _http_scope())
+        assert spawn.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_non_http_scope_passthrough(self):
+        called = {}
+
+        async def app(scope, receive, send):
+            called["yes"] = True
+
+        middleware = Transport503EmissionMiddleware(app)
+        with patch("src.mcp_transport.spawn_503_measurement") as spawn:
+            await middleware({"type": "websocket"}, None, None)
+        assert called == {"yes": True}
+        spawn.assert_not_called()
+
+
+# --- Aggregator ---
+
+
+def _fake_db(count_503: int, count_request: int):
+    """DB stub whose acquire() yields a conn returning the given counts."""
+
+    conn = AsyncMock()
+    conn.fetchrow.return_value = {
+        "count_503": count_503,
+        "count_request": count_request,
+    }
+
+    class FakeDB:
+        _pool = object()
+
+        @asynccontextmanager
+        async def acquire(self):
+            yield conn
+
+    return FakeDB()
+
+
+class TestCheck503BreachOnce:
+    @pytest.mark.asyncio
+    async def test_zero_denominator_never_breaches(self):
+        with patch("src.coordination_events.emit_event", new=AsyncMock()) as emit:
+            result = await check_503_breach_once(_fake_db(50, 0))
+        assert result is None
+        emit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rate_at_threshold_does_not_breach(self):
+        # Exactly 1% — §3.2 says "exceeds 1%", so equality stays quiet.
+        with patch("src.coordination_events.emit_event", new=AsyncMock()) as emit:
+            result = await check_503_breach_once(_fake_db(1, 100))
+        assert result is None
+        emit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_breach_emits_pinned_payload(self):
+        emit = AsyncMock()
+        with patch("src.coordination_events.emit_event", new=emit):
+            result = await check_503_breach_once(_fake_db(3, 100))
+        assert result == {
+            "window_seconds": AGGREGATOR_WINDOW_SECONDS,
+            "rate": 0.03,
+            "threshold": AGGREGATOR_THRESHOLD,
+            "count_503": 3,
+            "count_request": 100,
+        }
+        emit.assert_awaited_once()
+        kwargs = emit.await_args.kwargs
+        assert kwargs["service"] == "governance_mcp"
+        assert (
+            kwargs["event_type"]
+            == COORDINATION_FAILURE_GOVERNANCE_MCP_CUTOVER_503_RATE_BREACH
+        )
+        assert kwargs["payload"] == result
+
+    @pytest.mark.asyncio
+    async def test_breach_survives_emit_failure(self):
+        # Breach detection must outlive a broken emit channel.
+        emit = AsyncMock(side_effect=RuntimeError("pg down"))
+        with patch("src.coordination_events.emit_event", new=emit):
+            result = await check_503_breach_once(_fake_db(10, 100))
+        assert result is not None
+        assert result["rate"] == 0.1
+
+    @pytest.mark.asyncio
+    async def test_window_query_uses_both_types(self):
+        db = _fake_db(0, 10)
+        async with db.acquire() as conn:
+            pass  # grab the shared conn mock
+        with patch("src.coordination_events.emit_event", new=AsyncMock()):
+            await check_503_breach_once(db)
+        args = conn.fetchrow.await_args.args
+        assert MEASUREMENT_GOVERNANCE_MCP_503_EMISSION in args
+        assert MEASUREMENT_GOVERNANCE_MCP_REQUEST in args
+        assert float(AGGREGATOR_WINDOW_SECONDS) in args
+
+
+class TestAggregatorGating:
+    def test_disabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("WAVE3_CUTOVER_503_AGGREGATOR", raising=False)
+        assert aggregator_enabled() is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "YES", "on"])
+    def test_enabled_values(self, monkeypatch, value):
+        monkeypatch.setenv("WAVE3_CUTOVER_503_AGGREGATOR", value)
+        assert aggregator_enabled() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "", "off"])
+    def test_disabled_values(self, monkeypatch, value):
+        monkeypatch.setenv("WAVE3_CUTOVER_503_AGGREGATOR", value)
+        assert aggregator_enabled() is False
+
+    @pytest.mark.asyncio
+    async def test_task_is_inert_when_flag_off(self, monkeypatch):
+        monkeypatch.delenv("WAVE3_CUTOVER_503_AGGREGATOR", raising=False)
+        # Returns immediately — no DB access, no loop.
+        await asyncio.wait_for(cutover_503_aggregator_task(), timeout=1.0)


### PR DESCRIPTION
## §14 row 10

The last §14 prereq row that is unblocked right now: deps (#1 event-type constants, #6 measurement table + window) are on master, it lands no `elixir/handler_dispatch/` commits (consistent with the V0.3.4 (α) pause recorded in #625), and it doesn't collide with the in-flight drafts — row 4 is blocked on #622's identity surface, row 5 on #619's response envelope, rows 2/7/8 are Wave-3-specific implementation paused until the PR #599 window closes ~2026-06-24.

## What ships

**`src/mcp_transport.py`** (new — the RFC-named module), single source for the §3.2 contract:

- `make_unavailable_body()` — the pinned `{"ok": false, "error": "governance_temporarily_unavailable", "reason": ..., "retry_after_seconds": 5}` body. The cutover proxy and the §4(β) writer fail-fast build from here; SDK detection keys on the same literal.
- **Numerator**: `Transport503EmissionMiddleware` (pure ASGI, wired in `mcp_server.py`) writes one `measurement.governance_mcp.503_emission` row per 503 the transport returns, payload `{request_path, error_reason}` (reason sniffed from the first body chunk — typed cutover bodies and the readiness `warming_up` shape both attribute cleanly). Single emission point by design: the future proxy must not emit its own numerator row, or the rate double-counts.
- **Denominator**: `spawn_request_accepted_measurement` for the cutover proxy to call at its entry. No pre-cutover caller — §0 item 11's "per request accepted for proxying" has no referent until Wave 3 wires the proxy.
- **Aggregator**: 60s window / 15s poll / >1% breach → `coordination_failure.governance_mcp.cutover_503_rate_breach` with the payload pinned in `src/coordination_events.py`. Zero denominator = no rate, never a breach. Counts read from PG each tick, so the rate is restart-recoverable (§0 item 11 — no process-memory counter). Registered in `start_all_background_tasks` but **inert unless `WAVE3_CUTOVER_503_AGGREGATOR` is set** — same shipped-inert posture as the REST strict-identity gate; the cutover runbook sets the flag and restarts.

**Consumer retry (the §3.2 client retry policy), per named consumer in this repo:**

- `unitares_sdk` async client (Sentinel's path): typed-payload detection after parse + HTTP-layer 503 `Retry-After`; one retry at the server-suggested delay, then a typed `GovernanceUnavailableError` carrying `retry_after_seconds` so cycle loops can back off honestly.
- `unitares_sdk` sync REST client (Watcher's path): same contract at the `urlopen` layer; header first, body fallback.
- `agents/common/findings.py::post_finding`: one retry capped at 5s (agent-cycle hot path), still never raises.
- Detection requires the pinned error literal — bare `retry_after_seconds` does NOT trigger retry (the deep-health warming-up body also carries that field). Server-suggested delays bounded at 30s so a bad `Retry-After` can't park a resident.

**Cross-repo consumers** named by §3.2 but not in this repo: dispatch worker (Discord bridge) and plugin SessionStart paths — follow-ups in their own repos.

## What this deliberately does NOT do

- No edits to `beam-wave-3-handler-dispatch.md` or `beam-footprint-roadmap-v0.md` — #625 holds those single-writer docs in flight; the §14 row-10 status fold should land there or after it.
- No Wave 3a surface changes — `measurement.wave_3a.*` and `measurement.governance_mcp.*` stay separate families per the constants block.

## Verification

- New: 30 transport tests (`tests/test_mcp_transport_503.py`), 16 SDK retry tests (`agents/sdk/tests/test_retry_503.py`), 3 `post_finding` tests.
- Touched suites green: `agents/` 601 passed (1 pre-existing container failure, `test_extract_regions_works_against_real_repo` — real `git commit` rejected by this container's git, identical on a clean tree, same as documented in #623), coordination-events + lease-plane transport suites, smoke 138 passed.
- Full gate deferred to CI per AGENTS.md (remote container has no Postgres/AGE).

https://claude.ai/code/session_01HacXKPmg5MvV2aZEBeFrxF

---
_Generated by [Claude Code](https://claude.ai/code/session_01HacXKPmg5MvV2aZEBeFrxF)_