### PR TITLE
docs(workflow): frame per-turn check-in cadence + baseline rationale (#752)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,7 +177,7 @@ Per identity.md v2 ontology, fresh process-instances mint fresh identity. Lineag
 Default happy path:
 
 1. `onboard(force_new=true)` with NO `parent_agent_id` → save `agent_uuid` and `client_session_id` from response. A fresh session onboards fresh; co-location in this workspace is not lineage.
-2. `process_agent_update(response_text=..., complexity=..., client_session_id=...)` for in-process check-ins
+2. `process_agent_update(response_text=..., complexity=..., client_session_id=...)` for in-process check-ins. **Check in per working turn, not once.** Governance is a trajectory, not a point: the first check-in returns `margin: "settling"` (warmup — fewer than 3 check-ins, so the server cannot judge headroom yet), and calibration (`auto_ground_truth`) only means something once it has the volume of repeated (prediction, outcome) pairs a cadence produces. A per-turn cadence is **not performative** — its value is longitudinal and invisible at the single-call altitude, so judging it by one turn's payload is an altitude error. Keep each check-in substantive (a real `confidence`, what changed, what you are now uncertain about) rather than rote; rote logging and no logging both starve the baseline.
 3. On a future process-instance, repeat step 1 — onboard fresh, do not auto-resume and do not declare the prior session as a parent.
 
 Declare lineage (`parent_agent_id`) ONLY for a real causal event:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ Per identity.md v2 ontology, fresh process-instances mint fresh identity. Lineag
 Default happy path:
 
 1. `onboard(force_new=true)` with NO `parent_agent_id` → save `agent_uuid` and `client_session_id` from response. A fresh session onboards fresh; co-location in this workspace is not lineage.
-2. `process_agent_update(response_text=..., complexity=..., client_session_id=...)` for in-process check-ins
+2. `process_agent_update(response_text=..., complexity=..., client_session_id=...)` for in-process check-ins. **Check in per working turn, not once.** Governance is a trajectory, not a point: the first check-in returns `margin: "settling"` (warmup — fewer than 3 check-ins, so the server cannot judge headroom yet), and calibration (`auto_ground_truth`) only means something once it has the volume of repeated (prediction, outcome) pairs a cadence produces. A per-turn cadence is **not performative** — its value is longitudinal and invisible at the single-call altitude, so judging it by one turn's payload is an altitude error. Keep each check-in substantive (a real `confidence`, what changed, what you are now uncertain about) rather than rote; rote logging and no logging both starve the baseline.
 3. On a future process-instance, repeat step 1 — onboard fresh, do not auto-resume and do not declare the prior session as a parent.
 
 Declare lineage (`parent_agent_id`) ONLY for a real causal event:


### PR DESCRIPTION
## What

Reframes step 2 of the **Minimal Agent Workflow** (shared contract, in both `CLAUDE.md` and `AGENTS.md`) from a one-shot `process_agent_update` into a **per-turn cadence**, with the baseline rationale spelled out.

## Why

Surfaced from a dogfood thread (context: #752). The workflow described check-ins as a single step, so an agent had no reason not to dismiss repeated check-ins as "performative" — a judgment that, in practice, was inaccurate. The inaccuracy is structural:

- A single check-in returns `margin: "settling"` — warmup, fewer than 3 check-ins, **the server literally cannot judge headroom yet**. Verified live this session: a fresh onboard + one `process_agent_update` came back `margin: "settling"`, `nearest_edge: null`.
- Coherence/risk/calibration are trajectory-and-rate measures. Sparse sampling (only at moments the agent already flagged) is a biased sample that misses the *onset* of drift.
- `auto_ground_truth` calibration is statistical — it needs the volume of repeated (prediction, outcome) pairs a cadence produces.
- The "performative" dismissal is an **altitude error**: the value is longitudinal and invisible at the single-call altitude, so judging it by one turn's payload draws the wrong conclusion.

The grain of truth in the critique — a *rote* check-in ("fine/fine/fine") is low-value — is addressed by asking each check-in to stay substantive (real `confidence`, what changed, what's now uncertain) rather than by dropping the cadence. Rote logging and no logging both starve the baseline.

## Scope / safety

- Docs-only, inside the shared-contract block → edited identically in `CLAUDE.md` and `AGENTS.md`; `./scripts/dev/check-shared-contract.sh` reports **in sync**.
- This touches the identity/onboarding single-writer surface; checked for in-flight PRs first — none open.
- Additive guidance only; no change to identity resolution, schemas, or the `force_new` / `parent_agent_id` posture.

## Known divergence (deferred, intentional)

Other agent-facing surfaces carry a *milestone* cadence that differs in emphasis from this PR's "per working turn" framing:

- `commands/checkin.md`: "Prefer one check-in per meaningful milestone… do not check in after every trivial edit."
- `skills/governance-lifecycle/SKILL.md`: "Not after every single tool call — use judgment between these bounds."

These were **deliberately left untouched** (operator decision): this PR stays narrowly the shared-contract change, and the cross-surface cadence story (plus the `unitares-governance-plugin` adapter copies) is to be reconciled in a separate holistic pass rather than harmonized piecemeal here.

Relates to #752 (the "incentivized self-report" axis — this is the argument for why the self-report cadence is worth keeping, not the full posture implementation).

https://claude.ai/code/session_01NtYZ6hBDZ4fB7UBvr93sn4