### PR TITLE
Round display floats in process_update responses

### DIFF
--- a/src/mcp_handlers/response_formatter.py
+++ b/src/mcp_handlers/response_formatter.py
@@ -12,6 +12,32 @@ from src.monitor_result import DIVERGENCE_LINE_THRESHOLD
 logger = get_logger(__name__)
 
 
+def _round_display_floats(obj: Any, ndigits: int = 4) -> Any:
+    """Recursively round float values for display, in-place where possible.
+
+    Display-only: the canonical EISV/risk state lives in GovernanceState; this
+    only tidies the response copy so agents don't read coherence as
+    0.498543340633004 (#UX float-precision noise). Ints, bools, strings, and
+    None pass through untouched. NaN/inf are left as-is (round() would raise or
+    propagate). Recurses into nested dicts/lists.
+    """
+    if isinstance(obj, bool):
+        return obj
+    if isinstance(obj, float):
+        # Leave non-finite values alone; round() on inf/nan is not meaningful.
+        if obj != obj or obj in (float("inf"), float("-inf")):
+            return obj
+        return round(obj, ndigits)
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            obj[k] = _round_display_floats(v, ndigits)
+        return obj
+    if isinstance(obj, list):
+        for i, v in enumerate(obj):
+            obj[i] = _round_display_floats(v, ndigits)
+        return obj
+    return obj
+
 def _copy_passthrough_fields(response_data: dict, result: dict, fields: tuple) -> None:
     """Copy named fields from response_data to result if present (not None).
 
@@ -128,6 +154,9 @@ def format_response(
     if response_mode in ("minimal", "compact", "mirror"):
         _strip_context(response_data, is_new_agent, key_was_generated, api_key_auto_retrieved)
 
+    # Display-only: round float noise (e.g. coherence 0.498543340633004 -> 0.4985).
+    # Skipped for "full" mode, which contracts to return values as-is (early return above).
+    _round_display_floats(response_data)
     return response_data
 
 def _format_standard(response_data: dict, task_type: str, saved_trust_tier: Any = None) -> dict:

--- a/tests/test_response_formatter.py
+++ b/tests/test_response_formatter.py
@@ -20,7 +20,44 @@ from src.mcp_handlers.response_formatter import (
     _format_compact,
     _format_mirror,
     _strip_context,
+    _round_display_floats,
 )
+
+
+# ============================================================================
+# Display float rounding (#UX float-precision noise)
+# ============================================================================
+
+class TestRoundDisplayFloats:
+    def test_rounds_nested_floats_to_4dp(self):
+        obj = {"coherence": 0.498543340633004,
+               "metrics": {"phi": 0.14804268239681923, "risk_score": 0.2659786588015904}}
+        _round_display_floats(obj)
+        assert obj["coherence"] == 0.4985
+        assert obj["metrics"]["phi"] == 0.148
+        assert obj["metrics"]["risk_score"] == 0.266
+
+    def test_rounds_floats_in_lists(self):
+        obj = {"vec": [0.111111, 0.222222]}
+        _round_display_floats(obj)
+        assert obj["vec"] == [0.1111, 0.2222]
+
+    def test_preserves_bools_ints_strings_none(self):
+        obj = {"flag": True, "count": 3, "token": "v1.abc", "edge": None}
+        _round_display_floats(obj)
+        assert obj == {"flag": True, "count": 3, "token": "v1.abc", "edge": None}
+
+    def test_leaves_non_finite_alone(self):
+        nan = float("nan")
+        obj = {"a": float("inf"), "b": nan}
+        _round_display_floats(obj)
+        assert obj["a"] == float("inf")
+        assert obj["b"] != obj["b"]  # still NaN
+
+    def test_full_mode_not_rounded(self):
+        data = {"coherence": 0.498543340633004, "health_status": "healthy"}
+        out = format_response(data, {"response_mode": "full"})
+        assert out["coherence"] == 0.498543340633004
 
 
 # ============================================================================


### PR DESCRIPTION
## What

`format_response()` now applies a `_round_display_floats()` pass at its final return, so check-in responses stop surfacing 16-digit raw floats like `coherence: 0.498543340633004`, `phi: 0.14804268239681923`, `risk_score: 0.2659786588015904`. Rounded to 4 dp.

## Why

Surfaced while dogfooding the live onboard → sync_state flow as a fresh agent. Sixteen significant digits are unusable noise; the rounded `state_summary` and the raw values were coexisting in the same payload.

## Scope / safety

- **Display-only.** Canonical EISV/risk state lives in `GovernanceState` and is untouched — this only tidies the response copy. Calibration/outcome math is unaffected.
- **`full` mode exempt** by contract (early return above the rounding pass).
- Recursive over dicts/lists; type-guarded (bool/int/str/None pass through; NaN/inf left alone).

## Tests

Adds `TestRoundDisplayFloats` (5 cases: nested rounding, lists, type preservation, non-finite, full-mode exemption). **119 passed** in `tests/test_response_formatter.py`.

## Follow-ups (not in this PR)

Documented in a local handoff (`docs/handoffs/agent-experience-ux-audit-2026-06-14.md`, gitignored): identity-assurance tier transition needs a breadcrumb; health-field vocabulary sprawl (margin/basin/phi/void vs `mirror`); onboard response duplication / no minimal mode; the coercive onboarding nudge (lives in the plugin repo).