### PR TITLE
feat(agent-orchestrator): HTTP control surface for spawn/list/stop

### DIFF
--- a/docs/proposals/agent-orchestrator-beam-v0.md
+++ b/docs/proposals/agent-orchestrator-beam-v0.md
@@ -148,11 +148,49 @@ defer the architecture call." Fixed:
    `remote_heartbeat`, enforced by a DB CHECK. Callers must not infer accepted
    `remote_heartbeat` semantics from a 200.
 
+## v0.1 — HTTP control surface shipped (2026-06-17)
+
+The "spawn/list/stop agents from outside BEAM" item below is now built — the
+orchestrator is no longer drive-only-from-inside-the-VM.
+
+- **Routes** (`lib/agent_orchestrator/http_router.ex`, Plug + Bandit):
+  `GET /v1/health`, `POST /v1/agents` (spawn), `GET /v1/agents` (list),
+  `GET /v1/agents/:id` (snapshot), `POST /v1/agents/:id/await`,
+  `DELETE /v1/agents/:id` (stop). Typed JSON envelopes
+  (`schema_invalid`/`permission_denied`/`not_found`/`lease_denied`/
+  `await_timeout`/`service_unavailable`) + a `protocol_version` field, same
+  typed-absence discipline as the lease-plane router.
+- **Trust boundary = the lease plane's, and stricter in spirit.** Localhost-only
+  IPv4 bind + bearer auth (`AgentOrchestrator.HTTPAuth`,
+  `AGENT_ORCHESTRATOR_BEARER_TOKEN`) that **fails closed** (503 when no token is
+  configured). `POST /v1/agents` spawns an OS process, so it is an authenticated
+  RCE surface by design — the same capability the in-VM `run/1` already had,
+  exposed over one trust boundary. An optional `:cmd_allowlist` (default `nil` =
+  parity with the in-VM API) constrains which executables a caller may spawn.
+- **Spec translation is whitelist-only.** The JSON body → `AgentRunner` spec
+  mapping never `String.to_atom`s caller input (atom-exhaustion guard); lease /
+  lineage / server-url all route through the runner's existing validation, so a
+  bad parent UUID or non-http server URL refuses the spawn as a typed 422.
+- **`present/1` is JSON-safe.** `exit_status` is stringified on the abnormal
+  `{:port_closed, reason}` close path so a crashed agent's status cannot crash
+  the response encoder.
+- **Tests:** `test/http_router_test.exs` drives the router in-process via
+  `Plug.Test` (no socket, no live plane) — auth (503/401/case-insensitive
+  scheme), spawn→await round-trip, the 422/403/404/415/504 typed paths.
+- **Deploy:** `scripts/start.sh` (launchd entrypoint, sources secrets,
+  fail-closed). A `com.unitares.*` plist template is the remaining deploy step.
+
+Not yet covered by CI (the Elixir apps run `mix test` on the deploy host, not in
+GitHub Actions), so the operator's `mix deps.get && mix test` is the gate.
+
 ## Deferred (not in v0)
 
-- A control surface (HTTP/MCP) to spawn/list/stop agents from outside BEAM.
+- ~~A control surface (HTTP/MCP) to spawn/list/stop agents from outside BEAM.~~
+  **HTTP surface shipped in v0.1 (above).** An MCP-shaped surface is still
+  deferred.
 - Distributed Erlang multi-node fan-out.
 - The `agent:` surface scheme (finding 1) and any governance-onboarding env
   injection contract for spawned agents (so a spawned agent declares lineage to
   its orchestrator).
-- A launchd plist + deploy story (this is a library + smoke today, not a service).
+- ~~A launchd plist + deploy story~~ — `scripts/start.sh` shipped in v0.1; the
+  `com.unitares.agent-orchestrator.plist` template is the remaining piece.

--- a/elixir/agent_orchestrator/config/config.exs
+++ b/elixir/agent_orchestrator/config/config.exs
@@ -18,4 +18,18 @@ config :agent_orchestrator,
   # max caps the table under a churn burst within one TTL window.
   result_retention_ms: 300_000,
   result_sweep_interval_ms: 60_000,
-  result_store_max: 10_000
+  result_store_max: 10_000,
+  # Control surface (lib/agent_orchestrator/http_router.ex). Binds IPv4
+  # 127.0.0.1 only — a single localhost trust boundary, matching the lease
+  # plane (Bandit does not bind ::1, so the dotted-quad is intentional). The
+  # bearer is read from AGENT_ORCHESTRATOR_BEARER_TOKEN at boot (see
+  # application.ex); absent → HTTPAuth returns 503 (fail closed, never open).
+  # start_http is OFF under :test so the unit suite never binds a socket; the
+  # router is exercised in-process via Plug.Test.
+  start_http: config_env() != :test,
+  http_port: String.to_integer(System.get_env("AGENT_ORCHESTRATOR_HTTP_PORT", "8789")),
+  http_ip: {127, 0, 0, 1},
+  # Optional executable allowlist for POST /v1/agents (basenames). nil = parity
+  # with the in-VM AgentOrchestrator.run/1 (any cmd). Set e.g. ["claude", "sh"]
+  # to constrain what the authenticated control surface may spawn.
+  cmd_allowlist: nil

--- a/elixir/agent_orchestrator/lib/agent_orchestrator/application.ex
+++ b/elixir/agent_orchestrator/lib/agent_orchestrator/application.ex
@@ -21,22 +21,53 @@ defmodule AgentOrchestrator.Application do
   race (#581) where a finished agent's result was lost to `:not_found`.
 
   Lease-binding to the plane is the architectural-coherence payoff: an agent
-  acquires a `remote_heartbeat` lease on its `agent:<id>` surface when it spawns
-  and releases it on exit, so the fleet plane has a single source of truth for
-  "which ephemeral agents are live" and orphans self-heal via the reaper's TTL.
+  registers an `agent:/<id>` presence row when it spawns and releases it on
+  exit, so the fleet plane has a single source of truth for "which ephemeral
+  agents are live." The presence row uses the `remote_heartbeat` holder kind,
+  which migration 042 (PR #588) routes to the self-healing TTL-row path — so an
+  orphan left by a crash that skips `terminate/2` reaps itself at TTL rather
+  than leaking indefinitely. Explicit release on exit remains the fast path; the
+  TTL is the backstop, not the normal path. (Earlier drafts claimed self-heal
+  for every scheme — that was false before #588, when only `file://` got the
+  TTL-row path and other schemes were coerced to an auto-renewing holder. See
+  `AgentRunner`'s moduledoc for the full corrected story.)
   """
 
   use Application
 
   @impl true
   def start(_type, _args) do
-    children = [
-      {Registry, keys: :unique, name: AgentOrchestrator.Registry},
-      AgentOrchestrator.ResultStore,
-      AgentOrchestrator.AgentSupervisor
-    ]
+    # Bearer for the control surface, sourced from env at boot. Absent → HTTPAuth
+    # returns 503 on every request (fail closed, never silently open). Mirrors
+    # the lease plane's posture; matters more here because POST /v1/agents spawns
+    # an OS process — an unauthenticated reach is RCE.
+    if token = System.get_env("AGENT_ORCHESTRATOR_BEARER_TOKEN") do
+      Application.put_env(:agent_orchestrator, :bearer_token, token)
+    end
+
+    children =
+      [
+        {Registry, keys: :unique, name: AgentOrchestrator.Registry},
+        AgentOrchestrator.ResultStore,
+        AgentOrchestrator.AgentSupervisor
+      ] ++ http_children()
 
     opts = [strategy: :one_for_one, name: AgentOrchestrator.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  # Localhost-only Bandit listener for the control surface. Gated by
+  # :start_http (OFF under :test so the unit suite binds no socket). IPv4 only —
+  # Bandit does not bind ::1, and the localhost trust boundary is the security
+  # model, so off-host exposure is intentionally not a built-in option.
+  defp http_children do
+    if Application.get_env(:agent_orchestrator, :start_http, true) do
+      port = Application.get_env(:agent_orchestrator, :http_port, 8789)
+      ip = Application.get_env(:agent_orchestrator, :http_ip, {127, 0, 0, 1})
+
+      [{Bandit, plug: AgentOrchestrator.HTTPRouter, ip: ip, port: port}]
+    else
+      []
+    end
   end
 end

--- a/elixir/agent_orchestrator/lib/agent_orchestrator/http_auth.ex
+++ b/elixir/agent_orchestrator/lib/agent_orchestrator/http_auth.ex
@@ -1,0 +1,85 @@
+defmodule AgentOrchestrator.HTTPAuth do
+  @moduledoc """
+  Bearer-token Plug for the orchestrator's control surface.
+
+  Reads the expected token at request time from `:agent_orchestrator,
+  :bearer_token` (sourced from `AGENT_ORCHESTRATOR_BEARER_TOKEN` at boot — see
+  `AgentOrchestrator.Application`). Comparison is constant-time via
+  `Plug.Crypto.secure_compare/2` so timing side-channels cannot probe the token.
+
+  ## Why this matters more here than on the lease plane
+
+  This surface spawns OS processes (`POST /v1/agents` with an arbitrary `cmd`).
+  An unauthenticated caller reaching it is remote code execution. The posture is
+  therefore identical to, and at least as strict as, the lease plane:
+
+    * **Fail closed.** If no token is configured the plug returns 503 — never
+      silently open. A misconfigured deploy refuses every request instead of
+      accepting them unauthenticated.
+    * **Localhost-only bind** (enforced in `Application`, not here) — a single
+      trust boundary at `127.0.0.1`.
+
+  Auth runs BEFORE body parsing in the router so an unauthenticated caller
+  cannot probe endpoint existence (or trip the spawn path) by sending a body;
+  bearer auth only reads the `authorization` header.
+  """
+
+  import Plug.Conn
+
+  @behaviour Plug
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(conn, _opts) do
+    expected = Application.get_env(:agent_orchestrator, :bearer_token)
+
+    cond do
+      is_nil(expected) or expected == "" ->
+        send_json(conn, 503, %{
+          ok: false,
+          error: "service_unavailable",
+          reason: "bearer token not configured"
+        })
+
+      authorized?(conn, expected) ->
+        conn
+
+      true ->
+        send_json(conn, 401, %{
+          ok: false,
+          error: "permission_denied",
+          reason: "bearer token missing or invalid"
+        })
+    end
+  end
+
+  defp authorized?(conn, expected) do
+    case get_req_header(conn, "authorization") do
+      [value] -> bearer_matches?(value, expected)
+      _ -> false
+    end
+  end
+
+  # RFC 7235 §2.1: the auth scheme token is case-insensitive ("Bearer",
+  # "bearer", "BEARER" all valid). Match the scheme case-insensitively, compare
+  # the credential with secure_compare.
+  defp bearer_matches?(value, expected) do
+    case String.split(value, " ", parts: 2) do
+      [scheme, presented] ->
+        String.downcase(scheme) == "bearer" and
+          Plug.Crypto.secure_compare(presented, expected)
+
+      _ ->
+        false
+    end
+  end
+
+  defp send_json(conn, status, body) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(status, Jason.encode!(body))
+    |> halt()
+  end
+end

--- a/elixir/agent_orchestrator/lib/agent_orchestrator/http_router.ex
+++ b/elixir/agent_orchestrator/lib/agent_orchestrator/http_router.ex
@@ -1,0 +1,369 @@
+defmodule AgentOrchestrator.HTTPRouter do
+  @moduledoc """
+  HTTP control surface for the ephemeral-agent orchestrator — the "spawn / list
+  / stop agents from outside BEAM" capability deferred in
+  `docs/proposals/agent-orchestrator-beam-v0.md`.
+
+  Without this, the only way to drive the orchestrator was to BE Elixir code
+  running inside the same VM. This surface lets a Python/TS/shell caller (the
+  dispatch worker, a CLI, a future MCP shim) drive the same `AgentOrchestrator`
+  facade over localhost HTTP.
+
+  ## Routes
+
+      GET    /v1/health             liveness + live-agent count
+      POST   /v1/agents             spawn a supervised ephemeral agent
+      GET    /v1/agents             list live agent ids
+      GET    /v1/agents/:id         snapshot (captured output + status), no block
+      POST   /v1/agents/:id/await   block until exit (or `timeout_ms`)
+      DELETE /v1/agents/:id         stop: close the port (kill child) + release lease
+
+  ## Trust boundary
+
+  Bind is local-only (`127.0.0.1`, enforced in `Application`) and every route is
+  bearer-gated by `AgentOrchestrator.HTTPAuth`, which fails closed. `POST
+  /v1/agents` spawns an OS process, so this is an authenticated RCE surface by
+  design — the same capability the in-VM `AgentOrchestrator.run/1` already has,
+  exposed over one localhost trust boundary. An optional `:cmd_allowlist`
+  (config, default `nil` = parity with the in-VM API) restricts which
+  executables a caller may spawn.
+
+  ## Envelope
+
+  Every response is `{ok: boolean, ...}` JSON with a `protocol_version` field.
+  Errors are typed (`schema_invalid` / `permission_denied` / `not_found` /
+  `lease_denied` / `await_timeout` / `service_unavailable`) rather than leaky
+  HTML — same typed-absence discipline as the lease plane router.
+  """
+
+  use Plug.Router
+  use Plug.ErrorHandler
+
+  require Logger
+
+  @protocol_version "v0.1"
+
+  plug(:match)
+
+  # Auth BEFORE parsing: an unauthenticated caller must not be able to reach the
+  # spawn path or probe routes by sending a body. Bearer auth reads only the
+  # authorization header, so it needs no parsed body.
+  plug(AgentOrchestrator.HTTPAuth)
+
+  # SafeParsers wraps Plug.Parsers so malformed JSON / wrong media type become
+  # typed 422 / 415 at one named site, rather than Bandit's default empty 400
+  # (relying on Plug.ErrorHandler for that is unreliable — see SafeParsers).
+  plug(AgentOrchestrator.SafeParsers,
+    parsers: [:json],
+    pass: ["application/json"],
+    json_decoder: Jason
+  )
+
+  plug(:dispatch)
+
+  # Backstop: anything raised inside a route handler becomes a redacted 503
+  # (full error logged server-side only). Parse errors are handled upstream by
+  # SafeParsers, so they never reach here.
+  @impl Plug.ErrorHandler
+  def handle_errors(conn, %{kind: kind, reason: reason}) do
+    Logger.error("agent orchestrator HTTP error: #{Exception.format_banner(kind, reason)}")
+    json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
+  end
+
+  # ---------- routes ----------
+
+  get "/v1/health" do
+    json(conn, 200, %{ok: true, status: "ok", active_agents: AgentOrchestrator.count()})
+  end
+
+  post "/v1/agents" do
+    with {:ok, spec} <- build_spec(conn.body_params),
+         :ok <- check_allowed(spec.cmd) do
+      case AgentOrchestrator.run(spec) do
+        {:ok, agent_id, _pid} ->
+          json(conn, 201, %{ok: true, agent_id: agent_id})
+
+        {:error, reason} ->
+          spawn_error(conn, reason)
+      end
+    else
+      {:error, :cmd_not_allowed, cmd} ->
+        json(conn, 403, %{ok: false, error: "permission_denied", reason: "cmd not in allowlist: #{cmd}"})
+
+      {:error, detail} ->
+        json(conn, 422, %{ok: false, error: "schema_invalid", detail: detail})
+    end
+  end
+
+  get "/v1/agents" do
+    ids = AgentOrchestrator.list()
+    json(conn, 200, %{ok: true, agents: ids, count: length(ids)})
+  end
+
+  get "/v1/agents/:id" do
+    case AgentOrchestrator.snapshot(id) do
+      {:ok, result} -> json(conn, 200, %{ok: true, result: present(result)})
+      {:error, :not_found} -> json(conn, 404, %{ok: false, error: "not_found"})
+    end
+  end
+
+  post "/v1/agents/:id/await" do
+    case AgentOrchestrator.await(id, await_timeout(conn.body_params)) do
+      {:ok, result} ->
+        json(conn, 200, %{ok: true, result: present(result)})
+
+      {:error, :timeout} ->
+        # The await deadline passed; the agent may still be running. Distinct
+        # from not_found so a caller can re-await or snapshot.
+        json(conn, 504, %{ok: false, error: "await_timeout", agent_id: id})
+
+      {:error, :not_found} ->
+        json(conn, 404, %{ok: false, error: "not_found"})
+    end
+  end
+
+  delete "/v1/agents/:id" do
+    case AgentOrchestrator.stop(id) do
+      :ok -> json(conn, 200, %{ok: true})
+      {:error, :not_found} -> json(conn, 404, %{ok: false, error: "not_found"})
+    end
+  end
+
+  match _ do
+    json(conn, 404, %{ok: false, error: "not_found"})
+  end
+
+  # ---------- spec translation (JSON body -> AgentRunner spec) ----------
+
+  # Translate the JSON body (string keys) into the runner spec (atom keys) via a
+  # FIXED whitelist. We never `String.to_atom/1` on caller input — that is atom
+  # exhaustion and is how a control surface leaks into the VM's atom table.
+  defp build_spec(body) when is_map(body) do
+    with {:ok, cmd} <- fetch_cmd(body),
+         {:ok, args} <- fetch_args(body),
+         {:ok, env} <- fetch_env(body),
+         {:ok, cd} <- fetch_string(body, "cd"),
+         {:ok, max_lines} <- fetch_max_lines(body),
+         {:ok, lease} <- fetch_lease(body),
+         {:ok, lineage} <- fetch_lineage(body),
+         {:ok, server_url} <- fetch_string(body, "server_url") do
+      spec =
+        %{cmd: cmd, args: args, env: env}
+        |> put_opt(:cd, cd)
+        |> put_opt(:max_output_lines, max_lines)
+        |> put_opt(:lineage, lineage)
+        |> put_opt(:server_url, server_url)
+        |> put_lease(lease)
+
+      {:ok, spec}
+    end
+  end
+
+  defp build_spec(_), do: {:error, "body must be a JSON object"}
+
+  defp fetch_cmd(body) do
+    case Map.get(body, "cmd") do
+      cmd when is_binary(cmd) and byte_size(cmd) > 0 -> {:ok, cmd}
+      _ -> {:error, "cmd is required and must be a non-empty string"}
+    end
+  end
+
+  defp fetch_args(body) do
+    case Map.get(body, "args") do
+      nil -> {:ok, []}
+      list when is_list(list) ->
+        if Enum.all?(list, &is_binary/1),
+          do: {:ok, list},
+          else: {:error, "args must be a list of strings"}
+
+      _ ->
+        {:error, "args must be a list of strings"}
+    end
+  end
+
+  # JSON object {"KEY": "VAL"} -> [{"KEY", "VAL"}] (the Port env shape).
+  defp fetch_env(body) do
+    case Map.get(body, "env") do
+      nil ->
+        {:ok, []}
+
+      %{} = map ->
+        if Enum.all?(map, fn {k, v} -> is_binary(k) and is_binary(v) end),
+          do: {:ok, Map.to_list(map)},
+          else: {:error, "env must be a JSON object of string => string"}
+
+      _ ->
+        {:error, "env must be a JSON object of string => string"}
+    end
+  end
+
+  defp fetch_string(body, key) do
+    case Map.get(body, key) do
+      nil -> {:ok, nil}
+      v when is_binary(v) -> {:ok, v}
+      _ -> {:error, "#{key} must be a string"}
+    end
+  end
+
+  defp fetch_max_lines(body) do
+    case Map.get(body, "max_output_lines") do
+      nil -> {:ok, nil}
+      n when is_integer(n) and n > 0 -> {:ok, n}
+      _ -> {:error, "max_output_lines must be a positive integer"}
+    end
+  end
+
+  # Presence/lease: absent => omit (runner default = best-effort presence);
+  # `false` => opt out; object => override map (atom keys, whitelisted).
+  defp fetch_lease(body) do
+    case Map.get(body, "lease") do
+      nil -> {:ok, :absent}
+      false -> {:ok, false}
+      %{} = cfg -> lease_cfg(cfg)
+      _ -> {:error, "lease must be false or a JSON object"}
+    end
+  end
+
+  defp lease_cfg(cfg) do
+    Enum.reduce_while(
+      [
+        {"required", :required, &is_boolean/1, "required must be a boolean"},
+        {"surface_id", :surface_id, &nonempty_string?/1, "surface_id must be a non-empty string"},
+        {"holder_agent_uuid", :holder_agent_uuid, &nonempty_string?/1, "holder_agent_uuid must be a non-empty string"},
+        {"ttl_s", :ttl_s, &positive_integer?/1, "ttl_s must be a positive integer"}
+      ],
+      {:ok, %{}},
+      fn {json_key, atom_key, valid?, err}, {:ok, acc} ->
+        case Map.fetch(cfg, json_key) do
+          :error -> {:cont, {:ok, acc}}
+          {:ok, v} ->
+            if valid?.(v),
+              do: {:cont, {:ok, Map.put(acc, atom_key, v)}},
+              else: {:halt, {:error, err}}
+        end
+      end
+    )
+  end
+
+  # Lineage: absent => no lineage; object => {parent_agent_uuid, spawn_reason}.
+  # The runner does the authoritative UUID-shape check and refuses the spawn on a
+  # bad parent (mapped to 422 by spawn_error/2); we only translate keys + types.
+  defp fetch_lineage(body) do
+    case Map.get(body, "lineage") do
+      nil ->
+        {:ok, nil}
+
+      %{} = cfg ->
+        with {:ok, parent} <- require_string(cfg, "parent_agent_uuid"),
+             {:ok, reason} <- optional_string(cfg, "spawn_reason") do
+          base = %{parent_agent_uuid: parent}
+          {:ok, if(reason, do: Map.put(base, :spawn_reason, reason), else: base)}
+        end
+
+      _ ->
+        {:error, "lineage must be a JSON object"}
+    end
+  end
+
+  defp require_string(cfg, key) do
+    case Map.get(cfg, key) do
+      v when is_binary(v) and byte_size(v) > 0 -> {:ok, v}
+      _ -> {:error, "#{key} is required and must be a non-empty string"}
+    end
+  end
+
+  defp optional_string(cfg, key) do
+    case Map.get(cfg, key) do
+      nil -> {:ok, nil}
+      v when is_binary(v) and byte_size(v) > 0 -> {:ok, v}
+      _ -> {:error, "#{key} must be a non-empty string"}
+    end
+  end
+
+  defp nonempty_string?(v), do: is_binary(v) and byte_size(v) > 0
+  defp positive_integer?(v), do: is_integer(v) and v > 0
+
+  defp put_opt(spec, _key, nil), do: spec
+  defp put_opt(spec, key, value), do: Map.put(spec, key, value)
+
+  defp put_lease(spec, :absent), do: spec
+  defp put_lease(spec, value), do: Map.put(spec, :lease, value)
+
+  # ---------- spawn-error mapping ----------
+
+  defp spawn_error(conn, {:invalid_lineage, reason}),
+    do: json(conn, 422, %{ok: false, error: "schema_invalid", detail: "invalid lineage: #{inspect(reason)}"})
+
+  defp spawn_error(conn, {:invalid_server_url, reason}),
+    do: json(conn, 422, %{ok: false, error: "schema_invalid", detail: "invalid server_url: #{inspect(reason)}"})
+
+  defp spawn_error(conn, {:executable_not_found, cmd}),
+    do: json(conn, 422, %{ok: false, error: "schema_invalid", detail: "executable not found: #{cmd}"})
+
+  defp spawn_error(conn, {:lease_denied, reason}),
+    do: json(conn, 409, %{ok: false, error: "lease_denied", reason: inspect(reason)})
+
+  defp spawn_error(conn, {:already_running, id}),
+    do: json(conn, 409, %{ok: false, error: "already_running", agent_id: id})
+
+  defp spawn_error(conn, reason) do
+    Logger.error("agent orchestrator spawn failed: #{inspect(reason)}")
+    json(conn, 503, %{ok: false, error: "service_unavailable", reason: "spawn failed"})
+  end
+
+  # ---------- helpers ----------
+
+  # Default 30s, clamped to (0, 120_000]. The await holds a Bandit connection
+  # open, so an unbounded client-supplied timeout would let a caller pin a
+  # connection indefinitely.
+  defp await_timeout(body) when is_map(body) do
+    case Map.get(body, "timeout_ms") do
+      n when is_integer(n) and n > 0 -> min(n, 120_000)
+      _ -> 30_000
+    end
+  end
+
+  defp await_timeout(_), do: 30_000
+
+  defp check_allowed(cmd) do
+    case Application.get_env(:agent_orchestrator, :cmd_allowlist) do
+      nil -> :ok
+      list when is_list(list) ->
+        if Path.basename(cmd) in list, do: :ok, else: {:error, :cmd_not_allowed, cmd}
+    end
+  end
+
+  # JSON-safe projection of the runner result. exit_status is an integer for a
+  # clean exit but a `{:port_closed, reason}` tuple on an abnormal close — Jason
+  # cannot encode a tuple, so stringify the non-integer case rather than crash
+  # the response (which Plug.ErrorHandler would otherwise turn into a 503).
+  defp present(result) do
+    %{
+      agent_id: result.agent_id,
+      os_pid: result.os_pid,
+      lease_id: result.lease_id,
+      presence: result.presence,
+      lineage: result.lineage,
+      exit_status: encode_status(result.exit_status),
+      running: result.running,
+      lease_released: result.lease_released,
+      output: result.output
+    }
+  end
+
+  defp encode_status(nil), do: nil
+  defp encode_status(n) when is_integer(n), do: n
+  defp encode_status(other), do: inspect(other)
+
+  @doc "Control-surface protocol version, surfaced in every response body."
+  @spec protocol_version() :: String.t()
+  def protocol_version, do: @protocol_version
+
+  defp json(conn, status, body) do
+    versioned = Map.put(body, :protocol_version, @protocol_version)
+
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.send_resp(status, Jason.encode!(versioned))
+  end
+end

--- a/elixir/agent_orchestrator/lib/agent_orchestrator/safe_parsers.ex
+++ b/elixir/agent_orchestrator/lib/agent_orchestrator/safe_parsers.ex
@@ -1,0 +1,44 @@
+defmodule AgentOrchestrator.SafeParsers do
+  @moduledoc """
+  Wraps `Plug.Parsers` so a `Plug.Parsers.ParseError` (malformed JSON) or
+  `Plug.Parsers.UnsupportedMediaTypeError` becomes a typed-absence
+  `schema_invalid` (422) / `unsupported_media_type` (415) response instead of
+  Bandit's default empty-body 400.
+
+  Mirrors `UnitaresLeasePlane.SafeParsers`: relying on `Plug.ErrorHandler` to
+  convert these is unreliable (the exceptions carry a `Plug.Exception`
+  `plug_status` that the adapter renders directly), so the conversion lives at
+  one named site in the pipeline. `Plug.ErrorHandler` stays in the router as the
+  backstop for errors raised inside route handlers, not for parse errors.
+  """
+
+  @behaviour Plug
+
+  alias Plug.Conn
+  alias Plug.Parsers
+
+  @impl true
+  def init(opts), do: Parsers.init(opts)
+
+  @impl true
+  def call(conn, opts) do
+    try do
+      Parsers.call(conn, opts)
+    rescue
+      e in Parsers.ParseError ->
+        send_typed(conn, 422, "schema_invalid", "malformed request body: #{Exception.message(e)}")
+
+      e in Parsers.UnsupportedMediaTypeError ->
+        send_typed(conn, 415, "unsupported_media_type", "unsupported media type: #{Exception.message(e)}")
+    end
+  end
+
+  defp send_typed(conn, status, error, detail) do
+    body = Jason.encode!(%{ok: false, error: error, detail: detail})
+
+    conn
+    |> Conn.put_resp_content_type("application/json")
+    |> Conn.send_resp(status, body)
+    |> Conn.halt()
+  end
+end

--- a/elixir/agent_orchestrator/mix.exs
+++ b/elixir/agent_orchestrator/mix.exs
@@ -28,7 +28,12 @@ defmodule AgentOrchestrator.MixProject do
 
   defp deps do
     [
-      {:jason, "~> 1.4"}
+      {:jason, "~> 1.4"},
+      # Control surface (lib/agent_orchestrator/http_router.ex). Plug 1.18+ for
+      # the Plug.Parsers.ParseError shape the router's error handler matches;
+      # Bandit is the localhost listener. Same stack as the lease plane.
+      {:plug, "~> 1.18"},
+      {:bandit, "~> 1.6"}
     ]
   end
 end

--- a/elixir/agent_orchestrator/scripts/start.sh
+++ b/elixir/agent_orchestrator/scripts/start.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Launchd entrypoint for the Agent Orchestrator control surface (Elixir/OTP).
+#
+# Sources AGENT_ORCHESTRATOR_BEARER_TOKEN (and the lease-plane bearer, so
+# spawned agents can register presence) from ~/.config/cirwel/secrets.env
+# (mode 600), then execs `mix run --no-halt`. The HTTP control surface binds
+# 127.0.0.1:8789 by default; override via AGENT_ORCHESTRATOR_HTTP_PORT or the
+# :agent_orchestrator runtime config (see application.ex / config.exs).
+#
+# Manual invocation: `./elixir/agent_orchestrator/scripts/start.sh`
+#
+# Fail-closed posture: if secrets.env is missing or the bearer is unset, the
+# application starts but HTTPAuth returns 503 on every request — never silently
+# open. POST /v1/agents spawns an OS process, so an unauthenticated reach would
+# be RCE; the localhost bind + bearer gate are the trust boundary.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+ORCHESTRATOR_DIR="$REPO_ROOT/elixir/agent_orchestrator"
+SECRETS_FILE="$HOME/.config/cirwel/secrets.env"
+
+if [[ -f "$SECRETS_FILE" ]]; then
+    # shellcheck disable=SC1090
+    source "$SECRETS_FILE"
+else
+    echo "[agent-orchestrator] WARNING: $SECRETS_FILE missing — starting fail-closed (HTTPAuth → 503)" >&2
+fi
+
+# Homebrew Elixir lives at /opt/homebrew/bin on Apple Silicon. PATH inherited
+# from launchd's user environment is sparse, so set it explicitly.
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+cd "$ORCHESTRATOR_DIR"
+
+exec mix run --no-halt

--- a/elixir/agent_orchestrator/test/http_router_test.exs
+++ b/elixir/agent_orchestrator/test/http_router_test.exs
@@ -111,6 +111,17 @@ defmodule AgentOrchestrator.HTTPRouterTest do
       assert body_json(conn)["error"] == "schema_invalid"
     end
 
+    test "415 on an unsupported media type" do
+      conn =
+        conn(:post, "/v1/agents", "cmd=echo")
+        |> put_req_header("content-type", "text/plain")
+        |> put_req_header("authorization", "Bearer " <> @token)
+        |> call()
+
+      assert conn.status == 415
+      assert body_json(conn)["error"] == "unsupported_media_type"
+    end
+
     test "422 when the executable does not exist" do
       conn = call(authed(:post, "/v1/agents", %{cmd: "definitely-not-a-real-binary-xyz"}))
       assert conn.status == 422

--- a/elixir/agent_orchestrator/test/http_router_test.exs
+++ b/elixir/agent_orchestrator/test/http_router_test.exs
@@ -1,0 +1,173 @@
+defmodule AgentOrchestrator.HTTPRouterTest do
+  @moduledoc """
+  Exercises the control surface in-process via Plug.Test — no Bandit socket, no
+  live lease plane. The orchestrator supervision tree (Registry / ResultStore /
+  AgentSupervisor) is up because the app starts it; only the HTTP listener is
+  off under :test (config_env() != :test).
+  """
+  use ExUnit.Case, async: false
+
+  import Plug.Test
+  import Plug.Conn
+
+  alias AgentOrchestrator.HTTPRouter
+
+  @opts HTTPRouter.init([])
+  @token "test-bearer-token"
+
+  setup do
+    Application.put_env(:agent_orchestrator, :bearer_token, @token)
+    # Null the lease bearer so default-on presence is a deterministic no-network
+    # :no_bearer fast-fail (→ presence :unregistered) rather than hitting a plane.
+    Application.put_env(:agent_orchestrator, :lease_plane_bearer_token, nil)
+    Application.delete_env(:agent_orchestrator, :cmd_allowlist)
+
+    on_exit(fn ->
+      Enum.each(AgentOrchestrator.list(), &AgentOrchestrator.stop(&1, :test_cleanup))
+      Application.delete_env(:agent_orchestrator, :cmd_allowlist)
+    end)
+
+    :ok
+  end
+
+  defp call(conn), do: HTTPRouter.call(conn, @opts)
+
+  defp authed(method, path, body \\ nil) do
+    conn =
+      case body do
+        nil -> conn(method, path)
+        map -> conn(method, path, Jason.encode!(map)) |> put_req_header("content-type", "application/json")
+      end
+
+    put_req_header(conn, "authorization", "Bearer " <> @token)
+  end
+
+  defp body_json(conn), do: Jason.decode!(conn.resp_body)
+
+  describe "auth" do
+    test "503 when no bearer is configured (fail closed)" do
+      Application.delete_env(:agent_orchestrator, :bearer_token)
+      conn = call(conn(:get, "/v1/health"))
+      assert conn.status == 503
+      assert body_json(conn)["error"] == "service_unavailable"
+    end
+
+    test "401 when the bearer is missing or wrong" do
+      assert call(conn(:get, "/v1/health")).status == 401
+      assert call(conn(:get, "/v1/health") |> put_req_header("authorization", "Bearer nope")).status == 401
+    end
+
+    test "accepts a case-insensitive scheme" do
+      conn = call(conn(:get, "/v1/health") |> put_req_header("authorization", "bearer " <> @token))
+      assert conn.status == 200
+    end
+  end
+
+  describe "GET /v1/health" do
+    test "reports ok + a live-agent count + protocol version" do
+      conn = call(authed(:get, "/v1/health"))
+      assert conn.status == 200
+      body = body_json(conn)
+      assert body["ok"] == true
+      assert is_integer(body["active_agents"])
+      assert body["protocol_version"] == HTTPRouter.protocol_version()
+    end
+  end
+
+  describe "POST /v1/agents" do
+    test "spawns an agent and the result is awaitable" do
+      conn = call(authed(:post, "/v1/agents", %{cmd: "echo", args: ["hi there"]}))
+      assert conn.status == 201
+      agent_id = body_json(conn)["agent_id"]
+      assert is_binary(agent_id)
+
+      await = call(authed(:post, "/v1/agents/#{agent_id}/await", %{timeout_ms: 5_000}))
+      assert await.status == 200
+      result = body_json(await)["result"]
+      assert result["exit_status"] == 0
+      assert result["output"] == ["hi there"]
+      assert result["running"] == false
+    end
+
+    test "422 when cmd is missing" do
+      conn = call(authed(:post, "/v1/agents", %{args: ["x"]}))
+      assert conn.status == 422
+      assert body_json(conn)["error"] == "schema_invalid"
+    end
+
+    test "422 when args is not a list of strings" do
+      conn = call(authed(:post, "/v1/agents", %{cmd: "echo", args: [1, 2]}))
+      assert conn.status == 422
+    end
+
+    test "422 on a malformed JSON body" do
+      conn =
+        conn(:post, "/v1/agents", "{not json")
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "Bearer " <> @token)
+        |> call()
+
+      assert conn.status == 422
+      assert body_json(conn)["error"] == "schema_invalid"
+    end
+
+    test "422 when the executable does not exist" do
+      conn = call(authed(:post, "/v1/agents", %{cmd: "definitely-not-a-real-binary-xyz"}))
+      assert conn.status == 422
+      assert body_json(conn)["detail"] =~ "executable not found"
+    end
+
+    test "403 when cmd is outside the allowlist" do
+      Application.put_env(:agent_orchestrator, :cmd_allowlist, ["echo"])
+      conn = call(authed(:post, "/v1/agents", %{cmd: "sh", args: ["-c", "true"]}))
+      assert conn.status == 403
+      assert body_json(conn)["error"] == "permission_denied"
+    end
+
+    test "422 on a malformed lineage parent uuid (runner refuses the spawn)" do
+      conn =
+        call(authed(:post, "/v1/agents", %{cmd: "echo", lineage: %{parent_agent_uuid: "not-a-uuid"}}))
+
+      assert conn.status == 422
+      assert body_json(conn)["detail"] =~ "invalid lineage"
+    end
+  end
+
+  describe "GET /v1/agents" do
+    test "lists live agent ids" do
+      conn = call(authed(:get, "/v1/agents"))
+      assert conn.status == 200
+      body = body_json(conn)
+      assert is_list(body["agents"])
+      assert body["count"] == length(body["agents"])
+    end
+  end
+
+  describe "snapshot / stop / unknown" do
+    test "404 snapshot for an unknown id" do
+      assert call(authed(:get, "/v1/agents/ag-nope")).status == 404
+    end
+
+    test "404 stop for an unknown id" do
+      assert call(authed(:delete, "/v1/agents/ag-nope")).status == 404
+    end
+
+    test "404 on an unknown route" do
+      assert call(authed(:get, "/v1/bogus")).status == 404
+    end
+  end
+
+  describe "POST /v1/agents/:id/await timeout" do
+    test "504 when a long-running agent outlives the await deadline" do
+      conn = call(authed(:post, "/v1/agents", %{cmd: "sh", args: ["-c", "sleep 5"]}))
+      agent_id = body_json(conn)["agent_id"]
+
+      await = call(authed(:post, "/v1/agents/#{agent_id}/await", %{timeout_ms: 50}))
+      assert await.status == 504
+      assert body_json(await)["error"] == "await_timeout"
+
+      # Clean up the still-running agent.
+      assert call(authed(:delete, "/v1/agents/#{agent_id}")).status == 200
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds the **HTTP control surface** that was deferred in `docs/proposals/agent-orchestrator-beam-v0.md`, so the BEAM ephemeral-agent orchestrator can be driven from **outside** the VM (dispatch worker, a CLI, a future MCP shim) instead of only from in-VM Elixir code. This was the single biggest gap between the v0 library-and-smoke and an actual service.

Started from the question *"can agent SDKs live on BEAM"* → the repo's answer is *BEAM owns the **lifecycle** of SDK processes, not the agent loop* (Layer A orchestrator). This PR makes that orchestrator reachable.

## Routes (Plug + Bandit)

| Method | Path | Purpose |
|---|---|---|
| GET | `/v1/health` | liveness + live-agent count |
| POST | `/v1/agents` | spawn a supervised ephemeral agent |
| GET | `/v1/agents` | list live agent ids |
| GET | `/v1/agents/:id` | snapshot (captured output + status, no block) |
| POST | `/v1/agents/:id/await` | block until exit (or `timeout_ms`) |
| DELETE | `/v1/agents/:id` | stop: close the port (kill child) + release lease |

Typed JSON envelopes (`schema_invalid` / `permission_denied` / `not_found` / `lease_denied` / `await_timeout` / `service_unavailable`) + a `protocol_version` field — same typed-absence discipline as the lease-plane router.

## Security posture

Mirrors the lease plane, **stricter in spirit** because `POST /v1/agents` spawns an OS process (authenticated RCE by design — the same capability in-VM `run/1` already has, over one trust boundary):

- **Localhost-only** IPv4 bind (`application.ex`)
- **Bearer auth that fails closed** (`HTTPAuth`, `AGENT_ORCHESTRATOR_BEARER_TOKEN`) — 503 when unconfigured, never silently open
- Auth runs **before** body parsing, so an unauthenticated caller can't reach the spawn path
- Optional `:cmd_allowlist` (default `nil` = parity with the in-VM API) to constrain spawnable executables

## Correctness notes

- **Whitelist-only spec translation** — JSON body → `AgentRunner` spec never `String.to_atom`s caller input (atom-exhaustion guard). Lease / lineage / server-url route through the runner's existing validation, so a bad parent UUID or non-http server URL refuses the spawn as a typed 422.
- **`present/1` is JSON-safe** — `exit_status` is stringified on the abnormal `{:port_closed, reason}` close path so a crashed agent can't crash the response encoder.
- **`SafeParsers`** (mirrors `UnitaresLeasePlane.SafeParsers`) converts malformed JSON / wrong media type to typed 422 / 415; `Plug.ErrorHandler` is the route-handler backstop only.

## Tests

`test/http_router_test.exs` drives the router in-process via `Plug.Test` (no socket, no live plane): auth (503 fail-closed / 401 / case-insensitive scheme), spawn→await round-trip, and the 422/403/404/415/504 typed paths. `start_http` is off under `:test` so the suite binds no socket.

## Also

- `scripts/start.sh` — launchd entrypoint (sources secrets, fail-closed).
- v0 proposal updated: control surface + start.sh move from **Deferred** → **shipped (v0.1)**.
- Doc fix: corrected the stale `application.ex` self-heal comment (the originally-false claim the council caught, now true only via the `agent:/` scheme + #588).

## ⚠️ Verification gate

The Elixir apps are **not in CI** — they're verified by `mix test` on the deploy host. There is no Elixir toolchain in this session, so **this code was not compiled or run here.** The operator's `mix deps.get && mix test` (adds `plug` + `bandit` deps) is the gate. The most likely thing to need a tweak is the parse-error path, which is why I matched the lease plane's proven `SafeParsers` shim rather than relying on `Plug.ErrorHandler`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012gpTCVQBsGd79dBwrnoFHp)_