### PR TITLE
Automations: fix priority sort (null floated to top)

### DIFF
--- a/dashboard/redesign/sections/automations.js
+++ b/dashboard/redesign/sections/automations.js
@@ -88,8 +88,11 @@
       + `</div>`;
   }
   function priority(it) {
-    const p = Number(it.dashboard_priority);
-    return Number.isFinite(p) ? p : 999;
+    // dashboard_priority is null for un-prioritised rows — Number(null) is 0
+    // (not NaN), which would float them above priority-1 rows. Treat any
+    // non-number as the bottom (999) so explicit priorities win.
+    const p = it.dashboard_priority;
+    return typeof p === "number" && Number.isFinite(p) ? p : 999;
   }
 
   function visible() {


### PR DESCRIPTION
`priority()` used `Number(it.dashboard_priority)`; for un-prioritised rows that's `Number(null) === 0` (not NaN), so every default row sorted as priority 0 — *above* the explicitly priority-1 ungated backups (which landed at row 25). Guard: non-number → 999. Surfaced by the gate scorecard, where ungated items must lead. Frontend-only.

https://claude.ai/code/session_013QDsbjQ1DSQNTf7dpMCXDm