### PR TITLE
[codex] Wire branch hygiene into workspace closeout

### DIFF
--- a/agents/vigil_hygiene/agent.py
+++ b/agents/vigil_hygiene/agent.py
@@ -46,8 +46,11 @@ class SweepReport:
     started_at: str
     duration_s: float = 0.0
     dry_run: bool = True
+    branches_prunable: int = 0
     branches_pruned: int = 0
+    worktrees_removable: int = 0
     worktrees_removed: int = 0
+    origin_orphans_deletable: int = 0
     origin_orphans_deleted: int = 0
     holds_count: int = 0
     holds: list[str] = field(default_factory=list)
@@ -235,6 +238,14 @@ def sweep(repo: Path, dry_run: bool = True) -> SweepReport:
 
         wt = branch_to_wt.get(branch)
         if wt is not None:
+            if wt.resolve() == repo.resolve():
+                report.holds.append(branch)
+                report.holds_count += 1
+                log(
+                    f"HOLD gone-branch '{branch}': checked out in sweep repo {repo}; "
+                    "run hygiene from another checkout before removing this worktree"
+                )
+                continue
             status = _safe_status(wt)
             if status is None:
                 log(f"SKIP gone-branch '{branch}': could not check worktree status")
@@ -243,6 +254,7 @@ def sweep(repo: Path, dry_run: bool = True) -> SweepReport:
             if not check.is_clean:
                 log(f"SKIP gone-branch '{branch}': worktree {wt} not clean ({check.reason})")
                 continue
+            report.worktrees_removable += 1
             if dry_run:
                 log(f"DRY-RUN would worktree-remove {wt}")
             else:
@@ -255,6 +267,7 @@ def sweep(repo: Path, dry_run: bool = True) -> SweepReport:
                     report.errors.append(f"worktree remove {wt}: {e.stderr}")
                     continue
 
+        report.branches_prunable += 1
         if dry_run:
             log(f"DRY-RUN would branch -D '{branch}': {cherry_result.reason}")
         else:
@@ -285,6 +298,7 @@ def sweep(repo: Path, dry_run: bool = True) -> SweepReport:
         elif result.verdict == CherryVerdict.SKIP:
             log(f"SKIP origin/{branch}: {result.reason}")
         elif result.verdict == CherryVerdict.DELETE:
+            report.origin_orphans_deletable += 1
             if dry_run:
                 log(f"DRY-RUN would delete origin/{branch}: {result.reason}")
             else:
@@ -307,6 +321,7 @@ def sweep(repo: Path, dry_run: bool = True) -> SweepReport:
         check = check_worktree_clean(path, status)
         if not check.is_clean:
             continue
+        report.worktrees_removable += 1
         if dry_run:
             log(f"DRY-RUN would worktree-remove {path} (no branch)")
         else:

--- a/agents/vigil_hygiene/agent.py
+++ b/agents/vigil_hygiene/agent.py
@@ -217,6 +217,9 @@ def sweep(repo: Path, dry_run: bool = True) -> SweepReport:
 
     worktrees = list_worktrees(repo)
     branch_to_wt = {b: p for p, b in worktrees if b is not None}
+    protected_worktrees = {repo.resolve()}
+    if worktrees:
+        protected_worktrees.add(worktrees[0][0].resolve())
 
     # 2. Local [gone] cleanup
     for branch in list_gone_branches(repo):
@@ -238,12 +241,12 @@ def sweep(repo: Path, dry_run: bool = True) -> SweepReport:
 
         wt = branch_to_wt.get(branch)
         if wt is not None:
-            if wt.resolve() == repo.resolve():
+            if wt.resolve() in protected_worktrees:
                 report.holds.append(branch)
                 report.holds_count += 1
                 log(
-                    f"HOLD gone-branch '{branch}': checked out in sweep repo {repo}; "
-                    "run hygiene from another checkout before removing this worktree"
+                    f"HOLD gone-branch '{branch}': checked out in protected "
+                    f"worktree {wt}; move off the branch before removing it"
                 )
                 continue
             status = _safe_status(wt)
@@ -313,7 +316,7 @@ def sweep(repo: Path, dry_run: bool = True) -> SweepReport:
     # 4. Branchless worktree sweep
     refreshed = list_worktrees(repo)
     for path, branch in refreshed:
-        if path == repo or branch is not None:
+        if path.resolve() in protected_worktrees or branch is not None:
             continue
         status = _safe_status(path)
         if status is None:

--- a/commands/closeout.md
+++ b/commands/closeout.md
@@ -49,8 +49,8 @@ whose intended work is already committed/stashed, run:
 `--branch-hygiene-live` reuses the Vigil branch-hygiene safety contract in
 `docs/operations/branch-hygiene-runbook.md`: patch-equivalent or empty stale
 branches may be pruned, clean stale worktrees may be removed, and branches with
-unique commits, dirty worktrees, or the current sweep checkout are held for
-review instead of deleted.
+unique commits, dirty worktrees, or a protected checkout are held for review
+instead of deleted.
 
 Rules:
 

--- a/commands/closeout.md
+++ b/commands/closeout.md
@@ -8,6 +8,8 @@ servers, BEAM residents, or any cleanup request from the operator.
 First run a non-mutating check:
 
 - `python3 scripts/dev/workspace_closeout.py`
+- `python3 scripts/dev/workspace_closeout.py --branch-hygiene` when branch or
+  worktree cleanup is part of the question
 
 This uses `.unitares/workspace-closeout-baseline.json` when present. The
 baseline is written by `/governance-start` through `workspace_closeout.py
@@ -23,6 +25,8 @@ Report:
 - any staged, unstaged, or untracked files
 - any repo-rooted processes still running
 - whether a remaining process is managed by a LaunchAgent label
+- the `branch hygiene:` line when requested, including cleanup candidates,
+  safe deletions performed, held branches, and sweep errors
 
 If work should be delivered instead of left local, stage the intentional files
 and use the ship helper:
@@ -40,7 +44,13 @@ and use the ship helper:
 If the operator asked to clean the workspace, or if you are finishing a task
 whose intended work is already committed/stashed, run:
 
-- `python3 scripts/dev/workspace_closeout.py --stash-dirty --stop-repo-processes --bootout-launch-agents`
+- `python3 scripts/dev/workspace_closeout.py --stash-dirty --stop-repo-processes --bootout-launch-agents --branch-hygiene-live`
+
+`--branch-hygiene-live` reuses the Vigil branch-hygiene safety contract in
+`docs/operations/branch-hygiene-runbook.md`: patch-equivalent or empty stale
+branches may be pruned, clean stale worktrees may be removed, and branches with
+unique commits, dirty worktrees, or the current sweep checkout are held for
+review instead of deleted.
 
 Rules:
 
@@ -64,5 +74,8 @@ Rules:
   than reverting them.
 - Stop only processes rooted inside the current workspace. Do not stop services
   rooted in sibling deploy repos unless the operator explicitly asks.
+- Treat branch hygiene holds as cleanup findings, not green lights. Report the
+  branch names and either salvage them or leave them for a follow-up cleanup
+  agent.
 - Include the stash name, commit hash, and stopped LaunchAgent labels in the
   final response.

--- a/docs/operations/branch-hygiene-runbook.md
+++ b/docs/operations/branch-hygiene-runbook.md
@@ -24,8 +24,9 @@ For local branches whose upstream is gone:
 - unparseable or failed `git cherry` output means **SKIP**. Do not delete.
 - dirty worktrees, paused rebases, paused cherry-picks, merges, or bisects are
   never removed by the sweep.
-- a stale branch checked out in the sweep process's current repo is held; run
-  hygiene from another checkout to remove that worktree.
+- a stale branch checked out in the sweep process's current repo or in the
+  primary checkout is held; move that checkout off the branch before removing
+  it.
 
 For remote `origin/*` branches:
 

--- a/docs/operations/branch-hygiene-runbook.md
+++ b/docs/operations/branch-hygiene-runbook.md
@@ -3,6 +3,13 @@
 `agents/vigil_hygiene/agent.py` is the resident branch-hygiene sweep. It is
 designed to remove branch clutter without deleting salvageable work.
 
+The same safety contract is available during manual workspace closeout:
+
+- `python3 scripts/dev/workspace_closeout.py --branch-hygiene` reports stale
+  branch/worktree cleanup candidates without mutating them.
+- `python3 scripts/dev/workspace_closeout.py --branch-hygiene-live` performs the
+  safe sweep and surfaces held branches as closeout findings.
+
 ## Safety Contract
 
 For local branches whose upstream is gone:
@@ -17,6 +24,8 @@ For local branches whose upstream is gone:
 - unparseable or failed `git cherry` output means **SKIP**. Do not delete.
 - dirty worktrees, paused rebases, paused cherry-picks, merges, or bisects are
   never removed by the sweep.
+- a stale branch checked out in the sweep process's current repo is held; run
+  hygiene from another checkout to remove that worktree.
 
 For remote `origin/*` branches:
 

--- a/scripts/dev/workspace_closeout.py
+++ b/scripts/dev/workspace_closeout.py
@@ -16,6 +16,8 @@ work and terminate or boot out repo-rooted processes.
 from __future__ import annotations
 
 import argparse
+import contextlib
+import io
 import json
 import os
 import re
@@ -59,6 +61,21 @@ class ProcessInfo:
 
 
 @dataclass
+class BranchHygieneSummary:
+    dry_run: bool
+    branches_prunable: int
+    branches_pruned: int
+    worktrees_removable: int
+    worktrees_removed: int
+    origin_orphans_deletable: int
+    origin_orphans_deleted: int
+    holds_count: int
+    holds: list[str]
+    errors: list[str]
+    log_lines: list[str]
+
+
+@dataclass
 class CloseoutResult:
     workspace: str
     git: GitState
@@ -70,6 +87,7 @@ class CloseoutResult:
     stopped_processes: list[int]
     booted_out_labels: list[str]
     errors: list[str]
+    branch_hygiene: BranchHygieneSummary | None = None
 
 
 @dataclass
@@ -552,6 +570,32 @@ def stop_repo_processes(
     return stopped, labels, errors
 
 
+def run_branch_hygiene(root: Path, *, dry_run: bool) -> BranchHygieneSummary:
+    source_root = Path(__file__).resolve().parents[2]
+    if str(source_root) not in sys.path:
+        sys.path.insert(0, str(source_root))
+
+    from agents.vigil_hygiene.agent import sweep
+
+    log_buffer = io.StringIO()
+    with contextlib.redirect_stdout(log_buffer):
+        report = sweep(root, dry_run=dry_run)
+
+    return BranchHygieneSummary(
+        dry_run=report.dry_run,
+        branches_prunable=getattr(report, "branches_prunable", 0),
+        branches_pruned=report.branches_pruned,
+        worktrees_removable=getattr(report, "worktrees_removable", 0),
+        worktrees_removed=report.worktrees_removed,
+        origin_orphans_deletable=getattr(report, "origin_orphans_deletable", 0),
+        origin_orphans_deleted=report.origin_orphans_deleted,
+        holds_count=report.holds_count,
+        holds=list(report.holds),
+        errors=list(report.errors),
+        log_lines=[line for line in log_buffer.getvalue().splitlines() if line.strip()],
+    )
+
+
 def closeout(
     root: Path,
     *,
@@ -559,11 +603,14 @@ def closeout(
     stop_processes: bool = False,
     bootout_launch_agents: bool = False,
     use_baseline: bool = True,
+    branch_hygiene: bool = False,
+    branch_hygiene_live: bool = False,
 ) -> CloseoutResult:
     errors: list[str] = []
     state = git_state(root)
     stash_message: str | None = None
     stashed = False
+    hygiene_summary: BranchHygieneSummary | None = None
     baseline_keys = read_process_baseline(root) if use_baseline else set()
     baseline_file = baseline_path(root)
     baseline_used = bool(baseline_keys)
@@ -588,6 +635,16 @@ def closeout(
         errors.extend(stop_errors)
         processes = repo_rooted_processes(root, baseline_keys=baseline_keys)
 
+    if branch_hygiene or branch_hygiene_live:
+        try:
+            hygiene_summary = run_branch_hygiene(
+                root,
+                dry_run=not branch_hygiene_live,
+            )
+            state = git_state(root)
+        except Exception as exc:
+            errors.append(f"branch hygiene failed: {exc}")
+
     return CloseoutResult(
         workspace=str(root),
         git=state,
@@ -599,6 +656,7 @@ def closeout(
         stopped_processes=stopped,
         booted_out_labels=labels,
         errors=errors,
+        branch_hygiene=hygiene_summary,
     )
 
 
@@ -636,6 +694,7 @@ def start_check(
             stopped_processes=[],
             booted_out_labels=[],
             errors=[],
+            branch_hygiene=None,
         )
 
     baseline_written = False
@@ -661,10 +720,23 @@ def start_check(
 
 
 def result_has_issues(result: CloseoutResult) -> bool:
+    hygiene = result.branch_hygiene
+    hygiene_needs_attention = False
+    if hygiene is not None:
+        hygiene_needs_attention = bool(hygiene.errors or hygiene.holds_count)
+        if hygiene.dry_run:
+            hygiene_needs_attention = hygiene_needs_attention or any(
+                (
+                    hygiene.branches_prunable,
+                    hygiene.worktrees_removable,
+                    hygiene.origin_orphans_deletable,
+                )
+            )
     return (
         delivery_needs_attention(result.git)
         or bool(result.repo_processes)
         or bool(result.errors)
+        or hygiene_needs_attention
     )
 
 
@@ -734,6 +806,35 @@ def render_text(result: CloseoutResult) -> str:
         for pid in result.stopped_processes:
             lines.append(f"  {pid}")
 
+    if result.branch_hygiene is not None:
+        hygiene = result.branch_hygiene
+        mode = "dry-run" if hygiene.dry_run else "live"
+        if hygiene.dry_run:
+            action_detail = (
+                f"would_prune_branches={hygiene.branches_prunable} "
+                f"would_remove_worktrees={hygiene.worktrees_removable} "
+                f"would_delete_origin_branches={hygiene.origin_orphans_deletable}"
+            )
+        else:
+            action_detail = (
+                f"branches_pruned={hygiene.branches_pruned} "
+                f"worktrees_removed={hygiene.worktrees_removed} "
+                f"origin_branches_deleted={hygiene.origin_orphans_deleted}"
+            )
+        lines.append(
+            "branch hygiene: "
+            f"{mode} - {action_detail} "
+            f"holds={hygiene.holds_count} errors={len(hygiene.errors)}"
+        )
+        if hygiene.holds:
+            lines.append("branch hygiene holds:")
+            for branch in hygiene.holds:
+                lines.append(f"  {branch}")
+        if hygiene.log_lines:
+            lines.append("branch hygiene log:")
+            for line in hygiene.log_lines[-12:]:
+                lines.append(f"  {line}")
+
     if result.errors:
         lines.append("errors:")
         for error in result.errors:
@@ -794,6 +895,9 @@ def to_jsonable(result: CloseoutResult) -> dict[str, Any]:
         "stopped_processes": result.stopped_processes,
         "booted_out_labels": result.booted_out_labels,
         "errors": result.errors,
+        "branch_hygiene": (
+            asdict(result.branch_hygiene) if result.branch_hygiene else None
+        ),
         "clean": not result_has_issues(result),
     }
 
@@ -829,6 +933,22 @@ def main(argv: list[str] | None = None) -> int:
         "--bootout-launch-agents",
         action="store_true",
         help="on macOS, boot out matching LaunchAgent labels before SIGTERM",
+    )
+    parser.add_argument(
+        "--branch-hygiene",
+        action="store_true",
+        help=(
+            "run the branch/worktree hygiene sweep in dry-run mode and include "
+            "cleanup candidates in the closeout result"
+        ),
+    )
+    parser.add_argument(
+        "--branch-hygiene-live",
+        action="store_true",
+        help=(
+            "run the branch/worktree hygiene sweep with safe deletions enabled "
+            "(branches with unique commits and dirty worktrees are held)"
+        ),
     )
     parser.add_argument(
         "--write-baseline",
@@ -905,6 +1025,8 @@ def main(argv: list[str] | None = None) -> int:
             stop_processes=args.stop_repo_processes,
             bootout_launch_agents=args.bootout_launch_agents,
             use_baseline=not args.no_baseline,
+            branch_hygiene=args.branch_hygiene,
+            branch_hygiene_live=args.branch_hygiene_live,
         )
     except RuntimeError as exc:
         print(f"workspace-closeout: {exc}", file=sys.stderr)

--- a/tests/test_vigil_hygiene_sweep.py
+++ b/tests/test_vigil_hygiene_sweep.py
@@ -157,7 +157,31 @@ class TestSweepGoneBranchSalvageGuard:
         branches = _git(fake_repo, "branch", "--list", "codex/squash-merged").stdout
         assert "codex/squash-merged" not in branches
         assert report.holds == []
+        assert report.branches_prunable == 1
         assert report.branches_pruned == 1
+
+    def test_live_holds_current_gone_branch_in_sweep_repo(
+        self, fake_repo: Path, monkeypatch
+    ):
+        _git(fake_repo, "switch", "-c", "codex/current-merged")
+        (fake_repo / "current.txt").write_text("current branch work\n")
+        _git(fake_repo, "add", "current.txt")
+        _git(fake_repo, "commit", "-m", "current branch work")
+        feature_sha = _git(fake_repo, "rev-parse", "HEAD").stdout.strip()
+        _git(fake_repo, "push", "-u", "origin", "codex/current-merged")
+        _git(fake_repo, "switch", "master")
+        _git(fake_repo, "cherry-pick", feature_sha)
+        _git(fake_repo, "push", "origin", "master")
+        _git(fake_repo, "push", "origin", "--delete", "codex/current-merged")
+        _git(fake_repo, "switch", "codex/current-merged")
+        monkeypatch.setattr(agent_mod, "list_open_pr_branches", lambda repo: set())
+
+        report = sweep(fake_repo, dry_run=False)
+
+        branches = _git(fake_repo, "branch", "--list", "codex/current-merged").stdout
+        assert "codex/current-merged" in branches
+        assert "codex/current-merged" in report.holds
+        assert report.branches_pruned == 0
 
 
 class TestSweepHelpers:

--- a/tests/test_vigil_hygiene_sweep.py
+++ b/tests/test_vigil_hygiene_sweep.py
@@ -183,6 +183,19 @@ class TestSweepGoneBranchSalvageGuard:
         assert "codex/current-merged" in report.holds
         assert report.branches_pruned == 0
 
+    def test_branchless_primary_checkout_is_not_removable_from_linked_worktree(
+        self, fake_repo: Path, monkeypatch
+    ):
+        linked = fake_repo / ".worktrees" / "linked"
+        _git(fake_repo, "worktree", "add", "-b", "codex/linked", str(linked))
+        _git(fake_repo, "switch", "--detach")
+        monkeypatch.setattr(agent_mod, "list_open_pr_branches", lambda repo: set())
+
+        report = sweep(linked, dry_run=True)
+
+        assert fake_repo.exists()
+        assert report.worktrees_removable == 0
+
 
 class TestSweepHelpers:
     def test_list_worktrees_includes_main_and_added(self, fake_repo: Path):

--- a/tests/test_workspace_closeout.py
+++ b/tests/test_workspace_closeout.py
@@ -167,6 +167,74 @@ def test_closeout_stashes_dirty_repo_when_requested(closeout_module, git_repo, m
     assert "workspace-closeout auto-stash" in stash_list.stdout
 
 
+def test_closeout_branch_hygiene_dry_run_surfaces_cleanup_candidates(
+    closeout_module, git_repo, monkeypatch
+):
+    monkeypatch.setattr(closeout_module, "repo_rooted_processes", lambda *a, **k: [])
+    calls = []
+
+    def fake_hygiene(root, *, dry_run):
+        calls.append((root, dry_run))
+        return closeout_module.BranchHygieneSummary(
+            dry_run=True,
+            branches_prunable=1,
+            branches_pruned=0,
+            worktrees_removable=1,
+            worktrees_removed=0,
+            origin_orphans_deletable=0,
+            origin_orphans_deleted=0,
+            holds_count=0,
+            holds=[],
+            errors=[],
+            log_lines=["DRY-RUN would branch -D 'codex/stale'"],
+        )
+
+    monkeypatch.setattr(closeout_module, "run_branch_hygiene", fake_hygiene)
+
+    result = closeout_module.closeout(git_repo, branch_hygiene=True)
+
+    assert calls == [(git_repo, True)]
+    assert closeout_module.result_has_issues(result) is True
+    rendered = closeout_module.render_text(result)
+    assert "branch hygiene: dry-run" in rendered
+    assert "would_prune_branches=1" in rendered
+    assert "DRY-RUN would branch -D 'codex/stale'" in rendered
+    assert closeout_module.to_jsonable(result)["clean"] is False
+
+
+def test_closeout_branch_hygiene_live_can_clear_without_issue(
+    closeout_module, git_repo, monkeypatch
+):
+    monkeypatch.setattr(closeout_module, "repo_rooted_processes", lambda *a, **k: [])
+    calls = []
+
+    def fake_hygiene(root, *, dry_run):
+        calls.append((root, dry_run))
+        return closeout_module.BranchHygieneSummary(
+            dry_run=False,
+            branches_prunable=1,
+            branches_pruned=1,
+            worktrees_removable=1,
+            worktrees_removed=1,
+            origin_orphans_deletable=0,
+            origin_orphans_deleted=0,
+            holds_count=0,
+            holds=[],
+            errors=[],
+            log_lines=["deleted local branch: codex/stale"],
+        )
+
+    monkeypatch.setattr(closeout_module, "run_branch_hygiene", fake_hygiene)
+
+    result = closeout_module.closeout(git_repo, branch_hygiene_live=True)
+
+    assert calls == [(git_repo, False)]
+    assert closeout_module.result_has_issues(result) is False
+    rendered = closeout_module.render_text(result)
+    assert "branch hygiene: live" in rendered
+    assert "branches_pruned=1" in rendered
+
+
 def test_git_state_marks_dirty_work_as_not_delivered(closeout_module, git_repo):
     (git_repo / "seed.py").write_text("dirty\n")
 


### PR DESCRIPTION
## Summary

- add branch/worktree hygiene output to `workspace_closeout.py` behind explicit dry-run and live flags
- reuse the existing Vigil sweep safety contract so safe stale branches/worktrees can be pruned while unique or dirty work is held
- protect the running checkout and primary checkout from automatic worktree removal
- update closeout/runbook docs and add regression coverage for dry-run findings, live cleanup, self-worktree holds, and branchless primary checkout protection

## Why

Codex closeout could stash files and stop repo-rooted processes, but it did not surface or clean stale branches/worktrees. That made successful branch delivery look clean while residue stayed behind for someone else to notice. This makes those findings explicit and gives cleanup agents the same safe path the resident Vigil hygiene sweep already uses.

## Validation

- `pytest tests/test_workspace_closeout.py tests/test_vigil_hygiene_sweep.py tests/test_vigil_hygiene_cherry.py tests/test_vigil_hygiene_clean_check.py`
- `pytest tests/test_vigil_hygiene_sweep.py tests/test_workspace_closeout.py`
- `python3 scripts/dev/workspace_closeout.py --branch-hygiene` dry-run surfaced cleanup candidates and held branches as findings, without listing the primary checkout as removable after the guard
- `./scripts/dev/test-cache.sh` (`9740 passed, 34 skipped`)
- pre-push smoke (`138 passed, 9035 deselected`)
