### PR TITLE
fix(sdk): resident-tag reconcile can never crash the resume/identity path

### DIFF
--- a/agents/sdk/src/unitares_sdk/agent.py
+++ b/agents/sdk/src/unitares_sdk/agent.py
@@ -340,18 +340,25 @@ class GovernanceAgent:
                 self._sync_from_client(client)
                 self._save_session()
                 logger.info("%s: resumed via UUID %s", self.name, self.agent_uuid[:12])
-                # Reconcile resident tags on resume too — residents that always
-                # resume via UUID (refuse_fresh_onboard=True) never re-run the
-                # fresh-onboard stamp, so a dropped required tag would otherwise
-                # never self-heal (Sentinel 2026-06-15 resident_tag_gap finding).
-                await self._reconcile_resident_tags(client)
-                return
             except Exception as e:
                 logger.error(
                     "%s: UUID lookup failed for %s: %s — refusing to create ghost",
                     self.name, self.agent_uuid[:12], e,
                 )
                 raise
+
+            # Resume already succeeded and is persisted above. Reconcile resident
+            # tags as a best-effort, non-fatal step OUTSIDE the resume try block:
+            # residents that always resume via UUID (refuse_fresh_onboard=True)
+            # never re-run the fresh-onboard stamp, so a dropped required tag
+            # would otherwise never self-heal (Sentinel 2026-06-15
+            # resident_tag_gap finding). Keeping it inside the try would let a
+            # cosmetic tag-reconcile error be misattributed as a fatal "UUID
+            # lookup failed" and re-raised, taking the resident offline over a
+            # non-critical metadata write (Chronicler 2026-06-14 outage class).
+            # _reconcile_resident_tags is itself guarded to never raise.
+            await self._reconcile_resident_tags(client)
+            return
 
         # First run — onboard, get a UUID, save it
         if self.refuse_fresh_onboard and os.environ.get("UNITARES_FIRST_RUN") != "1":
@@ -380,6 +387,28 @@ class GovernanceAgent:
         await self._reconcile_resident_tags(client)
 
     async def _reconcile_resident_tags(self, client: GovernanceClient) -> None:
+        """Non-fatal guard wrapper around :meth:`_reconcile_resident_tags_inner`.
+
+        Resident-tag reconciliation is a cosmetic, self-healing convenience —
+        it must NEVER be able to crash the identity path. The inner method
+        already guards its read and write, but a defensive top-level catch-all
+        here guarantees that even an unexpected error (a bad response shape, a
+        client raising a non-``Exception`` payload, a future edit that adds an
+        unguarded line) can never propagate out and take a resident offline
+        over a metadata write. See the Chronicler 2026-06-14 outage class:
+        residents run ``refuse_fresh_onboard=True``, so anything that escapes
+        ``_ensure_identity`` is fatal with no fallback.
+        """
+        try:
+            await self._reconcile_resident_tags_inner(client)
+        except Exception as e:  # pragma: no cover - defensive belt-and-suspenders
+            logger.warning(
+                "%s: resident tag reconcile raised unexpectedly (ignored, "
+                "non-fatal): %r",
+                self.name, e,
+            )
+
+    async def _reconcile_resident_tags_inner(self, client: GovernanceClient) -> None:
         """Ensure a persistent resident carries the full ``RESIDENT_TAGS`` set.
 
         Residents need BOTH tags:

--- a/agents/sdk/tests/test_agent.py
+++ b/agents/sdk/tests/test_agent.py
@@ -366,6 +366,38 @@ class TestIdentityResolution:
         # Identity is still established despite the write failure.
         assert agent.agent_uuid == "uuid-test"
 
+    @pytest.mark.asyncio
+    async def test_reconcile_never_crashes_resume_path(self, tmp_path):
+        """Chronicler 2026-06-14 outage class: residents run
+        refuse_fresh_onboard=True, so anything that escapes _ensure_identity is
+        fatal with no fallback — the resident goes dark. Resident-tag reconcile
+        is a cosmetic, self-healing convenience and must NEVER be able to crash
+        the identity path, even on an unexpected error the inner method's own
+        read/write guards don't cover. Resume itself already succeeded and is
+        persisted before reconcile runs.
+        """
+        agent = SimpleAgent(
+            session_file=tmp_path / ".test_session",
+            persistent=True,
+            refuse_fresh_onboard=True,
+        )
+        agent.agent_uuid = "uuid-test"  # resume fast path
+
+        client = _mock_client_connected()
+        # Simulate an unexpected failure the inner guards don't anticipate
+        # (bad response shape, future unguarded edit, non-standard payload).
+        agent._reconcile_resident_tags_inner = AsyncMock(
+            side_effect=RuntimeError("unexpected reconcile boom")
+        )
+
+        # Must NOT raise: the resume succeeded, the reconcile failure is
+        # swallowed by the guard wrapper.
+        await agent._ensure_identity(client)
+
+        client.identity.assert_awaited_once()
+        client.onboard.assert_not_called()  # never falls through to fresh onboard
+        assert agent.agent_uuid == "uuid-test"  # identity intact
+
 
 # --- Session persistence ---
 


### PR DESCRIPTION
## Context — investigating "Chronicler is down"

Chronicler stopped checking in after **2026-06-14 20:51 UTC** (~3 days). Investigation findings:

- **Server is healthy** (v2.13.0, all 12 health checks green).
- **It's Chronicler-specific.** Every other resume-based resident checked in today (2026-06-17): Lumen, Sentinel, Vigil, Steward, Watcher. **Vigil uses the *identical* SDK code path** (`persistent=True`, `refuse_fresh_onboard=True`, one-shot `run_once()`) and is fine — so the SDK resume path and the June 16–17 server-side identity gates (#804/#805) are *not* the cause.
- Chronicler's last activity was **three manual runs in 30 minutes** on June 14, then silence — an operator hands-on session right before it went dark. **The live outage is operational** (its `com.unitares.chronicler` launchd job not firing, or a disturbed anchor) and must be resolved on the host — the launchd log (`~/Library/Logs/unitares-chronicler-launchd.log`) disambiguates.

## What this PR fixes (a real latent bug surfaced by the investigation)

`f0fb385` (#754) added `_reconcile_resident_tags` to the UUID-resume path so residents that always resume self-heal a dropped required tag. But the call was placed **inside the resume try-block** whose `except: raise` is fatal — and residents (`refuse_fresh_onboard=True`) have no fresh-onboard fallback. Any error in a *cosmetic* tag-reconcile would be misattributed as a fatal "UUID lookup failed" and **take the resident offline over a non-critical metadata write** — exactly the failure mode a resident going dark looks like.

This isn't the proven trigger of the current Chronicler outage (it no-ops for Chronicler, which already carries both required tags), but it's a genuine robustness regression that puts all five residents one cosmetic hiccup away from going dark.

### Changes
- **Move the reconcile call OUTSIDE the resume try-block.** Resume already succeeded and is persisted before reconcile runs; a tag hiccup can no longer be re-raised as a resume failure.
- **Split into a non-fatal guard wrapper** (`_reconcile_resident_tags`) delegating to `_reconcile_resident_tags_inner`. The inner method still guards its own read/write; the wrapper guarantees even an unexpected error (bad response shape, a future unguarded edit) is swallowed + logged, never propagated.
- **Regression test** pinning that an unexpected reconcile error does not escape `_ensure_identity`.

All 60 SDK agent tests pass; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjoaZwUzP4zkg3cJZD1Hax)_