### PR TITLE
feat(calibration): surface class-scoped overconfidence the global gate can't see

### DIFF
--- a/src/mcp_handlers/admin/calibration.py
+++ b/src/mcp_handlers/admin/calibration.py
@@ -11,6 +11,53 @@ from ..decorators import mcp_tool
 from src.logging_utils import get_logger
 logger = get_logger(__name__)
 
+# Class-scope overconfidence advisory. Magnitude matches the global gate's
+# _OVERCONFIDENCE_GATE; kept local so this descriptive surface stays decoupled
+# from the gating module. A class needs at least this many eligible samples
+# before its gap is trustworthy enough to surface.
+_CLASS_OVERCONFIDENCE_GATE = 0.2
+_CLASS_OVERCONFIDENCE_MIN_SAMPLES = 30
+
+
+def _derive_class_overconfidence_advisories(
+    by_class_envelope: Optional[Dict[str, Any]],
+    *,
+    gate: float = _CLASS_OVERCONFIDENCE_GATE,
+    min_samples: int = _CLASS_OVERCONFIDENCE_MIN_SAMPLES,
+) -> List[Dict[str, Any]]:
+    """Surface agent classes whose self-reported confidence materially exceeds
+    their real success rate.
+
+    The global calibration gate is class-unscoped by design (see
+    `check_calibration`): it bins by confidence across the whole fleet, so a
+    single overconfident cohort can hide behind well-calibrated peers in the
+    aggregated bins. This makes that masking legible. Descriptive only — it does
+    not gate anything.
+
+    `calibration_gap = empirical_accuracy - mean_confidence`, so a negative gap
+    is overconfidence; the magnitude flagged is `-gap`.
+    """
+    advisories: List[Dict[str, Any]] = []
+    by_class = (by_class_envelope or {}).get("by_class", {}) or {}
+    for class_tag, m in by_class.items():
+        if not isinstance(m, dict):
+            continue
+        samples = m.get("eligible_samples", 0) or 0
+        gap = m.get("calibration_gap")
+        if gap is None or samples < min_samples:
+            continue
+        overconfidence = -gap  # positive == declared above achieved
+        if overconfidence > gate:
+            advisories.append({
+                "class_tag": class_tag,
+                "declared_confidence": m.get("mean_confidence"),
+                "achieved_accuracy": m.get("empirical_accuracy"),
+                "overconfidence": round(overconfidence, 4),
+                "eligible_samples": samples,
+            })
+    advisories.sort(key=lambda a: a["overconfidence"], reverse=True)
+    return advisories
+
 
 def _build_calibration_guidance(
     *,
@@ -212,7 +259,23 @@ async def handle_check_calibration(arguments: Dict[str, Any]) -> Sequence[TextCo
     # scope and only appear on the tactical_evidence (global) envelope above).
     try:
         from src.sequential_calibration import get_sequential_calibration_tracker
-        response["by_class"] = get_sequential_calibration_tracker().compute_metrics_by_class()
+        by_class_env = get_sequential_calibration_tracker().compute_metrics_by_class()
+        response["by_class"] = by_class_env
+        # Make class-scoped overconfidence visible. The global gate is
+        # class-unscoped, so an overconfident cohort (e.g. ephemeral sessions
+        # declaring ~1.0 and achieving far less) can hide behind well-calibrated
+        # peers in the aggregated confidence bins. Descriptive only — does not gate.
+        class_advisories = _derive_class_overconfidence_advisories(by_class_env)
+        if class_advisories:
+            response["class_overconfidence_advisories"] = {
+                "note": (
+                    "The global calibration gate is class-unscoped: these classes "
+                    "are overconfident in aggregate but can hide behind well-"
+                    "calibrated peers in the global confidence bins. Descriptive "
+                    "only — does not gate."
+                ),
+                "classes": class_advisories,
+            }
     except Exception as e_bc:
         logger.debug(f"S10 by_class breakdown skipped: {e_bc}")
 

--- a/tests/test_class_overconfidence_advisory.py
+++ b/tests/test_class_overconfidence_advisory.py
@@ -1,0 +1,80 @@
+"""Tests for the class-scoped overconfidence advisory.
+
+The global calibration gate is class-unscoped: it bins by confidence across the
+whole fleet, so an overconfident cohort (e.g. ephemeral sessions declaring ~1.0
+and achieving ~0.67) can hide behind well-calibrated peers. This advisory makes
+that masking visible without changing what gates.
+
+`calibration_gap = empirical_accuracy - mean_confidence` (negative == overconfident).
+"""
+from src.mcp_handlers.admin.calibration import (
+    _derive_class_overconfidence_advisories,
+    _CLASS_OVERCONFIDENCE_MIN_SAMPLES,
+)
+
+
+def _env(classes):
+    return {"bootstrapped": True, "by_class": classes}
+
+
+def test_overconfident_class_is_surfaced():
+    env = _env({
+        "ephemeral": {
+            "eligible_samples": 1503,
+            "mean_confidence": 0.9995,
+            "empirical_accuracy": 0.6713,
+            "calibration_gap": -0.3282,
+        },
+    })
+    out = _derive_class_overconfidence_advisories(env)
+    assert len(out) == 1
+    assert out[0]["class_tag"] == "ephemeral"
+    assert abs(out[0]["overconfidence"] - 0.3282) < 1e-6
+    assert out[0]["eligible_samples"] == 1503
+
+
+def test_underconfident_class_not_surfaced():
+    env = _env({
+        "engaged_ephemeral": {
+            "eligible_samples": 93,
+            "mean_confidence": 0.7293,
+            "empirical_accuracy": 1.0,
+            "calibration_gap": 0.2707,  # underconfident
+        },
+    })
+    assert _derive_class_overconfidence_advisories(env) == []
+
+
+def test_overconfident_but_below_min_samples_not_surfaced():
+    env = _env({
+        "ephemeral": {
+            "eligible_samples": _CLASS_OVERCONFIDENCE_MIN_SAMPLES - 1,
+            "mean_confidence": 0.99,
+            "empirical_accuracy": 0.50,
+            "calibration_gap": -0.49,
+        },
+    })
+    assert _derive_class_overconfidence_advisories(env) == []
+
+
+def test_mild_overconfidence_under_gate_not_surfaced():
+    env = _env({
+        "session_like": {
+            "eligible_samples": 500,
+            "mean_confidence": 0.80,
+            "empirical_accuracy": 0.65,
+            "calibration_gap": -0.15,  # under the 0.20 gate
+        },
+    })
+    assert _derive_class_overconfidence_advisories(env) == []
+
+
+def test_sorted_worst_first_and_empty_safe():
+    env = _env({
+        "a": {"eligible_samples": 100, "mean_confidence": 0.9, "empirical_accuracy": 0.6, "calibration_gap": -0.30},
+        "b": {"eligible_samples": 100, "mean_confidence": 0.9, "empirical_accuracy": 0.4, "calibration_gap": -0.50},
+    })
+    out = _derive_class_overconfidence_advisories(env)
+    assert [a["class_tag"] for a in out] == ["b", "a"]  # worst first
+    assert _derive_class_overconfidence_advisories(None) == []
+    assert _derive_class_overconfidence_advisories({"by_class": {}}) == []


### PR DESCRIPTION
## Observation (now live-verified)

The calibration gate is **class-unscoped by design** — it bins by confidence across the whole fleet. So an overconfident cohort can hide behind well-calibrated peers in the aggregated bins. Confirmed against the running server:

- `by_class.ephemeral`: declared mean confidence **0.9995**, achieved **0.6713** (overconfidence **0.328**, 1503 samples).
- Those ~1.0 declarations land in the **global 0.9–1.0 tactical bin**, which reads `actual: 0.923, diagnosis: well_calibrated`.
- So the ephemeral cohort's overconfidence is **invisible** to the gate — non-ephemeral high-confidence declarers pull the bin average up and mask it.

## Change

Add a descriptive `class_overconfidence_advisories` block to the calibration response: any class overconfident beyond 0.2 (above a 30-sample floor) is surfaced with declared vs achieved + sample count, plus a note that the global gate is unscoped and doesn't catch it.

**Descriptive only — does NOT change what gates.** The global-unscoped gate is a deliberate design choice (calibration is global+agent-unscoped); this PR does not relitigate it. It just makes the masking legible — honest-by-disclosure, the same pattern as #816.

## Why not class-conditional gating

That would be a real governance-semantics change to a deliberate design decision — out of scope for an observation. Surfacing the hidden signal is the honest, low-risk move; whether to act on it (e.g. lower default confidence for the ephemeral cohort) is then your call with the data in front of you.

## Tests

5 cases (`tests/test_class_overconfidence_advisory.py`) using the live ephemeral numbers: surfaced / underconfident-skipped / below-min-skipped / under-gate-skipped / sorted-worst-first + None-safe. Admin suites: 128 pass.

**Caveat:** the pure helper is verified with live data, but the standalone tracker is unloaded (its state lives in the server process), so end-to-end surfacing in the response confirms post-deploy via a live `calibration(action=check)`.

Draft — operator merge gate.

https://claude.ai/code/session_01HES9ERjdTrV2rhLwvejve1