### PR TITLE
fix(r1): stop emitting trajectory_continuity_score nodes to the public KG

### DIFF
--- a/scripts/migration/r1_lineage_maintenance.py
+++ b/scripts/migration/r1_lineage_maintenance.py
@@ -8,8 +8,10 @@ Subcommands:
    scores call ``demote_lineage`` only when ``--apply-orphans`` is passed. The
    score evaluation itself writes the normal R1 audit/KG records.
 
-2. ``archive-public-kg`` — archive stale public R1 KG score nodes after the
-   v3.2-D TTL. Defaults to dry-run; pass ``--apply`` to update statuses.
+2. ``archive-public-kg`` — archive public R1 KG score nodes. Defaults to
+   dry-run; pass ``--apply`` to update statuses. ``--ttl-days 0`` archives
+   ALL open nodes regardless of age (one-shot backlog cleanup, since R1
+   scores are no longer emitted to the public KG).
 """
 
 from __future__ import annotations
@@ -55,7 +57,13 @@ async def main() -> int:
         "archive-public-kg",
         help="Archive stale public R1 KG score nodes after the TTL.",
     )
-    archive.add_argument("--ttl-days", type=int, default=30, help="TTL in days (default: 30).")
+    archive.add_argument(
+        "--ttl-days",
+        type=int,
+        default=30,
+        help="TTL in days (default: 30). Use 0 to archive ALL open nodes regardless of age "
+             "(one-shot backlog cleanup now that R1 scores are no longer emitted to the KG).",
+    )
     archive.add_argument("--limit", type=int, default=None, help="Limit rows archived.")
     archive.add_argument("--apply", action="store_true", help="Archive rows instead of dry-run.")
 

--- a/src/identity/r1_maintenance.py
+++ b/src/identity/r1_maintenance.py
@@ -150,11 +150,18 @@ async def archive_stale_public_r1_scores(
     """Archive stale public R1 KG nodes.
 
     The audit table keeps score history. Public KG nodes are the redacted,
-    deduped-by-pair projection and are archived after 30 days without re-score.
+    deduped-by-pair projection and are archived after the TTL without re-score.
+
+    ``ttl_days=0`` archives EVERY open ``trajectory_continuity_score`` node
+    regardless of age. R1 scores are no longer emitted to the public KG (the
+    emission was removed as KG pollution — see
+    ``src/identity/trajectory_continuity.py``), so this age-agnostic mode is
+    the one-shot backlog cleanup for the legacy nodes. It is idempotent: a
+    second run finds nothing because the first archived them all.
     """
     backend = db or _get_db()
-    if ttl_days <= 0:
-        raise ValueError("ttl_days must be positive")
+    if ttl_days < 0:
+        raise ValueError("ttl_days must be non-negative (0 = archive all)")
     if limit is not None and limit <= 0:
         raise ValueError("limit must be positive when provided")
 

--- a/src/identity/trajectory_continuity.py
+++ b/src/identity/trajectory_continuity.py
@@ -20,10 +20,16 @@ Non-goals (explicit per spec):
   to do with it)
 
 Side effects:
-- Awaited write to `audit.r1_score_audit` (full record) — score_id is the
-  join key into the redacted public KG payload (v3.3-A)
-- Public KG emission writes the redacted `_build_public_payload` projection to
-  `knowledge.discoveries`; audit remains the durable full record
+- Awaited write to `audit.r1_score_audit` (full record) — the canonical,
+  durable home for every score.
+
+R1 scores are intentionally NOT emitted to the public knowledge graph. They
+are per-session machine telemetry (one redacted node per fresh-successor
+lineage claim), and the `audit.r1_score_audit` table is the right avenue.
+Emitting them as `knowledge.discoveries` nodes polluted the agent-authored
+discovery graph: fresh successors defeat the dedupe-by-pair node id, so the
+nodes accreted one-per-session with no reader, and the 30-day TTL sweep was
+never scheduled. The audit table already logs everything a consumer needs.
 
 Calibration status: every score record stamps `calibration_status='seeded'` by
 default until operator transitions the lifecycle to `earned` or
@@ -34,7 +40,6 @@ that gating lives at the consumer layer (PR 3), not here.
 
 from __future__ import annotations
 
-import json
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -52,12 +57,6 @@ _THRESHOLD_UNSUPPORTED = 0.55
 _DEFAULT_MIN_OBSERVATIONS = 5
 _DEFAULT_WINDOW = timedelta(days=30)
 _DIMENSIONS = ("E", "I", "S", "V")
-
-# UUIDv5 namespace for the public KG node ID per (parent, successor) pair.
-# Stable across processes — derived from NAMESPACE_OID + a fixed name. The
-# resulting node ID is `f"r1_score:{uuid5(...)}"`; ON CONFLICT (id) DO UPDATE
-# in `kg_add_discovery` gives v3.2-D dedupe-by-pair for free.
-_R1_KG_NAMESPACE = uuid.uuid5(uuid.NAMESPACE_OID, "unitares.r1.trajectory_continuity_score")
 
 # Class tags recognized for R1's `class_tag` stamping (v3.3-G). Order matters
 # — most-specific first so calibration analyses can partition without
@@ -130,8 +129,8 @@ CalibrationStatus = Literal["seeded", "earned", "calibration_failed"]
 
 @dataclass
 class TrajectoryContinuityScore:
-    """Full per-call score record. Internal callers (policy layer) see this
-    dataclass; the public KG sees only `_build_public_payload(score)`."""
+    """Full per-call score record. Internal callers (the policy layer) see
+    this dataclass; the durable record is `audit.r1_score_audit`."""
     score_id: str
     plausibility: float
     verdict: Verdict
@@ -141,119 +140,6 @@ class TrajectoryContinuityScore:
     parent_mature: bool
     calibration_status: CalibrationStatus
     n_dims_used: int                             # number of components that contributed to plausibility
-
-
-# ---------------------------------------------------------------------------
-# Public payload builder — v3.3-A strict redaction
-# ---------------------------------------------------------------------------
-
-def _build_public_payload(score: TrajectoryContinuityScore) -> Dict[str, Any]:
-    """Redact the full score down to the four fields v3.3-A allows on the
-    public KG: verdict, calibration_status, n_dims_used, score_id.
-
-    No plausibility scalar. No per-dim observations. No parent_mature. No
-    reasons. The score_id is the join key into `audit.r1_score_audit` for
-    operator-only forensic access; no other field of the full record leaks
-    into the public KG.
-    """
-    return {
-        "verdict": score.verdict,
-        "calibration_status": score.calibration_status,
-        "n_dims_used": score.n_dims_used,
-        "score_id": score.score_id,
-    }
-
-
-def _public_kg_node_id(parent_id: str, successor_id: str) -> str:
-    """Deterministic node ID per (parent, successor) pair.
-
-    Per v3.2-D dedupe-by-pair: the N-th score for the same pair overwrites
-    the (N-1)-th in the public KG. ON CONFLICT (id) DO UPDATE in
-    `kg_add_discovery` (`src/db/mixins/knowledge_graph.py:82`) gives this
-    semantics for free as long as the id is deterministic from the pair.
-
-    Prefix `r1_score:` makes the id self-describing in logs/queries; the
-    UUIDv5 suffix is the deterministic-and-stable part.
-    """
-    return f"r1_score:{uuid.uuid5(_R1_KG_NAMESPACE, f'{parent_id}:{successor_id}')}"
-
-
-async def _emit_public_kg_node(
-    score: TrajectoryContinuityScore,
-    *,
-    parent_id: str,
-    successor_id: str,
-) -> bool:
-    """Publish the v3.3-A redacted score to the public KG.
-
-    Closes PR 2's deferred KG emission (commit 83e70aa: "KG public emission
-    deferred to PR 3 alongside consumer patches" — PR 3 stayed score-side,
-    so this is the actual write path).
-
-    Per v3.3-A:
-    - Public payload is exactly `{verdict, calibration_status, n_dims_used,
-      score_id}` — `_build_public_payload` produces this shape.
-    - Audit table is the canonical record; the public node is its redacted
-      projection joined by `score_id`.
-
-    Per v3.2-D:
-    - Dedupe by (parent_id, successor_id). N-th score overwrites (N-1)-th.
-      Achieved via deterministic node id + existing ON CONFLICT path.
-
-    Fail-soft contract: emission is observability, not a durability gate.
-    A failure here logs at warn but does not propagate — the audit row is
-    already written by the time we reach this helper, which is what
-    consumers needing forensic access read.
-
-    Returns True on successful write, False otherwise (so tests can assert
-    the side-effect path without parsing logs). False covers both the
-    "no data to score" skip below and the fail-soft exception path.
-    """
-    # When n_dims_used == 0 the verdict is forced to "inconclusive" by
-    # _classify_verdict's short-circuit (no channels had enough data to
-    # score). Emitting "I couldn't score this" to the public KG is noise:
-    # the audit row remains as the forensic anchor (canonical record per
-    # the v3.3-A docstring contract above), and downstream R2/sweep
-    # consumers operate on the audit table, not the KG node. Measured
-    # 2026-05-30: 24 of 26 new R1 KG discoveries were n_dims=0 from
-    # fresh-agent onboards that had no core.agent_state history yet.
-    if score.n_dims_used == 0:
-        return False
-    try:
-        from src.knowledge_graph import get_knowledge_graph
-        from src.knowledge_graph import DiscoveryNode
-
-        public = _build_public_payload(score)
-        node = DiscoveryNode(
-            id=_public_kg_node_id(parent_id, successor_id),
-            agent_id=successor_id,
-            type="trajectory_continuity_score",
-            summary=(
-                f"R1 lineage score: verdict={public['verdict']} "
-                f"calibration={public['calibration_status']} "
-                f"n_dims={public['n_dims_used']}"
-            ),
-            details=json.dumps(public),
-            tags=[
-                "r1",
-                "trajectory_continuity",
-                f"verdict:{public['verdict']}",
-                f"calibration:{public['calibration_status']}",
-            ],
-            severity="low",
-            status="open",
-        )
-        graph = await get_knowledge_graph()
-        await graph.add_discovery(node)
-        return True
-    except Exception as exc:
-        import logging
-        logging.getLogger(__name__).warning(
-            "[R1] public KG emission failed for score_id=%s parent=%s "
-            "successor=%s: %s",
-            score.score_id, parent_id[:8], successor_id[:8], exc,
-        )
-        return False
 
 
 # ---------------------------------------------------------------------------
@@ -271,9 +157,9 @@ async def score_trajectory_continuity(
     declared parent's, over the given window.
 
     See module docstring for the full contract. Returns a
-    `TrajectoryContinuityScore` dataclass. Side effects: awaited write to
-    `audit.r1_score_audit`, followed by fail-soft public KG emission of the
-    redacted `_build_public_payload(score)` projection.
+    `TrajectoryContinuityScore` dataclass. Side effect: awaited write to
+    `audit.r1_score_audit` (the canonical record). Scores are not emitted to
+    the public knowledge graph — see the module docstring for why.
 
     Threshold cuts (v3.1, seeded — calibration is shadow-mode work in PR 3+):
     - successor < min_observations rows OR parent_mature=False → inconclusive
@@ -383,11 +269,9 @@ async def score_trajectory_continuity(
         n_dims_used=n_dims_used,
     )
 
-    # Side effect: persist the full record to audit.r1_score_audit. Awaited
-    # so the score_id is durably present before any caller publishes the
-    # redacted KG payload that references it (v3.3-A join-semantics contract).
-    # If the write fails, we MUST refuse to return a score whose audit row is
-    # absent — otherwise PR 4's KG emission could publish a dangling score_id.
+    # Side effect: persist the full record to audit.r1_score_audit — the
+    # canonical, durable home for every score. If the write fails, we MUST
+    # refuse to return a score whose audit row is absent.
     persisted = await backend.record_r1_score_audit(_to_audit_record(
         score=score,
         parent_id=claimed_parent_id,
@@ -398,17 +282,12 @@ async def score_trajectory_continuity(
     if not persisted:
         raise RuntimeError(
             f"R1 audit write failed for score_id={score.score_id}; "
-            f"refusing to return a score whose audit anchor is absent "
-            f"(v3.3-A join-key durability contract)."
+            f"refusing to return a score whose audit anchor is absent."
         )
 
-    # v3.3-A public KG emission: redacted projection of the audit row,
-    # dedupe-by-pair via deterministic node id (v3.2-D). Fail-soft — audit
-    # is the durable record; this is the public observability surface.
-    await _emit_public_kg_node(
-        score, parent_id=claimed_parent_id, successor_id=successor_id,
-    )
-
+    # No public KG emission. R1 scores are per-session machine telemetry and
+    # live only in audit.r1_score_audit; emitting them as discovery nodes
+    # polluted the agent-authored knowledge graph (see module docstring).
     return score
 
 

--- a/tests/test_r1_maintenance.py
+++ b/tests/test_r1_maintenance.py
@@ -223,3 +223,39 @@ async def test_archive_stale_public_r1_scores_apply_archives_rows():
     sql = conn.fetch.await_args.args[0]
     assert "UPDATE knowledge.discoveries" in sql
     assert "LIMIT 1" in sql
+
+
+@pytest.mark.asyncio
+async def test_archive_stale_public_r1_scores_ttl_zero_archives_all_regardless_of_age():
+    """ttl_days=0 is the one-shot backlog cleanup: the SQL predicate becomes
+    COALESCE(updated_at, created_at) < now(), matching every existing node.
+    The guard must accept 0 (the prior `<= 0` guard rejected it)."""
+    from src.identity.r1_maintenance import archive_stale_public_r1_scores
+
+    now = datetime(2026, 6, 16, tzinfo=timezone.utc)
+    conn = SimpleNamespace()
+    conn.fetch = AsyncMock(return_value=[
+        {
+            "id": "r1_score:today",
+            "agent_id": "child",
+            "created_at": now,
+            "updated_at": now,
+            "status": "archived",
+        },
+    ])
+    backend = _Backend(conn)
+
+    result = await archive_stale_public_r1_scores(db=backend, ttl_days=0, dry_run=False)
+
+    assert result["ttl_days"] == 0
+    assert result["archived"] == 1
+    # ttl_days=0 is passed through to the age predicate (now() - 0 days = now()).
+    assert conn.fetch.await_args.args[1] == 0
+
+
+@pytest.mark.asyncio
+async def test_archive_stale_public_r1_scores_rejects_negative_ttl():
+    from src.identity.r1_maintenance import archive_stale_public_r1_scores
+
+    with pytest.raises(ValueError, match="non-negative"):
+        await archive_stale_public_r1_scores(db=_Backend(SimpleNamespace()), ttl_days=-1)

--- a/tests/test_trajectory_continuity.py
+++ b/tests/test_trajectory_continuity.py
@@ -278,40 +278,11 @@ async def test_score_record_audit_write_captures_full_record(mocked_db):
 
 
 @pytest.mark.asyncio
-async def test_score_kg_public_payload_is_strictly_redacted(mocked_db):
-    """Per v3.3-A: public KG payload contains ONLY:
-      verdict, calibration_status, n_dims_used, score_id.
-    No plausibility scalar, no per-dim observations, no parent_mature, no reasons."""
-    from src.identity.trajectory_continuity import score_trajectory_continuity, _build_public_payload
-
-    parent, successor = synthetic_trajectory_pair(seed=50, kind="genuine")
-    mocked_db.reconstruct_eisv_series = AsyncMock(
-        side_effect=_stub_reconstruct(parent, successor)
-    )
-
-    result = await score_trajectory_continuity(
-        claimed_parent_id="parent-uuid",
-        successor_id="successor-uuid",
-    )
-
-    public = _build_public_payload(result)
-
-    assert set(public.keys()) == {"verdict", "calibration_status", "n_dims_used", "score_id"}
-    # Confirm leak-prone fields are absent
-    assert "plausibility" not in public
-    assert "components" not in public
-    assert "observations" not in public
-    assert "parent_mature" not in public
-    assert "reasons" not in public
-
-
-@pytest.mark.asyncio
 async def test_score_raises_when_audit_write_fails(mocked_db):
     """Per v3.3-A: score_id must be durably present in audit.r1_score_audit
-    before any caller publishes the redacted KG payload that references it.
-    If record_r1_score_audit returns False, the primitive MUST raise rather
-    than return a score whose audit anchor is absent — otherwise PR 3's
-    public KG emission could publish a dangling score_id."""
+    so the score has a durable home. If record_r1_score_audit returns False,
+    the primitive MUST raise rather than return a score whose audit anchor is
+    absent."""
     from src.identity.trajectory_continuity import score_trajectory_continuity
 
     parent, successor = synthetic_trajectory_pair(seed=99, kind="genuine")
@@ -527,15 +498,17 @@ async def test_score_dataclass_internal_caller_surface_unchanged(mocked_db):
 
 
 # ---------------------------------------------------------------------------
-# v3.3-A public KG emission (closes PR 2's deferred work)
+# No public KG emission — R1 scores live only in audit.r1_score_audit
 # ---------------------------------------------------------------------------
+# R1 scores are per-session machine telemetry. Emitting them as discovery
+# nodes polluted the agent-authored knowledge graph (fresh successors defeat
+# dedupe-by-pair, so the nodes accreted one-per-session with no reader). The
+# audit table is the canonical home; the public KG emission was removed.
 
 @pytest.mark.asyncio
-async def test_score_emits_public_kg_node_after_audit(mocked_db):
-    """Per v3.3-A: score_trajectory_continuity publishes a redacted node to
-    the configured public KG backend, joined to the audit row by
-    score_id."""
-    import json
+async def test_score_does_not_emit_to_public_kg(mocked_db):
+    """A successful (plausible) score writes the audit row and does NOT emit
+    any node to the public knowledge graph."""
     from src.identity.trajectory_continuity import score_trajectory_continuity
 
     parent, successor = synthetic_trajectory_pair(seed=60, kind="genuine")
@@ -548,66 +521,20 @@ async def test_score_emits_public_kg_node_after_audit(mocked_db):
         successor_id="successor-uuid",
     )
 
-    mocked_db.public_kg_graph.add_discovery.assert_awaited_once()
-    # Inspect the DiscoveryNode that was passed
-    (node,), _kw = mocked_db.public_kg_graph.add_discovery.call_args
-    assert node.type == "trajectory_continuity_score"
-    assert node.agent_id == "successor-uuid"
-    assert node.id.startswith("r1_score:")
-    # Strict redaction: details JSON has ONLY the four allowed fields
-    public = json.loads(node.details)
-    assert set(public.keys()) == {"verdict", "calibration_status", "n_dims_used", "score_id"}
-    assert public["score_id"] == score.score_id
-    assert public["verdict"] == score.verdict
-    # Tags are observability-only; they MAY duplicate verdict/calibration but
-    # the source-of-truth shape lives in `details`.
-    assert "r1" in node.tags
-    assert "trajectory_continuity" in node.tags
+    # Canonical record still written.
+    assert score.verdict == "plausible"
+    mocked_db.record_r1_score_audit.assert_awaited_once()
+    # No KG pollution: nothing published to the discovery graph.
+    mocked_db.public_kg_graph.add_discovery.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_score_kg_node_id_is_deterministic_per_pair(mocked_db):
-    """Per v3.2-D dedupe-by-pair: the node id MUST be deterministic from
-    (parent_id, successor_id). Re-scoring the same pair produces the same
-    id, so ON CONFLICT (id) DO UPDATE in the active KG backend overwrites
-    rather than appends."""
+async def test_score_n_dims_zero_forces_inconclusive_and_writes_audit(mocked_db):
+    """When there are no EISV channels to compute on (n_dims_used=0, typical
+    for fresh-agent onboards with no core.agent_state history) the verdict is
+    forced inconclusive. The audit row still writes; no KG node is emitted."""
     from src.identity.trajectory_continuity import score_trajectory_continuity
 
-    parent, successor = synthetic_trajectory_pair(seed=61, kind="genuine")
-    mocked_db.reconstruct_eisv_series = AsyncMock(
-        side_effect=_stub_reconstruct(parent, successor)
-    )
-
-    await score_trajectory_continuity(
-        claimed_parent_id="parent-uuid", successor_id="successor-uuid",
-    )
-    await score_trajectory_continuity(
-        claimed_parent_id="parent-uuid", successor_id="successor-uuid",
-    )
-
-    assert mocked_db.public_kg_graph.add_discovery.await_count == 2
-    first_id = mocked_db.public_kg_graph.add_discovery.call_args_list[0][0][0].id
-    second_id = mocked_db.public_kg_graph.add_discovery.call_args_list[1][0][0].id
-    assert first_id == second_id
-    # Each score has a fresh score_id (audit retains all); the node id is
-    # the dedupe key, NOT the score_id.
-    first_payload = mocked_db.public_kg_graph.add_discovery.call_args_list[0][0][0].details
-    second_payload = mocked_db.public_kg_graph.add_discovery.call_args_list[1][0][0].details
-    assert first_payload != second_payload  # score_id differs across calls
-
-
-@pytest.mark.asyncio
-async def test_score_skips_kg_emit_when_n_dims_used_is_zero(mocked_db):
-    """When the score had no EISV channels to compute on (n_dims_used=0,
-    typical for fresh-agent onboards with no core.agent_state history),
-    the verdict is forced inconclusive by _classify_verdict's short-circuit.
-    The audit row still writes (forensic anchor), but the public KG node
-    is skipped to avoid noise. 2026-05-30: 24 of 26 KG R1 discoveries were
-    n_dims=0 from this exact path."""
-    from src.identity.trajectory_continuity import score_trajectory_continuity
-
-    # Empty series → reconstruct returns no usable data for any channel
-    # → n_dims_used=0 → verdict forced to inconclusive.
     empty_series = {"E": [], "I": [], "S": [], "V": []}
     mocked_db.reconstruct_eisv_series = AsyncMock(
         side_effect=_stub_reconstruct(empty_series, empty_series)
@@ -620,79 +547,5 @@ async def test_score_skips_kg_emit_when_n_dims_used_is_zero(mocked_db):
 
     assert score.n_dims_used == 0
     assert score.verdict == "inconclusive"
-    # Audit row written (canonical forensic record).
     mocked_db.record_r1_score_audit.assert_awaited_once()
-    # KG node skipped to avoid "I couldn't score this" noise.
-    mocked_db.public_kg_graph.add_discovery.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_score_kg_node_id_differs_across_pairs(mocked_db):
-    """Different (parent, successor) pairs must produce different node ids
-    so dedupe-by-pair is per-pair, not global."""
-    from src.identity.trajectory_continuity import score_trajectory_continuity
-
-    parent, successor = synthetic_trajectory_pair(seed=62, kind="genuine")
-    mocked_db.reconstruct_eisv_series = AsyncMock(
-        side_effect=_stub_reconstruct(parent, successor)
-    )
-
-    await score_trajectory_continuity(
-        claimed_parent_id="parent-A", successor_id="successor-1",
-    )
-    await score_trajectory_continuity(
-        claimed_parent_id="parent-B", successor_id="successor-1",
-    )
-    await score_trajectory_continuity(
-        claimed_parent_id="parent-A", successor_id="successor-2",
-    )
-
-    ids = [
-        mocked_db.public_kg_graph.add_discovery.call_args_list[i][0][0].id
-        for i in range(3)
-    ]
-    assert len(set(ids)) == 3, "expected 3 distinct node ids for 3 distinct pairs"
-
-
-@pytest.mark.asyncio
-async def test_score_kg_emission_failure_is_non_fatal(mocked_db):
-    """Per v3.3-A: audit is the durable record; KG is observability. A KG
-    emission failure MUST NOT propagate — the score still returns and the
-    audit row is durably written."""
-    from src.identity.trajectory_continuity import score_trajectory_continuity
-
-    mocked_db.public_kg_graph.add_discovery = AsyncMock(side_effect=RuntimeError("kg pool down"))
-    parent, successor = synthetic_trajectory_pair(seed=63, kind="genuine")
-    mocked_db.reconstruct_eisv_series = AsyncMock(
-        side_effect=_stub_reconstruct(parent, successor)
-    )
-
-    # Must not raise
-    score = await score_trajectory_continuity(
-        claimed_parent_id="parent-uuid", successor_id="successor-uuid",
-    )
-
-    assert score is not None
-    # Audit was still attempted + persisted (record_r1_score_audit default True)
-    mocked_db.record_r1_score_audit.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_score_kg_emission_skipped_when_audit_fails(mocked_db):
-    """Per v3.3-A join-key durability contract: if audit write fails, the
-    score primitive raises BEFORE KG emission — the public node must not
-    reference an absent audit row."""
-    from src.identity.trajectory_continuity import score_trajectory_continuity
-
-    mocked_db.record_r1_score_audit = AsyncMock(return_value=False)
-    parent, successor = synthetic_trajectory_pair(seed=64, kind="genuine")
-    mocked_db.reconstruct_eisv_series = AsyncMock(
-        side_effect=_stub_reconstruct(parent, successor)
-    )
-
-    with pytest.raises(RuntimeError, match="audit write failed"):
-        await score_trajectory_continuity(
-            claimed_parent_id="parent-uuid", successor_id="successor-uuid",
-        )
-
     mocked_db.public_kg_graph.add_discovery.assert_not_awaited()


### PR DESCRIPTION
## What

R1 lineage scores were being written into `knowledge.discoveries` as `trajectory_continuity_score` nodes (summary `R1 lineage score: verdict=… calibration=seeded n_dims=…`) on every lineage-declaring onboard. They polluted the **agent-authored** knowledge graph and surfaced as a growing pile of near-identical entries in the dashboard discovery view. (Operator-reported: *"are lineage reports polluting kg" → "i see it on KG thru dashboard"*.)

~50 such nodes existed at time of writing, all `status=open`, written by dozens of distinct agents, several added that same day.

## Root cause — both anti-pollution mechanisms miss

1. **Dedupe-by-pair is defeated by fresh identities.** Node id is `r1_score:uuid5(parent, successor)` with `ON CONFLICT DO UPDATE`, so re-scoring the *same* pair updates one node. But `force_new` is the default posture — every session mints a fresh successor UUID, so every lineaged session is a *new* pair = a *new* node. Dedupe only helps re-scores that never happen → ~one node per lineage-declaring session, forever.
2. **The 30-day TTL sweep never runs.** `archive_stale_public_r1_scores(ttl_days=30)` exists and works, but is only wired into the manual `r1_lineage_maintenance.py` script — no cron/plist/BEAM job calls it. Nodes sit `open` indefinitely.

## Why removal is safe

The canonical, durable record is `audit.r1_score_audit` (written *before* the fail-soft KG emission, and the only thing consumers read). The public KG node was a **write-only redundant projection with no reader** — verified repo-wide (no consumer in `src/`, `dashboard/`, `scripts/`, elixir; cross-repo check in progress). The KG is for agent-authored discoveries, not per-session machine telemetry.

## Changes

- Remove `_emit_public_kg_node` and its now-dead helpers (`_build_public_payload`, `_public_kg_node_id`, the `r1_score` KG namespace) from `src/identity/trajectory_continuity.py`. **Audit write path unchanged** (still the fail-loud durability gate).
- Rewrite the emission tests to assert **no** KG emission + audit still written.
- **Backlog cleanup:** relax `archive_stale_public_r1_scores` to accept `ttl_days=0`, which archives every open `trajectory_continuity_score` node regardless of age (predicate becomes `COALESCE(updated_at, created_at) < now()`). One-shot, idempotent.

## Deploy / cleanup sequence

1. Merge + deploy (stops the bleed).
2. One-shot backlog sweep (never-deletes, just archives → drops from default dashboard view):
   ```
   python3 scripts/migration/r1_lineage_maintenance.py archive-public-kg --ttl-days 0          # dry-run
   python3 scripts/migration/r1_lineage_maintenance.py archive-public-kg --ttl-days 0 --apply  # archive all
   ```

## Tests

`tests/test_trajectory_continuity.py` + `tests/test_r1_maintenance.py` green (26 passed); lineage/onboard-score suites green (29 passed).

🤖 Draft — identity hot-path surface; operator is the merge gate.