### PR TITLE
Phase space: authoritative per-agent basin ring

### DIFF
--- a/dashboard/phase.js
+++ b/dashboard/phase.js
@@ -141,6 +141,17 @@
         return a.label || a.display_name || a.name || (a.agent_id || '?').slice(0, 12);
     }
 
+    // Authoritative per-agent basin (server-computed classify_basin over the full
+    // 6-input classifier). This is the TRUE classification, drawn as the particle
+    // ring — so a dot's basin no longer has to be inferred from its I-axis band
+    // (which is only a 1-D projection and can disagree). No ring when basin absent.
+    function basinStroke(basin) {
+        if (basin === 'high') return 'rgba(52,211,153,0.9)';
+        if (basin === 'boundary') return 'rgba(251,191,36,0.9)';
+        if (basin === 'low') return 'rgba(96,165,250,0.95)';
+        return 'rgba(255,255,255,0.15)';
+    }
+
     // ========================================================================
     // SVG setup
     // ========================================================================
@@ -222,11 +233,13 @@
                 .attr('stroke-width', 0.8);
         });
 
-        // Basin labels (right-aligned, very subtle)
+        // I-axis bands — a 1-D projection of the classifier (integrity breakpoints
+        // only). The authoritative per-agent basin is the particle RING, not the
+        // band a dot sits in; labels say "low/high I" to avoid over-claiming.
         var labels = [
-            { text: 'LOW BASIN', y: 0.25, color: '96,165,250' },
-            { text: 'BOUNDARY', y: 0.6, color: '251,191,36' },
-            { text: 'HIGH BASIN', y: 0.85, color: '52,211,153' }
+            { text: 'low I', y: 0.25, color: '96,165,250' },
+            { text: 'mid I', y: 0.6, color: '251,191,36' },
+            { text: 'high I', y: 0.85, color: '52,211,153' }
         ];
         labels.forEach(function (l) {
             basins.append('text')
@@ -387,11 +400,13 @@
             .attr('fill', function (d) { return voidColorAlpha((d.metrics || {}).V, 0.08); })
             .attr('filter', 'url(#glow-outer)');
 
-        // Core circle
+        // Core circle. Fill = V (valence), size = S (entropy), ring = authoritative basin.
         enter.append('circle')
             .attr('class', 'agent-core')
             .attr('r', function (d) { return dotRadius((d.metrics || {}).S); })
             .attr('fill', function (d) { return voidColor((d.metrics || {}).V); })
+            .attr('stroke', function (d) { return basinStroke((d.metrics || {}).basin); })
+            .attr('stroke-width', 2.5)
             .attr('filter', 'url(#glow)')
             .style('cursor', 'pointer');
 
@@ -432,7 +447,8 @@
         merged.select('.agent-core')
             .transition().duration(CFG.transition)
             .attr('r', function (d) { return dotRadius((d.metrics || {}).S); })
-            .attr('fill', function (d) { return voidColor((d.metrics || {}).V); });
+            .attr('fill', function (d) { return voidColor((d.metrics || {}).V); })
+            .attr('stroke', function (d) { return basinStroke((d.metrics || {}).basin); });
 
         merged.select('.agent-label')
             .transition().duration(CFG.transition)

--- a/src/mcp_handlers/lifecycle/query.py
+++ b/src/mcp_handlers/lifecycle/query.py
@@ -713,6 +713,7 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                             "risk_score": safe_float(metrics.get("risk_score") or metrics.get("current_risk") or metrics.get("mean_risk", 0.5)),  # Governance/operational risk
                             "phi": metrics.get("phi"),  # Primary physics signal: Phi objective function
                             "verdict": metrics.get("verdict"),  # Primary governance signal: safe/caution/high-risk
+                            "basin": metrics.get("basin"),  # Authoritative classify_basin label (high/boundary/low) — used by /phase
                             "mean_risk": safe_float(metrics.get("mean_risk", 0.5)),  # Overall mean (all-time average) - for historical context
                             "lambda1": safe_float(monitor.state.lambda1),
                             "void_active": bool(monitor.state.void_active) if monitor.state.void_active is not None else False


### PR DESCRIPTION
Makes /phase honest about classification. The basin bands are a 1-D (I-axis) projection of the 6-input `classify_basin`, so a particle's vertical position could imply a basin the real classifier disagrees with — the bands *looked* authoritative but weren't (the code already flagged them 'illustrative').

- **Server:** surface the engine-computed `basin` in the `agent(list)` metrics. `monitor.get_metrics()` already runs `classify_basin` (monitor_metrics.py:173); the list handler just trimmed it. One additive field — single source of truth, no client-side re-classification or drift.
- **phase.js:** draw each particle's authoritative basin as a coloured **ring** (high=green / boundary=amber / low=blue), so the true classification no longer has to be inferred from the band.
- Relabel bands 'low/mid/high I' (what they are) instead of 'LOW/HIGH BASIN'. Tooltip `basin` is now populated.

Server change → waiting on full Python CI before merge. eslint clean.

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm