### PR TITLE
feat: add dogfood friction finding envelope

### DIFF
--- a/agents/common/dogfood_friction.py
+++ b/agents/common/dogfood_friction.py
@@ -1,0 +1,199 @@
+"""Dogfood friction finding envelopes for CI/CD issue surfacing.
+
+Fresh dogfood episodes are high-sensitivity probes. This module turns their
+observations into a canonical `/api/findings` event payload while keeping the
+layers separate: the event carries route hints for issue surfacing, KG sediment,
+dialectic review, and CI gates, but does not perform those downstream actions.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from agents.common.findings import compute_change_token, compute_fingerprint, post_finding
+
+REQUIRED_FIELDS = ("surface", "attempted_action", "expected", "observed")
+VALID_SEVERITIES = ("low", "medium", "high", "critical")
+CI_GATE_ACTIONS = frozenset({"block", "cooldown", "rollback"})
+DEFAULT_AGENT_ID = "dogfood-friction"
+DEFAULT_AGENT_NAME = "Dogfood Friction Probe"
+EVENT_TYPE = "dogfood_friction_finding"
+
+
+class DogfoodFrictionValidationError(ValueError):
+    """Raised when a dogfood friction envelope is missing required evidence."""
+
+
+def _clean_text(value: Any) -> str:
+    """Return a stripped string for JSON-ish input values."""
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _clean_bool(value: Any, *, default: bool = False) -> bool:
+    """Coerce common JSON/string boolean shapes without treating text as truthy."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "y", "on"}:
+        return True
+    if text in {"0", "false", "no", "n", "off"}:
+        return False
+    return default
+
+
+def _clean_int(value: Any, *, default: int = 0) -> int:
+    """Coerce a non-negative integer, falling back to ``default`` on bad input."""
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(parsed, 0)
+
+
+def normalize_dogfood_friction(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate and normalize a dogfood friction observation.
+
+    Required fields describe the measured friction itself. Optional fields add
+    evidence, recurrence, and routing context. The result is deterministic so
+    CI jobs can compare, hash, and dedupe repeated observations.
+    """
+    normalized: dict[str, Any] = {}
+    missing: list[str] = []
+
+    for field in REQUIRED_FIELDS:
+        text = _clean_text(payload.get(field))
+        if not text:
+            missing.append(field)
+        normalized[field] = text
+
+    if missing:
+        joined = ", ".join(missing)
+        raise DogfoodFrictionValidationError(f"dogfood friction missing required field(s): {joined}")
+
+    severity = _clean_text(payload.get("severity") or "low").lower()
+    if severity not in VALID_SEVERITIES:
+        allowed = ", ".join(VALID_SEVERITIES)
+        raise DogfoodFrictionValidationError(
+            f"dogfood friction severity {severity!r} must be one of: {allowed}"
+        )
+
+    normalized.update(
+        {
+            "kind": "dogfood_friction",
+            "fresh_agent_context": _clean_text(payload.get("fresh_agent_context")),
+            "evidence_uri": _clean_text(payload.get("evidence_uri")),
+            "repro_command": _clean_text(payload.get("repro_command")),
+            "workaround_used": _clean_text(payload.get("workaround_used")),
+            "severity": severity,
+            "reproducible": _clean_bool(payload.get("reproducible"), default=False),
+            "recurrence_count": _clean_int(payload.get("recurrence_count"), default=0),
+            "ambiguous": _clean_bool(payload.get("ambiguous"), default=False),
+            "policy_question": _clean_bool(payload.get("policy_question"), default=False),
+            "proposed_action": _clean_text(payload.get("proposed_action")).lower(),
+            "source": _clean_text(payload.get("source") or "dogfood"),
+        }
+    )
+    normalized["routes"] = route_dogfood_friction(normalized)
+    normalized["boundary_note"] = (
+        "Issue surfacing is measurement/instrumentation; KG is durable sediment; "
+        "dialectic is contested-meaning review; CI/CD is the actuator layer."
+    )
+    return normalized
+
+
+def route_dogfood_friction(friction: Mapping[str, Any]) -> list[str]:
+    """Return ordered route hints without performing downstream writes.
+
+    Order is intentionally policy-shaped: possible CI gate first, then ordinary
+    issue surfacing, then durable KG sediment, then dialectic for ambiguity.
+    """
+    severity = _clean_text(friction.get("severity")).lower()
+    proposed_action = _clean_text(friction.get("proposed_action")).lower()
+    routes: list[str] = []
+
+    if severity == "critical" or proposed_action in CI_GATE_ACTIONS:
+        routes.append("ci_gate")
+
+    if _clean_bool(friction.get("reproducible"), default=False):
+        routes.append("issue_surface")
+
+    if _clean_int(friction.get("recurrence_count"), default=0) >= 2:
+        routes.append("kg_note")
+
+    if (
+        _clean_bool(friction.get("ambiguous"), default=False)
+        or _clean_bool(friction.get("policy_question"), default=False)
+    ):
+        routes.append("dialectic_request")
+
+    if not routes:
+        routes.append("local_observation")
+    return routes
+
+
+def build_dogfood_friction_event(
+    payload: Mapping[str, Any],
+    *,
+    agent_id: str = DEFAULT_AGENT_ID,
+    agent_name: str = DEFAULT_AGENT_NAME,
+) -> dict[str, Any]:
+    """Build kwargs suitable for ``agents.common.findings.post_finding``.
+
+    ``fingerprint`` is the durable dedup identity: same surface + attempted
+    action + observed friction should collapse across CI runs even when the
+    evidence artifact URL changes. ``change_token`` includes the full normalized
+    evidence shape, so the event stream can emit when the condition changes.
+    """
+    friction = normalize_dogfood_friction(payload)
+    fingerprint = compute_fingerprint(
+        [
+            EVENT_TYPE,
+            friction["surface"],
+            friction["attempted_action"],
+            friction["observed"],
+        ]
+    )
+    message = (
+        f"[{friction['kind']}] {friction['surface']}: "
+        f"{friction['attempted_action']} -> {friction['observed']}"
+    )
+    change_token = compute_change_token(
+        {
+            "type": EVENT_TYPE,
+            "severity": friction["severity"],
+            "message": message,
+            "extra": friction,
+        }
+    )
+    return {
+        "event_type": EVENT_TYPE,
+        "severity": friction["severity"],
+        "message": message,
+        "agent_id": _clean_text(agent_id) or DEFAULT_AGENT_ID,
+        "agent_name": _clean_text(agent_name) or DEFAULT_AGENT_NAME,
+        "fingerprint": fingerprint,
+        "change_token": change_token,
+        "extra": friction,
+    }
+
+
+def post_dogfood_friction(
+    payload: Mapping[str, Any],
+    *,
+    agent_id: str = DEFAULT_AGENT_ID,
+    agent_name: str = DEFAULT_AGENT_NAME,
+) -> bool:
+    """Post a dogfood friction finding through the shared findings helper."""
+    event = build_dogfood_friction_event(
+        payload,
+        agent_id=agent_id,
+        agent_name=agent_name,
+    )
+    return post_finding(**event)

--- a/agents/common/tests/test_dogfood_friction.py
+++ b/agents/common/tests/test_dogfood_friction.py
@@ -1,0 +1,129 @@
+"""Tests for dogfood friction finding envelopes.
+
+Fresh dogfood runs should surface newcomer-friction as evidence, not as direct
+actuation. These tests pin the first CI/CD primitive: normalize a finding,
+compute stable dedup tokens, and emit route hints for issue/KG/dialectic/gate
+layers without performing those writes directly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+BASE_FRICTION = {
+    "surface": "unitares_mcp",
+    "fresh_agent_context": "fresh Hermes dogfood episode; no proof-bearing continuity token",
+    "attempted_action": "call process_agent_update with documented mirror payload",
+    "expected": "mirror check-in succeeds",
+    "observed": "schema rejected initial_state.task as an extra field",
+    "evidence_uri": "artifact://run-a/log.txt",
+    "repro_command": "hermes mcp call unitares process_agent_update @payload.json",
+    "workaround_used": "removed unsupported nested field",
+    "severity": "medium",
+    "reproducible": True,
+    "recurrence_count": 1,
+}
+
+
+def test_build_event_computes_stable_fingerprint_but_condition_token_tracks_evidence():
+    from agents.common.dogfood_friction import build_dogfood_friction_event
+
+    first = build_dogfood_friction_event(BASE_FRICTION)
+    rerun = build_dogfood_friction_event({**BASE_FRICTION, "evidence_uri": "artifact://run-b/log.txt"})
+
+    assert first["event_type"] == "dogfood_friction_finding"
+    assert first["fingerprint"] == rerun["fingerprint"]
+    assert first["change_token"] != rerun["change_token"]
+    assert len(first["fingerprint"]) == 16
+    assert first["severity"] == "medium"
+    assert first["agent_id"] == "dogfood-friction"
+    assert first["extra"]["kind"] == "dogfood_friction"
+    assert first["extra"]["routes"] == ["issue_surface"]
+    assert "actuator" in first["extra"]["boundary_note"]
+
+
+def test_routes_recurring_ambiguous_high_severity_to_separate_layers():
+    from agents.common.dogfood_friction import build_dogfood_friction_event
+
+    event = build_dogfood_friction_event({
+        **BASE_FRICTION,
+        "severity": "high",
+        "recurrence_count": 3,
+        "ambiguous": True,
+        "proposed_action": "block",
+    })
+
+    assert event["severity"] == "high"
+    assert event["extra"]["routes"] == [
+        "ci_gate",
+        "issue_surface",
+        "kg_note",
+        "dialectic_request",
+    ]
+    assert event["extra"]["proposed_action"] == "block"
+
+
+@pytest.mark.parametrize("missing", ["surface", "attempted_action", "expected", "observed"])
+def test_missing_required_fields_raise_clear_validation_error(missing):
+    from agents.common.dogfood_friction import DogfoodFrictionValidationError, build_dogfood_friction_event
+
+    payload = dict(BASE_FRICTION)
+    payload.pop(missing)
+
+    with pytest.raises(DogfoodFrictionValidationError, match=missing):
+        build_dogfood_friction_event(payload)
+
+
+def test_script_dry_run_prints_event_payload_without_posting(monkeypatch, capsys):
+    module_path = Path(__file__).resolve().parents[3] / "scripts" / "diagnostics" / "dogfood_friction_finding.py"
+    spec = importlib.util.spec_from_file_location("dogfood_friction_finding_cli", module_path)
+    assert spec and spec.loader
+    cli = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(cli)
+
+    posted = []
+    monkeypatch.setattr(cli, "post_dogfood_friction", lambda *args, **kwargs: posted.append((args, kwargs)))
+
+    input_payload = json.dumps(BASE_FRICTION)
+    rc = cli.main(["--input-json", input_payload])
+
+    assert rc == 0
+    assert posted == []
+    rendered = json.loads(capsys.readouterr().out)
+    assert rendered["event_type"] == "dogfood_friction_finding"
+    assert rendered["extra"]["surface"] == "unitares_mcp"
+
+
+def test_script_post_mode_calls_post_helper(monkeypatch, capsys):
+    module_path = Path(__file__).resolve().parents[3] / "scripts" / "diagnostics" / "dogfood_friction_finding.py"
+    spec = importlib.util.spec_from_file_location("dogfood_friction_finding_cli_post", module_path)
+    assert spec and spec.loader
+    cli = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(cli)
+
+    calls = []
+
+    def fake_post(payload, *, agent_id, agent_name):
+        calls.append({"payload": payload, "agent_id": agent_id, "agent_name": agent_name})
+        return True
+
+    monkeypatch.setattr(cli, "post_dogfood_friction", fake_post)
+
+    rc = cli.main([
+        "--input-json",
+        json.dumps(BASE_FRICTION),
+        "--post",
+        "--agent-id",
+        "ci-dogfood",
+        "--agent-name",
+        "CI Dogfood",
+    ])
+
+    assert rc == 0
+    assert calls == [{"payload": BASE_FRICTION, "agent_id": "ci-dogfood", "agent_name": "CI Dogfood"}]
+    assert json.loads(capsys.readouterr().out) == {"posted": True}

--- a/scripts/diagnostics/dogfood_friction_finding.py
+++ b/scripts/diagnostics/dogfood_friction_finding.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Build or post a canonical dogfood friction finding envelope.
+
+CI jobs and scheduled dogfood probes can use this script to turn a JSON
+observation into the same `/api/findings` event shape used by resident agents.
+The default is dry-run JSON output; pass ``--post`` only when a governance HTTP
+surface is available and the job is meant to emit the finding.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from agents.common.dogfood_friction import (  # noqa: E402
+    DEFAULT_AGENT_ID,
+    DEFAULT_AGENT_NAME,
+    DogfoodFrictionValidationError,
+    build_dogfood_friction_event,
+    post_dogfood_friction,
+)
+
+
+def _load_payload(args: argparse.Namespace) -> dict[str, Any]:
+    """Load the input JSON payload from an arg string, a file, or stdin."""
+    if args.input_json:
+        raw = args.input_json
+    elif args.input_file:
+        raw = Path(args.input_file).read_text()
+    else:
+        raw = sys.stdin.read()
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise DogfoodFrictionValidationError(f"invalid JSON input: {exc}") from exc
+    if not isinstance(data, dict):
+        raise DogfoodFrictionValidationError("dogfood friction input must be a JSON object")
+    return data
+
+
+def _parser() -> argparse.ArgumentParser:
+    """Create the CLI parser."""
+    parser = argparse.ArgumentParser(
+        description="Build or post a UNITARES dogfood friction finding event.",
+    )
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument(
+        "--input-json",
+        help="Dogfood friction JSON object as a string. Defaults to stdin when omitted.",
+    )
+    source.add_argument(
+        "--input-file",
+        help="Path to a dogfood friction JSON object.",
+    )
+    parser.add_argument(
+        "--post",
+        action="store_true",
+        help="Post to /api/findings instead of printing the dry-run event payload.",
+    )
+    parser.add_argument(
+        "--agent-id",
+        default=DEFAULT_AGENT_ID,
+        help="Agent id to attribute to the finding poster.",
+    )
+    parser.add_argument(
+        "--agent-name",
+        default=DEFAULT_AGENT_NAME,
+        help="Agent display name to attribute to the finding poster.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the dogfood friction finding CLI."""
+    parser = _parser()
+    args = parser.parse_args(argv)
+    try:
+        payload = _load_payload(args)
+        if args.post:
+            posted = post_dogfood_friction(
+                payload,
+                agent_id=args.agent_id,
+                agent_name=args.agent_name,
+            )
+            print(json.dumps({"posted": posted}, sort_keys=True))
+            return 0 if posted else 1
+
+        event = build_dogfood_friction_event(
+            payload,
+            agent_id=args.agent_id,
+            agent_name=args.agent_name,
+        )
+        print(json.dumps(event, indent=2, sort_keys=True))
+        return 0
+    except DogfoodFrictionValidationError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `agents.common.dogfood_friction` to normalize fresh dogfood friction observations into `/api/findings` event kwargs
- add `scripts/diagnostics/dogfood_friction_finding.py` for CI/dogfood jobs to dry-run or post canonical findings
- pin routing semantics: reproducible → issue surface, recurring → KG note, ambiguous → dialectic request, critical/block/cooldown/rollback → CI gate

## Validation
- RED: `python3 -m pytest -o addopts= agents/common/tests/test_dogfood_friction.py -q` failed before implementation with missing module/script
- GREEN: `python3 -m pytest -o addopts= agents/common/tests/test_dogfood_friction.py -q` → 8 passed
- Existing common tests: `python3 -m pytest -o addopts= agents/common/tests/test_findings.py agents/common/tests/test_dogfood_friction.py -q` → 24 passed
- Lint: `ruff check agents/common/dogfood_friction.py scripts/diagnostics/dogfood_friction_finding.py agents/common/tests/test_dogfood_friction.py` → All checks passed
- CLI smoke: `python3 scripts/diagnostics/dogfood_friction_finding.py --input-json ...` emitted `dogfood_friction_finding` with routes `[ci_gate, issue_surface, kg_note, dialectic_request]`
- Full gate: `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 ./scripts/dev/test-cache.sh --staged` → 9795 passed, 21 skipped, coverage 80.68%

## Note
A first full gate attempt without overriding PATH failed because subprocesses resolved bare `python3` to the Hermes venv, which lacks pytest-cov. Re-running with `/usr/local/bin` first in PATH passed.



Closes #710
