### PR TITLE
fix(checkin): fail-open sensor-divergence telemetry + lock the init invariant

### DIFF
--- a/src/governance_monitor.py
+++ b/src/governance_monitor.py
@@ -450,6 +450,51 @@ class UNITARESMonitor:
         """Detect current operational regime based on state and history."""
         return _detect_regime(self.state, behavioral=self._behavioral_state)
     
+    def _record_sensor_divergence(self, sensor_eisv) -> None:
+        """Record model<->body EISV divergence as an observability signal.
+
+        FAIL-OPEN by contract. This is optional telemetry on the *mandatory*
+        check-in path: update_dynamics() has already evolved the state and the
+        governance verdict does not depend on anything written here. So any
+        error must degrade to "no divergence recorded this cycle" and never
+        propagate — an exception here would reject the whole check-in.
+
+        Incident 2026-06-16 (#800/#803): an unguarded write on this exact path
+        (`self._sensor_divergence_history.append(...)` plus a missing-attr load
+        invariant) rejected check-ins fleet-wide. The init invariant is fixed
+        in __init__; this guard closes the broader class — a *future* fault in
+        eisv_divergence() or the record shape must not take check-ins down.
+        Mirrors the calibration-penalty fail-safe in update_dynamics().
+        """
+        self._last_sensor_divergence = None
+        if sensor_eisv is None:
+            return
+        try:
+            div = eisv_divergence(sensor_eisv, self.state.unitaires_state)
+            # Stamp + retain for trend reads (bounded by SENSOR_DIVERGENCE_HISTORY_MAX).
+            div["at"] = datetime.now().isoformat()
+            # Self-heal: a monitor restored bypassing __init__ — a pickle/cache
+            # instance from before this attribute existed, or the Pi plugin's
+            # older build — can lack the deque. Initialize it lazily (the reads
+            # at runtime_queries already guard with getattr; this is the write).
+            if not hasattr(self, "_sensor_divergence_history"):
+                self._sensor_divergence_history = deque(maxlen=SENSOR_DIVERGENCE_HISTORY_MAX)
+            self._sensor_divergence_history.append(div)
+            self._last_sensor_divergence = div
+            logger.debug(
+                "sensor_divergence agent=%s magnitude=%.4f "
+                "dE=%+.3f dI=%+.3f dS=%+.3f dV=%+.3f",
+                self.agent_id,
+                div["magnitude"], div["dE"], div["dI"], div["dS"], div["dV"],
+            )
+        except Exception:
+            # Telemetry only — log and move on; the check-in must still succeed.
+            logger.warning(
+                "sensor_divergence recording failed for agent=%s; skipping this "
+                "cycle (check-in unaffected)", self.agent_id, exc_info=True,
+            )
+            self._last_sensor_divergence = None
+
     def update_dynamics(self,
                        agent_state: Dict,
                        dt: float = None) -> None:
@@ -564,32 +609,10 @@ class UNITARESMonitor:
         # The ODE above evolved as an independent predictor; the sensor EISV is
         # the measured body. Their disagreement (cf. allostatic load) is recorded
         # for observability rather than sprung away. Coupling is opt-in and
-        # flag-gated inside step_state (see sensor_coupling_enabled()).
-        self._last_sensor_divergence = None
-        if sensor_eisv is not None:
-            self._last_sensor_divergence = eisv_divergence(
-                sensor_eisv, self.state.unitaires_state
-            )
-            # Stamp + retain for trend reads (bounded by SENSOR_DIVERGENCE_HISTORY_MAX).
-            self._last_sensor_divergence["at"] = datetime.now().isoformat()
-            # Self-heal: a monitor restored bypassing __init__ — a pickle/cache
-            # instance from before this attribute existed, or the Pi plugin's
-            # older build — can lack the deque. Initialize it lazily so a check-in
-            # never raises AttributeError here (the reads at :355 and
-            # runtime_queries already guard with getattr; this is the one write).
-            if not hasattr(self, "_sensor_divergence_history"):
-                self._sensor_divergence_history = deque(maxlen=SENSOR_DIVERGENCE_HISTORY_MAX)
-            self._sensor_divergence_history.append(self._last_sensor_divergence)
-            logger.debug(
-                "sensor_divergence agent=%s magnitude=%.4f "
-                "dE=%+.3f dI=%+.3f dS=%+.3f dV=%+.3f",
-                self.agent_id,
-                self._last_sensor_divergence["magnitude"],
-                self._last_sensor_divergence["dE"],
-                self._last_sensor_divergence["dI"],
-                self._last_sensor_divergence["dS"],
-                self._last_sensor_divergence["dV"],
-            )
+        # flag-gated inside step_state (see sensor_coupling_enabled()). This is
+        # OPTIONAL telemetry on the mandatory check-in path, so it is fail-open
+        # (see _record_sensor_divergence) — the verdict is already decided above.
+        self._record_sensor_divergence(sensor_eisv)
 
         # Epistemic humility safeguard: Enforce entropy floor (S >= 0.001) always
         # Perfect equilibrium (S=0.0) is dangerous and brittle - maintain epistemic humility at all times

--- a/tests/test_checkin_hotpath_invariants.py
+++ b/tests/test_checkin_hotpath_invariants.py
@@ -1,0 +1,172 @@
+"""Hot-path safety invariants for the governance check-in (update_dynamics).
+
+Two regressions are locked here, both born from the 2026-06-16 fleet-wide
+check-in outage (#800/#803):
+
+1. **Init-prologue invariant (lint).** Every ``self.X`` attribute that
+   ``UNITARESMonitor._initialize_fresh_state`` sets must ALSO be set
+   unconditionally in ``__init__`` (outside the ``if load_state:`` branch).
+   The persisted-state load path does NOT call ``_initialize_fresh_state``, so
+   an attribute set only there is absent on every established agent — exactly
+   how #803 reached ``update_dynamics`` with a missing ``_sensor_divergence_*``
+   attribute and rejected the check-in. This test fails the moment a new
+   attribute is added to the fresh-state helper without also being added to the
+   prologue.
+
+2. **Fail-open telemetry (behaviour).** ``_record_sensor_divergence`` is
+   optional telemetry on the mandatory check-in path; a fault inside it must
+   degrade to "no record this cycle", never raise.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+import pytest
+
+import src.governance_monitor as gm
+
+MONITOR_SRC = Path(gm.__file__)
+
+
+# ── 1. Init-prologue invariant ───────────────────────────────────────────────
+
+def _self_attrs_assigned(func_node: ast.FunctionDef, *, exclude_subtree=None) -> set[str]:
+    """Names X for every `self.X = ...` (Assign/AnnAssign) under func_node.
+
+    ``exclude_subtree`` is an AST node whose descendants are skipped — used to
+    drop the ``if load_state:`` block so we only see the unconditional prologue.
+    """
+    excluded = set()
+    if exclude_subtree is not None:
+        excluded = {id(n) for n in ast.walk(exclude_subtree)}
+
+    found: set[str] = set()
+    for node in ast.walk(func_node):
+        if id(node) in excluded:
+            continue
+        targets = []
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        for t in targets:
+            # self.NAME = ...  (plain attribute on self; not self.x.y = ...)
+            if (
+                isinstance(t, ast.Attribute)
+                and isinstance(t.value, ast.Name)
+                and t.value.id == "self"
+            ):
+                found.add(t.attr)
+    return found
+
+
+def _find_method(cls_node: ast.ClassDef, name: str) -> ast.FunctionDef:
+    for n in cls_node.body:
+        if isinstance(n, ast.FunctionDef) and n.name == name:
+            return n
+    raise AssertionError(f"method {name!r} not found on {cls_node.name}")
+
+
+@pytest.fixture(scope="module")
+def monitor_ast():
+    tree = ast.parse(MONITOR_SRC.read_text())
+    cls = next(
+        n for n in tree.body
+        if isinstance(n, ast.ClassDef) and n.name == "UNITARESMonitor"
+    )
+    return cls
+
+
+def test_fresh_state_attrs_are_all_set_in_init_prologue(monitor_ast):
+    init = _find_method(monitor_ast, "__init__")
+    fresh = _find_method(monitor_ast, "_initialize_fresh_state")
+
+    # The load branch inside __init__ that the persisted path takes instead of
+    # _initialize_fresh_state(). Attributes set only inside it do NOT count as
+    # part of the unconditional prologue.
+    load_branch = next(
+        (n for n in init.body
+         if isinstance(n, ast.If)
+         and "load_state" in {x.id for x in ast.walk(n.test) if isinstance(x, ast.Name)}),
+        None,
+    )
+    assert load_branch is not None, "expected an `if load_state:` block in __init__"
+
+    prologue_attrs = _self_attrs_assigned(init, exclude_subtree=load_branch)
+    fresh_attrs = _self_attrs_assigned(fresh)
+
+    missing = fresh_attrs - prologue_attrs
+    assert not missing, (
+        "These self attributes are set in _initialize_fresh_state but NOT in the "
+        "unconditional __init__ prologue, so the persisted-state load path "
+        f"(which skips _initialize_fresh_state) leaves them unset: {sorted(missing)}. "
+        "Set them in __init__ before the `if load_state:` branch (the #803 rule)."
+    )
+
+
+def test_known_hotpath_attrs_are_in_the_prologue(monitor_ast):
+    """Belt-and-suspenders: the specific attrs from the #803 incident."""
+    init = _find_method(monitor_ast, "__init__")
+    load_branch = next(
+        n for n in init.body
+        if isinstance(n, ast.If)
+        and "load_state" in {x.id for x in ast.walk(n.test) if isinstance(x, ast.Name)}
+    )
+    prologue = _self_attrs_assigned(init, exclude_subtree=load_branch)
+    for attr in ("_last_sensor_divergence", "_sensor_divergence_history", "created_at"):
+        assert attr in prologue, f"{attr} must be set in the __init__ prologue (#803)"
+
+
+# ── 2. Fail-open telemetry behaviour ─────────────────────────────────────────
+
+@pytest.fixture()
+def monitor():
+    # load_state=False: in-process, no DB, fresh state. Cheap.
+    return gm.UNITARESMonitor("test-hotpath-agent", load_state=False)
+
+
+def test_record_sensor_divergence_none_is_noop(monitor):
+    before = len(monitor._sensor_divergence_history)
+    monitor._record_sensor_divergence(None)
+    assert monitor._last_sensor_divergence is None
+    assert len(monitor._sensor_divergence_history) == before
+
+
+def test_record_sensor_divergence_happy_path(monitor):
+    before = len(monitor._sensor_divergence_history)
+    # Divergence of the current ODE state against itself: a valid, ~zero record.
+    monitor._record_sensor_divergence(monitor.state.unitaires_state)
+    assert isinstance(monitor._last_sensor_divergence, dict)
+    assert "magnitude" in monitor._last_sensor_divergence
+    assert len(monitor._sensor_divergence_history) == before + 1
+
+
+def test_record_sensor_divergence_fails_open(monitor, monkeypatch):
+    """A fault in the telemetry must NOT propagate — the check-in must survive."""
+    def boom(*_a, **_k):
+        raise RuntimeError("simulated eisv_divergence fault")
+
+    monkeypatch.setattr(gm, "eisv_divergence", boom)
+    before = len(monitor._sensor_divergence_history)
+
+    # Must not raise.
+    monitor._record_sensor_divergence(object())
+
+    assert monitor._last_sensor_divergence is None
+    assert len(monitor._sensor_divergence_history) == before
+
+
+def test_record_sensor_divergence_survives_missing_history_deque(monitor, monkeypatch):
+    """Self-heal: a monitor that lost its deque (old pickle/cache) still records."""
+    monkeypatch.setattr(
+        gm, "eisv_divergence",
+        lambda *_a, **_k: {"magnitude": 0.0, "dE": 0.0, "dI": 0.0, "dS": 0.0, "dV": 0.0},
+    )
+    del monitor._sensor_divergence_history
+    monitor._record_sensor_divergence(object())
+    assert isinstance(monitor._sensor_divergence_history, deque)
+    assert len(monitor._sensor_divergence_history) == 1
+    assert monitor._last_sensor_divergence is not None


### PR DESCRIPTION
## Why

The 2026-06-16 **fleet-wide check-in outage** (#800/#803) had two root causes on the mandatory check-in path (`UNITARESMonitor.update_dynamics`):

1. an **unguarded telemetry write** (`_sensor_divergence_history.append(...)`), and
2. a **load-path init invariant** — the divergence attrs were set only in `_initialize_fresh_state`, which the persisted-state branch *skips*, so every established agent reached `update_dynamics` without them and rejected its check-in with `AttributeError`.

#803 fixed (2) for that one attribute by setting it unconditionally in `__init__`. This PR closes the broader **class** of both, so the next variant can't recur.

## What

- **Fail-open telemetry.** Extract the divergence recording into `_record_sensor_divergence`, wrapped in `try/except` — mirroring the calibration-penalty `# Fail-safe` block right above it. The governance verdict is decided by `step_state()` **before** this runs, so a future fault in `eisv_divergence()` or the record shape now degrades to *"no record this cycle"* instead of taking down check-ins. The narrow `hasattr` self-heal for a lost deque is preserved. **Behaviour-identical on the happy path.**
- **Init-prologue lint.** A new AST test asserts every `self.X` set in `_initialize_fresh_state` is also set in the unconditional `__init__` prologue (outside `if load_state:`). It fails the instant someone reintroduces the #803 pattern — and is verified to have teeth against a synthetic violation.

## Testing

- **6 new tests** in `test_checkin_hotpath_invariants.py`: 4 behaviour (none-is-noop, happy path, **fails-open on injected fault**, self-heals a missing deque) + 2 invariant (general AST lint + explicit `_sensor_divergence_*`/`created_at` check).
- Existing `sensor`/`divergence`/`governance_monitor` suite green — **391 passed**, including `test_sensor_divergence_trend` which drives `update_dynamics` end-to-end with a real `sensor_eisv` and reads the trend back.
- Pre-push smoke gate green (138 passed).

## Risk / scope

One file of runtime change (`governance_monitor.py`), a pure extract-and-guard with the same happy-path semantics, on the check-in path. Strictly safer: optional telemetry can no longer reject a check-in. Not deployed — operator is the merge gate.

https://claude.ai/code/session_01J2tdWCnvbDgPgGdvh7A65d