### PR TITLE
feat: add resident supervised invocation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@ How to run this in production. Most readers can skip these.
 - [`lease-plane-operator-runbook.md`](operations/lease-plane-operator-runbook.md) — Elixir lease-plane operations
 - [`branch-hygiene-runbook.md`](operations/branch-hygiene-runbook.md) — resident branch-hygiene sweep (`agents/vigil_hygiene`)
 - [`resident-validation-cohort.md`](operations/resident-validation-cohort.md) — experimental long-running resident validation tick contract
+- [`resident-validation-supervised-invocation.md`](operations/resident-validation-supervised-invocation.md) — local-only supervised canary invocation wrapper
 - [`DATA_NOTES.md`](operations/DATA_NOTES.md) — operational data dictionary for the production governance database
 - [`DEPLOYMENT_DATA_CAVEAT.md`](operations/DEPLOYMENT_DATA_CAVEAT.md) — what the cited deployment numbers do and don't mean
 

--- a/docs/operations/resident-validation-supervised-invocation.md
+++ b/docs/operations/resident-validation-supervised-invocation.md
@@ -1,0 +1,86 @@
+# Resident Validation Supervised Invocation
+
+**Created:** June 14, 2026
+**Last Updated:** June 14, 2026
+**Status:** Experimental
+
+---
+
+## Purpose
+
+The supervised invocation layer turns the resident validation canary runner into a
+safe recurring-call target for cron, launchd, or a future BEAM/Plexus
+supervisor. It is still intentionally non-actuating: it appends local JSONL tick
+state and a local invocation audit row, but it does not submit UNITARES process
+updates, open GitHub issues, request dialectic, merge, deploy, force-push, or
+roll back anything.
+
+This is the layer between:
+
+1. the one-tick measurement contract (`resident_validation_tick`),
+2. the stateful local canary stream (`resident_validation_canary`), and
+3. a future durable runtime supervisor with leases, revocation, outcome events,
+   and governed-effect custody.
+
+## What it owns
+
+`scripts/diagnostics/resident_validation_supervised_invocation.py` owns only:
+
+- a local lock file so overlapping invocations do not run concurrently,
+- a per-run maximum tick count,
+- local tick JSONL append through `resident_validation_runner`,
+- a local invocation audit JSONL row,
+- a privacy-safe stdout acknowledgement for scheduler logs.
+
+The public stdout shape is deliberately constant:
+
+```json
+{"event_type":"resident_validation_supervised_invocation","status":"state_appended"}
+```
+
+If the local lock is held, stdout remains non-sensitive and the process exits
+with `75` (`EX_TEMPFAIL`-style retry hint):
+
+```json
+{"event_type":"resident_validation_supervised_invocation","status":"lock_held"}
+```
+
+## What it does not own
+
+This layer does not own durable governance truth. UNITARES remains responsible
+for identity, EISV trajectory, KG, dialectic, calibration, and outcome records.
+A later adapter may submit selected local tick/audit rows through governed write
+paths, but this CLI does not do that itself.
+
+It also does not own hot runtime governance beyond the local lock. BEAM/Plexus
+remains the future home for supervised processes, leases, revocation, and
+governed-effect custody.
+
+## Smoke command
+
+```bash
+python3 scripts/diagnostics/resident_validation_supervised_invocation.py \
+  --cohort-id rv-2026-06 \
+  --resident-id resident-dogfood-1 \
+  --resident-name 'Resident Dogfood Canary' \
+  --role dogfood_probe \
+  --cadence-seconds 600 \
+  --observation 'No actionable friction observed.' \
+  --prediction 'Next supervised tick remains bounded and non-mutating.' \
+  --confidence 0.72 \
+  --count 1 \
+  --max-ticks-per-run 1 \
+  --state-path data/resident_validation/canary.jsonl \
+  --lock-path data/resident_validation/supervised.lock.json \
+  --audit-path data/resident_validation/supervised_invocations.jsonl
+```
+
+## Scheduler boundary
+
+A scheduler may call this CLI on a cadence, but the scheduler is not itself the
+resident. The resident identity is the profile named in the tick stream; the
+scheduler is only the timer/process harness.
+
+Recommended initial cadence is conservative, for example 10-15 minutes, until
+there is enough tick history to evaluate continuity and calibration without
+creating noisy local state.

--- a/scripts/diagnostics/resident_validation_supervised_invocation.py
+++ b/scripts/diagnostics/resident_validation_supervised_invocation.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Run one supervised resident-validation canary invocation.
+
+This CLI is the safe cron/launchd/BEAM handoff surface for resident validation:
+it acquires a local invocation lock, appends bounded canary ticks to JSONL,
+records a local audit event, and prints only a constant non-sensitive status.
+It does not submit UNITARES writes, open issues, request dialectic, deploy,
+merge, or roll back anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.resident_validation import ResidentProfile  # noqa: E402
+from src.resident_validation_invocation import (  # noqa: E402
+    INVOCATION_EVENT_TYPE,
+    InvocationLockHeld,
+    SupervisedInvocationPlan,
+    run_supervised_canary_invocation,
+)
+
+
+def _parse_observed_at(value: str | None) -> datetime | None:
+    """Parse an ISO timestamp, accepting a trailing Z for UTC."""
+    if value is None:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the supervised invocation CLI parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cohort-id", required=True)
+    parser.add_argument("--resident-id", required=True)
+    parser.add_argument("--resident-name", required=True)
+    parser.add_argument(
+        "--role",
+        required=True,
+        choices=("dogfood_probe", "steward", "builder", "reviewer"),
+    )
+    parser.add_argument("--cadence-seconds", required=True, type=int)
+    parser.add_argument(
+        "--observation-scope",
+        default="repo,ci,kg,dialectic",
+        help="Comma-separated observation scopes for this resident.",
+    )
+    parser.add_argument("--observation", required=True)
+    parser.add_argument("--prediction", required=True)
+    parser.add_argument("--confidence", required=True, type=float)
+    parser.add_argument("--observed-at", default=None)
+    parser.add_argument("--count", type=int, default=1)
+    parser.add_argument("--max-ticks-per-run", type=int, default=1)
+    parser.add_argument("--lock-ttl-seconds", type=int, default=300)
+    parser.add_argument(
+        "--state-path",
+        type=Path,
+        default=Path("data/resident_validation/canary.jsonl"),
+    )
+    parser.add_argument(
+        "--lock-path",
+        type=Path,
+        default=Path("data/resident_validation/supervised.lock.json"),
+    )
+    parser.add_argument(
+        "--audit-path",
+        type=Path,
+        default=Path("data/resident_validation/supervised_invocations.jsonl"),
+    )
+    return parser
+
+
+def _print_summary(status: str) -> None:
+    """Print the public non-sensitive summary shape."""
+    print(
+        json.dumps(
+            {"event_type": INVOCATION_EVENT_TYPE, "status": status},
+            sort_keys=True,
+        )
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run one supervised resident-validation canary invocation."""
+    args = build_parser().parse_args(argv)
+    scope = tuple(
+        part.strip() for part in args.observation_scope.split(",") if part.strip()
+    )
+    profile = ResidentProfile(
+        cohort_id=args.cohort_id,
+        resident_id=args.resident_id,
+        resident_name=args.resident_name,
+        role=args.role,
+        cadence_seconds=args.cadence_seconds,
+        observation_scope=scope,
+    )
+    plan = SupervisedInvocationPlan(
+        profile=profile,
+        state_path=args.state_path,
+        lock_path=args.lock_path,
+        audit_path=args.audit_path,
+        max_ticks_per_run=args.max_ticks_per_run,
+        lock_ttl_seconds=args.lock_ttl_seconds,
+    )
+    try:
+        summary = run_supervised_canary_invocation(
+            plan,
+            count=args.count,
+            observation=args.observation,
+            prediction=args.prediction,
+            confidence=args.confidence,
+            now=_parse_observed_at(args.observed_at),
+        )
+    except InvocationLockHeld:
+        _print_summary("lock_held")
+        return 75
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/resident_validation_invocation.py
+++ b/src/resident_validation_invocation.py
@@ -1,0 +1,204 @@
+"""Supervised local invocation layer for resident validation canaries.
+
+This module is the first runtime wrapper above the stateful canary runner. It
+adds a small file lease, per-run tick bounds, and a local invocation audit
+stream. It deliberately does not submit UNITARES process updates, open GitHub
+issues, request dialectic, deploy, merge, or roll back anything.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from src.resident_validation import ResidentProfile
+from src.resident_validation_runner import build_canary_ticks
+
+LOCAL_OUTPUTS = frozenset({"local_state_jsonl", "local_invocation_audit_jsonl"})
+DEFAULT_ALLOWED_OUTPUTS = ("local_state_jsonl", "local_invocation_audit_jsonl")
+FORBIDDEN_OUTPUTS = frozenset(
+    {
+        "unitares_process_update",
+        "kg_note",
+        "dialectic_request",
+        "github_issue",
+        "deploy",
+        "merge",
+        "force_push",
+        "rollback",
+    }
+)
+INVOCATION_EVENT_TYPE = "resident_validation_supervised_invocation"
+
+
+class InvocationLockHeld(RuntimeError):
+    """Raised when a live supervised invocation lock already exists."""
+
+
+@dataclass(frozen=True)
+class SupervisedInvocationPlan:
+    """Local-only supervision settings for one resident canary invocation."""
+
+    profile: ResidentProfile
+    state_path: Path
+    lock_path: Path
+    audit_path: Path
+    max_ticks_per_run: int = 1
+    lock_ttl_seconds: int = 300
+    allowed_outputs: tuple[str, ...] = field(default=DEFAULT_ALLOWED_OUTPUTS)
+
+    def __post_init__(self) -> None:
+        """Validate that this layer remains local-only and bounded."""
+        if self.max_ticks_per_run <= 0:
+            raise ValueError("max_ticks_per_run must be positive")
+        if self.lock_ttl_seconds <= 0:
+            raise ValueError("lock_ttl_seconds must be positive")
+        outputs = set(self.allowed_outputs)
+        if outputs != LOCAL_OUTPUTS or outputs & FORBIDDEN_OUTPUTS:
+            raise ValueError(
+                "resident validation supervised invocation is local-only; "
+                "allowed_outputs must be local_state_jsonl and "
+                "local_invocation_audit_jsonl"
+            )
+
+
+def _ensure_utc(dt: datetime | None) -> datetime:
+    """Normalize optional datetimes to timezone-aware UTC."""
+    if dt is None:
+        return datetime.now(timezone.utc)
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _parse_timestamp(value: str) -> datetime:
+    """Parse an ISO timestamp and normalize it to UTC."""
+    return _ensure_utc(datetime.fromisoformat(value.replace("Z", "+00:00")))
+
+
+def _read_lock(lock_path: Path) -> dict[str, Any] | None:
+    """Read an invocation lock file if one exists."""
+    if not lock_path.exists():
+        return None
+    return json.loads(lock_path.read_text(encoding="utf-8"))
+
+
+def _lock_is_live(record: dict[str, Any], now: datetime) -> bool:
+    """Return true when a lock record has not reached its expiry."""
+    expires_at = record.get("expires_at")
+    if not isinstance(expires_at, str):
+        return True
+    return _parse_timestamp(expires_at) > now
+
+
+def acquire_invocation_lock(
+    lock_path: Path,
+    *,
+    owner: str,
+    now: datetime | None = None,
+    ttl_seconds: int = 300,
+) -> dict[str, Any]:
+    """Acquire or refresh an expired local invocation lock."""
+    if ttl_seconds <= 0:
+        raise ValueError("ttl_seconds must be positive")
+    if not owner.strip():
+        raise ValueError("owner is required")
+    observed_at = _ensure_utc(now)
+    existing = _read_lock(lock_path)
+    if existing is not None and _lock_is_live(existing, observed_at):
+        raise InvocationLockHeld("resident validation invocation lock is held")
+
+    record = {
+        "event_type": "resident_validation_invocation_lock",
+        "owner": owner,
+        "acquired_at": observed_at.isoformat(),
+        "expires_at": (observed_at + timedelta(seconds=ttl_seconds)).isoformat(),
+    }
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text(json.dumps(record, sort_keys=True) + "\n", encoding="utf-8")
+    return record
+
+
+def release_invocation_lock(lock_path: Path, *, owner: str) -> None:
+    """Release a local invocation lock when it is still owned by ``owner``."""
+    record = _read_lock(lock_path)
+    if record is None:
+        return
+    if record.get("owner") == owner:
+        lock_path.unlink(missing_ok=True)
+
+
+def _append_audit(audit_path: Path, event: dict[str, Any]) -> None:
+    """Append one invocation event to a local JSONL audit stream."""
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+    with audit_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, sort_keys=True) + "\n")
+
+
+def _safe_summary(status: str) -> dict[str, str]:
+    """Return the public non-sensitive invocation summary shape."""
+    return {"event_type": INVOCATION_EVENT_TYPE, "status": status}
+
+
+def run_supervised_canary_invocation(
+    plan: SupervisedInvocationPlan,
+    *,
+    count: int,
+    observation: str,
+    prediction: str,
+    confidence: float,
+    now: datetime | None = None,
+) -> dict[str, str]:
+    """Run one bounded resident canary invocation under a local lock.
+
+    Raw observations and predictions are written only to the configured local
+    state stream by ``build_canary_ticks``. The returned summary is intentionally
+    constant so cron/launchd logs do not become a private data surface.
+    """
+    if count <= 0:
+        raise ValueError("count must be positive")
+    if count > plan.max_ticks_per_run:
+        raise ValueError("count exceeds max_ticks_per_run")
+
+    observed_at = _ensure_utc(now)
+    owner = f"{plan.profile.cohort_id}:{plan.profile.resident_id}"
+    acquire_invocation_lock(
+        plan.lock_path,
+        owner=owner,
+        now=observed_at,
+        ttl_seconds=plan.lock_ttl_seconds,
+    )
+    try:
+        ticks = build_canary_ticks(
+            plan.profile,
+            state_path=plan.state_path,
+            count=count,
+            observation=observation,
+            prediction=prediction,
+            confidence=confidence,
+            now=observed_at,
+        )
+        audit_event = {
+            "event_type": INVOCATION_EVENT_TYPE,
+            "status": "state_appended",
+            "cohort_id": plan.profile.cohort_id,
+            "resident": {
+                "id": plan.profile.resident_id,
+                "role": plan.profile.role,
+            },
+            "observed_at": observed_at.isoformat(),
+            "tick_count": len(ticks),
+            "first_tick_index": ticks[0]["tick_index"],
+            "last_tick_index": ticks[-1]["tick_index"],
+            "authority": {
+                "allowed_outputs": list(plan.allowed_outputs),
+                "write_authority": False,
+            },
+        }
+        _append_audit(plan.audit_path, audit_event)
+        return _safe_summary("state_appended")
+    finally:
+        release_invocation_lock(plan.lock_path, owner=owner)

--- a/tests/test_resident_validation_invocation.py
+++ b/tests/test_resident_validation_invocation.py
@@ -1,0 +1,196 @@
+"""Supervised resident validation invocation tests."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from src.resident_validation import ResidentProfile
+from src.resident_validation_invocation import (
+    InvocationLockHeld,
+    SupervisedInvocationPlan,
+    acquire_invocation_lock,
+    run_supervised_canary_invocation,
+)
+
+
+def _profile() -> ResidentProfile:
+    """Build a low-authority resident profile for invocation tests."""
+    return ResidentProfile(
+        cohort_id="rv-supervised",
+        resident_id="resident-dogfood-1",
+        resident_name="Resident Dogfood Canary",
+        role="dogfood_probe",
+        cadence_seconds=600,
+        observation_scope=("repo", "ci"),
+    )
+
+
+def test_invocation_lock_rejects_live_holder_and_allows_expired_lock(
+    tmp_path: Path,
+) -> None:
+    """A supervised invocation lease blocks concurrent live runs but expires."""
+    lock_path = tmp_path / "resident.lock.json"
+    now = datetime.now(timezone.utc)
+
+    first = acquire_invocation_lock(
+        lock_path,
+        owner="resident-dogfood-1",
+        now=now,
+        ttl_seconds=60,
+    )
+
+    assert first["owner"] == "resident-dogfood-1"
+    with pytest.raises(InvocationLockHeld):
+        acquire_invocation_lock(
+            lock_path,
+            owner="resident-dogfood-2",
+            now=now + timedelta(seconds=1),
+            ttl_seconds=60,
+        )
+
+    refreshed = acquire_invocation_lock(
+        lock_path,
+        owner="resident-dogfood-2",
+        now=now + timedelta(seconds=61),
+        ttl_seconds=60,
+    )
+
+    assert refreshed["owner"] == "resident-dogfood-2"
+    assert json.loads(lock_path.read_text(encoding="utf-8"))["owner"] == (
+        "resident-dogfood-2"
+    )
+
+
+def test_invocation_plan_is_local_only_and_rejects_write_authority(
+    tmp_path: Path,
+) -> None:
+    """The supervisor layer may write local state/audit only, not UNITARES/GitHub."""
+    with pytest.raises(ValueError, match="local-only"):
+        SupervisedInvocationPlan(
+            profile=_profile(),
+            state_path=tmp_path / "ticks.jsonl",
+            lock_path=tmp_path / "resident.lock.json",
+            audit_path=tmp_path / "invocations.jsonl",
+            allowed_outputs=("local_state_jsonl", "unitares_process_update"),
+        )
+
+
+def test_supervised_invocation_appends_ticks_audit_and_releases_lock(
+    tmp_path: Path,
+) -> None:
+    """A bounded supervised run records local state and audit, then releases lock."""
+    plan = SupervisedInvocationPlan(
+        profile=_profile(),
+        state_path=tmp_path / "ticks.jsonl",
+        lock_path=tmp_path / "resident.lock.json",
+        audit_path=tmp_path / "invocations.jsonl",
+        max_ticks_per_run=2,
+    )
+    now = datetime.now(timezone.utc)
+
+    result = run_supervised_canary_invocation(
+        plan,
+        count=2,
+        observation="Private observation stays in local state only.",
+        prediction="Next supervised tick remains non-mutating.",
+        confidence=0.72,
+        now=now,
+    )
+
+    assert result == {
+        "event_type": "resident_validation_supervised_invocation",
+        "status": "state_appended",
+    }
+    assert not plan.lock_path.exists()
+    ticks = [
+        json.loads(line)
+        for line in plan.state_path.read_text(encoding="utf-8").splitlines()
+    ]
+    audits = [
+        json.loads(line)
+        for line in plan.audit_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert [tick["tick_index"] for tick in ticks] == [1, 2]
+    assert audits[-1]["tick_count"] == 2
+    assert audits[-1]["authority"] == {
+        "allowed_outputs": ["local_state_jsonl", "local_invocation_audit_jsonl"],
+        "write_authority": False,
+    }
+
+    with pytest.raises(ValueError, match="max_ticks_per_run"):
+        run_supervised_canary_invocation(
+            plan,
+            count=3,
+            observation="Still bounded.",
+            prediction="Still local-only.",
+            confidence=0.7,
+            now=now,
+        )
+
+
+def test_supervised_invocation_cli_stdout_is_constant_and_non_sensitive(
+    tmp_path: Path,
+) -> None:
+    """The CLI can be run by cron/launchd without leaking private tick content."""
+    state_path = tmp_path / "resident-canary.jsonl"
+    lock_path = tmp_path / "resident.lock.json"
+    audit_path = tmp_path / "invocations.jsonl"
+    script = Path("scripts/diagnostics/resident_validation_supervised_invocation.py")
+    private_observation = "Private observation: token-like material stays local."
+    private_prediction = "Private prediction: local context should not hit stdout."
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--cohort-id",
+            "rv-supervised",
+            "--resident-id",
+            "resident-dogfood-1",
+            "--resident-name",
+            "Resident Dogfood Canary",
+            "--role",
+            "dogfood_probe",
+            "--cadence-seconds",
+            "600",
+            "--observation",
+            private_observation,
+            "--prediction",
+            private_prediction,
+            "--confidence",
+            "0.72",
+            "--state-path",
+            str(state_path),
+            "--lock-path",
+            str(lock_path),
+            "--audit-path",
+            str(audit_path),
+            "--count",
+            "2",
+            "--max-ticks-per-run",
+            "2",
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert json.loads(completed.stdout) == {
+        "event_type": "resident_validation_supervised_invocation",
+        "status": "state_appended",
+    }
+    assert private_observation not in completed.stdout
+    assert private_prediction not in completed.stdout
+    assert "resident-dogfood-1" not in completed.stdout
+    assert str(state_path) not in completed.stdout
+    assert len(state_path.read_text(encoding="utf-8").splitlines()) == 2
+    assert len(audit_path.read_text(encoding="utf-8").splitlines()) == 1


### PR DESCRIPTION
## Summary
- add a local-only supervised resident validation invocation module with file-lock lease, max-tick bound, local state append, and local invocation audit JSONL
- add a scheduler-facing CLI that prints only a constant non-sensitive status for cron/launchd/BEAM logs
- document the boundary between canary invocation, UNITARES durable governance truth, and future BEAM/Plexus supervision

## Boundary
- Does not submit UNITARES `process_agent_update` or outcome writes
- Does not open GitHub issues, request dialectic, merge, deploy, force-push, or roll back
- Scheduler/cron/launchd is only the timer; the resident identity remains the profile in the tick stream

## Verification
- TDD red: `tests/test_resident_validation_invocation.py` initially failed with `ModuleNotFoundError: No module named 'src.resident_validation_invocation'`
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 -m pytest -o addopts= tests/test_resident_validation_cohort.py tests/test_resident_validation_runner.py tests/test_resident_validation_invocation.py -q` → `12 passed`
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 -m ruff check src/resident_validation_invocation.py scripts/diagnostics/resident_validation_supervised_invocation.py tests/test_resident_validation_invocation.py` → `All checks passed!`
- CLI smoke wrote 1 local tick row and 1 local invocation audit row while stdout stayed constant
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 ./scripts/dev/test-cache.sh --staged` → `9872 passed, 21 skipped, 2 warnings`, coverage `80.75%`
- After rebasing onto latest `origin/master`: focused tests and Ruff passed again
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 ./scripts/dev/test-cache.sh` → `9872 passed, 21 skipped, 2 warnings`, coverage `80.73%`
