### PR TITLE
fix(calibration): correct severe lower-bin underconfidence instead of capping it

### DIFF
--- a/src/calibration.py
+++ b/src/calibration.py
@@ -1045,8 +1045,15 @@ class CalibrationChecker:
                 # If expected 0.9 but actual 0.7, factor = 0.78
                 # If expected 0.5 but actual 0.6, factor = 1.2 (underconfident)
                 factor = actual_accuracy / expected_accuracy
-                # Clip to reasonable range [0.5, 1.5] to avoid extreme corrections
-                factor = max(0.5, min(1.5, factor))
+                # Asymmetric clip. The downside floor (0.5) guards against a
+                # single noisy low-accuracy sample cratering confidence. The
+                # upside is widened to 4.0 (was 1.5) so severe lower-bin
+                # underconfidence is reported honestly instead of silently
+                # capped — a 0.0-0.5 bin running near 1.0 accuracy has a true
+                # factor ~4x, which the old 1.5 cap hid. The production path
+                # (apply_confidence_correction) additionally bounds the applied
+                # output by the bin's measured accuracy.
+                factor = max(0.5, min(4.0, factor))
                 corrections[bin_key] = factor
 
         return corrections
@@ -1226,14 +1233,34 @@ class CalibrationChecker:
             return reported_confidence, None
 
         factor = actual_accuracy / expected_accuracy
-        factor = max(0.5, min(1.5, factor))  # Clip to reasonable range
 
-        corrected = reported_confidence * factor
+        if factor >= 1.0:
+            # Underconfident bin: the agent reports LESS confidence than the
+            # bin's measured accuracy warrants. The previous symmetric clip
+            # (factor capped at 1.5) mathematically blocked this correction — a
+            # 0.0-0.5 bin running near 1.0 accuracy needs a ~4x lift but was
+            # held to 1.5x, so the severe lower-bin underconfidence the
+            # calibration audit flagged (bins 0.0-0.5 / 0.5-0.7 / 0.7-0.8) was
+            # never actually corrected. Allow the full upward factor, bounded by
+            # the bin's *measured* accuracy: actual_accuracy is the evidence
+            # ceiling — never claim more confidence than the bin has achieved.
+            corrected = min(reported_confidence * factor, actual_accuracy)
+        else:
+            # Overconfident bin: keep the historical floor so a single noisy
+            # low-accuracy sample can't crater confidence. Regime unchanged.
+            factor = max(0.5, factor)
+            corrected = reported_confidence * factor
+
         corrected = max(0.0, min(1.0, corrected))  # Clamp to [0, 1]
 
-        # Only report if correction is significant (> 5%)
-        if abs(factor - 1.0) > 0.05:
-            info = f"calibration_adjusted: {reported_confidence:.2f} → {corrected:.2f} (factor={factor:.2f}, n={stats['count']})"
+        # Report when the *realized* correction is significant (> 5% absolute).
+        # Keyed on the applied delta rather than the raw factor, because the
+        # evidence ceiling can bound the correction below `factor`.
+        if abs(corrected - reported_confidence) > 0.05:
+            info = (
+                f"calibration_adjusted: {reported_confidence:.2f} → {corrected:.2f} "
+                f"(factor={factor:.2f}, actual={actual_accuracy:.2f}, n={stats['count']})"
+            )
             return corrected, info
 
         return corrected, None

--- a/tests/test_calibration_module.py
+++ b/tests/test_calibration_module.py
@@ -846,14 +846,18 @@ class TestComputeCorrectionFactors:
         factors = checker.compute_correction_factors(min_samples=5)
         assert factors["0.8-0.9"] >= 0.5
 
-    def test_factor_clipped_upper(self, checker):
-        # actual_accuracy/expected_accuracy could exceed 1.5
+    def test_factor_upper_reflects_underconfidence(self, checker):
+        # Critique #3: a 0.0-0.5 bin running at ~1.0 accuracy is severely
+        # underconfident (true factor ~4.0). The old symmetric clip hid this at
+        # 1.5; the widened upside reports it honestly (bounded at 4.0).
         checker.tactical_bin_stats["0.0-0.5"] = {
             "count": 20, "actual_correct": 20, "predicted_correct": 20,
             "confidence_sum": 5.0,  # avg 0.25, actual 1.0 -> factor 4.0
         }
         factors = checker.compute_correction_factors(min_samples=5)
-        assert factors["0.0-0.5"] <= 1.5
+        assert factors["0.0-0.5"] == pytest.approx(4.0, abs=0.01)
+        # And still bounded — never reports an unbounded factor.
+        assert factors["0.0-0.5"] <= 4.0
 
     def test_near_zero_expected_skipped(self, checker):
         checker.tactical_bin_stats["0.0-0.5"] = {
@@ -918,6 +922,44 @@ class TestApplyConfidenceCorrection:
         }
         corrected, info = checker.apply_confidence_correction(1.0, min_samples=5)
         assert 0.0 <= corrected <= 1.0
+
+    def test_underconfident_lower_bin_corrected_up(self, checker, monkeypatch):
+        # Critique #3 core: bin 0.0-0.5 reports ~0.25 confidence but is actually
+        # ~1.0 accurate. The old 1.5 factor cap left a 0.25 report at 0.375; the
+        # evidence-bounded fix lifts it toward the bin's measured accuracy.
+        monkeypatch.setattr(checker, "_tactical_signal_age_days", lambda: 0.5)
+        checker.tactical_bin_stats["0.0-0.5"] = {
+            "count": 20, "actual_correct": 20, "predicted_correct": 20,
+            "confidence_sum": 5.0,  # avg 0.25, actual 1.0
+        }
+        corrected, info = checker.apply_confidence_correction(0.25, min_samples=5)
+        # 0.25 * 4.0 = 1.0, bounded by measured accuracy (1.0).
+        assert corrected == pytest.approx(1.0, abs=1e-6)
+        # Strictly better than the old 1.5-cap ceiling of 0.375.
+        assert corrected > 0.375
+        assert info is not None and "calibration_adjusted" in info
+
+    def test_underconfidence_bounded_by_measured_accuracy(self, checker, monkeypatch):
+        # The lift never exceeds the bin's measured accuracy (evidence ceiling),
+        # even when reported * factor would overshoot it.
+        monkeypatch.setattr(checker, "_tactical_signal_age_days", lambda: 0.5)
+        checker.tactical_bin_stats["0.5-0.7"] = {
+            "count": 20, "actual_correct": 18, "predicted_correct": 20,
+            "confidence_sum": 11.0,  # avg 0.55, actual 0.90
+        }
+        # reported 0.69 (top of bin) * factor(0.90/0.55=1.636) = 1.13 -> capped at 0.90
+        corrected, info = checker.apply_confidence_correction(0.69, min_samples=5)
+        assert corrected == pytest.approx(0.90, abs=1e-6)
+
+    def test_overconfident_regime_unchanged(self, checker, monkeypatch):
+        # The overconfident path keeps the historical 0.5 floor behavior.
+        monkeypatch.setattr(checker, "_tactical_signal_age_days", lambda: 0.5)
+        checker.tactical_bin_stats["0.8-0.9"] = {
+            "count": 20, "actual_correct": 2, "predicted_correct": 20,
+            "confidence_sum": 17.0,  # avg 0.85, actual 0.10 -> raw factor 0.118, floored 0.5
+        }
+        corrected, info = checker.apply_confidence_correction(0.85, min_samples=5)
+        assert corrected == pytest.approx(0.85 * 0.5, abs=1e-6)
 
 
 # ===========================================================================


### PR DESCRIPTION
## What

Addresses critique **#3 — Severe Miscalibration in Lower Confidence Bins** (0.0–0.5: 75.4% error, 0.5–0.7: 40.5%, 0.7–0.8: 25.3% — system-wide underconfidence). Root cause per the critique: *"The system knows it's miscalibrated but hasn't fixed the underlying confidence estimation."*

The auto-calibration loop **already exists** and is **wired into the live update pipeline** (`apply_confidence_correction` → `phases.py:529` → `ctx.confidence`). It multiplies reported confidence by `factor = actual_accuracy / expected_accuracy`, then clipped symmetrically to `[0.5, 1.5]`.

**That 1.5 ceiling is the bug.** It mathematically blocks correcting underconfidence: a 0.0–0.5 bin running at ~1.0 accuracy (expected≈0.25) has a true factor of ~4.0, but the cap held it to 1.5 — so a 0.25 report was stuck at 0.375 instead of moving toward the bin's measured accuracy. The lower bins could *never* be corrected, exactly as observed.

## How

Replace the symmetric clip with an **asymmetric, evidence-bounded** correction:

- **Underconfident bins** (`factor ≥ 1`): apply the full upward factor, but cap the output at the bin's **measured** `actual_accuracy` — the evidence ceiling. We never claim more confidence than the bin has actually achieved, and at/above the bin mean a report maps onto the measured accuracy.
- **Overconfident bins** (`factor < 1`): keep the historical `0.5` floor — that regime wasn't flagged and is unchanged.
- Report on the **realized delta** rather than the raw factor (the ceiling can bound the applied correction below `factor`).
- `compute_correction_factors` (diagnostic, surfaced via the admin calibration handler) gets its upside widened `1.5 → 4.0` so the same underconfidence is reported honestly.

Worked example (critique's worst bin): reported 0.25, bin actual 1.0 → old: `0.25 × min(1.5, 4.0) = 0.375`; new: `min(0.25 × 4.0, 1.0) = 1.0`.

## Tests

- Updated `test_factor_clipped_upper` → `test_factor_upper_reflects_underconfidence` (it pinned the old 1.5 cap on the exact audited 0.0–0.5 case).
- Added: lower-bin lift toward measured accuracy; evidence-ceiling bound (a top-of-bin report can't overshoot the bin's accuracy); overconfident-regime-unchanged (0.5 floor preserved).
- Full calibration suites green: `test_calibration_module.py` + `test_calibration_corrections.py` (166), plus downstream `test_core_update.py` (75) and admin/consolidated calibration tests.

## Safety

The function already corrects confidence in production; this makes the *existing* correction effective in the underconfident regime rather than introducing a new behavior class. The lift is bounded by the bin's own measured accuracy (no overshoot), the overconfident path is untouched, and the existing stale-signal honest-absence guard (`calibration_skipped` after `max_staleness_days`) and weak-identity dampening still apply.

## Scope note

This fixes the *correction* mechanism — the lever that was structurally unable to move. The broader modeling work (e.g. isotonic/Platt recalibration, narrower adaptive bins, per-class calibration) remains a larger follow-up; this is the highest-leverage, lowest-risk slice that directly unblocks the audited lower bins.

https://claude.ai/code/session_01HV73D1geLp5pMJWAvhGpft

---
_Generated by [Claude Code](https://claude.ai/code/session_01HV73D1geLp5pMJWAvhGpft)_