### PR TITLE
fix(responses): reconcile six API-response honesty inconsistencies

### DIFF
--- a/src/agent_profile.py
+++ b/src/agent_profile.py
@@ -28,6 +28,11 @@ from typing import Dict, Optional, List
 
 # Window sizes
 _DENSITY_WINDOW_S = 3600.0       # 1 hour for update density
+# Minimum observed span before a per-hour density is extrapolated. Below this,
+# a tiny sample (e.g. 2 check-ins 36s apart) would project to a wildly
+# overclaimed rate (~350/hr) — the same flat-prior seed-vector overclaim the
+# "uninitialized" honesty guards avoid elsewhere (dogfood 2026-06-13).
+_DENSITY_MIN_SPAN_S = 300.0      # 5 minutes
 _VERDICT_HISTORY_SIZE = 20       # Last 20 verdicts
 _COMPLEXITY_HISTORY_SIZE = 50    # Last 50 complexity values
 _DRIFT_HISTORY_SIZE = 50         # Last 50 drift magnitudes
@@ -120,16 +125,28 @@ class AgentProfile:
     # ── Computed metrics ──────────────────────────────────────────
 
     @property
-    def update_density(self) -> float:
-        """Updates per hour over the last hour window."""
+    def update_density(self) -> Optional[float]:
+        """Updates per hour over the last hour window.
+
+        Returns the count of check-ins observed in the trailing window when
+        there are too few (0 or 1) to span a rate — a low, honest number, not
+        an extrapolation. Returns None when there ARE two-plus check-ins but
+        they fall inside a window shorter than ``_DENSITY_MIN_SPAN_S``:
+        dividing a tiny sample by a few seconds of span overclaims (2 check-ins
+        36s apart project to ~350/hr; dogfood 2026-06-13). None signals "not
+        enough observation window yet", distinct from a measured rate.
+        """
         if len(self._recent_timestamps) < 2:
-            return 0.0
+            return float(len(self._recent_timestamps))
         now = time.time()
         cutoff = now - _DENSITY_WINDOW_S
         recent = [t for t in self._recent_timestamps if t >= cutoff]
         if len(recent) < 2:
             return float(len(recent))
-        return len(recent) / ((now - recent[0]) / 3600.0)
+        span_s = now - recent[0]
+        if span_s < _DENSITY_MIN_SPAN_S:
+            return None
+        return len(recent) / (span_s / 3600.0)
 
     @property
     def session_tenure_hours(self) -> float:
@@ -210,9 +227,10 @@ class AgentProfile:
 
     def to_summary(self) -> Dict:
         """Serializable summary for API responses."""
-        return {
+        density = self.update_density
+        summary = {
             "total_updates": self.total_updates,
-            "update_density_per_hour": round(self.update_density, 2),
+            "update_density_per_hour": round(density, 2) if density is not None else None,
             "session_tenure_hours": round(self.session_tenure_hours, 2),
             "complexity": self.complexity_stats,
             "confidence": self.confidence_stats,
@@ -220,6 +238,13 @@ class AgentProfile:
             "verdict_trajectory": self.verdict_trajectory,
             "verdict_trend": self.verdict_trend,
         }
+        if density is None:
+            summary["update_density_note"] = (
+                "Observation window too short to report a per-hour rate without "
+                f"over-extrapolating; populates once activity spans "
+                f"{int(_DENSITY_MIN_SPAN_S // 60)}+ minutes."
+            )
+        return summary
 
     def to_dict(self) -> Dict:
         """Full serialization for persistence."""

--- a/src/governance_monitor.py
+++ b/src/governance_monitor.py
@@ -1028,10 +1028,22 @@ class UNITARESMonitor:
             )
         else:
             confidence = float(confidence)
+            # Agent-reported confidence is taken at face value, but it has NOT
+            # been validated against any calibration history. Claiming
+            # reliability "high" here contradicted calibration_samples: 0 in the
+            # surfaced response (dogfood 2026-06-13): with zero backing samples
+            # the reliability of the *estimate* is unknown, not high.
             confidence_metadata = {
                 'source': 'external',
-                'reliability': 'high',
+                'reliability': 'unknown',
+                'calibration_applied': False,
+                'calibration_samples': 0,
+                'external_provided': True,
                 'value': confidence,
+                'honesty_note': (
+                    'Agent-reported confidence taken as-is; not validated '
+                    'against calibration history (0 samples).'
+                ),
             }
 
         # Store confidence and metadata for audit logging and transparency

--- a/src/mcp_handlers/error_handling.py
+++ b/src/mcp_handlers/error_handling.py
@@ -3,7 +3,7 @@ from typing import Dict, Any, Tuple, Optional
 from mcp.types import TextContent
 import json
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 
 from src.logging_utils import get_logger
 
@@ -132,7 +132,7 @@ def error_response(
     response = {
         "success": False,
         "error": sanitized_message,
-        "server_time": datetime.now().isoformat()
+        "server_time": datetime.now(timezone.utc).isoformat()
     }
 
     if error_code:
@@ -174,7 +174,7 @@ def error_response(
                 "success": False,
                 "error": sanitized_message,
                 "error_code": error_code or "SERIALIZATION_ERROR",
-                "server_time": datetime.now().isoformat()
+                "server_time": datetime.now(timezone.utc).isoformat()
             }
             json_text = json.dumps(minimal_response, ensure_ascii=False)
 

--- a/src/mcp_handlers/introspection/feedback.py
+++ b/src/mcp_handlers/introspection/feedback.py
@@ -63,6 +63,15 @@ def get_calibration_feedback(include_complexity: bool = True) -> Dict[str, Any]:
                         # looking like personal calibration (dogfood
                         # 2026-06-10; same class as the #572 mirror fix).
                         'scope': 'fleet',
+                        # Self-describe the denominator so it can't be confused
+                        # with learning_context.calibration.total_decisions
+                        # (dogfood 2026-06-13: two calibration counts in one
+                        # payload with no indication of what each measured).
+                        # Both count the same fleet-wide STRATEGIC trajectory
+                        # population, so when the strategic check is the source
+                        # they reconcile to the same n.
+                        'population': 'strategic_trajectory_decisions',
+                        'samples': total_samples,
                         'system_accuracy': overall_accuracy,
                         'mean_confidence': mean_confidence,
                         'calibration_error': calibration_error

--- a/src/mcp_handlers/response_base.py
+++ b/src/mcp_handlers/response_base.py
@@ -2,7 +2,7 @@
 from typing import Dict, Any, Sequence
 from mcp.types import TextContent
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 
 from src.logging_utils import get_logger
 
@@ -27,7 +27,7 @@ def format_metrics_report(
     standardized["agent_id"] = agent_id
 
     if include_timestamp:
-        standardized["timestamp"] = datetime.now().isoformat()
+        standardized["timestamp"] = datetime.now(timezone.utc).isoformat()
 
     if include_context:
         if "health_status" not in standardized and "health_status" in metrics:
@@ -95,7 +95,10 @@ def success_response(data: Dict[str, Any], agent_id: str = None, arguments: Dict
 
     response = {
         "success": True,
-        "server_time": datetime.now().isoformat(),
+        # tz-aware UTC so server_time carries an explicit offset, matching
+        # tz-aware fields like paused_at (dogfood 2026-06-13: a bare-local
+        # server_time next to a +00:00 paused_at made duration math 6h wrong).
+        "server_time": datetime.now(timezone.utc).isoformat(),
         **data
     }
 

--- a/src/mcp_handlers/updates/enrichments.py
+++ b/src/mcp_handlers/updates/enrichments.py
@@ -24,6 +24,12 @@ from .context import UpdateContext
 from .pipeline import enrichment
 logger = get_logger(__name__)
 
+# Below this blended relevance, a related-discovery match is noise rather than
+# signal and is not surfaced as a "build on these" suggestion. The score is the
+# post-blend value (semantic similarity blended with connectivity, then decayed),
+# so this floor sits well under the raw similarity gate.
+_RELATED_DISCOVERY_RELEVANCE_FLOOR = 0.1
+
 # ─── Identity Reminder ─────────────────────────────────────────────────
 
 @enrichment(order=10)
@@ -849,12 +855,23 @@ def enrich_saturation_diagnostics(ctx: UpdateContext) -> None:
                 'will_saturate': sat_diag['will_saturate'],
                 'at_boundary': sat_diag['at_boundary'],
                 'I_equilibrium': sat_diag['I_equilibrium_linear'],
+                # Disambiguate from unitares_v41.equilibrium.I_target: this is
+                # the *instantaneous* fixed-point implied by the linear I-channel
+                # at the current state/params, not the prescribed design target
+                # the controller converges toward (dogfood 2026-06-13: 0.52 here
+                # vs 1.0 there, surfaced side by side with no label).
+                'I_equilibrium_kind': 'instantaneous_linear_fixed_point',
                 'forcing_term_A': sat_diag['A'],
                 '_interpretation': (
                     "Positive sat_margin means push-to-boundary (logistic mode will saturate I->1)"
                     if sat_diag['sat_margin'] > 0
                     else "Negative sat_margin - stable interior equilibrium exists"
-                )
+                ),
+                '_equilibrium_note': (
+                    "I_equilibrium is the instantaneous linear fixed-point for current "
+                    "params/state; it is NOT unitares_v41.equilibrium.I_target (the "
+                    "prescribed design attractor the controller converges toward)."
+                ),
             }
     except Exception as e:
         logger.debug(f"Could not compute saturation diagnostics: {e}")
@@ -1067,6 +1084,13 @@ async def enrich_learning_context(ctx: UpdateContext) -> None:
                 if cal_insight is not None:
                     learning_context["calibration"] = {
                         "total_decisions": total,
+                        # Self-describe the denominator so it can't be confused
+                        # with calibration_feedback's sample count (dogfood
+                        # 2026-06-13: two calibration counts in one payload, no
+                        # indication of what each measured). Both count the same
+                        # fleet-wide STRATEGIC trajectory population.
+                        "scope": "fleet",
+                        "population": "strategic_trajectory_decisions",
                         "trajectory_health": round(trajectory_health, 2),
                         "high_confidence_trajectory_health": round(high_conf_trajectory_health, 2),
                         "low_confidence_trajectory_health": round(low_conf_trajectory_health, 2),
@@ -1377,17 +1401,29 @@ async def _search_kg_by_checkin_text(ctx: UpdateContext) -> list:
                 disc, score = item, 0
 
             if isinstance(disc, dict):
+                relevance = score or disc.get("relevance", disc.get("score", 0))
                 entry = {
                     "summary": disc.get("summary", "")[:200],
                     "agent_id": disc.get("agent_id", "unknown"),
-                    "relevance": score or disc.get("relevance", disc.get("score", 0)),
+                    "relevance": relevance,
                 }
             else:
+                relevance = score or getattr(disc, 'relevance', 0)
                 entry = {
                     "summary": getattr(disc, 'summary', "")[:200],
                     "agent_id": getattr(disc, 'agent_id', "unknown"),
-                    "relevance": score or getattr(disc, 'relevance', 0),
+                    "relevance": relevance,
                 }
+            # Drop noise-floor matches. The surfaced relevance is the *blended*
+            # score (similarity*0.7 + connectivity*0.3, then temporal/status
+            # decay), so an entry can clear semantic_search's similarity gate yet
+            # collapse to ~0.05 — surfacing it as "build on these" is noise, not
+            # signal (dogfood 2026-06-13).
+            try:
+                if float(relevance) < _RELATED_DISCOVERY_RELEVANCE_FLOOR:
+                    continue
+            except (TypeError, ValueError):
+                continue
             kg_results.append(entry)
         return kg_results
     except Exception as e:

--- a/src/monitor_metrics.py
+++ b/src/monitor_metrics.py
@@ -207,6 +207,12 @@ def get_monitor_metrics(monitor: Any, include_state: bool = True) -> Dict:
         "basin": basin,
         "basin_warning": basin_warning,
         "equilibrium": {
+            # Prescribed design attractor (profile-dependent) the controller
+            # converges toward — distinct from the instantaneous linear
+            # fixed-point in saturation_diagnostics.I_equilibrium, which is
+            # derived from current params/state (dogfood 2026-06-13: the two
+            # were surfaced side by side, 1.0 vs 0.52, with no label).
+            "kind": "design_attractor_target",
             "I_target": I_target,
             "S_target": S_target,
             "E_target": E_target,

--- a/src/monitor_result.py
+++ b/src/monitor_result.py
@@ -1,6 +1,6 @@
 """Result assembly for governance monitor process_update."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict
 
 from governance_core import get_agent_baseline
@@ -129,7 +129,7 @@ def build_result(
         'policy_evaluation': _build_policy_evaluation(decision, metrics),
         'enforcement': _build_enforcement_stub(decision),
         'metrics': metrics,
-        'timestamp': datetime.now().isoformat(),
+        'timestamp': datetime.now(timezone.utc).isoformat(),
         'confidence_reliability': {
             'reliability': confidence_metadata.get('reliability', 'unknown'),
             'source': confidence_metadata.get('source', 'unknown'),

--- a/src/services/runtime_queries.py
+++ b/src/services/runtime_queries.py
@@ -308,11 +308,22 @@ async def get_governance_metrics_data(agent_id: str, arguments: Dict[str, Any], 
                 "will_saturate": sat_diag["will_saturate"],
                 "at_boundary": sat_diag["at_boundary"],
                 "I_equilibrium": sat_diag["I_equilibrium_linear"],
+                # Disambiguate from unitares_v41.equilibrium.I_target: this is
+                # the instantaneous linear fixed-point for current params/state,
+                # NOT the prescribed design attractor the controller converges
+                # toward (dogfood 2026-06-13: 0.52 here vs 1.0 there, side by
+                # side with no label).
+                "I_equilibrium_kind": "instantaneous_linear_fixed_point",
                 "forcing_term_A": sat_diag["A"],
                 "_interpretation": (
                     "⚠️ Positive sat_margin means push-to-boundary (logistic mode will saturate I→1)"
                     if sat_diag["sat_margin"] > 0
                     else "✓ Negative sat_margin - stable interior equilibrium exists"
+                ),
+                "_equilibrium_note": (
+                    "I_equilibrium is the instantaneous linear fixed-point for current "
+                    "params/state; it is NOT unitares_v41.equilibrium.I_target (the "
+                    "prescribed design attractor the controller converges toward)."
                 ),
             }
     except Exception as e:

--- a/src/services/update_response_service.py
+++ b/src/services/update_response_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Sequence
 
 from mcp.types import TextContent
@@ -61,7 +61,7 @@ def serialize_process_update_response(
     try:
         if serializer is not None:
             return serializer(response_data, agent_id=agent_uuid, arguments=arguments)
-        payload = {"success": True, "server_time": datetime.now().isoformat(), **response_data}
+        payload = {"success": True, "server_time": datetime.now(timezone.utc).isoformat(), **response_data}
         return [TextContent(type="text", text=json.dumps(payload, ensure_ascii=False, default=str))]
     except Exception as serialization_error:
         logger.error(f"Failed to serialize response: {serialization_error}", exc_info=True)

--- a/tests/test_agent_profile.py
+++ b/tests/test_agent_profile.py
@@ -134,9 +134,41 @@ class TestUpdateDensity:
         for i in range(10):
             p.record_checkin(complexity=0.5, timestamp=now - 1800 + i * 180)
         density = p.update_density
+        assert density is not None
         assert density > 0
         # ~10 updates in 0.5 hours = ~20/hr
         assert density > 10
+
+    def test_short_window_does_not_extrapolate(self):
+        """Two check-ins 36s apart must NOT project to a ~350/hr rate.
+
+        Regression for the flat-prior overclaim (dogfood 2026-06-13): a tiny
+        sample over a few seconds should report None ("not enough window yet"),
+        not a per-hour rate extrapolated from the burst.
+        """
+        p = AgentProfile()
+        now = time.time()
+        p.record_checkin(complexity=0.5, timestamp=now - 36)
+        p.record_checkin(complexity=0.5, timestamp=now)
+        assert p.update_density is None
+
+    def test_short_window_summary_carries_honest_note(self):
+        p = AgentProfile()
+        now = time.time()
+        p.record_checkin(complexity=0.5, timestamp=now - 36)
+        p.record_checkin(complexity=0.5, timestamp=now)
+        summary = p.to_summary()
+        assert summary["update_density_per_hour"] is None
+        assert "update_density_note" in summary
+
+    def test_long_window_summary_has_no_note(self):
+        p = AgentProfile()
+        now = time.time()
+        for i in range(10):
+            p.record_checkin(complexity=0.5, timestamp=now - 1800 + i * 180)
+        summary = p.to_summary()
+        assert summary["update_density_per_hour"] is not None
+        assert "update_density_note" not in summary
 
 
 class TestSessionTenure:


### PR DESCRIPTION
## What

A dogfood probe session (2026-06-13) surfaced seven API-response inconsistencies — fields that contradict themselves, mix conventions, or overclaim. This fixes **six**; #3 is deferred for coordination (see below). Theme throughout: *don't surface a number/label more confident than the data behind it, and make co-located fields self-describing.*

The probe agent marked its check-in synthetic in the KG and recovered itself, so fleet calibration isn't contaminated.

## Fixes

**1. `confidence_reliability` self-contradiction** — the external-confidence path hardcoded `reliability: "high"` while the response showed `calibration_samples: 0` and `honesty_note: "No metadata available"`. Agent self-reports aren't validated against calibration history, so reliability is now `"unknown"`, with explicit `calibration_applied`/`calibration_samples`/`external_provided` and an honest note. *(`src/governance_monitor.py`)*

**2. Timestamp timezone mixing** — `server_time`/result `timestamp` used naive `datetime.now()` (bare local, e.g. MDT) next to tz-aware `paused_at` (`+00:00`), so any duration math across the fields was hours off. All response-envelope timestamps now use `datetime.now(timezone.utc)`, matching the already-correct `paused_at`. *(`response_base.py`, `error_handling.py`, `update_response_service.py`, `monitor_result.py`)*

**4. Two unreconciled `I` equilibria side by side** — `saturation_diagnostics.I_equilibrium` (0.52, the instantaneous linear fixed-point) and `unitares_v41.equilibrium.I_target` (1.0, the prescribed design attractor) had no label distinguishing them. Both now carry a `kind`/`_equilibrium_note` disambiguator on every surfacing path. *(`enrichments.py`, `runtime_queries.py`, `monitor_metrics.py`)*

**5. `update_density_per_hour` flat-prior overclaim** — 2 updates over 36s projected to ~350/hr. The per-hour rate is now withheld (`null` + honest `update_density_note`) until activity spans a minimum observation window (5 min), mirroring the `uninitialized` honesty guards used elsewhere. The 0/1-in-window count case is unchanged (a low honest number, not an extrapolation). *(`src/agent_profile.py` + tests)*

**6. Semantic-search noise-floor matches** — related-discovery suggestions surfaced blended-relevance ~0.05 hits as "build on these". The surfaced `relevance` is the *post-blend* score (similarity·0.7 + connectivity·0.3, then temporal/status decay), so a hit can clear `semantic_search`'s 0.3 similarity gate yet collapse to noise. Entries below a relevance floor are now dropped. *(`enrichments.py`)*

**7. Calibration denominator divergence** — `learning_context.calibration.total_decisions` and `calibration_feedback`'s sample count appeared together with no indication of what each measured. Both now self-describe (`scope: "fleet"`, `population: "strategic_trajectory_decisions"`, explicit `samples`) so they're comparable rather than ambiguous — both count the same fleet-wide strategic trajectory population. *(`enrichments.py`, `feedback.py`)*

## Deferred — #3 identity serialization leak

The single note-write returning four handles for one agent (`claude_20260613`, the UUID, `claude-opus48-dogfood` in the `agent_id` slot, `Claude_Opus_4_8_20260613` as `structured_agent_id`) is real, but identity/onboarding serialization is a **writer-locked, cross-repo coupled surface** per `CLAUDE.md`, and `docs/ontology/plan.md` has an **active S4/S5 thread** classifying exactly these `structured_agent_id` surfacings (cosmetic vs load-bearing). Touching it here would risk colliding with that in-flight ontology work. Left untouched and flagged.

## Tests

Added pure-logic regression tests for the density guard (`tests/test_agent_profile.py`): the 36s/2-update case returns `None`, the summary carries the honest note, and a healthy window still reports a rate with no note. Verified directly.

The remaining changes are additive response-field labels / tz fixes validated by byte-compile; this environment is Python 3.11 (repo requires 3.12) so the full suite is left to CI.

https://claude.ai/code/session_014GVkDgKkypNy6qtZ9sXwM8

---
_Generated by [Claude Code](https://claude.ai/code/session_014GVkDgKkypNy6qtZ9sXwM8)_