### PR TITLE
fix(drift): wire calibration signal to the tactical overconfidence gap

### DIFF
--- a/src/monitor_drift.py
+++ b/src/monitor_drift.py
@@ -1,6 +1,6 @@
 """Ethical drift vector computation for governance monitor."""
 
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 from governance_core import (
     coherence, compute_ethical_drift, get_agent_baseline,
@@ -11,6 +11,38 @@ from src.calibration import calibration_checker
 from src.logging_utils import get_logger
 
 logger = get_logger(__name__)
+
+# Minimum tactical samples before the calibration signal is trusted for drift.
+_MIN_TACTICAL_SAMPLES = 10
+
+
+def compute_calibration_error(checker) -> Optional[float]:
+    """Current confidence-outcome mismatch from the TACTICAL calibration channel.
+
+    Returns the worst populated tactical bin's overconfidence — declared
+    confidence minus real success rate — clamped to [0, 1]. The worst bin, not a
+    sample-weighted mean, because over- and under-confident bins otherwise
+    cancel: a system miscalibrated in both directions would read ~0 and hide the
+    problem (the same masking the gate avoids by scoring per bin). Underconfidence
+    contributes zero drift; overconfidence is the safety-relevant direction
+    (consistent with `src/calibration.py::check_calibration`).
+
+    Returns None when no bin has enough evidence yet, so the drift engine falls
+    back to its baseline estimate rather than asserting a false zero.
+
+    This replaces a long-dead call to a non-existent `calibration_checker.check()`
+    (its AttributeError was swallowed, so the drift vector never carried a real
+    calibration signal) and the mis-scaled `trajectory_health / 100.0` fallback
+    that treated a 0-1 value as a percentage. The strategic `trajectory_health`
+    proxy is deliberately not used here — it is saturated (near-constant across
+    confidence levels) and was demoted to advisory in the gate.
+    """
+    tactical = checker.compute_tactical_metrics()
+    populated = [b for b in tactical.values() if b.count >= _MIN_TACTICAL_SAMPLES]
+    if not populated:
+        return None
+    worst_overconfidence = max(b.expected_accuracy - b.accuracy for b in populated)
+    return max(0.0, min(1.0, worst_overconfidence))
 
 
 def compute_drift_vector(
@@ -32,16 +64,16 @@ def compute_drift_vector(
     """
     agent_baseline = get_agent_baseline(monitor.agent_id)
 
-    # Get calibration error from calibration system if available
+    # Get calibration error (tactical confidence-outcome mismatch) if available.
     calibration_error = None
     try:
-        cal_status = calibration_checker.check()
-        if cal_status.get('calibrated') and cal_status.get('total_samples', 0) > 10:
-            trajectory_health = cal_status.get('trajectory_health', 0.5)
-            if trajectory_health is not None:
-                calibration_error = abs((trajectory_health / 100.0) - 0.5) * 2
-    except Exception:
-        pass
+        calibration_error = compute_calibration_error(calibration_checker)
+    except Exception as exc:
+        # Degrade gracefully — compute_ethical_drift falls back to a baseline
+        # estimate when this is None — but log rather than silently swallow, so a
+        # real future break is visible (the prior bare `except: pass` is exactly
+        # how the dead `.check()` call stayed invisible).
+        logger.warning(f"calibration_error unavailable for drift vector: {exc}")
 
     # Get current coherence for deviation calculation
     active_params = get_active_params()

--- a/tests/test_monitor_drift_calibration.py
+++ b/tests/test_monitor_drift_calibration.py
@@ -1,0 +1,65 @@
+"""Regression tests for the calibration signal feeding the drift vector.
+
+Guards against the long-lived bug where `src/monitor_drift.py` called a
+non-existent `calibration_checker.check()`, swallowed the AttributeError, and
+silently fed `calibration_error=None` into every drift vector — plus the
+mis-scaled `trajectory_health / 100.0` fallback. The signal now comes from the
+TACTICAL overconfidence gap (declared confidence minus real success rate).
+"""
+from src.calibration import CalibrationChecker
+from src.monitor_drift import compute_calibration_error, _MIN_TACTICAL_SAMPLES
+
+
+def _fresh_checker(tmp_path) -> CalibrationChecker:
+    # Isolate state to a temp file so the test never touches live calibration.
+    return CalibrationChecker(state_file=str(tmp_path / "cal_state.json"))
+
+
+def test_none_without_tactical_evidence(tmp_path):
+    """No tactical samples -> None, so the drift engine uses its baseline."""
+    checker = _fresh_checker(tmp_path)
+    assert compute_calibration_error(checker) is None
+
+
+def test_overconfidence_produces_positive_signal(tmp_path):
+    """Declared >> actual success -> a real, positive calibration_error in (0, 1]."""
+    checker = _fresh_checker(tmp_path)
+    # Declared ~0.6, actual 0 -> overconfidence gap ~0.6.
+    for _ in range(_MIN_TACTICAL_SAMPLES + 10):
+        checker.record_tactical_decision(0.6, "proceed", False)
+    err = compute_calibration_error(checker)
+    assert err is not None
+    assert 0.5 < err <= 1.0  # ~0.6
+
+
+def test_underconfidence_clamps_to_zero(tmp_path):
+    """Declared << actual success is not drift -> 0.0 (measured, not baseline)."""
+    checker = _fresh_checker(tmp_path)
+    for _ in range(_MIN_TACTICAL_SAMPLES + 10):
+        checker.record_tactical_decision(0.3, "proceed", True)  # underconfident
+    err = compute_calibration_error(checker)
+    assert err == 0.0
+
+
+def test_below_min_samples_returns_none(tmp_path):
+    """A handful of samples is not enough to trust the signal."""
+    checker = _fresh_checker(tmp_path)
+    for _ in range(_MIN_TACTICAL_SAMPLES - 1):
+        checker.record_tactical_decision(0.6, "proceed", False)
+    assert compute_calibration_error(checker) is None
+
+
+def test_worst_bin_not_cancelled_by_underconfident_bin(tmp_path):
+    """An overconfident bin must not be cancelled by an underconfident one.
+
+    A sample-weighted mean would average these toward ~0 and hide the real
+    overconfidence; the worst-bin signal surfaces it.
+    """
+    checker = _fresh_checker(tmp_path)
+    for _ in range(100):
+        checker.record_tactical_decision(0.6, "proceed", False)   # overconfident, gap ~0.6
+    for _ in range(100):
+        checker.record_tactical_decision(0.9, "proceed", True)    # underconfident, gap ~ -0.1
+    err = compute_calibration_error(checker)
+    assert err is not None
+    assert err > 0.5  # the 0.6 bin dominates, not a ~0.25 average


### PR DESCRIPTION
## Bug

`src/monitor_drift.py` called `calibration_checker.check()` — **a method that does not exist** on `CalibrationChecker`. The proxy's `__getattr__` turned it into an `AttributeError`, the bare `except Exception: pass` swallowed it, and `calibration_error` fell through to `None` in **every** drift vector. Stacked underneath: even had the method existed, the fallback did `trajectory_health / 100.0` — treating a 0–1 value (0.97) as a 0–100 percentage. Net effect: **drift detection has never consumed a calibration signal.** (Surfaced during the #874 council review; verified directly here — no `check()` method exists, traced the proxy + swallow.)

## Fix

`compute_calibration_error(checker)` returns the **worst populated tactical bin's overconfidence** (declared confidence − real success rate), clamped to [0, 1]:

- **Worst bin, not a mean** — over- and under-confident bins otherwise cancel; a system miscalibrated in both directions would read ~0 and hide it (the same masking the gate avoids by scoring per bin). Live confirms: the net mean is 0.06 (misleadingly calm), the worst bin is **0.251**.
- **Overconfidence-only** — underconfidence contributes zero drift; overconfidence is the safety-relevant direction, consistent with `check_calibration` (the gate merged in #874).
- **`None` with no evidence** — so `compute_ethical_drift` keeps its baseline fallback rather than asserting a false zero.
- Does **not** use the strategic `trajectory_health` proxy — it's saturated and was demoted to advisory in the gate.
- The bare `except: pass` is **narrowed to log** on unexpected error — the prior swallow is exactly how the dead call stayed invisible for so long.

## Result

Live: the drift vector now receives **0.2509** (the 0.5–0.7 overconfident bin) instead of `None`. So calibration finally contributes to `calibration_deviation` in the ethical-drift vector.

## Tests

New `tests/test_monitor_drift_calibration.py` (5): none-without-evidence, overconfidence→positive, underconfidence→0.0, below-min→none, worst-bin-not-cancelled. Broader drift/monitor sweep: 421 pass.

Draft — operator merge gate.

https://claude.ai/code/session_01HES9ERjdTrV2rhLwvejve1