### PR TITLE
test(kg-eval): pin the retrieval-eval scoring math with unit tests

### DIFF
--- a/scripts/eval/__init__.py
+++ b/scripts/eval/__init__.py
@@ -1,0 +1,3 @@
+# KG retrieval eval package. The pure scoring math lives in `metrics` so it can
+# be imported and unit-tested without the live Postgres + embeddings backend the
+# runner (`retrieval_eval.py`) needs.

--- a/scripts/eval/metrics.py
+++ b/scripts/eval/metrics.py
@@ -1,0 +1,60 @@
+"""Pure ranking-quality metrics for the KG retrieval eval.
+
+These are the scoring functions the eval (`retrieval_eval.py`) reports against a
+labeled (query, relevant_ids) corpus. They are deliberately kept free of any
+backend dependency: the runner needs live Postgres + embeddings, but the math
+that decides whether a ranking change is an improvement must be trustworthy and
+exercisable in CI on its own. `tests/test_retrieval_eval_metrics.py` pins them.
+
+All metrics use **binary** relevance (a doc is relevant or it is not), matching
+the label format in `tests/retrieval_eval/labels.json`.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Iterable, List, Set
+
+
+def dcg(relevances: List[int], k: int) -> float:
+    """Discounted cumulative gain at k for a binary-relevance gain list.
+
+    Position i (0-indexed) contributes ``rel_i / log2(i + 2)`` so rank 1 has
+    discount log2(2)=1, rank 2 has log2(3), etc. Only the first ``k`` positions
+    count.
+    """
+    return sum(rel / math.log2(i + 2) for i, rel in enumerate(relevances[:k]))
+
+
+def ndcg_at_k(ranked_ids: List[str], relevant_set: Set[str], k: int) -> float:
+    """nDCG@k with binary relevance.
+
+    The ideal ranking places every relevant doc first, so ideal-DCG is the DCG
+    of ``min(len(relevant_set), k)`` ones. Returns 0.0 when no relevant doc
+    exists (nothing is achievable, so nothing is forfeited).
+    """
+    rels = [1 if rid in relevant_set else 0 for rid in ranked_ids[:k]]
+    ideal = dcg([1] * min(len(relevant_set), k), k)
+    if ideal == 0:
+        return 0.0
+    return dcg(rels, k) / ideal
+
+
+def recall_at_k(ranked_ids: List[str], relevant_set: Set[str], k: int) -> float:
+    """Fraction of the relevant set that appears in the top-k of the ranking.
+
+    Returns 0.0 when there are no relevant docs (undefined recall, reported as
+    0 so it never inflates an aggregate).
+    """
+    if not relevant_set:
+        return 0.0
+    hits = sum(1 for rid in ranked_ids[:k] if rid in relevant_set)
+    return hits / len(relevant_set)
+
+
+def mrr(ranked_ids: Iterable[str], relevant_set: Set[str]) -> float:
+    """Reciprocal rank of the first relevant hit (1-indexed); 0.0 if none."""
+    for i, rid in enumerate(ranked_ids):
+        if rid in relevant_set:
+            return 1.0 / (i + 1)
+    return 0.0

--- a/scripts/eval/retrieval_eval.py
+++ b/scripts/eval/retrieval_eval.py
@@ -16,7 +16,6 @@ Requires live Postgres + embeddings backend.
 import argparse
 import asyncio
 import json
-import math
 import os
 import statistics
 import sys
@@ -26,36 +25,8 @@ from typing import Any, Dict, List
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
+from scripts.eval.metrics import dcg, mrr, ndcg_at_k, recall_at_k  # noqa: F401  (dcg re-exported for callers)
 from src.knowledge_graph import get_knowledge_graph
-
-
-def dcg(relevances: List[int], k: int) -> float:
-    """Discounted cumulative gain at k. Binary relevance."""
-    return sum(rel / math.log2(i + 2) for i, rel in enumerate(relevances[:k]))
-
-
-def ndcg_at_k(ranked_ids: List[str], relevant_set: set, k: int) -> float:
-    """nDCG@k with binary relevance."""
-    rels = [1 if rid in relevant_set else 0 for rid in ranked_ids[:k]]
-    ideal_rels = sorted(rels, reverse=True)
-    ideal = dcg([1] * min(len(relevant_set), k), k)
-    if ideal == 0:
-        return 0.0
-    return dcg(rels, k) / ideal
-
-
-def recall_at_k(ranked_ids: List[str], relevant_set: set, k: int) -> float:
-    if not relevant_set:
-        return 0.0
-    hits = sum(1 for rid in ranked_ids[:k] if rid in relevant_set)
-    return hits / len(relevant_set)
-
-
-def mrr(ranked_ids: List[str], relevant_set: set) -> float:
-    for i, rid in enumerate(ranked_ids):
-        if rid in relevant_set:
-            return 1.0 / (i + 1)
-    return 0.0
 
 
 async def run_query(

--- a/tests/test_retrieval_eval_metrics.py
+++ b/tests/test_retrieval_eval_metrics.py
@@ -1,0 +1,117 @@
+"""Unit tests for the KG retrieval-eval scoring math (`scripts/eval/metrics.py`).
+
+The eval harness is the tool used to decide whether a ranking change is an
+improvement (the 2026-06-13 "on-point hit ranked 4th at ~0.13 similarity"
+friction is exactly the kind of regression it should catch). That decision is
+only as trustworthy as the metrics underneath it, which previously ran only
+against a live backend and had no direct coverage. These tests pin the pure
+math so a refactor can't silently corrupt every baseline.
+"""
+
+import math
+
+import pytest
+
+from scripts.eval.metrics import dcg, mrr, ndcg_at_k, recall_at_k
+
+
+class TestDCG:
+    def test_empty_is_zero(self):
+        assert dcg([], 10) == 0.0
+
+    def test_single_relevant_at_rank1_no_discount(self):
+        # rank 0 → 1 / log2(2) = 1.0
+        assert dcg([1], 10) == 1.0
+
+    def test_discount_follows_log2_of_position_plus_2(self):
+        # ranks 0,1,2 → 1/log2(2) + 1/log2(3) + 1/log2(4)
+        expected = 1 / math.log2(2) + 1 / math.log2(3) + 1 / math.log2(4)
+        assert math.isclose(dcg([1, 1, 1], 10), expected)
+
+    def test_k_truncates_the_gain_list(self):
+        # only the first 2 positions count even though 3 are relevant
+        assert math.isclose(dcg([1, 1, 1], 2), 1 / math.log2(2) + 1 / math.log2(3))
+
+    def test_zero_gains_contribute_nothing(self):
+        # a relevant doc at rank 3 (index 2) only
+        assert math.isclose(dcg([0, 0, 1], 10), 1 / math.log2(4))
+
+
+class TestNDCG:
+    def test_perfect_ranking_is_one(self):
+        ranked = ["a", "b", "c", "x", "y"]
+        assert ndcg_at_k(ranked, {"a", "b", "c"}, 10) == 1.0
+
+    def test_no_relevant_docs_is_zero(self):
+        assert ndcg_at_k(["a", "b"], set(), 10) == 0.0
+
+    def test_no_hit_in_topk_is_zero(self):
+        assert ndcg_at_k(["x", "y", "z"], {"a"}, 10) == 0.0
+
+    def test_is_normalized_between_zero_and_one(self):
+        # one relevant doc buried at rank 4 (index 3)
+        score = ndcg_at_k(["x", "y", "z", "a"], {"a"}, 10)
+        assert 0.0 < score < 1.0
+        assert math.isclose(score, (1 / math.log2(5)) / 1.0)
+
+    def test_earlier_hit_scores_higher_than_later_hit(self):
+        early = ndcg_at_k(["a", "x", "y", "z"], {"a"}, 10)
+        late = ndcg_at_k(["x", "y", "z", "a"], {"a"}, 10)
+        assert early > late
+
+    def test_this_is_the_2026_06_13_friction_signal(self):
+        # The logged complaint: the on-point hit landed at rank 4 instead of 1.
+        # nDCG must visibly penalize that vs. the ideal, so a ranking fix that
+        # lifts it to rank 1 registers as an improvement.
+        relevant = {"on_point"}
+        rank4 = ndcg_at_k(["noise1", "noise2", "noise3", "on_point"], relevant, 10)
+        rank1 = ndcg_at_k(["on_point", "noise1", "noise2", "noise3"], relevant, 10)
+        assert rank1 == 1.0
+        assert rank4 < rank1
+
+    def test_ideal_capped_at_k_when_more_relevant_than_k(self):
+        # 3 relevant docs but k=2: ideal-DCG uses only the top 2 slots, so two
+        # relevant docs in the top 2 is still a perfect score at k=2.
+        ranked = ["a", "b", "c", "x"]
+        assert ndcg_at_k(ranked, {"a", "b", "c"}, 2) == 1.0
+
+    def test_partial_hit_below_perfect(self):
+        # 2 relevant; only one is in the top-2 → below 1.0
+        score = ndcg_at_k(["a", "x", "b"], {"a", "b"}, 2)
+        assert score < 1.0
+
+
+class TestRecall:
+    def test_all_relevant_found(self):
+        assert recall_at_k(["a", "b", "c"], {"a", "b"}, 3) == 1.0
+
+    def test_half_found(self):
+        assert recall_at_k(["a", "x", "y"], {"a", "b"}, 3) == 0.5
+
+    def test_no_relevant_docs_is_zero_not_div_by_zero(self):
+        assert recall_at_k(["a", "b"], set(), 5) == 0.0
+
+    def test_k_bounds_the_window(self):
+        # relevant doc sits at rank 3 but k=2 → not counted
+        assert recall_at_k(["x", "y", "a"], {"a"}, 2) == 0.0
+
+    def test_relevant_just_inside_window_counts(self):
+        assert recall_at_k(["x", "y", "a"], {"a"}, 3) == 1.0
+
+
+class TestMRR:
+    def test_first_position_is_one(self):
+        assert mrr(["a", "b", "c"], {"a"}) == 1.0
+
+    def test_reciprocal_of_first_hit_rank(self):
+        assert mrr(["x", "y", "a"], {"a"}) == pytest.approx(1 / 3)
+
+    def test_no_hit_is_zero(self):
+        assert mrr(["x", "y", "z"], {"a"}) == 0.0
+
+    def test_uses_earliest_of_several_hits(self):
+        # both "b" and "d" are relevant; first hit is "b" at rank 2
+        assert mrr(["a", "b", "c", "d"], {"b", "d"}) == pytest.approx(1 / 2)
+
+    def test_accepts_any_iterable(self):
+        assert mrr(iter(["x", "a"]), {"a"}) == pytest.approx(1 / 2)


### PR DESCRIPTION
## Summary

Follow-up to the KG-friction thread (#828/#829). I picked the **search-relevance** item next — but found the eval harness I'd offered to build **already exists** and is mature (`scripts/eval/retrieval_eval.py` + `tests/retrieval_eval/` with labels, 5 pinned baselines, nDCG/Recall/MRR, all pipeline configs). So building one would have been wasteful and collision-prone. Instead I closed the one real gap in it.

### The gap
The eval is the tool you'd use to decide whether a ranking change actually helps — the 2026-06-13 *"on-point hit ranked 4th at ~0.13 similarity"* friction is exactly the regression class it exists to catch. But its **own scoring math** (`dcg` / `ndcg_at_k` / `recall_at_k` / `mrr`) only ever ran against a live Postgres + embeddings backend and had **no direct test anywhere**. The harness that validates ranking changes was itself unvalidated, and couldn't run in CI. If that math drifts, every baseline silently becomes untrustworthy.

(Note for contrast: `src/retrieval.py`'s RRF/tag-boost/graph-expand functions *are* well-covered by `tests/test_retrieval_fusion.py` — it's specifically the eval's scorers that had nothing.)

### Change
- **Extract** the four pure scorers into `scripts/eval/metrics.py` (zero backend dependency); the runner imports them and re-exports them so any existing caller keeps working. Mirrors the existing `scripts/dev/calibration_harness` math-vs-runner split (`tests/test_calibration_harness_math.py` is the precedent).
- **Add** `tests/test_retrieval_eval_metrics.py` — 23 cases pinning: DCG log2 discount + k-truncation; nDCG normalization, ideal-cap-at-k, and *earlier-hit-scores-higher* (including an explicit **rank-4-vs-rank-1 friction-signal** test so the metric demonstrably rewards a fix that lifts the on-point hit); recall windowing + no-div-by-zero; MRR earliest-of-several-hits.
- Drops one dead variable (`ideal_rels`) in the moved nDCG.

**Runner behavior unchanged.** This makes the harness CI-runnable and trustworthy, which is the prerequisite for *actually* tuning ranking against the 2026-06-13 case later.

### Verification
`ruff` clean; all 23 assertions verified directly (this container lacks the full app stack that `tests/conftest.py` imports — `prometheus_client`/`mcp`/etc. — so the pytest gate runs in CI).

### Why not tune the ranking in this PR
Tuning RRF/reranker weights needs the labeled corpus *run against a live backend* and a fresh baseline diff — neither is reproducible in this container, and changing weights blind is exactly what this eval exists to prevent. This PR makes that future tuning safe to evaluate. A sensible next step (operator-side, needs the live KG) is to add the 2026-06-13 failing query as a labeled pair and re-baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjoaZwUzP4zkg3cJZD1Hax)_