### PR TITLE
fix(lease-plane): format code and redact error logs

### DIFF
--- a/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/http_router.ex
@@ -47,9 +47,7 @@ defmodule UnitaresLeasePlane.HTTPRouter do
   # error is logged server-side; the wire body never carries inspect output.
   @impl Plug.ErrorHandler
   def handle_errors(conn, %{kind: kind, reason: reason, stack: _stack}) do
-    Logger.error(
-      "lease plane HTTP error: kind=#{kind} reason=#{Exception.format_banner(kind, reason)}"
-    )
+    Logger.error("lease plane HTTP error: kind=#{kind} reason=#{safe_reason(reason)}")
 
     json(conn, 503, %{
       ok: false,
@@ -77,9 +75,12 @@ defmodule UnitaresLeasePlane.HTTPRouter do
             # missing fields caused production 409s to fail Pydantic validation
             # → degraded to AcquireSchemaInvalid → acquire_with_retry never retried).
             now = DateTime.utc_now()
+
             remaining_ms =
               max(0, DateTime.diff(info.expires_at, now, :millisecond))
+
             retry_after_hint_ms = min(remaining_ms, 5_000)
+
             json(conn, 409, %{
               ok: false,
               error: "held_by_other",
@@ -99,7 +100,7 @@ defmodule UnitaresLeasePlane.HTTPRouter do
             json(conn, 422, %{ok: false, error: "schema_invalid", detail: name})
 
           {:error, reason} ->
-            Logger.error("lease plane acquire failed: #{inspect(reason)}")
+            Logger.error("lease plane acquire failed: #{safe_reason(reason)}")
             json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
         end
 
@@ -185,8 +186,13 @@ defmodule UnitaresLeasePlane.HTTPRouter do
                 json(conn, 200, %{ok: true, lease: present_lease(lease)})
 
               {:error, reason} ->
-                Logger.error("lease plane status failed: #{inspect(reason)}")
-                json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
+                Logger.error("lease plane status failed: #{safe_reason(reason)}")
+
+                json(conn, 503, %{
+                  ok: false,
+                  error: "service_unavailable",
+                  reason: "internal error"
+                })
             end
         end
     end
@@ -210,7 +216,7 @@ defmodule UnitaresLeasePlane.HTTPRouter do
             json(conn, 404, %{ok: false, error: "not_found"})
 
           {:error, reason_atom} ->
-            Logger.error("lease plane release failed: #{inspect(reason_atom)}")
+            Logger.error("lease plane release failed: #{safe_reason(reason_atom)}")
             json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
         end
 
@@ -240,7 +246,7 @@ defmodule UnitaresLeasePlane.HTTPRouter do
             json(conn, 404, %{ok: false, error: "not_found"})
 
           {:error, reason_atom} ->
-            Logger.error("lease plane force-release failed: #{inspect(reason_atom)}")
+            Logger.error("lease plane force-release failed: #{safe_reason(reason_atom)}")
             json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
         end
 
@@ -260,7 +266,7 @@ defmodule UnitaresLeasePlane.HTTPRouter do
             json(conn, 404, %{ok: false, error: "not_found"})
 
           {:error, reason} ->
-            Logger.error("lease plane handoff offer failed: #{inspect(reason)}")
+            Logger.error("lease plane handoff offer failed: #{safe_reason(reason)}")
             json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
         end
 
@@ -283,7 +289,7 @@ defmodule UnitaresLeasePlane.HTTPRouter do
             json(conn, 409, %{ok: false, error: "expired"})
 
           {:error, reason} ->
-            Logger.error("lease plane handoff accept failed: #{inspect(reason)}")
+            Logger.error("lease plane handoff accept failed: #{safe_reason(reason)}")
             json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
         end
 
@@ -345,14 +351,20 @@ defmodule UnitaresLeasePlane.HTTPRouter do
               {:error, :not_found} ->
                 json(conn, 404, %{ok: false, error: "not_found"})
 
-              {:error, %Postgrex.Error{postgres: %{code: :check_violation, constraint_name: name}}} ->
+              {:error,
+               %Postgrex.Error{postgres: %{code: :check_violation, constraint_name: name}}} ->
                 # RFC §7.13.5 typed-error contract for renew CHECK violations.
                 # MUST precede the generic 503 arm.
                 json(conn, 422, %{ok: false, error: "schema_invalid", detail: name})
 
               {:error, reason} ->
-                Logger.error("lease plane renew failed: #{inspect(reason)}")
-                json(conn, 503, %{ok: false, error: "service_unavailable", reason: "internal error"})
+                Logger.error("lease plane renew failed: #{safe_reason(reason)}")
+
+                json(conn, 503, %{
+                  ok: false,
+                  error: "service_unavailable",
+                  reason: "internal error"
+                })
             end
         end
 
@@ -521,7 +533,7 @@ defmodule UnitaresLeasePlane.HTTPRouter do
         {:ok, lease_id, reason}
 
       true ->
-        {:error, "invalid release_reason: #{inspect(reason)}"}
+        {:error, "invalid release_reason"}
     end
   end
 
@@ -625,8 +637,27 @@ defmodule UnitaresLeasePlane.HTTPRouter do
 
   defp json(conn, status, body) do
     versioned_body = Map.put(body, :protocol_version, @protocol_version)
+
     conn
     |> Plug.Conn.put_resp_content_type("application/json")
     |> Plug.Conn.send_resp(status, Jason.encode!(versioned_body))
+  end
+
+  defp safe_reason(%module{}), do: inspect(module)
+  defp safe_reason(reason) when is_atom(reason), do: Atom.to_string(reason)
+  defp safe_reason(reason) when is_binary(reason), do: redact_sensitive(reason)
+
+  defp safe_reason(reason) do
+    reason
+    |> inspect(limit: 5, printable_limit: 120)
+    |> redact_sensitive()
+  end
+
+  defp redact_sensitive(text) do
+    Regex.replace(
+      ~r/(password|token|secret|authorization|bearer)(\s*[=:]\s*)[^\s,}\]]+/i,
+      text,
+      "\\1\\2[REDACTED]"
+    )
   end
 end

--- a/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
+++ b/elixir/lease_plane/lib/unitares_lease_plane/repo.ex
@@ -256,7 +256,11 @@ defmodule UnitaresLeasePlane.Repo do
       # (race against the reaper). Fall through to acquire_step_nil so the
       # caller still gets a fresh acquire instead of a confusing :not_found.
       {:ok, %{rows: []}} ->
-        acquire_step_nil(conn, p_from_existing(existing, substrate_state, substrate_observed_at), 0)
+        acquire_step_nil(
+          conn,
+          p_from_existing(existing, substrate_state, substrate_observed_at),
+          0
+        )
 
       {:error, e} ->
         {:error, e}

--- a/elixir/lease_plane/test/canonicalize_property_test.exs
+++ b/elixir/lease_plane/test/canonicalize_property_test.exs
@@ -161,6 +161,7 @@ defmodule UnitaresLeasePlane.CanonicalizeProperty do
     property "canonicalize/1 always returns {:ok,_} or {:error,_} for any binary, never raises" do
       check all(input <- StreamData.binary(min_length: 0, max_length: 256)) do
         result = Canonicalize.canonicalize(input)
+
         assert match?({:ok, _}, result) or match?({:error, _}, result),
                "expected tagged tuple, got #{inspect(result)}"
       end
@@ -193,6 +194,7 @@ defmodule UnitaresLeasePlane.CanonicalizeProperty do
         case Canonicalize.canonicalize(input) do
           {:ok, "capture:/" <> path} ->
             members = String.split(path, ",", trim: true)
+
             assert members == Enum.sort(members),
                    "expected sorted members, got #{inspect(members)}"
 
@@ -222,7 +224,15 @@ defmodule UnitaresLeasePlane.CanonicalizeProperty do
   describe "top-level ? rejection (PR 7 council BLOCK B1 — RFC §7.12.4 OPERATOR_NOTE 3)" do
     property "any input containing ? produces {:error, :reserved_query_string}" do
       check all(
-              prefix <- StreamData.member_of(["dialectic:/", "resident:/", "capture:/", "td:/", "file:///", ""]),
+              prefix <-
+                StreamData.member_of([
+                  "dialectic:/",
+                  "resident:/",
+                  "capture:/",
+                  "td:/",
+                  "file:///",
+                  ""
+                ]),
               before <- StreamData.string(:alphanumeric, max_length: 16),
               after_q <- StreamData.string(:alphanumeric, max_length: 16)
             ) do

--- a/elixir/lease_plane/test/http_router_test.exs
+++ b/elixir/lease_plane/test/http_router_test.exs
@@ -2,6 +2,7 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
   use ExUnit.Case, async: false
   import Plug.Test
   import Plug.Conn
+  import ExUnit.CaptureLog
 
   import LeaseTestHelpers
 
@@ -116,7 +117,8 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
       assert is_binary(lease["expires_at"])
     end
 
-    test "agent:/ surface routes to the remote_heartbeat self-healing path (migration 042)", _ctx do
+    test "agent:/ surface routes to the remote_heartbeat self-healing path (migration 042)",
+         _ctx do
       agent_surface = "agent:/ag-" <> binary_part(random_uuid(), 0, 8)
       on_exit(fn -> cleanup_surface(agent_surface) end)
 
@@ -299,6 +301,7 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
     test "file:// surface routes to remote_heartbeat (self-healing, no holder)", ctx do
       path = Path.join(ctx.tmp_dir, "edit-target.txt")
       File.write!(path, "x")
+
       resp =
         post_json(
           "/v1/lease/acquire",
@@ -314,6 +317,7 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
 
     test "resident:/ surface stays local_beam even when remote_heartbeat requested", _ctx do
       surface = "resident:/lease-routing-test-#{random_uuid()}"
+
       resp =
         post_json(
           "/v1/lease/acquire",
@@ -591,13 +595,21 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
       # pre-handler conn). Direct test of handle_errors/2 is the same coverage —
       # what matters is the response shape, not which integration triggered it.
       conn = conn(:post, "/v1/lease/renew")
+      parent = self()
 
-      result =
-        HTTPRouter.handle_errors(conn, %{
-          kind: :error,
-          reason: %RuntimeError{message: "postgresql password=hunter2 leaked"},
-          stack: []
-        })
+      log =
+        capture_log(fn ->
+          result =
+            HTTPRouter.handle_errors(conn, %{
+              kind: :error,
+              reason: %RuntimeError{message: "postgresql password=hunter2 leaked"},
+              stack: []
+            })
+
+          send(parent, {:handle_errors_result, result})
+        end)
+
+      assert_receive {:handle_errors_result, result}
 
       assert result.status == 503
       body = Jason.decode!(result.resp_body)
@@ -607,10 +619,13 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
                "error" => "service_unavailable",
                "reason" => "internal error"
              }
+
       assert body["protocol_version"] == "v1.0"
 
-      # Verify the leaky inspect string never made it to the wire.
+      # Verify the leaky inspect string never made it to the wire or logs.
       refute result.resp_body =~ "hunter2"
+      refute log =~ "hunter2"
+      refute log =~ "password=hunter2"
     end
   end
 
@@ -684,6 +699,7 @@ defmodule UnitaresLeasePlane.HTTPRouterTest do
 
     test "force-release token unconfigured → 503 fail-closed", _ctx do
       Application.put_env(:lease_plane, :force_release_token, nil)
+
       on_exit(fn ->
         Application.put_env(:lease_plane, :force_release_token, @force_release_token)
       end)

--- a/elixir/lease_plane/test/protocol_version_test.exs
+++ b/elixir/lease_plane/test/protocol_version_test.exs
@@ -97,13 +97,16 @@ defmodule UnitaresLeasePlane.HTTPRouter.ProtocolVersionTest do
     # `refute`d the field's presence and documented the gap.
     resp =
       :post
-      |> conn("/v1/lease/acquire", Jason.encode!(%{
-           surface_id: ctx.surface,
-           holder_agent_uuid: random_uuid(),
-           holder_kind: "local_beam",
-           holder_class: "process_instance",
-           ttl_s: 30
-         }))
+      |> conn(
+        "/v1/lease/acquire",
+        Jason.encode!(%{
+          surface_id: ctx.surface,
+          holder_agent_uuid: random_uuid(),
+          holder_kind: "local_beam",
+          holder_class: "process_instance",
+          ttl_s: 30
+        })
+      )
       |> put_req_header("content-type", "application/json")
       |> put_req_header("authorization", "Bearer wrong-token")
       |> HTTPRouter.call(@opts)
@@ -120,13 +123,16 @@ defmodule UnitaresLeasePlane.HTTPRouter.ProtocolVersionTest do
     # carry protocol_version post-Phase-A.5.
     resp =
       :post
-      |> conn("/v1/lease/acquire", Jason.encode!(%{
-           surface_id: ctx.surface,
-           holder_agent_uuid: random_uuid(),
-           holder_kind: "local_beam",
-           holder_class: "process_instance",
-           ttl_s: 30
-         }))
+      |> conn(
+        "/v1/lease/acquire",
+        Jason.encode!(%{
+          surface_id: ctx.surface,
+          holder_agent_uuid: random_uuid(),
+          holder_kind: "local_beam",
+          holder_class: "process_instance",
+          ttl_s: 30
+        })
+      )
       |> put_req_header("content-type", "application/json")
       |> HTTPRouter.call(@opts)
 
@@ -142,13 +148,16 @@ defmodule UnitaresLeasePlane.HTTPRouter.ProtocolVersionTest do
 
     resp =
       :post
-      |> conn("/v1/lease/acquire", Jason.encode!(%{
-           surface_id: ctx.surface,
-           holder_agent_uuid: random_uuid(),
-           holder_kind: "local_beam",
-           holder_class: "process_instance",
-           ttl_s: 30
-         }))
+      |> conn(
+        "/v1/lease/acquire",
+        Jason.encode!(%{
+          surface_id: ctx.surface,
+          holder_agent_uuid: random_uuid(),
+          holder_kind: "local_beam",
+          holder_class: "process_instance",
+          ttl_s: 30
+        })
+      )
       |> put_req_header("content-type", "application/json")
       |> put_req_header("authorization", "Bearer anything")
       |> HTTPRouter.call(@opts)

--- a/elixir/lease_plane/test/unitares_lease_plane_test.exs
+++ b/elixir/lease_plane/test/unitares_lease_plane_test.exs
@@ -158,6 +158,7 @@ defmodule UnitaresLeasePlaneTest do
       assert before.substrate_state_observed_at == nil
 
       observed_at = DateTime.utc_now()
+
       assert :ok =
                UnitaresLeasePlane.renew(
                  before.lease_id,
@@ -206,41 +207,49 @@ defmodule UnitaresLeasePlaneTest do
       # subsequent cycles ran. Fix: idempotent acquire COALESCE-updates
       # substrate columns when caller provided them.
 
-      surface = "resident:/test_elixir_idempotent_substrate_#{:erlang.unique_integer([:positive])}"
+      surface =
+        "resident:/test_elixir_idempotent_substrate_#{:erlang.unique_integer([:positive])}"
+
       on_exit(fn -> cleanup_surface(surface) end)
 
       params = local_beam_params(surface, ttl_s: 60)
-      params_with_substrate_v1 = Map.merge(params, %{
-        substrate_state: %{
-          "E" => 0.5,
-          "I" => 0.5,
-          "S" => 0.0,
-          "V" => 0.05,
-          "sensor" => %{"status" => "healthy"}
-        },
-        substrate_state_observed_at: DateTime.utc_now()
-      })
+
+      params_with_substrate_v1 =
+        Map.merge(params, %{
+          substrate_state: %{
+            "E" => 0.5,
+            "I" => 0.5,
+            "S" => 0.0,
+            "V" => 0.05,
+            "sensor" => %{"status" => "healthy"}
+          },
+          substrate_state_observed_at: DateTime.utc_now()
+        })
 
       assert {:ok, lease, :new} =
                UnitaresLeasePlane.acquire_local_beam(params_with_substrate_v1)
+
       first_observed_at = lease.substrate_state_observed_at
       assert lease.substrate_state["V"] == 0.05
 
       # Cycle 2: same holder, same surface, NEW substrate values.
       observed_at_2 = DateTime.add(DateTime.utc_now(), 1, :second)
-      params_with_substrate_v2 = Map.merge(params, %{
-        substrate_state: %{
-          "E" => 0.7,
-          "I" => 0.3,
-          "S" => 0.2,
-          "V" => 0.15,
-          "sensor" => %{"status" => "degraded"}
-        },
-        substrate_state_observed_at: observed_at_2
-      })
+
+      params_with_substrate_v2 =
+        Map.merge(params, %{
+          substrate_state: %{
+            "E" => 0.7,
+            "I" => 0.3,
+            "S" => 0.2,
+            "V" => 0.15,
+            "sensor" => %{"status" => "degraded"}
+          },
+          substrate_state_observed_at: observed_at_2
+        })
 
       assert {:ok, refreshed, :idempotent} =
                UnitaresLeasePlane.acquire_local_beam(params_with_substrate_v2)
+
       # New substrate values overwrote the old (THE BUG WAS: refreshed.substrate_state["V"] == 0.05)
       assert refreshed.substrate_state["V"] == 0.15
       assert refreshed.substrate_state["sensor"]["status"] == "degraded"
@@ -253,7 +262,9 @@ defmodule UnitaresLeasePlaneTest do
     end
 
     test "idempotent re-acquire WITHOUT substrate is unchanged (legacy callers preserved)" do
-      surface = "resident:/test_elixir_idempotent_no_substrate_#{:erlang.unique_integer([:positive])}"
+      surface =
+        "resident:/test_elixir_idempotent_no_substrate_#{:erlang.unique_integer([:positive])}"
+
       on_exit(fn -> cleanup_surface(surface) end)
 
       params = local_beam_params(surface, ttl_s: 60)
@@ -351,7 +362,8 @@ defmodule UnitaresLeasePlaneTest do
       assert %DateTime{} = forwarded_at
     end
 
-    test "§7.2.8 contract — top-level keys present, surface_id un-encoded, §6.1 LIKE works", ctx do
+    test "§7.2.8 contract — top-level keys present, surface_id un-encoded, §6.1 LIKE works",
+         ctx do
       params = local_beam_params(ctx.surface)
       assert {:ok, _lease, :new} = UnitaresLeasePlane.acquire_local_beam(params)
       event_id = acquire_event_id(ctx.surface)


### PR DESCRIPTION
## Summary
- run `mix format` across the lease-plane Elixir files that failed `mix format --check-formatted`
- add a `handle_errors/2` regression that captures logs and proves credential-shaped exception text does not leak
- sanitize lease-plane error logging via `safe_reason/1` instead of raw exception/message inspection

## Test Plan
- `cd elixir/lease_plane && mix format --check-formatted`
- `cd elixir/lease_plane && mix compile --warnings-as-errors`
- `cd elixir/lease_plane && mix test`
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 ./scripts/dev/test-cache.sh`
