### PR TITLE
fix(orchestrator): resume one identity per Discord thread instead of minting per turn

### DIFF
--- a/docs/proposals/discord-thread-identity-resume-v0.md
+++ b/docs/proposals/discord-thread-identity-resume-v0.md
@@ -62,15 +62,31 @@ provisioned the anchor, and the reference onboard hook hard-coded `force_new=tru
 
 ## Remaining cross-repo follow-ups (not in this PR)
 
-- **Dispatch / Discord-bridge worker** (separate repo): when spawning a turn's
-  agent via `POST /v1/agents`, pass `client_session_id: "agent:/thread-<discord-thread-id>"`
-  (one stable anchor per thread). This is the value that makes the whole chain
-  resume.
+The common contract is: **the `claude -p` child receives `UNITARES_CLIENT_SESSION_ID`
+in its env, stable per conversation** (e.g. `agent:/thread-<discord-thread-id>`).
+How the anchor *reaches* the child env depends on the spawn path:
+
+- **Dispatch / Discord-bridge worker** (separate repo) — two spawn paths, same
+  env-var destination:
+  - *HTTP-API spawners* (drive the orchestrator via `POST /v1/agents`): pass the
+    `client_session_id` field; the orchestrator provisions `UNITARES_CLIENT_SESSION_ID`
+    (this PR).
+  - *Direct-Port spawners* (e.g. `dispatch_beam`'s `Dispatch.AgentPort`, which
+    opens a BEAM `Port` to `claude -p` and does **not** call `/v1/agents`): set the
+    env var directly on the Port spawn —
+    `env: [{"UNITARES_CLIENT_SESSION_ID", "agent:/thread-#{thread_id}"}]`. `AgentPort`
+    already threads `env:` into `port_opts` and it composes with the stdin-redirect
+    wrapper, so the child's session-start hook inherits it. Same no-forging boundary
+    as the orchestrator path: anchor only, the child still self-onboards.
 - **gov-plugin session-start hook** (`unitares-governance-plugin`): mirror the
   `onboard_helper.py` change — when `UNITARES_CLIENT_SESSION_ID` is present, onboard
   in resume-by-anchor mode rather than `force_new`. The plugin hook is the actual
   onboarder for `claude -p` children; `onboard_helper.py` is the in-repo reference
   implementation of the same contract.
+
+**Sequencing:** the env var is a no-op until the gov-plugin hook reads it, so:
+this PR merges → gov-plugin hook mirrors the helper → the worker (HTTP or
+direct-Port) injects the anchor.
 
 ## Honesty boundary
 

--- a/docs/proposals/discord-thread-identity-resume-v0.md
+++ b/docs/proposals/discord-thread-identity-resume-v0.md
@@ -1,0 +1,83 @@
+# Discord BEAM thread identity — resume-per-thread (v0)
+
+**Created:** June 18, 2026
+**Status:** Orchestrator + reference-hook side SHIPPED in this PR; the gov-plugin
+session-hook mirror and the dispatch-worker anchor are the remaining cross-repo
+follow-ups (below). No new server behavior — the resume path already exists.
+**Operator decision (2026-06-18):** *one id per thread (resume)*, fix in *this
+repo (orchestrator + server)*.
+**Touches:** identity/onboarding (writer-locked surface — see CLAUDE.md). Operator
+is the merge gate.
+
+## The symptom
+
+The Discord "BEAM Claude" runs as an ephemeral agent spawned **per turn** through
+`AgentOrchestrator.AgentRunner` — one OS process per turn, wrapping a `Port` to a
+`claude -p` runtime. Each fresh process opens a **new** governance MCP session, so
+`derive_session_key` falls to the new per-connection MCP session id, and the
+session-start onboard mints a **fresh UUID every turn**. Consecutive turns of one
+Discord conversation were therefore disconnected identities, not one agent.
+
+## Why this is not just "fresh process = fresh agent"
+
+Per `identity.md` v2, a fresh process-instance *is* a fresh agent — that is correct
+for genuinely independent sessions. But the turns of one Discord thread are **one
+logical conversation**: the thread is the identity anchor (`thread_identity.py`:
+"A thread is the user's conversation — the true identity anchor"). The fix is to
+give those turns a **stable session anchor** so they resume one identity, rather
+than mint per turn. This is *resume*, not lineage — the turns are the same agent,
+not a parent/child chain.
+
+## The mechanism (already supported server-side)
+
+`handle_onboard_v2` defaults `resume=True` (`handlers.py:1670`). A stable
+`client_session_id` resolves to the **same** governance UUID across processes:
+
+1. **Turn 1** — onboard under anchor `agent:/thread-<id>`, `resume=True`, no
+   binding yet → PATH 2 fail-closed `session_resolve_miss` → falls through to the
+   create-finisher → mints + **binds** the session under the anchor key.
+2. **Turn 2..N** — same anchor, `resume=True` → PATH 1/2 hit → returns the turn-1
+   UUID. One id for the whole thread.
+
+So no server change was needed. The two gaps were purely *plumbing*: nothing
+provisioned the anchor, and the reference onboard hook hard-coded `force_new=true`.
+
+## What shipped here
+
+1. **Orchestrator (`agent_runner.ex` + `http_router.ex`).** New top-level spec key
+   `client_session_id:` provisions `UNITARES_CLIENT_SESSION_ID` into the child env,
+   under the same explicit-wins + validation discipline as `server_url` /
+   lineage. A blank or non-string anchor refuses the spawn
+   (`{:invalid_client_session_id, _}` → HTTP 422) — a blank anchor would silently
+   degrade back to fresh-mint-per-turn, the exact symptom this prevents. The
+   `POST /v1/agents` body accepts `client_session_id`. Tests mirror the
+   `server-url provisioning` block.
+
+2. **Reference onboard hook (`scripts/client/onboard_helper.py`).** When
+   `UNITARES_CLIENT_SESSION_ID` is set, the helper resumes under the anchor
+   (sends `client_session_id`, **omits** `force_new`, declares **no** lineage)
+   instead of the default fresh-mint posture. Additive and gated: when the env is
+   unset, behavior is byte-identical to before. An explicit `force_new` still wins
+   (a deliberate clean break).
+
+## Remaining cross-repo follow-ups (not in this PR)
+
+- **Dispatch / Discord-bridge worker** (separate repo): when spawning a turn's
+  agent via `POST /v1/agents`, pass `client_session_id: "agent:/thread-<discord-thread-id>"`
+  (one stable anchor per thread). This is the value that makes the whole chain
+  resume.
+- **gov-plugin session-start hook** (`unitares-governance-plugin`): mirror the
+  `onboard_helper.py` change — when `UNITARES_CLIENT_SESSION_ID` is present, onboard
+  in resume-by-anchor mode rather than `force_new`. The plugin hook is the actual
+  onboarder for `claude -p` children; `onboard_helper.py` is the in-repo reference
+  implementation of the same contract.
+
+## Honesty boundary
+
+This confers a **resumed process-instance identity within one conversation**, keyed
+on a caller-supplied anchor — *not* a cross-process *strong* credential. Resume by
+`client_session_id` stays weak/medium under the #425/#810 taxonomy (the anchor is a
+copyable string). Earning a genuine `strong` tier for orchestrated children is the
+separate, deferred `orchestrator-vouched-identity-v0.md` track. Resume-per-thread
+is the right tool for "one id per Discord conversation"; it does not and should not
+claim attestation.

--- a/elixir/agent_orchestrator/lib/agent_orchestrator/agent_runner.ex
+++ b/elixir/agent_orchestrator/lib/agent_orchestrator/agent_runner.ex
@@ -35,7 +35,8 @@ defmodule AgentOrchestrator.AgentRunner do
                                            # false = no presence; map = override
         lease_client: module(),            # injectable, default LeasePlaneClient
         lineage: nil | lineage_cfg,        # default nil = no lineage provisioning
-        server_url: String.t() | nil       # default nil = no server-URL provisioning
+        server_url: String.t() | nil,      # default nil = no server-URL provisioning
+        client_session_id: String.t() | nil # default nil = no session-anchor provisioning
       }
 
       lease_cfg :: %{
@@ -81,6 +82,27 @@ defmodule AgentOrchestrator.AgentRunner do
   {:invalid_server_url, _}}`) — a malformed URL fails at the child as a
   confusing OFFLINE, far from its cause.
 
+  ## Session-anchor provisioning (thread-stable identity)
+
+  `client_session_id:` provisions `UNITARES_CLIENT_SESSION_ID` into the child
+  env under the same explicit-wins rule. It is the **continuity anchor** a
+  spawner passes when many short-lived children are turns of one logical
+  conversation (the canonical case: the Discord BEAM bridge, where each user
+  turn is a fresh `claude -p` process). Each fresh process otherwise opens a new
+  governance session and onboards a fresh identity — a new UUID *every turn*.
+  When the spawner passes a **stable** per-conversation anchor (e.g.
+  `"agent:/thread-<discord-thread-id>"`), every turn's child onboards under the
+  same session key and the server resolves it to the **same** governance UUID
+  across turns (resume), instead of minting a disconnected identity each time.
+
+  This is transport/continuity config, not lineage (the turns are the *same*
+  agent resumed, not a parent/child chain), hence a top-level key rather than a
+  `lineage_cfg` field. The orchestrator does NOT onboard on the child's behalf;
+  it only places the anchor where the child's onboard hook can find it. An empty
+  or non-string value refuses the spawn (`{:error, {:invalid_client_session_id,
+  _}}`) — a blank anchor would silently degrade back to fresh-mint-per-turn, the
+  exact failure this provisioning exists to prevent.
+
   ## Presence
 
   By default an agent registers an `agent:/<id>` PRESENCE row on the lease plane
@@ -109,6 +131,7 @@ defmodule AgentOrchestrator.AgentRunner do
   # Lineage-provisioning env vars surfaced to the child (candidate
   # declarations — see "Lineage provisioning" in the moduledoc).
   @server_url_var "UNITARES_SERVER_URL"
+  @client_session_id_var "UNITARES_CLIENT_SESSION_ID"
   @lineage_parent_var "UNITARES_PARENT_AGENT_ID"
   @lineage_reason_var "UNITARES_SPAWN_REASON"
   @default_spawn_reason "subagent"
@@ -246,15 +269,25 @@ defmodule AgentOrchestrator.AgentRunner do
             {:stop, {:invalid_server_url, reason}}
 
           {:ok, server_url} ->
-            state = %__MODULE__{
-              agent_id: agent_id,
-              lease_client: lease_client,
-              lease_cfg: lease_cfg,
-              lineage: if(lineage_cfg, do: :provisioned, else: :none),
-              max_output_lines: Map.get(spec, :max_output_lines, @default_max_lines)
-            }
+            case normalize_client_session_id(Map.get(spec, :client_session_id)) do
+              {:error, reason} ->
+                {:stop, {:invalid_client_session_id, reason}}
 
-            init_with_lease(state, spec, candidate_env(lineage_cfg, server_url))
+              {:ok, client_session_id} ->
+                state = %__MODULE__{
+                  agent_id: agent_id,
+                  lease_client: lease_client,
+                  lease_cfg: lease_cfg,
+                  lineage: if(lineage_cfg, do: :provisioned, else: :none),
+                  max_output_lines: Map.get(spec, :max_output_lines, @default_max_lines)
+                }
+
+                init_with_lease(
+                  state,
+                  spec,
+                  candidate_env(lineage_cfg, server_url, client_session_id)
+                )
+            end
         end
     end
   end
@@ -545,9 +578,26 @@ defmodule AgentOrchestrator.AgentRunner do
 
   defp normalize_server_url(other), do: {:error, {:server_url_not_string, other}}
 
+  # Non-empty-string check only — the server canonicalizes/sanitizes the session
+  # key itself (see resolve_session_identity). An empty/blank anchor is refused
+  # here because it would silently fall back to fresh-mint-per-turn, the exact
+  # symptom this provisioning prevents (a confusing "still minting" far from the
+  # blank-anchor cause).
+  defp normalize_client_session_id(nil), do: {:ok, nil}
+
+  defp normalize_client_session_id(v) when is_binary(v) do
+    if String.trim(v) == "" do
+      {:error, {:client_session_id_blank, v}}
+    else
+      {:ok, v}
+    end
+  end
+
+  defp normalize_client_session_id(other), do: {:error, {:client_session_id_not_string, other}}
+
   # The full provisioned-candidate list for the child env, built from the
   # already-validated configs.
-  defp candidate_env(lineage_cfg, server_url) do
+  defp candidate_env(lineage_cfg, server_url, client_session_id) do
     lineage =
       case lineage_cfg do
         nil -> []
@@ -555,7 +605,8 @@ defmodule AgentOrchestrator.AgentRunner do
       end
 
     server = if server_url, do: [{@server_url_var, server_url}], else: []
-    lineage ++ server
+    session = if client_session_id, do: [{@client_session_id_var, client_session_id}], else: []
+    lineage ++ server ++ session
   end
 
   defp provisioned_env([], _env), do: []

--- a/elixir/agent_orchestrator/lib/agent_orchestrator/http_router.ex
+++ b/elixir/agent_orchestrator/lib/agent_orchestrator/http_router.ex
@@ -146,13 +146,15 @@ defmodule AgentOrchestrator.HTTPRouter do
          {:ok, max_lines} <- fetch_max_lines(body),
          {:ok, lease} <- fetch_lease(body),
          {:ok, lineage} <- fetch_lineage(body),
-         {:ok, server_url} <- fetch_string(body, "server_url") do
+         {:ok, server_url} <- fetch_string(body, "server_url"),
+         {:ok, client_session_id} <- fetch_string(body, "client_session_id") do
       spec =
         %{cmd: cmd, args: args, env: env}
         |> put_opt(:cd, cd)
         |> put_opt(:max_output_lines, max_lines)
         |> put_opt(:lineage, lineage)
         |> put_opt(:server_url, server_url)
+        |> put_opt(:client_session_id, client_session_id)
         |> put_lease(lease)
 
       {:ok, spec}
@@ -296,6 +298,9 @@ defmodule AgentOrchestrator.HTTPRouter do
 
   defp spawn_error(conn, {:invalid_server_url, reason}),
     do: json(conn, 422, %{ok: false, error: "schema_invalid", detail: "invalid server_url: #{inspect(reason)}"})
+
+  defp spawn_error(conn, {:invalid_client_session_id, reason}),
+    do: json(conn, 422, %{ok: false, error: "schema_invalid", detail: "invalid client_session_id: #{inspect(reason)}"})
 
   defp spawn_error(conn, {:executable_not_found, cmd}),
     do: json(conn, 422, %{ok: false, error: "schema_invalid", detail: "executable not found: #{cmd}"})

--- a/elixir/agent_orchestrator/test/agent_orchestrator_test.exs
+++ b/elixir/agent_orchestrator/test/agent_orchestrator_test.exs
@@ -407,6 +407,93 @@ defmodule AgentOrchestratorTest do
     end
   end
 
+  describe "session-anchor provisioning (thread-stable identity)" do
+    test "provisions UNITARES_CLIENT_SESSION_ID into the child env" do
+      {:ok, id, _} =
+        AgentOrchestrator.run(%{
+          cmd: "sh",
+          args: ["-c", "echo $UNITARES_CLIENT_SESSION_ID"],
+          client_session_id: "agent:/thread-discord-42"
+        })
+
+      assert {:ok, %{output: ["agent:/thread-discord-42"], exit_status: 0}} =
+               AgentOrchestrator.await(id)
+    end
+
+    test "an explicit env entry wins over the provisioned anchor" do
+      {:ok, id, _} =
+        AgentOrchestrator.run(%{
+          cmd: "sh",
+          args: ["-c", "echo $UNITARES_CLIENT_SESSION_ID"],
+          env: [{"UNITARES_CLIENT_SESSION_ID", "agent:/caller-anchor"}],
+          client_session_id: "agent:/provisioned-anchor"
+        })
+
+      assert {:ok, %{output: ["agent:/caller-anchor"]}} = AgentOrchestrator.await(id)
+    end
+
+    test "refuses a blank anchor (no acquire, no child)" do
+      assert {:error, {:invalid_client_session_id, {:client_session_id_blank, "  "}}} =
+               AgentOrchestrator.run(%{
+                 cmd: "echo",
+                 args: ["x"],
+                 client_session_id: "  ",
+                 lease_client: StubLeaseClient
+               })
+
+      refute_receive {:lease_event, _}, 100
+    end
+
+    test "refuses a non-string anchor" do
+      assert {:error, {:invalid_client_session_id, {:client_session_id_not_string, 123}}} =
+               AgentOrchestrator.run(%{cmd: "echo", args: ["x"], client_session_id: 123})
+    end
+
+    test "without the key nothing is provisioned" do
+      {:ok, id, _} =
+        AgentOrchestrator.run(%{
+          cmd: "sh",
+          args: ["-c", ~s(echo "${UNITARES_CLIENT_SESSION_ID-unset}")]
+        })
+
+      assert {:ok, %{output: ["unset"], exit_status: 0}} = AgentOrchestrator.await(id)
+    end
+
+    test "env: nil with client_session_id provisions without crashing" do
+      {:ok, id, _} =
+        AgentOrchestrator.run(%{
+          cmd: "sh",
+          args: ["-c", "echo $UNITARES_CLIENT_SESSION_ID"],
+          env: nil,
+          client_session_id: "agent:/thread-7"
+        })
+
+      assert {:ok, %{output: ["agent:/thread-7"], exit_status: 0}} =
+               AgentOrchestrator.await(id)
+    end
+
+    test "composes with lineage and server-url provisioning" do
+      {:ok, id, _} =
+        AgentOrchestrator.run(%{
+          cmd: "sh",
+          args: [
+            "-c",
+            ~s(echo "$UNITARES_PARENT_AGENT_ID|$UNITARES_SERVER_URL|$UNITARES_CLIENT_SESSION_ID")
+          ],
+          lineage: %{parent_agent_uuid: "55555555-5555-4555-8555-555555555555"},
+          server_url: "https://gov.example:8767",
+          client_session_id: "agent:/thread-9"
+        })
+
+      assert {:ok,
+              %{
+                output: [
+                  "55555555-5555-4555-8555-555555555555|https://gov.example:8767|agent:/thread-9"
+                ]
+              }} = AgentOrchestrator.await(id)
+    end
+  end
+
   describe "presence (default-on, best-effort)" do
     # Long-lived agents + snapshot/0 (read while alive) — avoids the await race
     # where a fast command exits and unregisters before the assertion runs.

--- a/elixir/agent_orchestrator/test/http_router_test.exs
+++ b/elixir/agent_orchestrator/test/http_router_test.exs
@@ -142,6 +142,36 @@ defmodule AgentOrchestrator.HTTPRouterTest do
       assert conn.status == 422
       assert body_json(conn)["detail"] =~ "invalid lineage"
     end
+
+    test "client_session_id threads through to the child env (thread-anchor resume)" do
+      conn =
+        call(
+          authed(:post, "/v1/agents", %{
+            cmd: "sh",
+            args: ["-c", "echo $UNITARES_CLIENT_SESSION_ID"],
+            client_session_id: "agent:/thread-discord-7"
+          })
+        )
+
+      assert conn.status == 201
+      agent_id = body_json(conn)["agent_id"]
+
+      await = call(authed(:post, "/v1/agents/#{agent_id}/await", %{timeout_ms: 5_000}))
+      assert await.status == 200
+      assert body_json(await)["result"]["output"] == ["agent:/thread-discord-7"]
+    end
+
+    test "422 on a blank client_session_id (runner refuses the spawn)" do
+      conn = call(authed(:post, "/v1/agents", %{cmd: "echo", client_session_id: "  "}))
+      assert conn.status == 422
+      assert body_json(conn)["detail"] =~ "invalid client_session_id"
+    end
+
+    test "422 on a non-string client_session_id" do
+      conn = call(authed(:post, "/v1/agents", %{cmd: "echo", client_session_id: 123}))
+      assert conn.status == 422
+      assert body_json(conn)["detail"] =~ "client_session_id must be a string"
+    end
   end
 
   describe "GET /v1/agents" do

--- a/scripts/client/onboard_helper.py
+++ b/scripts/client/onboard_helper.py
@@ -261,6 +261,7 @@ def run_onboard(
     workspace: Path,
     slot: str | None = None,
     force_new: bool = False,
+    client_session_id: str | None = None,
     auth_token: str | None = None,
     timeout: float = DEFAULT_TIMEOUT,
     with_bootstrap: bool = True,
@@ -275,6 +276,17 @@ def run_onboard(
     session_id from hook input). When omitted, falls back to the legacy
     shared session.json — preserves single-process behavior.
 
+    ``client_session_id`` is the **thread-anchor resume** path
+    (``UNITARES_CLIENT_SESSION_ID``, provisioned by the BEAM orchestrator for
+    conversation-turn agents like the Discord bridge). When set, the helper
+    resumes the SAME governance UUID under that stable anchor instead of the
+    default fresh-mint-per-process posture — so consecutive turns of one
+    conversation are one resumed agent, not a new id every turn. force_new is
+    omitted in this mode (the server defaults resume=True); the first turn
+    mints+binds the anchor, later turns resume it. When unset, behavior is
+    byte-identical to before (force_new + cached-lineage declaration). An
+    explicit ``force_new`` still wins — it is a deliberate clean break.
+
     ``with_bootstrap`` (default True) attaches an initial_state payload so
     the server writes a bootstrap check-in row at t=0 per
  §3.5. Idempotent on resume
@@ -283,18 +295,28 @@ def run_onboard(
     url = f"{server_url.rstrip('/')}/v1/tools/call"
     cache = read_cache(workspace, slot)
 
+    anchor = (client_session_id or "").strip()
     parent_agent_id = ""
-    if not force_new:
-        parent_agent_id = (cache.get("uuid") or cache.get("agent_uuid") or "").strip()
 
     arguments: dict[str, Any] = {
         "name": agent_name,
         "model_type": model_type,
-        "force_new": True,
     }
-    if parent_agent_id:
-        arguments["parent_agent_id"] = parent_agent_id
-        arguments["spawn_reason"] = "new_session"
+
+    if anchor and not force_new:
+        # Thread-anchored resume: stable per-conversation session key, one
+        # resumed UUID across turns. No force_new (server default resume=True),
+        # no lineage — the turns are the same agent, not a parent/child chain.
+        arguments["client_session_id"] = anchor
+    else:
+        # Default posture (identity.md v2): fresh process = fresh agent. Mint
+        # with force_new and declare cached lineage via parent_agent_id.
+        arguments["force_new"] = True
+        if not force_new:
+            parent_agent_id = (cache.get("uuid") or cache.get("agent_uuid") or "").strip()
+        if parent_agent_id:
+            arguments["parent_agent_id"] = parent_agent_id
+            arguments["spawn_reason"] = "new_session"
 
     if with_bootstrap:
         arguments["initial_state"] = _build_bootstrap_initial_state()
@@ -376,12 +398,21 @@ def main(argv: list[str] | None = None) -> int:
              "parallel processes in the same workspace don't collide on "
              "the same cache file.",
     )
+    parser.add_argument(
+        "--client-session-id",
+        default=os.environ.get("UNITARES_CLIENT_SESSION_ID", ""),
+        help="Stable per-conversation session anchor (typically provisioned "
+             "as UNITARES_CLIENT_SESSION_ID by the BEAM orchestrator for "
+             "turn-based agents like the Discord bridge). When set, resume the "
+             "SAME identity across turns instead of minting a new id each turn.",
+    )
     parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
     args = parser.parse_args(argv)
 
     auth_token = os.environ.get("UNITARES_HTTP_API_TOKEN") or None
     workspace = Path(args.workspace).expanduser().resolve()
     slot = (args.slot or "").strip() or None
+    client_session_id = (args.client_session_id or "").strip() or None
     result = run_onboard(
         server_url=args.server_url,
         agent_name=args.name,
@@ -389,6 +420,7 @@ def main(argv: list[str] | None = None) -> int:
         workspace=workspace,
         slot=slot,
         force_new=args.force_new,
+        client_session_id=client_session_id,
         with_bootstrap=args.with_bootstrap,
         auth_token=auth_token,
         timeout=args.timeout,

--- a/tests/test_onboard_helper.py
+++ b/tests/test_onboard_helper.py
@@ -321,6 +321,103 @@ class TestRunOnboard:
         assert "client_session_id" not in sent_args
 
 
+# --- thread-anchor resume (UNITARES_CLIENT_SESSION_ID) ---------------------
+
+class TestThreadAnchorResume:
+    """When the orchestrator provisions a stable per-conversation
+    client_session_id (UNITARES_CLIENT_SESSION_ID), the helper resumes the same
+    identity across turns instead of minting a new id every turn — the Discord
+    BEAM bridge case.
+    """
+
+    def _call(
+        self,
+        tmp_path: Path,
+        responses: list[dict],
+        *,
+        client_session_id: str | None,
+        force_new: bool = False,
+        initial_cache: dict | None = None,
+    ) -> tuple[dict, FakePoster]:
+        if initial_cache is not None:
+            cache_dir = tmp_path / ".unitares"
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            (cache_dir / "session.json").write_text(json.dumps(initial_cache))
+        poster = FakePoster(responses)
+        result = run_onboard(
+            server_url="http://fake",
+            agent_name="acme",
+            model_type="claude-code",
+            workspace=tmp_path,
+            client_session_id=client_session_id,
+            force_new=force_new,
+            post_json=poster,
+        )
+        return result, poster
+
+    def test_anchor_resumes_instead_of_force_new(self, tmp_path: Path) -> None:
+        _, poster = self._call(
+            tmp_path, [_success_response()],
+            client_session_id="agent:/thread-discord-42",
+        )
+        sent_args = poster.calls[0][1]["arguments"]
+        # Resume posture: stable anchor sent, NO force_new, NO lineage.
+        assert sent_args["client_session_id"] == "agent:/thread-discord-42"
+        assert "force_new" not in sent_args
+        assert "parent_agent_id" not in sent_args
+        assert "spawn_reason" not in sent_args
+
+    def test_anchor_does_not_declare_cached_lineage(self, tmp_path: Path) -> None:
+        """Even with a cached UUID, anchor mode resumes (one agent across turns),
+        it does NOT declare the cache as a parent."""
+        initial = {"uuid": "prior-turn-uuid", "client_session_id": "agent:/thread-1"}
+        _, poster = self._call(
+            tmp_path, [_success_response()],
+            client_session_id="agent:/thread-1",
+            initial_cache=initial,
+        )
+        sent_args = poster.calls[0][1]["arguments"]
+        assert sent_args["client_session_id"] == "agent:/thread-1"
+        assert "parent_agent_id" not in sent_args
+        assert "force_new" not in sent_args
+
+    def test_explicit_force_new_wins_over_anchor(self, tmp_path: Path) -> None:
+        """force_new is a deliberate clean break — it overrides the anchor."""
+        _, poster = self._call(
+            tmp_path, [_success_response()],
+            client_session_id="agent:/thread-9",
+            force_new=True,
+        )
+        sent_args = poster.calls[0][1]["arguments"]
+        assert sent_args["force_new"] is True
+        assert "client_session_id" not in sent_args
+
+    def test_blank_anchor_falls_back_to_default_mint(self, tmp_path: Path) -> None:
+        """A blank/whitespace anchor is treated as absent — default fresh mint."""
+        _, poster = self._call(
+            tmp_path, [_success_response()],
+            client_session_id="   ",
+        )
+        sent_args = poster.calls[0][1]["arguments"]
+        assert sent_args["force_new"] is True
+        assert "client_session_id" not in sent_args
+
+    def test_no_anchor_is_byte_identical_to_default(self, tmp_path: Path) -> None:
+        """Without the anchor, behavior is unchanged (force_new + no client id)."""
+        _, poster = self._call(tmp_path, [_success_response()], client_session_id=None)
+        sent_args = poster.calls[0][1]["arguments"]
+        assert sent_args["force_new"] is True
+        assert "client_session_id" not in sent_args
+
+    def test_anchor_still_attaches_bootstrap_initial_state(self, tmp_path: Path) -> None:
+        _, poster = self._call(
+            tmp_path, [_success_response()],
+            client_session_id="agent:/thread-5",
+        )
+        sent_args = poster.calls[0][1]["arguments"]
+        assert "initial_state" in sent_args
+
+
 # --- per-process slot isolation --------------------------------------------
 
 class TestSlotIsolation:


### PR DESCRIPTION
## Why "Discord BEAM Claude mints a new id every turn"

The Discord bridge runs as an **ephemeral agent spawned per turn** through `AgentOrchestrator.AgentRunner` — one OS process per turn wrapping a `Port` to a `claude -p` runtime. Each fresh process opens a **new** governance MCP session, so `derive_session_key` (`src/mcp_handlers/identity/session.py`) falls to the new per-connection MCP session id, and the session-start onboard mints a **fresh UUID every turn**. Consecutive turns of one Discord conversation were therefore disconnected identities, not one agent.

## The fix (operator decision 2026-06-18: *one id per thread (resume)*, in this repo)

The **server already supports resume-per-thread** — no server change needed:
- `handle_onboard_v2` defaults `resume=True` (`handlers.py:1670`).
- A stable `client_session_id` resolves to the **same** UUID across processes: turn 1 mints + binds the anchor (`session_resolve_miss` → create-finisher), turns 2..N resume it via PATH 1/2.

The two gaps were pure plumbing:

1. **Orchestrator** (`agent_runner.ex` + `http_router.ex`) — new top-level `client_session_id:` spec key provisions `UNITARES_CLIENT_SESSION_ID` into the child env, under the same explicit-wins + validation discipline as `server_url`/lineage. A blank/non-string anchor refuses the spawn (`{:invalid_client_session_id, _}` → HTTP 422) — a blank anchor would silently degrade back to fresh-mint-per-turn. `POST /v1/agents` accepts `client_session_id`.
2. **Reference onboard hook** (`scripts/client/onboard_helper.py`) — when `UNITARES_CLIENT_SESSION_ID` is set, resume under the anchor (send `client_session_id`, omit `force_new`, no lineage). **Additive and gated**: unset env ⇒ byte-identical to before; an explicit `force_new` still wins.

## Scope / honesty boundary

This confers a **resumed process-instance identity within one conversation**, keyed on a caller-supplied anchor — *not* a strong cross-process credential (the anchor is a copyable string; stays weak/medium under #425/#810). Earning a genuine `strong` tier for orchestrated children is the separate deferred `orchestrator-vouched-identity-v0.md` track.

## Remaining cross-repo follow-ups (not in this PR)

- **Dispatch / Discord-bridge worker** (separate repo): pass `client_session_id: "agent:/thread-<discord-thread-id>"` to `POST /v1/agents` — the value that makes the chain resume.
- **gov-plugin session-start hook** (`unitares-governance-plugin`): mirror the `onboard_helper.py` change (the plugin hook is the actual onboarder for `claude -p` children).

See `docs/proposals/discord-thread-identity-resume-v0.md`.

## Tests

- 6 new Python helper tests (anchor resumes / no lineage / explicit force_new wins / blank falls back / no-anchor byte-identical / bootstrap preserved). **Python suite green: 39/39.**
- 6 new Elixir runner tests + 3 router tests mirroring the `server-url provisioning` block. Elixir runs `mix test` on the deploy host (not CI) per `agent-orchestrator-beam-v0.md`.

> ⚠️ Touches the writer-locked identity/onboarding surface (per CLAUDE.md). No in-flight PRs on it at branch time. Operator is the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yXwYYm4UdbMFbYmn4akrK

---
_Generated by [Claude Code](https://claude.ai/code/session_012yXwYYm4UdbMFbYmn4akrK)_