### PR TITLE
Full-fleet trust tiers via cached-tier aggregate endpoint

### DIFF
--- a/dashboard/redesign/data.js
+++ b/dashboard/redesign/data.js
@@ -85,34 +85,34 @@
       const tc = (n, a) => callTool(n, a).catch(() => null);
       const rest = (p) => authFetch(p).catch(() => null);
       return withFallback(async () => {
-        const [agentsR, kgR, dlcR, stuckR, calR, anomR, healthR] = await Promise.all([
-          tc("agent", { action: "list", include_metrics: false, recent_days: 30, limit: 400, status_filter: "all" }),
+        const [agentsR, kgR, dlcR, stuckR, calR, anomR, healthR, tierR] = await Promise.all([
+          tc("agent", { action: "list", include_metrics: false, recent_days: 30, limit: 1, status_filter: "all" }), // summary only
           tc("knowledge", { action: "stats" }),
           tc("dialectic", { action: "list", limit: 50 }),
           tc("detect_stuck_agents", {}),
           tc("calibration", { action: "check" }),
           tc("detect_anomalies", {}),
           rest("/health/deep"),
+          rest("/v1/agents/tier_distribution"),
         ]);
-        if (![agentsR, kgR, dlcR, stuckR, calR, anomR, healthR].some(Boolean)) return null;
+        if (![agentsR, kgR, dlcR, stuckR, calR, anomR, healthR, tierR].some(Boolean)) return null;
 
-        // Agents count + trust-tier histogram. trust_tier is computed per agent
-        // (not a stored column), so a true all-2550 distribution is expensive and
-        // ~90% inactive-unknown; we count the live/recent fleet across the 5 real
-        // tiers and report how many agents that covers.
+        // Agent counts from the (light) summary; trust-tier distribution from the
+        // full-fleet aggregate endpoint (cached tier across all identities). The
+        // bars show the EARNED tiers — unknown dwarfs them ~18× at fleet scale, so
+        // it's reported as context, not a bar.
         let agentsActive = snap.agentsActive, agentsTotal = snap.agentsTotal;
-        let trustTiers = snap.trustTiers, trustCounted = null;
         if (agentsR && agentsR.summary) {
           agentsTotal = agentsR.summary.total;
           agentsActive = (agentsR.summary.by_status || {}).active;
-          const TIERS = ["verified", "established", "emerging", "provisional", "unknown"];
-          const b = {}; TIERS.forEach((t) => (b[t] = 0));
-          let counted = 0;
-          Object.values(agentsR.agents || {}).forEach((arr) => (arr || []).forEach((a) => {
-            if (a && typeof a === "object") { b[a.trust_tier in b ? a.trust_tier : "unknown"]++; counted++; }
-          }));
-          trustTiers = TIERS.map((t) => ({ tier: t, n: b[t] }));
-          trustCounted = counted;
+        }
+        let trustTiers = snap.trustTiers, trustEarned = null, trustFleet = null, trustUnknown = null;
+        if (tierR && tierR.tiers) {
+          const t = tierR.tiers;
+          trustTiers = ["verified", "established", "emerging", "provisional"].map((k) => ({ tier: k, n: t[k] || 0 }));
+          trustEarned = tierR.earned;
+          trustFleet = tierR.total;
+          trustUnknown = t.unknown || 0;
         }
 
         const kg = kgR ? (kgR.stats || kgR) : null;
@@ -120,7 +120,7 @@
         const hb = healthR && healthR.status_breakdown ? healthR.status_breakdown : null;
 
         return {
-          agentsActive, agentsTotal, trustTiers, trustCounted,
+          agentsActive, agentsTotal, trustTiers, trustEarned, trustFleet, trustUnknown,
           discoveries: kg && typeof kg.total_discoveries === "number" ? kg.total_discoveries : snap.discoveries,
           discoveriesToday: null, // no honest live "today" delta; show neutral subtitle
           dialectic: dlcSessions ? dlcSessions.filter((s) => !["resolved", "failed"].includes(s.phase || s.status)).length : snap.dialectic,

--- a/dashboard/redesign/sections/landing.js
+++ b/dashboard/redesign/sections/landing.js
@@ -72,7 +72,9 @@
       `<div title="${t.tier}: ${t.n}" style="flex:1;border-radius:3px 3px 0 0;background:${TIER_COLOR[t.tier] || "var(--faint)"};height:${Math.round((t.n / max) * 100)}%"></div>`).join("");
     const tierLegend = tiers.map((t) =>
       `<span><i style="background:${TIER_COLOR[t.tier] || "var(--faint)"}"></i>${t.tier} ${t.n}</span>`).join("");
-    const tierScope = typeof stats.trustCounted === "number" ? `over ${stats.trustCounted} active agents` : "";
+    const tierScope = typeof stats.trustEarned === "number"
+      ? `${stats.trustEarned.toLocaleString()} earned of ${stats.trustFleet.toLocaleString()} · ${(stats.trustUnknown || 0).toLocaleString()} unknown`
+      : "";
 
     $("stats").innerHTML = cards.map((s) =>
       `<div class="card ${s.rule ? "accent-rule" : ""}"><h3>${s.h}</h3>`

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -1007,6 +1007,45 @@ async def http_dashboard_redesign(request):
     return Response(content=content, media_type=media, headers={"Cache-Control": "no-cache"})
 
 
+async def http_tier_distribution(request):
+    """GET /v1/agents/tier_distribution — full-fleet trust-tier counts.
+
+    trust_tier is computed per agent (resolve_trust_tier), but the last-computed
+    value is cached in core.identities.metadata->'trust_tier'. One GROUP BY gives
+    the true distribution across all identities cheaply, without recomputing
+    per agent. Identities with no cached tier (never earned one) fold to unknown.
+    """
+    http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
+    if not _check_http_auth(request, http_api_token=http_api_token):
+        return _http_unauthorized()
+    try:
+        from src.db import get_db
+        db = get_db()
+        async with db.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT COALESCE(NULLIF(metadata->'trust_tier'->>'name', ''), 'unknown') AS tier,
+                       count(*) AS n
+                FROM core.identities
+                GROUP BY 1
+                """
+            )
+        order = ["verified", "established", "emerging", "provisional", "unknown"]
+        tiers = {t: 0 for t in order}
+        for r in rows:
+            t = r["tier"] if r["tier"] in tiers else "unknown"
+            tiers[t] += int(r["n"])
+        total = sum(tiers.values())
+        return JSONResponse({
+            "success": True,
+            "tiers": tiers,
+            "total": total,
+            "earned": total - tiers["unknown"],
+        })
+    except Exception as exc:  # noqa: BLE001 — read-only panel endpoint, degrade gracefully
+        return JSONResponse({"success": False, "error": str(exc)}, status_code=500)
+
+
 # HTTP polling fallback for EISV (when WebSocket is blocked by proxy auth)
 async def http_eisv_latest(request):
     """Return the latest EISV update as JSON (polling fallback for WebSocket)."""
@@ -2968,6 +3007,7 @@ def register_http_routes(
     app.routes.append(Route("/v1/bootstrap/silent", http_bootstrap_silent, methods=["GET"]))
     app.routes.append(Route("/v1/sentinel/summary", http_sentinel_summary, methods=["GET"]))
     app.routes.append(Route("/v1/vigil/summary", http_vigil_summary, methods=["GET"]))
+    app.routes.append(Route("/v1/agents/tier_distribution", http_tier_distribution, methods=["GET"]))
     app.routes.append(Route("/api/activity", http_activity, methods=["GET"]))
     app.routes.append(Route("/api/incidents", http_incidents, methods=["GET"]))
     app.routes.append(Route("/v1/residents", http_residents, methods=["GET"]))


### PR DESCRIPTION
Gives the Trust Tiers card a true full-fleet distribution.

`trust_tier` is computed per-agent (`resolve_trust_tier`, async + DB lookups), so a real 4,585-identity distribution can't come from the capped agent list. But the last-computed tier is **cached** in `core.identities.metadata->'trust_tier'`, so one `GROUP BY` gives it cheaply.

- New endpoint **GET /v1/agents/tier_distribution** — folds null/empty cached tier → unknown; returns `{tiers, total, earned}`.
- `stats()` sources tiers from it, and the agent-list call drops to `limit:1` (summary only) since it no longer counts tiers from the page — net lighter.
- The card shows the **earned** tiers as bars (verified / established / emerging / provisional) with 'X earned of N · M unknown' — unknown dwarfs the rest ~18× at fleet scale, so it's context, not a bar.

Verified the query against the live DB (unknown 4312 · emerging 238 · established 14 · provisional 12 · verified 9). Server change → waiting on full Python CI before merge.

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm