### PR TITLE
Simplify identity contract and harden KG search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Raw tool flow when slash commands are unavailable: `start_session(force_new=true
 
 ### Local continuity cache
 
-`.unitares/session.json` is Codex's authoritative local workspace state (not Claude's memory system). It holds `uuid`, `client_session_id`, `session_resolution_source`, and optional short-lived proof material for in-process calls. Helper: `scripts/client/session_cache.py`. On every new session or after a restart, call `onboard(force_new=true, parent_agent_id=<saved uuid>, spawn_reason="new_session")`.
+`.unitares/session.json` is Codex's authoritative local workspace state (not Claude's memory system). It holds `uuid`, `client_session_id`, `session_resolution_source`, and optional short-lived proof material for in-process calls. Helper: `scripts/client/session_cache.py`. On every new session or after a restart, call `onboard(force_new=true)`. Add `parent_agent_id=<saved uuid>, spawn_reason="new_session"` only when this is a real handoff from a finished predecessor, not merely because the cache exists.
 
 If `session_resolution_source` falls back to a weak source, rerun `/governance-start` or diagnose explicitly; do not repair it with bare UUID resume.
 
@@ -92,7 +92,7 @@ Before touching one of these, run `gh pr list -R CIRWEL/unitares --search "in:ti
 Surfaces:
 
 - **Migration slots and migration-drift fixes** — `db/postgres/migrations/`. Now CI-gated by `scripts/dev/unitares_doctor.py`; the doctor fails on slot/name drift, but session-level coordination still avoids wasted parallel work.
-- **Identity / onboarding — docs AND implementing code are one coupled surface** — docs (`docs/ontology/identity.md`, `commands/governance-start.md`, `skills/governance-lifecycle/SKILL.md`, the `AGENTS.md`/`CLAUDE.md` shared contract including the `Identity rules:` block below, the `force_new=true` / `parent_agent_id` posture) AND code (`src/mcp_handlers/identity/`, `src/mcp_handlers/middleware/identity_step.py`, `src/mcp_handlers/support/agent_auth.py`, `src/mcp_handlers/schemas/identity.py`). Treat as a single writer-locked region, not as separate doc/code workstreams. These also flow across two repos (unitares + gov-plugin); check both.
+- **Identity / onboarding — docs AND implementing code are one coupled surface** — docs (`docs/ontology/identity.md`, `commands/governance-start.md`, `skills/governance-lifecycle/SKILL.md`, the `AGENTS.md`/`CLAUDE.md` shared contract including the `Strict Identity, Simple Contract` block below, the `force_new=true` / `parent_agent_id` posture) AND code (`src/mcp_handlers/identity/`, `src/mcp_handlers/middleware/identity_step.py`, `src/mcp_handlers/support/agent_auth.py`, `src/mcp_handlers/schemas/identity.py`). Treat as a single writer-locked region, not as separate doc/code workstreams. These also flow across two repos (unitares + gov-plugin); check both.
 - **`docs/ontology/plan.md`** — chronological state ledger; two sessions appending rows in the same window collide trivially. If a session is already editing it, branch from its head rather than starting parallel.
 - **Active proposal/RFC docs in hot phase** — the Plexus / lease-plane / BEAM thread (`docs/proposals/plexus-scope.md`, `surface-lease-plane-v0.md`, `surface-lease-plane-phase-a-plan.md`, `beam-footprint-roadmap-v0.md`, `beam-coordination-kernel.md`). Restructure-during-flight is normal here; same rule as plan.md: branch from another session's head if one is in flight.
 - **Large test-layout consolidation** — `tests/` directory. If you're about to delete more than ~200 lines of tests, surface intent in a draft PR or issue first; a stale −3496 diff (`feat/agentskills-compat`) was lost to drift this way.
@@ -157,52 +157,56 @@ The three patterns below were the pre-ExecutorPool workarounds. They are **retir
 
 - Knowledge graph AGE tests require a live AGE connection (errors, not failures, when unavailable)
 
-## STRICT_IDENTITY_REQUIRED (#425 staged rollout)
+## Strict Identity, Simple Contract
 
-`STRICT_IDENTITY_REQUIRED=true` flips the dispatch middleware from auto-minting an ephemeral identity for non-`pre_onboard` tools to returning a typed-refusal response (`status: identity_required`). Default is `false` so existing callers (residents, dispatch workers, plugins doing bare `onboard()`) keep working. Per-tool identity requirements are declared via `requires_identity=` on the `@mcp_tool` decorator (see `src/mcp_handlers/decorators.py`).
+Strict identity is a write gate. Reads may work without a bound caller; writes
+must be accountable. Agents should not need the full identity ontology for the
+normal path.
 
-Rollout sequence:
+Operational rules:
 
-1. Local dev (your shell) → set the flag, run a session through, watch for typed refusals where you expected work. **Stage 1 run 2026-06-11**: typed refusal works as designed on the MCP transport — but **the flag does not reach the REST surface** (`/v1/tools/call` skips `identity_step`): unbound REST reads still succeed under strict, writes refuse with an off-contract generic `SESSION_ERROR`. Since the real unbound population is REST (dashboard 30s sweep, gateway-proxied connector traffic), a REST-side strict gate + a dashboard-identity decision are prerequisites before stages 2–4 achieve the rollout's goal. **REST gate shipped (inert while the flag is off):** `execute_http_tool` now mirrors the middleware's typed refusal via the single-sourced `identity_bootstrap.strict_identity_refusal_payload`, ahead of Wave-3a routing; credential-bearing and pre_onboard calls pass through. The gate keys on the RESOLVED context binding, never credential presence: the REST route transport-injects a synthetic `client_session_id` into every request, so presence-based bypasses pass all real traffic (council live finding, PR #610). **Action-level classification shipped:** both gates resolve at CALL granularity (`decorators.get_call_identity_requirement` — alias-aware, default_action-aware); the mixed tools declare `pre_onboard_actions` (knowledge: search/get/list/details/stats; agent: list/get; calibration: check; config: get; observe: agent/compare/similar/anomalies/aggregate; dialectic: get/list) so the dashboard's read sweep passes under strict while every write/operator action refuses — a drift-guard test pins that no mutating action can enter an exemption set. Remaining prerequisite: **the dashboard-identity decision (operator)** — under strict its reads now work unbound but its operator WRITE buttons (archive/resume/config-set/dialectic-request) refuse until they carry an operator credential.
-2. Lumen (Pi) → flag the Pi env, observe resident agents (vigil/sentinel/watcher/chronicler) for refusals at scheduled boundaries; fix offenders by adding `parent_agent_id` to their bootstrap.
-3. Dispatch (the Discord bridge / dispatch worker) → flag, observe per-thread agent spawns.
-4. Flip the default in code only after all three burn-ins are clean for ≥1 week.
+1. Start each driver with `start_session(force_new=true)` (`onboard` is the
+   canonical tool underneath). Save the returned `uuid` and `client_session_id`.
+2. For later check-ins and writes in the same running process, pass
+   `client_session_id`. Adapters should do this automatically.
+3. To continue prior work in a fresh process, mint fresh and declare the cause:
+   `start_session(force_new=true, parent_agent_id=<prior_uuid>, spawn_reason="new_session")`.
+   Use this only for a real handoff from a finished predecessor.
+4. Short dispatched subagents usually should not onboard. If one needs its own
+   identity, use `spawn_reason="subagent"`, set `parent_agent_id=<driver_uuid>`,
+   and land at least one real `sync_state()` before exit.
+5. Persistent/substrate agents use their dedicated substrate identity pattern.
+   Ordinary sessions should not copy that pattern.
 
-When investigating a typed-refusal, the response carries `tool`, `hint`, `ontology_ref`, and `rollout_flag` so the cause is structurally identifiable.
+Do not do these in normal agent code:
 
-## Minimal Agent Workflow
+- Bare `onboard()` or `identity()` as a way to guess identity.
+- Passing `continuity_token` on every call.
+- Treating a display name as identity.
+- Declaring `parent_agent_id` just because another session shares the workspace.
+- Writing KG notes before searching for an existing entry.
 
-Per identity.md v2 ontology, fresh process-instances mint fresh identity. Lineage is causal — declared only for a genuine spawn or handoff event, never to claim continuity with a co-located predecessor.
+Minimal glossary:
 
-Default happy path:
+- `uuid`: the server record for this process identity.
+- `client_session_id`: the proof string for this running process. Use it on
+  writes; do not treat it as cross-process selfhood.
+- `parent_agent_id`: a causal pointer to the process whose work this process is
+  inheriting.
+- `lineage`: "this process inherited work from that one," not "this process is
+  that one."
+- `continuity_token`: advanced same-live-process rebind proof. Not part of the
+  normal workflow.
 
-1. `onboard(force_new=true)` with NO `parent_agent_id` → save `agent_uuid` and `client_session_id` from response. A fresh session onboards fresh; co-location in this workspace is not lineage.
-2. `process_agent_update(response_text=..., complexity=..., client_session_id=...)` for in-process check-ins. **Check in per working turn, not once.** Governance is a trajectory, not a point: the first check-in returns `margin: "settling"` (warmup — fewer than 3 check-ins, so the server cannot judge headroom yet), and calibration (`auto_ground_truth`) only means something once it has the volume of repeated (prediction, outcome) pairs a cadence produces. A per-turn cadence is **not performative** — its value is longitudinal and invisible at the single-call altitude, so judging it by one turn's payload is an altitude error. Keep each check-in substantive (a real `confidence`, what changed, what you are now uncertain about) rather than rote; rote logging and no logging both starve the baseline.
-3. On a future process-instance, repeat step 1 — onboard fresh, do not auto-resume and do not declare the prior session as a parent.
+Friendly workflow aliases: `start_session` -> `onboard`, `sync_state` ->
+`process_agent_update`, `check_working_state` -> `get_governance_metrics`,
+`search_shared_memory` -> `knowledge(action="search")`, `record_result` ->
+`outcome_event`, and `request_review` -> `dialectic(action="request")`.
 
-Declare lineage (`parent_agent_id`) ONLY for a real causal event:
-
-- **Dispatched subagents** — `parent_agent_id=<dispatcher UUID>, spawn_reason="subagent"`. Usually set automatically by the dispatcher.
-- **A deliberate handoff from an EXITED prior session** — `spawn_reason="explicit"`. The successor inherits a predecessor that has finished, not a sibling still running.
-
-Declaring a currently-LIVE agent as `parent_agent_id` is rejected server-side (`lineage_coincidental_rejected`): a live agent is a concurrent sibling, not a predecessor. `subagent` and `compaction` are exempt — their parent is legitimately live. A genuine serial handoff to an exited predecessor is accepted and stays provisional until R1 confirms it.
-
-Friendly workflow aliases: the same happy path can be spelled with task-verb names — `start_session` → `onboard`, `sync_state` → `process_agent_update`, `check_working_state` → `get_governance_metrics`, `search_shared_memory` → `knowledge(action="search")`, `record_result` → `outcome_event`, `request_review` → `dialectic(action="request")`. Same parameters, same identity rules (the registry canonicalizes before the #425 gates judge). Calls made via these names return the normalized agent-experience envelope — `next_action` / `state_summary` / `risk_summary` / `memory_suggestions` / `recovery_hint` first, full canonical payload under `raw_governance` — while canonical names keep the raw response shape byte-identical.
-
-Shared-memory (KG) write discipline: `search` before you `store`. If a related entry exists, prefer a linked correction or `supersede` over a fresh note — the densest topics already carry several near-duplicate opens, and the store response's `consolidation_hint` flags this only *after* you have written. Store when a future agent would search for this and not already find it: a correction to a prior conclusion, a non-obvious failure mode plus its fingerprint, a closed mystery — not operational runbooks or step-lists (those live in `docs/`). Write caller-proven (echo your onboarded `client_session_id`) so the entry is not silently refused under strict identity.
-
-For an explicit handoff (rare — only when a prior session has EXITED):
-
-- **Plugin-loaded sessions** are the canonical path. The `unitares-governance-plugin` SessionStart banner surfaces the cached workspace UUID; Codex sessions get the same hint via `commands/governance-start.md` (S11-a). Treat that UUID as a handoff candidate only if that session has finished — if it is still running, it is a sibling and the server will reject it (`lineage_coincidental_rejected`). The default fresh onboard needs none of this.
-- **Server-only sessions** (working directly inside this repo without the plugin's hook chain) have no pre-onboard discovery surface. Onboarding without `parent_agent_id` mints honestly as `lineage_state: no_lineage_declared` — this is the expected default, not a degraded state. The onboard response returns `thread_context.predecessor.uuid` when a session-resolved predecessor exists; that is context, not a lineage instruction — do not declare it as a parent unless it represents a real handoff from an exited session.
-
-Identity rules:
-
-- A fresh process-instance is a fresh agent. Process-instance boundaries are honored.
-- `client_session_id` maintains identity within one process; weak across processes.
-- `continuity_token` is being narrowed (S1 in `docs/ontology/plan.md`) — present-day external clients can still resume with it, but plugin-internal flows declare lineage instead.
-- Substrate-anchored agents (Lumen, the long-lived residents) earn cross-process continuity via the substrate-earned identity pattern in `docs/ontology/identity.md` — they may use a hardcoded UUID across restarts.
-- Arg-less `onboard()` with no proof signal triggers the v2 fresh-instance gate — the server flips `force_new=true` and emits a `[FRESH_INSTANCE]` log line (S13).
-- Lineage is causal and declared at onboard time. The default fresh session declares no parent. Declare `parent_agent_id` only for a real spawn (`spawn_reason="subagent"`) or a handoff from an exited session (`spawn_reason="explicit"`); declaring a live agent as parent is rejected (`lineage_coincidental_rejected`).
+Shared-memory (KG) write discipline: search before writing. If a related entry
+exists, prefer a linked correction or `supersede` over a fresh note. Store when
+a future agent would search for this and not already find it: a correction to a
+prior conclusion, a non-obvious failure mode plus its fingerprint, or a closed
+mystery. Operational runbooks and step lists belong in `docs/`, not KG notes.
 
 <!-- END SHARED CONTRACT -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ Before touching one of these, run `gh pr list -R CIRWEL/unitares --search "in:ti
 Surfaces:
 
 - **Migration slots and migration-drift fixes** — `db/postgres/migrations/`. Now CI-gated by `scripts/dev/unitares_doctor.py`; the doctor fails on slot/name drift, but session-level coordination still avoids wasted parallel work.
-- **Identity / onboarding — docs AND implementing code are one coupled surface** — docs (`docs/ontology/identity.md`, `commands/governance-start.md`, `skills/governance-lifecycle/SKILL.md`, the `AGENTS.md`/`CLAUDE.md` shared contract including the `Identity rules:` block below, the `force_new=true` / `parent_agent_id` posture) AND code (`src/mcp_handlers/identity/`, `src/mcp_handlers/middleware/identity_step.py`, `src/mcp_handlers/support/agent_auth.py`, `src/mcp_handlers/schemas/identity.py`). Treat as a single writer-locked region, not as separate doc/code workstreams. These also flow across two repos (unitares + gov-plugin); check both.
+- **Identity / onboarding — docs AND implementing code are one coupled surface** — docs (`docs/ontology/identity.md`, `commands/governance-start.md`, `skills/governance-lifecycle/SKILL.md`, the `AGENTS.md`/`CLAUDE.md` shared contract including the `Strict Identity, Simple Contract` block below, the `force_new=true` / `parent_agent_id` posture) AND code (`src/mcp_handlers/identity/`, `src/mcp_handlers/middleware/identity_step.py`, `src/mcp_handlers/support/agent_auth.py`, `src/mcp_handlers/schemas/identity.py`). Treat as a single writer-locked region, not as separate doc/code workstreams. These also flow across two repos (unitares + gov-plugin); check both.
 - **`docs/ontology/plan.md`** — chronological state ledger; two sessions appending rows in the same window collide trivially. If a session is already editing it, branch from its head rather than starting parallel.
 - **Active proposal/RFC docs in hot phase** — the Plexus / lease-plane / BEAM thread (`docs/proposals/plexus-scope.md`, `surface-lease-plane-v0.md`, `surface-lease-plane-phase-a-plan.md`, `beam-footprint-roadmap-v0.md`, `beam-coordination-kernel.md`). Restructure-during-flight is normal here; same rule as plan.md: branch from another session's head if one is in flight.
 - **Large test-layout consolidation** — `tests/` directory. If you're about to delete more than ~200 lines of tests, surface intent in a draft PR or issue first; a stale −3496 diff (`feat/agentskills-compat`) was lost to drift this way.
@@ -136,52 +136,56 @@ The three patterns below were the pre-ExecutorPool workarounds. They are **retir
 
 - Knowledge graph AGE tests require a live AGE connection (errors, not failures, when unavailable)
 
-## STRICT_IDENTITY_REQUIRED (#425 staged rollout)
+## Strict Identity, Simple Contract
 
-`STRICT_IDENTITY_REQUIRED=true` flips the dispatch middleware from auto-minting an ephemeral identity for non-`pre_onboard` tools to returning a typed-refusal response (`status: identity_required`). Default is `false` so existing callers (residents, dispatch workers, plugins doing bare `onboard()`) keep working. Per-tool identity requirements are declared via `requires_identity=` on the `@mcp_tool` decorator (see `src/mcp_handlers/decorators.py`).
+Strict identity is a write gate. Reads may work without a bound caller; writes
+must be accountable. Agents should not need the full identity ontology for the
+normal path.
 
-Rollout sequence:
+Operational rules:
 
-1. Local dev (your shell) → set the flag, run a session through, watch for typed refusals where you expected work. **Stage 1 run 2026-06-11**: typed refusal works as designed on the MCP transport — but **the flag does not reach the REST surface** (`/v1/tools/call` skips `identity_step`): unbound REST reads still succeed under strict, writes refuse with an off-contract generic `SESSION_ERROR`. Since the real unbound population is REST (dashboard 30s sweep, gateway-proxied connector traffic), a REST-side strict gate + a dashboard-identity decision are prerequisites before stages 2–4 achieve the rollout's goal. **REST gate shipped (inert while the flag is off):** `execute_http_tool` now mirrors the middleware's typed refusal via the single-sourced `identity_bootstrap.strict_identity_refusal_payload`, ahead of Wave-3a routing; credential-bearing and pre_onboard calls pass through. The gate keys on the RESOLVED context binding, never credential presence: the REST route transport-injects a synthetic `client_session_id` into every request, so presence-based bypasses pass all real traffic (council live finding, PR #610). **Action-level classification shipped:** both gates resolve at CALL granularity (`decorators.get_call_identity_requirement` — alias-aware, default_action-aware); the mixed tools declare `pre_onboard_actions` (knowledge: search/get/list/details/stats; agent: list/get; calibration: check; config: get; observe: agent/compare/similar/anomalies/aggregate; dialectic: get/list) so the dashboard's read sweep passes under strict while every write/operator action refuses — a drift-guard test pins that no mutating action can enter an exemption set. Remaining prerequisite: **the dashboard-identity decision (operator)** — under strict its reads now work unbound but its operator WRITE buttons (archive/resume/config-set/dialectic-request) refuse until they carry an operator credential.
-2. Lumen (Pi) → flag the Pi env, observe resident agents (vigil/sentinel/watcher/chronicler) for refusals at scheduled boundaries; fix offenders by adding `parent_agent_id` to their bootstrap.
-3. Dispatch (the Discord bridge / dispatch worker) → flag, observe per-thread agent spawns.
-4. Flip the default in code only after all three burn-ins are clean for ≥1 week.
+1. Start each driver with `start_session(force_new=true)` (`onboard` is the
+   canonical tool underneath). Save the returned `uuid` and `client_session_id`.
+2. For later check-ins and writes in the same running process, pass
+   `client_session_id`. Adapters should do this automatically.
+3. To continue prior work in a fresh process, mint fresh and declare the cause:
+   `start_session(force_new=true, parent_agent_id=<prior_uuid>, spawn_reason="new_session")`.
+   Use this only for a real handoff from a finished predecessor.
+4. Short dispatched subagents usually should not onboard. If one needs its own
+   identity, use `spawn_reason="subagent"`, set `parent_agent_id=<driver_uuid>`,
+   and land at least one real `sync_state()` before exit.
+5. Persistent/substrate agents use their dedicated substrate identity pattern.
+   Ordinary sessions should not copy that pattern.
 
-When investigating a typed-refusal, the response carries `tool`, `hint`, `ontology_ref`, and `rollout_flag` so the cause is structurally identifiable.
+Do not do these in normal agent code:
 
-## Minimal Agent Workflow
+- Bare `onboard()` or `identity()` as a way to guess identity.
+- Passing `continuity_token` on every call.
+- Treating a display name as identity.
+- Declaring `parent_agent_id` just because another session shares the workspace.
+- Writing KG notes before searching for an existing entry.
 
-Per identity.md v2 ontology, fresh process-instances mint fresh identity. Lineage is causal — declared only for a genuine spawn or handoff event, never to claim continuity with a co-located predecessor.
+Minimal glossary:
 
-Default happy path:
+- `uuid`: the server record for this process identity.
+- `client_session_id`: the proof string for this running process. Use it on
+  writes; do not treat it as cross-process selfhood.
+- `parent_agent_id`: a causal pointer to the process whose work this process is
+  inheriting.
+- `lineage`: "this process inherited work from that one," not "this process is
+  that one."
+- `continuity_token`: advanced same-live-process rebind proof. Not part of the
+  normal workflow.
 
-1. `onboard(force_new=true)` with NO `parent_agent_id` → save `agent_uuid` and `client_session_id` from response. A fresh session onboards fresh; co-location in this workspace is not lineage.
-2. `process_agent_update(response_text=..., complexity=..., client_session_id=...)` for in-process check-ins. **Check in per working turn, not once.** Governance is a trajectory, not a point: the first check-in returns `margin: "settling"` (warmup — fewer than 3 check-ins, so the server cannot judge headroom yet), and calibration (`auto_ground_truth`) only means something once it has the volume of repeated (prediction, outcome) pairs a cadence produces. A per-turn cadence is **not performative** — its value is longitudinal and invisible at the single-call altitude, so judging it by one turn's payload is an altitude error. Keep each check-in substantive (a real `confidence`, what changed, what you are now uncertain about) rather than rote; rote logging and no logging both starve the baseline.
-3. On a future process-instance, repeat step 1 — onboard fresh, do not auto-resume and do not declare the prior session as a parent.
+Friendly workflow aliases: `start_session` -> `onboard`, `sync_state` ->
+`process_agent_update`, `check_working_state` -> `get_governance_metrics`,
+`search_shared_memory` -> `knowledge(action="search")`, `record_result` ->
+`outcome_event`, and `request_review` -> `dialectic(action="request")`.
 
-Declare lineage (`parent_agent_id`) ONLY for a real causal event:
-
-- **Dispatched subagents** — `parent_agent_id=<dispatcher UUID>, spawn_reason="subagent"`. Usually set automatically by the dispatcher.
-- **A deliberate handoff from an EXITED prior session** — `spawn_reason="explicit"`. The successor inherits a predecessor that has finished, not a sibling still running.
-
-Declaring a currently-LIVE agent as `parent_agent_id` is rejected server-side (`lineage_coincidental_rejected`): a live agent is a concurrent sibling, not a predecessor. `subagent` and `compaction` are exempt — their parent is legitimately live. A genuine serial handoff to an exited predecessor is accepted and stays provisional until R1 confirms it.
-
-Friendly workflow aliases: the same happy path can be spelled with task-verb names — `start_session` → `onboard`, `sync_state` → `process_agent_update`, `check_working_state` → `get_governance_metrics`, `search_shared_memory` → `knowledge(action="search")`, `record_result` → `outcome_event`, `request_review` → `dialectic(action="request")`. Same parameters, same identity rules (the registry canonicalizes before the #425 gates judge). Calls made via these names return the normalized agent-experience envelope — `next_action` / `state_summary` / `risk_summary` / `memory_suggestions` / `recovery_hint` first, full canonical payload under `raw_governance` — while canonical names keep the raw response shape byte-identical.
-
-Shared-memory (KG) write discipline: `search` before you `store`. If a related entry exists, prefer a linked correction or `supersede` over a fresh note — the densest topics already carry several near-duplicate opens, and the store response's `consolidation_hint` flags this only *after* you have written. Store when a future agent would search for this and not already find it: a correction to a prior conclusion, a non-obvious failure mode plus its fingerprint, a closed mystery — not operational runbooks or step-lists (those live in `docs/`). Write caller-proven (echo your onboarded `client_session_id`) so the entry is not silently refused under strict identity.
-
-For an explicit handoff (rare — only when a prior session has EXITED):
-
-- **Plugin-loaded sessions** are the canonical path. The `unitares-governance-plugin` SessionStart banner surfaces the cached workspace UUID; Codex sessions get the same hint via `commands/governance-start.md` (S11-a). Treat that UUID as a handoff candidate only if that session has finished — if it is still running, it is a sibling and the server will reject it (`lineage_coincidental_rejected`). The default fresh onboard needs none of this.
-- **Server-only sessions** (working directly inside this repo without the plugin's hook chain) have no pre-onboard discovery surface. Onboarding without `parent_agent_id` mints honestly as `lineage_state: no_lineage_declared` — this is the expected default, not a degraded state. The onboard response returns `thread_context.predecessor.uuid` when a session-resolved predecessor exists; that is context, not a lineage instruction — do not declare it as a parent unless it represents a real handoff from an exited session.
-
-Identity rules:
-
-- A fresh process-instance is a fresh agent. Process-instance boundaries are honored.
-- `client_session_id` maintains identity within one process; weak across processes.
-- `continuity_token` is being narrowed (S1 in `docs/ontology/plan.md`) — present-day external clients can still resume with it, but plugin-internal flows declare lineage instead.
-- Substrate-anchored agents (Lumen, the long-lived residents) earn cross-process continuity via the substrate-earned identity pattern in `docs/ontology/identity.md` — they may use a hardcoded UUID across restarts.
-- Arg-less `onboard()` with no proof signal triggers the v2 fresh-instance gate — the server flips `force_new=true` and emits a `[FRESH_INSTANCE]` log line (S13).
-- Lineage is causal and declared at onboard time. The default fresh session declares no parent. Declare `parent_agent_id` only for a real spawn (`spawn_reason="subagent"`) or a handoff from an exited session (`spawn_reason="explicit"`); declaring a live agent as parent is rejected (`lineage_coincidental_rejected`).
+Shared-memory (KG) write discipline: search before writing. If a related entry
+exists, prefer a linked correction or `supersede` over a fresh note. Store when
+a future agent would search for this and not already find it: a correction to a
+prior conclusion, a non-obvious failure mode plus its fingerprint, or a closed
+mystery. Operational runbooks and step lists belong in `docs/`, not KG notes.
 
 <!-- END SHARED CONTRACT -->

--- a/commands/checkin.md
+++ b/commands/checkin.md
@@ -12,9 +12,14 @@ If the newest entry contains `parent_agent_id`, treat it as local lineage contex
 
 If current binding is unclear, call `identity()` first to inspect the active binding.
 
-If you must rebind to a cached UUID, include a matching current in-process `continuity_token`: `identity(agent_uuid=<uuid>, continuity_token=<token>, resume=true)`. Do not use legacy cache files as token sources.
+If you must test a cached UUID, use an advanced proof-owned rebind only when a
+matching current in-process `continuity_token` is available. Do not use legacy
+cache files as token sources.
 
-If this is a fresh process and no ownership proof is available, use `/governance-start` to mint a fresh identity with `parent_agent_id=<cached uuid>` rather than bare UUID resume.
+If this is a fresh process and no ownership proof is available, use
+`/governance-start` to mint a fresh identity. Add `parent_agent_id` only when
+this process is genuinely inheriting work from a finished predecessor; do not
+infer lineage from the cache alone.
 
 If no local continuity state exists and the current identity is unclear, use `/governance-start` first.
 

--- a/commands/diagnose.md
+++ b/commands/diagnose.md
@@ -8,11 +8,16 @@ Use the shared helper in this repo:
 
 - `scripts/client/session_cache.py list`
 
-If the newest entry contains `parent_agent_id`, treat it as a local lineage candidate.
+If the newest entry contains `parent_agent_id`, treat it as lineage context, not
+proof that this process should declare the same parent.
 
-Do not verify by bare UUID resume. If you need to test ownership of a cached UUID, call `identity(agent_uuid=<uuid>, continuity_token=<token>, resume=true)` only when a matching current in-process token is available. Do not use legacy cache files as token sources.
+Do not verify by bare UUID resume. If you need to test ownership of a cached
+UUID, use an advanced proof-owned rebind only when a matching current in-process
+token is available. Do not use legacy cache files as token sources.
 
-If no proof-owned UUID rebind is available, call `identity()` to inspect current binding. Use `/governance-start` to create a fresh process identity with `parent_agent_id=<cached uuid>` if this process should inherit prior work.
+If no proof-owned UUID rebind is available, call `identity()` to inspect current
+binding. Use `/governance-start` to create a fresh process identity. Add
+`parent_agent_id` only for a real handoff from a finished predecessor.
 
 Call `identity()` first when continuity or binding is unclear.
 

--- a/commands/dialectic-respond.md
+++ b/commands/dialectic-respond.md
@@ -10,7 +10,10 @@ Use the shared helper:
 
 If the newest entry contains `parent_agent_id`, use it as expected-actor lineage context, not as proof by itself.
 
-If you need to bind to that exact cached UUID before responding, use `identity(agent_uuid=<uuid>, continuity_token=<token>, resume=true)` only with a matching current in-process token. Without proof, call `/governance-start` and declare `parent_agent_id=<cached uuid>` if this process is continuing the same work.
+If you need to bind to that exact cached UUID before responding, use an advanced
+proof-owned rebind only with a matching current in-process token. Without proof,
+call `/governance-start` to mint fresh. Declare `parent_agent_id` only when this
+process is genuinely inheriting work from a finished predecessor.
 
 Do not rely on weaker fingerprint/session fallback when dialectic authorization depends on the exact actor.
 

--- a/commands/governance-start.md
+++ b/commands/governance-start.md
@@ -25,7 +25,11 @@ failure (strict mode) once the fleet reliably works in worktrees — the
 advisory→strict rollout mirrors the Surface Lease Plane. Rationale:
 `docs/proposals/worktree-isolation-vs-lease-default.md`.
 
-A cached `parent_agent_id` from a prior session is context, not a lineage instruction: co-location in this workspace is not lineage, and the prior session is almost always still a sibling rather than an exited predecessor. Ignore any legacy `continuity_token` field for startup; tokens are only for explicit same-live-owner PATH 0 proof rebinds.
+A cached `parent_agent_id` from a prior session is context, not a lineage
+instruction: co-location in this workspace is not lineage, and the prior session
+is almost always still a sibling rather than an exited predecessor. Ignore any
+legacy `continuity_token` field for startup; tokens are only for advanced
+same-live-owner diagnostic rebinds.
 
 Call `onboard()` against UNITARES using the strongest honest mode:
 

--- a/docs/guides/START_HERE.md
+++ b/docs/guides/START_HERE.md
@@ -7,10 +7,10 @@ Status: thin entrypoint kept for compatibility. README is the primary overview; 
 Use this unless you have a specific reason not to:
 
 1. First run or fresh process: call `start_session(force_new=true)` and save `agent_uuid` / `client_session_id` from the response
-2. Fresh process continuing prior work: call `start_session(force_new=true, parent_agent_id=<saved uuid>, spawn_reason="new_session")`
-3. Call `sync_state()` after meaningful work
-4. Call `check_working_state()` for state
-5. Use `identity(agent_uuid=<uuid>, continuity_token=<token>, resume=true)` only for same-owner proof-owned rebinds
+2. Same running process: pass `client_session_id` on later check-ins and writes
+3. Fresh process continuing prior work: call `start_session(force_new=true, parent_agent_id=<saved uuid>, spawn_reason="new_session")` only for a real handoff from a finished predecessor
+4. Call `sync_state()` after meaningful work
+5. Call `check_working_state()` for state
 
 These primary workflow tools are the agent-facing surface. Raw implementation
 tools remain available for older clients and debugging:
@@ -33,15 +33,18 @@ result = start_session(force_new=True)
 save_to_file(result["agent_uuid"])
 
 # New process inheriting prior work:
+# Use only for a real handoff from a finished predecessor.
 start_session(force_new=True, parent_agent_id=saved_uuid, spawn_reason="new_session")
 
 # After work:
-sync_state(response_text="What you did", complexity=0.5)
+sync_state(response_text="What you did", complexity=0.5, client_session_id=session_id)
 ```
 
 ## Identity Rule
 
-UUID is an identity anchor, not proof that the current process owns that identity. Use `parent_agent_id` to declare lineage for a fresh process. Use `continuity_token` only as short-lived ownership proof when rebinding the same UUID.
+UUID is a server record, not proof that the current process owns that identity.
+Use `client_session_id` for writes in the same running process. Use
+`parent_agent_id` only to declare a real handoff into a fresh process.
 
 ## What To Trust
 
@@ -72,4 +75,4 @@ Important current semantics:
 
 This file used to be a larger onboarding guide from an earlier MCP/tooling phase. It is intentionally kept small now to avoid duplicated explanations drifting out of sync with the runtime.
 
-**Last Updated:** 2026-06-12 (measurement-policy-enforcement semantics aligned with runtime response layers)
+**Last Updated:** 2026-06-18 (identity contract simplified for normal agent workflows)

--- a/docs/ontology/identity.md
+++ b/docs/ontology/identity.md
@@ -5,6 +5,40 @@
 
 ---
 
+## Operational contract
+
+Most callers should only need this section. The rest of this document explains
+why the contract exists and where the edge cases live.
+
+Strict identity is a write boundary, not a demand that every agent understand
+the full ontology:
+
+1. **New driver process:** call `start_session(force_new=true)` and save the
+   returned `uuid` plus `client_session_id`.
+2. **Same running process:** pass `client_session_id` on check-ins and writes.
+   Client adapters should do this automatically.
+3. **Continuing prior work in a fresh process:** call
+   `start_session(force_new=true, parent_agent_id=<prior_uuid>, spawn_reason="new_session")`
+   only when there is a real handoff from a finished predecessor.
+4. **Short dispatched subagent:** do not mint a separate identity unless it is
+   separately governed. If it does onboard, declare
+   `spawn_reason="subagent"`, set `parent_agent_id=<driver_uuid>`, and check in
+   once before exit.
+5. **Persistent/substrate agent:** use the substrate-earned identity pattern.
+   Ordinary interactive sessions should not copy it.
+
+Normal agents should not pass `continuity_token`, call bare `onboard()`, treat
+names as identity, or declare lineage just because two processes share a host or
+workspace. Those are diagnostic/advanced cases, not the day-to-day path.
+
+Vocabulary boundary:
+
+- `uuid` is the server record for this process identity.
+- `client_session_id` is the accountable write binding for this running process.
+- `parent_agent_id` is a causal inheritance pointer.
+- `lineage` means "inherits work from," not "is identical to."
+- `continuity_token` is an advanced same-live-process rebind proof.
+
 ## Opening stance
 
 This document does not commit to a single ontology of agent identity. It describes what kinds of continuity exist in the system, distinguishes the ones that are earned from the ones that are performative, and opens a research agenda for inventing what would turn the performative kinds into earned ones.

--- a/src/mcp_handlers/introspection/tool_introspection.py
+++ b/src/mcp_handlers/introspection/tool_introspection.py
@@ -646,8 +646,8 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
         "search_shared_memory": "Search shared memory before writing duplicate discoveries",
         "record_result": "Record real task/tool/test outcome for calibration",
         "request_review": "Ask for structured review/recovery",
-        "onboard": "Register fresh process-instance with governance. Per v2 ontology, declare lineage via parent_agent_id rather than resume via token.",
-        "identity": "🪞 Check who you are or set your display name. Per v2 ontology, arg-less identity() with no proof signal mints fresh; pass continuity_token / agent_uuid + proof to resume.",
+        "onboard": "Register a fresh process identity. Prefer start_session(force_new=true); use parent_agent_id only for real handoffs.",
+        "identity": "🪞 Check current binding or set your display name. Not the normal start/resume path; use start_session first.",
         "process_agent_update": "Raw implementation for sync_state(); updates agent governance state",
         "get_governance_metrics": "📊 Get current state and metrics without updating",
         "simulate_update": "🧪 Test decisions without persisting state",
@@ -927,7 +927,7 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
             },
             "more": "list_tools(lite=false) for all tools with full category details",
             "tip": "describe_tool(tool_name=...) for parameter details and examples",
-            "quick_start": "Start fresh with start_session(force_new=true); use parent_agent_id for lineage, not bare UUID resume",
+            "quick_start": "Start fresh with start_session(force_new=true); pass client_session_id on later writes",
             "getting_started_path": _getting_started_path(),
             "essential_toolkit": _essential_toolkit(),
         }
@@ -936,7 +936,7 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
         if is_new_agent:
             response_data["first_time"] = {
                 "hint": "First time here? Start with start_session(force_new=true) to create your identity.",
-                "next_step": "Call start_session(force_new=true). If inheriting prior work, also pass parent_agent_id and spawn_reason='new_session'."
+                "next_step": "Call start_session(force_new=true), then pass its client_session_id on later writes."
             }
         
         # Add progressive metadata if enabled
@@ -1134,10 +1134,10 @@ async def handle_list_tools(arguments: Dict[str, Any]) -> Sequence[TextContent]:
         "quick_start": {
             "new_agent": [
                 "1. Call start_session(force_new=true) - creates a fresh process identity",
-                "2. If inheriting prior work, include parent_agent_id and spawn_reason='new_session'",
-                "3. Save uuid plus continuity diagnostics from response",
-                "4. Call sync_state() to share meaningful work",
-                "5. Use identity(name='...') to set a cosmetic label"
+                "2. Save uuid and client_session_id from the response",
+                "3. Pass client_session_id on later check-ins and writes",
+                "4. Use parent_agent_id only for a real handoff from a finished predecessor",
+                "5. Use identity(name='...') only to set a cosmetic label"
             ],
             "categories_to_explore": [
                 "🚀 Identity & Onboarding - Start here!",
@@ -1365,8 +1365,7 @@ async def handle_describe_tool(arguments: Dict[str, Any]) -> Sequence[TextConten
                     },
                     "identity": {
                         "check_identity": "identity()  # Shows current bound identity",
-                        "name_yourself": "identity(name=\"my_agent\")  # Set your display name",
-                        "proof_owned_rebind": "identity(agent_uuid=\"...\", continuity_token=\"...\", resume=true)  # Same-owner rebind"
+                        "name_yourself": "identity(name=\"my_agent\")  # Set your display name"
                     },
                     "list_agents": {
                         "all_agents": "list_agents()  # List all agents with metadata",

--- a/src/mcp_handlers/middleware/envelope_step.py
+++ b/src/mcp_handlers/middleware/envelope_step.py
@@ -56,6 +56,12 @@ def _lift(payload: Dict[str, Any], *keys: str) -> Dict[str, Any]:
     return {k: payload[k] for k in keys if payload.get(k) is not None}
 
 
+def _harvest_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Use nested canonical payloads when a caller hands us an envelope."""
+    raw = payload.get("raw_governance")
+    return raw if isinstance(raw, dict) else payload
+
+
 def _coherence_and_risk(payload: Dict[str, Any]) -> tuple[Optional[float], Optional[float]]:
     """Pull (coherence, risk_score) from the places handlers put them."""
     for container in (payload.get("metrics"), payload.get("current_state"), payload):
@@ -97,6 +103,16 @@ def _verdict_value(payload: Dict[str, Any]) -> Optional[str]:
     return str(value).lower() if value is not None else None
 
 
+def _decision_action(payload: Dict[str, Any]) -> Optional[str]:
+    for container in (payload.get("decision"), payload.get("verdict"), payload):
+        if not isinstance(container, dict):
+            continue
+        value = container.get("action") or container.get("value") or container.get("verdict")
+        if value is not None:
+            return str(value).lower()
+    return None
+
+
 def _needs_attention(payload: Dict[str, Any]) -> bool:
     verdict = _verdict_value(payload)
     if verdict in {"guide", "pause", "reject"}:
@@ -131,12 +147,22 @@ def _recovery_hint(
     attention = _needs_attention(payload)
     if not (risky or attention):
         return None
-    severe = _verdict_value(payload) in {"pause", "reject"} or (risk is not None and risk >= 0.7)
+    action = _decision_action(payload) or _verdict_value(payload)
+    severe = action in {"pause", "reject", "block", "stop"} or (
+        risk is not None and risk >= 0.7
+    )
     drifting = coherence is not None and coherence < _RECOVERY_COHERENCE_FLOOR
-    if severe or (attention and drifting):
+    continuing = action in {"proceed", "continue", "approve", "ok", "healthy"}
+    if severe or (attention and drifting and not continuing):
         return (
             "Working state looks degraded - pause and call "
             "self_recovery_review(reflection='...') before continuing."
+        )
+    if attention and drifting and continuing:
+        return (
+            "Coherence is near an edge - keep scope tight, sync_state after "
+            "the next substantial step, and use self_recovery_review(reflection='...') "
+            "only if work stalls."
         )
     return (
         "Risk is elevated - if you feel stuck, quick_resume() applies when "
@@ -147,7 +173,12 @@ def _recovery_hint(
 
 def _memory_suggestions(payload: Dict[str, Any]) -> Optional[List[Dict[str, Any]]]:
     """Surface prior discoveries the canonical payload already carries."""
-    candidates = payload.get("relevant_discoveries") or payload.get("results")
+    payload = _harvest_payload(payload)
+    candidates = (
+        payload.get("relevant_discoveries")
+        or payload.get("results")
+        or payload.get("discoveries")
+    )
     if not isinstance(candidates, list) or not candidates:
         return None
     suggestions = []
@@ -180,7 +211,8 @@ def build_experience_envelope(
     if "agent_uuid" not in envelope and payload.get("uuid") is not None:
         envelope["agent_uuid"] = payload["uuid"]
 
-    coherence, risk = _coherence_and_risk(payload)
+    source_payload = _harvest_payload(payload)
+    coherence, risk = _coherence_and_risk(source_payload)
 
     next_action: Any = None
     state_summary: Optional[Dict[str, Any]] = None
@@ -225,7 +257,12 @@ def build_experience_envelope(
             state_summary = verdict if isinstance(verdict, dict) else {"verdict": verdict}
 
     elif canonical_name == "knowledge":
-        total = payload.get("total_count", len(payload.get("results") or []))
+        candidates = source_payload.get("results") or source_payload.get("discoveries") or []
+        total = source_payload.get("total_count")
+        if total is None:
+            total = source_payload.get("count")
+        if total is None:
+            total = len(candidates)
         next_action = (
             f"{total} prior discoveries matched - read before redoing work. "
             "Full context: knowledge(action='details', discovery_id=...). "
@@ -271,7 +308,7 @@ def build_experience_envelope(
     if suggestions:
         envelope["memory_suggestions"] = suggestions
 
-    hint = _recovery_hint(payload, coherence, risk)
+    hint = _recovery_hint(source_payload, coherence, risk)
     if hint:
         envelope["recovery_hint"] = hint
 

--- a/src/storage/knowledge_graph_age.py
+++ b/src/storage/knowledge_graph_age.py
@@ -650,14 +650,14 @@ class KnowledgeGraphAGE:
             if where_clause:
                 cypher = f"""
                     {base_match} AND {where_clause}
-                    RETURN d
+                    RETURN DISTINCT d
                     ORDER BY d.timestamp DESC
                     LIMIT ${{limit}}
                 """
             else:
                 cypher = f"""
                     {base_match}
-                    RETURN d
+                    RETURN DISTINCT d
                     ORDER BY d.timestamp DESC
                     LIMIT ${{limit}}
                 """
@@ -678,6 +678,7 @@ class KnowledgeGraphAGE:
         logger.debug(f"AGE query returned {len(results)} results")
 
         discoveries = []
+        seen_ids = set()
         for result in results:
             # graph_query returns parsed agtype directly, not {"d": node}
             # Handle both dict with "d" key and direct node data
@@ -689,7 +690,8 @@ class KnowledgeGraphAGE:
             else:
                 node_data = self._parse_agtype_node(result)
             discovery = self._node_to_discovery(node_data)
-            if discovery:
+            if discovery and discovery.id not in seen_ids:
+                seen_ids.add(discovery.id)
                 discoveries.append(discovery)
 
         return discoveries

--- a/tests/test_agent_experience_envelope.py
+++ b/tests/test_agent_experience_envelope.py
@@ -201,6 +201,19 @@ def test_sync_state_envelope_does_not_warn_on_low_risk_proceed_mid_coherence():
     assert "recovery_hint" not in env
 
 
+def test_sync_state_envelope_near_edge_proceed_hint_does_not_say_pause():
+    payload = {
+        "success": True,
+        "verdict": {"value": "proceed"},
+        "margin": "near_edge",
+        "metrics": {"coherence": 0.51, "risk_score": 0.43},
+    }
+    env = build_experience_envelope("sync_state", "process_agent_update", payload)
+    assert "recovery_hint" in env
+    assert "pause" not in env["recovery_hint"].lower()
+    assert "only if work stalls" in env["recovery_hint"]
+
+
 def test_sync_state_envelope_surfaces_discoveries():
     payload = {
         "success": True,
@@ -233,6 +246,21 @@ def test_search_envelope_counts_and_suggests():
     }
     env = build_experience_envelope("search_shared_memory", "knowledge", payload)
     assert "1 prior discoveries matched" in env["next_action"]
+    assert env["memory_suggestions"][0]["summary"] == "prior art"
+
+
+def test_search_envelope_counts_nested_raw_governance_payload():
+    payload = {
+        "success": True,
+        "tool": "search_shared_memory",
+        "raw_governance": {
+            "success": True,
+            "count": 5,
+            "discoveries": [{"id": "d1", "summary": "prior art"}],
+        },
+    }
+    env = build_experience_envelope("search_shared_memory", "knowledge", payload)
+    assert "5 prior discoveries matched" in env["next_action"]
     assert env["memory_suggestions"][0]["summary"] == "prior art"
 
 

--- a/tests/test_knowledge_graph_age.py
+++ b/tests/test_knowledge_graph_age.py
@@ -799,6 +799,20 @@ class TestQuery:
         assert result[1].id == "d2"
 
     @pytest.mark.asyncio
+    async def test_query_deduplicates_duplicate_discovery_ids(self):
+        """Should return one result when AGE emits the same discovery twice."""
+        kg, mock_db = make_kg_with_mock_db()
+        mock_db.graph_query.return_value = [
+            {"properties": {"id": "d1", "agent_id": "a1", "summary": "one"}},
+            {"properties": {"id": "d1", "agent_id": "a1", "summary": "one"}},
+            {"properties": {"id": "d2", "agent_id": "a2", "summary": "two"}},
+        ]
+
+        result = await kg.query(tags=["python", "bug"])
+
+        assert [d.id for d in result] == ["d1", "d2"]
+
+    @pytest.mark.asyncio
     async def test_query_with_agent_id_filter(self):
         """Should include agent_id in query params."""
         kg, mock_db = make_kg_with_mock_db()
@@ -859,6 +873,7 @@ class TestQuery:
         params = call_args.args[1]
         assert "TAGGED" in cypher
         assert "Tag" in cypher
+        assert "RETURN DISTINCT d" in cypher
         assert params["tags"] == ["python", "bug"]
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Summary
- simplify the strict identity contract across agent docs, commands, ontology notes, and tool discovery
- dedupe KG tag-filtered search results in AGE and defensively in Python result conversion
- harden agent experience envelopes for nested KG search payloads and near-edge proceed hints

Validation
- ./scripts/dev/check-shared-contract.sh
- python3 -m pytest tests/test_agent_experience_envelope.py tests/test_knowledge_graph_age.py tests/test_describe_tool_drift.py::test_list_tools_lite_surfaces_workflow_aliases tests/test_list_tools_workflow_aliases.py tests/test_kg_search.py::TestSearchKnowledgeGraph::test_search_with_tags
- git diff --check HEAD^ HEAD
- pre-push smoke: 138 passed, 9623 deselected