### PR TITLE
feat(security): bearer-token gate on /mcp (+ close the SSE bypass)

### DIFF
--- a/scripts/ops/mcp_agent.py
+++ b/scripts/ops/mcp_agent.py
@@ -12,7 +12,9 @@ Usage:
     python3 scripts/mcp_agent.py process_agent_update response_text="My work" complexity=0.6
 
 Features:
-    - Auto-detects Streamable HTTP (/mcp) vs SSE (/sse) based on URL
+    - Uses Streamable HTTP (/mcp), the UNITARES transport (auto-detected from
+      the URL). SSE remains only as a fallback for non-/mcp URLs — UNITARES no
+      longer serves /sse.
     - Handles session continuity (saves/loads .mcp_session)
     - Zero boilerplate
     - Clean JSON output

--- a/src/connection_tracker.py
+++ b/src/connection_tracker.py
@@ -382,7 +382,8 @@ class ConnectionTrackingMiddleware:
     responses (like SSE) and can trigger:
       AssertionError: Unexpected message: {'type': 'http.response.start', ...}
 
-    This middleware is implemented as a pure ASGI middleware to be safe for /sse.
+    This middleware is implemented as a pure ASGI middleware to be safe for
+    streaming responses (the /mcp Streamable HTTP transport).
 
     Constructor params:
       app               - ASGI application (passed by Starlette's add_middleware)
@@ -404,35 +405,8 @@ class ConnectionTrackingMiddleware:
             return await self.app(scope, receive, send)
 
         path = scope.get("path", "")
-        is_sse = path == "/sse"
         from starlette.datastructures import Headers
         headers = Headers(scope=scope)
-
-        # === SSE Probe Safeguard ===
-        # Prevent agents from hanging by providing ?probe=true to test connectivity
-        # Returns immediately with server status instead of starting streaming connection
-        if is_sse:
-            query_string = scope.get("query_string", b"").decode("utf-8", errors="ignore")
-            if "probe=true" in query_string or "probe=1" in query_string:
-                server_ready = self.server_ready_fn()
-                response_body = json.dumps({
-                    "status": "ready" if server_ready else "warming_up",
-                    "endpoint": "/sse",
-                    "transport": "SSE",
-                    "message": "SSE endpoint is available. Remove ?probe to start streaming connection." if server_ready else "Server is warming up, please retry in 2 seconds.",
-                    "hint": "Use /health for quick health checks, /sse for MCP client connections",
-                    "server_version": self.server_version,
-                }).encode("utf-8")
-                await send({
-                    "type": "http.response.start",
-                    "status": 200 if server_ready else 503,
-                    "headers": [[b"content-type", b"application/json"]],
-                })
-                await send({
-                    "type": "http.response.body",
-                    "body": response_body,
-                })
-                return
 
         # === Server Warmup Check ===
         # Prevent "request before initialization" errors when clients reconnect
@@ -459,7 +433,7 @@ class ConnectionTrackingMiddleware:
             })
             return
 
-        # Generate base id (stable per SSE connection, unique per HTTP request)
+        # Generate base id (unique per HTTP request).
         # For /mcp/ path, SessionSignals are already set by the ASGI wrapper
         # so we just read from scope.state if available, otherwise compute here.
         from src.mcp_handlers.context import get_session_signals, SessionSignals, set_session_signals
@@ -472,7 +446,7 @@ class ConnectionTrackingMiddleware:
             if not base_id:
                 base_id = signals.x_client_id or signals.ip_ua_fingerprint or "unknown"
         else:
-            # Legacy paths (SSE, REST) — compute fingerprint and build signals
+            # Legacy / REST paths — compute fingerprint and build signals
             base_id = headers.get("x-client-id") or headers.get("x-mcp-client-id")
             ua = headers.get("user-agent", "unknown")
 
@@ -495,14 +469,13 @@ class ConnectionTrackingMiddleware:
                     client_hint=detect_client_from_user_agent(ua),
                     x_agent_name=headers.get("x-agent-name"),
                     x_agent_id=headers.get("x-agent-id"),
-                    transport="sse" if is_sse else "rest",
+                    transport="rest",
                 )
                 set_session_signals(legacy_signals)
 
-        if is_sse:
-            client_id = base_id
-        else:
-            client_id = f"{base_id}:{uuid.uuid4().hex[:8]}"
+        # Every request is now an ephemeral HTTP request (the long-lived /sse
+        # transport was removed). Unique client_id per request.
+        client_id = f"{base_id}:{uuid.uuid4().hex[:8]}"
 
         # Expose to downstream tool calls via FastMCP Context.request_context.request.state
         try:
@@ -510,14 +483,6 @@ class ConnectionTrackingMiddleware:
             state["governance_client_id"] = client_id
         except Exception:
             pass
-
-        # Track SSE connections (long-lived); HTTP requests are ephemeral.
-        if is_sse:
-            await self.connection_tracker.add_connection(client_id, {
-                "type": "sse",
-                "path": path,
-                "user_agent": headers.get("user-agent", "unknown"),
-            })
 
         # PROPAGATE IDENTITY via contextvars for tool handlers
         from src.mcp_handlers.context import set_session_context, reset_session_context
@@ -527,64 +492,12 @@ class ConnectionTrackingMiddleware:
             user_agent=headers.get("user-agent")
         )
 
-        disconnected = False
-
-        connection_tracker_ref = self.connection_tracker
-
-        async def wrapped_receive():
-            nonlocal disconnected
-            try:
-                message = await receive()
-                if message.get("type") == "http.disconnect":
-                    disconnected = True
-                    if is_sse:
-                        try:
-                            await connection_tracker_ref.remove_connection(client_id)
-                        except Exception:
-                            pass
-                return message
-            except Exception as e:
-                # Handle receive errors gracefully
-                logger.debug(f"Error in wrapped_receive for {client_id}: {e}")
-                disconnected = True
-                if is_sse:
-                    try:
-                        await connection_tracker_ref.remove_connection(client_id)
-                    except Exception:
-                        pass
-                raise
-
-        # CRITICAL FIX: Wrap send to handle streaming responses properly
-        # SSE responses are streaming, so we need to pass through all messages
-        # without interfering with the ASGI protocol
-        async def wrapped_send(message):
-            try:
-                # Pass through all ASGI messages unchanged for SSE streaming
-                await send(message)
-                # Only update activity after response starts (not on every chunk)
-                if is_sse and message.get("type") == "http.response.start":
-                    try:
-                        await connection_tracker_ref.update_activity(client_id)
-                    except Exception:
-                        pass  # Don't fail on activity update errors
-            except Exception as e:
-                # If send fails, mark as disconnected
-                logger.debug(f"Error in wrapped_send for {client_id}: {e}")
-                disconnected = True
-                if is_sse:
-                    try:
-                        await connection_tracker_ref.remove_connection(client_id)
-                    except Exception:
-                        pass
-                raise
-
+        # Pass the raw ASGI send/receive straight through — no wrapping. The
+        # wrappers only existed to track SSE connection lifecycle, which is gone;
+        # a raw pass-through is also maximally safe for /mcp streaming responses.
         try:
-            return await self.app(scope, wrapped_receive, wrapped_send)
+            return await self.app(scope, receive, send)
         finally:
             # Reset contextvars to prevent leakage
             if 'context_token' in locals():
                 reset_session_context(context_token)
-
-            # Only remove non-SSE connections (HTTP REST endpoints)
-            if not is_sse:
-                await self.connection_tracker.remove_connection(client_id)

--- a/src/mcp_listen_config.py
+++ b/src/mcp_listen_config.py
@@ -10,10 +10,13 @@ See CLAUDE.md for environment variables.
 
 from __future__ import annotations
 
+import hmac
 import os
-from typing import List
+from typing import List, Optional
 
 from mcp.server.transport_security import TransportSecuritySettings
+
+_MCP_BEARER_TOKENS_ENV = "UNITARES_MCP_BEARER_TOKENS"
 
 
 def env_truthy(name: str, default: bool = False) -> bool:
@@ -77,3 +80,55 @@ def build_transport_security_settings() -> TransportSecuritySettings:
 def cors_extra_origins() -> List[str]:
     """Optional extra CORS origins from UNITARES_HTTP_CORS_EXTRA_ORIGINS (comma-separated)."""
     return split_csv_env("UNITARES_HTTP_CORS_EXTRA_ORIGINS")
+
+
+def mcp_bearer_tokens() -> List[str]:
+    """Allowlist of bearer tokens accepted on the ``/mcp`` endpoint.
+
+    Read fresh each call so an operator can rotate tokens without a restart
+    (mirrors the operator-token allowlist in identity/operator.py). Empty by
+    default: when empty the ``/mcp`` bearer gate is OFF and the endpoint
+    behaves exactly as before — this preserves the localhost / self-host
+    default where no token is configured.
+    """
+    return split_csv_env(_MCP_BEARER_TOKENS_ENV)
+
+
+def mcp_bearer_required() -> bool:
+    """True when a ``/mcp`` bearer allowlist is configured (gate is ON)."""
+    return bool(mcp_bearer_tokens())
+
+
+def check_mcp_bearer(
+    authorization_header: Optional[str],
+    allow: Optional[List[str]] = None,
+) -> bool:
+    """Authorize an inbound ``/mcp`` request against the bearer allowlist.
+
+    Returns ``True`` (allow) when the gate is OFF (no tokens configured) — the
+    default, so localhost dev and existing self-host deployments are unchanged.
+    When the gate is ON, returns ``True`` only if the request presents
+    ``Authorization: Bearer <tok>`` with ``<tok>`` in the allowlist. The token
+    comparison is constant-time.
+
+    ``allow`` may be passed by a caller that already fetched the allowlist this
+    request (the ASGI gate does, to avoid a second env read and the tiny
+    add/remove TOCTOU between "is the gate on" and "is this token valid"). When
+    omitted it is read fresh from the environment.
+
+    Deliberately, and unlike the HTTP REST gate (``http_api._is_trusted_network``),
+    there is **no trusted-network bypass** here: a hosted endpoint typically sits
+    behind a reverse proxy, so the source IP is the proxy's and an IP-based
+    bypass would defeat the gate. Every request authenticates.
+    """
+    if allow is None:
+        allow = mcp_bearer_tokens()
+    if not allow:
+        return True  # gate off — default posture
+    if not authorization_header or not authorization_header.startswith("Bearer "):
+        return False
+    presented = authorization_header[len("Bearer "):].strip()
+    if not presented:
+        return False
+    # Constant-time membership test over a small allowlist.
+    return any(hmac.compare_digest(presented, tok) for tok in allow)

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -181,8 +181,10 @@ SERVER_VERSION = _load_version()
 
 from src.mcp_listen_config import (
     build_transport_security_settings,
+    check_mcp_bearer,
     cors_extra_origins,
     default_listen_host,
+    mcp_bearer_tokens,
 )
 
 # --- OAuth 2.1 configuration (optional, enabled by env var) ---
@@ -823,7 +825,19 @@ async def main():
         # is unused (all clients use /mcp), but sse_app() is needed because bare
         # Starlette(routes=[]) breaks POST body reading for REST routes.
         app = mcp.sse_app()
-        
+
+        # SECURITY: sse_app() wires /sse + /messages/ to the SAME _mcp_server tool
+        # registry, and with OAuth disabled (the default) it does so WITHOUT auth.
+        # That would bypass the /mcp bearer gate below by reaching the same tools
+        # over a different transport. The SSE transport is unused anyway, so drop
+        # those two routes — keep the rest of the sse_app() base (the body-reading
+        # setup the REST routes depend on). Closes the gate-bypass surface.
+        _sse_path = mcp.settings.sse_path
+        _msg_path = mcp.settings.message_path.rstrip("/")
+        _pruned = [r for r in app.routes if getattr(r, "path", None) in (_sse_path, _msg_path)]
+        app.routes[:] = [r for r in app.routes if getattr(r, "path", None) not in (_sse_path, _msg_path)]
+        logger.info(f"Pruned {len(_pruned)} unused/ungated SSE route(s): {_sse_path}, {_msg_path}")
+
         # === Add CORS support for web-based GPT/Gemini clients ===
         # CORS: restrict to known origins (dashboard, local dev, Tailscale)
         _cors_allow_origin = os.getenv("UNITARES_HTTP_CORS_ALLOW_ORIGIN")
@@ -925,6 +939,26 @@ async def main():
                 """ASGI app for Streamable HTTP MCP at /mcp."""
                 if scope.get("type") != "http":
                     return
+
+                # Bearer gate (default-OFF; see src/mcp_listen_config). When
+                # UNITARES_MCP_BEARER_TOKENS is set, every /mcp request must
+                # present a matching `Authorization: Bearer <tok>`. No trusted-
+                # network bypass — a hosted endpoint authenticates every call.
+                # When unset, this is a no-op and localhost dev is unchanged.
+                # Fetch the allowlist once and pass it through, so "is the gate
+                # on" and "is this token valid" read the same snapshot.
+                _bearer_allow = mcp_bearer_tokens()
+                if _bearer_allow:
+                    from starlette.datastructures import Headers as _BearerHeaders
+                    _auth = _BearerHeaders(scope=scope).get("authorization")
+                    if not check_mcp_bearer(_auth, _bearer_allow):
+                        await JSONResponse(
+                            {"error": "unauthorized",
+                             "detail": "valid bearer token required for /mcp"},
+                            status_code=401,
+                            headers={"WWW-Authenticate": "Bearer"},
+                        )(scope, receive, send)
+                        return
 
                 # BUILD SESSION SIGNALS — single capture of all transport headers
                 # No priority decisions here; derive_session_key() handles that.

--- a/tests/test_mcp_bearer_gate.py
+++ b/tests/test_mcp_bearer_gate.py
@@ -1,0 +1,116 @@
+"""Bearer gate for the /mcp endpoint (src/mcp_listen_config).
+
+This is the one primitive a hosted deployment needs and that was absent: a way
+to require an Authorization: Bearer token on every /mcp request, while staying
+byte-identical to current behavior when no token is configured (localhost dev /
+self-host). These tests pin both halves — the off-by-default posture and the
+on-path accept/reject rules — plus the deliberate no-trusted-bypass design.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import src.mcp_listen_config as cfg
+
+
+@pytest.fixture(autouse=True)
+def _clear_bearer_env(monkeypatch):
+    monkeypatch.delenv("UNITARES_MCP_BEARER_TOKENS", raising=False)
+    importlib.reload(cfg)
+    yield
+
+
+def test_gate_off_by_default():
+    # No env configured -> gate OFF, everything allowed, even no header.
+    assert cfg.mcp_bearer_required() is False
+    assert cfg.check_mcp_bearer(None) is True
+    assert cfg.check_mcp_bearer("anything") is True
+
+
+def test_gate_on_when_tokens_configured(monkeypatch):
+    monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "s3cret")
+    assert cfg.mcp_bearer_required() is True
+    assert cfg.mcp_bearer_tokens() == ["s3cret"]
+
+
+def test_valid_bearer_accepted(monkeypatch):
+    monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "s3cret")
+    assert cfg.check_mcp_bearer("Bearer s3cret") is True
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        None,                       # missing header
+        "",                         # empty header
+        "s3cret",                   # raw token, no "Bearer " scheme
+        "Bearer ",                  # scheme but empty token
+        "Bearer wrong",             # wrong token
+        "Basic s3cret",             # wrong scheme
+        "bearer s3cret",            # case-sensitive scheme (RFC says token68 scheme is case-insensitive,
+                                    # but we require the canonical "Bearer " prefix the clients send)
+    ],
+)
+def test_invalid_bearer_rejected_when_gate_on(monkeypatch, header):
+    monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "s3cret")
+    assert cfg.check_mcp_bearer(header) is False
+
+
+def test_token_rotation_accepts_any_listed(monkeypatch):
+    # CSV allowlist lets an operator rotate without dropping the old token mid-flight.
+    monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "old-token, new-token")
+    assert cfg.mcp_bearer_tokens() == ["old-token", "new-token"]
+    assert cfg.check_mcp_bearer("Bearer old-token") is True
+    assert cfg.check_mcp_bearer("Bearer new-token") is True
+    assert cfg.check_mcp_bearer("Bearer retired-token") is False
+
+
+def test_whitespace_only_env_is_gate_off(monkeypatch):
+    # "   ,  ," parses to zero tokens -> still OFF (no accidental empty-token allow).
+    monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "   ,  ,")
+    assert cfg.mcp_bearer_required() is False
+    assert cfg.check_mcp_bearer(None) is True
+
+
+def test_read_fresh_each_call_supports_runtime_rotation(monkeypatch):
+    monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "first")
+    assert cfg.check_mcp_bearer("Bearer first") is True
+    # Rotate in-process; no restart, no reload — read-fresh semantics.
+    monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "second")
+    assert cfg.check_mcp_bearer("Bearer first") is False
+    assert cfg.check_mcp_bearer("Bearer second") is True
+
+
+def test_explicit_allow_overrides_env(monkeypatch):
+    # The ASGI gate fetches the allowlist once and passes it through, so the
+    # decision uses one snapshot (no add/remove TOCTOU vs a second env read).
+    monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "env-token")
+    assert cfg.check_mcp_bearer("Bearer snapshot", allow=["snapshot"]) is True
+    assert cfg.check_mcp_bearer("Bearer env-token", allow=["snapshot"]) is False
+    # Empty explicit allow == gate off for this decision.
+    assert cfg.check_mcp_bearer(None, allow=[]) is True
+
+
+def test_sse_routes_are_prunable_to_close_gate_bypass():
+    # The /mcp bearer gate would be bypassable if /sse + /messages/ (which the
+    # SDK wires to the SAME tool registry, unauthenticated when OAuth is off)
+    # stayed mounted. mcp_server prunes them; assert that prune fully removes
+    # the SSE surface so no ungated route reaches the tools.
+    pytest.importorskip("mcp.server.fastmcp")
+    from mcp.server.fastmcp import FastMCP
+
+    m = FastMCP("probe")
+    app = m.sse_app()
+    before = {getattr(r, "path", None) for r in app.routes}
+    assert m.settings.sse_path in before  # /sse present pre-prune
+
+    _sse = m.settings.sse_path
+    _msg = m.settings.message_path.rstrip("/")
+    app.routes[:] = [r for r in app.routes if getattr(r, "path", None) not in (_sse, _msg)]
+
+    after = {getattr(r, "path", None) for r in app.routes}
+    assert _sse not in after
+    assert _msg not in after


### PR DESCRIPTION
## Why
The hosted-endpoint scope (#845) identified the one primitive both hosting models need and that is **absent today**: authentication on the governance endpoint. Currently `/mcp` accepts unauthenticated POSTs — fine for localhost, a non-starter for any hosted posture. This adds that gate, default-off so nothing changes for self-host/dev.

## What
- **Bearer gate on `/mcp`** (`src/mcp_listen_config.py` + the `streamable_mcp_asgi` entry). When `UNITARES_MCP_BEARER_TOKENS` (CSV) is set, every request must present `Authorization: Bearer <tok>` with a listed token, else **401**. Unset → no-op (localhost/self-host byte-identical).
  - Tokens read **fresh each request** (rotate without restart); **constant-time** compare (`hmac.compare_digest`); the gate fetches the allowlist once per request and passes it through (single snapshot, no add/remove race).
  - **No trusted-network bypass** — deliberately unlike the REST gate. A hosted endpoint sits behind a proxy, so the source IP is the proxy's; an IP bypass would defeat the gate.

- **Closes a gate bypass (the important part).** Adversarial review of the first cut found that `mcp.sse_app()` wires `/sse` + `/messages/` to the **same `_mcp_server` tool registry**, and with OAuth off (the default) it does so **without auth** — a client speaking the SSE transport would reach every tool *around* the `/mcp` gate. The SSE transport is unused (all clients use `/mcp`; **zero `/sse` hits in prod logs**), so the routes are pruned after `sse_app()`, keeping the rest of its base. Verified against the live `sse_app()` route table (`{/sse, /messages}` → pruned to `{}`).

## Tests
`tests/test_mcp_bearer_gate.py` (15): off-by-default; accept; reject (missing / empty / raw / `Bearer ` only / wrong token / wrong scheme / lowercase scheme); CSV rotation; whitespace-only env = off; single-snapshot allowlist; and the SSE-prune closing the bypass.

## Review provenance
First cut reviewed by an adversarial security pass that flagged the SSE-bypass (confidence 95). I **verified the claim against the SDK and the live route table** before acting (it was real), then fixed it and added the regression test. Comparison/header-parsing/fail-closed/default-off were reviewed and confirmed sound.

## Scope / follow-ups
- Cosmetic, deferred: a stale "use `/sse`" hint in `connection_tracker.py` and an SSE-mode comment in `scripts/ops/mcp_agent.py` now point at a pruned route.
- Client side (separate): for a hosted deployment the gov-plugin `.mcp.json` (#73) would add `headers: {Authorization: Bearer ${...}}`; not in this PR.

Security-sensitive; left as **draft** for operator review + merge.