### PR TITLE
fix(ops): deploy-mcp.sh migration preflight aborts on macOS bash 3.2

### DIFF
--- a/scripts/ops/deploy-mcp.sh
+++ b/scripts/ops/deploy-mcp.sh
@@ -125,13 +125,16 @@ mkdir -p "$DEPLOY/data/logs"
 MIGRATE="$DEPLOY/scripts/dev/apply_migrations.py"
 MIGRATE_DBURL=()
 [[ -n "${UNITARES_DEPLOY_DB_URL:-}" ]] && MIGRATE_DBURL=(--db-url "$UNITARES_DEPLOY_DB_URL")
+# Expand with the ${arr[@]+"${arr[@]}"} guard everywhere below: on macOS bash 3.2
+# (the default /bin/bash) "${empty_array[@]}" trips `set -u` ("unbound variable")
+# and aborts the deploy when no UNITARES_DEPLOY_DB_URL is set (the common case).
 if [[ -f "$MIGRATE" ]]; then
   echo "[deploy-mcp] migration preflight: is the live DB in sync with the deploy-worktree manifest?"
-  if ! python3 "$MIGRATE" --check "${MIGRATE_DBURL[@]}"; then
+  if ! python3 "$MIGRATE" --check "${MIGRATE_DBURL[@]+"${MIGRATE_DBURL[@]}"}"; then
     if [[ "$APPLY_MIGRATIONS" == 1 ]]; then
       echo "[deploy-mcp] applying pending migrations (operator opt-in) BEFORE restart"
-      if ! python3 "$MIGRATE" --apply "${MIGRATE_DBURL[@]}" \
-         || ! python3 "$MIGRATE" --check "${MIGRATE_DBURL[@]}"; then
+      if ! python3 "$MIGRATE" --apply "${MIGRATE_DBURL[@]+"${MIGRATE_DBURL[@]}"}" \
+         || ! python3 "$MIGRATE" --check "${MIGRATE_DBURL[@]+"${MIGRATE_DBURL[@]}"}"; then
         echo "[deploy-mcp] FAILED — migrations did not reach sync; rolling worktree back to ${PREV:0:8} and NOT restarting." >&2
         git -C "$DEPLOY" reset --hard "$PREV"
         exit 1


### PR DESCRIPTION
#951's migration preflight does `MIGRATE_DBURL=()` then expands `"${MIGRATE_DBURL[@]}"`. On macOS's default `/bin/bash` (3.2.57), expanding an **empty array under `set -u`** throws 'unbound variable' and aborts the deploy whenever `UNITARES_DEPLOY_DB_URL` is unset — i.e. every normal local deploy. (Caught it live: deploy-mcp.sh failed at the preflight with `MIGRATE_DBURL[@]: unbound variable`.)

Fix: guard the three expansions with `${arr[@]+"${arr[@]}"}` (bash-3.2-safe, expands to nothing when empty). Reproduced on 3.2.57 and verified the guard runs clean; `bash -n` passes.

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm