### PR TITLE
fix(ship): read shared watcher findings

### DIFF
--- a/scripts/dev/ship.sh
+++ b/scripts/dev/ship.sh
@@ -108,10 +108,37 @@ classify_worktree() {
 # processed a Watcher chime — CLAUDE.md asks for fingerprints in commit
 # messages, but post-edit-hook → next-turn-chime is a separate channel from
 # commit-message authorship. This pulls them back together.
+watcher_findings_file() {
+    local primary legacy
+    primary=$(python3 - <<'PY'
+import os
+from pathlib import Path
+
+override = os.environ.get("UNITARES_WATCHER_DATA_DIR")
+if override:
+    state_dir = Path(override).expanduser()
+else:
+    state_dir = Path.home() / ".unitares" / "watcher"
+print(state_dir / "findings.jsonl")
+PY
+)
+    legacy="$PROJECT_ROOT/data/watcher/findings.jsonl"
+
+    if [[ -s "$primary" ]]; then
+        printf '%s\n' "$primary"
+    elif [[ -s "$legacy" ]]; then
+        printf '%s\n' "$legacy"
+    elif [[ -f "$primary" ]]; then
+        printf '%s\n' "$primary"
+    else
+        printf '%s\n' "$legacy"
+    fi
+}
+
 collect_watcher_fingerprints() {
     local files; files=$(git diff --cached --name-only)
     [[ -n "$files" ]] || return 0
-    local findings="$PROJECT_ROOT/data/watcher/findings.jsonl"
+    local findings; findings=$(watcher_findings_file)
     [[ -f "$findings" ]] || return 0
     awk -v root="$PROJECT_ROOT" '{print root"/"$0}' <<< "$files" \
         | python3 "$PROJECT_ROOT/scripts/dev/_ship_watcher_fingerprints.py" "$findings"

--- a/tests/test_ship_workflow.py
+++ b/tests/test_ship_workflow.py
@@ -84,6 +84,34 @@ def ship_plan(repo: Path, *options: str) -> dict[str, str]:
     return parsed
 
 
+def write_watcher_finding(findings: Path, repo: Path, relative_path: str, fp: str) -> None:
+    findings.parent.mkdir(parents=True, exist_ok=True)
+    findings.write_text(
+        json.dumps(
+            {
+                "file": str(repo / relative_path),
+                "fingerprint": fp,
+                "status": "surfaced",
+            }
+        )
+        + "\n"
+    )
+
+
+def run_direct_ship(repo: Path, *, env: dict[str, str]) -> tuple[str, str]:
+    result = run(
+        [
+            str(repo / "scripts" / "dev" / "ship.sh"),
+            "--direct",
+            "test: change",
+        ],
+        repo,
+        env=env,
+    )
+    message = run(["git", "log", "-1", "--format=%B"], repo).stdout
+    return result.stdout, message
+
+
 def test_auto_routes_runtime_changes_to_draft_pr_branch(ship_repo: Path) -> None:
     stage_file(ship_repo, "src/mcp_server.py")
 
@@ -173,32 +201,62 @@ def test_direct_ship_reads_shared_watcher_dir_for_commit_trailer(
     stage_file(ship_repo, "agents/foo.py")
 
     watcher_dir = tmp_path / "watcher"
-    watcher_dir.mkdir()
-    (watcher_dir / "findings.jsonl").write_text(
-        json.dumps(
-            {
-                "file": str(ship_repo / "agents" / "foo.py"),
-                "fingerprint": "abc123",
-                "status": "surfaced",
-            }
-        )
-        + "\n"
+    write_watcher_finding(
+        watcher_dir / "findings.jsonl",
+        ship_repo,
+        "agents/foo.py",
+        "abc123",
     )
 
     env = {
         **os.environ,
         "UNITARES_WATCHER_DATA_DIR": str(watcher_dir),
     }
-    result = run(
-        [
-            str(ship_repo / "scripts" / "dev" / "ship.sh"),
-            "--direct",
-            "test: change",
-        ],
-        ship_repo,
-        env=env,
-    )
-    message = run(["git", "log", "-1", "--format=%B"], ship_repo).stdout
+    stdout, message = run_direct_ship(ship_repo, env=env)
 
-    assert "[ship] appended Watcher-Findings trailer: abc123" in result.stdout
+    assert "[ship] appended Watcher-Findings trailer: abc123" in stdout
     assert "Watcher-Findings: abc123" in message
+
+
+def test_direct_ship_reads_default_shared_watcher_dir_for_commit_trailer(
+    ship_repo: Path,
+    tmp_path: Path,
+) -> None:
+    stage_file(ship_repo, "agents/default_path.py")
+
+    home = tmp_path / "home"
+    write_watcher_finding(
+        home / ".unitares" / "watcher" / "findings.jsonl",
+        ship_repo,
+        "agents/default_path.py",
+        "default123",
+    )
+
+    env = {**os.environ, "HOME": str(home)}
+    env.pop("UNITARES_WATCHER_DATA_DIR", None)
+    stdout, message = run_direct_ship(ship_repo, env=env)
+
+    assert "[ship] appended Watcher-Findings trailer: default123" in stdout
+    assert "Watcher-Findings: default123" in message
+
+
+def test_direct_ship_falls_back_to_legacy_watcher_dir_for_commit_trailer(
+    ship_repo: Path,
+    tmp_path: Path,
+) -> None:
+    stage_file(ship_repo, "agents/legacy_path.py")
+
+    home = tmp_path / "home-without-shared-state"
+    write_watcher_finding(
+        ship_repo / "data" / "watcher" / "findings.jsonl",
+        ship_repo,
+        "agents/legacy_path.py",
+        "legacy123",
+    )
+
+    env = {**os.environ, "HOME": str(home)}
+    env.pop("UNITARES_WATCHER_DATA_DIR", None)
+    stdout, message = run_direct_ship(ship_repo, env=env)
+
+    assert "[ship] appended Watcher-Findings trailer: legacy123" in stdout
+    assert "Watcher-Findings: legacy123" in message

--- a/tests/test_ship_workflow.py
+++ b/tests/test_ship_workflow.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import os
 import shutil
 import stat
 import subprocess
@@ -12,12 +14,21 @@ import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 SHIP_SOURCE = PROJECT_ROOT / "scripts" / "dev" / "ship.sh"
+SHIP_WATCHER_HELPER_SOURCE = (
+    PROJECT_ROOT / "scripts" / "dev" / "_ship_watcher_fingerprints.py"
+)
 
 
-def run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+def run(
+    args: list[str],
+    cwd: Path,
+    *,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         args,
         cwd=cwd,
+        env=env,
         text=True,
         capture_output=True,
         check=True,
@@ -31,6 +42,10 @@ def ship_repo(tmp_path: Path) -> Path:
     script_path.parent.mkdir(parents=True)
     shutil.copy2(SHIP_SOURCE, script_path)
     script_path.chmod(script_path.stat().st_mode | stat.S_IXUSR)
+    shutil.copy2(
+        SHIP_WATCHER_HELPER_SOURCE,
+        script_path.parent / "_ship_watcher_fingerprints.py",
+    )
 
     run(["git", "init", "-q", "-b", "main"], repo)
     run(["git", "config", "user.email", "t@t"], repo)
@@ -39,6 +54,11 @@ def ship_repo(tmp_path: Path) -> Path:
     (repo / "README.md").write_text("seed\n")
     run(["git", "add", "README.md"], repo)
     run(["git", "commit", "-q", "-m", "seed"], repo)
+
+    origin = tmp_path / "origin.git"
+    run(["git", "init", "--bare", "-q", str(origin)], tmp_path)
+    run(["git", "remote", "add", "origin", str(origin)], repo)
+    run(["git", "push", "-q", "-u", "origin", "main"], repo)
     return repo
 
 
@@ -50,7 +70,12 @@ def stage_file(repo: Path, relative_path: str) -> None:
 
 
 def ship_plan(repo: Path, *options: str) -> dict[str, str]:
-    cmd = [str(repo / "scripts" / "dev" / "ship.sh"), "--plan", *options, "test: change"]
+    cmd = [
+        str(repo / "scripts" / "dev" / "ship.sh"),
+        "--plan",
+        *options,
+        "test: change",
+    ]
     result = run(cmd, repo)
     parsed: dict[str, str] = {}
     for line in result.stdout.splitlines():
@@ -139,3 +164,41 @@ def test_stage_all_plan_classifies_dirty_worktree_without_staging(ship_repo: Pat
     staged = run(["git", "diff", "--cached", "--name-only"], ship_repo)
     assert "?? src/" in status.stdout
     assert staged.stdout == ""
+
+
+def test_direct_ship_reads_shared_watcher_dir_for_commit_trailer(
+    ship_repo: Path,
+    tmp_path: Path,
+) -> None:
+    stage_file(ship_repo, "agents/foo.py")
+
+    watcher_dir = tmp_path / "watcher"
+    watcher_dir.mkdir()
+    (watcher_dir / "findings.jsonl").write_text(
+        json.dumps(
+            {
+                "file": str(ship_repo / "agents" / "foo.py"),
+                "fingerprint": "abc123",
+                "status": "surfaced",
+            }
+        )
+        + "\n"
+    )
+
+    env = {
+        **os.environ,
+        "UNITARES_WATCHER_DATA_DIR": str(watcher_dir),
+    }
+    result = run(
+        [
+            str(ship_repo / "scripts" / "dev" / "ship.sh"),
+            "--direct",
+            "test: change",
+        ],
+        ship_repo,
+        env=env,
+    )
+    message = run(["git", "log", "-1", "--format=%B"], ship_repo).stdout
+
+    assert "[ship] appended Watcher-Findings trailer: abc123" in result.stdout
+    assert "Watcher-Findings: abc123" in message


### PR DESCRIPTION
Re-delivers the Watcher/ship.sh fix against current master and includes the added regression coverage for the default shared watcher path plus legacy fallback.\n\nCommits:\n- d64070e9 fix(ship): read shared watcher findings\n- dcdcd85b test(ship): cover watcher findings path fallbacks\n\nValidation:\n- pytest -q tests/test_ship_workflow.py tests/test_ship_watcher_fingerprints.py\n- ./scripts/dev/test-cache.sh\n- ./scripts/dev/test-cache.sh --staged\n- ship.sh pre-push smoke