### PR TITLE
fix(anomalies): emit-on-change dedup so frozen-window risk_spikes stop re-firing

### DIFF
--- a/src/event_detector.py
+++ b/src/event_detector.py
@@ -179,6 +179,16 @@ class GovernanceEventDetector:
         # Key: fingerprint string. Value: datetime of last emit.
         self._recent_fingerprints: Dict[str, datetime] = {}
         self._dedup_window_seconds: int = 1800  # 30 minutes
+        # Change-token dedup for *persisting* conditions (emit-on-change).
+        # Key: fingerprint string. Value: last-emitted change token.
+        # Unlike the time window above, this suppression does NOT lapse with
+        # elapsed time — only when the underlying data changes. This is the
+        # correct dedup for a frozen condition: an idle agent's one-time
+        # historical risk_spike must not re-fire every sweep once the 30-min
+        # window elapses (see project_stale-history-riskspike-refire). Bounded
+        # by (#agents x #condition types) ever seen; capped below.
+        self._change_tokens: Dict[str, str] = {}
+        self._max_change_tokens: int = 5000
 
     def seed_known_agents(self, agents: list[tuple[str, str]]) -> int:
         """Pre-populate _prev_state so known agents don't fire agent_new after restart.
@@ -386,6 +396,14 @@ class GovernanceEventDetector:
         seen inside ``_dedup_window_seconds`` are dropped (returns None) so
         periodic re-emitters like Sentinel do not flood Discord.
 
+        If the caller supplies a ``change_token``, dedup switches to
+        emit-on-change: the event is dropped whenever the token equals the last
+        token emitted for this fingerprint, with NO time component. This is the
+        correct behavior for persisting/frozen conditions — e.g. an idle agent
+        whose one-time historical risk_spike would otherwise re-fire every sweep
+        once the 30-minute window lapses. A token-bearing event emits exactly
+        once per distinct underlying condition, however many sweeps observe it.
+
         Stamps ``event_id`` and ``timestamp`` in-place and returns the stored dict.
         """
         fingerprint = event.get("fingerprint")
@@ -393,18 +411,31 @@ class GovernanceEventDetector:
             return None
 
         now = datetime.now(timezone.utc)
-        last_seen = self._recent_fingerprints.get(fingerprint)
-        if last_seen is not None:
-            age_seconds = (now - last_seen).total_seconds()
-            if age_seconds < self._dedup_window_seconds:
+        change_token = event.get("change_token")
+        if change_token is not None:
+            # Emit-on-change path: time-independent suppression of an unchanged
+            # persisting condition. Keyed purely on whether the data moved.
+            if self._change_tokens.get(fingerprint) == change_token:
                 return None
+            self._change_tokens[fingerprint] = change_token
+            if len(self._change_tokens) > self._max_change_tokens:
+                # Drop ~10% oldest by insertion order to bound memory.
+                drop = max(1, self._max_change_tokens // 10)
+                for stale_fp in list(self._change_tokens)[:drop]:
+                    del self._change_tokens[stale_fp]
+        else:
+            last_seen = self._recent_fingerprints.get(fingerprint)
+            if last_seen is not None:
+                age_seconds = (now - last_seen).total_seconds()
+                if age_seconds < self._dedup_window_seconds:
+                    return None
 
-        # Sweep fingerprints older than 2x window so the dict does not grow forever
-        cutoff = now - timedelta(seconds=2 * self._dedup_window_seconds)
-        self._recent_fingerprints = {
-            fp: ts for fp, ts in self._recent_fingerprints.items() if ts > cutoff
-        }
-        self._recent_fingerprints[fingerprint] = now
+            # Sweep fingerprints older than 2x window so the dict does not grow forever
+            cutoff = now - timedelta(seconds=2 * self._dedup_window_seconds)
+            self._recent_fingerprints = {
+                fp: ts for fp, ts in self._recent_fingerprints.items() if ts > cutoff
+            }
+            self._recent_fingerprints[fingerprint] = now
 
         if "timestamp" not in event:
             event["timestamp"] = now.isoformat()

--- a/src/mcp_handlers/observability/handlers.py
+++ b/src/mcp_handlers/observability/handlers.py
@@ -637,6 +637,27 @@ async def handle_compare_me_to_similar(arguments: Dict[str, Any]) -> Sequence[Te
     
     return success_response(comparison_data)
 
+def anomaly_change_token(anomaly: Dict[str, Any]) -> str:
+    """Emit-on-change dedup token for a persisting anomaly.
+
+    Keyed on the data the anomaly was computed from — its type, agent, the
+    full-precision context values, and the newest analyzed sample's timestamp —
+    NOT on the human-readable description. This means the token advances exactly
+    when a new state sample lands: a frozen/idle history yields an identical
+    token every evaluation (suppressed), while a genuine recovery-then-respike
+    produces a new timestamp and therefore a new token (emitted), even if the
+    rounded values happen to match. Deliberately independent of the description
+    f-string so message-format edits can never silently re-fire the idle fleet.
+    """
+    import hashlib
+    ctx = anomaly.get("context") or {}
+    ctx_repr = "|".join(f"{k}={ctx[k]}" for k in sorted(ctx))
+    basis = (
+        f"{anomaly.get('type')}|{anomaly.get('agent_id')}|"
+        f"{anomaly.get('timestamp')}|{ctx_repr}"
+    )
+    return hashlib.sha256(basis.encode()).hexdigest()[:16]
+
 @mcp_tool("detect_anomalies", timeout=15.0, register=False)
 async def handle_detect_anomalies(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """Detect anomalies across agents"""
@@ -735,6 +756,7 @@ async def handle_detect_anomalies(arguments: Dict[str, Any]) -> Sequence[TextCon
             ).hexdigest()[:16]
             stored = event_detector.record_event({
                 "fingerprint": fp,
+                "change_token": anomaly_change_token(a),
                 "type": a.get("type"),
                 "severity": a.get("severity"),
                 "agent_id": a.get("agent_id"),

--- a/tests/test_event_detector.py
+++ b/tests/test_event_detector.py
@@ -232,3 +232,85 @@ class TestRecordEvent:
                                           "agent_id": "x", "agent_name": "n", "fingerprint": "fp"})
         assert "timestamp" in stored
         assert stored["timestamp"].endswith("+00:00") or stored["timestamp"].endswith("Z")
+
+    def test_change_token_suppresses_unchanged_condition_across_window(self, monkeypatch):
+        """A frozen/persisting condition (same change_token) must NOT re-emit even
+        after the time window lapses. This is the stale-history risk_spike bug:
+        an idle agent's one-time spike re-fired every 30-min sweep. Emit-on-change
+        suppression is time-independent, so the time jump must not resurrect it."""
+        from datetime import datetime, timedelta, timezone
+        detector = GovernanceEventDetector(max_stored_events=10)
+        t0 = datetime(2026, 6, 12, 1, 0, 0, tzinfo=timezone.utc)
+
+        class FakeDatetime:
+            @staticmethod
+            def now(tz=None):
+                return FakeDatetime._current
+            _current = t0
+
+        monkeypatch.setattr("src.event_detector.datetime", FakeDatetime)
+        FakeDatetime._current = t0
+        first = detector.record_event({
+            "type": "risk_spike", "severity": "medium",
+            "message": "m", "agent_id": "idle", "agent_name": "n",
+            "fingerprint": "fp", "change_token": "tok_033_055",
+        })
+        # Three sweeps, each well past the 30-min window — the frozen window
+        # yields the identical token every time and must stay suppressed.
+        suppressed = []
+        for mins in (31, 62, 120):
+            FakeDatetime._current = t0 + timedelta(minutes=mins)
+            suppressed.append(detector.record_event({
+                "type": "risk_spike", "severity": "medium",
+                "message": "m", "agent_id": "idle", "agent_name": "n",
+                "fingerprint": "fp", "change_token": "tok_033_055",
+            }))
+        assert first is not None
+        assert all(s is None for s in suppressed)
+        assert len(detector.get_recent_events(limit=10)) == 1
+
+    def test_change_token_emits_when_condition_changes(self):
+        """When the underlying data moves, the token changes and the event emits."""
+        detector = GovernanceEventDetector(max_stored_events=10)
+        first = detector.record_event({
+            "type": "risk_spike", "severity": "medium", "message": "m",
+            "agent_id": "a", "agent_name": "n",
+            "fingerprint": "fp", "change_token": "tok_v1",
+        })
+        same = detector.record_event({
+            "type": "risk_spike", "severity": "medium", "message": "m",
+            "agent_id": "a", "agent_name": "n",
+            "fingerprint": "fp", "change_token": "tok_v1",
+        })
+        changed = detector.record_event({
+            "type": "risk_spike", "severity": "high", "message": "m2",
+            "agent_id": "a", "agent_name": "n",
+            "fingerprint": "fp", "change_token": "tok_v2",
+        })
+        assert first is not None
+        assert same is None
+        assert changed is not None
+        assert len(detector.get_recent_events(limit=10)) == 2
+
+    def test_token_and_tokenless_paths_coexist(self):
+        """Token-less events keep the original time-window dedup; token events do
+        not pollute that path (backward compatibility)."""
+        detector = GovernanceEventDetector(max_stored_events=10)
+        a = detector.record_event({"type": "t", "severity": "info", "message": "m",
+                                    "agent_id": "x", "agent_name": "n", "fingerprint": "tl"})
+        a_dup = detector.record_event({"type": "t", "severity": "info", "message": "m",
+                                       "agent_id": "x", "agent_name": "n", "fingerprint": "tl"})
+        assert a is not None
+        assert a_dup is None  # time-window dedup still active for token-less
+
+    def test_change_tokens_dict_is_bounded(self):
+        """The change-token map must not grow unbounded across many agents."""
+        detector = GovernanceEventDetector(max_stored_events=10)
+        detector._max_change_tokens = 50
+        for i in range(120):
+            detector.record_event({
+                "type": "risk_spike", "severity": "medium", "message": "m",
+                "agent_id": f"agent_{i}", "agent_name": "n",
+                "fingerprint": f"fp_{i}", "change_token": f"tok_{i}",
+            })
+        assert len(detector._change_tokens) <= detector._max_change_tokens

--- a/tests/test_observability_handlers.py
+++ b/tests/test_observability_handlers.py
@@ -916,6 +916,49 @@ class TestHandleCompareMeToSimilar:
 # handle_detect_anomalies
 # ---------------------------------------------------------------------------
 
+class TestAnomalyChangeToken:
+    """The emit-on-change dedup token must key on data, not the description string."""
+
+    def _anomaly(self, *, ts, prev=0.33, cur=0.55, agent="a", typ="risk_spike"):
+        return {
+            "type": typ,
+            "agent_id": agent,
+            "timestamp": ts,
+            "description": f"Risk increased from {prev:.2f} to {cur:.2f}",
+            "context": {"previous_risk": prev, "current_risk": cur, "change": cur - prev},
+        }
+
+    def test_frozen_history_yields_stable_token(self):
+        from src.mcp_handlers.observability.handlers import anomaly_change_token
+        a = self._anomaly(ts="2026-06-11T15:25:00")
+        # Same underlying data evaluated twice (e.g. two sweeps over a frozen
+        # idle agent) must produce an identical token -> suppressed downstream.
+        assert anomaly_change_token(a) == anomaly_change_token(dict(a))
+
+    def test_recover_then_respike_to_same_values_emits(self):
+        from src.mcp_handlers.observability.handlers import anomaly_change_token
+        # Identical rounded values, but a NEW newest-sample timestamp (the agent
+        # recovered and genuinely re-spiked). Token must differ so it is NOT
+        # silently suppressed — the over-suppression failure mode.
+        first = self._anomaly(ts="2026-06-11T15:25:00")
+        respike = self._anomaly(ts="2026-06-12T09:00:00")
+        assert anomaly_change_token(first) != anomaly_change_token(respike)
+
+    def test_token_independent_of_description_wording(self):
+        from src.mcp_handlers.observability.handlers import anomaly_change_token
+        a = self._anomaly(ts="2026-06-11T15:25:00")
+        b = dict(a, description="completely different wording, same data")
+        # A future edit to the description f-string must not change the token
+        # (else every idle agent re-fires once on deploy).
+        assert anomaly_change_token(a) == anomaly_change_token(b)
+
+    def test_distinct_agents_get_distinct_tokens(self):
+        from src.mcp_handlers.observability.handlers import anomaly_change_token
+        a = self._anomaly(ts="2026-06-11T15:25:00", agent="a")
+        b = self._anomaly(ts="2026-06-11T15:25:00", agent="b")
+        assert anomaly_change_token(a) != anomaly_change_token(b)
+
+
 class TestHandleDetectAnomalies:
     """Tests for handle_detect_anomalies."""
 


### PR DESCRIPTION
## Symptom
An idle-but-active agent's one-time historical \`risk_spike\` re-fired to the #signals Discord channel **every ~30 min**, identical each time (caught via a screenshot of \`pdf-merge-helper\` spiking 0.33→0.55 repeatedly).

## Root cause
- \`detect_anomalies_in_history\` (\`src/pattern_analysis.py\`) flags a spike on \`mean(last 3) − mean(prior 3) > 0.15\`, with **no reference to sample recency**. For a frozen idle history the same spike recomputes forever.
- \`event_detector.record_event\` deduped by \`fingerprint=type|agent_id\` within \`_dedup_window_seconds = 1800\`. \`detect_anomalies\` is polled ad-hoc (dashboard \`/api/events\` chain). Once 1800s lapsed, the identical frozen spike re-emitted → bridge → Discord. The 30-min cadence was the **window lapsing**, not a scheduled sweep (confirmed via live-verifier).

## Fix (emission layer)
Add a \`change_token\` path to \`record_event\`: when present, suppression is **time-independent** — the event drops while the token equals the last token emitted for that fingerprint, and emits when it changes. A persisting condition therefore emits **once per distinct underlying state**, however many evaluations observe it.

\`anomaly_change_token(anomaly)\` derives the token from the anomaly's \`type\`, \`agent_id\`, full-precision \`context\` values, and the **newest analyzed sample's \`timestamp\`** — deliberately **not** the human description string. Consequences:
- Frozen idle window → identical token → suppressed (fixes the bug).
- Genuine recover-then-respike → new \`timestamp\` → new token → **emits** (no over-suppression, even if rounded values match).
- Editing the description f-string can never silently re-fire the idle fleet.

## Scope / follow-up
This is the emission-layer fix that stops the operator-visible Discord spam, and is legitimate defense-in-depth. The **detector still manufactures the stale anomaly** for consumers that bypass \`record_event\` (\`observe\`, dashboards). The detector-layer freshness guard — plus a \`change_token\` for Sentinel's \`post_finding\` persisting path — is tracked in **#637**.

## Council
3-agent adversarial review (code-reviewer / live-verifier / dialectic). Both blocking findings addressed: (1) token re-keyed off data not the description string; (2) detector-layer leak filed as #637 and referenced. Live-verifier confirmed \`record_event\` is the single choke point for \`risk_spike\` → Discord and no other emit path was missed.

## Tests
\`tests/test_event_detector.py\`: change_token suppresses an unchanged condition across the time window, emits on change, coexists with token-less time-window dedup, memory-bounded. \`tests/test_observability_handlers.py::TestAnomalyChangeToken\`: frozen→stable, recover-respike→differs, description-wording→invariant, distinct-agents→distinct. Full gate green locally: 9421 passed, 35 skipped, 80.19% cov.

## Operator note
The triggering identity (\`pdf-merge-helper\`) was archived manually to stop the live alerts immediately; this PR prevents the whole class for any idle agent.