### PR TITLE
feat(deploy): gate deploy-mcp.sh on a migration preflight

### DIFF
--- a/scripts/dev/apply_migrations.py
+++ b/scripts/dev/apply_migrations.py
@@ -124,6 +124,14 @@ def main(argv: list[str] | None = None) -> int:
         help="actually apply pending migrations (default: report only)",
     )
     parser.add_argument(
+        "--check", action="store_true",
+        help="preflight gate: exit non-zero if the DB is not fully in sync with "
+             "the source manifest (any pending migration or drift). Unlike the "
+             "default dry-run — which exits 0 when migrations are merely pending "
+             "— this is meant to gate a deploy from restarting code that expects "
+             "an unapplied schema.",
+    )
+    parser.add_argument(
         "--db-url", default=DEFAULT_DB_URL,
         help=f"Postgres DSN (default: {_redact(DEFAULT_DB_URL)})",
     )
@@ -153,6 +161,32 @@ def main(argv: list[str] | None = None) -> int:
         )
         for v in unexpected:
             print(f"  {v}: {actual[v]!r}", file=sys.stderr)
+
+    if args.check:
+        # Preflight gate: the DB is "ready for this code" only when there is
+        # nothing left to do. Any pending migration, name mismatch, or DB
+        # version with no source file blocks — a deploy must not restart code
+        # that expects an unapplied (or divergent) schema.
+        blockers: list[str] = []
+        if pending:
+            blockers.append(f"{len(pending)} pending migration(s): {pending}")
+        if mismatches:
+            blockers.append(f"{len(mismatches)} name mismatch(es): {mismatches}")
+        if unexpected:
+            blockers.append(
+                f"{len(unexpected)} DB version(s) with no source file "
+                f"(checkout behind the deployed DB): {unexpected}"
+            )
+        if blockers:
+            print("\nMigration check FAILED — DB not in sync with the source manifest:",
+                  file=sys.stderr)
+            for b in blockers:
+                print(f"  - {b}", file=sys.stderr)
+            print("\nApply with: python3 scripts/dev/apply_migrations.py --apply",
+                  file=sys.stderr)
+            return 1
+        print("\nMigration check OK — DB in sync with the source manifest.")
+        return 0
 
     if not pending:
         if mismatches or unexpected:

--- a/scripts/ops/deploy-mcp.sh
+++ b/scripts/ops/deploy-mcp.sh
@@ -30,6 +30,18 @@
 #   # rollback: cp "$PLIST.bak" "$PLIST"; launchctl unload "$PLIST"; launchctl load "$PLIST"
 set -euo pipefail
 
+# ── Flags ────────────────────────────────────────────────────────────────────
+# --apply-migrations: apply any pending DB migrations as part of the deploy
+# (opt-in, since DDL is a deliberate/approved action). Also settable via
+# UNITARES_DEPLOY_APPLY_MIGRATIONS=1. Default is detect-and-refuse on a gap.
+APPLY_MIGRATIONS="${UNITARES_DEPLOY_APPLY_MIGRATIONS:-0}"
+for arg in "$@"; do
+  case "$arg" in
+    --apply-migrations) APPLY_MIGRATIONS=1 ;;
+    *) echo "[deploy-mcp] unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
 REPO="${UNITARES_REPO:-$HOME/projects/unitares}"
 DEPLOY="${UNITARES_MCP_DEPLOY:-$HOME/projects/unitares-deploy}"
 LABEL="com.unitares.governance-mcp"
@@ -94,6 +106,49 @@ PREV="$(git -C "$DEPLOY" rev-parse HEAD)"
 echo "[deploy-mcp] fast-forwarding $DEPLOY to origin/master (ff-only; was ${PREV:0:8})"
 git -C "$DEPLOY" merge --ff-only origin/master
 mkdir -p "$DEPLOY/data/logs"
+
+# ── Migration preflight (gate, not silent) ───────────────────────────────────
+# This script historically restarted the MCP without touching DB migrations,
+# and migrations are applied by hand — twice the code went live expecting a
+# schema that wasn't there (the Phase-A half-deploy; migration 042). This gate
+# runs the just-fast-forwarded worktree's own migration checker against the
+# live DB and REFUSES to restart on a gap, rather than silently bringing up
+# code that expects an unapplied schema. DDL stays a deliberate, opt-in action:
+#   - default: detect a gap and refuse (with the apply recipe), rolling the
+#     worktree back to $PREV so on-disk code never gets left ahead of the
+#     still-running process (that mismatch is its own reboot-time foot-gun).
+#   - --apply-migrations: apply pending migrations FIRST (schema before code),
+#     re-verify, then proceed to the restart.
+# Note: a later health-failure rollback resets the worktree but NOT the DB —
+# migrations are forward-only and additive (IF NOT EXISTS), so new-schema +
+# old-code is the safe direction (the inverse is the failure mode above).
+MIGRATE="$DEPLOY/scripts/dev/apply_migrations.py"
+MIGRATE_DBURL=()
+[[ -n "${UNITARES_DEPLOY_DB_URL:-}" ]] && MIGRATE_DBURL=(--db-url "$UNITARES_DEPLOY_DB_URL")
+if [[ -f "$MIGRATE" ]]; then
+  echo "[deploy-mcp] migration preflight: is the live DB in sync with the deploy-worktree manifest?"
+  if ! python3 "$MIGRATE" --check "${MIGRATE_DBURL[@]}"; then
+    if [[ "$APPLY_MIGRATIONS" == 1 ]]; then
+      echo "[deploy-mcp] applying pending migrations (operator opt-in) BEFORE restart"
+      if ! python3 "$MIGRATE" --apply "${MIGRATE_DBURL[@]}" \
+         || ! python3 "$MIGRATE" --check "${MIGRATE_DBURL[@]}"; then
+        echo "[deploy-mcp] FAILED — migrations did not reach sync; rolling worktree back to ${PREV:0:8} and NOT restarting." >&2
+        git -C "$DEPLOY" reset --hard "$PREV"
+        exit 1
+      fi
+    else
+      echo "[deploy-mcp] REFUSING: live DB is not in sync with the migration manifest in the code about to deploy." >&2
+      echo "[deploy-mcp] Restarting now would bring up code expecting an unapplied schema (the Phase-A / #042 half-deploy failure mode)." >&2
+      echo "[deploy-mcp] Rolling the worktree back to ${PREV:0:8} (so disk does not sit ahead of the running process)." >&2
+      git -C "$DEPLOY" reset --hard "$PREV"
+      echo "[deploy-mcp] Then either apply the gap and re-deploy:" >&2
+      echo "[deploy-mcp]     python3 $MIGRATE --apply" >&2
+      echo "[deploy-mcp]   or re-run this deploy with migrations applied automatically:" >&2
+      echo "[deploy-mcp]     $0 --apply-migrations" >&2
+      exit 1
+    fi
+  fi
+fi
 
 echo "[deploy-mcp] restarting $LABEL (plist is static + already points at the worktree, so kickstart suffices)"
 launchctl kickstart -k "gui/$UID_NUM/$LABEL"

--- a/tests/test_apply_migrations_script.py
+++ b/tests/test_apply_migrations_script.py
@@ -91,3 +91,34 @@ def test_empty_db_makes_all_source_pending(mod):
     assert pending == [1, 2]
     assert mismatches == []
     assert unexpected == []
+
+
+# ── --check preflight gate ───────────────────────────────────────────────────
+# --check must exit non-zero on ANYTHING the DB-is-not-ready-for-this-code: a
+# pending migration (which the default dry-run treats as exit 0), a name
+# mismatch, or a DB version with no source file. It exits 0 only when fully in
+# sync. We drive main() with stubbed registry I/O so no live DB is needed.
+
+
+def _run_check(mod, monkeypatch, expected, actual):
+    monkeypatch.setattr(mod, "_source_schema_migrations", lambda _root: expected)
+    monkeypatch.setattr(mod, "query_applied", lambda _url: actual)
+    monkeypatch.setattr(mod, "KNOWN_SCHEMA_MIGRATION_EXCEPTIONS", {})
+    return mod.main(["--check", "--db-url", "postgresql://x/y"])
+
+
+def test_check_passes_when_in_sync(mod, monkeypatch):
+    assert _run_check(mod, monkeypatch, {1: "a", 2: "b"}, {1: "a", 2: "b"}) == 0
+
+
+def test_check_fails_on_pending(mod, monkeypatch):
+    # The default dry-run returns 0 here; --check must block instead.
+    assert _run_check(mod, monkeypatch, {1: "a", 2: "b"}, {1: "a"}) == 1
+
+
+def test_check_fails_on_name_mismatch(mod, monkeypatch):
+    assert _run_check(mod, monkeypatch, {1: "a", 2: "renamed"}, {1: "a", 2: "old"}) == 1
+
+
+def test_check_fails_on_unexpected_db_version(mod, monkeypatch):
+    assert _run_check(mod, monkeypatch, {1: "a"}, {1: "a", 99: "mystery"}) == 1


### PR DESCRIPTION
## Why

`deploy-mcp.sh` restarts the governance MCP but **never checks DB migrations** — and migrations are applied by hand. Twice this shipped code that expected a schema that wasn't there (the Phase-A half-deploy; migration #042), because `launchctl kickstart` silently brings up new code against an old DB and `/health/ready` passes anyway. This is the #1 recurring deploy-incident class in the ops notes.

This wires the *existing* `apply_migrations.py` (#821) into the deploy path as a gate. No new migration layer, no new DB tooling — just a preflight that refuses to restart on a schema gap.

## What

- **`apply_migrations.py`: add `--check`** — a preflight that exits non-zero when the DB is not fully in sync with the source manifest (any pending migration *or* drift/mismatch/unexpected). The default dry-run exits `0` on merely-*pending* migrations, so it can't gate a deploy on its own; `--check` can.
- **`deploy-mcp.sh`: migration gate** — after the ff and before the kickstart, run the just-fast-forwarded worktree's `apply_migrations.py --check` against the live DB.
  - **Default:** on a gap, **REFUSE** and roll the worktree back to `$PREV`, so on-disk code is never left ahead of the still-running process (that mismatch is its own reboot-time foot-gun — see the 2026-06-18 notes).
  - **`--apply-migrations`** (or `UNITARES_DEPLOY_APPLY_MIGRATIONS=1`): apply pending migrations **schema-before-code**, re-verify, then proceed. DDL stays a deliberate, opt-in action.

Forward-only by design: a later health-failure rollback resets the worktree but **not** the DB. New-schema + old-code is the safe direction (additive `IF NOT EXISTS` migrations); the inverse is exactly the failure mode this closes.

## Testing

- 4 new unit tests drive `main(["--check", ...])` with stubbed registry I/O — block on pending / name-mismatch / unexpected, pass only when in sync. **11/11 green** in `test_apply_migrations_script.py`.
- `--check` verified against the **live in-sync DB** (version 48 → exit 0).
- `bash -n` clean; pre-push smoke gate green (138 passed).

## Risk / scope

Touches only `scripts/dev/apply_migrations.py`, `scripts/ops/deploy-mcp.sh`, and the test. No server runtime code. The gate is fail-*closed* on a migration gap (refuse + rollback), which is strictly safer than today's silent restart. Not deployed — operator is the merge gate.

https://claude.ai/code/session_01J2tdWCnvbDgPgGdvh7A65d