### PR TITLE
feat(kg-search): low_confidence signal when results have no lexical anchor

### DIFF
--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -1091,6 +1091,10 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
         semantic_scores_dict = {}
         rerank_scores_dict = {}
         rrf_scores_dict = {}
+        # IDs the lexical (FTS) lane returned. None when no lexical lane ran
+        # (pure-semantic / substring scan), so the abstention signal below can
+        # tell "no keyword match" apart from "lexical judgement unavailable".
+        fts_anchor_ids = None
         search_degraded_warning = None
         hybrid_skipped_reason = None
         fts_fallback_skipped_reason = None
@@ -1249,6 +1253,7 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
 
                 sem_ids = [d.id for d, _ in sem_res]
                 fts_ids = [d.id for d in fts_res]
+                fts_anchor_ids = set(fts_ids)
                 fused = rrf_fuse([sem_ids, fts_ids], k=60)
 
                 pool: Dict[str, Any] = {d.id: d for d, _ in sem_res}
@@ -1365,6 +1370,8 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
                             f"query (limit {complex_query_term_limit}); pass operator='OR' "
                             "to request broad recall"
                         )
+                # All FTS candidates are lexical matches by construction.
+                fts_anchor_ids = {d.id for d in candidates}
                 search_mode = "fts"
             elif not hybrid_path and not use_semantic:
                 # JSON backend fallback: bounded scan of most recent entries.
@@ -1766,6 +1773,28 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
             if rrf_scores:
                 response_data["rrf_scores"] = rrf_scores
 
+        # Low-confidence / abstention signal — an honest "no strong match".
+        # Absolute cosine is unreliable on this corpus: embeddings are
+        # anisotropic, so a nonsense query can post a HIGHER top cosine than a
+        # genuine conceptual one (measured 2026-06-20: an off-domain query
+        # topped ~0.355 vs a real conceptual query's 0.311). So confidence keys
+        # on LEXICAL corroboration, not a cosine threshold: in a mode where an
+        # FTS lane ran, if NONE of the returned results actually matched the
+        # query terms, the hits are semantic-only and — given the weak score
+        # calibration — likely tangential. Surface that instead of presenting
+        # noise as confident signal. Pure-semantic / substring modes leave
+        # fts_anchor_ids None and are not flagged (no lexical lane to judge).
+        if query_text and results and fts_anchor_ids is not None:
+            lexical_hits = sum(1 for d in results if d.id in fts_anchor_ids)
+            if lexical_hits == 0:
+                response_data["low_confidence"] = True
+                response_data["confidence_note"] = (
+                    "No result matched your query terms lexically — these are "
+                    "semantic-only matches and may be tangential (semantic "
+                    "relevance is weakly calibrated on this corpus). Rephrase "
+                    "with distinctive key terms, or treat these as exploratory "
+                    "rather than authoritative."
+                )
 
         # UX FIX (Dec 2025): Add helpful hint when substring scan returns no results
         if search_mode == "substring_scan" and len(results) == 0 and query_text:

--- a/tests/test_kg_search.py
+++ b/tests/test_kg_search.py
@@ -215,6 +215,53 @@ class TestSearchKnowledgeGraph:
         assert data["count"] == 0
 
     @pytest.mark.asyncio
+    async def test_hybrid_no_lexical_match_flags_low_confidence(self, patch_common):
+        """Hybrid hits with zero FTS (lexical) anchor are flagged low_confidence.
+
+        Anisotropic cosine lets a query get semantic-only hits with no keyword
+        match (the 'confident noise' case the 2026-06-20 probes exposed). When
+        the FTS lane returns nothing, the surfaced results are semantic-only, so
+        the handler marks the response low_confidence instead of presenting it
+        as a trustworthy match.
+        """
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        disc = make_discovery(id="sem-only", summary="tangential semantic neighbor")
+        mock_graph.semantic_search = AsyncMock(return_value=[(disc, 0.36)])
+        mock_graph.full_text_search = AsyncMock(return_value=[])  # no keyword match
+
+        result = await handle_search_knowledge_graph({
+            "query": "how to bake sourdough bread",
+            "search_mode": "hybrid",
+        })
+
+        data = parse_result(result)
+        assert data["success"] is True
+        assert data.get("low_confidence") is True
+        assert "confidence_note" in data
+
+    @pytest.mark.asyncio
+    async def test_hybrid_with_lexical_match_not_low_confidence(self, patch_common):
+        """A keyword-anchored hybrid result is NOT flagged low_confidence."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        disc = make_discovery(id="anchored", summary="exact keyword match here")
+        mock_graph.semantic_search = AsyncMock(return_value=[(disc, 0.36)])
+        mock_graph.full_text_search = AsyncMock(return_value=[disc])  # FTS anchored it
+
+        result = await handle_search_knowledge_graph({
+            "query": "keyword",
+            "search_mode": "hybrid",
+        })
+
+        data = parse_result(result)
+        assert data["success"] is True
+        assert data.get("low_confidence") is not True
+        assert "confidence_note" not in data
+
+    @pytest.mark.asyncio
     async def test_search_with_include_details(self, patch_common):
         """Search with include_details=True returns full content."""
         mock_mcp_server, mock_graph = patch_common


### PR DESCRIPTION
## Summary

Lands the council-recommended "smallest safe step" from the #947 investigation: an honest **`low_confidence`** signal on KG search, so retrieval stops presenting noise as a confident match.

### Why (verified 2026-06-20)
A three-lens council pass + live measurement found the search relevance complaint (#945) is **not** a pruning problem and **not** broken embeddings — it's the ranking layer:
- An off-domain query (*"how to bake sourdough bread"*) topped cosine **0.355** — *higher* than a real conceptual query's **0.311**. Sentence embeddings here are **anisotropic** (cosines cluster in a narrow high band), so absolute cosine is an unreliable confidence cue.
- `rrf_fuse` ranks by **position only** (`retrieval.py:60`), discarding scores — so a nonsense query still yields a confident full ranking.
- The cross-encoder reranker — the one true relevance scorer — is **off by default** (`reranker.py:56`, `default=False`).

### What this does
Adds an abstention signal keyed on **lexical corroboration**, not a cosine threshold (because cosine is unreliable here): in a mode where the FTS lane ran, if **none** of the returned results actually matched the query terms, the hits are semantic-only and likely tangential → response is marked `low_confidence: true` with a `confidence_note` guiding the agent to rephrase or treat results as exploratory.

- Keyword-anchored results are **not** flagged.
- Pure-semantic and substring modes (no lexical lane to judge) are left unflagged rather than false-positived — avoids mislabeling genuine conceptual matches.

### Scope
- Deployment-independent (pure handler logic), so it helps regardless of server config.
- **Complements, does not replace**, enabling the cross-encoder reranker (`UNITARES_ENABLE_RERANKER=1`) — the larger ranking win, tracked as an ops action in #947.

### Tests
- `test_hybrid_no_lexical_match_flags_low_confidence` — hybrid with zero FTS anchor ⇒ `low_confidence: true`.
- `test_hybrid_with_lexical_match_not_low_confidence` — keyword-anchored hybrid ⇒ not flagged.
- Full `tests/test_kg_search.py` + `tests/test_kg_lifecycle.py` pass (154).

Part of the #945 / #947 dogfood-retrieval thread. Independent of #946 (lifecycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5mv3YCoCDAzK5dbJnkmWb)_