### PR TITLE
Dashboard automation registry view

### DIFF
--- a/dashboard/redesign/app.html
+++ b/dashboard/redesign/app.html
@@ -39,6 +39,7 @@
     <a href="#activity" data-section="activity">Activity</a>
     <a href="#eisv" data-section="eisv">EISV</a>
     <a href="#residents" data-section="residents">Residents</a>
+    <a href="#automations" data-section="automations">Automations</a>
   </nav>
 
   <main id="main">
@@ -102,6 +103,11 @@
       <h2 class="section-title">Residents</h2>
       <div id="res-mount"><div class="loading-skeleton"><div class="skeleton" style="width:35%"></div><div class="skeleton" style="width:88%"></div><div class="skeleton" style="width:72%"></div><div class="skeleton" style="width:80%"></div></div></div>
     </section>
+
+    <section class="section" data-pane="automations" hidden>
+      <h2 class="section-title">Automations</h2>
+      <div id="auto-mount"><div class="loading-skeleton"><div class="skeleton" style="width:35%"></div><div class="skeleton" style="width:88%"></div><div class="skeleton" style="width:72%"></div><div class="skeleton" style="width:80%"></div></div></div>
+    </section>
   </main>
 
   <p class="footnote" id="foot"></p>
@@ -117,6 +123,7 @@
 <script src="./sections/activity.js"></script>
 <script src="./sections/eisv.js"></script>
 <script src="./sections/residents.js"></script>
+<script src="./sections/automations.js"></script>
 <script>
 // theme toggle
 const themeBtn = document.getElementById("themeBtn");
@@ -156,6 +163,7 @@ function lazyLoad(id) {
   if (id === "activity" && window.Activity) { loaded[id] = true; window.Activity.load(); }
   if (id === "eisv" && window.EISV) { loaded[id] = true; window.EISV.load(); }
   if (id === "residents" && window.Residents) { loaded[id] = true; window.Residents.load(); }
+  if (id === "automations" && window.Automations) { loaded[id] = true; window.Automations.load(); }
 }
 
 // ── auto-refresh: keep the monitor views live ──────────────────────────────

--- a/dashboard/redesign/app.html
+++ b/dashboard/redesign/app.html
@@ -142,16 +142,26 @@ themeBtn.onclick = () => {
 
 // section switch
 const nav = document.getElementById("nav");
-nav.addEventListener("click", (e) => {
-  const a = e.target.closest("a[data-section]");
-  if (!a) return;
-  e.preventDefault();
-  const id = a.dataset.section;
-  nav.querySelectorAll("a").forEach((x) => x.classList.toggle("active", x === a));
+function activateSection(id, updateHash = false) {
+  const link = nav.querySelector(`a[data-section="${id}"]`);
+  if (!link) return false;
+  nav.querySelectorAll("a").forEach((x) => x.classList.toggle("active", x === link));
   document.querySelectorAll("[data-pane]").forEach((p) => { p.hidden = p.dataset.pane !== id; });
   activeSection = id;
   lazyLoad(id);
   updateLivePill();
+  if (updateHash && location.hash !== "#" + id) history.pushState(null, "", "#" + id);
+  return true;
+}
+nav.addEventListener("click", (e) => {
+  const a = e.target.closest("a[data-section]");
+  if (!a) return;
+  e.preventDefault();
+  activateSection(a.dataset.section, true);
+});
+window.addEventListener("hashchange", () => {
+  const id = (location.hash || "").replace("#", "");
+  if (id) activateSection(id, false);
 });
 
 const loaded = {};
@@ -178,6 +188,7 @@ const RELOAD = {
   activity: () => window.Activity && window.Activity.load(),
   residents: () => window.Residents && window.Residents.load(),
   eisv: () => window.EISV && window.EISV.load(),
+  automations: () => window.Automations && window.Automations.load(),
 };
 const livePill = document.getElementById("livePill");
 const liveText = document.getElementById("liveText");
@@ -224,8 +235,7 @@ window.Landing.render();
 updateLivePill();
 (function openFromHash() {
   const id = (location.hash || "").replace("#", "");
-  const link = id && nav.querySelector(`a[data-section="${id}"]`);
-  if (link) link.click();
+  if (id) activateSection(id, false);
 })();
 </script>
 </body>

--- a/dashboard/redesign/data.js
+++ b/dashboard/redesign/data.js
@@ -247,6 +247,14 @@
       }, () => S().eisv);
     },
 
+    async automations() {
+      // Automation census snapshot (launchd/hermes/codex/claude/github-actions).
+      return withFallback(
+        async () => authFetch("/api/automations"),
+        () => ({ schema: "unitares.automation_census.v1", summary: { total: 0, by_source: {}, by_kind: {}, needs_attention: [], warnings: [] }, automations: [], stale: true })
+      );
+    },
+
     async agentHistory(id, opts) {
       // EISV check-in trajectory for one agent (no snapshot fallback — empty if offline).
       // opts: { limit, mode: "recent"|"all" }. Returns { points, total, mode }.

--- a/dashboard/redesign/sections/automations.js
+++ b/dashboard/redesign/sections/automations.js
@@ -1,0 +1,130 @@
+/*
+ * Automations section — the automation registry / census map.
+ * Reads DATA.automations() (the `unitares-automations` census snapshot).
+ * Overview answers "do I need to care right now?"; this page answers
+ * "what exists, who runs it, when, where, and what did it last do?".
+ * Composes kit primitives; no fetch logic here, no styles here.
+ */
+(function () {
+  "use strict";
+  const $ = (id) => document.getElementById(id);
+  const esc = (s) => String(s == null ? "" : s).replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+  // Local schedulers the operator runs directly; github-actions (the bulk) is
+  // folded away by default so the map opens on what's actually theirs to mind.
+  const LOCAL = ["launchd", "hermes", "codex", "claude"];
+
+  let MODEL = { items: [], summary: {}, stale: false, ageS: null, warnings: [], attn: new Set(), source: "snapshot" };
+  let scope = "local"; // "local" (+attention) | "all"
+  let sourceF = "all", kindF = "all", q = "";
+
+  function fmtAge(s) {
+    if (s == null) return "age unknown";
+    return s < 90 ? s + "s old" : s < 5400 ? Math.round(s / 60) + "m old"
+      : s < 172800 ? (s / 3600).toFixed(1) + "h old" : (s / 86400).toFixed(1) + "d old";
+  }
+  function relTime(iso) {
+    if (!iso) return "—";
+    const ms = Date.now() - Date.parse(iso);
+    if (isNaN(ms)) return esc(iso);
+    const h = ms / 3.6e6;
+    return h < 1 ? Math.round(ms / 6e4) + "m ago" : h < 48 ? Math.round(h) + "h ago" : Math.round(h / 24) + "d ago";
+  }
+  function statusClass(s) {
+    s = (s || "").toLowerCase();
+    if (["active", "completed", "ok", "success", "healthy", "passed"].includes(s)) return "ok";
+    if (["failed", "error", "failure"].includes(s)) return "danger";
+    return "warn"; // pending / paused / stale / unknown
+  }
+  function statusTag(s) {
+    const k = statusClass(s);
+    const color = k === "ok" ? "var(--ok)" : k === "danger" ? "var(--danger)" : "var(--warn)";
+    return `<span class="tag" style="color:${color};border-color:color-mix(in srgb, ${color} 35%, var(--line-2))">${esc(s || "—")}</span>`;
+  }
+  function pathCell(it) {
+    const where = it.workdir || it.repo || "", cfg = it.config_path || "";
+    const tilde = (p) => p ? p.replace(/^\/Users\/[^/]+/, "~") : "";
+    return `<div style="font-family:var(--font-mono);font-size:var(--text-xs);color:var(--muted);max-width:230px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">`
+      + (where ? `<div title="${esc(where)}">${esc(tilde(where))}</div>` : "")
+      + (cfg ? `<div title="${esc(cfg)}" style="color:var(--faint)">${esc(tilde(cfg))}</div>` : "")
+      + (!where && !cfg ? "—" : "") + `</div>`;
+  }
+
+  function visible() {
+    return MODEL.items.filter((it) => {
+      if (sourceF !== "all") { if (it.source !== sourceF) return false; }
+      else if (scope === "local" && !(LOCAL.includes(it.source) || MODEL.attn.has(it.id))) return false;
+      if (kindF !== "all" && it.kind !== kindF) return false;
+      if (q) {
+        const hay = (it.name + " " + it.source + " " + it.kind + " " + (it.runner || "") + " "
+          + (it.workdir || "") + " " + (it.repo || "") + " " + (it.config_path || "")).toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+  }
+
+  function warnStrip() {
+    const bits = [];
+    const att = MODEL.summary.needs_attention || [];
+    if (att.length) bits.push({ cls: "attn-band", html: `<span class="glyph">●</span><span><b>${att.length}</b> automation${att.length > 1 ? "s" : ""} flagged for attention.</span>` });
+    if (MODEL.stale) bits.push({ cls: "attn-band", html: `<span class="glyph">⚠</span><span>census snapshot is <b>${fmtAge(MODEL.ageS)}</b> — run <code>unitares-automations census --write</code> to refresh.</span>` });
+    (MODEL.warnings || []).forEach((w) => bits.push({ cls: "attn-band calm", html: `<span class="glyph">·</span><span>${esc(w)}</span>` }));
+    return bits.map((b) => `<div class="${b.cls}" style="margin-bottom:var(--space-2)">${b.html}</div>`).join("");
+  }
+
+  function render() {
+    const sum = MODEL.summary || {};
+    const rows = visible();
+    const sel = (id, cur, opts) => `<select id="${id}" class="theme-toggle">${opts.map((o) => `<option value="${o}" ${o === cur ? "selected" : ""}>${o}</option>`).join("")}</select>`;
+    $("auto-mount").innerHTML =
+      warnStrip()
+      + `<div style="display:flex;align-items:center;gap:var(--space-4);flex-wrap:wrap;margin-bottom:var(--space-3);font-size:var(--text-xs);color:var(--muted)">
+           <span><b style="color:var(--ink)">${sum.total != null ? sum.total : MODEL.items.length}</b> automations</span>
+           <span>snapshot ${fmtAge(MODEL.ageS)}</span>
+           <span class="src-badge ${MODEL.source}">${MODEL.source}</span>
+         </div>`
+      + `<div style="display:flex;gap:var(--space-3);flex-wrap:wrap;align-items:center;margin-bottom:var(--space-4)">
+           <input id="auto-q" placeholder="search name · path · runner" value="${q.replace(/"/g, "&quot;")}"
+             style="flex:1;min-width:180px;padding:var(--space-2) var(--space-3);font-family:var(--font-sans);font-size:var(--text-sm);background:var(--surface);color:var(--ink);border:var(--hairline) solid var(--line-2);border-radius:var(--radius-sm)" />
+           ${sel("auto-source", sourceF, ["all"].concat(Object.keys(sum.by_source || {})))}
+           ${sel("auto-kind", kindF, ["all"].concat(Object.keys(sum.by_kind || {})))}
+           <label style="font-size:var(--text-xs);color:var(--muted);display:flex;gap:6px;align-items:center"><input type="checkbox" id="auto-all" ${scope === "all" ? "checked" : ""}/> show all sources</label>
+         </div>`
+      + (rows.length ? `<table class="tbl"><thead><tr>
+            <th>Automation</th><th>Source</th><th>Status</th><th>Cadence</th><th>Last run</th><th>Next run</th><th>Where</th></tr></thead><tbody>`
+        + rows.map((it) => `<tr>
+              <td><div style="font-weight:500;color:var(--ink)">${esc(it.name)}</div>
+                  <div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap;margin-top:2px"><span class="tag">${esc(it.kind)}</span>${MODEL.attn.has(it.id) ? `<span class="tag warn">attention</span>` : ""}${(it.notes || []).length ? `<span style="font-size:var(--text-xs);color:var(--faint)">${esc(it.notes.join(" · "))}</span>` : ""}</div></td>
+              <td><span class="tag">${esc(it.source)}</span><div style="font-size:var(--text-xs);color:var(--muted);margin-top:2px">${esc(it.runner || "")}</div></td>
+              <td>${statusTag(it.status)}</td>
+              <td style="font-size:var(--text-sm);color:var(--ink-2)">${esc(it.cadence || "—")}</td>
+              <td style="font-size:var(--text-sm);color:var(--muted)">${relTime(it.last_run)}${it.last_status ? " " + statusTag(it.last_status) : ""}</td>
+              <td style="font-size:var(--text-sm);color:var(--muted)">${it.next_run ? relTime(it.next_run) : "—"}</td>
+              <td>${pathCell(it)}</td></tr>`).join("")
+        + `</tbody></table>`
+        : `<p class="empty">No automations match — ${scope === "local" && sourceF === "all" ? "try “show all sources”." : "adjust the filters."}</p>`)
+      + `<div style="margin-top:var(--space-3);font-size:var(--text-xs);color:var(--faint)">showing ${rows.length} of ${MODEL.items.length}${scope === "local" && sourceF === "all" ? " · local + attention (toggle “show all sources” for github-actions)" : ""}</div>`;
+    wire();
+  }
+
+  function wire() {
+    const s = $("auto-q"); if (s) { s.oninput = () => { q = s.value.trim().toLowerCase(); render(); const e = $("auto-q"); if (e) { e.focus(); e.setSelectionRange(e.value.length, e.value.length); } }; }
+    const src = $("auto-source"); if (src) src.onchange = () => { sourceF = src.value; render(); };
+    const k = $("auto-kind"); if (k) k.onchange = () => { kindF = k.value; render(); };
+    const all = $("auto-all"); if (all) all.onchange = () => { scope = all.checked ? "all" : "local"; render(); };
+  }
+
+  async function load() {
+    const r = await DATA.automations();
+    const d = r.data || {};
+    MODEL = {
+      items: d.automations || [], summary: d.summary || {}, stale: !!d.stale,
+      ageS: d.snapshot_age_seconds,
+      warnings: (d.summary && d.summary.warnings) || d.warnings || [],
+      attn: new Set((d.summary && d.summary.needs_attention) || []),
+      source: r.source,
+    };
+    render();
+  }
+  window.Automations = { load };
+})();

--- a/dashboard/redesign/sections/automations.js
+++ b/dashboard/redesign/sections/automations.js
@@ -48,6 +48,29 @@
       + (cfg ? `<div title="${esc(cfg)}" style="color:var(--faint)">${esc(tilde(cfg))}</div>` : "")
       + (!where && !cfg ? "—" : "") + `</div>`;
   }
+  function listCell(values) {
+    const list = (values || []).filter(Boolean);
+    if (!list.length) return "—";
+    const shown = list.slice(0, 3).map((v) => `<span class="tag" title="${esc(v)}">${esc(v)}</span>`).join("");
+    const more = list.length > 3 ? `<span style="font-size:var(--text-xs);color:var(--faint)">+${list.length - 3}</span>` : "";
+    return `<div style="display:flex;gap:4px;flex-wrap:wrap;max-width:260px">${shown}${more}</div>`;
+  }
+  function ownerCell(it) {
+    if (!it.owner && !it.escalates_to && !it.description) return "—";
+    return `<div style="font-size:var(--text-sm);color:var(--ink-2)">${esc(it.owner || "—")}</div>`
+      + (it.escalates_to ? `<div style="font-size:var(--text-xs);color:var(--muted)">escalate: ${esc(it.escalates_to)}</div>` : "")
+      + (it.description ? `<div style="font-size:var(--text-xs);color:var(--faint);max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${esc(it.description)}">${esc(it.description)}</div>` : "");
+  }
+  function contractCell(it) {
+    return `<div style="display:grid;gap:4px">`
+      + `<div><span style="font-size:var(--text-xs);color:var(--faint)">outputs</span> ${listCell(it.expected_outputs)}</div>`
+      + `<div><span style="font-size:var(--text-xs);color:var(--faint)">surfaces</span> ${listCell(it.surface_claims)}</div>`
+      + `</div>`;
+  }
+  function priority(it) {
+    const p = Number(it.dashboard_priority);
+    return Number.isFinite(p) ? p : 999;
+  }
 
   function visible() {
     return MODEL.items.filter((it) => {
@@ -56,10 +79,18 @@
       if (kindF !== "all" && it.kind !== kindF) return false;
       if (q) {
         const hay = (it.name + " " + it.source + " " + it.kind + " " + (it.runner || "") + " "
-          + (it.workdir || "") + " " + (it.repo || "") + " " + (it.config_path || "")).toLowerCase();
+          + (it.owner || "") + " " + (it.escalates_to || "") + " " + (it.description || "") + " "
+          + (it.workdir || "") + " " + (it.repo || "") + " " + (it.config_path || "") + " "
+          + (it.expected_outputs || []).join(" ") + " " + (it.surface_claims || []).join(" ")).toLowerCase();
         if (!hay.includes(q)) return false;
       }
       return true;
+    }).sort((a, b) => {
+      const aa = MODEL.attn.has(a.id) ? 0 : 1, bb = MODEL.attn.has(b.id) ? 0 : 1;
+      if (aa !== bb) return aa - bb;
+      const pa = priority(a), pb = priority(b);
+      if (pa !== pb) return pa - pb;
+      return (a.source + a.name + a.id).localeCompare(b.source + b.name + b.id);
     });
   }
 
@@ -91,15 +122,16 @@
            <label style="font-size:var(--text-xs);color:var(--muted);display:flex;gap:6px;align-items:center"><input type="checkbox" id="auto-all" ${scope === "all" ? "checked" : ""}/> show all sources</label>
          </div>`
       + (rows.length ? `<table class="tbl"><thead><tr>
-            <th>Automation</th><th>Source</th><th>Status</th><th>Cadence</th><th>Last run</th><th>Next run</th><th>Where</th></tr></thead><tbody>`
+            <th>Automation</th><th>Owner</th><th>Source</th><th>Status</th><th>Cadence</th><th>Last run</th><th>Contract</th><th>Where</th></tr></thead><tbody>`
         + rows.map((it) => `<tr>
               <td><div style="font-weight:500;color:var(--ink)">${esc(it.name)}</div>
                   <div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap;margin-top:2px"><span class="tag">${esc(it.kind)}</span>${MODEL.attn.has(it.id) ? `<span class="tag warn">attention</span>` : ""}${(it.notes || []).length ? `<span style="font-size:var(--text-xs);color:var(--faint)">${esc(it.notes.join(" · "))}</span>` : ""}</div></td>
+              <td>${ownerCell(it)}</td>
               <td><span class="tag">${esc(it.source)}</span><div style="font-size:var(--text-xs);color:var(--muted);margin-top:2px">${esc(it.runner || "")}</div></td>
               <td>${statusTag(it.status)}</td>
-              <td style="font-size:var(--text-sm);color:var(--ink-2)">${esc(it.cadence || "—")}</td>
+              <td style="font-size:var(--text-sm);color:var(--ink-2)">${esc(it.cadence || "—")}${it.next_run ? `<div style="font-size:var(--text-xs);color:var(--muted)">next ${relTime(it.next_run)}</div>` : ""}</td>
               <td style="font-size:var(--text-sm);color:var(--muted)">${relTime(it.last_run)}${it.last_status ? " " + statusTag(it.last_status) : ""}</td>
-              <td style="font-size:var(--text-sm);color:var(--muted)">${it.next_run ? relTime(it.next_run) : "—"}</td>
+              <td>${contractCell(it)}</td>
               <td>${pathCell(it)}</td></tr>`).join("")
         + `</tbody></table>`
         : `<p class="empty">No automations match — ${scope === "local" && sourceF === "all" ? "try “show all sources”." : "adjust the filters."}</p>`)

--- a/dashboard/redesign/sections/landing.js
+++ b/dashboard/redesign/sections/landing.js
@@ -64,13 +64,21 @@
     } else { attn.hidden = true; }
   }
 
-  function renderStats(stats, residents, source) {
+  function renderStats(stats, residents, source, auto) {
     const live = residents.filter((r) => r.coherence != null);
     const fleetCoh = live.length ? (live.reduce((a, r) => a + r.coherence, 0) / live.length) : null;
+    // Automation Health — awareness only ("do I need to care?"); the map lives in /automations.
+    const asum = (auto && auto.summary) || {};
+    const aKind = asum.by_kind || {};
+    const aAtt = (asum.needs_attention || []).length;
+    const aStale = !!(auto && auto.stale);
+    const aWarn = aAtt > 0 || aStale;
+    const autoSub = `${aAtt} attention · ${aKind.dogfood || 0} dogfood · ${aKind.ablation || 0} ablation · ${aKind.qa || 0} QA${aStale ? " · stale" : ""}`;
     const cards = [
       { h: "Fleet Coherence", num: num(fleetCoh), sub: `${live.length} of ${residents.length} residents reporting`, cls: "up", rule: true },
       { h: "Agents", num: stats.agentsActive, of: "/ " + stats.agentsTotal, sub: "active / total" },
       { h: "Stuck", num: stats.stuck, sub: stats.stuck ? "needs attention" : "none flagged", cls: stats.stuck ? "down" : "up" },
+      { h: "Automations", num: asum.total || 0, sub: autoSub, cls: aWarn ? "down" : "up", href: "#automations" },
       { h: "Discoveries", num: (stats.discoveries || 0).toLocaleString(), sub: typeof stats.discoveriesToday === "number" ? "+" + stats.discoveriesToday + " today" : "knowledge graph" },
       { h: "Dialectic", num: stats.dialectic, sub: stats.dialectic ? "open sessions" : "no open sessions" },
       { h: "System Health", num: stats.systemHealth, sub: stats.systemHealthDetail || "db · ws · reaper", cls: stats.systemHealth === "OK" ? "up" : "down" },
@@ -89,11 +97,12 @@
       ? `${stats.trustEarned.toLocaleString()} earned of ${stats.trustFleet.toLocaleString()} · ${(stats.trustUnknown || 0).toLocaleString()} unknown`
       : "";
 
-    $("stats").innerHTML = cards.map((s) =>
-      `<div class="card ${s.rule ? "accent-rule" : ""}"><h3>${s.h}</h3>`
-      + `<div class="num">${s.num}${s.of ? `<span class="of"> ${s.of}</span>` : ""}</div>`
-      + `<div class="sub ${s.cls || ""}">${s.sub}</div></div>`
-    ).join("")
+    $("stats").innerHTML = cards.map((s) => {
+      const tag = s.href ? "a" : "div"; const attr = s.href ? ` href="${s.href}" style="text-decoration:none;color:inherit"` : "";
+      return `<${tag} class="card ${s.rule ? "accent-rule" : ""}"${attr}><h3>${s.h}</h3>`
+        + `<div class="num">${s.num}${s.of ? `<span class="of"> ${s.of}</span>` : ""}</div>`
+        + `<div class="sub ${s.cls || ""}">${s.sub}</div></${tag}>`;
+    }).join("")
       + `<div class="card wide"><h3>Trust Tiers ${tierScope ? `<span style="text-transform:none;letter-spacing:0;color:var(--faint);font-weight:400">· ${tierScope}</span>` : ""}</h3>`
       + `<div class="tiers">${tierBars}</div>`
       + `<div class="legend" style="margin-top:.5rem;flex-wrap:wrap">${tierLegend}</div></div>`;
@@ -146,11 +155,11 @@
 
   // Full first render — light (residents/pulse/health) + heavy (stats) together.
   async function render() {
-    const [health, residents, stats] = await Promise.all([DATA.health(), DATA.residents(), DATA.stats()]);
+    const [health, residents, stats, auto] = await Promise.all([DATA.health(), DATA.residents(), DATA.stats(), DATA.automations()]);
     lastResidents = residents;
     applyHealth(health);
     renderResidents(residents.data, residents.source);
-    renderStats(stats.data, residents.data, stats.source);
+    renderStats(stats.data, residents.data, stats.source, auto.data);
     renderPulse(residents.data);
     footnote([residents, stats, health].some((r) => r.source === "live"));
   }
@@ -167,9 +176,9 @@
   // Heavy refresh (slow cadence) — the 7-tool headline batch; reuse last residents
   // for fleet coherence rather than refetching them.
   async function refreshStats() {
-    const stats = await DATA.stats();
+    const [stats, auto] = await Promise.all([DATA.stats(), DATA.automations()]);
     const residents = lastResidents || (lastResidents = await DATA.residents());
-    renderStats(stats.data, residents.data, stats.source);
+    renderStats(stats.data, residents.data, stats.source, auto.data);
   }
 
   window.Landing = { render, refresh, refreshStats };

--- a/dashboard/tests/helpers/load-dashboard.js
+++ b/dashboard/tests/helpers/load-dashboard.js
@@ -19,6 +19,16 @@ const dashboardDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), 
  * @param {string[]} files - script filenames relative to dashboard/, in load order.
  */
 export function loadDashboardScripts(files) {
+    if (!window.localStorage || typeof window.localStorage.getItem !== 'function') {
+        const store = new Map();
+        const storage = {
+            getItem: (key) => (store.has(String(key)) ? store.get(String(key)) : null),
+            setItem: (key, value) => { store.set(String(key), String(value)); },
+            removeItem: (key) => { store.delete(String(key)); },
+            clear: () => { store.clear(); },
+        };
+        Object.defineProperty(window, 'localStorage', { value: storage, configurable: true });
+    }
     for (const file of files) {
         const src = fs.readFileSync(path.join(dashboardDir, file), 'utf8');
         // Indirect eval via window → runs in global scope, not this function's.

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -1097,6 +1097,43 @@ async def http_agent_history(request):
         return JSONResponse({"success": False, "error": str(exc)}, status_code=500)
 
 
+async def http_automations(request):
+    """GET /api/automations — automation census snapshot for the dashboard.
+
+    Reads the snapshot written by `unitares-automations census --write` (path
+    overridable via UNITARES_AUTOMATION_CENSUS_PATH). Read-only and does NOT
+    shell out — freshness comes from the snapshot's mtime, surfaced as
+    snapshot_age_seconds / stale so the panel can flag a stale census.
+    """
+    http_api_token = os.getenv("UNITARES_HTTP_API_TOKEN")
+    if not _check_http_auth(request, http_api_token=http_api_token):
+        return _http_unauthorized()
+    import json as _json
+    import time as _time
+    default_path = os.path.expanduser("~/.local/state/unitares-automations/last.json")
+    snapshot_path = os.getenv("UNITARES_AUTOMATION_CENSUS_PATH", default_path)
+    if not os.path.exists(snapshot_path):
+        return JSONResponse({
+            "schema": "unitares.automation_census.v1",
+            "summary": {"total": 0, "by_source": {}, "by_kind": {}, "needs_attention": [], "warnings": []},
+            "automations": [],
+            "snapshot_path": snapshot_path,
+            "snapshot_age_seconds": None,
+            "stale": True,
+            "warnings": ["census snapshot missing — run `unitares-automations census --write`"],
+        })
+    try:
+        with open(snapshot_path) as fh:
+            data = _json.load(fh)
+        age = int(_time.time() - os.path.getmtime(snapshot_path))
+        data["snapshot_path"] = snapshot_path
+        data["snapshot_age_seconds"] = age
+        data["stale"] = age > 86400  # older than 24h
+        return JSONResponse(data)
+    except Exception as exc:  # noqa: BLE001 — read-only panel endpoint, degrade gracefully
+        return JSONResponse({"success": False, "error": str(exc)}, status_code=500)
+
+
 async def http_tier_distribution(request):
     """GET /v1/agents/tier_distribution — full-fleet trust-tier counts.
 
@@ -3099,6 +3136,7 @@ def register_http_routes(
     app.routes.append(Route("/v1/vigil/summary", http_vigil_summary, methods=["GET"]))
     app.routes.append(Route("/v1/agents/tier_distribution", http_tier_distribution, methods=["GET"]))
     app.routes.append(Route("/v1/agents/{agent_id}/history", http_agent_history, methods=["GET"]))
+    app.routes.append(Route("/api/automations", http_automations, methods=["GET"]))
     app.routes.append(Route("/api/activity", http_activity, methods=["GET"]))
     app.routes.append(Route("/api/incidents", http_incidents, methods=["GET"]))
     app.routes.append(Route("/v1/residents", http_residents, methods=["GET"]))

--- a/tests/test_automations_endpoint.py
+++ b/tests/test_automations_endpoint.py
@@ -1,0 +1,61 @@
+"""Covers the read-only /api/automations census-snapshot endpoint.
+
+The endpoint reads the snapshot written by `unitares-automations census --write`
+(path overridable via UNITARES_AUTOMATION_CENSUS_PATH) and passes it through with
+freshness metadata. It must NOT shell out and must degrade gracefully when the
+snapshot is missing. Auth is exercised elsewhere; patched True here so the test
+focuses on the snapshot logic.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from src import http_api
+from src.http_api import http_automations
+
+
+def _req():
+    return SimpleNamespace(headers={})
+
+
+@pytest.mark.asyncio
+async def test_passthrough_with_freshness(tmp_path, monkeypatch):
+    monkeypatch.setattr(http_api, "_check_http_auth", lambda *a, **k: True)
+    snap = tmp_path / "census.json"
+    snap.write_text(json.dumps({
+        "schema": "unitares.automation_census.v1",
+        "summary": {"total": 2, "by_source": {"launchd": 2}, "by_kind": {"dogfood": 1},
+                    "needs_attention": ["a"], "warnings": []},
+        "automations": [
+            {"id": "a", "name": "A", "source": "launchd", "kind": "dogfood"},
+            {"id": "b", "name": "B", "source": "launchd", "kind": "test"},
+        ],
+    }))
+    monkeypatch.setenv("UNITARES_AUTOMATION_CENSUS_PATH", str(snap))
+
+    resp = await http_automations(_req())
+    assert resp.status_code == 200
+    body = json.loads(resp.body)
+    assert body["summary"]["total"] == 2
+    assert len(body["automations"]) == 2
+    assert body["snapshot_path"] == str(snap)
+    assert body["snapshot_age_seconds"] is not None
+    assert body["stale"] is False
+
+
+@pytest.mark.asyncio
+async def test_missing_snapshot_degrades(tmp_path, monkeypatch):
+    monkeypatch.setattr(http_api, "_check_http_auth", lambda *a, **k: True)
+    monkeypatch.setenv("UNITARES_AUTOMATION_CENSUS_PATH", str(tmp_path / "absent.json"))
+
+    resp = await http_automations(_req())
+    assert resp.status_code == 200
+    body = json.loads(resp.body)
+    assert body["automations"] == []
+    assert body["summary"]["total"] == 0
+    assert body["stale"] is True
+    assert any("census" in w.lower() for w in body["warnings"])


### PR DESCRIPTION
## Summary
- add read-only /api/automations snapshot endpoint for the automation census
- add Overview Automation Health card and dedicated Automations page
- show curated owner/escalation, expected outputs, surface claims, and priority metadata where present
- make hash/card navigation activate dashboard sections and keep Automations refreshable
- harden dashboard JS test loader against runtimes with a broken localStorage global

## Tests
- python3 -m py_compile src/http_api.py
- python3 -m pytest tests/test_automations_endpoint.py tests/test_dashboard_redesign_route.py tests/test_dashboard_static_allowlist.py tests/test_dashboard.py
- cd dashboard && npm ci
- cd dashboard && npm test
- git push pre-push smoke: 138 passed, 9812 deselected, 1 warning

## Notes
- Automations remain read-only in this PR; scheduler controls are intentionally out of scope.
- Residents still show resident fleet state. Scheduled/local jobs now belong in the Automations page.