### PR TITLE
fix(responses): honest verdict provenance + reconcile position/thread_size

### DIFF
--- a/src/monitor_decision.py
+++ b/src/monitor_decision.py
@@ -164,7 +164,21 @@ def make_decision(
             'action': 'pause',
             'sub_action': 'risk_pause',
             'reason': f'UNITARES high-risk verdict (risk_score={risk_score:.2f}) - safety pause suggested',
-            'guidance': 'This is a safety check, not a failure. The system detected high ethical risk and is protecting you from potential issues. Consider simplifying your approach.',
+            # Honest provenance: the verdict is driven by the signals the caller
+            # reported (ethical_drift, complexity, confidence), not by an
+            # independent measurement of behavior. Saying "the system detected
+            # high ethical risk" overclaimed — at current maturity the only
+            # non-self-attested signal (behavioral text model) does not carry
+            # this weight. See result['risk_attribution'] for the decomposition
+            # (dogfood 2026-06-13, P0).
+            'guidance': (
+                'This is a safety check, not a failure. Based on the signals you '
+                'reported (ethical_drift, complexity, confidence), this check-in '
+                'scored high-risk. These inputs are self-attested — the verdict '
+                'reflects what you reported, not an independent measurement of '
+                'your behavior (see risk_attribution). Consider simplifying your '
+                'approach.'
+            ),
             'critical': is_critical,
             'basin': basin,
             'margin': 'critical',

--- a/src/monitor_result.py
+++ b/src/monitor_result.py
@@ -71,6 +71,92 @@ def _build_enforcement_stub(decision: Dict) -> Dict:
     }
 
 
+def _build_risk_attribution(
+    metrics: Dict,
+    drift_vector,
+    continuity_metrics,
+    behavioral_assessment,
+) -> Dict:
+    """Decompose the risk/verdict by signal provenance.
+
+    The verdict path is a self-report integrity mechanism, not an
+    adversary-resistant monitor: risk is driven primarily by the
+    caller-supplied ``ethical_drift`` vector (it dominates the phi-based
+    score) plus self-reported complexity/confidence. The only
+    non-self-attested signal is the behavioral text model, and at current
+    maturity it does not carry enforcement weight (verification layer
+    reserved for v2). Surfacing the decomposition lets a reader see *what*
+    drove the verdict and how much of it is self-attested vs measured
+    (dogfood 2026-06-13, P0). All inputs here are already computed elsewhere
+    in the result; this only re-exposes them grouped by provenance.
+    """
+    self_reported: Dict = {
+        "provenance": "self_attested",
+        "description": (
+            "Magnitude of the caller-supplied ethical_drift vector — the "
+            "dominant input to the phi-based risk score. Reported by the agent, "
+            "not independently verified."
+        ),
+        "ethical_drift_norm": (
+            float(drift_vector.norm)
+            if drift_vector is not None and hasattr(drift_vector, "norm")
+            else None
+        ),
+    }
+
+    derived: Dict = {
+        "provenance": "derived",
+        "description": (
+            "Gap between self-reported and server-derived complexity. Derived "
+            "from inputs, but the self-reported half is still caller-supplied."
+        ),
+        "complexity_divergence": (
+            float(continuity_metrics.complexity_divergence)
+            if continuity_metrics is not None
+            and hasattr(continuity_metrics, "complexity_divergence")
+            else None
+        ),
+    }
+
+    behavioral: Dict = {
+        "provenance": "measured",
+        "description": (
+            "Independent text-risk model — the only non-self-attested signal. "
+            "Not yet weighted into the enforcement verdict (verification layer "
+            "reserved for v2); shown for comparison against the self-reported "
+            "drivers."
+        ),
+        "risk": (
+            float(behavioral_assessment.risk)
+            if behavioral_assessment is not None
+            else None
+        ),
+        "verdict": (
+            behavioral_assessment.verdict
+            if behavioral_assessment is not None
+            else None
+        ),
+    }
+
+    return {
+        "risk_score": metrics.get("risk_score"),
+        "verdict": metrics.get("verdict"),
+        "primary_driver": "self_reported",
+        "note": (
+            "At current maturity this verdict is driven primarily by signals you "
+            "reported (ethical_drift, complexity, confidence). An agent that "
+            "under-reports ethical_drift lowers this risk regardless of its "
+            "actual behavior. The behavioral signal is the only non-self-attested "
+            "input and does not yet carry enforcement weight."
+        ),
+        "sources": {
+            "self_reported": self_reported,
+            "derived": derived,
+            "behavioral": behavioral,
+        },
+    }
+
+
 def _complexity_divergence_novel(monitor, cm) -> bool:
     """True when the complexity divergence is worth surfacing again.
 
@@ -140,6 +226,15 @@ def build_result(
             'honesty_note': confidence_metadata.get('honesty_note', 'No metadata available')
         }
     }
+
+    # Verdict provenance: decompose risk by signal source so a reader can see
+    # how much of the verdict is self-attested vs measured (dogfood P0).
+    result['risk_attribution'] = _build_risk_attribution(
+        metrics,
+        monitor._last_drift_vector,
+        monitor._last_continuity_metrics,
+        behavioral_assessment,
+    )
 
     if task_type_adjustment:
         result['task_type_adjustment'] = task_type_adjustment

--- a/src/services/runtime_queries.py
+++ b/src/services/runtime_queries.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from numbers import Real
 from typing import Any, Dict
@@ -906,7 +906,10 @@ async def get_health_check_data(arguments: Dict[str, Any], server=None) -> Dict[
             "first_action": first_action,
             "identity_continuity_mode": continuity_status.get("mode", "unknown"),
         },
-        "timestamp": datetime.now().isoformat(),
+        # tz-aware UTC so the health timestamp carries an explicit offset,
+        # matching server_time elsewhere (dogfood 2026-06-13 P1: bare-local
+        # timestamps next to +00:00 fields made duration math 6h wrong).
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 
     # Circuit breaker telemetry — surfaced in both lite and full so dashboards

--- a/src/thread_identity.py
+++ b/src/thread_identity.py
@@ -182,12 +182,13 @@ def build_fork_context(
                 "label": prev_node.get("label"),
             }
 
-    return {
+    thread_size = len(all_nodes)
+    context = {
         "thread_id": thread_id,
         "position": position,
         "spawn_reason": spawn_reason,
         "predecessor": predecessor,
-        "thread_size": len(all_nodes),
+        "thread_size": thread_size,
         "is_root": is_root,
         "is_fork": is_fork,
         "episode_fork_kind": episode_fork_kind,
@@ -198,3 +199,20 @@ def build_fork_context(
             spawn_reason,
         ),
     }
+
+    # position and thread_size measure different things and can legitimately
+    # diverge — position is a monotonic claim counter (the Nth node ever
+    # claimed in this thread, never reused), while thread_size is the count of
+    # currently-live nodes. Pruned/archived forks lower the count without
+    # rewinding the counter (dogfood 2026-06-13 saw position 24 vs thread_size
+    # 19). Label them so the gap isn't read as a contradiction.
+    if position > thread_size:
+        context["position_note"] = (
+            "position is the node's monotonic claim sequence (Nth ever claimed "
+            "in this thread); thread_size is the count of currently-live nodes. "
+            f"position ({position}) > thread_size ({thread_size}) means "
+            f"{position - thread_size} earlier node(s) were pruned or archived — "
+            "expected, not a contradiction."
+        )
+
+    return context

--- a/tests/test_governance_monitor.py
+++ b/tests/test_governance_monitor.py
@@ -1118,6 +1118,19 @@ class TestMakeDecision:
         assert decision['action'] == 'pause'
         assert decision['critical'] is not None
 
+    def test_high_risk_guidance_states_self_reported_provenance(self, monitor):
+        """Dogfood 2026-06-13 P0: guidance must not claim the system
+        "detected high ethical risk" — the verdict is driven by self-reported
+        signals, not an independent measurement. The copy must say so."""
+        decision = monitor.make_decision(0.8, unitares_verdict='high-risk')
+        guidance = decision['guidance'].lower()
+        # The overclaiming copy is gone...
+        assert 'detected high ethical risk' not in guidance
+        assert 'protecting you' not in guidance
+        # ...replaced with honest provenance.
+        assert 'reported' in guidance
+        assert 'self-attested' in guidance
+
     def test_caution_verdict_low_risk(self, monitor):
         """Caution verdict with low risk should proceed."""
         decision = monitor.make_decision(0.1, unitares_verdict='caution')

--- a/tests/test_monitor_result_novelty.py
+++ b/tests/test_monitor_result_novelty.py
@@ -166,6 +166,122 @@ def test_build_result_exposes_policy_and_unapplied_enforcement_layers():
     }
 
 
+def test_risk_attribution_decomposes_by_provenance():
+    """Dogfood 2026-06-13 P0: the verdict is self-attested, not measured.
+    The result must expose WHAT drove the risk, grouped by provenance, so a
+    reader sees that risk is driven by self-reported ethical_drift while the
+    only non-self-attested signal (behavioral) is shown for comparison."""
+    from src.monitor_result import _build_risk_attribution
+
+    drift = SimpleNamespace(norm=0.84)
+    cm = SimpleNamespace(complexity_divergence=0.55)
+    behavioral = SimpleNamespace(risk=0.006, verdict="safe")
+    metrics = {"risk_score": 0.72, "verdict": "high-risk"}
+
+    attr = _build_risk_attribution(metrics, drift, cm, behavioral)
+
+    assert attr["risk_score"] == 0.72
+    assert attr["verdict"] == "high-risk"
+    assert attr["primary_driver"] == "self_reported"
+    assert attr["sources"]["self_reported"]["provenance"] == "self_attested"
+    assert attr["sources"]["self_reported"]["ethical_drift_norm"] == pytest.approx(0.84)
+    assert attr["sources"]["derived"]["provenance"] == "derived"
+    assert attr["sources"]["derived"]["complexity_divergence"] == pytest.approx(0.55)
+    # The non-self-attested signal is labeled "measured" and surfaced even
+    # though it disagrees with the self-reported verdict (0.006 vs high-risk).
+    assert attr["sources"]["behavioral"]["provenance"] == "measured"
+    assert attr["sources"]["behavioral"]["risk"] == pytest.approx(0.006)
+    assert attr["sources"]["behavioral"]["verdict"] == "safe"
+
+
+def test_risk_attribution_handles_missing_signals():
+    """No drift/continuity/behavioral computed → None, never a crash, and
+    still labeled by provenance."""
+    from src.monitor_result import _build_risk_attribution
+
+    attr = _build_risk_attribution(
+        {"risk_score": 0.26, "verdict": "safe"}, None, None, None
+    )
+    assert attr["sources"]["self_reported"]["ethical_drift_norm"] is None
+    assert attr["sources"]["derived"]["complexity_divergence"] is None
+    assert attr["sources"]["behavioral"]["risk"] is None
+    assert attr["sources"]["behavioral"]["verdict"] is None
+
+
+def test_build_result_includes_risk_attribution():
+    """build_result must always surface risk_attribution so every verdict
+    states whether it was driven by self-reported vs measured signal."""
+    from src.monitor_result import build_result
+
+    monitor = SimpleNamespace(
+        agent_id="agent-risk-attr",
+        _last_continuity_metrics=SimpleNamespace(
+            complexity_divergence=0.3,
+            self_complexity=0.6,
+            derived_complexity=0.3,
+            overconfidence_signal=False,
+            underconfidence_signal=False,
+            E_input=0.5,
+            I_input=0.5,
+            S_input=0.2,
+            calibration_weight=1.0,
+        ),
+        _last_restorative_status=None,
+        _last_drift_vector=SimpleNamespace(
+            norm=0.9,
+            norm_squared=0.81,
+            calibration_deviation=0.1,
+            complexity_divergence=0.3,
+            coherence_deviation=0.2,
+            stability_deviation=0.1,
+        ),
+        _gains_modulated=False,
+        adaptive_governor=None,
+        _last_surfaced_complexity_gap=None,
+        _behavioral_state=SimpleNamespace(to_dict=lambda: {}, is_baselined=False),
+        state=SimpleNamespace(
+            CE_history=[],
+            resonance_events=0,
+            damping_applied_count=0,
+            update_count=5,
+            current_rho=0.0,
+            self_complexity=None,
+        ),
+    )
+    decision = {"action": "pause", "sub_action": "risk_pause", "basin": "high"}
+    metrics = {"risk_score": 0.72, "verdict": "high-risk"}
+    oscillation = SimpleNamespace(oi=0.0, flips=0, resonant=False, trigger=None)
+
+    behavioral = SimpleNamespace(
+        health="healthy",
+        verdict="safe",
+        risk=0.006,
+        coherence=0.9,
+        components={},
+        guidance="continue working normally.",
+    )
+
+    result = build_result(
+        monitor,
+        status="warning",
+        decision=decision,
+        metrics=metrics,
+        confidence=0.1,
+        confidence_metadata={"source": "external"},
+        task_type_adjustment=None,
+        trajectory_validation=None,
+        oscillation_state=oscillation,
+        response_tier="proceed",
+        cirs_result=None,
+        damping_result=None,
+        behavioral_assessment=behavioral,
+    )
+
+    assert "risk_attribution" in result
+    assert result["risk_attribution"]["sources"]["self_reported"]["ethical_drift_norm"] == pytest.approx(0.9)
+    assert result["risk_attribution"]["sources"]["behavioral"]["risk"] == pytest.approx(0.006)
+
+
 def test_simulate_update_does_not_consume_novelty():
     """Council fold (PR #603): simulate_update runs the full governance
     cycle, including result building, which advances the novelty gate.

--- a/tests/test_thread_identity.py
+++ b/tests/test_thread_identity.py
@@ -183,6 +183,47 @@ class TestBuildForkContext:
         )
         assert ctx["thread_size"] == 4
 
+    def test_position_note_when_nodes_pruned(self):
+        """Dogfood 2026-06-13 P2.9: position (monotonic claim counter) can
+        exceed thread_size (live node count) when forks are pruned/archived.
+        Label the gap so it isn't read as a contradiction."""
+        # 19 live nodes, but this fork claimed the 24th position ever.
+        nodes = [
+            {"agent_id": f"uuid-{i}", "thread_position": i}
+            for i in range(1, 20)
+        ]
+        ctx = build_fork_context(
+            thread_id="t-pruned",
+            position=24,
+            parent_uuid=None,
+            spawn_reason="new_session",
+            all_nodes=nodes,
+            agent_uuid="uuid-24",
+        )
+        assert ctx["position"] == 24
+        assert ctx["thread_size"] == 19
+        assert "position_note" in ctx
+        assert "24" in ctx["position_note"]
+        assert "19" in ctx["position_note"]
+        assert "prune" in ctx["position_note"].lower()
+
+    def test_no_position_note_when_consistent(self):
+        """No note when position == thread_size (nothing pruned), so the
+        common case stays uncluttered and shape-compatible."""
+        nodes = [
+            {"agent_id": f"uuid-{i}", "thread_position": i}
+            for i in range(1, 5)
+        ]
+        ctx = build_fork_context(
+            thread_id="t-clean",
+            position=4,
+            parent_uuid=None,
+            spawn_reason="new_session",
+            all_nodes=nodes,
+            agent_uuid="uuid-4",
+        )
+        assert "position_note" not in ctx
+
     def test_handler_call_site_signature_contract(self):
         """Pin exact kwargs handlers.py:1946 passes after the 2026-05-02 fix.
 


### PR DESCRIPTION
## What

Implements the dogfooding findings brief (live MCP session 2026-06-13) for the items **not already covered by #665**. Every change is *more honesty* — surfacing provenance and reconciling apparent contradictions — never trading epistemic integrity for a cleaner-looking number.

Synthetic marker `note_id 2026-06-13T11:27:55.326741+00:00` is excluded from any analysis per the brief.

### P0 — Verdict provenance: the verdict is self-attested, not measured
- **`monitor_decision.py`** — the high-risk guidance no longer reads *"The system detected high ethical risk and is protecting you."* It detected *reported* risk. New copy: the verdict reflects the signals **you reported** (ethical_drift, complexity, confidence), which are self-attested, and points the reader at `risk_attribution`.
- **`monitor_result.py`** — new `risk_attribution` block on every `process_update` result, decomposing the verdict by signal **provenance**:
  - `self_reported` → `ethical_drift_norm` (`self_attested`, the dominant phi input)
  - `derived` → `complexity_divergence`
  - `behavioral` → `risk` / `verdict` (`measured` — the only non-self-attested signal, surfaced for comparison and explicitly noted as **not yet carrying enforcement weight**, verification layer reserved for v2)
  - All inputs were already computed in the result; this only re-exposes them grouped by source so a reader can see *what* drove the verdict.

### P2.9 — `thread_context` position vs thread_size mismatch
- **`thread_identity.py`** — confirmed root cause: `position` is a monotonic claim counter (`core.claim_thread_position`, the Nth node ever claimed, never reused) while `thread_size` is the count of currently-live nodes. Pruned/archived forks make them legitimately diverge (observed 24 vs 19). Adds a `position_note` (only when `position > thread_size`) labeling the gap so it isn't read as a contradiction. The common case stays uncluttered.

### P1.2 — Timestamp serialization
- **`runtime_queries.py`** — health-check `timestamp` is now tz-aware UTC with an explicit offset, matching the `server_time`/`monitor_result` fixes shipped in #665.

## Tests
Regression test per fix:
- `test_governance_monitor.py::test_high_risk_guidance_states_self_reported_provenance` — pins out the overclaiming copy, pins in the honest provenance wording.
- `test_monitor_result_novelty.py` — `risk_attribution` decomposition, missing-signal handling, and presence on `build_result`.
- `test_thread_identity.py` — `position_note` appears on prune-divergence, absent when consistent.

All touched suites pass locally (`test_governance_monitor`, `test_core_update`, `test_thread_identity`, `test_monitor_result_novelty`, `test_response_formatter`, `test_ux_fixes`).

## Not in this PR (deliberately scoped out)
- **P0 item 3** (enforcement gating / verification roadmap) — design work; enforcement at this layer is already advisory (`enforcement.applied=False`). Should be scheduled deliberately rather than rushed.
- **P1.3** (identity serialization leak — four handles for one agent) — lands on the identity/onboarding **single-writer surface** (CLAUDE.md), coupled across two repos; warrants its own coordinated change.
- **P2.8** (4-term hybrid-search cap) — opportunistic; needs a search-quality evaluation, not a blind cap bump.
- Several other P1/P2 items (confidence_reliability, equilibrium labels, density extrapolation, KG noise floor, calibration denominators) were already fixed in #665.

## Don't break (preserved)
Withholding-on-uninitialized, assurance-tier honesty, the "integration is yours to demonstrate" framing, self-incident-logging into the shared KG.

https://claude.ai/code/session_01HonFoNGJXDJAgN4f46TYhP

---
_Generated by [Claude Code](https://claude.ai/code/session_01HonFoNGJXDJAgN4f46TYhP)_