### PR TITLE
Fix agents.active.7d: count governed agents, not per-lease ephemeral ids

### DIFF
--- a/agents/chronicler/scrapers.py
+++ b/agents/chronicler/scrapers.py
@@ -102,10 +102,16 @@ def tests_unitares_count(repo_root: Path) -> float:
 
 
 def agents_active_7d(_repo_root: Path) -> float:
-    """Distinct agents with any tool call in the last 7 days — fleet liveness."""
+    """Distinct governed agents that checked in (wrote state) in the last 7 days.
+
+    Counts participating identities in ``core.agent_state`` — NOT distinct
+    ``audit.tool_usage.agent_id``, which is inflated ~130x by per-lease
+    presence ids that onboard-and-vanish ephemerals mint (lease.acquire/
+    lease.release pairs that never reach a real check-in).
+    """
     return _fetchval(
-        "SELECT count(DISTINCT agent_id) FROM audit.tool_usage "
-        "WHERE ts > now() - interval '7 days' AND agent_id IS NOT NULL"
+        "SELECT count(DISTINCT identity_id) FROM core.agent_state "
+        "WHERE recorded_at > now() - interval '7 days'"
     )
 
 

--- a/tests/test_chronicler.py
+++ b/tests/test_chronicler.py
@@ -47,7 +47,7 @@ class TestDbScrapers:
     with the right SQL shape — the actual DB round-trip is integration-tested
     elsewhere."""
 
-    def test_agents_active_7d_queries_distinct_tool_usage(self, tmp_path: Path):
+    def test_agents_active_7d_queries_distinct_governed_agents(self, tmp_path: Path):
         from agents.chronicler import scrapers
 
         with patch.object(scrapers, "_fetchval", return_value=42.0) as m:
@@ -55,8 +55,8 @@ class TestDbScrapers:
 
         assert value == 42.0
         sql = m.call_args.args[0]
-        assert "count(DISTINCT agent_id)" in sql
-        assert "audit.tool_usage" in sql
+        assert "count(DISTINCT identity_id)" in sql
+        assert "core.agent_state" in sql
         assert "7 days" in sql
 
     def test_kg_entries_count_queries_discoveries(self, tmp_path: Path):


### PR DESCRIPTION
## Problem
`agents.active.7d` (cirwel.org "Active agents (7d)", **and** the dashboard Fleet Metrics panel + resident-progress) read **~26,512** — but the fleet has ~199 real active agents.

## Root cause
The Chronicler scraper counted `count(DISTINCT agent_id) FROM audit.tool_usage`. That id space is flooded by the lease plane: each onboard-and-vanish ephemeral mints a fresh UUID, does exactly one `lease.acquire` + `lease.release` (its presence lease `agent:/<uuid>`), and never checks in. Result over 7d: **26,520 distinct agent_ids, 97% with exactly 2 calls, 0 overlap with core.agent_state, ~4K newly minted per day** (step change ~June 10). The real holders live in `session_id`, not `agent_id`.

## Fix
Repoint `agents_active_7d` to `count(DISTINCT identity_id) FROM core.agent_state WHERE recorded_at > now() - interval '7 days'` — distinct agents that actually wrote state. Live value: **26,520 → 199**. Matches the definition cirwel.org's snapshot already uses.

## Tests
Updated `test_agents_active_7d_*` to pin the new query; chronicler + fleet_metrics suites green (48 passed). Verified 199.0 through the real scraper against the live DB.

## Note
Fixes the metric (the meter). The underlying ~4K/day identity churn is a separate, known proliferation question — not addressed here.