### PR TITLE
feat(client): configurable ollama_bridge + ontology-aligned, strict-safe identity

### DIFF
--- a/scripts/client/ollama_bridge.py
+++ b/scripts/client/ollama_bridge.py
@@ -7,19 +7,55 @@ The raw MCP tool schemas have too many optional parameters for smaller models.
 This script creates simplified wrapper tools with minimal signatures, then
 exposes them to the model via CodeAgent (which writes Python, not JSON tool calls).
 
+Configuration (env vars; CLI flags override):
+    UNITARES_MCP_URL      governance MCP endpoint   (default http://127.0.0.1:8767/mcp/)
+    UNITARES_OLLAMA_URL   Ollama OpenAI-compat API  (default http://127.0.0.1:11434/v1)
+    UNITARES_LLM_MODEL    Ollama model to drive     (default gemma4:latest)
+
+Identity posture (v2 ontology — see docs/ontology/identity.md):
+    A fresh bridge run mints a fresh process-instance identity
+    (`onboard(force_new=true, spawn_reason="new_session")`, no parent).
+    Co-location is not lineage; the default declares no parent.
+
+    UNITARES_AGENT_UUID   substrate-anchored continuity: resume a fixed UUID
+                          across restarts (the long-lived-resident pattern,
+                          `identity(agent_uuid=..., resume=true)`) instead of
+                          minting fresh. Use only for a genuinely persistent
+                          local agent that earns one durable identity.
+    UNITARES_PARENT_AGENT_ID  declare causal lineage to a prior agent. Pair
+                          with a causal --spawn-reason (e.g. "explicit" for a
+                          handoff from an EXITED prior session). Declaring a
+                          LIVE agent as parent is rejected server-side
+                          (lineage_coincidental_rejected).
+    UNITARES_SPAWN_REASON one of new_session|explicit|subagent|compaction|
+                          dispatch (default new_session).
+
 Usage:
-    python3 ollama_bridge.py                          # interactive, gemma4:latest
+    python3 ollama_bridge.py                          # interactive, configured model
     python3 ollama_bridge.py --model gemma4:31b       # use a specific model
     python3 ollama_bridge.py --task "check health"    # single task, then exit
+    python3 ollama_bridge.py --agent-uuid <uuid>      # resume a durable identity
+    python3 ollama_bridge.py --parent-agent-id <uuid> --spawn-reason explicit
 """
 
 import argparse
+import json
+import os
 import sys
 
 from smolagents import tool, ToolCollection, OpenAIServerModel, CodeAgent
 
-GOVERNANCE_URL = "http://127.0.0.1:8767/mcp/"
-OLLAMA_URL = "http://127.0.0.1:11434/v1"
+# Defaults match repo conventions: UNITARES_MCP_URL (client URL, cf.
+# scripts/dev/with_checkin.py) and UNITARES_LLM_MODEL (cf. the call_model /
+# llm_delegation local path). Endpoints are config, not identity.
+DEFAULT_MCP_URL = os.getenv("UNITARES_MCP_URL", "http://127.0.0.1:8767/mcp/")
+DEFAULT_OLLAMA_URL = os.getenv("UNITARES_OLLAMA_URL", "http://127.0.0.1:11434/v1")
+DEFAULT_MODEL = os.getenv("UNITARES_LLM_MODEL", "gemma4:latest")
+
+# Valid spawn_reason values per the v2 ontology. "new_session" is the honest
+# fresh default (no parent); the rest are causal and expect a parent_agent_id.
+VALID_SPAWN_REASONS = ("new_session", "explicit", "subagent", "compaction", "dispatch")
+CAUSAL_SPAWN_REASONS = ("explicit", "subagent", "compaction", "dispatch")
 
 INSTRUCTIONS = """\
 You are a UNITARES governance agent running locally via Ollama.
@@ -39,7 +75,106 @@ You interact with the UNITARES governance system through Python tool calls.
 """
 
 
-def make_wrappers(mcp_tools: dict):
+class IdentityConfig:
+    """Operator-determined identity posture for this bridge run.
+
+    Identity is substrate config, not a model decision: the model calls
+    register_agent(name) with a cosmetic label, and the bridge applies the
+    configured posture (fresh / substrate-anchored / declared-lineage).
+    """
+
+    def __init__(self, agent_uuid=None, parent_agent_id=None, spawn_reason="new_session"):
+        self.agent_uuid = agent_uuid or None
+        self.parent_agent_id = parent_agent_id or None
+        self.spawn_reason = spawn_reason or "new_session"
+
+    @classmethod
+    def from_args(cls, args):
+        cfg = cls(
+            agent_uuid=args.agent_uuid or os.getenv("UNITARES_AGENT_UUID"),
+            parent_agent_id=args.parent_agent_id or os.getenv("UNITARES_PARENT_AGENT_ID"),
+            spawn_reason=(args.spawn_reason or os.getenv("UNITARES_SPAWN_REASON") or "new_session"),
+        )
+        cfg.validate()
+        return cfg
+
+    def validate(self):
+        if self.spawn_reason not in VALID_SPAWN_REASONS:
+            raise SystemExit(
+                f"Invalid --spawn-reason '{self.spawn_reason}'. "
+                f"Expected one of: {', '.join(VALID_SPAWN_REASONS)}."
+            )
+        # A causal spawn_reason names a real spawn/handoff and needs a parent.
+        if self.spawn_reason in CAUSAL_SPAWN_REASONS and not self.parent_agent_id:
+            raise SystemExit(
+                f"--spawn-reason '{self.spawn_reason}' is causal and requires "
+                "--parent-agent-id (the UUID of the prior agent). For a fresh "
+                "run, use spawn_reason 'new_session' (the default)."
+            )
+
+    def describe(self):
+        if self.agent_uuid:
+            return f"substrate-anchored resume of {self.agent_uuid}"
+        if self.parent_agent_id:
+            return f"fresh, lineage={self.spawn_reason} from {self.parent_agent_id}"
+        return f"fresh, {self.spawn_reason} (no lineage)"
+
+
+class Session:
+    """In-process identity binding for one bridge run.
+
+    Per the v2 ontology, `client_session_id` maintains identity within a single
+    process. register_agent captures it from the onboard/resume response, and
+    every later call echoes it so the model's successive tool calls form ONE
+    trajectory — not a scatter of fingerprint-resolved writes. Without this the
+    strict-identity gate refuses writes ("identity resolved by transport
+    fingerprint, not a proof you supplied") or, worse, lands them on a sibling
+    identity sharing the httpx fingerprint.
+    """
+
+    def __init__(self):
+        self.client_session_id = None
+        self.agent_uuid = None
+
+    def capture(self, raw: str) -> str:
+        """Extract client_session_id / agent_uuid from a tool response string."""
+        try:
+            data = json.loads(raw)
+        except (TypeError, ValueError):
+            return raw
+        csid = _deep_find(data, "client_session_id")
+        if csid:
+            self.client_session_id = csid
+        uuid = _deep_find(data, "agent_uuid")
+        if uuid:
+            self.agent_uuid = uuid
+        return raw
+
+    def bind(self, **kwargs) -> dict:
+        """Add the captured client_session_id to a call's kwargs if we have one."""
+        if self.client_session_id:
+            kwargs.setdefault("client_session_id", self.client_session_id)
+        return kwargs
+
+
+def _deep_find(obj, key):
+    """First value for `key` anywhere in a nested dict/list, or None."""
+    if isinstance(obj, dict):
+        if obj.get(key):
+            return obj[key]
+        for v in obj.values():
+            found = _deep_find(v, key)
+            if found:
+                return found
+    elif isinstance(obj, list):
+        for v in obj:
+            found = _deep_find(v, key)
+            if found:
+                return found
+    return None
+
+
+def make_wrappers(mcp_tools: dict, identity: "IdentityConfig", session: "Session"):
     """Create simplified tool wrappers over the raw MCP tools."""
 
     @tool
@@ -49,15 +184,28 @@ def make_wrappers(mcp_tools: dict):
 
     @tool
     def register_agent(name: str) -> str:
-        """Register as a new governance agent. Call this once at the start of a session.
+        """Register as a governance agent. Call this once at the start of a session.
         Args:
             name: Display name for this agent (e.g. 'ollama-local')
         """
-        # force_new=True creates a fresh UUID; `name` is stored as the
-        # cosmetic label (not used for resolution — name-claim removed
-        # 2026-04-17). Persistent Ollama sessions should cache the returned
-        # agent_uuid and call identity(agent_uuid=..., resume=true) next time.
-        return mcp_tools["onboard"](name=name, force_new=True, spawn_reason="explicit")
+        # Identity posture is operator-configured, not chosen here; `name` is
+        # the cosmetic label only (not used for resolution — name-claim removed
+        # 2026-04-17). Three ontology-correct paths:
+        #   1. substrate-anchored: resume a durable UUID across restarts (the
+        #      long-lived-resident pattern).
+        #   2. declared lineage: fresh mint that names a real causal parent.
+        #   3. fresh new_session (default): a fresh process-instance is a fresh
+        #      agent; co-location is not lineage.
+        # Either way we capture client_session_id so later calls stay one
+        # trajectory (strict-identity requires a caller-proven binding).
+        if identity.agent_uuid:
+            return session.capture(
+                mcp_tools["identity"](agent_uuid=identity.agent_uuid, resume=True)
+            )
+        kwargs = dict(name=name, force_new=True, spawn_reason=identity.spawn_reason)
+        if identity.parent_agent_id:
+            kwargs["parent_agent_id"] = identity.parent_agent_id
+        return session.capture(mcp_tools["onboard"](**kwargs))
 
     @tool
     def checkin(description: str, complexity: float, confidence: float = 0.7) -> str:
@@ -67,16 +215,16 @@ def make_wrappers(mcp_tools: dict):
             complexity: How complex the task was, from 0.0 (trivial) to 1.0 (very hard)
             confidence: How confident you are in your work, from 0.0 to 1.0 (default 0.7)
         """
-        return mcp_tools["process_agent_update"](
+        return mcp_tools["process_agent_update"](**session.bind(
             response_text=description,
             complexity=complexity,
             confidence=confidence,
-        )
+        ))
 
     @tool
     def get_metrics() -> str:
         """Get your current EISV state vector, coherence, risk score, and verdict."""
-        return mcp_tools["get_governance_metrics"]()
+        return mcp_tools["get_governance_metrics"](**session.bind())
 
     @tool
     def search_knowledge(query: str) -> str:
@@ -84,7 +232,7 @@ def make_wrappers(mcp_tools: dict):
         Args:
             query: What to search for (e.g. 'WiFi reliability', 'test failures')
         """
-        return mcp_tools["knowledge"](action="search", query=query, limit=5)
+        return mcp_tools["knowledge"](**session.bind(action="search", query=query, limit=5))
 
     @tool
     def save_note(summary: str, tags: str = "") -> str:
@@ -94,12 +242,12 @@ def make_wrappers(mcp_tools: dict):
             tags: Comma-separated tags (e.g. 'ollama,mcp,bridge')
         """
         tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else []
-        return mcp_tools["leave_note"](summary=summary, tags=tag_list)
+        return mcp_tools["leave_note"](**session.bind(summary=summary, tags=tag_list))
 
     @tool
     def list_agents() -> str:
         """List all registered governance agents and their current status."""
-        return mcp_tools["agent"](action="list")
+        return mcp_tools["agent"](**session.bind(action="list"))
 
     @tool
     def ask_tool(tool_name: str) -> str:
@@ -115,11 +263,11 @@ def make_wrappers(mcp_tools: dict):
     ]
 
 
-def build_agent(model_id: str, wrapper_tools: list):
+def build_agent(model_id: str, ollama_url: str, wrapper_tools: list):
     """Create a CodeAgent connected to Ollama with simplified tools."""
     model = OpenAIServerModel(
         model_id=model_id,
-        api_base=OLLAMA_URL,
+        api_base=ollama_url,
         api_key="ollama",
     )
     return CodeAgent(
@@ -171,8 +319,16 @@ def run_single(agent, task: str):
 def main():
     parser = argparse.ArgumentParser(description="Ollama-UNITARES Bridge")
     parser.add_argument(
-        "--model", default="gemma4:latest",
-        help="Ollama model to use (default: gemma4:latest)",
+        "--model", default=DEFAULT_MODEL,
+        help=f"Ollama model to use (default: {DEFAULT_MODEL}; env UNITARES_LLM_MODEL)",
+    )
+    parser.add_argument(
+        "--mcp-url", default=DEFAULT_MCP_URL,
+        help=f"Governance MCP URL (default: {DEFAULT_MCP_URL}; env UNITARES_MCP_URL)",
+    )
+    parser.add_argument(
+        "--ollama-url", default=DEFAULT_OLLAMA_URL,
+        help=f"Ollama OpenAI-compat API (default: {DEFAULT_OLLAMA_URL}; env UNITARES_OLLAMA_URL)",
     )
     parser.add_argument(
         "--task", default=None,
@@ -182,23 +338,42 @@ def main():
         "--max-steps", type=int, default=6,
         help="Max agent reasoning steps (default: 6)",
     )
+    parser.add_argument(
+        "--agent-uuid", default=None,
+        help="Substrate-anchored continuity: resume a fixed identity by UUID "
+             "(env UNITARES_AGENT_UUID). Use only for a durable persistent agent.",
+    )
+    parser.add_argument(
+        "--parent-agent-id", default=None,
+        help="Declare causal lineage to a prior agent's UUID "
+             "(env UNITARES_PARENT_AGENT_ID). Pair with a causal --spawn-reason.",
+    )
+    parser.add_argument(
+        "--spawn-reason", default=None,
+        help="One of " + "|".join(VALID_SPAWN_REASONS) +
+             " (default new_session; env UNITARES_SPAWN_REASON).",
+    )
     args = parser.parse_args()
 
-    print(f"Connecting to UNITARES MCP at {GOVERNANCE_URL} ...")
-    print(f"Using Ollama model: {args.model}")
+    identity = IdentityConfig.from_args(args)
+
+    print(f"Connecting to UNITARES MCP at {args.mcp_url} ...")
+    print(f"Using Ollama model: {args.model} via {args.ollama_url}")
+    print(f"Identity posture: {identity.describe()}")
 
     with ToolCollection.from_mcp(
-        {"url": GOVERNANCE_URL, "transport": "streamable-http"},
+        {"url": args.mcp_url, "transport": "streamable-http"},
         trust_remote_code=True,
         structured_output=False,
     ) as tc:
         mcp_tools = {t.name: t for t in tc.tools}
         print(f"Connected. {len(mcp_tools)} MCP tools available.")
 
-        wrapper_tools = make_wrappers(mcp_tools)
+        session = Session()
+        wrapper_tools = make_wrappers(mcp_tools, identity, session)
         print(f"Exposing {len(wrapper_tools)} simplified tools to model.")
 
-        agent = build_agent(args.model, wrapper_tools)
+        agent = build_agent(args.model, args.ollama_url, wrapper_tools)
         agent.max_steps = args.max_steps
 
         if args.task:

--- a/tests/test_ollama_bridge_script.py
+++ b/tests/test_ollama_bridge_script.py
@@ -1,0 +1,139 @@
+"""ollama_bridge.py unit tests — identity posture (v2 ontology) and the
+in-process client_session_id capture/echo that keeps the bridge one trajectory
+under the strict-identity gate.
+
+The module imports smolagents at top level (an optional client-only dep, not a
+declared server requirement), so the whole module is skipped where it is
+absent."""
+import argparse
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("smolagents")
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "client" / "ollama_bridge.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("ollama_bridge", _MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+bridge = _load_module()
+
+
+def _args(**over):
+    """Build an argparse.Namespace with the identity fields from_args reads."""
+    base = dict(agent_uuid=None, parent_agent_id=None, spawn_reason=None)
+    base.update(over)
+    return argparse.Namespace(**base)
+
+
+# --- IdentityConfig: ontology posture ---------------------------------------
+
+def test_fresh_default_is_new_session_no_lineage(monkeypatch):
+    monkeypatch.delenv("UNITARES_SPAWN_REASON", raising=False)
+    monkeypatch.delenv("UNITARES_PARENT_AGENT_ID", raising=False)
+    monkeypatch.delenv("UNITARES_AGENT_UUID", raising=False)
+    cfg = bridge.IdentityConfig.from_args(_args())
+    assert cfg.spawn_reason == "new_session"
+    assert cfg.parent_agent_id is None
+    assert cfg.agent_uuid is None
+    assert "no lineage" in cfg.describe()
+
+
+def test_causal_spawn_reason_requires_parent():
+    # "explicit" is a handoff from an EXITED predecessor — needs a parent UUID.
+    with pytest.raises(SystemExit):
+        bridge.IdentityConfig.from_args(_args(spawn_reason="explicit"))
+
+
+def test_causal_spawn_reason_with_parent_is_accepted():
+    cfg = bridge.IdentityConfig.from_args(
+        _args(spawn_reason="explicit", parent_agent_id="parent-uuid")
+    )
+    assert cfg.spawn_reason == "explicit"
+    assert cfg.parent_agent_id == "parent-uuid"
+    assert "explicit" in cfg.describe()
+
+
+def test_invalid_spawn_reason_rejected():
+    with pytest.raises(SystemExit):
+        bridge.IdentityConfig.from_args(_args(spawn_reason="bogus"))
+
+
+def test_env_supplies_defaults(monkeypatch):
+    monkeypatch.setenv("UNITARES_AGENT_UUID", "durable-uuid")
+    cfg = bridge.IdentityConfig.from_args(_args())
+    assert cfg.agent_uuid == "durable-uuid"
+    assert "substrate-anchored" in cfg.describe()
+
+
+# --- _deep_find -------------------------------------------------------------
+
+def test_deep_find_locates_nested_key():
+    blob = {"a": {"b": [{"client_session_id": "csid-123"}]}}
+    assert bridge._deep_find(blob, "client_session_id") == "csid-123"
+    assert bridge._deep_find(blob, "missing") is None
+
+
+# --- Session: in-process continuity (the strict-safety fix) -----------------
+
+def test_session_captures_and_echoes_client_session_id():
+    sess = bridge.Session()
+    # An onboard-shaped response carrying the proof signal.
+    sess.capture('{"agent_uuid": "u-1", "client_session_id": "csid-xyz"}')
+    assert sess.client_session_id == "csid-xyz"
+    assert sess.agent_uuid == "u-1"
+    # Every later call must echo it — otherwise the write resolves by transport
+    # fingerprint and lands on a sibling identity (or refuses under strict).
+    bound = sess.bind(response_text="did a thing", complexity=0.2)
+    assert bound["client_session_id"] == "csid-xyz"
+
+
+def test_session_bind_is_noop_before_capture():
+    sess = bridge.Session()
+    assert sess.bind(action="list") == {"action": "list"}
+
+
+def test_session_capture_tolerates_non_json():
+    sess = bridge.Session()
+    assert sess.capture("not json") == "not json"
+    assert sess.client_session_id is None
+
+
+# --- make_wrappers: writes echo the captured session id ---------------------
+
+def test_wrappers_echo_session_id_on_writes():
+    calls = {}
+
+    def rec(name):
+        def _f(**kwargs):
+            calls[name] = kwargs
+            # onboard hands back the proof signal the session should capture.
+            if name == "onboard":
+                return '{"agent_uuid": "u-9", "client_session_id": "csid-9"}'
+            return "{}"
+        return _f
+
+    mcp_tools = {n: rec(n) for n in (
+        "health_check", "onboard", "identity", "process_agent_update",
+        "get_governance_metrics", "knowledge", "leave_note", "agent",
+        "describe_tool",
+    )}
+    identity = bridge.IdentityConfig()  # fresh new_session
+    session = bridge.Session()
+    tools = {t.name: t for t in bridge.make_wrappers(mcp_tools, identity, session)}
+
+    tools["register_agent"]("ollama-local")
+    assert session.client_session_id == "csid-9"
+
+    tools["checkin"]("verified", 0.3, 0.8)
+    assert calls["process_agent_update"]["client_session_id"] == "csid-9"
+
+    tools["list_agents"]()
+    assert calls["agent"]["client_session_id"] == "csid-9"


### PR DESCRIPTION
## What

Makes `scripts/client/ollama_bridge.py` (the path for running a local Ollama model *as a governed UNITARES agent*) configurable, and fixes its identity handling to match the v2 ontology — plus a latent strict-identity bug found while live-testing.

## Configuration (was hardcoded literals)

| Knob | Env | Flag | Default |
|---|---|---|---|
| Governance MCP URL | `UNITARES_MCP_URL` | `--mcp-url` | `http://127.0.0.1:8767/mcp/` |
| Ollama API | `UNITARES_OLLAMA_URL` | `--ollama-url` | `http://127.0.0.1:11434/v1` |
| Model | `UNITARES_LLM_MODEL` | `--model` | `gemma4:latest` |

Defaults reuse existing repo conventions (`UNITARES_MCP_URL` from `with_checkin.py`; `UNITARES_LLM_MODEL` from the `call_model`/`llm_delegation` local path).

## Identity posture — now ontology-correct

The old `register_agent` hardcoded `onboard(force_new=true, spawn_reason="explicit")` — but `explicit` is the *causal* reason reserved for a handoff from an **exited** predecessor, and no parent was ever declared. Fixed:

- **Fresh (default):** `spawn_reason="new_session"`, no parent. A fresh process-instance is a fresh agent; co-location is not lineage.
- **Substrate-anchored:** `--agent-uuid` / `UNITARES_AGENT_UUID` resumes a durable UUID across restarts (the long-lived-resident pattern) via `identity(resume=true)`.
- **Declared lineage:** `--parent-agent-id` + `--spawn-reason` for a real causal event; a causal reason without a parent is rejected client-side.

## Strict-identity safety (latent bug)

Live-testing under `STRICT_IDENTITY_REQUIRED` surfaced this: the wrappers never threaded `client_session_id`, so `register_agent` onboarded fine but the *next* call resolved by transport (shared httpx) fingerprint — landing on an unrelated sibling identity (`77d859bf… Hermes GPT-5.5`) and refusing the write. `Session` now captures `client_session_id` from the onboard/resume response and echoes it on every subsequent call, so the model's calls form **one** trajectory. Re-tested: checkin now lands on the bridge's own fresh `ollama-local` identity with `verdict: proceed`.

## Tests

`tests/test_ollama_bridge_script.py` (10) — identity-posture validation, `_deep_find`, and the capture/echo flow at both the `Session` and `make_wrappers` level. Skips cleanly where `smolagents` (client-only dep) is absent.

Verified end-to-end against the live local MCP + Ollama (`qwen3-coder-next`, `gemma4`). ruff clean; pre-push smoke suite green (138 passed).