### PR TITLE
fix(lifecycle): guard manual archive paths against sweeping live agents

### DIFF
--- a/src/mcp_handlers/lifecycle/helpers.py
+++ b/src/mcp_handlers/lifecycle/helpers.py
@@ -27,6 +27,55 @@ def clear_loop_detector_state(meta) -> None:
     meta.recent_decisions = []
 
 
+# Spawn reasons that represent an intentional, causal lineage edge — as opposed
+# to the noisy co-location ``new_session`` default that the SessionStart nudge
+# mints between unrelated same-workspace sessions. Mirrors the taxonomy in
+# docs/proposals/lineage-causal-only-semantics.md (PR #721): a child declaring
+# one of these attests a real dependency, so its parent is something an operator
+# probably does not mean to sweep in a bulk "archive everyone" pass.
+_CAUSAL_SPAWN_REASONS = frozenset({"subagent", "compaction", "explicit", "dispatch"})
+
+
+async def manual_archive_liveness_signals(
+    agent_uuid: str,
+    meta: AgentMetadata,
+) -> list[str]:
+    """Return human-readable reasons the target looks live / intentionally kept.
+
+    An empty list means "safe to archive without force". Used by the manual
+    ``archive_agent`` path to refuse silent archival of an agent that is
+    plainly still in use, so a bulk "archive everyone" sweep can't strand a
+    running workflow (2026-06-14 council-agent incident). Best-effort and
+    fail-open: any signal lookup that errors is simply omitted.
+
+    Two orthogonal signals, deliberately matching the posture of the
+    auto-archival guards in PR #720/#721:
+      1. A live process binding — the conceptually-correct "running right now"
+         signal. (Recent ``last_update`` is intentionally NOT used: a check-in
+         minutes ago does not mean the process is still running, and gating on
+         it would block the routine archive-the-agent-I-just-looked-at flow.)
+      2. A declared *causal* lineage edge — the agent is a parent/successor in
+         an intentional chain (subagent/dispatch/explicit/compaction), not a
+         coincidental ``new_session`` co-location edge.
+    """
+    signals: list[str] = []
+
+    try:
+        from src.mcp_handlers.identity.process_binding import get_live_bindings
+        bindings = await get_live_bindings(agent_uuid)
+        if bindings:
+            signals.append(f"{len(bindings)} live process binding(s)")
+    except Exception as e:  # pragma: no cover - defensive, fail-open
+        logger.debug(f"manual_archive liveness binding check failed: {e}")
+
+    parent = getattr(meta, "parent_agent_id", None)
+    spawn = (getattr(meta, "spawn_reason", None) or "").lower()
+    if parent and spawn in _CAUSAL_SPAWN_REASONS:
+        signals.append(f"declared lineage (spawn_reason={spawn})")
+
+    return signals
+
+
 async def _resume_with_persistence(
     meta,
     *,

--- a/src/mcp_handlers/lifecycle/mutation.py
+++ b/src/mcp_handlers/lifecycle/mutation.py
@@ -200,6 +200,35 @@ async def handle_archive_agent(arguments: Dict[str, Any]) -> Sequence[TextConten
             }
         )]
 
+    # Liveness guard: refuse to silently archive an agent that is plainly still
+    # in use unless the caller opts in with force=true. A bulk "archive
+    # everyone" pass (the 2026-06-14 council-agent incident) should not be able
+    # to strand a running workflow without the operator confirming. Best-effort
+    # and fail-open — if no liveness signal is found, archival proceeds.
+    force = arguments.get("force", False)
+    if isinstance(force, str):
+        force = force.strip().lower() in ("true", "1", "yes")
+    if not force:
+        from .helpers import manual_archive_liveness_signals
+        live_signals = await manual_archive_liveness_signals(agent_uuid, meta)
+        if live_signals:
+            return [error_response(
+                f"Agent '{agent_id}' looks live or intentionally retained "
+                f"({'; '.join(live_signals)}). Archiving it now may strand an "
+                "active workflow. Pass force=true to archive anyway.",
+                error_code="AGENT_LOOKS_LIVE",
+                error_category="validation_error",
+                details={"agent_id": agent_id, "liveness_signals": live_signals},
+                recovery={
+                    "action": "Confirm the agent is really idle, then re-issue with force=true",
+                    "related_tools": ["observe", "ping_agent", "get_agent_metadata"],
+                    "workflow": [
+                        "1. Check recent activity: observe(action='agent', target_agent_id='...')",
+                        "2. If genuinely done, archive with force=true",
+                    ],
+                },
+            )]
+
     reason = arguments.get("reason", "Manual archive")
     keep_in_memory = arguments.get("keep_in_memory", False)
 

--- a/src/mcp_handlers/lifecycle/operations.py
+++ b/src/mcp_handlers/lifecycle/operations.py
@@ -550,14 +550,21 @@ async def handle_ping_agent(arguments: Dict[str, Any]) -> Sequence[TextContent]:
 async def handle_archive_old_test_agents(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     """Archive stale agents - test agents by default, or ALL stale agents with include_all=true
 
-    Use include_all=true to clean up any agent inactive for max_age_days (default: 3 days)
+    Use include_all=true to clean up any agent inactive for max_age_days (default: 3 days).
+
+    PREVIEW-FIRST: this sweep defaults to dry_run=true (mirrors
+    archive_orphan_agents) so a fleet-wide ``include_all`` pass shows what it
+    WOULD archive before touching anything. Pass dry_run=false to execute.
     """
     from src.agent_lifecycle import _agent_age_hours
 
     max_age_hours = arguments.get("max_age_hours", 6)
     max_age_days = arguments.get("max_age_days")
     include_all = arguments.get("include_all", False)
-    dry_run = arguments.get("dry_run", False)
+    # Default to preview: a bulk archival lever that executes immediately is the
+    # "archive everyone" footgun (2026-06-14 incident). Opt into execution
+    # explicitly with dry_run=false.
+    dry_run = arguments.get("dry_run", True)
 
     if include_all and max_age_days is None and "max_age_hours" not in arguments:
         max_age_days = 3

--- a/src/mcp_handlers/schemas/lifecycle.py
+++ b/src/mcp_handlers/schemas/lifecycle.py
@@ -154,6 +154,10 @@ class ArchiveAgentParams(AgentIdentityMixin):
     target_agent: str = Field(
         ..., description="UUID or label of agent to archive."
     )
+    force: Union[bool, str, None] = Field(
+        default=False,
+        description="Archive even if the agent looks live (running process, recent activity, or declared causal lineage). Default false refuses such archives."
+    )
 
 
 class ResumeAgentParams(AgentIdentityMixin):
@@ -189,11 +193,17 @@ class ArchiveOldTestAgentsParams(AgentIdentityMixin):
         default=3,
         description="Agents inactive for this many days will be archived (default: 3)."
     )
+    dry_run: Union[bool, str, None] = Field(
+        default=True,
+        description="If true (default), returns what WOULD be archived without taking action. Pass false to execute."
+    )
 
     @model_validator(mode='after')
     def coerce_booleans(self):
         if isinstance(self.include_all, str):
             self.include_all = self.include_all.lower() in ('true', '1', 'yes')
+        if isinstance(self.dry_run, str):
+            self.dry_run = self.dry_run.lower() in ('true', '1', 'yes')
         if isinstance(self.max_age_days, str):
             try:
                 self.max_age_days = int(self.max_age_days)
@@ -303,6 +313,7 @@ class AgentParams(ListAgentOptionsMixin, AgentIdentityMixin):
     tags: Optional[List[Any]] = Field(None, description="Tags to set (for action=update)")
     notes: Optional[str] = Field(None, description="Notes to set (for action=update)")
     confirm: Optional[bool] = Field(None, description="Confirm deletion (for action=delete)")
+    force: Optional[Union[bool, str]] = Field(None, description="For action=archive: archive even if the agent looks live (running process, recent activity, or declared causal lineage).")
 
 
 class SelfRecoveryParams(AgentIdentityMixin):

--- a/tests/test_manual_archive_liveness_guard.py
+++ b/tests/test_manual_archive_liveness_guard.py
@@ -1,0 +1,272 @@
+"""Liveness guard on the manual archive path + preview-first stale sweep.
+
+Two complementary footgun fixes (2026-06-14 council-agent incident, where a
+bulk manual archive swept agents that a workflow still expected):
+
+1. ``handle_archive_agent`` refuses to silently archive an agent that looks
+   live — a running process binding, recent activity, or a declared *causal*
+   lineage edge — unless the caller passes ``force=true``.
+2. ``handle_archive_old_test_agents`` defaults to ``dry_run=true`` (preview
+   first), mirroring ``archive_orphan_agents``, so the fleet-wide
+   ``include_all`` lever can't execute without an explicit opt-in.
+
+These are complementary to PRs #720/#721, which harden the *automatic*
+archival paths; this covers the *manual* path and the bulk-sweep default.
+"""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _payload(result):
+    """Unwrap a handler's TextContent list into the JSON dict."""
+    item = result[0] if isinstance(result, (list, tuple)) else result
+    return json.loads(item.text)
+
+
+def _make_meta(**overrides):
+    meta = SimpleNamespace(
+        agent_id="agent-uuid",
+        status="active",
+        archived_at=None,
+        notes="",
+        total_updates=5,
+        last_update=None,
+        parent_agent_id=None,
+        spawn_reason=None,
+    )
+    for k, v in overrides.items():
+        setattr(meta, k, v)
+    meta.add_lifecycle_event = MagicMock()
+    return meta
+
+
+def _archive_patches(meta, agent_uuid="agent-uuid"):
+    """Common patch set for handle_archive_agent tests."""
+    mock_server = MagicMock()
+    mock_server.agent_metadata = {agent_uuid: meta}
+    mock_server.load_metadata_async = AsyncMock()
+    mock_server.monitors = {}
+    mock_storage = MagicMock(update_agent=AsyncMock(return_value=True))
+    return mock_server, mock_storage
+
+
+# ----------------------------------------------------------------------
+# manual_archive_liveness_signals helper
+# ----------------------------------------------------------------------
+
+
+class TestLivenessSignalsHelper:
+    @pytest.mark.asyncio
+    async def test_no_signals_for_idle_unlineaged_agent(self):
+        from src.mcp_handlers.lifecycle.helpers import manual_archive_liveness_signals
+
+        meta = _make_meta()
+        with patch(
+            "src.mcp_handlers.identity.process_binding.get_live_bindings",
+            new=AsyncMock(return_value=[]),
+        ):
+            signals = await manual_archive_liveness_signals("agent-uuid", meta)
+        assert signals == []
+
+    @pytest.mark.asyncio
+    async def test_live_binding_is_a_signal(self):
+        from src.mcp_handlers.lifecycle.helpers import manual_archive_liveness_signals
+
+        meta = _make_meta()
+        with patch(
+            "src.mcp_handlers.identity.process_binding.get_live_bindings",
+            new=AsyncMock(return_value=[{"pid": 123}]),
+        ):
+            signals = await manual_archive_liveness_signals("agent-uuid", meta)
+        assert any("binding" in s for s in signals)
+
+    @pytest.mark.asyncio
+    async def test_causal_lineage_is_a_signal_but_new_session_is_not(self):
+        from src.mcp_handlers.lifecycle.helpers import manual_archive_liveness_signals
+
+        with patch(
+            "src.mcp_handlers.identity.process_binding.get_live_bindings",
+            new=AsyncMock(return_value=[]),
+        ):
+            causal = await manual_archive_liveness_signals(
+                "u", _make_meta(parent_agent_id="parent", spawn_reason="subagent")
+            )
+            noisy = await manual_archive_liveness_signals(
+                "u", _make_meta(parent_agent_id="parent", spawn_reason="new_session")
+            )
+        assert any("lineage" in s for s in causal)
+        assert noisy == []  # coincidental new_session edge is not a keep-alive signal
+
+    @pytest.mark.asyncio
+    async def test_recent_activity_alone_is_not_a_signal(self):
+        """A recent last_update is intentionally NOT a keep-alive signal — only
+        a live process binding or causal lineage blocks archival."""
+        from datetime import datetime, timezone
+        from src.mcp_handlers.lifecycle.helpers import manual_archive_liveness_signals
+
+        recent = datetime.now(timezone.utc).isoformat()
+        with patch(
+            "src.mcp_handlers.identity.process_binding.get_live_bindings",
+            new=AsyncMock(return_value=[]),
+        ):
+            signals = await manual_archive_liveness_signals(
+                "u", _make_meta(last_update=recent)
+            )
+        assert signals == []
+
+    @pytest.mark.asyncio
+    async def test_binding_lookup_failure_is_fail_open(self):
+        from src.mcp_handlers.lifecycle.helpers import manual_archive_liveness_signals
+
+        meta = _make_meta()
+        with patch(
+            "src.mcp_handlers.identity.process_binding.get_live_bindings",
+            new=AsyncMock(side_effect=RuntimeError("db down")),
+        ):
+            signals = await manual_archive_liveness_signals("u", meta)
+        assert signals == []  # error omitted, not raised
+
+
+# ----------------------------------------------------------------------
+# handle_archive_agent guard
+# ----------------------------------------------------------------------
+
+
+class TestManualArchiveGuard:
+    async def _run_archive(self, meta, arguments):
+        agent_uuid = "agent-uuid"
+        mock_server, mock_storage = _archive_patches(meta, agent_uuid)
+        with patch("src.mcp_handlers.lifecycle.mutation.mcp_server", mock_server), \
+             patch("src.mcp_handlers.lifecycle.mutation.agent_storage", mock_storage), \
+             patch(
+                 "src.mcp_handlers.lifecycle.mutation.require_registered_agent",
+                 return_value=(agent_uuid, None),
+             ), \
+             patch(
+                 "src.mcp_handlers.lifecycle.mutation.resolve_agent_uuid",
+                 return_value=agent_uuid,
+             ), \
+             patch(
+                 "src.mcp_handlers.lifecycle.helpers._archive_one_agent",
+                 new=AsyncMock(return_value=True),
+             ) as mock_arch, \
+             patch(
+                 "src.mcp_handlers.lifecycle.mutation._invalidate_agent_cache",
+                 new=AsyncMock(),
+             ), \
+             patch(
+                 "src.mcp_handlers.identity.process_binding.get_live_bindings",
+                 new=AsyncMock(return_value=meta._live_bindings),
+             ):
+            from src.mcp_handlers.lifecycle.mutation import handle_archive_agent
+            result = await handle_archive_agent(arguments)
+        return result, mock_arch
+
+    @pytest.mark.asyncio
+    async def test_refuses_archive_of_lineage_declared_agent(self):
+        meta = _make_meta(parent_agent_id="parent", spawn_reason="subagent")
+        meta._live_bindings = []
+        result, mock_arch = await self._run_archive(meta, {"agent_id": "agent-uuid"})
+        body = _payload(result)
+        assert body["success"] is False
+        assert body["error_code"] == "AGENT_LOOKS_LIVE"
+        assert body["liveness_signals"]  # details are flattened to top level
+        mock_arch.assert_not_awaited()  # nothing archived
+
+    @pytest.mark.asyncio
+    async def test_refuses_archive_of_agent_with_live_binding(self):
+        meta = _make_meta()
+        meta._live_bindings = [{"pid": 999}]
+        result, mock_arch = await self._run_archive(meta, {"agent_id": "agent-uuid"})
+        body = _payload(result)
+        assert body["error_code"] == "AGENT_LOOKS_LIVE"
+        mock_arch.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_force_overrides_the_guard(self):
+        meta = _make_meta(parent_agent_id="parent", spawn_reason="subagent")
+        meta._live_bindings = [{"pid": 999}]
+        result, mock_arch = await self._run_archive(
+            meta, {"agent_id": "agent-uuid", "force": True}
+        )
+        body = _payload(result)
+        assert body["success"] is True
+        mock_arch.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_force_accepts_string_true(self):
+        meta = _make_meta(parent_agent_id="parent", spawn_reason="dispatch")
+        meta._live_bindings = []
+        result, mock_arch = await self._run_archive(
+            meta, {"agent_id": "agent-uuid", "force": "true"}
+        )
+        assert _payload(result)["success"] is True
+        mock_arch.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_idle_unlineaged_agent_archives_without_force(self):
+        meta = _make_meta()  # no lineage, no recent activity
+        meta._live_bindings = []
+        result, mock_arch = await self._run_archive(meta, {"agent_id": "agent-uuid"})
+        assert _payload(result)["success"] is True
+        mock_arch.assert_awaited_once()
+
+
+# ----------------------------------------------------------------------
+# archive_old_test_agents preview-first default
+# ----------------------------------------------------------------------
+
+
+class TestArchiveOldTestAgentsPreviewDefault:
+    @pytest.mark.asyncio
+    async def test_defaults_to_dry_run_when_not_specified(self):
+        agent_uuid = "real_001"
+        meta = _make_meta(agent_id=agent_uuid, label="real-agent")
+        mock_server = MagicMock()
+        mock_server.agent_metadata = {agent_uuid: meta}
+        mock_server.load_metadata_async = AsyncMock()
+        mock_server.monitors = {}
+
+        with patch("src.mcp_handlers.lifecycle.operations.mcp_server", mock_server), \
+             patch("src.agent_lifecycle._agent_age_hours", return_value=1000.0), \
+             patch(
+                 "src.mcp_handlers.lifecycle.operations._archive_one_agent",
+                 new=AsyncMock(return_value=True),
+             ) as mock_arch:
+            from src.mcp_handlers.lifecycle.operations import handle_archive_old_test_agents
+            # include_all but NO dry_run key — must preview, not execute.
+            result = await handle_archive_old_test_agents({"include_all": True})
+
+        body = _payload(result)
+        assert body["dry_run"] is True
+        assert body["total_would_archive"] >= 1  # the stale agent is identified
+        mock_arch.assert_not_awaited()  # but nothing is actually archived
+
+    @pytest.mark.asyncio
+    async def test_dry_run_false_executes(self):
+        agent_uuid = "real_002"
+        meta = _make_meta(agent_id=agent_uuid, label="real-agent")
+        mock_server = MagicMock()
+        mock_server.agent_metadata = {agent_uuid: meta}
+        mock_server.load_metadata_async = AsyncMock()
+        mock_server.monitors = {}
+
+        with patch("src.mcp_handlers.lifecycle.operations.mcp_server", mock_server), \
+             patch("src.agent_lifecycle._agent_age_hours", return_value=1000.0), \
+             patch(
+                 "src.mcp_handlers.lifecycle.operations._archive_one_agent",
+                 new=AsyncMock(return_value=True),
+             ) as mock_arch:
+            from src.mcp_handlers.lifecycle.operations import handle_archive_old_test_agents
+            result = await handle_archive_old_test_agents(
+                {"include_all": True, "dry_run": False}
+            )
+
+        body = _payload(result)
+        assert body["dry_run"] is False
+        mock_arch.assert_awaited()  # execution path taken


### PR DESCRIPTION
## Why

A bulk "archive everyone" pass is the path of least resistance when cleaning up after a bug, and it can strand live work. Investigating the **2026-06-14 incident**, a manual archive burst (caller `6fcb12e8…`, reason `"Manual archive"`) swept 12 agents in ~28s — including two lineage-declared council/dispatch agents (`council-verifier-pr604`, `council-conceptual-coherence`) that a workflow referenced again two days later.

PRs **#720** / **#721** harden the *automatic* archival paths (lineage-succession sweep + declaration-time liveness guard). This PR closes the **two complementary gaps on the manual side** that those don't touch.

## What

1. **`archive_old_test_agents` defaults to `dry_run=true`** (preview-first), mirroring `archive_orphan_agents`. The fleet-wide `include_all` lever can no longer execute without an explicit `dry_run=false`. The "archive everyone" footgun now shows what it *would* archive first.

2. **Manual `archive_agent` refuses to silently archive an agent that looks live** unless `force=true`. Liveness signals (best-effort, fail-open):
   - a **live process binding** (`get_live_bindings` — the conceptually-correct "running now" signal, shared with #720/#721), and
   - a declared **causal lineage** edge (`spawn_reason` ∈ {subagent, dispatch, explicit, compaction}), which is what distinguishes the council agents from coincidental `new_session` co-location edges.

   Recent `last_update` is intentionally **not** a blocking signal — it's redundant with the binding signal and would block the routine "archive the agent I just looked at" flow (it broke 8 existing tests precisely because the common path archives recently-touched agents).

Returns a typed `AGENT_LOOKS_LIVE` refusal with the tripped signals and a `force=true` hint.

## Schema

- `force` added to `ArchiveAgentParams` and `AgentParams` (for `agent(action="archive")`).
- `dry_run` added to `ArchiveOldTestAgentsParams` (default `true`).

## Tests

`tests/test_manual_archive_liveness_guard.py` — helper signals, the manual-archive refusal/force/idle paths, and the preview-first default. Full lifecycle + schema suites pass (247 + 91 green locally).

## Note on scope

This is deliberately complementary to #720/#721 and touches different files (`mutation.py`, `operations.py`, `helpers.py`, `schemas/lifecycle.py`) — no overlap with their `stuck.py` / `identity/handlers.py` changes. The manual guard reuses the same `get_live_bindings` liveness signal for consistency.

https://claude.ai/code/session_01Y7m818HyAi26YjifzTiUVF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7m818HyAi26YjifzTiUVF)_