### PR TITLE
EISV trajectory: context-aware depth (recent ⇄ full lifespan)

### DIFF
--- a/dashboard/redesign/data.js
+++ b/dashboard/redesign/data.js
@@ -247,12 +247,17 @@
       }, () => S().eisv);
     },
 
-    async agentHistory(id, limit) {
+    async agentHistory(id, opts) {
       // EISV check-in trajectory for one agent (no snapshot fallback — empty if offline).
+      // opts: { limit, mode: "recent"|"all" }. Returns { points, total, mode }.
+      opts = opts || {};
       return withFallback(async () => {
-        const r = await authFetch("/v1/agents/" + encodeURIComponent(id) + "/history?limit=" + (limit || 80));
-        return r && Array.isArray(r.points) ? r.points : null;
-      }, () => []);
+        const q = "?limit=" + (opts.limit || 200) + (opts.mode === "all" ? "&mode=all" : "");
+        const r = await authFetch("/v1/agents/" + encodeURIComponent(id) + "/history" + q);
+        return r && Array.isArray(r.points)
+          ? { points: r.points, total: r.total || r.points.length, mode: r.mode || "recent" }
+          : null;
+      }, () => ({ points: [], total: 0, mode: "recent" }));
     },
 
     async residentPanels() {

--- a/dashboard/redesign/sections/agents.js
+++ b/dashboard/redesign/sections/agents.js
@@ -16,6 +16,7 @@
   let pageSize = 20;
   let selectedId = null;
   let histChart = null;
+  let histMode = "recent"; // "recent" (raw events) | "all" (full lifespan, sampled)
   const histCache = {};
 
   const BASIN_COLOR = { high: "var(--ok)", boundary: "var(--warn)", low: "var(--danger)" };
@@ -84,17 +85,34 @@
     const canvas = document.getElementById("ag-hist");
     const meta = document.getElementById("ag-hist-meta");
     if (!canvas || !window.Chart) return;
-    let pts = histCache[id];
-    if (!pts) { // fetch once per agent; re-renders (search/filter) reuse the cache
-      const r = await DATA.agentHistory(id, 200);
+    const ck = id + ":" + histMode;
+    let entry = histCache[ck];
+    if (!entry) { // fetch once per (agent, mode); re-renders (search/filter) reuse the cache
+      const r = await DATA.agentHistory(id, { limit: 200, mode: histMode });
       if (selectedId !== id || !document.getElementById("ag-hist")) return; // selection changed mid-fetch
-      pts = (r.data || []).filter(Boolean);
-      histCache[id] = pts;
+      const d = r.data || {};
+      entry = { pts: (d.points || []).filter(Boolean), total: d.total || 0 };
+      histCache[ck] = entry;
     }
+    const pts = entry.pts, total = entry.total;
     if (!pts.length) { if (meta) meta.textContent = "· no recorded history yet"; return; }
-    if (meta) meta.textContent = "· " + pts.length + " check-ins (each point = one)";
+    // Context-aware framing: how much of the agent's life is shown, and over what
+    // span. The recent⇄full toggle only appears when there's more history than the
+    // recent window holds — a sparse ephemeral session just shows its whole life.
+    const spanMs = pts.length > 1 ? (Date.parse(pts[pts.length - 1].t) - Date.parse(pts[0].t)) : 0;
+    const wideSpan = spanMs > 1.5 * 864e5; // > ~1.5 days ⇒ label by date, not clock
+    const fmtSpan = (ms) => { const h = ms / 3.6e6; return h < 1 ? Math.round(ms / 6e4) + "m" : h < 48 ? h.toFixed(0) + "h" : (h / 24).toFixed(0) + "d"; };
+    if (meta) {
+      const span = spanMs ? " · spans " + fmtSpan(spanMs) : "";
+      const ofTotal = total > pts.length ? " of " + total.toLocaleString() : "";
+      const deep = total > pts.length || histMode === "all"; // more history than recent holds
+      const seg = (m, label) => `<button data-hmode="${m}" class="hmode${histMode === m ? " on" : ""}" style="font:inherit;cursor:pointer;background:none;border:none;padding:0 4px;color:${histMode === m ? "var(--ink-2)" : "var(--faint)"};text-decoration:${histMode === m ? "underline" : "none"}">${label}</button>`;
+      meta.innerHTML = "· " + pts.length + (histMode === "all" ? " sampled" : "") + " check-ins" + ofTotal + span
+        + (deep ? ` &nbsp; ${seg("recent", "recent")}${seg("all", "full lifespan")}` : "");
+      meta.querySelectorAll(".hmode").forEach((b) => { b.onclick = () => { if (b.dataset.hmode !== histMode) { histMode = b.dataset.hmode; renderHistory(selectedId); } }; });
+    }
     const cv = (n) => getComputedStyle(document.documentElement).getPropertyValue(n).trim();
-    const labels = pts.map((p) => (p.t || "").slice(11, 16));
+    const labels = pts.map((p) => wideSpan ? (p.t || "").slice(5, 10) : (p.t || "").slice(11, 16));
     // Event-based: each check-in is a discrete, hover-trackable point; straight
     // segments (no tension) so the line reflects actual check-ins, not a smoothed
     // interpolation. Markers shrink as the series gets denser.
@@ -259,6 +277,7 @@
 
   // Open an agent's detail (also callable for deep-link/verification).
   function select(id) {
+    if (id && id !== selectedId) histMode = "recent"; // new agent → default to recent events
     selectedId = (id && id === selectedId) ? null : id; // click again to close
     render();
     const d = document.getElementById("ag-detail");

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -1038,7 +1038,11 @@ async def http_agent_history(request):
         limit = int(request.query_params.get("limit", "80"))
     except (TypeError, ValueError):
         limit = 80
-    limit = max(2, min(limit, 300))
+    limit = max(2, min(limit, 400))
+    # Context-aware: 'recent' = the last `limit` raw check-ins (event-by-event);
+    # 'all' = ~`limit` real check-ins sampled evenly across the agent's whole
+    # lifespan (decimation, not averaging — every point is a real check-in).
+    mode = "all" if request.query_params.get("mode") == "all" else "recent"
     try:
         from src.db import get_db
         db = get_db()
@@ -1046,7 +1050,8 @@ async def http_agent_history(request):
             # Identity resolution: check-in history is keyed by the agent's UUID
             # identity, but the agent list may show the structured id (mcp_DATE_<8hex>)
             # whose suffix is that UUID's prefix. Match exact id OR the UUID identity
-            # whose prefix == the structured id's trailing 8 hex.
+            # whose prefix == the structured id's trailing 8 hex. The numbered CTE
+            # carries the total so the panel can tell how much history exists.
             rows = await conn.fetch(
                 """
                 WITH ids AS (
@@ -1056,27 +1061,38 @@ async def http_agent_history(request):
                      WHERE substring($1 from '([0-9a-f]{8})$') IS NOT NULL
                        AND agent_id ~ '^[0-9a-f]{8}-'
                        AND agent_id LIKE substring($1 from '([0-9a-f]{8})$') || '%'
+                ),
+                numbered AS (
+                    SELECT s.recorded_at,
+                           (s.state_json->>'E')::real AS e,
+                           s.integrity AS i, s.entropy AS s_entropy, s.volatility AS v,
+                           s.coherence, s.risk_score,
+                           row_number() OVER (ORDER BY s.recorded_at) AS rn,
+                           count(*) OVER () AS total
+                    FROM core.agent_state s
+                    WHERE s.identity_id IN (SELECT identity_id FROM ids) AND s.synthetic = false
                 )
-                SELECT s.recorded_at,
-                       (s.state_json->>'E')::real AS e,
-                       s.integrity AS i, s.entropy AS s_entropy, s.volatility AS v,
-                       s.coherence, s.risk_score
-                FROM core.agent_state s
-                WHERE s.identity_id IN (SELECT identity_id FROM ids) AND s.synthetic = false
-                ORDER BY s.recorded_at DESC
-                LIMIT $2
+                SELECT recorded_at, e, i, s_entropy, v, coherence, risk_score, total
+                FROM numbered
+                WHERE CASE WHEN $3 = 'all'
+                           THEN (rn % GREATEST(1, (total / $2)::int) = 0 OR rn = 1 OR rn = total)
+                           ELSE rn > total - $2
+                      END
+                ORDER BY recorded_at
                 """,
-                agent_id, limit,
+                agent_id, limit, mode,
             )
+        total = rows[0]["total"] if rows else 0
         points = [
             {
                 "t": r["recorded_at"].isoformat(),
                 "E": r["e"], "I": r["i"], "S": r["s_entropy"], "V": r["v"],
                 "coherence": r["coherence"], "risk": r["risk_score"],
             }
-            for r in reversed(rows)
+            for r in rows
         ]
-        return JSONResponse({"success": True, "agent_id": agent_id, "count": len(points), "points": points})
+        return JSONResponse({"success": True, "agent_id": agent_id, "mode": mode,
+                             "count": len(points), "total": total, "points": points})
     except Exception as exc:  # noqa: BLE001 — read-only panel endpoint, degrade gracefully
         return JSONResponse({"success": False, "error": str(exc)}, status_code=500)
 


### PR DESCRIPTION
The trajectory now adapts to an agent's history depth.

- Endpoint returns `total` recorded check-ins + supports `mode=recent|all`; 'all' samples ~200 **real** check-ins evenly across the whole lifespan (decimation, not averaging — every point is a real check-in).
- Panel shows context (N of TOTAL · spans Xh/Xd) and offers a **recent ⇄ full-lifespan** toggle only when there's more history than the recent window holds — a sparse ephemeral session just shows its whole life, no toggle.
- X-axis labels switch to dates past ~1.5-day spans.

Verified vs live DB before shipping: Lumen recent=10h / full=203 pts over 90 days; an 8-check-in agent shows all 8. Server change → full CI.

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm