### PR TITLE
fix(metrics): source lite-mode threshold hints from canonical constants

### DIFF
--- a/src/services/runtime_queries.py
+++ b/src/services/runtime_queries.py
@@ -472,11 +472,16 @@ async def get_governance_metrics_data(agent_id: str, arguments: Dict[str, Any], 
                 "note": "get_governance_metrics is read-only; it does not initialize state.",
             }
             lite_metrics["related_tools"] = ["process_agent_update", "onboard", "identity"]
+        # Agent-facing reference points — sourced from the canonical decision
+        # constants so they never disagree with what governance actually does.
+        # Previously hardcoded 0.5/0.75, which did NOT match the real lines
+        # (RISK_APPROVE=0.45 = low/medium edge; RISK_REVISE=0.70 = the pause
+        # line, not 0.75). An agent reading these as its thresholds was misled.
         lite_metrics["thresholds"] = {
             "coherence_critical": GovernanceConfig.COHERENCE_CRITICAL_THRESHOLD,
-            "coherence_good": 0.50,
-            "risk_medium": 0.5,
-            "risk_high": 0.75,
+            "coherence_good": GovernanceConfig.TARGET_COHERENCE,
+            "risk_medium": GovernanceConfig.RISK_APPROVE_THRESHOLD,
+            "risk_high": GovernanceConfig.RISK_REVISE_THRESHOLD,
             "target_coherence": GovernanceConfig.TARGET_COHERENCE,
         }
         lite_metrics["_note"] = "Use lite=false for full diagnostics"

--- a/tests/test_core_metrics.py
+++ b/tests/test_core_metrics.py
@@ -422,6 +422,40 @@ class TestGetGovernanceMetrics:
             assert data["purpose"] == "test purpose"
 
     @pytest.mark.asyncio
+    async def test_lite_thresholds_sourced_from_canonical_constants(
+        self, mock_server, mock_monitor
+    ):
+        """Agent-facing 'thresholds' hints must match the real decision lines.
+
+        These were hardcoded 0.5/0.75, which disagreed with the actual
+        governance thresholds (RISK_APPROVE=0.45 low/medium edge, RISK_REVISE
+        =0.70 pause line) — misleading any agent that read them. Guard that
+        they are sourced from the constants, not a hardcoded copy.
+        """
+        from config.governance_config import GovernanceConfig
+
+        meta = _make_metadata(purpose="t")
+        mock_server.agent_metadata = {"agent-1": meta}
+        mock_server.get_or_create_monitor.return_value = mock_monitor
+
+        with patch("src.mcp_handlers.core.mcp_server", mock_server), \
+             patch("src.mcp_handlers.core.require_agent_id", return_value=("agent-1", None)), \
+             patch("src.governance_monitor.UNITARESMonitor") as MockClass:
+            MockClass.get_eisv_labels.return_value = {
+                "E": "Energy", "I": "Information", "S": "Entropy", "V": "Void"
+            }
+            from src.mcp_handlers.core import handle_get_governance_metrics
+            result = await handle_get_governance_metrics({})
+
+            t = _parse(result)["thresholds"]
+            assert t["risk_medium"] == GovernanceConfig.RISK_APPROVE_THRESHOLD
+            assert t["risk_high"] == GovernanceConfig.RISK_REVISE_THRESHOLD
+            assert t["coherence_good"] == GovernanceConfig.TARGET_COHERENCE
+            assert t["coherence_critical"] == GovernanceConfig.COHERENCE_CRITICAL_THRESHOLD
+            # The pause line must be the real one, not the old 0.75 literal.
+            assert t["risk_high"] != 0.75
+
+    @pytest.mark.asyncio
     async def test_full_mode(self, mock_server, mock_monitor):
         """Full mode returns interpretation and reflection."""
         meta = _make_metadata(purpose=None)


### PR DESCRIPTION
## What

The agent-facing `thresholds` block returned by `get_governance_metrics` (lite/minimal mode) hardcoded values that **did not match the real governance decision lines**:

| field | was (hardcoded) | real constant | value |
|-------|-----------------|---------------|-------|
| `risk_medium` | 0.5 | `RISK_APPROVE_THRESHOLD` | **0.45** |
| `risk_high` | 0.75 | `RISK_REVISE_THRESHOLD` (the pause line) | **0.70** |
| `coherence_good` | 0.50 | `TARGET_COHERENCE` | 0.50 (now sourced) |

An agent reading `risk_high` as its pause threshold would think it had headroom to 0.75 when governance actually pauses at 0.70. Nothing consumed these fields (confirmed: no dashboard JS or test referenced them), so the divergence went unnoticed.

## Change
- `src/services/runtime_queries.py`: wire all three to `GovernanceConfig` constants so they can't drift from the engine.
- Drift-guard test in `tests/test_core_metrics.py` asserting the exposed hints equal the canonical constants (and that `risk_high` is no longer the old 0.75 literal).

## Why
Same class as the just-merged #704 (phase basin bands): a hardcoded copy of an ontology constant silently diverging from its source of truth. Found while auditing the dashboard for 'broken or confusing' surfaces. Pure correctness — values change 0.5→0.45 and 0.75→0.70 to match reality; zero consumers, zero blast radius.

## Tests
`tests/test_core_metrics.py` lite suite green (5 passed).