### PR TITLE
docs(governance): second-pass council review on operator-vision delegation (follow-up to #769)

### DIFF
--- a/docs/proposals/ADR-001-operator-vision-delegation.md
+++ b/docs/proposals/ADR-001-operator-vision-delegation.md
@@ -99,3 +99,42 @@ Cited code anchors were re-verified directly against the repository when these
 docs were migrated in (the originating session read via `search_code` only).
 Council members independently reached "needs-design-first" from the
 composition-attack and category-error directions respectively.
+
+## Council review (2026-06-16, second pass)
+
+A three-lane parallel adversarial pass (architect/security red-team,
+code-reviewer, live-verifier) re-ran over this ADR and the Track A/B docs after
+they landed in-repo. **The decision stands and is strengthened** — the "operator
+token is not read-only" thesis is now triply grounded (see C4). But the pass
+surfaced five forcing findings: one is premise-level on Track B, one is a live
+standing hole independent of this work, and the Track A runbook's flag model is
+factually wrong. All findings are code-grounded; lane transcripts are
+ephemeral, so the load-bearing anchors are recorded here.
+
+| # | Finding | Evidence | Forces |
+|---|---|---|---|
+| **C1** | **The "single read seam" is a fiction.** Redaction lives only in `query.py` (`list_agents`/`get_agent_metadata`). `observe(action='agent'/'similar'/'compare')`, `dialectic(get/list)`, and `knowledge` provenance emit **raw cross-agent UUIDs with no operator gate** — several `pre_onboard`, reachable unbound under strict. A delegate scoped to `query.py`'s helpers is incomplete and built on a false premise. | `observe/handlers.py:231,307,364,449,593`; `knowledge/handlers.py:337,351`; `dialectic/handlers.py:961-966,1025-1028` | Track B (new prereq) |
+| **C2** | **Reusing the `operator_caller` boolean leaks resume credentials.** That flag also un-redacts `active_session_key` and `api_key`, not just UUID. Routing `caller_can_disclose()` through it hands a delegate the resume secrets. (Confirmed independently by two lanes.) | `query.py:197-201,236,263-269` | Track B design |
+| **C3** | **"Disclosure-only" composes into resume in the default config, and the runbook's flag model is wrong.** Bare-UUID resume refuses only under `strict`, but `UNITARES_IDENTITY_STRICT` defaults to `log`. Two flags are conflated — `STRICT_IDENTITY_REQUIRED` (bool, default false, `identity_bootstrap.py`) vs `UNITARES_IDENTITY_STRICT` (3-mode, `governance_config.py:1019`) — and **neither governs disclosure**. `IPUA_PIN_CHECK_MODE` defaults to `strict`, not `log`. | `handlers.py:795-824`; `governance_config.py:1019,1055,1095` | Track A correction |
+| **C4** | **The operator seam is write-capable, not read-only.** `resolve_operator_identity` mints a `caller_asserted` identity that bypasses every strict write gate (`phases.py` refuses only `server_inferred`). Confirms this ADR's thesis. | `operator.py:188-290`; `http_api.py:282-299`; `phases.py:300-342` | ADR confirmed |
+| **C5** | **Blueprint's gate-axis threat model is mislabeled.** `handle_archive_agent` has no app-level operator gate (transport bearer only); `handle_operator_resume_agent` does not exist (real handler `handle_resume_agent`). Right conclusion, wrong mechanism. | `mutation.py:164-186`; `operations.py:39` | Track B blueprint |
+
+### Non-forcing corrections folded forward
+
+- **Disjoint-token-list gap is unguarded** — needs a fail-closed startup assertion; `wave3a_admin.py:50-60` keeps a duplicate parser.
+- **REST mirror auto-shares the seam** — `list_agents`/`get_agent_metadata` fall through `execute_http_tool` to the same handlers, so any seam change is live on REST immediately; a delegate header must be captured in both `http_api.py:68-77` and `mcp_server.py:~989`, with REST rows in the test matrix. BEAM/Wave-3a has no identity middleware.
+- **`_emit_audit` is mis-cited** — it lives in `src/identity/lineage_lifecycle.py` (keyword-only `details=`), not `identity/handlers.py`.
+- **Divergent duplicate `_STRONG_IDENTITY_SOURCES`** in `services/identity_payloads.py` lacks `operator_token` — two sources of truth.
+- **PR #610 presence-bypass trap** — the delegate gate must key on the *resolved binding*, never header/arg presence (the REST synthetic-CSID path).
+
+### Confirmed clean
+- `verify_agent_ownership` is pure binding-identity → `config(set)` / `dialectic(request)` genuinely untouched by the seam.
+- v3.3-A `_build_public_payload` is write-time content redaction, not caller-keyed — cannot be widened by any caller scope (caveats: the node still carries raw `successor_id`; the `audit.r1_score_audit` read gate is unverified).
+
+### Standing security finding (independent of this ADR)
+
+`observe(action='agent', target_agent_id=<label>)` is an **open two-call
+UUID-disclosure oracle today** (`observe/handlers.py:231`, label-resolvable, no
+caller/operator check) — exactly the hijack the `list_agents` redaction was built
+to stop. This is a live hole, not a Track B footnote, and should be tracked
+separately.

--- a/docs/proposals/track-a-strict-identity-hardening-runbook.md
+++ b/docs/proposals/track-a-strict-identity-hardening-runbook.md
@@ -86,3 +86,28 @@ continues.
 
 After Track A is stable, proceed to Track B (`operator_delegate` design); do not
 delegate operator vision to any agent before Track A is enforced.
+
+## Council correction (2026-06-16) — the flag model above is imprecise
+
+The second-pass council (see ADR-001 §"Council review") refuted this runbook's
+"flip the flag and it's enforced" framing. Corrections, to apply on the next
+revision:
+
+- **There are two distinct flags this runbook conflates.**
+  `STRICT_IDENTITY_REQUIRED` (boolean, default `false`, `identity_bootstrap.py`)
+  gates auto-mint *refusal*; `UNITARES_IDENTITY_STRICT` (`IDENTITY_STRICT_MODE`,
+  three-mode, default `log`, `governance_config.py:1019`) gates the bare-UUID
+  resume path. They are not the same lever.
+- **Neither flag governs identifier disclosure.** Redaction in `query.py` keys on
+  `operator_caller` + `caller_uuid`, resolved independently of any strict flag.
+  Flipping these flags changes *mint/resume* behavior, not who-sees-which-UUID —
+  so Track A is a resume-hardening prerequisite, not a disclosure control.
+- **`IPUA_PIN_CHECK_MODE` already defaults to `strict`** (`governance_config.py:1095`),
+  so the "both default to `log`" claim is wrong for the pin-check leg.
+- **REST/BEAM enforcement gap.** The REST strict gate
+  (`http_tool_service._strict_identity_refusal_or_none`) only short-circuits
+  auto-mint and is disclosure-blind; BEAM/Wave-3a routing runs with no identity
+  middleware at all. Confirm the surface a caller lands on before assuming a flip
+  reaches it.
+- **Track B precondition tightened:** ship the delegate inert unless both resume
+  gates are `strict`, enforced by a startup assertion — not a prose prerequisite.

--- a/docs/proposals/track-b-implementation-blueprint.md
+++ b/docs/proposals/track-b-implementation-blueprint.md
@@ -169,3 +169,40 @@ delegate.
    test-matrix behavior live.
 4. (Option 2) Replace the env allowlist with the per-session grant store behind
    the unchanged `caller_can_disclose` seam.
+
+## Council corrections (2026-06-16) — apply before treating this as apply-ready
+
+The second-pass council (see ADR-001 §"Council review") found this blueprint
+**not yet apply-ready**. Blocking and corrective items:
+
+- **C1 (blocking).** The blueprint assumes a single `query.py` seam. There is
+  not one — `observe`, `dialectic` get/list, and `knowledge` provenance disclose
+  raw cross-agent UUIDs outside it. Centralize disclosure first (Track-B design
+  Prereq 0); otherwise §2's "only behavioral widening" is false by omission.
+- **C2 (blocking).** Do **not** feed the existing `operator_caller` boolean from
+  `caller_can_disclose()`. That flag also un-redacts `active_session_key` and
+  `api_key` (`query.py:197-201,236,263-269`). Introduce a distinct
+  `can_disclose_uuid` parameter consumed only by `_can_disclose_agent_uuid`
+  (`query.py:73-83`); keep `operator_caller` as the sole gate for the
+  session_key/api_key branches.
+- **C5 (factual).** §4 mis-states the write surface. `handle_archive_agent`
+  (`mutation.py:164-186`) has **no** app-level operator gate (transport bearer
+  only); `handle_operator_resume_agent` **does not exist** — the real handler is
+  `handle_resume_agent` (`operations.py:39`). Reclassify both and re-derive their
+  test-matrix rows.
+- **REST mirror (matrix gap).** `list_agents`/`get_agent_metadata` fall through
+  `execute_http_tool` to the same handlers, so any seam change is live on REST
+  immediately. A delegate header must be captured in **both** `http_api.py:68-77`
+  and `mcp_server.py:~989`; add REST rows for both disclosure handlers. BEAM/
+  Wave-3a has no identity middleware.
+- **Disjoint-token-list (gap).** Nothing enforces the operator and delegate
+  allowlists being disjoint; `wave3a_admin.py:50-60` keeps a duplicate parser.
+  Add a single fail-closed startup assertion both parsers consult.
+- **Audit helper (mis-cited).** §5's `_emit_audit` lives in
+  `src/identity/lineage_lifecycle.py` (keyword-only `details=`), not
+  `identity/handlers.py`. Call `await _emit_audit("<event>", agent_id, details={...})`.
+- **Resolution-source caveat.** Keep the delegate out of resolution: never route
+  it through `resolve_operator_identity`, never add a delegate source to
+  `_STRONG_IDENTITY_SOURCES` (note the divergent duplicate in
+  `services/identity_payloads.py`). Gate on the *resolved binding*, never on
+  header/arg presence (the PR #610 synthetic-CSID trap).

--- a/docs/proposals/track-b-operator-delegate-design.md
+++ b/docs/proposals/track-b-operator-delegate-design.md
@@ -93,3 +93,30 @@ write-time content contract and must remain non-bypassable by any delegate scope
 - No change to the resume/ownership model (PATH 0 continuity-token proof, S1-c).
 - No new write or admin capability for agents.
 - No widening of the KG public-payload contract.
+
+## Council finding (2026-06-16) — the "seam already exists" premise is false
+
+The second-pass council (see ADR-001 §"Council review", finding C1) **refuted**
+this design's load-bearing claim that `query.py`'s `_visible_*` helpers are the
+single disclosure seam. They are not: `observe(action='agent'/'similar'/'compare')`
+(`observe/handlers.py:231,307,364,449,593`), `dialectic` get/list
+(`dialectic/handlers.py:961-966,1025-1028`), and `knowledge` provenance
+(`knowledge/handlers.py:337,351`) all emit raw cross-agent UUIDs **without**
+routing through those helpers, several reachable unbound as `pre_onboard` reads.
+
+**Consequence:** an `operator_delegate` scoped to the `query.py` seam is both
+*incomplete* (the operator still cannot reason over lineage exposed only via
+`observe`/`knowledge`) and *unsound as a control* (those surfaces leak to any
+caller regardless of the grant). A real prerequisite is therefore added ahead of
+either Option:
+
+> **Prereq 0 — centralize disclosure.** Inventory every cross-agent
+> identifier-emitting path and route them through one redaction seam before a
+> delegate scope is meaningful. Until then `observe(action='agent')` is an open
+> UUID oracle (ADR-001 standing finding) and the delegate gates nothing.
+
+Additional council findings affecting this design: reusing the `operator_caller`
+boolean would also leak `active_session_key`/`api_key` (C2 — use a field-scoped
+predicate); the operator seam the delegate reuses is write-capable, not read-only
+(C4); and the delegate must never route through `resolve_operator_identity` nor
+appear in `_STRONG_IDENTITY_SOURCES`.


### PR DESCRIPTION
## What

Records a **second-pass, three-lane adversarial council review** over the operator-vision delegation docs merged in #769 (ADR-001 + Track A/B). Appends a council section to each doc, in the repo's established convention (cf. `s10-fleet-aggregation-plan.md` §6). No runtime change.

## Verdict

**ADR-001's decision stands and is strengthened** — "the operator token is not read-only" is now triply grounded. But the pass surfaced findings that block Track B as written and correct Track A's flag model.

### Five forcing findings (full anchors in ADR-001 §"Council review")

- **C1 — the "single read seam" is a fiction.** Redaction lives only in `query.py`; `observe(action='agent'/'similar'/'compare')`, `dialectic(get/list)`, and `knowledge` provenance emit raw cross-agent UUIDs with no operator gate (several `pre_onboard`, reachable unbound). A delegate scoped to that seam is incomplete and built on a false premise → new Track-B **Prereq 0** (centralize disclosure first).
- **C2 — reusing the `operator_caller` boolean leaks resume credentials** (`active_session_key`/`api_key`), not just UUID. Use a field-scoped predicate. *(Confirmed independently by two lanes.)*
- **C3 — Track A's flag model is wrong.** Two flags are conflated (`STRICT_IDENTITY_REQUIRED` vs `UNITARES_IDENTITY_STRICT`) and **neither governs disclosure**; `IPUA_PIN_CHECK_MODE` defaults to `strict`, not `log`.
- **C4 — the operator seam is write-capable, not read-only** (`resolve_operator_identity` mints a `caller_asserted` identity that bypasses strict write gates). Confirms the ADR thesis.
- **C5 — the blueprint mislabels the write-handler gate axes** (`handle_archive_agent` has no app-level operator gate; `handle_operator_resume_agent` doesn't exist).

### Standing security finding (independent of Track B)

`observe(action='agent', target_agent_id=<label>)` is an **open two-call UUID-disclosure oracle today** (`observe/handlers.py:231`, label-resolvable, no caller/operator check) — exactly the hijack `list_agents` redaction was built to stop. Worth tracking as its own issue.

## Files

- `ADR-001-operator-vision-delegation.md` — consolidated council-review section (findings table + corrections + confirmed-clean + standing finding)
- `track-a-strict-identity-hardening-runbook.md` — flag-model correction
- `track-b-operator-delegate-design.md` — C1 premise-refutation + Prereq 0
- `track-b-implementation-blueprint.md` — blocking/corrective items before apply-ready

Draft for operator review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyKQhxKfpda8ki7TXiafBg)_