### PR TITLE
fix(list_agents): keep non-resident participants visible on the dashboard

### DIFF
--- a/src/mcp_handlers/lifecycle/query.py
+++ b/src/mcp_handlers/lifecycle/query.py
@@ -767,8 +767,25 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
             except Exception as e:
                 logger.debug(f"Batch trust tier lookup failed: {e}")
 
-        # Sort by last_update (most recent first)
-        agents_list.sort(key=lambda x: x.get("last_update", ""), reverse=True)
+        # Sort participated agents (>=1 check-in) ahead of never-checked-in
+        # ghosts, then by recency (most recent first) within each group.
+        # Never-checked-in agents carry last_update == created (onboard time),
+        # so a burst of freshly-onboarded ghost sessions — the dashboard's own
+        # read sweep, anima/connector traffic minting fresh identities — would
+        # otherwise outrank genuinely-participated agents on a pure recency sort
+        # and crowd them out of the paginated `limit` window. That left only the
+        # always-on residents (which check in continuously) visible, with every
+        # other real participant pushed below the cutoff. #826 folds the ghosts
+        # client-side, but they must not starve real participants out of the
+        # limit first. The lite path already orders participated-first (line ~427
+        # via the -updates key); this brings the full path in line.
+        agents_list.sort(
+            key=lambda x: (
+                1 if (x.get("total_updates") or 0) >= 1 else 0,
+                x.get("last_update", "") or "",
+            ),
+            reverse=True,
+        )
 
         # Calculate status counts BEFORE pagination (for accurate totals)
         total_count = len(agents_list)

--- a/tests/test_handlers_lifecycle.py
+++ b/tests/test_handlers_lifecycle.py
@@ -757,3 +757,49 @@ class TestListAgentsParticipation:
             data = json.loads(result[0].text)
             assert data["participated"] == 2
             assert data["never_participated"] == 0
+
+    @pytest.mark.asyncio
+    async def test_participated_agents_not_starved_by_ghost_onboards(self, mock_mcp_server):
+        """Regression: a flood of never-checked-in ghost onboards must not push
+        genuinely-participated agents out of the paginated `limit` window.
+
+        Never-checked-in agents carry last_update == created (onboard time), so
+        on a pure-recency sort a burst of freshly-onboarded sessions outranks
+        older real participants. With a small `limit`, that left only the
+        always-on residents visible. The full-path sort must order participated
+        agents (total_updates >= 1) ahead of ghosts so the window fills with
+        real work first.
+        """
+        now = datetime.now(timezone.utc)
+        older = (now - timedelta(hours=6)).isoformat()
+        # Two real participants that last checked in 6h ago.
+        meta = {
+            "real1": make_agent_meta(label="Real1", total_updates=12, last_update=older),
+            "real2": make_agent_meta(label="Real2", total_updates=8, last_update=older),
+        }
+        # A flood of ghosts onboarded "just now" — last_update == created == now.
+        fresh = now.isoformat()
+        for i in range(10):
+            meta[f"ghost{i}"] = make_agent_meta(
+                label=f"claude-thread-{i}", total_updates=0,
+                last_update=fresh, created_at=fresh,
+            )
+        mock_mcp_server.agent_metadata = meta
+
+        with patch_lifecycle_server(mock_mcp_server):
+            from src.mcp_handlers.lifecycle.handlers import handle_list_agents
+            # Full path (include_metrics) with a limit smaller than the ghost flood.
+            result = await handle_list_agents({
+                "include_metrics": True, "grouped": True,
+                "status_filter": "all", "limit": 3,
+            })
+
+            data = json.loads(result[0].text)
+            returned = [a for bucket in data["agents"].values() for a in bucket]
+            returned_labels = {a["label"] for a in returned}
+            # Both real participants survive the limit despite the ghost flood.
+            assert "Real1" in returned_labels
+            assert "Real2" in returned_labels
+            # Counts stay truthful — ghosts are not dropped, just ordered last.
+            assert data["summary"]["participated"] == 2
+            assert data["summary"]["never_participated"] == 10


### PR DESCRIPTION
## Symptom

The dashboard appears to show **only resident agents** (Lumen/Steward/Sentinel/Watcher/Vigil) — every other agent's check-ins are missing from the active list, even agents that have done real work.

## Root cause

The dashboard's agent sweep calls `agent(action='list', include_metrics=true, recent_days=30, limit=200)`, which takes the **full** handler path in `src/mcp_handlers/lifecycle/query.py`. That path:

1. sorted the collected agents **purely by `last_update` descending** (`agents_list.sort(key=lambda x: x.get("last_update", ""), ...)`), then
2. truncated to `limit` (200).

Never-checked-in agents carry `last_update == created` (onboard time — verified live: 95/95 of the returned ghosts had `last_update == created`). So a burst of freshly-onboarded ghost sessions — the dashboard's own 30s read sweep, anima/connector traffic minting fresh identities, `claude-thread-*` spawns — all timestamp "now" and **outrank every genuinely-participated agent**, consuming the entire 200-row window.

**Reproduced against the live fleet:** 626 agents, summary reports `participated: 324`, yet the returned slice contained exactly **5 participated rows — all residents**. Residents survive only because they check in continuously (last_update = now). Every other real participant was pushed below the `limit` cutoff and never returned. PR #826 then folds the never-checked-in ghosts into a collapsed group client-side, leaving the operator a residents-only view.

## Fix

Sort participated agents (`total_updates >= 1`) **ahead of** never-checked-in ghosts, then by recency within each group. This brings the full path in line with the **lite path**, which already orders participated-first via its `-updates` key and skips ghosts in auto mode.

- Counts (`total`, `by_status`, `participated`, `never_participated`) are unchanged.
- Ghosts are **not dropped** — just ordered to the tail, where #826's client-side fold already hides them.
- No data-contract change.

## Test

Adds `test_participated_agents_not_starved_by_ghost_onboards`: floods the metadata with 10 ghost onboards (`last_update == created == now`) plus 2 older real participants, and asserts both real participants survive `limit=3`. Verified it **fails on the old sort** (returns only `claude-thread-*` ghosts — exactly the reported symptom) and **passes with the fix**. Full lifecycle + participation suites green (44 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015CWDAp4hoA7cBNEt6fjhG9)_