### PR TITLE
feat(identity): make onboard response_mode default to minimal (#734)

### DIFF
--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -2281,12 +2281,24 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
 
     # STEP 6: Build response
     verbose = coerce_bool(arguments.get("verbose"), default=False)
-    # #734: opt-in lean onboard envelope. Default "full" preserves the
-    # existing response shape for dashboard/plugin consumers; "minimal"
-    # drops the nested identity ontology and verbose extras.
-    response_mode = str(arguments.get("response_mode") or "full").strip().lower()
+    # #734: lean onboard envelope is now the DEFAULT. "minimal" drops the
+    # nested identity ontology (identity_context) and the descriptive extras
+    # (session_resolution_source, continuity_token_supported, date_context),
+    # keeping uuid / agent_id / client_session_id / a single identity_assurance
+    # block / trajectory genesis+trust_tier / lineage flags / continuity_token /
+    # next_step. Callers that need the full self-description pass
+    # response_mode="full". The functional fields the plugin/dashboard rely on
+    # (uuid, client_session_id) are retained in both modes.
+    #
+    # verbose=True is the legacy "give me everything" signal; honor it as full
+    # so existing verbose callers keep the next_calls/session_continuity/
+    # tool_mode/workflow extras (minimal returns before those are built). An
+    # explicit response_mode always wins over the verbose-derived default.
+    response_mode = str(
+        arguments.get("response_mode") or ("full" if verbose else "minimal")
+    ).strip().lower()
     if response_mode not in {"full", "minimal"}:
-        response_mode = "full"
+        response_mode = "full" if verbose else "minimal"
     try:
         from ..context import get_session_resolution_source, get_session_proof_origin
         continuity_source = get_session_resolution_source()

--- a/src/mcp_handlers/schemas/identity.py
+++ b/src/mcp_handlers/schemas/identity.py
@@ -115,13 +115,15 @@ class OnboardParams(AgentIdentityMixin):
         ),
     )
     response_mode: Optional[str] = Field(
-        default="full",
+        default="minimal",
         description=(
-            "Verbosity of the identity envelope. 'full' (default) returns the "
-            "complete identity ontology (identity_context + nested registry/"
-            "label/harness blocks). 'minimal' returns a lean payload — uuid, "
-            "agent_id, session id, a single identity_assurance block, the "
-            "resolution verdict, lineage flags, and a next_step hint."
+            "Verbosity of the identity envelope. 'minimal' (default) returns a "
+            "lean payload — uuid, agent_id, session id, a single "
+            "identity_assurance block, the resolution verdict, lineage flags, "
+            "and a next_step hint. 'full' returns the complete identity "
+            "ontology (identity_context + nested registry/label/harness blocks "
+            "and the descriptive session_resolution_source / "
+            "continuity_token_supported / date_context fields)."
         ),
     )
 

--- a/src/services/identity_payloads.py
+++ b/src/services/identity_payloads.py
@@ -336,6 +336,9 @@ def build_onboard_response_data(
         if was_archived:
             minimal["auto_resumed"] = True
             minimal["previous_status"] = "archived"
+        trajectory_block = _build_trajectory_block(trajectory_result)
+        if trajectory_block is not None:
+            minimal["trajectory"] = trajectory_block
         return minimal
 
     result = {
@@ -422,18 +425,32 @@ def build_onboard_response_data(
         result["auto_resumed"] = True
         result["previous_status"] = "archived"
 
-    if trajectory_result:
-        from src.governance_glossary import explain_trust_tier
-        result["trajectory"] = dict(trajectory_result)
-        # #428: glossary-sourced trust_tier with meaning + criteria.
-        # Preserves prior {tier, name, reason} shape and adds the explanation.
-        result["trajectory"]["trust_tier"] = explain_trust_tier({
-            "tier": 1,
-            "name": "emerging",
-            "reason": "Genesis stored at onboard. Identity will mature with behavioral consistency.",
-        })
+    trajectory_block = _build_trajectory_block(trajectory_result)
+    if trajectory_block is not None:
+        result["trajectory"] = trajectory_block
 
     return result
+
+
+def _build_trajectory_block(trajectory_result: Optional[dict]) -> Optional[dict]:
+    """Build the onboard `trajectory` block (genesis + glossary trust_tier).
+
+    Shared by the minimal and full onboard envelopes so the genesis/trust-tier
+    info an agent sees once at onboard stays identical across modes (#734).
+    Returns ``None`` when there is no trajectory result to surface.
+    """
+    if not trajectory_result:
+        return None
+    from src.governance_glossary import explain_trust_tier
+    block = dict(trajectory_result)
+    # #428: glossary-sourced trust_tier with meaning + criteria.
+    # Preserves prior {tier, name, reason} shape and adds the explanation.
+    block["trust_tier"] = explain_trust_tier({
+        "tier": 1,
+        "name": "emerging",
+        "reason": "Genesis stored at onboard. Identity will mature with behavioral consistency.",
+    })
+    return block
 
 
 def build_identity_response_context(

--- a/tests/test_identity_handlers.py
+++ b/tests/test_identity_handlers.py
@@ -1879,20 +1879,57 @@ class TestHandleOnboardV2:
         result = await handle_onboard_v2({"client_session_id": "onboard-new"})
         data = parse_result(result)
 
+        # #734: onboard now defaults to response_mode="minimal" — a lean
+        # envelope with a single identity_assurance block and no nested
+        # ontology / descriptive extras.
         assert data["success"] is True
         assert data["is_new"] is True
         assert data["identity_resolution_outcome"] == "minted_after_resume_miss"
+        assert data["response_mode"] == "minimal"
         assert "uuid" in data
         assert "client_session_id" in data
-        assert "session_resolution_source" in data
-        assert "continuity_token_supported" in data
-        assert "date_context" in data
+        assert "identity_assurance" in data
         assert "next_step" in data
-        # next_calls, session_continuity, workflow moved behind verbose=true
+        # Descriptive ontology + extras moved behind response_mode="full".
+        assert "identity_context" not in data
+        assert "session_resolution_source" not in data
+        assert "continuity_token_supported" not in data
+        assert "date_context" not in data
+        # next_calls, session_continuity, workflow are verbose/full-only.
         assert "next_calls" not in data
         assert "session_continuity" not in data
         assert "workflow" not in data
         assert "what_this_does" not in data
+
+    @pytest.mark.asyncio
+    async def test_onboard_full_mode_restores_descriptive_envelope(
+        self, patch_onboard_deps, mock_db, mock_redis
+    ):
+        """response_mode='full' returns the complete identity ontology and the
+        descriptive fields that minimal (the default) drops."""
+        from src.mcp_handlers.identity.handlers import handle_onboard_v2
+
+        mock_redis.get.return_value = None
+        mock_db.get_session.return_value = None
+        mock_db.find_agent_by_label.return_value = None
+        mock_db.get_identity.side_effect = [
+            None,
+            None,
+            SimpleNamespace(identity_id="new-ident", metadata={}),
+        ]
+
+        result = await handle_onboard_v2(
+            {"client_session_id": "onboard-full", "response_mode": "full"}
+        )
+        data = parse_result(result)
+
+        assert data["success"] is True
+        assert "response_mode" not in data  # full mode does not stamp the key
+        assert "identity_context" in data
+        assert "identity_assurance" in data
+        assert "session_resolution_source" in data
+        assert "continuity_token_supported" in data
+        assert "date_context" in data
 
     @pytest.mark.asyncio
     async def test_subagent_onboard_passes_if_absent_to_pin(self, patch_onboard_deps, mock_db, mock_redis):


### PR DESCRIPTION
Follow-up to #738. That PR landed the `response_mode` infrastructure with **opt-in** minimal (default stayed `"full"`). A push/merge race meant the default-flip commit didn't make it into the squash — this PR carries just that flip, rebased onto current master.

## Change

Flips the onboard default from `"full"` to `"minimal"`.

- `"minimal"` (default) — lean payload: `uuid`, `agent_id`, session id, a single `identity_assurance` block, trajectory genesis+trust_tier, lineage flags, `continuity_token`, `next_step`.
- `"full"` (opt-in) — the complete identity ontology (`identity_context` + nested registry/label/harness blocks) plus the descriptive `session_resolution_source` / `continuity_token_supported` / `date_context` fields.
- `verbose=True` is honored as full, so legacy verbose callers keep the `next_calls`/`session_continuity`/`tool_mode`/`workflow` extras (minimal returns before those are built). An explicit `response_mode` always wins.
- `trajectory` (genesis + glossary trust_tier) is surfaced in **both** modes via a shared `_build_trajectory_block` helper, so a fresh agent still sees its initial trust tier once at onboard without asking for full.

## Blast radius

No in-repo or dashboard consumer reads the dropped fields — `identity_context` is referenced only by the builder and its tests; the dashboard's only "onboard" mention is a help string. The functional fields the plugin SessionStart banner relies on (`uuid`, `client_session_id`) are retained in both modes.

⚠️ The one consumer I can't verify from this repo is the external `unitares-governance-plugin` banner — worth a glance before merge, though it only reads `uuid`/`client_session_id`.

## Tests

- `tests/test_identity_handlers.py` — `handle_onboard_v2` default now asserts the minimal shape; new test pins `response_mode="full"` restoring `identity_context` + the descriptive fields.
- `tests/test_identity_payloads.py` — minimal vs full envelope.

`test_identity_handlers.py` + `test_identity_payloads.py`: **147 passed** on this branch. (Broader identity/dispatch/integration sweep was 1178 passed on the pre-rebase branch.)

Completes the #734 work (the default flip #738 didn't capture).

https://claude.ai/code/session_01V13oeBP6uwh1iRvNCrFS2Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01V13oeBP6uwh1iRvNCrFS2Z)_