### PR TITLE
fix(lifecycle): subagent/compaction children never supersede their parent

### DIFF
--- a/src/mcp_handlers/lifecycle/stuck.py
+++ b/src/mcp_handlers/lifecycle/stuck.py
@@ -196,6 +196,16 @@ def _live_lineage_parent_ids(
         # A child pointing at its own id is not a successor — guard self-loops.
         if parent in (getattr(meta, "agent_uuid", None), getattr(meta, "agent_id", None)):
             continue
+        # Subagent/compaction children do NOT supersede their parent: their
+        # parent is concurrent-by-design (a dispatcher mid-dispatch, a
+        # compaction fork), not an exited predecessor. Treating their presence
+        # as succession archives the LIVE parent out from under itself — which
+        # is exactly how a council of dispatched subagents archived the main
+        # session 2026-06-16 (parent had ~12.9k updates, last check-in seconds
+        # earlier). These spawn_reasons declare ancestry with a live parent by
+        # definition; only an exited predecessor is a genuine succession.
+        if (getattr(meta, "spawn_reason", None) or "") in ("subagent", "compaction"):
+            continue
         age = _agent_age_minutes(meta, current_time)
         if age is not None and age <= window_minutes:
             live.add(parent)

--- a/tests/test_lifecycle_detect_stuck.py
+++ b/tests/test_lifecycle_detect_stuck.py
@@ -23,6 +23,7 @@ def _make_agent_meta(
     tags=None,
     parent_agent_id=None,
     agent_uuid=None,
+    spawn_reason=None,
 ):
     """Create mock agent metadata."""
     now = datetime.now(timezone.utc)
@@ -34,6 +35,7 @@ def _make_agent_meta(
         tags=tags or [],
         parent_agent_id=parent_agent_id,
         agent_uuid=agent_uuid,
+        spawn_reason=spawn_reason,
     )
     return meta
 
@@ -945,6 +947,51 @@ class TestLineageSuccession:
         live = _live_lineage_parent_ids(datetime.now(timezone.utc))
         assert live == set()
 
+    @patch(_PATCHES["mcp_server"])
+    def test_subagent_child_does_not_supersede_parent(self, mock_server):
+        """A dispatched subagent has a LIVE parent by definition (the
+        dispatcher mid-dispatch) — its presence must not mark that parent
+        superseded. Regression for 2026-06-16: a council of subagents archived
+        the live main session, which had ~12.9k updates and had checked in
+        seconds before, because each subagent declared it as parent."""
+        recent = datetime.now(timezone.utc) - timedelta(minutes=2)
+        mock_server.agent_metadata = {
+            "sub1": _make_agent_meta(
+                last_update=recent, parent_agent_id="main", spawn_reason="subagent"
+            ),
+        }
+        from src.mcp_handlers.lifecycle.stuck import _live_lineage_parent_ids
+        live = _live_lineage_parent_ids(datetime.now(timezone.utc))
+        assert live == set()
+
+    @patch(_PATCHES["mcp_server"])
+    def test_compaction_child_does_not_supersede_parent(self, mock_server):
+        """A compaction fork also has a live parent by design — same exemption."""
+        recent = datetime.now(timezone.utc) - timedelta(minutes=2)
+        mock_server.agent_metadata = {
+            "fork1": _make_agent_meta(
+                last_update=recent, parent_agent_id="main", spawn_reason="compaction"
+            ),
+        }
+        from src.mcp_handlers.lifecycle.stuck import _live_lineage_parent_ids
+        live = _live_lineage_parent_ids(datetime.now(timezone.utc))
+        assert live == set()
+
+    @patch(_PATCHES["mcp_server"])
+    def test_explicit_handoff_child_still_supersedes_parent(self, mock_server):
+        """A genuine serial handoff (spawn_reason='explicit', from an EXITED
+        predecessor) is still a real succession — it must NOT be exempted, or
+        we'd never retire legitimately-handed-off predecessors."""
+        recent = datetime.now(timezone.utc) - timedelta(minutes=2)
+        mock_server.agent_metadata = {
+            "succ": _make_agent_meta(
+                last_update=recent, parent_agent_id="pred", spawn_reason="explicit"
+            ),
+        }
+        from src.mcp_handlers.lifecycle.stuck import _live_lineage_parent_ids
+        live = _live_lineage_parent_ids(datetime.now(timezone.utc))
+        assert live == {"pred"}
+
     @pytest.mark.asyncio
     async def test_archive_superseded_parents_archives_parent(self):
         """auto_recover sweep retires a superseded parent as lineage_succession."""
@@ -1021,6 +1068,45 @@ class TestLineageSuccession:
         # ghost protected; only the checked-in superseded parent retired.
         assert archived_ids == ["done"]
         assert [r["agent_id"] for r in results] == ["done"]
+
+    @pytest.mark.asyncio
+    async def test_archive_superseded_parents_skips_parent_of_subagents(self):
+        """End-to-end regression for the 2026-06-16 incident: a live parent
+        whose only 'superseding' children are dispatched subagents must NOT be
+        archived — even with no live process binding (the parent's fingerprint
+        was churning, so the binding signal alone didn't protect it). The
+        spawn_reason exemption keeps the parent out of the superseded set
+        entirely, before the binding gate is ever consulted."""
+        recent = datetime.now(timezone.utc) - timedelta(minutes=1)
+        with patch(_PATCHES["mcp_server"]) as mock_server, \
+             patch("src.mcp_handlers.lifecycle.helpers._archive_one_agent") as mock_arch, \
+             patch("src.mcp_handlers.identity.process_binding.get_live_bindings") as mock_live:
+            mock_server.agent_metadata = {
+                # the main session — actively working, many updates
+                "main": _make_agent_meta(last_update=recent, total_updates=12900),
+                "sub1": _make_agent_meta(
+                    last_update=recent, parent_agent_id="main", spawn_reason="subagent"
+                ),
+                "sub2": _make_agent_meta(
+                    last_update=recent, parent_agent_id="main", spawn_reason="subagent"
+                ),
+            }
+            mock_server.monitors = {}
+
+            async def _ok(*a, **k):
+                return True
+            mock_arch.side_effect = _ok
+
+            async def _no_bindings(*a, **k):
+                return []  # fingerprint churn → no live binding seen
+            mock_live.side_effect = _no_bindings
+
+            from src.mcp_handlers.lifecycle.stuck import _archive_superseded_parents
+            results = await _archive_superseded_parents(datetime.now(timezone.utc))
+
+        # The parent of subagents is never superseded → nothing archived.
+        assert mock_arch.call_args_list == []
+        assert results == []
 
     @pytest.mark.asyncio
     async def test_archive_superseded_parents_skips_live_process_binding(self):


### PR DESCRIPTION
## Incident

A council of dispatched subagents archived the **live main session** as `lineage_succession` (2026-06-16). The parent (`b28af478`) had ~12.9k updates and had checked in **seconds** before; it was archived out from under itself mid-task the moment its subagents declared it `parent_agent_id`.

Forensics: `status=archived` but `archived_at` NULL and no lifecycle event — the raw `_archive_superseded_parents` path, reason `lineage_succession`.

## Root cause

`_live_lineage_parent_ids` (stuck.py) marks a parent "superseded" whenever **any** active recent child declares it as `parent_agent_id`. But a `subagent` (dispatcher mid-dispatch) or `compaction` (fork) child has a concurrent-by-design **live** parent — its presence attests ancestry, not that the parent exited. Only a genuinely-exited predecessor is a real succession.

#720's archival-time gate keys liveness **solely** on `get_live_bindings` (process fingerprint). The incident session's fingerprint was churning (`PATH1_FINGERPRINT_MISMATCH` across calls → "suspected hijack"), so it had no stable live binding and slipped past that gate despite being plainly alive. The `total_updates == 0` ghost guard also didn't apply (12.9k updates).

## Fix

Exempt `spawn_reason in {subagent, compaction}` children from the superseded-parent set in `_live_lineage_parent_ids`, so such a parent is **never even considered** for `lineage_succession` archival — independent of binding/fingerprint state (which is why it closes the hole #720's binding-only signal left open).

- `explicit` (genuine serial handoff from an **exited** predecessor) and `new_session` are unaffected — a real succession still retires its predecessor (test included).
- `meta.spawn_reason` is hydrated both on bulk load (`agent_metadata_persistence.py:127`) and at onboard-time registration (`resolution.py:1065` → `register_minted_agent_in_dict`), verified, so the gate is live-correct for a just-spawned child.
- Considered an absolute-window parent self-liveness gate as a second layer but **rejected it**: it broke the existing "archive a 10-min-silent superseded parent" test and is the brittle time-window-tuning anti-pattern. The semantic `spawn_reason` exemption is non-brittle and targets the actual incident.

Complements #720/#721 (the declaration- and archival-time liveness gates), which remain the discriminator for the non-subagent case.

## ⚠️ Deploy gap (separate, operator action)

This hardening is necessary but **not** the whole story: the incident also happened because **#720 and #721 are merged but not deployed**. The live governance-mcp server runs `08297d0e` (2026-06-14 **13:53**), which predates both merges that same afternoon — its `stuck.py` has **zero** `get_live_bindings`, i.e. no liveness gate at all. Deploying current master (which already carries #720/#721, and this PR once merged) is the operator's call — governance-mcp restart + the manual migration diff per the deploy runbook.

## Tests

`tests/test_lifecycle_detect_stuck.py`: +4 cases (subagent/compaction exempt, explicit still supersedes, end-to-end "subagent council doesn't archive the live parent with no binding"). 705 lifecycle/lineage tests green, ruff clean. Existing #720 tests unchanged.