### PR TITLE
docs(skills): document full margin enum + nearest_edge (#733)

### DIFF
--- a/skills/governance-fundamentals/SKILL.md
+++ b/skills/governance-fundamentals/SKILL.md
@@ -4,12 +4,13 @@ description: >
   Use when an agent needs to understand UNITARES governance concepts — EISV state vectors,
   basins, verdicts, coherence, calibration. Reference material for interpreting governance
   metrics and understanding the thermodynamic model.
-last_verified: "2026-06-11"
+last_verified: "2026-06-15"
 freshness_days: 14
 source_files:
   - unitares/config/governance_config.py
   - unitares/src/auto_ground_truth.py
   - unitares/src/governance_monitor.py
+  - unitares/src/monitor_decision.py
   - unitares/src/mcp_handlers/core.py
 ---
 
@@ -62,7 +63,19 @@ Governance issues a decision after each check-in. The response's `verdict` field
 
 Separately, `metrics.verdict` carries the internal UNITARES verdict from phi scoring — `safe` / `caution` / `high-risk`. It drives the decision above; read it as context, not as the action itself.
 
-A `margin: tight` flag means you are near a basin edge. Be more careful with next steps.
+### Margin
+
+`margin` describes how much headroom you have before the nearest state-space edge. It is a small enum, not a number:
+
+| `margin` | Meaning | What to do |
+|----------|---------|------------|
+| `settling` | Warmup — fewer than 3 check-ins, so there is not enough history to judge headroom yet | Keep checking in; a real margin appears after 3+ check-ins |
+| `comfortable` | Clear of every edge by a healthy distance | Proceed normally |
+| `tight` | Within the edge threshold of the nearest boundary (or in the boundary basin) | Be more careful with next steps; avoid increasing complexity |
+
+When `margin` is `tight`, a companion `nearest_edge` field names which boundary you are closest to — `risk`, `coherence`, or `void`. On `comfortable` and `settling`, `nearest_edge` is `null` (there is no edge to warn about). Prefer the live `margin`/`nearest_edge` values over assuming a fixed enum across runtime versions — `get_governance_metrics()` is the source of truth.
+
+The plain-English `mirror` array in your check-in response already summarizes anything actionable (including a tight margin) — read that first; `margin`/`nearest_edge` are the underlying data behind it.
 
 ## Coherence
 


### PR DESCRIPTION
Addresses the **docs-reconciliation** half of #733 (health-field vocabulary sprawl).

## What

`governance-fundamentals/SKILL.md` documented only `margin: tight`, but the live enum (from `monitor_decision.py` / `governance_config.py`) is:

| `margin` | Meaning |
|----------|---------|
| `settling` | Warmup — <3 check-ins, not enough history to judge headroom |
| `comfortable` | Clear of every edge |
| `tight` | Within the edge threshold (or in the boundary basin) |

The doc now carries the full enum table, documents that `nearest_edge` (∈ `risk`/`coherence`/`void`) is `null` unless margin is tight, and points agents at the plain-English `mirror` array as the first read — with `margin`/`nearest_edge` framed as the underlying data behind it. Refreshes `last_verified` and lists `monitor_decision.py` as a source file.

## What this deliberately does NOT do

The issue also suggests demoting `phi`/`basin`/`void_active`/`nearest_edge` behind `response_mode`. I left that out on purpose, confirmed with the operator:

- Mirror mode **already leads** with the `mirror` array.
- `basin`/`void_active` are **not** in the lean modes (mirror/minimal/compact) — only in `standard`/`full`.
- `phi`/`coherence`/`risk` in mirror are there by a **deliberate 2026-06-10 dogfood decision** (`response_formatter.py:358-367`): without them a mirror-mode agent needs a second `get_governance_metrics()` call to learn its own state. Demoting them would reverse that.

So the remaining "demotion" would contradict a recent intentional choice; flagging rather than silently reversing it.

## Tests

`tests/test_doc_drift.py` + `tests/test_skills_introspection.py`: **15 passed, 10 skipped** (no hardcoded-threshold or config-lookup violations introduced).

Partially addresses #733 (docs half).

https://claude.ai/code/session_01V13oeBP6uwh1iRvNCrFS2Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01V13oeBP6uwh1iRvNCrFS2Z)_