### PR TITLE
docs(proposals): fix force-release line-ref in governed-effects dossier

### DIFF
--- a/docs/proposals/beam-governed-effects-dossier-2026-06-18.md
+++ b/docs/proposals/beam-governed-effects-dossier-2026-06-18.md
@@ -14,7 +14,7 @@ A three-member council (dialectic + code-review + live-verifier) reviewed this d
 
 1. **The "new plane" already exists as built/live BEAM code — reframe as a lease-plane *effect-envelope extension*, not a new OTP app.** Verified against the running system:
    - **Leases + single-winner conflicts:** live. `surface_registry.ex:54-76` returns `{:error, :held_by_other}` to the loser; lease plane is the running `beam.smp` on `:8788`.
-   - **Revocation:** live **and enforced** — `POST /v1/lease/force-release` (`http_router.ex:205-227`) gated by a separate `LEASE_FORCE_RELEASE_TOKEN`; the regular bearer is barred. Evidence §1 below mis-frames revocation as a gap; it is already solved. *(Strike that framing.)*
+   - **Revocation:** live **and enforced** — `POST /v1/lease/force-release` (`http_router.ex:234-249`, token gate `:516-523`) gated by a separate `LEASE_FORCE_RELEASE_TOKEN`; the regular bearer is barred. Evidence §1 below mis-frames revocation as a gap; it is already solved. *(Strike that framing.)*
    - **Supervision / DynamicSupervisor / lease client:** already built in `elixir/agent_orchestrator/` (`agent_supervisor.ex`, `agent_runner.ex`, `lease_plane_client.ex`) — but **inert** (`:8789` not listening, no plist, nothing spawns through it). The "new governed-effect plane" is this app needing a plist + a caller, not a greenfield build. Do **not** create `elixir/governed_effect_plane/`.
 
 2. **Operator resolution of the execute/record fork: BEAM can do both, but the modes must be explicit.** This is no longer a binary choice. The protocol must carry a per-effect `custody_mode`:


### PR DESCRIPTION
Trivial doc fix surfaced by the live-verifier seat during the proprioception-case council pass (#906).

The dossier's Council Amendment cites `POST /v1/lease/force-release` at `http_router.ex:205-227`. Ground-truth against the running lease-plane source: the route is at **`:234-249`** (`post "/v1/lease/force-release"` at line 238; token gate at `:516-523`). `:205-227` is the regular `/v1/lease/release` route.

The surface is real and enforced — only the line-ref drifted. Fixed inline because it lives in the active amendment block (current-truth layer), not preserved-historical body text. No content/claim change.