### PR TITLE
fix(mirror): non-steady verdict must not collapse to 'steady state'

### DIFF
--- a/src/mcp_handlers/response_formatter.py
+++ b/src/mcp_handlers/response_formatter.py
@@ -19,6 +19,16 @@ logger = get_logger(__name__)
 # nearest_edge is pure vocabulary sprawl (#733).
 _ACTIONABLE_MARGINS = frozenset({"tight", "warning", "critical"})
 
+# Verdicts that genuinely represent a healthy/steady state — the only ones for
+# which the mirror's "No actionable signals — steady state" fallback is
+# truthful. Any other verdict (pause, reject, guide, caution, high-risk, …)
+# is by definition actionable and must surface a signal rather than collapse to
+# the steady-state line (dogfood 2026-06-18: a PAUSE verdict at risk 0.72 with
+# margin=critical returned mirror=["No actionable signals — steady state"] while
+# the same payload carried margin/nearest_edge/reflection — the lens hid the
+# very state it exists to reflect).
+_STEADY_VERDICTS = frozenset({"proceed", "continue", "safe"})
+
 
 def _copy_passthrough_fields(response_data: dict, result: dict, fields: tuple) -> None:
     """Copy named fields from response_data to result if present (not None).
@@ -362,6 +372,28 @@ def _format_mirror(response_data: dict, saved_trust_tier: Any, meta: Any = None)
             mirror_signals.append(f"Pace: {restorative_reason}")
         elif restorative_reasons:
             mirror_signals.append(f"Pace: {'; '.join(str(r) for r in restorative_reasons[:2])}")
+
+    # 4b. Verdict edge — a non-steady verdict must never collapse to the
+    # "No actionable signals — steady state" fallback below. The mirror is
+    # "a lens on the full data, not a filter that hides it" (docstring); a
+    # payload that carries margin/nearest_edge/reflection at the result level
+    # while the signals array reads "steady state" is self-contradictory
+    # (dogfood 2026-06-18). Reflect the fact descriptively — the directive
+    # ("stop, reflect, consider dialectic") stays the verdict's voice, which
+    # already rides on result["verdict"].next_action.
+    if verdict_raw not in _STEADY_VERDICTS:
+        facts = []
+        risk = metrics.get("risk_score")
+        if isinstance(risk, (int, float)):
+            facts.append(f"risk {risk:.0%}")
+        margin_val = decision.get("margin")
+        edge = decision.get("nearest_edge")
+        if isinstance(margin_val, str) and margin_val in _ACTIONABLE_MARGINS:
+            facts.append(f"{margin_val} margin" + (f" at the {edge} edge" if edge else ""))
+        elif edge:
+            facts.append(f"nearest edge: {edge}")
+        detail = f" ({', '.join(facts)})" if facts else ""
+        mirror_signals.append(f"Verdict is {str(verdict_raw).upper()}{detail}")
 
     # 5. Surface relevant KG discoveries — from mirror enrichment AND from existing enrichments
     relevant_prior = []

--- a/tests/test_response_formatter.py
+++ b/tests/test_response_formatter.py
@@ -565,6 +565,38 @@ class TestFormatMirror:
         assert "Needs attention" in result["verdict"]["meaning"]
         assert "next_action" in result["verdict"]
 
+    def test_pause_verdict_never_reads_steady_state(self):
+        """A PAUSE verdict must surface an actionable signal, not the
+        "steady state" fallback. Regression for dogfood 2026-06-18: a pause
+        at risk 0.72 / margin=critical returned mirror=["No actionable
+        signals — steady state"] while the same payload carried
+        margin/nearest_edge/reflection — the lens hid the very state it
+        exists to reflect."""
+        data = _sample_response()
+        data["_mirror_signals"] = []
+        data["relevant_discoveries"] = []  # isolate: no other signal source
+        data["decision"]["action"] = "pause"
+        data["decision"]["margin"] = "critical"
+        data["decision"]["nearest_edge"] = "risk"
+        data["metrics"]["risk_score"] = 0.72
+        result = _format_mirror(data, saved_trust_tier=None)
+        assert not any("steady state" in s.lower() for s in result["mirror"]), \
+            "PAUSE verdict must not collapse to the steady-state fallback"
+        signal = next(s for s in result["mirror"] if "PAUSE" in s)
+        assert "72%" in signal
+        assert "critical" in signal
+        assert "risk" in signal
+
+    def test_steady_verdict_keeps_steady_state_fallback(self):
+        """A healthy verdict with no other signals still gets the
+        steady-state line — the fix must not make every check-in noisy."""
+        data = _sample_response()
+        data["_mirror_signals"] = []
+        data["relevant_discoveries"] = []
+        data["decision"]["action"] = "proceed"
+        result = _format_mirror(data, saved_trust_tier=None)
+        assert result["mirror"] == ["No actionable signals — steady state"]
+
     def test_calibration_insight_inverted(self):
         data = _sample_response()
         data["learning_context"] = {


### PR DESCRIPTION
A `response_mode='mirror'` check-in returned `["No actionable signals — steady state"]` on a **PAUSE** verdict (risk 0.72, `margin=critical`, `nearest_edge=risk`) while the same payload carried `margin`/`nearest_edge`/`reflection` at the result level. The mirror is documented as "a lens on the full data, not a filter that hides it" — the steady-state fallback was hiding the very state it exists to reflect.

**Fix:** add `_STEADY_VERDICTS = {proceed, continue, safe}`; for any other verdict, append a descriptive verdict-edge signal (risk %, actionable margin, nearest edge) before the steady-state fallback check. Voice stays descriptive — the directive remains the verdict's job via `result["verdict"].next_action`.

Surfaced by an Opus 4.8 dogfood run 2026-06-18.

**Tests:** `test_pause_verdict_never_reads_steady_state` (PAUSE surfaces risk %/margin/edge), `test_steady_verdict_keeps_steady_state_fallback` (healthy verdict still gets the quiet line). Full suite green locally (10410 passed).

https://claude.ai/code/session_01JqgvE7zmGV1N6EeKyHqCLF