### PR TITLE
fix(docker): unbreak quickstart after apache/age:latest PG18 drift

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,21 @@ updates:
     labels:
       - "dependencies"
 
+  - package-ecosystem: "docker"
+    # Root compose/Dockerfile + the AGE+pgvector image. Pinned base tags here
+    # (apache/age, pgvector) get bump PRs instead of silently floating; the
+    # Docker Quickstart workflow validates each bump end to end before merge.
+    directories:
+      - "/"
+      - "/db/postgres"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "docker"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/docker-quickstart.yml
+++ b/.github/workflows/docker-quickstart.yml
@@ -1,0 +1,60 @@
+name: Docker Quickstart
+
+# Exercises the documented quickstart end to end so upstream image drift can't
+# silently break it again. `apache/age:latest` floated PG17 -> PG18 and broke
+# `docker compose up && make demo` with nothing to catch it; this job builds the
+# real stack and runs the demo against it. Pure-stdlib demo (urllib), no paid
+# model API — GITHUB_TOKEN only.
+#
+# Path-filtered: only runs when the build inputs change, so the common Python-only
+# PR doesn't pay the image-build cost.
+
+on:
+  push:
+    branches: [ master, main ]
+    paths:
+      - 'db/postgres/**'
+      - 'docker-compose.yml'
+      - 'Dockerfile'
+      - 'scripts/demo/quick_demo.py'
+      - '.github/workflows/docker-quickstart.yml'
+  pull_request:
+    branches: [ master, main ]
+    paths:
+      - 'db/postgres/**'
+      - 'docker-compose.yml'
+      - 'Dockerfile'
+      - 'scripts/demo/quick_demo.py'
+      - '.github/workflows/docker-quickstart.yml'
+
+jobs:
+  quickstart:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Build and start the documented stack
+        run: docker compose up -d --wait --build
+
+      - name: Assert PG / AGE / pgvector versions
+        run: |
+          set -euo pipefail
+          versions=$(docker exec unitares-postgres-age psql -U postgres -d governance -tAc \
+            "SELECT extname||'='||extversion FROM pg_extension WHERE extname IN ('age','vector') ORDER BY extname;")
+          echo "$versions"
+          echo "$versions" | grep -qx 'age=1.7.0'   || { echo "::error::AGE not 1.7.0"; exit 1; }
+          echo "$versions" | grep -qx 'vector=0.8.3' || { echo "::error::pgvector not 0.8.3"; exit 1; }
+
+      - name: Run the quickstart demo against the stack
+        run: make demo
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: docker compose logs --no-color --tail=200
+
+      - name: Tear down
+        if: always()
+        run: docker compose down -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,22 @@ jobs:
         pip install "ruff>=0.15"
         ruff check .
 
+    - name: Lint Dockerfiles for floating image tags
+      # Fails the build if any Dockerfile/compose base image floats (`:latest`
+      # or untagged). DB-free doctor check, so it runs without a live Postgres.
+      run: |
+        python - <<'PY'
+        import sys
+        from pathlib import Path
+        sys.path.insert(0, "scripts/dev")
+        import unitares_doctor as d
+        r = d.check_dockerfile_pinned_tags(Path("."))
+        print(f"[{r.status.value.upper()}] {r.message}")
+        if r.detail:
+            print(r.detail)
+        sys.exit(1 if r.status == d.Status.FAIL else 0)
+        PY
+
     - name: Run smoke tests
       run: |
         make test-smoke

--- a/db/postgres/Dockerfile.age-vector
+++ b/db/postgres/Dockerfile.age-vector
@@ -7,21 +7,27 @@
 # Or via docker-compose at the repo root:
 #   docker compose up
 
-FROM apache/age:latest
+# Pinned to a versioned tag: `apache/age:latest` floated to PG18 upstream while
+# this Dockerfile still installed postgresql-server-dev-17, breaking the pgvector
+# build (postgres.h not found). AGE 1.7.0 is required by the app (see
+# src/mcp_handlers/lifecycle/lineage_reachability.py), so pin the PG18_1.7.0 tag
+# rather than the PG17 image (whose newest AGE is only 1.6.0).
+FROM apache/age:release_PG18_1.7.0
 
-# Install build dependencies for pgvector
+# Install build dependencies for pgvector. Use $PG_MAJOR (set by the upstream
+# postgres base image) so the dev headers always match the base PG version.
 USER root
 RUN apt-get update && apt-get install -y \
     build-essential \
     git \
-    postgresql-server-dev-17 \
+    postgresql-server-dev-$PG_MAJOR \
     && rm -rf /var/lib/apt/lists/*
 
 # Build and install pgvector
 # OPTFLAGS="" avoids SIMD instructions that cause "Illegal instruction" on
 # some CPUs (notably older x86_64 and ARM under emulation).
 RUN cd /tmp && \
-    git clone --branch v0.8.0 https://github.com/pgvector/pgvector.git && \
+    git clone --branch v0.8.3 https://github.com/pgvector/pgvector.git && \
     cd pgvector && \
     make OPTFLAGS="" && \
     make install && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,10 @@ services:
       # is already taken on your machine (e.g., by a Homebrew Postgres).
       - "127.0.0.1:${POSTGRES_HOST_PORT:-5432}:5432"
     volumes:
-      - postgres-age-data:/var/lib/postgresql/data
+      # PG18+ official images store data in a major-version subdir and require
+      # the persistent mount at /var/lib/postgresql (not .../data, which the
+      # entrypoint rejects). See docker-library/postgres#1259.
+      - postgres-age-data:/var/lib/postgresql
       # Schema bootstrap: the official Postgres entrypoint runs this script
       # once for an empty data volume. The script owns ordering across base
       # schema files, migrations, partition setup, and AGE graph setup.

--- a/scripts/dev/unitares_doctor.py
+++ b/scripts/dev/unitares_doctor.py
@@ -679,6 +679,85 @@ def _redact(db_url: str) -> str:
     return db_url
 
 
+def check_dockerfile_pinned_tags(repo_root: Path) -> CheckResult:
+    """FAIL if any Dockerfile base image or compose `image:` uses a floating
+    tag (`:latest`, or no tag at all).
+
+    Why this is a gate: `apache/age:latest` silently floated PG17 -> PG18
+    upstream and broke the documented `docker compose up && make demo`
+    quickstart (pgvector compiled against the wrong PG headers, the PG18
+    entrypoint rejected the old volume mount). Nothing caught it because the
+    base image was unpinned and the quickstart was never built in CI. A pinned
+    digest/tag turns "upstream moved under us" into an explicit, reviewable
+    version bump (which Dependabot's docker ecosystem then proposes).
+
+    A `:latest` literal or a tagless `FROM image` / `image: name` is a FAIL.
+    Pinned tags (`:release_PG18_1.7.0`), digests (`@sha256:...`), and build
+    references to other stages (`FROM builder`) are fine. Local build stage
+    names declared earlier in the same file are not flagged.
+    """
+    name, mode = "dockerfile_pinned_tags", "local"
+
+    # Dockerfiles anywhere + root compose files. Skip vendored/build trees.
+    skip_parts = {"node_modules", "deps", "_build", ".git", ".venv", "venv"}
+    targets: list[Path] = []
+    for pat in ("**/Dockerfile", "**/Dockerfile.*"):
+        targets += repo_root.glob(pat)
+    for pat in ("docker-compose.yml", "docker-compose.yaml",
+                "docker-compose.*.yml", "docker-compose.*.yaml"):
+        targets += repo_root.glob(pat)
+    targets = [p for p in sorted(set(targets))
+               if not (skip_parts & set(p.parts))]
+
+    def _is_floating(ref: str) -> bool:
+        ref = ref.strip()
+        if "@sha256:" in ref:           # digest-pinned
+            return False
+        # Strip a registry-host:port prefix so its colon isn't read as a tag.
+        last = ref.rsplit("/", 1)[-1]
+        if ":" not in last:             # no tag at all -> floats to :latest
+            return True
+        return last.rsplit(":", 1)[1] == "latest"
+
+    offenders: list[str] = []
+    for f in targets:
+        try:
+            lines = f.read_text(errors="replace").splitlines()
+        except OSError:
+            continue
+        stage_names: set[str] = set()
+        for i, raw in enumerate(lines, 1):
+            line = raw.strip()
+            if line.startswith("FROM "):
+                parts = line[5:].split()
+                if not parts:
+                    continue
+                image = parts[0]
+                # `FROM x AS name` registers a local stage; later `FROM name`
+                # referencing it is not an external image.
+                if image in stage_names:
+                    pass
+                elif _is_floating(image):
+                    offenders.append(f"{f.relative_to(repo_root)}:{i} FROM {image}")
+                if len(parts) >= 3 and parts[1].upper() == "AS":
+                    stage_names.add(parts[2])
+            elif line.startswith("image:"):
+                ref = line.split(":", 1)[1].strip().strip('"').strip("'")
+                if ref and _is_floating(ref):
+                    offenders.append(f"{f.relative_to(repo_root)}:{i} image: {ref}")
+
+    if not targets:
+        return CheckResult(name, mode, Status.SKIP, "no Dockerfiles or compose files found")
+    if offenders:
+        return CheckResult(
+            name, mode, Status.FAIL,
+            f"{len(offenders)} floating base image tag(s) — pin to a version or digest",
+            detail="\n".join(offenders),
+        )
+    return CheckResult(name, mode, Status.PASS,
+                       f"all base images pinned ({len(targets)} file(s) scanned)")
+
+
 def build_checks(repo_root: Path, db_url: str) -> list[Check]:
     loaded_cache: dict[str, set[str]] = {}
 
@@ -698,6 +777,8 @@ def build_checks(repo_root: Path, db_url: str) -> list[Check]:
               lambda: check_elixir_deprecated_scheme_lint(db_url, repo_root)),
         Check("elixir_scheme_grammar_lint", "local",
               lambda: check_elixir_scheme_grammar_lint(db_url, repo_root)),
+        Check("dockerfile_pinned_tags", "local",
+              lambda: check_dockerfile_pinned_tags(repo_root)),
         Check("anchor_directory", "local", check_anchor_dir),
         Check("secrets_file", "local", check_secrets_file),
         Check("http_listening", "operator", check_http_listening),

--- a/tests/test_unitares_doctor_script.py
+++ b/tests/test_unitares_doctor_script.py
@@ -551,3 +551,47 @@ def test_grammar_lint_reports_all_drifting_schemes_sorted(doctor, monkeypatch, t
     assert result.status == doctor.Status.FAIL
     # Sorted: alpha before zeta.
     assert result.message.index("alpha") < result.message.index("zeta")
+
+
+def test_dockerfile_pinned_tags_passes_on_pinned_images(doctor, tmp_path):
+    (tmp_path / "Dockerfile").write_text("FROM python:3.12-slim\n")
+    (tmp_path / "db" / "postgres").mkdir(parents=True)
+    (tmp_path / "db" / "postgres" / "Dockerfile.age-vector").write_text(
+        "FROM apache/age:release_PG18_1.7.0\n"
+    )
+    (tmp_path / "docker-compose.yml").write_text(
+        'services:\n  redis:\n    image: "redis:7-alpine"\n'
+    )
+    result = doctor.check_dockerfile_pinned_tags(tmp_path)
+    assert result.status == doctor.Status.PASS
+
+
+def test_dockerfile_pinned_tags_flags_floating_from(doctor, tmp_path):
+    (tmp_path / "Dockerfile.age-vector").write_text("FROM apache/age:latest\n")
+    result = doctor.check_dockerfile_pinned_tags(tmp_path)
+    assert result.status == doctor.Status.FAIL
+    assert "apache/age:latest" in result.detail
+
+
+def test_dockerfile_pinned_tags_flags_tagless_image_and_compose(doctor, tmp_path):
+    # No tag at all floats to :latest implicitly.
+    (tmp_path / "Dockerfile").write_text("FROM ubuntu\n")
+    (tmp_path / "docker-compose.yml").write_text(
+        "services:\n  cache:\n    image: redis:latest\n"
+    )
+    result = doctor.check_dockerfile_pinned_tags(tmp_path)
+    assert result.status == doctor.Status.FAIL
+    assert "FROM ubuntu" in result.detail
+    assert "redis:latest" in result.detail
+
+
+def test_dockerfile_pinned_tags_ignores_build_stage_refs(doctor, tmp_path):
+    # `FROM builder` references an earlier stage, not a floating external image.
+    (tmp_path / "Dockerfile").write_text(
+        "FROM python:3.12-slim AS builder\n"
+        "RUN echo build\n"
+        "FROM builder\n"
+        "RUN echo final\n"
+    )
+    result = doctor.check_dockerfile_pinned_tags(tmp_path)
+    assert result.status == doctor.Status.PASS


### PR DESCRIPTION
## Problem
The documented quickstart `docker compose up -d --wait && make demo` fails to
build on a fresh machine. `apache/age:latest` drifted from PG17 to **PG18**
upstream while the repo still assumed PG17. Failure cascade observed building
the `postgres-age` image:

1. `postgres.h: No such file or directory` — pgvector compiled against PG18's
   `pg_config` but only `postgresql-server-dev-17` headers were installed.
2. After fixing headers: pgvector **v0.8.0** fails on PG18
   (`vacuum_delay_point` arg-count change). PG18 support landed in pgvector 0.8.1.
3. After fixing pgvector: the PG18 official image **rejects** a volume mounted at
   `/var/lib/postgresql/data` (docker-library/postgres#1259).

## Fix
- Pin base image `apache/age:latest` → `apache/age:release_PG18_1.7.0`.
- Hardcoded `postgresql-server-dev-17` → `postgresql-server-dev-$PG_MAJOR`.
- pgvector `v0.8.0` → `v0.8.3`.
- Volume mount `/var/lib/postgresql/data` → `/var/lib/postgresql`.

AGE is intentionally kept at **1.7.0** (required by
`src/mcp_handlers/lifecycle/lineage_reachability.py`); the only PG17 image,
`release_PG17_1.6.0`, ships AGE 1.6.0.

## Verification
Full stack built and came up healthy on Docker Desktop (macOS arm64), brought up
on override ports to avoid the live `:8767` server. Confirmed in the running
`unitares-postgres-age` container: `pg=180004`, `age=1.7.0`, `vector=0.8.3`; all
three services `(healthy)`; `make demo` (UNITARES_DEMO_PORT pointed at the
container) passes end to end — onboard → 7 check-ins → trajectory summary.

Docker-only change (no Python touched); CI is the gate.