### PR TITLE
feat(identity): extend S19 substrate gate to prefix-bind/session resume (#802)

### DIFF
--- a/src/mcp_handlers/identity/resolution.py
+++ b/src/mcp_handlers/identity/resolution.py
@@ -310,6 +310,68 @@ async def _soft_verify_trajectory(
 # CORE IDENTITY RESOLUTION (3 paths)
 # =============================================================================
 
+async def _substrate_http_reject(agent_uuid: str, source: str):
+    """S19 extension (#802): a substrate-anchored UUID must not resume over a
+    non-UDS (HTTP) transport via ANY session path — not just continuity_token.
+
+    The original S19 gate (PATH 2.8 / the pre-PATH-1 token gate) only fires when
+    the caller presents a `continuity_token` (`token_agent_uuid`). A caller who
+    knows a substrate resident's UUID can EVADE it by resuming through the
+    `agent-{uuid12}` prefix-bind form (PATH 1 cache hit) or a PG session row
+    (PATH 2) with NO token — `token_agent_uuid` is None, so the gate is skipped
+    and the resident's UUID is returned. On a shared-fingerprint localhost host
+    the scope-(a) per-path fingerprint check also passes, so this is the
+    same-fingerprint co-resident residual called out in #802.
+
+    This helper applies the same substrate-claims gate to a session-resolved
+    `agent_uuid`. It is self-scoping: a UUID with no `core.substrate_claims` row
+    returns None (no rejection), so non-substrate and non-enrolled agents are
+    unaffected and future enrollment extends coverage with no code change. A
+    legitimate resident connects over UDS (peer_pid present) and via PATH 0
+    (agent_uuid direct), never the prefix/session path over HTTP, so a substrate
+    UUID arriving here without a kernel-attested peer PID is never legitimate.
+
+    Returns a `resume_failed` refusal dict when rejected, else None. Any
+    unexpected error fails OPEN (returns None) — never breaks resolution.
+    """
+    try:
+        from src.mcp_handlers.context import get_session_signals
+        _signals = get_session_signals()
+        _peer_pid = _signals.peer_pid if _signals else None
+        if _peer_pid is not None:
+            # UDS path — the kernel can attest the peer; let normal
+            # substrate verification (handler_gate) judge it.
+            return None
+        from src.substrate.verification import fetch_substrate_claim
+        _claim = await fetch_substrate_claim(agent_uuid)
+        if _claim is None:
+            return None  # not substrate-anchored — unaffected
+        logger.warning(
+            "[SUBSTRATE_HTTP_REJECT] %s resume for substrate-anchored UUID "
+            "%s... over HTTP — refusing. Resident must connect via "
+            "UNITARES_UDS_SOCKET.",
+            source, agent_uuid[:8],
+        )
+        return {
+            "resume_failed": True,
+            "error": "substrate_anchored_uuid_requires_uds",
+            "agent_uuid": agent_uuid,
+            "message": (
+                f"Agent {agent_uuid[:8]}... is substrate-anchored "
+                f"({_claim.expected_launchd_label}). Session/prefix resume is "
+                f"not accepted over HTTP. Connect via the UNITARES_UDS_SOCKET "
+                f"path so the kernel can attest peer credentials."
+            ),
+        }
+    except Exception as exc:
+        logger.warning(
+            "[SUBSTRATE_HTTP_REJECT] %s gate raised for %s...: %s; falling "
+            "through to existing resolution",
+            source, agent_uuid[:8], exc, exc_info=True,
+        )
+        return None
+
+
 async def resolve_session_identity(
 
     session_key: str,
@@ -512,6 +574,18 @@ async def resolve_session_identity(
                     # agent as the new identity's predecessor.
                     # See docs/specs/2026-04-16-sever-fingerprint-eisv-inheritance-design.md
                     if resume:
+
+                        # S19 extension (#802): refuse a substrate-anchored UUID
+                        # resumed via prefix-bind / cached session over HTTP. The
+                        # token gate above only covers continuity_token resume;
+                        # this closes the no-token prefix-bind evasion (and the
+                        # same-fingerprint co-resident residual). Self-scoping —
+                        # non-substrate UUIDs are unaffected.
+                        _sub_reject = await _substrate_http_reject(
+                            agent_uuid, source="path1_prefix_session"
+                        )
+                        if _sub_reject is not None:
+                            return _sub_reject
 
                         # PATH 1 token ownership cross-check (issue #110,
                         # 2026-04-23). When the caller provided a signed
@@ -811,6 +885,16 @@ async def resolve_session_identity(
                     agent_uuid = stored_id
 
                     agent_id = stored_id
+
+                # S19 extension (#802): same gate as PATH 1, for a UUID resolved
+                # from a PG session row (Redis cache miss → PG hit). A substrate
+                # UUID resumed via session/prefix over HTTP is refused; self-
+                # scoping, so non-substrate UUIDs pass through untouched.
+                _sub_reject = await _substrate_http_reject(
+                    agent_uuid, source="path2_pg_session"
+                )
+                if _sub_reject is not None:
+                    return _sub_reject
 
                 label = await _get_agent_label(agent_uuid)
 

--- a/tests/test_identity_substrate_prefix_gate_802.py
+++ b/tests/test_identity_substrate_prefix_gate_802.py
@@ -1,0 +1,218 @@
+"""S19 extension — substrate gate on the prefix-bind / session resume path (#802).
+
+The original S19 substrate-HTTP-reject (resolution.py pre-PATH-1 gate + PATH 2.8)
+only fires when the caller presents a `continuity_token`. A caller holding a
+substrate resident's UUID can evade it by resuming via the `agent-{uuid12}`
+prefix-bind form (PATH 1) or a PG session row (PATH 2) with NO token. On a
+shared-fingerprint localhost host the scope-(a) per-path fingerprint check also
+passes, so this is the same-fingerprint co-resident residual from #802.
+
+`_substrate_http_reject` applies the substrate-claims gate to a session-resolved
+`agent_uuid`. It is self-scoping (no claim row → no rejection) and fails open.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_modes(monkeypatch):
+    monkeypatch.delenv("UNITARES_SESSION_FINGERPRINT_CHECK", raising=False)
+    monkeypatch.delenv("UNITARES_PREFIX_BIND_FINGERPRINT", raising=False)
+    yield
+
+
+def _signals(peer_pid=None, fp="ip-x:ua-x"):
+    return SimpleNamespace(peer_pid=peer_pid, ip_ua_fingerprint=fp)
+
+
+def _claim(label="com.unitares.sentinel"):
+    return SimpleNamespace(expected_launchd_label=label)
+
+
+SUBSTRATE_UUID = "f92dcea8-4786-412a-a0eb-362c273382f5"
+
+
+class TestSubstrateHttpRejectHelper:
+    """Direct unit coverage of the four branches of _substrate_http_reject."""
+
+    @pytest.mark.asyncio
+    async def test_http_substrate_uuid_is_rejected(self):
+        from src.mcp_handlers.identity import resolution as res
+
+        with patch(
+            "src.mcp_handlers.context.get_session_signals",
+            return_value=_signals(peer_pid=None),
+        ), patch(
+            "src.substrate.verification.fetch_substrate_claim",
+            new=AsyncMock(return_value=_claim()),
+        ):
+            out = await res._substrate_http_reject(SUBSTRATE_UUID, "unit")
+
+        assert out is not None
+        assert out.get("error") == "substrate_anchored_uuid_requires_uds"
+        assert out.get("resume_failed") is True
+        assert out.get("agent_uuid") == SUBSTRATE_UUID
+
+    @pytest.mark.asyncio
+    async def test_uds_peer_pid_present_passes(self):
+        """With a kernel-attested peer PID (UDS), the gate defers — returns None."""
+        from src.mcp_handlers.identity import resolution as res
+
+        claim_mock = AsyncMock(return_value=_claim())
+        with patch(
+            "src.mcp_handlers.context.get_session_signals",
+            return_value=_signals(peer_pid=4321),
+        ), patch(
+            "src.substrate.verification.fetch_substrate_claim", new=claim_mock
+        ):
+            out = await res._substrate_http_reject(SUBSTRATE_UUID, "unit")
+
+        assert out is None
+        # Short-circuits before even touching the claims table.
+        claim_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_substrate_uuid_passes(self):
+        from src.mcp_handlers.identity import resolution as res
+
+        with patch(
+            "src.mcp_handlers.context.get_session_signals",
+            return_value=_signals(peer_pid=None),
+        ), patch(
+            "src.substrate.verification.fetch_substrate_claim",
+            new=AsyncMock(return_value=None),  # no claim row → self-scoping pass
+        ):
+            out = await res._substrate_http_reject(
+                "00000000-1111-2222-3333-444444444444", "unit"
+            )
+
+        assert out is None
+
+    @pytest.mark.asyncio
+    async def test_fails_open_on_exception(self):
+        from src.mcp_handlers.identity import resolution as res
+
+        with patch(
+            "src.mcp_handlers.context.get_session_signals",
+            return_value=_signals(peer_pid=None),
+        ), patch(
+            "src.substrate.verification.fetch_substrate_claim",
+            new=AsyncMock(side_effect=RuntimeError("db down")),
+        ):
+            out = await res._substrate_http_reject(SUBSTRATE_UUID, "unit")
+
+        assert out is None  # never breaks resolution
+
+
+class TestPath1Wiring:
+    """The gate is wired into PATH 1 (Redis cache hit / prefix-bind)."""
+
+    @pytest.mark.asyncio
+    async def test_path1_substrate_over_http_refused(self):
+        from src.mcp_handlers.identity import resolution as res
+
+        cached_payload = {
+            "agent_id": SUBSTRATE_UUID,
+            "display_agent_id": "Sentinel",
+            "bind_ip_ua": "ip-orig:ua-orig",
+        }
+        fake_redis = MagicMock()
+        fake_redis.get = AsyncMock(return_value=cached_payload)
+
+        with patch.object(res, "_get_redis", return_value=fake_redis), patch(
+            "src.mcp_handlers.context.get_session_signals",
+            return_value=_signals(peer_pid=None),
+        ), patch(
+            "src.substrate.verification.fetch_substrate_claim",
+            new=AsyncMock(return_value=_claim()),
+        ):
+            result = await res.resolve_session_identity(
+                session_key=f"agent-{SUBSTRATE_UUID[:12]}",
+                resume=True,
+            )
+
+        assert result.get("error") == "substrate_anchored_uuid_requires_uds", (
+            f"Substrate UUID prefix-bind over HTTP must be refused. Got: {result}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_path1_substrate_over_uds_resumes(self):
+        from src.mcp_handlers.identity import resolution as res
+
+        cached_payload = {
+            "agent_id": SUBSTRATE_UUID,
+            "display_agent_id": "Sentinel",
+            "bind_ip_ua": "ip-orig:ua-orig",
+        }
+        fake_redis = MagicMock()
+        fake_redis.get = AsyncMock(return_value=cached_payload)
+
+        with patch.object(res, "_get_redis", return_value=fake_redis), patch(
+            "src.mcp_handlers.context.get_session_signals",
+            return_value=_signals(peer_pid=9999),  # UDS peer attested
+        ), patch(
+            "src.substrate.verification.fetch_substrate_claim",
+            new=AsyncMock(return_value=_claim()),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._agent_exists_in_postgres",
+            new=AsyncMock(return_value=True),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._get_agent_label",
+            new=AsyncMock(return_value="Sentinel"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._get_agent_status",
+            new=AsyncMock(return_value="active"),
+        ), patch(
+            "src.mcp_handlers.identity.resolution._soft_verify_trajectory",
+            new=AsyncMock(return_value={"verified": True}),
+        ):
+            result = await res.resolve_session_identity(
+                session_key=f"agent-{SUBSTRATE_UUID[:12]}",
+                resume=True,
+            )
+
+        assert result.get("source") == "redis"
+        assert result.get("agent_uuid") == SUBSTRATE_UUID
+
+
+class TestPath2Wiring:
+    """The gate is wired into PATH 2 (PG session row, Redis cache miss)."""
+
+    @pytest.mark.asyncio
+    async def test_path2_substrate_over_http_refused(self):
+        from src.mcp_handlers.identity import resolution as res
+
+        # Redis miss → fall to PATH 2.
+        fake_redis = MagicMock()
+        fake_redis.get = AsyncMock(return_value=None)
+
+        fake_db = MagicMock()
+        fake_db.init = AsyncMock(return_value=None)
+        fake_db.get_session = AsyncMock(
+            return_value=SimpleNamespace(agent_id=SUBSTRATE_UUID)
+        )
+
+        with patch.object(res, "_get_redis", return_value=fake_redis), patch(
+            "src.mcp_handlers.identity.resolution.get_db", return_value=fake_db
+        ), patch(
+            "src.mcp_handlers.identity.resolution._get_agent_id_from_metadata",
+            new=AsyncMock(return_value="Sentinel_mcp"),
+        ), patch(
+            "src.mcp_handlers.context.get_session_signals",
+            return_value=_signals(peer_pid=None),
+        ), patch(
+            "src.substrate.verification.fetch_substrate_claim",
+            new=AsyncMock(return_value=_claim()),
+        ):
+            result = await res.resolve_session_identity(
+                session_key=f"agent-{SUBSTRATE_UUID[:12]}",
+                resume=True,
+            )
+
+        assert result.get("error") == "substrate_anchored_uuid_requires_uds", (
+            f"Substrate UUID PG-session resume over HTTP must be refused. Got: {result}"
+        )


### PR DESCRIPTION
Closes the same-fingerprint co-resident residual from #802 — and a real evasion gap in S19 itself. Builds on #804 (merged).

## The gap

S19 refuses a substrate-anchored UUID resuming over HTTP (the token is a copyable bearer; only a UDS peer-PID can attest the resident). But that gate (`resolution.py` pre-PATH-1 + PATH 2.8) only fires **`if token_agent_uuid`** — i.e. only when a `continuity_token` is presented.

A caller holding a substrate resident's UUID can **evade it entirely** by resuming through the no-token paths:
- **PATH 1** — `client_session_id="agent-{victim_uuid12}"` (prefix-bind cache hit)
- **PATH 2** — a live PG session row under that key (Redis cache miss)

`token_agent_uuid` is `None`, so the S19 gate is skipped and the resident's UUID is returned. On a shared-fingerprint localhost host the scope-(a) per-path fingerprint check (#804) also passes (same IP:UA), so this is exactly the **same-fingerprint co-resident residual** #802 left open.

## The fix

`_substrate_http_reject(agent_uuid, source)` applies the same substrate-claims gate to a **session-resolved** `agent_uuid`, called at the PATH 1 and PATH 2 resume points. A substrate-anchored UUID (`core.substrate_claims` row) arriving without a kernel-attested peer PID (HTTP path) is refused with the existing `substrate_anchored_uuid_requires_uds` contract.

## Why it's safe

- **Self-scoping.** A UUID with no `substrate_claims` row → `None` (no rejection). Non-substrate and not-yet-enrolled agents are completely unaffected; future enrollment extends coverage with **zero code change**.
- **No legitimate flow breaks.** Residents connect over **UDS** (peer_pid present → gate defers to normal substrate verification) via **PATH 0** (`agent_uuid` direct), never the prefix/session path over HTTP. A substrate UUID arriving on PATH 1/2 over HTTP is never legitimate.
- **Fails open.** Any unexpected error in the gate returns `None` — resolution never breaks.
- Mirrors the existing always-on S19 token gate (same contract, same `[SUBSTRATE_HTTP_REJECT]` log) — this just closes the path an attacker could pick to dodge it.

## Coverage today

Live-verified: only **Sentinel** (`f92dcea8`) is enrolled in `core.substrate_claims`, so this protects Sentinel now. **Lumen/Vigil** gain protection the moment they're enrolled (operator action; no code).

## Residual after this

Same-fingerprint co-resident hijack of a **non-substrate** agent still isn't closed (no claim row → nothing to attest against). That's inherent: non-substrate agents have no kernel-attestable anchor, and per the identity ontology they shouldn't resume-as across processes at all. Redaction stays the information-layer denier. #802 can track that as the final ontological question (delete non-substrate resume-as).

## Tests

- `tests/test_identity_substrate_prefix_gate_802.py` — 4 helper-branch unit tests (HTTP-reject / UDS-pass / non-substrate-pass / fail-open) + PATH 1 refuse, PATH 1 UDS-resume, PATH 2 refuse wiring tests.
- Full suite: 10262 passed, 22 skipped (`test-cache.sh`). No regressions in the substrate/identity suites (1191 passed).

Identity is writer-locked — no in-flight identity PRs at branch time; builds directly on merged #804.