### PR TITLE
[codex] Gate self-relative EISV risk by basin health

### DIFF
--- a/docs/proposals/eisv-self-relative-basin-gating-2026-06-14.md
+++ b/docs/proposals/eisv-self-relative-basin-gating-2026-06-14.md
@@ -1,0 +1,82 @@
+# EISV Self-Relative Basin Gating
+
+Status: implemented for issue #689 on 2026-06-14.
+
+## Problem
+
+Self-relative behavioral scoring compares the current EMA-smoothed E/I/S/V
+state to each agent's own Welford baseline. For very stable residents, the
+baseline standard deviation can collapse to a tiny number because the input is
+already EMA-smoothed. On 2026-06-13, Sentinel had an absolutely safe wobble
+from its own norm and the self-relative z-scores produced high-risk behavioral
+components, which propagated to `cirs_block` and paused the resident for about
+18 hours.
+
+PR #686 added `MIN_MEANINGFUL_EISV_STD = 0.05` as a fleet-wide z-score
+denominator floor. That stopped the immediate false pause, but it was a blunt
+global desensitizer.
+
+## Candidate Designs
+
+### A. Gate self-relative risk by absolute EISV health
+
+Use raw E/I/S/V to decide whether movement from an agent's own norm is allowed
+to raise EISV risk. If the current state is absolutely safe, z-deviations are
+evidence only and the `low_E`, `low_I`, `high_S`, and `high_V` self-relative
+components are zeroed. `adversarial_rho`, `high_CE`, trend handling, and
+absolute safety floors stay active.
+
+This is the accepted design.
+
+The scorer deliberately does not call `classify_basin()` and does not use the
+full `BASIN_HIGH` shape. Calling `classify_basin()` would be circular because
+the behavioral scorer creates the risk input that basin classification uses.
+`BASIN_HIGH` is also too strict for this policy surface: its convergence target
+shape (`I >= 0.70`, `S <= 0.25`) would classify the captured Sentinel pause
+state (`I = 0.6572`, `S = 0.379`) as boundary even though the state was not
+dangerous. That would fail the regression.
+
+The non-circular EISV-safe gate is:
+
+- `E >= 0.60`
+- `I >= 0.60`
+- `S <= 0.50`, or `S <= 0.60` for convergent tasks
+- `abs(V) <= 0.15`
+
+### B. Per-dimension EMA-derived denominator floors
+
+A denominator floor can be derived from each dimension's EMA step instead of a
+single global constant. This avoids exact-zero/tiny variance blindness outside
+the safe gate without applying the old flat `0.05` to every dimension.
+
+This is used only as a secondary guard outside the safe gate:
+
+`min_std = DEFAULT_ALPHAS[dimension] * 0.25`
+
+Inside the safe gate, this guard cannot create risk because self-relative EISV
+components are suppressed.
+
+### C. Keep the flat `0.05` floor
+
+Rejected as the long-term rule. It fixes the captured incident, but it still
+lets healthy movement from self-baseline count as risk and it applies the same
+resolution to dimensions with different EMA alphas.
+
+## Validation Plan
+
+Empirical validation must reconstruct behavioral state from
+`core.agent_state.state_json->'behavioral_eisv'`, not from typed column names.
+The persisted behavioral blob contains current E/I/S/V, `updates`, `alphas`,
+and Welford `baseline_stats`; histories are intentionally absent from DB
+snapshots, so validation compares current and proposed scorers under the same
+history-free reconstruction.
+
+Checks:
+
+- Captured 2026-06-13 Sentinel state remains below caution/high-risk.
+- Synthetic basin-exit state using the same baseline still produces non-zero
+  E/I/S/V risk components.
+- Latest live baselined fleet rows are compared old-flat-floor vs new-gate for
+  risk/verdict/component differences.
+- Tight-baseline agents (`std < 0.05` for any E/I/S/V dimension) are reported
+  separately because they are the blast-radius population.

--- a/scripts/diagnostics/behavioral_basin_gate_validation.py
+++ b/scripts/diagnostics/behavioral_basin_gate_validation.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Validate issue #689 behavioral basin gating against live persisted state.
+
+The DB stores behavioral EISV snapshots under
+core.agent_state.state_json->'behavioral_eisv'. This script reconstructs those
+snapshots with BehavioralEISV.from_dict(), compares the previous flat-floor
+self-relative scorer to the current worktree scorer, and summarizes the
+tight-baseline blast radius.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict
+
+try:
+    import psycopg2
+    import psycopg2.extras
+except ImportError:
+    print("ERROR: psycopg2 not installed. Run: pip install psycopg2-binary", file=sys.stderr)
+    sys.exit(1)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.behavioral_assessment import (  # noqa: E402
+    ABSOLUTE_E_FLOOR,
+    ABSOLUTE_I_FLOOR,
+    ABSOLUTE_S_CEILING,
+    ABSOLUTE_V_CEILING,
+    RISK_CAUTION_THRESHOLD,
+    RISK_SAFE_THRESHOLD,
+    SIGMA_MILD,
+    SIGMA_MODERATE,
+    SIGMA_SEVERE,
+    assess_behavioral_state,
+)
+from src.behavioral_state import BehavioralEISV  # noqa: E402
+
+LEGACY_MIN_STD = 0.05
+
+
+def _json_obj(value: Any) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            loaded = json.loads(value)
+        except (TypeError, ValueError):
+            return {}
+        return loaded if isinstance(loaded, dict) else {}
+    return {}
+
+
+def _component_verdict(risk: float) -> str:
+    if risk < RISK_SAFE_THRESHOLD:
+        return "safe"
+    if risk < RISK_CAUTION_THRESHOLD:
+        return "caution"
+    return "high-risk"
+
+
+def _legacy_z(state: BehavioralEISV, dim: str) -> float:
+    stats = getattr(state, f"_baseline_{dim}")
+    current = getattr(state, dim)
+    return stats.z_score(current, min_std=LEGACY_MIN_STD)
+
+
+def _legacy_absolute_floors(state: BehavioralEISV) -> Dict[str, float]:
+    components: Dict[str, float] = {}
+    if state.E < ABSOLUTE_E_FLOOR:
+        components["low_E"] = 0.30 * (ABSOLUTE_E_FLOOR - state.E) / ABSOLUTE_E_FLOOR
+    if state.I < ABSOLUTE_I_FLOOR:
+        components["low_I"] = 0.30 * (ABSOLUTE_I_FLOOR - state.I) / ABSOLUTE_I_FLOOR
+    if state.S > ABSOLUTE_S_CEILING:
+        components["high_S"] = 0.20 * min(1.0, (state.S - ABSOLUTE_S_CEILING) / (1.0 - ABSOLUTE_S_CEILING))
+    if abs(state.V) > ABSOLUTE_V_CEILING:
+        components["high_V"] = 0.20 * min(1.0, (abs(state.V) - ABSOLUTE_V_CEILING) / (1.0 - ABSOLUTE_V_CEILING))
+    return components
+
+
+def legacy_assess(state: BehavioralEISV, rho: float = 0.0, continuity_energy: float = 0.0, task_type: str = "mixed") -> Dict[str, Any]:
+    components: Dict[str, float] = {}
+
+    if state.is_baselined:
+        z_e = _legacy_z(state, "E")
+        components["low_E"] = (
+            0.30 * min(1.0, (-z_e - SIGMA_MILD) / (SIGMA_SEVERE - SIGMA_MILD))
+            if z_e < -SIGMA_MILD
+            else 0.0
+        )
+
+        z_i = _legacy_z(state, "I")
+        components["low_I"] = (
+            0.30 * min(1.0, (-z_i - SIGMA_MILD) / (SIGMA_SEVERE - SIGMA_MILD))
+            if z_i < -SIGMA_MILD
+            else 0.0
+        )
+
+        z_s = _legacy_z(state, "S")
+        sigma_threshold = SIGMA_MODERATE if task_type == "convergent" else SIGMA_MILD
+        components["high_S"] = (
+            0.20 * min(1.0, (z_s - sigma_threshold) / (SIGMA_SEVERE - sigma_threshold))
+            if z_s > sigma_threshold
+            else 0.0
+        )
+
+        z_v = _legacy_z(state, "V")
+        components["high_V"] = (
+            0.20 * min(1.0, (abs(z_v) - SIGMA_MILD) / (SIGMA_SEVERE - SIGMA_MILD))
+            if abs(z_v) > SIGMA_MILD
+            else 0.0
+        )
+    else:
+        components["low_E"] = 0.30 * (0.4 - state.E) / 0.4 if state.E < 0.4 else 0.0
+        components["low_I"] = 0.30 * (0.4 - state.I) / 0.4 if state.I < 0.4 else 0.0
+        s_threshold = 0.6 if task_type == "convergent" else 0.5
+        components["high_S"] = (
+            0.20 * min(1.0, (state.S - s_threshold) / (1.0 - s_threshold))
+            if state.S > s_threshold
+            else 0.0
+        )
+        components["high_V"] = (
+            0.20 * min(1.0, (abs(state.V) - 0.15) / 0.85)
+            if abs(state.V) > 0.15
+            else 0.0
+        )
+
+    components["adversarial_rho"] = 0.15 * min(1.0, (-0.2 - rho) / 0.8) if rho < -0.2 else 0.0
+    components["high_CE"] = 0.10 * min(1.0, (continuity_energy - 0.5) / 1.5) if continuity_energy > 0.5 else 0.0
+
+    for key, value in _legacy_absolute_floors(state).items():
+        components[key] = max(components.get(key, 0.0), value)
+
+    risk = max(0.0, min(1.0, sum(components.values())))
+    return {
+        "risk": round(risk, 4),
+        "verdict": _component_verdict(risk),
+        "components": {k: round(v, 4) for k, v in components.items()},
+    }
+
+
+def fetch_latest(conn, limit: int | None = None) -> list[dict]:
+    limit_sql = "LIMIT %s" if limit else ""
+    sql = f"""
+        WITH latest AS (
+          SELECT DISTINCT ON (s.identity_id)
+                 s.state_id,
+                 s.identity_id,
+                 s.recorded_at,
+                 s.state_json,
+                 i.agent_id,
+                 i.metadata->>'label' AS label
+          FROM core.agent_state s
+          JOIN core.identities i USING(identity_id)
+          WHERE s.synthetic = false
+            AND s.state_json ? 'behavioral_eisv'
+          ORDER BY s.identity_id, s.recorded_at DESC
+        )
+        SELECT *
+        FROM latest
+        ORDER BY recorded_at DESC
+        {limit_sql}
+    """
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        if limit:
+            cur.execute(sql, (limit,))
+        else:
+            cur.execute(sql)
+        return [dict(row) for row in cur]
+
+
+def has_tight_std(state: BehavioralEISV) -> bool:
+    return any(
+        getattr(state, f"_baseline_{dim}").std < LEGACY_MIN_STD
+        for dim in ("E", "I", "S", "V")
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db-url", default="postgresql://postgres:postgres@localhost:5432/governance")
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--show", type=int, default=12, help="Rows to show from changed decisions")
+    args = parser.parse_args()
+
+    conn = psycopg2.connect(args.db_url)
+    rows = fetch_latest(conn, args.limit)
+
+    total = 0
+    baselined = 0
+    tight = 0
+    verdict_flips: Counter[str] = Counter()
+    risk_deltas = []
+    changed = []
+
+    for row in rows:
+        state_json = _json_obj(row["state_json"])
+        blob = _json_obj(state_json.get("behavioral_eisv"))
+        if not blob:
+            continue
+        state = BehavioralEISV.from_dict(blob)
+        total += 1
+        if state.is_baselined:
+            baselined += 1
+        if state.is_baselined and has_tight_std(state):
+            tight += 1
+
+        old = legacy_assess(state)
+        new = assess_behavioral_state(state)
+        risk_deltas.append(new.risk - old["risk"])
+        if old["verdict"] != new.verdict:
+            verdict_flips[f"{old['verdict']}->{new.verdict}"] += 1
+        if old["risk"] != new.risk or old["verdict"] != new.verdict:
+            changed.append((row, state, old, new))
+
+    print("BEHAVIORAL BASIN-GATE VALIDATION")
+    print(f"latest behavioral rows: {total}")
+    print(f"baselined by code:      {baselined}")
+    print(f"tight std baselined:    {tight}")
+    print(f"changed risk rows:      {len(changed)}")
+    print(f"verdict flips:          {dict(verdict_flips)}")
+    if risk_deltas:
+        print(f"risk delta min/max:     {min(risk_deltas):+.4f} / {max(risk_deltas):+.4f}")
+
+    print()
+    print("Changed examples:")
+    for row, state, old, new in changed[: args.show]:
+        label = row.get("label") or row.get("agent_id")
+        print(
+            f"- {label} {row['identity_id']} E={state.E:.4f} I={state.I:.4f} "
+            f"S={state.S:.4f} V={state.V:.4f} old={old['risk']:.4f}/{old['verdict']} "
+            f"new={new.risk:.4f}/{new.verdict}"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/behavioral_assessment.py
+++ b/src/behavioral_assessment.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Optional
 
-from src.behavioral_state import BehavioralEISV
+from src.behavioral_state import BehavioralEISV, eisv_min_std_for_dimension
 
 
 @dataclass
@@ -38,6 +38,27 @@ class AssessmentResult:
 # Verdict thresholds
 RISK_SAFE_THRESHOLD = 0.35
 RISK_CAUTION_THRESHOLD = 0.60
+
+# Component-level fixed-threshold risk boundaries.
+FIXED_E_RISK_FLOOR = 0.40
+FIXED_I_RISK_FLOOR = 0.40
+FIXED_S_RISK_CEILING = 0.50
+FIXED_CONVERGENT_S_RISK_CEILING = 0.60
+FIXED_V_RISK_CEILING = 0.15
+
+# Non-circular absolute EISV-safe gate for self-relative scoring.
+#
+# This is deliberately not the stricter BASIN_HIGH target shape from
+# governance_config because that shape includes convergence targets
+# (I>=0.70, S<=0.25) that healthy boundary residents can miss without being
+# dangerous; using it here would not fix the 2026-06-13 Sentinel false pause.
+# It is also not classify_basin(), because that would be circular: this scorer
+# is creating the risk input classify_basin needs.
+EISV_SAFE_E_MIN = 0.60
+EISV_SAFE_I_MIN = 0.60
+EISV_SAFE_S_MAX = 0.50
+EISV_SAFE_CONVERGENT_S_MAX = 0.60
+EISV_SAFE_V_ABS_MAX = 0.15
 
 # Absolute safety floors — always active, override baseline.
 # These catch states that are genuinely dangerous regardless of an agent's
@@ -150,22 +171,19 @@ def _score_fixed_threshold(
     components: Dict[str, float] = {}
 
     # --- Component 1: Low Energy (weight: 0.30) ---
-    if state.E < 0.4:
-        components["low_E"] = 0.30 * (0.4 - state.E) / 0.4
+    if state.E < FIXED_E_RISK_FLOOR:
+        components["low_E"] = 0.30 * (FIXED_E_RISK_FLOOR - state.E) / FIXED_E_RISK_FLOOR
     else:
         components["low_E"] = 0.0
 
     # --- Component 2: Low Integrity (weight: 0.30) ---
-    if state.I < 0.4:
-        components["low_I"] = 0.30 * (0.4 - state.I) / 0.4
+    if state.I < FIXED_I_RISK_FLOOR:
+        components["low_I"] = 0.30 * (FIXED_I_RISK_FLOOR - state.I) / FIXED_I_RISK_FLOOR
     else:
         components["low_I"] = 0.0
 
     # --- Component 3: High Entropy (weight: 0.20) ---
-    s_threshold = 0.5
-    task_type = ctx.get("task_type", "mixed")
-    if task_type == "convergent":
-        s_threshold = 0.6
+    s_threshold = _fixed_s_risk_ceiling(ctx)
     if state.S > s_threshold:
         components["high_S"] = 0.20 * min(1.0, (state.S - s_threshold) / (1.0 - s_threshold))
     else:
@@ -173,8 +191,8 @@ def _score_fixed_threshold(
 
     # --- Component 4: High |V| imbalance (weight: 0.20) ---
     abs_v = abs(state.V)
-    if abs_v > 0.15:
-        components["high_V"] = 0.20 * min(1.0, (abs_v - 0.15) / 0.85)
+    if abs_v > FIXED_V_RISK_CEILING:
+        components["high_V"] = 0.20 * min(1.0, (abs_v - FIXED_V_RISK_CEILING) / (1.0 - FIXED_V_RISK_CEILING))
     else:
         components["high_V"] = 0.0
 
@@ -205,38 +223,43 @@ def _score_self_relative(
     on sigma-deviations from the agent's characteristic operating point.
     """
     components: Dict[str, float] = {}
+    absolute_eisv_safe = _is_absolute_eisv_safe(state, ctx)
 
     # --- Component 1: E deviation below baseline (weight: 0.30) ---
-    z_E = state.deviation("E")
-    if z_E < -SIGMA_MILD:
+    # Inside the absolute EISV-safe region, movement from self-baseline is
+    # information, not risk. Outside it, relative deviations are allowed to
+    # contribute again, with a small per-dimension EMA-derived denominator
+    # guard so exact-zero baselines do not become invisible.
+    z_E = state.deviation("E", min_std=eisv_min_std_for_dimension("E"))
+    if not absolute_eisv_safe and z_E < -SIGMA_MILD:
         severity = min(1.0, (-z_E - SIGMA_MILD) / (SIGMA_SEVERE - SIGMA_MILD))
         components["low_E"] = 0.30 * severity
     else:
         components["low_E"] = 0.0
 
     # --- Component 2: I deviation below baseline (weight: 0.30) ---
-    z_I = state.deviation("I")
-    if z_I < -SIGMA_MILD:
+    z_I = state.deviation("I", min_std=eisv_min_std_for_dimension("I"))
+    if not absolute_eisv_safe and z_I < -SIGMA_MILD:
         severity = min(1.0, (-z_I - SIGMA_MILD) / (SIGMA_SEVERE - SIGMA_MILD))
         components["low_I"] = 0.30 * severity
     else:
         components["low_I"] = 0.0
 
     # --- Component 3: S deviation above baseline (weight: 0.20) ---
-    z_S = state.deviation("S")
+    z_S = state.deviation("S", min_std=eisv_min_std_for_dimension("S"))
     task_type = ctx.get("task_type", "mixed")
     sigma_threshold = SIGMA_MILD
     if task_type == "convergent":
         sigma_threshold = SIGMA_MODERATE
-    if z_S > sigma_threshold:
+    if not absolute_eisv_safe and z_S > sigma_threshold:
         severity = min(1.0, (z_S - sigma_threshold) / (SIGMA_SEVERE - sigma_threshold))
         components["high_S"] = 0.20 * severity
     else:
         components["high_S"] = 0.0
 
     # --- Component 4: |V| deviation above baseline (weight: 0.20) ---
-    z_V = state.deviation("V")
-    if abs(z_V) > SIGMA_MILD:
+    z_V = state.deviation("V", min_std=eisv_min_std_for_dimension("V"))
+    if not absolute_eisv_safe and abs(z_V) > SIGMA_MILD:
         severity = min(1.0, (abs(z_V) - SIGMA_MILD) / (SIGMA_SEVERE - SIGMA_MILD))
         components["high_V"] = 0.20 * severity
     else:
@@ -255,6 +278,30 @@ def _score_self_relative(
         components["high_CE"] = 0.0
 
     return components
+
+
+def _fixed_s_risk_ceiling(ctx: Dict) -> float:
+    """Absolute S boundary used by fixed-threshold scoring."""
+    if ctx.get("task_type", "mixed") == "convergent":
+        return FIXED_CONVERGENT_S_RISK_CEILING
+    return FIXED_S_RISK_CEILING
+
+
+def _eisv_safe_s_max(ctx: Dict) -> float:
+    """Task-aware S boundary for the non-circular EISV-safe gate."""
+    if ctx.get("task_type", "mixed") == "convergent":
+        return EISV_SAFE_CONVERGENT_S_MAX
+    return EISV_SAFE_S_MAX
+
+
+def _is_absolute_eisv_safe(state: BehavioralEISV, ctx: Dict) -> bool:
+    """True when raw EISV is safe enough that self-relative movement is not risk."""
+    return (
+        state.E >= EISV_SAFE_E_MIN
+        and state.I >= EISV_SAFE_I_MIN
+        and state.S <= _eisv_safe_s_max(ctx)
+        and abs(state.V) <= EISV_SAFE_V_ABS_MAX
+    )
 
 
 def _score_absolute_floors(state: BehavioralEISV) -> Dict[str, float]:

--- a/src/behavioral_assessment.py
+++ b/src/behavioral_assessment.py
@@ -230,7 +230,7 @@ def _score_self_relative(
     # information, not risk. Outside it, relative deviations are allowed to
     # contribute again, with a small per-dimension EMA-derived denominator
     # guard so exact-zero baselines do not become invisible.
-    z_E = state.deviation("E", min_std=eisv_min_std_for_dimension("E"))
+    z_E = state.deviation("E", min_std=eisv_min_std_for_dimension("E", state.alphas))
     if not absolute_eisv_safe and z_E < -SIGMA_MILD:
         severity = min(1.0, (-z_E - SIGMA_MILD) / (SIGMA_SEVERE - SIGMA_MILD))
         components["low_E"] = 0.30 * severity
@@ -238,7 +238,7 @@ def _score_self_relative(
         components["low_E"] = 0.0
 
     # --- Component 2: I deviation below baseline (weight: 0.30) ---
-    z_I = state.deviation("I", min_std=eisv_min_std_for_dimension("I"))
+    z_I = state.deviation("I", min_std=eisv_min_std_for_dimension("I", state.alphas))
     if not absolute_eisv_safe and z_I < -SIGMA_MILD:
         severity = min(1.0, (-z_I - SIGMA_MILD) / (SIGMA_SEVERE - SIGMA_MILD))
         components["low_I"] = 0.30 * severity
@@ -246,7 +246,7 @@ def _score_self_relative(
         components["low_I"] = 0.0
 
     # --- Component 3: S deviation above baseline (weight: 0.20) ---
-    z_S = state.deviation("S", min_std=eisv_min_std_for_dimension("S"))
+    z_S = state.deviation("S", min_std=eisv_min_std_for_dimension("S", state.alphas))
     task_type = ctx.get("task_type", "mixed")
     sigma_threshold = SIGMA_MILD
     if task_type == "convergent":
@@ -258,7 +258,7 @@ def _score_self_relative(
         components["high_S"] = 0.0
 
     # --- Component 4: |V| deviation above baseline (weight: 0.20) ---
-    z_V = state.deviation("V", min_std=eisv_min_std_for_dimension("V"))
+    z_V = state.deviation("V", min_std=eisv_min_std_for_dimension("V", state.alphas))
     if not absolute_eisv_safe and abs(z_V) > SIGMA_MILD:
         severity = min(1.0, (abs(z_V) - SIGMA_MILD) / (SIGMA_SEVERE - SIGMA_MILD))
         components["high_V"] = 0.20 * severity

--- a/src/behavioral_state.py
+++ b/src/behavioral_state.py
@@ -42,26 +42,18 @@ BOOTSTRAP_UPDATES = 10
 # 30 gives stable mean/std estimates.
 BASELINE_WARMUP_UPDATES = 30
 
-# Minimum meaningful standard deviation for EISV self-relative scoring.
-#
-# This is an EMPIRICAL constant calibrated against the 2026-06-13 Sentinel
-# false-pause trace — NOT a value derived from EISV [0,1] semantics. Note the
-# baseline std is computed over EMA-SMOOTHED E/I/S/V (see _baseline updates
-# below), so a steady agent's std collapses toward ~0.01 partly because the
-# EMA has already eaten the raw observation noise. Without a floor, that
-# artifact makes z = Δ/σ explode: an ultra-stable monitor turns a small,
-# absolutely-healthy fluctuation into a many-sigma "severe deviation" and gets
-# falsely flagged high-risk → cirs_block → paused. The floor caps that
-# sensitivity while leaving genuine multi-tenth moves and the absolute safety
-# floors (E/I<0.30, S>0.70, |V|>0.50) untouched. Empirically: the Sentinel
-# pause (E 0.77→0.66, I 0.68→0.66 — both healthy) scored risk 0.94 (high-risk)
-# with no floor vs 0.33 (safe) at 0.05; genuine degradations are unchanged.
-#
-# A flat floor is the blunt form of the more principled fix (gate self-relative
-# risk by absolute basin health); see the "health-gating" follow-up. A flat
-# value also slightly over-floors slow-alpha dimensions (I) and under-floors
-# fast-alpha ones (S) since the per-dimension EMA step differs.
-MIN_MEANINGFUL_EISV_STD = 0.05
+# Outside the absolute EISV-safe gate, self-relative scoring uses a small
+# denominator guard tied to each dimension's EMA step. This is not a global
+# risk desensitizer: inside the safe gate, self-relative EISV risk is suppressed
+# entirely; outside it, the guard only prevents exact-zero/tiny smoothed
+# baselines from making z-scores either explode or disappear.
+EMA_STEP_STD_FLOOR_FRACTION = 0.25
+
+
+def eisv_min_std_for_dimension(dimension: str, alphas: Optional[Dict[str, float]] = None) -> float:
+    """Minimum z-score denominator derived from the dimension's EMA step."""
+    alpha_map = alphas or DEFAULT_ALPHAS
+    return alpha_map.get(dimension, 0.0) * EMA_STEP_STD_FLOOR_FRACTION
 
 
 @dataclass
@@ -212,7 +204,7 @@ class BehavioralEISV:
             "V": {"mean": round(self._baseline_V.mean, 4), "std": round(self._baseline_V.std, 4), "count": self._baseline_V.count},
         }
 
-    def deviation(self, dimension: str) -> float:
+    def deviation(self, dimension: str, min_std: float = 0.0) -> float:
         """Z-score of current value from agent's own behavioral baseline.
 
         Returns 0.0 if warmup is incomplete or std is too small.
@@ -222,7 +214,7 @@ class BehavioralEISV:
         if stats is None or not self.is_baselined:
             return 0.0
         current = getattr(self, dimension, 0.5)
-        return stats.z_score(current, min_std=MIN_MEANINGFUL_EISV_STD)
+        return stats.z_score(current, min_std=min_std)
 
     def trend(self, dimension: str, window: int = 5) -> float:
         """Simple slope of recent history for a dimension.

--- a/tests/test_behavioral_state.py
+++ b/tests/test_behavioral_state.py
@@ -8,7 +8,10 @@ from src.behavioral_state import (
     BOOTSTRAP_S,
     BOOTSTRAP_V,
     BOOTSTRAP_UPDATES,
+    DEFAULT_ALPHAS,
+    EMA_STEP_STD_FLOOR_FRACTION,
     MAX_HISTORY,
+    eisv_min_std_for_dimension,
 )
 
 
@@ -31,6 +34,15 @@ class TestBehavioralEISVBasics:
         assert state.E != BOOTSTRAP_E  # should have moved toward 0.8
         assert state.I != BOOTSTRAP_I  # should have moved toward 0.7
         assert len(state.E_history) == 1
+
+    def test_min_std_is_derived_from_dimension_alpha(self):
+        assert eisv_min_std_for_dimension("E") == pytest.approx(
+            DEFAULT_ALPHAS["E"] * EMA_STEP_STD_FLOOR_FRACTION
+        )
+        assert eisv_min_std_for_dimension("I") == pytest.approx(
+            DEFAULT_ALPHAS["I"] * EMA_STEP_STD_FLOOR_FRACTION
+        )
+        assert eisv_min_std_for_dimension("unknown") == 0.0
 
     def test_v_ema_converges_toward_gap(self):
         """V should converge toward E-I gap after many constant updates."""

--- a/tests/test_stable_agent_risk_calibration.py
+++ b/tests/test_stable_agent_risk_calibration.py
@@ -1,18 +1,18 @@
 """Calibration: ultra-stable agents must not be falsely flagged high-risk for
-small, absolutely-healthy EISV wobbles.
+small, absolutely-safe EISV wobbles.
 
 Regression for the 2026-06-13 Sentinel pause: a long-running monitor with a
 very tight behavioral baseline (std ~0.007-0.024) had a perfectly healthy
 fluctuation (E 0.77->0.66, I 0.68->0.66) scored as a many-sigma "severe
-deviation" -> risk 0.94 -> high-risk -> cirs_block -> paused ~18h. The
-MIN_MEANINGFUL_EISV_STD floor caps z-score sensitivity at a meaningful
-resolution while preserving genuine multi-tenth moves and absolute floors.
+deviation" -> risk 0.94 -> high-risk -> cirs_block -> paused ~18h. The fix is
+to gate self-relative EISV risk by absolute EISV health: while raw E/I/S/V are
+safe, movement from the agent's own tight baseline is evidence, not danger.
 """
 
 import pytest
 
 from src.agent_behavioral_baseline import WelfordStats
-from src.behavioral_state import BehavioralEISV, MIN_MEANINGFUL_EISV_STD
+from src.behavioral_state import BehavioralEISV, eisv_min_std_for_dimension
 from src.behavioral_assessment import assess_behavioral_state, RISK_CAUTION_THRESHOLD
 
 
@@ -37,7 +37,7 @@ def _baselined(mean_m2, current, count=1239):
     return st
 
 
-class TestWelfordSigmaFloor:
+class TestWelfordMinStd:
     def test_min_std_caps_sensitivity_for_tight_variance(self):
         s = WelfordStats()
         for v in (0.500, 0.501, 0.499, 0.500, 0.501, 0.499):  # std ~0.0009
@@ -84,23 +84,55 @@ class TestStableSentinelNotFalselyPaused:
     def test_small_healthy_wobble_is_not_high_risk(self):
         state = _baselined(_SENTINEL_BASELINE, _SENTINEL_PAUSE_STATE)
         result = assess_behavioral_state(state, rho=0.0)
-        # With the floor this small, absolutely-healthy wobble is no longer
-        # high-risk (it scored 0.94 / high-risk before the floor).
+        # With absolute EISV-safe gating this small wobble is no longer
+        # high-risk (it scored 0.94 / high-risk before the gate).
         assert result.verdict != "high-risk"
         assert result.risk < RISK_CAUTION_THRESHOLD
+        assert result.components["low_E"] == 0.0
+        assert result.components["low_I"] == 0.0
+        assert result.components["high_S"] == 0.0
+        assert result.components["high_V"] == 0.0
+
+    def test_rho_and_continuity_energy_still_score_inside_safe_gate(self):
+        state = _baselined(_SENTINEL_BASELINE, _SENTINEL_PAUSE_STATE)
+        result = assess_behavioral_state(state, rho=-0.5, continuity_energy=1.0)
+        assert result.components["low_E"] == 0.0
+        assert result.components["low_I"] == 0.0
+        assert result.components["high_S"] == 0.0
+        assert result.components["adversarial_rho"] > 0.0
+        assert result.components["high_CE"] > 0.0
 
     def test_genuine_entropy_spike_still_flags(self):
         # The same tight baseline, but a real large entropy excursion must
-        # still produce a non-zero high_S risk component (floor preserves signal).
+        # still produce a non-zero high_S risk component once EISV leaves the
+        # absolute safe gate.
         state = _baselined(_SENTINEL_BASELINE, {"E": 0.773, "I": 0.681, "S": 0.70, "V": 0.092})
         result = assess_behavioral_state(state, rho=0.0)
         assert result.components.get("high_S", 0.0) > 0.0
 
+    def test_combined_basin_exit_still_flags(self):
+        state = _baselined(_SENTINEL_BASELINE, {"E": 0.35, "I": 0.34, "S": 0.65, "V": 0.20})
+        result = assess_behavioral_state(state, rho=0.0)
+        assert result.components["low_E"] > 0.0
+        assert result.components["low_I"] > 0.0
+        assert result.components["high_S"] > 0.0
+        assert result.components["high_V"] > 0.0
+        assert result.risk >= RISK_CAUTION_THRESHOLD
 
-class TestDeviationUsesFloor:
-    def test_deviation_applies_min_std(self):
+
+class TestDeviation:
+    def test_default_deviation_uses_raw_baseline_std(self):
         state = _baselined(_SENTINEL_BASELINE, _SENTINEL_PAUSE_STATE)
-        # E moved 0.112 from a baseline whose true std is ~0.024; without the
-        # floor this is ~-4.7 sigma, with the 0.05 floor it is ~-2.24.
         z_E = state.deviation("E")
-        assert z_E == pytest.approx((0.6608 - 0.7729981068548344) / MIN_MEANINGFUL_EISV_STD, rel=1e-2)
+        assert z_E == pytest.approx(
+            (0.6608 - 0.7729981068548344) / state._baseline_E.std,
+            rel=1e-2,
+        )
+
+    def test_deviation_accepts_ema_derived_min_std(self):
+        state = _baselined(_SENTINEL_BASELINE, _SENTINEL_PAUSE_STATE)
+        z_E = state.deviation("E", min_std=eisv_min_std_for_dimension("E"))
+        assert z_E == pytest.approx(
+            (0.6608 - 0.7729981068548344) / eisv_min_std_for_dimension("E"),
+            rel=1e-2,
+        )

--- a/tests/test_stable_agent_risk_calibration.py
+++ b/tests/test_stable_agent_risk_calibration.py
@@ -119,6 +119,26 @@ class TestStableSentinelNotFalselyPaused:
         assert result.components["high_V"] > 0.0
         assert result.risk >= RISK_CAUTION_THRESHOLD
 
+    def test_custom_slow_alpha_floor_preserves_outside_gate_signal(self):
+        state = _baselined(
+            {
+                "E": (0.62, 0.0),
+                "I": (0.62, 0.0),
+                "S": (0.20, 0.0),
+                "V": (0.00, 0.0),
+            },
+            {"E": 0.59, "I": 0.59, "S": 0.20, "V": 0.0},
+            count=50,
+        )
+        state.alphas["E"] = 0.01
+        state.alphas["I"] = 0.01
+
+        result = assess_behavioral_state(state, rho=0.0)
+
+        assert result.components["low_E"] > 0.0
+        assert result.components["low_I"] > 0.0
+        assert result.risk >= RISK_CAUTION_THRESHOLD
+
 
 class TestDeviation:
     def test_default_deviation_uses_raw_baseline_std(self):


### PR DESCRIPTION
## Summary
- Replace the flat EISV self-relative std floor with a non-circular absolute EISV-safe gate.
- Keep rho, continuity energy, trend handling, and absolute safety floors active while suppressing only E/I/S/V self-relative risk inside the safe gate.
- Add an EMA-derived per-dimension denominator guard outside the gate that honors persisted per-agent EMA alphas, plus focused regression tests, a design note, and a live validation script.

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q -p no:cacheprovider tests/test_stable_agent_risk_calibration.py tests/test_behavioral_assessment.py tests/test_behavioral_state.py: 61 passed
- PYTHONDONTWRITEBYTECODE=1 python3 scripts/diagnostics/behavioral_basin_gate_validation.py: 134 latest behavioral rows, 10 baselined, 10 tight std, 0 changed risk rows, 0 verdict flips
- ./scripts/dev/test-cache.sh: 9751 passed, 24 skipped, 2 warnings
- pre-push smoke: 138 passed, 9036 deselected; doc health clear

## Council
- Architect sidecar: recommended the non-circular EISV-safe gate and rejected direct classify_basin/BASIN_HIGH usage at this scoring layer.
- Live-verifier sidecar: confirmed the state_json->behavioral_eisv reconstruction path and DB schema gotchas.
- Code-review sidecar: found a custom-alpha floor bug; fixed in e876d8f3 with a regression test.

Closes #689.

Draft PR only; operator remains merge gate.