### PR TITLE
docs(proposals): index two live-but-unindexed proposals

### DIFF
--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -44,6 +44,7 @@ The ADR-001 thread: do not enable operator-vision delegation as first proposed; 
 | [`uuid-keyed-identity-migration-v0.md`](uuid-keyed-identity-migration-v0.md) | v0 proposal / design-only (2026-06-14) — make the UUID the sole identity key, reconciling schema with the ontology |
 | [`discord-thread-identity-resume-v0.md`](discord-thread-identity-resume-v0.md) | Reference decision record — Discord BEAM thread resume-per-thread plumbing; orchestrator + reference-hook side merged (#834), fail-closed/cross-repo follow-ups tracked separately |
 | [`principal-rollup-v0.md`](principal-rollup-v0.md) | v0 proposal (2026-06-18) — count the **principal** (logical worker) not the process-instance; first-class form of identity.md research #3 ("identity as integral, not point-value"). Measurement shipped (`scripts/dev/octopus_rollup.py`); count/mint changes operator-gated. Sits atop `uuid-keyed-identity-migration` |
+| [`orchestrator-vouched-identity-v0.md`](orchestrator-vouched-identity-v0.md) | DESIGN-FIRST RFC, council-reviewed 2026-06-17 — earn a genuine `strong` tier for orchestrated headless children (the deferred follow-on to resume-per-thread). Gate artifact for the 2026-06-24 Wave-3 read; no live cutover |
 
 ### Other active
 
@@ -53,6 +54,7 @@ The ADR-001 thread: do not enable operator-vision delegation as first proposed; 
 | [`operator-decision-packet-v0.md`](operator-decision-packet-v0.md) | v1 design — making load-bearing taste/authority/irreversible calls cheap to answer (decision-packet output contract; council pass live, dialectic `ESCALATE`/`design_review` are latent unwired scaffolds). Council-passed to v1 2026-06-17; design-first, no code |
 | [`mirror-effectiveness-measurement-v0.md`](mirror-effectiveness-measurement-v0.md) | Phases 0–1 landed (Phase 2 proposed) — deterministic, operator-funded-free measurement of whether a surfaced mirror signal changes agent behavior |
 | [`hosted-multi-tenant-endpoint-v0.md`](hosted-multi-tenant-endpoint-v0.md) | Scoping / not committed — hosted governance endpoint decision doc; recommends isolated-per-adopter hosting first and defers true multi-tenant SaaS |
+| [`dashboard-hero-severity-rollup.md`](dashboard-hero-severity-rollup.md) | Draft (2026-06-19) — fleet-severity rollup into the dashboard hero; `dashboard/` only, awaiting operator sign-off before implementation |
 
 ## Shipped / resolved
 


### PR DESCRIPTION
Doc-health sweep (prompted by 'too many docs / stale cleanup'). Finding: the proposals folder isn't rotting — **0 dead docs**, only **2 orphans missing from the index**, both live:

- `orchestrator-vouched-identity-v0.md` — council-reviewed RFC, gate artifact for the 2026-06-24 Wave-3 read, referenced by the resume-per-thread doc.
- `dashboard-hero-severity-rollup.md` — draft dated today, awaiting operator sign-off.

Adds both to the README index. No docs removed (dated proposals are preserved-by-design). Closes the orphan gap → every proposal is now indexed.