### PR TITLE
fix(kg-search): decouple auto-hybrid term cap from OR-recall cap

### DIFF
--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -996,10 +996,23 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
         fts_fallback_skipped_reason = None
         query_terms = str(query_text).split() if query_text else []
         query_term_count = len(query_terms)
-        # Broad agent-generated queries can spend the whole tool budget in
-        # hybrid fan-out or automatic OR recall fallback. Keep explicit caller
-        # intent available, but make auto mode cheap by default.
+        # Two DIFFERENT cost concerns, two limits (dogfood 2026-06-13 P2.8):
+        #
+        # - complex_query_term_limit gates the automatic AND→OR *recall*
+        #   fallback. OR across many terms explodes the FTS candidate set, so a
+        #   tight limit keeps a broad agent query from spending the whole tool
+        #   budget. Genuinely per-term expensive — stays low.
+        #
+        # - complex_hybrid_term_limit gates auto RRF fusion. Hybrid runs
+        #   semantic_search + an AND FTS query in parallel and fuses; the AND
+        #   FTS gets MORE restrictive (cheaper) with more terms and the
+        #   semantic side ignores term count entirely, so hybrid is NOT
+        #   per-term expensive. The old shared cap of 4 skipped fusion exactly
+        #   when normal multi-term conceptual queries (10 terms is normal for
+        #   agents) would benefit most. A generous cap restores fusion while
+        #   still bounding pathological term dumps.
         complex_query_term_limit = 4
+        complex_hybrid_term_limit = 12
 
         # Phase 3: cross-encoder reranker. When enabled, first-stage retrieval
         # fetches a wider pool (up to rerank_pool_size) so the reranker has
@@ -1099,12 +1112,12 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
             if (
                 hybrid_path
                 and search_mode_param == "auto"
-                and query_term_count > complex_query_term_limit
+                and query_term_count > complex_hybrid_term_limit
             ):
                 hybrid_path = False
                 hybrid_skipped_reason = (
                     f"auto hybrid skipped for {query_term_count}-term query "
-                    f"(limit {complex_query_term_limit}); use search_mode='hybrid' "
+                    f"(limit {complex_hybrid_term_limit}); use search_mode='hybrid' "
                     "to force RRF fusion"
                 )
             if hybrid_path:

--- a/tests/test_kg_search.py
+++ b/tests/test_kg_search.py
@@ -1770,16 +1770,46 @@ class TestKgSearchComplexityCeiling:
         mock_graph.semantic_search = AsyncMock(return_value=[(disc, 0.82)])
         mock_graph.full_text_search = AsyncMock(return_value=[disc])
 
+        # 13 terms — above the (decoupled) hybrid cap of 12, so auto still
+        # skips RRF fusion for truly pathological term dumps.
         result = await handle_search_knowledge_graph({
-            "query": "one two three four five six",
+            "query": "a b c d e f g h i j k l m",
         })
         data = parse_result(result)
 
         assert data["success"] is True
         assert data["search_mode_used"] == "semantic"
         assert "hybrid_skipped_reason" in data
+        assert "limit 12" in data["hybrid_skipped_reason"]
         mock_graph.semantic_search.assert_awaited_once()
         mock_graph.full_text_search.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_auto_hybrid_runs_for_normal_multiterm_query(self, patch_common, monkeypatch):
+        """Dogfood 2026-06-13 P2.8: a 10-term conceptual query is normal for
+        agents and must get RRF fusion, not silently degrade to pure-semantic.
+        The hybrid cap is decoupled from the (lower) OR-recall cap."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        monkeypatch.setenv("UNITARES_ENABLE_HYBRID", "1")
+        disc = make_discovery(id="sem-1", summary="Semantic match")
+        mock_graph.semantic_search = AsyncMock(return_value=[(disc, 0.82)])
+        mock_graph.full_text_search = AsyncMock(return_value=[disc])
+
+        # 10 terms — above the old shared cap of 4, below the new hybrid cap.
+        result = await handle_search_knowledge_graph({
+            "query": "alpha beta gamma delta epsilon zeta eta theta iota kappa",
+        })
+        data = parse_result(result)
+
+        assert data["success"] is True
+        assert data["search_mode_used"] == "hybrid_rrf"
+        assert "hybrid_skipped_reason" not in data
+        # Hybrid fuses semantic + an AND FTS query.
+        mock_graph.semantic_search.assert_awaited()
+        mock_graph.full_text_search.assert_awaited()
+        assert mock_graph.full_text_search.await_args.kwargs["operator"] == "AND"
 
     @pytest.mark.asyncio
     async def test_long_fts_query_skips_automatic_or_fallback(self, patch_common):


### PR DESCRIPTION
## What

Dogfood finding **P2.8**: a focused agent query observed `hybrid_skipped_reason: "auto hybrid skipped for 10-term query (limit 4)"` and silently fell back to pure-semantic, losing RRF fusion (and 1-hop graph expansion) exactly where a multi-term conceptual query would benefit most.

Root cause: one constant `complex_query_term_limit = 4` gated **two unrelated cost concerns**:

| Path | Per-term cost? | Decision |
|---|---|---|
| Automatic AND→OR **recall** fallback | **Yes** — OR across many terms explodes the FTS candidate set | keep limit at **4** |
| Auto **RRF fusion** (hybrid) | **No** — runs `semantic_search` + an **AND** FTS query in parallel; AND FTS gets *more* restrictive (cheaper) with more terms, semantic ignores term count (handlers.py:1117-1120 explicitly does no AND→OR fallback inside hybrid) | new `complex_hybrid_term_limit = **12**` |

So the old shared cap skipped fusion with no real cost saving. This splits the two limits: normal multi-term conceptual queries (10 terms is normal for agents) now fuse via `hybrid_rrf`, while the genuinely-expensive OR-recall fallback stays conservative and pathological term-dumps (>12) still skip hybrid.

## Second half of the finding — already handled
The brief also flagged the mirror auto-tag path feeding `_mirror_kg_results`. Verified it already searches on the check-in `response_text` (not derived tags) via `_search_kg_by_checkin_text`, and #665 added a noise-floor drop. No change needed there.

## Tests
- `test_auto_hybrid_skips_long_query_unless_forced` — now exercises the skip with a 13-term query (above the new cap), asserts `limit 12` in the reason.
- `test_auto_hybrid_runs_for_normal_multiterm_query` (new) — pins that a 10-term query runs `hybrid_rrf` with an AND FTS query, no skip reason.
- The OR-recall fallback test (6 terms, limit 4) is unchanged and still passes.

All 98 tests in `tests/test_kg_search.py` pass locally.

https://claude.ai/code/session_01HonFoNGJXDJAgN4f46TYhP

---
_Generated by [Claude Code](https://claude.ai/code/session_01HonFoNGJXDJAgN4f46TYhP)_