### PR TITLE
fix(monitor): initialize sensor-divergence attrs unconditionally in __init__ (root cause of #800)

### DIFF
--- a/src/governance_monitor.py
+++ b/src/governance_monitor.py
@@ -132,7 +132,17 @@ class UNITARESMonitor:
         
         # Initialize last_update timestamp (needed for simulate_update)
         self.last_update = datetime.now()
-        
+
+        # Model<->body sensor divergence ("compare, don't couple"). MUST be set
+        # here, not only in _initialize_fresh_state(): the persisted-state branch
+        # below (load_state=True + state file present) skips _initialize_fresh_state
+        # entirely, so any established agent whose state file predates these fields
+        # would otherwise reach update_dynamics without them and reject its check-in
+        # with AttributeError (incident 2026-06-16, #800). load_persisted_state()
+        # overrides these when the file carries a divergence history.
+        self._last_sensor_divergence: Optional[dict] = None
+        self._sensor_divergence_history: deque = deque(maxlen=SENSOR_DIVERGENCE_HISTORY_MAX)
+
         # Initialize dual-log architecture for grounded EISV inputs
         # ContinuityLayer compares operational (server-derived) vs reflective (agent-reported)
         # to produce grounded complexity, divergence metrics, and EISV inputs

--- a/src/governance_monitor.py
+++ b/src/governance_monitor.py
@@ -133,6 +133,13 @@ class UNITARESMonitor:
         # Initialize last_update timestamp (needed for simulate_update)
         self.last_update = datetime.now()
 
+        # created_at: same invariant — set unconditionally here so the persisted-state
+        # branch never returns a monitor without it. load_persisted_state() overrides
+        # with the file's created_at_iso when present; for older files this now() stands.
+        # (Replaces the post-hoc `if not hasattr(self,'created_at')` band-aid that
+        # patched this one attribute the same way #800 patched the divergence write.)
+        self.created_at = datetime.now()
+
         # Model<->body sensor divergence ("compare, don't couple"). MUST be set
         # here, not only in _initialize_fresh_state(): the persisted-state branch
         # below (load_state=True + state file present) skips _initialize_fresh_state
@@ -237,9 +244,9 @@ class UNITARESMonitor:
                     from governance_core.adaptive_governor import GovernorState
                     self.adaptive_governor.state = GovernorState.from_dict(gov_dict)
                     logger.debug(f"Restored governor state: tau={self.adaptive_governor.state.tau:.3f}, beta={self.adaptive_governor.state.beta:.3f}")
-                # Ensure created_at is set (fallback to now if not in state)
-                if not hasattr(self, 'created_at'):
-                    self.created_at = datetime.now()
+                # created_at is initialized unconditionally in the early block above
+                # and overridden by load_persisted_state() when the file carries it,
+                # so no post-hoc fallback is needed here.
                 logger.info(f"Loaded persisted state for agent: {agent_id} ({len(self.state.V_history)} history entries)")
             else:
                 # Initialize fresh state

--- a/tests/test_sensor_divergence_trend.py
+++ b/tests/test_sensor_divergence_trend.py
@@ -66,6 +66,35 @@ class TestSensorDivergenceTrend:
         # Bound is preserved on the restored deque.
         assert restored._sensor_divergence_history.maxlen == SENSOR_DIVERGENCE_HISTORY_MAX
 
+    def test_loads_pre780_state_file_without_divergence_keys(self, isolated_data_dir):
+        """Root-cause regression (incident 2026-06-16): an established agent whose
+        persisted state file predates the divergence fields loads via the
+        load_state branch, which SKIPS _initialize_fresh_state(). Before the fix
+        the attributes were set only in that method, so the monitor came up
+        WITHOUT them and rejected the next sensor-carrying check-in. They must now
+        be initialized unconditionally in __init__.
+        """
+        import json
+
+        # Seed a real save, then strip the divergence keys to mimic a pre-#780 file.
+        seed = UNITARESMonitor(agent_id="div_pre780", load_state=False)
+        seed.process_update(dict(BASE_STATE))
+        seed.save_persisted_state()
+
+        path = isolated_data_dir / "data" / "agents" / "div_pre780_state.json"
+        data = json.loads(path.read_text())
+        data.pop("sensor_divergence", None)
+        data.pop("sensor_divergence_history", None)
+        path.write_text(json.dumps(data))
+
+        # Load via the persisted-state branch — must still have the attributes.
+        restored = UNITARESMonitor(agent_id="div_pre780", load_state=True)
+        assert hasattr(restored, "_sensor_divergence_history")
+        assert hasattr(restored, "_last_sensor_divergence")
+        # And a sensor-carrying check-in records cleanly (no AttributeError).
+        restored.process_update({**BASE_STATE, "sensor_eisv": dict(SENSOR)})
+        assert len(restored._sensor_divergence_history) == 1
+
     def test_self_heals_when_attr_missing(self):
         """A monitor restored bypassing __init__ (a pickle/cache instance from
         before this attribute existed, or the Pi plugin's older build) lacks

--- a/tests/test_sensor_divergence_trend.py
+++ b/tests/test_sensor_divergence_trend.py
@@ -85,12 +85,15 @@ class TestSensorDivergenceTrend:
         data = json.loads(path.read_text())
         data.pop("sensor_divergence", None)
         data.pop("sensor_divergence_history", None)
+        data.pop("created_at_iso", None)  # also predates created_at persistence
         path.write_text(json.dumps(data))
 
         # Load via the persisted-state branch — must still have the attributes.
         restored = UNITARESMonitor(agent_id="div_pre780", load_state=True)
         assert hasattr(restored, "_sensor_divergence_history")
         assert hasattr(restored, "_last_sensor_divergence")
+        # Same invariant class — created_at must exist even with no fallback band-aid.
+        assert restored.created_at is not None
         # And a sensor-carrying check-in records cleanly (no AttributeError).
         restored.process_update({**BASE_STATE, "sensor_eisv": dict(SENSOR)})
         assert len(restored._sensor_divergence_history) == 1


### PR DESCRIPTION
## Root cause of the 2026-06-16 fleet-wide check-in outage

#800 fixed the *symptom* (lazy-init guard at the `.append` write site). This is the *disease*.

`_last_sensor_divergence` and `_sensor_divergence_history` were initialized **only** in `_initialize_fresh_state()`. But `__init__`'s persisted-state branch:

```python
if load_state:
    persisted_state = self.load_persisted_state()
    if persisted_state is not None:
        self.state = persisted_state      # <-- does NOT call _initialize_fresh_state()
    else:
        self._initialize_fresh_state()
else:
    self._initialize_fresh_state()
```

sets `self.state` and **skips `_initialize_fresh_state` entirely**. So every established agent whose persisted state file predated #780 loaded *without* the attributes and rejected its next sensor-carrying check-in with `AttributeError`. `load_persisted_state` only re-added them `if div_hist:`, which no pre-#780 file had.

This is why it was fleet-wide, not Lumen-only: the *behavioral* sensor is injected for every agent ≥3 check-ins (`phases.py:812`), so the broken branch ran for ~the whole active fleet. Lumen looked like the sole victim only because its 5-min physical-sensor cadence hit it relentlessly → fully dark; Vigil/Sentinel/Watcher were degraded.

There's a tell this bug class recurs: the `if not hasattr(self, 'created_at')` band-aid at the top of the persisted-load branch patches *one* attribute the same way. `prev_parameters`/`last_update` avoid it by living in the early *"must be initialized regardless of whether state is loaded"* block — which is exactly where these two belong.

## Fix

Move the two inits into that early unconditional block, so they exist on **every** construction path. `load_persisted_state` still overrides them when the file carries a divergence history. The redundant assignments left in `_initialize_fresh_state` are harmless.

## Test

`test_loads_pre780_state_file_without_divergence_keys` — writes a real state file with the divergence keys stripped (the actual pre-#780 path), loads via `load_state=True`, asserts the attributes exist and a sensor-carrying check-in records cleanly. **Fails without this change** (#800's write-site guard can't fix it — the test checks `hasattr` at construction, before any check-in). 266 monitor tests green.

## Relation to #800

Complementary. #800 (merged, deployed) keeps production safe right now; this removes the underlying cause. #800's guard stays as defense-in-depth. Draft for operator gate — not an emergency since #800 already protects the live path.