### PR TITLE
fix(ops): serialize deploys with a shared worktree lock

### DIFF
--- a/scripts/ops/deploy-lease-plane.sh
+++ b/scripts/ops/deploy-lease-plane.sh
@@ -25,6 +25,28 @@ UID_NUM="$(id -u)"
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
 
+# ── Serialize deploys (shared worktree) ──────────────────────────────────────
+# This script and deploy-mcp.sh both fast-forward the SAME deploy worktree, so
+# concurrent runs race the git index (and deploy-mcp's rollback can revert this
+# deploy). macOS has no flock(1), so guard with an atomic mkdir lock keyed to the
+# worktree, reclaiming it only if the holder process is dead. The lock is shared
+# with deploy-mcp.sh because the name derives from the (shared) DEPLOY path.
+# Override via UNITARES_DEPLOY_LOCK.
+LOCK_DIR="${UNITARES_DEPLOY_LOCK:-${TMPDIR:-/tmp}/unitares-deploy$(printf '%s' "$DEPLOY" | tr -c 'A-Za-z0-9' '_').lock}"
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  holder="$(cat "$LOCK_DIR/pid" 2>/dev/null || echo '?')"
+  if [[ "$holder" != '?' ]] && ! kill -0 "$holder" 2>/dev/null; then
+    echo "[deploy] reclaiming stale deploy lock (holder PID $holder is dead): $LOCK_DIR" >&2
+    rm -rf "$LOCK_DIR"
+    mkdir "$LOCK_DIR" 2>/dev/null || { echo "[deploy] lost a lock race — another deploy just started; refusing" >&2; exit 1; }
+  else
+    echo "[deploy] another deploy is in progress (lock: $LOCK_DIR, holder PID $holder) — refusing to run concurrently" >&2
+    exit 1
+  fi
+fi
+printf '%s' "$$" > "$LOCK_DIR/pid"
+trap 'rm -rf "$LOCK_DIR"' EXIT
+
 echo "[deploy] fetching origin/master"
 git -C "$REPO" fetch origin master --quiet
 

--- a/scripts/ops/deploy-mcp.sh
+++ b/scripts/ops/deploy-mcp.sh
@@ -39,6 +39,30 @@ PORT="${UNITARES_MCP_PORT:-8767}"
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
 
+# ── Serialize deploys (shared worktree) ──────────────────────────────────────
+# deploy-mcp.sh and deploy-lease-plane.sh both fast-forward the SAME deploy
+# worktree, and this script's failure path runs `git reset --hard $PREV`. Two
+# deploys at once race the git index and — worse — the rollback can revert a
+# parallel deploy to a stale commit (silent regression + a false "OK"). macOS
+# has no flock(1), so guard with an atomic mkdir lock keyed to the worktree,
+# reclaiming it only if the holder process is dead. Override via
+# UNITARES_DEPLOY_LOCK; the lock is shared with deploy-lease-plane.sh because the
+# name derives from the (shared) DEPLOY path.
+LOCK_DIR="${UNITARES_DEPLOY_LOCK:-${TMPDIR:-/tmp}/unitares-deploy$(printf '%s' "$DEPLOY" | tr -c 'A-Za-z0-9' '_').lock}"
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  holder="$(cat "$LOCK_DIR/pid" 2>/dev/null || echo '?')"
+  if [[ "$holder" != '?' ]] && ! kill -0 "$holder" 2>/dev/null; then
+    echo "[deploy-mcp] reclaiming stale deploy lock (holder PID $holder is dead): $LOCK_DIR" >&2
+    rm -rf "$LOCK_DIR"
+    mkdir "$LOCK_DIR" 2>/dev/null || { echo "[deploy-mcp] lost a lock race — another deploy just started; refusing" >&2; exit 1; }
+  else
+    echo "[deploy-mcp] another deploy is in progress (lock: $LOCK_DIR, holder PID $holder) — refusing to run concurrently" >&2
+    exit 1
+  fi
+fi
+printf '%s' "$$" > "$LOCK_DIR/pid"
+trap 'rm -rf "$LOCK_DIR"' EXIT
+
 if [[ ! -f "$PLIST" ]]; then
   echo "[deploy-mcp] $PLIST not installed — install the LaunchAgent first (see CLAUDE.md setup)" >&2
   exit 1


### PR DESCRIPTION
Follow-up to your question about multiple agents deploying/working concurrently. The sharpest hazard was **concurrent deploys**, and this closes it.

## The problem
`deploy-mcp.sh` and `deploy-lease-plane.sh` both fast-forward the **same** deploy worktree (`~/projects/unitares-deploy`), and `deploy-mcp.sh`'s failure path runs `git reset --hard $PREV`. With parallel agents (the dispatcher's normal mode), two deploys at once can:
1. race the shared git index (`.git/index.lock` aborts mid-script), and — worse —
2. let one run's **rollback revert the other's good deploy** to a stale commit, which then *passes the health check* → a silent regression reported as success.

## The fix
An atomic **`mkdir`-based lock** (macOS has no `flock(1)`), keyed to the deploy-worktree path so **both scripts share one lock** and mutually exclude:
- a second deploy **refuses loudly** (exit 1) instead of racing;
- a lock left by a **dead holder is reclaimed** (PID liveness check), so a killed deploy doesn't wedge future ones;
- released on exit via `trap`;
- overridable with `UNITARES_DEPLOY_LOCK`.

## Verified
- Concurrent run refused (exit 1); released lock re-acquirable; stale (dead-PID) lock reclaimed.
- Both scripts pass `bash -n`.

## What this does *not* fix (inherent, by design)
- A deploy still **restarts the single governance process** (~30–90s), dropping every connected agent/resident and wiping ephemeral in-memory `agent_metadata`. Mitigation is operational: deploy in quiet windows; residents reconnect.
- A deploy ships **current master HEAD** (everyone's merged commits), not "just my change."

These are the things to weigh before any *auto-deploy* automation — and the reason I'd want this lock in first. Concurrent agent *coding* is already governed by CLAUDE.md's single-writer-surface rules; this just extends that safety to the deploy step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015CWDAp4hoA7cBNEt6fjhG9)_