### PR TITLE
feat(eisv): flip behavioral V to single-EMA (v2) + migration reseed — real-trace validated

### DIFF
--- a/scripts/dev/export_valence_traces.py
+++ b/scripts/dev/export_valence_traces.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Export real per-agent behavioral observation traces for the Valence gate.
+
+Companion to ``validate_valence_formula.py``. The raw pre-EMA behavioral
+observations the gate replays (``[E_obs, I_obs, S_obs]``) are persisted ONLY in
+the per-agent JSON snapshots' ``behavioral_eisv.obs_history`` (the trimmed DB
+row drops history). This dumps them to the JSONL trace format the gate reads.
+
+Honest labeling (the gate gates the false-pause check on ``healthy``/``sentinel``):
+  * ``sentinel`` — known long-running autonomous residents (by DB label).
+  * ``healthy``  — >=30 obs AND the agent's REAL recorded ``verdict_history``
+                   is >=95% "safe" with zero "high-risk". This is production's
+                   own ground-truth that the trajectory was healthy, so a
+                   candidate-induced flip toward risk on it is the regression
+                   we care about — not a label we synthesised.
+  * ``unknown``  — everything else (flips still counted/reported, not gated).
+
+USAGE
+    python3 scripts/dev/export_valence_traces.py \
+        --data-dir ~/projects/unitares-deploy/data/agents \
+        --data-dir ~/projects/unitares/data/agents \
+        --labels /tmp/agent_labels.tsv \
+        --min-obs 10 --out /tmp/real_valence_traces.jsonl
+Stdlib only.
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import sys
+from pathlib import Path
+
+# Known autonomous residents — the tight-baseline shapes the council flagged.
+_RESIDENT_LABELS = {"sentinel", "vigil", "watcher", "steward", "lumen"}
+
+
+def _load_label_map(path: str | None) -> dict:
+    out: dict = {}
+    if not path or not os.path.exists(path):
+        return out
+    for line in Path(path).read_text().splitlines():
+        parts = line.split("\t")
+        if not parts or not parts[0]:
+            continue
+        aid = parts[0]
+        out[aid] = {
+            "label": parts[1] if len(parts) > 1 else "",
+            "status": parts[2] if len(parts) > 2 else "",
+            "tags": parts[3] if len(parts) > 3 else "",
+        }
+    return out
+
+
+def _health_label(obs_len: int, verdict_history: list, db_label: str) -> str:
+    name = (db_label or "").strip().lower()
+    if any(r in name for r in _RESIDENT_LABELS):
+        return "sentinel"
+    if obs_len >= 30 and verdict_history:
+        vh = [str(v).lower() for v in verdict_history]
+        safe = sum(1 for v in vh if v == "safe")
+        high = sum(1 for v in vh if v in ("high-risk", "high_risk"))
+        if high == 0 and safe / len(vh) >= 0.95:
+            return "healthy"
+    return "unknown"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--data-dir", action="append", required=True,
+                    help="data/agents dir (repeatable; earlier = higher priority on tie)")
+    ap.add_argument("--labels", help="TSV: agent_id<TAB>label<TAB>status<TAB>tags")
+    ap.add_argument("--min-obs", type=int, default=10)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    label_map = _load_label_map(args.labels)
+
+    # Dedup by agent_id, preferring the snapshot with the longest obs_history.
+    best: dict = {}
+    for d in args.data_dir:
+        d = os.path.expanduser(d)
+        for f in glob.glob(os.path.join(d, "*_state.json")):
+            try:
+                data = json.load(open(f))
+            except Exception:
+                continue
+            beh = data.get("behavioral_eisv") or {}
+            oh = beh.get("obs_history") or []
+            if not oh:
+                continue
+            aid = os.path.basename(f).replace("_state.json", "")
+            prev = best.get(aid)
+            if prev is None or len(oh) > len(prev["oh"]):
+                best[aid] = {"oh": oh, "vh": data.get("verdict_history") or []}
+
+    rows = []
+    for aid, blob in best.items():
+        oh = blob["oh"]
+        if len(oh) < args.min_obs:
+            continue
+        db_label = (label_map.get(aid) or {}).get("label", "")
+        label = _health_label(len(oh), blob["vh"], db_label)
+        rows.append({
+            "agent_id": aid,
+            "label": label,
+            "db_label": db_label,
+            "observations": [[float(x) for x in row[:3]] for row in oh],
+        })
+
+    rows.sort(key=lambda r: len(r["observations"]), reverse=True)
+    with open(os.path.expanduser(args.out), "w") as fh:
+        for r in rows:
+            fh.write(json.dumps(r) + "\n")
+
+    from collections import Counter
+    by_label = Counter(r["label"] for r in rows)
+    print(f"wrote {len(rows)} traces -> {args.out}", file=sys.stderr)
+    print(f"  by label: {dict(by_label)}", file=sys.stderr)
+    print(f"  obs lengths: {[len(r['observations']) for r in rows]}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/validate_valence_formula.py
+++ b/scripts/dev/validate_valence_formula.py
@@ -57,17 +57,27 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from src.behavioral_state import BehavioralEISV, BASELINE_WARMUP_UPDATES  # noqa: E402
+from src.behavioral_state import (  # noqa: E402
+    BehavioralEISV,
+    BASELINE_WARMUP_UPDATES,
+    MIN_MEANINGFUL_EISV_STD,
+)
 from src.behavioral_assessment import assess_behavioral_state  # noqa: E402
 
 _VERDICT_RANK = {"safe": 0, "caution": 1, "high-risk": 2}
+_MIN_STD_FLOOR = MIN_MEANINGFUL_EISV_STD
 
 
-class CandidateV(BehavioralEISV):
-    """Single-EMA-of-raw-imbalance candidate: gap of the RAW observations."""
+class LegacyV(BehavioralEISV):
+    """v1 deployed formula: gap of the already-EMA'd E,I (double-smoothing).
+
+    As of V_FORMULA_VERSION 2 the base class default IS the candidate
+    (single-EMA of raw imbalance, ``E_obs - I_obs``). This subclass restores the
+    v1 behavior so the gate remains a live A/B: ``LegacyV`` = old, base = new.
+    """
 
     def _raw_valence(self, E_obs: float, I_obs: float) -> float:
-        return E_obs - I_obs
+        return self.E - self.I
 
 
 # --------------------------------------------------------------------------- #
@@ -89,7 +99,8 @@ def _step_record(state: BehavioralEISV, idx: int) -> Dict:
 
 
 def replay(observations: List[List[float]], candidate: bool) -> List[Dict]:
-    state: BehavioralEISV = CandidateV() if candidate else BehavioralEISV()
+    # new (v2) = base default; old (v1) = LegacyV override.
+    state: BehavioralEISV = BehavioralEISV() if candidate else LegacyV()
     out: List[Dict] = []
     for idx, obs in enumerate(observations):
         e, i, s = (float(obs[0]), float(obs[1]), float(obs[2]))
@@ -147,35 +158,54 @@ def compare_trace(trace: Dict) -> Dict:
 def migration_probe(observations: List[List[float]], sigma_budget: float) -> Dict:
     """Quantify Seat 3 RISK 2: new-formula V judged against the OLD baseline.
 
-    Converge an agent under the deployed formula, snapshot its V baseline, then
-    take one more step computing V the NEW way. Without a reset the new value is
-    z-scored against the stale (old-formula, tighter-σ) baseline; with a reset
-    the baseline is re-seeded from the candidate trajectory.
+    Converge an agent under the v1 (deployed) formula, snapshot its V baseline,
+    then take one more step computing V the v2 (new) way. Without a reset the new
+    value is z-scored against the stale (v1, tighter-σ) baseline; with the reset
+    the baseline is re-seeded from the v2 trajectory.
+
+    ``z_spike_with_reset`` is no longer assumed — it exercises the REAL
+    ``BehavioralEISV._reseed_v_baseline`` so this gate proves the shipped reset
+    actually absorbs the spike, not just that one is planned.
     """
-    # Converge under the deployed (old) formula.
-    old = BehavioralEISV()
+    # Converge under the v1 (deployed) formula.
+    old = LegacyV()
     for obs in observations:
         old.update(float(obs[0]), float(obs[1]), float(obs[2]))
     base_mean, base_std = old._baseline_V.mean, old._baseline_V.std
 
-    # One more observation, V computed the candidate way.
+    # One more observation, V computed the v2 way (from the v1-converged V).
     nxt = observations[-1]
     e, i = float(nxt[0]), float(nxt[1])
     alpha_v = old.alphas["V"]
-    raw_v_new = e - i                       # candidate: raw imbalance
+    raw_v_new = e - i                       # v2: raw imbalance
     v_new = (1.0 - alpha_v) * old.V + alpha_v * raw_v_new
 
     denom = base_std if base_std > 1e-9 else 1e-9
     z_no_reset = abs(v_new - base_mean) / denom
-    z_with_reset = 0.0  # reset re-seeds baseline from candidate => first z ~ 0
+
+    # WITH reset: re-seed _baseline_V from the v2 trajectory exactly as the live
+    # migration does, then z-score the same v2 step against the re-seeded stats.
+    reseeded = BehavioralEISV()
+    reseeded.alphas = dict(old.alphas)
+    reseeded.obs_history = [[float(o[0]), float(o[1]), float(o[2])] for o in observations]
+    reseeded._reseed_v_baseline()
+    rs_mean, rs_std = reseeded._baseline_V.mean, reseeded._baseline_V.std
+    rs_denom = rs_std if rs_std > 1e-9 else _MIN_STD_FLOOR
+    z_with_reset = abs(v_new - rs_mean) / rs_denom
+
     return {
         "old_baseline_V_mean": round(base_mean, 5),
         "old_baseline_V_std": round(base_std, 6),
         "candidate_V_first_step": round(v_new, 5),
+        "reseeded_baseline_V_mean": round(rs_mean, 5),
+        "reseeded_baseline_V_std": round(rs_std, 6),
         "z_spike_no_reset": round(z_no_reset, 3),
         "z_spike_with_reset": round(z_with_reset, 3),
         "sigma_budget": sigma_budget,
         "exceeds_budget_without_reset": z_no_reset > sigma_budget,
+        "reset_clears_spike": z_with_reset <= sigma_budget,
+        # The reset is the mitigation; the residual "required" flag now means
+        # "would exceed budget if the reset were NOT applied".
         "reset_required": z_no_reset > sigma_budget,
     }
 
@@ -239,13 +269,19 @@ def build_report(traces: List[Dict], sigma_budget: float) -> Dict:
     ]
     total_healthy_regressions = sum(t["n_healthy_regressions"] for t in per_trace)
     migration_needs_reset = any(m["reset_required"] for m in migrations)
-    gate_pass = total_healthy_regressions == 0 and not migration_needs_reset
+    # As of V_FORMULA_VERSION 2 the reset ships WITH the flip, so the gate no
+    # longer fails merely because a stale-baseline spike WOULD occur without it;
+    # it fails only if a healthy verdict regresses, or the shipped reset fails
+    # to bring every flagged spike back inside the sigma budget.
+    reset_clears_all = all(m.get("reset_clears_spike", False) for m in migrations)
+    gate_pass = total_healthy_regressions == 0 and reset_clears_all
     return {
         "summary": {
             "n_traces": len(traces),
             "total_verdict_flips": sum(t["n_flips"] for t in per_trace),
             "total_healthy_regressions": total_healthy_regressions,
-            "migration_reset_required": migration_needs_reset,
+            "migration_reset_would_be_needed": migration_needs_reset,
+            "reset_clears_all_spikes": reset_clears_all,
             "gate_pass": gate_pass,
         },
         "per_trace": per_trace,
@@ -258,7 +294,7 @@ def _print_human(report: Dict) -> None:
     print("=== Valence formula validation ===", file=sys.stderr)
     print(f"traces: {s['n_traces']}  verdict_flips: {s['total_verdict_flips']}  "
           f"healthy_regressions: {s['total_healthy_regressions']}  "
-          f"migration_reset_required: {s['migration_reset_required']}", file=sys.stderr)
+          f"reset_clears_all_spikes: {s['reset_clears_all_spikes']}", file=sys.stderr)
     for t in report["per_trace"]:
         ratio = t["V_std_ratio"]
         print(f"  [{t['label']:9}] {t['agent_id']:14} flips={t['n_flips']} "
@@ -267,8 +303,9 @@ def _print_human(report: Dict) -> None:
               f"V_std old→new {t['V_std_old']:.4f}→{t['V_std_new']:.4f} "
               f"(x{ratio})", file=sys.stderr)
     for m in report["migration"]:
-        print(f"  [migration] {m['agent_id']:14} z_spike(no_reset)={m['z_spike_no_reset']} "
-              f"budget={m['sigma_budget']} reset_required={m['reset_required']}", file=sys.stderr)
+        print(f"  [migration] {m['agent_id']:14} z_spike no_reset={m['z_spike_no_reset']} "
+              f"→ with_reset={m['z_spike_with_reset']} budget={m['sigma_budget']} "
+              f"reset_clears={m['reset_clears_spike']}", file=sys.stderr)
     print(f"GATE: {'PASS' if s['gate_pass'] else 'FAIL'}", file=sys.stderr)
 
 

--- a/src/behavioral_state.py
+++ b/src/behavioral_state.py
@@ -42,6 +42,17 @@ BOOTSTRAP_UPDATES = 10
 # 30 gives stable mean/std estimates.
 BASELINE_WARMUP_UPDATES = 30
 
+# Behavioral-V formula version. Bumped when the V (Valence) computation changes
+# in a way that invalidates a previously-converged _baseline_V, so loads from an
+# older version trigger a one-time baseline re-seed (see _reseed_v_baseline).
+#   v1: double-smoothed — raw_v = self.E - self.I (gap of the already-EMA'd E,I)
+#   v2: single-EMA of raw imbalance — raw_v = E_obs - I_obs (one fewer smoothing
+#       stage; less lag). Gated on validate_valence_formula.py against real
+#       check-in traces (2026-06-19: 0 verdict flips / 0 healthy regressions on
+#       18 real agents incl. all 5 residents; resident Watcher would spike 3.12σ
+#       > 3.0σ budget against its stale baseline WITHOUT the reset below).
+V_FORMULA_VERSION = 2
+
 # Minimum meaningful standard deviation for EISV self-relative scoring.
 #
 # This is an EMPIRICAL constant calibrated against the 2026-06-13 Sentinel
@@ -134,15 +145,19 @@ class BehavioralEISV:
     def _raw_valence(self, E_obs: float, I_obs: float) -> float:
         """Pre-EMA valence (E-I imbalance) input fed into V's own EMA.
 
-        DEPLOYED default: the gap of the already-smoothed E and I — i.e. V ends
-        up double-smoothed (EMA of EMA(E)-EMA(I)). This is a known lag wart; a
-        single-EMA-of-raw-imbalance variant (return E_obs - I_obs) is under
-        trace-replay validation via scripts/dev/validate_valence_formula.py
-        before it may change the live verdict path. Kept as an override seam so
-        the candidate formula can be A/B'd through the real update + assessment
-        without forking this module.
+        V_FORMULA_VERSION 2: the gap of the RAW observations (E_obs - I_obs),
+        smoothed once by V's own EMA — so V is single-smoothed and tracks the
+        imbalance with less lag. The previous v1 default took the gap of the
+        already-EMA'd E,I (double-smoothing). The flip was gated on a trace
+        replay against real check-in traces via
+        scripts/dev/validate_valence_formula.py (2026-06-19): verdict-neutral
+        (0 flips, 0 healthy regressions on 18 real agents incl. all 5
+        residents); the one-time migration discontinuity it creates for already-
+        converged agents is absorbed by _reseed_v_baseline on load. Kept as an
+        override seam so the harness can still A/B v1 (return self.E - self.I)
+        against v2 through the real update + assessment without forking.
         """
-        return self.E - self.I
+        return E_obs - I_obs
 
     def update(
         self,
@@ -187,10 +202,10 @@ class BehavioralEISV:
         self.S = (1.0 - alpha_S) * self.S + alpha_S * S_obs
 
         # V: EMA-smoothed E-I imbalance — a derived, sign-actionable readout,
-        # not a true integral. (A known lag wart: this takes the gap of the
-        # already-smoothed E,I and smooths it again; a single-EMA-of-raw-
-        # imbalance fix is held pending trace-replay validation. See KG
-        # 2026-06-19 V-flat note + scripts/dev/validate_valence_formula.py.)
+        # not a true integral. As of V_FORMULA_VERSION 2 this is the gap of the
+        # RAW observations smoothed once (single-EMA, less lag), replacing the
+        # earlier double-smoothing. The formula lives behind _raw_valence; see
+        # scripts/dev/validate_valence_formula.py for the trace-replay gate.
         raw_v = self._raw_valence(E_obs, I_obs)
         self.V = (1.0 - alpha_V) * self.V + alpha_V * raw_v
 
@@ -221,6 +236,46 @@ class BehavioralEISV:
 
         self.update_count += 1
         self.last_update_time = time.monotonic()
+
+    def _reseed_v_baseline(self) -> None:
+        """One-time re-seed of _baseline_V after a V-formula migration.
+
+        A baseline converged under an older V formula (v1 double-smoothing) is
+        stale once _raw_valence changes: the new V gets z-scored against the old
+        mean/std and spikes (real resident Watcher: 3.12σ > the 3.0σ migration
+        budget — validate_valence_formula.py 2026-06-19). Re-seed so the first
+        post-migration z is ~0:
+          * obs_history present -> replay it under the CURRENT formula and
+            rebuild _baseline_V from the reconstructed V trajectory (accurate
+            mean AND std), and align the live V with that trajectory.
+          * obs_history absent (the lean DB-row restore drops history) -> seed a
+            single sample at the current V so mean==V (z~0); std rebuilds as
+            updates arrive. The deviation() min-std floor bounds it meanwhile.
+        """
+        fresh = WelfordStats()
+        if self.obs_history:
+            v = BOOTSTRAP_V
+            replayed: List[float] = []
+            for idx, row in enumerate(self.obs_history):
+                e_obs = max(0.0, min(1.0, float(row[0])))
+                i_obs = max(0.0, min(1.0, float(row[1])))
+                if idx < BOOTSTRAP_UPDATES:
+                    alpha_v = self.alphas["V"] + 0.5 * (1.0 - idx / BOOTSTRAP_UPDATES)
+                else:
+                    alpha_v = self.alphas["V"]
+                raw_v = e_obs - i_obs  # v2 formula (reseed only runs post-flip)
+                v = max(-1.0, min(1.0, (1.0 - alpha_v) * v + alpha_v * raw_v))
+                replayed.append(v)
+            # Drop the cold-start bootstrap transient from the baseline when the
+            # history is long enough to spare it; the live V still warms through
+            # those steps. Keep all samples for short histories.
+            seed = replayed[BOOTSTRAP_UPDATES:] if len(replayed) > BOOTSTRAP_UPDATES + 5 else replayed
+            for x in seed:
+                fresh.update(x)
+            self.V = replayed[-1]
+        else:
+            fresh.update(self.V)
+        self._baseline_V = fresh
 
     @property
     def confidence(self) -> float:
@@ -334,6 +389,7 @@ class BehavioralEISV:
         """
         d = self.to_dict()
         d["alphas"] = dict(self.alphas)
+        d["v_formula_version"] = V_FORMULA_VERSION
         d["baseline_stats"] = {
             "E": self._baseline_E.to_dict(),
             "I": self._baseline_I.to_dict(),
@@ -351,6 +407,7 @@ class BehavioralEISV:
         d["V_history"] = [round(v, 4) for v in self.V_history[-MAX_HISTORY:]]
         d["obs_history"] = [[round(v, 4) for v in row] for row in self.obs_history[-MAX_HISTORY:]]
         d["alphas"] = dict(self.alphas)
+        d["v_formula_version"] = V_FORMULA_VERSION
         # Persist baseline statistics for cross-restart continuity
         d["baseline_stats"] = {
             "E": self._baseline_E.to_dict(),
@@ -387,4 +444,12 @@ class BehavioralEISV:
             state._baseline_S = WelfordStats.from_dict(baseline_data["S"])
         if "V" in baseline_data:
             state._baseline_V = WelfordStats.from_dict(baseline_data["V"])
+        # One-time V-baseline migration: a state persisted under an older V
+        # formula carries a _baseline_V that no longer matches how V is now
+        # computed. Re-seed it once so the new-formula V is not judged against a
+        # stale baseline (would spike — see _reseed_v_baseline). Only when the
+        # baseline is already mature; an immature one rebuilds correctly anyway.
+        persisted_version = int(data.get("v_formula_version", 1))
+        if persisted_version < V_FORMULA_VERSION and state.is_baselined:
+            state._reseed_v_baseline()
         return state

--- a/tests/test_valence_formula_validation.py
+++ b/tests/test_valence_formula_validation.py
@@ -1,9 +1,12 @@
-"""Tests for the Valence-formula validation gate and the _raw_valence seam.
+"""Tests for the Valence-formula flip (V_FORMULA_VERSION 2), the migration
+re-seed, and the validation gate.
 
-These lock in (a) the seam is behavior-preserving by default, (b) the harness
-faithfully A/Bs the two formulas through the real assessment, and (c) the
-documented empirical findings from the 2026-06-19 council replay so a future
-change to either formula or the band-aids can't silently drift them.
+These lock in (a) the v2 default is single-EMA of the raw imbalance, (b) the
+LegacyV seam still reproduces the v1 double-smoothing so the gate stays a live
+A/B, (c) loading a v1-persisted mature state re-seeds _baseline_V so the new
+formula isn't judged against a stale baseline, and (d) the documented empirical
+findings from the 2026-06-19 real-trace replay, so a future change to either
+formula or the #686/#689 band-aids can't silently drift them.
 """
 
 from __future__ import annotations
@@ -11,7 +14,11 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-from src.behavioral_state import BehavioralEISV
+from src.behavioral_state import (
+    BehavioralEISV,
+    V_FORMULA_VERSION,
+    BASELINE_WARMUP_UPDATES,
+)
 
 _HARNESS = Path(__file__).resolve().parents[1] / "scripts" / "dev" / "validate_valence_formula.py"
 _spec = importlib.util.spec_from_file_location("validate_valence_formula", _HARNESS)
@@ -20,34 +27,98 @@ _spec.loader.exec_module(vvf)
 
 
 class TestSeam:
-    def test_default_raw_valence_is_double_smoothed(self):
-        """Default seam returns the gap of already-smoothed E,I (deployed behavior)."""
+    def test_default_raw_valence_is_raw_imbalance(self):
+        """v2 default returns the gap of the RAW observations."""
         s = BehavioralEISV()
-        s.E, s.I = 0.7, 0.55
-        assert s._raw_valence(0.9, 0.1) == 0.7 - 0.55  # ignores raw obs, uses smoothed
-
-    def test_candidate_raw_valence_is_raw_imbalance(self):
-        """Candidate seam returns the gap of the RAW observations."""
-        s = vvf.CandidateV()
         s.E, s.I = 0.7, 0.55
         assert s._raw_valence(0.9, 0.1) == 0.9 - 0.1  # uses raw obs, ignores smoothed
 
-    def test_seam_does_not_change_default_v_trajectory(self):
-        """A trace through the default class must match the explicit old formula."""
+    def test_legacy_raw_valence_is_double_smoothed(self):
+        """LegacyV seam restores v1: the gap of the already-smoothed E,I."""
+        s = vvf.LegacyV()
+        s.E, s.I = 0.7, 0.55
+        assert s._raw_valence(0.9, 0.1) == 0.7 - 0.55  # ignores raw obs, uses smoothed
+
+    def test_default_trajectory_matches_raw_imbalance_formula(self):
+        """A trace through the default class must match the explicit v2 formula."""
         obs = [[0.7, 0.8, 0.15], [0.72, 0.78, 0.16], [0.68, 0.82, 0.14]] * 10
         s = BehavioralEISV()
         ref = BehavioralEISV()
         for e, i, sv in obs:
             s.update(e, i, sv)
-            # reference: replicate old V update independently
             ae, ai, av = ref.alphas["E"], ref.alphas["I"], ref.alphas["V"]
             boost = 0.5 * (1.0 - ref.update_count / 10) if ref.update_count < 10 else 0.0
             ref.E = (1 - (ae + boost)) * ref.E + (ae + boost) * e
             ref.I = (1 - (ai + boost)) * ref.I + (ai + boost) * i
-            ref.V = (1 - (av + boost)) * ref.V + (av + boost) * (ref.E - ref.I)
+            ref.V = (1 - (av + boost)) * ref.V + (av + boost) * (e - i)  # v2: raw imbalance
             ref.V = max(-1.0, min(1.0, ref.V))
             ref.update_count += 1
         assert abs(s.V - ref.V) < 1e-9
+
+    def test_legacy_trajectory_diverges_on_transient(self):
+        """The whole point of v2: less lag, so v1/v2 diverge DURING a step change.
+
+        At steady state EMA(E)-EMA(I) -> E_obs-I_obs and the two converge; the
+        v2 win is responsiveness to transitions, so the divergence is measured as
+        the max gap across a stepped trace, not the final value.
+        """
+        obs = [[0.70, 0.80, 0.15]] * 20 + [[0.90, 0.50, 0.20]] * 20  # sharp imbalance step
+        v2 = BehavioralEISV()
+        v1 = vvf.LegacyV()
+        max_gap = 0.0
+        for e, i, sv in obs:
+            v2.update(e, i, sv)
+            v1.update(e, i, sv)
+            max_gap = max(max_gap, abs(v2.V - v1.V))
+        assert max_gap > 1e-2  # v2 leads v1 through the transient
+
+
+class TestMigrationReseed:
+    """The live path: BehavioralEISV.from_dict re-seeds _baseline_V on a v1 load."""
+
+    def _mature_v1_blob(self):
+        """A mature state persisted under v1 (double-smoothing, no version stamp)."""
+        legacy = vvf.LegacyV()
+        for _ in range(80):
+            legacy.update(0.78, 0.72, 0.2)  # mild E>I imbalance
+        blob = legacy.to_dict_with_history()
+        blob.pop("v_formula_version", None)  # simulate a pre-v2 snapshot
+        return blob
+
+    def test_v1_load_triggers_reseed(self):
+        blob = self._mature_v1_blob()
+        stale_mean = blob["baseline_stats"]["V"]["mean"]
+        restored = BehavioralEISV.from_dict(blob)
+        # Baseline mean should move off the stale v1 value toward the v2 trajectory.
+        assert abs(restored._baseline_V.mean - stale_mean) > 1e-6
+        # And the live V is realigned to the v2 trajectory it just replayed, so on
+        # this steady trace it sits near the freshly re-seeded baseline mean.
+        assert abs(restored.V - restored._baseline_V.mean) < 0.1
+        assert restored.is_baselined
+
+    def test_reseed_keeps_post_migration_z_in_budget(self):
+        blob = self._mature_v1_blob()
+        restored = BehavioralEISV.from_dict(blob)
+        # The first post-migration deviation must not spike out of a 3-sigma budget.
+        assert abs(restored.deviation("V")) <= 3.0
+
+    def test_v2_load_does_not_reseed(self):
+        """A state already at the current version must load untouched."""
+        s = BehavioralEISV()
+        for _ in range(80):
+            s.update(0.78, 0.72, 0.2)
+        blob = s.to_dict_with_history()
+        assert blob["v_formula_version"] == V_FORMULA_VERSION
+        restored = BehavioralEISV.from_dict(blob)
+        assert abs(restored._baseline_V.mean - blob["baseline_stats"]["V"]["mean"]) < 1e-9
+
+    def test_reseed_fallback_without_history(self):
+        """DB-row restore drops obs_history; reseed seeds a single current-V sample."""
+        blob = self._mature_v1_blob()
+        blob["obs_history"] = []  # mimic to_dict_for_persistence
+        restored = BehavioralEISV.from_dict(blob)
+        assert restored._baseline_V.count == 1
+        assert abs(restored._baseline_V.mean - restored.V) < 1e-9
 
 
 class TestHarness:
@@ -56,7 +127,8 @@ class TestHarness:
         assert set(report) == {"summary", "per_trace", "migration"}
         s = report["summary"]
         assert {"n_traces", "total_verdict_flips", "total_healthy_regressions",
-                "migration_reset_required", "gate_pass"} <= set(s)
+                "migration_reset_would_be_needed", "reset_clears_all_spikes",
+                "gate_pass"} <= set(s)
         assert len(report["per_trace"]) == 5
 
     def test_candidate_increases_v_variance(self):
@@ -71,18 +143,22 @@ class TestHarness:
         report = vvf.build_report(vvf.synthetic_traces(seed=7), sigma_budget=3.0)
         assert report["summary"]["total_healthy_regressions"] == 0
 
-    def test_migration_probe_quantifies_discontinuity(self):
-        """Seat 3 RISK 2: a no-reset formula switch spikes z; a reset zeroes it."""
+    def test_migration_probe_reset_reduces_spike(self):
+        """Seat 3 RISK 2: the reset cuts the no-reset spike to within budget."""
         traces = vvf.synthetic_traces(seed=7)
         sentinel = next(t for t in traces if t["label"] == "sentinel")
         m = vvf.migration_probe(sentinel["observations"], sigma_budget=3.0)
-        assert m["z_spike_with_reset"] == 0.0
-        assert m["z_spike_no_reset"] >= m["z_spike_with_reset"]
-        assert m["z_spike_no_reset"] > 1.0  # tight-sigma agent shows a real spike
+        assert m["z_spike_no_reset"] > 1.0          # tight-sigma agent shows a real spike
+        assert m["z_spike_with_reset"] < m["z_spike_no_reset"]
+        assert m["reset_clears_spike"] is True
 
-    def test_gate_fails_when_budget_tightened_below_observed_spike(self):
-        """A sigma budget below the observed sentinel spike must trip the gate."""
+    def test_gate_fails_when_budget_below_post_reset_spike(self):
+        """A sigma budget below even the post-reset spike must trip the gate."""
         traces = [t for t in vvf.synthetic_traces(seed=7) if t["label"] == "sentinel"]
-        report = vvf.build_report(traces, sigma_budget=0.5)
-        assert report["summary"]["migration_reset_required"] is True
+        report = vvf.build_report(traces, sigma_budget=0.1)
+        assert report["summary"]["reset_clears_all_spikes"] is False
         assert report["summary"]["gate_pass"] is False
+
+    def test_gate_passes_with_reset_at_default_budget(self):
+        report = vvf.build_report(vvf.synthetic_traces(seed=7), sigma_budget=3.0)
+        assert report["summary"]["gate_pass"] is True


### PR DESCRIPTION
## What

Lands the held **behavioral-V (Valence) math flip** that #902's gate was built to clear, now that the gate has been run against **real check-in traces** (the unblock the 2026-06-19 handoff was waiting on). Plus the **one-time `_baseline_V` migration reset** the real run proved *mandatory* (not just prudent).

> **Stacked on #902** (base = `claude/valence-validation-7kiogv`, itself on #901). GitHub auto-retargets to `master` as those merge. This is the PR the earlier two deferred to.

## The real-trace run (the unblock)

The raw pre-EMA observations the gate replays live only in the per-agent JSON snapshots' `behavioral_eisv.obs_history` (the DB row is trimmed). New `scripts/dev/export_valence_traces.py` dumps them to the gate's JSONL format; **18 real agents** exported (5 residents at the 100-obs cap + 5 healthy + 8 short), labeled honestly from each agent's **real recorded `verdict_history`** (production's own ground-truth) and DB identity.

```
python3 scripts/dev/export_valence_traces.py \
  --data-dir ~/projects/unitares-deploy/data/agents \
  --data-dir ~/projects/unitares/data/agents \
  --labels /tmp/agent_labels.tsv --min-obs 10 --out traces.jsonl
python3 scripts/dev/validate_valence_formula.py --trace traces.jsonl
# GATE: PASS  (exit 0)
```

| Signal | Synthetic (#902) | **Real traces (this PR)** |
|---|---|---|
| Verdict flips / healthy regressions | 0 / 0 | **0 / 0** (incl. all 5 residents) |
| V std post-warmup | ×1.37–2.33 (uniform↑) | **×0.59–2.07** (responsive on transients, not uniform) |
| Migration z-spike, no reset | ≤2.81σ (sub-budget) | **3.12σ on resident Watcher — over the 3.0σ budget** |
| Same spike, **with the shipped reset** | (assumed 0) | **1.44σ — within budget, exercised for real** |

The real data **upgraded** the council's RISK-2 from "prudent" to "load-bearing": synthetic never crossed the budget, but real resident **Watcher** does (3.12σ) — so the math flip is only safe *with* the reset below. The reset cuts every flagged resident spike back inside budget (Watcher 3.12→1.44σ).

## Changes

- **`behavioral_state._raw_valence`** default flipped to `E_obs - I_obs` (single-EMA of the raw imbalance; was the gap of the already-EMA'd `self.E - self.I`). One fewer smoothing stage → V tracks imbalance with less lag. Verdict-neutral per the gate.
- **`V_FORMULA_VERSION = 2`**, stamped in both persistence serializers. `from_dict` does a **one-time `_baseline_V` reseed** when loading an older-version *mature* state: replays `obs_history` under v2 to rebuild the baseline (accurate mean+std) and realigns live V; single-sample current-V fallback when the lean DB-row restore dropped history (z≈0, `deviation()` min-std floor bounds it). Self-stamps v2 on next save → fires once per agent.
- **`validate_valence_formula.py`** — inverted the A/B (`LegacyV` restores v1, base = v2) so the gate stays a live regression guard; the migration probe now exercises the **real** reseed instead of assuming z=0; `gate_pass` = no healthy regressions **and** the reset clears every spike.
- **`export_valence_traces.py`** — new, the real-trace exporter described above.
- **Tests** — rewritten to the v2 contract + new `TestMigrationReseed` covering the live `from_dict` reseed (triggers on v1 load, no-ops on v2, history + fallback paths, post-migration z within budget).

## README V-demote

Already honest on `master` (`V · Valence | derived: energy vs integrity`) — no further demote needed. The inaccurate "Integral/accumulated" wording was the scope of #901 (surfaced labels). Noting it here to close the handoff's third held item.

## Verification

- Real-trace gate: **PASS** (0 flips, 0 healthy regressions, reset clears all spikes).
- Touched tests: `test_valence_formula_validation` (14) + the behavioral/eisv/monitor sweep (372) green.
- Full `test-cache.sh`: **10505 passed, 22 skipped, 81.74% coverage**.

## Why draft / merge gate

This touches the **primary verdict on the live pause path** (behavioral risk) and interacts with the #686/#689 false-pause band-aids. Per repo convention the operator is the merge gate. The reseed strategy (obs_history replay) is new and worth a council eye before deploy. Deploy note: existing persisted states are unstamped (= v1), so the one-time reseed fires for every mature agent on first load post-deploy, then never again.