### PR TITLE
fix(watcher): re-validate required token at chime time (age out line-drift findings)

### DIFF
--- a/agents/watcher/agent.py
+++ b/agents/watcher/agent.py
@@ -99,6 +99,7 @@ from agents.watcher.findings import (
     _partition_findings_by_scope,
     _resolve_session_scope_root,
     _sweep_stale_quiet,
+    _sweep_token_drift_quiet,
     _write_findings_atomic,
     compact_findings,
     escalate,
@@ -1265,9 +1266,14 @@ def surface_pending() -> int:
     exists before computing the chime. Closes the failure mode observed
     on 2026-05-07 dogfood — 36% of open findings (48/132) were dangling
     against deleted worktree paths, inflating chime severity rankings.
-    Quiet so it doesn't pollute the chime block stdout.
+    A second quiet sweep ages out findings whose flagged line has drifted
+    off the pattern's required token (file still present, but the stored
+    line no longer holds the construct — the line-drift FP class behind
+    repeated P003/P001/P016 dismissal sweeps). Both are quiet so they
+    don't pollute the chime block stdout.
     """
     _sweep_stale_quiet()
+    _sweep_token_drift_quiet()
     all_findings = _iter_findings_raw()
     open_findings = [f for f in all_findings if f.get("status", "open") == "open"]
 

--- a/agents/watcher/findings.py
+++ b/agents/watcher/findings.py
@@ -443,6 +443,93 @@ def sweep_stale_findings() -> int:
     return 0
 
 
+def _current_source_line(path: str, line: int) -> str | None:
+    """Return the current text of ``line`` (1-based) in ``path``, or None if
+    the file is missing, unreadable, or the line is out of range.
+
+    Used to re-validate a finding's flagged construct against current disk
+    content after detection — line numbers drift as files are later edited.
+    """
+    if not path or line < 1:
+        return None
+    p = Path(path)
+    if not p.exists():
+        return None
+    try:
+        with p.open("r", encoding="utf-8", errors="replace") as fh:
+            for i, text in enumerate(fh, start=1):
+                if i == line:
+                    return text.rstrip("\n")
+    except OSError:
+        return None
+    return None  # line beyond EOF
+
+
+def _sweep_token_drift_quiet() -> int:
+    """Age out open/surfaced findings whose flagged line no longer carries the
+    pattern's required token.
+
+    Closes the line-drift staleness gap (patterns.md P016 note, 2026-05-04): a
+    finding is validated by the required-token verifier at DETECTION time, but
+    its stored line number drifts as the file is later edited, so the same
+    finding can surface pointing at a line that no longer holds the construct
+    (a return statement, a comment, a blank line). The detection gate
+    (``_PATTERN_REQUIRED_TOKENS`` in agent.py) is replayed here against CURRENT
+    disk content; when the required token is gone, the finding is stale and is
+    aged out rather than re-shown.
+
+    Conservative by construction:
+      * only token-gated patterns are touched (others have no token to replay);
+      * a line that STILL holds its required token is never aged out, so a real
+        match is never silently dropped;
+      * unreadable/out-of-range lines are left alone — the file-existence sweep
+        (``_sweep_stale_quiet``) and a future scan cover those.
+
+    Aged out (not deleted) so the audit trail and precision math keep the
+    record; ``--compact`` reclaims it after the TTL. Quiet variant — logs when
+    non-zero, never prints — safe to call from the chime path where stdout
+    becomes agent context. Returns the count aged out.
+    """
+    # Lazy import: the token map lives in agent.py, which imports this module
+    # at top level. A top-level import here would be circular (same reason as
+    # the _post_resolution_event lazy import in update_finding_status).
+    from agents.watcher.agent import _PATTERN_REQUIRED_TOKENS
+
+    findings = _iter_findings_raw()
+    if not findings:
+        return 0
+
+    now_iso = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    aged = 0
+    out: list[dict[str, Any]] = []
+    for f in findings:
+        if f.get("status", "open") in ("open", "surfaced"):
+            tokens = _PATTERN_REQUIRED_TOKENS.get(f.get("pattern", ""))
+            if tokens:
+                src_line = _current_source_line(
+                    f.get("file", ""), int(f.get("line", 0) or 0)
+                )
+                if src_line is not None and not any(tok in src_line for tok in tokens):
+                    f = {
+                        **f,
+                        "status": "aged_out",
+                        "aged_out_at": now_iso,
+                        "resolution_reason": "line_drift_token_absent",
+                    }
+                    aged += 1
+        out.append(f)
+
+    if aged == 0:
+        return 0
+
+    _write_findings_atomic(out)
+    log(
+        f"sweep_token_drift (auto): aged out {aged} finding(s) whose flagged "
+        f"line no longer carries the pattern's required token"
+    )
+    return aged
+
+
 # ---------------------------------------------------------------------------
 # Surfacing — how findings reach the main Claude session
 #

--- a/agents/watcher/tests/test_agent.py
+++ b/agents/watcher/tests/test_agent.py
@@ -722,13 +722,20 @@ def _seed_findings(watcher_module, entries: list[dict]) -> None:
 def _make_raw_entry(
     fingerprint: str,
     *,
-    pattern: str = "P001",
+    # Default to a NON-token-gated pattern (P011 has no entry in
+    # _PATTERN_REQUIRED_TOKENS). These raw entries exercise queue/status logic,
+    # not pattern detection, and point at an arbitrary line (:10) of this test
+    # file that holds no pattern construct — a token-gated default (e.g. P001)
+    # would be aged out by surface_pending's chime-time token-drift sweep before
+    # the queue assertions run. A real detection always carries its token; these
+    # synthetic fixtures don't, so they use a token-free pattern by default.
+    pattern: str = "P011",
     file: str = str(Path(__file__).resolve()),
     line: int = 10,
     status: str = "open",
     detected_at: str = "2026-04-11T00:00:00Z",
     severity: str = "high",
-    hint: str = "fire-and-forget task",
+    hint: str = "mutation before persistence",
 ) -> dict:
     return {
         "pattern": pattern,
@@ -3474,3 +3481,127 @@ class TestWatcherLifecycleIntegration:
         # Verify local status also updated
         findings = watcher_module._iter_findings_raw()
         assert findings[0]["status"] == "confirmed"
+
+
+# ---------------------------------------------------------------------------
+# Chime-time token-drift re-validation (_sweep_token_drift_quiet)
+# ---------------------------------------------------------------------------
+
+
+class TestTokenDriftRevalidation:
+    """``_sweep_token_drift_quiet`` ages out open/surfaced findings whose
+    flagged line no longer carries the pattern's required token — closing the
+    line-drift staleness gap where a finding validated at detection later
+    surfaces against a line that has since drifted off the construct.
+
+    Regression for the recurring P003/P001 line-drift dismissal sweeps: the
+    required-token gate only ran at detection, never replayed at surface time.
+    """
+
+    def _seed(self, finding: dict) -> None:
+        from agents.watcher import findings as wf
+
+        base = {
+            "hint": "x",
+            "severity": "high",
+            "detected_at": "2026-06-01T00:00:00Z",
+            "model_used": "test",
+            "status": "open",
+        }
+        wf._write_findings_atomic([{**base, **finding}])
+
+    def _records(self):
+        from agents.watcher import findings as wf
+
+        return {r["fingerprint"]: r for r in wf._iter_findings_raw()}
+
+    def test_ages_out_when_required_token_gone(self, tmp_path):
+        from agents.watcher import findings as wf
+
+        src = tmp_path / "mod.py"
+        # Line 2 is a return statement — NO `UNITARESMonitor(` token, the exact
+        # divergence-surface shape (constructor drifted away, return remains).
+        src.write_text("def get_primary_eisv(self):\n    return self.state.E\n")
+        self._seed({"pattern": "P003", "file": str(src), "line": 2, "fingerprint": "aaaa1111"})
+
+        aged = wf._sweep_token_drift_quiet()
+
+        assert aged == 1
+        rec = self._records()["aaaa1111"]
+        assert rec["status"] == "aged_out"
+        assert rec["resolution_reason"] == "line_drift_token_absent"
+        assert rec.get("aged_out_at")
+
+    def test_keeps_when_required_token_present(self, tmp_path):
+        from agents.watcher import findings as wf
+
+        src = tmp_path / "mod.py"
+        src.write_text("x = 1\nmonitor = UNITARESMonitor(agent_id)\n")  # line 2 holds the token
+        self._seed({"pattern": "P003", "file": str(src), "line": 2, "fingerprint": "bbbb2222"})
+
+        aged = wf._sweep_token_drift_quiet()
+
+        assert aged == 0
+        assert self._records()["bbbb2222"]["status"] == "open"
+
+    def test_p001_ages_out_without_create_task(self, tmp_path):
+        from agents.watcher import findings as wf
+
+        src = tmp_path / "uds.py"
+        # The uds_listener shape: flagged line is a bare `try:` in cleanup, no
+        # `create_task(` anywhere on it.
+        src.write_text("if os.path.exists(p):\n    try:\n        os.unlink(p)\n")
+        self._seed({"pattern": "P001", "file": str(src), "line": 2, "fingerprint": "cccc3333"})
+
+        assert wf._sweep_token_drift_quiet() == 1
+        assert self._records()["cccc3333"]["status"] == "aged_out"
+
+    def test_skips_pattern_without_required_token(self, tmp_path):
+        """P011 has no entry in _PATTERN_REQUIRED_TOKENS, so this sweep must
+        never touch it (its FPs are a verifier-quality issue, not staleness)."""
+        from agents.watcher import findings as wf
+
+        src = tmp_path / "r1.py"
+        src.write_text("for c in cs:\n    counts['evaluated'] += 1\n")
+        self._seed({"pattern": "P011", "file": str(src), "line": 2, "fingerprint": "dddd4444"})
+
+        assert wf._sweep_token_drift_quiet() == 0
+        assert self._records()["dddd4444"]["status"] == "open"
+
+    def test_does_not_touch_terminal_findings(self, tmp_path):
+        """A dismissed finding whose token is gone stays dismissed — the sweep
+        only acts on the active (open/surfaced) queue."""
+        from agents.watcher import findings as wf
+
+        src = tmp_path / "mod.py"
+        src.write_text("x = 1\n    return None\n")
+        self._seed(
+            {"pattern": "P003", "file": str(src), "line": 2, "fingerprint": "eeee5555", "status": "dismissed"}
+        )
+
+        assert wf._sweep_token_drift_quiet() == 0
+        assert self._records()["eeee5555"]["status"] == "dismissed"
+
+    def test_out_of_range_line_left_alone(self, tmp_path):
+        """File present but stored line is beyond EOF → conservative skip (no
+        false age-out; the file-existence sweep and future scans cover it)."""
+        from agents.watcher import findings as wf
+
+        src = tmp_path / "mod.py"
+        src.write_text("x = 1\ny = 2\n")  # only 2 lines
+        self._seed({"pattern": "P003", "file": str(src), "line": 50, "fingerprint": "ffff6666"})
+
+        assert wf._sweep_token_drift_quiet() == 0
+        assert self._records()["ffff6666"]["status"] == "open"
+
+    def test_missing_file_left_for_existence_sweep(self, tmp_path):
+        """A finding whose file no longer exists is not aged out here — that's
+        the separate _sweep_stale_quiet's job; this sweep must not crash on it."""
+        from agents.watcher import findings as wf
+
+        self._seed(
+            {"pattern": "P003", "file": str(tmp_path / "gone.py"), "line": 1, "fingerprint": "9999aaaa"}
+        )
+
+        assert wf._sweep_token_drift_quiet() == 0
+        assert self._records()["9999aaaa"]["status"] == "open"


### PR DESCRIPTION
## Problem

The Watcher's required-token verifier (`_PATTERN_REQUIRED_TOKENS`) only runs at **detection** time. A finding's stored line number drifts as the file is later edited, so the same finding can surface at chime pointing at a line that no longer holds the construct (a `return`, a docstring, a blank line). This is the line-drift false-positive class behind repeated P003/P001/P016 dismissal sweeps — `patterns.md` flagged the fix on 2026-05-04 ("replay the required-token check at chime time… would harden the *entire* detector pipeline"), but it was never shipped.

Surfaced concretely by a 2026-06-18 triage: **5 of 13 HIGH findings were token-drift stale** — 4× P003 pointing at `return`/docstring/`staticmethod`/blank lines (the single real `UNITARESMonitor(` constructor had drifted ~17 lines down), and 1× P001 pointing at a bare `try:` in socket cleanup.

## Fix

`surface_pending()` already sweeps findings whose **file** no longer exists. This adds a second quiet sweep (`_sweep_token_drift_quiet`) that replays the detection-time token gate against **current disk content** and **ages out** findings whose flagged line lost its required token.

- **Aged out, not deleted** — keeps the audit trail + precision math; `--compact` reclaims after the TTL.
- **Conservative by construction**: only token-gated patterns are touched; a line that *still* holds its token is never aged out (a real match is never dropped); unreadable/out-of-range lines are left for the file-existence sweep.
- **Scope honesty**: does **not** help patterns without a required token (P011 etc.) — those FPs (e.g. local-counter increments flagged as mutate-then-persist) are a verifier-quality issue, not staleness, and need a separate structural fix.

## Tests

7 new cases in `TestTokenDriftRevalidation` (token gone → `aged_out`; token present → kept; P001 without `create_task` → aged out; non-token pattern → skipped; terminal findings untouched; out-of-range + missing-file left alone). `_make_raw_entry`'s default pattern flipped to a token-free one so queue-logic fixtures don't trip the new sweep. **Full watcher suite green (261 passed).**

Wired only into the chime path (`surface_pending`); the read-only `--print-unresolved` (SessionStart) is left non-mutating, matching how the existing file-staleness sweep is wired — extending re-validation there (as a non-mutating display filter) is a natural follow-up.

https://claude.ai/code/session_01JqgvE7zmGV1N6EeKyHqCLF