### PR TITLE
feat(governance): escalate paused residents to the operator

### DIFF
--- a/src/background_tasks.py
+++ b/src/background_tasks.py
@@ -1172,6 +1172,19 @@ _silence_critical_alerted: set[str] = set()
 _silence_duplicate_warned: set[str] = set()
 _silence_server_start: datetime | None = None  # set on first iteration
 
+# Resident-pause escalation. The silence detector above only inspects
+# status=="active" agents, so a PAUSED resident is invisible to it — that is
+# exactly how a paused Sentinel stayed dark for ~18h. A one-shot lifecycle_paused
+# event fires at pause time, but it is not critical-severity and does not
+# distinguish a load-bearing resident from a routine ephemeral-agent pause, so it
+# scrolls away. This watchdog re-checks the explicit paused state of configured
+# residents and escalates (critical → #alerts via the bridge), re-nagging while
+# the resident stays paused. Keyed on the explicit status, so it is immune to the
+# silence-inference fragilities (proxy-alive suppression, server-restart clock
+# reset, duplicate-identity blindness).
+_resident_pause_alerted: dict[str, datetime] = {}  # agent_id -> last escalation time
+RESIDENT_PAUSE_REALERT_SECONDS = 3600  # re-nag at most hourly while still paused
+
 # Proxy agents whose recent activity proves another agent is alive.
 # Maps agent label → label of the proxy agent that calls the same host.
 # When the proxy has checked in recently, a missing direct check-in is
@@ -1427,6 +1440,81 @@ async def _silence_check_iteration() -> None:
     _silence_duplicate_warned.intersection_update(active_ids)
 
 
+async def _resident_pause_check_iteration() -> None:
+    """Escalate configured residents stuck in a paused (circuit-breaker) state.
+
+    The silence detector skips non-active agents, so a paused resident is
+    otherwise unmonitored. Keyed on the explicit ``meta.status == "paused"``
+    state (not silence inference), so proxy-alive suppression, server-restart
+    clock resets, and duplicate-identity blindness cannot hide it. Emits a
+    critical ``lifecycle_resident_paused`` event (the bridge routes
+    severity=critical to #alerts) and re-nags at most hourly while still paused.
+    """
+    from src.agent_metadata_model import agent_metadata
+    from src.broadcaster import broadcaster_instance
+    from src.audit_db import append_audit_event_async
+
+    try:
+        from src.grounding.class_indicator import KNOWN_RESIDENT_LABELS
+    except Exception:
+        KNOWN_RESIDENT_LABELS = frozenset()
+
+    now = datetime.now(timezone.utc)
+    paused_resident_ids: set[str] = set()
+
+    for agent_id, meta in list(agent_metadata.items()):
+        if getattr(meta, "status", None) != "paused":
+            continue
+        label = getattr(meta, "label", None)
+        if not label or label not in KNOWN_RESIDENT_LABELS:
+            continue
+
+        paused_resident_ids.add(agent_id)
+
+        last_alert = _resident_pause_alerted.get(agent_id)
+        if last_alert is not None and (now - last_alert).total_seconds() < RESIDENT_PAUSE_REALERT_SECONDS:
+            continue  # already escalated recently — don't spam
+
+        _resident_pause_alerted[agent_id] = now
+
+        paused_at_dt = _parse_last_update_aware(getattr(meta, "paused_at", None) or "")
+        paused_minutes = (now - paused_at_dt).total_seconds() / 60 if paused_at_dt else None
+        dur = f"{paused_minutes:.0f}m" if paused_minutes is not None else "unknown duration"
+
+        logger.error(
+            f"[RESIDENT_PAUSE] CRITICAL: resident {label} ({agent_id[:12]}) paused for {dur} "
+            "— dark to governance until recovered; escalating to operator."
+        )
+        await broadcaster_instance.broadcast_event(
+            "lifecycle_resident_paused",
+            agent_id=agent_id,
+            payload={
+                "severity": "critical",
+                "label": label,
+                "paused_at": getattr(meta, "paused_at", None),
+                "paused_minutes": round(paused_minutes, 1) if paused_minutes is not None else None,
+                "note": (
+                    "Configured resident is paused and dark to governance. "
+                    "Operator action: review and resume."
+                ),
+            },
+        )
+        await append_audit_event_async({
+            "timestamp": now.isoformat(),
+            "event_type": "resident_paused_escalation",
+            "agent_id": agent_id,
+            "details": {
+                "label": label,
+                "paused_minutes": round(paused_minutes, 1) if paused_minutes is not None else None,
+            },
+        })
+
+    # Re-arm: forget residents that are no longer paused so a future pause
+    # escalates immediately rather than waiting out the re-nag window.
+    for aid in [aid for aid in _resident_pause_alerted if aid not in paused_resident_ids]:
+        del _resident_pause_alerted[aid]
+
+
 async def check_agent_silence():
     """Detect persistent agents that have missed expected check-ins."""
     await asyncio.sleep(120)  # startup delay
@@ -1435,6 +1523,11 @@ async def check_agent_silence():
             await _silence_check_iteration()
         except Exception as e:
             logger.debug(f"[SILENCE] Check failed: {e}")
+
+        try:
+            await _resident_pause_check_iteration()
+        except Exception as e:
+            logger.debug(f"[RESIDENT_PAUSE] Check failed: {e}")
 
         await asyncio.sleep(600)  # every 10 minutes
 

--- a/tests/test_resident_pause_escalation.py
+++ b/tests/test_resident_pause_escalation.py
@@ -1,0 +1,128 @@
+"""Resident-pause escalation.
+
+A configured resident stuck in a paused (circuit-breaker) state must escalate to
+the operator. The silence detector only inspects status=="active" agents, so a
+paused resident is otherwise unmonitored — that is how a paused Sentinel stayed
+dark to governance for ~18h on 2026-06-13 with no operator-facing alert.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src import background_tasks
+from src.agent_metadata_model import AgentMetadata, agent_metadata
+
+
+@pytest.fixture
+def isolated_pause_state(monkeypatch):
+    agent_metadata.clear()
+    background_tasks._resident_pause_alerted.clear()
+
+    broadcaster = AsyncMock()
+    audit = AsyncMock()
+    import src.broadcaster as broadcaster_module
+    import src.audit_db as audit_module
+
+    monkeypatch.setattr(broadcaster_module, "broadcaster_instance", broadcaster)
+    monkeypatch.setattr(audit_module, "append_audit_event_async", audit)
+
+    yield broadcaster, audit
+
+    agent_metadata.clear()
+    background_tasks._resident_pause_alerted.clear()
+
+
+def _paused_resident(agent_id: str, label: str, paused_minutes_ago: int = 30) -> AgentMetadata:
+    now_iso = datetime.now(timezone.utc).isoformat()
+    paused_at = (datetime.now(timezone.utc) - timedelta(minutes=paused_minutes_ago)).isoformat()
+    return AgentMetadata(
+        agent_id=agent_id,
+        status="paused",
+        created_at=now_iso,
+        last_update=paused_at,
+        label=label,
+        paused_at=paused_at,
+    )
+
+
+@pytest.mark.asyncio
+async def test_paused_resident_escalates_critical(isolated_pause_state):
+    broadcaster, audit = isolated_pause_state
+    agent_metadata["sentinel-uuid"] = _paused_resident("sentinel-uuid", "Sentinel")
+
+    await background_tasks._resident_pause_check_iteration()
+
+    broadcaster.broadcast_event.assert_awaited_once()
+    call = broadcaster.broadcast_event.await_args
+    assert call.args[0] == "lifecycle_resident_paused"
+    assert call.kwargs["agent_id"] == "sentinel-uuid"
+    # severity=critical is what the bridge routes to #alerts
+    assert call.kwargs["payload"]["severity"] == "critical"
+    assert call.kwargs["payload"]["label"] == "Sentinel"
+    assert call.kwargs["payload"]["paused_minutes"] is not None
+    audit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_paused_ephemeral_agent_not_escalated(isolated_pause_state):
+    # Routine ephemeral-agent pauses must NOT page the operator.
+    broadcaster, _ = isolated_pause_state
+    agent_metadata["eph-uuid"] = _paused_resident("eph-uuid", "claude_code-claude_abcd")
+
+    await background_tasks._resident_pause_check_iteration()
+
+    broadcaster.broadcast_event.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_active_resident_not_escalated(isolated_pause_state):
+    broadcaster, _ = isolated_pause_state
+    now_iso = datetime.now(timezone.utc).isoformat()
+    agent_metadata["sentinel-uuid"] = AgentMetadata(
+        agent_id="sentinel-uuid",
+        status="active",
+        created_at=now_iso,
+        last_update=now_iso,
+        label="Sentinel",
+    )
+
+    await background_tasks._resident_pause_check_iteration()
+
+    broadcaster.broadcast_event.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_respam_within_renag_window(isolated_pause_state):
+    broadcaster, _ = isolated_pause_state
+    agent_metadata["sentinel-uuid"] = _paused_resident("sentinel-uuid", "Sentinel")
+
+    await background_tasks._resident_pause_check_iteration()
+    await background_tasks._resident_pause_check_iteration()  # immediate second pass
+
+    broadcaster.broadcast_event.assert_awaited_once()  # throttled within re-nag window
+
+
+@pytest.mark.asyncio
+async def test_rearm_after_resume(isolated_pause_state):
+    broadcaster, _ = isolated_pause_state
+    meta = _paused_resident("sentinel-uuid", "Sentinel")
+    agent_metadata["sentinel-uuid"] = meta
+
+    await background_tasks._resident_pause_check_iteration()
+    assert "sentinel-uuid" in background_tasks._resident_pause_alerted
+
+    # Resident resumes → watchdog re-arms (forgets it).
+    meta.status = "active"
+    meta.paused_at = None
+    await background_tasks._resident_pause_check_iteration()
+    assert "sentinel-uuid" not in background_tasks._resident_pause_alerted
+
+    # Pauses again → escalates immediately (not throttled).
+    meta.status = "paused"
+    meta.paused_at = datetime.now(timezone.utc).isoformat()
+    await background_tasks._resident_pause_check_iteration()
+    assert broadcaster.broadcast_event.await_count == 2


### PR DESCRIPTION
## Why

Answers "should any resident have caught the 18h Sentinel pause?" — **no layer did**, and the precise hole is one line: the silence detector (`_silence_check_iteration`) starts each agent with `if meta.status != "active": continue`, so **a paused resident is skipped entirely** and never monitored. The fleet monitor (Sentinel) is also self-blind by design (`self_observation` findings are split out), and Vigil only checks governance/Lumen HTTP health — not peer-resident lifecycle. A one-shot `lifecycle_paused` event does fire at pause time, but it isn't critical-severity and doesn't distinguish a load-bearing resident from routine ephemeral-agent pauses, so it scrolls past in `#events`.

## What
`_resident_pause_check_iteration`, run on the existing `check_agent_silence` loop (every 10 min): any configured resident (`KNOWN_RESIDENT_LABELS` = Lumen/Vigil/Sentinel/Watcher/Steward/Chronicler) in `status=="paused"` emits a **critical** `lifecycle_resident_paused` event + audit row, re-nagging at most hourly while still paused and re-arming on resume.

`severity="critical"` is what routes it to the Discord bridge's `#alerts` — `broadcast_event` flattens `payload` to the top level and the bridge's `is_critical_event` keys on top-level `severity == "critical"`. **No bridge change needed** (verified against the running bridge).

## Why this is robust where the old detection failed
Keyed on the **explicit paused state**, not silence inference — so it is immune to the three fragilities that hid the Sentinel:
- `_proxy_alive` downgrades silent-CRITICAL→warning when the host/process is alive (the exact "alive-but-dark-to-governance" state).
- silence is capped at `max(last_update, server_start)`, so every governance-mcp restart **resets the silence clock** (there were restarts at 17:37 and 18:42 in the incident).
- duplicate-identity blindness: the silence detector saw only the dead duplicate `366a5c42` and skipped it as a dup, never evaluating the canonical `f92dcea8`.

## Scope
Additive monitoring — no change to existing verdict/scoring/silence behavior. (Skipped a formal council given the low blast radius; verified the escalation plumbing live.)

## Related
- #685 (surface + bounded recovery in the beam) and #686 (the calibration that prevents the false pause at the source) address *causes*; this is the *detection/escalation* backstop so a paused resident can't go dark silently again.
- Follow-up still open: resolve the duplicate `Sentinel` identity (`366a5c42`) — it defeated the silence detector here.

## Tests
Full suite green (`9734 passed`). New: paused resident escalates critical; paused **ephemeral** agent does not; active resident does not; re-nag throttle within window; re-arm after resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)