### PR TITLE
Fix redesign preview: pin <base> so relative assets resolve when served

### DIFF
--- a/src/http_api.py
+++ b/src/http_api.py
@@ -988,8 +988,16 @@ async def http_dashboard_redesign(request):
         ".js": "application/javascript", ".md": "text/markdown",
     }[target.suffix]
     content = target.read_text()
-    # Inject the API token into the entry page so data.js authenticates live calls.
     if target.suffix == ".html":
+        # The entry page uses relative asset paths (./tokens.css, ./sections/*.js)
+        # so it stays portable when opened as a file. Served at /dashboard/redesign
+        # (no trailing slash), the browser would resolve those against /dashboard/.
+        # Pin the base so relative paths resolve to the redesign subtree regardless
+        # of trailing slash; absolute API calls (/v1/…, /api/…) are unaffected.
+        content = content.replace(
+            "<head>", '<head>\n<base href="/dashboard/redesign/">', 1
+        )
+        # Inject the API token so data.js authenticates live calls.
         http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
         if http_api_token:
             token_script = (

--- a/tests/test_dashboard_redesign_route.py
+++ b/tests/test_dashboard_redesign_route.py
@@ -25,6 +25,8 @@ async def test_serves_entry_page_by_default():
     assert resp.status_code == 200
     assert resp.media_type == "text/html"
     assert b"UNITARES" in resp.body
+    # Base must be pinned so relative assets resolve regardless of trailing slash.
+    assert b'<base href="/dashboard/redesign/">' in resp.body
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up bugfix to #916. The preview route served the entry page, but at `/dashboard/redesign` (no trailing slash) the browser resolved the relative `./tokens.css` and `./sections/*.js` against `/dashboard/` — they 404'd, so the page rendered **unstyled with no data**.

Fix: inject `<base href="/dashboard/redesign/">` into the served HTML so relative paths resolve to the redesign subtree regardless of trailing slash. Absolute API calls (`/v1/…`, `/api/…`) are unaffected, and `file://` opening still works (base is only injected server-side). Covered by an added assertion in `test_dashboard_redesign_route.py` (6 tests green).

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm