### PR TITLE
fix(sdk): reconcile resident tags on resume, not just fresh onboard

### DIFF
--- a/agents/sdk/src/unitares_sdk/agent.py
+++ b/agents/sdk/src/unitares_sdk/agent.py
@@ -413,7 +413,10 @@ class GovernanceAgent:
         """
         if not (self.persistent and self.agent_uuid):
             return
-        if self._resident_tags_reconciled:
+        # getattr-guarded: instances built via __new__ (test stubs) skip
+        # __init__, so the attribute may be absent. Treat absent as "not yet
+        # reconciled" rather than crashing the identity path.
+        if getattr(self, "_resident_tags_reconciled", False):
             return
 
         try:

--- a/agents/sdk/src/unitares_sdk/agent.py
+++ b/agents/sdk/src/unitares_sdk/agent.py
@@ -167,6 +167,12 @@ class GovernanceAgent:
         self.continuity_token: str | None = None
         self.agent_uuid: str | None = None
         self._last_checkin_time: float = 0.0
+        # Resident tag reconciliation runs at most once per process. Tags don't
+        # drift mid-process, so a per-cycle re-check would just add a
+        # get_agent_metadata read every cycle (substrate-tax sensitive). Set
+        # True once a read succeeds; left False on a read/write failure so the
+        # next cycle retries. See _reconcile_resident_tags.
+        self._resident_tags_reconciled = False
 
     # --- Subclass interface ---
 
@@ -334,6 +340,11 @@ class GovernanceAgent:
                 self._sync_from_client(client)
                 self._save_session()
                 logger.info("%s: resumed via UUID %s", self.name, self.agent_uuid[:12])
+                # Reconcile resident tags on resume too — residents that always
+                # resume via UUID (refuse_fresh_onboard=True) never re-run the
+                # fresh-onboard stamp, so a dropped required tag would otherwise
+                # never self-heal (Sentinel 2026-06-15 resident_tag_gap finding).
+                await self._reconcile_resident_tags(client)
                 return
             except Exception as e:
                 logger.error(
@@ -362,39 +373,100 @@ class GovernanceAgent:
         self._save_session()
         logger.info("%s: onboarded fresh (UUID %s)", self.name, self.agent_uuid[:12] if self.agent_uuid else "?")
 
-        if self.persistent and self.agent_uuid:
-            # Residents need BOTH tags:
-            #   - 'persistent':  protects from auto_archive_orphan_agents
-            #   - 'autonomous':  exempts from loop-detection pattern 4
-            #                    (agent_loop_detection.py:216). Resident cadences
-            #                    can't respond to pause verdicts within the 30s
-            #                    cooldown, so pattern-4 rejection silently starves
-            #                    their state writes (Steward 2026-04-20 regression).
-            #
-            # S8a Phase-1 (2026-04-23): the server now stamps these tags in the
-            # onboard handler for any name matching KNOWN_RESIDENT_LABELS (see
-            # src/grounding/onboard_classifier.py + identity/handlers.py
-            # _stamp_default_tags_on_onboard). This client-side write is now
-            # redundant against a current server, but retained as backward
-            # compatibility for older server deploys that predate Phase 1. It
-            # is a no-op when the server already stamped the same tags.
-            try:
-                await client.call_tool(
-                    "update_agent_metadata",
-                    {"agent_id": self.agent_uuid, "tags": RESIDENT_TAGS},
-                )
-                logger.info(
-                    "%s: stamped resident tags %s",
-                    self.name, RESIDENT_TAGS,
-                )
-            except Exception as e:
-                # Non-fatal. The agent still runs; it's just vulnerable to
-                # archive_orphan_agents AND loop-detection until someone tags it.
-                logger.warning(
-                    "%s: failed to stamp resident tags: %s "
-                    "(will retry on next fresh onboard; manual tagging may be needed)",
-                    self.name, e,
-                )
+        # Stamp/reconcile resident tags after fresh onboard. The server already
+        # stamps these in the onboard handler for KNOWN_RESIDENT_LABELS (S8a
+        # Phase-1, 2026-04-23), so this is usually a no-op against a current
+        # server; it still covers pre-Phase-1 deploys where the server didn't.
+        await self._reconcile_resident_tags(client)
+
+    async def _reconcile_resident_tags(self, client: GovernanceClient) -> None:
+        """Ensure a persistent resident carries the full ``RESIDENT_TAGS`` set.
+
+        Residents need BOTH tags:
+          - ``persistent``:  protects from ``auto_archive_orphan_agents``
+            (``is_agent_protected`` in ``src/agent_lifecycle.py``).
+          - ``autonomous``:  exempts from loop-detection pattern 4
+            (``agent_loop_detection.py:216``). Resident cadences can't respond
+            to pause verdicts within the 30s cooldown, so pattern-4 rejection
+            silently starves their state writes (Steward 2026-04-20 regression).
+
+        Both the SDK fresh-onboard stamp and the server-side onboard stamp only
+        fire at *creation*. Residents like Sentinel set
+        ``refuse_fresh_onboard=True`` and ALWAYS resume via UUID, so neither
+        re-runs after the identity exists. If a required tag is ever dropped —
+        an identity minted before ``autonomous`` was required, an archive/resume
+        cycle, or a tag-replacing metadata write — nothing re-adds it and
+        Vigil's ``resident_tag_hygiene`` check flags the gap on every cycle
+        until someone manually re-tags (Sentinel 2026-06-15).
+
+        Reconcile instead: read the current tags and, if any ``RESIDENT_TAGS``
+        are missing, write back the UNION. Additive on purpose —
+        ``update_agent_metadata`` REPLACES the tag list, so a bare
+        ``RESIDENT_TAGS`` write would clobber role/cadence tags (e.g.
+        ``cadence.10min``). A no-op (no write) when the tags are already
+        present, and runs at most once per process (see
+        ``_resident_tags_reconciled``).
+
+        Non-fatal throughout: the agent still runs if reconciliation can't
+        complete; the gap just persists (and stays visible to Vigil) until a
+        later cycle or restart succeeds.
+        """
+        if not (self.persistent and self.agent_uuid):
+            return
+        if self._resident_tags_reconciled:
+            return
+
+        try:
+            raw = await client.call_tool(
+                "get_agent_metadata", {"target_agent": self.agent_uuid}
+            )
+        except Exception as e:
+            # Couldn't read current tags — do NOT blind-write (that would risk
+            # clobbering cadence/role tags). Leave the flag unset so the next
+            # cycle retries.
+            logger.warning(
+                "%s: could not read tags to reconcile resident tag set: %s "
+                "(will retry next cycle)",
+                self.name, e,
+            )
+            return
+
+        if not isinstance(raw, dict):
+            logger.debug(
+                "%s: resident tag reconcile skipped — unexpected "
+                "get_agent_metadata response shape",
+                self.name,
+            )
+            return
+
+        current = [t for t in (raw.get("tags") or []) if isinstance(t, str)]
+        missing = [t for t in RESIDENT_TAGS if t not in current]
+        if not missing:
+            # Already healthy — record success so we don't re-read every cycle.
+            self._resident_tags_reconciled = True
+            return
+
+        merged = current + missing  # additive — preserves role/cadence tags
+        try:
+            await client.call_tool(
+                "update_agent_metadata",
+                {"agent_id": self.agent_uuid, "tags": merged},
+            )
+            logger.info(
+                "%s: reconciled resident tags — added %s (now %s)",
+                self.name, missing, merged,
+            )
+            self._resident_tags_reconciled = True
+        except Exception as e:
+            # Non-fatal. The agent still runs; it's just vulnerable to
+            # archive_orphan_agents AND loop-detection until tagged. Flag stays
+            # unset so the next cycle retries.
+            logger.warning(
+                "%s: failed to write reconciled resident tags %s: %s "
+                "(vulnerable to orphan-sweep / loop-detection pattern 4 "
+                "until tagged)",
+                self.name, merged, e,
+            )
 
     # --- Check-in handling ---
 

--- a/agents/sdk/tests/test_agent.py
+++ b/agents/sdk/tests/test_agent.py
@@ -90,6 +90,41 @@ def _mock_client_connected():
     return client
 
 
+def _call_tool_with_tags(existing_tags, *, fail_update=False):
+    """An AsyncMock for client.call_tool that answers get_agent_metadata with
+    ``existing_tags`` and records update_agent_metadata writes. ``fail_update``
+    makes the write raise (to exercise the non-fatal path)."""
+
+    async def _impl(tool, args, **kwargs):
+        if tool == "get_agent_metadata":
+            return {"success": True, "tags": list(existing_tags)}
+        if tool == "update_agent_metadata":
+            if fail_update:
+                raise RuntimeError("write down")
+            return {"success": True, "tags": args.get("tags")}
+        return {"success": True}
+
+    return AsyncMock(side_effect=_impl)
+
+
+def _tool_writes(client):
+    """The argument dicts passed to every update_agent_metadata call."""
+    return [
+        c.args[1]
+        for c in client.call_tool.await_args_list
+        if c.args and c.args[0] == "update_agent_metadata"
+    ]
+
+
+def _tool_reads(client):
+    """The target_agent of every get_agent_metadata call."""
+    return [
+        c.args[1].get("target_agent")
+        for c in client.call_tool.await_args_list
+        if c.args and c.args[0] == "get_agent_metadata"
+    ]
+
+
 # --- Identity resolution ---
 
 
@@ -175,6 +210,9 @@ class TestIdentityResolution:
         2026-04-20 because this path stamped only 'persistent'; once every 5min
         its sync was rejected, starving core.agent_state. RESIDENT_TAGS is the
         single source of truth.
+
+        Against a pre-Phase-1 server (no server-side onboard stamp) the
+        reconcile reads an empty tag set then writes RESIDENT_TAGS.
         """
         from unitares_sdk.agent import RESIDENT_TAGS
         assert "persistent" in RESIDENT_TAGS
@@ -183,18 +221,32 @@ class TestIdentityResolution:
         agent = SimpleAgent(session_file=tmp_path / ".test_session", persistent=True)
 
         client = _mock_client_connected()
+        client.call_tool = _call_tool_with_tags([])  # server hasn't stamped yet
         await agent._ensure_identity(client)
 
-        # Fresh onboard + subsequent update_agent_metadata call
+        # Fresh onboard, then read-then-write reconcile.
         client.onboard.assert_called_once()
-        client.call_tool.assert_awaited_once_with(
-            "update_agent_metadata",
-            {"agent_id": "uuid-test", "tags": RESIDENT_TAGS},
-        )
+        writes = _tool_writes(client)
+        assert writes == [{"agent_id": "uuid-test", "tags": RESIDENT_TAGS}]
+
+    @pytest.mark.asyncio
+    async def test_resident_tags_noop_on_fresh_onboard_when_server_stamped(self, tmp_path):
+        """Against a current server the onboard handler already stamped the tags,
+        so the SDK reconcile reads them present and issues no redundant write."""
+        from unitares_sdk.agent import RESIDENT_TAGS
+
+        agent = SimpleAgent(session_file=tmp_path / ".test_session", persistent=True)
+
+        client = _mock_client_connected()
+        client.call_tool = _call_tool_with_tags(list(RESIDENT_TAGS))
+        await agent._ensure_identity(client)
+
+        client.onboard.assert_called_once()
+        assert _tool_writes(client) == []  # read-only, no update
 
     @pytest.mark.asyncio
     async def test_persistent_tag_not_stamped_when_not_persistent(self, tmp_path):
-        """Default persistent=False must not call update_agent_metadata."""
+        """Default persistent=False must not touch metadata at all."""
         agent = SimpleAgent(session_file=tmp_path / ".test_session")
 
         client = _mock_client_connected()
@@ -204,34 +256,114 @@ class TestIdentityResolution:
         client.call_tool.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_persistent_tag_not_stamped_on_uuid_resume(self, tmp_path):
-        """Resuming an existing UUID skips tag stamping — it's already been tagged
-        on the original fresh onboard (or manually).
-        """
+    async def test_resident_tags_reconciled_on_uuid_resume_when_complete(self, tmp_path):
+        """Resuming a fully-tagged identity reads the tags but writes nothing."""
+        from unitares_sdk.agent import RESIDENT_TAGS
+
         agent = SimpleAgent(session_file=tmp_path / ".test_session", persistent=True)
         agent.agent_uuid = "uuid-test"  # triggers the resume fast path
 
         client = _mock_client_connected()
+        client.call_tool = _call_tool_with_tags(list(RESIDENT_TAGS))
         await agent._ensure_identity(client)
 
         client.identity.assert_awaited_once()
         client.onboard.assert_not_called()
-        client.call_tool.assert_not_called()
+        # Reconcile read happened, but no missing tag → no write.
+        assert _tool_reads(client) == ["uuid-test"]
+        assert _tool_writes(client) == []
 
     @pytest.mark.asyncio
-    async def test_persistent_tag_failure_is_non_fatal(self, tmp_path):
-        """If update_agent_metadata fails, the agent still onboards successfully."""
+    async def test_resident_tags_reconciled_on_uuid_resume_when_missing(self, tmp_path):
+        """Sentinel 2026-06-15 regression: a resident that always resumes via UUID
+        with a dropped 'autonomous' tag must self-heal on resume, not stay flagged
+        by Vigil forever. The fresh-onboard stamp never re-fires for these agents.
+        """
         agent = SimpleAgent(session_file=tmp_path / ".test_session", persistent=True)
+        agent.agent_uuid = "uuid-test"  # resume fast path
 
         client = _mock_client_connected()
-        client.call_tool = AsyncMock(side_effect=RuntimeError("db down"))
-
-        # Must not raise — the exception is caught and logged.
+        client.call_tool = _call_tool_with_tags(["persistent"])  # missing 'autonomous'
         await agent._ensure_identity(client)
 
-        client.onboard.assert_called_once()
-        client.call_tool.assert_awaited_once()
-        # Identity is still established.
+        client.identity.assert_awaited_once()
+        client.onboard.assert_not_called()
+        # Additive write restores the full set.
+        assert _tool_writes(client) == [
+            {"agent_id": "uuid-test", "tags": ["persistent", "autonomous"]},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_resident_tag_reconcile_preserves_role_tags(self, tmp_path):
+        """Reconcile is additive: role/cadence tags (cadence.10min) are preserved,
+        the missing required tag is appended. A bare RESIDENT_TAGS write would
+        clobber them because update_agent_metadata REPLACES the list.
+        """
+        agent = SimpleAgent(session_file=tmp_path / ".test_session", persistent=True)
+        agent.agent_uuid = "uuid-test"
+
+        client = _mock_client_connected()
+        client.call_tool = _call_tool_with_tags(["persistent", "cadence.10min"])
+        await agent._ensure_identity(client)
+
+        assert _tool_writes(client) == [
+            {"agent_id": "uuid-test", "tags": ["persistent", "cadence.10min", "autonomous"]},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_resident_tags_reconciled_once_per_process(self, tmp_path):
+        """A successful reconcile is not re-run on the next cycle (no per-cycle
+        get_agent_metadata read). _ensure_identity runs every cycle, so this
+        guards against a recurring substrate-tax read.
+        """
+        agent = SimpleAgent(session_file=tmp_path / ".test_session", persistent=True)
+        agent.agent_uuid = "uuid-test"
+
+        client = _mock_client_connected()
+        client.call_tool = _call_tool_with_tags(["persistent"])
+
+        await agent._ensure_identity(client)  # cycle 1: read + write
+        await agent._ensure_identity(client)  # cycle 2: must not re-check
+
+        assert _tool_reads(client) == ["uuid-test"]  # exactly one read total
+        assert len(_tool_writes(client)) == 1
+
+    @pytest.mark.asyncio
+    async def test_resident_tag_read_failure_is_non_fatal_and_retries(self, tmp_path):
+        """If the tag read fails we must NOT blind-write (clobber risk), must not
+        raise, and must leave the door open to retry on the next cycle."""
+        agent = SimpleAgent(session_file=tmp_path / ".test_session", persistent=True)
+        agent.agent_uuid = "uuid-test"
+
+        client = _mock_client_connected()
+        client.call_tool = AsyncMock(side_effect=RuntimeError("read down"))
+
+        # Must not raise — exception caught and logged.
+        await agent._ensure_identity(client)
+
+        client.identity.assert_awaited_once()
+        assert _tool_writes(client) == []  # never a blind write
+        assert agent._resident_tags_reconciled is False  # will retry next cycle
+
+    @pytest.mark.asyncio
+    async def test_resident_tag_write_failure_is_non_fatal_and_retries(self, tmp_path):
+        """If the reconcile write fails the agent still runs and the flag stays
+        unset so the next cycle retries the write."""
+        agent = SimpleAgent(session_file=tmp_path / ".test_session", persistent=True)
+        agent.agent_uuid = "uuid-test"
+
+        client = _mock_client_connected()
+        client.call_tool = _call_tool_with_tags(["persistent"], fail_update=True)
+
+        await agent._ensure_identity(client)
+
+        assert agent._resident_tags_reconciled is False
+        # Read succeeded, write was attempted (and failed) — both awaited.
+        assert _tool_reads(client) == ["uuid-test"]
+        assert _tool_writes(client) == [
+            {"agent_id": "uuid-test", "tags": ["persistent", "autonomous"]},
+        ]
+        # Identity is still established despite the write failure.
         assert agent.agent_uuid == "uuid-test"
 
 


### PR DESCRIPTION
## What Vigil flagged

Vigil's `resident_tag_hygiene` check reported a `resident_tag_gap` — **Sentinel missing a required tag** (`autonomous`). Required resident tags are `["persistent", "autonomous"]`; `autonomous` exempts from loop-detection pattern 4 (`agent_loop_detection.py:216`) and `persistent` exempts from `auto_archive_orphan_agents`. A resident missing `autonomous` gets its state writes silently starved once its cadence trips pattern 4 (the Steward 2026-04-20 regression class).

## Root cause

Resident class tags are only ever stamped at **creation**:
- the SDK fresh-onboard stamp (`GovernanceAgent._ensure_identity`), and
- the server-side onboard stamp (S8a Phase-1, `src/grounding/onboard_classifier.py` → `_stamp_default_tags_on_onboard`).

Both fire **once**. Residents like Sentinel set `refuse_fresh_onboard=True` and **always resume via UUID** (`client.identity(resume=True)`), so neither stamp path re-runs after the identity exists. If a required tag is ever dropped — an identity minted before `autonomous` became required, an archive/resume cycle, or a tag-replacing `update_agent_metadata` write — **nothing re-adds it**, and Vigil flags the gap on every cycle until someone manually re-tags. There was no reconciliation on resume; a test (`test_persistent_tag_not_stamped_on_uuid_resume`) even codified that resume *skips* stamping under the now-false assumption "it's already been tagged."

## Fix

`GovernanceAgent` now reconciles resident tags on **every identity resolution** (resume fast path included), not just fresh onboard:

- Reads current tags via `get_agent_metadata`, and **only if a required tag is missing** writes back the **union** of current + missing tags.
- **Additive on purpose:** `update_agent_metadata` *replaces* the tag list, so a bare `RESIDENT_TAGS` write would clobber role/cadence tags (e.g. `cadence.10min`). The union preserves them.
- **Runs at most once per process** (`_resident_tags_reconciled` flag) — `_ensure_identity` runs every cycle, and tags don't drift mid-process, so a per-cycle re-read would be a needless substrate-tax DB read.
- **Non-fatal throughout:** a read failure never blind-writes (clobber-safe) and retries next cycle; a write failure also retries next cycle.

The fresh-onboard path is unified onto the same reconcile call (no-op against a current server that already stamped; still covers pre-Phase-1 server deploys).

This self-heals **Sentinel** plus the other `GovernanceAgent` residents (**Vigil / Chronicler / Steward**) on their next cycle — no restart required, since `_ensure_identity` runs each cycle.

## Scope note

**Watcher** (`agents/watcher/agent.py`) uses a separate bespoke *synchronous* identity path with the identical resume-never-reconciles gap (PATH 0 UUID-direct resume at `agent.py:246` stamps only on fresh onboard). It's deliberately **left as a follow-up** to keep this diff focused on the reported Sentinel case and the shared base-class population. Worth a one-line symmetric reconcile there too.

## Tests

`agents/sdk/tests/test_agent.py` — rewrote the stamp tests around the new reconcile contract and added explicit coverage:
- Sentinel regression: resume with `["persistent"]` → additive write restores `["persistent", "autonomous"]`.
- Cadence preservation: resume with `["persistent", "cadence.10min"]` → write appends `autonomous`, keeps `cadence.10min`.
- No-op when tags already complete (read-only, no write); no-op against server that already stamped.
- Runs once per process (no per-cycle re-read).
- Read/write failures are non-fatal and leave the flag unset to retry.

All 59 SDK agent tests pass locally; `agents/vigil/tests/test_checks_resident_tag_hygiene.py` and `agents/sdk/tests/test_substrate_emission.py` green.

## Clearing the current finding

After deploy, the running residents reconcile on their next cycle and the Vigil finding clears on its own. If immediate closure is wanted before the next cycle, an operator `update_agent_metadata` on Sentinel adding `autonomous` resolves it now.

https://claude.ai/code/session_014yas9YK7kw2k1YsD7Vps5E

---
_Generated by [Claude Code](https://claude.ai/code/session_014yas9YK7kw2k1YsD7Vps5E)_