### PR TITLE
docs(ontology): flag plan.md's archived citations as intentional, not broken

### DIFF
--- a/docs/ontology/plan.md
+++ b/docs/ontology/plan.md
@@ -8,6 +8,8 @@
 
 **Reading order:** the **Status board** directly below is the live, scannable view of every row. The **Ledger** further down is the *history of record* — its cells carry the full decision trail, including withdrawn options and reversals, and are intentionally dense. Read the board first; drill into a ledger row only when you need the trail.
 
+**Archived citations (not broken links):** some specs cited below by filename were moved to the operator's private archive on 2026-05-21 and are intentionally *not* in this folder — the ledger keeps the citation as the historical record. As of this writing the dangling ontology citations are `r5-memory-deepening-reality.md`, `s7-kg-provenance-lineage-schema.md`, `s11a-skill-text-drift.md`, `s20-cache-scope-narrowing.md`, and `s21b-items-5-6-council-review-2026-04-30.md`; `docs/handoffs/*` snapshots are gitignored (operator-local) and likewise absent in a clone. If a cited path 404s, it is archived, not lost — see the canonical inventory in [`README.md`](README.md) § "Operator-archived docs" (do not re-add the files here without an operator decision).
+
 ---
 
 ## Status board (as of 2026-06-14)


### PR DESCRIPTION
## Why

Follow-up to #728. The second locatable piece of convolution in the ontology docs: `plan.md` cites several spec/handoff filenames that no longer exist in the tree, so a fresh reader following one hits a 404 and can't tell *archived-by-design* from *lost*. Verified the actual dangling set:

- **Archived to the operator's private archive (2026-05-21):** `r5-memory-deepening-reality.md`, `s7-kg-provenance-lineage-schema.md`, `s11a-skill-text-drift.md`, `s20-cache-scope-narrowing.md`, `s21b-items-5-6-council-review-2026-04-30.md`
- **Gitignored (operator-local provenance):** the two `docs/handoffs/*` snapshots
- **Not a citation:** `s11-consolidation.md` is an `e.g.,` placeholder in the handoff template — left untouched

## What changed (docs only, +2 lines)

One orientation note near the top of `plan.md`. It does **not** remove or rewrite any citation — the README is explicit that the ledger keeps them as the historical record. The note tells a reader that a 404 means archived, lists the currently-dangling paths, and points to the **canonical** inventory in `README.md` § "Operator-archived docs" rather than duplicating it (so there's no second list to drift).

## Scope

No code, no behavior change. With this, the navigability convolution I diagnosed is addressed end-to-end: live state buried under the ledger (#728) and dangling-by-design citations (here). The remaining item — the three-layer hook split — lives in the `unitares-governance-plugin` repo, outside this session's scope.

https://claude.ai/code/session_018QeUv4gwYN6kdyEEm4p6kC

---
_Generated by [Claude Code](https://claude.ai/code/session_018QeUv4gwYN6kdyEEm4p6kC)_