### PR TITLE
Sensor EISV: compare, don't couple (divergence recording + opt-out flag)

### DIFF
--- a/governance_core/__init__.py
+++ b/governance_core/__init__.py
@@ -27,6 +27,7 @@ from .dynamics import (
     compute_dynamics,
     step_state,
     compute_saturation_diagnostics,
+    eisv_divergence,
 )
 
 from .coherence import (
@@ -101,6 +102,7 @@ __all__ = [
     'compute_dynamics',
     'step_state',
     'compute_saturation_diagnostics',
+    'eisv_divergence',
 
     # Coherence functions
     'coherence',

--- a/governance_core/dynamics.py
+++ b/governance_core/dynamics.py
@@ -70,6 +70,29 @@ class State:
 DEFAULT_STATE = State(E=0.7, I=0.8, S=0.2, V=0.0)
 
 
+def eisv_divergence(sensor_eisv: State, ode_state: State) -> dict:
+    """Per-axis divergence between the body (sensor) and the model (ODE).
+
+    Returns ``sensor - ode`` on each axis plus the L2 magnitude. This is the
+    "compare, don't couple" measurement: the ODE evolves as an independent
+    predictor and the sensor is the measured body, so their sustained
+    disagreement is itself the signal (cf. allostatic load) rather than noise
+    to be sprung away.
+
+    The values are in each axis's NATIVE units and are not comparable across
+    axes: the ODE's V is a signed E-I-imbalance accumulator in [-2, 2], whereas
+    a sensor layer (e.g. Lumen's Pi mapping V=(1-presence)*0.3) may put V in a
+    different range derived from a different quantity. Read the axes
+    individually; treat ``magnitude`` as a coarse "how far apart" scalar only.
+    """
+    dE = sensor_eisv.E - ode_state.E
+    dI = sensor_eisv.I - ode_state.I
+    dS = sensor_eisv.S - ode_state.S
+    dV = sensor_eisv.V - ode_state.V
+    magnitude = (dE * dE + dI * dI + dS * dS + dV * dV) ** 0.5
+    return {"dE": dE, "dI": dI, "dS": dS, "dV": dV, "magnitude": magnitude}
+
+
 def _derivatives(
     state: State,
     d_eta_sq: float,
@@ -137,7 +160,9 @@ def _derivatives(
         - params.delta * V
     )
 
-    # Sensor anchoring: spring coupling to observed sensor state
+    # Sensor anchoring: spring coupling to observed sensor state.
+    # Only reached when coupling is opt-in enabled — compute_dynamics passes
+    # sensor_eisv=None here by default (compare, don't couple).
     if sensor_eisv is not None:
         E_range = params.E_max - params.E_min
         S_range = params.S_max - params.S_min
@@ -275,9 +300,12 @@ def compute_dynamics(
         dt: Time step for integration
         noise_S: Optional noise term for S dynamics
         complexity: Task complexity [0, 1] - increases entropy S (default: 0.5)
-        sensor_eisv: Optional sensor-derived EISV state for anchoring (e.g. from Lumen's Pi).
-            When provided, adds a spring coupling term k_anchor*(sensor - state) to each
-            derivative, preventing the ODE from diverging from physical sensor reality.
+        sensor_eisv: Optional sensor-derived EISV state (e.g. from Lumen's Pi, or
+            the behavioral sensor for non-embodied agents). When coupling is
+            enabled (default; UNITARES_SENSOR_COUPLING), it adds a spring term
+            k_anchor*(sensor - state) to each derivative. When disabled, the ODE
+            evolves independently and callers compare against the sensor via
+            eisv_divergence() ("compare, don't couple").
 
     Returns:
         New state after dt time evolution
@@ -289,17 +317,24 @@ def compute_dynamics(
     d_eta = drift_norm(delta_eta)
     d_eta_sq = d_eta * d_eta
 
+    # Sensor EISV coupling is flag-gated (default ON; see
+    # parameters.sensor_coupling_enabled). When disabled, the ODE evolves as an
+    # independent predictor and callers instead compare the result against the
+    # sensor via eisv_divergence() — "compare, don't couple". Coupling can inject
+    # bias when the sensor->EISV mapping is not commensurate per-axis.
+    from .parameters import get_integrator_mode, sensor_coupling_enabled
+    coupling_sensor = sensor_eisv if sensor_coupling_enabled() else None
+
     # Select integrator
-    from .parameters import get_integrator_mode
     integrator = get_integrator_mode()
 
     if integrator == "euler":
         new_state = _integrate_euler(
-            state, d_eta_sq, theta, params, dt, noise_S, complexity, sensor_eisv,
+            state, d_eta_sq, theta, params, dt, noise_S, complexity, coupling_sensor,
         )
     else:
         new_state = _integrate_rk4(
-            state, d_eta_sq, theta, params, dt, noise_S, complexity, sensor_eisv,
+            state, d_eta_sq, theta, params, dt, noise_S, complexity, coupling_sensor,
         )
 
     # Post-integration: complexity-proportional entropy floor

--- a/governance_core/parameters.py
+++ b/governance_core/parameters.py
@@ -160,6 +160,31 @@ def get_i_dynamics_mode() -> str:
     return os.getenv("UNITARES_I_DYNAMICS", "linear").strip().lower()
 
 
+def sensor_coupling_enabled() -> bool:
+    """
+    Whether sensor-derived EISV spring-couples into the ODE.
+
+    Default ON — preserves current production behavior. This is a fleet-wide
+    switch, NOT Lumen-only: when an agent publishes no physical sensor, a
+    behavioral sensor EISV (derived from governance observables) is injected and
+    also spring-coupled (see src/mcp_handlers/updates/phases.py). Flipping the
+    default therefore changes the dynamics for every agent with ≥3 check-ins.
+
+    The "compare, don't couple" posture (disable this) lets the ODE evolve as an
+    independent predictor and compares the sensor against it via
+    ``governance_core.dynamics.eisv_divergence`` — recording divergence (cf.
+    allostatic load) rather than springing it away. That divergence is recorded
+    regardless of this flag, so an operator can review real divergence data
+    before deciding to cut the spring.
+
+    Disable with UNITARES_SENSOR_COUPLING in {0, false, off, no}.
+    """
+    val = os.getenv("UNITARES_SENSOR_COUPLING")
+    if val is None:
+        return True  # default: coupling on (no behavior change vs. pre-flag)
+    return val.strip().lower() not in {"0", "false", "off", "no"}
+
+
 def get_params_profile_name() -> str:
     """
     Returns the active parameters profile name.

--- a/src/governance_monitor.py
+++ b/src/governance_monitor.py
@@ -50,6 +50,7 @@ from governance_core import (
     State, Theta,
     DEFAULT_STATE, DEFAULT_THETA, DEFAULT_PARAMS,
     step_state, coherence,
+    eisv_divergence,
     phi_objective, verdict_from_phi,  # noqa: F401 — re-exported; consumers import them from this module
     )
 
@@ -254,6 +255,10 @@ class UNITARESMonitor:
         # Previous state for drift calculation
         self.prev_parameters: Optional[np.ndarray] = None
 
+        # Most recent model<->body divergence (compare, don't couple); None until
+        # a check-in arrives carrying sensor_eisv (embodied agents like Lumen).
+        self._last_sensor_divergence: Optional[dict] = None
+
         # Timestamps for agent lifecycle tracking
         self.created_at = datetime.now()
         self.last_update = datetime.now()
@@ -283,6 +288,9 @@ class UNITARESMonitor:
                 beh_data = data.pop('behavioral_eisv', None)
                 if beh_data:
                     self._behavioral_state = BehavioralEISV.from_dict(beh_data)
+                # Restore last divergence snapshot if present (transient; pop so
+                # GovernanceState.from_dict does not see an unknown key).
+                self._last_sensor_divergence = data.pop('sensor_divergence', None)
                 # Restore created_at if persisted; otherwise __init__ will fall
                 # back to now() for older state files that predate this field.
                 created_at_iso = data.pop('created_at_iso', None)
@@ -325,6 +333,11 @@ class UNITARESMonitor:
             state_data = self.state.to_dict_with_history()
             # Include behavioral EISV state for persistence
             state_data['behavioral_eisv'] = self._behavioral_state.to_dict_with_history()
+            # Persist the most recent model<->body divergence snapshot (transient
+            # signal; recomputed each check-in, kept for observability/debugging).
+            last_div = getattr(self, '_last_sensor_divergence', None)
+            if last_div is not None:
+                state_data['sensor_divergence'] = last_div
             # Persist created_at so agent age/maturity survives process restarts.
             created_at = getattr(self, 'created_at', None)
             if created_at is not None:
@@ -499,8 +512,29 @@ class UNITARESMonitor:
             noise_S=calibration_penalty,  # Overconfidence raises entropy
             params=active_params,
             complexity=complexity,  # Complexity now affects S dynamics
-            sensor_eisv=sensor_eisv,  # Spring coupling to physical sensors (if available)
+            sensor_eisv=sensor_eisv,  # Compared (not coupled) unless UNITARES_SENSOR_COUPLING
         )
+
+        # Compare, don't couple: record model<->body divergence as a signal.
+        # The ODE above evolved as an independent predictor; the sensor EISV is
+        # the measured body. Their disagreement (cf. allostatic load) is recorded
+        # for observability rather than sprung away. Coupling is opt-in and
+        # flag-gated inside step_state (see sensor_coupling_enabled()).
+        self._last_sensor_divergence = None
+        if sensor_eisv is not None:
+            self._last_sensor_divergence = eisv_divergence(
+                sensor_eisv, self.state.unitaires_state
+            )
+            logger.debug(
+                "sensor_divergence agent=%s magnitude=%.4f "
+                "dE=%+.3f dI=%+.3f dS=%+.3f dV=%+.3f",
+                self.agent_id,
+                self._last_sensor_divergence["magnitude"],
+                self._last_sensor_divergence["dE"],
+                self._last_sensor_divergence["dI"],
+                self._last_sensor_divergence["dS"],
+                self._last_sensor_divergence["dV"],
+            )
 
         # Epistemic humility safeguard: Enforce entropy floor (S >= 0.001) always
         # Perfect equilibrium (S=0.0) is dangerous and brittle - maintain epistemic humility at all times

--- a/tests/test_governance_core_comprehensive.py
+++ b/tests/test_governance_core_comprehensive.py
@@ -37,6 +37,7 @@ from governance_core import (
 from governance_core.utils import barrier
 from governance_core.dynamics import (
     compute_equilibrium, estimate_convergence, check_basin, compute_saturation_diagnostics,
+    eisv_divergence,
 )
 from governance_core.phase_aware import (
     detect_phase, get_phase_detection_details,
@@ -355,8 +356,9 @@ class TestDynamics:
         assert isinstance(diagnostics, dict)
         assert "will_saturate" in diagnostics or "I_current" in diagnostics
 
-    def test_sensor_anchor_pulls_state_toward_reference(self, default_theta, default_params):
-        """Sensor spring coupling should pull ODE state toward sensor values."""
+    def test_sensor_couples_by_default(self, default_theta, default_params, monkeypatch):
+        """Default ON: spring coupling pulls ODE state toward sensor values."""
+        monkeypatch.delenv("UNITARES_SENSOR_COUPLING", raising=False)
         # ODE state is high-E, sensor state is low-E
         ode_state = State(E=0.9, I=0.9, S=0.02, V=0.0)
         sensor = State(E=0.4, I=0.7, S=0.2, V=0.1)
@@ -374,6 +376,33 @@ class TestDynamics:
         assert new_state.E < ode_state.E
         # S should have increased (pulled toward 0.2 from 0.02)
         assert new_state.S > ode_state.S
+
+    def test_sensor_decoupled_when_disabled(self, default_theta, default_params, monkeypatch):
+        """Compare, don't couple: with coupling disabled a sensor must NOT pull.
+
+        UNITARES_SENSOR_COUPLING=off makes the ODE evolve as an independent
+        predictor — passing a sensor produces a result identical to not passing
+        one. The sensor is only compared against the result (eisv_divergence).
+        """
+        monkeypatch.setenv("UNITARES_SENSOR_COUPLING", "off")
+        ode_state = State(E=0.9, I=0.9, S=0.02, V=0.0)
+        sensor = State(E=0.4, I=0.7, S=0.2, V=0.1)
+
+        with_sensor = compute_dynamics(
+            state=ode_state, delta_eta=[0.0],
+            theta=default_theta, params=default_params, dt=0.1,
+            sensor_eisv=sensor,
+        )
+        without_sensor = compute_dynamics(
+            state=ode_state, delta_eta=[0.0],
+            theta=default_theta, params=default_params, dt=0.1,
+            sensor_eisv=None,
+        )
+
+        assert with_sensor.E == without_sensor.E
+        assert with_sensor.I == without_sensor.I
+        assert with_sensor.S == without_sensor.S
+        assert with_sensor.V == without_sensor.V
 
     def test_no_sensor_anchor_backward_compatible(self, default_state, default_theta, default_params):
         """sensor_eisv=None should produce identical results to not passing it."""
@@ -394,8 +423,9 @@ class TestDynamics:
         assert result_without.S == result_with_none.S
         assert result_without.V == result_with_none.V
 
-    def test_sensor_anchor_respects_bounds(self, default_theta, default_params):
-        """Even with extreme sensor values, state should stay in bounds."""
+    def test_sensor_anchor_respects_bounds(self, default_theta, default_params, monkeypatch):
+        """Even with extreme sensor values (coupling on), state stays in bounds."""
+        monkeypatch.setenv("UNITARES_SENSOR_COUPLING", "1")
         ode_state = State(E=0.5, I=0.5, S=0.5, V=0.0)
         # Extreme sensor values at the edges
         sensor = State(E=1.0, I=0.0, S=2.0, V=2.0)
@@ -410,6 +440,31 @@ class TestDynamics:
         assert 0.0 <= new_state.I <= 1.0
         assert 0.0 <= new_state.S <= 1.0
         assert -1.0 <= new_state.V <= 1.0
+
+    def test_eisv_divergence_signed_per_axis(self):
+        """eisv_divergence returns sensor - ode on each axis, plus L2 magnitude."""
+        sensor = State(E=0.4, I=0.7, S=0.30, V=0.10)
+        ode = State(E=0.9, I=0.6, S=0.02, V=-0.49)
+
+        div = eisv_divergence(sensor, ode)
+
+        assert div["dE"] == pytest.approx(0.4 - 0.9)
+        assert div["dI"] == pytest.approx(0.7 - 0.6)
+        assert div["dS"] == pytest.approx(0.30 - 0.02)
+        assert div["dV"] == pytest.approx(0.10 - (-0.49))
+        expected_mag = math.sqrt(
+            (0.4 - 0.9) ** 2 + (0.7 - 0.6) ** 2
+            + (0.30 - 0.02) ** 2 + (0.10 + 0.49) ** 2
+        )
+        assert div["magnitude"] == pytest.approx(expected_mag)
+
+    def test_eisv_divergence_zero_when_aligned(self):
+        """Identical sensor and ODE states diverge by zero."""
+        s = State(E=0.6, I=0.7, S=0.2, V=0.0)
+        div = eisv_divergence(s, s)
+        assert div["dE"] == 0.0 and div["dI"] == 0.0
+        assert div["dS"] == 0.0 and div["dV"] == 0.0
+        assert div["magnitude"] == 0.0
 
 
 # ============================================================================


### PR DESCRIPTION
## What

Adds **model↔body divergence recording** and a **`UNITARES_SENSOR_COUPLING`** opt-out for sensor spring coupling. **Default is ON — no behavior change.** The spring still pulls the ODE toward the sensor exactly as before; the only new runtime behavior is that per-axis divergence (`sensor − ODE`) is computed, debug-logged, and persisted on every check-in carrying a `sensor_eisv`.

## Why

The sensor→EISV mapping isn't commensurate with the ODE's axes per-axis. Clearest case: Lumen's `V = (1−presence)·0.3` — a grounded body-sense forced into the slot the ODE evolves as a *signed E−I-imbalance accumulator* (`dV/dt = κ(E−I) − δV`). Spring-coupling a non-commensurate axis grounds nothing; it tugs the model toward a quantity that doesn't mean what the slot means. A live trace confirmed the tension: server V ≈ −0.49 while Lumen submits V ≈ +0.10, sustained ~0.6 units apart, with the spring fighting the ODE attractor.

The honest posture is **compare, don't couple**: let the ODE predict independently and treat sustained sensor↔model disagreement as *signal* (cf. allostatic load) rather than springing it away. This PR builds the "wire" (divergence) and the switch; it does not flip behavior.

## ⚠️ Scope: fleet-wide, not Lumen-only

When an agent publishes no physical sensor, a **behavioral** sensor EISV is injected and *also* spring-coupled (`src/mcp_handlers/updates/phases.py:781`, ≥3 check-ins). So disabling coupling changes the dynamics for **every** agent with enough history, not just Lumen. That's why the default is left ON and divergence is recorded unconditionally — so the operator can review real divergence data before deciding whether/where to cut the spring.

## Operator decision (the point of the draft)

1. **Rollout of `UNITARES_SENSOR_COUPLING=off`** — fleet-wide, Lumen-only (physical-sensor agents), or stay coupled and just keep the divergence telemetry?
2. Whether the V-axis costume warrants the deeper follow-ups (honest local valence accumulator for Lumen; the E/I CPU anti-correlation artifact; downstream readers assuming signed-V semantics — viability bounds, CIRS coherence, confidence penalty, `VOID_RISING` expression output).

## Changes
- `governance_core/dynamics.py` — `eisv_divergence(sensor, ode)`; spring gated behind `sensor_coupling_enabled()` in `compute_dynamics`; docstrings.
- `governance_core/parameters.py` — `sensor_coupling_enabled()` (default on; disable via `UNITARES_SENSOR_COUPLING` ∈ {0,false,off,no}).
- `src/governance_monitor.py` — compute + debug-log + persist last divergence.
- tests — default-couples, decoupled-when-disabled, divergence per-axis/zero.

## Tests
196 passing locally across `test_governance_core*`, `test_behavioral_sensor`, `test_update_workflow_service`. Behavior is inert by default; flipping the flag is what changes dynamics.

## Follow-ups (not in this PR)
- Surface divergence in the metrics response / dashboard panel (currently debug-log + persisted state only).