### PR TITLE
dashboard(chronicler): group metric picker into Fleet · Project · Infra

### DIFF
--- a/dashboard/fleet-metrics.js
+++ b/dashboard/fleet-metrics.js
@@ -192,6 +192,28 @@
         });
     }
 
+    // Chronicler emits three unrelated metric families into one catalog:
+    // fleet/governance state, project/codebase stats, and runtime-infra
+    // latency. A flat dropdown made the panel "mean three things at once".
+    // Classify by series-name prefix so the picker reads as Fleet · Project ·
+    // Infra optgroups; anything unmatched falls through to Other so a new
+    // series never silently disappears. `.error` twins classify by their base
+    // name so a failing scraper sorts next to the series it shadows.
+    var METRIC_GROUPS = [
+        { label: 'Fleet', test: /^(agents|checkins|kg)\./ },
+        { label: 'Project', test: /^(github|tests|tokei)\./ },
+        { label: 'Infra', test: /^(lease_plane|ode)\./ },
+    ];
+    var METRIC_GROUP_ORDER = ['Fleet', 'Project', 'Infra', 'Other'];
+
+    function metricGroupLabel(name) {
+        var base = name.replace(/\.error$/, '');
+        for (var i = 0; i < METRIC_GROUPS.length; i++) {
+            if (METRIC_GROUPS[i].test.test(base)) return METRIC_GROUPS[i].label;
+        }
+        return 'Other';
+    }
+
     function populateDropdown(metrics) {
         var select = document.getElementById('fleet-metrics-select');
         if (!select) return;
@@ -203,14 +225,30 @@
             select.appendChild(opt);
             return;
         }
-        for (var i = 0; i < metrics.length; i++) {
-            var m = metrics[i];
-            var o = document.createElement('option');
-            o.value = m.name;
-            o.textContent = m.name;
-            if (m.description) o.title = m.description;
-            select.appendChild(o);
-        }
+
+        // Bucket by family, preserving catalog order within each bucket, then
+        // emit optgroups in fixed family order. Empty buckets are skipped so a
+        // family with no registered series doesn't clutter the picker.
+        var buckets = {};
+        metrics.forEach(function (m) {
+            var label = metricGroupLabel(m.name);
+            (buckets[label] = buckets[label] || []).push(m);
+        });
+        METRIC_GROUP_ORDER.forEach(function (groupLabel) {
+            var items = buckets[groupLabel];
+            if (!items || items.length === 0) return;
+            var group = document.createElement('optgroup');
+            group.label = groupLabel;
+            items.forEach(function (m) {
+                var o = document.createElement('option');
+                o.value = m.name;
+                o.textContent = m.name;
+                if (m.description) o.title = m.description;
+                group.appendChild(o);
+            });
+            select.appendChild(group);
+        });
+
         if (!currentName || !metrics.some(function (m) { return m.name === currentName; })) {
             currentName = metrics[0].name;
         }


### PR DESCRIPTION
## What

The Chronicler panel's metric picker was a flat dropdown over 13 series spanning **three unrelated families**:

| Group | Series |
|-------|--------|
| **Fleet** (governance/agent state) | `agents.active.7d`, `checkins.7d`, `kg.entries.count` |
| **Project** (repo/codebase) | `github.cirwel.traffic.*`, `tests.unitares.count`, `tokei.unitares.src.code` |
| **Infra** (runtime latency) | `lease_plane.client.v1.lease.acquire.p50/p99`, `ode.numpy_step_ms.p50/p99` |

One panel meant three things at once. This groups the picker into `Fleet · Project · Infra` `<optgroup>`s.

## How

Purely client-side, inside `populateDropdown` (`dashboard/fleet-metrics.js`):
- Classify each series by name prefix into a fixed group order.
- Unmatched series fall through to **Other** so a newly-registered Chronicler series never silently disappears.
- `.error` twins classify by their base name, so a failing scraper sorts beside the series it shadows.

No backend, no catalog/API change, no script-load-chain change, no shared CSS touched — i.e. none of the surfaces that broke this panel before.

## Verification

- `node --check` parses clean.
- Classification dry-run over all 13 live series: every series lands in the correct family, zero `Other` fallthrough, `.error` twin sorts under Project. ✓
- Pre-push smoke gate: 138 passed.

## Not done (deliberately)

No renames. The panel's visible header is already "Chronicler"; `fleet-metrics` survives only as an internal id / filename / **shared** CSS class (reused by Watcher/Sentinel/Vigil/System Health) — renaming it would be churn with breakage risk and no user-facing benefit.