### PR TITLE
Wire Overview headline stats to live telemetry

### DIFF
--- a/dashboard/redesign/data.js
+++ b/dashboard/redesign/data.js
@@ -72,9 +72,56 @@
       }, () => S().residents);
     },
 
-    // Stats are several tool calls in the real dashboard; snapshot until each is wired.
+    // Headline telemetry aggregator. One coordinated parallel batch; each card
+    // is derived from its authoritative source and degrades to the snapshot
+    // value if that one source is unreachable. Fleet Coherence is NOT here — it
+    // is derived from the live residents in the landing view.
+    //   agents/tiers  ← agent(list)            stuck       ← detect_stuck_agents
+    //   discoveries   ← knowledge(stats)        calibration ← calibration(check)
+    //   dialectic     ← dialectic(list)         anomalies   ← detect_anomalies
+    //   systemHealth  ← /health/deep
     async stats() {
-      return withFallback(async () => null, () => S().stats);
+      const snap = S().stats;
+      const tc = (n, a) => callTool(n, a).catch(() => null);
+      const rest = (p) => authFetch(p).catch(() => null);
+      return withFallback(async () => {
+        const [agentsR, kgR, dlcR, stuckR, calR, anomR, healthR] = await Promise.all([
+          tc("agent", { action: "list", include_metrics: false, recent_days: 30, limit: 400, status_filter: "all" }),
+          tc("knowledge", { action: "stats" }),
+          tc("dialectic", { action: "list", limit: 50 }),
+          tc("detect_stuck_agents", {}),
+          tc("calibration", { action: "check" }),
+          tc("detect_anomalies", {}),
+          rest("/health/deep"),
+        ]);
+        if (![agentsR, kgR, dlcR, stuckR, calR, anomR, healthR].some(Boolean)) return null;
+
+        // Agents count + trust-tier histogram (verified/established → strong,
+        // emerging → medium, unknown → weak).
+        let agentsActive = snap.agentsActive, agentsTotal = snap.agentsTotal, trustTiers = snap.trustTiers;
+        if (agentsR && agentsR.summary) {
+          agentsTotal = agentsR.summary.total;
+          agentsActive = (agentsR.summary.by_status || {}).active;
+          const TIER = { verified: "strong", established: "strong", emerging: "medium", unknown: "weak" };
+          const b = { strong: 0, medium: 0, weak: 0 };
+          Object.values(agentsR.agents || {}).forEach((arr) => (arr || []).forEach((a) => { b[TIER[a.trust_tier] || "weak"]++; }));
+          trustTiers = [{ tier: "strong", n: b.strong }, { tier: "medium", n: b.medium }, { tier: "weak", n: b.weak }];
+        }
+
+        const kg = kgR ? (kgR.stats || kgR) : null;
+        const dlcSessions = dlcR && Array.isArray(dlcR.sessions) ? dlcR.sessions : null;
+
+        return {
+          agentsActive, agentsTotal, trustTiers,
+          discoveries: kg && typeof kg.total_discoveries === "number" ? kg.total_discoveries : snap.discoveries,
+          discoveriesToday: null, // no honest live "today" delta; show neutral subtitle
+          dialectic: dlcSessions ? dlcSessions.filter((s) => !["resolved", "failed"].includes(s.phase || s.status)).length : snap.dialectic,
+          stuck: stuckR ? (stuckR.stuck_agents || []).length : snap.stuck,
+          calibration: calR && typeof calR.trajectory_health === "number" ? calR.trajectory_health : snap.calibration,
+          anomalies: anomR && anomR.summary ? anomR.summary.total_anomalies : snap.anomalies,
+          systemHealth: healthR ? (healthR.status === "healthy" ? "OK" : healthR.status) : snap.systemHealth,
+        };
+      }, () => snap);
     },
 
     async agents() {

--- a/dashboard/redesign/sections/landing.js
+++ b/dashboard/redesign/sections/landing.js
@@ -46,11 +46,11 @@
       { h: "Fleet Coherence", num: num(fleetCoh), sub: `${live.length} of ${residents.length} residents reporting`, cls: "up", rule: true },
       { h: "Agents", num: stats.agentsActive, of: "/ " + stats.agentsTotal, sub: "active / total" },
       { h: "Stuck", num: stats.stuck, sub: stats.stuck ? "needs attention" : "none flagged", cls: stats.stuck ? "down" : "up" },
-      { h: "Discoveries", num: stats.discoveries.toLocaleString(), sub: "+" + stats.discoveriesToday + " today" },
+      { h: "Discoveries", num: (stats.discoveries || 0).toLocaleString(), sub: typeof stats.discoveriesToday === "number" ? "+" + stats.discoveriesToday + " today" : "knowledge graph" },
       { h: "Dialectic", num: stats.dialectic, sub: stats.dialectic ? "open sessions" : "no open sessions" },
       { h: "System Health", num: stats.systemHealth, sub: "db · ws · reaper" },
-      { h: "Calibration", num: num(stats.calibration), sub: "trajectory health", cls: "up" },
-      { h: "Anomalies", num: stats.anomalies, sub: stats.anomalies ? "1 active" : "clear", cls: stats.anomalies ? "down" : "up" },
+      { h: "Calibration", num: num(stats.calibration), sub: "trajectory health", cls: stats.calibration >= 0.8 ? "up" : "" },
+      { h: "Anomalies", num: stats.anomalies, sub: stats.anomalies ? stats.anomalies + " active" : "clear", cls: stats.anomalies ? "down" : "up" },
     ];
     const tiers = stats.trustTiers || [];
     const max = Math.max(1, ...tiers.map((t) => t.n));


### PR DESCRIPTION
Finishes the live-data wiring for the redesign's Overview. The headline stat cards were the last thing still rendering snapshot values; this makes them live, as one coherent telemetry layer rather than scattered fetches.

## Approach — one coordinated batch

`stats()` becomes an aggregator: a single parallel batch where each card derives from its authoritative source.

| Card | Source |
|---|---|
| Agents + Trust Tiers | `agent(list)` summary + trust_tier histogram |
| Discoveries | `knowledge(stats).total_discoveries` |
| Dialectic | `dialectic(list)` active sessions |
| Stuck | `detect_stuck_agents` |
| Calibration | `calibration(check).trajectory_health` |
| Anomalies | `detect_anomalies.summary.total_anomalies` |
| System Health | `/health/deep` |

Fleet Coherence stays derived from the live residents (not in this batch).

## Graceful degradation

Each metric falls back to its snapshot value if that one source is unreachable; the batch as a whole falls back to snapshot only if every source fails. So a single flaky tool degrades one card, not the panel.

## Honesty fixes

- Dropped the fabricated `+N today` discovery delta (no honest live source) → neutral "knowledge graph" subtitle.
- Anomaly card renders the real count instead of a hardcoded "1 active".

Verified live tool shapes before wiring (stuck/anomalies/calibration/knowledge-stats/agent-summary). eslint clean.