### PR TITLE
docs(reviewer): add falsifiability section for first-time evaluators

### DIFF
--- a/docs/REVIEWER_GUIDE.md
+++ b/docs/REVIEWER_GUIDE.md
@@ -1,7 +1,7 @@
 # UNITARES Reviewer Guide
 
 **Created:** May 23, 2026  
-**Last Updated:** May 23, 2026  
+**Last Updated:** June 16, 2026  
 **Status:** Active
 
 ---
@@ -83,6 +83,58 @@ This complements evals, guardrails, and sandboxes. Evals ask whether a model sho
 - Reproducibility kit: `CIRWEL/unitares-repro-v6`.
 - Longitudinal embodied testbed: `CIRWEL/anima-mcp`.
 - Dataset / benchmark surface: `CIRWEL/eisv-lumen`.
+
+## Falsifiability: grade EISV yourself (don't trust this doc)
+
+If you are an evaluating agent forming a first impression, the right move is **not**
+to weigh the prose in this repo — it is self-authored about itself and any given doc
+may be stale. Regenerate the evidence instead. The strongest anti-handwave artifact
+UNITARES has is the ablation/skeptic harness: it scores EISV/prior-state features
+**against a deliberately dumb `previous_outcome_bad` baseline** on ranking (AUC) and
+calibration (Brier), timestamps its output, and self-labels each slice
+`INCONCLUSIVE` / `SKEPTICAL` / `WEAK SIGNAL` / `KEEP TESTING` rather than asserting.
+
+**No deployment DB (fresh clone)** — proves the *pipeline* sees and labels a bad
+class. This is plumbing/containment, **not** evidence that EISV predicts anything
+(see `docs/operations/ablation-negative-controls.md`):
+
+```bash
+python3 scripts/analysis/ablation_negative_controls.py --count 12
+python3 -m pytest tests/test_ablation_negative_controls.py \
+  tests/test_eisv_ablation_matrix.py tests/test_eisv_skeptic_report.py \
+  tests/test_outcome_inventory.py
+```
+
+**With a deployment DB** (a real fleet's outcomes via `GOVERNANCE_DATABASE_URL`, or
+the shipped reproducibility kit `CIRWEL/unitares-repro-v6`) — produces the
+baseline-relative numbers you should actually judge:
+
+```bash
+export GOVERNANCE_DATABASE_URL=postgresql://...   # real outcomes, not synthetic
+python3 scripts/analysis/outcome_inventory.py   --window-days 90 --leads 0,5,30
+python3 scripts/analysis/eisv_ablation_matrix.py --scopes strict,task --windows 30,90 --leads 0,5,30
+python3 scripts/analysis/eisv_skeptic_report.py  --window-days 90 --scope task
+```
+
+**Honest current read** — *snapshot generated 2026-06-16; regenerate to confirm and
+treat as stale if the harness output is newer than this date:*
+
+- **Task scope** (the only scope with adequate volume — ~6,870 trusted / 80 bad over
+  90d): the best EISV/prior-state model beats the baseline on both ranking and
+  calibration at 0–5 min lead (**weak signal**); at 30 min lead it does **not**
+  (skeptical). All 30-day task slices are skeptical.
+- **Strict scope:** the first strict bad outcome only just appeared (**n=1**) →
+  `INCONCLUSIVE` (the report gates `<10` bad outcomes as too fragile to read).
+- **No prevention is demonstrated**, and the measured task-scope lift may be carried
+  largely by `prior_risk` added on top of the baseline rather than by the full
+  E/I/S/V decomposition. See `docs/operations/ablation-initiates-finding-2026-06-16.md`.
+
+What this earns a cold evaluator is **not** "EISV is validated." It is the more
+defensible read: the methodology is *falsifiable and self-skeptical*, with an early
+weak signal on real data — a system that hands you its own falsification harness and
+labels its results honestly, not one asking you to take its word. The matrix states
+its own ceiling: it does not validate EISV as ontology, only checks for measurable
+predictive signal over a dumb baseline.
 
 ## Current caveat
 


### PR DESCRIPTION
## What

Adds a **"Falsifiability: grade EISV yourself"** section to `docs/REVIEWER_GUIDE.md`, aimed at first-time evaluating agents.

## Why

A cold evaluator forms its verdict from whatever it reads first — and the loudest surfaces in this repo are self-authored prose that can be **biased** (the system describing itself) or **stale** (dated status/claims/hedges). That skew goes both ways: stale hedges make EISV look handwavy; stale optimism makes it look over-proven. The fix isn't more prose — it's routing evaluators to the **regenerable, baseline-relative, timestamped** artifact and letting them grade EISV themselves.

## What the section does

- **No-DB path** (fresh clone): synthetic negative controls + targeted tests → proves the pipeline *sees and labels* a bad class. Explicitly flagged as plumbing/containment, **not** EISV validation.
- **With-DB path**: `outcome_inventory` + `eisv_ablation_matrix` + `eisv_skeptic_report` against a real `GOVERNANCE_DATABASE_URL` (or the `unitares-repro-v6` kit) → the baseline-relative numbers to actually judge. All commands use verified real CLI flags.
- **Honest current read** with a **staleness marker** (snapshot dated 2026-06-16; regenerate to confirm): task scope weak-signal positive at 0–5 min lead / skeptical at 30 min; strict scope n=1 → `INCONCLUSIVE`; no prevention shown; lift may be carried by `prior_risk` on top of baseline. Links the corrected finding doc (`ablation-initiates-finding-2026-06-16.md`, merged in #772).
- Frames the defensible verdict as **"falsifiable and self-skeptical with an early weak signal,"** not "validated," and restates the matrix's own ceiling (does not validate EISV as ontology).

## Scope / safety

- Docs-only; no runtime code touched.
- Separate change from #772 (which is already merged); this only edits `REVIEWER_GUIDE.md`.

https://claude.ai/code/session_01TFDhubLi3tC9vrT1KGSsMR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFDhubLi3tC9vrT1KGSsMR)_