### PR TITLE
test(watcher): isolate the suite from the live server and real log

### DIFF
--- a/agents/watcher/tests/conftest.py
+++ b/agents/watcher/tests/conftest.py
@@ -1,0 +1,53 @@
+"""Shared isolation for watcher tests (#652).
+
+Found live during the 2026-06-12 strict-identity burn-in: the watcher
+test suite was making REAL HTTP calls to the production governance
+server (unbound knowledge writes from sandboxed test state — refused
+under STRICT_IDENTITY_REQUIRED, silently auto-minting ghost identities
+before it) and appending test output to the real
+~/Library/Logs/unitares-watcher.log.
+
+Two seams close both leaks for every test in this directory:
+
+1. ``urllib.request.urlopen`` is replaced with a hard failure. Both the
+   SDK sync client (governance REST) and the agent's Ollama call go
+   through it at call time, so no code path can reach a live service.
+   Tests that exercise HTTP behavior mock at a higher layer and never
+   hit this.
+
+2. Every loaded module whose ``LOG_FILE`` points at the real watcher
+   log is repointed into the test's tmp dir. The sys.modules sweep is
+   needed because several tests load agent.py via
+   ``importlib.util.spec_from_file_location`` under ad-hoc names, each
+   binding its own copy of the constant.
+"""
+from __future__ import annotations
+
+import sys
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+_REAL_LOG = Path.home() / "Library" / "Logs" / "unitares-watcher.log"
+
+
+@pytest.fixture(autouse=True)
+def _watcher_isolation(monkeypatch, tmp_path):
+    def _blocked(*args, **kwargs):
+        raise RuntimeError(
+            "watcher tests must not perform real network I/O (#652) — "
+            "mock the client/HTTP layer instead of letting the call "
+            "reach a live service"
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", _blocked)
+
+    sandbox_log = tmp_path / "unitares-watcher.log"
+    for mod in list(sys.modules.values()):
+        try:
+            if getattr(mod, "LOG_FILE", None) == _REAL_LOG:
+                monkeypatch.setattr(mod, "LOG_FILE", sandbox_log)
+        except Exception:
+            continue
+    yield

--- a/agents/watcher/tests/test_isolation_guard.py
+++ b/agents/watcher/tests/test_isolation_guard.py
@@ -1,0 +1,21 @@
+"""Pins the #652 isolation guard: no real network, no real log."""
+from __future__ import annotations
+
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+
+def test_urlopen_is_blocked():
+    with pytest.raises(RuntimeError, match="must not perform real network"):
+        urllib.request.urlopen("http://127.0.0.1:8767/health")
+
+
+def test_log_file_is_sandboxed():
+    import agents.watcher._util as _util
+    real = Path.home() / "Library" / "Logs" / "unitares-watcher.log"
+    assert _util.LOG_FILE != real
+    # And the shared log() helper writes to the sandbox, not the real file.
+    _util.log("isolation guard probe", "info")
+    assert _util.LOG_FILE.exists()


### PR DESCRIPTION
Closes #652. Found during the strict burn-in: watcher tests fired real HTTP at the production server (fp `355f8e`, refused under strict / ghost-minting before it) and wrote to the real `~/Library/Logs/unitares-watcher.log`.

Autouse conftest guard: `urllib.request.urlopen` → hard failure (covers the SDK sync client and the Ollama path at call time); `LOG_FILE` repointed to tmp_path across all loaded module copies (sys.modules sweep handles the `spec_from_file_location` loads).

All 250 existing tests pass under the guard; 2 new tests pin it. **Live-verified**: a full suite run now adds zero `355f8e` lines to the production server log (previously a ~51-line burst per run). Also removes this benign-refusal noise source from the burn-in evidence ahead of the 2026-06-19 stage-4 review.