### PR TITLE
docs(governance): operator-vision delegation ADR + Track A/B

### DIFF
--- a/docs/proposals/ADR-001-operator-vision-delegation.md
+++ b/docs/proposals/ADR-001-operator-vision-delegation.md
@@ -1,0 +1,101 @@
+# ADR-001 — Operator-vision delegation to agent sessions
+
+- **Status:** Accepted (decision: do not enable as proposed; pursue Track A + Track B)
+- **Date:** 2026-06-16
+- **Scope:** UNITARES governance system (`CIRWEL/unitares`)
+- **Deciders:** Operator + design council (security red-team, identity-ontology architect)
+- **Supersedes:** an earlier informal "safe to enable now" recommendation, refuted by the council
+
+## Context
+
+In the CIRWEL single-operator deployment the human operator is **always mediated
+by a conversational agent** — there is no routine direct human-to-server path. So
+when the operator wants to reason over agent **lineage** (parent/child UUID edges)
+that the governance server redacts, the natural-but-wrong move is to hand the
+mediating agent session "operator-class" vision.
+
+Agent identity/lineage is redacted from cross-agent reads. The redaction is
+caller-keyed in `src/mcp_handlers/lifecycle/query.py`:
+
+```
+if operator_caller or agent_id == caller_uuid:
+    return True   # disclose; else -> _public_agent_identifier(...), redacted
+```
+
+`operator_caller` is set by `is_operator_caller()`
+(`src/mcp_handlers/identity/operator.py`), which validates the
+`X-Unitares-Operator` header against the `UNITARES_OPERATOR_TOKENS` env allowlist
+(default deny).
+
+## Decision
+
+**Do not grant agent sessions operator-class vision by reusing
+`UNITARES_OPERATOR_TOKENS`.** The original "disclosure is decoupled from resume,
+so this is safe now" thesis is **false in the deployment's own default
+configuration.** Instead:
+
+- **Track A (hardening, prerequisite):** flip `UNITARES_IDENTITY_STRICT` and
+  `UNITARES_SESSION_FINGERPRINT_CHECK` to `strict`. See
+  `track-a-strict-identity-hardening-runbook.md`.
+- **Track B (the feature, design-first):** introduce a disclosure-only scope —
+  ideally a first-class, per-session, expiring, audited `operator_delegate`
+  grant — distinct from the operator write/admin token. See
+  `track-b-operator-delegate-design.md`.
+- **Interim:** the operator reads lineage through the dashboard (the non-agent,
+  operator-driven surface); agents stay redacted.
+
+## Why the thesis was refuted (verified against code)
+
+1. **The operator token is not read-only.** It also authorizes un-owned WRITE
+   actions. `src/mcp_handlers/lifecycle/operations.py` (operator resume):
+   *"Lightweight resume handler for human operators (dashboard). No ownership
+   check -- mirrors archive_agent pattern."* `tests/test_lifecycle_clobber.py`
+   exercises `handle_operator_resume_agent` against an arbitrary
+   `target_agent_id`. The same token class gates Wave-3a admin/rollback
+   (`src/mcp_handlers/wave3a_admin.py`, `scripts/ops/wave-3a-rollback.sh`).
+
+2. **The operator token is itself a resume/identity-resolution credential.**
+   `src/mcp_handlers/updates/phases.py` lists `operator_token` as a HIGH
+   identity-resolution source: *"X-Unitares-Operator bearer token, validated
+   against the env allowlist on every call (#425) — per-call proof, stronger than
+   the stable-header sources above."* So disclosure → resume is **one token, one
+   hop**, not two decoupled capabilities.
+
+3. **The gates that would re-couple safety are off in production.** Both
+   `UNITARES_IDENTITY_STRICT` and `UNITARES_SESSION_FINGERPRINT_CHECK` default to
+   `"log"` (`config/governance_config.py`). A live probe resolved a session via
+   `"resolution_source": "ip_ua_fingerprint"`, auto-binding to an existing agent
+   UUID with no ownership proof and no typed refusal — confirming non-strict mode.
+   `config/governance_config.py` warns this path lets *"any caller who learns a
+   UUID hijack the binding."* Operator vision is precisely a UUID-learning oracle,
+   so it composes with this live hole even in a "read-only" framing.
+
+4. **Ontology:** "operator-class" is a human-trust-root; an agent is a governed
+   peer (`docs/ontology/identity.md` — identity is minted and server-adjudicated,
+   not asserted; `lineage_coincidental_rejected`). Handing the trust-root bearer
+   to a peer collapses the governed/governing distinction the system is built on.
+
+## What stays out of scope of any new disclosure grant
+
+The knowledge-graph public-payload redaction (v3.3-A,
+`_build_public_payload` in `src/identity/trajectory_continuity.py`) is a
+**write-time content contract**, not a caller-keyed access check, and must remain
+non-bypassable by operator or delegate scopes. The full record already lives in
+`audit.r1_score_audit`, reachable by `score_id` for operator-side queries.
+
+## Consequences
+
+- Lineage visibility for the operator is delivered through the dashboard until
+  Track B ships; no agent receives operator-class vision in the interim.
+- Track A has independent security value (closes the fingerprint-pin hole) and is
+  a prerequisite for external pilots regardless of Track B.
+- Track B replaces a shared, unattributable, non-expiring bearer token with a
+  scoped, auditable, per-session delegation aligned to the identity ontology.
+
+## Provenance
+
+Decision recorded from a code-grounded design council over `CIRWEL/unitares`.
+Cited code anchors were re-verified directly against the repository when these
+docs were migrated in (the originating session read via `search_code` only).
+Council members independently reached "needs-design-first" from the
+composition-attack and category-error directions respectively.

--- a/docs/proposals/track-a-strict-identity-hardening-runbook.md
+++ b/docs/proposals/track-a-strict-identity-hardening-runbook.md
@@ -1,0 +1,88 @@
+# Track A — Strict identity hardening runbook
+
+- **Status:** Ready to execute
+- **Target:** UNITARES governance server (`CIRWEL/unitares`)
+- **Goal:** Close the fingerprint-pin resume hole and enable strict identity
+  refusals, so that UUID disclosure cannot be turned into identity hijack. This
+  is the prerequisite for any operator-vision delegation (see ADR-001).
+
+## The two flags
+
+Both currently default to permissive `log` mode
+(`config/governance_config.py`):
+
+| Env var | Default | Strict behavior |
+|---|---|---|
+| `UNITARES_IDENTITY_STRICT` | `log` | Reject non-`pre_onboard` tool calls that lack a bound identity with a typed `identity_required` refusal, instead of auto-minting an ephemeral identity. |
+| `UNITARES_SESSION_FINGERPRINT_CHECK` | `log` | On an IP/UA fingerprint mismatch during pin-fallback resume, fall through to a fresh mint instead of silently rebinding to the pinned UUID. |
+
+Modes for each: `off` (emergency rollback) → `log` (observe, warn, allow) →
+`strict` (enforce).
+
+### Confirmed current state
+
+- Code defaults: both `log`.
+- Live probe: a session resolved via `"resolution_source": "ip_ua_fingerprint"`
+  and auto-bound to an existing UUID with no ownership proof and no refusal →
+  both gates non-strict in production.
+- Partial enforcement already live: `required`-class tools (e.g. `call_model`)
+  refuse with `identity_required` even now (the #425 staged rollout), while
+  `pre_onboard` read tools still auto-bind. Strict closes the read/auto-bind gap.
+
+## Pre-flight
+
+1. **Inventory unbound callers.** In `log` mode the server emits
+   `[IDENTITY_STRICT]` and `[PATH2_IPUA_PIN_RESUME]` / `identity_hijack_suspected`
+   warnings. Pull recent occurrences; every distinct caller there will either
+   refuse or re-mint under strict.
+2. **Fix resident agents first.** Residents (Vigil, Sentinel, Watcher, Steward,
+   Chronicler, Lumen) must declare lineage at onboard (`parent_agent_id`) or hold
+   a substrate-earned identity so they survive the flip. Per project notes, fix
+   offenders by adding `parent_agent_id` to their bootstrap before flipping.
+3. **REST surface.** Confirm the REST gate is wired (it ships inert while the
+   flag is off). Unbound REST reads currently succeed under strict; the
+   dashboard's 30s read sweep is `pre_onboard`-classified and should pass, but its
+   operator WRITE buttons require an operator credential under strict — verify the
+   dashboard presents one.
+
+## Execution (staged, reversible)
+
+Roll each flag independently; do not flip both blind at once.
+
+1. **Fingerprint check → strict.**
+   ```
+   UNITARES_SESSION_FINGERPRINT_CHECK=strict
+   ```
+   Restart / reload. Watch for legitimate residents falling through to fresh
+   mints (would show as lineage breaks / new ghost UUIDs). If clean for a full
+   resident cycle (longest cron is ~30 min; give it a few hours), proceed.
+
+2. **Identity strict → strict.**
+   ```
+   UNITARES_IDENTITY_STRICT=strict
+   ```
+   Restart / reload. Watch for `identity_required` refusals on paths that should
+   have been bound. Expected: previously auto-minted ephemeral callers now refuse
+   until they `onboard()`.
+
+3. **Verify.** Re-run the probe: a fresh, unbound call to a `pre_onboard` read
+   tool should still work; a `required`-class call without onboard should refuse;
+   a bare-UUID resume attempt should be denied; a fingerprint-mismatched resume
+   should mint fresh rather than rebind.
+
+## Rollback
+
+Set the offending flag back to `log` (observe) or `off` (full pre-Part-C
+behavior) and reload. No data migration is involved — these gate request-time
+resolution only. Keep `off` reserved for emergencies; prefer `log` so telemetry
+continues.
+
+## Done criteria
+
+- No legitimate resident refuses or loses lineage across a full cron cycle.
+- Bare-UUID resume denied; fingerprint-mismatch resume mints fresh.
+- Dashboard reads pass; dashboard writes carry an operator credential.
+- `identity_hijack_suspected` warnings drop to zero for known-good callers.
+
+After Track A is stable, proceed to Track B (`operator_delegate` design); do not
+delegate operator vision to any agent before Track A is enforced.

--- a/docs/proposals/track-b-implementation-blueprint.md
+++ b/docs/proposals/track-b-implementation-blueprint.md
@@ -17,7 +17,8 @@ Two capabilities must stay separate:
 | Capability | Credential that may grant it | Must NOT be granted by delegate |
 |---|---|---|
 | Read-only identifier/lineage disclosure | full operator token **or** delegate grant | — |
-| Write/admin (`archive_agent`, `operator_resume_agent`, config-set, dialectic-request, wave3a admin) | full operator token only | ✅ delegate rejected |
+| Write/admin, operator-token axis (`archive_agent`, `operator_resume_agent`, wave3a admin) | full operator token only | ✅ delegate rejected |
+| Write/admin, ownership axis (`config(set)`, `dialectic(request)`) | owning agent's session (config-set also needs admin tag / 100+ updates) | ✅ delegate confers no ownership |
 | Per-call identity resolution (resume) | full operator token (today) | ✅ delegate never a resolution source |
 
 The delegate is **additive on the read path only**. Nothing already gated by the
@@ -92,8 +93,13 @@ identity (see test matrix).
 
 ### 4. Write/admin handlers — confirm they reject the delegate
 
-These currently key on full-operator presence and do **no** ownership check, so
-they are safe **iff** they keep calling `is_operator_caller` (not
+The write surface is gated on **two distinct axes**, and the delegate token
+satisfies **neither** — but the seam must not accidentally widen the operator-token
+axis. Both groups verified in-repo:
+
+**Axis 1 — operator-token, no ownership check.** These key on full-operator
+presence (or its HTTP mirror) and do **no** per-agent ownership check, so they are
+safe **iff** they keep gating on `is_operator_caller` / `_is_operator` (not
 `caller_can_disclose`):
 
 - `src/mcp_handlers/lifecycle/mutation.py` — `@mcp_tool("archive_agent", ...,
@@ -105,12 +111,23 @@ they are safe **iff** they keep calling `is_operator_caller` (not
 - `src/mcp_handlers/wave3a_admin.py` — gates via its own `_is_operator(request)`
   helper against `UNITARES_OPERATOR_TOKENS` (header `x-unitares-operator`, fresh
   allowlist read per request) **(verified)**. A delegate token is absent from
-  that allowlist, so it 401s here without any code change. config-set and
-  dialectic-request call sites **(confirm exact gate)**.
+  that allowlist, so it 401s here with no code change.
 
-Action: audit each to confirm it gates on `is_operator_caller` (or `_is_operator`
-for the wave3a HTTP surface). Add an explicit assertion/test that a delegate-only
-token is rejected by every one of them.
+**Axis 2 — session ownership (NOT the operator token).** These do **not** call
+`is_operator_caller` at all; they gate on `verify_agent_ownership` against the
+caller's bound UUID, so they are unaffected by the `caller_can_disclose` seam and
+reject a delegate token automatically (a delegate confers no session ownership):
+
+- `config(action='set')` → `handle_set_thresholds`
+  (`src/mcp_handlers/admin/config.py`) — requires `verify_agent_ownership` **plus**
+  an `admin` tag or 100+ updates (`is_admin or total_updates >= 100`) **(verified)**.
+- `dialectic(action='request')` → `handle_request_dialectic_review`
+  (`src/mcp_handlers/dialectic/handlers.py:532`) — gates on `verify_agent_ownership`
+  (line 549) **(verified)**.
+
+Action: keep Axis-1 handlers gating on `is_operator_caller` / `_is_operator`
+(never `caller_can_disclose`); Axis-2 needs no change. Add an explicit test that a
+delegate-only token is rejected by every handler in both groups.
 
 ### 5. Audit event
 

--- a/docs/proposals/track-b-implementation-blueprint.md
+++ b/docs/proposals/track-b-implementation-blueprint.md
@@ -1,0 +1,154 @@
+# Track B — Implementation blueprint (`operator_delegate` disclosure scope)
+
+- **Status:** Ready to apply against `CIRWEL/unitares` (this repo).
+- **Prereq:** Track A enforced (`UNITARES_IDENTITY_STRICT=strict`,
+  `UNITARES_SESSION_FINGERPRINT_CHECK=strict`). Do not ship Track B first.
+- **Goal:** Grant a blessed agent session **read-only** UUID/lineage disclosure
+  without granting the operator write/admin surface or any resume capability.
+
+> Anchors marked **(verified)** were read directly from code. All anchors flagged
+> "confirm-at-implementation" in the originating session have since been resolved
+> against the repository and are now marked **(verified)**.
+
+## Design invariant
+
+Two capabilities must stay separate:
+
+| Capability | Credential that may grant it | Must NOT be granted by delegate |
+|---|---|---|
+| Read-only identifier/lineage disclosure | full operator token **or** delegate grant | — |
+| Write/admin (`archive_agent`, `operator_resume_agent`, config-set, dialectic-request, wave3a admin) | full operator token only | ✅ delegate rejected |
+| Per-call identity resolution (resume) | full operator token (today) | ✅ delegate never a resolution source |
+
+The delegate is **additive on the read path only**. Nothing already gated by the
+full operator token loosens.
+
+## Touch points
+
+### 1. `src/mcp_handlers/identity/operator.py` — add a disclosure scope
+
+Today: `is_operator_caller(signals: Optional[SessionSignals]) -> bool` **(verified)**
+validates `X-Unitares-Operator` against `UNITARES_OPERATOR_TOKENS`
+(`_OPERATOR_TOKENS_ENV`, **verified**; CSV→set helper, default deny, two-part
+check).
+
+Add a parallel, strictly-weaker check:
+
+```python
+_DELEGATE_TOKENS_ENV = "UNITARES_DISCLOSURE_DELEGATE_TOKENS"  # new, CSV allowlist
+
+def is_disclosure_delegate_caller(signals: Optional[SessionSignals] = None) -> bool:
+    """True if the request presents a valid *disclosure-only* delegate token.
+
+    Same two-part shape as is_operator_caller (header present AND in allowlist),
+    but against a SEPARATE allowlist. Default deny. Grants ONLY read-only
+    identifier/lineage disclosure — never writes, never identity resolution.
+    """
+    # mirror is_operator_caller's signal extraction + allowlist compare,
+    # keyed on _DELEGATE_TOKENS_ENV. A token may NOT appear in both lists
+    # (validate disjoint at load; if it does, treat as operator, not delegate,
+    # and log a config warning).
+
+def caller_can_disclose(signals: Optional[SessionSignals] = None) -> bool:
+    return is_operator_caller(signals) or is_disclosure_delegate_caller(signals)
+```
+
+(Option 2 / ontology-clean variant: replace the env allowlist with a per-session
+grant store `{grant_id, agent_uuid, granted_by, scope, issued_at, expires_at}` and
+have `is_disclosure_delegate_caller` resolve the bound agent's active grant. Start
+with the env-token form behind the same `caller_can_disclose` seam so the call
+sites below never change when you upgrade.)
+
+### 2. `src/mcp_handlers/lifecycle/query.py` — widen the read gate only
+
+Today **(verified)**: `_is_operator_request()` wraps `is_operator_caller()`; the
+disclosure helpers `_visible_agent_identifier(...)` and
+`_visible_related_agent_identifier(agent_id, caller_uuid, operator_caller)` gate on
+`if operator_caller or agent_id == caller_uuid: return True`.
+
+Change: feed these helpers from `caller_can_disclose()` instead of
+`is_operator_caller()`. Rename the local for honesty:
+
+```python
+def _can_disclose_request() -> bool:
+    from src.mcp_handlers.identity.operator import caller_can_disclose
+    try:
+        return caller_can_disclose()
+    except Exception:
+        return False
+# pass this in where operator_caller= is currently sourced from _is_operator_request()
+```
+
+This is the ONLY behavioral widening. The gate logic itself is unchanged.
+
+### 3. `src/mcp_handlers/updates/phases.py` — keep delegate OUT of resolution
+
+The strong identity-source set `_STRONG_IDENTITY_SOURCES` containing
+`"operator_token"` **(verified; set name `_STRONG_IDENTITY_SOURCES`, sibling to
+`_MEDIUM_IDENTITY_SOURCES`)** — must **not** gain a delegate entry. The delegate
+token is never an identity-resolution source; it cannot stand in as per-call
+resume proof. Add a regression test asserting the delegate token does not resolve
+identity (see test matrix).
+
+### 4. Write/admin handlers — confirm they reject the delegate
+
+These currently key on full-operator presence and do **no** ownership check, so
+they are safe **iff** they keep calling `is_operator_caller` (not
+`caller_can_disclose`):
+
+- `src/mcp_handlers/lifecycle/mutation.py` — `@mcp_tool("archive_agent", ...,
+  register=False)` `handle_archive_agent`, *"No ownership check -- dashboard and
+  operator agents need to archive"* **(verified)**.
+- `src/mcp_handlers/lifecycle/operations.py` + `.../self_recovery.py` —
+  `handle_operator_resume_agent`, *"No ownership check -- mirrors archive_agent
+  pattern"* **(verified)**.
+- `src/mcp_handlers/wave3a_admin.py` — gates via its own `_is_operator(request)`
+  helper against `UNITARES_OPERATOR_TOKENS` (header `x-unitares-operator`, fresh
+  allowlist read per request) **(verified)**. A delegate token is absent from
+  that allowlist, so it 401s here without any code change. config-set and
+  dialectic-request call sites **(confirm exact gate)**.
+
+Action: audit each to confirm it gates on `is_operator_caller` (or `_is_operator`
+for the wave3a HTTP surface). Add an explicit assertion/test that a delegate-only
+token is rejected by every one of them.
+
+### 5. Audit event
+
+On any disclosure performed because `is_disclosure_delegate_caller` was true (i.e.
+not full operator, not self), emit an audit event
+`{event: "lineage_disclosed_via_delegate", grant_id|token_id, agent_uuid,
+disclosed_agent_id}` mirroring the existing `_emit_audit` helper in
+`src/mcp_handlers/identity/handlers.py` **(verified; `_emit_audit`, fail-soft,
+used e.g. for `lineage_coincidental_rejected`)**. This restores attribution that a
+shared bearer otherwise destroys.
+
+### 6. Out of scope — do not touch
+
+`_build_public_payload` (v3.3-A KG redaction,
+`src/identity/trajectory_continuity.py`, **verified earlier**) stays
+non-bypassable. The delegate scope is identifier/lineage disclosure only, never
+KG payload widening.
+
+## Test matrix
+
+| Caller | Read UUID/lineage | archive/operator_resume/config-set | Resolves identity (resume) |
+|---|---|---|---|
+| no token | redacted | reject | no |
+| self (`agent_id == caller_uuid`) | disclosed | n/a | own session |
+| delegate token | **disclosed** | **reject** | **no** |
+| full operator token | disclosed | allow | yes (unchanged) |
+| token in both lists | treat as operator + config warning | allow | yes |
+
+Plus: delegate token absent from the `phases.py` `_STRONG_IDENTITY_SOURCES` set;
+disclosure via delegate emits the audit event; KG public payload unchanged for
+delegate.
+
+## Rollout
+
+1. Land code behind an unset `UNITARES_DISCLOSURE_DELEGATE_TOKENS` (no-op until a
+   token is configured — same default-deny posture as the operator token).
+2. Confirm Track A strict flags are enforced.
+3. Mint a delegate token, set it on exactly one trusted agent session, verify the
+   test-matrix behavior live.
+4. (Option 2) Replace the env allowlist with the per-session grant store behind
+   the unchanged `caller_can_disclose` seam.

--- a/docs/proposals/track-b-operator-delegate-design.md
+++ b/docs/proposals/track-b-operator-delegate-design.md
@@ -1,0 +1,95 @@
+# Track B — `operator_delegate` scoped disclosure design
+
+- **Status:** Proposal (design-first; do not implement before Track A is enforced)
+- **Target:** UNITARES governance system (`CIRWEL/unitares`)
+- **Problem:** Let the operator reason over agent lineage **through their
+  mediating agent**, without handing that agent the human-trust-root operator
+  token. See ADR-001 for why reusing `UNITARES_OPERATOR_TOKENS` is unsafe.
+
+## Requirement
+
+Exactly one new capability is needed: **read-only disclosure of otherwise-redacted
+agent identifiers and lineage edges** (`agent_id`, `agent_uuid`,
+`parent_agent_id`, `identity_view`) to a specifically-blessed agent session.
+
+Everything else the operator token carries — `archive_agent`,
+`operator_resume_agent`, config-set, dialectic-request, Wave-3a admin/rollback,
+and its role as a HIGH identity-resolution source in
+`src/mcp_handlers/updates/phases.py` — must **not** be granted.
+
+## The seam already exists
+
+`src/mcp_handlers/lifecycle/query.py` already separates disclosure from operator
+power: `_visible_agent_identifier(...)` and
+`_visible_related_agent_identifier(..., operator_caller=...)` gate **only** whether
+an identifier is shown vs. redacted. That read-only axis is distinct from the
+WRITE surface in `wave3a_admin.py`. Track B carves the disclosure axis out as its
+own scope rather than letting the env token grant both.
+
+## Option 1 — Disclosure-scoped token class (minimal)
+
+A second credential class that:
+
+- `is_operator_caller`-style check recognizes **for disclosure only** — i.e. it
+  satisfies the `operator_caller` branch in `query.py` `_visible_*` helpers.
+- Is **rejected by every write handler** (`archive_agent`,
+  `operator_resume_agent`, config-set, dialectic-request, `wave3a_admin`).
+- Is **removed from / never added to** the HIGH `_STRONG_IDENTITY_SOURCES` set in
+  `phases.py`, so it can never serve as per-call resume proof.
+
+Pros: small change, reuses the existing disclosure gate. Cons: still a shared
+bearer (unattributable, manual rotation); easy to misconfigure back into the
+write path.
+
+## Option 2 — First-class `operator_delegate` grant (recommended)
+
+Make delegation an explicit, auditable identity object rather than a secret.
+
+**Shape:**
+
+```
+operator_delegate {
+  grant_id:      uuid,            # stable handle for audit
+  agent_uuid:    uuid,            # the mediating agent's already-minted identity
+  granted_by:    operator principal,
+  scope:         ["lineage_disclosure"],   # closed set; disclosure only
+  issued_at:     ts,
+  expires_at:    ts,             # short, per-session
+}
+```
+
+**Properties:**
+
+- **Agent stays a governed peer.** Its identity remains minted/server-adjudicated;
+  the grant is a separate, scoped object it *carries*, not a trust-root it *is*.
+- **Attributable.** Every disclosure performed under a grant is logged with
+  `grant_id` + `agent_uuid`, mirroring the existing audit-event pattern in
+  `src/mcp_handlers/identity/handlers.py` (e.g. `lineage_coincidental_rejected`).
+- **Expiring + per-session.** Rotation is automatic (grant TTL), not a manual env
+  edit. A leaked grant dies on expiry and is scoped to disclosure only.
+- **Enforced at the existing seam.** The `query.py` `_visible_*` helpers accept
+  "operator_caller OR active disclosure grant for this caller"; write handlers and
+  `phases.py` resolution sources are untouched, so no write/resume power leaks.
+
+**Out of scope, explicitly:** the v3.3-A KG public-payload redaction
+(`_build_public_payload` in `src/identity/trajectory_continuity.py`) is a
+write-time content contract and must remain non-bypassable by any delegate scope.
+
+## Decision points to resolve before implementing
+
+1. **Issuance path.** How does the operator mint a grant for a session — dashboard
+   action (operator-authenticated, non-agent surface) binding to the agent's
+   UUID? CLI? This is the one step that must remain on a real operator-trust path.
+2. **Scope vocabulary.** Start with a single `lineage_disclosure` scope; design
+   the field as a set so future read-only scopes can be added without a new
+   credential class.
+3. **TTL + revocation.** Pick a default expiry (session-length) and a revoke path.
+4. **Option 1 vs 2 sequencing.** Option 1 can ship as an interim if a disclosure
+   need is urgent, but only *after* Track A, and with Option 2 as the committed
+   end state — Option 1's shared-bearer downsides are exactly what Option 2 fixes.
+
+## Non-goals
+
+- No change to the resume/ownership model (PATH 0 continuity-token proof, S1-c).
+- No new write or admin capability for agents.
+- No widening of the KG public-payload contract.


### PR DESCRIPTION
## What

Relocates four governance design docs into their home repo (originally opened against \`cirwel/CIRWEL#2\` only because unitares was out of that session's write scope). All cited code anchors have been **re-verified directly against this repository** — the originating session could only read via \`search_code\`.

Docs under \`docs/proposals/\`:

- **ADR-001 — Operator-vision delegation.** Decision: **do not** grant agent sessions operator-class vision by reusing \`UNITARES_OPERATOR_TOKENS\`. The "disclosure is decoupled from resume, so it's safe now" thesis was refuted by the council and confirmed against code.
- **Track A — Strict identity hardening runbook.** Flip \`UNITARES_IDENTITY_STRICT\` and \`UNITARES_SESSION_FINGERPRINT_CHECK\` to \`strict\`. Prerequisite for any disclosure delegation; closes the fingerprint-pin hijack hole.
- **Track B — \`operator_delegate\` design.** A scoped, expiring, audited per-session disclosure grant distinct from the operator write/admin token.
- **Track B — implementation blueprint.** File-by-file, apply-ready plan: a \`caller_can_disclose\` seam widening only the \`query.py\` read gate, keeping the delegate token out of the \`phases.py\` identity-source set, leaving write handlers untouched, plus an audit event, test matrix, and rollout.

## Why the original thesis was wrong (verified in-repo)

1. The operator token is **not read-only** — \`src/mcp_handlers/lifecycle/operations.py\` operator resume and \`src/mcp_handlers/lifecycle/mutation.py\` archive: *"No ownership check."*
2. The operator token is **itself a HIGH identity-resolution source** — \`src/mcp_handlers/updates/phases.py\`: \`operator_token\` ∈ \`_STRONG_IDENTITY_SOURCES\`. Disclosure → resume is one token, one hop.
3. The strict gates that would re-couple safety **default to \`log\` mode** (\`config/governance_config.py\`); a live probe resolved via \`ip_ua_fingerprint\` with no ownership proof.

## All "confirm-at-implementation" anchors now resolved against code

Every marker the prior session left provisional has been ground-truthed in-repo:

- \`phases.py\` strong-source set = \`_STRONG_IDENTITY_SOURCES\` (prior guess was \`_IDENTITY_SOURCES\`) — corrected in design + blueprint.
- Audit helper = \`_emit_audit\` in \`src/mcp_handlers/identity/handlers.py\` (fail-soft).
- \`wave3a_admin.py\` gates via its own \`_is_operator(request)\` against \`UNITARES_OPERATOR_TOKENS\` — a delegate token 401s here with no code change.
- **config-set and dialectic-request gate on a *different axis* than the prior draft assumed**: \`handle_set_thresholds\` (\`admin/config.py\`) and \`handle_request_dialectic_review\` (\`dialectic/handlers.py:532\`) gate on \`verify_agent_ownership\` (config-set also needs \`admin\` tag or 100+ updates), **not** \`is_operator_caller\`. A delegate token confers no ownership, so they reject it automatically; the \`caller_can_disclose\` seam never touches them. Blueprint §4 + the design-invariant table now split the write surface into the operator-token axis and the ownership axis.

## Scope / caveats

- No runtime change — Track A is an ops/env action; Track B is design + plan.

Supersedes \`cirwel/CIRWEL#2\`. Draft for operator review.