### PR TITLE
fix(identity): single-flight + PG adopt-winner for operator-token first-use mint race

### DIFF
--- a/src/mcp_handlers/identity/operator.py
+++ b/src/mcp_handlers/identity/operator.py
@@ -40,6 +40,7 @@ Token storage:
   so a compromise can be revoked without disrupting all operators.
 """
 
+import asyncio
 import hashlib
 import os
 import time
@@ -123,6 +124,20 @@ _OPERATOR_IDENTITY_TTL = 300.0  # seconds; bounds DB lookups, not authorization
 # rotation revokes immediately; the cache only skips re-resolution.
 _operator_identity_cache: Dict[str, Tuple[str, float]] = {}
 
+# Single-flight guard for the miss→mint path. First use of a token arrives
+# as a concurrent burst (two dashboard tabs × a multi-tool sweep); without
+# this, every in-flight request takes the resume-miss→force_new path and
+# mints its own identity (2026-06-12: 5 mints in one burst, issue #644).
+# Keyed per fingerprint so distinct tokens never serialize each other.
+_operator_mint_locks: Dict[str, "asyncio.Lock"] = {}
+
+
+def _operator_mint_lock(fingerprint: str) -> "asyncio.Lock":
+    lock = _operator_mint_locks.get(fingerprint)
+    if lock is None:
+        lock = _operator_mint_locks.setdefault(fingerprint, asyncio.Lock())
+    return lock
+
 
 def operator_token_fingerprint(token: str) -> str:
     """Stable, non-reversible fingerprint used to key operator identity.
@@ -141,6 +156,33 @@ def operator_session_key(token: str) -> str:
     transport-derived sessions.
     """
     return f"operator:{operator_token_fingerprint(token)}"
+
+
+async def _persisted_operator_uuid(session_key: str) -> Optional[str]:
+    """UUID named by the PG session row for ``session_key``, or None.
+
+    Deliberately bypasses the Redis session cache: this is the
+    adopt-winner ground-truth read, and the cache may hold the calling
+    process's own racing mint. Best-effort — any failure returns None
+    and the caller keeps its minted identity.
+    """
+    try:
+        from src.db import get_db
+        db = get_db()
+        if hasattr(db, "init"):
+            await db.init()
+        session = await db.get_session(session_key)
+        stored = session.agent_id if session else None
+        # PATH 2 convention: rows may carry a UUID or a legacy model+date
+        # id; operator rows are always UUID-keyed, so require that shape.
+        if stored and len(stored) == 36 and stored.count("-") == 4:
+            return stored
+    except Exception as e:
+        logger.debug(
+            "[OPERATOR] adopt-winner PG readback failed for %s...: %s",
+            session_key[:24], e,
+        )
+    return None
 
 
 async def resolve_operator_identity(
@@ -177,29 +219,58 @@ async def resolve_operator_identity(
 
     from src.mcp_handlers.identity.handlers import resolve_session_identity
 
-    identity = await resolve_session_identity(
-        session_key,
-        persist=True,
-        client_hint="operator",
-        resume=True,
-    )
-    if (identity.get("resume_failed")
-            and identity.get("error") == "session_resolve_miss"):
-        # First use of this token: mint explicitly (S21-a fail-closed PATH 2
-        # means resume never silently creates). spawn_reason makes the mint
-        # legible in the lineage audit trail.
+    async with _operator_mint_lock(fingerprint):
+        # Re-check under the lock: a concurrent request may have resolved
+        # (or minted) while this one waited.
+        cached = _operator_identity_cache.get(fingerprint)
+        if cached and (time.monotonic() - cached[1]) < _OPERATOR_IDENTITY_TTL:
+            return {
+                "agent_uuid": cached[0],
+                "session_key": session_key,
+                "source": "operator_token",
+            }
+
         identity = await resolve_session_identity(
             session_key,
             persist=True,
             client_hint="operator",
-            force_new=True,
-            spawn_reason="operator_credential",
+            resume=True,
         )
-        logger.info(
-            "[OPERATOR] minted operator identity %s... for token fp=%s",
-            (identity.get("agent_uuid") or "")[:8],
-            fingerprint,
-        )
+        if (identity.get("resume_failed")
+                and identity.get("error") == "session_resolve_miss"):
+            # First use of this token: mint explicitly (S21-a fail-closed
+            # PATH 2 means resume never silently creates). spawn_reason makes
+            # the mint legible in the lineage audit trail.
+            identity = await resolve_session_identity(
+                session_key,
+                persist=True,
+                client_hint="operator",
+                force_new=True,
+                spawn_reason="operator_credential",
+            )
+            logger.info(
+                "[OPERATOR] minted operator identity %s... for token fp=%s",
+                (identity.get("agent_uuid") or "")[:8],
+                fingerprint,
+            )
+            # Adopt-winner: create_session is ON CONFLICT DO NOTHING, so if
+            # another writer (a second server process, or a pre-lock burst)
+            # persisted the row first, OUR mint is the ghost. Read the PG row
+            # DIRECTLY — resolve_session_identity(resume=True) consults the
+            # Redis cache (PATH 1) first, and PATH 3 just populated it with
+            # OUR mint, so the resolver can never surface a cross-process
+            # winner (council finding on this fix).
+            winner_uuid = await _persisted_operator_uuid(session_key)
+            our_uuid = identity.get("agent_uuid")
+            if winner_uuid and our_uuid and winner_uuid != our_uuid:
+                logger.info(
+                    "[OPERATOR] adopting persisted operator identity %s... "
+                    "over our racing mint %s... for token fp=%s",
+                    winner_uuid[:8],
+                    our_uuid[:8],
+                    fingerprint,
+                )
+                identity = {"agent_uuid": winner_uuid, "source": "postgres"}
 
     agent_uuid = identity.get("agent_uuid")
     if not agent_uuid:

--- a/tests/test_operator_identity_resolution.py
+++ b/tests/test_operator_identity_resolution.py
@@ -23,6 +23,7 @@ sys.path.insert(0, str(project_root))
 
 from src.mcp_handlers.identity.operator import (
     _operator_identity_cache,
+    _operator_mint_locks,
     operator_session_key,
     operator_token_fingerprint,
     resolve_operator_identity,
@@ -51,8 +52,10 @@ VALID_TOKEN = "op-secret-token-1"
 @pytest.fixture(autouse=True)
 def clean_operator_cache():
     _operator_identity_cache.clear()
+    _operator_mint_locks.clear()
     yield
     _operator_identity_cache.clear()
+    _operator_mint_locks.clear()
 
 
 @pytest.fixture
@@ -123,7 +126,12 @@ class TestResolution:
             "src.mcp_handlers.identity.handlers.resolve_session_identity",
             new_callable=AsyncMock,
             side_effect=[_miss(), _resumed("uuid-operator-minted")],
-        ) as mock_resolve:
+        ) as mock_resolve, patch(
+            "src.mcp_handlers.identity.operator._persisted_operator_uuid",
+            new_callable=AsyncMock,
+            # adopt-winner PG readback (#644): row names our mint
+            return_value="uuid-operator-minted",
+        ):
             result = await resolve_operator_identity(signals)
 
         assert result["agent_uuid"] == "uuid-operator-minted"
@@ -197,6 +205,103 @@ class TestCacheAndRotation:
             result = await resolve_operator_identity(signals)
         assert result["agent_uuid"] == "uuid-fresh"
         mock_resolve.assert_awaited_once()
+
+
+class TestMintRace:
+    """First-use single-flight + adopt-winner (issue #644).
+
+    Live 2026-06-12: two dashboard tabs' cold-cache sweep burst minted 5
+    operator identities for one token fingerprint — every in-flight request
+    took the resume-miss→force_new path before the first session row landed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_first_use_mints_exactly_once(self, allowlist):
+        import asyncio
+
+        signals = FakeSignals(unitares_operator_token=VALID_TOKEN)
+        minted = []
+        persisted = {"uuid": None}
+
+        async def fake_resolver(session_key, **kwargs):
+            # Simulate the real PG semantics: resume misses until a mint
+            # persists the row; force_new always mints a fresh UUID but only
+            # the FIRST mint's row wins (create_session ON CONFLICT DO
+            # NOTHING). The sleep(0) yields the event loop so the gather
+            # genuinely interleaves — without it the first task runs to
+            # completion uninterrupted and the lock is never contended.
+            await asyncio.sleep(0)
+            if kwargs.get("force_new"):
+                uuid = f"uuid-mint-{len(minted) + 1}"
+                minted.append(uuid)
+                if persisted["uuid"] is None:
+                    persisted["uuid"] = uuid
+                return {"agent_uuid": uuid, "source": "created", "created": True}
+            if persisted["uuid"] is not None:
+                return _resumed(persisted["uuid"])
+            return _miss()
+
+        async def fake_pg_readback(session_key):
+            await asyncio.sleep(0)
+            return persisted["uuid"]
+
+        with patch(
+            "src.mcp_handlers.identity.handlers.resolve_session_identity",
+            new=fake_resolver,
+        ), patch(
+            "src.mcp_handlers.identity.operator._persisted_operator_uuid",
+            new=fake_pg_readback,
+        ):
+            results = await asyncio.gather(
+                *[resolve_operator_identity(signals) for _ in range(10)]
+            )
+
+        assert len(minted) == 1, f"expected single-flight mint, got {minted}"
+        uuids = {r["agent_uuid"] for r in results}
+        assert uuids == {persisted["uuid"]}
+
+    @pytest.mark.asyncio
+    async def test_lost_persist_race_adopts_winner(self, allowlist):
+        """If our session-row insert lost (second process / pre-lock burst),
+        the post-mint PG readback adopts the persisted identity, not our
+        ghost. The readback must bypass the resolver entirely — PATH 1
+        (Redis) holds our own racing mint at this point."""
+        signals = FakeSignals(unitares_operator_token=VALID_TOKEN)
+        with patch(
+            "src.mcp_handlers.identity.handlers.resolve_session_identity",
+            new_callable=AsyncMock,
+            side_effect=[
+                _miss(),                     # initial resume: no row yet
+                _resumed("uuid-our-ghost"),  # our mint
+            ],
+        ), patch(
+            "src.mcp_handlers.identity.operator._persisted_operator_uuid",
+            new_callable=AsyncMock,
+            return_value="uuid-the-winner",  # PG row: another writer won
+        ):
+            result = await resolve_operator_identity(signals)
+
+        assert result["agent_uuid"] == "uuid-the-winner"
+        fp = operator_token_fingerprint(VALID_TOKEN)
+        assert _operator_identity_cache[fp][0] == "uuid-the-winner"
+
+    @pytest.mark.asyncio
+    async def test_pg_readback_failure_keeps_our_mint(self, allowlist):
+        """Adopt-winner is best-effort: a failed PG readback keeps the
+        minted identity rather than degrading to unbound."""
+        signals = FakeSignals(unitares_operator_token=VALID_TOKEN)
+        with patch(
+            "src.mcp_handlers.identity.handlers.resolve_session_identity",
+            new_callable=AsyncMock,
+            side_effect=[_miss(), _resumed("uuid-our-mint")],
+        ), patch(
+            "src.mcp_handlers.identity.operator._persisted_operator_uuid",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            result = await resolve_operator_identity(signals)
+
+        assert result["agent_uuid"] == "uuid-our-mint"
 
 
 class TestRestPrebindIntegration:


### PR DESCRIPTION
Closes #644.

First use of an operator token arrives as a concurrent burst (two dashboard tabs × a multi-tool sweep); every in-flight request took the resume-miss→`force_new` path before the first session row landed and minted its own identity (live 2026-06-12: **5 mints for one fingerprint**).

## Fix
- **Per-fingerprint `asyncio.Lock` single-flight** around the miss→mint path, double-checked cache re-read under the lock. Council-verified one event loop in production (REST prebind + MCP both on uvicorn's loop; ExecutorPool DB work awaited from it), so a plain Lock is sound. Lock dict is bounded by allowlist size.
- **Adopt-winner readback reads the PG session row directly** (`_persisted_operator_uuid`): `resolve_session_identity(resume=true)` consults Redis PATH 1 first, and PATH 3 just populated it with OUR mint, so the resolver can never surface a cross-process winner — council caught this on the first draft, which used the resolver for the readback. Best-effort: a failed readback keeps the mint rather than degrading to unbound.

## Tests
- Concurrency test yields the loop inside the fake resolver (`asyncio.sleep(0)`) so `gather` genuinely interleaves — verified the test fails (10 mints) with single-flight defeated, and that in that no-lock scenario all 9 losers adopt the persisted winner (the cross-process path works).
- Lost-persist-race adopt-winner + readback-failure-keeps-mint tests.
- 93 focused tests green (operator + dispatch + action-level identity).

Remaining from #644: archive the 4 ghost operator identities from today's burst (operational).