### PR TITLE
chore(watcher): demote P008 to experimental — model can't apply its own firing condition

### DIFF
--- a/agents/watcher/patterns.md
+++ b/agents/watcher/patterns.md
@@ -208,27 +208,15 @@ failure the caller needs to know about.
      experimental section for the original definition. -->
 
 
-### P008 — Unchecked shell input (severity: critical, violation_class: VOI)
+<!-- P008 has been demoted to the EXPERIMENTAL section below (2026-06-12).
+     The local model cannot apply the rule's own firing condition: both
+     historical findings flagged safe LIST-FORM subprocess calls (and not
+     even the call lines — adjacent lines that merely mentioned subprocess
+     context). 100% dismiss rate over 2 months, zero true positives; the
+     `p008_actually_fires` AST post-filter in agent.py caught every FP and
+     stays in place as defense-in-depth should the model emit P008 anyway.
+     See the experimental section for the original definition. -->
 
-Fire **only** when both conditions hold:
-1. The call is `subprocess.*(..., shell=True)` OR `os.system(...)` OR `os.popen(...)`.
-2. The command string includes user/external input without `shlex.quote`.
-
-**Do NOT fire** on list-form subprocess calls — those bypass the shell entirely
-and are the recommended safe form. Examples that must NOT be flagged:
-```python
-subprocess.run(["find", path, "-name", "*.py"], check=True)
-subprocess.run(["wc", "-l"] + files, capture_output=True)
-subprocess.Popen(["git", "log", "--oneline"])
-```
-
-Examples that SHOULD be flagged:
-```python
-subprocess.run(f"find {path} -name '*.py'", shell=True)  # unquoted interpolation
-os.system("rm -rf " + user_input)                         # shell + external input
-```
-
-**Hint template:** `shell injection — use shlex.quote or list-form subprocess`
 
 ### P009 — Runaway polling without iteration cap (severity: medium, violation_class: ENT)
 
@@ -472,6 +460,31 @@ no per-pool tracking exists. See `src/db/postgres_backend.py:170-205` for the
 post-fix reference shape.
 
 **Seen in:** `src/db/postgres_backend.py` pool mismatch bug
+
+### EXP-P008 — Unchecked shell input (critical, violation_class: VOI)
+
+Fire **only** when both conditions hold:
+1. The call is `subprocess.*(..., shell=True)` OR `os.system(...)` OR `os.popen(...)`.
+2. The command string includes user/external input without `shlex.quote`.
+
+List-form subprocess calls (`subprocess.run(["wc", "-l"] + files)`) bypass the
+shell entirely and must NOT be flagged.
+
+**Why disabled (2026-06-12):** the local model cannot reliably distinguish
+shell-form from list-form subprocess calls — both historical findings
+(chronicler/scrapers.py:63 and :71, 2026-04-23) flagged lines NEAR safe
+list-form calls, neither of which used `shell=True`. 100% dismiss rate, zero
+true positives in 2 months. The deterministic `p008_actually_fires` AST
+post-filter in `agent.py` (commit d37c1b57) correctly suppressed every FP and
+remains active as defense-in-depth. Re-promote when a model can apply
+condition (1) — i.e. actually verify `shell=True` is present — or replace
+with a pure-AST detector that doesn't need the LLM at all (the post-filter is
+already 90% of one).
+
+**Seen in:** no true positives to date; rule imported from generic security
+practice rather than a project incident.
+
+**Hint template:** `shell injection — use shlex.quote or list-form subprocess`
 
 ## Adding new patterns
 


### PR DESCRIPTION
Follow-up from the 2026-06-12 dashboard dossier (Watcher patterns at 100% dismiss rate: P003/P005/P008/P016).

Evidence-based triage of all four:

| Pattern | Findings (2mo) | Verdict | Why |
|---|---|---|---|
| P008 | 2, both FP | **demote to EXP** | LLM flagged lines NEAR safe list-form subprocess calls; it cannot verify `shell=True`, which is the rule's own firing condition. Zero true positives ever (rule was imported from generic practice, not an incident). |
| P003 | 1, auto-dropped FP | keep | The one finding was inside `get_or_create_monitor` itself (the documented verifier-handled shape). Real incident provenance; near-zero noise cost. |
| P005 | 4, all FP | keep | Mature verifier suite catches the known shapes; asyncpg leaks are a real bug class. |
| P016 | 7, all FP | keep | Caught a real bug (parse_onboard, 718ccd3); verifiers handle the 3 documented FP shapes. |

Mechanics mirror the P007 demotion: HTML comment at the old slot, full definition preserved under `## Experimental patterns` as EXP-P008 with a re-promotion condition. The `p008_actually_fires` AST post-filter in agent.py is untouched — it stays as defense-in-depth if the model emits P008 anyway, and is already 90% of the pure-AST detector that could replace this rule.

Side observation for a future pass: the dashboard's Watcher pattern table presents verifier-auto-dropped findings as a 'dismiss rate', which reads as 'noisy detector' when it actually means 'FP filters working' — that presentation conflation is what put three healthy patterns on this triage list.

Doc-only change; 250 watcher tests pass; `load_pattern_severities()` confirmed P008 absent from the active set.