### PR TITLE
Dashboard: wide tables scroll horizontally on phones

### DIFF
--- a/dashboard/redesign/kit.css
+++ b/dashboard/redesign/kit.css
@@ -227,3 +227,12 @@ body {
   .grid { grid-template-columns: repeat(2, 1fr); }
   .topbar { flex-wrap: wrap; }
 }
+
+/* Phone: wide tables (agents, automations) can't fit ~390px without clipping
+   columns. Let the table scroll horizontally inside its own block instead —
+   pure CSS, no per-section wrapper. Cells keep wrapping (so the name column
+   stays compact and the key columns — name/source/status — show by default;
+   swipe right for cadence/last/next/where). Verified at 390px. */
+@media (max-width: 640px) {
+  .tbl { display: block; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+}


### PR DESCRIPTION
At ~390px the agents/automations tables ran off the right edge (columns clipped, no scroll). Centralized fix in the `.tbl` primitive: below 640px the table becomes its own horizontal-scroll block — name/source/status show by default, swipe right for the rest. Pure CSS, propagates to every `.tbl`. Verified live at 390px. Everything else (nav, resident chips, stat cards) already reflowed via the design system.

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm