### PR TITLE
feat(kg-search): record recall miss telemetry

### DIFF
--- a/src/mcp_handlers/knowledge/handlers.py
+++ b/src/mcp_handlers/knowledge/handlers.py
@@ -72,6 +72,7 @@ from src.mcp_handlers.knowledge.limits import MAX_SUMMARY_LEN, MAX_DETAILS_LEN
 from config.governance_config import config
 from src.logging_utils import get_logger
 from src.perf_monitor import record_ms
+from src.recall_telemetry import LOW_CONFIDENCE, ZERO_RESULT, record_recall_event
 from ..support.llm_delegation import synthesize_results
 from ..support.tool_hints import (
     KNOWLEDGE_SEARCH_TOOL,
@@ -1693,6 +1694,20 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
         
         # UX FIX: Add contextual helpful hints for empty results
         if len(results) == 0:
+            # Instrument-first (2026-06-20): record the miss so query-expansion
+            # demand becomes measurable before we build it. Fail-open. Only
+            # text searches count; a filter-only query is not a recall miss.
+            if query_text:
+                record_recall_event(
+                    ZERO_RESULT,
+                    query_text,
+                    query_terms=query_term_count,
+                    search_mode=search_mode,
+                    detail={
+                        "hybrid_skipped": bool(hybrid_skipped_reason),
+                        "fts_or_fallback_skipped": bool(fts_fallback_skipped_reason),
+                    },
+                )
             hints = []
             # Count words properly (split on spaces, also handle underscores as word separators)
             if query_text:
@@ -1803,6 +1818,14 @@ async def handle_search_knowledge_graph(arguments: Dict[str, Any]) -> Sequence[T
             lexical_hits = sum(1 for d in results if d.id in fts_anchor_ids)
             if lexical_hits == 0:
                 response_data["low_confidence"] = True
+                # A semantic-only hit with no lexical anchor is exactly the
+                # vocab-gap class query expansion would target.
+                record_recall_event(
+                    LOW_CONFIDENCE,
+                    query_text,
+                    query_terms=query_term_count,
+                    search_mode=search_mode,
+                )
                 response_data["confidence_note"] = (
                     "No result matched your query terms lexically — these are "
                     "semantic-only matches and may be tangential (semantic "

--- a/src/recall_telemetry.py
+++ b/src/recall_telemetry.py
@@ -1,0 +1,92 @@
+"""Recall-miss telemetry for KG search failures.
+
+Instrument-first (2026-06-20). Before building query expansion, measure whether
+vocab-gap and zero-result searches accumulate in live use. This appends one
+JSONL row per failed or low-confidence text search under
+``data/telemetry/recall_misses.jsonl`` so later analysis can distinguish real
+vocab gaps from absent knowledge and automated-battery noise.
+
+Fail-open: telemetry errors must never break a search.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from src.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+_lock = threading.Lock()
+
+ZERO_RESULT = "zero_result"
+LOW_CONFIDENCE = "low_confidence"
+
+
+def _telemetry_file() -> Path:
+    data_dir = Path(__file__).parent.parent / "data" / "telemetry"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    return data_dir / "recall_misses.jsonl"
+
+
+def record_recall_event(
+    event_class: str,
+    query: Optional[str],
+    *,
+    query_terms: Optional[int] = None,
+    search_mode: Optional[str] = None,
+    detail: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Append one recall-failure event without raising into the caller."""
+    try:
+        query_str = str(query or "")
+        row = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "class": event_class,
+            "query": query_str[:500],
+            "query_terms": (
+                query_terms if query_terms is not None else len(query_str.split())
+            ),
+            "search_mode": search_mode,
+            "detail": detail or {},
+        }
+        line = json.dumps(row, sort_keys=True)
+        with _lock:
+            with open(_telemetry_file(), "a", encoding="utf-8") as f:
+                f.write(line + "\n")
+    except Exception as exc:
+        logger.debug(f"recall telemetry append failed (non-fatal): {exc}")
+
+
+def summarize(limit: int = 50000) -> Dict[str, Any]:
+    """Return coarse recent counts by event class."""
+    try:
+        path = _telemetry_file()
+        if not path.exists():
+            return {"total": 0, "by_class": {}, "file": str(path)}
+        with _lock:
+            with open(path, encoding="utf-8") as f:
+                lines = f.readlines()
+        if len(lines) > limit:
+            lines = lines[-limit:]
+
+        by_class: Dict[str, int] = {}
+        total = 0
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event_class = json.loads(line).get("class", "unknown")
+            except Exception:
+                continue
+            by_class[event_class] = by_class.get(event_class, 0) + 1
+            total += 1
+        return {"total": total, "by_class": by_class, "file": str(path)}
+    except Exception as exc:
+        logger.debug(f"recall telemetry summarize failed: {exc}")
+        return {"total": 0, "by_class": {}, "error": str(exc)}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -354,6 +354,21 @@ def _isolate_tool_usage_tracker(tmp_path_factory):
 
 
 @pytest.fixture(autouse=True)
+def _isolate_recall_telemetry(monkeypatch, tmp_path):
+    """Keep recall-miss telemetry out of the real data/telemetry file."""
+    try:
+        import src.recall_telemetry as recall_telemetry
+
+        monkeypatch.setattr(
+            recall_telemetry,
+            "_telemetry_file",
+            lambda: tmp_path / "recall_misses.jsonl",
+        )
+    except Exception:
+        pass
+
+
+@pytest.fixture(autouse=True)
 def _neutralize_metadata_loading(monkeypatch):
     """
     Prevent ensure_metadata_loaded() from trying to connect to PostgreSQL.

--- a/tests/test_kg_search.py
+++ b/tests/test_kg_search.py
@@ -103,11 +103,14 @@ def mock_graph():
 @pytest.fixture
 def patch_common(mock_mcp_server, mock_graph):
     """Patch all common dependencies for knowledge graph handlers."""
+    recall_event_recorder = MagicMock()
     with patch("src.mcp_handlers.context.get_context_agent_id", return_value=None), \
          patch("src.mcp_handlers.shared.get_mcp_server", return_value=mock_mcp_server), \
          patch("src.mcp_handlers.knowledge.handlers.mcp_server", mock_mcp_server), \
          patch("src.mcp_handlers.knowledge.handlers.get_knowledge_graph", new_callable=AsyncMock, return_value=mock_graph), \
+         patch("src.mcp_handlers.knowledge.handlers.record_recall_event", recall_event_recorder), \
          patch("src.mcp_handlers.knowledge.handlers.record_ms"):
+        mock_mcp_server.recall_event_recorder = recall_event_recorder
         yield mock_mcp_server, mock_graph
 
 
@@ -213,6 +216,15 @@ class TestSearchKnowledgeGraph:
         data = parse_result(result)
         assert data["success"] is True
         assert data["count"] == 0
+        mock_mcp_server.recall_event_recorder.assert_called_once()
+        args, kwargs = mock_mcp_server.recall_event_recorder.call_args
+        assert args[:2] == ("zero_result", "nonexistent stuff")
+        assert kwargs["query_terms"] == 2
+        assert kwargs["search_mode"] == "fts"
+        assert kwargs["detail"] == {
+            "hybrid_skipped": False,
+            "fts_or_fallback_skipped": False,
+        }
 
     @pytest.mark.asyncio
     async def test_hybrid_no_lexical_match_flags_low_confidence(self, patch_common):
@@ -240,6 +252,12 @@ class TestSearchKnowledgeGraph:
         assert data["success"] is True
         assert data.get("low_confidence") is True
         assert "confidence_note" in data
+        mock_mcp_server.recall_event_recorder.assert_called_once_with(
+            "low_confidence",
+            "how to bake sourdough bread",
+            query_terms=5,
+            search_mode="hybrid_rrf",
+        )
 
     @pytest.mark.asyncio
     async def test_hybrid_with_lexical_match_not_low_confidence(self, patch_common):
@@ -2136,5 +2154,3 @@ class TestIssue165Provenance:
         mock_graph.add_discovery.assert_awaited()
         node = mock_graph.add_discovery.await_args.args[0]
         assert node.provenance["source"] == "self_recovery_quick_resume"
-
-

--- a/tests/test_recall_telemetry.py
+++ b/tests/test_recall_telemetry.py
@@ -1,0 +1,47 @@
+import json
+
+from src import recall_telemetry
+
+
+def test_record_recall_event_and_summarize(tmp_path, monkeypatch):
+    telemetry_file = tmp_path / "recall_misses.jsonl"
+    monkeypatch.setattr(recall_telemetry, "_telemetry_file", lambda: telemetry_file)
+
+    recall_telemetry.record_recall_event(
+        recall_telemetry.ZERO_RESULT,
+        "needle in haystack",
+        query_terms=3,
+        search_mode="fts",
+        detail={"hybrid_skipped": False},
+    )
+    recall_telemetry.record_recall_event(
+        recall_telemetry.LOW_CONFIDENCE,
+        "semantic only",
+        search_mode="hybrid_rrf",
+    )
+
+    rows = [json.loads(line) for line in telemetry_file.read_text().splitlines()]
+    assert rows[0]["class"] == "zero_result"
+    assert rows[0]["query"] == "needle in haystack"
+    assert rows[0]["query_terms"] == 3
+    assert rows[0]["search_mode"] == "fts"
+    assert rows[0]["detail"] == {"hybrid_skipped": False}
+    assert rows[1]["class"] == "low_confidence"
+
+    summary = recall_telemetry.summarize()
+    assert summary["total"] == 2
+    assert summary["by_class"] == {"zero_result": 1, "low_confidence": 1}
+    assert summary["file"] == str(telemetry_file)
+
+
+def test_recall_telemetry_fail_open(monkeypatch):
+    def explode():
+        raise OSError("no telemetry today")
+
+    monkeypatch.setattr(recall_telemetry, "_telemetry_file", explode)
+
+    recall_telemetry.record_recall_event(recall_telemetry.ZERO_RESULT, "query")
+    summary = recall_telemetry.summarize()
+
+    assert summary["total"] == 0
+    assert "error" in summary


### PR DESCRIPTION
## Summary
- record zero-result and low-confidence KG search events to append-only recall telemetry
- add a small recall telemetry module with summary helper
- cover handler instrumentation and JSONL summary behavior in tests

## Tests
- python3 -m py_compile src/recall_telemetry.py src/mcp_handlers/knowledge/handlers.py
- python3 -m pytest tests/test_kg_search.py tests/test_recall_telemetry.py -q
- pre-push smoke hook: 138 passed, 9821 deselected, 1 warning