### PR TITLE
fix(taxonomy): drop stale P008 reference — un-red master after #659

### DIFF
--- a/src/violation_taxonomy.yaml
+++ b/src/violation_taxonomy.yaml
@@ -77,6 +77,6 @@ classes:
       Action taken despite insufficient validation, hidden failure state,
       or unresolved uncertainty.
     surfaces:
-      watcher_patterns: [P006, P008, P013, P014, P015]
+      watcher_patterns: [P006, P013, P014, P015]  # P008 demoted to experimental 2026-06-12 (#659); re-add on re-promotion
       sentinel_findings: []
       broadcast_events: []


### PR DESCRIPTION
## Hotfix: master `Tests` workflow has been red since #659

`test_taxonomy_surfaces_exist_in_codebase` fails on master: the violation taxonomy lists `P008` under class VOI, but **#659** demoted `P008` to the experimental section of `patterns.md` (so it left `load_pattern_severities()`), leaving the taxonomy reference stale — exactly the "removed pattern still listed" case that test exists to catch.

Confirmed via the `Tests` workflow history on `master`:

| Commit | PR | `Tests` |
|---|---|---|
| `0f86453` | #657 | ✅ success |
| **`92101e4`** | **#659 (P008 demotion)** | ❌ **failure** |
| `3235c67` | #660 | ❌ failure (inherited) |

#659 was treated as doc-only (its body: *"Doc-only change; 250 watcher tests pass"* — watcher subset only), so the full-suite failure slipped through the merge.

## Fix

One line: drop the stale `P008` entry from VOI's `watcher_patterns`. The bidirectional contract holds — `test_all_watcher_patterns_are_classified` will force `P008` back into the taxonomy if it's ever re-promoted from experimental (noted in a comment).

Split out of #662 (the breadcrumb PR that surfaced this) so master can go green immediately without waiting on the rest of that work. #662 carries the identical commit and will dedupe on rebase once this lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKUTn8NVgBRfjvBoFvzukk)_