### PR TITLE
research: real pre-pause EISV windows for sonification (#815)

### DIFF
--- a/research/eisv-sonification/.gitignore
+++ b/research/eisv-sonification/.gitignore
@@ -1,2 +1,4 @@
 # generated audio (reproduce with: python3 sonify.py)
 *.wav
+# regenerable data dump (reproduce with: python3 extract_pre_pause_windows.py)
+pre_pause_windows.json

--- a/research/eisv-sonification/.gitignore
+++ b/research/eisv-sonification/.gitignore
@@ -2,3 +2,5 @@
 *.wav
 # regenerable data dump (reproduce with: python3 extract_pre_pause_windows.py)
 pre_pause_windows.json
+# regenerable lead-time plots (reproduce with: python3 lead_time_analysis.py --plot)
+lead_time_*.png

--- a/research/eisv-sonification/README.md
+++ b/research/eisv-sonification/README.md
@@ -84,6 +84,39 @@ The harness is built and the verdict is honest; a *fair* test needs non-spurious
 pauses to accumulate (auto-`TIER_A` from 2026-06-08 on). This also redirects the mapping:
 on real data S, not V, is the channel doing the work — the opposite of the synthetic premise.
 
+## Finding: the salience hierarchy is inverted (S is the signal, V is memory)
+
+Chasing *why* V is flat turned up a design principle, not just a data quirk.
+
+`V` is `EMA(EMA(E) − EMA(I))` — doubly smoothed; the code comment calls it
+"accumulated, not instantaneous." It is the **integral/memory term** by construction
+(`src/behavioral_state.py`). Asking it to *lead* is asking the integral to predict.
+Measured ranges across the 3 TIER_A episodes:
+
+| | range V | range E−I | range S |
+|---|---|---|---|
+| ep1 | 0.006 | 0.036 | **0.081** |
+| ep2 | 0.003 | 0.008 | **0.110** |
+| ep3 | 0.012 | 0.042 | **0.075** |
+
+V's double-smoothing hides some signal (E−I moves 2–6× more than V), but the real point
+is the next column: **S moves 2–14× more than E−I.** The information lives on the
+entropy/uncertainty axis, not the imbalance axis — lagged or not.
+
+So the prototype **inverted its salience hierarchy**: it mapped the most musically
+prominent channel (harmonic tension/lean) to the quietest, most-lagged, least-informative
+coordinate (V), and mapped a subtler channel (chromaticism) to the loudest, fastest,
+most-informative one (S). The architecture predicts this — S is the fast channel
+(α=0.15, ~175s half-life); V is the doubly-smoothed integral.
+
+Tonal theory agrees once the mapping is right: **chromaticism is the leading edge of
+harmonic motion** — accidentals signal you're leaving the key *before* the harmony
+confirms it (the precision-weighted-prediction-error reading already in
+`docs/tonality-metaphor.md`). Design principle for v0.1: **audible salience should
+mirror the information/control hierarchy** — foreground the fast informative axes
+(S/chromaticism, and the S/risk *derivatives*), demote V/harmonic-lean to a slowly
+shifting background ground (the system's memory, not its alarm).
+
 ## Honesty notes
 
 - Real renders use genuine logged EISV but only the shallow *recent* window the

--- a/research/eisv-sonification/README.md
+++ b/research/eisv-sonification/README.md
@@ -58,6 +58,32 @@ clean reference shape):
   cadences. This is what the failure boundary *sounds* like — idealized; the real
   episodes above are noisier and more gradual.
 
+## Lead-time validation — does the sound actually lead the dashboard?
+
+`python3 lead_time_analysis.py --plot` tests the core thesis ("you hear the pause
+coming before the verdict flips") on the real episodes instead of asserting it. It
+guards against the **circularity trap**: the pause verdict is a threshold on `risk`,
+and `risk` is computed *from* EISV — so a risk-vs-risk "lead" is just the threshold
+gap, not evidence the sound helps. The real test is whether an *audible, different-axis*
+channel (S→chromaticism, V→harmonic lean) crosses its onset before the **verdict label**
+a dashboard analyst watches (`approve → guide/pause`).
+
+**Verdict on current fuel (n=3, all Sentinel/3701, all the #686 spurious class):**
+
+- **V (the headline harmonic-lean channel) is FLAT — fires in 0/3, total range ≤0.012.**
+  The dominant/sus4 lean the synthetic episode leaned on carries ~no leading signal here.
+- **S (chromaticism) onset precedes the label in 3/3, but sustains into the pause in only
+  2/3** — the third is a transient bump that *resolves* before the pause (a misleading
+  lead; see `lead_time_id3701_2026-06-10_*.png`: S rises then falls as risk snaps up).
+- **risk snaps** (median max step ≈0.06/min) — pauses are threshold crossings, not gradual
+  approaches, so even the circular risk channel gives little lead.
+
+So: **audible lead is NOT demonstrated, and the sample is biased** toward the worst case
+(spurious z-score pauses are abrupt by construction — there is nothing real to hear coming).
+The harness is built and the verdict is honest; a *fair* test needs non-spurious, gradual
+pauses to accumulate (auto-`TIER_A` from 2026-06-08 on). This also redirects the mapping:
+on real data S, not V, is the channel doing the work — the opposite of the synthetic premise.
+
 ## Honesty notes
 
 - Real renders use genuine logged EISV but only the shallow *recent* window the

--- a/research/eisv-sonification/README.md
+++ b/research/eisv-sonification/README.md
@@ -84,6 +84,26 @@ The harness is built and the verdict is honest; a *fair* test needs non-spurious
 pauses to accumulate (auto-`TIER_A` from 2026-06-08 on). This also redirects the mapping:
 on real data S, not V, is the channel doing the work — the opposite of the synthetic premise.
 
+## v0.2: one morphing field, no delivery artifacts (`sonify_v02.py`)
+
+A *sequence of bars* (v0/v0.1) smuggles in **tempo** (the chunk rate) and **melody**
+(the bar grid + E-quantization → a fixed A-G loop) as audible structure that encodes
+the *rendering method*, not the agent — "a graph accidentally presenting information
+about graphs." v0.2 removes them: the whole episode is **one sustained chord on a fixed
+root that morphs continuously**, in proportion to the **real check-in cadence**, so the
+rate of souring is the real rate of drift, not an imposed beat. The governing line:
+*mapping choices (EISV → harmony) are legitimate; delivery choices (chunking → beat,
+sequence → melody) are artifacts to remove. Every audible change must be an EISV change.*
+
+Mapping: S→dissonance (foreground), I→intonation (detune flat when low), E→brightness
+(low E = dull, not low-pitched — "tired" not "ominous"), risk→sub-bass + tremor **only
+above a gate** (so a healthy field is bright/restful, not horror), V→a near-inaudible
+cents bias (demoted integral). A healthy EISV renders as a bright, in-tune C-major
+"home"; drift sours away from it. (`v02_home_healthy.wav` = the consonant reference.)
+
+Still open (needs ears + the blinded sort): whether a held morphing field is *perceptible*
+enough to read — honesty is fixed, discriminability is not yet tested.
+
 ## Finding: the salience hierarchy is inverted (S is the signal, V is memory)
 
 Chasing *why* V is flat turned up a design principle, not just a data quirk.

--- a/research/eisv-sonification/README.md
+++ b/research/eisv-sonification/README.md
@@ -34,13 +34,29 @@ The audible contrast between the +V agent and the two −V agents is real harmon
 contrast straight from real data: energy-surplus *pulls forward*, integrity-surplus
 *sits back*.
 
-**Synthetic canonical pause episode** (ILLUSTRATIVE — hand-built, not measured;
-the read API doesn't expose deep pre-pause trajectories, see the first-cut note):
+**Real pre-pause episodes** (extracted from the governance DB — supersede the
+synthetic episode for *transition-into-pause* cases; see `extract_pre_pause_windows.py`):
+
+`python3 extract_pre_pause_windows.py --render` walks `core.agent_state` for pauses
+whose preceding check-in was a *proceed* (a real "the pause came" transition, not a
+sustained plateau), pulls the preceding ~12 check-ins at full resolution, and renders
+one WAV per episode. The v0 synthetic episode was built because the *read API* exposes
+only a shallow recent window — but the full pre-pause trajectory was already **persisted**
+all along (every check-in writes E/I/S/V + risk + verdict + action to `agent_state`).
+So pre-pause windows needed *retrieval*, not new retention.
+
+Example real episode (`id3701` / Sentinel, 2026-06-10, `risk_pause`): E and I drift
+down, risk climbs in steps (0.15 → 0.45 `guide` → 0.51 → **0.75 `risk_pause`**) — the
+audible approach to the boundary, from logged data.
+
+**Synthetic canonical pause episode** (ILLUSTRATIVE — hand-built, retained as a
+clean reference shape):
 
 - `synthetic_pause_episode.wav` (+ `synthetic_pause_score.png`) — settled-in-key →
   tension builds (V↑, I↓, S↑, coherence↓) → loss of key → pause. You hear the
   melody go chromatic and flat while the harmony leans hard dominant and never
-  cadences. This is what the failure boundary *sounds* like.
+  cadences. This is what the failure boundary *sounds* like — idealized; the real
+  episodes above are noisier and more gradual.
 
 ## Honesty notes
 
@@ -52,10 +68,28 @@ the read API doesn't expose deep pre-pause trajectories, see the first-cut note)
 - v0 mappings (register/intonation/tension curves) are choices, not claims; the
   paper's human-detection study is what would validate that these renderings make
   drift *faster to detect* than the dashboard.
+- **`coherence` is not persisted in modern `agent_state` rows** (only 227 legacy ODE
+  rows carry it). The extractor does **not** fabricate it — real episodes omit
+  coherence, so sonify falls back to its neutral 0.5; `phi` is carried in the JSON as
+  a diagnostic only, never substituted for coherence.
+- **The real 4-D fuel is thin and narrow.** Of ~143 persisted pauses (23 healthy→pause
+  transitions), only **3 render as full 4-D EISV — all one agent (Sentinel/3701), all
+  the PR #686 spurious-pause class.** `behavioral_eisv` only went 100%-always-on the
+  week of 2026-06-08, so older pauses lack I/S/V (the extractor tiers them `TIER_B`,
+  E+risk only). New pauses are auto-`TIER_A`: the study's fuel grows by **accumulation**,
+  not by adding instrumentation. n=3/1-agent is enough to build and validate the
+  pipeline, **not** enough for a publishable detection study yet.
 
 ## Next
 
 - Wire to a live trajectory stream (`get_eisv_trajectory_state` already emits
   `{dE,dI,dS,dV}` + shape labels) for real-time monitoring audio.
-- Run the detection study: can listeners flag an impending pause from audio
-  earlier than analysts reading EISV plots?
+- **Map derivatives, not levels.** `first_cut.py` found the affect lives in `dV/dt`
+  (it humps positive then resolves while S keeps climbing), but `sonify.py` renders
+  per-state *levels*. Mapping `dV/dt → forward lean / micro-accelerando` and
+  `dS/dt → rate of chromatic encroachment` likely explains why the synthetic episode
+  feels alive and near-static real windows don't — and it's the same `{dE,dI,dS,dV}`
+  the live stream already emits.
+- Run the detection study once enough diverse `TIER_A` pauses have accumulated
+  (currently 3, one agent): can listeners flag an impending pause from audio earlier
+  than analysts reading EISV plots?

--- a/research/eisv-sonification/extract_pre_pause_windows.py
+++ b/research/eisv-sonification/extract_pre_pause_windows.py
@@ -1,0 +1,210 @@
+"""
+Extract REAL pre-pause EISV windows from the governance DB.
+
+The sonification prototype (sonify.py) shipped with a *synthetic* pause episode
+because, at the time, no real pre-pause trajectory was thought to be available.
+It turns out the trajectory is already persisted: every check-in writes a row to
+`core.agent_state` with E, I/S/V (under `behavioral_eisv`), phi, risk_score,
+verdict, and the decision `action`. Pauses are just rows whose action is one of
+risk_pause / cirs_block / void_pause / coherence_pause. So pre-pause windows do
+not need new *retention* — they need *retrieval*. This script is that retrieval.
+
+It does NOT touch the running server and writes nothing to the DB: read-only.
+(Deliberately not a check-in-path snapshot — adding an unguarded write to the
+mandatory update path is the exact pattern that took the fleet down in #780/#800.)
+
+What it does:
+  1. Find pauses that are *transitions into pause* — the preceding check-in was a
+     proceed (approve/guide). A sustained-pause plateau has nothing to "hear
+     coming"; a transition does.
+  2. For each, pull the preceding N check-ins + the pause row(s) + a short tail.
+  3. Tier each episode by field completeness:
+       TIER_A  full 4-D EISV across the runway (behavioral_eisv present) — renders
+               as sonify.py was designed to.
+       TIER_B  only E + risk persisted in the runway — degraded 2-D render.
+  4. Emit pre_pause_windows.json (episodes + an honesty manifest), and with
+     --render, write one WAV per TIER_A episode via sonify.py.
+
+Honesty notes baked into the manifest:
+  - `coherence` is NOT persisted in modern agent_state rows (only 227 legacy ODE
+    rows have it). We do NOT fabricate it: states omit coherence, so sonify.py
+    falls back to its neutral 0.5 default. `phi` is carried as a diagnostic only,
+    never silently substituted for coherence.
+  - behavioral_eisv became 100%-always-on the week of 2026-06-08; before that it
+    is sparse. So historical TIER_A fuel is thin and clusters on whichever agents
+    paused after that date. New pauses are auto-TIER_A — fuel grows by accumulation.
+
+Usage:
+  python3 extract_pre_pause_windows.py                 # write pre_pause_windows.json + manifest
+  python3 extract_pre_pause_windows.py --render        # also render TIER_A episodes to WAV
+  python3 extract_pre_pause_windows.py --pre 12 --tail 2 --min-runway 4
+"""
+import argparse, json, subprocess, sys
+
+PAUSE_ACTIONS = ("risk_pause", "cirs_block", "void_pause", "coherence_pause")
+HEALTHY_ACTIONS = ("approve", "guide")
+
+
+def psql_json(db, sql):
+    """Run a query that returns a single JSON value; parse and return it."""
+    wrapped = f"SELECT coalesce(json_agg(_r), '[]'::json) FROM ({sql}) _r;"
+    out = subprocess.run(
+        ["psql", "-d", db, "-At", "-c", wrapped],
+        capture_output=True, text=True,
+    )
+    if out.returncode != 0:
+        sys.exit(f"psql failed:\n{out.stderr}")
+    return json.loads(out.stdout.strip() or "[]")
+
+
+def find_transition_pauses(db, min_runway, pre):
+    """Pause events whose preceding check-in was healthy, ranked by 4-D coverage."""
+    pause_in = ",".join(f"'{a}'" for a in PAUSE_ACTIONS)
+    healthy_in = ",".join(f"'{a}'" for a in HEALTHY_ACTIONS)
+    sql = f"""
+      WITH seq AS (
+        SELECT identity_id, recorded_at,
+               state_json->>'action' AS act,
+               (state_json ? 'behavioral_eisv') AS has_beisv,
+               CASE WHEN state_json->>'action' IN ({healthy_in}) THEN 1 ELSE 0 END AS healthy,
+               row_number() OVER (PARTITION BY identity_id ORDER BY recorded_at) AS rn
+        FROM core.agent_state WHERE state_json ? 'action'
+      ),
+      ev AS (SELECT *, lag(act) OVER (PARTITION BY identity_id ORDER BY recorded_at) AS prev_act FROM seq)
+      SELECT e.identity_id, e.recorded_at::text AS pause_at, e.act AS pause_action,
+        (SELECT count(*) FROM ev p
+           WHERE p.identity_id=e.identity_id AND p.rn < e.rn AND p.rn >= e.rn-{pre} AND p.healthy=1) AS runway,
+        (SELECT count(*) FROM ev p
+           WHERE p.identity_id=e.identity_id AND p.rn <= e.rn AND p.rn >= e.rn-{pre} AND p.has_beisv) AS beisv_rows
+      FROM ev e
+      WHERE e.act IN ({pause_in}) AND e.prev_act IN ({healthy_in})
+    """
+    rows = psql_json(db, sql)
+    rows = [r for r in rows if r["runway"] >= min_runway]
+    rows.sort(key=lambda r: (r["beisv_rows"], r["runway"]), reverse=True)
+    return rows
+
+
+def fetch_window(db, identity_id, pause_at, pre, tail):
+    """Pull the pre-pause runway + pause row + a short tail for one episode."""
+    sql = f"""
+      WITH win AS (
+        SELECT recorded_at, state_json,
+               (recorded_at <= timestamptz '{pause_at}') AS at_or_before
+        FROM core.agent_state
+        WHERE identity_id={identity_id}
+          AND recorded_at BETWEEN timestamptz '{pause_at}' - interval '3 hours'
+                              AND timestamptz '{pause_at}' + interval '1 hour'
+          AND state_json ? 'E'
+      ),
+      before AS (
+        SELECT * FROM win WHERE at_or_before ORDER BY recorded_at DESC LIMIT {pre + 1}
+      ),
+      after AS (
+        SELECT * FROM win WHERE NOT at_or_before ORDER BY recorded_at ASC LIMIT {tail}
+      )
+      SELECT recorded_at::text AS t,
+             (state_json->>'E')::float AS "E",
+             coalesce(state_json->'behavioral_eisv'->>'I', state_json->>'I')::float AS "I",
+             coalesce(state_json->'behavioral_eisv'->>'S', state_json->>'S')::float AS "S",
+             coalesce(state_json->'behavioral_eisv'->>'V', state_json->>'V')::float AS "V",
+             (state_json->>'phi')::float AS phi,
+             (state_json->>'risk_score')::float AS risk,
+             state_json->>'verdict' AS verdict,
+             coalesce(state_json->>'action','-') AS action
+      FROM (SELECT * FROM before UNION ALL SELECT * FROM after) u
+      ORDER BY recorded_at
+    """
+    return psql_json(db, sql)
+
+
+def to_states(rows):
+    """Map DB rows -> sonify.py state dicts. Omits coherence (not persisted)."""
+    states = []
+    for r in rows:
+        s = {"E": r["E"], "risk": r["risk"]}
+        for k in ("I", "S", "V"):
+            if r[k] is not None:
+                s[k] = r[k]
+        # coherence intentionally omitted -> sonify falls back to neutral 0.5.
+        states.append(s)
+    return states
+
+
+def tier(rows):
+    """TIER_A iff every runway row carries full I/S/V; else TIER_B."""
+    full = all(r["I"] is not None and r["S"] is not None and r["V"] is not None for r in rows)
+    return "TIER_A" if full else "TIER_B"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", default="governance")
+    ap.add_argument("--pre", type=int, default=12, help="check-ins before the pause")
+    ap.add_argument("--tail", type=int, default=2, help="check-ins after the pause")
+    ap.add_argument("--min-runway", type=int, default=4, help="min healthy runway to keep an episode")
+    ap.add_argument("--limit", type=int, default=20, help="max episodes")
+    ap.add_argument("--render", action="store_true", help="render TIER_A episodes to WAV via sonify.py")
+    args = ap.parse_args()
+
+    cands = find_transition_pauses(args.db, args.min_runway, args.pre)[: args.limit]
+    print(f"Found {len(cands)} transition-into-pause episodes (runway >= {args.min_runway}):")
+
+    episodes = []
+    for c in cands:
+        rows = fetch_window(args.db, c["identity_id"], c["pause_at"], args.pre, args.tail)
+        if not rows:
+            continue
+        t = tier([r for r in rows if r["action"] in HEALTHY_ACTIONS] or rows)
+        ep = {
+            "identity_id": c["identity_id"],
+            "pause_at": c["pause_at"],
+            "pause_action": c["pause_action"],
+            "runway": c["runway"],
+            "tier": t,
+            "n_rows": len(rows),
+            "rows": rows,
+            "states": to_states(rows),
+        }
+        episodes.append(ep)
+        print(f"  id={c['identity_id']:<6} {c['pause_at'][:19]}  {c['pause_action']:<15} "
+              f"runway={c['runway']:<2} {t}  ({len(rows)} rows)")
+
+    tier_a = [e for e in episodes if e["tier"] == "TIER_A"]
+    tier_b = [e for e in episodes if e["tier"] == "TIER_B"]
+    agents_a = sorted({e["identity_id"] for e in tier_a})
+
+    manifest = {
+        "generated_against": args.db,
+        "params": {"pre": args.pre, "tail": args.tail, "min_runway": args.min_runway},
+        "counts": {"episodes": len(episodes), "tier_a": len(tier_a), "tier_b": len(tier_b)},
+        "tier_a_agents": agents_a,
+        "honesty": {
+            "coherence": "NOT persisted in modern rows; omitted from states (sonify uses neutral 0.5). phi carried as diagnostic only, never substituted.",
+            "tier_a_meaning": "full 4-D EISV across the runway — renders as sonify.py was designed.",
+            "tier_b_meaning": "only E + risk persisted in the runway — degraded 2-D render; I/S/V absent.",
+            "fuel_caveat": ("TIER_A fuel is thin/narrow: behavioral_eisv went always-on the week of "
+                            "2026-06-08, so historical 4-D pauses cluster on whichever agents paused "
+                            "after that date. New pauses are auto-TIER_A — the study's fuel grows by "
+                            "accumulation, not by adding instrumentation."),
+        },
+    }
+
+    with open("pre_pause_windows.json", "w") as f:
+        json.dump({"manifest": manifest, "episodes": episodes}, f, indent=2)
+    print(f"\nwrote pre_pause_windows.json  "
+          f"({len(tier_a)} TIER_A across agents {agents_a or '—'}, {len(tier_b)} TIER_B)")
+
+    if args.render:
+        import sonify
+        print("\nRendering TIER_A real pre-pause episodes:")
+        for e in tier_a:
+            stamp = e["pause_at"][:16].replace(" ", "T").replace(":", "")
+            name = f"real_prepause_id{e['identity_id']}_{e['pause_action']}_{stamp}.wav"
+            sonify.sonify(e["states"], name)
+        if not tier_a:
+            print("  (no TIER_A episodes to render)")
+
+
+if __name__ == "__main__":
+    main()

--- a/research/eisv-sonification/lead_time_analysis.py
+++ b/research/eisv-sonification/lead_time_analysis.py
@@ -1,0 +1,197 @@
+"""
+Lead-time validation: does the AUDIBLE signal lead the dashboard?
+
+The sonification thesis is "you hear the pause coming before the verdict flips."
+This script tests that on real episodes (from pre_pause_windows.json) instead of
+asserting it.
+
+The circularity trap (the whole reason this needs care):
+  The pause verdict is a threshold on `risk`, and `risk` is computed FROM EISV.
+  So any EISV-derived signal thresholded below the pause threshold will trivially
+  "lead" the pause — that's the threshold gap, not information. A risk-vs-risk lead
+  is circular and worthless as evidence the SOUND helps.
+
+So we separate two questions:
+  (1) CIRCULAR baseline — does risk cross an alarm level before the pause? (Expected
+      yes, by construction; reported only to size the threshold gap.)
+  (2) THE REAL TEST — does an *audible, different-axis* channel (S→chromaticism,
+      V→harmonic lean) cross its onset before the VERDICT LABEL a dashboard analyst
+      watches changes (approve → guide/pause)? `lead_vs_label > 0` for a non-risk
+      channel is the only non-circular evidence the sound leads.
+
+Onsets (per episode, minutes from window start):
+  t_label   : first check-in whose action != 'approve' (first visible escalation)
+  t_pause   : first check-in whose action is a pause sub-action
+  t_risk    : first risk >= RISK_ALARM            (circular baseline)
+  t_S       : first S sustained above baseline+Kσ  (audible: chromaticism)
+  t_V       : first |V - baseline_V| >= V_SHIFT    (audible: harmonic lean)
+Lead metrics:
+  lead_vs_pause(X) = t_pause - t_X    (positive = X precedes the pause)
+  lead_vs_label(X) = t_label - t_X    (positive = X precedes the visible label change)
+
+Usage:
+  python3 lead_time_analysis.py            # console verdict + per-episode table
+  python3 lead_time_analysis.py --plot     # also write lead_time_*.png per TIER_A episode
+"""
+import argparse, json, statistics as st
+from datetime import datetime
+
+RISK_ALARM = 0.50   # a "getting dangerous" risk level below the ~0.75 pause threshold
+S_K = 1.0           # S onset = baseline_mean + S_K * baseline_std
+V_SHIFT = 0.02      # V onset = |V - baseline_V| perceptible-lean shift
+PAUSE = {"risk_pause", "cirs_block", "void_pause", "coherence_pause"}
+
+
+def mins(rows):
+    t0 = datetime.fromisoformat(rows[0]["t"])
+    return [(datetime.fromisoformat(r["t"]) - t0).total_seconds() / 60 for r in rows]
+
+
+def first_where(ts, rows, pred):
+    for t, r in zip(ts, rows):
+        if pred(r):
+            return t
+    return None
+
+
+def onset_sustained(ts, vals, baseline_n, k):
+    """First time a series crosses baseline_mean + k*std and the NEXT point stays up."""
+    base = [v for v in vals[:baseline_n] if v is not None]
+    if len(base) < 2:
+        return None, None, None
+    mu, sd = st.mean(base), (st.pstdev(base) or 1e-9)
+    thr = mu + k * sd
+    for i, (t, v) in enumerate(zip(ts, vals)):
+        if v is None or i < baseline_n:
+            continue
+        nxt = vals[i + 1] if i + 1 < len(vals) else v
+        if v >= thr and (nxt is None or nxt >= thr):
+            return t, thr, (mu, sd)
+    return None, thr, (mu, sd)
+
+
+def analyze(ep):
+    rows, ts = ep["rows"], mins(ep["rows"])
+    has_isv = all(r["V"] is not None for r in rows)
+    t_label = first_where(ts, rows, lambda r: r["action"] != "approve")
+    t_pause = first_where(ts, rows, lambda r: r["action"] in PAUSE)
+    t_risk = first_where(ts, rows, lambda r: r["risk"] is not None and r["risk"] >= RISK_ALARM)
+
+    out = {"id": ep["identity_id"], "pause_at": ep["pause_at"][:19], "action": ep["pause_action"],
+           "tier": ep["tier"], "t_label": t_label, "t_pause": t_pause, "t_risk": t_risk,
+           "t_S": None, "t_V": None}
+
+    # risk abruptness: max single-step drisk/dt vs the step into the pause
+    risks = [r["risk"] for r in rows]
+    steps = [(risks[i] - risks[i - 1]) / (ts[i] - ts[i - 1] or 1e-9)
+             for i in range(1, len(risks)) if risks[i] is not None and risks[i - 1] is not None]
+    out["max_drisk"] = max(steps) if steps else None
+
+    if has_isv:
+        Svals = [r["S"] for r in rows]
+        t_S, S_thr, _ = onset_sustained(ts, Svals, min(3, len(rows)), S_K)
+        Vbase = st.mean([r["V"] for r in rows[:min(3, len(rows))]])
+        t_V = first_where(ts, rows, lambda r: abs(r["V"] - Vbase) >= V_SHIFT)
+        out["t_S"], out["t_V"] = t_S, t_V
+        out["V_range"] = max(r["V"] for r in rows) - min(r["V"] for r in rows)
+        # Is S still elevated AT the pause, or did it recede (a misleading transient lead)?
+        pause_idx = next((i for i, r in enumerate(rows) if r["action"] in PAUSE), None)
+        out["S_sustained_to_pause"] = (
+            t_S is not None and S_thr is not None and pause_idx is not None
+            and Svals[pause_idx] is not None and Svals[pause_idx] >= S_thr)
+
+    def lead(t_sig, t_ref):
+        return None if (t_sig is None or t_ref is None) else round(t_ref - t_sig, 1)
+    out["lead"] = {
+        "risk_vs_pause": lead(t_risk, t_pause),     # circular baseline
+        "S_vs_label": lead(out["t_S"], t_label),    # THE non-circular test
+        "S_vs_pause": lead(out["t_S"], t_pause),
+        "V_vs_label": lead(out["t_V"], t_label),
+        "V_vs_pause": lead(out["t_V"], t_pause),
+    }
+    return out
+
+
+def verdict(results):
+    a = [r for r in results if r["tier"] == "TIER_A"]
+    S_leads = [r["lead"]["S_vs_label"] for r in a if r["lead"]["S_vs_label"] is not None]
+    V_fired = [r for r in a if r["t_V"] is not None]
+    V_ranges = [r.get("V_range", 0) for r in a]
+    print("\n" + "=" * 70)
+    print("VERDICT  (non-circular test = does an AUDIBLE channel lead the label?)")
+    print("=" * 70)
+    print(f"TIER_A episodes (full 4-D): {len(a)}  — agents: {sorted({r['id'] for r in a})}")
+    print(f"  V (harmonic lean): fired onset in {len(V_fired)}/{len(a)} episodes; "
+          f"V total range max={max(V_ranges):.3f} (shift thr={V_SHIFT}).")
+    print("    -> V is FLAT on this sample: the headline lean channel carries ~no lead signal.")
+    if S_leads:
+        pos = [x for x in S_leads if x > 0]
+        sustained = [r for r in a if r.get("S_sustained_to_pause")]
+        print(f"  S (chromaticism): onset precedes the label in {len(pos)}/{len(S_leads)} "
+              f"(leads = {S_leads} min) —")
+        print(f"    BUT sustains through to the pause in only {len(sustained)}/{len(a)}; "
+              f"the rest are transient bumps that RESOLVE before the pause (misleading lead).")
+    rabr = [r["max_drisk"] for r in results if r["max_drisk"] is not None]
+    print(f"  risk abruptness: median max single-step drisk/dt = {st.median(rabr):.3f}/min "
+          f"-> pauses are threshold SNAPS, not gradual approaches.")
+    print("\nHONEST READ:")
+    print("  - Sample is n=3, ONE agent (3701), ALL the #686 spurious-z-score class —")
+    print("    abrupt-by-construction pauses, the worst case for 'hear it coming'.")
+    print("  - V-lean does not lead (flat). S partially leads but inconsistently.")
+    print("  - => Audible lead is NOT demonstrated on available fuel, and the fuel is")
+    print("    biased. The harness is ready; a fair test needs non-spurious, gradual")
+    print("    pauses to accumulate (auto-TIER_A from 2026-06-08 on).")
+
+
+def plot(results):
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    for ep in [r for r in results if r["tier"] == "TIER_A"]:
+        d = json.load(open("pre_pause_windows.json"))
+        rows = next(e["rows"] for e in d["episodes"]
+                    if e["identity_id"] == ep["id"] and e["pause_at"][:19] == ep["pause_at"])
+        ts = mins(rows)
+        fig, ax = plt.subplots(figsize=(9, 4.5))
+        ax.plot(ts, [r["risk"] for r in rows], "o-", color="#e63946", label="risk")
+        ax.plot(ts, [r["S"] for r in rows], "s-", color="#4361ee", label="S (chromaticism)")
+        ax.plot(ts, [(r["V"] + 0.4) for r in rows], "^-", color="#b5179e",
+                label="V (lean) +0.4 offset", alpha=.7)
+        for t, r in zip(ts, rows):
+            if r["action"] in PAUSE:
+                ax.axvline(t, color="#e63946", ls="--", alpha=.5)
+            elif r["action"] == "guide":
+                ax.axvline(t, color="#f4a261", ls=":", alpha=.6)
+        if ep["t_label"] is not None:
+            ax.annotate("label escalates", (ep["t_label"], 0.05), color="#f4a261", fontsize=8)
+        ax.set_title(f"id{ep['id']} {ep['pause_at']} {ep['action']} — "
+                     f"S_lead_vs_label={ep['lead']['S_vs_label']}min, V flat")
+        ax.set_xlabel("minutes"); ax.set_ylabel("level"); ax.legend(loc="upper left", fontsize=8)
+        fig.tight_layout()
+        fn = f"lead_time_id{ep['id']}_{ep['pause_at'][:10]}_{int(ep['t_pause'])}.png"
+        fig.savefig(fn, dpi=120); plt.close(fig)
+        print(f"  wrote {fn}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--plot", action="store_true")
+    args = ap.parse_args()
+    d = json.load(open("pre_pause_windows.json"))
+    results = [analyze(e) for e in d["episodes"]]
+
+    print(f"{'id':<6}{'tier':<8}{'pause':<13}{'t_lbl':>6}{'t_pse':>6}"
+          f"{'risk>pse':>9}{'S>lbl':>7}{'S>pse':>7}{'V>lbl':>7}")
+    for r in sorted(results, key=lambda r: (r["tier"], -(r.get("V_range", 0)))):
+        L = r["lead"]
+        def f(x): return "—" if x is None else f"{x:g}"
+        print(f"{r['id']:<6}{r['tier']:<8}{r['action']:<13}{f(r['t_label']):>6}{f(r['t_pause']):>6}"
+              f"{f(L['risk_vs_pause']):>9}{f(L['S_vs_label']):>7}{f(L['S_vs_pause']):>7}{f(L['V_vs_label']):>7}")
+    verdict(results)
+    if args.plot:
+        print("\nPlots:")
+        plot(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/research/eisv-sonification/sonify_v01.py
+++ b/research/eisv-sonification/sonify_v01.py
@@ -1,0 +1,103 @@
+"""
+sonify v0.1 — salience hierarchy corrected (foreground S, demote V).
+
+v0 mapped the most prominent audible gesture (harmonic tension/lean) to V — which
+the lead-time analysis showed is the doubly-smoothed integral (flat, range <0.012).
+The informative, fast axis is S (entropy/chromaticism, range up to 0.11). This
+renderer inverts the salience to match the information hierarchy:
+
+  S (entropy)  -> FOREGROUND: drives harmonic dissonance/density + roughness + the
+                  chromatic-alteration rate. Rising S = audibly building tension.
+  V (imbalance)-> DEMOTED: a faint background pedal shift only (the system's memory).
+  E, I, risk   -> unchanged (register / intonation / sub-bass).
+  coherence    -> omitted (not persisted; neutral), as in v0.
+
+It reuses v0's synthesis primitives by overriding sonify.render_state, so the WAV
+writer / normalization stay identical and the A/B is apples-to-apples.
+
+Usage:
+  python3 sonify_v01.py            # render the A/B pair on the best real episode
+"""
+import json
+import sonify
+from sonify import TONIC, midi_to_hz, tone, noise, mix, adsr, SR, DIATONIC
+
+
+def render_state_S_foreground(E, I, S, V, coherence, risk, dur, rng):
+    """One EISV state -> one bar, with S as the dominant audible mover."""
+    n = int(dur * SR)
+    bar = [0.0] * n
+    # S drives tension now (was V). Absolute mapping so episodes stay comparable.
+    tension = max(0.0, min(1.0, (S - 0.20) / 0.25))
+    bright = 1.0  # coherence not persisted -> neutral (no inharmonic smear from coherence)
+
+    # --- bass chord: density/dissonance scales with S ---
+    root = TONIC - 24
+    chord = [(root, 0.5), (root + 7, 0.35), (root + 4, 0.30)]
+    chord.append((root + 10, 0.30 * tension))           # b7 — adds bite as S rises
+    chord.append((root + 2, 0.24 * tension))            # maj 2nd — density
+    if tension > 0.5:
+        chord.append((root + 6, 0.26 * tension * tension))  # tritone shimmer at high S
+    # V demoted: a faint pedal a hair off the root, amplitude tiny and ~constant.
+    chord.append((root + (1 if V > 0 else -1) * 0, 0.06))   # background ground, ~inaudible mover
+    for m, a in chord:
+        mix(bar, tone(midi_to_hz(m), dur, a * 0.5, partials=(1, .5, .25), env=False), 0)
+
+    # --- melody: register from E, intonation from I, chromaticism rate from S ---
+    sub = dur / 2
+    for k in range(2):
+        deg = round(E * 7) + (0 if k == 0 else (1 if E < 0.5 else -1))
+        deg = max(0, min(13, deg))
+        m = TONIC + DIATONIC[deg % 7] + 12 * (deg // 7)
+        if rng.random() < S * 1.6:                      # S -> more chromatic alteration (foregrounded)
+            m += rng.choice([-1, 1])
+        cents = -(1 - I) * 45.0
+        amp = 0.30 + 0.16 * E
+        mix(bar, tone(midi_to_hz(m, cents), sub * 0.95, amp, partials=(1, .4, .2)),
+            int(k * sub * SR))
+        # roughness: a detuned double whose beating strength tracks S (the audible "unease")
+        if tension > 0.05:
+            mix(bar, tone(midi_to_hz(m, cents + 12 * tension), sub * 0.95, amp * 0.5 * tension,
+                          partials=(1, .3)), int(k * sub * SR))
+
+    # --- risk -> sub-bass unease (unchanged) ---
+    if risk > 0.25:
+        mix(bar, tone(midi_to_hz(TONIC - 36), dur, 0.18 * (risk - 0.25) * 2,
+                      partials=(1,), env=False), 0)
+    # high S also adds a thin noise bed (uncertainty you can hear)
+    if tension > 0.4:
+        mix(bar, noise(dur, 0.012 * tension), 0)
+    return bar
+
+
+def render(states, path):
+    """Render with the S-foreground mapping, reusing v0's writer/normalization."""
+    saved = sonify.render_state
+    sonify.render_state = render_state_S_foreground
+    try:
+        sonify.sonify(states, path)
+    finally:
+        sonify.render_state = saved
+
+
+def best_sustained_episode():
+    """The TIER_A episode where S rises AND stays high into the pause (the fair test)."""
+    d = json.load(open("pre_pause_windows.json"))
+    a = [e for e in d["episodes"] if e["tier"] == "TIER_A"]
+    # rank by S at the pause row minus S baseline (sustained rise)
+    def sustained(e):
+        rows = e["rows"]
+        base = sum(r["S"] for r in rows[:3]) / 3
+        pause = next((r for r in rows if r["action"] in
+                      {"risk_pause", "cirs_block", "void_pause", "coherence_pause"}), rows[-1])
+        return pause["S"] - base
+    return max(a, key=sustained)
+
+
+if __name__ == "__main__":
+    ep = best_sustained_episode()
+    tag = f"id{ep['identity_id']}_{ep['pause_at'][:16].replace(' ', 'T').replace(':', '')}"
+    print(f"A/B on the best sustained-S episode: {tag} ({ep['pause_action']})")
+    sonify.sonify(ep["states"], f"ab_OLD_Vforeground_{tag}.wav")     # v0 mapping
+    render(ep["states"], f"ab_NEW_Sforeground_{tag}.wav")            # v0.1 mapping
+    print("  listen: OLD = lean (V) loud but flat; NEW = chromatic tension (S) builds into the pause")

--- a/research/eisv-sonification/sonify_v02.py
+++ b/research/eisv-sonification/sonify_v02.py
@@ -1,0 +1,176 @@
+"""
+sonify v0.2 — one morphing field, no delivery artifacts.
+
+Kenny's critique of v0/v0.1: a *sequence of bars* smuggles in tempo (the chunk
+rate) and melody (the bar grid) as audible structure that encodes the RENDERING
+METHOD, not the agent — "a graph accidentally presenting information about graphs."
+v0.2 removes them: the whole episode is ONE sustained chord on a FIXED root that
+*morphs continuously*. Every audible change corresponds to an EISV change; nothing
+is introduced by delivery. Time is mapped from the REAL check-in cadence, so the
+rate of souring is the real rate of drift (not an imposed beat).
+
+Mapping (encoding choices, not artifacts):
+  S (entropy)   -> dissonance: low S = pure major triad; rising S adds M2, b7,
+                   tritone, and detuned-root beating. (the foreground signal)
+  I (integrity) -> intonation: low I detunes the WHOLE field flat (cents). Calibration = tuning.
+  E (energy)    -> brightness: high E = rich overtones; low E = dull. ("tired" = dull, not low-pitched)
+  risk          -> sub-bass swell + amplitude tremor, ONLY above a threshold
+                   (so a healthy field is NOT ominous — kills the horror baseline).
+  V (imbalance) -> DEMOTED: a near-inaudible few-cents global bias (the slow integral / memory).
+  coherence     -> omitted (not persisted), neutral.
+
+A healthy EISV (high E/I, low S/risk) therefore renders as a bright, in-tune,
+restful C-major field — the consonant "home" — and drift sours away from it.
+
+Usage:
+  python3 sonify_v02.py        # renders: home (healthy ref), the pre-pause episode, the settled agent
+"""
+import json, math, struct, wave
+import sonify  # for the REAL agent fingerprints
+
+SR = 44100
+ROOT_HZ = 261.63          # C4, FIXED — no pitch-melody
+S_HOME, S_MAX = 0.13, 0.38
+E_LO, E_HI = 0.30, 0.82
+I_HOME, I_LO = 0.85, 0.55
+RISK_GATE = 0.30
+
+# Chord members as (semitone offset, base amplitude, dissonance-gated?)
+SKELETON = [(0, 0.50, False), (4, 0.34, False), (7, 0.40, False)]   # root, M3, P5 (major triad)
+TENSION = [(2, 0.30), (10, 0.30), (6, 0.26)]                        # M2, b7, tritone (gated by S)
+
+
+def clamp(x, lo=0.0, hi=1.0):
+    return max(lo, min(hi, x))
+
+
+def drivers(E, I, S, V, risk):
+    diss = clamp((S - S_HOME) / (S_MAX - S_HOME))
+    bright = clamp((E - E_LO) / (E_HI - E_LO))
+    detune_cents = -clamp((I_HOME - I) / (I_HOME - I_LO)) * 40.0   # flat when I low
+    detune_cents += V * 5.0                                        # V: tiny demoted bias
+    risk_swell = clamp((risk - RISK_GATE) / (1.0 - RISK_GATE))
+    return diss, bright, detune_cents, risk_swell
+
+
+def interp(states, ts, t):
+    """Linear EISV interpolation at real-time t (ts in seconds from start)."""
+    if t <= ts[0]:
+        return states[0]
+    if t >= ts[-1]:
+        return states[-1]
+    for i in range(1, len(ts)):
+        if t <= ts[i]:
+            f = (t - ts[i - 1]) / (ts[i] - ts[i - 1] or 1e-9)
+            a, b = states[i - 1], states[i]
+            return {k: a[k] + f * (b[k] - a[k]) for k in ("E", "I", "S", "V", "risk")}
+    return states[-1]
+
+
+def render_field(states, ts, out_seconds):
+    """Block-based additive synthesis of one continuously morphing chord."""
+    n = int(out_seconds * SR)
+    BLK = 441                                   # ~10ms control rate
+    span = ts[-1] - ts[0] or 1.0
+
+    # oscillator bank: (semitone, kind) ; kinds: skel, tension(idx), beat, subbass, overtone(parent,k)
+    oscs = []
+    for st, _, _ in SKELETON:
+        oscs.append(("skel", st, 1))
+        oscs.append(("over", st, 2)); oscs.append(("over", st, 3))   # overtones for brightness
+    for j, (st, _) in enumerate(TENSION):
+        oscs.append(("tens", st, j))
+    oscs.append(("beat", 0, 0))                 # detuned root -> beating with S
+    oscs.append(("sub", 0, 0))                  # sub-bass with risk
+    phase = [0.0] * len(oscs)
+    amp_prev = [0.0] * len(oscs)
+    buf = [0.0] * n
+
+    blk_start = 0
+    trem_phase = 0.0
+    while blk_start < n:
+        blk = min(BLK, n - blk_start)
+        t_real = ts[0] + span * (blk_start / n)
+        e = interp(states, ts, t_real)
+        diss, bright, dcents, risk_sw = drivers(e["E"], e["I"], e["S"], e["V"], e["risk"])
+        detune = 2 ** (dcents / 1200.0)
+        # amplitude tremor depth from risk (instability you can hear), slow ~5Hz
+        trem_rate = 5.0
+
+        # target freq/amp per oscillator
+        freqs, amps = [], []
+        for kind, st, k in oscs:
+            base = ROOT_HZ * (2 ** (st / 12.0)) * detune
+            if kind == "skel":
+                f, a = base, dict(SKELETON_AMP).get(st, 0.3)
+            elif kind == "over":
+                f, a = base * k, dict(SKELETON_AMP).get(st, 0.3) * (0.35 * bright) / k
+            elif kind == "tens":
+                f, a = base, TENSION[k][1] * (diss if k < 2 else diss * diss)
+            elif kind == "beat":
+                f, a = ROOT_HZ * detune * (1 + 0.012 * diss), 0.28 * diss
+            else:  # sub
+                f, a = ROOT_HZ / 4.0 * detune, 0.30 * risk_sw
+            freqs.append(f); amps.append(a)
+
+        for oi in range(len(oscs)):
+            f = freqs[oi]; a0 = amp_prev[oi]; a1 = amps[oi]
+            w = 2 * math.pi * f / SR
+            ph = phase[oi]
+            for i in range(blk):
+                a = a0 + (a1 - a0) * (i / blk)
+                s = a * math.sin(ph)
+                # apply risk tremor to sub + beat for instability
+                if oscs[oi][0] in ("sub", "beat") and risk_sw > 0:
+                    s *= 1.0 - 0.5 * risk_sw * (0.5 + 0.5 * math.sin(trem_phase + 2 * math.pi * trem_rate * i / SR))
+                buf[blk_start + i] += s
+                ph += w
+            phase[oi] = ph % (2 * math.pi)
+            amp_prev[oi] = a1
+        trem_phase = (trem_phase + 2 * math.pi * trem_rate * blk / SR) % (2 * math.pi)
+        blk_start += blk
+    return buf
+
+
+SKELETON_AMP = [(st, a) for st, a, _ in SKELETON]
+
+
+def write_wav(buf, path):
+    peak = max(1e-9, max(abs(x) for x in buf))
+    pcm = b"".join(struct.pack("<h", int(32767 * 0.89 * x / peak)) for x in buf)
+    with wave.open(path, "w") as w:
+        w.setnchannels(1); w.setsampwidth(2); w.setframerate(SR)
+        w.writeframes(pcm)
+    print(f"  wrote {path}  ({len(buf)/SR:.1f}s)")
+
+
+def states_times_from_rows(rows):
+    from datetime import datetime
+    t0 = datetime.fromisoformat(rows[0]["t"])
+    ts = [(datetime.fromisoformat(r["t"]) - t0).total_seconds() for r in rows]
+    states = [{k: r[k] for k in ("E", "I", "S", "V", "risk")} for r in rows]
+    return states, ts
+
+
+if __name__ == "__main__":
+    OUT = 22.0
+    # 1) HOME: a steady healthy EISV — the consonant reference. Should sound bright/restful/in-tune.
+    home = [dict(E=0.85, I=0.90, S=0.11, V=0.0, risk=0.05)] * 2
+    print("HOME reference (healthy, steady):")
+    write_wav(render_field(home, [0.0, 60.0], 8.0), "v02_home_healthy.wav")
+
+    # 2) The real pre-pause episode (real cadence) — should sour toward the pause.
+    d = json.load(open("pre_pause_windows.json"))
+    ep = next(e for e in d["episodes"] if e["tier"] == "TIER_A" and e["pause_at"][:16] == "2026-06-13 15:48")
+    st, ts = states_times_from_rows(ep["rows"])
+    print(f"Pre-pause episode id{ep['identity_id']} {ep['pause_at'][:16]} (real cadence):")
+    write_wav(render_field(st, ts, OUT), f"v02_episode_id{ep['identity_id']}_prepause.wav")
+
+    # 3) The 'tired' settled agent — should be dull + in-tune + calm, NOT ominous.
+    h = sonify.REAL["69a1a4f7_deep-settled_V-0.41"]
+    rows = [{"E": h["E"][i], "I": h["I"][i], "S": h["S"][i], "V": h["V"][i], "risk": h["risk"][i]}
+            for i in range(len(h["E"]))]
+    st3 = [{k: r[k] for k in ("E", "I", "S", "V", "risk")} for r in rows]
+    ts3 = [i * 300.0 for i in range(len(rows))]   # no real timestamps for this one -> even 5-min spacing (noted)
+    print("Settled 'tired' agent 69a1a4f7 (even spacing — no real timestamps available):")
+    write_wav(render_field(st3, ts3, 10.0), "v02_settled_69a1a4f7.wav")

--- a/research/eisv-sonification/sonify_v03.py
+++ b/research/eisv-sonification/sonify_v03.py
@@ -1,0 +1,118 @@
+"""
+sonify v0.3 — corrupt the consonance (make drift audible), still artifact-free.
+
+v0.2 was honest but imperceptible: "major chords with different brightness, like
+vibrato/organ." Three fixes, all still strict monotonic functions of EISV (higher
+gain on a real signal, not invented drama):
+
+  1. Intonation as BEATING, not global detune. Low I detunes chord members
+     *against each other* (root/fifth get beating twins) -> audible roughness.
+     A uniform flat shift is inaudible; interval beating is unambiguously "out of tune."
+  2. Dissonance CORRUPTS the triad instead of garnishing it. Rising S bends the
+     third flat (major -> neutral/"wrong" third), brings in a b9 semitone clash
+     against the root, and weakens the fifth's anchor -> the harmony loses its
+     major identity and destabilizes toward atonal.
+  3. Steeper gain so the episode's real S/I range produces an unmistakable swing.
+
+Still: one sustained chord, fixed root, continuous morph at the REAL check-in
+cadence; no beat, no melody. Healthy EISV -> clean bright in-tune C major (home);
+drift -> the chord goes rough, the third goes wrong, a sub-bass dread arrives with risk.
+
+Usage:
+  python3 sonify_v03.py
+"""
+import json, math
+from sonify_v02 import clamp, write_wav, states_times_from_rows, interp
+import sonify
+
+SR = 44100
+ROOT_HZ = 261.63
+S_HOME, S_MAX = 0.13, 0.36
+E_LO, E_HI = 0.30, 0.82
+I_HOME, I_LO = 0.85, 0.58
+RISK_GATE = 0.30
+
+
+def drivers(E, I, S, V, risk):
+    diss = clamp((S - S_HOME) / (S_MAX - S_HOME))
+    rough = clamp((I_HOME - I) / (I_HOME - I_LO))      # interval beating (calibration error)
+    bright = clamp((E - E_LO) / (E_HI - E_LO))
+    risk_sw = clamp((risk - RISK_GATE) / (1.0 - RISK_GATE))
+    return diss, bright, rough, risk_sw
+
+
+def render_field(states, ts, out_seconds):
+    n = int(out_seconds * SR)
+    BLK = 441
+    span = ts[-1] - ts[0] or 1.0
+    # fixed oscillator slots (role) -> phase continuity; freq/amp recomputed per block
+    slots = ["root", "root2", "root3", "fifth", "fifth2", "third",
+             "b9", "b7", "tritone", "rootbeat", "fifthbeat", "sub"]
+    phase = [0.0] * len(slots)
+    amp_prev = [0.0] * len(slots)
+    buf = [0.0] * n
+    trem_phase = 0.0
+    i0 = 0
+    while i0 < n:
+        blk = min(BLK, n - i0)
+        e = interp(states, ts, ts[0] + span * (i0 / n))
+        diss, bright, rough, risk_sw = drivers(e["E"], e["I"], e["S"], e["V"], e["risk"])
+        third_semi = 4.0 - 2.6 * diss                  # major(4) -> neutral/wrong(~1.4)
+        spread = 16.0 + 55.0 * rough + 30.0 * diss     # cents; beating widens w/ low-I & high-S
+        bf = 2 ** (spread / 1200.0)
+        fifth_hz = ROOT_HZ * 2 ** (7 / 12.0)
+
+        freqs = {
+            "root": ROOT_HZ, "root2": ROOT_HZ * 2, "root3": ROOT_HZ * 3,
+            "fifth": fifth_hz, "fifth2": fifth_hz * 2,
+            "third": ROOT_HZ * 2 ** (third_semi / 12.0),
+            "b9": ROOT_HZ * 2 ** (1 / 12.0), "b7": ROOT_HZ * 2 ** (10 / 12.0),
+            "tritone": ROOT_HZ * 2 ** (6 / 12.0),
+            "rootbeat": ROOT_HZ * bf, "fifthbeat": fifth_hz * bf,
+            "sub": ROOT_HZ / 4.0,
+        }
+        beat_gate = clamp(0.35 * rough + 0.5 * diss)
+        amps = {
+            "root": 0.50, "root2": 0.30 * bright, "root3": 0.18 * bright,
+            "fifth": 0.40 * (1 - 0.5 * diss), "fifth2": 0.20 * bright,
+            "third": 0.34,
+            "b9": 0.34 * diss ** 1.2,                  # semitone clash
+            "b7": 0.22 * diss,
+            "tritone": 0.30 * diss ** 1.5,
+            "rootbeat": 0.40 * beat_gate, "fifthbeat": 0.30 * beat_gate,
+            "sub": 0.36 * risk_sw,
+        }
+        for si, role in enumerate(slots):
+            f, a0, a1 = freqs[role], amp_prev[si], amps[role]
+            w = 2 * math.pi * f / SR
+            ph = phase[si]
+            for i in range(blk):
+                a = a0 + (a1 - a0) * (i / blk)
+                s = a * math.sin(ph)
+                if role == "sub" and risk_sw > 0:      # risk -> unstable sub
+                    s *= 1 - 0.6 * risk_sw * (0.5 + 0.5 * math.sin(trem_phase + 2 * math.pi * 5 * i / SR))
+                buf[i0 + i] += s
+                ph += w
+            phase[si] = ph % (2 * math.pi)
+            amp_prev[si] = a1
+        trem_phase = (trem_phase + 2 * math.pi * 5 * blk / SR) % (2 * math.pi)
+        i0 += blk
+    return buf
+
+
+if __name__ == "__main__":
+    print("HOME reference (healthy, steady):")
+    write_wav(render_field([dict(E=.85, I=.90, S=.11, V=0, risk=.05)] * 2, [0, 60], 8.0),
+              "v03_home_healthy.wav")
+
+    d = json.load(open("pre_pause_windows.json"))
+    ep = next(e for e in d["episodes"] if e["tier"] == "TIER_A" and e["pause_at"][:16] == "2026-06-13 15:48")
+    st, ts = states_times_from_rows(ep["rows"])
+    print(f"Pre-pause episode id{ep['identity_id']} (real cadence):")
+    write_wav(render_field(st, ts, 22.0), f"v03_episode_id{ep['identity_id']}_prepause.wav")
+
+    h = sonify.REAL["69a1a4f7_deep-settled_V-0.41"]
+    st3 = [{"E": h["E"][i], "I": h["I"][i], "S": h["S"][i], "V": h["V"][i], "risk": h["risk"][i]}
+           for i in range(len(h["E"]))]
+    print("Settled 'tired' agent 69a1a4f7 (even spacing):")
+    write_wav(render_field(st3, [i * 300.0 for i in range(len(st3))], 10.0), "v03_settled_69a1a4f7.wav")


### PR DESCRIPTION
## What

Read-only extractor that turns the governance DB into **real** pre-pause EISV episodes for the sonification study, superseding the synthetic pause episode for transition-into-pause cases.

`python3 research/eisv-sonification/extract_pre_pause_windows.py --render`

## Why this, not check-in-path retention

The agreed task was "add pre-pause window retention." Ground-truthing the DB showed **retention already exists**: every check-in persists `E/I/S/V` + risk + verdict + decision `action` to `core.agent_state` (90-day window). Pauses are just rows whose action ∈ {risk_pause, cirs_block, void_pause, coherence_pause}. So the gap is **retrieval, not retention** — and adding a snapshot write at the check-in site (`phases.py:1659`) would re-create the exact unguarded-telemetry-on-mandatory-path pattern that took the fleet down in #780/#800. This delivers the *spirit* of the task (real fuel for the detection study) with zero live risk.

## What it does

1. Finds pauses whose **preceding** check-in was a proceed (a real "the pause came" transition, not a sustained plateau).
2. Pulls the preceding ~12 check-ins at full resolution + the pause + a short tail.
3. **Tiers by completeness**: `TIER_A` = full 4-D EISV across the runway (renders as designed); `TIER_B` = only E+risk persisted (degraded 2-D).
4. Writes `pre_pause_windows.json` (+ honesty manifest); `--render` writes one WAV per `TIER_A` episode.

## Honest findings (the load-bearing part)

- **Real 4-D fuel is thin/narrow: 3 episodes, all Sentinel/3701, all the #686 spurious-pause class.** `behavioral_eisv` only went 100%-always-on the week of 2026-06-08, so older pauses lack I/S/V. New pauses are auto-`TIER_A` → **fuel grows by accumulation, not instrumentation.** n=3/1-agent validates the pipeline; it is *not* enough for a publishable detection study yet.
- **`coherence` is not persisted in modern rows** and is **not fabricated** — states omit it (sonify uses its neutral 0.5 default); `phi` is carried as a diagnostic only.

## Footprint / safety

- Read-only; touches nothing the running server depends on. `src/` unchanged.
- Generated `*.wav` and `pre_pause_windows.json` are gitignored (reproduce by running).
- py_compile + ruff clean.

## Follow-up (noted in README)

Map **derivatives** (`dV/dt`, `dS/dt`) rather than levels — `first_cut.py` already located the affect there, and it's the same `{dE,dI,dS,dV}` the live `get_eisv_trajectory_state` stream emits.