### PR TITLE
fix(kg): close write-path bugs — id collisions, naive ts, batch parity

### DIFF
--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -14,7 +14,8 @@ Claude Desktop compatible: All operations are async and non-blocking.
 
 from typing import Dict, Any, Sequence, Optional
 from mcp.types import TextContent
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
+import threading
 
 
 def _utc_now_iso() -> str:
@@ -27,6 +28,37 @@ def _utc_now_iso() -> str:
     timestamps must be UTC-aware.
     """
     return datetime.now(timezone.utc).isoformat()
+
+
+_discovery_id_lock = threading.Lock()
+_last_discovery_id_dt: Optional[datetime] = None
+
+
+def _new_discovery_id() -> str:
+    """Generate a strictly-monotonic UTC ISO timestamp for use as a discovery id.
+
+    Discovery ids double as the primary key *and* as a lex-sortable creation
+    timestamp (consumers parse them with ``datetime.fromisoformat`` and the
+    not-found helper prefix-matches them). A bare ``datetime.now()`` collides
+    when two writes land in the same microsecond — a batch loop or rapid
+    successive single stores — and the storage layer's
+    ``INSERT ... ON CONFLICT (id) DO UPDATE`` then *silently overwrites* the
+    first write (data loss, no error returned). Bumping by 1µs on collision
+    guarantees uniqueness within this process while preserving the
+    ISO-timestamp contract and chronological ordering.
+
+    Residual: two *separate* processes can still mint the same microsecond
+    id; closing that requires moving the primary key off a bare timestamp,
+    which is a contract change (docs + tests treat ids as parseable ISO
+    timestamps) and is out of scope here.
+    """
+    global _last_discovery_id_dt
+    with _discovery_id_lock:
+        now = datetime.now(timezone.utc)
+        if _last_discovery_id_dt is not None and now <= _last_discovery_id_dt:
+            now = _last_discovery_id_dt + timedelta(microseconds=1)
+        _last_discovery_id_dt = now
+        return now.isoformat()
 import time
 from ..utils import success_response, error_response, require_argument, require_agent_id, require_registered_agent
 from ..decorators import mcp_tool
@@ -625,8 +657,8 @@ async def handle_store_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[Te
             raw_details = raw_details[:MAX_DETAILS_LEN] + "... [truncated]"
         
         # Create discovery node
-        discovery_id = _utc_now_iso()
-        
+        discovery_id = _new_discovery_id()
+
         # Parse response_to if provided (typed response to parent discovery)
         response_to = None
         if "response_to" in arguments and arguments["response_to"]:
@@ -848,7 +880,7 @@ async def handle_store_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[Te
             await graph.update_discovery(supersedes_id, {
                 "status": "superseded",
                 "superseded_by": discovery_id,
-                "updated_at": datetime.now().isoformat(),
+                "updated_at": _utc_now_iso(),
             })
 
         # v2.5.3: Resolve UUID to display name for human-readable output
@@ -2120,7 +2152,8 @@ async def _handle_store_knowledge_graph_batch(arguments: Dict[str, Any], agent_i
         # Process each discovery with graceful error handling
         stored = []
         errors = []
-        
+        warnings: list[str] = []
+
         for idx, disc_data in enumerate(discoveries):
             try:
                 # Validate required fields
@@ -2166,8 +2199,8 @@ async def _handle_store_knowledge_graph_batch(arguments: Dict[str, Any], agent_i
                     details = details[:MAX_DETAILS_LEN] + "... [truncated]"
                 
                 # Create discovery node
-                discovery_id = _utc_now_iso()
-                
+                discovery_id = _new_discovery_id()
+
                 # Parse response_to if provided
                 response_to = None
                 if "response_to" in disc_data and disc_data["response_to"]:
@@ -2185,11 +2218,21 @@ async def _handle_store_knowledge_graph_batch(arguments: Dict[str, Any], agent_i
                                 response_type=response_type
                             )
                 
-                # Validate severity
+                # Validate severity. On an invalid value, store the entry with
+                # severity unset and warn — never fabricate a specific severity.
+                # (Previously this silently coerced to "medium", which both
+                # contradicts the documented "falls back to None" intent and
+                # invents a severity claim the writer never made.)
                 severity = disc_data.get("severity")
                 if severity is not None:
+                    severity = str(severity).lower()
                     if severity not in VALID_SEVERITIES:
-                        severity = "medium"  # Use default if invalid
+                        warnings.append(
+                            f"Discovery {idx}: invalid severity "
+                            f"'{disc_data.get('severity')}' ignored (stored unset). "
+                            f"Valid: {sorted(VALID_SEVERITIES)}"
+                        )
+                        severity = None
                 
                 # Parse confidence if provided
                 batch_confidence = None
@@ -2232,6 +2275,11 @@ async def _handle_store_knowledge_graph_batch(arguments: Dict[str, Any], agent_i
                 
                 # Add to graph (rate limiting handled internally)
                 await graph.add_discovery(discovery)
+                # Mirror the single-write path: batch writes were landing in
+                # the KG but never reaching the dashboard/bridge live timeline
+                # because they skipped this broadcast (the exact gap
+                # _broadcast_knowledge_write was created to close).
+                await _broadcast_knowledge_write(discovery, agent_id)
                 stored_item = {
                     "discovery_id": discovery_id,
                     "summary": summary,
@@ -2262,6 +2310,11 @@ async def _handle_store_knowledge_graph_batch(arguments: Dict[str, Any], agent_i
 
         if errors:
             response["errors"] = errors
+
+        # Non-fatal per-item notes (e.g. invalid severity ignored). The entry
+        # is still stored; the warning explains why it differs from the input.
+        if warnings:
+            response["warnings"] = warnings
 
         # Check if any items were truncated (v2.5.0+)
         truncated_count = sum(1 for s in stored if "_truncated" in s)
@@ -2804,7 +2857,7 @@ async def store_discovery_internal(
     from src.knowledge_graph import tag_provenance_source
 
     graph = await get_knowledge_graph()
-    discovery_id = _utc_now_iso()
+    discovery_id = _new_discovery_id()
     provenance = tag_provenance_source(extra_provenance, source)
     node = DiscoveryNode(
         id=discovery_id,

--- a/tests/test_kg_store.py
+++ b/tests/test_kg_store.py
@@ -1484,6 +1484,108 @@ class TestUtcTimestamps:
         assert abs((id_dt - captured_dt).total_seconds()) < 1.0
 
 
+class TestMonotonicDiscoveryId:
+    """Discovery ids must be collision-free: a bare timestamp PK + the
+    storage layer's ON CONFLICT (id) DO UPDATE silently overwrote any two
+    writes that landed in the same microsecond (batch loops, rapid stores)."""
+
+    def test_new_discovery_id_strictly_monotonic_under_same_microsecond(self):
+        """Even when wall-clock now() repeats, ids are unique, increasing, ISO/UTC."""
+        from datetime import datetime, timezone
+        from unittest.mock import patch as _patch
+        import src.mcp_handlers.knowledge.handlers as h
+
+        frozen = datetime(2026, 6, 13, 20, 36, 40, 123456, tzinfo=timezone.utc)
+        with _patch.object(h, "_last_discovery_id_dt", None):
+            with _patch("src.mcp_handlers.knowledge.handlers.datetime") as mock_dt:
+                # now() always returns the same instant; fromisoformat/etc. pass through
+                mock_dt.now.return_value = frozen
+                ids = [h._new_discovery_id() for _ in range(5)]
+
+        assert len(set(ids)) == 5, f"ids collided: {ids}"
+        assert ids == sorted(ids), "ids must be strictly increasing"
+        for value in ids:
+            parsed = datetime.fromisoformat(value)
+            assert parsed.tzinfo is not None and parsed.utcoffset().total_seconds() == 0
+
+    @pytest.mark.asyncio
+    async def test_batch_store_produces_unique_ids(self, patch_common, registered_agent):
+        """A batch of discoveries never reuses a discovery_id."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_store_knowledge_graph
+
+        result = await handle_store_knowledge_graph({
+            "agent_id": registered_agent,
+            "discoveries": [
+                {"discovery_type": "note", "summary": f"Note {i}"}
+                for i in range(5)
+            ],
+        })
+
+        data = parse_result(result)
+        assert data["success"] is True
+        assert data["success_count"] == 5
+        stored_ids = [d.id for (d,), _ in
+                      (c for c in mock_graph.add_discovery.call_args_list)]
+        assert len(set(stored_ids)) == 5, f"batch ids collided: {stored_ids}"
+
+
+class TestBatchStoreBroadcastAndSeverity:
+    @pytest.mark.asyncio
+    async def test_batch_store_emits_knowledge_write_per_item(
+        self, patch_common, registered_agent
+    ):
+        """Batch writes reach the live timeline (parity with single-write path)."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_store_knowledge_graph
+
+        with patch(
+            "src.mcp_handlers.knowledge.handlers.broadcaster_instance.broadcast_event",
+            new_callable=AsyncMock,
+        ) as bc:
+            result = await handle_store_knowledge_graph({
+                "agent_id": registered_agent,
+                "discoveries": [
+                    {"discovery_type": "note", "summary": "First"},
+                    {"discovery_type": "note", "summary": "Second"},
+                ],
+            })
+
+        data = parse_result(result)
+        assert data["success"] is True
+        write_calls = [
+            c for c in bc.await_args_list
+            if c.args and c.args[0] == "knowledge_write"
+        ]
+        assert len(write_calls) == 2, "expected one knowledge_write per stored item"
+
+    @pytest.mark.asyncio
+    async def test_batch_store_invalid_severity_stored_unset_with_warning(
+        self, patch_common, registered_agent
+    ):
+        """Invalid severity is dropped (not fabricated as 'medium') and warned."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_store_knowledge_graph
+
+        result = await handle_store_knowledge_graph({
+            "agent_id": registered_agent,
+            "discoveries": [
+                {
+                    "discovery_type": "note",
+                    "summary": "Bad severity",
+                    "severity": "ultra_critical",
+                },
+            ],
+        })
+
+        data = parse_result(result)
+        assert data["success"] is True
+        assert data["success_count"] == 1
+        stored_discovery = mock_graph.add_discovery.call_args[0][0]
+        assert stored_discovery.severity is None, "invalid severity must not become 'medium'"
+        assert any("ultra_critical" in w for w in data.get("warnings", []))
+
+
 # ============================================================================
 # superseded_by field round-trip (KG hygiene v1)
 # ============================================================================


### PR DESCRIPTION
## Summary

Audited the KG write path (`src/mcp_handlers/knowledge/handlers.py`, the postgres backend, `kg_add_discovery`) for bugs and friction. Found one data-loss bug and a cluster of batch-vs-single divergences. This PR fixes them.

## Fixes

**1. Discovery-id collisions → silent overwrite (data loss).** Discovery ids were a bare `_utc_now_iso()` timestamp used as the primary key. The storage layer does `INSERT ... ON CONFLICT (id) DO UPDATE` (`src/db/mixins/knowledge_graph.py:82`), so two writes landing in the same microsecond — a batch loop or rapid successive stores — silently overwrote each other with **no error returned**. Added `_new_discovery_id()`: a strictly-monotonic per-process UTC ISO generator that bumps by 1µs on collision, preserving the ISO-timestamp / lex-sort contract that consumers (`fromisoformat`, the not-found prefix helper) and tests depend on. Applied to the single, batch, and `store_discovery_internal` write sites.

> Residual: two *separate* processes can still mint the same microsecond id. Closing that fully means moving the PK off a bare timestamp — a documented-contract change (docs + tests treat ids as parseable ISO timestamps) — so it's deliberately out of scope here and noted in the helper docstring.

**2. Naive timestamp in the supersedes flip.** The supersession path wrote `updated_at` with naive `datetime.now()` (server-local TZ) — the lone straggler from the 2026-04-25 UTC-timestamp fix documented at the top of the file. Now uses `_utc_now_iso()`.

**3. Batch writes skipped the live-timeline broadcast.** `_handle_store_knowledge_graph_batch` never called `_broadcast_knowledge_write`, so batch-stored discoveries landed in the DB but never reached the dashboard/bridge live timeline — the exact gap that helper was created to close. Batch now broadcasts per stored item.

**4. Batch silently fabricated severities.** Invalid severity in a batch item was coerced to `"medium"` — inventing a severity claim the writer never made, and contradicting the code's own "falls back to None" docstring. Now stored unset with a per-item warning surfaced in the response under `warnings`.

## Not changed (investigated, not a clear bug)
Batch high-severity ownership: passing `agent_id` works correctly; only fully-anonymous high-severity writes are refused, which is the intended behavior. Left as-is.

## Tests
Added cases for monotonic/collision-free ids (incl. forced same-microsecond), batch broadcast parity, and the severity-warning behavior. Green locally:
- `tests/test_kg_store.py` — 66 passed
- `test_kg_search`, `test_kg_lifecycle`, `test_kg_synthesis`, `test_knowledge_enum_sync`, `test_param_aliases` — 183 passed
- `test_self_recovery*`, `test_dialectic_handlers` — dependent suites green

https://claude.ai/code/session_01YFZE69oZjWNMexwv7X2qQr

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFZE69oZjWNMexwv7X2qQr)_