### PR TITLE
fix(stuck): lineage successor suppresses parent stuck-flag, archive as succession

### DIFF
--- a/src/mcp_handlers/lifecycle/stuck.py
+++ b/src/mcp_handlers/lifecycle/stuck.py
@@ -144,6 +144,73 @@ MARGIN_STUCK_STALE_CAP_MINUTES = 1440.0      # 24h, matches the cadence cap
 # it errs toward flagging, and the signal is soft. Also note the MULTIPLIER is
 # floor-dominated for fast agents (avg_gap < 5min => 6*gap < 30 => floor wins).
 
+# Lineage succession: a parent process is "succeeded" — not stuck — when a child
+# that declared it via parent_agent_id at onboard (the predecessor's UUID; see
+# the Minimal Agent Workflow in CLAUDE.md) is still active and has checked in
+# within this window. The process rotated, lineage continuous (KG 2026-05-06,
+# empirically the Discord-Dispatch turn chains). Matches CADENCE_ACTIVE_MAX_GAP:
+# the child counts as live only while it still has an active cadence.
+LINEAGE_SUCCESSION_FRESH_WINDOW_MINUTES = 30.0
+
+
+def _agent_age_minutes(meta, current_time) -> float | None:
+    """Minutes since meta.last_update (falling back to created_at). None if unparseable."""
+    try:
+        last_update_str = meta.last_update or meta.created_at
+        if isinstance(last_update_str, str):
+            dt = datetime.fromisoformat(
+                last_update_str.replace('Z', '+00:00') if 'Z' in last_update_str else last_update_str
+            )
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+        else:
+            dt = last_update_str
+        return (current_time - dt).total_seconds() / 60
+    except (ValueError, TypeError, AttributeError):
+        return None
+
+
+def _live_lineage_parent_ids(
+    current_time, window_minutes: float = LINEAGE_SUCCESSION_FRESH_WINDOW_MINUTES
+) -> set:
+    """Identities that have an active lineage child checking in recently.
+
+    One O(n) pass over the agent pool. A child declares its predecessor at
+    onboard via parent_agent_id; when that child is still active and has updated
+    within window_minutes, the predecessor's silence is explained by succession,
+    not a hang. Returns the set of parent_agent_id values that are currently
+    succeeded so callers can both (a) suppress stuck flags on the parent and
+    (b) archive it as lineage_succession.
+
+    Trusting parent_agent_id here is consistent with the current security
+    posture: the ghost-proliferation hijack surface was closed by PRs #78/#81/#83
+    (plugin #14); this is the leftover ergonomic surface that fix left open.
+    """
+    live: set = set()
+    for meta in mcp_server.agent_metadata.values():
+        parent = getattr(meta, "parent_agent_id", None)
+        if not parent:
+            continue
+        if getattr(meta, "status", None) != "active":
+            continue
+        # A child pointing at its own id is not a successor — guard self-loops.
+        if parent in (getattr(meta, "agent_uuid", None), getattr(meta, "agent_id", None)):
+            continue
+        age = _agent_age_minutes(meta, current_time)
+        if age is not None and age <= window_minutes:
+            live.add(parent)
+    return live
+
+
+def _is_superseded_by_lineage(agent_id, meta, live_parent_ids: set) -> bool:
+    """True if a live lineage child has taken over from this agent."""
+    if not live_parent_ids:
+        return False
+    return (
+        agent_id in live_parent_ids
+        or getattr(meta, "agent_uuid", None) in live_parent_ids
+    )
+
 
 def stuck_change_token(stuck_agents: list) -> str:
     """Emit-on-change dedup token for the stuck_detected audit write.
@@ -207,6 +274,9 @@ def _detect_stuck_agents(
     """
     stuck_agents = []
     current_time = datetime.now(timezone.utc)
+    # Parents whose declared-lineage child is actively checking in. Computed once
+    # per sweep so the per-agent supersession test below is O(1).
+    live_parent_ids = _live_lineage_parent_ids(current_time)
 
     for agent_id, meta in mcp_server.agent_metadata.items():
         # Skip if already archived/deleted
@@ -226,6 +296,14 @@ def _detect_stuck_agents(
         # Skip agents with too few updates (likely orphan/test agents)
         total_updates = getattr(meta, "total_updates", 0) or 0
         if total_updates < min_updates:
+            continue
+
+        # Lineage succession: a parent whose declared-lineage child is actively
+        # checking in is not stuck — the process rotated, lineage continuous
+        # (KG 2026-05-06). Suppress EVERY stuck reason for it (cadence-silence,
+        # margin, pattern); the auto_recover sweep archives it as
+        # lineage_succession via _archive_superseded_parents.
+        if _is_superseded_by_lineage(agent_id, meta, live_parent_ids):
             continue
 
         # Calculate age since last update
@@ -487,6 +565,44 @@ async def _handle_safe_active_agent(agent_id, meta, stuck, risk_score, coherence
     return results
 
 
+async def _archive_superseded_parents(current_time) -> list:
+    """Archive active parents whose declared-lineage child has taken over.
+
+    Mirrors the suppression in _detect_stuck_agents: a parent with a live
+    lineage successor is retired with a lineage_succession lifecycle event
+    rather than left to re-trip detection until the stale cap. Mutation path —
+    only called from the auto_recover sweep, never the read-only dashboard
+    refresh. Best-effort: _archive_one_agent persists-first and returns False
+    on DB failure, so a failed write simply leaves the parent for next sweep.
+    """
+    from .helpers import _archive_one_agent
+
+    results = []
+    live_parent_ids = _live_lineage_parent_ids(current_time)
+    if not live_parent_ids:
+        return results
+
+    for agent_id, meta in list(mcp_server.agent_metadata.items()):
+        if meta.status != "active":
+            continue
+        if not _is_superseded_by_lineage(agent_id, meta, live_parent_ids):
+            continue
+        # Self-managed agents own their lifecycle — same exclusion as detection.
+        agent_tags = getattr(meta, "tags", []) or []
+        if {"autonomous", "embodied", "anima"} & set(t.lower() for t in agent_tags):
+            continue
+        ok = await _archive_one_agent(
+            agent_id, meta, "lineage_succession", monitors=mcp_server.monitors
+        )
+        if ok:
+            results.append({
+                "agent_id": agent_id,
+                "action": "archived_lineage_succession",
+                "reason": "lineage_succession",
+            })
+    return results
+
+
 async def _try_recover_agent(stuck: dict, note_cooldown_minutes: float) -> list:
     """Attempt recovery for a single stuck agent. Returns list of recovery results."""
     agent_id = stuck["agent_id"]
@@ -613,7 +729,13 @@ async def handle_detect_stuck_agents(arguments: Dict[str, Any]) -> Sequence:
 
         # Auto-recover if requested
         recovered = []
-        if auto_recover and stuck_agents:
+        if auto_recover:
+            # Retire superseded parents first (lineage_succession). These were
+            # already suppressed from stuck_agents by detection; archiving them
+            # stops the next sweep from re-evaluating a process that rotated.
+            superseded = await _archive_superseded_parents(datetime.now(timezone.utc))
+            if superseded:
+                recovered.extend(superseded)
             for stuck in stuck_agents:
                 # Soft signals (e.g. cadence_silence) are surfaced via the audit
                 # trail only — never auto-recovered. The agent is silent/gone, not
@@ -641,7 +763,6 @@ async def handle_detect_stuck_agents(arguments: Dict[str, Any]) -> Sequence:
             if token != _last_stuck_audit_token:
                 _last_stuck_audit_token = token
                 from src.audit_log import audit_logger, AuditEntry
-                from datetime import datetime
                 audit_logger._write_entry(AuditEntry(
                     timestamp=datetime.now().isoformat(),
                     agent_id="system",

--- a/tests/test_lifecycle_detect_stuck.py
+++ b/tests/test_lifecycle_detect_stuck.py
@@ -21,6 +21,8 @@ def _make_agent_meta(
     created_at=None,
     total_updates=5,
     tags=None,
+    parent_agent_id=None,
+    agent_uuid=None,
 ):
     """Create mock agent metadata."""
     now = datetime.now(timezone.utc)
@@ -30,6 +32,8 @@ def _make_agent_meta(
         created_at=(created_at or now).isoformat(),
         total_updates=total_updates,
         tags=tags or [],
+        parent_agent_id=parent_agent_id,
+        agent_uuid=agent_uuid,
     )
     return meta
 
@@ -827,3 +831,143 @@ def _async_none():
     async def _coro():
         return None
     return _coro()
+
+
+class TestLineageSuccession:
+    """A parent whose declared-lineage child is actively checking in is not
+    stuck — the process rotated, lineage continuous (KG 2026-05-06)."""
+
+    @patch(_PATCHES["gov_config"])
+    @patch(_PATCHES["mcp_server"])
+    def test_parent_with_live_child_suppressed(self, mock_server, mock_config):
+        """Parent would fire critical_margin_timeout, but a live lineage child
+        checking in suppresses it entirely."""
+        old_time = datetime.now(timezone.utc) - timedelta(minutes=10)
+        recent = datetime.now(timezone.utc) - timedelta(minutes=2)
+        mock_server.agent_metadata = {
+            "p1": _make_agent_meta(last_update=old_time),
+            "c1": _make_agent_meta(last_update=recent, parent_agent_id="p1"),
+        }
+        monitor = _make_monitor(risk=0.8, coherence=0.42)
+        mock_server.monitors = {"p1": monitor, "c1": _make_monitor()}
+        mock_config.compute_proprioceptive_margin.return_value = _margin_info(
+            "critical", nearest_edge="risk", distance=0.02
+        )
+
+        from src.mcp_handlers.lifecycle.stuck import _detect_stuck_agents
+        result = _detect_stuck_agents(
+            critical_margin_timeout_minutes=5, include_pattern_detection=False
+        )
+        # p1 suppressed by lineage; c1 is recent + healthy → neither stuck.
+        assert result == []
+
+    @patch(_PATCHES["gov_config"])
+    @patch(_PATCHES["mcp_server"])
+    def test_parent_matched_by_agent_uuid(self, mock_server, mock_config):
+        """Child declares the parent's agent_uuid (not the dict key) → suppressed."""
+        old_time = datetime.now(timezone.utc) - timedelta(minutes=10)
+        recent = datetime.now(timezone.utc) - timedelta(minutes=2)
+        mock_server.agent_metadata = {
+            "p1": _make_agent_meta(last_update=old_time, agent_uuid="uuid-parent"),
+            "c1": _make_agent_meta(last_update=recent, parent_agent_id="uuid-parent"),
+        }
+        mock_server.monitors = {"p1": _make_monitor(risk=0.8), "c1": _make_monitor()}
+        mock_config.compute_proprioceptive_margin.return_value = _margin_info("critical")
+
+        from src.mcp_handlers.lifecycle.stuck import _detect_stuck_agents
+        result = _detect_stuck_agents(
+            critical_margin_timeout_minutes=5, include_pattern_detection=False
+        )
+        assert result == []
+
+    @patch(_PATCHES["gov_config"])
+    @patch(_PATCHES["mcp_server"])
+    def test_stale_child_does_not_suppress(self, mock_server, mock_config):
+        """A child that itself went silent (beyond the freshness window) does NOT
+        explain the parent's silence → parent still flagged."""
+        old_time = datetime.now(timezone.utc) - timedelta(minutes=10)
+        stale_child = datetime.now(timezone.utc) - timedelta(minutes=90)
+        mock_server.agent_metadata = {
+            "p1": _make_agent_meta(last_update=old_time),
+            "c1": _make_agent_meta(
+                last_update=stale_child, parent_agent_id="p1", total_updates=2
+            ),
+        }
+        mock_server.monitors = {"p1": _make_monitor(risk=0.8, coherence=0.42)}
+        mock_server.load_monitor_state.return_value = None
+        mock_config.compute_proprioceptive_margin.return_value = _margin_info(
+            "critical", nearest_edge="risk", distance=0.02
+        )
+
+        from src.mcp_handlers.lifecycle.stuck import _detect_stuck_agents
+        result = _detect_stuck_agents(
+            critical_margin_timeout_minutes=5, include_pattern_detection=False
+        )
+        assert len(result) == 1
+        assert result[0]["agent_id"] == "p1"
+        assert result[0]["reason"] == "critical_margin_timeout"
+
+    @patch(_PATCHES["gov_config"])
+    @patch(_PATCHES["mcp_server"])
+    def test_inactive_child_does_not_suppress(self, mock_server, mock_config):
+        """A non-active (paused/archived) child is not a live successor."""
+        old_time = datetime.now(timezone.utc) - timedelta(minutes=10)
+        recent = datetime.now(timezone.utc) - timedelta(minutes=2)
+        mock_server.agent_metadata = {
+            "p1": _make_agent_meta(last_update=old_time),
+            "c1": _make_agent_meta(
+                status="paused", last_update=recent, parent_agent_id="p1"
+            ),
+        }
+        mock_server.monitors = {"p1": _make_monitor(risk=0.8, coherence=0.42)}
+        mock_config.compute_proprioceptive_margin.return_value = _margin_info(
+            "critical", nearest_edge="risk", distance=0.02
+        )
+
+        from src.mcp_handlers.lifecycle.stuck import _detect_stuck_agents
+        result = _detect_stuck_agents(
+            critical_margin_timeout_minutes=5, include_pattern_detection=False
+        )
+        assert len(result) == 1
+        assert result[0]["agent_id"] == "p1"
+
+    @patch(_PATCHES["mcp_server"])
+    def test_self_referential_parent_id_ignored(self, mock_server):
+        """A child whose parent_agent_id points at its own id is not a successor
+        of itself — must not be added to the live-parent set."""
+        recent = datetime.now(timezone.utc) - timedelta(minutes=2)
+        mock_server.agent_metadata = {
+            "a1": _make_agent_meta(
+                last_update=recent, parent_agent_id="a1", agent_uuid="a1"
+            ),
+        }
+        from src.mcp_handlers.lifecycle.stuck import _live_lineage_parent_ids
+        live = _live_lineage_parent_ids(datetime.now(timezone.utc))
+        assert live == set()
+
+    @pytest.mark.asyncio
+    async def test_archive_superseded_parents_archives_parent(self):
+        """auto_recover sweep retires a superseded parent as lineage_succession."""
+        old_time = datetime.now(timezone.utc) - timedelta(minutes=10)
+        recent = datetime.now(timezone.utc) - timedelta(minutes=2)
+        with patch(_PATCHES["mcp_server"]) as mock_server, \
+             patch("src.mcp_handlers.lifecycle.helpers._archive_one_agent") as mock_arch:
+            mock_server.agent_metadata = {
+                "p1": _make_agent_meta(last_update=old_time),
+                "c1": _make_agent_meta(last_update=recent, parent_agent_id="p1"),
+            }
+            mock_server.monitors = {}
+
+            async def _ok(*a, **k):
+                return True
+            mock_arch.side_effect = _ok
+
+            from src.mcp_handlers.lifecycle.stuck import _archive_superseded_parents
+            results = await _archive_superseded_parents(datetime.now(timezone.utc))
+
+        assert len(results) == 1
+        assert results[0]["agent_id"] == "p1"
+        assert results[0]["reason"] == "lineage_succession"
+        # The child must never be archived — it is the live successor.
+        archived_ids = [c.args[0] for c in mock_arch.call_args_list]
+        assert archived_ids == ["p1"]


### PR DESCRIPTION
## What

Closes the **stuck-detector × lineage gap** (KG discovery `2026-05-06T06:32:00.969288+00:00`): a parent agent whose child declared it via `parent_agent_id` at onboard, and is actively checking in, still fired `stuck_detected` on `critical_margin_timeout` (and the tight-margin / cadence-silence / pattern reasons). The parent's silence is explained by **succession** — the process rotated, lineage continuous — not by a hang. Empirically confirmed via the Discord-Dispatch turn chain in thread `t-d588dc931a` (predecessor `9e052529`, current `72a070eb`).

This is the leftover *ergonomic* surface that the ghost-proliferation *security* fix (#78/#81/#83, plugin #14) left open.

## How

In `src/mcp_handlers/lifecycle/stuck.py`:

- `_live_lineage_parent_ids()` — one O(n) pass over the agent pool building the set of parent identities that have an **active** lineage child that **checked in within 30 min** (`LINEAGE_SUCCESSION_FRESH_WINDOW_MINUTES`, matching the active-cadence intuition). Self-loops (`parent_agent_id == own id`) are guarded out.
- `_detect_stuck_agents()` computes that set once per sweep and **suppresses every stuck reason** for a superseded parent (`_is_superseded_by_lineage`), matched by dict-key id *or* `agent_uuid`.
- `_archive_superseded_parents()` — on the **`auto_recover` sweep only** (mutation path; the read-only dashboard refresh just stops the false flag and never mutates) — retires superseded parents via `_archive_one_agent(..., "lineage_succession")` so a rotated process stops re-tripping detection until the stale cap. Best-effort: persist-first, returns False on DB failure → parent simply left for next sweep.

Hermes-style fixed-UUID daemons (no children) and ephemeral one-shots (no children) are unaffected.

Also removes a redundant function-local `from datetime import datetime` in `handle_detect_stuck_agents` that shadowed the module import (would have raised `UnboundLocalError` on the new early `datetime.now()` call).

## Tests

New `TestLineageSuccession` class in `tests/test_lifecycle_detect_stuck.py` (6 cases): live child suppresses parent; match by `agent_uuid`; stale child does *not* suppress; inactive/paused child does *not* suppress; self-referential `parent_agent_id` ignored; `_archive_superseded_parents` archives the parent but never the live child.

Local: `test_lifecycle_detect_stuck.py`, `test_lifecycle_recovery.py`, `test_lifecycle_agents.py`, `test_handlers_lifecycle.py` → **276 passed**. (Unrelated `test_tool_modes.py` failures are a missing `psutil` dep in this bare container, in an untouched file.)

## Note on scope

This addresses the single clearest *concrete code bug* among the open KG watcher/governance findings. The local `data/watcher/findings.jsonl` store is gitignored and absent in a fresh clone, so there were no live Watcher fingerprints to resolve in this session.

https://claude.ai/code/session_01HvXawVPqSsMSDYR8uEEVNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01HvXawVPqSsMSDYR8uEEVNU)_