### PR TITLE
Tuning R3: visual polish (calm reconnect state + skeleton loaders)

### DIFF
--- a/dashboard/redesign/app.html
+++ b/dashboard/redesign/app.html
@@ -72,35 +72,35 @@
     <!-- Agents (increment 2) -->
     <section class="section" data-pane="agents" hidden>
       <h2 class="section-title">Agents</h2>
-      <div id="ag-mount"><p class="empty">loading…</p></div>
+      <div id="ag-mount"><div class="loading-skeleton"><div class="skeleton" style="width:35%"></div><div class="skeleton" style="width:88%"></div><div class="skeleton" style="width:72%"></div><div class="skeleton" style="width:80%"></div></div></div>
     </section>
 
     <!-- Discoveries (increment 3) -->
     <section class="section" data-pane="discoveries" hidden>
       <h2 class="section-title">Discoveries</h2>
-      <div id="dsc-mount"><p class="empty">loading…</p></div>
+      <div id="dsc-mount"><div class="loading-skeleton"><div class="skeleton" style="width:35%"></div><div class="skeleton" style="width:88%"></div><div class="skeleton" style="width:72%"></div><div class="skeleton" style="width:80%"></div></div></div>
     </section>
 
     <!-- Dialectic (increment 4) -->
     <section class="section" data-pane="dialectic" hidden>
       <h2 class="section-title">Dialectic</h2>
-      <div id="dlc-mount"><p class="empty">loading…</p></div>
+      <div id="dlc-mount"><div class="loading-skeleton"><div class="skeleton" style="width:35%"></div><div class="skeleton" style="width:88%"></div><div class="skeleton" style="width:72%"></div><div class="skeleton" style="width:80%"></div></div></div>
     </section>
 
     <!-- Activity (increment 5) -->
     <section class="section" data-pane="activity" hidden>
       <h2 class="section-title">Activity</h2>
-      <div id="act-mount"><p class="empty">loading…</p></div>
+      <div id="act-mount"><div class="loading-skeleton"><div class="skeleton" style="width:35%"></div><div class="skeleton" style="width:88%"></div><div class="skeleton" style="width:72%"></div><div class="skeleton" style="width:80%"></div></div></div>
     </section>
 
     <!-- Sections built in later increments -->
     <section class="section" data-pane="eisv" hidden>
       <h2 class="section-title">EISV</h2>
-      <div id="eisv-mount"><p class="empty">loading…</p></div>
+      <div id="eisv-mount"><div class="loading-skeleton"><div class="skeleton" style="width:35%"></div><div class="skeleton" style="width:88%"></div><div class="skeleton" style="width:72%"></div><div class="skeleton" style="width:80%"></div></div></div>
     </section>
     <section class="section" data-pane="residents" hidden>
       <h2 class="section-title">Residents</h2>
-      <div id="res-mount"><p class="empty">loading…</p></div>
+      <div id="res-mount"><div class="loading-skeleton"><div class="skeleton" style="width:35%"></div><div class="skeleton" style="width:88%"></div><div class="skeleton" style="width:72%"></div><div class="skeleton" style="width:80%"></div></div></div>
     </section>
   </main>
 

--- a/dashboard/redesign/kit.css
+++ b/dashboard/redesign/kit.css
@@ -99,6 +99,18 @@ body {
 }
 .attn-band b { color: var(--ink); font-weight: 600; }
 .attn-band .glyph { color: var(--warn); font-weight: 600; }
+/* calm variant — informational (reconnect window, not an alarm) */
+.attn-band.calm { background: var(--surface-2); border-color: var(--line); border-left-color: var(--info); }
+.attn-band.calm .glyph { color: var(--info); }
+
+/* skeleton loader — replaces bare "loading…" */
+.skeleton { position: relative; overflow: hidden; background: var(--surface-2); border-radius: var(--radius-sm); }
+.skeleton::after { content: ""; position: absolute; inset: 0; transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--ink) 6%, transparent), transparent);
+  animation: skeleton-shimmer 1.4s var(--ease) infinite; }
+@keyframes skeleton-shimmer { 100% { transform: translateX(100%); } }
+.loading-skeleton { padding: var(--space-4) 0; display: flex; flex-direction: column; gap: var(--space-3); }
+.loading-skeleton .skeleton { height: 14px; }
 
 /* ---------------- stat cards ---------------- */
 .grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: var(--space-4); }

--- a/dashboard/redesign/sections/landing.js
+++ b/dashboard/redesign/sections/landing.js
@@ -25,17 +25,29 @@
         + `<span class="meta">${meta} · ${fmtSil(r.silence)}</span></span>`;
     }).join("");
 
-    // attention band — derive from real state, don't hardcode
-    const flags = [];
+    // Attention band — distinguish a real alarm (silent past threshold) from a
+    // calm fleet-wide reconnect window (no EISV after a restart is steady-state,
+    // not a problem; residents report on their own cadence).
+    const silent = [], noEisv = [];
     residents.forEach((r) => {
       const thr = r.silenceThreshold || 3600;
-      if (r.silence != null && r.silence > thr) flags.push(`<b>${r.name}</b> silent ${fmtSil(r.silence)}`);
-      else if (r.status === "dark" || (r.coherence == null && r.status !== "silent")) flags.push(`<b>${r.name}</b> reporting no EISV`);
+      if (r.silence != null && r.silence > thr) silent.push(r.name);
+      else if (r.coherence == null && r.status !== "silent") noEisv.push(r.name);
     });
     const attn = $("attn");
-    if (flags.length) {
-      attn.hidden = false;
-      attn.innerHTML = `<span class="glyph">⚠</span><span>${flags.join(" · ")} — past check-in threshold.</span>`;
+    const names = (a) => a.map((n) => `<b>${n}</b>`).join(" · ");
+    const fleetWide = noEisv.length >= Math.ceil(residents.length / 2);
+    if (silent.length) {
+      attn.hidden = false; attn.className = "attn-band";
+      let msg = `${names(silent)} past check-in threshold`;
+      if (noEisv.length && !fleetWide) msg += ` · ${noEisv.length} awaiting first check-in`;
+      attn.innerHTML = `<span class="glyph">⚠</span><span>${msg}.</span>`;
+    } else if (fleetWide) {
+      attn.hidden = false; attn.className = "attn-band calm";
+      attn.innerHTML = `<span class="glyph">↻</span><span><b>${noEisv.length} of ${residents.length}</b> residents awaiting first check-in — they report on their own cadence.</span>`;
+    } else if (noEisv.length) {
+      attn.hidden = false; attn.className = "attn-band calm";
+      attn.innerHTML = `<span class="glyph">·</span><span>${names(noEisv)} reporting no EISV yet.</span>`;
     } else { attn.hidden = true; }
   }
 


### PR DESCRIPTION
Round 3 — the 'scaffolding shows' moments.

- **Attention band** no longer alarms during the post-restart reconnect window. A genuine silent-past-threshold is still a warn alarm, but a fleet-wide 'no EISV' (every resident dark right after a restart) now shows a calm, info-styled '↻ N of M residents awaiting first check-in — they report on their own cadence' instead of N red warnings. With R2 auto-refresh it clears itself as residents check back in.
- **Skeleton shimmer loaders** replace the bare 'loading…' text on every section mount.
- New kit primitives: `.attn-band.calm` + `.skeleton`.

eslint + node --check clean.

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm