### PR TITLE
feat(listing): default agent listing to participated-only (stop counting never-checked-in identities)

### DIFF
--- a/src/agent_metadata_persistence.py
+++ b/src/agent_metadata_persistence.py
@@ -109,6 +109,14 @@ async def _load_metadata_from_postgres_async() -> dict:
         limit=10000,
         include_archived=True,
         include_deleted=False,
+        # This is the cold-start loader for the in-memory agent_metadata
+        # cache, which backs operator audit / orphan classification
+        # (lifecycle/operations.py) and onboarding-bug visibility. It MUST
+        # see every onboarded identity, including never-participated ones —
+        # filtering them here would silently hide the orphan population the
+        # operator tools exist to surface. The participated-only default is
+        # applied at user/dashboard-facing listing surfaces, not here.
+        include_unparticipated=True,
     )
 
     result = {}

--- a/src/agent_storage.py
+++ b/src/agent_storage.py
@@ -453,16 +453,31 @@ async def list_agents(
     offset: int = 0,
     include_archived: bool = False,
     include_deleted: bool = False,
+    include_unparticipated: bool = False,
 ) -> List[AgentRecord]:
     """
     List agents with optional filtering.
 
     By default excludes archived and deleted agents unless explicitly included.
+
+    By default also excludes "never participated" identities — rows that
+    exist from an ``onboard()`` but whose process never recorded a real
+    (``synthetic = false``) check-in. ~48% of ``core.identities`` are this
+    class and they pollute listings and counts. Pass
+    ``include_unparticipated=True`` to restore the historic show-everything
+    behavior (operator audit / orphan classification / the cold-start
+    metadata cache load all opt in). This is **view-only**: it filters what
+    is returned and never archives, deletes, or mutates any identity.
     """
     await _ensure_db_ready()
     db = get_db()
 
-    identities = await db.list_identities(status=status, limit=limit, offset=offset)
+    identities = await db.list_identities(
+        status=status,
+        limit=limit,
+        offset=offset,
+        participated_only=(not include_unparticipated),
+    )
 
     # Fetch labels from core.agents in one batch query
     agent_labels = {}

--- a/src/db/base.py
+++ b/src/db/base.py
@@ -146,8 +146,14 @@ class DatabaseBackend(ABC):
         status: Optional[str] = None,
         limit: int = 100,
         offset: int = 0,
+        participated_only: bool = False,
     ) -> List[IdentityRecord]:
-        """List identities with optional filtering."""
+        """List identities with optional filtering.
+
+        ``participated_only=True`` restricts to identities with at least one
+        measured (``synthetic = false``) ``core.agent_state`` row. Default
+        ``False`` preserves the show-everything behavior.
+        """
         pass
 
     @abstractmethod

--- a/src/db/mixins/identity.py
+++ b/src/db/mixins/identity.py
@@ -101,27 +101,56 @@ class IdentityMixin:
         status: Optional[str] = None,
         limit: int = 100,
         offset: int = 0,
+        participated_only: bool = False,
     ) -> List[IdentityRecord]:
+        """List identities with optional filtering.
+
+        ``participated_only=True`` restricts the result to identities that
+        have actually checked in — i.e. those with at least one *measured*
+        (``synthetic = false``) row in ``core.agent_state``. This matches the
+        existing measured-only convention: substrate_interpretation rows
+        count as participation, bootstrap synthetic anchors do not. The
+        filter is a derived EXISTS predicate; it is **view-only** and never
+        archives, deletes, or mutates any row. Default ``False`` preserves
+        the historic "show every onboarded identity" behavior for callers
+        that opt out (operator audit / orphan classification / cache loads).
+        """
+        # core.identities is aliased ``i`` so the EXISTS subquery can
+        # correlate on i.identity_id without column ambiguity.
+        participated_clause = (
+            " AND EXISTS (SELECT 1 FROM core.agent_state s "
+            "WHERE s.identity_id = i.identity_id AND s.synthetic = false)"
+            if participated_only
+            else ""
+        )
         async with self.acquire() as conn:
             if status:
                 rows = await conn.fetch(
-                    """
-                    SELECT identity_id, agent_id, api_key_hash, created_at, updated_at,
-                           status, parent_agent_id, spawn_reason, disabled_at, last_activity_at, metadata
-                    FROM core.identities
-                    WHERE status = $1
-                    ORDER BY created_at DESC
+                    f"""
+                    SELECT i.identity_id, i.agent_id, i.api_key_hash, i.created_at, i.updated_at,
+                           i.status, i.parent_agent_id, i.spawn_reason, i.disabled_at, i.last_activity_at, i.metadata
+                    FROM core.identities i
+                    WHERE i.status = $1{participated_clause}
+                    ORDER BY i.created_at DESC
                     LIMIT $2 OFFSET $3
                     """,
                     status, limit, offset,
                 )
             else:
+                # No status filter: a WHERE clause may still be needed for the
+                # participated predicate. Build it so the EXISTS lands under
+                # WHERE (not a dangling AND) when there is no status.
+                no_status_where = (
+                    " WHERE" + participated_clause[len(" AND"):]
+                    if participated_only
+                    else ""
+                )
                 rows = await conn.fetch(
-                    """
-                    SELECT identity_id, agent_id, api_key_hash, created_at, updated_at,
-                           status, parent_agent_id, spawn_reason, disabled_at, last_activity_at, metadata
-                    FROM core.identities
-                    ORDER BY created_at DESC
+                    f"""
+                    SELECT i.identity_id, i.agent_id, i.api_key_hash, i.created_at, i.updated_at,
+                           i.status, i.parent_agent_id, i.spawn_reason, i.disabled_at, i.last_activity_at, i.metadata
+                    FROM core.identities i{no_status_where}
+                    ORDER BY i.created_at DESC
                     LIMIT $1 OFFSET $2
                     """,
                     limit, offset,

--- a/tests/test_agent_storage.py
+++ b/tests/test_agent_storage.py
@@ -638,7 +638,9 @@ class TestListAgents:
             from src.agent_storage import list_agents
             await list_agents(status="paused", limit=50, offset=10)
 
-        db.list_identities.assert_awaited_once_with(status="paused", limit=50, offset=10)
+        db.list_identities.assert_awaited_once_with(
+            status="paused", limit=50, offset=10, participated_only=True
+        )
 
     @pytest.mark.asyncio
     async def test_health_from_state(self):
@@ -719,6 +721,26 @@ class TestListAgents:
 
         assert result[0].health_status == "unknown"
         db.get_latest_agent_state.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_participated_only(self):
+        """list_agents() defaults to participated_only=True at the DB layer."""
+        db = _mock_db(list_identities=[])
+        with patch("src.agent_storage.get_db", return_value=db):
+            from src.agent_storage import list_agents
+            await list_agents()
+        _, kwargs = db.list_identities.await_args
+        assert kwargs["participated_only"] is True
+
+    @pytest.mark.asyncio
+    async def test_include_unparticipated_disables_participated_filter(self):
+        """include_unparticipated=True passes participated_only=False through."""
+        db = _mock_db(list_identities=[])
+        with patch("src.agent_storage.get_db", return_value=db):
+            from src.agent_storage import list_agents
+            await list_agents(include_unparticipated=True)
+        _, kwargs = db.list_identities.await_args
+        assert kwargs["participated_only"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_identity_mixin_participated.py
+++ b/tests/test_identity_mixin_participated.py
@@ -1,0 +1,145 @@
+"""Tests for the participated-only filter on IdentityMixin.list_identities.
+
+An identity "participated" iff it has >=1 row in core.agent_state with
+synthetic=false (the established measured-only convention). This filter is
+view-only: it changes what listings return, never archiving or mutating rows.
+
+These tests drive the mixin against a fake connection that (a) lets us assert
+on the generated SQL and (b) simulates the EXISTS(synthetic=false) predicate
+against in-memory rows so the three spec cases are covered without a live DB.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.db.mixins.identity import IdentityMixin
+
+
+def _row(agent_id: str, identity_id: int) -> dict:
+    now = datetime.now(timezone.utc)
+    return {
+        "identity_id": identity_id,
+        "agent_id": agent_id,
+        "api_key_hash": "h",
+        "created_at": now,
+        "updated_at": now,
+        "status": "active",
+        "parent_agent_id": None,
+        "spawn_reason": None,
+        "disabled_at": None,
+        "last_activity_at": now,
+        "metadata": {},
+    }
+
+
+class _Acquire:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _Backend(IdentityMixin):
+    """IdentityMixin bound to a fake connection.
+
+    The fake connection models core.identities (``identities``) joined
+    against the set of identity_ids that have a measured (synthetic=false)
+    agent_state row (``measured_ids``). When the query carries the
+    participated EXISTS predicate, only measured identities are returned.
+    """
+
+    def __init__(self, identities, measured_ids):
+        self._identities = identities
+        self._measured_ids = set(measured_ids)
+        conn = MagicMock()
+        conn.fetch = AsyncMock(side_effect=self._fetch)
+        self._conn = conn
+        self.last_sql = None
+
+    def acquire(self):
+        return _Acquire(self._conn)
+
+    async def _fetch(self, sql, *params):
+        self.last_sql = sql
+        participated = "s.synthetic = false" in sql
+        rows = self._identities
+        if participated:
+            rows = [r for r in rows if r["identity_id"] in self._measured_ids]
+        return rows
+
+
+@pytest.mark.asyncio
+async def test_participated_only_returns_identity_with_measured_state():
+    """An identity with a non-synthetic agent_state row IS returned."""
+    backend = _Backend([_row("a1", 1)], measured_ids={1})
+    result = await backend.list_identities(participated_only=True)
+    assert [r.agent_id for r in result] == ["a1"]
+
+
+@pytest.mark.asyncio
+async def test_participated_only_excludes_identity_with_zero_state_rows():
+    """An identity with ZERO agent_state rows is NOT returned by default..."""
+    backend = _Backend([_row("ghost", 2)], measured_ids=set())
+    result = await backend.list_identities(participated_only=True)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_unparticipated_returned_when_filter_off():
+    """...but IS returned when participated_only=False (opt-out)."""
+    backend = _Backend([_row("ghost", 2)], measured_ids=set())
+    result = await backend.list_identities(participated_only=False)
+    assert [r.agent_id for r in result] == ["ghost"]
+
+
+@pytest.mark.asyncio
+async def test_synthetic_only_identity_treated_as_unparticipated():
+    """An identity whose only agent_state row is synthetic=true does not
+    appear in measured_ids, so participated_only filters it out."""
+    # measured_ids is empty: the synthetic row never satisfies synthetic=false.
+    backend = _Backend([_row("boot", 3)], measured_ids=set())
+    result = await backend.list_identities(participated_only=True)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_predicate_present_only_when_requested():
+    """The EXISTS(synthetic=false) predicate is emitted iff participated_only."""
+    backend = _Backend([_row("a1", 1)], measured_ids={1})
+
+    await backend.list_identities(participated_only=False)
+    assert "s.synthetic = false" not in backend.last_sql
+
+    await backend.list_identities(participated_only=True)
+    assert "EXISTS" in backend.last_sql
+    assert "s.synthetic = false" in backend.last_sql
+    assert "s.identity_id = i.identity_id" in backend.last_sql
+
+
+@pytest.mark.asyncio
+async def test_predicate_lands_under_where_with_status_filter():
+    """With a status filter, the predicate appends via AND to the WHERE."""
+    backend = _Backend([_row("a1", 1)], measured_ids={1})
+    await backend.list_identities(status="active", participated_only=True)
+    sql = backend.last_sql
+    assert "i.status = $1" in sql
+    assert "AND EXISTS" in sql
+
+
+@pytest.mark.asyncio
+async def test_predicate_lands_under_fresh_where_without_status():
+    """Without a status filter, the predicate introduces its own WHERE
+    (no dangling AND)."""
+    backend = _Backend([_row("a1", 1)], measured_ids={1})
+    await backend.list_identities(participated_only=True)
+    sql = backend.last_sql
+    assert " WHERE EXISTS" in sql
+    assert "AND EXISTS" not in sql


### PR DESCRIPTION
## What

Default `list_agents()` (and the underlying `db.list_identities()`) to **participated-only**: an identity is returned only if it has at least one *measured* row in `core.agent_state` (`synthetic = false`). ~48% of `core.identities` rows are "never participated" — a row exists from `onboard()` but the process never recorded a real check-in. They pollute agent listings and counts.

An identity counts as participated iff `EXISTS (SELECT 1 FROM core.agent_state s WHERE s.identity_id = i.identity_id AND s.synthetic = false)`. This matches the existing measured-only convention (migrations 022/023/038, `tool_usage.py`): `substrate_interpretation` rows count; bootstrap synthetic anchors do not. A partial index (`idx_agent_state_synthetic_partial`, migration 022) backs the predicate.

## View-only — NOT an auto-sweep

This is a **derived SQL predicate** on the read path. It filters what listings return; it **never archives, deletes, or mutates any identity/agent row**. No background reaper, TTL, or periodic cleanup is added. This is deliberate: the `periodic_orphan_cleanup` auto-sweep was removed 2026-04-19 (see `src/background_tasks.py:1822`) because it hid onboarding bugs behind archival. The never-participated population stays fully visible to operator/audit tooling (see caller audit) — it is simply excluded from default user-facing listings. No DB migration and no new column.

## Changes

- `src/db/mixins/identity.py` — `list_identities(..., participated_only: bool = False)`. When `True`, appends the EXISTS predicate (aliasing `core.identities` as `i`). Handles both the status-given branch (appends via `AND`) and the no-status branch (introduces a fresh `WHERE`). Default `False` = no behavior change.
- `src/db/base.py` — abstract `list_identities` signature updated to match.
- `src/agent_storage.py` — `list_agents(..., include_unparticipated: bool = False)`, passing `participated_only=(not include_unparticipated)`. So `list_agents` **defaults to participated-only**.

## Caller audit

Every caller of `list_agents(` / `list_identities(` across `src/` was checked.

**Left at the new participated-only default (user/dashboard-facing):**
- `list_agents()` itself — new default applies to all callers that don't opt out.
- `handle_list_agents` (`src/mcp_handlers/lifecycle/query.py`) — reads the in-memory `mcp_server.agent_metadata` cache, not `list_agents()` directly, and already does its own ghost/ephemeral filtering. It inherits the cleaner cache via the loader below.

**Changed to opt out (`include_unparticipated=True`) — operator audit / orphan classification surface:**
- `src/agent_metadata_persistence.py` `_load_metadata_from_postgres_async` — the **only** direct DB caller of `list_agents`. It is the cold-start loader for the in-memory `agent_metadata` cache that backs operator audit and orphan classification (`lifecycle/operations.py` resume/archive/orphan flows at lines 578/658) plus onboarding-bug visibility. It MUST see every onboarded identity, including never-participated ones — filtering here would silently hide the orphan population the operator tools exist to surface. The participated-only default therefore lives at the listing surface, not in this cache load.

(Other `agent_storage` imports in `src/` reference `get_agent`, `extract_actions_verdicts`, `get_agent_state_history` — not `list_agents` — so they are unaffected.)

## Tests

- `tests/test_identity_mixin_participated.py` (new) — drives `IdentityMixin.list_identities` against a fake connection that simulates the EXISTS(synthetic=false) predicate. Covers the three spec cases: identity with a non-synthetic `agent_state` row IS returned; identity with ZERO `agent_state` rows is NOT returned by default but IS returned with the filter off; identity with ONLY a `synthetic=true` row is treated as unparticipated. Plus SQL-shape assertions (predicate present iff requested; lands under `AND` with a status filter and under a fresh `WHERE` without).
- `tests/test_agent_storage.py` — added `test_defaults_to_participated_only` and `test_include_unparticipated_disables_participated_filter`; updated `test_passes_status_limit_offset` for the new kwarg.

Full suite green locally: `./scripts/dev/test-cache.sh` → 10282 passed, 21 skipped, coverage 81.27%.