### PR TITLE
docs(troubleshooting): note web/streamable-HTTP check-in approval gate

### DIFF
--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -215,6 +215,38 @@ Also verify the shell token matches the running service token. Launchd deploymen
 
 ---
 
+### Issue 8: Check-In (or Other Write Tool) Fails From a Web / Streamable-HTTP Session
+
+**Symptoms:**
+- A governance tool call fails with:
+  ```
+  Streamable HTTP error: Error POSTing to endpoint: MCP tool call requires approval
+  ```
+- It fails on every retry, even though a matching `permissions.allow` entry exists in `.claude/settings.local.json`.
+- Read-only / non-gated tools (e.g. `onboard`) succeed on the **same** connection, so the MCP server and transport are healthy.
+- Most often hits the stateful/write tools (`process_agent_update` / check-ins, operator actions) while reads pass.
+
+**Cause:** This is a Claude Code **harness / remote-transport** limitation, *not* a UNITARES server defect — the governance server processes check-ins normally (residents and local/plugin clients are unaffected). When an MCP tool requires per-call approval, the **streamable HTTP transport in the web/remote environment has no way to surface and resolve the approval prompt**, so the tool-call POST hard-errors instead of pausing for approval. Because the gate is enforced at the transport/gateway layer, the local `permissions.allow` allowlist is not consulted, and two facts make a settings-based workaround impossible:
+- environment-injected MCP servers have **ephemeral per-session IDs** (`mcp__<uuid>__…`), so an allow rule can't persist across sessions;
+- allow rules can't wildcard the server-name segment (`mcp__*__tool` is invalid), so there's no stable rule to write.
+
+**Workarounds:**
+
+1. **Use a transport that supports approval / pre-exemption.** Local stdio or direct-loopback MCP (the plugin / `~/.claude.json` config against `http://localhost:8767`) handles the approval handshake. The `unitares-governance-plugin` session-start path calls the governance REST API directly and is unaffected.
+2. **Drive check-ins over REST instead of the gated MCP tool** when in a web session:
+   ```bash
+   curl -s -X POST http://127.0.0.1:8767/v1/tools/call \
+     -H "Authorization: Bearer $UNITARES_HTTP_API_TOKEN" \
+     -H "Content-Type: application/json" \
+     --data '{"name":"process_agent_update","arguments":{"client_session_id":"<sid>","response_text":"...","complexity":0.5}}'
+   ```
+3. **Pre-exempt the tool at the environment's MCP gateway** (the same mechanism that already lets `onboard` through), if you control the remote environment config.
+4. **Report it upstream** via `/feedback` in your Claude Code client — it is a transport-layer bug (approval handshake unsupported over streamable HTTP), not specific to this repo.
+
+**Note on governance coverage:** because of this, agents working in web/streamable-HTTP sessions **cannot complete check-ins through the MCP tool** and will run ungoverned unless they fall back to REST or a local transport. Onboard in-conversation (there is no plugin hook to auto-onboard a server-only/web session — that is the expected default), and use a REST/local path for the check-in loop.
+
+---
+
 ## Debugging Steps
 
 ### Step 1: Check Basic Connectivity

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -226,9 +226,11 @@ Also verify the shell token matches the running service token. Launchd deploymen
 - Read-only / non-gated tools (e.g. `onboard`) succeed on the **same** connection, so the MCP server and transport are healthy.
 - Most often hits the stateful/write tools (`process_agent_update` / check-ins, operator actions) while reads pass.
 
-**Cause:** This is a Claude Code **harness / remote-transport** limitation, *not* a UNITARES server defect — the governance server processes check-ins normally (residents and local/plugin clients are unaffected). When an MCP tool requires per-call approval, the **streamable HTTP transport in the web/remote environment has no way to surface and resolve the approval prompt**, so the tool-call POST hard-errors instead of pausing for approval. Because the gate is enforced at the transport/gateway layer, the local `permissions.allow` allowlist is not consulted, and two facts make a settings-based workaround impossible:
+**Cause:** This is a Claude Code **harness / remote-transport** limitation, *not* a UNITARES server defect — the governance server processes check-ins normally (residents and local/plugin clients are unaffected). When an MCP tool requires per-call approval, the **streamable HTTP transport in the web/remote environment has no way to surface and resolve the approval prompt**, so the tool-call POST hard-errors instead of pausing for approval. The gate is enforced at the **remote environment's MCP gateway, above Claude Code's local permission engine** — confirmed empirically: the call still returns `requires approval` even with `permissions.defaultMode: "bypassPermissions"` and an `mcp__<server>__*` wildcard set in `.claude/settings.local.json`. No repo-local setting overrides it. Two further facts make a settings-based workaround impossible even in principle:
 - environment-injected MCP servers have **ephemeral per-session IDs** (`mcp__<uuid>__…`), so an allow rule can't persist across sessions;
 - allow rules can't wildcard the server-name segment (`mcp__*__tool` is invalid), so there's no stable rule to write.
+
+The only place to "allow all" for the injected server is the **environment's permission policy** (chosen when the environment is created — see https://code.claude.com/docs/en/claude-code-on-the-web), not anything in the repo.
 
 **Workarounds:**
 


### PR DESCRIPTION
Adds **Issue 8** to `docs/guides/TROUBLESHOOTING.md` documenting the web/streamable-HTTP check-in limitation surfaced while dogfooding the governance loop from a Claude Code web session.

## What it documents

A governance write tool (`process_agent_update` / check-in) fails from a web/remote session with:
```
Streamable HTTP error: Error POSTing to endpoint: MCP tool call requires approval
```
…on every retry, even with a matching `permissions.allow` entry — while `onboard` succeeds on the **same** connection.

**Root cause (documented as a harness/transport limitation, not a UNITARES defect):** the streamable HTTP transport can't surface/resolve the approval prompt, so an approval-gated tool-call POST hard-errors. The gate sits above the local `permissions.allow` allowlist, and ephemeral per-session server IDs + the ban on server-segment wildcards (`mcp__*__tool` is invalid) make a durable settings-based allow rule impossible. The governance server itself processes check-ins normally — residents and local/plugin clients are unaffected.

**Workarounds captured:** local/plugin transport, REST `/v1/tools/call` check-in, gateway pre-exemption, and `/feedback` upstream. Plus a "governance coverage" note: web/streamable-HTTP sessions can't complete the MCP check-in and run ungoverned unless they fall back to REST or a local path — and that onboarding in-conversation is the expected default for server-only/web sessions (no plugin hook to auto-onboard).

## Scope

Docs-only (`docs/guides/TROUBLESHOOTING.md`). Not covered by `test_doc_drift` (which only validates `skills/`), so no test impact.

Context: surfaced during the #729 dogfood follow-up; the underlying transport bug is being reported upstream via `/feedback` (not a unitares issue).

https://claude.ai/code/session_01V13oeBP6uwh1iRvNCrFS2Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01V13oeBP6uwh1iRvNCrFS2Z)_