### PR TITLE
feat(dashboard): clickable Fleet Health critical count → filter Agents

### DIFF
--- a/dashboard/agents.js
+++ b/dashboard/agents.js
@@ -217,7 +217,14 @@
             info.textContent = 'No agents match filters (' + total + ' loaded)';
             return;
         }
-        // Info text is now driven by pagination footer, keep this minimal
+        // Surface an active health filter (set by clicking the Fleet Health count)
+        // so the user knows the list is scoped and how to clear it.
+        var healthFilter = state.get('agentHealthFilter');
+        if (healthFilter) {
+            info.textContent = 'Showing ' + healthFilter + ' agents only — click the count again or Reset to clear';
+            return;
+        }
+        // Info text is otherwise driven by pagination footer, keep this minimal
         info.textContent = '';
     }
 
@@ -564,6 +571,7 @@
 
         var cachedAgents = state.get('cachedAgents');
         var tierFilter = state.get('agentTierFilter');
+        var healthFilter = state.get('agentHealthFilter');
         var tierNameToNum = { unknown: 0, emerging: 1, established: 2, verified: 3 };
         var filteredAgents = cachedAgents.filter(function (agent) {
             // Production filter
@@ -579,6 +587,13 @@
                     ? (typeof raw === 'number' ? raw : (tierNameToNum[String(raw).toLowerCase()] || 0))
                     : 0;
                 if (tierNum !== tierFilter) return false;
+            }
+
+            // Health filter — set by clicking the Fleet Health "N critical" count
+            // so a critical agent is always reachable from its count (no more
+            // phantom number with no row).
+            if (healthFilter && (agent.health_status || 'unknown') !== healthFilter) {
+                return false;
             }
 
             if (searchTerm) {
@@ -630,7 +645,7 @@
         if (statusFilterInput) statusFilterInput.value = 'all';
         if (metricsOnlyInput) metricsOnlyInput.checked = false;
         if (sortInput) sortInput.value = 'recent';
-        state.set({ agentTierFilter: null });
+        state.set({ agentTierFilter: null, agentHealthFilter: null });
         applyAgentFilters();
     }
 

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -981,7 +981,12 @@ async function loadAgents() {
                     return rs !== undefined && rs !== null && Number(rs) > 0.6;
                 }).length;
                 const parts = [];
-                if (criticalCount > 0) parts.push(`${criticalCount} critical`);
+                // Make "N critical" a clickable filter so the agent(s) behind the
+                // count are always reachable — no more phantom number with no row.
+                if (criticalCount > 0) {
+                    const activeHealth = state.get('agentHealthFilter') === 'critical';
+                    parts.push(`<span class="fleet-critical-link${activeHealth ? ' active' : ''}" role="button" tabindex="0" data-health="critical" title="Show critical agents">${criticalCount} critical</span>`);
+                }
                 if (highRiskCount > 0) parts.push(`${highRiskCount} high-risk`);
                 // Fleet coherence change indicator
                 if (previousStats.fleetCoherence !== undefined && previousStats.fleetCoherence !== null) {
@@ -2591,6 +2596,33 @@ if (anomaliesCard) {
             if (isNaN(tierNum)) return;
             e.preventDefault();
             toggleTier(tierNum);
+        });
+    }
+
+    // Fleet Health card — click the "N critical" count to filter the Agents list
+    // to critical agents (so the count is never a dead, unclickable number).
+    // Click again (or Reset) to clear.
+    const fleetCard = document.getElementById('fleet-coherence-card');
+    if (fleetCard) {
+        const toggleHealth = (health) => {
+            const current = state.get('agentHealthFilter');
+            const next = current === health ? null : health;
+            state.set({ agentHealthFilter: next });
+            if (typeof applyAgentFilters === 'function') applyAgentFilters();
+            scrollToSection('agents-section');
+        };
+        fleetCard.addEventListener('click', (e) => {
+            const link = e.target.closest('.fleet-critical-link');
+            if (!link) return;
+            e.stopPropagation();
+            toggleHealth(link.dataset.health || 'critical');
+        });
+        fleetCard.addEventListener('keydown', (e) => {
+            if (e.key !== 'Enter' && e.key !== ' ') return;
+            const link = e.target.closest('.fleet-critical-link');
+            if (!link) return;
+            e.preventDefault();
+            toggleHealth(link.dataset.health || 'critical');
         });
     }
 })();

--- a/dashboard/state.js
+++ b/dashboard/state.js
@@ -75,7 +75,8 @@
         prodOnlyActive: typeof localStorage !== 'undefined' && localStorage.getItem('unitares_prod_only') === 'true',
         showODE: typeof localStorage !== 'undefined' && localStorage.getItem('unitares_show_ode') !== 'false',
         agentPageSize: 20,
-        agentTierFilter: null
+        agentTierFilter: null,
+        agentHealthFilter: null
     });
 
     // Restore pinned agent from localStorage

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -836,6 +836,26 @@ body::after {
     color: var(--text-secondary);
 }
 
+/* Clickable "N critical" in the Fleet Health card → filters the Agents list. */
+.fleet-critical-link {
+    color: var(--color-error, #ef4444);
+    cursor: pointer;
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
+}
+
+.fleet-critical-link:hover,
+.fleet-critical-link.active {
+    text-decoration-style: solid;
+    filter: brightness(1.1);
+}
+
+.fleet-critical-link:focus-visible {
+    outline: 2px solid var(--accent-cyan);
+    outline-offset: 2px;
+    border-radius: 3px;
+}
+
 .stat-card .stat-label {
     font-size: 0.65em;
     color: var(--text-muted);

--- a/dashboard/tests/agents.test.js
+++ b/dashboard/tests/agents.test.js
@@ -147,3 +147,36 @@ describe('agent cards are keyboard-operable (WCAG 2.1.1 / 4.1.2)', () => {
         expect(card.getAttribute('aria-label')).toContain('RealWorker');
     });
 });
+
+describe('health filter — clickable critical count (#fix-1)', () => {
+    function critAndWell() {
+        return [
+            agent({ label: 'CritAgent', total_updates: 5, health_status: 'critical' }),
+            agent({ label: 'WellAgent', total_updates: 5, health_status: 'healthy' }),
+        ];
+    }
+
+    it('applyAgentFilters shows only agents matching agentHealthFilter', () => {
+        const all = critAndWell();
+        window.state.set({ cachedAgents: all, agentHealthFilter: 'critical' });
+        Agents.applyAgentFilters();
+        const html = document.getElementById('agents-container').innerHTML;
+        expect(html).toContain('CritAgent');
+        expect(html).not.toContain('WellAgent');
+    });
+
+    it('shows all agents when no health filter is set', () => {
+        const all = critAndWell();
+        window.state.set({ cachedAgents: all, agentHealthFilter: null });
+        Agents.applyAgentFilters();
+        const html = document.getElementById('agents-container').innerHTML;
+        expect(html).toContain('CritAgent');
+        expect(html).toContain('WellAgent');
+    });
+
+    it('clearAgentFilters drops the health filter', () => {
+        window.state.set({ cachedAgents: critAndWell(), agentHealthFilter: 'critical' });
+        Agents.clearAgentFilters();
+        expect(window.state.get('agentHealthFilter')).toBeNull();
+    });
+});


### PR DESCRIPTION
**Fix #1 of 3** — make the critical count honest & clickable, so it can never again be a dead number.

## Change
The Fleet Health card's **"N critical"** is now a clickable control that **filters the Agents list to critical agents** and scrolls there — mirroring the existing clickable trust-tier bars. Click again (or Reset) to clear; the filter-info bar shows when the list is scoped.

- **state:** new `agentHealthFilter` (`null | health_status`).
- **agents.js:** `applyAgentFilters` honors it; `clearAgentFilters` resets it; `updateAgentFilterInfo` surfaces the active scope.
- **dashboard.js:** renders "N critical" as a focusable `role="button"`; a delegated click/keydown on the Fleet Health card toggles the filter.
- **styles:** clickable affordance + `:focus-visible`.

## Why it pairs with #885
#885 stops the agent-list call from timing out, so `cachedAgents` stays fresh and complete. With that, this count is accurate and clicking it always lands on a **live, actionable row** — closing out the "phantom critical" symptom from both ends (accurate data + a path to the agent).

## Tests
- 3 new frontend tests: the filter shows only matching agents, shows all when unset, and `clearAgentFilters` drops it. **48 frontend tests total.**
- `lint` ✓ · `format:check` ✓ · `test` ✓ · `build` ✓.
- Visual affordance (the dotted-underline link, focus ring) wants a quick in-browser glance before merge, but the filter logic is unit-tested.

## Remaining
**#3** — reap the 968 ghosts / 1,907 test agents inflating every scan. That one involves destructive DB writes, so I'll do a **dry-run reporter first and get your explicit approval** before anything is archived/deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015CWDAp4hoA7cBNEt6fjhG9)_