### PR TITLE
fix(stuck): dedupe stuck_detected audit writes + stale-cap margin rules

### DIFF
--- a/src/mcp_handlers/lifecycle/stuck.py
+++ b/src/mcp_handlers/lifecycle/stuck.py
@@ -131,12 +131,39 @@ CADENCE_SILENCE_MULTIPLIER = 6.0        # silent for >= this many times its own 
 # this is what keeps the audit trail from filling with finished-but-unarchived
 # ephemeral agents (which cadence cannot distinguish from a genuine hang).
 CADENCE_SILENCE_STALE_CAP_MINUTES = 1440.0   # 24h
+# The margin timeout rules get the same upper bound. An abandoned identity's
+# margin is computed from its FROZEN state — no new check-ins ever arrive to
+# move it off critical/tight — so without a cap the agent stays "stuck" forever,
+# pinning the stuck KPI and re-firing the audit trail on every sweep (observed
+# 2026-06-12: ~24 day-old unnamed identities held the count indefinitely).
+MARGIN_STUCK_STALE_CAP_MINUTES = 1440.0      # 24h, matches the cadence cap
 # NOTE on the cadence proxy: avg_gap is computed over the agent's WHOLE life
 # (created_at -> last_update), which is a coarse proxy for "recent rhythm." A
 # recent-window cadence (last N gaps) would be more precise but needs the
 # per-check-in timestamp series, which this path doesn't have. Coarse-but-safe:
 # it errs toward flagging, and the signal is soft. Also note the MULTIPLIER is
 # floor-dominated for fast agents (avg_gap < 5min => 6*gap < 30 => floor wins).
+
+
+def stuck_change_token(stuck_agents: list) -> str:
+    """Emit-on-change dedup token for the stuck_detected audit write.
+
+    Keyed on the detected set itself — sorted (agent_id, reason) pairs — not on
+    counts or human-readable details, so the token advances exactly when an
+    agent enters or leaves the stuck set or its reason changes. Repeated sweeps
+    over an unchanged set yield an identical token and write nothing. Mirrors
+    anomaly_change_token (#638).
+    """
+    import hashlib
+    basis = "|".join(
+        sorted(f"{s.get('agent_id')}:{s.get('reason')}" for s in stuck_agents)
+    )
+    return hashlib.sha256(basis.encode()).hexdigest()[:16]
+
+
+# Last-written stuck_detected token (process-lifetime; a restart re-emits one
+# row for a persisting set, which is acceptable and self-documents the restart).
+_last_stuck_audit_token: str | None = None
 
 
 def _detect_stuck_agents(
@@ -267,6 +294,14 @@ def _detect_stuck_agents(
                         continue
         except (ValueError, TypeError, AttributeError) as e:
             logger.debug(f"cadence-silence check failed for {agent_id}: {e}")
+
+        # Stale cap (mirrors CADENCE_SILENCE_STALE_CAP_MINUTES): beyond this,
+        # an idle agent is abandoned/archive-pending, not a live hang. Its
+        # margin is frozen — no new check-ins will ever move it — so evaluating
+        # it below would flag it "stuck" on every sweep until the end of time.
+        # Skipping here also avoids hydrating monitors for dead agents.
+        if age_minutes > MARGIN_STUCK_STALE_CAP_MINUTES:
+            continue
 
         # Get current metrics to compute margin
         try:
@@ -590,20 +625,35 @@ async def handle_detect_stuck_agents(arguments: Dict[str, Any]) -> Sequence:
                 if result:
                     recovered.extend(result if isinstance(result, list) else [result])
 
-        # Log stuck agents to audit trail (if any detected)
+        # Log stuck agents to audit trail — emit-on-change only. This handler
+        # runs on every dashboard refresh PLUS a 5-min background sweep;
+        # unconditional writes filled the audit trail with hundreds of identical
+        # rows per hour (observed ~250/h on 2026-06-12). Same pattern as
+        # anomaly_change_token (#638). A cleared set resets the token, so a
+        # genuine re-occurrence of the same set is logged again.
+        # Concurrency note: the read-compare-assign-write below is await-free,
+        # so under asyncio it runs atomically between suspension points —
+        # concurrent handler invocations serialize around it. No lock needed
+        # unless an await is ever introduced inside this block.
+        global _last_stuck_audit_token
         if stuck_agents:
-            from src.audit_log import audit_logger, AuditEntry
-            from datetime import datetime
-            audit_logger._write_entry(AuditEntry(
-                timestamp=datetime.now().isoformat(),
-                agent_id="system",
-                event_type="stuck_detected",
-                confidence=1.0,
-                details={
-                    "count": len(stuck_agents),
-                    "agents": [{"agent_id": s.get("agent_id"), "reason": s.get("reason"), "agent_name": s.get("agent_name", "")} for s in stuck_agents[:10]],
-                }
-            ))
+            token = stuck_change_token(stuck_agents)
+            if token != _last_stuck_audit_token:
+                _last_stuck_audit_token = token
+                from src.audit_log import audit_logger, AuditEntry
+                from datetime import datetime
+                audit_logger._write_entry(AuditEntry(
+                    timestamp=datetime.now().isoformat(),
+                    agent_id="system",
+                    event_type="stuck_detected",
+                    confidence=1.0,
+                    details={
+                        "count": len(stuck_agents),
+                        "agents": [{"agent_id": s.get("agent_id"), "reason": s.get("reason"), "agent_name": s.get("agent_name", "")} for s in stuck_agents[:10]],
+                    }
+                ))
+        else:
+            _last_stuck_audit_token = None
 
         return success_response({
             "stuck_agents": stuck_agents,

--- a/tests/test_lifecycle_detect_stuck.py
+++ b/tests/test_lifecycle_detect_stuck.py
@@ -695,3 +695,135 @@ class TestDetectStuckAgentsCadenceSilence:
         result = [r for r in _detect_stuck_agents(critical_margin_timeout_minutes=5) if r["agent_id"] == "a1"]
         assert len(result) == 1
         assert result[0]["reason"] == "cadence_silence"
+
+
+class TestMarginStaleCap:
+    """Margin timeout rules must not fire on abandoned identities (> 24h idle).
+
+    An abandoned agent's margin is computed from its frozen state — no new
+    check-ins ever arrive to move it off critical — so without the cap it is
+    "stuck" forever (observed 2026-06-12: ~24 day-old identities pinned the
+    stuck KPI and re-fired the audit trail on every sweep).
+    """
+
+    @patch(_PATCHES["gov_config"])
+    @patch(_PATCHES["mcp_server"])
+    def test_abandoned_critical_margin_suppressed(self, mock_server, mock_config):
+        """Critical margin but idle > MARGIN_STUCK_STALE_CAP_MINUTES → not stuck."""
+        old_time = datetime.now(timezone.utc) - timedelta(hours=25)
+        mock_server.agent_metadata = {
+            "a1": _make_agent_meta(last_update=old_time),
+        }
+        mock_server.monitors = {"a1": _make_monitor(risk=0.8, coherence=0.42)}
+        mock_config.compute_proprioceptive_margin.return_value = _margin_info(
+            "critical", nearest_edge="risk", distance=0.02
+        )
+
+        from src.mcp_handlers.lifecycle.stuck import _detect_stuck_agents
+        result = _detect_stuck_agents(
+            critical_margin_timeout_minutes=5,
+            include_pattern_detection=False,
+        )
+        assert result == []
+
+    @patch(_PATCHES["gov_config"])
+    @patch(_PATCHES["mcp_server"])
+    def test_old_but_under_cap_still_stuck(self, mock_server, mock_config):
+        """Idle 23h (< cap) with critical margin → still detected."""
+        old_time = datetime.now(timezone.utc) - timedelta(hours=23)
+        mock_server.agent_metadata = {
+            "a1": _make_agent_meta(last_update=old_time),
+        }
+        mock_server.monitors = {"a1": _make_monitor(risk=0.8, coherence=0.42)}
+        mock_config.compute_proprioceptive_margin.return_value = _margin_info(
+            "critical", nearest_edge="risk", distance=0.02
+        )
+
+        from src.mcp_handlers.lifecycle.stuck import _detect_stuck_agents
+        result = _detect_stuck_agents(
+            critical_margin_timeout_minutes=5,
+            include_pattern_detection=False,
+        )
+        assert len(result) == 1
+        assert result[0]["reason"] == "critical_margin_timeout"
+
+
+class TestStuckAuditDedupe:
+    """stuck_detected audit writes are emit-on-change (stuck_change_token).
+
+    The handler runs on every dashboard refresh plus a 5-min background sweep;
+    unconditional writes produced ~250 identical audit rows/hour (2026-06-12).
+    """
+
+    def setup_method(self):
+        import src.mcp_handlers.lifecycle.stuck as stuck_module
+        stuck_module._last_stuck_audit_token = None
+
+    def _stuck_set(self, *ids_reasons):
+        return [
+            {"agent_id": aid, "reason": reason, "age_minutes": 10.0}
+            for aid, reason in ids_reasons
+        ]
+
+    def test_token_stable_across_order(self):
+        from src.mcp_handlers.lifecycle.stuck import stuck_change_token
+        a = self._stuck_set(("a1", "critical_margin_timeout"), ("a2", "cadence_silence"))
+        b = self._stuck_set(("a2", "cadence_silence"), ("a1", "critical_margin_timeout"))
+        assert stuck_change_token(a) == stuck_change_token(b)
+
+    def test_token_changes_on_membership_and_reason(self):
+        from src.mcp_handlers.lifecycle.stuck import stuck_change_token
+        base = self._stuck_set(("a1", "critical_margin_timeout"))
+        grown = self._stuck_set(("a1", "critical_margin_timeout"), ("a2", "cadence_silence"))
+        reasoned = self._stuck_set(("a1", "tight_margin_timeout"))
+        assert stuck_change_token(base) != stuck_change_token(grown)
+        assert stuck_change_token(base) != stuck_change_token(reasoned)
+
+    @pytest.mark.asyncio
+    async def test_unchanged_set_writes_audit_once(self):
+        stuck_set = self._stuck_set(("a1", "critical_margin_timeout"))
+        with patch(_PATCHES["mcp_server"]) as mock_server, \
+             patch("src.mcp_handlers.lifecycle.stuck._detect_stuck_agents", return_value=stuck_set) as mock_detect, \
+             patch("src.audit_log.audit_logger._write_entry") as mock_write:
+            mock_server.load_metadata_async = MagicMock(return_value=_async_none())
+            from src.mcp_handlers.lifecycle.stuck import handle_detect_stuck_agents
+            await handle_detect_stuck_agents({})
+            # Pin the executor argument order: (max_age, critical_timeout,
+            # tight_timeout, include_patterns, min_updates)
+            mock_detect.assert_called_once_with(30.0, 5.0, 15.0, True, 1)
+            mock_server.load_metadata_async = MagicMock(return_value=_async_none())
+            await handle_detect_stuck_agents({})
+            assert mock_write.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_changed_set_writes_again(self):
+        first = self._stuck_set(("a1", "critical_margin_timeout"))
+        second = self._stuck_set(("a1", "critical_margin_timeout"), ("a2", "cadence_silence"))
+        with patch(_PATCHES["mcp_server"]) as mock_server, \
+             patch("src.mcp_handlers.lifecycle.stuck._detect_stuck_agents", side_effect=[first, second]), \
+             patch("src.audit_log.audit_logger._write_entry") as mock_write:
+            mock_server.load_metadata_async = MagicMock(side_effect=lambda: _async_none())
+            from src.mcp_handlers.lifecycle.stuck import handle_detect_stuck_agents
+            await handle_detect_stuck_agents({})
+            await handle_detect_stuck_agents({})
+            assert mock_write.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_cleared_set_resets_token(self):
+        """non-empty → empty → same non-empty set again must log twice."""
+        stuck_set = self._stuck_set(("a1", "critical_margin_timeout"))
+        with patch(_PATCHES["mcp_server"]) as mock_server, \
+             patch("src.mcp_handlers.lifecycle.stuck._detect_stuck_agents", side_effect=[stuck_set, [], stuck_set]), \
+             patch("src.audit_log.audit_logger._write_entry") as mock_write:
+            mock_server.load_metadata_async = MagicMock(side_effect=lambda: _async_none())
+            from src.mcp_handlers.lifecycle.stuck import handle_detect_stuck_agents
+            await handle_detect_stuck_agents({})
+            await handle_detect_stuck_agents({})
+            await handle_detect_stuck_agents({})
+            assert mock_write.call_count == 2
+
+
+def _async_none():
+    async def _coro():
+        return None
+    return _coro()


### PR DESCRIPTION
## Problem (from dashboard investigation dossier, 2026-06-12)

The Stuck Agents KPI was pinned at 16–25 with a 100-incident history of identical rows logged multiple times per minute.

Ground-truthed live before this fix:
- `audit.events` received **418 `stuck_detected` rows in 2 hours (~3/min)**, ~200 consecutive rows carrying the identical agent set — `handle_detect_stuck_agents` wrote an audit row on every call, and the dashboard refresh loop calls it ~3×/min on top of the 5-min background sweep.
- The stuck set itself never drains: the margin timeout rules have no upper age bound, so abandoned identities (day-old unnamed session corpses with frozen critical/tight margins) stay "stuck" forever — no new check-ins ever arrive to move their margin.

## Fix

1. **Emit-on-change audit writes** — `stuck_change_token` keyed on sorted `(agent_id, reason)` pairs; the handler writes only when the set changes, and a cleared set resets the token so a genuine re-occurrence logs again. Mirrors `anomaly_change_token` (#638). The token block is await-free, so it is atomic under asyncio (documented in a comment).
2. **`MARGIN_STUCK_STALE_CAP_MINUTES` (24h)** — margin/pattern evaluation skips agents idle beyond the cap, mirroring `CADENCE_SILENCE_STALE_CAP_MINUTES` and its rationale: beyond 24h an idle agent is abandoned/archive-pending, not a live hang. Also avoids hydrating monitors for dead agents on every sweep.

## Council review notes

3-agent council (code-reviewer + live-verifier) ran on the diff:
- Reviewer's race-condition concern on the module-level token: not applicable — the check→set→write sequence contains no await, so concurrent invocations serialize on the event loop (comment added).
- Accepted trade: the stale cap also suppresses pattern-based detection (cognitive_loop/time_box) for >24h-idle agents — their patterns derive from updates that are themselves >24h old.
- Pre-existing, out of scope: handler `min_updates` default (1) diverges from the function default (3); audit payload `agents` array is capped at 10 while `count` reports the full set.

## Tests

5 new tests: stale-cap suppression at 25h + still-stuck control at 23h; token order-stability and membership/reason sensitivity; audit-once for unchanged set (with executor arg-order pin); write-again on change; token reset on cleared set. Full local gate green.