### PR TITLE
feat(kg): fold tag normalize() into the write path + lifecycle synonym pass + backfill

### DIFF
--- a/scripts/ops/backfill_tag_normalization.py
+++ b/scripts/ops/backfill_tag_normalization.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+One-time backfill: canonicalize tags on existing knowledge-graph rows.
+
+The write path now routes every new write through the extended
+``normalize_tags`` (formatting + the postgresql→postgres spelling-variant map),
+but historical rows were written before that and still fragment search
+(``Postgres`` / ``postgres`` / ``PostgreSQL`` filed three ways). This replays
+the canonical normalizer over existing discoveries so old entries stop
+fragmenting search.
+
+Two layers, mirroring the runtime split:
+  * Always applies the formatting layer (``normalize_tags``) — safe, lossless
+    spelling/format folding.
+  * With ``--include-semantic`` also applies the curated semantic synonym map
+    (``db``→``database``, ``auth``→``identity``) — the same rewrite the
+    lifecycle pass performs. Off by default so the backfill stays purely
+    formatting unless explicitly asked for the semantic merge.
+
+DRY RUN BY DEFAULT. Nothing is written without ``--apply``. Run against the
+live governance DB at deploy time; this script does not create or migrate
+schema.
+
+Usage:
+    python3 scripts/ops/backfill_tag_normalization.py                      # dry run, formatting only
+    python3 scripts/ops/backfill_tag_normalization.py --include-semantic   # dry run, + semantic map
+    python3 scripts/ops/backfill_tag_normalization.py --apply              # apply, formatting only
+    python3 scripts/ops/backfill_tag_normalization.py --apply --include-semantic -v
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Add project root to path
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+
+# Statuses that make up the queryable corpus. Archived/cold rows are included
+# so historical search over those tiers also de-fragments; this is a one-time
+# pass, not the recurring lifecycle sweep (which scopes to the active corpus).
+CORPUS_STATUSES = ("open", "resolved", "archived", "cold", "superseded", "disputed")
+
+
+def _canonical_tags(tags, include_semantic: bool):
+    """Return the canonical tag list for ``tags`` under the chosen layers."""
+    from src.knowledge_graph import normalize_tags
+
+    canonical = normalize_tags(tags)
+    if include_semantic:
+        from src.knowledge_ontology import apply_semantic_synonyms
+
+        canonical = apply_semantic_synonyms(canonical)
+    return canonical
+
+
+async def backfill(apply: bool, include_semantic: bool, verbose: bool, limit: int) -> dict:
+    from src.knowledge_graph import get_knowledge_graph
+
+    graph = await get_knowledge_graph()
+
+    seen_ids: set[str] = set()
+    scanned = 0
+    changed = 0
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    for status in CORPUS_STATUSES:
+        rows = await graph.query(status=status, limit=limit)
+        for discovery in rows:
+            if discovery.id in seen_ids:
+                continue
+            seen_ids.add(discovery.id)
+            scanned += 1
+
+            current = list(discovery.tags or [])
+            if not current:
+                continue
+            canonical = _canonical_tags(current, include_semantic)
+            if canonical == current:
+                continue
+
+            changed += 1
+            if verbose or not apply:
+                print(f"  {discovery.id}: {current} -> {canonical}")
+            if apply:
+                await graph.update_discovery(discovery.id, {
+                    "tags": canonical,
+                    "updated_at": now_iso,
+                })
+
+    return {"scanned": scanned, "changed": changed, "applied": apply}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true",
+                        help="Write the canonicalized tags (default: dry run)")
+    parser.add_argument("--include-semantic", action="store_true",
+                        help="Also apply the curated semantic synonym map")
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="Print every rewrite even when applying")
+    parser.add_argument("--limit", type=int, default=10000,
+                        help="Max rows per status tier to scan (default: 10000)")
+    args = parser.parse_args()
+
+    mode = "APPLY" if args.apply else "DRY RUN"
+    layers = "formatting + semantic" if args.include_semantic else "formatting only"
+    print(f"[{mode}] tag-normalization backfill ({layers})")
+
+    result = asyncio.run(
+        backfill(args.apply, args.include_semantic, args.verbose, args.limit)
+    )
+
+    print(
+        f"\nScanned {result['scanned']} discoveries; "
+        f"{result['changed']} need(ed) canonicalization."
+    )
+    if not args.apply and result["changed"]:
+        print("Re-run with --apply to write these changes.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/knowledge_graph.py
+++ b/src/knowledge_graph.py
@@ -24,8 +24,20 @@ logger = get_logger(__name__)
 def normalize_tags(tags) -> List[str]:
     """Normalize tags to canonical form for consistent search.
 
-    Applies: lowercase, strip whitespace, collapse separators (hyphens/underscores/spaces)
-    to single hyphens, deduplicate while preserving order.
+    Applies: lowercase, fold any run of separators/punctuation to a single
+    hyphen, strip edge hyphens, apply the formatting-layer spelling-variant
+    map (``postgresql`` → ``postgres``), deduplicate while preserving order.
+
+    This mirrors the governance-plugin client normalizer (``tag_normalize.py``)
+    so tags minted server-side, by non-plugin clients, or via the direct REST
+    path all converge on the same canonical form. Tag fragmentation is mostly
+    a formatting problem (``Postgres`` / ``postgres`` / ``PostgreSQL`` filed
+    three ways); this collapses it at every write and tag-filtered search.
+
+    Deliberately conservative: no plural stripping (``metrics`` → ``metric``
+    is lossy) and no semantic synonym merging (``auth`` vs ``identity``). The
+    semantic residue is handled by the lifecycle pass via
+    ``src.knowledge_ontology.apply_semantic_synonyms``, never here.
 
     Handles string input (JSON arrays or comma-separated) gracefully since MCP
     unified tools may pass tags as strings instead of lists.
@@ -33,11 +45,14 @@ def normalize_tags(tags) -> List[str]:
     Examples:
         ["EISV", "eisv-dynamics", "eisv_framework"] → ["eisv", "eisv-dynamics", "eisv-framework"]
         ["bug", "Bug Fix", "bug-fix", "bug_fix"] → ["bug", "bug-fix"]
+        ["Postgres", "postgres", "PostgreSQL"] → ["postgres"]
+        ["node.js", "C++"] → ["node-js", "c"]
         '["ux", "identity"]' → ["ux", "identity"]
         "ux, identity" → ["ux", "identity"]
     """
     if not tags:
         return []
+    from src.knowledge_ontology import SPELLING_VARIANTS
     # Handle string input: try JSON parse, then comma-split
     if isinstance(tags, str):
         import json
@@ -56,12 +71,16 @@ def normalize_tags(tags) -> List[str]:
         t = tag.strip().lower()
         if not t:
             continue
-        # Replace underscores and spaces with hyphens, collapse runs
-        t = re.sub(r'[\s_]+', '-', t)
-        # Collapse multiple hyphens
-        t = re.sub(r'-{2,}', '-', t)
+        # Fold any run of separators/punctuation (spaces, underscores, dots,
+        # slashes, etc.) to a single hyphen. A run collapses in one pass, so
+        # no separate multi-hyphen collapse is needed.
+        t = re.sub(r'[^a-z0-9]+', '-', t)
         # Strip leading/trailing hyphens
         t = t.strip('-')
+        if not t:
+            continue
+        # Formatting-layer spelling-variant map (postgresql → postgres).
+        t = SPELLING_VARIANTS.get(t, t)
         if t and t not in seen:
             seen.add(t)
             result.append(t)

--- a/src/knowledge_graph_lifecycle.py
+++ b/src/knowledge_graph_lifecycle.py
@@ -145,6 +145,7 @@ class KnowledgeGraphLifecycle:
             "discoveries_archived": 0,
             "discoveries_to_cold": 0,
             "ephemeral_archived": 0,
+            "tags_canonicalized": 0,
             "skipped_permanent": 0,
             "discoveries_deleted": 0,  # Always 0 - we don't delete
             "philosophy": "Never delete. Archive forever.",
@@ -153,6 +154,13 @@ class KnowledgeGraphLifecycle:
 
         try:
             graph = await self._get_graph()
+
+            # Step 0: Canonicalize tags via the curated semantic synonym map.
+            # Formatting fragmentation is fixed at write time by normalize_tags;
+            # this catches the semantic residue (db→database, auth→identity) on
+            # the active corpus, where the rewrite is visible and auditable.
+            canonicalized = await self._canonicalize_tags(now, dry_run)
+            summary["tags_canonicalized"] = len(canonicalized)
 
             # Step 1: Archive ephemeral discoveries (fastest deprecation)
             ephemeral = await self._archive_ephemeral(now, dry_run)
@@ -205,6 +213,49 @@ class KnowledgeGraphLifecycle:
                 )
         except Exception as e:
             logger.debug(f"PG sync skipped for lifecycle update: {e}")
+
+    async def _canonicalize_tags(self, now: datetime, dry_run: bool) -> List[str]:
+        """Apply the curated semantic synonym map to the active corpus.
+
+        Scans open + resolved discoveries and rewrites tags whose canonical
+        form (``normalize_tags`` then ``apply_semantic_synonyms``) differs from
+        what is stored. This is the lifecycle-only semantic layer — write-path
+        ``normalize_tags`` deliberately does not merge synonyms. Never deletes;
+        only rewrites the ``tags`` list in place.
+
+        Returns the list of discovery IDs whose tags changed.
+        """
+        from src.knowledge_graph import normalize_tags
+        from src.knowledge_ontology import apply_semantic_synonyms
+
+        graph = await self._get_graph()
+        changed: List[str] = []
+
+        # Active corpus only — archived/cold rows are not re-queried.
+        candidates = []
+        for status in ("open", "resolved"):
+            candidates.extend(await graph.query(status=status, limit=1000))
+
+        for discovery in candidates:
+            current = list(discovery.tags or [])
+            if not current:
+                continue
+            canonical = apply_semantic_synonyms(normalize_tags(current))
+            if canonical == current:
+                continue
+            changed.append(discovery.id)
+            if not dry_run:
+                await graph.update_discovery(discovery.id, {
+                    "tags": canonical,
+                    "updated_at": now.isoformat(),
+                })
+
+        logger.info(
+            "%s tags on %d discoveries via semantic synonym map",
+            "[DRY RUN] Would canonicalize" if dry_run else "Canonicalized",
+            len(changed),
+        )
+        return changed
 
     async def _archive_ephemeral(self, now: datetime, dry_run: bool) -> List[str]:
         """Archive ephemeral discoveries older than threshold."""

--- a/src/knowledge_ontology.py
+++ b/src/knowledge_ontology.py
@@ -1,0 +1,67 @@
+"""Curated tag-ontology tables for the knowledge graph.
+
+Two hand-curated, deterministic layers — NOT inference, NOT an ontology
+system. Per the 2026-06-13 ontology-need analysis, shared-graph tag
+fragmentation is *mostly a formatting problem* (``Postgres`` / ``postgres`` /
+``PostgreSQL`` filed three ways, each a future search miss). The formatting
+layer is fixed by :func:`src.knowledge_graph.normalize_tags`; the small
+*semantic* residue that formatting cannot reach (``db`` vs ``database``)
+is fixed here, deliberately and by hand.
+
+Layer separation (kept identical to the governance-plugin client normalizer
+so server-minted and plugin-minted tags converge on the same canonical form):
+
+- ``SPELLING_VARIANTS`` — **formatting layer**, applied on every write via
+  ``normalize_tags``. Spelling/format variants of the *same* token
+  (``postgresql`` → ``postgres``). The plugin's ``tag_normalize.py`` carries
+  the identical map client-side; this server-side copy catches non-plugin
+  clients and the direct REST/API write path.
+
+- ``SEMANTIC_SYNONYMS`` — **semantic layer**, applied only in the KG
+  lifecycle pass (``run_cleanup``), never at write time. Distinct tokens that
+  mean the same thing (``db`` → ``database``, ``auth`` → ``identity``).
+  Merging these at write time would be a silent lossy rewrite of caller
+  intent, so it is deferred to the periodic janitorial sweep where it is
+  visible and auditable.
+
+Both tables are intentionally tiny and hand-curated. Add an entry only when a
+real fragmentation has been observed — never auto-derive. Explicitly out of
+scope: plural stripping (``metrics`` → ``metric`` is lossy), entity
+resolution, richer typed edges, any standing ontology agent.
+"""
+
+from typing import Dict, List
+
+# Formatting layer — spelling/format variants of the SAME token. Keys are
+# post-slug (lowercase, hyphen-folded) forms; values are the canonical form.
+# Applied inside normalize_tags(), so it runs on every write and on every
+# tag-filtered search (keeping stored and queried tags consistent).
+SPELLING_VARIANTS: Dict[str, str] = {
+    "postgresql": "postgres",
+}
+
+# Semantic layer — distinct tokens that denote the same concept. Hand-curated.
+# Applied ONLY by the lifecycle pass, never at write time. Keys and values are
+# already in canonical (post-normalize_tags) form.
+SEMANTIC_SYNONYMS: Dict[str, str] = {
+    "db": "database",
+    "auth": "identity",
+}
+
+
+def apply_semantic_synonyms(tags: List[str]) -> List[str]:
+    """Map curated semantic synonyms to their canonical form, order-preserving.
+
+    Expects ``tags`` already run through ``normalize_tags`` (lowercase,
+    hyphen-folded). Deduplicates after mapping so that, e.g.,
+    ``["db", "database"]`` collapses to ``["database"]``. Unknown tags pass
+    through untouched. Idempotent: canonical forms are never themselves keys.
+    """
+    seen: set[str] = set()
+    result: List[str] = []
+    for tag in tags:
+        canonical = SEMANTIC_SYNONYMS.get(tag, tag)
+        if canonical and canonical not in seen:
+            seen.add(canonical)
+            result.append(canonical)
+    return result

--- a/tests/test_tag_normalization_ontology.py
+++ b/tests/test_tag_normalization_ontology.py
@@ -1,0 +1,108 @@
+"""Tests for the tag-ontology layers: write-path normalize_tags formatting +
+spelling-variant map, and the lifecycle-only curated semantic synonym map.
+
+Mirrors the governance-plugin client normalizer so server-minted and
+plugin-minted tags converge. See src/knowledge_ontology.py.
+"""
+
+from src.knowledge_graph import normalize_tags
+from src.knowledge_ontology import (
+    SEMANTIC_SYNONYMS,
+    SPELLING_VARIANTS,
+    apply_semantic_synonyms,
+)
+
+
+class TestNormalizeTagsFormatting:
+    def test_lowercase_and_separator_folding(self):
+        assert normalize_tags(["EISV", "eisv-dynamics", "eisv_framework"]) == [
+            "eisv",
+            "eisv-dynamics",
+            "eisv-framework",
+        ]
+
+    def test_dedup_across_separator_variants(self):
+        assert normalize_tags(["bug", "Bug Fix", "bug-fix", "bug_fix"]) == [
+            "bug",
+            "bug-fix",
+        ]
+
+    def test_punctuation_folds_to_hyphen(self):
+        # Dots, slashes, plus signs, etc. all fold to a single hyphen — the
+        # behavior that catches "node.js" vs "node-js" fragmentation.
+        assert normalize_tags(["node.js"]) == ["node-js"]
+        assert normalize_tags(["client/server"]) == ["client-server"]
+        assert normalize_tags(["a..b__c  d"]) == ["a-b-c-d"]
+
+    def test_trailing_punctuation_dropped(self):
+        # "C++" -> "c" (trailing punctuation stripped after folding).
+        assert normalize_tags(["C++"]) == ["c"]
+
+    def test_pure_punctuation_tag_dropped(self):
+        assert normalize_tags(["++", "  ", "--"]) == []
+
+    def test_spelling_variant_map_applied(self):
+        assert normalize_tags(["PostgreSQL"]) == ["postgres"]
+
+    def test_spelling_variants_collapse_to_single_canonical(self):
+        assert normalize_tags(["Postgres", "postgres", "PostgreSQL"]) == ["postgres"]
+
+    def test_idempotent(self):
+        once = normalize_tags(["Postgres", "node.js", "Bug Fix"])
+        assert normalize_tags(once) == once
+
+    def test_string_input_json_and_csv(self):
+        assert normalize_tags('["ux", "identity"]') == ["ux", "identity"]
+        assert normalize_tags("ux, identity") == ["ux", "identity"]
+
+    def test_empty_input(self):
+        assert normalize_tags([]) == []
+        assert normalize_tags(None) == []
+
+    def test_no_semantic_merge_at_write_time(self):
+        # The formatting layer must NOT merge semantic synonyms — that is
+        # reserved for the lifecycle pass.
+        assert normalize_tags(["db", "auth"]) == ["db", "auth"]
+
+
+class TestSemanticSynonyms:
+    def test_documented_synonyms_map(self):
+        assert apply_semantic_synonyms(["db"]) == ["database"]
+        assert apply_semantic_synonyms(["auth"]) == ["identity"]
+
+    def test_collapse_synonym_and_canonical(self):
+        assert apply_semantic_synonyms(["db", "database"]) == ["database"]
+
+    def test_unknown_tags_pass_through(self):
+        assert apply_semantic_synonyms(["eisv", "coherence"]) == ["eisv", "coherence"]
+
+    def test_order_preserving(self):
+        assert apply_semantic_synonyms(["coherence", "db", "eisv"]) == [
+            "coherence",
+            "database",
+            "eisv",
+        ]
+
+    def test_idempotent(self):
+        # Canonical forms are never themselves keys, so a second pass is a
+        # no-op.
+        for canonical in SEMANTIC_SYNONYMS.values():
+            assert canonical not in SEMANTIC_SYNONYMS
+
+    def test_empty(self):
+        assert apply_semantic_synonyms([]) == []
+
+
+class TestLayerSeparation:
+    def test_spelling_variants_are_formatting_not_semantic(self):
+        # Spelling variants live in the write-path map; semantic synonyms do
+        # not leak into it.
+        assert "postgresql" in SPELLING_VARIANTS
+        assert "db" not in SPELLING_VARIANTS
+        assert "auth" not in SPELLING_VARIANTS
+
+    def test_combined_pipeline(self):
+        # The lifecycle pass runs normalize_tags THEN apply_semantic_synonyms.
+        raw = ["PostgreSQL", "DB", "Auth_Service"]
+        canonical = apply_semantic_synonyms(normalize_tags(raw))
+        assert canonical == ["postgres", "database", "auth-service"]


### PR DESCRIPTION
## What

The **server-side half** of the ontology-normalization thread (KG discovery `2026-06-13T20:22:48.527805+00:00`). The governance-plugin client normalizer (`tag_normalize.py`, PRs 56/58) already ships, but the client hook only fixes **new** writes from cooperating clients. This brings the same canonicalization server-side so **all** writers — non-plugin clients, the direct REST/API path — get canonical tags, and de-fragments historical rows.

Tag fragmentation is *mostly a formatting problem*: `Postgres` / `postgres` / `PostgreSQL` is one tag filed three ways, each a future search miss.

### 1. Write path — `normalize_tags()` (`src/knowledge_graph.py`)
Extended to mirror the plugin normalizer:
- Fold **any** run of separators/punctuation to a single hyphen (was: only whitespace/underscore) → `node.js` → `node-js`, `C++` → `c`.
- Apply the formatting-layer spelling-variant map (`postgresql` → `postgres`).

`normalize_tags()` is the universal write **and** tag-filtered-search chokepoint (handlers, AGE/Postgres storage, db mixin, synthesis all route through it), so stored and queried tags stay consistent for free. Deliberately conservative — **no** plural stripping (`metrics`→`metric` is lossy), **no** semantic merging at write time.

### 2. Lifecycle pass — semantic synonym map (`src/knowledge_graph_lifecycle.py`)
New Step 0 in `run_cleanup` applies the hand-curated semantic map (`db`→`database`, `auth`→`identity`) to the **active corpus** — the small semantic residue formatting can't reach. Done in the janitorial sweep (visible, auditable, dry-run-able) rather than silently rewriting caller intent at write time.

### 3. Backfill — `scripts/ops/backfill_tag_normalization.py`
Replays the canonical normalizer over existing rows so historical entries stop fragmenting search. **DRY RUN by default**; `--apply` to write, `--include-semantic` to also apply the synonym map. (This ephemeral session has no live DB — the script is delivered for the operator to run at deploy, not executed here.)

### Single-sourcing
Both tables live in the new `src/knowledge_ontology.py`: `SPELLING_VARIANTS` (formatting layer, write path) and `SEMANTIC_SYNONYMS` (semantic layer, lifecycle only). Both hand-curated, **not** inference.

## Explicitly NOT building
Entity resolution, richer typed edges (YAGNI until a query needs them), any ontology system or standing ontology agent — per the analysis.

## Tests
`tests/test_tag_normalization_ontology.py` (19 cases): punctuation folding, spelling-variant collapse, idempotence, no-semantic-merge-at-write-time, the semantic map, layer separation, and the combined lifecycle pipeline. Verified no regression across `test_kg_store`, `test_kg_search`, `test_kg_synthesis`, `test_kg_lifecycle`, `test_knowledge_graph_lifecycle`, `test_knowledge_graph_postgres_unit`, `test_knowledge_graph_age_parsing`, `test_kg_audit` (322 passing locally on py3.12).

## Notes
- The plugin's canonical `tag_normalize.py` wasn't reachable from this session (plugin repo out of scope); behavior was reconstructed from the KG discovery's spec. If the plugin map grows beyond `postgresql`→`postgres`, mirror it into `SPELLING_VARIANTS`.

https://claude.ai/code/session_01FVeW41TQTMLyat8PG49fwo

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVeW41TQTMLyat8PG49fwo)_