### PR TITLE
fix(analysis): split harness telemetry from EISV slices

### DIFF
--- a/scripts/analysis/eisv_ablation_matrix.py
+++ b/scripts/analysis/eisv_ablation_matrix.py
@@ -38,6 +38,9 @@ from scripts.analysis.eisv_skeptic_report import (
     score_deltas_vs_baseline,
     summarize_conclusion,
 )
+from scripts.analysis.outcome_inventory import harness_lane_from_detail
+
+DEFAULT_EXCLUDED_HARNESS_LANES = ("beam",)
 
 
 @dataclass(frozen=True)
@@ -70,6 +73,25 @@ def _fmt_lead(value: float) -> str:
 
 def _baseline(scores: Sequence[ModelScore]) -> ModelScore | None:
     return next((score for score in scores if score.name == "previous_outcome_bad"), None)
+
+
+def filter_rows_for_validation(
+    rows: Sequence[OutcomeRow],
+    *,
+    exclude_harness_lanes: Sequence[str] = DEFAULT_EXCLUDED_HARNESS_LANES,
+) -> list[OutcomeRow]:
+    """Exclude runtime-harness telemetry from EISV predictive slices.
+
+    Harness rows remain visible in the outcome inventory, but the ablation matrix
+    is about prior-state/EISV predictive lift. A runtime harness such as BEAM can
+    emit many externally verified task outcomes without a matching agent-state
+    trajectory; keeping it in the same slice can look like an EISV signal or a
+    coverage collapse when it is really instrumentation.
+    """
+    excluded = {str(lane) for lane in exclude_harness_lanes if str(lane)}
+    if not excluded:
+        return list(rows)
+    return [row for row in rows if harness_lane_from_detail(row.detail) not in excluded]
 
 
 def build_matrix_row(
@@ -120,6 +142,7 @@ def format_matrix_report(
     rows: Sequence[AblationMatrixRow],
     *,
     generated_at: datetime | None = None,
+    excluded_harness_lanes: Sequence[str] = (),
 ) -> str:
     """Render a compact markdown table for skeptical multi-slice reporting."""
     generated_at = generated_at or datetime.now(timezone.utc)
@@ -128,11 +151,21 @@ def format_matrix_report(
         "",
         f"Generated: {generated_at.strftime('%Y-%m-%d %H:%M:%S %Z')}",
         "",
+    ]
+    excluded = tuple(str(lane) for lane in excluded_harness_lanes if str(lane))
+    if excluded:
+        lines.extend(
+            [
+                "Excluded harness lanes: " + ", ".join(f"`{lane}`" for lane in excluded),
+                "",
+            ]
+        )
+    lines.extend([
         "Positive AUC delta means better ranking than `previous_outcome_bad`; positive Brier improvement means lower probability error. `Beats both?` is the conservative quick read.",
         "",
         "| Scope | Window days | Lead min | Trusted | Bad | Prior state | Prior risk | Baseline AUC | Baseline Brier | Best EISV/prior model | AUC delta | Brier improvement | Beats both? | Conclusion |",
         "|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---|",
-    ]
+    ])
     if rows:
         for row in rows:
             lines.append(
@@ -163,6 +196,10 @@ def _parse_float_list(raw: str) -> list[float]:
     return [float(part.strip()) for part in raw.split(",") if part.strip()]
 
 
+def _parse_string_list(raw: str) -> tuple[str, ...]:
+    return tuple(part.strip() for part in raw.split(",") if part.strip())
+
+
 def _parse_scope_list(raw: str) -> list[str]:
     scopes = [part.strip() for part in raw.split(",") if part.strip()]
     invalid = [scope for scope in scopes if scope not in {"strict", "task"}]
@@ -179,17 +216,21 @@ async def build_matrix_from_db(
     leads: Sequence[float],
     train_fraction: float = 0.7,
     min_feature_rows: int = 30,
+    exclude_harness_lanes: Sequence[str] = DEFAULT_EXCLUDED_HARNESS_LANES,
 ) -> list[AblationMatrixRow]:
     matrix_rows: list[AblationMatrixRow] = []
     for scope in scopes:
         outcome_types = STRICT_OUTCOMES if scope == "strict" else TASK_OUTCOMES
         for window_days in windows:
             for lead_minutes in leads:
-                outcome_rows = await fetch_rows(
-                    db_url,
-                    window_days=window_days,
-                    lead_minutes=lead_minutes,
-                    outcome_types=outcome_types,
+                outcome_rows = filter_rows_for_validation(
+                    await fetch_rows(
+                        db_url,
+                        window_days=window_days,
+                        lead_minutes=lead_minutes,
+                        outcome_types=outcome_types,
+                    ),
+                    exclude_harness_lanes=exclude_harness_lanes,
                 )
                 matrix_rows.append(
                     build_matrix_row(
@@ -212,6 +253,12 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--leads", type=_parse_float_list, default="0,5,30")
     parser.add_argument("--train-fraction", type=float, default=0.7)
     parser.add_argument("--min-feature-rows", type=int, default=30)
+    parser.add_argument(
+        "--exclude-harness-lanes",
+        type=_parse_string_list,
+        default=DEFAULT_EXCLUDED_HARNESS_LANES,
+        help="Comma-separated runtime harness lanes excluded from predictive slices; empty string includes all.",
+    )
     parser.add_argument("--output", help="Optional markdown output path")
     return parser.parse_args(argv)
 
@@ -227,8 +274,9 @@ async def main_async(args: argparse.Namespace) -> int:
         leads=args.leads,
         train_fraction=args.train_fraction,
         min_feature_rows=args.min_feature_rows,
+        exclude_harness_lanes=args.exclude_harness_lanes,
     )
-    report = format_matrix_report(rows)
+    report = format_matrix_report(rows, excluded_harness_lanes=args.exclude_harness_lanes)
     if args.output:
         path = Path(args.output)
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/analysis/outcome_inventory.py
+++ b/scripts/analysis/outcome_inventory.py
@@ -61,6 +61,7 @@ class InventoryBucket:
     hard_exogenous: bool
     eprocess_eligible: bool
     prediction_binding: str
+    harness_lane: str = "substrate"
     n_total: int = 0
     n_bad: int = 0
     prediction_id_count: int = 0
@@ -87,6 +88,7 @@ class OutcomeInventory:
     hard_exogenous_count: int
     eprocess_eligible_count: int
     total_prediction_id_count: int
+    eprocess_eligible_by_harness_lane: dict[str, int] = field(default_factory=dict)
 
     @property
     def total_bad_rate(self) -> float | None:
@@ -188,6 +190,20 @@ def _has_prediction_id(detail: Mapping[str, Any]) -> bool:
     return prediction_id not in (None, "")
 
 
+def harness_lane_from_detail(detail: Mapping[str, Any] | str | None) -> str:
+    """Return the analysis lane for a row's harness provenance.
+
+    Rows without an explicit harness belong to the substrate lane. Runtime
+    harnesses such as the BEAM dispatch harness are useful telemetry, but they
+    must be visible as their own lane before any EISV predictive read.
+    """
+    normalized = _normalized_detail(detail)
+    harness = normalized.get("harness") or normalized.get("harness_type")
+    if not harness:
+        return "substrate"
+    return str(harness)
+
+
 def build_inventory(
     rows: Sequence[OutcomeInventoryRow],
     *,
@@ -195,7 +211,7 @@ def build_inventory(
 ) -> OutcomeInventory:
     """Aggregate outcome rows by provenance, objectivity, and lead coverage."""
     leads = tuple(float(lead) for lead in lead_minutes)
-    buckets: dict[tuple[str, str, str, bool, bool, str], InventoryBucket] = {}
+    buckets: dict[tuple[str, str, str, bool, bool, str, str], InventoryBucket] = {}
 
     total_outcomes = 0
     total_bad = 0
@@ -203,6 +219,7 @@ def build_inventory(
     strict_bad = 0
     hard_exogenous_count = 0
     eprocess_eligible_count = 0
+    eprocess_eligible_by_harness_lane: dict[str, int] = {}
     total_prediction_id_count = 0
 
     for row in rows:
@@ -211,6 +228,7 @@ def build_inventory(
         hard_exogenous = _truthy(detail.get("hard_exogenous"))
         eprocess_eligible = _truthy(detail.get("eprocess_eligible"))
         prediction_binding = _prediction_binding(detail)
+        harness_lane = harness_lane_from_detail(detail)
         key = (
             scope,
             _grouped_outcome_type(row.outcome_type),
@@ -218,6 +236,7 @@ def build_inventory(
             hard_exogenous,
             eprocess_eligible,
             prediction_binding,
+            harness_lane,
         )
         bucket = buckets.get(key)
         if bucket is None:
@@ -228,6 +247,7 @@ def build_inventory(
                 hard_exogenous=key[3],
                 eprocess_eligible=key[4],
                 prediction_binding=key[5],
+                harness_lane=key[6],
                 prior_state_counts={lead: 0 for lead in leads},
             )
             buckets[key] = bucket
@@ -245,6 +265,9 @@ def build_inventory(
             hard_exogenous_count += 1
         if eprocess_eligible:
             eprocess_eligible_count += 1
+            eprocess_eligible_by_harness_lane[harness_lane] = (
+                eprocess_eligible_by_harness_lane.get(harness_lane, 0) + 1
+            )
         if _has_prediction_id(detail):
             bucket.prediction_id_count += 1
             total_prediction_id_count += 1
@@ -262,6 +285,7 @@ def build_inventory(
                 bucket.hard_exogenous,
                 bucket.eprocess_eligible,
                 bucket.prediction_binding,
+                bucket.harness_lane,
             ),
         )
     )
@@ -275,6 +299,7 @@ def build_inventory(
         hard_exogenous_count=hard_exogenous_count,
         eprocess_eligible_count=eprocess_eligible_count,
         total_prediction_id_count=total_prediction_id_count,
+        eprocess_eligible_by_harness_lane=dict(sorted(eprocess_eligible_by_harness_lane.items())),
     )
 
 
@@ -310,6 +335,10 @@ def format_inventory_report(
         f"strict_bad: {inventory.strict_bad}",
         f"hard_exogenous: {inventory.hard_exogenous_count}",
         f"eprocess_eligible: {inventory.eprocess_eligible_count}",
+        *[
+            f"eprocess_eligible_{lane}: {count}"
+            for lane, count in sorted(inventory.eprocess_eligible_by_harness_lane.items())
+        ],
         f"prediction_id_present: {inventory.total_prediction_id_count}",
         "",
     ]
@@ -319,6 +348,7 @@ def format_inventory_report(
         "scope",
         "outcome_type",
         "verification_source",
+        "harness_lane",
         "hard_exogenous",
         "eprocess_eligible",
         "prediction_binding",
@@ -340,6 +370,7 @@ def format_inventory_report(
                     bucket.scope,
                     bucket.outcome_type,
                     bucket.verification_source,
+                    bucket.harness_lane,
                     str(bucket.hard_exogenous).lower(),
                     str(bucket.eprocess_eligible).lower(),
                     bucket.prediction_binding,

--- a/tests/test_eisv_ablation_matrix.py
+++ b/tests/test_eisv_ablation_matrix.py
@@ -8,6 +8,7 @@ import sys
 from scripts.analysis.eisv_ablation_matrix import (
     AblationMatrixRow,
     build_matrix_row,
+    filter_rows_for_validation,
     format_matrix_report,
 )
 from scripts.analysis.eisv_skeptic_report import OutcomeRow
@@ -42,6 +43,17 @@ def _row(idx: int, *, bad: bool, risk: float | None, agent: str = "agent-a") -> 
         snapshot_phi=None,
         snapshot_coherence=None,
     )
+
+
+def test_filter_rows_for_validation_excludes_beam_harness_by_default():
+    substrate = _row(0, bad=False, risk=0.1)
+    beam = _row(1, bad=True, risk=None)
+    beam = OutcomeRow(**{**beam.__dict__, "detail": {"harness": "beam"}})
+
+    filtered = filter_rows_for_validation([substrate, beam])
+
+    assert filtered == [substrate]
+    assert filter_rows_for_validation([substrate, beam], exclude_harness_lanes=()) == [substrate, beam]
 
 
 def test_build_matrix_row_summarizes_baseline_and_best_candidate():
@@ -100,9 +112,10 @@ def test_format_matrix_report_contains_skeptical_ablation_table():
         )
     ]
 
-    report = format_matrix_report(rows)
+    report = format_matrix_report(rows, excluded_harness_lanes=("beam",))
 
     assert report.startswith("# EISV Ablation Matrix")
+    assert "Excluded harness lanes: `beam`" in report
     assert "| Scope | Window days | Lead min | Trusted | Bad | Prior state | Prior risk |" in report
     assert "| task | 90 | 30 | 120 | 24 | 120 | 120 |" in report
     assert "prior_risk_binned" in report

--- a/tests/test_outcome_inventory.py
+++ b/tests/test_outcome_inventory.py
@@ -98,6 +98,35 @@ def test_build_inventory_groups_by_scope_type_source_and_evidence_flags():
     assert inventory.total_prediction_id_count == 2
 
 
+def test_build_inventory_splits_beam_harness_from_substrate_lane():
+    rows = [
+        OutcomeInventoryRow(
+            outcome_type="task_completed",
+            is_bad=False,
+            verification_source="external_signal",
+            detail={"hard_exogenous": True, "eprocess_eligible": True, "harness": "beam"},
+            prior_state_by_lead={0.0: False},
+        ),
+        OutcomeInventoryRow(
+            outcome_type="task_completed",
+            is_bad=False,
+            verification_source="external_signal",
+            detail={"hard_exogenous": True, "eprocess_eligible": True},
+            prior_state_by_lead={0.0: True},
+        ),
+    ]
+
+    inventory = build_inventory(rows, lead_minutes=(0.0,))
+    by_lane = {bucket.harness_lane: bucket for bucket in inventory.buckets}
+
+    assert set(by_lane) == {"beam", "substrate"}
+    assert by_lane["beam"].n_total == 1
+    assert by_lane["beam"].prior_state_counts == {0.0: 0}
+    assert by_lane["substrate"].n_total == 1
+    assert by_lane["substrate"].prior_state_counts == {0.0: 1}
+    assert inventory.eprocess_eligible_by_harness_lane == {"beam": 1, "substrate": 1}
+
+
 def test_format_inventory_report_exposes_zero_bad_strict_and_prior_coverage():
     rows = [
         OutcomeInventoryRow(


### PR DESCRIPTION
## Summary
- split outcome inventory by `harness_lane` so BEAM/runtime harness telemetry is visible separately from substrate outcomes
- exclude `beam` harness rows from EISV ablation matrix predictive slices by default, while allowing override with `--exclude-harness-lanes ''`
- add regressions showing BEAM telemetry remains inventoried but does not masquerade as EISV/prior-state validation evidence

## Verification
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 -m pytest tests/test_outcome_inventory.py tests/test_eisv_ablation_matrix.py tests/test_eisv_skeptic_report.py -q -o 'addopts='` → 19 passed
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 ./scripts/dev/test-cache.sh` → 10392 passed, 21 skipped, coverage 81.26%
- `UNITARES_REPO=/Users/cirwel/projects/wt/unitares-ablation-harness-lane UNITARES_WATCHDOG_NO_WRITE=1 /Users/cirwel/.hermes/hermes-agent/venv/bin/python3 /Users/cirwel/.hermes/scripts/unitares_ablation_watchdog.py` → exit 0

## Operational read
The watchdog still reports the eprocess eligibility jump, but inventory now attributes it by lane:
- `eprocess_eligible=1778`
- `eprocess_eligible_beam=1493`
- `eprocess_eligible_substrate=285`

The matrix now states `Excluded harness lanes: beam` and continues to report strict slices as inconclusive (`strict_bad=0`) plus mixed/skeptical task slices. This keeps runtime harness telemetry from being read as EISV predictive validation.
