### PR TITLE
feat(lifecycle): bucket test agents separately in identity_health counts

### DIFF
--- a/src/mcp_handlers/lifecycle/query.py
+++ b/src/mcp_handlers/lifecycle/query.py
@@ -177,6 +177,7 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
             total_all = 0  # Count all agents before filtering
             ghost_count = 0
             ephemeral_count = 0
+            test_count = 0
             for agent_id, meta in list(mcp_server.agent_metadata.items()):
                 total_all += 1
                 # Ghost: no label, no purpose, zero check-ins — session-binding artifact
@@ -189,6 +190,12 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                 )
                 if is_ghost:
                     ghost_count += 1
+                elif _is_test_agent(agent_id, getattr(meta, 'label', None)):
+                    # Test agents (pytest/itest suites) get their own health
+                    # bucket — they carry labels, so without this they'd
+                    # inflate "real". Buckets are mutually exclusive; ghost
+                    # classification wins for unlabeled test-pattern ids.
+                    test_count += 1
                 elif meta.total_updates <= 2 and not has_label:
                     # Short-lived but did some work — legitimate ephemeral
                     ephemeral_count += 1
@@ -295,7 +302,8 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                 "identity_health": {
                     "ghosts": ghost_count,
                     "ephemeral": ephemeral_count,
-                    "real": total_all - ghost_count,
+                    "test": test_count,
+                    "real": total_all - ghost_count - test_count,
                 },
             }
 

--- a/tests/test_handlers_lifecycle.py
+++ b/tests/test_handlers_lifecycle.py
@@ -73,6 +73,51 @@ class TestListAgentsLite:
             assert "test_agent_1" not in ids
 
     @pytest.mark.asyncio
+    async def test_identity_health_buckets_test_agents_separately(self, mock_mcp_server):
+        mock_mcp_server.agent_metadata = {
+            "real-agent": make_agent_meta(label="Real", total_updates=10),
+            # itest-labeled with zero updates: must land in "test", not "real"
+            "11111111-aaaa-bbbb-cccc-000000000001": make_agent_meta(
+                label="itest-plugin#deadbeef_11111111", total_updates=0
+            ),
+            "22222222-aaaa-bbbb-cccc-000000000002": make_agent_meta(
+                label="cli-pytest-worker", total_updates=1
+            ),
+            # Unlabeled zero-update artifact: ghost, even though nothing test-y
+            "33333333-aaaa-bbbb-cccc-000000000003": make_agent_meta(
+                label=None, total_updates=0
+            ),
+        }
+
+        with patch_lifecycle_server(mock_mcp_server):
+            from src.mcp_handlers.lifecycle.handlers import handle_list_agents
+            result = await handle_list_agents({"lite": True})
+
+            data = json.loads(result[0].text)
+            health = data["identity_health"]
+            assert health["test"] == 2
+            assert health["ghosts"] == 1
+            assert health["real"] == 1  # total 4 - 1 ghost - 2 test
+
+    @pytest.mark.asyncio
+    async def test_identity_health_ghost_wins_over_test_pattern(self, mock_mcp_server):
+        # Unlabeled zero-update agent whose id matches the test pattern:
+        # buckets are mutually exclusive and ghost classification wins.
+        mock_mcp_server.agent_metadata = {
+            "test_orphan_1": make_agent_meta(label=None, total_updates=0),
+        }
+
+        with patch_lifecycle_server(mock_mcp_server):
+            from src.mcp_handlers.lifecycle.handlers import handle_list_agents
+            result = await handle_list_agents({"lite": True})
+
+            data = json.loads(result[0].text)
+            health = data["identity_health"]
+            assert health["ghosts"] == 1
+            assert health["test"] == 0
+            assert health["real"] == 0
+
+    @pytest.mark.asyncio
     async def test_includes_test_agents_when_requested(self, mock_mcp_server):
         mock_mcp_server.agent_metadata = {
             "real-agent": make_agent_meta(label="Real"),


### PR DESCRIPTION
## Why

The 2026-06-12 uninitialized-agents diagnosis found that 40 of 58 zero-checkin identities minted in the last 14 days were `itest-plugin#…` pairs from the plugin integration suites. They archive at teardown and `_is_test_agent` already hides them from listings, but they carry labels — so the ghost classifier (which requires *no* label) can't catch them and they inflate `identity_health.real` and `total_all` forever.

## What

- `identity_health` in the lite `agent(list)` response now reports a mutually-exclusive `test` bucket, reusing the existing `_is_test_agent` patterns.
- `real` = total − ghosts − test.
- Ghost classification wins over the test pattern for unlabeled zero-update ids, so the session-binding-artifact signal is unchanged.

No consumers outside the response read `identity_health` (checked dashboard + src), so the semantic change to `real` is safe.

## Tests

Two new tests in `tests/test_handlers_lifecycle.py` (bucket separation + ghost-wins precedence). Full local gate green: 9552 passed.