### PR TITLE
test(dashboard): cover DashboardState pub/sub and DataProcessor formatters

### DIFF
--- a/dashboard/tests/state.test.js
+++ b/dashboard/tests/state.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { loadDashboardScripts } from './helpers/load-dashboard.js';
+
+// DashboardState is a standalone pub/sub container (state.js, no deps). We build
+// fresh instances via the exported constructor so tests never touch the singleton.
+let DashboardState;
+
+beforeEach(() => {
+    loadDashboardScripts(['state.js']);
+    DashboardState = window.DashboardState;
+});
+
+describe('DashboardState get/set', () => {
+    it('returns initial values and undefined for unknown keys', () => {
+        const s = new DashboardState({ a: 1, b: 'two' });
+        expect(s.get('a')).toBe(1);
+        expect(s.get('b')).toBe('two');
+        expect(s.get('missing')).toBeUndefined();
+    });
+
+    it('set updates values and a later get reflects them', () => {
+        const s = new DashboardState({ count: 0 });
+        s.set({ count: 5, added: true });
+        expect(s.get('count')).toBe(5);
+        expect(s.get('added')).toBe(true);
+    });
+
+    it('set ignores inherited (non-own) properties', () => {
+        const s = new DashboardState({});
+        // An object whose prototype carries `polluted` — for..in would surface it
+        // without the own-property guard fixed in state.js.
+        const proto = { polluted: 'nope' };
+        const updates = Object.create(proto);
+        updates.real = 'yes';
+        s.set(updates);
+        expect(s.get('real')).toBe('yes');
+        expect(s.get('polluted')).toBeUndefined();
+    });
+});
+
+describe('DashboardState subscriptions', () => {
+    it('notifies a key listener with (newVal, oldVal, key)', () => {
+        const s = new DashboardState({ x: 1 });
+        const calls = [];
+        s.on('x', (newVal, oldVal, key) => calls.push([newVal, oldVal, key]));
+        s.set({ x: 2 });
+        expect(calls).toEqual([[2, 1, 'x']]);
+    });
+
+    it('does not fire a key listener for other keys', () => {
+        const s = new DashboardState({ x: 1, y: 1 });
+        let fired = false;
+        s.on('x', () => {
+            fired = true;
+        });
+        s.set({ y: 9 });
+        expect(fired).toBe(false);
+    });
+
+    it('notifies wildcard listeners with (key, newVal, oldVal)', () => {
+        const s = new DashboardState({ x: 1 });
+        const calls = [];
+        s.on('*', (key, newVal, oldVal) => calls.push([key, newVal, oldVal]));
+        s.set({ x: 7 });
+        expect(calls).toEqual([['x', 7, 1]]);
+    });
+
+    it('the returned unsubscribe stops further key notifications', () => {
+        const s = new DashboardState({ x: 1 });
+        let count = 0;
+        const off = s.on('x', () => {
+            count += 1;
+        });
+        s.set({ x: 2 });
+        off();
+        s.set({ x: 3 });
+        expect(count).toBe(1);
+    });
+
+    it('the returned unsubscribe stops further wildcard notifications', () => {
+        const s = new DashboardState({ x: 1 });
+        let count = 0;
+        const off = s.on('*', () => {
+            count += 1;
+        });
+        s.set({ x: 2 });
+        off();
+        s.set({ x: 3 });
+        expect(count).toBe(1);
+    });
+});
+
+describe('DashboardState snapshot', () => {
+    it('returns a shallow copy that does not mutate internal state', () => {
+        const s = new DashboardState({ a: 1 });
+        const snap = s.snapshot();
+        snap.a = 999;
+        expect(s.get('a')).toBe(1);
+    });
+});

--- a/dashboard/tests/utils.test.js
+++ b/dashboard/tests/utils.test.js
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { loadDashboardScripts } from './helpers/load-dashboard.js';
+
+// DataProcessor is a Layer-0 module (utils.js, no deps). escapeHtml and
+// highlightMatch are the dashboard's XSS boundary, so they get the most coverage.
+let DataProcessor;
+
+beforeEach(() => {
+    loadDashboardScripts(['utils.js']);
+    DataProcessor = window.DataProcessor;
+});
+
+describe('DataProcessor.escapeHtml', () => {
+    it('returns empty string for null/undefined', () => {
+        expect(DataProcessor.escapeHtml(null)).toBe('');
+        expect(DataProcessor.escapeHtml(undefined)).toBe('');
+    });
+
+    it('escapes the five HTML-sensitive characters', () => {
+        expect(DataProcessor.escapeHtml('&')).toBe('&amp;');
+        expect(DataProcessor.escapeHtml('<')).toBe('&lt;');
+        expect(DataProcessor.escapeHtml('>')).toBe('&gt;');
+        expect(DataProcessor.escapeHtml('"')).toBe('&quot;');
+        expect(DataProcessor.escapeHtml("'")).toBe('&#39;');
+    });
+
+    it('neutralizes a script-tag XSS payload', () => {
+        expect(DataProcessor.escapeHtml("<script>alert('x')</script>")).toBe(
+            '&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;'
+        );
+    });
+
+    it('coerces non-string input to string', () => {
+        expect(DataProcessor.escapeHtml(42)).toBe('42');
+    });
+});
+
+describe('DataProcessor.highlightMatch', () => {
+    it('escapes the text when no term is given', () => {
+        expect(DataProcessor.highlightMatch('<b>', '')).toBe('&lt;b&gt;');
+        expect(DataProcessor.highlightMatch('<b>', null)).toBe('&lt;b&gt;');
+    });
+
+    it('wraps a case-insensitive match in a <mark>', () => {
+        expect(DataProcessor.highlightMatch('Hello World', 'world')).toBe(
+            'Hello <mark class="highlight">World</mark>'
+        );
+    });
+
+    it('escapes HTML in both the matched and unmatched segments', () => {
+        // The matched "<world>" is HTML-escaped inside the <mark>; surrounding
+        // text is escaped too. Confirms highlighting never opens an XSS hole.
+        expect(DataProcessor.highlightMatch('a <world> b', '<world>')).toBe(
+            'a <mark class="highlight">&lt;world&gt;</mark> b'
+        );
+    });
+
+    it('treats regex metacharacters in the term as literals', () => {
+        // "a.b" must match the literal "a.b", not "axb" — the term is regex-escaped.
+        expect(DataProcessor.highlightMatch('axb a.b', 'a.b')).toBe(
+            'axb <mark class="highlight">a.b</mark>'
+        );
+    });
+});
+
+describe('DataProcessor.formatRelativeTime', () => {
+    const MIN = 60 * 1000;
+    const HOUR = 60 * MIN;
+    const DAY = 24 * HOUR;
+
+    it('returns null for falsy input', () => {
+        expect(DataProcessor.formatRelativeTime(0)).toBeNull();
+        expect(DataProcessor.formatRelativeTime(null)).toBeNull();
+    });
+
+    it('returns "just now" for non-positive elapsed time', () => {
+        expect(DataProcessor.formatRelativeTime(Date.now() + 5000)).toBe('just now');
+    });
+
+    it('buckets seconds / minutes / hours / days', () => {
+        expect(DataProcessor.formatRelativeTime(Date.now() - 5000)).toBe('5s ago');
+        expect(DataProcessor.formatRelativeTime(Date.now() - 3 * MIN)).toBe('3m ago');
+        expect(DataProcessor.formatRelativeTime(Date.now() - 2 * HOUR)).toBe('2h ago');
+        expect(DataProcessor.formatRelativeTime(Date.now() - 3 * DAY)).toBe('3d ago');
+    });
+
+    it('buckets weeks / months / years', () => {
+        expect(DataProcessor.formatRelativeTime(Date.now() - 14 * DAY)).toBe('2w ago');
+        expect(DataProcessor.formatRelativeTime(Date.now() - 60 * DAY)).toBe('2mo ago');
+        expect(DataProcessor.formatRelativeTime(Date.now() - 800 * DAY)).toBe('2y ago');
+    });
+});
+
+describe('DataProcessor.formatTimestamp', () => {
+    it('returns null for falsy or unparseable input', () => {
+        expect(DataProcessor.formatTimestamp(null)).toBeNull();
+        expect(DataProcessor.formatTimestamp('not-a-date')).toBeNull();
+    });
+
+    it('produces a readable string for a valid timestamp', () => {
+        // Exact time is locale/timezone dependent; assert structure, not the clock.
+        const out = DataProcessor.formatTimestamp('2026-03-15T12:00:00Z');
+        expect(out).toMatch(/Mar \d+/);
+        expect(typeof out).toBe('string');
+    });
+});


### PR DESCRIPTION
Continuing the DX direction on my own initiative, after the toolchain landed (#851). The frontend suite only exercised the agent-list render; this adds coverage for the two core logic modules that had **zero tests**, using the same jsdom harness from #849.

## What's covered

**`state.js` / `DashboardState`** (9 tests) — the pub/sub state container every module reads/writes through:
- `get`/`set` semantics
- key listeners and `*` wildcard listeners, with the exact callback argument order
- the unsubscribe function returned by `on()`
- `snapshot()` isolation
- the **own-property guard** — an inherited prototype key must not be copied in by `set()` (regression-locks the `hasOwnProperty` fix from #851)

**`utils.js` / `DataProcessor`** (14 tests) — the dashboard's **XSS boundary** gets the most attention:
- `escapeHtml`: the five sensitive chars, a `<script>` payload, null/undefined, non-string coercion
- `highlightMatch`: HTML-escaping of **both** matched and unmatched segments (highlighting must never open an XSS hole), and **regex-metacharacter literalization** in the search term (`a.b` matches literal `a.b`, not `axb`)
- `formatRelativeTime`: s/m/h/d/w/mo/y bucketing, falsy input, and the future→"just now" path
- `formatTimestamp`: null/invalid handling (exact clock left untested since it's locale/timezone dependent)

## Notes
- **32 frontend tests total, up from 9.** Pure additions — no runtime code touched.
- Verified locally by exit code: `lint` ✓, `format:check` ✓, `test` ✓ (32 passed), `build` ✓.

This is a safe, self-contained quality step; no deployment decisions involved. The bigger open items (switching production serving to the bundle, the repo-wide Prettier pass, the incremental ESM migration, then the UX pass) remain as discussed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015CWDAp4hoA7cBNEt6fjhG9)_