### PR TITLE
refactor: remove the inert SSE-only ConnectionTracker subsystem

### DIFF
--- a/scripts/ops/mcp_agent.py
+++ b/scripts/ops/mcp_agent.py
@@ -12,7 +12,9 @@ Usage:
     python3 scripts/mcp_agent.py process_agent_update response_text="My work" complexity=0.6
 
 Features:
-    - Auto-detects Streamable HTTP (/mcp) vs SSE (/sse) based on URL
+    - Uses Streamable HTTP (/mcp), the UNITARES transport (auto-detected from
+      the URL). SSE remains only as a fallback for non-/mcp URLs — UNITARES no
+      longer serves /sse.
     - Handles session continuity (saves/loads .mcp_session)
     - Zero boilerplate
     - Clean JSON output

--- a/src/background_tasks.py
+++ b/src/background_tasks.py
@@ -13,83 +13,8 @@ from pathlib import Path
 from typing import Optional
 
 from src.logging_utils import get_logger
-from src.connection_tracker import CONNECTIONS_ACTIVE
 
 logger = get_logger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# Connection heartbeat
-# ---------------------------------------------------------------------------
-
-async def connection_heartbeat_task(connection_tracker):
-    """
-    Comprehensive connection health monitoring:
-    - Clean up stale connections every 5 minutes
-    - Check health of all connections every 2 minutes
-    - Log diagnostic summary every 10 minutes
-    """
-    consecutive_failures = 0
-    max_consecutive_failures = 5
-    iteration = 0
-
-    while True:
-        try:
-            await asyncio.sleep(60)
-            iteration += 1
-
-            if iteration % 2 == 0:
-                for client_id in list(connection_tracker.connections.keys()):
-                    try:
-                        health = await connection_tracker.check_health(client_id)
-                        if not health.get("healthy"):
-                            logger.warning(
-                                f"[HEARTBEAT] Unhealthy connection: {client_id} - {health.get('issues', [])}"
-                            )
-                    except Exception as e:
-                        logger.debug(f"[HEARTBEAT] Health check failed for {client_id}: {e}")
-
-            if iteration % 5 == 0:
-                await connection_tracker.cleanup_stale_connections(max_idle_minutes=30.0)
-
-            if iteration % 10 == 0:
-                diagnostics = await connection_tracker.get_diagnostics()
-                health_summary = diagnostics.get("health_summary", {})
-                reconnect_summary = diagnostics.get("reconnection_summary", {})
-
-                logger.info(
-                    f"[HEARTBEAT] Connection summary: "
-                    f"{diagnostics['total_connections']} connected, "
-                    f"{health_summary.get('healthy', 0)} healthy, "
-                    f"{health_summary.get('degraded', 0)} degraded"
-                )
-
-                high_reconnectors = {k: v for k, v in reconnect_summary.items() if v > 5}
-                if high_reconnectors:
-                    logger.warning(
-                        f"[HEARTBEAT] High reconnection clients: {high_reconnectors}. "
-                        f"Check network stability."
-                    )
-
-                CONNECTIONS_ACTIVE.set(diagnostics['total_connections'])
-
-            consecutive_failures = 0
-
-        except asyncio.CancelledError:
-            logger.info("[HEARTBEAT] Connection heartbeat task cancelled")
-            break
-        except Exception as e:
-            consecutive_failures += 1
-            logger.warning(
-                f"[HEARTBEAT] Error (failure {consecutive_failures}/{max_consecutive_failures}): {e}",
-                exc_info=True
-            )
-            if consecutive_failures >= max_consecutive_failures:
-                logger.error(
-                    f"[HEARTBEAT] Failed {consecutive_failures} times consecutively. "
-                    f"Connection monitoring degraded. Consider restarting the server."
-                )
-                consecutive_failures = 0
 
 
 # ---------------------------------------------------------------------------
@@ -1784,17 +1709,13 @@ async def stop_all_background_tasks() -> None:
             )
 
 
-def start_all_background_tasks(connection_tracker, set_ready):
+def start_all_background_tasks(set_ready):
     """
     Start all background tasks. Call once during server initialization.
 
     Args:
-        connection_tracker: The ConnectionTracker instance
         set_ready: Callable that sets SERVER_READY = True
     """
-    _supervised_create_task(connection_heartbeat_task(connection_tracker), name="heartbeat")
-    logger.info("[HEARTBEAT] Connection health monitoring started")
-
     _supervised_create_task(startup_auto_calibration(), name="auto_calibration")
     # KG lifecycle temporarily disabled — AGE graph queries deadlock in anyio context
     # _supervised_create_task(startup_kg_lifecycle(), name="kg_lifecycle")

--- a/src/connection_tracker.py
+++ b/src/connection_tracker.py
@@ -382,7 +382,8 @@ class ConnectionTrackingMiddleware:
     responses (like SSE) and can trigger:
       AssertionError: Unexpected message: {'type': 'http.response.start', ...}
 
-    This middleware is implemented as a pure ASGI middleware to be safe for /sse.
+    This middleware is implemented as a pure ASGI middleware to be safe for
+    streaming responses (the /mcp Streamable HTTP transport).
 
     Constructor params:
       app               - ASGI application (passed by Starlette's add_middleware)
@@ -404,35 +405,8 @@ class ConnectionTrackingMiddleware:
             return await self.app(scope, receive, send)
 
         path = scope.get("path", "")
-        is_sse = path == "/sse"
         from starlette.datastructures import Headers
         headers = Headers(scope=scope)
-
-        # === SSE Probe Safeguard ===
-        # Prevent agents from hanging by providing ?probe=true to test connectivity
-        # Returns immediately with server status instead of starting streaming connection
-        if is_sse:
-            query_string = scope.get("query_string", b"").decode("utf-8", errors="ignore")
-            if "probe=true" in query_string or "probe=1" in query_string:
-                server_ready = self.server_ready_fn()
-                response_body = json.dumps({
-                    "status": "ready" if server_ready else "warming_up",
-                    "endpoint": "/sse",
-                    "transport": "SSE",
-                    "message": "SSE endpoint is available. Remove ?probe to start streaming connection." if server_ready else "Server is warming up, please retry in 2 seconds.",
-                    "hint": "Use /health for quick health checks, /sse for MCP client connections",
-                    "server_version": self.server_version,
-                }).encode("utf-8")
-                await send({
-                    "type": "http.response.start",
-                    "status": 200 if server_ready else 503,
-                    "headers": [[b"content-type", b"application/json"]],
-                })
-                await send({
-                    "type": "http.response.body",
-                    "body": response_body,
-                })
-                return
 
         # === Server Warmup Check ===
         # Prevent "request before initialization" errors when clients reconnect
@@ -459,7 +433,7 @@ class ConnectionTrackingMiddleware:
             })
             return
 
-        # Generate base id (stable per SSE connection, unique per HTTP request)
+        # Generate base id (unique per HTTP request).
         # For /mcp/ path, SessionSignals are already set by the ASGI wrapper
         # so we just read from scope.state if available, otherwise compute here.
         from src.mcp_handlers.context import get_session_signals, SessionSignals, set_session_signals
@@ -472,7 +446,7 @@ class ConnectionTrackingMiddleware:
             if not base_id:
                 base_id = signals.x_client_id or signals.ip_ua_fingerprint or "unknown"
         else:
-            # Legacy paths (SSE, REST) — compute fingerprint and build signals
+            # Legacy / REST paths — compute fingerprint and build signals
             base_id = headers.get("x-client-id") or headers.get("x-mcp-client-id")
             ua = headers.get("user-agent", "unknown")
 
@@ -495,14 +469,13 @@ class ConnectionTrackingMiddleware:
                     client_hint=detect_client_from_user_agent(ua),
                     x_agent_name=headers.get("x-agent-name"),
                     x_agent_id=headers.get("x-agent-id"),
-                    transport="sse" if is_sse else "rest",
+                    transport="rest",
                 )
                 set_session_signals(legacy_signals)
 
-        if is_sse:
-            client_id = base_id
-        else:
-            client_id = f"{base_id}:{uuid.uuid4().hex[:8]}"
+        # Every request is now an ephemeral HTTP request (the long-lived /sse
+        # transport was removed). Unique client_id per request.
+        client_id = f"{base_id}:{uuid.uuid4().hex[:8]}"
 
         # Expose to downstream tool calls via FastMCP Context.request_context.request.state
         try:
@@ -510,14 +483,6 @@ class ConnectionTrackingMiddleware:
             state["governance_client_id"] = client_id
         except Exception:
             pass
-
-        # Track SSE connections (long-lived); HTTP requests are ephemeral.
-        if is_sse:
-            await self.connection_tracker.add_connection(client_id, {
-                "type": "sse",
-                "path": path,
-                "user_agent": headers.get("user-agent", "unknown"),
-            })
 
         # PROPAGATE IDENTITY via contextvars for tool handlers
         from src.mcp_handlers.context import set_session_context, reset_session_context
@@ -527,64 +492,12 @@ class ConnectionTrackingMiddleware:
             user_agent=headers.get("user-agent")
         )
 
-        disconnected = False
-
-        connection_tracker_ref = self.connection_tracker
-
-        async def wrapped_receive():
-            nonlocal disconnected
-            try:
-                message = await receive()
-                if message.get("type") == "http.disconnect":
-                    disconnected = True
-                    if is_sse:
-                        try:
-                            await connection_tracker_ref.remove_connection(client_id)
-                        except Exception:
-                            pass
-                return message
-            except Exception as e:
-                # Handle receive errors gracefully
-                logger.debug(f"Error in wrapped_receive for {client_id}: {e}")
-                disconnected = True
-                if is_sse:
-                    try:
-                        await connection_tracker_ref.remove_connection(client_id)
-                    except Exception:
-                        pass
-                raise
-
-        # CRITICAL FIX: Wrap send to handle streaming responses properly
-        # SSE responses are streaming, so we need to pass through all messages
-        # without interfering with the ASGI protocol
-        async def wrapped_send(message):
-            try:
-                # Pass through all ASGI messages unchanged for SSE streaming
-                await send(message)
-                # Only update activity after response starts (not on every chunk)
-                if is_sse and message.get("type") == "http.response.start":
-                    try:
-                        await connection_tracker_ref.update_activity(client_id)
-                    except Exception:
-                        pass  # Don't fail on activity update errors
-            except Exception as e:
-                # If send fails, mark as disconnected
-                logger.debug(f"Error in wrapped_send for {client_id}: {e}")
-                disconnected = True
-                if is_sse:
-                    try:
-                        await connection_tracker_ref.remove_connection(client_id)
-                    except Exception:
-                        pass
-                raise
-
+        # Pass the raw ASGI send/receive straight through — no wrapping. The
+        # wrappers only existed to track SSE connection lifecycle, which is gone;
+        # a raw pass-through is also maximally safe for /mcp streaming responses.
         try:
-            return await self.app(scope, wrapped_receive, wrapped_send)
+            return await self.app(scope, receive, send)
         finally:
             # Reset contextvars to prevent leakage
             if 'context_token' in locals():
                 reset_session_context(context_token)
-
-            # Only remove non-SSE connections (HTTP REST endpoints)
-            if not is_sse:
-                await self.connection_tracker.remove_connection(client_id)

--- a/src/connection_tracker.py
+++ b/src/connection_tracker.py
@@ -1,402 +1,47 @@
 """
-Connection tracking for multi-agent awareness and reliability.
+Per-request identity propagation middleware.
 
-Extracted from mcp_server.py — contains:
-- ConnectionTracker: tracks client connections, reconnections, health
-- ConnectionTrackingMiddleware: ASGI middleware for connection lifecycle
+Contains ConnectionTrackingMiddleware — pure-ASGI middleware that derives a
+per-request ``governance_client_id``, propagates it via contextvars for tool
+handlers, and gates ``/health`` during warmup. The SSE-only connection registry
+(ConnectionTracker) was removed when the ``/sse`` transport was retired —
+nothing populated it once /mcp became the only transport.
 """
 
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import json
 import uuid
-from datetime import datetime
-from typing import Any, Callable, Dict
-
-from prometheus_client import Counter, Gauge, Histogram
+from typing import Callable
 
 from src.logging_utils import get_logger
 
 logger = get_logger(__name__)
 
-# ============================================================================
-# Prometheus Metrics for Connection Tracking
-# ============================================================================
-
-CONNECTION_EVENTS = Counter(
-    'unitares_connection_events_total',
-    'Connection lifecycle events',
-    ['event_type']  # connected, disconnected, reconnected, stale_cleaned
-)
-
-CONNECTION_DURATION = Histogram(
-    'unitares_connection_duration_seconds',
-    'Duration of client connections',
-    buckets=(1, 5, 15, 30, 60, 120, 300, 600, 1800, 3600)
-)
-
-CONNECTION_HEALTH = Gauge(
-    'unitares_connection_health',
-    'Connection health status (1=healthy, 0=unhealthy)',
-    ['client_id']
-)
-
-# Also owns CONNECTIONS_ACTIVE — imported back by mcp_server.py where needed
-CONNECTIONS_ACTIVE = Gauge(
-    'unitares_connections_active',
-    'Number of active SSE connections'
-)
-
-
-class ConnectionTracker:
-    """
-    Enhanced connection tracker for multi-agent awareness and reliability.
-
-    Features:
-    - Reconnection tracking (detects clients that reconnect frequently)
-    - Connection health monitoring (idle time, request rate)
-    - Detailed diagnostics for debugging
-    - History for forensics
-    """
-
-    _MAX_HISTORY = 100
-    _MAX_DISCONNECTION_REASONS = 500
-    _MAX_RECONNECTION_IPS = 200
-
-    def __init__(self):
-        self.connections: Dict[str, Dict[str, Any]] = {}
-        self._lock = asyncio.Lock()
-        # Track connection history for diagnostics (bounded)
-        self._history: list = []
-        # Track reconnections by base client ID (IP) — bounded
-        self._reconnection_counts: Dict[str, int] = {}
-        # Track disconnection reasons — bounded
-        self._disconnection_reasons: Dict[str, str] = {}
-
-    def _log_event(self, event_type: str, client_id: str, details: Dict[str, Any] = None):
-        """Log connection event to history and metrics."""
-        event = {
-            "timestamp": datetime.now().isoformat(),
-            "event": event_type,
-            "client_id": client_id,
-            "details": details or {}
-        }
-        self._history.append(event)
-        # Trim history if needed
-        if len(self._history) > self._MAX_HISTORY:
-            self._history = self._history[-self._MAX_HISTORY:]
-
-        # Update Prometheus metrics
-        CONNECTION_EVENTS.labels(event_type=event_type).inc()
-
-        # Log at appropriate level
-        if event_type in ("disconnected", "stale_cleaned"):
-            logger.info(f"[CONNECTION] {event_type}: {client_id} - {details}")
-        else:
-            logger.info(f"[CONNECTION] {event_type}: {client_id}")
-
-    def _get_base_client_id(self, client_id: str) -> str:
-        """Extract base client ID (IP) for reconnection tracking."""
-        # client_id format is typically "IP:PORT" or "IP:PORT:uuid"
-        parts = client_id.split(":")
-        return parts[0] if parts else client_id
-
-    async def add_connection(self, client_id: str, metadata: Dict[str, Any] = None):
-        """Register a new client connection with reconnection detection."""
-        now = datetime.now()
-        now_iso = now.isoformat()
-        base_id = self._get_base_client_id(client_id)
-
-        # Track reconnection
-        reconnect_count = self._reconnection_counts.get(base_id, 0)
-        is_reconnect = reconnect_count > 0
-
-        connection_data = {
-            "connected_at": now_iso,
-            "last_activity": now_iso,
-            "metadata": metadata or {},
-            "request_count": 0,
-            "reconnect_count": reconnect_count,
-            "health_status": "healthy",
-            "last_health_check": now_iso
-        }
-
-        async with self._lock:
-            # Check if connection already exists (collision detection)
-            if client_id in self.connections:
-                existing = self.connections[client_id]
-                prev_connected = existing.get('connected_at', 'unknown')
-                prev_requests = existing.get('request_count', 0)
-
-                # Calculate duration of previous connection
-                try:
-                    prev_connected_dt = datetime.fromisoformat(prev_connected)
-                    duration = (now - prev_connected_dt).total_seconds()
-                    CONNECTION_DURATION.observe(duration)
-                except (ValueError, TypeError):
-                    duration = 0
-
-                logger.warning(
-                    f"[CONNECTION] Client ID collision: '{client_id}' replacing existing. "
-                    f"Previous: connected={prev_connected}, requests={prev_requests}, duration={duration:.1f}s"
-                )
-
-                # Increment reconnection count
-                self._reconnection_counts[base_id] = reconnect_count + 1
-                connection_data["reconnect_count"] = reconnect_count + 1
-
-                self._log_event("reconnected", client_id, {
-                    "previous_duration_seconds": duration,
-                    "previous_requests": prev_requests,
-                    "reconnect_count": reconnect_count + 1
-                })
-            else:
-                self._reconnection_counts[base_id] = reconnect_count + 1
-                event_type = "reconnected" if is_reconnect else "connected"
-                self._log_event(event_type, client_id, {
-                    "user_agent": (metadata or {}).get("user_agent", "unknown"),
-                    "reconnect_count": reconnect_count if is_reconnect else 0
-                })
-
-            self.connections[client_id] = connection_data
-
-            # Update Prometheus gauge
-            CONNECTIONS_ACTIVE.set(len(self.connections))
-            CONNECTION_HEALTH.labels(client_id=client_id).set(1)
-
-            logger.info(
-                f"[CONNECTION] Client {'reconnected' if is_reconnect else 'connected'}: "
-                f"{client_id} (total: {len(self.connections)}, reconnects: {connection_data['reconnect_count']})"
-            )
-
-    async def remove_connection(self, client_id: str, reason: str = "client_disconnect"):
-        """Remove a client connection with reason tracking."""
-        async with self._lock:
-            if client_id in self.connections:
-                conn_data = self.connections[client_id]
-                connected_at = conn_data.get("connected_at")
-                request_count = conn_data.get("request_count", 0)
-
-                # Calculate connection duration
-                try:
-                    connected_dt = datetime.fromisoformat(connected_at)
-                    duration = (datetime.now() - connected_dt).total_seconds()
-                    CONNECTION_DURATION.observe(duration)
-                except (ValueError, TypeError):
-                    duration = 0
-
-                del self.connections[client_id]
-                self._disconnection_reasons[client_id] = reason
-                # Prune oldest disconnection reasons if over limit
-                if len(self._disconnection_reasons) > self._MAX_DISCONNECTION_REASONS:
-                    excess = len(self._disconnection_reasons) - self._MAX_DISCONNECTION_REASONS
-                    for key in list(self._disconnection_reasons)[:excess]:
-                        del self._disconnection_reasons[key]
-
-                # Update Prometheus
-                CONNECTIONS_ACTIVE.set(len(self.connections))
-                try:
-                    CONNECTION_HEALTH.remove(client_id)
-                except Exception:
-                    pass  # Label may not exist
-
-                self._log_event("disconnected", client_id, {
-                    "reason": reason,
-                    "duration_seconds": duration,
-                    "request_count": request_count
-                })
-
-                logger.info(
-                    f"[CONNECTION] Client disconnected: {client_id} "
-                    f"(reason={reason}, duration={duration:.1f}s, requests={request_count}, total: {len(self.connections)})"
-                )
-
-    async def update_activity(self, client_id: str):
-        """Update last activity timestamp for a client."""
-        now = datetime.now().isoformat()
-
-        async with self._lock:
-            if client_id in self.connections:
-                self.connections[client_id]["last_activity"] = now
-                self.connections[client_id]["request_count"] += 1
-
-    async def check_health(self, client_id: str) -> Dict[str, Any]:
-        """Check health of a specific connection."""
-        now = datetime.now()
-
-        async with self._lock:
-            if client_id not in self.connections:
-                return {"healthy": False, "reason": "not_connected"}
-
-            conn = self.connections[client_id]
-
-            # Check idle time
-            try:
-                last_activity = datetime.fromisoformat(conn["last_activity"])
-                idle_seconds = (now - last_activity).total_seconds()
-            except (ValueError, TypeError):
-                idle_seconds = float('inf')
-
-            # Check connection age
-            try:
-                connected_at = datetime.fromisoformat(conn["connected_at"])
-                age_seconds = (now - connected_at).total_seconds()
-            except (ValueError, TypeError):
-                age_seconds = 0
-
-            # Determine health status
-            issues = []
-            if idle_seconds > 300:  # 5 minutes idle
-                issues.append(f"idle for {idle_seconds:.0f}s")
-            if conn.get("reconnect_count", 0) > 5:
-                issues.append(f"reconnected {conn['reconnect_count']} times")
-
-            healthy = len(issues) == 0
-            health_status = "healthy" if healthy else "degraded"
-
-            # Update stored health status
-            conn["health_status"] = health_status
-            conn["last_health_check"] = now.isoformat()
-
-            # Update Prometheus
-            CONNECTION_HEALTH.labels(client_id=client_id).set(1 if healthy else 0)
-
-            return {
-                "healthy": healthy,
-                "status": health_status,
-                "idle_seconds": idle_seconds,
-                "age_seconds": age_seconds,
-                "request_count": conn.get("request_count", 0),
-                "reconnect_count": conn.get("reconnect_count", 0),
-                "issues": issues if issues else None
-            }
-
-    async def cleanup_stale_connections(self, max_idle_minutes: float = 30.0):
-        """Remove connections that haven't been active recently and prune history bounds."""
-        now = datetime.now()
-        stale = []
-
-        # First pass: identify stale connections and prune bounds
-        async with self._lock:
-            # Prune unbounded dicts
-            if len(self._disconnection_reasons) > self._MAX_DISCONNECTION_REASONS:
-                keep_count = self._MAX_DISCONNECTION_REASONS // 2
-                items_to_keep = list(self._disconnection_reasons.items())[-keep_count:]
-                self._disconnection_reasons = dict(items_to_keep)
-            if len(self._reconnection_counts) > self._MAX_RECONNECTION_IPS:
-                # Keep IPs with active connections, prune the rest
-                active_ips = {self._get_base_client_id(cid) for cid in self.connections}
-                pruned = {ip: cnt for ip, cnt in self._reconnection_counts.items()
-                          if ip in active_ips}
-                self._reconnection_counts = pruned
-
-            for client_id, conn_data in self.connections.items():
-                last_activity_str = conn_data.get("last_activity")
-                if last_activity_str:
-                    try:
-                        last_activity = datetime.fromisoformat(last_activity_str)
-                        idle_minutes = (now - last_activity).total_seconds() / 60
-                        if idle_minutes > max_idle_minutes:
-                            stale.append((client_id, idle_minutes))
-                    except (ValueError, TypeError):
-                        stale.append((client_id, float('inf')))
-
-        # Second pass: remove stale connections
-        if stale:
-            for client_id, idle_mins in stale:
-                await self.remove_connection(client_id, reason=f"stale_idle_{idle_mins:.1f}min")
-
-            self._log_event("stale_cleaned", "batch", {
-                "count": len(stale),
-                "clients": [c[0] for c in stale]
-            })
-
-            logger.info(f"[CONNECTION] Cleaned up {len(stale)} stale connection(s)")
-
-    async def get_diagnostics(self) -> Dict[str, Any]:
-        """Get comprehensive connection diagnostics."""
-        now = datetime.now()
-
-        async with self._lock:
-            clients = []
-            for client_id, conn in self.connections.items():
-                try:
-                    connected_at = datetime.fromisoformat(conn["connected_at"])
-                    last_activity = datetime.fromisoformat(conn["last_activity"])
-                    age = (now - connected_at).total_seconds()
-                    idle = (now - last_activity).total_seconds()
-                except (ValueError, TypeError):
-                    age = idle = 0
-
-                clients.append({
-                    "client_id": client_id,
-                    "user_agent": conn.get("metadata", {}).get("user_agent", "unknown"),
-                    "connected_at": conn["connected_at"],
-                    "age_seconds": age,
-                    "idle_seconds": idle,
-                    "request_count": conn.get("request_count", 0),
-                    "reconnect_count": conn.get("reconnect_count", 0),
-                    "health_status": conn.get("health_status", "unknown")
-                })
-
-            # Sort by most recent activity
-            clients.sort(key=lambda x: x["idle_seconds"])
-
-            # Get recent events
-            recent_events = self._history[-20:] if self._history else []
-
-            # Identify potentially problematic clients
-            problematic = [c for c in clients if c["reconnect_count"] > 3 or c["idle_seconds"] > 300]
-
-            return {
-                "timestamp": now.isoformat(),
-                "total_connections": len(self.connections),
-                "connections": clients,
-                "recent_events": recent_events,
-                "problematic_clients": problematic,
-                "reconnection_summary": dict(self._reconnection_counts),
-                "health_summary": {
-                    "healthy": len([c for c in clients if c["health_status"] == "healthy"]),
-                    "degraded": len([c for c in clients if c["health_status"] != "healthy"]),
-                }
-            }
-
-    def get_connected_clients(self) -> Dict[str, Dict[str, Any]]:
-        """Get all connected clients."""
-        return dict(self.connections)
-
-    @property
-    def count(self) -> int:
-        """Number of connected clients."""
-        return len(self.connections)
-
 
 class ConnectionTrackingMiddleware:
     """
-    ASGI middleware for connection lifecycle tracking.
+    Pure-ASGI middleware for per-request identity propagation and warmup gating.
 
     IMPORTANT:
     Do NOT use Starlette's BaseHTTPMiddleware here. It is known to break streaming
-    responses (like SSE) and can trigger:
+    responses and can trigger:
       AssertionError: Unexpected message: {'type': 'http.response.start', ...}
 
     This middleware is implemented as a pure ASGI middleware to be safe for
     streaming responses (the /mcp Streamable HTTP transport).
 
     Constructor params:
-      app               - ASGI application (passed by Starlette's add_middleware)
-      connection_tracker - ConnectionTracker instance
-      server_ready_fn    - callable returning bool (is the server ready?)
-      server_version     - version string for probe/health responses
+      app             - ASGI application (passed by Starlette's add_middleware)
+      server_ready_fn - callable returning bool (is the server ready?)
+      server_version  - version string for warmup responses
     """
 
-    def __init__(self, app, connection_tracker: ConnectionTracker,
+    def __init__(self, app,
                  server_ready_fn: Callable[[], bool] = lambda: True,
                  server_version: str = "unknown"):
         self.app = app
-        self.connection_tracker = connection_tracker
         self.server_ready_fn = server_ready_fn
         self.server_version = server_version
 

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -699,7 +699,10 @@ async def http_health(request):
         else:
             db_health = {"status": "no_pool"}
     except Exception as e:
-        db_health = {"status": "error", "error": str(e)}
+        # /health is public (no auth) — log the detail server-side, don't leak
+        # the raw exception text (DSN, host, internal paths) in the response.
+        logger.warning("/health DB pool check failed: %s", e, exc_info=True)
+        db_health = {"status": "error"}
 
     return JSONResponse({
         "status": "ok" if server_ready else "warming_up",

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -34,7 +34,6 @@ from src.metrics_registry import (
     SERVER_INFO,
     SERVER_UPTIME,
 )
-from src.connection_tracker import CONNECTIONS_ACTIVE
 from src.broadcaster import broadcaster_instance
 from src.services.http_tool_service import execute_http_tool
 
@@ -42,7 +41,6 @@ if TYPE_CHECKING:
     from starlette.applications import Starlette
     from starlette.requests import Request
     from starlette.websockets import WebSocket
-    from src.connection_tracker import ConnectionTracker
 
 logger = get_logger(__name__)
 
@@ -669,7 +667,6 @@ async def http_health(request):
     server_ready = request.state._http_api_server_ready_fn()
     server_start_time = request.state._http_api_server_start_time
     server_version = request.state._http_api_server_version
-    conn_tracker: ConnectionTracker = request.state._http_api_connection_tracker
     has_streamable_http = request.state._http_api_has_streamable_http
     http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
 
@@ -711,10 +708,6 @@ async def http_health(request):
             "seconds": int(uptime_seconds),
             "formatted": uptime_str,
             "started_at": datetime.fromtimestamp(server_start_time).isoformat() if server_start_time else None
-        },
-        "connections": {
-            "active": conn_tracker.count,
-            "healthy": sum(1 for c in conn_tracker.connections.values() if c.get("health_status") == "healthy")
         },
         "database": db_health,
         "transports": {
@@ -800,7 +793,6 @@ async def http_metrics(request):
     # These are injected by register_http_routes via request.state
     server_start_time = request.state._http_api_server_start_time
     server_version = request.state._http_api_server_version
-    conn_tracker: ConnectionTracker = request.state._http_api_connection_tracker
 
     try:
         # Update gauges with current values before generating output
@@ -810,9 +802,6 @@ async def http_metrics(request):
         # Server uptime
         uptime_seconds = time.time() - server_start_time
         SERVER_UPTIME.set(uptime_seconds)
-
-        # Connection metrics
-        CONNECTIONS_ACTIVE.set(conn_tracker.count)
 
         # Agent metrics (from cached metadata — no DB call in handler path)
         try:
@@ -2837,7 +2826,6 @@ async def http_debug_memory(request):
 def register_http_routes(
     app: Starlette,
     *,
-    connection_tracker: ConnectionTracker,
     server_ready_fn,
     server_start_time: float,
     server_version: str,
@@ -2856,7 +2844,7 @@ def register_http_routes(
     from starlette.types import ASGIApp, Receive, Scope, Send
 
     # Tiny middleware that injects server context into request.state
-    # so endpoint handlers can access connection_tracker, server_version, etc.
+    # so endpoint handlers can access server_ready_fn, server_version, etc.
     class _InjectContextMiddleware:
         def __init__(self, app: ASGIApp):
             self.app = app
@@ -2864,7 +2852,6 @@ def register_http_routes(
         async def __call__(self, scope: Scope, receive: Receive, send: Send):
             if scope["type"] in ("http", "websocket"):
                 state = scope.setdefault("state", {})
-                state["_http_api_connection_tracker"] = connection_tracker
                 state["_http_api_server_ready_fn"] = server_ready_fn
                 state["_http_api_server_start_time"] = server_start_time
                 state["_http_api_server_version"] = server_version

--- a/src/mcp_listen_config.py
+++ b/src/mcp_listen_config.py
@@ -10,10 +10,13 @@ See CLAUDE.md for environment variables.
 
 from __future__ import annotations
 
+import hmac
 import os
-from typing import List
+from typing import List, Optional
 
 from mcp.server.transport_security import TransportSecuritySettings
+
+_MCP_BEARER_TOKENS_ENV = "UNITARES_MCP_BEARER_TOKENS"
 
 
 def env_truthy(name: str, default: bool = False) -> bool:
@@ -77,3 +80,55 @@ def build_transport_security_settings() -> TransportSecuritySettings:
 def cors_extra_origins() -> List[str]:
     """Optional extra CORS origins from UNITARES_HTTP_CORS_EXTRA_ORIGINS (comma-separated)."""
     return split_csv_env("UNITARES_HTTP_CORS_EXTRA_ORIGINS")
+
+
+def mcp_bearer_tokens() -> List[str]:
+    """Allowlist of bearer tokens accepted on the ``/mcp`` endpoint.
+
+    Read fresh each call so an operator can rotate tokens without a restart
+    (mirrors the operator-token allowlist in identity/operator.py). Empty by
+    default: when empty the ``/mcp`` bearer gate is OFF and the endpoint
+    behaves exactly as before — this preserves the localhost / self-host
+    default where no token is configured.
+    """
+    return split_csv_env(_MCP_BEARER_TOKENS_ENV)
+
+
+def mcp_bearer_required() -> bool:
+    """True when a ``/mcp`` bearer allowlist is configured (gate is ON)."""
+    return bool(mcp_bearer_tokens())
+
+
+def check_mcp_bearer(
+    authorization_header: Optional[str],
+    allow: Optional[List[str]] = None,
+) -> bool:
+    """Authorize an inbound ``/mcp`` request against the bearer allowlist.
+
+    Returns ``True`` (allow) when the gate is OFF (no tokens configured) — the
+    default, so localhost dev and existing self-host deployments are unchanged.
+    When the gate is ON, returns ``True`` only if the request presents
+    ``Authorization: Bearer <tok>`` with ``<tok>`` in the allowlist. The token
+    comparison is constant-time.
+
+    ``allow`` may be passed by a caller that already fetched the allowlist this
+    request (the ASGI gate does, to avoid a second env read and the tiny
+    add/remove TOCTOU between "is the gate on" and "is this token valid"). When
+    omitted it is read fresh from the environment.
+
+    Deliberately, and unlike the HTTP REST gate (``http_api._is_trusted_network``),
+    there is **no trusted-network bypass** here: a hosted endpoint typically sits
+    behind a reverse proxy, so the source IP is the proxy's and an IP-based
+    bypass would defeat the gate. Every request authenticates.
+    """
+    if allow is None:
+        allow = mcp_bearer_tokens()
+    if not allow:
+        return True  # gate off — default posture
+    if not authorization_header or not authorization_header.startswith("Bearer "):
+        return False
+    presented = authorization_header[len("Bearer "):].strip()
+    if not presented:
+        return False
+    # Constant-time membership test over a small allowlist.
+    return any(hmac.compare_digest(presented, tok) for tok in allow)

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -181,8 +181,10 @@ SERVER_VERSION = _load_version()
 
 from src.mcp_listen_config import (
     build_transport_security_settings,
+    check_mcp_bearer,
     cors_extra_origins,
     default_listen_host,
+    mcp_bearer_tokens,
 )
 
 # --- OAuth 2.1 configuration (optional, enabled by env var) ---
@@ -823,7 +825,19 @@ async def main():
         # is unused (all clients use /mcp), but sse_app() is needed because bare
         # Starlette(routes=[]) breaks POST body reading for REST routes.
         app = mcp.sse_app()
-        
+
+        # SECURITY: sse_app() wires /sse + /messages/ to the SAME _mcp_server tool
+        # registry, and with OAuth disabled (the default) it does so WITHOUT auth.
+        # That would bypass the /mcp bearer gate below by reaching the same tools
+        # over a different transport. The SSE transport is unused anyway, so drop
+        # those two routes — keep the rest of the sse_app() base (the body-reading
+        # setup the REST routes depend on). Closes the gate-bypass surface.
+        _sse_path = mcp.settings.sse_path
+        _msg_path = mcp.settings.message_path.rstrip("/")
+        _pruned = [r for r in app.routes if getattr(r, "path", None) in (_sse_path, _msg_path)]
+        app.routes[:] = [r for r in app.routes if getattr(r, "path", None) not in (_sse_path, _msg_path)]
+        logger.info(f"Pruned {len(_pruned)} unused/ungated SSE route(s): {_sse_path}, {_msg_path}")
+
         # === Add CORS support for web-based GPT/Gemini clients ===
         # CORS: restrict to known origins (dashboard, local dev, Tailscale)
         _cors_allow_origin = os.getenv("UNITARES_HTTP_CORS_ALLOW_ORIGIN")
@@ -925,6 +939,26 @@ async def main():
                 """ASGI app for Streamable HTTP MCP at /mcp."""
                 if scope.get("type") != "http":
                     return
+
+                # Bearer gate (default-OFF; see src/mcp_listen_config). When
+                # UNITARES_MCP_BEARER_TOKENS is set, every /mcp request must
+                # present a matching `Authorization: Bearer <tok>`. No trusted-
+                # network bypass — a hosted endpoint authenticates every call.
+                # When unset, this is a no-op and localhost dev is unchanged.
+                # Fetch the allowlist once and pass it through, so "is the gate
+                # on" and "is this token valid" read the same snapshot.
+                _bearer_allow = mcp_bearer_tokens()
+                if _bearer_allow:
+                    from starlette.datastructures import Headers as _BearerHeaders
+                    _auth = _BearerHeaders(scope=scope).get("authorization")
+                    if not check_mcp_bearer(_auth, _bearer_allow):
+                        await JSONResponse(
+                            {"error": "unauthorized",
+                             "detail": "valid bearer token required for /mcp"},
+                            status_code=401,
+                            headers={"WWW-Authenticate": "Bearer"},
+                        )(scope, receive, send)
+                        return
 
                 # BUILD SESSION SIGNALS — single capture of all transport headers
                 # No priority decisions here; derive_session_key() handles that.

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -76,9 +76,7 @@ SERVER_START_TIME = time.time()  # Track server start time for uptime metric
 from src.metrics_registry import (
     TOOL_CALLS_TOTAL, TOOL_CALL_DURATION,
 )
-from src.connection_tracker import (
-    ConnectionTracker, ConnectionTrackingMiddleware,
-)
+from src.connection_tracker import ConnectionTrackingMiddleware
 
 # Try to import MCP SDK
 try:
@@ -104,13 +102,6 @@ from src.wave3a_beam_proxy import proxy_to_beam as _wave3a_proxy_to_beam
 
 # Tool schemas are now in src/tool_schemas.py (shared module)
 
-# ============================================================================
-# Connection Tracking for Multi-Agent Awareness
-# (ConnectionTracker and ConnectionTrackingMiddleware live in src/connection_tracker.py)
-# ============================================================================
-
-# Global connection tracker
-connection_tracker = ConnectionTracker()
 
 def _session_id_from_ctx(ctx: Context | None) -> str | None:
     """
@@ -860,7 +851,6 @@ async def main():
         # Class lives in src/connection_tracker.py — see ConnectionTrackingMiddleware
         app.add_middleware(
             ConnectionTrackingMiddleware,
-            connection_tracker=connection_tracker,
             server_ready_fn=lambda: SERVER_READY,
             server_version=SERVER_VERSION,
         )
@@ -880,10 +870,7 @@ async def main():
             SERVER_READY = True
             SERVER_STARTUP_TIME = datetime.now()
 
-        start_all_background_tasks(
-            connection_tracker=connection_tracker,
-            set_ready=_set_server_ready,
-        )
+        start_all_background_tasks(set_ready=_set_server_ready)
 
         # === HTTP REST endpoints for non-MCP clients (Llama, Mistral, etc.) ===
         HTTP_CORS_ALLOW_ORIGIN = os.getenv("UNITARES_HTTP_CORS_ALLOW_ORIGIN")  # e.g. "*" or "http://localhost:3000"
@@ -891,7 +878,6 @@ async def main():
         from src.http_api import register_http_routes
         register_http_routes(
             app,
-            connection_tracker=connection_tracker,
             server_ready_fn=lambda: SERVER_READY,
             server_start_time=SERVER_START_TIME,
             server_version=SERVER_VERSION,

--- a/tests/resident_progress/test_probe_integration.py
+++ b/tests/resident_progress/test_probe_integration.py
@@ -18,13 +18,7 @@ async def test_progress_flat_probe_task_is_supervised_when_started(monkeypatch):
     async def fake_set_ready():
         pass
 
-    class _NoopTracker:
-        def add(self, *a, **kw):
-            pass
-
-    background_tasks.start_all_background_tasks(
-        connection_tracker=_NoopTracker(), set_ready=fake_set_ready,
-    )
+    background_tasks.start_all_background_tasks(set_ready=fake_set_ready)
     names = [t.get_name() if hasattr(t, "get_name") else (getattr(t, "_name", "") or "") for t in background_tasks._supervised_tasks]
     assert any("progress_flat_probe" in n for n in names), \
         f"progress_flat_probe not in supervised task list: {names}"

--- a/tests/test_mcp_bearer_gate.py
+++ b/tests/test_mcp_bearer_gate.py
@@ -1,0 +1,116 @@
+"""Bearer gate for the /mcp endpoint (src/mcp_listen_config).
+
+This is the one primitive a hosted deployment needs and that was absent: a way
+to require an Authorization: Bearer token on every /mcp request, while staying
+byte-identical to current behavior when no token is configured (localhost dev /
+self-host). These tests pin both halves — the off-by-default posture and the
+on-path accept/reject rules — plus the deliberate no-trusted-bypass design.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import src.mcp_listen_config as cfg
+
+
+@pytest.fixture(autouse=True)
+def _clear_bearer_env(monkeypatch):
+    monkeypatch.delenv("UNITARES_MCP_BEARER_TOKENS", raising=False)
+    importlib.reload(cfg)
+    yield
+
+
+def test_gate_off_by_default():
+    # No env configured -> gate OFF, everything allowed, even no header.
+    assert cfg.mcp_bearer_required() is False
+    assert cfg.check_mcp_bearer(None) is True
+    assert cfg.check_mcp_bearer("anything") is True
+
+
+def test_gate_on_when_tokens_configured(monkeypatch):
+    monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "s3cret")
+    assert cfg.mcp_bearer_required() is True
+    assert cfg.mcp_bearer_tokens() == ["s3cret"]
+
+
+def test_valid_bearer_accepted(monkeypatch):
+    monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "s3cret")
+    assert cfg.check_mcp_bearer("Bearer s3cret") is True
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        None,                       # missing header
+        "",                         # empty header
+        "s3cret",                   # raw token, no "Bearer " scheme
+        "Bearer ",                  # scheme but empty token
+        "Bearer wrong",             # wrong token
+        "Basic s3cret",             # wrong scheme
+        "bearer s3cret",            # case-sensitive scheme (RFC says token68 scheme is case-insensitive,
+                                    # but we require the canonical "Bearer " prefix the clients send)
+    ],
+)
+def test_invalid_bearer_rejected_when_gate_on(monkeypatch, header):
+    monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "s3cret")
+    assert cfg.check_mcp_bearer(header) is False
+
+
+def test_token_rotation_accepts_any_listed(monkeypatch):
+    # CSV allowlist lets an operator rotate without dropping the old token mid-flight.
+    monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "old-token, new-token")
+    assert cfg.mcp_bearer_tokens() == ["old-token", "new-token"]
+    assert cfg.check_mcp_bearer("Bearer old-token") is True
+    assert cfg.check_mcp_bearer("Bearer new-token") is True
+    assert cfg.check_mcp_bearer("Bearer retired-token") is False
+
+
+def test_whitespace_only_env_is_gate_off(monkeypatch):
+    # "   ,  ," parses to zero tokens -> still OFF (no accidental empty-token allow).
+    monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "   ,  ,")
+    assert cfg.mcp_bearer_required() is False
+    assert cfg.check_mcp_bearer(None) is True
+
+
+def test_read_fresh_each_call_supports_runtime_rotation(monkeypatch):
+    monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "first")
+    assert cfg.check_mcp_bearer("Bearer first") is True
+    # Rotate in-process; no restart, no reload — read-fresh semantics.
+    monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "second")
+    assert cfg.check_mcp_bearer("Bearer first") is False
+    assert cfg.check_mcp_bearer("Bearer second") is True
+
+
+def test_explicit_allow_overrides_env(monkeypatch):
+    # The ASGI gate fetches the allowlist once and passes it through, so the
+    # decision uses one snapshot (no add/remove TOCTOU vs a second env read).
+    monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "env-token")
+    assert cfg.check_mcp_bearer("Bearer snapshot", allow=["snapshot"]) is True
+    assert cfg.check_mcp_bearer("Bearer env-token", allow=["snapshot"]) is False
+    # Empty explicit allow == gate off for this decision.
+    assert cfg.check_mcp_bearer(None, allow=[]) is True
+
+
+def test_sse_routes_are_prunable_to_close_gate_bypass():
+    # The /mcp bearer gate would be bypassable if /sse + /messages/ (which the
+    # SDK wires to the SAME tool registry, unauthenticated when OAuth is off)
+    # stayed mounted. mcp_server prunes them; assert that prune fully removes
+    # the SSE surface so no ungated route reaches the tools.
+    pytest.importorskip("mcp.server.fastmcp")
+    from mcp.server.fastmcp import FastMCP
+
+    m = FastMCP("probe")
+    app = m.sse_app()
+    before = {getattr(r, "path", None) for r in app.routes}
+    assert m.settings.sse_path in before  # /sse present pre-prune
+
+    _sse = m.settings.sse_path
+    _msg = m.settings.message_path.rstrip("/")
+    app.routes[:] = [r for r in app.routes if getattr(r, "path", None) not in (_sse, _msg)]
+
+    after = {getattr(r, "path", None) for r in app.routes}
+    assert _sse not in after
+    assert _msg not in after


### PR DESCRIPTION
> **Stacked on #847** — the first two commits in this diff ARE #847 (bearer gate + SSE removal); only the last commit (`36df1047`, the ConnectionTracker removal) is new here. The diff will collapse to just that once #847 merges to master. Review/merge #847 first.

## Why
#847 retired the `/sse` transport. The connection-tracking subsystem existed only to track SSE connections — once `/sse` was gone, nothing called `add_connection`, so `ConnectionTracker.connections` was permanently empty and every consumer reported zero. Dead-but-wired infra (the "dormant capability a future agent misreads as live" debt). Remove it end to end.

## What (commit 36df1047)
- **`connection_tracker.py`** — delete the `ConnectionTracker` class + its four prometheus metrics (`unitares_connections_active`, `_connection_health`, `_connection_events`, `_connection_duration`). Keep the live `ConnectionTrackingMiddleware` (identity propagation + `/health` warmup); drop its now-unused `connection_tracker` param.
- **`background_tasks.py`** — remove the `connection_heartbeat_task` reaper (looped an always-empty dict every 60s); drop the `connection_tracker` arg from `start_all_background_tasks`.
- **`http_api.py`** — drop the `/health` `"connections"` block, the `/metrics` `CONNECTIONS_ACTIVE` gauge, the `request.state` injection, and imports.
- **`mcp_server.py`** — unwire the instance. Plus the one stub-tracker test.

Net **−467 lines** for that commit.

## Consumer-visible (please confirm acceptable)
- `/health` no longer carries a `"connections": {active, healthy}` object.
- `/metrics` no longer exposes the four `unitares_connection_*` series.

Both only ever reflected SSE connections, which no longer exist (they'd read 0 now). Flagged in case any external dashboard/alert charts those series.

## Verification
parse + ruff clean on all 5 files; modules import; `test_probe_integration` (signature change) + `test_mcp_bearer_gate` pass. The 2 `test_telemetry.py` failures seen under a broad `-k` run are **pre-existing** — they reproduce on the base with this change stashed (prometheus-registry/test-ordering flake) and pass in isolation + full-file.

Draft — operator review, especially the consumer-visible `/health` + `/metrics` shape change.