### PR TITLE
feat(list_agents): surface participated vs never-checked-in in the count

### DIFF
--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -906,7 +906,13 @@ async function loadAgents() {
 
         // Use summary counts (accurate) not array lengths (limited by pagination)
         const total = summary.total || 0;
-        const active = (byStatus.active || 0) + (byStatus.waiting_input || 0);
+        // "active" headline = agents that have actually checked in at least once
+        // (participated). Falls back to lifecycle-active if the backend predates
+        // the participation split. Never-participated are still in `total`.
+        const neverParticipated = summary.never_participated || 0;
+        const active = (summary.participated != null)
+            ? summary.participated
+            : ((byStatus.active || 0) + (byStatus.waiting_input || 0));
         const paused = byStatus.paused || 0;
         const archived = byStatus.archived || 0;
         const deleted = byStatus.deleted || 0;
@@ -941,6 +947,7 @@ async function loadAgents() {
         const agentsChange = formatChange(total, previousStats.totalAgents);
         const breakdown = [];
         if (active > 0) breakdown.push(`${active} active`);
+        if (neverParticipated > 0) breakdown.push(`${neverParticipated} never checked in`);
         if (paused > 0) breakdown.push(`${paused} paused`);
         if (archived > 0) breakdown.push(`${archived} archived`);
         if (deleted > 0) breakdown.push(`${deleted} deleted`);

--- a/src/mcp_handlers/lifecycle/query.py
+++ b/src/mcp_handlers/lifecycle/query.py
@@ -780,6 +780,12 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
             "deleted": sum(1 for a in agents_list if a.get("lifecycle_status") == "deleted"),
             "unknown": sum(1 for a in agents_list if a.get("lifecycle_status") not in ["active", "waiting_input", "paused", "archived", "deleted"])
         }
+        # Participation split (before pagination): an agent has "participated"
+        # once it has recorded at least one check-in (total_updates >= 1). This
+        # is the same signal the lite-path ghost filter uses (total_updates < 1).
+        # Surfaced so count consumers can show working agents, not raw row count.
+        participated = sum(1 for a in agents_list if (a.get("total_updates") or 0) >= 1)
+        never_participated = total_count - participated
 
         # Apply pagination (optimization)
         if limit is not None:
@@ -808,7 +814,9 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                     "returned": len(agents_list),  # Number actually returned (after pagination)
                     "offset": offset,
                     "limit": limit,
-                    "by_status": status_counts  # Use counts from BEFORE pagination
+                    "by_status": status_counts,  # Use counts from BEFORE pagination
+                    "participated": participated,  # checked in >=1 time
+                    "never_participated": never_participated  # onboarded but never checked in
                 }
             }
 
@@ -830,7 +838,9 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                     "returned": len(agents_list),  # Number actually returned (after pagination)
                     "offset": offset,
                     "limit": limit,
-                    "by_status": status_counts  # Use counts from BEFORE pagination
+                    "by_status": status_counts,  # Use counts from BEFORE pagination
+                    "participated": participated,  # checked in >=1 time
+                    "never_participated": never_participated  # onboarded but never checked in
                 }
             }
 

--- a/tests/test_handlers_lifecycle.py
+++ b/tests/test_handlers_lifecycle.py
@@ -711,3 +711,49 @@ class TestArchiveOldTestAgents:
             assert data["include_all"] is True
             # 5 days old > 3 day default for include_all
             assert data["archived_count"] >= 1
+
+
+# ============================================================================
+# list_agents participation split (summary surface — count consumers)
+# ============================================================================
+
+class TestListAgentsParticipation:
+
+    @pytest.fixture
+    def mock_mcp_server(self):
+        return make_mock_server()
+
+    @pytest.mark.asyncio
+    async def test_summary_splits_participated_vs_never(self, mock_mcp_server):
+        # 2 agents have checked in (total_updates >= 1), 2 never did (==0)
+        mock_mcp_server.agent_metadata = {
+            "p1": make_agent_meta(label="Worker1", total_updates=5),
+            "p2": make_agent_meta(label="Worker2", total_updates=1),
+            "n1": make_agent_meta(label="Never1", total_updates=0),
+            "n2": make_agent_meta(label="Never2", total_updates=0),
+        }
+
+        with patch_lifecycle_server(mock_mcp_server):
+            from src.mcp_handlers.lifecycle.handlers import handle_list_agents
+            result = await handle_list_agents({"summary_only": True})
+
+            data = json.loads(result[0].text)
+            assert data["participated"] == 2
+            assert data["never_participated"] == 2
+            # total accounts for both buckets — never-participated are not hidden
+            assert data["total"] == data["participated"] + data["never_participated"]
+
+    @pytest.mark.asyncio
+    async def test_summary_all_participated(self, mock_mcp_server):
+        mock_mcp_server.agent_metadata = {
+            "p1": make_agent_meta(label="Worker1", total_updates=4),
+            "p2": make_agent_meta(label="Worker2", total_updates=9),
+        }
+
+        with patch_lifecycle_server(mock_mcp_server):
+            from src.mcp_handlers.lifecycle.handlers import handle_list_agents
+            result = await handle_list_agents({"summary_only": True})
+
+            data = json.loads(result[0].text)
+            assert data["participated"] == 2
+            assert data["never_participated"] == 0


### PR DESCRIPTION
Follow-up to #819 (deployed but inert). #819 added a DB-level `participated_only` filter, but its sole caller opts out and the displayed surface (`handle_list_agents`) reads the **in-memory cache**, so the live count still showed all **701 active** including ~149 never-checked-in agents — the original 'agent proliferation / uninitialized' complaint.

This wires participation into the **actual count surface**:
- **query.py**: the `list_agents` summary (grouped + flat paths) now carries `participated` (`total_updates >= 1`) and `never_participated`, computed before pagination over the same population as `total`/`by_status`. `total_updates < 1` is the codebase's existing never-participated/ghost signal.
- **dashboard.js**: the Agents card headline 'active' now shows **participated** (working agents); never-checked-in is surfaced in the breakdown sub-label; `total` stays truthful so nothing is hidden. Falls back to lifecycle-active if the backend predates the split.

Additive/non-breaking — `total` and `by_status` unchanged. Tests: `TestListAgentsParticipation` (split + all-participated); full `test_handlers_lifecycle.py` green (36); dashboard.js `node --check` clean.