### PR TITLE
Redesign: cache-bust assets (stale JS blanked the Agents table)

### DIFF
--- a/src/http_api.py
+++ b/src/http_api.py
@@ -989,6 +989,16 @@ async def http_dashboard_redesign(request):
     }[target.suffix]
     content = target.read_text()
     if target.suffix == ".html":
+        # Cache-bust the relative asset refs with ?v=<max mtime of the redesign
+        # tree>. no-cache without a validator lets browsers serve stale JS/CSS
+        # (e.g. a months-old agents.js that crashes the table); a version query
+        # forces a fresh fetch after every deploy. Absolute CDN refs are untouched.
+        import re as _re
+        try:
+            _v = str(int(max((f.stat().st_mtime for f in base.rglob("*") if f.is_file()), default=0)))
+            content = _re.sub(r'(src|href)="(\./[^"?]+)"', rf'\1="\2?v={_v}"', content)
+        except Exception:
+            pass
         # The entry page uses relative asset paths (./tokens.css, ./sections/*.js)
         # so it stays portable when opened as a file. Served at /dashboard/redesign
         # (no trailing slash), the browser would resolve those against /dashboard/.


### PR DESCRIPTION
The Agents table rendered fine in a fresh browser but blank in a real one — the browser loaded a fresh app.html (no-cache) but a months-stale `agents.js` (the pre-#927 crashing version). `no-cache` without a validator (no ETag/Last-Modified) lets browsers serve stale assets indefinitely.

Fix: rewrite the entry page's relative asset refs to `./x?v=<max mtime of the redesign tree>` (same approach as the legacy index handler). Each deploy changes the mtime → new query → guaranteed fresh fetch. Absolute CDN refs untouched.

Immediate workaround for anyone affected: hard-refresh (Cmd+Shift+R). Server change → full Python CI before merge.

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm