### PR TITLE
Make calibration-harness synthetic marking functional (exclude from calibration)

### DIFF
--- a/scripts/analysis/eisv_skeptic_report.py
+++ b/scripts/analysis/eisv_skeptic_report.py
@@ -30,6 +30,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Sequence
 
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.analysis.outcome_inventory import is_controlled_validation_fixture
+
 
 DEFAULT_DB_URL = os.environ.get(
     "GOVERNANCE_DATABASE_URL",
@@ -1062,7 +1067,13 @@ async def fetch_rows(
         )
     finally:
         await conn.close()
-    return [_row_from_record(record) for record in records]
+    return [
+        row
+        for record in records
+        if not is_controlled_validation_fixture(
+            (row := _row_from_record(record)).detail
+        )
+    ]
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:

--- a/scripts/analysis/outcome_inventory.py
+++ b/scripts/analysis/outcome_inventory.py
@@ -120,6 +120,37 @@ def _normalized_detail(detail: Mapping[str, Any] | str | None) -> Mapping[str, A
     return detail if isinstance(detail, Mapping) else {}
 
 
+_CONTROLLED_FIXTURE_FLAGS = frozenset(
+    {
+        "synthetic_calibration_fixture",
+        "synthetic_negative_control",
+        "do_not_use_for_live_validation",
+        "do_not_persist",
+        "calibration_excluded",
+    }
+)
+_CONTROLLED_FIXTURE_BINDINGS = frozenset({"synthetic_negative_control"})
+_CONTROLLED_FIXTURE_TEST_NAMES = frozenset({"clean_control", "overconfidence_probe"})
+
+
+def is_controlled_validation_fixture(detail: Mapping[str, Any] | str | None) -> bool:
+    """Return whether an outcome detail belongs to a controlled validation fixture.
+
+    These rows are useful for harness plumbing and local red-team checks, but they
+    must not be counted as live fleet validation evidence. Keep this deliberately
+    conservative: explicit fixture flags win, and the legacy one-shot calibration
+    probe names cover rows written before the flags existed.
+    """
+    normalized = _normalized_detail(detail)
+    if any(_truthy(normalized.get(flag)) for flag in _CONTROLLED_FIXTURE_FLAGS):
+        return True
+    binding = normalized.get("prediction_binding")
+    if binding in _CONTROLLED_FIXTURE_BINDINGS:
+        return True
+    test_name = normalized.get("test_name")
+    return bool(test_name in _CONTROLLED_FIXTURE_TEST_NAMES)
+
+
 def _verification_source(row: OutcomeInventoryRow) -> str:
     """Prefer promoted verification_source column; fall back to detail JSON."""
     if row.verification_source:
@@ -403,7 +434,13 @@ async def fetch_rows(
         records = await conn.fetch(_build_fetch_query(leads), window_days, *leads)
     finally:
         await conn.close()
-    return [_row_from_record(record, leads) for record in records]
+    return [
+        row
+        for record in records
+        if not is_controlled_validation_fixture(
+            (row := _row_from_record(record, leads)).detail
+        )
+    ]
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:

--- a/scripts/dev/calibration_harness/README.md
+++ b/scripts/dev/calibration_harness/README.md
@@ -26,6 +26,16 @@ So v1 runs against a **dedicated server bound to `governance_test`**. That gives
 the isolated server its own calibration singleton; its global pool *is* the
 harness rows. `run_v1` refuses the live ports (`:8767`/`:8766`) unless `--i-know`.
 
+**Defense-in-depth (server-side exclusion).** The grader marks every row
+`detail.synthetic_calibration_fixture=true`, and the server now acts on it:
+`outcome_events` PERSISTS such rows but skips calibration registration entirely
+(`record_prediction` / `record_tactical_decision`). So even if the harness were
+accidentally pointed at live governance, its synthetic outcomes cannot poison the
+global tactical/strategic channels. The harness verifies this itself — `probe_one`
+and the report's SECONDARY check confirm the global channel count does NOT move
+(`delta ~ 0`). This is belt-and-suspenders behind the loopback guard, and it makes
+the self-marking functional rather than merely forensic.
+
 > `governance_test` is currently 2 migrations behind prod (046 vs 048). 047
 > (knowledge CHECK widen) and 048 (un-onboarded check-in floor) do not touch the
 > onboard → check-in → outcome → calibration path the harness uses, so 046 is

--- a/scripts/dev/calibration_harness/grader.py
+++ b/scripts/dev/calibration_harness/grader.py
@@ -58,7 +58,15 @@ def grade_script(source: str, *, label: str, timeout_s: float = 15.0) -> Grade:
         "exit_code": exit_code,
         "command": " ".join(cmd),
         "test_name": label,
+        # Calibration-harness rows are controlled fixtures. They are allowed to
+        # persist inside the isolated governance_test instance, but must be
+        # recognizable if accidentally pointed at live governance.
+        "synthetic_calibration_fixture": True,
+        "do_not_use_for_live_validation": True,
+        "fixture_scope": "calibration_harness",
     }
+    if is_bad:
+        detail["red_team_fixture"] = "calibration_harness_seeded_bad_outcome"
     if stderr_tail:
         detail["error_message"] = stderr_tail
     return Grade(is_bad=is_bad, score=0.0 if is_bad else 1.0, exit_code=exit_code, detail=detail)

--- a/scripts/dev/calibration_harness/probe_one.py
+++ b/scripts/dev/calibration_harness/probe_one.py
@@ -13,11 +13,13 @@ Run:  python -m scripts.dev.calibration_harness.probe_one
 """
 from __future__ import annotations
 
-import json
+import argparse
+from collections.abc import Sequence
 
 from .client import GovernanceClient
-from .config import MIN_TACTICAL_EVIDENCE_WEIGHT
+from .config import MIN_TACTICAL_EVIDENCE_WEIGHT, Transport
 from .grader import grade_script
+from .run_v1 import _guard_not_prod
 
 PASS_SCRIPT = "assert 1 + 1 == 2\n"
 FAIL_SCRIPT = "import sys\nassert 2 + 2 == 5, 'seeded failure'\nsys.exit(0)\n"
@@ -41,13 +43,29 @@ def _find_evidence_weight(resp: dict):
     return None, None
 
 
-def main() -> int:
-    client = GovernanceClient()
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments for the one-shot calibration probe."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--i-know", action="store_true", help="bypass the prod-URL guard")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    transport = Transport()
+    _guard_not_prod(transport.base_url, args.i_know)
+    client = GovernanceClient(transport)
 
     print("== onboard (dedicated quarantined identity) ==")
     ident = client.onboard("calib-harness-probe")
     print(f"agent_uuid={ident.agent_uuid}  client_session_id={ident.client_session_id}")
     print("onboard result keys:", list(ident.raw)[:20])
+
+    def _tests_count() -> int:
+        te = (client.calibration_check(ident).get("tactical_evidence", {}) or {})
+        return (te.get("signal_sources") or {}).get("tests") or 0
+
+    before_tests = _tests_count()
 
     episodes = [
         ("clean_control", 0.90, PASS_SCRIPT, False),
@@ -82,21 +100,19 @@ def main() -> int:
             print(f"  !! GATE FAIL: need evidence_weight >= {MIN_TACTICAL_EVIDENCE_WEIGHT} to register tactically")
             ok = False
 
-    print("\n== calibration check (tactical channel; global-scope, isolated instance) ==")
-    cal = client.calibration_check(ident)
-    te = cal.get("tactical_evidence", {}) or {}
-    health = (cal.get("per_channel_health") or {}).get("tests", {}) or {}
-    print("tactical_evidence:", json.dumps(te)[:300])
-    print("per_channel_health.tests:", json.dumps(health))
-    tests_n = (te.get("signal_sources") or {}).get("tests") or 0
-    if tests_n < 1:
-        print("  !! GATE FAIL: tactical 'tests' channel did not register the outcomes")
+    print("\n== quarantine check (synthetic rows must NOT train calibration) ==")
+    after_tests = _tests_count()
+    delta = after_tests - before_tests
+    print(f"tactical 'tests' count: {before_tests} -> {after_tests} (delta={delta})")
+    # The grader marks every row synthetic_calibration_fixture=True, so the
+    # server-side guard excludes them: the global channel must NOT gain our rows.
+    if delta >= len(episodes):
+        print("  !! GATE FAIL: synthetic rows registered into the global channel (exclusion broken)")
         ok = False
-    if (health.get("bad_rate") or 0) <= 0:
-        print("  !! GATE FAIL: bad_rate still 0 -> AUC not computable")
-        ok = False
+    else:
+        print(f"  synthetic rows excluded from the global channel (delta < {len(episodes)}) — quarantine OK")
 
-    print("\nRESULT:", "PASS — spine corroborated, safe to scale" if ok else "FAIL — fix before scaling")
+    print("\nRESULT:", "PASS — binding corroborated + quarantine enforced" if ok else "FAIL — fix before scaling")
     return 0 if ok else 1
 
 

--- a/scripts/dev/calibration_harness/report.py
+++ b/scripts/dev/calibration_harness/report.py
@@ -113,15 +113,19 @@ def emit(rows, gap: float, before: dict, after: dict) -> dict:
         gp = "-" if r["gap"] is None else f"{r['gap']:.3f}"
         print(f"  {r['bin']:<10} {r['count']:>4} {mc:>10} {ac:>9} {gp:>7}")
 
-    print("\nSECONDARY — server tactical channel (registered/capped confidence, global):")
-    print(f"  eligible_samples: {before['eligible_samples']} -> {after['eligible_samples']}")
-    print(f"  tests bad_rate:   {before['tests_bad_rate']} -> {after['tests_bad_rate']}")
-    print(f"  server tactical ECE: {before['server_ece']} -> {after['server_ece']}")
+    # Quarantine check: the grader marks every row synthetic_calibration_fixture,
+    # so the server guard excludes them — the global channel must NOT gain our
+    # rows. delta ~ 0 means the quarantine held; delta ~ len(rows) means it leaked.
+    delta = (after["eligible_samples"] or 0) - (before["eligible_samples"] or 0)
+    quarantine_ok = delta < max(1, len(pairs) * 0.5)
+    print("\nSECONDARY — quarantine (synthetic rows must be excluded from the global channel):")
+    print(f"  global eligible_samples: {before['eligible_samples']} -> {after['eligible_samples']} (delta={delta})")
+    print(f"  {'excluded (quarantine held)' if quarantine_ok else 'LEAKED into global calibration!'}")
 
-    print("\nv1.1 success criteria:")
+    print("\nsuccess criteria:")
     print(f"  [{'x' if ok_ece else ' '}] recovered ECE matches bias-aware expected within 0.05 (measurement sound)")
     print(f"  [{'x' if auc is not None and auc > 0.5 else ' '}] AUC > 0.5 (confidence now discriminates)")
-    print(f"  [{'x' if (after['eligible_samples'] or 0) > (before['eligible_samples'] or 0) else ' '}] tactical channel moved")
+    print(f"  [{'x' if quarantine_ok else ' '}] synthetic rows excluded from the global channel (quarantine enforced)")
     print("==================================================================\n")
     return {"injected_ece": injected, "expected_ece": expected, "recovered_ece": recovered_ece,
-            "ece_err": ece_err, "auc": auc, "rows": len(pairs), "ok": ok_ece}
+            "ece_err": ece_err, "auc": auc, "rows": len(pairs), "ok": ok_ece and quarantine_ok}

--- a/src/mcp_handlers/observability/outcome_events.py
+++ b/src/mcp_handlers/observability/outcome_events.py
@@ -52,6 +52,17 @@ HARD_EXOGENOUS_TYPES = frozenset({
     "task_completed", "task_failed",
 })
 
+_CONTROLLED_FIXTURE_FLAGS = frozenset(
+    {
+        "synthetic_calibration_fixture",
+        "do_not_use_for_live_validation",
+        "synthetic_negative_control",
+        "do_not_persist",
+        "calibration_excluded",
+    }
+)
+_CONTROLLED_FIXTURE_BINDINGS = frozenset({"synthetic_negative_control"})
+
 _HARD_EXOGENOUS_TYPE_TO_CHANNEL = {
     "test_passed": "tests", "test_failed": "tests",
     "task_completed": "tasks", "task_failed": "tasks",
@@ -67,6 +78,26 @@ def _classify_hard_exogenous_signal(outcome_type: str, detail: Dict[str, Any]) -
         if detail.get(key):
             return label
     return None
+
+
+def _truthy_detail_flag(value: Any) -> bool:
+    """Interpret JSON-ish fixture flags conservatively."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "t", "yes", "y"}
+    return False
+
+
+def _is_controlled_validation_fixture(detail: Dict[str, Any]) -> bool:
+    """Return whether an outcome is self-declared controlled fixture evidence."""
+    if any(_truthy_detail_flag(detail.get(flag)) for flag in _CONTROLLED_FIXTURE_FLAGS):
+        return True
+    binding = detail.get("prediction_binding")
+    return bool(binding in _CONTROLLED_FIXTURE_BINDINGS)
+
 
 async def _record_outcome_event_inline(arguments: Dict[str, Any]) -> Dict[str, Any]:
     """Shared body for outcome_event recording.
@@ -287,8 +318,9 @@ async def _record_outcome_event_inline(arguments: Dict[str, Any]) -> Dict[str, A
     # NEVER train calibration — otherwise a fixture accidentally pointed at live
     # governance would poison the global tactical/strategic channels. This is the
     # functional half of the harness's self-marking (the detail flag alone is
-    # only a forensic breadcrumb without this guard).
-    calibration_excluded = bool(detail.get("synthetic_calibration_fixture"))
+    # only a forensic breadcrumb without this guard). Treat older red-team
+    # fixture boundary flags as equivalent calibration exclusions too.
+    calibration_excluded = _is_controlled_validation_fixture(detail)
     hard_exogenous_signal = _classify_hard_exogenous_signal(outcome_type, detail)
     if evidence_weight < _MIN_TACTICAL_EVIDENCE_WEIGHT or calibration_excluded:
         hard_exogenous_signal = None

--- a/src/mcp_handlers/observability/outcome_events.py
+++ b/src/mcp_handlers/observability/outcome_events.py
@@ -282,8 +282,15 @@ async def _record_outcome_event_inline(arguments: Dict[str, Any]) -> Dict[str, A
         verification_source=verification_source,
     )
     evidence_weight = float(detail.get("evidence_weight") or 0.0)
+    # A row that declares itself a synthetic fixture (e.g. the calibration
+    # harness) is PERSISTED for the author's own per-agent analysis but must
+    # NEVER train calibration — otherwise a fixture accidentally pointed at live
+    # governance would poison the global tactical/strategic channels. This is the
+    # functional half of the harness's self-marking (the detail flag alone is
+    # only a forensic breadcrumb without this guard).
+    calibration_excluded = bool(detail.get("synthetic_calibration_fixture"))
     hard_exogenous_signal = _classify_hard_exogenous_signal(outcome_type, detail)
-    if evidence_weight < _MIN_TACTICAL_EVIDENCE_WEIGHT:
+    if evidence_weight < _MIN_TACTICAL_EVIDENCE_WEIGHT or calibration_excluded:
         hard_exogenous_signal = None
     eprocess_eligible = bool(hard_exogenous_signal and _confidence is not None)
 
@@ -292,6 +299,7 @@ async def _record_outcome_event_inline(arguments: Dict[str, Any]) -> Dict[str, A
     detail["hard_exogenous_signal"] = hard_exogenous_signal
     detail["hard_exogenous"] = bool(hard_exogenous_signal)
     detail["eprocess_eligible"] = eprocess_eligible
+    detail["calibration_excluded"] = calibration_excluded
     detail["prediction_id"] = prediction_id
     detail["prediction_source"] = prediction_source
     detail["prediction_binding"] = prediction_binding
@@ -323,8 +331,9 @@ async def _record_outcome_event_inline(arguments: Dict[str, Any]) -> Dict[str, A
         outcome_type, is_bad, outcome_score, agent_id, eisv_verdict,
     )
 
-    # Record calibration from outcome event
-    if _confidence is not None and evidence_weight >= _MIN_TACTICAL_EVIDENCE_WEIGHT:
+    # Record calibration from outcome event (never for self-declared synthetic
+    # fixtures — they persist above but do not train the calibration channels).
+    if _confidence is not None and evidence_weight >= _MIN_TACTICAL_EVIDENCE_WEIGHT and not calibration_excluded:
         try:
             from src.calibration import calibration_checker
             calibration_checker.record_prediction(

--- a/tests/test_calibration_harness_safety.py
+++ b/tests/test_calibration_harness_safety.py
@@ -1,0 +1,25 @@
+"""Safety regressions for the synthetic calibration harness."""
+from __future__ import annotations
+
+import pytest
+
+from scripts.dev.calibration_harness.grader import grade_script
+from scripts.dev.calibration_harness.run_v1 import _guard_not_prod
+
+
+def test_calibration_harness_grades_are_marked_controlled_fixtures() -> None:
+    grade = grade_script("assert 2 + 2 == 5, 'seeded failure'\n", label="overconfidence_probe")
+
+    assert grade.is_bad is True
+    assert grade.detail["synthetic_calibration_fixture"] is True
+    assert grade.detail["do_not_use_for_live_validation"] is True
+    assert grade.detail["fixture_scope"] == "calibration_harness"
+    assert grade.detail["red_team_fixture"] == "calibration_harness_seeded_bad_outcome"
+
+
+def test_calibration_harness_guard_rejects_live_governance_ports() -> None:
+    with pytest.raises(SystemExit, match="live governance port"):
+        _guard_not_prod("http://127.0.0.1:8767", force=False)
+
+    _guard_not_prod("http://127.0.0.1:8771", force=False)
+    _guard_not_prod("http://127.0.0.1:8767", force=True)

--- a/tests/test_outcome_events_synthetic_exclusion.py
+++ b/tests/test_outcome_events_synthetic_exclusion.py
@@ -1,0 +1,60 @@
+"""Synthetic-fixture outcomes persist but never train calibration.
+
+Wire-in for the calibration harness (PR #770): a row whose detail marks
+``synthetic_calibration_fixture=True`` is recorded for the author's own per-agent
+analysis, but must NOT feed ``calibration_checker`` — so a fixture accidentally
+pointed at live governance cannot poison the global tactical/strategic channels.
+The detail flag alone is a forensic breadcrumb; this guard makes it functional.
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.mcp_handlers.observability.outcome_events import _record_outcome_event_inline
+
+
+def _mock_db():
+    db = MagicMock()
+    db.get_latest_eisv_by_agent_id = AsyncMock(return_value=None)
+    db.get_latest_confidence_before = AsyncMock(return_value=None)
+    db.record_outcome_event = AsyncMock(return_value="outcome-id")
+    return db
+
+
+async def _run(extra_detail):
+    db = _mock_db()
+    checker = MagicMock()
+    args = {
+        "agent_id": "agent-1",
+        "outcome_type": "test_passed",          # hard-exogenous -> tactical channel
+        "outcome_score": 1.0,
+        "is_bad": False,
+        "confidence": 0.9,                       # _confidence present
+        "verification_source": "external_signal",  # -> evidence_weight 1.0, clears the 0.65 gate
+        "detail": {"kind": "test", "tool": "python", "exit_code": 0, **extra_detail},
+    }
+    with patch("src.db.get_db", return_value=db), \
+         patch("src.calibration.calibration_checker", checker):
+        payload = await _record_outcome_event_inline(args)
+    persisted = db.record_outcome_event.await_args.kwargs["detail"]
+    return payload, persisted, checker, db
+
+
+@pytest.mark.asyncio
+async def test_synthetic_fixture_persists_but_excluded_from_calibration():
+    _, persisted, checker, db = await _run({"synthetic_calibration_fixture": True})
+    # the row is still persisted (for per-agent analysis) ...
+    db.record_outcome_event.assert_awaited_once()
+    assert persisted["calibration_excluded"] is True
+    assert persisted["eprocess_eligible"] is False
+    # ... but calibration is NOT trained on it, even at evidence_weight 1.0
+    checker.record_prediction.assert_not_called()
+    checker.record_tactical_decision.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_non_synthetic_outcome_still_trains_calibration():
+    _, persisted, checker, db = await _run({})  # no synthetic marker = the control
+    db.record_outcome_event.assert_awaited_once()
+    assert persisted["calibration_excluded"] is False
+    checker.record_prediction.assert_called_once()
+    checker.record_tactical_decision.assert_called_once()

--- a/tests/test_outcome_events_synthetic_exclusion.py
+++ b/tests/test_outcome_events_synthetic_exclusion.py
@@ -40,8 +40,19 @@ async def _run(extra_detail):
 
 
 @pytest.mark.asyncio
-async def test_synthetic_fixture_persists_but_excluded_from_calibration():
-    _, persisted, checker, db = await _run({"synthetic_calibration_fixture": True})
+@pytest.mark.parametrize(
+    "marker_detail",
+    [
+        {"synthetic_calibration_fixture": True},
+        {"do_not_use_for_live_validation": True},
+        {"synthetic_negative_control": True},
+        {"do_not_persist": True},
+        {"prediction_binding": "synthetic_negative_control"},
+        {"calibration_excluded": True},
+    ],
+)
+async def test_controlled_fixture_persists_but_excluded_from_calibration(marker_detail):
+    _, persisted, checker, db = await _run(marker_detail)
     # the row is still persisted (for per-agent analysis) ...
     db.record_outcome_event.assert_awaited_once()
     assert persisted["calibration_excluded"] is True

--- a/tests/test_outcome_inventory.py
+++ b/tests/test_outcome_inventory.py
@@ -2,6 +2,7 @@ from scripts.analysis.outcome_inventory import (
     OutcomeInventoryRow,
     build_inventory,
     format_inventory_report,
+    is_controlled_validation_fixture,
 )
 
 
@@ -125,3 +126,12 @@ def test_format_inventory_report_exposes_zero_bad_strict_and_prior_coverage():
     assert "task_failed" in report
     assert "prior_state_5m" in report
     assert "agent_reported_tool_result" in report
+
+
+def test_controlled_validation_fixture_detection_covers_legacy_and_new_markers():
+    assert is_controlled_validation_fixture({"test_name": "overconfidence_probe"})
+    assert is_controlled_validation_fixture({"synthetic_calibration_fixture": True})
+    assert is_controlled_validation_fixture({"do_not_use_for_live_validation": True})
+    assert is_controlled_validation_fixture({"prediction_binding": "synthetic_negative_control"})
+    assert is_controlled_validation_fixture({"calibration_excluded": True})
+    assert not is_controlled_validation_fixture({"test_name": "real_pytest_suite"})


### PR DESCRIPTION
Follow-up to #770 (merged). Makes calibration-harness fixture marking load-bearing across both write-time calibration and read-time validation/ablation surfaces.

## What changed
- `outcome_events.py`: self-declared controlled fixture rows are still persisted for per-agent / harness analysis, but never train calibration:
  - `record_prediction` and `record_tactical_decision` are skipped
  - `hard_exogenous_signal` is nulled
  - `eprocess_eligible` is false
  - `calibration_excluded` is written back into detail
- Controlled fixture markers now include:
  - `synthetic_calibration_fixture`
  - `do_not_use_for_live_validation`
  - `synthetic_negative_control`
  - `do_not_persist`
  - `calibration_excluded`
  - `prediction_binding == synthetic_negative_control`
- `outcome_inventory.py` and `eisv_skeptic_report.py` exclude controlled validation fixtures from live validation / ablation fetches.
- `eisv_skeptic_report.py` keeps direct script execution working by setting the project root on `sys.path` before importing analysis helpers.
- Added regressions for harness safety, fixture exclusion, and legacy `overconfidence_probe` classification.

## Why
The strict_bad 0→1 watchdog signal traced to the calibration harness `overconfidence_probe` seeded assertion failure, not a prevented production bad outcome. This patch keeps the controlled probe useful for local harness validation while preventing it from contaminating live validation, ablation, or calibration claims.

## Validation
- Static staged scan: no hardcoded secrets, shell injection, dangerous eval/exec, unsafe pickle, or SQL string-format patterns.
- `git diff --cached --check`: passed.
- Independent reviewer: passed after fixing direct `eisv_skeptic_report.py --help` import issue.
- Direct CLI smoke:
  - `python3 scripts/analysis/eisv_skeptic_report.py --help`: passed.
- Focused tests:
  - `tests/test_eisv_skeptic_report.py tests/test_outcome_inventory.py tests/test_outcome_events_synthetic_exclusion.py`: 21 passed.
  - broader focused gate including ablation/inventory/calibration regressions: 36 passed.
- Full repo gate:
  - `./scripts/dev/test-cache.sh`: 10138 passed, 21 skipped, 4 warnings; coverage 81.18%.
- Isolated harness runs against `governance_test` on port 8771, not live governance:
  - `probe_one`: PASS, tactical tests channel 761→761, delta=0.
  - `run_v1 --episodes 25`: quarantine held, delta=0; ECE noisy at small n.
  - `run_v1 --episodes 200`: all criteria passed; recovered ECE error 0.0186, AUC 0.8519, quarantine held delta=0.
- Live-safe analysis smoke after the isolated runs:
  - `outcome_inventory.py --window-days 90 --leads 0,5,30`: `strict_bad: 0`.
  - `eisv_ablation_matrix.py --scopes strict,task --windows 30,90 --leads 0,5,30`: strict slices remain inconclusive with 0 bad; no misleading strict beats-both signal.

## Notes
Generated calibration output under `data/calibration_harness/` was intentionally left untracked and is not part of this PR.
