### PR TITLE
Fix identity-surface frictions: read-tool side-effects + identifier docs (#945)

### DIFF
--- a/docs/ontology/identity.md
+++ b/docs/ontology/identity.md
@@ -39,6 +39,66 @@ Vocabulary boundary:
 - `lineage` means "inherits work from," not "is identical to."
 - `continuity_token` is an advanced same-live-process rebind proof.
 
+## Identifier reference: which one do I pass, when?
+
+A single agent surfaces many identifiers (`uuid`, `agent_id`,
+`structured_agent_id`, `display_name`, `client_session_id`,
+`continuity_token`, `thread_id`). They are not interchangeable, and most of
+them you should **not** pass on the normal path. This table is the
+authoritative "which one when" so callers don't have to reverse-engineer the
+resolvers (`src/mcp_handlers/support/agent_auth.py`).
+
+| Identifier | What it is | Pass it when | Never use it as |
+|---|---|---|---|
+| `client_session_id` | Accountable **write binding** for the running process; returned by `start_session`/`onboard`. | The normal path: every check-in and write from the same live process (adapters do this automatically). | — (this *is* the day-to-day proof) |
+| `uuid` (`agent_uuid`) | Immutable server record key; internal storage key. | Resume-by-proof (`identity(agent_uuid=…, continuity_token=…)`) or an operator/admin targeting a specific agent. | A bearer credential on its own — a bare `agent_uuid` resume is refused without a matching token (see "strict" mode). |
+| `agent_id` (argument) | **Overloaded** target selector: accepts a UUID, `display_name`/`label`, `structured_agent_id`, or `public_agent_id`; resolvers canonicalize it to the UUID. | You are targeting a **different** agent (cross-agent/admin op). For *self*, leave it unset — the session binding resolves it. | Self-identification when you're already session-bound (passing your own label round-trips through alias resolution for nothing). |
+| `agent_id` (return field) | The **display** value (chosen `display_name`, else an auto id). | — (read-only output) | An input proof — it is cosmetic on the way out. |
+| `structured_agent_id` / `public_agent_id` | Auto-derived model+date style label. | Rarely; only as a human-readable cross-agent reference. | Proof of anything; it is server-generated and cosmetic. |
+| `display_name` / `label` | User-chosen cosmetic name. | Display only. | Identity. "Name is cosmetic" (identity-invariant #4). |
+| `continuity_token` | Advanced **same-live-process** rebind proof (signed, carries the `aid` claim). | Resume-by-proof together with `agent_uuid`, in a still-live process. Not the day-to-day path. | A cross-process or cross-channel identity credential (performative — see "Three stances"). |
+| `thread_id` | Conversation/thread anchor. Short opaque `t-<16hex>` form (`generate_thread_id`, `src/thread_identity.py`) **and** a full-UUID form are both accepted. | Claiming thread membership/position when the caller already knows it. | A substitute for `client_session_id` — a thread groups forks; it is not the per-process write binding. |
+
+### Canonical resolution order
+
+When the server needs to answer "who is this caller?" the **canonical order
+is**:
+
+1. **Explicit `agent_id` argument** (UUID, or an alias the resolver
+   canonicalizes to a UUID) — used to *target*, and for cross-agent ops it is
+   honored verbatim so ownership checks can run downstream.
+2. **Session-bound context identity** — the UUID the dispatch middleware bound
+   for this request (from `client_session_id` / sticky transport binding /
+   `continuity_token`).
+3. **Refuse / unbound** — under `STRICT_IDENTITY_REQUIRED` an unresolved write
+   returns a typed identity-required refusal; it does **not** auto-mint.
+   (Pre-`pre_onboard` *reads* with no proof short-circuit to unbound without
+   resolving at all — they never produce a cacheable identity. See
+   `src/mcp_handlers/middleware/identity_step.py` and the REST parity guard in
+   `src/http_api.py::_resolve_http_bound_agent`.)
+
+The three resolvers in `src/mcp_handlers/support/agent_auth.py` are
+**specializations of this one order**, not independent priority schemes —
+read them against the canonical order above:
+
+- **`compute_agent_signature`** (read/signature path) — steps 1→2, then
+  returns `{"uuid": None}` instead of auto-generating. It also refuses to
+  resolve when the binding was `server_inferred` (sticky/fingerprint) and the
+  caller gave no explicit identity, so a low-assurance read does not get
+  stamped with a borrowed UUID.
+- **`require_agent_id`** (write gate) — steps 1→2, with alias→UUID
+  canonicalization for self-references and verbatim pass-through for
+  cross-agent references; step 3 is auto-generation in legacy mode and a
+  typed refusal under strict mode.
+- **`require_registered_agent`** (write + existence verify) — runs
+  `require_agent_id` first (so the same 1→2→3 order), then adds an existence
+  resolution layer: direct UUID lookup → alias scan over registered metadata
+  → context-bound fallback → trusted middleware `identity_result`.
+
+If you are writing new code that needs the caller's identity, prefer the
+session-bound context (`get_context_agent_id()`) and let these helpers apply
+the canonical order — do not invent a fourth resolution scheme.
+
 ## Opening stance
 
 This document does not commit to a single ontology of agent identity. It describes what kinds of continuity exist in the system, distinguishes the ones that are earned from the ones that are performative, and opens a research agenda for inventing what would turn the performative kinds into earned ones.

--- a/src/http_api.py
+++ b/src/http_api.py
@@ -367,6 +367,20 @@ async def _resolve_http_bound_agent(tool_name: str, arguments: dict, signals) ->
     # returns whichever agent the cache holds (issue #110).
     _token_agent_uuid = extract_token_agent_uuid_safe(arguments.get("continuity_token"))
 
+    # #945 §1 (REST parity): a pre_onboard READ with no remaining proof must not
+    # fingerprint-resolve. By this point the proof-carrying paths have already
+    # returned (explicit UUID, operator token, sticky-cache hit); the only proof
+    # left to honor is a continuity_token. Without one, resolving here would
+    # lazily bind an identity AND write it back into the sticky cache below — the
+    # exact read-tool side effect #945 targets. The stale `skip_tools` set above
+    # missed get_governance_metrics and the action-level reads (knowledge.search
+    # etc.); judging the canonical CALL via get_call_identity_requirement covers
+    # them without another hardcoded list.
+    if not _token_agent_uuid:
+        from src.mcp_handlers.decorators import get_call_identity_requirement
+        if get_call_identity_requirement(tool_name, arguments) == "pre_onboard":
+            return None
+
     resolved = await resolve_session_identity(
         session_key,
         persist=False,

--- a/src/mcp_handlers/middleware/identity_step.py
+++ b/src/mcp_handlers/middleware/identity_step.py
@@ -51,6 +51,12 @@ _MIDDLEWARE_IDENTITY_ARG_KEYS = (
     "_core_agent_row_status",
 )
 
+# Identity-lifecycle tools are `pre_onboard` but are NOT pure reads — they
+# establish/inspect identity and own their own resolution downstream. The
+# pre_onboard read short-circuit (#945 §1) must skip these so onboard/identity
+# still receive the dispatch-threaded resolution they rely on.
+_IDENTITY_LIFECYCLE_TOOLS = frozenset({"identity", "onboard", "bind_session"})
+
 
 def _clear_middleware_identity(arguments: Optional[Dict[str, Any]]) -> None:
     """Remove caller-provided internal identity handoff fields."""
@@ -630,6 +636,59 @@ async def resolve_identity(name: str, arguments: Dict[str, Any], ctx) -> Any:
     _token_agent_uuid = extract_token_agent_uuid_safe(
         arguments.get("continuity_token") if arguments else None
     )
+
+    # #945 §1: short-circuit identity resolution for pre_onboard READ calls
+    # that present no proof. The old shape resolved-then-guarded — EVERY tool
+    # ran resolve_session_identity(resume=True) and pre_onboard tools were only
+    # spared the force_new auto-mint *retry* below. But the resume itself can
+    # fingerprint-bind to an existing identity, which then gets written into the
+    # sticky transport cache at the tail of this function, so a pure read by an
+    # unbound caller still PRODUCED a cacheable identity as a side effect.
+    # Guarding-first instead: when the call resolves to pre_onboard, is not an
+    # identity-lifecycle tool, and the caller supplied no proof (continuity
+    # token / client_session_id / agent_uuid / UUID X-Agent-Id), skip resolution
+    # entirely and leave the request unbound. Reads that DO carry proof still
+    # resume-resolve — reading an existing identity is legitimate, not
+    # "producing" one — preserving the test_read_only_*_session_miss contract.
+    _has_identity_proof = bool(
+        _token_agent_uuid
+        or (arguments and arguments.get("client_session_id"))
+        or (arguments and arguments.get("agent_uuid"))
+        or (
+            x_agent_id_header
+            and len(x_agent_id_header) == 36
+            and x_agent_id_header.count("-") == 4
+        )
+    )
+    if not _has_identity_proof and canonical_name not in _IDENTITY_LIFECYCLE_TOOLS:
+        from src.mcp_handlers.decorators import get_call_identity_requirement
+        if get_call_identity_requirement(canonical_name, arguments) == "pre_onboard":
+            logger.info(
+                "[DISPATCH] pre_onboard read %s with no proof — short-circuiting "
+                "identity resolution (no resolve, no mint, no sticky cache)",
+                name,
+            )
+            from ..context import set_session_context
+            client_hint = arguments.get("client_hint") if arguments else None
+            context_token = set_session_context(
+                session_key=session_key,
+                client_session_id=client_session_id,
+                agent_id=None,
+                client_hint=client_hint,
+                identity_result=None,
+            )
+            ctx.session_key = session_key
+            ctx.client_session_id = client_session_id
+            ctx.bound_agent_id = None
+            ctx.context_token = context_token
+            ctx.client_hint = client_hint
+            ctx.identity_result = None
+            _attach_middleware_identity(
+                arguments,
+                session_key=session_key,
+                identity_result=None,
+            )
+            return name, arguments, ctx
 
     bound_agent_id = None
     identity_result = None

--- a/tests/test_dispatch_ephemeral_identity.py
+++ b/tests/test_dispatch_ephemeral_identity.py
@@ -66,7 +66,9 @@ class TestEphemeralIdentityMarking:
             p.start()
         try:
             ctx = DispatchContext()
-            result = await resolve_identity("status", {}, ctx)
+            # `required` tool so resolution runs (a no-proof pre_onboard read
+            # now short-circuits before the ephemeral/TTL marking under test).
+            result = await resolve_identity("process_agent_update", {}, ctx)
         finally:
             for p in reversed(patches):
                 p.stop()
@@ -92,7 +94,9 @@ class TestEphemeralIdentityMarking:
             p.start()
         try:
             ctx = DispatchContext()
-            result = await resolve_identity("status", {}, ctx)
+            # `required` tool so resolution runs (a no-proof pre_onboard read
+            # now short-circuits before the ephemeral/TTL marking under test).
+            result = await resolve_identity("process_agent_update", {}, ctx)
         finally:
             for p in reversed(patches):
                 p.stop()
@@ -115,7 +119,9 @@ class TestEphemeralIdentityMarking:
             p.start()
         try:
             ctx = DispatchContext()
-            result = await resolve_identity("status", {}, ctx)
+            # `required` tool so resolution runs (a no-proof pre_onboard read
+            # now short-circuits before the ephemeral/TTL marking under test).
+            result = await resolve_identity("process_agent_update", {}, ctx)
         finally:
             for p in reversed(patches):
                 p.stop()
@@ -139,7 +145,9 @@ class TestEphemeralIdentityMarking:
             p.start()
         try:
             ctx = DispatchContext()
-            result = await resolve_identity("status", {}, ctx)
+            # `required` tool so resolution runs (a no-proof pre_onboard read
+            # now short-circuits before the ephemeral/TTL marking under test).
+            result = await resolve_identity("process_agent_update", {}, ctx)
         finally:
             for p in reversed(patches):
                 p.stop()
@@ -213,6 +221,95 @@ class TestEphemeralIdentityMarking:
         assert ctx.bound_agent_id is None
         assert ctx.identity_result is identity_result
         mock_db.update_session_activity.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pre_onboard_read_no_proof_short_circuits_resolution(self, mock_db):
+        """#945 §1: a pre_onboard read with no proof must skip resolution entirely.
+
+        The old shape resolved-then-guarded (resolve_session_identity ran for
+        EVERY tool); a fingerprint hit could bind + sticky-cache an identity for
+        a pure read. Guarding-first: no proof + pre_onboard read => no resolve,
+        no mint, no sticky cache, request left unbound.
+        """
+        resolve_mock = AsyncMock(return_value={"agent_uuid": "should-not-be-used"})
+        patches = [
+            patch("src.mcp_handlers.context.get_session_signals", return_value=None),
+            patch("src.mcp_handlers.identity.handlers.derive_session_key", new_callable=AsyncMock, return_value="fp-session"),
+            patch("src.mcp_handlers.identity.handlers.resolve_session_identity", resolve_mock),
+            patch("src.mcp_handlers.context.set_session_context", return_value=MagicMock()),
+            patch("src.db.get_db", return_value=mock_db),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            ctx = DispatchContext()
+            await resolve_identity("get_governance_metrics", {}, ctx)
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        # The whole point: resolution was never invoked.
+        assert resolve_mock.await_count == 0
+        assert ctx.bound_agent_id is None
+        assert ctx.identity_result is None
+        mock_db.update_session_activity.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pre_onboard_read_with_proof_still_resolves(self, mock_db):
+        """Proof-carrying reads must NOT be short-circuited — reading an existing
+        identity is legitimate. With client_session_id present, the resume path
+        still runs (await_count == 1)."""
+        resolve_mock = AsyncMock(return_value={
+            "resume_failed": True,
+            "error": "session_resolve_miss",
+            "session_key": "fp-session",
+        })
+        patches = [
+            patch("src.mcp_handlers.context.get_session_signals", return_value=None),
+            patch("src.mcp_handlers.identity.handlers.derive_session_key", new_callable=AsyncMock, return_value="fp-session"),
+            patch("src.mcp_handlers.identity.handlers.resolve_session_identity", resolve_mock),
+            patch("src.mcp_handlers.context.set_session_context", return_value=MagicMock()),
+            patch("src.db.get_db", return_value=mock_db),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            ctx = DispatchContext()
+            await resolve_identity("get_governance_metrics", {"client_session_id": "fp-session"}, ctx)
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        assert resolve_mock.await_count == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("tool_name", ["onboard", "identity", "bind_session"])
+    async def test_identity_lifecycle_no_proof_not_short_circuited(self, tool_name, mock_db):
+        """Lifecycle tools are pre_onboard but must still resolve so the handler
+        receives the dispatch-threaded resolution. They are excluded from the
+        #945 §1 read short-circuit even with no proof."""
+        resolve_mock = AsyncMock(return_value={
+            "resume_failed": True,
+            "error": "session_resolve_miss",
+            "session_key": "fp-session",
+        })
+        patches = [
+            patch("src.mcp_handlers.context.get_session_signals", return_value=None),
+            patch("src.mcp_handlers.identity.handlers.derive_session_key", new_callable=AsyncMock, return_value="fp-session"),
+            patch("src.mcp_handlers.identity.handlers.resolve_session_identity", resolve_mock),
+            patch("src.mcp_handlers.context.set_session_context", return_value=MagicMock()),
+            patch("src.db.get_db", return_value=mock_db),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            ctx = DispatchContext()
+            await resolve_identity(tool_name, {}, ctx)
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        assert resolve_mock.await_count == 1
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("tool_name", ["identity", "onboard"])

--- a/tests/test_handler_error_paths.py
+++ b/tests/test_handler_error_paths.py
@@ -188,40 +188,44 @@ async def test_authentication_failures():
 async def test_nonexistent_resources():
     """Test handlers handle non-existent resources gracefully (identity_v2)
 
-    Note: With identity_v2, session binding controls which agents you can access:
-    - First call auto-creates and binds an identity
-    - get_governance_metrics without agent_id uses the bound agent
-    - Trying to access a non-existent agent_id returns "Session mismatch" error
+    #945 §1: pre_onboard READ tools (get_governance_metrics) no longer resolve,
+    mint, or bind an identity as a side effect. An unbound read of a
+    non-existent agent is served gracefully as the uninitialized shape — it does
+    NOT auto-create a ghost identity, and it does NOT raise a session mismatch
+    (cross-agent READS are not blocked; the impersonation guard only fires for a
+    BOUND writer — see test_authentication_failures).
     """
     print("\n=== Testing Non-Existent Resources ===")
 
-    # First call establishes session binding
+    # A bare read serves the unbound/uninitialized shape without minting identity.
     result = await dispatch_tool("get_governance_metrics", {})
     assert result is not None, "Should return result"
     response_data = json.loads(result[0].text)
-    # With identity_v2, this succeeds using auto-bound agent
-    assert response_data.get("success") == True, "Should succeed with auto-binding"
-    bound_agent = response_data.get("agent_id")
-    print(f"✅ Bound agent metrics retrieved: {bound_agent[:8] if bound_agent else 'N/A'}...")
+    assert response_data.get("success") == True, "Unbound read should succeed gracefully"
+    # The §1 contract: a pure read produces no cacheable/bound identity.
+    assert response_data.get("agent_signature", {}).get("uuid") is None, \
+        "A pure read must not mint/bind an identity"
+    print("✅ Unbound read served without minting identity")
 
-    # Test get_agent_metadata for bound agent
+    # get_agent_metadata for an unbound caller returns gracefully (no crash).
     result = await dispatch_tool("get_agent_metadata", {})
     assert result is not None, "Should return response"
     response_data = json.loads(result[0].text)
-    # Metadata for bound agent should work (may fail if not persisted yet)
     print(f"✅ Agent metadata retrieval: success={response_data.get('success')}")
 
-    # Test trying to access different agent - should fail with session mismatch
+    # Reading a non-existent agent_id from an UNBOUND caller is served as the
+    # uninitialized shape — cross-agent reads are not blocked, and no ghost is
+    # minted (the foreign agent_id is a target selector, not caller proof).
     result = await dispatch_tool("get_governance_metrics", {
         "agent_id": "nonexistent_agent_12345"
     })
     assert result is not None, "Should return result"
     response_data = json.loads(result[0].text)
-    # With identity_v2, this fails with session mismatch (not "not found")
-    assert response_data.get("success") == False, "Should fail with session mismatch"
-    error_msg = response_data.get("error", "").lower()
-    assert "mismatch" in error_msg or "bound" in error_msg, f"Should mention session mismatch (got: {error_msg})"
-    print("✅ Session binding prevents accessing non-existent agents")
+    assert response_data.get("success") == True, \
+        "Unbound read of a non-existent agent should be served gracefully"
+    assert response_data.get("agent_signature", {}).get("uuid") is None, \
+        "Reading a foreign agent_id must not mint/bind an identity"
+    print("✅ Non-existent agent read handled gracefully without minting identity")
 
 
 @pytest.mark.asyncio
@@ -268,18 +272,34 @@ async def test_validation_errors():
 
 @pytest.mark.asyncio
 async def test_error_response_format():
-    """Test that error responses have consistent format"""
+    """Test that error responses have consistent format
+
+    Uses the session-mismatch (impersonation) guard as the error source: a
+    BOUND writer that then requests a DIFFERENT agent_id is refused with a
+    structured error. #945 §1 note: a pre_onboard READ no longer auto-binds, so
+    it can't trip the guard on its own — the binding here is established by a
+    `required` write tool (process_agent_update), which still resolves/binds.
+    """
     print("\n=== Testing Error Response Format ===")
 
-    # Test that errors include error_code when available
-    # With identity_v2, trying to access different agent triggers session mismatch
-    result = await dispatch_tool("get_governance_metrics", {
-        "agent_id": "nonexistent_agent"
+    # Establish a real session binding via a write tool.
+    result = await dispatch_tool("process_agent_update", {
+        "response_text": "bind for error-format test",
+        "complexity": 0.5,
+        "confidence": 0.9,
+    })
+    assert result is not None, "Should bind via write tool"
+    assert json.loads(result[0].text).get("success") == True, "Bind should succeed"
+
+    # Bound writer requesting a DIFFERENT agent_id → structured session mismatch.
+    result = await dispatch_tool("process_agent_update", {
+        "agent_id": "nonexistent_agent",
+        "complexity": 0.5,
+        "confidence": 0.9,
     })
     assert result is not None, "Should return error response"
     response_data = json.loads(result[0].text)
-    # With identity_v2, this triggers session mismatch (error)
-    assert response_data.get("success") == False, "Should be error"
+    assert response_data.get("success") == False, "Should be error (session mismatch)"
     assert "error" in response_data, "Should have error message"
     # Should have recovery guidance for identity_v2 errors
     if "recovery" in response_data:

--- a/tests/test_operator_identity_resolution.py
+++ b/tests/test_operator_identity_resolution.py
@@ -386,6 +386,37 @@ class TestRestPrebindIntegration:
             result = await _resolve_http_bound_agent("archive_agent", {}, signals)
         assert result is None
 
+    @pytest.mark.asyncio
+    async def test_pre_onboard_read_no_proof_skips_resolution(self):
+        """#945 §1 (REST parity): a pre_onboard read with no proof must not
+        fingerprint-resolve — that would lazily bind + sticky-cache an identity
+        for a pure read. get_governance_metrics is the case the stale skip_tools
+        set missed; the get_call_identity_requirement check now covers it."""
+        from src.http_api import _resolve_http_bound_agent
+        from src.mcp_handlers.middleware.identity_step import (
+            _transport_identity_cache,
+        )
+
+        _transport_identity_cache.clear()
+        resolve_mock = AsyncMock(return_value=_resumed("uuid-should-not-bind"))
+        signals = FakeSignals(ip_ua_fingerprint="9.9.9.9:uaRO")
+        with patch(
+            "src.mcp_handlers.identity.handlers.derive_session_key",
+            new_callable=AsyncMock,
+            return_value="sk-readonly",
+        ), patch(
+            "src.mcp_handlers.identity.handlers.resolve_session_identity",
+            resolve_mock,
+        ):
+            result = await _resolve_http_bound_agent(
+                "get_governance_metrics", {}, signals
+            )
+
+        assert result is None
+        assert resolve_mock.await_count == 0
+        # Nothing cached from a pure read.
+        assert not _transport_identity_cache
+
 
 class TestStrictGateEndToEnd:
     """Under STRICT_IDENTITY_REQUIRED: operator-resolved binding passes the


### PR DESCRIPTION
Closes the two verified frictions tracked in #945. Both touch the identity single-writer surface; checked for in-flight identity PRs first (none open).

## §1 — Read tools no longer resolve/mint identity as a side effect

The dispatch middleware previously ran `resolve_session_identity(resume=True)` for **every** tool and only spared `pre_onboard` tools the `force_new` auto-mint *retry* (`identity_step.py`). But the initial resume could still fingerprint-bind to an existing identity, which then got written into the sticky transport cache at the tail of the function — so a pure read by an unbound caller still **produced a cacheable identity**.

Replaced resolve-then-guard with **guard-first**: a `pre_onboard` read call that carries no proof (`continuity_token` / `client_session_id` / `agent_uuid` / UUID `X-Agent-Id`) short-circuits *before* resolution and stays unbound — no resolve, no mint, no sticky cache. Reads that **do** present proof still resume-resolve (reading an existing identity is legitimate, not "producing" one), preserving the existing `test_read_only_*_session_miss` contract.

- Identity-lifecycle tools (`identity`/`onboard`/`bind_session`) are explicitly excluded — they're `pre_onboard` but not pure reads, and still receive their dispatch-threaded resolution.
- **REST parity**: `_resolve_http_bound_agent` (`http_api.py`) gets the same guard, replacing the stale hardcoded `skip_tools` set (which missed `get_governance_metrics` and the action-level reads) with the attribute-driven `get_call_identity_requirement` check.

## §2 — Identifier surface documentation

Added an **"Identifier reference: which one do I pass, when?"** section to `docs/ontology/identity.md`:
- A table covering `uuid`, `agent_id` (arg vs. return), `structured_agent_id`, `display_name`, `client_session_id`, `continuity_token`, `thread_id` (short `t-…` and full-UUID forms).
- **One canonical resolution order**, with the three resolvers in `agent_auth.py` (`compute_agent_signature`, `require_agent_id`, `require_registered_agent`) framed as *specializations* of that single order rather than divergent priority schemes.

Docs/consolidation only, no resolver code churn — per the issue's stated direction.

## Tests
- `test_pre_onboard_read_no_proof_short_circuits_resolution` — MCP: resolve never called, request unbound.
- `test_pre_onboard_read_with_proof_still_resolves` — proof-carrying reads still resume.
- `test_identity_lifecycle_no_proof_not_short_circuited` — onboard/identity/bind_session still resolve.
- `test_pre_onboard_read_no_proof_skips_resolution` — REST parity (no resolve, nothing cached).
- The 4 existing ephemeral/TTL tests now use a `required` tool (`process_agent_update`) since a no-proof `pre_onboard` read like `status()` now short-circuits before that logic.

`1297 passed, 42 skipped` across the identity/dispatch/middleware suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0185VET3Ku3wgB23yYtJtws7)_