### PR TITLE
docs: lead with the mechanism — separate deployed EISV from target semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ From each check-in, UNITARES tracks four numbers per agent — together called *
 - **E (Energy)** — is the work advancing? Tool calls succeeding and decisions resolving raise E; thrashing, retries, and no-progress lower it.
 - **I (Integrity)** — do the agent's claims match its results? Confidence that lines up with the observed success rate raises I; high confidence with low actual success lowers it.
 - **S (Entropy)** — is the agent drifting from its own normal behavior? A steady, consistent trajectory keeps S low; erratic, divergent behavior pushes it up.
-- **V (Valence)** — a single summary number derived from the gap between E and I. Positive means *energetic but incoherent* (lots of motion, claims not matching outcomes); negative means *coherent but running low on progress*.
+- **V (Valence)** — a derived readout of the E−I gap, not an independent fourth dimension. Positive means *energetic but incoherent* (lots of motion, claims not matching outcomes); negative means *coherent but running low on progress*.
+
+These four numbers are computed from **auditable heuristic blends over observable behavior** — decision outcomes, calibration error (claimed confidence vs. verified success), drift from the agent's own baseline, tool results — then EMA-smoothed. There is no black box. The *information-theoretic* readings of E/I/S/V (entropy, mutual information, free energy) used in [Paper v6](https://github.com/cirwel/unitares-paper-v6) are **target semantics**, not what the running code computes today; the exact deployed formulas, with provenance tags, are in [How EISV is computed](docs/EISV_COMPUTATION.md).
 
 Each check-in returns a plain verdict — `proceed` / `guide` / `pause` / `reject` — so the agent can correct itself before any external safety system has to step in. Humans read the same state on a dashboard; other agents can read it over the API.
 
@@ -38,7 +40,7 @@ Self-reported confidence is only one input. UNITARES also watches **real outcome
 
 After about 30 check-ins, the four numbers are graded against the agent's *own* running history rather than a one-size-fits-all threshold. Absolute safety floors still apply on top of that.
 
-Running continuously since November 2025. State is stored in PostgreSQL + AGE. The underlying theory and the math (dynamical-systems) version of this model are in [Paper v6](https://github.com/cirwel/unitares-paper-v6) (DOI 10.5281/zenodo.19647159) — start there if you want the full derivation.
+Running continuously since November 2025; state in PostgreSQL + AGE. **The verdict path is the auditable behavioral model described above** — component risk plus self-relative z-scores, source in [`src/behavioral_assessment.py`](src/behavioral_assessment.py). A separate dynamical-systems model (`governance_core/`, the thermodynamic / free-energy formulation) runs **in parallel as a research cross-check and does not drive verdicts by default** ([`governance_monitor.py`](src/governance_monitor.py): *"the ODE runs in parallel but does NOT drive verdicts… primary verdicts come from behavioral assessment"*). Its derivation is in [Paper v6](https://github.com/cirwel/unitares-paper-v6) (DOI 10.5281/zenodo.19647159). Want the theory → start with the paper; want what actually fires → [How EISV is computed](docs/EISV_COMPUTATION.md).
 
 ### Who should integrate this
 

--- a/docs/EISV_COMPUTATION.md
+++ b/docs/EISV_COMPUTATION.md
@@ -1,0 +1,93 @@
+# How EISV Is Actually Computed
+
+**The formulas the running code computes, beside the information-theoretic semantics the paper targets.**
+
+UNITARES is described with thermodynamic and information-theoretic language (energy, entropy, valence, coherence; in [Paper v6](https://github.com/cirwel/unitares-paper-v6), `S` as response-distribution entropy, `I` as mutual information, `E` as negative variational free energy). That vocabulary is the **target semantics** — the model the project is working toward and tests honestly. It is **not** what the running code computes today.
+
+What the deployed system actually computes is the honest, defensible claim: **EISV is a set of auditable heuristic blends over observable agent behavior, EMA-smoothed, with verdicts from a transparent weighted-threshold model.** No entropy, mutual information, or free energy is computed on the primary path. Every coordinate carries a provenance tier tag (`e_source`, `s_source`, …) so a heuristic is never laundered as a measurement. This document gives the exact formulas with source references, so you can judge — or reproduce — them.
+
+## Pipeline (primary, verdict-driving path)
+
+```
+observables ──► observation blend ──► EMA smoothing ──► component risk ──► verdict
+(decisions,     (behavioral_         (behavioral_       (behavioral_       proceed/
+ calibration,    sensor.py)           state.py)          assessment.py)     guide/
+ drift, tools)                                                              pause/reject
+```
+
+The dynamical-systems / thermodynamic model (`governance_core/`, the ODE) runs **in parallel and does not drive verdicts** by default (`governance_monitor.py:1013-1017`: *"The ODE engine runs in parallel but does NOT drive verdicts… Primary verdicts come from behavioral assessment (EMA + z-score deviations)."*). It supplies the phi objective, regime detection, and historical continuity — the research lens, not the control loop.
+
+## Step 1 — Observations (`src/behavioral_sensor.py`)
+
+For non-embodied agents (the common case), three observations are computed from governance observables. Embodied agents (e.g. the Raspberry-Pi deployment) instead supply hardware `sensor_eisv` directly (`governance_monitor.py:967-972`).
+
+**E_obs** — productive capacity (`_compute_E`):
+```
+decision_e = exp-weighted (α=0.3) mean of verdict scores over last 10 decisions
+             {proceed/approve: 1.0, guide: 0.7, revise/reflect: 0.5, pause/reject: 0.0}
+coh_e      = mean coherence remapped [0.35, 0.65] → [0.3, 0.9]
+cal_e      = clamp(1 − complexity_divergence, 0.3, 1.0)
+E_obs      = 0.40·decision_e + 0.30·coh_e + 0.30·cal_e         # no outcomes
+           = 0.35·decision_e + 0.25·coh_e + 0.20·cal_e + 0.20·outcome_e   # with outcomes
+```
+
+**I_obs** — claims-match-results (`_compute_I`):
+```
+cal_I = clamp(1 − calibration_error, 0, 1)     # calibration_error = drift-blended claimed-vs-observed deviation (monitor_drift.py), not literally |confidence − success|
+coh_I = split-half coherence trend, mapped to [0.3, 0.9]
+I_obs = 0.6·cal_I + 0.4·coh_I                                   # no outcomes
+      = 0.50·cal_I + 0.30·coh_I + 0.20·consistency_I            # with outcomes
+```
+
+**S_obs** — drift from own normal behavior (`_compute_S`):
+```
+drift_s  = min(1, drift_norm · 1.5)
+regime_s = regime transitions / window      (instability)
+cd_s     = min(1, complexity_divergence)
+S_obs    = 0.40·drift_s + 0.35·regime_s + 0.25·cd_s
+```
+
+Optional small blends (when those signals exist): continuity-log inputs (≤20%), tool error-rate (≤15%), tool velocity / unique-tools ratio (≤10%). The weights are hand-set, not derived — that is the honest status of the current estimator.
+
+## Step 2 — Smoothing, and what V really is (`src/behavioral_state.py`)
+
+State is an EMA of the observations (α ramps from ~0.5 during bootstrap to a configured value):
+```
+E = (1−α)·E + α·E_obs        I = (1−α)·I + α·I_obs        S = (1−α)·S + α·S_obs
+```
+
+**V is not an independent dimension.** It is the EMA-smoothed E−I imbalance (`behavioral_state.py:174-176`):
+```
+raw_v = E − I
+V     = (1−α_V)·V + α_V·raw_v
+```
+So "four-dimensional state vector" is really three observed axes (E, I, S) plus a derived imbalance readout (V). V is surfaced separately because its **sign** is operationally actionable — positive = running hot (energetic but claims outrun results), negative = running careful (coherent but low progress) — not because it carries independent information.
+
+(If you grep the codebase you will find a second `_compute_V` — a slope-plus-level formula — in `behavioral_sensor.py`. It is **unused on the verdict path**: `governance_monitor.py:1002` passes only E/I/S observations to `behavioral_state.update()`, which recomputes V as the EMA of E−I above. The live V is the one described here.)
+
+## Step 3 — Verdict (`src/behavioral_assessment.py`)
+
+*"No sigmoid/phi black box. Each risk component has a clear source and weight. Assessment is auditable — you can trace exactly why a verdict was issued."* (module docstring.)
+
+- Total risk = sum of named components (`low_E`, `low_I`, high-`S`, `|V|`, …), each with an explicit weight.
+- **Warmup** (first ~30 check-ins): fixed universal thresholds.
+- **After warmup**: self-relative z-score deviations from the agent's *own* behavioral baseline.
+- **Absolute safety floors always apply**, overriding the baseline.
+- Self-relative deviation risk is **gated by absolute basin health** (issue #689): inside the healthy basin a deviation from your own norm is treated as information, not danger; the gate opens only as a dimension leaves the basin toward its absolute floor. (This replaced a flat σ-floor that was false-pausing ultra-stable agents.)
+
+Internally the assessment emits a `safe` / `caution` / `high-risk` label; that drives the binary `proceed` / `pause` action (qualified by a sub-action), which the agent reads back as `proceed` / `guide` / `pause` / `reject`.
+
+## Deployed vs. target, at a glance
+
+| Coord | Deployed today (tier: heuristic / resource) | Target semantics (Paper v6) |
+|---|---|---|
+| **E** | weighted blend of decision-success, coherence, complexity-calibration, outcomes | negative variational free energy (−F) |
+| **I** | calibration accuracy + coherence trend (+ outcome consistency) | mutual information I(context; response) |
+| **S** | drift-norm + regime instability + complexity divergence | response-distribution entropy H |
+| **V** | EMA-smoothed E−I imbalance (derived) | accumulated free-energy residual |
+
+The paper states this plainly: the deployed resource-rate form *"is **not** equivalent to −F and does not approximate it under stationarity in any formal sense."* The target forms become instrumentable only when the inference layer exposes the quantities they require (e.g. token-level logprobs for entropy). Until then, the heuristic is the claim and the information-theoretic form is the direction.
+
+## Don't take this document's word for it
+
+Whether these numbers predict anything beyond a dumb baseline is an **open, measured** question — not an assumption. The [Reviewer Guide's falsifiability harness](REVIEWER_GUIDE.md#falsifiability-grade-eisv-yourself-dont-trust-this-doc) scores EISV/prior-state features against a deliberately dumb `previous_outcome_bad` baseline on ranking (AUC) and calibration (Brier) and self-labels each slice (`INCONCLUSIVE` / `SKEPTICAL` / `WEAK SIGNAL` / `KEEP TESTING`). The current read is a weak early signal on the task scope at short lead, no demonstrated prevention, and a caveat that the lift may be carried by a single `prior_risk` feature rather than the full decomposition. Run it yourself.

--- a/docs/REVIEWER_GUIDE.md
+++ b/docs/REVIEWER_GUIDE.md
@@ -78,6 +78,7 @@ This complements evals, guardrails, and sandboxes. Evals ask whether a model sho
 
 ## Evidence to check
 
+- Deployed EISV formulas, with provenance tags and the deployed-vs-target-semantics table: [`docs/EISV_COMPUTATION.md`](EISV_COMPUTATION.md). Read this if the thermodynamic vocabulary makes you suspect hand-waving — it states exactly what the running code computes (auditable heuristic blends, EMA-smoothed) versus what the paper targets.
 - Public CI: tests, documentation validation, and CodeQL on the default branch.
 - Public release history: latest `v2.x` release in this repository.
 - Paper DOI: `10.5281/zenodo.19647159`.


### PR DESCRIPTION
## Why

Follow-up to #784/#785. Those made the README *current*; this makes its central construct *credible to a skeptical AI evaluator*. The first reader of this repo is increasingly a bot doing due diligence, and the strongest 'this is hand-wavy / numerology' trigger is **physics vocabulary (entropy, mutual information, free energy) describing a computation the running code does not perform** — the deployed E/I/S/V are auditable heuristic blends.

I ran an actual skeptical-reviewer agent against the repo to get the real doubt-triggers (not my guess), reframed to defuse them, then re-ran the skeptic to confirm. Per your call: **lead with the mechanism; physics as clearly-labeled target semantics.**

## What changed (docs only)

- **New `docs/EISV_COMPUTATION.md`** — the exact deployed formulas (`behavioral_sensor.py` blends → `behavioral_state.py` EMA → `behavioral_assessment.py` verdict) with source refs, provenance tier tags, and a deployed-vs-target table. A reader can now reproduce every number.
- **README EISV intro** — names the four numbers as auditable heuristic blends over observables (not a black box); the information-theoretic readings are **target semantics**, not what runs today; links the formulas doc.
- **V demoted** from 'fourth dimension' to derived E−I readout — it *is* `EMA(E−I)` at `behavioral_state.py:174-176`, not independent.
- **Verdict path separated from theory** — the auditable behavioral model drives verdicts; the ODE/thermodynamic model runs in parallel, diagnostic-only, *does not drive verdicts by default* (quoted from `governance_monitor.py`).
- **Reviewer Guide** — points skeptics at the formulas doc.

## Validation (the part that matters)

Re-ran the skeptic against the revised copy:
- **All four original triggers DEFUSED** (physics-as-decoration, physics-not-in-loop, V-padding, non-reproducible numbers).
- **Formulas verified accurate against source**, line by line. Two minor flags it raised (a loose `calibration_error` comment; a dormant unused `_compute_V` in the sensor file) are **fixed in this PR**.
- Bottom line, in its words: moves a skeptic *'from dismiss-as-numerology toward engage-with-an-honestly-scoped-heuristic.'*

## Note on positioning

This touches your EISV/thermodynamic framing — your call, which you made ('lead with the mechanism'). It reframes the **evaluator-facing copy only**; the **paper's** title/abstract is the same tension on a heavier surface (published DOI) and is a separate decision I did *not* touch. Docs-only; tool-count check green. Draft — you're the merge gate.