### PR TITLE
fix(analysis): harden dogfood ablation evidence gates

### DIFF
--- a/scripts/analysis/eisv_ablation_matrix.py
+++ b/scripts/analysis/eisv_ablation_matrix.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import random
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -33,6 +34,8 @@ from scripts.analysis.eisv_skeptic_report import (
     TASK_OUTCOMES,
     ModelScore,
     OutcomeRow,
+    auc_score,
+    brier_score,
     build_model_scores,
     fetch_rows,
     score_deltas_vs_baseline,
@@ -41,6 +44,16 @@ from scripts.analysis.eisv_skeptic_report import (
 from scripts.analysis.outcome_inventory import harness_lane_from_detail
 
 DEFAULT_EXCLUDED_HARNESS_LANES = ("beam",)
+
+
+@dataclass(frozen=True)
+class DeltaUncertainty:
+    """Bootstrap/permutation uncertainty for one paired candidate delta."""
+
+    paired_n: int
+    auc_delta_ci: tuple[float, float] | None
+    brier_improvement_ci: tuple[float, float] | None
+    brier_permutation_p: float | None
 
 
 @dataclass(frozen=True)
@@ -59,6 +72,9 @@ class AblationMatrixRow:
     best_brier_improvement: float | None
     beats_both: bool
     conclusion: str
+    best_auc_delta_ci: tuple[float, float] | None = None
+    best_brier_improvement_ci: tuple[float, float] | None = None
+    best_brier_permutation_p: float | None = None
 
 
 def _fmt_float(value: float | None, digits: int = 3) -> str:
@@ -71,8 +87,131 @@ def _fmt_lead(value: float) -> str:
     return f"{value:g}"
 
 
+def _fmt_ci(value: tuple[float, float] | None, digits: int) -> str:
+    if value is None:
+        return "-"
+    low, high = value
+    return f"[{low:.{digits}f}, {high:.{digits}f}]"
+
+
 def _baseline(scores: Sequence[ModelScore]) -> ModelScore | None:
     return next((score for score in scores if score.name == "previous_outcome_bad"), None)
+
+
+def _paired_vectors(
+    baseline: ModelScore,
+    candidate: ModelScore,
+) -> tuple[list[int], list[float], list[float], list[float], list[float]]:
+    """Return paired y/candidate/baseline vectors over candidate-covered rows."""
+
+    baseline_by_key = {key: idx for idx, key in enumerate(baseline.scored_row_keys)}
+    y_true: list[int] = []
+    candidate_prob: list[float] = []
+    candidate_auc_score: list[float] = []
+    baseline_prob: list[float] = []
+    baseline_auc_score: list[float] = []
+    for candidate_idx, key in enumerate(candidate.scored_row_keys):
+        baseline_idx = baseline_by_key.get(key)
+        if baseline_idx is None:
+            continue
+        if baseline.y_true[baseline_idx] != candidate.y_true[candidate_idx]:
+            continue
+        y_true.append(candidate.y_true[candidate_idx])
+        candidate_prob.append(candidate.y_prob[candidate_idx])
+        candidate_auc_score.append(candidate.y_auc_score[candidate_idx])
+        baseline_prob.append(baseline.y_prob[baseline_idx])
+        baseline_auc_score.append(baseline.y_auc_score[baseline_idx])
+    return y_true, candidate_prob, candidate_auc_score, baseline_prob, baseline_auc_score
+
+
+def _percentile(values: Sequence[float], fraction: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    pos = (len(ordered) - 1) * fraction
+    lower = int(pos)
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = pos - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+def estimate_delta_uncertainty(
+    baseline: ModelScore,
+    candidate: ModelScore,
+    *,
+    resamples: int = 200,
+    seed: int = 0,
+    confidence: float = 0.95,
+) -> DeltaUncertainty | None:
+    """Estimate paired delta uncertainty with bootstrap CIs and permutation p.
+
+    The bootstrap resamples paired rows with replacement and reports confidence
+    intervals for AUC delta and Brier improvement. The permutation p-value is a
+    paired sign-flip test over per-row Brier improvements.
+    """
+
+    y_true, candidate_prob, candidate_auc, baseline_prob, baseline_auc = _paired_vectors(
+        baseline,
+        candidate,
+    )
+    n = len(y_true)
+    if n == 0 or resamples <= 0:
+        return None
+
+    rng = random.Random(seed)
+    auc_deltas: list[float] = []
+    brier_improvements: list[float] = []
+    for _ in range(resamples):
+        sample_indices = [rng.randrange(n) for _ in range(n)]
+        sample_true = [y_true[idx] for idx in sample_indices]
+        sample_candidate_prob = [candidate_prob[idx] for idx in sample_indices]
+        sample_candidate_auc = [candidate_auc[idx] for idx in sample_indices]
+        sample_baseline_prob = [baseline_prob[idx] for idx in sample_indices]
+        sample_baseline_auc = [baseline_auc[idx] for idx in sample_indices]
+        candidate_auc_value = auc_score(sample_true, sample_candidate_auc)
+        baseline_auc_value = auc_score(sample_true, sample_baseline_auc)
+        if candidate_auc_value is not None and baseline_auc_value is not None:
+            auc_deltas.append(candidate_auc_value - baseline_auc_value)
+        candidate_brier = brier_score(sample_true, sample_candidate_prob)
+        baseline_brier = brier_score(sample_true, sample_baseline_prob)
+        if candidate_brier is not None and baseline_brier is not None:
+            brier_improvements.append(baseline_brier - candidate_brier)
+
+    alpha = (1.0 - confidence) / 2.0
+    auc_ci = None
+    if auc_deltas:
+        low = _percentile(auc_deltas, alpha)
+        high = _percentile(auc_deltas, 1.0 - alpha)
+        auc_ci = None if low is None or high is None else (low, high)
+    brier_ci = None
+    if brier_improvements:
+        low = _percentile(brier_improvements, alpha)
+        high = _percentile(brier_improvements, 1.0 - alpha)
+        brier_ci = None if low is None or high is None else (low, high)
+
+    per_row_improvements = [
+        (base - truth) ** 2 - (cand - truth) ** 2
+        for truth, cand, base in zip(y_true, candidate_prob, baseline_prob)
+    ]
+    observed = sum(per_row_improvements) / n
+    extreme = 0
+    for _ in range(resamples):
+        null_mean = sum(
+            value if rng.choice((True, False)) else -value
+            for value in per_row_improvements
+        ) / n
+        if abs(null_mean) >= abs(observed):
+            extreme += 1
+    permutation_p = (extreme + 1) / (resamples + 1)
+
+    return DeltaUncertainty(
+        paired_n=n,
+        auc_delta_ci=auc_ci,
+        brier_improvement_ci=brier_ci,
+        brier_permutation_p=permutation_p,
+    )
 
 
 def filter_rows_for_validation(
@@ -102,6 +241,8 @@ def build_matrix_row(
     lead_minutes: float,
     train_fraction: float = 0.7,
     min_feature_rows: int = 30,
+    uncertainty_resamples: int = 0,
+    uncertainty_seed: int = 0,
 ) -> AblationMatrixRow:
     """Summarize one scope/window/lead ablation slice."""
     scores = build_model_scores(
@@ -120,6 +261,16 @@ def build_matrix_row(
         ),
         default=None,
     )
+    uncertainty = None
+    if best_delta and uncertainty_resamples > 0 and baseline:
+        candidate_score = next((score for score in scores if score.name == best_delta.name), None)
+        if candidate_score:
+            uncertainty = estimate_delta_uncertainty(
+                baseline,
+                candidate_score,
+                resamples=uncertainty_resamples,
+                seed=uncertainty_seed,
+            )
     return AblationMatrixRow(
         scope=scope,
         window_days=window_days,
@@ -135,6 +286,13 @@ def build_matrix_row(
         best_brier_improvement=(best_delta.brier_improvement if best_delta else None),
         beats_both=bool(best_delta and best_delta.beats_baseline),
         conclusion=summarize_conclusion(rows, scores),
+        best_auc_delta_ci=uncertainty.auc_delta_ci if uncertainty else None,
+        best_brier_improvement_ci=(
+            uncertainty.brier_improvement_ci if uncertainty else None
+        ),
+        best_brier_permutation_p=(
+            uncertainty.brier_permutation_p if uncertainty else None
+        ),
     )
 
 
@@ -163,8 +321,8 @@ def format_matrix_report(
     lines.extend([
         "Positive AUC delta means better ranking than `previous_outcome_bad`; positive Brier improvement means lower probability error. `Beats both?` is the conservative quick read.",
         "",
-        "| Scope | Window days | Lead min | Trusted | Bad | Prior state | Prior risk | Baseline AUC | Baseline Brier | Best EISV/prior model | AUC delta | Brier improvement | Beats both? | Conclusion |",
-        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---|",
+        "| Scope | Window days | Lead min | Trusted | Bad | Prior state | Prior risk | Baseline AUC | Baseline Brier | Best EISV/prior model | AUC delta | AUC delta 95% CI | Brier improvement | Brier improvement 95% CI | Brier perm p | Beats both? | Conclusion |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---:|---:|---:|---|---|",
     ])
     if rows:
         for row in rows:
@@ -174,11 +332,14 @@ def format_matrix_report(
                 f"| {row.trusted} | {row.bad} | {row.prior_state} | {row.prior_risk} "
                 f"| {_fmt_float(row.baseline_auc, 3)} | {_fmt_float(row.baseline_brier, 4)} "
                 f"| {row.best_candidate or '-'} | {_fmt_float(row.best_auc_delta, 3)} "
+                f"| {_fmt_ci(row.best_auc_delta_ci, 3)} "
                 f"| {_fmt_float(row.best_brier_improvement, 4)} "
+                f"| {_fmt_ci(row.best_brier_improvement_ci, 4)} "
+                f"| {_fmt_float(row.best_brier_permutation_p, 3)} "
                 f"| {'yes' if row.beats_both else 'no'} | {row.conclusion} |"
             )
     else:
-        lines.append("| - | - | - | 0 | 0 | 0 | 0 | - | - | - | - | - | no | no rows |")
+        lines.append("| - | - | - | 0 | 0 | 0 | 0 | - | - | - | - | - | - | - | - | no | no rows |")
     lines.extend(
         [
             "",
@@ -217,6 +378,8 @@ async def build_matrix_from_db(
     train_fraction: float = 0.7,
     min_feature_rows: int = 30,
     exclude_harness_lanes: Sequence[str] = DEFAULT_EXCLUDED_HARNESS_LANES,
+    uncertainty_resamples: int = 0,
+    uncertainty_seed: int = 0,
 ) -> list[AblationMatrixRow]:
     matrix_rows: list[AblationMatrixRow] = []
     for scope in scopes:
@@ -240,6 +403,8 @@ async def build_matrix_from_db(
                         lead_minutes=lead_minutes,
                         train_fraction=train_fraction,
                         min_feature_rows=min_feature_rows,
+                        uncertainty_resamples=uncertainty_resamples,
+                        uncertainty_seed=uncertainty_seed,
                     )
                 )
     return matrix_rows
@@ -253,6 +418,18 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--leads", type=_parse_float_list, default="0,5,30")
     parser.add_argument("--train-fraction", type=float, default=0.7)
     parser.add_argument("--min-feature-rows", type=int, default=30)
+    parser.add_argument(
+        "--uncertainty-resamples",
+        type=int,
+        default=0,
+        help="Bootstrap/permutation resamples for best-candidate delta uncertainty; 0 disables.",
+    )
+    parser.add_argument(
+        "--uncertainty-seed",
+        type=int,
+        default=0,
+        help="Deterministic seed for bootstrap/permutation uncertainty estimates.",
+    )
     parser.add_argument(
         "--exclude-harness-lanes",
         type=_parse_string_list,
@@ -275,6 +452,8 @@ async def main_async(args: argparse.Namespace) -> int:
         train_fraction=args.train_fraction,
         min_feature_rows=args.min_feature_rows,
         exclude_harness_lanes=args.exclude_harness_lanes,
+        uncertainty_resamples=args.uncertainty_resamples,
+        uncertainty_seed=args.uncertainty_seed,
     )
     report = format_matrix_report(rows, excluded_harness_lanes=args.exclude_harness_lanes)
     if args.output:

--- a/scripts/analysis/outcome_inventory.py
+++ b/scripts/analysis/outcome_inventory.py
@@ -29,6 +29,7 @@ DEFAULT_DB_URL = os.environ.get(
 )
 
 STRICT_OUTCOMES = frozenset({"test_passed", "test_failed", "tool_rejected"})
+STRICT_BAD_MIN_FOR_VALIDATION = 10
 TASK_OUTCOMES = frozenset(
     {
         "test_passed",
@@ -333,6 +334,8 @@ def format_inventory_report(
         f"total_bad_rate: {_format_rate(inventory.total_bad_rate)}",
         f"strict_outcomes: {inventory.strict_outcomes}",
         f"strict_bad: {inventory.strict_bad}",
+        f"strict_bad_min_for_validation: {STRICT_BAD_MIN_FOR_VALIDATION}",
+        f"strict_bad_gap_to_min: {max(0, STRICT_BAD_MIN_FOR_VALIDATION - inventory.strict_bad)}",
         f"hard_exogenous: {inventory.hard_exogenous_count}",
         f"eprocess_eligible: {inventory.eprocess_eligible_count}",
         *[

--- a/scripts/analysis/prospective_prediction_cohort.py
+++ b/scripts/analysis/prospective_prediction_cohort.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Report prospective prediction-bound outcome cohorts.
+
+This is a small holdout-oriented companion to the skeptical ablation matrix. It
+counts only outcomes tied to a real prospective prediction registry binding,
+not fallback confidence/audit bindings, so future validation can be separated
+from retrospective or heuristic labels.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+if __package__ is None or __package__ == "":
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.analysis.eisv_skeptic_report import (  # noqa: E402
+    DEFAULT_DB_URL,
+    STRICT_OUTCOMES,
+    TASK_OUTCOMES,
+    OutcomeRow,
+    fetch_rows,
+)
+from scripts.analysis.outcome_inventory import (  # noqa: E402
+    harness_lane_from_detail,
+    is_controlled_validation_fixture,
+)
+
+
+@dataclass(frozen=True)
+class ProspectiveCohortSummary:
+    """Compact prospective prediction-bound cohort summary."""
+
+    scope: str
+    window_days: int
+    lead_minutes: float
+    total_outcomes: int
+    prediction_bound: int
+    prediction_bound_bad: int
+    prediction_bound_prior_state: int
+    by_harness_lane: dict[str, int]
+
+    @property
+    def prediction_coverage(self) -> float:
+        """Share of trusted rows with registry-bound prospective predictions."""
+
+        return self.prediction_bound / self.total_outcomes if self.total_outcomes else 0.0
+
+    @property
+    def prediction_bound_bad_rate(self) -> float:
+        """Bad-outcome rate within the prospective prediction-bound cohort."""
+
+        return (
+            self.prediction_bound_bad / self.prediction_bound
+            if self.prediction_bound
+            else 0.0
+        )
+
+
+def is_prospective_prediction_bound(row: OutcomeRow) -> bool:
+    """True only for rows tied to a real registry prediction binding."""
+
+    return bool(row.detail.get("prediction_id")) and row.detail.get("prediction_binding") == "registry"
+
+
+def build_cohort_summary(
+    rows: Sequence[OutcomeRow],
+    *,
+    scope: str,
+    window_days: int,
+    lead_minutes: float,
+) -> ProspectiveCohortSummary:
+    """Summarize prospective prediction-bound rows without fallback leakage."""
+
+    trusted = [row for row in rows if not is_controlled_validation_fixture(row.detail)]
+    prediction_rows = [row for row in trusted if is_prospective_prediction_bound(row)]
+    by_lane: dict[str, int] = {}
+    for row in prediction_rows:
+        lane = harness_lane_from_detail(row.detail)
+        by_lane[lane] = by_lane.get(lane, 0) + 1
+    return ProspectiveCohortSummary(
+        scope=scope,
+        window_days=window_days,
+        lead_minutes=lead_minutes,
+        total_outcomes=len(trusted),
+        prediction_bound=len(prediction_rows),
+        prediction_bound_bad=sum(int(row.is_bad) for row in prediction_rows),
+        prediction_bound_prior_state=sum(
+            1 for row in prediction_rows if row.prior_state_age_seconds is not None
+        ),
+        by_harness_lane=dict(sorted(by_lane.items())),
+    )
+
+
+def _fmt_lead(value: float) -> str:
+    return f"{value:g}"
+
+
+def format_cohort_report(summary: ProspectiveCohortSummary) -> str:
+    """Render a markdown summary for prospective holdout readiness."""
+
+    lanes = ",".join(
+        f"{lane}={count}" for lane, count in summary.by_harness_lane.items()
+    ) or "none"
+    return "\n".join(
+        [
+            "# Prospective Prediction Cohort",
+            "",
+            f"scope: {summary.scope}",
+            f"window_days: {summary.window_days}",
+            f"lead_minutes: {_fmt_lead(summary.lead_minutes)}",
+            f"trusted_outcomes: {summary.total_outcomes}",
+            f"prediction_bound: {summary.prediction_bound}",
+            f"prediction_coverage: {summary.prediction_coverage:.3f}",
+            f"prediction_bound_bad: {summary.prediction_bound_bad}",
+            f"prediction_bound_bad_rate: {summary.prediction_bound_bad_rate:.3f}",
+            "prediction_bound_prior_state: "
+            f"{summary.prediction_bound_prior_state}/{summary.prediction_bound}",
+            f"harness_lanes: {lanes}",
+            "",
+            "Interpretation rule: this is prospective holdout plumbing only. "
+            "It counts registry-bound predictions that existed before outcomes; "
+            "it does not validate EISV unless a frozen holdout later beats boring baselines.",
+        ]
+    )
+
+
+async def build_summary_from_db(
+    db_url: str,
+    *,
+    scope: str,
+    window_days: int,
+    lead_minutes: float,
+) -> ProspectiveCohortSummary:
+    """Fetch trusted rows and summarize registry-bound prediction coverage."""
+
+    outcome_types = STRICT_OUTCOMES if scope == "strict" else TASK_OUTCOMES
+    rows = await fetch_rows(
+        db_url,
+        window_days=window_days,
+        lead_minutes=lead_minutes,
+        outcome_types=outcome_types,
+    )
+    return build_cohort_summary(
+        rows,
+        scope=scope,
+        window_days=window_days,
+        lead_minutes=lead_minutes,
+    )
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse CLI options."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db-url", default=DEFAULT_DB_URL)
+    parser.add_argument("--scope", choices=("strict", "task"), default="task")
+    parser.add_argument("--window-days", type=int, default=90)
+    parser.add_argument("--lead-minutes", type=float, default=30.0)
+    parser.add_argument("--output", help="Optional markdown output path")
+    return parser.parse_args(argv)
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    """Run the prospective cohort report."""
+
+    summary = await build_summary_from_db(
+        args.db_url,
+        scope=args.scope,
+        window_days=args.window_days,
+        lead_minutes=args.lead_minutes,
+    )
+    report = format_cohort_report(summary)
+    if args.output:
+        path = Path(args.output)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(report + "\n", encoding="utf-8")
+        print(f"Wrote {path}")
+    else:
+        print(report)
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entrypoint."""
+
+    return asyncio.run(main_async(parse_args(argv)))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/diagnostics/dogfood_ablation_guard.py
+++ b/scripts/diagnostics/dogfood_ablation_guard.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Silent guard for UNITARES dogfood identity and ablation-lane invariants.
+
+This script is deliberately small and CI-testable: pure helper functions hold the
+invariants, while the CLI wires them to the live REST endpoint and repo-local
+analysis scripts. Empty stdout means no regression detected.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Sequence
+
+DEFAULT_HTTP_URL = "http://127.0.0.1:8767"
+DEFAULT_REPO = Path(__file__).resolve().parents[2]
+DEFAULT_PYTHON = "/usr/local/bin/python3"
+DEFAULT_TIMEOUT_SECONDS = 120
+IDENTITY_ALERT = "no-session get_governance_metrics is not identity-neutral"
+INVENTORY_ALERT = "outcome inventory no longer exposes BEAM/substrate eprocess lanes"
+MATRIX_ALERT = "ablation matrix default no longer excludes BEAM harness lane"
+
+
+def identity_neutrality_alert(metrics: dict[str, Any]) -> str | None:
+    """Return an alert when a no-session read exposes a caller identity."""
+
+    signature = metrics.get("agent_signature")
+    signature_uuid = signature.get("uuid") if isinstance(signature, dict) else None
+    identity_values = (
+        metrics.get("agent_id"),
+        metrics.get("display_name"),
+        metrics.get("agent_uuid"),
+        signature_uuid,
+    )
+    if metrics.get("status") != "⚪ unbound" or any(identity_values):
+        return IDENTITY_ALERT
+    return None
+
+
+def parse_inventory_counts(text: str) -> dict[str, int]:
+    """Parse top-level integer counters from an outcome-inventory report."""
+
+    counts: dict[str, int] = {}
+    for key in (
+        "strict_bad",
+        "strict_outcomes",
+        "eprocess_eligible",
+        "eprocess_eligible_beam",
+        "eprocess_eligible_substrate",
+        "prediction_id_present",
+    ):
+        match = re.search(rf"^{re.escape(key)}:\s*(\d+)\s*$", text, re.MULTILINE)
+        if match:
+            counts[key] = int(match.group(1))
+    return counts
+
+
+def inventory_lane_alert(counts: dict[str, int]) -> str | None:
+    """Return an alert if inventory output stopped exposing harness lanes."""
+
+    if "eprocess_eligible_beam" not in counts or "eprocess_eligible_substrate" not in counts:
+        return INVENTORY_ALERT
+    return None
+
+
+def matrix_exclusion_alert(text: str) -> str | None:
+    """Return an alert if default matrix output no longer excludes BEAM."""
+
+    return None if "Excluded harness lanes: `beam`" in text else MATRIX_ALERT
+
+
+def render_alert_report(alerts: Sequence[str], evidence: Sequence[str]) -> str:
+    """Render a Hermes no-agent cron alert; return empty string when healthy."""
+
+    if not alerts:
+        return ""
+    lines = [
+        "UNITARES dogfood/ablation guard",
+        "Signal: " + "; ".join(alerts),
+        "Evidence:",
+    ]
+    lines.extend(f"- {item}" for item in evidence)
+    lines.append(
+        "Next: inspect identity proof-origin and harness-lane code before interpreting dogfood or ablation signals."
+    )
+    return "\n".join(lines)
+
+
+def call_tool_no_session(http_url: str, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Call the REST tool endpoint without session or identity headers."""
+
+    payload = {"name": name, "arguments": arguments}
+    req = urllib.request.Request(
+        f"{http_url.rstrip('/')}/v1/tools/call",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Accept": "application/json", "Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=10) as response:  # noqa: S310 - localhost ops guard
+        outer = json.loads(response.read().decode("utf-8"))
+    result = outer.get("result") if isinstance(outer, dict) else outer
+    if isinstance(result, str):
+        try:
+            result = json.loads(result)
+        except json.JSONDecodeError:
+            return {"raw_result": result}
+    return result if isinstance(result, dict) else {"raw_result": result}
+
+
+def run_repo_script(
+    repo: Path,
+    python: str,
+    script: str,
+    args: Sequence[str],
+    *,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    """Run a repo-local analysis script under the intended project Python."""
+
+    env = os.environ.copy()
+    env["PATH"] = f"/usr/local/bin:{env.get('PATH', '')}"
+    env["UNITARES_PYTHON"] = python
+    proc = subprocess.run(
+        [python, script, *args],
+        cwd=repo,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=timeout_seconds,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"{script} exited {proc.returncode}: {proc.stdout[-1200:]}")
+    return proc.stdout
+
+
+def collect_alerts(
+    *,
+    http_url: str,
+    repo: Path,
+    python: str,
+    timeout_seconds: int,
+) -> tuple[list[str], list[str]]:
+    """Collect guard alerts and compact evidence from live/local checks."""
+
+    alerts: list[str] = []
+    evidence: list[str] = []
+
+    try:
+        metrics = call_tool_no_session(http_url, "get_governance_metrics", {"lite": True})
+        identity_summary = {
+            "status": metrics.get("status"),
+            "agent_id": metrics.get("agent_id"),
+            "display_name": metrics.get("display_name"),
+            "agent_uuid": metrics.get("agent_uuid"),
+            "signature_uuid": (metrics.get("agent_signature") or {}).get("uuid")
+            if isinstance(metrics.get("agent_signature"), dict)
+            else None,
+        }
+        evidence.append(
+            "no_session_metrics="
+            + json.dumps(identity_summary, ensure_ascii=False, sort_keys=True)
+        )
+        if alert := identity_neutrality_alert(metrics):
+            alerts.append(alert)
+    except (OSError, urllib.error.URLError, RuntimeError, json.JSONDecodeError) as exc:
+        alerts.append("no-session identity neutrality check failed to run")
+        evidence.append(f"identity_check_error={type(exc).__name__}: {exc}")
+
+    try:
+        inventory = run_repo_script(
+            repo,
+            python,
+            "scripts/analysis/outcome_inventory.py",
+            ("--window-days", "90", "--leads", "0,5,30"),
+            timeout_seconds=timeout_seconds,
+        )
+        counts = parse_inventory_counts(inventory)
+        evidence.append(
+            "inventory="
+            f"eprocess_eligible={counts.get('eprocess_eligible')}, "
+            f"lanes=beam={counts.get('eprocess_eligible_beam')},"
+            f"substrate={counts.get('eprocess_eligible_substrate')}, "
+            f"strict_bad={counts.get('strict_bad')}"
+        )
+        if alert := inventory_lane_alert(counts):
+            alerts.append(alert)
+    except (OSError, RuntimeError, subprocess.TimeoutExpired) as exc:
+        alerts.append("outcome inventory lane check failed to run")
+        evidence.append(f"inventory_error={type(exc).__name__}: {exc}")
+
+    try:
+        matrix = run_repo_script(
+            repo,
+            python,
+            "scripts/analysis/eisv_ablation_matrix.py",
+            ("--scopes", "strict,task", "--windows", "30,90", "--leads", "0,5,30"),
+            timeout_seconds=timeout_seconds,
+        )
+        excluded = matrix_exclusion_alert(matrix) is None
+        evidence.append(f"matrix_excludes_beam={excluded}")
+        if not excluded:
+            alerts.append(MATRIX_ALERT)
+    except (OSError, RuntimeError, subprocess.TimeoutExpired) as exc:
+        alerts.append("ablation matrix lane-exclusion check failed to run")
+        evidence.append(f"matrix_error={type(exc).__name__}: {exc}")
+
+    return alerts, evidence
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse CLI options for the silent guard."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--http-url", default=os.environ.get("UNITARES_HTTP_URL", DEFAULT_HTTP_URL))
+    parser.add_argument("--repo", type=Path, default=Path(os.environ.get("UNITARES_REPO", DEFAULT_REPO)))
+    parser.add_argument("--python", default=os.environ.get("UNITARES_PYTHON", DEFAULT_PYTHON))
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=int(os.environ.get("UNITARES_GUARD_TIMEOUT", str(DEFAULT_TIMEOUT_SECONDS))),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the guard and print only actionable alerts."""
+
+    args = parse_args(argv)
+    alerts, evidence = collect_alerts(
+        http_url=args.http_url,
+        repo=args.repo,
+        python=args.python,
+        timeout_seconds=args.timeout_seconds,
+    )
+    report = render_alert_report(alerts, evidence)
+    if report:
+        print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_dogfood_ablation_guard.py
+++ b/tests/test_dogfood_ablation_guard.py
@@ -1,0 +1,73 @@
+from scripts.diagnostics.dogfood_ablation_guard import (
+    identity_neutrality_alert,
+    inventory_lane_alert,
+    matrix_exclusion_alert,
+    parse_inventory_counts,
+    render_alert_report,
+)
+
+
+def test_identity_neutrality_accepts_unbound_no_session_metrics():
+    metrics = {
+        "status": "⚪ unbound",
+        "agent_id": None,
+        "display_name": None,
+        "agent_uuid": None,
+        "agent_signature": {"uuid": None},
+    }
+
+    assert identity_neutrality_alert(metrics) is None
+
+
+def test_identity_neutrality_alerts_on_laundered_server_identity():
+    metrics = {
+        "status": "🟡 moderate",
+        "agent_id": "Chronicler",
+        "display_name": "Chronicler",
+        "agent_uuid": "deb879b6-4ff8-4dee-81ce-0683f4563dc5",
+        "agent_signature": {"uuid": None},
+    }
+
+    assert identity_neutrality_alert(metrics) == "no-session get_governance_metrics is not identity-neutral"
+
+
+def test_inventory_lane_guard_requires_beam_and_substrate_counts():
+    output = """# Outcome Inventory
+strict_bad: 0
+eprocess_eligible: 1779
+eprocess_eligible_beam: 1494
+eprocess_eligible_substrate: 285
+"""
+
+    counts = parse_inventory_counts(output)
+
+    assert counts["eprocess_eligible"] == 1779
+    assert counts["eprocess_eligible_beam"] == 1494
+    assert counts["eprocess_eligible_substrate"] == 285
+    assert inventory_lane_alert(counts) is None
+    assert inventory_lane_alert({"eprocess_eligible": 1779}) == (
+        "outcome inventory no longer exposes BEAM/substrate eprocess lanes"
+    )
+
+
+def test_matrix_guard_requires_default_beam_exclusion_header():
+    assert matrix_exclusion_alert("Excluded harness lanes: `beam`\n") is None
+    assert matrix_exclusion_alert("# EISV Ablation Matrix\n") == (
+        "ablation matrix default no longer excludes BEAM harness lane"
+    )
+
+
+def test_render_alert_report_is_silent_when_all_guards_pass():
+    assert render_alert_report([], ["inventory=eprocess_eligible=1"]) == ""
+
+
+def test_render_alert_report_includes_signal_evidence_next_when_alerting():
+    report = render_alert_report(
+        ["no-session get_governance_metrics is not identity-neutral"],
+        ["no_session_metrics={...}"],
+    )
+
+    assert report.startswith("UNITARES dogfood/ablation guard\n")
+    assert "Signal: no-session get_governance_metrics is not identity-neutral" in report
+    assert "- no_session_metrics={...}" in report
+    assert "Next: inspect identity proof-origin" in report

--- a/tests/test_eisv_ablation_matrix.py
+++ b/tests/test_eisv_ablation_matrix.py
@@ -8,10 +8,11 @@ import sys
 from scripts.analysis.eisv_ablation_matrix import (
     AblationMatrixRow,
     build_matrix_row,
+    estimate_delta_uncertainty,
     filter_rows_for_validation,
     format_matrix_report,
 )
-from scripts.analysis.eisv_skeptic_report import OutcomeRow
+from scripts.analysis.eisv_skeptic_report import ModelScore, OutcomeRow
 
 
 def _row(idx: int, *, bad: bool, risk: float | None, agent: str = "agent-a") -> OutcomeRow:
@@ -70,6 +71,8 @@ def test_build_matrix_row_summarizes_baseline_and_best_candidate():
         lead_minutes=30,
         train_fraction=0.7,
         min_feature_rows=10,
+        uncertainty_resamples=50,
+        uncertainty_seed=7,
     )
 
     assert row.scope == "task"
@@ -89,8 +92,54 @@ def test_build_matrix_row_summarizes_baseline_and_best_candidate():
     }
     assert row.best_auc_delta is not None
     assert row.best_brier_improvement is not None
+    assert row.best_auc_delta_ci is not None
+    assert row.best_brier_improvement_ci is not None
+    assert row.best_brier_permutation_p is not None
     assert isinstance(row.beats_both, bool)
 
+
+def _score(name: str, probs: tuple[float, ...], auc_scores: tuple[float, ...]) -> ModelScore:
+    y_true = (0, 0, 0, 1, 1, 1)
+    keys = tuple(f"row-{idx}" for idx in range(len(y_true)))
+    return ModelScore(
+        name=name,
+        n_train=10,
+        n_test=len(y_true),
+        n_test_scored=len(y_true),
+        auc=None,
+        brier=None,
+        scored_row_keys=keys,
+        y_true=y_true,
+        y_prob=probs,
+        y_auc_score=auc_scores,
+    )
+
+
+def test_estimate_delta_uncertainty_reports_bootstrap_ci_and_permutation_p():
+    baseline = _score(
+        "previous_outcome_bad",
+        probs=(0.30, 0.30, 0.30, 0.70, 0.70, 0.70),
+        auc_scores=(0.30, 0.30, 0.30, 0.70, 0.70, 0.70),
+    )
+    candidate = _score(
+        "prior_risk_binned",
+        probs=(0.05, 0.10, 0.20, 0.80, 0.90, 0.95),
+        auc_scores=(0.05, 0.10, 0.20, 0.80, 0.90, 0.95),
+    )
+
+    uncertainty = estimate_delta_uncertainty(
+        baseline,
+        candidate,
+        resamples=80,
+        seed=17,
+    )
+
+    assert uncertainty is not None
+    assert uncertainty.paired_n == 6
+    assert uncertainty.auc_delta_ci is not None
+    assert uncertainty.brier_improvement_ci is not None
+    assert uncertainty.brier_improvement_ci[0] > 0
+    assert 0.0 <= uncertainty.brier_permutation_p <= 1.0
 
 def test_format_matrix_report_contains_skeptical_ablation_table():
     rows = [
@@ -107,6 +156,9 @@ def test_format_matrix_report_contains_skeptical_ablation_table():
             best_candidate="prior_risk_binned",
             best_auc_delta=0.03,
             best_brier_improvement=0.01,
+            best_auc_delta_ci=(0.01, 0.05),
+            best_brier_improvement_ci=(0.002, 0.02),
+            best_brier_permutation_p=0.04,
             beats_both=True,
             conclusion="KEEP TESTING: synthetic row",
         )
@@ -117,7 +169,13 @@ def test_format_matrix_report_contains_skeptical_ablation_table():
     assert report.startswith("# EISV Ablation Matrix")
     assert "Excluded harness lanes: `beam`" in report
     assert "| Scope | Window days | Lead min | Trusted | Bad | Prior state | Prior risk |" in report
+    assert "AUC delta 95% CI" in report
+    assert "Brier improvement 95% CI" in report
+    assert "Brier perm p" in report
     assert "| task | 90 | 30 | 120 | 24 | 120 | 120 |" in report
+    assert "[0.010, 0.050]" in report
+    assert "[0.0020, 0.0200]" in report
+    assert "0.040" in report
     assert "prior_risk_binned" in report
     assert "KEEP TESTING" in report
 

--- a/tests/test_outcome_inventory.py
+++ b/tests/test_outcome_inventory.py
@@ -152,6 +152,8 @@ def test_format_inventory_report_exposes_zero_bad_strict_and_prior_coverage():
     assert "total_outcomes: 2" in report
     assert "strict_outcomes: 1" in report
     assert "strict_bad: 0" in report
+    assert "strict_bad_min_for_validation: 10" in report
+    assert "strict_bad_gap_to_min: 10" in report
     assert "task_failed" in report
     assert "prior_state_5m" in report
     assert "agent_reported_tool_result" in report

--- a/tests/test_prospective_prediction_cohort.py
+++ b/tests/test_prospective_prediction_cohort.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from scripts.analysis.eisv_skeptic_report import OutcomeRow
+from scripts.analysis.prospective_prediction_cohort import (
+    build_cohort_summary,
+    format_cohort_report,
+)
+
+
+def _row(
+    idx: int,
+    *,
+    bad: bool = False,
+    prediction_id: str | None = None,
+    binding: str | None = None,
+    harness: str | None = None,
+    prior_state: bool = True,
+) -> OutcomeRow:
+    detail = {}
+    if prediction_id:
+        detail["prediction_id"] = prediction_id
+    if binding:
+        detail["prediction_binding"] = binding
+    if harness:
+        detail["harness"] = harness
+    return OutcomeRow(
+        ts=datetime.now(timezone.utc).replace(microsecond=0) + timedelta(minutes=idx),
+        agent_id=f"agent-{idx % 2}",
+        outcome_type="task_failed" if bad else "task_completed",
+        is_bad=bad,
+        outcome_score=0.0 if bad else 1.0,
+        verification_source="server_observation",
+        reported_confidence=None,
+        reported_complexity=None,
+        detail=detail,
+        prior_state_age_seconds=30.0 if prior_state else None,
+        prior_risk=0.8 if bad and prior_state else (0.2 if prior_state else None),
+        prior_phi=None,
+        prior_verdict=None,
+        prior_coherence=None,
+        prior_e=None,
+        prior_i=None,
+        prior_s=None,
+        prior_v=None,
+        snapshot_verdict=None,
+        snapshot_e=None,
+        snapshot_i=None,
+        snapshot_s=None,
+        snapshot_v=None,
+        snapshot_phi=None,
+        snapshot_coherence=None,
+    )
+
+
+def test_build_cohort_summary_counts_only_registry_prediction_bound_rows():
+    rows = [
+        _row(0, prediction_id="pred-1", binding="registry", prior_state=True),
+        _row(1, bad=True, prediction_id="pred-2", binding="registry", harness="beam", prior_state=False),
+        _row(2, prediction_id="pred-3", binding="prev_confidence_fallback"),
+        _row(3),
+    ]
+
+    summary = build_cohort_summary(rows, scope="task", window_days=90, lead_minutes=30)
+
+    assert summary.total_outcomes == 4
+    assert summary.prediction_bound == 2
+    assert summary.prediction_coverage == 0.5
+    assert summary.prediction_bound_bad == 1
+    assert summary.prediction_bound_prior_state == 1
+    assert summary.by_harness_lane == {"beam": 1, "substrate": 1}
+
+
+def test_format_cohort_report_keeps_holdout_language_and_lane_counts():
+    rows = [
+        _row(0, prediction_id="pred-1", binding="registry", prior_state=True),
+        _row(1, bad=True, prediction_id="pred-2", binding="registry", harness="beam", prior_state=False),
+    ]
+    summary = build_cohort_summary(rows, scope="task", window_days=90, lead_minutes=30)
+
+    report = format_cohort_report(summary)
+
+    assert report.startswith("# Prospective Prediction Cohort")
+    assert "scope: task" in report
+    assert "prediction_bound: 2" in report
+    assert "prediction_coverage: 1.000" in report
+    assert "prediction_bound_prior_state: 1/2" in report
+    assert "harness_lanes: beam=1,substrate=1" in report
+    assert "prospective holdout" in report


### PR DESCRIPTION
## Summary
- add repo-local silent dogfood/ablation guard for no-session identity neutrality and harness-lane invariants
- add optional bootstrap CIs + paired permutation p-values to the EISV ablation matrix
- add prospective prediction cohort report for registry-bound holdout coverage
- surface strict bad-outcome minimum/gap directly in outcome inventory

## Test Plan
- [x] `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 -m compileall -q scripts/diagnostics/dogfood_ablation_guard.py scripts/analysis/eisv_ablation_matrix.py scripts/analysis/outcome_inventory.py scripts/analysis/prospective_prediction_cohort.py`
- [x] `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 -m pytest tests/test_dogfood_ablation_guard.py tests/test_eisv_ablation_matrix.py tests/test_outcome_inventory.py tests/test_prospective_prediction_cohort.py -q`
- [x] `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 ./scripts/dev/test-cache.sh`
- [x] live repo guard run stayed silent
- [x] live matrix smoke with `--uncertainty-resamples 30` prints CI/p-value columns
- [x] live prospective cohort report prints registry-bound coverage
- [x] live inventory prints strict bad minimum/gap plus BEAM/substrate lanes
