### PR TITLE
Phase basin: compute it in the handler (get_metrics didn't carry it)

### DIFF
--- a/src/mcp_handlers/lifecycle/query.py
+++ b/src/mcp_handlers/lifecycle/query.py
@@ -703,17 +703,31 @@ async def handle_list_agents(arguments: ToolArgumentsDict) -> Sequence[TextConte
                             void_active=void_active
                         )
                         agent_info["health_status"] = health_status_obj.value
+                        _m_E = safe_float(monitor.state.E)
+                        _m_I = safe_float(monitor.state.I)
+                        _m_S = safe_float(monitor.state.S)
+                        _m_V = safe_float(monitor.state.V)
+                        _m_coh = safe_float(monitor.state.coherence)
+                        _m_risk = safe_float(metrics.get("risk_score") or metrics.get("current_risk") or metrics.get("mean_risk", 0.5))
+                        # Authoritative basin: run the engine's classify_basin on the same
+                        # state we surface (monitor.get_metrics() does not carry basin).
+                        try:
+                            from config.governance_config import classify_basin
+                            _m_basin = classify_basin(E=_m_E, I=_m_I, S=_m_S, V=_m_V,
+                                                      coherence=_m_coh, risk_score=_m_risk)
+                        except Exception:
+                            _m_basin = None
                         agent_info["metrics"] = {
-                            "E": safe_float(monitor.state.E),
-                            "I": safe_float(monitor.state.I),
-                            "S": safe_float(monitor.state.S),
-                            "V": safe_float(monitor.state.V),
-                            "coherence": safe_float(monitor.state.coherence),
+                            "E": _m_E,
+                            "I": _m_I,
+                            "S": _m_S,
+                            "V": _m_V,
+                            "coherence": _m_coh,
                             "current_risk": metrics.get("current_risk"),  # Recent trend (last 10) - USED FOR HEALTH STATUS
-                            "risk_score": safe_float(metrics.get("risk_score") or metrics.get("current_risk") or metrics.get("mean_risk", 0.5)),  # Governance/operational risk
+                            "risk_score": _m_risk,  # Governance/operational risk
                             "phi": metrics.get("phi"),  # Primary physics signal: Phi objective function
                             "verdict": metrics.get("verdict"),  # Primary governance signal: safe/caution/high-risk
-                            "basin": metrics.get("basin"),  # Authoritative classify_basin label (high/boundary/low) — used by /phase
+                            "basin": _m_basin,  # Authoritative classify_basin label (high/boundary/low) — used by /phase ring
                             "mean_risk": safe_float(metrics.get("mean_risk", 0.5)),  # Overall mean (all-time average) - for historical context
                             "lambda1": safe_float(monitor.state.lambda1),
                             "void_active": bool(monitor.state.void_active) if monitor.state.void_active is not None else False


### PR DESCRIPTION
Follow-up to #928. The basin key landed but was always `None`: `monitor.get_metrics()` (governance_monitor.py) is a different function from the `monitor_metrics.py` builder and doesn't compute basin. Now `classify_basin` runs directly in the handler over the same state values we surface.

Verified locally against live state samples — Watcher→boundary, Lumen→low (V=−0.52 breach), Sentinel→boundary, me→high. So the /phase rings get real high/boundary/low labels.

Server change → full Python CI before merge.

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm