### PR TITLE
ci: alias-aware validate_tool_modes wired into smoke gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,6 +46,13 @@ jobs:
       run: |
         python scripts/diagnostics/check_doc_drift.py
 
+    - name: Validate tool-mode / schema config
+      # DB-free: confirms TOOL_CATEGORIES matches the tool schema (alias-aware)
+      # and minimal/lite keep their discovery tools, so TOOL_MODE filtering stays
+      # consistent with the served surface.
+      run: |
+        python scripts/diagnostics/validate_tool_modes.py
+
     - name: Dead-code gate (unused imports)
       run: |
         pip install "ruff>=0.15"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -132,6 +132,7 @@ checks:
 | Script | Description |
 |--------|-------------|
 | `agent_fragmentation.py` | Read-only report for identities with zero or sparse real check-ins, grouped by model/session/thread so fresh-UUID fragmentation is visible. |
+| `validate_tool_modes.py` | Asserts `TOOL_CATEGORIES` matches the tool schema (alias-aware) and that minimal/lite keep their discovery tools. DB-free; wired into the CI `smoke` gate. |
 
 ### `migration/`
 Database maintenance scripts (corpus re-embedding, ghost agent cleanup, knowledge graph maintenance).

--- a/scripts/diagnostics/validate_tool_modes.py
+++ b/scripts/diagnostics/validate_tool_modes.py
@@ -24,16 +24,30 @@ def main() -> int:
 
     from src.tool_schemas import get_tool_definitions
     from src import tool_modes
+    from src.mcp_handlers.tool_stability import (
+        AGENT_WORKFLOW_ALIASES,
+        resolve_tool_alias,
+    )
 
     schema_tools = sorted({t.name for t in get_tool_definitions()})
     schema_set = set(schema_tools)
+
+    # Friendly workflow aliases (start_session, sync_state, ...) are registered as
+    # live tool names by mcp_server._register_common_aliases and so legitimately
+    # appear in TOOL_CATEGORIES, but get_tool_definitions() only returns the
+    # canonical targets they resolve to. Treat an alias as valid iff it resolves
+    # to a real schema tool; an alias pointing at nothing IS real drift.
+    alias_names = set(AGENT_WORKFLOW_ALIASES)
+    valid_aliases = {a for a in alias_names if resolve_tool_alias(a)[0] in schema_set}
+    dangling_aliases = sorted(alias_names - valid_aliases)
 
     categories_union = set()
     for _, tools in tool_modes.TOOL_CATEGORIES.items():
         categories_union |= set(tools)
 
-    # Category drift: names in categories but not in schema
-    extra_in_categories = sorted(categories_union - schema_set)
+    # Category drift: names in categories that are neither a schema tool nor a
+    # valid alias of one.
+    extra_in_categories = sorted(categories_union - schema_set - valid_aliases)
 
     # Uncategorized tools (should be 0 for ergonomics, but correctness is via full mode)
     uncategorized = sorted(schema_set - categories_union)
@@ -54,15 +68,23 @@ def main() -> int:
 
     if extra_in_categories:
         ok = False
-        print("FAIL: TOOL_CATEGORIES contains tools not present in schema:")
+        print("FAIL: TOOL_CATEGORIES contains tools that are neither a schema tool nor a valid alias:")
         for n in extra_in_categories:
             print(f"  - {n}")
 
-    if uncategorized:
-        # Not fatal for correctness, but a UX problem.
-        print("WARN: schema tools not present in any TOOL_CATEGORIES (categorization gap):")
-        for n in uncategorized:
+    if dangling_aliases:
+        ok = False
+        print("FAIL: AGENT_WORKFLOW_ALIASES entries that do not resolve to a schema tool:")
+        for n in dangling_aliases:
             print(f"  - {n}")
+
+    if uncategorized:
+        # Not fatal: uncategorized tools are still reachable via full mode (the
+        # default); they only fall out of minimal/lite, which is often deliberate.
+        print(
+            f"WARN: {len(uncategorized)} schema tool(s) not in any TOOL_CATEGORIES "
+            f"(absent from minimal/lite only): {', '.join(uncategorized)}"
+        )
 
     if full_missing or full_extra:
         ok = False


### PR DESCRIPTION
Follow-up to #897 (merged). That PR revived `validate_tool_modes.py` (fixed the stale path so it runs again). You asked to wire it into CI — doing that surfaced that its **core invariant was also stale**, not just the path, so this PR fixes the logic and then wires it.

## What was wrong
Run green-to-be, it FAILed: it flagged six tools in `TOOL_CATEGORIES` as "not in schema" — `start_session`, `sync_state`, `check_working_state`, `record_result`, `request_review`, `search_shared_memory`. Those are exactly the **friendly workflow aliases** (`AGENT_WORKFLOW_ALIASES`) that `mcp_server._register_common_aliases` registers as live tool names. They legitimately live in `TOOL_CATEGORIES` (so `TOOL_MODE` filtering includes them), but `get_tool_definitions()` only returns their canonical targets (`onboard`, `process_agent_update`, …). The validator predated the alias layer.

`tool_modes` is live — `get_tools_for_mode(TOOL_MODE)` gates the served surface in `mcp_server.py`, `http_api.py`, `mcp_server_std.py`, and `identity/handlers.py` — so this is a real invariant worth a gate.

## Changes
- **Alias-aware:** a name in `TOOL_CATEGORIES` is valid if it's a schema tool **or** an `AGENT_WORKFLOW_ALIASES` entry that resolves to one. A *dangling* alias (resolves to nothing) becomes its own FAIL, so genuine drift still trips it.
- **Condensed** the uncategorized-tools WARN to one line (non-fatal: those tools stay reachable via full mode — the default — and only drop out of minimal/lite, which is often deliberate).
- **Wired** into the `tests.yml` `smoke` job as a DB-free config-integrity gate, beside `check_doc_drift` and the dead-code gate.
- README: listed under diagnostics as a CI-wired check.

Now exits 0 (`OK: schema_tools=74, categorized=47`); ruff clean; YAML valid. Draft per convention.

https://claude.ai/code/session_015j272g7czLEj3oFzzZTiTq