### PR TITLE
fix(dialectic): exclude non-reasoning agents from reviewer auto-selection

### DIFF
--- a/src/mcp_handlers/dialectic/reviewer.py
+++ b/src/mcp_handlers/dialectic/reviewer.py
@@ -18,6 +18,7 @@ import asyncio
 import contextvars
 
 from src.dialectic_protocol import calculate_authority_score, DialecticPhase
+from src.grounding.class_indicator import KNOWN_RESIDENT_LABELS
 from src.logging_utils import get_logger
 
 # Reentrancy guard for the auto-resolve pre-check inside is_agent_in_active_session.
@@ -42,6 +43,42 @@ from src.dialectic_db import (
 )
 
 logger = get_logger(__name__)
+
+
+# Tags that mark an agent as a non-reasoning substrate with no thesis-response
+# code path. `autonomous` is a RESIDENT_TAG (the cron-driven resident fleet runs
+# deterministic scripts — pytest, threshold checks, regex scanners); `embodied`
+# is the physical-substrate / streaming-observer class; `anima` is the embodied
+# Pi-side persona. None of these can read a thesis and author an antithesis, so
+# none can serve as a dialectic reviewer. Mirrors the paused-agent skip in
+# handle_request_dialectic_review (handlers.py).
+NON_REASONING_TAGS = frozenset({"autonomous", "embodied", "anima"})
+
+
+def _can_perform_dialectic_review(
+    label: Optional[str], tags: Optional[List[str]]
+) -> bool:
+    """Whether a candidate has a code path that can author an antithesis.
+
+    Reviewer auto-selection (gated behind UNITARES_AUTOSELECT_REVIEWER) must
+    never assign an agent that cannot respond. The named resident fleet
+    (KNOWN_RESIDENT_LABELS: Lumen / Vigil / Sentinel / Watcher / Steward /
+    Chronicler) and anything carrying a NON_REASONING_TAGS tag are deterministic
+    processes — they have no dialectic-reasoning path. Assigning one as reviewer
+    leaves the session stuck at the ANTITHESIS phase until the stuck-reviewer
+    reaper times it out: wasted facilitation churn and a dishonest "reviewer
+    assigned" signal. The capability filter is independent of the autoselect
+    flag — enabling the flag asserts that *some* real reasoner now exists in the
+    pool, not that the residents have grown a reasoning path.
+
+    Unknown/untagged agents are treated as capable (return True); the filter
+    only excludes the classes we positively know cannot respond.
+    """
+    if label and label in KNOWN_RESIDENT_LABELS:
+        return False
+    if tags and (set(tags) & NON_REASONING_TAGS):
+        return False
+    return True
 
 
 def _autoselect_enabled() -> bool:
@@ -316,6 +353,20 @@ async def select_reviewer(paused_agent_id: str,
             continue
 
         if isinstance(agent_meta, str) or agent_meta is None:
+            continue
+
+        # Capability gate: never assign a reviewer that has no thesis-response
+        # code path. The resident fleet and embodied/autonomous agents are
+        # deterministic processes — assigning one strands the session at the
+        # ANTITHESIS phase until the stuck-reviewer reaper fails it. Cheap
+        # (pure tag/label inspection) so it runs before the PG/disk lookups.
+        label = agent_meta.get('label') if isinstance(agent_meta, dict) else getattr(agent_meta, 'label', None)
+        tags = agent_meta.get('tags') if isinstance(agent_meta, dict) else getattr(agent_meta, 'tags', None)
+        if not _can_perform_dialectic_review(label, tags):
+            logger.debug(
+                "[DIALECTIC] Skipping reviewer candidate '%s' — non-reasoning "
+                "agent (no antithesis code path)", agent_id[:8],
+            )
             continue
 
         status = agent_meta.get('status') if isinstance(agent_meta, dict) else getattr(agent_meta, 'status', None)

--- a/tests/test_remaining_modules.py
+++ b/tests/test_remaining_modules.py
@@ -1127,6 +1127,51 @@ class TestSelectReviewer:
             result = await select_reviewer("agent-1", metadata=metadata)
             assert result is None
 
+    @pytest.mark.asyncio
+    async def test_skips_resident_label_candidate(self):
+        # A known resident (Sentinel) has no thesis-response code path and must
+        # never be auto-assigned as reviewer, even when otherwise eligible.
+        metadata = {
+            "agent-1": {"status": "active"},
+            "agent-2": {"status": "active", "label": "Sentinel"},
+        }
+        with patch("src.mcp_handlers.dialectic.reviewer.is_agent_in_active_session",
+                    new_callable=AsyncMock, return_value=False), \
+             patch("src.mcp_handlers.dialectic.reviewer._has_recently_reviewed",
+                    new_callable=AsyncMock, return_value=False):
+            result = await select_reviewer("agent-1", metadata=metadata)
+            assert result is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("tag", ["autonomous", "embodied", "anima"])
+    async def test_skips_non_reasoning_tagged_candidate(self, tag):
+        # Non-reasoning substrate tags exclude a candidate regardless of label.
+        metadata = {
+            "agent-1": {"status": "active"},
+            "agent-2": {"status": "active", "tags": [tag]},
+        }
+        with patch("src.mcp_handlers.dialectic.reviewer.is_agent_in_active_session",
+                    new_callable=AsyncMock, return_value=False), \
+             patch("src.mcp_handlers.dialectic.reviewer._has_recently_reviewed",
+                    new_callable=AsyncMock, return_value=False):
+            result = await select_reviewer("agent-1", metadata=metadata)
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_picks_reasoning_candidate_over_resident(self):
+        # A reasoning agent is selectable even when a resident is also present.
+        metadata = {
+            "agent-1": {"status": "active"},
+            "resident": {"status": "active", "tags": ["autonomous", "persistent"]},
+            "reasoner": {"status": "active"},
+        }
+        with patch("src.mcp_handlers.dialectic.reviewer.is_agent_in_active_session",
+                    new_callable=AsyncMock, return_value=False), \
+             patch("src.mcp_handlers.dialectic.reviewer._has_recently_reviewed",
+                    new_callable=AsyncMock, return_value=False):
+            result = await select_reviewer("agent-1", metadata=metadata)
+            assert result == "reasoner"
+
 
 # ---------------------------------------------------------------------------
 # 8. dialectic_calibration  (45 % -> higher)


### PR DESCRIPTION
## What

Closes the **dialectic auto-assignment design gap** (critique #1): `select_reviewer` could auto-assign a reviewer that has no thesis-response code path.

`select_reviewer` (`src/mcp_handlers/dialectic/reviewer.py`) filtered candidates by status, recency, active-session, and collusion — but **never by dialectic-reasoning capability**. With `UNITARES_AUTOSELECT_REVIEWER` enabled it could pick a resident (Lumen/Vigil/Sentinel/Watcher/Steward/Chronicler) or an `embodied`/`autonomous`/`anima` agent as reviewer. None of those can read a thesis and author an antithesis, so the session strands at the `ANTITHESIS` phase until the stuck-reviewer reaper times it out — wasted facilitation churn and a dishonest "reviewer assigned" signal.

The existing `_autoselect_enabled()` gate (default off) was only a *blanket* mitigation. This adds the missing *per-candidate* capability filter, which is the critique's recommended fix: "refuse auto-assignment for classes without dialectic capability."

## How

- New `_can_perform_dialectic_review(label, tags)` predicate + `NON_REASONING_TAGS` constant.
- Excludes candidates whose label ∈ `KNOWN_RESIDENT_LABELS` (reused from `grounding/class_indicator.py`) or whose tags intersect `{autonomous, embodied, anima}` (same convention as the paused-agent skip in `handle_request_dialectic_review` and `agent_loop_detection.py`).
- Runs **before** the PG/disk lookups (pure tag/label inspection, cheap).
- Excluded candidates leave the reviewer slot open → falls through to first-responder / awaiting-facilitation, exactly as the `None` path already handles.
- Independent of the autoselect flag: enabling the flag asserts *some* real reasoner now exists in the pool, not that residents grew a reasoning path.
- Untagged / unknown agents stay capable (filter only excludes classes we positively know cannot respond).

## Tests

Added to `TestSelectReviewer` (`tests/test_remaining_modules.py`):
- skips a known resident-label candidate
- skips `autonomous` / `embodied` / `anima`-tagged candidates (parametrized)
- still picks a reasoning candidate when a resident is also present

Full dialectic suite green locally: `test_remaining_modules::TestSelectReviewer` (18), plus `test_dialectic_handlers`, `test_dialectic_reviewer_reentrancy`, `test_reassign_reviewer`, `test_dialectic_modules_integration` (95 total).

## Scope note

This PR addresses critique **#1** only. During investigation I confirmed the critique #2 error string `"No approval received."` **does not exist anywhere in this repo's source** (`"approval"` appears only in docs/scripts); `dialectic(action='list')` is `pre_onboard`-classified and defaults to `list`, so that error originates outside this repo (plugin harness / live dispatch) and needs separate reproduction. The remaining critiques (#3 calibration, #4 UUID ownership-proof, #6 timeout coarseness) are real but out of scope here.

https://claude.ai/code/session_01HV73D1geLp5pMJWAvhGpft

---
_Generated by [Claude Code](https://claude.ai/code/session_01HV73D1geLp5pMJWAvhGpft)_