### PR TITLE
test: add synthetic ablation negative controls

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@ The system's versioned identity ontology, the resolution ledger, and the working
 How to run this in production. Most readers can skip these.
 
 - [`OPERATOR_RUNBOOK.md`](operations/OPERATOR_RUNBOOK.md) — primary runbook
+- [`ablation-negative-controls.md`](operations/ablation-negative-controls.md) — synthetic bad-outcome fixtures for red-team ablation plumbing
 - [`DEFINITIVE_PORTS.md`](operations/DEFINITIVE_PORTS.md) — port assignments across services
 - [`database_architecture.md`](operations/database_architecture.md) — single-Postgres / schema-isolation model
 - [`lease-plane-operator-runbook.md`](operations/lease-plane-operator-runbook.md) — Elixir lease-plane operations

--- a/docs/operations/ablation-negative-controls.md
+++ b/docs/operations/ablation-negative-controls.md
@@ -1,0 +1,75 @@
+# Ablation Negative Controls
+
+**Created:** June 14, 2026
+**Last Updated:** June 14, 2026
+**Status:** Experimental
+
+---
+
+## Purpose
+
+Ablation tests need negative controls. If every resident, dogfood probe, and
+outcome row is well-behaved, the analysis pipeline only proves the happy path.
+`ablation_negative_controls.py` creates known-safe synthetic bad outcomes so the
+EISV/outcome inventory path can prove it sees, counts, labels, and refuses to
+overinterpret adverse fixtures.
+
+These rows are **not** real failures. They are fixture data for local smoke tests
+and red-team checks.
+
+## Safety boundary
+
+Negative controls must stay synthetic-only:
+
+- do not persist them into production outcome tables,
+- do not submit them through UNITARES MCP write tools,
+- do not promote them to KG,
+- do not request dialectic from them,
+- do not open GitHub issues or CI gates from them.
+
+Every serialized row carries:
+
+- `verification_source = synthetic_fixture`,
+- `detail.synthetic_negative_control = true`,
+- `detail.do_not_persist = true`,
+- `detail.prediction_binding = synthetic_negative_control`.
+
+## What the fixture proves
+
+The fixture includes strict bad outcomes (`test_failed`, `tool_rejected`) with
+high prior risk and strict good outcomes (`test_passed`) with low prior risk.
+That proves the local analysis path can observe a bad class and detect a
+predictive synthetic prior without claiming live validation.
+
+Use this to test containment and instrumentation, not agent obedience.
+
+## CLI smoke
+
+```bash
+python3 scripts/analysis/ablation_negative_controls.py \
+  --generated-at 2026-06-14T23:30:00+00:00 \
+  --count 12 \
+  --output-jsonl data/analysis/negative-controls.jsonl
+```
+
+Expected stdout is a compact non-sensitive summary:
+
+```json
+{"event_type":"ablation_negative_controls","generated_rows":12,"mode":"synthetic_only","status":"fixtures_written","strict_bad":4}
+```
+
+The output JSONL is local fixture material. It is safe to delete after the smoke.
+
+## Interpretation discipline
+
+Good language:
+
+> Synthetic negative controls show the analysis path can observe a bad class and
+> route fixture evidence without contaminating production state.
+
+Bad language:
+
+> The red-team fixture validates EISV.
+
+It does not. It only validates plumbing and containment for a known-safe adverse
+case.

--- a/scripts/analysis/ablation_negative_controls.py
+++ b/scripts/analysis/ablation_negative_controls.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Synthetic negative controls for UNITARES/EISV ablation checks.
+
+These fixtures deliberately create known-safe bad outcomes in memory or local
+JSONL only. They are red-team controls for the analysis path, not a write
+adapter: do not import them into production outcome tables, KG, dialectic, or
+CI gates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, replace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+if __package__ is None or __package__ == "":
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.analysis.eisv_ablation_matrix import (  # noqa: E402
+    AblationMatrixRow,
+    build_matrix_row,
+)
+from scripts.analysis.eisv_skeptic_report import OutcomeRow  # noqa: E402
+from scripts.analysis.outcome_inventory import (  # noqa: E402
+    OutcomeInventory,
+    OutcomeInventoryRow,
+    build_inventory,
+)
+
+SYNTHETIC_FIXTURE_SOURCE = "synthetic_fixture"
+EVENT_TYPE = "ablation_negative_controls"
+DEFAULT_COUNT = 60
+
+
+def _ensure_utc(dt: datetime | None) -> datetime:
+    """Normalize optional datetimes to timezone-aware UTC."""
+    if dt is None:
+        return datetime.now(timezone.utc)
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    """Parse an optional ISO timestamp, accepting a trailing Z."""
+    if value is None:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _outcome_for_index(index: int) -> tuple[str, bool, float, float, str]:
+    """Return outcome fields for a deterministic synthetic fixture row."""
+    if index % 3 == 2:
+        outcome_type = "test_failed" if (index // 3) % 2 == 0 else "tool_rejected"
+        return outcome_type, True, 0.0, 0.92, "high-risk"
+    return "test_passed", False, 1.0, 0.08, "safe"
+
+
+def _detail(index: int) -> dict[str, Any]:
+    """Return non-secret fixture metadata that explicitly forbids persistence."""
+    return {
+        "synthetic_negative_control": True,
+        "do_not_persist": True,
+        "fixture_id": f"negative-control-{index:03d}",
+        "prediction_id": f"synthetic-prediction-{index:03d}",
+        "prediction_binding": "synthetic_negative_control",
+        "hard_exogenous": True,
+        "eprocess_eligible": True,
+        "red_team_fixture": "known_safe_bad_outcome",
+    }
+
+
+def build_negative_control_outcome_rows(
+    *,
+    generated_at: datetime | None = None,
+    count: int = DEFAULT_COUNT,
+) -> list[OutcomeRow]:
+    """Build synthetic rows with a known bad class and predictive prior risk."""
+    if count <= 0:
+        raise ValueError("count must be positive")
+    observed_at = _ensure_utc(generated_at)
+    rows: list[OutcomeRow] = []
+    previous_bad = False
+    for index in range(count):
+        outcome_type, is_bad, outcome_score, risk, verdict = _outcome_for_index(index)
+        ts = observed_at + timedelta(minutes=index)
+        row = OutcomeRow(
+            ts=ts,
+            agent_id=f"synthetic-negative-control/agent-{index % 4}",
+            outcome_type=outcome_type,
+            is_bad=is_bad,
+            outcome_score=outcome_score,
+            verification_source=SYNTHETIC_FIXTURE_SOURCE,
+            reported_confidence=0.8 if not is_bad else 0.6,
+            reported_complexity=0.2,
+            detail=_detail(index),
+            prior_state_age_seconds=30.0,
+            prior_risk=risk,
+            prior_phi=1.0 - risk,
+            prior_verdict=verdict,
+            prior_coherence=0.8 if not is_bad else 0.35,
+            prior_e=0.7,
+            prior_i=0.75 if not is_bad else 0.35,
+            prior_s=0.12 if not is_bad else 0.86,
+            prior_v=0.05 if not is_bad else 0.45,
+            snapshot_verdict=None,
+            snapshot_e=None,
+            snapshot_i=None,
+            snapshot_s=None,
+            snapshot_v=None,
+            snapshot_phi=None,
+            snapshot_coherence=None,
+            row_key=f"synthetic-negative-control-{index:03d}",
+            previous_bad=previous_bad,
+        )
+        rows.append(row)
+        previous_bad = is_bad
+    return rows
+
+
+def _inventory_rows(
+    rows: Sequence[OutcomeRow],
+    lead_minutes: Sequence[float],
+) -> list[OutcomeInventoryRow]:
+    """Convert skeptic-report rows into outcome-inventory rows."""
+    leads = tuple(float(lead) for lead in lead_minutes)
+    return [
+        OutcomeInventoryRow(
+            outcome_type=row.outcome_type,
+            is_bad=row.is_bad,
+            verification_source=row.verification_source,
+            detail=row.detail,
+            prior_state_by_lead={lead: True for lead in leads},
+        )
+        for row in rows
+    ]
+
+
+def build_negative_control_inventory(
+    *,
+    generated_at: datetime | None = None,
+    count: int = DEFAULT_COUNT,
+    lead_minutes: Sequence[float] = (0, 5, 30),
+) -> OutcomeInventory:
+    """Build an inventory report over synthetic negative-control rows."""
+    rows = build_negative_control_outcome_rows(
+        generated_at=generated_at,
+        count=count,
+    )
+    return build_inventory(_inventory_rows(rows, lead_minutes), lead_minutes=lead_minutes)
+
+
+def build_negative_control_matrix_rows(
+    *,
+    generated_at: datetime | None = None,
+    count: int = DEFAULT_COUNT,
+    scopes: Sequence[str] = ("strict", "task"),
+    window_days: int = 90,
+    lead_minutes: float = 5,
+) -> list[AblationMatrixRow]:
+    """Build ablation matrix rows labeled as synthetic negative controls."""
+    rows = build_negative_control_outcome_rows(
+        generated_at=generated_at,
+        count=count,
+    )
+    matrix_rows: list[AblationMatrixRow] = []
+    for scope in scopes:
+        if scope not in {"strict", "task"}:
+            raise ValueError("scope must be strict or task")
+        matrix = build_matrix_row(
+            rows,
+            scope=scope,
+            window_days=window_days,
+            lead_minutes=lead_minutes,
+            train_fraction=0.7,
+            min_feature_rows=6,
+        )
+        matrix_rows.append(
+            replace(
+                matrix,
+                conclusion=(
+                    "SYNTHETIC NEGATIVE CONTROL: analysis path observed a "
+                    f"known bad class; not validation. {matrix.conclusion}"
+                ),
+            )
+        )
+    return matrix_rows
+
+
+def serialize_outcome_rows(rows: Sequence[OutcomeRow]) -> list[dict[str, Any]]:
+    """Serialize synthetic rows for local JSONL fixture files."""
+    serialized: list[dict[str, Any]] = []
+    for row in rows:
+        item = asdict(row)
+        item["ts"] = row.ts.isoformat()
+        serialized.append(item)
+    return serialized
+
+
+def _write_jsonl(path: Path, rows: Sequence[dict[str, Any]]) -> None:
+    """Write synthetic rows to a local JSONL file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def _strict_bad(rows: Sequence[OutcomeRow]) -> int:
+    """Count synthetic strict bad rows."""
+    return sum(
+        1
+        for row in rows
+        if row.is_bad and row.outcome_type in {"test_failed", "tool_rejected"}
+    )
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--generated-at", default=None)
+    parser.add_argument("--count", type=int, default=DEFAULT_COUNT)
+    parser.add_argument("--output-jsonl", type=Path, default=None)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Generate synthetic negative-control fixtures without real writes."""
+    args = parse_args(argv)
+    rows = build_negative_control_outcome_rows(
+        generated_at=_parse_datetime(args.generated_at),
+        count=args.count,
+    )
+    if args.output_jsonl is not None:
+        _write_jsonl(args.output_jsonl, serialize_outcome_rows(rows))
+        status = "fixtures_written"
+    else:
+        status = "fixtures_built"
+    print(
+        json.dumps(
+            {
+                "event_type": EVENT_TYPE,
+                "mode": "synthetic_only",
+                "status": status,
+                "generated_rows": len(rows),
+                "strict_bad": _strict_bad(rows),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ablation_negative_controls.py
+++ b/tests/test_ablation_negative_controls.py
@@ -1,0 +1,123 @@
+"""Synthetic negative-control fixtures for ablation tests."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from scripts.analysis.ablation_negative_controls import (
+    SYNTHETIC_FIXTURE_SOURCE,
+    build_negative_control_inventory,
+    build_negative_control_matrix_rows,
+    build_negative_control_outcome_rows,
+    serialize_outcome_rows,
+)
+
+NOW = datetime(2026, 6, 14, 23, 30, tzinfo=timezone.utc)
+
+
+def test_negative_control_rows_are_synthetic_strict_and_not_persistable() -> None:
+    """Negative controls create known bad strict outcomes without real writes."""
+    rows = build_negative_control_outcome_rows(generated_at=NOW)
+
+    assert len(rows) >= 40
+    assert {row.outcome_type for row in rows} >= {"test_failed", "tool_rejected"}
+    assert any(row.is_bad for row in rows)
+    assert all(row.verification_source == SYNTHETIC_FIXTURE_SOURCE for row in rows)
+    assert all(row.agent_id.startswith("synthetic-negative-control/") for row in rows)
+    assert all(row.detail["synthetic_negative_control"] is True for row in rows)
+    assert all(row.detail["do_not_persist"] is True for row in rows)
+    assert all(row.detail["prediction_binding"] == "synthetic_negative_control" for row in rows)
+    assert all(row.prior_state_age_seconds is not None for row in rows)
+    assert min(row.prior_risk for row in rows if row.is_bad) > max(
+        row.prior_risk for row in rows if not row.is_bad
+    )
+
+
+def test_inventory_reports_synthetic_strict_bad_without_real_provenance() -> None:
+    """Inventory sees the bad class but labels it synthetic-only."""
+    inventory = build_negative_control_inventory(generated_at=NOW, lead_minutes=(0, 5, 30))
+
+    assert inventory.total_outcomes >= 40
+    assert inventory.total_bad > 0
+    assert inventory.strict_bad > 0
+    assert inventory.hard_exogenous_count == inventory.total_outcomes
+    assert inventory.eprocess_eligible_count == inventory.total_outcomes
+    assert inventory.total_prediction_id_count == inventory.total_outcomes
+    assert {bucket.verification_source for bucket in inventory.buckets} == {
+        SYNTHETIC_FIXTURE_SOURCE
+    }
+    assert {bucket.prediction_binding for bucket in inventory.buckets} == {
+        "synthetic_negative_control"
+    }
+
+
+def test_matrix_rows_are_explicitly_labeled_synthetic_controls() -> None:
+    """Ablation smoke can prove detection while refusing validation language."""
+    matrix_rows = build_negative_control_matrix_rows(
+        generated_at=NOW,
+        scopes=("strict", "task"),
+        window_days=90,
+        lead_minutes=5,
+    )
+
+    assert [row.scope for row in matrix_rows] == ["strict", "task"]
+    assert all(row.bad > 0 for row in matrix_rows)
+    assert all(row.prior_state == row.trusted for row in matrix_rows)
+    assert all("SYNTHETIC NEGATIVE CONTROL" in row.conclusion for row in matrix_rows)
+    assert any(row.beats_both for row in matrix_rows)
+
+
+def test_serialized_rows_keep_fixture_label_and_drop_private_fields() -> None:
+    """JSONL export is local fixture data, not a DB/import payload."""
+    rows = build_negative_control_outcome_rows(generated_at=NOW, count=4)
+
+    serialized = serialize_outcome_rows(rows)
+
+    assert len(serialized) == 4
+    assert all(item["detail"]["synthetic_negative_control"] is True for item in serialized)
+    assert all(item["detail"]["do_not_persist"] is True for item in serialized)
+    assert all("continuity_token" not in json.dumps(item) for item in serialized)
+    assert all("GOVERNANCE_DATABASE_URL" not in json.dumps(item) for item in serialized)
+
+
+def test_cli_outputs_summary_and_writes_local_jsonl_only(tmp_path: Path) -> None:
+    """The CLI is a safe red-team fixture generator, not a write adapter."""
+    output_path = tmp_path / "negative-controls.jsonl"
+    script = Path("scripts/analysis/ablation_negative_controls.py")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--generated-at",
+            "2026-06-14T23:30:00+00:00",
+            "--count",
+            "12",
+            "--output-jsonl",
+            str(output_path),
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    summary = json.loads(completed.stdout)
+    assert summary == {
+        "event_type": "ablation_negative_controls",
+        "mode": "synthetic_only",
+        "status": "fixtures_written",
+        "generated_rows": 12,
+        "strict_bad": 4,
+    }
+    assert str(output_path) not in completed.stdout
+    assert output_path.exists()
+    exported = [json.loads(line) for line in output_path.read_text().splitlines()]
+    assert len(exported) == 12
+    assert all(item["detail"]["do_not_persist"] is True for item in exported)


### PR DESCRIPTION
## Summary
- add synthetic negative-control fixtures for UNITARES/EISV ablation plumbing
- label every fixture row as `synthetic_fixture` / `do_not_persist` so bad outcomes cannot be mistaken for production evidence
- add a local-only JSONL CLI and operator doc for safe red-team bad-outcome smoke tests

## Test Plan
- [x] TDD red: `tests/test_ablation_negative_controls.py` initially failed with missing `scripts.analysis.ablation_negative_controls`
- [x] `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 -m pytest -o addopts= tests/test_ablation_negative_controls.py tests/test_eisv_ablation_matrix.py tests/test_eisv_skeptic_report.py tests/test_outcome_inventory.py -q`
- [x] `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 -m ruff check scripts/analysis/ablation_negative_controls.py tests/test_ablation_negative_controls.py`
- [x] CLI smoke: `python3 scripts/analysis/ablation_negative_controls.py --generated-at 2026-06-14T23:30:00+00:00 --count 12 --output-jsonl <tmp>/negative-controls.jsonl`
- [x] `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 ./scripts/dev/test-cache.sh --staged`
- [x] pre-push smoke hook: `138 passed, 9156 deselected`

## Safety Boundary
- synthetic/local JSONL only
- no UNITARES write adapter
- no KG/dialectic/issue/CI-gate side effects
- explicit `do_not_persist` labels on every fixture row
