### PR TITLE
feat(mirror): Phase 0 mirror_signal.emit instrumentation

### DIFF
--- a/docs/proposals/mirror-effectiveness-measurement-v0.md
+++ b/docs/proposals/mirror-effectiveness-measurement-v0.md
@@ -1,6 +1,8 @@
 # Mirror effectiveness measurement — v0
 
-Status: proposal / not built. Follow-up from the 2026-06-14 mirror-mode scoping (PR #741, which closed the #583 "reflect, don't advise" seam in `_detect_gaming`). Defines a deterministic, operator-funded-free way to answer "does a surfaced mirror signal actually change agent behavior?" — replacing the current dogfood-only, qualitative tuning loop. **Recommends instrumentation + offline analysis first; no agent-facing behavior change in v0.**
+Status: **Phase 0 landed** (the rest proposed). Follow-up from the 2026-06-14 mirror-mode scoping (PR #741, which closed the #583 "reflect, don't advise" seam in `_detect_gaming`). Defines a deterministic, operator-funded-free way to answer "does a surfaced mirror signal actually change agent behavior?" — replacing the current dogfood-only, qualitative tuning loop. **Recommends instrumentation + offline analysis first; no agent-facing behavior change in v0.**
+
+Phase 0 shipped: `enrich_mirror_signals` now produces structured `_mirror_signal_records` (autopilot complexity/confidence variance + complexity divergence) and `response_formatter._emit_mirror_signal_records` logs one `mirror_signal.emit` audit event per fired check-in, tagged `surfaced = (response_mode == "mirror")`. Off-switch: `UNITARES_MIRROR_SIGNAL_EMIT=0`. Phases 1 (offline re-eval) and 2 (operator-gated feedback) remain proposed.
 
 ## Why
 

--- a/src/audit_log.py
+++ b/src/audit_log.py
@@ -541,6 +541,41 @@ class AuditLogger:
         )
         self._write_entry(entry)
 
+    def log_mirror_signal_emit(
+        self,
+        *,
+        agent_id: Optional[str],
+        update_index: Optional[int],
+        response_mode: Optional[str],
+        surfaced: bool,
+        signals: List[Dict],
+    ) -> None:
+        """Phase 0 mirror-effectiveness instrumentation (mirror-effectiveness-measurement-v0).
+
+        Records, per check-in that fired at least one structured mirror signal,
+        what fired and whether the agent actually saw it. ``surfaced`` is the
+        lever: it is True only when the resolved ``response_mode`` was ``mirror``.
+        Agents on minimal/compact/standard/full compute the same signals (the
+        enrichment runs before mode filtering) but never see them — they are the
+        natural shadow control the Phase 1 analysis joins against.
+
+        Each entry in ``signals`` is a structured trigger record:
+        ``{"signal_type", "metric", "value", "threshold", ...}``.
+        """
+        entry = AuditEntry(
+            timestamp=datetime.now().isoformat(),
+            agent_id=agent_id,
+            event_type="mirror_signal.emit",
+            confidence=1.0,
+            details={
+                "update_index": update_index,
+                "response_mode": response_mode,
+                "surfaced": bool(surfaced),
+                "signals": signals,
+            },
+        )
+        self._write_entry(entry)
+
     def _write_entry(self, entry: AuditEntry):
         """Write audit entry to JSONL log file with locking.
 

--- a/src/mcp_handlers/response_formatter.py
+++ b/src/mcp_handlers/response_formatter.py
@@ -23,6 +23,33 @@ def _copy_passthrough_fields(response_data: dict, result: dict, fields: tuple) -
         if value is not None:
             result[field] = value
 
+def _emit_mirror_signal_records(response_data: dict, response_mode: str, meta: Any) -> None:
+    """Phase 0 mirror-effectiveness instrumentation (mirror-effectiveness-measurement-v0).
+
+    Logs one ``mirror_signal.emit`` audit event per check-in that fired at least
+    one structured signal, tagged with ``surfaced = (response_mode == "mirror")``.
+    Always pops the internal ``_mirror_signal_records`` key so it never leaks into
+    a returned payload (including full mode). Fully best-effort: never raise into
+    the response path. Disable with ``UNITARES_MIRROR_SIGNAL_EMIT=0``.
+    """
+    records = response_data.pop("_mirror_signal_records", None)
+    if not records:
+        return
+    if os.getenv("UNITARES_MIRROR_SIGNAL_EMIT", "1").strip().lower() in ("0", "false", "no"):
+        return
+    try:
+        from src.audit_log import get_audit_log
+        get_audit_log().log_mirror_signal_emit(
+            agent_id=response_data.get("agent_id"),
+            update_index=getattr(meta, "total_updates", None) if meta else None,
+            response_mode=response_mode,
+            surfaced=(response_mode == "mirror"),
+            signals=records,
+        )
+    except Exception as e:
+        logger.debug(f"Could not emit mirror signal records: {e}")
+
+
 def format_response(
     response_data: dict,
     arguments: dict,
@@ -84,10 +111,6 @@ def format_response(
 
     using_default_mode = not arguments.get("response_mode") and not agent_verbosity_pref
 
-    # Full mode: no filtering
-    if response_mode == "full":
-        return response_data
-
     # AUTO MODE: Adaptive verbosity based on health status
     if response_mode == "auto":
         metrics = response_data.get("metrics", {}) if isinstance(response_data.get("metrics"), dict) else {}
@@ -107,6 +130,16 @@ def format_response(
             response_mode = "standard"
         else:
             response_mode = "compact"
+
+    # Phase 0 mirror-effectiveness instrumentation: emit structured signal
+    # records (every resolved mode) with surfaced = (mode == "mirror"), so the
+    # non-mirror population becomes the shadow control. Runs before the full
+    # early-return and before stripping; consumes/clears the internal key.
+    _emit_mirror_signal_records(response_data, response_mode, meta)
+
+    # Full mode: no filtering
+    if response_mode == "full":
+        return response_data
 
     # MIRROR MODE: Actionable self-awareness signals
     if response_mode == "mirror":

--- a/src/mcp_handlers/updates/enrichments.py
+++ b/src/mcp_handlers/updates/enrichments.py
@@ -1294,9 +1294,13 @@ async def enrich_mirror_signals(ctx: UpdateContext) -> None:
         ctx.response_data["_has_sensor_data"] = has_sensor_data
 
         signals = []
+        # Phase 0 instrumentation: structured trigger records for the numeric
+        # signals, surfaced-or-not is decided later in response_formatter once
+        # the response_mode is resolved (mirror-effectiveness-measurement-v0).
+        signal_records: list = []
 
         # 1. Gaming / autopilot detection (low variance in recent reports)
-        signals.extend(_detect_gaming(ctx))
+        signals.extend(_detect_gaming(ctx, records=signal_records))
 
         # 2. Targeted reflection — descriptive, only when state warrants it
         reflection = _generate_mirror_reflection(ctx, signals)
@@ -1309,15 +1313,45 @@ async def enrich_mirror_signals(ctx: UpdateContext) -> None:
             if kg_results:
                 ctx.response_data["_mirror_kg_results"] = kg_results
 
+        # Complexity-divergence trigger record — same gate the surfaced line
+        # uses (_get_complexity_disagreement honors the >3-update baseline and
+        # the novelty gate), so the record fires exactly when the signal does.
+        disagreement = _get_complexity_disagreement(ctx.response_data, ctx.meta)
+        if disagreement and disagreement.get("divergence") is not None:
+            threshold = (
+                DIVERGENCE_LINE_THRESHOLD
+                if disagreement.get("source") == "continuity"
+                else 0.3
+            )
+            signal_records.append({
+                "signal_type": "complexity_divergence",
+                "metric": "complexity_divergence",
+                "value": disagreement.get("divergence"),
+                "threshold": threshold,
+                "reported": disagreement.get("reported"),
+                "derived": disagreement.get("derived"),
+                "source": disagreement.get("source"),
+            })
+
         if signals:
             ctx.response_data["_mirror_signals"] = signals
+        if signal_records:
+            ctx.response_data["_mirror_signal_records"] = signal_records
 
     except Exception as e:
         logger.debug(f"Could not enrich mirror signals: {e}")
 
 
-def _detect_gaming(ctx: UpdateContext) -> list:
-    """Detect low-variance reporting patterns that suggest autopilot."""
+_GAMING_VARIANCE_THRESHOLD = 0.005
+
+
+def _detect_gaming(ctx: UpdateContext, records: list | None = None) -> list:
+    """Detect low-variance reporting patterns that suggest autopilot.
+
+    When ``records`` is provided, append a structured trigger record per fired
+    signal (Phase 0 mirror-effectiveness instrumentation: signal_type, the
+    measured variance, and the threshold it crossed) alongside the prose line.
+    """
     signals = []
     try:
         mcp_server = ctx.mcp_server
@@ -1336,16 +1370,30 @@ def _detect_gaming(ctx: UpdateContext) -> list:
             import statistics
             if len(set(recent)) > 1:
                 variance = statistics.variance(recent)
-                if variance < 0.005:
+                if variance < _GAMING_VARIANCE_THRESHOLD:
                     signals.append(
                         f"Your last {len(recent)} complexity reports vary little "
                         f"(variance={variance:.4f}) — flat enough to read as autopilot."
                     )
+                    if records is not None:
+                        records.append({
+                            "signal_type": "autopilot_complexity",
+                            "metric": "complexity_variance",
+                            "value": variance,
+                            "threshold": _GAMING_VARIANCE_THRESHOLD,
+                        })
             elif len(set(recent)) == 1:
                 signals.append(
                     f"Your last {len(recent)} complexity reports were all {recent[0]:.2f} — "
                     "no variance, reads as autopilot."
                 )
+                if records is not None:
+                    records.append({
+                        "signal_type": "autopilot_complexity",
+                        "metric": "complexity_variance",
+                        "value": 0.0,
+                        "threshold": _GAMING_VARIANCE_THRESHOLD,
+                    })
 
         # Check confidence history variance
         if hasattr(state, 'confidence_history') and len(state.confidence_history) >= 5:
@@ -1354,16 +1402,30 @@ def _detect_gaming(ctx: UpdateContext) -> list:
                 import statistics
                 if len(set(recent_conf)) > 1:
                     conf_var = statistics.variance(recent_conf)
-                    if conf_var < 0.005:
+                    if conf_var < _GAMING_VARIANCE_THRESHOLD:
                         signals.append(
                             f"Your confidence reports show very low variance ({conf_var:.4f}) — "
                             "flat across recent check-ins."
                         )
+                        if records is not None:
+                            records.append({
+                                "signal_type": "autopilot_confidence",
+                                "metric": "confidence_variance",
+                                "value": conf_var,
+                                "threshold": _GAMING_VARIANCE_THRESHOLD,
+                            })
                 elif len(set(recent_conf)) == 1:
                     signals.append(
                         f"Your last {len(recent_conf)} confidence reports were all {recent_conf[0]:.2f} — "
                         "no variance across check-ins."
                     )
+                    if records is not None:
+                        records.append({
+                            "signal_type": "autopilot_confidence",
+                            "metric": "confidence_variance",
+                            "value": 0.0,
+                            "threshold": _GAMING_VARIANCE_THRESHOLD,
+                        })
     except Exception as e:
         logger.debug(f"Gaming detection failed: {e}")
     return signals

--- a/tests/test_enrichments_mirror.py
+++ b/tests/test_enrichments_mirror.py
@@ -116,6 +116,30 @@ class TestDetectGaming:
         assert len(signals) >= 1
         assert any("variance" in s.lower() or "autopilot" in s.lower() for s in signals)
 
+    def test_records_capture_structured_trigger(self):
+        # Phase 0 instrumentation: structured trigger record alongside prose.
+        records = []
+        ctx = _make_ctx(
+            complexity_history=[0.5, 0.5, 0.5, 0.5, 0.5],
+            confidence_history=[0.8, 0.8, 0.8, 0.8, 0.8],
+        )
+        signals = _detect_gaming(ctx, records=records)
+        assert len(signals) >= 1
+        assert len(records) >= 1
+        types = {r["signal_type"] for r in records}
+        assert "autopilot_complexity" in types
+        assert "autopilot_confidence" in types
+        for r in records:
+            assert r["metric"].endswith("_variance")
+            assert r["threshold"] == 0.005
+            assert isinstance(r["value"], float)
+
+    def test_records_optional_back_compat(self):
+        # Called without records (the historical signature) still returns prose.
+        ctx = _make_ctx(complexity_history=[0.5, 0.5, 0.5, 0.5, 0.5])
+        signals = _detect_gaming(ctx)
+        assert any("autopilot" in s.lower() for s in signals)
+
     def test_signals_are_observational_not_interrogative(self):
         # #583 discipline ("reflect, don't advise") applies to the raw gaming
         # signals too, not just the distilled reflection: a mirror line states

--- a/tests/test_response_formatter.py
+++ b/tests/test_response_formatter.py
@@ -20,6 +20,7 @@ from src.mcp_handlers.response_formatter import (
     _format_compact,
     _format_mirror,
     _strip_context,
+    _emit_mirror_signal_records,
 )
 
 
@@ -944,6 +945,73 @@ class TestFormatResponseMirror:
         data = _sample_response()
         result = format_response(data, {"response_mode": "mirror"}, is_new_agent=False)
         assert "eisv_labels" not in result
+
+
+# ============================================================================
+# Phase 0: mirror_signal.emit instrumentation (mirror-effectiveness-measurement-v0)
+# ============================================================================
+
+class TestEmitMirrorSignalRecords:
+    """_emit_mirror_signal_records: shadow-emit signal records, tag surfaced."""
+
+    def _records(self):
+        return [{"signal_type": "autopilot_complexity", "metric": "complexity_variance",
+                 "value": 0.0, "threshold": 0.005}]
+
+    def test_surfaced_true_under_mirror(self):
+        data = _sample_response()
+        data["_mirror_signal_records"] = self._records()
+        meta = MagicMock()
+        meta.total_updates = 12
+        logger_mock = MagicMock()
+        with patch("src.audit_log.get_audit_log", return_value=logger_mock):
+            _emit_mirror_signal_records(data, "mirror", meta)
+        logger_mock.log_mirror_signal_emit.assert_called_once()
+        kwargs = logger_mock.log_mirror_signal_emit.call_args.kwargs
+        assert kwargs["surfaced"] is True
+        assert kwargs["response_mode"] == "mirror"
+        assert kwargs["update_index"] == 12
+        assert kwargs["agent_id"] == "test-agent-123"
+        # internal key always consumed
+        assert "_mirror_signal_records" not in data
+
+    def test_surfaced_false_under_non_mirror(self):
+        data = _sample_response()
+        data["_mirror_signal_records"] = self._records()
+        logger_mock = MagicMock()
+        with patch("src.audit_log.get_audit_log", return_value=logger_mock):
+            _emit_mirror_signal_records(data, "minimal", MagicMock())
+        kwargs = logger_mock.log_mirror_signal_emit.call_args.kwargs
+        assert kwargs["surfaced"] is False
+        assert "_mirror_signal_records" not in data
+
+    def test_no_records_no_emit(self):
+        data = _sample_response()
+        logger_mock = MagicMock()
+        with patch("src.audit_log.get_audit_log", return_value=logger_mock):
+            _emit_mirror_signal_records(data, "mirror", MagicMock())
+        logger_mock.log_mirror_signal_emit.assert_not_called()
+
+    def test_env_flag_disables_emit_but_still_consumes_key(self):
+        data = _sample_response()
+        data["_mirror_signal_records"] = self._records()
+        logger_mock = MagicMock()
+        with patch.dict(os.environ, {"UNITARES_MIRROR_SIGNAL_EMIT": "0"}):
+            with patch("src.audit_log.get_audit_log", return_value=logger_mock):
+                _emit_mirror_signal_records(data, "mirror", MagicMock())
+        logger_mock.log_mirror_signal_emit.assert_not_called()
+        assert "_mirror_signal_records" not in data
+
+    def test_full_mode_consumes_key_no_leak(self):
+        # full mode returns response_data as-is; the internal key must not leak.
+        data = _sample_response()
+        data["_mirror_signal_records"] = self._records()
+        logger_mock = MagicMock()
+        with patch("src.audit_log.get_audit_log", return_value=logger_mock):
+            result = format_response(data, {"response_mode": "full"}, meta=MagicMock())
+        assert "_mirror_signal_records" not in result
+        logger_mock.log_mirror_signal_emit.assert_called_once()
+        assert logger_mock.log_mirror_signal_emit.call_args.kwargs["surfaced"] is False
 
 
 # ============================================================================


### PR DESCRIPTION
## What

Implements **Phase 0** of the mirror-effectiveness-measurement-v0 proposal (merged in #744): the missing instrumentation that makes "does a surfaced mirror signal actually move agent behavior?" measurable at all. Until now signals were computed and discarded — nothing recorded what fired or whether the agent saw it.

## How

- **`enrich_mirror_signals`** now builds structured `_mirror_signal_records` for the numeric signals:
  - autopilot complexity / confidence variance — `_detect_gaming(ctx, records=...)` appends a `{signal_type, metric, value, threshold}` record alongside each prose line (threshold factored into `_GAMING_VARIANCE_THRESHOLD`).
  - complexity divergence — via the existing `_get_complexity_disagreement` gate, so the record fires **exactly** when the surfaced line does (same >3-update baseline + novelty gate).
- **`response_formatter`** resolves `response_mode` first, then `_emit_mirror_signal_records` logs one `mirror_signal.emit` audit event per fired check-in with **`surfaced = (response_mode == "mirror")`**. Non-mirror modes (`minimal`/`compact`/`standard`/`full`) compute the same signals but never show them → the natural **shadow control** Phase 1 joins against. The internal record key is always consumed, so it never leaks into a returned payload (including full mode).
- **`AuditLogger.log_mirror_signal_emit`** follows the existing JSONL-truth + fire-and-forget-PG pattern; best-effort, never raises into the response path.

## Properties

- **Zero agent-facing change** — pure instrumentation.
- **Kill switch:** `UNITARES_MIRROR_SIGNAL_EMIT=0`.
- **Write volume tracks signal incidence**, not every check-in (emits only when ≥1 signal fired → one JSONL append, not one per record).
- Constraints honored: deterministic, no model API, no migration slot (reuses `audit.events` via the executor-pooled write path).

## Tests

`tests/test_enrichments_mirror.py` (record capture + back-compat signature), `tests/test_response_formatter.py` (surfaced true under mirror / false under non-mirror / no-records-no-emit / env-flag-disables / full-mode-no-leak). Ran `test_enrichments_mirror` + `test_response_formatter` + `test_enrichment_pipeline` (150) and `test_audit_log*` (78) — all green on Python 3.12, plus an end-to-end enrich→format→emit sanity check.

## Scope

Draft so you're the merge gate. Phases 1 (offline re-eval) and 2 (operator-gated feedback) remain proposed, not built. Proposal status doc updated to "Phase 0 landed."

https://claude.ai/code/session_01JR8iksWN3JUeuEV8htzG1h

---
_Generated by [Claude Code](https://claude.ai/code/session_01JR8iksWN3JUeuEV8htzG1h)_