### PR TITLE
feat(dashboard): fleet-severity rollup into the hero + needs-attention band

### DIFF
--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -1338,6 +1338,35 @@ async function loadServerInfo() {
  * Update the Quick Status hero section.
  * Shows fleet health at a glance: green/yellow/red dot + summary.
  */
+/**
+ * Render the "Needs attention" band under the hero from the fleet-severity
+ * reasons. Each reason becomes a deep-link chip to its panel. The band is hidden
+ * when there are no active exceptions (no empty-state noise).
+ * @param {Array<{label:string, anchor:string, severity:string}>} reasons
+ */
+function renderNeedsAttention(reasons) {
+    const band = document.getElementById('needs-attention');
+    if (!band) return;
+    reasons = reasons || [];
+    if (reasons.length === 0) {
+        band.innerHTML = '';
+        band.hidden = true;
+        return;
+    }
+    const esc = (typeof DataProcessor !== 'undefined' && DataProcessor.escapeHtml)
+        ? DataProcessor.escapeHtml
+        : (s => String(s));
+    const chips = reasons.map(r => {
+        const cls = 'needs-attention-chip sev-' + (r.severity === 'critical' ? 'critical' : 'caution');
+        const label = esc(r.label) + ' →';
+        return r.anchor
+            ? '<a class="' + cls + '" href="' + esc(r.anchor) + '">' + label + '</a>'
+            : '<span class="' + cls + '">' + label + '</span>';
+    }).join('');
+    band.innerHTML = '<span class="needs-attention-label">Needs attention</span>' + chips;
+    band.hidden = false;
+}
+
 function updateQuickStatus(agents, stuckAgents) {
     const dot = document.getElementById('qs-dot');
     const label = document.getElementById('qs-label');
@@ -1358,21 +1387,45 @@ function updateQuickStatus(agents, stuckAgents) {
         ? agentsWithMetrics.reduce((s, a) => s + Number(a.metrics.coherence), 0) / agentsWithMetrics.length
         : null;
 
+    // Aggregate ALL severity sources (not just agents) so the hero can't read
+    // "healthy" while the DB is down or Watcher has criticals. The panels publish
+    // their summaries to state; computeFleetSeverity (fleet-severity.js) takes the
+    // worst. Falls back to the legacy agent-only computation if the module is
+    // absent. See docs/proposals/dashboard-hero-severity-rollup.md.
     let status = 'healthy';
     let statusText = 'All systems healthy';
-    if (stuckAgents.length > 2 || criticalAgents > 0) {
-        status = 'critical';
-        statusText = criticalAgents + ' critical' + (stuckAgents.length > 0 ? ', ' + stuckAgents.length + ' stuck' : '');
-    } else if (stuckAgents.length > 0 || (avgCoherence !== null && avgCoherence < 0.4)) {
-        status = 'warning';
-        const parts = [];
-        if (stuckAgents.length > 0) parts.push(stuckAgents.length + ' stuck');
-        if (avgCoherence !== null && avgCoherence < 0.4) parts.push('coherence ' + (avgCoherence * 100).toFixed(0) + '%');
-        statusText = parts.join(', ');
+    let attentionReasons = [];
+    if (typeof computeFleetSeverity === 'function') {
+        const severity = computeFleetSeverity({
+            criticalAgents: criticalAgents,
+            stuckCount: stuckAgents.length,
+            avgCoherence: avgCoherence,
+            systemHealth: state.get('systemHealthOverall'),
+            watcher: state.get('watcherSummary'),
+            sentinel: state.get('sentinelSummary'),
+            silentResidents: state.get('silentResidents'),
+        });
+        // Map severity level → existing hero CSS class (caution → warning).
+        status = severity.level === 'critical' ? 'critical'
+            : severity.level === 'caution' ? 'warning' : 'healthy';
+        statusText = severity.text;
+        attentionReasons = severity.reasons;
+    } else {
+        if (stuckAgents.length > 2 || criticalAgents > 0) {
+            status = 'critical';
+            statusText = criticalAgents + ' critical' + (stuckAgents.length > 0 ? ', ' + stuckAgents.length + ' stuck' : '');
+        } else if (stuckAgents.length > 0 || (avgCoherence !== null && avgCoherence < 0.4)) {
+            status = 'warning';
+            const parts = [];
+            if (stuckAgents.length > 0) parts.push(stuckAgents.length + ' stuck');
+            if (avgCoherence !== null && avgCoherence < 0.4) parts.push('coherence ' + (avgCoherence * 100).toFixed(0) + '%');
+            statusText = parts.join(', ');
+        }
     }
 
     dot.className = 'quick-status-dot ' + status;
     label.textContent = statusText;
+    renderNeedsAttention(attentionReasons);
 
     // Detail: agent count
     if (detail) {

--- a/dashboard/fleet-severity.js
+++ b/dashboard/fleet-severity.js
@@ -1,0 +1,114 @@
+/**
+ * Unitares Dashboard — Fleet Severity Rollup
+ *
+ * Aggregates every "something is wrong" signal in the dashboard into a single
+ * worst-case fleet severity for the Quick Status hero, plus a list of exception
+ * "reasons" for the "Needs attention" band. See
+ * docs/proposals/dashboard-hero-severity-rollup.md.
+ *
+ * Policy (operator-chosen, 2026-06-19): CRITICAL → red, everything else →
+ * amber ("caution"). All exceptions appear in the band regardless of level.
+ *
+ * computeFleetSeverity() is a PURE function (no DOM, no globals) so the severity
+ * math is unit-tested; the gather/render wiring lives in dashboard.js.
+ */
+(function () {
+    'use strict';
+
+    // Anchors map a reason to the panel that explains it (for band deep-links).
+    var ANCHORS = {
+        agents: '#agents-section',
+        systemHealth: '#system-health-section',
+        watcher: '#watcher-section',
+        sentinel: '#sentinel-section',
+        residents: '#residents-section',
+    };
+
+    function num(value) {
+        var n = Number(value);
+        return isFinite(n) && n > 0 ? n : 0;
+    }
+
+    /**
+     * @param {object} inputs
+     * @param {number} [inputs.criticalAgents]  count of agents at health_status 'critical'
+     * @param {number} [inputs.stuckCount]      count of stuck agents
+     * @param {number|null} [inputs.avgCoherence] fleet average coherence (0..1) or null
+     * @param {string|null} [inputs.systemHealth] overall system-health status string
+     * @param {object|null} [inputs.watcher]    { critical, high } or { error:true }
+     * @param {object|null} [inputs.sentinel]   { critical, high } or { error:true }
+     * @param {Array|number} [inputs.silentResidents] silent resident labels or a count
+     * @returns {{level:'healthy'|'caution'|'critical', reasons:Array, text:string}}
+     */
+    function computeFleetSeverity(inputs) {
+        inputs = inputs || {};
+        var critical = [];
+        var caution = [];
+
+        function add(bucket, label, anchorKey) {
+            bucket.push({
+                label: label,
+                anchor: ANCHORS[anchorKey] || null,
+                severity: bucket === critical ? 'critical' : 'caution',
+            });
+        }
+
+        // ── Critical contributors (escalate the hero to red) ──
+        var sysHealth = inputs.systemHealth;
+        if (sysHealth === 'critical' || sysHealth === 'unavailable' || sysHealth === 'error') {
+            add(critical, 'System health: ' + sysHealth, 'systemHealth');
+        }
+        var critAgents = num(inputs.criticalAgents);
+        if (critAgents > 0) {
+            add(critical, critAgents + ' agent' + (critAgents === 1 ? '' : 's') + ' critical', 'agents');
+        }
+        if (inputs.watcher && num(inputs.watcher.critical) > 0) {
+            add(critical, 'Watcher: ' + num(inputs.watcher.critical) + ' critical', 'watcher');
+        }
+        if (inputs.sentinel && num(inputs.sentinel.critical) > 0) {
+            add(critical, 'Sentinel: ' + num(inputs.sentinel.critical) + ' critical', 'sentinel');
+        }
+
+        // ── Caution contributors (amber; or band-only when hero is already red) ──
+        var stuck = num(inputs.stuckCount);
+        if (stuck > 0) {
+            add(caution, stuck + ' stuck', 'agents');
+        }
+        if (inputs.sentinel && num(inputs.sentinel.high) > 0) {
+            add(caution, 'Sentinel: ' + num(inputs.sentinel.high) + ' high', 'sentinel');
+        }
+        var silent = Array.isArray(inputs.silentResidents)
+            ? inputs.silentResidents.length
+            : num(inputs.silentResidents);
+        if (silent > 0) {
+            add(caution, silent + ' resident' + (silent === 1 ? '' : 's') + ' silent', 'residents');
+        }
+        // A monitoring feed that failed to load is concerning but not fleet-critical
+        // — surface it as caution so a dead endpoint can't masquerade as "0 findings".
+        if (inputs.watcher && inputs.watcher.error) {
+            add(caution, 'Watcher feed unavailable', 'watcher');
+        }
+        if (inputs.sentinel && inputs.sentinel.error) {
+            add(caution, 'Sentinel feed unavailable', 'sentinel');
+        }
+        if (inputs.avgCoherence !== null && inputs.avgCoherence !== undefined && inputs.avgCoherence < 0.4) {
+            add(caution, 'Coherence ' + Math.round(inputs.avgCoherence * 100) + '%', 'agents');
+        }
+
+        var reasons = critical.concat(caution);
+        var level = critical.length > 0 ? 'critical' : caution.length > 0 ? 'caution' : 'healthy';
+
+        var text;
+        if (level === 'healthy') {
+            text = 'All systems healthy';
+        } else {
+            text = reasons[0].label + (reasons.length > 1 ? ' (+' + (reasons.length - 1) + ' more)' : '');
+        }
+
+        return { level: level, reasons: reasons, text: text };
+    }
+
+    if (typeof window !== 'undefined') {
+        window.computeFleetSeverity = computeFleetSeverity;
+    }
+})();

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -21,6 +21,7 @@
     <script src="/dashboard/state.js"></script>
     <script src="/dashboard/colors.js"></script>
     <script src="/dashboard/components.js"></script>
+    <script src="/dashboard/fleet-severity.js"></script>
     <!-- Layer 1: Visualizations (depends on Chart.js, utils, colors) -->
     <script src="/dashboard/visualizations.js"></script>
     <!-- Layer 2: Domain modules (depend on state, colors, utils) -->
@@ -111,6 +112,10 @@
             <span class="quick-status-lumen" id="qs-detail"></span>
             <span class="quick-status-lumen" id="qs-lumen"></span>
         </div>
+
+        <!-- Needs-attention band: deep-link chips for active exceptions, surfaced
+             from the fleet-severity rollup. Hidden when the fleet is healthy. -->
+        <div id="needs-attention" class="needs-attention" role="region" aria-label="Needs attention" hidden></div>
 
         <div class="stats-grid" id="stats-section">
             <div class="stat-card" data-accent="coherence" id="fleet-coherence-card">

--- a/dashboard/residents.js
+++ b/dashboard/residents.js
@@ -181,11 +181,19 @@
             return;
         }
         var nowMs = Date.now();
+        var silent = [];
         var pills = orderedLabels.map(function (label) {
             var r = residentsByLabel[label];
-            return r ? renderCard(r, nowMs) : '';
+            if (!r) return '';
+            // A non-event-driven resident past its silence threshold is an
+            // exception the fleet-severity hero rollup should reflect.
+            if (!isEventDriven(r) && statusForCard(r, nowMs) === 'silent') {
+                silent.push(label);
+            }
+            return renderCard(r, nowMs);
         });
         container.innerHTML = pills.join('');
+        if (typeof state !== 'undefined') state.set({ silentResidents: silent });
     }
 
     // ---------------------------------------------------------------------

--- a/dashboard/sentinel.js
+++ b/dashboard/sentinel.js
@@ -195,11 +195,18 @@
         if (summary) {
             renderCounts(summary);
             renderClassBreakdown(summary);
+            // Publish severity counts for the fleet-severity hero rollup.
+            var sev = summary.by_severity || {};
+            if (typeof state !== 'undefined') {
+                state.set({ sentinelSummary: { critical: sev.critical || 0, high: sev.high || 0 } });
+            }
         } else {
             setMetric('sentinel-count-total', '—');
             setMetric('sentinel-count-critical', '—');
             setMetric('sentinel-count-high', '—');
             setMetric('sentinel-count-medium', '—');
+            // Feed-error marker so a dead endpoint isn't read as "0 findings".
+            if (typeof state !== 'undefined') state.set({ sentinelSummary: { error: true } });
         }
         await refreshStream();
     }

--- a/dashboard/src/main.js
+++ b/dashboard/src/main.js
@@ -20,6 +20,7 @@ import '../utils.js';
 import '../state.js';
 import '../colors.js';
 import '../components.js';
+import '../fleet-severity.js';
 import '../visualizations.js';
 import '../agents.js';
 import '../discoveries.js';

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -3602,6 +3602,58 @@ main {
 }
 
 /* ============================================
+   Needs-attention band (fleet-severity rollup)
+   ============================================ */
+.needs-attention {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    margin: 0 0 16px;
+    padding: 8px 12px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md, 8px);
+}
+
+.needs-attention-label {
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-secondary);
+    margin-right: 4px;
+}
+
+.needs-attention-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 10px;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 500;
+    text-decoration: none;
+    border: 1px solid transparent;
+    white-space: nowrap;
+}
+
+.needs-attention-chip.sev-critical {
+    color: var(--color-error, #ef4444);
+    background: rgba(239, 68, 68, 0.12);
+    border-color: rgba(239, 68, 68, 0.3);
+}
+
+.needs-attention-chip.sev-caution {
+    color: var(--color-warning, #f59e0b);
+    background: rgba(245, 158, 11, 0.12);
+    border-color: rgba(245, 158, 11, 0.3);
+}
+
+a.needs-attention-chip:hover {
+    filter: brightness(1.12);
+}
+
+/* ============================================
    Agent Metrics — Collapsible Override
    ============================================ */
 .agent-item .agent-metrics {

--- a/dashboard/system-health.js
+++ b/dashboard/system-health.js
@@ -111,6 +111,9 @@
         setMetric('system-health-count-warning', breakdown.warning || 0);
         setMetric('system-health-count-unavailable', breakdown.unavailable || 0);
         setMetric('system-health-count-error', breakdown.error || 0);
+        // Publish overall status for the fleet-severity hero rollup — this is the
+        // signal that makes a DB-down state reach the top-of-page hero.
+        if (typeof state !== 'undefined') state.set({ systemHealthOverall: status });
     }
 
     function renderChecks(snapshot) {
@@ -189,6 +192,8 @@
         var snapshot = await fetchDeepHealth();
         if (!snapshot) {
             renderErrorState();
+            // The health endpoint itself is down — surface that to the hero.
+            if (typeof state !== 'undefined') state.set({ systemHealthOverall: 'error' });
             return;
         }
         if (snapshot._not_yet_populated) {

--- a/dashboard/tests/fleet-severity.test.js
+++ b/dashboard/tests/fleet-severity.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { loadDashboardScripts } from './helpers/load-dashboard.js';
+
+// computeFleetSeverity is a pure function (fleet-severity.js, no deps).
+let compute;
+
+beforeEach(() => {
+    loadDashboardScripts(['fleet-severity.js']);
+    compute = window.computeFleetSeverity;
+});
+
+describe('computeFleetSeverity — level', () => {
+    it('is healthy with no signals', () => {
+        const r = compute({});
+        expect(r.level).toBe('healthy');
+        expect(r.reasons).toEqual([]);
+        expect(r.text).toBe('All systems healthy');
+    });
+
+    it('is healthy when counts are zero/falsy', () => {
+        expect(
+            compute({
+                criticalAgents: 0,
+                stuckCount: 0,
+                watcher: { critical: 0, high: 0 },
+                sentinel: { critical: 0, high: 0 },
+                silentResidents: [],
+            }).level
+        ).toBe('healthy');
+    });
+
+    it('escalates to critical when the database (system health) is unavailable', () => {
+        // The proposal's canonical failure: hero must NOT read healthy here.
+        const r = compute({ systemHealth: 'unavailable' });
+        expect(r.level).toBe('critical');
+        expect(r.text).toContain('System health');
+    });
+
+    it('treats system health error and critical as critical too', () => {
+        expect(compute({ systemHealth: 'error' }).level).toBe('critical');
+        expect(compute({ systemHealth: 'critical' }).level).toBe('critical');
+        expect(compute({ systemHealth: 'healthy' }).level).toBe('healthy');
+        expect(compute({ systemHealth: 'warning' }).level).toBe('healthy'); // warning isn't critical
+    });
+
+    it('critical agents, Watcher critical, and Sentinel critical each escalate to red', () => {
+        expect(compute({ criticalAgents: 1 }).level).toBe('critical');
+        expect(compute({ watcher: { critical: 2 } }).level).toBe('critical');
+        expect(compute({ sentinel: { critical: 1 } }).level).toBe('critical');
+    });
+
+    it('stuck agents, Sentinel-high, and silent residents are caution (amber), not red', () => {
+        expect(compute({ stuckCount: 3 }).level).toBe('caution');
+        expect(compute({ sentinel: { high: 4 } }).level).toBe('caution');
+        expect(compute({ silentResidents: ['Vigil'] }).level).toBe('caution');
+        expect(compute({ avgCoherence: 0.3 }).level).toBe('caution');
+    });
+
+    it('a failed monitoring feed is caution, never silently "all clear"', () => {
+        expect(compute({ sentinel: { error: true } }).level).toBe('caution');
+        expect(compute({ watcher: { error: true } }).level).toBe('caution');
+    });
+
+    it('critical wins over caution when both are present', () => {
+        const r = compute({ criticalAgents: 1, stuckCount: 5 });
+        expect(r.level).toBe('critical');
+    });
+});
+
+describe('computeFleetSeverity — reasons & text', () => {
+    it('orders critical reasons ahead of caution reasons', () => {
+        const r = compute({ stuckCount: 2, criticalAgents: 1 });
+        expect(r.reasons[0].severity).toBe('critical');
+        expect(r.reasons[r.reasons.length - 1].severity).toBe('caution');
+    });
+
+    it('attaches a deep-link anchor to each reason', () => {
+        const r = compute({ watcher: { critical: 1 }, silentResidents: 2 });
+        const byAnchor = r.reasons.map((x) => x.anchor);
+        expect(byAnchor).toContain('#watcher-section');
+        expect(byAnchor).toContain('#residents-section');
+    });
+
+    it('summarizes the hero text as the top reason plus an overflow count', () => {
+        const r = compute({ criticalAgents: 1, stuckCount: 2, silentResidents: 1 });
+        expect(r.text).toMatch(/^1 agent critical \(\+2 more\)$/);
+    });
+
+    it('singularizes/pluralizes agent and resident labels', () => {
+        expect(compute({ criticalAgents: 1 }).reasons[0].label).toBe('1 agent critical');
+        expect(compute({ criticalAgents: 2 }).reasons[0].label).toBe('2 agents critical');
+        expect(compute({ silentResidents: 1 }).reasons[0].label).toBe('1 resident silent');
+        expect(compute({ silentResidents: ['a', 'b'] }).reasons[0].label).toBe(
+            '2 residents silent'
+        );
+    });
+});

--- a/dashboard/watcher.js
+++ b/dashboard/watcher.js
@@ -215,12 +215,20 @@
             setMetric('watcher-count-dismissed', '—');
             setMetric('watcher-count-critical', '—');
             setMetric('watcher-count-high', '—');
+            // Publish a feed-error marker for the fleet-severity hero rollup so a
+            // dead endpoint surfaces as "unavailable", not a silent "0 findings".
+            if (typeof state !== 'undefined') state.set({ watcherSummary: { error: true } });
             return;
         }
         renderCounts(summary);
         renderPatterns(summary);
         renderChart(summary);
         setFooter(summary);
+        // Publish severity counts for the fleet-severity hero rollup.
+        var sev = summary.by_severity_open || {};
+        if (typeof state !== 'undefined') {
+            state.set({ watcherSummary: { critical: sev.critical || 0, high: sev.high || 0 } });
+        }
     }
 
     function wire() {

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -930,6 +930,7 @@ async def http_dashboard_static(request):
     # Only allow specific files for security
     allowed_files = [
         "utils.js", "state.js", "colors.js", "components.js",
+        "fleet-severity.js",
         "visualizations.js", "agents.js", "discoveries.js",
         "dialectic.js", "eisv-charts.js", "timeline.js",
         "residents.js", "fleet-metrics.js", "watcher.js", "sentinel.js",


### PR DESCRIPTION
Implements the merged proposal (`docs/proposals/dashboard-hero-severity-rollup.md`), Phase 1, with the severity policy you chose (**critical → red, everything else → amber**). This is the fix that makes the **5-second fleet-health test pass**: the Quick Status hero was computed from only agent coherence + stuck counts, so it could read **"All systems healthy" while the database was down** or Watcher had criticals.

## What it does

- **`fleet-severity.js` — pure `computeFleetSeverity(inputs)`** that takes the *worst* severity across agents, system health, Watcher, Sentinel, and resident silence, returning `{ level, reasons, text }`. Policy:
  - **red:** agent critical · Watcher critical · Sentinel critical · system health `unavailable`/`error`
  - **amber:** stuck agents · Sentinel high · silent residents · low coherence · a *failed monitoring feed* (so a dead endpoint can't masquerade as "0 findings")
- **Panels publish to `state` on refresh** — Watcher/Sentinel severity counts, system-health overall (incl. a feed-down → `error` marker), and the list of silent residents. Small additive hooks.
- **`updateQuickStatus` consumes it** (with a legacy agent-only fallback if the module is absent) and renders a **"Needs attention" band** of deep-link chips under the hero — each links to the relevant panel, and the band is hidden when the fleet is healthy (no empty-state noise).
- Registered the new module in `index.html`, the static-file allowlist (`http_api.py`), and the Vite bundle entry.

## Tests / verification
- **12 new unit tests** for `computeFleetSeverity` (the severity math — including the canonical "DB unavailable → not healthy" case, critical-wins-over-caution, feed-error handling, label pluralization). **45 frontend tests total.**
- `lint` ✓ · `format:check` ✓ · `test` ✓ (45) · `build` ✓; verified the static-allowlist parity so `smoke` stays green.
- **What I can't verify from here:** the band's visual placement/styling and that the amber/red chips read correctly. The *logic* is unit-tested; the *look* wants an in-browser check in both themes before merge.

## Notes
- Behavior change to the hero, as designed — the legacy fallback means it degrades gracefully if `fleet-severity.js` fails to load.
- One deliberate behavior shift: 3+ stuck agents used to turn the hero red; under the chosen policy stuck is amber (critical is reserved for true criticals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015CWDAp4hoA7cBNEt6fjhG9)_