### PR TITLE
feat(kg-age): backfill script to rebuild AGE nodes for SQL-only discoveries

### DIFF
--- a/scripts/ops/backfill_age_nodes.py
+++ b/scripts/ops/backfill_age_nodes.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+One-time backfill: rebuild AGE graph nodes for SQL-only knowledge discoveries.
+
+``knowledge.discoveries`` (PostgreSQL) is the source of truth; the AGE graph is
+a derived index over it. Rows written while ``UNITARES_KNOWLEDGE_BACKEND`` was
+``postgres`` — or whose AGE node write silently no-opped — exist in SQL but have
+no ``Discovery`` vertex. The #949 SQL fallback makes those rows retrievable via
+``knowledge(action='get'|'search'|'list')``, but graph traversal (response
+chains, related-edge expansion, tag rollups, hybrid graph search) can only see
+rows that have an AGE node. This pass recreates the missing vertices and their
+edges (AUTHORED / RESPONDS_TO / RELATED_TO / TAGGED) straight from SQL.
+
+Idempotent: every Cypher builder uses MERGE, so re-running only fills gaps.
+
+DRY RUN BY DEFAULT. Nothing is written without ``--apply``. Run against the live
+governance DB; this script does not create or migrate schema. Requires the AGE
+backend (``UNITARES_KNOWLEDGE_BACKEND=age``); it exits early on any other backend.
+
+Usage:
+    python3 scripts/ops/backfill_age_nodes.py                 # dry run, full scan
+    python3 scripts/ops/backfill_age_nodes.py --limit 500     # dry run, recent 500
+    python3 scripts/ops/backfill_age_nodes.py --apply         # rebuild missing nodes
+    python3 scripts/ops/backfill_age_nodes.py --apply --limit 500
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+# Add project root to path
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+
+async def _run(apply: bool, limit: int | None) -> dict:
+    from src.knowledge_graph import get_knowledge_graph, selected_backend_name
+
+    backend = selected_backend_name()
+    if backend != "age":
+        raise SystemExit(
+            f"Active knowledge backend is '{backend}', not 'age'. The AGE node "
+            "backfill only applies to the AGE graph backend. Set "
+            "UNITARES_KNOWLEDGE_BACKEND=age to run it."
+        )
+
+    graph = await get_knowledge_graph()
+    if not hasattr(graph, "backfill_missing_age_nodes"):
+        raise SystemExit(
+            f"Backend {type(graph).__name__} has no backfill_missing_age_nodes()."
+        )
+
+    return await graph.backfill_missing_age_nodes(dry_run=not apply, limit=limit)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Rebuild AGE graph nodes for SQL-only knowledge discoveries.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write the missing AGE nodes. Without this, runs as a dry run.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Only scan the most recent N SQL discoveries (default: all).",
+    )
+    args = parser.parse_args()
+
+    summary = asyncio.run(_run(apply=args.apply, limit=args.limit))
+
+    mode = "APPLIED" if not summary.get("dry_run") else "DRY RUN"
+    print(f"=== AGE node backfill ({mode}) ===")
+    print(f"  scanned (SQL rows):     {summary['scanned']}")
+    print(f"  present in AGE graph:   {summary['age_present']}")
+    print(f"  missing from AGE graph: {summary['missing']}")
+    if summary.get("sample_missing"):
+        print(f"  sample missing ids:     {summary['sample_missing']}")
+    if not summary.get("dry_run"):
+        print(f"  nodes created:          {summary['created']}")
+        print(f"  failed:                 {summary['failed']}")
+    elif summary["missing"]:
+        print("  (dry run — re-run with --apply to rebuild these nodes)")
+    else:
+        print("  AGE graph is in sync with the SQL source of truth.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/db/mixins/knowledge_graph.py
+++ b/src/db/mixins/knowledge_graph.py
@@ -334,6 +334,21 @@ class KnowledgeGraphMixin:
             "total_agents": len(by_agent),
         }
 
+    async def kg_all_discovery_ids(self, limit: Optional[int] = None) -> List[str]:
+        """Return discovery ids from knowledge.discoveries, most recent first.
+
+        Used by the AGE backend's graph backfill to diff the SQL source-of-truth
+        against the AGE Discovery vertices and find rows missing a graph node.
+        """
+        query = "SELECT id FROM knowledge.discoveries ORDER BY created_at DESC"
+        params: list = []
+        if limit is not None:
+            params.append(limit)
+            query += f" LIMIT ${len(params)}"
+        async with self.acquire() as conn:
+            rows = await conn.fetch(query, *params)
+        return [r["id"] for r in rows]
+
     async def kg_update_status(
         self,
         discovery_id: str,

--- a/src/storage/knowledge_graph_age.py
+++ b/src/storage/knowledge_graph_age.py
@@ -509,6 +509,160 @@ class KnowledgeGraphAGE:
 
         logger.debug(f"Added discovery {discovery.id} to AGE graph")
 
+    async def _create_age_graph_for_discovery(self, db, discovery: DiscoveryNode) -> None:
+        """Create the AGE Discovery vertex and its edges for one discovery.
+
+        Mirrors the graph half of add_discovery() — node, agent, AUTHORED,
+        RESPONDS_TO, RELATED_TO and TAGGED — but skips the rate-limit check,
+        the SQL row persist, and embedding storage. Used by the backfill to
+        rebuild graph nodes for rows that already exist in knowledge.discoveries
+        (the source of truth). Every builder uses MERGE, so this is idempotent.
+        """
+        from src.knowledge_graph import normalize_tags
+
+        tags = normalize_tags(discovery.tags) if discovery.tags else []
+
+        eisv_e = eisv_i = eisv_s = eisv_v = regime = coherence = None
+        if discovery.type == "self_observation" and discovery.provenance:
+            prov = discovery.provenance
+            eisv_e = prov.get("E") or prov.get("eisv_e")
+            eisv_i = prov.get("I") or prov.get("eisv_i")
+            eisv_s = prov.get("S") or prov.get("eisv_s")
+            eisv_v = prov.get("V") or prov.get("eisv_v")
+            regime = prov.get("regime")
+            coherence = prov.get("coherence")
+
+        timestamp = self._parse_optional_datetime(discovery.timestamp) or datetime.now()
+        resolved_at = self._parse_optional_datetime(discovery.resolved_at)
+        metadata = self._build_discovery_metadata(discovery)
+
+        node_cypher, node_params = create_discovery_node(
+            discovery_id=discovery.id,
+            agent_id=discovery.agent_id,
+            discovery_type=discovery.type,
+            summary=discovery.summary,
+            details=discovery.details,
+            severity=discovery.severity,
+            status=discovery.status,
+            timestamp=timestamp,
+            resolved_at=resolved_at,
+            eisv_e=eisv_e,
+            eisv_i=eisv_i,
+            eisv_s=eisv_s,
+            eisv_v=eisv_v,
+            regime=regime,
+            coherence=coherence,
+            tags=tags,
+            metadata=metadata,
+        )
+
+        async with db.transaction() as conn:
+            await db.graph_query(node_cypher, node_params, conn=conn)
+
+            agent_cypher, agent_params = create_agent_node(
+                agent_id=discovery.agent_id,
+                created_at=timestamp,
+                updated_at=timestamp,
+            )
+            await db.graph_query(agent_cypher, agent_params, conn=conn)
+
+            authored_cypher, authored_params = create_authored_edge(
+                agent_id=discovery.agent_id,
+                discovery_id=discovery.id,
+                at=timestamp,
+            )
+            await db.graph_query(authored_cypher, authored_params, conn=conn)
+
+            if discovery.response_to:
+                responds_cypher, responds_params = create_responds_to_edge(
+                    from_discovery_id=discovery.id,
+                    to_discovery_id=discovery.response_to.discovery_id,
+                )
+                await db.graph_query(responds_cypher, responds_params, conn=conn)
+
+            for related_id in discovery.related_to or []:
+                related_cypher, related_params = create_related_to_edge(
+                    from_discovery_id=discovery.id,
+                    to_discovery_id=related_id,
+                )
+                await db.graph_query(related_cypher, related_params, conn=conn)
+
+            for tag in tags:
+                tagged_cypher, tagged_params = create_tagged_edge(
+                    discovery_id=discovery.id,
+                    tag_name=tag,
+                )
+                await db.graph_query(tagged_cypher, tagged_params, conn=conn)
+
+    async def backfill_missing_age_nodes(
+        self, *, dry_run: bool = False, limit: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Rebuild AGE graph nodes for discoveries that exist only in SQL.
+
+        knowledge.discoveries is the source of truth; the AGE graph is a derived
+        index over it. Rows written while UNITARES_KNOWLEDGE_BACKEND was
+        'postgres' (or whose node write silently no-opped) have no Discovery
+        vertex, so graph traversal — response chains, related-edge expansion,
+        tag rollups, hybrid graph search — can't see them. The #949 SQL fallback
+        makes those rows retrievable via query()/get()/search(), but only a
+        backfill restores graph traversal over them.
+
+        Every builder uses MERGE, so this is idempotent and safe to re-run.
+
+        Args:
+            dry_run: When True, only count what would be created; no writes.
+            limit: Cap how many SQL rows to scan (most recent first). None scans
+                the whole table.
+
+        Returns:
+            {scanned, age_present, missing, created, failed, dry_run,
+             sample_missing}.
+        """
+        db = await self._get_db()
+        if not await db.graph_available():
+            raise RuntimeError(
+                "AGE graph not available; cannot backfill. Check the PostgreSQL "
+                "AGE extension and UNITARES_KNOWLEDGE_BACKEND=age."
+            )
+
+        age_rows = await db.graph_query("MATCH (d:Discovery) RETURN collect(d.id)", {})
+        age_ids = set(age_rows[0]) if age_rows and isinstance(age_rows[0], list) else set()
+
+        sql_ids = await db.kg_all_discovery_ids(limit=limit)
+        missing = [sid for sid in sql_ids if sid not in age_ids]
+
+        summary: Dict[str, Any] = {
+            "scanned": len(sql_ids),
+            "age_present": len(age_ids),
+            "missing": len(missing),
+            "created": 0,
+            "failed": 0,
+            "dry_run": dry_run,
+            "sample_missing": missing[:10],
+        }
+        if dry_run or not missing:
+            return summary
+
+        for disc_id in missing:
+            try:
+                row = await db.kg_get_discovery(disc_id)
+                discovery = self._dict_to_discovery(row)
+                if discovery is None:
+                    logger.warning(f"backfill: SQL row vanished for {disc_id}, skipping")
+                    summary["failed"] += 1
+                    continue
+                await self._create_age_graph_for_discovery(db, discovery)
+                summary["created"] += 1
+            except Exception as exc:
+                logger.warning(f"backfill: failed to create AGE node for {disc_id}: {exc}")
+                summary["failed"] += 1
+
+        logger.info(
+            "AGE node backfill complete: created=%d failed=%d (of %d missing)",
+            summary["created"], summary["failed"], summary["missing"],
+        )
+        return summary
+
     async def get_discovery(self, discovery_id: str) -> Optional[DiscoveryNode]:
         """Get a discovery by ID."""
         db = await self._get_db()

--- a/tests/test_age_sql_fallback.py
+++ b/tests/test_age_sql_fallback.py
@@ -723,3 +723,126 @@ class TestGetStatsSQLFallback:
         assert stats["total_discoveries"] == 0
         # Falls through to the AGE response shape, which carries the AGE note.
         assert "AGE backend has no epoch property" in stats["scope"]["note"]
+
+
+# ===========================================================================
+# backfill_missing_age_nodes — rebuild graph nodes for SQL-only rows
+# ===========================================================================
+#
+# The SQL fallback above makes orphan rows retrievable; the backfill restores
+# the AGE graph nodes/edges so traversal (response chains, related expansion,
+# tag rollups) sees them too.
+
+def _backfill_graph_query(age_ids):
+    """graph_query side_effect: report `age_ids` as existing Discovery vertices.
+
+    The collect(d.id) probe returns the known AGE ids; all other Cypher calls
+    (node/edge MERGEs issued during creation) are no-op stubs returning [].
+    """
+    async def fake(cypher, params=None, conn=None):
+        if "collect(d.id)" in cypher:
+            return [list(age_ids)]
+        return []
+    return fake
+
+
+@pytest.mark.asyncio
+class TestBackfillMissingAgeNodes:
+
+    async def test_raises_when_graph_unavailable(self):
+        db = _make_db(graph_available=False)
+        kg = await _make_kg(db)
+
+        with pytest.raises(RuntimeError):
+            await kg.backfill_missing_age_nodes()
+
+    async def test_dry_run_reports_missing_without_writing(self):
+        db = _make_db(graph_available=True)
+        db.graph_query = AsyncMock(side_effect=_backfill_graph_query({"disc-age-001"}))
+        db.kg_all_discovery_ids = AsyncMock(return_value=["disc-age-001", "disc-sql-001", "disc-sql-002"])
+        db.kg_get_discovery = AsyncMock(return_value=_sql_row())
+        kg = await _make_kg(db)
+
+        summary = await kg.backfill_missing_age_nodes(dry_run=True)
+
+        assert summary["scanned"] == 3
+        assert summary["age_present"] == 1
+        assert summary["missing"] == 2
+        assert summary["created"] == 0
+        assert summary["dry_run"] is True
+        # Dry run must not load rows or create nodes.
+        db.kg_get_discovery.assert_not_awaited()
+
+    async def test_apply_creates_missing_nodes(self):
+        db = _make_db(graph_available=True)
+        db.graph_query = AsyncMock(side_effect=_backfill_graph_query({"disc-age-001"}))
+        db.kg_all_discovery_ids = AsyncMock(return_value=["disc-age-001", "disc-sql-001"])
+        db.kg_get_discovery = AsyncMock(side_effect=lambda did: _sql_row(discovery_id=did))
+        kg = await _make_kg(db)
+
+        created_for: list = []
+
+        async def fake_create(db_, discovery):
+            created_for.append(discovery.id)
+
+        kg._create_age_graph_for_discovery = fake_create  # type: ignore[assignment]
+
+        summary = await kg.backfill_missing_age_nodes(dry_run=False)
+
+        assert summary["missing"] == 1
+        assert summary["created"] == 1
+        assert summary["failed"] == 0
+        assert created_for == ["disc-sql-001"]
+        # The already-present AGE id is never reloaded or recreated.
+        db.kg_get_discovery.assert_awaited_once_with("disc-sql-001")
+
+    async def test_noop_when_graph_in_sync(self):
+        db = _make_db(graph_available=True)
+        db.graph_query = AsyncMock(side_effect=_backfill_graph_query({"disc-1", "disc-2"}))
+        db.kg_all_discovery_ids = AsyncMock(return_value=["disc-1", "disc-2"])
+        kg = await _make_kg(db)
+
+        summary = await kg.backfill_missing_age_nodes(dry_run=False)
+
+        assert summary["missing"] == 0
+        assert summary["created"] == 0
+
+    async def test_counts_failures_and_continues(self):
+        db = _make_db(graph_available=True)
+        db.graph_query = AsyncMock(side_effect=_backfill_graph_query(set()))
+        db.kg_all_discovery_ids = AsyncMock(return_value=["disc-a", "disc-b"])
+        db.kg_get_discovery = AsyncMock(side_effect=lambda did: _sql_row(discovery_id=did))
+        kg = await _make_kg(db)
+
+        async def flaky_create(db_, discovery):
+            if discovery.id == "disc-a":
+                raise RuntimeError("boom")
+
+        kg._create_age_graph_for_discovery = flaky_create  # type: ignore[assignment]
+
+        summary = await kg.backfill_missing_age_nodes(dry_run=False)
+
+        assert summary["missing"] == 2
+        assert summary["created"] == 1
+        assert summary["failed"] == 1
+
+    async def test_create_age_graph_issues_node_and_edges(self):
+        """_create_age_graph_for_discovery MERGEs the node + AUTHORED + TAGGED."""
+        db = _make_db(graph_available=True)
+        issued: list = []
+
+        async def record(cypher, params=None, conn=None):
+            issued.append(cypher)
+            return []
+
+        db.graph_query = AsyncMock(side_effect=record)
+        kg = await _make_kg(db)
+
+        discovery = kg._dict_to_discovery(_sql_row(tags=["k8s"]))
+        await kg._create_age_graph_for_discovery(db, discovery)
+
+        joined = "\n".join(issued)
+        assert "MERGE (d:Discovery" in joined
+        assert "MERGE (a:Agent" in joined
+        assert ":AUTHORED" in joined
+        assert ":TAGGED" in joined


### PR DESCRIPTION
## Why

Follow-up to #949. That PR made SQL-only orphan discoveries — rows in `knowledge.discoveries` with no AGE vertex (written while `UNITARES_KNOWLEDGE_BACKEND` was `postgres`, or whose AGE node write silently no-opped) — **retrievable** again via `query`/`get`/`search` through a SQL source-of-truth fallback.

But the fallback only restores *retrieval*. **Graph traversal** — response chains, related-edge expansion, tag rollups, hybrid graph search — still can't see a row that has no AGE `Discovery` vertex. This adds the one-time backfill that rebuilds those nodes from SQL, so the graph index fully catches up with the source of truth.

## What

- **`KnowledgeGraphAGE.backfill_missing_age_nodes(dry_run, limit)`** — diffs the SQL id set against existing AGE `Discovery` vertices and recreates the missing ones. Returns a summary (`scanned`, `age_present`, `missing`, `created`, `failed`, …).
- **`_create_age_graph_for_discovery()`** — mirrors the graph half of `add_discovery()` (the `Discovery` node + `AUTHORED` / `RESPONDS_TO` / `RELATED_TO` / `TAGGED` edges), minus the rate-limit check, SQL persist, and embedding storage. Every Cypher builder uses `MERGE`, so the backfill is **idempotent and safe to re-run**.
- **`kg_all_discovery_ids()`** mixin helper — the SQL id set, most-recent-first.
- **`scripts/ops/backfill_age_nodes.py`** — dry-run-by-default CLI driver (`--apply` to write, `--limit N` to scope to recent rows), guarded to the AGE backend (exits early on any other backend).

## Usage

```bash
python3 scripts/ops/backfill_age_nodes.py            # dry run, full scan — reports the gap
python3 scripts/ops/backfill_age_nodes.py --apply    # rebuild the missing AGE nodes
python3 scripts/ops/backfill_age_nodes.py --apply --limit 500
```

The `knowledge(action='list')` / stats response added in #949 now annotates SQL-substituted counts with a pointer to run exactly this.

## Tests

6 new regression tests in `tests/test_age_sql_fallback.py` (graph-unavailable guard, dry-run-no-write, apply-creates-missing, in-sync no-op, failure-counting/continue, and node+edge issuance). Full AGE/graph-mixin suites pass:

```
tests/test_age_sql_fallback.py + test_knowledge_graph_age.py + test_graph_mixin.py
214 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTvQgAFe4N9XvAgWFSP7Wc)_