### PR TITLE
Tuning R2: auto-refresh (live monitor views)

### DIFF
--- a/dashboard/redesign/app.html
+++ b/dashboard/redesign/app.html
@@ -10,6 +10,14 @@
 <link rel="stylesheet" href="./tokens.css" />
 <link rel="stylesheet" href="./kit.css" />
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+<style>
+  .live-pill { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono);
+    font-size: var(--text-xs); color: var(--muted); }
+  .live-pill .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--ok);
+    animation: live-pulse 2s var(--ease) infinite; }
+  .live-pill.paused .dot { background: var(--faint); animation: none; }
+  @keyframes live-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.25; } }
+</style>
 </head>
 <body>
 <div class="wrap">
@@ -19,6 +27,7 @@
     <span class="brand-sub">Governance</span>
     <span class="spring"></span>
     <span class="server-stat" id="serverStat">—</span>
+    <span class="live-pill" id="livePill" title="Auto-refreshing monitor views"><span class="dot"></span><span id="liveText">live</span></span>
     <button class="theme-toggle" id="themeBtn">◑ paper</button>
   </header>
 
@@ -132,7 +141,9 @@ nav.addEventListener("click", (e) => {
   const id = a.dataset.section;
   nav.querySelectorAll("a").forEach((x) => x.classList.toggle("active", x === a));
   document.querySelectorAll("[data-pane]").forEach((p) => { p.hidden = p.dataset.pane !== id; });
+  activeSection = id;
   lazyLoad(id);
+  updateLivePill();
 });
 
 const loaded = {};
@@ -146,8 +157,48 @@ function lazyLoad(id) {
   if (id === "residents" && window.Residents) { loaded[id] = true; window.Residents.load(); }
 }
 
+// ── auto-refresh: keep the monitor views live ──────────────────────────────
+// Explore views (agents/discoveries/dialectic) have filters/inputs and stay
+// manual; the monitor views refresh on a tick. Refresh pauses while the tab is
+// hidden or an input is focused, and fires immediately on tab re-focus.
+let activeSection = "overview";
+const REFRESH_MS = 10000;       // light monitor refresh
+const STATS_REFRESH_MS = 30000; // heavy headline batch (7 tools) — gentler cadence
+const RELOAD = {
+  overview: () => window.Landing && window.Landing.refresh(),
+  activity: () => window.Activity && window.Activity.load(),
+  residents: () => window.Residents && window.Residents.load(),
+  eisv: () => window.EISV && window.EISV.load(),
+};
+const livePill = document.getElementById("livePill");
+const liveText = document.getElementById("liveText");
+function isAutoSection(id) { return Object.prototype.hasOwnProperty.call(RELOAD, id); }
+function isTyping() {
+  const el = document.activeElement;
+  return el && ["INPUT", "SELECT", "TEXTAREA"].includes(el.tagName);
+}
+function updateLivePill() {
+  const auto = isAutoSection(activeSection);
+  livePill.classList.toggle("paused", !auto);
+  liveText.textContent = auto ? "live" : "manual";
+  livePill.title = auto ? "Auto-refreshing every 10s" : "This view is manual — switch to a monitor view for live updates";
+}
+function refreshTick() {
+  if (document.hidden || isTyping() || !isAutoSection(activeSection)) return;
+  const fn = RELOAD[activeSection];
+  if (fn) fn();
+}
+setInterval(refreshTick, REFRESH_MS);
+// Heavier headline batch on a gentler cadence, only while watching the Overview.
+setInterval(() => {
+  if (document.hidden || isTyping() || activeSection !== "overview") return;
+  if (window.Landing && window.Landing.refreshStats) window.Landing.refreshStats();
+}, STATS_REFRESH_MS);
+document.addEventListener("visibilitychange", () => { if (!document.hidden) refreshTick(); });
+
 // boot
 window.Landing.render();
+updateLivePill();
 (function openFromHash() {
   const id = (location.hash || "").replace("#", "");
   const link = id && nav.querySelector(`a[data-section="${id}"]`);

--- a/dashboard/redesign/sections/eisv.js
+++ b/dashboard/redesign/sections/eisv.js
@@ -103,12 +103,29 @@
     else $("#eisv-mount").insertAdjacentHTML("beforeend", `<p class="empty">Chart.js not loaded.</p>`);
   }
 
+  // Update the existing charts' data in place (smooth, no rebuild flicker).
+  function updateInPlace() {
+    const s = MODEL.series, labels = s.map((p) => p.t);
+    upper.data.labels = labels;
+    upper.data.datasets[0].data = s.map((p) => p.E);
+    upper.data.datasets[1].data = s.map((p) => p.I);
+    upper.data.datasets[2].data = s.map((p) => p.C);
+    lower.data.labels = labels;
+    lower.data.datasets[0].data = s.map((p) => p.S);
+    lower.data.datasets[1].data = s.map((p) => p.V);
+    upper.update(); lower.update();
+    const badge = document.querySelector("#eisv-mount .src-badge");
+    if (badge) { badge.className = "src-badge " + MODEL.source; badge.textContent = MODEL.source; }
+  }
+
   async function load() {
     const r = await DATA.eisv();
     MODEL = { series: r.data.series || [], coherenceEq: r.data.coherenceEq || 0.5, source: r.source };
-    render();
+    // Refresh in place if the charts are already mounted; full render on first load.
+    if (upper && lower && document.getElementById("eisv-upper") && window.Chart) updateInPlace();
+    else render();
   }
-  // re-theme without refetch (called on theme toggle)
+  // re-theme without refetch (called on theme toggle) — full rebuild reads new tokens
   function retheme() { if (MODEL.series.length && window.Chart) build(); }
 
   window.EISV = { load, retheme };

--- a/dashboard/redesign/sections/landing.js
+++ b/dashboard/redesign/sections/landing.js
@@ -102,22 +102,48 @@
     }).join("");
   }
 
-  async function render() {
-    const [health, residents, stats] = await Promise.all([DATA.health(), DATA.residents(), DATA.stats()]);
+  let lastResidents = null;
+
+  function applyHealth(health) {
     if (health.data) {
       const h = health.data;
       $("serverStat").innerHTML = `v<b>${h.version}</b> · up <b>${h.uptime}</b> · db <b>${h.db}</b>`;
     }
-    renderResidents(residents.data, residents.source);
-    renderStats(stats.data, residents.data, stats.source);
-    renderPulse(residents.data);
-
-    const anyLive = [residents, stats, health].some((r) => r.source === "live");
+  }
+  function footnote(anyLive) {
     $("foot").innerHTML = anyLive
       ? "Redesign · served live · design system in <code>tokens.css</code> + <code>kit.css</code>."
       : "Redesign reference · rendering bundled snapshot (open served same-origin for live data) · "
         + "design system in <code>tokens.css</code> + <code>kit.css</code>. Toggle theme to reskin via one token swap.";
   }
 
-  window.Landing = { render };
+  // Full first render — light (residents/pulse/health) + heavy (stats) together.
+  async function render() {
+    const [health, residents, stats] = await Promise.all([DATA.health(), DATA.residents(), DATA.stats()]);
+    lastResidents = residents;
+    applyHealth(health);
+    renderResidents(residents.data, residents.source);
+    renderStats(stats.data, residents.data, stats.source);
+    renderPulse(residents.data);
+    footnote([residents, stats, health].some((r) => r.source === "live"));
+  }
+
+  // Light refresh (fast cadence) — the "is the fleet alive" glance only.
+  async function refresh() {
+    const [health, residents] = await Promise.all([DATA.health(), DATA.residents()]);
+    lastResidents = residents;
+    applyHealth(health);
+    renderResidents(residents.data, residents.source);
+    renderPulse(residents.data);
+  }
+
+  // Heavy refresh (slow cadence) — the 7-tool headline batch; reuse last residents
+  // for fleet coherence rather than refetching them.
+  async function refreshStats() {
+    const stats = await DATA.stats();
+    const residents = lastResidents || (lastResidents = await DATA.residents());
+    renderStats(stats.data, residents.data, stats.source);
+  }
+
+  window.Landing = { render, refresh, refreshStats };
 })();


### PR DESCRIPTION
Round 2 — make it a living monitor instead of snapshot-on-nav.

- Monitor views (Overview, Activity, Residents, EISV) auto-refresh on a 10s tick; explore views (Agents/Discoveries/Dialectic) stay manual (they carry filters/inputs).
- Refresh **pauses** while the tab is hidden or an input is focused, and fires immediately on tab re-focus.
- Overview split by cost: light glance (residents + Pulse + health) every 10s; heavy 7-tool headline batch every 30s — a watched Overview won't hammer the governance server.
- EISV refreshes chart **data in place** (Chart.js animates) — no rebuild flicker.
- A 'live' pulse indicator in the header (shows 'manual' on explore views). Also self-heals the post-restart window — residents fill back in as they check in, no reload.

eslint + node --check clean.

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm