### PR TITLE
fix(rate-limit): per-caller buckets for unbound traffic — end the shared-anonymous bootstrap lockout

### DIFF
--- a/src/mcp_handlers/middleware/rate_limit_step.py
+++ b/src/mcp_handlers/middleware/rate_limit_step.py
@@ -2,7 +2,7 @@
 
 import time
 from collections import defaultdict, deque
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from src.logging_utils import get_logger
 from src.rate_limiter import get_rate_limiter
@@ -14,22 +14,110 @@ logger = get_logger(__name__)
 # Persistent state for expensive-read-only loop detection
 _tool_call_history: Dict[str, deque] = defaultdict(lambda: deque(maxlen=200))
 
+# Pure read tools exempt from the general limiter. These are standalone
+# registered tools (not aliases), so the names survive resolve_alias on
+# both the MCP and REST pipelines. Mixed read/write tools (knowledge,
+# agent, observe, ...) are exempted per-call below via their declared
+# pre_onboard_actions instead of by name. NOTE: the @mcp_tool
+# rate_limit_exempt flag is declared on ~25 tools but consulted nowhere —
+# it is NOT trusted here because its declarations include mutating tools
+# (archive_orphan_agents, cleanup_stale_locks); audit before wiring it.
+_READ_ONLY_TOOLS = {
+    'health_check', 'get_server_info', 'list_tools', 'get_thresholds',
+    'search_knowledge_graph', 'get_governance_metrics', 'skills',
+    'detect_stuck_agents',
+}
+
+# Expensive-read loop detection keys: (canonical name, resolved action).
+# 'agent'/'list' is what the legacy list_agents alias dispatches as.
+_EXPENSIVE_READ_CALLS = {("agent", "list")}
+_LEGACY_EXPENSIVE_READ_TOOLS = {"list_agents"}  # direct-step callers/tests
+
+
+def _loop_detection_key(name: str, arguments: Dict[str, Any]) -> Optional[str]:
+    """Return the loop-detection history key for expensive read calls."""
+    if name in _LEGACY_EXPENSIVE_READ_TOOLS:
+        return name
+    action = arguments.get("action") or arguments.get("op")
+    action = str(action).lower() if action else None
+    if (name, action) in _EXPENSIVE_READ_CALLS:
+        return f"{name}:{action}"
+    return None
+
+
+def _rate_bucket_key(arguments: Dict[str, Any], ctx) -> str:
+    """Resolve the rate-limit bucket for this call.
+
+    Bound callers are bucketed by agent id. Unbound callers are bucketed
+    per transport fingerprint (IP + UA hash) so one anonymous flood — a
+    polling dashboard tab, an un-onboarded service — cannot exhaust a
+    shared global bucket and lock every other caller out of onboard()
+    (the 2026-06-12 bootstrap-lockout incident). The fingerprint is
+    caller-supplied and spoofable; this is runaway protection, not an
+    auth boundary — identity enforcement lives in the #425 gates.
+    """
+    agent_id = arguments.get('agent_id')
+    if agent_id:
+        return str(agent_id)
+    bound = getattr(ctx, 'bound_agent_id', None)
+    if bound:
+        return str(bound)
+    try:
+        from ..context import get_session_signals
+        signals = get_session_signals()
+        if signals and signals.ip_ua_fingerprint:
+            return f"anon:{signals.ip_ua_fingerprint}"
+    except Exception:
+        pass
+    return 'anonymous'
+
+
+def _is_pre_onboard_read_call(name: str, arguments: Dict[str, Any]) -> bool:
+    """True iff this call resolves to a declared pre_onboard_actions read.
+
+    Reuses the #425 call-granularity classification (alias-aware,
+    default_action-aware). Tool-level pre_onboard lifecycle tools
+    (onboard, identity, bind_session, ...) deliberately return False —
+    they stay rate-limited per caller so identity minting can't run away.
+    The drift-guard test on pre_onboard_actions pins that no mutating
+    action can enter these sets.
+    """
+    try:
+        from ..decorators import get_call_identity_requirement, get_tool_definition
+        from ..tool_stability import resolve_tool_alias
+        canonical, _ = resolve_tool_alias(name)
+        td = get_tool_definition(canonical)
+        if td is None or td.requires_identity != "required" or not td.pre_onboard_actions:
+            return False
+        return get_call_identity_requirement(name, arguments) == "pre_onboard"
+    except Exception:
+        # Classification failure fails closed: the call stays rate-limited.
+        # Logged (like get_call_identity_requirement) because a regression
+        # here silently re-limits every pre-onboard read with no signal.
+        logger.warning(
+            "_is_pre_onboard_read_call: classification failed for %r — "
+            "failing closed (rate-limited)",
+            name,
+            exc_info=True,
+        )
+        return False
+
 
 async def check_rate_limit(name: str, arguments: Dict[str, Any], ctx) -> Any:
     """Rate limiting for non-read-only tools + loop detection for expensive reads."""
 
     # Loop detection for expensive read-only tools
-    expensive_read_only_tools = {'list_agents'}
-    if name in expensive_read_only_tools:
+    loop_key = _loop_detection_key(name, arguments)
+    if loop_key is not None:
         now = time.time()
-        tool_history = _tool_call_history[name]
+        tool_history = _tool_call_history[loop_key]
 
         # Clean up old calls (keep last 60 seconds)
         cutoff = now - 60
         while tool_history and tool_history[0] < cutoff:
             tool_history.popleft()
         if not tool_history:
-            del _tool_call_history[name]
+            del _tool_call_history[loop_key]
 
         if len(tool_history) >= 20:
             return [error_response(
@@ -43,20 +131,21 @@ async def check_rate_limit(name: str, arguments: Dict[str, Any], ctx) -> Any:
                 context={
                     "tool_name": name,
                     "calls_in_last_minute": len(tool_history),
-                    "note": "Global rate limit (list_agents doesn't have agent_id parameter)"
+                    "note": "Global rate limit (agent listing has no per-caller key)"
                 }
             )]
 
-        _tool_call_history[name].append(now)
+        _tool_call_history[loop_key].append(now)
 
-    # General rate limiting (skip for read-only tools)
-    read_only_tools = {'health_check', 'get_server_info', 'list_tools', 'get_thresholds', 'search_knowledge_graph', 'get_governance_metrics', 'skills'}
-    if name not in read_only_tools:
-        agent_id = arguments.get('agent_id') or 'anonymous'
-        rate_limiter = get_rate_limiter()
-        allowed, error_msg = rate_limiter.check_rate_limit(agent_id)
+    # General rate limiting (skip for read-only tools and pre-onboard reads)
+    if name in _READ_ONLY_TOOLS or _is_pre_onboard_read_call(name, arguments):
+        return name, arguments, ctx
 
-        if not allowed:
-            return rate_limit_error(agent_id, rate_limiter.get_stats(agent_id))
+    bucket = _rate_bucket_key(arguments, ctx)
+    rate_limiter = get_rate_limiter()
+    allowed, error_msg = rate_limiter.check_rate_limit(bucket)
+
+    if not allowed:
+        return rate_limit_error(bucket, rate_limiter.get_stats(bucket))
 
     return name, arguments, ctx

--- a/tests/test_dispatch_integration.py
+++ b/tests/test_dispatch_integration.py
@@ -356,6 +356,113 @@ class TestCheckRateLimit:
         assert not _is_short_circuit(result)
 
 
+class TestPerCallerRateBuckets:
+    """Per-caller bucketing: one anonymous flood must not lock out other
+    callers' onboard() (the 2026-06-12 bootstrap-lockout incident)."""
+
+    @pytest.fixture(autouse=True)
+    def fresh_limiter_and_history(self):
+        from src.rate_limiter import get_rate_limiter
+        get_rate_limiter().reset()
+        _tool_call_history.clear()
+        yield
+        get_rate_limiter().reset()
+        _tool_call_history.clear()
+
+    def _set_signals(self, fp):
+        from src.mcp_handlers.context import set_session_signals, SessionSignals
+        return set_session_signals(SessionSignals(ip_ua_fingerprint=fp))
+
+    @pytest.mark.asyncio
+    async def test_flooded_fingerprint_does_not_block_other_callers(self):
+        """Exhausting one unbound caller's bucket leaves other unbound
+        callers — including a fresh session calling onboard — unaffected."""
+        from src.mcp_handlers.context import reset_session_signals
+        from src.rate_limiter import get_rate_limiter
+        ctx = _make_ctx()
+
+        tok = self._set_signals("127.0.0.1:f100dd")
+        try:
+            limiter = get_rate_limiter()
+            # Saturate the flooding caller's per-minute budget directly.
+            for _ in range(limiter.max_per_minute):
+                limiter.check_rate_limit("anon:127.0.0.1:f100dd")
+            result = await check_rate_limit("onboard", {}, ctx)
+            assert _is_short_circuit(result), "flooding caller should be limited"
+        finally:
+            reset_session_signals(tok)
+
+        tok = self._set_signals("127.0.0.1:a200bb")
+        try:
+            result = await check_rate_limit("onboard", {}, ctx)
+            assert not _is_short_circuit(result), (
+                "a different caller must not inherit the flooder's bucket"
+            )
+        finally:
+            reset_session_signals(tok)
+
+    @pytest.mark.asyncio
+    async def test_unbound_call_buckets_on_fingerprint(self):
+        """Unbound calls are keyed anon:<ip_ua_fingerprint>, not 'anonymous'."""
+        from src.mcp_handlers.context import reset_session_signals
+        from src.rate_limiter import get_rate_limiter
+        ctx = _make_ctx()
+        tok = self._set_signals("127.0.0.1:b300cc")
+        try:
+            result = await check_rate_limit("process_agent_update", {}, ctx)
+            assert not _is_short_circuit(result)
+            stats = get_rate_limiter().get_stats("anon:127.0.0.1:b300cc")
+            assert stats["requests_last_minute"] == 1
+        finally:
+            reset_session_signals(tok)
+
+    @pytest.mark.asyncio
+    async def test_bound_agent_without_injected_arg_uses_bound_id(self):
+        """When inject_identity skipped injection, ctx.bound_agent_id keys
+        the bucket (attribution to the bound agent, not 'anonymous')."""
+        from src.rate_limiter import get_rate_limiter
+        ctx = _make_ctx(bound_agent_id="agent-bound-1")
+        result = await check_rate_limit("process_agent_update", {}, ctx)
+        assert not _is_short_circuit(result)
+        stats = get_rate_limiter().get_stats("agent-bound-1")
+        assert stats["requests_last_minute"] == 1
+
+    @pytest.mark.asyncio
+    async def test_pre_onboard_reads_skip_general_limit(self):
+        """Declared pre_onboard_actions reads (knowledge search, agent list,
+        dialectic get, ...) skip the general limiter even for a saturated
+        caller; writes on the same tools do not."""
+        from src.mcp_handlers.context import reset_session_signals
+        from src.rate_limiter import get_rate_limiter
+        import src.mcp_handlers  # noqa: F401 — ensure tool registration
+        ctx = _make_ctx()
+        tok = self._set_signals("127.0.0.1:c400dd")
+        try:
+            limiter = get_rate_limiter()
+            for _ in range(limiter.max_per_minute):
+                limiter.check_rate_limit("anon:127.0.0.1:c400dd")
+            result = await check_rate_limit("knowledge", {"action": "search"}, ctx)
+            assert not _is_short_circuit(result), "knowledge search is a pre-onboard read"
+            result = await check_rate_limit("dialectic", {"action": "get"}, ctx)
+            assert not _is_short_circuit(result), "dialectic get is a pre-onboard read"
+            result = await check_rate_limit("knowledge", {"action": "store"}, ctx)
+            assert _is_short_circuit(result), "knowledge store must stay limited"
+        finally:
+            reset_session_signals(tok)
+
+    @pytest.mark.asyncio
+    async def test_loop_detection_matches_canonical_agent_list(self):
+        """list_agents arrives at this step as agent(action=list) after
+        resolve_alias — loop detection must key on the canonical call."""
+        ctx = _make_ctx()
+        now = time.time()
+        history = _tool_call_history["agent:list"]
+        for _ in range(20):
+            history.append(now - 1)
+        result = await check_rate_limit("agent", {"action": "list"}, ctx)
+        assert _is_short_circuit(result)
+        text = _extract_text(result)
+        assert "loop detected" in text.lower()
 
 
 class TestResolveToolAlias:
@@ -446,8 +553,11 @@ class TestDispatchToolIntegration:
     @pytest.fixture
     def clean_rate_limit(self):
         """Clear rate limit history and reset rate limiter."""
+        from src.rate_limiter import get_rate_limiter
+        get_rate_limiter().reset()
         _tool_call_history.clear()
         yield
+        get_rate_limiter().reset()
         _tool_call_history.clear()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Incident (2026-06-12)

The general rate limiter keys every unbound call into one literal `'anonymous'` bucket (`rate_limit_step.py`). The Discord bridge's unbound sweep (~51 calls per 40–60s burst, UA `python-httpx/0.28.1`, fp `51befd`) plus the dashboard's 30s read sweep (fp `f304dd`, plus a new third browser fp `e4e158`) exhausted the shared 1000/hr budget. Result: **bootstrap lockout** — `onboard()` shares the anonymous bucket, so fresh sessions could not mint an identity at all (observed firsthand: onboard refused at 1000/1000).

## Fix

- **Per-caller buckets**: unbound calls key on `anon:<ip_ua_fingerprint>` from SessionSignals (live-verified populated on both the MCP streamable-HTTP and REST ASGI paths; fingerprints stable per UA across 152k+ log lines). Bound calls key on injected `agent_id` or `ctx.bound_agent_id`. Fingerprint is caller-supplied and spoofable — this is runaway protection, not an auth boundary (#425 gates own identity enforcement).
- **Pre-onboard READ exemption** via the #425 call-granularity classifier (`get_call_identity_requirement`, alias-aware): knowledge search / agent list / dialectic get etc. skip the general limiter. Lifecycle `pre_onboard` tools (onboard/identity/bind_session) **stay limited** per caller so identity minting can't run away. Classification failure fails closed and logs.
- **Loop-detection stale key**: it keyed on `list_agents`, a name that never reaches this step — `resolve_alias` rewrites it to `agent(action=list)` earlier on BOTH pipelines. Now keys on the canonical call (legacy key kept for direct-step callers).
- **Exemptions restored, not widened**: old name set kept (`get_thresholds`, `search_knowledge_graph` are standalone registered tools, not aliases — verified) + `detect_stuck_agents` (tool-level pre_onboard read swept by the dashboard).

## Known dead flag (follow-up candidate, NOT wired here)

`@mcp_tool(rate_limit_exempt=True)` is declared on ~25 tools but consulted nowhere. Not trusted by this PR because its declarations include mutating tools (`archive_orphan_agents`, `cleanup_stale_locks`, `rebuild_calibration`). Audit before wiring or remove the flag.

## Review

3-lane council: code-reviewer (2 folds applied: classification-failure logging, fixture singleton reset), live-verifier (SessionSignals claims VERIFIED on both transports; bridge cadence corrected to ~40–60s bursts of ~51 calls; bucket saturation is cyclic — it had drained by verification time), full test suite green.

Companion work: the bridge itself gets onboarded (separate PR in unitares-discord-bridge); dashboard write-credential decision tracked in the #425 handoff.