### PR TITLE
Resident strip: cadence-aware timing (scheduled ≠ stalled)

### DIFF
--- a/dashboard/redesign/data.js
+++ b/dashboard/redesign/data.js
@@ -67,7 +67,7 @@
         return j.residents.map((r) => ({
           name: r.label, status: r.status, coherence: r.coherence, risk: r.risk_score,
           verdict: r.verdict, eisv: r.eisv, silence: r.silence_seconds,
-          silenceThreshold: r.silence_threshold_seconds,
+          silenceThreshold: r.silence_threshold_seconds, event_driven: r.event_driven === true,
         }));
       }, () => S().residents);
     },

--- a/dashboard/redesign/sections/landing.js
+++ b/dashboard/redesign/sections/landing.js
@@ -15,14 +15,27 @@
     el.textContent = source === "live" ? "live" : "snapshot";
   }
 
+  // Cadence-aware timing: a scheduled/sparse resident within its check-in
+  // threshold should read "ran Xh ago" (calm), not "silent Xh" (alarming).
+  // Only past-threshold is genuinely overdue.
+  function resTiming(r) {
+    if (r.event_driven) return { txt: "event-driven", overdue: false };
+    if (r.silence == null) return { txt: "—", overdue: false };
+    const thr = r.silenceThreshold || 3600;
+    if (r.silence > thr) return { txt: "overdue " + fmtSil(r.silence - thr), overdue: true };
+    const daily = thr >= 82800; // ~23h+ threshold ⇒ a daily resident
+    return { txt: (daily ? "daily · ran " : "ran ") + fmtSil(r.silence) + " ago", overdue: false };
+  }
+
   function renderResidents(residents, source) {
     badge($("resSrc"), source);
     $("residents").innerHTML = residents.map((r) => {
-      const cls = r.status === "silent" ? "attention" : r.status === "dark" ? "dark" : "";
+      const t = resTiming(r);
+      const cls = t.overdue ? "attention" : r.status === "dark" ? "dark" : "";
       const meta = r.coherence == null ? "no EISV" : "coh " + num(r.coherence);
       return `<span class="res ${cls}"><span class="pip"></span>`
         + `<span class="name">${r.name}</span>`
-        + `<span class="meta">${meta} · ${fmtSil(r.silence)}</span></span>`;
+        + `<span class="meta">${meta} · ${t.txt}</span></span>`;
     }).join("");
 
     // Attention band — distinguish a real alarm (silent past threshold) from a

--- a/dashboard/redesign/snapshot.js
+++ b/dashboard/redesign/snapshot.js
@@ -9,12 +9,12 @@ window.SNAPSHOT = {
   capturedAt: "2026-06-19T19:30:00Z",
   health: { version: "2.13.0", uptime: "21h 15m", db: "connected" },
   residents: [
-    { name:"Watcher",    status:"healthy", coherence:0.50, risk:0.00, verdict:"proceed", eisv:{E:0.77,I:0.66,S:0.24,V:+0.10}, silence:25 },
-    { name:"Vigil",      status:"healthy", coherence:0.49, risk:0.00, verdict:"proceed", eisv:{E:0.75,I:0.77,S:0.16,V:-0.02}, silence:101 },
-    { name:"Lumen",      status:"careful", coherence:0.50, risk:0.00, verdict:"proceed", eisv:{E:0.31,I:0.83,S:0.15,V:-0.52}, silence:56 },
-    { name:"Sentinel",   status:"healthy", coherence:0.50, risk:0.00, verdict:"proceed", eisv:{E:0.77,I:0.68,S:0.26,V:+0.09}, silence:273 },
-    { name:"Steward",    status:"dark",    coherence:null, risk:null, verdict:null,      eisv:null,                          silence:32 },
-    { name:"Chronicler", status:"silent",  coherence:0.50, risk:0.00, verdict:"proceed", eisv:{E:0.81,I:0.68,S:0.22,V:+0.11}, silence:67156 },
+    { name:"Watcher",    status:"healthy", coherence:0.50, risk:0.00, verdict:"proceed", eisv:{E:0.77,I:0.66,S:0.24,V:+0.10}, silence:25,    silenceThreshold:3600,   event_driven:true },
+    { name:"Vigil",      status:"healthy", coherence:0.49, risk:0.00, verdict:"proceed", eisv:{E:0.75,I:0.77,S:0.16,V:-0.02}, silence:101,   silenceThreshold:3600 },
+    { name:"Lumen",      status:"careful", coherence:0.50, risk:0.00, verdict:"proceed", eisv:{E:0.31,I:0.83,S:0.15,V:-0.52}, silence:56,    silenceThreshold:3600 },
+    { name:"Sentinel",   status:"healthy", coherence:0.50, risk:0.00, verdict:"proceed", eisv:{E:0.77,I:0.68,S:0.26,V:+0.09}, silence:273,   silenceThreshold:3600 },
+    { name:"Steward",    status:"dark",    coherence:null, risk:null, verdict:null,      eisv:null,                          silence:32,    silenceThreshold:3600 },
+    { name:"Chronicler", status:"healthy", coherence:0.50, risk:0.00, verdict:"proceed", eisv:{E:0.81,I:0.68,S:0.22,V:+0.11}, silence:67156, silenceThreshold:172800 },
   ],
   // representative until wired to live tool calls (agent/detect_stuck/knowledge/calibration)
   stats: {


### PR DESCRIPTION
Follow-up from the Chronicler diagnosis. A daily resident within its check-in threshold read 'silent 23h' like a stalled agent.

- event-driven residents (Watcher) → 'event-driven' (silence isn't a liveness signal for them).
- within threshold → 'ran Xh ago' (calm); daily residents (threshold ≥23h) → 'daily · ran Xh ago' so it's clearly scheduled.
- only past-threshold → 'overdue X' with the attention border.
- map event_driven through the live residents accessor; give snapshot residents silenceThreshold/event_driven so offline matches.

Frontend-only. eslint clean, verified locally.

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm