### PR TITLE
docs(proposals): v0.2 council fold for the proprioception case (corrects #905)

### DIFF
--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -28,7 +28,7 @@ Several of these are **single-writer surfaces** (see the shared contract in `AGE
 | [`beam-governed-effects-dossier-2026-06-18.md`](beam-governed-effects-dossier-2026-06-18.md) | Draft dossier + phased plan — narrows current evidence to BEAM as dual-mode record/execute governed-effect runtime custody, not whole-governance rewrite |
 | [`governed-effect-plane-v0.md`](governed-effect-plane-v0.md) | Draft v0.1 — Phase 2 protocol contract for the dossier (dual `custody_mode`, effect envelope, typed errors, idempotency/custody-TTL/payload holes closed); council-revised, first effect class = both (record_only shadow built in PR #866) |
 | [`wave-3-section-5-2-boundary-audit-summary.md`](wave-3-section-5-2-boundary-audit-summary.md) | CI-checkable §5.2 boundary-cost audit summary (2026-06-10), required before `elixir/handler_dispatch/` commits |
-| [`beam-proprioception-case-v0.md`](beam-proprioception-case-v0.md) | Draft v0 — conceptual companion behind A′; names the dossier's Decision Boundary as the seam between interoceptive self-knowledge (stays Python) and runtime proprioception (moves to BEAM). Orthogonal to latency; non-relitigating; moves no boundary |
+| [`beam-proprioception-case-v0.md`](beam-proprioception-case-v0.md) | Draft v0.2 — conceptual companion behind A′ (council-folded). Epistemic claim: honest, provenance-tagged runtime introspection is privileged self-evidence (`external_signal`→`externally_verified`; #846 `harness_lane`); build governance on the layer that introspects honestly. Orthogonal to latency; non-relitigating; moves no boundary |
 
 ### Operator-vision delegation / identity hardening
 

--- a/docs/proposals/beam-proprioception-case-v0.md
+++ b/docs/proposals/beam-proprioception-case-v0.md
@@ -1,68 +1,78 @@
 # The Proprioception Case for the BEAM Footprint
 
 **Created:** June 19, 2026
-**Status:** Draft v0 — conceptual companion to the committed A′ destination. **This is not a relitigation.** It argues no change to scope, sequencing, or the decision boundary already set by [`beam-footprint-roadmap-v0.md`](beam-footprint-roadmap-v0.md) (v0.3, A′ committed) and [`beam-governed-effects-dossier-2026-06-18.md`](beam-governed-effects-dossier-2026-06-18.md). It supplies a *name and a frame* for the boundary those documents already drew, so the commitment is easier to hold and harder to re-open from cold.
-**Relationship to existing docs:** read the footprint roadmap V0.3 RESOLUTION and the dossier's Decision Boundary first. This doc sits behind both; it adds no new surface and gates nothing.
+**Last Updated:** June 19, 2026 (v0.2 — reframed after a three-seat council pass; the v0.1 "two proprioceptions" taxonomy was rejected as a relabel and is replaced by an epistemic claim. See *What changed in v0.2*.)
+**Status:** Draft v0.2 — conceptual companion to the committed A′ destination. **This is not a relitigation.** It argues no change to scope, sequencing, or the decision boundary already set by [`beam-footprint-roadmap-v0.md`](beam-footprint-roadmap-v0.md) (v0.3, A′ committed) and [`beam-governed-effects-dossier-2026-06-18.md`](beam-governed-effects-dossier-2026-06-18.md). It adds no surface and gates nothing.
+**Relationship to existing docs:** read the footprint roadmap V0.3 RESOLUTION and the dossier's Decision Boundary first. This doc sits behind both.
 
 ---
 
-## Why this doc exists
+## What changed in v0.2 (council fold)
 
-Every prior round of this debate has been fought on the **latency axis**, and the substrate keeps losing that fight honestly: PRs #350 / #354 / #360 / #361 / #533 each collapsed a measured floor Python-side (#533 alone was 104× on user-visible overhead with one `run_in_executor`). The roadmap's own V0.3.1 amendment names this and flags the documented `feedback_substrate-migration-status-quo-bias.md` pole. The latency argument for migration is genuinely weak, and saying so is the honest posture.
+A three-seat council (dialectic + code-review + live-verifier) reviewed v0.1. The substance verified; the *frame* did not.
 
-This doc makes a claim on a **different axis entirely**, one the latency rebuttals do not touch:
+- **Dialectic [B]:** v0.1's "two proprioceptions, one boundary" was a relabel of the roadmap's existing stateful-coordination/stateless-computation cut — it reclassified no surface, so it did no inferential work. **Folded:** the taxonomy is dropped. v0.2 makes an *epistemic* claim on a different axis (which self-reports are admissible evidence), not a taxonomic one.
+- **Dialectic [B] + source check:** v0.1 called $V_{\text{anima}}$ "interoceptive." The paper (Wang 2026, §1.2, lines 161–173) **explicitly rejects** "interoception" on parsimony grounds and names the signal *proprioception*. **Folded:** "interoception" is struck entirely; this doc uses "proprioception" only in the paper's strict sense (a state-tracking signal — *what the signal does* — with no metaphysical claim).
+- **Code-review [C]:** v0.1's "item for item" mapping dropped two Keep-in-Python items. **Folded:** the mapping claim is removed along with the taxonomy.
+- **Code-review [C] / correction:** the `#18` citation is a real dispatch_beam PR (commit `f47d0e3`), but opaque cross-repo. **Folded:** cited explicitly below.
+- **Live-verifier:** 4/5 runtime claims VERIFIED against the running system (sentinel-beam live pid 2259; lease plane :8788; orchestrator inert :8789; dispatch_beam live pid 78896). One DRIFT was in the *dossier* (`force-release` line refs), not here — noted for separate repair.
 
-> A *governance* substrate's core job is self-sensing — an agent (and the fleet) perceiving its own state honestly. BEAM is built to perceive its own running processes; UNITARES is built to integrate an agent's deviation trajectory over time. These are two distinct senses of proprioception, and the committed migration boundary is exactly the seam between them. Each kind of self-sensing belongs on the substrate shaped for it.
+The council itself is the worked example of this doc's thesis (see §4).
 
-If that framing holds, the A′ boundary is not an empirical compromise pending the next benchmark — it is principled, and that is what stops the relitigation loop.
+---
 
-## Two proprioceptions, one boundary
+## 1. The claim
 
-The ecosystem already runs **two** distinct self-sensing systems. They are usually discussed separately; naming them as a pair is the contribution here.
+Every prior round of this debate was fought on the **latency axis**, and the substrate keeps losing it honestly (PRs #350 / #354 / #360 / #361 / #533 — #533 collapsed 104× of user-visible overhead with one `run_in_executor`; the roadmap's V0.3.1 amendment and `feedback_substrate-migration-status-quo-bias.md` already concede this). This doc abandons the latency axis and argues one the latency rebuttals do not touch:
 
-**1. Interoceptive / autobiographical self-knowledge — stays Python (UNITARES).**
-This is the sense formalized in the digital-proprioception paper (Wang 2026): the Anima Void Integral $V_{\text{anima}}(t) = \int_0^t \lVert \mathbf{a}(\tau) - \boldsymbol{\mu_a} \rVert\, d\tau$, the time-integrated deviation of an agent from its operating point — allostatic load on a four-dimensional EISV manifold. It is *durable, semantic, and historical*: identity continuity, trajectory, calibration, KG sediment, dialectic record. It answers "how far have I drifted, over my whole life, from who I am?" That is meaning-legibility, and it lives in Postgres/AGE and the analysis lane by design.
+> **Honest, attributed runtime introspection is the closest a governed system gets to ground truth about itself — and a governance substrate should be built on the layer that can produce it.** A self-narrated state model can confabulate; an externally-observable runtime state is costlier to fake and costlier to fool yourself with. BEAM's edge is not speed; it is that its self-reports are *introspective* (PIDs, `:DOWN` monitors, supervision trees, Registry, ETS — structural facts about the running body) rather than *narrated*.
 
-**2. Runtime / process proprioception — moves to BEAM (A′ surfaces).**
-This is the sense the substrate is built to give natively: which process holds which lease, what crashed, what is queued, who is the single winner of a contested surface, what was revoked. It is *live, structural, and immediate*. It answers "what is true about my running body right now?" That is runtime-legibility, and OTP supplies it as ambient physics — PIDs, `:DOWN` monitors, supervision trees, Registry, bounded mailboxes — rather than as bookkeeping simulated in a `Map`.
+This is an axis the roadmap's stateful/stateless cut does not address. That cut decides *where computation lives*. This decides *which self-reports are admissible evidence* — a governance question, not a placement question.
 
-**The dossier's Decision Boundary is this split, item for item.** Its "Move to BEAM" column — runtime custody, supervision (failures visible/isolated/restartable), leases/conflicts, revocation, bounded queues, typed telemetry — is precisely runtime proprioception. Its "Keep in Python" column — durable identity, EISV/calibration, KG/dialectic, ablation — is precisely interoceptive self-knowledge. The boundary was drawn empirically, surface by surface, under adversarial council review. This doc observes that it converged on a clean conceptual seam, which is evidence the boundary is real and not an artifact of where the benchmarks happened to land.
+## 2. Why this is not "more signal is always better"
 
-## Why this argument is immune to the latency rebuttal
+The naive form — "BEAM emits more signal, more signal beats doubt" — is false, and **this migration already proved it false.** Dossier Evidence §2 / PR #846: BEAM harness telemetry is "operationally important but **analytically contaminating unless partitioned**." The ablation watchdog (`eprocess_eligible=1778`, `beam=1493`, `substrate=285`) showed BEAM rows would *masquerade* as EISV prior-state predictive signal; they are now **excluded by default** until tagged with `harness_lane`. There, more signal *raised* doubt until provenance resolved it.
 
-The Python-side fixes optimize *how fast the system computes*. They do not give the system *legible knowledge of its own running state* — because that was never their target. You cannot `run_in_executor` your way to "this process honestly knows it is no longer the lease holder after a restart." That property is structural to the actor model, not a hot path you can profile and unblock.
+So the law is conditional, and the conditions are the whole point:
 
-Concretely, the lease-plane's own documented failure mode — *holder UUID does not survive restart → false `held_by_other`* — is a **runtime-proprioception defect**: the system held a false belief about its own process state. The roadmap's "architectural ceiling" point (per-agent GenServer dissolves the shared lock) is the same observation from the performance side. Naming it as proprioception unifies the lease-plane bug, the shared-lock ceiling, and the dossier's custody/revocation invariants under one property the substrate provides and Python emulates. None of those three is a latency claim; all three survive every Python floor-fix in the project's history.
+> More **honest, provenance-tagged** signal lowers doubt. More **unattributed** signal raises it.
 
-## Existence proof: dispatch_beam
+Two conditions convert volume into confidence:
+1. **Honesty** — the introspection is not subverted (a compromised process can lie about its own state; this is the threat the `s19` attestation and `track-a` strict-identity work defend).
+2. **Attribution** — the signal carries provenance (`harness_lane`, `effect_lane`, `verification_source`) so it cannot masquerade as a different kind of evidence (the #846 lesson).
 
-`~/projects/dispatch_beam` is a governed Discord orchestrator **already running on BEAM**, and it is a working instance of exactly this split:
+BEAM's value is that it is high-volume *and* structurally introspective; #846 is the standing reminder that volume without attribution is contamination, not confidence.
 
-- It draws the same boundary in miniature — its `PLAN.md` "Proprioception" section and "ontology payoff" keep the agent's governance identity out of the harness (the load-bearing identity-honesty caveat) while letting OTP own holder lifecycle, exactly as the dossier's invariant 1 requires of the effect plane ("BEAM never asserts a caller identity from transport inference alone").
-- Its recent robustness audit (#18: resume-failure recovery, active-run reap distinction, write-amplification collapse) was **tractable because the runtime state was legible** — `Process.info`, `Port.info`, the Registry, ETS gave honest answers about what was actually running. That is runtime proprioception paying off as operability, not as throughput.
+## 3. The substrate already runs this thesis
 
-dispatch_beam is the cheap, low-blast-radius demonstration that the runtime-proprioception layer behaves as claimed before more of UNITARES's governed effects ride on it. It is a citation, not a dependency.
+This is not a new principle imported from outside — it is the operating logic of the existing system, just unnamed:
 
-## What this doc explicitly does NOT argue
+- **`verification_source: "external_signal"` → `externally_verified` corroboration grade.** A harness-observed outcome is graded *above* an agent's self-report precisely because external observation beats narration (dispatch_beam `governance.ex`; same pattern in UNITARES outcome ingestion).
+- **The #846 `harness_lane` partition** is condition 2 enforced.
+- **The `s19` attestation / `track-a` identity-hardening proposals** are condition 1 defended.
+- **The dossier's Required Invariant 4** ("telemetry provenance: every emitted event includes lane tags") is this thesis written as a protocol rule.
 
-- **It does not move the boundary.** Stateless computation (numpy ODE, embeddings, LLM SDK, EISV) stays Python. MCP transport stays Python until the SDK gate is evaluated. No surface is added, promoted, or resequenced. Phases 3–5 of the dossier stay gated behind the dual-mode contract and the 2026-06-24 Wave-3 gate.
-- **It does not claim a latency win.** The opposite: it concedes the latency axis to the Python-fix posture and argues the case lives elsewhere.
-- **It does not relitigate A′.** A′ is committed by operator decision. This doc strengthens the rationale future-sessions read so the destination is not re-derived from cold each time.
+The contribution of this doc is only to *name* the axis these already serve, so the A′ commitment reads as principled — built on "the layer that can introspect honestly" — rather than as the residue of where the last benchmark happened to land.
 
-## Bias accountability (both poles)
+The relation to the proprioception paper is now clean: the paper claims "proprioception" (strict sense) for the durable trajectory-deviation signal $V_{\text{anima}}(t) = \int_0^t \lVert \mathbf{a}(\tau) - \boldsymbol{\mu_a}\rVert\, d\tau$ (defined in Wang 2026b, Trajectory Identity §6.1.1; imported by the paper's §2.2). Runtime introspection is the same *kind* of signal — honest state-tracking, "where my joints are" — at an immediate timescale rather than an integrated one. One family, two timescales; no second metaphysical category, and no "interoception."
 
-`feedback_substrate-migration-status-quo-bias.md` warns that this author reliably *resists* substrate migrations. That pole is real and must be priced in. But the symmetric failure is also real: a *pro-migration* proprioception narrative is rhetorically attractive precisely because it is clean, and clean frames invite motivated reasoning. Two guards:
+## 4. The council as the worked example
 
-1. This doc is **falsifiable in the same shape as the roadmap's stop-signs.** If Wave-1 Sentinel-on-BEAM or the governed-effect plane produces runtime-state defects (lost custody, false lease beliefs, supervision that fails to isolate) that the Python path did *not* have, the proprioception claim is *wrong* — BEAM would be giving worse self-knowledge, not better — and that is a v0.4 trigger, not a footnote.
-2. It earns its place only by being **orthogonal**: it must not be cited to override a latency stop-sign or to accelerate a gated phase. If it is ever used to justify moving faster than the dossier's gates allow, it has been misused.
+This doc's own review demonstrates its claim. Three seats reviewed it: two (dialectic, code-review) reasoned over text and file-search — the *narrated* layer — and one (live-verifier) did runtime introspection (`ps`, `lsof`, `curl` against the live system). The introspective seat returned the cleanest, most ground-truthed verdict (4/5 VERIFIED, the lone drift not even in this doc). The narrated seats caught a real error the introspective one could not — that "interoception" contradicts the paper — *because that error lives in the text, not the runtime.* The division of labor is itself the thesis: **introspection is the privileged evidence for runtime-state claims; narration remains necessary for meaning-and-source claims; confusing the two is the failure mode.** v0.1's confabulated "interoception" was a narrated self-model drifting from its source, caught by a ground-truth check — in the very doc arguing ground-truth checks beat self-models.
 
-## Suggested disposition
+## 5. Falsifier and discipline
 
-A conceptual companion, not an RFC. If accepted, the only mechanical change is a one-line entry under "BEAM footprint (substrate migration waves)" in [`docs/proposals/README.md`](README.md) pointing here, and (optionally) a single back-reference from the roadmap's "Why migrate anyway, eyes-open" §1 noting that the architectural-ceiling argument has a proprioception framing recorded here. A council pass on *the frame itself* (does naming the two proprioceptions clarify or merely decorate the committed boundary?) would be appropriate before either cross-link lands.
+- **Falsifier (not co-extensive with the roadmap's Stop Sign #1):** if a BEAM surface's *honest, attributed* introspection proves a *worse* evidence source than the Python path's self-reports — i.e., runtime state that is attributed yet still systematically misleads about what the system did — the thesis is wrong. (Stop Sign #1 is about contention/coordination *failure*; this is about *evidential quality* of self-reports. They can come apart: a surface can coordinate fine yet report its state misleadingly, or vice versa.)
+- **Self-limiting:** this doc may not be cited to override a latency stop-sign, to accelerate a gated phase, or to reclassify a surface. It is an evidentiary frame, not a scope lever.
+- **Bias, both poles, priced not just named:** `feedback_substrate-migration-status-quo-bias.md` warns this author resists migrations; the mirror risk is that a clean introspection narrative invites motivated reasoning. The discount this doc actually takes: it *concedes* the latency axis outright (§1), it *accepts* a documented counterexample to its own naive form (§2, #846), and it *survived* deletion of its v0.1 frame without losing the claim (§"What changed"). A frame that gives up its most attractive version and still stands is the one worth keeping.
+
+## 6. Suggested disposition
+
+A conceptual companion, not an RFC; moves no boundary. If accepted, the only mechanical changes are the existing one-line `proposals/README.md` index entry and (optionally) a back-reference clause from the roadmap's "Why migrate anyway, eyes-open" §1 noting the architectural-ceiling argument has an evidentiary framing recorded here. Separately, the live-verifier caught a stale line-ref in the dossier (`force-release` cited as `http_router.ex:205-227`; actual `:234-249`) — worth a one-line fix in that file, independent of this doc.
 
 ## References
 
-- [`beam-footprint-roadmap-v0.md`](beam-footprint-roadmap-v0.md) — v0.3, A′ committed; this doc sits behind its RESOLUTION.
-- [`beam-governed-effects-dossier-2026-06-18.md`](beam-governed-effects-dossier-2026-06-18.md) — the Decision Boundary this doc names.
-- Wang, K. (2026). *Digital Proprioception and Allostatic Load* (`~/projects/digital-proprioception-paper/paper.md`) — the interoceptive sense ($V_{\text{anima}}$).
-- `~/projects/dispatch_beam` `PLAN.md` — the running existence proof; "Proprioception (the prophetic case)" + "The ontology payoff".
+- [`beam-footprint-roadmap-v0.md`](beam-footprint-roadmap-v0.md) — v0.3, A′ committed.
+- [`beam-governed-effects-dossier-2026-06-18.md`](beam-governed-effects-dossier-2026-06-18.md) — the Decision Boundary, Evidence §2 (PR #846), Required Invariant 4.
+- Wang, K. (2026). *Digital Proprioception and Allostatic Load* (`~/projects/digital-proprioception-paper/paper.md`), §1.2 — proprioception in the strict sense, and the explicit rejection of "interoception."
+- `~/projects/dispatch_beam`: `PLAN.md` ("The ontology payoff"); `lib/dispatch/governance.ex` (`external_signal`); PR #18 / commit `f47d0e3` (the robustness audit: resume-failure recovery, active-run vs idle-reap distinction, snapshot write-amplification collapse) — the running existence proof, cited not depended on.


### PR DESCRIPTION
Follow-up to **#905** (merged v0.1). A three-seat council reviewed v0.1 — substance verified, **frame rejected**. This corrects the canon. Still docs-only, still moves no boundary.

## Why a correction was needed

**#905 merged a verified factual error into master.** v0.1 labeled $V_{\text{anima}}$ "interoceptive," but the paper (`digital-proprioception-paper/paper.md` §1.2, lines 161–173) **explicitly rejects** "interoception" on parsimony grounds and deliberately names the signal *proprioception*. v0.1 inverted its own cited source.

## Council findings folded

- **Dialectic [B]** — v0.1's "two proprioceptions, one boundary" was a relabel of the roadmap's existing stateful/stateless cut (reclassified no surface → no inferential work). **Dropped.** v0.2 makes an *epistemic* claim on a different axis: *which self-reports are admissible evidence*, not where computation lives.
- **Dialectic [B] / source** — "interoception" struck entirely.
- **Code-review [C]** — "item for item" mapping overstated (dropped two Keep-in-Python items) → removed with the taxonomy; `#18` citation made explicit (real: dispatch_beam `f47d0e3`).
- **Live-verifier** — 4/5 VERIFIED against the *running* system (sentinel-beam pid 2259; lease plane :8788; orchestrator inert :8789; dispatch_beam pid 78896). The lone DRIFT is in the dossier (`force-release` line-ref), not here — flagged for separate repair.

## The v0.2 claim

> Honest, **provenance-tagged** runtime introspection is the closest a governed system gets to ground truth about itself — build governance on the layer that can produce it. A narrated self-model can confabulate; externally-observable runtime state is costlier to fake.

Crucially it does **not** claim "more signal always wins." The migration's own evidence (PR **#846**, dossier Evidence §2) is the counterexample: unattributed BEAM telemetry *contaminated* EISV inference until `harness_lane`-partitioned. So: more *honest, attributed* signal lowers doubt; more *unattributed* signal raises it. The thesis is already operationalized in the substrate (`external_signal`→`externally_verified`, `harness_lane`, `s19`/`track-a` attestation) — v0.2 only names the axis.

The council is the worked example: the introspective seat (live runtime checks) was cleanest; the narrated seats caught a text-only error introspection couldn't. Confusing the two layers is the failure mode — and v0.1's "interoception" was exactly that, a narrated self-model drifting from source, caught by a ground-truth check.

Falsifier is now distinct from roadmap Stop Sign #1 (evidential quality of self-reports vs coordination failure).