### PR TITLE
feat(list_agents): surface principal (octopus) rollup in the summary

### DIFF
--- a/src/mcp_handlers/lifecycle/query.py
+++ b/src/mcp_handlers/lifecycle/query.py
@@ -287,6 +287,81 @@ def _is_operator_request() -> bool:
         return False
 
 
+def _principal_rollup(agents_list: Sequence[dict], meta_lookup=None) -> dict:
+    """Roll the listed identities up into PRINCIPALS (logical workers) — the
+    octopus to the per-process-instance tentacle.
+
+    A principal is a connected component over only agent-DECLARED edges:
+    shared ``thread_id`` and declared lineage (``parent_agent_id``). Spoofable
+    or coarse keys (IP:UA fingerprint, the ``<harness>_<date>`` label) are
+    excluded by construction — the ontology names both performative. This is the
+    first-class form of identity.md research-agenda #3 ("identity as integral,
+    not point-value"); see docs/proposals/principal-rollup-v0.md.
+
+    Reads the REAL ``thread_id``/``parent_agent_id`` from agent metadata (the
+    output dicts may carry a redacted parent/id), over exactly the population in
+    ``agents_list``. Returns counts only — additive to the existing summary,
+    never a behavioral change.
+    """
+    if meta_lookup is None:
+        meta_lookup = mcp_server.agent_metadata.get
+
+    parent: dict[str, str] = {}
+
+    def find(x: str) -> str:
+        parent.setdefault(x, x)
+        root = x
+        while parent[root] != root:
+            root = parent[root]
+        while parent[x] != root:  # path compression
+            parent[x], x = root, parent[x]
+        return root
+
+    def union(a: str, b: str) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    uuids: set[str] = set()
+    by_thread: dict[str, list[str]] = {}
+    parents: dict[str, str] = {}
+    participated: set[str] = set()
+    for a in agents_list:
+        uid = a.get("_agent_uuid") or a.get("id")
+        if not uid:
+            continue
+        uuids.add(uid)
+        find(uid)
+        meta = meta_lookup(uid)
+        thread = getattr(meta, "thread_id", None) if meta else None
+        par = getattr(meta, "parent_agent_id", None) if meta else None
+        if thread:
+            by_thread.setdefault(thread, []).append(uid)
+        if par:
+            parents[uid] = par
+        if (a.get("total_updates") or 0) >= 1:
+            participated.add(uid)
+
+    for members in by_thread.values():
+        for m in members[1:]:
+            union(members[0], m)
+    for uid, par in parents.items():
+        if par in uuids:  # only chain to a parent in this population
+            union(uid, par)
+
+    comps: dict[str, list[str]] = {}
+    for uid in uuids:
+        comps.setdefault(find(uid), []).append(uid)
+
+    return {
+        "principals": len(comps),
+        "participated_principals": sum(
+            1 for ms in comps.values() if any(m in participated for m in ms)
+        ),
+        "multi_instance_principals": sum(1 for ms in comps.values() if len(ms) > 1),
+    }
+
+
 @mcp_tool("list_agents", timeout=15.0, register=False)
 async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextContent]:
     """List all agents currently being monitored with lifecycle metadata and health status
@@ -803,6 +878,10 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
         # Surfaced so count consumers can show working agents, not raw row count.
         participated = sum(1 for a in agents_list if (a.get("total_updates") or 0) >= 1)
         never_participated = total_count - participated
+        # Principal (octopus) rollup over the same pre-pagination population:
+        # how many LOGICAL workers these process-instances represent. Additive —
+        # `total`/`participated` are unchanged. See _principal_rollup.
+        principal_counts = _principal_rollup(agents_list)
 
         # Apply pagination (optimization)
         if limit is not None:
@@ -833,7 +912,10 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                     "limit": limit,
                     "by_status": status_counts,  # Use counts from BEFORE pagination
                     "participated": participated,  # checked in >=1 time
-                    "never_participated": never_participated  # onboarded but never checked in
+                    "never_participated": never_participated,  # onboarded but never checked in
+                    "principals": principal_counts["principals"],  # distinct logical workers (octopi)
+                    "participated_principals": principal_counts["participated_principals"],  # principals with >=1 checked-in instance
+                    "multi_instance_principals": principal_counts["multi_instance_principals"],  # principals spanning >1 process-instance
                 }
             }
 
@@ -857,7 +939,10 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                     "limit": limit,
                     "by_status": status_counts,  # Use counts from BEFORE pagination
                     "participated": participated,  # checked in >=1 time
-                    "never_participated": never_participated  # onboarded but never checked in
+                    "never_participated": never_participated,  # onboarded but never checked in
+                    "principals": principal_counts["principals"],  # distinct logical workers (octopi)
+                    "participated_principals": principal_counts["participated_principals"],  # principals with >=1 checked-in instance
+                    "multi_instance_principals": principal_counts["multi_instance_principals"],  # principals spanning >1 process-instance
                 }
             }
 

--- a/tests/test_principal_rollup_summary.py
+++ b/tests/test_principal_rollup_summary.py
@@ -1,0 +1,90 @@
+"""Tests for the principal (octopus) rollup added to the list_agents summary.
+
+A principal is a connected component over agent-declared edges only — shared
+thread_id and declared lineage. The rollup is additive to the summary (it never
+changes `total`/`participated`); see docs/proposals/principal-rollup-v0.md.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.mcp_handlers.lifecycle.query import _principal_rollup
+
+
+def _meta(thread=None, parent=None):
+    return SimpleNamespace(thread_id=thread, parent_agent_id=parent)
+
+
+def _agent(uid, updates=1):
+    return {"_agent_uuid": uid, "total_updates": updates}
+
+
+def _rollup(agents, metas):
+    return _principal_rollup(agents, meta_lookup=metas.get)
+
+
+def test_singletons_stay_singular():
+    agents = [_agent("a"), _agent("b"), _agent("c")]
+    metas = {"a": _meta(), "b": _meta(), "c": _meta()}
+    r = _rollup(agents, metas)
+    assert r["principals"] == 3
+    assert r["multi_instance_principals"] == 0
+    assert r["participated_principals"] == 3
+
+
+def test_shared_thread_merges():
+    agents = [_agent("a"), _agent("b"), _agent("c")]
+    metas = {"a": _meta(thread="t1"), "b": _meta(thread="t1"), "c": _meta(thread="t1")}
+    r = _rollup(agents, metas)
+    assert r["principals"] == 1
+    assert r["multi_instance_principals"] == 1
+
+
+def test_declared_lineage_merges_across_threads():
+    # b -> a, c -> b on different threads: one principal via lineage
+    agents = [_agent("a"), _agent("b"), _agent("c")]
+    metas = {
+        "a": _meta(thread="t1"),
+        "b": _meta(thread="t2", parent="a"),
+        "c": _meta(thread="t3", parent="b"),
+    }
+    assert _rollup(agents, metas)["principals"] == 1
+
+
+def test_lineage_and_thread_combine():
+    # {a,b} share a thread; c chains to b -> all one principal
+    agents = [_agent("a"), _agent("b"), _agent("c")]
+    metas = {"a": _meta(thread="t1"), "b": _meta(thread="t1"), "c": _meta(parent="b")}
+    assert _rollup(agents, metas)["principals"] == 1
+
+
+def test_unknown_parent_does_not_merge():
+    # parent outside the listed population (e.g. archived ancestor) -> no merge
+    agents = [_agent("a"), _agent("b")]
+    metas = {"a": _meta(parent="ghost-not-listed"), "b": _meta()}
+    assert _rollup(agents, metas)["principals"] == 2
+
+
+def test_principal_participated_if_any_instance_did():
+    # one thread, two instances: one ghost (0 updates), one checked in ->
+    # the principal counts as participated.
+    agents = [_agent("a", updates=0), _agent("b", updates=3)]
+    metas = {"a": _meta(thread="t1"), "b": _meta(thread="t1")}
+    r = _rollup(agents, metas)
+    assert r["principals"] == 1
+    assert r["participated_principals"] == 1
+
+
+def test_all_ghost_principal_not_participated():
+    agents = [_agent("a", updates=0), _agent("b", updates=0)]
+    metas = {"a": _meta(thread="t1"), "b": _meta(thread="t1")}
+    r = _rollup(agents, metas)
+    assert r["principals"] == 1
+    assert r["participated_principals"] == 0
+
+
+def test_falls_back_to_id_when_no_agent_uuid():
+    # lite-shaped dicts may not carry _agent_uuid; the rollup uses `id`.
+    agents = [{"id": "a", "total_updates": 1}, {"id": "b", "total_updates": 1}]
+    metas = {"a": _meta(thread="t1"), "b": _meta(thread="t1")}
+    assert _rollup(agents, metas)["principals"] == 1


### PR DESCRIPTION
**Move 2** of the principal-rollup proposal (`docs/proposals/principal-rollup-v0.md`, #878; tool in #877). Blessed direction.

The `list_agents` summary already reports `total` / `participated` / `never_participated` at the **process-instance** grain (#822). This adds the **logical-worker** grain alongside it — **additive, no behavioral change**:

| field | meaning |
|---|---|
| `principals` | distinct logical workers (octopi) |
| `participated_principals` | principals with ≥1 checked-in instance |
| `multi_instance_principals` | principals spanning >1 process-instance |

A **principal** is a connected component over agent-**declared** edges only — shared `thread_id` and declared lineage (`parent_agent_id`) — reading the **real** thread/parent from agent metadata (output dicts may carry a redacted parent/id). Spoofable/coarse keys (IP:UA fingerprint, the `<harness>_<date>` label) are excluded by construction, matching the ontology's performative list. **Subsumes #822**: a principal participated if *any* of its instances did.

Computed over the **same pre-pagination population** as `participated`, so the counts reconcile. Union-find is near-linear — trivial over the active set.

## Scope / safety

- Additive only — `total`/`participated`/`never_participated` are unchanged.
- Touches the **list/query** surface (same one #822/#826 modified), **not** the writer-locked `identity/` path. Move 3 (`principal_id` at mint) stays operator/council-gated.
- The dashboard headline reading `summary.principals` is a small frontend follow-up once this deploys.

## Tests

8 cases (thread merge, lineage merge, transitive combine, unknown-parent no-merge, any-instance participation, all-ghost, id fallback). Lifecycle suite green (172).

https://claude.ai/code/session_01JqgvE7zmGV1N6EeKyHqCLF