### PR TITLE
fix(uds): bind governance.sock at 0600 (uvicorn was chmod'ing it 0666)

### DIFF
--- a/src/uds_listener.py
+++ b/src/uds_listener.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import socket
+import stat
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -98,19 +100,33 @@ def make_peer_cred_protocol_class() -> type:
     return PeerCredHTTPProtocol
 
 
+#: Listen backlog for the pre-bound UDS socket (uvicorn's own default is 2048).
+_UDS_BACKLOG = 2048
+
+
 async def start_uds_listener(
     app, uds_path: str, *, log_level: str = "info"
 ) -> "asyncio.Task[None]":
     """Start a uvicorn UDS listener as a background task.
 
     Returns the task; caller is responsible for cancellation at shutdown.
-    The socket file is created with mode 0600 (owner-only read/write) so
-    only the same OS user can connect — matches the same-UID threat
-    boundary documented in proposal v2 §Adversary models.
 
-    The protocol class is the one built by ``make_peer_cred_protocol_class()``,
-    so every request scope will have ``scope["unitares_peer_pid"]`` set when
-    the kernel was able to read peer credentials.
+    **Socket permissions are 0600 (owner-only), race-free.** We bind the
+    AF_UNIX socket *ourselves* and hand it to uvicorn via ``serve(sockets=...)``
+    rather than letting uvicorn bind a ``uds=`` path. The reason is a real
+    incident (governance.sock observed at mode 0666 live, 2026-06-17): when
+    uvicorn binds the uds itself it ``chmod``s the socket to ``0o666`` during
+    startup, which *races with and overwrites* any post-bind ``chmod 0600`` we
+    do — and on a restart that skips the tighten step, the socket simply stays
+    world-writable. World-writable defeats the same-UID threat boundary the S19
+    peer-cred design documents (proposal v2 §Adversary models): any local
+    process could connect and present a UUID.
+
+    By binding first under a tight umask and ``chmod``-ing before ``listen``,
+    the socket is *never* reachable at a looser mode, and because uvicorn is
+    given an already-bound socket it never applies its own 0666. The protocol
+    class from ``make_peer_cred_protocol_class()`` still injects
+    ``scope["unitares_peer_pid"]`` per request.
     """
     import uvicorn
 
@@ -124,41 +140,62 @@ async def start_uds_listener(
         except OSError as exc:
             logger.warning("[UDS] could not unlink stale socket %s: %s", uds_path, exc)
 
+    # Bind the AF_UNIX socket ourselves so we own its mode with no
+    # world-writable window. umask 0o177 → the socket node is created 0600;
+    # the explicit chmod re-asserts it (defense in depth) before listen(), so
+    # the socket accepts no connection until it is owner-only.
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        prev_umask = os.umask(0o177)
+        try:
+            sock.bind(uds_path)
+        finally:
+            os.umask(prev_umask)
+        os.chmod(uds_path, 0o600)
+        # listen() before handing the socket to uvicorn so the kernel queues
+        # connections immediately — otherwise a client connecting in the window
+        # before uvicorn's serve() task calls listen() gets ECONNREFUSED.
+        # asyncio's create_server(sock=...) calling listen() again is harmless.
+        sock.listen(_UDS_BACKLOG)
+        sock.setblocking(False)
+    except OSError:
+        sock.close()
+        # Clean up a partially-created socket file so a retry can rebind.
+        if os.path.exists(uds_path):
+            try:
+                os.unlink(uds_path)
+            except OSError:
+                pass
+        raise
+
+    # Verify the on-disk mode is actually 0600 before we serve — surfaces any
+    # future regression loudly instead of silently shipping a 0666 socket.
+    actual_mode = stat.S_IMODE(os.stat(uds_path).st_mode)
+    if actual_mode != 0o600:
+        logger.warning(
+            "[UDS] socket %s mode is %o after bind+chmod, expected 0600",
+            uds_path, actual_mode,
+        )
+    else:
+        logger.info(
+            "[UDS] listening at %s (mode 0600, peer-cred enabled)", uds_path
+        )
+
     protocol_class = make_peer_cred_protocol_class()
     config = uvicorn.Config(
         app=app,
-        uds=uds_path,
+        # NOTE: no uds= here — we pass the pre-bound socket to serve() so
+        # uvicorn does not re-bind (and does not apply its own 0666 chmod).
         http=protocol_class,
         log_level=log_level,
         # Disable uvicorn's lifespan and CORS — those are handled by the
         # primary HTTP listener; UDS is just a transport into the same app.
         lifespan="off",
         access_log=False,
+        backlog=_UDS_BACKLOG,
     )
     server = uvicorn.Server(config)
-    task = asyncio.create_task(server.serve(), name="unitares-uds-listener")
-
-    # Tighten socket permissions to mode 0600 once uvicorn has created it.
-    # We poll briefly for the file because uvicorn binds asynchronously.
-    async def _tighten_socket_mode() -> None:
-        for _ in range(50):  # up to ~5s
-            if os.path.exists(uds_path):
-                try:
-                    os.chmod(uds_path, 0o600)
-                    logger.info(
-                        "[UDS] listening at %s (mode 0600, peer-cred enabled)",
-                        uds_path,
-                    )
-                except OSError as exc:
-                    logger.warning(
-                        "[UDS] chmod 0600 failed for %s: %s", uds_path, exc
-                    )
-                return
-            await asyncio.sleep(0.1)
-        logger.warning(
-            "[UDS] socket %s did not appear within 5s; chmod skipped",
-            uds_path,
-        )
-
-    asyncio.create_task(_tighten_socket_mode(), name="unitares-uds-chmod")
+    task = asyncio.create_task(
+        server.serve(sockets=[sock]), name="unitares-uds-listener"
+    )
     return task

--- a/tests/test_uds_listener.py
+++ b/tests/test_uds_listener.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import os
 import socket
+import stat
 import sys
 import tempfile
 from typing import Any
@@ -266,3 +267,57 @@ async def test_uds_listener_end_to_end_injects_peer_pid_into_scope() -> None:
     assert first.get("unitares_peer_pid") == os.getpid(), (
         f"expected unitares_peer_pid={os.getpid()}, got {first.get('unitares_peer_pid')!r}"
     )
+
+
+# =============================================================================
+# Socket permissions — 0600, race-free (regression: governance.sock 0666)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_uds_socket_created_mode_0600() -> None:
+    """The listener's socket must be owner-only (0600), not world-writable.
+
+    Regression for the live incident where uvicorn's own uds bind chmod'd the
+    socket to 0666, defeating the same-UID peer-cred threat boundary. We now
+    pre-bind under a tight umask and pass the socket to uvicorn, so 0666 is
+    never applied.
+    """
+    if sys.platform != "darwin":
+        pytest.skip("macOS-specific test")
+
+    async def app(scope: dict[str, Any], receive: Any, send: Any) -> None:
+        if scope["type"] == "http":
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b""})
+
+    with tempfile.TemporaryDirectory() as tmp:
+        sock_path = os.path.join(tmp, "perms.sock")
+        listener_task = await uds_listener.start_uds_listener(
+            app, sock_path, log_level="error"
+        )
+        try:
+            assert os.path.exists(sock_path), "socket not created"
+            mode = stat.S_IMODE(os.stat(sock_path).st_mode)
+            assert mode == 0o600, f"expected 0600, got {oct(mode)} (world-writable risk)"
+            # And it must actually serve over that socket (perms didn't break it).
+            reader, writer = await asyncio.open_unix_connection(sock_path)
+            try:
+                writer.write(
+                    b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+                )
+                await writer.drain()
+                resp = await reader.read()
+                assert resp.startswith(b"HTTP/1.1 200"), resp[:40]
+            finally:
+                writer.close()
+                try:
+                    await writer.wait_closed()
+                except Exception:
+                    pass
+        finally:
+            listener_task.cancel()
+            try:
+                await listener_task
+            except (asyncio.CancelledError, Exception):
+                pass


### PR DESCRIPTION
## Problem (surfaced by the orchestrator-vouched-identity council, #827)

The S19 UDS listener's socket `governance.sock` is **live at mode 0666** (world-writable), not the 0600 it logs. That defeats the same-UID peer-cred threat boundary the substrate design documents: *any* local process can connect and present a UUID.

**Root cause:** the listener relied on a post-bind `chmod 0600`, but uvicorn's own `uds=` bind chmods the socket to `0o666` during startup — racing with and overwriting our chmod. On a restart that skips the tighten step, the socket just stays world-writable. Confirmed live: socket mtime matches the gov-mcp restart (PID 26148, Jun 17 14:24), perms 0666, despite the 0600 log line.

## Fix

Bind the AF_UNIX socket **ourselves** under `umask 0o177`, `chmod 0600`, and `listen()` before handing it to uvicorn via `serve(sockets=[sock])`. Because uvicorn receives an already-bound socket it never applies its own 0666, and the socket is never reachable at a looser mode for even an instant (race-free, not a post-hoc tighten). Added a synchronous mode assertion that logs loudly on any future regression.

## Test

`test_uds_socket_created_mode_0600` asserts the socket is **0600 AND still serves** a request over it. The existing peer-pid e2e test stays green. `11 passed`.

## Scope

- Corrects **future** binds. The live socket stays 0666 until the gov-mcp is redeployed/restarted (operator action — `launchctl unload/load` the gov-mcp plist).
- Independent of the deferred Wave-3 vouch work (#827); this is a pre-existing S19 defect.

Draft — operator merge gate.