### PR TITLE
Redesign: serve entry HTML no-store (complete the cache-bust)

### DIFF
--- a/src/http_api.py
+++ b/src/http_api.py
@@ -1014,7 +1014,12 @@ async def http_dashboard_redesign(request):
                 f'<script>localStorage.setItem("unitares_api_token","{http_api_token}")</script>'
             )
             content = content.replace("</head>", f"{token_script}</head>", 1)
-    return Response(content=content, media_type=media, headers={"Cache-Control": "no-cache"})
+    # The entry HTML must NEVER be cached: it carries the ?v=<mtime> asset refs,
+    # so a stale app.html would point at stale JS/CSS even though those are
+    # version-busted. no-store guarantees a fresh entry on every load; the
+    # versioned assets keep no-cache (their URL changes per deploy).
+    cache = "no-store" if target.suffix == ".html" else "no-cache"
+    return Response(content=content, media_type=media, headers={"Cache-Control": cache})
 
 
 async def http_agent_history(request):


### PR DESCRIPTION
Completes #931. The `?v=` versioning busts JS/CSS, but the entry `app.html` was `no-cache` **without a validator**, so a browser could still serve a stale app.html carrying old `?v=` refs → stale assets. That's why a hard-refresh was still sometimes needed (and it masked the EISV-chart deploy in my own verification). Serve `.html` as `no-store` (never cached) so the entry is always fresh; versioned assets keep `no-cache`.

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm