### PR TITLE
docs(proposals): BEAM governed-effects dossier + council amendment

### DIFF
--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -25,6 +25,7 @@ Several of these are **single-writer surfaces** (see the shared contract in `AGE
 | [`beam-wave-3-handler-dispatch.md`](beam-wave-3-handler-dispatch.md) | v0.3.2 — active redraft; supersedes v0.2/v0.1.x |
 | [`beam-wave-3a-read-only-handlers.md`](beam-wave-3a-read-only-handlers.md) | v0.2 — council-fold complete; operator review pending |
 | [`agent-orchestrator-beam-v0.md`](agent-orchestrator-beam-v0.md) | v0 thin slice — council-reviewed library + smoke, not merged to any running surface |
+| [`beam-governed-effects-dossier-2026-06-18.md`](beam-governed-effects-dossier-2026-06-18.md) | Draft dossier + phased plan — narrows current evidence to BEAM as governed-effect / runtime-custody plane, not whole-governance rewrite |
 | [`wave-3-section-5-2-boundary-audit-summary.md`](wave-3-section-5-2-boundary-audit-summary.md) | CI-checkable §5.2 boundary-cost audit summary (2026-06-10), required before `elixir/handler_dispatch/` commits |
 
 ### Operator-vision delegation / identity hardening

--- a/docs/proposals/beam-governed-effects-dossier-2026-06-18.md
+++ b/docs/proposals/beam-governed-effects-dossier-2026-06-18.md
@@ -1,0 +1,334 @@
+# BEAM Governed-Effects Dossier and Migration Plan
+
+> **For Hermes:** Use `elixir-beam-governance` and `subagent-driven-development` before implementing tasks from this plan. Execute task-by-task with TDD, ExUnit where BEAM code is touched, and Python regression tests where UNITARES analysis/governance code is touched.
+
+**Created:** June 18, 2026  
+**Last Updated:** June 18, 2026  
+**Status:** Draft dossier + implementation plan — **amended post-council 2026-06-18 (see Council Amendment below)**
+
+---
+
+## Council Amendment (2026-06-18)
+
+A three-member council (dialectic + code-review + live-verifier) reviewed this dossier against the running system. The boundary reasoning holds; the **mechanism does not**. Verdict: **accept the question, reframe the plane, ship only the telemetry phase.** Corrections, in priority order:
+
+1. **The "new plane" already exists as built/live BEAM code — reframe as a lease-plane *effect-envelope extension*, not a new OTP app.** Verified against the running system:
+   - **Leases + single-winner conflicts:** live. `surface_registry.ex:54-76` returns `{:error, :held_by_other}` to the loser; lease plane is the running `beam.smp` on `:8788`.
+   - **Revocation:** live **and enforced** — `POST /v1/lease/force-release` (`http_router.ex:205-227`) gated by a separate `LEASE_FORCE_RELEASE_TOKEN`; the regular bearer is barred. Evidence §1 below mis-frames revocation as a gap; it is already solved. *(Strike that framing.)*
+   - **Supervision / DynamicSupervisor / lease client:** already built in `elixir/agent_orchestrator/` (`agent_supervisor.ex`, `agent_runner.ex`, `lease_plane_client.ex`) — but **inert** (`:8789` not listening, no plist, nothing spawns through it). The "new governed-effect plane" is this app needing a plist + a caller, not a greenfield build. Do **not** create `elixir/governed_effect_plane/`.
+
+2. **The load-bearing undecided question — answer it in Phase 2 before any Elixir:** *Does BEAM **execute** the committed effect, or only **record** the proposal?* A lease is custody of a *surface*; an effect is custody of a *transition* (payload + a commit veto on non-exclusivity grounds). But this dossier assigns the novel half (`governance_blocked`) to UNITARES, leaving BEAM's share isomorphic to a lease. The new safety property ("agents propose, BEAM commits") exists **iff BEAM is the executing party**. The protocol sketch's `payload_ref` (a *reference*, not bytes) leans toward record-only, which would make the thesis a relabel. Decide this fork first.
+
+3. **Phase 1 is already fully shipped by PR #846 — demote it to verification.** `harness_lane_from_detail()`, `DEFAULT_EXCLUDED_HARNESS_LANES=("beam",)`, both negative-control tests, and BEAM emitter-disable in test configs all exist and pass. Do not re-implement.
+
+4. **Repo-qualify all Phase 1 paths.** `scripts/analysis/*` and `tests/test_*` live in **`unitares-deploy`**, not the `unitares` server repo the preamble points Hermes at. The verification command needs `cd ~/projects/unitares-deploy &&`.
+
+5. **Phase 4 surface collisions.** `resident:/sentinel_cycle` is already **live + enforced** (`LEASE_PLANE_ENFORCED_SURFACE_KINDS=resident`); `agent:/<id>` is already a `remote_heartbeat` TTL row. Both would double-book. **`repo://unitares/doc_update` is the only clean greenfield first surface.**
+
+6. **Protocol holes (Phase 2):** no idempotency key (retry-after-timeout mints a second `effect_id` and races the surface); proposer-crash-after-202 / custody-TTL unspecified; `payload_ref` has no type/size contract (collides with invariant 7).
+
+7. **Substrate-tax framing is overstated.** PR #218's `ExecutorPool` already mitigated the asyncpg ~60× amplification; the honest residual is **Redis** (still unwrapped). Cite the mitigation, not just the wound — and note this is the dossier's *positive* case for BEAM-on-this-class, currently omitted.
+
+8. **Sequence behind the 2026-06-24 Wave-3 gate.** The effect plane coordinates against the same `core` tables A′ deferred, riding an inert orchestrator. Phase 1 (telemetry hygiene, already shipped) is the only part that proceeds now; Phases 3–5 gate behind both the execute/record decision (#2) and the gate read.
+
+Rhetoric to strike until #2 is answered: **"membrane"** and **"effect custody"** as control-of-*act* both assert a property the design hasn't bought (they currently describe a logbook). The load-bearing, surviving content is the typed-denial vocabulary, the provenance lane-tags, and the rollback discipline.
+
+Decision-packet mapping: this is **Option B (amend)** sharpened toward **Option C (telemetry hygiene only, no new runtime surface yet)**. The sections below are preserved as originally written; read them through this amendment.
+
+---
+
+## Goal
+
+Establish an evidence-grounded plan for moving **governed-effect custody and hot runtime coordination** to BEAM/OTP without rewriting UNITARES durable governance, EISV analysis, calibration, KG, or Lumen body loops.
+
+## Executive Thesis
+
+The June 18 dogfood + ablation run is **not** a blanket argument to migrate UNITARES to BEAM. It is a strong argument for a narrower runtime boundary:
+
+> Agents may propose; only a BEAM-supervised governed-effect plane may commit.
+
+BEAM should own process supervision, leases, revocation, effect custody, bounded queues, and telemetry emission. UNITARES should remain the durable truth substrate for identity, EISV trajectory, calibration, dialectic, outcome history, observability, and KG sediment. Python analysis should remain the primary ablation and reporting lane unless a specific runtime property forces a port.
+
+## Current Evidence Packet
+
+### 1. Identity bleed was a proof-origin bug, not a BEAM failure
+
+- Finding: no-proof/pre-onboard read-only MCP paths could surface a resident identity (`Chronicler`) because server-inferred session/transport context was treated as caller-owned identity.
+- Fix landed separately as PR #839: pre-onboard read tools stay identity-neutral unless caller proof is explicit.
+- Interpretation: this is an identity/provenance boundary lesson. It does **not** imply identity should be reimplemented in BEAM.
+- Boundary consequence: any BEAM governed-effect plane must consume explicit UNITARES identity/proof envelopes and must not mint or launder identity.
+
+### 2. BEAM harness telemetry is operationally important but analytically contaminating unless partitioned
+
+- Ablation watchdog after lane split:
+  - `eprocess_eligible=1778`
+  - `eprocess_eligible_beam=1493`
+  - `eprocess_eligible_substrate=285`
+- Fix landed as PR #846: outcome inventory exposes `harness_lane`, and EISV ablation matrix excludes `beam` harness rows by default.
+- Interpretation: BEAM/runtime telemetry is a large and useful signal stream, but it must not masquerade as EISV/prior-state predictive validation.
+- Boundary consequence: BEAM can emit telemetry, but UNITARES analysis must classify it by provenance before using it for EISV claims.
+
+### 3. Existing roadmap already points to stateful coordination, not whole-system rewrite
+
+Existing BEAM roadmap language already favors A′:
+
+- stateful coordination to BEAM in waves;
+- stateless computation stays Python via Ports / HTTP;
+- MCP transport remains Python until SDK/fitness gates close;
+- each wave needs its own RFC, council pass, state ownership, rollback, and test strategy.
+
+This dossier narrows the current argument further: start with **governed effects** and **runtime custody**, not governance-brain migration.
+
+## Decision Boundary
+
+### Move to BEAM/OTP
+
+BEAM should own surfaces with these properties:
+
+1. **Runtime custody** — a process owns the effect lifecycle from proposal to commit/reject/revoke.
+2. **Supervision** — failures are visible, isolated, and restartable under OTP.
+3. **Leases and conflicts** — shared mutable surfaces have one owner or one clear loser.
+4. **Revocation** — an operator or governance policy can stop a stale or unsafe holder.
+5. **Bounded queues** — backpressure is explicit instead of being accidental event-loop pressure.
+6. **Telemetry emission** — runtime facts are emitted in typed, provenance-tagged envelopes.
+
+### Keep in UNITARES/Python/Postgres
+
+Do not migrate these merely because they touch governance:
+
+1. **Durable identity and continuity** — UNITARES remains source of truth.
+2. **EISV computation and calibration** — analysis stays Python unless a specific measured bottleneck survives Python fixes.
+3. **Knowledge graph and dialectic records** — durable semantic sediment remains in UNITARES/Postgres/AGE.
+4. **Ablation and skeptical analysis** — Python tooling remains the measurement/reporting lane.
+5. **Lumen/anima body loops** — Python remains the embodied creature/runtime unless separately decided.
+6. **MCP tool surface** — stays Python until the Elixir MCP SDK gate is explicitly evaluated and passed.
+
+## Proposed Architecture
+
+```text
+Hermes / agents / resident processes
+        |
+        | propose effect + explicit identity/provenance envelope
+        v
+BEAM Governed-Effect Plane
+  - Supervisor tree
+  - Registry by canonical surface/effect id
+  - DynamicSupervisor per active custody process
+  - Lease / revocation client
+  - telemetry sink with harness_lane/effect_lane tags
+        |
+        | accepted/rejected/committed/revoked runtime event
+        v
+UNITARES Governance MCP / Postgres
+  - durable identity
+  - outcome_event / audit_event
+  - EISV trajectory
+  - calibration / ablation / KG / dialectic
+```
+
+The plane is not an alternate governance brain. It is an effect-custody membrane.
+
+## Required Invariants
+
+1. **Identity ownership:** BEAM never asserts a caller identity from transport/session inference alone.
+2. **Effect custody:** no effect commits unless a custody process owns the effect id and required lease(s).
+3. **Typed denial:** rejected effects return stable typed errors (`identity_required`, `lease_held`, `revoked`, `governance_blocked`, `schema_invalid`, etc.).
+4. **Telemetry provenance:** every emitted event includes lane tags such as `harness_lane`, `effect_lane`, and `verification_source`.
+5. **Analysis separation:** runtime telemetry is visible by default but excluded from EISV validation unless it has prior-state eligibility and non-fixture provenance.
+6. **Rollback:** every wave has a named fallback path to the previous Python/direct-effect behavior.
+7. **No secret leakage:** continuity tokens and bearer credentials never appear in telemetry, KG, docs, logs, or final summaries.
+
+## Phased Plan
+
+### Phase 0 — Dossier Acceptance and Council Gate
+
+**Objective:** Decide whether this dossier is the right boundary document before writing code.
+
+**Files:**
+- Create: `docs/proposals/beam-governed-effects-dossier-2026-06-18.md`
+- Modify: `docs/proposals/README.md`
+
+**Steps:**
+1. Review this dossier against `beam-footprint-roadmap-v0.md` and `agent-orchestrator-beam-v0.md`.
+2. Confirm operator decision: governed-effect custody first; no broad rewrite.
+3. Run a council/review pass on the boundary if this becomes implementation-guiding.
+4. Record any amendments at the top of this file rather than creating duplicate roadmap docs.
+
+**Verification:**
+- `python3 scripts/diagnostics/check_doc_health.py`
+- `./scripts/dev/check-shared-contract.sh` if AGENTS/CLAUDE shared-contract files are touched.
+
+**Exit criteria:**
+- Operator accepts the boundary or names amendments.
+- No open PR collision on BEAM/proposal single-writer surfaces.
+
+### Phase 1 — Telemetry Hygiene **Verification** (already shipped by PR #846)
+
+> **Council amendment:** This phase is **already implemented and tested** by PR #846 — `harness_lane_from_detail()` (`scripts/analysis/outcome_inventory.py`), `DEFAULT_EXCLUDED_HARNESS_LANES=("beam",)` and `filter_rows_for_validation()` (`scripts/analysis/eisv_ablation_matrix.py:43,78-94`), both negative-control tests, and BEAM emitter-disable in test configs (`elixir/sentinel/config/test.exs:15` `emit_checkins: false`; `agent_orchestrator` has zero governance emit calls). Do **not** re-implement. Phase 1 is reduced to a confirmation gate.
+
+**Objective:** Confirm the shipped telemetry hygiene still holds before any new BEAM surface grows.
+
+**Files (all in `unitares-deploy`, NOT the `unitares` server repo):**
+- Confirm: `unitares-deploy/scripts/analysis/outcome_inventory.py`
+- Confirm: `unitares-deploy/scripts/analysis/eisv_ablation_matrix.py`
+- Confirm tests: `unitares-deploy/tests/test_outcome_inventory.py`, `unitares-deploy/tests/test_eisv_ablation_matrix.py`
+
+**Tasks:**
+1. Confirm every BEAM harness event carries `detail.harness="beam"` (Invariant 4 is the *emission* contract; Invariant 5 the *analysis* contract — Invariant 5 is unenforceable unless emit always tags the lane).
+2. Confirm the negative-control test proving BEAM rows cannot enter the default EISV validation matrix still passes.
+3. Confirm BEAM tests run with live governance emitters disabled.
+
+**Verification:**
+```bash
+cd ~/projects/unitares-deploy && \
+PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 -m pytest \
+  tests/test_outcome_inventory.py \
+  tests/test_eisv_ablation_matrix.py
+```
+
+**Exit criteria:**
+- BEAM/runtime rows are visible in reports.
+- Default EISV validation excludes BEAM/harness rows unless explicitly requested.
+
+### Phase 2 — Governed-Effect Protocol Contract
+
+**Objective:** Define one protocol before building runtime machinery.
+
+> **Council amendment — answer this fork FIRST, before any Elixir:** *Does BEAM **execute** the committed effect, or only **record** the proposal?* If execute → there is a real new safety property (mediated effect execution; `governance_blocked` can stop a side-effect a lease-holder would otherwise just *do*) and the `payload` must be the actual bytes/command, not a ref. If record-only → this is advisory bookkeeping and should be an audit feature, not an enforcement plane. The `payload_ref` sketch below leans record-only; reconcile it with this decision. Three more holes the protocol must close: **(a) idempotency key** — a proposer-supplied UUID/content-hash so a retry after timeout returns the existing `effect_id` instead of minting a second and racing the surface (the lease plane already does idempotent re-acquire, `repo.ex:8,38`); **(b) proposer-crash-after-202** — specify the custody TTL for `proposed`/`held` effects, whether it derives from `required_leases` TTL or is independent, and who heartbeats; **(c) `payload_ref` type/size contract** — hash vs URL vs redacted-summary-string with a max length, reconciled with Invariant 7 (no secret leakage).
+
+**Files:**
+- Create: `docs/proposals/governed-effect-plane-v0.md` or append an accepted protocol section here.
+- Potential future code: `elixir/governed_effect_plane/` or extension of the existing BEAM orchestrator app, pending operator call.
+
+**Protocol sketch:**
+
+```text
+POST /v1/effects
+{
+  "effect_type": "file_write" | "command" | "repo_commit" | "service_restart",
+  "surface": "surface://file//absolute/path" | "resident:/..." | "repo://...",
+  "proposer": { "agent_uuid": "...", "identity_assurance": "..." },
+  "provenance": { "harness": "hermes", "session_id": "...", "verification_source": "agent_reported_tool_result" },
+  "payload_ref": "opaque ref or redacted summary",
+  "required_leases": [...]
+}
+```
+
+```text
+202 accepted: {effect_id, status: proposed|held|committed|rejected|revoked}
+4xx typed: {error: schema_invalid|identity_required|lease_held|revoked|governance_blocked}
+```
+
+**Tasks:**
+1. Write the schema and error vocabulary.
+2. Decide the first effect class. Recommended: `file_write` or `repo_commit`, not service restart.
+3. Define what UNITARES records durably (`audit_event`, `outcome_event`, or both).
+4. Define what BEAM owns in memory versus what Postgres owns durably.
+5. Define the rollback mode: bypass plane, shadow plane, or fail-closed.
+
+**Exit criteria:**
+- One effect class is specified end-to-end.
+- No implementation starts until protocol semantics are reviewable.
+
+### Phase 3 — BEAM Thin Slice: Shadow Custody
+
+**Objective:** Prove OTP custody without blocking production effects.
+
+**Files:**
+- Existing candidate: `elixir/agent_orchestrator/` if extending the current orchestrator.
+- New candidate: `elixir/governed_effect_plane/` if separating effect custody from agent orchestration.
+
+**TDD tasks:**
+1. Write ExUnit test: free surface accepts proposed effect and returns `{:ok, effect_id}`.
+2. Write ExUnit test: concurrent proposals for same exclusive surface produce one winner and one typed loser.
+3. Write ExUnit test: revocation moves effect to `revoked` and prevents commit.
+4. Write ExUnit test: crash/restart preserves durable committed/rejected facts or rehydrates pending custody safely.
+5. Implement minimal GenServer + Registry + DynamicSupervisor topology.
+6. Emit telemetry only to a test sink by default.
+
+**Verification:**
+```bash
+cd elixir/<chosen_app>
+mix compile --warnings-as-errors
+mix test
+mix format --check-formatted
+```
+
+**Exit criteria:**
+- Shadow custody works under tests.
+- No production effect is blocked yet.
+- Telemetry contains no secrets and carries lane tags.
+
+### Phase 4 — Enforced Custody for One Low-Blast-Radius Surface
+
+**Objective:** Turn shadow custody into enforcement for exactly one surface.
+
+**Candidate surfaces:**
+1. ~~`resident:/sentinel_cycle` style resident cadence custody.~~ **COLLISION — already live + enforced** (`LEASE_PLANE_ENFORCED_SURFACE_KINDS=resident`, `local_beam` auto-renew). Stacking effect-custody here triples the coordination layers with no reconciliation.
+2. ~~`agent:/<id>` ephemeral agent presence/effect lifecycle.~~ **COLLISION — already a `remote_heartbeat` TTL row** (`http_router.ex:453-458`); `AgentRunner` acquires/releases it in `init/1`/`terminate/2`. Double-gates presence.
+3. **`repo://unitares/doc_update` — RECOMMENDED first surface.** The only candidate with no existing lease/coordination coverage; lowest blast radius and rollback cost. Define lease semantics explicitly.
+
+**Tasks:**
+1. Pick one surface with low rollback cost.
+2. Add a fail-closed feature flag.
+3. Add live-smoke script with explicit bearer config and no secret logging.
+4. Prove acquire → propose → commit/reject → release/revoke.
+5. Document rollback command sequence.
+
+**Verification:**
+- ExUnit full suite passes.
+- Python integration smoke passes.
+- Watchdog/ablation reports show telemetry in its own lane.
+
+**Exit criteria:**
+- One governed-effect path is enforced.
+- Rollback is tested.
+- UNITARES health remains green.
+
+### Phase 5 — Expand Only After Evidence
+
+**Objective:** Expand surfaces only when the narrow lane proves useful.
+
+**Possible next waves:**
+1. agent orchestration effect custody;
+2. resident-agent cadence control;
+3. repo commit / PR merge custody;
+4. service restart custody;
+5. handler dispatch only if Wave 3 gates independently pass.
+
+**Stop signs:**
+- BEAM telemetry again contaminates EISV validation.
+- Runtime plane requires identity issuance rather than consuming explicit UNITARES proof.
+- A Python-side fix collapses the measured problem with lower blast radius.
+- Rollback path is unclear.
+- Cross-runtime boundary adds more substrate tax than it removes.
+
+## Open Questions
+
+1. What is the first effect class worth governing: file write, repo commit, agent spawn, resident cycle, or service restart?
+2. Should governed-effect custody extend the existing `agent_orchestrator` app or be a new OTP app?
+3. Should UNITARES record governed-effect lifecycle as `audit_event`, `outcome_event`, or a dedicated table/event stream?
+4. What is the minimum identity assurance tier for enforced effects?
+5. Which surfaces should stay advisory forever?
+6. What operator UI should show proposed/held/revoked effects?
+
+## Acceptance Criteria for This Dossier
+
+- It distinguishes measurement/instrumentation from diagnosis, governance policy, and enforcement.
+- It uses BEAM for runtime properties, not as a universal rewrite target.
+- It preserves UNITARES as durable truth.
+- It gives the next implementer exact phases, files, tests, and stop signs.
+- It can be amended in place as evidence changes.
+
+## Next Clean Step
+
+Operator decision packet:
+
+```text
+Decision: Do we accept “BEAM governed-effect plane first” as the next BEAM migration boundary?
+Options:
+A. Accept this dossier as the planning boundary.
+B. Amend: pick a different first effect class.
+C. Defer: keep only telemetry hygiene and no new BEAM runtime surface.
+D. Reject: return to the broader Wave 3 handler-dispatch roadmap.
+```


### PR DESCRIPTION
Adds the BEAM governed-effects dossier and indexes it in the proposals README, **amended with a three-member council review** (dialectic-knowledge-architect + feature-dev:code-reviewer + live-verifier) ground-truthed against the running system.

## Council verdict
**Accept the question, reframe the plane, ship only the telemetry phase.** The boundary reasoning holds; the *mechanism* does not — most of the proposed "new Governed-Effect Plane" already exists as live/built BEAM code.

## What the live-verifier confirmed
| Property the dossier wanted to "move to BEAM" | Reality |
|---|---|
| Leases / single-winner conflicts | **Live** — `surface_registry.ex:54-76`, lease plane running on `:8788` |
| Revocation | **Live + enforced** — `POST /v1/lease/force-release` + separate `LEASE_FORCE_RELEASE_TOKEN` (`http_router.ex:205-227`) |
| Supervision / DynamicSupervisor / lease client | **Built but inert** in `agent_orchestrator` (`:8789` not listening, no plist) |
| Telemetry lane tags | Python side shipped (#846); no BEAM-side emitter yet |

So the "new plane" is the `agent_orchestrator` app needing a plist + caller — not a greenfield build. Reframe as a **lease-plane effect-envelope extension**.

## Key amendments folded in
- **Phase 2 load-bearing fork (decide before any Elixir):** does BEAM *execute* the committed effect or only *record* it? `payload_ref` leans record-only, which would make "agents propose, BEAM commits" a relabel.
- **Phase 1 demoted to verification** — already shipped by #846.
- **Repo-qualified Phase 1 paths** (deploy repo, not the server repo the preamble points at) + `cd` guard.
- **Phase 4 collisions flagged:** `resident:/sentinel_cycle` (enforced) and `agent:/<id>` (remote_heartbeat row) already governed; recommend `repo://unitares/doc_update` as the clean first surface.
- **Protocol holes added:** idempotency key, proposer-crash/custody-TTL, `payload_ref` type/size contract.
- **Substrate-tax framing corrected** — #218 ExecutorPool already mitigated asyncpg; Redis is the honest residual.
- **Phases 3–5 gated behind the 2026-06-24 Wave-3 read.**

## Verification
- `python3 scripts/diagnostics/check_doc_health.py` → exit 0 (two pre-existing orphan warnings, unrelated to this change).

Draft because it's on the hot single-writer BEAM/proposals thread and the boundary decision (Phase 0 options A/B/C/D) is the operator's to make.

https://claude.ai/code/session_015Av2ieVjMSfGKttQvodkCj