### PR TITLE
fix(dashboard): status honesty — truthful last-updated + auto-refresh stale panels

### DIFF
--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -1719,10 +1719,10 @@ async function refresh(options = {}) {
     // Always do full refresh on force or when search is empty.
 
     clearError();
+    // NOTE: do not stamp "last updated" here — that runs before any data loads
+    // and unconditionally, so the clock advanced even when every request failed,
+    // showing a fresh time over stale data. It is set only on success below.
     const lastUpdateEl = document.getElementById('last-update');
-    if (lastUpdateEl) {
-        lastUpdateEl.textContent = new Date().toLocaleTimeString();
-    }
 
     try {
         console.log('Starting parallel load...');
@@ -1761,6 +1761,23 @@ async function refresh(options = {}) {
             updateConnectionBanner(false);
         }
 
+        // Stamp "last updated" only on a successful refresh, so the clock can't
+        // advance over stale data. On failure, mark the existing time stale
+        // instead of refreshing it.
+        if (lastUpdateEl) {
+            if (criticalFailures < 2) {
+                lastUpdateEl.textContent = new Date().toLocaleTimeString();
+                lastUpdateEl.classList.remove('stale');
+                lastUpdateEl.removeAttribute('title');
+            } else {
+                lastUpdateEl.classList.add('stale');
+                lastUpdateEl.title = 'Last refresh failed — showing the last successful update time';
+                if (!lastUpdateEl.textContent || lastUpdateEl.textContent === '-') {
+                    lastUpdateEl.textContent = 'unavailable';
+                }
+            }
+        }
+
         // Log any individual failures
         results.forEach((result, index) => {
             if (result.status === 'rejected') {
@@ -1773,6 +1790,10 @@ async function refresh(options = {}) {
     } catch (error) {
         // This should rarely happen since we're using Promise.allSettled
         updateConnectionBanner(true);
+        if (lastUpdateEl) {
+            lastUpdateEl.classList.add('stale');
+            lastUpdateEl.title = 'Last refresh failed';
+        }
         console.error('Refresh error:', error);
         showError(`Refresh failed: ${error.message}`);
     }

--- a/dashboard/fleet-metrics.js
+++ b/dashboard/fleet-metrics.js
@@ -314,6 +314,13 @@
             refreshBtn.addEventListener('click', refresh);
         }
         refresh();
+        // Auto-refresh on the dashboard's 30s cadence, honoring the global
+        // "Pause auto-refresh" toggle. Without this the panel loaded once at
+        // init and then showed indefinitely-stale metrics with no cue.
+        setInterval(function () {
+            if (typeof state !== 'undefined' && state.get('autoRefreshPaused')) return;
+            refresh();
+        }, 30000);
     }
 
     if (document.readyState === 'loading') {

--- a/dashboard/sentinel.js
+++ b/dashboard/sentinel.js
@@ -217,6 +217,13 @@
             });
         }
         refresh();
+        // Auto-refresh on the dashboard's 30s cadence, honoring the global
+        // "Pause auto-refresh" toggle. Without this the panel loaded once at
+        // init and then showed indefinitely-stale findings with no cue.
+        setInterval(function () {
+            if (typeof state !== 'undefined' && state.get('autoRefreshPaused')) return;
+            refresh();
+        }, 30000);
     }
 
     if (document.readyState === 'loading') {

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -616,6 +616,17 @@ body::after {
     font-family: var(--font-mono);
 }
 
+/* "Last updated" goes stale when a refresh fails. The "(stale)" text marker is
+   the accessible signal (not colour alone, WCAG 1.4.1); colour reinforces it. */
+#last-update.stale {
+    color: var(--color-warning);
+}
+
+#last-update.stale::after {
+    content: ' (stale)';
+    font-style: italic;
+}
+
 /* ============================================
    Section Navigation
    ============================================ */

--- a/dashboard/vigil.js
+++ b/dashboard/vigil.js
@@ -189,6 +189,13 @@
         var btn = document.getElementById('vigil-refresh');
         if (btn) btn.addEventListener('click', refresh);
         refresh();
+        // Auto-refresh on the dashboard's 30s cadence, honoring the global
+        // "Pause auto-refresh" toggle. Without this the panel loaded once at
+        // init and then showed indefinitely-stale cycles with no cue.
+        setInterval(function () {
+            if (typeof state !== 'undefined' && state.get('autoRefreshPaused')) return;
+            refresh();
+        }, 30000);
     }
 
     if (document.readyState === 'loading') {

--- a/dashboard/watcher.js
+++ b/dashboard/watcher.js
@@ -228,6 +228,13 @@
         var btn = document.getElementById('watcher-refresh');
         if (btn) btn.addEventListener('click', refresh);
         refresh();
+        // Auto-refresh on the dashboard's 30s cadence, honoring the global
+        // "Pause auto-refresh" toggle. Without this the panel loaded once at
+        // init and then showed indefinitely-stale findings with no cue.
+        setInterval(function () {
+            if (typeof state !== 'undefined' && state.get('autoRefreshPaused')) return;
+            refresh();
+        }, 30000);
     }
 
     if (document.readyState === 'loading') {


### PR DESCRIPTION
Second UX slice from the design-council audit — the **status-visibility P0s** the usability and IA reviewers both flagged. Pure behavior/honesty fixes, no visual restructuring.

## Changes

**1. "Last updated" no longer lies.** It was stamped at the *start* of `refresh()`, unconditionally (`dashboard.js:1722`) — so the clock advanced even when every request failed, showing a fresh time over stale data. Now it's stamped **only after a successful refresh** (`criticalFailures < 2`). On failure, the existing timestamp is marked stale rather than refreshed:
- a **"(stale)" text marker** — the accessible signal, not colour alone (WCAG 1.4.1) — via CSS `::after`
- plus a warning colour and a `title` explaining it's showing the last successful time.

**2. Four panels now auto-refresh.** Watcher, Sentinel, Vigil, and Chronicler (fleet-metrics) loaded **once at page init and never refreshed** — an open operator tab showed indefinitely-stale findings with no cue. Added a 30s interval to each, **guarded by the global "Pause auto-refresh" toggle** (`state.autoRefreshPaused`) — matching the rest of the dashboard's cadence and honoring pause (which even the existing `system-health` interval doesn't do).

## Notes
- `lint` ✓ · `format:check` ✓ · `test` ✓ (32) · `build` ✓ (verified by exit code).
- These are refresh-loop/interval behaviors that are impractical to unit-test in jsdom without heavy network mocking; verified by reading + the bundle compiling. A quick check before merge (pull the network, confirm "(stale)" appears and the clock stops advancing) would confirm the runtime path.
- Independent of the a11y PR (#870) — different regions; both branch from master.

## Remaining from the audit
- **Visual tokens** (next): the caution-vs-critical colour bug (`--accent-orange` is actually red), tabular numerals, reduced decorative motion. These are visual, so I'll want your eyes on them.
- **Structural (your sign-off):** rolling all severity sources into the hero so it can't read "healthy" while the DB is down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015CWDAp4hoA7cBNEt6fjhG9)_