### PR TITLE
feat(identity): declaration-time liveness guard — reject coincidental lineage

### DIFF
--- a/docs/proposals/lineage-causal-only-semantics.md
+++ b/docs/proposals/lineage-causal-only-semantics.md
@@ -1,0 +1,90 @@
+# Causal-only lineage declaration
+
+Status: DRAFT (operator-decided 2026-06-14; pending council)
+Author: agent ec46292a (lineage to 1b4172bb)
+Related: PR #720 (archival liveness gate — the safety net under this change)
+
+## Decision (REFINED post-council, operator-confirmed 2026-06-14)
+
+The discriminator is **parent liveness**, not a blanket `new_session` ban. A
+*live* parent means concurrent sibling (the archival cause); a *dead* parent
+means genuine succession. Council live data: `new_session` edges confirm at 6%,
+`subagent` at 33% — and `spawn_reason="explicit"` has been used 2 times ever
+with a parent, so a pure "use explicit for handoffs" rule would silently kill
+the real serial-handoff signal (operator close-and-continue workflow). So we
+keep `new_session` edges flowing as *provisional* (R1 adjudicates the 6% real
+ones) and gate only on liveness:
+
+| spawn_reason | live parent | dead parent |
+|---|---|---|
+| `subagent`   | **allow** (dispatcher alive by design) | allow |
+| `compaction` | **allow** (same live session continuing past a context boundary) | allow |
+| `explicit`   | reject (concurrent sibling) | allow |
+| `new_session`| **reject** (concurrent sibling — the archival cause) | allow as provisional → R1 |
+
+**Liveness guard** uses the same `get_live_bindings()` signal as #720
+(symmetric: #720 is the archival-time guard, this is the declaration-time one).
+Mechanism is **record-then-demote** via the existing R2 pre-check / FSM (new
+reason `lineage_coincidental_rejected`, mirroring `lineage_cross_role_rejected`)
+so the audit trail survives. Rejected by council: write-time hard-drop (fights
+the claim-based ontology, destroys audit) and `explicit`-as-handoff-carrier
+(nobody sets it). Rejected: liveness-guarding `compaction` (its semantics
+*require* a live parent).
+
+## Why
+
+The SessionStart nudge surfaced "the prior workspace session" as a lineage
+candidate to *every* new session, and "continuing the workspace's work" reads
+true for a concurrent session too. That minted false parent→child edges between
+co-located, non-causally-related sessions (chain `1b4172bb → ad111882 →
+d8c219dd`, none actually each other's children), which the (pre-#720) archival
+path then acted on destructively. The onboarding nudge already warns "false
+ancestry claims pollute the lineage DAG" — but defaults toward declaring it.
+
+Lineage edges are most valuable to the trajectory-identity research (TIWD) when
+each edge is a real causal event. Co-location inference is low-fidelity noise;
+the system already treats these declarations as *provisional claims* (R2),
+unconfirmed until R1 evaluation — so dropping auto-declaration discards noise,
+not confirmed data.
+
+## What consumes new_session lineage today (so we know the blast radius)
+
+- `trajectory_identity.py` — seeds child trajectory **genesis** from the parent.
+- `identity/trajectory_continuity.py` — registers the provisional lineage **claim** (R2).
+- `identity/lineage_lifecycle.py` — `provisional → {confirmed,demoted,archived}` state machine; already has `lineage_cross_role_rejected`.
+- `identity/provenance_chain.py`, `agent_fragmentation.py`, `provenance_context.py` — DAG / provenance views.
+- `agent_lifecycle.py` (lineage_info), `stuck.py` (archival — fixed by #720).
+
+## Proposed implementation (fit the existing framework)
+
+1. **Server write point** — `ensure_agent_persisted` / the `_spawn` resolution in
+   `src/mcp_handlers/identity/handlers.py` (~1207): stop the
+   `("new_session" if _parent else None)` default from creating an edge. If the
+   resolved `spawn_reason` is `new_session`, **do not persist `parent_agent_id`**
+   (onboard fresh, `lineage_state: no_lineage_declared`). Only
+   subagent/explicit/compaction persist the edge.
+2. **Liveness guard** — before persisting an edge for explicit/compaction (NOT
+   subagent), call `get_live_bindings(parent_id)`; if live, reject the edge
+   (emit a rejection event, mirror `lineage_cross_role_rejected` — e.g.
+   `lineage_coincidental_rejected`) and onboard fresh. Best-effort (DB error → []
+   → allow, same posture as #720).
+3. **Nudge surfaces** (stop steering clients to declare new_session lineage):
+   - plugin SessionStart hook (`unitares-governance-plugin`)
+   - `~/.claude/hooks/prompt-onboarding-nudge.sh` (local)
+   - server onboard-response lineage hint
+4. **Docs** (the coupled single-writer surface): `CLAUDE.md`/`AGENTS.md` shared
+   contract (Minimal Agent Workflow + Identity rules), `docs/ontology/identity.md`,
+   `commands/governance-start.md`, `skills/governance-lifecycle/SKILL.md`.
+
+## Open questions for council
+
+- Does dropping new_session edges break R2 evaluation or trajectory-genesis
+  seeding for the *legitimate* serial-handoff case — and is that case now
+  required to use `spawn_reason="explicit"`? Confirm the explicit path seeds
+  genesis identically.
+- Write-time hard-drop vs. record-then-immediately-demote via the existing
+  state machine: which is truer to the framework and keeps audit trail?
+- Liveness guard exemption for `subagent` — confirm the dispatcher-alive case
+  is the only legitimate live-parent and nothing else relies on live-parent
+  edges.
+- Is there an existing "PR 3 consumer gating" effort this overlaps/collides with?

--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -1952,10 +1952,11 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
                     _parent_agent_id,
                     name,
                     mcp_server.agent_metadata.get(agent_uuid),
+                    _spawn_reason,
                 )
-                if _r2_state == "rejected_cross_role":
+                if _r2_state in ("rejected_cross_role", "rejected_coincidental"):
                     _parent_agent_id = None
-                    _lineage_for_response = "rejected_cross_role"
+                    _lineage_for_response = _r2_state
                 else:
                     _lineage_for_response = "provisional"
                     from src.background_tasks import create_tracked_task
@@ -2048,10 +2049,11 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
                     _parent_agent_id,
                     name,
                     mcp_server.agent_metadata.get(agent_uuid),
+                    _spawn_reason,
                 )
-                if _r2_state == "rejected_cross_role":
+                if _r2_state in ("rejected_cross_role", "rejected_coincidental"):
                     _parent_agent_id = None
-                    _lineage_for_response = "rejected_cross_role"
+                    _lineage_for_response = _r2_state
                 else:
                     _lineage_for_response = "provisional"
                     try:
@@ -2683,6 +2685,7 @@ async def _r2_pre_check_and_declare(
     parent_id: str,
     name: Optional[str],
     meta: Optional[Any],
+    spawn_reason: Optional[str] = None,
 ) -> tuple[str, Optional[Dict[str, Any]]]:
     """R2 PR 3 — cross-role pre-check + lineage_declared emission.
 
@@ -2730,6 +2733,81 @@ async def _r2_pre_check_and_declare(
     from src.grounding.onboard_classifier import default_tags_for_onboard
     from src.db import get_db
 
+    backend = get_db()
+
+    # Liveness pre-check (declaration-time concurrent-sibling guard).
+    # Declaring parent_agent_id attests ancestry, not that the parent exited.
+    # If the named parent is a CURRENTLY-LIVE process, the declarant is a
+    # concurrent sibling, not a successor — minting the edge is what produced
+    # the 2026-06-14 false-archival chain (1b4172bb -> ad111882 -> d8c219dd).
+    # Reject (clear + audit), mirroring the cross-role path. Symmetric with
+    # PR #720's archival-time liveness guard.
+    #   - subagent: exempt — the dispatcher is alive by design.
+    #   - compaction: exempt — the same live session continuing past a context
+    #     boundary legitimately has a live "parent".
+    #   - explicit / new_session: a live parent means concurrent sibling → reject.
+    #     A dead parent stays provisional and R1 adjudicates (preserves the
+    #     genuine serial-handoff signal).
+    # Best-effort: get_live_bindings returns [] on DB error → treated as
+    # not-live → allow, same fail-open posture as #720.
+    if spawn_reason not in ("subagent", "compaction"):
+        from src.mcp_handlers.identity.process_binding import get_live_bindings
+        parent_uuid = parent_id
+        try:
+            _prec = await backend.get_identity(parent_id)
+            if _prec:
+                parent_uuid = (
+                    _prec.get("agent_uuid")
+                    or _prec.get("id")
+                    or _prec.get("uuid")
+                    or parent_id
+                )
+        except Exception:
+            pass
+        try:
+            live_bindings = await get_live_bindings(parent_uuid)
+        except Exception as e:
+            logger.warning(
+                f"[R2] liveness pre-check failed for {agent_uuid[:8]}...: {e}"
+            )
+            live_bindings = []
+        if live_bindings:
+            try:
+                await backend.clear_lineage_declaration(agent_uuid)
+            except Exception as e:
+                logger.warning(
+                    f"[R2] coincidental: failed to clear lineage declaration "
+                    f"for {agent_uuid[:8]}...: {e}"
+                )
+            if meta is not None:
+                try:
+                    meta.parent_agent_id = None
+                    meta.spawn_reason = None
+                except Exception:
+                    pass
+            try:
+                await _emit_audit(
+                    "lineage_coincidental_rejected",
+                    agent_uuid,
+                    details={
+                        "claimed_parent_id": parent_id,
+                        "reason": "parent_live_at_declaration",
+                        "spawn_reason": spawn_reason,
+                        "live_binding_count": len(live_bindings),
+                    },
+                )
+            except Exception as e:
+                logger.warning(
+                    f"[R2] coincidental audit emit failed for "
+                    f"{agent_uuid[:8]}...: {e}"
+                )
+            logger.info(
+                f"[R2] Coincidental lineage rejected: {agent_uuid[:8]}... -> "
+                f"{parent_id[:8]}... (parent live: {len(live_bindings)} "
+                f"binding(s), spawn_reason={spawn_reason})"
+            )
+            return "rejected_coincidental", None
+
     # Determine the successor's would-be primary class. The classifier
     # returns None when existing_tags is non-empty (caller-asserted
     # class) — in that branch use the caller's tags directly so the
@@ -2741,7 +2819,6 @@ async def _r2_pre_check_and_declare(
     successor_class = successor_tags[0] if successor_tags else None
 
     rejection = await pre_check_cross_role(parent_id, successor_class)
-    backend = get_db()
 
     if rejection is not None:
         # Clear parent_agent_id AND spawn_reason from the storage row

--- a/tests/test_lineage_liveness_guard.py
+++ b/tests/test_lineage_liveness_guard.py
@@ -1,0 +1,105 @@
+"""Declaration-time liveness guard in `_r2_pre_check_and_declare`.
+
+A child declaring `parent_agent_id` attests ancestry, not that the parent
+exited. If the named parent is a CURRENTLY-LIVE process, the declarant is a
+concurrent sibling, not a successor — minting the edge produced the 2026-06-14
+false-archival chain. The guard rejects such declarations (`rejected_coincidental`),
+mirroring the cross-role reject path, and is symmetric with PR #720's
+archival-time liveness guard.
+
+Exemptions: `subagent` (dispatcher alive by design) and `compaction` (same live
+session continuing past a context boundary) legitimately have a live parent.
+
+Tests use a cross-role rejection as a short-circuit to assert the post-liveness
+path was reached without mocking the full declare path.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.mcp_handlers.identity.handlers import _r2_pre_check_and_declare
+
+
+def _meta():
+    # tags non-empty → successor_class resolves without a DB read
+    return SimpleNamespace(
+        tags=["ephemeral"], parent_agent_id="parent-uuid", spawn_reason=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_new_session_live_parent_rejected_coincidental():
+    """new_session declaring a LIVE parent → rejected_coincidental (the bug)."""
+    backend = AsyncMock()
+    backend.get_identity = AsyncMock(return_value={"id": "parent-uuid"})
+    backend.clear_lineage_declaration = AsyncMock()
+    with patch("src.db.get_db", return_value=backend), \
+         patch("src.mcp_handlers.identity.process_binding.get_live_bindings",
+               new=AsyncMock(return_value=[{"pid": 123}])) as mock_live, \
+         patch("src.identity.lineage_lifecycle._emit_audit", new=AsyncMock()) as mock_audit, \
+         patch("src.identity.lineage_lifecycle.pre_check_cross_role", new=AsyncMock(return_value=None)) as mock_cross:
+        state, _ = await _r2_pre_check_and_declare(
+            "child-uuid", "parent-uuid", None, _meta(), "new_session"
+        )
+
+    assert state == "rejected_coincidental"
+    backend.clear_lineage_declaration.assert_awaited_once_with("child-uuid")
+    # audited as coincidental, and we never reached the cross-role check
+    assert mock_audit.await_args.args[0] == "lineage_coincidental_rejected"
+    mock_cross.assert_not_awaited()
+    mock_live.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exempt_reason", ["subagent", "compaction"])
+async def test_exempt_spawn_reasons_skip_liveness(exempt_reason):
+    """subagent/compaction never run the liveness check — a live parent is
+    legitimate for them (dispatcher alive / same live session continuing)."""
+    backend = AsyncMock()
+    backend.get_identity = AsyncMock(return_value={"id": "parent-uuid"})
+    backend.clear_lineage_declaration = AsyncMock()
+    with patch("src.db.get_db", return_value=backend), \
+         patch("src.mcp_handlers.identity.process_binding.get_live_bindings",
+               new=AsyncMock(return_value=[{"pid": 123}])) as mock_live, \
+         patch("src.identity.lineage_lifecycle._emit_audit", new=AsyncMock()), \
+         patch("src.identity.lineage_lifecycle.pre_check_cross_role",
+               new=AsyncMock(return_value={"parent_class": "persistent",
+                                           "successor_class": "ephemeral",
+                                           "reason": "role_envelope_mismatch"})):
+        # cross-role rejection short-circuits the declare path
+        state, _ = await _r2_pre_check_and_declare(
+            "child-uuid", "parent-uuid", None, _meta(), exempt_reason
+        )
+
+    # liveness never consulted; proceeded straight to the cross-role check
+    mock_live.assert_not_awaited()
+    assert state == "rejected_cross_role"
+
+
+@pytest.mark.asyncio
+async def test_new_session_dead_parent_not_coincidental():
+    """new_session declaring a DEAD parent is NOT liveness-rejected — it stays
+    on the normal path (provisional → R1), preserving genuine serial handoffs."""
+    backend = AsyncMock()
+    backend.get_identity = AsyncMock(return_value={"id": "parent-uuid"})
+    backend.clear_lineage_declaration = AsyncMock()
+    with patch("src.db.get_db", return_value=backend), \
+         patch("src.mcp_handlers.identity.process_binding.get_live_bindings",
+               new=AsyncMock(return_value=[])) as mock_live, \
+         patch("src.identity.lineage_lifecycle._emit_audit", new=AsyncMock()), \
+         patch("src.identity.lineage_lifecycle.pre_check_cross_role",
+               new=AsyncMock(return_value={"parent_class": "persistent",
+                                           "successor_class": "ephemeral",
+                                           "reason": "role_envelope_mismatch"})):
+        state, _ = await _r2_pre_check_and_declare(
+            "child-uuid", "parent-uuid", None, _meta(), "new_session"
+        )
+
+    # liveness WAS consulted (returned empty), edge not coincidental-rejected;
+    # falls through to the normal cross-role path (here a cross-role reject).
+    mock_live.assert_awaited_once()
+    assert state == "rejected_cross_role"
+    backend.clear_lineage_declaration.assert_awaited_once()  # by cross-role, not coincidental


### PR DESCRIPTION
Auto-shipped by ship.sh as a draft PR. Local work is visible; mark ready after validation/review.