### PR TITLE
Dashboard: stack two-up panels on phones

### DIFF
--- a/dashboard/redesign/app.html
+++ b/dashboard/redesign/app.html
@@ -57,7 +57,7 @@
           <span class="verdict" id="pulseVerdict"><span class="pip"></span><span>—</span></span>
           <span class="fresh" id="pulseFresh"></span>
         </div>
-        <div style="display:grid;grid-template-columns:1.4fr 1fr;gap:var(--space-7);align-items:center" id="pulseMain">
+        <div class="split-wide" style="gap:var(--space-7);align-items:center" id="pulseMain">
           <div>
             <div class="risk-label"><span class="k">Risk</span><span class="v" id="riskVal">—</span></div>
             <div class="track"><div class="fill" id="riskFill" style="width:0%"></div></div>

--- a/dashboard/redesign/kit.css
+++ b/dashboard/redesign/kit.css
@@ -223,6 +223,11 @@ body {
 .src-badge.live { color: var(--ok); background: color-mix(in srgb, var(--ok) 12%, transparent); }
 .src-badge.snapshot { color: var(--warn); background: color-mix(in srgb, var(--warn) 12%, transparent); }
 
+/* Two-up layouts (agent detail state|identity, resident panels, Pulse risk|eisv)
+   that collapse to a single stacked column on phones — see the 640px block. */
+.split-2 { display: grid; grid-template-columns: 1fr 1fr; }
+.split-wide { display: grid; grid-template-columns: 1.4fr 1fr; }
+
 @media (max-width: 860px) {
   .grid { grid-template-columns: repeat(2, 1fr); }
   .topbar { flex-wrap: wrap; }
@@ -235,4 +240,6 @@ body {
    swipe right for cadence/last/next/where). Verified at 390px. */
 @media (max-width: 640px) {
   .tbl { display: block; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+  /* Stack the two-up layouts so neither column gets crushed on a phone. */
+  .split-2, .split-wide { grid-template-columns: 1fr; }
 }

--- a/dashboard/redesign/sections/agents.js
+++ b/dashboard/redesign/sections/agents.js
@@ -60,7 +60,7 @@
         <span class="spring"></span>
         <button class="theme-toggle" id="ag-detail-close">✕ close</button>
       </div>
-      <div style="display:grid;grid-template-columns:1fr 1fr;gap:var(--space-6)">
+      <div class="split-2" style="gap:var(--space-6)">
         <div id="ag-state">${stateBlock(m, "")}</div>
         <div>
           <div class="eyebrow" style="margin-bottom:var(--space-3)">Identity</div>

--- a/dashboard/redesign/sections/residents.js
+++ b/dashboard/redesign/sections/residents.js
@@ -99,7 +99,7 @@
     document.querySelector("#res-mount").innerHTML =
       `<div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-4)">
          <span class="eyebrow" style="margin:0">Always-on fleet</span><span class="spring"></span><span class="src-badge ${r.source}">${r.source}</span></div>
-       <div style="display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4)">
+       <div class="split-2" style="gap:var(--space-4)">
          ${watcher(d.watcher)}${sentinel(d.sentinel)}${vigil(d.vigil)}${health(d.health)}
        </div>
        <div style="margin-top:var(--space-4)">${chronicler(d.chronicler)}</div>`;


### PR DESCRIPTION
Follow-up to the mobile-table fix. Three fixed 2-column grids stayed 2-up at phone width and got crushed: the **agent detail panel** (state|identity), the **resident panels** grid, and the Overview **Pulse** (risk|eisv). Moved their column definitions into `.split-2` / `.split-wide` kit classes that collapse to one stacked column below 640px. Centralized (no `!important`). Verified at 390px.

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm