### PR TITLE
fix(lifecycle): guard int(limit) when limit is None in list_agents

### DIFF
--- a/src/mcp_handlers/lifecycle/query.py
+++ b/src/mcp_handlers/lifecycle/query.py
@@ -479,8 +479,12 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                 },
             }
 
-            # Add helpful hints
-            if len(agents) > int(limit):
+            # Add helpful hints. `limit` is None when the caller omits it and the
+            # Pydantic layer injects the null default (the lite-path default of 20
+            # only applies when the key is absent, not when it arrives as None), so
+            # guard int(limit) like the slices above (:470/:471) or the whole list
+            # call crashes with int(NoneType) — the dashboard's read sweep hit this.
+            if limit and len(agents) > int(limit):
                 result["more"] = f"Showing {limit} of {len(agents)} recent. Use limit=50 or recent_days=30 to see more."
             if recent_days:
                 result["filter"] = f"Active in last {recent_days} days. Use recent_days=0 for all."

--- a/tests/test_handlers_lifecycle.py
+++ b/tests/test_handlers_lifecycle.py
@@ -164,6 +164,28 @@ class TestListAgentsLite:
             assert len(data["agents"]) == 3
 
     @pytest.mark.asyncio
+    async def test_limit_none_does_not_crash(self, mock_mcp_server):
+        """Regression: the MCP/Pydantic layer injects limit=None when the caller
+        omits it. The 'more' hint did `int(limit)` unconditionally, crashing the
+        whole list call with int(NoneType) and taking the dashboard read sweep
+        dark. limit=None must list all agents without raising. Incident 2026-06-16."""
+        mock_mcp_server.agent_metadata = {
+            f"agent-{i}": make_agent_meta(label=f"Agent {i}", total_updates=i)
+            for i in range(5)
+        }
+
+        with patch_lifecycle_server(mock_mcp_server):
+            from src.mcp_handlers.lifecycle.handlers import handle_list_agents
+            result = await handle_list_agents(
+                {"lite": True, "limit": None, "recent_days": 0, "status_filter": "all"}
+            )
+
+            data = json.loads(result[0].text)
+            assert len(data["agents"]) == 5
+            assert data["shown"] == 5
+            assert "more" not in data  # no limit => no truncation hint
+
+    @pytest.mark.asyncio
     async def test_filters_stale_agents_by_recency(self, mock_mcp_server):
         recent = datetime.now(timezone.utc).isoformat()
         old = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()


### PR DESCRIPTION
## Problem

`agent(action='list')` / `list_agents` crashes with `int() argument must be a string, a bytes-like object or a real number, not 'NoneType'` whenever the caller omits `limit`. The MCP/Pydantic layer injects `limit=None` (the lite-path `get('limit', 20)` default only fires for an *absent* key, not a present-but-None one), and the 'more' hint at query.py:483 did `int(limit)` unconditionally. The two slices above it already guard (`is not None` / falsy); this one didn't.

This is what made the dashboard / FleetView read **"all agents dark"** during the 2026-06-16 incident — the agents were checking in fine; the *listing* was crashing.

## Fix

Guard `int(limit)` like its siblings: `if limit and len(agents) > int(limit):`.

## Test

`test_limit_none_does_not_crash` — lists with `limit=None` and asserts all agents return without raising. Fails without the fix (crash → error response), passes with it. Full `test_handlers_lifecycle.py` green (34).

Found while diagnosing why resident agents weren't checking in (separate root cause: #800).