### PR TITLE
refactor: remove the never-consulted rate_limit_exempt decorator flag

### DIFF
--- a/src/mcp_handlers/admin/calibration.py
+++ b/src/mcp_handlers/admin/calibration.py
@@ -60,7 +60,7 @@ def _build_calibration_guidance(
     }
 
 
-@mcp_tool("check_calibration", timeout=10.0, rate_limit_exempt=True, register=False)
+@mcp_tool("check_calibration", timeout=10.0, register=False)
 async def handle_check_calibration(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """
     Check calibration of confidence estimates.
@@ -274,7 +274,7 @@ async def handle_check_calibration(arguments: Dict[str, Any]) -> Sequence[TextCo
     
     return success_response(response)
 
-@mcp_tool("rebuild_calibration", timeout=60.0, rate_limit_exempt=True, register=False)
+@mcp_tool("rebuild_calibration", timeout=60.0, register=False)
 async def handle_rebuild_calibration(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """
     Rebuild calibration from scratch using auto ground truth collection.
@@ -445,7 +445,7 @@ async def handle_update_calibration_ground_truth(arguments: Dict[str, Any]) -> S
         except Exception as e:
             return [error_response(str(e))]
 
-@mcp_tool("backfill_calibration_from_dialectic", timeout=20.0, rate_limit_exempt=True, register=False)
+@mcp_tool("backfill_calibration_from_dialectic", timeout=20.0, register=False)
 async def handle_backfill_calibration_from_dialectic(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """
     Retroactively update calibration from historical resolved verification-type dialectic sessions.

--- a/src/mcp_handlers/admin/config.py
+++ b/src/mcp_handlers/admin/config.py
@@ -13,7 +13,7 @@ logger = get_logger(__name__)
 
 # Import from mcp_server_std module (using shared utility)
 
-@mcp_tool("get_thresholds", timeout=10.0, rate_limit_exempt=True, register=False)
+@mcp_tool("get_thresholds", timeout=10.0, register=False)
 async def handle_get_thresholds(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """Get current governance threshold configuration"""
     from src.runtime_config import get_thresholds

--- a/src/mcp_handlers/admin/handlers.py
+++ b/src/mcp_handlers/admin/handlers.py
@@ -141,7 +141,7 @@ def build_server_info_payload() -> Dict[str, Any]:
     }
 
 
-@mcp_tool("get_server_info", timeout=10.0, rate_limit_exempt=True, requires_identity="pre_onboard")
+@mcp_tool("get_server_info", timeout=10.0, requires_identity="pre_onboard")
 async def handle_get_server_info(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """Get MCP server version, process information, and health status"""
     return success_response(build_server_info_payload())
@@ -257,7 +257,7 @@ async def handle_check_continuity_health(arguments: Dict[str, Any]) -> Sequence[
         logger.error(f"Continuity health check failed: {e}", exc_info=True)
         return [error_response(f"Continuity health check failed: {e}")]
 
-@mcp_tool("get_tool_usage_stats", timeout=15.0, rate_limit_exempt=True, register=False)
+@mcp_tool("get_tool_usage_stats", timeout=15.0, register=False)
 async def handle_get_tool_usage_stats(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """Get tool usage statistics to identify which tools are actually used vs unused"""
     from src.tool_usage_tracker import get_tool_usage_tracker
@@ -301,7 +301,7 @@ def set_workspace_last_agent(mcp_server, agent_id: str) -> None:
     except Exception:
         pass  # Non-critical
 
-@mcp_tool("health_check", timeout=5.0, rate_limit_exempt=True, requires_identity="pre_onboard")
+@mcp_tool("health_check", timeout=5.0, requires_identity="pre_onboard")
 async def handle_health_check(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """Read the most recent cached health snapshot.
 
@@ -372,7 +372,7 @@ async def handle_health_check(arguments: Dict[str, Any]) -> Sequence[TextContent
     }
     return success_response(response)
 
-@mcp_tool("get_telemetry_metrics", timeout=15.0, rate_limit_exempt=True, register=False)
+@mcp_tool("get_telemetry_metrics", timeout=15.0, register=False)
 async def handle_get_telemetry_metrics(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """Get comprehensive telemetry metrics: skip rates, confidence distributions, calibration status
     
@@ -450,7 +450,7 @@ async def handle_reset_monitor(arguments: Dict[str, Any]) -> Sequence[TextConten
         "agent_id": agent_id
     })
 
-@mcp_tool("cleanup_stale_locks", timeout=15.0, rate_limit_exempt=True, register=False)
+@mcp_tool("cleanup_stale_locks", timeout=15.0, register=False)
 async def handle_cleanup_stale_locks(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """Clean up stale lock files that are no longer held by active processes"""
     try:
@@ -475,7 +475,7 @@ async def handle_cleanup_stale_locks(arguments: Dict[str, Any]) -> Sequence[Text
     except Exception as e:
         return [error_response(f"Error cleaning stale locks: {str(e)}")]
 
-@mcp_tool("get_workspace_health", timeout=20.0, rate_limit_exempt=True, register=False)
+@mcp_tool("get_workspace_health", timeout=20.0, register=False)
 async def handle_get_workspace_health(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """Handle get_workspace_health tool - comprehensive workspace health status"""
     from src.workspace_health import get_workspace_health
@@ -494,7 +494,7 @@ async def handle_get_workspace_health(arguments: Dict[str, Any]) -> Sequence[Tex
             }
         )]
 
-@mcp_tool("debug_request_context", timeout=5.0, rate_limit_exempt=True, register=False)
+@mcp_tool("debug_request_context", timeout=5.0, register=False)
 async def handle_debug_request_context(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """
     Debug request context - shows raw diagnostic info about session, identity, and bindings.
@@ -600,7 +600,7 @@ async def handle_debug_request_context(arguments: Dict[str, Any]) -> Sequence[Te
 
     return success_response(result)
 
-@mcp_tool("validate_file_path", timeout=5.0, rate_limit_exempt=True, register=False)
+@mcp_tool("validate_file_path", timeout=5.0, register=False)
 async def handle_validate_file_path(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """
     Validate file path against project policies (anti-proliferation).
@@ -671,7 +671,7 @@ async def handle_validate_file_path(arguments: Dict[str, Any]) -> Sequence[TextC
         "message": "File path complies with project policies"
     })
 
-@mcp_tool("get_connection_status", timeout=5.0, rate_limit_exempt=True, register=False)
+@mcp_tool("get_connection_status", timeout=5.0, register=False)
 async def handle_get_connection_status(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """
     Get MCP connection status and tool availability.

--- a/src/mcp_handlers/decorators.py
+++ b/src/mcp_handlers/decorators.py
@@ -29,7 +29,6 @@ class ToolDefinition:
     deprecated: bool = False
     hidden: bool = False
     superseded_by: Optional[str] = None
-    rate_limit_exempt: bool = False
     # Identity-bootstrap declaration (#425). One of:
     #   "required"     — default; tool needs a bound identity.
     #   "pre_onboard"  — protocol-inspection or identity-lifecycle tool;
@@ -56,7 +55,6 @@ def mcp_tool(
     name: Optional[str] = None,
     timeout: float = 30.0,
     description: Optional[str] = None,
-    rate_limit_exempt: bool = False,
     deprecated: bool = False,
     hidden: bool = False,
     superseded_by: Optional[str] = None,
@@ -90,7 +88,6 @@ def mcp_tool(
         name: Tool name (defaults to function name without 'handle_' prefix)
         timeout: Timeout in seconds (default: 30.0)
         description: Tool description (defaults to function docstring)
-        rate_limit_exempt: If True, skip rate limiting for this tool
         deprecated: If True, tool still works but warns users to use superseded_by
         hidden: If True, tool is not shown in list_tools (internal use only)
         superseded_by: Name of tool that replaces this one (for deprecation messages)
@@ -121,7 +118,6 @@ def mcp_tool(
         # Attach metadata to function for introspection
         func._mcp_tool_name = tool_name
         func._mcp_timeout = timeout
-        func._mcp_rate_limit_exempt = rate_limit_exempt
         func._mcp_deprecated = deprecated
         func._mcp_hidden = hidden
         func._mcp_superseded_by = superseded_by
@@ -233,7 +229,6 @@ def mcp_tool(
                 deprecated=deprecated,
                 hidden=hidden,
                 superseded_by=superseded_by,
-                rate_limit_exempt=rate_limit_exempt,
                 requires_identity=requires_identity,
                 pre_onboard_actions=_pre_onboard_actions,
                 default_action=_default_action,

--- a/src/mcp_handlers/dialectic/handlers.py
+++ b/src/mcp_handlers/dialectic/handlers.py
@@ -767,7 +767,7 @@ async def handle_request_dialectic_review(arguments: Dict[str, Any]) -> Sequence
         "note": note
     })
 
-@mcp_tool("get_dialectic_session", timeout=10.0, rate_limit_exempt=True, register=False)
+@mcp_tool("get_dialectic_session", timeout=10.0, register=False)
 async def handle_get_dialectic_session(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """
     View an active or past dialectic session.
@@ -979,7 +979,7 @@ async def handle_get_dialectic_session(arguments: Dict[str, Any]) -> Sequence[Te
             recovery=get_session_exception_recovery(),
         )]
 
-@mcp_tool("list_dialectic_sessions", timeout=15.0, rate_limit_exempt=True, register=False)
+@mcp_tool("list_dialectic_sessions", timeout=15.0, register=False)
 async def handle_list_dialectic_sessions(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """
     List all dialectic sessions with optional filtering.

--- a/src/mcp_handlers/introspection/skills.py
+++ b/src/mcp_handlers/introspection/skills.py
@@ -190,7 +190,7 @@ def _filter_skills(
 # Handler
 # ---------------------------------------------------------------------
 
-@mcp_tool("skills", timeout=10.0, rate_limit_exempt=True, requires_identity="pre_onboard")
+@mcp_tool("skills", timeout=10.0, requires_identity="pre_onboard")
 async def handle_skills(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """Return server-authored skill bundle for adapter consumption.
 

--- a/src/mcp_handlers/introspection/tool_introspection.py
+++ b/src/mcp_handlers/introspection/tool_introspection.py
@@ -186,7 +186,7 @@ def _essential_toolkit() -> Dict[str, Any]:
         },
     }
 
-@mcp_tool("list_tools", timeout=10.0, rate_limit_exempt=True, requires_identity="pre_onboard")
+@mcp_tool("list_tools", timeout=10.0, requires_identity="pre_onboard")
 async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """List all available governance tools with descriptions and categories
     
@@ -1206,7 +1206,7 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     
     return success_response(tools_info)
 
-@mcp_tool("describe_tool", timeout=10.0, rate_limit_exempt=True, requires_identity="pre_onboard")
+@mcp_tool("describe_tool", timeout=10.0, requires_identity="pre_onboard")
 async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """
     Return full details for a single tool (full description + full schema) on demand.

--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -922,7 +922,7 @@ async def handle_store_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[Te
     except Exception as e:
         return [error_response(f"Failed to store knowledge: {str(e)}")]
 
-@mcp_tool("search_knowledge_graph", timeout=15.0, rate_limit_exempt=True, requires_identity="pre_onboard")
+@mcp_tool("search_knowledge_graph", timeout=15.0, requires_identity="pre_onboard")
 async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """Search knowledge graph (indexed filters; optional FTS query).
 
@@ -1702,7 +1702,7 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
     except Exception as e:
         return [error_response(f"Failed to search knowledge: {str(e)}")]
 
-@mcp_tool("get_knowledge_graph", timeout=15.0, rate_limit_exempt=True, register=False)
+@mcp_tool("get_knowledge_graph", timeout=15.0, register=False)
 async def handle_get_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """Get all knowledge for an agent - summaries only (use get_discovery_details for full content)"""
     # SECURITY FIX: Verify agent_id is registered (prevents phantom agent_ids)
@@ -1776,7 +1776,7 @@ async def handle_get_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[Text
     except Exception as e:
         return [error_response(f"Failed to retrieve knowledge: {str(e)}")]
 
-@mcp_tool("list_knowledge_graph", timeout=10.0, rate_limit_exempt=True, register=False)
+@mcp_tool("list_knowledge_graph", timeout=10.0, register=False)
 async def handle_list_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """List knowledge graph statistics — raw status aggregate.
 
@@ -1994,7 +1994,7 @@ async def handle_update_discovery_status_graph(arguments: Dict[str, Any]) -> Seq
     except Exception as e:
         return [error_response(f"Failed to update discovery: {str(e)}")]
 
-@mcp_tool("get_discovery_details", timeout=10.0, rate_limit_exempt=True, register=False)
+@mcp_tool("get_discovery_details", timeout=10.0, register=False)
 async def handle_get_discovery_details(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """Get full details for a specific discovery with optional pagination and response chain.
 
@@ -2661,7 +2661,7 @@ async def handle_synthesize_knowledge_graph(arguments: Dict[str, Any]) -> Sequen
     except Exception as e:
         return [error_response(f"Failed to synthesize knowledge graph: {str(e)}")]
 
-@mcp_tool("get_lifecycle_stats", timeout=30.0, rate_limit_exempt=True, register=False)
+@mcp_tool("get_lifecycle_stats", timeout=30.0, register=False)
 async def handle_get_lifecycle_stats(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """Get knowledge graph lifecycle statistics.
 

--- a/src/mcp_handlers/lifecycle/operations.py
+++ b/src/mcp_handlers/lifecycle/operations.py
@@ -455,7 +455,7 @@ async def handle_self_recovery_review(arguments: Dict[str, Any]) -> Sequence[Tex
             ]
         })
 
-@mcp_tool("ping_agent", timeout=5.0, rate_limit_exempt=True, register=False)
+@mcp_tool("ping_agent", timeout=5.0, register=False)
 async def handle_ping_agent(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """Ping an agent to check if it's responsive/alive.
 
@@ -546,7 +546,7 @@ async def handle_ping_agent(arguments: Dict[str, Any]) -> Sequence[TextContent]:
         logger.error(f"Error pinging agent: {e}", exc_info=True)
         return [error_response(f"Error pinging agent: {str(e)}")]
 
-@mcp_tool("archive_old_test_agents", timeout=20.0, rate_limit_exempt=True, register=False)
+@mcp_tool("archive_old_test_agents", timeout=20.0, register=False)
 async def handle_archive_old_test_agents(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """Archive stale agents - test agents by default, or ALL stale agents with include_all=true
 
@@ -615,7 +615,7 @@ async def handle_archive_old_test_agents(arguments: Dict[str, Any]) -> Sequence[
         "action": "preview - use dry_run=false to execute" if dry_run else "archived"
     })
 
-@mcp_tool("archive_orphan_agents", timeout=30.0, rate_limit_exempt=True)
+@mcp_tool("archive_orphan_agents", timeout=30.0)
 async def handle_archive_orphan_agents(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """Aggressively archive orphan agents to prevent proliferation.
 

--- a/src/mcp_handlers/lifecycle/query.py
+++ b/src/mcp_handlers/lifecycle/query.py
@@ -126,7 +126,7 @@ def _is_operator_request() -> bool:
         return False
 
 
-@mcp_tool("list_agents", timeout=15.0, rate_limit_exempt=True, register=False)
+@mcp_tool("list_agents", timeout=15.0, register=False)
 async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextContent]:
     """List all agents currently being monitored with lifecycle metadata and health status
 

--- a/src/mcp_handlers/lifecycle/stuck.py
+++ b/src/mcp_handlers/lifecycle/stuck.py
@@ -566,7 +566,7 @@ async def _try_recover_agent(stuck: dict, note_cooldown_minutes: float) -> list:
     return results
 
 
-@mcp_tool("detect_stuck_agents", timeout=15.0, rate_limit_exempt=True, requires_identity="pre_onboard")
+@mcp_tool("detect_stuck_agents", timeout=15.0, requires_identity="pre_onboard")
 async def handle_detect_stuck_agents(arguments: Dict[str, Any]) -> Sequence:
     """Detect stuck agents using proprioceptive margin + patterns.
 

--- a/src/mcp_handlers/middleware/rate_limit_step.py
+++ b/src/mcp_handlers/middleware/rate_limit_step.py
@@ -18,10 +18,9 @@ _tool_call_history: Dict[str, deque] = defaultdict(lambda: deque(maxlen=200))
 # registered tools (not aliases), so the names survive resolve_alias on
 # both the MCP and REST pipelines. Mixed read/write tools (knowledge,
 # agent, observe, ...) are exempted per-call below via their declared
-# pre_onboard_actions instead of by name. NOTE: the @mcp_tool
-# rate_limit_exempt flag is declared on ~25 tools but consulted nowhere —
-# it is NOT trusted here because its declarations include mutating tools
-# (archive_orphan_agents, cleanup_stale_locks); audit before wiring it.
+# pre_onboard_actions instead of by name. (A never-consulted
+# rate_limit_exempt decorator flag was removed 2026-06-12 — this set and
+# the pre_onboard_actions classification are the only exemption sources.)
 _READ_ONLY_TOOLS = {
     'health_check', 'get_server_info', 'list_tools', 'get_thresholds',
     'search_knowledge_graph', 'get_governance_metrics', 'skills',

--- a/src/mcp_handlers/resident_progress.py
+++ b/src/mcp_handlers/resident_progress.py
@@ -17,7 +17,7 @@ from src.logging_utils import get_logger
 logger = get_logger(__name__)
 
 
-@mcp_tool("record_progress_pulse", timeout=5.0, register=True, rate_limit_exempt=False)
+@mcp_tool("record_progress_pulse", timeout=5.0, register=True)
 async def handle_record_progress_pulse(
     arguments: Dict[str, Any],
 ) -> Sequence[TextContent]:


### PR DESCRIPTION
Follow-up flagged in #642. `rate_limit_exempt=True` is declared on ~25 tools and consulted by **nothing** — the only enforcement sources are `rate_limit_step`'s canonical read-only set and the #425 `pre_onboard_actions` classification. The declarations also claimed exemption on mutating tools (`archive_orphan_agents`, `cleanup_stale_locks`, `rebuild_calibration`), so the flag read as policy while enforcing nothing.

Removal over wiring: wiring would widen exemptions based on unaudited claims; removal is behavior-neutral by construction (verified: no consumer in src/tests/agents/dashboard/scripts, not serialized by describe_tool/list_tools). Full suite green locally (9,603 passed).