### PR TITLE
fix(monitor): self-heal _sensor_divergence_history (live check-in crashes)

### DIFF
--- a/src/governance_monitor.py
+++ b/src/governance_monitor.py
@@ -555,6 +555,13 @@ class UNITARESMonitor:
             )
             # Stamp + retain for trend reads (bounded by SENSOR_DIVERGENCE_HISTORY_MAX).
             self._last_sensor_divergence["at"] = datetime.now().isoformat()
+            # Self-heal: a monitor restored bypassing __init__ — a pickle/cache
+            # instance from before this attribute existed, or the Pi plugin's
+            # older build — can lack the deque. Initialize it lazily so a check-in
+            # never raises AttributeError here (the reads at :355 and
+            # runtime_queries already guard with getattr; this is the one write).
+            if not hasattr(self, "_sensor_divergence_history"):
+                self._sensor_divergence_history = deque(maxlen=SENSOR_DIVERGENCE_HISTORY_MAX)
             self._sensor_divergence_history.append(self._last_sensor_divergence)
             logger.debug(
                 "sensor_divergence agent=%s magnitude=%.4f "

--- a/tests/test_sensor_divergence_trend.py
+++ b/tests/test_sensor_divergence_trend.py
@@ -66,6 +66,23 @@ class TestSensorDivergenceTrend:
         # Bound is preserved on the restored deque.
         assert restored._sensor_divergence_history.maxlen == SENSOR_DIVERGENCE_HISTORY_MAX
 
+    def test_self_heals_when_attr_missing(self):
+        """A monitor restored bypassing __init__ (a pickle/cache instance from
+        before this attribute existed, or the Pi plugin's older build) lacks
+        _sensor_divergence_history. A check-in carrying sensor_eisv must NOT
+        raise AttributeError — it self-heals and records the divergence.
+
+        Regression for the live 'UNITARESMonitor object has no attribute
+        _sensor_divergence_history' crash on process_agent_update (2026-06-16).
+        """
+        monitor = UNITARESMonitor(agent_id="div_heal", load_state=False)
+        del monitor._sensor_divergence_history
+        assert not hasattr(monitor, "_sensor_divergence_history")
+        # Must not raise — self-heals lazily at the write site.
+        monitor.process_update({**BASE_STATE, "sensor_eisv": dict(SENSOR)})
+        assert len(monitor._sensor_divergence_history) == 1
+        assert monitor._sensor_divergence_history.maxlen == SENSOR_DIVERGENCE_HISTORY_MAX
+
 
 class TestDivergenceInMetrics:
 


### PR DESCRIPTION
**Live fix.** ~60 `process_agent_update` check-ins + Steward/Lumen (Pi plugin) are actively failing with `AttributeError: 'UNITARESMonitor' object has no attribute '_sensor_divergence_history'`.

## Root cause
The attribute is set in `__init__` (line 267) and the json `load_state` restore (304), but a monitor restored **bypassing `__init__`** — a pickle/cache instance from before the sensor-divergence work (#773/#780, ~17:00 today) added the attribute, or the Pi plugin's older build — lacks it. The **reads** already guard (`governance_monitor.py:355`, `runtime_queries.py:88` both use `getattr`); only the **write** in `update_dynamics` (line 558) was unguarded → crash.

## Fix
Self-heal: lazily initialize the bounded `deque` at the write site if missing, so a check-in never raises here. One-site defensive guard, behavior-preserving for normal monitors.

## Not the lineage flip
This is pre-existing on master — `governance_monitor.py` is untouched by the lineage-archival flip (#798). Independent, and rollback of #798 would not fix it.

## Test
`test_self_heals_when_attr_missing`: a monitor with the attribute deleted records a `sensor_eisv` check-in without raising; 7/7 in `test_sensor_divergence_trend.py` green.

Marking ready — live degradation, should land promptly.