### PR TITLE
Keep pre-onboard read tools identity-neutral

### DIFF
--- a/src/mcp_handlers/core.py
+++ b/src/mcp_handlers/core.py
@@ -151,11 +151,20 @@ async def handle_get_governance_metrics(arguments: ToolArgumentsDict) -> Sequenc
     # stale-client_session_id case this block originally covered.
     if not arguments.get("agent_id"):
         try:
-            from src.mcp_handlers.context import get_context_agent_id
+            from src.mcp_handlers.context import (
+                get_context_agent_id,
+                get_session_proof_origin,
+            )
             bound_agent_id = get_context_agent_id()
+            proof_origin = get_session_proof_origin()
         except Exception:
             bound_agent_id = None
-        if not bound_agent_id:
+            proof_origin = None
+        # A server-inferred binding (transport-injected CSID, sticky cache, or
+        # fingerprint/pin fallback) is enough to protect strict writes, but it
+        # is not caller proof for a pre-onboard read. Otherwise a fresh
+        # no-proof Hermes/MCP episode can display a resident sibling's state.
+        if not bound_agent_id or proof_origin == "server_inferred":
             return success_response(unbound_metrics_payload())
 
     agent_id, error = require_agent_id(arguments)

--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -305,12 +305,13 @@ async def _broadcast_knowledge_read(
 
 def _resolve_reader_agent_id(arguments: Dict[str, Any]) -> Optional[str]:
     """Best-effort reader-identity extraction for read-side audit events."""
-    from ..context import get_context_agent_id
-    return (
-        arguments.get("_agent_uuid")
-        or get_context_agent_id()
-        or arguments.get("agent_id")
-    )
+    from ..context import get_context_agent_id, get_session_proof_origin
+    explicit_reader = arguments.get("_agent_uuid") or arguments.get("agent_id")
+    if explicit_reader:
+        return explicit_reader
+    if get_session_proof_origin() == "server_inferred":
+        return None
+    return get_context_agent_id()
 
 
 def _compute_staleness_warning(discovery, current_server_version: str) -> Optional[str]:

--- a/src/mcp_handlers/support/agent_auth.py
+++ b/src/mcp_handlers/support/agent_auth.py
@@ -68,11 +68,19 @@ def compute_agent_signature(
     3. Session binding lookup
     """
     try:
-        from ..context import get_context_agent_id
+        from ..context import get_context_agent_id, get_session_proof_origin
         from ..shared import get_mcp_server
         mcp_server = get_mcp_server()
 
         context_bound_id = get_context_agent_id()
+        proof_origin = get_session_proof_origin()
+        has_explicit_identity = bool(
+            agent_id
+            or (arguments or {}).get("agent_id")
+            or (arguments or {}).get("_agent_uuid")
+        )
+        if proof_origin == "server_inferred" and not has_explicit_identity:
+            return {"uuid": None}
         bound_id = agent_id or context_bound_id
 
         logger.debug(

--- a/tests/test_pre_onboard_read_identity_honesty.py
+++ b/tests/test_pre_onboard_read_identity_honesty.py
@@ -1,0 +1,90 @@
+"""Pre-onboard read tools must not launder server-inferred identity.
+
+A no-proof Hermes/MCP episode can share a transport session with a resident
+binding. Read-only pre-onboard tools should report an unbound caller instead of
+presenting that resident as the caller.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_governance_metrics_server_inferred_binding_returns_unbound(monkeypatch):
+    """Injected/sticky transport identity is not caller proof for read identity."""
+    import src.mcp_handlers.context as context
+    import src.mcp_handlers.core as core
+    import src.services.runtime_queries as runtime_queries
+
+    calls: list[str] = []
+
+    monkeypatch.setattr(context, "get_context_agent_id", lambda: "chronicler-uuid")
+    monkeypatch.setattr(context, "get_session_proof_origin", lambda: "server_inferred")
+    monkeypatch.setattr(context, "get_session_resolution_source", lambda: "explicit_client_session_id")
+    monkeypatch.setattr(core, "require_agent_id", lambda _arguments: ("chronicler-uuid", None))
+
+    async def fake_metrics(agent_id, arguments, server=None):
+        calls.append(agent_id)
+        return {"status": "🟡 moderate", "agent_id": "Chronicler"}
+
+    monkeypatch.setattr(runtime_queries, "get_governance_metrics_data", fake_metrics)
+
+    result = await core.handle_get_governance_metrics({})
+    payload = json.loads(result[0].text)
+
+    assert payload["status"] == "⚪ unbound"
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_governance_metrics_caller_asserted_binding_still_reads_agent(monkeypatch):
+    """A caller-proven session binding keeps the convenient status read path."""
+    import src.mcp_handlers.context as context
+    import src.mcp_handlers.core as core
+    import src.services.runtime_queries as runtime_queries
+
+    calls: list[str] = []
+
+    monkeypatch.setattr(context, "get_context_agent_id", lambda: "agent-uuid")
+    monkeypatch.setattr(context, "get_session_proof_origin", lambda: "caller_asserted")
+    monkeypatch.setattr(core, "require_agent_id", lambda _arguments: ("agent-uuid", None))
+
+    async def fake_metrics(agent_id, arguments, server=None):
+        calls.append(agent_id)
+        return {"status": "🟢 low", "agent_id": "Caller"}
+
+    monkeypatch.setattr(runtime_queries, "get_governance_metrics_data", fake_metrics)
+
+    result = await core.handle_get_governance_metrics({})
+    payload = json.loads(result[0].text)
+
+    assert payload["status"] == "🟢 low"
+    assert payload["agent_id"] == "Caller"
+    assert calls == ["agent-uuid"]
+
+
+def test_success_response_omits_signature_for_server_inferred_context(monkeypatch):
+    """Generic read envelopes should not advertise a server-inferred sibling."""
+    import src.mcp_handlers.context as context
+    from src.mcp_handlers.response_base import success_response
+
+    monkeypatch.setattr(context, "get_context_agent_id", lambda: "chronicler-uuid")
+    monkeypatch.setattr(context, "get_session_proof_origin", lambda: "server_inferred")
+
+    payload = json.loads(success_response({"results": []}, arguments={})[0].text)
+
+    assert payload["agent_signature"] == {"uuid": None}
+
+
+def test_knowledge_read_audit_omits_server_inferred_reader(monkeypatch):
+    """Read-side KG telemetry should not attribute no-proof reads to a sibling."""
+    import src.mcp_handlers.context as context
+    from src.mcp_handlers.knowledge.handlers import _resolve_reader_agent_id
+
+    monkeypatch.setattr(context, "get_context_agent_id", lambda: "chronicler-uuid")
+    monkeypatch.setattr(context, "get_session_proof_origin", lambda: "server_inferred")
+
+    assert _resolve_reader_agent_id({}) is None


### PR DESCRIPTION
## Summary\n- keep pre-onboard get_governance_metrics unbound when the only identity is server-inferred from transport/session context\n- avoid emitting agent_signature UUIDs for server-inferred read responses\n- avoid KG read-audit attribution to server-inferred identities\n\n## Tests\n- PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 -m compileall -q src/mcp_handlers/core.py src/mcp_handlers/support/agent_auth.py src/mcp_handlers/knowledge/handlers.py tests/test_pre_onboard_read_identity_honesty.py\n- PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 -m pytest tests/test_pre_onboard_read_identity_honesty.py tests/test_strict_proof_origin.py tests/test_response_base.py tests/test_kg_store.py tests/test_kg_lifecycle.py -q -o 'addopts='\n