### PR TITLE
fix(kg): reject degenerate writes that absorbed tool-call markup

### DIFF
--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -116,6 +116,53 @@ def _normalize_discovery_type(discovery_type: Any) -> Any:
     return discovery_type
 
 
+# Tool-call serialization markers that must never appear in a stored discovery.
+# Their presence means the harness folded a later argument (commonly `tags`)
+# into a text field as raw markup while the structured arg arrived empty —
+# storing it yields a corrupt, unsearchable row (tags=[] + literal markup in
+# details) with no warning. Legit prose effectively never contains these, so a
+# hard reject is low-false-positive. (KG 2026-06-13 footgun: "knowledge
+# store/update silently accepts degenerate writes".)
+_TOOLCALL_MARKUP_MARKERS = (
+    "<parameter name=",
+    "</parameter>",
+    "<invoke name=",
+    "</invoke>",
+    "<function_calls>",
+    "</function_calls>",
+    "antml:parameter",
+    "antml:invoke",
+)
+
+
+def _detect_toolcall_markup_leak(*texts: Any) -> "str | None":
+    """Return the first tool-call markup marker found in any text arg, else None."""
+    for text in texts:
+        if not isinstance(text, str):
+            continue
+        for marker in _TOOLCALL_MARKUP_MARKERS:
+            if marker in text:
+                return marker
+    return None
+
+
+def _degenerate_write_response(leaked_marker: str, field: str):
+    """Loud, actionable reject for a text field that absorbed tool-call markup."""
+    return error_response(
+        f"Refusing to store: `{field}` contains tool-call markup "
+        f"({leaked_marker!r}). This usually means a later argument (commonly "
+        f"`tags`) was folded into the text and the structured argument arrived "
+        f"empty — storing it would persist a corrupt, unsearchable row. Re-send "
+        f"with each argument as a separate parameter.",
+        error_code="degenerate_write_rejected",
+        error_category="validation_error",
+        recovery={
+            "action": "Resend the call with summary, content/details, and tags "
+            "as distinct arguments; do not embed tags or markup inside content."
+        },
+    )
+
+
 def _invalid_enum_response(field: str, value: Any, valid_values: set[str], *, tip: str | None = None):
     normalized = str(value).strip().lower()
     suggestion = None
@@ -631,6 +678,19 @@ async def handle_store_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[Te
         raw_summary = summary
         # Accept both 'details' and 'content' as parameter names
         raw_details = arguments.get("details") or arguments.get("content") or ""
+
+        # Foolproofing (KG 2026-06-13 footgun): reject a write whose text fields
+        # absorbed tool-call markup — the harness folded a later argument
+        # (commonly `tags`) into summary/content and the structured arg arrived
+        # empty. Silently storing it persists a corrupt, unsearchable row.
+        leaked_marker = _detect_toolcall_markup_leak(raw_summary, raw_details)
+        if leaked_marker:
+            field = (
+                "summary"
+                if isinstance(raw_summary, str) and leaked_marker in raw_summary
+                else "content"
+            )
+            return [_degenerate_write_response(leaked_marker, field)]
 
         # Track truncation for visibility (v2.5.0+)
         truncation_info = {}
@@ -1912,6 +1972,18 @@ async def handle_update_discovery_status_graph(arguments: Dict[str, Any]) -> Seq
     severity = arguments.get("severity")
     discovery_type = arguments.get("discovery_type")
     tags = arguments.get("tags")
+
+    # Foolproofing (KG 2026-06-13 footgun): same guard as the store path —
+    # reject an edit whose text fields absorbed tool-call markup rather than
+    # silently persisting a corrupt update.
+    leaked_marker = _detect_toolcall_markup_leak(summary, raw_details, resolution_note_text)
+    if leaked_marker:
+        field = (
+            "summary"
+            if isinstance(summary, str) and leaked_marker in summary
+            else "content"
+        )
+        return [_degenerate_write_response(leaked_marker, field)]
 
     if not any(value is not None for value in (status, raw_details, resolution_note_text, summary, severity, discovery_type, tags)):
         return [error_response(

--- a/tests/test_kg_lifecycle.py
+++ b/tests/test_kg_lifecycle.py
@@ -161,6 +161,24 @@ class TestUpdateDiscoveryStatusGraph:
         assert "resolved" in data["message"]
 
     @pytest.mark.asyncio
+    async def test_update_rejects_toolcall_markup(self, patch_common, registered_agent):
+        """KG 2026-06-13 footgun: the update path gets the same degenerate-write
+        guard as store — an edit whose content absorbed tool-call markup is
+        rejected, not silently persisted."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_update_discovery_status_graph
+
+        result = await handle_update_discovery_status_graph({
+            "agent_id": registered_agent,
+            "discovery_id": "2026-01-01T00:00:00.000000",
+            "content": 'edited <parameter name="tags">["x"]</parameter>',
+        })
+
+        data = parse_result(result)
+        assert data["success"] is False
+        assert data["error_code"] == "degenerate_write_rejected"
+
+    @pytest.mark.asyncio
     async def test_update_missing_discovery_id(self, patch_common, registered_agent):
         """Update fails when discovery_id is missing."""
         mock_mcp_server, mock_graph = patch_common

--- a/tests/test_kg_store.py
+++ b/tests/test_kg_store.py
@@ -176,6 +176,60 @@ class TestStoreKnowledgeGraph:
         assert "summary" in data["error"].lower() or "missing" in data["error"].lower()
 
     @pytest.mark.asyncio
+    async def test_store_rejects_toolcall_markup_in_content(self, patch_common, registered_agent):
+        """KG 2026-06-13 footgun: a write whose content absorbed tool-call markup
+        (because the harness folded the `tags` arg into it and tags arrived empty)
+        must be rejected loudly, not stored as a corrupt, unsearchable row."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_store_knowledge_graph
+
+        result = await handle_store_knowledge_graph({
+            "agent_id": registered_agent,
+            "summary": "A real finding",
+            "content": 'details here <parameter name="tags">["a","b"]</parameter>',
+            # tags arrived empty because they were folded into content above
+        })
+
+        data = parse_result(result)
+        assert data["success"] is False
+        assert data["error_code"] == "degenerate_write_rejected"
+        mock_graph.add_discovery.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_store_rejects_toolcall_markup_in_summary(self, patch_common, registered_agent):
+        """The same guard covers the summary field."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_store_knowledge_graph
+
+        result = await handle_store_knowledge_graph({
+            "agent_id": registered_agent,
+            "summary": "Finding </invoke>",
+        })
+
+        data = parse_result(result)
+        assert data["success"] is False
+        assert data["error_code"] == "degenerate_write_rejected"
+        mock_graph.add_discovery.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_store_allows_brackets_and_angle_text_in_prose(self, patch_common, registered_agent):
+        """Low false-positive: legit prose with JSON-ish brackets or comparison
+        operators (not tool-call markup) must still store."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_store_knowledge_graph
+
+        result = await handle_store_knowledge_graph({
+            "agent_id": registered_agent,
+            "summary": "Config takes a list like [\"a\", \"b\"] and x < y holds",
+            "content": "Saw payload {\"tags\": [\"x\"]} and a<b in the diff — all fine.",
+            "tags": ["config"],
+        })
+
+        data = parse_result(result)
+        assert data["success"] is True
+        mock_graph.add_discovery.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_store_defaults_to_note_type(self, patch_common, registered_agent):
         """Discovery type defaults to 'note' when not specified."""
         mock_mcp_server, mock_graph = patch_common


### PR DESCRIPTION
## Summary

Resolves one of the KG frictions logged in shared memory — the **2026-06-13 footgun** *"knowledge store/update silently accepts degenerate writes (tags absorbed into content, persisted as tags=[] + tool-call markup in details) with no warning"* (KG discovery `fac35bde`, type `improvement`, still open).

### The bug
When a harness folds a later argument (commonly `tags`) into a text field as raw tool-call markup, the structured arg arrives empty and the server **stored the row anyway** — `tags=[]` plus literal markup inside `details`. The result is a corrupt, unsearchable discovery, written with a `success` response and no warning. (I hit the adjacent UX rough edge myself this session — the `discovery_type` enum rejection — which is what sent me to the friction log.)

### The fix
Both write paths — `handle_store_knowledge_graph` and `handle_update_discovery_status_graph` — now run `_detect_toolcall_markup_leak()` over `summary` / `content` / `resolution_notes` and return a loud, actionable `error_code: degenerate_write_rejected` asking the caller to resend each argument as a separate parameter (with a `recovery.action`). The markers (`<parameter name=`, `</invoke>`, `<function_calls>`, `antml:*`, …) effectively never appear in legitimate prose, so the guard is **low-false-positive** — a test pins that JSON-ish brackets (`{"tags": ["x"]}`) and comparison text (`a < b`) in normal prose still store fine.

Turns a silent corrupt write into a caught one — `fac35bde`'s stated goal.

### Tests
4 new: store rejects markup in content / in summary, store still allows bracket+angle prose, update rejects markup. **24 store + 53 lifecycle tests pass; `ruff` clean.**

### Scope note — the other KG frictions
This is the one bounded, low-risk friction. The others logged in `cb954a90` (search-relevance ranking, onboard tier/`client_session_id` friction, lifecycle-status trust) are deliberately **not** in this PR — they need an eval harness or touch the writer-locked identity surface, so they shouldn't be blind-changed. Happy to scope those as follow-ups.

When merged, the `fac35bde` discovery can be closed: `knowledge(action='update', discovery_id='2026-06-13T20:29:45.496914+00:00', status='resolved')`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjoaZwUzP4zkg3cJZD1Hax)_