### PR TITLE
ops(lease-plane): synthetic end-to-end acquire health check + alert

### DIFF
--- a/elixir/lease_plane/scripts/ops/com.unitares.lease-plane-acquire-healthcheck.plist.template
+++ b/elixir/lease_plane/scripts/ops/com.unitares.lease-plane-acquire-healthcheck.plist.template
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Synthetic end-to-end ACQUIRE health check for the Surface Lease Plane.
+
+    Runs lease_plane_acquire_healthcheck.sh every 5 minutes: a REAL
+    acquire+release round-trip against the running plane, alerting (→
+    /tmp/unitares_alerts.log) after MAX_FAILURES consecutive failures. This
+    catches the silent fail-open acquire-outage class that a liveness /health
+    ping cannot — see the 2026-06-19 incident, where acquires returned HTTP 000
+    for ~4 days while "process up" stayed green and the file-lease hook failed
+    open with no alert.
+
+    Before installing, substitute the placeholder:
+      __UNITARES_ROOT__ → absolute path to the deploy checkout
+                          (the same root the lease-plane plist runs from,
+                          e.g. $HOME/projects/unitares-deploy)
+
+    Example:
+      mkdir -p "$HOME/projects/unitares-deploy/data/logs"
+      sed -e "s|__UNITARES_ROOT__|$HOME/projects/unitares-deploy|g" \
+          elixir/lease_plane/scripts/ops/com.unitares.lease-plane-acquire-healthcheck.plist.template \
+          > ~/Library/LaunchAgents/com.unitares.lease-plane-acquire-healthcheck.plist
+      launchctl load ~/Library/LaunchAgents/com.unitares.lease-plane-acquire-healthcheck.plist
+
+    The check reads LEASE_PLANE_BEARER_TOKEN from ~/.config/cirwel/secrets.env
+    itself, so no secret is placed in this plist.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.unitares.lease-plane-acquire-healthcheck</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__UNITARES_ROOT__/elixir/lease_plane/scripts/ops/lease_plane_acquire_healthcheck.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__UNITARES_ROOT__</string>
+
+    <key>StartInterval</key>
+    <integer>300</integer>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>__UNITARES_ROOT__/data/logs/lease_plane_acquire_healthcheck.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__UNITARES_ROOT__/data/logs/lease_plane_acquire_healthcheck.log</string>
+</dict>
+</plist>

--- a/elixir/lease_plane/scripts/ops/lease_plane_acquire_healthcheck.sh
+++ b/elixir/lease_plane/scripts/ops/lease_plane_acquire_healthcheck.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Synthetic end-to-end ACQUIRE health check for the Surface Lease Plane.
+#
+# Why this exists, separate from a /health liveness ping: the lease plane can be
+# "process up" (liveness 200) while every real acquire silently fails. That is
+# exactly the 2026-06-19 outage — acquires returned HTTP 000 for ~4 days because
+# the deploy checkout's deps/ was incomplete (plug/postgrex missing), and the
+# file-lease hook fails OPEN, so nothing alerted. "Process up" != "working".
+#
+# This does a REAL acquire + release round-trip against the running plane and
+# alerts when that round-trip breaks — the one signal a liveness ping cannot
+# give. Scheduled one-shot (see com.unitares.lease-plane-acquire-healthcheck.
+# plist.template); consecutive-failure state persists across runs so a single
+# transient blip never pages — it alerts only after MAX_FAILURES in a row, and
+# emits a one-shot RECOVERED note when it comes back.
+#
+# Alert sink matches scripts/ops/monitor_health.sh: a line appended to
+# $UNITARES_ALERT_LOG (default /tmp/unitares_alerts.log) and stderr.
+
+# NOT `set -e`: curl/probe failures are handled explicitly via fail(), which must
+# still update state and alert rather than abort on the first non-zero command.
+set -uo pipefail
+
+BASE_URL="${LEASE_PLANE_BASE_URL:-http://127.0.0.1:8788}"
+SECRETS_FILE="${UNITARES_SECRETS_ENV:-$HOME/.config/cirwel/secrets.env}"
+STATE_FILE="${LEASE_PLANE_HEALTHCHECK_STATE:-$HOME/.unitares/lease-plane-healthcheck.state}"
+ALERT_LOG="${UNITARES_ALERT_LOG:-/tmp/unitares_alerts.log}"
+MAX_FAILURES="${MAX_FAILURES:-2}"
+TIMEOUT_S="${HEALTHCHECK_TIMEOUT_S:-5}"
+# A dedicated probe surface in /tmp — never a real file, so the check can never
+# collide with a genuine holder. TTL is short so a crash mid-probe self-reaps.
+SURFACE="${HEALTHCHECK_SURFACE:-file:///tmp/lease-plane-acquire-healthcheck}"
+# Any valid UUID; fixed so repeated probes are idempotent on the same holder.
+HOLDER_UUID="${HEALTHCHECK_HOLDER_UUID:-11111111-1111-1111-1111-111111111111}"
+
+ts() { date '+%Y-%m-%d %H:%M:%S'; }
+
+read_failcount() {
+  local n
+  n="$(cat "$STATE_FILE" 2>/dev/null || echo 0)"
+  case "$n" in (*[!0-9]*|"") n=0 ;; esac   # sanitize to a non-negative integer
+  printf '%s' "$n"
+}
+write_failcount() { mkdir -p "$(dirname "$STATE_FILE")" 2>/dev/null || true; printf '%s' "$1" >"$STATE_FILE" 2>/dev/null || true; }
+
+alert() { echo "[$(ts)] ALERT: $1" | tee -a "$ALERT_LOG" >&2; }
+
+fail() {
+  local n; n=$(( $(read_failcount) + 1 ))
+  write_failcount "$n"
+  echo "[$(ts)] lease-plane acquire probe FAILED ($n/$MAX_FAILURES): $1" >&2
+  if [ "$n" -ge "$MAX_FAILURES" ]; then
+    alert "lease plane synthetic acquire failing ${n}x consecutively ($BASE_URL): $1 — file-lease coordination is degraded and failing OPEN. Check deps in unitares-deploy/elixir/lease_plane and ~/Library/Logs/unitares-lease-plane.log"
+  fi
+  exit 1
+}
+
+# Pull only the bearer token from secrets (subshell so nothing else leaks).
+TOKEN="$( ( [ -f "$SECRETS_FILE" ] && set -a && . "$SECRETS_FILE" >/dev/null 2>&1; printf '%s' "${LEASE_PLANE_BEARER_TOKEN:-}" ) || true )"
+[ -z "$TOKEN" ] && fail "no LEASE_PLANE_BEARER_TOKEN in $SECRETS_FILE"
+
+# --- end-to-end probe: acquire -> assert ok -> release ---
+body=$(printf '{"surface_id":"%s","holder_agent_uuid":"%s","holder_kind":"remote_heartbeat","ttl_s":30,"holder_class":"process_instance","holder_pid":"%s","intent":"healthcheck","audit_session":"healthcheck"}' "$SURFACE" "$HOLDER_UUID" "$$")
+
+resp=$(curl -s --max-time "$TIMEOUT_S" -w $'\n%{http_code}' \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -X POST "$BASE_URL/v1/lease/acquire" -d "$body" 2>/dev/null)
+code=$(printf '%s' "$resp" | tail -1)
+json=$(printf '%s' "$resp" | sed '$d')
+
+[ "$code" = "200" ] || fail "acquire HTTP=$code (expected 200; 000=connection reset/crash, 503=fail-closed auth)"
+
+ok=$(printf '%s' "$json" | python3 -c "import sys,json; print(json.load(sys.stdin).get('ok'))" 2>/dev/null || echo "parse_error")
+[ "$ok" = "True" ] || fail "acquire ok=$ok body=$(printf '%s' "$json" | head -c 140)"
+
+lease_id=$(printf '%s' "$json" | python3 -c "import sys,json; print(json.load(sys.stdin).get('lease',{}).get('lease_id',''))" 2>/dev/null || echo "")
+
+# Release best-effort — a release hiccup is not a health failure (the 30s TTL
+# reaps the probe lease either way).
+[ -n "$lease_id" ] && curl -s --max-time "$TIMEOUT_S" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -X POST "$BASE_URL/v1/lease/release" -d "{\"lease_id\":\"$lease_id\"}" >/dev/null 2>&1
+
+prev=$(read_failcount)
+write_failcount 0
+if [ "$prev" -ge "$MAX_FAILURES" ]; then
+  alert "RECOVERED: lease plane synthetic acquire succeeding again after $prev consecutive failures"
+fi
+echo "[$(ts)] lease-plane acquire probe OK (lease_id=${lease_id:-?})"
+exit 0

--- a/elixir/lease_plane/scripts/ops/lease_plane_acquire_healthcheck.sh
+++ b/elixir/lease_plane/scripts/ops/lease_plane_acquire_healthcheck.sh
@@ -32,6 +32,11 @@ TIMEOUT_S="${HEALTHCHECK_TIMEOUT_S:-5}"
 SURFACE="${HEALTHCHECK_SURFACE:-file:///tmp/lease-plane-acquire-healthcheck}"
 # Any valid UUID; fixed so repeated probes are idempotent on the same holder.
 HOLDER_UUID="${HEALTHCHECK_HOLDER_UUID:-11111111-1111-1111-1111-111111111111}"
+# Governance HTTP API — POST /api/findings emits into the event ring buffer the
+# Discord bridge polls; a `*_finding` at severity=critical pages the bridge's
+# #alerts channel. Best-effort surfacing on top of the always-written log; the
+# log stays the floor in case governance itself is down.
+GOV_API_URL="${UNITARES_GOVERNANCE_HTTP_URL:-http://127.0.0.1:8767}"
 
 ts() { date '+%Y-%m-%d %H:%M:%S'; }
 
@@ -45,18 +50,47 @@ write_failcount() { mkdir -p "$(dirname "$STATE_FILE")" 2>/dev/null || true; pri
 
 alert() { echo "[$(ts)] ALERT: $1" | tee -a "$ALERT_LOG" >&2; }
 
+# Surface to Discord via the governance event ring buffer (the bridge polls it).
+# Best-effort: a failure here never affects the check's exit status — the log
+# line above already recorded the alert. fingerprint dedupes, so a persistent
+# outage pages #alerts once, not every interval. $HTTP_API_TOKEN may be empty
+# (the API is open on localhost when no token is configured).
+post_finding() {
+  local severity="$1" fingerprint="$2" message="$3"
+  local payload
+  payload=$(python3 -c '
+import json,sys
+print(json.dumps({
+  "type": "lease_plane_health_finding",
+  "severity": sys.argv[1],
+  "message": sys.argv[2],
+  "agent_id": "lease-plane-healthcheck",
+  "agent_name": "lease-plane-healthcheck",
+  "fingerprint": sys.argv[3],
+}))' "$severity" "$message" "$fingerprint" 2>/dev/null) || return 0
+  curl -s --max-time "$TIMEOUT_S" -o /dev/null \
+    ${HTTP_API_TOKEN:+-H "Authorization: Bearer $HTTP_API_TOKEN"} \
+    -H "Content-Type: application/json" \
+    -X POST "$GOV_API_URL/api/findings" -d "$payload" 2>/dev/null || true
+}
+
 fail() {
   local n; n=$(( $(read_failcount) + 1 ))
   write_failcount "$n"
   echo "[$(ts)] lease-plane acquire probe FAILED ($n/$MAX_FAILURES): $1" >&2
   if [ "$n" -ge "$MAX_FAILURES" ]; then
-    alert "lease plane synthetic acquire failing ${n}x consecutively ($BASE_URL): $1 — file-lease coordination is degraded and failing OPEN. Check deps in unitares-deploy/elixir/lease_plane and ~/Library/Logs/unitares-lease-plane.log"
+    local msg="lease plane synthetic acquire failing ${n}x consecutively ($BASE_URL): $1 — file-lease coordination is degraded and failing OPEN. Check deps in unitares-deploy/elixir/lease_plane and ~/Library/Logs/unitares-lease-plane.log"
+    alert "$msg"
+    post_finding "critical" "lease-plane-acquire-outage" "$msg"
   fi
   exit 1
 }
 
-# Pull only the bearer token from secrets (subshell so nothing else leaks).
+# Pull the bearer tokens from secrets (subshell so nothing else leaks). The
+# lease bearer authenticates the probe; the HTTP API token (optional — the API
+# is open on localhost without one) authenticates the Discord-surfacing finding.
 TOKEN="$( ( [ -f "$SECRETS_FILE" ] && set -a && . "$SECRETS_FILE" >/dev/null 2>&1; printf '%s' "${LEASE_PLANE_BEARER_TOKEN:-}" ) || true )"
+HTTP_API_TOKEN="$( ( [ -f "$SECRETS_FILE" ] && set -a && . "$SECRETS_FILE" >/dev/null 2>&1; printf '%s' "${UNITARES_HTTP_API_TOKEN:-}" ) || true )"
 [ -z "$TOKEN" ] && fail "no LEASE_PLANE_BEARER_TOKEN in $SECRETS_FILE"
 
 # --- end-to-end probe: acquire -> assert ok -> release ---
@@ -84,7 +118,11 @@ lease_id=$(printf '%s' "$json" | python3 -c "import sys,json; print(json.load(sy
 prev=$(read_failcount)
 write_failcount 0
 if [ "$prev" -ge "$MAX_FAILURES" ]; then
-  alert "RECOVERED: lease plane synthetic acquire succeeding again after $prev consecutive failures"
+  rec="RECOVERED: lease plane synthetic acquire succeeding again after $prev consecutive failures"
+  alert "$rec"
+  # severity=info: shows in the bridge's event feed to close the loop, without
+  # re-paging #alerts (only critical / *_finding-high page).
+  post_finding "info" "lease-plane-acquire-recovery" "$rec"
 fi
 echo "[$(ts)] lease-plane acquire probe OK (lease_id=${lease_id:-?})"
 exit 0


### PR DESCRIPTION
## What

A scheduled **real acquire+release probe** against the running lease plane, plus a launchd template to run it every 5 min. Companion to #910.

## Why — "process up" ≠ "working"

The 2026-06-19 incident: the lease plane returned **HTTP 000 on every real acquire for ~4 days**, but the process stayed up and a `/health` liveness ping would have read OK. The file-lease hook **fails open**, so file-lease coordination was silently degraded and *nothing alerted*. The existing `scripts/ops/monitor_health.sh` checks liveness (`/health` 200) — exactly the signal that stayed green through the outage.

Only an **end-to-end acquire** catches this. This probe does the real round-trip and alerts when it breaks.

## `lease_plane_acquire_healthcheck.sh`

- Acquires a dedicated `/tmp` probe surface, asserts `{"ok":true}`, releases it (30s TTL reaps the probe lease if the script dies mid-run).
- **Consecutive-failure state** persists across runs (`~/.unitares/lease-plane-healthcheck.state`) so a single transient blip never pages — alerts only after `MAX_FAILURES` (default 2) in a row, with a one-shot **RECOVERED** note when it comes back.
- Alert sink matches `monitor_health.sh`: a line appended to `$UNITARES_ALERT_LOG` (default `/tmp/unitares_alerts.log`) + stderr.
- Reads `LEASE_PLANE_BEARER_TOKEN` from `secrets.env` itself — **no secret in any committed file**.

## Verification

- Success path: acquires + releases, exit 0 (`lease_id` logged). Idempotent across runs.
- Failure path: against a dead port → `FAILED (1/2)`, then `FAILED (2/2)` **+ ALERT** with an actionable message (points at the deps + the plane log). This is the exact `HTTP 000` signature the real outage produced.
- `bash -n` clean; plist lints clean (`plutil -lint`).

## Install (operator)

```
mkdir -p ~/projects/unitares-deploy/data/logs
sed -e "s|__UNITARES_ROOT__|$HOME/projects/unitares-deploy|g" \
    elixir/lease_plane/scripts/ops/com.unitares.lease-plane-acquire-healthcheck.plist.template \
    > ~/Library/LaunchAgents/com.unitares.lease-plane-acquire-healthcheck.plist
launchctl load ~/Library/LaunchAgents/com.unitares.lease-plane-acquire-healthcheck.plist
```

## Together with #910

- **#910** (boot-time `mix deps.get`) — *prevents* the missing-deps crash-loop.
- **this** — *detects* the silent fail-open acquire degradation. The alert sink is a log file today; wiring it to the Discord bridge is a natural follow-up.