### PR TITLE
fix(list_agents): stop per-agent monitor hydration that timed out the list

### DIFF
--- a/src/mcp_handlers/lifecycle/query.py
+++ b/src/mcp_handlers/lifecycle/query.py
@@ -24,7 +24,6 @@ from ..decorators import mcp_tool
 from ..support.coerce import safe_float
 from ..support.naming_helpers import disambiguate_public_handle
 from src.logging_utils import get_logger
-from src.agent_monitor_state import ensure_hydrated
 
 from .helpers import _is_test_agent
 
@@ -648,82 +647,24 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                         agent_info["metrics"] = None
                         logger.warning(f"Error getting metrics for {agent_id}: {e}")
                 else:
-                    # Monitor not in memory - load it to get metrics
-                    cached_health = getattr(meta, 'health_status', None)
-                    try:
-                        monitor = mcp_server.get_or_create_monitor(agent_id)
-                        await ensure_hydrated(monitor, agent_id)
-                        metrics_dict = monitor.get_metrics()
-
-                        # Get health status
-                        if cached_health and cached_health != "unknown":
-                            agent_info["health_status"] = cached_health
-                        else:
-                            risk_score = metrics_dict.get('risk_score', None)
-                            coherence = float(monitor.state.coherence) if monitor.state else metrics_dict.get('coherence', None)
-                            void_active = bool(monitor.state.void_active) if monitor.state else metrics_dict.get('void_active', False)
-
-                            health_status_obj, _ = mcp_server.health_checker.get_health_status(
-                                risk_score=risk_score,
-                                coherence=coherence,
-                                void_active=void_active
-                            )
-                            agent_info["health_status"] = health_status_obj.value
-
-                            # Cache for future use
-                            if meta:
-                                meta.health_status = health_status_obj.value
-
-                        # Populate metrics from monitor state
-                        if monitor.state:
-                            agent_info["metrics"] = {
-                                "E": safe_float(monitor.state.E),
-                                "I": safe_float(monitor.state.I),
-                                "S": safe_float(monitor.state.S),
-                                "V": safe_float(monitor.state.V),
-                                "coherence": safe_float(monitor.state.coherence),
-                                "current_risk": metrics_dict.get("current_risk"),
-                                "risk_score": safe_float(metrics_dict.get("risk_score") or metrics_dict.get("current_risk") or metrics_dict.get("mean_risk", 0.5)),
-                                "phi": metrics_dict.get("phi"),
-                                "verdict": metrics_dict.get("verdict"),
-                                "mean_risk": safe_float(metrics_dict.get("mean_risk", 0.5)),
-                                "lambda1": safe_float(monitor.state.lambda1),
-                                "void_active": bool(monitor.state.void_active) if monitor.state.void_active is not None else False
-                            }
-                        else:
-                            agent_info["metrics"] = None
-                    except Exception as e:
-                        logger.debug(f"Could not load metrics for agent '{agent_id}': {e}")
-                        agent_info["health_status"] = cached_health or "unknown"
-                        agent_info["metrics"] = None
+                    # Monitor not resident — do NOT hydrate it from the DB here.
+                    # Loading every un-loaded monitor turned this list into N
+                    # synchronous DB round-trips (the anyio/asyncpg amplification
+                    # in CLAUDE.md's Substrate Tax), blowing the 15s budget on a
+                    # large fleet. The dashboard's include_metrics=true call then
+                    # timed out and froze its cached counts — surfacing as a
+                    # phantom "N critical" with no live, clickable row. Use the
+                    # health_status that process_agent_update persists on
+                    # agent_metadata on every check-in (phases.py); metrics are
+                    # None for non-resident agents (the dashboard renders null
+                    # metrics as "-").
+                    agent_info["health_status"] = getattr(meta, 'health_status', None) or "unknown"
+                    agent_info["metrics"] = None
             else:
-                # No metrics requested - try cached health_status first, calculate if missing
-                cached_health = getattr(meta, 'health_status', None)
-                if cached_health and cached_health != "unknown":
-                    agent_info["health_status"] = cached_health
-                else:
-                    # No cached health status or it's "unknown" - calculate it
-                    try:
-                        monitor = mcp_server.get_or_create_monitor(agent_id)
-                        await ensure_hydrated(monitor, agent_id)
-                        metrics_dict = monitor.get_metrics()
-                        attention_score = metrics_dict.get('attention_score') or metrics_dict.get('risk_score', None)
-                        coherence = metrics_dict.get('coherence', None)
-                        void_active = metrics_dict.get('void_active', False)
-
-                        health_status_obj, _ = mcp_server.health_checker.get_health_status(
-                            risk_score=attention_score,
-                            coherence=coherence,
-                            void_active=void_active
-                        )
-                        agent_info["health_status"] = health_status_obj.value
-
-                        # Cache for future use
-                        if meta:
-                            meta.health_status = health_status_obj.value
-                    except Exception as e:
-                        logger.debug(f"Could not calculate health status for agent '{agent_id}': {e}")
-                        agent_info["health_status"] = "unknown"
+                # No metrics requested — use the cached health_status only; never
+                # hydrate a monitor from the DB in the list path (same reason as
+                # the include_metrics branch above).
+                agent_info["health_status"] = getattr(meta, 'health_status', None) or "unknown"
                 agent_info["metrics"] = None
 
             # Add standardized fields if requested

--- a/tests/test_handlers_lifecycle.py
+++ b/tests/test_handlers_lifecycle.py
@@ -803,3 +803,68 @@ class TestListAgentsParticipation:
             # Counts stay truthful — ghosts are not dropped, just ordered last.
             assert data["summary"]["participated"] == 2
             assert data["summary"]["never_participated"] == 10
+
+
+# ============================================================================
+# list_agents — no per-agent DB hydration (timeout fix)
+# ============================================================================
+
+class TestListAgentsNoHydration:
+    """The full list path must not hydrate a monitor per agent.
+
+    Hydrating every un-loaded monitor turned the include_metrics list into N
+    synchronous DB round-trips (anyio/asyncpg amplification), blowing the 15s
+    timeout on a large fleet — which froze the dashboard's cached health counts
+    (a phantom "N critical" with no live row). Non-resident agents must instead
+    use the health_status cached on agent_metadata.
+    """
+
+    @pytest.fixture
+    def mock_mcp_server(self):
+        return make_mock_server()
+
+    @pytest.mark.asyncio
+    async def test_uses_cached_health_without_loading_monitors(self, mock_mcp_server):
+        # An agent that is NOT resident (monitors is empty) but has cached health.
+        mock_mcp_server.monitors = {}
+        mock_mcp_server.agent_metadata = {
+            "crit-1": make_agent_meta(label="Critical1", total_updates=5, health_status="critical"),
+            "well-1": make_agent_meta(label="Healthy1", total_updates=5, health_status="healthy"),
+        }
+
+        with patch_lifecycle_server(mock_mcp_server):
+            from src.mcp_handlers.lifecycle.handlers import handle_list_agents
+            result = await handle_list_agents({
+                "include_metrics": True, "grouped": True, "status_filter": "all",
+            })
+
+            data = json.loads(result[0].text)
+            by_label = {
+                a["label"]: a
+                for bucket in data["agents"].values() for a in bucket
+            }
+            # Cached health is surfaced verbatim, metrics are None (not hydrated).
+            assert by_label["Critical1"]["health_status"] == "critical"
+            assert by_label["Critical1"]["metrics"] is None
+            assert by_label["Healthy1"]["health_status"] == "healthy"
+            # by_health rollup still reflects the cached criticals.
+            assert data["summary"]["by_health"]["critical"] == 1
+            # The hot path: NO monitor was created/hydrated for any agent.
+            mock_mcp_server.get_or_create_monitor.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_cached_health_falls_back_to_unknown(self, mock_mcp_server):
+        mock_mcp_server.monitors = {}
+        meta = make_agent_meta(label="NoHealth", total_updates=1)
+        meta.health_status = None  # nothing cached yet
+        mock_mcp_server.agent_metadata = {"a-1": meta}
+
+        with patch_lifecycle_server(mock_mcp_server):
+            from src.mcp_handlers.lifecycle.handlers import handle_list_agents
+            result = await handle_list_agents({
+                "include_metrics": True, "grouped": True, "status_filter": "all",
+            })
+            data = json.loads(result[0].text)
+            agent = [a for bucket in data["agents"].values() for a in bucket][0]
+            assert agent["health_status"] == "unknown"
+            mock_mcp_server.get_or_create_monitor.assert_not_called()


### PR DESCRIPTION
**Fix #2 of 3** for the phantom-critical-agent issue — the root cause.

## The bug
`handle_list_agents` advertises a "fast path" (load metrics only for resident monitors), but the `else`-branch for a **non-resident** monitor called `get_or_create_monitor()` + `await ensure_hydrated()` — a synchronous DB load — for **every un-loaded agent in the page**. Over the live fleet (**4,538 agents, ~700 active**) that's N DB round-trips under the anyio/asyncpg amplification (the "Substrate Tax" in CLAUDE.md), which blows the 15s tool budget.

I reproduced it against the live server: `agent(list, include_metrics=true, …)` times out at 15s every time; the lite (no-metrics) path returns instantly. When the dashboard's `include_metrics=true` sweep times out, `loadAgents` catches it and **keeps the stale `cachedAgents`** — which is exactly why you saw a **"1 critical" with no live, clickable row, absent from every other card**: a frozen count the list could never refresh.

## The fix
Non-resident agents now use the `health_status` that `process_agent_update` already persists on `agent_metadata` **on every check-in** (`phases.py:1559`), with `metrics=None` (the dashboard renders null metrics as "-"). Resident monitors keep their fast in-memory path. So:
- Health stays accurate for every agent that's actually checked in (residents + active sessions).
- Truly idle/never-seen agents read their last cached value or `"unknown"` instead of hanging the entire call.
- Removed the now-unused `ensure_hydrated` import (ruff dead-import gate).

## Tests
- New `TestListAgentsNoHydration`: the full `include_metrics` path surfaces cached health (incl. the `by_health` critical rollup) and **never calls `get_or_create_monitor`**; a missing cached value falls back to `"unknown"`.
- Full `test_handlers_lifecycle.py` (39) + allowlist + participation suites pass; ruff clean on the changed file.

## Follow-ups (the other two you asked for)
- **#1** — make the critical count honest & clickable (frontend), so a count can never again be a dead number.
- **#3** — reap the 968 ghosts / 1,907 test agents inflating every scan (will need a dry-run + your approval before anything destructive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015CWDAp4hoA7cBNEt6fjhG9)_