### PR TITLE
feat(lineage): flip transitive succession-reachability to drive archival (flagged, default OFF)

### DIFF
--- a/src/mcp_handlers/lifecycle/stuck.py
+++ b/src/mcp_handlers/lifecycle/stuck.py
@@ -601,6 +601,20 @@ async def _handle_safe_active_agent(agent_id, meta, stuck, risk_score, coherence
     return results
 
 
+def _transitive_archival_enabled() -> bool:
+    """Whether transitive succession-reachability DRIVES archival (vs shadow).
+
+    Default OFF: the activation prerequisite (lease-plane ephemeral liveness, so
+    the per-agent guard can tell a live ephemeral agent from an exited one) must
+    be proven live first. Toggle with ``UNITARES_LINEAGE_TRANSITIVE_ARCHIVAL=true``
+    — a no-redeploy kill switch for this archival-mutation behavior.
+    """
+    import os
+    return (os.getenv("UNITARES_LINEAGE_TRANSITIVE_ARCHIVAL") or "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
 async def _archive_superseded_parents(current_time) -> list:
     """Archive active parents whose declared-lineage child has taken over.
 
@@ -618,19 +632,32 @@ async def _archive_superseded_parents(current_time) -> list:
     if not live_parent_ids:
         return results
 
-    # SHADOW (observation-only, no mutation): measure what transitive
-    # succession-reachability WOULD add beyond this single-hop set, and log the
-    # AGE-vs-CTE topology agreement (evidence for the AGE-canonical step-1
-    # decision). Stays measurement-only until the liveness gate sources ephemeral
-    # agents from the lease plane — see lineage_reachability ACTIVATION
-    # PREREQUISITE. Never drives the archival loop below.
+    # Transitive succession-reachability. A parent whose lineage continued
+    # through a now-stale intermediate to a still-live descendant (P->M->C, M
+    # stale, C live) is also succeeded, but the single-hop pass above misses it.
+    #
+    # ACTIVE (UNITARES_LINEAGE_TRANSITIVE_ARCHIVAL=true): expand the superseded
+    # set with the CTE-authoritative transitive ancestors. Additive + recoverable
+    # — reachable_ancestors returns empty on any error, so a failure never
+    # expands. Every added ancestor still passes the per-agent guards below —
+    # crucially get_live_bindings AND has_live_agent_lease — so a still-running
+    # agent (now detectable via its lease-plane presence lease) is never archived
+    # regardless of lineage. Env-gated so it is a no-redeploy kill switch.
+    #
+    # SHADOW (default): measure-only — log what the expansion WOULD add plus the
+    # AGE-vs-CTE agreement, and drive nothing.
     try:
-        from .lineage_reachability import measure_transitive_expansion
-        await measure_transitive_expansion(
-            _live_child_uuids(current_time), live_parent_ids
-        )
-    except Exception as e:  # pragma: no cover - observation must never block archival
-        logger.debug("transitive lineage shadow measure failed: %s", type(e).__name__)
+        child_uuids = _live_child_uuids(current_time)
+        if _transitive_archival_enabled():
+            from .lineage_reachability import reachable_ancestors
+            ancestors = await reachable_ancestors(child_uuids)
+            if ancestors:
+                live_parent_ids = set(live_parent_ids) | ancestors
+        else:
+            from .lineage_reachability import measure_transitive_expansion
+            await measure_transitive_expansion(child_uuids, live_parent_ids)
+    except Exception as e:  # pragma: no cover - must never block archival
+        logger.debug("transitive lineage step failed: %s", type(e).__name__)
 
     for agent_id, meta in list(mcp_server.agent_metadata.items()):
         if meta.status != "active":

--- a/tests/test_lineage_transitive_flip.py
+++ b/tests/test_lineage_transitive_flip.py
@@ -1,0 +1,128 @@
+"""Transitive succession-reachability FLIP (shadow -> active archival).
+
+``UNITARES_LINEAGE_TRANSITIVE_ARCHIVAL`` gates whether transitive ancestors drive
+archival. Pins:
+  * default OFF  -> shadow (single-hop only; a transitive ancestor is NOT archived)
+  * ON           -> expand: a deep-chain EXITED ancestor the flat pass misses IS
+                    retired as lineage_succession
+  * SAFETY       -> a live ancestor (lease/binding) is NEVER archived even when
+                    transitively reached — the liveness guard still wins.
+"""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+from unittest.mock import patch
+
+
+def _meta(status="active", last_update=None, total_updates=5, tags=None,
+          parent_agent_id=None, agent_uuid=None, spawn_reason=None):
+    now = datetime.now(timezone.utc)
+    return SimpleNamespace(
+        status=status,
+        last_update=(last_update or now).isoformat(),
+        created_at=now.isoformat(),
+        total_updates=total_updates,
+        tags=tags or [],
+        parent_agent_id=parent_agent_id,
+        agent_uuid=agent_uuid,
+        spawn_reason=spawn_reason,
+    )
+
+
+async def _ok(*a, **k):
+    return True
+
+
+async def _no_bindings(*a, **k):
+    return []
+
+
+async def _false(*a, **k):
+    return False
+
+
+async def _ret_gp1(*a, **k):
+    return {"gp1"}
+
+
+async def _lease_live_for_gp1(uuid):
+    return uuid == "gp1"
+
+
+def _set_flag(monkeypatch, on: bool):
+    if on:
+        monkeypatch.setenv("UNITARES_LINEAGE_TRANSITIVE_ARCHIVAL", "true")
+    else:
+        monkeypatch.delenv("UNITARES_LINEAGE_TRANSITIVE_ARCHIVAL", raising=False)
+
+
+def test_flag_parsing(monkeypatch):
+    from src.mcp_handlers.lifecycle.stuck import _transitive_archival_enabled
+    monkeypatch.delenv("UNITARES_LINEAGE_TRANSITIVE_ARCHIVAL", raising=False)
+    assert _transitive_archival_enabled() is False
+    for v in ("true", "1", "YES", "on", " True "):
+        monkeypatch.setenv("UNITARES_LINEAGE_TRANSITIVE_ARCHIVAL", v)
+        assert _transitive_archival_enabled() is True
+    monkeypatch.setenv("UNITARES_LINEAGE_TRANSITIVE_ARCHIVAL", "false")
+    assert _transitive_archival_enabled() is False
+
+
+async def _run_archive(srv_metadata, lease_fn=_false):
+    from src.mcp_handlers.lifecycle.stuck import _archive_superseded_parents
+    with patch("src.mcp_handlers.lifecycle.stuck.mcp_server") as srv, \
+         patch("src.mcp_handlers.lifecycle.helpers._archive_one_agent") as arch, \
+         patch("src.mcp_handlers.identity.process_binding.get_live_bindings",
+               side_effect=_no_bindings), \
+         patch("src.mcp_handlers.identity.process_binding.has_live_agent_lease",
+               side_effect=lease_fn), \
+         patch("src.mcp_handlers.lifecycle.lineage_reachability.reachable_ancestors",
+               side_effect=_ret_gp1):
+        srv.agent_metadata = srv_metadata
+        srv.monitors = {}
+        arch.side_effect = _ok
+        await _archive_superseded_parents(datetime.now(timezone.utc))
+        return [c.args[0] for c in arch.call_args_list]
+
+
+def _chain_metadata():
+    old = datetime.now(timezone.utc) - timedelta(minutes=10)
+    recent = datetime.now(timezone.utc) - timedelta(minutes=2)
+    # p1 superseded single-hop (live child c1); gp1 reachable only transitively.
+    return {
+        "p1": _meta(last_update=old, agent_uuid="p1"),
+        "c1": _meta(last_update=recent, parent_agent_id="p1"),
+        "gp1": _meta(last_update=old, agent_uuid="gp1"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_shadow_off_does_not_expand(monkeypatch):
+    """Flag OFF (default): gp1 reachable transitively but NOT archived (shadow).
+
+    gp1 is exited (no lease) so the ONLY thing sparing it is the flag being off.
+    """
+    _set_flag(monkeypatch, False)
+    archived = await _run_archive(_chain_metadata(), lease_fn=_false)
+    assert archived == ["p1"]
+
+
+@pytest.mark.asyncio
+async def test_flip_on_archives_exited_transitive_ancestor(monkeypatch):
+    """Flag ON: an EXITED transitive ancestor (gp1) is retired alongside p1."""
+    _set_flag(monkeypatch, True)
+    archived = await _run_archive(_chain_metadata(), lease_fn=_false)
+    assert archived == ["p1", "gp1"]
+    assert "c1" not in archived  # the live child is never archived
+
+
+@pytest.mark.asyncio
+async def test_flip_on_live_ancestor_is_protected(monkeypatch):
+    """Flag ON SAFETY: gp1 is transitively reached but holds a live lease -> the
+    liveness guard wins and gp1 is NOT archived. Only the exited p1 is retired.
+    This is the invariant that makes the flip safe post-lease-wire."""
+    _set_flag(monkeypatch, True)
+    archived = await _run_archive(_chain_metadata(), lease_fn=_lease_live_for_gp1)
+    assert archived == ["p1"]
+    assert "gp1" not in archived


### PR DESCRIPTION
Activates #795's shadow transitive reachability behind **`UNITARES_LINEAGE_TRANSITIVE_ARCHIVAL`** (default **OFF** — a no-redeploy kill switch). Now that the lease-plane liveness wire (#796/#797) is **deployed and verified live**, the activation prerequisite is met.

## What flips

When the flag is on, `_archive_superseded_parents` expands the single-hop superseded set with the **CTE-authoritative transitive ancestors**, so a parent whose lineage continued through a now-stale intermediate to a live descendant (`P→M→C`, M stale, C live) is retired as `lineage_succession` instead of left to re-trip stuck detection. Default OFF keeps the existing shadow measurement.

## Safe by construction

- **Additive + recoverable:** `reachable_ancestors` returns empty on any error → a failure never expands. Flag OFF → shadow only.
- **Liveness still wins:** every transitively-added ancestor passes the same per-agent guards — crucially `get_live_bindings` **and** `has_live_agent_lease`. A still-running agent (now detectable via its `agent:/` presence lease, verified live today) is **never** archived regardless of lineage. Pinned by `test_flip_on_live_ancestor_is_protected`.

## Verification

- 4 flip tests (flag parsing; shadow-off doesn't expand; on-archives-an-exited-ancestor; **on-protects-a-live-ancestor**) + archival-gate regressions green (**89 passed**).
- **Live dry-run:** **0** shadow "would-expand" events since the lease-wire deploy (sweep confirmed running — `stuck_detected` events post-deploy). So activating currently expands nothing; it only acts on a genuine deep chain.

## Activation (operator)

Merging changes nothing live (default OFF). To activate after deploy:
1. Merge + deploy (`deploy-mcp.sh`) → flip code live, still OFF.
2. Set `UNITARES_LINEAGE_TRANSITIVE_ARCHIVAL=true` on the MCP plist + `unload`/`load` (kickstart won't re-read plist env).
3. Kill switch = remove the key + reload. No redeploy.

Draft — operator is the merge + activation gate.