### PR TITLE
docs(identity): RFC + inert PoC for orchestrator-vouched identity (Wave 3, deferred)

### DIFF
--- a/docs/proposals/orchestrator-vouched-identity-v0.md
+++ b/docs/proposals/orchestrator-vouched-identity-v0.md
@@ -18,11 +18,21 @@ Operator is the merge gate. Do NOT auto-merge.
 ## 0. The one-sentence claim
 
 An agent that the BEAM orchestrator actually **spawned and owns** can be moved
-from the "non-substrate, unverifiable" identity class into a **substrate-attested**
+from the "non-substrate, unverifiable" identity class into a **runtime-attested**
 class — by having the orchestrator (itself S19-enrolled, speaking to governance
 over the already-trusted UDS peer-cred channel) **vouch** the child's
 `(uuid, os_pid, start_tvsec)` at spawn, so the child's later calls resolve at a
 genuine `strong` tier by *proof*, not by echoing a copyable string.
+
+> **Word choice (council 2026-06-17):** the child class is **runtime-attested**,
+> *not* "substrate-attested." The child has **no dedicated substrate of its own**
+> (§6.3 — the substrate is the orchestrator's); calling the child "substrate-X"
+> would smuggle in a class membership it provably lacks (the Appendix's
+> three-condition test, which a child fails at condition 1). What is
+> substrate-anchored is the **voucher**; the child is *attested by* a
+> substrate-anchored runtime, which is exactly S19's own mechanism applied
+> dynamically. "Substrate attestation" names the voucher's S19 check; the child
+> earns **runtime-attested process-instance identity**, never substrate class.
 
 This is the **first honest `strong` cross-process credential for an ephemeral
 agent** — the gap #810 names explicitly as having no answer today.
@@ -79,10 +89,25 @@ of of a pre-seeded table row.
 > rests on reading that phrase as scoped to **self-asserting callers that lack a
 > witnessing lifecycle-owner** — not as "no runtime can ever witness an ephemeral
 > process." An orchestrated child *has* a witnessing runtime (the earner), so it
-> is not a "non-substrate agent" in the relevant sense. If the operator's intent
-> in #810 was the stronger universal reading, this RFC touches the ratified frame
-> and the reinterpretation must be confirmed before the cutover row opens. It is
-> surfaced here, not absorbed silently.
+> is not a "non-substrate agent" in the relevant sense.
+>
+> **Adversarial council 2026-06-17 settled the MERITS half of this question:** the
+> universal reading is **internally incoherent with the ratified frame**, because
+> a launchd S19 resident is *also* an ephemeral process that admits only copyable
+> strings from its own mouth — yet earns strong cross-process via a trusted
+> third-party (kernel/launchd) attestation, which #810 explicitly **preserves** as
+> the one honest strong path. A truly universal "ephemeral ⇒ no strong
+> cross-process" would delete S19. So the only frame-coherent scope of "by
+> construction" is **"no strong from the process's *own self-assertion*"** — which
+> *is* the narrow reading. The narrow reading is therefore **forced by S19's
+> survival**, not a free reinterpretation.
+>
+> **What remains genuinely operator-intent:** only whether the operator, when
+> ratifying #810, *meant* the (now-shown-incoherent) universal or the (forced)
+> narrow scope. The merits no longer hinge on it — but since #810 is operator-
+> ratified and identity is writer-locked, confirm the reading before the cutover
+> row opens. The decision has shrunk from "is the third row legitimate?" to "ack
+> the narrow scope you were already committed to by keeping S19."
 
 ## 2. Scope boundary (state plainly)
 
@@ -117,6 +142,22 @@ load-bearing constraint of the whole design. If implementation cannot put the
 orchestrator on a UDS peer-cred channel to governance, the design does not ship —
 a bearer-token vouch is explicitly rejected (it would re-introduce the S19/#802
 copyable-secret vector at the voucher).
+
+> **THE SINGLE SEAM (adversarial council 2026-06-17, both reviewers converged).**
+> The entire merits-case for this design — everything that makes the child's
+> `strong` *earned* rather than a better-dressed #807 — rests on **one
+> implementation invariant**: the `vouch_child` write MUST be gated by the same
+> `verify_substrate_at_resume` peer-cred check that proves the caller is the
+> enrolled orchestrator (§4.2 step 3). The live UDS socket is **mode 0666**, so
+> *any* local process can connect to it (a pre-existing S19 defect — see O4
+> footnote). If `vouch_child` is ever an **ungated** endpoint on that socket, any
+> local process calls `vouch_child(attacker_uuid, attacker_pid, attacker_start)`,
+> the row is written, and its `strong` is as unchecked as any bearer token — the
+> third row collapses straight back into #807. This invariant is **more important
+> than the #810 interpretation question**: the #810 reading is forced by S19's
+> survival (see §1), but *this* seam can be silently broken in code. A cutover
+> acceptance test (§8) must assert a non-orchestrator UDS caller's `vouch_child`
+> is refused.
 
 What this design **does** honestly claim:
 
@@ -363,6 +404,22 @@ orchestrator says it is, right now*, and claims nothing about continuity beyond
 the process. Cross-restart continuity for orchestrated agents remains
 unearned-by-design and is explicitly out of scope.
 
+**On "process-instance layer, consumed cross-process" (council seam, resolved).**
+The taxonomy sorts layers by *what survives a process boundary*, and
+process-instance continuity does **not** survive — so a *cross-process credential*
+cannot be a process-instance-*continuity* claim. The vouch is not one. What
+crosses the boundary is **not the child's continuity** (that stays inside the
+child process and dies with it) but an **external attestation of an instantaneous
+fact** — "this PID is the process I spawned, right now" — made by one process
+(orchestrator), read by another (governance). That is structurally identical to
+how an S19 launchd `substrate_claim` already works: launchd witnesses a resident,
+and a *different* process (governance) reads the attestation. Nobody calls S19 "a
+cross-process use of within-process continuity"; it is a trusted third party
+reporting an observation. The vouch is the same pattern on the process-instance
+layer instead of the substrate layer. So the conferred tier is **attested
+process-instance identity at an instant**, never "process-instance continuity
+that travels."
+
 ## 7. Open questions (for council)
 
 - **O1 — RESOLVED (council 2026-06-17) toward distinct `orchestrator_vouched`.**
@@ -452,7 +509,16 @@ unearned-by-design and is explicitly out of scope.
 3. **DEFERRED cutover (post-2026-06-24 gate, separate PRs).** UDS vouch client in
    Elixir; `vouch_child` handler; child-resolution gate in `resolution.py`; SDK
    UDS routing for orchestrated children; voucher enrollment. Each single-concern,
-   operator-gated, identity-writer-locked.
+   operator-gated, identity-writer-locked. **Mandatory acceptance test (the §3
+   single seam):** a UDS caller whose peer-cred does **not** verify as the enrolled
+   orchestrator (`verify_substrate_at_resume` → not accepted) must have its
+   `vouch_child` **refused** — assert an attacker-chosen `(uuid, pid, start_tvsec)`
+   never writes a `vouched_bindings` row. Plus a PID-reuse-window test (O2/O3) and
+   a child-resolution test that a `start_tvsec` mismatch resolves weak, never
+   strong. **Prerequisite (pre-existing defect to fix first):** reconcile the live
+   `governance.sock` to mode 0600 — it is currently 0666 (`_tighten_socket_mode`
+   ran per the log but something re-bound it), which widens the connect population
+   from same-UID to any local user for S19 *today*, independent of this design.
 
 ## 9. Non-goals
 
@@ -476,7 +542,24 @@ unearned-by-design and is explicitly out of scope.
   proof_origin → `substrate_attested` is net-new) and corrected in §5.
 - **O4 feasibility (HTTP-over-UDS from BEAM): CONFIRMED VIABLE.** OTP 28,
   live `governance.sock`; client is net-new code, not a blocker (§7 O4).
-- **OPEN operator call:** the #810 "by construction" reinterpretation (§1 ⚠ box) —
-  must be confirmed before the cutover row opens.
+- **Adversarial council 2026-06-17 (second pass, on the blocking decision):** two
+  reviewers tasked to *break* the narrow reading.
+  - **Merits verdict: the narrow reading SURVIVES** — forced by S19's survival
+    (universal reading deletes S19, which #810 preserves). The earned/performative
+    line is drawn at *verification*; kernel peer-cred is verification #807's
+    fingerprint-pin structurally lacks, so the third row is different in **kind**,
+    not merely strength.
+  - **Two label wounds folded:** §0 "substrate-attested" → "runtime-attested" (the
+    child has no substrate of its own); §6.3 clarified that what crosses processes
+    is an *attestation of an instantaneous fact*, not within-process continuity.
+  - **The single load-bearing seam elevated (§3 callout):** `vouch_child` MUST be
+    peer-cred-gated — this is *more* fragile than the #810 question and gets a
+    mandatory cutover acceptance test (§8).
+  - **Pre-existing live defect surfaced:** `governance.sock` is mode 0666 not 0600
+    (S19 connect population is wider than the listener claims) — flagged for a
+    fix-first prerequisite at cutover, independent of this design.
+- **OPEN operator call (now intent-only):** acknowledge the narrow #810 scope
+  (§1 ⚠ box) before the cutover row opens. The merits are settled; only the
+  intent confirmation remains.
 - **Implementation correctness: NOT GATED** — lives in the PoC tests + the
   deferred cutover's adversary suite.

--- a/docs/proposals/orchestrator-vouched-identity-v0.md
+++ b/docs/proposals/orchestrator-vouched-identity-v0.md
@@ -1,0 +1,482 @@
+# Orchestrator-Vouched Identity — v0 (design + inert PoC seam)
+
+**Created:** June 17, 2026
+**Status:** DESIGN-FIRST RFC, **council-reviewed 2026-06-17** (dialectic-knowledge-architect:
+sound-with-changes; feature-dev:code-reviewer: 2 critical + 3 important, all folded;
+live-verifier: O4 feasibility **CONFIRMED**, 1 refuted claim corrected). No live
+cutover. Wave 3 deferred to the 2026-06-24 gate read. This doc is the gate artifact;
+an inert/flag-gated PoC seam may open after this review.
+**Author identity:** `04d9ae79-fb64-4cba-b5f3-6b88feb5121a` (fresh process-instance, no lineage).
+**Companion to:** `docs/ontology/identity.md` (§"Transport-level continuity",
+Appendix "Substrate-Earned Identity"); `docs/proposals/s19-attestation-mechanism.md`;
+`docs/proposals/agent-orchestrator-beam-v0.md`; issues #807, #810, #805 (S19 substrate-gate).
+**Writer-locked surface:** identity (docs + `src/mcp_handlers/identity/` + gov-plugin).
+Operator is the merge gate. Do NOT auto-merge.
+
+---
+
+## 0. The one-sentence claim
+
+An agent that the BEAM orchestrator actually **spawned and owns** can be moved
+from the "non-substrate, unverifiable" identity class into a **substrate-attested**
+class — by having the orchestrator (itself S19-enrolled, speaking to governance
+over the already-trusted UDS peer-cred channel) **vouch** the child's
+`(uuid, os_pid, start_tvsec)` at spawn, so the child's later calls resolve at a
+genuine `strong` tier by *proof*, not by echoing a copyable string.
+
+This is the **first honest `strong` cross-process credential for an ephemeral
+agent** — the gap #810 names explicitly as having no answer today.
+
+## 1. Why this exists (the problem #807/#810 left open)
+
+Issues #807/#810 concluded, operator-ratified, now in `identity.md`:
+
+> There is **no honest `strong` cross-process credential for a non-substrate
+> agent, by construction.** An ephemeral process can only carry a *copyable
+> string* across its own boundary, and a copyable string cannot be cryptographic
+> proof. The only honest strong path is **substrate attestation** — a trusted
+> runtime witnesses the process and the server asks *it*, not the process's
+> self-claim.
+
+Today that path is **S19**: OS kernel + launchd + UDS peer-cred, available to
+long-lived launchd residents only. Live state confirms the narrowness — exactly
+**one** agent is enrolled in `core.substrate_claims` (Sentinel,
+`f92dcea8-…`); every other agent is in the unverifiable class.
+
+#810's ratified framing draws the line:
+
+- **Substrate-anchored agents** (residents): cross-process strong is earned via
+  S19 attestation (Option C) — *not* a token.
+- **Session-like agents** (Claude Code, Codex, SDK callers): **no honest strong
+  cross-process tier.** Their legit writes are same-process; cross-process is
+  genuinely unproven and should resolve weak/medium.
+
+This RFC adds a **third row** to that table that #810 did not enumerate, because
+the orchestrator did not yet vouch:
+
+| Agent class | Spawned by | Honest cross-process strong path |
+|---|---|---|
+| Substrate-anchored resident | launchd | **S19** (static substrate_claim, peer-cred) |
+| Session-like (Claude Code / Codex / external SDK) | its own harness | **none** — weak/medium, by construction (#810) |
+| **Orchestrated ephemeral** (this RFC) | **BEAM orchestrator** | **orchestrator vouch** (dynamic substrate_claim, peer-cred) |
+
+### The insight (from the mission framing)
+
+The *earner* of strong identity isn't any specific runtime — it is **"having a
+lifecycle-owner the server can interrogate."** S19's earner is launchd. The BEAM
+OTP runtime is a **second instance of that same earner**: when the orchestrator
+spawns a child via an OTP `Port`, BEAM witnessed the spawn, knows the child's
+`os_pid` (it reads `Port.info(:os_pid)` — see `agent_runner.ex:498`), tracks its
+liveness, and **a process cannot forge another process's PID**. So an
+*orchestrated* agent has a runtime that can be asked "did you spawn pid X as
+agent Y?" — which is precisely what a static launchd substrate_claim answers for
+a resident, except asked **dynamically, per-spawn, of a trusted voucher** instead
+of of a pre-seeded table row.
+
+> **⚠ OPERATOR CALL — reinterpretation of #810's "by construction."** #810's
+> ratified phrasing reads as a universal: "no honest strong cross-process
+> credential for a non-substrate agent, *by construction*." This RFC's third row
+> rests on reading that phrase as scoped to **self-asserting callers that lack a
+> witnessing lifecycle-owner** — not as "no runtime can ever witness an ephemeral
+> process." An orchestrated child *has* a witnessing runtime (the earner), so it
+> is not a "non-substrate agent" in the relevant sense. If the operator's intent
+> in #810 was the stronger universal reading, this RFC touches the ratified frame
+> and the reinterpretation must be confirmed before the cutover row opens. It is
+> surfaced here, not absorbed silently.
+
+## 2. Scope boundary (state plainly)
+
+This helps **only agents BEAM actually spawns and owns** through
+`AgentOrchestrator.AgentRunner`. It does **not** help:
+
+- **Claude Code / Codex / external SDK callers** — spawned by their own harness,
+  not BEAM. They stay copyable-string callers, weak/medium cross-process, exactly
+  as #810 ratified. Out of scope.
+- **Routing the governance *request path* through BEAM** — that is the wrong end
+  of the wire. Caller identity is established *upstream* of which server answers
+  the call; moving the answering server to BEAM changes nothing about who the
+  caller is. "BEAM" in this RFC means the **orchestration/lease plane**, NOT a
+  governance-MCP rewrite (that is the separate Wave 1–3 handler-dispatch track).
+
+The population this serves is **currently empty** — the orchestrator is inert
+(`agent-orchestrator-beam-v0.md`: "NOT merged to any running surface… nothing
+spawns through it yet"). That is *why* this is design-first: we define the honest
+identity contract **before** anything spawns through the orchestrator, so the
+first orchestrated agent is born attested rather than retrofitted.
+
+## 3. The honest seam (state this loudest)
+
+> **An orchestrator-vouch is only as strong as the orchestrator→governance
+> channel.** If that channel is a bearer token, we have *relocated* the
+> copyable-string problem (N copyable child strings → 1 copyable voucher token),
+> not killed it.
+
+Therefore the vouch channel **MUST be UDS peer-cred** (the orchestrator is itself
+S19-enrolled and governance peer-creds *it*), **NOT a bearer token.** This is the
+load-bearing constraint of the whole design. If implementation cannot put the
+orchestrator on a UDS peer-cred channel to governance, the design does not ship —
+a bearer-token vouch is explicitly rejected (it would re-introduce the S19/#802
+copyable-secret vector at the voucher).
+
+What this design **does** honestly claim:
+
+- **Trust concentration (re-shaped, not net-eliminated).** The number of
+  *copyable secrets* at the child end drops to **zero** (the child presents a
+  non-secret uuid, proven by kernel peer-cred). What replaces N copyable strings
+  is **one anchorable voucher** (kernel-attested, binary/label-checked) **plus two
+  named runtime assumptions**: (i) BEAM correctly reports the os_pid of its own
+  Port child, and (ii) the `(pid, start_tvsec)` pair holds across the vouch
+  window. This is honestly *fewer copyable secrets and a smaller, anchorable
+  attack surface* — not *fewer total trust assumptions*. We do not claim net trust
+  reduction; we claim the trust is moved onto an anchorable voucher and made
+  kernel-attested at both ends.
+- **End-to-end PID-attested binding** for the child: governance peer-creds the
+  child's *own* PID when it connects over UDS, and matches it against the
+  orchestrator-vouched `(uuid, pid, start_tvsec)`. Neither the orchestrator nor
+  the child presents a copyable secret; both ends are kernel-attested.
+
+What this design does **NOT** claim:
+
+- Pure end-to-end cryptographic non-forgeability independent of the runtime. The
+  guarantee is **conditioned on** (a) the kernel's peer-cred being honest, (b)
+  the orchestrator's binary being the enrolled one, and (c) BEAM correctly
+  reporting the os_pid of its own Port child. (a) is the project-wide substrate
+  assumption (same as S19); (b) is the S19 enrollment check (label + exec-path +
+  start_tvsec); (c) is OTP Port semantics. We claim trust *concentration onto an
+  anchorable voucher*, not trust *elimination*.
+
+## 4. Mechanism
+
+### 4.1 Topology of the vouch
+
+```
+  ┌─────────────────────┐    (1) S19 enroll (operator, once)
+  │ core.substrate_claims│◄───  voucher_uuid → label+exec_path of the
+  └─────────────────────┘       BEAM node hosting the orchestrator
+            ▲
+            │ (3) peer-cred verify voucher  ── UDS, kernel-attested PID
+  ┌─────────┴───────────┐
+  │  governance MCP      │◄══════════════════════╗
+  │  (UDS listener)      │   (4) vouch_child(     ║  trusted channel
+  │                      │        child_uuid,     ║  (NOT a bearer token)
+  │  core.vouched_       │        child_os_pid,   ║
+  │  bindings (TTL'd)    │        child_start,    ║
+  └─────────┬───────────┘        spawn_reason)   ║
+            │                                     ║
+            │ (6) peer-cred child PID,    ┌───────╨────────────┐
+            │     match vouched binding   │  AgentOrchestrator  │
+            ▼                             │  (BEAM, S19-enrolled)│
+  ┌─────────────────────┐                └───────┬────────────┘
+  │ child resolves at    │                        │ (2) Port.open → os_pid
+  │ tier: strong         │   (5) child onboards    │     read start_tvsec
+  │ proof_origin:        │◄───  over UDS  ─────────┤
+  │ orchestrator_vouched │   (UNITARES_UDS_SOCKET  │  AgentRunner GenServer
+  └─────────────────────┘    provisioned by orch)  └─ Port → child OS process
+```
+
+### 4.2 Step by step
+
+1. **Voucher enrollment (operator, once).** The BEAM node hosting the
+   orchestrator is S19-enrolled: a `core.substrate_claims` row keyed by the
+   orchestrator's governance `voucher_uuid`, with `expected_launchd_label` and
+   `expected_executable_path` matching its launchd job. **Live posture (verified
+   by live-verifier 2026-06-17):** the orchestrator is a **standalone OTP app**
+   (`agent_orchestrator/mix.exs`, its own `Application`, its own `start.sh`,
+   Bandit control surface on :8789) — it is **NOT** embedded in or a dependency of
+   the lease-plane node (lease-plane's mix deps are only postgrex/jason/plug/
+   bandit/stream_data). It currently has **no launchd plist installed** and is not
+   running. So enrollment targets a **new dedicated `com.unitares.agent-orchestrator`
+   launchd job** — a clean S19 enrollment, not a shared one. Two deployment
+   prerequisites, neither code: (i) install the orchestrator plist; (ii) enroll the
+   voucher UUID. Note `scripts/ops/enroll_resident.py` has no BEAM-node enrollment
+   path today — the `expected_executable_path` for a BEAM job is the `beam.smp` /
+   release binary, not a Python interpreter; the enrollment tool needs a small
+   extension (cutover-row work). No vouch is trusted until the voucher is enrolled.
+
+2. **Spawn (existing code).** `AgentRunner.init/1` opens the Port and reads
+   `os_pid` (`agent_runner.ex:498`). The orchestrator additionally reads the
+   child's `start_tvsec` (BEAM has no built-in for this; candidate: a one-shot
+   `proc_pidinfo` via a tiny port/NIF, or read it from the child's first
+   governance call — see §7 open question O3). It already generates/owns the
+   child's governance `holder_agent_uuid` (`agent_runner.ex:420`).
+
+3. **Voucher verification (per orchestrator connection).** The orchestrator
+   opens a UDS connection to governance. Governance reads the kernel-attested
+   peer PID (`uds_listener.py` → `scope["unitares_peer_pid"]`) and runs the
+   **existing** `verify_substrate_at_resume` flow against the voucher's
+   substrate_claim. If the peer is not the enrolled orchestrator, every vouch on
+   that connection is refused. This reuses S19 unchanged — the voucher is just
+   another substrate-anchored agent.
+
+   (Note: `verify_substrate_at_resume` is a read-only **check** returning a
+   `VerificationResult` — it verifies the *caller is the enrolled orchestrator*
+   but does **not** write the vouch. The vouch write in step 4 is entirely new
+   code, not a mode of the existing gate — code-reviewer I3.)
+
+4. **Vouch (new code, over the trusted channel).** The orchestrator calls a new
+   governance operation `vouch_child(child_uuid, child_os_pid, child_start_tvsec,
+   spawn_reason)`. Governance, having peer-cred-verified the *caller* is the
+   enrolled orchestrator, writes a **short-TTL** `core.vouched_bindings` row:
+   `(child_uuid, child_os_pid, child_start_tvsec, voucher_uuid, expires_at)`. This
+   is a **dynamic, ephemeral substrate_claim** — semantically the same as the
+   static resident table, but asserted by a trusted runtime per-spawn instead of
+   pre-seeded by an operator. `child_start_tvsec` is **required, not optional** in
+   this row (step 6 + O3) — it is the anti-PID-reuse anchor; a row without it must
+   not confer strong.
+
+5. **Child connects (provisioned).** The orchestrator provisions
+   `UNITARES_UDS_SOCKET` into the child env (same explicit-wins provisioning
+   mechanism already used for `UNITARES_PARENT_AGENT_ID` / `UNITARES_SERVER_URL`
+   in `agent_runner.ex` `candidate_env/2`). The child's SDK routes governance
+   calls over UDS (the S19 SDK change, `s19-attestation-mechanism.md §SDK changes`).
+
+6. **Child resolution (new gate).** When the child onboards/calls over UDS,
+   governance reads the child's *own* kernel-attested peer PID **and its live
+   `start_tvsec`**, looks up `vouched_bindings` by pid, and confirms **all three**:
+   the row's `start_tvsec` is present and equals the live `start_tvsec`, the pid
+   matches, **and** the child's claimed `child_uuid` matches the row's
+   `child_uuid`. **`start_tvsec` is mandatory-for-strong at resolution time** — a
+   PID-only match (no verified start time) resolves weak, never strong (the
+   start-time pair is the only thing defeating PID-reuse within the TTL window).
+   On full match → confer the new strong tier. On mismatch or expiry → fall
+   through to existing gating (weak/medium) — the vouch gate is **additive and
+   fail-open to the status quo**, never a new denial path for non-orchestrated
+   callers.
+
+   **Cache caveat (code-reviewer I2):** S19's `VerifiedPairsCache`
+   (`verification.py`) is keyed by `agent_id → (pid, start_tvsec)` and cannot be
+   reused as-is — the vouch lookup is **pid → row** (the child's agent_id is not
+   known until the row is found), and two ephemeral children cycling through the
+   same OS pid within one TTL would collide on an agent_id-keyed cache. The vouched
+   resolution path keys on `(pid, start_tvsec)` from the `vouched_bindings` row
+   itself, not the S19 cache; the PoC's `verify_vouched_binding` keeps the
+   `cache`-shaped signature for parity but the cutover must use a pid-keyed (or
+   row-backed) structure.
+
+### 4.3 Why the child PID can't be self-asserted into strong
+
+The child never presents a copyable secret to *earn* strong. It presents its
+`child_uuid` (which is not secret — it's just a label). Strong is conferred only
+when the **kernel-attested PID of the connecting child** matches a binding that a
+**peer-cred-verified orchestrator** vouched. An impostor would need to (a) be
+running at the exact `os_pid` the orchestrator vouched, with (b) the matching
+`start_tvsec` — i.e., *be* the process BEAM spawned. The copyable thing (the
+uuid) is worthless without the PID the kernel attests, and the PID cannot be
+forged.
+
+## 5. Tier / proof_origin / label (the honest taxonomy)
+
+**Live taxonomy (verified by live-verifier 2026-06-17 — corrects the v0 draft):**
+the only two `proof_origin` values emitted anywhere are `caller_asserted`
+(http_api.py:298, session.py:637-641) and `server_inferred` (http_api.py:338,
+identity_step.py:437); the default is `None` (context.py:227). `caller_proven`
+is computed by **three independent hardcoded equality checks**, not a shared
+helper: `identity_payloads.py:601`, `phases.py:133`, and the source-classification
+in `session.py` via the `_CALLER_ASSERTED_SOURCES` set (`session.py:619`). The
+strict write-gate (`phases.py:300`) refuses **only** `proof_origin == "server_inferred"`;
+`None`/`unknown` pass **fail-open**.
+
+**Important correction:** a successful **S19** substrate resume currently stamps
+**no** `proof_origin` at all (`handlers.py:760-767` sets `_partc_owned = True` and
+logs `[SUBSTRATE_VERIFIED]` but never calls `set_session_proof_origin`). It passes
+strict only because its `session_resolution_source` is `agent_uuid_direct[_fastpath]`
+(already in `_STRONG_IDENTITY_SOURCES`) **and** `None != "server_inferred"`. So
+`substrate_attested` **does not exist today** — it is net-new, not "shared with
+S19." A vouched binding must therefore mint a positive proof_origin (so it passes
+strict *by proof*, not by the fail-open accident the S19 path currently relies on).
+
+A vouched binding is **not** "caller-asserted" (the child asserted nothing
+provable; the *orchestrator* attested). Forcing it under `caller_asserted` would
+lie about *who* proved it.
+
+**Proposed (council-leaning — O1 resolved toward distinct):**
+
+- New `proof_origin` value **`orchestrator_vouched`** (distinct, *not* shared with
+  a hypothetical S19 `substrate_attested`). Audit-separability is the deciding
+  argument: a dynamic runtime-asserted per-spawn vouch and a static
+  operator-seeded launchd claim have different trust derivations and failure modes
+  (O5: voucher death); collapsing them into one origin loses exactly the audit
+  seam this section wants. `caller_proven` becomes
+  `proof_origin in {caller_asserted, orchestrator_vouched}` — a small explicit
+  widening, *not* a default-true.
+- **This is a multi-site change, not one line (code-reviewer C1).** The widening
+  must be applied at **all three** `caller_proven` sites (`identity_payloads.py:601`,
+  `phases.py:133`) and the new source/origin wired consistently through
+  `session.py`'s `_mark` path. Miss one and the strict gate keeps the old
+  `== "caller_asserted"` test and refuses vouched writes — defeating the
+  mechanism. The cutover should first **extract a shared helper**
+  (`is_caller_proven(proof_origin)`) so the set is defined once. `_how_to_strengthen`
+  in both files must also learn the new value or it emits a misleading
+  "how to reach strong" hint to an already-strong agent.
+- New `session_source` **`beam_orchestrated_attestation`** added to
+  `_STRONG_IDENTITY_SOURCES` (`identity_payloads.py:11-20`). This is the honest,
+  auditable label: "strong because the orchestrator attested over a peer-cred
+  channel," distinct from the #807 tokenless-prefix-echo that *looks* strong but
+  is unverifiable.
+- The label must read true under the `identity.md` taxonomy: it is
+  **runtime-attested process-instance identity** (the process-instance layer is
+  "automatic — present whenever the process runs," `identity.md:44`), **not**
+  substrate-*earned* continuity. "Earned" is the Appendix's reserved term for the
+  three-condition cross-restart pattern, which a child cannot meet (its substrate
+  is the orchestrator's, not its own — §6.3). The vouch attests **identity at an
+  instant**, never continuity.
+
+This is the **opposite** of the #807 debt: #807 is a binding that labels itself
+strong without proof; this is a binding that is *actually* proven (peer-cred both
+ends) and gets labeled strong honestly. The RFC must not let the label drift back
+toward the #807 over-claim — hence the distinct `session_source` so audits can
+tell the two apart.
+
+## 6. Interactions
+
+### 6.1 With #425 strict gate
+
+This is a **legitimate way for an orchestrated agent to PASS strict by proof.**
+Under strict, `server_inferred` writes are refused (`phases.py:300`). A vouched
+child carries `proof_origin = orchestrator_vouched` → `caller_proven = true` →
+passes. So when #425 defaults on (stage 4), orchestrated agents do not need a
+copyable token to write — they pass by attestation. This is exactly the
+"strong-by-proof, not by over-claim" path #807/#810 wanted to exist.
+
+### 6.2 With `substrate_claims` enrollment
+
+**The orchestrator's single enrollment covers all its children.** Children do
+**not** each need a static `substrate_claims` row — they cannot (no launchd
+label, no dedicated exec path; `claude -p` and a python worker share an
+interpreter path with everything else, so a static exec-path check is
+meaningless for them). The vouched binding is the *dynamic* analogue: one static
+enrollment (the voucher) + N ephemeral vouched rows (the children). This is the
+trust-concentration claim made concrete in the schema.
+
+### 6.3 With the Appendix three conditions (`identity.md` "Substrate-Earned Identity")
+
+The Appendix requires **dedicated substrate + sustained behavior + declared
+role** for substrate-earned continuity. A child agent satisfies these *only for
+the lifetime of its process-instance*, and the substrate is the **orchestrator's**,
+not the child's own. So the honest framing is: the vouch confers strong identity
+at the **process-instance layer** (the layer `identity.md` calls "the only layer
+phenomenologically continuous"), **not** cross-restart substrate-earned
+continuity. A child that exits and respawns is a **new** agent with a **new**
+vouch — never a resumed one. This keeps us inside axiom #3 ("build nothing that
+appears more alive than it is"): the vouch proves *this process is who the
+orchestrator says it is, right now*, and claims nothing about continuity beyond
+the process. Cross-restart continuity for orchestrated agents remains
+unearned-by-design and is explicitly out of scope.
+
+## 7. Open questions (for council)
+
+- **O1 — RESOLVED (council 2026-06-17) toward distinct `orchestrator_vouched`.**
+  `substrate_attested` does not exist today (live-verifier) and the S19 path stamps
+  nothing, so there is no value to "share." Audit-separability (distinct trust
+  derivation + distinct failure mode under voucher death, O5) decides it: mint a
+  distinct `orchestrator_vouched`. See §5. Re-opens only if the operator wants S19
+  *also* given a positive stamp and a unified attestation origin.
+- **O2 — TTL and re-vouch cadence.** The vouched binding is short-TTL (candidate:
+  match the lease TTL, 300s, since the orchestrator already heartbeats the
+  child's `agent:/` presence lease). Does the orchestrator re-vouch on a timer, or
+  does the binding ride the existing presence-lease lifecycle (release on child
+  exit → expire the vouch)? Tying it to the presence lease (already
+  self-healing/reaped, `file-lease-leak` project) avoids a second timer.
+- **O3 — How does the orchestrator learn the child's `start_tvsec`? RESOLVED:
+  option (a) only.** BEAM gives `os_pid` but not start time, so the orchestrator
+  needs a tiny `proc_pidinfo` shim (mirror `peer_attestation.read_process_start_time`
+  on the BEAM side) and vouches the full `(uuid, pid, start_tvsec)`.
+  **Option (b) — server-side TOFU (vouch only `(uuid, pid)`, let governance pin
+  start_tvsec on first contact) — is REJECTED**, with the same status as the
+  bearer-token channel in §3. TOFU-within-window means the *first* connector at
+  that pid defines the binding, which is exactly the same-fingerprint co-resident
+  free-ride class (S19/#802 residual); it reintroduces a self-asserted seam at the
+  child end and would make the strong label partly performative
+  (dialectic-knowledge-architect, seam 2). A vouch without a voucher-supplied
+  `start_tvsec` may only ever resolve weak.
+- **O4 — Can the orchestrator reach the UDS listener? CONFIRMED VIABLE
+  (live-verifier 2026-06-17).** The orchestrator builds against **Erlang/OTP 28 /
+  Elixir 1.19.5**, so `:gen_tcp.connect({:local, path}, 0, …)` AF_UNIX (OTP 19+) is
+  available. The governance UDS listener is **live**: `UNITARES_UDS_SOCKET =
+  /Users/cirwel/.unitares/governance.sock` is set in the gov-mcp plist and the
+  socket exists (`srw-rw-rw-`, last bound today). It speaks HTTP framing over
+  AF_UNIX (`uds_listener.py`, uvicorn H11). **The remaining cost, not a blocker:**
+  `:httpc` cannot do AF_UNIX, and the existing `LeasePlaneClient` (`:httpc` + TCP)
+  is **non-portable** to UDS — the vouch client is **net-new code** (raw HTTP/1.1
+  over `:gen_tcp` `{:local, …}`, or a `Mint`/`Finch` custom transport;
+  code-reviewer I1). The honest seam (§3) is therefore *satisfiable*: a kernel
+  peer-cred UDS channel exists end-to-end; the only work is writing the BEAM-side
+  HTTP-over-UDS client. (Footnote: the live socket is mode `0666`, not the `0600`
+  the listener's `_tighten_socket_mode` intends — same-UID threat boundary still
+  holds on this single-user host, but worth reconciling at cutover.)
+- **O5 — Voucher liveness ↔ child validity.** If the orchestrator BEAM node
+  dies, are outstanding vouched bindings still honored until TTL? Recommend: yes,
+  TTL-bounded (the vouch was valid when made; the child is still the process it
+  was). But a *re-vouch* requires a live, re-verified orchestrator. This mirrors
+  S19's per-server-lifetime cache semantics.
+
+## 8. Sequencing (design → inert PoC → deferred cutover)
+
+1. **This RFC + council review.** (dialectic-knowledge-architect + feature-dev:
+   code-reviewer + live-verifier.) Gate: design ratified, O4 feasibility
+   confirmed.
+2. **Inert PoC seam (flag-gated, no wiring) — SHIPPED IN THIS PR.** All behind
+   `UNITARES_ORCHESTRATOR_VOUCH` (default off, inert):
+   - `core.vouched_bindings` DDL **authored as a reviewable constant**
+     (`vouch.VOUCHED_BINDINGS_DDL`), **not** a `db/postgres/migrations/NNN_*.sql`
+     slot. Rationale: an unapplied migration slot shows as drift in the *local*
+     `unitares_doctor` `schema_migrations` check until the operator applies it, and
+     this PoC is deferred past 2026-06-24 — a real slot would leave the local
+     doctor red for weeks. The cutover row promotes the constant verbatim into the
+     next real slot and applies it manually (MANUAL-migration discipline).
+   - A pure module `src/substrate/vouch.py` mirroring `verification.py`'s shape:
+     `VouchedBinding` dataclass + `verify_vouched_binding(binding, *, peer_pid,
+     live_start_tvsec, claimed_child_uuid, now_epoch) -> VerificationResult`,
+     **with 24 unit tests** (`tests/test_substrate_vouch.py`, all green), and
+     **NOT wired into `resolution.py`.** Pure logic, no DB, no async, no
+     `set_session_proof_origin`. Signature differs from S19's `cache`-shaped one
+     deliberately (code-reviewer I2): lookup is pid→row, anti-reuse anchor is the
+     row's `start_tvsec` vs the child's live `start_tvsec`, not an agent_id-keyed
+     cache.
+   - The `proof_origin`/`session_source` additions left **unwired** (constants
+     defined in `vouch.py` only, not referenced by the live tier path) until the
+     cutover row.
+   - **Inertness invariant (code-reviewer C2 — must hold for the PoC to be safe):**
+     do **NOT** add `beam_orchestrated_attestation` to `_STRONG_IDENTITY_SOURCES`
+     and do **NOT** add it to `session.py`'s `_CALLER_ASSERTED_SOURCES` (line 619)
+     in the PoC — that set is a **live gating point** read at every
+     `derive_session_key`. Adding the new source there (even "just to make a test
+     pass") without the `vouched_bindings` lookup would let *any* caller who can
+     produce that `session_resolution_source` reach `caller_proven` with no vouch
+     check. The PoC's tests must construct `VouchedBinding`/`VerificationResult`
+     objects directly, never route through the live resolution path. A drift-guard
+     test should assert the new source is absent from both live sets while the flag
+     is off.
+   - Elixir side: **no code** in the PoC. A doc note in `agent_orchestrator`
+     pointing at this RFC. The Elixir HTTP-over-UDS vouch client is cutover-row work.
+3. **DEFERRED cutover (post-2026-06-24 gate, separate PRs).** UDS vouch client in
+   Elixir; `vouch_child` handler; child-resolution gate in `resolution.py`; SDK
+   UDS routing for orchestrated children; voucher enrollment. Each single-concern,
+   operator-gated, identity-writer-locked.
+
+## 9. Non-goals
+
+- Helping session-like agents (Claude Code / Codex / external SDK) reach strong
+  cross-process — explicitly ruled out by #810; unchanged here.
+- A bearer-token vouch channel — rejected at §3 (relocates the problem).
+- Cross-restart continuity for orchestrated children — out of scope by §6.3.
+- Routing governance request-handling through BEAM — wrong end of the wire (§2).
+- Any live deploy before the 2026-06-24 Wave-3 gate read.
+- Retiring `continuity_token` or changing the #807 tokenless-echo down-rating —
+  that is #807/#810's own track; this RFC only *adds* the third honest row.
+
+## 10. Reviewer gate state
+
+- **Design selection: COUNCIL-REVIEWED 2026-06-17, sound-with-changes (all
+  folded).** dialectic-knowledge-architect: ontology sound; the "earned" wording,
+  O3-TOFU demotion, mandatory-`start_tvsec`, N→1 honesty, and #810 reinterpretation
+  surfacing are incorporated. feature-dev:code-reviewer: C1 (multi-site
+  `caller_proven`), C2 (`_CALLER_ASSERTED_SOURCES` inertness invariant), I1–I3 all
+  incorporated. live-verifier: 5 claims confirmed, 1 refuted (S19 stamps no
+  proof_origin → `substrate_attested` is net-new) and corrected in §5.
+- **O4 feasibility (HTTP-over-UDS from BEAM): CONFIRMED VIABLE.** OTP 28,
+  live `governance.sock`; client is net-new code, not a blocker (§7 O4).
+- **OPEN operator call:** the #810 "by construction" reinterpretation (§1 ⚠ box) —
+  must be confirmed before the cutover row opens.
+- **Implementation correctness: NOT GATED** — lives in the PoC tests + the
+  deferred cutover's adversary suite.

--- a/docs/proposals/orchestrator-vouched-identity-v0.md
+++ b/docs/proposals/orchestrator-vouched-identity-v0.md
@@ -102,12 +102,13 @@ of of a pre-seeded table row.
 > *is* the narrow reading. The narrow reading is therefore **forced by S19's
 > survival**, not a free reinterpretation.
 >
-> **What remains genuinely operator-intent:** only whether the operator, when
+> **What remained genuinely operator-intent:** only whether the operator, when
 > ratifying #810, *meant* the (now-shown-incoherent) universal or the (forced)
-> narrow scope. The merits no longer hinge on it — but since #810 is operator-
-> ratified and identity is writer-locked, confirm the reading before the cutover
-> row opens. The decision has shrunk from "is the third row legitimate?" to "ack
-> the narrow scope you were already committed to by keeping S19."
+> narrow scope. **✅ RATIFIED narrow, operator, 2026-06-17.** The narrow scope —
+> "no strong from the process's own self-assertion; substrate/runtime attestation
+> by a trusted witness is the honest strong path" — is the committed reading. The
+> third row is legitimate under it. (This unblocks the *design* gate only; the
+> cutover is still deferred to the 2026-06-24 Wave-3 read.)
 
 ## 2. Scope boundary (state plainly)
 
@@ -558,8 +559,7 @@ that travels."
   - **Pre-existing live defect surfaced:** `governance.sock` is mode 0666 not 0600
     (S19 connect population is wider than the listener claims) — flagged for a
     fix-first prerequisite at cutover, independent of this design.
-- **OPEN operator call (now intent-only):** acknowledge the narrow #810 scope
-  (§1 ⚠ box) before the cutover row opens. The merits are settled; only the
-  intent confirmation remains.
+- **✅ Operator call RESOLVED 2026-06-17: narrow #810 scope ratified** (§1 ⚠ box).
+  Design gate clear; cutover still deferred to the 2026-06-24 Wave-3 read.
 - **Implementation correctness: NOT GATED** — lives in the PoC tests + the
   deferred cutover's adversary suite.

--- a/src/substrate/vouch.py
+++ b/src/substrate/vouch.py
@@ -1,0 +1,249 @@
+"""Orchestrator-vouched identity — INERT proof-of-concept seam.
+
+⚠ THIS MODULE IS NOT WIRED INTO IDENTITY RESOLUTION. It is the pure-logic seam
+for the design in ``docs/proposals/orchestrator-vouched-identity-v0.md`` (Wave 3,
+deferred to the 2026-06-24 gate read). Nothing here is referenced by
+``src/mcp_handlers/identity/resolution.py``, the tier classifier
+(``identity_payloads.py``), or the strict write-gate (``phases.py``). Importing
+it has no effect on live identity resolution.
+
+The mechanism (full design in the RFC): the BEAM Agent Orchestrator — itself
+S19-enrolled and speaking to governance over the kernel-peer-cred UDS channel —
+VOUCHES for an ephemeral child it spawned by writing a short-TTL
+``core.vouched_bindings`` row ``(child_uuid, child_os_pid, child_start_tvsec,
+voucher_uuid, expires_at)``. When the child later connects over UDS, governance
+reads the child's *own* kernel-attested peer PID + live start time and matches
+them against the vouched row. On full match the child resolves at a genuine
+``strong`` tier (``proof_origin = orchestrator_vouched``) — the first honest
+strong cross-process credential for an ephemeral agent (the gap #807/#810 leaves
+open), earned by attestation, not by echoing a copyable string.
+
+This file deliberately mirrors the *shape* of ``src/substrate/verification.py``
+(S19) but with the differences the council flagged:
+
+- The lookup direction is **pid → row** (the child's agent_id is not known until
+  the row is found), so there is NO ``agent_id``-keyed ``VerifiedPairsCache`` here;
+  the anti-PID-reuse anchor is the ``start_tvsec`` stored *in the vouched row*
+  (supplied by the voucher) compared against the child's *live* ``start_tvsec``
+  at resolution (code-reviewer I2).
+- ``start_tvsec`` is **mandatory-for-strong**: a binding or a live read missing
+  it resolves to a rejection, never a weak-but-passing accept. Server-side TOFU
+  on ``start_tvsec`` is rejected by design (RFC O3 / dialectic seam 2).
+
+Boundary discipline (same as S19): pure logic only — no async, no DB, no
+``set_session_proof_origin``, no env reads beyond the inert flag helper. The DB
+table, the ``vouch_child`` handler, the BEAM HTTP-over-UDS client, and the
+resolution-gate wiring are all cutover-row work, gated on the operator confirming
+the #810 "by construction" reinterpretation (RFC §1 ⚠ box).
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+# Reuse the S19 result shape so the cutover gate can treat a vouch outcome and a
+# substrate-claim outcome uniformly at the call site.
+from src.substrate.verification import VerificationResult
+
+# ---------------------------------------------------------------------------
+# Inert flag + label constants (DEFINED, NOT WIRED).
+#
+# These names are the contract the cutover row will adopt. They are referenced
+# only inside this module and its tests; adding them to _STRONG_IDENTITY_SOURCES
+# or session.py's _CALLER_ASSERTED_SOURCES is explicitly OUT OF SCOPE for the PoC
+# (code-reviewer C2 inertness invariant — doing so would create a live gating
+# point with no vouch check behind it).
+# ---------------------------------------------------------------------------
+
+#: Master flag. Default off/inert. The cutover wiring (resolution gate, handler)
+#: must no-op unless this is truthy.
+VOUCH_FLAG_ENV = "UNITARES_ORCHESTRATOR_VOUCH"
+
+#: proof_origin value a vouched binding earns. DISTINCT from any S19 value
+#: (RFC O1 resolved): a dynamic per-spawn runtime vouch has a different trust
+#: derivation + failure mode than a static launchd substrate_claim.
+PROOF_ORIGIN_ORCHESTRATOR_VOUCHED = "orchestrator_vouched"
+
+#: session_source the cutover row will add to _STRONG_IDENTITY_SOURCES. Kept
+#: here (not there) so the PoC stays inert.
+SESSION_SOURCE_BEAM_ORCHESTRATED = "beam_orchestrated_attestation"
+
+
+def is_orchestrator_vouch_enabled() -> bool:
+    """Return whether the (inert, default-off) vouch path is enabled.
+
+    The cutover wiring gates on this; today nothing calls it in the live path.
+    Accepts the usual truthy spellings to match the project's other flag readers.
+    """
+    return os.environ.get(VOUCH_FLAG_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+# ---------------------------------------------------------------------------
+# Data shape
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class VouchedBinding:
+    """Snapshot of one ``core.vouched_bindings`` row.
+
+    Written by the (future) ``vouch_child`` handler after the voucher's own S19
+    peer-cred check passed, and read at child-resolution time. Frozen so it
+    cannot be mutated mid-verify.
+
+    ``child_start_tvsec`` is ``Optional`` only to model the *rejected* TOFU case
+    explicitly (a row that somehow lacks it must fail, not silently pass) — the
+    voucher is required to supply it (RFC O3).
+    """
+
+    child_uuid: str
+    child_os_pid: int
+    child_start_tvsec: Optional[int]
+    voucher_uuid: str
+    #: epoch seconds; the row is only valid while now < expires_at.
+    expires_at_epoch: int
+
+
+# ---------------------------------------------------------------------------
+# Pure verification
+# ---------------------------------------------------------------------------
+
+#: failure_code vocabulary (mirrors verification.py's style):
+#:   no_binding   — no vouched row for the connecting pid
+#:   expired      — the vouched row's TTL has passed
+#:   missing_start_tvsec — row or live read lacks start_tvsec (TOFU rejected)
+#:   pid_mismatch — (defensive) row pid != connecting pid
+#:   start_mismatch — live start_tvsec != vouched start_tvsec (PID reuse)
+#:   uuid_mismatch — child's claimed uuid != the vouched row's uuid
+
+
+def verify_vouched_binding(
+    binding: Optional[VouchedBinding],
+    *,
+    peer_pid: int,
+    live_start_tvsec: Optional[int],
+    claimed_child_uuid: str,
+    now_epoch: int,
+) -> VerificationResult:
+    """Decide accept/reject for a child resolving against a vouched binding.
+
+    Inputs are all caller-supplied facts; this function does no I/O. The caller
+    (cutover row) is responsible for: (a) reading the kernel-attested
+    ``peer_pid`` from the UDS scope, (b) reading the child's ``live_start_tvsec``
+    via ``peer_attestation.read_process_start_time(peer_pid)``, (c) looking up the
+    ``vouched_bindings`` row *by pid* and constructing ``binding``, and (d) on
+    accept, stamping ``proof_origin = PROOF_ORIGIN_ORCHESTRATOR_VOUCHED`` and
+    ``session_source = SESSION_SOURCE_BEAM_ORCHESTRATED``.
+
+    Check order is significant: existence → TTL → start-time presence (both
+    sides) → pid → start match → uuid. A failure short-circuits.
+    """
+    if binding is None:
+        return VerificationResult(
+            accepted=False,
+            reason=f"no vouched binding for pid {peer_pid}; child is not orchestrator-vouched",
+            failure_code="no_binding",
+        )
+
+    if now_epoch >= binding.expires_at_epoch:
+        return VerificationResult(
+            accepted=False,
+            reason=(
+                f"vouched binding for {binding.child_uuid} expired at "
+                f"{binding.expires_at_epoch} (now {now_epoch}); re-vouch required"
+            ),
+            failure_code="expired",
+        )
+
+    # start_tvsec is mandatory-for-strong on BOTH sides. A row without it means
+    # the voucher tried (or was coerced into) the rejected TOFU path; a live read
+    # without it means we cannot defeat PID reuse. Either way: reject, never a
+    # weak-pass (RFC O3 / dialectic seam 2).
+    if binding.child_start_tvsec is None:
+        return VerificationResult(
+            accepted=False,
+            reason=(
+                f"vouched binding for {binding.child_uuid} lacks child_start_tvsec; "
+                "server-side TOFU on start time is rejected by design"
+            ),
+            failure_code="missing_start_tvsec",
+        )
+    if live_start_tvsec is None:
+        return VerificationResult(
+            accepted=False,
+            reason=f"could not read live start_tvsec for connecting pid {peer_pid}",
+            failure_code="missing_start_tvsec",
+        )
+
+    if binding.child_os_pid != peer_pid:
+        # Defensive: the caller looked the row up BY pid, so this should not
+        # happen — but if a row is fetched by another key in a future refactor,
+        # never trust a pid that does not match the kernel-attested peer.
+        return VerificationResult(
+            accepted=False,
+            reason=(
+                f"vouched pid {binding.child_os_pid} != kernel-attested peer pid {peer_pid}"
+            ),
+            failure_code="pid_mismatch",
+        )
+
+    if binding.child_start_tvsec != live_start_tvsec:
+        # Same pid, different start time → the pid was recycled to a different
+        # process since the vouch. This is the anti-PID-reuse anchor.
+        return VerificationResult(
+            accepted=False,
+            reason=(
+                f"start_tvsec mismatch for pid {peer_pid}: vouched "
+                f"{binding.child_start_tvsec}, live {live_start_tvsec} (PID reuse)"
+            ),
+            failure_code="start_mismatch",
+        )
+
+    if binding.child_uuid != claimed_child_uuid:
+        return VerificationResult(
+            accepted=False,
+            reason=(
+                f"claimed child uuid {claimed_child_uuid} != vouched uuid "
+                f"{binding.child_uuid} for pid {peer_pid}"
+            ),
+            failure_code="uuid_mismatch",
+        )
+
+    return VerificationResult(
+        accepted=True,
+        reason=(
+            f"orchestrator-vouched: uuid={binding.child_uuid} pid={peer_pid} "
+            f"start_tvsec={live_start_tvsec} voucher={binding.voucher_uuid}"
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema DDL — AUTHORED, NOT APPLIED, NOT IN A MIGRATION SLOT.
+#
+# Held as a reviewable constant rather than a db/postgres/migrations/NNN_*.sql
+# file ON PURPOSE: an unapplied migration slot would show as drift in the LOCAL
+# unitares_doctor schema_migrations check until the operator applied it, and this
+# PoC is explicitly deferred past 2026-06-24. The cutover row promotes this DDL
+# verbatim into the next real migration slot and applies it manually per the
+# project's MANUAL-migration discipline.
+# ---------------------------------------------------------------------------
+
+VOUCHED_BINDINGS_DDL = """
+CREATE TABLE IF NOT EXISTS core.vouched_bindings (
+    child_uuid          UUID        NOT NULL,
+    child_os_pid        INTEGER     NOT NULL,
+    child_start_tvsec   BIGINT      NOT NULL,   -- mandatory: no server-side TOFU
+    voucher_uuid        UUID        NOT NULL,   -- the S19-enrolled orchestrator
+    spawn_reason        TEXT        NOT NULL DEFAULT 'subagent',
+    vouched_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at          TIMESTAMPTZ NOT NULL,   -- short TTL; re-vouch to extend
+    PRIMARY KEY (child_uuid)
+);
+-- Resolution looks up BY the kernel-attested connecting pid, then validates
+-- start_tvsec + uuid. Partial-unique on the live (pid, start_tvsec) pair guards
+-- against two live vouched processes claiming the same pid within a TTL window.
+CREATE UNIQUE INDEX IF NOT EXISTS vouched_bindings_pid_start_ux
+    ON core.vouched_bindings (child_os_pid, child_start_tvsec);
+"""

--- a/tests/test_substrate_vouch.py
+++ b/tests/test_substrate_vouch.py
@@ -1,0 +1,176 @@
+"""Orchestrator-vouched identity — INERT PoC seam (pure-logic tests).
+
+Covers ``src/substrate/vouch.py``. The module under test is NOT wired into
+identity resolution (see its docstring + RFC orchestrator-vouched-identity-v0.md);
+these tests construct ``VouchedBinding`` objects directly and never route through
+the live resolution path — that boundary is the C2 inertness invariant.
+
+Verified behaviour:
+- no_binding / expired / missing_start_tvsec (both sides) / pid_mismatch /
+  start_mismatch (PID reuse) / uuid_mismatch rejections
+- happy path accept
+- server-side TOFU is rejected (a row without start_tvsec never passes)
+- the flag is default-off and inert
+- the new label constants are ABSENT from the live strong/caller-asserted sets
+  (drift-guard: the PoC must not create a live gating point)
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.substrate.vouch import (
+    PROOF_ORIGIN_ORCHESTRATOR_VOUCHED,
+    SESSION_SOURCE_BEAM_ORCHESTRATED,
+    VOUCH_FLAG_ENV,
+    VouchedBinding,
+    is_orchestrator_vouch_enabled,
+    verify_vouched_binding,
+)
+
+_NOW = 1_000_000
+_PID = 4242
+_START = 9_999
+_UUID = "11111111-1111-4111-8111-111111111111"
+_VOUCHER = "22222222-2222-4222-8222-222222222222"
+
+
+def _binding(**overrides) -> VouchedBinding:
+    base = dict(
+        child_uuid=_UUID,
+        child_os_pid=_PID,
+        child_start_tvsec=_START,
+        voucher_uuid=_VOUCHER,
+        expires_at_epoch=_NOW + 300,
+    )
+    base.update(overrides)
+    return VouchedBinding(**base)
+
+
+def _verify(binding, *, peer_pid=_PID, live_start=_START, uuid=_UUID, now=_NOW):
+    return verify_vouched_binding(
+        binding,
+        peer_pid=peer_pid,
+        live_start_tvsec=live_start,
+        claimed_child_uuid=uuid,
+        now_epoch=now,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Happy path
+# --------------------------------------------------------------------------- #
+
+
+def test_full_match_accepts():
+    result = _verify(_binding())
+    assert result.accepted is True
+    assert result.failure_code is None
+    assert str(_PID) in result.reason and _VOUCHER in result.reason
+
+
+# --------------------------------------------------------------------------- #
+# Rejections (check order)
+# --------------------------------------------------------------------------- #
+
+
+def test_no_binding_rejects():
+    result = _verify(None)
+    assert result.accepted is False
+    assert result.failure_code == "no_binding"
+
+
+def test_expired_rejects():
+    result = _verify(_binding(expires_at_epoch=_NOW - 1))
+    assert result.accepted is False
+    assert result.failure_code == "expired"
+
+
+def test_expiry_is_exclusive_at_boundary():
+    # now == expires_at must be treated as expired (>=), not still-valid.
+    result = _verify(_binding(expires_at_epoch=_NOW))
+    assert result.accepted is False
+    assert result.failure_code == "expired"
+
+
+def test_binding_missing_start_tvsec_rejects_no_tofu():
+    # The rejected server-side-TOFU case: a row that lacks start_tvsec must
+    # fail, never silently pass (RFC O3 / dialectic seam 2).
+    result = _verify(_binding(child_start_tvsec=None))
+    assert result.accepted is False
+    assert result.failure_code == "missing_start_tvsec"
+
+
+def test_live_start_tvsec_unreadable_rejects():
+    result = _verify(_binding(), live_start=None)
+    assert result.accepted is False
+    assert result.failure_code == "missing_start_tvsec"
+
+
+def test_pid_mismatch_rejects():
+    result = _verify(_binding(child_os_pid=_PID + 1))
+    assert result.accepted is False
+    assert result.failure_code == "pid_mismatch"
+
+
+def test_start_mismatch_is_pid_reuse_rejection():
+    # Same pid, different live start time → pid recycled to another process.
+    result = _verify(_binding(), live_start=_START + 1)
+    assert result.accepted is False
+    assert result.failure_code == "start_mismatch"
+
+
+def test_uuid_mismatch_rejects():
+    result = _verify(_binding(), uuid="33333333-3333-4333-8333-333333333333")
+    assert result.accepted is False
+    assert result.failure_code == "uuid_mismatch"
+
+
+# --------------------------------------------------------------------------- #
+# Flag is inert / default-off
+# --------------------------------------------------------------------------- #
+
+
+def test_flag_default_off(monkeypatch):
+    monkeypatch.delenv(VOUCH_FLAG_ENV, raising=False)
+    assert is_orchestrator_vouch_enabled() is False
+
+
+@pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on", " On "])
+def test_flag_truthy_spellings(monkeypatch, val):
+    monkeypatch.setenv(VOUCH_FLAG_ENV, val)
+    assert is_orchestrator_vouch_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", "", "garbage"])
+def test_flag_falsey_spellings(monkeypatch, val):
+    monkeypatch.setenv(VOUCH_FLAG_ENV, val)
+    assert is_orchestrator_vouch_enabled() is False
+
+
+# --------------------------------------------------------------------------- #
+# Drift-guard: the PoC constants must NOT be in the live gating sets.
+# This is the C2 inertness invariant made executable — if a future change adds
+# the vouched session_source to a live strong/caller-asserted set WITHOUT the
+# vouch lookup behind it, this test fails.
+# --------------------------------------------------------------------------- #
+
+
+def test_vouched_session_source_absent_from_strong_sources():
+    from src.services.identity_payloads import _STRONG_IDENTITY_SOURCES
+
+    assert SESSION_SOURCE_BEAM_ORCHESTRATED not in _STRONG_IDENTITY_SOURCES
+
+
+def test_vouched_labels_absent_from_session_classification_source():
+    # session.py's caller-asserted classification set (_CALLER_ASSERTED_SOURCES)
+    # is function-local, so it can't be imported. Guard at the source level: the
+    # vouched label literals must not appear in session.py at all while the PoC
+    # is inert. If a future change wires them there WITHOUT the vouch lookup, this
+    # fails (the C2 inertness invariant made executable).
+    import inspect
+
+    from src.mcp_handlers.identity import session as session_mod
+
+    src = inspect.getsource(session_mod)
+    assert SESSION_SOURCE_BEAM_ORCHESTRATED not in src
+    assert PROOF_ORIGIN_ORCHESTRATOR_VOUCHED not in src


### PR DESCRIPTION
## What

Design-first RFC + an **inert, flag-gated** proof-of-concept seam for **orchestrator-vouched identity** — the first honest `strong` cross-process credential for an *ephemeral* agent, the gap #807/#810 leave open by construction.

**The claim:** an agent the BEAM Agent Orchestrator actually spawns and owns can move from the "non-substrate, unverifiable" class into a **substrate-attested** class. The orchestrator — itself S19-enrolled, speaking to governance over the **kernel-peer-cred UDS channel** (not a bearer token) — vouches the child's `(uuid, os_pid, start_tvsec)` at spawn. The child later resolves `strong` because governance peer-creds its *own* PID and matches the orchestrator's vouch — by **proof**, not by echoing a copyable `client_session_id`.

The earner isn't a specific runtime; it's *having a lifecycle-owner the server can interrogate*. launchd is one (S19); BEAM OTP is a second.

## Scope / honesty seam

- Helps **only** agents BEAM spawns. Claude Code / Codex / external SDK callers stay copyable-string callers, weak/medium cross-process — exactly as #810 ratified. Out of scope.
- The vouch is only as strong as the orchestrator→governance channel, so that channel **MUST be UDS peer-cred, not a bearer token** (else we relocate the copyable-string problem). The honest claim is **trust concentration onto an anchorable voucher**, not end-to-end cryptographic non-forgeability.

## Council-reviewed 2026-06-17 (all folded)

dialectic-knowledge-architect (ontology: sound-with-changes) · feature-dev:code-reviewer (2 critical + 3 important) · live-verifier (5 confirmed, 1 refuted → corrected):

- **O4 feasibility CONFIRMED VIABLE** — OTP 28 / Elixir 1.19.5 (`gen_tcp` AF_UNIX), live `governance.sock`. HTTP-over-UDS client is net-new code, not a blocker.
- `substrate_attested` **does not exist** and the S19 success path stamps **no** `proof_origin` (passes strict via fail-open) → the vouched stamp is net-new; mint a **distinct `orchestrator_vouched`** (O1 resolved).
- `caller_proven` is computed at **3 sites** + `_CALLER_ASSERTED_SOURCES` is a 4th live gating point → multi-site change, extract a shared helper at cutover (C1).
- `start_tvsec` is **mandatory-for-strong**; server-side TOFU **rejected** (O3 / seam 2).
- The orchestrator is a **standalone OTP app** with no launchd job yet → enrollment targets a new dedicated job (live-verifier correction).
- #810's "by construction" reinterpretation surfaced as an **explicit operator call** (§1 ⚠ box) — must be confirmed before any cutover.

## What's in this PR (inert, all behind `UNITARES_ORCHESTRATOR_VOUCH`, default off)

- `docs/proposals/orchestrator-vouched-identity-v0.md` — the RFC.
- `src/substrate/vouch.py` — pure `VouchedBinding` + `verify_vouched_binding`; label constants **defined, not wired**; DDL as a reviewable constant (not a migration slot, to avoid local-doctor drift on a deferred PoC). **Not wired into `resolution.py`.**
- `tests/test_substrate_vouch.py` — 24 tests incl. a drift-guard asserting the vouched labels are absent from the live strong/caller-asserted sets (the C2 inertness invariant, executable).

## Not in scope here

No live deploy before the **2026-06-24 Wave-3 gate read**. The UDS vouch client (Elixir), `vouch_child` handler, resolution gate, SDK UDS routing, and voucher enrollment are deferred cutover-row work.

## Merge posture

Identity is a writer-locked, cross-repo surface. **Draft — operator is the merge gate. Do not auto-merge.** The #810 reinterpretation is an open operator call.