### PR TITLE
feat: add resident validation tick envelope

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@ How to run this in production. Most readers can skip these.
 - [`database_architecture.md`](operations/database_architecture.md) — single-Postgres / schema-isolation model
 - [`lease-plane-operator-runbook.md`](operations/lease-plane-operator-runbook.md) — Elixir lease-plane operations
 - [`branch-hygiene-runbook.md`](operations/branch-hygiene-runbook.md) — resident branch-hygiene sweep (`agents/vigil_hygiene`)
+- [`resident-validation-cohort.md`](operations/resident-validation-cohort.md) — experimental long-running resident validation tick contract
 - [`DATA_NOTES.md`](operations/DATA_NOTES.md) — operational data dictionary for the production governance database
 - [`DEPLOYMENT_DATA_CAVEAT.md`](operations/DEPLOYMENT_DATA_CAVEAT.md) — what the cited deployment numbers do and don't mean
 

--- a/docs/operations/resident-validation-cohort.md
+++ b/docs/operations/resident-validation-cohort.md
@@ -1,0 +1,74 @@
+# Resident Validation Cohort
+
+**Created:** June 14, 2026
+**Last Updated:** June 14, 2026
+**Status:** Experimental
+
+---
+
+## Purpose
+
+Long-running residents validate UNITARES differently from cron probes. Cron can prove that scheduled checks run; residents can prove whether durable identity, heartbeat, prediction, outcome recording, calibration, and governed recovery improve over time.
+
+This v0 cohort keeps residents low-authority. A resident may observe, emit findings, leave KG sediment, or request dialectic review. It may not deploy, merge, force-push, or roll back production by itself.
+
+## V0 primitive
+
+`scripts/diagnostics/resident_validation_tick.py` emits one deterministic `resident_validation_tick` envelope. A supervisor, launchd job, BEAM process, or Hermes cron can call it repeatedly to form a long-running stream.
+
+The tick includes:
+
+- resident identity and role
+- heartbeat cadence and next due timestamp
+- prospective prediction plus confidence
+- observation text
+- bounded authority metadata
+- stable tick id for dedupe and comparison
+
+The same CLI can emit `process_agent_update` kwargs with `--process-update-kwargs`; this is the handoff shape for UNITARES calibration and trajectory storage.
+
+## Validation roles
+
+Recommended first cohort:
+
+| Role | Purpose | Authority |
+|---|---|---|
+| `dogfood_probe` | Notice fresh friction and schema/runtime drift | observe, emit finding |
+| `steward` | Route findings to issue/KG/dialectic layers | observe, emit finding, leave KG note, request dialectic |
+| `builder` | Attempt small bounded tasks with prospective predictions | observe, emit finding; no merge/deploy |
+| `reviewer` | Evaluate resident outputs and policy ambiguity | observe, request dialectic |
+
+## Boundary
+
+This primitive is not itself a resident supervisor. It is the one-tick measurement contract that a supervisor can call. BEAM/Plexus remains the preferred future lane for true supervision, leases, revocation, and governed effect custody; UNITARES remains the durable truth layer for identity, EISV, KG, dialectic, calibration, and outcomes.
+
+## Smoke command
+
+```bash
+python3 scripts/diagnostics/resident_validation_tick.py \
+  --cohort-id rv-2026-06 \
+  --resident-id resident-dogfood-1 \
+  --resident-name 'Resident Dogfood Canary' \
+  --role dogfood_probe \
+  --cadence-seconds 600 \
+  --tick-index 1 \
+  --observation 'No actionable friction observed.' \
+  --prediction 'Next tick remains bounded and non-mutating.' \
+  --confidence 0.72
+```
+
+For UNITARES write-shape smoke:
+
+```bash
+python3 scripts/diagnostics/resident_validation_tick.py \
+  --process-update-kwargs \
+  --cohort-id rv-2026-06 \
+  --resident-id resident-steward-1 \
+  --resident-name 'Resident Steward Canary' \
+  --role steward \
+  --cadence-seconds 900 \
+  --tick-index 1 \
+  --observation 'Finding queue inspected; no mutation required.' \
+  --prediction 'No dialectic escalation should be needed in the next horizon.' \
+  --confidence 0.68
+```

--- a/scripts/diagnostics/resident_validation_tick.py
+++ b/scripts/diagnostics/resident_validation_tick.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Emit one bounded resident-validation tick envelope.
+
+This CLI is intentionally a one-tick primitive. Supervisors, launchd jobs, BEAM
+processes, or Hermes cron can call it repeatedly to create a long-running
+resident validation stream without giving the resident direct deploy/merge
+authority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.resident_validation import (  # noqa: E402
+    ResidentProfile,
+    build_process_update_kwargs,
+    build_tick_envelope,
+)
+
+
+def _parse_observed_at(value: str | None) -> datetime | None:
+    """Parse an ISO timestamp, accepting a trailing Z for UTC."""
+    if value is None:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _append_state(path: Path, payload: dict) -> None:
+    """Append the sorted JSON envelope to a local JSONL state file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cohort-id", required=True)
+    parser.add_argument("--resident-id", required=True)
+    parser.add_argument("--resident-name", required=True)
+    parser.add_argument(
+        "--role",
+        required=True,
+        choices=("dogfood_probe", "steward", "builder", "reviewer"),
+    )
+    parser.add_argument("--cadence-seconds", required=True, type=int)
+    parser.add_argument(
+        "--observation-scope",
+        default="repo,ci,kg,dialectic",
+        help="Comma-separated observation scopes for this resident.",
+    )
+    parser.add_argument("--tick-index", required=True, type=int)
+    parser.add_argument("--observation", required=True)
+    parser.add_argument("--prediction", required=True)
+    parser.add_argument("--confidence", required=True, type=float)
+    parser.add_argument("--observed-at", default=None)
+    parser.add_argument("--state-path", type=Path, default=None)
+    parser.add_argument(
+        "--process-update-kwargs",
+        action="store_true",
+        help="Output process_agent_update kwargs instead of the raw tick envelope.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the CLI."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    scope = tuple(
+        part.strip() for part in args.observation_scope.split(",") if part.strip()
+    )
+    profile = ResidentProfile(
+        cohort_id=args.cohort_id,
+        resident_id=args.resident_id,
+        resident_name=args.resident_name,
+        role=args.role,
+        cadence_seconds=args.cadence_seconds,
+        observation_scope=scope,
+    )
+    envelope = build_tick_envelope(
+        profile,
+        tick_index=args.tick_index,
+        observation=args.observation,
+        prediction=args.prediction,
+        confidence=args.confidence,
+        now=_parse_observed_at(args.observed_at),
+    )
+    payload = build_process_update_kwargs(envelope) if args.process_update_kwargs else envelope
+    if args.state_path:
+        _append_state(args.state_path, payload)
+    print(json.dumps(payload, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/resident_validation.py
+++ b/src/resident_validation.py
@@ -1,0 +1,163 @@
+"""Resident validation cohort envelopes for long-running UNITARES probes.
+
+The v0 cohort is deliberately narrow: residents can observe, emit findings,
+leave KG sediment, or request dialectic review, but they cannot deploy, merge,
+or force-push. This module creates deterministic tick envelopes that can be
+written locally, sent through process_agent_update, or consumed by a future
+supervisor without giving the resident direct actuator authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+VALID_ROLES = frozenset({"dogfood_probe", "steward", "builder", "reviewer"})
+DEFAULT_ALLOWED_EFFECTS = ("emit_finding", "leave_kg_note", "request_dialectic")
+FORBIDDEN_EFFECTS = frozenset({"deploy", "merge", "force_push", "rollback"})
+
+
+@dataclass(frozen=True)
+class ResidentProfile:
+    """Static identity and authority boundary for one validation resident."""
+
+    cohort_id: str
+    resident_id: str
+    resident_name: str
+    role: str
+    cadence_seconds: int
+    observation_scope: tuple[str, ...]
+    allowed_effects: tuple[str, ...] = field(default=DEFAULT_ALLOWED_EFFECTS)
+    deploy_authority: bool = False
+
+    def __post_init__(self) -> None:
+        """Validate v0 resident bounds before any envelope is emitted."""
+        if not self.cohort_id.strip():
+            raise ValueError("cohort_id is required")
+        if not self.resident_id.strip():
+            raise ValueError("resident_id is required")
+        if not self.resident_name.strip():
+            raise ValueError("resident_name is required")
+        if self.role not in VALID_ROLES:
+            raise ValueError(f"role must be one of {sorted(VALID_ROLES)}")
+        if self.cadence_seconds <= 0:
+            raise ValueError("cadence_seconds must be positive")
+        if not self.observation_scope:
+            raise ValueError("observation_scope must not be empty")
+        forbidden = sorted(set(self.allowed_effects) & FORBIDDEN_EFFECTS)
+        if self.deploy_authority or forbidden:
+            detail = ", ".join(forbidden) if forbidden else "deploy_authority=True"
+            raise ValueError(f"v0 validation residents have no deploy authority: {detail}")
+
+
+def stable_tick_id(cohort_id: str, resident_id: str, tick_index: int) -> str:
+    """Return a stable 16-hex tick id for cohort/resident/index identity."""
+    if tick_index < 0:
+        raise ValueError("tick_index must be non-negative")
+    raw = f"{cohort_id}|{resident_id}|{tick_index}"
+    return "rv_" + hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def _ensure_utc(dt: datetime) -> datetime:
+    """Return a timezone-aware UTC datetime without changing absolute time."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def build_tick_envelope(
+    profile: ResidentProfile,
+    *,
+    tick_index: int,
+    observation: str,
+    prediction: str,
+    confidence: float,
+    now: datetime | None = None,
+    horizon_seconds: int | None = None,
+    decision_action: str = "observe",
+    outcome: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build one resident-validation tick envelope.
+
+    The envelope is a measurement artifact: it names the resident, heartbeat,
+    prediction, bounded authority, and optional outcome, but it does not perform
+    downstream KG/dialectic/CI/GitHub actions by itself.
+    """
+    if not observation.strip():
+        raise ValueError("observation is required")
+    if not prediction.strip():
+        raise ValueError("prediction is required")
+    if not 0 <= confidence <= 1:
+        raise ValueError("confidence must be between 0 and 1")
+
+    observed_at = _ensure_utc(now or datetime.now(timezone.utc))
+    horizon = horizon_seconds or profile.cadence_seconds
+    next_due = observed_at + timedelta(seconds=profile.cadence_seconds)
+    envelope: dict[str, Any] = {
+        "event_type": "resident_validation_tick",
+        "cohort_id": profile.cohort_id,
+        "tick_id": stable_tick_id(profile.cohort_id, profile.resident_id, tick_index),
+        "tick_index": tick_index,
+        "resident": {
+            "id": profile.resident_id,
+            "name": profile.resident_name,
+            "role": profile.role,
+            "observation_scope": list(profile.observation_scope),
+        },
+        "heartbeat": {
+            "cadence_seconds": profile.cadence_seconds,
+            "observed_at": observed_at.isoformat(),
+            "next_due_at": next_due.isoformat(),
+        },
+        "prediction": {
+            "claim": prediction,
+            "confidence": float(confidence),
+            "horizon_seconds": horizon,
+            "decision_action": decision_action,
+        },
+        "observation": observation,
+        "authority": {
+            "allowed_effects": list(profile.allowed_effects),
+            "deploy_authority": profile.deploy_authority,
+            "forbidden_effects": sorted(FORBIDDEN_EFFECTS),
+        },
+    }
+    if outcome is not None:
+        envelope["outcome"] = outcome
+    return envelope
+
+
+def build_process_update_kwargs(envelope: dict[str, Any]) -> dict[str, Any]:
+    """Build process_agent_update kwargs for a resident-validation tick."""
+    resident = envelope["resident"]
+    prediction = envelope["prediction"]
+    tick_index = envelope["tick_index"]
+    summary = (
+        f"{resident['name']} tick {tick_index} observed without governed mutation"
+    )
+    return {
+        "response_text": (
+            f"Resident validation tick {envelope['tick_id']}: "
+            f"{envelope['observation']} Prediction: {prediction['claim']}"
+        ),
+        "task_type": "exploration",
+        "complexity": 0.2,
+        "confidence": prediction["confidence"],
+        "epistemic_class": "prediction",
+        "provenance_context": {
+            "harness_type": "resident_validation_cohort",
+            "cohort_id": envelope["cohort_id"],
+            "resident_role": resident["role"],
+            "tick_id": envelope["tick_id"],
+            "governance_mode": "bounded_observation",
+        },
+        "recent_tool_results": [
+            {
+                "kind": "tool_call",
+                "tool": "resident_validation_tick",
+                "summary": summary,
+            }
+        ],
+    }

--- a/tests/test_resident_validation_cohort.py
+++ b/tests/test_resident_validation_cohort.py
@@ -1,0 +1,162 @@
+"""Resident validation cohort protocol tests."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.resident_validation import (
+    ResidentProfile,
+    build_process_update_kwargs,
+    build_tick_envelope,
+    stable_tick_id,
+)
+
+
+NOW = datetime(2026, 6, 14, 19, 45, tzinfo=timezone.utc)
+
+
+def test_resident_profile_rejects_direct_deploy_authority() -> None:
+    """V0 validation residents are probes, not deploy actors."""
+    with pytest.raises(ValueError, match="deploy authority"):
+        ResidentProfile(
+            cohort_id="rv-2026-06",
+            resident_id="resident-builder-1",
+            resident_name="Resident Builder Canary",
+            role="builder",
+            cadence_seconds=300,
+            observation_scope=("repo", "ci"),
+            allowed_effects=("emit_finding", "deploy"),
+        )
+
+
+def test_tick_envelope_carries_prediction_heartbeat_and_authority_boundary() -> None:
+    profile = ResidentProfile(
+        cohort_id="rv-2026-06",
+        resident_id="resident-dogfood-1",
+        resident_name="Resident Dogfood Canary",
+        role="dogfood_probe",
+        cadence_seconds=600,
+        observation_scope=("hermes_cron", "unitares_mcp"),
+    )
+
+    envelope = build_tick_envelope(
+        profile,
+        tick_index=3,
+        observation="No actionable friction observed in this tick.",
+        prediction="Next tick should also complete without mutation.",
+        confidence=0.74,
+        now=NOW,
+    )
+
+    assert envelope["event_type"] == "resident_validation_tick"
+    assert envelope["cohort_id"] == "rv-2026-06"
+    assert envelope["resident"]["role"] == "dogfood_probe"
+    assert envelope["heartbeat"] == {
+        "cadence_seconds": 600,
+        "observed_at": "2026-06-14T19:45:00+00:00",
+        "next_due_at": "2026-06-14T19:55:00+00:00",
+    }
+    assert envelope["prediction"] == {
+        "claim": "Next tick should also complete without mutation.",
+        "confidence": 0.74,
+        "horizon_seconds": 600,
+        "decision_action": "observe",
+    }
+    assert envelope["authority"]["deploy_authority"] is False
+    assert "merge" not in envelope["authority"]["allowed_effects"]
+    assert "emit_finding" in envelope["authority"]["allowed_effects"]
+
+
+def test_stable_tick_id_depends_on_resident_and_tick_not_wallclock() -> None:
+    first = stable_tick_id("rv-2026-06", "resident-dogfood-1", 7)
+    second = stable_tick_id("rv-2026-06", "resident-dogfood-1", 7)
+    different_tick = stable_tick_id("rv-2026-06", "resident-dogfood-1", 8)
+
+    assert first == second
+    assert first != different_tick
+    assert first.startswith("rv_")
+    assert len(first) == len("rv_") + 16
+
+
+def test_process_update_kwargs_preserve_prediction_and_bounded_authority() -> None:
+    profile = ResidentProfile(
+        cohort_id="rv-2026-06",
+        resident_id="resident-steward-1",
+        resident_name="Resident Steward Canary",
+        role="steward",
+        cadence_seconds=900,
+        observation_scope=("findings", "kg", "dialectic"),
+    )
+    envelope = build_tick_envelope(
+        profile,
+        tick_index=1,
+        observation="Finding queue inspected; no mutation required.",
+        prediction="No dialectic escalation should be needed in the next horizon.",
+        confidence=0.68,
+        now=NOW,
+    )
+
+    kwargs = build_process_update_kwargs(envelope)
+
+    assert kwargs["epistemic_class"] == "prediction"
+    assert kwargs["task_type"] == "exploration"
+    assert kwargs["confidence"] == 0.68
+    assert kwargs["provenance_context"]["harness_type"] == "resident_validation_cohort"
+    assert kwargs["provenance_context"]["cohort_id"] == "rv-2026-06"
+    assert kwargs["recent_tool_results"] == [
+        {
+            "kind": "tool_call",
+            "tool": "resident_validation_tick",
+            "summary": "Resident Steward Canary tick 1 observed without governed mutation",
+        }
+    ]
+
+
+def test_cli_emits_json_and_appends_state(tmp_path: Path) -> None:
+    state_path = tmp_path / "resident_ticks.jsonl"
+    script = Path("scripts/diagnostics/resident_validation_tick.py")
+
+    completed = subprocess.run(
+        [
+            "python3",
+            str(script),
+            "--cohort-id",
+            "rv-2026-06",
+            "--resident-id",
+            "resident-dogfood-1",
+            "--resident-name",
+            "Resident Dogfood Canary",
+            "--role",
+            "dogfood_probe",
+            "--cadence-seconds",
+            "600",
+            "--tick-index",
+            "2",
+            "--observation",
+            "No actionable friction observed.",
+            "--prediction",
+            "Next tick remains bounded.",
+            "--confidence",
+            "0.72",
+            "--observed-at",
+            "2026-06-14T19:45:00+00:00",
+            "--state-path",
+            str(state_path),
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout)
+    assert payload["event_type"] == "resident_validation_tick"
+    assert payload["resident"]["name"] == "Resident Dogfood Canary"
+    assert state_path.read_text(encoding="utf-8").strip() == json.dumps(payload, sort_keys=True)


### PR DESCRIPTION
## Summary
- add a v0 resident-validation tick envelope for long-running UNITARES validation cohorts
- add a CLI that emits deterministic resident heartbeat/prediction/authority envelopes or `process_agent_update` kwargs
- document the experimental resident cohort boundary: observe/emit finding/KG/dialectic only; no deploy/merge/force-push authority

## Boundary
This is the one-tick measurement contract, not a resident supervisor. BEAM/Plexus remains the natural next layer for actual long-running supervision, leases, revocation, and governed-effect custody.

## Validation
- RED: `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 -m pytest -o addopts= tests/test_resident_validation_cohort.py -q` failed before implementation with `ModuleNotFoundError: No module named 'src.resident_validation'`
- GREEN: targeted resident validation tests → `5 passed`
- Ruff: `ruff check src/resident_validation.py scripts/diagnostics/resident_validation_tick.py tests/test_resident_validation_cohort.py` → `All checks passed!`
- CLI smoke emitted raw `resident_validation_tick` JSON and `--process-update-kwargs` JSON
- Doc health: `python3 scripts/diagnostics/check_doc_health.py --changed-only docs/operations/resident-validation-cohort.md docs/README.md` → `Doc health: all clear`
- Full staged gate: `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 ./scripts/dev/test-cache.sh --staged` → `9824 passed, 21 skipped`, coverage `80.71%`
- Post-rebase targeted check: `5 passed`
