### PR TITLE
fix(audit): surface details-spread error_type instead of generic tool_error

### DIFF
--- a/src/services/tool_usage_recorder.py
+++ b/src/services/tool_usage_recorder.py
@@ -60,7 +60,17 @@ def classify_tool_result(result: Any) -> Tuple[bool, Optional[str]]:
         category = payload.get("error_category")
         if category in _EISV_CAUSED_ERROR_CATEGORIES:
             return True, None  # governance-caused refusal — not an EISV-blind failure
-        error_type = category or payload.get("error_code") or "tool_error"
+        # Legacy error_response() refusals (e.g. the reserved-prefix guard in
+        # validators.py) carry only a details-spread "error_type" — without
+        # this fallback they audit as generic "tool_error". Six months of
+        # reserved_prefix refusals (~820k rows, surfaced by #543) were
+        # indistinguishable from real failures until a live repro.
+        error_type = (
+            category
+            or payload.get("error_code")
+            or payload.get("error_type")
+            or "tool_error"
+        )
         return False, str(error_type)
     return True, None
 

--- a/tests/test_tool_usage_classification.py
+++ b/tests/test_tool_usage_classification.py
@@ -149,3 +149,21 @@ async def test_http_pause_verdict_records_success():
     kwargs = mock_tracker.log_tool_call.call_args.kwargs
     assert kwargs["success"] is True
     assert kwargs["error_type"] is None
+
+
+def test_details_spread_error_type_is_used_when_category_and_code_absent():
+    """Legacy error_response() refusals (reserved-prefix guard) carry only a
+    details-spread error_type; the audit row must not collapse to tool_error."""
+    payload = {"success": False, "error_type": "reserved_prefix",
+               "error": "SECURITY: agent_id 'mcp_x' uses reserved prefix"}
+    success, error_type = classify_tool_result(payload)
+    assert success is False
+    assert error_type == "reserved_prefix"
+
+
+def test_error_category_still_wins_over_details_error_type():
+    payload = {"success": False, "error_category": "identity_error",
+               "error_type": "reserved_prefix"}
+    success, error_type = classify_tool_result(payload)
+    assert success is False
+    assert error_type == "identity_error"


### PR DESCRIPTION
Diagnosis of the get_governance_metrics '46% error rate' anomaly (820k failures/14d) found it was a telemetry-visibility artifact, not an outage: the `mcp_` agent_id prefix has been reserved since 2025-12 (validators.py RESERVED_PREFIXES), legacy auto-minted `mcp_YYYYMMDD` identities tripped it on every metrics call, and #543 (2026-05-30) made those long-standing refusals visible in `audit.tool_usage.success`. The stream has since fully drained (pollers re-minted under `Claude_*` names; this morning's sweep archived the stragglers; zero failures since 04:30 except my repro).

Why this PR: those refusals audited as generic `tool_error` because `error_response()` spreads `error_type` from `details` while `classify_tool_result` only reads `error_category`/`error_code` — so the diagnosis needed a live repro instead of one audit query. This adds the details-spread `error_type` to the fallback chain (after category and code, before the generic label). Two tests: the reserved-prefix shape resolves, and `error_category` still wins.

No deploy urgency — rides the next routine deploy.