### PR TITLE
fix(lifecycle): don't archive live agents as lineage_succession

### DIFF
--- a/src/mcp_handlers/lifecycle/operations.py
+++ b/src/mcp_handlers/lifecycle/operations.py
@@ -592,6 +592,15 @@ async def handle_archive_old_test_agents(arguments: Dict[str, Any]) -> Sequence[
             archived_agents.append({"id": agent_id, "reason": "low_updates", "updates": meta.total_updates})
             continue
 
+        # Initializing agents (never checked in) are ghosts, not orphans —
+        # mirrors classify_for_archival's protection so a fresh, still-working
+        # session isn't age-archived out from under itself when an operator runs
+        # this sweep with a short max_age_hours. Test/ping cruft is already
+        # handled by the immediate-archive block above; manual archive_agent
+        # still works for deliberate removal.
+        if int(getattr(meta, "total_updates", 0) or 0) == 0:
+            continue
+
         # Age-based archive
         age_h = _agent_age_hours(meta)
         if age_h is None or age_h < max_age_hours:

--- a/src/mcp_handlers/lifecycle/stuck.py
+++ b/src/mcp_handlers/lifecycle/stuck.py
@@ -587,9 +587,33 @@ async def _archive_superseded_parents(current_time) -> list:
             continue
         if not _is_superseded_by_lineage(agent_id, meta, live_parent_ids):
             continue
+        # Initializing agents (never checked in) are ghosts, not retired
+        # predecessors — declaring parent_agent_id attests ancestry, not that
+        # the parent has exited. A fresh session that onboarded and is working
+        # but hasn't checked in yet (total_updates == 0) must never be archived
+        # out from under itself the moment a concurrent same-workspace sibling
+        # declares it parent. This mirrors classify_for_archival's ghost
+        # protection, which this lineage-succession path was bypassing.
+        # (Incident 2026-06-14: agent 1b4172bb archived 22 min into active work,
+        # 0 check-ins, because sibling ad111882 onboarded declaring it parent.)
+        if int(getattr(meta, "total_updates", 0) or 0) == 0:
+            continue
         # Self-managed agents own their lifecycle — same exclusion as detection.
         agent_tags = getattr(meta, "tags", []) or []
         if {"autonomous", "embodied", "anima"} & set(t.lower() for t in agent_tags):
+            continue
+        # Final, conceptually-correct guard: a parent with a LIVE process
+        # binding is a running process, not a rotated-out predecessor. A child
+        # declaring parent_agent_id attests ancestry, not that the parent
+        # exited — so a still-running parent (e.g. mid long tool call or
+        # subagent dispatch, silent past the 30-min window) must not be
+        # archived just because a concurrent sibling onboarded behind it. The
+        # updates==0 guard above is a cheap no-DB fallback for the not-yet-bound
+        # case; this is the real liveness signal. Best-effort: get_live_bindings
+        # returns [] on DB error, falling back to prior behavior rather than
+        # blocking cleanup.
+        from src.mcp_handlers.identity.process_binding import get_live_bindings
+        if await get_live_bindings(agent_id):
             continue
         ok = await _archive_one_agent(
             agent_id, meta, "lineage_succession", monitors=mcp_server.monitors

--- a/tests/test_lifecycle_detect_stuck.py
+++ b/tests/test_lifecycle_detect_stuck.py
@@ -951,7 +951,8 @@ class TestLineageSuccession:
         old_time = datetime.now(timezone.utc) - timedelta(minutes=10)
         recent = datetime.now(timezone.utc) - timedelta(minutes=2)
         with patch(_PATCHES["mcp_server"]) as mock_server, \
-             patch("src.mcp_handlers.lifecycle.helpers._archive_one_agent") as mock_arch:
+             patch("src.mcp_handlers.lifecycle.helpers._archive_one_agent") as mock_arch, \
+             patch("src.mcp_handlers.identity.process_binding.get_live_bindings") as mock_live:
             mock_server.agent_metadata = {
                 "p1": _make_agent_meta(last_update=old_time),
                 "c1": _make_agent_meta(last_update=recent, parent_agent_id="p1"),
@@ -962,6 +963,10 @@ class TestLineageSuccession:
                 return True
             mock_arch.side_effect = _ok
 
+            async def _no_bindings(*a, **k):
+                return []
+            mock_live.side_effect = _no_bindings
+
             from src.mcp_handlers.lifecycle.stuck import _archive_superseded_parents
             results = await _archive_superseded_parents(datetime.now(timezone.utc))
 
@@ -971,3 +976,89 @@ class TestLineageSuccession:
         # The child must never be archived — it is the live successor.
         archived_ids = [c.args[0] for c in mock_arch.call_args_list]
         assert archived_ids == ["p1"]
+
+    @pytest.mark.asyncio
+    async def test_archive_superseded_parents_skips_initializing_ghost(self):
+        """A parent that has never checked in (total_updates == 0) is an
+        initializing ghost and must NOT be archived even when a live child
+        declares it — declaring parent_agent_id attests ancestry, not exit.
+
+        Regression for the 2026-06-14 incident: a fresh session working but
+        not yet checked in was archived out from under itself the moment a
+        concurrent same-workspace sibling onboarded declaring it parent.
+        Mirrors classify_for_archival's ghost protection.
+        """
+        recent = datetime.now(timezone.utc) - timedelta(minutes=2)
+        with patch(_PATCHES["mcp_server"]) as mock_server, \
+             patch("src.mcp_handlers.lifecycle.helpers._archive_one_agent") as mock_arch, \
+             patch("src.mcp_handlers.identity.process_binding.get_live_bindings") as mock_live:
+            mock_server.agent_metadata = {
+                # ghost: superseded by a live child but 0 check-ins → protected
+                "ghost": _make_agent_meta(last_update=recent, total_updates=0),
+                "c_ghost": _make_agent_meta(
+                    last_update=recent, parent_agent_id="ghost"
+                ),
+                # checked-in parent superseded by a live child → still archived
+                "done": _make_agent_meta(last_update=recent, total_updates=4),
+                "c_done": _make_agent_meta(
+                    last_update=recent, parent_agent_id="done"
+                ),
+            }
+            mock_server.monitors = {}
+
+            async def _ok(*a, **k):
+                return True
+            mock_arch.side_effect = _ok
+
+            async def _no_bindings(*a, **k):
+                return []
+            mock_live.side_effect = _no_bindings
+
+            from src.mcp_handlers.lifecycle.stuck import _archive_superseded_parents
+            results = await _archive_superseded_parents(datetime.now(timezone.utc))
+
+        archived_ids = [c.args[0] for c in mock_arch.call_args_list]
+        # ghost protected; only the checked-in superseded parent retired.
+        assert archived_ids == ["done"]
+        assert [r["agent_id"] for r in results] == ["done"]
+
+    @pytest.mark.asyncio
+    async def test_archive_superseded_parents_skips_live_process_binding(self):
+        """A checked-in parent that is STILL a running process (live process
+        binding) must NOT be archived even when a live child declares it —
+        lineage declaration attests ancestry, not that the parent exited.
+
+        Covers the residual hole the updates==0 guard alone leaves: a parent
+        that checked in (total_updates >= 1) then works silently past the
+        succession window (long tool call / subagent dispatch) while a sibling
+        onboards declaring it parent. The live process binding is the
+        conceptually-correct liveness signal (architect council finding).
+        """
+        recent = datetime.now(timezone.utc) - timedelta(minutes=2)
+        with patch(_PATCHES["mcp_server"]) as mock_server, \
+             patch("src.mcp_handlers.lifecycle.helpers._archive_one_agent") as mock_arch, \
+             patch("src.mcp_handlers.identity.process_binding.get_live_bindings") as mock_live:
+            mock_server.agent_metadata = {
+                # checked-in parent, superseded by a live child, but its own
+                # process is still alive → must survive.
+                "alive": _make_agent_meta(last_update=recent, total_updates=7),
+                "c_alive": _make_agent_meta(
+                    last_update=recent, parent_agent_id="alive"
+                ),
+            }
+            mock_server.monitors = {}
+
+            async def _ok(*a, **k):
+                return True
+            mock_arch.side_effect = _ok
+
+            async def _live_for_alive(agent_id, *a, **k):
+                return [{"pid": 123, "last_seen": recent.isoformat()}] if agent_id == "alive" else []
+            mock_live.side_effect = _live_for_alive
+
+            from src.mcp_handlers.lifecycle.stuck import _archive_superseded_parents
+            results = await _archive_superseded_parents(datetime.now(timezone.utc))
+
+        # The parent's live binding protects it — nothing archived.
+        assert mock_arch.call_args_list == []
+        assert results == []


### PR DESCRIPTION
Auto-shipped by ship.sh as a draft PR. Local work is visible; mark ready after validation/review.