### PR TITLE
fix(sdk): surface strict-identity check-in refusals (Chronicler silent-dark root cause) + fix reconcile tool name

### DIFF
--- a/agents/sdk/src/unitares_sdk/agent.py
+++ b/agents/sdk/src/unitares_sdk/agent.py
@@ -448,9 +448,15 @@ class GovernanceAgent:
         if getattr(self, "_resident_tags_reconciled", False):
             return
 
+        # Use the unified `agent` tool (action=get/update). The standalone
+        # get_agent_metadata / update_agent_metadata tools were consolidated
+        # away and now return "Unknown tool" on a current server, so #754's
+        # original calls failed every cycle (Chronicler launchd log
+        # 2026-06-17: "Unknown tool: get_agent_metadata"). The unified tool
+        # returns tags at the top level just the same.
         try:
             raw = await client.call_tool(
-                "get_agent_metadata", {"target_agent": self.agent_uuid}
+                "agent", {"action": "get", "agent_id": self.agent_uuid}
             )
         except Exception as e:
             # Couldn't read current tags — do NOT blind-write (that would risk
@@ -466,7 +472,7 @@ class GovernanceAgent:
         if not isinstance(raw, dict):
             logger.debug(
                 "%s: resident tag reconcile skipped — unexpected "
-                "get_agent_metadata response shape",
+                "agent(action=get) response shape",
                 self.name,
             )
             return
@@ -481,8 +487,8 @@ class GovernanceAgent:
         merged = current + missing  # additive — preserves role/cadence tags
         try:
             await client.call_tool(
-                "update_agent_metadata",
-                {"agent_id": self.agent_uuid, "tags": merged},
+                "agent",
+                {"action": "update", "agent_id": self.agent_uuid, "tags": merged},
             )
             logger.info(
                 "%s: reconciled resident tags — added %s (now %s)",

--- a/agents/sdk/src/unitares_sdk/client.py
+++ b/agents/sdk/src/unitares_sdk/client.py
@@ -19,6 +19,7 @@ from unitares_sdk.errors import (
     GovernanceTimeoutError,
     GovernanceUnavailableError,
     IdentityDriftError,
+    extract_identity_refusal,
     extract_retry_after_seconds,
     parse_retry_after_header,
 )
@@ -461,6 +462,16 @@ class GovernanceClient:
 
         raw = await self.call_tool("process_agent_update", args)
         self._raise_for_tool_failure("process_agent_update", raw)
+
+        # #425: a strict-identity refusal comes back as a structured SUCCESS
+        # shape (no isError, no "error" key), so _raise_for_tool_failure passes
+        # it through. Left undetected, the verdict extraction below defaults to
+        # "proceed" and we report a successful check-in while the server
+        # recorded NOTHING — the resident goes silently dark (Chronicler
+        # 2026-06-14). Detect the refusal marker and fail loud instead.
+        refusal = extract_identity_refusal(raw)
+        if refusal is not None:
+            raise refusal
 
         # Extract verdict for potential error raising
         decision = raw.get("decision", {})

--- a/agents/sdk/src/unitares_sdk/errors.py
+++ b/agents/sdk/src/unitares_sdk/errors.py
@@ -111,3 +111,58 @@ class IdentityBootstrapRefused(GovernanceError):
     bootstrap a new identity by running the agent once with the
     UNITARES_FIRST_RUN=1 environment variable set. Never silently swap
     identities."""
+
+
+# Single source for the #425 STRICT_IDENTITY_REQUIRED typed-refusal shape. The
+# server emits it via strict_identity_refusal_payload() wrapped in
+# success_response() — i.e. HTTP 200, NOT isError, NO "error" key — so neither
+# the transport layer nor _raise_for_tool_failure flags it. Detection therefore
+# keys on the payload's own marker field, mirroring extract_retry_after_seconds.
+STRICT_IDENTITY_ROLLOUT_FLAG = "STRICT_IDENTITY_REQUIRED"
+
+
+class IdentityRefusedError(GovernanceError):
+    """Server refused a write because identity was not caller-proven under
+    STRICT_IDENTITY_REQUIRED (#425).
+
+    The refusal is a *structured success-shape*, not an error — by design, so
+    that catch-paths don't retry-with-mint and reintroduce ghost leaks. But for
+    a resident's check-in that shape is dangerous: without this detection the
+    SDK reads the absent verdict as a default "proceed" and reports a SUCCESSFUL
+    check-in while the server recorded nothing. A resident then goes silently
+    dark — clean logs, 200 OK, zero recorded updates (Chronicler 2026-06-14:
+    three days of "successful" daily runs, no EISV trajectory written).
+
+    Raising instead makes the refusal loud: the cycle fails, the launchd log
+    shows it, and notify_on_error fires. Fix the offender per the rollout doc
+    (carry a caller-proven binding — echo the onboarded client_session_id or
+    pass continuity_token — or add parent_agent_id / substrate exemption)."""
+
+    def __init__(self, tool: str, hint: str | None = None, status: str | None = None):
+        self.tool = tool
+        self.hint = hint
+        self.status = status
+        msg = f"Governance refused {tool} under strict identity (status={status})"
+        if hint:
+            msg += f" — {hint}"
+        super().__init__(msg)
+
+
+def extract_identity_refusal(payload: object) -> "IdentityRefusedError | None":
+    """Return an IdentityRefusedError when ``payload`` is the #425 typed
+    strict-identity refusal, else ``None``.
+
+    Keys on ``rollout_flag == STRICT_IDENTITY_REQUIRED`` — the marker the
+    single-sourced server payload always sets — NOT on the bare presence of a
+    ``status`` field, so a normal check-in response (decision/metrics, no
+    rollout_flag) never trips it.
+    """
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("rollout_flag") != STRICT_IDENTITY_ROLLOUT_FLAG:
+        return None
+    return IdentityRefusedError(
+        tool=payload.get("tool") or "unknown",
+        hint=payload.get("hint"),
+        status=payload.get("status"),
+    )

--- a/agents/sdk/tests/test_agent.py
+++ b/agents/sdk/tests/test_agent.py
@@ -91,14 +91,18 @@ def _mock_client_connected():
 
 
 def _call_tool_with_tags(existing_tags, *, fail_update=False):
-    """An AsyncMock for client.call_tool that answers get_agent_metadata with
-    ``existing_tags`` and records update_agent_metadata writes. ``fail_update``
-    makes the write raise (to exercise the non-fatal path)."""
+    """An AsyncMock for client.call_tool that answers the unified agent tool's
+    action=get with ``existing_tags`` and records action=update writes.
+    ``fail_update`` makes the write raise (to exercise the non-fatal path).
+
+    The standalone get_agent_metadata/update_agent_metadata tools were
+    consolidated into the unified ``agent`` tool; reconcile must use it (the
+    old names now return "Unknown tool" on a current server)."""
 
     async def _impl(tool, args, **kwargs):
-        if tool == "get_agent_metadata":
+        if tool == "agent" and args.get("action") == "get":
             return {"success": True, "tags": list(existing_tags)}
-        if tool == "update_agent_metadata":
+        if tool == "agent" and args.get("action") == "update":
             if fail_update:
                 raise RuntimeError("write down")
             return {"success": True, "tags": args.get("tags")}
@@ -108,20 +112,20 @@ def _call_tool_with_tags(existing_tags, *, fail_update=False):
 
 
 def _tool_writes(client):
-    """The argument dicts passed to every update_agent_metadata call."""
+    """The argument dicts passed to every agent(action=update) call."""
     return [
-        c.args[1]
+        {"agent_id": c.args[1].get("agent_id"), "tags": c.args[1].get("tags")}
         for c in client.call_tool.await_args_list
-        if c.args and c.args[0] == "update_agent_metadata"
+        if c.args and c.args[0] == "agent" and c.args[1].get("action") == "update"
     ]
 
 
 def _tool_reads(client):
-    """The target_agent of every get_agent_metadata call."""
+    """The agent_id of every agent(action=get) call."""
     return [
-        c.args[1].get("target_agent")
+        c.args[1].get("agent_id")
         for c in client.call_tool.await_args_list
-        if c.args and c.args[0] == "get_agent_metadata"
+        if c.args and c.args[0] == "agent" and c.args[1].get("action") == "get"
     ]
 
 

--- a/agents/sdk/tests/test_client.py
+++ b/agents/sdk/tests/test_client.py
@@ -16,6 +16,7 @@ from unitares_sdk.errors import (
     GovernanceConnectionError,
     GovernanceTimeoutError,
     IdentityDriftError,
+    IdentityRefusedError,
 )
 from unitares_sdk.models import CheckinResult, IdentityResult, OnboardResult
 
@@ -574,6 +575,47 @@ class TestCheckinVerdict:
 
         with pytest.raises(GovernanceConnectionError, match="governance down"):
             await client.checkin("test work")
+
+    @pytest.mark.asyncio
+    async def test_strict_identity_refusal_raises_not_silent_proceed(self):
+        """#425 / Chronicler 2026-06-14: a strict-identity refusal comes back as
+        a structured SUCCESS shape (no isError, no "error" key, no decision), so
+        _raise_for_tool_failure passes it through. Undetected, the verdict would
+        default to "proceed" and the SDK would report a successful check-in
+        while the server recorded NOTHING — a resident goes silently dark. The
+        refusal must surface loud instead."""
+        session = AsyncMock()
+        session.call_tool = AsyncMock(return_value=make_mcp_result({
+            "status": "identity_required",
+            "tool": "process_agent_update",
+            "tool_class": "required",
+            "hint": "echo your client_session_id or pass continuity_token",
+            "ontology_ref": "CLAUDE.md \"STRICT_IDENTITY_REQUIRED (#425 staged rollout)\"",
+            "rollout_flag": "STRICT_IDENTITY_REQUIRED",
+        }))
+        client = make_client_with_session(session)
+
+        with pytest.raises(IdentityRefusedError) as exc_info:
+            await client.checkin("test work")
+        assert exc_info.value.tool == "process_agent_update"
+        assert exc_info.value.status == "identity_required"
+
+    @pytest.mark.asyncio
+    async def test_normal_checkin_not_mistaken_for_refusal(self):
+        """A normal check-in response (decision/metrics, no rollout_flag) must
+        NOT trip the refusal detector — it keys on the rollout_flag marker, not
+        the bare presence of a status field."""
+        session = AsyncMock()
+        session.call_tool = AsyncMock(return_value=make_mcp_result({
+            "success": True,
+            "status": "active",
+            "decision": {"action": "proceed"},
+            "metrics": {"coherence": 0.8},
+        }))
+        client = make_client_with_session(session)
+
+        result = await client.checkin("test work")
+        assert result.verdict == "proceed"
 
 
 class TestSearchKnowledgeFailure:


### PR DESCRIPTION
## Root cause of the Chronicler outage

The launchd log the operator pulled overturned the initial "job not firing" theory. Chronicler **was** running daily (June 16 03:33, June 17 05:04 local), resuming identity (`resumed via UUID deb879b6`), posting all 9 metrics, and ending each run on a clean `POST /mcp/ 200 OK` with no `chronicler failed` — yet the server recorded **zero EISV check-ins after 2026-06-14**.

Two defects explain it, both in the resident SDK:

### (A) `checkin()` silently mistakes a strict-identity refusal for success — the outage cause
Under `STRICT_IDENTITY_REQUIRED` (#425), `process_agent_update` returns a typed refusal **wrapped in `success_response()`** — HTTP 200, no `isError`, no `error` key (`src/mcp_handlers/identity_bootstrap.py:39`, deliberately "a structured success-shape, not an error"). So the SDK's `_raise_for_tool_failure` passes it through, `verdict` defaults to `"proceed"` (`client.py:467`), and `checkin()` returns a **fake-success `CheckinResult`**. The resident believes it checked in; the server recorded nothing. Clean logs, 200 OK, no trajectory — silently dark for days.

**Fix:** a single-sourced detector (`errors.extract_identity_refusal`, keyed on the `rollout_flag` marker the server payload always sets) raises a new typed `IdentityRefusedError` from `checkin()`. The cycle now fails **loud** — surfaced in the launchd log and via `notify_on_error` — instead of faking success. This protects every resident from the silent-dark class, regardless of which path triggered the refusal.

### (B) reconcile calls tools that no longer exist
The log shows every cycle: `Unknown tool: get_agent_metadata`. `#754`'s reconcile called the standalone `get_agent_metadata` / `update_agent_metadata` tools, which were consolidated into the unified `agent` tool. Functionally non-fatal (the read failure was already caught after #823), but resident-tag self-healing never actually worked. Switched to `agent` (`action=get` / `action=update`), which returns tags at the same top level.

## Tests
- Strict refusal raises `IdentityRefusedError` instead of silent `proceed`.
- A normal check-in (decision/metrics, no `rollout_flag`) is **not** mistaken for a refusal.
- Reconcile read/write exercise the unified `agent` tool.
- All 220 SDK tests pass; `ruff` clean.

## Operator note — what this does and doesn't do
This makes the failure **diagnosable**, not invisible. To actually restore Chronicler's check-ins you still need to resolve *why* its write is refused under strict — confirm `STRICT_IDENTITY_REQUIRED` on the Mac governance server and either (a) ensure Chronicler's resume carries a caller-proven binding (echoed `client_session_id` / `continuity_token`), or (b) confirm its substrate-earned exemption. With this fix deployed, the next run will log a clear `IdentityRefusedError` pinning exactly that, rather than pretending success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjoaZwUzP4zkg3cJZD1Hax)_