### PR TITLE
fix(governance): gate EISV self-relative risk by absolute basin health (#689)

### DIFF
--- a/docs/proposals/eisv-basin-health-gating-v0.md
+++ b/docs/proposals/eisv-basin-health-gating-v0.md
@@ -174,12 +174,14 @@ identical state (E=0.20/healthy-rest scores 0.15 fresh vs 0.34 gated — the gat
 is the more conservative of the two), so it is not masking relative to the
 absolute standard; (b) the absolute floors were nonetheless never strong enough
 for a single hard danger-edge breach to stand on its own, and the gate makes that
-latent weakness reachable on more states. Strengthening the floors so one hard
-breach (E/I<0.30, S>0.70, |V|>0.50) alone crosses caution is a **fleet-wide
-calibration change** affecting fixed-threshold mode too, so it is tracked as a
-**separate follow-up** rather than folded in here. The live-verifier's `--db`
-sweep (`genuine-risk-masked` count) gates whether this is theoretical or live for
-the current 21 tight-σ agents; it is the operator-side pre-merge step.
+latent weakness reachable on more states.
+
+**Operator decision (2026-06-14): leave as-is, no follow-up.** Because the gated
+score is already the more conservative of the two relative to the absolute
+baseline, the single-floor-breach behavior is accepted as the intended floor
+semantics; the absolute floors are not being strengthened now. Documented here
+so the behavior is discoverable and not later mistaken for a regression
+introduced by the gate.
 
 ## Acceptance mapping
 

--- a/docs/proposals/eisv-basin-health-gating-v0.md
+++ b/docs/proposals/eisv-basin-health-gating-v0.md
@@ -1,0 +1,180 @@
+# EISV self-relative risk: absolute-basin-health gating (issue #689)
+
+Status: proposed (design + implementation in `claude/eisv-basin-health-gating-bl7jcg`)
+Supersedes the blunt portion of: PR #686 (`MIN_MEANINGFUL_EISV_STD = 0.05`)
+Council: architect + code-reviewer + live-verifier (see "Council" below)
+
+## Problem
+
+After warmup, `assess_behavioral_state` scores risk from **z-score deviations of
+the agent's current EISV from its own behavioral baseline**
+(`_score_self_relative`). For an ultra-stable agent the baseline σ collapses to
+~0.007–0.024, so a small, **absolutely healthy** fluctuation becomes a many-σ
+"severe deviation". On 2026-06-13 the Sentinel resident (E 0.77→0.66, I 0.68→0.66
+— both healthy) scored:
+
+| component | z (σ≈true) | risk |
+|-----------|-----------|------|
+| low_E     | −4.69     | 0.300 |
+| low_I     | −3.51     | 0.300 |
+| high_S    | +3.17     | 0.200 |
+| high_V    | −2.57     | 0.143 |
+| **risk**  |           | **0.943 → high-risk → cirs_block → ~18h pause** |
+
+PR #686 added a flat floor on the z denominator
+(`MIN_MEANINGFUL_EISV_STD = 0.05`, `WelfordStats.z_score(min_std=…)` via
+`BehavioralEISV.deviation()`). It drops the Sentinel trace to 0.333 (safe) and is
+live. It works but is blunt:
+
+1. It is an empirical constant with no EISV-semantic derivation.
+2. The baseline σ is computed over **EMA-smoothed** E/I/S/V
+   (`behavioral_state.update` feeds the smoothed scalars into Welford), so σ
+   collapse is partly a *double-smoothing artifact*. A single flat 0.05
+   over-floors slow-α dims (I, α=0.08) and under-floors fast-α ones (S, α=0.15).
+3. It still lets a tight-σ agent accrue risk from purely self-relative motion
+   while sitting in an absolutely-healthy state.
+
+Blast radius: ~21–22 of 96 recently-baselined agents have tight (σ<0.05) E/I;
+**all baselined residents are in this hypersensitive class.**
+
+## Options considered
+
+### (a) Basin-gate self-relative risk — **chosen**
+Multiply each self-relative EISV risk component by a per-dimension gate
+`g ∈ [0,1]` that measures how far the **absolute** value has travelled from the
+healthy-basin edge toward its absolute danger floor:
+
+```
+low_E  : g = clamp((0.60 − E) / (0.60 − 0.30), 0, 1)     # BASIN_HIGH.E_min → ABSOLUTE_E_FLOOR
+low_I  : g = clamp((0.70 − I) / (0.70 − 0.30), 0, 1)     # BASIN_HIGH.I_min → ABSOLUTE_I_FLOOR
+high_S : g = clamp((S − 0.25) / (0.70 − 0.25), 0, 1)     # BASIN_HIGH.S_max → ABSOLUTE_S_CEILING
+high_V : g = clamp((|V| − 0.15) / (0.50 − 0.15), 0, 1)   # BASIN_HIGH.V_abs_max → ABSOLUTE_V_CEILING
+```
+
+Inside the healthy basin `g = 0`: "you moved from your own norm" is information,
+not danger, and contributes no risk. As a dimension leaves the basin toward its
+absolute floor, `g` ramps 0→1, restoring full self-relative sensitivity exactly
+where σ resolution is meaningful. The absolute floors (`_score_absolute_floors`)
+remain a hard backstop via the existing per-component `max()`.
+
+Why this is principled:
+- It gates on **absolute health**, never on σ — so it never blunts the
+  meaningful variance of a genuinely unstable agent (rejects the global-
+  desensitization failure mode the issue calls out).
+- It **sidesteps the double-smoothing artifact entirely**: inside the basin a
+  collapsed σ is irrelevant because the gate is 0, regardless of how many σ the
+  move spans. No per-α correction needed.
+- The healthy edges are single-sourced from `config.governance_config.BASIN_HIGH`
+  (duplicated as constants in `behavioral_assessment` only to keep numpy/config
+  off the scoring hot path; a drift-guard test pins parity).
+
+### (b) Per-dimension σ floor tied to the EMA step — rejected
+Derive `min_std_dim` from each dimension's EMA α (e.g. the steady-state variance
+attenuation `α/(2−α)`). This corrects the over/under-floor asymmetry of (a-flat)
+but is still a σ-floor: it desensitizes by dimension globally, still raises risk
+for self-relative motion inside the basin, and adds a second hand-tuned mapping
+(α→floor). The basin-gate removes the *need* for any σ correction in the
+in-basin regime, so (b) solves a problem (a) no longer has.
+
+### (c) Keep the flat floor, justify the value — rejected as the primary fix
+Retained only as **secondary** defense-in-depth (see below). As the primary
+mechanism it leaves all three weaknesses above.
+
+## Decision
+
+- **Primary:** basin-health gate (`_basin_health_gate`) applied to the four
+  EISV-derived components in `_score_self_relative`. rho and continuity-energy
+  components are absolute signals and are intentionally not gated.
+- **Secondary:** `MIN_MEANINGFUL_EISV_STD = 0.05` is **retained** as
+  defense-in-depth — it bounds the raw z-magnitude in the boundary region (gate
+  partially open) so a collapsed σ cannot produce an absurd z there. It only
+  binds when `std < 0.05`, so it never touches unstable agents. With the gate in
+  front, its exact value is far less load-bearing than under #686.
+
+This is "augment" rather than "replace": the gate is the new principled
+mechanism; the flat floor degrades to a numerical guard. Minimal blast radius —
+`deviation()` semantics are unchanged, and the #686 σ-floor tests stay green.
+
+## Empirical validation
+
+Harness: `scripts/analysis/validate_basin_gate.py` — rebuilds a `BehavioralEISV`
+from a persisted baseline + current EISV and assesses it under the current
+(flat-floor-only, gate forced open) vs proposed (gate active) regimes. Runs
+trace-anchored cases always; `--db` adds a live-fleet sweep over the most recent
+`state_json->'behavioral_eisv'` per recently-baselined agent in
+`core.agent_state` (the path the live-verifier runs post-merge).
+
+Field provenance (issue gotcha): EISV is read from `state_json->'behavioral_eisv'`
+(phi from `state_json->>'phi'`). The `core.agent_state.entropy` column stores
+behavioral **S**, not phi.
+
+Results (this environment — trace + parametric sweep; the live DB is not
+reachable from the web container, so the 21-agent live sweep is deferred to the
+live-verifier's environment via `--db`):
+
+```
+Sentinel pause (real trace)        before=0.333/safe       after=0.053/safe
+Sentinel S=0.70 (danger edge)      after high_S=0.200 (genuine excursion still scores)
+
+in-basin +0.06 E wobble            before=0.000/safe       after=0.000/safe
+in-basin +0.05 S wobble            before=0.000/safe       after=0.000/safe
+in-basin multi-dim small wobble    before=0.093/safe       after=0.000/safe
+boundary I→0.40 (de-escalation)    before=0.800/high-risk  after=0.278/safe
+boundary S→0.62 (de-escalation)    before=0.800/high-risk  after=0.289/safe
+deep exit E→0.35,I→0.45,S→0.65     before=1.000/high-risk  after=0.644/high-risk
+abs-floor breach E→0.20,I→0.25     before=0.867/high-risk  after=0.800/high-risk
+```
+
+Key properties confirmed:
+- **False-pause fixed:** the real Sentinel trace lands at 0.053 (deep safe),
+  not merely below the caution line.
+- **No masking of basin-exit / absolute danger:** the deep multi-dim basin exit
+  (0.644) and the absolute-floor breach (0.800) still reach high-risk → pause.
+  (See "Accepted cost" below for the one regime this path deliberately does not
+  cover — slow creep that stays *fully inside* the basin.)
+- **Gate never raises risk:** `after ≤ before` for every case (multiplier ∈ [0,1]).
+- **Sensitivity preserved, not desensitized:** the boundary states the gate
+  de-escalates (0.278, 0.289) still score *above* what the system's own absolute
+  fixed-threshold scoring gives a fresh agent at the identical state (0.016,
+  0.048). The gate sits between "absolute" (floor) and "ungated self-relative"
+  (ceiling) — closer to absolute the deeper inside the basin.
+
+## Accepted cost / non-goal
+
+By design, self-relative degradation that stays **fully inside** the healthy
+basin accrues **zero** risk on this path (gate = 0). The deliberate consequence:
+a slow drift that asymptotes just inside a basin edge — never crossing
+E=0.60 / I=0.70 / S=0.25 / |V|=0.15 — is not caught by self-relative scoring.
+This is the intended semantics ("inside the basin, moving from your own norm is
+information, not danger"), not an oversight, but it is a real trade against the
+pre-#686 behavior, which would have flagged such drift via the σ-explosion.
+
+In-basin slow creep is left to the other, orthogonal signals that already exist:
+the boundary ramp (the moment any dimension crosses its basin edge the gate
+begins to open), the absolute floors, the `trend` bonus/penalty path, and
+coherence-based health. If longitudinal in-basin creep detection is later judged
+necessary, it belongs in a dedicated trend monitor, not in re-sensitizing the
+self-relative z-path inside the basin (which would reintroduce the false-pause).
+
+## Acceptance mapping
+
+| Acceptance criterion | Status |
+|---|---|
+| Stable-agent false-pause stays fixed (Sentinel trace safe) | ✅ 0.053, verdict safe |
+| Genuine basin-exit still pauses | ✅ deep exit 0.644 / floor breach 0.800 → high-risk |
+| Flat 0.05 replaced/justified by basin-gated rule | ✅ gate primary; flat floor demoted to documented secondary guard |
+| Tests cover false-positive (stable wobble safe) + true-positive (basin exit flags) | ✅ `TestBasinHealthGate`, `TestBasinGateSentinelTrace` |
+| Full test-cache.sh green | see PR CI |
+
+## Council
+
+- **Architect** — design framing: is basin-gating the right principled fix vs
+  per-dim σ floor; is the healthy-edge=BASIN_HIGH / danger-edge=ABSOLUTE_* choice
+  sound; should the flat floor be kept or dropped.
+- **Code-reviewer** — the diff: gate correctness, no circularity with the risk
+  being computed, parity drift-guard, blast radius on `deviation()` callers.
+- **Live-verifier** — empirical rigor: re-run `validate_basin_gate.py --db`
+  across the 21 tight-σ agents on the live fleet, confirm 0 genuine-risk states
+  masked.
+
+Operator is the merge gate; PR left as draft. Do not auto-merge.

--- a/docs/proposals/eisv-basin-health-gating-v0.md
+++ b/docs/proposals/eisv-basin-health-gating-v0.md
@@ -156,6 +156,31 @@ coherence-based health. If longitudinal in-basin creep detection is later judged
 necessary, it belongs in a dedicated trend monitor, not in re-sensitizing the
 self-relative z-path inside the basin (which would reintroduce the false-pause).
 
+### Gate-exposed weakness of the absolute floors (live-verifier finding)
+
+The live-verifier's adversarial grid surfaced a class the gate **exposes but does
+not create**: a state breaching exactly ONE absolute floor while the other
+dimensions are healthy (e.g. E=0.20 with I=0.65, S=0.18, V=0.0) goes
+`before=0.60/high-risk → after=0.34/safe`. Root cause: a single absolute-floor
+breach contributes at most ~0.30 (E→0) or ~0.20 (S/|V|), both below the 0.35
+safe threshold. Pre-#689 such a state was held high-risk by the **false**
+self-relative σ-explosion on the *healthy* dimensions (counting I=0.65 as −3σ
+"dangerous"); the gate correctly removes that false contribution, leaving only
+the genuinely-weak floor backstop.
+
+Two things are true at once: (a) the gate never scores a baselined agent *below*
+what the system's own absolute fixed-threshold scoring gives a fresh agent at the
+identical state (E=0.20/healthy-rest scores 0.15 fresh vs 0.34 gated — the gate
+is the more conservative of the two), so it is not masking relative to the
+absolute standard; (b) the absolute floors were nonetheless never strong enough
+for a single hard danger-edge breach to stand on its own, and the gate makes that
+latent weakness reachable on more states. Strengthening the floors so one hard
+breach (E/I<0.30, S>0.70, |V|>0.50) alone crosses caution is a **fleet-wide
+calibration change** affecting fixed-threshold mode too, so it is tracked as a
+**separate follow-up** rather than folded in here. The live-verifier's `--db`
+sweep (`genuine-risk-masked` count) gates whether this is theoretical or live for
+the current 21 tight-σ agents; it is the operator-side pre-merge step.
+
 ## Acceptance mapping
 
 | Acceptance criterion | Status |
@@ -168,13 +193,25 @@ self-relative z-path inside the basin (which would reintroduce the false-pause).
 
 ## Council
 
-- **Architect** — design framing: is basin-gating the right principled fix vs
-  per-dim σ floor; is the healthy-edge=BASIN_HIGH / danger-edge=ABSOLUTE_* choice
-  sound; should the flat floor be kept or dropped.
-- **Code-reviewer** — the diff: gate correctness, no circularity with the risk
-  being computed, parity drift-guard, blast radius on `deviation()` callers.
-- **Live-verifier** — empirical rigor: re-run `validate_basin_gate.py --db`
-  across the 21 tight-σ agents on the live fleet, confirm 0 genuine-risk states
-  masked.
+- **Architect — APPROVE-WITH-CHANGES (addressed).** Confirmed basin-gating is
+  the right fix over a per-dim σ floor; confirmed the linear ramp (not assumed
+  in-basin membership) is what keeps the boundary-region Sentinel safe; confirmed
+  no circularity (gate reads only absolute EISV, never risk/coherence). Required:
+  document the in-basin slow-creep accepted cost (done, "Accepted cost" above).
+  Suggested: clarify the floor `max()` backstop in the docstring (done).
+- **Code-reviewer — APPROVE.** Verified gate math (no div-by-zero: the
+  `value>=healthy`/`value<=danger` early-returns precede the division), correct
+  component application (rho/CE ungated), the `max()` floor backstop, parity
+  drift-guard sufficiency, `deviation()` callers unaffected, and strong (non-
+  tautological) tests. Nit (addressed): reworded the import-avoidance comment.
+- **Live-verifier — APPROVE-WITH-CHANGES.** Audited the harness method (correct;
+  reads `state_json->'behavioral_eisv'`, not the entropy column). Reproduced the
+  default run; confirmed 0 violations of "gate never raises risk" across a 9,680-
+  point grid. Live DB not reachable from this container — the 21-agent `--db`
+  sweep is the operator-side pre-merge step. Found the gate-exposed single-floor-
+  breach masking class (documented above) — recommends running `--db` before
+  merge and a separate follow-up to strengthen the absolute floors.
 
-Operator is the merge gate; PR left as draft. Do not auto-merge.
+Operator is the merge gate; PR left as draft. Do not auto-merge. Pre-merge
+operator step: `python3 scripts/analysis/validate_basin_gate.py --db` in a
+DB-reachable env; a `genuine-risk-masked: 0` line clears the live sweep.

--- a/scripts/analysis/validate_basin_gate.py
+++ b/scripts/analysis/validate_basin_gate.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Empirical validation for issue #689 — absolute-basin-health gating.
+
+Compares the *current* live behaviour (flat MIN_MEANINGFUL_EISV_STD σ-floor only,
+i.e. the basin gate forced fully open) against the *proposed* behaviour (basin
+gate active) by rebuilding a ``BehavioralEISV`` from a persisted baseline +
+current EISV and calling ``assess_behavioral_state`` under both regimes.
+
+Two data sources:
+
+  1. Trace-anchored cases (always available): the real captured 2026-06-13
+     Sentinel false-pause trace plus a parametric sweep of the tight-σ class
+     (the ~21 recently-baselined agents with σ<0.05 on E/I — all baselined
+     residents are in this hypersensitive class). Healthy wobbles must stay
+     SAFE; genuine basin-exit states must still FLAG.
+
+  2. Live fleet (optional): pass ``--db`` to pull the most recent persisted
+     ``state_json->'behavioral_eisv'`` per recently-baselined agent from
+     ``core.agent_state`` and run the same comparison across the real fleet.
+     Requires asyncpg and a reachable PostgreSQL (DATABASE_URL or PG* env, or
+     --dsn). This is the path the live-verifier runs post-merge.
+
+NOTE on field provenance (issue #689 gotcha): read behavioral E/I/S/V/phi from
+``state_json->'behavioral_eisv'`` (and phi from ``state_json->>'phi'``). The
+``core.agent_state.entropy`` column stores behavioral S exactly, NOT phi — do
+not read EISV from column names.
+
+Usage:
+    python3 scripts/analysis/validate_basin_gate.py            # trace + sweep
+    python3 scripts/analysis/validate_basin_gate.py --db       # + live fleet
+    python3 scripts/analysis/validate_basin_gate.py --db --dsn postgresql://...
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from contextlib import contextmanager
+from typing import Dict, Optional, Tuple
+
+sys.path.insert(0, ".")
+
+from src.agent_behavioral_baseline import WelfordStats  # noqa: E402
+from src.behavioral_state import BehavioralEISV  # noqa: E402
+import src.behavioral_assessment as ba  # noqa: E402
+from src.behavioral_assessment import (  # noqa: E402
+    assess_behavioral_state,
+    RISK_SAFE_THRESHOLD,
+    RISK_CAUTION_THRESHOLD,
+)
+
+
+# --- Real captured Sentinel baseline at the moment of the 2026-06-13 false pause
+# (count, mean, m2) per dim; 1239 updates. From tests/test_stable_agent_risk_calibration.py.
+_SENTINEL_BASELINE = {
+    "E": (0.7729981068548344, 0.7055579515066273),
+    "I": (0.6811142748149669, 0.057464469736054416),
+    "S": (0.23501023019317843, 2.5585618595179382),
+    "V": (0.09186701608785974, 0.3958598283268047),
+}
+_SENTINEL_PAUSE_STATE = {"E": 0.6608, "I": 0.6572, "S": 0.379, "V": 0.046}
+
+
+def _build(baseline_mean_m2: Dict[str, Tuple[float, float]],
+           current: Dict[str, float], count: int = 1239) -> BehavioralEISV:
+    """Rebuild a baselined BehavioralEISV from (mean, m2) baseline + current EISV."""
+    st = BehavioralEISV()
+    for dim, (mean, m2) in baseline_mean_m2.items():
+        bl: WelfordStats = getattr(st, f"_baseline_{dim}")
+        bl.count, bl.mean, bl.m2 = count, mean, m2
+    for dim, val in current.items():
+        setattr(st, dim, val)
+    st.update_count = count
+    return st
+
+
+def _build_from_stats(baseline_stats: Dict[str, dict],
+                      current: Dict[str, float]) -> Optional[BehavioralEISV]:
+    """Rebuild from a persisted ``baseline_stats`` dict (to_dict() form)."""
+    st = BehavioralEISV()
+    counts = []
+    for dim in ("E", "I", "S", "V"):
+        d = baseline_stats.get(dim)
+        if not d:
+            return None
+        bl: WelfordStats = getattr(st, f"_baseline_{dim}")
+        bl.count = int(d.get("count", 0))
+        bl.mean = float(d.get("mean", 0.0))
+        bl.m2 = float(d.get("m2", 0.0))
+        counts.append(bl.count)
+    for dim in ("E", "I", "S", "V"):
+        if dim in current and current[dim] is not None:
+            setattr(st, dim, float(current[dim]))
+    st.update_count = max(counts) if counts else 0
+    return st
+
+
+@contextmanager
+def _gate_disabled():
+    """Force the basin gate fully open → reproduces pre-#689 (flat-floor) scoring."""
+    original = ba._basin_health_gate
+    ba._basin_health_gate = lambda state: {  # type: ignore[assignment]
+        "low_E": 1.0, "low_I": 1.0, "high_S": 1.0, "high_V": 1.0,
+    }
+    try:
+        yield
+    finally:
+        ba._basin_health_gate = original  # type: ignore[assignment]
+
+
+def _assess_both(state: BehavioralEISV, rho: float = 0.0):
+    """Return (before_result, after_result): flat-floor-only vs basin-gate."""
+    after = assess_behavioral_state(state, rho=rho)
+    with _gate_disabled():
+        before = assess_behavioral_state(state, rho=rho)
+    return before, after
+
+
+def _verdict_tag(risk: float) -> str:
+    if risk < RISK_SAFE_THRESHOLD:
+        return "safe"
+    if risk < RISK_CAUTION_THRESHOLD:
+        return "caution"
+    return "high-risk"
+
+
+def _row(label: str, before, after) -> str:
+    return (f"  {label:<46} "
+            f"before={before.risk:0.3f}/{before.verdict:<9} "
+            f"after={after.risk:0.3f}/{after.verdict:<9}")
+
+
+def run_trace_cases() -> bool:
+    print("=== Trace-anchored: 2026-06-13 Sentinel false-pause ===")
+    ok = True
+
+    st = _build(_SENTINEL_BASELINE, _SENTINEL_PAUSE_STATE)
+    before, after = _assess_both(st)
+    print(_row("Sentinel pause state (healthy wobble)", before, after))
+    # Acceptance: proposed must NOT be high-risk; must be safe.
+    if after.verdict == "high-risk" or after.risk >= RISK_CAUTION_THRESHOLD:
+        print("  FAIL: proposed gate leaves Sentinel pause non-safe"); ok = False
+
+    # Genuine entropy excursion on the same tight baseline → must still flag high_S.
+    st_spike = _build(_SENTINEL_BASELINE, {"E": 0.773, "I": 0.681, "S": 0.70, "V": 0.092})
+    _, after_spike = _assess_both(st_spike)
+    print(f"  {'Sentinel S=0.70 (absolute danger edge)':<46} "
+          f"after high_S={after_spike.components.get('high_S', 0.0):0.3f} "
+          f"risk={after_spike.risk:0.3f}/{after_spike.verdict}")
+    if after_spike.components.get("high_S", 0.0) <= 0.0:
+        print("  FAIL: genuine entropy excursion no longer scores high_S"); ok = False
+
+    return ok
+
+
+def run_sweep() -> bool:
+    """Parametric sweep of the tight-σ class (representative of the ~21 affected).
+
+    Asserts the principled invariants of the gate rather than arbitrary labels:
+      - the gate NEVER raises risk (multiplier ∈ [0,1]):          after <= before
+      - in-basin wobbles are safe:                                 verdict == safe
+      - genuine multi-dim basin exits still pause:                 high-risk
+      - absolute-floor breaches still pause regardless of gate:    high-risk
+    """
+    print("\n=== Parametric sweep: tight-σ baselined agents (σ≈0.012) ===")
+    ok = True
+    TIGHT = 0.012  # baseline std; ultra-stable, well below the 0.05 flat floor
+
+    def tight_baseline(meanE, meanI, meanS, meanV, count=600):
+        m2 = TIGHT * TIGHT * (count - 1)
+        return {"E": (meanE, m2), "I": (meanI, m2), "S": (meanS, m2), "V": (meanV, m2)}
+
+    # (label, baseline means, current EISV, expect) — expect: safe | pause | none
+    #   safe  → verdict must be "safe" (in-basin: deviation is information)
+    #   pause → verdict must be "high-risk" (genuine danger must still escalate)
+    #   none  → no verdict assertion; case demonstrates graded de-escalation
+    cases = [
+        ("in-basin: +0.06 E wobble",
+         (0.75, 0.78, 0.18, -0.03), {"E": 0.69, "I": 0.78, "S": 0.18, "V": -0.03}, "safe"),
+        ("in-basin: +0.05 S wobble",
+         (0.72, 0.76, 0.16, 0.0), {"E": 0.72, "I": 0.76, "S": 0.21, "V": 0.0}, "safe"),
+        ("in-basin: multi-dim small wobble",
+         (0.74, 0.80, 0.15, 0.02), {"E": 0.66, "I": 0.72, "S": 0.24, "V": 0.10}, "safe"),
+        ("boundary: I→0.40 (graded de-escalation)",
+         (0.74, 0.80, 0.18, 0.0), {"E": 0.62, "I": 0.40, "S": 0.30, "V": 0.22}, "none"),
+        ("boundary: S→0.62 (graded de-escalation)",
+         (0.70, 0.76, 0.18, 0.0), {"E": 0.55, "I": 0.60, "S": 0.62, "V": 0.05}, "none"),
+        ("deep exit: E→0.35,I→0.45,S→0.65,V→0.20",
+         (0.74, 0.78, 0.18, 0.0), {"E": 0.35, "I": 0.45, "S": 0.65, "V": 0.20}, "pause"),
+        ("abs-floor breach: E→0.20,I→0.25,S→0.80",
+         (0.74, 0.78, 0.18, 0.0), {"E": 0.20, "I": 0.25, "S": 0.80, "V": 0.10}, "pause"),
+    ]
+
+    for label, (mE, mI, mS, mV), cur, expect in cases:
+        st = _build(tight_baseline(mE, mI, mS, mV), cur)
+        before, after = _assess_both(st)
+        print(_row(label, before, after))
+        # Invariant: the gate is a [0,1] multiplier — it must never raise risk.
+        if after.risk > before.risk + 1e-9:
+            print(f"  FAIL: gate raised risk ({before.risk:.3f}→{after.risk:.3f})"); ok = False
+        if expect == "safe" and after.verdict != "safe":
+            print(f"  FAIL: in-basin wobble not safe (got {after.verdict})"); ok = False
+        if expect == "pause" and after.verdict != "high-risk":
+            print(f"  FAIL: genuine danger did not escalate (got {after.verdict})"); ok = False
+    return ok
+
+
+async def run_live(dsn: Optional[str], limit: int) -> bool:
+    print("\n=== Live fleet: recently-baselined agents from core.agent_state ===")
+    import json
+    import os
+    try:
+        import asyncpg  # type: ignore
+    except Exception:
+        print("  SKIP: asyncpg not installed."); return True
+
+    dsn = dsn or os.environ.get("DATABASE_URL")
+    try:
+        conn = await asyncpg.connect(dsn) if dsn else await asyncpg.connect()
+    except Exception as e:  # noqa: BLE001
+        print(f"  SKIP: could not connect to PostgreSQL ({e})."); return True
+
+    masked = 0
+    flagged_before_safe_after = 0
+    newly_masked = 0  # genuine risk the gate would hide (must be 0)
+    try:
+        rows = await conn.fetch(
+            """
+            SELECT DISTINCT ON (agent_id) agent_id,
+                   state_json->'behavioral_eisv' AS beisv
+            FROM core.agent_state
+            WHERE state_json ? 'behavioral_eisv'
+            ORDER BY agent_id, created_at DESC
+            LIMIT $1
+            """,
+            limit,
+        )
+    except Exception as e:  # noqa: BLE001
+        print(f"  SKIP: query failed ({e})."); await conn.close(); return True
+
+    examined = 0
+    for r in rows:
+        beisv = r["beisv"]
+        if beisv is None:
+            continue
+        if isinstance(beisv, str):
+            beisv = json.loads(beisv)
+        baseline_stats = beisv.get("baseline_stats")
+        if not baseline_stats:
+            continue
+        current = {k: beisv.get(k) for k in ("E", "I", "S", "V")}
+        st = _build_from_stats(baseline_stats, current)
+        if st is None or not st.is_baselined:
+            continue
+        examined += 1
+        before, after = _assess_both(st)
+        if before.verdict == "high-risk" and after.verdict != "high-risk":
+            flagged_before_safe_after += 1
+        # A genuine risk would be: state outside basin (absolute floors / fixed
+        # thresholds say bad) but gate downgrades it. Detect masking: before
+        # high-risk AND after safe AND the state is genuinely degraded.
+        degraded = (after.components.get("low_E", 0) > 0 or
+                    after.components.get("low_I", 0) > 0 or
+                    after.components.get("high_S", 0) > 0 or
+                    after.components.get("high_V", 0) > 0)
+        if before.verdict == "high-risk" and after.verdict == "safe" and not degraded:
+            masked += 1  # gate fully suppressed — confirm absolute health below
+        # genuine masking check: was the ABSOLUTE state actually unhealthy?
+        if before.verdict == "high-risk" and after.verdict == "safe":
+            absolutely_bad = (st.E < ba.ABSOLUTE_E_FLOOR or st.I < ba.ABSOLUTE_I_FLOOR
+                              or st.S > ba.ABSOLUTE_S_CEILING or abs(st.V) > ba.ABSOLUTE_V_CEILING)
+            if absolutely_bad:
+                newly_masked += 1
+                print(f"  WARN masked genuine risk: {r['agent_id']} "
+                      f"E={st.E:.2f} I={st.I:.2f} S={st.S:.2f} V={st.V:.2f}")
+    await conn.close()
+    print(f"  examined={examined} baselined agents; "
+          f"de-escalated high-risk→non-high-risk by gate: {flagged_before_safe_after}; "
+          f"fully-suppressed-in-basin: {masked}; "
+          f"genuine-risk-masked (must be 0): {newly_masked}")
+    if newly_masked > 0:
+        print("  FAIL: gate masked genuinely-degraded (absolute floor) states"); return False
+    return True
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", action="store_true", help="also run against live fleet DB")
+    ap.add_argument("--dsn", default=None, help="explicit PostgreSQL DSN")
+    ap.add_argument("--limit", type=int, default=200)
+    args = ap.parse_args()
+
+    ok = True
+    ok &= run_trace_cases()
+    ok &= run_sweep()
+    if args.db:
+        import asyncio
+        ok &= asyncio.run(run_live(args.dsn, args.limit))
+
+    print("\n" + ("PASS — acceptance criteria met" if ok else "FAIL — see above"))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/behavioral_assessment.py
+++ b/src/behavioral_assessment.py
@@ -65,8 +65,9 @@ ABSOLUTE_V_CEILING = 0.50
 #
 # Healthy edge = BASIN_HIGH per-dimension EISV bounds. These MIRROR
 # config.governance_config.BASIN_HIGH; they are duplicated here (rather than
-# imported) to keep this scoring module free of the numpy/config import chain on
-# the hot path. Parity is drift-guarded by
+# imported) to keep this module's IMPORT free of the numpy/config chain —
+# importing config.governance_config pulls numpy at import time (an `np.ndarray`
+# annotation is evaluated at class-definition time). Parity is drift-guarded by
 # tests/test_stable_agent_risk_calibration.py::test_basin_gate_edges_match_config.
 # Danger edge = the ABSOLUTE_* floors/ceilings above.
 #

--- a/src/behavioral_assessment.py
+++ b/src/behavioral_assessment.py
@@ -6,6 +6,12 @@ Assessment is auditable — you can trace exactly why a verdict was issued.
 After warmup, scoring switches from fixed universal thresholds to
 self-relative z-score deviations from the agent's own behavioral baseline.
 Absolute safety floors always apply regardless of baseline.
+
+Self-relative deviation risk is gated by absolute basin health (issue #689):
+inside the healthy basin a deviation from your own norm is information, not
+danger, so it raises no risk; outside the basin the gate opens and the absolute
+floors fire. This replaces the flat MIN_MEANINGFUL_EISV_STD σ-floor as the
+principled fix for the 2026-06-13 ultra-stable-agent false-pause (#686).
 """
 
 from __future__ import annotations
@@ -49,10 +55,70 @@ ABSOLUTE_I_FLOOR = 0.30
 ABSOLUTE_S_CEILING = 0.70
 ABSOLUTE_V_CEILING = 0.50
 
+# --- Absolute-basin-health gate edges (issue #689) ----------------------------
+# Self-relative z-deviation risk is gated by how far the ABSOLUTE EISV value sits
+# between the healthy-basin edge and the absolute danger edge. Inside the healthy
+# basin "you moved from your own norm" is information, not danger, so the gate is
+# 0 and self-relative deviations contribute no risk; as a dimension leaves the
+# basin toward its absolute floor the gate ramps 0→1, restoring full self-relative
+# sensitivity exactly where it matters (and where σ resolution is meaningful).
+#
+# Healthy edge = BASIN_HIGH per-dimension EISV bounds. These MIRROR
+# config.governance_config.BASIN_HIGH; they are duplicated here (rather than
+# imported) to keep this scoring module free of the numpy/config import chain on
+# the hot path. Parity is drift-guarded by
+# tests/test_stable_agent_risk_calibration.py::test_basin_gate_edges_match_config.
+# Danger edge = the ABSOLUTE_* floors/ceilings above.
+#
+# This is the principled replacement for the flat MIN_MEANINGFUL_EISV_STD floor:
+# it does not touch σ at all, so it never blunts the meaningful variance of a
+# genuinely unstable agent, and it sidesteps the EMA double-smoothing artifact
+# (a tight σ inside the basin no longer matters because the gate is 0 there).
+BASIN_E_HEALTHY = 0.60   # == BASIN_HIGH.E_min
+BASIN_I_HEALTHY = 0.70   # == BASIN_HIGH.I_min
+BASIN_S_HEALTHY = 0.25   # == BASIN_HIGH.S_max
+BASIN_V_HEALTHY = 0.15   # == BASIN_HIGH.V_abs_max
+
 # Sigma thresholds for self-relative scoring
 SIGMA_MILD = 1.5      # noticeably different from self
 SIGMA_MODERATE = 2.0   # concerning
 SIGMA_SEVERE = 3.0     # severe deviation
+
+
+def _basin_health_gate(state: BehavioralEISV) -> Dict[str, float]:
+    """Per-dimension absolute-health gate in [0, 1] for self-relative risk.
+
+    0.0 == dimension is inside the healthy basin (deviation is information, not
+    danger); 1.0 == dimension has reached its absolute danger edge (full
+    self-relative sensitivity). Linear ramp between the basin edge and the
+    absolute floor. Keyed by the risk-component name the gate multiplies.
+
+    Uses ONLY the absolute EISV value — never risk or coherence — so there is no
+    circularity with the risk score being computed.
+    """
+
+    def _floor_gate(value: float, healthy: float, danger: float) -> float:
+        # lower-is-worse dimensions (E, I): gate opens as value falls below healthy
+        if value >= healthy:
+            return 0.0
+        if value <= danger:
+            return 1.0
+        return (healthy - value) / (healthy - danger)
+
+    def _ceiling_gate(value: float, healthy: float, danger: float) -> float:
+        # higher-is-worse dimensions (S, |V|): gate opens as value rises above healthy
+        if value <= healthy:
+            return 0.0
+        if value >= danger:
+            return 1.0
+        return (value - healthy) / (danger - healthy)
+
+    return {
+        "low_E": _floor_gate(state.E, BASIN_E_HEALTHY, ABSOLUTE_E_FLOOR),
+        "low_I": _floor_gate(state.I, BASIN_I_HEALTHY, ABSOLUTE_I_FLOOR),
+        "high_S": _ceiling_gate(state.S, BASIN_S_HEALTHY, ABSOLUTE_S_CEILING),
+        "high_V": _ceiling_gate(abs(state.V), BASIN_V_HEALTHY, ABSOLUTE_V_CEILING),
+    }
 
 
 def assess_behavioral_state(
@@ -203,14 +269,27 @@ def _score_self_relative(
 
     Same components and weights as fixed-threshold mode, but triggers are based
     on sigma-deviations from the agent's characteristic operating point.
+
+    Each EISV-derived component is then multiplied by an absolute-basin-health
+    gate (issue #689): inside the healthy basin the gate is 0, so a deviation
+    from your own norm raises no risk; as a dimension leaves the basin toward its
+    absolute floor the gate ramps 0→1, restoring full self-relative sensitivity.
+    The rho and continuity-energy components are absolute signals (not baseline-
+    relative) and are intentionally NOT gated.
+
+    NOTE: a gated-to-0 component here does NOT mean the dimension cannot raise
+    risk — ``assess_behavioral_state`` takes ``max()`` of this result with
+    ``_score_absolute_floors`` per component, so the absolute floors remain a
+    hard backstop regardless of the gate.
     """
     components: Dict[str, float] = {}
+    gate = _basin_health_gate(state)
 
     # --- Component 1: E deviation below baseline (weight: 0.30) ---
     z_E = state.deviation("E")
     if z_E < -SIGMA_MILD:
         severity = min(1.0, (-z_E - SIGMA_MILD) / (SIGMA_SEVERE - SIGMA_MILD))
-        components["low_E"] = 0.30 * severity
+        components["low_E"] = 0.30 * severity * gate["low_E"]
     else:
         components["low_E"] = 0.0
 
@@ -218,7 +297,7 @@ def _score_self_relative(
     z_I = state.deviation("I")
     if z_I < -SIGMA_MILD:
         severity = min(1.0, (-z_I - SIGMA_MILD) / (SIGMA_SEVERE - SIGMA_MILD))
-        components["low_I"] = 0.30 * severity
+        components["low_I"] = 0.30 * severity * gate["low_I"]
     else:
         components["low_I"] = 0.0
 
@@ -230,7 +309,7 @@ def _score_self_relative(
         sigma_threshold = SIGMA_MODERATE
     if z_S > sigma_threshold:
         severity = min(1.0, (z_S - sigma_threshold) / (SIGMA_SEVERE - sigma_threshold))
-        components["high_S"] = 0.20 * severity
+        components["high_S"] = 0.20 * severity * gate["high_S"]
     else:
         components["high_S"] = 0.0
 
@@ -238,7 +317,7 @@ def _score_self_relative(
     z_V = state.deviation("V")
     if abs(z_V) > SIGMA_MILD:
         severity = min(1.0, (abs(z_V) - SIGMA_MILD) / (SIGMA_SEVERE - SIGMA_MILD))
-        components["high_V"] = 0.20 * severity
+        components["high_V"] = 0.20 * severity * gate["high_V"]
     else:
         components["high_V"] = 0.0
 

--- a/src/behavioral_state.py
+++ b/src/behavioral_state.py
@@ -57,10 +57,20 @@ BASELINE_WARMUP_UPDATES = 30
 # pause (E 0.77→0.66, I 0.68→0.66 — both healthy) scored risk 0.94 (high-risk)
 # with no floor vs 0.33 (safe) at 0.05; genuine degradations are unchanged.
 #
-# A flat floor is the blunt form of the more principled fix (gate self-relative
-# risk by absolute basin health); see the "health-gating" follow-up. A flat
-# value also slightly over-floors slow-alpha dimensions (I) and under-floors
-# fast-alpha ones (S) since the per-dimension EMA step differs.
+# As of issue #689 this flat floor is SECONDARY. The principled fix — gating
+# self-relative deviation risk by absolute basin health — lives in
+# behavioral_assessment._basin_health_gate: inside the healthy basin the
+# self-relative components are multiplied by 0, so a tight-σ agent's small,
+# absolutely-healthy wobble raises no risk regardless of how many σ it spans.
+# That gate, not this constant, is what now keeps the Sentinel trace safe.
+#
+# The floor is retained as defense-in-depth: it bounds the raw z-magnitude in
+# the boundary region (where the gate is partially open) so a collapsed σ cannot
+# produce an absurd z there. It does NOT touch σ for unstable agents (it only
+# binds when std < the floor), so it never blunts meaningful variance. A flat
+# value still slightly over-floors slow-alpha dims (I) and under-floors fast-alpha
+# ones (S) since the per-dimension EMA step differs — but with the basin gate in
+# front, the exact value is far less load-bearing than it was under #686.
 MIN_MEANINGFUL_EISV_STD = 0.05
 
 

--- a/tests/test_stable_agent_risk_calibration.py
+++ b/tests/test_stable_agent_risk_calibration.py
@@ -104,3 +104,104 @@ class TestDeviationUsesFloor:
         # floor this is ~-4.7 sigma, with the 0.05 floor it is ~-2.24.
         z_E = state.deviation("E")
         assert z_E == pytest.approx((0.6608 - 0.7729981068548344) / MIN_MEANINGFUL_EISV_STD, rel=1e-2)
+
+
+# --- Issue #689: absolute-basin-health gating of self-relative risk -----------
+
+from src.behavioral_assessment import (  # noqa: E402
+    _basin_health_gate,
+    _score_self_relative,
+    RISK_SAFE_THRESHOLD,
+    BASIN_E_HEALTHY,
+    BASIN_I_HEALTHY,
+    BASIN_S_HEALTHY,
+    BASIN_V_HEALTHY,
+)
+
+
+class TestBasinHealthGate:
+    def test_gate_closed_inside_basin(self):
+        # All EISV dims comfortably inside BASIN_HIGH → every gate is 0.
+        st = BehavioralEISV()
+        st.E, st.I, st.S, st.V = 0.75, 0.80, 0.15, 0.02
+        gate = _basin_health_gate(st)
+        assert gate == {"low_E": 0.0, "low_I": 0.0, "high_S": 0.0, "high_V": 0.0}
+
+    def test_gate_full_at_absolute_edge(self):
+        # At/below the absolute floors the gate is fully open (1.0).
+        st = BehavioralEISV()
+        st.E, st.I, st.S, st.V = 0.30, 0.30, 0.70, 0.50
+        gate = _basin_health_gate(st)
+        assert gate == {"low_E": 1.0, "low_I": 1.0, "high_S": 1.0, "high_V": 1.0}
+
+    def test_gate_ramps_linearly_in_boundary(self):
+        # E halfway between healthy edge (0.60) and danger floor (0.30) → 0.5.
+        st = BehavioralEISV()
+        st.E, st.I, st.S, st.V = 0.45, 0.80, 0.15, 0.0
+        assert _basin_health_gate(st)["low_E"] == pytest.approx(0.5)
+
+    def test_gate_zeroes_self_relative_inside_basin(self):
+        # An ultra-stable agent firmly inside the basin: even a many-σ move from
+        # its own norm produces NO self-relative EISV risk (gate is 0).
+        st = _baselined(
+            {"E": (0.75, 0.01), "I": (0.80, 0.01), "S": (0.15, 0.01), "V": (0.0, 0.01)},
+            {"E": 0.66, "I": 0.72, "S": 0.24, "V": 0.10},
+        )
+        comps = _score_self_relative(st, rho=0.0, continuity_energy=0.0, ctx={})
+        assert comps["low_E"] == 0.0
+        assert comps["low_I"] == 0.0
+        assert comps["high_S"] == 0.0
+        assert comps["high_V"] == 0.0
+
+
+class TestBasinGateSentinelTrace:
+    def test_sentinel_pause_is_well_below_caution(self):
+        # The gate (not just the flat floor) drives the real Sentinel false-pause
+        # trace deep into safe territory: 0.94 ungated → ~0.05 gated.
+        state = _baselined(_SENTINEL_BASELINE, _SENTINEL_PAUSE_STATE)
+        result = assess_behavioral_state(state, rho=0.0)
+        assert result.verdict == "safe"
+        assert result.risk < RISK_SAFE_THRESHOLD
+
+    def test_gate_never_raises_risk(self):
+        # The gate is a [0,1] multiplier: gated risk <= ungated risk for any state.
+        import src.behavioral_assessment as ba
+        state = _baselined(_SENTINEL_BASELINE, _SENTINEL_PAUSE_STATE)
+        gated = assess_behavioral_state(state, rho=0.0).risk
+        original = ba._basin_health_gate
+        ba._basin_health_gate = lambda s: {"low_E": 1.0, "low_I": 1.0, "high_S": 1.0, "high_V": 1.0}
+        try:
+            ungated = assess_behavioral_state(state, rho=0.0).risk
+        finally:
+            ba._basin_health_gate = original
+        assert gated <= ungated + 1e-9
+
+    def test_genuine_basin_exit_still_high_risk(self):
+        # A real multi-dimensional basin exit on a tight baseline must still pause.
+        state = _baselined(
+            {"E": (0.74, 0.08), "I": (0.78, 0.08), "S": (0.18, 0.08), "V": (0.0, 0.08)},
+            {"E": 0.35, "I": 0.45, "S": 0.65, "V": 0.20},
+        )
+        result = assess_behavioral_state(state, rho=0.0)
+        assert result.verdict == "high-risk"
+
+    def test_absolute_floor_breach_pauses_regardless_of_gate(self):
+        # Below the absolute floors, the floors fire and the gate is fully open.
+        state = _baselined(
+            {"E": (0.74, 0.08), "I": (0.78, 0.08), "S": (0.18, 0.08), "V": (0.0, 0.08)},
+            {"E": 0.20, "I": 0.25, "S": 0.80, "V": 0.10},
+        )
+        result = assess_behavioral_state(state, rho=0.0)
+        assert result.verdict == "high-risk"
+
+
+class TestBasinGateEdgesMatchConfig:
+    def test_basin_gate_edges_match_config(self):
+        # Drift-guard: the healthy-edge constants duplicated in behavioral_assessment
+        # (kept local to avoid the numpy/config import chain on the hot path) must
+        # stay byte-identical to config.governance_config.BASIN_HIGH.
+        from config.governance_config import BASIN_HIGH
+        assert BASIN_E_HEALTHY == BASIN_HIGH.E_min
+        assert BASIN_I_HEALTHY == BASIN_HIGH.I_min
+        assert BASIN_S_HEALTHY == BASIN_HIGH.S_max
+        assert BASIN_V_HEALTHY == BASIN_HIGH.V_abs_max


### PR DESCRIPTION
Closes #689.

## What

Replaces the flat `MIN_MEANINGFUL_EISV_STD = 0.05` σ-floor (the #686 stop-gap) as the **primary** mechanism with **absolute-basin-health gating** of self-relative EISV risk.

After warmup, `_score_self_relative` scores risk from z-deviations of an agent's current EISV from its own baseline. For ultra-stable agents the baseline σ collapses (~0.007–0.024), so a small, absolutely-healthy wobble becomes a many-σ "severe deviation" → false high-risk → `cirs_block` → pause (the 2026-06-13 Sentinel ~18h false-pause).

Each self-relative EISV component is now multiplied by a per-dimension gate `g ∈ [0,1]`:
- **0** inside the healthy basin (`BASIN_HIGH` edges: E≥0.6, I≥0.7, S≤0.25, |V|≤0.15) — a deviation from your own norm is information, not danger;
- ramps **linearly to 1** at the absolute danger floors (E/I=0.30, S=0.70, |V|=0.50) — full self-relative sensitivity exactly where σ resolution is meaningful;
- the absolute floors remain a hard backstop via the existing per-component `max()`.

The gate keys **only on absolute EISV** (never risk/coherence → no circularity with the risk being computed) and **never touches σ**, so it cannot blunt a genuinely-unstable agent's meaningful variance, and it sidesteps the EMA double-smoothing artifact (a collapsed σ inside the basin is irrelevant because the gate is 0 there).

The flat floor is **retained as documented defense-in-depth** (bounds raw z in the boundary region where the gate is partially open; only binds when `std < 0.05`). `deviation()` semantics are unchanged.

## Why basin-gating over a per-dimension σ floor

A per-α σ floor (option b) is still a σ-floor: it desensitizes by dimension globally and still raises self-relative risk for motion *inside* an absolutely-healthy state. The basin-gate attacks the actual semantic error — treating self-relative motion as danger while the agent is objectively fine — and removes the *need* for any σ correction in-basin. Full rationale + rejected options in `docs/proposals/eisv-basin-health-gating-v0.md`.

## Empirical validation

`scripts/analysis/validate_basin_gate.py` (trace + parametric sweep; `--db` adds the live 21-agent tight-σ sweep over `state_json->'behavioral_eisv'` in `core.agent_state`):

| case | before (flat-floor) | after (gate) |
|---|---|---|
| 2026-06-13 Sentinel false-pause (real trace) | 0.333 / safe | **0.053 / safe** |
| in-basin wobbles | safe | safe |
| boundary I→0.40 / S→0.62 (de-escalation) | 0.800 / high-risk | 0.278 / 0.289 safe |
| deep multi-dim basin exit | 1.000 / high-risk | **0.644 / high-risk** |
| absolute-floor breach (E→0.20,I→0.25,S→0.80) | 0.867 / high-risk | **0.800 / high-risk** |

Properties confirmed: false-pause fixed; gate never *raises* risk (`after ≤ before`); genuine basin-exit + absolute-floor breaches still pause; de-escalated boundary states still score *above* the system's own absolute fixed-threshold scoring for a fresh agent at the same state (0.016 / 0.048).

> The live DB is not reachable from the web container, so the 21-agent live sweep is run by the live-verifier via `--db` in a DB-reachable env (pre-merge, operator-side).

## Accepted cost

By design, self-relative degradation that stays **fully inside** the basin accrues zero risk on this path — slow creep that asymptotes just inside a basin edge is left to the boundary ramp, absolute floors, trend, and coherence signals (not re-sensitizing the in-basin z-path, which would reintroduce the false-pause). Documented in the design doc.

## Council

- **Architect — APPROVE-WITH-CHANGES** ✅ addressed: documented the in-basin slow-creep accepted-cost/non-goal; clarified the floor `max()` backstop in the docstring. Confirmed the linear ramp (not assumed basin membership) is what keeps the boundary-region Sentinel safe, and that circularity is correctly avoided.
- **Code-reviewer** — review in flight; findings will be folded into this PR.
- **Live-verifier** — review in flight; will run `--db` against the live 21-agent sweep to confirm 0 genuine-risk states masked.

## Tests

New: `TestBasinHealthGate`, `TestBasinGateSentinelTrace`, `TestBasinGateEdgesMatchConfig` (parity drift-guard) in `tests/test_stable_agent_risk_calibration.py`. 42 behavioral tests green locally; full gate via CI.

Draft — **operator is the merge gate; do not auto-merge.**

https://claude.ai/code/session_018a6AYGFZcWXv5q2onjNeCN

---
_Generated by [Claude Code](https://claude.ai/code/session_018a6AYGFZcWXv5q2onjNeCN)_