### PR TITLE
fix(dashboard): collapse never-checked-in agents into a folded group

### DIFF
--- a/dashboard/agents.js
+++ b/dashboard/agents.js
@@ -244,7 +244,6 @@
 
         updateAgentFilterInfo(agents.length);
         var agentEISVHistory = state.get('agentEISVHistory') || {};
-        var displayAgents = agents.slice(0, state.get('agentPageSize'));
 
         // Build lineage lookup maps from the full cached set, so a parent
         // filtered out of the current view still resolves its short label
@@ -264,7 +263,7 @@
             }
         }
 
-        var cardsHtml = displayAgents.map(function (agent) {
+        function buildAgentCard(agent) {
             var status = getAgentStatus(agent);
             var statusClass = status === 'paused' ? 'paused' :
                 status === 'archived' ? 'archived' :
@@ -491,22 +490,61 @@
                     '</div>';
                 })() +
             '</div>';
-        }).join('');
+        }
 
-        // Pagination footer
+        // Partition the filtered view: agents that have checked in at least once
+        // ("participated") render in the main list; agents that onboarded but
+        // never produced an observation (total_updates === 0) collapse into a
+        // single folded group. Without this, a server restart re-hydrates the
+        // entire stale 0-checkin cohort into the cache at once and floods the
+        // active list with "uninitialized" rows that look like a fresh swarm
+        // (2026-06-17). The split mirrors the summary headline's
+        // participated/never_participated counts surfaced by #822.
+        var participated = [];
+        var neverChecked = [];
+        for (var ai = 0; ai < agents.length; ai++) {
+            if ((agents[ai].total_updates || 0) >= 1) participated.push(agents[ai]);
+            else neverChecked.push(agents[ai]);
+        }
+
+        var displayAgents = participated.slice(0, state.get('agentPageSize'));
+        var cardsHtml = displayAgents.map(buildAgentCard).join('');
+
+        // Pagination footer — over the participated list only.
         var paginationHtml = '';
-        if (agents.length > state.get('agentPageSize')) {
+        if (participated.length > state.get('agentPageSize')) {
             paginationHtml = '<div class="agents-pagination">' +
-                '<span class="pagination-info">Showing ' + displayAgents.length + ' of ' + agents.length + ' agents</span>' +
+                '<span class="pagination-info">Showing ' + displayAgents.length + ' of ' + participated.length + ' agents</span>' +
                 '<button class="show-more-btn" type="button">Show more</button>' +
             '</div>';
-        } else if (agents.length > 0) {
+        } else if (participated.length > 0) {
             paginationHtml = '<div class="agents-pagination">' +
-                '<span class="pagination-info">Showing ' + agents.length + ' of ' + agents.length + ' agents</span>' +
+                '<span class="pagination-info">Showing ' + participated.length + ' of ' + participated.length + ' agents</span>' +
             '</div>';
         }
 
-        container.innerHTML = cardsHtml + paginationHtml;
+        // Collapsed "never checked in" group. Folded by default so it never
+        // floods the list; expandable for audit. Cards reuse buildAgentCard so
+        // pin/copy/detail delegation keeps working inside the <details>.
+        var ghostHtml = '';
+        if (neverChecked.length > 0) {
+            var emptyMainNote = participated.length === 0
+                ? '<div class="loading">No agents have checked in for the current filters. ' +
+                  neverChecked.length + ' onboarded but never produced an observation — see below.</div>'
+                : '';
+            paginationHtml = emptyMainNote + paginationHtml;
+            var ghostCards = neverChecked.map(buildAgentCard).join('');
+            ghostHtml = '<details class="agent-ghost-group">' +
+                '<summary class="agent-ghost-summary">' +
+                    '<span class="agent-ghost-arrow">▸</span> ' +
+                    'Never checked in — ' + neverChecked.length +
+                    '<span class="agent-ghost-hint">onboarded, no observations yet</span>' +
+                '</summary>' +
+                '<div class="agent-ghost-list">' + ghostCards + '</div>' +
+            '</details>';
+        }
+
+        container.innerHTML = cardsHtml + paginationHtml + ghostHtml;
     }
 
     // ========================================================================

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -3715,6 +3715,51 @@ main {
 }
 
 /* ============================================
+   Never-checked-in (ghost) collapsed group
+   ============================================ */
+.agent-ghost-group {
+    margin-top: 10px;
+    border-top: 1px solid var(--border-color);
+}
+
+.agent-ghost-summary {
+    list-style: none;
+    cursor: pointer;
+    padding: 10px 2px;
+    font-size: 0.82rem;
+    color: var(--text-secondary);
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    user-select: none;
+}
+
+/* Suppress the native disclosure triangle; we render our own. */
+.agent-ghost-summary::-webkit-details-marker { display: none; }
+.agent-ghost-summary::marker { content: ''; }
+
+.agent-ghost-arrow {
+    display: inline-block;
+    transition: transform 0.15s ease;
+    color: var(--text-secondary);
+}
+
+.agent-ghost-group[open] > .agent-ghost-summary .agent-ghost-arrow {
+    transform: rotate(90deg);
+}
+
+.agent-ghost-hint {
+    font-size: 0.72rem;
+    opacity: 0.65;
+    font-style: italic;
+}
+
+.agent-ghost-list {
+    margin-top: 6px;
+    opacity: 0.82;
+}
+
+/* ============================================
    Production Toggle
    ============================================ */
 .prod-toggle {


### PR DESCRIPTION
## Why

You saw the dashboard surface a swarm of "uninitialized" agents ~an hour ago — "resurrecting zombies" — even though Codex hadn't been active. It wasn't a spawn event.

**Root cause (ground-truthed against the live DB):**
- The 'uninitialized' agents are **151 identities that onboarded but never checked in** (zero `agent_state` rows — verified, not a counting artifact).
- They're **stale**: 0 created in the last 2h, only 3 in the last 24h, 148 older than a day, 109 older than a week. Codex did **not** spawn them.
- UNITARES never auto-archives 0-checkin agents and the periodic reaper was removed in April, so they linger forever as `status='active'`.
- The governance server was **SIGKILL'd and relaunched at 13:01** (last exit `-9`). On restart the cold-loader (`_load_metadata_from_postgres_async`, `include_unparticipated=True`) re-hydrates the *entire* active set into the in-memory cache. Each ghost monitor is `update_count=0` → `monitor_metrics.py` renders `status: 'uninitialized'`, and the dashboard list (`dashboard.js:880`) buckets purely by raw status → all 151 land in the active list at once.

#822 fixed the **summary headline** (participated vs never_participated) but left the **per-agent list** lumping them as active. This finishes that view fix.

## What

- Per-agent list now partitions the filtered view: `total_updates >= 1` render in the main paginated list; `total_updates === 0` collapse into a single folded `Never checked in — N` `<details>` group (foldable for audit).
- No archival, no reaper — the rows stay as honest records, just out of the active view. (Consistent with the standing council verdict: fix the count as a view, keep the substrate floor; a reaper would reverse two deliberate decisions.)
- `buildAgentCard` is the prior inline card builder extracted verbatim and reused for both groups, so pin/copy/detail click-delegation keeps working inside the `<details>`.

## Verification

- `node --check dashboard/agents.js` ✅
- Partition logic unit-harnessed (555 participated / 151 ghosts / page-20 / missing-field → ghost / only-ghosts edge) ✅
- Click delegation is document/container-level via `closest()` → robust to `<details>` nesting (code-reviewed) ✅
- **Not yet** visually verified live (frontend-only, served from disk — no restart needed to deploy: `git pull` in the deploy checkout + browser refresh). Happy to deploy + screenshot on request.

## Deploy note

Frontend-only. After merge: `git -C ~/projects/unitares-deploy pull` (fast-forward master) + browser refresh. **No** allowlist change, **no** server restart.