### PR TITLE
Fix: Agents section not loading (truncation-marker crash)

### DIFF
--- a/dashboard/redesign/data.js
+++ b/dashboard/redesign/data.js
@@ -143,6 +143,7 @@
         const flat = [];
         Object.keys(groups).forEach((status) => {
           (groups[status] || []).forEach((a) => {
+            if (!a || typeof a !== "object") return; // skip the "... (N more items)" truncation marker
             const m = a.metrics || {};
             flat.push({
               agent_id: a.agent_id, label: a.label, status: a.lifecycle_status || a.status || status,

--- a/dashboard/redesign/sections/agents.js
+++ b/dashboard/redesign/sections/agents.js
@@ -65,7 +65,7 @@
 
     const cmp = {
       recent: (a, b) => Date.parse(b.last || 0) - Date.parse(a.last || 0),
-      name: (a, b) => (a.label || a.agent_id).localeCompare(b.label || b.agent_id),
+      name: (a, b) => (a.label || a.agent_id || "").localeCompare(b.label || b.agent_id || ""),
       coherence: (a, b) => (b.metrics.coherence ?? -1) - (a.metrics.coherence ?? -1),
       risk: (a, b) => (b.metrics.risk ?? -1) - (a.metrics.risk ?? -1),
       updates: (a, b) => (b.updates || 0) - (a.updates || 0),
@@ -78,7 +78,7 @@
 
     const tr = (a) => {
       const st = staleness(a.last, MODEL.nowMs);
-      const name = a.label || `<span style="color:var(--muted)">anon · ${a.agent_id.slice(0, 8)}</span>`;
+      const name = a.label || `<span style="color:var(--muted)">anon · ${(a.agent_id || "—").slice(0, 8)}</span>`;
       const pip = a.status === "paused" ? "var(--warn)" : a.status === "archived" ? "var(--faint)"
         : st.level === "dead" ? "var(--faint)" : "var(--ok)";
       return `<tr>


### PR DESCRIPTION
The Agents table was stuck on its loading skeleton on live data.

Root cause: `agent(list)` appends a string `'... (N more items)'` to a capped group list. The data layer treated that string as an agent record; `agents.js` then threw on `a.agent_id.slice()`, and one bad entry blanked the entire table. The snapshot had no marker, so it only manifested live (my increment-2 verify was on the snapshot — a real lesson in verifying the *served* surface).

- `data.js`: skip non-object entries when flattening agent groups.
- `agents.js`: guard `agent_id`/`label` in row render + name sort so no single record can blank the table again.

Verified against the live response in Node (108 clean records, no throw). eslint clean.

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm