### PR TITLE
fix(audit): strict-gate refusals are failures, not anonymous successes

### DIFF
--- a/src/services/http_tool_service.py
+++ b/src/services/http_tool_service.py
@@ -223,8 +223,16 @@ async def execute_http_tool(tool_name: str, arguments: Dict[str, Any]) -> Any:
         refusal = _strict_identity_refusal_or_none(tool_name, arguments)
         if refusal is not None:
             latency_ms = int((time.monotonic() - t0) * 1000)
+            # A typed refusal is NOT a tool success. Recording success=True
+            # here made every strict-gate refusal look like a SUCCEEDING
+            # anonymous call in audit.tool_usage — poisoning exactly the
+            # burn-in question "did any unbound write get through?" (#543
+            # honesty class; found day 1 of the 2026-06-12 stage 2-4
+            # burn-in). error_type mirrors the refusal payload's status so
+            # triage queries can subtract refusals without log archaeology.
             record_tool_usage(tool_name=tool_name, agent_id=None,
-                              success=True, latency_ms=latency_ms)
+                              success=False, error_type="identity_required",
+                              latency_ms=latency_ms)
             return refusal
 
         # Wave 3a routing — HTTP path symmetric with MCP-protocol wrapper.

--- a/tests/test_rest_strict_identity_gate.py
+++ b/tests/test_rest_strict_identity_gate.py
@@ -14,7 +14,7 @@ rollout advances.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -221,3 +221,29 @@ async def test_execute_flag_off_falls_through(strict_off, unbound_context):
 
     assert result == {"ok": True}
     fallback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_refusal_audit_row_is_failure_not_success(strict_on, unbound_context):
+    """A typed refusal must land in audit.tool_usage as a FAILURE with
+    error_type='identity_required'. Recording success=True made every
+    strict-gate refusal indistinguishable from a succeeding anonymous
+    call — poisoning the burn-in question 'did any unbound write get
+    through?' (found day 1 of the 2026-06-12 stage 2-4 burn-in; #543
+    audit-honesty class)."""
+    recorder = MagicMock()
+    fallback = AsyncMock()
+    with patch(
+        "src.services.http_tool_service.execute_http_dispatch_fallback", fallback
+    ), patch("src.services.http_tool_service.record_tool_usage", recorder):
+        result = await execute_http_tool(
+            "knowledge",
+            {"action": "store", "summary": "x"},
+        )
+
+    assert result["status"] == "identity_required"
+    recorder.assert_called_once()
+    kwargs = recorder.call_args.kwargs
+    assert kwargs["success"] is False
+    assert kwargs["error_type"] == "identity_required"
+    assert kwargs["agent_id"] is None


### PR DESCRIPTION
Found day 1 of the stage 2–4 burn-in: `execute_http_tool` records every typed strict-gate refusal as `success=True, agent_id=None` in `audit.tool_usage` (`http_tool_service.py:226`) — indistinguishable from a **succeeding anonymous call**. Operator spotted what looked like an anonymous KG write; the KG table proved nothing landed — the audit row was a mislabeled refusal. Same #543 audit-honesty class.

This matters for the 2026-06-19 stage-4 flip review: its core evidence query is "did any unbound write succeed during the burn-in week?" — with this bug the audit answers yes for every refusal.

Fix: refusals record `success=False, error_type='identity_required'`. Test pins the row shape. Data caveat for analyses reading `audit.tool_usage` between 2026-06-12 13:25 UTC (flag flip) and this PR's deploy: unbound rows with `success=true` on identity-gated tools are refusals, not successes.