### PR TITLE
Calibration harness v1 (synthetic fixture; isolated-instance)

### DIFF
--- a/scripts/dev/calibration_harness/README.md
+++ b/scripts/dev/calibration_harness/README.md
@@ -69,30 +69,26 @@ python3 -m scripts.dev.calibration_harness.run_v1 --episodes 200
   and `calibration_guidance.failure_modes.tactical.ece` (the latter has a
   min-sample floor; it is `None` until enough samples).
 
-## What v1 validates — and what it does NOT (council review, PR #770)
+## What the harness validates (v1.1, after council review of PR #770)
 
-A 3-agent adversarial council reviewed this. The honest scope:
+A 3-agent adversarial council reviewed v1 and caught that it validated only the
+*binding*, not the *measurement* (outcomes were independent of confidence by
+construction). v1.1 closes that gap.
 
-**v1 validates the BINDING/REGISTRATION spine** — stated confidence → `prediction_id`
-→ external (exit-code) outcome → corroborated tactical row → read-back. That path
-is sound and well-built; the exit-code outcome is exogenous ground truth (no
-circularity).
+**Binding/registration spine** — stated confidence → `prediction_id` → external
+(exit-code) outcome → corroborated tactical row. Sound; the exit-code outcome is
+exogenous ground truth (no circularity).
 
-**v1 does NOT yet validate the calibration MEASUREMENT.** The sampler assigns
-pass/fail by *position* (`i < n_fail`) and draws confidence *independently* by
-bin, so **outcome and confidence are statistically independent by construction**.
-There is no injected miscalibration for ECE/AUC to recover — so AUC ≈ 0.5 is
-*expected* (any deviation is a sampler artifact), and the ECE is dominated by the
-0.55 cap + corrector fixed point + the constant per-bin fail ratio, not by a
-calibration relationship. Printing these as "calibration" without that caveat was
-a self-deception seam; `report.py` now states it inline.
-
-### The v1.1 fix (the real work item)
-Make the **outcome a function of confidence** with an injectable miscalibration
-knob: draw pass/fail with probability `f(drawn_confidence; bias)`. Then ECE/AUC
-become *recoverable ground truth* — "I injected calibration error X; did the
-channel report ≈ X?" — which is the actual measurement-plumbing test. Until then,
-v1 is a binding smoke test, not a calibration validator.
+**Calibration measurement** — the outcome is now drawn from a KNOWN curve
+(`miscalibration.true_accuracy(c) = clamp(c - gap)`; `--gap`, default 0.2), so
+confidence and outcome are coupled by an injected miscalibration. `report.py` bins
+on the controlled (stated) confidence and checks that the **recovered ECE matches
+the analytic injected ECE** within sampling tolerance, and that **AUC > 0.5**
+(confidence now discriminates). Validated live: gap 0.2 → injected ECE 0.186,
+recovered 0.223 (|err| 0.037), AUC 0.83. That recovery is the actual
+measurement-plumbing proof. The server's tactical channel (registered/capped
+confidence) is reported as a SECONDARY view; the divergence between the two is the
+cap/corrector finding, not noise.
 
 ### The confidence cap (v1 ceiling)
 Weak-tier agents get `min(confidence, 0.55)` (`phases.py:667-669`), so the 0.6–1.0
@@ -114,12 +110,13 @@ well-calibrated" — but that still needs the v1.1 knob to have any ground truth
 
 | file | role |
 |---|---|
-| `config.py` | bins, fail-ratio, transport, the 0.65 gate constant |
+| `config.py` | bins, transport, the 0.65 gate constant |
 | `client.py` | thin REST wrapper over `/v1/tools/call` (onboard/check-in/outcome/calibration) |
 | `grader.py` | sandboxed subprocess runner → exit-code → external signal |
-| `episodes/` | `Episode` ABC + `CleanControl` (pass) / `SeededTestFail` (deterministic fail) |
-| `sampler.py` | stratified (bin × pass/fail) plan + overconfidence cell |
-| `runner.py` | per-episode check-in → grade → outcome, binding via `prediction_id` |
-| `report.py` | ECE + AUC from per-agent DB rows; server tactical before/after |
-| `probe_one.py` | single-episode live verification (the build-order gate) |
-| `run_v1.py` | entrypoint; prod-URL guard |
+| `miscalibration.py` | injected curve `true_accuracy(c)=clamp(c-gap)` + analytic injected ECE |
+| `episodes/` | `Episode` ABC + `CleanControl` (pass) / `SeededTestFail` (fail) source generators |
+| `sampler.py` | stratified confidence-bin slots (outcome drawn in the runner, not here) |
+| `runner.py` | per-slot: draw confidence → draw outcome from the curve → check-in → grade → outcome |
+| `report.py` | recover injected ECE from stated confidence + AUC; server tactical before/after |
+| `probe_one.py` | single-episode live verification (the binding gate) |
+| `run_v1.py` | entrypoint; loopback-only guard; `--gap` knob |

--- a/scripts/dev/calibration_harness/README.md
+++ b/scripts/dev/calibration_harness/README.md
@@ -1,0 +1,113 @@
+# Calibration Harness (v1)
+
+A **synthetic calibration fixture** for the UNITARES governance server. It drives
+the `confidence → prediction_id → outcome` binding through controlled,
+ground-truth-known episodes to prove the **measurement plumbing** works:
+
+- the tactical calibration channel populates and its ECE moves, and
+- once injected failures make `bad_rate > 0`, discrimination (AUC) is computable.
+
+It does **not** measure any real agent's calibration — confidences are drawn to
+land in a target bin behind a known outcome. Read every number as "the harness
+can measure," never "the fleet is well-calibrated."
+
+## Why an isolated instance is mandatory
+
+Tactical calibration is a **global, agent-unscoped, in-process** signal:
+`calibration check` returns `tactical_evidence.scope == "global"` and ignores
+`agent_id` for the `check` action (`src/mcp_handlers/admin/calibration.py`). The
+`by_class` breakdown is *derived* (ephemeral → engaged_ephemeral after ≥3
+check-ins), so the harness gets no private bucket there either. Therefore the
+synthetic failures this harness injects **cannot be filtered out of the live
+fleet's calibration** — they would permanently shift the signal that governs
+real agents.
+
+So v1 runs against a **dedicated server bound to `governance_test`**. That gives
+the isolated server its own calibration singleton; its global pool *is* the
+harness rows. `run_v1` refuses the live ports (`:8767`/`:8766`) unless `--i-know`.
+
+> `governance_test` is currently 2 migrations behind prod (046 vs 048). 047
+> (knowledge CHECK widen) and 048 (un-onboarded check-in floor) do not touch the
+> onboard → check-in → outcome → calibration path the harness uses, so 046 is
+> sufficient for v1. Bring it current if that changes.
+
+## Run
+
+```bash
+# 1) bring up an isolated server against governance_test (own port + token)
+DB_POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/governance_test \
+DB_AGE_GRAPH=governance_graph DB_POSTGRES_MIN_CONN=1 DB_POSTGRES_MAX_CONN=4 \
+UNITARES_HTTP_API_TOKEN=calib-harness-test-token UNITARES_MCP_HOST=127.0.0.1 \
+UNITARES_DISABLE_AUTO_ONBOARD=1 \
+python3 src/mcp_server.py --port 8771 &
+
+# 2) verify the spine end-to-end (single-episode gate)
+GOVERNANCE_HTTP_URL=http://127.0.0.1:8771 UNITARES_HTTP_API_TOKEN=calib-harness-test-token \
+python3 -m scripts.dev.calibration_harness.probe_one
+
+# 3) run v1
+GOVERNANCE_HTTP_URL=http://127.0.0.1:8771 UNITARES_HTTP_API_TOKEN=calib-harness-test-token \
+python3 -m scripts.dev.calibration_harness.run_v1 --episodes 200
+```
+
+## Design facts pinned against the live API (2026-06-16)
+
+- **0.65 gate, not 0.1.** Tactical calibration only registers a (confidence,
+  outcome) pair when `evidence_weight >= GRADE_WEIGHTS[TOOL_OBSERVED] = 0.65`
+  (`_MIN_TACTICAL_EVIDENCE_WEIGHT`). Below that the row is silently dropped from
+  the tactical denominator. The grader sends `verification_source="external_signal"`
+  → grade `externally_verified` → weight `1.0`, and also includes the real
+  `exit_code`/`command` in `detail` so the grade is grounded in tool observation.
+- **Stated confidence is NOT registered as-is.** `process_agent_update`
+  (`src/mcp_handlers/updates/phases.py:635-669`) applies two transforms to the
+  stated confidence before it becomes the tactical prediction: (1)
+  `apply_confidence_correction` (global calibration adjustment) and (2) a
+  **weak-identity cap** `min(confidence, 0.55)` when `identity_assurance.tier ==
+  "weak"`. `report.py` therefore bins on `detail.reported_confidence` (the
+  registered value), never the stated input.
+- **`bad_rate` / `ece` exist** in the response: `per_channel_health.tests.bad_rate`
+  and `calibration_guidance.failure_modes.tactical.ece` (the latter has a
+  min-sample floor; it is `None` until enough samples).
+
+## Known limitation (v1 ceiling) & v2 levers
+
+**REST-onboarded agents are weak-tier, so confidence is capped at 0.55.** The
+REST surface binds identity by server inference (`caller_proven: false`,
+`proof_origin: server_inferred`) — it cannot reach `strong` even when
+`continuity_token` and `client_session_id` are passed (the #425 REST transport
+injects a synthetic session id). Weak tier triggers the `min(confidence, 0.55)`
+dampener, so **the 0.6–1.0 confidence bins are structurally unreachable over
+REST**, and the calibration the harness measures is of the *corrected, capped*
+confidence — not raw stated confidence across the full range.
+
+Verified live: stated `0.93` → registered `0.55`; stated `0.138` → registered
+`0.18`. v1's success criteria (bad_rate > 0, AUC computable, tactical channel
+moves) still hold, but the reliability table only populates ≤ 0.55.
+
+v2 levers, in order of leverage:
+1. **Strong identity over the MCP transport** — talk to the server via the MCP
+   streamable-HTTP/stdio transport with caller-proven process binding instead
+   of the REST token wrapper. Lifts the cap and unlocks the high bins. This is
+   the real fix and the main v2 work item.
+2. **Measure what the server actually scores** — accept that tactical
+   calibration scores the EISV-corrected/capped confidence and frame the report
+   as "is the governance system's *own* confidence well-calibrated," which is
+   arguably the more useful question. report.py already bins on the registered
+   value, so this needs only framing.
+3. **Pre-distort stated confidence** to hit target *registered* bins by
+   inverting the correction — brittle and does not defeat the 0.55 cap, so only
+   useful in combination with (1).
+
+## Files
+
+| file | role |
+|---|---|
+| `config.py` | bins, fail-ratio, transport, the 0.65 gate constant |
+| `client.py` | thin REST wrapper over `/v1/tools/call` (onboard/check-in/outcome/calibration) |
+| `grader.py` | sandboxed subprocess runner → exit-code → external signal |
+| `episodes/` | `Episode` ABC + `CleanControl` (pass) / `SeededTestFail` (deterministic fail) |
+| `sampler.py` | stratified (bin × pass/fail) plan + overconfidence cell |
+| `runner.py` | per-episode check-in → grade → outcome, binding via `prediction_id` |
+| `report.py` | ECE + AUC from per-agent DB rows; server tactical before/after |
+| `probe_one.py` | single-episode live verification (the build-order gate) |
+| `run_v1.py` | entrypoint; prod-URL guard |

--- a/scripts/dev/calibration_harness/README.md
+++ b/scripts/dev/calibration_harness/README.md
@@ -90,28 +90,38 @@ measurement-plumbing proof. The server's tactical channel (registered/capped
 confidence) is reported as a SECONDARY view; the divergence between the two is the
 cap/corrector finding, not noise.
 
-### The confidence cap (v1 ceiling)
+### The confidence cap — lifted in v2 (`--transport mcp`, default)
 Weak-tier agents get `min(confidence, 0.55)` (`phases.py:667-669`), so the 0.6–1.0
-bins don't populate. **Reaching strong tier requires the MCP transport** — that is
-confirmed (a council agent on the MCP transport logged at strong/1.0). The plain
-REST `/v1/tools/call` surface this harness uses does **not** reach strong in
-testing: echoing `client_session_id` in the body and sending an `X-Session-ID`
-header both yield `proof_origin: unknown` → weak → capped (verified live, three
-ways). So the v2 lever stands: talk to the server over the MCP transport with
-caller-proven binding. (Earlier wording called the cap "structural to REST"; more
-precisely it's structural to *every REST handshake tested* — strong is confirmed
-only on the MCP transport.)
+bins can't populate. The fix, pinned live: **strong tier requires the MCP transport
+AND a `continuity_token`** passed on each call (`session.py:619-642` marks
+`continuity_token` → `caller_asserted` → strong). The plain REST `/v1/tools/call`
+surface *ignores* the token (it resolves identity by `ip_ua_fingerprint` → weak →
+capped); the MCP streamable-HTTP transport honors it. Verified three ways: REST +
+body-CSID, REST + `X-Session-ID`, and REST + `continuity_token` all stay weak;
+MCP + `continuity_token` reaches strong and removes the cap.
 
-Secondary lever: accept that tactical calibration scores the EISV-corrected
-confidence and frame v1.1 as "is the governance system's *own* confidence
-well-calibrated" — but that still needs the v1.1 knob to have any ground truth.
+`client_mcp.MCPGovernanceClient` implements this (same interface as the REST
+client; the runner/report are unchanged). At n=200, gap 0.2 it recovers the
+injected miscalibration across the **full** range — e.g. the 0.8–1.0 bin shows
+accuracy 0.73 vs mean confidence 0.92, recovering the ~0.2 overconfidence that was
+unreachable under the cap.
+
+Two operational notes:
+- **Identity rotation.** A single strong-tier agent accumulating synthetic
+  failures gets governance-*paused* mid-run; `run_v1` catches that, rotates to a
+  fresh identity, and retries (measurement-neutral — the report bins on stated
+  confidence, so identity is irrelevant).
+- **Per-call session.** The MCP client opens a short-lived session per call
+  (continuity_token is portable proof). Simple and correct; a persistent session
+  is a v2.1 perf optimization. Use `--transport rest` for faster capped runs.
 
 ## Files
 
 | file | role |
 |---|---|
 | `config.py` | bins, transport, the 0.65 gate constant |
-| `client.py` | thin REST wrapper over `/v1/tools/call` (onboard/check-in/outcome/calibration) |
+| `client.py` | thin REST wrapper over `/v1/tools/call` (weak tier, capped at 0.55) |
+| `client_mcp.py` | MCP streamable-HTTP client; `continuity_token` → strong tier → cap lifted (v2) |
 | `grader.py` | sandboxed subprocess runner → exit-code → external signal |
 | `miscalibration.py` | injected curve `true_accuracy(c)=clamp(c-gap)` + analytic injected ECE |
 | `episodes/` | `Episode` ABC + `CleanControl` (pass) / `SeededTestFail` (fail) source generators |

--- a/scripts/dev/calibration_harness/README.md
+++ b/scripts/dev/calibration_harness/README.md
@@ -69,34 +69,46 @@ python3 -m scripts.dev.calibration_harness.run_v1 --episodes 200
   and `calibration_guidance.failure_modes.tactical.ece` (the latter has a
   min-sample floor; it is `None` until enough samples).
 
-## Known limitation (v1 ceiling) & v2 levers
+## What v1 validates — and what it does NOT (council review, PR #770)
 
-**REST-onboarded agents are weak-tier, so confidence is capped at 0.55.** The
-REST surface binds identity by server inference (`caller_proven: false`,
-`proof_origin: server_inferred`) — it cannot reach `strong` even when
-`continuity_token` and `client_session_id` are passed (the #425 REST transport
-injects a synthetic session id). Weak tier triggers the `min(confidence, 0.55)`
-dampener, so **the 0.6–1.0 confidence bins are structurally unreachable over
-REST**, and the calibration the harness measures is of the *corrected, capped*
-confidence — not raw stated confidence across the full range.
+A 3-agent adversarial council reviewed this. The honest scope:
 
-Verified live: stated `0.93` → registered `0.55`; stated `0.138` → registered
-`0.18`. v1's success criteria (bad_rate > 0, AUC computable, tactical channel
-moves) still hold, but the reliability table only populates ≤ 0.55.
+**v1 validates the BINDING/REGISTRATION spine** — stated confidence → `prediction_id`
+→ external (exit-code) outcome → corroborated tactical row → read-back. That path
+is sound and well-built; the exit-code outcome is exogenous ground truth (no
+circularity).
 
-v2 levers, in order of leverage:
-1. **Strong identity over the MCP transport** — talk to the server via the MCP
-   streamable-HTTP/stdio transport with caller-proven process binding instead
-   of the REST token wrapper. Lifts the cap and unlocks the high bins. This is
-   the real fix and the main v2 work item.
-2. **Measure what the server actually scores** — accept that tactical
-   calibration scores the EISV-corrected/capped confidence and frame the report
-   as "is the governance system's *own* confidence well-calibrated," which is
-   arguably the more useful question. report.py already bins on the registered
-   value, so this needs only framing.
-3. **Pre-distort stated confidence** to hit target *registered* bins by
-   inverting the correction — brittle and does not defeat the 0.55 cap, so only
-   useful in combination with (1).
+**v1 does NOT yet validate the calibration MEASUREMENT.** The sampler assigns
+pass/fail by *position* (`i < n_fail`) and draws confidence *independently* by
+bin, so **outcome and confidence are statistically independent by construction**.
+There is no injected miscalibration for ECE/AUC to recover — so AUC ≈ 0.5 is
+*expected* (any deviation is a sampler artifact), and the ECE is dominated by the
+0.55 cap + corrector fixed point + the constant per-bin fail ratio, not by a
+calibration relationship. Printing these as "calibration" without that caveat was
+a self-deception seam; `report.py` now states it inline.
+
+### The v1.1 fix (the real work item)
+Make the **outcome a function of confidence** with an injectable miscalibration
+knob: draw pass/fail with probability `f(drawn_confidence; bias)`. Then ECE/AUC
+become *recoverable ground truth* — "I injected calibration error X; did the
+channel report ≈ X?" — which is the actual measurement-plumbing test. Until then,
+v1 is a binding smoke test, not a calibration validator.
+
+### The confidence cap (v1 ceiling)
+Weak-tier agents get `min(confidence, 0.55)` (`phases.py:667-669`), so the 0.6–1.0
+bins don't populate. **Reaching strong tier requires the MCP transport** — that is
+confirmed (a council agent on the MCP transport logged at strong/1.0). The plain
+REST `/v1/tools/call` surface this harness uses does **not** reach strong in
+testing: echoing `client_session_id` in the body and sending an `X-Session-ID`
+header both yield `proof_origin: unknown` → weak → capped (verified live, three
+ways). So the v2 lever stands: talk to the server over the MCP transport with
+caller-proven binding. (Earlier wording called the cap "structural to REST"; more
+precisely it's structural to *every REST handshake tested* — strong is confirmed
+only on the MCP transport.)
+
+Secondary lever: accept that tactical calibration scores the EISV-corrected
+confidence and frame v1.1 as "is the governance system's *own* confidence
+well-calibrated" — but that still needs the v1.1 knob to have any ground truth.
 
 ## Files
 

--- a/scripts/dev/calibration_harness/__init__.py
+++ b/scripts/dev/calibration_harness/__init__.py
@@ -1,0 +1,34 @@
+"""Calibration harness (v1) for the UNITARES governance server.
+
+Purpose
+-------
+A *synthetic calibration fixture*. It drives the confidence -> prediction_id ->
+outcome binding through the governance API under controlled, ground-truth-known
+episodes so we can prove the **measurement plumbing** works:
+
+  * the tactical calibration channel populates and its ECE moves, and
+  * once injected failures make bad_rate > 0, discrimination (AUC) is computable.
+
+What v1 does NOT claim
+----------------------
+It does not measure any real agent's calibration. Confidences are *drawn to land
+in a target bin* behind a known outcome, so the resulting ECE/AUC describe the
+fixture, not a fleet. Read every number here as "the harness can measure," never
+"the fleet is well-calibrated." (See report.py header.)
+
+Design corrections baked in from the live-API review (2026-06-16)
+-----------------------------------------------------------------
+1. Tactical calibration only registers a (confidence, outcome) pair when the
+   outcome's ``evidence_weight >= 0.65`` (``GRADE_WEIGHTS[TOOL_OBSERVED]``, the
+   server's ``_MIN_TACTICAL_EVIDENCE_WEIGHT``). Below that the row is silently
+   dropped from the tactical denominator. So the single-episode gate is
+   "tactical bin populated AND evidence_weight == 1.0", not "> 0.1".
+2. Quarantine is by **agent_id**, not a provenance tag: ``calibration(check)``
+   filters on agent_id and has no locus/agent_class filter. Each harness class
+   runs under its own dedicated agent UUID, so the fleet's pool is untouched.
+3. ``verification_source`` is the *source*; the corroboration *grade*
+   (claim_only ... externally_verified) is derived from it plus structured
+   detail. ``external_signal`` short-circuits to externally_verified (weight
+   1.00). The grader also includes the real ``exit_code``/``command`` in detail
+   so the grade is grounded in tool observation, not just the label.
+"""

--- a/scripts/dev/calibration_harness/client.py
+++ b/scripts/dev/calibration_harness/client.py
@@ -32,6 +32,9 @@ class Identity:
     agent_uuid: str
     client_session_id: str | None
     raw: dict[str, Any]
+    # Signed ownership proof. Reaches strong tier (lifting the 0.55 cap) ONLY
+    # over the MCP transport; ignored by the REST surface. See client_mcp.py.
+    continuity_token: str | None = None
 
 
 def _first(d: dict[str, Any], *keys: str) -> Any:
@@ -79,7 +82,8 @@ class GovernanceClient:
         if not agent_uuid:
             raise GovernanceError(f"onboard returned no agent uuid; keys={list(res)}")
         csid = _first(res, "client_session_id", "session_id")
-        return Identity(agent_uuid=str(agent_uuid), client_session_id=csid, raw=res)
+        ct = res.get("continuity_token")
+        return Identity(agent_uuid=str(agent_uuid), client_session_id=csid, raw=res, continuity_token=ct)
 
     def check_in(
         self,

--- a/scripts/dev/calibration_harness/client.py
+++ b/scripts/dev/calibration_harness/client.py
@@ -1,0 +1,148 @@
+"""Thin REST wrapper over the UNITARES governance server.
+
+Transport contract (confirmed live 2026-06-16):
+    POST {base}/v1/tools/call
+    headers: Authorization: Bearer <token>, Content-Type: application/json
+    body:    {"name": <tool>, "arguments": {...}}
+    resp:    {"name": ..., "success": true, "result": {...}}  (result is the
+             tool's own dict; on failure success=false / no result)
+
+Only stdlib urllib is used (matches src/mcp_server_std.py's proxy), so the
+harness has no third-party transport dependency.
+"""
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+from .config import LOCUS, Transport
+
+
+class GovernanceError(RuntimeError):
+    """Raised when a tools/call returns success=false or HTTP errors."""
+
+
+@dataclass
+class Identity:
+    """A bound harness identity; the quarantine boundary for a class."""
+
+    agent_uuid: str
+    client_session_id: str | None
+    raw: dict[str, Any]
+
+
+def _first(d: dict[str, Any], *keys: str) -> Any:
+    for k in keys:
+        v = d.get(k)
+        if v:
+            return v
+    return None
+
+
+class GovernanceClient:
+    def __init__(self, transport: Transport | None = None) -> None:
+        self.t = transport or Transport()
+
+    # --- low-level -------------------------------------------------------
+    def call(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        body = json.dumps({"name": name, "arguments": arguments or {}}).encode()
+        headers = {"Accept": "application/json", "Content-Type": "application/json"}
+        if self.t.token:
+            headers["Authorization"] = f"Bearer {self.t.token}"
+        req = urllib.request.Request(
+            f"{self.t.base_url}/v1/tools/call", data=body, headers=headers, method="POST"
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self.t.timeout_s) as r:
+                payload = json.loads(r.read().decode())
+        except urllib.error.HTTPError as e:  # noqa: PERF203 - want the body
+            raise GovernanceError(f"{name}: HTTP {e.code}: {e.read().decode()[:300]}") from e
+        if isinstance(payload, dict) and payload.get("success") is True and "result" in payload:
+            return payload["result"]
+        raise GovernanceError(f"{name}: non-success payload: {json.dumps(payload)[:300]}")
+
+    # --- governance verbs ------------------------------------------------
+    def onboard(self, display_name: str, *, spawn_reason: str = "new_session") -> Identity:
+        res = self.call(
+            "onboard",
+            {
+                "force_new": True,
+                "name": display_name,
+                "spawn_reason": spawn_reason,
+            },
+        )
+        # Prefer the canonical `uuid`; `agent_id` may be a slot alias (anon_*).
+        agent_uuid = _first(res, "uuid", "agent_uuid", "agent_id")
+        if not agent_uuid:
+            raise GovernanceError(f"onboard returned no agent uuid; keys={list(res)}")
+        csid = _first(res, "client_session_id", "session_id")
+        return Identity(agent_uuid=str(agent_uuid), client_session_id=csid, raw=res)
+
+    def check_in(
+        self,
+        ident: Identity,
+        *,
+        confidence: float,
+        response_text: str,
+        task_label: str,
+        task_type: str = "testing",
+        complexity: float = 0.5,
+    ) -> str:
+        """process_agent_update; returns the minted tactical prediction_id."""
+        res = self.call(
+            "process_agent_update",
+            {
+                "agent_id": ident.agent_uuid,
+                "client_session_id": ident.client_session_id,
+                "confidence": confidence,
+                "complexity": complexity,
+                "task_type": task_type,
+                "task_label": task_label,
+                "response_text": response_text,
+                "provenance_context": {"locus": LOCUS, "harness_class": ident.agent_uuid},
+            },
+        )
+        pred_id = _first(res, "prediction_id")
+        if not pred_id:
+            raise GovernanceError(
+                f"check_in minted no prediction_id (confidence required); keys={list(res)}"
+            )
+        return str(pred_id)
+
+    def record_outcome(
+        self,
+        ident: Identity,
+        *,
+        prediction_id: str,
+        is_bad: bool,
+        outcome_score: float,
+        detail: dict[str, Any],
+        outcome_type: str | None = None,
+    ) -> dict[str, Any]:
+        return self.call(
+            "outcome_event",
+            {
+                "agent_id": ident.agent_uuid,
+                "client_session_id": ident.client_session_id,
+                "outcome_type": outcome_type or ("test_failed" if is_bad else "test_passed"),
+                "is_bad": is_bad,
+                "outcome_score": outcome_score,
+                "prediction_id": prediction_id,
+                "verification_source": "external_signal",  # -> externally_verified, weight 1.0
+                "decision_action": "proceed",
+                "detail": detail,
+            },
+        )
+
+    def calibration_check(self, ident: Identity) -> dict[str, Any]:
+        return self.call(
+            "calibration",
+            {
+                "action": "check",
+                "agent_id": ident.agent_uuid,
+                "client_session_id": ident.client_session_id,
+            },
+        )

--- a/scripts/dev/calibration_harness/client_mcp.py
+++ b/scripts/dev/calibration_harness/client_mcp.py
@@ -1,0 +1,124 @@
+"""MCP streamable-HTTP transport client — the v2 path that lifts the 0.55 cap.
+
+The REST surface ignores `continuity_token` and resolves identity by
+ip_ua_fingerprint, so it is stuck at weak tier (confidence capped at 0.55). The
+MCP transport DOES honor the signed `continuity_token`: passing it on every call
+reaches `strong` tier (`proof_origin: caller_asserted`, `session_source:
+continuity_token`), which removes the cap and unlocks the 0.6-1.0 confidence
+bins. Verified live 2026-06-16.
+
+Same interface as client.GovernanceClient (onboard / check_in / record_outcome /
+calibration_check), so the runner/sampler/report are unchanged — only the
+transport differs. Each call opens a short-lived MCP session (continuity_token is
+portable proof, so a fresh session still resolves to strong); that trades a
+handshake per call for zero persistent-session state.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from .client import GovernanceError, Identity, _first
+from .config import LOCUS, Transport
+
+
+class MCPGovernanceClient:
+    def __init__(self, transport: Transport | None = None) -> None:
+        self.t = transport or Transport()
+
+    def _mcp_url(self) -> str:
+        return self.t.base_url.rstrip("/") + "/mcp/"
+
+    # --- transport -------------------------------------------------------
+    def call(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        return asyncio.run(self._call_once(name, arguments or {}))
+
+    async def _call_once(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        from mcp import ClientSession
+        from mcp.client.streamable_http import streamablehttp_client
+
+        headers = {"Authorization": f"Bearer {self.t.token}"} if self.t.token else None
+        async with streamablehttp_client(self._mcp_url(), headers=headers) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                res = await session.call_tool(name, arguments)
+                for c in res.content:
+                    if getattr(c, "type", None) == "text":
+                        return json.loads(c.text)
+        raise GovernanceError(f"{name}: no text content in MCP result")
+
+    # --- governance verbs (continuity_token threaded for strong tier) ----
+    def onboard(self, display_name: str, *, spawn_reason: str = "new_session") -> Identity:
+        res = self.call("onboard", {"force_new": True, "name": display_name, "spawn_reason": spawn_reason})
+        agent_uuid = _first(res, "uuid", "agent_uuid", "agent_id")
+        if not agent_uuid:
+            raise GovernanceError(f"onboard returned no agent uuid; keys={list(res)}")
+        ct = res.get("continuity_token")
+        if not ct:
+            raise GovernanceError("onboard returned no continuity_token; cannot reach strong tier")
+        return Identity(
+            agent_uuid=str(agent_uuid),
+            client_session_id=_first(res, "client_session_id", "session_id"),
+            raw=res,
+            continuity_token=ct,
+        )
+
+    def check_in(
+        self,
+        ident: Identity,
+        *,
+        confidence: float,
+        response_text: str,
+        task_label: str,
+        task_type: str = "testing",
+        complexity: float = 0.5,
+    ) -> str:
+        res = self.call(
+            "process_agent_update",
+            {
+                "agent_id": ident.agent_uuid,
+                "continuity_token": ident.continuity_token,
+                "confidence": confidence,
+                "complexity": complexity,
+                "task_type": task_type,
+                "task_label": task_label,
+                "response_text": response_text,
+                "provenance_context": {"locus": LOCUS},
+            },
+        )
+        pred_id = _first(res, "prediction_id")
+        if not pred_id:
+            raise GovernanceError(f"check_in minted no prediction_id; keys={list(res)}")
+        return str(pred_id)
+
+    def record_outcome(
+        self,
+        ident: Identity,
+        *,
+        prediction_id: str,
+        is_bad: bool,
+        outcome_score: float,
+        detail: dict[str, Any],
+        outcome_type: str | None = None,
+    ) -> dict[str, Any]:
+        return self.call(
+            "outcome_event",
+            {
+                "agent_id": ident.agent_uuid,
+                "continuity_token": ident.continuity_token,
+                "outcome_type": outcome_type or ("test_failed" if is_bad else "test_passed"),
+                "is_bad": is_bad,
+                "outcome_score": outcome_score,
+                "prediction_id": prediction_id,
+                "verification_source": "external_signal",
+                "decision_action": "proceed",
+                "detail": detail,
+            },
+        )
+
+    def calibration_check(self, ident: Identity) -> dict[str, Any]:
+        return self.call(
+            "calibration",
+            {"action": "check", "agent_id": ident.agent_uuid, "continuity_token": ident.continuity_token},
+        )

--- a/scripts/dev/calibration_harness/config.py
+++ b/scripts/dev/calibration_harness/config.py
@@ -48,16 +48,9 @@ class Transport:
     timeout_s: float = 30.0
 
 
-@dataclass(frozen=True)
-class ClassSpec:
-    """One agent class == one dedicated, quarantined governance identity."""
-
-    key: str           # short tag, e.g. "harness_a"
-    display_name: str  # onboarded agent display name
-
-
-# v1 entrypoint runs 2 classes, ~200 episodes total (100 each).
-CLASSES: list[ClassSpec] = [
-    ClassSpec(key="harness_a", display_name="calib-harness-a"),
-    ClassSpec(key="harness_b", display_name="calib-harness-b"),
-]
+# A single dedicated harness identity. A multi-class structure used to live here,
+# but it was inert: the report bins on stated confidence across all rows and the
+# server has no per-class calibration read, so N identities measured the same
+# thing. The meaningful version (v1.2) would inject a DIFFERENT gap per class and
+# have the report break out by agent — until then, one identity is honest.
+HARNESS_AGENT_NAME: str = "calib-harness"

--- a/scripts/dev/calibration_harness/config.py
+++ b/scripts/dev/calibration_harness/config.py
@@ -1,0 +1,62 @@
+"""Calibration-harness configuration: bins, ratios, transport, quarantine tags.
+
+All knobs live here so run_v1 and the report stay declarative.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+# --- Stratification (the whole point of the sampler) -----------------------
+# Five confidence bins; FAIL_RATIO failures per bin so BOTH calibration error
+# (per bin) AND discrimination (AUC, needs bad_rate > 0) are measurable.
+BINS: list[tuple[float, float]] = [
+    (0.0, 0.2),
+    (0.2, 0.4),
+    (0.4, 0.6),
+    (0.6, 0.8),
+    (0.8, 1.0),
+]
+FAIL_RATIO: float = 0.4
+EPISODE_COUNT: int = 200
+
+# --- Evidence-weight gate (mirror of the server constant) ------------------
+# src/outcome_corroboration.py GRADE_WEIGHTS / observability/outcome_events.py
+# _MIN_TACTICAL_EVIDENCE_WEIGHT = GRADE_WEIGHTS[TOOL_OBSERVED] = 0.65.
+# An outcome below this weight is NOT registered into the tactical channel.
+MIN_TACTICAL_EVIDENCE_WEIGHT: float = 0.65
+EXTERNALLY_VERIFIED_WEIGHT: float = 1.00  # what external_signal should yield
+
+# --- Provenance / quarantine -----------------------------------------------
+# locus is a human-readable tag only; it is NOT a calibration filter. The real
+# quarantine boundary is the dedicated agent_id per class (see ClassSpec).
+LOCUS: str = "calibration_harness"
+
+# --- Transport -------------------------------------------------------------
+DEFAULT_BASE_URL = "http://127.0.0.1:8767"
+
+
+@dataclass(frozen=True)
+class Transport:
+    base_url: str = field(
+        default_factory=lambda: os.environ.get("GOVERNANCE_HTTP_URL", DEFAULT_BASE_URL)
+    )
+    token: str | None = field(
+        default_factory=lambda: os.environ.get("UNITARES_HTTP_API_TOKEN")
+    )
+    timeout_s: float = 30.0
+
+
+@dataclass(frozen=True)
+class ClassSpec:
+    """One agent class == one dedicated, quarantined governance identity."""
+
+    key: str           # short tag, e.g. "harness_a"
+    display_name: str  # onboarded agent display name
+
+
+# v1 entrypoint runs 2 classes, ~200 episodes total (100 each).
+CLASSES: list[ClassSpec] = [
+    ClassSpec(key="harness_a", display_name="calib-harness-a"),
+    ClassSpec(key="harness_b", display_name="calib-harness-b"),
+]

--- a/scripts/dev/calibration_harness/config.py
+++ b/scripts/dev/calibration_harness/config.py
@@ -8,8 +8,9 @@ import os
 from dataclasses import dataclass, field
 
 # --- Stratification (the whole point of the sampler) -----------------------
-# Five confidence bins; FAIL_RATIO failures per bin so BOTH calibration error
-# (per bin) AND discrimination (AUC, needs bad_rate > 0) are measurable.
+# Five confidence bins. v1.1 stratifies CONFIDENCE across these; the pass/fail
+# outcome is drawn in the runner from the injected curve (see miscalibration.py),
+# not assigned per bin — so there is no fixed fail-ratio knob anymore.
 BINS: list[tuple[float, float]] = [
     (0.0, 0.2),
     (0.2, 0.4),
@@ -17,19 +18,19 @@ BINS: list[tuple[float, float]] = [
     (0.6, 0.8),
     (0.8, 1.0),
 ]
-FAIL_RATIO: float = 0.4
 EPISODE_COUNT: int = 200
 
 # --- Evidence-weight gate (mirror of the server constant) ------------------
 # src/outcome_corroboration.py GRADE_WEIGHTS / observability/outcome_events.py
 # _MIN_TACTICAL_EVIDENCE_WEIGHT = GRADE_WEIGHTS[TOOL_OBSERVED] = 0.65.
 # An outcome below this weight is NOT registered into the tactical channel.
+# external_signal => grade externally_verified => weight 1.0, which clears it.
 MIN_TACTICAL_EVIDENCE_WEIGHT: float = 0.65
-EXTERNALLY_VERIFIED_WEIGHT: float = 1.00  # what external_signal should yield
 
 # --- Provenance / quarantine -----------------------------------------------
-# locus is a human-readable tag only; it is NOT a calibration filter. The real
-# quarantine boundary is the dedicated agent_id per class (see ClassSpec).
+# locus is a human-readable tag only; it is NOT a calibration filter and the
+# server has no per-agent calibration read scope. Quarantine is by isolated
+# INSTANCE (governance_test), not by tag or agent_id.
 LOCUS: str = "calibration_harness"
 
 # --- Transport -------------------------------------------------------------

--- a/scripts/dev/calibration_harness/episodes/__init__.py
+++ b/scripts/dev/calibration_harness/episodes/__init__.py
@@ -1,0 +1,6 @@
+"""Episode types for the calibration harness."""
+from .base import Episode, elicit_confidence
+from .clean_control import CleanControl
+from .seeded_test_fail import SeededTestFail
+
+__all__ = ["Episode", "elicit_confidence", "CleanControl", "SeededTestFail"]

--- a/scripts/dev/calibration_harness/episodes/base.py
+++ b/scripts/dev/calibration_harness/episodes/base.py
@@ -1,0 +1,54 @@
+"""Episode ABC and confidence elicitation.
+
+An Episode knows its ground truth *by construction*: it emits a python script
+whose exit code is deterministic, so the grader's verdict is decided before the
+agent ever "attempts" it. That is what makes the harness a calibration fixture
+rather than a behavioral measurement.
+"""
+from __future__ import annotations
+
+import random
+from abc import ABC, abstractmethod
+
+
+class Episode(ABC):
+    """One bounded, ground-truth-known task."""
+
+    def __init__(self, target_bin: tuple[float, float], index: int, tag: str = "") -> None:
+        self.target_bin = target_bin
+        self.index = index
+        self.tag = tag
+
+    @property
+    def label(self) -> str:
+        lo, hi = self.target_bin
+        suffix = f":{self.tag}" if self.tag else ""
+        return f"{self.kind}[{lo:.1f}-{hi:.1f}]#{self.index}{suffix}"
+
+    @property
+    @abstractmethod
+    def kind(self) -> str:
+        """Short stable kind name, e.g. 'clean_control'."""
+
+    @property
+    @abstractmethod
+    def expected_bad(self) -> bool:
+        """Ground-truth outcome: True if this episode is constructed to fail."""
+
+    @abstractmethod
+    def build_source(self) -> str:
+        """Return deterministic python source whose exit code encodes the truth."""
+
+
+def elicit_confidence(target_bin: tuple[float, float], rng: random.Random) -> float:
+    """Draw a stated confidence inside the target bin (synthetic fixture).
+
+    NOTE: process_agent_update registers a *transformed* confidence, not this
+    raw value (observed: 0.90 -> 0.9148). The harness submits this to land
+    roughly in-bin; report.py reads the registered ``reported_confidence`` back
+    from the DB for the actual ECE/AUC computation rather than trusting this.
+    """
+    lo, hi = target_bin
+    # keep a hair inside the edges so rounding doesn't cross a boundary
+    span = hi - lo
+    return round(lo + 0.1 * span + rng.random() * 0.8 * span, 4)

--- a/scripts/dev/calibration_harness/episodes/clean_control.py
+++ b/scripts/dev/calibration_harness/episodes/clean_control.py
@@ -1,0 +1,22 @@
+"""A genuinely solvable task across difficulties. Always passes (exit 0)."""
+from __future__ import annotations
+
+from .base import Episode
+
+
+class CleanControl(Episode):
+    kind = "clean_control"
+    expected_bad = False
+
+    def build_source(self) -> str:
+        # Difficulty varies with index but the result is always correct, so the
+        # exit code is deterministically 0. The arithmetic is real work, not a
+        # no-op, so the grader exercises a genuine subprocess.
+        n = self.index + 1
+        return (
+            "import sys\n"
+            f"acc = sum(i * i for i in range({n} % 50 + 3))\n"
+            f"expected = sum(i * i for i in range({n} % 50 + 3))\n"
+            "assert acc == expected, 'control should never fail'\n"
+            "sys.exit(0)\n"
+        )

--- a/scripts/dev/calibration_harness/episodes/seeded_test_fail.py
+++ b/scripts/dev/calibration_harness/episodes/seeded_test_fail.py
@@ -1,0 +1,31 @@
+"""A deterministic failing test hidden behind a plausible change (exit 1).
+
+Fixed by construction: the assertion is always false, so the grader always
+reports a failure. Used to inject the bad outcomes that make bad_rate > 0 and
+discrimination (AUC) computable. Placed in high confidence bins it becomes an
+explicit overconfidence probe.
+"""
+from __future__ import annotations
+
+from .base import Episode
+
+
+class SeededTestFail(Episode):
+    kind = "seeded_test_fail"
+    expected_bad = True
+
+    def build_source(self) -> str:
+        # A "plausible change": an off-by-one the author believes is correct.
+        n = self.index + 1
+        return (
+            "import sys\n"
+            f"def window_sum(xs, k):\n"
+            f"    # bug: inclusive end -> reads one past the window\n"
+            f"    return sum(xs[: k + 1])\n"
+            f"data = list(range({n} % 40 + 5))\n"
+            f"k = 3\n"
+            f"got = window_sum(data, k)\n"
+            f"want = sum(data[:k])\n"
+            "assert got == want, f'seeded failure: {got} != {want}'\n"
+            "sys.exit(0)\n"
+        )

--- a/scripts/dev/calibration_harness/grader.py
+++ b/scripts/dev/calibration_harness/grader.py
@@ -1,0 +1,64 @@
+"""External test-runner grader.
+
+Runs a real subprocess (a python assertion script) in a sandboxed temp dir and
+reads the exit code. The exit code is an honest *external signal*: the grade fed
+to governance is grounded in a tool observation, not agent prose.
+
+Returns a Grade whose ``detail`` carries the real ``exit_code``/``command`` so
+the corroboration classifier reaches ``externally_verified`` (weight 1.0) on the
+structured evidence too, not only on the ``external_signal`` source label.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class Grade:
+    is_bad: bool
+    score: float           # 1.0 pass .. 0.0 fail
+    exit_code: int
+    detail: dict[str, Any] = field(default_factory=dict)
+
+
+def grade_script(source: str, *, label: str, timeout_s: float = 15.0) -> Grade:
+    """Write `source` to a temp file, run it isolated, grade by exit code.
+
+    Sandboxing: a throwaway temp dir as cwd; the injected failures are pure
+    `assert`/`sys.exit(1)` in the script text, so nothing touches real systems.
+    """
+    with tempfile.TemporaryDirectory(prefix="calib_ep_") as td:
+        script = Path(td) / "episode.py"
+        script.write_text(source)
+        cmd = [sys.executable, str(script)]
+        try:
+            proc = subprocess.run(  # noqa: S603 - fixed argv, sandboxed temp dir
+                cmd,
+                cwd=td,
+                capture_output=True,
+                text=True,
+                timeout=timeout_s,
+            )
+            exit_code = proc.returncode
+            stderr_tail = proc.stderr[-400:]
+        except subprocess.TimeoutExpired:
+            exit_code = 124
+            stderr_tail = f"timeout after {timeout_s}s"
+
+    is_bad = exit_code != 0
+    detail: dict[str, Any] = {
+        # Fields the corroboration classifier keys on for tool_observed:
+        "kind": "test",
+        "tool": "python",
+        "exit_code": exit_code,
+        "command": " ".join(cmd),
+        "test_name": label,
+    }
+    if stderr_tail:
+        detail["error_message"] = stderr_tail
+    return Grade(is_bad=is_bad, score=0.0 if is_bad else 1.0, exit_code=exit_code, detail=detail)

--- a/scripts/dev/calibration_harness/miscalibration.py
+++ b/scripts/dev/calibration_harness/miscalibration.py
@@ -1,0 +1,68 @@
+"""Injectable miscalibration model — the v1.1 fix (council architect #1).
+
+v1's outcomes were independent of confidence, so ECE/AUC had no ground truth to
+recover. Here the outcome is drawn from a KNOWN calibration curve, so the report
+can check "I injected error X — did the channel recover ≈ X?". That is the actual
+measurement-plumbing test, distinct from the binding smoke test.
+
+Model: an overconfident agent. Its TRUE success probability at stated confidence
+`c` is `c - gap` (clamped to [0,1]). With gap > 0 the agent claims more than it
+delivers, so a correct ECE estimate should recover ≈ gap (over the region where
+the clamp is inactive), and AUC should exceed 0.5 because success now rises
+monotonically with confidence.
+"""
+from __future__ import annotations
+
+import math
+
+
+def true_accuracy(confidence: float, gap: float) -> float:
+    """Injected calibration curve: P(success | confidence) = clamp(confidence - gap)."""
+    return min(1.0, max(0.0, confidence - gap))
+
+
+def injected_ece(confidences: list[float], gap: float) -> float:
+    """Bias-free target: per-sample |confidence - true_accuracy(confidence)|, averaged.
+
+    The miscalibration we actually injected, independent of binning or sampling.
+    """
+    if not confidences:
+        return 0.0
+    return sum(abs(c - true_accuracy(c, gap)) for c in confidences) / len(confidences)
+
+
+def _phi(x: float) -> float:
+    return 0.5 * (1.0 + math.erf(x / math.sqrt(2.0)))
+
+
+def _folded_normal_mean(mu: float, sigma: float) -> float:
+    """E|X| for X ~ N(mu, sigma^2). The per-bin |mean_conf - empirical_acc|."""
+    if sigma <= 0:
+        return abs(mu)
+    return sigma * math.sqrt(2.0 / math.pi) * math.exp(-(mu**2) / (2 * sigma**2)) + mu * (1 - 2 * _phi(-mu / sigma))
+
+
+def expected_recovered_ece(confidences: list[float], gap: float, bins: list[tuple[float, float]]) -> float:
+    """Bias-AWARE target: what a binned ECE estimator should report at finite n.
+
+    Binned empirical accuracy is a noisy estimate of mean true accuracy, and ECE
+    sums |mean_conf - accuracy|, so each bin contributes a folded-normal mean that
+    is positive even at perfect calibration. This models that floor, so the
+    recovered ECE can be checked against a principled target at ANY gap (including
+    gap=0, where injected_ece=0 but a finite-sample estimator cannot report 0).
+    """
+    total = len(confidences)
+    if not total:
+        return 0.0
+    out = 0.0
+    for lo, hi in bins:
+        members = [c for c in confidences if (lo <= c < hi) or (hi == 1.0 and c == 1.0)]
+        if not members:
+            continue
+        n_b = len(members)
+        ps = [true_accuracy(c, gap) for c in members]
+        mean_conf = sum(members) / n_b
+        mean_acc = sum(ps) / n_b
+        var_acc = sum(p * (1 - p) for p in ps) / (n_b * n_b)  # var of the bin mean
+        out += (n_b / total) * _folded_normal_mean(mean_conf - mean_acc, math.sqrt(var_acc))
+    return out

--- a/scripts/dev/calibration_harness/probe_one.py
+++ b/scripts/dev/calibration_harness/probe_one.py
@@ -1,0 +1,104 @@
+"""Single-episode live verification of the calibration spine.
+
+Build-order gate (handoff): confirm the end-to-end path lands a *corroborated*
+outcome (evidence_weight == 1.0) and populates the tactical channel BEFORE
+scaling to 200. Runs two episodes under one dedicated, quarantined harness
+identity:
+
+  * a clean_control pass  (high confidence, exit 0  -> test_passed)
+  * an overconfidence probe (high confidence, exit 1 -> test_failed, bad_rate>0)
+
+Run:  python -m scripts.dev.calibration_harness.probe_one
+      (from the repo root; needs UNITARES_HTTP_API_TOKEN + a live server)
+"""
+from __future__ import annotations
+
+import json
+
+from .client import GovernanceClient
+from .config import MIN_TACTICAL_EVIDENCE_WEIGHT
+from .grader import grade_script
+
+PASS_SCRIPT = "assert 1 + 1 == 2\n"
+FAIL_SCRIPT = "import sys\nassert 2 + 2 == 5, 'seeded failure'\nsys.exit(0)\n"
+
+
+def _dig(d: dict, *path):
+    cur = d
+    for p in path:
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(p)
+    return cur
+
+
+def _find_evidence_weight(resp: dict):
+    # be tolerant of nesting until we pin the exact shape from live output
+    for path in (("evidence_weight",), ("detail", "evidence_weight"), ("result", "evidence_weight")):
+        v = _dig(resp, *path)
+        if v is not None:
+            return v, path
+    return None, None
+
+
+def main() -> int:
+    client = GovernanceClient()
+
+    print("== onboard (dedicated quarantined identity) ==")
+    ident = client.onboard("calib-harness-probe")
+    print(f"agent_uuid={ident.agent_uuid}  client_session_id={ident.client_session_id}")
+    print("onboard result keys:", list(ident.raw)[:20])
+
+    episodes = [
+        ("clean_control", 0.90, PASS_SCRIPT, False),
+        ("overconfidence_probe", 0.90, FAIL_SCRIPT, True),
+    ]
+    ok = True
+    for label, conf, src, expect_bad in episodes:
+        print(f"\n== episode: {label} (confidence={conf}) ==")
+        pred_id = client.check_in(
+            ident,
+            confidence=conf,
+            response_text=f"[{label}] attempting bounded task; expect {'fail' if expect_bad else 'pass'}",
+            task_label=label,
+        )
+        print(f"prediction_id={pred_id}")
+
+        grade = grade_script(src, label=label)
+        print(f"grade: is_bad={grade.is_bad} exit_code={grade.exit_code} score={grade.score}")
+        assert grade.is_bad == expect_bad, f"grader disagreed with construction for {label}"
+
+        out = client.record_outcome(
+            ident,
+            prediction_id=pred_id,
+            is_bad=grade.is_bad,
+            outcome_score=grade.score,
+            detail=grade.detail,
+        )
+        ew, path = _find_evidence_weight(out)
+        print(f"outcome response keys: {list(out)[:20]}")
+        print(f"evidence_weight={ew}  (found at {path})")
+        if ew is None or float(ew) < MIN_TACTICAL_EVIDENCE_WEIGHT:
+            print(f"  !! GATE FAIL: need evidence_weight >= {MIN_TACTICAL_EVIDENCE_WEIGHT} to register tactically")
+            ok = False
+
+    print("\n== calibration check (tactical channel; global-scope, isolated instance) ==")
+    cal = client.calibration_check(ident)
+    te = cal.get("tactical_evidence", {}) or {}
+    health = (cal.get("per_channel_health") or {}).get("tests", {}) or {}
+    print("tactical_evidence:", json.dumps(te)[:300])
+    print("per_channel_health.tests:", json.dumps(health))
+    tests_n = (te.get("signal_sources") or {}).get("tests") or 0
+    if tests_n < 1:
+        print("  !! GATE FAIL: tactical 'tests' channel did not register the outcomes")
+        ok = False
+    if (health.get("bad_rate") or 0) <= 0:
+        print("  !! GATE FAIL: bad_rate still 0 -> AUC not computable")
+        ok = False
+
+    print("\nRESULT:", "PASS — spine corroborated, safe to scale" if ok else "FAIL — fix before scaling")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/calibration_harness/report.py
+++ b/scripts/dev/calibration_harness/report.py
@@ -1,0 +1,152 @@
+"""The proof. Computes ECE + AUC from the harness's own DB rows and shows the
+server's tactical channel before/after.
+
+Why compute our own ECE/AUC instead of trusting `calibration check`?
+  * `calibration check` is GLOBAL and agent-unscoped (tactical_evidence.scope
+    == "global"); on a shared server it folds in every agent. The harness runs
+    against an isolated test instance precisely so the global pool == harness
+    rows, but we still compute independently from per-agent rows as a
+    cross-check that should agree with the server's per_channel numbers.
+  * We bin on the REGISTERED confidence (detail.reported_confidence), which is
+    the transformed value the server actually scored — not our stated input.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import psycopg2  # type: ignore
+import psycopg2.extras  # type: ignore
+
+from .client import GovernanceClient
+from .config import BINS
+
+TEST_DB_URL = "postgresql://postgres:postgres@localhost:5432/governance_test"
+
+
+@dataclass
+class Pair:
+    confidence: float  # registered/transformed confidence
+    success: bool      # not is_bad
+
+
+def _connect():
+    return psycopg2.connect(os.environ.get("DB_POSTGRES_URL", TEST_DB_URL))
+
+
+def fetch_pairs(agent_uuids: list[str]) -> list[Pair]:
+    """Per-agent corroborated test outcomes with their registered confidence."""
+    # Read verification_source from detail jsonb, not the column: the column
+    # (migration 039) is absent on databases built from base DDL (e.g.
+    # governance_test), but the value is always mirrored into detail.
+    sql = """
+        SELECT (detail->>'reported_confidence')::float8 AS conf, is_bad
+        FROM audit.outcome_events
+        WHERE agent_id = ANY(%(ids)s)
+          AND detail->>'verification_source' = 'external_signal'
+          AND outcome_type IN ('test_passed','test_failed')
+          AND detail->>'reported_confidence' IS NOT NULL
+    """
+    with _connect() as conn, conn.cursor() as cur:
+        cur.execute(sql, {"ids": agent_uuids})
+        return [Pair(confidence=float(c), success=(not b)) for c, b in cur.fetchall()]
+
+
+def compute_ece(pairs: list[Pair]) -> tuple[float, list[dict]]:
+    """Expected Calibration Error over the configured bins + reliability table."""
+    table: list[dict] = []
+    total = len(pairs)
+    ece = 0.0
+    for lo, hi in BINS:
+        members = [p for p in pairs if (lo <= p.confidence < hi) or (hi == 1.0 and p.confidence == 1.0)]
+        if not members:
+            table.append({"bin": f"{lo:.1f}-{hi:.1f}", "count": 0, "mean_conf": None, "accuracy": None, "gap": None})
+            continue
+        mean_conf = sum(p.confidence for p in members) / len(members)
+        accuracy = sum(1 for p in members if p.success) / len(members)
+        gap = abs(mean_conf - accuracy)
+        ece += (len(members) / total) * gap
+        table.append({
+            "bin": f"{lo:.1f}-{hi:.1f}", "count": len(members),
+            "mean_conf": round(mean_conf, 4), "accuracy": round(accuracy, 4), "gap": round(gap, 4),
+        })
+    return ece, table
+
+
+def compute_auc(pairs: list[Pair]) -> float | None:
+    """Rank-based AUC: can confidence discriminate success from failure?
+
+    Needs both classes present (bad_rate > 0 and < 1). Returns None otherwise.
+    """
+    pos = [p.confidence for p in pairs if p.success]
+    neg = [p.confidence for p in pairs if not p.success]
+    if not pos or not neg:
+        return None
+    # Mann-Whitney U via average ranks, tie-aware.
+    scored = sorted(((p.confidence, p.success) for p in pairs), key=lambda x: x[0])
+    ranks: list[float] = [0.0] * len(scored)
+    i = 0
+    while i < len(scored):
+        j = i
+        while j + 1 < len(scored) and scored[j + 1][0] == scored[i][0]:
+            j += 1
+        avg_rank = (i + j) / 2.0 + 1.0  # 1-based average rank for the tie group
+        for k in range(i, j + 1):
+            ranks[k] = avg_rank
+        i = j + 1
+    sum_ranks_pos = sum(r for r, (_, succ) in zip(ranks, scored) if succ)
+    n_pos, n_neg = len(pos), len(neg)
+    u = sum_ranks_pos - n_pos * (n_pos + 1) / 2.0
+    return u / (n_pos * n_neg)
+
+
+def snapshot_tactical(client: GovernanceClient) -> dict:
+    res = client.call("calibration", {"action": "check"})
+    te = res.get("tactical_evidence", {}) or {}
+    health = (res.get("per_channel_health") or {}).get("tests", {}) or {}
+    fm = (((res.get("calibration_guidance") or {}).get("failure_modes") or {}).get("tactical") or {})
+    return {
+        "eligible_samples": te.get("eligible_samples"),
+        "signal_sources": te.get("signal_sources"),
+        "tests_bad_rate": health.get("bad_rate"),
+        "tests_samples": health.get("samples"),
+        "server_ece": fm.get("ece"),
+        "server_total_samples": fm.get("total_samples"),
+    }
+
+
+def emit(agent_uuids: list[str], before: dict, after: dict) -> dict:
+    pairs = fetch_pairs(agent_uuids)
+    ece, table = compute_ece(pairs)
+    auc = compute_auc(pairs)
+    n_bad = sum(1 for p in pairs if not p.success)
+
+    print("\n================ CALIBRATION HARNESS v1 — REPORT ================")
+    print("NOTE: synthetic fixture. ECE/AUC describe the harness's measurement,")
+    print("      NOT any agent's real calibration. Confidences are drawn to land")
+    print("      in target bins behind known outcomes.\n")
+
+    print(f"harness rows: {len(pairs)}  (failures={n_bad}, bad_rate={n_bad/len(pairs):.3f})" if pairs else "harness rows: 0")
+    print(f"harness-computed ECE (registered confidence): {ece:.4f}")
+    print(f"harness-computed AUC (discrimination):        {auc if auc is None else round(auc, 4)}"
+          + ("  <- bad_rate=0, not computable" if auc is None else ""))
+
+    print("\nreliability table (expected vs actual per bin):")
+    print(f"  {'bin':<10} {'n':>4} {'mean_conf':>10} {'accuracy':>9} {'gap':>7}")
+    for r in table:
+        mc = "-" if r["mean_conf"] is None else f"{r['mean_conf']:.3f}"
+        ac = "-" if r["accuracy"] is None else f"{r['accuracy']:.3f}"
+        gp = "-" if r["gap"] is None else f"{r['gap']:.3f}"
+        print(f"  {r['bin']:<10} {r['count']:>4} {mc:>10} {ac:>9} {gp:>7}")
+
+    print("\nserver tactical channel (isolated instance, before -> after):")
+    print(f"  eligible_samples: {before['eligible_samples']} -> {after['eligible_samples']}")
+    print(f"  tests bad_rate:   {before['tests_bad_rate']} -> {after['tests_bad_rate']}")
+    print(f"  server tactical ECE: {before['server_ece']} -> {after['server_ece']}")
+
+    print("\nv1 success criteria:")
+    print(f"  [{'x' if pairs and n_bad > 0 else ' '}] bad_rate > 0 -> AUC computable")
+    print(f"  [{'x' if auc is not None else ' '}] AUC computed")
+    print(f"  [{'x' if (after['eligible_samples'] or 0) > (before['eligible_samples'] or 0) else ' '}] tactical channel moved")
+    print("================================================================\n")
+    return {"ece": ece, "auc": auc, "rows": len(pairs), "bad": n_bad, "table": table}

--- a/scripts/dev/calibration_harness/report.py
+++ b/scripts/dev/calibration_harness/report.py
@@ -122,13 +122,19 @@ def emit(agent_uuids: list[str], before: dict, after: dict) -> dict:
     n_bad = sum(1 for p in pairs if not p.success)
 
     print("\n================ CALIBRATION HARNESS v1 — REPORT ================")
-    print("NOTE: synthetic fixture. ECE/AUC describe the harness's measurement,")
-    print("      NOT any agent's real calibration. Confidences are drawn to land")
-    print("      in target bins behind known outcomes.\n")
+    print("SCOPE (council, read this): v1 validates the BINDING/REGISTRATION spine")
+    print("  (stated confidence -> prediction_id -> external outcome -> tactical row).")
+    print("  It does NOT yet validate the calibration MEASUREMENT: outcomes are drawn")
+    print("  INDEPENDENTLY of confidence (sampler assigns pass/fail by position, not by")
+    print("  confidence), so there is no injected miscalibration for ECE/AUC to recover.")
+    print("  => AUC ~ 0.5 is EXPECTED; any deviation is a sampler artifact, not skill.")
+    print("  => ECE here is dominated by the 0.55 cap + corrector fixed point + the")
+    print("     constant per-bin fail ratio, not by a calibration relationship.")
+    print("  The v1.1 fix is an injectable miscalibration knob (see README).\n")
 
     print(f"harness rows: {len(pairs)}  (failures={n_bad}, bad_rate={n_bad/len(pairs):.3f})" if pairs else "harness rows: 0")
-    print(f"harness-computed ECE (registered confidence): {ece:.4f}")
-    print(f"harness-computed AUC (discrimination):        {auc if auc is None else round(auc, 4)}"
+    print(f"harness-computed ECE (registered confidence): {ece:.4f}  [cap/corrector-dominated]")
+    print(f"harness-computed AUC (~0.5 expected):         {auc if auc is None else round(auc, 4)}"
           + ("  <- bad_rate=0, not computable" if auc is None else ""))
 
     print("\nreliability table (expected vs actual per bin):")

--- a/scripts/dev/calibration_harness/report.py
+++ b/scripts/dev/calibration_harness/report.py
@@ -1,59 +1,32 @@
-"""The proof. Computes ECE + AUC from the harness's own DB rows and shows the
-server's tactical channel before/after.
+"""The proof (v1.1). Validates the calibration MEASUREMENT by recovering a known
+injected miscalibration, then shows the server's tactical channel before/after.
 
-Why compute our own ECE/AUC instead of trusting `calibration check`?
-  * `calibration check` is GLOBAL and agent-unscoped (tactical_evidence.scope
-    == "global"); on a shared server it folds in every agent. The harness runs
-    against an isolated test instance precisely so the global pool == harness
-    rows, but we still compute independently from per-agent rows as a
-    cross-check that should agree with the server's per_channel numbers.
-  * We bin on the REGISTERED confidence (detail.reported_confidence), which is
-    the transformed value the server actually scored — not our stated input.
+Primary check (self-contained, server-independent): bin on the STATED confidence
+the harness controlled, compute ECE/AUC from the Bernoulli outcomes, and compare
+the recovered ECE to the analytic injected ECE. If they match within sampling
+noise, report.py's measurement math is sound. AUC should exceed 0.5 because the
+injected curve makes success rise with confidence.
+
+Secondary view: the server's tactical channel (global, registered/capped
+confidence) before vs after — what the server actually scored, distorted by the
+0.55 cap + corrector. The gap between primary and secondary IS the finding.
 """
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
-
-import psycopg2  # type: ignore
-import psycopg2.extras  # type: ignore
 
 from .client import GovernanceClient
 from .config import BINS
-
-TEST_DB_URL = "postgresql://postgres:postgres@localhost:5432/governance_test"
+from .miscalibration import expected_recovered_ece, injected_ece
 
 
 @dataclass
 class Pair:
-    confidence: float  # registered/transformed confidence
-    success: bool      # not is_bad
-
-
-def _connect():
-    return psycopg2.connect(os.environ.get("DB_POSTGRES_URL", TEST_DB_URL))
-
-
-def fetch_pairs(agent_uuids: list[str]) -> list[Pair]:
-    """Per-agent corroborated test outcomes with their registered confidence."""
-    # Read verification_source from detail jsonb, not the column: the column
-    # (migration 039) is absent on databases built from base DDL (e.g.
-    # governance_test), but the value is always mirrored into detail.
-    sql = """
-        SELECT (detail->>'reported_confidence')::float8 AS conf, is_bad
-        FROM audit.outcome_events
-        WHERE agent_id = ANY(%(ids)s)
-          AND detail->>'verification_source' = 'external_signal'
-          AND outcome_type IN ('test_passed','test_failed')
-          AND detail->>'reported_confidence' IS NOT NULL
-    """
-    with _connect() as conn, conn.cursor() as cur:
-        cur.execute(sql, {"ids": agent_uuids})
-        return [Pair(confidence=float(c), success=(not b)) for c, b in cur.fetchall()]
+    confidence: float
+    success: bool
 
 
 def compute_ece(pairs: list[Pair]) -> tuple[float, list[dict]]:
-    """Expected Calibration Error over the configured bins + reliability table."""
     table: list[dict] = []
     total = len(pairs)
     ece = 0.0
@@ -64,37 +37,33 @@ def compute_ece(pairs: list[Pair]) -> tuple[float, list[dict]]:
             continue
         mean_conf = sum(p.confidence for p in members) / len(members)
         accuracy = sum(1 for p in members if p.success) / len(members)
-        gap = abs(mean_conf - accuracy)
-        ece += (len(members) / total) * gap
+        g = abs(mean_conf - accuracy)
+        ece += (len(members) / total) * g
         table.append({
             "bin": f"{lo:.1f}-{hi:.1f}", "count": len(members),
-            "mean_conf": round(mean_conf, 4), "accuracy": round(accuracy, 4), "gap": round(gap, 4),
+            "mean_conf": round(mean_conf, 4), "accuracy": round(accuracy, 4), "gap": round(g, 4),
         })
     return ece, table
 
 
 def compute_auc(pairs: list[Pair]) -> float | None:
-    """Rank-based AUC: can confidence discriminate success from failure?
-
-    Needs both classes present (bad_rate > 0 and < 1). Returns None otherwise.
-    """
-    pos = [p.confidence for p in pairs if p.success]
-    neg = [p.confidence for p in pairs if not p.success]
+    """Tie-aware rank AUC. None unless both classes present."""
+    pos = [p for p in pairs if p.success]
+    neg = [p for p in pairs if not p.success]
     if not pos or not neg:
         return None
-    # Mann-Whitney U via average ranks, tie-aware.
-    scored = sorted(((p.confidence, p.success) for p in pairs), key=lambda x: x[0])
-    ranks: list[float] = [0.0] * len(scored)
+    scored = sorted(pairs, key=lambda p: p.confidence)
+    ranks = [0.0] * len(scored)
     i = 0
     while i < len(scored):
         j = i
-        while j + 1 < len(scored) and scored[j + 1][0] == scored[i][0]:
+        while j + 1 < len(scored) and scored[j + 1].confidence == scored[i].confidence:
             j += 1
-        avg_rank = (i + j) / 2.0 + 1.0  # 1-based average rank for the tie group
+        avg_rank = (i + j) / 2.0 + 1.0
         for k in range(i, j + 1):
             ranks[k] = avg_rank
         i = j + 1
-    sum_ranks_pos = sum(r for r, (_, succ) in zip(ranks, scored) if succ)
+    sum_ranks_pos = sum(r for r, p in zip(ranks, scored) if p.success)
     n_pos, n_neg = len(pos), len(neg)
     u = sum_ranks_pos - n_pos * (n_pos + 1) / 2.0
     return u / (n_pos * n_neg)
@@ -107,37 +76,36 @@ def snapshot_tactical(client: GovernanceClient) -> dict:
     fm = (((res.get("calibration_guidance") or {}).get("failure_modes") or {}).get("tactical") or {})
     return {
         "eligible_samples": te.get("eligible_samples"),
-        "signal_sources": te.get("signal_sources"),
         "tests_bad_rate": health.get("bad_rate"),
-        "tests_samples": health.get("samples"),
         "server_ece": fm.get("ece"),
-        "server_total_samples": fm.get("total_samples"),
     }
 
 
-def emit(agent_uuids: list[str], before: dict, after: dict) -> dict:
-    pairs = fetch_pairs(agent_uuids)
-    ece, table = compute_ece(pairs)
+def emit(rows, gap: float, before: dict, after: dict) -> dict:
+    pairs = [Pair(confidence=r.stated_confidence, success=not r.is_bad) for r in rows]
+    confidences = [p.confidence for p in pairs]
+    recovered_ece, table = compute_ece(pairs)
+    injected = injected_ece(confidences, gap)              # bias-free: what we injected
+    expected = expected_recovered_ece(confidences, gap, BINS)  # bias-aware: what a binned estimator should report
     auc = compute_auc(pairs)
     n_bad = sum(1 for p in pairs if not p.success)
+    ece_err = abs(recovered_ece - expected)
+    ok_ece = ece_err <= 0.05  # vs the bias-aware target, robust at any gap
 
-    print("\n================ CALIBRATION HARNESS v1 — REPORT ================")
-    print("SCOPE (council, read this): v1 validates the BINDING/REGISTRATION spine")
-    print("  (stated confidence -> prediction_id -> external outcome -> tactical row).")
-    print("  It does NOT yet validate the calibration MEASUREMENT: outcomes are drawn")
-    print("  INDEPENDENTLY of confidence (sampler assigns pass/fail by position, not by")
-    print("  confidence), so there is no injected miscalibration for ECE/AUC to recover.")
-    print("  => AUC ~ 0.5 is EXPECTED; any deviation is a sampler artifact, not skill.")
-    print("  => ECE here is dominated by the 0.55 cap + corrector fixed point + the")
-    print("     constant per-bin fail ratio, not by a calibration relationship.")
-    print("  The v1.1 fix is an injectable miscalibration knob (see README).\n")
+    print("\n================ CALIBRATION HARNESS v1.1 — REPORT ================")
+    print("Synthetic fixture. Outcomes drawn from an INJECTED curve")
+    print(f"  true_accuracy(c) = clamp(c - {gap}), so a correct ECE estimate should")
+    print("  recover ~ the injected ECE, and AUC should exceed 0.5.\n")
 
-    print(f"harness rows: {len(pairs)}  (failures={n_bad}, bad_rate={n_bad/len(pairs):.3f})" if pairs else "harness rows: 0")
-    print(f"harness-computed ECE (registered confidence): {ece:.4f}  [cap/corrector-dominated]")
-    print(f"harness-computed AUC (~0.5 expected):         {auc if auc is None else round(auc, 4)}"
-          + ("  <- bad_rate=0, not computable" if auc is None else ""))
+    print(f"rows: {len(pairs)}  failures: {n_bad}  bad_rate: {n_bad/len(pairs):.3f}" if pairs else "rows: 0")
+    print("\nPRIMARY — measurement validation (binned on STATED confidence):")
+    print(f"  injected ECE (bias-free):       {injected:.4f}   <- the miscalibration we injected")
+    print(f"  expected ECE (bias-aware floor): {expected:.4f}   <- what a binned estimator should report at this n")
+    print(f"  recovered ECE (measured):       {recovered_ece:.4f}   (|err vs expected|={ece_err:.4f})")
+    print(f"  AUC: {auc if auc is None else round(auc, 4)}"
+          + ("  <- one class only" if auc is None else "  (>0.5 expected)"))
 
-    print("\nreliability table (expected vs actual per bin):")
+    print("\nreliability table (stated confidence; accuracy should track c-gap):")
     print(f"  {'bin':<10} {'n':>4} {'mean_conf':>10} {'accuracy':>9} {'gap':>7}")
     for r in table:
         mc = "-" if r["mean_conf"] is None else f"{r['mean_conf']:.3f}"
@@ -145,14 +113,15 @@ def emit(agent_uuids: list[str], before: dict, after: dict) -> dict:
         gp = "-" if r["gap"] is None else f"{r['gap']:.3f}"
         print(f"  {r['bin']:<10} {r['count']:>4} {mc:>10} {ac:>9} {gp:>7}")
 
-    print("\nserver tactical channel (isolated instance, before -> after):")
+    print("\nSECONDARY — server tactical channel (registered/capped confidence, global):")
     print(f"  eligible_samples: {before['eligible_samples']} -> {after['eligible_samples']}")
     print(f"  tests bad_rate:   {before['tests_bad_rate']} -> {after['tests_bad_rate']}")
     print(f"  server tactical ECE: {before['server_ece']} -> {after['server_ece']}")
 
-    print("\nv1 success criteria:")
-    print(f"  [{'x' if pairs and n_bad > 0 else ' '}] bad_rate > 0 -> AUC computable")
-    print(f"  [{'x' if auc is not None else ' '}] AUC computed")
+    print("\nv1.1 success criteria:")
+    print(f"  [{'x' if ok_ece else ' '}] recovered ECE matches bias-aware expected within 0.05 (measurement sound)")
+    print(f"  [{'x' if auc is not None and auc > 0.5 else ' '}] AUC > 0.5 (confidence now discriminates)")
     print(f"  [{'x' if (after['eligible_samples'] or 0) > (before['eligible_samples'] or 0) else ' '}] tactical channel moved")
-    print("================================================================\n")
-    return {"ece": ece, "auc": auc, "rows": len(pairs), "bad": n_bad, "table": table}
+    print("==================================================================\n")
+    return {"injected_ece": injected, "expected_ece": expected, "recovered_ece": recovered_ece,
+            "ece_err": ece_err, "auc": auc, "rows": len(pairs), "ok": ok_ece}

--- a/scripts/dev/calibration_harness/run_v1.py
+++ b/scripts/dev/calibration_harness/run_v1.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from . import report
 from .client import GovernanceClient, Identity
 from .config import BINS, CLASSES, EPISODE_COUNT, Transport
-from .runner import run_episode
+from .runner import run_slot
 from .sampler import plan
 
 SEED = 1729  # fixed -> reproducible
@@ -59,6 +59,8 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--episodes", type=int, default=EPISODE_COUNT)
     ap.add_argument("--classes", type=int, default=len(CLASSES))
+    ap.add_argument("--gap", type=float, default=0.2,
+                    help="injected overconfidence gap; report should recover ~ this ECE")
     ap.add_argument("--out", type=str, default="data/calibration_harness/run_v1.csv")
     ap.add_argument("--i-know", action="store_true", help="bypass the prod-URL guard")
     args = ap.parse_args()
@@ -79,16 +81,15 @@ def main() -> int:
     print(f"onboarded {n_classes} harness identities: {[i.agent_uuid for i in idents]}")
 
     before = report.snapshot_tactical(client)
-    episodes = plan(args.episodes)
-    print(f"planned {len(episodes)} episodes against {transport.base_url}")
+    slots = plan(args.episodes)
+    print(f"planned {len(slots)} episodes against {transport.base_url} (injected gap={args.gap})")
 
     rows = []
-    for k, ep in enumerate(episodes):
+    for k, slot in enumerate(slots):
         ident = idents[k % n_classes]
-        row = run_episode(client, ident, ep, rng)
-        rows.append(row)
+        rows.append(run_slot(client, ident, slot, rng, args.gap))
         if (k + 1) % 25 == 0:
-            print(f"  {k + 1}/{len(episodes)} done")
+            print(f"  {k + 1}/{len(slots)} done")
 
     after = report.snapshot_tactical(client)
 
@@ -104,7 +105,7 @@ def main() -> int:
     else:
         print("no rows produced; skipping CSV write")
 
-    report.emit([i.agent_uuid for i in idents], before, after)
+    report.emit(rows, args.gap, before, after)
     return 0
 
 

--- a/scripts/dev/calibration_harness/run_v1.py
+++ b/scripts/dev/calibration_harness/run_v1.py
@@ -20,19 +20,38 @@ from pathlib import Path
 
 from . import report
 from .client import GovernanceClient, Identity
-from .config import CLASSES, EPISODE_COUNT, Transport
+from .config import BINS, CLASSES, EPISODE_COUNT, Transport
 from .runner import run_episode
 from .sampler import plan
 
 SEED = 1729  # fixed -> reproducible
 PROD_URL_MARKERS = (":8767", ":8766")  # the live governance ports on this host
+_LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
 
 
 def _guard_not_prod(base_url: str, force: bool) -> None:
-    if not force and any(m in base_url for m in PROD_URL_MARKERS):
+    """Refuse anything that isn't a loopback address (council C1).
+
+    A port-substring blocklist was theater: a prod server fronted by nginx on
+    80/443 or a remote host without the magic ports would sail through. The
+    isolated instance is always local, so allowlist loopback instead.
+    """
+    if force:
+        return
+    from urllib.parse import urlparse
+
+    host = urlparse(base_url).hostname or ""
+    if host not in _LOOPBACK_HOSTS:
         raise SystemExit(
-            f"REFUSING to run against {base_url!r} — that looks like the live fleet. "
-            "Point GOVERNANCE_HTTP_URL at an isolated test instance, or pass --i-know."
+            f"REFUSING {base_url!r} — not a loopback address. The harness injects "
+            "synthetic failures into the GLOBAL tactical pool; run it only against a "
+            "local isolated instance (governance_test), or pass --i-know."
+        )
+    # belt-and-suspenders: never the known live ports, even on loopback
+    if any(m in base_url for m in PROD_URL_MARKERS):
+        raise SystemExit(
+            f"REFUSING {base_url!r} — that is a live governance port. "
+            "Point GOVERNANCE_HTTP_URL at the isolated instance (e.g. :8771), or pass --i-know."
         )
 
 
@@ -43,6 +62,12 @@ def main() -> int:
     ap.add_argument("--out", type=str, default="data/calibration_harness/run_v1.csv")
     ap.add_argument("--i-know", action="store_true", help="bypass the prod-URL guard")
     args = ap.parse_args()
+
+    if args.episodes < len(BINS):
+        raise SystemExit(
+            f"--episodes must be >= {len(BINS)} (one per confidence bin); got "
+            f"{args.episodes}. Fewer collapses the per-bin plan to empty (council H6)."
+        )
 
     transport = Transport()
     _guard_not_prod(transport.base_url, args.i_know)
@@ -67,14 +92,17 @@ def main() -> int:
 
     after = report.snapshot_tactical(client)
 
-    out = Path(args.out)
-    out.parent.mkdir(parents=True, exist_ok=True)
-    with out.open("w", newline="") as f:
-        w = csv.DictWriter(f, fieldnames=[f.name for f in dataclasses.fields(rows[0])])
-        w.writeheader()
-        for r in rows:
-            w.writerow(dataclasses.asdict(r))
-    print(f"wrote {len(rows)} rows -> {out}")
+    if rows:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        with out.open("w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=[f.name for f in dataclasses.fields(rows[0])])
+            w.writeheader()
+            for r in rows:
+                w.writerow(dataclasses.asdict(r))
+        print(f"wrote {len(rows)} rows -> {out}")
+    else:
+        print("no rows produced; skipping CSV write")
 
     report.emit([i.agent_uuid for i in idents], before, after)
     return 0

--- a/scripts/dev/calibration_harness/run_v1.py
+++ b/scripts/dev/calibration_harness/run_v1.py
@@ -19,7 +19,7 @@ import random
 from pathlib import Path
 
 from . import report
-from .client import GovernanceClient
+from .client import GovernanceClient, GovernanceError
 from .config import BINS, EPISODE_COUNT, HARNESS_AGENT_NAME, Transport
 from .runner import run_slot
 from .sampler import plan
@@ -61,6 +61,9 @@ def main() -> int:
     ap.add_argument("--gap", type=float, default=0.2,
                     help="injected overconfidence gap; report should recover ~ this ECE")
     ap.add_argument("--out", type=str, default="data/calibration_harness/run_v1.csv")
+    ap.add_argument("--transport", choices=["mcp", "rest"], default="mcp",
+                    help="mcp: strong tier (continuity_token) -> no 0.55 cap, full confidence range. "
+                         "rest: weak tier, confidence capped at 0.55 (faster, no per-call handshake).")
     ap.add_argument("--i-know", action="store_true", help="bypass the prod-URL guard")
     args = ap.parse_args()
 
@@ -72,9 +75,15 @@ def main() -> int:
 
     transport = Transport()
     _guard_not_prod(transport.base_url, args.i_know)
-    client = GovernanceClient(transport)
+    if args.transport == "mcp":
+        from .client_mcp import MCPGovernanceClient
+        client = MCPGovernanceClient(transport)
+    else:
+        client = GovernanceClient(transport)
     rng = random.Random(SEED)
 
+    print(f"transport={args.transport} "
+          f"({'strong tier, full confidence range' if args.transport == 'mcp' else 'weak tier, capped at 0.55'})")
     ident = client.onboard(HARNESS_AGENT_NAME)
     print(f"onboarded harness identity: {ident.agent_uuid}")
 
@@ -83,10 +92,24 @@ def main() -> int:
     print(f"planned {len(slots)} episodes against {transport.base_url} (injected gap={args.gap})")
 
     rows = []
+    rotations = 0
     for k, slot in enumerate(slots):
-        rows.append(run_slot(client, ident, slot, rng, args.gap))
+        try:
+            rows.append(run_slot(client, ident, slot, rng, args.gap))
+        except GovernanceError:
+            # The agent accumulates synthetic failures and governance pauses it.
+            # Rotate to a fresh identity (the measurement bins on stated
+            # confidence, so identity is irrelevant) and retry the slot once.
+            rotations += 1
+            ident = client.onboard(HARNESS_AGENT_NAME)
+            try:
+                rows.append(run_slot(client, ident, slot, rng, args.gap))
+            except GovernanceError as e2:
+                print(f"  slot {k} dropped after rotation: {str(e2)[:120]}")
         if (k + 1) % 25 == 0:
             print(f"  {k + 1}/{len(slots)} done")
+    if rotations:
+        print(f"rotated identity {rotations}x (governance paused the agent on synthetic-failure volume)")
 
     after = report.snapshot_tactical(client)
 

--- a/scripts/dev/calibration_harness/run_v1.py
+++ b/scripts/dev/calibration_harness/run_v1.py
@@ -1,0 +1,84 @@
+"""v1 entrypoint: 2 dedicated harness identities, ~200 stratified episodes.
+
+SAFETY: run this ONLY against an isolated governance instance (a server bound
+to governance_test), never the live fleet — the episodes inject synthetic
+failures into the GLOBAL tactical calibration pool, which is agent-unscoped on
+the read side. Guard below refuses the known prod URL unless --i-know.
+
+    # bring up an isolated server first (see README), then:
+    GOVERNANCE_HTTP_URL=http://127.0.0.1:8771 \
+    UNITARES_HTTP_API_TOKEN=<test-token> \
+    python -m scripts.dev.calibration_harness.run_v1 --episodes 200
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import dataclasses
+import random
+from pathlib import Path
+
+from . import report
+from .client import GovernanceClient, Identity
+from .config import CLASSES, EPISODE_COUNT, Transport
+from .runner import run_episode
+from .sampler import plan
+
+SEED = 1729  # fixed -> reproducible
+PROD_URL_MARKERS = (":8767", ":8766")  # the live governance ports on this host
+
+
+def _guard_not_prod(base_url: str, force: bool) -> None:
+    if not force and any(m in base_url for m in PROD_URL_MARKERS):
+        raise SystemExit(
+            f"REFUSING to run against {base_url!r} — that looks like the live fleet. "
+            "Point GOVERNANCE_HTTP_URL at an isolated test instance, or pass --i-know."
+        )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--episodes", type=int, default=EPISODE_COUNT)
+    ap.add_argument("--classes", type=int, default=len(CLASSES))
+    ap.add_argument("--out", type=str, default="data/calibration_harness/run_v1.csv")
+    ap.add_argument("--i-know", action="store_true", help="bypass the prod-URL guard")
+    args = ap.parse_args()
+
+    transport = Transport()
+    _guard_not_prod(transport.base_url, args.i_know)
+    client = GovernanceClient(transport)
+    rng = random.Random(SEED)
+
+    n_classes = max(1, min(args.classes, len(CLASSES)))
+    idents: list[Identity] = [client.onboard(CLASSES[i].display_name) for i in range(n_classes)]
+    print(f"onboarded {n_classes} harness identities: {[i.agent_uuid for i in idents]}")
+
+    before = report.snapshot_tactical(client)
+    episodes = plan(args.episodes)
+    print(f"planned {len(episodes)} episodes against {transport.base_url}")
+
+    rows = []
+    for k, ep in enumerate(episodes):
+        ident = idents[k % n_classes]
+        row = run_episode(client, ident, ep, rng)
+        rows.append(row)
+        if (k + 1) % 25 == 0:
+            print(f"  {k + 1}/{len(episodes)} done")
+
+    after = report.snapshot_tactical(client)
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=[f.name for f in dataclasses.fields(rows[0])])
+        w.writeheader()
+        for r in rows:
+            w.writerow(dataclasses.asdict(r))
+    print(f"wrote {len(rows)} rows -> {out}")
+
+    report.emit([i.agent_uuid for i in idents], before, after)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/calibration_harness/run_v1.py
+++ b/scripts/dev/calibration_harness/run_v1.py
@@ -19,8 +19,8 @@ import random
 from pathlib import Path
 
 from . import report
-from .client import GovernanceClient, Identity
-from .config import BINS, CLASSES, EPISODE_COUNT, Transport
+from .client import GovernanceClient
+from .config import BINS, EPISODE_COUNT, HARNESS_AGENT_NAME, Transport
 from .runner import run_slot
 from .sampler import plan
 
@@ -58,7 +58,6 @@ def _guard_not_prod(base_url: str, force: bool) -> None:
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--episodes", type=int, default=EPISODE_COUNT)
-    ap.add_argument("--classes", type=int, default=len(CLASSES))
     ap.add_argument("--gap", type=float, default=0.2,
                     help="injected overconfidence gap; report should recover ~ this ECE")
     ap.add_argument("--out", type=str, default="data/calibration_harness/run_v1.csv")
@@ -76,9 +75,8 @@ def main() -> int:
     client = GovernanceClient(transport)
     rng = random.Random(SEED)
 
-    n_classes = max(1, min(args.classes, len(CLASSES)))
-    idents: list[Identity] = [client.onboard(CLASSES[i].display_name) for i in range(n_classes)]
-    print(f"onboarded {n_classes} harness identities: {[i.agent_uuid for i in idents]}")
+    ident = client.onboard(HARNESS_AGENT_NAME)
+    print(f"onboarded harness identity: {ident.agent_uuid}")
 
     before = report.snapshot_tactical(client)
     slots = plan(args.episodes)
@@ -86,7 +84,6 @@ def main() -> int:
 
     rows = []
     for k, slot in enumerate(slots):
-        ident = idents[k % n_classes]
         rows.append(run_slot(client, ident, slot, rng, args.gap))
         if (k + 1) % 25 == 0:
             print(f"  {k + 1}/{len(slots)} done")

--- a/scripts/dev/calibration_harness/runner.py
+++ b/scripts/dev/calibration_harness/runner.py
@@ -1,7 +1,10 @@
-"""Per-episode loop: check-in -> attempt (sandboxed) -> grade -> outcome.
+"""Per-slot loop: draw confidence -> draw outcome from the injected curve ->
+check-in -> grade the matching subprocess -> outcome event.
 
-Binding is the whole point: the prediction_id from check-in is threaded into
-the outcome so the registered confidence (not a temporal proxy) is what scores.
+The outcome is decided by `Bernoulli(true_accuracy(confidence; gap))`, then a real
+pass/fail subprocess is run to realize it — so confidence and outcome are coupled
+by the known curve while the graded signal stays exogenous (a real exit code,
+external_signal). Binding is via prediction_id.
 """
 from __future__ import annotations
 
@@ -9,18 +12,19 @@ import random
 from dataclasses import dataclass
 
 from .client import GovernanceClient, Identity
-from .episodes import Episode, elicit_confidence
+from .episodes import CleanControl, SeededTestFail, elicit_confidence
 from .grader import grade_script
+from .miscalibration import true_accuracy
+from .sampler import Slot
 
 
 @dataclass
 class RunRow:
     label: str
-    kind: str
-    tag: str
     target_lo: float
     target_hi: float
     stated_confidence: float
+    injected_p_success: float
     is_bad: bool
     exit_code: int
     prediction_id: str
@@ -28,21 +32,24 @@ class RunRow:
     evidence_weight: float | None
 
 
-def run_episode(client: GovernanceClient, ident: Identity, ep: Episode, rng: random.Random) -> RunRow:
-    conf = elicit_confidence(ep.target_bin, rng)
+def run_slot(client: GovernanceClient, ident: Identity, slot: Slot, rng: random.Random, gap: float) -> RunRow:
+    conf = elicit_confidence(slot.target_bin, rng)
+    p_success = true_accuracy(conf, gap)
+    should_pass = rng.random() < p_success
+    label = f"[{slot.target_bin[0]:.1f}-{slot.target_bin[1]:.1f}]#{slot.index}{':'+slot.tag if slot.tag else ''}"
+
     pred_id = client.check_in(
         ident,
         confidence=conf,
-        response_text=f"[{ep.label}] attempting bounded task; constructed to {'fail' if ep.expected_bad else 'pass'}",
-        task_label=ep.label,
+        response_text=f"{label} confidence={conf:.3f} injected_p={p_success:.3f} -> {'pass' if should_pass else 'fail'}",
+        task_label=label,
     )
 
-    grade = grade_script(ep.build_source(), label=ep.label)
-    # Sanity: the grader must agree with the construction, else the fixture lies.
-    if grade.is_bad != ep.expected_bad:
-        raise RuntimeError(
-            f"{ep.label}: grader/construction mismatch (is_bad={grade.is_bad}, expected={ep.expected_bad})"
-        )
+    # Realize the drawn outcome with a real subprocess (exogenous exit code).
+    src = (CleanControl if should_pass else SeededTestFail)(slot.target_bin, index=slot.index).build_source()
+    grade = grade_script(src, label=label)
+    if grade.is_bad == should_pass:  # pass-source must pass, fail-source must fail
+        raise RuntimeError(f"{label}: subprocess outcome ({not grade.is_bad}) != drawn ({should_pass})")
 
     out = client.record_outcome(
         ident,
@@ -53,12 +60,11 @@ def run_episode(client: GovernanceClient, ident: Identity, ep: Episode, rng: ran
     )
     ew = out.get("evidence_weight")
     return RunRow(
-        label=ep.label,
-        kind=ep.kind,
-        tag=ep.tag,
-        target_lo=ep.target_bin[0],
-        target_hi=ep.target_bin[1],
+        label=label,
+        target_lo=slot.target_bin[0],
+        target_hi=slot.target_bin[1],
         stated_confidence=conf,
+        injected_p_success=round(p_success, 4),
         is_bad=grade.is_bad,
         exit_code=grade.exit_code,
         prediction_id=pred_id,

--- a/scripts/dev/calibration_harness/runner.py
+++ b/scripts/dev/calibration_harness/runner.py
@@ -1,0 +1,67 @@
+"""Per-episode loop: check-in -> attempt (sandboxed) -> grade -> outcome.
+
+Binding is the whole point: the prediction_id from check-in is threaded into
+the outcome so the registered confidence (not a temporal proxy) is what scores.
+"""
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+
+from .client import GovernanceClient, Identity
+from .episodes import Episode, elicit_confidence
+from .grader import grade_script
+
+
+@dataclass
+class RunRow:
+    label: str
+    kind: str
+    tag: str
+    target_lo: float
+    target_hi: float
+    stated_confidence: float
+    is_bad: bool
+    exit_code: int
+    prediction_id: str
+    agent_uuid: str
+    evidence_weight: float | None
+
+
+def run_episode(client: GovernanceClient, ident: Identity, ep: Episode, rng: random.Random) -> RunRow:
+    conf = elicit_confidence(ep.target_bin, rng)
+    pred_id = client.check_in(
+        ident,
+        confidence=conf,
+        response_text=f"[{ep.label}] attempting bounded task; constructed to {'fail' if ep.expected_bad else 'pass'}",
+        task_label=ep.label,
+    )
+
+    grade = grade_script(ep.build_source(), label=ep.label)
+    # Sanity: the grader must agree with the construction, else the fixture lies.
+    if grade.is_bad != ep.expected_bad:
+        raise RuntimeError(
+            f"{ep.label}: grader/construction mismatch (is_bad={grade.is_bad}, expected={ep.expected_bad})"
+        )
+
+    out = client.record_outcome(
+        ident,
+        prediction_id=pred_id,
+        is_bad=grade.is_bad,
+        outcome_score=grade.score,
+        detail=grade.detail,
+    )
+    ew = out.get("evidence_weight")
+    return RunRow(
+        label=ep.label,
+        kind=ep.kind,
+        tag=ep.tag,
+        target_lo=ep.target_bin[0],
+        target_hi=ep.target_bin[1],
+        stated_confidence=conf,
+        is_bad=grade.is_bad,
+        exit_code=grade.exit_code,
+        prediction_id=pred_id,
+        agent_uuid=ident.agent_uuid,
+        evidence_weight=float(ew) if ew is not None else None,
+    )

--- a/scripts/dev/calibration_harness/sampler.py
+++ b/scripts/dev/calibration_harness/sampler.py
@@ -1,28 +1,32 @@
-"""Stratified (confidence_bin x pass/fail) sampler — stratification is the point.
+"""Stratified confidence-bin sampler.
 
-Each bin gets FAIL_RATIO injected failures so BOTH calibration error (per bin)
-AND discrimination (AUC, needs bad_rate > 0) are measurable. An explicit
-overconfidence cell (high bin + injected failure) is appended.
+v1.1: the sampler only stratifies CONFIDENCE across bins. The pass/fail outcome
+is NO LONGER assigned here — it is drawn in the runner from the injected
+calibration curve `true_accuracy(confidence; gap)`, so outcome and confidence are
+coupled by a known relationship the report can recover. (In v1 the outcome was
+assigned by position here, making it independent of confidence — the flaw the
+council caught.)
 """
 from __future__ import annotations
 
-from .config import BINS, EPISODE_COUNT, FAIL_RATIO
-from .episodes import CleanControl, Episode, SeededTestFail
+from dataclasses import dataclass
+
+from .config import BINS, EPISODE_COUNT
 
 
-def plan(n: int = EPISODE_COUNT) -> list[Episode]:
-    episodes: list[Episode] = []
+@dataclass
+class Slot:
+    target_bin: tuple[float, float]
+    index: int
+    tag: str = ""
+
+
+def plan(n: int = EPISODE_COUNT) -> list[Slot]:
+    slots: list[Slot] = []
     per_bin = n // len(BINS)
     idx = 0
     for lo, hi in BINS:
-        n_fail = round(per_bin * FAIL_RATIO)
-        for i in range(per_bin):
-            cls = SeededTestFail if i < n_fail else CleanControl
-            episodes.append(cls((lo, hi), index=idx))
+        for _ in range(per_bin):
+            slots.append(Slot((lo, hi), index=idx))
             idx += 1
-    # Explicit overconfidence probe: high bin + injected failure.
-    hi_lo, hi_hi = BINS[-1]
-    for _ in range(per_bin // 2):
-        episodes.append(SeededTestFail((hi_lo, hi_hi), index=idx, tag="overconfidence_probe"))
-        idx += 1
-    return episodes
+    return slots

--- a/scripts/dev/calibration_harness/sampler.py
+++ b/scripts/dev/calibration_harness/sampler.py
@@ -1,0 +1,28 @@
+"""Stratified (confidence_bin x pass/fail) sampler — stratification is the point.
+
+Each bin gets FAIL_RATIO injected failures so BOTH calibration error (per bin)
+AND discrimination (AUC, needs bad_rate > 0) are measurable. An explicit
+overconfidence cell (high bin + injected failure) is appended.
+"""
+from __future__ import annotations
+
+from .config import BINS, EPISODE_COUNT, FAIL_RATIO
+from .episodes import CleanControl, Episode, SeededTestFail
+
+
+def plan(n: int = EPISODE_COUNT) -> list[Episode]:
+    episodes: list[Episode] = []
+    per_bin = n // len(BINS)
+    idx = 0
+    for lo, hi in BINS:
+        n_fail = round(per_bin * FAIL_RATIO)
+        for i in range(per_bin):
+            cls = SeededTestFail if i < n_fail else CleanControl
+            episodes.append(cls((lo, hi), index=idx))
+            idx += 1
+    # Explicit overconfidence probe: high bin + injected failure.
+    hi_lo, hi_hi = BINS[-1]
+    for _ in range(per_bin // 2):
+        episodes.append(SeededTestFail((hi_lo, hi_hi), index=idx, tag="overconfidence_probe"))
+        idx += 1
+    return episodes

--- a/tests/test_calibration_harness_math.py
+++ b/tests/test_calibration_harness_math.py
@@ -1,0 +1,125 @@
+"""Unit tests for the calibration harness's pure math.
+
+Guards the ECE / AUC / injected-miscalibration computation the council
+scrutinized (scripts/dev/calibration_harness, PR #770). No server needed — these
+are pure functions.
+"""
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from scripts.dev.calibration_harness.miscalibration import (
+    _folded_normal_mean,
+    expected_recovered_ece,
+    injected_ece,
+    true_accuracy,
+)
+from scripts.dev.calibration_harness.report import Pair, compute_auc, compute_ece
+
+BINS = [(0.0, 0.2), (0.2, 0.4), (0.4, 0.6), (0.6, 0.8), (0.8, 1.0)]
+
+
+# --- true_accuracy / injected_ece ------------------------------------------
+
+def test_true_accuracy_subtracts_gap_and_clamps():
+    assert true_accuracy(0.5, 0.2) == pytest.approx(0.3)
+    assert true_accuracy(0.9, 0.0) == pytest.approx(0.9)
+    assert true_accuracy(0.1, 0.2) == 0.0   # clamped at 0
+    assert true_accuracy(1.5, 0.0) == 1.0   # clamped at 1
+
+
+def test_injected_ece_is_mean_abs_gap():
+    # |c - (c-gap)| = gap where the clamp is inactive
+    assert injected_ece([0.5, 0.7, 0.9], 0.2) == pytest.approx(0.2)
+    # clamp active: true_accuracy(0.1,0.2)=0 -> |0.1-0|=0.1
+    assert injected_ece([0.1], 0.2) == pytest.approx(0.1)
+    assert injected_ece([], 0.2) == 0.0
+
+
+# --- folded normal ----------------------------------------------------------
+
+def test_folded_normal_mean_zero_mu():
+    # E|N(0, s^2)| = s * sqrt(2/pi)
+    assert _folded_normal_mean(0.0, 0.1) == pytest.approx(0.1 * math.sqrt(2 / math.pi))
+
+
+def test_folded_normal_mean_zero_sigma_is_abs_mu():
+    assert _folded_normal_mean(-0.3, 0.0) == pytest.approx(0.3)
+    assert _folded_normal_mean(0.25, 0.0) == pytest.approx(0.25)
+
+
+def test_folded_normal_mean_large_mu_approaches_abs_mu():
+    # when mu >> sigma the folded mean ~ |mu|
+    assert _folded_normal_mean(1.0, 0.01) == pytest.approx(1.0, abs=1e-3)
+
+
+# --- expected_recovered_ece (bias-aware target) -----------------------------
+
+def test_expected_ece_is_at_least_injected_and_converges():
+    confs = [i / 1000 for i in range(50, 1000)]  # dense, spread across bins
+    inj = injected_ece(confs, 0.3)
+    exp = expected_recovered_ece(confs, 0.3, BINS)
+    # bias is non-negative, and with many samples per bin it is small
+    assert exp >= inj - 1e-9
+    assert exp == pytest.approx(inj, abs=0.02)
+
+
+def test_expected_ece_has_positive_floor_at_gap_zero():
+    # at perfect calibration injected ECE is 0 but a finite-n estimator is > 0
+    confs = [i / 200 for i in range(10, 200)]  # ~95 samples
+    assert injected_ece(confs, 0.0) == pytest.approx(0.0)
+    assert expected_recovered_ece(confs, 0.0, BINS) > 0.01
+
+
+# --- compute_ece ------------------------------------------------------------
+
+def test_compute_ece_single_bin_known_value():
+    # 4 rows in bin 0.8-1.0, conf 0.9, half succeed -> accuracy 0.5, gap 0.4
+    pairs = [Pair(0.9, True), Pair(0.9, True), Pair(0.9, False), Pair(0.9, False)]
+    ece, table = compute_ece(pairs)
+    assert ece == pytest.approx(0.4)
+    last = [r for r in table if r["bin"] == "0.8-1.0"][0]
+    assert last["accuracy"] == pytest.approx(0.5)
+    assert last["mean_conf"] == pytest.approx(0.9)
+
+
+def test_compute_ece_empty_is_zero_no_crash():
+    ece, table = compute_ece([])
+    assert ece == 0.0
+    assert all(r["count"] == 0 for r in table)
+
+
+def test_compute_ece_bin_boundary_half_open_and_one_inclusive():
+    # 0.2 lands in [0.2,0.4), 1.0 lands in the last bin (hi==1.0 inclusive)
+    pairs = [Pair(0.2, True), Pair(1.0, True)]
+    _, table = compute_ece(pairs)
+    by_bin = {r["bin"]: r["count"] for r in table}
+    assert by_bin["0.2-0.4"] == 1
+    assert by_bin["0.0-0.2"] == 0  # 0.2 is NOT in [0.0,0.2)
+    assert by_bin["0.8-1.0"] == 1  # 1.0 included
+
+
+# --- compute_auc ------------------------------------------------------------
+
+def test_compute_auc_perfect_separation():
+    pairs = [Pair(0.1, False), Pair(0.2, False), Pair(0.8, True), Pair(0.9, True)]
+    assert compute_auc(pairs) == pytest.approx(1.0)
+
+
+def test_compute_auc_inverted_separation():
+    # successes at LOW confidence -> worst discrimination
+    pairs = [Pair(0.1, True), Pair(0.2, True), Pair(0.8, False), Pair(0.9, False)]
+    assert compute_auc(pairs) == pytest.approx(0.0)
+
+
+def test_compute_auc_one_class_is_none():
+    assert compute_auc([Pair(0.5, True), Pair(0.6, True)]) is None
+    assert compute_auc([Pair(0.5, False)]) is None
+
+
+def test_compute_auc_ties_average_to_half():
+    # identical confidences, one of each class -> chance discrimination
+    pairs = [Pair(0.5, True), Pair(0.5, False)]
+    assert compute_auc(pairs) == pytest.approx(0.5)


### PR DESCRIPTION
## What

A `scripts/dev/calibration_harness/` measurement harness that drives the
`confidence → prediction_id → outcome` binding through ground-truth-known
episodes to prove the **tactical calibration plumbing**: the channel populates,
ECE moves, and injected failures make `bad_rate > 0` so AUC is computable.

It is a **synthetic fixture** — confidences are drawn to land in target bins
behind known outcomes. Every number describes "the harness can measure," not
"the fleet is well-calibrated."

Built end-to-end and live-verified against an isolated server bound to
`governance_test`. v1 success criteria all pass at n=40: `bad_rate=0.43`, AUC
computed, tactical channel moved 26→70 samples.

## What the build surfaced (the real value)

Three architectural facts the original design assumed wrong, each pinned against
the live API:

1. **Tactical calibration is global + agent-unscoped.** `calibration check`
   returns `tactical_evidence.scope: "global"` and ignores `agent_id`
   (`admin/calibration.py`). `by_class` is *derived* (ephemeral→engaged_ephemeral
   after ≥3 check-ins), so no private bucket there either. → the harness's
   injected failures cannot be filtered out of the live fleet's calibration, so
   it **must** run against an isolated instance (operator decision). `run_v1`
   guards the prod ports.

2. **The 0.65 evidence-weight gate is real and load-bearing.** A row registers
   into the tactical channel only when `evidence_weight ≥ GRADE_WEIGHTS[TOOL_OBSERVED]
   = 0.65`. `verification_source="external_signal"` → `externally_verified` →
   `1.0` clears it; the grader also includes real `exit_code`/`command` in
   `detail` so the grade is grounded in tool observation, not just the label.

3. **Stated confidence is corrected and capped — REST agents are weak-tier.**
   `phases.py:635-669` applies `apply_confidence_correction` and then
   `min(confidence, 0.55)` when `identity_assurance.tier == "weak"`. REST onboard
   is structurally weak (`caller_proven: false`; #425 synthetic session id), and
   passing `continuity_token` does **not** reach strong over REST. Live: stated
   `0.93` → registered `0.55`; stated `0.138` → registered `0.18`. So **the
   0.6–1.0 bins are unreachable over REST** and v1 measures calibration of the
   corrected/capped confidence in the ≤0.55 region. The v2 lever is strong
   identity over the MCP transport (see README).

Also: `governance_test` lacks the `verification_source` column (migration 039
not applied to the base-DDL test DB); `report.py` reads it from `detail` jsonb,
which is drift-robust.

## Layout

`config / client (REST) / grader (sandboxed subprocess) / episodes (CleanControl,
SeededTestFail) / sampler (stratified + overconfidence cell) / runner / report
(ECE + AUC from per-agent DB rows) / probe_one (single-episode gate) / run_v1`.
README documents run steps, the isolated-instance requirement, and v2 levers.

## Not in v1 (deliberate)

- High confidence bins (blocked by the weak-tier cap — needs MCP-transport
  strong identity).
- No `tests/` unit coverage yet — it's a live-integration harness; the
  `probe_one` gate is the validation. Add fixture-level unit tests if this
  graduates out of `scripts/dev`.

Draft — operator is the merge gate.