### PR TITLE
fix(identity): complete #674 — sticky/operator proof_origin + self-heal + Lumen exemption

### DIFF
--- a/src/http_api.py
+++ b/src/http_api.py
@@ -260,6 +260,7 @@ async def _resolve_http_bound_agent(tool_name: str, arguments: dict, signals) ->
 
     from src.mcp_handlers.context import (
         set_session_resolution_source,
+        set_session_proof_origin,
         update_context_agent_id,
     )
     from src.mcp_handlers.identity.handlers import derive_session_key, resolve_session_identity
@@ -291,6 +292,10 @@ async def _resolve_http_bound_agent(tool_name: str, arguments: dict, signals) ->
         update_context_agent_id(agent_uuid)
         arguments["agent_id"] = agent_uuid
         set_session_resolution_source("operator_token")
+        # Operator token is a per-call credential the caller transmitted —
+        # caller-proven. Stamp explicitly so this early-return (which never
+        # reaches derive_session_key/_mark) isn't left at a stale proof_origin.
+        set_session_proof_origin("caller_asserted")
         return agent_uuid
 
     # Sticky transport cache: single-sourced consult shared with the MCP
@@ -322,6 +327,15 @@ async def _resolve_http_bound_agent(tool_name: str, arguments: dict, signals) ->
             # (and bindings created before this field was threaded)
             # carry original="unknown" and continue to map to weak.
             set_session_resolution_source(sticky_resolution_source(cached))
+            # A sticky-cache hit resolves a binding by IP:UA fingerprint with NO
+            # per-call proof from the caller — it is the steady-state repeat of
+            # the same mis-attribution the gate exists to refuse (a concurrent
+            # same-host sibling can land on a cached binding). Stamp
+            # server_inferred so the strict gate refuses it unless the resolved
+            # agent is substrate-earned. Residents echo their CSID (→ explicit,
+            # caller_asserted) and never reach this path. This early-return runs
+            # before derive_session_key, so proof_origin must be set here.
+            set_session_proof_origin("server_inferred")
             return cached.agent_uuid
     except Exception as e:
         logger.debug("[STICKY-REST] cache check failed: %s", e)
@@ -508,6 +522,12 @@ async def http_call_tool(request):
         # For auth signals, read SessionSignals (headers) or continuity_token (HMAC-signed).
         # See PR #35 revert (gap #1) and PR #42 Part C rationale.
         client_session_id = None
+        # Reset the injection flag per-request so it can never leak True from a
+        # prior request on a reused context and mislabel this caller's genuine
+        # CSID as server-inferred (false refusal). Self-healing: set on every
+        # path, like session_resolution_source.
+        from src.mcp_handlers.context import set_csid_transport_injected
+        set_csid_transport_injected(False)
         if isinstance(arguments, dict) and "client_session_id" not in arguments:
             client_session_id = await _extract_client_session_id(request)
             arguments["client_session_id"] = client_session_id
@@ -515,7 +535,6 @@ async def http_call_tool(request):
             # mark it so identity resolution does not treat it as caller-proven
             # (otherwise a pin/fingerprint-derived injected CSID would satisfy
             # strict for a write under a sibling's identity).
-            from src.mcp_handlers.context import set_csid_transport_injected
             set_csid_transport_injected(True)
         elif isinstance(arguments, dict):
             client_session_id = arguments.get("client_session_id")

--- a/src/mcp_handlers/middleware/identity_step.py
+++ b/src/mcp_handlers/middleware/identity_step.py
@@ -424,8 +424,17 @@ async def resolve_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
         # decay-by-one (strong→medium, medium→weak, weak→weak) against
         # the original proof, instead of treating every cache hit as
         # uniformly weak. See `_compute_identity_assurance`.
-        from ..context import set_session_context, set_session_resolution_source
+        from ..context import (
+            set_session_context,
+            set_session_resolution_source,
+            set_session_proof_origin,
+        )
         set_session_resolution_source(sticky_resolution_source(cached))
+        # Sticky-cache hit = fingerprint resolution with no per-call proof. Stamp
+        # server_inferred so the strict write gate refuses it unless the resolved
+        # agent is substrate-earned (this early-return runs before _mark). Mirror
+        # of the REST sticky path in http_api._resolve_http_bound_agent.
+        set_session_proof_origin("server_inferred")
         client_hint = arguments.get("client_hint") if arguments else None
         identity_result = {
             "agent_uuid": cached.agent_uuid,

--- a/src/mcp_handlers/support/wrapper_generator.py
+++ b/src/mcp_handlers/support/wrapper_generator.py
@@ -353,6 +353,13 @@ def _create_session_wrapper(
             if isinstance(wrapped, dict):
                 kwargs.update(wrapped)
 
+        # Reset the injection flag per-call (self-healing; cannot leak True from
+        # a prior call on a reused context and falsely refuse a real caller).
+        try:
+            from src.mcp_handlers.context import set_csid_transport_injected
+            set_csid_transport_injected(False)
+        except Exception:
+            pass
         # Inject session if available and not already provided
         if session_extractor and ctx:
             session_id = session_extractor(ctx)
@@ -362,7 +369,6 @@ def _create_session_wrapper(
                 # Transport-injected, not caller-sent — mark so resolution does
                 # not treat it as caller-proven (parity with the REST inject site).
                 try:
-                    from src.mcp_handlers.context import set_csid_transport_injected
                     set_csid_transport_injected(True)
                 except Exception:
                     pass

--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -271,6 +271,21 @@ async def resolve_identity_and_guards(ctx: UpdateContext) -> Optional[Sequence[T
             try:
                 from src.db import get_db
                 exempt = await get_db().is_substrate_earned(ctx.agent_uuid)
+                if not exempt:
+                    # is_substrate_earned only checks core.substrate_claims +
+                    # the (currently sentinel-only) Pi allowlist. Also honor the
+                    # canonical substrate-earned pattern so embodied/anchored
+                    # residents that resolve by fingerprint are not refused —
+                    # notably Lumen (embodied tag, NOT in substrate_claims).
+                    # Key on `dedicated_substrate` (embodied, or persistent+
+                    # anchor) — the "real substrate-anchored resident" signal —
+                    # not full R4 `earned`, so a freshly-restarted resident that
+                    # hasn't yet met the tenure bar is still exempt. Fail-closed.
+                    from src.identity.substrate import verify_substrate_earned
+                    result = await verify_substrate_earned(ctx.agent_uuid)
+                    exempt = bool(
+                        (result.get("conditions") or {}).get("dedicated_substrate")
+                    )
             except Exception:
                 exempt = False
             if not exempt:

--- a/tests/test_strict_proof_origin.py
+++ b/tests/test_strict_proof_origin.py
@@ -60,11 +60,16 @@ def _patch_ctx(monkeypatch, *, agent_uuid, source, proof_origin):
     monkeypatch.setattr(ctxmod, "get_trajectory_confidence", lambda: None)
 
 
-def _patch_db(monkeypatch, *, earned):
+def _patch_db(monkeypatch, *, earned, dedicated=False):
     class _DB:
         async def is_substrate_earned(self, agent_id):
             return earned
     monkeypatch.setattr(dbmod, "get_db", lambda: _DB())
+    import src.identity.substrate as submod
+
+    async def _verify(agent_uuid, **kw):
+        return {"conditions": {"dedicated_substrate": dedicated}}
+    monkeypatch.setattr(submod, "verify_substrate_earned", _verify)
 
 
 def _is_refusal(result):
@@ -119,13 +124,27 @@ async def test_strict_allows_caller_asserted_write(monkeypatch):
 @pytest.mark.asyncio
 async def test_strict_exempts_substrate_earned_resident(monkeypatch):
     """A resident resolving by fingerprint (server_inferred) still writes —
-    the exemption is keyed on the resolved agent being substrate-earned."""
+    the exemption is keyed on the resolved agent being substrate-earned
+    (substrate_claims path)."""
     monkeypatch.setattr(ib, "is_strict_identity_required", lambda: True)
-    _patch_ctx(monkeypatch, agent_uuid="lumen-uuid",
+    _patch_ctx(monkeypatch, agent_uuid="sentinel-uuid",
                source="ip_ua_fingerprint", proof_origin="server_inferred")
     _patch_db(monkeypatch, earned=True)
     result = await resolve_identity_and_guards(_new_ctx())
     assert not _is_refusal(result), "substrate-earned resident must be exempt"
+
+
+@pytest.mark.asyncio
+async def test_strict_exempts_embodied_resident_not_in_substrate_claims(monkeypatch):
+    """Lumen case: embodied tag (dedicated_substrate) but NOT in substrate_claims.
+    is_substrate_earned returns False; verify_substrate_earned's dedicated_substrate
+    must still exempt it so an embodied resident isn't refused on deploy."""
+    monkeypatch.setattr(ib, "is_strict_identity_required", lambda: True)
+    _patch_ctx(monkeypatch, agent_uuid="lumen-uuid",
+               source="ip_ua_fingerprint", proof_origin="server_inferred")
+    _patch_db(monkeypatch, earned=False, dedicated=True)
+    result = await resolve_identity_and_guards(_new_ctx())
+    assert not _is_refusal(result), "embodied resident must be exempt via dedicated_substrate"
 
 
 @pytest.mark.asyncio

--- a/tests/test_strict_proof_origin.py
+++ b/tests/test_strict_proof_origin.py
@@ -178,3 +178,19 @@ async def test_injected_csid_classified_server_inferred():
     set_csid_transport_injected(True)  # transport synthesized it
     await derive_session_key(arguments={"client_session_id": "agent-abc123"})
     assert get_session_proof_origin() == "server_inferred"
+
+
+@pytest.mark.asyncio
+async def test_per_request_reset_prevents_injection_flag_leak():
+    """Self-heal contract: a prior request that injected (flag True) must not
+    bleed into a later caller-sent CSID. The transport resets the flag per
+    request (http_call_tool / wrapper_generator); with that reset a genuine
+    caller CSID is correctly caller_asserted, not falsely server_inferred."""
+    from src.mcp_handlers.identity.session import derive_session_key
+    from src.mcp_handlers.context import (
+        get_session_proof_origin, set_csid_transport_injected,
+    )
+    set_csid_transport_injected(True)   # prior request injected (would leak)
+    set_csid_transport_injected(False)  # transport's per-request reset
+    await derive_session_key(arguments={"client_session_id": "agent-real-caller"})
+    assert get_session_proof_origin() == "caller_asserted"


### PR DESCRIPTION
## Why this exists
**#674 merged an incomplete state.** It landed the proof_origin carrier + gate, but the **diff-review council fixes** (commits 77bc19bc) and the **Lumen exemption** (91cb0a4f) were pushed *after* the squash-merge captured the branch, so master is missing them. Master currently has the version the council flagged **BLOCK**. This PR cherry-picks the two missing commits onto current master.

## What was missing from master (now restored)
1. **Sticky-cache early-returns fail OPEN** (the dominant mis-attribution path). REST (`http_api.py`) + MCP (`identity_step.py`) sticky hits resolve a sibling by fingerprint and return *before* derive_session_key, leaving proof_origin None → gate passes. Now stamp `server_inferred`.
2. **Operator-token early-return** now stamps `caller_asserted`.
3. **csid_transport_injected self-heal** — reset False per-request (was set-True-never-reset → cross-request leak / false-refusal risk).
4. **Lumen exemption** — gate exemption now honors the canonical `verify_substrate_earned` → `dedicated_substrate` (embodied tag), not just `substrate_claims`. Lumen (`69a1a4f7`, embodied, verified live, NOT in substrate_claims) would otherwise be refused if it resolved server_inferred.

## Tests
13 proof-origin + 397 strict/sticky/identity/dispatch/substrate tests green on current master.

## ⚠️ Still live-affecting (strict flag is on). Merge promptly to replace the council-blocked version now in master; deploy is the operator call.