### PR TITLE
feat(http-api): GET /v1/sentinel/backlog — durable HIGH-finding review surface

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -563,11 +563,15 @@
 
         <!-- Sentinel — fleet-anomaly findings stream. Unlike Watcher there's no
              open/resolved lifecycle: findings are transient state signals.
-             Backed by /v1/sentinel/summary. -->
+             Counts/breakdown backed by /v1/sentinel/summary (live ring buffer,
+             24h). The stream toggles between that live view and the durable
+             HIGH backlog (/v1/sentinel/backlog) which survives mcp restarts. -->
         <div class="panel" id="sentinel-section">
             <div class="panel-header">
                 <h2>Sentinel</h2>
                 <div class="panel-controls">
+                    <button id="sentinel-toggle-durable" class="panel-button" type="button"
+                            title="Live = recent ring-buffer findings (wiped on restart). Durable HIGH = persisted high/critical findings over 7d (survives restarts).">Stream: Live</button>
                     <button id="sentinel-refresh" class="panel-button" type="button">Refresh</button>
                 </div>
             </div>

--- a/dashboard/sentinel.js
+++ b/dashboard/sentinel.js
@@ -2,15 +2,22 @@
 //
 // Consumes:
 //   GET /v1/sentinel/summary — counts by severity + violation class, recent stream
+//                              (live in-memory ring buffer, wiped on mcp restart)
+//   GET /v1/sentinel/backlog — durable HIGH/critical findings from audit.events
+//                              (survives restarts; the "did I miss one?" view)
 //
 // Unlike Watcher, Sentinel findings are transient fleet-state signals with no
-// open/closed lifecycle. This panel is a chronological log with a class
-// breakdown — not an actionable queue.
+// open/closed lifecycle. The counts + class breakdown are always the live 24h
+// summary; the STREAM toggles between the live recent log and the durable HIGH
+// backlog so a finding that fired before a deploy is still reviewable.
 //
 // Auth + fetch go through `authFetch` from utils.js.
 
 (function () {
     'use strict';
+
+    // 'live' = summary.recent (ring buffer) · 'durable' = backlog (audit.events)
+    var streamMode = 'live';
 
     async function fetchSummary() {
         try {
@@ -23,6 +30,21 @@
             return data;
         } catch (e) {
             console.warn('[Sentinel] summary fetch failed:', e);
+            return null;
+        }
+    }
+
+    async function fetchBacklog() {
+        try {
+            var resp = await authFetch('/v1/sentinel/backlog?severity=high&window_hours=168');
+            if (!resp.ok) throw new Error('HTTP ' + resp.status);
+            var data = await resp.json();
+            if (!data || data.success === false) {
+                throw new Error((data && data.error) || 'unknown');
+            }
+            return data;
+        } catch (e) {
+            console.warn('[Sentinel] backlog fetch failed:', e);
             return null;
         }
     }
@@ -88,20 +110,19 @@
         return Math.floor(secs / 86400) + 'd ago';
     }
 
-    function renderStream(summary) {
+    function renderStreamRows(rows, emptyText) {
         var container = document.getElementById('sentinel-stream');
         if (!container) return;
         container.innerHTML = '';
-        var recent = summary.recent || [];
-        if (recent.length === 0) {
+        if (!rows || rows.length === 0) {
             var empty = document.createElement('div');
             empty.className = 'sentinel-stream-empty';
-            empty.textContent = 'No Sentinel findings in the last ' + (summary.window_hours || 24) + ' hours.';
+            empty.textContent = emptyText;
             container.appendChild(empty);
             return;
         }
-        for (var i = 0; i < recent.length; i++) {
-            var r = recent[i];
+        for (var i = 0; i < rows.length; i++) {
+            var r = rows[i];
             var row = document.createElement('div');
             row.className = 'sentinel-row';
 
@@ -131,32 +152,70 @@
         }
     }
 
-    function setFooter(summary) {
+    function setFooter(text) {
         var el = document.getElementById('sentinel-meta');
-        if (!el) return;
-        el.textContent = 'window: ' + (summary.window_hours || 24) + 'h'
-            + ' · ' + (summary.total || 0) + ' findings'
-            + ' · refreshed ' + formatRelative(summary.generated_at);
+        if (el) el.textContent = text;
+    }
+
+    // The counts + class breakdown are always the live 24h summary. Only the
+    // stream switches source.
+    async function refreshStream() {
+        if (streamMode === 'durable') {
+            var backlog = await fetchBacklog();
+            if (!backlog) {
+                renderStreamRows([], 'Durable backlog unavailable.');
+                return;
+            }
+            renderStreamRows(
+                backlog.findings,
+                'No durable HIGH findings in the last '
+                    + Math.round((backlog.window_hours || 168) / 24) + 'd.'
+            );
+            setFooter('stream: durable HIGH · ' + (backlog.count || 0)
+                + ' findings · ' + Math.round((backlog.window_hours || 168) / 24)
+                + 'd · survives restarts');
+        } else {
+            var summary = await fetchSummary();
+            if (!summary) {
+                renderStreamRows([], 'Live stream unavailable.');
+                return;
+            }
+            renderStreamRows(
+                summary.recent,
+                'No Sentinel findings in the last ' + (summary.window_hours || 24) + ' hours.'
+            );
+            setFooter('stream: live · ' + (summary.total || 0) + ' findings · '
+                + (summary.window_hours || 24) + 'h · refreshed '
+                + formatRelative(summary.generated_at));
+        }
     }
 
     async function refresh() {
         var summary = await fetchSummary();
-        if (!summary) {
+        if (summary) {
+            renderCounts(summary);
+            renderClassBreakdown(summary);
+        } else {
             setMetric('sentinel-count-total', '—');
             setMetric('sentinel-count-critical', '—');
             setMetric('sentinel-count-high', '—');
             setMetric('sentinel-count-medium', '—');
-            return;
         }
-        renderCounts(summary);
-        renderClassBreakdown(summary);
-        renderStream(summary);
-        setFooter(summary);
+        await refreshStream();
     }
 
     function wire() {
         var btn = document.getElementById('sentinel-refresh');
         if (btn) btn.addEventListener('click', refresh);
+        var toggle = document.getElementById('sentinel-toggle-durable');
+        if (toggle) {
+            toggle.addEventListener('click', function () {
+                streamMode = (streamMode === 'durable') ? 'live' : 'durable';
+                toggle.textContent = (streamMode === 'durable')
+                    ? 'Stream: Durable HIGH' : 'Stream: Live';
+                refreshStream();
+            });
+        }
         refresh();
     }
 

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -15,7 +15,7 @@ import json
 import os
 import secrets
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Optional
 
@@ -1155,6 +1155,12 @@ _FINDING_SEVERITIES = frozenset({"info", "low", "medium", "warning", "high", "cr
 _FINDING_TYPE_SUFFIX = "_finding"
 # Required top-level fields on the posted JSON
 _FINDING_REQUIRED_FIELDS = ("type", "severity", "message", "agent_id", "agent_name", "fingerprint")
+# Sentinel finding event types as persisted in audit.events (the durable store
+# behind the transient ring buffer). The backlog endpoint reads these.
+_SENTINEL_FINDING_EVENT_TYPES = ("sentinel_finding", "sentinel_alarm_finding")
+# Default severities the operator cares about when reviewing "did I miss
+# something across restarts?" — the load-bearing findings.
+_SENTINEL_BACKLOG_DEFAULT_SEVERITIES = frozenset({"high", "critical"})
 
 
 async def http_post_metric(request):
@@ -2074,6 +2080,88 @@ async def http_substrate_dark_sessions(request):
         return JSONResponse({"success": False, "error": str(e)}, status_code=500)
 
 
+async def http_sentinel_backlog(request):
+    """GET /v1/sentinel/backlog?window_hours=168&limit=200&severity=high — durable backlog.
+
+    Sentinel findings are durably persisted to audit.events by the broadcast
+    path (broadcaster._persist_event), so the underlying record already
+    survives governance-mcp restarts. What was missing is a read surface:
+    /v1/sentinel/summary reads only the in-memory ring buffer (wiped on every
+    restart), and /v1/incidents queries anomaly/stuck events, not findings. This
+    endpoint reads the persisted finding rows so the operator can answer "did a
+    HIGH finding fire that I missed across a deploy?" by query, not memory.
+
+    Defaults to high/critical (the load-bearing findings). Pass severity=all to
+    include every severity, or severity=<value> to pin one. Read-only.
+    """
+    http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
+    if not _check_http_auth(request, http_api_token=http_api_token):
+        return _http_unauthorized()
+    try:
+        try:
+            window_hours = float(request.query_params.get("window_hours", "168"))
+        except (TypeError, ValueError):
+            window_hours = 168.0
+        window_hours = max(1.0, min(window_hours, 24 * 90))
+        try:
+            limit = int(request.query_params.get("limit", "200"))
+        except (TypeError, ValueError):
+            limit = 200
+        limit = max(1, min(limit, 1000))
+
+        severity_param = (request.query_params.get("severity") or "").strip().lower()
+        if severity_param == "all":
+            severity_filter = None  # no filter — every severity
+        elif severity_param in _FINDING_SEVERITIES:
+            severity_filter = {severity_param}
+        else:
+            severity_filter = set(_SENTINEL_BACKLOG_DEFAULT_SEVERITIES)
+
+        from src.audit_db import query_audit_events_async
+        start_time = (
+            datetime.now(timezone.utc) - timedelta(hours=window_hours)
+        ).isoformat()
+        # Over-fetch before the in-Python severity filter so the cap still
+        # yields up to `limit` matching rows.
+        events = await query_audit_events_async(
+            event_types=list(_SENTINEL_FINDING_EVENT_TYPES),
+            start_time=start_time,
+            order="desc",
+            limit=max(limit * 4, limit),
+        )
+
+        findings = []
+        for e in events:
+            details = e.get("details") or {}
+            severity = details.get("severity")
+            if severity_filter is not None and severity not in severity_filter:
+                continue
+            findings.append({
+                "timestamp": e.get("timestamp"),
+                "severity": severity,
+                "finding_type": details.get("finding_type") or details.get("alarm_kind"),
+                "violation_class": details.get("violation_class"),
+                "message": details.get("message"),
+                "agent_id": e.get("agent_id"),
+                "agent_name": details.get("agent_name"),
+                "fingerprint": details.get("fingerprint"),
+                "event_id": e.get("event_id"),
+            })
+            if len(findings) >= limit:
+                break
+
+        return JSONResponse({
+            "success": True,
+            "window_hours": window_hours,
+            "severity": "all" if severity_filter is None else sorted(severity_filter),
+            "count": len(findings),
+            "findings": findings,
+        })
+    except Exception as e:
+        logger.error(f"Error reading sentinel backlog: {e}")
+        return JSONResponse({"success": False, "error": str(e), "findings": []}, status_code=500)
+
+
 # Incident history endpoint (anomalies + stuck agents from audit log)
 async def http_incidents(request):
     """Return historical anomaly and stuck-agent incidents from the audit trail."""
@@ -2806,6 +2894,7 @@ def register_http_routes(
     app.routes.append(Route("/api/findings", http_record_finding, methods=["POST"]))
     app.routes.append(Route("/v1/substrate/observe", http_substrate_observe, methods=["POST"]))
     app.routes.append(Route("/v1/substrate/dark_sessions", http_substrate_dark_sessions, methods=["GET"]))
+    app.routes.append(Route("/v1/sentinel/backlog", http_sentinel_backlog, methods=["GET"]))
     app.routes.append(Route("/v1/metrics", http_post_metric, methods=["POST"]))
     app.routes.append(Route("/v1/metrics/series", http_get_metrics, methods=["GET"]))
     app.routes.append(Route("/v1/metrics/catalog", http_get_metrics_catalog, methods=["GET"]))

--- a/tests/test_http_api_sentinel_backlog.py
+++ b/tests/test_http_api_sentinel_backlog.py
@@ -1,0 +1,145 @@
+"""Tests for GET /v1/sentinel/backlog — durable Sentinel finding backlog.
+
+The endpoint reads the durable audit.events store (where findings already
+persist via broadcaster._persist_event), filtered to sentinel finding event
+types. These tests mock the audit query so they need no live DB.
+"""
+
+import os
+
+import pytest
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+import src.audit_db as audit_db
+from src.http_api import http_sentinel_backlog
+
+
+@pytest.fixture(autouse=True)
+def _no_http_api_token(monkeypatch):
+    monkeypatch.delenv("UNITARES_HTTP_API_TOKEN", raising=False)
+
+
+@pytest.fixture
+def client():
+    app = Starlette(routes=[Route("/v1/sentinel/backlog", http_sentinel_backlog, methods=["GET"])])
+    return TestClient(app)
+
+
+def _audit_row(severity, finding_type="verdict_shift", vclass="ENT", ts="2026-06-16T16:00:00+00:00"):
+    """Shape one audit.events row as query_audit_events_async returns it."""
+    return {
+        "timestamp": ts,
+        "agent_id": "Sentinel",
+        "event_type": "sentinel_finding",
+        "confidence": 1.0,
+        "event_id": 42,
+        "details": {
+            "severity": severity,
+            "finding_type": finding_type,
+            "violation_class": vclass,
+            "message": f"{finding_type} fired",
+            "fingerprint": f"fp-{finding_type}-{severity}",
+            "agent_name": "Sentinel",
+        },
+    }
+
+
+def _patch_query(monkeypatch, rows):
+    captured = {}
+
+    async def _fake_query(**kwargs):
+        captured.update(kwargs)
+        return rows
+
+    monkeypatch.setattr(audit_db, "query_audit_events_async", _fake_query)
+    return captured
+
+
+def test_default_filters_to_high_and_critical(client, monkeypatch):
+    rows = [
+        _audit_row("high", "coordinated_degradation", "CON"),
+        _audit_row("medium", "entropy_outlier", "ENT"),
+        _audit_row("critical", "verdict_shift", "ENT"),
+        _audit_row("info", "correlated_events", "BEH"),
+    ]
+    captured = _patch_query(monkeypatch, rows)
+
+    r = client.get("/v1/sentinel/backlog")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["success"] is True
+    severities = {f["severity"] for f in body["findings"]}
+    assert severities == {"high", "critical"}
+    assert body["count"] == 2
+    # Default queries the sentinel finding event types over a window.
+    assert set(captured["event_types"]) == {"sentinel_finding", "sentinel_alarm_finding"}
+    assert captured["order"] == "desc"
+
+
+def test_severity_all_returns_every_severity(client, monkeypatch):
+    rows = [_audit_row("high"), _audit_row("medium"), _audit_row("info")]
+    _patch_query(monkeypatch, rows)
+
+    r = client.get("/v1/sentinel/backlog?severity=all")
+    body = r.json()
+    assert body["count"] == 3
+    assert body["severity"] == "all"
+
+
+def test_severity_pin_one_value(client, monkeypatch):
+    rows = [_audit_row("high"), _audit_row("medium"), _audit_row("critical")]
+    _patch_query(monkeypatch, rows)
+
+    r = client.get("/v1/sentinel/backlog?severity=medium")
+    body = r.json()
+    assert body["count"] == 1
+    assert body["findings"][0]["severity"] == "medium"
+
+
+def test_row_shaping_maps_details_fields(client, monkeypatch):
+    _patch_query(monkeypatch, [_audit_row("high", "coordinated_degradation", "CON")])
+
+    r = client.get("/v1/sentinel/backlog")
+    f = r.json()["findings"][0]
+    assert f["finding_type"] == "coordinated_degradation"
+    assert f["violation_class"] == "CON"
+    assert f["message"] == "coordinated_degradation fired"
+    assert f["fingerprint"] == "fp-coordinated_degradation-high"
+    assert f["agent_name"] == "Sentinel"
+    assert f["agent_id"] == "Sentinel"
+    assert f["event_id"] == 42
+
+
+def test_limit_is_capped_after_severity_filter(client, monkeypatch):
+    # 5 high rows; limit=2 must yield exactly 2 after filtering.
+    rows = [_audit_row("high") for _ in range(5)]
+    captured = _patch_query(monkeypatch, rows)
+
+    r = client.get("/v1/sentinel/backlog?limit=2")
+    body = r.json()
+    assert body["count"] == 2
+    # Over-fetches beyond the requested limit so the post-filter cap can fill.
+    assert captured["limit"] >= 2
+
+
+def test_alarm_kind_fallback_for_finding_type(client, monkeypatch):
+    row = _audit_row("high")
+    del row["details"]["finding_type"]
+    row["details"]["alarm_kind"] = "forced_release"
+    _patch_query(monkeypatch, [row])
+
+    r = client.get("/v1/sentinel/backlog")
+    assert r.json()["findings"][0]["finding_type"] == "forced_release"
+
+
+def test_query_failure_returns_500_with_empty_list(client, monkeypatch):
+    async def _boom(**kwargs):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(audit_db, "query_audit_events_async", _boom)
+
+    r = client.get("/v1/sentinel/backlog")
+    assert r.status_code == 500
+    assert r.json()["findings"] == []


### PR DESCRIPTION
## Why

Started from Kenny's worry: *"if a Sentinel alert fires only once I might miss it."* Investigation flipped my own premise mid-build — worth stating plainly because it changed the design:

- **Findings already persist durably.** The broadcast path (`broadcaster._persist_event`) writes every finding to `audit.events`. Verified live: **129 `sentinel_finding` + 170 `sentinel_alarm_finding` rows**, back to May 18, including HIGH `verdict_shift` ("Pause rate 33% in last 10min") — exactly the class in question.
- **The gap is the read surface, not durability.** `/v1/sentinel/summary` reads only the in-memory ring buffer (wiped on every governance-mcp restart, by design). `/v1/incidents` queries anomaly/stuck events, not findings. So a HIGH finding that fired before a deploy was *stored but un-reviewable*.

An earlier draft of this branch added a `core.sentinel_findings_durable` table + write path. **Dropped** once the `audit.events` persistence was confirmed live — it was pure redundancy. This PR is the small, honest version: read-only.

## What

`GET /v1/sentinel/backlog?window_hours=168&limit=200&severity=high`

- Reads persisted finding rows from `audit.events` (`query_audit_events_async`, IN-list on the two sentinel finding event types).
- Defaults to **high/critical** (the load-bearing `coordinated_degradation` / `verdict_shift` class). `severity=all` includes every severity; `severity=<value>` pins one.
- Windowed (default 7d, max 90d), capped (default 200, max 1000), over-fetches before the post-filter cap, fail-soft 500 with empty list.

No schema change. No write-path change. Does not touch the live stream or the ring buffer.

## Test

`tests/test_http_api_sentinel_backlog.py` (7 tests, mock the audit query — no live DB): default high/critical filter, `severity=all`, pinned severity, row shaping, `alarm_kind` fallback, limit cap after filter, query-failure 500. Full related suite (findings + sentinel_summary + backlog + substrate_floor) green: 38 passed.

## Follow-up (not in this PR)

Dashboard panel wiring (`dashboard/*.js`) to surface the backlog — separate change, lives in the dashboard allowlist.