### PR TITLE
test: add regression coverage for hck_reflexive math + gateway query router

### DIFF
--- a/tests/test_hck_reflexive.py
+++ b/tests/test_hck_reflexive.py
@@ -1,0 +1,132 @@
+"""Regression tests for src/hck_reflexive.py (HCK v3.0 reflexive control math).
+
+These are pure, stateless functions feeding the PI controller and stability
+tracking: update coherence rho(t), continuity energy CE(t), and PI-gain
+modulation. They had no direct coverage. Pin the input->output contract so a
+change to the coherence/energy formulas is caught.
+
+NOTE — modulate_gains doc/behavior mismatch (surfaced by this test):
+the docstring's worked example claims `rho=0 -> factor=0.75`, but the
+implementation computes `max(min_factor, (rho + 1) / 2)`, which yields 0.5 at
+rho=0 and a *flat* 0.5 floor for every rho <= 0. The tests below pin the actual
+implemented behavior (0.5), not the docstring's number. Flagged for a human to
+decide whether the doc or the formula is wrong.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.hck_reflexive import (
+    compute_update_coherence,
+    compute_continuity_energy,
+    modulate_gains,
+)
+
+
+# --------------------------------------------------------------------------- #
+# compute_update_coherence — directional alignment of E and I updates
+# --------------------------------------------------------------------------- #
+
+class TestUpdateCoherence:
+    def test_aligned_updates_approach_plus_one(self):
+        assert compute_update_coherence(0.2, 0.3) == pytest.approx(1.0, abs=1e-6)
+        assert compute_update_coherence(-0.2, -0.3) == pytest.approx(1.0, abs=1e-6)
+
+    def test_opposed_updates_approach_minus_one(self):
+        assert compute_update_coherence(0.2, -0.3) == pytest.approx(-1.0, abs=1e-6)
+        assert compute_update_coherence(-0.2, 0.3) == pytest.approx(-1.0, abs=1e-6)
+
+    def test_zero_delta_is_neutral(self):
+        assert compute_update_coherence(0.0, 0.5) == pytest.approx(0.0)
+        assert compute_update_coherence(0.5, 0.0) == pytest.approx(0.0)
+        assert compute_update_coherence(0.0, 0.0) == pytest.approx(0.0)
+
+    def test_result_always_within_unit_range(self):
+        for dE, dI in [(1e6, 1e6), (-1e6, 1e6), (1e-9, -1e-9), (5.0, -0.001)]:
+            rho = compute_update_coherence(dE, dI)
+            assert -1.0 <= rho <= 1.0
+
+    def test_magnitude_independent_only_direction_matters(self):
+        small = compute_update_coherence(0.01, 0.02)
+        large = compute_update_coherence(100.0, 200.0)
+        assert small == pytest.approx(large, abs=1e-4)
+
+
+# --------------------------------------------------------------------------- #
+# compute_continuity_energy — work to maintain consistency as state evolves
+# --------------------------------------------------------------------------- #
+
+class TestContinuityEnergy:
+    def test_insufficient_history_is_zero(self):
+        assert compute_continuity_energy([]) == 0.0
+        assert compute_continuity_energy([{"E": 0.5}]) == 0.0
+
+    def test_pure_state_delta_weighted_by_alpha_state(self):
+        # Single EISV change of 0.1 (in E), no route changes.
+        # CE = alpha_state * avg_state_delta = 0.6 * 0.1
+        history = [
+            {"E": 0.5, "I": 0.5, "S": 0.5, "V": 0.0},
+            {"E": 0.6, "I": 0.5, "S": 0.5, "V": 0.0},
+        ]
+        assert compute_continuity_energy(history) == pytest.approx(0.06)
+
+    def test_route_flips_weighted_by_alpha_decision(self):
+        # Stable EISV, route flips a->b->a over 3 states => 2 changes / 2 = 1.0
+        # CE = alpha_decision * 1.0 = 0.4
+        history = [
+            {"E": 0.5, "I": 0.5, "S": 0.5, "V": 0.0, "route": "a"},
+            {"E": 0.5, "I": 0.5, "S": 0.5, "V": 0.0, "route": "b"},
+            {"E": 0.5, "I": 0.5, "S": 0.5, "V": 0.0, "route": "a"},
+        ]
+        assert compute_continuity_energy(history) == pytest.approx(0.4)
+
+    def test_window_limits_states_considered(self):
+        # 50 flat states then a big jump only in the last pair; with window=2
+        # only the last two states are considered → the jump dominates.
+        history = [{"E": 0.5, "I": 0.5, "S": 0.5, "V": 0.0} for _ in range(50)]
+        history.append({"E": 1.0, "I": 0.5, "S": 0.5, "V": 0.0})  # +0.5 in E
+        ce = compute_continuity_energy(history, window=2)
+        assert ce == pytest.approx(0.6 * 0.5)
+
+    def test_energy_is_non_negative(self):
+        history = [
+            {"E": 0.9, "I": 0.1, "S": 0.2, "V": -0.3, "route": "x"},
+            {"E": 0.1, "I": 0.9, "S": 0.8, "V": 0.3, "route": "y"},
+        ]
+        assert compute_continuity_energy(history) >= 0.0
+
+
+# --------------------------------------------------------------------------- #
+# modulate_gains — reduce PI aggressiveness when updates are incoherent
+# --------------------------------------------------------------------------- #
+
+class TestModulateGains:
+    def test_full_coherence_leaves_gains_unchanged(self):
+        kp, ki = modulate_gains(1.0, 2.0, rho=1.0)
+        assert kp == pytest.approx(1.0)
+        assert ki == pytest.approx(2.0)
+
+    def test_positive_rho_scales_linearly(self):
+        # rho=0.5 -> factor = max(0.5, 0.75) = 0.75
+        kp, ki = modulate_gains(1.0, 2.0, rho=0.5)
+        assert kp == pytest.approx(0.75)
+        assert ki == pytest.approx(1.5)
+
+    def test_zero_rho_hits_floor_not_doc_example(self):
+        # Implementation: max(0.5, (0+1)/2) = 0.5  (docstring claims 0.75)
+        kp, ki = modulate_gains(1.0, 1.0, rho=0.0)
+        assert kp == pytest.approx(0.5)
+        assert ki == pytest.approx(0.5)
+
+    @pytest.mark.parametrize("rho", [0.0, -0.25, -0.5, -1.0])
+    def test_nonpositive_rho_clamped_to_min_factor(self, rho):
+        # Every rho <= 0 collapses to the 0.5 floor (flat, not a smooth curve).
+        kp, ki = modulate_gains(1.0, 1.0, rho=rho)
+        assert kp == pytest.approx(0.5)
+        assert ki == pytest.approx(0.5)
+
+    def test_custom_min_factor_respected(self):
+        kp, ki = modulate_gains(1.0, 1.0, rho=-1.0, min_factor=0.2)
+        assert kp == pytest.approx(0.2)
+        assert ki == pytest.approx(0.2)

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -1,0 +1,138 @@
+"""Regression tests for src/gateway/query_engine.py.
+
+The gateway's natural-language router classifies a question into one of five
+intents (status/checkin/search/note/help) and maps it to a tool call. It tries
+an LLM first, then a deterministic keyword fallback. Only the LLM path needs a
+client; the keyword classifier and the intent->tool routing are pure and were
+untested. These tests pin the fallback contract (the safety net when the LLM is
+unavailable) and the routing table.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.gateway.query_engine import (
+    _keyword_classify,
+    classify_intent,
+    route_query,
+)
+
+
+class _FakeClient:
+    """Minimal GovernanceMCPClient stand-in for classify_intent.
+
+    Either returns a canned call_model result or raises, to exercise the
+    LLM-success and LLM-failure branches.
+    """
+
+    def __init__(self, result=None, raises=False):
+        self._result = result
+        self._raises = raises
+        self.calls = []
+
+    async def call_tool(self, name, args):
+        self.calls.append((name, args))
+        if self._raises:
+            raise RuntimeError("model unavailable")
+        return self._result
+
+
+# --------------------------------------------------------------------------- #
+# _keyword_classify — deterministic fallback
+# --------------------------------------------------------------------------- #
+
+class TestKeywordClassify:
+    @pytest.mark.parametrize(
+        "question, expected",
+        [
+            ("what is my eisv coherence right now", "status"),
+            ("show me the current verdict and health", "status"),
+            ("I finished the refactor and completed tests", "checkin"),
+            ("find the knowledge graph entry", "search"),
+            ("please save this as a note", "note"),
+            ("what tools are available, help", "help"),
+        ],
+    )
+    def test_keyword_routes(self, question, expected):
+        assert _keyword_classify(question) == expected
+
+    def test_unmatched_defaults_to_search(self):
+        assert _keyword_classify("zxqw plover frobnicate") == "search"
+
+    def test_is_case_insensitive(self):
+        assert _keyword_classify("EISV STATUS PLEASE") == "status"
+
+    def test_first_pattern_wins_on_overlap(self):
+        # Contains both a status word ('state') and a search word ('find');
+        # status is earlier in KEYWORD_PATTERNS so it must win.
+        assert _keyword_classify("find my state") == "status"
+
+
+# --------------------------------------------------------------------------- #
+# classify_intent — LLM-first with keyword fallback
+# --------------------------------------------------------------------------- #
+
+class TestClassifyIntent:
+    @pytest.mark.asyncio
+    async def test_uses_valid_llm_intent(self):
+        client = _FakeClient(result={"response": "note"})
+        # question keywords would say 'status', but a valid LLM answer wins.
+        assert await classify_intent("what is my status", client) == "note"
+
+    @pytest.mark.asyncio
+    async def test_unknown_llm_intent_falls_back_to_keywords(self):
+        client = _FakeClient(result={"response": "frobnicate"})
+        assert await classify_intent("what is my status", client) == "status"
+
+    @pytest.mark.asyncio
+    async def test_llm_failure_falls_back_to_keywords(self):
+        client = _FakeClient(raises=True)
+        assert await classify_intent("please save this note", client) == "note"
+
+    @pytest.mark.asyncio
+    async def test_string_result_is_accepted(self):
+        client = _FakeClient(result="search")
+        assert await classify_intent("anything", client) == "search"
+
+
+# --------------------------------------------------------------------------- #
+# route_query — intent -> tool/args mapping
+# --------------------------------------------------------------------------- #
+
+class TestRouteQuery:
+    @pytest.mark.asyncio
+    async def test_status_route(self):
+        client = _FakeClient(result={"response": "status"})
+        assert await route_query("how am I doing", client) == {"tool": "status", "args": {}}
+
+    @pytest.mark.asyncio
+    async def test_checkin_carries_question_as_summary(self):
+        client = _FakeClient(result={"response": "checkin"})
+        out = await route_query("I shipped the parser", client)
+        assert out == {"tool": "checkin", "args": {"summary": "I shipped the parser"}}
+
+    @pytest.mark.asyncio
+    async def test_search_carries_question_as_query(self):
+        client = _FakeClient(result={"response": "search"})
+        out = await route_query("where is the migration doc", client)
+        assert out == {"tool": "search", "args": {"query": "where is the migration doc"}}
+
+    @pytest.mark.asyncio
+    async def test_note_carries_question_as_content(self):
+        client = _FakeClient(result={"response": "note"})
+        out = await route_query("remember to rotate keys", client)
+        assert out == {"tool": "note", "args": {"content": "remember to rotate keys"}}
+
+    @pytest.mark.asyncio
+    async def test_help_route(self):
+        client = _FakeClient(result={"response": "help"})
+        assert await route_query("what can you do", client) == {"tool": "help", "args": {}}
+
+    @pytest.mark.asyncio
+    async def test_default_routes_to_search(self):
+        # LLM raises and the question matches no keyword → default search,
+        # with the question carried as the query.
+        client = _FakeClient(raises=True)
+        out = await route_query("zxqw plover", client)
+        assert out == {"tool": "search", "args": {"query": "zxqw plover"}}


### PR DESCRIPTION
## What

Adds regression tests for the remaining real-logic blind-spot modules:
- `tests/test_hck_reflexive.py` (18 cases) — `src/hck_reflexive.py`, pure HCK v3.0 control math
- `tests/test_query_engine.py` (19 cases) — `src/gateway/query_engine.py`, the gateway's NL intent router

37 cases total. Fourth in the series (after merged #749 auth, #758 monitor-math, #761 OAuth).

## ⚠️ Doc/behavior mismatch surfaced

`modulate_gains`'s docstring worked-example claims `rho=0 → factor=0.75`, but the implementation computes `max(min_factor, (rho + 1) / 2)` → **0.5** at `rho=0`, and a *flat* 0.5 floor for **every** `rho ≤ 0` (not the smooth 0.5→0.75→1.0 curve the comment describes). The tests pin the **implemented** behavior (0.5); flagging for a human to decide whether the docstring or the formula is the bug. The controller currently damps PI gains harder at/under neutral coherence than the docs imply.

## What's guarded

**`hck_reflexive.py`**
- `compute_update_coherence` — aligned→+1 / opposed→−1 / zero→0, `[-1,1]` clamping, magnitude-independence (direction-only signal)
- `compute_continuity_energy` — insufficient-history zero, state-delta vs decision-flip weighting (`alpha_state`/`alpha_decision`), window limiting, non-negativity
- `modulate_gains` — linear scaling for positive rho, the `min_factor` floor for all `rho ≤ 0`, custom floor

**`query_engine.py`**
- `_keyword_classify` — all five intents, case-insensitivity, first-pattern-wins precedence, default-to-search
- `classify_intent` — valid LLM intent wins; unknown/failed LLM falls back to keywords; string-result handling
- `route_query` — intent→tool/args table for every branch + default

## Deliberate non-coverage

`monitor_cirs.run_cirs` is **not** tested: it's orchestration over the `adaptive_governor` / `oscillation_detector` / `resonance_damper` subsystems, so a test would exercise mocks rather than real logic (which lives in `src/cirs.py`). Padding it would add a brittle change-detector with no signal.

## Verification

- `pytest tests/test_hck_reflexive.py tests/test_query_engine.py` → **37 passed**
- `ruff check` → clean

Purely additive — no product code changed.

https://claude.ai/code/session_014ufUKGg6WcEm5gi6Ha4nMr

---
_Generated by [Claude Code](https://claude.ai/code/session_014ufUKGg6WcEm5gi6Ha4nMr)_