### PR TITLE
fix(calibration): stop the saturated strategic proxy from raising a false inverted-curve alarm

### DIFF
--- a/src/calibration.py
+++ b/src/calibration.py
@@ -44,6 +44,12 @@ class ComplexityCalibrationBin:
 # direction without loosening the magnitude.
 _OVERCONFIDENCE_GATE = 0.2
 
+# Minimum margin before a confidence/outcome curve counts as "inverted". A
+# near-ceiling jitter on a saturated channel (e.g. trajectory_health 0.969 at low
+# confidence vs 0.933 at high) is noise, not evidence that confident verdicts are
+# untrustworthy — the alarming "inverted curve" warning should not fire on it.
+_CURVE_INVERSION_MARGIN = 0.05
+
 
 class CalibrationChecker:
     """
@@ -1130,22 +1136,40 @@ class CalibrationChecker:
             "tactical": self._characterize_dimension(tactical, min_samples),
         }
 
-        is_inverted = result["strategic"].get("curve_inverted", False)
-        worst = result["strategic"].get("worst_bin")
+        # The verdict-quality warning prefers the TACTICAL channel — real
+        # exogenous outcomes (tests, commands, lint). The STRATEGIC channel's
+        # truth signal (trajectory_health) is a saturated proxy: near-constant
+        # across confidence levels, so its "inversion" is jitter, not evidence
+        # that confident verdicts are untrustworthy. Drive the warning off real
+        # outcomes; fall back to a clearly-labeled proxy note only when there is
+        # no tactical data.
+        source = None
+        proxy = False
+        if result["tactical"].get("status") == "analyzed":
+            source = result["tactical"]
+        elif result["strategic"].get("status") == "analyzed":
+            source = result["strategic"]
+            proxy = True
 
-        if is_inverted:
-            result["verdict_quality_warning"] = (
-                "INVERTED calibration curve: agents with HIGH confidence have WORSE outcomes. "
-                "High-confidence 'proceed' verdicts may be the LEAST trustworthy."
-            )
-        elif worst and worst.get("calibration_error", 0) > 0.3:
-            result["verdict_quality_warning"] = (
-                f"Severe miscalibration in bin {worst.get('bin')}: "
-                f"calibration error {worst['calibration_error']:.2f}. "
-                "Verdicts in this confidence range should be treated with caution."
-            )
-        else:
-            result["verdict_quality_warning"] = None
+        warning = None
+        if source is not None:
+            label = (" (strategic trajectory_health proxy — a saturated channel, "
+                     "not a real-outcome signal)") if proxy else ""
+            worst = source.get("worst_bin")
+            if source.get("curve_inverted"):
+                warning = (
+                    "INVERTED calibration curve: agents with HIGH confidence have "
+                    "WORSE outcomes. High-confidence 'proceed' verdicts may be the "
+                    f"LEAST trustworthy.{label}"
+                )
+            elif worst and worst.get("calibration_error", 0) > 0.3:
+                warning = (
+                    f"Severe miscalibration in bin {worst.get('bin')}: "
+                    f"calibration error {worst['calibration_error']:.2f}. "
+                    f"Verdicts in this confidence range should be treated with caution.{label}"
+                )
+
+        result["verdict_quality_warning"] = warning
 
         return result
 
@@ -1168,7 +1192,9 @@ class CalibrationChecker:
         if len(sorted_bins) >= 2:
             low_conf_acc = sorted_bins[0][1].accuracy
             high_conf_acc = sorted_bins[-1][1].accuracy
-            curve_inverted = high_conf_acc < low_conf_acc
+            # Require a material margin — a near-ceiling jitter on a saturated
+            # channel is noise, not a real inversion.
+            curve_inverted = (low_conf_acc - high_conf_acc) > _CURVE_INVERSION_MARGIN
 
         worst = max(valid.items(), key=lambda x: x[1].calibration_error)
 

--- a/tests/test_calibration_failure_mode_warning.py
+++ b/tests/test_calibration_failure_mode_warning.py
@@ -1,0 +1,97 @@
+"""Tests for the verdict-quality warning in characterize_failure_modes.
+
+The alarming "INVERTED calibration curve" warning previously fired off the
+STRATEGIC channel (trajectory_health), a saturated proxy whose near-ceiling
+jitter (e.g. 0.969 low-confidence vs 0.933 high-confidence) tripped it falsely.
+Now: a curve counts as inverted only past a material margin, and the warning is
+sourced from the TACTICAL (real-outcome) channel, with strategic used only as a
+clearly-labeled proxy fallback.
+"""
+from src.calibration import CalibrationBin, CalibrationChecker
+
+
+def _bin(lo, hi, *, n, declared, actual) -> CalibrationBin:
+    correct = round(actual * n)
+    return CalibrationBin(
+        bin_range=(lo, hi),
+        count=n,
+        predicted_correct=correct,
+        actual_correct=correct,
+        accuracy=actual,
+        expected_accuracy=declared,
+        calibration_error=abs(actual - declared),
+    )
+
+
+def _checker(tmp_path) -> CalibrationChecker:
+    return CalibrationChecker(state_file=str(tmp_path / "cal.json"))
+
+
+def test_near_ceiling_jitter_is_not_inverted(tmp_path):
+    """0.969 (low conf) vs 0.933 (high conf): margin 0.036 < 0.05 -> not inverted."""
+    checker = _checker(tmp_path)
+    bins = {
+        "0.0-0.5": _bin(0.0, 0.5, n=50, declared=0.30, actual=0.969),
+        "0.9-1.0": _bin(0.9, 1.0, n=50, declared=0.95, actual=0.933),
+    }
+    dim = checker._characterize_dimension(bins, min_samples=5)
+    assert dim["curve_inverted"] is False
+
+
+def test_material_inversion_still_flagged(tmp_path):
+    """A real inversion (high-conf 0.60 << low-conf 0.90) exceeds the margin."""
+    checker = _checker(tmp_path)
+    bins = {
+        "0.0-0.5": _bin(0.0, 0.5, n=50, declared=0.30, actual=0.90),
+        "0.9-1.0": _bin(0.9, 1.0, n=50, declared=0.95, actual=0.60),
+    }
+    dim = checker._characterize_dimension(bins, min_samples=5)
+    assert dim["curve_inverted"] is True
+
+
+def test_warning_prefers_tactical_over_saturated_strategic(tmp_path, monkeypatch):
+    """A materially-inverted strategic proxy must not warn when tactical is clean."""
+    checker = _checker(tmp_path)
+    strat_inverted = {
+        "0.0-0.5": _bin(0.0, 0.5, n=50, declared=0.30, actual=0.90),
+        "0.9-1.0": _bin(0.9, 1.0, n=50, declared=0.95, actual=0.60),
+    }
+    tactical_clean = {
+        "0.0-0.5": _bin(0.0, 0.5, n=50, declared=0.30, actual=0.35),
+        "0.9-1.0": _bin(0.9, 1.0, n=50, declared=0.92, actual=0.93),
+    }
+    monkeypatch.setattr(checker, "compute_calibration_metrics", lambda: strat_inverted)
+    monkeypatch.setattr(checker, "compute_tactical_metrics", lambda: tactical_clean)
+    fm = checker.characterize_failure_modes(min_samples=5)
+    assert fm["verdict_quality_warning"] is None
+
+
+def test_strategic_only_warning_is_labeled_proxy(tmp_path, monkeypatch):
+    """With no tactical data, a strategic warning must disclose it is a proxy."""
+    checker = _checker(tmp_path)
+    strat_inverted = {
+        "0.0-0.5": _bin(0.0, 0.5, n=50, declared=0.30, actual=0.90),
+        "0.9-1.0": _bin(0.9, 1.0, n=50, declared=0.95, actual=0.60),
+    }
+    monkeypatch.setattr(checker, "compute_calibration_metrics", lambda: strat_inverted)
+    monkeypatch.setattr(checker, "compute_tactical_metrics", lambda: {})
+    fm = checker.characterize_failure_modes(min_samples=5)
+    warning = fm["verdict_quality_warning"]
+    assert warning is not None
+    assert "proxy" in warning.lower()
+
+
+def test_tactical_inversion_warns_without_proxy_label(tmp_path, monkeypatch):
+    """A genuine tactical inversion warns, and is NOT labeled a proxy."""
+    checker = _checker(tmp_path)
+    tactical_inverted = {
+        "0.0-0.5": _bin(0.0, 0.5, n=50, declared=0.30, actual=0.90),
+        "0.9-1.0": _bin(0.9, 1.0, n=50, declared=0.95, actual=0.60),
+    }
+    monkeypatch.setattr(checker, "compute_calibration_metrics", lambda: {})
+    monkeypatch.setattr(checker, "compute_tactical_metrics", lambda: tactical_inverted)
+    fm = checker.characterize_failure_modes(min_samples=5)
+    warning = fm["verdict_quality_warning"]
+    assert warning is not None
+    assert "INVERTED" in warning
+    assert "proxy" not in warning.lower()


### PR DESCRIPTION
## Problem

The calibration response emits `verdict_quality_warning: "INVERTED calibration curve: agents with HIGH confidence have WORSE outcomes. High-confidence 'proceed' verdicts may be the LEAST trustworthy."` — fired off the **STRATEGIC** channel (`trajectory_health`), which is a **saturated proxy**. Its 'inversion' is a near-ceiling jitter (low-confidence 0.969 vs high-confidence 0.933, margin **0.036**), not a real signal. This is the same saturation that led #874 to demote the strategic channel to advisory — so this maximally-alarming string directly contradicted the understanding we just merged.

## Fix

- **Material-margin guard:** `curve_inverted` now requires the low-vs-high accuracy gap to exceed `_CURVE_INVERSION_MARGIN = 0.05`. Near-ceiling jitter on a saturated channel no longer registers.
- **Source from real outcomes:** `verdict_quality_warning` is driven by the **TACTICAL** channel (tests/commands/lint), with strategic used only as a **clearly-labeled proxy** fallback when there is no tactical data.

## Result

Live: `strategic.curve_inverted` -> `False`, `verdict_quality_warning` -> `None`. Tactical is genuinely clean at high confidence (declare ~1.0, succeed ~0.92); the real mid-band overconfidence (0.5-0.7, ~0.25) is below the 0.3 'severe' threshold for this warning and is already surfaced via the gate's `issues`. So no information is lost — just the false alarm.

## Tests

5 new in `tests/test_calibration_failure_mode_warning.py` (synthetic-bin, precise); 379 in the calibration/admin/formatter suites pass.

Draft — operator merge gate.

https://claude.ai/code/session_01HES9ERjdTrV2rhLwvejve1