### PR TITLE
feat(liveness): consume agent:/ lease-plane presence in the archival gate (#795 activation, consumer half)

### DIFF
--- a/src/db/mixins/graph.py
+++ b/src/db/mixins/graph.py
@@ -226,11 +226,13 @@ class GraphMixin:
 
         except Exception as e:
             if self._is_column_arity_error(e):
+                # Do NOT log the query text — a caller-built cypher can carry
+                # inline sensitive literals (clear-text-logging). The message is
+                # self-explanatory and the re-raise preserves the traceback.
                 logger.error(
                     "Cypher query failed (column arity): graph_query supports a "
                     "single return expression — use a map literal "
-                    "RETURN {a: expr1, b: expr2} for multiple values. Query: %s",
-                    cypher,
+                    "RETURN {a: expr1, b: expr2} for multiple values."
                 )
                 raise
             # Never attempt DDL-based repair on a caller-owned transaction

--- a/src/db/mixins/graph.py
+++ b/src/db/mixins/graph.py
@@ -14,6 +14,12 @@ logger = get_logger(__name__)
 class GraphMixin:
     """Apache AGE graph query operations."""
 
+    # Set True once the configured AGE graph is confirmed to exist, so the
+    # steady-state read path can skip the per-query ag_catalog.ag_graph
+    # existence round-trip. Reset by the stale-graph repair path so existence
+    # is re-validated after a drop/recreate.
+    _graph_exists_confirmed: bool = False
+
     async def graph_available(self) -> bool:
         """Check if AGE graph queries are available."""
         async with self.acquire() as conn:
@@ -30,15 +36,35 @@ class GraphMixin:
         await conn.execute("LOAD 'age'")
         await conn.execute("SET search_path = ag_catalog, core, audit, public")
 
-    async def _ensure_age_graph_exists(self, conn) -> None:
-        """Ensure the configured AGE graph exists, creating it when absent."""
+    async def _ensure_age_graph_exists(self, conn, *, external_conn: bool = False) -> None:
+        """Ensure the configured AGE graph exists, creating it when absent.
+
+        Short-circuits once existence is confirmed (steady state). When
+        ``external_conn`` is True the connection belongs to a caller-owned
+        transaction (e.g. the dual-write in add_discovery): creating the graph
+        here would issue DDL — an implicit COMMIT — mid-transaction and break
+        the caller's atomicity. So we never create on a borrowed transaction
+        connection; we surface a clear error and let the caller run graph setup
+        outside the transaction.
+        """
+        if self._graph_exists_confirmed:
+            return
         graph_exists = await conn.fetchval(
             "SELECT EXISTS(SELECT 1 FROM ag_catalog.ag_graph WHERE name = $1)",
             self._age_graph,
         )
-        if not graph_exists:
-            logger.warning(f"AGE graph '{self._age_graph}' missing, creating it")
-            await conn.execute("SELECT * FROM ag_catalog.create_graph($1)", self._age_graph)
+        if graph_exists:
+            self._graph_exists_confirmed = True
+            return
+        if external_conn:
+            raise RuntimeError(
+                f"AGE graph '{self._age_graph}' is missing and cannot be created on a "
+                "caller-owned transaction connection (DDL would break the transaction). "
+                "Run graph setup outside the transaction."
+            )
+        logger.warning(f"AGE graph '{self._age_graph}' missing, creating it")
+        await conn.execute("SELECT * FROM ag_catalog.create_graph($1)", self._age_graph)
+        self._graph_exists_confirmed = True
 
     async def _probe_age_graph(self, conn) -> None:
         """Verify the configured AGE graph can execute a trivial Cypher query."""
@@ -51,6 +77,60 @@ class GraphMixin:
         """Detect AGE catalog drift where the named graph points at a dead OID."""
         message = str(error).lower()
         return "graph with oid" in message and "does not exist" in message
+
+    @staticmethod
+    def _is_column_arity_error(error: Exception) -> bool:
+        """Detect a RETURN-arity vs output-column mismatch.
+
+        graph_query declares a single ``result agtype`` output column, so a
+        multi-column ``RETURN a, b`` is rejected by AGE/PostgreSQL. Surfaced as
+        a clear, actionable error rather than a silently-swallowed empty result.
+        """
+        message = str(error).lower()
+        return "column definition list" in message and (
+            "do not match" in message
+            or "does not match" in message
+            or "same number" in message
+        )
+
+    @staticmethod
+    def _decode_agtype_value(result: Any) -> Any:
+        """Decode one ``agtype`` output-column value (text form) into Python.
+
+        AGE annotates typed values with a ``::vertex``/``::edge``/``::path``
+        suffix AFTER the object/array they annotate — INCLUDING inside a map or
+        list, e.g. ``{"node": {...}::vertex, "depth": 0}``. We strip those
+        suffixes wherever they follow a ``}``/``]`` (the lookbehind avoids
+        touching identical text inside a quoted string value), plus a trailing
+        scalar ``::agtype``, so the whole value parses as JSON. Non-string
+        inputs (already-decoded dict/list/scalars) pass through unchanged.
+        """
+        if not isinstance(result, str):
+            return result
+        clean = re.sub(r"(?<=[}\]])::(?:vertex|edge|path)\b", "", result)
+        if clean.endswith("::agtype"):
+            clean = clean[: -len("::agtype")]
+        try:
+            return json.loads(clean)
+        except json.JSONDecodeError:
+            return result
+
+    def _interpolate_params(self, cypher: str, params: Optional[Dict[str, Any]]) -> str:
+        """Substitute ``${key}`` placeholders with sanitized values in ONE pass.
+
+        AGE has no native parameterization, so values are sanitized and
+        interpolated. A single combined-pattern pass (rather than re-scanning
+        the string per key) ensures a sanitized value that itself contains a
+        ``${otherkey}`` sequence — e.g. discovery text describing template
+        syntax — can never be re-interpolated on a later key's pass.
+        """
+        if not params:
+            return cypher
+        sanitized = {k: self._sanitize_cypher_param(v) for k, v in params.items()}
+        pattern = re.compile(
+            r"\$\{(" + "|".join(re.escape(k) for k in sanitized) + r")\}"
+        )
+        return pattern.sub(lambda m: sanitized[m.group(1)], cypher)
 
     async def _repair_stale_age_graph(self, conn, error: Exception) -> bool:
         """
@@ -71,6 +151,8 @@ class GraphMixin:
         async with self.acquire() as fresh_conn:
             await fresh_conn.execute("SELECT * FROM ag_catalog.drop_graph($1, true)", self._age_graph)
             await fresh_conn.execute("SELECT * FROM ag_catalog.create_graph($1)", self._age_graph)
+        # OID changed; force the next query to re-validate existence.
+        self._graph_exists_confirmed = False
         return True
 
     async def graph_query(
@@ -84,6 +166,12 @@ class GraphMixin:
 
         Parameters are validated and safely interpolated since AGE doesn't support
         parameterized Cypher queries ($1, $2 style).
+
+        Convention: a query must have a SINGLE return expression so it maps to
+        the one ``result agtype`` output column. For multiple values, project a
+        map literal: ``RETURN {a: expr1, b: expr2}`` (decoded to one dict per
+        row). A bare multi-column ``RETURN a, b`` raises an AGE column-arity
+        error.
 
         Args:
             cypher: Cypher query with ${param} placeholders
@@ -99,12 +187,17 @@ class GraphMixin:
         params: Optional[Dict[str, Any]],
         conn=None,
     ) -> List[Dict[str, Any]]:
-        """Internal graph query execution, supports both pooled and passed connections."""
+        """Internal graph query execution, supports both pooled and passed connections.
+
+        A passed-in ``conn`` is a caller-owned transaction connection: it is
+        flagged ``external_conn=True`` so the AGE-graph existence/repair paths
+        never run DDL on it (which would break the caller's transaction).
+        """
         if conn is not None:
-            return await self._run_cypher_on_conn(conn, cypher, params)
+            return await self._run_cypher_on_conn(conn, cypher, params, external_conn=True)
 
         async with self.acquire() as pooled_conn:
-            return await self._run_cypher_on_conn(pooled_conn, cypher, params)
+            return await self._run_cypher_on_conn(pooled_conn, cypher, params, external_conn=False)
 
     async def _run_cypher_on_conn(
         self,
@@ -113,6 +206,7 @@ class GraphMixin:
         params: Optional[Dict[str, Any]],
         *,
         _allow_repair: bool = True,
+        external_conn: bool = False,
     ) -> List[Dict[str, Any]]:
         """Execute a Cypher query on a specific connection."""
         try:
@@ -120,43 +214,29 @@ class GraphMixin:
             # RESET ALL on connection release, which clears search_path.
             # The 2 extra round-trips per query are worth correctness.
             await self._prepare_age_connection(conn)
-            await self._ensure_age_graph_exists(conn)
+            await self._ensure_age_graph_exists(conn, external_conn=external_conn)
 
-            safe_cypher = cypher
-            if params:
-                for k, v in params.items():
-                    safe_value = self._sanitize_cypher_param(v)
-                    safe_cypher = re.sub(
-                        rf'\$\{{{re.escape(k)}\}}',
-                        lambda _match, replacement=safe_value: replacement,
-                        safe_cypher,
-                    )
+            safe_cypher = self._interpolate_params(cypher, params)
 
             rows = await conn.fetch(
                 f"SELECT * FROM cypher('{self._age_graph}', $$ {safe_cypher} $$) as (result agtype)"
             )
 
-            results = []
-            for row in rows:
-                result = row["result"]
-                if isinstance(result, str):
-                    clean_result = result
-                    for suffix in ("::vertex", "::edge", "::agtype"):
-                        if clean_result.endswith(suffix):
-                            clean_result = clean_result[:-len(suffix)]
-                            break
-                    try:
-                        results.append(json.loads(clean_result))
-                    except json.JSONDecodeError:
-                        results.append(result)
-                elif isinstance(result, (dict, list)):
-                    results.append(result)
-                else:
-                    results.append(result)
-            return results
+            return [self._decode_agtype_value(row["result"]) for row in rows]
 
         except Exception as e:
-            if _allow_repair and self._is_stale_age_graph_error(e):
+            if self._is_column_arity_error(e):
+                logger.error(
+                    "Cypher query failed (column arity): graph_query supports a "
+                    "single return expression — use a map literal "
+                    "RETURN {a: expr1, b: expr2} for multiple values. Query: %s",
+                    cypher,
+                )
+                raise
+            # Never attempt DDL-based repair on a caller-owned transaction
+            # connection: drop/create_graph plus a retry on an already-aborted
+            # transaction corrupts the caller's atomicity (dual-write loss).
+            if _allow_repair and not external_conn and self._is_stale_age_graph_error(e):
                 repaired = await self._repair_stale_age_graph(conn, e)
                 if repaired:
                     return await self._run_cypher_on_conn(
@@ -164,6 +244,7 @@ class GraphMixin:
                         cypher,
                         params,
                         _allow_repair=False,
+                        external_conn=external_conn,
                     )
             logger.error(f"Cypher query failed: {e}")
             raise

--- a/src/mcp_handlers/identity/process_binding.py
+++ b/src/mcp_handlers/identity/process_binding.py
@@ -307,6 +307,47 @@ async def get_live_bindings(agent_id: str) -> List[Dict[str, Any]]:
         return []
 
 
+async def has_live_agent_lease(agent_uuid: Optional[str]) -> bool:
+    """True if the agent holds a live ``agent:/<uuid>`` lease-plane presence lease.
+
+    The lease-plane liveness signal for EPHEMERAL agents — the ones that don't
+    hold a ``local_beam`` resident lease and (today) write no process binding, so
+    ``get_live_bindings`` is structurally blind to them. The recurring
+    false-archival bug is exactly that blindness: an ephemeral agent with no
+    runtime liveness signal gets archived as a succeeded predecessor while still
+    working. Pairs with the check-in-path producer that acquires/heartbeats the
+    ``agent:/<uuid>`` lease.
+
+    Liveness = an unreleased ``agent:/`` surface lease whose TTL has not expired
+    (keyed on ``expires_at``, NOT ``last_heartbeat_at`` — resident leases leave
+    that NULL by design). Reads ``lease_plane.surface_leases`` directly (same
+    governance DB). Returns False on a missing uuid or ANY error, so the caller
+    falls back to its other liveness signals — this can only ADD protection,
+    never remove it.
+    """
+    if not agent_uuid:
+        return False
+    try:
+        from src.db import get_db
+        db = get_db()
+        async with db.acquire() as conn:
+            live = await conn.fetchval(
+                """
+                SELECT EXISTS(
+                    SELECT 1 FROM lease_plane.surface_leases
+                    WHERE surface_id = $1
+                      AND released_at IS NULL
+                      AND expires_at > NOW()
+                )
+                """,
+                f"agent:/{agent_uuid}",
+            )
+        return bool(live)
+    except Exception as e:  # pragma: no cover - defensive, fail-open to other signals
+        logger.debug(f"[PROCESS_BINDING] has_live_agent_lease failed (non-fatal): {e}")
+        return False
+
+
 async def process_binding_sweeper_task() -> None:
     """Periodic sweeper — runs every LIVE_WINDOW_SECONDS.
 

--- a/src/mcp_handlers/lifecycle/helpers.py
+++ b/src/mcp_handlers/lifecycle/helpers.py
@@ -61,10 +61,17 @@ async def manual_archive_liveness_signals(
     signals: list[str] = []
 
     try:
-        from src.mcp_handlers.identity.process_binding import get_live_bindings
+        from src.mcp_handlers.identity.process_binding import (
+            get_live_bindings,
+            has_live_agent_lease,
+        )
         bindings = await get_live_bindings(agent_uuid)
         if bindings:
             signals.append(f"{len(bindings)} live process binding(s)")
+        # Lease-plane presence — the liveness signal for ephemeral agents that
+        # binding-liveness is structurally blind to (see has_live_agent_lease).
+        if await has_live_agent_lease(agent_uuid):
+            signals.append("live agent:/ lease-plane presence lease")
     except Exception as e:  # pragma: no cover - defensive, fail-open
         logger.debug(f"manual_archive liveness binding check failed: {e}")
 

--- a/src/mcp_handlers/lifecycle/lineage_reachability.py
+++ b/src/mcp_handlers/lifecycle/lineage_reachability.py
@@ -1,0 +1,203 @@
+"""Transitive lineage-succession reachability — a de-risk capability for the
+AGE-canonical knowledge-graph move, wired in SHADOW mode over the archival
+decision.
+
+Single-hop ``_live_lineage_parent_ids`` marks a parent "superseded" when it has
+an active, recent child whose ``spawn_reason`` is a SUCCESSION — anything except
+``subagent``/``compaction``, which keep the parent live by design (#779). The
+flat one-hop pass misses a chain ``P -> M -> C`` where the intermediate ``M``
+has exited but a deeper descendant ``C`` is live: ``P``'s lineage continued, but
+one hop can't see past the stale ``M``.
+
+This module computes the TRANSITIVE succession-ancestor set:
+
+  * Authoritative source = a recursive CTE over ``core.identities``, applying the
+    SAME succession filter as the single-hop pass (``spawn_reason NOT IN
+    {subagent, compaction}``). Relational truth, deterministic, no AGE dependency.
+  * AGE cross-check = a single-round-trip ``SPAWNED*1..N`` Cypher walk. AGE 1.7.0
+    cannot causal-filter a variable-length path (no ``ALL()`` predicate, no
+    ``relationships()`` property access — both raise), so the walk is UNFILTERED
+    and ADVISORY: it measures whether the graph's reachability TOPOLOGY matches
+    the relational truth. That agreement is the evidence the step-1 (discovery
+    canonical-collapse) decision needs, and it is the one thing only the graph
+    can show cheaply.
+
+Recoverable by construction: every failure path yields an EMPTY set, so a caller
+keeps its existing single-hop behavior. The module can only ever ADD succeeded
+ancestors; it never removes a caller's protection, and the caller's
+``get_live_bindings`` gate stays the hard stop against retiring a still-running
+agent. It is wired in SHADOW mode first (measure + log, no mutation) because
+amplifying the superseded set on a correctness-critical archival path warrants
+live evidence before it drives real archivals.
+
+ACTIVATION PREREQUISITE (do not flip shadow -> active until this holds):
+The transitive set enlarges the candidate pool that the liveness gate must
+protect. The recurring false-archival bug is, at root, a *liveness-signal* gap:
+ephemeral session agents do not spawn through the orchestrator, hold no
+``agent:`` lease, and have no reliable runtime liveness signal — so prior fixes
+fell back to stale ``agent_state`` and archived live work. The lease plane tracks
+liveness for residents but not (yet) for those ephemeral agents. Before this set
+drives real archivals, the gate must source liveness from the LEASE PLANE (with
+ephemeral-agent liveness actually tracked there), not from ``agent_state``.
+Until then, the single-hop ``get_live_bindings`` gate carries archival and this
+module only measures.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from src.db import get_db
+from src.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+# Spawn reasons that keep the parent LIVE by design — a child declaring one is
+# NOT a successor (its parent is its still-running dispatcher / same session).
+# Mirrors the single-hop exclusion in stuck.py::_live_lineage_parent_ids (#779).
+# Every other reason (explicit, dispatch, new_session, fleet_dispatch, ...) — and
+# a NULL reason — is treated as a succession edge, exactly as the single-hop pass
+# does, so the transitive set is a superset of the single-hop set, not a
+# differently-scoped one.
+_NON_SUCCESSION_SPAWN_REASONS = ("subagent", "compaction")
+
+# Hard cap on transitive depth; succession chains are shallow in practice
+# (the live probe found depth-5 added only 2 nodes beyond depth-1).
+_MAX_DEPTH = 5
+
+
+async def reachable_ancestors(
+    live_child_ids: Iterable[str], depth_limit: int = _MAX_DEPTH
+) -> set[str]:
+    """Transitive succession-ancestor UUIDs of the given live child agents.
+
+    Returns the set of agent UUIDs that are ancestors (1..depth_limit hops) of
+    any live child via SUCCESSION lineage, per the authoritative relational CTE.
+    Runs the AGE walk alongside purely to log topology agreement. Returns an
+    EMPTY set on empty input or ANY error — the caller then keeps its single-hop
+    behavior.
+    """
+    child_ids = {c for c in live_child_ids if c}
+    if not child_ids:
+        return set()
+
+    try:
+        db = get_db()
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("lineage_reachability: get_db failed (%s); no expansion", type(e).__name__)
+        return set()
+
+    try:
+        causal = await _cte_ancestors(db, child_ids, depth_limit)
+    except Exception as e:
+        logger.warning("lineage_reachability: CTE failed (%s); no expansion", type(e).__name__)
+        return set()
+
+    # Advisory AGE cross-check — never drives the returned set.
+    try:
+        age = await _age_ancestors(db, child_ids, depth_limit)
+        _record_reachability_agreement(age, causal)
+    except Exception as e:
+        logger.debug("lineage_reachability: AGE cross-check unavailable (%s)", type(e).__name__)
+
+    return causal
+
+
+async def _cte_ancestors(db, child_ids: set[str], depth_limit: int) -> set[str]:
+    """Recursive CTE over core.identities — succession-filtered transitive ancestors.
+
+    Succession filter mirrors the single-hop pass: an edge counts unless its
+    spawn_reason is subagent/compaction (NULL counts as succession-eligible).
+    """
+    depth = max(1, min(int(depth_limit), _MAX_DEPTH))
+    sql = """
+        WITH RECURSIVE ancestors(agent_id, depth) AS (
+            SELECT i.parent_agent_id, 1
+            FROM core.identities i
+            WHERE i.agent_id = ANY($1::text[])
+              AND i.parent_agent_id IS NOT NULL
+              AND (i.spawn_reason IS NULL OR i.spawn_reason <> ALL($2::text[]))
+            UNION ALL
+            SELECT i.parent_agent_id, a.depth + 1
+            FROM core.identities i
+            JOIN ancestors a ON i.agent_id = a.agent_id
+            WHERE i.parent_agent_id IS NOT NULL
+              AND (i.spawn_reason IS NULL OR i.spawn_reason <> ALL($2::text[]))
+              AND a.depth < $3
+        )
+        SELECT DISTINCT agent_id FROM ancestors WHERE agent_id IS NOT NULL
+    """
+    async with db.acquire() as conn:
+        rows = await conn.fetch(
+            sql, list(child_ids), list(_NON_SUCCESSION_SPAWN_REASONS), depth
+        )
+    return {r["agent_id"] for r in rows if r["agent_id"]}
+
+
+async def _age_ancestors(db, child_ids: set[str], depth_limit: int) -> set[str]:
+    """AGE SPAWNED*1..N walk (UNFILTERED — advisory cross-check only).
+
+    AGE 1.7.0 cannot filter a variable-length path by edge property, so this is
+    the full reachability including coincidental new_session edges. Used solely
+    to measure topology agreement against the authoritative CTE — never to drive
+    archival.
+    """
+    depth = max(1, min(int(depth_limit), _MAX_DEPTH))
+    cypher = (
+        f"MATCH (ancestor:Agent)-[:SPAWNED*1..{depth}]->(child:Agent) "
+        "WHERE child.id IN ${child_ids} AND ancestor.id <> child.id "
+        "RETURN DISTINCT {ancestor: ancestor.id}"
+    )
+    rows = await db.graph_query(cypher, {"child_ids": sorted(child_ids)})
+    out: set[str] = set()
+    for row in rows or []:
+        if isinstance(row, dict) and row.get("ancestor"):
+            out.add(row["ancestor"])
+    return out
+
+
+def _record_reachability_agreement(age: set[str], causal: set[str]) -> None:
+    """Log AGE-vs-CTE reachability agreement — evidence for the step-1 decision.
+
+    AGE (unfiltered) should be a SUPERSET of the causal CTE: the extra entries are
+    reachable only via non-succession (coincidental) edges, and any causal entry
+    AGE misses indicates a stale/missing SPAWNED edge (write-path lag).
+    """
+    if age == causal:
+        logger.info("lineage_reachability: AGE==CTE topology match (%d ancestors)", len(causal))
+        return
+    coincidental_only = age - causal
+    missing_in_age = causal - age
+    logger.info(
+        "lineage_reachability: AGE/CTE divergence — causal=%d age=%d "
+        "coincidental_only=%d missing_in_age=%d",
+        len(causal), len(age), len(coincidental_only), len(missing_in_age),
+    )
+
+
+async def measure_transitive_expansion(
+    live_child_ids: Iterable[str],
+    single_hop_parent_ids: Iterable[str],
+    depth_limit: int = _MAX_DEPTH,
+) -> dict:
+    """SHADOW measurement: what transitive succession-reachability WOULD add to
+    the single-hop superseded set (and the AGE/CTE agreement logged inside
+    ``reachable_ancestors``). Read-only — logs a summary and returns it, never
+    mutates the archival decision.
+    """
+    single_hop = {p for p in single_hop_parent_ids if p}
+    ancestors = await reachable_ancestors(live_child_ids, depth_limit)
+    new_beyond_single_hop = ancestors - single_hop
+    summary = {
+        "single_hop": len(single_hop),
+        "transitive_total": len(ancestors),
+        "new_beyond_single_hop": len(new_beyond_single_hop),
+    }
+    if new_beyond_single_hop:
+        logger.info(
+            "lineage_reachability SHADOW: transitive would add +%d ancestor(s) "
+            "beyond single-hop %s",
+            len(new_beyond_single_hop),
+            summary,
+        )
+    return summary

--- a/src/mcp_handlers/lifecycle/stuck.py
+++ b/src/mcp_handlers/lifecycle/stuck.py
@@ -212,6 +212,32 @@ def _live_lineage_parent_ids(
     return live
 
 
+def _live_child_uuids(
+    current_time, window_minutes: float = LINEAGE_SUCCESSION_FRESH_WINDOW_MINUTES
+) -> set:
+    """UUIDs of the active, recent SUCCESSION children feeding _live_lineage_parent_ids.
+
+    Same selection as _live_lineage_parent_ids (active + recent + non-subagent/
+    compaction spawn_reason), but returns the CHILD UUIDs rather than their
+    declared parents — the seed set for transitive succession-ancestor lookups.
+    """
+    children: set = set()
+    for meta in mcp_server.agent_metadata.values():
+        parent = getattr(meta, "parent_agent_id", None)
+        if not parent:
+            continue
+        if getattr(meta, "status", None) != "active":
+            continue
+        if (getattr(meta, "spawn_reason", None) or "") in ("subagent", "compaction"):
+            continue
+        age = _agent_age_minutes(meta, current_time)
+        if age is not None and age <= window_minutes:
+            uid = getattr(meta, "agent_uuid", None) or getattr(meta, "agent_id", None)
+            if uid:
+                children.add(uid)
+    return children
+
+
 def _is_superseded_by_lineage(agent_id, meta, live_parent_ids: set) -> bool:
     """True if a live lineage child has taken over from this agent."""
     if not live_parent_ids:
@@ -591,6 +617,20 @@ async def _archive_superseded_parents(current_time) -> list:
     live_parent_ids = _live_lineage_parent_ids(current_time)
     if not live_parent_ids:
         return results
+
+    # SHADOW (observation-only, no mutation): measure what transitive
+    # succession-reachability WOULD add beyond this single-hop set, and log the
+    # AGE-vs-CTE topology agreement (evidence for the AGE-canonical step-1
+    # decision). Stays measurement-only until the liveness gate sources ephemeral
+    # agents from the lease plane — see lineage_reachability ACTIVATION
+    # PREREQUISITE. Never drives the archival loop below.
+    try:
+        from .lineage_reachability import measure_transitive_expansion
+        await measure_transitive_expansion(
+            _live_child_uuids(current_time), live_parent_ids
+        )
+    except Exception as e:  # pragma: no cover - observation must never block archival
+        logger.debug("transitive lineage shadow measure failed: %s", type(e).__name__)
 
     for agent_id, meta in list(mcp_server.agent_metadata.items()):
         if meta.status != "active":

--- a/src/mcp_handlers/lifecycle/stuck.py
+++ b/src/mcp_handlers/lifecycle/stuck.py
@@ -662,8 +662,21 @@ async def _archive_superseded_parents(current_time) -> list:
         # case; this is the real liveness signal. Best-effort: get_live_bindings
         # returns [] on DB error, falling back to prior behavior rather than
         # blocking cleanup.
-        from src.mcp_handlers.identity.process_binding import get_live_bindings
+        #
+        # Two liveness sources, either of which protects: (1) a process binding
+        # (today only written when a client sends process_fingerprint — rare, so
+        # this is structurally blind to most ephemeral agents); (2) a live
+        # agent:/<uuid> lease-plane presence lease, the signal the check-in-path
+        # producer keeps fresh for exactly the ephemeral agents binding-liveness
+        # misses. Both fail-open (False on error) so a liveness lookup failure
+        # never blocks cleanup; either being live is sufficient to preserve.
+        from src.mcp_handlers.identity.process_binding import (
+            get_live_bindings,
+            has_live_agent_lease,
+        )
         if await get_live_bindings(agent_id):
+            continue
+        if await has_live_agent_lease(getattr(meta, "agent_uuid", None)):
             continue
         ok = await _archive_one_agent(
             agent_id, meta, "lineage_succession", monitors=mcp_server.monitors

--- a/src/storage/knowledge_graph_age.py
+++ b/src/storage/knowledge_graph_age.py
@@ -553,27 +553,23 @@ class KnowledgeGraphAGE:
 
         # Traverse from any node d to the root (discovery_id) via RESPONDS_TO edges.
         # Include depth 0 so the root itself is present in the chain.
+        # Project a single map literal (not a bare multi-column `RETURN d, depth`):
+        # graph_query declares one `result agtype` output column, so a map keeps
+        # node + depth in one column. Ordering is done in Python below.
         cypher = f"""
             MATCH (root:Discovery {{id: ${{discovery_id}}}})
             MATCH p = (d:Discovery)-[:RESPONDS_TO*0..{max_depth}]->(root:Discovery)
-            RETURN d, length(p) AS depth
-            ORDER BY depth ASC
+            RETURN {{node: d, depth: length(p)}}
         """
         rows = await db.graph_query(cypher, {"discovery_id": discovery_id})
 
         # Deduplicate by id using smallest depth
         best: Dict[str, tuple[int, DiscoveryNode]] = {}
         for row in rows or []:
-            # Handle different result formats
-            if isinstance(row, dict):
-                node_data = self._parse_agtype_node(row.get("d", row))
-                depth = int(row.get("depth", 0))
-            elif isinstance(row, (list, tuple)) and len(row) >= 2:
-                node_data = self._parse_agtype_node(row[0])
-                depth = int(row[1]) if row[1] is not None else 0
-            else:
-                node_data = self._parse_agtype_node(row)
-                depth = 0
+            if not isinstance(row, dict):
+                continue
+            node_data = self._parse_agtype_node(row.get("node", row))
+            depth = int(row.get("depth", 0) or 0)
             d = self._node_to_discovery(node_data)
             if not d or not d.id:
                 continue

--- a/tests/test_graph_query_reliability.py
+++ b/tests/test_graph_query_reliability.py
@@ -1,0 +1,199 @@
+"""graph_query wrapper reliability — the AGE-canonical read-path gate.
+
+These pin the wrapper-level behaviour that a council/live-diagnosis session
+established about `src/db/mixins/graph.py`:
+
+  * AGE itself is deterministic/correct at the psql layer; the only real
+    defects were in the Python wrapper.
+  * The single confirmed flakiness was a *multi-column* RETURN against the
+    hardcoded single `result agtype` output column — surface it as a clear
+    error and steer callers to the `RETURN {map}` convention instead.
+  * agtype text embeds `::vertex`/`::edge` type suffixes INSIDE maps/lists,
+    which the old trailing-only strip could not decode.
+  * `${param}` interpolation must be single-pass so a sanitized value that
+    contains a `${otherkey}` sequence can't be re-interpolated.
+  * DDL (`create_graph`/`drop_graph`) must NEVER run on a caller-owned
+    transaction connection (it would break dual-write atomicity).
+
+All strings below are the actual agtype text captured live from the
+`governance_graph` AGE graph, so the decode is pinned against reality.
+"""
+
+import pytest
+
+from src.db.mixins.graph import GraphMixin
+
+
+class _Graph(GraphMixin):
+    """Bare mixin host with just the attributes the unit under test reads."""
+
+    def __init__(self, age_graph: str = "test_graph"):
+        self._age_graph = age_graph
+
+
+class _FakeConn:
+    """Minimal asyncpg-conn stand-in for _ensure_age_graph_exists."""
+
+    def __init__(self, graph_exists: bool, *, fetchval_raises: bool = False):
+        self._graph_exists = graph_exists
+        self._fetchval_raises = fetchval_raises
+        self.executed: list = []
+
+    async def fetchval(self, *args):
+        if self._fetchval_raises:
+            raise AssertionError("fetchval should not be called (existence cached)")
+        return self._graph_exists
+
+    async def execute(self, *args):
+        self.executed.append(args)
+
+
+# --------------------------------------------------------------------------
+# agtype decode (_decode_agtype_value)
+# --------------------------------------------------------------------------
+
+def test_decode_scalar_count():
+    assert GraphMixin._decode_agtype_value("125") == 125
+
+
+def test_decode_string_value():
+    # `RETURN d.id AS id` came back as a quoted agtype string.
+    assert GraphMixin._decode_agtype_value('"2025-11-28T04:10:24.346843"') == (
+        "2025-11-28T04:10:24.346843"
+    )
+
+
+def test_decode_reachability_map():
+    # The PR2 reachability shape: pure-string map, no nested vertex.
+    raw = '{"ancestor": "da300b4a", "descendant": "0bc5ce0c"}'
+    assert GraphMixin._decode_agtype_value(raw) == {
+        "ancestor": "da300b4a",
+        "descendant": "0bc5ce0c",
+    }
+
+
+def test_decode_map_with_embedded_vertex_suffix():
+    # get_response_chain's `RETURN {node: d, depth: length(p)}` embeds a
+    # `::vertex` suffix INSIDE the map — the old trailing-only strip failed here.
+    raw = (
+        '{"node": {"id": 844424930131969, "label": "Discovery", '
+        '"properties": {"id": "2025-11-28T04:10:24", "status": "archived"}}'
+        '::vertex, "depth": 0}'
+    )
+    decoded = GraphMixin._decode_agtype_value(raw)
+    assert isinstance(decoded, dict)
+    assert decoded["depth"] == 0
+    assert decoded["node"]["properties"]["status"] == "archived"
+    assert decoded["node"]["label"] == "Discovery"
+
+
+def test_decode_bare_vertex_trailing_suffix():
+    raw = '{"id": 1, "label": "Agent", "properties": {"id": "x"}}::vertex'
+    decoded = GraphMixin._decode_agtype_value(raw)
+    assert decoded["properties"]["id"] == "x"
+
+
+def test_decode_does_not_strip_suffix_inside_string_value():
+    # A property string that literally contains '::vertex' must survive — the
+    # lookbehind only strips after a closing brace/bracket, not inside quotes.
+    raw = '{"summary": "the foo::vertex pattern", "n": 1}'
+    decoded = GraphMixin._decode_agtype_value(raw)
+    assert decoded["summary"] == "the foo::vertex pattern"
+
+
+def test_decode_none_passthrough():
+    assert GraphMixin._decode_agtype_value(None) is None
+
+
+def test_decode_unparseable_returns_raw():
+    assert GraphMixin._decode_agtype_value("not json {") == "not json {"
+
+
+# --------------------------------------------------------------------------
+# single-pass param interpolation (_interpolate_params)
+# --------------------------------------------------------------------------
+
+def test_interpolate_basic():
+    g = _Graph()
+    out = g._interpolate_params(
+        "MATCH (a:Agent {id: ${aid}}) RETURN a", {"aid": "abc"}
+    )
+    assert out == "MATCH (a:Agent {id: 'abc'}) RETURN a"
+
+
+def test_interpolate_no_params_noop():
+    g = _Graph()
+    assert g._interpolate_params("RETURN 1", None) == "RETURN 1"
+    assert g._interpolate_params("RETURN 1", {}) == "RETURN 1"
+
+
+def test_interpolate_single_pass_no_recursive_substitution():
+    # A value that itself contains another key's `${...}` placeholder must NOT
+    # be re-interpolated on the later key's pass.
+    g = _Graph()
+    out = g._interpolate_params(
+        "RETURN ${a}, ${b}", {"a": "${b}", "b": "real"}
+    )
+    # ${a} -> '${b}' (literal, single-quoted, sanitized), ${b} -> 'real'.
+    # The injected ${b} text must stay literal, not become 'real'.
+    assert out == "RETURN '${b}', 'real'"
+
+
+def test_interpolate_escapes_quotes():
+    g = _Graph()
+    out = g._interpolate_params("RETURN ${v}", {"v": "O'Brien"})
+    assert out == "RETURN 'O\\'Brien'"
+
+
+# --------------------------------------------------------------------------
+# column-arity error detection (_is_column_arity_error)
+# --------------------------------------------------------------------------
+
+def test_arity_error_detected():
+    err = Exception("return row and column definition list do not match")
+    assert GraphMixin._is_column_arity_error(err) is True
+
+
+def test_non_arity_error_not_flagged():
+    assert GraphMixin._is_column_arity_error(Exception("syntax error at or near")) is False
+
+
+# --------------------------------------------------------------------------
+# DDL never runs on a caller-owned transaction connection
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_ensure_graph_external_conn_missing_raises_not_creates():
+    g = _Graph()
+    conn = _FakeConn(graph_exists=False)
+    with pytest.raises(RuntimeError):
+        await g._ensure_age_graph_exists(conn, external_conn=True)
+    # Critically, it did NOT issue create_graph DDL on the transaction conn.
+    assert conn.executed == []
+    assert g._graph_exists_confirmed is False
+
+
+@pytest.mark.asyncio
+async def test_ensure_graph_pooled_conn_missing_creates():
+    g = _Graph()
+    conn = _FakeConn(graph_exists=False)
+    await g._ensure_age_graph_exists(conn, external_conn=False)
+    assert any("create_graph" in str(a) for a in conn.executed)
+    assert g._graph_exists_confirmed is True
+
+
+@pytest.mark.asyncio
+async def test_ensure_graph_present_marks_confirmed():
+    g = _Graph()
+    conn = _FakeConn(graph_exists=True)
+    await g._ensure_age_graph_exists(conn, external_conn=True)
+    assert g._graph_exists_confirmed is True
+
+
+@pytest.mark.asyncio
+async def test_ensure_graph_confirmed_short_circuits():
+    g = _Graph()
+    g._graph_exists_confirmed = True
+    # fetchval raising proves we never hit the DB once existence is confirmed.
+    conn = _FakeConn(graph_exists=True, fetchval_raises=True)
+    await g._ensure_age_graph_exists(conn, external_conn=True)

--- a/tests/test_knowledge_graph_age.py
+++ b/tests/test_knowledge_graph_age.py
@@ -688,15 +688,15 @@ class TestGetResponseChain:
         kg, mock_db = make_kg_with_mock_db()
         mock_db.graph_query.return_value = [
             {
-                "d": {"properties": {"id": "root", "agent_id": "a1", "summary": "root"}},
+                "node": {"properties": {"id": "root", "agent_id": "a1", "summary": "root"}},
                 "depth": 0,
             },
             {
-                "d": {"properties": {"id": "reply1", "agent_id": "a2", "summary": "reply"}},
+                "node": {"properties": {"id": "reply1", "agent_id": "a2", "summary": "reply"}},
                 "depth": 1,
             },
             {
-                "d": {"properties": {"id": "reply2", "agent_id": "a3", "summary": "deep reply"}},
+                "node": {"properties": {"id": "reply2", "agent_id": "a3", "summary": "deep reply"}},
                 "depth": 2,
             },
         ]
@@ -713,11 +713,11 @@ class TestGetResponseChain:
         kg, mock_db = make_kg_with_mock_db()
         mock_db.graph_query.return_value = [
             {
-                "d": {"properties": {"id": "disc-A", "agent_id": "a1", "summary": "A"}},
+                "node": {"properties": {"id": "disc-A", "agent_id": "a1", "summary": "A"}},
                 "depth": 0,
             },
             {
-                "d": {"properties": {"id": "disc-A", "agent_id": "a1", "summary": "A duplicate"}},
+                "node": {"properties": {"id": "disc-A", "agent_id": "a1", "summary": "A duplicate"}},
                 "depth": 3,
             },
         ]
@@ -727,11 +727,17 @@ class TestGetResponseChain:
         assert result[0].id == "disc-A"
 
     @pytest.mark.asyncio
-    async def test_handles_tuple_results(self):
-        """Should handle tuple/list result format."""
+    async def test_skips_non_dict_rows(self):
+        """Non-dict rows are skipped (single-column map convention).
+
+        The Cypher now projects a single ``RETURN {node: d, depth: length(p)}``
+        map, so every row decodes to a dict. A stray non-dict row (e.g. a bare
+        scalar) is skipped rather than crashing the chain.
+        """
         kg, mock_db = make_kg_with_mock_db()
         mock_db.graph_query.return_value = [
             ({"properties": {"id": "disc-X", "agent_id": "a1", "summary": "X"}}, 0),
+            {"node": {"properties": {"id": "disc-X", "agent_id": "a1", "summary": "X"}}, "depth": 0},
         ]
 
         result = await kg.get_response_chain("disc-X")
@@ -755,8 +761,8 @@ class TestGetResponseChain:
         """Should skip results that parse to no valid discovery."""
         kg, mock_db = make_kg_with_mock_db()
         mock_db.graph_query.return_value = [
-            {"d": {"properties": {"summary": "missing id"}}, "depth": 0},
-            {"d": {"properties": {"id": "valid", "agent_id": "a", "summary": "ok"}}, "depth": 1},
+            {"node": {"properties": {"summary": "missing id"}}, "depth": 0},
+            {"node": {"properties": {"id": "valid", "agent_id": "a", "summary": "ok"}}, "depth": 1},
         ]
 
         result = await kg.get_response_chain("root")

--- a/tests/test_lease_plane_liveness.py
+++ b/tests/test_lease_plane_liveness.py
@@ -1,0 +1,79 @@
+"""Lease-plane liveness signal for ephemeral agents (has_live_agent_lease).
+
+Pins the consumer contract: surface_id is ``agent:/<uuid>`` (colon-SLASH — must
+match the producer + the BEAM canonical grammar), liveness keys on
+``expires_at``, and every failure path fails OPEN (False) so the archival gate
+falls back to its other signals — this can only ADD protection, never remove it.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from src.mcp_handlers.identity import process_binding as pb
+
+
+class _AcquireCtx:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _DbWithConn:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def acquire(self):
+        return _AcquireCtx(self._conn)
+
+
+@pytest.mark.asyncio
+async def test_missing_uuid_is_false():
+    assert await pb.has_live_agent_lease(None) is False
+    assert await pb.has_live_agent_lease("") is False
+
+
+@pytest.mark.asyncio
+async def test_live_lease_is_true():
+    conn = AsyncMock()
+    conn.fetchval = AsyncMock(return_value=True)
+    with patch("src.db.get_db", return_value=_DbWithConn(conn)):
+        assert await pb.has_live_agent_lease("uuid-1") is True
+
+
+@pytest.mark.asyncio
+async def test_no_lease_is_false():
+    conn = AsyncMock()
+    conn.fetchval = AsyncMock(return_value=False)
+    with patch("src.db.get_db", return_value=_DbWithConn(conn)):
+        assert await pb.has_live_agent_lease("uuid-1") is False
+
+
+@pytest.mark.asyncio
+async def test_surface_id_uses_colon_slash():
+    # Producer/consumer contract: the BEAM grammar is `agent:/<uuid>` (slash),
+    # not `agent:<uuid>`. A mismatch here means the gate silently never matches
+    # the producer's leases.
+    conn = AsyncMock()
+    conn.fetchval = AsyncMock(return_value=False)
+    with patch("src.db.get_db", return_value=_DbWithConn(conn)):
+        await pb.has_live_agent_lease("abc-123")
+    assert conn.fetchval.await_args.args[1] == "agent:/abc-123"
+
+
+@pytest.mark.asyncio
+async def test_db_error_fails_open_false():
+    with patch("src.db.get_db", side_effect=RuntimeError("db down")):
+        assert await pb.has_live_agent_lease("uuid-1") is False
+
+
+@pytest.mark.asyncio
+async def test_query_error_fails_open_false():
+    conn = AsyncMock()
+    conn.fetchval = AsyncMock(side_effect=RuntimeError("query boom"))
+    with patch("src.db.get_db", return_value=_DbWithConn(conn)):
+        assert await pb.has_live_agent_lease("uuid-1") is False

--- a/tests/test_lineage_reachability.py
+++ b/tests/test_lineage_reachability.py
@@ -1,0 +1,143 @@
+"""Transitive lineage-succession reachability (de-risk capability, shadow mode).
+
+Pins the recoverable-by-construction contract: any failure yields an EMPTY set
+(caller keeps single-hop behavior), the CTE is authoritative, and the AGE walk is
+advisory cross-check only — its failure can never affect the result.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from src.mcp_handlers.lifecycle import lineage_reachability as lr
+
+
+class _AcquireCtx:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _DbWithConn:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def acquire(self):
+        return _AcquireCtx(self._conn)
+
+
+# --------------------------------------------------------------------------
+# reachable_ancestors — recoverability + CTE-authoritative contract
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_empty_input_returns_empty():
+    assert await lr.reachable_ancestors([]) == set()
+    assert await lr.reachable_ancestors([None, ""]) == set()
+
+
+@pytest.mark.asyncio
+async def test_returns_cte_set_and_runs_age_crosscheck():
+    age_mock = AsyncMock(return_value={"a", "b", "c"})  # AGE superset
+    with patch.object(lr, "get_db", return_value=object()), \
+         patch.object(lr, "_cte_ancestors", AsyncMock(return_value={"a", "b"})), \
+         patch.object(lr, "_age_ancestors", age_mock):
+        result = await lr.reachable_ancestors({"child1"})
+    assert result == {"a", "b"}        # CTE drives the result, not AGE
+    age_mock.assert_awaited_once()      # AGE cross-check still ran
+
+
+@pytest.mark.asyncio
+async def test_cte_failure_returns_empty_recoverable():
+    with patch.object(lr, "get_db", return_value=object()), \
+         patch.object(lr, "_cte_ancestors", AsyncMock(side_effect=RuntimeError("db down"))):
+        assert await lr.reachable_ancestors({"child1"}) == set()
+
+
+@pytest.mark.asyncio
+async def test_age_crosscheck_failure_does_not_affect_result():
+    # AGE is advisory: its failure must not perturb the authoritative CTE result.
+    with patch.object(lr, "get_db", return_value=object()), \
+         patch.object(lr, "_cte_ancestors", AsyncMock(return_value={"a"})), \
+         patch.object(lr, "_age_ancestors", AsyncMock(side_effect=RuntimeError("age down"))):
+        assert await lr.reachable_ancestors({"child1"}) == {"a"}
+
+
+@pytest.mark.asyncio
+async def test_get_db_failure_returns_empty():
+    with patch.object(lr, "get_db", side_effect=RuntimeError("no db")):
+        assert await lr.reachable_ancestors({"child1"}) == set()
+
+
+# --------------------------------------------------------------------------
+# _cte_ancestors — succession filter + parsing
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_cte_ancestors_parses_and_filters_nulls():
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(
+        return_value=[{"agent_id": "p1"}, {"agent_id": "gp1"}, {"agent_id": None}]
+    )
+    out = await lr._cte_ancestors(_DbWithConn(conn), {"c1"}, 5)
+    assert out == {"p1", "gp1"}
+    # The non-succession exclusion list is passed to the query.
+    passed = conn.fetch.await_args.args
+    assert list(lr._NON_SUCCESSION_SPAWN_REASONS) == passed[2]
+
+
+@pytest.mark.asyncio
+async def test_cte_depth_is_clamped():
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(return_value=[])
+    await lr._cte_ancestors(_DbWithConn(conn), {"c1"}, 999)
+    assert conn.fetch.await_args.args[3] == lr._MAX_DEPTH  # clamped
+
+
+# --------------------------------------------------------------------------
+# _age_ancestors — map-row parsing
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_age_ancestors_parses_map_rows():
+    db = AsyncMock()
+    db.graph_query = AsyncMock(
+        return_value=[{"ancestor": "p1"}, {"ancestor": "gp1"}, {"other": 1}, None]
+    )
+    out = await lr._age_ancestors(db, {"c1"}, 5)
+    assert out == {"p1", "gp1"}
+
+
+# --------------------------------------------------------------------------
+# measure_transitive_expansion — shadow delta
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_measure_reports_delta_beyond_single_hop():
+    with patch.object(lr, "reachable_ancestors", AsyncMock(return_value={"p1", "gp1", "ggp1"})):
+        summary = await lr.measure_transitive_expansion({"c1"}, {"p1"})
+    assert summary == {
+        "single_hop": 1,
+        "transitive_total": 3,
+        "new_beyond_single_hop": 2,
+    }
+
+
+@pytest.mark.asyncio
+async def test_measure_no_expansion_when_subset():
+    with patch.object(lr, "reachable_ancestors", AsyncMock(return_value={"p1"})):
+        summary = await lr.measure_transitive_expansion({"c1"}, {"p1", "p2"})
+    assert summary["new_beyond_single_hop"] == 0
+
+
+# --------------------------------------------------------------------------
+# agreement logging — exercises match + divergence paths without raising
+# --------------------------------------------------------------------------
+
+def test_record_agreement_paths_do_not_raise():
+    lr._record_reachability_agreement({"a"}, {"a"})                      # match
+    lr._record_reachability_agreement({"a", "coincidental"}, {"a", "missing"})  # divergence


### PR DESCRIPTION
Stacked on #795. **Consumer half** of the lease-plane ephemeral-liveness wire — the activation gate that flips #795 shadow→active.

## Why this matters beyond #795

Scope found that the deployed #720 false-archival protection is **currently a no-op for ephemeral agents**: `core.agent_process_bindings` has **0 rows** (nothing sends `process_fingerprint`), so `get_live_bindings()` returns `[]` for every ephemeral agent and the archival liveness gate (`stuck.py`) **never fires**. The lease-plane wire is what makes that protection real.

## What this adds (consumer)

- `process_binding.has_live_agent_lease(uuid)` → True iff a live, unreleased `agent:/<uuid>` surface lease exists. Keyed on **`expires_at`**, not `last_heartbeat_at` (resident leases leave that NULL by design — repo.ex only writes it when `heartbeat_required=true`). Direct read of `lease_plane.surface_leases` (same governance DB). **Fail-open** (False on any error) — can only ADD protection.
- Wired into `_archive_superseded_parents` (auto sweep) and `manual_archive_liveness_signals` (manual path), alongside the existing binding check.
- **`surface_id = agent:/<uuid>`** (colon-SLASH) per the BEAM canonical grammar (`canonicalize.ex:140`), pinned by a test so producer/consumer can't drift. (Note: the scope-note SQL used `agent:`||uuid — the slash is required.)

## Safety

Inert until the producer lands (no `agent:/` rows today → the extra gate check is always-False), so it's safe to merge first. Only ever *adds* a preserve condition; a stale/wrong lease over-preserves (the safe direction), never archives. 6 new tests; existing `test_lifecycle_detect_stuck` / `test_manual_archive_liveness_guard` / `test_lineage_liveness_guard` green (72 passed).

## Producer (next, separate — the sensitive half)

Check-in path (`process_agent_update`): acquire-or-heartbeat `agent:/<uuid>`, `heartbeat_required=true`, TTL ~300–600s, via the SDK `LeasePlaneClient` (sync → `run_in_executor`, no-ops without `LEASE_PLANE_BEARER_TOKEN`). **Must be excluded from `src/activity_tracker.py`** (the Dec loop-detection false-positive class — lease heartbeat is a side-effect, not a high-impact action). On the check-in path, not onboard, because residents + raw-MCP agents bypass onboard.

Draft — operator is the merge gate.