### PR TITLE
test(resident_progress): guard CHRONICLER_SERIES_NAMES against scraper drift

### DIFF
--- a/tests/resident_progress/test_sources.py
+++ b/tests/resident_progress/test_sources.py
@@ -92,6 +92,28 @@ def test_chronicler_series_names_includes_tokei():
     assert "tokei.unitares.src.code" in CHRONICLER_SERIES_NAMES
 
 
+def test_chronicler_series_names_are_all_backed_by_a_scraper():
+    """Every name in CHRONICLER_SERIES_NAMES must be a key Chronicler actually
+    writes (a SCRAPERS entry). The two lists are hand-kept in sync via a comment
+    in sources.py; without this guard a rename/removal on the Chronicler side
+    leaves MetricsSeriesSource querying a series name nobody writes, which
+    returns 0 forever with no error — the silent-zero failure the comment warns
+    about.
+
+    Subset, not equality: SCRAPERS also contains the github.* traffic series,
+    which are deliberately excluded from CHRONICLER_SERIES_NAMES (they're
+    repo-traffic signals, not resident-progress signals).
+    """
+    from agents.chronicler.scrapers import SCRAPERS
+
+    orphans = sorted(n for n in CHRONICLER_SERIES_NAMES if n not in SCRAPERS)
+    assert not orphans, (
+        f"CHRONICLER_SERIES_NAMES entries with no backing scraper: {orphans}. "
+        "A series name here must match a key in agents/chronicler/scrapers.py "
+        "SCRAPERS, or MetricsSeriesSource will silently count zero for it."
+    )
+
+
 @pytest.mark.asyncio
 async def test_metrics_series_source_returns_uniform_count(test_db):
     src = MetricsSeriesSource(test_db)


### PR DESCRIPTION
## What

Adds a pure (DB-free) test guarding the hand-maintained sync between `CHRONICLER_SERIES_NAMES` (`src/resident_progress/sources.py`) and Chronicler's `SCRAPERS` dict (`agents/chronicler/scrapers.py`).

## Why

`sources.py` keeps a copy of Chronicler's metric-series names, kept in sync only by a comment (*"Must stay in sync with that file; if Chronicler adds a series, add it here."*). That sync is unenforced. The failure mode is silent: if a scraper is renamed or removed, `MetricsSeriesSource` keeps querying a series name nobody writes and returns **0 forever with no error** — precisely the silent-zero class the comment warns about, and the kind of drift the resident fleet otherwise exists to catch.

The only existing coverage (`test_chronicler_series_names_includes_tokei`) asserts a single name is present.

## How

A subset assertion — every `CHRONICLER_SERIES_NAMES` entry must be a key in `SCRAPERS`. Deliberately **subset, not equality**: the `github.*` traffic series live in `SCRAPERS` but are intentionally excluded from the resident-progress list (they're repo-traffic signals, not resident-progress signals), so full parity would be wrong.

No production code changes. Verified locally that the guard passes against current state and fires on injected drift; full pytest suite runs in CI (not installable in this environment).

## Context

Came out of a review of the resident-agent fleet's usefulness. This is the one self-contained, correctly-scoped gap that surfaced — the broader findings (Sentinel's Python→BEAM Wave-1 migration, Watcher/Vigil being the load-bearing Python residents) are operator-decision territory and out of scope for a code change.

https://claude.ai/code/session_01G52ok4HD8KeXn9Sg99ruke

---
_Generated by [Claude Code](https://claude.ai/code/session_01G52ok4HD8KeXn9Sg99ruke)_