### PR TITLE
feat(residents): make resident roster + progress registry deployment config, empty by default

### DIFF
--- a/agents/sdk/src/unitares_sdk/_substrate.py
+++ b/agents/sdk/src/unitares_sdk/_substrate.py
@@ -12,10 +12,12 @@ swallowed to keep the checkin contract — RFC §7.13.4 contract: lease-plane
 failures MUST NOT fail the resident's checkin loop.
 
 Design:
-- `KNOWN_RESIDENT_NAMES` mirrors `src/grounding/class_indicator.py::
-  KNOWN_RESIDENT_LABELS`. Hardcoded here because the SDK is a standalone
-  package that should not import from `src/`. Drift between the two lists
-  is caught by `tests/test_substrate_resident_names_match_class_indicator.py`.
+- `KNOWN_RESIDENT_NAMES` is the deployment's resident roster, read from the
+  `UNITARES_RESIDENTS` env var (comma-separated labels). It mirrors
+  `src/grounding/class_indicator.py::KNOWN_RESIDENT_LABELS`, which reads the
+  same env var. The env var NAME is the cross-package contract — the SDK is
+  a standalone package that must not import from `src/`. Unset/empty means
+  this install has no named residents (the user-agnostic default).
 - Emission is GATED on `name in KNOWN_RESIDENT_NAMES` — non-resident agents
   using the SDK don't emit (the migration-034 `substrate_state_only_on_resident_kind`
   CHECK would reject them at the DB anyway; gating client-side is friendlier).
@@ -32,10 +34,22 @@ from uuid import UUID
 
 logger = logging.getLogger(__name__)
 
-# Mirror of src/grounding/class_indicator.py::KNOWN_RESIDENT_LABELS.
-# Drift caught by tests/test_substrate_resident_names_match_class_indicator.py.
-KNOWN_RESIDENT_NAMES: frozenset[str] = frozenset(
-    {"Lumen", "Vigil", "Sentinel", "Watcher", "Steward", "Chronicler"}
+# Deployment resident roster, read from UNITARES_RESIDENTS (comma-separated
+# labels). Mirrors src/grounding/class_indicator.py::KNOWN_RESIDENT_LABELS,
+# which reads the same env var — the env var name is the cross-package
+# contract. Empty by default (user-agnostic install with no named residents).
+RESIDENT_ROSTER_ENV = "UNITARES_RESIDENTS"
+
+
+def parse_resident_roster(raw: str | None) -> frozenset[str]:
+    """Parse a comma-separated resident roster string into a label set."""
+    if not raw:
+        return frozenset()
+    return frozenset(part.strip() for part in raw.split(",") if part.strip())
+
+
+KNOWN_RESIDENT_NAMES: frozenset[str] = parse_resident_roster(
+    os.environ.get(RESIDENT_ROSTER_ENV)
 )
 
 

--- a/agents/sdk/tests/conftest.py
+++ b/agents/sdk/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Pytest configuration for the unitares-sdk test suite.
+
+The resident roster is deployment config (UNITARES_RESIDENTS), empty by
+default. The SDK's KNOWN_RESIDENT_NAMES is resolved at module-import time
+from this env var, so configure the canonical fleet here BEFORE any test
+imports unitares_sdk._substrate.
+"""
+import os
+
+os.environ.setdefault(
+    "UNITARES_RESIDENTS",
+    "Lumen,Vigil,Sentinel,Watcher,Steward,Chronicler",
+)

--- a/agents/sdk/tests/test_substrate_emission.py
+++ b/agents/sdk/tests/test_substrate_emission.py
@@ -164,12 +164,33 @@ def _metrics():
             "coherence": 0.7, "risk": 0.2}
 
 
-def test_resident_names_match_class_indicator():
-    """KNOWN_RESIDENT_NAMES MUST mirror src/grounding/class_indicator.py::
-    KNOWN_RESIDENT_LABELS (the source of truth for who's a resident). The
-    SDK can't import from src/, so this test guards against drift."""
-    expected = {"Lumen", "Vigil", "Sentinel", "Watcher", "Steward", "Chronicler"}
-    assert KNOWN_RESIDENT_NAMES == expected
+def test_resident_roster_loaded_from_env():
+    """The resident roster is deployment config read from UNITARES_RESIDENTS.
+
+    Both the SDK (_substrate.KNOWN_RESIDENT_NAMES) and core
+    (src/grounding/class_indicator.KNOWN_RESIDENT_LABELS) read the SAME env
+    var — the env var NAME is the cross-package contract, since the SDK
+    cannot import from src/. conftest.py configures the canonical fleet for
+    this suite; assert the roster reflects that configuration rather than a
+    hardcoded literal."""
+    from unitares_sdk._substrate import RESIDENT_ROSTER_ENV
+
+    assert RESIDENT_ROSTER_ENV == "UNITARES_RESIDENTS"
+    assert KNOWN_RESIDENT_NAMES == {
+        "Lumen", "Vigil", "Sentinel", "Watcher", "Steward", "Chronicler",
+    }
+
+
+def test_parse_resident_roster_default_empty():
+    """Unset/empty roster => no named residents (user-agnostic default)."""
+    from unitares_sdk._substrate import parse_resident_roster
+
+    assert parse_resident_roster(None) == frozenset()
+    assert parse_resident_roster("") == frozenset()
+    assert parse_resident_roster("  ") == frozenset()
+    assert parse_resident_roster("Vigil, Sentinel ,Lumen") == {
+        "Vigil", "Sentinel", "Lumen",
+    }
 
 
 def test_resolve_resident_name_known_returns_name():

--- a/agents/vigil/agent.py
+++ b/agents/vigil/agent.py
@@ -128,8 +128,15 @@ def detect_changes(prev: Dict[str, Any], current: Dict[str, Any]) -> List[Dict[s
     """Compare previous and current cycle state. Returns list of notable changes."""
     notes: List[Dict[str, str]] = []
 
-    # Health status transitions
-    for service in ("governance", "lumen"):
+    # Health status transitions — for EVERY monitored service, not just a
+    # hardcoded (governance, lumen) pair. Services are discovered from the
+    # `{svc}_healthy` keys that _collect_health_state emits for each
+    # registered check, so a deployment's own health-check plugins get
+    # outage/recovery notes automatically.
+    services = sorted(
+        k[: -len("_healthy")] for k in current if k.endswith("_healthy")
+    )
+    for service in services:
         prev_ok = prev.get(f"{service}_healthy")
         curr_ok = current.get(f"{service}_healthy")
         if prev_ok is not None and prev_ok != curr_ok:
@@ -144,15 +151,16 @@ def detect_changes(prev: Dict[str, Any], current: Dict[str, Any]) -> List[Dict[s
                     "tags": ["vigil", "outage", service],
                 })
 
-    # Consecutive Lumen outage
-    prev_streak = prev.get("lumen_down_streak", 0)
-    curr_streak = current.get("lumen_down_streak", 0)
-    if curr_streak >= 3 and curr_streak > prev_streak and curr_streak % 3 == 0:
-        hours = curr_streak * 0.5  # 30-min cycles
-        notes.append({
-            "summary": f"Lumen unreachable for {curr_streak} consecutive cycles (~{hours:.0f}h)",
-            "tags": ["vigil", "outage", "lumen", "sustained"],
-        })
+    # Sustained outage — any service tracking a consecutive down-streak.
+    for service in services:
+        prev_streak = prev.get(f"{service}_down_streak", 0)
+        curr_streak = current.get(f"{service}_down_streak", 0)
+        if curr_streak >= 3 and curr_streak > prev_streak and curr_streak % 3 == 0:
+            hours = curr_streak * 0.5  # 30-min cycles
+            notes.append({
+                "summary": f"{service.title()} unreachable for {curr_streak} consecutive cycles (~{hours:.0f}h)",
+                "tags": ["vigil", "outage", service, "sustained"],
+            })
 
     # EISV drift
     prev_coherence = prev.get("coherence")
@@ -219,6 +227,28 @@ def _collect_health_state(
 
     if lumen_r and lumen_r.detail:
         state.update(lumen_r.detail)
+
+    # Any other registered checks (deployment-specific health-check plugins)
+    # get the same per-service bookkeeping — {svc}_healthy / _detail /
+    # _up_cycles / _down_streak — so detect_changes emits outage/recovery
+    # notes for them too. governance and lumen keep their bespoke keys above
+    # (governance's uptime counter is `gov_up_cycles`, not
+    # `governance_up_cycles`, and lumen is always present even when absent).
+    for svc, r in by_key.items():
+        if svc in ("governance", "lumen"):
+            continue
+        healthy = r.ok if r else True
+        state[f"{svc}_healthy"] = healthy
+        state[f"{svc}_detail"] = r.summary if r else "not configured"
+        state[f"{svc}_up_cycles"] = (
+            prev_state.get(f"{svc}_up_cycles", 0) + (1 if healthy else 0)
+        )
+        svc_streak = 0
+        if r and not healthy:
+            svc_streak = prev_state.get(f"{svc}_down_streak", 0) + 1
+        state[f"{svc}_down_streak"] = svc_streak
+        if r and r.detail:
+            state.update(r.detail)
 
     return state
 

--- a/agents/vigil/tests/test_collect_health_state.py
+++ b/agents/vigil/tests/test_collect_health_state.py
@@ -113,3 +113,36 @@ def test_lumen_down_streak_resets_on_recovery():
         prev_state={"lumen_down_streak": 5},
     )
     assert state["lumen_down_streak"] == 0
+
+
+def test_arbitrary_service_gets_full_bookkeeping():
+    """A deployment-specific health check (not governance/lumen) gets the same
+    per-service keys, so it participates in uptime + change-note tracking."""
+    from agents.vigil.agent import _collect_health_state
+
+    gov_check = _FakeCheck("governance_health", "governance")
+    gov_result = CheckResult(ok=True, summary="ok")
+    redis_check = _FakeCheck("redis_health", "redis")
+    redis_result = CheckResult(
+        ok=False, summary="Redis: UNREACHABLE", severity="critical",
+        fingerprint_key="redis_down",
+    )
+
+    state = _collect_health_state(
+        [(gov_check, gov_result), (redis_check, redis_result)],
+        prev_state={"redis_up_cycles": 4, "redis_down_streak": 1},
+    )
+    assert state["redis_healthy"] is False
+    assert state["redis_detail"] == "Redis: UNREACHABLE"
+    assert state["redis_up_cycles"] == 4  # not incremented while down
+    assert state["redis_down_streak"] == 2
+
+    # Recovery clears the streak and advances uptime.
+    state2 = _collect_health_state(
+        [(gov_check, gov_result),
+         (redis_check, CheckResult(ok=True, summary="Redis: ok"))],
+        prev_state={"redis_up_cycles": 4, "redis_down_streak": 2},
+    )
+    assert state2["redis_healthy"] is True
+    assert state2["redis_up_cycles"] == 5
+    assert state2["redis_down_streak"] == 0

--- a/agents/vigil/tests/test_groundskeeper.py
+++ b/agents/vigil/tests/test_groundskeeper.py
@@ -563,6 +563,50 @@ class TestDetectChangesGroundskeeper:
         assert len(gk_changes) == 1  # 15 > 0 + 10
 
 
+class TestDetectChangesArbitraryService:
+    """Health transitions are detected for ANY monitored service, not just a
+    hardcoded governance/lumen pair — so a deployment's own health-check
+    plugins (e.g. a 'redis' or 'gateway' check) get outage/recovery notes."""
+
+    def test_custom_service_outage_note(self):
+        prev = {"redis_healthy": True}
+        curr = {"redis_healthy": False, "redis_detail": "Redis: UNREACHABLE"}
+        changes = detect_changes(prev, curr)
+        outage = [c for c in changes if "redis" in c.get("tags", [])]
+        assert len(outage) == 1
+        assert "outage" in outage[0]["tags"]
+        assert "down" in outage[0]["summary"].lower()
+
+    def test_custom_service_recovery_note(self):
+        prev = {"redis_healthy": False}
+        curr = {"redis_healthy": True}
+        changes = detect_changes(prev, curr)
+        recovery = [c for c in changes if "recovery" in c.get("tags", [])]
+        assert len(recovery) == 1
+        assert "redis" in recovery[0]["tags"]
+
+    def test_custom_service_sustained_outage_note(self):
+        prev = {"redis_healthy": False, "redis_down_streak": 2}
+        curr = {"redis_healthy": False, "redis_down_streak": 3}
+        changes = detect_changes(prev, curr)
+        sustained = [c for c in changes if "sustained" in c.get("tags", [])]
+        assert len(sustained) == 1
+        assert "redis" in sustained[0]["tags"]
+        assert "consecutive" in sustained[0]["summary"].lower()
+
+    def test_lumen_sustained_note_unchanged(self):
+        """Regression: the canonical Lumen sustained-outage note still reads
+        exactly as before the generalization."""
+        prev = {"lumen_healthy": False, "lumen_down_streak": 2}
+        curr = {"lumen_healthy": False, "lumen_down_streak": 3}
+        changes = detect_changes(prev, curr)
+        sustained = [c for c in changes if "sustained" in c.get("tags", [])]
+        assert len(sustained) == 1
+        assert sustained[0]["summary"] == (
+            "Lumen unreachable for 3 consecutive cycles (~2h)"
+        )
+
+
 # =============================================================================
 # Tests: uptime tracking
 # =============================================================================

--- a/config/resident_progress.example.json
+++ b/config/resident_progress.example.json
@@ -1,0 +1,38 @@
+{
+  "_comment": "Canonical resident-progress manifest for the reference fleet. Point UNITARES_RESIDENT_PROGRESS_MANIFEST at this file (or a deployment-specific copy) to enable progress probing. Unset => no residents probed. 'source' must match a source registered in src/background_tasks.py (kg_writes, watcher_findings, eisv_sync_rows, metrics_series, sentinel_pulse, agent_checkins). See docs/operations/resident-roster.md.",
+  "vigil": {
+    "source": "kg_writes",
+    "metric": "rows_written",
+    "window_seconds": 3600,
+    "threshold": 1,
+    "expected_cadence_s": 1800
+  },
+  "watcher": {
+    "source": "watcher_findings",
+    "metric": "rows_any",
+    "window_seconds": 21600,
+    "threshold": 1,
+    "expected_cadence_s": null
+  },
+  "steward": {
+    "source": "eisv_sync_rows",
+    "metric": "rows_written",
+    "window_seconds": 1800,
+    "threshold": 1,
+    "expected_cadence_s": 300
+  },
+  "chronicler": {
+    "source": "metrics_series",
+    "metric": "rows_written",
+    "window_seconds": 93600,
+    "threshold": 1,
+    "expected_cadence_s": 86400
+  },
+  "sentinel": {
+    "source": "agent_checkins",
+    "metric": "checkin_count",
+    "window_seconds": 1800,
+    "threshold": 1,
+    "expected_cadence_s": 300
+  }
+}

--- a/docs/ontology/identity.md
+++ b/docs/ontology/identity.md
@@ -70,6 +70,14 @@ The administrative label "resident" (Vigil/Sentinel/Watcher/Steward/Lumen) colla
 
 "Resident" remains a useful deployment label (launchd-registered, fleet-managed). It is not an ontological category.
 
+**Implementation note (2026-06-14):** this is now literally true in code — the
+resident roster is deployment configuration, not a hardcoded fleet. Named
+residents (incl. Lumen) are declared via the `UNITARES_RESIDENTS` env var and
+the resident-progress probe via `UNITARES_RESIDENT_PROGRESS_MANIFEST`, both
+empty by default. A fresh install inherits no operator-specific identities and
+no N=1 calibration classes; the reference fleet is opt-in. See
+`docs/operations/resident-roster.md`.
+
 ## Earned vs. performative today
 
 ### Earned

--- a/docs/operations/resident-roster.md
+++ b/docs/operations/resident-roster.md
@@ -1,0 +1,65 @@
+# Resident roster (`UNITARES_RESIDENTS`)
+
+The set of **named resident agents** for a deployment is configuration, not a
+hardcoded fleet. It is declared via the `UNITARES_RESIDENTS` environment
+variable, read by both the governance server and the agent SDK.
+
+## Why this exists
+
+UNITARES ships with reference resident agents (Vigil, Sentinel, Watcher,
+Chronicler, plus the embodied Lumen on the canonical deployment). Earlier these
+names were hardcoded in two places — `src/grounding/class_indicator.py`
+(`KNOWN_RESIDENT_LABELS`) and `agents/sdk/.../​_substrate.py`
+(`KNOWN_RESIDENT_NAMES`). That baked one operator's fleet into the framework,
+so a fresh install inherited identities (and an N=1 calibration class for
+`Lumen`) that did not exist on that machine.
+
+The roster is now read from `UNITARES_RESIDENTS`, **empty by default**. A fresh
+install therefore has *no* named residents: every agent classifies by tag
+(`embodied` / `persistent` / `ephemeral`) or falls through to the `default`
+calibration class. Named residents are an opt-in specialization, not a baked-in
+fleet.
+
+## Format
+
+Comma-separated labels, matching the `name` each resident onboards with
+(capitalized per the identity rules):
+
+```
+UNITARES_RESIDENTS=Vigil,Sentinel,Watcher,Chronicler
+```
+
+Unset or empty ⇒ no named residents.
+
+## Where to set it
+
+The value **must be consistent** across the processes that classify or emit for
+residents:
+
+- **Governance server** (`com.unitares.governance-mcp.plist`) — classifies
+  every agent, so it needs the full roster.
+- **Each resident agent** (`com.unitares.{vigil,sentinel,sentinel-beam,chronicler,vigil-hygiene}.plist`)
+  — the SDK gates substrate-state emission on the resident's own name being in
+  the roster.
+
+The checked-in plist + templates under `scripts/ops/` set the canonical fleet
+(`Lumen,Vigil,Sentinel,Watcher,Steward,Chronicler`). A different deployment
+edits these to its own roster, or clears them for a residentless install.
+
+## Calibration note
+
+Each named resident becomes its own N=1 calibration class. If you add a
+resident to the roster, it must also have class-conditional scale constants in
+`config/governance_config.py` (`DELTA_NORM_MAX_BY_CLASS`,
+`HEALTHY_OPERATING_POINT_BY_CLASS`, etc.) — `tests/test_grounding_scale_constants.py`
+enforces this. Residents with no constants fall back to fleet defaults via the
+`.get(agent_class, *_DEFAULT)` lookups, so an *unnamed* agent is always safe;
+the constraint only applies to names you place in the roster.
+
+## Cross-package contract
+
+The env var **name** (`UNITARES_RESIDENTS`) is the contract between core and the
+SDK — the standalone SDK cannot import from `src/`. Both sides parse it
+identically (`parse_resident_roster`). `agents/sdk/tests/test_substrate_emission.py`
+and `tests/test_grounding_class_indicator.py` pin the parsing and the env var
+name on each side.

--- a/docs/operations/resident-roster.md
+++ b/docs/operations/resident-roster.md
@@ -56,6 +56,31 @@ enforces this. Residents with no constants fall back to fleet defaults via the
 `.get(agent_class, *_DEFAULT)` lookups, so an *unnamed* agent is always safe;
 the constraint only applies to names you place in the roster.
 
+## Resident-progress manifest (`UNITARES_RESIDENT_PROGRESS_MANIFEST`)
+
+The resident-**progress probe** (liveness/output monitoring in the server's
+background tasks) has its own roster, because it needs more than a name per
+resident: a metric source, window, threshold, and heartbeat cadence. It is
+loaded from a JSON manifest pointed to by `UNITARES_RESIDENT_PROGRESS_MANIFEST`,
+**empty by default** (no residents probed).
+
+The canonical fleet ships as `config/resident_progress.example.json`. Point the
+env var at it (or a deployment-specific copy):
+
+```
+UNITARES_RESIDENT_PROGRESS_MANIFEST=/path/to/unitares/config/resident_progress.example.json
+```
+
+Set this on the **governance server** plist (the probe runs there). Each entry's
+`source` must match a source registered in `src/background_tasks.py`
+(`kg_writes`, `watcher_findings`, `eisv_sync_rows`, `metrics_series`,
+`sentinel_pulse`, `agent_checkins`). Labels are lowercase to match the anchor
+filenames under `~/.unitares/anchors/`.
+
+`UNITARES_RESIDENTS` (names/calibration) and this manifest (progress probing)
+are related but distinct: a deployment that runs residents typically sets both,
+listing the same residents in each.
+
 ## Cross-package contract
 
 The env var **name** (`UNITARES_RESIDENTS`) is the contract between core and the

--- a/docs/operations/resident-roster.md
+++ b/docs/operations/resident-roster.md
@@ -81,6 +81,21 @@ filenames under `~/.unitares/anchors/`.
 are related but distinct: a deployment that runs residents typically sets both,
 listing the same residents in each.
 
+## Vigil health-check targets
+
+Vigil's health checks are pluggable (`VIGIL_CHECK_PLUGINS`, see
+`agents/vigil/checks/registry.py`). The built-in checks are governance health,
+resident-tag hygiene, and plugin-hook liveness; the **Lumen/anima health check
+is an external plugin**, not shipped in this repo — a residentless install
+simply doesn't register it (Vigil reports Lumen as `not configured` and
+healthy, so nothing breaks).
+
+Any health check a deployment registers — its own `redis`, `gateway`, etc. —
+now gets full per-service bookkeeping (`{svc}_healthy` / `_detail` /
+`_up_cycles` / `_down_streak`) and outage/recovery/sustained-outage change
+notes, the same treatment governance and Lumen get. No service names are
+hardcoded into the change-detection path.
+
 ## Cross-package contract
 
 The env var **name** (`UNITARES_RESIDENTS`) is the contract between core and the

--- a/scripts/ops/com.unitares.chronicler.plist.template
+++ b/scripts/ops/com.unitares.chronicler.plist.template
@@ -42,6 +42,11 @@
 
     <key>EnvironmentVariables</key>
     <dict>
+        <!-- Must match UNITARES_RESIDENTS on the governance-mcp plist so the
+             SDK recognizes this resident's substrate emissions. Empty = no
+             named residents (user-agnostic install). -->
+        <key>UNITARES_RESIDENTS</key>
+        <string>Lumen,Vigil,Sentinel,Watcher,Steward,Chronicler</string>
         <key>PYTHONPATH</key>
         <string>__UNITARES_ROOT__</string>
         <key>PATH</key>

--- a/scripts/ops/com.unitares.governance-mcp.plist
+++ b/scripts/ops/com.unitares.governance-mcp.plist
@@ -48,6 +48,13 @@
 
     <key>EnvironmentVariables</key>
     <dict>
+        <!-- Resident roster for this deployment (comma-separated labels).
+             Each named resident is its own N=1 calibration class. Omit or
+             leave empty for a user-agnostic install with no named residents.
+             MUST match the residents this deployment actually runs (and the
+             UNITARES_RESIDENTS set in each resident's plist). -->
+        <key>UNITARES_RESIDENTS</key>
+        <string>Lumen,Vigil,Sentinel,Watcher,Steward,Chronicler</string>
         <key>UNITARES_BIND_ALL_INTERFACES</key>
         <string>1</string>
         <key>UNITARES_MCP_ALLOWED_HOSTS</key>

--- a/scripts/ops/com.unitares.governance-mcp.plist
+++ b/scripts/ops/com.unitares.governance-mcp.plist
@@ -55,6 +55,11 @@
              UNITARES_RESIDENTS set in each resident's plist). -->
         <key>UNITARES_RESIDENTS</key>
         <string>Lumen,Vigil,Sentinel,Watcher,Steward,Chronicler</string>
+        <!-- Resident-progress probe manifest (JSON). Points at the shipped
+             canonical fleet; copy + edit for a different deployment, or omit
+             for a user-agnostic install that probes no residents. -->
+        <key>UNITARES_RESIDENT_PROGRESS_MANIFEST</key>
+        <string>/PATH/TO/UNITARES/config/resident_progress.example.json</string>
         <key>UNITARES_BIND_ALL_INTERFACES</key>
         <string>1</string>
         <key>UNITARES_MCP_ALLOWED_HOSTS</key>

--- a/scripts/ops/com.unitares.sentinel-beam.plist.template
+++ b/scripts/ops/com.unitares.sentinel-beam.plist.template
@@ -60,6 +60,11 @@
 
     <key>EnvironmentVariables</key>
     <dict>
+        <!-- Must match UNITARES_RESIDENTS on the governance-mcp plist so the
+             SDK recognizes this resident's substrate emissions. Empty = no
+             named residents (user-agnostic install). -->
+        <key>UNITARES_RESIDENTS</key>
+        <string>Lumen,Vigil,Sentinel,Watcher,Steward,Chronicler</string>
         <key>HOME</key>
         <string>__HOME__</string>
         <key>LANG</key>

--- a/scripts/ops/com.unitares.sentinel.plist.template
+++ b/scripts/ops/com.unitares.sentinel.plist.template
@@ -51,6 +51,11 @@
 
     <key>EnvironmentVariables</key>
     <dict>
+        <!-- Must match UNITARES_RESIDENTS on the governance-mcp plist so the
+             SDK recognizes this resident's substrate emissions. Empty = no
+             named residents (user-agnostic install). -->
+        <key>UNITARES_RESIDENTS</key>
+        <string>Lumen,Vigil,Sentinel,Watcher,Steward,Chronicler</string>
         <key>PYTHONPATH</key>
         <string>__UNITARES_ROOT__</string>
         <key>PATH</key>

--- a/scripts/ops/com.unitares.vigil-hygiene.plist.template
+++ b/scripts/ops/com.unitares.vigil-hygiene.plist.template
@@ -61,6 +61,11 @@
 
     <key>EnvironmentVariables</key>
     <dict>
+        <!-- Must match UNITARES_RESIDENTS on the governance-mcp plist so the
+             SDK recognizes this resident's substrate emissions. Empty = no
+             named residents (user-agnostic install). -->
+        <key>UNITARES_RESIDENTS</key>
+        <string>Lumen,Vigil,Sentinel,Watcher,Steward,Chronicler</string>
         <key>PATH</key>
         <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
     </dict>

--- a/scripts/ops/com.unitares.vigil.plist.template
+++ b/scripts/ops/com.unitares.vigil.plist.template
@@ -49,6 +49,11 @@
 
     <key>EnvironmentVariables</key>
     <dict>
+        <!-- Must match UNITARES_RESIDENTS on the governance-mcp plist so the
+             SDK recognizes this resident's substrate emissions. Empty = no
+             named residents (user-agnostic install). -->
+        <key>UNITARES_RESIDENTS</key>
+        <string>Lumen,Vigil,Sentinel,Watcher,Steward,Chronicler</string>
         <key>PYTHONPATH</key>
         <string>__UNITARES_ROOT__</string>
         <key>PATH</key>

--- a/src/grounding/class_indicator.py
+++ b/src/grounding/class_indicator.py
@@ -10,13 +10,49 @@ class, where fleet-wide constants apply.
 Returns a class name string used to key into the class-conditional scale
 maps in config/governance_config.py (S_SCALE_BY_CLASS, etc.).
 """
+import os
 from typing import Any, Iterable, Optional
+
+# The resident roster is *deployment configuration*, not a hardcoded fleet.
+# A deployment declares its named residents via the UNITARES_RESIDENTS env
+# var (comma-separated labels, e.g. "Vigil,Sentinel,Lumen"). Unset or empty
+# means this install has no named residents — every agent then classifies by
+# tag (embodied / persistent / ephemeral) or falls through to the default
+# class, where fleet-wide constants apply. This is what makes UNITARES
+# user-agnostic: a fresh install inherits no operator-specific identities.
+#
+# Each named resident becomes its own N=1 calibration class, so a deployment
+# that names residents must also provide their class-conditional scale
+# constants (config/governance_config.py) — guarded by
+# tests/test_grounding_scale_constants.py.
+#
+# The SDK mirrors this contract by reading the same env var; see
+# agents/sdk/src/unitares_sdk/_substrate.py. The env var NAME is the
+# cross-package contract (the SDK cannot import from src/).
+RESIDENT_ROSTER_ENV = "UNITARES_RESIDENTS"
+
+
+def parse_resident_roster(raw: Optional[str]) -> frozenset[str]:
+    """Parse a comma-separated resident roster string into a label set."""
+    if not raw:
+        return frozenset()
+    return frozenset(part.strip() for part in raw.split(",") if part.strip())
+
+
+def load_resident_labels() -> frozenset[str]:
+    """Resident labels for this deployment, from ``UNITARES_RESIDENTS``.
+
+    Read once at import into ``KNOWN_RESIDENT_LABELS`` (server processes read
+    their roster at startup). Tests that vary the roster set the env var
+    before import (see tests/conftest.py) or call this helper directly.
+    """
+    return parse_resident_roster(os.environ.get(RESIDENT_ROSTER_ENV))
+
 
 # Specific labels that identify a unique resident agent. Each is its own
 # calibration class because population N=1 means class==agent in practice.
-KNOWN_RESIDENT_LABELS = frozenset(
-    {"Lumen", "Vigil", "Sentinel", "Watcher", "Steward", "Chronicler"}
-)
+# Empty by default; populated from UNITARES_RESIDENTS — see above.
+KNOWN_RESIDENT_LABELS = load_resident_labels()
 
 # Tag-derived class names.
 CLASS_EMBODIED = "embodied"
@@ -27,7 +63,9 @@ CLASS_DEFAULT = "default"
 
 
 def classify_by_label_and_tags(
-    label: Optional[str], tags: Optional[Iterable[str]]
+    label: Optional[str],
+    tags: Optional[Iterable[str]],
+    known: Optional[frozenset[str]] = None,
 ) -> str:
     """Canonical fold: return the calibration class name from raw label + tags.
 
@@ -56,8 +94,13 @@ def classify_by_label_and_tags(
     any transient state where both tags coexist (the promotion UPDATE
     strips ephemeral atomically, but the in-memory cache sync is best
     effort), the post-promotion class wins.
+
+    ``known`` overrides the resident roster (defaults to the deployment's
+    ``KNOWN_RESIDENT_LABELS``); pass an explicit set to classify against a
+    specific roster without mutating module state.
     """
-    if label and label in KNOWN_RESIDENT_LABELS:
+    roster = KNOWN_RESIDENT_LABELS if known is None else known
+    if label and label in roster:
         return label
 
     tags_set = set(tags) if tags else set()

--- a/src/resident_progress/registry.py
+++ b/src/resident_progress/registry.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
@@ -40,19 +41,82 @@ class ResidentConfig:
             )
 
 
-RESIDENT_PROGRESS_REGISTRY: dict[str, ResidentConfig] = {
-    "vigil":      ResidentConfig("kg_writes",        "rows_written", timedelta(minutes=60),  1, expected_cadence_s=1800),
-    "watcher":    ResidentConfig("watcher_findings", "rows_any",     timedelta(hours=6),     1, expected_cadence_s=None),
-    "steward":    ResidentConfig("eisv_sync_rows",   "rows_written", timedelta(minutes=30),  1, expected_cadence_s=300),
-    "chronicler": ResidentConfig("metrics_series",   "rows_written", timedelta(hours=26),    1, expected_cadence_s=86400),
-    # Sentinel runs on the Elixir/BEAM runtime (com.unitares.sentinel-beam). It
-    # does NOT post record_progress_pulse (Python-only) but it DOES check in via
-    # process_agent_update like every other resident — so it's measured on the
-    # substrate-agnostic `agent_checkins` source (core.agent_state), not the
-    # Python pulse. PR #566 retired it as a stopgap; this is the real re-key.
-    # Cadence is the BEAM fleet-cycle (~5min), not the old Python 60s loop.
-    "sentinel":   ResidentConfig("agent_checkins",   "checkin_count", timedelta(minutes=30),  1, expected_cadence_s=300),
-}
+# The resident-progress roster is deployment configuration, not a hardcoded
+# fleet. It is loaded from a JSON manifest pointed to by the
+# UNITARES_RESIDENT_PROGRESS_MANIFEST env var; unset/missing => no residents
+# are probed (the user-agnostic default). The canonical fleet ships as
+# config/resident_progress.example.json — a deployment points the env var at
+# that file or its own copy. See docs/operations/resident-roster.md.
+#
+# Manifest shape (one entry per resident label, lowercase to match anchor
+# filenames):
+#   {
+#     "vigil": {
+#       "source": "kg_writes",          # must be a source registered in
+#                                        # background_tasks.py's sources dict
+#       "metric": "rows_written",        # human-readable label on the snapshot
+#       "window_seconds": 3600,
+#       "threshold": 1,                  # candidate fires when metric < threshold
+#       "expected_cadence_s": 1800       # null for event-driven residents
+#     }
+#   }
+RESIDENT_PROGRESS_MANIFEST_ENV = "UNITARES_RESIDENT_PROGRESS_MANIFEST"
+
+
+def parse_resident_progress_manifest(doc: dict) -> dict[str, ResidentConfig]:
+    """Build the label→ResidentConfig registry from a parsed manifest dict."""
+    registry: dict[str, ResidentConfig] = {}
+    for label, entry in doc.items():
+        # Underscore-prefixed keys (e.g. "_comment") are manifest metadata.
+        if label.startswith("_") or not isinstance(entry, dict):
+            continue
+        cadence = entry.get("expected_cadence_s")
+        registry[label] = ResidentConfig(
+            source=entry["source"],
+            metric=entry["metric"],
+            window=timedelta(seconds=int(entry["window_seconds"])),
+            threshold=int(entry["threshold"]),
+            expected_cadence_s=None if cadence is None else int(cadence),
+        )
+    return registry
+
+
+def load_resident_progress_registry(
+    path: str | Path | None = None,
+) -> dict[str, ResidentConfig]:
+    """Load the resident-progress registry from a JSON manifest.
+
+    Reads ``path`` if given, else ``UNITARES_RESIDENT_PROGRESS_MANIFEST``.
+    Unset, empty, missing, or unreadable => empty registry (no residents
+    probed), the user-agnostic default. Read once at import; tests that vary
+    the roster set the env/path and call this helper directly.
+    """
+    raw = str(path) if path is not None else os.environ.get(
+        RESIDENT_PROGRESS_MANIFEST_ENV, ""
+    )
+    if not raw.strip():
+        return {}
+    manifest_path = Path(raw)
+    try:
+        doc = json.loads(manifest_path.read_text())
+    except FileNotFoundError:
+        logger.warning(
+            "resident-progress manifest %s not found; probing no residents",
+            manifest_path,
+        )
+        return {}
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning(
+            "resident-progress manifest %s unreadable (%s); probing no residents",
+            manifest_path, e,
+        )
+        return {}
+    return parse_resident_progress_manifest(doc)
+
+
+RESIDENT_PROGRESS_REGISTRY: dict[str, ResidentConfig] = (
+    load_resident_progress_registry()
+)
 
 
 def is_event_driven_label(label: str | None) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,17 @@ os.environ.setdefault(
     "Lumen,Vigil,Sentinel,Watcher,Steward,Chronicler",
 )
 
+# The resident-progress registry is likewise deployment config, loaded from a
+# JSON manifest (UNITARES_RESIDENT_PROGRESS_MANIFEST), empty by default. Point
+# the suite at the canonical fleet manifest BEFORE any test imports
+# src.resident_progress.registry (RESIDENT_PROGRESS_REGISTRY is built at
+# module-import time). Tests that vary it call load_resident_progress_registry()
+# directly or patch the registry.
+os.environ.setdefault(
+    "UNITARES_RESIDENT_PROGRESS_MANIFEST",
+    str(Path(__file__).resolve().parent.parent / "config" / "resident_progress.example.json"),
+)
+
 # Filter ResourceWarnings globally before any imports
 warnings.filterwarnings("ignore", category=ResourceWarning)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,17 @@ os.environ.setdefault(
     str(Path(tempfile.gettempdir()) / "unitares-vigil-test.log"),
 )
 
+# The resident roster is now deployment config (UNITARES_RESIDENTS), empty by
+# default for user-agnostic installs. The test suite validates the resident
+# machinery against the canonical fleet, so configure it here BEFORE any test
+# imports src.grounding.class_indicator (KNOWN_RESIDENT_LABELS is resolved at
+# module-import time from this env var). Tests that need a different roster set
+# the env var and call class_indicator.load_resident_labels() directly.
+os.environ.setdefault(
+    "UNITARES_RESIDENTS",
+    "Lumen,Vigil,Sentinel,Watcher,Steward,Chronicler",
+)
+
 # Filter ResourceWarnings globally before any imports
 warnings.filterwarnings("ignore", category=ResourceWarning)
 

--- a/tests/resident_progress/test_registry.py
+++ b/tests/resident_progress/test_registry.py
@@ -7,11 +7,61 @@ from pathlib import Path
 import pytest
 
 from src.resident_progress.registry import (
+    RESIDENT_PROGRESS_MANIFEST_ENV,
     RESIDENT_PROGRESS_REGISTRY,
     ResidentConfig,
     is_event_driven_label,
+    load_resident_progress_registry,
+    parse_resident_progress_manifest,
     resolve_resident_uuid,
 )
+
+
+def test_load_registry_empty_by_default(monkeypatch):
+    """Unset manifest => no residents probed (user-agnostic default)."""
+    monkeypatch.delenv(RESIDENT_PROGRESS_MANIFEST_ENV, raising=False)
+    assert load_resident_progress_registry() == {}
+    # Empty/whitespace path is also treated as "no manifest".
+    assert load_resident_progress_registry("") == {}
+
+
+def test_load_registry_missing_file_is_empty(tmp_path):
+    """A pointed-but-absent manifest degrades to empty, not a crash."""
+    assert load_resident_progress_registry(tmp_path / "nope.json") == {}
+
+
+def test_load_registry_from_manifest(tmp_path):
+    manifest = tmp_path / "residents.json"
+    manifest.write_text(json.dumps({
+        "_comment": "metadata keys are ignored",
+        "vigil": {
+            "source": "kg_writes", "metric": "rows_written",
+            "window_seconds": 3600, "threshold": 1,
+            "expected_cadence_s": 1800,
+        },
+        "watcher": {
+            "source": "watcher_findings", "metric": "rows_any",
+            "window_seconds": 21600, "threshold": 1,
+            "expected_cadence_s": None,
+        },
+    }))
+    reg = load_resident_progress_registry(manifest)
+    assert set(reg) == {"vigil", "watcher"}
+    assert reg["vigil"].window == timedelta(seconds=3600)
+    assert reg["vigil"].expected_cadence_s == 1800
+    assert reg["watcher"].expected_cadence_s is None
+
+
+def test_parse_manifest_skips_metadata_and_nondict():
+    reg = parse_resident_progress_manifest({
+        "_comment": "ignored",
+        "_version": 1,
+        "vigil": {
+            "source": "kg_writes", "metric": "rows",
+            "window_seconds": 60, "threshold": 1, "expected_cadence_s": 30,
+        },
+    })
+    assert set(reg) == {"vigil"}
 
 
 def test_registry_has_five_residents():

--- a/tests/test_grounding_class_indicator.py
+++ b/tests/test_grounding_class_indicator.py
@@ -6,6 +6,9 @@ from src.grounding.class_indicator import (
     classify_agent,
     classify_by_label_and_tags,
     KNOWN_RESIDENT_LABELS,
+    RESIDENT_ROSTER_ENV,
+    load_resident_labels,
+    parse_resident_roster,
     CLASS_EMBODIED,
     CLASS_RESIDENT_PERSISTENT,
     CLASS_EPHEMERAL,
@@ -16,6 +19,35 @@ from src.grounding.class_indicator import (
 
 def _meta(label=None, tags=None):
     return SimpleNamespace(label=label, tags=tags or [])
+
+
+def test_roster_env_default_empty(monkeypatch):
+    """Unset UNITARES_RESIDENTS => no named residents (user-agnostic default)."""
+    monkeypatch.delenv(RESIDENT_ROSTER_ENV, raising=False)
+    assert load_resident_labels() == frozenset()
+    assert parse_resident_roster(None) == frozenset()
+    assert parse_resident_roster("Vigil, Sentinel ,Lumen") == {
+        "Vigil", "Sentinel", "Lumen",
+    }
+
+
+def test_unnamed_resident_falls_through_to_tags(monkeypatch):
+    """With an empty roster, an agent named 'Lumen' is NOT its own class — it
+    classifies by tags (or default), proving the roster is config, not baked in."""
+    monkeypatch.setenv(RESIDENT_ROSTER_ENV, "")
+    roster = load_resident_labels()
+    # classify_by_label_and_tags resolves the label against whatever roster is
+    # passed via the module constant; simulate an empty-roster install by
+    # checking the label is absent and tag/default resolution wins.
+    assert "Lumen" not in roster
+    assert classify_by_label_and_tags("Lumen", ["embodied"], known=roster) == CLASS_EMBODIED
+    assert classify_by_label_and_tags("Lumen", [], known=roster) == CLASS_DEFAULT
+
+
+def test_named_resident_is_own_class_when_configured():
+    """When the roster names 'Lumen', it becomes its own N=1 calibration class."""
+    roster = parse_resident_roster("Lumen,Vigil")
+    assert classify_by_label_and_tags("Lumen", ["embodied"], known=roster) == "Lumen"
 
 
 def test_none_meta_returns_default():


### PR DESCRIPTION
## Why

Making UNITARES **user-agnostic**: someone else who installs it doesn't have Lumen (or any of this operator's resident agents), so those identities shouldn't be baked into the framework. Residents become opt-in and customizable; a fresh install runs none and inherits none.

Stacked commits on one working branch:

### 1 — Resident roster (names / calibration classes) `02cf93e`

Hardcoded `KNOWN_RESIDENT_LABELS` (core) / `KNOWN_RESIDENT_NAMES` (SDK) → read from **`UNITARES_RESIDENTS`** env var (the var *name* is the cross-package contract; the standalone SDK can't import `src/`), default **empty**. Empty roster ⇒ agents classify by tag or the `default` class, which degrades safely via `.get(agent_class, *_DEFAULT)`.

### 2 — Resident-progress registry (liveness probe) `6bea190`

Hardcoded `RESIDENT_PROGRESS_REGISTRY` → loaded from a JSON manifest via **`UNITARES_RESIDENT_PROGRESS_MANIFEST`**, default **empty** (probe writes only its dogfood row). Ships `config/resident_progress.example.json` (field-identical to the old dict). Separate from `UNITARES_RESIDENTS` because it needs per-resident source/metric/window/threshold/cadence.

### 3 — Vigil health bookkeeping `375b03c`

Vigil hardcoded a `(governance, lumen)` pair, so only those got outage/recovery/sustained notes + uptime/streak tracking. Now `detect_changes` discovers services from `{svc}_healthy` keys and `_collect_health_state` emits per-service bookkeeping for **any** registered check — a deployment's own health plugins (redis/gateway/…) get full treatment. Additive: governance keeps `gov_up_cycles`, lumen keeps its always-present default (no-anima agnostic case unchanged), the Lumen sustained note is byte-identical. The Lumen check itself was already an external `VIGIL_CHECK_PLUGINS` plugin, not in this repo.

### 4 — Docs `d6bd3e7`

`identity.md` notes the roster is now literally deployment config (reinforcing "'resident' is not an ontological category"). Full operator guide in `docs/operations/resident-roster.md`.

### Shared

- **conftest** (root + new `agents/sdk/tests/conftest.py`) configure the canonical fleet so the suite validates the machinery against a real roster, not a baked-in one.
- **ops plists/templates** set both env vars to the canonical fleet so the standard install keeps its residents; edit/clear for other deployments.

## ⚠️ Operator action

The **live** plists in `~/Library/LaunchAgents/` aren't in the repo. After this lands, set `UNITARES_RESIDENTS` and `UNITARES_RESIDENT_PROGRESS_MANIFEST` on the running governance-mcp + residents (and reload), or the live fleet silently loses its N=1 calibration classes and progress probing. The checked-in plist + templates carry the values for fresh installs.

## Validation

- Roster + grounding + chronicler + class-promotion + void-threshold + http-residents + onboard-classifier + calibrate-class, SDK `test_substrate_emission.py` — pass.
- `tests/resident_progress/` — 52 pass / 26 skip (DB-gated).
- `agents/vigil/tests/` — 105 pass.
- Broad sweep — 817 pass, 0 failures (remaining errors elsewhere are missing DB drivers in the sandbox).
- Verified empty env ⇒ no residents / empty progress registry; configured ⇒ fleet restored.

## Remaining (operator / out-of-session)

- Confirm the `unitares-governance-plugin` repo's SDK mirror doesn't diverge — couldn't be checked from this session (repo out of scope; `list_repos` unavailable).
- Optional: mirror a one-line `UNITARES_RESIDENTS` mention into the CLAUDE.md/AGENTS.md shared-contract Setup block (skipped here to avoid churning the writer-locked shared surface; the standalone ops doc covers it).

https://claude.ai/code/session_01AovUqZF2eVH6etDki3oFVe