### PR TITLE
fix(tests): de-flake 4 list_agents lifecycle tests asserting removed behavior

### DIFF
--- a/tests/test_lifecycle_agents.py
+++ b/tests/test_lifecycle_agents.py
@@ -2022,15 +2022,18 @@ class TestListAgentsFullModeEdgeCases:
             assert agent["metrics"] is None
 
     @pytest.mark.asyncio
-    async def test_full_mode_metrics_from_not_in_memory_monitor(self, server):
-        """Lines 304-359: monitor not in memory - loads via get_or_create_monitor."""
+    async def test_full_mode_metrics_from_resident_monitor(self, server):
+        """Resident monitor: recalculates health and populates metrics from state.
+
+        Non-resident agents are intentionally not hydrated in the list path (see
+        query.py's anti-DB-thrash else branch); the recalc + metrics path only
+        runs for monitors already in memory.
+        """
         server.agent_metadata = {
             "agent-load": make_agent_meta(status="active", total_updates=5, notes="", health_status=None),
         }
-        # No monitor in memory
-        server.monitors = {}
         mock_monitor = self._make_monitor()
-        server.get_or_create_monitor.return_value = mock_monitor
+        server.monitors = {"agent-load": mock_monitor}
         with patch_lifecycle_server(server):
             from src.mcp_handlers.lifecycle.handlers import handle_list_agents
             result = await handle_list_agents({
@@ -2080,13 +2083,16 @@ class TestListAgentsFullModeEdgeCases:
             assert agent["metrics"] is None
 
     @pytest.mark.asyncio
-    async def test_full_mode_no_metrics_calculates_health(self, server):
-        """Lines 384-386: when no cached health, calculates from monitor."""
+    async def test_full_mode_no_metrics_no_cached_health_is_unknown(self, server):
+        """include_metrics=False with no cached health: reports 'unknown'.
+
+        The list path never hydrates a monitor when metrics are not requested
+        (query.py), so with no persisted health_status it reports 'unknown'
+        rather than recalculating.
+        """
         meta = make_agent_meta(status="active", total_updates=5, notes="", health_status=None)
         server.agent_metadata = {"agent-calc": meta}
         server.monitors = {}
-        mock_monitor = self._make_monitor()
-        server.get_or_create_monitor.return_value = mock_monitor
         with patch_lifecycle_server(server):
             from src.mcp_handlers.lifecycle.handlers import handle_list_agents
             result = await handle_list_agents({
@@ -2094,9 +2100,8 @@ class TestListAgentsFullModeEdgeCases:
             })
             data = _parse(result)
             agent = data["agents"][0]
-            assert agent["health_status"] == "healthy"
-            # Should have cached the health status
-            assert meta.health_status == "healthy"
+            assert agent["health_status"] == "unknown"
+            assert agent["metrics"] is None
 
     @pytest.mark.asyncio
     async def test_full_mode_no_metrics_calculation_error(self, server):

--- a/tests/test_lifecycle_recovery.py
+++ b/tests/test_lifecycle_recovery.py
@@ -1233,13 +1233,11 @@ class TestListAgentsFullModeMonitorEdgeCases:
             assert agent["metrics"] is None
 
     @pytest.mark.asyncio
-    async def test_not_in_memory_safe_float_none_handling(self, server):
-        """Lines 334, 337-338: safe_float handles None and unconvertable values
-        when monitor is not in memory but gets loaded."""
+    async def test_resident_safe_float_none_handling(self, server):
+        """Resident monitor: safe_float coerces None / unconvertable state to 0.0."""
         server.agent_metadata = {
             "agent-sf": make_agent_meta(status="active", total_updates=5, notes="", health_status=None),
         }
-        server.monitors = {}
         mock_monitor = MagicMock()
         mock_monitor.state = SimpleNamespace(
             E=None, I="not-a-number", S=0.5, V=0.0, coherence=0.8,
@@ -1249,7 +1247,7 @@ class TestListAgentsFullModeMonitorEdgeCases:
             "risk_score": None, "current_risk": None,
             "phi": None, "verdict": None, "mean_risk": None,
         }
-        server.get_or_create_monitor.return_value = mock_monitor
+        server.monitors = {"agent-sf": mock_monitor}
         with patch_lifecycle_server(server):
             from src.mcp_handlers.lifecycle.handlers import handle_list_agents
             result = await handle_list_agents({
@@ -1262,12 +1260,12 @@ class TestListAgentsFullModeMonitorEdgeCases:
             assert agent["metrics"]["I"] == 0.0
 
     @pytest.mark.asyncio
-    async def test_not_in_memory_unknown_health_recalculated(self, server):
-        """Lines 313-327: health_status='unknown' triggers recalculation."""
+    async def test_resident_health_recalculated_over_persisted(self, server):
+        """Resident monitor: health is recalculated from the monitor, overriding a
+        stale persisted 'unknown'."""
         server.agent_metadata = {
             "agent-unk": make_agent_meta(status="active", total_updates=5, notes="", health_status="unknown"),
         }
-        server.monitors = {}
         mock_monitor = MagicMock()
         mock_monitor.state = SimpleNamespace(
             E=0.7, I=0.3, S=0.5, V=0.0, coherence=0.8,
@@ -1277,7 +1275,7 @@ class TestListAgentsFullModeMonitorEdgeCases:
             "risk_score": 0.3, "current_risk": 0.3,
             "phi": 0.5, "verdict": "safe", "mean_risk": 0.3,
         }
-        server.get_or_create_monitor.return_value = mock_monitor
+        server.monitors = {"agent-unk": mock_monitor}
         with patch_lifecycle_server(server):
             from src.mcp_handlers.lifecycle.handlers import handle_list_agents
             result = await handle_list_agents({


### PR DESCRIPTION
## What

Four tests in `test_lifecycle_agents.py` / `test_lifecycle_recovery.py` were latent flakes that any PR shifting test distribution could trip — and #890 (the worktree reaper) tripped them by adding a test file, which reshuffled the xdist worker buckets.

## Root cause (traced to the line)

`query.py:688` only recalculates an agent's health/metrics for **resident** monitors (`if agent_id in mcp_server.monitors`). The non-resident `else` deliberately uses *persisted* health + `None` metrics — the anti-DB-thrash fix from the #888 'phantom N critical' work.

These 4 tests set `monitors = {}` (non-resident) but asserted the **recalc** results (`health == 'healthy'`, `metrics['E'] == 0.7`, `safe_float` coercion). On current code that's deterministically wrong — they only ever passed when a prior test in the same xdist worker **leaked a populated `mcp_server.monitors`**, making the agent look resident. #888/#887/#889 happened to get a worker layout that satisfied that; a distribution shift unmasks them.

Verified: the 4 fail in isolation on unmodified master code; #888 is green on the identical code; the only newer master commits are docs.

## Fix

Point each test at the **resident** path its assertions actually target (`monitors = {agent_id: mock_monitor}`) so it deterministically exercises the recalc + `safe_float` + metrics logic, and rename to match. The one `include_metrics=False` case can't recalc by design, so it now asserts the real contract (no cached health → `'unknown'`, `None` metrics).

## Verification

- All 4 pass **in isolation** (previously failed in isolation — the de-flake proof).
- Full lifecycle files: **197 passed** (was 193 passed + 4 failed).
- Sibling non-resident tests (`cached_health_status_used`, `no_metrics_uses_cached_health`, `monitor_load_exception`) untouched and green — the non-resident contract stays covered.
- ruff clean.

Unblocks the `test (3.12)` job for #890 and any future PR that shifts test distribution.

Draft — operator merge gate.

https://claude.ai/code/session_01HES9ERjdTrV2rhLwvejve1