### PR TITLE
feat: add resident validation canary runner

### DIFF
--- a/scripts/diagnostics/resident_validation_canary.py
+++ b/scripts/diagnostics/resident_validation_canary.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Run one bounded resident-validation canary tick batch.
+
+The canary is intentionally stateful but non-actuating: it appends raw
+``resident_validation_tick`` envelopes to JSONL and prints a compact JSON
+summary. A future launchd/BEAM supervisor can call this repeatedly for
+long-running validation without giving the canary merge/deploy authority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.resident_validation import ResidentProfile  # noqa: E402
+from src.resident_validation_runner import build_canary_ticks  # noqa: E402
+
+
+def _parse_observed_at(value: str | None) -> datetime | None:
+    """Parse an ISO timestamp, accepting a trailing Z for UTC."""
+    if value is None:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the canary CLI parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cohort-id", required=True)
+    parser.add_argument("--resident-id", required=True)
+    parser.add_argument("--resident-name", required=True)
+    parser.add_argument(
+        "--role",
+        required=True,
+        choices=("dogfood_probe", "steward", "builder", "reviewer"),
+    )
+    parser.add_argument("--cadence-seconds", required=True, type=int)
+    parser.add_argument(
+        "--observation-scope",
+        default="repo,ci,kg,dialectic",
+        help="Comma-separated observation scopes for this resident.",
+    )
+    parser.add_argument("--observation", required=True)
+    parser.add_argument("--prediction", required=True)
+    parser.add_argument("--confidence", required=True, type=float)
+    parser.add_argument("--observed-at", default=None)
+    parser.add_argument("--count", type=int, default=1)
+    parser.add_argument(
+        "--state-path",
+        type=Path,
+        default=Path("data/resident_validation/canary.jsonl"),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the canary tick batch."""
+    args = build_parser().parse_args(argv)
+    scope = tuple(
+        part.strip() for part in args.observation_scope.split(",") if part.strip()
+    )
+    profile = ResidentProfile(
+        cohort_id=args.cohort_id,
+        resident_id=args.resident_id,
+        resident_name=args.resident_name,
+        role=args.role,
+        cadence_seconds=args.cadence_seconds,
+        observation_scope=scope,
+    )
+    ticks = build_canary_ticks(
+        profile,
+        state_path=args.state_path,
+        count=args.count,
+        observation=args.observation,
+        prediction=args.prediction,
+        confidence=args.confidence,
+        now=_parse_observed_at(args.observed_at),
+    )
+    print(
+        json.dumps(
+            {
+                "event_type": "resident_validation_canary_batch",
+                "cohort_id": args.cohort_id,
+                "resident_id": args.resident_id,
+                "state_path": str(args.state_path),
+                "ticks": ticks,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/diagnostics/resident_validation_canary.py
+++ b/scripts/diagnostics/resident_validation_canary.py
@@ -82,14 +82,15 @@ def main(argv: list[str] | None = None) -> int:
         confidence=args.confidence,
         now=_parse_observed_at(args.observed_at),
     )
+    first_tick_index = ticks[0]["tick_index"]
+    last_tick_index = ticks[-1]["tick_index"]
     print(
         json.dumps(
             {
                 "event_type": "resident_validation_canary_batch",
-                "cohort_id": args.cohort_id,
-                "resident_id": args.resident_id,
-                "state_path": str(args.state_path),
-                "ticks": ticks,
+                "first_tick_index": first_tick_index,
+                "last_tick_index": last_tick_index,
+                "tick_count": len(ticks),
             },
             sort_keys=True,
         )

--- a/scripts/diagnostics/resident_validation_canary.py
+++ b/scripts/diagnostics/resident_validation_canary.py
@@ -73,7 +73,7 @@ def main(argv: list[str] | None = None) -> int:
         cadence_seconds=args.cadence_seconds,
         observation_scope=scope,
     )
-    ticks = build_canary_ticks(
+    build_canary_ticks(
         profile,
         state_path=args.state_path,
         count=args.count,
@@ -82,15 +82,11 @@ def main(argv: list[str] | None = None) -> int:
         confidence=args.confidence,
         now=_parse_observed_at(args.observed_at),
     )
-    first_tick_index = ticks[0]["tick_index"]
-    last_tick_index = ticks[-1]["tick_index"]
     print(
         json.dumps(
             {
                 "event_type": "resident_validation_canary_batch",
-                "first_tick_index": first_tick_index,
-                "last_tick_index": last_tick_index,
-                "tick_count": len(ticks),
+                "status": "state_appended",
             },
             sort_keys=True,
         )

--- a/src/resident_validation_runner.py
+++ b/src/resident_validation_runner.py
@@ -1,0 +1,90 @@
+"""Stateful canary runner for resident validation ticks.
+
+This module sits one layer above ``resident_validation``. It turns a one-tick
+measurement contract into a repeatable canary stream by reading a JSONL state
+file, choosing the next tick index for a resident, building bounded envelopes,
+and appending them back to state.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from src.resident_validation import ResidentProfile, build_tick_envelope
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Read JSONL rows from ``path``, skipping blank lines."""
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        rows.append(json.loads(stripped))
+    return rows
+
+
+def next_tick_index(state_path: Path, cohort_id: str, resident_id: str) -> int:
+    """Return the next 1-based tick index for a cohort/resident state stream."""
+    latest = 0
+    for row in _read_jsonl(state_path):
+        if row.get("cohort_id") != cohort_id:
+            continue
+        resident = row.get("resident") or {}
+        if resident.get("id") != resident_id:
+            continue
+        tick_index = int(row.get("tick_index") or 0)
+        latest = max(latest, tick_index)
+    return latest + 1
+
+
+def append_ticks(state_path: Path, ticks: list[dict[str, Any]]) -> None:
+    """Append raw tick envelopes to the JSONL state stream."""
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    with state_path.open("a", encoding="utf-8") as handle:
+        for tick in ticks:
+            handle.write(json.dumps(tick, sort_keys=True) + "\n")
+
+
+def _ensure_utc(dt: datetime | None) -> datetime:
+    """Normalize optional datetimes to timezone-aware UTC."""
+    if dt is None:
+        return datetime.now(timezone.utc)
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def build_canary_ticks(
+    profile: ResidentProfile,
+    *,
+    state_path: Path,
+    count: int,
+    observation: str,
+    prediction: str,
+    confidence: float,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Build and persist ``count`` sequential canary ticks for ``profile``."""
+    if count <= 0:
+        raise ValueError("count must be positive")
+    observed_at = _ensure_utc(now)
+    start = next_tick_index(state_path, profile.cohort_id, profile.resident_id)
+    ticks = [
+        build_tick_envelope(
+            profile,
+            tick_index=start + offset,
+            observation=observation,
+            prediction=prediction,
+            confidence=confidence,
+            now=observed_at,
+        )
+        for offset in range(count)
+    ]
+    append_ticks(state_path, ticks)
+    return ticks

--- a/tests/test_resident_validation_runner.py
+++ b/tests/test_resident_validation_runner.py
@@ -84,9 +84,11 @@ def test_build_canary_ticks_appends_sequential_bounded_envelopes(tmp_path: Path)
     assert [tick["tick_id"] for tick in saved] == [tick["tick_id"] for tick in ticks]
 
 
-def test_cli_can_emit_two_canary_ticks_without_process_update(tmp_path: Path) -> None:
+def test_cli_summary_avoids_echoing_private_tick_content(tmp_path: Path) -> None:
     state_path = tmp_path / "resident-canary.jsonl"
     script = Path("scripts/diagnostics/resident_validation_canary.py")
+    private_observation = "Private observation: token-like material stays in state only."
+    private_prediction = "Private prediction: resident may mention sensitive local context."
 
     completed = subprocess.run(
         [
@@ -103,9 +105,9 @@ def test_cli_can_emit_two_canary_ticks_without_process_update(tmp_path: Path) ->
             "--cadence-seconds",
             "600",
             "--observation",
-            "No actionable friction observed.",
+            private_observation,
             "--prediction",
-            "Next tick remains bounded.",
+            private_prediction,
             "--confidence",
             "0.72",
             "--observed-at",
@@ -124,7 +126,14 @@ def test_cli_can_emit_two_canary_ticks_without_process_update(tmp_path: Path) ->
 
     assert completed.returncode == 0, completed.stderr
     payload = json.loads(completed.stdout)
-    assert [tick["tick_index"] for tick in payload["ticks"]] == [1, 2]
-    assert payload["resident_id"] == "resident-dogfood-1"
-    assert payload["state_path"] == str(state_path)
+    assert payload == {
+        "event_type": "resident_validation_canary_batch",
+        "first_tick_index": 1,
+        "last_tick_index": 2,
+        "tick_count": 2,
+    }
+    assert private_observation not in completed.stdout
+    assert private_prediction not in completed.stdout
+    assert "resident-dogfood-1" not in completed.stdout
+    assert str(state_path) not in completed.stdout
     assert len(state_path.read_text(encoding="utf-8").splitlines()) == 2

--- a/tests/test_resident_validation_runner.py
+++ b/tests/test_resident_validation_runner.py
@@ -128,9 +128,7 @@ def test_cli_summary_avoids_echoing_private_tick_content(tmp_path: Path) -> None
     payload = json.loads(completed.stdout)
     assert payload == {
         "event_type": "resident_validation_canary_batch",
-        "first_tick_index": 1,
-        "last_tick_index": 2,
-        "tick_count": 2,
+        "status": "state_appended",
     }
     assert private_observation not in completed.stdout
     assert private_prediction not in completed.stdout

--- a/tests/test_resident_validation_runner.py
+++ b/tests/test_resident_validation_runner.py
@@ -1,0 +1,130 @@
+"""Resident validation canary runner tests."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+from src.resident_validation import ResidentProfile
+from src.resident_validation_runner import build_canary_ticks, next_tick_index
+
+
+NOW = datetime(2026, 6, 14, 20, 5, tzinfo=timezone.utc)
+
+
+def test_next_tick_index_tracks_matching_cohort_and_resident_only(tmp_path: Path) -> None:
+    state_path = tmp_path / "ticks.jsonl"
+    state_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "cohort_id": "rv-2026-06",
+                        "tick_index": 1,
+                        "resident": {"id": "resident-dogfood-1"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "cohort_id": "other-cohort",
+                        "tick_index": 99,
+                        "resident": {"id": "resident-dogfood-1"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "cohort_id": "rv-2026-06",
+                        "tick_index": 4,
+                        "resident": {"id": "other-resident"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "cohort_id": "rv-2026-06",
+                        "tick_index": 2,
+                        "resident": {"id": "resident-dogfood-1"},
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert next_tick_index(state_path, "rv-2026-06", "resident-dogfood-1") == 3
+
+
+def test_build_canary_ticks_appends_sequential_bounded_envelopes(tmp_path: Path) -> None:
+    state_path = tmp_path / "ticks.jsonl"
+    profile = ResidentProfile(
+        cohort_id="rv-2026-06",
+        resident_id="resident-dogfood-1",
+        resident_name="Resident Dogfood Canary",
+        role="dogfood_probe",
+        cadence_seconds=600,
+        observation_scope=("repo", "ci"),
+    )
+
+    ticks = build_canary_ticks(
+        profile,
+        state_path=state_path,
+        count=2,
+        observation="No actionable friction observed.",
+        prediction="Next tick remains bounded.",
+        confidence=0.72,
+        now=NOW,
+    )
+
+    assert [tick["tick_index"] for tick in ticks] == [1, 2]
+    assert all(tick["authority"]["deploy_authority"] is False for tick in ticks)
+    assert state_path.exists()
+    saved = [json.loads(line) for line in state_path.read_text(encoding="utf-8").splitlines()]
+    assert [tick["tick_id"] for tick in saved] == [tick["tick_id"] for tick in ticks]
+
+
+def test_cli_can_emit_two_canary_ticks_without_process_update(tmp_path: Path) -> None:
+    state_path = tmp_path / "resident-canary.jsonl"
+    script = Path("scripts/diagnostics/resident_validation_canary.py")
+
+    completed = subprocess.run(
+        [
+            "python3",
+            str(script),
+            "--cohort-id",
+            "rv-2026-06",
+            "--resident-id",
+            "resident-dogfood-1",
+            "--resident-name",
+            "Resident Dogfood Canary",
+            "--role",
+            "dogfood_probe",
+            "--cadence-seconds",
+            "600",
+            "--observation",
+            "No actionable friction observed.",
+            "--prediction",
+            "Next tick remains bounded.",
+            "--confidence",
+            "0.72",
+            "--observed-at",
+            "2026-06-14T20:05:00+00:00",
+            "--state-path",
+            str(state_path),
+            "--count",
+            "2",
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout)
+    assert [tick["tick_index"] for tick in payload["ticks"]] == [1, 2]
+    assert payload["resident_id"] == "resident-dogfood-1"
+    assert payload["state_path"] == str(state_path)
+    assert len(state_path.read_text(encoding="utf-8").splitlines()) == 2


### PR DESCRIPTION
## Summary
- add a stateful resident-validation canary runner on top of the merged tick envelope
- track next tick index per cohort/resident from a JSONL state stream
- add a CLI that appends bounded canary ticks and prints only a non-sensitive success acknowledgement

## Boundary
This is still non-actuating: the canary writes local JSONL tick envelopes only. It does not deploy, merge, roll back, or call UNITARES write APIs by itself. The next clean layer is a supervised scheduler/launchd/BEAM process that invokes this CLI and separately submits tick summaries to UNITARES.

The CLI intentionally does not echo resident IDs, state paths, observations, predictions, or raw ticks to stdout; those may contain private local/resident context. Detailed tick data stays in the configured JSONL state file.

## Validation
- RED: `tests/test_resident_validation_runner.py` failed before implementation with `ModuleNotFoundError: No module named 'src.resident_validation_runner'`
- RED: CodeQL flagged clear-text logging of sensitive resident canary data; regression now asserts CLI stdout does not echo private observation/prediction/resident/path inputs
- Targeted runner tests: `3 passed`
- Ruff: `ruff check src/resident_validation_runner.py scripts/diagnostics/resident_validation_canary.py tests/test_resident_validation_runner.py` → `All checks passed!`
- Full staged gate after CodeQL fix: `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 ./scripts/dev/test-cache.sh --staged` → `9835 passed, 21 skipped`, coverage `80.69%`
