### PR TITLE
fix(identity): fail-closed guard on thread-anchor resume (require orchestration marker)

### DIFF
--- a/docs/proposals/discord-thread-identity-resume-v0.md
+++ b/docs/proposals/discord-thread-identity-resume-v0.md
@@ -1,11 +1,14 @@
 # Discord BEAM thread identity — resume-per-thread (v0)
 
 **Created:** June 18, 2026
-**Status:** Orchestrator + reference-hook side SHIPPED in this PR; the gov-plugin
-session-hook mirror and the dispatch-worker anchor are the remaining cross-repo
-follow-ups (below). No new server behavior — the resume path already exists.
+**Status:** Orchestrator + reference-hook side merged (#834). The **fail-closed
+guard** (anchor honored only with an explicit orchestration marker) is a follow-up
+hardening on top of #834. The gov-plugin session-hook mirror and the dispatch-worker
+anchor remain cross-repo follow-ups (below). No new server behavior — the resume
+path already exists.
 **Operator decision (2026-06-18):** *one id per thread (resume)*, fix in *this
-repo (orchestrator + server)*.
+repo (orchestrator + server)*; *fail-closed, no council* (the guard re-applies the
+ratified anti-siphon principle, it is not a new ontological claim).
 **Touches:** identity/onboarding (writer-locked surface — see CLAUDE.md). Operator
 is the merge gate.
 
@@ -54,39 +57,69 @@ provisioned the anchor, and the reference onboard hook hard-coded `force_new=tru
    `server-url provisioning` block.
 
 2. **Reference onboard hook (`scripts/client/onboard_helper.py`).** When
-   `UNITARES_CLIENT_SESSION_ID` is set, the helper resumes under the anchor
-   (sends `client_session_id`, **omits** `force_new`, declares **no** lineage)
-   instead of the default fresh-mint posture. Additive and gated: when the env is
-   unset, behavior is byte-identical to before. An explicit `force_new` still wins
-   (a deliberate clean break).
+   `UNITARES_CLIENT_SESSION_ID` is set **and** the orchestration signal is present
+   (see fail-closed guard below), the helper resumes under the anchor (sends
+   `client_session_id`, **omits** `force_new`, declares **no** lineage) instead of
+   the default fresh-mint posture. Additive and gated: with no anchor (or no
+   orchestration signal), behavior is byte-identical to before. An explicit
+   `force_new` still wins (a deliberate clean break).
+
+## Fail-closed: why a bare anchor is not enough
+
+**The same onboard hook is the onboarder for *normal interactive* sessions, not
+just `claude -p` children.** So "resume whenever `UNITARES_CLIENT_SESSION_ID` is
+set" is too blunt: if that var ever leaked into a normal session's environment (a
+stray global `export`, an inherited shell), the session would silently flip into
+resume mode — and two normal sessions that happened to share the leaked value would
+resume onto **one** governance UUID. That is exactly the ghost-siphon the v2
+ontology removed name-claim resolution to prevent (multiple subjects collapsing
+onto one identity by a weak shared signal).
+
+The guard: resume is honored only with an **explicit positive orchestration
+signal** — `UNITARES_ORCHESTRATED=1`, set by the spawner *alongside* the anchor.
+The orchestrator/dispatch KNOWS its children are orchestrated headless turn-children,
+so it declares it; an interactive session never carries the marker. Absent the
+marker, the anchor is ignored and the hook mints exactly as today. So a leaked
+anchor on an interactive session is a **no-op, never a siphon** — the dangerous
+direction is structurally impossible, which is why this needs no council (it
+re-applies a ratified principle, fail-closed).
+
+- Orchestrator: `agent_runner.ex` provisions `UNITARES_ORCHESTRATED=1` *with* the
+  anchor (one unit — both or neither).
+- Reference hook: `run_onboard(orchestrated=...)`; the anchor wins only when
+  `orchestrated` is true. The CLI derives it from `--orchestrated` /
+  `UNITARES_ORCHESTRATED` (affirmatives only — `_env_truthy`).
+- Defense-in-depth for the real plugin: it should set `orchestrated=True` only for
+  **headless `-p`** children (its own structural discriminator from the hook input),
+  so interactive sessions are immune even if the marker leaked too.
 
 ## Remaining cross-repo follow-ups (not in this PR)
 
-The common contract is: **the `claude -p` child receives `UNITARES_CLIENT_SESSION_ID`
-in its env, stable per conversation** (e.g. `agent:/thread-<discord-thread-id>`).
-How the anchor *reaches* the child env depends on the spawn path:
+The common contract is: **the `claude -p` child receives BOTH
+`UNITARES_CLIENT_SESSION_ID` (the per-conversation anchor) AND
+`UNITARES_ORCHESTRATED=1` (the fail-closed marker) in its env.** How they *reach*
+the child depends on the spawn path:
 
 - **Dispatch / Discord-bridge worker** (separate repo) — two spawn paths, same
   env-var destination:
   - *HTTP-API spawners* (drive the orchestrator via `POST /v1/agents`): pass the
-    `client_session_id` field; the orchestrator provisions `UNITARES_CLIENT_SESSION_ID`
-    (this PR).
+    `client_session_id` field; the orchestrator provisions both env vars.
   - *Direct-Port spawners* (e.g. `dispatch_beam`'s `Dispatch.AgentPort`, which
-    opens a BEAM `Port` to `claude -p` and does **not** call `/v1/agents`): set the
-    env var directly on the Port spawn —
-    `env: [{"UNITARES_CLIENT_SESSION_ID", "agent:/thread-#{thread_id}"}]`. `AgentPort`
-    already threads `env:` into `port_opts` and it composes with the stdin-redirect
-    wrapper, so the child's session-start hook inherits it. Same no-forging boundary
-    as the orchestrator path: anchor only, the child still self-onboards.
+    opens a BEAM `Port` to `claude -p` and does **not** call `/v1/agents`): set both
+    on the Port spawn —
+    `env: [{"UNITARES_CLIENT_SESSION_ID", "agent:/thread-#{thread_id}"}, {"UNITARES_ORCHESTRATED", "1"}]`.
+    `AgentPort` already threads `env:` into `port_opts` and it composes with the
+    stdin-redirect wrapper, so the child's session-start hook inherits them. Same
+    no-forging boundary: anchor only, the child still self-onboards.
 - **gov-plugin session-start hook** (`unitares-governance-plugin`): mirror the
-  `onboard_helper.py` change — when `UNITARES_CLIENT_SESSION_ID` is present, onboard
-  in resume-by-anchor mode rather than `force_new`. The plugin hook is the actual
-  onboarder for `claude -p` children; `onboard_helper.py` is the in-repo reference
-  implementation of the same contract.
+  `onboard_helper.py` contract — resume under the anchor only when the orchestration
+  signal is present (and, defense-in-depth, the session is headless). The plugin
+  hook is the actual onboarder for `claude -p` children; `onboard_helper.py` is the
+  in-repo reference implementation.
 
-**Sequencing:** the env var is a no-op until the gov-plugin hook reads it, so:
-this PR merges → gov-plugin hook mirrors the helper → the worker (HTTP or
-direct-Port) injects the anchor.
+**Sequencing:** the env vars are a no-op until the gov-plugin hook reads them, so:
+gov-plugin hook mirrors the helper → the worker (HTTP or direct-Port) injects the
+anchor + marker.
 
 ## Honesty boundary
 

--- a/elixir/agent_orchestrator/lib/agent_orchestrator/agent_runner.ex
+++ b/elixir/agent_orchestrator/lib/agent_orchestrator/agent_runner.ex
@@ -103,6 +103,20 @@ defmodule AgentOrchestrator.AgentRunner do
   _}}`) — a blank anchor would silently degrade back to fresh-mint-per-turn, the
   exact failure this provisioning exists to prevent.
 
+  ### Fail-closed marker (`UNITARES_ORCHESTRATED`)
+
+  The anchor is provisioned WITH a companion `UNITARES_ORCHESTRATED=1` marker.
+  The same onboard hook serves *normal interactive* sessions, so it must not
+  treat a bare `UNITARES_CLIENT_SESSION_ID` as sufficient to resume — a stray
+  global export of that var leaking into an interactive session would otherwise
+  flip it into resume mode, and two sessions sharing the leaked value would
+  resume onto ONE governance UUID (the ghost-siphon the v2 identity ontology
+  removed name-claim to prevent). So the hook fail-closes: it resumes only when
+  the marker explicitly declares an orchestrated headless turn-child. The
+  orchestrator KNOWS its children are exactly that, so it sets the marker; an
+  interactive session never carries it and therefore can never resume-share. The
+  two vars are one unit — set together or not at all.
+
   ## Presence
 
   By default an agent registers an `agent:/<id>` PRESENCE row on the lease plane
@@ -132,6 +146,12 @@ defmodule AgentOrchestrator.AgentRunner do
   # declarations — see "Lineage provisioning" in the moduledoc).
   @server_url_var "UNITARES_SERVER_URL"
   @client_session_id_var "UNITARES_CLIENT_SESSION_ID"
+  # Fail-closed companion to the session anchor: the child's onboard hook resumes
+  # under the anchor ONLY when this orchestration marker is present, so a stray
+  # UNITARES_CLIENT_SESSION_ID leaked into a normal interactive session (which the
+  # same hook serves) cannot trigger resume-sharing — it mints. See the
+  # session-anchor moduledoc section and onboard_helper.run_onboard's `orchestrated`.
+  @orchestrated_var "UNITARES_ORCHESTRATED"
   @lineage_parent_var "UNITARES_PARENT_AGENT_ID"
   @lineage_reason_var "UNITARES_SPAWN_REASON"
   @default_spawn_reason "subagent"
@@ -605,7 +625,16 @@ defmodule AgentOrchestrator.AgentRunner do
       end
 
     server = if server_url, do: [{@server_url_var, server_url}], else: []
-    session = if client_session_id, do: [{@client_session_id_var, client_session_id}], else: []
+
+    # The anchor travels WITH the orchestration marker: the child's hook
+    # fail-closes on the marker, so provisioning the anchor without it would
+    # make a genuine orchestrated child fail to resume (anchor ignored). They
+    # are one unit — set both, or neither.
+    session =
+      if client_session_id,
+        do: [{@client_session_id_var, client_session_id}, {@orchestrated_var, "1"}],
+        else: []
+
     lineage ++ server ++ session
   end
 

--- a/elixir/agent_orchestrator/test/agent_orchestrator_test.exs
+++ b/elixir/agent_orchestrator/test/agent_orchestrator_test.exs
@@ -420,6 +420,28 @@ defmodule AgentOrchestratorTest do
                AgentOrchestrator.await(id)
     end
 
+    test "provisions UNITARES_ORCHESTRATED=1 alongside the anchor (fail-closed marker)" do
+      {:ok, id, _} =
+        AgentOrchestrator.run(%{
+          cmd: "sh",
+          args: ["-c", ~s(echo "$UNITARES_CLIENT_SESSION_ID|$UNITARES_ORCHESTRATED")],
+          client_session_id: "agent:/thread-1"
+        })
+
+      assert {:ok, %{output: ["agent:/thread-1|1"], exit_status: 0}} =
+               AgentOrchestrator.await(id)
+    end
+
+    test "no anchor => no orchestration marker (the marker never travels alone)" do
+      {:ok, id, _} =
+        AgentOrchestrator.run(%{
+          cmd: "sh",
+          args: ["-c", ~s(echo "${UNITARES_ORCHESTRATED-unset}")]
+        })
+
+      assert {:ok, %{output: ["unset"], exit_status: 0}} = AgentOrchestrator.await(id)
+    end
+
     test "an explicit env entry wins over the provisioned anchor" do
       {:ok, id, _} =
         AgentOrchestrator.run(%{

--- a/scripts/client/onboard_helper.py
+++ b/scripts/client/onboard_helper.py
@@ -37,6 +37,12 @@ CACHE_DIR = ".unitares"
 CACHE_FILE = "session.json"
 
 
+def _env_truthy(value: str | None) -> bool:
+    """Parse a boolean-ish env var. Only explicit affirmatives count as True so
+    a stray ``UNITARES_ORCHESTRATED=0`` / empty value fails closed to mint."""
+    return (value or "").strip().lower() in ("1", "true", "yes", "on")
+
+
 def _slot_filename(slot: str | None) -> str:
     """Return the cache filename, optionally namespaced by a slot key.
 
@@ -262,6 +268,7 @@ def run_onboard(
     slot: str | None = None,
     force_new: bool = False,
     client_session_id: str | None = None,
+    orchestrated: bool = False,
     auth_token: str | None = None,
     timeout: float = DEFAULT_TIMEOUT,
     with_bootstrap: bool = True,
@@ -278,14 +285,28 @@ def run_onboard(
 
     ``client_session_id`` is the **thread-anchor resume** path
     (``UNITARES_CLIENT_SESSION_ID``, provisioned by the BEAM orchestrator for
-    conversation-turn agents like the Discord bridge). When set, the helper
-    resumes the SAME governance UUID under that stable anchor instead of the
-    default fresh-mint-per-process posture — so consecutive turns of one
-    conversation are one resumed agent, not a new id every turn. force_new is
-    omitted in this mode (the server defaults resume=True); the first turn
-    mints+binds the anchor, later turns resume it. When unset, behavior is
-    byte-identical to before (force_new + cached-lineage declaration). An
-    explicit ``force_new`` still wins — it is a deliberate clean break.
+    conversation-turn agents like the Discord bridge). When set AND
+    ``orchestrated`` is True, the helper resumes the SAME governance UUID under
+    that stable anchor instead of the default fresh-mint-per-process posture —
+    so consecutive turns of one conversation are one resumed agent, not a new id
+    every turn. force_new is omitted in this mode (the server defaults
+    resume=True); the first turn mints+binds the anchor, later turns resume it.
+
+    ``orchestrated`` is the **fail-closed guard** (the load-bearing safety
+    property). This same helper is the onboarder for *normal* interactive
+    sessions too — so honoring a bare ``client_session_id`` would be dangerous:
+    if that env var ever leaked into a normal session (a stray global export,
+    an inherited shell), the session would silently switch to resume mode, and
+    two sessions sharing the leaked value would resume onto ONE UUID — the
+    ghost-siphon the v2 ontology removed name-claim to prevent. So resume
+    requires an EXPLICIT positive signal that this is an orchestrated headless
+    turn-child (set ``orchestrated=True`` only for ``claude -p`` children the
+    orchestrator spawned; the spawner provisions ``UNITARES_ORCHESTRATED=1``
+    alongside the anchor). Absent that signal, the anchor is ignored and the
+    helper mints exactly as today — a leaked anchor on an interactive session
+    is a no-op, never a siphon. When unset, behavior is byte-identical to
+    before (force_new + cached-lineage declaration). An explicit ``force_new``
+    still wins — it is a deliberate clean break.
 
     ``with_bootstrap`` (default True) attaches an initial_state payload so
     the server writes a bootstrap check-in row at t=0 per
@@ -303,14 +324,18 @@ def run_onboard(
         "model_type": model_type,
     }
 
-    if anchor and not force_new:
-        # Thread-anchored resume: stable per-conversation session key, one
-        # resumed UUID across turns. No force_new (server default resume=True),
-        # no lineage — the turns are the same agent, not a parent/child chain.
+    if anchor and orchestrated and not force_new:
+        # Thread-anchored resume — ONLY in an explicitly-declared orchestrated
+        # context (fail-closed; see ``orchestrated`` above). Stable
+        # per-conversation session key, one resumed UUID across turns. No
+        # force_new (server default resume=True), no lineage — the turns are the
+        # same agent, not a parent/child chain.
         arguments["client_session_id"] = anchor
     else:
         # Default posture (identity.md v2): fresh process = fresh agent. Mint
-        # with force_new and declare cached lineage via parent_agent_id.
+        # with force_new and declare cached lineage via parent_agent_id. A bare
+        # anchor without the orchestration signal lands here — it mints, it does
+        # NOT resume-share.
         arguments["force_new"] = True
         if not force_new:
             parent_agent_id = (cache.get("uuid") or cache.get("agent_uuid") or "").strip()
@@ -403,8 +428,19 @@ def main(argv: list[str] | None = None) -> int:
         default=os.environ.get("UNITARES_CLIENT_SESSION_ID", ""),
         help="Stable per-conversation session anchor (typically provisioned "
              "as UNITARES_CLIENT_SESSION_ID by the BEAM orchestrator for "
-             "turn-based agents like the Discord bridge). When set, resume the "
-             "SAME identity across turns instead of minting a new id each turn.",
+             "turn-based agents like the Discord bridge). Resumes the SAME "
+             "identity across turns instead of minting a new id each turn — but "
+             "ONLY when --orchestrated is also set (fail-closed; see below).",
+    )
+    parser.add_argument(
+        "--orchestrated",
+        action="store_true",
+        default=_env_truthy(os.environ.get("UNITARES_ORCHESTRATED")),
+        help="Declare this is an orchestrated headless turn-child (the "
+             "orchestrator provisions UNITARES_ORCHESTRATED=1 alongside the "
+             "anchor). REQUIRED for --client-session-id to trigger resume; "
+             "without it a (possibly leaked) anchor is ignored and the helper "
+             "mints — so an interactive session can never resume-share.",
     )
     parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
     args = parser.parse_args(argv)
@@ -421,6 +457,7 @@ def main(argv: list[str] | None = None) -> int:
         slot=slot,
         force_new=args.force_new,
         client_session_id=client_session_id,
+        orchestrated=args.orchestrated,
         with_bootstrap=args.with_bootstrap,
         auth_token=auth_token,
         timeout=args.timeout,

--- a/tests/test_onboard_helper.py
+++ b/tests/test_onboard_helper.py
@@ -336,6 +336,7 @@ class TestThreadAnchorResume:
         responses: list[dict],
         *,
         client_session_id: str | None,
+        orchestrated: bool = True,
         force_new: bool = False,
         initial_cache: dict | None = None,
     ) -> tuple[dict, FakePoster]:
@@ -350,6 +351,7 @@ class TestThreadAnchorResume:
             model_type="claude-code",
             workspace=tmp_path,
             client_session_id=client_session_id,
+            orchestrated=orchestrated,
             force_new=force_new,
             post_json=poster,
         )
@@ -366,6 +368,20 @@ class TestThreadAnchorResume:
         assert "force_new" not in sent_args
         assert "parent_agent_id" not in sent_args
         assert "spawn_reason" not in sent_args
+
+    def test_anchor_without_orchestrated_flag_mints_not_siphons(self, tmp_path: Path) -> None:
+        """THE fail-closed guard: a bare anchor with NO orchestration signal
+        (e.g. a leaked global UNITARES_CLIENT_SESSION_ID on a normal session)
+        must MINT, never resume-share. This is the property that keeps the
+        shared hook from siphoning interactive sessions onto one UUID."""
+        _, poster = self._call(
+            tmp_path, [_success_response()],
+            client_session_id="agent:/leaked-global-anchor",
+            orchestrated=False,
+        )
+        sent_args = poster.calls[0][1]["arguments"]
+        assert sent_args["force_new"] is True
+        assert "client_session_id" not in sent_args
 
     def test_anchor_does_not_declare_cached_lineage(self, tmp_path: Path) -> None:
         """Even with a cached UUID, anchor mode resumes (one agent across turns),
@@ -404,7 +420,10 @@ class TestThreadAnchorResume:
 
     def test_no_anchor_is_byte_identical_to_default(self, tmp_path: Path) -> None:
         """Without the anchor, behavior is unchanged (force_new + no client id)."""
-        _, poster = self._call(tmp_path, [_success_response()], client_session_id=None)
+        _, poster = self._call(
+            tmp_path, [_success_response()],
+            client_session_id=None, orchestrated=False,
+        )
         sent_args = poster.calls[0][1]["arguments"]
         assert sent_args["force_new"] is True
         assert "client_session_id" not in sent_args
@@ -416,6 +435,17 @@ class TestThreadAnchorResume:
         )
         sent_args = poster.calls[0][1]["arguments"]
         assert "initial_state" in sent_args
+
+    def test_env_truthy_fails_closed(self) -> None:
+        """UNITARES_ORCHESTRATED parsing: only explicit affirmatives are True so
+        an empty / 0 / garbage value cannot accidentally arm resume."""
+        from scripts.client.onboard_helper import _env_truthy
+        assert _env_truthy("1") is True
+        assert _env_truthy("true") is True
+        assert _env_truthy("YES") is True
+        assert _env_truthy("on") is True
+        for falsey in (None, "", "0", "false", "no", "off", "  ", "maybe"):
+            assert _env_truthy(falsey) is False, falsey
 
 
 # --- per-process slot isolation --------------------------------------------


### PR DESCRIPTION
Follow-up hardening on top of #834 (merged). Addresses the siphon risk cirwel flagged: **the gov-plugin onboard hook is the onboarder for normal interactive sessions too, not just the Discord `claude -p` children** — so honoring a bare `UNITARES_CLIENT_SESSION_ID` is unsafe.

## The risk

If that env var ever leaked into a normal session (a stray global `export`, an inherited shell), the session would silently flip into resume mode, and two sessions sharing the leaked value would resume onto **one** governance UUID — the ghost-siphon the v2 ontology removed name-claim resolution to prevent. The orchestrator only sets the var scoped-to-child, so the realistic trigger is operator misconfig — narrow, but the failure is severe and silent.

## The guard (fail-closed)

Resume is honored **only with an explicit positive orchestration signal** — `UNITARES_ORCHESTRATED=1`, set by the spawner *alongside* the anchor. The orchestrator/dispatch knows its children are orchestrated headless turn-children, so it declares it; an interactive session never carries the marker. **Absent the marker, the anchor is ignored and the hook mints exactly as today** — a leaked anchor on an interactive session is a no-op, never a siphon. The dangerous direction is structurally impossible.

This is why it needs no council: it re-applies the already-ratified anti-siphon principle, fail-closed — not a new ontological claim. (Operator call, this thread.)

## Changes

- **`agent_runner.ex`** — provision `UNITARES_ORCHESTRATED=1` *with* the anchor (one unit; both or neither).
- **`onboard_helper.run_onboard`** — new `orchestrated` param; the anchor wins only when it's true. CLI derives it from `--orchestrated` / `UNITARES_ORCHESTRATED` (affirmatives only via `_env_truthy`, so `=0`/empty/garbage fail closed).
- **Doc** — fail-closed section; both env vars in the cross-repo contract; the real plugin should additionally gate on **headless `-p`** (defense-in-depth, its own structural discriminator from the hook input).

## Tests

- **Python (+2 → 41/41 green):** `test_anchor_without_orchestrated_flag_mints_not_siphons` (the load-bearing guard), `test_env_truthy_fails_closed`. Existing anchor tests updated to pass `orchestrated=True`.
- **Elixir (+2):** marker travels with the anchor (`agent:/thread-1|1`); never alone (no anchor ⇒ no marker). Runs `mix test` on the deploy host per `agent-orchestrator-beam-v0.md`.

## Remaining cross-repo follow-ups (unchanged, now require both env vars)

- Dispatch/`dispatch_beam`: set `UNITARES_CLIENT_SESSION_ID` **and** `UNITARES_ORCHESTRATED=1` on the spawn.
- gov-plugin hook: mirror the helper — resume only with the orchestration signal (and headless, defense-in-depth).

> ⚠️ Writer-locked identity/onboarding surface (CLAUDE.md). Operator is the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yXwYYm4UdbMFbYmn4akrK

---
_Generated by [Claude Code](https://claude.ai/code/session_012yXwYYm4UdbMFbYmn4akrK)_