### PR TITLE
[codex] chore(workflow): route stuck work to draft PRs

### DIFF
--- a/commands/closeout.md
+++ b/commands/closeout.md
@@ -24,6 +24,17 @@ Report:
 - any repo-rooted processes still running
 - whether a remaining process is managed by a LaunchAgent label
 
+If work should be delivered instead of left local, stage the intentional files
+and use the ship helper:
+
+- `./scripts/dev/ship.sh --plan "commit message"` previews the delivery route
+- `./scripts/dev/ship.sh --draft-pr "commit message"` commits, pushes, and opens
+  a draft PR
+- `./scripts/dev/ship.sh "commit message"` uses the default route: runtime or
+  detached work becomes a draft PR; ordinary non-runtime branch work direct-pushes
+- `./scripts/dev/ship.sh --auto-merge "commit message"` opts into the old
+  auto-merge-on-green behavior for PR-routed work
+
 If the operator asked to clean the workspace, or if you are finishing a task
 whose intended work is already committed/stashed, run:
 
@@ -37,9 +48,12 @@ Rules:
 - If there are staged changes, decide whether to commit, unstage, or stash
   before final response; do not leave them ambiguous.
 - If `delivery` is `local_changes`, say plainly: not committed, not pushed,
-  not merged.
+  not merged. If the changes are intentional, name the ship command that would
+  move them to a branch or draft PR.
 - If `delivery` is `unpushed_commits`, say plainly: committed locally but not
   pushed or merged.
+- If the checkout is detached, do not direct-push. Use `ship.sh --draft-pr` or
+  create a named branch first.
 - If `delivery` is `pushed_branch`, do not claim merge completion unless you
   also checked GitHub PR state explicitly.
 - If the operator asks "merged?", answer directly from delivery state and any

--- a/scripts/dev/ship.sh
+++ b/scripts/dev/ship.sh
@@ -3,17 +3,24 @@
 #
 # Routes changes to the right delivery path based on what they touch:
 #   - Runtime code (agents/, src/mcp_handlers/, src/mcp_server*, src/core.py,
-#     src/background_tasks.py) → feature branch + PR + auto-merge-on-green.
+#     src/background_tasks.py) → feature branch + draft PR by default.
+#   - Detached HEAD work → feature branch + draft PR by default.
 #   - Everything else → direct commit + push on the current branch.
 #
 # The split exists because multiple agents push to this repo concurrently.
 # Runtime changes need a rollback artifact (the PR) and cross-agent
 # visibility; docs/tests/helpers don't, and PR friction for every tiny
-# edit would slow the fleet down.
+# edit would slow the fleet down. Draft PRs make unfinished runtime/detached
+# work visible without pretending it is ready to merge.
 #
 # Usage:
 #   ./scripts/dev/ship.sh "commit message"
+#   ./scripts/dev/ship.sh --draft-pr "commit message"
+#   ./scripts/dev/ship.sh --open-pr "commit message"
+#   ./scripts/dev/ship.sh --auto-merge "commit message"
+#   ./scripts/dev/ship.sh --direct "commit message"
 #   ./scripts/dev/ship.sh --classify          # just print "runtime" or "other"
+#   ./scripts/dev/ship.sh --plan "commit message"
 #
 # Requirements: staged changes (git add already done), gh CLI authed.
 
@@ -88,26 +95,152 @@ collect_watcher_fingerprints() {
         | python3 "$PROJECT_ROOT/scripts/dev/_ship_watcher_fingerprints.py" "$findings"
 }
 
-if [[ "${1:-}" == "--classify" ]]; then
-    classify
-    exit 0
-fi
+usage() {
+    cat >&2 <<'USAGE'
+usage: ship.sh [--draft-pr|--open-pr|--auto-merge|--direct] "commit message"
+       ship.sh --classify
+       ship.sh --plan "commit message"
 
-MESSAGE="${1:-}"
+Modes:
+  auto         runtime or detached work -> draft PR; other branch work -> direct push
+  --draft-pr  commit, push current/new branch, and open a draft PR
+  --open-pr   commit, push current/new branch, and open a ready PR
+  --auto-merge
+               commit, push current/new branch, open a ready PR, and enable auto-merge
+  --direct    commit and push the current branch; refuses detached HEAD
+USAGE
+}
+
+MODE="${UNITARES_SHIP_MODE:-auto}"
+PLAN_ONLY=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --classify)
+            classify
+            exit 0
+            ;;
+        --plan|--dry-run)
+            PLAN_ONLY=1
+            shift
+            ;;
+        --draft-pr|--draft)
+            MODE="draft_pr"
+            shift
+            ;;
+        --open-pr|--pr)
+            MODE="open_pr"
+            shift
+            ;;
+        --auto-merge)
+            MODE="auto_merge"
+            shift
+            ;;
+        --direct)
+            MODE="direct"
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        --*)
+            echo "unknown option: $1" >&2
+            usage
+            exit 2
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+MESSAGE="${*:-}"
 if [[ -z "$MESSAGE" ]]; then
-    echo "usage: ship.sh \"commit message\"" >&2
+    usage
     exit 2
 fi
 
 KIND=$(classify)
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
+BRANCH=$(git branch --show-current)
+HEAD_SHORT=$(git rev-parse --short HEAD)
+DETACHED=0
+if [[ -z "$BRANCH" ]]; then
+    DETACHED=1
+fi
+
+normalize_mode() {
+    case "$1" in
+        auto|draft_pr|open_pr|auto_merge|direct)
+            echo "$1" ;;
+        draft-pr|draft)
+            echo "draft_pr" ;;
+        open-pr|pr)
+            echo "open_pr" ;;
+        auto-merge)
+            echo "auto_merge" ;;
+        *)
+            echo "invalid" ;;
+    esac
+}
+
+MODE=$(normalize_mode "$MODE")
+if [[ "$MODE" == "invalid" ]]; then
+    echo "invalid UNITARES_SHIP_MODE; expected auto, draft-pr, open-pr, auto-merge, or direct" >&2
+    exit 2
+fi
+
+DELIVERY="$MODE"
+FORCE_AUTO_BRANCH=0
+if [[ "$MODE" == "auto" ]]; then
+    if [[ "$KIND" == "runtime" ]]; then
+        DELIVERY="draft_pr"
+        FORCE_AUTO_BRANCH=1
+    elif [[ "$DETACHED" == "1" ]]; then
+        DELIVERY="draft_pr"
+        FORCE_AUTO_BRANCH=1
+    else
+        DELIVERY="direct"
+    fi
+elif [[ "$DETACHED" == "1" && "$MODE" != "direct" ]]; then
+    FORCE_AUTO_BRANCH=1
+fi
+
+if [[ "$KIND" == "empty" ]]; then
+    echo "nothing staged — stage files with 'git add' first" >&2
+    exit 2
+fi
+
+if [[ "$DELIVERY" == "direct" && "$DETACHED" == "1" ]]; then
+    echo "detached HEAD cannot use direct delivery; rerun with --draft-pr or create a branch" >&2
+    exit 2
+fi
+
+if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
+    case "$DELIVERY" in
+        draft_pr|open_pr|auto_merge)
+            FORCE_AUTO_BRANCH=1 ;;
+    esac
+fi
+
+if [[ "$PLAN_ONLY" == "1" ]]; then
+    branch_label="${BRANCH:-"(detached)"}"
+    echo "kind=$KIND"
+    echo "branch=$branch_label"
+    echo "head=$HEAD_SHORT"
+    echo "mode=$MODE"
+    echo "delivery=$DELIVERY"
+    echo "force_auto_branch=$FORCE_AUTO_BRANCH"
+    exit 0
+fi
 
 # Phase A advisory / Phase B enforcement lease. In advisory mode a
 # held_by_other or service_unavailable outcome is telemetry-only. When
 # LEASE_PLANE_ENFORCED_SURFACE_KINDS includes this surface kind, a missing
 # lease blocks the ship.
+LEASE_BRANCH="${BRANCH:-detached-$HEAD_SHORT}"
 LEASE_RESULT=$(python3 "$PROJECT_ROOT/scripts/dev/_ship_lease_advisory.py" acquire \
-    --surface-id="resident:/ship_sh_$BRANCH" \
+    --surface-id="resident:/ship_sh_$LEASE_BRANCH" \
     --surface-kind="ship_sh" \
     --intent="$MESSAGE" \
     --ttl-s=300 2>/dev/null || echo '{"outcome":"client_error","lease_id":null}')
@@ -148,42 +281,99 @@ if git diff --cached --name-only | grep -q '^skills/'; then
     fi
 fi
 
-case "$KIND" in
-    empty)
-        echo "nothing staged — stage files with 'git add' first" >&2
-        exit 2 ;;
-    runtime)
-        SLUG=$(printf '%s' "$MESSAGE" | tr '[:upper:] ' '[:lower:]-' | tr -cd 'a-z0-9-' | cut -c1-40)
-        # Agent-scoped prefix so concurrent agents' auto-branches are self-identifying.
-        # Override with UNITARES_SHIP_AGENT=<name>; otherwise detect from env.
-        AGENT_PREFIX="${UNITARES_SHIP_AGENT:-}"
-        if [[ -z "$AGENT_PREFIX" ]]; then
-            if [[ -n "${CLAUDECODE:-}" ]]; then
-                AGENT_PREFIX="claude"
-            else
-                AGENT_PREFIX="codex"
-            fi
+if [[ "$KIND" != "runtime" && "$KIND" != "other" ]]; then
+    echo "unknown staged-change classification: $KIND" >&2
+    exit 2
+fi
+
+create_auto_branch_if_needed() {
+    if [[ "$FORCE_AUTO_BRANCH" != "1" ]]; then
+        return 0
+    fi
+
+    local slug
+    slug=$(printf '%s' "$MESSAGE" | tr '[:upper:] ' '[:lower:]-' | tr -cd 'a-z0-9-' | cut -c1-40)
+    if [[ -z "$slug" ]]; then
+        slug="change"
+    fi
+
+    # Agent-scoped prefix so concurrent agents' auto-branches are self-identifying.
+    # Override with UNITARES_SHIP_AGENT=<name>; otherwise detect from env.
+    local agent_prefix="${UNITARES_SHIP_AGENT:-}"
+    if [[ -z "$agent_prefix" ]]; then
+        if [[ -n "${CLAUDECODE:-}" ]]; then
+            agent_prefix="claude"
+        else
+            agent_prefix="codex"
         fi
-        NEW_BRANCH="${AGENT_PREFIX}/auto/$(date +%Y%m%d-%H%M%S)-${SLUG}"
-        echo "[ship] runtime path → $NEW_BRANCH (PR + auto-merge)"
-        git checkout -b "$NEW_BRANCH"
-        git commit -m "$COMMIT_MESSAGE"
-        git push -u origin "$NEW_BRANCH"
-        # GitHub caps PR titles at 256 chars; conventional-commit subjects are
-        # ~72. Use only the first line so multi-line commit messages (subject +
-        # body) don't blow past the GraphQL limit and fail PR creation. See
-        # issue #289 — hit on PR #288 with a long-bodied commit.
-        PR_TITLE=$(printf '%s\n' "$MESSAGE" | head -n1)
-        PR_URL=$(gh pr create --title "$PR_TITLE" --body "Auto-shipped by ship.sh — runtime path. Auto-merge is enabled; CI gate applies.")
-        echo "$PR_URL"
-        gh pr merge --auto --squash "$PR_URL" || \
+    fi
+
+    local new_branch="${agent_prefix}/auto/$(date +%Y%m%d-%H%M%S)-${slug}"
+    echo "[ship] creating PR branch: $new_branch"
+    git checkout -b "$new_branch"
+    BRANCH="$new_branch"
+}
+
+create_or_show_pr() {
+    local pr_kind="$1"
+    local pr_title pr_body pr_url existing_url
+
+    # GitHub caps PR titles at 256 chars; conventional-commit subjects are
+    # ~72. Use only the first line so multi-line commit messages (subject +
+    # body) don't blow past the GraphQL limit and fail PR creation. See
+    # issue #289 — hit on PR #288 with a long-bodied commit.
+    pr_title=$(printf '%s\n' "$MESSAGE" | head -n1)
+
+    existing_url=$(gh pr view --json url --jq .url 2>/dev/null || true)
+    if [[ -n "$existing_url" ]]; then
+        echo "[ship] PR already exists for $BRANCH"
+        echo "$existing_url"
+        return 0
+    fi
+
+    case "$pr_kind" in
+        draft_pr)
+            pr_body="Auto-shipped by ship.sh as a draft PR. Local work is visible; mark ready after validation/review."
+            pr_url=$(gh pr create --draft --title "$pr_title" --body "$pr_body")
+            ;;
+        open_pr)
+            pr_body="Auto-shipped by ship.sh as an open PR. CI gate applies."
+            pr_url=$(gh pr create --title "$pr_title" --body "$pr_body")
+            ;;
+        auto_merge)
+            pr_body="Auto-shipped by ship.sh. Auto-merge requested; CI gate applies."
+            pr_url=$(gh pr create --title "$pr_title" --body "$pr_body")
+            ;;
+        *)
+            echo "internal error: unknown PR kind $pr_kind" >&2
+            exit 2
+            ;;
+    esac
+    echo "$pr_url"
+
+    if [[ "$pr_kind" == "auto_merge" ]]; then
+        gh pr merge --auto --squash "$pr_url" || \
             echo "[ship] auto-merge not enabled (branch protection may require manual setup); PR is open"
-        ;;
-    other)
-        echo "[ship] non-runtime → direct commit + push on $BRANCH"
+    fi
+}
+
+case "$DELIVERY" in
+    direct)
+        echo "[ship] direct path → commit + push on $BRANCH"
         git commit -m "$COMMIT_MESSAGE"
         # Push to the same-name branch on origin, not whatever upstream tracks
         # (a feature branch may track master and would otherwise push ambiguously).
-        git push origin "HEAD:$BRANCH"
+        git push -u origin "HEAD:$BRANCH"
+        ;;
+    draft_pr|open_pr|auto_merge)
+        create_auto_branch_if_needed
+        echo "[ship] PR path → $BRANCH ($DELIVERY)"
+        git commit -m "$COMMIT_MESSAGE"
+        git push -u origin "$BRANCH"
+        create_or_show_pr "$DELIVERY"
+        ;;
+    *)
+        echo "internal error: unknown delivery path $DELIVERY" >&2
+        exit 2
         ;;
 esac

--- a/tests/test_ship_workflow.py
+++ b/tests/test_ship_workflow.py
@@ -1,0 +1,106 @@
+"""Tests for scripts/dev/ship.sh delivery routing."""
+
+from __future__ import annotations
+
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SHIP_SOURCE = PROJECT_ROOT / "scripts" / "dev" / "ship.sh"
+
+
+def run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+
+@pytest.fixture
+def ship_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    script_path = repo / "scripts" / "dev" / "ship.sh"
+    script_path.parent.mkdir(parents=True)
+    shutil.copy2(SHIP_SOURCE, script_path)
+    script_path.chmod(script_path.stat().st_mode | stat.S_IXUSR)
+
+    run(["git", "init", "-q", "-b", "main"], repo)
+    run(["git", "config", "user.email", "t@t"], repo)
+    run(["git", "config", "user.name", "t"], repo)
+    run(["git", "config", "commit.gpgsign", "false"], repo)
+    (repo / "README.md").write_text("seed\n")
+    run(["git", "add", "README.md"], repo)
+    run(["git", "commit", "-q", "-m", "seed"], repo)
+    return repo
+
+
+def stage_file(repo: Path, relative_path: str) -> None:
+    path = repo / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"{relative_path}\n")
+    run(["git", "add", relative_path], repo)
+
+
+def ship_plan(repo: Path, *options: str) -> dict[str, str]:
+    cmd = [str(repo / "scripts" / "dev" / "ship.sh"), "--plan", *options, "test: change"]
+    result = run(cmd, repo)
+    parsed: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        key, value = line.split("=", 1)
+        parsed[key] = value
+    return parsed
+
+
+def test_auto_routes_runtime_changes_to_draft_pr_branch(ship_repo: Path) -> None:
+    stage_file(ship_repo, "src/mcp_server.py")
+
+    plan = ship_plan(ship_repo)
+
+    assert plan["kind"] == "runtime"
+    assert plan["branch"] == "main"
+    assert plan["delivery"] == "draft_pr"
+    assert plan["force_auto_branch"] == "1"
+
+
+def test_auto_routes_detached_non_runtime_changes_to_draft_pr(ship_repo: Path) -> None:
+    run(["git", "checkout", "--detach", "-q"], ship_repo)
+    stage_file(ship_repo, "docs/workflow-note.md")
+
+    plan = ship_plan(ship_repo)
+
+    assert plan["kind"] == "other"
+    assert plan["branch"] == "(detached)"
+    assert plan["delivery"] == "draft_pr"
+    assert plan["force_auto_branch"] == "1"
+
+
+def test_auto_routes_feature_branch_docs_to_direct_push(ship_repo: Path) -> None:
+    run(["git", "checkout", "-q", "-b", "docs/workflow-note"], ship_repo)
+    stage_file(ship_repo, "docs/workflow-note.md")
+
+    plan = ship_plan(ship_repo)
+
+    assert plan["kind"] == "other"
+    assert plan["branch"] == "docs/workflow-note"
+    assert plan["delivery"] == "direct"
+    assert plan["force_auto_branch"] == "0"
+
+
+def test_explicit_draft_pr_uses_current_feature_branch(ship_repo: Path) -> None:
+    run(["git", "checkout", "-q", "-b", "codex/workflow-note"], ship_repo)
+    stage_file(ship_repo, "docs/workflow-note.md")
+
+    plan = ship_plan(ship_repo, "--draft-pr")
+
+    assert plan["kind"] == "other"
+    assert plan["branch"] == "codex/workflow-note"
+    assert plan["delivery"] == "draft_pr"
+    assert plan["force_auto_branch"] == "0"


### PR DESCRIPTION
Summary:
- Make ship.sh route runtime and detached work to draft PRs by default instead of auto-merge/direct-push dead ends.
- Add explicit --draft-pr, --open-pr, --auto-merge, --direct, and --plan modes.
- Update closeout docs with delivery commands and add route-decision tests.

Validation:
- bash -n scripts/dev/ship.sh
- python3 -m pytest -q tests/test_ship_workflow.py
- ./scripts/dev/test-cache.sh --staged: 9575 passed, 35 skipped
- pre-push hook: 138 passed, 8873 deselected