### PR TITLE
fix(dashboard): correct phase-space basin bands + source them from the engine

### DIFF
--- a/dashboard/phase.js
+++ b/dashboard/phase.js
@@ -18,10 +18,11 @@
         // risk, plus the BASIN_HIGH box) — the background bands cannot show the
         // full classifier, so the authoritative per-agent label is the `basin`
         // field rendered in each dot's tooltip, not the band an agent sits in.
-        // Values track the I-axis breakpoints of classify_basin:
-        //   low  = BASIN_LOW_I_CEIL (0.5): I below this forces the LOW basin.
-        //   high = BASIN_HIGH.I_min (0.7): I below this can never be HIGH.
-        // Keep in sync with those two constants if they change.
+        // These values are SOURCED LIVE from the server at init via
+        // config(action='get') -> thresholds.basin_low_i_ceil / basin_high_i_min
+        // (the I-axis breakpoints of classify_basin), so the bands cannot drift
+        // from the engine. The literals below are only a fallback if that fetch
+        // fails; they mirror BASIN_LOW_I_CEIL (0.5) and BASIN_HIGH.I_min (0.7).
         basin: { low: 0.5, high: 0.7 },
         // Steady-state equilibrium (governance_config.py calibration note)
         equilibrium: { E: 0.70, I: 0.75 },
@@ -646,15 +647,34 @@
     // Init
     // ========================================================================
 
+    // Source basin band breakpoints from the engine's own constants so the
+    // bands cannot drift from classify_basin. Falls back to CFG.basin literals
+    // on any failure (unauthenticated read, older server without the field).
+    function loadBasinThresholds() {
+        return callTool('config', { action: 'get' })
+            .then(function (result) {
+                var t = (result && result.thresholds) || {};
+                if (typeof t.basin_low_i_ceil === 'number') CFG.basin.low = t.basin_low_i_ceil;
+                if (typeof t.basin_high_i_min === 'number') CFG.basin.high = t.basin_high_i_min;
+            })
+            .catch(function (err) {
+                console.warn('[Phase] basin thresholds fetch failed, using fallback:', err);
+            });
+    }
+
     function init() {
         setupSVG();
-        drawBasins();
-        drawEquilibrium();
-        drawFlowField();
-        drawAxes();
-        loadAndRender();
-        startRefresh();
-        connectWebSocket();
+        // Fetch engine basin breakpoints before drawing the static bands so
+        // they reflect live config; fall through to fallback literals on error.
+        loadBasinThresholds().then(function () {
+            drawBasins();
+            drawEquilibrium();
+            drawFlowField();
+            drawAxes();
+            loadAndRender();
+            startRefresh();
+            connectWebSocket();
+        });
     }
 
     if (document.readyState === 'loading') {

--- a/dashboard/phase.js
+++ b/dashboard/phase.js
@@ -12,8 +12,17 @@
     // ========================================================================
 
     var CFG = {
-        // Basin boundaries (governance_state.py _interpret_basin)
-        basin: { low: 0.4, high: 0.6 },
+        // Basin band boundaries along the I axis. These are an illustrative
+        // 1-D PROJECTION of the engine's multi-dimensional classifier
+        // (config/governance_config.py classify_basin, over I, coherence, |V|,
+        // risk, plus the BASIN_HIGH box) — the background bands cannot show the
+        // full classifier, so the authoritative per-agent label is the `basin`
+        // field rendered in each dot's tooltip, not the band an agent sits in.
+        // Values track the I-axis breakpoints of classify_basin:
+        //   low  = BASIN_LOW_I_CEIL (0.5): I below this forces the LOW basin.
+        //   high = BASIN_HIGH.I_min (0.7): I below this can never be HIGH.
+        // Keep in sync with those two constants if they change.
+        basin: { low: 0.5, high: 0.7 },
         // Steady-state equilibrium (governance_config.py calibration note)
         equilibrium: { E: 0.70, I: 0.75 },
         // ODE params (governance_config.py)
@@ -214,9 +223,9 @@
 
         // Basin labels (right-aligned, very subtle)
         var labels = [
-            { text: 'LOW BASIN', y: 0.2, color: '96,165,250' },
-            { text: 'BOUNDARY', y: 0.5, color: '251,191,36' },
-            { text: 'HIGH BASIN', y: 0.8, color: '52,211,153' }
+            { text: 'LOW BASIN', y: 0.25, color: '96,165,250' },
+            { text: 'BOUNDARY', y: 0.6, color: '251,191,36' },
+            { text: 'HIGH BASIN', y: 0.85, color: '52,211,153' }
         ];
         labels.forEach(function (l) {
             basins.append('text')

--- a/src/runtime_config.py
+++ b/src/runtime_config.py
@@ -50,6 +50,14 @@ def get_thresholds() -> Dict[str, float]:
         "lambda1_max": config.LAMBDA1_MAX,
         "target_coherence": config.TARGET_COHERENCE,
         "target_void_freq": config.TARGET_VOID_FREQ,
+        # Basin breakpoints along the I axis — the structural (non-overridable)
+        # I-axis projection of classify_basin. Exposed so the /phase view and
+        # other read clients render basin bands from the engine's own constants
+        # instead of hardcoding a copy that silently drifts. classify_basin is
+        # multi-dimensional (I, coherence, |V|, risk + the BASIN_HIGH box); these
+        # two values are only its I-axis breakpoints, not the full classifier.
+        "basin_low_i_ceil": config_module.BASIN_LOW_I_CEIL,
+        "basin_high_i_min": config_module.BASIN_HIGH.I_min,
     }
 
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -45,6 +45,25 @@ class TestConfigManager:
         # Should have some threshold values
         assert len(thresholds) >= 0
 
+    def test_get_thresholds_exposes_basin_breakpoints(self):
+        """get_thresholds must expose the engine's I-axis basin breakpoints.
+
+        The /phase dashboard sources its basin bands from these keys so the
+        rendered bands cannot drift from classify_basin. Guard that the keys
+        exist and are wired to the canonical constants (not a hardcoded copy).
+        """
+        from src.runtime_config import get_thresholds
+        from config import governance_config as gc
+
+        thresholds = get_thresholds()
+
+        assert "basin_low_i_ceil" in thresholds
+        assert "basin_high_i_min" in thresholds
+        assert thresholds["basin_low_i_ceil"] == gc.BASIN_LOW_I_CEIL
+        assert thresholds["basin_high_i_min"] == gc.BASIN_HIGH.I_min
+        # Sanity: LOW/BOUNDARY edge must sit below BOUNDARY/HIGH edge.
+        assert thresholds["basin_low_i_ceil"] < thresholds["basin_high_i_min"]
+
     def test_get_threshold_with_default(self):
         """Test getting specific threshold with default"""
         from src.config_manager import ConfigManager


### PR DESCRIPTION
## What

The `/phase` view hardcoded basin band boundaries as `{low: 0.4, high: 0.6}` along the I axis, with a stale comment citing `governance_state.py _interpret_basin` (which no longer does a scalar cut — it delegates to the **multi-dimensional** `config/governance_config.py:classify_basin`, over I, coherence, |V|, risk, plus the `BASIN_HIGH` box).

This PR fixes the wrong values **and** removes the drift class that produced them.

## Two commits

### 1. Correct the band values (frontend-only)
The frozen `0.4/0.6` copy had drifted from the engine's real I-axis breakpoints:

| band edge | hardcoded | real constant | value |
|-----------|-----------|---------------|-------|
| LOW / BOUNDARY | 0.4 | `BASIN_LOW_I_CEIL` | **0.5** |
| BOUNDARY / HIGH | 0.6 | `BASIN_HIGH.I_min` | **0.7** |

Symptom: an agent at I=0.6 is `boundary` per `classify_basin` (pinned by existing `test_governance_state.py:325`) but rendered inside the green **HIGH** band. Corrected the boundaries and re-centered the band labels.

### 2. Source the breakpoints from the engine (drift-proof)
- `get_thresholds()` now exposes `basin_low_i_ceil` / `basin_high_i_min`, read from the canonical `governance_config` constants, so `config(action='get').thresholds` carries them. `config: get` is already a `pre_onboard` action, so the dashboard read passes under strict identity.
- `/phase` fetches these once at init and overrides `CFG.basin` from live config, falling back to the literals only if the fetch fails (unauthenticated read / older server).
- Drift-guard test asserts `get_thresholds` wires the keys to the canonical constants rather than a hardcoded value.

Result: the bands can no longer drift from `classify_basin` — the engine constants are the single source.

## Honest limitation (documented in code)

A horizontal band on the I axis is structurally a **1-D projection** of a classifier that also reads coherence, |V|, and risk. An agent at I=0.8 / coherence=0.3 is LOW per the engine yet sits in the HIGH band. The authoritative per-agent basin remains the tooltip's `basin` field (the real engine value); this PR makes the background bands a *correct, non-drifting* I-axis guide and documents that they are a projection, not the classifier.

## Tests
- `tests/test_utilities.py` — new drift-guard test (passes).
- `test_runtime_config.py`, `test_extracted_handlers.py` green; pre-push full gate green (138 passed).