### PR TITLE
fix(watcher): attempt token-less PATH 0 resume under UDS (#727)

### DIFF
--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -220,15 +220,30 @@ def resolve_identity(client) -> None:
     # token explicitly; generic client auto-injection is intentionally token-free.
     if saved.get("agent_uuid"):
         token = saved.get("continuity_token") or getattr(client, "continuity_token", None)
-        if token:
-            if not getattr(client, "continuity_token", None):
-                client.continuity_token = token
+        if token and not getattr(client, "continuity_token", None):
+            client.continuity_token = token
+        # Attempt PATH 0 even when token-less, provided we are UDS-anchored.
+        # A substrate-enrolled resident connecting over UNITARES_UDS_SOCKET
+        # resumes via kernel-attested peer match: the server's S19 PR3e gate
+        # treats the UDS peer credential as ownership proof equivalent to the
+        # continuity_token. The token-only anchor under UDS deliberately drops
+        # the token at rest (anchor-disclosure defense — a leaked token would
+        # otherwise satisfy PATH 0's _partc_owned and bypass peer attestation),
+        # so REQUIRING a token here would make an enrolled resident permanently
+        # unresumable (#727). Pass the token when we have it; otherwise rely on
+        # the server's substrate gate. Over plain HTTP a token-less resume has
+        # no proof channel and the server refuses, so we skip the pointless
+        # round-trip and fall through to the fresh-onboard guard.
+        uds_anchored = bool(os.environ.get("UNITARES_UDS_SOCKET"))
+        if token or uds_anchored:
             try:
-                client.identity(
-                    agent_uuid=saved["agent_uuid"],
-                    continuity_token=token,
-                    resume=True,
-                )
+                identity_kwargs: dict = {
+                    "agent_uuid": saved["agent_uuid"],
+                    "resume": True,
+                }
+                if token:
+                    identity_kwargs["continuity_token"] = token
+                client.identity(**identity_kwargs)
                 _sync_identity(client)
                 return
             except GovernanceTimeoutError as e:
@@ -240,7 +255,12 @@ def resolve_identity(client) -> None:
             except Exception as e:
                 log(f"uuid-direct resume failed: {e}", "warning")
         else:
-            log("uuid-direct resume skipped: missing continuity_token ownership proof", "warning")
+            log(
+                "uuid-direct resume skipped: no continuity_token and not UDS-anchored "
+                "(set UNITARES_UDS_SOCKET so a substrate-enrolled resident can resume "
+                "via kernel-attested peer match)",
+                "warning",
+            )
 
     # Step 1: Fresh onboard — only when no proof-owned UUID rebind works.
     # Silent-fork guard (added 2026-04-19 anchor-resilience series): Watcher

--- a/agents/watcher/tests/test_refuse_fresh_onboard.py
+++ b/agents/watcher/tests/test_refuse_fresh_onboard.py
@@ -101,3 +101,82 @@ def test_watcher_resume_path_unaffected_by_guard(
 
     assert client.identity_calls == 1
     assert client.onboard_calls == 0
+
+
+# ── #727: token-less UDS anchor must still attempt PATH 0 resume ──
+#
+# A substrate-enrolled resident under UNITARES_UDS_SOCKET deliberately writes
+# a token-less ("uuid_only") anchor. The server's S19 PR3e gate authorizes the
+# resume via kernel-attested peer match, so the client MUST attempt the
+# agent_uuid-direct resume even without a continuity_token. The pre-fix code
+# gated the attempt on token presence and skipped PATH 0 entirely, leaving an
+# enrolled resident permanently stuck-down.
+
+
+class _MockClientNoToken:
+    """Mock client that mirrors a fresh UDS connection: no pre-set token."""
+
+    client_session_id = "sess"
+    continuity_token = None
+    agent_uuid = "uuid"
+
+    def __init__(self):
+        self.onboard_calls = 0
+        self.identity_calls = 0
+        self.last_identity_kwargs = None
+
+    def onboard(self, *a, **kw):
+        self.onboard_calls += 1
+        return type("R", (), {"success": True})()
+
+    def identity(self, **kw):
+        self.identity_calls += 1
+        self.last_identity_kwargs = kw
+        return type("R", (), {"success": True})()
+
+
+def test_watcher_resumes_token_less_anchor_under_uds(
+    watcher_module, monkeypatch, tmp_path
+):
+    """Token-less anchor + UDS-anchored → attempt PATH 0 resume WITHOUT a
+    continuity_token, relying on the server's substrate peer-attestation gate."""
+    import json
+
+    session_file = tmp_path / "watcher.json"
+    session_file.write_text(json.dumps({"agent_uuid": "uuid"}))
+    monkeypatch.setattr(watcher_module, "SESSION_FILE", session_file)
+    monkeypatch.delenv("UNITARES_FIRST_RUN", raising=False)
+    monkeypatch.setenv("UNITARES_UDS_SOCKET", str(tmp_path / "gov.sock"))
+    monkeypatch.setattr(watcher_module, "_watcher_identity", None)
+
+    client = _MockClientNoToken()
+    watcher_module.resolve_identity(client)
+
+    assert client.identity_calls == 1
+    assert client.onboard_calls == 0
+    # Attempted token-free — no continuity_token in the call.
+    assert "continuity_token" not in client.last_identity_kwargs
+    assert client.last_identity_kwargs["agent_uuid"] == "uuid"
+    assert client.last_identity_kwargs["resume"] is True
+
+
+def test_watcher_skips_token_less_anchor_without_uds(
+    watcher_module, monkeypatch, tmp_path
+):
+    """Token-less anchor + NOT UDS-anchored → no proof channel, so PATH 0 is
+    skipped (no pointless round-trip) and the fresh-onboard guard refuses."""
+    import json
+
+    session_file = tmp_path / "watcher.json"
+    session_file.write_text(json.dumps({"agent_uuid": "uuid"}))
+    monkeypatch.setattr(watcher_module, "SESSION_FILE", session_file)
+    monkeypatch.delenv("UNITARES_FIRST_RUN", raising=False)
+    monkeypatch.delenv("UNITARES_UDS_SOCKET", raising=False)
+    monkeypatch.setattr(watcher_module, "_watcher_identity", None)
+
+    client = _MockClientNoToken()
+    watcher_module.resolve_identity(client)
+
+    assert client.identity_calls == 0
+    assert client.onboard_calls == 0
+    assert watcher_module.get_watcher_identity() is None


### PR DESCRIPTION
Fixes the genuinely-live resident-availability defect in #727.

## Diagnosis (refines the issue)

The issue framed this as the SDK + Watcher both being unable to resume from a token-less anchor, with the open question "should `uuid_only_anchor` exist at all?". Tracing the live code, the picture is narrower:

1. **`uuid_only_anchor` is correct and load-bearing.** Dropping the `continuity_token` at rest under UDS is a real defense: a leaked token would satisfy PATH 0's `_partc_owned` check (`handlers.py:715`) and **bypass** the kernel-attested peer match the substrate design requires. So it should stay.
2. **The server already authorizes token-less UDS resume.** The S19 PR3e gate (`_try_resume_by_agent_uuid_direct`, `handlers.py:717-768`) treats a UDS peer-credential match (`verify_substrate_at_resume`) as ownership proof equivalent to the token, for any UUID with a `core.substrate_claims` row.
3. **The SDK already works.** `_ensure_identity` (`agents/sdk/.../agent.py:302-326`) attempts `client.identity(agent_uuid=…, resume=True)` with the token *optional*, so an enrolled UDS resident resumes via the substrate gate.
4. **Watcher was the bug.** Its bespoke `resolve_identity` gated the PATH 0 attempt on having a token (`if token:` … `else: skip`, `agents/watcher/agent.py:221-243`). For a token-less UDS anchor it **never attempted** the resume the server would have accepted, fell through to the fresh-onboard guard, and left an enrolled resident permanently stuck-down (retry loop, never resumes).

## Fix

Watcher now attempts the `agent_uuid`-direct resume whenever it has a token **or** is UDS-anchored, passing the token only when present — mirroring the SDK. Over plain HTTP a token-less resume has no proof channel (server refuses), so that pointless round-trip is still skipped and we fall through to the fresh-onboard guard. Fail-closed posture and `uuid_only_anchor` are untouched.

This answers the issue's open questions: the token-drop **should** exist; the re-acquisition path on restart is the UDS peer-attestation gate, and the defect was the client refusing to use it.

## Tests

`agents/watcher/tests/test_refuse_fresh_onboard.py`:
- token-less anchor + UDS → attempts a **token-free** PATH 0 resume (asserts no `continuity_token` in the call);
- token-less anchor + no UDS → skips PATH 0, fresh-onboard guard refuses.

Watcher + identity-honesty + substrate suites: **282 passed**. (One unrelated failure, `test_hook_input.py::test_extract_regions_works_against_real_repo`, is environment-only — it shells out to `git commit` and the sandbox's commit-signing server returns 400; nothing to do with this change.)

## Note

The SDK's `_ensure_identity` is already correct, so it's untouched. Its one rough edge — a generic "refusing to create ghost" error for a *misconfigured* (UDS-but-not-enrolled) resident — is a diagnostics nicety, not an availability bug; left as a possible follow-up rather than churning the locked SDK surface here.

Closes #727.

https://claude.ai/code/session_01V13oeBP6uwh1iRvNCrFS2Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01V13oeBP6uwh1iRvNCrFS2Z)_