### PR TITLE
docs: currency pass — refresh snapshot + add scope/threat-model section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ UNITARES is for you if you run **multiple long-lived autonomous agents** — too
 
 **Integration cost:** one MCP/REST `sync_state` call per agent unit-of-work, plus a `record_result` callback for any task with a verifiable outcome (tests, exit codes, tool results). The dashboard, knowledge graph, peer review, and continuity features are all downstream of those two calls.
 
+**The threshold that matters is check-in count, not wall-clock time.** Self-relative grading needs roughly **30 check-ins** to establish an agent's baseline (absolute safety floors apply before that). An agent doing dozens of units of work — over an hour or a week — crosses it; one that does three and exits never does. That's the real line for "is my session long enough to benefit," not a duration.
+
 **Probably not worth it yet for** short-lived chatbot turns, where per-turn overhead outweighs the benefit, or for teams that can't instrument their agent loop. Whether this is useful outside the author's own deployment is still an open question — the [Production snapshot](#production-snapshot) is honest about that.
 
 ### Try it
@@ -129,20 +131,34 @@ The agent reads its own metrics and adjusts *before* external controls have to f
 
 ---
 
+## Scope and threat model
+
+UNITARES is **adversarial-aware, not adversarial-naive** — but its enforcement is deliberately conservative.
+
+**What resists gaming.** The signal is anchored to outcomes an agent can't fake: test pass/fail, exit codes, and tool results sent via `record_result()`. An agent can inflate its self-reported `confidence`, but not its actual success rate — sustained overconfidence drives Integrity (I) down regardless of what the agent claims. Drift (S) is graded against the agent's *own* prior trajectory, so there is no fixed threshold to pre-game, and calibration compounds over many tasks rather than judging any single check-in.
+
+**Why enforcement leans lenient.** Verdicts are biased toward `proceed`/`guide` over `pause`/`reject` by design. A false-positive pause on a productive agent is itself a failure mode — acutely so here, since the agents building UNITARES run under UNITARES. The verdict ladder exists so most signal arrives as information the agent can act on, not as a halt: high-confidence degradation trips a pause, ambiguity is surfaced rather than blocked.
+
+**What "no ethics classifier" does and doesn't mean.** It means there is no hand-labeled "is this ethical?" model in the loop — *not* that the system is value-free. Two consequences worth stating plainly: drift (S) is a *salience flag*, not a verdict — high entropy raises attention, it does not auto-fail, so beneficial exploration surfaces as something to look at rather than something to punish. And Integrity (I) is anchored to *ground truth* (outcomes), not to the agent's own history — an agent drifting toward better results shows *rising* I, not a penalty. The "past behavior was the desirable behavior" assumption applies only to S, not to the model as a whole.
+
+**The genuine open question.** Robustness against a *motivated* attacker deliberately optimizing the EISV proxy, at scale, is unproven. The deployment is single-operator with no red-team. That is the real limitation — not an absence of adversarial design, but an absence of adversarial *testing*.
+
+---
+
 ## Production snapshot
 
-Frozen public snapshot from May 6, 2026 (single-operator deployment — the author's own traffic, not external adoption). Headline: **351K+ governance events processed · ≈94K in the last 7 days**.
+Frozen public snapshot from June 16, 2026 (single-operator deployment — the author's own traffic, not external adoption). Headline: **3.7M+ governance events processed · ≈714K in the last 7 days**.
 
 <details>
 <summary><strong>Full metrics table</strong></summary>
 
 | Metric | Value |
 |--------|-------|
-| Agents onboarded | 3,660 total process-instances — overwhelmingly ephemeral CLI sessions from one operator's workstation plus a handful of long-running resident agents (launchd crons) |
-| Distinct event-emitting identities (last 21 days) | 1,144 total; mostly ephemeral local CLI sessions, not external adoption |
-| Unique agents active (last 7 days) | 135 distinct event emitters |
-| Governance events processed | 351,000+ (≈94K in the last 7 days) |
-| Knowledge graph discoveries | 860 |
+| Agents onboarded | 3,777 total process-instances — overwhelmingly ephemeral CLI sessions from one operator's workstation plus a handful of long-running resident agents (launchd crons) |
+| Distinct event-emitting identities (last 21 days) | 510; mostly ephemeral local CLI sessions, not external adoption (lower than earlier snapshots as identity-consolidation work cut phantom per-session identities) |
+| Unique agents active (last 7 days) | 369 distinct event emitters |
+| Governance events processed | 3,748,000+ (≈714K in the last 7 days) |
+| Knowledge graph discoveries | 1,054 |
 | V operating range | Active agents often within [-0.1, 0.1] |
 | Tests | 8,500+ collected · smoke/pre-push subset plus 25% min coverage gate |
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 Status: live. First public commit 2025-12-04. Cold evaluators can start with the [Reviewer Guide](docs/REVIEWER_GUIDE.md); architecture details are in [docs/UNIFIED_ARCHITECTURE.md](docs/UNIFIED_ARCHITECTURE.md).
 
+**Evaluating this with an agent? Don't trust the prose — regenerate the evidence.** On a fresh clone with no deployment DB, the [falsifiability harness](docs/REVIEWER_GUIDE.md#falsifiability-grade-eisv-yourself-dont-trust-this-doc) scores EISV/prior-state features against a deliberately dumb baseline on ranking (AUC) and calibration (Brier), timestamps its output, and self-labels each slice (`INCONCLUSIVE` / `SKEPTICAL` / `WEAK SIGNAL` / `KEEP TESTING`) rather than asserting. The deployment numbers below are a dated snapshot; the harness is the part you run yourself.
+
 **UNITARES watches a fleet of AI agents while they work and tells you — and each agent — when one is starting to go off the rails, before anything visibly breaks.**
 
 When you run many autonomous agents, you can already tell *who* is calling (identity) and *whether a model is good enough to deploy* (evals). What you usually can't see is what the fleet is doing **right now**: whether each agent is still making real progress, whether its confidence matches its actual results, and whether it's drifting away from how it normally behaves. That live picture is what UNITARES provides. It runs alongside your evals and guardrails — it doesn't replace them.

--- a/docs/REVIEWER_GUIDE.md
+++ b/docs/REVIEWER_GUIDE.md
@@ -24,7 +24,8 @@ UNITARES is runtime state telemetry for long-lived AI-agent fleets: agents check
 
 - Not an output filter or guardrail classifier.
 - Not a sandbox or permission system.
-- Not a universal ethics oracle.
+- Not a universal ethics oracle. "No ethics classifier" means no hand-labeled ethics model — not that the system is value-free; drift is a salience flag, not a verdict, and Integrity is anchored to outcomes rather than to the agent's own history.
+- Not hardened against a motivated adversary gaming the EISV proxy. The design is adversarial-aware — outcomes can't be faked, baselines are self-relative — but enforcement leans lenient by intent and there has been no red-team. See [README → Scope and threat model](../README.md#scope-and-threat-model).
 - Not a claim of broad external adoption yet; the public deployment metrics describe a single-operator stress test.
 
 ## Fast path: three minutes


### PR DESCRIPTION
## Why

An external evaluator's critique landed mostly on **stale info**, not on real gaps — the kind of thing where you've already moved past what the public docs say. This makes the public surface current so the next evaluation reasons from where the system actually is.

## What changed (docs only)

**1. Production snapshot — refreshed May 6 → June 16.** Numbers were ~10× stale. Pulled live from the governance DB:

| Metric | Was (May 6) | Now (Jun 16) |
|---|---|---|
| Events processed | 351K+ | **3.75M+** |
| Events last 7d | ≈94K | **≈714K** |
| Agents onboarded | 3,660 | 3,777 |
| KG discoveries | 860 | 1,054 |
| Active 7d | 135 | 369 |
| Distinct emitters 21d | 1,144 | 510 |

The distinct-21d **drop** (1,144 → 510) is real and honest to show: identity-consolidation work cut phantom per-session identities. Added a parenthetical so it doesn't read as decline.

**2. New `Scope and threat model` section** — the critique's gaming point had no public answer, so its absence read as a hole. Frames it correctly: **adversarial-aware, not adversarial-naive** (outcome anchoring can't be faked, baselines are self-relative), enforcement **deliberately lenient** (a false-positive pause on a productive agent is itself a failure — acutely so since the agents building UNITARES run under it), and states the **genuine** open question: no red-team at scale. Does *not* concede a non-adversarial threat model.

**3. Minimum-viable threshold** — replaced the hand-wavy 'hours or days' with the real number: **~30 check-ins** to establish a baseline, not wall-clock time.

**4. Neutrality tightening** — 'no ethics classifier' = no hand-labeled ethics model, *not* value-free; drift (S) is a salience flag not a verdict; Integrity (I) is ground-truth-anchored not baseline-anchored.

**5. Reviewer Guide** 'What this is not' — two bullets mirroring 2 & 4, linking the README section.

## Operator calls for you

- **Frozen-snapshot date:** I bumped the frozen date + numbers rather than leave a fixed historical point. If you'd rather keep May 6 as a citeable reference, say so and I'll revert just the snapshot.
- **Deferred:** the critique's op-complexity point (#2 — what's load-bearing vs droppable in the PG+AGE+pgvector+Redis stack) is left out to keep this focused. Easy follow-up if you want it.

Docs-only; tool-count check passes. Draft — you're the merge gate.