### PR TITLE
fix(mirror): make gaming signals observational, not interrogative (#583)

### DIFF
--- a/src/mcp_handlers/updates/enrichments.py
+++ b/src/mcp_handlers/updates/enrichments.py
@@ -1338,13 +1338,13 @@ def _detect_gaming(ctx: UpdateContext) -> list:
                 variance = statistics.variance(recent)
                 if variance < 0.005:
                     signals.append(
-                        f"Your last {len(recent)} reports had nearly identical complexity "
-                        f"(variance={variance:.4f}). Real work varies -- are you on autopilot?"
+                        f"Your last {len(recent)} complexity reports vary little "
+                        f"(variance={variance:.4f}) — flat enough to read as autopilot."
                     )
             elif len(set(recent)) == 1:
                 signals.append(
-                    f"Your last {len(recent)} complexity reports were all {recent[0]:.2f}. "
-                    "Real work varies -- are you on autopilot?"
+                    f"Your last {len(recent)} complexity reports were all {recent[0]:.2f} — "
+                    "no variance, reads as autopilot."
                 )
 
         # Check confidence history variance
@@ -1356,13 +1356,13 @@ def _detect_gaming(ctx: UpdateContext) -> list:
                     conf_var = statistics.variance(recent_conf)
                     if conf_var < 0.005:
                         signals.append(
-                            f"Your confidence reports show very low variance ({conf_var:.4f}). "
-                            "Are you calibrating each report individually?"
+                            f"Your confidence reports show very low variance ({conf_var:.4f}) — "
+                            "flat across recent check-ins."
                         )
                 elif len(set(recent_conf)) == 1:
                     signals.append(
-                        f"Your last {len(recent_conf)} confidence reports were all {recent_conf[0]:.2f}. "
-                        "Consider calibrating each report individually."
+                        f"Your last {len(recent_conf)} confidence reports were all {recent_conf[0]:.2f} — "
+                        "no variance across check-ins."
                     )
     except Exception as e:
         logger.debug(f"Gaming detection failed: {e}")

--- a/tests/test_enrichments_mirror.py
+++ b/tests/test_enrichments_mirror.py
@@ -116,6 +116,20 @@ class TestDetectGaming:
         assert len(signals) >= 1
         assert any("variance" in s.lower() or "autopilot" in s.lower() for s in signals)
 
+    def test_signals_are_observational_not_interrogative(self):
+        # #583 discipline ("reflect, don't advise") applies to the raw gaming
+        # signals too, not just the distilled reflection: a mirror line states
+        # the fact, it does not interrogate or prescribe.
+        ctx = _make_ctx(
+            complexity_history=[0.5, 0.5, 0.5, 0.5, 0.5],
+            confidence_history=[0.8, 0.8, 0.8, 0.8, 0.8],
+        )
+        signals = _detect_gaming(ctx)
+        assert len(signals) >= 1
+        for s in signals:
+            assert "?" not in s, f"gaming signal is interrogative: {s!r}"
+            assert "consider " not in s.lower(), f"gaming signal prescribes: {s!r}"
+
 
 # ============================================================================
 # _generate_mirror_reflection
@@ -177,7 +191,9 @@ class TestGenerateMirrorReflection:
 
     def test_autopilot_signal_reflects_repetition(self):
         ctx = _make_ctx()
-        reflection = _generate_mirror_reflection(ctx, signals=["Real work varies -- are you on autopilot?"])
+        reflection = _generate_mirror_reflection(
+            ctx, signals=["Your last 5 complexity reports were all 0.50 — no variance, reads as autopilot."]
+        )
         assert reflection is not None
         assert "repetitive" in reflection.lower()
         assert "?" not in reflection


### PR DESCRIPTION
## Context

Scoped out mirror mode (the de-facto default response shape for healthy disembodied agents, `response_formatter.py:100-103`) and found one seam in the **"reflect, don't advise"** discipline shipped in #583.

That discipline is rigorously enforced on the distilled `reflection` line (`_generate_mirror_reflection` is question-free, with a test asserting `"?" not in reflection`). But the raw `_detect_gaming` signal lines — which land directly in the agent-facing `mirror` list — were never cleaned up. They still ended in:

- `"...Real work varies -- are you on autopilot?"` (a question)
- `"...Are you calibrating each report individually?"` (a question)
- `"...Consider calibrating each report individually."` (a prescription)

So the polished rule guarded the reflection but not the signals feeding it — exactly the kind of line #583 set out to remove.

## Change

Rewrite the four gaming signals as flat observations (no `?`, no "consider"), preserving the keywords the reflection matcher keys on (`autopilot`, `variance`, `confidence`) so downstream reflection routing is unchanged:

| before | after |
|---|---|
| `...nearly identical complexity (variance=…). Real work varies -- are you on autopilot?` | `...complexity reports vary little (variance=…) — flat enough to read as autopilot.` |
| `...complexity reports were all X. Real work varies -- are you on autopilot?` | `...complexity reports were all X — no variance, reads as autopilot.` |
| `...very low variance (…). Are you calibrating each report individually?` | `...very low variance (…) — flat across recent check-ins.` |
| `...confidence reports were all X. Consider calibrating each report individually.` | `...confidence reports were all X — no variance across check-ins.` |

Added a regression test (`test_signals_are_observational_not_interrogative`) pinning that detected signals stay observational, and updated `test_autopilot_signal_reflects_repetition` to feed the matcher a realistic question-free string.

## Validation

`tests/test_enrichments_mirror.py` (19), `tests/test_response_formatter.py` (114), `tests/test_enrichment_pipeline.py` (10) — all green locally on Python 3.12.

## Scope note

Pure string/wording + test change; no behavior, signal-routing, or schema change. This is the small fix from the mirror-mode scoping; the larger "measure mirror effectiveness rather than tune by feel" idea was left as a follow-up, not built here.

https://claude.ai/code/session_01JR8iksWN3JUeuEV8htzG1h

---
_Generated by [Claude Code](https://claude.ai/code/session_01JR8iksWN3JUeuEV8htzG1h)_