### PR TITLE
feat(dev): regenerate README snapshot from live DB (kill the staleness class)

### DIFF
--- a/scripts/dev/refresh_snapshot.py
+++ b/scripts/dev/refresh_snapshot.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Regenerate the README "Production snapshot" numbers from the live governance DB.
+
+The snapshot in README.md is a dated, single-operator figure block. Hand-maintaining
+it means it silently goes stale (it drifted ~10x once). This turns the refresh into one
+command so an evaluator never quotes a number that is six weeks behind.
+
+Usage:
+    python3 scripts/dev/refresh_snapshot.py              # print refreshed block to stdout
+    python3 scripts/dev/refresh_snapshot.py --write README.md   # update in place (row-keyed)
+    python3 scripts/dev/refresh_snapshot.py --check README.md   # report drift (exit 1 if stale)
+
+--check is a manual "is the snapshot stale?" probe. It is deliberately NOT wired into CI:
+the live numbers move every day, so a hard gate would always be red. Run it before a
+release or when an external evaluation is imminent.
+
+DB-derived rows come from audit.events / core.agents / knowledge.discoveries. The two
+non-DB rows ("V operating range", "Tests") are left untouched by --write and emitted from
+constants by the print path.
+
+Connection: GOVERNANCE_DATABASE_URL (same env the analysis scripts use), default local.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import re
+import sys
+from dataclasses import dataclass
+
+DEFAULT_DB_URL = os.environ.get(
+    "GOVERNANCE_DATABASE_URL",
+    "postgresql://postgres:postgres@localhost:5432/governance",
+)
+
+# Non-DB rows: preserved as-is by --write, emitted verbatim by the print path.
+STATIC_ROWS = [
+    ("V operating range", "Active agents often within [-0.1, 0.1]"),
+    (
+        "Tests",
+        "8,500+ collected · smoke/pre-push subset plus 25% min coverage gate",
+    ),
+]
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    events_total: int
+    events_7d: int
+    agents_total: int
+    distinct_21d: int
+    distinct_7d: int
+    kg_discoveries: int
+
+
+def humanize(n: int) -> str:
+    """Compact human form: 3,748,915 -> '3.7M', 713,540 -> '714K'."""
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{round(n / 1_000)}K"
+    return str(n)
+
+
+def floor_thousands(n: int) -> str:
+    """Conservative '+' floor: 3,748,915 -> '3,748,000'."""
+    return f"{(n // 1000) * 1000:,}"
+
+
+def headline(snap: Snapshot, date_str: str) -> str:
+    events = humanize(snap.events_total)
+    last7 = humanize(snap.events_7d)
+    return (
+        f"Frozen public snapshot from {date_str} (single-operator deployment — "
+        f"the author's own traffic, not external adoption). Headline: "
+        f"**{events}+ governance events processed · ≈{last7} in the last 7 days**."
+    )
+
+
+def db_rows(snap: Snapshot) -> list[tuple[str, str]]:
+    """The DB-derived (metric, value) rows, in README order."""
+    last7 = humanize(snap.events_7d)
+    return [
+        (
+            "Agents onboarded",
+            f"{snap.agents_total:,} total process-instances — overwhelmingly ephemeral "
+            "CLI sessions from one operator's workstation plus a handful of long-running "
+            "resident agents (launchd crons)",
+        ),
+        (
+            "Distinct event-emitting identities (last 21 days)",
+            f"{snap.distinct_21d:,}; mostly ephemeral local CLI sessions, not external adoption",
+        ),
+        (
+            "Unique agents active (last 7 days)",
+            f"{snap.distinct_7d:,} distinct event emitters",
+        ),
+        (
+            "Governance events processed",
+            f"{floor_thousands(snap.events_total)}+ (≈{last7} in the last 7 days)",
+        ),
+        ("Knowledge graph discoveries", f"{snap.kg_discoveries:,}"),
+    ]
+
+
+def render_block(snap: Snapshot, date_str: str) -> str:
+    """Full, paste-ready snapshot block: headline + complete metrics table."""
+    lines = [headline(snap, date_str), "", "| Metric | Value |", "|--------|-------|"]
+    for metric, value in db_rows(snap) + STATIC_ROWS:
+        lines.append(f"| {metric} | {value} |")
+    return "\n".join(lines)
+
+
+def _row_re(metric: str) -> re.Pattern[str]:
+    # Match a markdown table row keyed on the metric cell (leading pipe + metric).
+    return re.compile(r"^\| " + re.escape(metric) + r" \| .*\|\s*$", re.MULTILINE)
+
+
+_HEADLINE_RE = re.compile(
+    r"^Frozen public snapshot from .*? in the last 7 days\*\*\.\s*$",
+    re.MULTILINE,
+)
+
+
+def apply_to_readme(text: str, snap: Snapshot, date_str: str) -> str:
+    """Row-keyed in-place update of headline + DB rows. Loud failure if anchors absent."""
+    if not _HEADLINE_RE.search(text):
+        raise SystemExit("error: snapshot headline line not found in target; aborting --write.")
+    text = _HEADLINE_RE.sub(lambda _m: headline(snap, date_str), text, count=1)
+    for metric, value in db_rows(snap):
+        pat = _row_re(metric)
+        if not pat.search(text):
+            raise SystemExit(f"error: table row '{metric}' not found in target; aborting --write.")
+        text = pat.sub(lambda _m, v=value, k=metric: f"| {k} | {v} |", text, count=1)
+    return text
+
+
+def check_readme(text: str, snap: Snapshot) -> list[str]:
+    """Return a list of human-readable drift descriptions (empty = current)."""
+    drift: list[str] = []
+    for metric, value in db_rows(snap):
+        m = _row_re(metric).search(text)
+        if m is None:
+            drift.append(f"{metric}: row missing from README")
+            continue
+        expected = f"| {metric} | {value} |"
+        if m.group(0).rstrip() != expected:
+            drift.append(f"{metric}: README has `{m.group(0).strip()}` — live is `{value}`")
+    return drift
+
+
+async def fetch_snapshot(db_url: str) -> Snapshot:
+    try:
+        import asyncpg
+    except ModuleNotFoundError:
+        raise SystemExit("error: asyncpg not installed. Install with `pip install asyncpg`.")
+
+    conn = await asyncpg.connect(db_url)
+    try:
+        scalar = conn.fetchval
+        return Snapshot(
+            events_total=await scalar("SELECT count(*) FROM audit.events"),
+            events_7d=await scalar(
+                "SELECT count(*) FROM audit.events WHERE ts > now() - interval '7 days'"
+            ),
+            agents_total=await scalar("SELECT count(*) FROM core.agents"),
+            distinct_21d=await scalar(
+                "SELECT count(DISTINCT agent_id) FROM audit.events "
+                "WHERE ts > now() - interval '21 days'"
+            ),
+            distinct_7d=await scalar(
+                "SELECT count(DISTINCT agent_id) FROM audit.events "
+                "WHERE ts > now() - interval '7 days'"
+            ),
+            kg_discoveries=await scalar("SELECT count(*) FROM knowledge.discoveries"),
+        )
+    finally:
+        await conn.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--write", metavar="PATH", help="update the snapshot in PATH in place")
+    parser.add_argument("--check", metavar="PATH", help="report drift in PATH (exit 1 if stale)")
+    parser.add_argument(
+        "--date",
+        help="snapshot date label (default: today, UTC). Pass explicitly for reproducible runs.",
+    )
+    parser.add_argument("--db-url", default=DEFAULT_DB_URL, help="governance DB URL")
+    args = parser.parse_args(argv)
+
+    if args.date:
+        date_str = args.date
+    else:
+        # Imported lazily so the pure formatters above stay clock-free and unit-testable.
+        from datetime import datetime, timezone
+
+        date_str = datetime.now(timezone.utc).strftime("%B %-d, %Y")
+
+    snap = asyncio.run(fetch_snapshot(args.db_url))
+
+    if args.check:
+        with open(args.check, encoding="utf-8") as fh:
+            drift = check_readme(fh.read(), snap)
+        if drift:
+            print(f"snapshot STALE in {args.check}:", file=sys.stderr)
+            for d in drift:
+                print(f"  - {d}", file=sys.stderr)
+            return 1
+        print(f"snapshot current in {args.check}")
+        return 0
+
+    if args.write:
+        with open(args.write, encoding="utf-8") as fh:
+            original = fh.read()
+        updated = apply_to_readme(original, snap, date_str)
+        if updated == original:
+            print(f"{args.write}: already current, no change")
+            return 0
+        with open(args.write, "w", encoding="utf-8") as fh:
+            fh.write(updated)
+        print(f"{args.write}: snapshot updated ({date_str})")
+        return 0
+
+    print(render_block(snap, date_str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_refresh_snapshot.py
+++ b/tests/test_refresh_snapshot.py
@@ -1,0 +1,107 @@
+"""Unit tests for scripts/dev/refresh_snapshot.py.
+
+The DB fetch is brittle in CI (needs a live governance DB), so these exercise the
+pure, clock-free pieces: humanization, block rendering, in-place row replacement,
+and drift detection — driven by a fixed Snapshot so no clock or DB is touched.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "dev" / "refresh_snapshot.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("refresh_snapshot", SCRIPT)
+    assert spec and spec.loader
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["refresh_snapshot"] = m  # dataclass needs the module registered
+    spec.loader.exec_module(m)
+    return m
+
+
+@pytest.fixture
+def snap(mod):
+    return mod.Snapshot(
+        events_total=3_748_915,
+        events_7d=713_540,
+        agents_total=3_777,
+        distinct_21d=510,
+        distinct_7d=369,
+        kg_discoveries=1_054,
+    )
+
+
+def test_humanize(mod):
+    assert mod.humanize(3_748_915) == "3.7M"
+    assert mod.humanize(713_540) == "714K"
+    assert mod.humanize(999) == "999"
+    assert mod.humanize(1_000) == "1K"
+
+
+def test_floor_thousands(mod):
+    assert mod.floor_thousands(3_748_915) == "3,748,000"
+    assert mod.floor_thousands(999) == "0"
+
+
+def test_headline(mod, snap):
+    line = mod.headline(snap, "June 16, 2026")
+    assert line.startswith("Frozen public snapshot from June 16, 2026")
+    assert "**3.7M+ governance events processed · ≈714K in the last 7 days**." in line
+
+
+def test_render_block_includes_db_and_static_rows(mod, snap):
+    block = mod.render_block(snap, "June 16, 2026")
+    assert "| Governance events processed | 3,748,000+ (≈714K in the last 7 days) |" in block
+    assert "| Knowledge graph discoveries | 1,054 |" in block
+    # Static (non-DB) rows survive into the printed block.
+    assert "| V operating range | Active agents often within [-0.1, 0.1] |" in block
+    assert "| Tests | 8,500+ collected" in block
+
+
+def test_apply_to_readme_updates_db_rows_and_leaves_static(mod, snap):
+    original = (
+        "Frozen public snapshot from May 6, 2026 (single-operator deployment — "
+        "the author's own traffic, not external adoption). Headline: "
+        "**351K+ governance events processed · ≈94K in the last 7 days**.\n\n"
+        "| Metric | Value |\n"
+        "|--------|-------|\n"
+        "| Agents onboarded | 3,660 total process-instances — old text |\n"
+        "| Distinct event-emitting identities (last 21 days) | 1,144 total; old |\n"
+        "| Unique agents active (last 7 days) | 135 distinct event emitters |\n"
+        "| Governance events processed | 351,000+ (≈94K in the last 7 days) |\n"
+        "| Knowledge graph discoveries | 860 |\n"
+        "| V operating range | Active agents often within [-0.1, 0.1] |\n"
+        "| Tests | 8,500+ collected · smoke/pre-push subset plus 25% min coverage gate |\n"
+    )
+    updated = mod.apply_to_readme(original, snap, "June 16, 2026")
+    assert "**3.7M+ governance events processed · ≈714K in the last 7 days**." in updated
+    assert "| Governance events processed | 3,748,000+ (≈714K in the last 7 days) |" in updated
+    assert "| Knowledge graph discoveries | 1,054 |" in updated
+    # Non-DB rows are untouched.
+    assert "| V operating range | Active agents often within [-0.1, 0.1] |" in updated
+    assert "| Tests | 8,500+ collected · smoke/pre-push subset plus 25% min coverage gate |" in updated
+    # Old numbers are gone.
+    assert "351,000+" not in updated
+    assert "| Knowledge graph discoveries | 860 |" not in updated
+
+
+def test_apply_to_readme_aborts_when_anchor_missing(mod, snap):
+    with pytest.raises(SystemExit):
+        mod.apply_to_readme("no snapshot here", snap, "June 16, 2026")
+
+
+def test_check_readme_reports_drift_and_clean(mod, snap):
+    current_rows = "\n".join(f"| {k} | {v} |" for k, v in mod.db_rows(snap))
+    assert mod.check_readme(current_rows, snap) == []
+
+    stale = "| Knowledge graph discoveries | 860 |"
+    drift = mod.check_readme(stale, snap)
+    assert any("Knowledge graph discoveries" in d for d in drift)


### PR DESCRIPTION
## Why

Companion to #784. That PR fixed the *instance* (snapshot was 10× stale); this fixes the *class* — the root cause was hand-maintained numbers with no refresh trigger. The README is the first artifact a bot evaluating UNITARES parses, and a stale figure becomes its headline finding. This turns the refresh into one command.

## What

`scripts/dev/refresh_snapshot.py` — pulls the snapshot numbers live from the governance DB (`audit.events` / `core.agents` / `knowledge.discoveries`, via the same `GOVERNANCE_DATABASE_URL` the analysis scripts use):

- **default** — print a paste-ready headline + full metrics table to stdout
- **`--write README.md`** — row-keyed in-place update; leaves the two non-DB rows (`V operating range`, `Tests`) untouched, aborts loudly if the table anchors are missing
- **`--check README.md`** — report drift, exit 1 if stale

`--check` is deliberately **not** wired into CI: the live numbers move every day (they drifted measurably in the ~20 min while I built this), so a hard gate would always be red. It's a manual pre-release / pre-evaluation probe.

## Verification

- 7 unit tests on the pure, clock/DB-free pieces (humanize, render, in-place replace, drift detect) — green.
- Ran live: print mode emits a correct block; `--check` against the stale `master` README correctly reports all five drifted rows and exits 1.
- ruff clean. Additive only (new script + test, no README edit) → no conflict with #784.

## Ordering

Independent of #784 — merge in either order. `--write` works against the post-#784 README too (it keys on row labels, not values). Draft; you're the merge gate.