### PR TITLE
fix(kg-lifecycle): exempt permanent entries from the archived→cold sweep

### DIFF
--- a/src/knowledge_graph_lifecycle.py
+++ b/src/knowledge_graph_lifecycle.py
@@ -313,7 +313,16 @@ class KnowledgeGraphLifecycle:
         return to_archive, skipped
 
     async def _move_to_cold(self, now: datetime, dry_run: bool) -> List[str]:
-        """Move very old archived discoveries to cold storage tier."""
+        """Move very old archived discoveries to cold storage tier.
+
+        Respects permanent policy for symmetry with ``_archive_old_resolved``:
+        the stated philosophy is "permanent → never auto-archive", and moving a
+        row to cold takes it out of default search scope (the deeper archival
+        step), so a permanent entry that ever lands in ``archived`` — e.g. a
+        manual archive, a re-type after archival, or a row stored before the
+        resolved→archived permanent-skip existed — must not be buried by the
+        cold sweep.
+        """
         graph = await self._get_graph()
         cutoff = now - timedelta(days=self.ARCHIVED_TO_COLD_DAYS)
         cutoff_iso = cutoff.isoformat()
@@ -323,6 +332,9 @@ class KnowledgeGraphLifecycle:
 
         to_cold = []
         for discovery in archived:
+            # Permanent entries are never auto-tiered, even out of archived.
+            if self.get_lifecycle_policy(discovery) == "permanent":
+                continue
             # Check if updated_at (when it was archived) is old enough
             if discovery.updated_at and discovery.updated_at < cutoff_iso:
                 to_cold.append(discovery.id)
@@ -400,6 +412,7 @@ class KnowledgeGraphLifecycle:
         old_archived = sum(
             1 for d in archived_discoveries
             if d.updated_at and d.updated_at < cutoff_archived
+            and self.get_lifecycle_policy(d) != "permanent"
         )
 
         # Count ephemeral ready to archive

--- a/tests/test_knowledge_graph_lifecycle.py
+++ b/tests/test_knowledge_graph_lifecycle.py
@@ -200,6 +200,26 @@ class TestRunCleanup:
         assert result["discoveries_to_cold"] == 1
 
     @pytest.mark.asyncio
+    async def test_cleanup_skips_permanent_archived_from_cold(self):
+        """Permanent discoveries must not be swept to cold even if archived+old.
+
+        Symmetry with the resolved→archived permanent-skip: 'never auto-archive'
+        extends to the deeper cold tier, so a permanent entry that ended up in
+        'archived' stays in default search scope instead of being buried.
+        """
+        old_time = (datetime.now() - timedelta(days=120)).isoformat()
+        d = MockDiscovery(id="perm_arch1", type="root_cause_analysis", tags=[],
+                          status="archived", updated_at=old_time)
+
+        graph = make_mock_graph(archived_items=[d])
+        lifecycle = KnowledgeGraphLifecycle(graph=graph)
+
+        result = await lifecycle.run_cleanup(dry_run=False)
+
+        assert result["discoveries_to_cold"] == 0
+        graph.update_discovery.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_cleanup_never_deletes(self):
         """Cleanup should NEVER delete anything - core philosophy."""
         old_time = (datetime.now() - timedelta(days=365)).isoformat()


### PR DESCRIPTION
## Summary

Follow-up to the dogfood triage (issue #945, PR #944). The user asked me to chase one lead from the search-relevance / status-trust investigation: *are "permanent" learnings being archived out of default search scope?*

**The primary hypothesis was disproven** — the resolved→archived path (`_archive_old_resolved`) already correctly skips permanent-policy entries. But chasing it surfaced a real **asymmetry one tier deeper**:

`_move_to_cold` moved **any** archived row older than 90 days to the cold tier with **no** permanent-policy check — unlike `_archive_old_resolved`, which has one. Moving to cold takes an entry out of default search scope (it's the deeper archival step), so this contradicts the module's stated philosophy: *"permanent → never auto-archive."*

A permanent entry can land in `archived` via a manual archive, a re-type after archival, or simply by predating the resolved→archived permanent-skip — and the cold sweep would then silently bury it. With ~774 archived rows live, some permanent learnings may already be exposed to this.

## Change
- `_move_to_cold`: skip permanent-policy discoveries, symmetric with `_archive_old_resolved`.
- `get_lifecycle_stats`: exclude permanent entries from the `archived_ready_for_cold` candidate count so it matches what would actually move.

## Test
- New: a permanent (`root_cause_analysis`) archived+old entry is **not** swept to cold and triggers no status update.
- Full `tests/test_knowledge_graph_lifecycle.py` suite passes (25 tests).

## Scope note
This addresses one concrete, contained slice of the #945 findings. The broader items — *recurrence detection for `resolved` status* and *valuable resolved/archived learnings dropping out of default search scope* — remain design questions tracked in #945, not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5mv3YCoCDAzK5dbJnkmWb)_