### PR TITLE
Residents panel: Chronicler live + cadence-aware

### DIFF
--- a/dashboard/redesign/data.js
+++ b/dashboard/redesign/data.js
@@ -257,13 +257,14 @@
 
     async residentPanels() {
       return withFallback(async () => {
-        const [w, sn, vg, h] = await Promise.all([
+        const [w, sn, vg, h, res] = await Promise.all([
           authFetch("/v1/watcher/summary").catch(() => null),
           authFetch("/v1/sentinel/summary").catch(() => null),
           authFetch("/v1/vigil/summary").catch(() => null),
           authFetch("/health/deep").catch(() => null),
+          authFetch("/v1/residents").catch(() => null),
         ]);
-        if (!w && !sn && !vg && !h) return null;
+        if (!w && !sn && !vg && !h && !res) return null;
         const out = {};
         if (w) out.watcher = { total: w.total, byStatus: w.by_status || {}, openSev: w.by_severity_open || {},
           patterns: (w.patterns || []).map((p) => ({ p: p.pattern, confirmed: p.confirmed, dismissed: p.dismissed, surfaced: p.surfaced, ratio: p.dismiss_ratio })) };
@@ -276,7 +277,13 @@
         if (h) out.health = { status: h.status, version: h.version, checks: h.status_breakdown || {},
           breakers: { governance: (h.circuit_breakers && h.circuit_breakers.governance || {}).trips_24h || 0, redis: (h.circuit_breakers && h.circuit_breakers.redis || {}).trips_24h || 0 },
           calibration: (h.checks && h.checks.calibration || {}).status, redis: h.redis_present, continuity: h.identity_continuity_mode };
-        out.chronicler = S().residentPanels.chronicler; // not a REST summary; carry snapshot note
+        // Chronicler has no dedicated summary endpoint — pull its live state from
+        // /v1/residents (daily resident; cadence-aware rendering happens in the view).
+        const c = res && res.residents && res.residents.find((r) => r.label === "Chronicler");
+        out.chronicler = c
+          ? { status: c.status, silence: c.silence_seconds, silenceThreshold: c.silence_threshold_seconds,
+              lastCheckin: c.last_checkin_at, eisv: c.eisv, coherence: c.coherence }
+          : S().residentPanels.chronicler;
         return out;
       }, () => S().residentPanels);
     },

--- a/dashboard/redesign/sections/residents.js
+++ b/dashboard/redesign/sections/residents.js
@@ -68,8 +68,22 @@
 
   function chronicler(c) {
     if (!c) return "";
-    return `<div class="panel" style="border-left:2px solid var(--warn)">${head("Chronicler", "silent", "daily resident")}
-      <div style="color:var(--ink-2);font-size:var(--text-sm)"><span class="tag warn">silent ${c.silenceH}h</span> ${esc(c.note || "")}</div></div>`;
+    // Daily resident: silence within its (48h) threshold is steady-state, not an
+    // alarm. Only genuinely past-threshold is "overdue".
+    let timing, overdue;
+    if (typeof c.silence === "number") {
+      const thr = c.silenceThreshold || 86400;
+      overdue = c.silence > thr;
+      timing = overdue ? "overdue " + ago(c.silence - thr) : "ran " + ago(c.silence) + " ago";
+    } else {
+      overdue = false;
+      timing = "ran " + (c.silenceH != null ? c.silenceH + "h" : "—") + " ago";
+    }
+    const e = c.eisv || {};
+    const badge = overdue ? `<span class="tag warn">${timing}</span>` : `<span class="tag">daily · ${timing}</span>`;
+    return `<div class="panel" style="${overdue ? "border-left:2px solid var(--warn)" : ""}">${head("Chronicler", overdue ? "silent" : "healthy", "longitudinal · daily")}
+      <div style="color:var(--ink-2);font-size:var(--text-sm)">${badge}${overdue && c.note ? " " + esc(c.note) : ""}</div>
+      ${e.E != null ? `<div style="margin-top:var(--space-3);display:flex;gap:var(--space-5);font-family:var(--font-mono);font-size:var(--text-sm);color:var(--ink-2)"><span>E ${e.E.toFixed(2)}</span><span>I ${e.I.toFixed(2)}</span><span>S ${e.S.toFixed(2)}</span><span>V ${e.V.toFixed(2)}</span></div>` : ""}</div>`;
   }
 
   function health(h) {


### PR DESCRIPTION
The Residents-section Chronicler panel was hardcoded to a snapshot ('silent 18.6h', warn border) — never live. Now `residentPanels()` pulls Chronicler's live state from `/v1/residents` and the panel is cadence-aware: 'daily · ran Xh ago' (calm) within its 48h threshold, 'overdue' (warn) only past it, plus live EISV when present.

Frontend-only. eslint clean.

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm