### PR TITLE
fix(sdk): recover strict-identity check-in via continuity-token rebind (Chronicler cliff)

### DIFF
--- a/agents/sdk/src/unitares_sdk/client.py
+++ b/agents/sdk/src/unitares_sdk/client.py
@@ -471,7 +471,30 @@ class GovernanceClient:
         # 2026-06-14). Detect the refusal marker and fail loud instead.
         refusal = extract_identity_refusal(raw)
         if refusal is not None:
-            raise refusal
+            # Recovery for the resume-binding cliff: a long-cadence resident
+            # (e.g. Chronicler, daily) can wake with its PG session binding
+            # expired AND the anchor's continuity token stale (1h TTL << 24h
+            # cadence). The identity() resume reissues a fresh in-memory token
+            # but its agent_uuid passthrough (PATH 0) does not mint a session,
+            # so this first check-in resolves to a PATH2_RESUME_MISS and the
+            # strict gate refuses it. #513 deliberately keeps the continuity
+            # token OFF the happy path (S1-c narrowing); here we re-prove
+            # ownership EXPLICITLY by presenting the fresh in-memory token on a
+            # single recovery retry, which the server honors via PATH 2.8
+            # token-rebind (mints a fresh caller-proven session). The token
+            # rides the wire only on this recovery — frequent residents whose
+            # session row is still live never reach this branch.
+            if self.continuity_token and not args.get("continuity_token"):
+                retry_args = dict(args)
+                retry_args["continuity_token"] = self.continuity_token
+                raw = await self.call_tool("process_agent_update", retry_args)
+                self._raise_for_tool_failure("process_agent_update", raw)
+                # Capture the rebound session so later calls this run ride it
+                # without re-presenting the token.
+                self._capture_identity(raw)
+                refusal = extract_identity_refusal(raw)
+            if refusal is not None:
+                raise refusal
 
         # Extract verdict for potential error raising
         decision = raw.get("decision", {})

--- a/agents/sdk/tests/test_client.py
+++ b/agents/sdk/tests/test_client.py
@@ -336,6 +336,82 @@ class TestToolMapping:
         assert args["prompt"] == "test prompt"
 
 
+# --- Strict-identity check-in recovery (resume-binding cliff) ---
+
+
+def _strict_refusal(tool: str = "process_agent_update") -> dict:
+    """The #425 typed strict-identity refusal success-shape."""
+    return {
+        "rollout_flag": "STRICT_IDENTITY_REQUIRED",
+        "status": "identity_required",
+        "tool": tool,
+        "hint": "resolved by transport fingerprint, not caller-proven",
+    }
+
+
+def _checkin_success() -> dict:
+    return {
+        "success": True,
+        "status": "active",
+        "decision": {"action": "proceed"},
+        "metrics": {"E": 0.7, "I": 0.8, "S": 0.2, "V": 0.0, "coherence": 0.85},
+    }
+
+
+class TestCheckinIdentityRecovery:
+    @pytest.mark.asyncio
+    async def test_recovers_via_continuity_token_on_refusal(self):
+        """A long-cadence resident whose session expired gets refused on the
+        token-less check-in, then succeeds on a single retry that presents the
+        in-memory continuity token (server PATH 2.8 token-rebind)."""
+        session = AsyncMock()
+        session.call_tool = AsyncMock(side_effect=[
+            make_mcp_result(_strict_refusal()),
+            make_mcp_result(_checkin_success()),
+        ])
+        client = make_client_with_session(session)
+        client.client_session_id = "agent-deb879b6-4ff"
+        client.continuity_token = "v1.fresh-token"
+
+        result = await client.checkin("daily scrape done")
+
+        assert isinstance(result, CheckinResult)
+        assert session.call_tool.call_count == 2
+        # First attempt carries no token (happy path stays token-free, #513).
+        first_args = session.call_tool.call_args_list[0][0][1]
+        assert "continuity_token" not in first_args
+        # Recovery retry carries the in-memory token as explicit ownership proof.
+        retry_args = session.call_tool.call_args_list[1][0][1]
+        assert retry_args["continuity_token"] == "v1.fresh-token"
+
+    @pytest.mark.asyncio
+    async def test_refusal_without_token_raises(self):
+        """No continuity token to re-prove ownership → fail loud, no retry."""
+        session = AsyncMock()
+        session.call_tool = AsyncMock(return_value=make_mcp_result(_strict_refusal()))
+        client = make_client_with_session(session)
+        client.continuity_token = None
+
+        with pytest.raises(IdentityRefusedError):
+            await client.checkin("work")
+        assert session.call_tool.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_persistent_refusal_after_recovery_raises(self):
+        """If the token-rebind retry is also refused, surface the refusal."""
+        session = AsyncMock()
+        session.call_tool = AsyncMock(side_effect=[
+            make_mcp_result(_strict_refusal()),
+            make_mcp_result(_strict_refusal()),
+        ])
+        client = make_client_with_session(session)
+        client.continuity_token = "v1.expired-token"
+
+        with pytest.raises(IdentityRefusedError):
+            await client.checkin("work")
+        assert session.call_tool.call_count == 2
+
+
 # --- Kwargs passthrough ---
 
 


### PR DESCRIPTION
## Problem

Chronicler (daily resident, `StartInterval 86400`, UUID `deb879b6…`) went **governance-dark after 2026-06-14** — `update_count` frozen at 56 — while its 9 metric scrapers kept succeeding (`/v1/metrics` 201). Diagnosed live:

- `_CONTINUITY_TTL = 3600` (**1h**) vs Chronicler's **24h** cadence. The continuity token in its anchor is always expired by the next run (decoded: `iat→exp` = exactly 1h).
- `identity(agent_uuid=…, continuity_token=<expired>, resume=true)` falls to the **PATH 0 agent_uuid passthrough**, which reissues a fresh in-memory token but **does not mint a session**.
- The first, token-less `process_agent_update` then resolves to `PATH2_RESUME_MISS`; under `STRICT_IDENTITY_REQUIRED` the #425 gate **refuses** it. Pre-strict this fell through to a silent ghost-mint; strict made it a hard refusal, and #824 made it loud.

This is a time-dependence cliff (token TTL « cadence) — same class as the Watcher 24h-identity-cliff (PR #595).

## Why not enrollment

Adding Chronicler to `core.substrate_claims` would trip `SUBSTRATE_HTTP_REJECT` (S19/#802): a substrate-anchored UUID may not resume over **HTTP** (must use UDS). Chronicler is an HTTP client → enrollment converts one refusal into another. Not the fix.

## Fix (SDK-only, respects #513)

#513 deliberately keeps the continuity token **off the happy path** (S1-c narrowing), so this does **not** re-add blanket injection. Instead, on a refused check-in, `checkin()` retries **once** presenting the fresh in-memory token as an explicit ownership re-proof. The server honors it via the **existing PATH 2.8 token-rebind** — mints a caller-proven session (`proof_origin=caller_asserted`), clearing both the resume-miss guard and the `phases.py:334` strict write precondition. The token rides the wire **only on recovery**; frequent residents (live session row) never reach the branch, so #513's narrowing holds. The S19 substrate gate is untouched.

## Verification

- New unit tests (`test_client.py::TestCheckinIdentityRecovery`): recovery-on-refusal, no-token→raise, persistent-refusal→raise. Existing #513 `test_injects_session_id` (no auto-inject) still green. Full SDK suite: 46 + 64 pass. Pre-push smoke: 138 passed.
- **Live against the running strict server** (patched SDK via PYTHONPATH, real Chronicler anchor/UUID/DB): `update_count` **56 → 57 → 58**, fresh check-ins at `18:28:47` and `18:30:20`. The `58` run used a **deliberately-unusable anchor token** to simulate the real daily-expired case — recovery still landed.

## Deploy note

SDK-only; no server restart. The deploy/editable-install checkout (`~/projects/unitares`, already pulled to master for #823/#824) picks this up on Chronicler's next daily run once merged.

🤖 https://claude.ai/code/session_018saztth5RWghm8YWjT9Ggc