### PR TITLE
fix(age): harden graph_query read path (AGE-canonical KG gate, step 2A)

### DIFF
--- a/src/db/mixins/graph.py
+++ b/src/db/mixins/graph.py
@@ -226,11 +226,13 @@ class GraphMixin:
 
         except Exception as e:
             if self._is_column_arity_error(e):
+                # Do NOT log the query text — a caller-built cypher can carry
+                # inline sensitive literals (clear-text-logging). The message is
+                # self-explanatory and the re-raise preserves the traceback.
                 logger.error(
                     "Cypher query failed (column arity): graph_query supports a "
                     "single return expression — use a map literal "
-                    "RETURN {a: expr1, b: expr2} for multiple values. Query: %s",
-                    cypher,
+                    "RETURN {a: expr1, b: expr2} for multiple values."
                 )
                 raise
             # Never attempt DDL-based repair on a caller-owned transaction

--- a/src/db/mixins/graph.py
+++ b/src/db/mixins/graph.py
@@ -14,6 +14,12 @@ logger = get_logger(__name__)
 class GraphMixin:
     """Apache AGE graph query operations."""
 
+    # Set True once the configured AGE graph is confirmed to exist, so the
+    # steady-state read path can skip the per-query ag_catalog.ag_graph
+    # existence round-trip. Reset by the stale-graph repair path so existence
+    # is re-validated after a drop/recreate.
+    _graph_exists_confirmed: bool = False
+
     async def graph_available(self) -> bool:
         """Check if AGE graph queries are available."""
         async with self.acquire() as conn:
@@ -30,15 +36,35 @@ class GraphMixin:
         await conn.execute("LOAD 'age'")
         await conn.execute("SET search_path = ag_catalog, core, audit, public")
 
-    async def _ensure_age_graph_exists(self, conn) -> None:
-        """Ensure the configured AGE graph exists, creating it when absent."""
+    async def _ensure_age_graph_exists(self, conn, *, external_conn: bool = False) -> None:
+        """Ensure the configured AGE graph exists, creating it when absent.
+
+        Short-circuits once existence is confirmed (steady state). When
+        ``external_conn`` is True the connection belongs to a caller-owned
+        transaction (e.g. the dual-write in add_discovery): creating the graph
+        here would issue DDL — an implicit COMMIT — mid-transaction and break
+        the caller's atomicity. So we never create on a borrowed transaction
+        connection; we surface a clear error and let the caller run graph setup
+        outside the transaction.
+        """
+        if self._graph_exists_confirmed:
+            return
         graph_exists = await conn.fetchval(
             "SELECT EXISTS(SELECT 1 FROM ag_catalog.ag_graph WHERE name = $1)",
             self._age_graph,
         )
-        if not graph_exists:
-            logger.warning(f"AGE graph '{self._age_graph}' missing, creating it")
-            await conn.execute("SELECT * FROM ag_catalog.create_graph($1)", self._age_graph)
+        if graph_exists:
+            self._graph_exists_confirmed = True
+            return
+        if external_conn:
+            raise RuntimeError(
+                f"AGE graph '{self._age_graph}' is missing and cannot be created on a "
+                "caller-owned transaction connection (DDL would break the transaction). "
+                "Run graph setup outside the transaction."
+            )
+        logger.warning(f"AGE graph '{self._age_graph}' missing, creating it")
+        await conn.execute("SELECT * FROM ag_catalog.create_graph($1)", self._age_graph)
+        self._graph_exists_confirmed = True
 
     async def _probe_age_graph(self, conn) -> None:
         """Verify the configured AGE graph can execute a trivial Cypher query."""
@@ -51,6 +77,60 @@ class GraphMixin:
         """Detect AGE catalog drift where the named graph points at a dead OID."""
         message = str(error).lower()
         return "graph with oid" in message and "does not exist" in message
+
+    @staticmethod
+    def _is_column_arity_error(error: Exception) -> bool:
+        """Detect a RETURN-arity vs output-column mismatch.
+
+        graph_query declares a single ``result agtype`` output column, so a
+        multi-column ``RETURN a, b`` is rejected by AGE/PostgreSQL. Surfaced as
+        a clear, actionable error rather than a silently-swallowed empty result.
+        """
+        message = str(error).lower()
+        return "column definition list" in message and (
+            "do not match" in message
+            or "does not match" in message
+            or "same number" in message
+        )
+
+    @staticmethod
+    def _decode_agtype_value(result: Any) -> Any:
+        """Decode one ``agtype`` output-column value (text form) into Python.
+
+        AGE annotates typed values with a ``::vertex``/``::edge``/``::path``
+        suffix AFTER the object/array they annotate — INCLUDING inside a map or
+        list, e.g. ``{"node": {...}::vertex, "depth": 0}``. We strip those
+        suffixes wherever they follow a ``}``/``]`` (the lookbehind avoids
+        touching identical text inside a quoted string value), plus a trailing
+        scalar ``::agtype``, so the whole value parses as JSON. Non-string
+        inputs (already-decoded dict/list/scalars) pass through unchanged.
+        """
+        if not isinstance(result, str):
+            return result
+        clean = re.sub(r"(?<=[}\]])::(?:vertex|edge|path)\b", "", result)
+        if clean.endswith("::agtype"):
+            clean = clean[: -len("::agtype")]
+        try:
+            return json.loads(clean)
+        except json.JSONDecodeError:
+            return result
+
+    def _interpolate_params(self, cypher: str, params: Optional[Dict[str, Any]]) -> str:
+        """Substitute ``${key}`` placeholders with sanitized values in ONE pass.
+
+        AGE has no native parameterization, so values are sanitized and
+        interpolated. A single combined-pattern pass (rather than re-scanning
+        the string per key) ensures a sanitized value that itself contains a
+        ``${otherkey}`` sequence — e.g. discovery text describing template
+        syntax — can never be re-interpolated on a later key's pass.
+        """
+        if not params:
+            return cypher
+        sanitized = {k: self._sanitize_cypher_param(v) for k, v in params.items()}
+        pattern = re.compile(
+            r"\$\{(" + "|".join(re.escape(k) for k in sanitized) + r")\}"
+        )
+        return pattern.sub(lambda m: sanitized[m.group(1)], cypher)
 
     async def _repair_stale_age_graph(self, conn, error: Exception) -> bool:
         """
@@ -71,6 +151,8 @@ class GraphMixin:
         async with self.acquire() as fresh_conn:
             await fresh_conn.execute("SELECT * FROM ag_catalog.drop_graph($1, true)", self._age_graph)
             await fresh_conn.execute("SELECT * FROM ag_catalog.create_graph($1)", self._age_graph)
+        # OID changed; force the next query to re-validate existence.
+        self._graph_exists_confirmed = False
         return True
 
     async def graph_query(
@@ -84,6 +166,12 @@ class GraphMixin:
 
         Parameters are validated and safely interpolated since AGE doesn't support
         parameterized Cypher queries ($1, $2 style).
+
+        Convention: a query must have a SINGLE return expression so it maps to
+        the one ``result agtype`` output column. For multiple values, project a
+        map literal: ``RETURN {a: expr1, b: expr2}`` (decoded to one dict per
+        row). A bare multi-column ``RETURN a, b`` raises an AGE column-arity
+        error.
 
         Args:
             cypher: Cypher query with ${param} placeholders
@@ -99,12 +187,17 @@ class GraphMixin:
         params: Optional[Dict[str, Any]],
         conn=None,
     ) -> List[Dict[str, Any]]:
-        """Internal graph query execution, supports both pooled and passed connections."""
+        """Internal graph query execution, supports both pooled and passed connections.
+
+        A passed-in ``conn`` is a caller-owned transaction connection: it is
+        flagged ``external_conn=True`` so the AGE-graph existence/repair paths
+        never run DDL on it (which would break the caller's transaction).
+        """
         if conn is not None:
-            return await self._run_cypher_on_conn(conn, cypher, params)
+            return await self._run_cypher_on_conn(conn, cypher, params, external_conn=True)
 
         async with self.acquire() as pooled_conn:
-            return await self._run_cypher_on_conn(pooled_conn, cypher, params)
+            return await self._run_cypher_on_conn(pooled_conn, cypher, params, external_conn=False)
 
     async def _run_cypher_on_conn(
         self,
@@ -113,6 +206,7 @@ class GraphMixin:
         params: Optional[Dict[str, Any]],
         *,
         _allow_repair: bool = True,
+        external_conn: bool = False,
     ) -> List[Dict[str, Any]]:
         """Execute a Cypher query on a specific connection."""
         try:
@@ -120,43 +214,29 @@ class GraphMixin:
             # RESET ALL on connection release, which clears search_path.
             # The 2 extra round-trips per query are worth correctness.
             await self._prepare_age_connection(conn)
-            await self._ensure_age_graph_exists(conn)
+            await self._ensure_age_graph_exists(conn, external_conn=external_conn)
 
-            safe_cypher = cypher
-            if params:
-                for k, v in params.items():
-                    safe_value = self._sanitize_cypher_param(v)
-                    safe_cypher = re.sub(
-                        rf'\$\{{{re.escape(k)}\}}',
-                        lambda _match, replacement=safe_value: replacement,
-                        safe_cypher,
-                    )
+            safe_cypher = self._interpolate_params(cypher, params)
 
             rows = await conn.fetch(
                 f"SELECT * FROM cypher('{self._age_graph}', $$ {safe_cypher} $$) as (result agtype)"
             )
 
-            results = []
-            for row in rows:
-                result = row["result"]
-                if isinstance(result, str):
-                    clean_result = result
-                    for suffix in ("::vertex", "::edge", "::agtype"):
-                        if clean_result.endswith(suffix):
-                            clean_result = clean_result[:-len(suffix)]
-                            break
-                    try:
-                        results.append(json.loads(clean_result))
-                    except json.JSONDecodeError:
-                        results.append(result)
-                elif isinstance(result, (dict, list)):
-                    results.append(result)
-                else:
-                    results.append(result)
-            return results
+            return [self._decode_agtype_value(row["result"]) for row in rows]
 
         except Exception as e:
-            if _allow_repair and self._is_stale_age_graph_error(e):
+            if self._is_column_arity_error(e):
+                logger.error(
+                    "Cypher query failed (column arity): graph_query supports a "
+                    "single return expression — use a map literal "
+                    "RETURN {a: expr1, b: expr2} for multiple values. Query: %s",
+                    cypher,
+                )
+                raise
+            # Never attempt DDL-based repair on a caller-owned transaction
+            # connection: drop/create_graph plus a retry on an already-aborted
+            # transaction corrupts the caller's atomicity (dual-write loss).
+            if _allow_repair and not external_conn and self._is_stale_age_graph_error(e):
                 repaired = await self._repair_stale_age_graph(conn, e)
                 if repaired:
                     return await self._run_cypher_on_conn(
@@ -164,6 +244,7 @@ class GraphMixin:
                         cypher,
                         params,
                         _allow_repair=False,
+                        external_conn=external_conn,
                     )
             logger.error(f"Cypher query failed: {e}")
             raise

--- a/src/storage/knowledge_graph_age.py
+++ b/src/storage/knowledge_graph_age.py
@@ -553,27 +553,23 @@ class KnowledgeGraphAGE:
 
         # Traverse from any node d to the root (discovery_id) via RESPONDS_TO edges.
         # Include depth 0 so the root itself is present in the chain.
+        # Project a single map literal (not a bare multi-column `RETURN d, depth`):
+        # graph_query declares one `result agtype` output column, so a map keeps
+        # node + depth in one column. Ordering is done in Python below.
         cypher = f"""
             MATCH (root:Discovery {{id: ${{discovery_id}}}})
             MATCH p = (d:Discovery)-[:RESPONDS_TO*0..{max_depth}]->(root:Discovery)
-            RETURN d, length(p) AS depth
-            ORDER BY depth ASC
+            RETURN {{node: d, depth: length(p)}}
         """
         rows = await db.graph_query(cypher, {"discovery_id": discovery_id})
 
         # Deduplicate by id using smallest depth
         best: Dict[str, tuple[int, DiscoveryNode]] = {}
         for row in rows or []:
-            # Handle different result formats
-            if isinstance(row, dict):
-                node_data = self._parse_agtype_node(row.get("d", row))
-                depth = int(row.get("depth", 0))
-            elif isinstance(row, (list, tuple)) and len(row) >= 2:
-                node_data = self._parse_agtype_node(row[0])
-                depth = int(row[1]) if row[1] is not None else 0
-            else:
-                node_data = self._parse_agtype_node(row)
-                depth = 0
+            if not isinstance(row, dict):
+                continue
+            node_data = self._parse_agtype_node(row.get("node", row))
+            depth = int(row.get("depth", 0) or 0)
             d = self._node_to_discovery(node_data)
             if not d or not d.id:
                 continue

--- a/tests/test_graph_query_reliability.py
+++ b/tests/test_graph_query_reliability.py
@@ -1,0 +1,199 @@
+"""graph_query wrapper reliability — the AGE-canonical read-path gate.
+
+These pin the wrapper-level behaviour that a council/live-diagnosis session
+established about `src/db/mixins/graph.py`:
+
+  * AGE itself is deterministic/correct at the psql layer; the only real
+    defects were in the Python wrapper.
+  * The single confirmed flakiness was a *multi-column* RETURN against the
+    hardcoded single `result agtype` output column — surface it as a clear
+    error and steer callers to the `RETURN {map}` convention instead.
+  * agtype text embeds `::vertex`/`::edge` type suffixes INSIDE maps/lists,
+    which the old trailing-only strip could not decode.
+  * `${param}` interpolation must be single-pass so a sanitized value that
+    contains a `${otherkey}` sequence can't be re-interpolated.
+  * DDL (`create_graph`/`drop_graph`) must NEVER run on a caller-owned
+    transaction connection (it would break dual-write atomicity).
+
+All strings below are the actual agtype text captured live from the
+`governance_graph` AGE graph, so the decode is pinned against reality.
+"""
+
+import pytest
+
+from src.db.mixins.graph import GraphMixin
+
+
+class _Graph(GraphMixin):
+    """Bare mixin host with just the attributes the unit under test reads."""
+
+    def __init__(self, age_graph: str = "test_graph"):
+        self._age_graph = age_graph
+
+
+class _FakeConn:
+    """Minimal asyncpg-conn stand-in for _ensure_age_graph_exists."""
+
+    def __init__(self, graph_exists: bool, *, fetchval_raises: bool = False):
+        self._graph_exists = graph_exists
+        self._fetchval_raises = fetchval_raises
+        self.executed: list = []
+
+    async def fetchval(self, *args):
+        if self._fetchval_raises:
+            raise AssertionError("fetchval should not be called (existence cached)")
+        return self._graph_exists
+
+    async def execute(self, *args):
+        self.executed.append(args)
+
+
+# --------------------------------------------------------------------------
+# agtype decode (_decode_agtype_value)
+# --------------------------------------------------------------------------
+
+def test_decode_scalar_count():
+    assert GraphMixin._decode_agtype_value("125") == 125
+
+
+def test_decode_string_value():
+    # `RETURN d.id AS id` came back as a quoted agtype string.
+    assert GraphMixin._decode_agtype_value('"2025-11-28T04:10:24.346843"') == (
+        "2025-11-28T04:10:24.346843"
+    )
+
+
+def test_decode_reachability_map():
+    # The PR2 reachability shape: pure-string map, no nested vertex.
+    raw = '{"ancestor": "da300b4a", "descendant": "0bc5ce0c"}'
+    assert GraphMixin._decode_agtype_value(raw) == {
+        "ancestor": "da300b4a",
+        "descendant": "0bc5ce0c",
+    }
+
+
+def test_decode_map_with_embedded_vertex_suffix():
+    # get_response_chain's `RETURN {node: d, depth: length(p)}` embeds a
+    # `::vertex` suffix INSIDE the map — the old trailing-only strip failed here.
+    raw = (
+        '{"node": {"id": 844424930131969, "label": "Discovery", '
+        '"properties": {"id": "2025-11-28T04:10:24", "status": "archived"}}'
+        '::vertex, "depth": 0}'
+    )
+    decoded = GraphMixin._decode_agtype_value(raw)
+    assert isinstance(decoded, dict)
+    assert decoded["depth"] == 0
+    assert decoded["node"]["properties"]["status"] == "archived"
+    assert decoded["node"]["label"] == "Discovery"
+
+
+def test_decode_bare_vertex_trailing_suffix():
+    raw = '{"id": 1, "label": "Agent", "properties": {"id": "x"}}::vertex'
+    decoded = GraphMixin._decode_agtype_value(raw)
+    assert decoded["properties"]["id"] == "x"
+
+
+def test_decode_does_not_strip_suffix_inside_string_value():
+    # A property string that literally contains '::vertex' must survive — the
+    # lookbehind only strips after a closing brace/bracket, not inside quotes.
+    raw = '{"summary": "the foo::vertex pattern", "n": 1}'
+    decoded = GraphMixin._decode_agtype_value(raw)
+    assert decoded["summary"] == "the foo::vertex pattern"
+
+
+def test_decode_none_passthrough():
+    assert GraphMixin._decode_agtype_value(None) is None
+
+
+def test_decode_unparseable_returns_raw():
+    assert GraphMixin._decode_agtype_value("not json {") == "not json {"
+
+
+# --------------------------------------------------------------------------
+# single-pass param interpolation (_interpolate_params)
+# --------------------------------------------------------------------------
+
+def test_interpolate_basic():
+    g = _Graph()
+    out = g._interpolate_params(
+        "MATCH (a:Agent {id: ${aid}}) RETURN a", {"aid": "abc"}
+    )
+    assert out == "MATCH (a:Agent {id: 'abc'}) RETURN a"
+
+
+def test_interpolate_no_params_noop():
+    g = _Graph()
+    assert g._interpolate_params("RETURN 1", None) == "RETURN 1"
+    assert g._interpolate_params("RETURN 1", {}) == "RETURN 1"
+
+
+def test_interpolate_single_pass_no_recursive_substitution():
+    # A value that itself contains another key's `${...}` placeholder must NOT
+    # be re-interpolated on the later key's pass.
+    g = _Graph()
+    out = g._interpolate_params(
+        "RETURN ${a}, ${b}", {"a": "${b}", "b": "real"}
+    )
+    # ${a} -> '${b}' (literal, single-quoted, sanitized), ${b} -> 'real'.
+    # The injected ${b} text must stay literal, not become 'real'.
+    assert out == "RETURN '${b}', 'real'"
+
+
+def test_interpolate_escapes_quotes():
+    g = _Graph()
+    out = g._interpolate_params("RETURN ${v}", {"v": "O'Brien"})
+    assert out == "RETURN 'O\\'Brien'"
+
+
+# --------------------------------------------------------------------------
+# column-arity error detection (_is_column_arity_error)
+# --------------------------------------------------------------------------
+
+def test_arity_error_detected():
+    err = Exception("return row and column definition list do not match")
+    assert GraphMixin._is_column_arity_error(err) is True
+
+
+def test_non_arity_error_not_flagged():
+    assert GraphMixin._is_column_arity_error(Exception("syntax error at or near")) is False
+
+
+# --------------------------------------------------------------------------
+# DDL never runs on a caller-owned transaction connection
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_ensure_graph_external_conn_missing_raises_not_creates():
+    g = _Graph()
+    conn = _FakeConn(graph_exists=False)
+    with pytest.raises(RuntimeError):
+        await g._ensure_age_graph_exists(conn, external_conn=True)
+    # Critically, it did NOT issue create_graph DDL on the transaction conn.
+    assert conn.executed == []
+    assert g._graph_exists_confirmed is False
+
+
+@pytest.mark.asyncio
+async def test_ensure_graph_pooled_conn_missing_creates():
+    g = _Graph()
+    conn = _FakeConn(graph_exists=False)
+    await g._ensure_age_graph_exists(conn, external_conn=False)
+    assert any("create_graph" in str(a) for a in conn.executed)
+    assert g._graph_exists_confirmed is True
+
+
+@pytest.mark.asyncio
+async def test_ensure_graph_present_marks_confirmed():
+    g = _Graph()
+    conn = _FakeConn(graph_exists=True)
+    await g._ensure_age_graph_exists(conn, external_conn=True)
+    assert g._graph_exists_confirmed is True
+
+
+@pytest.mark.asyncio
+async def test_ensure_graph_confirmed_short_circuits():
+    g = _Graph()
+    g._graph_exists_confirmed = True
+    # fetchval raising proves we never hit the DB once existence is confirmed.
+    conn = _FakeConn(graph_exists=True, fetchval_raises=True)
+    await g._ensure_age_graph_exists(conn, external_conn=True)

--- a/tests/test_knowledge_graph_age.py
+++ b/tests/test_knowledge_graph_age.py
@@ -688,15 +688,15 @@ class TestGetResponseChain:
         kg, mock_db = make_kg_with_mock_db()
         mock_db.graph_query.return_value = [
             {
-                "d": {"properties": {"id": "root", "agent_id": "a1", "summary": "root"}},
+                "node": {"properties": {"id": "root", "agent_id": "a1", "summary": "root"}},
                 "depth": 0,
             },
             {
-                "d": {"properties": {"id": "reply1", "agent_id": "a2", "summary": "reply"}},
+                "node": {"properties": {"id": "reply1", "agent_id": "a2", "summary": "reply"}},
                 "depth": 1,
             },
             {
-                "d": {"properties": {"id": "reply2", "agent_id": "a3", "summary": "deep reply"}},
+                "node": {"properties": {"id": "reply2", "agent_id": "a3", "summary": "deep reply"}},
                 "depth": 2,
             },
         ]
@@ -713,11 +713,11 @@ class TestGetResponseChain:
         kg, mock_db = make_kg_with_mock_db()
         mock_db.graph_query.return_value = [
             {
-                "d": {"properties": {"id": "disc-A", "agent_id": "a1", "summary": "A"}},
+                "node": {"properties": {"id": "disc-A", "agent_id": "a1", "summary": "A"}},
                 "depth": 0,
             },
             {
-                "d": {"properties": {"id": "disc-A", "agent_id": "a1", "summary": "A duplicate"}},
+                "node": {"properties": {"id": "disc-A", "agent_id": "a1", "summary": "A duplicate"}},
                 "depth": 3,
             },
         ]
@@ -727,11 +727,17 @@ class TestGetResponseChain:
         assert result[0].id == "disc-A"
 
     @pytest.mark.asyncio
-    async def test_handles_tuple_results(self):
-        """Should handle tuple/list result format."""
+    async def test_skips_non_dict_rows(self):
+        """Non-dict rows are skipped (single-column map convention).
+
+        The Cypher now projects a single ``RETURN {node: d, depth: length(p)}``
+        map, so every row decodes to a dict. A stray non-dict row (e.g. a bare
+        scalar) is skipped rather than crashing the chain.
+        """
         kg, mock_db = make_kg_with_mock_db()
         mock_db.graph_query.return_value = [
             ({"properties": {"id": "disc-X", "agent_id": "a1", "summary": "X"}}, 0),
+            {"node": {"properties": {"id": "disc-X", "agent_id": "a1", "summary": "X"}}, "depth": 0},
         ]
 
         result = await kg.get_response_chain("disc-X")
@@ -755,8 +761,8 @@ class TestGetResponseChain:
         """Should skip results that parse to no valid discovery."""
         kg, mock_db = make_kg_with_mock_db()
         mock_db.graph_query.return_value = [
-            {"d": {"properties": {"summary": "missing id"}}, "depth": 0},
-            {"d": {"properties": {"id": "valid", "agent_id": "a", "summary": "ok"}}, "depth": 1},
+            {"node": {"properties": {"summary": "missing id"}}, "depth": 0},
+            {"node": {"properties": {"id": "valid", "agent_id": "a", "summary": "ok"}}, "depth": 1},
         ]
 
         result = await kg.get_response_chain("root")


### PR DESCRIPTION
## What

The **read-reliability gate** for the AGE-canonical knowledge-graph move (handoff step 2A). Live diagnosis established that **AGE itself is deterministic and correct at the psql layer** — the read "flakiness" a parallel session saw was entirely in the Python `graph_query` wrapper. This hardens that wrapper and is a prerequisite for the lineage-reachability work (step 2B) and any later discovery canonical-collapse (step 1).

## Findings (live, in-process)

Ran the actual wrapper against `governance_graph`, 5 serial + 8 concurrent each:
- literal count, param count, single-property RETURN, `SPAWNED*1..N` traversal → **all deterministic** (125/125/125, 28, …).
- The **only** real defect: a multi-column `RETURN a, b` against the hardcoded single `result agtype` output column → `DatatypeMismatchError` (surfaced as "empty" in callers that swallow it). Not flaky — deterministic.

## Changes (`src/db/mixins/graph.py`)

- **DDL safety (latent dual-write corruption):** never run `create_graph`/`drop_graph` — or the stale-graph repair + retry — on a **caller-owned transaction connection** (it COMMITs mid-transaction and breaks `add_discovery`'s atomicity). New `external_conn` flag; missing-graph on a borrowed txn raises a clear error.
- **graph-existence cache:** skip the per-query `ag_graph` EXISTS round-trip once confirmed; reset on repair.
- **single-pass `${param}` interpolation:** a sanitized value containing a `${otherkey}` sequence can no longer be re-interpolated.
- **agtype decode:** strip embedded `::vertex`/`::edge`/`::path` suffixes *inside* maps/lists (lookbehind avoids quoted-string false positives), so `RETURN {map}` forms parse — not just trailing suffixes.
- **column-arity:** detect the single-vs-multi RETURN mismatch and raise a clear error steering callers to the `RETURN {map}` convention (documented on `graph_query`).

Fix the one live violator: `get_response_chain` now projects `RETURN {node: d, depth: length(p)}` (single agtype column) instead of the bare `RETURN d, length(p)` that errored.

## Tests

- 18 new tests (`tests/test_graph_query_reliability.py`) pinning decode / one-pass interpolation / DDL-guard against agtype strings **captured live** from `governance_graph`.
- Existing `get_response_chain` mocks updated to the map shape.
- Verified end-to-end in-process against live AGE: deterministic counts, 30 reachability pairs, map-with-vertex decode. `212 passed` across the AGE KG + fallback + reliability files.

## Scope / safety

Additive and behavior-preserving for existing single-value callers; no `graph_query` signature change. This is **read-path hardening only** — the lineage-reachability gate + archival wiring (recoverable-by-construction, with fallback) lands in a follow-up PR.

Council-reviewed (architect + adversarial reviewer + live-verifier). Draft — operator is the merge gate.