### PR TITLE
Dashboard: show '—' for unavailable metrics, never stale-as-live

### DIFF
--- a/dashboard/redesign/data.js
+++ b/dashboard/redesign/data.js
@@ -97,16 +97,18 @@
         ]);
         if (![agentsR, kgR, dlcR, stuckR, calR, anomR, healthR, tierR].some(Boolean)) return null;
 
-        // Agent counts from the (light) summary; trust-tier distribution from the
-        // full-fleet aggregate endpoint (cached tier across all identities). The
-        // bars show the EARNED tiers — unknown dwarfs them ~18× at fleet scale, so
-        // it's reported as context, not a bar.
-        let agentsActive = snap.agentsActive, agentsTotal = snap.agentsTotal;
+        // Live path: a sub-tool that fails is NULL, not a stale snapshot value.
+        // Showing the bundled snapshot under a "live" badge would read as a current
+        // metric — the card renders "—" (unavailable) instead, and `degraded`
+        // flags how many sources didn't answer. The whole-accessor snapshot
+        // fallback (() => snap, honestly badged "snapshot") only fires when EVERY
+        // source failed.
+        let agentsActive = null, agentsTotal = null;
         if (agentsR && agentsR.summary) {
           agentsTotal = agentsR.summary.total;
           agentsActive = (agentsR.summary.by_status || {}).active;
         }
-        let trustTiers = snap.trustTiers, trustEarned = null, trustFleet = null, trustUnknown = null;
+        let trustTiers = null, trustEarned = null, trustFleet = null, trustUnknown = null;
         if (tierR && tierR.tiers) {
           const t = tierR.tiers;
           trustTiers = ["verified", "established", "emerging", "provisional"].map((k) => ({ tier: k, n: t[k] || 0 }));
@@ -121,14 +123,15 @@
 
         return {
           agentsActive, agentsTotal, trustTiers, trustEarned, trustFleet, trustUnknown,
-          discoveries: kg && typeof kg.total_discoveries === "number" ? kg.total_discoveries : snap.discoveries,
+          discoveries: kg && typeof kg.total_discoveries === "number" ? kg.total_discoveries : null,
           discoveriesToday: null, // no honest live "today" delta; show neutral subtitle
-          dialectic: dlcSessions ? dlcSessions.filter((s) => !["resolved", "failed"].includes(s.phase || s.status)).length : snap.dialectic,
-          stuck: stuckR ? (stuckR.stuck_agents || []).length : snap.stuck,
-          calibration: calR && typeof calR.trajectory_health === "number" ? calR.trajectory_health : snap.calibration,
-          anomalies: anomR && anomR.summary ? anomR.summary.total_anomalies : snap.anomalies,
-          systemHealth: healthR ? (healthR.status === "healthy" ? "OK" : healthR.status) : snap.systemHealth,
+          dialectic: dlcSessions ? dlcSessions.filter((s) => !["resolved", "failed"].includes(s.phase || s.status)).length : null,
+          stuck: stuckR ? (stuckR.stuck_agents || []).length : null,
+          calibration: calR && typeof calR.trajectory_health === "number" ? calR.trajectory_health : null,
+          anomalies: anomR && anomR.summary ? anomR.summary.total_anomalies : null,
+          systemHealth: healthR ? (healthR.status === "healthy" ? "OK" : healthR.status) : null,
           systemHealthDetail: hb ? `${hb.healthy || 0} ok · ${hb.warning || 0} warn${hb.error ? " · " + hb.error + " err" : ""}` : null,
+          degraded: [agentsR, kgR, dlcR, stuckR, calR, anomR, healthR, tierR].filter((x) => !x).length,
         };
       }, () => snap);
     },

--- a/dashboard/redesign/sections/landing.js
+++ b/dashboard/redesign/sections/landing.js
@@ -74,17 +74,23 @@
     const aStale = !!(auto && auto.stale);
     const aWarn = aAtt > 0 || aStale;
     const autoSub = `${aAtt} attention · ${aKind.dogfood || 0} dogfood · ${aKind.ablation || 0} ablation · ${aKind.qa || 0} QA${aStale ? " · stale" : ""}`;
+    // A null metric = its live source didn't answer this cycle. Show "—"
+    // (unavailable), never a stale snapshot value passed off as current.
+    const un = (v) => v == null;
     const cards = [
       { h: "Fleet Coherence", num: num(fleetCoh), sub: `${live.length} of ${residents.length} residents reporting`, cls: "up", rule: true },
-      { h: "Agents", num: stats.agentsActive, of: "/ " + stats.agentsTotal, sub: "active / total" },
-      { h: "Stuck", num: stats.stuck, sub: stats.stuck ? "needs attention" : "none flagged", cls: stats.stuck ? "down" : "up" },
+      { h: "Agents", num: un(stats.agentsActive) ? "—" : stats.agentsActive, of: un(stats.agentsTotal) ? "" : "/ " + stats.agentsTotal, sub: un(stats.agentsActive) ? "unavailable" : "active / total" },
+      { h: "Stuck", num: un(stats.stuck) ? "—" : stats.stuck, sub: un(stats.stuck) ? "unavailable" : (stats.stuck ? "needs attention" : "none flagged"), cls: un(stats.stuck) ? "" : (stats.stuck ? "down" : "up") },
       { h: "Automations", num: asum.total || 0, sub: autoSub, cls: aWarn ? "down" : "up", href: "#automations" },
-      { h: "Discoveries", num: (stats.discoveries || 0).toLocaleString(), sub: typeof stats.discoveriesToday === "number" ? "+" + stats.discoveriesToday + " today" : "knowledge graph" },
-      { h: "Dialectic", num: stats.dialectic, sub: stats.dialectic ? "open sessions" : "no open sessions" },
-      { h: "System Health", num: stats.systemHealth, sub: stats.systemHealthDetail || "db · ws · reaper", cls: stats.systemHealth === "OK" ? "up" : "down" },
-      { h: "Calibration", num: num(stats.calibration), sub: "trajectory health", cls: stats.calibration >= 0.8 ? "up" : "" },
-      { h: "Anomalies", num: stats.anomalies, sub: stats.anomalies ? stats.anomalies + " active" : "clear", cls: stats.anomalies ? "down" : "up" },
+      { h: "Discoveries", num: un(stats.discoveries) ? "—" : stats.discoveries.toLocaleString(), sub: un(stats.discoveries) ? "unavailable" : (typeof stats.discoveriesToday === "number" ? "+" + stats.discoveriesToday + " today" : "knowledge graph") },
+      { h: "Dialectic", num: un(stats.dialectic) ? "—" : stats.dialectic, sub: un(stats.dialectic) ? "unavailable" : (stats.dialectic ? "open sessions" : "no open sessions") },
+      { h: "System Health", num: un(stats.systemHealth) ? "—" : stats.systemHealth, sub: un(stats.systemHealth) ? "unavailable" : (stats.systemHealthDetail || "db · ws · reaper"), cls: un(stats.systemHealth) ? "" : (stats.systemHealth === "OK" ? "up" : "down") },
+      { h: "Calibration", num: num(stats.calibration), sub: un(stats.calibration) ? "unavailable" : "trajectory health", cls: stats.calibration >= 0.8 ? "up" : "" },
+      { h: "Anomalies", num: un(stats.anomalies) ? "—" : stats.anomalies, sub: un(stats.anomalies) ? "unavailable" : (stats.anomalies ? stats.anomalies + " active" : "clear"), cls: un(stats.anomalies) ? "" : (stats.anomalies ? "down" : "up") },
     ];
+    const degradeBanner = stats.degraded > 0
+      ? `<div style="grid-column:1/-1;font-size:var(--text-xs);color:var(--warn);display:flex;gap:6px;align-items:center;margin-bottom:calc(-1 * var(--space-2))"><span>⚠</span><span>${stats.degraded} metric${stats.degraded > 1 ? "s" : ""} couldn't refresh just now — showing "—" instead of stale values.</span></div>`
+      : "";
     // 5 real trust tiers (earned → forming → unearned), each its own colour.
     const TIER_COLOR = { verified: "var(--ok)", established: "var(--eisv-c)", emerging: "var(--eisv-s)", provisional: "var(--warn)", unknown: "var(--faint)" };
     const tiers = stats.trustTiers || [];
@@ -97,15 +103,16 @@
       ? `${stats.trustEarned.toLocaleString()} earned of ${stats.trustFleet.toLocaleString()} · ${(stats.trustUnknown || 0).toLocaleString()} unknown`
       : "";
 
-    $("stats").innerHTML = cards.map((s) => {
+    const trustBody = stats.trustTiers
+      ? `<div class="tiers">${tierBars}</div><div class="legend" style="margin-top:.5rem;flex-wrap:wrap">${tierLegend}</div>`
+      : `<div class="sub" style="color:var(--muted)">unavailable</div>`;
+    $("stats").innerHTML = degradeBanner + cards.map((s) => {
       const tag = s.href ? "a" : "div"; const attr = s.href ? ` href="${s.href}" style="text-decoration:none;color:inherit"` : "";
       return `<${tag} class="card ${s.rule ? "accent-rule" : ""}"${attr}><h3>${s.h}</h3>`
         + `<div class="num">${s.num}${s.of ? `<span class="of"> ${s.of}</span>` : ""}</div>`
         + `<div class="sub ${s.cls || ""}">${s.sub}</div></${tag}>`;
     }).join("")
-      + `<div class="card wide"><h3>Trust Tiers ${tierScope ? `<span style="text-transform:none;letter-spacing:0;color:var(--faint);font-weight:400">· ${tierScope}</span>` : ""}</h3>`
-      + `<div class="tiers">${tierBars}</div>`
-      + `<div class="legend" style="margin-top:.5rem;flex-wrap:wrap">${tierLegend}</div></div>`;
+      + `<div class="card wide"><h3>Trust Tiers ${tierScope ? `<span style="text-transform:none;letter-spacing:0;color:var(--faint);font-weight:400">· ${tierScope}</span>` : ""}</h3>${trustBody}</div>`;
   }
 
   function renderPulse(residents) {


### PR DESCRIPTION
Degraded-state honesty fix. The Overview stats batch (`agent`/`knowledge`/`dialectic`/`detect_stuck`/`calibration`/`detect_anomalies` + 2 REST) wraps each tool in `.catch(()=>null)` and **fell back to the bundled snapshot value per-metric while still tagging the accessor `source:'live'`**. So a single tool erroring mid-cycle showed a stale snapshot number under a 'live · streaming' badge.

Verified live by failing `/v1/tools/call`: six cards kept showing snapshot values, badge still 'live'. After: a failed sub-tool → `null` → card renders **'—' (unavailable)** + a *'N metrics couldn't refresh'* banner. The whole-accessor snapshot fallback (server fully down) is unchanged and still honestly badged 'snapshot'.

Frontend-only. eslint clean.

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm