### PR TITLE
[codex] Allow orchestrated thread anchor first-bind under strict identity

### DIFF
--- a/docs/proposals/discord-thread-identity-resume-v0.md
+++ b/docs/proposals/discord-thread-identity-resume-v0.md
@@ -2,10 +2,12 @@
 
 **Created:** June 18, 2026
 **Status:** Orchestrator + reference-hook side merged (#834). The **fail-closed
-guard** (anchor honored only with an explicit orchestration marker) is a follow-up
-hardening on top of #834. The gov-plugin session-hook mirror and the dispatch-worker
-anchor remain cross-repo follow-ups (below). No new server behavior — the resume
-path already exists.
+guard** (anchor honored only with an explicit orchestration marker) was mirrored
+into the gov-plugin hook, and dispatch_beam now provisions the marker alongside
+the anchor. Strict-mode rollout added one narrow server-side first-bind carve-out:
+`orchestrated=true` plus an `agent:/thread-*` anchor may mint and persist the
+anchor binding after a resume miss, while a bare anchor still refuses under
+`STRICT_IDENTITY_REQUIRED`.
 **Operator decision (2026-06-18):** *one id per thread (resume)*, fix in *this
 repo (orchestrator + server)*; *fail-closed, no council* (the guard re-applies the
 ratified anti-siphon principle, it is not a new ontological claim).
@@ -31,19 +33,22 @@ give those turns a **stable session anchor** so they resume one identity, rather
 than mint per turn. This is *resume*, not lineage — the turns are the same agent,
 not a parent/child chain.
 
-## The mechanism (already supported server-side)
+## The mechanism
 
 `handle_onboard_v2` defaults `resume=True` (`handlers.py:1670`). A stable
 `client_session_id` resolves to the **same** governance UUID across processes:
 
-1. **Turn 1** — onboard under anchor `agent:/thread-<id>`, `resume=True`, no
-   binding yet → PATH 2 fail-closed `session_resolve_miss` → falls through to the
-   create-finisher → mints + **binds** the session under the anchor key.
+1. **Turn 1** — onboard under anchor `agent:/thread-<id>`, `resume=True`,
+   `orchestrated=true`, no binding yet → PATH 2 fail-closed
+   `session_resolve_miss` → strict Path B recognizes the orchestrated thread
+   anchor declaration → falls through to the create-finisher → mints +
+   **binds** the session under the normalized anchor key (`agent:_thread-...`).
 2. **Turn 2..N** — same anchor, `resume=True` → PATH 1/2 hit → returns the turn-1
    UUID. One id for the whole thread.
 
-So no server change was needed. The two gaps were purely *plumbing*: nothing
-provisioned the anchor, and the reference onboard hook hard-coded `force_new=true`.
+The strict-mode server carve-out is intentionally narrow: without
+`orchestrated=true`, the same resume miss still returns
+`lineage_declaration_required` instead of minting.
 
 ## What shipped here
 

--- a/src/mcp_handlers/identity/handlers.py
+++ b/src/mcp_handlers/identity/handlers.py
@@ -1685,10 +1685,26 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
         from ..context import get_context_client_hint
         client_hint = get_context_client_hint() or "unknown"
 
+    orchestrated = coerce_bool(arguments.get("orchestrated"), default=False)
+    raw_client_session_id_arg = arguments.get("client_session_id")
+
     # Derive base session key (unified — pin lookup integrated in derive_session_key)
     from ..context import get_session_signals
     signals = get_session_signals()
     base_session_key = await derive_session_key(signals, arguments)
+    raw_client_session_id = arguments.get("client_session_id")
+    anchor_candidates = [raw_client_session_id_arg, raw_client_session_id]
+    orchestrated_thread_anchor = (
+        orchestrated
+        and any(
+            isinstance(candidate, str)
+            and (
+                candidate.startswith("agent:/thread-")
+                or candidate.startswith("agent:_thread-")
+            )
+            for candidate in anchor_candidates
+        )
+    )
     # Initialize session_key eagerly so no downstream branch can hit
     # UnboundLocalError if the control flow misses its assignment (the
     # 2026-04-19 crash was exactly this — schema/handler resume-default
@@ -1774,7 +1790,11 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
                 # canary refuted by 0 dispatch_auto_mint rows in
                 # core.agents). Caller-provided values are preserved.
                 if not _spawn_reason:
-                    _spawn_reason = "auto_onboard_no_session"
+                    _spawn_reason = (
+                        "orchestrated_thread_anchor"
+                        if orchestrated_thread_anchor
+                        else "auto_onboard_no_session"
+                    )
 
                 # #425 Path B: when STRICT_IDENTITY_REQUIRED is on, refuse
                 # bare onboard() (no parent_agent_id and no force_new=True)
@@ -1786,7 +1806,8 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
                 from src.mcp_handlers.identity_bootstrap import is_strict_identity_required
                 if (is_strict_identity_required()
                         and not _parent_agent_id
-                        and not force_new):
+                        and not force_new
+                        and not orchestrated_thread_anchor):
                     logger.info(
                         "[ONBOARD] STRICT_IDENTITY_REQUIRED=true and bare "
                         "onboard() (no parent_agent_id, no force_new=true) "
@@ -2364,7 +2385,11 @@ async def handle_onboard_v2(arguments: Dict[str, Any]) -> Sequence[TextContent]:
         else None
     )
     if not identity_resolution_outcome:
-        if is_new and _spawn_reason in {"dispatch_auto_mint", "auto_onboard_no_session"}:
+        if is_new and _spawn_reason in {
+            "dispatch_auto_mint",
+            "auto_onboard_no_session",
+            "orchestrated_thread_anchor",
+        }:
             identity_resolution_outcome = "minted_after_resume_miss"
         elif is_new and force_new:
             identity_resolution_outcome = "minted_force_new"

--- a/src/mcp_handlers/identity/resolution.py
+++ b/src/mcp_handlers/identity/resolution.py
@@ -31,7 +31,11 @@ logger = get_logger(__name__)
 
 def _created_identity_outcome(*, force_new: bool, spawn_reason: Optional[str]) -> str:
     """Classify a successful PATH 3 mint separately from the input lane."""
-    if spawn_reason in {"dispatch_auto_mint", "auto_onboard_no_session"}:
+    if spawn_reason in {
+        "dispatch_auto_mint",
+        "auto_onboard_no_session",
+        "orchestrated_thread_anchor",
+    }:
         return "minted_after_resume_miss"
     if force_new:
         return "minted_force_new"

--- a/src/mcp_handlers/schemas/identity.py
+++ b/src/mcp_handlers/schemas/identity.py
@@ -53,6 +53,15 @@ class OnboardParams(AgentIdentityMixin):
         default=None,
         description="Client hint string"
     )
+    orchestrated: Union[bool, str, None] = Field(
+        default=False,
+        description=(
+            "Declare that a client_session_id is a thread-stable anchor "
+            "provisioned by an orchestrator for a headless turn-child. Used "
+            "only to allow first-bind creation under STRICT_IDENTITY_REQUIRED; "
+            "ordinary interactive callers should leave this false."
+        )
+    )
     resume: Union[bool, str, None] = Field(
         default=True,
         description=(
@@ -133,6 +142,8 @@ class OnboardParams(AgentIdentityMixin):
             self.resume = self.resume.lower() in ('true', '1', 'yes')
         if isinstance(self.force_new, str):
             self.force_new = self.force_new.lower() in ('true', '1', 'yes')
+        if isinstance(self.orchestrated, str):
+            self.orchestrated = self.orchestrated.lower() in ('true', '1', 'yes', 'on')
         return self
 
 class LinkIdentityTrajectoryParams(AgentIdentityMixin):
@@ -184,4 +195,3 @@ class BindSessionParams(AgentIdentityMixin):
         if isinstance(self.strict, str):
             self.strict = self.strict.lower() in ('true', '1', 'yes')
         return self
-

--- a/tests/test_identity_s21a.py
+++ b/tests/test_identity_s21a.py
@@ -18,8 +18,10 @@ import json
 import sys
 from pathlib import Path
 from unittest.mock import patch, MagicMock, AsyncMock
+from types import SimpleNamespace
 
 import pytest
+from tests.helpers import parse_result
 
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
@@ -405,6 +407,123 @@ class TestS21AFollowupSpawnReason:
             f"every session_resolve_miss-driven onboard mint persists with NULL "
             f"spawn_reason and the no-lineage ghost-fork rate doesn't move."
         )
+
+    @pytest.mark.asyncio
+    async def test_strict_bare_onboard_session_resolve_miss_refuses(self, monkeypatch):
+        """#425 Path B still refuses ambiguous bare onboard() under strict.
+
+        A plain client_session_id without force_new/parent/orchestrated marker
+        must not mint after a resume miss.
+        """
+        from src.mcp_handlers.identity.handlers import handle_onboard_v2
+
+        db = _make_db_no_session()
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.bind = AsyncMock()
+
+        async def _get_raw():
+            r = AsyncMock()
+            r.get = AsyncMock(return_value=None)
+            r.setex = AsyncMock()
+            r.expire = AsyncMock()
+            return r
+
+        monkeypatch.setenv("STRICT_IDENTITY_REQUIRED", "true")
+        with patch("src.mcp_handlers.identity.persistence._redis_cache", None), \
+             patch("src.cache.get_session_cache", return_value=mock_redis), \
+             patch("src.mcp_handlers.identity.handlers.get_db", return_value=db), \
+             patch("src.mcp_handlers.identity.resolution.get_db", return_value=db), \
+             patch("src.mcp_handlers.identity.persistence.get_db", return_value=db), \
+             patch("src.cache.redis_client.get_redis", new=_get_raw), \
+             patch("src.mcp_handlers.context.get_mcp_session_id", return_value=None), \
+             patch("src.mcp_handlers.context.get_context_session_key", return_value=None), \
+             patch("src.mcp_handlers.context.get_context_agent_id", return_value=None), \
+             patch("src.mcp_handlers.context.update_context_agent_id"):
+            result = await handle_onboard_v2({"client_session_id": "agent-no-prior"})
+
+        data = parse_result(result)
+        assert data["status"] == "lineage_declaration_required"
+        assert db.upsert_agent.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_strict_orchestrated_thread_anchor_mints_and_persists_anchor(self, monkeypatch):
+        """Orchestrated thread anchors are an explicit first-bind declaration.
+
+        Under STRICT_IDENTITY_REQUIRED, the first turn of a Discord thread has no
+        PG session row yet. The orchestrated marker + agent:/thread-* anchor may
+        create and persist that binding so later turns, including after restart,
+        resolve through PATH 2 instead of hitting lineage_declaration_required.
+        """
+        from src.mcp_handlers.identity.handlers import handle_onboard_v2
+
+        db = AsyncMock()
+        db.init = AsyncMock()
+        db.get_session = AsyncMock(return_value=None)
+        db.find_agent_by_label = AsyncMock(return_value=None)
+        db.get_agent_label = AsyncMock(return_value=None)
+        db.update_session_activity = AsyncMock()
+        db.create_session = AsyncMock()
+        db.upsert_agent = AsyncMock()
+        db.upsert_identity = AsyncMock()
+        db.update_agent_fields = AsyncMock(return_value=True)
+        db.get_agent_thread_info = AsyncMock(return_value=None)
+        db.get_thread_nodes = AsyncMock(return_value=[])
+        db.create_or_get_thread = AsyncMock()
+        db.claim_thread_position = AsyncMock(return_value=1)
+        db.get_agent = AsyncMock(return_value=None)
+
+        identity_row = SimpleNamespace(identity_id=42, metadata={})
+        seen_identity = False
+
+        async def get_identity(_agent_uuid):
+            nonlocal seen_identity
+            if not seen_identity:
+                seen_identity = True
+                return None
+            return identity_row
+
+        db.get_identity = AsyncMock(side_effect=get_identity)
+
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.bind = AsyncMock()
+
+        async def _get_raw():
+            r = AsyncMock()
+            r.get = AsyncMock(return_value=None)
+            r.setex = AsyncMock()
+            r.expire = AsyncMock()
+            return r
+
+        mock_server = MagicMock()
+        mock_server.agent_metadata = {}
+
+        monkeypatch.setenv("STRICT_IDENTITY_REQUIRED", "true")
+        anchor = "agent:/thread-discord-42"
+        with patch("src.mcp_handlers.identity.persistence._redis_cache", None), \
+             patch("src.cache.get_session_cache", return_value=mock_redis), \
+             patch("src.mcp_handlers.identity.handlers.get_db", return_value=db), \
+             patch("src.mcp_handlers.identity.resolution.get_db", return_value=db), \
+             patch("src.mcp_handlers.identity.persistence.get_db", return_value=db), \
+             patch("src.cache.redis_client.get_redis", new=_get_raw), \
+             patch("src.mcp_handlers.context.get_mcp_session_id", return_value=None), \
+             patch("src.mcp_handlers.context.get_context_session_key", return_value=None), \
+             patch("src.mcp_handlers.context.get_context_agent_id", return_value=None), \
+             patch("src.mcp_handlers.context.update_context_agent_id"), \
+             patch("src.mcp_handlers.shared.get_mcp_server", return_value=mock_server):
+            result = await handle_onboard_v2({
+                "client_session_id": anchor,
+                "orchestrated": True,
+            })
+
+        data = parse_result(result)
+        assert data["success"] is True
+        assert data["is_new"] is True
+        assert data["identity_resolution_outcome"] == "minted_after_resume_miss"
+        assert db.upsert_agent.call_args.kwargs["spawn_reason"] == "orchestrated_thread_anchor"
+        session_ids = [call.kwargs.get("session_id") for call in db.create_session.await_args_list]
+        assert "agent:_thread-discord-42" in session_ids
 
 
 class TestS21BSpawnReasonPlumbing:


### PR DESCRIPTION
## Summary

- Add an `orchestrated` onboard parameter for headless orchestrator-provisioned thread anchors.
- Under `STRICT_IDENTITY_REQUIRED`, keep refusing bare `client_session_id` resume misses, but allow the narrow first-bind case for `orchestrated=true` plus `agent:/thread-*` anchors.
- Classify that first-bind mint as `minted_after_resume_miss`, persist the normalized anchor session key, and document the corrected restart-boundary behavior.

## Why

The dispatch thread identity handoff needs one governance identity per orchestrated thread across daemon restarts. The plugin side now fails closed by honoring anchors only with the orchestration marker; the server also needs to recognize that marked first turn as an explicit anchor declaration under strict identity. Without that carve-out, strict mode returns `lineage_declaration_required` before the first thread binding can be created.

## Validation

- `python3 -m pytest tests/test_identity_s21a.py tests/test_identity_handlers.py tests/test_strict_proof_origin.py -q` (`166 passed`)
- `git diff --check origin/master`
- Pre-push smoke hook (`138 passed, 9768 deselected, 1 warning`)
