### PR TITLE
[codex] Add identity lifecycle visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,19 @@ Additional services (started via launchd, not bundled into `docker compose up`):
 # Inside the agent's loop
 result = sync_state(response_text=output, complexity=0.6, confidence=0.8)
 raw = result.get("raw_governance", result)  # alias envelope preserves the full canonical payload
-metrics = raw.get("metrics", raw)
+metrics = raw.get("metrics") or {}
+eisv = (
+    raw.get("primary_eisv")
+    or raw.get("behavioral_eisv")
+    or metrics.get("eisv")
+    or metrics
+)
 
-if metrics["integrity"] < 0.4:
+if eisv.get("I") is not None and eisv["I"] < 0.4:
     agent.require_human_review("integrity low — pausing autonomous actions")
-elif metrics["entropy"] > 0.7:
+elif eisv.get("S") is not None and eisv["S"] > 0.7:
     agent.narrow_scope()            # fewer tools, tighter search
-elif metrics["energy"] < 0.2:
+elif eisv.get("E") is not None and eisv["E"] < 0.2:
     agent.stop_and_summarize()      # avoid thrashing
 ```
 
@@ -281,7 +287,7 @@ graph LR
     A[AI Agent] -->|check-in| M["MCP Server :8767"]
     M -->|observations| BS[Behavioral EISV]
     BS -->|"verdict + guidance"| M
-    M -->|parallel diagnostic| UC[unitares-core ODE]
+    M -->|parallel diagnostic| UC[governance_core ODE]
     UC -.->|analysis only| M
     M -->|"verdict + guidance"| A
     M <-->|"state, audit, calibration"| PG[("PostgreSQL + AGE")]

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -40,7 +40,7 @@ The token must be present in the server's `UNITARES_OPERATOR_TOKENS` allowlist (
 - **Stats:** fleet coherence, active/total agents, stuck agents, discoveries, dialectic sessions, system health, calibration, anomalies, and trust-tier distribution.
 - **Pulse:** latest governance decision, risk/confidence/complexity vitals, event sparkline, and pinned-agent support.
 - **EISV:** fleet and per-agent time-series charts backed by Chart.js.
-- **Agents:** searchable/filterable agent table with pagination, status, metrics, trust tiers, lineage badges, and operator actions.
+- **Agents:** searchable/filterable agent table with pagination, status, metrics, trust tiers, lineage/supersession badges, lifecycle reason display, and operator actions.
 - **Discoveries:** recent knowledge graph entries with filters and status actions.
 - **Dialectic:** peer-review/recovery sessions, phase/status counts, and transcript views.
 - **Activity:** timeline of check-ins, verdicts, discoveries, dialectic events, lifecycle events, and resident events.
@@ -109,6 +109,8 @@ Dedicated HTTP endpoints include:
 - `/v1/sentinel/summary`
 - `/v1/vigil/summary`
 - `/ws/eisv`
+
+Agent rows come from `agent(action="list", include_metrics=true, status_filter="all")`. The dashboard consumes compact list fields only: `parent_agent_id`, `spawn_reason`, `last_lifecycle_event`, `last_lifecycle_reason`, `last_lifecycle_at`, `superseded`, and `superseded_reason`. Full `identity_view` belongs to `get_agent_metadata` detail responses and is not required for the agent grid.
 
 ## Development
 

--- a/dashboard/agents.js
+++ b/dashboard/agents.js
@@ -135,6 +135,27 @@
         return null;
     }
 
+    function formatLifecycleEventLabel(eventName) {
+        if (!eventName) return '-';
+        return String(eventName).replace(/_/g, ' ').replace(/\b\w/g, function (m) {
+            return m.toUpperCase();
+        });
+    }
+
+    function formatLifecycleReasonLabel(reason) {
+        if (!reason) return '-';
+        var labels = {
+            lineage_succession: 'Lineage succession'
+        };
+        return labels[reason] || formatLifecycleEventLabel(reason);
+    }
+
+    function getSupersededBadgeHtml(agent) {
+        if (!agent || agent.superseded !== true) return '';
+        var reason = formatLifecycleReasonLabel(agent.superseded_reason || agent.last_lifecycle_reason);
+        return '<span class="lineage-badge lineage-superseded" title="' + escapeHtml(reason) + '">Superseded</span>';
+    }
+
     // ========================================================================
     // Agent UI helpers
     // ========================================================================
@@ -309,6 +330,7 @@
             if (children.length > 0) {
                 lineageBadgeHtml += '<span class="lineage-badge lineage-parent" title="' + children.length + ' child agent(s) declared this as parent">' + children.length + ' child' + (children.length !== 1 ? 'ren' : '') + '</span>';
             }
+            var supersededBadgeHtml = getSupersededBadgeHtml(agent);
 
             var hasMetrics = agentHasMetrics(agent);
             var isPinned = state.get('pinnedAgentId') === agentId;
@@ -384,7 +406,7 @@
                         '<span class="agent-name">' + nameHtml + '</span>' +
                         stuckBadgeHtml + inactiveBadgeHtml +
                         healthBadgeHtml + staleBadgeHtml +
-                        trustTierHtml + lineageBadgeHtml + anomalyHtml +
+                        trustTierHtml + lineageBadgeHtml + supersededBadgeHtml + anomalyHtml +
                         sparklineHtml +
                         actionsHtml +
                     '</div>' +
@@ -648,6 +670,27 @@
                     escapeHtml(agent.last_update || '-') +
                 '</div>' +
             '</div>' +
+
+            (function () {
+                if (!agent.superseded && !agent.last_lifecycle_event && !agent.last_lifecycle_reason) return '';
+                var lifecycleEvent = agent.last_lifecycle_event || (agent.superseded ? 'archived' : '');
+                var lifecycleReason = agent.superseded_reason || agent.last_lifecycle_reason || '';
+                var lifecycleAt = agent.last_lifecycle_at
+                    ? DataProcessor.formatTimestamp(agent.last_lifecycle_at)
+                    : '-';
+                return '<div class="grid-2col mb-md">' +
+                    '<div>' +
+                        '<strong class="text-secondary-sm">Last Lifecycle:</strong><br>' +
+                        '<span class="status-chip ' + escapeHtml(status) + '">' + escapeHtml(formatLifecycleEventLabel(lifecycleEvent)) + '</span>' +
+                        (agent.superseded ? ' ' + getSupersededBadgeHtml(agent) : '') +
+                    '</div>' +
+                    '<div>' +
+                        '<strong class="text-secondary-sm">Lifecycle Reason:</strong><br>' +
+                        '<span class="detail-box-value">' + escapeHtml(formatLifecycleReasonLabel(lifecycleReason)) + '</span>' +
+                        '<br><span class="text-secondary-xs">' + escapeHtml(lifecycleAt) + '</span>' +
+                    '</div>' +
+                '</div>';
+            })() +
 
             (function () {
                 // Lineage section — parent and children, resolved against cachedAgents
@@ -987,6 +1030,11 @@
 
         hit.lifecycle_status = newStatus;
         hit.status = newStatus;  // some renderers read .status directly
+        hit.last_lifecycle_event = data.event || newStatus;
+        hit.last_lifecycle_reason = data.reason || null;
+        hit.last_lifecycle_at = data.timestamp || new Date().toISOString();
+        hit.superseded = newStatus === 'archived' && data.reason === 'lineage_succession';
+        hit.superseded_reason = hit.superseded ? data.reason : null;
 
         applyAgentFilters();
         flashAgentCard(data.agent_id);

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -1429,6 +1429,12 @@ main {
     border: 1px solid rgba(255, 170, 80, 0.3);
 }
 
+.lineage-badge.lineage-superseded {
+    background: rgba(148, 163, 184, 0.14);
+    color: var(--text-secondary);
+    border: 1px solid rgba(148, 163, 184, 0.28);
+}
+
 /* Stuck badge — shown on agent cards when detect_stuck_agents flags them */
 .stuck-badge {
     font-size: 0.7em;

--- a/src/mcp_handlers/lifecycle/query.py
+++ b/src/mcp_handlers/lifecycle/query.py
@@ -110,6 +110,154 @@ def _visible_related_agent_identifier(
     return f"agent-redacted-{digest}", True
 
 
+def _latest_lifecycle_event(meta: Any) -> Optional[dict[str, Any]]:
+    events = getattr(meta, "lifecycle_events", None) or []
+    for event in reversed(events):
+        if isinstance(event, dict):
+            return event
+    return None
+
+
+def _is_lineage_supersession(event: Optional[dict[str, Any]]) -> bool:
+    if not event:
+        return False
+    return (
+        event.get("event") == "archived"
+        and event.get("reason") == "lineage_succession"
+    )
+
+
+def _compact_lifecycle_fields(meta: Any) -> dict[str, Any]:
+    event = _latest_lifecycle_event(meta)
+    if not event:
+        return {}
+
+    fields = {
+        "last_lifecycle_event": event.get("event"),
+        "last_lifecycle_reason": event.get("reason"),
+    }
+    timestamp = event.get("timestamp") or event.get("ts")
+    if timestamp:
+        fields["last_lifecycle_at"] = timestamp
+
+    if _is_lineage_supersession(event):
+        fields["superseded"] = True
+        fields["superseded_reason"] = event.get("reason")
+
+    return fields
+
+
+def _identity_view(
+    agent_id: str,
+    meta: Any,
+    *,
+    caller_uuid: Optional[str],
+    operator_caller: bool,
+) -> dict[str, Any]:
+    visible_id, id_redacted = _visible_agent_identifier(
+        agent_id,
+        meta,
+        caller_uuid=caller_uuid,
+        operator_caller=operator_caller,
+    )
+    parent_agent_id = getattr(meta, "parent_agent_id", None)
+    visible_parent_id, parent_redacted = _visible_related_agent_identifier(
+        parent_agent_id,
+        caller_uuid=caller_uuid,
+        operator_caller=operator_caller,
+    )
+    lifecycle_event = _latest_lifecycle_event(meta)
+    lifecycle_timestamp = None
+    if lifecycle_event:
+        lifecycle_timestamp = lifecycle_event.get("timestamp") or lifecycle_event.get("ts")
+
+    current = {
+        "id": visible_id,
+        "id_redacted": id_redacted,
+        "label": getattr(meta, "label", None),
+        "display_name": getattr(meta, "display_name", None),
+        "public_handle": (
+            getattr(meta, "public_agent_id", None)
+            or getattr(meta, "structured_id", None)
+        ),
+    }
+    if (
+        (operator_caller or agent_id == caller_uuid)
+        and getattr(meta, "active_session_key", None)
+    ):
+        current["session_key"] = getattr(meta, "active_session_key")
+
+    superseded = _is_lineage_supersession(lifecycle_event)
+    lifecycle = {
+        "status": getattr(meta, "status", None),
+        "latest_event": lifecycle_event.get("event") if lifecycle_event else None,
+        "latest_reason": lifecycle_event.get("reason") if lifecycle_event else None,
+        "latest_at": lifecycle_timestamp,
+        "superseded": superseded,
+    }
+    if superseded:
+        lifecycle["superseded_reason"] = lifecycle_event.get("reason")
+
+    return {
+        "schema_version": "identity_view.v1",
+        "current": current,
+        "lineage": {
+            "parent_agent_id": visible_parent_id,
+            "parent_agent_id_redacted": parent_redacted,
+            "spawn_reason": getattr(meta, "spawn_reason", None),
+            "lineage_state": "declared" if parent_agent_id else "no_lineage_declared",
+            "lineage_state_source": "derived",
+        },
+        "lifecycle": lifecycle,
+    }
+
+
+def _metadata_dict_for_response(
+    agent_id: str,
+    meta: Any,
+    *,
+    caller_uuid: Optional[str],
+    operator_caller: bool,
+) -> dict[str, Any]:
+    metadata = dict(meta.to_dict())
+    sensitive_identity_allowed = operator_caller or agent_id == caller_uuid
+
+    visible_agent_id, uuid_redacted = _visible_agent_identifier(
+        agent_id,
+        meta,
+        caller_uuid=caller_uuid,
+        operator_caller=operator_caller,
+    )
+    if "agent_id" in metadata or uuid_redacted:
+        metadata["agent_id"] = visible_agent_id
+    if uuid_redacted:
+        metadata["agent_id_redacted"] = True
+        if "agent_uuid" in metadata:
+            metadata.pop("agent_uuid", None)
+            metadata["agent_uuid_redacted"] = True
+
+    parent_agent_id = getattr(meta, "parent_agent_id", None) or metadata.get("parent_agent_id")
+    visible_parent_id, parent_redacted = _visible_related_agent_identifier(
+        parent_agent_id,
+        caller_uuid=caller_uuid,
+        operator_caller=operator_caller,
+    )
+    if parent_agent_id or "parent_agent_id" in metadata:
+        metadata["parent_agent_id"] = visible_parent_id
+    if parent_redacted:
+        metadata["parent_agent_id_redacted"] = True
+
+    if not sensitive_identity_allowed:
+        if metadata.get("active_session_key"):
+            metadata["active_session_key_redacted"] = True
+        metadata.pop("active_session_key", None)
+        if metadata.get("api_key"):
+            metadata["api_key_redacted"] = True
+        metadata.pop("api_key", None)
+
+    return metadata
+
+
 def _context_agent_id() -> Optional[str]:
     try:
         from ..context import get_context_agent_id
@@ -252,6 +400,7 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                     "spawn_reason": getattr(meta, 'spawn_reason', None),
                     "event_driven": is_event_driven_label(label),
                 }
+                agent_entry.update(_compact_lifecycle_fields(meta))
                 if uuid_redacted:
                     agent_entry["uuid_redacted"] = True
                 if parent_redacted:
@@ -272,7 +421,7 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                         caller_uuid=caller_uuid,
                         operator_caller=operator_caller,
                     )
-                    agents.append({
+                    caller_entry = {
                         "id": caller_uuid,
                         "label": caller_label or caller_public,
                         "status": caller_meta.status,
@@ -284,7 +433,9 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                         "parent_agent_id": parent_id,
                         "spawn_reason": getattr(caller_meta, 'spawn_reason', None),
                         "you": True,
-                    })
+                    }
+                    caller_entry.update(_compact_lifecycle_fields(caller_meta))
+                    agents.append(caller_entry)
                     if parent_redacted:
                         agents[-1]["parent_agent_id_redacted"] = True
 
@@ -426,6 +577,7 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                 "spawn_reason": getattr(meta, 'spawn_reason', None),
                 "event_driven": is_event_driven_label(getattr(meta, 'label', None)),
             }
+            agent_info.update(_compact_lifecycle_fields(meta))
             if uuid_redacted:
                 agent_info["agent_id_redacted"] = True
             if parent_redacted:
@@ -689,6 +841,8 @@ async def handle_get_agent_metadata(arguments: Sequence[TextContent]) -> list:
     """
     # Check for target_agent parameter (allows looking up other agents by UUID or label)
     target_agent = arguments.get("target_agent") or arguments.get("agent_id")
+    caller_uuid = _context_agent_id()
+    operator_caller = _is_operator_request()
 
     if target_agent:
         # FAST PATH: Check Redis cache first (by UUID)
@@ -707,7 +861,12 @@ async def handle_get_agent_metadata(arguments: Sequence[TextContent]) -> list:
                 mcp_server.agent_metadata[agent_id] = meta
                 # Skip to response building (meta already loaded)
                 monitor = mcp_server.monitors.get(agent_id)
-                metadata_response = meta.to_dict()
+                metadata_response = _metadata_dict_for_response(
+                    agent_id,
+                    meta,
+                    caller_uuid=caller_uuid,
+                    operator_caller=operator_caller,
+                )
                 # Add computed fields
                 if monitor:
                     metadata_response["current_state"] = {
@@ -721,6 +880,12 @@ async def handle_get_agent_metadata(arguments: Sequence[TextContent]) -> list:
                     }
                 else:
                     metadata_response["current_state"] = None
+                metadata_response["identity_view"] = _identity_view(
+                    agent_id,
+                    meta,
+                    caller_uuid=caller_uuid,
+                    operator_caller=operator_caller,
+                )
                 # Add EISV labels (__import__('src.governance_monitor', fromlist=['UNITARESMonitor']).UNITARESMonitor imported at module level)
                 metadata_response["eisv_labels"] = __import__('src.governance_monitor', fromlist=['UNITARESMonitor']).UNITARESMonitor.get_eisv_labels()
                 return success_response(metadata_response)
@@ -760,6 +925,7 @@ async def handle_get_agent_metadata(arguments: Sequence[TextContent]) -> list:
         agent_id, error = require_registered_agent(arguments)
         if error:
             return [error]  # Returns onboarding guidance if not registered
+        caller_uuid = caller_uuid or agent_id
 
     meta = mcp_server.agent_metadata[agent_id]
     monitor = mcp_server.monitors.get(agent_id)
@@ -771,7 +937,18 @@ async def handle_get_agent_metadata(arguments: Sequence[TextContent]) -> list:
     except Exception as e:
         logger.debug(f"Failed to cache metadata: {e}")
 
-    metadata_response = meta.to_dict()
+    metadata_response = _metadata_dict_for_response(
+        agent_id,
+        meta,
+        caller_uuid=caller_uuid,
+        operator_caller=operator_caller,
+    )
+    metadata_response["identity_view"] = _identity_view(
+        agent_id,
+        meta,
+        caller_uuid=caller_uuid,
+        operator_caller=operator_caller,
+    )
 
     # Add computed fields
     if monitor:

--- a/tests/test_lifecycle_agents.py
+++ b/tests/test_lifecycle_agents.py
@@ -252,6 +252,33 @@ class TestListAgentsLite:
             assert by_id["orphan-agent"]["parent_agent_id"] is None
 
     @pytest.mark.asyncio
+    async def test_lite_exposes_compact_supersession_metadata(self, server):
+        meta = make_agent_meta(status="archived", label="Parent", total_updates=20)
+        meta.lifecycle_events = [{
+            "event": "archived",
+            "reason": "lineage_succession",
+            "timestamp": "2026-06-14T01:23:12+00:00",
+        }]
+        server.agent_metadata = {"parent-agent": meta}
+
+        with patch_lifecycle_server(server):
+            from src.mcp_handlers.lifecycle.handlers import handle_list_agents
+            result = await handle_list_agents({
+                "lite": True,
+                "status_filter": "all",
+                "recent_days": 0,
+            })
+            data = _parse(result)
+
+        agent = data["agents"][0]
+        assert agent["last_lifecycle_event"] == "archived"
+        assert agent["last_lifecycle_reason"] == "lineage_succession"
+        assert agent["last_lifecycle_at"] == "2026-06-14T01:23:12+00:00"
+        assert agent["superseded"] is True
+        assert agent["superseded_reason"] == "lineage_succession"
+        assert "identity_view" not in agent
+
+    @pytest.mark.asyncio
     async def test_lite_redacts_uuid_ids_for_non_operator(self, server):
         parent_uuid = "11111111-2222-3333-4444-555555555555"
         child_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
@@ -645,6 +672,102 @@ class TestGetAgentMetadata:
             data = _parse(result)
             assert data.get("days_since_update") is not None
             assert data["days_since_update"] >= 2
+
+    @pytest.mark.asyncio
+    async def test_get_metadata_identity_view_redacts_non_operator_target(self, server):
+        parent_uuid = "11111111-2222-3333-4444-555555555555"
+        child_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        child_meta = make_agent_meta(
+            label="Child",
+            total_updates=3,
+            parent_agent_id=parent_uuid,
+            spawn_reason="new_session",
+            active_session_key="mcp:secret-session",
+        )
+        child_meta.to_dict.return_value.update({
+            "agent_id": child_uuid,
+            "parent_agent_id": parent_uuid,
+            "active_session_key": "mcp:secret-session",
+        })
+        server.agent_metadata = {
+            parent_uuid: make_agent_meta(label="Parent", total_updates=20),
+            child_uuid: child_meta,
+        }
+        server.monitors = {}
+
+        with patch_lifecycle_server(server), \
+             patch("src.cache.get_metadata_cache", side_effect=Exception("no cache")):
+            from src.mcp_handlers.lifecycle.handlers import handle_get_agent_metadata
+            result = await handle_get_agent_metadata({"target_agent": child_uuid})
+            data = _parse(result)
+
+        view = data["identity_view"]
+        assert data["agent_id"] == "Child"
+        assert data["agent_id_redacted"] is True
+        assert data["parent_agent_id"] == "Parent"
+        assert data["parent_agent_id_redacted"] is True
+        assert "active_session_key" not in data
+        assert data["active_session_key_redacted"] is True
+        assert view["current"]["id"] == "Child"
+        assert view["current"]["id_redacted"] is True
+        assert "session_key" not in view["current"]
+        assert view["lineage"]["parent_agent_id"] == "Parent"
+        assert view["lineage"]["parent_agent_id_redacted"] is True
+        assert view["lineage"]["spawn_reason"] == "new_session"
+        assert view["lineage"]["lineage_state"] == "declared"
+        assert view["lineage"]["lineage_state_source"] == "derived"
+
+    @pytest.mark.asyncio
+    async def test_get_metadata_identity_view_self_includes_session_key(self, server):
+        self_uuid = "11111111-2222-3333-4444-555555555555"
+        meta = make_agent_meta(
+            label="Self",
+            total_updates=20,
+            active_session_key="mcp:self-session",
+        )
+        meta.to_dict.return_value.update({
+            "agent_id": self_uuid,
+            "active_session_key": "mcp:self-session",
+        })
+        server.agent_metadata = {self_uuid: meta}
+        server.monitors = {}
+
+        with patch_lifecycle_server(server, require_registered=(self_uuid, None)), \
+             patch("src.mcp_handlers.context.get_context_agent_id", return_value=self_uuid):
+            from src.mcp_handlers.lifecycle.handlers import handle_get_agent_metadata
+            result = await handle_get_agent_metadata({})
+            data = _parse(result)
+
+        view = data["identity_view"]
+        assert data["agent_id"] == self_uuid
+        assert data["active_session_key"] == "mcp:self-session"
+        assert view["current"]["id"] == self_uuid
+        assert view["current"]["id_redacted"] is False
+        assert view["current"]["session_key"] == "mcp:self-session"
+        assert view["lineage"]["lineage_state"] == "no_lineage_declared"
+
+    @pytest.mark.asyncio
+    async def test_get_metadata_identity_view_marks_lineage_succession(self, server):
+        meta = make_agent_meta(status="archived", label="Parent", total_updates=20)
+        meta.lifecycle_events = [{
+            "event": "archived",
+            "reason": "lineage_succession",
+            "timestamp": "2026-06-14T01:23:12+00:00",
+        }]
+        server.agent_metadata = {"agent-1": meta}
+        server.monitors = {}
+
+        with patch_lifecycle_server(server, require_registered=("agent-1", None)):
+            from src.mcp_handlers.lifecycle.handlers import handle_get_agent_metadata
+            result = await handle_get_agent_metadata({})
+            data = _parse(result)
+
+        lifecycle = data["identity_view"]["lifecycle"]
+        assert lifecycle["latest_event"] == "archived"
+        assert lifecycle["latest_reason"] == "lineage_succession"
+        assert lifecycle["latest_at"] == "2026-06-14T01:23:12+00:00"
+        assert lifecycle["superseded"] is True
+        assert lifecycle["superseded_reason"] == "lineage_succession"
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- add compact lifecycle/supersession fields to agent list responses without adding full `identity_view` to lite rows
- add detail-only `identity_view` on `get_agent_metadata`, routed through existing UUID/session redaction gates
- surface superseded lineage state and lifecycle reason in the dashboard detail/card UI
- fix README examples to match current uppercase EISV response keys

## Validation

- `node --check dashboard/agents.js`
- `python3 scripts/diagnostics/check_doc_health.py`
- `python3 -m pytest -q tests/test_dashboard_static_allowlist.py tests/test_lifecycle_agents.py tests/test_lifecycle_recovery.py::TestGetAgentMetadataAdditional tests/test_handler_error_paths.py::test_nonexistent_resources` (`144 passed`)
- `python3 -m pytest -q tests/test_dashboard.py tests/test_dashboard_static_allowlist.py` (`41 passed`)
- browser smoke: dashboard loaded at `http://127.0.0.1:8767/dashboard`, agents panel rendered, no console errors
- `./scripts/dev/test-cache.sh` (`9708 passed, 25 skipped`)
- pre-push smoke (`138 passed, 8994 deselected`) and doc health clear

## Notes

- The list response stays compact; full identity semantics are only on metadata detail.
- `active_session_key` is operator/self detail-only and redacted for non-self callers.
- The dashboard consumes only the compact lifecycle fields for agent cards.
