### PR TITLE
[codex] fix(dashboard): respect redacted lineage ids

### DIFF
--- a/dashboard/agents.js
+++ b/dashboard/agents.js
@@ -101,6 +101,27 @@
         return agent.label || agent.display_name || agent.name || agent.agent_id || 'Unknown';
     }
 
+    function isCanonicalLineageId(value) {
+        return typeof value === 'string' &&
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+    }
+
+    function isAgentIdRedacted(agent) {
+        return !!(agent && (agent.agent_id_redacted || agent.id_redacted || agent.uuid_redacted));
+    }
+
+    function isParentIdRedacted(agent) {
+        return !!(agent && agent.parent_agent_id_redacted);
+    }
+
+    function canUseAgentLineageId(agent, value) {
+        return isCanonicalLineageId(value) && !isAgentIdRedacted(agent);
+    }
+
+    function canUseParentLineageId(agent, value) {
+        return isCanonicalLineageId(value) && !isParentIdRedacted(agent);
+    }
+
     function agentHasMetrics(agent) {
         var metrics = agent.metrics || {};
         return metrics && (metrics.E !== undefined || metrics.I !== undefined || metrics.S !== undefined);
@@ -234,9 +255,11 @@
             var la = cachedAgents[li];
             var laId = la.agent_id || la.id;
             if (!laId) continue;
-            agentsById[laId] = la;
+            if (canUseAgentLineageId(la, laId)) {
+                agentsById[laId] = la;
+            }
             var pid = la.parent_agent_id;
-            if (pid) {
+            if (pid && canUseParentLineageId(la, pid)) {
                 (childrenByParent[pid] = childrenByParent[pid] || []).push(laId);
             }
         }
@@ -318,7 +341,9 @@
             // the flat card list.
             var lineageBadgeHtml = '';
             var parentId = agent.parent_agent_id;
-            if (parentId) {
+            if (parentId && !canUseParentLineageId(agent, parentId)) {
+                lineageBadgeHtml += '<span class="lineage-badge lineage-child" title="Parent lineage exists but is redacted for this view">Lineage redacted</span>';
+            } else if (parentId) {
                 var parentAgent = agentsById[parentId];
                 var parentShort = parentAgent
                     ? getAgentDisplayName(parentAgent)
@@ -326,7 +351,7 @@
                 var spawn = agent.spawn_reason ? ' (' + escapeHtml(agent.spawn_reason) + ')' : '';
                 lineageBadgeHtml += '<span class="lineage-badge lineage-child" data-parent-uuid="' + escapeHtml(parentId) + '" title="Spawned from ' + escapeHtml(parentId) + spawn + '">↑ ' + escapeHtml(parentShort) + '</span>';
             }
-            var children = childrenByParent[agentId] || [];
+            var children = canUseAgentLineageId(agent, agentId) ? (childrenByParent[agentId] || []) : [];
             if (children.length > 0) {
                 lineageBadgeHtml += '<span class="lineage-badge lineage-parent" title="' + children.length + ' child agent(s) declared this as parent">' + children.length + ' child' + (children.length !== 1 ? 'ren' : '') + '</span>';
             }
@@ -702,12 +727,20 @@
                     var other = all[ki];
                     var oid = other.agent_id || other.id;
                     if (!oid) continue;
-                    byIdLocal[oid] = other;
-                    if (other.parent_agent_id === agentId) childrenLocal.push(other);
+                    if (canUseAgentLineageId(other, oid)) {
+                        byIdLocal[oid] = other;
+                    }
+                    if (canUseAgentLineageId(agent, agentId) &&
+                            canUseParentLineageId(other, other.parent_agent_id) &&
+                            other.parent_agent_id === agentId) {
+                        childrenLocal.push(other);
+                    }
                 }
                 if (!parentId && childrenLocal.length === 0) return '';
                 var parentHtml = '-';
-                if (parentId) {
+                if (parentId && !canUseParentLineageId(agent, parentId)) {
+                    parentHtml = '<span class="text-secondary-sm">Redacted in this view</span>';
+                } else if (parentId) {
                     var parentAgent = byIdLocal[parentId];
                     var parentName = parentAgent ? getAgentDisplayName(parentAgent) : (parentId.slice(0, 12) + '...');
                     var spawn = agent.spawn_reason ? ' <span class="text-secondary-xs">(' + escapeHtml(agent.spawn_reason) + ')</span>' : '';

--- a/tests/test_dashboard_agents_lineage_redaction.py
+++ b/tests/test_dashboard_agents_lineage_redaction.py
@@ -1,0 +1,225 @@
+"""Regression coverage for dashboard agent lineage redaction."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.mark.skipif(
+    shutil.which("node") is None,
+    reason="node is required for dashboard JS regression",
+)
+def test_agents_lineage_redaction_does_not_link_or_render_redacted_ids(tmp_path: Path) -> None:
+    """Run agents.js with a tiny DOM and pin redacted lineage rendering."""
+    script = tmp_path / "agents_lineage_redaction_contract.cjs"
+    agents_path = ROOT / "dashboard" / "agents.js"
+
+    script.write_text(
+        textwrap.dedent(
+            f"""
+            const fs = require("fs");
+            const vm = require("vm");
+
+            function assertIncludes(value, needle) {{
+              if (!value.includes(needle)) {{
+                throw new Error(`Expected ${{JSON.stringify(needle)}} in ${{value}}`);
+              }}
+            }}
+
+            function assertNotIncludes(value, needle) {{
+              if (value.includes(needle)) {{
+                throw new Error(`Did not expect ${{JSON.stringify(needle)}} in ${{value}}`);
+              }}
+            }}
+
+            function makeElement(id) {{
+              return {{
+                id,
+                value: "",
+                innerHTML: "",
+                textContent: "",
+                className: "",
+                title: "",
+                style: {{}},
+                classList: {{
+                  add() {{}},
+                  remove() {{}}
+                }},
+                listeners: {{}},
+                addEventListener(event, callback) {{
+                  this.listeners[event] = callback;
+                }},
+                querySelector() {{
+                  return null;
+                }},
+                querySelectorAll() {{
+                  return [];
+                }}
+              }};
+            }}
+
+            const elements = {{
+              "agents-container": makeElement("agents-container"),
+              "agents-filter-info": makeElement("agents-filter-info"),
+              "panel-modal": makeElement("panel-modal"),
+              "modal-title": makeElement("modal-title"),
+              "modal-body": makeElement("modal-body")
+            }};
+
+            const visibleParentUuid = "11111111-1111-4111-8111-111111111111";
+            const visibleChildUuid = "22222222-2222-4222-8222-222222222222";
+            const redactedLabel = "Parent";
+            const redactedChildUuid = "33333333-3333-4333-8333-333333333333";
+
+            const agents = [
+              {{
+                agent_id: visibleParentUuid,
+                label: "Visible Parent",
+                lifecycle_status: "active",
+                total_updates: 4
+              }},
+              {{
+                agent_id: visibleChildUuid,
+                label: "Visible Child",
+                parent_agent_id: visibleParentUuid,
+                spawn_reason: "subagent",
+                lifecycle_status: "active",
+                total_updates: 2
+              }},
+              {{
+                agent_id: redactedChildUuid,
+                label: "Redacted Child",
+                parent_agent_id: redactedLabel,
+                parent_agent_id_redacted: true,
+                lifecycle_status: "active",
+                total_updates: 2
+              }},
+              {{
+                agent_id: redactedLabel,
+                label: "Redacted Parent Alias",
+                agent_id_redacted: true,
+                lifecycle_status: "active",
+                total_updates: 1
+              }}
+            ];
+
+            const stateValues = {{
+              cachedAgents: agents,
+              agentEISVHistory: {{}},
+              agentPageSize: 20,
+              pinnedAgentId: null,
+              cachedDiscoveries: []
+            }};
+
+            const context = {{
+              console,
+              Date,
+              DashboardState: {{}},
+              state: {{
+                get(key) {{
+                  return stateValues[key];
+                }},
+                set(key, value) {{
+                  stateValues[key] = value;
+                }}
+              }},
+              VERDICT_ICONS: {{}},
+              MetricColors: {{
+                forValue() {{
+                  return "rgb(0, 0, 0)";
+                }}
+              }},
+              DataProcessor: {{
+                escapeHtml(value) {{
+                  return String(value || "")
+                    .replace(/&/g, "&amp;")
+                    .replace(/</g, "&lt;")
+                    .replace(/>/g, "&gt;")
+                    .replace(/"/g, "&quot;");
+                }},
+                highlightMatch(value) {{
+                  return String(value || "");
+                }},
+                formatRelativeTime() {{
+                  return "";
+                }},
+                formatTimestamp(value) {{
+                  return String(value || "");
+                }},
+                formatEISVMetric(value) {{
+                  return {{ display: Number(value).toFixed(3), interpretation: "", color: "black" }};
+                }}
+              }},
+              document: {{
+                body: {{ style: {{}} }},
+                getElementById(id) {{
+                  return elements[id] || null;
+                }},
+                querySelector() {{
+                  return null;
+                }},
+                querySelectorAll() {{
+                  return [];
+                }},
+                addEventListener() {{}}
+              }},
+              requestAnimationFrame(callback) {{
+                callback();
+              }},
+              setTimeout() {{}},
+              CSS: {{
+                escape(value) {{
+                  return String(value || "");
+                }}
+              }}
+            }};
+            context.window = context;
+
+            vm.createContext(context);
+            vm.runInContext(
+              fs.readFileSync({json.dumps(str(agents_path))}, "utf8"),
+              context,
+              {{ filename: "dashboard/agents.js" }}
+            );
+
+            const agentsModule = context.AgentsModule;
+            agentsModule.renderAgentsList(agents, "");
+            const listHtml = elements["agents-container"].innerHTML;
+
+            assertIncludes(listHtml, "Visible Parent");
+            assertIncludes(listHtml, "Visible Child");
+            assertIncludes(listHtml, "Lineage redacted");
+            assertIncludes(listHtml, `data-parent-uuid="${{visibleParentUuid}}"`);
+            assertNotIncludes(listHtml, `data-parent-uuid="${{redactedLabel}}"`);
+            assertNotIncludes(listHtml, `title="Spawned from ${{redactedLabel}}`);
+
+            agentsModule.showAgentDetail(agents[2]);
+            const detailHtml = elements["modal-body"].innerHTML;
+            assertIncludes(detailHtml, "Redacted in this view");
+            assertNotIncludes(detailHtml, `<span class="text-secondary-xs">${{redactedLabel}}</span>`);
+
+            agentsModule.showAgentDetail(agents[0]);
+            const parentDetailHtml = elements["modal-body"].innerHTML;
+            assertIncludes(parentDetailHtml, "Visible Child");
+            assertNotIncludes(parentDetailHtml, "Redacted Child");
+            """
+        )
+    )
+
+    result = subprocess.run(
+        ["node", str(script)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout


### PR DESCRIPTION
## Summary

- Guard dashboard lineage linking/counts behind canonical, unredacted UUIDs.
- Render redacted parent lineage as an explicit redacted state instead of treating labels as IDs.
- Add a Node-backed regression test for redacted lineage list and detail rendering.

## Root Cause

The dashboard accepted any non-empty `parent_agent_id` as linkable lineage. When the API returned a redacted label plus `parent_agent_id_redacted`, the UI could render that label as if it were a real parent UUID.

## Validation

- `node --check dashboard/agents.js`
- `python3 -m pytest tests/test_dashboard_agents_lineage_redaction.py tests/test_dashboard_static_allowlist.py`
- `./scripts/dev/test-cache.sh --staged`
