### PR TITLE
gitignore: add docs/personal/ for local-only workflow notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,11 +159,18 @@ secrets/
 # LaunchAgent plists (contain secrets — installed copy lives in ~/Library/LaunchAgents/)
 scripts/ops/*.plist
 
-# Documentation — only docs/*.md and docs/guides/ tracked; everything else local
+# Documentation — docs/ subtrees are TRACKED by default (operations, ontology,
+# proposals, integration, install, dev, guides, assets). The entries below are
+# the explicit exceptions kept local-only: machine config, retired/handoff docs,
+# any *.local.md file, and personal workflow notes under docs/personal/.
 docs/INTERNAL_CONFIG.md
 docs/archive/
 docs/handoffs/
 *.local.md
+# Personal workflow patterns — local-only, never committed. Drop any file here
+# (no naming discipline needed) and it stays on your machine; intended for
+# non-coder operators keeping their own workflow notes.
+docs/personal/
 
 # Agent guides (generated onboarding docs, not project documentation)
 .agent-guides/


### PR DESCRIPTION
## What

Adds a gitignored `docs/personal/` directory for local-only workflow notes, and corrects a stale comment in `.gitignore`.

## Why

Personal workflow patterns — especially for a non-coder operator — shouldn't be committed. The existing `*.local.md` mechanism works but requires remembering to suffix every file. A dedicated ignored folder is foolproof: drop any file in `docs/personal/` and it stays local, no naming discipline needed.

## Changes

- **`docs/personal/`** — new gitignore entry; anything placed here is local-only.
- **Stale comment fix** — the old comment claimed "only docs/*.md and docs/guides/ tracked; everything else local," which is false. `docs/operations/`, `docs/ontology/`, `docs/proposals/`, `docs/integration/`, `docs/install/`, and `docs/dev/` are all tracked. Comment now reflects the real policy: subtrees tracked by default, with explicit local-only exceptions.

## Verification

```
$ git check-ignore -v docs/personal/my-workflow.md docs/notes.local.md
.gitignore:173:docs/personal/	docs/personal/my-workflow.md
.gitignore:169:*.local.md	docs/notes.local.md
```
Tracked docs (e.g. `docs/operations/github-workflow-conventions.md`) are correctly not ignored.

https://claude.ai/code/session_01R3AMsCWGyCDGQR6RnRiNyc

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3AMsCWGyCDGQR6RnRiNyc)_