### PR TITLE
feat(dashboard): persist one-time ?operator_token= handoff into localStorage

### DIFF
--- a/dashboard/utils.js
+++ b/dashboard/utils.js
@@ -53,6 +53,29 @@ function getOperatorToken() {
         new URLSearchParams(window.location.search).get('operator_token');
 }
 
+/**
+ * One-time ?operator_token=... handoff: persist it to localStorage and
+ * scrub it from the address bar, so the credential survives reloads
+ * without re-entering browser history on every navigation. Private
+ * browsing (localStorage throws) keeps the URL fallback untouched.
+ */
+(function persistOperatorTokenFromUrl() {
+    const params = new URLSearchParams(window.location.search);
+    const fromUrl = params.get('operator_token');
+    if (!fromUrl) return;
+    try {
+        localStorage.setItem('unitares_operator_token', fromUrl);
+    } catch (e) {
+        return;
+    }
+    params.delete('operator_token');
+    const qs = params.toString();
+    window.history.replaceState(
+        null, '',
+        window.location.pathname + (qs ? '?' + qs : '') + window.location.hash
+    );
+})();
+
 class DashboardAPI {
     /**
      * Centralized API client with retry logic, error handling, and caching.


### PR DESCRIPTION
Companion to #630 (operator token → stable identity). The URL-param form of the operator token is the only injection path that doesn't require DevTools, but it lingers in the address bar and re-enters history on every reload. On load: persist to localStorage, scrub via replaceState. Private browsing keeps the URL fallback.

Closes the provisioning gap in the #425 dashboard write-credential story: `open 'http://127.0.0.1:8767/dashboard?operator_token=…'` is now a durable one-time handoff.