### PR TITLE
Cut over: /dashboard serves the redesign; old at /dashboard/classic

### DIFF
--- a/src/http_api.py
+++ b/src/http_api.py
@@ -2934,12 +2934,17 @@ def register_http_routes(
     # static allowlist (which would 403 it). Additive and reversible.
     app.routes.append(Route("/dashboard/redesign", http_dashboard_redesign, methods=["GET"]))
     app.routes.append(Route("/dashboard/redesign/{file:path}", http_dashboard_redesign, methods=["GET"]))
+    # CUTOVER (2026-06-19): /dashboard (and /) now serve the redesign; the prior
+    # dashboard stays reachable at /dashboard/classic (registered before the
+    # static {file} route so the flat allowlist doesn't swallow it). The old
+    # dashboard uses absolute asset paths, so it serves unchanged from /classic.
+    app.routes.append(Route("/dashboard/classic", http_dashboard, methods=["GET"]))
     # IMPORTANT: Static file route must come BEFORE dashboard route
     # to match /dashboard/utils.js, etc.
     app.routes.append(Route("/dashboard/{file}", http_dashboard_static, methods=["GET"]))
-    app.routes.append(Route("/dashboard", http_dashboard, methods=["GET"]))
+    app.routes.append(Route("/dashboard", http_dashboard_redesign, methods=["GET"]))
     app.routes.append(Route("/phase", http_phase, methods=["GET"]))
-    app.routes.append(Route("/", http_dashboard, methods=["GET"]))  # Root also serves dashboard
+    app.routes.append(Route("/", http_dashboard_redesign, methods=["GET"]))  # Root also serves the redesign
     app.routes.append(Route("/v1/tools", http_list_tools, methods=["GET"]))
     app.routes.append(Route("/v1/tools/call", http_call_tool, methods=["POST"]))
     app.routes.append(Route("/health", http_health, methods=["GET"]))


### PR DESCRIPTION
The cutover (operator-approved). Makes the redesign the default operator surface while keeping the prior dashboard one URL away.

- `/dashboard` and `/` now serve the redesign (`http_dashboard_redesign`, which injects `<base href="/dashboard/redesign/">` so its relative assets resolve from any mount point).
- **The prior dashboard stays live at `/dashboard/classic`** — registered before the static `/dashboard/{file}` route so the flat allowlist doesn't 403 it. It uses absolute asset paths, so it serves unchanged.
- `/dashboard/redesign` still works too.

Fully reversible — revert the three route lines and `/dashboard` is back to the old one. Dual dashboards by design, per operator request, so the cutover carries no risk to live monitoring.