### PR TITLE
fix(identity): make auto-generated structured_agent_id unique per agent

### DIFF
--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -1247,7 +1247,8 @@ async def handle_identity_adapter(arguments: Dict[str, Any]) -> Sequence[TextCon
                     context=context,
                     existing_ids=existing_ids,
                     client_hint=get_context_client_hint(),
-                    model_type=model_type
+                    model_type=model_type,
+                    agent_uuid=agent_uuid
                 )
                 structured_id = meta.structured_id
                 logger.info(f"[IDENTITY] Regenerated structured_id with model: {structured_id}")

--- a/src/mcp_handlers/identity/persistence.py
+++ b/src/mcp_handlers/identity/persistence.py
@@ -719,7 +719,8 @@ async def set_agent_label(agent_uuid: str, label: str, session_key: Optional[str
                             meta.structured_id = generate_structured_id(
                                 context=context,
                                 existing_ids=existing_ids,
-                                client_hint=get_context_client_hint()
+                                client_hint=get_context_client_hint(),
+                                agent_uuid=agent_uuid
                             )
                             logger.info(f"Migrated structured_id: {meta.structured_id}")
                         except Exception as e:
@@ -761,7 +762,8 @@ async def set_agent_label(agent_uuid: str, label: str, session_key: Optional[str
                         meta.structured_id = generate_structured_id(
                             context=context,
                             existing_ids=existing_ids,
-                            client_hint=get_context_client_hint()
+                            client_hint=get_context_client_hint(),
+                            agent_uuid=agent_uuid
                         )
                         logger.info(f"Generated structured_id: {meta.structured_id}")
                     except Exception as e:

--- a/src/mcp_handlers/support/naming_helpers.py
+++ b/src/mcp_handlers/support/naming_helpers.py
@@ -143,7 +143,8 @@ def generate_structured_id(
     context: Optional[Dict[str, str]] = None,
     existing_ids: Optional[List[str]] = None,
     client_hint: Optional[str] = None,
-    model_type: Optional[str] = None
+    model_type: Optional[str] = None,
+    agent_uuid: Optional[str] = None
 ) -> str:
     """
     Generate a structured auto-id for an agent.
@@ -153,9 +154,23 @@ def generate_structured_id(
     - agent_id (structured) - this function, auto-generated
     - display_name (nickname) - user-chosen via identity(name=...)
 
-    Format: {interface}_{model}_{date} e.g., "chatgpt_claude_20251226"
-    Or without model: {interface}_{date} e.g., "cursor_20251226"
-    If collision, appends counter: "cursor_20251226_2"
+    Format: {interface}_{model}_{date}_{uuid8} e.g.,
+        "chatgpt_claude_20251226_a4be406c"
+    Or without model: {interface}_{date}_{uuid8} e.g.,
+        "cursor_20251226_a4be406c"
+
+    The {interface}_{model}_{date} prefix stays greppable/bucketable; the
+    uuid8 fragment (first block of agent_uuid, matching the existing label
+    convention) makes the id structurally unique per agent. Without it,
+    every same-model/same-day mint collapses onto one bucket label — and
+    the legacy collision-counter below only ever saw in-memory metadata, so
+    the suffix never fired across the persisted registry and produced
+    *exact* repeats (e.g. dozens of "Claude_20260613" sharing one id
+    string). Residents pin their structured id explicitly and never flow
+    through here, so their cross-restart continuity is unaffected.
+
+    When agent_uuid is omitted, falls back to the legacy collision-counter
+    suffix ("cursor_20251226_2") for callers that have no uuid in scope.
 
     Args:
         context: Interface context (from detect_interface_context)
@@ -164,6 +179,9 @@ def generate_structured_id(
                      Takes precedence over auto-detected interface
         model_type: Optional model identifier (e.g., "claude", "gemini", "gpt4")
                     When provided, creates distinct identity per model
+        agent_uuid: Optional agent UUID. When provided, its first block is
+                    appended as a uuid8 fragment so the id is unique per
+                    agent rather than a per-day bucket label.
 
     Returns:
         Unique structured ID string
@@ -198,6 +216,17 @@ def generate_structured_id(
         base_id = f"{interface}_{model}_{timestamp}"
     else:
         base_id = f"{interface}_{timestamp}"
+
+    # Append a uuid8 fragment when we have the agent's UUID. This is what
+    # makes the id unique per agent instead of a per-(interface,model,day)
+    # bucket; the fragment is the first UUID block (same convention as
+    # agent labels, e.g. "...claude_a4be406c"). A uuid-suffixed id is
+    # already unique, so the collision-counter below is a no-op for it and
+    # only serves the legacy (agent_uuid=None) callers.
+    if agent_uuid:
+        fragment = str(agent_uuid).split("-")[0].lower()
+        if fragment:
+            base_id = f"{base_id}_{fragment}"
 
     # Check for collisions
     if existing_ids:

--- a/tests/test_naming_helpers.py
+++ b/tests/test_naming_helpers.py
@@ -204,6 +204,38 @@ class TestGenerateStructuredId:
         assert "_client" not in result
         assert "mcp" in result
 
+    def test_agent_uuid_appends_uuid8_fragment(self):
+        ctx = {"interface": "cursor", "model_hint": None, "environment": None}
+        result = generate_structured_id(
+            context=ctx, agent_uuid="a4be406c-1234-5678-9abc-def012345678"
+        )
+        assert result.endswith("_a4be406c")
+        assert "cursor" in result  # bucketable prefix preserved
+
+    def test_agent_uuid_disambiguates_same_model_same_day(self):
+        """Two agents with identical context but different UUIDs must not
+        collapse onto one structured id — this is the duplicate-id fix."""
+        ctx = {"interface": "claude_code", "model_hint": None, "environment": None}
+        first = generate_structured_id(
+            context=ctx, model_type="claude", agent_uuid="11111111-aaaa-bbbb-cccc-dddddddddddd"
+        )
+        second = generate_structured_id(
+            context=ctx, model_type="claude", agent_uuid="22222222-aaaa-bbbb-cccc-dddddddddddd"
+        )
+        assert first != second
+        assert first.endswith("_11111111")
+        assert second.endswith("_22222222")
+
+    def test_no_agent_uuid_keeps_legacy_bucket_format(self):
+        """Callers with no UUID in scope keep the legacy collision-counter
+        behavior (no uuid8 fragment appended)."""
+        ctx = {"interface": "cursor", "model_hint": None, "environment": None}
+        result = generate_structured_id(context=ctx)
+        # Legacy format is {interface}_{date} with no trailing uuid8 block.
+        assert result.startswith("cursor_")
+        # Trailing token is the 8-digit date, not a hex uuid fragment.
+        assert result.split("_")[-1].isdigit()
+
 
 # ============================================================================
 # format_naming_guidance


### PR DESCRIPTION
## What

The `structured_agent_id` ("agent_id" tier in the three-tier identity model) was `{interface}_{model}_{date}`, which buckets by interface + model + **day**. Every same-model/same-day mint collapsed onto one id string, so dozens of distinct agents (different UUIDs, different labels) all surface as the same id — e.g. in the current 7-day active window ~15 agents share `Claude_20260613` and ~12 share `Claude_20260612`. That's the "mcp id duplicates."

The existing collision-counter in `generate_structured_id` (`_2`/`_3` suffix) only ever saw in-memory `agent_metadata` — a small subset of the 4051-row registry — so the suffix never fired across the persisted set and produced *exact* repeats rather than disambiguated ones.

## Change

Append the agent's **uuid8 fragment** (first UUID block, matching the existing label convention `...claude_a4be406c`) when generating the structured id. Format becomes `{interface}_{model}_{date}_{uuid8}` (e.g. `claude_code_claude_20260614_a4be406c`). Threaded through the three mint sites that have `agent_uuid` in scope:

- `src/mcp_handlers/support/naming_helpers.py` — new opt-in `agent_uuid` param
- `src/mcp_handlers/identity/handlers.py` — model-type regeneration path
- `src/mcp_handlers/identity/persistence.py` — both lazy-mint/migration paths

The `{interface}_{model}_{date}` prefix stays greppable/bucketable; ids are now structurally unique per agent.

## Why it's safe

- **Residents unaffected** — substrate-anchored agents (Lumen = `mcp_20260428`, etc.) pin their structured id explicitly and never flow through `generate_structured_id`, so cross-restart continuity is intact.
- **KG lookups unaffected** — `knowledge/handlers.py` matches `structured_id` symmetrically against the stored value, so the longer format resolves fine; legacy `model+date` data still matches itself.
- **Legacy callers unaffected** — when `agent_uuid` is omitted, the function keeps the legacy collision-counter fallback.
- **Resident-fork classifier unaffected** — it matches by label, not structured-id format.

## Tests

Added to `tests/test_naming_helpers.py`:
- uuid8 fragment is appended and the bucketable prefix is preserved
- two agents with same context but different UUIDs no longer collapse onto one id
- no-uuid callers keep the legacy bucket format

Verified the generation logic directly (local container is Python 3.11; the project requires ≥3.12, so the full pytest gate runs in CI):

```
uuid#1: claude_code_claude_20260614_a4be406c
uuid#2: claude_code_claude_20260614_11111111   (unique: True)
legacy: cursor_20260614                          (no-uuid fallback)
legacy collision: cursor_20260614_2              (counter still works)
```

## Scope note

This addresses the **duplicate id-string** problem (the chosen direction). It does **not** sweep the existing ~750 ghost / 288 ephemeral agents inflating the registry — that's an operational `archive_orphan_agents` run, separate from this code fix. The structured id is a coupled identity surface; if the `unitares-governance-plugin` repo parses the `structured_agent_id` format anywhere, that should get a matching read (out of this session's repo scope to verify).

Draft PR — operator remains the merge gate.

https://claude.ai/code/session_01D8qHqFNaCEjLs1JNa1dKuH

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8qHqFNaCEjLs1JNa1dKuH)_