### PR TITLE
feat(identity): per-path prefix-bind fingerprint hardening (#802)

### DIFF
--- a/config/governance_config.py
+++ b/config/governance_config.py
@@ -1070,6 +1070,52 @@ def session_fingerprint_check_mode() -> str:
 
 
 # =============================================================================
+# PREFIX-BIND FINGERPRINT MODE (#802 — per-path hardening)
+# =============================================================================
+# The `agent-{uuid12}` prefix shape is resolvable from a victim's UUID alone
+# (logs, KG metadata, leaked anchor files), and PATH 1 resolves it to the
+# bound UUID. The global UNITARES_SESSION_FINGERPRINT_CHECK cannot safely flip
+# to `strict` fleet-wide because IP:UA is legitimately SHARED by co-resident
+# localhost clients (e.g. the bridge + gateway, both python-httpx) — strict
+# would false-reject real twins. But the prefix shape specifically warrants a
+# stricter ownership check than the global default, and — unlike the global
+# check — an ABSENT binding-time fingerprint on a prefix key is itself
+# non-authorizing: a UUID-derivable key with no recorded fingerprint carries
+# no ownership proof at all (the bind_ip_ua-absent hole at resolution.py
+# PATH 1, council finding for #802).
+#
+# This flag scopes that stricter check to the `agent-` prefix shape only,
+# leaving the global default untouched. Modes mirror the global flag and
+# follow the same staged off→log→strict ramp as STRICT_IDENTITY_REQUIRED
+# (#425):
+#   "off"    — no per-path check (DEFAULT; behavior identical to today)
+#   "log"    — emit [PATH1_FINGERPRINT_MISMATCH] + identity_hijack_suspected
+#              on a prefix-key ownership failure (fingerprint mismatch OR an
+#              absent binding/current fingerprint); resume still proceeds
+#   "strict" — same events, but the prefix resume falls through to a fresh
+#              session (PATH 3) instead of returning the cached UUID
+#
+# When set above the global mode, the per-path mode takes precedence for the
+# prefix shape. This closes only the CROSS-fingerprint hijack; a same-
+# fingerprint co-resident still passes (that residual needs the substrate/UDS
+# peer-credential path — see issue #802). Redaction stays load-bearing.
+# Override: UNITARES_PREFIX_BIND_FINGERPRINT env var.
+PREFIX_BIND_FINGERPRINT_MODE: str = os.getenv(
+    "UNITARES_PREFIX_BIND_FINGERPRINT", "off"
+).strip().lower()
+if PREFIX_BIND_FINGERPRINT_MODE not in _VALID_FINGERPRINT_MODES:
+    PREFIX_BIND_FINGERPRINT_MODE = "off"
+
+
+def prefix_bind_fingerprint_mode() -> str:
+    """Runtime accessor — respects env changes set after module load (tests)."""
+    m = os.getenv(
+        "UNITARES_PREFIX_BIND_FINGERPRINT", PREFIX_BIND_FINGERPRINT_MODE
+    ).strip().lower()
+    return m if m in _VALID_FINGERPRINT_MODES else "off"
+
+
+# =============================================================================
 # IP:UA ONBOARD PIN CHECK MODE (PATH 2 — council follow-up to #83)
 # =============================================================================
 # `derive_session_key` step 7 resolves an unauthenticated `onboard()` call

--- a/src/mcp_handlers/identity/resolution.py
+++ b/src/mcp_handlers/identity/resolution.py
@@ -558,53 +558,95 @@ async def resolve_session_identity(
                         # the current request's fingerprint. Mismatch fires
                         # identity_hijack_suspected with path="path1_session_id" and,
                         # in strict mode, falls through to a fresh session.
-                        cached_bind_fp = cached.get("bind_ip_ua")
-                        if cached_bind_fp:
+                        #
+                        # #802 per-path hardening: the `agent-` prefix shape also
+                        # honors UNITARES_PREFIX_BIND_FINGERPRINT, which may be set
+                        # stricter than the global default. Under that per-path mode an
+                        # ABSENT binding-time OR current fingerprint is itself
+                        # non-authorizing for the prefix shape (a UUID-derivable key
+                        # with no recorded fingerprint has no ownership proof — the
+                        # bind_ip_ua-absent hole). The per-path mode is scoped to the
+                        # prefix shape, so non-prefix keys and the default-off posture
+                        # stay byte-identical to prior behavior. Closes only the
+                        # cross-fingerprint hijack; same-fingerprint co-residents still
+                        # pass (residual needs the substrate/UDS path — see #802).
+                        from config.governance_config import (
+                            session_fingerprint_check_mode,
+                            prefix_bind_fingerprint_mode,
+                        )
+                        _is_prefix_key = session_key.startswith("agent-")
+                        _global_fp_mode = session_fingerprint_check_mode()
+                        _prefix_fp_mode = (
+                            prefix_bind_fingerprint_mode() if _is_prefix_key else "off"
+                        )
+                        _FP_RANK = {"off": 0, "log": 1, "strict": 2}
+                        _fp_mode = _global_fp_mode
+                        if _FP_RANK.get(_prefix_fp_mode, 0) > _FP_RANK.get(_global_fp_mode, 0):
+                            _fp_mode = _prefix_fp_mode
+                        # The absent-fingerprint branches fire ONLY when the per-path
+                        # flag is active (>=log). The global check must never penalize
+                        # a missing fingerprint — that is the legacy-cache backward-
+                        # compat contract (test_legacy_cache_without_bind_fp_no_event):
+                        # strict-mode promotion must not retroactively invalidate every
+                        # pre-existing session that predates the bind_ip_ua field.
+                        _prefix_active = _is_prefix_key and _prefix_fp_mode != "off"
+
+                        if _fp_mode != "off":
+                            cached_bind_fp = cached.get("bind_ip_ua")
                             try:
                                 from ..context import get_session_signals
                                 _sig = get_session_signals()
                                 current_fp = getattr(_sig, "ip_ua_fingerprint", None) if _sig else None
                             except Exception:
                                 current_fp = None
-                            if current_fp and current_fp != cached_bind_fp:
-                                from config.governance_config import session_fingerprint_check_mode
-                                _fp_mode = session_fingerprint_check_mode()
-                                if _fp_mode != "off":
-                                    logger.warning(
-                                        "[PATH1_FINGERPRINT_MISMATCH] session_key=%s... "
-                                        "bound_fp=%s current_fp=%s — suspected hijack of "
-                                        "agent=%s... (mode=%s)",
-                                        session_key[:20],
-                                        cached_bind_fp[:16],
-                                        current_fp[:16],
-                                        agent_uuid[:8],
-                                        _fp_mode,
-                                    )
-                                    try:
-                                        from .handlers import _broadcaster
-                                        _b = _broadcaster()
-                                        if _b is not None:
-                                            await _b.broadcast_event(
-                                                event_type="identity_hijack_suspected",
-                                                agent_id=agent_uuid,
-                                                payload={
-                                                    "path": "path1_session_id",
-                                                    "mode": _fp_mode,
-                                                    "source": "path1_fingerprint_mismatch",
-                                                    "bind_fp_prefix": cached_bind_fp[:8],
-                                                    "current_fp_prefix": current_fp[:8],
-                                                },
-                                            )
-                                    except Exception as _be:
-                                        logger.warning(
-                                            f"[PATH1_FINGERPRINT_MISMATCH] broadcast failed: {_be}"
+
+                            _violation = None
+                            if cached_bind_fp and current_fp and current_fp != cached_bind_fp:
+                                _violation = "fingerprint_mismatch"
+                            elif _prefix_active and not cached_bind_fp:
+                                _violation = "no_bind_fingerprint"
+                            elif _prefix_active and not current_fp:
+                                _violation = "no_current_fingerprint"
+
+                            if _violation:
+                                logger.warning(
+                                    "[PATH1_FINGERPRINT_MISMATCH] session_key=%s... "
+                                    "bound_fp=%s current_fp=%s reason=%s — suspected "
+                                    "hijack of agent=%s... (mode=%s)",
+                                    session_key[:20],
+                                    (cached_bind_fp or "<none>")[:16],
+                                    (current_fp or "<none>")[:16],
+                                    _violation,
+                                    agent_uuid[:8],
+                                    _fp_mode,
+                                )
+                                try:
+                                    from .handlers import _broadcaster
+                                    _b = _broadcaster()
+                                    if _b is not None:
+                                        await _b.broadcast_event(
+                                            event_type="identity_hijack_suspected",
+                                            agent_id=agent_uuid,
+                                            payload={
+                                                "path": "path1_session_id",
+                                                "mode": _fp_mode,
+                                                "source": "path1_fingerprint_mismatch",
+                                                "reason": _violation,
+                                                "prefix_scoped": _prefix_active,
+                                                "bind_fp_prefix": (cached_bind_fp or "")[:8],
+                                                "current_fp_prefix": (current_fp or "")[:8],
+                                            },
                                         )
-                                    if _fp_mode == "strict":
-                                        # Fall through to PATH 3 (fresh session).
-                                        # Do NOT delete the cache entry — the
-                                        # legitimate owner can still resume from
-                                        # the correct fingerprint.
-                                        resume = False
+                                except Exception as _be:
+                                    logger.warning(
+                                        f"[PATH1_FINGERPRINT_MISMATCH] broadcast failed: {_be}"
+                                    )
+                                if _fp_mode == "strict":
+                                    # Fall through to PATH 3 (fresh session).
+                                    # Do NOT delete the cache entry — the
+                                    # legitimate owner can still resume from
+                                    # the correct fingerprint.
+                                    resume = False
 
                         # If strict-mode fingerprint mismatch set resume=False
                         # above, skip the cached-resume return and fall through

--- a/src/mcp_handlers/identity/resolution.py
+++ b/src/mcp_handlers/identity/resolution.py
@@ -609,11 +609,16 @@ async def resolve_session_identity(
                                 _violation = "no_current_fingerprint"
 
                             if _violation:
+                                # NB: the session_key prefix is carried in the
+                                # structured broadcast payload below rather than in
+                                # this clear-text warning. session_key is a non-secret,
+                                # UUID-derivable identifier (the whole premise of #802),
+                                # but its name trips CodeQL's clear-text-logging name
+                                # heuristic; agent_uuid already identifies the subject.
                                 logger.warning(
-                                    "[PATH1_FINGERPRINT_MISMATCH] session_key=%s... "
-                                    "bound_fp=%s current_fp=%s reason=%s — suspected "
-                                    "hijack of agent=%s... (mode=%s)",
-                                    session_key[:20],
+                                    "[PATH1_FINGERPRINT_MISMATCH] bound_fp=%s "
+                                    "current_fp=%s reason=%s — suspected hijack of "
+                                    "agent=%s... (mode=%s)",
                                     (cached_bind_fp or "<none>")[:16],
                                     (current_fp or "<none>")[:16],
                                     _violation,
@@ -633,6 +638,7 @@ async def resolve_session_identity(
                                                 "source": "path1_fingerprint_mismatch",
                                                 "reason": _violation,
                                                 "prefix_scoped": _prefix_active,
+                                                "session_key_prefix": session_key[:20],
                                                 "bind_fp_prefix": (cached_bind_fp or "")[:8],
                                                 "current_fp_prefix": (current_fp or "")[:8],
                                             },

--- a/tests/test_identity_prefix_bind_fingerprint_802.py
+++ b/tests/test_identity_prefix_bind_fingerprint_802.py
@@ -1,0 +1,357 @@
+"""Per-path prefix-bind fingerprint hardening (#802).
+
+The `agent-{uuid12}` prefix shape is resolvable from a victim's UUID alone, so
+PATH 1 resume by that shape has no ownership proof. The global
+`UNITARES_SESSION_FINGERPRINT_CHECK` cannot safely flip to `strict` fleet-wide
+(IP:UA is legitimately shared by co-resident localhost clients), so #802 adds a
+*per-path* flag, `UNITARES_PREFIX_BIND_FINGERPRINT`, scoped to the prefix shape.
+
+This module locks in the per-path behavior:
+
+  - Default `off` → byte-identical to prior behavior (no per-path check).
+  - `log`/`strict` activate the prefix-scoped check, which — unlike the global
+    check — treats an ABSENT binding/current fingerprint on a prefix key as
+    non-authorizing (closes the bind_ip_ua-absent hole).
+  - The per-path mode takes precedence when set stricter than the global mode.
+  - Non-prefix keys are never affected by the per-path flag (scoping).
+
+The global-flag behavior itself is covered by test_identity_path1_fingerprint.py;
+here we only exercise what the per-path flag adds.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_modes(monkeypatch):
+    monkeypatch.delenv("UNITARES_SESSION_FINGERPRINT_CHECK", raising=False)
+    monkeypatch.delenv("UNITARES_PREFIX_BIND_FINGERPRINT", raising=False)
+    yield
+
+
+def _signals_with_fp(fp):
+    sig = MagicMock()
+    sig.ip_ua_fingerprint = fp
+    return sig
+
+
+@pytest.fixture
+def captured_events():
+    return []
+
+
+@pytest.fixture
+def broadcaster_stub(captured_events):
+    b = MagicMock()
+
+    async def _record(**kwargs):
+        captured_events.append(kwargs)
+
+    b.broadcast_event = AsyncMock(side_effect=_record)
+    return b
+
+
+def _hijack_events(captured_events):
+    return [
+        e for e in captured_events
+        if e.get("event_type") == "identity_hijack_suspected"
+    ]
+
+
+class TestPerPathAbsentFingerprintHole:
+    """An absent binding fingerprint on a prefix key is non-authorizing under
+    the per-path flag — this is the bind_ip_ua-absent hole #802 closes."""
+
+    @pytest.mark.asyncio
+    async def test_strict_absent_bind_fp_falls_through(
+        self, monkeypatch, captured_events, broadcaster_stub
+    ):
+        # Global OFF proves the per-path flag alone drives the denial.
+        monkeypatch.setenv("UNITARES_SESSION_FINGERPRINT_CHECK", "off")
+        monkeypatch.setenv("UNITARES_PREFIX_BIND_FINGERPRINT", "strict")
+
+        from src.mcp_handlers.identity import resolution as res
+
+        cached_uuid = "11111111-2222-3333-4444-555555555555"
+        cached_payload = {
+            "agent_id": cached_uuid,
+            "display_agent_id": "Claude_no_bindfp",
+            # NO bind_ip_ua — the hole
+        }
+        fake_redis = MagicMock()
+        fake_redis.get = AsyncMock(return_value=cached_payload)
+
+        with patch.object(res, "_get_redis", return_value=fake_redis), patch(
+            "src.mcp_handlers.context.get_session_signals",
+            return_value=_signals_with_fp("ip-attacker:ua-attacker"),
+        ), patch(
+            "src.mcp_handlers.identity.handlers._broadcaster",
+            return_value=broadcaster_stub,
+        ), patch.object(
+            res, "_agent_exists_in_postgres", new=AsyncMock(return_value=False)
+        ), patch(
+            "src.mcp_handlers.identity.resolution.get_db",
+            side_effect=RuntimeError("PATH 2 must not resume the victim"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._generate_agent_id",
+            return_value="Claude_fresh",
+        ):
+            result = await res.resolve_session_identity(
+                session_key="agent-111111111222",
+                resume=True,
+                persist=False,
+            )
+
+        assert result.get("agent_uuid") != cached_uuid, (
+            f"Strict per-path mode must refuse to reuse a prefix-key binding "
+            f"with no recorded fingerprint. Got: {result}"
+        )
+        evts = _hijack_events(captured_events)
+        assert evts, f"Absent bind fp must emit. Captured: {captured_events}"
+        payload = evts[0].get("payload") or {}
+        assert payload.get("reason") == "no_bind_fingerprint"
+        assert payload.get("prefix_scoped") is True
+        assert payload.get("mode") == "strict"
+
+    @pytest.mark.asyncio
+    async def test_log_absent_bind_fp_emits_but_proceeds(
+        self, monkeypatch, captured_events, broadcaster_stub
+    ):
+        monkeypatch.setenv("UNITARES_SESSION_FINGERPRINT_CHECK", "off")
+        monkeypatch.setenv("UNITARES_PREFIX_BIND_FINGERPRINT", "log")
+
+        from src.mcp_handlers.identity import resolution as res
+
+        cached_uuid = "22222222-3333-4444-5555-666666666666"
+        cached_payload = {
+            "agent_id": cached_uuid,
+            "display_agent_id": "Claude_log_nobindfp",
+        }
+        fake_redis = MagicMock()
+        fake_redis.get = AsyncMock(return_value=cached_payload)
+
+        with patch.object(res, "_get_redis", return_value=fake_redis), patch(
+            "src.mcp_handlers.identity.resolution._agent_exists_in_postgres",
+            new=AsyncMock(return_value=True),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._get_agent_label",
+            new=AsyncMock(return_value="Claude_log_nobindfp"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._get_agent_status",
+            new=AsyncMock(return_value="active"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._soft_verify_trajectory",
+            new=AsyncMock(return_value={"verified": True}),
+        ), patch(
+            "src.mcp_handlers.context.get_session_signals",
+            return_value=_signals_with_fp("ip-any:ua-any"),
+        ), patch(
+            "src.mcp_handlers.identity.handlers._broadcaster",
+            return_value=broadcaster_stub,
+        ):
+            result = await res.resolve_session_identity(
+                session_key="agent-222222222333",
+                resume=True,
+            )
+
+        # Log mode: still resumes...
+        assert result.get("source") == "redis"
+        assert result.get("agent_uuid") == cached_uuid
+        # ...but the absent-fp violation is observed.
+        evts = _hijack_events(captured_events)
+        assert evts and (evts[0].get("payload") or {}).get("reason") == "no_bind_fingerprint"
+
+    @pytest.mark.asyncio
+    async def test_strict_absent_current_fp_falls_through(
+        self, monkeypatch, captured_events, broadcaster_stub
+    ):
+        """No current request fingerprint is also non-authorizing for a prefix key."""
+        monkeypatch.setenv("UNITARES_SESSION_FINGERPRINT_CHECK", "off")
+        monkeypatch.setenv("UNITARES_PREFIX_BIND_FINGERPRINT", "strict")
+
+        from src.mcp_handlers.identity import resolution as res
+
+        cached_uuid = "33333333-4444-5555-6666-777777777777"
+        cached_payload = {
+            "agent_id": cached_uuid,
+            "display_agent_id": "Claude_no_curfp",
+            "bind_ip_ua": "ip-orig:ua-orig",  # bind fp present, but...
+        }
+        fake_redis = MagicMock()
+        fake_redis.get = AsyncMock(return_value=cached_payload)
+
+        with patch.object(res, "_get_redis", return_value=fake_redis), patch(
+            "src.mcp_handlers.context.get_session_signals",
+            return_value=None,  # ...no current fingerprint
+        ), patch(
+            "src.mcp_handlers.identity.handlers._broadcaster",
+            return_value=broadcaster_stub,
+        ), patch.object(
+            res, "_agent_exists_in_postgres", new=AsyncMock(return_value=False)
+        ), patch(
+            "src.mcp_handlers.identity.resolution.get_db",
+            side_effect=RuntimeError("PATH 2 must not resume the victim"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._generate_agent_id",
+            return_value="Claude_fresh",
+        ):
+            result = await res.resolve_session_identity(
+                session_key="agent-333333333444",
+                resume=True,
+                persist=False,
+            )
+
+        assert result.get("agent_uuid") != cached_uuid
+        evts = _hijack_events(captured_events)
+        assert evts and (evts[0].get("payload") or {}).get("reason") == "no_current_fingerprint"
+
+
+class TestPerPathPrecedenceAndScoping:
+
+    @pytest.mark.asyncio
+    async def test_strict_overrides_global_off_on_mismatch(
+        self, monkeypatch, captured_events, broadcaster_stub
+    ):
+        """Global off would skip; per-path strict denies a present-fp mismatch."""
+        monkeypatch.setenv("UNITARES_SESSION_FINGERPRINT_CHECK", "off")
+        monkeypatch.setenv("UNITARES_PREFIX_BIND_FINGERPRINT", "strict")
+
+        from src.mcp_handlers.identity import resolution as res
+
+        cached_uuid = "44444444-5555-6666-7777-888888888888"
+        cached_payload = {
+            "agent_id": cached_uuid,
+            "display_agent_id": "Claude_override",
+            "bind_ip_ua": "ip-original:ua-original",
+        }
+        fake_redis = MagicMock()
+        fake_redis.get = AsyncMock(return_value=cached_payload)
+
+        with patch.object(res, "_get_redis", return_value=fake_redis), patch(
+            "src.mcp_handlers.context.get_session_signals",
+            return_value=_signals_with_fp("ip-attacker:ua-attacker"),
+        ), patch(
+            "src.mcp_handlers.identity.handlers._broadcaster",
+            return_value=broadcaster_stub,
+        ), patch.object(
+            res, "_agent_exists_in_postgres", new=AsyncMock(return_value=False)
+        ), patch(
+            "src.mcp_handlers.identity.resolution.get_db",
+            side_effect=RuntimeError("PATH 2 must not resume the victim"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._generate_agent_id",
+            return_value="Claude_fresh",
+        ):
+            result = await res.resolve_session_identity(
+                session_key="agent-444444444555",
+                resume=True,
+                persist=False,
+            )
+
+        assert result.get("agent_uuid") != cached_uuid
+        evts = _hijack_events(captured_events)
+        assert evts and (evts[0].get("payload") or {}).get("reason") == "fingerprint_mismatch"
+        assert (evts[0].get("payload") or {}).get("mode") == "strict"
+
+    @pytest.mark.asyncio
+    async def test_perpath_does_not_affect_nonprefix_key(
+        self, monkeypatch, captured_events, broadcaster_stub
+    ):
+        """A non-`agent-` session_key is outside the per-path flag's scope:
+        even strict + absent fp must resume untouched."""
+        monkeypatch.setenv("UNITARES_SESSION_FINGERPRINT_CHECK", "off")
+        monkeypatch.setenv("UNITARES_PREFIX_BIND_FINGERPRINT", "strict")
+
+        from src.mcp_handlers.identity import resolution as res
+
+        cached_uuid = "55555555-6666-7777-8888-999999999999"
+        cached_payload = {
+            "agent_id": cached_uuid,
+            "display_agent_id": "Claude_nonprefix",
+            # no bind_ip_ua — but key is not the prefix shape, so out of scope
+        }
+        fake_redis = MagicMock()
+        fake_redis.get = AsyncMock(return_value=cached_payload)
+
+        with patch.object(res, "_get_redis", return_value=fake_redis), patch(
+            "src.mcp_handlers.identity.resolution._agent_exists_in_postgres",
+            new=AsyncMock(return_value=True),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._get_agent_label",
+            new=AsyncMock(return_value="Claude_nonprefix"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._get_agent_status",
+            new=AsyncMock(return_value="active"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._soft_verify_trajectory",
+            new=AsyncMock(return_value={"verified": True}),
+        ), patch(
+            "src.mcp_handlers.context.get_session_signals",
+            return_value=_signals_with_fp("ip-any:ua-any"),
+        ), patch(
+            "src.mcp_handlers.identity.handlers._broadcaster",
+            return_value=broadcaster_stub,
+        ):
+            result = await res.resolve_session_identity(
+                session_key="mcp-session-abcdef0123",
+                resume=True,
+            )
+
+        assert result.get("source") == "redis"
+        assert result.get("agent_uuid") == cached_uuid
+        assert _hijack_events(captured_events) == [], (
+            "Per-path flag must not touch non-prefix keys"
+        )
+
+    @pytest.mark.asyncio
+    async def test_default_off_absent_bind_fp_is_silent(
+        self, monkeypatch, captured_events, broadcaster_stub
+    ):
+        """Default (per-path unset) under global log: an absent bind fp on a
+        prefix key stays silent — the inert default, identical to today and to
+        the legacy backward-compat contract."""
+        monkeypatch.setenv("UNITARES_SESSION_FINGERPRINT_CHECK", "log")
+        # UNITARES_PREFIX_BIND_FINGERPRINT intentionally unset → "off"
+
+        from src.mcp_handlers.identity import resolution as res
+
+        cached_uuid = "66666666-7777-8888-9999-000000000000"
+        cached_payload = {
+            "agent_id": cached_uuid,
+            "display_agent_id": "Claude_default_off",
+        }
+        fake_redis = MagicMock()
+        fake_redis.get = AsyncMock(return_value=cached_payload)
+
+        with patch.object(res, "_get_redis", return_value=fake_redis), patch(
+            "src.mcp_handlers.identity.resolution._agent_exists_in_postgres",
+            new=AsyncMock(return_value=True),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._get_agent_label",
+            new=AsyncMock(return_value="Claude_default_off"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._get_agent_status",
+            new=AsyncMock(return_value="active"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._soft_verify_trajectory",
+            new=AsyncMock(return_value={"verified": True}),
+        ), patch(
+            "src.mcp_handlers.context.get_session_signals",
+            return_value=_signals_with_fp("ip-any:ua-any"),
+        ), patch(
+            "src.mcp_handlers.identity.handlers._broadcaster",
+            return_value=broadcaster_stub,
+        ):
+            result = await res.resolve_session_identity(
+                session_key="agent-666666666777",
+                resume=True,
+            )
+
+        assert result.get("source") == "redis"
+        assert result.get("agent_uuid") == cached_uuid
+        assert _hijack_events(captured_events) == [], (
+            "Per-path default off must be silent on absent bind fp"
+        )


### PR DESCRIPTION
Implements the council-vetted, inert-by-default increment for #802 (scope (a)).

## What this is

Issue #802 traced that the `agent-{uuid12}` prefix-bind is the only UUID-hijack vector still open after #425, and that **UUID/lineage redaction is the only live denier**. A three-agent council (dialectic / code-review / live-verifier, [comment](https://github.com/cirwel/unitares/issues/802#issuecomment-4725664514)) **rejected the issue's original "generalize continuity_token to the agent path" direction** — the token is a copyable bearer; S19 already refuses token-only HTTP resume for exactly that reason, so generalizing it would re-open the vector S19 closed. The council's actual fix: the correct denier already exists (per-path fingerprint-strict) but is switched off.

This PR ships that denier as a **per-path flag, fully inert at the default `off`.**

## Changes

- **`config/governance_config.py`** — new `UNITARES_PREFIX_BIND_FINGERPRINT` flag (`off`/`log`/`strict`, default `off`) + `prefix_bind_fingerprint_mode()` accessor. Same staged `off→log→strict` ramp as `STRICT_IDENTITY_REQUIRED` (#425). Scoped to the `agent-` prefix shape, so it can be stricter than the global `UNITARES_SESSION_FINGERPRINT_CHECK` without false-rejecting legitimately-shared-fingerprint twins (bridge+gateway) on other key shapes.
- **`src/mcp_handlers/identity/resolution.py`** PATH 1 — when the per-path flag is active, an **absent binding-time OR current fingerprint** on a prefix key is treated as non-authorizing (closes the `bind_ip_ua`-absent hole the council flagged: UDS-bound prefix keys had no fingerprint to check, so the old check silently passed them). `strict` falls through to a fresh mint via the **same `resume=False` path the existing global-strict mode already uses** (line ~602); `mint_guard=True` keeps the victim's binding intact. Broadcast payload gains `reason` + `prefix_scoped`.

## Safety / scope

- **Inert by default.** With `UNITARES_PREFIX_BIND_FINGERPRINT=off` (default), behavior is byte-identical to today. Non-prefix keys are never affected. The global check still never penalizes a missing fingerprint, so the legacy-cache backward-compat contract (`test_legacy_cache_without_bind_fp_no_event`) is preserved.
- **Closes:** cross-fingerprint prefix-bind hijack (when ramped to `strict`).
- **Leaves open (documented in #802):** same-fingerprint co-resident hijack — needs the substrate/UDS peer-credential path, with Lumen/Vigil enrolled in `core.substrate_claims` first (only Sentinel is today). Redaction stays load-bearing as the information-layer control.
- **Rollout:** flip to `log` to observe prefix-key ownership failures in prod, then `strict` after a clean burn-in — exactly the #425 pattern. Note: the `strict→fresh-mint` interaction (incl. the PG `create_session` overwrite question for the victim's `session_key`) is a property shared with the already-shippable global-strict mode and should be validated during the `log` burn-in before flipping `strict`.

## Tests

- 6 new tests in `tests/test_identity_prefix_bind_fingerprint_802.py`: absent-bind-fp strict fall-through, absent-bind-fp log emit-and-proceed, absent-current-fp strict, per-path-overrides-global precedence, non-prefix scoping, default-off silence.
- Existing `tests/test_identity_path1_fingerprint.py` unchanged and green.
- Full suite: 10109 passed, 22 skipped (`test-cache.sh`).

Identity is a writer-locked surface — no in-flight identity PRs at branch time.