### PR TITLE
fix(kg): default status-less stores to "open" at the source

### DIFF
--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -862,7 +862,14 @@ async def handle_store_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[Te
             details=raw_details,
             tags=normalize_tags(arguments.get("tags", [])),
             severity=severity,
-            status=arguments.get("status", "open"),
+            # Default status-less writes to "open" at the source. The unified
+            # knowledge(action="store") path arrives via params_step.model_dump(),
+            # which injects status=None into arguments — so .get("status", "open")
+            # would yield None, not the default. `or "open"` also folds an explicit
+            # null/empty back to "open" so the in-memory node, the response, and the
+            # broadcast all agree with the storage-layer `or "open"` coercion instead
+            # of surfacing a null the DB silently rewrites.
+            status=arguments.get("status") or "open",
             response_to=response_to,
             references_files=arguments.get("related_files", []),
             provenance=provenance,

--- a/tests/test_kg_store.py
+++ b/tests/test_kg_store.py
@@ -362,6 +362,68 @@ class TestStoreKnowledgeGraph:
         assert "2026-06-04T00:00:00" in related_ids
 
     @pytest.mark.asyncio
+    async def test_store_defaults_status_to_open(self, patch_common, registered_agent):
+        """Status-less writes land as "open" at the source, not null.
+
+        The unified knowledge(action="store") path arrives via
+        params_step.model_dump(), which injects status=None into arguments. A bare
+        .get("status", "open") would then yield None (key present), persisting a
+        status-less row. The handler must fold both an absent key and an explicit
+        None back to "open" so the in-memory node and the response agree with the
+        storage-layer coercion instead of surfacing a null.
+        """
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_store_knowledge_graph
+
+        captured = {}
+        orig_add = mock_graph.add_discovery
+
+        async def _capture(node):
+            captured["status"] = node.status
+            return await orig_add(node) if orig_add else None
+
+        mock_graph.add_discovery = AsyncMock(side_effect=_capture)
+
+        # Explicit None mirrors what model_dump() produces for an omitted status.
+        result = await handle_store_knowledge_graph({
+            "agent_id": registered_agent,
+            "summary": "A finding with no status",
+            "discovery_type": "insight",
+            "status": None,
+        })
+
+        data = parse_result(result)
+        assert data["success"] is True
+        assert captured["status"] == "open"
+        assert data["discovery"]["status"] == "open"
+
+    @pytest.mark.asyncio
+    async def test_store_preserves_explicit_status(self, patch_common, registered_agent):
+        """An explicit, meaningful status is not clobbered by the default."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_store_knowledge_graph
+
+        captured = {}
+        orig_add = mock_graph.add_discovery
+
+        async def _capture(node):
+            captured["status"] = node.status
+            return await orig_add(node) if orig_add else None
+
+        mock_graph.add_discovery = AsyncMock(side_effect=_capture)
+
+        result = await handle_store_knowledge_graph({
+            "agent_id": registered_agent,
+            "summary": "A finding that is already resolved",
+            "discovery_type": "insight",
+            "status": "resolved",
+        })
+
+        data = parse_result(result)
+        assert data["success"] is True
+        assert captured["status"] == "resolved"
+
+    @pytest.mark.asyncio
     async def test_store_graph_exception(self, patch_common, registered_agent):
         """Exception from graph backend returns error response."""
         mock_mcp_server, mock_graph = patch_common


### PR DESCRIPTION
## Problem

This is the behavioral follow-up flagged after the recent status-reporting fix: *should `knowledge` store default status to `"open"` instead of persisting null, stopping new status-less rows at the source?*

`knowledge(action="store")` is dispatched through `src/mcp_handlers/middleware/params_step.py:233`, which validates against the Pydantic schema and then calls `validated.model_dump()`. Because `KnowledgeParams.status` defaults to `None`, the dumped dict carries `status: None` into the handler.

The single-write path then did:

```python
status=arguments.get("status", "open"),
```

Since the `status` key is *present* (value `None`), `dict.get` returned `None` rather than the `"open"` default. The in-memory `DiscoveryNode`, the response returned to the caller, and the write broadcast all surfaced `status: null`. Only the storage-layer band-aids (`discovery.status or "open"` in both `src/db/mixins/knowledge_graph.py` and `src/storage/knowledge_graph_age.py`) rewrote it to `"open"` on the way to the DB — leaving the response inconsistent with the persisted row.

## Fix

`src/mcp_handlers/knowledge/handlers.py` now folds an absent key, an explicit `null`, and an empty string back to `"open"`:

```python
status=arguments.get("status") or "open",
```

The node, the response, the broadcast, and the persisted row now all agree — status-less rows are stopped at the source instead of relying on downstream coercion. An explicit, meaningful status (e.g. `"resolved"`) is still preserved untouched. The batch and `note` paths already defaulted correctly and are unchanged.

## Tests

Added to `tests/test_kg_store.py`:
- `test_store_defaults_status_to_open` — an explicit `status=None` (mirroring `model_dump`) lands as `"open"` on both the stored node and the response.
- `test_store_preserves_explicit_status` — `status="resolved"` is not clobbered.

`tests/test_kg_store.py` (71) and `tests/test_pydantic_schemas.py` pass locally on Python 3.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PabksH4HtHKSukcSrxzzhw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PabksH4HtHKSukcSrxzzhw)_