### PR TITLE
fix(kg/age): bucket status-less discoveries so by_status reconciles with total

### DIFF
--- a/src/storage/knowledge_graph_age.py
+++ b/src/storage/knowledge_graph_age.py
@@ -977,7 +977,17 @@ class KnowledgeGraphAGE:
             # cold here means a list response with including_cold=False reports
             # exactly the rows it bucketed.
             total_count = max(0, total_count - cold_count)
-        by_status = dict(Counter(s for s in statuses if s))
+        # Bucket status-less rows under a None key rather than dropping them.
+        # A Discovery vertex created without a status property returns null for
+        # d.status; the old `Counter(s for s in statuses if s)` filtered those
+        # (and empty strings) out, so sum(by_status.values()) < total_discoveries
+        # by the count of status-less rows while total_discoveries still counted
+        # them — an unreconcilable gap (dogfood 2026-06-18: 1066 total vs 1003
+        # bucketed = 63 status-less discoveries). Folding them into a None key
+        # restores the invariant sum(by_status.values()) == total_discoveries
+        # (at including_cold=True) and matches the postgres backend, whose
+        # GROUP BY status yields a NULL group for the same rows.
+        by_status = dict(Counter(s if s else None for s in statuses))
         
         # Count edges
         cypher = "MATCH ()-[r]->() RETURN count(r)"

--- a/tests/test_knowledge_graph_age.py
+++ b/tests/test_knowledge_graph_age.py
@@ -1110,6 +1110,35 @@ class TestGetStats:
         assert result["by_tag"] == {"python": 2, "bug": 1}
 
     @pytest.mark.asyncio
+    async def test_status_less_rows_reconcile_under_none_bucket(self):
+        """Discoveries with null/empty status must be bucketed (under None),
+        not dropped — so sum(by_status.values()) == total_discoveries.
+
+        Regression for dogfood 2026-06-18: collect(d.status) returns null for
+        status-less vertices; the old `Counter(s for s in statuses if s)`
+        dropped them, leaving by_status summing below total_discoveries
+        (observed live: 1066 total vs 1003 bucketed = 63 status-less rows).
+        """
+        kg, mock_db = make_kg_with_mock_db()
+
+        mock_db.graph_query.side_effect = [
+            [5],                                          # total discoveries
+            [["a1", "a1", "a2", "a3", "a4"]],             # collect(agent_ids)
+            [["insight", "bug", "note", "note", "note"]], # collect(types)
+            [["open", "resolved", None, "", "open"]],     # collect(statuses): 2 status-less
+            [3],                                          # count edges
+            [10],                                         # count tags
+            [["python"]],                                 # collect(tag names)
+        ]
+
+        result = await kg.get_stats(including_cold=True)
+
+        # Both the None and the "" status fold into the None bucket.
+        assert result["by_status"] == {"open": 2, "resolved": 1, None: 2}
+        # The invariant the live gap violated: buckets reconcile with the total.
+        assert sum(result["by_status"].values()) == result["total_discoveries"]
+
+    @pytest.mark.asyncio
     async def test_handles_empty_graph(self):
         """Should handle empty graph gracefully."""
         kg, mock_db = make_kg_with_mock_db()


### PR DESCRIPTION
AGE `get_stats` counted every Discovery vertex in `total_discoveries` but built `by_status` via `Counter(s for s in statuses if s)`, silently dropping rows whose `status` is null/empty. Result: `sum(by_status.values()) < total_discoveries` by the count of status-less rows, with no explanation.

Dogfood 2026-06-18: raw total **1066** vs `by_status` sum **1003** = **63 status-less discoveries**. A knowledge store without an explicit status persists `status=null`, so the gap grows over time.

**Fix:** fold falsy statuses into a `None` bucket — restoring the invariant `sum(by_status.values()) == total_discoveries` at `including_cold=True`, and matching the postgres backend whose `GROUP BY status` already yields a NULL group.

Distinct from the existing `count_scope_warning` (lifecycle-bucket vs raw-total gap) — that warning is left unchanged.

**Tests:** `test_status_less_rows_reconcile_under_none_bucket` (null + empty fold to `None`; buckets sum to total). Full suite green locally (10410 passed).

https://claude.ai/code/session_01JqgvE7zmGV1N6EeKyHqCLF