### PR TITLE
fix(dashboard): accessibility pass — keyboard cards, live regions, contrast

### DIFF
--- a/dashboard/agents.js
+++ b/dashboard/agents.js
@@ -423,7 +423,7 @@
                 ? '<span class="agent-metrics-toggle" data-agent-uuid="' + escapeHtml(agentId) + '"><span class="toggle-arrow">\u25B8</span> Metrics</span>'
                 : '';
 
-            return '<div class="agent-item ' + statusClass + '" data-agent-uuid="' + escapeHtml(agentId) + '" title="Click to view details">' +
+            return '<div class="agent-item ' + statusClass + '" data-agent-uuid="' + escapeHtml(agentId) + '" role="button" tabindex="0" aria-label="View details for ' + escapeHtml(displayName) + '" title="View details">' +
                 '<div class="agent-meta">' +
                     '<div class="agent-title">' +
                         statusIndicator +

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -251,7 +251,7 @@ document.querySelector('.panel-modal-close')?.addEventListener('click', closeMod
     overlay.className = 'shortcuts-overlay';
     overlay.innerHTML =
         '<div class="shortcuts-panel">' +
-        '<div class="shortcuts-header"><h3>Keyboard Shortcuts</h3><button class="shortcuts-close" type="button">&times;</button></div>' +
+        '<div class="shortcuts-header"><h3>Keyboard Shortcuts</h3><button class="shortcuts-close" type="button" aria-label="Close">&times;</button></div>' +
         '<div class="shortcuts-grid">' +
         '<div class="shortcut-row"><kbd>r</kbd><span>Refresh data</span></div>' +
         '<div class="shortcut-row"><kbd>t</kbd><span>Toggle theme</span></div>' +
@@ -2072,6 +2072,23 @@ if (agentsContainer) {
         if (!agentUuid) return;
         const agent = cachedAgents.find(a => (a.agent_id || '') === agentUuid);
         if (agent) showAgentDetail(agent);
+    });
+
+    // Keyboard: agent cards are role="button" tabindex="0" — Enter/Space opens
+    // detail, matching the click path above so the primary interaction is not
+    // mouse-only (WCAG 2.1.1). Only act when the card itself is focused, so
+    // Enter/Space inside nested controls (copy/pin/metrics toggle) is untouched.
+    agentsContainer.addEventListener('keydown', event => {
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        const agentItem = event.target.closest('.agent-item');
+        if (!agentItem || event.target !== agentItem) return;
+        const agentUuid = agentItem.getAttribute('data-agent-uuid');
+        if (!agentUuid) return;
+        const agent = cachedAgents.find(a => (a.agent_id || '') === agentUuid);
+        if (agent) {
+            event.preventDefault(); // stop Space from scrolling the page
+            showAgentDetail(agent);
+        }
     });
 }
 

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -44,7 +44,7 @@
         <span class="subtitle">Multi-Agent Coordination</span>
     </div>
 
-    <div id="connection-banner" class="banner hidden"></div>
+    <div id="connection-banner" class="banner hidden" role="alert"></div>
 
     <div class="toolbar">
         <div class="toolbar-group">
@@ -71,7 +71,7 @@
         </div>
     </div>
 
-    <div id="error-container"></div>
+    <div id="error-container" role="alert" aria-live="assertive"></div>
 
     <nav class="section-nav" id="section-nav" aria-label="Dashboard sections">
         <a href="#stats-section" class="section-nav-item active" data-section="stats-section">Stats</a>
@@ -104,7 +104,7 @@
         </section>
 
         <!-- Quick Status Hero -->
-        <div class="quick-status" id="quick-status">
+        <div class="quick-status" id="quick-status" role="status" aria-live="polite">
             <span class="quick-status-dot healthy" id="qs-dot"></span>
             <span class="quick-status-label" id="qs-label">Loading...</span>
             <span class="quick-status-separator"></span>
@@ -377,7 +377,7 @@
                 </div>
                 <div id="agents-filter-info" class="filter-info"></div>
                 <div id="agents-status-legend" class="filter-info"></div>
-                <div id="agents-container" class="agent-list">
+                <div id="agents-container" class="agent-list" tabindex="-1">
                     <div class="skeleton-initial" id="agents-skeleton"></div>
                 </div>
             </div>
@@ -689,7 +689,7 @@
         <div class="panel-modal">
             <div class="panel-modal-header">
                 <h2 id="modal-title">Panel</h2>
-                <button class="panel-modal-close">&times;</button>
+                <button class="panel-modal-close" type="button" aria-label="Close">&times;</button>
             </div>
             <div class="panel-modal-body" id="modal-body">
                 <!-- Content injected by JS -->

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -7,7 +7,7 @@
     --border-highlight: rgba(255, 255, 255, 0.15);
     --text-primary: #f0f0f5;
     --text-secondary: #9aa0af;
-    --text-muted: #6e7681;
+    --text-muted: #8b929c; /* lifted from #6e7681 → ≥4.5:1 on --bg-color (WCAG 1.4.3) */
 
     /* Transitions & Dynamics */
     --transition-fast: 0.15s cubic-bezier(0.4, 0, 0.2, 1);
@@ -78,6 +78,9 @@
     --border-color: rgba(0, 0, 0, 0.08);
     --text-primary: #121214;
     --text-secondary: #5e6472;
+    /* --text-muted is shared from :root; the dark value is too light for the
+       light background, so pin a known ≥4.5:1 value here (WCAG 1.4.3). */
+    --text-muted: #5e6472;
     --item-bg: rgba(255, 255, 255, 0.6);
     --toolbar-bg: rgba(255, 255, 255, 0.85);
     --input-bg: rgba(0, 0, 0, 0.03);

--- a/dashboard/tests/agents.test.js
+++ b/dashboard/tests/agents.test.js
@@ -133,3 +133,17 @@ describe('renderAgentsList — participated vs never-checked-in partition (#826/
         expect(html).toContain('No agents match the current filters');
     });
 });
+
+describe('agent cards are keyboard-operable (WCAG 2.1.1 / 4.1.2)', () => {
+    it('renders each card as a focusable button with an accessible name', () => {
+        const all = [agent({ label: 'RealWorker', total_updates: 7 })];
+        window.state.set({ cachedAgents: all });
+        Agents.renderAgentsList(all, '');
+
+        const card = document.querySelector('#agents-container .agent-item');
+        expect(card).not.toBeNull();
+        expect(card.getAttribute('role')).toBe('button');
+        expect(card.getAttribute('tabindex')).toBe('0');
+        expect(card.getAttribute('aria-label')).toContain('RealWorker');
+    });
+});

--- a/dashboard/utils.js
+++ b/dashboard/utils.js
@@ -824,6 +824,9 @@ function showToast(message, durationMs) {
     durationMs = durationMs || 3000;
     var toast = document.createElement('div');
     toast.className = 'toast';
+    // role="status" makes the toast a polite live region so screen readers
+    // announce it (WCAG 4.1.3 Status Messages).
+    toast.setAttribute('role', 'status');
     toast.textContent = message;
     document.body.appendChild(toast);
     // Trigger reflow then add visible class for animation


### PR DESCRIPTION
First slice of the UX work you asked for. I convened a **4-lens design council** (visual design · usability/Nielsen heuristics · accessibility/WCAG 2.2 · IA & data-viz) to audit the dashboard, then synthesized the findings. This PR ships the **accessibility** subset — the safest, highest-value, no-browser-needed wins, several of them P0.

## Changes (each cites the WCAG criterion)

- **Keyboard-operable agent cards (2.1.1 / 4.1.2)** — the primary Agents interaction was a click on a plain `<div>`, unreachable by keyboard. Cards are now `role="button" tabindex="0"` with an `aria-label`, and a delegated Enter/Space `keydown` (beside the existing click handler) opens detail. It only fires when the card itself is focused, so nested controls (copy/pin/metrics-toggle) are untouched.
- **Status messages reach assistive tech (4.1.3)** — the codebase had *zero* `aria-live`. Added `role="alert"` to the connection banner and error container, `role="status" aria-live="polite"` to the quick-status hero, and `role="status"` to toasts.
- **Accessible names on icon-only close buttons (4.1.2)** — `aria-label="Close"` on the panel-modal and shortcuts-overlay `×` buttons (+ `type="button"` on the modal close).
- **Skip-link actually moves focus (2.4.1)** — `#agents-container` was a non-focusable `<div>`; added `tabindex="-1"`.
- **Muted-text contrast (1.4.3)** — `--text-muted` `#6e7681` failed 4.5:1 on the dark background; lifted to `#8b929c`. The token is shared with the light theme, so I pinned a known-passing override there too (lightening it naively would have *hurt* light-mode contrast).

## Tests / verification
- New vitest assertion: rendered cards expose `role`/`tabindex`/`aria-label`. **33 frontend tests pass.**
- `lint` ✓ · `format:check` ✓ · `test` ✓ · `build` ✓ (verified by exit code).
- All changes are additive attributes or clearly-correct logic — no layout/visual restructuring. I **can't render a browser from here**, so a quick keyboard + screen-reader smoke test before merge is worth it, but nothing here can regress layout.

## What's next (from the same audit, deliberately separate PRs)
- **Status honesty:** `last-update` is stamped at refresh *start* so it advances even when every request fails; four panels (Watcher/Sentinel/Vigil/Chronicler) never auto-refresh; fetch errors blank to `—` (identical to "healthy & quiet").
- **Visual tokens:** `--accent-orange` is actually red (`#ff3d00`), so "caution" looks identical to "critical"; tabular numerals on metric values; reduce always-on decorative motion.
- **Structural (needs your sign-off):** the hero only reflects agent coherence, so it can read "All systems healthy" while the DB is down — rolling all severity sources into the hero + a "needs attention" band is the fix that makes the 5-second test pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015CWDAp4hoA7cBNEt6fjhG9)_