### PR TITLE
test(beam): stabilize Wave 3a unwired handler checks

### DIFF
--- a/elixir/wave3a_handlers/test/handlers/health_check_test.exs
+++ b/elixir/wave3a_handlers/test/handlers/health_check_test.exs
@@ -108,11 +108,13 @@ defmodule Wave3aHandlers.Handlers.HealthCheckTest do
       assert body["status"] == "healthy"
       assert body["version"] == "0.42.0"
       assert body["redis_present"] == true
+
       assert body["status_breakdown"] == %{
                "healthy" => 7,
                "degraded" => 0,
                "failed" => 0
              }
+
       assert body["_note"] == "Use lite=false for full diagnostic detail"
       assert is_map(body["_cache"]), "_cache must surface through from the probe payload"
 
@@ -121,8 +123,10 @@ defmodule Wave3aHandlers.Handlers.HealthCheckTest do
       postgres = body["checks"]["postgres"]
       assert postgres["status"] == "healthy"
       assert postgres["mode"] == "executor_pool"
+
       refute Map.has_key?(postgres, "extra_diagnostic_field"),
              "lite filter MUST drop diagnostic fields not on the passthrough list"
+
       refute Map.has_key?(postgres, "details"),
              "lite filter MUST drop `details` (not on the passthrough list)"
 
@@ -141,6 +145,7 @@ defmodule Wave3aHandlers.Handlers.HealthCheckTest do
       # Verbatim passthrough — diagnostic fields are present.
       assert body["checks"]["postgres"]["extra_diagnostic_field"] ==
                "this is dropped by lite filter"
+
       assert body["checks"]["postgres"]["details"] == "connections=10"
       assert body["_cache"]["age_seconds"] == 15.2
     end
@@ -224,6 +229,7 @@ defmodule Wave3aHandlers.Handlers.HealthCheckTest do
       # 600ms upstream), the handler returns a typed envelope rather than
       # raising or hanging.
       stub_probe_ok(@probe_envelope)
+
       :meck.expect(Wave3aHandlers.ProbeClient, :health_snapshot, fn ->
         :timer.sleep(600)
         {:error, :timeout}
@@ -298,13 +304,15 @@ defmodule Wave3aHandlers.Handlers.HealthCheckTest do
       assert body["error"] == "probe_unavailable"
     end
 
-    test "other tool names still return the 501 envelope (only health_check is wired)" do
-      # Sanity that the dispatch table only wires `health_check` — every
-      # other tool name still goes through the 501 fallback. Subsequent
-      # PRs (#6, #7, #8) add their own clauses.
+    test "unwired tool names still return the 501 envelope" do
+      # Sanity that names absent from the dispatch table go through the 501
+      # fallback. Use a deliberately fake tool name so this test does not
+      # drift when future Wave 3a cutovers wire real handlers.
+      unwired_tool_name = "__unwired_tool_for_501_test__"
+
       resp =
         :post
-        |> conn("/v1/handlers/get_server_info", Jason.encode!(%{}))
+        |> conn("/v1/handlers/#{unwired_tool_name}", Jason.encode!(%{}))
         |> put_req_header("content-type", "application/json")
         |> authed()
         |> HTTPRouter.call(@opts)
@@ -312,7 +320,7 @@ defmodule Wave3aHandlers.Handlers.HealthCheckTest do
       assert resp.status == 501
       body = parsed(resp)
       assert body["error"] == "not_implemented"
-      assert body["tool_name"] == "get_server_info"
+      assert body["tool_name"] == unwired_tool_name
     end
   end
 end

--- a/elixir/wave3a_handlers/test/timeout_discipline_test.exs
+++ b/elixir/wave3a_handlers/test/timeout_discipline_test.exs
@@ -68,16 +68,16 @@ defmodule Wave3aHandlers.TimeoutDisciplineTest do
   end
 
   test "POST /v1/handlers/:tool_name 501 path is also well under 500ms" do
-    # The 501 path is the closest analog to PR #5's eventual happy-path
-    # dispatch — it goes through the full auth → parse → route → encode
-    # pipeline minus the probe call. PR #5 wired `health_check`, so this
-    # test uses `get_server_info` (next PR's target) as a stable unwired
-    # tool name. Steady-state should be in the single-digit ms range.
+    # The 501 path is the closest analog to a routed dispatch miss — it goes
+    # through the full auth → parse → route → encode pipeline minus any probe
+    # call. Use a deliberately fake tool name so the test remains stable as
+    # real Wave 3a handlers are wired.
+    unwired_tool_name = "__unwired_tool_for_latency_test__"
     body = Jason.encode!(%{})
 
     _ =
       :post
-      |> conn("/v1/handlers/get_server_info", body)
+      |> conn("/v1/handlers/#{unwired_tool_name}", body)
       |> put_req_header("content-type", "application/json")
       |> authed()
       |> HTTPRouter.call(@opts)
@@ -85,7 +85,7 @@ defmodule Wave3aHandlers.TimeoutDisciplineTest do
     {elapsed_us, resp} =
       :timer.tc(fn ->
         :post
-        |> conn("/v1/handlers/get_server_info", body)
+        |> conn("/v1/handlers/#{unwired_tool_name}", body)
         |> put_req_header("content-type", "application/json")
         |> authed()
         |> HTTPRouter.call(@opts)


### PR DESCRIPTION
## Summary
- Updates Wave 3a 501-path tests to use deliberately fake unwired tool names instead of `get_server_info`.
- Keeps the tests stable now that `get_server_info` is a real wired handler.
- Includes formatter-only cleanup produced by `mix format` for the touched Wave 3a test file.

## Verification
- `cd elixir/wave3a_handlers && mix format --check-formatted && mix compile --warnings-as-errors && mix test` → 53 tests, 0 failures
- Adjusted BEAM app gate:
  - `elixir/lease_plane`: `mix format --check-formatted && mix compile --warnings-as-errors && mix test` → 181 tests, 0 failures
  - `elixir/wave3a_handlers`: `mix format --check-formatted && mix compile --warnings-as-errors && mix test` → 53 tests, 0 failures
  - `elixir/sentinel`: `mix compile --warnings-as-errors && mix test` → 139 tests, 0 failures
  - `elixir/agent_orchestrator`: `mix deps.get && mix compile --warnings-as-errors && mix test` → 68 tests, 0 failures
- `git diff --check`

## Notes
- `sentinel` and `agent_orchestrator` currently do not have `.formatter.exs`; their local gates are compile/test rather than format-check.
