### PR TITLE
fix(watcher-panel): stop flagging FP-filtered patterns as noisy; track Table 5 governor deltas

### DIFF
--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -5273,6 +5273,12 @@ main {
     color: #f59e0b;
 }
 
+/* High dismiss ratio but the rule still confirms real bugs: FP filters are
+   working, not a noisy detector. Muted, not alarming. */
+.watcher-dismiss-ratio-ok {
+    color: var(--text-secondary);
+}
+
 .watcher-patterns-empty {
     color: var(--text-secondary);
     font-style: italic;

--- a/dashboard/watcher.js
+++ b/dashboard/watcher.js
@@ -86,8 +86,21 @@
                 var td = document.createElement('td');
                 td.textContent = cells[c];
                 if (c === 4 && p.dismiss_ratio != null && p.dismiss_ratio >= 0.75) {
-                    td.className = 'watcher-dismiss-ratio-high';  // flag noisy rules
-                    td.title = 'Most closed findings for this rule were dismissed — likely false-positive heavy';
+                    // A high dismiss ratio is only a "noisy rule" signal when the
+                    // rule has never confirmed a real bug. When confirmed > 0, the
+                    // dismissals are the FP-filter pipeline catching known-benign
+                    // matches while the rule still earns its keep — don't paint it
+                    // as noise (the conflation that put healthy P003/P005/P016 on
+                    // the 2026-06-12 retirement triage; see PR #659).
+                    if (Number(p.confirmed) > 0) {
+                        td.className = 'watcher-dismiss-ratio-ok';
+                        td.title = 'High dismiss ratio, but this rule still confirms real bugs ('
+                            + p.confirmed + ' confirmed) — false-positive filters working, not noise'
+                            + (p.dismissed_fp ? ' · ' + p.dismissed_fp + ' dismissed as confirmed FPs' : '');
+                    } else {
+                        td.className = 'watcher-dismiss-ratio-high';  // genuine retirement candidate
+                        td.title = 'Mostly dismissed with zero confirmed bugs — candidate for review/retirement';
+                    }
                 }
                 tr.appendChild(td);
             }

--- a/governance_core/adaptive_governor.py
+++ b/governance_core/adaptive_governor.py
@@ -8,7 +8,11 @@ management. Thresholds are living per-agent state, not config constants.
 The D-term IS the damping. Oscillation produces large derivatives, which
 produce large corrections. The system self-stabilizes.
 
-Design: docs/plans/2026-02-19-cirs-v2-adaptive-governor-design.md
+Design: the original design note (docs/plans/2026-02-19-cirs-v2-adaptive-governor-
+design.md) is not present in this repo. Production thresholds intentionally
+deviate from the paper's Table 5 (see the `# Paper:` annotations on each
+GovernorConfig constant below); reconciling those deltas — ratify as permanent
+vs. recalibrate toward the paper — is tracked in unitares#661.
 
 Update cycle (called from process_agent_update):
   1. Detect phase from EISV histories (calls governance_core.phase_aware.detect_phase)

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -1354,7 +1354,9 @@ def _watcher_summary_from_rows(rows, now=None, window_days=_WATCHER_DAILY_WINDOW
 
     by_status = Counter()
     by_severity = Counter()   # open-only (surfaced + open) — the actionable queue
-    by_pattern = defaultdict(lambda: {"surfaced": 0, "confirmed": 0, "dismissed": 0, "other": 0})
+    by_pattern = defaultdict(
+        lambda: {"surfaced": 0, "confirmed": 0, "dismissed": 0, "dismissed_fp": 0, "other": 0}
+    )
     daily = defaultdict(int)  # yyyy-mm-dd → count of detected_at in that day
     resolutions_daily = defaultdict(lambda: {"confirmed": 0, "dismissed": 0})
 
@@ -1387,6 +1389,13 @@ def _watcher_summary_from_rows(rows, now=None, window_days=_WATCHER_DAILY_WINDOW
         bucket = by_pattern[pattern]
         if status in ("confirmed", "dismissed"):
             bucket[status] += 1
+            # A dismissal with reason "fp" is a *confirmed false positive* the
+            # verifier/operator caught — the detector fired on a known-benign
+            # shape. Tracking it separately lets the panel tell "FP filters
+            # working" apart from "rule produces no signal" (see findings.py
+            # DISMISSAL_REASONS / PRECISION_REASONS_TRUE_NEGATIVE).
+            if status == "dismissed" and str(row.get("resolution_reason") or "") == "fp":
+                bucket["dismissed_fp"] += 1
         elif status in ("surfaced", "open"):
             bucket["surfaced"] += 1
             by_severity[severity] += 1
@@ -1414,6 +1423,7 @@ def _watcher_summary_from_rows(rows, now=None, window_days=_WATCHER_DAILY_WINDOW
             "surfaced": b["surfaced"],
             "confirmed": b["confirmed"],
             "dismissed": b["dismissed"],
+            "dismissed_fp": b["dismissed_fp"],
             "other": b["other"],
             "dismiss_ratio": dismiss_ratio,
         })

--- a/src/violation_taxonomy.yaml
+++ b/src/violation_taxonomy.yaml
@@ -77,6 +77,6 @@ classes:
       Action taken despite insufficient validation, hidden failure state,
       or unresolved uncertainty.
     surfaces:
-      watcher_patterns: [P006, P008, P013, P014, P015]
+      watcher_patterns: [P006, P013, P014, P015]  # P008 demoted to experimental 2026-06-12 (#659); re-add on re-promotion
       sentinel_findings: []
       broadcast_events: []

--- a/tests/test_http_api_watcher_summary.py
+++ b/tests/test_http_api_watcher_summary.py
@@ -183,13 +183,16 @@ class TestStatusAndSeverityCounts:
 
 class TestPatternTable:
     def test_pattern_breakdown_with_dismiss_ratio(self):
-        """Patterns that get dismissed frequently are the false-positive-heavy
-        rules — surfacing dismiss_ratio on the panel lets an operator spot
-        noisy rules at a glance."""
+        """dismiss_ratio is a descriptive stat, not a noise verdict on its own.
+        A high ratio only signals a retirement candidate when the rule has
+        *also* never confirmed a real bug — when confirmed > 0 the dismissals
+        are the FP-filter pipeline catching known-benign matches (PR #659). The
+        panel makes that call via confirmed + dismissed_fp; this test just pins
+        the underlying counts the panel reads."""
         rows = [
             _row(pattern="P008", status="dismissed"),
             _row(pattern="P008", status="dismissed"),
-            _row(pattern="P008", status="dismissed"),   # 3/3 dismissed — noisy
+            _row(pattern="P008", status="dismissed"),   # 3/3 dismissed, 0 confirmed — retire
             _row(pattern="P001", status="confirmed"),
             _row(pattern="P001", status="confirmed"),   # 0/2 dismissed — signal
             _row(pattern="P001", status="surfaced"),    # 1 still open
@@ -200,6 +203,31 @@ class TestPatternTable:
         assert by["P008"]["dismiss_ratio"] == pytest.approx(1.0)
         assert by["P001"]["confirmed"] == 2 and by["P001"]["dismissed"] == 0
         assert by["P001"]["dismiss_ratio"] == pytest.approx(0.0)
+
+    def test_dismissed_fp_counts_only_false_positive_reason(self):
+        """dismissed_fp isolates dismissals closed as confirmed false positives
+        (reason='fp') from other dismissal reasons. This is the signal that
+        distinguishes 'FP filters working' from 'rule produces no usable
+        signal' — a healthy rule can have a high dismiss ratio made entirely of
+        fp closures while still confirming real bugs."""
+        rows = [
+            # P016: high dismiss ratio, but every dismissal is a caught FP and
+            # it still confirms a real bug — the PR #659 "keep it" shape.
+            _row(pattern="P016", status="dismissed", resolution_reason="fp"),
+            _row(pattern="P016", status="dismissed", resolution_reason="fp"),
+            _row(pattern="P016", status="dismissed", resolution_reason="fp"),
+            _row(pattern="P016", status="confirmed"),
+            # P777: dismissed for non-fp reasons (out of scope / won't fix) —
+            # not counted as caught false positives.
+            _row(pattern="P777", status="dismissed", resolution_reason="out_of_scope"),
+            _row(pattern="P777", status="dismissed", resolution_reason="wont_fix"),
+            _row(pattern="P777", status="dismissed"),  # no reason recorded
+        ]
+        out = _watcher_summary_from_rows(rows, now=NOW)
+        by = {p["pattern"]: p for p in out["patterns"]}
+        assert by["P016"]["dismissed"] == 3 and by["P016"]["dismissed_fp"] == 3
+        assert by["P016"]["confirmed"] == 1  # still earns its keep
+        assert by["P777"]["dismissed"] == 3 and by["P777"]["dismissed_fp"] == 0
 
     def test_dismiss_ratio_is_none_when_nothing_closed(self):
         """With no closed findings for a pattern, the ratio is undefined —


### PR DESCRIPTION
Two breadcrumbs surfaced while sweeping recent governance work for unfinished follow-ups.

## 1. Watcher dashboard pattern table (side observation in #659)

The pattern table painted any rule with `dismiss_ratio >= 0.75` as "likely false-positive heavy" (amber "noisy rule" flag). But for a rule whose dismissals are confirmed false positives the verifier pipeline caught **and** which still confirms real bugs, a high dismiss ratio is the FP filters *working* — not noise. This is exactly the conflation #659 flagged: it put healthy P003/P005/P016 on the 2026-06-12 retirement triage.

The fix follows the PR #659 triage's own logic — P008 was demoted for "zero true positives ever," while P016 was kept because it "caught a real bug" despite high dismissals:

- **`src/http_api.py` `_watcher_summary_from_rows`** — add per-pattern `dismissed_fp` (dismissals closed with `resolution_reason="fp"`), so "FP filters working" is distinguishable from "rule produces no usable signal." Backward-compatible additive field.
- **`dashboard/watcher.js`** — the red `watcher-dismiss-ratio-high` "retirement candidate" flag now fires only when dismiss ratio is high **AND** `confirmed == 0`. High dismiss with `confirmed > 0` gets a muted, informational treatment (`watcher-dismiss-ratio-ok`) whose tooltip names the confirmed count and the caught-FP count.
- **`dashboard/styles.css`** — muted style for the new informational class.
- **tests** — fixed the docstring that encoded the conflation ("dismiss_ratio… lets an operator spot noisy rules at a glance"); pinned `dismissed_fp` (fp vs non-fp reasons) and the confirmed-protects-the-rule distinction.

## 2. Adaptive governor — Table 5 deltas

`governance_core/adaptive_governor.py`'s module docstring pointed at `docs/plans/2026-02-19-cirs-v2-adaptive-governor-design.md`, which **is not present in this repo and has no tracked history here** — a dangling breadcrumb. The production constants deliberately deviate from the paper's Table 5 (documented inline via `# Paper:` annotations), but nothing tracked whether those deltas are permanent or provisional.

- Repointed the docstring at the reconciliation tracker (#661) and stated the production-vs-paper gap inline. **Constants unchanged** — this is decision-hygiene, not a calibration change.
- Opened #661 to carry the ratify-vs-recalibrate decision.

## Verification

The full suite needs Python 3.12 + server deps (this was developed on a 3.11 clone), so the data-layer change was verified by executing the edited `_watcher_summary_from_rows` source directly: `dismissed_fp` counts only `fp`-reason dismissals, `confirmed` is preserved, and the empty/legacy paths are intact. `watcher.js` passes `node --check`. Leaving the full gate to CI.

Closes the #659 side observation; tracks the Table 5 deltas via #661.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKUTn8NVgBRfjvBoFvzukk)_