### PR TITLE
fix(governance): floor EISV z-score sensitivity for stable agents + anchor quick-resume to target coherence

### DIFF
--- a/src/agent_behavioral_baseline.py
+++ b/src/agent_behavioral_baseline.py
@@ -42,11 +42,21 @@ class WelfordStats:
     def std(self) -> float:
         return math.sqrt(self.variance)
 
-    def z_score(self, value: float) -> float:
-        """Z-score of value relative to running stats. Returns 0.0 if insufficient data."""
-        if self.count < 5 or self.std < 1e-9:
+    def z_score(self, value: float, min_std: float = 0.0) -> float:
+        """Z-score of value relative to running stats. Returns 0.0 if insufficient data.
+
+        ``min_std`` floors the denominator at a minimum meaningful resolution.
+        Without it, an ultra-stable signal (tiny baseline variance) turns a
+        small, characteristically-irrelevant change into a many-sigma event.
+        Default 0.0 keeps the bare ``1e-9`` div-by-zero guard for callers that
+        score signals with no meaningful absolute scale.
+        """
+        if self.count < 5:
             return 0.0
-        return (value - self.mean) / self.std
+        effective_std = max(self.std, min_std)
+        if effective_std < 1e-9:
+            return 0.0
+        return (value - self.mean) / effective_std
 
     def to_dict(self) -> dict:
         return {"count": self.count, "mean": self.mean, "m2": self.m2}

--- a/src/behavioral_state.py
+++ b/src/behavioral_state.py
@@ -42,6 +42,18 @@ BOOTSTRAP_UPDATES = 10
 # 30 gives stable mean/std estimates.
 BASELINE_WARMUP_UPDATES = 30
 
+# Minimum meaningful standard deviation for EISV self-relative scoring.
+# EISV dimensions are bounded [0,1] (V is [-1,1]); a characteristic deviation
+# below ~5% of range is below the meaningful behavioral resolution. Without a
+# floor, an ultra-stable agent (e.g. a long-running monitor whose baseline
+# variance is ~0.01) turns a small, absolutely-healthy fluctuation into a
+# many-sigma "severe deviation" and gets falsely flagged high-risk → paused.
+# A floor caps that sensitivity while preserving genuine multi-tenth moves and
+# the absolute safety floors. Empirically: the Sentinel pause of 2026-06-13
+# (E 0.77→0.66, I 0.68→0.66 — both healthy) scored risk 0.94 (high-risk) with
+# no floor vs 0.33 (safe) at 0.05, while genuine degradations are unchanged.
+MIN_MEANINGFUL_EISV_STD = 0.05
+
 
 @dataclass
 class BehavioralEISV:
@@ -201,7 +213,7 @@ class BehavioralEISV:
         if stats is None or not self.is_baselined:
             return 0.0
         current = getattr(self, dimension, 0.5)
-        return stats.z_score(current)
+        return stats.z_score(current, min_std=MIN_MEANINGFUL_EISV_STD)
 
     def trend(self, dimension: str, window: int = 5) -> float:
         """Simple slope of recent history for a dimension.

--- a/src/behavioral_state.py
+++ b/src/behavioral_state.py
@@ -43,15 +43,24 @@ BOOTSTRAP_UPDATES = 10
 BASELINE_WARMUP_UPDATES = 30
 
 # Minimum meaningful standard deviation for EISV self-relative scoring.
-# EISV dimensions are bounded [0,1] (V is [-1,1]); a characteristic deviation
-# below ~5% of range is below the meaningful behavioral resolution. Without a
-# floor, an ultra-stable agent (e.g. a long-running monitor whose baseline
-# variance is ~0.01) turns a small, absolutely-healthy fluctuation into a
-# many-sigma "severe deviation" and gets falsely flagged high-risk → paused.
-# A floor caps that sensitivity while preserving genuine multi-tenth moves and
-# the absolute safety floors. Empirically: the Sentinel pause of 2026-06-13
-# (E 0.77→0.66, I 0.68→0.66 — both healthy) scored risk 0.94 (high-risk) with
-# no floor vs 0.33 (safe) at 0.05, while genuine degradations are unchanged.
+#
+# This is an EMPIRICAL constant calibrated against the 2026-06-13 Sentinel
+# false-pause trace — NOT a value derived from EISV [0,1] semantics. Note the
+# baseline std is computed over EMA-SMOOTHED E/I/S/V (see _baseline updates
+# below), so a steady agent's std collapses toward ~0.01 partly because the
+# EMA has already eaten the raw observation noise. Without a floor, that
+# artifact makes z = Δ/σ explode: an ultra-stable monitor turns a small,
+# absolutely-healthy fluctuation into a many-sigma "severe deviation" and gets
+# falsely flagged high-risk → cirs_block → paused. The floor caps that
+# sensitivity while leaving genuine multi-tenth moves and the absolute safety
+# floors (E/I<0.30, S>0.70, |V|>0.50) untouched. Empirically: the Sentinel
+# pause (E 0.77→0.66, I 0.68→0.66 — both healthy) scored risk 0.94 (high-risk)
+# with no floor vs 0.33 (safe) at 0.05; genuine degradations are unchanged.
+#
+# A flat floor is the blunt form of the more principled fix (gate self-relative
+# risk by absolute basin health); see the "health-gating" follow-up. A flat
+# value also slightly over-floors slow-alpha dimensions (I) and under-floors
+# fast-alpha ones (S) since the per-dimension EMA step differs.
 MIN_MEANINGFUL_EISV_STD = 0.05
 
 

--- a/src/mcp_handlers/lifecycle/self_recovery.py
+++ b/src/mcp_handlers/lifecycle/self_recovery.py
@@ -186,7 +186,7 @@ async def handle_self_recovery(arguments: Dict[str, Any]) -> Sequence[TextConten
 
     Actions:
         check  - See what recovery options are available (read-only)
-        quick  - Fast resume for safe states (coherence > 0.60, risk < 0.40)
+        quick  - Fast resume for safe states (coherence >= target ~0.50, risk < 0.40)
         review - Full recovery with reflection (for moderate states)
 
     Natural workflow:
@@ -325,7 +325,7 @@ async def handle_quick_resume(arguments: Dict[str, Any]) -> Sequence[TextContent
     Quick resume for agents in clearly safe states - no reflection required.
     
     This is the fastest path to recovery when:
-    - coherence > 0.60 (high confidence state)
+    - coherence >= target coherence (~0.50, "good" or better)
     - risk < 0.40 (low risk)
     - no void active
     - status is waiting_input or paused
@@ -395,8 +395,13 @@ async def handle_quick_resume(arguments: Dict[str, Any]) -> Sequence[TextContent
     except Exception as e:
         return [error_response(f"Could not assess state: {e}")]
     
-    # Strict safety checks for quick_resume (stricter than self_recovery_review)
-    QUICK_RESUME_MIN_COHERENCE = 0.60
+    # Strict safety checks for quick_resume (stricter than self_recovery_review).
+    # Coherence gate is anchored to the config's target/"good" coherence rather
+    # than a hardcoded 0.60: the old value sat ABOVE TARGET_COHERENCE (0.50), so
+    # an agent at its healthy target coherence could never quick-resume. risk_low
+    # (<=0.40) remains the substantive safety gate — a genuinely risky paused
+    # agent still cannot quick-resume regardless of coherence.
+    QUICK_RESUME_MIN_COHERENCE = GovernanceConfig.TARGET_COHERENCE  # 0.50
     QUICK_RESUME_MAX_RISK = 0.40
 
     # Uninitialized agents (0 check-ins) have default EISV values (~0.5) which

--- a/tests/test_self_recovery.py
+++ b/tests/test_self_recovery.py
@@ -396,6 +396,67 @@ class TestQuickResume:
             assert data.get("success") is True or data.get("recovered") is True
 
     @pytest.mark.asyncio
+    async def test_quick_resume_allows_target_coherence(self):
+        # Coherence at the config target (~0.50) with low risk must quick-resume.
+        # The old hardcoded 0.60 gate sat ABOVE target, so a healthy agent at
+        # its target coherence could never quick-resume — that was the bug.
+        from src.mcp_handlers.lifecycle.self_recovery import handle_quick_resume
+        from config.governance_config import GovernanceConfig
+
+        mock_server = self._make_mock_server(coherence=GovernanceConfig.TARGET_COHERENCE + 0.02, risk=0.2)
+
+        with patch(
+            "src.mcp_handlers.lifecycle.self_recovery.require_registered_agent",
+            return_value=("test-agent", None),
+        ), patch(
+            "src.mcp_handlers.lifecycle.self_recovery.verify_agent_ownership",
+            return_value=True,
+        ), patch(
+            "src.mcp_handlers.lifecycle.self_recovery.mcp_server",
+            mock_server,
+        ), patch(
+            "src.mcp_handlers.lifecycle.self_recovery.store_discovery_internal",
+            new_callable=AsyncMock,
+            create=True,
+        ), patch(
+            "src.agent_storage.update_agent",
+            new_callable=AsyncMock,
+        ), patch(
+            "src.agent_storage.persist_runtime_state",
+            new_callable=AsyncMock,
+        ):
+            result = await handle_quick_resume({"_agent_uuid": "test-uuid"})
+            text = json.loads(result[0].text)
+            data = text.get("data", text)
+            assert data.get("success") is True or data.get("recovered") is True
+
+    @pytest.mark.asyncio
+    async def test_quick_resume_high_risk_still_refused_at_good_coherence(self):
+        # Re-anchoring the coherence gate must NOT weaken the substantive safety
+        # gate: a genuinely risky agent (risk > 0.40) is refused even at healthy
+        # coherence.
+        from src.mcp_handlers.lifecycle.self_recovery import handle_quick_resume
+
+        mock_server = self._make_mock_server(coherence=0.7, risk=0.6)
+
+        with patch(
+            "src.mcp_handlers.lifecycle.self_recovery.require_registered_agent",
+            return_value=("test-agent", None),
+        ), patch(
+            "src.mcp_handlers.lifecycle.self_recovery.verify_agent_ownership",
+            return_value=True,
+        ), patch(
+            "src.mcp_handlers.lifecycle.self_recovery.mcp_server",
+            mock_server,
+        ), patch(
+            "src.agent_storage.persist_runtime_state",
+            new_callable=AsyncMock,
+        ):
+            result = await handle_quick_resume({"_agent_uuid": "test-uuid"})
+            text = json.loads(result[0].text)
+            assert "error" in text or "NOT_SAFE" in str(text)
+
+    @pytest.mark.asyncio
     async def test_quick_resume_unsafe_state(self):
         from src.mcp_handlers.lifecycle.self_recovery import handle_quick_resume
         mock_server = self._make_mock_server(coherence=0.4, risk=0.6)

--- a/tests/test_stable_agent_risk_calibration.py
+++ b/tests/test_stable_agent_risk_calibration.py
@@ -59,6 +59,18 @@ class TestWelfordSigmaFloor:
             s.update(v)
         assert s.z_score(0.9, min_std=0.05) == 0.0
 
+    def test_zero_variance_with_floor_scores_at_floor(self):
+        # Exactly-zero variance: with min_std=0 the 1e-9 guard returns 0.0
+        # (unchanged); with min_std=0.05 a move now scores at the floor scale
+        # rather than being invisible. Intended regime change — pinned here.
+        s = WelfordStats()
+        for _ in range(10):
+            s.update(0.5)
+        assert s.std == 0.0
+        assert s.z_score(0.6) == 0.0  # default min_std=0.0 → unchanged
+        assert s.z_score(0.6, min_std=0.05) == pytest.approx((0.6 - 0.5) / 0.05)
+        assert s.z_score(0.5, min_std=0.05) == 0.0  # no move → no deviation
+
     def test_large_move_still_scores_with_floor(self):
         # A genuine, large deviation must still register even with the floor.
         s = WelfordStats()

--- a/tests/test_stable_agent_risk_calibration.py
+++ b/tests/test_stable_agent_risk_calibration.py
@@ -1,0 +1,94 @@
+"""Calibration: ultra-stable agents must not be falsely flagged high-risk for
+small, absolutely-healthy EISV wobbles.
+
+Regression for the 2026-06-13 Sentinel pause: a long-running monitor with a
+very tight behavioral baseline (std ~0.007-0.024) had a perfectly healthy
+fluctuation (E 0.77->0.66, I 0.68->0.66) scored as a many-sigma "severe
+deviation" -> risk 0.94 -> high-risk -> cirs_block -> paused ~18h. The
+MIN_MEANINGFUL_EISV_STD floor caps z-score sensitivity at a meaningful
+resolution while preserving genuine multi-tenth moves and absolute floors.
+"""
+
+import pytest
+
+from src.agent_behavioral_baseline import WelfordStats
+from src.behavioral_state import BehavioralEISV, MIN_MEANINGFUL_EISV_STD
+from src.behavioral_assessment import assess_behavioral_state, RISK_CAUTION_THRESHOLD
+
+
+# Real captured Sentinel baseline (1239 updates) at the moment of the false pause.
+_SENTINEL_BASELINE = {
+    "E": (0.7729981068548344, 0.7055579515066273),
+    "I": (0.6811142748149669, 0.057464469736054416),
+    "S": (0.23501023019317843, 2.5585618595179382),
+    "V": (0.09186701608785974, 0.3958598283268047),
+}
+_SENTINEL_PAUSE_STATE = {"E": 0.6608, "I": 0.6572, "S": 0.379, "V": 0.046}
+
+
+def _baselined(mean_m2, current, count=1239):
+    st = BehavioralEISV()
+    for dim, (mean, m2) in mean_m2.items():
+        bl = getattr(st, f"_baseline_{dim}")
+        bl.count, bl.mean, bl.m2 = count, mean, m2
+    for dim, val in current.items():
+        setattr(st, dim, val)
+    st.update_count = count
+    return st
+
+
+class TestWelfordSigmaFloor:
+    def test_min_std_caps_sensitivity_for_tight_variance(self):
+        s = WelfordStats()
+        for v in (0.500, 0.501, 0.499, 0.500, 0.501, 0.499):  # std ~0.0009
+            s.update(v)
+        raw = s.z_score(0.60)
+        floored = s.z_score(0.60, min_std=0.05)
+        assert abs(floored) < abs(raw)
+        assert abs(floored) == pytest.approx(abs(0.60 - s.mean) / 0.05, rel=1e-3)
+
+    def test_default_call_unchanged(self):
+        s = WelfordStats()
+        for v in (0.1, 0.5, 0.9, 0.3, 0.7):
+            s.update(v)
+        assert s.z_score(0.5) == pytest.approx((0.5 - s.mean) / s.std)
+
+    def test_below_min_count_returns_zero(self):
+        s = WelfordStats()
+        for v in (0.5, 0.5, 0.5):  # count < 5
+            s.update(v)
+        assert s.z_score(0.9, min_std=0.05) == 0.0
+
+    def test_large_move_still_scores_with_floor(self):
+        # A genuine, large deviation must still register even with the floor.
+        s = WelfordStats()
+        for v in (0.500, 0.501, 0.499, 0.500, 0.501):
+            s.update(v)
+        z = s.z_score(0.95, min_std=0.05)  # +0.45 from mean
+        assert abs(z) >= 3.0
+
+
+class TestStableSentinelNotFalselyPaused:
+    def test_small_healthy_wobble_is_not_high_risk(self):
+        state = _baselined(_SENTINEL_BASELINE, _SENTINEL_PAUSE_STATE)
+        result = assess_behavioral_state(state, rho=0.0)
+        # With the floor this small, absolutely-healthy wobble is no longer
+        # high-risk (it scored 0.94 / high-risk before the floor).
+        assert result.verdict != "high-risk"
+        assert result.risk < RISK_CAUTION_THRESHOLD
+
+    def test_genuine_entropy_spike_still_flags(self):
+        # The same tight baseline, but a real large entropy excursion must
+        # still produce a non-zero high_S risk component (floor preserves signal).
+        state = _baselined(_SENTINEL_BASELINE, {"E": 0.773, "I": 0.681, "S": 0.70, "V": 0.092})
+        result = assess_behavioral_state(state, rho=0.0)
+        assert result.components.get("high_S", 0.0) > 0.0
+
+
+class TestDeviationUsesFloor:
+    def test_deviation_applies_min_std(self):
+        state = _baselined(_SENTINEL_BASELINE, _SENTINEL_PAUSE_STATE)
+        # E moved 0.112 from a baseline whose true std is ~0.024; without the
+        # floor this is ~-4.7 sigma, with the 0.05 floor it is ~-2.24.
+        z_E = state.deviation("E")
+        assert z_E == pytest.approx((0.6608 - 0.7729981068548344) / MIN_MEANINGFUL_EISV_STD, rel=1e-2)


### PR DESCRIPTION
## Why

Follow-up to the Sentinel false-pause (see #685). The Sentinel was circuit-breaker paused for ~18h on 2026-06-13 despite **healthy** EISV. Root cause traced here: after baselining, behavioral risk uses **self-relative z-scoring** against each agent's own baseline. For an ultra-stable agent (a long-running monitor; baseline std ~0.007–0.024) a tiny, absolutely-healthy fluctuation becomes a many-σ "severe deviation":

```
E 0.77→0.66  →  z = −4.70  →  low_E = 0.30 (max)
I 0.68→0.66  →  z = −3.51  →  low_I = 0.30 (max)
                              → risk 0.94 → high-risk → cirs_block → paused
```

Two distinct mis-calibrations:

**1. No σ-floor on EISV z-scoring** (`WelfordStats.z_score` only floored at `1e-9`). Fix: optional `min_std` (default `0.0` — existing/tracked-signal callers unchanged), and `BehavioralEISV.deviation()` passes `MIN_MEANINGFUL_EISV_STD = 0.05`. Empirically the Sentinel state drops **0.94 → 0.33 (safe)** while genuine large excursions and the absolute safety floors (E/I<0.30, S>0.70, |V|>0.50) are unchanged. The constant is **empirical** (calibrated to the trace), and the σ it floors is over EMA-smoothed values — so the floor corrects a double-smoothing artifact (documented honestly in the comment).

**2. Quick-resume coherence gate above "good"** — `QUICK_RESUME_MIN_COHERENCE` was a hardcoded `0.60`, *above* the system's own `TARGET_COHERENCE`/"good" coherence (`0.50`), so a healthy agent at target coherence could never quick-resume. Now anchored to `GovernanceConfig.TARGET_COHERENCE`. `risk_low (≤0.40)` remains the substantive safety gate — a genuinely risky paused agent still cannot quick-resume.

## Blast radius
~21 of 96 recently-baselined agents have tight enough baselines (σ<0.05 on E or I) to be affected by the floor — exactly the hypersensitive class.

## Council (architect + reviewer + live-verifier, adversarial)
- **live-verifier (live data): SAFE-TO-SHIP.** 47/57 high-risk events in the last 14d are the Sentinel's spurious tight-baseline amplification (all resolved by the floor). **0 agents found where the floor masks a genuinely degraded state** — absolute floors still fire on real cases (e.g. Lumen E=0.146). The other 6 high-risk agents are non-baselined (floor has no effect).
- **reviewer: clean**, no critical/important issues — `min_std` isolated to the EISV path (tracked signals untouched), zero-variance handled, re-anchor safe.
- **architect: ship-with-changes** (applied): honest grounding of the 0.05 constant + a zero-variance test.

## Follow-ups (not in this PR, for operator)
- **Principled end-state**: convert the flat σ-floor to **absolute-basin-health gating** (only let self-relative deviations raise risk when absolute EISV leaves the healthy basin) — the `_score_absolute_floors` machinery already exists.
- **Side finding**: `core.agent_state.entropy` column holds **phi**, not behavioral E — monitoring/queries filtering on it as "energy" read the wrong field (use `state_json->'behavioral_eisv'->>'E'`).
- After this + #685 land, watch both false-pause rate **and** missed-genuine-pause rate (the floor's failure mode is silent under-detection).

## Tests
Full suite green (`9728 passed, 34 skipped`). New: `WelfordStats` floor (caps tight variance, default unchanged, count<5, zero-variance, large-move-still-scores); Sentinel state no longer high-risk while a genuine entropy spike still flags; `deviation()` applies the floor; quick-resume allowed at target coherence but still refused at high risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)