### PR TITLE
fix(dashboard): inner deadline degrades slow fleet read instead of 15s hang

### DIFF
--- a/src/mcp_handlers/admin/dashboard.py
+++ b/src/mcp_handlers/admin/dashboard.py
@@ -3,6 +3,8 @@
 Bypasses session binding so visualizers and dashboards can see the full system.
 """
 
+import asyncio
+import os
 from datetime import datetime, timezone, timedelta
 from typing import Any, Dict, Sequence
 from mcp.types import TextContent
@@ -15,13 +17,55 @@ from src.logging_utils import get_logger
 
 logger = get_logger(__name__)
 
+# Inner deadline for the one slow external call — the full-fleet state read.
+# The @mcp_tool decorator's 15s timeout is a HARD backstop, not a fine-grained
+# guard: without an inner deadline a hung or scheduler-amplified DB read (see
+# CLAUDE.md "Substrate Tax" — a documented ~60x in-handler amplification) makes
+# the whole dashboard hang the full 15s and then fail outright, even though the
+# in-memory metadata and live ODE overlay needed for a useful overview are
+# already on hand. This budget degrades to that in-memory view fast instead.
+# Generous relative to the ≤500ms Redis guards because a full-fleet state query
+# legitimately does more work; override via env for tighter/looser tuning.
+_DASHBOARD_DB_BUDGET_S_DEFAULT = 5.0
+
+
+def _dashboard_db_budget_s() -> float:
+    """Inner DB-read budget in seconds (env-overridable, falls back on garbage)."""
+    raw = os.environ.get("UNITARES_DASHBOARD_DB_BUDGET_S")
+    if raw is None:
+        return _DASHBOARD_DB_BUDGET_S_DEFAULT
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return _DASHBOARD_DB_BUDGET_S_DEFAULT
+    return value if value > 0 else _DASHBOARD_DB_BUDGET_S_DEFAULT
+
 
 @mcp_tool("dashboard", timeout=15.0, description="Read-only system overview: all agents with EISV state. No session binding required.")
 async def handle_dashboard(arguments: ToolArgumentsDict) -> Sequence[TextContent]:
     """Return all active agents with their current EISV vectors."""
     try:
         db = get_db()
-        states = await db.get_all_latest_agent_states()
+
+        # Inner fast-fail guard. On a hung/amplified read we degrade to the
+        # in-memory overview rather than letting the decorator's 15s backstop
+        # hang the caller and then return nothing useful. A DB *exception*
+        # still falls through to the outer except (full error response) — only
+        # a *slow* read degrades here.
+        db_budget_s = _dashboard_db_budget_s()
+        degraded = False
+        try:
+            states = await asyncio.wait_for(
+                db.get_all_latest_agent_states(), timeout=db_budget_s
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Dashboard DB state read exceeded %.1fs budget — degrading to "
+                "in-memory metadata/ODE overlay (DB-derived EISV omitted this call)",
+                db_budget_s,
+            )
+            states = []
+            degraded = True
 
         # Index states by agent_id — E now comes from s.energy (extracted in _row_to_agent_state)
         state_by_agent: Dict[str, Any] = {}
@@ -139,13 +183,21 @@ async def handle_dashboard(arguments: ToolArgumentsDict) -> Sequence[TextContent
         total = len(agents)
         agents = agents[offset:offset + limit]
 
-        return success_response({
+        response: Dict[str, Any] = {
             "agents": agents,
             "total": total,
             "showing": len(agents),
             "offset": offset,
             "has_more": (offset + len(agents)) < total,
-        })
+            "degraded": degraded,
+        }
+        if degraded:
+            response["degraded_reason"] = (
+                f"DB state read exceeded {db_budget_s:.0f}s inner budget; showing "
+                "in-memory metadata and live ODE overlay only "
+                "(DB-derived EISV omitted this call)"
+            )
+        return success_response(response)
 
     except Exception as e:
         logger.error(f"Dashboard error: {e}")

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -15,6 +15,7 @@ Tests cover:
 - Backward compatibility: new params default to current behavior
 """
 
+import asyncio
 import json
 import sys
 from dataclasses import dataclass, field
@@ -503,6 +504,78 @@ class TestDashboardErrors:
         data = parse_result(result)
         assert data["success"] is False
         assert "connection lost" in data["error"]
+
+
+# ============================================================================
+# Inner deadline / degraded fall-through (critique #6: timeout coarseness)
+# ============================================================================
+
+class TestDashboardInnerDeadline:
+
+    @pytest.mark.asyncio
+    async def test_slow_db_degrades_to_in_memory(self, mock_server, monkeypatch):
+        """A DB read that exceeds the inner budget degrades fast instead of
+        hanging the full 15s decorator timeout, and still returns the in-memory
+        overview with a degraded flag."""
+        monkeypatch.setenv("UNITARES_DASHBOARD_DB_BUDGET_S", "0.05")
+
+        async def _slow_states():
+            await asyncio.sleep(5)  # would blow the inner budget
+            return []
+
+        mock_db = AsyncMock()
+        mock_db.get_all_latest_agent_states = _slow_states
+        now = datetime.now(timezone.utc).isoformat()
+        mock_server.agent_metadata = {
+            "agent-1": make_metadata("agent-1", total_updates=5, last_update=now),
+        }
+        with patch("src.mcp_handlers.admin.dashboard.get_db", return_value=mock_db), \
+             patch("src.mcp_handlers.admin.dashboard.mcp_server", mock_server):
+            from src.mcp_handlers.admin.dashboard import handle_dashboard
+            result = await handle_dashboard({})
+
+        data = parse_result(result)
+        # Success (not a hard error) and the in-memory agent is still surfaced.
+        assert data["success"] is True
+        assert data["degraded"] is True
+        assert "degraded_reason" in data
+        assert data["total"] == 1
+        assert data["agents"][0]["id"] == "agent-1"
+        # No DB-derived EISV on the degraded call.
+        assert "eisv" not in data["agents"][0]
+
+    @pytest.mark.asyncio
+    async def test_fast_db_not_degraded(self, mock_db, mock_server):
+        """Normal (fast) DB read reports degraded=False."""
+        mock_server.agent_metadata = {
+            "agent-1": make_metadata("agent-1"),
+        }
+        with patch("src.mcp_handlers.admin.dashboard.get_db", return_value=mock_db), \
+             patch("src.mcp_handlers.admin.dashboard.mcp_server", mock_server):
+            from src.mcp_handlers.admin.dashboard import handle_dashboard
+            result = await handle_dashboard({})
+
+        data = parse_result(result)
+        assert data["success"] is True
+        assert data["degraded"] is False
+        assert "degraded_reason" not in data
+
+    def test_budget_env_override_and_fallback(self, monkeypatch):
+        from src.mcp_handlers.admin.dashboard import (
+            _dashboard_db_budget_s,
+            _DASHBOARD_DB_BUDGET_S_DEFAULT,
+        )
+
+        monkeypatch.delenv("UNITARES_DASHBOARD_DB_BUDGET_S", raising=False)
+        assert _dashboard_db_budget_s() == _DASHBOARD_DB_BUDGET_S_DEFAULT
+
+        monkeypatch.setenv("UNITARES_DASHBOARD_DB_BUDGET_S", "2.5")
+        assert _dashboard_db_budget_s() == 2.5
+
+        # Garbage / non-positive values fall back to the default.
+        for bad in ("not-a-number", "0", "-3"):
+            monkeypatch.setenv("UNITARES_DASHBOARD_DB_BUDGET_S", bad)
+            assert _dashboard_db_budget_s() == _DASHBOARD_DB_BUDGET_S_DEFAULT
 
 
 # ============================================================================


### PR DESCRIPTION
## What

Addresses critique **#6 — Timeout Coarseness**: "Decorator-level 15s timeout is NOT equivalent to inner guards (cached data / run_in_executor / wait_for ≤500ms per spec). It lets pipeline hang 15s before falling through."

The `@mcp_tool` decorator's timeout is a **hard backstop**, not a fine-grained guard — when an inner external call hangs, the whole handler waits the full decorator timeout (15s) and then fails outright. The `dashboard` tool was a clean instance: its only slow external call, `db.get_all_latest_agent_states()`, had no inner deadline, so a hung or scheduler-amplified read (CLAUDE.md "Substrate Tax" — a documented ~60× in-handler amplification) hung the tool 15s and returned **nothing useful**, even though the in-memory metadata + live ODE/behavioral overlay needed for a useful overview are already gathered in-handler.

## How

- Wrap the single slow DB call in `asyncio.wait_for` with an env-overridable budget (`UNITARES_DASHBOARD_DB_BUDGET_S`, default **5s**, comfortably under the 15s backstop).
- On timeout: **degrade** to the in-memory overview and flag it (`degraded: true` + `degraded_reason`) instead of hanging.
- A DB **exception** still falls through to the full error response (unchanged) — only a **slow** read degrades.
- Matches the established `wait_for`-guard convention (the Watcher even enforces it via pattern P004).

This is the in-spec, per-handler fix the critique calls for (`wait_for ≤ budget → fast degraded fall-through`). The generic decorator timeout can't synthesize a meaningful degraded response — only the handler knows its in-memory fallback — so the fix lives at the call site by design.

## Tests

Added `TestDashboardInnerDeadline`:
- slow DB read degrades to in-memory overview (`degraded=true`, agent still surfaced, no DB-derived EISV)
- fast read stays `degraded=false`
- budget env-override + garbage/non-positive fallback

Full `tests/test_dashboard.py` green (37 passed). (Pre-existing `psutil`-not-installed failures in `test_admin_handlers.py` are unrelated to this change and pass under CI.)

## Scope note

Scoped to the `dashboard` handler — the most user-facing 15s read with a clean in-memory fallback — rather than retrofitting all ~30 `timeout=15.0` handlers in one PR. The pattern here is the template for extending the same inner-deadline guard to other substrate-tax-exposed read handlers (`observe`, `aggregate_metrics`, etc.) as follow-ups if desired.

https://claude.ai/code/session_01HV73D1geLp5pMJWAvhGpft

---
_Generated by [Claude Code](https://claude.ai/code/session_01HV73D1geLp5pMJWAvhGpft)_