### PR TITLE
feat(dev): octopus_rollup — count logical workers (principals), not process-instances

### DIFF
--- a/scripts/dev/octopus_rollup.py
+++ b/scripts/dev/octopus_rollup.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""octopus_rollup.py — count logical workers (octopi), not process-instances (tentacles).
+
+The governance identity model mints one identity per process-instance x onboard
+event (the `force_new` posture, for WRITE-accountability — each writer is a
+distinct, attributable identity). That is the right *write* unit but the wrong
+*count* unit: a persistent worker (the BEAM Sentinel, the Discord Hermes harness,
+a Claude session-chain across /clears) sheds a fresh identity per episode, so
+"how many agents" reports tentacles, not octopi.
+
+This is a READ-ONLY report. It rolls identities up into PRINCIPALS (octopi) using
+only signals the agent itself declared — never spoofable heuristics:
+
+  * declared lineage edges (parent_agent_id -> agent_id), and
+  * shared thread_id (same conversation / logical worker).
+
+A principal is a connected component over the union of those edges. Deliberately
+EXCLUDED as grouping keys:
+
+  * IP/UA fingerprint — spoofable and legitimately shared (e.g. a bridge and a
+    gateway both on localhost httpx hash to one fingerprint); rejected as a
+    credential in the prefix-bind hijack work. An octopus built on it would
+    mis-merge unrelated workers.
+  * the public `<harness>_<date>` label (e.g. `mcp_20260414`) — a daily cohort,
+    not an agent: hundreds of unrelated process-instances from one day share it.
+
+True singletons (a one-shot session with no lineage and no thread reuse) stay
+singular — that is honest. The compression lands where it should: on the
+persistent / recurring workers, which is exactly where the model already holds
+the signal (thread_id, parent_agent_id) but does not count by it.
+
+Usage:
+    scripts/dev/octopus_rollup.py                # active identities (default)
+    scripts/dev/octopus_rollup.py --all          # include archived/deleted
+    scripts/dev/octopus_rollup.py --db governance --top 10
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections import defaultdict
+
+
+def fetch_rows(db: str, include_all: bool) -> list[tuple[str, str, str]]:
+    """Return (agent_id, thread_id, parent_agent_id) for the requested identities.
+
+    Fields are uuids or empty — no embedded tabs — so a tab-separated read is
+    unambiguous.
+    """
+    where = "" if include_all else "where status = 'active'"
+    sql = (
+        "select agent_id, coalesce(metadata->>'thread_id',''), "
+        "coalesce(parent_agent_id::text,'') "
+        f"from core.identities {where}"
+    )
+    proc = subprocess.run(
+        ["psql", "-d", db, "-tAF", "\t", "-c", sql],
+        capture_output=True, text=True, check=True,
+    )
+    rows: list[tuple[str, str, str]] = []
+    for line in proc.stdout.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        if len(parts) >= 3 and parts[0]:
+            rows.append((parts[0], parts[1], parts[2]))
+    return rows
+
+
+class UnionFind:
+    def __init__(self) -> None:
+        self.parent: dict[str, str] = {}
+
+    def find(self, x: str) -> str:
+        self.parent.setdefault(x, x)
+        root = x
+        while self.parent[root] != root:
+            root = self.parent[root]
+        while self.parent[x] != root:  # path compression
+            self.parent[x], x = root, self.parent[x]
+        return root
+
+    def union(self, a: str, b: str) -> None:
+        ra, rb = self.find(a), self.find(b)
+        if ra != rb:
+            self.parent[ra] = rb
+
+
+def rollup(rows: list[tuple[str, str, str]]) -> dict[str, list[str]]:
+    """Connected components over {shared thread} U {declared lineage}."""
+    uf = UnionFind()
+    ids = {aid for aid, _, _ in rows}
+    for aid, _, _ in rows:
+        uf.find(aid)  # ensure every identity is its own component to start
+
+    by_thread: dict[str, list[str]] = defaultdict(list)
+    for aid, thread, _ in rows:
+        if thread:
+            by_thread[thread].append(aid)
+    for members in by_thread.values():
+        for m in members[1:]:
+            uf.union(members[0], m)
+
+    for aid, _, parent in rows:
+        if parent and parent in ids:  # only chain to a parent we actually hold
+            uf.union(aid, parent)
+
+    comps: dict[str, list[str]] = defaultdict(list)
+    for aid, _, _ in rows:
+        comps[uf.find(aid)].append(aid)
+    return comps
+
+
+def _bucket(size: int) -> str:
+    if size == 1:
+        return "1 (singleton)"
+    if size <= 3:
+        return "2-3"
+    if size <= 10:
+        return "4-10"
+    return "11+"
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--db", default="governance")
+    ap.add_argument("--all", action="store_true",
+                    help="include archived/deleted identities (default: active only)")
+    ap.add_argument("--top", type=int, default=8,
+                    help="show the N largest octopi")
+    args = ap.parse_args(argv)
+
+    try:
+        rows = fetch_rows(args.db, args.all)
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        print(f"error: could not query db {args.db!r}: {e}", file=sys.stderr)
+        return 1
+    if not rows:
+        print("no identities matched.")
+        return 0
+
+    comps = rollup(rows)
+    n_tent, n_octo = len(rows), len(comps)
+
+    order = ["1 (singleton)", "2-3", "4-10", "11+"]
+    octopi_by, tent_by = defaultdict(int), defaultdict(int)
+    for members in comps.values():
+        b = _bucket(len(members))
+        octopi_by[b] += 1
+        tent_by[b] += len(members)
+
+    scope = "all" if args.all else "active"
+    print(f"scope: {scope} identities")
+    print(f"tentacles (identities): {n_tent}")
+    print(f"octopi (principals):    {n_octo}")
+    print(f"compression:            {n_tent / n_octo:.2f} tentacles/octopus\n")
+    print(f"  {'octopus size':16} {'octopi':>7} {'tentacles':>10}")
+    for b in order:
+        print(f"  {b:16} {octopi_by[b]:7} {tent_by[b]:10}")
+
+    multi_o = sum(v for k, v in octopi_by.items() if k != "1 (singleton)")
+    multi_t = sum(v for k, v in tent_by.items() if k != "1 (singleton)")
+    print(f"\n  {multi_o} multi-instance octopi hold {multi_t} tentacles "
+          f"(counted today as {multi_t} separate agents).")
+
+    largest = sorted(comps.values(), key=len, reverse=True)[:args.top]
+    if largest and len(largest[0]) > 1:
+        print(f"\n  largest octopi (instances rolled into one logical worker):")
+        for members in largest:
+            if len(members) == 1:
+                break
+            print(f"    {len(members):3} instances  (e.g. {members[0][:8]})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_octopus_rollup.py
+++ b/tests/test_octopus_rollup.py
@@ -1,0 +1,54 @@
+"""Tests for the octopus rollup logic (scripts/dev/octopus_rollup.py).
+
+Covers the pure connected-component rollup: thread-reuse merges, lineage merges,
+the two combining transitively, and singletons staying singular.
+"""
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "dev" / "octopus_rollup.py"
+_spec = importlib.util.spec_from_file_location("octopus_rollup", _SCRIPT)
+octopus_rollup = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(octopus_rollup)
+
+rollup = octopus_rollup.rollup
+
+
+def _sizes(rows):
+    return sorted((len(v) for v in rollup(rows).values()), reverse=True)
+
+
+def test_singletons_stay_singular():
+    # three unrelated one-shots: no thread, no lineage -> three octopi
+    rows = [("a", "", ""), ("b", "", ""), ("c", "", "")]
+    assert _sizes(rows) == [1, 1, 1]
+
+
+def test_shared_thread_merges():
+    # same thread = same logical worker (the Hermes / Claude-session-chain shape)
+    rows = [("a", "t1", ""), ("b", "t1", ""), ("c", "t1", "")]
+    assert _sizes(rows) == [3]
+
+
+def test_declared_lineage_merges():
+    # b -> a, c -> b across DIFFERENT threads: still one octopus via lineage
+    rows = [("a", "t1", ""), ("b", "t2", "a"), ("c", "t3", "b")]
+    assert _sizes(rows) == [3]
+
+
+def test_lineage_and_thread_combine_transitively():
+    # {a,b} share a thread; c chains to b by lineage -> all three are one octopus
+    rows = [("a", "t1", ""), ("b", "t1", ""), ("c", "t9", "b")]
+    assert _sizes(rows) == [3]
+
+
+def test_unknown_parent_does_not_merge():
+    # parent points outside the set (e.g. an archived ancestor not in scope):
+    # the child must not be merged into a phantom — it stands alone.
+    rows = [("a", "", "ghost-not-in-set"), ("b", "", "")]
+    assert _sizes(rows) == [1, 1]
+
+
+def test_two_distinct_workers_stay_distinct():
+    rows = [("a", "t1", ""), ("b", "t1", ""), ("c", "t2", ""), ("d", "t2", "")]
+    assert _sizes(rows) == [2, 2]


### PR DESCRIPTION
## Why

The identity model mints one identity per **process-instance × onboard event** (the `force_new` posture — correct for *write-accountability*: each writer is a distinct, attributable identity). But it's the wrong unit for *counting*: a persistent worker (the BEAM Sentinel, the Discord Hermes harness, a Claude session-chain across `/clear`s) sheds a fresh identity per episode, so "how many agents" reports **tentacles, not octopi**.

This read-only report rolls identities up into **principals (octopi)** — connected components over only signals the agent itself declared:
- **shared `thread_id`** (same conversation / logical worker), and
- **declared lineage** (`parent_agent_id → agent_id`).

Deliberately excluded as grouping keys: **IP:UA fingerprint** (spoofable + legitimately shared across localhost twins — rejected as a credential in the prefix-bind hijack work) and the **`<harness>_<date>` label** (e.g. `mcp_20260414` = hundreds of unrelated same-day instances — a daily cohort, not an agent). True singletons stay singular; the compression lands exactly on the persistent workers, where the model already *holds* the signal but doesn't count by it.

## Live headline (2026-06-18, post anon-ghost archive)

```
scope: active identities
tentacles (identities): 817
octopi (principals):    530        (1.54x)
  41 multi-instance octopi hold 328 tentacles (counted today as 328 separate agents)
  largest octopi: 38, 30, 29, 24, 22 instances rolled into one logical worker
all-history largest: 117 instances = one worker shown as 117 agents
```

## Scope

Step 1 of the "principal as a first-class grain" direction: **measure before touching the writer-locked `identity/` path**. This is read-only — no schema change, no mint-path change. Promotion to a real `principal_id` (resolve-or-create at onboard from declared lineage / thread / a harness-persisted instance-key) and re-expressing the dashboard count by principal are the follow-on, operator-gated steps.

Tests: 6 cases (thread merge, lineage merge, transitive combine, unknown-parent no-merge, singletons stay singular).

https://claude.ai/code/session_01JqgvE7zmGV1N6EeKyHqCLF