### PR TITLE
Tuning R1: data fidelity (recent discoveries, 5 trust tiers, live health detail)

### DIFF
--- a/dashboard/redesign/data.js
+++ b/dashboard/redesign/data.js
@@ -96,23 +96,31 @@
         ]);
         if (![agentsR, kgR, dlcR, stuckR, calR, anomR, healthR].some(Boolean)) return null;
 
-        // Agents count + trust-tier histogram (verified/established → strong,
-        // emerging → medium, unknown → weak).
-        let agentsActive = snap.agentsActive, agentsTotal = snap.agentsTotal, trustTiers = snap.trustTiers;
+        // Agents count + trust-tier histogram. trust_tier is computed per agent
+        // (not a stored column), so a true all-2550 distribution is expensive and
+        // ~90% inactive-unknown; we count the live/recent fleet across the 5 real
+        // tiers and report how many agents that covers.
+        let agentsActive = snap.agentsActive, agentsTotal = snap.agentsTotal;
+        let trustTiers = snap.trustTiers, trustCounted = null;
         if (agentsR && agentsR.summary) {
           agentsTotal = agentsR.summary.total;
           agentsActive = (agentsR.summary.by_status || {}).active;
-          const TIER = { verified: "strong", established: "strong", emerging: "medium", unknown: "weak" };
-          const b = { strong: 0, medium: 0, weak: 0 };
-          Object.values(agentsR.agents || {}).forEach((arr) => (arr || []).forEach((a) => { b[TIER[a.trust_tier] || "weak"]++; }));
-          trustTiers = [{ tier: "strong", n: b.strong }, { tier: "medium", n: b.medium }, { tier: "weak", n: b.weak }];
+          const TIERS = ["verified", "established", "emerging", "provisional", "unknown"];
+          const b = {}; TIERS.forEach((t) => (b[t] = 0));
+          let counted = 0;
+          Object.values(agentsR.agents || {}).forEach((arr) => (arr || []).forEach((a) => {
+            if (a && typeof a === "object") { b[a.trust_tier in b ? a.trust_tier : "unknown"]++; counted++; }
+          }));
+          trustTiers = TIERS.map((t) => ({ tier: t, n: b[t] }));
+          trustCounted = counted;
         }
 
         const kg = kgR ? (kgR.stats || kgR) : null;
         const dlcSessions = dlcR && Array.isArray(dlcR.sessions) ? dlcR.sessions : null;
+        const hb = healthR && healthR.status_breakdown ? healthR.status_breakdown : null;
 
         return {
-          agentsActive, agentsTotal, trustTiers,
+          agentsActive, agentsTotal, trustTiers, trustCounted,
           discoveries: kg && typeof kg.total_discoveries === "number" ? kg.total_discoveries : snap.discoveries,
           discoveriesToday: null, // no honest live "today" delta; show neutral subtitle
           dialectic: dlcSessions ? dlcSessions.filter((s) => !["resolved", "failed"].includes(s.phase || s.status)).length : snap.dialectic,
@@ -120,6 +128,7 @@
           calibration: calR && typeof calR.trajectory_health === "number" ? calR.trajectory_health : snap.calibration,
           anomalies: anomR && anomR.summary ? anomR.summary.total_anomalies : snap.anomalies,
           systemHealth: healthR ? (healthR.status === "healthy" ? "OK" : healthR.status) : snap.systemHealth,
+          systemHealthDetail: hb ? `${hb.healthy || 0} ok · ${hb.warning || 0} warn${hb.error ? " · " + hb.error + " err" : ""}` : null,
         };
       }, () => snap);
     },
@@ -161,7 +170,7 @@
         const [r, statsR] = await Promise.all([
           callTool("knowledge", query
             ? { action: "search", query, include_details: true, limit: 30 }
-            : { action: "search", query: "governance identity calibration", include_details: true, limit: 30 }),
+            : { action: "search", include_details: true, limit: 30 }), // no query → recent-first
           callTool("knowledge", { action: "stats" }).catch(() => null),
         ]);
         const items = r && (r.discoveries || r.results || (Array.isArray(r) ? r : null));

--- a/dashboard/redesign/sections/landing.js
+++ b/dashboard/redesign/sections/landing.js
@@ -48,24 +48,28 @@
       { h: "Stuck", num: stats.stuck, sub: stats.stuck ? "needs attention" : "none flagged", cls: stats.stuck ? "down" : "up" },
       { h: "Discoveries", num: (stats.discoveries || 0).toLocaleString(), sub: typeof stats.discoveriesToday === "number" ? "+" + stats.discoveriesToday + " today" : "knowledge graph" },
       { h: "Dialectic", num: stats.dialectic, sub: stats.dialectic ? "open sessions" : "no open sessions" },
-      { h: "System Health", num: stats.systemHealth, sub: "db · ws · reaper" },
+      { h: "System Health", num: stats.systemHealth, sub: stats.systemHealthDetail || "db · ws · reaper", cls: stats.systemHealth === "OK" ? "up" : "down" },
       { h: "Calibration", num: num(stats.calibration), sub: "trajectory health", cls: stats.calibration >= 0.8 ? "up" : "" },
       { h: "Anomalies", num: stats.anomalies, sub: stats.anomalies ? stats.anomalies + " active" : "clear", cls: stats.anomalies ? "down" : "up" },
     ];
+    // 5 real trust tiers (earned → forming → unearned), each its own colour.
+    const TIER_COLOR = { verified: "var(--ok)", established: "var(--eisv-c)", emerging: "var(--eisv-s)", provisional: "var(--warn)", unknown: "var(--faint)" };
     const tiers = stats.trustTiers || [];
     const max = Math.max(1, ...tiers.map((t) => t.n));
-    const tierBars = tiers.map((t) => `<div class="t ${t.tier}" style="height:${Math.round((t.n / max) * 100)}%"></div>`).join("");
+    const tierBars = tiers.map((t) =>
+      `<div title="${t.tier}: ${t.n}" style="flex:1;border-radius:3px 3px 0 0;background:${TIER_COLOR[t.tier] || "var(--faint)"};height:${Math.round((t.n / max) * 100)}%"></div>`).join("");
+    const tierLegend = tiers.map((t) =>
+      `<span><i style="background:${TIER_COLOR[t.tier] || "var(--faint)"}"></i>${t.tier} ${t.n}</span>`).join("");
+    const tierScope = typeof stats.trustCounted === "number" ? `over ${stats.trustCounted} active agents` : "";
 
     $("stats").innerHTML = cards.map((s) =>
       `<div class="card ${s.rule ? "accent-rule" : ""}"><h3>${s.h}</h3>`
       + `<div class="num">${s.num}${s.of ? `<span class="of"> ${s.of}</span>` : ""}</div>`
       + `<div class="sub ${s.cls || ""}">${s.sub}</div></div>`
     ).join("")
-      + `<div class="card wide"><h3>Trust Tiers</h3><div class="tiers">${tierBars}</div>`
-      + `<div class="legend" style="margin-top:.5rem">`
-      + `<span><i style="background:var(--eisv-i)"></i>strong</span>`
-      + `<span><i style="background:var(--eisv-s)"></i>medium</span>`
-      + `<span><i style="background:var(--faint)"></i>weak</span></div></div>`;
+      + `<div class="card wide"><h3>Trust Tiers ${tierScope ? `<span style="text-transform:none;letter-spacing:0;color:var(--faint);font-weight:400">· ${tierScope}</span>` : ""}</h3>`
+      + `<div class="tiers">${tierBars}</div>`
+      + `<div class="legend" style="margin-top:.5rem;flex-wrap:wrap">${tierLegend}</div></div>`;
   }
 
   function renderPulse(residents) {


### PR DESCRIPTION
Round 1 of dashboard tuning — sharpen the numbers.

- **Discoveries** default drops the biased `governance identity calibration` seed query → query-less search returns genuinely recent-first.
- **Trust Tiers**: 5 real tiers (verified / established / emerging / provisional / unknown), each its own colour, over the live/recent fleet, labelled with the agent count. `trust_tier` is computed per-agent (not stored), so a true all-2550 distribution is expensive and ~90% inactive-unknown — the active fleet is the higher-signal, honest scope.
- **System Health** subtitle shows real check counts (N ok · M warn) from `/health/deep`.

eslint clean.

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm