### PR TITLE
docs: resolve remaining doc-staleness items (running-hot status, TROUBLESHOOTING date)

### DIFF
--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -2,7 +2,7 @@
 
 Status: live troubleshooting guide. Use for failure diagnosis and operator recovery steps, not as the primary architecture reference.
 
-**Last Updated:** April 2026
+**Last Updated:** June 2026
 
 ---
 
@@ -314,4 +314,4 @@ curl http://localhost:8767/health | python3 -m json.tool
 
 ---
 
-*Last updated: March 2026*
+*Last updated: June 2026*

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -29,9 +29,9 @@ Several of these are **single-writer surfaces** (see the shared contract in `AGE
 
 ### Other active
 
-| Doc | Status (as of 2026-06-11) |
+| Doc | Status (as of 2026-06-14) |
 |---|---|
-| [`behavioral-running-hot-detector-v0.md`](behavioral-running-hot-detector-v0.md) | v0.1 plan, pending council |
+| [`behavioral-running-hot-detector-v0.md`](behavioral-running-hot-detector-v0.md) | v0.1 plan, parked — pending council; unbuilt, blocked on the behavioral-EISV arm emitting signal |
 
 ## Shipped / resolved
 

--- a/docs/proposals/behavioral-running-hot-detector-v0.md
+++ b/docs/proposals/behavioral-running-hot-detector-v0.md
@@ -1,6 +1,6 @@
 # Behavioral "running-hot" detector → orchestrator worker-state read (v0.1, plan)
 
-**Status:** v0.1 plan, pending council. Not an RFC yet — a scoped capture so a fresh (non-hot) session can council + execute. Born 2026-06-03 from a live demonstration during a marathon session.
+**Status:** v0.1 plan, parked — pending council. Not an RFC yet — a scoped capture so a fresh (non-hot) session can council + execute. Born 2026-06-03 from a live demonstration during a marathon session. **Blocked (as of 2026-06-14):** unbuilt — gated on step (a) of "Honest scope" below (the behavioral-EISV arm must actually emit signal before the index has anything to read; no running-hot index exists in `src/` yet). Revisit when [[project_eisv-validation-gap]] closes.
 
 ## Origin (why this doc exists)
 


### PR DESCRIPTION
## What

Follow-up to #703, closing out the two doc-staleness items that were deferred there for operator judgment. After investigation, two warranted edits and one confirmed false-positive:

### 1. `behavioral-running-hot-detector-v0.md` + `proposals/README.md` — clarify parked/blocked status
The doc read "v0.1 plan, pending council," which left readers unable to tell *abandoned* from *pending*. Verified there is **zero implementation** of a running-hot index anywhere in `src/`, `governance_core/`, or `elixir/`. It's a parked plan, **blocked on its own named prerequisite** (the behavioral-EISV arm must emit signal — step (a) of its "Honest scope" — before the index has anything to read). Surfaced that to the status line and the index entry so it stops getting re-litigated. No decision invented; this restates the doc's own dependency.

### 2. `TROUBLESHOOTING.md` — fix stale (and self-contradicting) date stamps
Header said "April 2026", footer said "March 2026". Re-verified every command against current reality — port 8767, `data/logs/mcp_server.log`, `--port/--host/--force`, `DB_POSTGRES_URL`, postgresql@17, `/health` + `/dashboard` all still correct — then set both stamps to **June 2026**.

### 3. `DEPLOYMENT_DATA_CAVEAT.md` — intentionally left untouched
Its `2025-12-11 → 2026-04-10` (120-day) window is a **fixed historical measurement window the paper cites**, not a stale runtime fact. Editing the dates would corrupt a paper-coupled disclosure. This was a false-positive staleness flag; no change.

## Safety
Docs-only. No open PR touches these files (checked). No version/tool-count surfaces affected.

https://claude.ai/code/session_014bCuTwgahnsuPj6VyRQCkY

---
_Generated by [Claude Code](https://claude.ai/code/session_014bCuTwgahnsuPj6VyRQCkY)_