### PR TITLE
fix(findings): emit resident findings only on condition changes

### DIFF
--- a/agents/common/findings.py
+++ b/agents/common/findings.py
@@ -49,8 +49,34 @@ def compute_change_token(parts: dict[str, Any]) -> str:
     event ingestion can suppress repeat emissions indefinitely; if severity,
     message, or stable context changes, it emits once for the new condition.
     """
-    normalized = json.dumps(parts, sort_keys=True, separators=(",", ":"), default=str)
+    normalized = json.dumps(
+        _stable_json_value(parts),
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
     return hashlib.sha256(normalized.encode()).hexdigest()[:16]
+
+
+def _stable_json_value(value: Any) -> Any:
+    """Return a deterministic JSON-ish shape for hashing.
+
+    ``post_finding`` is best-effort and must not raise just because optional
+    finding context has non-string keys, tuples, sets, or non-JSON leaf values.
+    """
+    if isinstance(value, dict):
+        return {
+            str(k): _stable_json_value(v)
+            for k, v in sorted(value.items(), key=lambda item: str(item[0]))
+        }
+    if isinstance(value, (list, tuple)):
+        return [_stable_json_value(v) for v in value]
+    if isinstance(value, set):
+        return sorted(
+            (_stable_json_value(v) for v in value),
+            key=lambda item: repr(item),
+        )
+    return value
 
 
 def _httpx_post(url: str, json: dict, headers: dict, timeout: float):

--- a/agents/common/findings.py
+++ b/agents/common/findings.py
@@ -8,6 +8,7 @@ token is only sent if UNITARES_HTTP_API_TOKEN is set in env.
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import os
 import time
@@ -40,6 +41,18 @@ def compute_fingerprint(parts: Iterable[Any]) -> str:
     return hashlib.sha256(normalized.encode()).hexdigest()[:16]
 
 
+def compute_change_token(parts: dict[str, Any]) -> str:
+    """16-hex-char SHA-256 prefix for an underlying finding condition.
+
+    Unlike ``fingerprint`` (which names the finding identity), this token names
+    the currently observed condition. If the same finding persists unchanged,
+    event ingestion can suppress repeat emissions indefinitely; if severity,
+    message, or stable context changes, it emits once for the new condition.
+    """
+    normalized = json.dumps(parts, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(normalized.encode()).hexdigest()[:16]
+
+
 def _httpx_post(url: str, json: dict, headers: dict, timeout: float):
     """Thin wrapper so tests can monkeypatch this single call."""
     return httpx.post(url, json=json, headers=headers, timeout=timeout)
@@ -68,6 +81,7 @@ def post_finding(
     agent_id: str,
     agent_name: str,
     fingerprint: str,
+    change_token: Optional[str] = None,
     extra: Optional[dict] = None,
     url: str = DEFAULT_URL,
     timeout: float = DEFAULT_TIMEOUT_SECONDS,
@@ -79,6 +93,27 @@ def post_finding(
 
     This function MUST NOT raise. It's called from hot paths in agent cycles.
     """
+    explicit_extra_change_token = None
+    if extra and extra.get("change_token") is not None:
+        explicit_extra_change_token = str(extra["change_token"])
+
+    resolved_change_token = (
+        str(change_token)
+        if change_token is not None
+        else explicit_extra_change_token
+    )
+    if resolved_change_token is None:
+        stable_extra = {
+            k: v for k, v in (extra or {}).items()
+            if k != "change_token"
+        }
+        resolved_change_token = compute_change_token({
+            "type": event_type,
+            "severity": severity,
+            "message": message,
+            "extra": stable_extra,
+        })
+
     body: dict = {
         "type": event_type,
         "severity": severity,
@@ -86,6 +121,7 @@ def post_finding(
         "agent_id": agent_id,
         "agent_name": agent_name,
         "fingerprint": fingerprint,
+        "change_token": resolved_change_token,
     }
     if extra:
         for k, v in extra.items():

--- a/agents/common/tests/test_findings.py
+++ b/agents/common/tests/test_findings.py
@@ -35,6 +35,18 @@ def test_compute_change_token_is_stable_and_condition_scoped():
     assert len(compute_change_token(base)) == 16
 
 
+def test_compute_change_token_handles_non_jsonish_context():
+    parts = {
+        "type": "sentinel_finding",
+        "severity": "high",
+        "message": "fleet coherence dipped",
+        "extra": {1: ("a", "b"), "set": {"x", "y"}},
+    }
+
+    assert compute_change_token(parts) == compute_change_token(parts)
+    assert len(compute_change_token(parts)) == 16
+
+
 def test_post_finding_success(monkeypatch):
     calls = []
 

--- a/agents/common/tests/test_findings.py
+++ b/agents/common/tests/test_findings.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from agents.common.findings import compute_fingerprint, post_finding
+from agents.common.findings import compute_change_token, compute_fingerprint, post_finding
 
 
 def test_compute_fingerprint_is_stable():
@@ -18,6 +18,21 @@ def test_compute_fingerprint_differs_on_input():
     fp1 = compute_fingerprint(["sentinel", "a"])
     fp2 = compute_fingerprint(["sentinel", "b"])
     assert fp1 != fp2
+
+
+def test_compute_change_token_is_stable_and_condition_scoped():
+    base = {
+        "type": "sentinel_finding",
+        "severity": "high",
+        "message": "fleet coherence dipped",
+        "extra": {"violation_class": "BEH"},
+    }
+    same = dict(base)
+    changed = {**base, "severity": "critical"}
+
+    assert compute_change_token(base) == compute_change_token(same)
+    assert compute_change_token(base) != compute_change_token(changed)
+    assert len(compute_change_token(base)) == 16
 
 
 def test_post_finding_success(monkeypatch):
@@ -50,7 +65,72 @@ def test_post_finding_success(monkeypatch):
     assert body["type"] == "sentinel_finding"
     assert body["violation_class"] == "BEH"
     assert body["fingerprint"] == "abcd1234"
+    assert body["change_token"] == compute_change_token({
+        "type": "sentinel_finding",
+        "severity": "high",
+        "message": "fleet coherence dipped",
+        "extra": {"violation_class": "BEH"},
+    })
     assert calls[0]["url"].endswith("/api/findings")
+
+
+def test_post_finding_accepts_explicit_change_token(monkeypatch):
+    captured = {}
+
+    def fake_post(url, json, headers, timeout):  # noqa: A002
+        captured["body"] = json
+
+        class FakeResp:
+            status_code = 200
+
+            def json(self):
+                return {"success": True, "deduped": False}
+
+        return FakeResp()
+
+    monkeypatch.setattr("agents.common.findings._httpx_post", fake_post)
+    post_finding(
+        event_type="sentinel_finding",
+        severity="high",
+        message="fleet coherence dipped",
+        agent_id="sentinel-01",
+        agent_name="Sentinel",
+        fingerprint="abcd1234",
+        change_token="condition-v2",
+        extra={"change_token": "legacy-extra-token", "violation_class": "BEH"},
+    )
+
+    assert captured["body"]["change_token"] == "condition-v2"
+    assert captured["body"]["violation_class"] == "BEH"
+
+
+def test_post_finding_preserves_legacy_extra_change_token(monkeypatch):
+    captured = {}
+
+    def fake_post(url, json, headers, timeout):  # noqa: A002
+        captured["body"] = json
+
+        class FakeResp:
+            status_code = 200
+
+            def json(self):
+                return {"success": True, "deduped": False}
+
+        return FakeResp()
+
+    monkeypatch.setattr("agents.common.findings._httpx_post", fake_post)
+    post_finding(
+        event_type="watcher_finding",
+        severity="critical",
+        message="persistent finding",
+        agent_id="watcher",
+        agent_name="Watcher",
+        fingerprint="fp",
+        extra={"change_token": "legacy-token", "pattern": "P005"},
+    )
+
+    assert captured["body"]["change_token"] == "legacy-token"
+    assert captured["body"]["pattern"] == "P005"
 
 
 def test_post_finding_swallows_network_errors(monkeypatch):


### PR DESCRIPTION
## What

Add explicit `change_token` support to the shared `post_finding()` helper used by resident agents.

`post_finding()` now:

- accepts a first-class `change_token=` argument
- preserves the legacy `extra={"change_token": ...}` escape hatch
- derives a stable condition-scoped token by default from type, severity, message, and stable extra context
- sends the token to `/api/findings`, so `record_event()` uses emit-on-change dedup instead of the 30-minute fingerprint window for resident findings
- keeps token derivation deterministic and no-raise for common non-JSON-ish context values such as mixed keys, tuples, and sets

## Why

Refs #637. This handles the issue's shared-helper follow-up: persistent Sentinel/Vigil/Watcher finding conditions should not re-fire after the time-window dedup expires just because the same condition is still present.

This does **not** close the detector-layer stale-anomaly issue in #637; `detect_anomalies_in_history()` can still manufacture stale observe/dashboard anomalies and needs its own follow-up.

## Testing

- `python3 scripts/diagnostics/check_doc_health.py` -> all clear
- `python3 -m pytest -q tests/test_doc_health_dead_refs.py` -> 14 passed
- `python3 -m pytest -q agents/common/tests/test_findings.py tests/test_http_api_findings.py tests/test_event_detector.py agents/sentinel/tests/test_findings_emit.py agents/vigil/tests/test_findings_emit.py agents/watcher/tests/test_resolution_event.py` -> 57 passed
- `./scripts/dev/test-cache.sh --staged` -> 9463 passed, 34 skipped
- pre-push smoke -> 138 passed, doc health all clear
