### PR TITLE
feat(analysis): expose harness lane evidence splits

### DIFF
--- a/scripts/analysis/eisv_ablation_matrix.py
+++ b/scripts/analysis/eisv_ablation_matrix.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import os
 import random
+import re
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -75,6 +77,7 @@ class AblationMatrixRow:
     best_auc_delta_ci: tuple[float, float] | None = None
     best_brier_improvement_ci: tuple[float, float] | None = None
     best_brier_permutation_p: float | None = None
+    harness_lane: str | None = None
 
 
 def _fmt_float(value: float | None, digits: int = 3) -> str:
@@ -94,8 +97,24 @@ def _fmt_ci(value: tuple[float, float] | None, digits: int) -> str:
     return f"[{low:.{digits}f}, {high:.{digits}f}]"
 
 
+def _redact_sensitive_report_text(text: str) -> str:
+    """Redact credential-shaped substrings before report storage/stdout."""
+    redacted = re.sub(
+        r"(?i)\b([a-z][a-z0-9+.-]*://[^\s:/@]+):([^\s/@]+)@",
+        r"\1:[REDACTED]@",
+        text,
+    )
+    return re.sub(
+        r"(?i)\b(api[_-]?key|passwd|password|secret|token)\s*([:=])\s*[^\s,;|]+",
+        r"\1\2[REDACTED]",
+        redacted,
+    )
+
+
 def _baseline(scores: Sequence[ModelScore]) -> ModelScore | None:
-    return next((score for score in scores if score.name == "previous_outcome_bad"), None)
+    return next(
+        (score for score in scores if score.name == "previous_outcome_bad"), None
+    )
 
 
 def _paired_vectors(
@@ -121,7 +140,13 @@ def _paired_vectors(
         candidate_auc_score.append(candidate.y_auc_score[candidate_idx])
         baseline_prob.append(baseline.y_prob[baseline_idx])
         baseline_auc_score.append(baseline.y_auc_score[baseline_idx])
-    return y_true, candidate_prob, candidate_auc_score, baseline_prob, baseline_auc_score
+    return (
+        y_true,
+        candidate_prob,
+        candidate_auc_score,
+        baseline_prob,
+        baseline_auc_score,
+    )
 
 
 def _percentile(values: Sequence[float], fraction: float) -> float | None:
@@ -152,9 +177,11 @@ def estimate_delta_uncertainty(
     paired sign-flip test over per-row Brier improvements.
     """
 
-    y_true, candidate_prob, candidate_auc, baseline_prob, baseline_auc = _paired_vectors(
-        baseline,
-        candidate,
+    y_true, candidate_prob, candidate_auc, baseline_prob, baseline_auc = (
+        _paired_vectors(
+            baseline,
+            candidate,
+        )
     )
     n = len(y_true)
     if n == 0 or resamples <= 0:
@@ -198,10 +225,13 @@ def estimate_delta_uncertainty(
     observed = sum(per_row_improvements) / n
     extreme = 0
     for _ in range(resamples):
-        null_mean = sum(
-            value if rng.choice((True, False)) else -value
-            for value in per_row_improvements
-        ) / n
+        null_mean = (
+            sum(
+                value if rng.choice((True, False)) else -value
+                for value in per_row_improvements
+            )
+            / n
+        )
         if abs(null_mean) >= abs(observed):
             extreme += 1
     permutation_p = (extreme + 1) / (resamples + 1)
@@ -233,6 +263,16 @@ def filter_rows_for_validation(
     return [row for row in rows if harness_lane_from_detail(row.detail) not in excluded]
 
 
+def split_rows_by_harness_lane(
+    rows: Sequence[OutcomeRow],
+) -> dict[str, list[OutcomeRow]]:
+    """Group rows by explicit runtime harness lane, defaulting to substrate."""
+    grouped: dict[str, list[OutcomeRow]] = {}
+    for row in rows:
+        grouped.setdefault(harness_lane_from_detail(row.detail), []).append(row)
+    return dict(sorted(grouped.items()))
+
+
 def build_matrix_row(
     rows: Sequence[OutcomeRow],
     *,
@@ -243,6 +283,7 @@ def build_matrix_row(
     min_feature_rows: int = 30,
     uncertainty_resamples: int = 0,
     uncertainty_seed: int = 0,
+    harness_lane: str | None = None,
 ) -> AblationMatrixRow:
     """Summarize one scope/window/lead ablation slice."""
     scores = build_model_scores(
@@ -263,7 +304,9 @@ def build_matrix_row(
     )
     uncertainty = None
     if best_delta and uncertainty_resamples > 0 and baseline:
-        candidate_score = next((score for score in scores if score.name == best_delta.name), None)
+        candidate_score = next(
+            (score for score in scores if score.name == best_delta.name), None
+        )
         if candidate_score:
             uncertainty = estimate_delta_uncertainty(
                 baseline,
@@ -293,6 +336,7 @@ def build_matrix_row(
         best_brier_permutation_p=(
             uncertainty.brier_permutation_p if uncertainty else None
         ),
+        harness_lane=harness_lane,
     )
 
 
@@ -314,32 +358,87 @@ def format_matrix_report(
     if excluded:
         lines.extend(
             [
-                "Excluded harness lanes: " + ", ".join(f"`{lane}`" for lane in excluded),
+                "Excluded harness lanes: "
+                + ", ".join(f"`{lane}`" for lane in excluded),
                 "",
             ]
         )
-    lines.extend([
-        "Positive AUC delta means better ranking than `previous_outcome_bad`; positive Brier improvement means lower probability error. `Beats both?` is the conservative quick read.",
-        "",
-        "| Scope | Window days | Lead min | Trusted | Bad | Prior state | Prior risk | Baseline AUC | Baseline Brier | Best EISV/prior model | AUC delta | AUC delta 95% CI | Brier improvement | Brier improvement 95% CI | Brier perm p | Beats both? | Conclusion |",
-        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---:|---:|---:|---|---|",
-    ])
+    grouped_by_harness_lane = any(row.harness_lane is not None for row in rows)
+    if grouped_by_harness_lane:
+        lines.extend(["Harness lane mode: grouped", ""])
+    columns = [
+        *(["Lane"] if grouped_by_harness_lane else []),
+        "Scope",
+        "Window days",
+        "Lead min",
+        "Trusted",
+        "Bad",
+        "Prior state",
+        "Prior risk",
+        "Baseline AUC",
+        "Baseline Brier",
+        "Best EISV/prior model",
+        "AUC delta",
+        "AUC delta 95% CI",
+        "Brier improvement",
+        "Brier improvement 95% CI",
+        "Brier perm p",
+        "Beats both?",
+        "Conclusion",
+    ]
+    lines.extend(
+        [
+            "Positive AUC delta means better ranking than `previous_outcome_bad`; positive Brier improvement means lower probability error. `Beats both?` is the conservative quick read.",
+            "",
+            "| " + " | ".join(columns) + " |",
+            "|" + "|".join("---" for _ in columns) + "|",
+        ]
+    )
     if rows:
         for row in rows:
-            lines.append(
-                "| "
-                f"{row.scope} | {row.window_days} | {_fmt_lead(row.lead_minutes)} "
-                f"| {row.trusted} | {row.bad} | {row.prior_state} | {row.prior_risk} "
-                f"| {_fmt_float(row.baseline_auc, 3)} | {_fmt_float(row.baseline_brier, 4)} "
-                f"| {row.best_candidate or '-'} | {_fmt_float(row.best_auc_delta, 3)} "
-                f"| {_fmt_ci(row.best_auc_delta_ci, 3)} "
-                f"| {_fmt_float(row.best_brier_improvement, 4)} "
-                f"| {_fmt_ci(row.best_brier_improvement_ci, 4)} "
-                f"| {_fmt_float(row.best_brier_permutation_p, 3)} "
-                f"| {'yes' if row.beats_both else 'no'} | {row.conclusion} |"
-            )
+            cells = [
+                *([row.harness_lane or "substrate"] if grouped_by_harness_lane else []),
+                row.scope,
+                str(row.window_days),
+                _fmt_lead(row.lead_minutes),
+                str(row.trusted),
+                str(row.bad),
+                str(row.prior_state),
+                str(row.prior_risk),
+                _fmt_float(row.baseline_auc, 3),
+                _fmt_float(row.baseline_brier, 4),
+                row.best_candidate or "-",
+                _fmt_float(row.best_auc_delta, 3),
+                _fmt_ci(row.best_auc_delta_ci, 3),
+                _fmt_float(row.best_brier_improvement, 4),
+                _fmt_ci(row.best_brier_improvement_ci, 4),
+                _fmt_float(row.best_brier_permutation_p, 3),
+                "yes" if row.beats_both else "no",
+                row.conclusion,
+            ]
+            lines.append("| " + " | ".join(cells) + " |")
     else:
-        lines.append("| - | - | - | 0 | 0 | 0 | 0 | - | - | - | - | - | - | - | - | no | no rows |")
+        empty_cells = [
+            *(["-"] if grouped_by_harness_lane else []),
+            "-",
+            "-",
+            "-",
+            "0",
+            "0",
+            "0",
+            "0",
+            "-",
+            "-",
+            "-",
+            "-",
+            "-",
+            "-",
+            "-",
+            "-",
+            "no",
+            "no rows",
+        ]
+        lines.append("| " + " | ".join(empty_cells) + " |")
     lines.extend(
         [
             "",
@@ -378,35 +477,51 @@ async def build_matrix_from_db(
     train_fraction: float = 0.7,
     min_feature_rows: int = 30,
     exclude_harness_lanes: Sequence[str] = DEFAULT_EXCLUDED_HARNESS_LANES,
+    group_by_harness_lane: bool = False,
     uncertainty_resamples: int = 0,
     uncertainty_seed: int = 0,
 ) -> list[AblationMatrixRow]:
     matrix_rows: list[AblationMatrixRow] = []
+    excluded = {str(lane) for lane in exclude_harness_lanes if str(lane)}
     for scope in scopes:
         outcome_types = STRICT_OUTCOMES if scope == "strict" else TASK_OUTCOMES
         for window_days in windows:
             for lead_minutes in leads:
-                outcome_rows = filter_rows_for_validation(
-                    await fetch_rows(
-                        db_url,
-                        window_days=window_days,
-                        lead_minutes=lead_minutes,
-                        outcome_types=outcome_types,
-                    ),
-                    exclude_harness_lanes=exclude_harness_lanes,
+                fetched_rows = await fetch_rows(
+                    db_url,
+                    window_days=window_days,
+                    lead_minutes=lead_minutes,
+                    outcome_types=outcome_types,
                 )
-                matrix_rows.append(
-                    build_matrix_row(
-                        outcome_rows,
-                        scope=scope,
-                        window_days=window_days,
-                        lead_minutes=lead_minutes,
-                        train_fraction=train_fraction,
-                        min_feature_rows=min_feature_rows,
-                        uncertainty_resamples=uncertainty_resamples,
-                        uncertainty_seed=uncertainty_seed,
+                if group_by_harness_lane:
+                    lane_groups = {
+                        lane: lane_rows
+                        for lane, lane_rows in split_rows_by_harness_lane(
+                            fetched_rows
+                        ).items()
+                        if lane not in excluded
+                    }
+                else:
+                    lane_groups = {
+                        None: filter_rows_for_validation(
+                            fetched_rows,
+                            exclude_harness_lanes=exclude_harness_lanes,
+                        )
+                    }
+                for harness_lane, outcome_rows in lane_groups.items():
+                    matrix_rows.append(
+                        build_matrix_row(
+                            outcome_rows,
+                            scope=scope,
+                            window_days=window_days,
+                            lead_minutes=lead_minutes,
+                            train_fraction=train_fraction,
+                            min_feature_rows=min_feature_rows,
+                            uncertainty_resamples=uncertainty_resamples,
+                            uncertainty_seed=uncertainty_seed,
+                            harness_lane=harness_lane,
+                        )
                     )
-                )
     return matrix_rows
 
 
@@ -433,8 +548,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--exclude-harness-lanes",
         type=_parse_string_list,
-        default=DEFAULT_EXCLUDED_HARNESS_LANES,
+        default=None,
         help="Comma-separated runtime harness lanes excluded from predictive slices; empty string includes all.",
+    )
+    parser.add_argument(
+        "--group-by-harness-lane",
+        action="store_true",
+        help="Run separate substrate/BEAM/runtime-harness slices instead of mixing lanes.",
     )
     parser.add_argument("--output", help="Optional markdown output path")
     return parser.parse_args(argv)
@@ -444,6 +564,12 @@ async def main_async(args: argparse.Namespace) -> int:
     if not (0.1 <= args.train_fraction <= 0.9):
         print("error: --train-fraction must be between 0.1 and 0.9")
         return 2
+    if args.exclude_harness_lanes is None:
+        exclude_harness_lanes = (
+            () if args.group_by_harness_lane else DEFAULT_EXCLUDED_HARNESS_LANES
+        )
+    else:
+        exclude_harness_lanes = args.exclude_harness_lanes
     rows = await build_matrix_from_db(
         args.db_url,
         scopes=args.scopes,
@@ -451,18 +577,28 @@ async def main_async(args: argparse.Namespace) -> int:
         leads=args.leads,
         train_fraction=args.train_fraction,
         min_feature_rows=args.min_feature_rows,
-        exclude_harness_lanes=args.exclude_harness_lanes,
+        exclude_harness_lanes=exclude_harness_lanes,
+        group_by_harness_lane=args.group_by_harness_lane,
         uncertainty_resamples=args.uncertainty_resamples,
         uncertainty_seed=args.uncertainty_seed,
     )
-    report = format_matrix_report(rows, excluded_harness_lanes=args.exclude_harness_lanes)
+    report = _redact_sensitive_report_text(
+        format_matrix_report(rows, excluded_harness_lanes=exclude_harness_lanes)
+    )
+    payload = (report + "\n").encode("utf-8")
     if args.output:
         path = Path(args.output)
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(report + "\n", encoding="utf-8")
+        # Store only redacted aggregate report bytes, not raw DB rows or DSNs.
+        fd = os.open(os.fspath(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.write(fd, payload)
+        finally:
+            os.close(fd)
         print(f"Wrote {path}")
     else:
-        print(report)
+        # Emit only redacted aggregate report bytes, not raw DB rows or DSNs.
+        sys.stdout.buffer.write(payload)
     return 0
 
 

--- a/scripts/analysis/outcome_inventory.py
+++ b/scripts/analysis/outcome_inventory.py
@@ -300,7 +300,9 @@ def build_inventory(
         hard_exogenous_count=hard_exogenous_count,
         eprocess_eligible_count=eprocess_eligible_count,
         total_prediction_id_count=total_prediction_id_count,
-        eprocess_eligible_by_harness_lane=dict(sorted(eprocess_eligible_by_harness_lane.items())),
+        eprocess_eligible_by_harness_lane=dict(
+            sorted(eprocess_eligible_by_harness_lane.items())
+        ),
     )
 
 
@@ -314,6 +316,64 @@ def _format_rate(rate: float | None) -> str:
 def _format_lead(lead: float) -> str:
     """Format a lead-minute value for stable column names."""
     return str(int(lead)) if float(lead).is_integer() else str(lead).replace(".", "p")
+
+
+def _harness_lane_summary_rows(
+    inventory: OutcomeInventory,
+    *,
+    lead_minutes: Sequence[float],
+) -> list[list[str]]:
+    """Summarize outcome, task-scope, and prior-state coverage by harness lane."""
+    leads = tuple(float(lead) for lead in lead_minutes)
+    summaries: dict[str, dict[str, Any]] = {}
+    for bucket in inventory.buckets:
+        lane_summary = summaries.setdefault(
+            bucket.harness_lane,
+            {
+                "outcomes": 0,
+                "bad": 0,
+                "strict_outcomes": 0,
+                "strict_bad": 0,
+                "task_scope_outcomes": 0,
+                "task_scope_bad": 0,
+                "eprocess_eligible": 0,
+                "prediction_id": 0,
+                "prior_state": {lead: 0 for lead in leads},
+            },
+        )
+        lane_summary["outcomes"] += bucket.n_total
+        lane_summary["bad"] += bucket.n_bad
+        if bucket.scope == "strict":
+            lane_summary["strict_outcomes"] += bucket.n_total
+            lane_summary["strict_bad"] += bucket.n_bad
+        if bucket.scope in {"strict", "task"}:
+            lane_summary["task_scope_outcomes"] += bucket.n_total
+            lane_summary["task_scope_bad"] += bucket.n_bad
+        if bucket.eprocess_eligible:
+            lane_summary["eprocess_eligible"] += bucket.n_total
+        lane_summary["prediction_id"] += bucket.prediction_id_count
+        for lead in leads:
+            lane_summary["prior_state"][lead] += bucket.prior_state_counts.get(lead, 0)
+
+    rows: list[list[str]] = []
+    for lane, summary in sorted(summaries.items()):
+        outcomes = int(summary["outcomes"])
+        prior_state = summary["prior_state"]
+        rows.append(
+            [
+                lane,
+                str(outcomes),
+                str(summary["bad"]),
+                str(summary["strict_outcomes"]),
+                str(summary["strict_bad"]),
+                str(summary["task_scope_outcomes"]),
+                str(summary["task_scope_bad"]),
+                str(summary["eprocess_eligible"]),
+                str(summary["prediction_id"]),
+                *[f"{prior_state[lead]}/{outcomes}" for lead in leads],
+            ]
+        )
+    return rows
 
 
 def format_inventory_report(
@@ -340,11 +400,33 @@ def format_inventory_report(
         f"eprocess_eligible: {inventory.eprocess_eligible_count}",
         *[
             f"eprocess_eligible_{lane}: {count}"
-            for lane, count in sorted(inventory.eprocess_eligible_by_harness_lane.items())
+            for lane, count in sorted(
+                inventory.eprocess_eligible_by_harness_lane.items()
+            )
         ],
         f"prediction_id_present: {inventory.total_prediction_id_count}",
         "",
+        "## Harness Lane Summary",
+        "",
     ]
+
+    summary_headers = [
+        "Lane",
+        "Outcomes",
+        "Bad",
+        "Strict outcomes",
+        "Strict bad",
+        "Task-scope outcomes",
+        "Task-scope bad",
+        "E-process eligible",
+        "Prediction IDs",
+        *[f"Prior state {_format_lead(lead)}m" for lead in leads],
+    ]
+    lines.append("| " + " | ".join(summary_headers) + " |")
+    lines.append("|" + "|".join("---" for _ in summary_headers) + "|")
+    for row in _harness_lane_summary_rows(inventory, lead_minutes=leads):
+        lines.append("| " + " | ".join(row) + " |")
+    lines.append("")
 
     lead_headers = [f"prior_state_{_format_lead(lead)}m" for lead in leads]
     headers = [
@@ -406,8 +488,7 @@ def _build_fetch_query(lead_minutes: Sequence[float]) -> str:
     lead_selects = []
     for index, _lead in enumerate(lead_minutes):
         placeholder = index + 2
-        lead_selects.append(
-            f"""
+        lead_selects.append(f"""
                 EXISTS (
                     SELECT 1
                     FROM core.identities ident
@@ -418,8 +499,7 @@ def _build_fetch_query(lead_minutes: Sequence[float]) -> str:
                       AND state.recorded_at <= o.ts - (${placeholder}::double precision * INTERVAL '1 minute')
                     LIMIT 1
                 ) AS {_lead_alias(index)}
-            """
-        )
+            """)
     return f"""
         SELECT
             o.outcome_type,
@@ -433,7 +513,9 @@ def _build_fetch_query(lead_minutes: Sequence[float]) -> str:
     """
 
 
-def _row_from_record(record: Mapping[str, Any], lead_minutes: Sequence[float]) -> OutcomeInventoryRow:
+def _row_from_record(
+    record: Mapping[str, Any], lead_minutes: Sequence[float]
+) -> OutcomeInventoryRow:
     """Convert an asyncpg record to an inventory row."""
     data = dict(record)
     prior_state_by_lead = {
@@ -459,7 +541,10 @@ async def fetch_rows(
     try:
         asyncpg = importlib.import_module("asyncpg")
     except ImportError:
-        print("error: asyncpg not installed. Install with `pip install asyncpg`.", file=sys.stderr)
+        print(
+            "error: asyncpg not installed. Install with `pip install asyncpg`.",
+            file=sys.stderr,
+        )
         raise SystemExit(1) from None
 
     leads = tuple(float(lead) for lead in lead_minutes)

--- a/tests/test_eisv_ablation_matrix.py
+++ b/tests/test_eisv_ablation_matrix.py
@@ -1,21 +1,26 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import subprocess
 import sys
 
+import scripts.analysis.eisv_ablation_matrix as matrix_module
 from scripts.analysis.eisv_ablation_matrix import (
     AblationMatrixRow,
     build_matrix_row,
     estimate_delta_uncertainty,
     filter_rows_for_validation,
     format_matrix_report,
+    split_rows_by_harness_lane,
 )
 from scripts.analysis.eisv_skeptic_report import ModelScore, OutcomeRow
 
 
-def _row(idx: int, *, bad: bool, risk: float | None, agent: str = "agent-a") -> OutcomeRow:
+def _row(
+    idx: int, *, bad: bool, risk: float | None, agent: str = "agent-a"
+) -> OutcomeRow:
     ts = datetime.now(timezone.utc).replace(microsecond=0) + timedelta(minutes=idx)
     return OutcomeRow(
         ts=ts,
@@ -54,7 +59,97 @@ def test_filter_rows_for_validation_excludes_beam_harness_by_default():
     filtered = filter_rows_for_validation([substrate, beam])
 
     assert filtered == [substrate]
-    assert filter_rows_for_validation([substrate, beam], exclude_harness_lanes=()) == [substrate, beam]
+    assert filter_rows_for_validation([substrate, beam], exclude_harness_lanes=()) == [
+        substrate,
+        beam,
+    ]
+
+
+def test_split_rows_by_harness_lane_keeps_beam_visible():
+    substrate = _row(0, bad=False, risk=0.1)
+    beam = _row(1, bad=True, risk=None)
+    beam = OutcomeRow(**{**beam.__dict__, "detail": {"harness": "beam"}})
+
+    by_lane = split_rows_by_harness_lane([substrate, beam])
+
+    assert by_lane == {"beam": [beam], "substrate": [substrate]}
+
+
+def test_build_matrix_from_db_groups_lanes_and_respects_explicit_exclusions(
+    monkeypatch,
+):
+    substrate = _row(0, bad=False, risk=0.1)
+    beam = _row(1, bad=True, risk=None)
+    beam = OutcomeRow(**{**beam.__dict__, "detail": {"harness": "beam"}})
+
+    async def fake_fetch_rows(*_args, **_kwargs):
+        return [substrate, beam]
+
+    monkeypatch.setattr(matrix_module, "fetch_rows", fake_fetch_rows)
+
+    default_rows = asyncio.run(
+        matrix_module.build_matrix_from_db(
+            "postgresql://unit-test",
+            scopes=["task"],
+            windows=[90],
+            leads=[0],
+        )
+    )
+    assert [(row.harness_lane, row.trusted, row.bad) for row in default_rows] == [
+        (None, 1, 0)
+    ]
+
+    grouped_rows = asyncio.run(
+        matrix_module.build_matrix_from_db(
+            "postgresql://unit-test",
+            scopes=["task"],
+            windows=[90],
+            leads=[0],
+            group_by_harness_lane=True,
+            exclude_harness_lanes=(),
+        )
+    )
+    assert [(row.harness_lane, row.trusted, row.bad) for row in grouped_rows] == [
+        ("beam", 1, 1),
+        ("substrate", 1, 0),
+    ]
+
+    grouped_excluding_beam = asyncio.run(
+        matrix_module.build_matrix_from_db(
+            "postgresql://unit-test",
+            scopes=["task"],
+            windows=[90],
+            leads=[0],
+            group_by_harness_lane=True,
+            exclude_harness_lanes=("beam",),
+        )
+    )
+    assert [row.harness_lane for row in grouped_excluding_beam] == ["substrate"]
+
+
+def test_parse_args_distinguishes_default_from_explicit_harness_exclusion():
+    default_args = matrix_module.parse_args([])
+    explicit_args = matrix_module.parse_args(
+        ["--group-by-harness-lane", "--exclude-harness-lanes", "beam"]
+    )
+
+    assert default_args.exclude_harness_lanes is None
+    assert explicit_args.group_by_harness_lane is True
+    assert explicit_args.exclude_harness_lanes == ("beam",)
+
+
+def test_redact_sensitive_report_text_removes_credential_shapes():
+    redacted = matrix_module._redact_sensitive_report_text(
+        "db=postgresql://reporter:s3cr3t@example.test/governance "
+        "token: abc12345 password=letmein"
+    )
+
+    assert "s3cr3t" not in redacted
+    assert "abc12345" not in redacted
+    assert "letmein" not in redacted
+    assert "postgresql://reporter:[REDACTED]@example.test/governance" in redacted
+    assert "token:[REDACTED]" in redacted
+    assert "password=[REDACTED]" in redacted
 
 
 def test_build_matrix_row_summarizes_baseline_and_best_candidate():
@@ -98,7 +193,9 @@ def test_build_matrix_row_summarizes_baseline_and_best_candidate():
     assert isinstance(row.beats_both, bool)
 
 
-def _score(name: str, probs: tuple[float, ...], auc_scores: tuple[float, ...]) -> ModelScore:
+def _score(
+    name: str, probs: tuple[float, ...], auc_scores: tuple[float, ...]
+) -> ModelScore:
     y_true = (0, 0, 0, 1, 1, 1)
     keys = tuple(f"row-{idx}" for idx in range(len(y_true)))
     return ModelScore(
@@ -141,6 +238,7 @@ def test_estimate_delta_uncertainty_reports_bootstrap_ci_and_permutation_p():
     assert uncertainty.brier_improvement_ci[0] > 0
     assert 0.0 <= uncertainty.brier_permutation_p <= 1.0
 
+
 def test_format_matrix_report_contains_skeptical_ablation_table():
     rows = [
         AblationMatrixRow(
@@ -168,7 +266,10 @@ def test_format_matrix_report_contains_skeptical_ablation_table():
 
     assert report.startswith("# EISV Ablation Matrix")
     assert "Excluded harness lanes: `beam`" in report
-    assert "| Scope | Window days | Lead min | Trusted | Bad | Prior state | Prior risk |" in report
+    assert (
+        "| Scope | Window days | Lead min | Trusted | Bad | Prior state | Prior risk |"
+        in report
+    )
     assert "AUC delta 95% CI" in report
     assert "Brier improvement 95% CI" in report
     assert "Brier perm p" in report
@@ -178,6 +279,52 @@ def test_format_matrix_report_contains_skeptical_ablation_table():
     assert "0.040" in report
     assert "prior_risk_binned" in report
     assert "KEEP TESTING" in report
+
+
+def test_format_matrix_report_labels_grouped_harness_lane_rows():
+    rows = [
+        AblationMatrixRow(
+            scope="task",
+            window_days=90,
+            lead_minutes=0,
+            trusted=2,
+            bad=1,
+            prior_state=0,
+            prior_risk=0,
+            baseline_auc=None,
+            baseline_brier=0.25,
+            best_candidate=None,
+            best_auc_delta=None,
+            best_brier_improvement=None,
+            beats_both=False,
+            conclusion="BEAM lane needs runtime features",
+            harness_lane="beam",
+        ),
+        AblationMatrixRow(
+            scope="task",
+            window_days=90,
+            lead_minutes=0,
+            trusted=2,
+            bad=0,
+            prior_state=2,
+            prior_risk=2,
+            baseline_auc=None,
+            baseline_brier=0.0,
+            best_candidate=None,
+            best_auc_delta=None,
+            best_brier_improvement=None,
+            beats_both=False,
+            conclusion="substrate lane separate",
+            harness_lane="substrate",
+        ),
+    ]
+
+    report = format_matrix_report(rows)
+
+    assert "Harness lane mode: grouped" in report
+    assert "| Lane | Scope | Window days | Lead min |" in report
+    assert "| beam | task | 90 | 0 | 2 | 1 | 0 | 0 |" in report
+    assert "| substrate | task | 90 | 0 | 2 | 0 | 2 | 2 |" in report
 
 
 def test_cli_help_runs_when_invoked_as_a_file():
@@ -192,3 +339,4 @@ def test_cli_help_runs_when_invoked_as_a_file():
 
     assert result.returncode == 0, result.stderr
     assert "Run a compact EISV ablation matrix" in result.stdout
+    assert "--group-by-harness-lane" in result.stdout

--- a/tests/test_outcome_inventory.py
+++ b/tests/test_outcome_inventory.py
@@ -65,33 +65,39 @@ def test_build_inventory_groups_by_scope_type_source_and_evidence_flags():
         for bucket in inventory.buckets
     }
 
-    strict_tests = by_key[(
-        "strict",
-        "test_passed/test_failed",
-        "server_observation",
-        True,
-        True,
-        "registry",
-    )]
+    strict_tests = by_key[
+        (
+            "strict",
+            "test_passed/test_failed",
+            "server_observation",
+            True,
+            True,
+            "registry",
+        )
+    ]
     assert strict_tests.n_total == 2
     assert strict_tests.n_bad == 1
     assert strict_tests.bad_rate == 0.5
     assert strict_tests.prior_state_counts == {0.0: 2, 5.0: 1, 30.0: 0}
     assert strict_tests.prediction_id_count == 2
 
-    task_failed = by_key[(
-        "task",
-        "task_failed",
-        "agent_reported_tool_result",
-        False,
-        False,
-        "prev_confidence_fallback",
-    )]
+    task_failed = by_key[
+        (
+            "task",
+            "task_failed",
+            "agent_reported_tool_result",
+            False,
+            False,
+            "prev_confidence_fallback",
+        )
+    ]
     assert task_failed.n_total == 1
     assert task_failed.n_bad == 1
     assert task_failed.prior_state_counts == {0.0: 1, 5.0: 1, 30.0: 1}
 
-    other = by_key[("other", "drawing_completed", "external_signal", False, False, "none")]
+    other = by_key[
+        ("other", "drawing_completed", "external_signal", False, False, "none")
+    ]
     assert other.n_total == 1
     assert inventory.total_outcomes == 4
     assert inventory.total_bad == 2
@@ -104,7 +110,11 @@ def test_build_inventory_splits_beam_harness_from_substrate_lane():
             outcome_type="task_completed",
             is_bad=False,
             verification_source="external_signal",
-            detail={"hard_exogenous": True, "eprocess_eligible": True, "harness": "beam"},
+            detail={
+                "hard_exogenous": True,
+                "eprocess_eligible": True,
+                "harness": "beam",
+            },
             prior_state_by_lead={0.0: False},
         ),
         OutcomeInventoryRow(
@@ -125,6 +135,62 @@ def test_build_inventory_splits_beam_harness_from_substrate_lane():
     assert by_lane["substrate"].n_total == 1
     assert by_lane["substrate"].prior_state_counts == {0.0: 1}
     assert inventory.eprocess_eligible_by_harness_lane == {"beam": 1, "substrate": 1}
+
+
+def test_format_inventory_report_includes_harness_lane_summary():
+    rows = [
+        OutcomeInventoryRow(
+            outcome_type="task_completed",
+            is_bad=False,
+            verification_source="external_signal",
+            detail={
+                "hard_exogenous": True,
+                "eprocess_eligible": True,
+                "harness": "beam",
+            },
+            prior_state_by_lead={0.0: False},
+        ),
+        OutcomeInventoryRow(
+            outcome_type="task_failed",
+            is_bad=True,
+            verification_source="external_signal",
+            detail={
+                "hard_exogenous": True,
+                "eprocess_eligible": True,
+                "harness": "beam",
+            },
+            prior_state_by_lead={0.0: False},
+        ),
+        OutcomeInventoryRow(
+            outcome_type="test_passed",
+            is_bad=False,
+            verification_source="server_observation",
+            detail={
+                "hard_exogenous": True,
+                "eprocess_eligible": True,
+                "prediction_id": "pred-1",
+            },
+            prior_state_by_lead={0.0: True},
+        ),
+        OutcomeInventoryRow(
+            outcome_type="task_failed",
+            is_bad=True,
+            verification_source="agent_reported_tool_result",
+            detail={"hard_exogenous": False, "eprocess_eligible": False},
+            prior_state_by_lead={0.0: True},
+        ),
+    ]
+
+    inventory = build_inventory(rows, lead_minutes=(0.0,))
+    report = format_inventory_report(inventory, window_days=90, lead_minutes=(0.0,))
+
+    assert "## Harness Lane Summary" in report
+    assert (
+        "| Lane | Outcomes | Bad | Strict outcomes | Strict bad | Task-scope outcomes | Task-scope bad | E-process eligible | Prediction IDs | Prior state 0m |"
+        in report
+    )
+    assert "| beam | 2 | 1 | 0 | 0 | 2 | 1 | 2 | 0 | 0/2 |" in report
+    assert "| substrate | 2 | 1 | 1 | 0 | 2 | 1 | 1 | 1 | 2/2 |" in report
 
 
 def test_format_inventory_report_exposes_zero_bad_strict_and_prior_coverage():
@@ -163,6 +229,8 @@ def test_controlled_validation_fixture_detection_covers_legacy_and_new_markers()
     assert is_controlled_validation_fixture({"test_name": "overconfidence_probe"})
     assert is_controlled_validation_fixture({"synthetic_calibration_fixture": True})
     assert is_controlled_validation_fixture({"do_not_use_for_live_validation": True})
-    assert is_controlled_validation_fixture({"prediction_binding": "synthetic_negative_control"})
+    assert is_controlled_validation_fixture(
+        {"prediction_binding": "synthetic_negative_control"}
+    )
     assert is_controlled_validation_fixture({"calibration_excluded": True})
     assert not is_controlled_validation_fixture({"test_name": "real_pytest_suite"})


### PR DESCRIPTION
## Summary
- Add an outcome-inventory Harness Lane Summary so BEAM/runtime-harness and substrate counts are visible side-by-side.
- Add grouped harness-lane ablation output via `--group-by-harness-lane` while preserving conservative substrate-only default behavior.
- Add regression tests for lane splitting, grouped reporting, explicit harness exclusions, report redaction, and inventory summary output.

## Validation
- `PATH=/usr/local/bin:$PATH UNITARES_PYTHON=/usr/local/bin/python3 /usr/local/bin/python3 -m pytest tests/test_outcome_inventory.py tests/test_eisv_ablation_matrix.py tests/test_dogfood_ablation_guard.py -q -o 'addopts='` → `21 passed in 0.56s`
- `ruff format --check scripts/analysis/outcome_inventory.py scripts/analysis/eisv_ablation_matrix.py tests/test_outcome_inventory.py tests/test_eisv_ablation_matrix.py` → `4 files already formatted`
- `ruff check scripts/analysis/outcome_inventory.py scripts/analysis/eisv_ablation_matrix.py tests/test_outcome_inventory.py tests/test_eisv_ablation_matrix.py` → `All checks passed!`
- `/usr/local/bin/python3 -m py_compile scripts/analysis/outcome_inventory.py scripts/analysis/eisv_ablation_matrix.py` → passed
- `scripts/diagnostics/dogfood_ablation_guard.py --repo /Users/cirwel/projects/unitares-wt/beam-lane-report-clean --timeout-seconds 180` → `exit_code=0`
- Pre-push hook on the pushed branch → `138 passed, 9810 deselected, 1 warning`
- Live grouped smoke shows `beam` has 1533 task outcomes / 493 bad / 0 prior-state coverage, while `substrate` has 7434 task outcomes / 84 bad / 4303 prior-state rows.

## Notes
- Supersedes the initial draft PR #955, which was accidentally based on older KG-search commits from a dirty base. This branch is clean against `origin/master` and contains only the four analysis/test files above.
- The ablation report path redacts credential-shaped substrings before stdout/file output; the report is still aggregate-only, not raw DB rows.
