### PR TITLE
feat(security): align REST auth with the /mcp bearer gate

### DIFF
--- a/src/http_api.py
+++ b/src/http_api.py
@@ -36,6 +36,7 @@ from src.metrics_registry import (
 )
 from src.broadcaster import broadcaster_instance
 from src.services.http_tool_service import execute_http_tool
+from src.mcp_listen_config import check_mcp_bearer, mcp_bearer_required
 
 if TYPE_CHECKING:
     from starlette.applications import Starlette
@@ -177,14 +178,33 @@ def _http_unauthorized():
         {
             "success": False,
             "error": "Unauthorized",
-            "hint": "Set UNITARES_HTTP_API_TOKEN in your environment and pass it as: Authorization: Bearer <token>",
+            "hint": "Provide a valid bearer token: Authorization: Bearer <token>. Tokens come from UNITARES_MCP_BEARER_TOKENS (hosted) or UNITARES_HTTP_API_TOKEN (local).",
         },
         status_code=401,
     )
 
 
 def _check_http_auth(request, *, http_api_token: str | None) -> bool:
-    """Bearer token auth for HTTP endpoints. Trusted networks bypass auth."""
+    """Bearer token auth for HTTP endpoints.
+
+    Hosted mode — when ``UNITARES_MCP_BEARER_TOKENS`` is configured, the REST
+    surface inherits the strict ``/mcp`` posture: a valid bearer is required and
+    the trusted-network bypass does **not** apply. This closes a real gap: the
+    trusted set includes every RFC1918 range (10/8, 192.168/16, 172.16/12) plus
+    Tailscale, so a hosted server behind a cloud proxy (source IP typically
+    ``10.x``) would otherwise bypass auth on the write path. Same token, same
+    rule, both transports.
+
+    Local / self-host default — no MCP bearer configured: the legacy posture
+    stands. Trusted networks bypass, and the optional ``UNITARES_HTTP_API_TOKEN``
+    gates the rest.
+    """
+    # Hosted posture: the MCP bearer governs every transport; no IP bypass.
+    if mcp_bearer_required():
+        auth = request.headers.get("authorization") or request.headers.get("Authorization")
+        return check_mcp_bearer(auth)
+
+    # Legacy / local posture.
     if _is_trusted_network(request):
         return True
     if not http_api_token:
@@ -2783,6 +2803,9 @@ async def websocket_eisv_stream(websocket):
 
 async def http_debug_memory(request):
     """Top memory allocations via tracemalloc (if enabled)."""
+    # Debug endpoint — leaks internal paths/allocations; never serve it open.
+    if not _check_http_auth(request, http_api_token=os.getenv("UNITARES_HTTP_API_TOKEN")):
+        return _http_unauthorized()
     import tracemalloc
     if not tracemalloc.is_tracing():
         return JSONResponse({"error": "tracemalloc not enabled"}, status_code=503)

--- a/src/mcp_listen_config.py
+++ b/src/mcp_listen_config.py
@@ -125,9 +125,13 @@ def check_mcp_bearer(
         allow = mcp_bearer_tokens()
     if not allow:
         return True  # gate off — default posture
-    if not authorization_header or not authorization_header.startswith("Bearer "):
+    if not authorization_header:
         return False
-    presented = authorization_header[len("Bearer "):].strip()
+    # RFC 7235: the auth scheme is case-insensitive. Accept "Bearer"/"bearer"/etc.
+    scheme, _, presented = authorization_header.partition(" ")
+    if scheme.lower() != "bearer":
+        return False
+    presented = presented.strip()
     if not presented:
         return False
     # Constant-time membership test over a small allowlist.

--- a/tests/test_mcp_bearer_gate.py
+++ b/tests/test_mcp_bearer_gate.py
@@ -50,13 +50,18 @@ def test_valid_bearer_accepted(monkeypatch):
         "Bearer ",                  # scheme but empty token
         "Bearer wrong",             # wrong token
         "Basic s3cret",             # wrong scheme
-        "bearer s3cret",            # case-sensitive scheme (RFC says token68 scheme is case-insensitive,
-                                    # but we require the canonical "Bearer " prefix the clients send)
     ],
 )
 def test_invalid_bearer_rejected_when_gate_on(monkeypatch, header):
     monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "s3cret")
     assert cfg.check_mcp_bearer(header) is False
+
+
+@pytest.mark.parametrize("header", ["Bearer s3cret", "bearer s3cret", "BEARER s3cret"])
+def test_bearer_scheme_is_case_insensitive(monkeypatch, header):
+    # RFC 7235: the auth scheme is case-insensitive. Real clients send "bearer".
+    monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "s3cret")
+    assert cfg.check_mcp_bearer(header) is True
 
 
 def test_token_rotation_accepts_any_listed(monkeypatch):

--- a/tests/test_rest_auth_align.py
+++ b/tests/test_rest_auth_align.py
@@ -1,0 +1,79 @@
+"""REST auth alignment with the /mcp bearer gate.
+
+The /mcp transport (bearer gate, #847) and the REST tool-call surface reach the
+same tools. Before, REST bypassed auth for any trusted network — which includes
+every RFC1918 range, so a hosted server behind a cloud proxy (source IP ~10.x)
+would bypass the write path. These tests pin the aligned posture: when the
+hosted bearer (UNITARES_MCP_BEARER_TOKENS) is set, REST requires it with NO
+trusted-network bypass; otherwise the legacy local posture is unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.http_api import _check_http_auth
+
+
+class _Req:
+    """Minimal stand-in for a Starlette request: .headers.get + .client.host."""
+
+    def __init__(self, ip: str = "10.1.2.3", auth: str | None = None):
+        self.headers = {"authorization": auth} if auth is not None else {}
+        self.client = type("C", (), {"host": ip})()
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("UNITARES_MCP_BEARER_TOKENS", raising=False)
+    monkeypatch.delenv("UNITARES_HTTP_API_TOKEN", raising=False)
+    yield
+
+
+# ---- Hosted mode: MCP bearer configured -> strict, no IP bypass ----
+
+def test_hosted_trusted_ip_without_bearer_is_rejected(monkeypatch):
+    # The core fix: a 10.x cloud-internal peer must NOT bypass auth when hosted.
+    monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "s3cret")
+    assert _check_http_auth(_Req(ip="10.1.2.3", auth=None), http_api_token=None) is False
+
+
+def test_hosted_valid_bearer_is_accepted(monkeypatch):
+    monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "s3cret")
+    assert _check_http_auth(_Req(ip="10.1.2.3", auth="Bearer s3cret"), http_api_token=None) is True
+
+
+def test_hosted_lowercase_bearer_accepted(monkeypatch):
+    # REST historically accepted case-insensitive "bearer "; the aligned gate
+    # must not regress that (RFC 7235 — scheme is case-insensitive).
+    monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "s3cret")
+    assert _check_http_auth(_Req(ip="10.1.2.3", auth="bearer s3cret"), http_api_token=None) is True
+
+
+def test_hosted_wrong_bearer_is_rejected(monkeypatch):
+    monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "s3cret")
+    assert _check_http_auth(_Req(ip="127.0.0.1", auth="Bearer nope"), http_api_token=None) is False
+
+
+def test_hosted_localhost_still_needs_bearer(monkeypatch):
+    # Even localhost gets no free pass in hosted mode.
+    monkeypatch.setenv("UNITARES_MCP_BEARER_TOKENS", "s3cret")
+    assert _check_http_auth(_Req(ip="127.0.0.1", auth=None), http_api_token=None) is False
+
+
+# ---- Local default: no MCP bearer -> legacy posture unchanged ----
+
+def test_local_trusted_network_bypasses(monkeypatch):
+    assert _check_http_auth(_Req(ip="192.168.1.5", auth=None), http_api_token=None) is True
+
+
+def test_local_untrusted_no_token_allows(monkeypatch):
+    # Default-off: no token configured -> open (unchanged legacy behavior).
+    assert _check_http_auth(_Req(ip="8.8.8.8", auth=None), http_api_token=None) is True
+
+
+def test_local_untrusted_with_token_enforced(monkeypatch):
+    req_ok = _Req(ip="8.8.8.8", auth="Bearer localtok")
+    req_bad = _Req(ip="8.8.8.8", auth="Bearer wrong")
+    assert _check_http_auth(req_ok, http_api_token="localtok") is True
+    assert _check_http_auth(req_bad, http_api_token="localtok") is False


### PR DESCRIPTION
Clean re-creation of #858 (which got tangled in duplicate history after #847/#850 squash-merged). Single commit on top of current master — no stacking.

## Why
#847 gated `/mcp`, but the REST surface reaches the **same tools**, and `POST /v1/tools/call` can invoke any tool — **writes included**. `_check_http_auth` bypassed auth for any *trusted network*, and that set is every RFC1918 range (`10/8`, `192.168/16`, `172.16/12`) + Tailscale. So a hosted server behind a cloud proxy (peer IP ~`10.x`) would **bypass auth on the write path entirely**.

## What
- **`_check_http_auth`** — hosted mode (`UNITARES_MCP_BEARER_TOKENS` set): require the same bearer as `/mcp`, **drop the trusted-network bypass**. Local default (no bearer): legacy posture **byte-identical**.
- **`check_mcp_bearer`** — accept a **case-insensitive** auth scheme (RFC 7235); REST historically accepted lowercase `bearer ` and we must not regress that. (Also improves `/mcp`.)
- **Gate `/debug/memory`** — was open in every mode; leaks `tracemalloc` paths/allocations.

## Review provenance
Adversarial review of the original cut found the case-sensitivity regression and the open `/debug/memory` — both fixed here. Core write-path gate confirmed fail-closed; local mode unchanged.

## Tests
`test_rest_auth_align.py` (hosted: trusted-IP-without-bearer rejected, valid/lowercase bearer accepted, wrong/none rejected, localhost still gated; local: bypass + token unchanged) + case-insensitive `check_mcp_bearer` tests. 32 in the affected set pass; ruff clean.

## Follow-up (operator decision, not here)
Review also found `/v1/eisv/latest`, `/v1/eisv/recent`, `/api/activity`, `/health/deep` are unauthenticated reads. Gating them is a product call (intentionally public for dashboards/probes?) — left for you.

Security-sensitive; **draft** for review + merge.