### PR TITLE
Dashboard: don't auto-refresh the Automations registry

### DIFF
--- a/dashboard/redesign/app.html
+++ b/dashboard/redesign/app.html
@@ -188,7 +188,9 @@ const RELOAD = {
   activity: () => window.Activity && window.Activity.load(),
   residents: () => window.Residents && window.Residents.load(),
   eisv: () => window.EISV && window.EISV.load(),
-  automations: () => window.Automations && window.Automations.load(),
+  // Automations is NOT auto-refreshed: it's a filter/search registry (like
+  // Agents/Discoveries) and the census snapshot changes rarely, so a 10s
+  // re-render would just churn scroll/focus for no fresh data. Loads on nav.
 };
 const livePill = document.getElementById("livePill");
 const liveText = document.getElementById("liveText");


### PR DESCRIPTION
Follow-up to #966 (per operator request). The registry was in the 10s auto-refresh map, so it re-rendered every tick — churning scroll/focus on a filter/search page whose census snapshot rarely changes. Removed; loads on nav like Agents/Discoveries. The Overview Automation Health card still refreshes with the stats batch, so awareness stays live. Frontend-only, one line.

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm