### PR TITLE
fix(identity): reconcile resident tags on check-in (covers BEAM Sentinel)

### DIFF
--- a/src/grounding/onboard_classifier.py
+++ b/src/grounding/onboard_classifier.py
@@ -121,3 +121,127 @@ async def stamp_default_class_tags(
     if meta is not None:
         meta.tags = default_tags
     return default_tags
+
+
+# Process-local memo of resident UUIDs already reconciled (or confirmed
+# healthy) this server process, so the common per-check-in path short-circuits
+# without even re-comparing tags. Bounded by the resident roster, never the
+# ephemeral population (reconcile is a no-op and never memoizes non-residents).
+_reconciled_residents: set[str] = set()
+
+# One-shot guard so the empty-roster warning fires once per process, not on
+# every check-in for every agent.
+_empty_roster_warned = False
+
+
+def _warn_empty_roster_once() -> None:
+    global _empty_roster_warned
+    if _empty_roster_warned:
+        return
+    _empty_roster_warned = True
+    import logging
+
+    logging.getLogger(__name__).warning(
+        "resident-tag reconcile: a resident label arrived but "
+        "KNOWN_RESIDENT_LABELS is empty — UNITARES_RESIDENTS is unset or "
+        "misconfigured. Resident tag reconcile AND the tag_audit endpoint are "
+        "no-ops until it is set; resident tag gaps will not self-heal."
+    )
+
+
+async def reconcile_resident_tags(
+    agent_uuid: str,
+    name: Optional[str] = None,
+    *,
+    meta: Optional[Any] = None,
+) -> Optional[list[str]]:
+    """Re-union ``RESIDENT_DEFAULT_TAGS`` onto an EXISTING resident identity.
+
+    The creation-time stamp (``stamp_default_class_tags``) only fires when an
+    identity is first minted. Residents resume an existing UUID, so that stamp
+    never re-runs. Two ways the required tags then go missing without anything
+    re-adding them:
+
+      - an identity minted before ``autonomous`` was required, an
+        archive/resume cycle, or a tag-replacing ``update_agent`` write; and
+      - a resident that never calls ``onboard`` at all. The BEAM Sentinel
+        only ever attaches ``agent_id`` to ``process_agent_update`` (see
+        ``elixir/sentinel/lib/unitares_sentinel/governance_checkin.ex``), so
+        it has no onboard handshake to stamp from — the SDK-side fix
+        (``GovernanceAgent._reconcile_resident_tags``, #754) never reaches it.
+
+    This is the substrate-agnostic server-side equivalent of #754: every
+    client checks in through ``process_agent_update``, so reconciling on the
+    check-in path covers SDK, BEAM, and REST residents alike. Without it,
+    Vigil's ``resident_tag_hygiene`` flags the gap on every cycle until
+    someone re-tags by hand (Sentinel 2026-06-14/15).
+
+    Additive on purpose: writes the UNION so role/cadence tags (e.g.
+    ``cadence.10min``) survive — ``update_agent`` REPLACES the list. Cheap on
+    the healthy path: a memo hit, or a subset test on in-memory tags; only the
+    rare gap touches the DB. No-op (returns ``None``) for non-resident labels
+    or when the tags are already present. Memoized per UUID per process.
+
+    Semantics note: these are safety-exemption tags, not behavioral signals, so
+    re-adding them restores intended protection rather than hiding a fault.
+    There is no opt-out — a *deliberate* removal of a required tag from a
+    resident is silently reverted on the next check-in (matching the SDK's
+    #754 behavior). If a resident must be subjected to loop-detection
+    pattern 4, use a different lever than tag removal.
+
+    Args:
+      agent_uuid: The resident's identity UUID.
+      name: Label to classify against ``KNOWN_RESIDENT_LABELS``. Falls back to
+        ``meta.label`` when ``None``.
+      meta: In-memory metadata. ``meta.tags`` is the cheap tag source and is
+        updated in place after a write so later reads in the same process see
+        the reconciled set. When ``None`` the current tags are read from PG.
+
+    Returns:
+      The merged tag list that was written, or ``None`` when no write was
+      needed (non-resident, already healthy, or already memoized).
+
+    Non-fatal on exception — caller catches and logs; the gap stays visible to
+    Vigil until a later check-in succeeds.
+    """
+    if agent_uuid in _reconciled_residents:
+        return None
+
+    resolved_name = name
+    if resolved_name is None and meta is not None:
+        resolved_name = getattr(meta, "label", None)
+    if not resolved_name or resolved_name not in KNOWN_RESIDENT_LABELS:
+        # Surface the silent-inert failure mode: if a real label arrives but
+        # the roster is empty, UNITARES_RESIDENTS is unset/misconfigured and
+        # this reconcile (and the audit endpoint) are no-ops fleet-wide. Warn
+        # once per process so a dropped env var on deploy is visible rather
+        # than masquerading as a healthy fleet.
+        if resolved_name and not KNOWN_RESIDENT_LABELS:
+            _warn_empty_roster_once()
+        return None
+
+    from src import agent_storage
+
+    if meta is not None and getattr(meta, "tags", None) is not None:
+        current = list(meta.tags)
+    else:
+        record = await agent_storage.get_agent(agent_uuid)
+        current = list(getattr(record, "tags", None) or []) if record is not None else []
+
+    missing = [t for t in RESIDENT_DEFAULT_TAGS if t not in current]
+    if not missing:
+        # Already healthy — memoize so we don't re-compare every check-in.
+        _reconciled_residents.add(agent_uuid)
+        return None
+
+    merged = current + missing  # additive — preserves role/cadence tags
+    # Persist before the in-memory mutation and before memoizing (P011): a
+    # failed DB write must leave meta.tags untouched and the UUID un-memoized
+    # so the next check-in retries. Two concurrent check-ins that both race
+    # past the memo here will issue an idempotent double-write (same merged
+    # list) — harmless, and bounded to at most once per process per resident.
+    await agent_storage.update_agent(agent_id=agent_uuid, tags=merged)
+    if meta is not None:
+        meta.tags = merged
+    _reconciled_residents.add(agent_uuid)
+    return merged

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -2537,11 +2537,16 @@ async def http_residents(request):
 # Resident tag-hygiene audit — Vigil consumes this to detect tag drift
 # ---------------------------------------------------------------------------
 
-# Tags every active resident must carry. Keep in sync with
+from src.grounding.onboard_classifier import RESIDENT_DEFAULT_TAGS
+
+# Tags every active resident must carry. Single-sourced from the server-side
+# RESIDENT_DEFAULT_TAGS (the same constant the creation-time stamp and the
+# check-in reconcile use) so the audit endpoint and the writers cannot drift
+# apart within this process. Keep in sync with the cross-process SDK copy
 # agents/sdk/src/unitares_sdk/agent.py::RESIDENT_TAGS. The Steward regression
 # of 2026-04-20 was caused by this set drifting across onboarding paths —
 # this endpoint exists so future drift is detectable in production.
-RESIDENT_REQUIRED_TAGS: frozenset[str] = frozenset({"persistent", "autonomous"})
+RESIDENT_REQUIRED_TAGS: frozenset[str] = frozenset(RESIDENT_DEFAULT_TAGS)
 
 
 async def http_resident_tag_audit(request):

--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -426,6 +426,34 @@ async def resolve_identity_and_guards(ctx: UpdateContext) -> Optional[Sequence[T
             meta = mcp_server.agent_metadata[ctx.agent_uuid]
             meta.label = ctx.label
 
+    # Substrate-agnostic resident-tag reconcile: server-side equivalent of the
+    # SDK's GovernanceAgent._reconcile_resident_tags (#754). The creation-time
+    # stamp only fires at mint; residents resume an existing UUID and so never
+    # re-stamp. Crucially this covers the BEAM Sentinel, which never calls
+    # onboard — it only attaches agent_id to this check-in — so an onboard-path
+    # reconcile would never reach it. Memoized + subset-guarded: a no-op on the
+    # healthy path, a single additive write the one time a tag is missing.
+    if not ctx.is_new_agent:
+        try:
+            from src.grounding.onboard_classifier import reconcile_resident_tags
+            _resident_meta = mcp_server.agent_metadata.get(ctx.agent_uuid)
+            # Classify by meta.label (the canonical resident label), same
+            # source the tag_audit endpoint uses. ctx.label is unreliable here:
+            # the BEAM Sentinel attaches agent_id=<uuid>, so ctx.label is the
+            # UUID, not "Sentinel". Fall back to ctx.label only when meta has
+            # no label.
+            _resident_label = getattr(_resident_meta, "label", None) or ctx.label
+            reconciled = await reconcile_resident_tags(
+                ctx.agent_uuid, _resident_label, meta=_resident_meta
+            )
+            if reconciled is not None:
+                logger.info(
+                    f"[CHECKIN] resident-tag reconcile: {ctx.agent_uuid[:8]}... "
+                    f"-> {reconciled} (label={ctx.label!r})"
+                )
+        except Exception as e:
+            logger.debug(f"resident-tag reconcile failed (non-fatal): {e}")
+
     ctx.loop = asyncio.get_running_loop()
     ctx.key_was_generated = False
     ctx.api_key_auto_retrieved = False

--- a/tests/test_onboard_classifier.py
+++ b/tests/test_onboard_classifier.py
@@ -175,6 +175,160 @@ async def test_stamp_does_not_mutate_meta_when_persist_fails():
     fake_update.assert_awaited_once()
 
 
+# --- reconcile_resident_tags: server-side resume-equivalent reconcile (#754
+# server-side companion). Covers the BEAM Sentinel, which never calls onboard
+# and so never hits the creation-time stamp; it only attaches agent_id to
+# process_agent_update. -------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_reconcile_memo():
+    """The reconcile memo is process-global module state; clear it around each
+    test so memoization from one case never masks a write expected by another."""
+    from src.grounding import onboard_classifier
+    onboard_classifier._reconciled_residents.clear()
+    yield
+    onboard_classifier._reconciled_residents.clear()
+
+
+async def _run_reconcile(name, tags, *, missing_meta=False, meta_label=None, db_tags=None):
+    meta = None if missing_meta else _make_meta(tags=tags, label=meta_label)
+    agent_uuid = "uuid-resident-1"
+    fake_update = AsyncMock()
+    fake_get = AsyncMock(return_value=_make_meta(tags=db_tags) if db_tags is not None else None)
+
+    with patch("src.agent_storage.update_agent", fake_update), patch(
+        "src.agent_storage.get_agent", fake_get
+    ):
+        from src.grounding.onboard_classifier import reconcile_resident_tags
+        result = await reconcile_resident_tags(agent_uuid, name, meta=meta)
+
+    return meta, fake_update, result
+
+
+@pytest.mark.asyncio
+async def test_reconcile_adds_missing_autonomous_tag():
+    """The live Sentinel gap: persistent present, autonomous missing."""
+    meta, fake_update, result = await _run_reconcile("Sentinel", ["Sentinel", "persistent"])
+    assert result == ["Sentinel", "persistent", "autonomous"]
+    assert meta.tags == ["Sentinel", "persistent", "autonomous"]
+    fake_update.assert_awaited_once_with(
+        agent_id="uuid-resident-1", tags=["Sentinel", "persistent", "autonomous"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconcile_is_additive_preserving_role_tags():
+    """update_agent REPLACES, so the union must keep cadence/role tags."""
+    meta, fake_update, result = await _run_reconcile(
+        "Vigil", ["Vigil", "persistent", "cadence.30min"]
+    )
+    assert result == ["Vigil", "persistent", "cadence.30min", "autonomous"]
+    assert "cadence.30min" in meta.tags
+    fake_update.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_healthy_resident_is_noop():
+    meta, fake_update, result = await _run_reconcile(
+        "Sentinel", ["Sentinel", "persistent", "autonomous"]
+    )
+    assert result is None
+    fake_update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_non_resident_label_is_noop():
+    meta, fake_update, result = await _run_reconcile("claude_desktop-claude", [])
+    assert result is None
+    fake_update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_writes_both_when_all_missing():
+    meta, fake_update, result = await _run_reconcile("Steward", ["Steward"])
+    assert result == ["Steward", "persistent", "autonomous"]
+    fake_update.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_name_none_falls_back_to_meta_label():
+    meta, fake_update, result = await _run_reconcile(
+        None, ["Watcher", "persistent"], meta_label="Watcher"
+    )
+    assert result == ["Watcher", "persistent", "autonomous"]
+
+
+@pytest.mark.asyncio
+async def test_reconcile_reads_db_tags_when_meta_absent():
+    """No in-memory meta — current tags come from PG so we don't clobber."""
+    meta, fake_update, result = await _run_reconcile(
+        "Sentinel", None, missing_meta=True, db_tags=["Sentinel", "persistent"]
+    )
+    assert result == ["Sentinel", "persistent", "autonomous"]
+    fake_update.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_memoizes_after_success():
+    """Second call for the same UUID short-circuits — no second DB touch."""
+    from src.grounding.onboard_classifier import reconcile_resident_tags
+    meta = _make_meta(tags=["Sentinel", "persistent"], label="Sentinel")
+    fake_update = AsyncMock()
+    with patch("src.agent_storage.update_agent", fake_update):
+        first = await reconcile_resident_tags("uuid-memo", "Sentinel", meta=meta)
+        second = await reconcile_resident_tags("uuid-memo", "Sentinel", meta=meta)
+    assert first == ["Sentinel", "persistent", "autonomous"]
+    assert second is None
+    fake_update.assert_awaited_once()  # only the first call wrote
+
+
+@pytest.mark.asyncio
+async def test_reconcile_healthy_resident_is_memoized():
+    """A healthy resident memoizes too, so we stop re-comparing every check-in."""
+    from src.grounding import onboard_classifier as oc
+    meta = _make_meta(tags=["Sentinel", "persistent", "autonomous"], label="Sentinel")
+    await oc.reconcile_resident_tags("uuid-healthy", "Sentinel", meta=meta)
+    assert "uuid-healthy" in oc._reconciled_residents
+
+
+@pytest.mark.asyncio
+async def test_reconcile_warns_once_when_roster_empty():
+    """A real label with an empty roster means UNITARES_RESIDENTS is unset —
+    warn once so the silent-inert deploy is visible, and still no-op."""
+    from src.grounding import onboard_classifier as oc
+    oc._empty_roster_warned = False
+    fake_update = AsyncMock()
+    with patch.object(oc, "KNOWN_RESIDENT_LABELS", frozenset()), patch(
+        "src.agent_storage.update_agent", fake_update
+    ), patch.object(oc, "_warn_empty_roster_once", wraps=oc._warn_empty_roster_once) as warn:
+        r1 = await oc.reconcile_resident_tags(
+            "uuid-empty-1", "Sentinel", meta=_make_meta(tags=["Sentinel"], label="Sentinel")
+        )
+        r2 = await oc.reconcile_resident_tags(
+            "uuid-empty-2", "Sentinel", meta=_make_meta(tags=["Sentinel"], label="Sentinel")
+        )
+    assert r1 is None and r2 is None
+    fake_update.assert_not_awaited()
+    assert warn.call_count == 2  # guard is invoked each time...
+    # ...but the underlying logger.warning fires only once (guarded by the flag)
+    oc._empty_roster_warned = False
+
+
+@pytest.mark.asyncio
+async def test_reconcile_does_not_mutate_meta_or_memoize_on_persist_failure():
+    """P011-style: persist before in-memory mutation, and don't memoize a
+    failed write — the next check-in must retry."""
+    from src.grounding import onboard_classifier as oc
+    meta = _make_meta(tags=["Sentinel", "persistent"], label="Sentinel")
+    fake_update = AsyncMock(side_effect=RuntimeError("PG unavailable"))
+    with patch("src.agent_storage.update_agent", fake_update):
+        with pytest.raises(RuntimeError):
+            await oc.reconcile_resident_tags("uuid-fail", "Sentinel", meta=meta)
+    assert meta.tags == ["Sentinel", "persistent"]
+    assert "uuid-fail" not in oc._reconciled_residents
+
+
 @pytest.mark.asyncio
 async def test_onboard_wrapper_still_calls_through():
     """The thin ``_stamp_default_tags_on_onboard`` wrapper in identity/handlers.py


### PR DESCRIPTION
## Problem

Vigil's `resident_tag_hygiene` check flagged the live **Sentinel** (`f92dcea8`) as missing the `autonomous` tag — the loop-detection pattern-4 exemption. Without it, pause verdicts can silently starve a resident's state writes (the same single-tag-stamp class as the Steward 2026-04-20 incident, which went 3 days with zero `core.agent_state` rows). Tags were `["Sentinel", "persistent"]`.

**Fixed live** (union-safe re-tag → `{Sentinel, persistent, autonomous}`, audit clean), but the gap recurs by design.

## Root cause

The creation-time stamp (`stamp_default_class_tags`) only fires at mint. The SDK added `_reconcile_resident_tags` on resume (#754) — but Sentinel migrated off the SDK to the **BEAM agent** (`com.unitares.sentinel-beam`; old `sentinel.plist` is `.retired`). The BEAM agent **never calls `onboard`** — it only attaches `agent_id=<uuid>` to `process_agent_update` REST calls — so it escapes the SDK reconcile, and Vigil re-flags it every cycle.

## Fix

Substrate-agnostic **server-side reconcile on the check-in path** (`resolve_identity_and_guards`). Every client — SDK, BEAM, REST — checks in through `process_agent_update`, so reconciling here covers them all.

- Classifies by `meta.label` (the canonical resident label the `tag_audit` endpoint uses), **not** the passed `agent_id` — the BEAM agent passes the UUID.
- Additive union preserves role/cadence tags (`update_agent` REPLACES).
- Persist-before-mutate + don't-memoize-on-failure (P011).
- Process-local memo + subset guard → no-op on the healthy path (Sentinel has ~14.9k updates).
- Single-sources `RESIDENT_REQUIRED_TAGS` (http_api) from `RESIDENT_DEFAULT_TAGS` to retire one in-process drift surface.
- Warns once when `UNITARES_RESIDENTS` is empty, so a misconfigured deploy surfaces instead of being silently inert.

## Verification

Council-reviewed (architect + adversarial code-reviewer + live-verifier). Live-verifier confirmed **4/4** runtime claims against the running server:
1. `meta.label == "Sentinel"` ✓
2. BEAM agent passes `agent_id=<uuid>`, never onboards ✓
3. REST `process_agent_update` → `resolve_identity_and_guards` (no bypass) ✓
4. `UNITARES_RESIDENTS` set live → reconcile is active, not a no-op ✓

Tests: `tests/test_onboard_classifier.py` (+10 cases for `reconcile_resident_tags`), 231 check-in-path tests green, ruff clean.

## Deploy note

This is runtime code on the identity/onboarding surface — operator is the merge gate. After merge + deploy + governance-mcp restart, the BEAM Sentinel's next check-in reconciles automatically; verify via `curl -s http://localhost:8767/v1/residents/tag_audit` showing `missing: {}`.