### PR TITLE
fix(calibration): gate the calibrated flag on real overconfidence, not a saturated proxy

### DIFF
--- a/src/calibration.py
+++ b/src/calibration.py
@@ -36,6 +36,15 @@ class ComplexityCalibrationBin:
     high_discrepancy_rate: float  # Percentage with discrepancy > 0.3
 
 
+# Calibration gating philosophy (2026-06-19, council-reviewed):
+# only the safety-relevant error direction gates the `calibrated` flag.
+# OVERCONFIDENCE — declared confidence materially exceeding the real success
+# rate — is the failure that matters (acting on false certainty). The gap that
+# counts as "material" matches the legacy blanket threshold so we narrow the
+# direction without loosening the magnitude.
+_OVERCONFIDENCE_GATE = 0.2
+
+
 class CalibrationChecker:
     """
     Checks calibration of confidence estimates.
@@ -536,46 +545,80 @@ class CalibrationChecker:
         if not strategic_metrics and not tactical_metrics:
             return False, {"error": "No calibration data"}
         
-        # Check strategic calibration
+        # Check strategic calibration.
+        #
+        # The strategic truth signal is trajectory_health — a SATURATED proxy.
+        # It sits near ~0.97-0.99 across every confidence bin because the basin
+        # self-heals nearly everyone regardless of declared confidence. A
+        # near-constant outcome carries no calibration information: low-confidence
+        # bins look "underconfident" against it by construction, not because an
+        # agent is miscalibrated in a way that matters. So the blanket
+        # calibration_error > 0.2 check is DEMOTED to advisory here; the only
+        # strategic condition that still gates is the genuine danger direction
+        # (high confidence paired with low trajectory health).
         issues = []
         strategic_issues = []
+        strategic_advisories = []
         for bin_key, bin_metrics in strategic_metrics.items():
             if bin_metrics.count < min_samples_per_bin:
                 continue
-            
-            # High confidence bins should have high trajectory health
-            if bin_metrics.bin_range[0] >= 0.8:
-                if bin_metrics.accuracy < 0.7:
-                    strategic_issues.append(
-                        f"Bin {bin_key}: high confidence ({bin_metrics.expected_accuracy:.2f}) "
-                        f"but low trajectory health ({bin_metrics.accuracy:.2f})"
-                    )
-            
-            # Large calibration error indicates miscalibration
-            if bin_metrics.calibration_error > 0.2:
+
+            # Danger direction: high confidence but low trajectory health — gates.
+            if bin_metrics.bin_range[0] >= 0.8 and bin_metrics.accuracy < 0.7:
                 strategic_issues.append(
-                    f"Bin {bin_key}: large calibration error ({bin_metrics.calibration_error:.2f})"
+                    f"Bin {bin_key}: high confidence ({bin_metrics.expected_accuracy:.2f}) "
+                    f"but low trajectory health ({bin_metrics.accuracy:.2f})"
                 )
-        
-        # Check tactical calibration (if we have data)
+
+            # Large error against the saturated proxy — advisory only, does not gate.
+            if bin_metrics.calibration_error > 0.2:
+                strategic_advisories.append(
+                    f"Bin {bin_key}: large strategic calibration error "
+                    f"({bin_metrics.calibration_error:.2f}) — advisory, trajectory_health proxy"
+                )
+
+        # Check tactical calibration (if we have data).
+        #
+        # The TACTICAL channel is grounded in hard exogenous outcomes (tests,
+        # commands, lint), so its errors are real. Both directions are reported,
+        # but only OVERCONFIDENCE gates: declaring more confidence than outcomes
+        # justify is the safety-relevant failure. Underconfidence is advisory.
         tactical_issues = []
+        tactical_advisories = []
         for bin_key, bin_metrics in tactical_metrics.items():
             if bin_metrics.count < min_samples_per_bin:
                 continue
-            
-            # For tactical: high confidence should mean high per-decision accuracy
-            if bin_metrics.bin_range[0] >= 0.8:
-                if bin_metrics.accuracy < 0.7:
-                    tactical_issues.append(
-                        f"Bin {bin_key}: high confidence ({bin_metrics.expected_accuracy:.2f}) "
-                        f"but low decision accuracy ({bin_metrics.accuracy:.2f})"
-                    )
-        
+
+            overconfidence_gap = bin_metrics.expected_accuracy - bin_metrics.accuracy
+
+            if bin_metrics.bin_range[0] >= 0.8 and bin_metrics.accuracy < 0.7:
+                # Danger direction: high confidence but low decision accuracy.
+                tactical_issues.append(
+                    f"Bin {bin_key}: high confidence ({bin_metrics.expected_accuracy:.2f}) "
+                    f"but low decision accuracy ({bin_metrics.accuracy:.2f})"
+                )
+            elif overconfidence_gap > _OVERCONFIDENCE_GATE:
+                # Overconfidence in any populated bin: declared confidence
+                # materially exceeds the real success rate.
+                tactical_issues.append(
+                    f"Bin {bin_key}: overconfident — declared {bin_metrics.expected_accuracy:.2f} "
+                    f"but only {bin_metrics.accuracy:.2f} of decisions succeeded "
+                    f"(gap {overconfidence_gap:.2f})"
+                )
+            elif -overconfidence_gap > _OVERCONFIDENCE_GATE:
+                # Underconfidence — real, but not safety-relevant. Advisory only.
+                tactical_advisories.append(
+                    f"Bin {bin_key}: underconfident — declared {bin_metrics.expected_accuracy:.2f} "
+                    f"but {bin_metrics.accuracy:.2f} succeeded — advisory"
+                )
+
         is_calibrated = len(strategic_issues) == 0 and len(tactical_issues) == 0
         
         result = {
             "is_calibrated": is_calibrated,
             "issues": strategic_issues + tactical_issues,
+            # Non-gating observations (underconfidence, saturated-proxy error).
+            "advisories": strategic_advisories + tactical_advisories,
             # STRATEGIC calibration (trajectory health) - formerly just "bins"
             "strategic_calibration": {
                 "description": "Trajectory health by confidence level (retroactive marking)",
@@ -645,7 +688,11 @@ class CalibrationChecker:
                     is_calibrated = False
         
         result["is_calibrated"] = is_calibrated
-        result["issues"] = strategic_issues + tactical_issues
+        # `issues` is the gating set. Include complexity issues (which set
+        # is_calibrated=False above) so a False verdict is never returned with an
+        # empty issues list — that previously made complexity failures invisible.
+        result["issues"] = strategic_issues + tactical_issues + issues
+        result["advisories"] = strategic_advisories + tactical_advisories
 
         # Per-channel breakdown (additive — aggregate fields above are unchanged).
         # Allows callers to ask "miscalibrated where?" instead of just "miscalibrated".
@@ -655,13 +702,23 @@ class CalibrationChecker:
             for channel, bin_metrics in per_channel_metrics.items():
                 channel_samples = sum(b.count for b in bin_metrics.values())
                 channel_issues = []
+                channel_advisories = []
                 max_gap = 0.0
                 for bin_key, b in bin_metrics.items():
                     if b.count < min_samples_per_bin:
                         continue
-                    if b.calibration_error > 0.2:
+                    # Mirror the top-level gate: overconfidence gates the
+                    # per-channel `calibrated` flag; other large errors are advisory
+                    # so per-channel and aggregate verdicts tell one consistent story.
+                    overconfidence_gap = b.expected_accuracy - b.accuracy
+                    if overconfidence_gap > _OVERCONFIDENCE_GATE:
                         channel_issues.append(
-                            f"Bin {bin_key}: large calibration error ({b.calibration_error:.2f})"
+                            f"Bin {bin_key}: overconfident (declared {b.expected_accuracy:.2f}, "
+                            f"succeeded {b.accuracy:.2f}, gap {overconfidence_gap:.2f})"
+                        )
+                    elif b.calibration_error > 0.2:
+                        channel_advisories.append(
+                            f"Bin {bin_key}: large calibration error ({b.calibration_error:.2f}) — advisory"
                         )
                     if b.calibration_error > max_gap:
                         max_gap = b.calibration_error
@@ -670,6 +727,7 @@ class CalibrationChecker:
                     "samples": channel_samples,
                     "calibration_gap": max_gap,
                     "issues": channel_issues,
+                    "advisories": channel_advisories,
                 }
             result["per_channel_calibration"] = per_channel_response
 

--- a/src/mcp_handlers/admin/calibration.py
+++ b/src/mcp_handlers/admin/calibration.py
@@ -183,6 +183,7 @@ async def handle_check_calibration(arguments: Dict[str, Any]) -> Sequence[TextCo
         "calibration_status": calibration_status,
         "tactical_staleness_days": tactical_staleness_days,
         "issues": metrics.get('issues', []),
+        "advisories": metrics.get('advisories', []),
         "accuracy": accuracy_value,
         "trajectory_health": overall_trajectory_health,
         "truth_channel": truth_channel,

--- a/tests/test_calibration_module.py
+++ b/tests/test_calibration_module.py
@@ -612,15 +612,40 @@ class TestCheckCalibration:
         assert len(issues) == 0
         assert is_cal is True
 
-    def test_large_calibration_error_flagged(self, checker):
-        """Calibration error > 0.2 should be flagged."""
-        # Confidence ~0.6 but all wrong -> accuracy=0, expected=0.6, error=0.6
+    def test_strategic_large_error_is_advisory_not_gating(self, checker):
+        """A large STRATEGIC error outside the danger direction is advisory, not gating.
+
+        trajectory_health is a saturated proxy: low-confidence bins look
+        'underconfident' against it by construction. Confidence ~0.6 in the
+        0.5-0.7 bin (below the 0.8 danger threshold) must NOT flip the flag,
+        but the error stays visible in advisories.
+        """
         for _ in range(20):
-            checker.update_ground_truth(0.6, True, False)
+            checker.update_ground_truth(0.6, True, False)  # error 0.6, but bin < 0.8
+        is_cal, metrics = checker.check_calibration(min_samples_per_bin=5)
+        assert is_cal is True
+        assert metrics.get("issues", []) == []
+        advisories = metrics.get("advisories", [])
+        assert any("calibration error" in a.lower() for a in advisories)
+
+    def test_tactical_overconfidence_gates(self, checker):
+        """Declared confidence materially exceeding real success rate gates the flag."""
+        # Tactical 0.6-0.7 bin: declared ~0.6, actual 0 -> overconfidence gap 0.6 > 0.2
+        for _ in range(20):
+            checker.record_tactical_decision(0.6, "proceed", False)
         is_cal, metrics = checker.check_calibration(min_samples_per_bin=5)
         assert is_cal is False
-        issues = metrics.get("issues", [])
-        assert any("calibration error" in i.lower() for i in issues)
+        assert any("overconfident" in i.lower() for i in metrics.get("issues", []))
+
+    def test_tactical_underconfidence_is_advisory_not_gating(self, checker):
+        """Underconfidence (declared << real success) is real but not safety-relevant."""
+        # Tactical 0.3-0.4 bin: declared ~0.3, actual 1.0 -> underconfident, advisory only
+        for _ in range(20):
+            checker.record_tactical_decision(0.3, "proceed", True)
+        is_cal, metrics = checker.check_calibration(min_samples_per_bin=5)
+        assert is_cal is True
+        assert metrics.get("issues", []) == []
+        assert any("underconfident" in a.lower() for a in metrics.get("advisories", []))
 
     def test_backward_compat_bins_key(self, checker):
         for _ in range(10):


### PR DESCRIPTION
## Problem

The operator asked how to flip `calibration(action=check)` from `calibrated: false` to `true`. Council review (dialectic-knowledge-architect + feature-dev:code-reviewer + live-verifier, all three reports grounded against the running server) found the honest answer is **not** a gate edit — but it also surfaced that the gate itself is measuring the wrong thing.

**Live-verified (6/6):** the flag is false **purely** because of the STRATEGIC channel. Its truth signal is `trajectory_health`, a **saturated proxy** sitting at 0.969–0.998 across *every* confidence bin (the basin self-heals nearly everyone regardless of declared confidence). Low-confidence bins therefore read as 'underconfident' against a near-constant — by construction, not because anyone is miscalibrated in a way that matters. The blanket `calibration_error > 0.2` check fired on that artifact.

Meanwhile the TACTICAL channel — real exogenous outcomes (tests, commands, lint; 1,596 fresh samples, 0.33-day staleness) — shows **genuine overconfidence** (declared 0.59 / succeeded 0.34 at the 0.5–0.7 bin) that the gate **never checked** (tactical only checked the ≥0.8 danger direction).

So the old flag punished *humility against a self-healing basin* while ignoring *real overconfidence*. The original 'just drop the strategic check to go green' idea was rejected by council: flipping `calibrated` true also flips `confidence_policy` to `use_reported_confidence` and silences the fleet calibration warning (`feedback.py:27`) — i.e. it would tell agents to trust confidence that the real-outcome data says is inflated.

## Change

Gate on the **safety-relevant direction**, demote the proxy:

- **Strategic** blanket `error > 0.2` → **advisory** (still visible, no longer gates). Strategic still gates the true danger direction (≥0.8 confidence + low trajectory health).
- **Tactical** now gates **overconfidence** in any populated bin (`declared − actual > 0.2`). Underconfidence → advisory.
- New `advisories` field on the result + MCP response so the demoted signal stays operator-visible.
- **Bugfix:** complexity-triggered `False` no longer returns an empty `issues` list (`calibration.py:648` now includes complexity issues) — caught by code-review, pre-existing.
- **Per-channel** `calibrated` mirrors the same overconfidence gate, so per-channel and aggregate verdicts can't disagree on mere underconfidence.
- Rewrote `test_large_calibration_error_flagged` → three tests asserting the new asymmetric semantics.

## Outcome

The flag stays **honestly red today** (real tactical overconfidence) and earns green when that overconfidence narrows — a reality change, not a gate edit. This makes the instrument *more* trustworthy, in line with the system's honest-proprioception thesis.

## Tests

`tests/test_calibration_module.py` 138 pass; per-channel + admin-handler suites 147 pass; broader calibration/monitor/telemetry sweep 506 pass.

## Caveat (confirm post-deploy)

Whether the **live** top-level flag stays red depends on `compute_tactical_metrics()` producing a populated bin with overconfidence > 0.2. Live evidence strongly indicates yes (per-channel `tasks` gap 0.63; `by_class.ephemeral` gap −0.328; tactical 0.5–0.7 gap 0.252). Confirm with a live `calibration(action=check)` after deploy.

Draft — operator is the merge gate (calibration is load-bearing).

https://claude.ai/code/session_01HES9ERjdTrV2rhLwvejve1