### PR TITLE
Dashboard: route section switches on hashchange (fixes in-page links)

### DIFF
--- a/dashboard/redesign/app.html
+++ b/dashboard/redesign/app.html
@@ -222,6 +222,15 @@ if (window.GovSocket) window.GovSocket.make(onWsEvent, onWsStatus);
 // boot
 window.Landing.render();
 updateLivePill();
+// Drive section switches from the hash too, so in-page links (e.g. the Overview
+// Automations card's href="#automations") and back/forward navigate — not just
+// nav clicks. Reuses the nav-click path by clicking the matching link.
+window.addEventListener("hashchange", () => {
+  const id = (location.hash || "").replace("#", "");
+  const link = id && nav.querySelector(`a[data-section="${id}"]`);
+  if (link && id !== activeSection) link.click();
+});
+
 (function openFromHash() {
   const id = (location.hash || "").replace("#", "");
   const link = id && nav.querySelector(`a[data-section="${id}"]`);


### PR DESCRIPTION
Section switching was bound only to nav clicks, so in-page links that change the hash — notably the new Overview **Automations** card (`href=#automations`) — and browser back/forward didn't switch sections. Add a `hashchange` listener that reuses the nav-click path. Caught while verifying the automations card: it changed the URL but the section stayed hidden. Frontend-only.

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm