### PR TITLE
fix(identity): resume response reports harness_type=unknown

### DIFF
--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -611,6 +611,28 @@ async def handle_identity_v2(
 # DECORATOR-COMPATIBLE ADAPTER
 # =============================================================================
 
+def _resolve_response_client_hint(arguments: Optional[Dict[str, Any]]) -> Optional[str]:
+    """Resolve client_hint for the response harness_context, matching onboard().
+
+    identity() previously reported ``harness_context.harness_type="unknown"``
+    on resume because its response builders received only
+    ``arguments.get("client_hint")`` — callers rarely repeat the hint on a
+    resume. onboard() falls back to the transport-bound hint
+    (handle_onboard_adapter, see get_context_client_hint). Mirror that
+    fallback so the descriptive harness_context is consistent across the two
+    surfaces within one session. Response-shape only — never feeds the
+    continuity-token pin or assurance tier.
+    """
+    hint = (arguments or {}).get("client_hint")
+    if not hint or hint == "unknown":
+        try:
+            from ..context import get_context_client_hint
+            hint = get_context_client_hint() or hint
+        except Exception:
+            pass
+    return hint
+
+
 def _build_identity_diag_payload_for_request(
     arguments: Dict[str, Any],
     model_type: Optional[str],
@@ -660,7 +682,7 @@ def _build_identity_diag_payload_for_request(
         identity_resolution_outcome=identity_resolution_outcome,
         provisional_lineage=provisional_lineage,
         lineage_state=lineage_state,
-        client_hint=arguments.get("client_hint"),
+        client_hint=_resolve_response_client_hint(arguments),
         model_type=model_type,
     )
 
@@ -1306,7 +1328,7 @@ async def handle_identity_adapter(arguments: Dict[str, Any]) -> Sequence[TextCon
         verbose=verbose,
         provisional_lineage=_r2_prov_main,
         lineage_state=_r2_state_main,
-        client_hint=arguments.get("client_hint"),
+        client_hint=_resolve_response_client_hint(arguments),
     )
 
     # Auto-bind: automatically perform session binding so agents don't need a separate bind_session call

--- a/tests/test_identity_response_harness_hint.py
+++ b/tests/test_identity_response_harness_hint.py
@@ -1,0 +1,55 @@
+"""Regression: identity() response harness_context must match onboard().
+
+identity() resume previously reported harness_context.harness_type="unknown"
+because its response builders received only arguments.get("client_hint"),
+while onboard() falls back to the transport-bound hint. The
+_resolve_response_client_hint helper mirrors that fallback so the
+descriptive harness context is consistent across both surfaces.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.mcp_handlers.identity.handlers import _resolve_response_client_hint
+from src.mcp_handlers.context import (
+    set_transport_client_hint,
+    reset_transport_client_hint,
+)
+
+
+def test_explicit_arg_wins():
+    assert _resolve_response_client_hint({"client_hint": "cursor"}) == "cursor"
+
+
+def test_falls_back_to_transport_when_arg_missing():
+    """The resume case: no client_hint in args, transport carries it."""
+    token = set_transport_client_hint("claude_code")
+    try:
+        assert _resolve_response_client_hint({}) == "claude_code"
+        assert _resolve_response_client_hint(None) == "claude_code"
+    finally:
+        reset_transport_client_hint(token)
+
+
+def test_falls_back_to_transport_when_arg_is_unknown():
+    token = set_transport_client_hint("claude_code")
+    try:
+        assert _resolve_response_client_hint({"client_hint": "unknown"}) == "claude_code"
+    finally:
+        reset_transport_client_hint(token)
+
+
+def test_returns_none_when_nothing_available():
+    """No arg, no transport hint -> None (builder maps to 'unknown')."""
+    assert _resolve_response_client_hint({}) is None
+
+
+def test_arg_preferred_over_transport():
+    token = set_transport_client_hint("claude_code")
+    try:
+        assert _resolve_response_client_hint({"client_hint": "cursor"}) == "cursor"
+    finally:
+        reset_transport_client_hint(token)


### PR DESCRIPTION
## Problem

Dogfooding the agent loop surfaced an inconsistency: within one session, `onboard()` reported `identity_context.harness_context.harness_type: "claude_code"`, but the immediately-following `identity()` resume reported `"unknown"`.

The field is explicitly `is_identity_proof: false` (descriptive context only), so this is cosmetic — but it's a real cross-call inconsistency on the same session.

## Cause

`identity()`'s response builders received only `arguments.get("client_hint")`. Callers rarely repeat `client_hint` on a resume, so it resolves to `None` → `"unknown"`. `onboard()` (handle_onboard_adapter) already falls back to the transport-bound hint via `get_context_client_hint()`.

## Fix

Add `_resolve_response_client_hint()` mirroring onboard's fallback (`arg → transport contextvar → None`) and apply it at the **two response harness_context call sites** only:
- the diag fast-path (`_build_identity_diag_payload_for_request`)
- the main `build_identity_response_data` path

The continuity-token pin (1243) and deprecation-telemetry (1344) sites are deliberately **left on raw `arguments.get()`** — response-shape only, no pin/assurance-tier semantics touched.

## Tests

New `tests/test_identity_response_harness_hint.py` (5 cases: arg-wins, transport-fallback on missing/unknown, none-when-empty, arg-preferred-over-transport). Related suites green: `test_identity_payloads`, `test_transport_resolution_parity`, `test_identity_session`, `test_context` (169 passed).

Found via dogfooding the governance MCP.