### PR TITLE
[codex] feat: make agent workflow tools primary

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ When you run many autonomous agents, you can already tell *who* is calling (iden
 
 After each unit of work, an agent checks in by calling `sync_state()`. The check-in includes a self-reported `confidence`, a self-reported `complexity`, the `response_text`, and any `recent_tool_results` — test outcomes, exit codes, lint output, file changes — i.e. things the system can verify instead of taking the agent's word for.
 
-> **A note on tool names:** every tool has a plain task-verb name (`sync_state`, `start_session`, `record_result`) and an older canonical name (`process_agent_update`, `onboard`, `outcome_event`). They're the same calls. This README uses the task-verb names throughout; the full mapping is in [Tool names](#tool-names).
+> **A note on tool names:** agents should use the primary task-verb tools (`sync_state`, `start_session`, `record_result`). Older raw implementation names (`process_agent_update`, `onboard`, `outcome_event`) remain stable for compatibility and debugging. This README uses the primary names throughout; the full mapping is in [Tool names](#tool-names).
 
 From each check-in, UNITARES tracks four numbers per agent — together called **EISV**:
 
@@ -230,9 +230,9 @@ The `start_session()` response includes `agent_uuid` and `client_session_id` at 
 
 ### Tool names
 
-Every tool has a plain task-verb name and an older canonical name. They make the same call; the task-verb versions just return a friendlier, self-awareness-oriented response shape (with the full payload preserved under `raw_governance`). Use whichever you prefer.
+Agents should use the primary task-verb tools. The older raw implementation names remain available for compatibility, older clients, and cases where you explicitly want the raw handler response shape. Primary tools return the agent-experience envelope, with the full payload preserved under `raw_governance`.
 
-| Task-verb name (used in this README) | Canonical name |
+| Primary workflow tool | Raw implementation tool |
 |---|---|
 | `start_session` | `onboard` |
 | `sync_state` | `process_agent_update` |

--- a/docs/guides/START_HERE.md
+++ b/docs/guides/START_HERE.md
@@ -12,9 +12,10 @@ Use this unless you have a specific reason not to:
 4. Call `check_working_state()` for state
 5. Use `identity(agent_uuid=<uuid>, continuity_token=<token>, resume=true)` only for same-owner proof-owned rebinds
 
-Agent-facing workflow aliases are also registered:
+These primary workflow tools are the agent-facing surface. Raw implementation
+tools remain available for older clients and debugging:
 
-| Job | Workflow alias | Canonical tool |
+| Job | Primary workflow tool | Raw implementation tool |
 | --- | --- | --- |
 | Start working | `start_session(force_new=true, ...)` | `onboard` |
 | Check in after meaningful work | `sync_state(response_text=..., complexity=...)` | `process_agent_update` |
@@ -23,8 +24,8 @@ Agent-facing workflow aliases are also registered:
 | Record a real outcome | `record_result(...)` | `outcome_event` |
 | Ask for review | `request_review(issue_description=...)` | `dialectic(action="request")` |
 
-The workflow aliases return the agent-experience envelope, with the full
-canonical payload preserved under `raw_governance`.
+The primary workflow tools return the agent-experience envelope, with the full
+raw implementation payload preserved under `raw_governance`.
 
 ```python
 # First run:

--- a/docs/integration/MCP_CLIENTS.md
+++ b/docs/integration/MCP_CLIENTS.md
@@ -32,9 +32,10 @@ Claude Desktop does not support `type: http` natively; use `mcp-remote` as a std
 }
 ```
 
-Agents self-identify through `start_session()` (`onboard(...)` canonically); no hardcoded agent-name header is required.
+Agents self-identify through the primary `start_session()` tool; no hardcoded
+agent-name header is required. The raw implementation tool is `onboard(...)`.
 
-Agent-facing workflow aliases are registered for the core loop:
+Primary agent-facing workflow tools are registered for the core loop:
 
 - `start_session(...)` → `onboard(...)`
 - `sync_state(...)` → `process_agent_update(...)`
@@ -66,10 +67,10 @@ See [`scripts/ops/`](../../scripts/ops/) for an example LaunchAgent plist with b
 
 For a fresh process, call `start_session(force_new=true)`. If the process is continuing prior work, call `start_session(force_new=true, parent_agent_id=<prior uuid>, spawn_reason="new_session")`.
 
-Use canonical `onboard(...)` instead when targeting older servers or when a raw
-canonical response shape is required. Friendly alias responses lift
+Use raw `onboard(...)` instead when targeting older servers or when a raw
+implementation response shape is required. Primary workflow responses lift
 `agent_uuid`, `client_session_id`, and `next_action` while preserving the full
-canonical payload under `raw_governance`.
+raw payload under `raw_governance`.
 
 For a same-owner rebind to an existing UUID, call `identity(agent_uuid=..., continuity_token=..., resume=true)` with the matching short-lived token. Do not teach clients to use bare `identity(agent_uuid=..., resume=true)`: UUID alone is an unsigned claim and is hijack-shaped under strict identity mode.
 

--- a/docs/operations/OPERATOR_RUNBOOK.md
+++ b/docs/operations/OPERATOR_RUNBOOK.md
@@ -190,7 +190,7 @@ Symptom:
 
 Fix:
 
-- rerun `start_session(force_new=true)` (`onboard(...)` canonically)
+- rerun `start_session(force_new=true)` (raw implementation: `onboard(...)`)
 - if the process is continuing prior work, include `parent_agent_id=<prior uuid>` and `spawn_reason="new_session"`
 - avoid bare `identity(agent_uuid=..., resume=true)`; use a matching `continuity_token` only for same-owner rebinding
 
@@ -212,7 +212,7 @@ When something feels wrong, do the checks in this order:
 1. Run `./scripts/diagnostics/check_health.sh`
 2. If HTTP is up, call `health_check()`
 3. If an agent identity looks wrong, call `identity()`
-4. If the issue is governance-state related, call `check_working_state()` (`get_governance_metrics(...)` canonically)
+4. If the issue is governance-state related, call `check_working_state()` (raw implementation: `get_governance_metrics(...)`)
 5. Only after that inspect logs or restart services
 
 This order matters because many apparent "agent bugs" are actually continuity or process issues, and many apparent "graph bugs" are now observable directly through `health_check()` without guessing from symptoms.

--- a/skills/governance-lifecycle/SKILL.md
+++ b/skills/governance-lifecycle/SKILL.md
@@ -18,11 +18,11 @@ source_files:
 
 **Last Updated:** 2026-06-11
 
-## Friendly Workflow Names
+## Primary Workflow Names
 
-The core lifecycle can be driven with task-verb aliases. Each resolves to its canonical tool — same parameters, same identity rules — and returns a **normalized envelope**: the operationally useful fields first (`next_action`, `state_summary`, `risk_summary`, `memory_suggestions`, `recovery_hint`), with the full canonical payload preserved under `raw_governance`.
+The core lifecycle should use primary task-verb tools. Each is implemented by a raw tool with the same parameters and identity rules, and returns a **normalized envelope**: the operationally useful fields first (`next_action`, `state_summary`, `risk_summary`, `memory_suggestions`, `recovery_hint`), with the full raw payload preserved under `raw_governance`.
 
-| Task | Friendly name | Canonical tool |
+| Task | Primary workflow tool | Raw implementation tool |
 |------|---------------|----------------|
 | Start working | `start_session(force_new=true, ...)` | `onboard` |
 | Check in after meaningful work | `sync_state(response_text=..., complexity=...)` | `process_agent_update` |
@@ -31,7 +31,7 @@ The core lifecycle can be driven with task-verb aliases. Each resolves to its ca
 | Record what actually happened | `record_result(...)` | `outcome_event` |
 | Ask for a structured review | `request_review(issue_description=...)` | `dialectic(action="request")` |
 
-Use whichever spelling you prefer; the canonical names keep their raw response shape, the friendly names add the envelope. Everything below applies to both.
+Use the primary workflow tools by default. Use raw implementation names only for older servers, compatibility code, or when you explicitly need the unwrapped handler response.
 
 ## Starting a Session
 
@@ -48,7 +48,7 @@ identity(agent_uuid="<uuid>", continuity_token="<token>", resume=true) # same li
 
 Declaring a currently-live agent as parent is rejected (`lineage_coincidental_rejected`): a live agent is a concurrent sibling, not a predecessor. `subagent` and `compaction` are exempt — their parent is legitimately live. A genuine handoff to an exited predecessor stays provisional until R1 confirms it.
 
-Use canonical `onboard(...)` instead when targeting older servers or when you
+Use raw `onboard(...)` instead when targeting older servers or when you
 need the unwrapped raw response.
 
 Returns:
@@ -88,8 +88,8 @@ sync_state(
 )
 ~~~
 
-Use canonical `process_agent_update(...)` when you need the raw handler
-payload; alias responses preserve it under `raw_governance`.
+Use raw `process_agent_update(...)` when you need the raw handler payload;
+primary workflow responses preserve it under `raw_governance`.
 
 ### When to Check In
 
@@ -145,12 +145,12 @@ Recovery is not a shortcut — `self_recovery()` examines your EISV state and de
 
 ### Essential (use in every session)
 
-- `start_session(force_new=true, parent_agent_id=...)` / `onboard(...)` — Create a fresh process identity, optionally declaring lineage
-- `sync_state()` / `process_agent_update()` — Check in with work summary, complexity, confidence
-- `check_working_state()` / `get_governance_metrics()` — Read your current EISV state
+- `start_session(force_new=true, parent_agent_id=...)` — Create a fresh process identity, optionally declaring lineage
+- `sync_state()` — Check in with work summary, complexity, confidence
+- `check_working_state()` — Read your current EISV state
 - `identity()` — Confirm who the runtime thinks you are and how continuity was resolved; include `continuity_token` for proof-owned UUID rebinds
 - `health_check()` — Check operator-facing server health when behavior seems odd
-- `search_shared_memory(query=...)` / `knowledge(action="search", ...)` — Find existing knowledge before creating new entries
+- `search_shared_memory(query=...)` — Find existing knowledge before creating new entries
 - `knowledge(action="note", ...)` — Quick contribution to the knowledge graph
 
 ### Common (use when needed)

--- a/skills/unitares-governance/SKILL.md
+++ b/skills/unitares-governance/SKILL.md
@@ -31,16 +31,17 @@ UNITARES evaluates agent state with the **EISV** model:
 - `V`: valence (signed E-I imbalance)
 
 Agents typically start with `start_session(force_new=true)` and continue with
-`sync_state()` as their main check-in loop. These are friendly aliases over the
-canonical `onboard(...)` and `process_agent_update(...)` tools; the full
-canonical payload remains available under `raw_governance`.
+`sync_state()` as their main check-in loop. These are the primary workflow
+tools; raw implementation tools such as `onboard(...)` and
+`process_agent_update(...)` remain available for compatibility. The full raw
+payload remains available under `raw_governance`.
 
 ## Session Continuity
 
 Use `start_session(force_new=true)` to register a fresh process identity. If the
 process is continuing prior work, declare that with
 `parent_agent_id=<prior uuid>` and `spawn_reason="new_session"`.
-Use canonical `onboard(...)` instead for older servers or raw response shape.
+Use raw `onboard(...)` instead for older servers or raw response shape.
 
 Use `identity(agent_uuid=..., continuity_token=..., resume=true)` only when
 rebinding the same live owner to an existing UUID. The `continuity_token` is
@@ -55,7 +56,7 @@ process. `client_session_id` is in-session continuity only — weak across
 processes, not identity proof on its own.
 
 Use `sync_state()` after meaningful work to record progress, complexity, and
-confidence, then read the returned governance verdict. Use canonical
+confidence, then read the returned governance verdict. Use raw
 `process_agent_update()` when you need the raw handler response.
 
 ## Knowledge Layer

--- a/src/mcp_handlers/introspection/tool_introspection.py
+++ b/src/mcp_handlers/introspection/tool_introspection.py
@@ -134,13 +134,14 @@ def _format_lite_parameter(
 
 
 def _getting_started_path() -> List[Dict[str, Any]]:
-    """Canonical low-friction path for first-time governance callers."""
+    """Primary low-friction path for first-time governance callers."""
     return [
         {
             "step": 1,
             "tool": "start_session",
             "call": "start_session(force_new=true)",
             "canonical_tool": "onboard",
+            "implementation_tool": "onboard",
             "why": "Mint a fresh process identity. If continuing prior work, include parent_agent_id and spawn_reason='new_session'.",
         },
         {
@@ -148,6 +149,7 @@ def _getting_started_path() -> List[Dict[str, Any]]:
             "tool": "sync_state",
             "call": "sync_state(response_text='what changed', complexity=0.5, confidence=0.7)",
             "canonical_tool": "process_agent_update",
+            "implementation_tool": "process_agent_update",
             "why": "Record meaningful work and receive a governance verdict.",
         },
         {
@@ -155,6 +157,7 @@ def _getting_started_path() -> List[Dict[str, Any]]:
             "tool": "check_working_state",
             "call": "check_working_state()",
             "canonical_tool": "get_governance_metrics",
+            "implementation_tool": "get_governance_metrics",
             "why": "Inspect current EISV state without mutating history.",
         },
         {
@@ -162,6 +165,7 @@ def _getting_started_path() -> List[Dict[str, Any]]:
             "tool": "search_shared_memory",
             "call": "search_shared_memory(query='topic')",
             "canonical_tool": "knowledge(action='search')",
+            "implementation_tool": "knowledge(action='search')",
             "why": "Reuse shared memory before writing duplicate discoveries.",
         },
         {
@@ -636,15 +640,15 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
     # Build tools list dynamically from registered tools
     # Description mapping for tools (fallback to generic if not found)
     tool_descriptions = {
-        "start_session": "Start a UNITARES session; alias for onboard(force_new=true, parent_agent_id=...)",
-        "sync_state": "Check in after meaningful work; alias for process_agent_update(...)",
-        "check_working_state": "Read current EISV state without mutating history; alias for get_governance_metrics()",
-        "search_shared_memory": "Search shared memory before writing; alias for knowledge(action='search')",
-        "record_result": "Record real task/tool/test outcome; alias for outcome_event(...)",
-        "request_review": "Ask for structured review/recovery; alias for dialectic(action='request')",
+        "start_session": "Start a UNITARES session; primary workflow name for onboarding",
+        "sync_state": "Check in after meaningful work; primary workflow name for state updates",
+        "check_working_state": "Read current EISV state without mutating history",
+        "search_shared_memory": "Search shared memory before writing duplicate discoveries",
+        "record_result": "Record real task/tool/test outcome for calibration",
+        "request_review": "Ask for structured review/recovery",
         "onboard": "Register fresh process-instance with governance. Per v2 ontology, declare lineage via parent_agent_id rather than resume via token.",
         "identity": "🪞 Check who you are or set your display name. Per v2 ontology, arg-less identity() with no proof signal mints fresh; pass continuity_token / agent_uuid + proof to resume.",
-        "process_agent_update": "💬 Share your work and get supportive feedback. Your main check-in tool",
+        "process_agent_update": "Raw implementation for sync_state(); updates agent governance state",
         "get_governance_metrics": "📊 Get current state and metrics without updating",
         "simulate_update": "🧪 Test decisions without persisting state",
         "get_thresholds": "⚙️ View current threshold configuration",
@@ -916,7 +920,6 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
                 "search_shared_memory": "(query?:str, tags?:list, limit?:int, include_details?:bool)",
                 "record_result": "(outcome_type:str, confidence?:float, prediction_id?:str, detail?:dict)",
                 "request_review": "(issue_description:str, reason?:str)",
-                "process_agent_update": "(complexity:float, response_text?:str, confidence?:float, task_type?:str)",
                 "store_knowledge_graph": "(summary:str, tags?:list, severity?:str, details?:str)",
                 "search_knowledge_graph": "(query?:str, tags?:list, limit?:int, include_details?:bool)",
                 "knowledge_search": "(action='search', query?:str, tags?:list, limit?:int, include_details?:bool)",
@@ -932,8 +935,8 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
         # Add first-time hint for new agents
         if is_new_agent:
             response_data["first_time"] = {
-                "hint": "👋 First time here? Start with onboard(force_new=true) to create your identity!",
-                "next_step": "Call onboard(force_new=true). If inheriting prior work, also pass parent_agent_id and spawn_reason='new_session'."
+                "hint": "First time here? Start with start_session(force_new=true) to create your identity.",
+                "next_step": "Call start_session(force_new=true). If inheriting prior work, also pass parent_agent_id and spawn_reason='new_session'."
             }
         
         # Add progressive metadata if enabled
@@ -1130,10 +1133,10 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
         "note": "Use this tool to discover available capabilities. MCP protocol also provides tool definitions, but this provides categorized overview useful for onboarding. Use 'essential_only=true' or 'tier=essential' to reduce cognitive load by showing only core workflow tools (~10 tools).",
         "quick_start": {
             "new_agent": [
-                "1. Call onboard(force_new=true) - creates a fresh process identity",
+                "1. Call start_session(force_new=true) - creates a fresh process identity",
                 "2. If inheriting prior work, include parent_agent_id and spawn_reason='new_session'",
                 "3. Save uuid plus continuity diagnostics from response",
-                "4. Call process_agent_update() to share meaningful work",
+                "4. Call sync_state() to share meaningful work",
                 "5. Use identity(name='...') to set a cosmetic label"
             ],
             "categories_to_explore": [
@@ -1156,9 +1159,9 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
 │  🚀 START                                                           │
 │     │                                                               │
 │     ▼                                                               │
-│  ┌─────────┐                                                        │
-│  │ onboard │──────────────────┐                                     │
-│  └────┬────┘                  │                                     │
+│  ┌───────────────┐                                                  │
+│  │ start_session │────────────┐                                     │
+│  └───────┬───────┘            │                                     │
 │       │                       ▼                                     │
 │       │              ┌──────────────┐                               │
 │       │              │   identity   │ ◄── name yourself             │
@@ -1166,7 +1169,7 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
 │       │                                                             │
 │       ▼                                                             │
 │  ┌────────────────────────┐       ┌─────────────────────────────┐  │
-│  │ process_agent_update   │◄─────►│ get_governance_metrics      │  │
+│  │ sync_state             │◄─────►│ check_working_state         │  │
 │  │ (main check-in)        │       │ (view state)                │  │
 │  └───────────┬────────────┘       └─────────────────────────────┘  │
 │              │                                                      │
@@ -1176,8 +1179,8 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
 │  ┌───────────────────────┐              ┌────────────────────────┐ │
 │  │ KNOWLEDGE GRAPH       │              │ OBSERVABILITY          │ │
 │  ├───────────────────────┤              ├────────────────────────┤ │
-│  │ store_knowledge_graph │              │ list_agents            │ │
-│  │ search_knowledge_graph│              │ observe_agent          │ │
+│  │ search_shared_memory  │              │ list_agents            │ │
+│  │ knowledge             │              │ observe_agent          │ │
 │  │ leave_note            │              │ compare_agents         │ │
 │  │ get_discovery_details │              │ detect_anomalies       │ │
 │  └───────────────────────┘              └────────────────────────┘ │
@@ -1221,7 +1224,7 @@ async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextConten
             return [error_response(
                 "tool_name is required",
                 recovery={
-                    "action": "Call list_tools to find the canonical name, then call describe_tool(tool_name=...)",
+                    "action": "Call list_tools to find the primary tool name, then call describe_tool(tool_name=...)",
                     "related_tools": ["list_tools"],
                 },
             )]
@@ -1473,9 +1476,14 @@ async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextConten
                     "note": "Lite mode - use describe_tool(tool_name=..., lite=false) for full schema"
                 }
                 if alias_info:
+                    response_data["primary_tool"] = requested_tool_name
+                    response_data["implementation_tool"] = tool_name
                     response_data["canonical_tool"] = tool_name
                     response_data["alias"] = {
                         "reason": alias_info.reason,
+                        "role": "primary_agent_workflow",
+                        "primary_tool": requested_tool_name,
+                        "implementation_tool": alias_info.new_name,
                         "canonical_tool": alias_info.new_name,
                         "injected_action": alias_info.inject_action,
                         "note": alias_info.migration_note,
@@ -1533,9 +1541,14 @@ async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextConten
                     "note": "Lite mode - use describe_tool(tool_name=..., lite=false) for full schema"
                 }
                 if alias_info:
+                    response_data["primary_tool"] = requested_tool_name
+                    response_data["implementation_tool"] = tool_name
                     response_data["canonical_tool"] = tool_name
                     response_data["alias"] = {
                         "reason": alias_info.reason,
+                        "role": "primary_agent_workflow",
+                        "primary_tool": requested_tool_name,
+                        "implementation_tool": alias_info.new_name,
                         "canonical_tool": alias_info.new_name,
                         "injected_action": alias_info.inject_action,
                         "note": alias_info.migration_note,
@@ -1564,8 +1577,13 @@ async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextConten
         }
         if alias_info:
             full_response["tool"]["canonical_name"] = tool_name
+            full_response["tool"]["implementation_name"] = tool_name
+            full_response["tool"]["role"] = "primary_agent_workflow"
             full_response["alias"] = {
                 "reason": alias_info.reason,
+                "role": "primary_agent_workflow",
+                "primary_tool": requested_tool_name,
+                "implementation_tool": alias_info.new_name,
                 "canonical_tool": alias_info.new_name,
                 "injected_action": alias_info.inject_action,
                 "note": alias_info.migration_note,

--- a/src/mcp_handlers/support/param_normalization.py
+++ b/src/mcp_handlers/support/param_normalization.py
@@ -1,7 +1,7 @@
-"""Alias-layer parameter normalization for friendly check-in aliases.
+"""Primary-workflow parameter normalization for check-in tools.
 
-Canonical tools stay strict: process_agent_update rejects complexity outside
-0-1. The friendly aliases (checkin/log/update/sync_state) absorb common agent
+Raw implementation tools stay strict: process_agent_update rejects complexity
+outside 0-1. The workflow tools (checkin/log/update/sync_state) absorb common agent
 vocabulary by normalizing it BEFORE schema validation, and the dispatch
 envelope discloses every transform via ``normalized_parameters``.
 
@@ -12,7 +12,7 @@ or use a named level.
 
 from typing import Any, Callable, Dict
 
-# Named levels accepted on friendly aliases. Synonyms map to the same anchor
+# Named levels accepted on workflow tools. Synonyms map to the same anchor
 # values so the disclosure record stays unambiguous.
 NAMED_LEVELS: Dict[str, float] = {
     "trivial": 0.1,
@@ -35,7 +35,7 @@ ParamNormalizer = Callable[[Dict[str, Any]], NormalizationRecords]
 
 
 class ParamNormalizationError(ValueError):
-    """A parameter on a friendly alias could not be normalized unambiguously."""
+    """A workflow parameter could not be normalized unambiguously."""
 
     def __init__(self, message: str, *, parameter: str, provided: Any):
         super().__init__(message)

--- a/src/mcp_handlers/tool_stability.py
+++ b/src/mcp_handlers/tool_stability.py
@@ -54,72 +54,13 @@ class ToolLifecycle:
 # ============================================================================
 # Tool Aliases Registry
 # ============================================================================
-# When tools are renamed/consolidated, add aliases here so old names still work
-# This prevents breaking existing code/agents
+# When tools are renamed/consolidated, add aliases here so old names still work.
+# Primary agent workflow names also live here: they dispatch through raw
+# implementation tools, but are the public first-run surface for agents.
 
 _CHECKIN_COMPLEXITY_NORMALIZER = normalize_unit_interval("complexity")
 
 _TOOL_ALIASES: Dict[str, ToolAlias] = {
-    # Agent workflow aliases — first-class UX names for the core loop.
-    # These are intentionally advertised/registered, unlike most historical
-    # compatibility aliases, so cold MCP agents can discover task verbs.
-    "start_session": ToolAlias(
-        old_name="start_session",
-        new_name="onboard",
-        reason="intuitive_alias",
-        migration_note=(
-            "Workflow alias for onboard(force_new=true, parent_agent_id=...). "
-            "Starts a fresh process identity or declares lineage."
-        ),
-    ),
-    "sync_state": ToolAlias(
-        old_name="sync_state",
-        new_name="process_agent_update",
-        reason="intuitive_alias",
-        migration_note=(
-            "Workflow alias for process_agent_update(response_text='...', "
-            "complexity=..., confidence=...)."
-        ),
-    ),
-    "check_working_state": ToolAlias(
-        old_name="check_working_state",
-        new_name="get_governance_metrics",
-        reason="intuitive_alias",
-        migration_note=(
-            "Workflow alias for get_governance_metrics(). Reads current EISV "
-            "state without writing a check-in."
-        ),
-    ),
-    "search_shared_memory": ToolAlias(
-        old_name="search_shared_memory",
-        new_name="knowledge",
-        reason="intuitive_alias",
-        migration_note=(
-            "Workflow alias for knowledge(action='search', query='...'). "
-            "Search shared memory before writing a duplicate discovery."
-        ),
-        inject_action="search",
-    ),
-    "record_result": ToolAlias(
-        old_name="record_result",
-        new_name="outcome_event",
-        reason="intuitive_alias",
-        migration_note=(
-            "Workflow alias for outcome_event(...). Records the real outcome "
-            "of a task, test, tool call, or external validation signal."
-        ),
-    ),
-    "request_review": ToolAlias(
-        old_name="request_review",
-        new_name="dialectic",
-        reason="intuitive_alias",
-        migration_note=(
-            "Workflow alias for dialectic(action='request', "
-            "issue_description='...'). Starts structured review/recovery."
-        ),
-        inject_action="request",
-    ),
-
     # Identity tools - all point to identity() (the primary identity tool)
     # NOTE: who_am_i has its own handler in admin.py, so NOT aliased
     #
@@ -381,9 +322,9 @@ _TOOL_ALIASES: Dict[str, ToolAlias] = {
         migration_note="Use knowledge(action='stats')", inject_action="stats"),
 
     # ==========================================================================
-    # Agent-experience aliases (Jun 2026) — task-verb names for the core
-    # agent workflow. Additive layer: canonical tools, schemas, and EISV
-    # semantics are unchanged underneath. Identity classification is
+    # Primary agent workflow names (Jun 2026) — task verbs for the core
+    # agent workflow. Additive layer: raw implementation tools, schemas,
+    # and EISV semantics are unchanged underneath. Identity classification is
     # inherited automatically: get_call_identity_requirement canonicalizes
     # through this registry (alias + inject_action) before judging.
     # `experience=True` opts the response into the normalized envelope
@@ -391,28 +332,28 @@ _TOOL_ALIASES: Dict[str, ToolAlias] = {
     # ==========================================================================
     "start_session": ToolAlias(
         old_name="start_session", new_name="onboard", reason="intuitive_alias",
-        migration_note="Resolves to onboard() - creates identity and returns templates",
+        migration_note="Primary workflow name for starting a session; implemented by onboard().",
         experience=True),
     "sync_state": ToolAlias(
         old_name="sync_state", new_name="process_agent_update", reason="intuitive_alias",
-        migration_note="Resolves to process_agent_update() - check in your working state",
+        migration_note="Primary workflow name for checking in state; implemented by process_agent_update().",
         param_normalizer=_CHECKIN_COMPLEXITY_NORMALIZER,
         experience=True),
     "check_working_state": ToolAlias(
         old_name="check_working_state", new_name="get_governance_metrics", reason="intuitive_alias",
-        migration_note="Resolves to get_governance_metrics() - your current EISV working state",
+        migration_note="Primary workflow name for reading current EISV state; implemented by get_governance_metrics().",
         experience=True),
     "search_shared_memory": ToolAlias(
         old_name="search_shared_memory", new_name="knowledge", reason="intuitive_alias",
-        migration_note="Resolves to knowledge(action='search') - find prior discoveries, avoid duplicate work",
+        migration_note="Primary workflow name for memory search; implemented by knowledge(action='search').",
         inject_action="search", experience=True),
     "record_result": ToolAlias(
         old_name="record_result", new_name="outcome_event", reason="intuitive_alias",
-        migration_note="Resolves to outcome_event() - record what actually happened",
+        migration_note="Primary workflow name for recording outcomes; implemented by outcome_event().",
         experience=True),
     "request_review": ToolAlias(
         old_name="request_review", new_name="dialectic", reason="intuitive_alias",
-        migration_note="Resolves to dialectic(action='request', issue_description='...') - ask for a structured review",
+        migration_note="Primary workflow name for structured review; implemented by dialectic(action='request').",
         inject_action="request", experience=True),
 }
 
@@ -509,10 +450,10 @@ def is_experience_alias(tool_name: str) -> bool:
 
 
 def experience_alias_map() -> Dict[str, str]:
-    """Friendly experience-alias name -> canonical tool name.
+    """Primary agent workflow name -> raw implementation tool name.
 
     Single source for the discoverability surfaces (list_tools catalog)
-    so the advertised friendly names can never drift from the registry.
+    so the advertised primary names can never drift from the registry.
     """
     return {
         name: alias.new_name

--- a/src/tool_modes.py
+++ b/src/tool_modes.py
@@ -19,14 +19,11 @@ TOOL_MODE = os.getenv("GOVERNANCE_TOOL_MODE", "lite").lower()
 
 # Minimal mode: Essential tools + list_tools for discovery
 MINIMAL_MODE_TOOLS: Set[str] = {
-    # Agent workflow aliases (task verbs over canonical implementation names)
+    # Primary agent workflow tools (task verbs over raw implementation names)
     "start_session",
     "sync_state",
     "check_working_state",
-    "onboard",                # 🚀 Portal tool - call this FIRST (Dec 2025)
     "identity",               # Check/set identity (auto-creates on first call)
-    "process_agent_update",   # Log your work (ongoing)
-    "get_governance_metrics", # Check your state (as needed)
     "list_tools",             # Discover available tools (bootstrap)
     "describe_tool",          # Pull full details for a specific tool (lazy schema)
 }
@@ -35,20 +32,15 @@ MINIMAL_MODE_TOOLS: Set[str] = {
 # THIS IS THE SINGLE SOURCE OF TRUTH - admin.py imports from here
 # Updated Feb 2026: Use consolidated tools to reduce cognitive load
 LITE_MODE_TOOLS: Set[str] = {
-    # Agent workflow aliases (visible, first-class UX names)
-    "start_session",              # Alias for onboard
-    "sync_state",                 # Alias for process_agent_update
-    "check_working_state",        # Alias for get_governance_metrics
-    "search_shared_memory",       # Alias for knowledge(action='search')
-    "record_result",              # Alias for outcome_event
-    "request_review",             # Alias for dialectic(action='request')
-
-    # Core governance
-    "process_agent_update",       # Log agent work
-    "get_governance_metrics",     # Check agent state
+    # Primary agent workflow tools
+    "start_session",              # Start or declare lineage
+    "sync_state",                 # Log agent work
+    "check_working_state",        # Check agent state
+    "search_shared_memory",       # Search shared memory
+    "record_result",              # Record task/tool/test outcomes
+    "request_review",             # Ask for structured review
 
     # Identity (streamlined - Dec 2025)
-    "onboard",                    # 🚀 Portal tool - call this FIRST
     "identity",                   # Primary identity tool (auto-creates on first call)
 
     # Consolidated tools (Feb 2026)
@@ -70,9 +62,16 @@ LITE_MODE_TOOLS: Set[str] = {
     "leave_note",                 # Quick notes
     "call_model",                 # LLM access
 
-    # Session & calibration hooks (required by automation)
+    # Session hook (required by automation)
     "bind_session",               # Session-start hook for MCP identity sync
-    "outcome_event",              # PostToolUse hook for auto-calibration
+
+    # Raw implementation tools kept callable for compatibility wrappers/hooks.
+    # They are intentionally common-tier, not essential-tier: primary workflow
+    # names remain the promoted agent-facing surface.
+    "onboard",                    # Raw implementation for start_session
+    "process_agent_update",       # Raw implementation for sync_state
+    "get_governance_metrics",     # Raw implementation for check_working_state
+    "outcome_event",              # Raw implementation for record_result
 
     # Recovery
     "self_recovery",              # Primary recovery path for stuck agents
@@ -132,16 +131,13 @@ OPERATOR_RECOVERY_MODE_TOOLS: Set[str] = OPERATOR_READONLY_MODE_TOOLS | {
 # ============================================================================
 TOOL_TIERS: dict[str, Set[str]] = {
     "essential": {  # Tier 1: Core workflow tools (~10 tools)
-        "start_session",          # Workflow alias for onboard
-        "sync_state",             # Workflow alias for process_agent_update
-        "check_working_state",    # Workflow alias for get_governance_metrics
-        "search_shared_memory",   # Workflow alias for knowledge(search)
-        "record_result",          # Workflow alias for outcome_event
-        "request_review",         # Workflow alias for dialectic(request)
-        "onboard",                # 🚀 Portal tool - call FIRST (Dec 2025)
+        "start_session",          # Start or declare lineage
+        "sync_state",             # Log agent work
+        "check_working_state",    # Check state without updating
+        "search_shared_memory",   # Search shared memory
+        "record_result",          # Record outcomes
+        "request_review",         # Ask for structured review
         "identity",               # Primary identity tool (auto-creates on first call)
-        "process_agent_update",   # Log agent work
-        "get_governance_metrics", # Check state without updating
         "list_tools",             # Discover available tools
         "describe_tool",          # Get full tool details
         "list_agents",            # View all agents
@@ -150,6 +146,10 @@ TOOL_TIERS: dict[str, Set[str]] = {
         "leave_note",             # Quick notes
     },
     "common": {  # Tier 2: Regularly used tools
+        "onboard",                         # Raw implementation for start_session
+        "process_agent_update",            # Raw implementation for sync_state
+        "get_governance_metrics",          # Raw implementation for check_working_state
+        "outcome_event",                   # Raw implementation for record_result
         "update_discovery_status_graph",
         "observe_agent",
         "get_agent_metadata",
@@ -202,7 +202,7 @@ TOOL_TIERS: dict[str, Set[str]] = {
 # admin: System administration (may read or write internal state)
 # ============================================================================
 TOOL_OPERATIONS: dict[str, str] = {
-    # Agent workflow aliases
+    # Primary agent workflow tools
     "start_session": "read",
     "sync_state": "write",
     "check_working_state": "read",
@@ -294,13 +294,14 @@ TOOL_CATEGORIES = {
         "sync_state",
         "check_working_state",
         "record_result",
-        "process_agent_update",
-        "get_governance_metrics",
         "simulate_update",
+        "process_agent_update",     # raw implementation
+        "get_governance_metrics",   # raw implementation
+        "outcome_event",            # raw implementation
     },
     "identity": {
         "start_session",
-        "onboard",                # Dec 2025: Portal tool - call FIRST
+        "onboard",                # raw implementation
         "identity",               # Dec 2025: Primary identity tool (auto-creates on first call)
         "list_agents",
         "get_agent_metadata",

--- a/tests/test_describe_tool_drift.py
+++ b/tests/test_describe_tool_drift.py
@@ -89,8 +89,11 @@ async def test_workflow_alias_describe_resolves_to_canonical_schema():
     params = "\n".join(data["parameters"])
 
     assert data["tool"] == "sync_state"
+    assert data["primary_tool"] == "sync_state"
+    assert data["implementation_tool"] == "process_agent_update"
     assert data["canonical_tool"] == "process_agent_update"
     assert data["alias"]["reason"] == "intuitive_alias"
+    assert data["alias"]["role"] == "primary_agent_workflow"
     assert "response_text" in params
     assert "complexity" in params
     assert "confidence" in params
@@ -115,6 +118,14 @@ async def test_list_tools_lite_surfaces_workflow_aliases():
         "request_review",
     ):
         assert alias in names
+
+    for raw_tool in (
+        "onboard",
+        "process_agent_update",
+        "get_governance_metrics",
+        "outcome_event",
+    ):
+        assert raw_tool not in names
 
     assert data["getting_started_path"][0]["tool"] == "start_session"
     assert data["getting_started_path"][1]["tool"] == "sync_state"

--- a/tests/test_list_tools_workflow_aliases.py
+++ b/tests/test_list_tools_workflow_aliases.py
@@ -1,10 +1,10 @@
 """Drift-guard: the list_tools catalog must keep advertising every
-agent-experience alias, and each must resolve to a real tool.
+primary agent-experience workflow tool, and each must resolve to a real tool.
 
-The friendly task-verb names (start_session, sync_state, ...) are
+The primary task-verb names (start_session, sync_state, ...) are
 surfaced for in-band discovery across the catalog's lite `signatures`
 and full tool list. Those are hand-maintained strings; this guard pins
-them to the registry (`experience_alias_map`) so a future alias rename
+them to the registry (`experience_alias_map`) so a future workflow rename
 or removal fails here instead of silently dropping a name from
 discovery while the registry still routes it.
 """
@@ -42,17 +42,17 @@ def _tool_names(obj, acc: set) -> set:
 
 
 def test_experience_aliases_discoverable_in_lite_catalog():
-    friendly = set(experience_alias_map())
+    primary_tools = set(experience_alias_map())
     signatures = set(_catalog({"lite": True}).get("signatures", {}))
-    missing = friendly - signatures
-    assert not missing, f"experience aliases absent from lite signatures: {sorted(missing)}"
+    missing = primary_tools - signatures
+    assert not missing, f"primary workflow tools absent from lite signatures: {sorted(missing)}"
 
 
 def test_experience_aliases_discoverable_in_full_catalog():
-    friendly = set(experience_alias_map())
+    primary_tools = set(experience_alias_map())
     advertised = _tool_names(_catalog({"lite": False}), set())
-    missing = friendly - advertised
-    assert not missing, f"experience aliases absent from full catalog: {sorted(missing)}"
+    missing = primary_tools - advertised
+    assert not missing, f"primary workflow tools absent from full catalog: {sorted(missing)}"
 
 
 def test_every_advertised_alias_resolves_to_a_registered_tool():
@@ -60,7 +60,7 @@ def test_every_advertised_alias_resolves_to_a_registered_tool():
     must resolve to a registered canonical handler."""
     from src.mcp_handlers import TOOL_HANDLERS
 
-    for friendly, canonical in experience_alias_map().items():
-        resolved, alias = resolve_tool_alias(friendly)
-        assert resolved == canonical, f"{friendly} -> {resolved}, expected {canonical}"
-        assert canonical in TOOL_HANDLERS, f"{friendly} -> {canonical} not registered"
+    for primary_tool, implementation_tool in experience_alias_map().items():
+        resolved, alias = resolve_tool_alias(primary_tool)
+        assert resolved == implementation_tool, f"{primary_tool} -> {resolved}, expected {implementation_tool}"
+        assert implementation_tool in TOOL_HANDLERS, f"{primary_tool} -> {implementation_tool} not registered"

--- a/tests/test_tool_modes.py
+++ b/tests/test_tool_modes.py
@@ -37,14 +37,17 @@ class TestModeSets:
     """Tests for the mode tool sets."""
 
     def test_minimal_mode_has_essentials(self):
-        assert "onboard" in MINIMAL_MODE_TOOLS
-        assert "process_agent_update" in MINIMAL_MODE_TOOLS
-        assert "get_governance_metrics" in MINIMAL_MODE_TOOLS
+        assert "start_session" in MINIMAL_MODE_TOOLS
+        assert "sync_state" in MINIMAL_MODE_TOOLS
+        assert "check_working_state" in MINIMAL_MODE_TOOLS
         assert "list_tools" in MINIMAL_MODE_TOOLS
+        assert "onboard" not in MINIMAL_MODE_TOOLS
+        assert "process_agent_update" not in MINIMAL_MODE_TOOLS
+        assert "get_governance_metrics" not in MINIMAL_MODE_TOOLS
 
     def test_lite_mode_superset_of_minimal_essentials(self):
-        """Lite should include the core governance tools from minimal."""
-        for tool in ["onboard", "process_agent_update", "get_governance_metrics"]:
+        """Lite should include the primary workflow tools from minimal."""
+        for tool in ["start_session", "sync_state", "check_working_state"]:
             assert tool in LITE_MODE_TOOLS, f"{tool} should be in lite mode"
 
     def test_lite_mode_has_consolidated_tools(self):
@@ -119,7 +122,7 @@ class TestShouldIncludeTool:
     """Tests for should_include_tool()."""
 
     def test_tool_in_mode(self):
-        assert should_include_tool("onboard", mode="minimal") is True
+        assert should_include_tool("start_session", mode="minimal") is True
 
     def test_tool_not_in_mode(self):
         assert should_include_tool("call_model", mode="minimal") is False
@@ -145,7 +148,7 @@ class TestShouldIncludeTool:
 
     def test_non_claude_desktop_no_exclusion(self):
         """Non-Claude-Desktop clients should not be affected by exclusions."""
-        assert should_include_tool("onboard", mode="lite", client_type=None) is True
+        assert should_include_tool("start_session", mode="lite", client_type=None) is True
 
 
 # --- TOOL_TIERS Tests ---
@@ -160,8 +163,11 @@ class TestToolTiers:
         assert "advanced" in TOOL_TIERS
 
     def test_essential_has_core_tools(self):
-        assert "onboard" in TOOL_TIERS["essential"]
-        assert "process_agent_update" in TOOL_TIERS["essential"]
+        assert "start_session" in TOOL_TIERS["essential"]
+        assert "sync_state" in TOOL_TIERS["essential"]
+        assert "check_working_state" in TOOL_TIERS["essential"]
+        assert "onboard" not in TOOL_TIERS["essential"]
+        assert "process_agent_update" not in TOOL_TIERS["essential"]
         assert "health_check" in TOOL_TIERS["essential"]
 
     def test_tiers_are_sets(self):


### PR DESCRIPTION
## Summary

- Promote the task-verb workflow tools as the primary agent-facing surface in docs, skills, and list/describe metadata.
- Move raw implementation names out of the essential tier while keeping the raw backing tools callable in lite mode for compatibility wrappers and hooks.
- Add drift coverage so primary workflow tools remain discoverable and describe output identifies the primary/implementation mapping.

## Root Cause

The workflow aliases were implemented, but many discovery and guidance surfaces still framed the raw implementation tools as the primary entry point. That made cold-start agents more likely to choose the older raw names and made the alias layer look optional instead of the intended front door.

During branch closeout, the full cache gate caught that removing raw `process_agent_update` from lite mode also removed its FastMCP registration, breaking extra-argument passthrough. The final version keeps those raw backing tools callable while leaving primary workflow names as the promoted essential surface.

## Validation

- `python3 -m pytest tests/test_describe_tool_drift.py tests/test_list_tools_workflow_aliases.py tests/test_tool_modes.py tests/test_tool_stability.py`
- `python3 -m pytest tests/test_mcp_extra_passthrough.py tests/test_tool_modes.py tests/test_describe_tool_drift.py tests/test_list_tools_workflow_aliases.py tests/test_tool_stability.py`
- `./scripts/dev/test-cache.sh --staged`
- `./scripts/dev/test-cache.sh`
- pre-push smoke tests
