### PR TITLE
Per-source sensor coupling: cut Lumen's spring, keep the fleet

### DIFF
--- a/governance_core/parameters.py
+++ b/governance_core/parameters.py
@@ -185,6 +185,53 @@ def sensor_coupling_enabled() -> bool:
     return val.strip().lower() not in {"0", "false", "off", "no"}
 
 
+def sensor_coupling_mode() -> str:
+    """
+    Coupling policy from UNITARES_SENSOR_COUPLING, resolved to a canonical mode:
+
+      - 'on'              (default; any truthy / unset)  — couple every sensor source
+      - 'off'             ({0,false,off,no})             — couple nothing
+      - 'behavioral_only' — couple the behavioral sensor, NOT physical (cuts an
+                            embodied agent's spring while leaving the disembodied
+                            fleet anchored — the Lumen-only cut)
+      - 'physical_only'   — couple physical sensors, NOT the behavioral sensor
+
+    'behavioral_only'/'physical_only' read as truthy to the coarse
+    sensor_coupling_enabled() gate (they are not off-values), so the fine-grained
+    source decision lives in sensor_coupling_allows() and is applied where the
+    sensor source is known (the monitor).
+    """
+    val = os.getenv("UNITARES_SENSOR_COUPLING")
+    if val is None:
+        return "on"
+    v = val.strip().lower()
+    if v in {"0", "false", "off", "no"}:
+        return "off"
+    if v in {"behavioral_only", "physical_only", "on"}:
+        return v
+    return "on"  # any other truthy value (1/true/yes/...) couples everything
+
+
+def sensor_coupling_allows(source) -> bool:
+    """Whether a sensor of the given source ('physical' | 'behavioral' | None)
+    should spring-couple into the ODE under the current policy.
+
+    Unknown/None source is treated as physical: physical sensors are the
+    caller-published ``sensor_data["eisv"]``; only the behavioral sensor
+    self-identifies as 'behavioral'."""
+    mode = sensor_coupling_mode()
+    if mode == "on":
+        return True
+    if mode == "off":
+        return False
+    is_behavioral = source == "behavioral"
+    if mode == "behavioral_only":
+        return is_behavioral
+    if mode == "physical_only":
+        return not is_behavioral
+    return True
+
+
 def get_params_profile_name() -> str:
     """
     Returns the active parameters profile name.

--- a/src/governance_monitor.py
+++ b/src/governance_monitor.py
@@ -485,6 +485,17 @@ class UNITARESMonitor:
             except (TypeError, ValueError, KeyError):
                 sensor_eisv = None
 
+        # Per-source coupling policy: decide whether THIS sensor source may spring
+        # into the ODE. `sensor_eisv` (the full submitted reading) is always kept
+        # for divergence; only `coupling_sensor` (possibly None) reaches the ODE.
+        # This is how the Lumen-only cut works: UNITARES_SENSOR_COUPLING=behavioral_only
+        # nulls physical coupling while leaving the behavioral fleet anchored.
+        from governance_core.parameters import sensor_coupling_allows
+        sensor_source = agent_state.get('sensor_eisv_source')
+        coupling_sensor = sensor_eisv if (
+            sensor_eisv is not None and sensor_coupling_allows(sensor_source)
+        ) else None
+
         # Store parameters for potential future use (deprecated - not used in coherence)
         # Note: param_coherence removed in favor of pure thermodynamic signal
         self.prev_parameters = parameters.copy() if len(parameters) > 0 else None
@@ -529,7 +540,7 @@ class UNITARESMonitor:
             noise_S=calibration_penalty,  # Overconfidence raises entropy
             params=active_params,
             complexity=complexity,  # Complexity now affects S dynamics
-            sensor_eisv=sensor_eisv,  # Compared (not coupled) unless UNITARES_SENSOR_COUPLING
+            sensor_eisv=coupling_sensor,  # per-source gated; None => no spring (still compared below)
         )
 
         # Compare, don't couple: record model<->body divergence as a signal.

--- a/src/mcp_handlers/updates/phases.py
+++ b/src/mcp_handlers/updates/phases.py
@@ -804,6 +804,9 @@ async def prepare_unlocked_inputs(ctx: UpdateContext) -> None:
         sensor_eisv = sensor_data.get("eisv")
         if sensor_eisv and isinstance(sensor_eisv, dict):
             ctx.agent_state["sensor_eisv"] = sensor_eisv
+            # Caller-published physical sensor (e.g. Lumen's Pi). Source tag lets
+            # the monitor apply per-source coupling policy (sensor_coupling_allows).
+            ctx.agent_state["sensor_eisv_source"] = "physical"
 
     # Behavioral sensor: compute EISV from governance observables for non-embodied agents
     if "sensor_eisv" not in ctx.agent_state:
@@ -889,6 +892,7 @@ async def prepare_unlocked_inputs(ctx: UpdateContext) -> None:
                 )
                 if behavioral_eisv:
                     ctx.agent_state["sensor_eisv"] = behavioral_eisv
+                    ctx.agent_state["sensor_eisv_source"] = "behavioral"
                     logger.debug(f"Behavioral sensor_eisv injected for {ctx.agent_id}: {behavioral_eisv}")
         except Exception as e:
             logger.debug(f"Behavioral sensor skipped for {ctx.agent_id}: {e}")

--- a/tests/test_per_source_coupling.py
+++ b/tests/test_per_source_coupling.py
@@ -1,0 +1,113 @@
+"""
+Per-source sensor coupling policy ("cut Lumen's spring, keep the fleet").
+
+UNITARES_SENSOR_COUPLING gains two fine-grained modes — behavioral_only /
+physical_only — resolved by sensor_coupling_mode()/sensor_coupling_allows().
+The monitor applies the decision where the sensor source is known: only
+`coupling_sensor` (possibly None) reaches the ODE, while the full submitted
+sensor is always kept for divergence.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from governance_core.parameters import sensor_coupling_mode, sensor_coupling_allows
+from src.governance_monitor import UNITARESMonitor
+
+BASE = {"response_text": "x", "complexity": 0.5, "parameters": [0.5] * 128}
+SENSOR = {"E": 0.4, "I": 0.7, "S": 0.2, "V": 0.1}
+
+
+class TestCouplingPolicy:
+    @pytest.mark.parametrize("env,expected", [
+        (None, "on"), ("on", "on"), ("1", "on"), ("true", "on"), ("yes", "on"),
+        ("off", "off"), ("0", "off"), ("no", "off"), ("false", "off"),
+        ("behavioral_only", "behavioral_only"), ("physical_only", "physical_only"),
+        ("garbage", "on"),
+    ])
+    def test_mode_resolution(self, env, expected, monkeypatch):
+        if env is None:
+            monkeypatch.delenv("UNITARES_SENSOR_COUPLING", raising=False)
+        else:
+            monkeypatch.setenv("UNITARES_SENSOR_COUPLING", env)
+        assert sensor_coupling_mode() == expected
+
+    @pytest.mark.parametrize("mode,source,allows", [
+        ("on", "physical", True), ("on", "behavioral", True), ("on", None, True),
+        ("off", "physical", False), ("off", "behavioral", False),
+        ("behavioral_only", "behavioral", True),
+        ("behavioral_only", "physical", False),
+        ("behavioral_only", None, False),   # unknown treated as physical
+        ("physical_only", "physical", True),
+        ("physical_only", None, True),
+        ("physical_only", "behavioral", False),
+    ])
+    def test_allows(self, mode, source, allows, monkeypatch):
+        monkeypatch.setenv("UNITARES_SENSOR_COUPLING", mode)
+        assert sensor_coupling_allows(source) is allows
+
+
+def _run(monitor, source):
+    st = dict(BASE)
+    st["sensor_eisv"] = dict(SENSOR)
+    if source is not None:
+        st["sensor_eisv_source"] = source
+    return monitor.process_update(st)
+
+
+def _spy_step_state():
+    """Wrap the real step_state, capturing the sensor_eisv kwarg it receives."""
+    import src.governance_monitor as gm
+    captured = {}
+    real = gm.step_state
+
+    def spy(*args, **kwargs):
+        captured["sensor_eisv"] = kwargs.get("sensor_eisv")
+        return real(*args, **kwargs)
+
+    return captured, spy
+
+
+class TestMonitorPerSourceGate:
+
+    def test_physical_spring_cut_under_behavioral_only(self, monkeypatch):
+        monkeypatch.setenv("UNITARES_SENSOR_COUPLING", "behavioral_only")
+        captured, spy = _spy_step_state()
+        m = UNITARESMonitor(agent_id="ps_phys_cut", load_state=False)
+        with patch("src.governance_monitor.step_state", spy):
+            _run(m, "physical")
+        # Lumen's (physical) spring is cut: nothing reaches the ODE...
+        assert captured["sensor_eisv"] is None
+        # ...but divergence is still recorded from the full submitted sensor.
+        assert m._last_sensor_divergence is not None
+
+    def test_behavioral_still_couples_under_behavioral_only(self, monkeypatch):
+        monkeypatch.setenv("UNITARES_SENSOR_COUPLING", "behavioral_only")
+        captured, spy = _spy_step_state()
+        m = UNITARESMonitor(agent_id="ps_beh_couple", load_state=False)
+        with patch("src.governance_monitor.step_state", spy):
+            _run(m, "behavioral")
+        assert captured["sensor_eisv"] is not None
+
+    def test_default_on_couples_physical(self, monkeypatch):
+        monkeypatch.delenv("UNITARES_SENSOR_COUPLING", raising=False)
+        captured, spy = _spy_step_state()
+        m = UNITARESMonitor(agent_id="ps_default", load_state=False)
+        with patch("src.governance_monitor.step_state", spy):
+            _run(m, "physical")
+        assert captured["sensor_eisv"] is not None  # no behavior change by default
+
+    def test_off_cuts_everything(self, monkeypatch):
+        monkeypatch.setenv("UNITARES_SENSOR_COUPLING", "off")
+        captured, spy = _spy_step_state()
+        m = UNITARESMonitor(agent_id="ps_off", load_state=False)
+        with patch("src.governance_monitor.step_state", spy):
+            _run(m, "behavioral")
+        assert captured["sensor_eisv"] is None
+        assert m._last_sensor_divergence is not None


### PR DESCRIPTION
## What
Adds `behavioral_only` / `physical_only` modes to `UNITARES_SENSOR_COUPLING` so the spring can be cut for **one sensor source** without touching the others. **Default `on` — no behavior change.**

`behavioral_only` is the **Lumen-only cut**: stop forcing the physical sensor (Lumen's Pi) into the ODE while leaving the disembodied fleet's behavioral sensor anchored.

## Why
The fleet-wide flag from #773 was all-or-nothing — cutting Lumen's spring meant cutting every agent's. But the commensurability problem is specific: Lumen's `V=(1−presence)·0.3` is a body-sense forced into the ODE's E−I-accumulator slot. The behavioral sensor (derived from governance observables) is a different question we haven't audited. This lets us cut the one we've diagnosed and leave the rest anchored until audited.

## How
- **`parameters.py`** — `sensor_coupling_mode()` → `{on,off,behavioral_only,physical_only}` (default `on`); the fine modes read truthy to the coarse `sensor_coupling_enabled()` gate so they compose. `sensor_coupling_allows(source)` is the per-source decision.
- **`phases.py`** — tag `sensor_eisv_source` = `physical` (caller-published `sensor_data["eisv"]`) vs `behavioral` (governance-derived).
- **`governance_monitor.py`** — apply the policy where the source is known: only the gated `coupling_sensor` (possibly `None`) reaches `step_state`; the **full submitted sensor is always kept for divergence**, so cutting the spring doesn't stop the measurement — it makes it the *clean, un-sprung* measurement (the proof condition).
- **tests** — mode/allows truth table + monitor spy proving physical is cut and behavioral still couples under `behavioral_only`; default still couples; `off` cuts all. (275 green across touched + adjacent suites.)

## Rollout
After merge + deploy, set `UNITARES_SENSOR_COUPLING=behavioral_only` on the live MCP → Lumen's ODE stops being tugged toward its body-sense, and Lumen's divergence readout becomes the clean un-sprung evidence (E/I/S should track; V is expected to drift — that drift is the documented homonym). Reversible via the flag. Fleet behavioral coupling untouched pending its own commensurability audit.