### PR TITLE
fix(identity): NameError in diag-payload principal block

### DIFF
--- a/src/services/identity_payloads.py
+++ b/src/services/identity_payloads.py
@@ -189,7 +189,7 @@ def build_identity_diag_payload(
     # NEVER a credential. See src/services/principal_rollup.py.
     _principal = _principal_lookup(agent_uuid)
     if _principal:
-        response_data["principal"] = _principal
+        payload["principal"] = _principal
     if identity_resolution_outcome:
         payload["identity_resolution_outcome"] = identity_resolution_outcome
     # R2 PR 3: persisted-lineage flag (see build_identity_response_data).

--- a/tests/test_identity_payloads.py
+++ b/tests/test_identity_payloads.py
@@ -77,6 +77,28 @@ def test_build_identity_diag_payload_keeps_fast_path_shape_consistent():
     assert payload["identity_context"]["label"]["is_identity_key"] is False
 
 
+def test_build_identity_diag_payload_includes_principal_when_present(monkeypatch):
+    """Regression: the diag fast-path folded in a derived principal but
+    assigned it to `response_data` (a name from the sibling builder) instead
+    of `payload`, raising NameError for any agent with a principal. Patch the
+    lookup to return one and assert the payload carries it without raising."""
+    monkeypatch.setattr(
+        "src.services.identity_payloads._principal_lookup",
+        lambda uuid: {"principal_id": "P-1", "role": "advisory"},
+    )
+    payload = build_identity_diag_payload(
+        agent_uuid="uuid-123",
+        agent_id="agent-123",
+        display_name="Tester",
+        client_session_id="sess-123",
+        continuity_source="client_session_id",
+        continuity_support={"enabled": True},
+        continuity_token="token-abc",
+        identity_status="resumed",
+    )
+    assert payload["principal"] == {"principal_id": "P-1", "role": "advisory"}
+
+
 def test_build_onboard_response_data_includes_thread_and_workflow_when_verbose():
     payload = build_onboard_response_data(
         agent_uuid="uuid-123",


### PR DESCRIPTION
## Summary

Closes a Watcher-flagged `NameError` (fd526a58 / P011) on the identity diag fast-path.

`build_identity_diag_payload` folded in a derived principal but assigned it to `response_data` — a name copy-pasted from the sibling `build_identity_response_data`, undefined in this scope. Any agent with a derived principal hit `NameError` at `identity_payloads.py:192` on the diag/fast-return path. Now assigns to `payload`.

Added a regression test (patches `_principal_lookup` to return a principal) — verified it raises `NameError` against the bug and passes with the fix.

## Test

`tests/test_identity_payloads.py` — 16/16 pass.

## Notes

Rebased onto current `master`; the principal-rollup feature this repairs is already merged, so this is a clean single-commit follow-up fix.

Watcher: fd526a58 (P011) resolved; a0dfd152, 90994119 (P016) and 23f55a70, 23210d2c (P009) dismissed as false positives.