### PR TITLE
fix(locking): self-heal the lock dir on acquire, not just at init

### DIFF
--- a/src/cache/distributed_lock.py
+++ b/src/cache/distributed_lock.py
@@ -58,11 +58,24 @@ class DistributedLock:
             project_root = Path(__file__).parent.parent.parent
             lock_dir = project_root / "data" / "locks"
         self.lock_dir = lock_dir
-        self.lock_dir.mkdir(parents=True, exist_ok=True)
+        self._ensure_lock_dir()
         self.lock_timeout = lock_timeout
 
         # Track active file locks (for fallback cleanup)
         self._file_locks: Dict[str, int] = {}  # resource_id -> fd
+
+    def _ensure_lock_dir(self) -> None:
+        """Ensure the file-fallback lock directory exists.
+
+        Called at construction AND before each file-fallback acquisition. The
+        lock directory is gitignored and can be removed out from under a
+        long-running process (e.g. a ``git worktree remove``/``add`` rebuild of
+        a deploy worktree, ``git clean -fdx``, or a manual ``rm``), after which
+        ``os.open(lock_file, O_CREAT)`` would raise ENOENT forever. Re-creating
+        here makes the fallback self-healing; ``exist_ok=True`` is a cheap stat
+        when the directory is already present.
+        """
+        self.lock_dir.mkdir(parents=True, exist_ok=True)
 
     @asynccontextmanager
     async def acquire(
@@ -178,6 +191,8 @@ class DistributedLock:
         """Fallback to file-based locking (fcntl)."""
         import fcntl
 
+        # Re-create the lock dir if it was removed since construction.
+        self._ensure_lock_dir()
         lock_file = self.lock_dir / f"{resource_id}.lock"
         fd = None
         start_time = time.monotonic()

--- a/src/state_locking.py
+++ b/src/state_locking.py
@@ -43,10 +43,24 @@ class StateLockManager:
             project_root = Path(__file__).parent.parent
             lock_dir = project_root / "data" / "locks"
         self.lock_dir = lock_dir
-        self.lock_dir.mkdir(parents=True, exist_ok=True)
+        self._ensure_lock_dir()
         self.auto_cleanup_stale = auto_cleanup_stale
         self.stale_threshold = stale_threshold  # Seconds before considering lock stale
-        
+
+    def _ensure_lock_dir(self) -> None:
+        """Ensure the lock directory exists.
+
+        Called at construction AND at the start of every acquisition. The lock
+        directory is gitignored and can be removed out from under a long-running
+        process (deploy cleanup, ``git clean -fdx``, manual ``rm``). When that
+        happens, a manager that only created the directory in ``__init__`` keeps
+        a stale path and every subsequent ``os.open(lock_file, O_CREAT)`` raises
+        ENOENT — which surfaced as fleet-wide check-in failures until the server
+        was restarted. Re-creating here makes acquisition self-healing without a
+        restart; ``exist_ok=True`` keeps it a cheap stat in the common case.
+        """
+        self.lock_dir.mkdir(parents=True, exist_ok=True)
+
     def _check_and_clean_stale_lock(self, lock_file: Path) -> bool:
         """
         Check if lock file is stale and clean it if so.
@@ -160,9 +174,11 @@ class StateLockManager:
             timeout: Timeout per retry attempt in seconds
             max_retries: Maximum number of retry attempts with cleanup
         """
+        # Re-create the lock dir if it was removed since construction.
+        self._ensure_lock_dir()
         lock_file = self.lock_dir / f"{agent_id}.lock"
         lock_fd = None
-        
+
         # Automatic stale lock cleanup before attempting acquisition
         if self.auto_cleanup_stale:
             try:
@@ -294,9 +310,11 @@ class StateLockManager:
             timeout: Timeout per retry attempt in seconds
             max_retries: Maximum number of retry attempts with cleanup
         """
+        # Re-create the lock dir if it was removed since construction.
+        self._ensure_lock_dir()
         lock_file = self.lock_dir / f"{agent_id}.lock"
         lock_fd = None
-        
+
         # Automatic stale lock cleanup before attempting acquisition
         # Run in executor to avoid blocking event loop (file I/O operations)
         if self.auto_cleanup_stale:

--- a/tests/test_state_locking.py
+++ b/tests/test_state_locking.py
@@ -105,6 +105,55 @@ class TestStateLockManagerInit:
 
 
 # ============================================================================
+# Lock-dir self-heal (regression for the 2026-06-19 fleet-wide check-in outage)
+#
+# The lock dir is gitignored and was physically removed out from under the
+# long-running server (a `git worktree remove`/`add` rebuild of the deploy
+# worktree). Because StateLockManager only mkdir'd the dir in __init__, every
+# subsequent acquire raised ENOENT on os.open until the server restarted.
+# Acquisition must now re-create the dir on demand.
+# ============================================================================
+
+class TestLockDirSelfHeal:
+
+    def test_acquire_recreates_removed_lock_dir(self, tmp_path):
+        """Sync acquire must succeed even if the lock dir was deleted post-init."""
+        lock_dir = tmp_path / "locks"
+        mgr = StateLockManager(lock_dir=lock_dir)
+        assert lock_dir.exists()
+
+        # Simulate the worktree-rebuild / git-clean / rm that removed the dir.
+        import shutil
+        shutil.rmtree(lock_dir)
+        assert not lock_dir.exists()
+
+        # Acquisition should re-create the dir instead of raising ENOENT.
+        with mgr.acquire_agent_lock("healed_agent", timeout=2.0, max_retries=1):
+            assert lock_dir.exists()
+            assert (lock_dir / "healed_agent.lock").exists()
+
+    @pytest.mark.asyncio
+    async def test_async_acquire_recreates_removed_lock_dir(self, tmp_path):
+        """Async acquire must also self-heal a removed lock dir."""
+        import shutil
+        lock_dir = tmp_path / "locks"
+        mgr = StateLockManager(lock_dir=lock_dir)
+        shutil.rmtree(lock_dir)
+        assert not lock_dir.exists()
+
+        async with mgr.acquire_agent_lock_async("healed_async", timeout=2.0, max_retries=1):
+            assert lock_dir.exists()
+            assert (lock_dir / "healed_async.lock").exists()
+
+    def test_ensure_lock_dir_idempotent(self, tmp_path):
+        """_ensure_lock_dir is safe to call repeatedly (exist_ok)."""
+        mgr = StateLockManager(lock_dir=tmp_path / "locks")
+        mgr._ensure_lock_dir()
+        mgr._ensure_lock_dir()
+        assert mgr.lock_dir.exists()
+
+
+# ============================================================================
 # _check_and_clean_stale_lock
 # ============================================================================
 


### PR DESCRIPTION
## What

Make file-lock acquisition **self-heal** a missing lock directory instead of failing forever. `_ensure_lock_dir()` (mkdir `parents/exist_ok`) now runs at the top of every acquisition path — sync + async `StateLockManager`, and `DistributedLock`'s file fallback — not only in `__init__`.

## Why (incident, 2026-06-19)

The gitignored `data/locks/` dir was physically removed out from under the running governance-MCP process when the **deploy worktree was rebuilt** (`git worktree remove` + re-add ~04:38–04:58Z; the re-add restores only tracked files, never the empty gitignored dir). Because `StateLockManager` only `mkdir`'d the dir in `__init__` and the server (PID 23960, up since Jun 18 16:12) was never restarted, every `process_agent_update` after that threw:

```
[Errno 2] No such file or directory: .../data/locks/<uuid>.lock
```

This was **fleet-wide** (reproduced with a fresh session's own check-in), not agent-specific. **Lumen, Vigil, and Sentinel** all went silent ~04:40Z and were escalated to `lifecycle_silent_critical`. Recreating the dir (`mkdir -p`) restored check-ins immediately and all three reconnected — but the server-restart-or-manual-mkdir requirement is the real defect. This PR closes the class regardless of what removes the dir.

## Change

- `src/state_locking.py` — extract `_ensure_lock_dir()`; call it in both `acquire_agent_lock` and `acquire_agent_lock_async`.
- `src/cache/distributed_lock.py` — same helper; call it in `_acquire_file`.
- `tests/test_state_locking.py` — `TestLockDirSelfHeal`: `rmtree` the dir after construction, assert sync + async acquire re-create it and succeed. (The async case caught a real miss during development — the first pass only patched the sync path.)

## Risk

Low. `exist_ok=True` makes the added call a cheap stat in the steady state; no behavior change when the dir exists. Touches the live check-in path, so flagged for operator merge rather than auto-merge.

Focused tests: `64 passed` (`tests/test_state_locking.py tests/test_distributed_lock.py`).
