### PR TITLE
ops(lease-plane): self-heal deps on boot to prevent missing-deps crash-loop

### DIFF
--- a/elixir/lease_plane/scripts/start.sh
+++ b/elixir/lease_plane/scripts/start.sh
@@ -32,6 +32,20 @@ export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
 
 cd "$LEASE_PLANE_DIR"
 
+# --- Self-heal dependencies before boot ---
+# A long-lived VM masks an incomplete deps/ tree: the running node holds its
+# modules in memory, but a fresh `mix run` fails the dependency check and
+# crash-loops under launchd KeepAlive. 2026-06-19: plug/postgrex/plug_crypto
+# were absent from this deploy checkout's deps/ — invisible while the 4-day-old
+# VM ran (and while file-lease acquires silently failed open), and only surfaced
+# as a full outage on the next restart. Fetch deps here so a restart self-repairs
+# instead of crash-looping. Non-fatal on a transient fetch failure when deps are
+# already present; `mix run` below still fails loudly if they genuinely can't
+# load, so this never hides a real problem — it only closes the
+# missing-deps-on-restart trap.
+echo "[lease-plane] ensuring dependencies (mix deps.get)…" >&2
+mix deps.get >&2 || echo "[lease-plane] WARN: mix deps.get failed (offline?) — continuing with on-disk deps" >&2
+
 # --- Distributed node for BEAM hot-code-reload ---
 # When LEASE_PLANE_NODE_COOKIE is set (in secrets.env) we start the node
 # *named* + *cookied* so an operator can attach a remote shell or drive an


### PR DESCRIPTION
## What

The lease-plane launchd entrypoint (`elixir/lease_plane/scripts/start.sh`) exec'd `mix run --no-halt` directly. This adds a `mix deps.get` self-heal step before the exec.

## Why — 2026-06-19 incident

The lease plane (`:8788`) had been returning **HTTP 000 / `service_unavailable` on every real acquire for ~4 days**, silently — file-lease coordination was failing open the whole time, so nothing alerted.

Root cause: the **deploy checkout's** `deps/` was incomplete (missing `plug`, `postgrex`, `plug_crypto`, `thousand_island`). The long-lived VM had them resident in memory, but couldn't lazily load the `Plug.Exception` protocol → Bandit's error renderer itself crashed → connection reset. Reads/validation (422) worked because they don't touch the DB; only the acquire **write** path raised.

A restart then took it **fully down**: a fresh `mix run` fails the dependency check and crash-loops under KeepAlive — `mix run` compiles but does **not** fetch missing deps.

## Fix

Run `mix deps.get` in `start.sh` before exec, so a restart self-repairs instead of crash-looping. Non-fatal on a transient fetch failure when deps already exist (`|| WARN`); `mix run` below still fails loudly if deps genuinely can't load, so it never hides a real problem — it only closes the missing-deps-on-restart trap.

`bash -n` clean. The running service is already healed manually (deps fetched + restarted; acquires verified `{"ok":true}`); this prevents recurrence. The deploy checkout picks it up on its next master sync.

## Follow-up (not in this PR)

A **synthetic-acquire health check + alert** — a periodic real acquire that pages on failure. fail-open means "process up" ≠ "working"; an end-to-end probe is the only thing that catches a silent acquire outage like this one.