### PR TITLE
Automation registry: navigation + columns polish (reconciles #964)

### DIFF
--- a/dashboard/redesign/app.html
+++ b/dashboard/redesign/app.html
@@ -233,14 +233,9 @@ if (window.GovSocket) window.GovSocket.make(onWsEvent, onWsStatus);
 // boot
 window.Landing.render();
 updateLivePill();
-// Drive section switches from the hash too, so in-page links (e.g. the Overview
-// Automations card's href="#automations") and back/forward navigate — not just
-// nav clicks. Reuses the nav-click path by clicking the matching link.
-window.addEventListener("hashchange", () => {
-  const id = (location.hash || "").replace("#", "");
-  const link = id && nav.querySelector(`a[data-section="${id}"]`);
-  if (link && id !== activeSection) link.click();
-});
+// (hashchange routing is handled by the activateSection listener above, which
+// supersedes the earlier nav-click-reuse approach — in-page links like the
+// Overview Automations card and back/forward both route through it.)
 
 (function openFromHash() {
   const id = (location.hash || "").replace("#", "");

--- a/dashboard/redesign/app.html
+++ b/dashboard/redesign/app.html
@@ -142,16 +142,26 @@ themeBtn.onclick = () => {
 
 // section switch
 const nav = document.getElementById("nav");
-nav.addEventListener("click", (e) => {
-  const a = e.target.closest("a[data-section]");
-  if (!a) return;
-  e.preventDefault();
-  const id = a.dataset.section;
-  nav.querySelectorAll("a").forEach((x) => x.classList.toggle("active", x === a));
+function activateSection(id, updateHash = false) {
+  const link = nav.querySelector(`a[data-section="${id}"]`);
+  if (!link) return false;
+  nav.querySelectorAll("a").forEach((x) => x.classList.toggle("active", x === link));
   document.querySelectorAll("[data-pane]").forEach((p) => { p.hidden = p.dataset.pane !== id; });
   activeSection = id;
   lazyLoad(id);
   updateLivePill();
+  if (updateHash && location.hash !== "#" + id) history.pushState(null, "", "#" + id);
+  return true;
+}
+nav.addEventListener("click", (e) => {
+  const a = e.target.closest("a[data-section]");
+  if (!a) return;
+  e.preventDefault();
+  activateSection(a.dataset.section, true);
+});
+window.addEventListener("hashchange", () => {
+  const id = (location.hash || "").replace("#", "");
+  if (id) activateSection(id, false);
 });
 
 const loaded = {};
@@ -178,6 +188,7 @@ const RELOAD = {
   activity: () => window.Activity && window.Activity.load(),
   residents: () => window.Residents && window.Residents.load(),
   eisv: () => window.EISV && window.EISV.load(),
+  automations: () => window.Automations && window.Automations.load(),
 };
 const livePill = document.getElementById("livePill");
 const liveText = document.getElementById("liveText");
@@ -233,8 +244,7 @@ window.addEventListener("hashchange", () => {
 
 (function openFromHash() {
   const id = (location.hash || "").replace("#", "");
-  const link = id && nav.querySelector(`a[data-section="${id}"]`);
-  if (link) link.click();
+  if (id) activateSection(id, false);
 })();
 </script>
 </body>

--- a/dashboard/redesign/sections/automations.js
+++ b/dashboard/redesign/sections/automations.js
@@ -48,6 +48,29 @@
       + (cfg ? `<div title="${esc(cfg)}" style="color:var(--faint)">${esc(tilde(cfg))}</div>` : "")
       + (!where && !cfg ? "—" : "") + `</div>`;
   }
+  function listCell(values) {
+    const list = (values || []).filter(Boolean);
+    if (!list.length) return "—";
+    const shown = list.slice(0, 3).map((v) => `<span class="tag" title="${esc(v)}">${esc(v)}</span>`).join("");
+    const more = list.length > 3 ? `<span style="font-size:var(--text-xs);color:var(--faint)">+${list.length - 3}</span>` : "";
+    return `<div style="display:flex;gap:4px;flex-wrap:wrap;max-width:260px">${shown}${more}</div>`;
+  }
+  function ownerCell(it) {
+    if (!it.owner && !it.escalates_to && !it.description) return "—";
+    return `<div style="font-size:var(--text-sm);color:var(--ink-2)">${esc(it.owner || "—")}</div>`
+      + (it.escalates_to ? `<div style="font-size:var(--text-xs);color:var(--muted)">escalate: ${esc(it.escalates_to)}</div>` : "")
+      + (it.description ? `<div style="font-size:var(--text-xs);color:var(--faint);max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${esc(it.description)}">${esc(it.description)}</div>` : "");
+  }
+  function contractCell(it) {
+    return `<div style="display:grid;gap:4px">`
+      + `<div><span style="font-size:var(--text-xs);color:var(--faint)">outputs</span> ${listCell(it.expected_outputs)}</div>`
+      + `<div><span style="font-size:var(--text-xs);color:var(--faint)">surfaces</span> ${listCell(it.surface_claims)}</div>`
+      + `</div>`;
+  }
+  function priority(it) {
+    const p = Number(it.dashboard_priority);
+    return Number.isFinite(p) ? p : 999;
+  }
 
   function visible() {
     return MODEL.items.filter((it) => {
@@ -56,10 +79,18 @@
       if (kindF !== "all" && it.kind !== kindF) return false;
       if (q) {
         const hay = (it.name + " " + it.source + " " + it.kind + " " + (it.runner || "") + " "
-          + (it.workdir || "") + " " + (it.repo || "") + " " + (it.config_path || "")).toLowerCase();
+          + (it.owner || "") + " " + (it.escalates_to || "") + " " + (it.description || "") + " "
+          + (it.workdir || "") + " " + (it.repo || "") + " " + (it.config_path || "") + " "
+          + (it.expected_outputs || []).join(" ") + " " + (it.surface_claims || []).join(" ")).toLowerCase();
         if (!hay.includes(q)) return false;
       }
       return true;
+    }).sort((a, b) => {
+      const aa = MODEL.attn.has(a.id) ? 0 : 1, bb = MODEL.attn.has(b.id) ? 0 : 1;
+      if (aa !== bb) return aa - bb;
+      const pa = priority(a), pb = priority(b);
+      if (pa !== pb) return pa - pb;
+      return (a.source + a.name + a.id).localeCompare(b.source + b.name + b.id);
     });
   }
 
@@ -91,15 +122,16 @@
            <label style="font-size:var(--text-xs);color:var(--muted);display:flex;gap:6px;align-items:center"><input type="checkbox" id="auto-all" ${scope === "all" ? "checked" : ""}/> show all sources</label>
          </div>`
       + (rows.length ? `<table class="tbl"><thead><tr>
-            <th>Automation</th><th>Source</th><th>Status</th><th>Cadence</th><th>Last run</th><th>Next run</th><th>Where</th></tr></thead><tbody>`
+            <th>Automation</th><th>Owner</th><th>Source</th><th>Status</th><th>Cadence</th><th>Last run</th><th>Contract</th><th>Where</th></tr></thead><tbody>`
         + rows.map((it) => `<tr>
               <td><div style="font-weight:500;color:var(--ink)">${esc(it.name)}</div>
                   <div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap;margin-top:2px"><span class="tag">${esc(it.kind)}</span>${MODEL.attn.has(it.id) ? `<span class="tag warn">attention</span>` : ""}${(it.notes || []).length ? `<span style="font-size:var(--text-xs);color:var(--faint)">${esc(it.notes.join(" · "))}</span>` : ""}</div></td>
+              <td>${ownerCell(it)}</td>
               <td><span class="tag">${esc(it.source)}</span><div style="font-size:var(--text-xs);color:var(--muted);margin-top:2px">${esc(it.runner || "")}</div></td>
               <td>${statusTag(it.status)}</td>
-              <td style="font-size:var(--text-sm);color:var(--ink-2)">${esc(it.cadence || "—")}</td>
+              <td style="font-size:var(--text-sm);color:var(--ink-2)">${esc(it.cadence || "—")}${it.next_run ? `<div style="font-size:var(--text-xs);color:var(--muted)">next ${relTime(it.next_run)}</div>` : ""}</td>
               <td style="font-size:var(--text-sm);color:var(--muted)">${relTime(it.last_run)}${it.last_status ? " " + statusTag(it.last_status) : ""}</td>
-              <td style="font-size:var(--text-sm);color:var(--muted)">${it.next_run ? relTime(it.next_run) : "—"}</td>
+              <td>${contractCell(it)}</td>
               <td>${pathCell(it)}</td></tr>`).join("")
         + `</tbody></table>`
         : `<p class="empty">No automations match — ${scope === "local" && sourceF === "all" ? "try “show all sources”." : "adjust the filters."}</p>`)

--- a/dashboard/tests/helpers/load-dashboard.js
+++ b/dashboard/tests/helpers/load-dashboard.js
@@ -23,9 +23,15 @@ export function loadDashboardScripts(files) {
         const store = new Map();
         const storage = {
             getItem: (key) => (store.has(String(key)) ? store.get(String(key)) : null),
-            setItem: (key, value) => { store.set(String(key), String(value)); },
-            removeItem: (key) => { store.delete(String(key)); },
-            clear: () => { store.clear(); },
+            setItem: (key, value) => {
+                store.set(String(key), String(value));
+            },
+            removeItem: (key) => {
+                store.delete(String(key));
+            },
+            clear: () => {
+                store.clear();
+            },
         };
         Object.defineProperty(window, 'localStorage', { value: storage, configurable: true });
     }

--- a/dashboard/tests/helpers/load-dashboard.js
+++ b/dashboard/tests/helpers/load-dashboard.js
@@ -19,6 +19,16 @@ const dashboardDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), 
  * @param {string[]} files - script filenames relative to dashboard/, in load order.
  */
 export function loadDashboardScripts(files) {
+    if (!window.localStorage || typeof window.localStorage.getItem !== 'function') {
+        const store = new Map();
+        const storage = {
+            getItem: (key) => (store.has(String(key)) ? store.get(String(key)) : null),
+            setItem: (key, value) => { store.set(String(key), String(value)); },
+            removeItem: (key) => { store.delete(String(key)); },
+            clear: () => { store.clear(); },
+        };
+        Object.defineProperty(window, 'localStorage', { value: storage, configurable: true });
+    }
     for (const file of files) {
         const src = fs.readFileSync(path.join(dashboardDir, file), 'utf8');
         // Indirect eval via window → runs in global scope, not this function's.


### PR DESCRIPTION
Conflict-free version of #964. That PR was on the stale `claude/dashboard-automations` branch (already squash-merged as #959), so it conflicted with master. This cherry-picks **only Codex's net-new polish commit** (`e6f98e4b`, *Polish automation dashboard navigation*) onto current master.

Codex's polish, intact:
- **Owner** and **Contract** (expected_outputs / surface_claims) columns + `dashboard_priority` field; search extended to cover them.
- **Attention-first sort**, then priority, then alphabetical.
- Cleaner router: `activateSection(id, updateHash)` with `pushState` (supersedes the #961 nav-click-reuse approach; nav clicks now update the URL → proper back/forward).
- **localStorage polyfill** in the JS test harness — fixes the previously-failing suite (now **48/48 green** locally).

My only reconciliation: removed a **duplicate hashchange listener** the auto-merge left (Codex's new one + the #961 leftover both fired). eslint clean, Python dashboard tests green.

One thing for you/Codex to confirm (not changed here): the patch adds `automations` to the auto-refresh RELOAD map, so the registry re-renders every 10s. Since the census snapshot changes rarely and the page has filters/search, that's arguable churn — easy to drop one line if you'd rather it stay manual like Agents.

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm