### PR TITLE
fix(kg-search): raise OR-recall cap 4→24; fix embedding_coverage null

### DIFF
--- a/scripts/dev/reranker_ab.py
+++ b/scripts/dev/reranker_ab.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Reranker A/B: does the bge-reranker-v2-m3 cross-encoder improve KG retrieval?
+
+Methodology (known-item retrieval with paraphrase, to avoid lexical leakage):
+  1. For each gold item, LOCK the target discovery id via a distinctive-keyword
+     query (high-precision anchor the operator can eyeball).
+  2. EVALUATE retrieval on a *different* natural-language paraphrase of the same
+     information need — the phrasing an agent actually types.
+  3. First stage: semantic_search(paraphrase, limit=POOL). Record rank of target.
+  4. Rerank the same pool with the cross-encoder. Record new rank.
+  5. Aggregate MRR / mean-rank / recall@5 before vs after, plus rerank latency.
+
+Honesty caveats (same class as the trajectory-discrimination pilot): the gold
+set is hand-curated, small (n≈12), and within-corpus. This measures re-ranking
+of a fixed first-stage pool, not end-to-end hybrid+graph. Treat as a directional
+signal for the enable/skip decision, not a benchmark.
+
+Run:  UNITARES_EMBEDDING_MODEL=bge-m3 python scripts/dev/reranker_ab.py
+"""
+import asyncio
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from src.knowledge_graph import get_knowledge_graph
+from src.reranker import rerank
+from src.mcp_handlers.knowledge.limits import EMBED_DETAILS_WINDOW
+
+POOL = 50  # first-stage pool size handed to the reranker
+
+# (anchor_query → locks target id, paraphrase → what we actually evaluate).
+# Anchors are distinctive keyword phrases; paraphrases are natural questions
+# that deliberately avoid the anchor's exact terms.
+GOLD = [
+    ("ephemeral liveness lease agent uuid check-in path false-archival",
+     "how do we stop concurrent sessions from archiving each other"),
+    ("sonification entropy chromaticism drift carrier valence flat",
+     "which EISV dimension actually carries the early-warning signal in audio"),
+    ("empirical adoption audit unprompted calls agents do not voluntarily",
+     "do agents ever call governance on their own without being told"),
+    ("calibration check strongest empirical accuracy evidence channel bins",
+     "is the calibration accuracy number something I can actually trust"),
+    ("AGE relational canonical advisory variable-length path causal filter",
+     "should the knowledge graph treat the AGE store as the source of truth"),
+    ("reserved prefix mcp auto-mint anonymous tool_usage incident gate",
+     "why were anonymous callers failing every gated tool call"),
+    ("Sentinel paused 18h silent swallow AGENT_PAUSED behavioral z-score",
+     "what caused the resident agent to go dark for most of a day"),
+    ("agent proliferation uninitialized counting artifact participated view",
+     "why does the dashboard say half the agents are uninitialized"),
+    ("strict identity 425 prefix-bind hijack fingerprint cache free-ride",
+     "can a session impersonate another by reusing a cached binding"),
+    ("orchestrator vouched UDS peer-cred strong cross-process ephemeral",
+     "how can a short-lived agent get a strong identity it can prove"),
+    ("dialectic independent reasoner heterogeneous reviewer rubber-stamp",
+     "why was the dialectic review just rubber-stamping itself"),
+    ("lease plane file lease leak remote_heartbeat TTL reaper self-heal",
+     "what happens to a file lock when the session holding it dies"),
+]
+
+
+def build_text(d) -> str:
+    details = (d.details or "")[:EMBED_DETAILS_WINDOW]
+    return f"{d.summary or ''}\n{details}".strip()
+
+
+def rank_of(target_id, ordered_ids):
+    """1-based rank of target in ordered list, or None if absent."""
+    for i, did in enumerate(ordered_ids, 1):
+        if did == target_id:
+            return i
+    return None
+
+
+async def lock_target(graph, anchor):
+    """Lock the gold target id as the top hit of the distinctive anchor query."""
+    res = await graph.full_text_search(anchor, limit=5, operator="OR")
+    if not res:
+        res = await graph.semantic_search(anchor, limit=5, min_similarity=0.2)
+        res = [d for d, _ in res]
+    return res[0].id if res else None
+
+
+async def main():
+    graph = await get_knowledge_graph()
+    rows = []
+    rerank_latencies = []
+
+    for anchor, paraphrase in GOLD:
+        target = await lock_target(graph, anchor)
+        if target is None:
+            rows.append((paraphrase, None, None, None, "no target locked"))
+            continue
+
+        # First-stage pool via semantic search on the natural-language paraphrase.
+        sem = await graph.semantic_search(paraphrase, limit=POOL, min_similarity=0.0)
+        if isinstance(sem, tuple):  # degraded
+            rows.append((paraphrase, target, None, None, "semantic degraded"))
+            continue
+        pool = [d for d, _ in sem]
+        first_ids = [d.id for d in pool]
+        rank_before = rank_of(target, first_ids)
+
+        # Rerank the same pool.
+        cands = [(d.id, build_text(d)) for d in pool]
+        t0 = time.perf_counter()
+        reranked = await rerank(paraphrase, cands, top_k=POOL, max_rerank_size=POOL)
+        rerank_latencies.append((time.perf_counter() - t0) * 1000)
+        rank_after = rank_of(target, [rid for rid, _ in reranked])
+
+        rows.append((paraphrase, target, rank_before, rank_after, ""))
+
+    # ---- report ----
+    def mrr(ranks):
+        vals = [1.0 / r for r in ranks if r]
+        return sum(vals) / len(GOLD)
+
+    def recall_at(ranks, k):
+        return sum(1 for r in ranks if r and r <= k) / len(GOLD)
+
+    before = [r[2] for r in rows]
+    after = [r[3] for r in rows]
+
+    print(f"\nReranker A/B — n={len(GOLD)} gold items, pool={POOL}, "
+          f"embedder={os.getenv('UNITARES_EMBEDDING_MODEL', 'minilm')}\n")
+    print(f"{'paraphrase query':<58} {'before':>7} {'after':>7}  {'Δ':>4}")
+    print("-" * 82)
+    improved = worsened = same = 0
+    for q, _t, rb, ra, note in rows:
+        if note:
+            print(f"{q[:56]:<58} {note}")
+            continue
+        sb = str(rb) if rb else "miss"
+        sa = str(ra) if ra else "miss"
+        delta = ""
+        if rb and ra:
+            d = rb - ra
+            delta = f"+{d}" if d > 0 else (str(d) if d < 0 else "0")
+            improved += d > 0; worsened += d < 0; same += d == 0
+        elif ra and not rb:
+            delta = "rescued"; improved += 1
+        elif rb and not ra:
+            delta = "lost"; worsened += 1
+        print(f"{q[:56]:<58} {sb:>7} {sa:>7}  {delta:>4}")
+
+    print("-" * 82)
+    print(f"MRR        before={mrr(before):.3f}   after={mrr(after):.3f}   "
+          f"Δ={mrr(after) - mrr(before):+.3f}")
+    print(f"recall@5   before={recall_at(before,5):.2f}     after={recall_at(after,5):.2f}")
+    print(f"recall@1   before={recall_at(before,1):.2f}     after={recall_at(after,1):.2f}")
+    print(f"items improved={improved}  worsened={worsened}  unchanged={same}")
+    if rerank_latencies:
+        avg = sum(rerank_latencies) / len(rerank_latencies)
+        print(f"rerank latency: avg={avg:.0f}ms  max={max(rerank_latencies):.0f}ms "
+              f"(pool={POOL}, per-search added cost)")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/knowledge_graph_lifecycle.py
+++ b/src/knowledge_graph_lifecycle.py
@@ -356,15 +356,21 @@ class KnowledgeGraphLifecycle:
         try:
             from src.db import get_db
             from src.embeddings import get_active_table_name
-            db = await get_db()
+            db = get_db()  # SYNC accessor — `await get_db()` raised TypeError
             table = get_active_table_name()
-            total = await db._pool.fetchval(
-                "SELECT COUNT(*) FROM knowledge.discoveries"
-            ) or 0
-            with_embeddings = await db._pool.fetchval(
-                f"SELECT COUNT(*) FROM knowledge.discoveries d "
-                f"WHERE d.id IN (SELECT discovery_id FROM {table})"
-            ) or 0
+            # Use the ExecutorPool-wrapped acquire() path (canonical post-PR
+            # #218). The old body did `db = await get_db()` (get_db is sync, so
+            # this raised "object can't be awaited") then `db._pool.fetchval`;
+            # both threw and the except-return-None swallowed it, so coverage
+            # surfaced as null on the live backend (fixed 2026-06-20).
+            async with db.acquire() as conn:
+                total = await conn.fetchval(
+                    "SELECT COUNT(*) FROM knowledge.discoveries"
+                ) or 0
+                with_embeddings = await conn.fetchval(
+                    f"SELECT COUNT(*) FROM knowledge.discoveries d "
+                    f"WHERE d.id IN (SELECT discovery_id FROM {table})"
+                ) or 0
             without = max(0, total - with_embeddings)
             ratio = round(with_embeddings / total, 4) if total else 0.0
             return {

--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -1106,9 +1106,16 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
         # Two DIFFERENT cost concerns, two limits (dogfood 2026-06-13 P2.8):
         #
         # - complex_query_term_limit gates the automatic AND→OR *recall*
-        #   fallback. OR across many terms explodes the FTS candidate set, so a
-        #   tight limit keeps a broad agent query from spending the whole tool
-        #   budget. Genuinely per-term expensive — stays low.
+        #   fallback. OR across many terms widens the FTS candidate set, but the
+        #   SQL `LIMIT` already bounds returned rows and the GIN index keeps the
+        #   scan cheap at this corpus size (~1k discoveries). The cap exists only
+        #   to stop a pathological term-dump (a pasted paragraph) from OR-ing
+        #   against everything. The old value of 4 was far too tight: it skipped
+        #   OR recall on ordinary 10-20 word natural-language questions, which is
+        #   exactly when the AND pass returns nothing and OR is the last resort
+        #   before a bare 0 result (dogfood 2026-06-20: a 14-term question whose
+        #   answer existed returned 0 because OR was skipped here). Raised to 24
+        #   to cover real questions while still bounding term-dumps.
         #
         # - complex_hybrid_term_limit gates auto RRF fusion. Hybrid runs
         #   semantic_search + an AND FTS query in parallel and fuses; the AND
@@ -1118,7 +1125,7 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
         #   when normal multi-term conceptual queries (10 terms is normal for
         #   agents) would benefit most. A generous cap restores fusion while
         #   still bounding pathological term dumps.
-        complex_query_term_limit = 4
+        complex_query_term_limit = 24
         complex_hybrid_term_limit = 12
 
         # Phase 3: cross-encoder reranker. When enabled, first-stage retrieval

--- a/tests/test_kg_search.py
+++ b/tests/test_kg_search.py
@@ -262,6 +262,40 @@ class TestSearchKnowledgeGraph:
         assert "confidence_note" not in data
 
     @pytest.mark.asyncio
+    async def test_long_query_gets_or_recall_fallback(self, patch_common):
+        """Recall floor (2026-06-20): a long natural-language query whose
+        AND-FTS misses must still get the OR-recall fallback.
+
+        Reproduces the live zero-result floor: semantic returns nothing, the
+        semantic→FTS fallback runs AND (which a 14-term query rarely satisfies),
+        and the OR retry — the one that would hit — was gated off by the old
+        complex_query_term_limit=4. With the cap raised, OR recall fires and the
+        answer is returned instead of a bare 0.
+        """
+        mock_mcp_server, mock_graph = patch_common
+        from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
+
+        hit = make_discovery(id="or-hit", summary="agent adoption governance answer")
+
+        async def fts(query, limit, operator):
+            # AND matches nothing (not all 14 terms co-occur); OR recovers it.
+            return [hit] if operator == "OR" else []
+
+        mock_graph.semantic_search = AsyncMock(return_value=[])
+        mock_graph.full_text_search = AsyncMock(side_effect=fts)
+
+        result = await handle_search_knowledge_graph({
+            "query": "what should I work on next to make agents actually want to use governance",
+        })
+
+        data = parse_result(result)
+        assert data["success"] is True
+        assert data["count"] == 1
+        # OR recall fired rather than being skipped for being "too long".
+        assert "fts_fallback_skipped_reason" not in data
+        assert data.get("fts_fallback_used") is True
+
+    @pytest.mark.asyncio
     async def test_search_with_include_details(self, patch_common):
         """Search with include_details=True returns full content."""
         mock_mcp_server, mock_graph = patch_common
@@ -1966,15 +2000,23 @@ class TestKgSearchComplexityCeiling:
         assert mock_graph.full_text_search.await_args.kwargs["operator"] == "AND"
 
     @pytest.mark.asyncio
-    async def test_long_fts_query_skips_automatic_or_fallback(self, patch_common):
+    async def test_term_dump_still_skips_automatic_or_fallback(self, patch_common):
+        """The OR-recall cap still bounds a pathological term-dump.
+
+        Cap raised 4→24 (2026-06-20) so ordinary natural-language questions get
+        OR recall, but a 25-term dump still skips the automatic OR fallback so a
+        pasted paragraph can't OR against the whole corpus. Pass operator='OR'
+        explicitly to override.
+        """
         mock_mcp_server, mock_graph = patch_common
         from src.mcp_handlers.knowledge.handlers import handle_search_knowledge_graph
 
         del mock_graph.semantic_search
         mock_graph.full_text_search = AsyncMock(return_value=[])
 
+        # 25 terms — above the new OR-recall cap of 24.
         result = await handle_search_knowledge_graph({
-            "query": "one two three four five six",
+            "query": " ".join(f"term{i}" for i in range(25)),
         })
         data = parse_result(result)
 


### PR DESCRIPTION
## Why

Live dogfood of KG search (2026-06-20) surfaced that natural-language questions — exactly how an agent phrases "what next" — hit a **zero-result floor**, while the same intent in keywords returned the answer at rank 1. Two root causes, both fixed here. (Diagnosis corrected mid-investigation: first hypotheses — missing embeddings, "FTS never runs" — were both wrong on inspection; bge-m3 has full 1085/1085 coverage and a semantic→FTS fallback already exists.)

## What

**1. Zero-result floor → raise OR-recall cap 4 → 24**
Repro: `"what should I work on next to make agents actually want to use governance"` (14 terms) → 0 results, even though the answer existed and was rank-1 under a 6-term phrasing. Trace: semantic returned nothing → existing semantic→FTS fallback ran AND (a 14-term AND matches nothing) → the OR-recall retry that *would* hit was gated off by `complex_query_term_limit=4`. That tight cap guards an "OR explosion" that doesn't exist at this corpus size (~1k discoveries): SQL `LIMIT` bounds rows and the GIN index keeps the scan cheap. Raised to 24 so ordinary 10–20 word questions get OR recall; a 25-term term-dump still skips auto-OR (override with `operator='OR'`).

Deliberately did **not** re-introduce the 0.2 semantic-retry removed 2026-04-20 (near cosine noise floor — confident noise on genuine misses, worse than nothing).

**2. `embedding_coverage: null` in `knowledge(action='stats')`**
The probe did `db = await get_db()`, but `get_db()` is synchronous — it raised `TypeError`, swallowed by `except → return None`. Fixed to the canonical sync `get_db()` + ExecutorPool `acquire()` pattern. **Live-verified**: now reports `with_embeddings: 1085, ratio: 1.0, active_table: core.discovery_embeddings_bge_m3`.

## Tests
- Replaced the cap-encoding test with a term-dump ceiling test at the new threshold.
- Added an OR-recall-fires regression for the floor case.
- `160 passed` (test_kg_search + test_kg_lifecycle).

## Scope / not in this PR
Safe correctness slice only. Separately measuring whether to enable the cross-encoder reranker (`bge-reranker-v2-m3`, wired but off live) — the bigger precision lever, being A/B'd before any flip.

Draft — operator is the merge + deploy gate.

https://claude.ai/code/session_011onoEr3t2JbEEUDQZHwvk8