### PR TITLE
[codex] add agent workflow aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ Additional services (started via launchd, not bundled into `docker compose up`):
 | Gateway MCP (reduced surface) | `8768` | `http://localhost:8768/mcp/` |
 | Surface lease plane (bearer-auth) | `8788` | `http://localhost:8788/v1/lease/*` |
 
-**Workflow:** `onboard(force_new=true)` → `process_agent_update()` → `get_governance_metrics()`. Use `parent_agent_id` for fresh-process lineage — details in [Getting Started](docs/guides/START_HERE.md).
+**Workflow:** `start_session(force_new=true)` → `sync_state()` → `check_working_state()`. These are first-class aliases for `onboard`, `process_agent_update`, and `get_governance_metrics`. Use `parent_agent_id` for fresh-process lineage — details in [Getting Started](docs/guides/START_HERE.md).
+
+**Resident agents:** for long-running or scheduled agents, start with the SDK in [`agents/sdk/README.md`](agents/sdk/README.md). It handles MCP connection, identity anchors, check-ins, heartbeats, log rotation, state persistence, and pause hooks.
 
 **Transports:** MCP on `/mcp/` (Streamable HTTP) · REST on `/v1/tools/call` · Dashboard on `/dashboard`
 
@@ -91,7 +93,7 @@ Additional services (started via launchd, not bundled into `docker compose up`):
 
 ```python
 # Inside the agent's loop
-result = process_agent_update(response_text=output, complexity=0.6, confidence=0.8)
+result = sync_state(response_text=output, complexity=0.6, confidence=0.8)
 
 if result["metrics"]["integrity"] < 0.4:
     agent.require_human_review("integrity low — pausing autonomous actions")
@@ -170,15 +172,15 @@ Frozen public snapshot from May 6, 2026 (single-operator deployment — self-tra
 ## Quick Start
 
 ```
-1. onboard(force_new=true)      → Get a fresh process identity
-2. process_agent_update()       → Log your work
-3. get_governance_metrics()     → Check your state
+1. start_session(force_new=true) → Get a fresh process identity
+2. sync_state()                  → Log your work
+3. check_working_state()         → Check your state
 ```
 
 Example check-in (non-mirror responses include full `metrics`, `decision`, etc.):
 
 ```jsonc
-process_agent_update({
+sync_state({
   "response_text": "Refactored auth module, added rate limiting",
   "complexity": 0.6,
   "confidence": 0.8,
@@ -187,26 +189,30 @@ process_agent_update({
 })
 ```
 
-**`response_mode: "mirror"`** shapes the payload for self-awareness: `mirror` is a **list of strings** (actionable signals), not a nested object. Optional top-level `question` and `relevant_prior_work` surface a targeted nudge and knowledge-graph items when relevant. See `_format_mirror` in [`src/mcp_handlers/response_formatter.py`](src/mcp_handlers/response_formatter.py).
+**`response_mode: "mirror"`** shapes the payload for self-awareness: `mirror` is a **list of strings** (actionable signals), not a nested object. Optional top-level `reflection` and `relevant_prior_work` surface a state reflection and knowledge-graph items when relevant. See `_format_mirror` in [`src/mcp_handlers/response_formatter.py`](src/mcp_handlers/response_formatter.py).
 
 ```jsonc
 {
-  "verdict": "proceed",
+  "verdict": {
+    "value": "proceed",
+    "meaning": "State is healthy.",
+    "next_action": "Continue working normally."
+  },
   "_mode": "mirror",
   "mirror": [
     "Fleet calibration: 72% accuracy over 12 fleet-wide decisions (high-conf: 0.8, low-conf: 0.5)",
     "Complexity divergence: you reported 0.60 but system derives 0.45 (divergence=0.15)"
   ],
-  "question": "What's driving your sense of difficulty?",
+  "reflection": "Complexity estimate is diverging from the output-surface proxy.",
   "relevant_prior_work": [
     { "summary": "Rate limiter bypass in auth …", "by": "agent-abc", "relevance": 0.82 }
   ]
 }
 ```
 
-**Verdict field:** Responses expose `verdict` from `decision.action`. Governance actions are **`proceed` / `guide` / `pause` / `reject`** ([Architecture](docs/UNIFIED_ARCHITECTURE.md)). If `action` is absent, formatters fall back to **`continue`** — see `response_formatter.py`.
+**Verdict field:** Mirror/compact responses wrap the verdict with `value`, `meaning`, and `next_action`. Governance actions are **`proceed` / `guide` / `pause` / `reject`** ([Architecture](docs/UNIFIED_ARCHITECTURE.md)). If `action` is absent, formatters fall back to **`continue`** — see `response_formatter.py`.
 
-The `onboard()` response includes `agent_uuid`. Store it as an identity anchor. On a fresh process that continues prior work, call `onboard(force_new=true, parent_agent_id=<prior uuid>, spawn_reason="new_session")`. Use `identity(agent_uuid=..., continuity_token=..., resume=true)` only for same-owner proof-owned rebinds.
+The `start_session()` / `onboard()` response includes `agent_uuid`. Store it as an identity anchor. On a fresh process that continues prior work, call `start_session(force_new=true, parent_agent_id=<prior uuid>, spawn_reason="new_session")`. Use `identity(agent_uuid=..., continuity_token=..., resume=true)` only for same-owner proof-owned rebinds.
 
 ### Installation
 

--- a/docs/guides/START_HERE.md
+++ b/docs/guides/START_HERE.md
@@ -12,16 +12,27 @@ Use this unless you have a specific reason not to:
 4. Call `get_governance_metrics()` for state
 5. Use `identity(agent_uuid=<uuid>, continuity_token=<token>, resume=true)` only for same-owner proof-owned rebinds
 
+Agent-facing workflow aliases are also registered:
+
+| Job | Workflow alias | Canonical tool |
+| --- | --- | --- |
+| Start working | `start_session(force_new=true, ...)` | `onboard` |
+| Check in after meaningful work | `sync_state(response_text=..., complexity=...)` | `process_agent_update` |
+| Check current state | `check_working_state()` | `get_governance_metrics` |
+| Search shared memory | `search_shared_memory(query=...)` | `knowledge(action="search")` |
+| Record a real outcome | `record_result(...)` | `outcome_event` |
+| Ask for review | `request_review(issue_description=...)` | `dialectic(action="request")` |
+
 ```python
 # First run:
-result = onboard(force_new=True)
+result = start_session(force_new=True)
 save_to_file(result["uuid"])
 
 # New process inheriting prior work:
-onboard(force_new=True, parent_agent_id=saved_uuid, spawn_reason="new_session")
+start_session(force_new=True, parent_agent_id=saved_uuid, spawn_reason="new_session")
 
 # After work:
-process_agent_update(response_text="What you did", complexity=0.5)
+sync_state(response_text="What you did", complexity=0.5)
 ```
 
 ## Identity Rule

--- a/docs/integration/MCP_CLIENTS.md
+++ b/docs/integration/MCP_CLIENTS.md
@@ -34,6 +34,15 @@ Claude Desktop does not support `type: http` natively; use `mcp-remote` as a std
 
 Agents self-identify through `onboard()`; no hardcoded agent-name header is required.
 
+Agent-facing workflow aliases are registered for the core loop:
+
+- `start_session(...)` → `onboard(...)`
+- `sync_state(...)` → `process_agent_update(...)`
+- `check_working_state(...)` → `get_governance_metrics(...)`
+- `search_shared_memory(...)` → `knowledge(action="search", ...)`
+- `record_result(...)` → `outcome_event(...)`
+- `request_review(...)` → `dialectic(action="request", ...)`
+
 ## Endpoints
 
 | Endpoint | Transport | Use case |
@@ -55,7 +64,7 @@ See [`scripts/ops/`](../../scripts/ops/) for an example LaunchAgent plist with b
 
 ## Agent Identity
 
-For a fresh process, call `onboard(force_new=true)`. If the process is continuing prior work, call `onboard(force_new=true, parent_agent_id=<prior uuid>, spawn_reason="new_session")`.
+For a fresh process, call `start_session(force_new=true)` / `onboard(force_new=true)`. If the process is continuing prior work, call `start_session(force_new=true, parent_agent_id=<prior uuid>, spawn_reason="new_session")`.
 
 For a same-owner rebind to an existing UUID, call `identity(agent_uuid=..., continuity_token=..., resume=true)` with the matching short-lived token. Do not teach clients to use bare `identity(agent_uuid=..., resume=true)`: UUID alone is an unsigned claim and is hijack-shaped under strict identity mode.
 

--- a/skills/governance-lifecycle/SKILL.md
+++ b/skills/governance-lifecycle/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Use when an agent is interacting with UNITARES governance for the first time, needs to
   onboard, check in, or recover from a pause/reject verdict. Covers the full agent lifecycle
   from session start through check-ins to recovery.
-last_verified: "2026-04-25"
+last_verified: "2026-06-11"
 freshness_days: 14
 source_files:
   - unitares/src/mcp_handlers/core.py
@@ -14,15 +14,30 @@ source_files:
 
 # Agent Lifecycle
 
-**Last Updated:** 2026-05-01
+**Last Updated:** 2026-06-11
+
+## Friendly Workflow Names
+
+Current UNITARES servers expose task-verb aliases for the core agent workflow.
+Prefer them when you want the most agent-readable response shape; use the
+canonical names when you need legacy/raw compatibility.
+
+| Job | Friendly alias | Canonical tool |
+| --- | --- | --- |
+| Start working | `start_session(force_new=true, ...)` | `onboard` |
+| Check in after meaningful work | `sync_state(response_text=..., complexity=...)` | `process_agent_update` |
+| Check your working state | `check_working_state()` | `get_governance_metrics` |
+| Avoid duplicate work | `search_shared_memory(query=...)` | `knowledge(action="search")` |
+| Record what actually happened | `record_result(...)` | `outcome_event` |
+| Ask for a structured review | `request_review(issue_description=...)` | `dialectic(action="request")` |
 
 ## Starting a Session
 
 Choose creation, lineage, or proof-owned resume explicitly:
 
 ~~~text
-onboard(force_new=true)                                              # first run / fresh process
-onboard(force_new=true, parent_agent_id="<prior-uuid>",
+start_session(force_new=true)                                        # first run / fresh process
+start_session(force_new=true, parent_agent_id="<prior-uuid>",
         spawn_reason="new_session")                                  # fresh process inheriting prior work
 identity(agent_uuid="<uuid>", continuity_token="<token>", resume=true) # same live owner / proof-owned rebind
 ~~~
@@ -39,8 +54,8 @@ Returns:
 
 Default rules:
 
-1. Fresh first run: call `onboard(force_new=true)`.
-2. New process continuing prior work: call `onboard(force_new=true, parent_agent_id="<prior-uuid>", spawn_reason="new_session")`.
+1. Fresh first run: call `start_session(force_new=true)`.
+2. New process continuing prior work: call `start_session(force_new=true, parent_agent_id="<prior-uuid>", spawn_reason="new_session")`.
 3. Same live process or explicit ownership rebind: call `identity(agent_uuid="<uuid>", continuity_token="<token>", resume=true)`.
 4. Ordinary check-ins: pass `continuity_token` when available, otherwise rely on the active session binding.
 
@@ -54,10 +69,10 @@ Avoid these patterns:
 
 ## Check-ins
 
-Call `process_agent_update()` after meaningful work:
+Call `sync_state()` after meaningful work:
 
 ~~~text
-process_agent_update(
+sync_state(
   response_text: "Brief summary of what you did",
   complexity: 0.0-1.0,   # Task difficulty estimate
   confidence: 0.0-1.0    # How confident you are (be honest)
@@ -118,12 +133,12 @@ Recovery is not a shortcut — `self_recovery()` examines your EISV state and de
 
 ### Essential (use in every session)
 
-- `onboard(force_new=true, parent_agent_id=...)` — Create a fresh process identity, optionally declaring lineage
-- `process_agent_update()` — Check in with work summary, complexity, confidence
-- `get_governance_metrics()` — Read your current EISV state
+- `start_session(force_new=true, parent_agent_id=...)` / `onboard(...)` — Create a fresh process identity, optionally declaring lineage
+- `sync_state()` / `process_agent_update()` — Check in with work summary, complexity, confidence
+- `check_working_state()` / `get_governance_metrics()` — Read your current EISV state
 - `identity()` — Confirm who the runtime thinks you are and how continuity was resolved; include `continuity_token` for proof-owned UUID rebinds
 - `health_check()` — Check operator-facing server health when behavior seems odd
-- `knowledge(action="search", ...)` — Find existing knowledge before creating new entries
+- `search_shared_memory(query=...)` / `knowledge(action="search", ...)` — Find existing knowledge before creating new entries
 - `knowledge(action="note", ...)` — Quick contribution to the knowledge graph
 
 ### Common (use when needed)

--- a/src/mcp_handlers/introspection/tool_introspection.py
+++ b/src/mcp_handlers/introspection/tool_introspection.py
@@ -143,27 +143,31 @@ def _getting_started_path() -> List[Dict[str, Any]]:
     return [
         {
             "step": 1,
-            "tool": "onboard",
-            "call": "onboard(force_new=true)",
+            "tool": "start_session",
+            "call": "start_session(force_new=true)",
+            "canonical_tool": "onboard",
             "why": "Mint a fresh process identity. If continuing prior work, include parent_agent_id and spawn_reason='new_session'.",
         },
         {
             "step": 2,
-            "tool": "process_agent_update",
-            "call": "process_agent_update(response_text='what changed', complexity=0.5, confidence=0.7)",
+            "tool": "sync_state",
+            "call": "sync_state(response_text='what changed', complexity=0.5, confidence=0.7)",
+            "canonical_tool": "process_agent_update",
             "why": "Record meaningful work and receive a governance verdict.",
         },
         {
             "step": 3,
-            "tool": "get_governance_metrics",
-            "call": "get_governance_metrics()",
+            "tool": "check_working_state",
+            "call": "check_working_state()",
+            "canonical_tool": "get_governance_metrics",
             "why": "Inspect current EISV state without mutating history.",
         },
         {
             "step": 4,
-            "tool": "knowledge",
-            "call": "knowledge(action='search', query='topic') or knowledge(action='note', content='short note')",
-            "why": "Reuse shared memory before writing; leave lightweight notes when useful.",
+            "tool": "search_shared_memory",
+            "call": "search_shared_memory(query='topic')",
+            "canonical_tool": "knowledge(action='search')",
+            "why": "Reuse shared memory before writing duplicate discoveries.",
         },
         {
             "step": 5,
@@ -201,7 +205,8 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     
     # Get actual registered tools from TOOL_HANDLERS registry
     from src.mcp_handlers import TOOL_HANDLERS
-    registered_tool_names = sorted(TOOL_HANDLERS.keys())
+    from ..tool_stability import AGENT_WORKFLOW_ALIASES
+    registered_tool_names = sorted(set(TOOL_HANDLERS.keys()) | set(AGENT_WORKFLOW_ALIASES))
     
     # Parse filter parameters (handle string booleans from MCP transport)
     essential_only = coerce_bool(arguments.get("essential_only"), False)
@@ -218,10 +223,40 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     # Deprecated tools - hidden from list_tools by default
     # Source of truth: tool_stability.py (aliases handle routing)
     from ..tool_stability import list_all_aliases
-    DEPRECATED_TOOLS = set(list_all_aliases().keys())
+    DEPRECATED_TOOLS = set(list_all_aliases().keys()) - set(AGENT_WORKFLOW_ALIASES)
 
     # Define tool relationships and workflows
     tool_relationships = {
+        "start_session": {
+            "depends_on": [],
+            "related_to": ["onboard", "identity"],
+            "category": "identity",
+        },
+        "sync_state": {
+            "depends_on": [],
+            "related_to": ["process_agent_update", "check_working_state"],
+            "category": "core",
+        },
+        "check_working_state": {
+            "depends_on": [],
+            "related_to": ["get_governance_metrics", "sync_state"],
+            "category": "core",
+        },
+        "search_shared_memory": {
+            "depends_on": [],
+            "related_to": ["knowledge", "leave_note"],
+            "category": "knowledge",
+        },
+        "record_result": {
+            "depends_on": ["sync_state"],
+            "related_to": ["outcome_event", "process_agent_update"],
+            "category": "core",
+        },
+        "request_review": {
+            "depends_on": ["sync_state"],
+            "related_to": ["dialectic", "self_recovery"],
+            "category": "dialectic",
+        },
         "process_agent_update": {
             "depends_on": [],  # No deps - identity auto-creates
             "related_to": ["simulate_update", "get_governance_metrics", "get_system_history"],
@@ -606,6 +641,12 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     # Build tools list dynamically from registered tools
     # Description mapping for tools (fallback to generic if not found)
     tool_descriptions = {
+        "start_session": "Start a UNITARES session; alias for onboard(force_new=true, parent_agent_id=...)",
+        "sync_state": "Check in after meaningful work; alias for process_agent_update(...)",
+        "check_working_state": "Read current EISV state without mutating history; alias for get_governance_metrics()",
+        "search_shared_memory": "Search shared memory before writing; alias for knowledge(action='search')",
+        "record_result": "Record real task/tool/test outcome; alias for outcome_event(...)",
+        "request_review": "Ask for structured review/recovery; alias for dialectic(action='request')",
         "onboard": "Register fresh process-instance with governance. Per v2 ontology, declare lineage via parent_agent_id rather than resume via token.",
         "identity": "🪞 Check who you are or set your display name. Per v2 ontology, arg-less identity() with no proof signal mints fresh; pass continuity_token / agent_uuid + proof to resume.",
         "process_agent_update": "💬 Share your work and get supportive feedback. Your main check-in tool",
@@ -795,9 +836,14 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
             lite_tools = [lite_tools_dict[name] for name in ordered_lite_names if name in lite_tools_dict]
         else:
             # Default workflow order
-            order = ["onboard", "identity", "process_agent_update", "get_governance_metrics",
-                     "list_tools", "describe_tool", "list_agents", "health_check",
-                     "store_knowledge_graph", "search_knowledge_graph", "leave_note"]
+            order = [
+                "start_session", "sync_state", "check_working_state",
+                "search_shared_memory", "record_result", "request_review",
+                "onboard", "identity", "process_agent_update",
+                "get_governance_metrics", "list_tools", "describe_tool",
+                "agent", "knowledge", "dialectic", "health_check",
+                "store_knowledge_graph", "search_knowledge_graph", "leave_note",
+            ]
             lite_tools.sort(key=lambda x: order.index(x["name"]) if x["name"] in order else 99)
         
         # Group by category for better organization
@@ -861,13 +907,20 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
             },
             # Quick workflows (v2.5.0+) - progressive disclosure
             "workflows": {
-                "new_agent": ["onboard(force_new=true)", "process_agent_update(response_text='...', complexity=0.5)", "agent(action='list') or list_agents()"],
-                "check_in": ["process_agent_update(response_text='...', complexity=0.5)"],
+                "new_agent": ["start_session(force_new=true)", "sync_state(response_text='...', complexity=0.5)", "agent(action='list')"],
+                "check_in": ["sync_state(response_text='...', complexity=0.5)"],
                 "save_insight": ["knowledge(action='note', content='...')", "OR knowledge(action='store', summary='...', tags=[...])"],
-                "find_info": ["knowledge(action='search', query='...')", "OR knowledge(action='search', tags=[...])"]
+                "find_info": ["search_shared_memory(query='...')", "OR knowledge(action='search', tags=[...])"],
+                "recover": ["request_review(issue_description='...')", "OR self_recovery(action='review', reflection='...')"],
             },
             # Common signatures (type hints at a glance)
             "signatures": {
+                "start_session": "(force_new:bool=true, parent_agent_id?:str, spawn_reason?:str)",
+                "sync_state": "(response_text?:str, complexity?:float, confidence?:float, task_type?:str)",
+                "check_working_state": "(lite?:bool, include_state?:bool)",
+                "search_shared_memory": "(query?:str, tags?:list, limit?:int, include_details?:bool)",
+                "record_result": "(outcome_type:str, confidence?:float, prediction_id?:str, detail?:dict)",
+                "request_review": "(issue_description:str, reason?:str)",
                 "process_agent_update": "(complexity:float, response_text?:str, confidence?:float, task_type?:str)",
                 "store_knowledge_graph": "(summary:str, tags?:list, severity?:str, details?:str)",
                 "search_knowledge_graph": "(query?:str, tags?:list, limit?:int, include_details?:bool)",
@@ -876,7 +929,7 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
             },
             "more": "list_tools(lite=false) for all tools with full category details",
             "tip": "describe_tool(tool_name=...) for parameter details and examples",
-            "quick_start": "Start fresh with onboard(force_new=true); use parent_agent_id for lineage, not bare UUID resume",
+            "quick_start": "Start fresh with start_session(force_new=true); use parent_agent_id for lineage, not bare UUID resume",
             "getting_started_path": _getting_started_path(),
             "essential_toolkit": _essential_toolkit(),
         }
@@ -1168,8 +1221,8 @@ async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextConten
     Shows only required params + key optional params with simple examples.
     """
     try:
-        tool_name = (arguments.get("tool_name") or "").strip()
-        if not tool_name:
+        requested_tool_name = (arguments.get("tool_name") or "").strip()
+        if not requested_tool_name:
             return [error_response(
                 "tool_name is required",
                 recovery={
@@ -1183,22 +1236,68 @@ async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextConten
         # LITE-FIRST: Simpler schemas by default for local models
         lite = arguments.get("lite", True)
 
-        from src.tool_schemas import get_tool_definitions
-        tools = get_tool_definitions(verbosity="full")
-        tool = next((t for t in tools if t.name == tool_name), None)
-        if tool is None:
+        from ..tool_stability import resolve_tool_alias
+        tool_name, alias_info = resolve_tool_alias(requested_tool_name)
+
+        from src.tool_descriptions import TOOL_DESCRIPTIONS
+        from src.tool_schemas import get_pydantic_schemas
+
+        schema_model = get_pydantic_schemas().get(tool_name)
+        tool_schema = None
+        if schema_model is not None:
+            tool_schema = schema_model.model_json_schema()
+            description = TOOL_DESCRIPTIONS.get(tool_name) or schema_model.__doc__ or f"Tool: {tool_name}"
+        else:
+            # Fallback for decorator-defined/plugin tools that are not backed
+            # by a Pydantic Params model. Avoid rebuilding every Tool object
+            # just to describe one name.
+            from ..decorators import get_tool_definition
+
+            definition = get_tool_definition(tool_name)
+            if definition is not None:
+                description = definition.description or TOOL_DESCRIPTIONS.get(tool_name) or f"Tool: {tool_name}"
+                tool_schema = {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": True,
+                }
+            else:
+                # Compatibility path for test/plugin tool objects that are
+                # only discoverable through the MCP Tool schema builder. The
+                # common Pydantic path above still avoids rebuilding the full
+                # registry for normal describe_tool calls.
+                from src.tool_schemas import get_tool_definitions
+
+                description = None
+                for candidate in get_tool_definitions():
+                    if candidate.name == tool_name:
+                        description = (
+                            candidate.description
+                            or TOOL_DESCRIPTIONS.get(tool_name)
+                            or f"Tool: {tool_name}"
+                        )
+                        tool_schema = candidate.inputSchema or {
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": True,
+                        }
+                        break
+
+        if tool_schema is None:
             return [error_response(
                 f"Unknown tool: {tool_name}",
                 recovery={
                     "action": "Call list_tools to see available tool names",
                     "related_tools": ["list_tools"],
                 },
-                context={"tool_name": tool_name},
+                context={
+                    "tool_name": requested_tool_name,
+                    "resolved_tool_name": tool_name,
+                },
             )]
 
-        description = tool.description
         if not include_full_description:
-            description = (tool.description or "").splitlines()[0].strip() if tool.description else ""
+            description = (description or "").splitlines()[0].strip() if description else ""
 
         # Helper function to get common patterns (shared between both branches)
         def get_common_patterns(tool_name: str) -> dict:
@@ -1208,6 +1307,30 @@ async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextConten
                         "basic": "process_agent_update(complexity=0.5)  # identity auto-injected",
                         "with_response": "process_agent_update(response_text=\"Fixed bug\", complexity=0.3, confidence=0.9)",
                         "task_type": "process_agent_update(complexity=0.7, task_type=\"divergent\")"
+                    },
+                    "start_session": {
+                        "fresh": "start_session(force_new=true)",
+                        "lineage": "start_session(force_new=true, parent_agent_id=\"...\", spawn_reason=\"new_session\")",
+                    },
+                    "sync_state": {
+                        "basic": "sync_state(response_text=\"Fixed bug\", complexity=0.3, confidence=0.9)",
+                        "mirror": "sync_state(response_text=\"Finished task\", complexity=0.5, response_mode=\"mirror\")",
+                    },
+                    "check_working_state": {
+                        "basic": "check_working_state()",
+                        "full": "check_working_state(lite=false)",
+                    },
+                    "search_shared_memory": {
+                        "by_query": "search_shared_memory(query=\"identity continuity\", limit=5)",
+                        "with_details": "search_shared_memory(query=\"calibration\", include_details=true)",
+                    },
+                    "record_result": {
+                        "test_passed": "record_result(outcome_type=\"test_passed\", confidence=0.8)",
+                        "linked": "record_result(outcome_type=\"task_completed\", prediction_id=\"...\", detail={\"summary\":\"...\"})",
+                    },
+                    "request_review": {
+                        "recovery": "request_review(issue_description=\"Paused after conflicting evidence\")",
+                        "with_reason": "request_review(issue_description=\"Need adversarial review\", reason=\"uncertain root cause\")",
                     },
                     "store_knowledge_graph": {
                         "insight": "store_knowledge_graph(summary=\"Key insight about X\", tags=[\"insight\"])",
@@ -1266,10 +1389,9 @@ async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextConten
             # Try Pydantic schema first for structured lite output
             lite_schema = None
             try:
-                from src.tool_schemas import get_pydantic_schemas
-                pydantic_model = get_pydantic_schemas().get(tool_name)
+                pydantic_model = schema_model
                 if pydantic_model:
-                    schema = pydantic_model.model_json_schema()
+                    schema = tool_schema or pydantic_model.model_json_schema()
                     properties = schema.get("properties", {})
                     required_fields = schema.get("required", [])
 
@@ -1325,7 +1447,7 @@ async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextConten
                 params_simple = lite_schema["params_simple"]
 
                 # Get common patterns
-                common_patterns = get_common_patterns(tool_name)
+                common_patterns = get_common_patterns(requested_tool_name) or get_common_patterns(tool_name)
 
                 # Get parameter aliases for discoverability
                 from ..validators import PARAM_ALIASES
@@ -1334,9 +1456,10 @@ async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextConten
                 # UX FIX (Feb 2026): Add tier information to help agents understand tool complexity
                 from src.tool_modes import TOOL_TIERS, TOOL_OPERATIONS
                 tool_tier = "common"  # Default
-                if tool_name in TOOL_TIERS["essential"]:
+                tier_lookup_name = requested_tool_name if alias_info else tool_name
+                if tier_lookup_name in TOOL_TIERS["essential"] or tool_name in TOOL_TIERS["essential"]:
                     tool_tier = "essential"
-                elif tool_name in TOOL_TIERS["advanced"]:
+                elif tier_lookup_name in TOOL_TIERS["advanced"] or tool_name in TOOL_TIERS["advanced"]:
                     tool_tier = "advanced"
 
                 tier_guidance = {
@@ -1346,14 +1469,22 @@ async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextConten
                 }
 
                 response_data = {
-                    "tool": tool_name,
+                    "tool": requested_tool_name,
                     "description": (description or "").splitlines()[0].strip(),
                     "tier": tool_tier,
                     "tier_note": tier_guidance.get(tool_tier, ""),
-                    "operation": TOOL_OPERATIONS.get(tool_name, "read"),  # read/write/admin
+                    "operation": TOOL_OPERATIONS.get(tier_lookup_name, TOOL_OPERATIONS.get(tool_name, "read")),  # read/write/admin
                     "parameters": params_simple,
                     "note": "Lite mode - use describe_tool(tool_name=..., lite=false) for full schema"
                 }
+                if alias_info:
+                    response_data["canonical_tool"] = tool_name
+                    response_data["alias"] = {
+                        "reason": alias_info.reason,
+                        "canonical_tool": alias_info.new_name,
+                        "injected_action": alias_info.inject_action,
+                        "note": alias_info.migration_note,
+                    }
 
                 deprecation = _describe_tool_deprecation_block(tool_name)
                 if deprecation is not None:
@@ -1371,7 +1502,7 @@ async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextConten
                 return success_response(response_data)
             else:
                 # Fallback: extract from inputSchema
-                schema = tool.inputSchema or {}
+                schema = tool_schema or {}
                 properties = schema.get("properties", {})
                 required = schema.get("required", [])
                 
@@ -1394,18 +1525,26 @@ async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextConten
                     params_simple.append(f"... and {total_optional - shown_count} more (use lite=false for full schema)")
                 
                 # Get common patterns using shared helper
-                common_patterns = get_common_patterns(tool_name)
+                common_patterns = get_common_patterns(requested_tool_name) or get_common_patterns(tool_name)
 
                 # Get parameter aliases for discoverability
                 from ..validators import PARAM_ALIASES
                 tool_aliases = PARAM_ALIASES.get(tool_name, {})
 
                 response_data = {
-                    "tool": tool_name,
+                    "tool": requested_tool_name,
                     "description": (description or "").splitlines()[0].strip(),
                     "parameters": params_simple,
                     "note": "Lite mode - use describe_tool(tool_name=..., lite=false) for full schema"
                 }
+                if alias_info:
+                    response_data["canonical_tool"] = tool_name
+                    response_data["alias"] = {
+                        "reason": alias_info.reason,
+                        "canonical_tool": alias_info.new_name,
+                        "injected_action": alias_info.inject_action,
+                        "note": alias_info.migration_note,
+                    }
 
                 deprecation = _describe_tool_deprecation_block(tool_name)
                 if deprecation is not None:
@@ -1423,11 +1562,19 @@ async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextConten
 
         full_response: Dict[str, Any] = {
             "tool": {
-                "name": tool.name,
+                "name": requested_tool_name,
                 "description": description,
-                "inputSchema": tool.inputSchema if include_schema else None,
+                "inputSchema": tool_schema if include_schema else None,
             }
         }
+        if alias_info:
+            full_response["tool"]["canonical_name"] = tool_name
+            full_response["alias"] = {
+                "reason": alias_info.reason,
+                "canonical_tool": alias_info.new_name,
+                "injected_action": alias_info.inject_action,
+                "note": alias_info.migration_note,
+            }
         deprecation = _describe_tool_deprecation_block(tool_name)
         if deprecation is not None:
             full_response["deprecation"] = deprecation

--- a/src/mcp_handlers/tool_stability.py
+++ b/src/mcp_handlers/tool_stability.py
@@ -52,6 +52,66 @@ class ToolLifecycle:
 # This prevents breaking existing code/agents
 
 _TOOL_ALIASES: Dict[str, ToolAlias] = {
+    # Agent workflow aliases — first-class UX names for the core loop.
+    # These are intentionally advertised/registered, unlike most historical
+    # compatibility aliases, so cold MCP agents can discover task verbs.
+    "start_session": ToolAlias(
+        old_name="start_session",
+        new_name="onboard",
+        reason="intuitive_alias",
+        migration_note=(
+            "Workflow alias for onboard(force_new=true, parent_agent_id=...). "
+            "Starts a fresh process identity or declares lineage."
+        ),
+    ),
+    "sync_state": ToolAlias(
+        old_name="sync_state",
+        new_name="process_agent_update",
+        reason="intuitive_alias",
+        migration_note=(
+            "Workflow alias for process_agent_update(response_text='...', "
+            "complexity=..., confidence=...)."
+        ),
+    ),
+    "check_working_state": ToolAlias(
+        old_name="check_working_state",
+        new_name="get_governance_metrics",
+        reason="intuitive_alias",
+        migration_note=(
+            "Workflow alias for get_governance_metrics(). Reads current EISV "
+            "state without writing a check-in."
+        ),
+    ),
+    "search_shared_memory": ToolAlias(
+        old_name="search_shared_memory",
+        new_name="knowledge",
+        reason="intuitive_alias",
+        migration_note=(
+            "Workflow alias for knowledge(action='search', query='...'). "
+            "Search shared memory before writing a duplicate discovery."
+        ),
+        inject_action="search",
+    ),
+    "record_result": ToolAlias(
+        old_name="record_result",
+        new_name="outcome_event",
+        reason="intuitive_alias",
+        migration_note=(
+            "Workflow alias for outcome_event(...). Records the real outcome "
+            "of a task, test, tool call, or external validation signal."
+        ),
+    ),
+    "request_review": ToolAlias(
+        old_name="request_review",
+        new_name="dialectic",
+        reason="intuitive_alias",
+        migration_note=(
+            "Workflow alias for dialectic(action='request', "
+            "issue_description='...'). Starts structured review/recovery."
+        ),
+        inject_action="request",
+    ),
+
     # Identity tools - all point to identity() (the primary identity tool)
     # NOTE: who_am_i has its own handler in admin.py, so NOT aliased
     #
@@ -315,6 +375,16 @@ for alias in _TOOL_ALIASES.values():
         _ALIAS_REVERSE[alias.new_name] = []
     _ALIAS_REVERSE[alias.new_name].append(alias.old_name)
 
+
+AGENT_WORKFLOW_ALIASES: tuple[str, ...] = (
+    "start_session",
+    "sync_state",
+    "check_working_state",
+    "search_shared_memory",
+    "record_result",
+    "request_review",
+)
+
 # ============================================================================
 # Tool Stability Registry
 # ============================================================================
@@ -401,4 +471,3 @@ def register_extra_aliases(aliases: Dict[str, ToolAlias]) -> None:
                 f"'{_TOOL_ALIASES[old_name].new_name}'"
             )
         _TOOL_ALIASES[old_name] = alias
-

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -514,10 +514,16 @@ auto_register_all_tools()
 # agents can use intuitive names like status() without "Unknown tool" errors.
 
 def _register_common_aliases():
-    from src.mcp_handlers.tool_stability import resolve_tool_alias
-    from src.mcp_handlers.support.wrapper_generator import create_typed_wrapper
+    from src.mcp_handlers.tool_stability import (
+        AGENT_WORKFLOW_ALIASES,
+        resolve_tool_alias,
+    )
+    from src.mcp_handlers.support.wrapper_generator import (
+        create_typed_wrapper,
+        enable_extra_argument_passthrough,
+    )
 
-    common = ["status", "list_agents", "observe_agent"]
+    common = list(AGENT_WORKFLOW_ALIASES)
     count = 0
     for alias_name in common:
         actual, info = resolve_tool_alias(alias_name)
@@ -572,6 +578,15 @@ def _register_common_aliases():
             )
             desc = f"{info.migration_note or f'Alias for {actual}'}"
             mcp.tool(description=desc, structured_output=False)(wrapper)
+            if actual in EXTRA_ARGUMENT_PASSTHROUGH_TOOLS:
+                tool_manager = getattr(mcp, "_tool_manager", None)
+                registered_tool = (
+                    tool_manager.get_tool(alias_name)
+                    if tool_manager and hasattr(tool_manager, "get_tool")
+                    else None
+                )
+                if registered_tool is not None:
+                    enable_extra_argument_passthrough(registered_tool)
             count += 1
         except Exception as e:
             logger.debug(f"[ALIAS] Failed to register {alias_name}: {e}")
@@ -579,7 +594,7 @@ def _register_common_aliases():
     if count:
         logger.info(f"[AUTO_REGISTER] Registered {count} common aliases")
 
-# _register_common_aliases()  # Removed: aliases inflate tool count; use consolidated forms
+_register_common_aliases()
 
 # ============================================================================
 # LEGACY MANUAL REGISTRATIONS (kept for reference, will be removed)

--- a/src/tool_modes.py
+++ b/src/tool_modes.py
@@ -19,6 +19,10 @@ TOOL_MODE = os.getenv("GOVERNANCE_TOOL_MODE", "lite").lower()
 
 # Minimal mode: Essential tools + list_tools for discovery
 MINIMAL_MODE_TOOLS: Set[str] = {
+    # Agent workflow aliases (task verbs over canonical implementation names)
+    "start_session",
+    "sync_state",
+    "check_working_state",
     "onboard",                # 🚀 Portal tool - call this FIRST (Dec 2025)
     "identity",               # Check/set identity (auto-creates on first call)
     "process_agent_update",   # Log your work (ongoing)
@@ -31,6 +35,14 @@ MINIMAL_MODE_TOOLS: Set[str] = {
 # THIS IS THE SINGLE SOURCE OF TRUTH - admin.py imports from here
 # Updated Feb 2026: Use consolidated tools to reduce cognitive load
 LITE_MODE_TOOLS: Set[str] = {
+    # Agent workflow aliases (visible, first-class UX names)
+    "start_session",              # Alias for onboard
+    "sync_state",                 # Alias for process_agent_update
+    "check_working_state",        # Alias for get_governance_metrics
+    "search_shared_memory",       # Alias for knowledge(action='search')
+    "record_result",              # Alias for outcome_event
+    "request_review",             # Alias for dialectic(action='request')
+
     # Core governance
     "process_agent_update",       # Log agent work
     "get_governance_metrics",     # Check agent state
@@ -120,6 +132,12 @@ OPERATOR_RECOVERY_MODE_TOOLS: Set[str] = OPERATOR_READONLY_MODE_TOOLS | {
 # ============================================================================
 TOOL_TIERS: dict[str, Set[str]] = {
     "essential": {  # Tier 1: Core workflow tools (~10 tools)
+        "start_session",          # Workflow alias for onboard
+        "sync_state",             # Workflow alias for process_agent_update
+        "check_working_state",    # Workflow alias for get_governance_metrics
+        "search_shared_memory",   # Workflow alias for knowledge(search)
+        "record_result",          # Workflow alias for outcome_event
+        "request_review",         # Workflow alias for dialectic(request)
         "onboard",                # 🚀 Portal tool - call FIRST (Dec 2025)
         "identity",               # Primary identity tool (auto-creates on first call)
         "process_agent_update",   # Log agent work
@@ -184,6 +202,14 @@ TOOL_TIERS: dict[str, Set[str]] = {
 # admin: System administration (may read or write internal state)
 # ============================================================================
 TOOL_OPERATIONS: dict[str, str] = {
+    # Agent workflow aliases
+    "start_session": "read",
+    "sync_state": "write",
+    "check_working_state": "read",
+    "search_shared_memory": "read",
+    "record_result": "write",
+    "request_review": "write",
+
     # Identity & Onboarding
     "onboard": "read",                    # Returns identity + templates (creates if new)
     "identity": "read",                   # Returns identity (creates if new)
@@ -265,11 +291,15 @@ TOOL_OPERATIONS: dict[str, str] = {
 # Tool categories for selective loading (excludes deprecated tools)
 TOOL_CATEGORIES = {
     "core": {
+        "sync_state",
+        "check_working_state",
+        "record_result",
         "process_agent_update",
         "get_governance_metrics",
         "simulate_update",
     },
     "identity": {
+        "start_session",
         "onboard",                # Dec 2025: Portal tool - call FIRST
         "identity",               # Dec 2025: Primary identity tool (auto-creates on first call)
         "list_agents",
@@ -308,6 +338,7 @@ TOOL_CATEGORIES = {
         "aggregate_metrics",
     },
     "knowledge": {
+        "search_shared_memory",
         "store_knowledge_graph",   # Primary: add knowledge (handles responses via response_to)
         "get_discovery_details",   # Drill into discovery (includes related/chain)
         "leave_note",
@@ -316,6 +347,7 @@ TOOL_CATEGORIES = {
         "get_lifecycle_stats",       # Lifecycle statistics (Dec 2025)
     },
     "dialectic": {
+        "request_review",
         "request_dialectic_review",      # Create dialectic session
         "submit_thesis",                 # Paused agent explains reasoning
         "submit_antithesis",             # Reviewer raises concerns

--- a/tests/test_action_level_identity.py
+++ b/tests/test_action_level_identity.py
@@ -96,6 +96,16 @@ def test_legacy_alias_canonicalizes_with_injected_action():
     assert get_call_identity_requirement("list_agents", {}) == "pre_onboard"
 
 
+def test_workflow_alias_identity_classification_matches_canonical_calls():
+    assert get_call_identity_requirement("start_session", {"force_new": True}) == "pre_onboard"
+    assert get_call_identity_requirement("check_working_state", {}) == "pre_onboard"
+    assert get_call_identity_requirement("search_shared_memory", {}) == "pre_onboard"
+
+    assert get_call_identity_requirement("sync_state", {}) == "required"
+    assert get_call_identity_requirement("record_result", {}) == "required"
+    assert get_call_identity_requirement("request_review", {}) == "required"
+
+
 def test_legacy_write_alias_stays_required():
     """A write-implying alias (request_dialectic_review →
     dialectic(request)) must NOT inherit read treatment."""

--- a/tests/test_admin_handlers.py
+++ b/tests/test_admin_handlers.py
@@ -513,7 +513,7 @@ class TestDescribeTool:
         with patch("src.tool_schemas.get_tool_definitions",
                     side_effect=ImportError("module not found")):
             from src.mcp_handlers.introspection.tool_introspection import handle_describe_tool
-            result = await handle_describe_tool({"tool_name": "health_check"})
+            result = await handle_describe_tool({"tool_name": "custom_error_tool"})
 
             data = parse_result(result)
             assert data["success"] is False
@@ -1805,7 +1805,7 @@ class TestListTools:
             assert data["success"] is True
             assert "tools" in data
             assert data["shown"] > 0
-            assert data["getting_started_path"][0]["tool"] == "onboard"
+            assert data["getting_started_path"][0]["tool"] == "start_session"
             assert data["essential_toolkit"]["preferred_consolidated_tools"]["dialectic"].startswith("Use action='quick'")
 
     @pytest.mark.asyncio
@@ -1850,7 +1850,7 @@ class TestListTools:
             assert "categories" in data
             assert "workflows" in data
             assert "tool_map" in data
-            assert data["getting_started"]["path"][0]["tool"] == "onboard"
+            assert data["getting_started"]["path"][0]["tool"] == "start_session"
             assert "knowledge" in data["getting_started"]["essential_toolkit"]["preferred_consolidated_tools"]
             assert data["total_tools"] >= 0
 

--- a/tests/test_describe_tool_drift.py
+++ b/tests/test_describe_tool_drift.py
@@ -80,6 +80,47 @@ async def test_process_agent_update_lite_mentions_current_parameters():
 
 
 @pytest.mark.asyncio
+async def test_workflow_alias_describe_resolves_to_canonical_schema():
+    import json
+    from src.mcp_handlers.introspection.tool_introspection import handle_describe_tool
+
+    result = await handle_describe_tool({"tool_name": "sync_state", "lite": True})
+    data = json.loads(result[0].text)
+    params = "\n".join(data["parameters"])
+
+    assert data["tool"] == "sync_state"
+    assert data["canonical_tool"] == "process_agent_update"
+    assert data["alias"]["reason"] == "intuitive_alias"
+    assert "response_text" in params
+    assert "complexity" in params
+    assert "confidence" in params
+    assert "sync_state(" in json.dumps(data["common_patterns"])
+
+
+@pytest.mark.asyncio
+async def test_list_tools_lite_surfaces_workflow_aliases():
+    import json
+    from src.mcp_handlers.introspection.tool_introspection import handle_list_tools
+
+    result = await handle_list_tools({"essential_only": True, "lite": True})
+    data = json.loads(result[0].text)
+    names = [tool["name"] for tool in data["tools"]]
+
+    for alias in (
+        "start_session",
+        "sync_state",
+        "check_working_state",
+        "search_shared_memory",
+        "record_result",
+        "request_review",
+    ):
+        assert alias in names
+
+    assert data["getting_started_path"][0]["tool"] == "start_session"
+    assert data["getting_started_path"][1]["tool"] == "sync_state"
+
+
+@pytest.mark.asyncio
 async def test_outcome_event_lite_mentions_calibration_parameters():
     import json
     from src.mcp_handlers.introspection.tool_introspection import handle_describe_tool


### PR DESCRIPTION
## Summary
- add first-class workflow aliases for the core agent loop: start_session, sync_state, check_working_state, search_shared_memory, record_result, request_review
- make list_tools and describe_tool alias-aware, including a faster single-tool describe path
- update onboarding docs and lifecycle skill to teach aliases first while keeping canonical tools documented

## Validation
- python3 -m pytest -q tests/test_describe_tool_drift.py tests/test_action_level_identity.py
- python3 -c "import src.mcp_server as s; aliases=('start_session','sync_state','check_working_state','search_shared_memory','record_result','request_review'); missing=[name for name in aliases if s.mcp._tool_manager.get_tool(name) is None]; print('missing_aliases=', missing)"
- make test-smoke
- pre-push hook: 138 passed, doc health all clear