### PR TITLE
fix(kg): tag-search SQL crash, update credential asymmetry, clearer session-mismatch

### DIFF
--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -1956,11 +1956,11 @@ async def handle_update_discovery_status_graph(arguments: Dict[str, Any]) -> Seq
     SECURITY: Requires authentication for high-severity discoveries.
     Low/medium severity discoveries can be updated by any registered agent (collaborative).
     """
-    # SECURITY FIX: Require registered agent_id (prevents phantom agent_ids)
-    agent_id, error = require_registered_agent(arguments)
-    if error:
-        return [error]
-    
+    # Identity is resolved below, after we fetch the discovery and know its
+    # severity — see the severity-keyed gate in the try block (Credential Loop
+    # Asymmetry fix). Resolving here unconditionally with require_registered_agent
+    # is what blocked a low-friction writer from editing the very row it was
+    # allowed to create.
     discovery_id, error = require_argument(arguments, "discovery_id",
                                          "discovery_id is required")
     if error:
@@ -2005,7 +2005,23 @@ async def handle_update_discovery_status_graph(arguments: Dict[str, Any]) -> Seq
         discovery = await graph.get_discovery(discovery_id)
         if not discovery:
             return [await _discovery_not_found(discovery_id, graph)]
-        
+
+        # Identity gate, keyed on the EXISTING discovery's severity so update
+        # mirrors store (Credential Loop Asymmetry fix). store() lets low/medium
+        # rows be written by a low-friction writer — including the stable
+        # anonymous writer (anonkg_*) derived for fingerprint-pinned callers —
+        # but update() previously demanded a registered agent unconditionally,
+        # so a caller could create a row yet not edit it without re-running
+        # onboard() (which mints a sibling identity). Match the store gate:
+        # high/critical still require a registered, session-bound agent; the
+        # high-severity ownership checks below are unchanged.
+        if discovery.severity in ["high", "critical"]:
+            agent_id, error = require_registered_agent(arguments)
+        else:
+            agent_id, error, _ = _resolve_low_friction_writer(arguments)
+        if error:
+            return [error]
+
         # SECURITY: Require session ownership for high-severity discoveries (UUID-based auth, Dec 2025)
         if discovery.severity in ["high", "critical"]:
             from ..utils import verify_agent_ownership

--- a/src/mcp_handlers/middleware/params_step.py
+++ b/src/mcp_handlers/middleware/params_step.py
@@ -178,8 +178,17 @@ async def inject_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
                         },
                         recovery={
                             "action": "Remove agent_id parameter (session binding handles identity)",
-                            "note": "Each session is bound to one agent. Identity auto-binds on first tool call.",
-                            "related_tools": ["identity"]
+                            "note": (
+                                "Each session is bound to one agent, and this guard only blocks "
+                                "ACTING AS another agent (writes/mutations) — it does NOT block "
+                                "READING another agent's work. To discover another agent's "
+                                f"knowledge, search is unrestricted: "
+                                f"knowledge(action='search', agent_id='{provided_id}') filters to "
+                                "that agent's entries without binding to it. Identity auto-binds "
+                                "on first tool call."
+                            ),
+                            "read_path": f"knowledge(action='search', agent_id='{provided_id}')",
+                            "related_tools": ["identity", "knowledge"]
                         }
                     )]
         elif provided_id:

--- a/src/storage/knowledge_graph_age.py
+++ b/src/storage/knowledge_graph_age.py
@@ -645,21 +645,27 @@ class KnowledgeGraphAGE:
             # Normalize search tags to match stored normalized form
             from src.knowledge_graph import normalize_tags
             params["tags"] = normalize_tags(tags)
-            # Combined MATCH: Discovery with tag relationship
+            # Combined MATCH: Discovery with tag relationship.
+            #
+            # AGE cannot emit `RETURN DISTINCT d ORDER BY d.timestamp` — it
+            # translates to `SELECT DISTINCT ... ORDER BY <prop>` where the
+            # ORDER BY expression is not in the DISTINCT select list, so
+            # Postgres rejects it: "for SELECT DISTINCT, ORDER BY expressions
+            # must appear in select list". Mirror find_similar_by_tags: dedupe
+            # with `WITH DISTINCT d`, drop the Cypher-level ORDER BY/LIMIT, and
+            # apply "most recent first" ordering + the limit in Python below.
             base_match = "MATCH (d:Discovery)-[:TAGGED]->(t:Tag) WHERE t.name IN ${tags}"
             if where_clause:
                 cypher = f"""
                     {base_match} AND {where_clause}
-                    RETURN DISTINCT d
-                    ORDER BY d.timestamp DESC
-                    LIMIT ${{limit}}
+                    WITH DISTINCT d
+                    RETURN d
                 """
             else:
                 cypher = f"""
                     {base_match}
-                    RETURN DISTINCT d
-                    ORDER BY d.timestamp DESC
-                    LIMIT ${{limit}}
+                    WITH DISTINCT d
+                    RETURN d
                 """
         else:
             # No tag filter
@@ -679,6 +685,7 @@ class KnowledgeGraphAGE:
 
         discoveries = []
         seen_ids = set()
+        tag_sort_keys: Dict[str, str] = {}
         for result in results:
             # graph_query returns parsed agtype directly, not {"d": node}
             # Handle both dict with "d" key and direct node data
@@ -693,6 +700,21 @@ class KnowledgeGraphAGE:
             if discovery and discovery.id not in seen_ids:
                 seen_ids.add(discovery.id)
                 discoveries.append(discovery)
+                if tags:
+                    # Capture the RAW stored timestamp for sorting. _node_to_discovery
+                    # defaults a missing timestamp to now(), which would make ordering
+                    # nondeterministic; the raw value (empty when absent) keeps ties
+                    # in insertion order under the stable sort below.
+                    raw_ts = node_data.get("timestamp") or node_data.get("created_at") or ""
+                    tag_sort_keys[discovery.id] = str(raw_ts)
+
+        if tags:
+            # Tag queries skip the Cypher ORDER BY/LIMIT (AGE DISTINCT
+            # limitation above), so reproduce "most recent first" + LIMIT here.
+            # ISO-8601 timestamps sort lexicographically; rows without a stored
+            # timestamp keep their original order (stable sort, empty key).
+            discoveries.sort(key=lambda disc: tag_sort_keys.get(disc.id, ""), reverse=True)
+            discoveries = discoveries[:limit]
 
         return discoveries
 

--- a/tests/test_kg_lifecycle.py
+++ b/tests/test_kg_lifecycle.py
@@ -229,14 +229,41 @@ class TestUpdateDiscoveryStatusGraph:
         assert "not found" in data["error"].lower()
 
     @pytest.mark.asyncio
-    async def test_update_unregistered_agent(self, patch_common):
-        """Update fails for unregistered agent."""
+    async def test_update_low_severity_unregistered_allowed(self, patch_common):
+        """Low/medium updates accept an unregistered writer (mirrors store).
+
+        Credential Loop Asymmetry fix: store() lets unregistered / low-friction
+        callers create low+medium rows, so update() must let them edit those
+        rows too — otherwise a caller can create a row it cannot maintain
+        without re-running onboard() (which mints a sibling identity).
+        """
         mock_mcp_server, mock_graph = patch_common
+        mock_graph.get_discovery = AsyncMock(return_value=make_discovery(severity="low"))
         from src.mcp_handlers.knowledge.handlers import handle_update_discovery_status_graph
 
         result = await handle_update_discovery_status_graph({
             "agent_id": "unregistered",
-            "discovery_id": "2026-01-01T00:00:00.000000",
+            "discovery_id": "disc-1",
+            "status": "resolved",
+        })
+
+        data = parse_result(result)
+        assert data["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_update_high_severity_unregistered_rejected(self, patch_common):
+        """High/critical updates still require a registered agent (unchanged).
+
+        The Credential Loop Asymmetry fix only relaxes the low/medium gate; the
+        security boundary on high+critical rows is preserved.
+        """
+        mock_mcp_server, mock_graph = patch_common
+        mock_graph.get_discovery = AsyncMock(return_value=make_discovery(severity="critical"))
+        from src.mcp_handlers.knowledge.handlers import handle_update_discovery_status_graph
+
+        result = await handle_update_discovery_status_graph({
+            "agent_id": "unregistered",
+            "discovery_id": "disc-1",
             "status": "resolved",
         })
 

--- a/tests/test_knowledge_graph_age.py
+++ b/tests/test_knowledge_graph_age.py
@@ -873,7 +873,11 @@ class TestQuery:
         params = call_args.args[1]
         assert "TAGGED" in cypher
         assert "Tag" in cypher
-        assert "RETURN DISTINCT d" in cypher
+        # AGE cannot emit `RETURN DISTINCT d ORDER BY d.timestamp` — Postgres
+        # rejects it ("for SELECT DISTINCT, ORDER BY expressions must appear in
+        # select list"). Dedupe with `WITH DISTINCT d` and order in Python.
+        assert "WITH DISTINCT d" in cypher
+        assert "ORDER BY" not in cypher
         assert params["tags"] == ["python", "bug"]
 
     @pytest.mark.asyncio
@@ -890,6 +894,31 @@ class TestQuery:
         assert "TAGGED" in cypher
         assert params["agent_id"] == "agent-1"
         assert params["tags"] == ["python"]
+
+    @pytest.mark.asyncio
+    async def test_query_with_tags_sorts_recent_first_and_limits_in_python(self):
+        """Tag queries order by timestamp DESC and apply the limit in Python.
+
+        Regression for the Tag Search SQL crash: AGE cannot run
+        `RETURN DISTINCT d ORDER BY d.timestamp` (Postgres rejects "for SELECT
+        DISTINCT, ORDER BY expressions must appear in select list"), so the
+        Cypher drops ORDER BY/LIMIT and ordering + cap happen in Python.
+        """
+        kg, mock_db = make_kg_with_mock_db()
+        # Deliberately out of chronological order to prove Python sorts them.
+        mock_db.graph_query.return_value = [
+            {"properties": {"id": "old", "agent_id": "a1", "summary": "old",
+                            "timestamp": "2026-01-01T00:00:00+00:00"}},
+            {"properties": {"id": "new", "agent_id": "a1", "summary": "new",
+                            "timestamp": "2026-06-01T00:00:00+00:00"}},
+            {"properties": {"id": "mid", "agent_id": "a1", "summary": "mid",
+                            "timestamp": "2026-03-01T00:00:00+00:00"}},
+        ]
+
+        result = await kg.query(tags=["python"], limit=2)
+
+        # Most-recent-first, capped at the limit.
+        assert [d.id for d in result] == ["new", "mid"]
 
     @pytest.mark.asyncio
     async def test_query_with_limit(self):


### PR DESCRIPTION
## Summary

Verifies a batch of dogfood-reported UX frictions and fixes the three that are **real, code-level, and tractable**. Each fix was checked against both the live MCP server and the source.

### What was verified (full triage)

| Claim | Verdict |
|---|---|
| Tag Search SQL crash | ✅ **Real — reproduced live**, fixed here |
| Credential Loop Asymmetry (store vs update) | ✅ **Real**, fixed here |
| Session Binding "wall" blocks cross-agent **discovery** | ⚠️ Real friction, wrong diagnosis (reads aren't blocked) — error message clarified here |
| Read tools mint identity / orphan agents | ✅ Real (single guard + after-the-fact cleanup) — *filed, not in this PR* |
| Identity surface too wide (7+ IDs) | ✅ Real — *filed, not in this PR* |
| client_hint leaks into agent_id | ❌ Not present (validation `^[A-Za-z0-9_-]{1,40}$` already rejects it) |
| Weak default tier (0.35) | ✅ Real (confirmed by my own onboarding landing at weak/0.35) — by-design, *filed* |
| Poor search relevance / untrustworthy lifecycle status | ➖ Data-dependent, not code-fixable here |

## Fixes in this PR

**1. Tag Search SQL crash** (`KnowledgeGraphAGE.query`)
`knowledge(action=search, tags=[...])` failed for *every* tag-filtered search with:
`Failed to search knowledge: for SELECT DISTINCT, ORDER BY expressions must appear in select list`.
Cause: the tag branch emitted `RETURN DISTINCT d ORDER BY d.timestamp`, which AGE lowers to `SELECT DISTINCT … ORDER BY <prop>` where the ORDER BY expression isn't in the DISTINCT select list. Fix mirrors the existing `find_similar_by_tags` pattern: dedupe with `WITH DISTINCT d`, drop the Cypher `ORDER BY`/`LIMIT`, and apply most-recent-first ordering + limit in Python (sorting on the raw stored timestamp so missing-timestamp rows stay stable).

**2. Credential Loop Asymmetry** (`update_discovery_status`)
`store()` lets a low-friction / anonymous writer (`anonkg_*`, derived from a fingerprint pin) create low+medium rows, but `update()` required a registered agent unconditionally — so a caller could create a row it couldn't edit without re-running `onboard()` (which mints a sibling identity → the identity-proliferation footgun the dogfood note flagged). Fix keys the update identity gate on the **existing discovery's severity**: low/medium accept the same low-friction writer as `store()`; **high/critical still require a registered, session-bound agent** and all existing ownership checks are unchanged.

**3. Session-mismatch error clarity** (`inject_identity` middleware)
The guard only blocks *acting as* another agent (writes); it does **not** block reading another agent's work. The recovery hint now says so and points to the working read path: `knowledge(action='search', agent_id='<other>')`.

## Tests
- New regression: tag query orders most-recent-first and applies the limit in Python (locks in the SQL-crash fix).
- Updated the `RETURN DISTINCT d` assertion to the new `WITH DISTINCT d` / no-`ORDER BY` shape.
- Replaced `test_update_unregistered_agent` with two precise tests: low-severity unregistered update now **allowed**; high-severity unregistered update still **rejected**.
- Touched-area suites pass locally (`test_knowledge_graph_age`, `test_kg_search`, `test_kg_lifecycle`, `test_kg_store`, `test_dispatch_*`, `test_agent_identity_auth`).

Follow-ups (read-tool identity side-effects, identity-surface width, weak-default tier) are being filed as separate issues rather than bundled here, since they touch the identity single-writer surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5mv3YCoCDAzK5dbJnkmWb)_