### PR TITLE
test(lifecycle): align list-agents tests with no-hydration behavior

### DIFF
--- a/tests/test_lifecycle_agents.py
+++ b/tests/test_lifecycle_agents.py
@@ -2022,8 +2022,8 @@ class TestListAgentsFullModeEdgeCases:
             assert agent["metrics"] is None
 
     @pytest.mark.asyncio
-    async def test_full_mode_metrics_from_not_in_memory_monitor(self, server):
-        """Lines 304-359: monitor not in memory - loads via get_or_create_monitor."""
+    async def test_full_mode_metrics_not_in_memory_uses_cached_health(self, server):
+        """Non-resident monitors are not hydrated from list_agents."""
         server.agent_metadata = {
             "agent-load": make_agent_meta(status="active", total_updates=5, notes="", health_status=None),
         }
@@ -2038,9 +2038,9 @@ class TestListAgentsFullModeEdgeCases:
             })
             data = _parse(result)
             agent = data["agents"][0]
-            assert agent["health_status"] == "healthy"
-            assert agent["metrics"] is not None
-            assert agent["metrics"]["E"] == 0.7
+            assert agent["health_status"] == "unknown"
+            assert agent["metrics"] is None
+            server.get_or_create_monitor.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_full_mode_cached_health_status_used(self, server):
@@ -2080,8 +2080,8 @@ class TestListAgentsFullModeEdgeCases:
             assert agent["metrics"] is None
 
     @pytest.mark.asyncio
-    async def test_full_mode_no_metrics_calculates_health(self, server):
-        """Lines 384-386: when no cached health, calculates from monitor."""
+    async def test_full_mode_no_metrics_without_cached_health_stays_unknown(self, server):
+        """No-metrics list_agents uses cached health only and never hydrates."""
         meta = make_agent_meta(status="active", total_updates=5, notes="", health_status=None)
         server.agent_metadata = {"agent-calc": meta}
         server.monitors = {}
@@ -2094,9 +2094,9 @@ class TestListAgentsFullModeEdgeCases:
             })
             data = _parse(result)
             agent = data["agents"][0]
-            assert agent["health_status"] == "healthy"
-            # Should have cached the health status
-            assert meta.health_status == "healthy"
+            assert agent["health_status"] == "unknown"
+            assert meta.health_status is None
+            server.get_or_create_monitor.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_full_mode_no_metrics_calculation_error(self, server):

--- a/tests/test_lifecycle_recovery.py
+++ b/tests/test_lifecycle_recovery.py
@@ -1233,9 +1233,8 @@ class TestListAgentsFullModeMonitorEdgeCases:
             assert agent["metrics"] is None
 
     @pytest.mark.asyncio
-    async def test_not_in_memory_safe_float_none_handling(self, server):
-        """Lines 334, 337-338: safe_float handles None and unconvertable values
-        when monitor is not in memory but gets loaded."""
+    async def test_not_in_memory_metrics_not_hydrated_for_safe_float_values(self, server):
+        """Non-resident monitors return null metrics instead of hydrating."""
         server.agent_metadata = {
             "agent-sf": make_agent_meta(status="active", total_updates=5, notes="", health_status=None),
         }
@@ -1257,13 +1256,13 @@ class TestListAgentsFullModeMonitorEdgeCases:
             })
             data = _parse(result)
             agent = data["agents"][0]
-            # safe_float(None) -> 0.0, safe_float("not-a-number") -> 0.0
-            assert agent["metrics"]["E"] == 0.0
-            assert agent["metrics"]["I"] == 0.0
+            assert agent["health_status"] == "unknown"
+            assert agent["metrics"] is None
+            server.get_or_create_monitor.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_not_in_memory_unknown_health_recalculated(self, server):
-        """Lines 313-327: health_status='unknown' triggers recalculation."""
+    async def test_not_in_memory_unknown_health_stays_unknown(self, server):
+        """Cached unknown health does not trigger monitor hydration."""
         server.agent_metadata = {
             "agent-unk": make_agent_meta(status="active", total_updates=5, notes="", health_status="unknown"),
         }
@@ -1285,7 +1284,9 @@ class TestListAgentsFullModeMonitorEdgeCases:
             })
             data = _parse(result)
             agent = data["agents"][0]
-            assert agent["health_status"] == "healthy"
+            assert agent["health_status"] == "unknown"
+            assert agent["metrics"] is None
+            server.get_or_create_monitor.assert_not_called()
 
 
 class TestGetAgentMetadataAdditional:


### PR DESCRIPTION
## Summary
- Update stale lifecycle/list-agents tests for the intended non-resident monitor behavior.
- Assert `list_agents` does **not** hydrate absent monitors, returns cached health when present, and returns `unknown`/`metrics: null` when not cached.
- This addresses the current master CI failure after the README/doc-health merges; implementation already follows the no-hydration path.

## Root cause
`src/mcp_handlers/lifecycle/query.py` intentionally stopped hydrating non-resident monitors in `list_agents` to avoid N synchronous DB round-trips and dashboard timeouts. Older tests in `tests/test_lifecycle_agents.py` and `tests/test_lifecycle_recovery.py` still expected monitor hydration/recalculated health.

## Verification
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 -m pytest tests/test_lifecycle_agents.py tests/test_lifecycle_recovery.py -q`
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 scripts/diagnostics/check_doc_health.py`
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 scripts/diagnostics/check_doc_drift.py`
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 ./scripts/dev/test-cache.sh` → `10485 passed, 21 skipped`
- Pre-push smoke + doc-health hook passed.
