### PR TITLE
fix(kg): make bulk archival dual-write both stores (AGE + relational)

### DIFF
--- a/src/identity/r1_maintenance.py
+++ b/src/identity/r1_maintenance.py
@@ -146,8 +146,9 @@ async def archive_stale_public_r1_scores(
     dry_run: bool = True,
     limit: Optional[int] = None,
     db: Any = None,
+    graph: Any = None,
 ) -> dict[str, Any]:
-    """Archive stale public R1 KG nodes.
+    """Archive stale public R1 KG nodes — through the DUAL-WRITE backend path.
 
     The audit table keeps score history. Public KG nodes are the redacted,
     deduped-by-pair projection and are archived after the TTL without re-score.
@@ -158,6 +159,14 @@ async def archive_stale_public_r1_scores(
     ``src/identity/trajectory_continuity.py``), so this age-agnostic mode is
     the one-shot backlog cleanup for the legacy nodes. It is idempotent: a
     second run finds nothing because the first archived them all.
+
+    Archival delegates to ``KnowledgeGraph.archive_discoveries_batch`` so BOTH
+    the AGE graph node (which the live search/dashboard reads) and the canonical
+    relational ``knowledge.discoveries`` row are updated. The earlier raw
+    ``UPDATE knowledge.discoveries`` only touched the relational mirror, leaving
+    the AGE node stale — so archived scores kept showing in the dashboard. The
+    candidate enumeration still uses the relational table (every discovery is
+    dual-written, so it is a valid membership source).
     """
     backend = db or _get_db()
     if ttl_days < 0:
@@ -165,34 +174,53 @@ async def archive_stale_public_r1_scores(
     if limit is not None and limit <= 0:
         raise ValueError("limit must be positive when provided")
 
-    async with backend.acquire() as conn:
-        if dry_run:
+    if dry_run:
+        async with backend.acquire() as conn:
             rows = await conn.fetch(
                 _stale_public_r1_scores_select_sql(limit=limit),
                 ttl_days,
             )
             sample = [_row_to_stale_score(r) for r in rows]
             count = await conn.fetchval(_stale_public_r1_scores_count_sql(), ttl_days)
-            return {
-                "dry_run": True,
-                "ttl_days": ttl_days,
-                "would_archive": int(count or 0),
-                "sample": sample,
-                "limit": limit,
-            }
+        return {
+            "dry_run": True,
+            "ttl_days": ttl_days,
+            "would_archive": int(count or 0),
+            "sample": sample,
+            "limit": limit,
+        }
 
+    # Enumerate stale candidate ids (no default cap — archive all matching,
+    # bounded only by an explicit ``limit``), then dual-write archive them.
+    async with backend.acquire() as conn:
         rows = await conn.fetch(
-            _stale_public_r1_scores_archive_sql(limit=limit),
+            _stale_public_r1_scores_ids_sql(limit=limit),
             ttl_days,
         )
-        archived = [_row_to_stale_score(r) for r in rows]
+    sample = [_row_to_stale_score(r) for r in rows]
+    ids = [r["id"] for r in rows]
+    if not ids:
         return {
             "dry_run": False,
             "ttl_days": ttl_days,
-            "archived": len(archived),
-            "sample": archived,
+            "archived": 0,
+            "sample": [],
             "limit": limit,
         }
+
+    kg = graph
+    if kg is None:
+        from src.knowledge_graph import get_knowledge_graph
+        kg = await get_knowledge_graph()
+    result = await kg.archive_discoveries_batch(ids, reason="r1_public_kg_ttl")
+    return {
+        "dry_run": False,
+        "ttl_days": ttl_days,
+        "archived": int(result.get("archived", 0)),
+        "errors": result.get("errors", []),
+        "sample": sample,
+        "limit": limit,
+    }
 
 
 async def _load_provisional_lineage_candidates(
@@ -252,25 +280,22 @@ def _stale_public_r1_scores_select_sql(*, limit: Optional[int]) -> str:
     """
 
 
-def _stale_public_r1_scores_archive_sql(*, limit: Optional[int]) -> str:
+def _stale_public_r1_scores_ids_sql(*, limit: Optional[int]) -> str:
+    """Enumerate stale public R1 score ids for the apply path.
+
+    Unlike the dry-run select (which caps the *sample* at 20), this returns
+    every matching id (bounded only by an explicit ``limit``) so the apply
+    path archives the whole stale set, not just a 20-row preview.
+    """
     limit_sql = f"LIMIT {int(limit)}" if limit is not None else ""
     return f"""
-        WITH stale AS (
-            SELECT id
-            FROM knowledge.discoveries
-            WHERE type = 'trajectory_continuity_score'
-              AND status = 'open'
-              AND COALESCE(updated_at, created_at) < now() - ($1::int * INTERVAL '1 day')
-            ORDER BY COALESCE(updated_at, created_at)
-            {limit_sql}
-        )
-        UPDATE knowledge.discoveries d
-        SET status = 'archived',
-            resolved_at = now(),
-            updated_at = now()
-        FROM stale
-        WHERE d.id = stale.id
-        RETURNING d.id, d.agent_id, d.created_at, d.updated_at, d.status
+        SELECT id, agent_id, created_at, updated_at, status
+        FROM knowledge.discoveries
+        WHERE type = 'trajectory_continuity_score'
+          AND status = 'open'
+          AND COALESCE(updated_at, created_at) < now() - ($1::int * INTERVAL '1 day')
+        ORDER BY COALESCE(updated_at, created_at)
+        {limit_sql}
     """
 
 

--- a/src/storage/knowledge_graph_age.py
+++ b/src/storage/knowledge_graph_age.py
@@ -2308,9 +2308,23 @@ class KnowledgeGraphAGE:
         reason: str = "lifecycle_cleanup",
     ) -> Dict[str, Any]:
         """
-        Archive multiple discoveries in a batch.
+        Archive multiple discoveries in a batch — DUAL-WRITE.
 
-        Sets status to 'archived' and adds archive metadata.
+        Sets status to 'archived' on BOTH the AGE graph node and the canonical
+        relational ``knowledge.discoveries`` row, in a single transaction, so the
+        two stores stay consistent. The live search/dashboard reads the AGE
+        nodes; the relational table is the canonical row store. A previous
+        version updated only the AGE node, silently diverging the stores (an
+        archived discovery still showed `status='open'` in relational and vice
+        versa).
+
+        Accounting note: AGE's ``UNWIND … MATCH … SET … RETURN`` yields no rows
+        in the deployed AGE build even when the SET applies, so we must NOT
+        derive the archived count from that RETURN (the old code did, and always
+        reported `archived: 0 / all-errors` on success). We instead take the
+        authoritative affected-id list from the relational UPDATE's RETURNING —
+        valid because every discovery is dual-written, so the relational row is
+        the membership source of truth.
 
         Args:
             discovery_ids: List of discovery IDs to archive
@@ -2330,29 +2344,40 @@ class KnowledgeGraphAGE:
         from datetime import datetime
         archived_at = datetime.now().isoformat()
 
-        # Archive all discoveries in a single batch query
-        cypher = """
+        # AGE node update. No RETURN — the count comes from the relational side
+        # (AGE UNWIND-SET-RETURN is empty on this build even when SET succeeds).
+        age_cypher = """
             UNWIND ${ids} AS disc_id
             MATCH (d:Discovery {id: disc_id})
             SET d.status = 'archived',
                 d.archived_at = ${archived_at},
                 d.archive_reason = ${reason}
-            RETURN d.id as id
         """
 
         try:
-            results = await db.graph_query(cypher, {
-                "ids": discovery_ids,
-                "archived_at": archived_at,
-                "reason": reason,
-            })
-            archived_ids = set()
-            for r in results:
-                if isinstance(r, dict) and "error" not in r:
-                    rid = r.get("id") or r.get("discovery", {}).get("id")
-                    if rid:
-                        archived_ids.add(rid)
-
+            async with db.transaction() as conn:
+                # 1) AGE graph nodes (the store search/dashboard reads).
+                await db.graph_query(
+                    age_cypher,
+                    {"ids": discovery_ids, "archived_at": archived_at, "reason": reason},
+                    conn=conn,
+                )
+                # 2) Canonical relational rows — same transaction. RETURNING
+                #    gives the authoritative set of rows actually archived.
+                #    (relational has no archived_at/archive_reason columns; that
+                #    metadata lives only on the AGE node.)
+                rows = await conn.fetch(
+                    """
+                    UPDATE knowledge.discoveries
+                    SET status = 'archived',
+                        resolved_at = COALESCE(resolved_at, now()),
+                        updated_at = now()
+                    WHERE id = ANY($1::text[])
+                    RETURNING id
+                    """,
+                    discovery_ids,
+                )
+            archived_ids = {r["id"] for r in rows}
             errors = [
                 {"id": did, "error": "Not found or update failed"}
                 for did in discovery_ids if did not in archived_ids

--- a/tests/test_knowledge_graph_age.py
+++ b/tests/test_knowledge_graph_age.py
@@ -2444,24 +2444,48 @@ class TestArchiveDiscoveriesBatch:
 
     @pytest.mark.asyncio
     async def test_archives_successfully(self):
-        """Should archive all discoveries in a single batch query."""
+        """Should archive in BOTH stores; count comes from the relational
+        RETURNING, not the AGE UNWIND RETURN (which is empty on this build)."""
         kg, mock_db = make_kg_with_mock_db()
-        # Single batch UNWIND query returns all archived IDs
-        mock_db.graph_query.return_value = [{"id": "d1"}, {"id": "d2"}]
+        # AGE UNWIND-SET-RETURN yields nothing even on success — must not be
+        # used for accounting. The relational UPDATE RETURNING is authoritative.
+        mock_db.graph_query.return_value = []
+        mock_db._mock_conn.fetch.return_value = [{"id": "d1"}, {"id": "d2"}]
 
         result = await kg.archive_discoveries_batch(["d1", "d2"], reason="test_cleanup")
         assert result["success"] is True
         assert result["archived"] == 2
         assert result["reason"] == "test_cleanup"
-        # Should be a single graph_query call (batch UNWIND)
+
+    @pytest.mark.asyncio
+    async def test_dual_writes_both_stores_in_one_transaction(self):
+        """The archive must hit the AGE node (graph_query) AND the relational
+        row (conn.fetch UPDATE) within a single transaction — the regression
+        guard for the split-brain bug."""
+        kg, mock_db = make_kg_with_mock_db()
+        mock_db.graph_query.return_value = []
+        mock_db._mock_conn.fetch.return_value = [{"id": "d1"}]
+
+        await kg.archive_discoveries_batch(["d1"])
+
+        # AGE side: one UNWIND-SET on the Discovery nodes.
         assert mock_db.graph_query.await_count == 1
+        age_cypher = mock_db.graph_query.await_args.args[0]
+        assert "SET d.status = 'archived'" in age_cypher
+        # Relational side: an UPDATE on the canonical table, same conn/txn.
+        assert mock_db._mock_conn.fetch.await_count == 1
+        rel_sql = mock_db._mock_conn.fetch.await_args.args[0]
+        assert "UPDATE knowledge.discoveries" in rel_sql
+        assert "status = 'archived'" in rel_sql
+        mock_db.transaction.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_records_errors_for_failed_archives(self):
-        """Should record errors for discoveries not found in batch result."""
+        """Should record errors for ids the relational UPDATE did not return."""
         kg, mock_db = make_kg_with_mock_db()
-        # Batch returns only d1 (d2 was not found)
-        mock_db.graph_query.return_value = [{"id": "d1"}]
+        mock_db.graph_query.return_value = []
+        # Relational UPDATE returns only d1 (d2 had no row).
+        mock_db._mock_conn.fetch.return_value = [{"id": "d1"}]
 
         result = await kg.archive_discoveries_batch(["d1", "d2"])
         assert result["archived"] == 1
@@ -2470,11 +2494,10 @@ class TestArchiveDiscoveriesBatch:
 
     @pytest.mark.asyncio
     async def test_records_error_for_empty_result(self):
-        """Should record error when archive returns error result."""
+        """Nothing archived (no relational rows matched) → all errors."""
         kg, mock_db = make_kg_with_mock_db()
-        mock_db.graph_query.side_effect = [
-            [{"error": "not found"}],
-        ]
+        mock_db.graph_query.return_value = []
+        mock_db._mock_conn.fetch.return_value = []
 
         result = await kg.archive_discoveries_batch(["d1"])
         assert result["archived"] == 0

--- a/tests/test_r1_maintenance.py
+++ b/tests/test_r1_maintenance.py
@@ -198,31 +198,63 @@ async def test_archive_stale_public_r1_scores_dry_run_reports_count_and_sample()
     conn.fetchval.assert_awaited_once()
 
 
+class _FakeGraph:
+    """Stand-in for the KG backend; records the dual-write archive call."""
+
+    def __init__(self, archived=None):
+        self.calls = []
+        self._archived = archived
+
+    async def archive_discoveries_batch(self, ids, reason="lifecycle_cleanup"):
+        self.calls.append({"ids": list(ids), "reason": reason})
+        n = len(ids) if self._archived is None else self._archived
+        return {"success": True, "archived": n, "errors": [], "reason": reason}
+
+
 @pytest.mark.asyncio
-async def test_archive_stale_public_r1_scores_apply_archives_rows():
+async def test_archive_stale_public_r1_scores_apply_delegates_to_dual_write_batch():
+    """Apply path enumerates stale ids (relational), then archives via the
+    backend-aware DUAL-WRITE batch — NOT a raw relational UPDATE (which left
+    the AGE node stale, the original pollution bug)."""
     from src.identity.r1_maintenance import archive_stale_public_r1_scores
 
     now = datetime(2026, 5, 5, tzinfo=timezone.utc)
     conn = SimpleNamespace()
     conn.fetch = AsyncMock(return_value=[
-        {
-            "id": "r1_score:old",
-            "agent_id": "child",
-            "created_at": now,
-            "updated_at": now,
-            "status": "archived",
-        },
+        {"id": "r1_score:old", "agent_id": "child",
+         "created_at": now, "updated_at": now, "status": "open"},
     ])
     backend = _Backend(conn)
+    graph = _FakeGraph()
 
-    result = await archive_stale_public_r1_scores(db=backend, dry_run=False, limit=1)
+    result = await archive_stale_public_r1_scores(
+        db=backend, graph=graph, dry_run=False, limit=1
+    )
 
     assert result["dry_run"] is False
     assert result["archived"] == 1
-    assert result["sample"][0]["status"] == "archived"
+    # Enumeration is a SELECT, not a raw UPDATE.
     sql = conn.fetch.await_args.args[0]
-    assert "UPDATE knowledge.discoveries" in sql
+    assert "SELECT id" in sql and "UPDATE knowledge.discoveries" not in sql
     assert "LIMIT 1" in sql
+    # The dual-write batch was invoked with the enumerated ids.
+    assert graph.calls == [{"ids": ["r1_score:old"], "reason": "r1_public_kg_ttl"}]
+
+
+@pytest.mark.asyncio
+async def test_archive_stale_public_r1_scores_apply_no_candidates_skips_batch():
+    """No stale ids → return archived=0 without calling the batch archiver."""
+    from src.identity.r1_maintenance import archive_stale_public_r1_scores
+
+    conn = SimpleNamespace()
+    conn.fetch = AsyncMock(return_value=[])
+    backend = _Backend(conn)
+    graph = _FakeGraph()
+
+    result = await archive_stale_public_r1_scores(db=backend, graph=graph, dry_run=False)
+
+    assert result["archived"] == 0
+    assert graph.calls == []
 
 
 @pytest.mark.asyncio
@@ -235,17 +267,15 @@ async def test_archive_stale_public_r1_scores_ttl_zero_archives_all_regardless_o
     now = datetime(2026, 6, 16, tzinfo=timezone.utc)
     conn = SimpleNamespace()
     conn.fetch = AsyncMock(return_value=[
-        {
-            "id": "r1_score:today",
-            "agent_id": "child",
-            "created_at": now,
-            "updated_at": now,
-            "status": "archived",
-        },
+        {"id": "r1_score:today", "agent_id": "child",
+         "created_at": now, "updated_at": now, "status": "open"},
     ])
     backend = _Backend(conn)
+    graph = _FakeGraph()
 
-    result = await archive_stale_public_r1_scores(db=backend, ttl_days=0, dry_run=False)
+    result = await archive_stale_public_r1_scores(
+        db=backend, graph=graph, ttl_days=0, dry_run=False
+    )
 
     assert result["ttl_days"] == 0
     assert result["archived"] == 1


### PR DESCRIPTION
## Context

Follow-up to #782. While clearing the R1-score KG pollution, the archival appeared to work (relational rows showed `archived`) but the **dashboard still displayed the nodes** — because the live KG runs on the **AGE backend** (`UNITARES_KNOWLEDGE_BACKEND=age`) and the dashboard reads the **AGE graph nodes**, which were still `open`. This surfaced a real consistency-bug class.

## The dual-store model

Every discovery lives in BOTH `knowledge.discoveries` (relational, canonical row store) AND an AGE `Discovery` graph node (what search/dashboard read). The canonical paths keep them consistent in one transaction:
- `add_discovery` → `_persist_discovery_row` + AGE node ✅
- `update_discovery` → AGE Cypher `SET` + `_sync_updated_discovery_row` + embedding ✅
- agent-facing `knowledge update`/`supersede` route through `update_discovery` ✅

## The bug: two bulk paths bypass the dual-write

| Path | Wrote | Effect |
|------|-------|--------|
| `archive_discoveries_batch` | **AGE only** | relational left stale; **also reported `archived: 0/all-errors` on success** because AGE's `UNWIND…SET…RETURN` yields no rows on this build |
| `cleanup_stale_discoveries` | calls the above | lifecycle janitor inherits both bugs |
| `r1_maintenance.archive_stale_public_r1_scores` | **relational only** (raw SQL) | AGE node stayed `open` → archived R1 scores kept showing (the reported symptom) |

## Fixes
- **`archive_discoveries_batch`** — archive the AGE node **and** the relational row in a single transaction; take the authoritative archived-id set from the **relational UPDATE's `RETURNING`** (not the empty AGE RETURN). Transitively fixes `cleanup_stale_discoveries`.
- **`archive_stale_public_r1_scores`** — enumerate stale ids from relational (valid membership source — every row is dual-written), then delegate to the now-correct `archive_discoveries_batch`.
- **Tests** — assert the batch dual-writes both stores in one transaction and counts via the relational RETURNING; assert the maintenance sweep delegates to the backend-aware batch.

## Verification
- Unit: `tests/test_knowledge_graph_age.py` (162) + `tests/test_r1_maintenance.py` (9) green.
- **Live (AGE+PG):** new `archive_discoveries_batch` returns `success/archived=2/0-errors` and both stores read `archived` (was `0/all-errors` before).

## Out of scope (flagged)
- **Existing store divergence** — a live audit found **~300/1054 discoveries** with mismatched status between the stores (264 `archived|cold` historical, ~36 `open`-in-AGE-but-`archived/resolved`-in-relational — the same "should be hidden but still shows" class). This fix stops new divergence; reconciling the existing rows is a **separate, operator-gated** step (it mass-mutates KG data and needs a which-store-wins decision).
- `db/mixins/knowledge_graph.update_discovery_status` (relational-only) is unreachable under `backend=age`; left as-is.

🤖 Draft — load-bearing KG storage; operator is the merge gate.