### PR TITLE
fix(lifecycle): close two false-archival follow-up gaps

### DIFF
--- a/src/agent_storage.py
+++ b/src/agent_storage.py
@@ -398,7 +398,13 @@ async def archive_agent(
     )
 
     if hasattr(db, "update_agent_fields"):
-        await db.update_agent_fields(agent_id=agent_id, status="archived")
+        # Write archived_at alongside status so core.agents stays
+        # self-consistent (previously the timestamp landed only in
+        # core.identities.disabled_at + audit.events, leaving
+        # core.agents.archived_at NULL).
+        await db.update_agent_fields(
+            agent_id=agent_id, status="archived", archived_at=disabled_at
+        )
 
     # S21-b §3
     try:

--- a/src/db/base.py
+++ b/src/db/base.py
@@ -223,12 +223,17 @@ class DatabaseBackend(ABC):
         parent_agent_id: Optional[str] = None,
         spawn_reason: Optional[str] = None,
         label: Optional[str] = None,
+        archived_at: Optional[datetime] = None,
     ) -> bool:
         """
         Update selected fields on core.agents WITHOUT touching api_key.
 
         Safer than upsert_agent() for routine metadata edits (purpose/notes/tags),
         because it avoids accidental overwrites of api_key or created_at.
+
+        ``archived_at`` is written when provided so ``core.agents`` stays
+        self-consistent (status='archived' ⟺ archived_at set) instead of
+        leaving the timestamp only in audit.events.
         """
         pass
 

--- a/src/db/mixins/agent.py
+++ b/src/db/mixins/agent.py
@@ -88,8 +88,14 @@ class AgentMixin:
         parent_agent_id: Optional[str] = None,
         spawn_reason: Optional[str] = None,
         label: Optional[str] = None,
+        archived_at: Optional["datetime"] = None,
     ) -> bool:
-        """Partial update of core.agents (does NOT modify api_key)."""
+        """Partial update of core.agents (does NOT modify api_key).
+
+        ``archived_at`` is written when provided so core.agents stays
+        self-consistent with status='archived' (the timestamp previously
+        lived only in audit.events).
+        """
         async with self.acquire() as conn:
             try:
                 result = await conn.execute(
@@ -103,6 +109,7 @@ class AgentMixin:
                         parent_agent_id = COALESCE($6, parent_agent_id),
                         spawn_reason = COALESCE($7, spawn_reason),
                         label = COALESCE($8, label),
+                        archived_at = COALESCE($9, archived_at),
                         updated_at = now()
                     WHERE id = $1
                     """,
@@ -114,6 +121,7 @@ class AgentMixin:
                     parent_agent_id,
                     spawn_reason,
                     label,
+                    archived_at,
                 )
                 return "UPDATE 1" in result
             except Exception as e:

--- a/src/mcp_handlers/support/agent_auth.py
+++ b/src/mcp_handlers/support/agent_auth.py
@@ -180,7 +180,12 @@ def check_agent_can_operate(agent_uuid: str) -> Optional[TextContent]:
             error_code="AGENT_ARCHIVED",
             error_category="state_error",
             details={"agent_id": agent_uuid[:12], "status": "archived"},
-            recovery={"action": "Create a new agent or restore via agent(action='update')"}
+            recovery={"action": (
+                "Reclaim the SAME identity if this is the same live process: "
+                "onboard(resume=true) with your continuity_token or "
+                "client_session_id (auto-unarchives). Operator restore: "
+                "agent(action='update'). Otherwise onboard fresh."
+            )}
         )
 
     return None
@@ -447,14 +452,37 @@ def require_registered_agent(arguments: Dict[str, Any]) -> Tuple[str, Optional[T
             if agent_status not in _REGISTERED_AGENT_ALLOWED_STATUSES:
                 # Map to the inferer's keyword so error_code lands in the
                 # right category (AGENT_ARCHIVED / AGENT_DELETED / etc.).
-                return None, error_response(
-                    f"Agent '{agent_id}' is {agent_status} and cannot accept calls.",
-                    recovery={
+                if agent_status == "archived":
+                    # Archival is reversible for the SAME live process:
+                    # onboard(resume=true) auto-unarchives the same UUID. Route
+                    # there first so a (possibly falsely-)archived live agent
+                    # reclaims its identity + trajectory rather than being forced
+                    # to mint a new one. Forward-lineage is the fallback only
+                    # when continuity can't be proven.
+                    _recovery = {
+                        "error_type": "agent_archived",
+                        "agent_status": "archived",
+                        "action": (
+                            "If this is the same live process, reclaim the SAME "
+                            "identity: onboard(resume=true) with your "
+                            "continuity_token or client_session_id — this "
+                            "auto-unarchives the agent. Only if you cannot prove "
+                            "continuity, onboard fresh and declare this UUID as "
+                            "parent_agent_id (a new identity succeeding the "
+                            "archived one)."
+                        ),
+                        "related_tools": ["onboard", "self_recovery"],
+                    }
+                else:
+                    _recovery = {
                         "error_type": f"agent_{agent_status}",
                         "agent_status": agent_status,
                         "action": "Onboard a fresh identity with parent_agent_id set to this UUID to declare lineage.",
                         "related_tools": ["onboard"],
-                    },
+                    }
+                return None, error_response(
+                    f"Agent '{agent_id}' is {agent_status} and cannot accept calls.",
+                    recovery=_recovery,
                 )
 
         if not agent_found:

--- a/tests/test_archival_gaps.py
+++ b/tests/test_archival_gaps.py
@@ -1,0 +1,68 @@
+"""Follow-up fixes for the 2026-06-14 lineage false-archival incident.
+
+Gap 2: core.agents.archived_at was never written (timestamp lived only in
+core.identities.disabled_at + audit.events). archive_agent now passes
+archived_at to update_agent_fields so core.agents is self-consistent.
+
+Gap 1: an archived agent's gate-refusal recovery hint misrouted to
+forward-lineage (mint a NEW identity), when the same live process can reclaim
+the SAME identity via onboard(resume=true) (auto-unarchive). The hint now
+routes to the reclaim path first.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Gap 2 — archive_agent writes archived_at to core.agents
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_archive_agent_writes_archived_at_to_core_agents():
+    from src import agent_storage
+
+    db = MagicMock()
+    db.update_identity_status = AsyncMock()
+    db.update_agent_fields = AsyncMock()
+
+    iso = "2026-06-14T20:27:32+00:00"
+    with patch.object(agent_storage, "_ensure_db_ready", new=AsyncMock()), \
+         patch.object(agent_storage, "get_db", return_value=db):
+        ok = await agent_storage.archive_agent("agent-1", archived_at=iso)
+
+    assert ok is True
+    # the timestamp must reach core.agents, not just core.identities
+    db.update_agent_fields.assert_awaited_once()
+    kwargs = db.update_agent_fields.await_args.kwargs
+    assert kwargs["status"] == "archived"
+    assert kwargs["archived_at"] == datetime.fromisoformat(iso)
+
+
+# ---------------------------------------------------------------------------
+# Gap 1 — archived gate-refusal routes to reclaim, not forward-lineage
+# ---------------------------------------------------------------------------
+
+
+def test_archived_recovery_hint_routes_to_reclaim():
+    from src.mcp_handlers.support import agent_auth
+
+    uuid = "1b4172bb-8d50-447c-8a68-51a75e20eb26"
+    srv = SimpleNamespace(agent_metadata={uuid: SimpleNamespace(status="archived")})
+
+    with patch("src.mcp_handlers.shared.get_mcp_server", return_value=srv):
+        result = agent_auth.check_agent_can_operate(uuid)
+
+    assert result is not None
+    payload = json.loads(result.text)
+    action = payload["recovery"]["action"].lower()
+    # reclaim path surfaced (the capability already exists via onboard resume)
+    assert "resume=true" in action
+    # and it is not ONLY the forward "mint a new identity" guidance
+    assert "auto-unarchive" in action or "reclaim" in action


### PR DESCRIPTION
Auto-shipped by ship.sh as a draft PR. Local work is visible; mark ready after validation/review.