### PR TITLE
docs: correct modulate_gains docstring to match floor-clamp behavior (#765)

### DIFF
--- a/src/hck_reflexive.py
+++ b/src/hck_reflexive.py
@@ -104,17 +104,33 @@ def modulate_gains(K_p: float, K_i: float, rho: float,
     When rho(t) is low (misaligned updates), reduce controller aggressiveness
     to prevent instability.
 
+    The gain multiplier is a linear ramp ``(rho + 1) / 2`` clamped at
+    ``min_factor`` from below. With the default ``min_factor=0.5`` this gives a
+    *flat 0.5 floor for every rho <= 0*, then a linear rise to 1.0 over
+    rho in (0, 1]:
+
+        rho=1.0 -> factor=1.0
+        rho=0.5 -> factor=0.75
+        rho=0.0 -> factor=0.5   (floor; the ramp would give 0.5 here too)
+        rho<=0  -> factor=0.5   (clamped flat at the floor)
+
+    So the controller damps hard at and below neutral coherence rather than
+    smoothly interpolating down to the floor only at rho=-1. (See issue #765:
+    an earlier docstring claimed a smooth 0.5->0.75->1.0 curve; the floor-clamp
+    behavior below is the intended one and is what the tests pin.)
+
     Args:
         K_p: Base proportional gain
         K_i: Base integral gain
         rho: Update coherence [-1, 1]
-        min_factor: Minimum gain multiplier (default 0.5)
+        min_factor: Minimum gain multiplier (default 0.5). For min_factor < 0.5
+            the floor only engages below rho = 2*min_factor - 1.
 
     Returns:
         (K_p_adjusted, K_i_adjusted)
     """
-    # Map rho from [-1, 1] to [min_factor, 1.0]
-    # rho=1 -> factor=1.0, rho=0 -> factor=0.75, rho=-1 -> factor=0.5
+    # Linear ramp (rho+1)/2, clamped at min_factor. Default floor 0.5 => flat
+    # for rho<=0, linear up to 1.0 for rho in (0, 1]. See issue #765.
     coherence_factor = max(min_factor, (rho + 1) / 2)
 
     return K_p * coherence_factor, K_i * coherence_factor

--- a/tests/test_hck_reflexive.py
+++ b/tests/test_hck_reflexive.py
@@ -5,12 +5,12 @@ tracking: update coherence rho(t), continuity energy CE(t), and PI-gain
 modulation. They had no direct coverage. Pin the input->output contract so a
 change to the coherence/energy formulas is caught.
 
-NOTE — modulate_gains doc/behavior mismatch (surfaced by this test):
-the docstring's worked example claims `rho=0 -> factor=0.75`, but the
+NOTE — modulate_gains doc/behavior (resolved, issue #765):
+an earlier docstring claimed a smooth `rho=0 -> factor=0.75` curve, but the
 implementation computes `max(min_factor, (rho + 1) / 2)`, which yields 0.5 at
-rho=0 and a *flat* 0.5 floor for every rho <= 0. The tests below pin the actual
-implemented behavior (0.5), not the docstring's number. Flagged for a human to
-decide whether the doc or the formula is wrong.
+rho=0 and a *flat* 0.5 floor for every rho <= 0. The operator confirmed the
+floor-clamp formula is the intended behavior; the docstring was corrected to
+match. The tests below pin that implemented behavior (the 0.5 floor).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Resolves #765 — the docstring/behavior mismatch in `src/hck_reflexive.py::modulate_gains`.

Per the operator decision on the issue (**"code is right, fix the docs"**), this is a **docstring-only change with no runtime behavior change**.

## Background

The old docstring claimed a smooth curve (`rho=0 -> factor=0.75`, `rho=-1 -> 0.5`), but the implementation is:

```python
coherence_factor = max(min_factor, (rho + 1) / 2)
```

which is a linear ramp clamped at `min_factor` from below — i.e. with the default `min_factor=0.5` it's a **flat 0.5 floor for every `rho <= 0`**, then linear up to 1.0 over `rho` in `(0, 1]`. The controller damps harder at/below neutral coherence than the old comment implied.

## Changes

- `src/hck_reflexive.py`: rewrote the docstring worked example + inline comments to describe the actual floor-clamp curve, including the `min_factor < 0.5` crossover (`rho = 2*min_factor - 1`), and referenced #765.
- `tests/test_hck_reflexive.py`: updated the header NOTE from "flagged for a human to decide" to "resolved — operator confirmed the floor-clamp formula is intended."

## Verification

No formula change, so the existing tests that pin the implemented (0.5-floor) behavior stay green:

- `tests/test_hck_reflexive.py` — 18 passed
- `tests/test_governance_monitor*.py` (`-k modulate`) — 10 passed

https://claude.ai/code/session_01QbU9SzpwL3coJyQw1Q831B

---
_Generated by [Claude Code](https://claude.ai/code/session_01QbU9SzpwL3coJyQw1Q831B)_