### PR TITLE
Serve redesign at /dashboard/redesign (additive preview route)

### DIFF
--- a/src/http_api.py
+++ b/src/http_api.py
@@ -966,6 +966,39 @@ async def http_dashboard_static(request):
     }, status_code=404)
 
 
+# Redesign reference — additive preview path. Serves dashboard/redesign/** on
+# the live origin so the redesign renders on real governance data. This is a
+# NON-destructive preview: the production /dashboard route and index.html are
+# untouched, and the route is fully reversible (remove it and nothing changes).
+async def http_dashboard_redesign(request):
+    """Serve the buildless dashboard redesign reference at /dashboard/redesign/."""
+    rel = request.path_params.get("file", "") or "app.html"
+    if ".." in rel or rel.startswith("/"):
+        return JSONResponse({"error": "Invalid file path"}, status_code=400)
+    if not rel.endswith((".html", ".css", ".js", ".md")):
+        return JSONResponse({"error": "File type not allowed", "requested": rel}, status_code=403)
+
+    base = (Path(__file__).parent.parent / "dashboard" / "redesign").resolve()
+    target = (base / rel).resolve()
+    if not str(target).startswith(str(base) + os.sep) or not target.is_file():
+        return JSONResponse({"error": "File not found", "requested": rel}, status_code=404)
+
+    media = {
+        ".html": "text/html", ".css": "text/css",
+        ".js": "application/javascript", ".md": "text/markdown",
+    }[target.suffix]
+    content = target.read_text()
+    # Inject the API token into the entry page so data.js authenticates live calls.
+    if target.suffix == ".html":
+        http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
+        if http_api_token:
+            token_script = (
+                f'<script>localStorage.setItem("unitares_api_token","{http_api_token}")</script>'
+            )
+            content = content.replace("</head>", f"{token_script}</head>", 1)
+    return Response(content=content, media_type=media, headers={"Cache-Control": "no-cache"})
+
+
 # HTTP polling fallback for EISV (when WebSocket is blocked by proxy auth)
 async def http_eisv_latest(request):
     """Return the latest EISV update as JSON (polling fallback for WebSocket)."""
@@ -2888,6 +2921,11 @@ def register_http_routes(
 
     app.add_middleware(_InjectContextMiddleware)
 
+    # Redesign preview routes — must come BEFORE /dashboard/{file} so that
+    # /dashboard/redesign resolves to the redesign handler, not the flat
+    # static allowlist (which would 403 it). Additive and reversible.
+    app.routes.append(Route("/dashboard/redesign", http_dashboard_redesign, methods=["GET"]))
+    app.routes.append(Route("/dashboard/redesign/{file:path}", http_dashboard_redesign, methods=["GET"]))
     # IMPORTANT: Static file route must come BEFORE dashboard route
     # to match /dashboard/utils.js, etc.
     app.routes.append(Route("/dashboard/{file}", http_dashboard_static, methods=["GET"]))

--- a/tests/test_dashboard_redesign_route.py
+++ b/tests/test_dashboard_redesign_route.py
@@ -1,0 +1,60 @@
+"""Covers the additive /dashboard/redesign preview route.
+
+The redesign reference is served from dashboard/redesign/** so it renders on
+live governance data without touching the production /dashboard route. These
+tests exercise the handler directly: it serves the entry page and nested
+assets, and it stays sandboxed (no traversal, no disallowed file types).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.http_api import http_dashboard_redesign
+
+
+def _req(file: str):
+    return SimpleNamespace(path_params={"file": file})
+
+
+@pytest.mark.asyncio
+async def test_serves_entry_page_by_default():
+    resp = await http_dashboard_redesign(_req(""))
+    assert resp.status_code == 200
+    assert resp.media_type == "text/html"
+    assert b"UNITARES" in resp.body
+
+
+@pytest.mark.asyncio
+async def test_serves_nested_section_module():
+    resp = await http_dashboard_redesign(_req("sections/landing.js"))
+    assert resp.status_code == 200
+    assert resp.media_type == "application/javascript"
+    assert b"Landing" in resp.body
+
+
+@pytest.mark.asyncio
+async def test_serves_tokens_css():
+    resp = await http_dashboard_redesign(_req("tokens.css"))
+    assert resp.status_code == 200
+    assert resp.media_type == "text/css"
+
+
+@pytest.mark.asyncio
+async def test_rejects_path_traversal():
+    resp = await http_dashboard_redesign(_req("../http_api.py"))
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_rejects_disallowed_extension():
+    resp = await http_dashboard_redesign(_req("shot-eisv.png"))
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_missing_file_is_404():
+    resp = await http_dashboard_redesign(_req("does-not-exist.js"))
+    assert resp.status_code == 404


### PR DESCRIPTION
Follow-up to #915 (the redesign reference, now merged). Adds a **non-destructive preview route** so the merged redesign renders on **live governance data**, same-origin — without touching the production `/dashboard` route or `index.html`.

## Why

#915 landed the redesign as static files under `dashboard/redesign/`, but the server only serves an allowlisted set of top-level `/dashboard/{file}` paths, so the nested redesign 404s. `data.js` already prefers live endpoints and falls back to the bundled snapshot — it just needs to be served same-origin for the live calls to authenticate.

## What

- `http_dashboard_redesign` handler serving `dashboard/redesign/**` with a path-traversal guard and an extension allowlist (`.html/.css/.js/.md`); injects the API token into the entry page exactly like the index handler.
- Routes `/dashboard/redesign` and `/dashboard/redesign/{file:path}`, registered **before** `/dashboard/{file}` so they resolve to the new handler instead of the flat allowlist.
- `tests/test_dashboard_redesign_route.py` — serves entry page + nested modules + css; rejects traversal (400), bad extensions (403), missing files (404). 6 tests, all green locally.

## Risk / reversibility

Additive and fully reversible — remove the route and nothing changes. The production route and `index.html` are untouched. **Needs a server deploy to take effect.** The production-route swap (the actual cutover) remains a separate, explicit decision.

Once deployed, the redesign is viewable live at `…/dashboard/redesign` (theme toggle top-right).

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm