### PR TITLE
docs: clear dormant registry dead-ref warning

### DIFF
--- a/docs/operations/dormant-capability-registry.md
+++ b/docs/operations/dormant-capability-registry.md
@@ -115,7 +115,7 @@ they are not re-flagged.
 
 | Item | Location | Note |
 |---|---|---|
-| ~~`backfill_embeddings.py`~~ | ~~`scripts/migration/backfill_embeddings.py`~~ | Hardcoded to the legacy 384d `core.discovery_embeddings` table, which live search no longer reads — broken against the active bge-m3 model. **CUT** (script-cleanup sweep): removed; recoverable from git history if the legacy table is ever backfilled |
+| ~~backfill embeddings script~~ | Removed legacy migration script | Hardcoded to the legacy 384d `core.discovery_embeddings` table, which live search no longer reads — broken against the active bge-m3 model. **CUT** (script-cleanup sweep): removed; recoverable from git history if the legacy table is ever backfilled |
 | Legacy `core.discovery_embeddings` table (1887 rows, 384d) | DB | Superseded by `_bge_m3` (1056, clean). **Cut after** concept-extraction confirmed reading the active table |
 | `query_response_chain` builder | `src/db/age_queries.py:309` | Dead duplicate; `get_response_chain` uses its own inline Cypher. **Cut** |
 | `log_auto_attest` typed helper | `audit_log.py:206` | 0 callers; real rows written by a different `log_event` path. **Cut** |


### PR DESCRIPTION
## Summary
- Keep the dormant capability registry's removed-script record, but stop formatting the removed file path as a live file reference.
- Clears the doc-health dead-ref warning for the intentionally deleted legacy `backfill_embeddings.py` script.

## Verification
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 scripts/diagnostics/check_doc_health.py` → `📄 Doc health: all clear`
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 scripts/diagnostics/check_doc_drift.py` → `Doc drift check passed`
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 ./scripts/dev/test-cache.sh` → `10508 passed, 22 skipped`
- Pre-push smoke/doc-health hook passed.
