### PR TITLE
docs(connectors): document remote MCP connector setup (Host allowlist + API key)

### DIFF
--- a/docs/integration/MCP_CLIENTS.md
+++ b/docs/integration/MCP_CLIENTS.md
@@ -63,6 +63,60 @@ The server binds to `127.0.0.1` by default. For LAN or remote access:
 
 See [`scripts/ops/`](../../scripts/ops/) for an example LaunchAgent plist with bind-all plus allowlists.
 
+## Remote connectors (Claude.ai, Perplexity, etc.)
+
+A hosted MCP connector reaches the server over the public internet, usually via
+a reverse proxy or Cloudflare tunnel (e.g. `https://gov.example.org/mcp/`).
+Two server-side gates must be configured or the connection fails before any
+tool runs:
+
+1. **Host/Origin allowlist (DNS-rebinding protection, on by default).** The
+   request arrives with `Host: gov.example.org`, which is rejected with
+   **HTTP 403** unless allowlisted. A 403 here surfaces in the client as a
+   generic auth/"API key" error even though the cause is the Host gate — it
+   runs *before* auth. Fix:
+
+   ```bash
+   export UNITARES_BIND_ALL_INTERFACES=1
+   export UNITARES_MCP_ALLOWED_HOSTS="gov.example.org,gov.example.org:*"
+   export UNITARES_MCP_ALLOWED_ORIGINS="https://gov.example.org"
+   ```
+
+   List both the bare host and the `:*` form: over HTTPS the `Host` header is
+   usually bare (`gov.example.org`), but a proxy may forward a port.
+
+2. **Authentication.** A public endpoint must not run on the connector's
+   "none" option. Two choices:
+
+   - **API key (simplest).** Mint a secret yourself — it is not retrieved from
+     anywhere — and set it on the server, then paste the identical string into
+     the client's "API key" field:
+
+     ```bash
+     export UNITARES_MCP_BEARER_TOKENS="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+     ```
+
+     The client sends it as `Authorization: Bearer <token>`. Comma-separated
+     values allow rotation without a restart.
+
+   - **OAuth 2.1.** Set `UNITARES_OAUTH_ISSUER_URL` to the public base URL. The
+     server then advertises Dynamic Client Registration, so a DCR-capable
+     client (e.g. Claude.ai custom connector) leaves client_id/client_secret
+     blank and self-registers. Note: client registrations are in-memory and
+     reset on restart. See `src/oauth_provider.py`.
+
+The Host allowlist applies regardless of the auth choice — set it even when
+using "none" locally is fine, but for a public host you need both the
+allowlist entry *and* an auth gate.
+
+After changing any of these, restart the server, then sanity-check from
+outside:
+
+```bash
+curl -i https://gov.example.org/mcp/ -H 'Accept: text/event-stream'
+# 403 gone -> Host gate open. 401 -> bearer gate is on (expected once a key is set).
+```
+
 ## Agent Identity
 
 For a fresh process, call `start_session(force_new=true)`. If the process is continuing prior work, call `start_session(force_new=true, parent_agent_id=<prior uuid>, spawn_reason="new_session")`.

--- a/scripts/ops/com.unitares.governance-mcp.plist
+++ b/scripts/ops/com.unitares.governance-mcp.plist
@@ -62,10 +62,27 @@
         <string>/PATH/TO/UNITARES/config/resident_progress.example.json</string>
         <key>UNITARES_BIND_ALL_INTERFACES</key>
         <string>1</string>
+        <!-- Host/Origin allowlist (DNS-rebinding protection, on by default).
+             A request whose Host header is not listed here is rejected with
+             HTTP 403 BEFORE any auth runs. localhost-only is correct for a
+             purely local install. To reach the server from a remote MCP
+             connector (Claude.ai, Perplexity, etc.) through a reverse proxy
+             or Cloudflare tunnel, add the PUBLIC hostname the client connects
+             to — e.g. for https://your-tunnel-host.example.org/mcp/ add both
+             the bare host and the :* form:
+               your-tunnel-host.example.org,your-tunnel-host.example.org:*
+             and the matching https origin below. -->
         <key>UNITARES_MCP_ALLOWED_HOSTS</key>
         <string>localhost:*</string>
         <key>UNITARES_MCP_ALLOWED_ORIGINS</key>
         <string>http://localhost:*</string>
+        <!-- Static bearer-token gate for /mcp (API-key auth). Empty/unset =
+             gate OFF (localhost dev). For a publicly reachable connector set
+             this to a long random secret (python3 -c "import secrets;
+             print(secrets.token_hex(32))") and paste the SAME value into the
+             client's "API key" field. Comma-separated allows rotation. -->
+        <key>UNITARES_MCP_BEARER_TOKENS</key>
+        <string></string>
         <key>PYTHONPATH</key>
         <string>/PATH/TO/UNITARES</string>
         <key>DB_BACKEND</key>


### PR DESCRIPTION
## Why

A remote MCP connector (Perplexity, Claude.ai) pointed at a public host/tunnel (e.g. `gov.cirwel.org/mcp/`) is rejected with **HTTP 403** by the default localhost-only Host/Origin allowlist (`enable_dns_rebinding_protection=True`, allowlist = localhost only). The 403 fires *before* any auth runs, so the client surfaces it as a generic auth / "API key" error — which is misleading, because the cause is the Host gate, not the credential.

This came out of a live debugging session: connecting Perplexity to the server with auth "none" returned `[API_CLIENTS_ERROR] MCP server returned HTTP 403`. Root cause was the Host header (`gov.cirwel.org`) not being in `UNITARES_MCP_ALLOWED_HOSTS`.

## What

- **`docs/integration/MCP_CLIENTS.md`** — new "Remote connectors" section documenting the two server-side gates that must be configured for a hosted connector:
  1. Host/Origin allowlist (the 403 source), with the bare-host + `:*` guidance.
  2. Authentication — API key (`UNITARES_MCP_BEARER_TOKENS`, self-minted) or OAuth 2.1 (DCR). Clarifies that the API key is minted by the operator, not retrieved.
  Plus a `curl` sanity-check to confirm the Host gate is open.
- **`scripts/ops/com.unitares.governance-mcp.plist`** — commented the `UNITARES_MCP_ALLOWED_HOSTS` block explaining the 403-before-auth behavior and how to add a tunnel host, and added a commented `UNITARES_MCP_BEARER_TOKENS` key for the API-key gate.

Docs/template only — no runtime code change. The live fix for an affected deployment is operator-side env config (allowlist the public host + set a bearer token) and a restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzyKSBUbcvoNo5JcuahKSv)_