### PR TITLE
test: add regression coverage for error/response/db-compat/plugin modules

### DIFF
--- a/tests/test_acquire_compat.py
+++ b/tests/test_acquire_compat.py
@@ -1,0 +1,99 @@
+"""Regression tests for src/db/acquire_compat.py.
+
+compatible_acquire is a small but load-bearing shim: it encodes a *fix for a
+real connection-leak bug*. The previous implementation used
+inspect.isawaitable() to detect test mocks, but asyncpg's PoolAcquireContext is
+ALSO awaitable, so production connections were acquired via `await` and never
+released. The current code prefers the async-context-manager form whenever
+__aenter__ exists, falling back to the awaitable form only for mocks.
+
+These tests pin all three branches so that regression cannot silently return.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.db.acquire_compat import compatible_acquire
+
+
+class _CtxConn:
+    """A connection exposed via async-context-manager (the asyncpg shape)."""
+
+    def __init__(self):
+        self.entered = False
+        self.exited = False
+
+    async def __aenter__(self):
+        self.entered = True
+        return "real-conn"
+
+    async def __aexit__(self, *exc):
+        self.exited = True
+        return False
+
+
+class _CtxPool:
+    def __init__(self, ctx):
+        self._ctx = ctx
+
+    def acquire(self):
+        # asyncpg's PoolAcquireContext is both awaitable AND an async CM;
+        # the shim must take the CM path to guarantee release.
+        return self._ctx
+
+
+class _AwaitableConn:
+    """A mock connection: awaitable that resolves to itself, with async close."""
+
+    def __init__(self):
+        self.closed = False
+
+    def __await__(self):
+        async def _resolve():
+            return self
+        return _resolve().__await__()
+
+    async def close(self):
+        self.closed = True
+
+
+class _AwaitablePool:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def acquire(self):
+        return self._conn
+
+
+class _BadPool:
+    def acquire(self):
+        return object()  # neither a context manager nor awaitable
+
+
+@pytest.mark.asyncio
+async def test_context_manager_path_enters_and_exits():
+    ctx = _CtxConn()
+    pool = _CtxPool(ctx)
+    async with compatible_acquire(pool) as conn:
+        assert conn == "real-conn"
+        assert ctx.entered is True
+        assert ctx.exited is False   # still inside
+    assert ctx.exited is True        # released on exit (no leak)
+
+
+@pytest.mark.asyncio
+async def test_awaitable_mock_path_yields_and_closes():
+    conn = _AwaitableConn()
+    pool = _AwaitablePool(conn)
+    async with compatible_acquire(pool) as c:
+        assert c is conn
+        assert conn.closed is False
+    assert conn.closed is True       # best-effort release for mocks
+
+
+@pytest.mark.asyncio
+async def test_unexpected_acquire_type_raises():
+    with pytest.raises(TypeError):
+        async with compatible_acquire(_BadPool()):
+            pass

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,152 @@
+"""Regression tests for src/mcp_handlers/error_handling.py.
+
+This is the error-response surface every handler funnels failures through. Two
+pieces carry real, security-relevant logic that was untested:
+
+  * _sanitize_error_message strips file paths, stack traces, and internal
+    module qualifications *before the text reaches a client* — its whole job is
+    to prevent internal-structure leakage, so a regression that stops stripping
+    is a security regression.
+  * _infer_error_code_and_category maps free-text messages to a stable
+    (code, category) contract, with a deliberately ordered pattern list (the
+    timeout-before-session ordering is load-bearing — see the inline comment
+    about list_dialectic_sessions).
+
+These tests pin both, plus the error_response envelope shape.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.mcp_handlers.error_handling import (
+    _infer_error_code_and_category,
+    _sanitize_error_message,
+    error_response,
+)
+
+
+# --------------------------------------------------------------------------- #
+# _infer_error_code_and_category
+# --------------------------------------------------------------------------- #
+
+class TestInferErrorCode:
+    @pytest.mark.parametrize(
+        "message, code, category",
+        [
+            ("Agent not found", "NOT_FOUND", "validation_error"),
+            ("missing required parameter agent_id", "MISSING_REQUIRED", "validation_error"),
+            ("value already exists", "ALREADY_EXISTS", "validation_error"),
+            ("Request timed out", "TIMEOUT", "system_error"),
+            ("permission denied", "PERMISSION_DENIED", "auth_error"),
+            ("agent is paused", "AGENT_PAUSED", "state_error"),
+            ("database connection lost", "CONNECTION_ERROR", "system_error"),
+        ],
+    )
+    def test_pattern_maps_to_expected_code(self, message, code, category):
+        assert _infer_error_code_and_category(message) == (code, category)
+
+    def test_unmatched_message_returns_none(self):
+        assert _infer_error_code_and_category("zxqw plover gibberish") == (None, None)
+
+    def test_timeout_wins_over_session_substring(self):
+        # The pattern order is load-bearing: a timeout on a tool whose name
+        # contains 'session' must classify as TIMEOUT/system, not SESSION/auth.
+        code, category = _infer_error_code_and_category(
+            "Request timed out calling list_dialectic_sessions")
+        assert code == "TIMEOUT"
+        assert category == "system_error"
+
+    def test_validation_wins_over_auth(self):
+        # 'invalid' (validation) precedes 'session' (auth) in the pattern list.
+        code, category = _infer_error_code_and_category("invalid session token")
+        assert code == "INVALID_PARAM"
+        assert category == "validation_error"
+
+
+# --------------------------------------------------------------------------- #
+# _sanitize_error_message
+# --------------------------------------------------------------------------- #
+
+class TestSanitizeErrorMessage:
+    def test_non_string_coerced(self):
+        assert _sanitize_error_message(12345) == "12345"
+
+    def test_strips_absolute_path_keeps_filename(self):
+        out = _sanitize_error_message("boom in /home/user/unitares/src/foo.py now")
+        assert "/home/user" not in out
+        assert "foo.py" in out
+
+    def test_line_numbers_generalized(self):
+        out = _sanitize_error_message("failure at line 4321 somewhere")
+        assert "line 4321" not in out
+        assert "line N" in out
+
+    def test_traceback_removed_but_final_error_kept(self):
+        msg = (
+            "Traceback (most recent call last):\n"
+            '  File "/x/y.py", line 10, in f\n'
+            "    raise ValueError('boom')\n"
+            "ValueError: boom"
+        )
+        out = _sanitize_error_message(msg)
+        assert "Traceback" not in out
+        assert "boom" in out
+
+    def test_internal_module_qualification_stripped(self):
+        out = _sanitize_error_message("src.mcp_handlers.identity.handler exploded")
+        assert "src.mcp_handlers" not in out
+        assert "exploded" in out
+
+    def test_long_message_truncated_to_limit(self):
+        # No sentence boundary → hard truncation with ellipsis. Limit is 500.
+        out = _sanitize_error_message("x" * 600)
+        assert len(out) <= 503
+        assert out.endswith("...")
+
+    def test_truncates_at_sentence_boundary_when_available(self):
+        body = "First sentence is short. " + "y" * 600
+        out = _sanitize_error_message(body)
+        assert out.endswith(".")
+        assert "First sentence is short." in out
+
+
+# --------------------------------------------------------------------------- #
+# error_response envelope
+# --------------------------------------------------------------------------- #
+
+class TestErrorResponse:
+    def _payload(self, *args, **kwargs):
+        tc = error_response(*args, **kwargs)
+        return json.loads(tc.text)
+
+    def test_basic_envelope_shape(self):
+        d = self._payload("Agent not found", arguments=None)
+        assert d["success"] is False
+        assert d["error"] == "Agent not found"
+        assert "server_time" in d
+        assert "agent_signature" in d
+
+    def test_auto_infers_code_and_category(self):
+        d = self._payload("Agent not found", arguments=None)
+        assert d["error_code"] == "NOT_FOUND"
+        assert d["error_category"] == "validation_error"
+
+    def test_explicit_code_not_overridden(self):
+        d = self._payload("Agent not found", error_code="CUSTOM",
+                          error_category="auth_error", arguments=None)
+        assert d["error_code"] == "CUSTOM"
+        assert d["error_category"] == "auth_error"
+
+    def test_message_is_sanitized_in_envelope(self):
+        d = self._payload("crash in /secret/path/to/module.py", arguments=None)
+        assert "/secret/path" not in d["error"]
+        assert "module.py" in d["error"]
+
+    def test_string_details_are_sanitized(self):
+        d = self._payload("bad", details={"hint": "see /home/op/x.py"},
+                          arguments=None)
+        assert "/home/op" not in d["hint"]
+        assert "x.py" in d["hint"]

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1,0 +1,70 @@
+"""Regression tests for src/plugin_loader.py.
+
+load_plugins discovers governance_mcp.plugins entry points and calls each
+register(). Two contracts matter and were untested:
+
+  * the UNITARES_DISABLE_PLUGINS escape hatch must short-circuit to [] (used
+    for test isolation and stripped OSS builds), and
+  * failure isolation — "one broken plugin can't take governance down": a
+    register() that raises is logged and skipped, never propagated, and the
+    other plugins still load.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import src.plugin_loader as plugin_loader
+
+
+def _ep(name, register_fn):
+    return SimpleNamespace(name=name, value=f"pkg.{name}:register",
+                           load=lambda: register_fn)
+
+
+@pytest.fixture(autouse=True)
+def _clear_disable_flag(monkeypatch):
+    monkeypatch.delenv("UNITARES_DISABLE_PLUGINS", raising=False)
+
+
+def test_disable_flag_short_circuits(monkeypatch):
+    monkeypatch.setenv("UNITARES_DISABLE_PLUGINS", "1")
+    called = []
+    monkeypatch.setattr(plugin_loader, "entry_points",
+                        lambda group: [_ep("p", lambda: called.append("p"))])
+    assert plugin_loader.load_plugins() == []
+    assert called == []   # never even enumerated
+
+
+def test_loads_all_registered_plugins(monkeypatch):
+    calls = []
+    eps = [
+        _ep("alpha", lambda: calls.append("alpha")),
+        _ep("beta", lambda: calls.append("beta")),
+    ]
+    monkeypatch.setattr(plugin_loader, "entry_points", lambda group: eps)
+    loaded = plugin_loader.load_plugins()
+    assert sorted(loaded) == ["alpha", "beta"]
+    assert sorted(calls) == ["alpha", "beta"]
+
+
+def test_failure_is_isolated(monkeypatch):
+    def boom():
+        raise RuntimeError("plugin exploded")
+
+    calls = []
+    eps = [
+        _ep("good_a", lambda: calls.append("good_a")),
+        _ep("broken", boom),
+        _ep("good_b", lambda: calls.append("good_b")),
+    ]
+    monkeypatch.setattr(plugin_loader, "entry_points", lambda group: eps)
+
+    # Must not raise despite the broken plugin...
+    loaded = plugin_loader.load_plugins()
+    # ...and the broken one is excluded while the others still load.
+    assert "broken" not in loaded
+    assert sorted(loaded) == ["good_a", "good_b"]
+    assert sorted(calls) == ["good_a", "good_b"]

--- a/tests/test_response_base.py
+++ b/tests/test_response_base.py
@@ -1,0 +1,110 @@
+"""Regression tests for src/mcp_handlers/response_base.py.
+
+Response-formatting helpers shared across handlers: the metrics report builder,
+its text renderer (EISV / float formatting), and the success envelope (agent
+signature, lite-response opt-out, param-coercion surfacing). Untested before;
+these pin the output contract.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.mcp_handlers.response_base import (
+    format_metrics_report,
+    format_metrics_text,
+    success_response,
+)
+
+
+# --------------------------------------------------------------------------- #
+# format_metrics_report
+# --------------------------------------------------------------------------- #
+
+class TestFormatMetricsReport:
+    def test_includes_agent_id_and_timestamp(self):
+        out = format_metrics_report({"coherence": 0.5}, agent_id="agent-1")
+        assert out["agent_id"] == "agent-1"
+        assert "timestamp" in out
+
+    def test_timestamp_suppressed_when_disabled(self):
+        out = format_metrics_report({"coherence": 0.5}, agent_id="a",
+                                    include_timestamp=False)
+        assert "timestamp" not in out
+
+    def test_eisv_subdict_built_from_components(self):
+        out = format_metrics_report(
+            {"E": 0.1, "I": 0.8, "S": 0.2, "V": 0.0}, agent_id="a")
+        assert out["eisv"] == {"E": 0.1, "I": 0.8, "S": 0.2, "V": 0.0}
+
+    def test_no_eisv_key_when_no_components(self):
+        out = format_metrics_report({"coherence": 0.5}, agent_id="a")
+        assert "eisv" not in out
+
+    def test_text_style_returns_string(self):
+        out = format_metrics_report({"E": 0.1, "I": 0.8, "S": 0.2, "V": 0.0},
+                                    agent_id="a", format_style="text")
+        assert isinstance(out, str)
+        assert "Agent: a" in out
+
+
+# --------------------------------------------------------------------------- #
+# format_metrics_text
+# --------------------------------------------------------------------------- #
+
+class TestFormatMetricsText:
+    def test_agent_line_always_present(self):
+        assert format_metrics_text({}).startswith("Agent: unknown")
+
+    def test_eisv_from_subdict_three_decimals(self):
+        text = format_metrics_text({"eisv": {"E": 0.12345, "I": 0.8, "S": 0.2, "V": 0.0}})
+        assert "E=0.123" in text
+        assert "I=0.800" in text
+
+    def test_eisv_from_top_level_components(self):
+        # The elif branch: no 'eisv' key but E/I/S/V at top level.
+        text = format_metrics_text({"E": 0.5, "I": 0.6, "S": 0.7, "V": 0.8})
+        assert "E=0.500 I=0.600 S=0.700 V=0.800" in text
+
+    def test_float_metrics_rounded_strings_passthrough(self):
+        text = format_metrics_text({"coherence": 0.55555, "verdict": "PROCEED"})
+        assert "coherence: 0.556" in text   # float → 3 decimals
+        assert "verdict: PROCEED" in text    # non-float → as-is
+
+
+# --------------------------------------------------------------------------- #
+# success_response
+# --------------------------------------------------------------------------- #
+
+class TestSuccessResponse:
+    def _payload(self, *args, **kwargs):
+        seq = success_response(*args, **kwargs)
+        assert len(seq) == 1
+        return json.loads(seq[0].text)
+
+    def test_basic_success_envelope(self):
+        d = self._payload({"value": 42}, agent_id="a")
+        assert d["success"] is True
+        assert d["value"] == 42
+        assert "server_time" in d
+        assert "agent_signature" in d
+
+    def test_lite_response_omits_signature(self):
+        d = self._payload({"value": 1}, agent_id="a",
+                          arguments={"lite_response": True})
+        assert "agent_signature" not in d
+
+    def test_param_coercions_surfaced(self):
+        d = self._payload(
+            {"value": 1}, agent_id="a",
+            arguments={"_param_coercions": {"complexity": "0.5->0.5"}})
+        assert d["_param_coercions"]["applied"] == {"complexity": "0.5->0.5"}
+        assert "note" in d["_param_coercions"]
+
+    def test_param_coercions_hidden_in_lite(self):
+        d = self._payload(
+            {"value": 1}, agent_id="a",
+            arguments={"lite_response": True, "_param_coercions": {"x": "y"}})
+        assert "_param_coercions" not in d


### PR DESCRIPTION
## What

Adds regression tests for the four logic-bearing modules I'd earlier mislabeled "trivial glue" (41 cases). Fifth in the series (after merged #749, #758, #761, #762).

## Context — correcting the "trivial" call

You pushed back on me calling these trivial, and after actually reading them you were right: only `metrics_registry.py` is genuinely declaration-only (Prometheus metric singletons, no functions/branches — left untested with that rationale). The other four carry real, testable contracts:

## What's guarded

**`mcp_handlers/error_handling.py`** *(security-relevant — leak prevention)*
- `_sanitize_error_message` — strips absolute paths (keeps filename), generalizes line numbers, removes tracebacks while keeping the final error line, strips internal `src.mcp_handlers.*` qualifications, sentence-boundary vs hard truncation at the 500-char limit
- `_infer_error_code_and_category` — message→(code, category) including the **load-bearing pattern ordering** (timeout-before-session so `list_dialectic_sessions` timeouts aren't misclassified as auth; validation-before-auth)
- `error_response` — envelope shape, auto-inference, explicit-override, message + string-detail sanitization

**`mcp_handlers/response_base.py`**
- `format_metrics_report` / `format_metrics_text` — agent line, EISV subdict vs top-level components, float 3-decimal vs string passthrough
- `success_response` — signature default, `lite_response` opt-out, `_param_coercions` surfacing

**`db/acquire_compat.py`** *(pins a prior connection-leak bug fix)*
- `compatible_acquire` all three branches — the async-context-manager path (asyncpg, guarantees release), the awaitable-mock path (yield + close), and the `TypeError` guard. This is the shim whose old `inspect.isawaitable` check leaked production connections.

**`plugin_loader.py`**
- the `UNITARES_DISABLE_PLUGINS` short-circuit, and **per-plugin failure isolation** — one broken `register()` is logged and skipped, never propagated, and the other plugins still load.

## Deliberate non-coverage

`metrics_registry.py` — Prometheus metric *declarations* only; a test would re-type the source as assertions with zero behavioral signal.

## Verification

- `pytest` (4 files) → **41 passed**
- `ruff check` → clean

Purely additive — no product code changed.

https://claude.ai/code/session_014ufUKGg6WcEm5gi6Ha4nMr

---
_Generated by [Claude Code](https://claude.ai/code/session_014ufUKGg6WcEm5gi6Ha4nMr)_