### PR TITLE
fix(identity): stop laundering server-injected fingerprint CSID into strong assurance tier (#679)

### DIFF
--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -659,10 +659,12 @@ def _build_identity_diag_payload_for_request(
 
     stable_session_id = make_client_session_id(agent_uuid)
     try:
-        from ..context import get_session_resolution_source
+        from ..context import get_session_resolution_source, get_session_proof_origin
         continuity_source = get_session_resolution_source()
+        proof_origin = get_session_proof_origin()
     except Exception:
         continuity_source = None
+        proof_origin = None
     continuity_support = continuity_token_support_status()
     continuity_token = create_continuity_token(
         agent_uuid,
@@ -684,6 +686,7 @@ def _build_identity_diag_payload_for_request(
         lineage_state=lineage_state,
         client_hint=_resolve_response_client_hint(arguments),
         model_type=model_type,
+        proof_origin=proof_origin,
     )
 
 
@@ -1265,10 +1268,12 @@ async def handle_identity_adapter(arguments: Dict[str, Any]) -> Sequence[TextCon
         client_hint=arguments.get("client_hint"),
     )
     try:
-        from ..context import get_session_resolution_source
+        from ..context import get_session_resolution_source, get_session_proof_origin
         continuity_source = get_session_resolution_source()
+        proof_origin = get_session_proof_origin()
     except Exception:
         continuity_source = None
+        proof_origin = None
     continuity_support = continuity_token_support_status()
 
     verbose = coerce_bool(arguments.get("verbose"), default=False) if arguments else False
@@ -1329,6 +1334,7 @@ async def handle_identity_adapter(arguments: Dict[str, Any]) -> Sequence[TextCon
         provisional_lineage=_r2_prov_main,
         lineage_state=_r2_state_main,
         client_hint=_resolve_response_client_hint(arguments),
+        proof_origin=proof_origin,
     )
 
     # Auto-bind: automatically perform session binding so agents don't need a separate bind_session call
@@ -2273,10 +2279,12 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     # STEP 6: Build response
     verbose = coerce_bool(arguments.get("verbose"), default=False)
     try:
-        from ..context import get_session_resolution_source
+        from ..context import get_session_resolution_source, get_session_proof_origin
         continuity_source = get_session_resolution_source()
+        proof_origin = get_session_proof_origin()
     except Exception:
         continuity_source = None
+        proof_origin = None
     continuity_support = continuity_token_support_status()
     continuity_token = create_continuity_token(
         agent_uuid,
@@ -2380,6 +2388,7 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
         tool_mode_info=tool_mode_info,
         lineage_state=_lineage_for_response,
         provisional_lineage=_r2_provisional_lineage,
+        proof_origin=proof_origin,
     )
 
     # Bootstrap check-in (onboard-bootstrap-checkin §3.5). Conditional on

--- a/src/services/identity_payloads.py
+++ b/src/services/identity_payloads.py
@@ -46,6 +46,7 @@ def build_identity_response_data(
     provisional_lineage: bool = False,
     lineage_state: Optional[str] = None,
     client_hint: Optional[str] = None,
+    proof_origin: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Build the identity() response payload."""
     identity_context = build_identity_response_context(
@@ -57,6 +58,7 @@ def build_identity_response_data(
         identity_resolution_outcome=identity_resolution_outcome,
         client_hint=client_hint,
         model_type=model_type,
+        proof_origin=proof_origin,
     )
     response_data = {
         "uuid": agent_uuid,
@@ -144,6 +146,7 @@ def build_identity_diag_payload(
     lineage_state: Optional[str] = None,
     client_hint: Optional[str] = None,
     model_type: Optional[str] = None,
+    proof_origin: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Build the lightweight identity diagnostic payload used by fast-return paths."""
     identity_context = build_identity_response_context(
@@ -155,6 +158,7 @@ def build_identity_diag_payload(
         identity_resolution_outcome=identity_resolution_outcome,
         client_hint=client_hint,
         model_type=model_type,
+        proof_origin=proof_origin,
     )
     payload = {
         "uuid": agent_uuid,
@@ -208,6 +212,7 @@ def build_onboard_response_data(
     identity_resolution_outcome: Optional[str] = None,
     lineage_state: Optional[str] = None,
     provisional_lineage: bool = False,
+    proof_origin: Optional[str] = None,
 ) -> dict:
     """Build the onboard() response payload."""
     identity_status = "created" if is_new else ("reactivated" if was_archived else "resumed")
@@ -220,6 +225,7 @@ def build_onboard_response_data(
         identity_resolution_outcome=identity_resolution_outcome,
         client_hint=client_hint,
         model_type=None,
+        proof_origin=proof_origin,
     )
     next_calls = [
         {
@@ -395,6 +401,7 @@ def build_identity_response_context(
     identity_resolution_outcome: Optional[str] = None,
     client_hint: Optional[str] = None,
     model_type: Optional[str] = None,
+    proof_origin: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Build S22 response annotation for identity/onboard payloads.
 
@@ -405,7 +412,7 @@ def build_identity_response_context(
     strength of the session-resolution signal.
     """
     source_key = _normalize_source(session_resolution_source)
-    identity_assurance = _identity_assurance_from_source(source_key)
+    identity_assurance = _identity_assurance_from_source(source_key, proof_origin)
     continuity_claim = _continuity_claim(
         source_key,
         identity_status=identity_status,
@@ -466,7 +473,10 @@ def _tier_for_source(source_key: str) -> str:
     return "weak"
 
 
-def _identity_assurance_from_source(source_key: str) -> Dict[str, Any]:
+def _identity_assurance_from_source(
+    source_key: str,
+    proof_origin: Optional[str] = None,
+) -> Dict[str, Any]:
     """Compute assurance tier from a session-resolution source.
 
     Recognizes the S3 `sticky_cache:<original>` envelope: the original
@@ -474,7 +484,33 @@ def _identity_assurance_from_source(source_key: str) -> Dict[str, Any]:
     (strong→medium, medium→weak, weak→weak). Mirrors the same logic in
     `mcp_handlers/updates/phases.py:_compute_identity_assurance` so the
     identity() response and update-path tier stay consistent.
+
+    `proof_origin` ('caller_asserted' | 'server_inferred' | None) is
+    authoritative over the source label (#679). A server-inferred binding
+    (transport-injected CSID, fingerprint pin, context fallback) is NEVER
+    strong, no matter what source label resolution stamped on it — this is
+    what closes the laundering path where an injected `ip_ua_fingerprint`
+    wore the `explicit_client_session_id` label and was reported strong/1.0.
+    `None` (unknown origin) leaves the tier unchanged so legacy callers that
+    don't thread provenance keep today's behavior (fail-open), exactly like
+    the write-path `_compute_identity_assurance`.
     """
+    if proof_origin == "server_inferred":
+        # Authoritative downgrade — a server-guessed binding is weak proof no
+        # matter what source label resolution stamped on it (#679).
+        score, _ = _TIER_PAYLOADS["weak"]
+        return {
+            "tier": "weak",
+            "score": score,
+            "session_source": source_key,
+            "trajectory_confidence": None,
+            "reason": f"server-inferred binding ('{source_key}'); not caller-proven",
+            "caller_proven": False,
+            "proof_origin": proof_origin,
+        }
+
+    caller_proven = (proof_origin == "caller_asserted")
+
     if source_key.startswith(_STICKY_CACHE_PREFIX):
         original_key = source_key[len(_STICKY_CACHE_PREFIX):] or "unknown"
         original_tier = _tier_for_source(original_key)
@@ -496,6 +532,8 @@ def _identity_assurance_from_source(source_key: str) -> Dict[str, Any]:
             "session_source": source_key,
             "trajectory_confidence": None,
             "reason": reason,
+            "caller_proven": caller_proven,
+            "proof_origin": proof_origin or "unknown",
         }
 
     tier = _tier_for_source(source_key)
@@ -506,6 +544,8 @@ def _identity_assurance_from_source(source_key: str) -> Dict[str, Any]:
         "session_source": source_key,
         "trajectory_confidence": None,
         "reason": reason,
+        "caller_proven": caller_proven,
+        "proof_origin": proof_origin or "unknown",
     }
 
 

--- a/tests/test_identity_payloads.py
+++ b/tests/test_identity_payloads.py
@@ -142,3 +142,100 @@ def test_identity_response_context_distinguishes_uuid_label_harness_and_assuranc
     assert context["harness_context"]["is_identity_proof"] is False
     assert context["identity_assurance"]["tier"] == "medium"
     assert context["continuity_claim"] == "resumed_by_recent_onboard_pin"
+
+
+# ── #679: server-injected fingerprint must not be laundered into strong ──
+#
+# On the stateless streamable transport (claude.ai remote connector), the
+# typed wrapper injects `signals.ip_ua_fingerprint` as `client_session_id`
+# when the caller omits one. Resolution then labels it
+# `explicit_client_session_id` (a strong source). The write-path assurance
+# (`phases._compute_identity_assurance`) already downgrades server-inferred
+# bindings to weak via proof_origin; these tests pin the SAME honesty into
+# the identity()/onboard RESPONSE assurance so the two surfaces agree.
+
+
+def test_injected_explicit_csid_is_downgraded_to_weak_in_response():
+    context = build_identity_response_context(
+        agent_uuid="uuid-1",
+        agent_id="agent-1",
+        display_name=None,
+        session_resolution_source="explicit_client_session_id",
+        identity_status="resumed",
+        proof_origin="server_inferred",
+    )
+    assurance = context["identity_assurance"]
+    assert assurance["tier"] == "weak"
+    assert assurance["score"] == 0.35
+    assert assurance["caller_proven"] is False
+    assert assurance["proof_origin"] == "server_inferred"
+
+
+def test_server_inferred_overrides_even_a_strong_source_label():
+    """proof_origin is authoritative over the source label — a strong label
+    (mcp_session_id) resolved by server inference is still weak."""
+    context = build_identity_response_context(
+        agent_uuid="uuid-2",
+        agent_id="agent-2",
+        display_name=None,
+        session_resolution_source="mcp_session_id",
+        identity_status="resumed",
+        proof_origin="server_inferred",
+    )
+    assert context["identity_assurance"]["tier"] == "weak"
+
+
+def test_caller_asserted_explicit_csid_stays_strong():
+    context = build_identity_response_context(
+        agent_uuid="uuid-3",
+        agent_id="agent-3",
+        display_name=None,
+        session_resolution_source="explicit_client_session_id",
+        identity_status="resumed",
+        proof_origin="caller_asserted",
+    )
+    assurance = context["identity_assurance"]
+    assert assurance["tier"] == "strong"
+    assert assurance["caller_proven"] is True
+
+
+def test_unknown_proof_origin_leaves_tier_unchanged_backward_compat():
+    """Legacy callers that don't thread provenance keep today's behavior
+    (fail-open) — an explicit source with no proof_origin stays strong."""
+    context = build_identity_response_context(
+        agent_uuid="uuid-4",
+        agent_id="agent-4",
+        display_name=None,
+        session_resolution_source="explicit_client_session_id",
+        identity_status="resumed",
+    )
+    assurance = context["identity_assurance"]
+    assert assurance["tier"] == "strong"
+    assert assurance["caller_proven"] is False
+    assert assurance["proof_origin"] == "unknown"
+
+
+def test_onboard_response_threads_server_inferred_downgrade():
+    """End-to-end through the onboard builder: an injected CSID surfaces as
+    weak in the onboard() response identity_assurance."""
+    payload = build_onboard_response_data(
+        agent_uuid="uuid-5",
+        structured_agent_id="agent-5",
+        agent_label=None,
+        stable_session_id="sess-5",
+        is_new=False,
+        force_new=False,
+        client_hint="claude",
+        was_archived=False,
+        trajectory_result=None,
+        parent_agent_id=None,
+        thread_context=None,
+        verbose=False,
+        continuity_source="explicit_client_session_id",
+        continuity_support={"enabled": False},
+        continuity_token=None,
+        system_activity=None,
+        tool_mode_info=None,
+        proof_origin="server_inferred",
+    )
+    assert payload["identity_assurance"]["tier"] == "weak"


### PR DESCRIPTION
Closes #679.

## Problem

The `identity()` / `onboard()` response `identity_assurance` tier was computed **purely from the session-resolution source label** (`_identity_assurance_from_source` in `src/services/identity_payloads.py`).

On the stateless streamable transport (the claude.ai remote connector — no `Mcp-Session-Id`, no stable headers), the typed wrapper injects `signals.ip_ua_fingerprint` as `client_session_id`. Resolution then labels that injected value `explicit_client_session_id`, a **strong** source → it was reported `strong / 1.0`. Net: a heuristic fingerprint was presented as cryptographic-strength explicit-session proof, and distinct agents behind one gateway IP+UA collapsed onto a single shared-fingerprint identity at a *strong* label.

## Fix (the issue's option 2 — "thread provenance", lowest blast radius)

The write-path assurance (`phases._compute_identity_assurance`) **already** downgrades server-inferred bindings to `weak` via the `proof_origin` context var (the same `csid_transport_injected` flag set at both inject sites). The response-path builder was simply never made provenance-aware — so `identity()` reported `strong` while `process_agent_update` reported `weak` for the *same* binding. This closes that gap:

- `_identity_assurance_from_source(source_key, proof_origin=None)` now applies the authoritative `server_inferred → weak` downgrade, mirroring the write path exactly.
- `proof_origin` threaded through `build_identity_response_context` and the three builders (`build_identity_response_data`, `build_identity_diag_payload`, `build_onboard_response_data`).
- `handlers.py` reads `get_session_proof_origin()` alongside the existing `get_session_resolution_source()` at the three response-build sites and passes it through.

## Why this is low blast radius (not the worst-case in the issue)

The issue worried a strong→weak reclassification would interact with the **#425 strict gate**. It doesn't: the strict gate (`resolve_identity_and_guards`) keys on `proof_origin` / `caller_proven`, **not** on the reported `identity_assurance.tier`, and it already downgrades. So this PR only corrects the *reported* tier in the identity/onboard response (telemetry + dashboards + client-visible honesty) — making it consistent with the already-shipped write-path behavior. No gate behavior changes.

**Backward-compatible:** `proof_origin=None` (unknown) leaves the tier unchanged — legacy callers that don't thread provenance keep today's behavior (fail-open), matching `_compute_identity_assurance`'s contract.

## Tests

`tests/test_identity_payloads.py` gains regressions:
- injected `explicit_client_session_id` (server_inferred) → `weak` in the response
- `server_inferred` overrides even a genuinely-strong source label (e.g. `mcp_session_id`)
- `caller_asserted` explicit CSID stays `strong` + `caller_proven=True`
- unknown `proof_origin` leaves the tier unchanged (backward-compat)
- end-to-end through `build_onboard_response_data`

All 50 focused identity tests pass (payloads / strict-proof-origin / honesty-partc / checkin-surface), plus 164 in `test_identity_handlers` + `test_onboard_helper`.

https://claude.ai/code/session_019TqoxARJeAJuTnRD49im22

---
_Generated by [Claude Code](https://claude.ai/code/session_019TqoxARJeAJuTnRD49im22)_