### PR TITLE
fix(sentinel): surface governance pause + bounded server-gated self-recovery

### DIFF
--- a/elixir/sentinel/lib/unitares_sentinel/fleet_finding_emitter.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/fleet_finding_emitter.ex
@@ -139,7 +139,10 @@ defmodule UnitaresSentinel.FleetFindingEmitter do
         self_observation: true,
         summary:
           "Sentinel governance check-in refused: agent is PAUSED (circuit breaker), " <>
-            "paused_at=#{inspect(paused_at)}. Check-ins are dark until recovered."
+            "paused_at=#{inspect(paused_at)}. Check-ins are dark until recovered. " <>
+            "Bounded quick-resume is attempted once per episode but is server-gated on " <>
+            "coherence; a resident whose baseline coherence sits below that gate needs " <>
+            "operator review / threshold attention, not self-resume."
       }
 
       finding_opts =
@@ -359,15 +362,20 @@ defmodule UnitaresSentinel.FleetFindingEmitter do
     Logger.info("FleetFindingEmitter: [#{finding.severity}] #{cls_tag}#{finding.summary}")
   end
 
-  # Episode gate: disarm recovery after a governance refusal (no looping),
-  # re-arm once a check-in succeeds (no pause), otherwise hold the gate.
-  defp next_recovery_gate(state, result) do
-    case result do
-      %{recovery_outcome: :refused} -> true
-      %{checkin_pause: nil} -> false
-      _ -> Map.get(state, :recovery_blocked_episode?, false)
-    end
-  end
+  # Episode gate, in priority order:
+  #   1. A clean (non-paused) check-in means the episode cleared → re-arm.
+  #   2. Any recovery ATTEMPT this cycle (refused / granted / transport error)
+  #      disarms for the rest of the episode — strictly once-per-episode, so a
+  #      granted-but-still-paused or a flapping-transport outcome cannot loop.
+  #   3. Otherwise (paused, no attempt — already disarmed) hold the gate.
+  defp next_recovery_gate(_state, %{checkin_pause: nil}), do: false
+
+  defp next_recovery_gate(_state, %{recovery_outcome: outcome})
+       when outcome in [:refused, :recovered, :error],
+       do: true
+
+  defp next_recovery_gate(state, _result),
+    do: Map.get(state, :recovery_blocked_episode?, false)
 
   defp schedule_next_tick(state) do
     Process.send_after(self(), :tick, state.interval_ms + sample_jitter(state.jitter_ms))

--- a/elixir/sentinel/lib/unitares_sentinel/fleet_finding_emitter.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/fleet_finding_emitter.ex
@@ -37,7 +37,9 @@ defmodule UnitaresSentinel.FleetFindingEmitter do
           self_findings: [map()],
           posted_count: non_neg_integer(),
           checkin: map(),
-          checkin_result: {:ok, map()} | {:error, term()} | nil
+          checkin_result: {:ok, map()} | {:error, term()} | nil,
+          checkin_pause: map() | nil,
+          recovery_outcome: :recovered | :refused | :error | :not_attempted | :not_paused
         }
 
   @doc false
@@ -103,13 +105,94 @@ defmodule UnitaresSentinel.FleetFindingEmitter do
         GovernanceCheckin.checkin(checkin, Keyword.get(opts, :checkin_opts, []))
       end
 
+    pause = handle_checkin_pause(checkin_result, self_agent_id, opts)
+
     %{
       fleet_findings: fleet_findings,
       self_findings: self_findings,
       posted_count: posted_count,
       checkin: checkin,
-      checkin_result: checkin_result
+      checkin_result: checkin_result,
+      checkin_pause: pause.detail,
+      recovery_outcome: pause.recovery_outcome
     }
+  end
+
+  # The governance check-in surfaced a circuit-breaker PAUSE. Make it loud
+  # (warning + a deduped self-finding so the dark state is visible on the
+  # dashboard) and, if recovery is armed for this episode, ask governance for
+  # a bounded `quick` resume. Recovery is server-gated, so a refusal just
+  # leaves the resident surfaced for the operator rather than looping.
+  defp handle_checkin_pause({:error, {:agent_paused, detail}}, self_agent_id, opts) do
+    paused_at = Map.get(detail, "paused_at")
+
+    Logger.warning(
+      "FleetFindingEmitter: governance check-in REFUSED (AGENT_PAUSED) for #{self_agent_id} " <>
+        "paused_at=#{inspect(paused_at)} — resident is DARK to governance until recovered."
+    )
+
+    if Keyword.get(opts, :emit_findings, true) do
+      finding = %{
+        type: "sentinel_self_pause",
+        severity: "high",
+        violation_class: "BEH",
+        self_observation: true,
+        summary:
+          "Sentinel governance check-in refused: agent is PAUSED (circuit breaker), " <>
+            "paused_at=#{inspect(paused_at)}. Check-ins are dark until recovered."
+      }
+
+      finding_opts =
+        opts
+        |> Keyword.get(:findings_opts, [])
+        |> Keyword.put_new(:agent_id, self_agent_id)
+        |> Keyword.put_new(:agent_name, agent_name(opts))
+
+      Findings.post_finding(finding, finding_opts)
+    end
+
+    %{detail: detail, recovery_outcome: maybe_recover(opts)}
+  end
+
+  defp handle_checkin_pause(_checkin_result, _self_agent_id, _opts),
+    do: %{detail: nil, recovery_outcome: :not_paused}
+
+  # Bounded, once-per-episode recovery: the GenServer disarms (`recovery_armed?:
+  # false`) after a governance refusal so a single episode never loops. Default
+  # armed so a standalone tick still attempts one server-gated resume.
+  defp maybe_recover(opts) do
+    armed? = Keyword.get(opts, :recovery_armed?, true)
+
+    auto? =
+      Keyword.get(opts, :auto_recover, Application.get_env(:unitares_sentinel, :auto_recover, true))
+
+    if armed? and auto? do
+      case GovernanceCheckin.recover(Keyword.get(opts, :checkin_opts, [])) do
+        {:ok, _result} ->
+          Logger.warning("FleetFindingEmitter: bounded self-recovery GRANTED by governance.")
+          :recovered
+
+        {:error, {:agent_paused, _}} ->
+          Logger.warning("FleetFindingEmitter: self-recovery REFUSED (still paused) — staying surfaced.")
+          :refused
+
+        {:error, {:tool_error, reason}} ->
+          Logger.warning(
+            "FleetFindingEmitter: self-recovery REFUSED by governance (#{inspect(reason)}) — staying surfaced for operator."
+          )
+
+          :refused
+
+        {:error, reason} ->
+          Logger.warning(
+            "FleetFindingEmitter: self-recovery transport error (#{inspect(reason)}) — will retry next cycle."
+          )
+
+          :error
+      end
+    else
+      :not_attempted
+    end
   end
 
   @impl true
@@ -168,7 +251,11 @@ defmodule UnitaresSentinel.FleetFindingEmitter do
       lease_opts: Keyword.get(opts, :lease_opts, []),
       cycle_count: Keyword.get(opts, :cycle_count, 0),
       running?: false,
-      last_result: nil
+      last_result: nil,
+      # Disarmed for the rest of a pause episode once governance refuses a
+      # bounded recovery, so a single episode never loops pause→resume→pause.
+      # Re-armed when a check-in succeeds (episode cleared).
+      recovery_blocked_episode?: false
     }
 
     Process.send_after(self(), :tick, initial_delay_ms + sample_jitter(jitter_ms))
@@ -197,7 +284,13 @@ defmodule UnitaresSentinel.FleetFindingEmitter do
             schedule_next_tick(state)
 
             {:noreply,
-             %{state | running?: false, last_result: result, cycle_count: state.cycle_count + 1}}
+             %{
+               state
+               | running?: false,
+                 last_result: result,
+                 cycle_count: state.cycle_count + 1,
+                 recovery_blocked_episode?: next_recovery_gate(state, result)
+             }}
 
           :timeout ->
             Logger.warning(
@@ -213,8 +306,18 @@ defmodule UnitaresSentinel.FleetFindingEmitter do
     end
   end
 
-  defp await_runtime_tick(%{tick_timeout_ms: timeout_ms, opts: opts, cycle_count: cycle_count}) do
-    task = Task.async(fn -> tick(Keyword.put(opts, :cycle_count, cycle_count + 1)) end)
+  defp await_runtime_tick(%{
+         tick_timeout_ms: timeout_ms,
+         opts: opts,
+         cycle_count: cycle_count,
+         recovery_blocked_episode?: blocked?
+       }) do
+    tick_opts =
+      opts
+      |> Keyword.put(:cycle_count, cycle_count + 1)
+      |> Keyword.put(:recovery_armed?, not blocked?)
+
+    task = Task.async(fn -> tick(tick_opts) end)
     Process.unlink(task.pid)
 
     case Task.yield(task, timeout_ms) || Task.shutdown(task, :brutal_kill) do
@@ -254,6 +357,16 @@ defmodule UnitaresSentinel.FleetFindingEmitter do
     vcls = Map.get(finding, :violation_class, "")
     cls_tag = if vcls == "", do: "", else: "[#{vcls}] "
     Logger.info("FleetFindingEmitter: [#{finding.severity}] #{cls_tag}#{finding.summary}")
+  end
+
+  # Episode gate: disarm recovery after a governance refusal (no looping),
+  # re-arm once a check-in succeeds (no pause), otherwise hold the gate.
+  defp next_recovery_gate(state, result) do
+    case result do
+      %{recovery_outcome: :refused} -> true
+      %{checkin_pause: nil} -> false
+      _ -> Map.get(state, :recovery_blocked_episode?, false)
+    end
   end
 
   defp schedule_next_tick(state) do

--- a/elixir/sentinel/lib/unitares_sentinel/governance_checkin.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/governance_checkin.ex
@@ -142,10 +142,10 @@ defmodule UnitaresSentinel.GovernanceCheckin do
   Posts `self_recovery` (default `action=quick`) to the same `/v1/tools/call`
   surface with the session anchor identity. Recovery is **server-gated**:
   governance grants a quick resume only for safe states and refuses while the
-  underlying risk is still high, so this never forces a resume or neuters the
-  circuit breaker — it asks, and governance decides. A refusal comes back as a
-  `{:error, {:tool_error, _}}` (or `{:error, {:agent_paused, _}}`) and the
-  caller stays surfaced for the operator.
+  underlying risk is still high (or coherence sits below the quick-resume gate),
+  so this never forces a resume or neuters the circuit breaker — it asks, and
+  governance decides. A refusal (e.g. `NOT_SAFE_FOR_QUICK_RESUME`) comes back as
+  `{:error, {:tool_error, _}}` and the caller stays surfaced for the operator.
   """
   @spec recover(keyword()) :: {:ok, map()} | {:error, term()}
   def recover(opts \\ []) do

--- a/elixir/sentinel/lib/unitares_sentinel/governance_checkin.ex
+++ b/elixir/sentinel/lib/unitares_sentinel/governance_checkin.ex
@@ -114,10 +114,62 @@ defmodule UnitaresSentinel.GovernanceCheckin do
     end
   end
 
+  # A circuit-breaker / governance pause is NOT an ordinary tool error: the
+  # agent is dark to governance until recovered, and silently swallowing it
+  # (as a generic tool_error logged at :debug) is exactly how a paused
+  # resident stayed invisible for ~18h. Classify it distinctly so the caller
+  # can surface it and attempt a bounded, server-gated self-recovery.
+  defp ensure_tool_success(%{"success" => false, "error_code" => "AGENT_PAUSED"} = result),
+    do: {:error, {:agent_paused, pause_detail(result)}}
+
   defp ensure_tool_success(%{"success" => false} = result),
     do: {:error, {:tool_error, Map.get(result, "error", "unknown")}}
 
   defp ensure_tool_success(_result), do: :ok
+
+  defp pause_detail(result) do
+    %{
+      "error" => Map.get(result, "error", "Agent is paused and cannot process updates"),
+      "paused_at" => Map.get(result, "paused_at"),
+      "status" => Map.get(result, "status", "paused"),
+      "recovery" => Map.get(result, "recovery")
+    }
+  end
+
+  @doc """
+  Attempt a bounded self-recovery for a paused Sentinel identity.
+
+  Posts `self_recovery` (default `action=quick`) to the same `/v1/tools/call`
+  surface with the session anchor identity. Recovery is **server-gated**:
+  governance grants a quick resume only for safe states and refuses while the
+  underlying risk is still high, so this never forces a resume or neuters the
+  circuit breaker — it asks, and governance decides. A refusal comes back as a
+  `{:error, {:tool_error, _}}` (or `{:error, {:agent_paused, _}}`) and the
+  caller stays surfaced for the operator.
+  """
+  @spec recover(keyword()) :: {:ok, map()} | {:error, term()}
+  def recover(opts \\ []) do
+    anchor = Keyword.get(opts, :anchor, %{})
+
+    arguments =
+      %{"action" => Keyword.get(opts, :recovery_action, "quick")}
+      |> put_optional(
+        "reason",
+        Keyword.get(opts, :reason, "sentinel automated bounded recovery after governance pause")
+      )
+      |> put_optional("agent_id", Keyword.get(opts, :agent_id) || Map.get(anchor, "agent_uuid"))
+      |> put_optional(
+        "client_session_id",
+        Keyword.get(opts, :client_session_id) || Map.get(anchor, "client_session_id")
+      )
+      |> put_optional(
+        "continuity_token",
+        Keyword.get(opts, :continuity_token) || Map.get(anchor, "continuity_token")
+      )
+
+    %{"name" => "self_recovery", "arguments" => arguments}
+    |> post_json(opts)
+  end
 
   defp headers do
     base = [{"Content-Type", "application/json"}]

--- a/elixir/sentinel/test/unitares_sentinel/fleet_finding_emitter_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/fleet_finding_emitter_test.exs
@@ -370,4 +370,52 @@ defmodule UnitaresSentinel.FleetFindingEmitterTest do
 
     GenServer.stop(pid)
   end
+
+  test "GenServer does not re-attempt recovery after a GRANTED resume that did not clear the pause" do
+    parent = self()
+
+    # Recovery is GRANTED, but process_agent_update keeps reporting paused (the
+    # resume did not take / re-paused). A buggy gate that only disarms on
+    # :refused would re-attempt every cycle; the once-per-episode invariant must
+    # disarm on any attempt, granted included.
+    checkin_http_post = fn _url, body, _headers, _timeout_ms ->
+      case body["name"] do
+        "process_agent_update" ->
+          {:ok, 200,
+           Jason.encode!(%{
+             "success" => true,
+             "result" => %{"success" => false, "error_code" => "AGENT_PAUSED", "status" => "paused"}
+           })}
+
+        "self_recovery" ->
+          send(parent, :recovery_attempted)
+
+          {:ok, 200,
+           Jason.encode!(%{"success" => true, "result" => %{"lifecycle_status" => "active"}})}
+      end
+    end
+
+    {:ok, pid} =
+      FleetFindingEmitter.start_link(
+        name: :"test_fleet_finding_emitter_granted_#{System.unique_integer([:positive])}",
+        initial_delay_ms: 60_000,
+        interval_ms: 60_000,
+        jitter_ms: 0,
+        lease_advisory: false,
+        snapshot: %{agents: %{}, events: []},
+        analysis_fun: fn _s, _o -> [] end,
+        self_agent_id: "sentinel-test",
+        emit_checkins: true,
+        findings_opts: [http_post: fn _u, _b, _h, _t -> {:ok, 200, ~s({"success":true})} end],
+        checkin_opts: [url: "http://example.test/v1/tools/call", http_post: checkin_http_post]
+      )
+
+    send(pid, :tick)
+    assert_receive :recovery_attempted, 1_000
+
+    send(pid, :tick)
+    refute_receive :recovery_attempted, 300
+
+    GenServer.stop(pid)
+  end
 end

--- a/elixir/sentinel/test/unitares_sentinel/fleet_finding_emitter_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/fleet_finding_emitter_test.exs
@@ -226,4 +226,148 @@ defmodule UnitaresSentinel.FleetFindingEmitterTest do
 
     GenServer.stop(pid)
   end
+
+  defp paused_checkin_post(parent) do
+    fn _url, body, _headers, _timeout_ms ->
+      case body["name"] do
+        "process_agent_update" ->
+          send(parent, :checkin_attempted)
+
+          {:ok, 200,
+           Jason.encode!(%{
+             "success" => true,
+             "result" => %{
+               "success" => false,
+               "error" => "Agent is paused and cannot process updates",
+               "error_code" => "AGENT_PAUSED",
+               "paused_at" => "2026-06-13T23:40:11Z",
+               "status" => "paused"
+             }
+           })}
+
+        "self_recovery" ->
+          send(parent, {:recovery_attempted, body["arguments"]["action"]})
+
+          {:ok, 200,
+           Jason.encode!(%{"success" => true, "result" => %{"lifecycle_status" => "active"}})}
+      end
+    end
+  end
+
+  test "tick surfaces a governance pause and attempts a bounded server-gated recovery" do
+    parent = self()
+
+    findings_http_post = fn _url, body, _headers, _timeout_ms ->
+      send(parent, {:finding_posted, body})
+      {:ok, 200, ~s({"success":true})}
+    end
+
+    result =
+      FleetFindingEmitter.tick(
+        snapshot: %{agents: %{}, events: []},
+        analysis_fun: fn _s, _o -> [] end,
+        self_agent_id: "sentinel-test",
+        emit_checkins: true,
+        findings_opts: [http_post: findings_http_post],
+        checkin_opts: [
+          url: "http://example.test/v1/tools/call",
+          http_post: paused_checkin_post(parent),
+          agent_id: "sentinel-test"
+        ]
+      )
+
+    assert {:error, {:agent_paused, _}} = result.checkin_result
+    assert result.checkin_pause["status"] == "paused"
+    assert result.recovery_outcome == :recovered
+
+    assert_receive :checkin_attempted
+    assert_receive {:recovery_attempted, "quick"}
+    assert_receive {:finding_posted, finding}
+    assert finding["finding_type"] == "sentinel_self_pause"
+    assert finding["severity"] == "high"
+    assert finding["agent_id"] == "sentinel-test"
+  end
+
+  test "tick still surfaces a pause but does not attempt recovery when disarmed" do
+    parent = self()
+
+    findings_http_post = fn _url, body, _headers, _timeout_ms ->
+      send(parent, {:finding_posted, body})
+      {:ok, 200, ~s({"success":true})}
+    end
+
+    result =
+      FleetFindingEmitter.tick(
+        snapshot: %{agents: %{}, events: []},
+        analysis_fun: fn _s, _o -> [] end,
+        self_agent_id: "sentinel-test",
+        emit_checkins: true,
+        recovery_armed?: false,
+        findings_opts: [http_post: findings_http_post],
+        checkin_opts: [
+          url: "http://example.test/v1/tools/call",
+          http_post: paused_checkin_post(parent)
+        ]
+      )
+
+    assert result.recovery_outcome == :not_attempted
+    assert_receive {:finding_posted, finding}
+    assert finding["finding_type"] == "sentinel_self_pause"
+    refute_receive {:recovery_attempted, _action}, 100
+  end
+
+  test "GenServer attempts recovery only once per pause episode (no pause->resume loop)" do
+    parent = self()
+
+    # process_agent_update always reports paused; self_recovery is REFUSED, so
+    # the episode never clears and a buggy implementation would retry forever.
+    checkin_http_post = fn _url, body, _headers, _timeout_ms ->
+      case body["name"] do
+        "process_agent_update" ->
+          {:ok, 200,
+           Jason.encode!(%{
+             "success" => true,
+             "result" => %{
+               "success" => false,
+               "error_code" => "AGENT_PAUSED",
+               "status" => "paused"
+             }
+           })}
+
+        "self_recovery" ->
+          send(parent, :recovery_attempted)
+
+          {:ok, 200,
+           Jason.encode!(%{
+             "success" => true,
+             "result" => %{"success" => false, "error" => "Recovery thresholds not met"}
+           })}
+      end
+    end
+
+    {:ok, pid} =
+      FleetFindingEmitter.start_link(
+        name: :"test_fleet_finding_emitter_pause_#{System.unique_integer([:positive])}",
+        initial_delay_ms: 60_000,
+        interval_ms: 60_000,
+        jitter_ms: 0,
+        lease_advisory: false,
+        snapshot: %{agents: %{}, events: []},
+        analysis_fun: fn _s, _o -> [] end,
+        self_agent_id: "sentinel-test",
+        emit_checkins: true,
+        findings_opts: [http_post: fn _u, _b, _h, _t -> {:ok, 200, ~s({"success":true})} end],
+        checkin_opts: [url: "http://example.test/v1/tools/call", http_post: checkin_http_post]
+      )
+
+    send(pid, :tick)
+    assert_receive :recovery_attempted, 1_000
+
+    # Episode is now disarmed; a second tick on the same (still-paused) episode
+    # must NOT attempt recovery again.
+    send(pid, :tick)
+    refute_receive :recovery_attempted, 300
+
+    GenServer.stop(pid)
+  end
 end

--- a/elixir/sentinel/test/unitares_sentinel/governance_checkin_test.exs
+++ b/elixir/sentinel/test/unitares_sentinel/governance_checkin_test.exs
@@ -86,4 +86,72 @@ defmodule UnitaresSentinel.GovernanceCheckinTest do
     assert {:error, %RuntimeError{message: "connection refused"}} =
              GovernanceCheckin.checkin(summary(), http_post: http_post)
   end
+
+  test "checkin classifies a circuit-breaker pause distinctly from a generic tool error" do
+    http_post = fn _url, _body, _headers, _timeout_ms ->
+      {:ok, 200,
+       Jason.encode!(%{
+         "success" => true,
+         "result" => %{
+           "success" => false,
+           "error" => "Agent is paused and cannot process updates",
+           "error_code" => "AGENT_PAUSED",
+           "paused_at" => "2026-06-13T23:40:11.993752+00:00",
+           "status" => "paused",
+           "recovery" => %{"action" => "Use self_recovery(action='quick')"}
+         }
+       })}
+    end
+
+    assert {:error, {:agent_paused, detail}} =
+             GovernanceCheckin.checkin(summary(), http_post: http_post)
+
+    assert detail["paused_at"] == "2026-06-13T23:40:11.993752+00:00"
+    assert detail["status"] == "paused"
+    assert detail["recovery"]["action"] =~ "self_recovery"
+  end
+
+  test "recover posts self_recovery (quick) carrying the session anchor identity" do
+    parent = self()
+
+    http_post = fn url, body, _headers, _timeout_ms ->
+      send(parent, {:posted, url, body})
+
+      {:ok, 200,
+       Jason.encode!(%{
+         "success" => true,
+         "result" => %{"lifecycle_status" => "active", "previous_status" => "paused"}
+       })}
+    end
+
+    assert {:ok, %{"lifecycle_status" => "active"}} =
+             GovernanceCheckin.recover(
+               url: "http://example.test/v1/tools/call",
+               http_post: http_post,
+               anchor: %{
+                 "agent_uuid" => @agent_uuid,
+                 "client_session_id" => @client_session_id
+               }
+             )
+
+    assert_receive {:posted, "http://example.test/v1/tools/call", body}
+    assert body["name"] == "self_recovery"
+    assert body["arguments"]["action"] == "quick"
+    assert body["arguments"]["agent_id"] == @agent_uuid
+    assert body["arguments"]["client_session_id"] == @client_session_id
+    assert body["arguments"]["reason"] =~ "bounded recovery"
+  end
+
+  test "recover surfaces a governance refusal as an error (never forces resume)" do
+    http_post = fn _url, _body, _headers, _timeout_ms ->
+      {:ok, 200,
+       Jason.encode!(%{
+         "success" => true,
+         "result" => %{"success" => false, "error" => "Recovery thresholds not met"}
+       })}
+    end
+
+    assert {:error, {:tool_error, "Recovery thresholds not met"}} =
+             GovernanceCheckin.recover(http_post: http_post)
+  end
 end


### PR DESCRIPTION
## Why

Operator saw the dashboard report "Sentinel 44 days stale." Root cause: the BEAM Sentinel (`f92dcea8`) was **circuit-breaker PAUSED** at 2026-06-13 17:40 MDT (phi collapsed to ~0.12 → `risk=1.0` → `cirs_block`, while its EISV was otherwise healthy). Every check-in since returned `AGENT_PAUSED`, and the check-in client **swallowed it at `:debug`** while the emitter ignored `checkin_result` entirely — so the resident kept cycling leases while going completely dark to governance. It sat paused **~18h** before a human noticed. (Live agent has since been operator-resumed; this closes the blind spot.)

The dashboard's "44 days" is a *separate* display bug — `/v1/residents` resolves the "Sentinel" label to a dead duplicate identity `366a5c42` (last seen 2026-05-01). Left out of scope per operator.

## What

- **`GovernanceCheckin`**: classify `AGENT_PAUSED` distinctly (`{:error, {:agent_paused, detail}}`) instead of as a generic, unlogged tool error. Add `recover/1` → posts `self_recovery` (`action=quick`) on the same `/v1/tools/call` surface with the session-anchor identity.
- **`FleetFindingEmitter`**: on a paused check-in, log at `:warning` and emit a deduped high-severity `sentinel_self_pause` finding (the dark state becomes visible), then attempt recovery **once per pause episode**. The GenServer disarms recovery after *any* attempt and re-arms only on a clean (non-paused) check-in — so there is no pause→resume→pause loop.

### Server-gated, never forced
Recovery is `action=quick`, which governance grants only for safe states. A refusal leaves the resident **surfaced for the operator** and never neuters the breaker. Deliberately **no** `review`+canned-reflection fallback — auto-generating a reflection to clear the review gate would launder an auto-resume through the path meant to require thought ("pause is a hypothesis, not a verdict").

## Council review
Architect + code-reviewer + live-verifier (parallel, adversarial):
- **live-verifier** confirmed the REST path binds `agent_id` correctly (the #674 MCP fingerprint under-guard does *not* affect the REST `agent_id` early-resolution), so the fix is not inert plumbing-wise.
- **architect + reviewer** both independently caught a real `next_recovery_gate/2` bug (only disarmed on `:refused`; `:recovered`/`:error` re-armed and looped) — fixed + test added.
- Both endorsed quick-only over a review fallback.

## Follow-ups (out of scope, for operator)
- **Calibration**: `quick_resume` requires `coherence >= 0.60`, but residents' *normal* coherence is ~0.48 — so a resident can essentially never quick-recover, and a phi/coherence pause tuned to fleet-average fires on the Sentinel's healthy baseline. The finding text now says so.
- Dashboard duplicate-identity resolution (`366a5c42` vs live `f92dcea8`).

## Tests
`mix test` green (138, 0 failures). New: pause classification; `recover/1` body/identity + refusal; tick surfacing + armed/disarmed recovery; two GenServer tests pinning the once-per-episode no-loop invariant (refused path + granted-but-still-paused path).