### PR TITLE
[codex] docs: establish turn baseline check-ins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,17 +8,17 @@ The installable Codex/Claude adapter bundle is canonical in the companion `unita
 
 ## Codex-specific wiring
 
-Codex has no hook system analogous to Claude's. **Nothing is automatic.** You decide when to check in, diagnose, and surface Watcher findings.
+Codex has no hook system analogous to Claude's. **Nothing is automatic.** You decide when to check in, diagnose, and surface Watcher findings. The expected Codex baseline is one real check-in per assistant turn, with extra check-ins around high-risk or long-running work. Do not confuse that with per-tool or per-edit check-ins; those are usually noise.
 
 ### Slash commands (`commands/*.md`)
 
 - `/governance-start` — onboard or resume; refreshes local continuity state
-- `/checkin` — governance update after meaningful work
+- `/checkin` — governance update for the current turn, plus meaningful milestones
 - `/diagnose` — identity, state, and operator diagnostics
 - `/dialectic` — structured review
 - `/closeout` — final workspace hygiene check; reports dirty files, Git delivery state (local vs pushed/merged), and repo-rooted processes; can stash/stop when cleanup is requested
 
-Raw tool flow when slash commands are unavailable: `start_session(force_new=true, parent_agent_id=<prior uuid if continuing>, spawn_reason="new_session")` → save `agent_uuid` + `client_session_id` → `sync_state(response_text, complexity, client_session_id=...)` → `check_working_state()` for read-only checks → `health_check()` only if system health is suspect. Canonical/raw equivalents are `onboard(...)`, `process_agent_update(...)`, and `get_governance_metrics(...)`.
+Raw tool flow when slash commands are unavailable: `start_session(force_new=true, parent_agent_id=<prior uuid if continuing>, spawn_reason="new_session")` → save `agent_uuid` + `client_session_id` → `sync_state(response_text, complexity, client_session_id=...)` once per assistant turn and at meaningful milestones → `check_working_state()` for read-only checks → `health_check()` only if system health is suspect. Canonical/raw equivalents are `onboard(...)`, `process_agent_update(...)`, and `get_governance_metrics(...)`.
 
 ### Local continuity cache
 

--- a/CODEX_START.md
+++ b/CODEX_START.md
@@ -8,14 +8,14 @@ The installable Codex adapter itself is canonical in the companion `unitares-gov
 
 ## Goal
 
-Connect to a running UNITARES governance server, preserve continuity cleanly, and check in at meaningful milestones instead of every trivial edit.
+Connect to a running UNITARES governance server, preserve continuity cleanly, and check in once per assistant turn as a behavioral baseline. Add milestone check-ins for substantial work; avoid per-tool or per-edit noise.
 
 ## Stable Workflow
 
 1. Run `/governance-start`
 2. Keep continuity in `.unitares/session.json`
 3. Do real work
-4. Run `/checkin` after a meaningful milestone
+4. Run `/checkin` once per assistant turn, and after meaningful milestones
 5. Run `/diagnose` when continuity or governance state looks wrong
 6. Use `/dialectic` when you need structured review
 7. Run `/closeout` before saying edited work is done
@@ -24,7 +24,7 @@ If you are not using commands directly, the equivalent raw tool flow is:
 
 1. First run or fresh process: `start_session(force_new=true)` and save `agent_uuid` / `client_session_id`
 2. Fresh process continuing prior work: `start_session(force_new=true, parent_agent_id=<saved uuid>, spawn_reason="new_session")`
-3. `sync_state()` after meaningful work
+3. `sync_state()` once per assistant turn, and after meaningful work
 4. Same live owner / proof-owned rebind only: `identity(agent_uuid=..., continuity_token=..., resume=true)`
 5. `check_working_state()` for read-only state checks
 6. `health_check()` only if the system itself may be part of the problem
@@ -37,7 +37,7 @@ payload under `raw_governance`.
 ## Codex Reality
 
 - Codex uses slash commands and explicit tool calls, not Claude hooks
-- nothing auto-checks in for you
+- nothing auto-checks in for you; keep the turn-level baseline yourself
 - Watcher findings are manual unless you invoke the watcher CLI yourself
 - `.unitares/session.json` is local workspace state; use its `uuid` as a lineage candidate, not a resume credential
 
@@ -77,10 +77,11 @@ Typical session:
 
 - start or declare lineage with `/governance-start`
 - do meaningful work
-- check in after a milestone, completed step, or decision point
+- check in once per assistant turn as a baseline
+- add a check-in after a milestone, completed step, or decision point
 - diagnose only when needed
 
-Do not treat every file edit as a governance event. High-signal check-ins are more useful than noisy ones.
+Do not treat every file edit or tool call as a governance event. Turn-level baseline check-ins are useful; raw file churn is not.
 
 ## What to Watch
 
@@ -138,7 +139,7 @@ pushes, and `--auto-merge` is only for when the operator explicitly asks.
 ## Commands
 
 - `/governance-start` to create or declare lineage and refresh local continuity state
-- `/checkin` for a governance update after meaningful work
+- `/checkin` for the turn baseline and meaningful milestones
 - `/diagnose` for identity, state, and operator diagnostics
 - `/dialectic` for structured review
 - `/closeout` for workspace hygiene and explicit GitHub delivery state

--- a/commands/checkin.md
+++ b/commands/checkin.md
@@ -1,5 +1,5 @@
 ---
-description: "Manual UNITARES governance check-in after meaningful work"
+description: "Manual UNITARES governance check-in for the current turn"
 ---
 
 Before calling tools, check the local workspace cache inventory.
@@ -18,7 +18,7 @@ If this is a fresh process and no ownership proof is available, use `/governance
 
 If no local continuity state exists and the current identity is unclear, use `/governance-start` first.
 
-Call `process_agent_update` for the current agent after a meaningful unit of work.
+Call `process_agent_update` for the current agent once per assistant turn to establish a behavioral baseline. Also call it after meaningful milestones, before/after high-risk work, or when uncertainty/drift shows up.
 
 Inputs:
 
@@ -30,8 +30,9 @@ Inputs:
 
 Guidelines:
 
-- Do not check in after every trivial edit.
-- Prefer one check-in per meaningful milestone, completed step, or decision point.
+- Do not check in after every trivial edit or tool call.
+- Prefer one baseline check-in per assistant turn.
+- Add a check-in for meaningful milestones, completed steps, or decision points.
 - If you had to rebind with `identity()`, only use that restored binding when the response shows strong/proof-owned continuity.
 - If recent local edit context exists, use it to improve the summary, but do not report raw file churn as if it were real progress.
 - If deterministic results already happened in the workflow, mention them concretely instead of speaking in generalities.

--- a/commands/governance-start.md
+++ b/commands/governance-start.md
@@ -62,7 +62,7 @@ When reporting back:
 - show the resolved display name or agent id
 - note whether continuity is strong or weak
 - mention the next useful command:
-  - `/checkin` after meaningful work
+  - `/checkin` for the turn baseline, then after meaningful milestones
   - `/diagnose` if continuity still looks wrong
 
 Do not dump raw JSON unless the user asks for it.


### PR DESCRIPTION
## Summary
- Document one real Codex check-in per assistant turn as the expected baseline
- Keep extra check-ins around meaningful milestones and higher-risk work
- Clarify that per-tool/per-edit check-ins are noise

## Validation
- ./scripts/dev/check-shared-contract.sh
- ./scripts/dev/test-cache.sh --staged: 9981 passed, 22 skipped
- pre-push smoke: 138 passed, 9243 deselected
- consistency scan for stale milestone-only wording