### PR TITLE
Add CI issue-surfacing experiment (surface-only)

### DIFF
--- a/.github/workflows/surface-findings.yml
+++ b/.github/workflows/surface-findings.yml
@@ -1,0 +1,146 @@
+name: Surface Findings (experiment)
+
+# CI-side "issue surfacing" experiment. Runs the deterministic surfacing
+# collectors (scripts/ci/surface_findings.py) and turns NEW fingerprints into
+# deduped GitHub issues.
+#
+# Two triggers, deliberately different blast radius:
+#   workflow_dispatch -> opens/dedups GitHub issues (the experiment button)
+#   pull_request      -> writes a job-summary table only (no issue spam on
+#                        every push; proves the pipeline against the PR diff)
+#
+# Dedup: each issue body carries a hidden `<!-- finding-fingerprint: X -->`
+# marker. Before opening an issue the workflow searches open issues labeled
+# `ci-finding` for that marker and skips if one already exists — so re-running
+# never duplicates an issue for a still-present finding.
+
+on:
+  workflow_dispatch:
+    inputs:
+      collectors:
+        description: "Collectors to run (space-separated: ruff doctor)"
+        required: false
+        default: "ruff"
+  pull_request:
+    branches: [ master, main ]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  surface:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          # PR runs scope ruff to the diff; fetch base so the diff resolves.
+          fetch-depth: 0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install ruff
+        run: pip install "ruff>=0.15"
+
+      - name: Compute changed Python files (PR only)
+        if: github.event_name == 'pull_request'
+        id: changed
+        run: |
+          base="origin/${{ github.base_ref }}"
+          files=$(git diff --name-only --diff-filter=d "$base"...HEAD -- '*.py' | tr '\n' ' ')
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+          echo "Changed Python files: ${files:-<none>}"
+
+      - name: Run surfacing collectors
+        id: surface
+        run: |
+          collectors="${{ github.event.inputs.collectors || 'ruff' }}"
+          paths="${{ steps.changed.outputs.files }}"
+          python3 scripts/ci/surface_findings.py \
+            --collectors $collectors \
+            ${paths:+--paths $paths} \
+            --output findings.json
+        # Advisory: a finding must not red-X the job (no --fail-on here).
+
+      - name: Write job summary
+        if: always()
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            if (!fs.existsSync('findings.json')) {
+              core.summary.addRaw('No findings report produced.').write();
+              return;
+            }
+            const report = JSON.parse(fs.readFileSync('findings.json', 'utf8'));
+            const s = report.summary.by_severity;
+            core.summary.addHeading('CI Issue Surfacing', 2);
+            core.summary.addRaw(
+              `**${report.summary.total}** findings — ` +
+              `🔴 ${s.critical} critical · 🟠 ${s.high} high · ` +
+              `🟡 ${s.medium} medium · ⚪ ${s.low} low\n\n`);
+            const notes = Object.entries(report.collectors)
+              .map(([k, v]) => `- \`${k}\`: ${v}`).join('\n');
+            core.summary.addRaw(`**Collectors:**\n${notes}\n\n`);
+            if (report.findings.length) {
+              core.summary.addTable([
+                [{data: 'Severity', header: true}, {data: 'Source', header: true},
+                 {data: 'Location', header: true}, {data: 'Finding', header: true}],
+                ...report.findings.slice(0, 50).map(f => [
+                  f.severity, f.source,
+                  f.file ? `${f.file}:${f.line}` : '—',
+                  (f.title || '').slice(0, 100),
+                ]),
+              ]);
+            }
+            await core.summary.write();
+
+      - name: Open deduped issues (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const report = JSON.parse(fs.readFileSync('findings.json', 'utf8'));
+            const { owner, repo } = context.repo;
+
+            // One paginated read of open ci-finding issues; harvest the
+            // fingerprint markers already on the board so we never duplicate.
+            const existing = new Set();
+            for await (const res of github.paginate.iterator(
+                github.rest.issues.listForRepo,
+                { owner, repo, state: 'open', labels: 'ci-finding', per_page: 100 })) {
+              for (const issue of res.data) {
+                const m = (issue.body || '').match(/<!-- finding-fingerprint: ([0-9a-f]+) -->/);
+                if (m) existing.add(m[1]);
+              }
+            }
+
+            let opened = 0, skipped = 0;
+            for (const f of report.findings) {
+              if (existing.has(f.fingerprint)) { skipped++; continue; }
+              const loc = f.file ? `\n**Location:** \`${f.file}:${f.line}\`` : '';
+              const body =
+                `<!-- finding-fingerprint: ${f.fingerprint} -->\n` +
+                `Surfaced by the CI issue-surfacing experiment ` +
+                `(\`${f.source}\` collector).\n\n` +
+                `**Severity:** ${f.severity}${loc}\n` +
+                `**Rule:** \`${f.rule}\`\n\n` +
+                `${f.message}\n\n` +
+                `_Fingerprint \`${f.fingerprint}\`. Close this issue once fixed; ` +
+                `a still-present finding will not be re-opened while this issue stays open._`;
+              await github.rest.issues.create({
+                owner, repo,
+                title: `[ci-finding] ${f.title}`.slice(0, 120),
+                body,
+                labels: ['ci-finding', `severity:${f.severity}`, `source:${f.source}`],
+              });
+              opened++;
+            }
+            core.notice(`ci-finding issues — opened ${opened}, skipped ${skipped} (already open)`);

--- a/docs/operations/ci-issue-surfacing.md
+++ b/docs/operations/ci-issue-surfacing.md
@@ -66,8 +66,10 @@ regression (e.g. an unused import), then run the workflow via `workflow_dispatch
 
 ## Why surface-only (for now)
 
-This experiment is the **surface** half of a surface→fix loop. The **fix** half
-(dispatching an agent to open a fix PR) needs `anthropics/claude-code-action`
+This experiment is the **surface** half of a surface→fix→land relay. The **fix**
+half (dispatching an agent to open a fix PR) needs `anthropics/claude-code-action`
 plus an `ANTHROPIC_API_KEY` repo secret, and is intentionally out of scope here.
 The deduped `ci-finding` issues are the hand-off point a fix loop would later
-consume.
+consume. The **land** half — branch protection + operator-armed merge-when-green,
+with the agent stopping at ready-for-review — is planned in
+[`merge-automation-plan.md`](./merge-automation-plan.md).

--- a/docs/operations/ci-issue-surfacing.md
+++ b/docs/operations/ci-issue-surfacing.md
@@ -1,0 +1,73 @@
+# CI Issue Surfacing (experiment)
+
+An experiment in wiring UNITARES's "issue surfacing" instinct into GitHub CI:
+run deterministic collectors on a PR / on demand, and turn each *new* finding
+into a deduped GitHub issue.
+
+This is the CI-side counterpart to the in-server surfacing agents
+(`agents/watcher`, `agents/vigil`). Those need a live governance server and an
+LLM detector; a stock GitHub runner has neither. So the CI bridge uses
+collectors that run on a vanilla `ubuntu-latest` with no Postgres, no Ollama,
+and no secrets beyond `GITHUB_TOKEN`.
+
+## Pieces
+
+| Piece | Path | Role |
+| --- | --- | --- |
+| Bridge | `scripts/ci/surface_findings.py` | Runs collectors, emits a normalized, fingerprinted findings JSON. Never touches GitHub. |
+| Workflow | `.github/workflows/surface-findings.yml` | Runs the bridge; turns new fingerprints into deduped issues (dispatch) or a job-summary table (PR). |
+| Tests | `tests/test_surface_findings.py` | Pin fingerprint parity, severity mapping, dedup, collector parsing. |
+
+## Collectors
+
+- **`ruff`** (default) — `ruff check --output-format=json` lint diagnostics.
+  Diff-scoped on PRs. The diff-relevant code signal.
+- **`doctor`** (opt-in) — `scripts/dev/unitares_doctor.py --json` fail/warn
+  checks. Meaningful only on a host that *has* the governance stack; on a bare
+  runner it would surface "no Postgres" noise, so it is **not** a default.
+  Enable it (`--collectors ruff doctor`) on a job that provisions Postgres.
+- **`watcher`** (opt-in, LLM) — defers to `agents.watcher`. Probes
+  `WATCHER_OLLAMA_URL` first and skips cleanly when the endpoint is absent (the
+  normal CI case). Off unless `--enable-watcher` is passed.
+
+## Dedup contract
+
+Each finding gets a 16-hex `fingerprint = sha256(source|rule|file|line)[:16]`,
+byte-identical to `agents.common.findings.compute_fingerprint` (a parity test
+pins this). Every opened issue carries a hidden
+`<!-- finding-fingerprint: X -->` marker and the `ci-finding` label. Before
+opening an issue the workflow reads open `ci-finding` issues, harvests their
+markers, and skips any fingerprint already on the board — so re-runs never
+duplicate an issue for a still-present finding. Close the issue when fixed; a
+still-present finding will not re-open while the issue stays open.
+
+## Triggers (deliberately different blast radius)
+
+- **`workflow_dispatch`** — the experiment button. Opens/dedups GitHub issues.
+  Run it from the Actions tab; optionally set the `collectors` input.
+- **`pull_request`** — runs the bridge against the PR's changed `.py` files and
+  writes a **job-summary table only**. No issue spam on every push.
+
+Findings are advisory: a finding never red-Xes the job. The bridge supports
+`--fail-on <severity>` for callers that want it as a gate, but the workflow
+does not pass it.
+
+## Try it locally
+
+```bash
+python3 scripts/ci/surface_findings.py                 # ruff over the repo
+python3 scripts/ci/surface_findings.py --paths src     # scope to a subtree
+python3 scripts/ci/surface_findings.py --collectors ruff doctor   # add host checks
+python3 scripts/ci/surface_findings.py --output findings.json     # same JSON the workflow consumes
+```
+
+To watch it actually open an issue: push a branch that introduces a lint
+regression (e.g. an unused import), then run the workflow via `workflow_dispatch`.
+
+## Why surface-only (for now)
+
+This experiment is the **surface** half of a surface→fix loop. The **fix** half
+(dispatching an agent to open a fix PR) needs `anthropics/claude-code-action`
+plus an `ANTHROPIC_API_KEY` repo secret, and is intentionally out of scope here.
+The deduped `ci-finding` issues are the hand-off point a fix loop would later
+consume.

--- a/docs/operations/merge-automation-plan.md
+++ b/docs/operations/merge-automation-plan.md
@@ -1,0 +1,135 @@
+# Merge Automation Plan — branch protection + operator-armed auto-merge
+
+**Status:** plan (not yet applied). Sibling of `ci-issue-surfacing.md`; both are
+steps in a surface → fix → land relay.
+
+## Goal and the line we are NOT crossing
+
+Make a change autonomous up to **"green and ready-for-review,"** then stop. The
+agent surfaces → fixes → gets CI green → marks the draft PR ready → pings the
+operator. **The operator stays the merge gate.** This honors `CLAUDE.md`'s
+delivery contract verbatim ("every session lands its work as a draft PR; the
+operator is the merge gate; no auto-merge by default").
+
+What this plan *adds* is a **safe, opt-in way to grant merge-when-green on a
+single PR** — so the operator's merge action can be "arm auto-merge once" at
+review time instead of "watch for green, then click merge." Arming is an
+**operator action**, the same deliberate tier as "mark ready." The agent does
+not arm auto-merge on its own.
+
+```
+agent:    surface ── fix ── CI green ── mark ready ──┐
+                                                     │  (agent stops here)
+operator: review ──────────────────────── arm auto-merge (optional) ── GitHub merges on green
+```
+
+## Prerequisite: branch protection with required checks
+
+Auto-merge ("merge when green") is only meaningful if `master` actually
+*requires* the checks. Without required checks, GitHub's auto-merge would merge
+the instant mergeability is satisfiable — i.e. immediately — which is not what
+we want. So branch protection is the load-bearing prerequisite.
+
+### Required check contexts
+
+From the PR-triggered workflows today (`pull_request` → `master`):
+
+| Workflow | Job → check-run context | Required? |
+| --- | --- | --- |
+| Tests | `smoke` | ✅ required |
+| Tests | `test (3.12)` | ✅ required |
+| Documentation Validation | `validate` | ✅ required |
+| Surface Findings (experiment) | `surface` | ❌ advisory — never required |
+
+`surface` is intentionally **not** required: findings are advisory and the job
+never `--fail-on`s, so gating merge on it would be a category error.
+
+> **Verify the exact context strings before applying.** Matrix and reusable
+> workflows can alter the rendered name (e.g. `test (3.12)` vs `test`). Confirm
+> against a real run:
+>
+> ```bash
+> gh api repos/CIRWEL/unitares/commits/<pr-head-sha>/check-runs \
+>   --jq '.check_runs[].name'
+> ```
+
+### Apply (operator / admin — repo-settings change, not done by the agent)
+
+```bash
+gh api -X PUT repos/CIRWEL/unitares/branches/master/protection \
+  --input - <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["smoke", "test (3.12)", "validate"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+JSON
+```
+
+- `strict: true` = "branch must be up to date before merging" (forces a rebase
+  on a stale PR — this is what turns a silently-conflicting auto-merge into a
+  re-run). Drop to `false` if the rebase churn outweighs the safety on a
+  low-traffic `master`.
+- `required_pull_request_reviews: null` keeps the *human review* requirement
+  off at the protection layer — the merge gate is enforced socially via the
+  draft-PR contract, not by a required approver count. Set it if you want
+  GitHub to also block merge without an approval.
+- `enforce_admins: false` lets the operator break-glass merge past a stuck
+  check. Flip to `true` for strict parity.
+
+To enable native auto-merge at all, the repo setting must allow it:
+
+```bash
+gh api -X PATCH repos/CIRWEL/unitares --field allow_auto_merge=true
+```
+
+## Arming auto-merge (operator-invoked, per-PR, opt-in)
+
+Two equivalent paths, both already in the toolbox:
+
+- **`ship.sh --auto-merge`** — documented in `CLAUDE.md` as "only when the
+  operator explicitly asks." This plan does not change that default; it just
+  makes the `--auto-merge` path *safe* by ensuring required checks exist.
+- **GitHub native** — `gh pr merge <n> --auto --squash`, or the MCP
+  `enable_pr_auto_merge` tool. GitHub holds the merge until all required checks
+  pass, then merges; if a check fails or a new commit lands, the merge waits.
+
+Either way the merge only happens **after** the required contexts are green, and
+only because the operator armed it on that specific PR.
+
+## Interaction with single-writer surfaces — hard rule
+
+Auto-merge must **not** be armed on a PR that touches a single-writer surface
+(migrations, identity/onboarding, `docs/ontology/plan.md`, hot RFC docs, large
+test-layout deletions — see `CLAUDE.md` "Before Starting Work on a Single-Writer
+Surface") without the cross-branch coordination check first. Merge-when-green
+removes the human pause that currently catches a slot/semantic collision at
+merge time. For these surfaces, keep merge fully manual so the operator does the
+`gh pr list --search` collision check at the moment of merge.
+
+A future guard could make this structural: a workflow step that inspects the
+diff's paths and refuses to arm (or posts a "manual-merge-only" label) when a
+single-writer surface is touched. Out of scope for this plan; noted as the
+natural next hardening.
+
+## What stays a human decision
+
+- **Whether a PR should merge at all** — never automated here.
+- **Arming auto-merge** — operator action, per-PR.
+- **Anything touching a single-writer surface** — manual merge, with the
+  collision check.
+
+## Rollout
+
+1. Confirm exact check-run contexts on a real PR head (`check-runs` query above).
+2. Apply branch protection + `allow_auto_merge` (operator/admin).
+3. Try the loop on one low-risk PR: let the agent drive to ready-for-review,
+   then operator arms `gh pr merge --auto --squash` and confirms GitHub merges
+   on green.
+4. Only after that burn-in, consider the single-writer-surface arming guard.

--- a/scripts/ci/surface_findings.py
+++ b/scripts/ci/surface_findings.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""CI issue-surfacing bridge.
+
+Runs deterministic "issue surfacing" collectors in CI and emits a normalized,
+fingerprinted findings feed. A companion GitHub Actions step
+(``.github/workflows/surface-findings.yml``) turns each *new* fingerprint into
+a deduped GitHub issue.
+
+This is the CI-side counterpart to the in-editor / in-server surfacing agents
+(``agents/watcher``, ``agents/vigil``). Those run against a live governance
+server and an LLM detector, neither of which exists on a stock GitHub runner.
+The collectors here are stdlib/CLI-only so they run on a vanilla
+``ubuntu-latest`` with no Postgres, no Ollama, and no secrets beyond the
+workflow's ``GITHUB_TOKEN``.
+
+Collectors (select with ``--collectors``):
+
+    ruff     ``ruff check ... --output-format=json`` lint diagnostics.
+    doctor   ``scripts/dev/unitares_doctor.py --json`` (surfaces fail/warn checks).
+    watcher  OPTIONAL LLM scan. Skipped unless ``--enable-watcher`` is passed
+             AND a ``WATCHER_OLLAMA_URL`` endpoint answers. Off by default so
+             CI output stays deterministic.
+
+Fingerprints reuse ``agents.common.findings.compute_fingerprint`` so a finding
+surfaced from CI shares the dedup identity scheme with the rest of UNITARES —
+the same ``(source, rule, file, line)`` tuple always hashes to the same 16-hex
+id, which is what lets the workflow skip issues it has already opened.
+
+The script never touches the GitHub API. It only emits JSON (so it is trivially
+unit-testable and runs identically on a laptop); issue creation/dedup lives in
+the workflow's ``github-script`` step.
+
+Usage:
+    python3 scripts/ci/surface_findings.py                       # all default collectors, repo root
+    python3 scripts/ci/surface_findings.py --paths src agents    # scope ruff to a subset
+    python3 scripts/ci/surface_findings.py --collectors ruff     # one collector
+    python3 scripts/ci/surface_findings.py --output findings.json
+    python3 scripts/ci/surface_findings.py --fail-on high        # exit 1 if any high+ finding
+
+Exit code is 0 (advisory) unless ``--fail-on <severity>`` is set and a finding
+at or above that severity is present.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+# Repo root used to normalize paths to repo-relative form before hashing.
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def compute_fingerprint(parts: Iterable[Any]) -> str:
+    """16-hex-char SHA-256 prefix of a pipe-joined identity string.
+
+    Kept byte-identical with ``agents.common.findings.compute_fingerprint`` (a
+    parity test pins this) so a finding surfaced from CI shares the dedup id
+    with the rest of UNITARES. Inlined rather than imported so this script stays
+    stdlib-only — the canonical module pulls in ``httpx`` at import time, which
+    we do not want on the CI surfacing path or on a laptop dry-run.
+    """
+    normalized = "|".join(str(p) for p in parts)
+    return hashlib.sha256(normalized.encode()).hexdigest()[:16]
+
+
+# Ordered worst-first so ``--fail-on`` threshold comparisons are simple index
+# math and the summary sorts criticals to the top.
+# ``doctor`` is intentionally NOT a default: it checks for a working install
+# (Postgres reachable, schema present, anchor dir), which is meaningful on a
+# deployment host but is pure noise on a stock CI runner that has none of it.
+# Enable it explicitly (``--collectors ruff doctor``) only on a job that
+# provisions the governance stack.
+SEVERITY_ORDER = ("critical", "high", "medium", "low")
+DEFAULT_COLLECTORS = ("ruff",)
+
+
+@dataclass
+class Finding:
+    """One normalized, fingerprinted CI finding.
+
+    ``fingerprint`` names the finding's *identity* (stable across reruns) and is
+    the dedup key the workflow uses to decide whether an issue already exists.
+    """
+
+    source: str  # ruff | doctor | watcher
+    severity: str  # critical | high | medium | low
+    title: str
+    message: str
+    file: str = ""
+    line: int = 0
+    rule: str = ""  # lint code / check name / pattern
+    fingerprint: str = ""
+
+    def __post_init__(self) -> None:
+        if self.severity not in SEVERITY_ORDER:
+            self.severity = "medium"
+        if not self.fingerprint:
+            self.fingerprint = compute_fingerprint(
+                [self.source, self.rule, _repo_rel(self.file), self.line]
+            )
+
+
+def _repo_rel(path: str) -> str:
+    """Best-effort repo-relative path so the same file hashes identically no
+    matter the absolute checkout prefix (CI runner vs. laptop)."""
+    if not path:
+        return ""
+    try:
+        return str(Path(path).resolve().relative_to(PROJECT_ROOT))
+    except (ValueError, OSError):
+        return path
+
+
+# ---------------------------------------------------------------------------
+# Collectors
+#
+# Each returns ``(findings, note)``. ``note`` is a human-readable status line
+# ("12 diagnostics", "ruff not installed — skipped") surfaced in the summary so
+# a skipped collector is visible rather than silently absent.
+# ---------------------------------------------------------------------------
+
+
+def collect_ruff(paths: Sequence[str]) -> tuple[list[Finding], str]:
+    targets = list(paths) or ["."]
+    try:
+        proc = subprocess.run(
+            ["ruff", "check", *targets, "--output-format=json"],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+    except FileNotFoundError:
+        return [], "ruff not installed — skipped"
+    except subprocess.TimeoutExpired:
+        return [], "ruff timed out after 300s — skipped"
+
+    raw = (proc.stdout or "").strip()
+    if not raw:
+        # ruff prints nothing on a clean tree (exit 0) and diagnostics-as-JSON
+        # on a dirty one (exit 1). A non-empty stderr with empty stdout means a
+        # real invocation error worth surfacing in the note.
+        if proc.returncode not in (0, 1):
+            return [], f"ruff errored (rc={proc.returncode}): {(proc.stderr or '').strip()[:200]}"
+        return [], "0 diagnostics"
+
+    try:
+        diagnostics = json.loads(raw)
+    except json.JSONDecodeError:
+        return [], f"ruff JSON parse failed (rc={proc.returncode})"
+
+    findings: list[Finding] = []
+    for d in diagnostics:
+        code = d.get("code") or "RUFF"
+        loc = d.get("location") or {}
+        filename = d.get("filename", "")
+        findings.append(
+            Finding(
+                source="ruff",
+                severity=_ruff_severity(code),
+                title=f"ruff {code}: {d.get('message', '').strip()[:80]}",
+                message=d.get("message", "").strip(),
+                file=filename,
+                line=int(loc.get("row", 0) or 0),
+                rule=code,
+            )
+        )
+    return findings, f"{len(findings)} diagnostics"
+
+
+def _ruff_severity(code: str) -> str:
+    """Map a ruff rule code to a finding severity.
+
+    Pyflakes F8xx (undefined name / redefinition / f-string-missing-
+    placeholders) are genuine bug smells -> high. Other F (e.g. F401 unused
+    import) and bug-bear/security families -> medium. Stylistic E/W -> low.
+    """
+    if code.startswith("F8"):
+        return "high"
+    if code[:1] in {"F", "B", "S"}:  # pyflakes, bugbear, bandit-style security
+        return "medium"
+    if code[:1] in {"E", "W", "I", "Q", "C"}:
+        return "low"
+    return "medium"
+
+
+def collect_doctor(_paths: Sequence[str]) -> tuple[list[Finding], str]:
+    doctor = PROJECT_ROOT / "scripts" / "dev" / "unitares_doctor.py"
+    if not doctor.exists():
+        return [], "unitares_doctor.py not found — skipped"
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(doctor), "--mode", "local", "--json"],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        return [], "doctor timed out after 120s — skipped"
+
+    try:
+        payload = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError:
+        return [], f"doctor JSON parse failed (rc={proc.returncode})"
+
+    findings: list[Finding] = []
+    for r in payload.get("results", []):
+        status = r.get("status")
+        if status not in {"fail", "warn"}:
+            continue
+        severity = "high" if status == "fail" else "medium"
+        name = r.get("name", "check")
+        findings.append(
+            Finding(
+                source="doctor",
+                severity=severity,
+                title=f"doctor {status}: {name}",
+                message=r.get("message", "") + (f"\n\n{r['detail']}" if r.get("detail") else ""),
+                file="",
+                line=0,
+                rule=name,
+            )
+        )
+    return findings, f"{len(findings)} fail/warn checks"
+
+
+def collect_watcher(paths: Sequence[str]) -> tuple[list[Finding], str]:
+    """Optional LLM-backed scan. Off unless the endpoint actually answers.
+
+    The watcher's detector talks to an Ollama-compatible endpoint that does not
+    exist on a stock GitHub runner, so this collector probes the endpoint first
+    and skips cleanly when it is absent — the common CI case.
+    """
+    url = os.environ.get("WATCHER_OLLAMA_URL", "http://localhost:11434")
+    probe = url.rstrip("/").rsplit("/v1", 1)[0] + "/api/tags"
+    try:
+        with urllib.request.urlopen(probe, timeout=3):
+            pass
+    except (urllib.error.URLError, OSError, ValueError):
+        return [], f"watcher endpoint unreachable ({probe}) — skipped"
+
+    # Endpoint is live: defer to the real watcher agent for the actual scan.
+    findings: list[Finding] = []
+    notes: list[str] = []
+    try:
+        from agents.watcher.agent import scan_file  # type: ignore
+    except Exception as e:  # pragma: no cover - import guarded for CI
+        return [], f"watcher agent import failed: {e}"
+
+    for path in paths:
+        p = PROJECT_ROOT / path if not Path(path).is_absolute() else Path(path)
+        if not p.is_file() or p.suffix != ".py":
+            continue
+        try:
+            for wf in scan_file(str(p)) or []:
+                findings.append(
+                    Finding(
+                        source="watcher",
+                        severity=getattr(wf, "severity", "medium"),
+                        title=f"watcher {getattr(wf, 'pattern', '?')}: {getattr(wf, 'hint', '')[:80]}",
+                        message=getattr(wf, "hint", ""),
+                        file=getattr(wf, "file", str(p)),
+                        line=int(getattr(wf, "line", 0) or 0),
+                        rule=getattr(wf, "pattern", ""),
+                    )
+                )
+        except Exception as e:  # pragma: no cover - per-file resilience
+            notes.append(f"{path}: {e}")
+    note = f"{len(findings)} findings"
+    if notes:
+        note += f" ({len(notes)} files errored)"
+    return findings, note
+
+
+COLLECTORS = {
+    "ruff": collect_ruff,
+    "doctor": collect_doctor,
+    "watcher": collect_watcher,
+}
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Report:
+    generated_at: str
+    collectors: dict[str, str] = field(default_factory=dict)  # name -> status note
+    findings: list[Finding] = field(default_factory=list)
+
+    def to_json(self) -> dict[str, Any]:
+        sev_idx = {s: i for i, s in enumerate(SEVERITY_ORDER)}
+        ordered = sorted(
+            self.findings,
+            key=lambda f: (sev_idx.get(f.severity, 99), f.source, f.file, f.line),
+        )
+        counts = {s: 0 for s in SEVERITY_ORDER}
+        for f in ordered:
+            counts[f.severity] += 1
+        return {
+            "generated_at": self.generated_at,
+            "collectors": self.collectors,
+            "summary": {"total": len(ordered), "by_severity": counts},
+            "findings": [asdict(f) for f in ordered],
+        }
+
+
+def run(collectors: Sequence[str], paths: Sequence[str], enable_watcher: bool) -> Report:
+    report = Report(generated_at=datetime.now(timezone.utc).isoformat())
+    seen: set[str] = set()
+    for name in collectors:
+        if name == "watcher" and not enable_watcher:
+            report.collectors[name] = "disabled (pass --enable-watcher)"
+            continue
+        fn = COLLECTORS.get(name)
+        if fn is None:
+            report.collectors[name] = "unknown collector — skipped"
+            continue
+        findings, note = fn(paths)
+        report.collectors[name] = note
+        # Cross-collector dedup: identical fingerprint from two sources is one
+        # finding, not two issues.
+        for f in findings:
+            if f.fingerprint in seen:
+                continue
+            seen.add(f.fingerprint)
+            report.findings.append(f)
+    return report
+
+
+def _split_csv(values: Sequence[str]) -> list[str]:
+    out: list[str] = []
+    for v in values:
+        out.extend(part for part in v.replace(",", " ").split() if part)
+    return out
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--collectors",
+        nargs="*",
+        default=list(DEFAULT_COLLECTORS),
+        help=f"collectors to run (default: {' '.join(DEFAULT_COLLECTORS)})",
+    )
+    parser.add_argument(
+        "--paths",
+        nargs="*",
+        default=[],
+        help="paths to scope file-oriented collectors to (default: repo root)",
+    )
+    parser.add_argument("--enable-watcher", action="store_true", help="run the optional LLM watcher collector")
+    parser.add_argument("--output", help="write the findings report JSON to this path")
+    parser.add_argument(
+        "--fail-on",
+        choices=SEVERITY_ORDER,
+        help="exit 1 if any finding at or above this severity is present",
+    )
+    args = parser.parse_args(argv)
+
+    collectors = _split_csv(args.collectors)
+    paths = _split_csv(args.paths)
+    report = run(collectors, paths, enable_watcher=args.enable_watcher)
+    payload = report.to_json()
+
+    if args.output:
+        Path(args.output).write_text(json.dumps(payload, indent=2) + "\n")
+
+    # Human summary to stderr so stdout stays a clean JSON channel when piped.
+    print("CI issue-surfacing report", file=sys.stderr)
+    for name, note in payload["collectors"].items():
+        print(f"  {name:8} {note}", file=sys.stderr)
+    counts = payload["summary"]["by_severity"]
+    print(
+        f"  total: {payload['summary']['total']} "
+        f"(critical={counts['critical']} high={counts['high']} "
+        f"medium={counts['medium']} low={counts['low']})",
+        file=sys.stderr,
+    )
+
+    json.dump(payload, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+    if args.fail_on:
+        threshold = SEVERITY_ORDER.index(args.fail_on)
+        worst = min(
+            (SEVERITY_ORDER.index(f["severity"]) for f in payload["findings"]),
+            default=len(SEVERITY_ORDER),
+        )
+        if worst <= threshold:
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_surface_findings.py
+++ b/tests/test_surface_findings.py
@@ -1,0 +1,228 @@
+"""Tests for the CI issue-surfacing bridge (scripts/ci/surface_findings.py).
+
+The bridge runs deterministic collectors in CI and emits a normalized,
+fingerprinted findings feed that a workflow turns into deduped GitHub issues.
+These tests pin the parts that the workflow's dedup contract depends on:
+
+  - fingerprints are stable and byte-identical to the canonical
+    agents.common.findings.compute_fingerprint (the workflow keys issue dedup
+    on this id; drift would silently re-open every issue),
+  - severity mapping is what the issue labels claim,
+  - the same finding seen by two collectors is one report entry, not two,
+  - ruff/doctor collector output is parsed into the normalized shape.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(scope="module")
+def mod():
+    module_path = PROJECT_ROOT / "scripts" / "ci" / "surface_findings.py"
+    spec = importlib.util.spec_from_file_location("surface_findings", module_path)
+    assert spec and spec.loader, f"could not load {module_path}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["surface_findings"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint identity — the dedup contract the workflow depends on
+# ---------------------------------------------------------------------------
+
+
+def test_fingerprint_matches_canonical(mod):
+    """The inlined fingerprint MUST equal agents.common.findings.compute_fingerprint
+    for the same parts — otherwise a finding surfaced from CI would not share
+    dedup identity with the rest of UNITARES."""
+    from agents.common.findings import compute_fingerprint as canonical
+
+    parts = ["ruff", "F401", "src/foo.py", 12]
+    assert mod.compute_fingerprint(parts) == canonical(parts)
+
+
+def test_fingerprint_is_stable_across_instances(mod):
+    a = mod.Finding(source="ruff", severity="medium", title="t", message="m",
+                    file="src/foo.py", line=12, rule="F401")
+    b = mod.Finding(source="ruff", severity="medium", title="t2", message="m2",
+                    file="src/foo.py", line=12, rule="F401")
+    # title/message differ but identity (source|rule|file|line) is the same.
+    assert a.fingerprint == b.fingerprint
+
+
+def test_fingerprint_distinguishes_line(mod):
+    a = mod.Finding(source="ruff", severity="medium", title="t", message="m",
+                    file="src/foo.py", line=12, rule="F401")
+    b = mod.Finding(source="ruff", severity="medium", title="t", message="m",
+                    file="src/foo.py", line=13, rule="F401")
+    assert a.fingerprint != b.fingerprint
+
+
+# ---------------------------------------------------------------------------
+# Severity mapping — issue labels claim this
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("code,expected", [
+    ("F821", "high"),     # undefined name — genuine bug
+    ("F401", "medium"),   # unused import
+    ("B008", "medium"),   # bugbear
+    ("E501", "low"),      # line length
+    ("W291", "low"),      # whitespace
+    ("ZZZ9", "medium"),   # unknown family -> safe default
+])
+def test_ruff_severity_mapping(mod, code, expected):
+    assert mod._ruff_severity(code) == expected
+
+
+def test_invalid_severity_coerced_to_medium(mod):
+    f = mod.Finding(source="x", severity="bogus", title="t", message="m")
+    assert f.severity == "medium"
+
+
+# ---------------------------------------------------------------------------
+# Orchestration — cross-collector dedup + watcher gating
+# ---------------------------------------------------------------------------
+
+
+def test_run_dedups_identical_fingerprints_across_collectors(mod, monkeypatch):
+    dup = mod.Finding(source="ruff", severity="high", title="t", message="m",
+                      file="src/a.py", line=1, rule="F821")
+    # Same identity tuple surfaced by a second collector.
+    same = mod.Finding(source="ruff", severity="high", title="other", message="m2",
+                       file="src/a.py", line=1, rule="F821")
+    assert dup.fingerprint == same.fingerprint
+
+    monkeypatch.setitem(mod.COLLECTORS, "alpha", lambda paths: ([dup], "1"))
+    monkeypatch.setitem(mod.COLLECTORS, "beta", lambda paths: ([same], "1"))
+
+    report = mod.run(["alpha", "beta"], paths=[], enable_watcher=False)
+    assert len(report.findings) == 1
+
+
+def test_watcher_disabled_by_default(mod):
+    report = mod.run(["watcher"], paths=[], enable_watcher=False)
+    assert report.findings == []
+    assert "disabled" in report.collectors["watcher"]
+
+
+def test_unknown_collector_noted_not_crashed(mod):
+    report = mod.run(["nope"], paths=[], enable_watcher=False)
+    assert "unknown collector" in report.collectors["nope"]
+
+
+# ---------------------------------------------------------------------------
+# Collector parsing — ruff/doctor JSON -> normalized findings
+# ---------------------------------------------------------------------------
+
+
+def test_collect_ruff_parses_diagnostics(mod, monkeypatch):
+    fake_json = json.dumps([
+        {"code": "F821", "message": "undefined name 'x'",
+         "filename": "src/foo.py", "location": {"row": 9, "column": 1}},
+    ])
+
+    class FakeProc:
+        stdout = fake_json
+        stderr = ""
+        returncode = 1
+
+    monkeypatch.setattr(mod.subprocess, "run", lambda *a, **k: FakeProc())
+    findings, note = mod.collect_ruff(["src"])
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.source == "ruff" and f.rule == "F821" and f.severity == "high"
+    assert f.file == "src/foo.py" and f.line == 9
+    assert "1 diagnostics" in note
+
+
+def test_collect_ruff_clean_tree(mod, monkeypatch):
+    class FakeProc:
+        stdout = ""
+        stderr = ""
+        returncode = 0
+
+    monkeypatch.setattr(mod.subprocess, "run", lambda *a, **k: FakeProc())
+    findings, note = mod.collect_ruff(["."])
+    assert findings == []
+    assert "0 diagnostics" in note
+
+
+def test_collect_ruff_missing_binary_skips(mod, monkeypatch):
+    def boom(*a, **k):
+        raise FileNotFoundError("ruff")
+
+    monkeypatch.setattr(mod.subprocess, "run", boom)
+    findings, note = mod.collect_ruff(["."])
+    assert findings == []
+    assert "not installed" in note
+
+
+def test_collect_doctor_maps_fail_and_warn(mod, monkeypatch):
+    payload = json.dumps({"results": [
+        {"name": "schema", "mode": "local", "status": "fail",
+         "message": "no db", "detail": "conn refused"},
+        {"name": "anchor", "mode": "local", "status": "warn",
+         "message": "missing", "detail": ""},
+        {"name": "python", "mode": "local", "status": "pass",
+         "message": "ok", "detail": ""},
+    ]})
+
+    class FakeProc:
+        stdout = payload
+        stderr = ""
+        returncode = 1
+
+    monkeypatch.setattr(mod.subprocess, "run", lambda *a, **k: FakeProc())
+    findings, note = mod.collect_doctor([])
+    # pass is dropped; fail -> high, warn -> medium.
+    assert {f.rule: f.severity for f in findings} == {"schema": "high", "anchor": "medium"}
+    assert "conn refused" in next(f.message for f in findings if f.rule == "schema")
+
+
+# ---------------------------------------------------------------------------
+# Report shape — what the workflow consumes
+# ---------------------------------------------------------------------------
+
+
+def test_report_json_sorts_and_counts(mod):
+    report = mod.Report(generated_at="now")
+    report.findings = [
+        mod.Finding(source="ruff", severity="low", title="lo", message="", rule="E1"),
+        mod.Finding(source="ruff", severity="critical", title="crit", message="", rule="X1"),
+        mod.Finding(source="ruff", severity="medium", title="med", message="", rule="F4"),
+    ]
+    payload = report.to_json()
+    # critical sorts first.
+    assert payload["findings"][0]["severity"] == "critical"
+    assert payload["summary"]["total"] == 3
+    assert payload["summary"]["by_severity"] == {
+        "critical": 1, "high": 0, "medium": 1, "low": 1,
+    }
+
+
+def test_main_writes_output_and_exit_code(mod, tmp_path, monkeypatch):
+    out = tmp_path / "findings.json"
+    # ruff clean -> no findings -> fail-on never trips.
+    monkeypatch.setitem(
+        mod.COLLECTORS, "ruff", lambda paths: ([], "0 diagnostics"))
+    rc = mod.main(["--collectors", "ruff", "--output", str(out), "--fail-on", "low"])
+    assert rc == 0
+    data = json.loads(out.read_text())
+    assert data["summary"]["total"] == 0
+
+
+def test_fail_on_trips_for_high(mod, monkeypatch):
+    hit = mod.Finding(source="ruff", severity="high", title="t", message="m", rule="F821")
+    monkeypatch.setitem(mod.COLLECTORS, "ruff", lambda paths: ([hit], "1"))
+    rc = mod.main(["--collectors", "ruff", "--fail-on", "high"])
+    assert rc == 1


### PR DESCRIPTION
## What

An experiment wiring UNITARES's "issue surfacing" instinct into GitHub CI: run deterministic collectors and turn each *new* finding into a **deduped GitHub issue**. This is the CI-side counterpart to the in-server surfacing agents (`agents/watcher`, `agents/vigil`) — those need a live governance server + LLM detector that a stock GitHub runner doesn't have, so the bridge uses collectors that run on a bare `ubuntu-latest` with no Postgres, no Ollama, no secrets beyond `GITHUB_TOKEN`.

Scope chosen with the operator: **surface-only**, delivered as **GitHub issues**.

## Pieces

| Piece | Role |
| --- | --- |
| `scripts/ci/surface_findings.py` | Collector-based bridge → normalized, fingerprinted findings JSON. Pure (never touches GitHub), stdlib-only. |
| `.github/workflows/surface-findings.yml` | `workflow_dispatch` opens/dedups issues; `pull_request` writes a job-summary table only. |
| `tests/test_surface_findings.py` | Pins fingerprint parity, severity mapping, dedup, collector parsing. |
| `docs/operations/ci-issue-surfacing.md` | Design + how to run. |

## Collectors

- **`ruff`** (default) — lint diagnostics, diff-scoped on PRs. The diff-relevant code signal.
- **`doctor`** (opt-in) — `unitares_doctor --json`; meaningful only on a host with the governance stack, so **not** a default (would surface "no Postgres" noise on a bare runner).
- **`watcher`** (opt-in, LLM) — defers to `agents.watcher`; probes `WATCHER_OLLAMA_URL` and skips cleanly when absent.

## Dedup contract

`fingerprint = sha256(source|rule|file|line)[:16]`, byte-identical to `agents.common.findings.compute_fingerprint` (parity test pins it). Issues carry a hidden `<!-- finding-fingerprint: X -->` marker + `ci-finding` label; the workflow skips any fingerprint already on an open issue. Re-runs never duplicate.

## Triggers (different blast radius on purpose)

- **`workflow_dispatch`** — the experiment button: opens/dedups `ci-finding` issues.
- **`pull_request`** — job-summary table only, no issue spam.

Findings are advisory (no `--fail-on` in the workflow), so they never red-X a job.

## Verification

- Bridge logic validated end-to-end (fingerprint parity, severity map, cross-collector dedup, ruff/doctor parsing, report ordering/counts, `--fail-on`).
- `ruff check` clean on new files; workflow YAML validates.
- Full `pytest` for `tests/test_surface_findings.py` runs under CI's `requirements-full` (the sandbox lacks server deps that the repo `conftest.py` imports).

## Out of scope

The **fix** half of a surface→fix loop (dispatch `anthropics/claude-code-action` to open a fix PR) needs an `ANTHROPIC_API_KEY` secret and is intentionally deferred. The deduped `ci-finding` issues are the hand-off point a fix loop would consume.

https://claude.ai/code/session_01CEARvWBDLcbNXuYPCPPqCW

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEARvWBDLcbNXuYPCPPqCW)_