### PR TITLE
[codex] Scale EISV z-floor by EMA alpha

### DIFF
--- a/scripts/analysis/validate_basin_gate.py
+++ b/scripts/analysis/validate_basin_gate.py
@@ -226,11 +226,15 @@ async def run_live(dsn: Optional[str], limit: int) -> bool:
     try:
         rows = await conn.fetch(
             """
-            SELECT DISTINCT ON (agent_id) agent_id,
-                   state_json->'behavioral_eisv' AS beisv
-            FROM core.agent_state
-            WHERE state_json ? 'behavioral_eisv'
-            ORDER BY agent_id, created_at DESC
+            SELECT DISTINCT ON (s.identity_id)
+                   i.agent_id,
+                   i.metadata->>'label' AS label,
+                   s.state_json->'behavioral_eisv' AS beisv
+            FROM core.agent_state s
+            JOIN core.identities i USING(identity_id)
+            WHERE s.synthetic = false
+              AND s.state_json ? 'behavioral_eisv'
+            ORDER BY s.identity_id, s.recorded_at DESC
             LIMIT $1
             """,
             limit,

--- a/src/behavioral_state.py
+++ b/src/behavioral_state.py
@@ -67,11 +67,28 @@ BASELINE_WARMUP_UPDATES = 30
 # The floor is retained as defense-in-depth: it bounds the raw z-magnitude in
 # the boundary region (where the gate is partially open) so a collapsed σ cannot
 # produce an absurd z there. It does NOT touch σ for unstable agents (it only
-# binds when std < the floor), so it never blunts meaningful variance. A flat
-# value still slightly over-floors slow-alpha dims (I) and under-floors fast-alpha
-# ones (S) since the per-dimension EMA step differs — but with the basin gate in
-# front, the exact value is far less load-bearing than it was under #686.
+# binds when std < the floor), so it never blunts meaningful variance. Default
+# alphas preserve the original 0.05 guard exactly; tuned per-agent alphas scale
+# the guard proportionally so the secondary floor follows the EMA smoothing step
+# restored from persistence.
 MIN_MEANINGFUL_EISV_STD = 0.05
+
+
+def eisv_min_std_for_dimension(dimension: str, alphas: Optional[Dict[str, float]] = None) -> float:
+    """Minimum z-score denominator scaled by the dimension's EMA alpha.
+
+    Default alphas preserve the #686/#696 floor exactly. If an agent tunes a
+    dimension to a slower or faster EMA, scale the secondary floor with that
+    persisted alpha so the boundary-region guard follows the smoothing step
+    instead of silently falling back to the fleet defaults.
+    """
+    default_alpha = DEFAULT_ALPHAS.get(dimension)
+    if not default_alpha:
+        return MIN_MEANINGFUL_EISV_STD
+    alpha = (alphas or DEFAULT_ALPHAS).get(dimension, default_alpha)
+    if alpha <= 0:
+        alpha = default_alpha
+    return MIN_MEANINGFUL_EISV_STD * (alpha / default_alpha)
 
 
 @dataclass
@@ -232,7 +249,7 @@ class BehavioralEISV:
         if stats is None or not self.is_baselined:
             return 0.0
         current = getattr(self, dimension, 0.5)
-        return stats.z_score(current, min_std=MIN_MEANINGFUL_EISV_STD)
+        return stats.z_score(current, min_std=eisv_min_std_for_dimension(dimension, self.alphas))
 
     def trend(self, dimension: str, window: int = 5) -> float:
         """Simple slope of recent history for a dimension.

--- a/tests/test_stable_agent_risk_calibration.py
+++ b/tests/test_stable_agent_risk_calibration.py
@@ -12,7 +12,11 @@ resolution while preserving genuine multi-tenth moves and absolute floors.
 import pytest
 
 from src.agent_behavioral_baseline import WelfordStats
-from src.behavioral_state import BehavioralEISV, MIN_MEANINGFUL_EISV_STD
+from src.behavioral_state import (
+    BehavioralEISV,
+    MIN_MEANINGFUL_EISV_STD,
+    eisv_min_std_for_dimension,
+)
 from src.behavioral_assessment import assess_behavioral_state, RISK_CAUTION_THRESHOLD
 
 
@@ -105,6 +109,20 @@ class TestDeviationUsesFloor:
         z_E = state.deviation("E")
         assert z_E == pytest.approx((0.6608 - 0.7729981068548344) / MIN_MEANINGFUL_EISV_STD, rel=1e-2)
 
+    def test_default_alpha_floor_preserves_flat_floor(self):
+        assert eisv_min_std_for_dimension("E") == pytest.approx(MIN_MEANINGFUL_EISV_STD)
+        assert eisv_min_std_for_dimension("I") == pytest.approx(MIN_MEANINGFUL_EISV_STD)
+        assert eisv_min_std_for_dimension("S") == pytest.approx(MIN_MEANINGFUL_EISV_STD)
+        assert eisv_min_std_for_dimension("V") == pytest.approx(MIN_MEANINGFUL_EISV_STD)
+
+    def test_custom_alpha_scales_floor(self):
+        assert eisv_min_std_for_dimension("E", {"E": 0.06}) == pytest.approx(
+            MIN_MEANINGFUL_EISV_STD * 0.5
+        )
+
+    def test_non_positive_alpha_preserves_flat_floor(self):
+        assert eisv_min_std_for_dimension("E", {"E": 0.0}) == pytest.approx(MIN_MEANINGFUL_EISV_STD)
+
 
 # --- Issue #689: absolute-basin-health gating of self-relative risk -----------
 
@@ -193,6 +211,28 @@ class TestBasinGateSentinelTrace:
         )
         result = assess_behavioral_state(state, rho=0.0)
         assert result.verdict == "high-risk"
+
+    def test_custom_slow_alpha_floor_preserves_boundary_signal(self):
+        # Default 0.05 would make this small boundary-region move sub-threshold
+        # on an exact-zero baseline. A custom slow alpha carries a smaller
+        # persisted EMA step, so the secondary floor should preserve signal.
+        state = _baselined(
+            {
+                "E": (0.62, 0.0),
+                "I": (0.62, 0.0),
+                "S": (0.20, 0.0),
+                "V": (0.00, 0.0),
+            },
+            {"E": 0.59, "I": 0.59, "S": 0.20, "V": 0.0},
+            count=50,
+        )
+        state.alphas["E"] = 0.01
+        state.alphas["I"] = 0.01
+
+        result = assess_behavioral_state(state, rho=0.0)
+
+        assert result.components["low_E"] > 0.0
+        assert result.components["low_I"] > 0.0
 
 
 class TestBasinGateEdgesMatchConfig:


### PR DESCRIPTION
## Summary

Follow-up to merged #696 / #689. This keeps the absolute basin-health gate from #696 intact and only carries over the non-overlapping useful piece from the superseded #698 work.

- Scale the secondary EISV z-score denominator floor by the persisted per-dimension EMA alpha, while preserving the exact 0.05 floor for default alphas.
- Fall back to the default floor for non-positive persisted alpha values.
- Fix `scripts/analysis/validate_basin_gate.py --db` to query the current schema via `core.identities`, skip synthetic state rows, and order latest state by `recorded_at`.
- Add tests for default alpha preservation, custom alpha scaling, invalid-alpha fallback, and boundary-region signal preservation.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q -p no:cacheprovider tests/test_stable_agent_risk_calibration.py tests/test_behavioral_assessment.py tests/test_behavioral_state.py` -> 69 passed
- `PYTHONDONTWRITEBYTECODE=1 python3 scripts/analysis/validate_basin_gate.py` -> PASS
- `PYTHONDONTWRITEBYTECODE=1 python3 scripts/analysis/validate_basin_gate.py --db --dsn postgresql://postgres:postgres@localhost:5432/governance` -> PASS; examined 9 baselined agents, genuine-risk-masked=0
- `./scripts/dev/test-cache.sh` -> 9783 passed, 21 skipped, coverage 80.72%
