### PR TITLE
fix(kg-search): exclude cold storage from default search; rank cold below archived

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,7 +41,7 @@ _Curated backfill of notable changes merged since 2.13.0 (2026-05-04). Versioned
 - **§129:** un-blind the substrate-tax gate (nesting) + stop counting shutdown noise (#576)
 - **identity:** strict gate keys on caller-proven binding, not binding-presence (#674, #675); single-flight + PG adopt-winner for operator-token first-use mint race (#646); stop laundering server-injected fingerprint CSID into the strong assurance tier (#682); anonymous auto-mint must not use the reserved `mcp_` prefix (#598); subagent onboards must not displace the driver's fingerprint pin (#604); lineage successor suppresses parent stuck-flag (#677)
 - **kg:** close write-path bugs — id collisions, naive ts, batch parity (#673); decouple auto-hybrid term cap from OR-recall cap (#672)
-- **kg:** stop cold-storage rows leaking into default search un-down-ranked — search now excludes `cold` unless `include_cold=true` (mirrors archived), and `cold` ranks below `archived` in the blend's status multipliers (#PLACEHOLDER)
+- **kg:** stop cold-storage rows leaking into default search un-down-ranked — search now excludes `cold` unless `include_cold=true` (mirrors archived), and `cold` ranks below `archived` in the blend's status multipliers (#950)
 - **calibration:** correct severe lower-bin underconfidence, not just cap it (#668)
 - **responses:** honest verdict provenance + reconcile position/thread_size (#670); reconcile six API-response honesty inconsistencies (#665)
 - **dashboard:** inner deadline degrades slow fleet read instead of a 15s hang (#666)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,7 @@ _Curated backfill of notable changes merged since 2.13.0 (2026-05-04). Versioned
 - **§129:** un-blind the substrate-tax gate (nesting) + stop counting shutdown noise (#576)
 - **identity:** strict gate keys on caller-proven binding, not binding-presence (#674, #675); single-flight + PG adopt-winner for operator-token first-use mint race (#646); stop laundering server-injected fingerprint CSID into the strong assurance tier (#682); anonymous auto-mint must not use the reserved `mcp_` prefix (#598); subagent onboards must not displace the driver's fingerprint pin (#604); lineage successor suppresses parent stuck-flag (#677)
 - **kg:** close write-path bugs — id collisions, naive ts, batch parity (#673); decouple auto-hybrid term cap from OR-recall cap (#672)
+- **kg:** stop cold-storage rows leaking into default search un-down-ranked — search now excludes `cold` unless `include_cold=true` (mirrors archived), and `cold` ranks below `archived` in the blend's status multipliers (#PLACEHOLDER)
 - **calibration:** correct severe lower-bin underconfidence, not just cap it (#668)
 - **responses:** honest verdict provenance + reconcile position/thread_size (#670); reconcile six API-response honesty inconsistencies (#665)
 - **dashboard:** inner deadline degrades slow fleet read instead of a 15s hang (#666)

--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -1086,6 +1086,9 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
             status = "open"
         # Default: exclude archived entries unless explicitly requested
         include_archived = arguments.get("include_archived", False)
+        # Cold storage is long-term memory, queryable only with include_cold=true
+        # (mirrors the lifecycle contract). Default search excludes it.
+        include_cold = arguments.get("include_cold", False)
 
         # Track semantic scores if semantic search is used
         semantic_scores_dict = {}
@@ -1401,6 +1404,9 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
                 # Exclude archived entries by default (unless status filter or include_archived)
                 if not status and not include_archived and d.status == "archived":
                     continue
+                # Exclude cold-storage entries by default (unless status filter or include_cold)
+                if not status and not include_cold and d.status == "cold":
+                    continue
                 if tags and not search_mode.startswith("hybrid_rrf"):
                     # In hybrid mode, tags are a score boost in RRF space (handled
                     # upstream via apply_tag_boost). Everywhere else, they remain a
@@ -1451,6 +1457,7 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
             # Without this, LIMIT grabs N most recent (mostly archived junk), then
             # post-hoc filtering removes them, returning far fewer than N results.
             should_exclude_archived = not status and not include_archived
+            should_exclude_cold = not status and not include_cold
             results = await graph.query(
                 agent_id=agent_id,
                 tags=tags,
@@ -1459,6 +1466,7 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
                 status=status,
                 limit=limit,
                 exclude_archived=should_exclude_archived,
+                exclude_cold=should_exclude_cold,
             )
             search_mode = "indexed_filters"
             operator_used = "N/A"  # No text search, just filters

--- a/src/storage/knowledge_graph_age.py
+++ b/src/storage/knowledge_graph_age.py
@@ -589,6 +589,7 @@ class KnowledgeGraphAGE:
         tags: Optional[List[str]] = None,
         limit: int = 100,
         exclude_archived: bool = False,
+        exclude_cold: bool = False,
     ) -> List[DiscoveryNode]:
         """
         Query discoveries with filters.
@@ -600,6 +601,8 @@ class KnowledgeGraphAGE:
             severity: Filter by severity
             tags: Filter by tags (any match)
             limit: Maximum results
+            exclude_archived: Drop archived rows when no explicit status filter
+            exclude_cold: Drop cold-storage rows when no explicit status filter
         """
         db = await self._get_db()
 
@@ -636,6 +639,10 @@ class KnowledgeGraphAGE:
             # Use IS NULL OR to include entries with missing status (AGE NULL semantics:
             # NULL <> 'archived' evaluates to NULL, not TRUE, so those rows get filtered out)
             conditions.append("(d.status IS NULL OR d.status <> 'archived')")
+
+        # Cold storage is opt-in (include_cold). Same NULL-safe pattern as archived.
+        if exclude_cold and not status:
+            conditions.append("(d.status IS NULL OR d.status <> 'cold')")
 
         where_clause = " AND ".join(conditions) if conditions else ""
         
@@ -1786,11 +1793,14 @@ class KnowledgeGraphAGE:
             logger.debug(f"Failed to get batch connectivity scores: {e}")
             return {d: 0.0 for d in discovery_ids}
 
-    # Status multipliers for search ranking - resolved/archived entries rank lower
+    # Status multipliers for search ranking - resolved/archived/cold entries rank lower.
+    # cold is long-term storage (queryable only with include_cold) and ranks below
+    # archived so that, when explicitly surfaced, it never outranks live tiers.
     STATUS_MULTIPLIERS = {
         "open": 1.0,
         "resolved": 0.6,
         "archived": 0.3,
+        "cold": 0.2,
         "disputed": 0.5,
     }
 

--- a/src/storage/knowledge_graph_postgres.py
+++ b/src/storage/knowledge_graph_postgres.py
@@ -67,6 +67,7 @@ class KnowledgeGraphPostgres:
         status: Optional[str] = None,
         limit: int = 50,
         exclude_archived: bool = False,
+        exclude_cold: bool = False,
     ) -> List[DiscoveryNode]:
         """Query discoveries with filters."""
         db = await self._get_db()
@@ -82,9 +83,13 @@ class KnowledgeGraphPostgres:
             status=effective_status if effective_status != "!archived" else status,
             limit=limit,
         )
-        # Post-hoc filter as fallback since kg_query may not support negated status
-        if exclude_archived and not status:
-            rows = [r for r in rows if r.get("status") != "archived"]
+        # Post-hoc filter as fallback since kg_query may not support negated status.
+        # Cold storage is opt-in (include_cold), mirroring archived exclusion.
+        if not status:
+            if exclude_archived:
+                rows = [r for r in rows if r.get("status") != "archived"]
+            if exclude_cold:
+                rows = [r for r in rows if r.get("status") != "cold"]
         return [self._dict_to_discovery(r) for r in rows]
 
     async def full_text_search(

--- a/tests/test_kg_search.py
+++ b/tests/test_kg_search.py
@@ -1537,6 +1537,113 @@ class TestSearchArchivedFiltering:
         assert "d-archived" not in result_ids
 
 
+class TestSearchColdFiltering:
+    """Cold storage is opt-in (include_cold), mirroring archived exclusion."""
+
+    @pytest.mark.asyncio
+    async def test_search_excludes_cold_by_default(self, patch_common):
+        """Cold-storage entries should be excluded from search results by default."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        discoveries = [
+            make_discovery(id="d-open", status="open"),
+            make_discovery(id="d-cold", status="cold"),
+            make_discovery(id="d-resolved", status="resolved"),
+        ]
+
+        # Mock query to respect exclude_cold parameter (like real backend)
+        async def query_with_filtering(**kwargs):
+            rows = discoveries
+            if kwargs.get("exclude_cold", False):
+                rows = [d for d in rows if d.status != "cold"]
+            return rows
+
+        mock_graph.query = AsyncMock(side_effect=query_with_filtering)
+
+        result = await handle_search_knowledge_graph({})
+        data = parse_result(result)
+
+        assert data["success"] is True
+        result_ids = [d["id"] for d in data["discoveries"]]
+        assert "d-open" in result_ids
+        assert "d-resolved" in result_ids
+        assert "d-cold" not in result_ids
+
+    @pytest.mark.asyncio
+    async def test_search_includes_cold_when_requested(self, patch_common):
+        """Cold entries should be included when include_cold=True."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        discoveries = [
+            make_discovery(id="d-open", status="open"),
+            make_discovery(id="d-cold", status="cold"),
+        ]
+        mock_graph.query = AsyncMock(return_value=discoveries)
+
+        result = await handle_search_knowledge_graph({"include_cold": True})
+        data = parse_result(result)
+
+        assert data["success"] is True
+        result_ids = [d["id"] for d in data["discoveries"]]
+        assert "d-open" in result_ids
+        assert "d-cold" in result_ids
+
+    @pytest.mark.asyncio
+    async def test_search_includes_cold_when_status_filter_set(self, patch_common):
+        """When status='cold' is explicitly set, don't apply cold exclusion."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        discoveries = [
+            make_discovery(id="d-cold", status="cold"),
+        ]
+        mock_graph.query = AsyncMock(return_value=discoveries)
+
+        result = await handle_search_knowledge_graph({"status": "cold"})
+        data = parse_result(result)
+
+        assert data["success"] is True
+        result_ids = [d["id"] for d in data["discoveries"]]
+        assert "d-cold" in result_ids
+
+    @pytest.mark.asyncio
+    async def test_search_fts_excludes_cold_by_default(self, patch_common):
+        """FTS/post-filter path should also exclude cold entries by default."""
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        discoveries = [
+            make_discovery(id="d-open", summary="matching text", status="open"),
+            make_discovery(id="d-cold", summary="matching text", status="cold"),
+        ]
+        mock_graph.full_text_search = AsyncMock(return_value=discoveries)
+        if hasattr(mock_graph, 'semantic_search'):
+            del mock_graph.semantic_search
+
+        result = await handle_search_knowledge_graph({"query": "matching"})
+        data = parse_result(result)
+
+        assert data["success"] is True
+        result_ids = [d["id"] for d in data["discoveries"]]
+        assert "d-open" in result_ids
+        assert "d-cold" not in result_ids
+
+
+class TestStatusMultipliersCold:
+    """Cold ranks below archived in the AGE blend's status multipliers."""
+
+    def test_cold_multiplier_present_and_below_archived(self):
+        from src.storage.knowledge_graph_age import KnowledgeGraphAGE
+
+        mults = KnowledgeGraphAGE.STATUS_MULTIPLIERS
+        assert "cold" in mults, "cold must have an explicit ranking multiplier"
+        assert mults["cold"] < mults["archived"], (
+            "cold storage should rank below archived when surfaced"
+        )
+
+
 # ============================================================================
 # _or_default_query helper
 # ============================================================================


### PR DESCRIPTION
## Problem

Cold-storage rows leaked into default `knowledge(action="search")` results **un-down-ranked**, contradicting the lifecycle contract that cold is long-term memory queryable only with `include_cold=true` (`knowledge_graph_lifecycle.py`: *"Never delete. Archive to cold. Query with include_cold=true."*).

Found during the KG dogfood-frictions triage as a latent bug (not in the original 9 claims). Two independent root causes:

1. **No cold filter in search.** The search handler excluded `archived` by default but never `cold` — on both the text/semantic post-filter path (`handlers.py`) and the indexed-query path (`graph.query(...)`).
2. **No cold ranking penalty.** `STATUS_MULTIPLIERS` (AGE blend) had no `cold` key, so cold rows scored at the default `1.0` — outranking even `open` entries when they did surface.

## Fix

- Add `include_cold` (default `False`) to the search handler, mirroring the existing `include_archived` contract. Applied on both search paths; an explicit `status` filter (e.g. `status="cold"`) bypasses the exclusion, same as archived.
- Plumb `exclude_cold` through `query()` on **both** backends (`knowledge_graph_age.py`, `knowledge_graph_postgres.py`) for signature parity.
- Add `cold: 0.2` to `STATUS_MULTIPLIERS` (below `archived: 0.3`) so cold, when explicitly surfaced via `include_cold`/`status=cold`, never outranks live tiers.

## Tests

New `TestSearchColdFiltering` mirrors the existing archived suite: default-exclude (indexed + FTS paths), `include_cold=true`, explicit `status="cold"`. Plus `TestStatusMultipliersCold` asserts `cold < archived`.

```
tests/test_kg_search.py tests/test_kg_lifecycle.py tests/test_knowledge_graph_lifecycle.py — 182 passed
```

## Notes

- `include_cold` follows the same undocumented-but-supported pattern as `include_archived` (raw arg read; `SearchKnowledgeGraphParams` is not wired to the action_router validation). CHANGELOG entry added.
- Default fleet behavior is unchanged except that cold rows that were previously leaking are now correctly hidden — this *restores* the intended contract rather than changing a default.