### PR TITLE
Dashboard redesign reference (design-system-first, on the side)

### DIFF
--- a/dashboard/eslint.config.mjs
+++ b/dashboard/eslint.config.mjs
@@ -13,8 +13,9 @@ export default [
     },
     js.configs.recommended,
     {
-        // Browser source modules.
-        files: ['*.js'],
+        // Browser source modules — top-level dashboard scripts plus the
+        // buildless redesign reference (same global-IIFE style, not the Vite app).
+        files: ['*.js', 'redesign/**/*.js'],
         ignores: ['*.config.js', 'src/**'],
         languageOptions: {
             ecmaVersion: 2022,

--- a/dashboard/redesign/PLAN.md
+++ b/dashboard/redesign/PLAN.md
@@ -1,0 +1,59 @@
+# Dashboard Redesign — Plan & Decisions
+
+**Branch:** `claude/dashboard-redesign-reference`
+**Status:** reference built (landing surface), kit not yet extracted. On the side; live dashboard untouched.
+**Approach:** design-system-first *strangler* reskin — NOT a rewrite. Old dashboard stays live and serves as the oracle.
+
+## Why not a rewrite
+
+The live dashboard is load-bearing (operator watches Sentinel/Vigil/fleet/identity through it) and its
+~17.4k lines of JS encode months of discovered real states. A big-bang rewrite would drop those lessons and
+risk a dark cutover. Instead: introduce a token + primitive design layer, then convert one nav section at a
+time behind the existing nav. Old and new coexist; each increment ships independently.
+
+## The old dashboard is the oracle (robustness method)
+
+Its accreted special-cases ARE the spec. For each section migrated:
+1. Read the OLD JS for every state branch it handles (dark residents, silence detection, tight-margin
+   verdicts, lineage/supersession badges, the 4x-broken Fleet Metrics panel, etc.) — mine edge cases, not
+   the happy path.
+2. Reproduce each state in the new component.
+3. Diff the new render against the live panel on real data before the increment lands.
+The old code's special-cases are the regression suite; robustness is inherited, not re-derived.
+
+## Locked decisions
+
+- **Theme:** `ink` (dark) default; `paper` (light) first-class via toggle. Default flips in one token line.
+- **Accent:** clay (`--accent`: #d97757 ink / #b8502e paper) — the only accent; everything else neutral.
+- **Type:** Fraunces (display serif) · Inter (UI) · Geist Mono (data/numbers, tabular figures).
+- **Buildless:** prod serves raw HTML/CSS/JS from `dashboard/`. Redesign matches — plain CSS tokens + small
+  JS primitives, no framework, no Vite-bundle in the serving path. (Vite/vitest stay for local dev/CI only.)
+- **EISV/semantic color is data-only**, desaturated — never decoration. Neutral base carries the layout.
+- **Migration unit:** one nav section = one draft PR, validated against the live panel first.
+
+## Design layer (this dir)
+
+- `tokens.css` — the system. One calm base, one accent, semantic data-hues, two themes via `[data-theme]`.
+  Replaces the role of the 5,877-line `styles.css`.
+- `preview.html` — landing reference (residents strip + stats grid + Pulse) on a real fleet snapshot.
+  Component CSS is inline here; it gets extracted into the primitive kit in increment 1.
+
+## Primitive kit (to extract in increment 1)
+
+Card/Stat · Panel · EISVMeter · ResidentChip · VerdictBadge · AttentionBand · Track/Bar · eyebrow label.
+
+## Increment order (risk-ascending)
+
+1. **Landing** — Stats grid + Pulse + residents strip (reference done; extract kit, wire to live data).
+2. **Agents** — table, filters, pagination, trust tiers, lineage/lifecycle badges.
+3. **Discoveries** — KG list + filters + status actions.
+4. **Dialectic** — sessions, phase/status counts, transcripts.
+5. **Activity** — unified timeline.
+6. **EISV charts** — Chart.js dark-theme tokens (the fragile part; on a proven kit).
+7. **Resident panels** — Watcher / Sentinel / Vigil / Chronicler / System Health + `/phase` (D3).
+
+## Conventions to honor (from the unitares-dashboard skill)
+
+- Script-load chain order in `index.html`; `authFetch` bearer-token helper; `DashboardAPI.callTool` →
+  `/v1/tools/call`; `.panel` layout contract; Chart.js dark-theme defaults; file allowlist for served assets.
+- Operator write actions need `X-Unitares-Operator` token under STRICT_IDENTITY (#425); reads don't.

--- a/dashboard/redesign/app.html
+++ b/dashboard/redesign/app.html
@@ -1,0 +1,158 @@
+<!doctype html>
+<html lang="en" data-theme="ink">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>UNITARES · Governance</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Inter:wght@400;500;600&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="./tokens.css" />
+<link rel="stylesheet" href="./kit.css" />
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+</head>
+<body>
+<div class="wrap">
+
+  <header class="topbar">
+    <span class="brand">UNITARES<span class="dot">.</span></span>
+    <span class="brand-sub">Governance</span>
+    <span class="spring"></span>
+    <span class="server-stat" id="serverStat">—</span>
+    <button class="theme-toggle" id="themeBtn">◑ paper</button>
+  </header>
+
+  <nav class="nav" id="nav">
+    <a href="#overview" class="active" data-section="overview">Overview</a>
+    <a href="#agents" data-section="agents">Agents</a>
+    <a href="#discoveries" data-section="discoveries">Discoveries</a>
+    <a href="#dialectic" data-section="dialectic">Dialectic</a>
+    <a href="#activity" data-section="activity">Activity</a>
+    <a href="#eisv" data-section="eisv">EISV</a>
+    <a href="#residents" data-section="residents">Residents</a>
+  </nav>
+
+  <main id="main">
+    <!-- Overview (increment 1) -->
+    <section class="section" data-pane="overview">
+      <div class="eyebrow">Resident Fleet <span class="src-badge" id="resSrc"></span></div>
+      <div class="residents" id="residents"></div>
+      <div class="attn-band" id="attn" hidden></div>
+      <div class="grid" id="stats" style="margin-bottom:var(--space-7)"></div>
+
+      <section class="panel">
+        <div class="panel-head">
+          <h2>Pulse</h2><span class="who" id="pulseWho">—</span>
+          <span class="spring"></span>
+          <span class="verdict" id="pulseVerdict"><span class="pip"></span><span>—</span></span>
+          <span class="fresh" id="pulseFresh"></span>
+        </div>
+        <div style="display:grid;grid-template-columns:1.4fr 1fr;gap:var(--space-7);align-items:center" id="pulseMain">
+          <div>
+            <div class="risk-label"><span class="k">Risk</span><span class="v" id="riskVal">—</span></div>
+            <div class="track"><div class="fill" id="riskFill" style="width:0%"></div></div>
+            <div class="ticks">
+              <span style="left:35%">approve</span><span style="left:60%">proceed</span><span style="left:70%">pause</span>
+            </div>
+          </div>
+          <div class="eisv" id="eisv"></div>
+        </div>
+      </section>
+    </section>
+
+    <!-- Agents (increment 2) -->
+    <section class="section" data-pane="agents" hidden>
+      <h2 class="section-title">Agents</h2>
+      <div id="ag-mount"><p class="empty">loading…</p></div>
+    </section>
+
+    <!-- Discoveries (increment 3) -->
+    <section class="section" data-pane="discoveries" hidden>
+      <h2 class="section-title">Discoveries</h2>
+      <div id="dsc-mount"><p class="empty">loading…</p></div>
+    </section>
+
+    <!-- Dialectic (increment 4) -->
+    <section class="section" data-pane="dialectic" hidden>
+      <h2 class="section-title">Dialectic</h2>
+      <div id="dlc-mount"><p class="empty">loading…</p></div>
+    </section>
+
+    <!-- Activity (increment 5) -->
+    <section class="section" data-pane="activity" hidden>
+      <h2 class="section-title">Activity</h2>
+      <div id="act-mount"><p class="empty">loading…</p></div>
+    </section>
+
+    <!-- Sections built in later increments -->
+    <section class="section" data-pane="eisv" hidden>
+      <h2 class="section-title">EISV</h2>
+      <div id="eisv-mount"><p class="empty">loading…</p></div>
+    </section>
+    <section class="section" data-pane="residents" hidden>
+      <h2 class="section-title">Residents</h2>
+      <div id="res-mount"><p class="empty">loading…</p></div>
+    </section>
+  </main>
+
+  <p class="footnote" id="foot"></p>
+</div>
+
+<script src="./snapshot.js"></script>
+<script src="./data.js"></script>
+<script src="./sections/landing.js"></script>
+<script src="./sections/agents.js"></script>
+<script src="./sections/discoveries.js"></script>
+<script src="./sections/dialectic.js"></script>
+<script src="./sections/activity.js"></script>
+<script src="./sections/eisv.js"></script>
+<script src="./sections/residents.js"></script>
+<script>
+// theme toggle
+const themeBtn = document.getElementById("themeBtn");
+const qp = new URLSearchParams(location.search).get("theme");
+if (qp === "ink" || qp === "paper") document.documentElement.setAttribute("data-theme", qp);
+function syncThemeLabel() {
+  themeBtn.textContent = document.documentElement.getAttribute("data-theme") === "ink" ? "◑ paper" : "◐ ink";
+}
+syncThemeLabel();
+themeBtn.onclick = () => {
+  const ink = document.documentElement.getAttribute("data-theme") === "ink";
+  document.documentElement.setAttribute("data-theme", ink ? "paper" : "ink");
+  syncThemeLabel();
+  if (window.EISV && window.EISV.retheme) window.EISV.retheme();
+};
+
+// section switch
+const nav = document.getElementById("nav");
+nav.addEventListener("click", (e) => {
+  const a = e.target.closest("a[data-section]");
+  if (!a) return;
+  e.preventDefault();
+  const id = a.dataset.section;
+  nav.querySelectorAll("a").forEach((x) => x.classList.toggle("active", x === a));
+  document.querySelectorAll("[data-pane]").forEach((p) => { p.hidden = p.dataset.pane !== id; });
+  lazyLoad(id);
+});
+
+const loaded = {};
+function lazyLoad(id) {
+  if (loaded[id]) return;
+  if (id === "agents" && window.Agents) { loaded[id] = true; window.Agents.load(); }
+  if (id === "discoveries" && window.Discoveries) { loaded[id] = true; window.Discoveries.load(); }
+  if (id === "dialectic" && window.Dialectic) { loaded[id] = true; window.Dialectic.load(); }
+  if (id === "activity" && window.Activity) { loaded[id] = true; window.Activity.load(); }
+  if (id === "eisv" && window.EISV) { loaded[id] = true; window.EISV.load(); }
+  if (id === "residents" && window.Residents) { loaded[id] = true; window.Residents.load(); }
+}
+
+// boot
+window.Landing.render();
+(function openFromHash() {
+  const id = (location.hash || "").replace("#", "");
+  const link = id && nav.querySelector(`a[data-section="${id}"]`);
+  if (link) link.click();
+})();
+</script>
+</body>
+</html>

--- a/dashboard/redesign/data.js
+++ b/dashboard/redesign/data.js
@@ -1,0 +1,211 @@
+/*
+ * Data layer — live-or-snapshot.
+ * --------------------------------------------------------
+ * Each accessor tries the live governance endpoint (same helpers the
+ * production dashboard uses: bearer-token authFetch for REST, callTool
+ * for /v1/tools/call) and falls back to the bundled SNAPSHOT when the
+ * call fails or returns nothing (e.g. opened as a file, cross-origin, or
+ * server down). Views never touch fetch directly — they await these and
+ * read `.source` ('live' | 'snapshot') to badge freshness.
+ *
+ * This is the ONE seam between "renders portably now" and "wired to live
+ * when served same-origin." No view changes when the seam flips.
+ */
+(function () {
+  "use strict";
+
+  function token() {
+    try {
+      const u = new URLSearchParams(location.search).get("token");
+      return u || localStorage.getItem("unitares_api_token") || null;
+    } catch (_) { return null; }
+  }
+
+  async function authFetch(path, opts) {
+    opts = opts || {};
+    const headers = Object.assign({}, opts.headers);
+    const t = token();
+    if (t) headers["Authorization"] = "Bearer " + t;
+    const r = await fetch(path, Object.assign({}, opts, { headers }));
+    if (!r.ok) throw new Error(path + " -> " + r.status);
+    return r.json();
+  }
+
+  async function callTool(name, args) {
+    const body = JSON.stringify({ name, arguments: args || {} });
+    const j = await authFetch("/v1/tools/call", {
+      method: "POST", headers: { "Content-Type": "application/json" }, body,
+    });
+    return j.result !== undefined ? j.result : j;
+  }
+
+  // wrap an accessor so any failure degrades to snapshot, tagged.
+  async function withFallback(liveFn, snapFn) {
+    try {
+      const v = await liveFn();
+      if (v == null) throw new Error("empty");
+      return { source: "live", data: v };
+    } catch (_) {
+      return { source: "snapshot", data: snapFn() };
+    }
+  }
+
+  const S = () => window.SNAPSHOT;
+
+  const DATA = {
+    async health() {
+      return withFallback(async () => {
+        const h = await authFetch("/health");
+        return { version: h.version, uptime: h.uptime && h.uptime.formatted, db: h.database && h.database.status };
+      }, () => S().health);
+    },
+
+    async residents() {
+      return withFallback(async () => {
+        const j = await authFetch("/v1/residents");
+        if (!j || !j.residents) return null;
+        return j.residents.map((r) => ({
+          name: r.label, status: r.status, coherence: r.coherence, risk: r.risk_score,
+          verdict: r.verdict, eisv: r.eisv, silence: r.silence_seconds,
+          silenceThreshold: r.silence_threshold_seconds,
+        }));
+      }, () => S().residents);
+    },
+
+    // Stats are several tool calls in the real dashboard; snapshot until each is wired.
+    async stats() {
+      return withFallback(async () => null, () => S().stats);
+    },
+
+    async agents() {
+      return withFallback(async () => {
+        const r = await callTool("agent", {
+          action: "list", include_metrics: true, recent_days: 14, limit: 200, status_filter: "all", grouped: true,
+        });
+        if (!r || !r.agents) return null;
+        const groups = r.agents;
+        const flat = [];
+        Object.keys(groups).forEach((status) => {
+          (groups[status] || []).forEach((a) => {
+            const m = a.metrics || {};
+            flat.push({
+              agent_id: a.agent_id, label: a.label, status: a.lifecycle_status || a.status || status,
+              tier: typeof a.trust_tier === "string" ? a.trust_tier : a.trust_tier, updates: a.total_updates || 0,
+              last: a.last_update || a.created, purpose: a.purpose, tags: a.tags || [],
+              event_driven: a.event_driven === true, health: a.health_status,
+              redacted: a.agent_id_redacted === true, parent: a.parent_agent_id,
+              superseded: a.superseded === true, lifecycleReason: a.last_lifecycle_reason,
+              metrics: { coherence: m.coherence, risk: m.risk_score, verdict: m.verdict, E: m.E, I: m.I, S: m.S, V: m.V },
+            });
+          });
+        });
+        const s = r.summary || {};
+        return {
+          list: flat,
+          summary: { total: s.total, active: (s.by_status || {}).active, archived: (s.by_status || {}).archived,
+            paused: (s.by_status || {}).paused, participated: s.participated, neverParticipated: s.never_participated },
+        };
+      }, () => ({ list: S().agentsList, summary: S().agentsSummary }));
+    },
+
+    async discoveries(query) {
+      return withFallback(async () => {
+        const r = await callTool("knowledge", query
+          ? { action: "search", query, include_details: true, limit: 30 }
+          : { action: "search", query: "governance identity calibration", include_details: true, limit: 30 });
+        const items = r.discoveries || r.results || (Array.isArray(r) ? r : null);
+        if (!items) return null;
+        const list = items.map((d) => ({
+          id: d.id || d.created_at || d.timestamp, type: d.type || d.discovery_type || "note",
+          status: d.status || "open", by: d.by || d.agent_id || d._agent_id, tags: d.tags || [],
+          summary: d.summary || "Untitled", details: d.details || d.content || d.discovery || "",
+          stale: !!d.staleness_warning,
+        }));
+        return { list, total: r.total, byType: null, byStatus: null };
+      }, () => {
+        const d = S().discoveries;
+        return { list: d.list, total: d.total, byType: d.byType, byStatus: d.byStatus };
+      });
+    },
+
+    async dialectic() {
+      return withFallback(async () => {
+        const r = await callTool("dialectic", { action: "list", limit: 50 });
+        if (!r || !r.sessions) return null;
+        const sessions = r.sessions.map((s) => ({
+          id: s.session_id, phase: s.phase || s.status, type: s.session_type || "review",
+          paused: (s.paused_agent || s.paused_agent_id || "").slice(0, 8), reviewer: (s.reviewer || s.reviewer_agent_id || "") ? (s.reviewer || s.reviewer_agent_id).slice(0, 8) : null,
+          synthesizer: s.synthesizer, topic: s.topic || s.reason || "", created: s.created || s.created_at, msgs: s.message_count || 0,
+          resolution: s.resolution ? { action: s.resolution.action || s.resolution.type, reasoning: s.resolution.reasoning || s.resolution.reason, conditions: (s.resolution.conditions || []).length, rootCause: s.resolution.root_cause } : null,
+        }));
+        const c = { total: sessions.length, resolved: 0, active: 0, failed: 0 };
+        sessions.forEach((s) => { if (["resolved"].includes(s.phase)) c.resolved++; else if (["failed", "escalated"].includes(s.phase)) c.failed++; else c.active++; });
+        return { sessions, counts: c };
+      }, () => ({ sessions: S().dialectic.sessions, counts: S().dialectic.counts }));
+    },
+
+    async activity() {
+      return withFallback(async () => {
+        const [ev, act] = await Promise.all([authFetch("/api/events?limit=40"), authFetch("/api/activity?window=60&bucket=5")]);
+        if (!ev || !ev.events) return null;
+        const events = ev.events.map((e) => ({
+          type: e.type, severity: e.severity, agent: e.agent_name || e.agent_id, ts: e.timestamp || e.ts,
+          message: e.message, vclass: e.violation_class,
+        }));
+        const buckets = (act && act.buckets ? act.buckets : []).map((b) => ({ p: b.proceed || 0, g: b.guide || 0, x: b.pause || 0 }));
+        return { events, buckets, windowMin: (act && act.window_minutes) || 60, bucketMin: (act && act.bucket_minutes) || 5 };
+      }, () => S().activity);
+    },
+
+    async eisv() {
+      return withFallback(async () => {
+        const r = await authFetch("/v1/eisv/recent?limit=120");
+        const evs = (r && r.events) || [];
+        if (!evs.length) return null;
+        // fleet-average into 1-min buckets (mirrors eisv-charts __fleet__)
+        const buckets = {};
+        evs.forEach((e) => {
+          const ts = e.timestamp || "";
+          if (ts.length < 16) return;
+          const k = ts.slice(11, 16);
+          const m = e.eisv || {};
+          (buckets[k] || (buckets[k] = [])).push({ E: m.E, I: m.I, S: m.S, V: m.V, C: e.coherence, R: e.risk });
+        });
+        const avg = (xs, f) => { const v = xs.map((x) => x[f]).filter((n) => typeof n === "number"); return v.length ? v.reduce((a, n) => a + n, 0) / v.length : null; };
+        const series = Object.keys(buckets).sort().slice(-20).map((t) => {
+          const xs = buckets[t];
+          return { t, E: avg(xs, "E"), I: avg(xs, "I"), S: avg(xs, "S"), V: avg(xs, "V"), C: avg(xs, "C"), R: avg(xs, "R") };
+        });
+        return { series, coherenceEq: 0.5 };
+      }, () => S().eisv);
+    },
+
+    async residentPanels() {
+      return withFallback(async () => {
+        const [w, sn, vg, h] = await Promise.all([
+          authFetch("/v1/watcher/summary").catch(() => null),
+          authFetch("/v1/sentinel/summary").catch(() => null),
+          authFetch("/v1/vigil/summary").catch(() => null),
+          authFetch("/health/deep").catch(() => null),
+        ]);
+        if (!w && !sn && !vg && !h) return null;
+        const out = {};
+        if (w) out.watcher = { total: w.total, byStatus: w.by_status || {}, openSev: w.by_severity_open || {},
+          patterns: (w.patterns || []).map((p) => ({ p: p.pattern, confirmed: p.confirmed, dismissed: p.dismissed, surfaced: p.surfaced, ratio: p.dismiss_ratio })) };
+        if (sn) out.sentinel = { total: sn.total, bySeverity: sn.by_severity || {},
+          byClass: (sn.by_violation_class || []).map((c) => ({ c: c.violation_class, n: c.count })),
+          recent: (sn.recent || []).map((r) => ({ ts: r.timestamp, severity: r.severity, vclass: r.violation_class, type: r.finding_type, message: r.message })) };
+        if (vg && vg.stats) out.vigil = { cycles24h: vg.stats.cycles_24h, writesWindow: vg.stats.total_writes_in_window, lastVerdict: vg.stats.last_verdict,
+          lastCycleAgeS: vg.stats.last_cycle_age_seconds, avgCoherence: vg.stats.avg_coherence_window,
+          eisv: vg.cycles && vg.cycles[0] ? vg.cycles[0] : null };
+        if (h) out.health = { status: h.status, version: h.version, checks: h.status_breakdown || {},
+          breakers: { governance: (h.circuit_breakers && h.circuit_breakers.governance || {}).trips_24h || 0, redis: (h.circuit_breakers && h.circuit_breakers.redis || {}).trips_24h || 0 },
+          calibration: (h.checks && h.checks.calibration || {}).status, redis: h.redis_present, continuity: h.identity_continuity_mode };
+        out.chronicler = S().residentPanels.chronicler; // not a REST summary; carry snapshot note
+        return out;
+      }, () => S().residentPanels);
+    },
+  };
+
+  window.DATA = DATA;
+})();

--- a/dashboard/redesign/data.js
+++ b/dashboard/redesign/data.js
@@ -18,7 +18,7 @@
     try {
       const u = new URLSearchParams(location.search).get("token");
       return u || localStorage.getItem("unitares_api_token") || null;
-    } catch (_) { return null; }
+    } catch { return null; }
   }
 
   async function authFetch(path, opts) {
@@ -45,7 +45,7 @@
       const v = await liveFn();
       if (v == null) throw new Error("empty");
       return { source: "live", data: v };
-    } catch (_) {
+    } catch {
       return { source: "snapshot", data: snapFn() };
     }
   }

--- a/dashboard/redesign/kit.css
+++ b/dashboard/redesign/kit.css
@@ -1,0 +1,217 @@
+/*
+ * UNITARES Dashboard — Primitive Kit (redesign)
+ * --------------------------------------------------------
+ * The reusable component layer. Every section composes these; no section
+ * ships its own base styles. Pairs with tokens.css — all values derive
+ * from tokens, so a theme swap reskins every primitive at once.
+ *
+ * Primitives: app shell + nav · eyebrow · card/stat · panel · resident
+ * chip · verdict badge · attention band · track/bar · eisv meter · table.
+ */
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { background: var(--bg); }
+body {
+  font-family: var(--font-sans);
+  color: var(--ink);
+  background: var(--bg);
+  line-height: var(--leading-body);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  padding-bottom: var(--space-8);
+}
+.wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 var(--space-5); }
+.spring { flex: 1; }
+[hidden] { display: none !important; }
+
+/* ---------------- top bar ---------------- */
+.topbar {
+  display: flex; align-items: baseline; gap: var(--space-4);
+  padding: var(--space-5) 0 var(--space-4);
+  border-bottom: var(--hairline) solid var(--line);
+}
+.brand { font-family: var(--font-display); font-weight: 600; font-size: var(--text-lg);
+  letter-spacing: -0.01em; color: var(--ink); }
+.brand .dot { color: var(--accent); }
+.brand-sub { font-size: var(--text-sm); color: var(--muted);
+  letter-spacing: var(--tracking-label); text-transform: uppercase; }
+.server-stat { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--muted); }
+.server-stat b { color: var(--ink-2); font-weight: 500; }
+.theme-toggle {
+  font-family: var(--font-mono); font-size: var(--text-xs); color: var(--ink-2);
+  background: var(--surface); border: var(--hairline) solid var(--line-2);
+  border-radius: var(--radius-pill); padding: var(--space-1) var(--space-3);
+  cursor: pointer; transition: all var(--dur) var(--ease);
+}
+.theme-toggle:hover { border-color: var(--accent); color: var(--accent); }
+
+/* ---------------- section nav ---------------- */
+.nav {
+  display: flex; gap: var(--space-1); flex-wrap: wrap;
+  padding: var(--space-4) 0; margin-bottom: var(--space-5);
+  border-bottom: var(--hairline) solid var(--line);
+  position: sticky; top: 0; background: var(--bg); z-index: 10;
+}
+.nav a {
+  font-size: var(--text-sm); color: var(--muted); text-decoration: none;
+  padding: var(--space-2) var(--space-3); border-radius: var(--radius-sm);
+  font-weight: 500; transition: all var(--dur) var(--ease); white-space: nowrap;
+}
+.nav a:hover { color: var(--ink); background: var(--surface-2); }
+.nav a.active { color: var(--accent); background: var(--accent-soft); }
+
+/* ---------------- eyebrow label ---------------- */
+.eyebrow {
+  font-size: var(--text-xs); letter-spacing: var(--tracking-label);
+  text-transform: uppercase; color: var(--muted); font-weight: 600;
+  margin-bottom: var(--space-3);
+}
+
+/* ---------------- section ---------------- */
+.section { margin-bottom: var(--space-7); }
+.section-title {
+  font-family: var(--font-display); font-weight: 500; font-size: var(--text-xl);
+  letter-spacing: -0.01em; margin-bottom: var(--space-5);
+}
+
+/* ---------------- resident chip ---------------- */
+.residents { display: flex; flex-wrap: wrap; gap: var(--space-3); margin-bottom: var(--space-4); }
+.res {
+  display: flex; align-items: center; gap: var(--space-3);
+  background: var(--surface); border: var(--hairline) solid var(--line);
+  border-radius: var(--radius-pill); padding: var(--space-2) var(--space-4) var(--space-2) var(--space-3);
+  box-shadow: var(--shadow-soft);
+}
+.res .pip { width: 7px; height: 7px; border-radius: 50%; background: var(--ok); flex: none; }
+.res.attention { border-color: var(--warn); }
+.res.attention .pip { background: var(--warn); }
+.res.dark .pip { background: var(--faint); }
+.res .name { font-weight: 500; font-size: var(--text-sm); }
+.res .meta { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--muted); }
+
+/* ---------------- attention band ---------------- */
+.attn-band {
+  display: flex; align-items: center; gap: var(--space-3);
+  background: var(--accent-soft); border: var(--hairline) solid var(--line-2);
+  border-left: 2px solid var(--warn);
+  border-radius: var(--radius-md); padding: var(--space-3) var(--space-4);
+  margin-bottom: var(--space-6); font-size: var(--text-sm); color: var(--ink-2);
+}
+.attn-band b { color: var(--ink); font-weight: 600; }
+.attn-band .glyph { color: var(--warn); font-weight: 600; }
+
+/* ---------------- stat cards ---------------- */
+.grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: var(--space-4); }
+.card {
+  background: var(--surface); border: var(--hairline) solid var(--line);
+  border-radius: var(--radius-lg); padding: var(--space-5);
+  box-shadow: var(--shadow); display: flex; flex-direction: column; gap: var(--space-2);
+  transition: border-color var(--dur) var(--ease);
+}
+.card:hover { border-color: var(--line-2); }
+.card h3 { font-size: var(--text-xs); letter-spacing: var(--tracking-label);
+  text-transform: uppercase; color: var(--muted); font-weight: 600; }
+.card .num { font-family: var(--font-mono); font-size: var(--text-2xl); font-weight: 500;
+  line-height: 1; letter-spacing: -0.02em; color: var(--ink); font-variant-numeric: tabular-nums; }
+.card .num .of { font-size: var(--text-lg); color: var(--faint); }
+.card .sub { font-size: var(--text-xs); color: var(--muted); }
+.card .sub.up { color: var(--ok); } .card .sub.down { color: var(--danger); }
+.card.wide { grid-column: span 2; }
+.card.accent-rule { border-top: 2px solid var(--accent); }
+
+/* trust-tier mini bars */
+.tiers { display: flex; gap: 3px; align-items: flex-end; height: 34px; margin-top: var(--space-1); }
+.tiers .t { flex: 1; border-radius: 3px 3px 0 0; background: var(--eisv-c); opacity: 0.85; }
+.tiers .t.strong { background: var(--eisv-i); }
+.tiers .t.medium { background: var(--eisv-s); }
+.tiers .t.weak { background: var(--faint); }
+.legend { display: flex; gap: var(--space-3); font-size: var(--text-xs); color: var(--muted); }
+.legend i { width: 8px; height: 8px; border-radius: 2px; display: inline-block; margin-right: 4px; }
+
+/* ---------------- panel ---------------- */
+.panel {
+  background: var(--surface); border: var(--hairline) solid var(--line);
+  border-radius: var(--radius-lg); padding: var(--space-6); box-shadow: var(--shadow);
+}
+.panel + .panel { margin-top: var(--space-5); }
+.panel-head { display: flex; align-items: baseline; gap: var(--space-3); margin-bottom: var(--space-5); }
+.panel-head h2 { font-family: var(--font-display); font-weight: 500; font-size: var(--text-lg); }
+.panel-head .who { font-family: var(--font-mono); font-size: var(--text-sm); color: var(--accent); }
+
+/* ---------------- verdict badge ---------------- */
+.verdict {
+  display: inline-flex; align-items: center; gap: var(--space-2);
+  font-size: var(--text-sm); font-weight: 500; color: var(--ok);
+  background: color-mix(in srgb, var(--ok) 12%, transparent);
+  padding: var(--space-1) var(--space-3); border-radius: var(--radius-pill);
+}
+.verdict .pip { width: 7px; height: 7px; border-radius: 50%; background: var(--ok); }
+.verdict.warn { color: var(--warn); background: color-mix(in srgb, var(--warn) 14%, transparent); }
+.verdict.warn .pip { background: var(--warn); }
+.verdict.danger { color: var(--danger); background: color-mix(in srgb, var(--danger) 14%, transparent); }
+.verdict.danger .pip { background: var(--danger); }
+.fresh { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--muted); }
+
+/* ---------------- track / risk bar ---------------- */
+.risk-label { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: var(--space-2); }
+.risk-label .k { font-size: var(--text-xs); letter-spacing: var(--tracking-label);
+  text-transform: uppercase; color: var(--muted); font-weight: 600; }
+.risk-label .v { font-family: var(--font-mono); font-size: var(--text-xl); color: var(--ink);
+  font-variant-numeric: tabular-nums; }
+.track { height: 8px; background: var(--bg-sunken); border-radius: var(--radius-pill);
+  position: relative; overflow: hidden; }
+.track .fill { height: 100%; border-radius: var(--radius-pill); background: var(--ok);
+  transition: width var(--dur) var(--ease); }
+.ticks { position: relative; height: 18px; margin-top: var(--space-2); }
+.ticks span { position: absolute; transform: translateX(-50%); font-size: 0.68rem;
+  color: var(--faint); font-family: var(--font-mono); }
+.ticks span::before { content: ""; position: absolute; top: -6px; left: 50%;
+  width: 1px; height: 4px; background: var(--line-2); }
+
+/* ---------------- eisv meter ---------------- */
+.eisv { display: flex; flex-direction: column; gap: var(--space-3); }
+.eisv-row { display: grid; grid-template-columns: 16px 1fr 44px; align-items: center; gap: var(--space-3); }
+.eisv-row .k { font-family: var(--font-mono); font-size: var(--text-sm); color: var(--ink-2); font-weight: 500; }
+.eisv-row .bar { height: 6px; background: var(--bg-sunken); border-radius: var(--radius-pill);
+  overflow: hidden; position: relative; }
+.eisv-row .bar i { position: absolute; left: 0; top: 0; height: 100%; border-radius: var(--radius-pill); }
+.eisv-row .bar.signed::before { content:""; position:absolute; left:50%; top:0; width:1px; height:100%; background: var(--line-2); }
+.eisv-row .val { font-family: var(--font-mono); font-size: var(--text-sm); text-align: right;
+  color: var(--ink); font-variant-numeric: tabular-nums; }
+.eisv i.e { background: var(--eisv-e); } .eisv i.i { background: var(--eisv-i); }
+.eisv i.s { background: var(--eisv-s); } .eisv i.v { background: var(--eisv-v); }
+
+/* ---------------- table ---------------- */
+.tbl { width: 100%; border-collapse: collapse; font-size: var(--text-sm); }
+.tbl thead th {
+  text-align: left; font-size: var(--text-xs); letter-spacing: var(--tracking-label);
+  text-transform: uppercase; color: var(--muted); font-weight: 600;
+  padding: var(--space-3) var(--space-3); border-bottom: var(--hairline) solid var(--line-2);
+}
+.tbl tbody td { padding: var(--space-3) var(--space-3); border-bottom: var(--hairline) solid var(--line);
+  color: var(--ink-2); vertical-align: middle; }
+.tbl tbody tr:hover { background: var(--surface-2); }
+.tbl .mono { font-family: var(--font-mono); font-variant-numeric: tabular-nums; color: var(--ink); }
+.tag {
+  display: inline-block; font-size: var(--text-xs); font-family: var(--font-mono);
+  padding: 1px var(--space-2); border-radius: var(--radius-sm);
+  background: var(--surface-2); border: var(--hairline) solid var(--line-2); color: var(--muted);
+}
+.tag.ok { color: var(--ok); border-color: color-mix(in srgb, var(--ok) 40%, var(--line-2)); }
+.tag.warn { color: var(--warn); border-color: color-mix(in srgb, var(--warn) 40%, var(--line-2)); }
+.tag.danger { color: var(--danger); border-color: color-mix(in srgb, var(--danger) 40%, var(--line-2)); }
+
+/* ---------------- misc ---------------- */
+.dot-pip { width: 7px; height: 7px; border-radius: 50%; display: inline-block; background: var(--ok); }
+.empty { color: var(--muted); font-size: var(--text-sm); padding: var(--space-6); text-align: center; }
+.footnote { color: var(--muted); font-size: var(--text-xs); margin-top: var(--space-6);
+  text-align: center; line-height: var(--leading-body); }
+.footnote code { font-family: var(--font-mono); color: var(--ink-2); }
+.src-badge { font-family: var(--font-mono); font-size: 0.68rem; padding: 1px 6px; border-radius: var(--radius-sm); }
+.src-badge.live { color: var(--ok); background: color-mix(in srgb, var(--ok) 12%, transparent); }
+.src-badge.snapshot { color: var(--warn); background: color-mix(in srgb, var(--warn) 12%, transparent); }
+
+@media (max-width: 860px) {
+  .grid { grid-template-columns: repeat(2, 1fr); }
+  .topbar { flex-wrap: wrap; }
+}

--- a/dashboard/redesign/preview.html
+++ b/dashboard/redesign/preview.html
@@ -1,0 +1,311 @@
+<!doctype html>
+<html lang="en" data-theme="paper">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>UNITARES · redesign reference</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Inter:wght@400;500;600&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="./tokens.css" />
+<style>
+/* ============================================================
+   COMPONENT LAYER (reference)
+   In the real migration these become small files behind the
+   existing nav. Here they live inline so the page is portable
+   and renders with no server. Every value derives from tokens.
+   ============================================================ */
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { background: var(--bg); }
+body {
+  font-family: var(--font-sans);
+  color: var(--ink);
+  background: var(--bg);
+  line-height: var(--leading-body);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  padding-bottom: var(--space-8);
+}
+.wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 var(--space-5); }
+
+/* ---- top bar ---- */
+.topbar {
+  display: flex; align-items: baseline; gap: var(--space-4);
+  padding: var(--space-5) 0 var(--space-4);
+  border-bottom: var(--hairline) solid var(--line);
+  margin-bottom: var(--space-6);
+}
+.brand { font-family: var(--font-display); font-weight: 600; font-size: var(--text-lg);
+  letter-spacing: -0.01em; color: var(--ink); }
+.brand .dot { color: var(--accent); }
+.brand-sub { font-size: var(--text-sm); color: var(--muted); letter-spacing: var(--tracking-label);
+  text-transform: uppercase; }
+.topbar .spring { flex: 1; }
+.server-stat { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--muted); }
+.server-stat b { color: var(--ink-2); font-weight: 500; }
+.theme-toggle {
+  font-family: var(--font-mono); font-size: var(--text-xs); color: var(--ink-2);
+  background: var(--surface); border: var(--hairline) solid var(--line-2);
+  border-radius: var(--radius-pill); padding: var(--space-1) var(--space-3);
+  cursor: pointer; transition: all var(--dur) var(--ease);
+}
+.theme-toggle:hover { border-color: var(--accent); color: var(--accent); }
+
+/* ---- section label ---- */
+.eyebrow {
+  font-size: var(--text-xs); letter-spacing: var(--tracking-label);
+  text-transform: uppercase; color: var(--muted); font-weight: 600;
+  margin-bottom: var(--space-3);
+}
+
+/* ---- residents strip ---- */
+.residents { display: flex; flex-wrap: wrap; gap: var(--space-3); margin-bottom: var(--space-4); }
+.res {
+  display: flex; align-items: center; gap: var(--space-3);
+  background: var(--surface); border: var(--hairline) solid var(--line);
+  border-radius: var(--radius-pill); padding: var(--space-2) var(--space-4) var(--space-2) var(--space-3);
+  box-shadow: var(--shadow-soft);
+}
+.res .pip { width: 7px; height: 7px; border-radius: 50%; background: var(--ok); flex: none; }
+.res.attention { border-color: var(--warn); }
+.res.attention .pip { background: var(--warn); }
+.res.dark .pip { background: var(--faint); }
+.res .name { font-weight: 500; font-size: var(--text-sm); }
+.res .meta { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--muted); }
+
+/* ---- attention banner ---- */
+.attn-band {
+  display: flex; align-items: center; gap: var(--space-3);
+  background: var(--accent-soft); border: var(--hairline) solid var(--line-2);
+  border-left: 2px solid var(--warn);
+  border-radius: var(--radius-md); padding: var(--space-3) var(--space-4);
+  margin-bottom: var(--space-6); font-size: var(--text-sm); color: var(--ink-2);
+}
+.attn-band b { color: var(--ink); font-weight: 600; }
+.attn-band .glyph { color: var(--warn); font-weight: 600; }
+
+/* ---- stats grid ---- */
+.grid {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-4); margin-bottom: var(--space-7);
+}
+.card {
+  background: var(--surface); border: var(--hairline) solid var(--line);
+  border-radius: var(--radius-lg); padding: var(--space-5);
+  box-shadow: var(--shadow); display: flex; flex-direction: column; gap: var(--space-2);
+  transition: border-color var(--dur) var(--ease), transform var(--dur) var(--ease);
+}
+.card:hover { border-color: var(--line-2); }
+.card h3 {
+  font-size: var(--text-xs); letter-spacing: var(--tracking-label);
+  text-transform: uppercase; color: var(--muted); font-weight: 600;
+}
+.card .num {
+  font-family: var(--font-mono); font-size: var(--text-2xl); font-weight: 500;
+  line-height: 1; letter-spacing: -0.02em; color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+.card .num .of { font-size: var(--text-lg); color: var(--faint); }
+.card .sub { font-size: var(--text-xs); color: var(--muted); }
+.card .sub.up { color: var(--ok); } .card .sub.down { color: var(--danger); }
+.card.wide { grid-column: span 2; }
+.card.accent-rule { border-top: 2px solid var(--accent); }
+
+/* trust-tier mini bars */
+.tiers { display: flex; gap: 3px; align-items: flex-end; height: 34px; margin-top: var(--space-1); }
+.tiers .t { flex: 1; border-radius: 3px 3px 0 0; background: var(--eisv-c); opacity: 0.85; }
+.tiers .t.strong { background: var(--eisv-i); }
+.tiers .t.medium { background: var(--eisv-s); }
+.tiers .t.weak { background: var(--faint); }
+.legend { display: flex; gap: var(--space-3); font-size: var(--text-xs); color: var(--muted); }
+.legend i { width: 8px; height: 8px; border-radius: 2px; display: inline-block; margin-right: 4px; }
+
+/* ---- pulse panel ---- */
+.panel {
+  background: var(--surface); border: var(--hairline) solid var(--line);
+  border-radius: var(--radius-lg); padding: var(--space-6); box-shadow: var(--shadow);
+}
+.panel-head { display: flex; align-items: baseline; gap: var(--space-3); margin-bottom: var(--space-5); }
+.panel-head h2 { font-family: var(--font-display); font-weight: 500; font-size: var(--text-lg); }
+.panel-head .who { font-family: var(--font-mono); font-size: var(--text-sm); color: var(--accent); }
+.panel-head .spring { flex: 1; }
+.verdict {
+  display: inline-flex; align-items: center; gap: var(--space-2);
+  font-size: var(--text-sm); font-weight: 500; color: var(--ok);
+  background: color-mix(in srgb, var(--ok) 12%, transparent);
+  padding: var(--space-1) var(--space-3); border-radius: var(--radius-pill);
+}
+.verdict .pip { width: 7px; height: 7px; border-radius: 50%; background: var(--ok); }
+.fresh { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--muted); }
+
+.pulse-main { display: grid; grid-template-columns: 1.4fr 1fr; gap: var(--space-7); align-items: center; }
+.risk-label { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: var(--space-2); }
+.risk-label .k { font-size: var(--text-xs); letter-spacing: var(--tracking-label); text-transform: uppercase; color: var(--muted); font-weight: 600; }
+.risk-label .v { font-family: var(--font-mono); font-size: var(--text-xl); color: var(--ink); font-variant-numeric: tabular-nums; }
+.track { height: 8px; background: var(--bg-sunken); border-radius: var(--radius-pill); position: relative; overflow: hidden; }
+.track .fill { height: 100%; border-radius: var(--radius-pill); background: var(--ok); transition: width var(--dur) var(--ease); }
+.ticks { position: relative; height: 18px; margin-top: var(--space-2); }
+.ticks span { position: absolute; transform: translateX(-50%); font-size: 0.68rem; color: var(--faint); font-family: var(--font-mono); }
+.ticks span::before { content: ""; position: absolute; top: -6px; left: 50%; width: 1px; height: 4px; background: var(--line-2); }
+
+/* eisv readout */
+.eisv { display: flex; flex-direction: column; gap: var(--space-3); }
+.eisv-row { display: grid; grid-template-columns: 16px 1fr 44px; align-items: center; gap: var(--space-3); }
+.eisv-row .k { font-family: var(--font-mono); font-size: var(--text-sm); color: var(--ink-2); font-weight: 500; }
+.eisv-row .bar { height: 6px; background: var(--bg-sunken); border-radius: var(--radius-pill); overflow: hidden; position: relative; }
+.eisv-row .bar i { position: absolute; left: 0; top: 0; height: 100%; border-radius: var(--radius-pill); }
+.eisv-row .bar.signed { background: var(--bg-sunken); }
+.eisv-row .bar.signed::before { content:""; position:absolute; left:50%; top:0; width:1px; height:100%; background: var(--line-2); }
+.eisv-row .val { font-family: var(--font-mono); font-size: var(--text-sm); text-align: right; color: var(--ink); font-variant-numeric: tabular-nums; }
+.e i.e { background: var(--eisv-e); } .e i.i { background: var(--eisv-i); }
+.e i.s { background: var(--eisv-s); } .e i.v { background: var(--eisv-v); }
+
+.footnote { color: var(--muted); font-size: var(--text-xs); margin-top: var(--space-6); text-align: center; line-height: var(--leading-body); }
+.footnote code { font-family: var(--font-mono); color: var(--ink-2); }
+
+@media (max-width: 860px) {
+  .grid { grid-template-columns: repeat(2, 1fr); }
+  .card.wide { grid-column: span 2; }
+  .pulse-main { grid-template-columns: 1fr; gap: var(--space-5); }
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header class="topbar">
+    <span class="brand">UNITARES<span class="dot">.</span></span>
+    <span class="brand-sub">Governance</span>
+    <span class="spring"></span>
+    <span class="server-stat">v<b>2.13.0</b> · up <b>21h 15m</b> · db <b>connected</b></span>
+    <button class="theme-toggle" id="themeBtn">◐ ink</button>
+  </header>
+
+  <div class="eyebrow">Resident Fleet</div>
+  <div class="residents" id="residents"></div>
+  <div class="attn-band" id="attn"></div>
+
+  <div class="grid" id="stats"></div>
+
+  <section class="panel">
+    <div class="panel-head">
+      <h2>Pulse</h2><span class="who" id="pulseWho">—</span>
+      <span class="spring"></span>
+      <span class="verdict" id="pulseVerdict"><span class="pip"></span><span>proceed</span></span>
+      <span class="fresh" id="pulseFresh"></span>
+    </div>
+    <div class="pulse-main">
+      <div>
+        <div class="risk-label"><span class="k">Risk</span><span class="v" id="riskVal">0.00</span></div>
+        <div class="track"><div class="fill" id="riskFill" style="width:2%"></div></div>
+        <div class="ticks">
+          <span style="left:35%">approve</span>
+          <span style="left:60%">proceed</span>
+          <span style="left:70%">pause</span>
+        </div>
+      </div>
+      <div class="eisv e" id="eisv"></div>
+    </div>
+  </section>
+
+  <p class="footnote" id="foot"></p>
+</div>
+
+<script>
+/* Real snapshot pulled live from /v1/residents + /health on 2026-06-19.
+   This is what the new primitives render — same data the live dashboard
+   reads, just inlined so the reference is portable. Retargeting to the
+   live endpoints is the migration step, not a rewrite. */
+const FLEET = [
+  { name:"Watcher",    status:"healthy",  coh:0.50, eisv:{E:0.77,I:0.66,S:0.24,V:+0.10}, sil:25 },
+  { name:"Vigil",      status:"healthy",  coh:0.49, eisv:{E:0.75,I:0.77,S:0.16,V:-0.02}, sil:101 },
+  { name:"Lumen",      status:"careful",  coh:0.50, eisv:{E:0.31,I:0.83,S:0.15,V:-0.52}, sil:56 },
+  { name:"Sentinel",   status:"healthy",  coh:0.50, eisv:{E:0.77,I:0.68,S:0.26,V:+0.09}, sil:273 },
+  { name:"Steward",    status:"dark",     coh:null, eisv:null,                            sil:32 },
+  { name:"Chronicler", status:"silent",   coh:0.50, eisv:{E:0.81,I:0.68,S:0.22,V:+0.11}, sil:67156 },
+];
+
+const fmtSil = s => s==null ? "—" : s<90 ? s+"s" : s<5400 ? Math.round(s/60)+"m" : (s/3600).toFixed(1)+"h";
+
+// residents strip
+document.getElementById("residents").innerHTML = FLEET.map(r => {
+  const cls = r.status==="silent" ? "attention" : r.status==="dark" ? "dark" : "";
+  const meta = r.coh==null ? "no EISV" : "coh "+r.coh.toFixed(2);
+  return `<span class="res ${cls}"><span class="pip"></span><span class="name">${r.name}</span>`
+       + `<span class="meta">${meta} · ${fmtSil(r.sil)}</span></span>`;
+}).join("");
+
+// attention band — surfaces the real Chronicler silence cliff
+document.getElementById("attn").innerHTML =
+  `<span class="glyph">⚠</span><span><b>Chronicler</b> silent 18.6h `
+  + `— daily resident past its 1h check-in threshold. `
+  + `<b>Steward</b> reporting no EISV vector.</span>`;
+
+// stats grid — live where available (coherence, fleet size), representative elsewhere
+const liveCoh = FLEET.filter(r=>r.coh!=null);
+const fleetCoh = (liveCoh.reduce((a,r)=>a+r.coh,0)/liveCoh.length).toFixed(2);
+const STATS = [
+  { h:"Fleet Coherence", num:fleetCoh, sub:"5 of 6 residents reporting", cls:"up", rule:true },
+  { h:"Agents", num:"6", of:"/ 658", sub:"active / total" },
+  { h:"Stuck", num:"0", sub:"none flagged", cls:"up" },
+  { h:"Discoveries", num:"1,204", sub:"+12 today" },
+  { h:"Dialectic", num:"0", sub:"no open sessions" },
+  { h:"System Health", num:"OK", sub:"db · ws · reaper" },
+  { h:"Calibration", num:"0.71", sub:"trajectory health", cls:"up" },
+  { h:"Anomalies", num:"1", sub:"Chronicler silence", cls:"down" },
+];
+document.getElementById("stats").innerHTML = STATS.map(s =>
+  `<div class="card ${s.rule?'accent-rule':''}"><h3>${s.h}</h3>`
+  + `<div class="num">${s.num}${s.of?`<span class="of"> ${s.of}</span>`:''}</div>`
+  + `<div class="sub ${s.cls||''}">${s.sub}</div></div>`
+).join("") +
+  `<div class="card wide"><h3>Trust Tiers</h3>
+     <div class="tiers">
+       <div class="t strong" style="height:78%"></div><div class="t strong" style="height:64%"></div>
+       <div class="t strong" style="height:90%"></div><div class="t medium" style="height:44%"></div>
+       <div class="t medium" style="height:52%"></div><div class="t weak" style="height:30%"></div>
+       <div class="t weak" style="height:22%"></div>
+     </div>
+     <div class="legend" style="margin-top:.5rem">
+       <span><i style="background:var(--eisv-i)"></i>strong</span>
+       <span><i style="background:var(--eisv-s)"></i>medium</span>
+       <span><i style="background:var(--faint)"></i>weak</span>
+     </div></div>`;
+
+// pulse — last check-in (Watcher, 25s ago)
+const last = FLEET[0];
+document.getElementById("pulseWho").textContent = last.name;
+document.getElementById("pulseFresh").textContent = "checked in "+fmtSil(last.sil)+" ago";
+const E = last.eisv;
+const rows = [
+  ["E", E.E, "e", false], ["I", E.I, "i", false],
+  ["S", E.S, "s", false], ["V", E.V, "v", true],
+];
+document.getElementById("eisv").innerHTML = rows.map(([k,v,c,signed]) => {
+  const w = signed ? Math.abs(v)*50 : v*100;
+  const left = signed ? (v<0 ? 50-Math.abs(v)*50 : 50) : 0;
+  return `<div class="eisv-row"><span class="k">${k}</span>`
+    + `<span class="bar ${signed?'signed':''}"><i class="${c}" style="left:${left}%;width:${w}%"></i></span>`
+    + `<span class="val">${v>=0&&!signed?'':''}${v.toFixed(2)}</span></div>`;
+}).join("");
+
+document.getElementById("foot").innerHTML =
+  "Reference reskin · 2 files (<code>tokens.css</code> + this page) vs the live "
+  + "<code>5,877-line styles.css</code> · same fleet data, rendered through the design system. "
+  + "Toggle theme to see one token swap reskin everything.";
+
+// honor ?theme= for static capture
+const qp = new URLSearchParams(location.search).get("theme");
+if (qp === "ink" || qp === "paper") {
+  document.documentElement.setAttribute("data-theme", qp);
+}
+// theme toggle
+const btn = document.getElementById("themeBtn");
+btn.onclick = () => {
+  const ink = document.documentElement.getAttribute("data-theme") === "ink";
+  document.documentElement.setAttribute("data-theme", ink ? "paper" : "ink");
+  btn.textContent = ink ? "◐ ink" : "◑ paper";
+};
+</script>
+</body>
+</html>

--- a/dashboard/redesign/sections/activity.js
+++ b/dashboard/redesign/sections/activity.js
@@ -1,0 +1,94 @@
+/*
+ * Activity section — histogram + event stream.
+ * Built from old timeline.js oracle: a proceed/guide/pause activity
+ * histogram over the window, plus a filterable event timeline (icon by
+ * type, severity/verdict colour, violation-class badge, agent, time,
+ * message). Composes kit; reads DATA.activity() (live-or-snapshot).
+ */
+(function () {
+  "use strict";
+  const $ = (s, r = document) => r.querySelector(s);
+  const esc = (s) => String(s == null ? "" : s).replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+
+  // type → icon (mirrors timeline.js glyph vocabulary)
+  const ICON = {
+    checkin: "●", verdict: "■", lifecycle: "⚑", identity: "◆", knowledge: "✎",
+    circuit_breaker: "⚡", agent_new: "+", sentinel_finding: "○", sentinel_alarm_finding: "⚡", event: "○",
+  };
+  const SEV_COLOR = { critical: "var(--danger)", high: "var(--danger)", medium: "var(--warn)", moderate: "var(--warn)", warning: "var(--warn)", low: "var(--muted)", info: "var(--eisv-c)" };
+  const importantSev = (s) => ["critical", "high", "medium", "moderate", "warning"].includes(s);
+
+  function relTime(iso) {
+    const ms = Date.now() - Date.parse(iso); if (isNaN(ms)) return "";
+    const m = ms / 6e4, h = m / 60, d = h / 24;
+    if (m < 60) return Math.max(1, Math.round(m)) + "m ago";
+    if (h < 24) return Math.round(h) + "h ago";
+    return Math.round(d) + "d ago";
+  }
+  const clock = (iso) => { const t = Date.parse(iso); return isNaN(t) ? "" : new Date(t).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" }); };
+
+  let MODEL = { events: [], buckets: [], windowMin: 60, bucketMin: 5, source: "snapshot" };
+  let filter = "all";
+
+  function histogram() {
+    const b = MODEL.buckets;
+    if (!b.length) return "";
+    const max = Math.max(1, ...b.map((x) => x.p + x.g + x.x));
+    const bars = b.map((x) => {
+      const seg = (n, color) => n ? `<div style="height:${(n / max) * 100}%;background:${color}"></div>` : "";
+      return `<div style="flex:1;display:flex;flex-direction:column-reverse;height:100%;gap:1px" title="${x.p} proceed · ${x.g} guide · ${x.x} pause">
+        ${seg(x.p, "var(--ok)")}${seg(x.g, "var(--warn)")}${seg(x.x, "var(--danger)")}</div>`;
+    }).join("");
+    const total = b.reduce((a, x) => a + x.p + x.g + x.x, 0);
+    return `<div class="panel" style="padding:var(--space-5);margin-bottom:var(--space-5)">
+      <div style="display:flex;align-items:baseline;gap:var(--space-3);margin-bottom:var(--space-3)">
+        <span class="eyebrow" style="margin:0">Check-in activity</span>
+        <span class="fresh">last ${MODEL.windowMin}m · ${MODEL.bucketMin}m buckets · ${total} check-ins</span>
+        <span class="spring"></span>
+        <span class="legend" style="font-size:var(--text-xs)"><span><i style="background:var(--ok)"></i>proceed</span><span><i style="background:var(--warn)"></i>guide</span><span><i style="background:var(--danger)"></i>pause</span></span>
+      </div>
+      <div style="display:flex;gap:3px;align-items:flex-end;height:90px">${bars}</div>
+    </div>`;
+  }
+
+  function row(e) {
+    const color = SEV_COLOR[e.severity] || "var(--muted)";
+    const icon = ICON[e.type] || ICON.event;
+    const vclass = e.vclass ? `<span class="tag" title="violation class ${esc(e.vclass)}">${esc(e.vclass)}</span>` : "";
+    return `<div style="display:flex;gap:var(--space-3);align-items:baseline;padding:var(--space-2) 0;border-bottom:var(--hairline) solid var(--line)">
+      <span style="color:${color};width:14px;flex:none;text-align:center">${icon}</span>
+      <span class="fresh" style="width:64px;flex:none" title="${esc(e.ts)}">${clock(e.ts)}</span>
+      <span style="font-weight:500;color:var(--ink);width:170px;flex:none;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${esc(e.agent)}">${esc(e.agent || "—")}</span>
+      ${vclass}
+      <span style="color:var(--ink-2);flex:1;min-width:0">${esc(e.message || e.type)}</span>
+      <span class="fresh" style="flex:none">${relTime(e.ts)}</span>
+    </div>`;
+  }
+
+  function render() {
+    let rows = MODEL.events.slice();
+    if (filter === "important") rows = rows.filter((e) => importantSev(e.severity));
+    else if (filter !== "all") rows = rows.filter((e) => e.type === filter);
+    rows.sort((a, b) => Date.parse(b.ts || 0) - Date.parse(a.ts || 0));
+
+    const types = Array.from(new Set(MODEL.events.map((e) => e.type)));
+    const chips = [["all", "all"], ["important", "important"]].concat(types.map((t) => [t, t.replace(/_/g, " ")]))
+      .map(([v, t]) => `<button class="theme-toggle act-f" data-f="${v}" style="${v === filter ? "border-color:var(--accent);color:var(--accent)" : ""}">${esc(t)}</button>`).join("");
+
+    $("#act-mount").innerHTML =
+      histogram() +
+      `<div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;margin-bottom:var(--space-3)">
+         ${chips}<span class="spring"></span><span class="src-badge ${MODEL.source}">${MODEL.source}</span></div>
+       <div class="panel" style="padding:var(--space-4) var(--space-5)">
+         ${rows.length ? rows.slice(0, 50).map(row).join("") : `<p class="empty">No events in this view.</p>`}
+       </div>`;
+    document.querySelectorAll(".act-f").forEach((b) => b.onclick = () => { filter = b.dataset.f; render(); });
+  }
+
+  async function load() {
+    const r = await DATA.activity();
+    MODEL = { events: r.data.events || [], buckets: r.data.buckets || [], windowMin: r.data.windowMin || 60, bucketMin: r.data.bucketMin || 5, source: r.source };
+    render();
+  }
+  window.Activity = { load };
+})();

--- a/dashboard/redesign/sections/agents.js
+++ b/dashboard/redesign/sections/agents.js
@@ -1,0 +1,148 @@
+/*
+ * Agents section — table, filters, badges, cohort split.
+ * Rebuilt from the oracle (old agents.js) state model: status, trust
+ * tier, lineage/superseded, stuck/inactive/stale, event-driven, redaction,
+ * and the participated / never-participated partition. Composes kit
+ * primitives; reads DATA.agents() (live-or-snapshot).
+ */
+(function () {
+  "use strict";
+
+  const $ = (s, r = document) => r.querySelector(s);
+  const TIER = { verified: 3, established: 2, emerging: 1, unknown: 0 };
+  const num = (x, d = 2) => typeof x === "number" ? x.toFixed(d) : "—";
+
+  let MODEL = { list: [], summary: {}, source: "snapshot", nowMs: 0 };
+  let pageSize = 20;
+
+  function staleness(lastIso, nowMs) {
+    if (!lastIso) return { level: "unknown", label: "—" };
+    const age = nowMs - Date.parse(lastIso);
+    const m = age / 60000, h = m / 60, d = h / 24;
+    if (m < 10) return { level: "fresh", label: "just now" };
+    if (m < 60) return { level: "recent", label: Math.round(m) + "m ago" };
+    if (h < 24) return { level: "stale", label: Math.round(h) + "h ago" };
+    return { level: "dead", label: Math.round(d) + "d ago" };
+  }
+
+  function verdictClass(v) {
+    if (["proceed", "approve", "safe"].includes(v)) return "ok";
+    if (["caution", "guide"].includes(v)) return "warn";
+    return "danger";
+  }
+
+  function tierBadge(tier) {
+    const t = TIER[tier] ?? 0;
+    return `<span class="tag" title="Trust tier ${t}: ${tier}">T${t}</span>`;
+  }
+
+  function rowBadges(a, st) {
+    const out = [];
+    if (a.event_driven) out.push(`<span class="tag" title="event-driven resident — silence is not a liveness signal">event</span>`);
+    else if (st.level === "stale" || st.level === "dead") out.push(`<span class="tag warn">inactive</span>`);
+    if (a.superseded) out.push(`<span class="tag warn" title="${a.lifecycleReason || "superseded"}">superseded</span>`);
+    if (a.parent) out.push(`<span class="tag" title="lineage parent ${a.parent}">↑ lineage</span>`);
+    else if (a.redacted) out.push(`<span class="tag" title="identifiers redacted">redacted</span>`);
+    return out.join(" ");
+  }
+
+  function render() {
+    const list = MODEL.list.slice();
+    const q = ($("#ag-search") && $("#ag-search").value || "").toLowerCase().trim();
+    const statusF = $("#ag-status") ? $("#ag-status").value : "all";
+    const sortF = $("#ag-sort") ? $("#ag-sort").value : "recent";
+    const prodOnly = $("#ag-prod") ? $("#ag-prod").checked : false;
+
+    let rows = list.filter((a) => {
+      if (statusF !== "all" && a.status !== statusF) return false;
+      if (prodOnly && (a.tags || []).some((t) => /test|experimental|ephemeral/.test(t))) return false;
+      if (q) {
+        const hay = ((a.label || "") + " " + a.agent_id + " " + (a.purpose || "") + " " + (a.tags || []).join(" ")).toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+
+    const cmp = {
+      recent: (a, b) => Date.parse(b.last || 0) - Date.parse(a.last || 0),
+      name: (a, b) => (a.label || a.agent_id).localeCompare(b.label || b.agent_id),
+      coherence: (a, b) => (b.metrics.coherence ?? -1) - (a.metrics.coherence ?? -1),
+      risk: (a, b) => (b.metrics.risk ?? -1) - (a.metrics.risk ?? -1),
+      updates: (a, b) => (b.updates || 0) - (a.updates || 0),
+    }[sortF] || cmp_recent;
+    rows.sort(cmp);
+
+    const participated = rows.filter((a) => (a.updates || 0) >= 1);
+    const never = rows.filter((a) => (a.updates || 0) === 0);
+    const shown = participated.slice(0, pageSize);
+
+    const tr = (a) => {
+      const st = staleness(a.last, MODEL.nowMs);
+      const name = a.label || `<span style="color:var(--muted)">anon · ${a.agent_id.slice(0, 8)}</span>`;
+      const pip = a.status === "paused" ? "var(--warn)" : a.status === "archived" ? "var(--faint)"
+        : st.level === "dead" ? "var(--faint)" : "var(--ok)";
+      return `<tr>
+        <td><span class="dot-pip" style="background:${pip}"></span></td>
+        <td><div style="display:flex;flex-wrap:wrap;gap:6px;align-items:center">
+            <span style="font-weight:500;color:var(--ink)">${name}</span> ${tierBadge(a.tier)} ${rowBadges(a, st)}
+          </div>${a.purpose ? `<div style="font-size:var(--text-xs);color:var(--muted);margin-top:2px">${a.purpose}</div>` : ""}</td>
+        <td><span class="tag ${verdictClass(a.metrics.verdict)}">${a.metrics.verdict || "—"}</span></td>
+        <td class="mono">${num(a.metrics.coherence)}</td>
+        <td class="mono">${num(a.metrics.risk)}</td>
+        <td class="mono">${(a.updates || 0).toLocaleString()}</td>
+        <td class="mono" style="color:var(--muted)">${st.label}</td>
+      </tr>`;
+    };
+
+    const head = `<thead><tr>
+      <th></th><th>Agent</th><th>Verdict</th><th>Coh</th><th>Risk</th><th>Updates</th><th>Last seen</th>
+    </tr></thead>`;
+
+    const sm = MODEL.summary || {};
+    const moreBtn = participated.length > pageSize
+      ? `<div style="text-align:center;margin-top:var(--space-4)"><button class="theme-toggle" id="ag-more">Show ${Math.min(20, participated.length - pageSize)} more (${shown.length} of ${participated.length})</button></div>` : "";
+    const neverGroup = never.length || sm.neverParticipated
+      ? `<details style="margin-top:var(--space-5)"><summary style="cursor:pointer;color:var(--muted);font-size:var(--text-sm)">
+           Never checked in — ${sm.neverParticipated ?? never.length} <span style="color:var(--faint)">· onboarded, no observations yet</span></summary>
+         ${never.length ? `<table class="tbl" style="margin-top:var(--space-3)">${head}<tbody>${never.slice(0, 30).map(tr).join("")}</tbody></table>`
+            : `<p class="empty">Not in this snapshot subset — ${sm.neverParticipated} fleet-wide.</p>`}</details>` : "";
+
+    $("#ag-mount").innerHTML =
+      `<div style="display:flex;gap:var(--space-3);flex-wrap:wrap;align-items:center;margin-bottom:var(--space-4)">
+         <input id="ag-search" placeholder="search name · id · purpose · tag" value="${q.replace(/"/g, "&quot;")}"
+           style="flex:1;min-width:200px;padding:var(--space-2) var(--space-3);font-family:var(--font-sans);font-size:var(--text-sm);background:var(--surface);color:var(--ink);border:var(--hairline) solid var(--line-2);border-radius:var(--radius-sm)" />
+         <select id="ag-status" class="theme-toggle">${["all", "active", "paused", "archived"].map((s) => `<option ${s === statusF ? "selected" : ""}>${s}</option>`).join("")}</select>
+         <select id="ag-sort" class="theme-toggle">${[["recent", "newest"], ["name", "name"], ["coherence", "coherence"], ["risk", "risk"], ["updates", "updates"]].map(([v, t]) => `<option value="${v}" ${v === sortF ? "selected" : ""}>${t}</option>`).join("")}</select>
+         <label style="font-size:var(--text-xs);color:var(--muted);display:flex;gap:6px;align-items:center"><input type="checkbox" id="ag-prod" ${prodOnly ? "checked" : ""}/> prod only</label>
+       </div>
+       <div style="display:flex;gap:var(--space-5);margin-bottom:var(--space-3);font-size:var(--text-xs);color:var(--muted)">
+         <span><b style="color:var(--ink)">${sm.total ?? rows.length}</b> total</span>
+         <span><b style="color:var(--ink)">${sm.active ?? "—"}</b> active</span>
+         <span><b style="color:var(--ink)">${sm.participated ?? participated.length}</b> participated</span>
+         <span><b style="color:var(--ink)">${sm.archived ?? 0}</b> archived</span>
+         <span class="src-badge ${MODEL.source}">${MODEL.source}</span>
+       </div>
+       ${shown.length ? `<table class="tbl">${head}<tbody>${shown.map(tr).join("")}</tbody></table>` : `<p class="empty">No agents match the current filters.</p>`}
+       ${moreBtn}${neverGroup}`;
+
+    wire();
+  }
+  function cmp_recent(a, b) { return Date.parse(b.last || 0) - Date.parse(a.last || 0); }
+
+  function wire() {
+    const s = $("#ag-search"); if (s) s.oninput = () => { pageSize = 20; render(); };
+    ["#ag-status", "#ag-sort", "#ag-prod"].forEach((id) => { const el = $(id); if (el) el.onchange = () => { pageSize = 20; render(); }; });
+    const more = $("#ag-more"); if (more) more.onclick = () => { pageSize += 20; render(); };
+  }
+
+  async function load() {
+    const r = await DATA.agents();
+    MODEL = {
+      list: r.data.list || [], summary: r.data.summary || {}, source: r.source,
+      nowMs: r.source === "live" ? Date.now() : Date.parse((window.SNAPSHOT && window.SNAPSHOT.capturedAt) || 0) || Date.now(),
+    };
+    render();
+  }
+
+  window.Agents = { load };
+})();

--- a/dashboard/redesign/sections/dialectic.js
+++ b/dashboard/redesign/sections/dialectic.js
@@ -1,0 +1,90 @@
+/*
+ * Dialectic section — peer-review / recovery sessions.
+ * Rebuilt from old dialectic.js: counts (resolved/active/failed), phase
+ * filter, session cards (phase badge, type, agents, topic, msgs, time) and
+ * expandable resolution (action, reasoning, conditions, root cause).
+ * Composes kit; reads DATA.dialectic() (live-or-snapshot).
+ */
+(function () {
+  "use strict";
+  const $ = (s, r = document) => r.querySelector(s);
+  const esc = (s) => String(s == null ? "" : s).replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+
+  const PHASE = {
+    resolved: { color: "var(--ok)", label: "Resolved" },
+    failed: { color: "var(--warn)", label: "Failed" },
+    escalated: { color: "var(--warn)", label: "Escalated" },
+    quorum_voting: { color: "var(--eisv-e)", label: "Quorum" },
+    thesis: { color: "var(--eisv-c)", label: "Thesis" },
+    antithesis: { color: "var(--eisv-e)", label: "Antithesis" },
+    synthesis: { color: "var(--eisv-s)", label: "Synthesis" },
+    awaiting_thesis: { color: "var(--muted)", label: "Awaiting thesis" },
+  };
+  function relTime(iso) {
+    const ms = Date.now() - Date.parse(iso); if (isNaN(ms)) return "";
+    const h = ms / 3.6e6, d = h / 24;
+    if (h < 24) return Math.round(h) + "h ago";
+    if (d < 60) return Math.round(d) + "d ago";
+    return Math.round(d / 30) + "mo ago";
+  }
+
+  let MODEL = { sessions: [], counts: {}, source: "snapshot" };
+  let phaseFilter = "all";
+
+  function agentPill(role, id, cls) {
+    if (!id) return "";
+    return `<span class="tag" style="${cls || ""}" title="${role}">${role}: ${esc(id)}</span>`;
+  }
+
+  function card(s) {
+    const p = PHASE[s.phase] || { color: "var(--muted)", label: s.phase || "—" };
+    const res = s.resolution;
+    const pills = [
+      agentPill("requestor", s.paused),
+      agentPill("reviewer", s.reviewer),
+      s.synthesizer ? agentPill("synth", s.synthesizer, "color:var(--eisv-e)") : "",
+    ].filter(Boolean).join(" ");
+    return `<div class="panel" style="padding:var(--space-5)">
+      <div style="display:flex;gap:var(--space-3);align-items:center;flex-wrap:wrap;margin-bottom:var(--space-2)">
+        <span class="tag" style="color:${p.color};border-color:color-mix(in srgb, ${p.color} 40%, var(--line-2))">${p.label}</span>
+        <span class="tag">${esc(s.type)}</span>
+        <span class="fresh" title="${esc(s.id)}">${esc((s.id || "").slice(0, 12))}…</span>
+        <span class="spring"></span>
+        <span class="fresh">${s.msgs} msg${s.msgs === 1 ? "" : "s"} · ${relTime(s.created)}</span>
+      </div>
+      ${s.topic ? `<div style="color:var(--ink);font-size:var(--text-base);line-height:var(--leading-body);margin-bottom:var(--space-3)">${esc(s.topic)}</div>`
+        : `<div style="color:var(--muted);font-style:italic;font-size:var(--text-sm);margin-bottom:var(--space-3)">(no topic recorded)</div>`}
+      <div style="display:flex;gap:6px;flex-wrap:wrap;${res ? "margin-bottom:var(--space-3)" : ""}">${pills}</div>
+      ${res ? `<details><summary style="cursor:pointer;color:var(--muted);font-size:var(--text-sm)">resolution · ${esc(res.action || "—")}${res.conditions ? ` · ${res.conditions} condition${res.conditions === 1 ? "" : "s"}` : ""}</summary>
+        <div style="margin-top:var(--space-2);font-size:var(--text-sm);color:var(--ink-2);line-height:var(--leading-body)">
+          ${res.reasoning ? `<div style="margin-bottom:var(--space-2)">${esc(res.reasoning)}</div>` : ""}
+          ${res.rootCause ? `<div style="color:var(--muted)"><b style="color:var(--ink-2)">root cause:</b> ${esc(res.rootCause)}</div>` : ""}
+        </div></details>` : ""}
+    </div>`;
+  }
+
+  function render() {
+    const c = MODEL.counts || {};
+    let rows = MODEL.sessions.slice();
+    if (phaseFilter === "active") rows = rows.filter((s) => !["resolved", "failed"].includes(s.phase));
+    else if (phaseFilter !== "all") rows = rows.filter((s) => s.phase === phaseFilter);
+    rows.sort((a, b) => Date.parse(b.created || 0) - Date.parse(a.created || 0));
+
+    const chips = [["all", "all " + (c.total ?? "")], ["active", "active " + (c.active ?? 0)], ["resolved", "resolved " + (c.resolved ?? 0)], ["failed", "failed " + (c.failed ?? 0)]]
+      .map(([v, t]) => `<button class="theme-toggle dlc-f" data-f="${v}" style="${v === phaseFilter ? "border-color:var(--accent);color:var(--accent)" : ""}">${t}</button>`).join("");
+
+    $("#dlc-mount").innerHTML =
+      `<div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;margin-bottom:var(--space-4)">
+         ${chips}<span class="spring"></span><span class="src-badge ${MODEL.source}">${MODEL.source}</span></div>
+       ${rows.length ? `<div style="display:flex;flex-direction:column;gap:var(--space-3)">${rows.map(card).join("")}</div>`
+         : `<div class="empty">🔄 No dialectic sessions in this view. Sessions open when an agent's circuit-breaker trips or review is requested.</div>`}`;
+    document.querySelectorAll(".dlc-f").forEach((b) => b.onclick = () => { phaseFilter = b.dataset.f; render(); });
+  }
+
+  async function load() {
+    const r = await DATA.dialectic();
+    MODEL = { sessions: r.data.sessions || [], counts: r.data.counts || {}, source: r.source };
+    render();
+  }
+  window.Dialectic = { load };
+})();

--- a/dashboard/redesign/sections/discoveries.js
+++ b/dashboard/redesign/sections/discoveries.js
@@ -32,7 +32,7 @@
     text = esc(text);
     if (!q) return text;
     try { return text.replace(new RegExp("(" + q.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + ")", "ig"), "<mark>$1</mark>"); }
-    catch (_) { return text; }
+    catch { return text; }
   }
 
   let MODEL = { list: [], byType: {}, byStatus: {}, total: 0, source: "snapshot" };

--- a/dashboard/redesign/sections/discoveries.js
+++ b/dashboard/redesign/sections/discoveries.js
@@ -1,0 +1,118 @@
+/*
+ * Discoveries section — knowledge-graph entries.
+ * Rebuilt from old discoveries.js: lifecycle bar + type legend (clickable
+ * filter) + search/type/time filters + cards (type badge, agent, date,
+ * summary w/ highlight, tags, expandable details, staleness). Composes kit;
+ * reads DATA.discoveries() (live-or-snapshot).
+ */
+(function () {
+  "use strict";
+  const $ = (s, r = document) => r.querySelector(s);
+
+  const TYPE_ORDER = ["insight", "improvement", "bug_found", "pattern", "question", "answer", "analysis", "note", "exploration"];
+  const STATUS_COLOR = { open: "var(--ok)", resolved: "var(--eisv-c)", archived: "var(--faint)", superseded: "var(--warn)", closed: "var(--muted)" };
+  const esc = (s) => String(s == null ? "" : s).replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+  const label = (t) => t.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+
+  function relTime(iso) {
+    const ms = Date.now() - Date.parse(iso);
+    if (isNaN(ms)) return "";
+    const h = ms / 3.6e6, d = h / 24;
+    if (h < 1) return Math.max(1, Math.round(ms / 6e4)) + "m ago";
+    if (h < 24) return Math.round(h) + "h ago";
+    if (d < 60) return Math.round(d) + "d ago";
+    return Math.round(d / 30) + "mo ago";
+  }
+  function dateLabel(iso) {
+    const t = Date.parse(iso);
+    if (isNaN(t)) return String(iso || "").slice(0, 10);
+    return new Date(t).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  }
+  function highlight(text, q) {
+    text = esc(text);
+    if (!q) return text;
+    try { return text.replace(new RegExp("(" + q.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + ")", "ig"), "<mark>$1</mark>"); }
+    catch (_) { return text; }
+  }
+
+  let MODEL = { list: [], byType: {}, byStatus: {}, total: 0, source: "snapshot" };
+  let typeFilter = "all", timeFilter = "all";
+
+  function card(d, q) {
+    const tags = (d.tags || []).slice(0, 5).map((t) => `<span class="tag">${esc(t)}</span>`).join(" ");
+    const details = (d.details || "").trim();
+    const stale = d.stale ? `<span class="tag warn" title="aged / still open — verify before acting">stale</span>` : "";
+    return `<div class="panel" style="padding:var(--space-5)">
+      <div style="display:flex;gap:var(--space-3);align-items:center;flex-wrap:wrap;margin-bottom:var(--space-2)">
+        <span class="tag" style="border-color:var(--line-2)">${label(d.type)}</span>
+        <span class="tag" style="color:${STATUS_COLOR[d.status] || "var(--muted)"}">${esc(d.status)}</span>
+        ${stale}
+        <span class="spring"></span>
+        <span class="fresh">${esc(d.by || "—")} · ${dateLabel(d.id)} <span style="color:var(--faint)">(${relTime(d.id)})</span></span>
+      </div>
+      <div style="color:var(--ink);font-size:var(--text-base);line-height:var(--leading-body);margin-bottom:${details || tags ? "var(--space-3)" : "0"}">${highlight(d.summary, q)}</div>
+      ${tags ? `<div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:${details ? "var(--space-3)" : "0"}">${tags}</div>` : ""}
+      ${details ? `<details><summary style="cursor:pointer;color:var(--muted);font-size:var(--text-sm)">details</summary>
+        <div style="margin-top:var(--space-2);color:var(--ink-2);font-size:var(--text-sm);white-space:pre-wrap">${esc(details)}</div></details>` : ""}
+    </div>`;
+  }
+
+  function render() {
+    const q = ($("#dsc-search") && $("#dsc-search").value || "").toLowerCase().trim();
+    let rows = MODEL.list.slice();
+    if (typeFilter !== "all") rows = rows.filter((d) => (d.type || "note") === typeFilter);
+    if (timeFilter !== "all") {
+      const cut = Date.now() - { "24h": 864e5, "7d": 6048e5, "30d": 2592e6 }[timeFilter];
+      rows = rows.filter((d) => Date.parse(d.id) >= cut);
+    }
+    if (q) rows = rows.filter((d) => ((d.summary || "") + " " + (d.details || "") + " " + (d.tags || []).join(" ")).toLowerCase().includes(q));
+    rows.sort((a, b) => Date.parse(b.id || 0) - Date.parse(a.id || 0));
+
+    // lifecycle bar
+    const bs = MODEL.byStatus || {};
+    const totalS = Object.values(bs).reduce((a, n) => a + n, 0) || 1;
+    const barOrder = ["open", "resolved", "archived", "superseded", "closed"];
+    const bar = barOrder.filter((k) => bs[k]).map((k) =>
+      `<div title="${k}: ${bs[k]}" style="width:${(bs[k] / totalS) * 100}%;background:${STATUS_COLOR[k]};height:100%"></div>`).join("");
+    const barLegend = barOrder.filter((k) => bs[k]).map((k) =>
+      `<span><i style="background:${STATUS_COLOR[k]}"></i>${k} ${bs[k]}</span>`).join("");
+
+    // type legend
+    const bt = MODEL.byType || {};
+    const types = Object.keys(bt).sort((a, b) => (TYPE_ORDER.indexOf(a) + 1 || 99) - (TYPE_ORDER.indexOf(b) + 1 || 99));
+    const legend = ["all"].concat(types).map((t) => {
+      const n = t === "all" ? MODEL.total : bt[t];
+      const on = t === typeFilter;
+      return `<button class="theme-toggle dsc-type" data-type="${t}" style="${on ? "border-color:var(--accent);color:var(--accent)" : ""}">${label(t)} <span style="color:var(--faint)">${n ?? ""}</span></button>`;
+    }).join("");
+
+    $("#dsc-mount").innerHTML =
+      `${Object.keys(bs).length ? `<div style="margin-bottom:var(--space-4)">
+         <div class="track" style="height:10px;display:flex;gap:1px">${bar}</div>
+         <div class="legend" style="margin-top:var(--space-2)">${barLegend} <span class="src-badge ${MODEL.source}" style="margin-left:auto">${MODEL.source}</span></div>
+       </div>` : ""}
+       <div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:var(--space-4)">${legend}</div>
+       <div style="display:flex;gap:var(--space-3);flex-wrap:wrap;margin-bottom:var(--space-4)">
+         <input id="dsc-search" placeholder="search summary · details · tags" value="${esc(q)}"
+           style="flex:1;min-width:200px;padding:var(--space-2) var(--space-3);font-family:var(--font-sans);font-size:var(--text-sm);background:var(--surface);color:var(--ink);border:var(--hairline) solid var(--line-2);border-radius:var(--radius-sm)" />
+         <select id="dsc-time" class="theme-toggle">${[["all", "all time"], ["24h", "24h"], ["7d", "7 days"], ["30d", "30 days"]].map(([v, t]) => `<option value="${v}" ${v === timeFilter ? "selected" : ""}>${t}</option>`).join("")}</select>
+       </div>
+       <div style="display:flex;flex-direction:column;gap:var(--space-3)">
+         ${rows.length ? rows.map((d) => card(d, q)).join("") : `<p class="empty">No matches. Clear filters or change search.</p>`}
+       </div>`;
+    wire();
+  }
+
+  function wire() {
+    const s = $("#dsc-search"); if (s) { s.oninput = render; if (s.value) { s.focus(); s.setSelectionRange(s.value.length, s.value.length); } }
+    const t = $("#dsc-time"); if (t) t.onchange = () => { timeFilter = t.value; render(); };
+    document.querySelectorAll(".dsc-type").forEach((b) => b.onclick = () => { typeFilter = b.dataset.type; render(); });
+  }
+
+  async function load() {
+    const r = await DATA.discoveries();
+    MODEL = { list: r.data.list || [], byType: r.data.byType || {}, byStatus: r.data.byStatus || {}, total: r.data.total || (r.data.list || []).length, source: r.source };
+    render();
+  }
+  window.Discoveries = { load };
+})();

--- a/dashboard/redesign/sections/eisv.js
+++ b/dashboard/redesign/sections/eisv.js
@@ -1,0 +1,115 @@
+/*
+ * EISV section — fleet trajectory charts (Chart.js).
+ * Built from eisv-charts.js oracle, distilled to two line charts:
+ *   upper = E, I, coherence (+ coherence equilibrium line)
+ *   lower = S, V (+ zero line)
+ * Upgrade over the oracle: series/grid/tick colours are read from the
+ * design tokens via getComputedStyle, so the charts are THEME-AWARE —
+ * they re-render correctly in paper or ink. Reads DATA.eisv().
+ */
+(function () {
+  "use strict";
+  const $ = (s) => document.querySelector(s);
+  const cssVar = (name) => getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+
+  let MODEL = { series: [], coherenceEq: 0.5, source: "snapshot" };
+  let upper = null, lower = null;
+
+  function rgba(hex, a) {
+    const h = hex.replace("#", "");
+    if (h.length < 6) return hex;
+    const n = parseInt(h, 16);
+    return `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},${a})`;
+  }
+
+  function baseOptions(extraY) {
+    const grid = rgba(cssVar("--ink") || "#888", 0.06);
+    const tick = cssVar("--muted") || "#888";
+    const surface = cssVar("--surface") || "#222";
+    const line = cssVar("--line-2") || "#444";
+    return {
+      responsive: true, maintainAspectRatio: false, animation: { duration: 250 },
+      interaction: { mode: "index", intersect: false },
+      plugins: {
+        legend: { display: true, position: "bottom", labels: { color: tick, font: { family: "Inter", size: 11 }, boxWidth: 10, boxHeight: 10, usePointStyle: true } },
+        tooltip: { backgroundColor: surface, borderColor: line, borderWidth: 1, titleColor: cssVar("--ink"), bodyColor: tick, titleFont: { family: "Geist Mono" }, bodyFont: { family: "Geist Mono", size: 11 }, padding: 10 },
+      },
+      scales: {
+        x: { grid: { color: grid, drawTicks: false }, ticks: { color: tick, font: { family: "Geist Mono", size: 10 }, maxRotation: 0, autoSkipPadding: 16 } },
+        y: Object.assign({ grid: { color: grid }, ticks: { color: tick, font: { family: "Geist Mono", size: 10 }, callback: (v) => v.toFixed(2) } }, extraY),
+      },
+    };
+  }
+
+  function ds(label, data, color, opts) {
+    return Object.assign({ label, data, borderColor: color, backgroundColor: rgba(color, 0.08), borderWidth: 2, pointRadius: 0, tension: 0.35, fill: true }, opts || {});
+  }
+
+  // dashed reference-line plugin (equilibrium / zero)
+  function refLine(value, color) {
+    return {
+      id: "ref" + value, afterDraw(chart) {
+        const { ctx, chartArea: { left, right }, scales: { y } } = chart;
+        if (!y) return;
+        const yp = y.getPixelForValue(value);
+        ctx.save(); ctx.beginPath(); ctx.setLineDash([4, 4]); ctx.strokeStyle = rgba(color, 0.5);
+        ctx.moveTo(left, yp); ctx.lineTo(right, yp); ctx.stroke(); ctx.restore();
+      },
+    };
+  }
+
+  function build() {
+    if (upper) { upper.destroy(); upper = null; }
+    if (lower) { lower.destroy(); lower = null; }
+    const s = MODEL.series, labels = s.map((p) => p.t);
+    const E = cssVar("--eisv-e"), I = cssVar("--eisv-i"), Sc = cssVar("--eisv-s"), V = cssVar("--eisv-v"), C = cssVar("--eisv-c");
+    const muted = cssVar("--muted");
+
+    upper = new Chart($("#eisv-upper"), {
+      type: "line",
+      data: { labels, datasets: [
+        ds("Energy", s.map((p) => p.E), E),
+        ds("Integrity", s.map((p) => p.I), I),
+        ds("Coherence", s.map((p) => p.C), C, { fill: false, borderDash: [5, 4], borderWidth: 1.5 }),
+      ] },
+      options: baseOptions({ min: 0, max: 1 }),
+      plugins: [refLine(MODEL.coherenceEq, muted)],
+    });
+    lower = new Chart($("#eisv-lower"), {
+      type: "line",
+      data: { labels, datasets: [
+        ds("Entropy", s.map((p) => p.S), Sc),
+        ds("Valence", s.map((p) => p.V), V),
+      ] },
+      options: baseOptions({ min: -0.6, max: 1 }),
+      plugins: [refLine(0, muted)],
+    });
+  }
+
+  function render() {
+    $("#eisv-mount").innerHTML =
+      `<div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-4)">
+         <span class="eyebrow" style="margin:0">Fleet trajectory · last ${MODEL.series.length} min</span>
+         <span class="spring"></span><span class="src-badge ${MODEL.source}">${MODEL.source}</span></div>
+       <div class="panel" style="margin-bottom:var(--space-5)">
+         <div class="panel-head" style="margin-bottom:var(--space-3)"><h2>Energy · Integrity · Coherence</h2></div>
+         <div style="height:240px"><canvas id="eisv-upper"></canvas></div>
+       </div>
+       <div class="panel">
+         <div class="panel-head" style="margin-bottom:var(--space-3)"><h2>Entropy · Valence</h2></div>
+         <div style="height:200px"><canvas id="eisv-lower"></canvas></div>
+       </div>`;
+    if (window.Chart) build();
+    else $("#eisv-mount").insertAdjacentHTML("beforeend", `<p class="empty">Chart.js not loaded.</p>`);
+  }
+
+  async function load() {
+    const r = await DATA.eisv();
+    MODEL = { series: r.data.series || [], coherenceEq: r.data.coherenceEq || 0.5, source: r.source };
+    render();
+  }
+  // re-theme without refetch (called on theme toggle)
+  function retheme() { if (MODEL.series.length && window.Chart) build(); }
+
+  window.EISV = { load, retheme };
+})();

--- a/dashboard/redesign/sections/landing.js
+++ b/dashboard/redesign/sections/landing.js
@@ -1,0 +1,119 @@
+/*
+ * Landing section — residents strip + stats grid + Pulse.
+ * Composes kit primitives, reads the data layer (live-or-snapshot),
+ * badges its own freshness. No fetch here; no styles here.
+ */
+(function () {
+  "use strict";
+
+  const $ = (id) => document.getElementById(id);
+  const fmtSil = (s) => s == null ? "—" : s < 90 ? s + "s" : s < 5400 ? Math.round(s / 60) + "m" : (s / 3600).toFixed(1) + "h";
+  const num = (x, d = 2) => typeof x === "number" ? x.toFixed(d) : "—";
+
+  function badge(el, source) {
+    el.className = "src-badge " + source;
+    el.textContent = source === "live" ? "live" : "snapshot";
+  }
+
+  function renderResidents(residents, source) {
+    badge($("resSrc"), source);
+    $("residents").innerHTML = residents.map((r) => {
+      const cls = r.status === "silent" ? "attention" : r.status === "dark" ? "dark" : "";
+      const meta = r.coherence == null ? "no EISV" : "coh " + num(r.coherence);
+      return `<span class="res ${cls}"><span class="pip"></span>`
+        + `<span class="name">${r.name}</span>`
+        + `<span class="meta">${meta} · ${fmtSil(r.silence)}</span></span>`;
+    }).join("");
+
+    // attention band — derive from real state, don't hardcode
+    const flags = [];
+    residents.forEach((r) => {
+      const thr = r.silenceThreshold || 3600;
+      if (r.silence != null && r.silence > thr) flags.push(`<b>${r.name}</b> silent ${fmtSil(r.silence)}`);
+      else if (r.status === "dark" || (r.coherence == null && r.status !== "silent")) flags.push(`<b>${r.name}</b> reporting no EISV`);
+    });
+    const attn = $("attn");
+    if (flags.length) {
+      attn.hidden = false;
+      attn.innerHTML = `<span class="glyph">⚠</span><span>${flags.join(" · ")} — past check-in threshold.</span>`;
+    } else { attn.hidden = true; }
+  }
+
+  function renderStats(stats, residents, source) {
+    const live = residents.filter((r) => r.coherence != null);
+    const fleetCoh = live.length ? (live.reduce((a, r) => a + r.coherence, 0) / live.length) : null;
+    const cards = [
+      { h: "Fleet Coherence", num: num(fleetCoh), sub: `${live.length} of ${residents.length} residents reporting`, cls: "up", rule: true },
+      { h: "Agents", num: stats.agentsActive, of: "/ " + stats.agentsTotal, sub: "active / total" },
+      { h: "Stuck", num: stats.stuck, sub: stats.stuck ? "needs attention" : "none flagged", cls: stats.stuck ? "down" : "up" },
+      { h: "Discoveries", num: stats.discoveries.toLocaleString(), sub: "+" + stats.discoveriesToday + " today" },
+      { h: "Dialectic", num: stats.dialectic, sub: stats.dialectic ? "open sessions" : "no open sessions" },
+      { h: "System Health", num: stats.systemHealth, sub: "db · ws · reaper" },
+      { h: "Calibration", num: num(stats.calibration), sub: "trajectory health", cls: "up" },
+      { h: "Anomalies", num: stats.anomalies, sub: stats.anomalies ? "1 active" : "clear", cls: stats.anomalies ? "down" : "up" },
+    ];
+    const tiers = stats.trustTiers || [];
+    const max = Math.max(1, ...tiers.map((t) => t.n));
+    const tierBars = tiers.map((t) => `<div class="t ${t.tier}" style="height:${Math.round((t.n / max) * 100)}%"></div>`).join("");
+
+    $("stats").innerHTML = cards.map((s) =>
+      `<div class="card ${s.rule ? "accent-rule" : ""}"><h3>${s.h}</h3>`
+      + `<div class="num">${s.num}${s.of ? `<span class="of"> ${s.of}</span>` : ""}</div>`
+      + `<div class="sub ${s.cls || ""}">${s.sub}</div></div>`
+    ).join("")
+      + `<div class="card wide"><h3>Trust Tiers</h3><div class="tiers">${tierBars}</div>`
+      + `<div class="legend" style="margin-top:.5rem">`
+      + `<span><i style="background:var(--eisv-i)"></i>strong</span>`
+      + `<span><i style="background:var(--eisv-s)"></i>medium</span>`
+      + `<span><i style="background:var(--faint)"></i>weak</span></div></div>`;
+  }
+
+  function renderPulse(residents) {
+    // last check-in = smallest silence among reporting residents
+    const reporting = residents.filter((r) => r.eisv);
+    const last = reporting.sort((a, b) => (a.silence ?? 1e9) - (b.silence ?? 1e9))[0];
+    if (!last) return;
+    $("pulseWho").textContent = last.name;
+    $("pulseFresh").textContent = "checked in " + fmtSil(last.silence) + " ago";
+
+    const risk = last.risk ?? 0;
+    $("riskVal").textContent = num(risk);
+    $("riskFill").style.width = Math.max(2, risk * 100) + "%";
+    const fill = $("riskFill");
+    fill.style.background = risk < 0.35 ? "var(--ok)" : risk < 0.6 ? "var(--warn)" : "var(--danger)";
+
+    const v = $("pulseVerdict");
+    const verd = last.verdict || "—";
+    v.className = "verdict" + (verd === "proceed" ? "" : risk >= 0.7 ? " danger" : " warn");
+    v.querySelector("span:last-child").textContent = verd;
+
+    const E = last.eisv;
+    const rows = [["E", E.E, "e", false], ["I", E.I, "i", false], ["S", E.S, "s", false], ["V", E.V, "v", true]];
+    $("eisv").innerHTML = rows.map(([k, val, c, signed]) => {
+      const w = signed ? Math.abs(val) * 50 : val * 100;
+      const left = signed ? (val < 0 ? 50 - Math.abs(val) * 50 : 50) : 0;
+      return `<div class="eisv-row"><span class="k">${k}</span>`
+        + `<span class="bar ${signed ? "signed" : ""}"><i class="${c}" style="left:${left}%;width:${w}%"></i></span>`
+        + `<span class="val">${num(val)}</span></div>`;
+    }).join("");
+  }
+
+  async function render() {
+    const [health, residents, stats] = await Promise.all([DATA.health(), DATA.residents(), DATA.stats()]);
+    if (health.data) {
+      const h = health.data;
+      $("serverStat").innerHTML = `v<b>${h.version}</b> · up <b>${h.uptime}</b> · db <b>${h.db}</b>`;
+    }
+    renderResidents(residents.data, residents.source);
+    renderStats(stats.data, residents.data, stats.source);
+    renderPulse(residents.data);
+
+    const anyLive = [residents, stats, health].some((r) => r.source === "live");
+    $("foot").innerHTML = anyLive
+      ? "Redesign · served live · design system in <code>tokens.css</code> + <code>kit.css</code>."
+      : "Redesign reference · rendering bundled snapshot (open served same-origin for live data) · "
+        + "design system in <code>tokens.css</code> + <code>kit.css</code>. Toggle theme to reskin via one token swap.";
+  }
+
+  window.Landing = { render };
+})();

--- a/dashboard/redesign/sections/residents.js
+++ b/dashboard/redesign/sections/residents.js
@@ -1,0 +1,94 @@
+/*
+ * Residents section — per-resident detail panels.
+ * Consolidates the old watcher.js / sentinel.js / vigil.js / system-health.js
+ * panels into one section: Watcher findings funnel, Sentinel findings by
+ * severity/class + recent stream, Vigil cycles/writes + EISV, Chronicler
+ * silence note, and System Health. Composes kit; reads DATA.residentPanels().
+ */
+(function () {
+  "use strict";
+  const esc = (s) => String(s == null ? "" : s).replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+  const SEV = { high: "var(--danger)", medium: "var(--warn)", low: "var(--muted)", info: "var(--eisv-c)" };
+  function relTime(iso) { const ms = Date.now() - Date.parse(iso); if (isNaN(ms)) return ""; const h = ms / 3.6e6; return h < 1 ? Math.round(ms / 6e4) + "m" : h < 24 ? Math.round(h) + "h" : Math.round(h / 24) + "d"; }
+  function ago(sec) { return sec == null ? "—" : sec < 90 ? Math.round(sec) + "s" : sec < 5400 ? Math.round(sec / 60) + "m" : (sec / 3600).toFixed(1) + "h"; }
+
+  function head(name, status, sub) {
+    const color = status === "silent" ? "var(--warn)" : status === "dark" ? "var(--faint)" : "var(--ok)";
+    return `<div class="panel-head" style="margin-bottom:var(--space-4)">
+      <span class="dot-pip" style="background:${color}"></span>
+      <h2 style="font-family:var(--font-display);font-size:var(--text-lg)">${name}</h2>
+      <span class="spring"></span><span class="fresh">${esc(sub || "")}</span></div>`;
+  }
+  function stat(label, val, color) {
+    return `<div><div style="font-family:var(--font-mono);font-size:var(--text-lg);color:${color || "var(--ink)"};line-height:1">${val}</div>
+      <div style="font-size:var(--text-xs);color:var(--muted);text-transform:uppercase;letter-spacing:var(--tracking-label)">${label}</div></div>`;
+  }
+  const statRow = (items) => `<div style="display:flex;gap:var(--space-6);flex-wrap:wrap">${items.join("")}</div>`;
+
+  function watcher(w) {
+    if (!w) return "";
+    const s = w.byStatus || {}, total = w.total || 0;
+    const seg = (n, color, t) => n ? `<div title="${t}: ${n}" style="width:${(n / total) * 100}%;background:${color};height:100%"></div>` : "";
+    const pats = (w.patterns || []).slice(0, 4).map((p) =>
+      `<div style="display:flex;gap:var(--space-3);align-items:center;font-size:var(--text-sm)">
+         <span class="tag" style="font-family:var(--font-mono)">${esc(p.p)}</span>
+         <span style="color:var(--ok)">${p.confirmed || 0}✓</span><span style="color:var(--muted)">${p.dismissed || 0}✗</span>
+         <span class="spring"></span><span class="fresh">${p.ratio == null ? "—" : "dismiss " + Math.round(p.ratio * 100) + "%"}</span></div>`).join("");
+    return `<div class="panel">${head("Watcher", "healthy", "diagnostic · event-driven")}
+      ${statRow([stat("findings", total), stat("confirmed", s.confirmed || 0, "var(--ok)"), stat("dismissed", s.dismissed || 0, "var(--muted)"), stat("open high", (w.openSev || {}).high || 0, "var(--danger)")])}
+      <div class="track" style="height:8px;display:flex;gap:1px;margin:var(--space-4) 0 var(--space-2)">
+        ${seg(s.confirmed, "var(--ok)", "confirmed")}${seg(s.surfaced, "var(--warn)", "surfaced")}${seg(s.dismissed, "var(--faint)", "dismissed")}</div>
+      <div class="legend" style="margin-bottom:var(--space-4)"><span><i style="background:var(--ok)"></i>confirmed</span><span><i style="background:var(--warn)"></i>surfaced</span><span><i style="background:var(--faint)"></i>dismissed</span></div>
+      <div style="display:flex;flex-direction:column;gap:var(--space-2)">${pats}</div></div>`;
+  }
+
+  function sentinel(sn) {
+    if (!sn) return "";
+    const classes = (sn.byClass || []).map((c) => `<span class="tag">${esc(c.c || "?")} ${c.n}</span>`).join(" ");
+    const recent = (sn.recent || []).slice(0, 3).map((r) =>
+      `<div style="display:flex;gap:var(--space-3);align-items:baseline;font-size:var(--text-sm);padding:var(--space-2) 0;border-top:var(--hairline) solid var(--line)">
+         <span style="color:${SEV[r.severity] || "var(--muted)"};flex:none">●</span>
+         ${r.vclass ? `<span class="tag" style="flex:none">${esc(r.vclass)}</span>` : ""}
+         <span style="color:var(--ink-2);flex:1;min-width:0">${esc(r.message)}</span>
+         <span class="fresh" style="flex:none">${relTime(r.ts)} ago</span></div>`).join("");
+    return `<div class="panel">${head("Sentinel", "healthy", "analytical · fleet monitor")}
+      ${statRow([stat("findings", sn.total || 0), stat("high", (sn.bySeverity || {}).high || 0, "var(--danger)"), stat("medium", (sn.bySeverity || {}).medium || 0, "var(--warn)")])}
+      <div style="display:flex;gap:6px;flex-wrap:wrap;margin:var(--space-4) 0">${classes}</div>
+      <div class="eyebrow" style="margin-bottom:0">recent findings</div>${recent}</div>`;
+  }
+
+  function vigil(v) {
+    if (!v) return "";
+    const e = v.eisv || {};
+    return `<div class="panel">${head("Vigil", "healthy", "janitorial · 30min cron · last " + ago(v.lastCycleAgeS) + " ago")}
+      ${statRow([stat("cycles 24h", v.cycles24h || 0), stat("writes", v.writesWindow || 0), stat("avg coh", (v.avgCoherence || 0).toFixed(2)), stat("verdict", v.lastVerdict || "—", "var(--ok)")])}
+      ${e.E != null ? `<div style="margin-top:var(--space-4);display:flex;gap:var(--space-5);font-family:var(--font-mono);font-size:var(--text-sm);color:var(--ink-2)">
+        <span>E ${e.E.toFixed(2)}</span><span>I ${e.I.toFixed(2)}</span><span>S ${e.S.toFixed(2)}</span><span>V ${e.V.toFixed(2)}</span></div>` : ""}</div>`;
+  }
+
+  function chronicler(c) {
+    if (!c) return "";
+    return `<div class="panel" style="border-left:2px solid var(--warn)">${head("Chronicler", "silent", "daily resident")}
+      <div style="color:var(--ink-2);font-size:var(--text-sm)"><span class="tag warn">silent ${c.silenceH}h</span> ${esc(c.note || "")}</div></div>`;
+  }
+
+  function health(h) {
+    if (!h) return "";
+    const ch = h.checks || {};
+    return `<div class="panel">${head("System Health", h.status === "healthy" ? "healthy" : "silent", "v" + esc(h.version || "") + " · continuity " + esc(h.continuity || "—"))}
+      ${statRow([stat("checks ok", ch.healthy || 0, "var(--ok)"), stat("warnings", ch.warning || 0, (ch.warning ? "var(--warn)" : "var(--muted)")), stat("breaker trips 24h", (h.breakers || {}).governance || 0, "var(--ok)"), stat("calibration", h.calibration || "—", "var(--ok)")])}</div>`;
+  }
+
+  async function load() {
+    const r = await DATA.residentPanels();
+    const d = r.data || {};
+    document.querySelector("#res-mount").innerHTML =
+      `<div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-4)">
+         <span class="eyebrow" style="margin:0">Always-on fleet</span><span class="spring"></span><span class="src-badge ${r.source}">${r.source}</span></div>
+       <div style="display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4)">
+         ${watcher(d.watcher)}${sentinel(d.sentinel)}${vigil(d.vigil)}${health(d.health)}
+       </div>
+       <div style="margin-top:var(--space-4)">${chronicler(d.chronicler)}</div>`;
+  }
+  window.Residents = { load };
+})();

--- a/dashboard/redesign/snapshot.js
+++ b/dashboard/redesign/snapshot.js
@@ -1,0 +1,134 @@
+/*
+ * Bundled real snapshot — pulled live from the governance server on
+ * 2026-06-19 (/v1/residents + /health). Lets the redesign render
+ * portably (opened as a file, no auth) and gives data.js a truthful
+ * fallback when a live endpoint is unreachable. Retargeting to live is
+ * data.js's job, not a rewrite of any view.
+ */
+window.SNAPSHOT = {
+  capturedAt: "2026-06-19T19:30:00Z",
+  health: { version: "2.13.0", uptime: "21h 15m", db: "connected" },
+  residents: [
+    { name:"Watcher",    status:"healthy", coherence:0.50, risk:0.00, verdict:"proceed", eisv:{E:0.77,I:0.66,S:0.24,V:+0.10}, silence:25 },
+    { name:"Vigil",      status:"healthy", coherence:0.49, risk:0.00, verdict:"proceed", eisv:{E:0.75,I:0.77,S:0.16,V:-0.02}, silence:101 },
+    { name:"Lumen",      status:"careful", coherence:0.50, risk:0.00, verdict:"proceed", eisv:{E:0.31,I:0.83,S:0.15,V:-0.52}, silence:56 },
+    { name:"Sentinel",   status:"healthy", coherence:0.50, risk:0.00, verdict:"proceed", eisv:{E:0.77,I:0.68,S:0.26,V:+0.09}, silence:273 },
+    { name:"Steward",    status:"dark",    coherence:null, risk:null, verdict:null,      eisv:null,                          silence:32 },
+    { name:"Chronicler", status:"silent",  coherence:0.50, risk:0.00, verdict:"proceed", eisv:{E:0.81,I:0.68,S:0.22,V:+0.11}, silence:67156 },
+  ],
+  // representative until wired to live tool calls (agent/detect_stuck/knowledge/calibration)
+  stats: {
+    agentsActive: 6, agentsTotal: 658, stuck: 0, discoveries: 1204, discoveriesToday: 12,
+    dialectic: 0, systemHealth: "OK", calibration: 0.71, anomalies: 1,
+    trustTiers: [
+      { tier:"strong", n:78 }, { tier:"strong", n:64 }, { tier:"strong", n:90 },
+      { tier:"medium", n:44 }, { tier:"medium", n:52 }, { tier:"weak", n:30 }, { tier:"weak", n:22 },
+    ],
+  },
+  // Real subset from agent(list) on 2026-06-19T20:03Z — covers residents
+  // (verified/persistent), engaged-ephemerals (emerging), one-shots (unknown),
+  // a redacted resident, an event-driven resident, and an anon. Plus the
+  // real fleet summary so counts and the never-participated cohort are true.
+  agentsSummary: { total:620, active:584, archived:36, paused:0, participated:259, neverParticipated:361 },
+  agentsList: [
+    { agent_id:"mcp_20260428_69a1a4f7", label:"Lumen", status:"active", tier:"verified", updates:125681, last:"2026-06-19T20:01:21Z", purpose:"Lumen — embodied digital creature", tags:["pinned","autonomous","embodied","persistent"], event_driven:false, health:"healthy", redacted:true, metrics:{coherence:0.497,risk:0.191,verdict:"safe",E:0.851,I:0.854,S:0.048,V:-0.005} },
+    { agent_id:"mcp_20260407_f92dcea8", label:"Sentinel", status:"active", tier:"verified", updates:15669, last:"2026-06-19T19:59:05Z", purpose:"Sentinel — analytical resident, WebSocket fleet monitor", tags:["persistent","autonomous"], event_driven:false, health:"healthy", redacted:true, lifecycleReason:"Self-recovery probe", metrics:{coherence:0.497,risk:0.265,verdict:"safe",E:0.764,I:0.768,S:0.095,V:-0.006} },
+    { agent_id:"mcp_20260416_907e3195", label:"Watcher", status:"active", tier:"verified", updates:5182, last:"2026-06-19T19:55:54Z", purpose:"Watcher — diagnostic resident, event-driven on Edit/Write", tags:["persistent","autonomous"], event_driven:true, health:"healthy", redacted:true, metrics:{coherence:0.499,risk:0.248,verdict:"safe",E:0.765,I:0.766,S:0.077,V:-0.002} },
+    { agent_id:"mcp_20260406_e55caaf1", label:"Vigil", status:"active", tier:"verified", updates:3171, last:"2026-06-19T19:56:56Z", purpose:"Vigil — janitorial resident, 30min cron", tags:["persistent","autonomous","cadence.30min"], event_driven:false, health:"healthy", redacted:true, metrics:{coherence:0.489,risk:0.221,verdict:"safe",E:0.792,I:0.808,S:0.059,V:-0.023} },
+    { agent_id:"mcp_20260417_9a6681ec", label:"Steward", status:"active", tier:"unknown", updates:15112, last:"2026-06-19T20:03:06Z", purpose:"Steward — custodial resident, Pi→Mac EISV sync", tags:["persistent","autonomous"], event_driven:false, health:"healthy", redacted:true, lifecycleReason:"Energy-integrity imbalance — recalibrate", metrics:{coherence:0.495,risk:0.279,verdict:"safe",E:0.838,I:0.845,S:0.090,V:-0.011} },
+    { agent_id:"7a424397-3f2c-4a33-8b8a-fd706c3a5ac8", label:"dashboard-redesign", status:"active", tier:"unknown", updates:2, last:"2026-06-19T20:00:50Z", purpose:"implementation", tags:["ephemeral"], event_driven:false, health:"healthy", redacted:false, metrics:{coherence:0.489,risk:0.282,verdict:"safe",E:0.729,I:0.796,S:0.142,V:-0.022} },
+    { agent_id:"Claude_Code_20260619_18d9a014", label:"claude-cirwel#49251cfd", status:"active", tier:"emerging", updates:26, last:"2026-06-19T19:56:00Z", purpose:null, tags:["engaged_ephemeral"], event_driven:false, health:"healthy", redacted:true, metrics:{coherence:0.506,risk:0.283,verdict:"safe",E:0.778,I:0.770,S:0.083,V:0.012} },
+    { agent_id:"Claude_20260619_18ff4568", label:"claude_code-claude_18ff4568", status:"active", tier:"emerging", updates:21, last:"2026-06-19T17:38:01Z", purpose:"review", tags:["engaged_ephemeral"], event_driven:false, health:"healthy", redacted:true, metrics:{coherence:0.504,risk:0.261,verdict:"safe",E:0.788,I:0.780,S:0.076,V:0.008} },
+    { agent_id:"Claude_Code_20260618_a0382d76", label:"claude-dispatch_beam#0b06a37f", status:"active", tier:"emerging", updates:12, last:"2026-06-19T14:59:09Z", purpose:"testing", tags:["engaged_ephemeral"], event_driven:false, health:"healthy", redacted:true, metrics:{coherence:0.500,risk:0.306,verdict:"safe",E:0.776,I:0.766,S:0.088,V:-0.000} },
+    { agent_id:"Gpt_5_5_20260619_11723403", label:"UNITARES Dogfood Pulse", status:"active", tier:"unknown", updates:1, last:"2026-06-19T18:32:35Z", purpose:"review", tags:["ephemeral"], event_driven:false, health:"healthy", redacted:true, metrics:{coherence:0.496,risk:0.259,verdict:"safe",E:0.708,I:0.799,S:0.174,V:-0.009} },
+    { agent_id:"anon_20260619_3a73a16c", label:"Euler", status:"active", tier:"unknown", updates:1, last:"2026-06-19T15:09:52Z", purpose:null, tags:["ephemeral"], event_driven:false, health:"healthy", redacted:true, metrics:{coherence:0.499,risk:0.263,verdict:"safe",E:0.703,I:0.800,S:0.190,V:-0.003} },
+    { agent_id:"anon_20260619_98e07da6", label:"Codex Weekly Release Notes", status:"active", tier:"unknown", updates:3, last:"2026-06-19T15:02:54Z", purpose:"deployment", tags:["engaged_ephemeral"], event_driven:false, health:"healthy", redacted:true, metrics:{coherence:0.490,risk:0.296,verdict:"safe",E:0.722,I:0.797,S:0.138,V:-0.020} },
+    { agent_id:"anon_20260619_b59c548a", label:null, status:"active", tier:"unknown", updates:1, last:"2026-06-19T14:42:34Z", purpose:"review", tags:["ephemeral"], event_driven:false, health:"healthy", redacted:true, metrics:{coherence:0.499,risk:0.266,verdict:"safe",E:0.703,I:0.800,S:0.190,V:-0.003} },
+    { agent_id:"Hermes_Agent_20260618_ea594d5d", label:"Hermes Agent_ea594d5d", status:"active", tier:"unknown", updates:2, last:"2026-06-19T02:19:47Z", purpose:"debugging", tags:["ephemeral"], event_driven:false, health:"healthy", redacted:true, metrics:{coherence:0.493,risk:0.260,verdict:"safe",E:0.713,I:0.798,S:0.161,V:-0.013} },
+  ],
+  // Real KG entries + aggregate stats from knowledge(list/search) 2026-06-19T20:14Z.
+  discoveries: {
+    total: 1075,
+    byType: { note:474, insight:234, improvement:104, bug_found:89, trajectory_continuity_score:50, pattern:30, answer:22, architectural_decision:19, bug_fix:13, recovery_reflection:13, question:11, experiment:8, exploration:2 },
+    byStatus: { open:134, resolved:84, archived:774, superseded:18, closed:2 },
+    list: [
+      { id:"2026-04-21T08:29:49Z", type:"insight", status:"resolved", by:"Claude_Opus_4_7_20260419", tags:["identity","metaphysics","research-direction","behavioral-identity","lifespan-as-trust"], summary:"Identity metaphysics — layer identification: the persistent-per-role vs per-instance question is mis-fixed at the harness layer. UNITARES's offering is a different layer — tools the harness can't provide. Four candidate directions captured for research, not code.", details:"Kenny is aiming for heterogeneity by default, not shared continuity. Behavioral identity (EISV trajectory fingerprint), lifespan-as-earned-trust, self-discontinuity detection, heterogeneous shared context." },
+      { id:"2026-06-16T15:36:34Z", type:"note", status:"open", by:"Hermes GPT-5.5 CLI dogfood", tags:["unitares","ablation","calibration-harness","synthetic-negative-control"], summary:"Calibration-harness strict_bad alert traced to a controlled probe (overconfidence_probe, seeded assertion failure) rather than a prevented production bad outcome. Fix: mark harness outcomes synthetic_calibration_fixture and exclude from live ablation reports.", details:"Refuse known live governance ports in probe_one; preserve fixtures in isolated harness analysis only." },
+      { id:"2026-06-16T08:10:44Z", type:"recovery_reflection", status:"open", by:"Codex Desktop UNITARES", tags:["recovery","self-reflection","tight"], summary:"Self-recovery reflection: thread moving quickly through several sidecar increments; governance flagged a tight coherence margin. Keeping the pass narrowly scoped, avoiding identity-contract changes, running focused + full validation before shipping.", details:"Metrics at reflection: coherence=0.493, risk=0.333, void=-0.014" },
+      { id:"2025-12-13T04:49:59Z", type:"pattern", status:"open", by:"cursor-opus-exploration", tags:["calibration","overconfidence","trajectory-health","epistemic-humility"], summary:"Inverted-U in calibration: low-confidence agents (0.0–0.5) show 95.7% trajectory health vs 33.1% for high-confidence (0.9–1.0). Epistemic humility correlates with good outcomes.", details:"From 1605 samples over 24h. Confidence 0.7–0.8 bin dips to 7.6% trajectory health.", stale:true },
+      { id:"2026-05-20T07:39:29Z", type:"note", status:"resolved", by:"Hermes", tags:["unitares","dogfood","calibration","mirror-mode","resolved"], summary:"Mirror-mode calibration wording finding resolved: a fresh strong-identity check-in now says \"Fleet calibration: 99% trajectory health\" instead of labeling the strategic proxy as \"accuracy\". calibration(check) still exposes tactical accuracy=0.804 separately.", details:"" },
+      { id:"2026-04-16T03:25:50Z", type:"insight", status:"open", by:"opus_dogfood_claude_code", tags:["governance-plugin","calibration","eisv-trajectory","check-in-cadence"], summary:"Governance plugin binds identity but doesn't generate continuous EISV trajectory — 4 check-ins across a 4.5h session leaves calibration with no data. The system can't distinguish a healthy agent from an absent one.", details:"Approaches: auto-check-in per turn, derive EISV from observable signals (tool calls/commits/tests), or both.", stale:true },
+      { id:"2025-12-14T21:44:32Z", type:"improvement", status:"resolved", by:"claude-opus-hikewa", tags:["architecture","identity","agi-forward","refactor"], summary:"AGI-Forward Identity Refactor spec — removes scaffolding for confused LLMs, designs for genuine self-concept. Triggered by Qwen/Goose trying to bind to another agent's ID.", details:"Remove candidate lists; strict authentication; treat IDs as identities to respect, not resources to use." },
+      { id:"2025-12-13T05:53:10Z", type:"pattern", status:"open", by:"cursor-opus-exploration", tags:["design-principle","self-governance","calibration","philosophy"], summary:"Design principle: self-governance over human-as-oracle — agents should calibrate from objective outcomes (tests, linters, commands) rather than treating human judgment as ground truth.", details:"Human-as-oracle creates bottlenecks, is often wrong, and is philosophically flawed.", stale:true },
+    ],
+  },
+  // Real dialectic sessions from dialectic(list) 2026-06-19T20:30Z.
+  dialectic: {
+    counts: { total:12, resolved:8, active:0, failed:4 },
+    sessions: [
+      { id:"51902877fe3c5632", phase:"resolved", type:"review", paused:"37f5f08e", reviewer:null, synthesizer:"llm-synthetic-reviewer", topic:"Live post-deploy verification of end-to-end path on the deploy-worktree process, reframed as an audit of governance resilience under synthetic stress.", created:"2026-06-17T19:55:49Z", msgs:3, resolution:{ action:"resume", reasoning:"Core goal remains confirming end-to-end path functionality, but execution is reframed as an audit of governance resilience under synthetic stress.", conditions:3, rootCause:"Live post-deploy verification; synthetic-reviewer completion (PR #825) drives the thesis to a resolved synthesis inline." } },
+      { id:"818cc0592c4ac70b", phase:"failed", type:"review", paused:"fac35bde", reviewer:null, synthesizer:null, topic:"Council (conceptual + implementation) diverges on whether a protected Core tier is safe for an identity-bearing store. Need adversarial pressure-test before committing code.", created:"2026-06-16T07:42:25Z", msgs:1, resolution:null },
+      { id:"95c9ddfd6bb09308", phase:"resolved", type:"review", paused:"07d0f9c7", reviewer:"9f60251c", synthesizer:null, topic:"Next step after a proposal to first audit existing Discord/leave_note/KG overlap; warned Hermes should not author the RFC alone. Need parallel dialectic seasoning before implementation.", created:"2026-04-30T10:04:15Z", msgs:5, resolution:{ action:"resume", reasoning:"Antithesis hardens v1 boundaries rather than overturning the thesis. Shrink the primitive to a PostgreSQL-backed lease table with validated evidence references and explicit fork/compaction handling.", conditions:0, rootCause:"Missing low-latency but bounded coordination primitive for single-writer surfaces across concurrent loci." } },
+      { id:"aeca25ec9a2097a6", phase:"resolved", type:"review", paused:"6c0e4190", reviewer:"6c0e4190", synthesizer:null, topic:"Required re-run council pass on changed load-bearing identity-resolution/auth surfaces before merge.", created:"2026-04-30T06:50:03Z", msgs:3, resolution:{ action:"resume", reasoning:"Implementation is locally coherent and addresses council findings with tests, but should stay an implementation candidate until a real external council/live-verifier reviews the diff.", conditions:4, rootCause:"Council found a missing PATH0 persisted-status handoff and an unbounded DB await." } },
+      { id:"2364de8c0c08c971", phase:"resolved", type:"review", paused:"fe5975a6", reviewer:"fe5975a6", synthesizer:null, topic:"Exploration scope vs synthesis rhythm.", created:"2026-04-29T02:06:05Z", msgs:4, resolution:{ action:"resume", reasoning:"Converged synthesis: keep exploration scope but enforce synthesis rhythm. The failure was execution (timing), not strategy (scope).", conditions:5, rootCause:"Timing failure in exploration — not scope; enforce synthesis rhythm during breadth-first discovery." } },
+      { id:"fa26935f484a9890", phase:"resolved", type:"review", paused:"086a9abd", reviewer:"4e706031", synthesizer:null, topic:"Should verdict action semantics be class-conditional, or does the uniform-contract view win? The cost of honoring pause varies by 4 orders of magnitude across the fleet.", created:"2026-04-19T08:32:05Z", msgs:4, resolution:{ action:"resume", reasoning:"Converged: the verdict CONTRACT stays class-invariant for interpretability; the real gap is the verdict payload lacking class context. This is payload completeness, not contract redefinition.", conditions:4, rootCause:"Session recursively self-demonstrated the framework's facilitator-load (auto-assigned a monitoring agent with no thesis-response code)." } },
+      { id:"56bead4ed32ab6a5", phase:"failed", type:"review", paused:"f92dcea8", reviewer:"f92dcea8", synthesizer:null, topic:"Exploration — probing whether UNITARES' self-governance loop produces useful insights or just recursive noise.", created:"2026-04-25T22:47:21Z", msgs:3, resolution:null },
+      { id:"cbdfc95a258c6470", phase:"resolved", type:"recovery", paused:"69a1a4f7", reviewer:"9d3ac2cb", synthesizer:null, topic:"", created:"2026-03-12T13:15:04Z", msgs:0, resolution:{ action:"resume", reasoning:"Session auto-created for non-reasoning embodied agent; root cause fixed at system level.", conditions:0, rootCause:"Trust-tier calculation bug (Lumen observation_count used anima cycle count instead of governance lifetime updates), fixed in bed604a." } },
+    ],
+  },
+  // Real event stream + activity histogram from /api/events + /api/activity 2026-06-19T20:30Z.
+  activity: {
+    buckets: [ {p:5,g:0,x:0},{p:7,g:0,x:0},{p:8,g:0,x:0},{p:3,g:0,x:0},{p:10,g:0,x:0},{p:4,g:0,x:0},{p:7,g:0,x:0},{p:9,g:0,x:0},{p:12,g:0,x:0},{p:5,g:0,x:0},{p:10,g:0,x:0},{p:5,g:0,x:0} ],
+    windowMin: 60, bucketMin: 5,
+    events: [
+      { type:"sentinel_alarm_finding", severity:"high", agent:"Sentinel", ts:"2026-06-19T20:29:58Z", message:"forced release: td:/force-release-contract-test (lease d52d1995…)" },
+      { type:"agent_new", severity:"info", agent:"Codex #425 identity guard handoff", ts:"2026-06-19T20:23:11Z", message:"New agent onboarded" },
+      { type:"sentinel_finding", severity:"medium", agent:"Sentinel", ts:"2026-06-19T20:18:59Z", vclass:"BEH", message:"5 governance events in 10min: identity_assurance_change, knowledge_read, knowledge_write" },
+      { type:"agent_new", severity:"info", agent:"Hermes Agent_10c43cd7", ts:"2026-06-19T19:59:33Z", message:"New agent onboarded" },
+      { type:"agent_new", severity:"info", agent:"dashboard-redesign", ts:"2026-06-19T19:58:37Z", message:"New agent onboarded" },
+      { type:"sentinel_finding", severity:"medium", agent:"Sentinel", ts:"2026-06-19T19:44:00Z", vclass:"ENT", message:"claude-cirwel#49251cfd entropy outlier (z=2.6, S=0.366)" },
+      { type:"agent_new", severity:"info", agent:"Hermes Agent_8838508f", ts:"2026-06-19T19:41:15Z", message:"New agent onboarded" },
+      { type:"agent_new", severity:"info", agent:"Hermes Agent_69e0c0bb", ts:"2026-06-19T19:40:44Z", message:"New agent onboarded" },
+      { type:"agent_new", severity:"info", agent:"claude-unitares#74e219d4", ts:"2026-06-19T19:37:17Z", message:"New agent onboarded" },
+      { type:"agent_new", severity:"info", agent:"claude-dashboard#74e219d4", ts:"2026-06-19T19:24:42Z", message:"New agent onboarded" },
+      { type:"sentinel_finding", severity:"medium", agent:"Sentinel", ts:"2026-06-19T19:20:00Z", vclass:"ENT", message:"claude-cirwel#49251cfd entropy outlier (z=2.1, S=0.287)" },
+    ],
+  },
+  // Real fleet-average EISV series (1-min buckets) from /v1/eisv/recent 2026-06-19T20:38Z.
+  eisv: {
+    coherenceEq: 0.50,
+    series: [
+      {t:"20:22",E:0.292,I:0.826,S:0.171,V:-0.517,C:0.497,R:0.0},
+      {t:"20:23",E:0.733,I:0.735,S:0.250,V:0.045,C:0.498,R:0.138},
+      {t:"20:24",E:0.775,I:0.647,S:0.263,V:0.116,C:0.499,R:0.10},
+      {t:"20:25",E:0.288,I:0.826,S:0.173,V:-0.519,C:0.497,R:0.0},
+      {t:"20:26",E:0.741,I:0.781,S:0.152,V:-0.020,C:0.489,R:0.148},
+      {t:"20:27",E:0.783,I:0.650,S:0.319,V:0.123,C:0.503,R:0.10},
+      {t:"20:28",E:0.607,I:0.713,S:0.249,V:-0.103,C:0.497,R:0.041},
+      {t:"20:29",E:0.790,I:0.653,S:0.354,V:0.129,C:0.506,R:0.20},
+      {t:"20:30",E:0.735,I:0.651,S:0.447,V:-0.001,C:0.497,R:0.05},
+      {t:"20:31",E:0.734,I:0.649,S:0.440,V:0.008,C:0.498,R:0.20},
+      {t:"20:32",E:0.508,I:0.736,S:0.297,V:-0.254,C:0.498,R:0.089},
+      {t:"20:33",E:0.765,I:0.671,S:0.314,V:0.092,C:0.496,R:0.102},
+      {t:"20:35",E:0.279,I:0.825,S:0.173,V:-0.526,C:0.497,R:0.131},
+      {t:"20:36",E:0.734,I:0.643,S:0.424,V:0.023,C:0.503,R:0.05},
+      {t:"20:37",E:0.732,I:0.640,S:0.431,V:0.030,C:0.504,R:0.05},
+      {t:"20:38",E:0.521,I:0.749,S:0.247,V:-0.218,C:0.496,R:0.0},
+    ],
+  },
+  // Real resident-panel data from /v1/{watcher,sentinel,vigil}/summary + /health/deep 2026-06-19T20:41Z.
+  residentPanels: {
+    watcher: { total:76, byStatus:{ dismissed:54, confirmed:17, surfaced:5 }, openSev:{ high:3, medium:2 },
+      patterns:[ {p:"P011",confirmed:6,dismissed:16,surfaced:1,ratio:0.73}, {p:"P001",confirmed:7,dismissed:7,surfaced:0,ratio:0.50}, {p:"P016",confirmed:0,dismissed:7,surfaced:2,ratio:1.0}, {p:"P009",confirmed:0,dismissed:0,surfaced:2,ratio:null} ] },
+    sentinel: { total:22, bySeverity:{ medium:14, high:8 },
+      byClass:[ {c:"?",n:9}, {c:"ENT",n:8}, {c:"BEH",n:5} ],
+      recent:[ {ts:"2026-06-19T20:30:19Z",severity:"high",vclass:null,type:"ad_hoc",message:"forced release: td:/force-release-contract-test (lease d52d1995…)"},
+        {ts:"2026-06-19T20:18:59Z",severity:"medium",vclass:"BEH",type:"correlated_events",message:"5 governance events in 10min: identity_assurance_change, knowledge_read, knowledge_write"},
+        {ts:"2026-06-19T19:44:00Z",severity:"medium",vclass:"ENT",type:"entropy_outlier",message:"claude-cirwel#49251cfd entropy outlier (z=2.6, S=0.366)"} ] },
+    vigil: { cycles24h:42, writesWindow:30, lastVerdict:"proceed", lastCycleAgeS:890, avgCoherence:0.489,
+      eisv:{E:0.750,I:0.766,S:0.159,V:-0.017,coherence:0.489} },
+    chronicler: { status:"silent", silenceH:18.6, note:"daily resident past its 1h check-in threshold" },
+    health: { status:"healthy", version:"2.13.0", checks:{ healthy:12, warning:0, error:0 },
+      breakers:{ governance:0, redis:0 }, calibration:"healthy", dbPool:{ size:8, idle:4, max:25 }, redis:true, continuity:"redis" },
+  },
+};

--- a/dashboard/redesign/tokens.css
+++ b/dashboard/redesign/tokens.css
@@ -1,0 +1,127 @@
+/*
+ * UNITARES Dashboard — Design Tokens (redesign reference)
+ * --------------------------------------------------------
+ * The discipline, in one file. Everything visual derives from these
+ * variables: one calm base, ONE accent, and a small set of semantic
+ * data-hues that are deliberately desaturated — they carry meaning in
+ * charts and metrics, never decoration. Swap [data-theme] to reskin the
+ * whole app; no component knows which theme is active.
+ *
+ * This replaces the role that 5,877 lines of accreted styles.css plays
+ * today. Components reference tokens, not raw hex.
+ */
+
+:root {
+  /* ---- Type scale (1.20 minor-third), tabular figures for data ---- */
+  --font-display: "Fraunces", Georgia, "Times New Roman", serif;
+  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-mono: "Geist Mono", ui-monospace, "SF Mono", "Menlo", monospace;
+
+  --text-xs:   0.75rem;
+  --text-sm:   0.8125rem;
+  --text-base: 0.9375rem;
+  --text-md:   1.0625rem;
+  --text-lg:   1.375rem;
+  --text-xl:   1.875rem;
+  --text-2xl:  2.75rem;   /* hero metric numbers */
+  --text-3xl:  3.5rem;
+
+  --tracking-label: 0.08em;  /* small-caps section labels */
+  --leading-tight: 1.15;
+  --leading-body: 1.55;
+
+  /* ---- Spacing (8px base, generous) ---- */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+  --space-7: 3rem;
+  --space-8: 4rem;
+
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --radius-pill: 999px;
+
+  --hairline: 1px;
+  --maxw: 1180px;
+
+  /* motion — restrained */
+  --ease: cubic-bezier(0.2, 0, 0, 1);
+  --dur: 180ms;
+}
+
+/* =================  THEME: PAPER (light)  ================= */
+:root,
+[data-theme="paper"] {
+  --bg:        #f6f2ea;  /* warm paper */
+  --bg-sunken: #efe9dd;
+  --surface:   #fffdf8;  /* cards float a shade above the page */
+  --surface-2: #faf6ee;
+
+  --ink:       #211e1a;  /* near-black, warm */
+  --ink-2:     #4a443c;  /* secondary text */
+  --muted:     #8a8278;  /* labels, captions */
+  --faint:     #b7afa2;
+
+  --line:      #e6dfd2;  /* hairlines */
+  --line-2:    #d8cfbd;
+
+  --accent:        #b8502e;  /* clay — the ONE accent */
+  --accent-soft:   #f1e3da;
+  --accent-ink:    #ffffff;
+
+  /* semantic state (desaturated — data only) */
+  --ok:     #4f7d5e;
+  --warn:   #b07d2b;
+  --hot:    #b8502e;
+  --danger: #a8412f;
+  --info:   #4a6f93;
+
+  /* EISV data-hues — calm, distinguishable, never neon */
+  --eisv-e: #6e5aa8;  /* energy   — violet  */
+  --eisv-i: #3f8a6e;  /* integrity— green   */
+  --eisv-s: #b07d2b;  /* entropy  — amber   */
+  --eisv-v: #a8412f;  /* valence  — red     */
+  --eisv-c: #3f7d93;  /* coherence— teal    */
+
+  --shadow: 0 1px 2px rgba(40, 30, 16, 0.04), 0 6px 20px rgba(40, 30, 16, 0.05);
+  --shadow-soft: 0 1px 0 rgba(40, 30, 16, 0.03);
+}
+
+/* =================  THEME: INK (dark)  ================= */
+[data-theme="ink"] {
+  --bg:        #19181a;
+  --bg-sunken: #141315;
+  --surface:   #211f22;
+  --surface-2: #262428;
+
+  --ink:       #ece8e2;
+  --ink-2:     #c2bcb2;
+  --muted:     #8d867c;
+  --faint:     #5e5852;
+
+  --line:      #322f33;
+  --line-2:    #3d3a3e;
+
+  --accent:        #d97757;  /* clay, lifted for dark */
+  --accent-soft:   #33241f;
+  --accent-ink:    #1a120e;
+
+  --ok:     #6fae84;
+  --warn:   #d4a24c;
+  --hot:    #d97757;
+  --danger: #d4705e;
+  --info:   #6f9bc4;
+
+  --eisv-e: #a18fd6;
+  --eisv-i: #5fb992;
+  --eisv-s: #d4a24c;
+  --eisv-v: #d4705e;
+  --eisv-c: #5fa6c4;
+
+  --shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 8px 28px rgba(0, 0, 0, 0.35);
+  --shadow-soft: 0 1px 0 rgba(0, 0, 0, 0.2);
+}


### PR DESCRIPTION
## What this is

A complete Claude-discipline reskin of the operator dashboard, built **on the side** in `dashboard/redesign/`. The live dashboard (`dashboard/index.html` + the existing modules) is **untouched** — this is a reference/preview, not a cutover.

Draft on purpose: it's for review of the *direction*, not merge-ready. The strangle step (wiring live + swapping the route) is separate and operator-gated.

## Approach

Design-system-first **strangler**, not a rewrite. The existing dashboard is mined as the **oracle** so its hard-won states survive the rebuild — the participated/never-participated cohort split, identifier redaction, Watcher dismiss-ratios, event-driven silence handling, the Chronicler check-in cliff, tight-margin verdicts.

## What's here

- **`tokens.css` + `kit.css`** — the design system. One calm base, one clay accent, desaturated EISV/semantic data-hues, two themes via `[data-theme]` (ink default, paper toggle). Stands in for the role of the 5,877-line `styles.css`, and **needed zero changes across all 7 sections** — the system-first payoff.
- **`data.js`** — live-or-snapshot accessors. Each tries the real governance endpoints/tools (`/v1/residents`, `agent(list)`, `knowledge(search)`, `dialectic(list)`, `/api/events`, `/api/activity`, `/v1/eisv/recent`, resident summaries, `/health/deep`) and falls back to a bundled **real** snapshot, tagging the source. The one seam to flip for full-live when served same-origin.
- **`app.html`** — buildless modular shell, 7-section nav, hash-deep-linkable, lazy-loads sections.
- **`sections/`** — landing, agents, discoveries, dialectic, activity, eisv (theme-aware Chart.js), residents.
- **`PLAN.md`** — decisions + the strangler/oracle method, for resuming.

## Sections (all rendered on real fleet data)

| Section | Notes |
|---|---|
| Overview | Stats, Pulse, residents strip; attention band derived from real state |
| Agents | table, search/filter/sort/paginate, tier/event/inactive/redacted/superseded badges, 620 agents + never-participated cohort |
| Discoveries | lifecycle bar, clickable type legend (1,075 entries), entry cards |
| Dialectic | counts, session cards, resolution (action/reasoning/conditions/root-cause) |
| Activity | check-in histogram + filterable event stream |
| EISV | **theme-aware** Chart.js (colors read from tokens via `getComputedStyle`; works paper + ink, where the original hardcoded dark) |
| Residents | Watcher funnel, Sentinel by class, Vigil cycles/EISV, Chronicler silence, System Health |

## Build/serving notes

- **Buildless** — plain HTML/CSS/JS, matches how prod serves `dashboard/`. No framework, no Vite-bundle in the serving path. Chart.js from the same CDN the live dashboard uses.
- Open `dashboard/redesign/app.html` directly (renders on the bundled snapshot, no server needed; theme toggle top-right).
- Screenshots are not committed (kept the diff to source).

## Not done (deliberate, operator's call)

1. The **strangle** — wire accessors live + point `/dashboard` at it / replace `index.html`.
2. Per-section parity validation against the live panels before any swap.

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm