### PR TITLE
docs: register cross-device/orchestration audit API as KEEP-DORMANT

### DIFF
--- a/docs/operations/dormant-capability-registry.md
+++ b/docs/operations/dormant-capability-registry.md
@@ -83,6 +83,7 @@ and the registry's primary protectees.**
 | Lineage credit-assignment aggregation | `identity/provenance_chain.py:83/170` | Read/scoring half orphaned; write half produces empty chains (0/1056) | **DECIDE** — depends on whether discovery→lineage attribution is still a goal |
 | S22 H5 cross-harness coverage assessor | `identity/s22_h5_comparison.py:110/190/277` | Diagnostic-script-only; input data live (30k provenance rows) but no MCP surface reads the gate | **DECIDE** — surface via `get_governance_metrics`, or keep as a script |
 | `backfill_calibration_from_historical_sessions` | `mcp_handlers/dialectic/calibration.py:193` | One-shot admin migration util; no scheduled caller (by design) | **KEEP-DORMANT** — document as manual-only |
+| Cross-device / orchestration audit API (`AuditLogger.log_orchestration_request` / `log_orchestration_complete` / `log_cross_device_call` / `log_device_health_check` / `log_eisv_sync`) | `src/audit_log.py:229/265/294/331/361` | 0 in-repo callers — the consumer (Mac→Pi orchestration) was extracted to the external `unitares-pi-plugin` package in the Phase B1 Lumen decoupling (see `src/mcp_handlers/__init__.py:133`, `src/services/runtime_queries.py:849`). This repo owns the writer surface; the caller lives cross-repo. Same external-API shape as `register_extra_schemas` (Theme 5) | **KEEP-DORMANT** — cross-repo audit API; removal is a deprecation decision coordinated with `unitares-pi-plugin` |
 
 ## Theme 5 — Mechanical singletons (vulture cross-pass, 2026-06-16)
 


### PR DESCRIPTION
## What

Follow-on to the `src/` dead-code pass (the audit work from #808). Adds one evidence-backed row to the dormant-capability registry.

## Why

The dead-code pass flagged five `AuditLogger` methods as having **zero in-repo callers**:
`log_orchestration_request`, `log_orchestration_complete`, `log_cross_device_call`, `log_device_health_check`, `log_eisv_sync` (`src/audit_log.py:229/265/294/331/361`).

Tracing the consumer showed they are **not dead** — the Mac→Pi orchestration that calls them was **extracted to the external `unitares-pi-plugin` package** during the Phase B1 Lumen decoupling. Evidence in-tree:
- `src/mcp_handlers/__init__.py:133` — "Pi orchestration moved out to the `unitares-pi-plugin` package"
- `src/services/runtime_queries.py:849` — `from unitares_pi_plugin.handlers import …`

So this repo owns the audit **writer** surface while the **caller** lives cross-repo. That's the same external-API shape as the existing `register_extra_schemas` extension-hook row — exactly the "0 callers → looks dead → gets deleted → rebuilt" failure mode the registry exists to prevent.

## Change

One row under **Theme 4 (external-dependency gated)**, status **KEEP-DORMANT**, noting removal is a deprecation decision to coordinate with `unitares-pi-plugin`.

Docs-only. `check_doc_health --strict` is green; cited line numbers verified against `src/audit_log.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PmHantuBmUQuJyvBB8sNju)_