### PR TITLE
fix: hold strong ref to fire-and-forget baseline-save task

### DIFF
--- a/src/agent_behavioral_baseline.py
+++ b/src/agent_behavioral_baseline.py
@@ -125,6 +125,11 @@ class AgentBehavioralBaseline:
 
 _baselines: Dict[str, AgentBehavioralBaseline] = {}
 
+# Strong refs to in-flight save tasks. The event loop only keeps weak refs to
+# tasks, so a fire-and-forget create_task() can be GC'd mid-await before the DB
+# write completes. Holding the ref until done (then discarding) closes that race.
+_save_tasks: set = set()
+
 
 def get_agent_behavioral_baseline(agent_id: str) -> AgentBehavioralBaseline:
     """Get or create the behavioral baseline for an agent.
@@ -182,7 +187,9 @@ def schedule_baseline_save(agent_id: str) -> None:
 
     try:
         loop = asyncio.get_running_loop()
-        loop.create_task(_do_save())
+        task = loop.create_task(_do_save())
+        _save_tasks.add(task)
+        task.add_done_callback(_save_tasks.discard)
     except RuntimeError:
         pass  # No event loop — skip persistence (e.g. tests, CLI)
 

--- a/tests/test_agent_behavioral_baseline.py
+++ b/tests/test_agent_behavioral_baseline.py
@@ -3,12 +3,16 @@
 import math
 import pytest
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 from src.agent_behavioral_baseline import (
     WelfordStats,
     AgentBehavioralBaseline,
     get_agent_behavioral_baseline,
     compute_anomaly_entropy,
+    schedule_baseline_save,
     _baselines,
+    _save_tasks,
 )
 
 
@@ -216,3 +220,40 @@ class TestGlobalRegistry:
         assert b1 is not b2
         b1.update("coherence", 0.9)
         assert b2._stats["coherence"].count == 0
+
+
+# ══════════════════════════════════════════════════
+#  schedule_baseline_save — fire-and-forget GC safety
+# ══════════════════════════════════════════════════
+
+class TestScheduleBaselineSave:
+    def setup_method(self):
+        _baselines.clear()
+        _save_tasks.clear()
+
+    def test_no_baseline_is_noop(self):
+        # No baseline registered → nothing scheduled, no error.
+        schedule_baseline_save("unknown-agent")
+        assert len(_save_tasks) == 0
+
+    def test_no_event_loop_is_noop(self):
+        # Called from sync context (no running loop) → skip silently.
+        get_agent_behavioral_baseline("agent-1")
+        schedule_baseline_save("agent-1")  # not inside a loop
+        assert len(_save_tasks) == 0
+
+    @pytest.mark.asyncio
+    async def test_task_ref_held_until_done(self):
+        get_agent_behavioral_baseline("agent-1")
+        mock_db = MagicMock()
+        mock_db.save_behavioral_baseline = AsyncMock()
+        with patch("src.db.get_db", return_value=mock_db):
+            schedule_baseline_save("agent-1")
+            # Strong ref is held while the save is in flight (guards against the
+            # event loop's weak-ref GC dropping the task mid-await).
+            assert len(_save_tasks) == 1
+            task = next(iter(_save_tasks))
+            await task
+            # Done-callback discards the ref so the set does not leak.
+            assert len(_save_tasks) == 0
+        mock_db.save_behavioral_baseline.assert_awaited_once()


### PR DESCRIPTION
## What

`schedule_baseline_save` called `loop.create_task(_do_save())` and dropped the return value. The asyncio event loop keeps only a **weak** reference to tasks, so a fire-and-forget save can be garbage-collected mid-`await` — before `db.save_behavioral_baseline(...)` completes.

Impact is low (best-effort persistence; a lost save self-heals on the next write, and exceptions are already swallowed to debug) but it's a real correctness gap and a trivial fix.

## Fix

- Module-level `_save_tasks: set` holds a strong ref while the save is in flight.
- `task.add_done_callback(_save_tasks.discard)` drops the ref on completion so the set doesn't leak.

## Tests

3 new cases in `tests/test_agent_behavioral_baseline.py` (26/26 pass):
- ref held in-flight → discarded on done (DB save mocked)
- no running loop → no-op (sync/CLI path)
- no baseline registered → no-op

## Provenance

Resolves Watcher **P001 #e7a51518**. Branches off current `master` (the original commit rode on `claude/monitor-resident-risk-calibration`, already squash-merged as #686/`da8720a4`).