### PR TITLE
Surface the model↔body divergence trend (get_governance_metrics)

### DIFF
--- a/src/governance_monitor.py
+++ b/src/governance_monitor.py
@@ -13,9 +13,13 @@ Version History:
 import os
 import numpy as np
 from typing import Dict, Optional, Any
+from collections import deque
 from datetime import datetime
 from pathlib import Path
 import json
+
+# How many model<->body divergence samples to retain per agent for trend reads.
+SENSOR_DIVERGENCE_HISTORY_MAX = 200
 
 from config.governance_config import config
 
@@ -257,7 +261,10 @@ class UNITARESMonitor:
 
         # Most recent model<->body divergence (compare, don't couple); None until
         # a check-in arrives carrying sensor_eisv (embodied agents like Lumen).
+        # The bounded history makes the divergence legible as a TREND — the
+        # evidence of whether the EISV mapping holds without coupling forcing it.
         self._last_sensor_divergence: Optional[dict] = None
+        self._sensor_divergence_history: deque = deque(maxlen=SENSOR_DIVERGENCE_HISTORY_MAX)
 
         # Timestamps for agent lifecycle tracking
         self.created_at = datetime.now()
@@ -291,6 +298,12 @@ class UNITARESMonitor:
                 # Restore last divergence snapshot if present (transient; pop so
                 # GovernanceState.from_dict does not see an unknown key).
                 self._last_sensor_divergence = data.pop('sensor_divergence', None)
+                # Restore bounded divergence trend history (pop for the same reason).
+                div_hist = data.pop('sensor_divergence_history', None)
+                if div_hist:
+                    self._sensor_divergence_history = deque(
+                        div_hist, maxlen=SENSOR_DIVERGENCE_HISTORY_MAX
+                    )
                 # Restore created_at if persisted; otherwise __init__ will fall
                 # back to now() for older state files that predate this field.
                 created_at_iso = data.pop('created_at_iso', None)
@@ -338,6 +351,10 @@ class UNITARESMonitor:
             last_div = getattr(self, '_last_sensor_divergence', None)
             if last_div is not None:
                 state_data['sensor_divergence'] = last_div
+            # Persist the bounded divergence trend so it survives restarts.
+            div_hist = getattr(self, '_sensor_divergence_history', None)
+            if div_hist:
+                state_data['sensor_divergence_history'] = list(div_hist)
             # Persist created_at so agent age/maturity survives process restarts.
             created_at = getattr(self, 'created_at', None)
             if created_at is not None:
@@ -525,6 +542,9 @@ class UNITARESMonitor:
             self._last_sensor_divergence = eisv_divergence(
                 sensor_eisv, self.state.unitaires_state
             )
+            # Stamp + retain for trend reads (bounded by SENSOR_DIVERGENCE_HISTORY_MAX).
+            self._last_sensor_divergence["at"] = datetime.now().isoformat()
+            self._sensor_divergence_history.append(self._last_sensor_divergence)
             logger.debug(
                 "sensor_divergence agent=%s magnitude=%.4f "
                 "dE=%+.3f dI=%+.3f dS=%+.3f dV=%+.3f",

--- a/src/services/runtime_queries.py
+++ b/src/services/runtime_queries.py
@@ -78,6 +78,19 @@ def _build_eisv_semantics(metrics: Dict[str, Any], monitor: Any) -> Dict[str, An
         behavioral_eisv = None
         behavioral_confidence = 0.0
 
+    # Model<->body divergence (compare, don't couple). Present only for agents
+    # that submit a sensor EISV (embodied like Lumen, or behavioral). The recent
+    # trend is the evidence of whether the EISV mapping holds without the spring
+    # forcing agreement — read per-axis (dV is expected to drift for Lumen).
+    sensor_divergence = getattr(monitor, "_last_sensor_divergence", None)
+    sensor_divergence_recent = None
+    try:
+        hist = getattr(monitor, "_sensor_divergence_history", None)
+        if hist:
+            sensor_divergence_recent = list(hist)[-20:]
+    except Exception:
+        sensor_divergence_recent = None
+
     primary_source = "behavioral" if behavioral_confidence >= 0.3 else "ode_fallback"
     from src.governance_glossary import explain_eisv_source
     primary_source_meta = explain_eisv_source(primary_source)
@@ -98,6 +111,8 @@ def _build_eisv_semantics(metrics: Dict[str, Any], monitor: Any) -> Dict[str, An
         "behavioral_eisv": behavioral_eisv,
         "ode_eisv": ode_eisv,
         "ode_diagnostics": ode_diagnostics,
+        "sensor_divergence": sensor_divergence,
+        "sensor_divergence_recent": sensor_divergence_recent,
         "state_semantics": {
             "flat_fields_mean": "primary_eisv",
             "primary_eisv_role": (
@@ -114,6 +129,11 @@ def _build_eisv_semantics(metrics: Dict[str, Any], monitor: Any) -> Dict[str, An
                 "Used for convergence tracking and phi calculation. NOT used for verdicts."
             ),
             "ode_diagnostics_role": "Thermostat dynamics diagnostics (phi, regime, lambda1)",
+            "sensor_divergence_role": (
+                "Per-axis sensor - ODE gap (and recent trend). Evidence of whether the "
+                "EISV mapping holds without coupling forcing it; read per-axis in native "
+                "units (axes are not cross-comparable). Null when no sensor EISV is submitted."
+            ),
             "measurement_policy_contract": (
                 "EISV measurements feed governance policy; policy evaluation chooses guidance/action; "
                 "enforcement is a separate runtime boundary."

--- a/tests/test_sensor_divergence_trend.py
+++ b/tests/test_sensor_divergence_trend.py
@@ -1,0 +1,99 @@
+"""
+Tests for the model<->body sensor-divergence trend ("compare, don't couple").
+
+The monitor records per-axis divergence (sensor - ODE) on every check-in that
+carries a sensor_eisv, retains a bounded history, persists it across restarts,
+and surfaces the latest value + a recent slice in the governance-metrics read.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.governance_monitor import UNITARESMonitor, SENSOR_DIVERGENCE_HISTORY_MAX
+
+
+SENSOR = {"E": 0.4, "I": 0.7, "S": 0.2, "V": 0.1}
+BASE_STATE = {"response_text": "x", "complexity": 0.5, "parameters": [0.5] * 128}
+
+
+@pytest.fixture
+def isolated_data_dir(tmp_path, monkeypatch):
+    """Redirect ensure_project_root to tmp_path so state files are isolated."""
+    import src._imports
+    monkeypatch.setattr(src._imports, "ensure_project_root", lambda: str(tmp_path))
+    (tmp_path / "data" / "agents").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+class TestSensorDivergenceTrend:
+
+    def test_history_accumulates_with_sensor(self):
+        monitor = UNITARESMonitor(agent_id="div_accum", load_state=False)
+        for _ in range(3):
+            monitor.process_update({**BASE_STATE, "sensor_eisv": dict(SENSOR)})
+
+        assert monitor._last_sensor_divergence is not None
+        assert len(monitor._sensor_divergence_history) == 3
+        for d in monitor._sensor_divergence_history:
+            assert {"dE", "dI", "dS", "dV", "magnitude", "at"} <= set(d.keys())
+
+    def test_no_sensor_means_no_divergence(self):
+        monitor = UNITARESMonitor(agent_id="div_none", load_state=False)
+        monitor.process_update(dict(BASE_STATE))
+        assert monitor._last_sensor_divergence is None
+        assert len(monitor._sensor_divergence_history) == 0
+
+    def test_history_is_bounded(self):
+        monitor = UNITARESMonitor(agent_id="div_bound", load_state=False)
+        for _ in range(SENSOR_DIVERGENCE_HISTORY_MAX + 5):
+            monitor.process_update({**BASE_STATE, "sensor_eisv": dict(SENSOR)})
+        assert len(monitor._sensor_divergence_history) == SENSOR_DIVERGENCE_HISTORY_MAX
+
+    def test_history_persists_across_save_load(self, isolated_data_dir):
+        monitor = UNITARESMonitor(agent_id="div_persist", load_state=False)
+        for _ in range(4):
+            monitor.process_update({**BASE_STATE, "sensor_eisv": dict(SENSOR)})
+        monitor.save_persisted_state()
+
+        restored = UNITARESMonitor(agent_id="div_persist", load_state=True)
+        assert len(restored._sensor_divergence_history) == 4
+        assert restored._last_sensor_divergence is not None
+        # Bound is preserved on the restored deque.
+        assert restored._sensor_divergence_history.maxlen == SENSOR_DIVERGENCE_HISTORY_MAX
+
+
+class TestDivergenceInMetrics:
+
+    def test_metrics_expose_divergence_when_present(self):
+        from src.services.runtime_queries import _build_eisv_semantics
+        class FakeMonitor:
+            _behavioral_state = None
+            _last_sensor_divergence = {
+                "dE": -0.1, "dI": 0.05, "dS": 0.0, "dV": 0.6,
+                "magnitude": 0.61, "at": "2026-06-16T00:00:00",
+            }
+            _sensor_divergence_history = [
+                {"dE": -0.1, "dI": 0.05, "dS": 0.0, "dV": 0.6, "magnitude": 0.61, "at": "t"},
+            ]
+
+        out = _build_eisv_semantics({"E": 0.6, "I": 0.7, "S": 0.2, "V": 0.0}, FakeMonitor())
+        assert out["sensor_divergence"]["dV"] == 0.6
+        assert isinstance(out["sensor_divergence_recent"], list)
+        assert len(out["sensor_divergence_recent"]) == 1
+        assert "sensor_divergence_role" in out["state_semantics"]
+
+    def test_metrics_divergence_null_when_absent(self):
+        from src.services.runtime_queries import _build_eisv_semantics
+        class FakeMonitor:
+            _behavioral_state = None
+            _last_sensor_divergence = None
+            _sensor_divergence_history = None
+
+        out = _build_eisv_semantics({"E": 0.6, "I": 0.7, "S": 0.2, "V": 0.0}, FakeMonitor())
+        assert out["sensor_divergence"] is None
+        assert out["sensor_divergence_recent"] is None


### PR DESCRIPTION
## What

Follow-up to #773. Makes the model↔body divergence legible as a **trend**, not just a last value, and surfaces it in the standard `get_governance_metrics` readout (so it flows to the dashboard and any reader automatically — the "shared language" surface).

- **`governance_monitor.py`** — bounded per-agent history (`_sensor_divergence_history`, deque `maxlen=200`), each sample timestamped; persisted/restored next to the last value (mirrors the `behavioral_eisv` pattern).
- **`runtime_queries._build_eisv_semantics`** — adds `sensor_divergence` (latest) and `sensor_divergence_recent` (last ~20) to the metrics response, plus a self-describing `sensor_divergence_role` (per-axis, native units, null when no sensor EISV is submitted).
- **tests** — accumulation, none-case, bounding, save/load round-trip, metrics shape (6 new; 155 green across monitor/persistence/core suites).

## Why

The point of "compare, don't couple" is that **un-coupled agreement between the model's independent prediction and the sensor is the evidence the EISV mapping is real** — and disagreement (esp. Lumen's V) is the honest signal. You can't read that from a single sample; you need the trend. This lands the trend in the standard readout so it can be watched and, eventually, charted.

## Honest constraints
- **Inert until deployed.** No divergence data flows until #773 + this deploy.
- **Forward-only.** Past sensor readings were never persisted, so there's no retroactive trend — it accumulates from deploy onward.
- **Strongest signal is Lumen** (real body); regular agents' "sensor" is the behavioral model, so their divergence is two-estimators-agree (consistency), not ground-truth proof.

## Follow-ups (not here)
- Dashboard panel to render the trend.
- Operator decision: deploy + flip Lumen's spring `UNITARES_SENSOR_COUPLING=off` to start the clean (un-sprung) proof.