### PR TITLE
docs(proposals): dossier dual-mode decision + first-effect-class vehicle fork

### DIFF
--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -25,7 +25,7 @@ Several of these are **single-writer surfaces** (see the shared contract in `AGE
 | [`beam-wave-3-handler-dispatch.md`](beam-wave-3-handler-dispatch.md) | v0.3.2 — active redraft; supersedes v0.2/v0.1.x |
 | [`beam-wave-3a-read-only-handlers.md`](beam-wave-3a-read-only-handlers.md) | v0.2 — council-fold complete; operator review pending |
 | [`agent-orchestrator-beam-v0.md`](agent-orchestrator-beam-v0.md) | v0 thin slice — council-reviewed library + smoke, not merged to any running surface |
-| [`beam-governed-effects-dossier-2026-06-18.md`](beam-governed-effects-dossier-2026-06-18.md) | Draft dossier + phased plan — narrows current evidence to BEAM as governed-effect / runtime-custody plane, not whole-governance rewrite |
+| [`beam-governed-effects-dossier-2026-06-18.md`](beam-governed-effects-dossier-2026-06-18.md) | Draft dossier + phased plan — narrows current evidence to BEAM as dual-mode record/execute governed-effect runtime custody, not whole-governance rewrite |
 | [`wave-3-section-5-2-boundary-audit-summary.md`](wave-3-section-5-2-boundary-audit-summary.md) | CI-checkable §5.2 boundary-cost audit summary (2026-06-10), required before `elixir/handler_dispatch/` commits |
 
 ### Operator-vision delegation / identity hardening

--- a/docs/proposals/beam-governed-effects-dossier-2026-06-18.md
+++ b/docs/proposals/beam-governed-effects-dossier-2026-06-18.md
@@ -4,7 +4,7 @@
 
 **Created:** June 18, 2026  
 **Last Updated:** June 18, 2026  
-**Status:** Draft dossier + implementation plan — **amended post-council 2026-06-18 (see Council Amendment below)**
+**Status:** Draft dossier + implementation plan — **amended post-council and operator dual-mode decision 2026-06-18 (see Council Amendment below)**
 
 ---
 
@@ -17,7 +17,10 @@ A three-member council (dialectic + code-review + live-verifier) reviewed this d
    - **Revocation:** live **and enforced** — `POST /v1/lease/force-release` (`http_router.ex:205-227`) gated by a separate `LEASE_FORCE_RELEASE_TOKEN`; the regular bearer is barred. Evidence §1 below mis-frames revocation as a gap; it is already solved. *(Strike that framing.)*
    - **Supervision / DynamicSupervisor / lease client:** already built in `elixir/agent_orchestrator/` (`agent_supervisor.ex`, `agent_runner.ex`, `lease_plane_client.ex`) — but **inert** (`:8789` not listening, no plist, nothing spawns through it). The "new governed-effect plane" is this app needing a plist + a caller, not a greenfield build. Do **not** create `elixir/governed_effect_plane/`.
 
-2. **The load-bearing undecided question — answer it in Phase 2 before any Elixir:** *Does BEAM **execute** the committed effect, or only **record** the proposal?* A lease is custody of a *surface*; an effect is custody of a *transition* (payload + a commit veto on non-exclusivity grounds). But this dossier assigns the novel half (`governance_blocked`) to UNITARES, leaving BEAM's share isomorphic to a lease. The new safety property ("agents propose, BEAM commits") exists **iff BEAM is the executing party**. The protocol sketch's `payload_ref` (a *reference*, not bytes) leans toward record-only, which would make the thesis a relabel. Decide this fork first.
+2. **Operator resolution of the execute/record fork: BEAM can do both, but the modes must be explicit.** This is no longer a binary choice. The protocol must carry a per-effect `custody_mode`:
+   - `record_only` / shadow mode: BEAM receives the proposal, checks identity/provenance shape, may acquire/observe leases, emits typed telemetry/audit, and returns a durable `effect_id`; the original caller or some external actor still executes. This is useful for migration, dry-run, replay, and learning, but it must not borrow "BEAM committed" language.
+   - `execute` / enforced mode: BEAM becomes the executor/committer. It owns the bounded payload or command contract, holds required leases, can veto on `governance_blocked`, and emits the final committed/rejected/revoked fact. The new safety property ("agents propose, BEAM commits") exists in this mode.
+   - Phase 2 therefore decides **mode per effect class**, not a single permanent answer. `repo://unitares/doc_update` can start record-only, then promote to execute once payload/idempotency/rollback are specified.
 
 3. **Phase 1 is already fully shipped by PR #846 — demote it to verification.** `harness_lane_from_detail()`, `DEFAULT_EXCLUDED_HARNESS_LANES=("beam",)`, both negative-control tests, and BEAM emitter-disable in test configs all exist and pass. Do not re-implement.
 
@@ -29,11 +32,11 @@ A three-member council (dialectic + code-review + live-verifier) reviewed this d
 
 7. **Substrate-tax framing is overstated.** PR #218's `ExecutorPool` already mitigated the asyncpg ~60× amplification; the honest residual is **Redis** (still unwrapped). Cite the mitigation, not just the wound — and note this is the dossier's *positive* case for BEAM-on-this-class, currently omitted.
 
-8. **Sequence behind the 2026-06-24 Wave-3 gate.** The effect plane coordinates against the same `core` tables A′ deferred, riding an inert orchestrator. Phase 1 (telemetry hygiene, already shipped) is the only part that proceeds now; Phases 3–5 gate behind both the execute/record decision (#2) and the gate read.
+8. **Sequence behind the 2026-06-24 Wave-3 gate.** The effect plane coordinates against the same `core` tables A′ deferred, riding an inert orchestrator. Phase 1 (telemetry hygiene, already shipped) is the only part that proceeds immediately; Phase 2 can proceed as a design-only dual-mode contract. Phases 3–5 gate behind the dual-mode contract, a named first execute-mode surface, and the 2026-06-24 gate read.
 
-Rhetoric to strike until #2 is answered: **"membrane"** and **"effect custody"** as control-of-*act* both assert a property the design hasn't bought (they currently describe a logbook). The load-bearing, surviving content is the typed-denial vocabulary, the provenance lane-tags, and the rollback discipline.
+Rhetoric discipline after the operator decision: **"membrane"** and **"effect custody"** are valid only when the effect is in `execute` mode. In `record_only` mode, call it shadow custody, audit, or proposal logging. Do not let record-only telemetry borrow commit/execution language.
 
-Decision-packet mapping: this is **Option B (amend)** sharpened toward **Option C (telemetry hygiene only, no new runtime surface yet)**. The sections below are preserved as originally written; read them through this amendment.
+Decision-packet mapping: this is **Option B (amend)** with an operator clarification: BEAM supports both record-only and execute modes. Phase 1 remains shipped telemetry hygiene; Phase 2 becomes the dual-mode protocol contract; runtime Phases 3–5 remain gated until the first execute-mode effect class and rollback path are named. The sections below are preserved as originally written; read them through this amendment.
 
 ---
 
@@ -192,13 +195,19 @@ PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/
 
 ### Phase 2 — Governed-Effect Protocol Contract
 
-**Objective:** Define one protocol before building runtime machinery.
+**Objective:** Define the dual-mode governed-effect protocol before building runtime machinery.
 
-> **Council amendment — answer this fork FIRST, before any Elixir:** *Does BEAM **execute** the committed effect, or only **record** the proposal?* If execute → there is a real new safety property (mediated effect execution; `governance_blocked` can stop a side-effect a lease-holder would otherwise just *do*) and the `payload` must be the actual bytes/command, not a ref. If record-only → this is advisory bookkeeping and should be an audit feature, not an enforcement plane. The `payload_ref` sketch below leans record-only; reconcile it with this decision. Three more holes the protocol must close: **(a) idempotency key** — a proposer-supplied UUID/content-hash so a retry after timeout returns the existing `effect_id` instead of minting a second and racing the surface (the lease plane already does idempotent re-acquire, `repo.ex:8,38`); **(b) proposer-crash-after-202** — specify the custody TTL for `proposed`/`held` effects, whether it derives from `required_leases` TTL or is independent, and who heartbeats; **(c) `payload_ref` type/size contract** — hash vs URL vs redacted-summary-string with a max length, reconciled with Invariant 7 (no secret leakage).
+> **Operator amendment — BEAM can do both:** Phase 2 no longer chooses "execute vs record" globally. It specifies both modes and requires every effect class to declare which mode it is in. `record_only` mode is advisory/shadow custody: proposal logging, idempotent effect ids, lease observation/acquire if useful, typed telemetry, and no claim that BEAM committed the side effect. `execute` mode is enforcement: BEAM owns the bounded payload or command contract, holds required leases, can veto on `governance_blocked`, and performs or delegates the commit under OTP supervision. Three protocol holes remain mandatory before any execute-mode code: **(a) idempotency key** — a proposer-supplied UUID/content-hash so retry after timeout returns the existing `effect_id`; **(b) proposer-crash-after-202** — custody TTL and heartbeat rules for `proposed`/`held` effects; **(c) payload contract** — mode-specific type, hash, size limit, and redaction rules reconciled with no-secret leakage.
+
+> **Council note — the first effect class picks the *vehicle*, and they are different code:** "extend `agent_orchestrator`" is correct for *one* effect class, not all of them. The orchestrator's native effect is **spawn / await / kill an ephemeral agent** — that is the surface it already models (`AgentRunner` + `Port.open`, `agent:/<id>` presence lease). A *content* effect like `repo://unitares/doc_update` is **not** an orchestrator concern; it belongs on the **lease-plane effect-envelope extension** (a `payload`/`commit_status` envelope on a lease), and the orchestrator stays uninvolved. So the vehicle is determined by the chosen first effect class:
+> - **First effect = agent-spawn** → vehicle is `agent_orchestrator`, which is **built but inert** (`:8789` not listening, no plist). De-inerting it is cheap and mechanical (launchd plist mirroring the lease-plane's + set `AGENT_ORCHESTRATOR_BEARER_TOKEN`; it already has `start.sh`, a fail-closed bearer-gated control surface, and lease integration). The real cost is that this stands up a localhost endpoint that **spawns OS processes** (RCE-class surface if the bearer leaks) — which is *why* it's fail-closed and why "turn it on" needs a real caller, not just a plist.
+> - **First effect = a content surface (e.g. `doc_update`)** → vehicle is the **lease-plane envelope extension**; the orchestrator is not touched and stays inert until separately needed.
+>
+> Phase 2 must therefore name the first effect class *before* deciding which app to write, and the "extend agent_orchestrator" line below applies **only** if that class is agent-spawn.
 
 **Files:**
 - Create: `docs/proposals/governed-effect-plane-v0.md` or append an accepted protocol section here.
-- Potential future code: `elixir/governed_effect_plane/` or extension of the existing BEAM orchestrator app, pending operator call.
+- Potential future code, **vehicle-dependent on the first effect class (see council note above):** for an **agent-spawn** effect, extend `elixir/agent_orchestrator/` (and stand up its launchd plist + bearer). For a **content** effect (`doc_update` etc.), extend the lease plane with an effect envelope rather than the orchestrator. Do **not** create `elixir/governed_effect_plane/` unless a later council explicitly rejects both extension paths.
 
 **Protocol sketch:**
 
@@ -206,45 +215,57 @@ PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/
 POST /v1/effects
 {
   "effect_type": "file_write" | "command" | "repo_commit" | "service_restart",
+  "custody_mode": "record_only" | "execute",
+  "executor": "caller" | "beam",
+  "idempotency_key": "proposer-scoped UUID or content hash",
+  "custody_ttl_ms": 120000,
   "surface": "surface://file//absolute/path" | "resident:/..." | "repo://...",
   "proposer": { "agent_uuid": "...", "identity_assurance": "..." },
   "provenance": { "harness": "hermes", "session_id": "...", "verification_source": "agent_reported_tool_result" },
-  "payload_ref": "opaque ref or redacted summary",
+  "payload": {
+    "kind": "redacted_summary" | "artifact_ref" | "inline_text" | "command_argv" | "repo_patch_ref",
+    "sha256": "...",
+    "max_bytes": 65536,
+    "ref": "optional ref for record_only or artifact-backed execute"
+  },
   "required_leases": [...]
 }
 ```
 
 ```text
-202 accepted: {effect_id, status: proposed|held|committed|rejected|revoked}
-4xx typed: {error: schema_invalid|identity_required|lease_held|revoked|governance_blocked}
+202 accepted: {effect_id, custody_mode, executor, status: proposed|recorded|held|executing|committed|rejected|revoked}
+4xx typed: {error: schema_invalid|identity_required|lease_held|revoked|governance_blocked|payload_too_large|idempotency_conflict}
 ```
 
 **Tasks:**
-1. Write the schema and error vocabulary.
-2. Decide the first effect class. Recommended: `file_write` or `repo_commit`, not service restart.
-3. Define what UNITARES records durably (`audit_event`, `outcome_event`, or both).
+1. Write the dual-mode schema and error vocabulary.
+2. Decide the first `record_only` surface and the first `execute` surface. Recommended path: `repo://unitares/doc_update` starts `record_only`, then promotes to `execute` once payload and rollback semantics are specified.
+3. Define what UNITARES records durably (`audit_event`, `outcome_event`, or both) for each mode.
 4. Define what BEAM owns in memory versus what Postgres owns durably.
-5. Define the rollback mode: bypass plane, shadow plane, or fail-closed.
+5. Define rollback mode by custody mode: bypass plane, shadow plane, or fail-closed.
+6. Add an explicit rule: `record_only` status may become `recorded`, but never `committed`; `committed` is reserved for `execute` mode.
 
 **Exit criteria:**
-- One effect class is specified end-to-end.
+- One record-only effect class and one execute-mode candidate are specified end-to-end.
+- Idempotency, custody TTL, and payload limits are specified.
 - No implementation starts until protocol semantics are reviewable.
 
-### Phase 3 — BEAM Thin Slice: Shadow Custody
+### Phase 3 — BEAM Thin Slice: Dual-Mode Shadow + Execute Dry Run
 
-**Objective:** Prove OTP custody without blocking production effects.
+**Objective:** Prove OTP custody in both modes without blocking production effects.
 
 **Files:**
-- Existing candidate: `elixir/agent_orchestrator/` if extending the current orchestrator.
-- New candidate: `elixir/governed_effect_plane/` if separating effect custody from agent orchestration.
+- Existing candidate: extend `elixir/agent_orchestrator/`; it already owns supervised Ports, `DynamicSupervisor`, and the lease-plane client.
+- Do **not** create a new OTP app unless the Phase 2 contract proves `agent_orchestrator` is the wrong host.
 
 **TDD tasks:**
-1. Write ExUnit test: free surface accepts proposed effect and returns `{:ok, effect_id}`.
-2. Write ExUnit test: concurrent proposals for same exclusive surface produce one winner and one typed loser.
-3. Write ExUnit test: revocation moves effect to `revoked` and prevents commit.
-4. Write ExUnit test: crash/restart preserves durable committed/rejected facts or rehydrates pending custody safely.
-5. Implement minimal GenServer + Registry + DynamicSupervisor topology.
-6. Emit telemetry only to a test sink by default.
+1. Write ExUnit test: `record_only` proposal returns stable `effect_id`, status `recorded`, and never reports `committed`.
+2. Write ExUnit test: `execute` dry-run proposal acquires required lease, transitions `held -> executing -> committed|rejected`, and emits final telemetry.
+3. Write ExUnit test: concurrent proposals for same exclusive surface produce one winner and one typed loser.
+4. Write ExUnit test: revocation moves effect to `revoked` and prevents execute-mode commit.
+5. Write ExUnit test: crash/restart preserves durable recorded/committed/rejected facts or rehydrates pending custody safely.
+6. Implement minimal GenServer + Registry extension using existing orchestrator supervision.
+7. Emit telemetry only to a test sink by default.
 
 **Verification:**
 ```bash
@@ -259,9 +280,9 @@ mix format --check-formatted
 - No production effect is blocked yet.
 - Telemetry contains no secrets and carries lane tags.
 
-### Phase 4 — Enforced Custody for One Low-Blast-Radius Surface
+### Phase 4 — Enforced Execute Mode for One Low-Blast-Radius Surface
 
-**Objective:** Turn shadow custody into enforcement for exactly one surface.
+**Objective:** Promote one record-only surface into BEAM-executed enforcement.
 
 **Candidate surfaces:**
 1. ~~`resident:/sentinel_cycle` style resident cadence custody.~~ **COLLISION — already live + enforced** (`LEASE_PLANE_ENFORCED_SURFACE_KINDS=resident`, `local_beam` auto-renew). Stacking effect-custody here triples the coordination layers with no reconciliation.
@@ -269,10 +290,10 @@ mix format --check-formatted
 3. **`repo://unitares/doc_update` — RECOMMENDED first surface.** The only candidate with no existing lease/coordination coverage; lowest blast radius and rollback cost. Define lease semantics explicitly.
 
 **Tasks:**
-1. Pick one surface with low rollback cost.
-2. Add a fail-closed feature flag.
+1. Pick one low-rollback surface and run it in `record_only` first.
+2. Add a fail-closed feature flag for `execute` promotion.
 3. Add live-smoke script with explicit bearer config and no secret logging.
-4. Prove acquire → propose → commit/reject → release/revoke.
+4. Prove acquire → propose → execute/commit-or-reject → release/revoke.
 5. Document rollback command sequence.
 
 **Verification:**
@@ -305,12 +326,12 @@ mix format --check-formatted
 
 ## Open Questions
 
-1. What is the first effect class worth governing: file write, repo commit, agent spawn, resident cycle, or service restart?
-2. Should governed-effect custody extend the existing `agent_orchestrator` app or be a new OTP app?
+1. Which effect class becomes the first `record_only` shadow: repo doc update, repo commit proposal, or agent spawn? *(This also picks the vehicle — see the Phase 2 council note: agent-spawn → de-inert `agent_orchestrator`; content effects → lease-plane envelope extension. They are different code.)*
+2. Which effect class becomes the first `execute` promotion candidate after record-only evidence?
 3. Should UNITARES record governed-effect lifecycle as `audit_event`, `outcome_event`, or a dedicated table/event stream?
-4. What is the minimum identity assurance tier for enforced effects?
-5. Which surfaces should stay advisory forever?
-6. What operator UI should show proposed/held/revoked effects?
+4. What is the minimum identity assurance tier for enforced execute-mode effects?
+5. Which surfaces should stay advisory/record-only forever?
+6. What operator UI should show proposed/recorded/held/executing/committed/revoked effects?
 
 ## Acceptance Criteria for This Dossier
 
@@ -325,10 +346,11 @@ mix format --check-formatted
 Operator decision packet:
 
 ```text
-Decision: Do we accept “BEAM governed-effect plane first” as the next BEAM migration boundary?
+Decision already amended: BEAM can do both record and execute.
+Next decision: which effect class gets the first dual-mode protocol?
 Options:
-A. Accept this dossier as the planning boundary.
-B. Amend: pick a different first effect class.
-C. Defer: keep only telemetry hygiene and no new BEAM runtime surface.
-D. Reject: return to the broader Wave 3 handler-dispatch roadmap.
+A. repo://unitares/doc_update — record_only first, promote to execute after payload/rollback proof.
+B. repo commit / PR merge proposal — higher value, higher blast radius; record_only only at first.
+C. agent spawn/effect lifecycle — extend AgentOrchestrator presence into effect proposals.
+D. Defer execute mode until after the 2026-06-24 Wave-3 gate; keep only record_only design.
 ```


### PR DESCRIPTION
Follow-up to #857 (merged). #857 landed the council amendment but predated the operator's **dual-mode decision** on the execute/record fork — so master currently frames that fork as *unresolved* when it's actually been decided. This PR brings master current.

## What this adds on top of #857
1. **Operator dual-mode resolution.** The execute-vs-record fork is no longer binary: every effect class declares a per-effect `custody_mode`:
   - `record_only` (shadow/advisory): proposal logging, idempotent `effect_id`, optional lease observation, typed telemetry — **no claim BEAM committed the side effect**.
   - `execute` (enforcement): BEAM owns the payload/command contract, holds leases, can veto on `governance_blocked`, performs/delegates the commit under OTP supervision.
   - Phase 2 decides mode **per effect class**; `repo://unitares/doc_update` can start record-only then promote.
2. **Council clarification — the first effect class picks the *vehicle*, and they're different code:**
   - **agent-spawn** effect → extend `agent_orchestrator` (built but **inert** at `:8789`; de-inerting is a launchd plist + bearer, but stands up an OS-process-spawning endpoint = RCE-class surface, hence fail-closed).
   - **content** effect (`doc_update` etc.) → **lease-plane effect envelope**; orchestrator untouched, stays inert.
   - Open Question 1 is coupled to this; the Phase 2 "extend agent_orchestrator" line is scoped to the agent-spawn class only, so an implementer doesn't de-inert the orchestrator for a content effect that doesn't belong there.

## Provenance note
The operator's dual-mode edit was uncommitted when a concurrent fast-forward moved the deploy worktree to detached HEAD; it was preserved by the session-end auto-stash and recovered here. This branch is cut fresh from current master (the original #857 branch was built off a stale base and would have reverted #851's dashboard work).

## Verification
- `python3 scripts/diagnostics/check_doc_health.py` → exit 0.
- Diff vs master is exactly the dossier + README index line — no unrelated reverts.

Draft because the Phase 0 boundary decision (and now the first-effect-class / vehicle choice) is operator authority.

https://claude.ai/code/session_015Av2ieVjMSfGKttQvodkCj