### PR TITLE
feat(orchestrator): lineage provisioning — candidate parent/spawn-reason env for spawned agents

### DIFF
--- a/elixir/agent_orchestrator/lib/agent_orchestrator.ex
+++ b/elixir/agent_orchestrator/lib/agent_orchestrator.ex
@@ -12,6 +12,18 @@ defmodule AgentOrchestrator do
 
       {:ok, id, _} = AgentOrchestrator.run(%{cmd: "claude", args: ["-p", task], lease: %{}})
 
+  Lineage-provisioned — the child env gains `UNITARES_PARENT_AGENT_ID` /
+  `UNITARES_SPAWN_REASON` as CANDIDATE declarations the child declares (or
+  declines) in its own onboard call; the orchestrator never onboards on the
+  child's behalf:
+
+      {:ok, id, _} =
+        AgentOrchestrator.run(%{
+          cmd: "claude",
+          args: ["-p", task],
+          lineage: %{parent_agent_uuid: spawner_governance_uuid}
+        })
+
   See `AgentOrchestrator.AgentRunner` for the full spec.
   """
 

--- a/elixir/agent_orchestrator/lib/agent_orchestrator/agent_runner.ex
+++ b/elixir/agent_orchestrator/lib/agent_orchestrator/agent_runner.ex
@@ -33,7 +33,8 @@ defmodule AgentOrchestrator.AgentRunner do
         max_output_lines: pos_integer(),   # buffer cap (default 1000)
         lease: nil | false | lease_cfg,    # default (absent/nil) = best-effort agent:/ presence;
                                            # false = no presence; map = override
-        lease_client: module()             # injectable, default LeasePlaneClient
+        lease_client: module(),            # injectable, default LeasePlaneClient
+        lineage: nil | lineage_cfg         # default nil = no lineage provisioning
       }
 
       lease_cfg :: %{
@@ -42,6 +43,31 @@ defmodule AgentOrchestrator.AgentRunner do
         holder_agent_uuid: String.t(),     # the agent's governance UUID (generated if absent)
         ttl_s: pos_integer()               # default from config :default_lease_ttl_s
       }
+
+      lineage_cfg :: %{
+        parent_agent_uuid: String.t(),     # spawner's governance UUID (required, UUID-shaped)
+        spawn_reason: String.t()           # default "subagent" (server vocabulary also has
+                                           # compaction | new_session | explicit)
+      }
+
+  ## Lineage provisioning (not injection)
+
+  A spawner that knows its own governance UUID can pass `lineage:`, and the
+  child env gains `UNITARES_PARENT_AGENT_ID` / `UNITARES_SPAWN_REASON`. These
+  are CANDIDATE declarations, consistent with the declaration-based identity
+  ontology (identity.md v2): the child declares lineage in its own
+  onboard/start_session call — or declines to. The orchestrator cannot and
+  does not make a governance call on the child's behalf; it only puts the
+  ground-truth parent UUID where the child (or its session-start hook) can
+  find it, so lineage correctness comes from the spawn context instead of a
+  prompt convention someone has to remember.
+
+  Explicit `env:` entries win over provisioned ones — a caller that sets
+  `UNITARES_PARENT_AGENT_ID` itself has made the more specific statement. A
+  malformed `parent_agent_uuid` refuses the spawn (`{:error,
+  {:invalid_lineage, _}}`): a garbage candidate at the provisioning boundary
+  surfaces downstream as false ancestry in the lineage DAG. The result's
+  `:lineage` field reports `:provisioned` or `:none`.
 
   ## Presence
 
@@ -68,6 +94,15 @@ defmodule AgentOrchestrator.AgentRunner do
   @default_max_lines 1000
   @line_max_bytes 65_536
 
+  # Lineage-provisioning env vars surfaced to the child (candidate
+  # declarations — see "Lineage provisioning" in the moduledoc).
+  @lineage_parent_var "UNITARES_PARENT_AGENT_ID"
+  @lineage_reason_var "UNITARES_SPAWN_REASON"
+  @default_spawn_reason "subagent"
+
+  # Shape check only (8-4-4-4-12 hex) — ancestry truth is the server's call.
+  @uuid_re ~r/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+
   defstruct [
     :agent_id,
     :port,
@@ -76,6 +111,9 @@ defmodule AgentOrchestrator.AgentRunner do
     :lease_client,
     :lease_cfg,
     :presence,
+    # :provisioned | :none — provisioning status only; the lineage_cfg map
+    # itself is consumed in init/1 and never stored.
+    :lineage,
     :exit_status,
     :release_status,
     output: [],
@@ -183,13 +221,26 @@ defmodule AgentOrchestrator.AgentRunner do
     lease_client = Map.get(spec, :lease_client, LeasePlaneClient)
     lease_cfg = normalize_lease_cfg(Map.get(spec, :lease), agent_id)
 
-    state = %__MODULE__{
-      agent_id: agent_id,
-      lease_client: lease_client,
-      lease_cfg: lease_cfg,
-      max_output_lines: Map.get(spec, :max_output_lines, @default_max_lines)
-    }
+    # Validate lineage BEFORE the lease acquire: a refused spawn must not have
+    # touched the plane (no acquire-then-release churn for a config error).
+    case normalize_lineage_cfg(Map.get(spec, :lineage)) do
+      {:error, reason} ->
+        {:stop, {:invalid_lineage, reason}}
 
+      {:ok, lineage_cfg} ->
+        state = %__MODULE__{
+          agent_id: agent_id,
+          lease_client: lease_client,
+          lease_cfg: lease_cfg,
+          lineage: if(lineage_cfg, do: :provisioned, else: :none),
+          max_output_lines: Map.get(spec, :max_output_lines, @default_max_lines)
+        }
+
+        init_with_lease(state, spec, lineage_cfg)
+    end
+  end
+
+  defp init_with_lease(state, spec, lineage_cfg) do
     # Not a `with`: the acquired lease_id must be in scope on the port-open
     # failure path so we can release it. A `with/else` only sees the failing
     # clause's value, so the acquired lease_id would be invisible there and the
@@ -202,10 +253,10 @@ defmodule AgentOrchestrator.AgentRunner do
       {:ok, lease_id, presence} ->
         state = %{state | lease_id: lease_id, presence: presence}
 
-        case open_port(spec) do
+        case open_port(spec, lineage_cfg) do
           {:ok, port, os_pid} ->
             Logger.info(
-              "agent #{agent_id} started os_pid=#{os_pid} lease=#{lease_id || "none"} cmd=#{Map.get(spec, :cmd)}"
+              "agent #{state.agent_id} started os_pid=#{os_pid} lease=#{lease_id || "none"} cmd=#{Map.get(spec, :cmd)}"
             )
 
             {:ok, %{state | port: port, os_pid: os_pid}}
@@ -399,7 +450,7 @@ defmodule AgentOrchestrator.AgentRunner do
     end
   end
 
-  defp open_port(spec) do
+  defp open_port(spec, lineage_cfg) do
     cmd = Map.fetch!(spec, :cmd)
 
     case resolve_executable(cmd) do
@@ -407,6 +458,11 @@ defmodule AgentOrchestrator.AgentRunner do
         {:error, {:executable_not_found, cmd}}
 
       path ->
+        # `|| []` not just a default: an explicit `env: nil` (spec built from
+        # nullable config) must not crash the merge below — that exception
+        # escapes open_port's rescue and orphans the just-acquired lease.
+        env = Map.get(spec, :env, []) || []
+
         opts =
           [
             :binary,
@@ -415,7 +471,7 @@ defmodule AgentOrchestrator.AgentRunner do
             {:line, @line_max_bytes},
             {:args, Map.get(spec, :args, [])}
           ]
-          |> maybe_opt(:env, encode_env(Map.get(spec, :env, [])))
+          |> maybe_opt(:env, encode_env(env ++ lineage_env(lineage_cfg, env)))
           |> maybe_opt(:cd, Map.get(spec, :cd))
 
         try do
@@ -430,6 +486,44 @@ defmodule AgentOrchestrator.AgentRunner do
 
   defp resolve_executable(cmd) do
     if String.contains?(cmd, "/"), do: cmd, else: System.find_executable(cmd)
+  end
+
+  # Lineage PROVISIONING (see moduledoc): candidate declarations only — the
+  # child makes its own onboard call. Validated up front because a malformed
+  # parent UUID does not fail here; it fails later as false ancestry in the
+  # governance lineage DAG, attributed to whatever agent declared it.
+  defp normalize_lineage_cfg(nil), do: {:ok, nil}
+
+  defp normalize_lineage_cfg(%{} = cfg) do
+    parent = Map.get(cfg, :parent_agent_uuid)
+    spawn_reason = Map.get(cfg, :spawn_reason, @default_spawn_reason)
+
+    cond do
+      not (is_binary(parent) and Regex.match?(@uuid_re, parent)) ->
+        {:error, {:parent_agent_uuid_not_uuid, parent}}
+
+      not (is_binary(spawn_reason) and spawn_reason != "") ->
+        {:error, {:spawn_reason_invalid, spawn_reason}}
+
+      true ->
+        {:ok, %{parent_agent_uuid: parent, spawn_reason: spawn_reason}}
+    end
+  end
+
+  defp normalize_lineage_cfg(other), do: {:error, {:lineage_not_map, other}}
+
+  defp lineage_env(nil, _env), do: []
+
+  defp lineage_env(%{} = cfg, env) do
+    explicit = MapSet.new(env, fn {k, _v} -> k end)
+
+    # Explicit env wins: the caller setting the var directly has made the more
+    # specific statement; silently overriding it would be the invasive version.
+    [
+      {@lineage_parent_var, cfg.parent_agent_uuid},
+      {@lineage_reason_var, cfg.spawn_reason}
+    ]
+    |> Enum.reject(fn {k, _v} -> MapSet.member?(explicit, k) end)
   end
 
   defp maybe_opt(opts, _key, nil), do: opts
@@ -469,6 +563,7 @@ defmodule AgentOrchestrator.AgentRunner do
       os_pid: state.os_pid,
       lease_id: state.lease_id,
       presence: state.presence,
+      lineage: state.lineage,
       exit_status: state.exit_status,
       running: state.exit_status == nil,
       lease_released: state.release_status == :ok,

--- a/elixir/agent_orchestrator/test/agent_orchestrator_test.exs
+++ b/elixir/agent_orchestrator/test/agent_orchestrator_test.exs
@@ -227,6 +227,116 @@ defmodule AgentOrchestratorTest do
     end
   end
 
+  describe "lineage provisioning" do
+    @parent_uuid "33333333-3333-4333-8333-333333333333"
+
+    test "provisions UNITARES_PARENT_AGENT_ID and UNITARES_SPAWN_REASON into the child env" do
+      {:ok, id, _} =
+        AgentOrchestrator.run(%{
+          cmd: "sh",
+          args: ["-c", ~s(echo "$UNITARES_PARENT_AGENT_ID|$UNITARES_SPAWN_REASON")],
+          lineage: %{parent_agent_uuid: @parent_uuid, spawn_reason: "explicit"}
+        })
+
+      assert {:ok, result} = AgentOrchestrator.await(id)
+      assert result.output == ["#{@parent_uuid}|explicit"]
+      assert result.lineage == :provisioned
+    end
+
+    test "spawn_reason defaults to subagent" do
+      {:ok, id, _} =
+        AgentOrchestrator.run(%{
+          cmd: "sh",
+          args: ["-c", "echo $UNITARES_SPAWN_REASON"],
+          lineage: %{parent_agent_uuid: @parent_uuid}
+        })
+
+      assert {:ok, %{output: ["subagent"]}} = AgentOrchestrator.await(id)
+    end
+
+    test "an explicit env entry wins over the provisioned value" do
+      {:ok, id, _} =
+        AgentOrchestrator.run(%{
+          cmd: "sh",
+          args: ["-c", ~s(echo "$UNITARES_PARENT_AGENT_ID|$UNITARES_SPAWN_REASON")],
+          env: [{"UNITARES_PARENT_AGENT_ID", "caller-override"}],
+          lineage: %{parent_agent_uuid: @parent_uuid}
+        })
+
+      # Parent var overridden by the explicit entry; spawn_reason still provisioned.
+      assert {:ok, %{output: ["caller-override|subagent"]}} = AgentOrchestrator.await(id)
+    end
+
+    test "without :lineage nothing is provisioned and the result says :none" do
+      {:ok, id, _} =
+        AgentOrchestrator.run(%{
+          cmd: "sh",
+          # ${VAR-unset}: distinguish absent from empty.
+          args: ["-c", ~s(echo "${UNITARES_PARENT_AGENT_ID-unset}")]
+        })
+
+      assert {:ok, result} = AgentOrchestrator.await(id)
+      assert result.output == ["unset"]
+      assert result.lineage == :none
+    end
+
+    test "refuses to spawn on a malformed parent UUID (no acquire, no child)" do
+      assert {:error, {:invalid_lineage, {:parent_agent_uuid_not_uuid, "not-a-uuid"}}} =
+               AgentOrchestrator.run(%{
+                 cmd: "echo",
+                 args: ["x"],
+                 lineage: %{parent_agent_uuid: "not-a-uuid"},
+                 lease_client: StubLeaseClient
+               })
+
+      # Validation runs before the lease path — no plane churn for a config error.
+      refute_receive {:lease_event, _}, 100
+    end
+
+    test "refuses a lineage map with no parent_agent_uuid" do
+      assert {:error, {:invalid_lineage, {:parent_agent_uuid_not_uuid, nil}}} =
+               AgentOrchestrator.run(%{cmd: "echo", args: ["x"], lineage: %{}})
+    end
+
+    test "refuses a non-map lineage value" do
+      assert {:error, {:invalid_lineage, {:lineage_not_map, "bad"}}} =
+               AgentOrchestrator.run(%{cmd: "echo", args: ["x"], lineage: "bad"})
+    end
+
+    test "refuses an empty spawn_reason" do
+      assert {:error, {:invalid_lineage, {:spawn_reason_invalid, ""}}} =
+               AgentOrchestrator.run(%{
+                 cmd: "echo",
+                 args: ["x"],
+                 lineage: %{parent_agent_uuid: @parent_uuid, spawn_reason: ""}
+               })
+    end
+
+    test "the inverse partial override: explicit spawn_reason, provisioned parent" do
+      {:ok, id, _} =
+        AgentOrchestrator.run(%{
+          cmd: "sh",
+          args: ["-c", ~s(echo "$UNITARES_PARENT_AGENT_ID|$UNITARES_SPAWN_REASON")],
+          env: [{"UNITARES_SPAWN_REASON", "caller-reason"}],
+          lineage: %{parent_agent_uuid: @parent_uuid}
+        })
+
+      assert {:ok, %{output: ["#{@parent_uuid}|caller-reason"]}} = AgentOrchestrator.await(id)
+    end
+
+    test "env: nil with lineage provisions without crashing (lease-orphan regression)" do
+      {:ok, id, _} =
+        AgentOrchestrator.run(%{
+          cmd: "sh",
+          args: ["-c", "echo $UNITARES_SPAWN_REASON"],
+          env: nil,
+          lineage: %{parent_agent_uuid: @parent_uuid}
+        })
+
+      assert {:ok, %{output: ["subagent"], exit_status: 0}} = AgentOrchestrator.await(id)
+    end
+  end
+
   describe "presence (default-on, best-effort)" do
     # Long-lived agents + snapshot/0 (read while alive) — avoids the await race
     # where a fast command exits and unregisters before the assertion runs.


### PR DESCRIPTION
## What

Ships the open operator call from #581 ("governance-lineage-injection") as its consent-shaped version: **provisioning, not injection**.

A spawner that knows its own governance UUID passes a first-class spec key:

```elixir
AgentOrchestrator.run(%{
  cmd: "claude", args: ["-p", task],
  lineage: %{parent_agent_uuid: spawner_uuid}   # spawn_reason defaults to "subagent"
})
```

and the child env gains `UNITARES_PARENT_AGENT_ID` / `UNITARES_SPAWN_REASON` as **candidate declarations**. Per the declaration-based identity ontology (identity.md v2), the child declares — or declines — lineage in its own onboard call; the orchestrator never makes a governance call on the child's behalf. It only puts the ground-truth parent UUID where the child (or its session-start hook) can find it, replacing prompt-convention lineage with spawn-context lineage.

## Semantics

- Explicit `env:` entries win over provisioned ones (partial override works both directions, tested).
- Malformed `parent_agent_uuid` refuses the spawn (`{:error, {:invalid_lineage, _}}`) **before** any lease acquire — garbage at the provisioning boundary surfaces downstream as false ancestry in the lineage DAG. Live-verified: the server stores `parent_agent_id` without shape validation, so this orchestrator check is the strictest gate in the chain.
- Result gains `lineage: :provisioned | :none`.
- `env: nil` with lineage no longer crashes the merge (would have escaped `open_port`'s rescue and orphaned the just-acquired lease — council finding, regression-tested).

## Council

3-agent review (code-reviewer + architect + live-verifier), all findings addressed:
- reviewer: `env: nil` lease-orphan path → fixed + test
- architect: ship-with-changes → added non-map-lineage, empty-spawn_reason, inverse-partial-override tests; renamed `{:spawn_reason_not_string,_}` → `{:spawn_reason_invalid,_}`
- live-verifier: `"subagent"` confirmed against live server vocabulary; `UNITARES_PARENT_AGENT_ID`/`UNITARES_SPAWN_REASON` confirmed unclaimed (no existing reader/setter in unitares, gov-plugin, agents/, or launchd plists)

## Tests

`mix test`: 33 tests, 0 failures (10 new). Elixir is not in CI; ran locally.

## Follow-up (next PR, gov-plugin repo)

session-start hook gains the env-var lineage source: `UNITARES_PARENT_AGENT_ID` becomes the highest-confidence lineage candidate, above slot-file and scan-newest.