### PR TITLE
test: drift-guard for list_tools agent-experience alias discoverability

### DIFF
--- a/src/mcp_handlers/tool_stability.py
+++ b/src/mcp_handlers/tool_stability.py
@@ -507,6 +507,20 @@ def is_experience_alias(tool_name: str) -> bool:
     alias = _TOOL_ALIASES.get(tool_name)
     return bool(alias and alias.experience)
 
+
+def experience_alias_map() -> Dict[str, str]:
+    """Friendly experience-alias name -> canonical tool name.
+
+    Single source for the discoverability surfaces (list_tools catalog)
+    so the advertised friendly names can never drift from the registry.
+    """
+    return {
+        name: alias.new_name
+        for name, alias in _TOOL_ALIASES.items()
+        if alias.experience
+    }
+
+
 def list_all_aliases() -> Dict[str, ToolAlias]:
     """Get all tool aliases (for admin/debugging)"""
     return _TOOL_ALIASES.copy()

--- a/tests/test_list_tools_workflow_aliases.py
+++ b/tests/test_list_tools_workflow_aliases.py
@@ -1,0 +1,66 @@
+"""Drift-guard: the list_tools catalog must keep advertising every
+agent-experience alias, and each must resolve to a real tool.
+
+The friendly task-verb names (start_session, sync_state, ...) are
+surfaced for in-band discovery across the catalog's lite `signatures`
+and full tool list. Those are hand-maintained strings; this guard pins
+them to the registry (`experience_alias_map`) so a future alias rename
+or removal fails here instead of silently dropping a name from
+discovery while the registry still routes it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+import src.mcp_handlers.core  # noqa: F401  (settle handler registration)
+import src.mcp_handlers.consolidated  # noqa: F401
+import src.mcp_handlers.identity.handlers  # noqa: F401
+
+from src.mcp_handlers.introspection.tool_introspection import handle_list_tools
+from src.mcp_handlers.tool_stability import experience_alias_map, resolve_tool_alias
+
+
+def _catalog(arguments: dict) -> dict:
+    return json.loads(asyncio.run(handle_list_tools(arguments))[0].text)
+
+
+def _tool_names(obj, acc: set) -> set:
+    """Collect every advertised tool name in the (nested) full catalog."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if k == "name" and isinstance(v, str):
+                acc.add(v)
+            _tool_names(v, acc)
+    elif isinstance(obj, list):
+        for x in obj:
+            _tool_names(x, acc)
+    return acc
+
+
+def test_experience_aliases_discoverable_in_lite_catalog():
+    friendly = set(experience_alias_map())
+    signatures = set(_catalog({"lite": True}).get("signatures", {}))
+    missing = friendly - signatures
+    assert not missing, f"experience aliases absent from lite signatures: {sorted(missing)}"
+
+
+def test_experience_aliases_discoverable_in_full_catalog():
+    friendly = set(experience_alias_map())
+    advertised = _tool_names(_catalog({"lite": False}), set())
+    missing = friendly - advertised
+    assert not missing, f"experience aliases absent from full catalog: {sorted(missing)}"
+
+
+def test_every_advertised_alias_resolves_to_a_registered_tool():
+    """No dead discovery entries: each friendly name the catalog advertises
+    must resolve to a registered canonical handler."""
+    from src.mcp_handlers import TOOL_HANDLERS
+
+    for friendly, canonical in experience_alias_map().items():
+        resolved, alias = resolve_tool_alias(friendly)
+        assert resolved == canonical, f"{friendly} -> {resolved}, expected {canonical}"
+        assert canonical in TOOL_HANDLERS, f"{friendly} -> {canonical} not registered"

--- a/tests/test_tool_stability.py
+++ b/tests/test_tool_stability.py
@@ -161,6 +161,23 @@ class TestAgentExperienceAliases:
         assert alias.reason == "intuitive_alias"
         assert alias.inject_action == inject_action
 
+    def test_experience_alias_map_is_the_flagged_set(self):
+        """experience_alias_map() is the single source the discoverability
+        surfaces key off — it must be exactly the experience-flagged
+        aliases, mapped to their canonical tool."""
+        from src.mcp_handlers.tool_stability import experience_alias_map
+
+        mapping = experience_alias_map()
+        assert mapping == {
+            "start_session": "onboard",
+            "sync_state": "process_agent_update",
+            "check_working_state": "get_governance_metrics",
+            "search_shared_memory": "knowledge",
+            "record_result": "outcome_event",
+            "request_review": "dialectic",
+        }
+        assert set(mapping) == {n for n, a in _TOOL_ALIASES.items() if a.experience}
+
 
 # ============================================================================
 # get_tool_stability


### PR DESCRIPTION
## Context

Follow-up to the agent-experience layer (#619), after #633 and #632 also landed on the alias surface. While doing the planned discoverability follow-up I found that **#633 already surfaces all six friendly task-verb names in the `list_tools` catalog** (lite `signatures` + `workflows`, full-mode `tool_descriptions` as "alias for …"). So the in-band discovery gap is closed — no new catalog block is needed, and I deliberately did **not** restructure the catalog dicts #633 just wrote.

## The residual gap this closes

Those catalog entries are **hand-maintained strings** with nothing tying them to the alias registry. A future alias rename/removal could silently drop a name from discovery while dispatch still routes it — a classic UI-vs-source drift bug.

## Change (helper + tests only)

- `experience_alias_map()` in `tool_stability.py` — single source mapping each `experience=True` alias to its canonical tool.
- **Drift-guard** (`tests/test_list_tools_workflow_aliases.py`): every experience alias must appear in both the lite and full `list_tools` catalogs **and** resolve to a registered handler — no dead discovery entries.
- Unit test pinning `experience_alias_map()` to the flagged set.

No production behavior change; `+31 / -0` plus one new test file. Catalog dicts untouched.

## Testing

185 passed across the alias-dependent suites (tool_stability, action-level identity, describe-tool drift, list_tools/introspection, param-normalization, agent-experience envelope).

## Note for reviewers

This branch was reset onto current `master` (post-#619/#632/#633 merges) before the change, so the diff is exactly the guard — not a replay of already-merged commits.

https://claude.ai/code/session_016wnEAx8YoXRQovHeuVHrNY

---
_Generated by [Claude Code](https://claude.ai/code/session_016wnEAx8YoXRQovHeuVHrNY)_